### PR TITLE
docs(AGENTS): point at dev-docs/debug-bridge.md as the verification harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Shared instructions for all AI agents (Claude, Codex, etc.).
     - Exceptions: CSS-only, docs, config. See `.claude/rules/10-tdd.md` for full scope.
   - Run `xcodebuild test -only-testing:vreaderTests` for unit test gates. Skip UI tests during development.
   - Default simulator: **iPhone 17 Pro** (Dynamic Island — catches safe area bugs).
+  - **Verification harness** (DEBUG only): `vreader-debug://` URL scheme drives reset / seed / open / settle / snapshot / eval from `xcrun simctl openurl`, so verification runs don't need computer-use for reproduction or assertion. See `dev-docs/debug-bridge.md`.
   - **Task workflow** (three files, one flow):
     - `docs/tasks.md` — **inbox**. User writes free-form descriptions. Agent triages (classify only, do not fix or implement during triage). See `docs/tasks.md` for classification rules, deduplication, and triage record format.
     - `docs/bugs.md` — **bug tracker**. Something implemented but broken. Follow the bug fix workflow defined in `docs/bugs.md` (Understand → RED → GREEN → REFACTOR → Verify → Track).


### PR DESCRIPTION
## Summary

One-line pointer in AGENTS.md so agents discover `vreader-debug://` instead of falling back to computer-use for simulator verification.

Surfaced during the WebDAV backup verification (PR #128) — I drove the new backup section through Save → Back Up Now → Restore → Delete via mouse clicks on the simulator window, which is dramatically slower than the URL-scheme recipes already documented in `dev-docs/debug-bridge.md`. AGENTS.md was the natural place to discover the harness, but it had no reference to the dev-doc.

## Test plan

- [x] AGENTS.md still under 50 lines, fits the existing working-agreement bullet style
- [x] Doesn't duplicate content — points at the existing canonical doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)