### PR TITLE
fix(#44): post-audit-3 hardening — six findings

### DIFF
--- a/scripts/verify-release-no-debugbridge.sh
+++ b/scripts/verify-release-no-debugbridge.sh
@@ -52,6 +52,9 @@ fi
 
 # 2a. No DebugFixtures directory or fixture file should be present anywhere
 # in the .app bundle. Catches accidental copying via build phase changes.
+# We check both: (a) the directory itself, and (b) every fixture filename
+# at the bundle root (Xcode flat-copies resources, so the dir wouldn't exist
+# if the EXCLUDED glob took effect — but the file might still leak by name).
 LEAKED_FIXTURES=$(find "$APP_PATH" -type d -name "DebugFixtures" -o -path "*/DebugFixtures/*" 2>/dev/null | head -10)
 if [[ -n "$LEAKED_FIXTURES" ]]; then
     echo "FAIL: bundle contains DebugFixtures content:" >&2
@@ -59,6 +62,28 @@ if [[ -n "$LEAKED_FIXTURES" ]]; then
     FAIL=1
 else
     echo "OK: no DebugFixtures directory in bundle"
+fi
+
+# 2b. Reject every fixture file by name. Driven by the actual contents of
+# vreader/Resources/DebugFixtures/, so adding a new fixture is automatically
+# checked without editing this script.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURES_DIR="$SCRIPT_DIR/../vreader/Resources/DebugFixtures"
+if [[ -d "$FIXTURES_DIR" ]]; then
+    LEAKED_FIXTURE_FILES=()
+    while IFS= read -r fixture; do
+        name=$(basename "$fixture")
+        if find "$APP_PATH" -name "$name" -type f 2>/dev/null | grep -q .; then
+            LEAKED_FIXTURE_FILES+=("$name")
+        fi
+    done < <(find "$FIXTURES_DIR" -type f)
+    if [[ "${#LEAKED_FIXTURE_FILES[@]}" -gt 0 ]]; then
+        echo "FAIL: catalog fixture files found in bundle:" >&2
+        printf '  %s\n' "${LEAKED_FIXTURE_FILES[@]}" >&2
+        FAIL=1
+    else
+        echo "OK: no catalog fixture filenames in bundle"
+    fi
 fi
 
 # 2b. No file in the .app bundle should be named with DebugBridge identifiers

--- a/vreader/App/VReaderApp.swift
+++ b/vreader/App/VReaderApp.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import SwiftData
 
 @main
+@MainActor
 struct VReaderApp: App {
     private let modelContainer: ModelContainer?
     private let initError: String?
@@ -115,18 +116,16 @@ struct VReaderApp: App {
             )
 
             #if DEBUG
-            // Build the DebugBridge synchronously so .onOpenURL can never
-            // race with bridge construction. App init runs on the main
-            // thread; assumeIsolated is the right tool for entering the
-            // MainActor-isolated context from a nonisolated struct init.
-            self.debugBridge = MainActor.assumeIsolated {
-                DebugBridge(
-                    context: RealDebugBridgeContext(
-                        persistence: persistence,
-                        importer: importer
-                    )
+            // Build the DebugBridge synchronously. The struct is
+            // @MainActor-isolated, so init() runs on the main actor and
+            // we can construct the @MainActor DebugBridge directly with
+            // no isolation gymnastics.
+            self.debugBridge = DebugBridge(
+                context: RealDebugBridgeContext(
+                    persistence: persistence,
+                    importer: importer
                 )
-            }
+            )
             #endif
         } catch {
             self.modelContainer = nil

--- a/vreader/Services/DebugBridge/DebugBridge.swift
+++ b/vreader/Services/DebugBridge/DebugBridge.swift
@@ -72,6 +72,38 @@ final class DebugBridge {
         }
     }
 
+    /// Render an error as a stable string for the snapshot's `lastError`
+    /// field. Format is `"category: detail"`; consumers may pin on the
+    /// category prefix without depending on Swift's enum-case spelling.
+    /// Categories: `parse.<kind>`, `bridge.<kind>`, `unknown`.
+    /// `nonisolated` so tests can call without hopping to MainActor.
+    nonisolated static func stableErrorMessage(for error: Error) -> String {
+        switch error {
+        case let e as DebugCommandError:
+            switch e {
+            case .invalidScheme:
+                return "parse.invalidScheme"
+            case .unknownCommand(let host):
+                return "parse.unknownCommand: \(host)"
+            case .missingParam(let name):
+                return "parse.missingParam: \(name)"
+            case .invalidParam(let name, let reason):
+                return "parse.invalidParam: \(name) (\(reason))"
+            }
+        case let e as DebugBridgeContextError:
+            switch e {
+            case .unknownFixture(let name):
+                return "bridge.unknownFixture: \(name)"
+            case .fixtureResourceMissing(let name):
+                return "bridge.fixtureResourceMissing: \(name)"
+            case .notImplemented(let cmd):
+                return "bridge.notImplemented: \(cmd)"
+            }
+        default:
+            return "unknown: \(String(describing: type(of: error)))"
+        }
+    }
+
     private func dispatch(_ cmd: DebugCommand) async throws {
         switch cmd {
         case .reset:
@@ -88,7 +120,7 @@ final class DebugBridge {
             // Pass the bridge's current lastError so snapshot can encode it.
             // After this call returns successfully, process() clears lastError
             // — the snapshot captures the state at dispatch time.
-            let msg = lastError.map { String(describing: $0) }
+            let msg = lastError.map { Self.stableErrorMessage(for: $0) }
             try await context.snapshot(dest: dest, lastErrorMessage: msg)
         case .eval(let bridge, let js):
             try await context.eval(bridge: bridge, js: js)

--- a/vreader/Services/DebugBridge/DebugSnapshot.swift
+++ b/vreader/Services/DebugBridge/DebugSnapshot.swift
@@ -11,7 +11,15 @@ import Foundation
 /// `DebugSnapshot.encoder` (sorted keys for deterministic output, explicit
 /// `null` for missing values so consumers can distinguish "absent" from
 /// "unknown").
+///
+/// Schema versioning: bump `schemaVersion` whenever fields are added,
+/// removed, or change semantics. The `partial` array names fields whose
+/// nil value means "not yet implemented in this build" rather than "no
+/// value" — consumers should not treat partial-listed nil fields as
+/// authoritative.
 struct DebugSnapshot: Codable, Equatable {
+    /// Schema version. Increment on field add/remove/semantics-change.
+    let schemaVersion: Int
     let ts: String
     let currentBookId: String?
     let format: String?
@@ -22,6 +30,14 @@ struct DebugSnapshot: Codable, Equatable {
     let highlightCount: Int
     let renderPhase: String
     let lastError: String?
+    /// Field names whose nil value in this snapshot means "not yet
+    /// implemented" rather than "no value". Empty/nil array means every
+    /// nil field is authoritative.
+    let partial: [String]?
+
+    /// Current schema version. Update with care — consumers may pin a
+    /// version they recognize.
+    static let currentSchemaVersion = 1
 
     /// Selected text in the active reader, if any.
     struct SelectionInfo: Codable, Equatable {
@@ -42,14 +58,15 @@ struct DebugSnapshot: Codable, Equatable {
     }()
 
     enum CodingKeys: String, CodingKey {
-        case ts, currentBookId, format, position, theme, fontSize
-        case selection, highlightCount, renderPhase, lastError
+        case schemaVersion, ts, currentBookId, format, position, theme, fontSize
+        case selection, highlightCount, renderPhase, lastError, partial
     }
 
     /// Custom encoder: emits every field, writing `null` for nil optionals
     /// so consumers can distinguish "absent" from "unknown".
     func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(schemaVersion, forKey: .schemaVersion)
         try c.encode(ts, forKey: .ts)
         try Self.encodeOptional(currentBookId, forKey: .currentBookId, in: &c)
         try Self.encodeOptional(format, forKey: .format, in: &c)
@@ -60,6 +77,7 @@ struct DebugSnapshot: Codable, Equatable {
         try c.encode(highlightCount, forKey: .highlightCount)
         try c.encode(renderPhase, forKey: .renderPhase)
         try Self.encodeOptional(lastError, forKey: .lastError, in: &c)
+        try Self.encodeOptional(partial, forKey: .partial, in: &c)
     }
 
     private static func encodeOptional<T: Encodable>(

--- a/vreader/Services/DebugBridge/RealDebugBridgeContext.swift
+++ b/vreader/Services/DebugBridge/RealDebugBridgeContext.swift
@@ -4,9 +4,10 @@
 // WI-5 commits) so each command performs real work rather than logging.
 // DEBUG-only.
 //
-// Composition: VReaderApp.init() builds one of these with the same
-// dependencies it injects into LibraryViewModel, then installs it on
-// DebugBridgeProvider.shared so .onOpenURL dispatches to the real handlers.
+// Composition: VReaderApp builds one of these with the same dependencies
+// it injects into LibraryViewModel and stores it as a `let debugBridge`
+// property. .onOpenURL captures the bridge by value and dispatches to
+// it. There is no global indirection — the bridge is owned by the App.
 
 #if DEBUG
 
@@ -123,14 +124,16 @@ final class RealDebugBridgeContext: DebugBridgeContext {
     /// impossible.
     ///
     /// V0 fields filled in: ts, theme, fontSize, highlightCount, renderPhase
-    /// ("idle"), lastError. Reader-derived fields (currentBookId, format,
-    /// position, selection) are nil until the active-reader registry lands
-    /// in a later WI-5 commit.
+    /// ("idle"), lastError, schemaVersion, partial.
+    /// Reader-derived fields (currentBookId, format, position, selection)
+    /// are listed in `partial` so consumers know nil ≠ "no value" — they
+    /// land when the active-reader registry ships in a later WI-5 commit.
     func snapshot(dest: String, lastErrorMessage: String?) async throws {
         let store = ReaderSettingsStore(defaults: userDefaults)
         let highlightCount = try await totalHighlightCount()
 
         let snap = DebugSnapshot(
+            schemaVersion: DebugSnapshot.currentSchemaVersion,
             ts: ISO8601DateFormatter().string(from: Date()),
             currentBookId: nil,
             format: nil,
@@ -140,7 +143,8 @@ final class RealDebugBridgeContext: DebugBridgeContext {
             selection: nil,
             highlightCount: highlightCount,
             renderPhase: "idle",
-            lastError: lastErrorMessage
+            lastError: lastErrorMessage,
+            partial: ["currentBookId", "format", "position", "selection"]
         )
 
         let data = try DebugSnapshot.encoder.encode(snap)
@@ -168,13 +172,7 @@ final class RealDebugBridgeContext: DebugBridgeContext {
     }
 
     private func totalHighlightCount() async throws -> Int {
-        let books = try await persistence.fetchAllLibraryBooks()
-        var total = 0
-        for book in books {
-            let highlights = try await persistence.fetchHighlights(forBookWithKey: book.fingerprintKey)
-            total += highlights.count
-        }
-        return total
+        try await persistence.countAllHighlights()
     }
 
     func eval(bridge: String, js: String) async throws {

--- a/vreader/Services/PersistenceActor+Highlights.swift
+++ b/vreader/Services/PersistenceActor+Highlights.swift
@@ -143,6 +143,14 @@ extension PersistenceActor: HighlightPersisting {
             .map { highlightToRecord($0) }
     }
 
+    /// Total count of all highlights in the library, across all books.
+    /// Single aggregate query — does not materialize any record.
+    func countAllHighlights() async throws -> Int {
+        let context = ModelContext(modelContainer)
+        let descriptor = FetchDescriptor<Highlight>()
+        return try context.fetchCount(descriptor)
+    }
+
     // MARK: - Private
 
     private func highlightToRecord(_ highlight: Highlight) -> HighlightRecord {

--- a/vreaderTests/Services/DebugBridge/DebugBridgeTests.swift
+++ b/vreaderTests/Services/DebugBridge/DebugBridgeTests.swift
@@ -80,6 +80,46 @@ final class DebugBridgeTests: XCTestCase {
         XCTAssertEqual(context.calls, [.reset, .seed(fixture: "alice"), .reset])
     }
 
+    // MARK: - stableErrorMessage
+
+    func test_stableErrorMessage_parseErrors_useParsePrefix() {
+        XCTAssertEqual(
+            DebugBridge.stableErrorMessage(for: DebugCommandError.invalidScheme),
+            "parse.invalidScheme"
+        )
+        XCTAssertEqual(
+            DebugBridge.stableErrorMessage(for: DebugCommandError.unknownCommand("teleport")),
+            "parse.unknownCommand: teleport"
+        )
+        XCTAssertEqual(
+            DebugBridge.stableErrorMessage(for: DebugCommandError.missingParam("fixture")),
+            "parse.missingParam: fixture"
+        )
+    }
+
+    func test_stableErrorMessage_bridgeContextErrors_useBridgePrefix() {
+        XCTAssertEqual(
+            DebugBridge.stableErrorMessage(for: DebugBridgeContextError.unknownFixture("foo")),
+            "bridge.unknownFixture: foo"
+        )
+        XCTAssertEqual(
+            DebugBridge.stableErrorMessage(for: DebugBridgeContextError.fixtureResourceMissing("foo.txt")),
+            "bridge.fixtureResourceMissing: foo.txt"
+        )
+        XCTAssertEqual(
+            DebugBridge.stableErrorMessage(for: DebugBridgeContextError.notImplemented(command: "open")),
+            "bridge.notImplemented: open"
+        )
+    }
+
+    func test_stableErrorMessage_unknownError_usesUnknownPrefix() {
+        struct DummyError: Error {}
+        let msg = DebugBridge.stableErrorMessage(for: DummyError())
+        XCTAssertTrue(msg.hasPrefix("unknown:"), "got \(msg)")
+    }
+
+    // MARK: - Routing
+
     @MainActor
     func test_handle_concurrentCalls_doNotInterleave() async {
         // A slow context exposes interleaving. Without serialization, two

--- a/vreaderTests/Services/DebugBridge/DebugSnapshotTests.swift
+++ b/vreaderTests/Services/DebugBridge/DebugSnapshotTests.swift
@@ -14,6 +14,7 @@ final class DebugSnapshotTests: XCTestCase {
 
     func test_encode_includesAllRequiredKeys() throws {
         let snap = DebugSnapshot(
+            schemaVersion: 1,
             ts: "2026-05-02T10:00:00Z",
             currentBookId: "book-123",
             format: "epub",
@@ -23,19 +24,21 @@ final class DebugSnapshotTests: XCTestCase {
             selection: nil,
             highlightCount: 3,
             renderPhase: "settled",
-            lastError: nil
+            lastError: nil,
+            partial: nil
         )
         let dict = try encodeAsDictionary(snap)
         let expectedKeys: Set<String> = [
-            "ts", "currentBookId", "format", "position",
+            "schemaVersion", "ts", "currentBookId", "format", "position",
             "theme", "fontSize", "selection", "highlightCount",
-            "renderPhase", "lastError",
+            "renderPhase", "lastError", "partial",
         ]
         XCTAssertEqual(Set(dict.keys), expectedKeys)
     }
 
     func test_encode_outputIsStableJSON_sortedKeys() throws {
         let snap = DebugSnapshot(
+            schemaVersion: 1,
             ts: "2026-05-02T10:00:00Z",
             currentBookId: nil,
             format: nil,
@@ -45,7 +48,8 @@ final class DebugSnapshotTests: XCTestCase {
             selection: nil,
             highlightCount: 0,
             renderPhase: "idle",
-            lastError: nil
+            lastError: nil,
+            partial: nil
         )
         let data = try DebugSnapshot.encoder.encode(snap)
         let json = String(decoding: data, as: UTF8.self)
@@ -66,6 +70,7 @@ final class DebugSnapshotTests: XCTestCase {
 
     func test_encode_nilOptionalsRenderAsNullExplicitly() throws {
         let snap = DebugSnapshot(
+            schemaVersion: 1,
             ts: "2026-05-02T10:00:00Z",
             currentBookId: nil,
             format: nil,
@@ -75,7 +80,8 @@ final class DebugSnapshotTests: XCTestCase {
             selection: nil,
             highlightCount: 0,
             renderPhase: "idle",
-            lastError: nil
+            lastError: nil,
+            partial: nil
         )
         let dict = try encodeAsDictionary(snap)
         // Explicit nulls so the consumer can distinguish "absent" from "unknown".
@@ -90,6 +96,7 @@ final class DebugSnapshotTests: XCTestCase {
 
     func test_encode_nonNilOptionalsRenderWithValues() throws {
         let snap = DebugSnapshot(
+            schemaVersion: 1,
             ts: "2026-05-02T10:00:00Z",
             currentBookId: "uuid-1",
             format: "txt",
@@ -99,7 +106,8 @@ final class DebugSnapshotTests: XCTestCase {
             selection: nil,
             highlightCount: 7,
             renderPhase: "settled",
-            lastError: "nothing"
+            lastError: "nothing",
+            partial: ["currentBookId"]
         )
         let dict = try encodeAsDictionary(snap)
         XCTAssertEqual(dict["currentBookId"] as? String, "uuid-1")
@@ -117,6 +125,7 @@ final class DebugSnapshotTests: XCTestCase {
     func test_encode_selectionRendersAsNestedObject() throws {
         let selection = DebugSnapshot.SelectionInfo(text: "hello", startOffset: 100, endOffset: 105)
         let snap = DebugSnapshot(
+            schemaVersion: 1,
             ts: "2026-05-02T10:00:00Z",
             currentBookId: "book",
             format: "epub",
@@ -126,7 +135,8 @@ final class DebugSnapshotTests: XCTestCase {
             selection: selection,
             highlightCount: 0,
             renderPhase: "settled",
-            lastError: nil
+            lastError: nil,
+            partial: nil
         )
         let dict = try encodeAsDictionary(snap)
         let nested = dict["selection"] as? [String: Any]
@@ -140,6 +150,7 @@ final class DebugSnapshotTests: XCTestCase {
 
     func test_roundTrip_preservesAllFields() throws {
         let original = DebugSnapshot(
+            schemaVersion: 1,
             ts: "2026-05-02T10:00:00Z",
             currentBookId: "uuid",
             format: "azw3",
@@ -149,7 +160,8 @@ final class DebugSnapshotTests: XCTestCase {
             selection: .init(text: "world", startOffset: 0, endOffset: 5),
             highlightCount: 12,
             renderPhase: "settled",
-            lastError: nil
+            lastError: nil,
+            partial: ["selection"]
         )
         let data = try DebugSnapshot.encoder.encode(original)
         let decoded = try JSONDecoder().decode(DebugSnapshot.self, from: data)

--- a/vreaderTests/Services/DebugBridge/RealDebugBridgeContextTests.swift
+++ b/vreaderTests/Services/DebugBridge/RealDebugBridgeContextTests.swift
@@ -285,6 +285,7 @@ final class RealDebugBridgeContextTests: XCTestCase {
         let data = try Data(contentsOf: url)
         let snap = try JSONDecoder().decode(DebugSnapshot.self, from: data)
 
+        XCTAssertEqual(snap.schemaVersion, 1)
         XCTAssertFalse(snap.ts.isEmpty)
         XCTAssertEqual(snap.theme, "dark")
         XCTAssertEqual(snap.fontSize, 22)
@@ -295,6 +296,11 @@ final class RealDebugBridgeContextTests: XCTestCase {
         XCTAssertNil(snap.format)
         XCTAssertNil(snap.position)
         XCTAssertNil(snap.selection)
+        // partial lists fields whose nil means "not yet implemented"
+        XCTAssertEqual(
+            Set(snap.partial ?? []),
+            Set(["currentBookId", "format", "position", "selection"])
+        )
 
         // Cleanup
         try? FileManager.default.removeItem(at: url)
@@ -317,9 +323,11 @@ final class RealDebugBridgeContextTests: XCTestCase {
     }
 
     @MainActor
-    func test_snapshot_afterFailedCommand_includesErrorInJSON() async throws {
+    func test_snapshot_afterFailedCommand_includesStableErrorCodeInJSON() async throws {
         // Drive through the bridge so lastError flows from a failed dispatch
-        // into the snapshot via the parameter.
+        // into the snapshot via the parameter. Asserts on the stable error
+        // code prefix (`bridge.unknownFixture`) — independent of Swift's
+        // enum-case spelling.
         let context = RealDebugBridgeContext(
             persistence: persistence,
             importer: importer,
@@ -337,8 +345,8 @@ final class RealDebugBridgeContextTests: XCTestCase {
         let snap = try JSONDecoder().decode(DebugSnapshot.self, from: Data(contentsOf: url))
         XCTAssertNotNil(snap.lastError, "snapshot must encode bridge.lastError from previous failure")
         XCTAssertTrue(
-            snap.lastError?.contains("unknownFixture") == true,
-            "lastError content should mention the previous failure: \(snap.lastError ?? "nil")"
+            snap.lastError?.hasPrefix("bridge.unknownFixture") == true,
+            "lastError must start with the stable category prefix `bridge.unknownFixture`, got: \(snap.lastError ?? "nil")"
         )
         try? FileManager.default.removeItem(at: url)
     }


### PR DESCRIPTION
## Summary

Post-Codex-audit-3 hardening for the DebugBridge feature. Six findings landed in one commit (`e3dda1a`):

1. **Snapshot adds `schemaVersion` + `partial` fields** — consumers can now distinguish "no value" from "not yet implemented".
2. **`@MainActor` on VReaderApp** — eliminates `MainActor.assumeIsolated`, gives compile-time isolation guarantee.
3. **Stable error serialization** — `lastError` JSON now uses category prefixes (`bridge.unknownFixture: <name>`) instead of `String(describing:)` enum spellings; refactor-safe.
4. **Release verifier rejects every fixture filename** — closes the gap where flat-copied fixtures could leak past the directory check.
5. **`highlightCount` uses `fetchCount` aggregate** — O(1) instead of N+1.
6. **Stale comment fix** — RealDebugBridgeContext header no longer references the removed `DebugBridgeProvider`.

## Test plan

- [x] 71/71 unit tests pass in 0.34s
- [x] Debug build clean
- [x] Release build clean
- [x] `scripts/verify-release-no-debugbridge.sh` passes 6/6 checks (added fixture-filename check)
- [x] End-to-end smoke test on iPhone 17 Pro simulator: failed seed → snapshot shows `schemaVersion: 1`, `partial: [...]`, `lastError: "bridge.unknownFixture: missing"`

Refs #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)