### PR TITLE
fix: optimize test gate — fix crash + split build/test

### DIFF
--- a/.claude/tdd-guardian/config.json
+++ b/.claude/tdd-guardian/config.json
@@ -1,6 +1,6 @@
 {
   "enabled": true,
-  "testCommand": "DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project vreader.xcodeproj -scheme vreader -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:vreaderTests -quiet",
+  "testCommand": "DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build-for-testing -project vreader.xcodeproj -scheme vreader -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -quiet && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test-without-building -project vreader.xcodeproj -scheme vreader -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:vreaderTests -quiet",
   "coverageCommand": "",
   "coverageSummaryPath": "",
   "mutationCommand": "",

--- a/vreaderTests/Services/TXT/TXTServiceTests.swift
+++ b/vreaderTests/Services/TXT/TXTServiceTests.swift
@@ -225,7 +225,11 @@ struct SearchServiceOffsetTests {
     @Test func restoreSegmentOffsetsAreUsed() async throws {
         let store = try SearchIndexStore()
         let service = SearchService(store: store)
-        let fp = DocumentFingerprint(canonicalKey: "test:sha256:abc123")!
+        let fp = DocumentFingerprint(
+            contentSHA256: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+            fileByteCount: 1000,
+            format: .txt
+        )
         let offsets: [Int: Int] = [0: 0, 1: 500, 2: 1200]
 
         await service.restoreSegmentOffsets(fingerprint: fp, offsets: offsets)


### PR DESCRIPTION
## Summary

- Fix `TXTServiceTests` force-unwrap crash (`DocumentFingerprint(canonicalKey:)` returned nil)
- Split gate command into `build-for-testing` + `test-without-building`

The crash caused 18 test runner restarts adding ~6 min of overhead per gate run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)