### PR TITLE
docs: require a version bump in every PR + bump to 3.10.2

### DIFF
--- a/.claude/rules/40-version-bump.md
+++ b/.claude/rules/40-version-bump.md
@@ -2,6 +2,26 @@
 
 vreader's version lives in `project.yml` (xcodegen) under `targets: vreader: settings: base:`. xcodegen regenerates `vreader.xcodeproj/project.pbxproj` from it; pbxproj is checked in but should not be hand-edited for a bump.
 
+## When to bump
+
+**Every PR must include a version bump.** The version line is owned by the PR
+that ships the change, not by a separate release commit, so:
+
+- **Bump before opening the PR** — bumping after the PR is open and rebasing
+  conflicts with reviews.
+- **Bump as the last step on the branch** — after the feature commits are in,
+  not interleaved with them. A clean tail commit `chore: bump version to X.Y.Z`
+  is easier to revert than a bump folded into a feature commit.
+- **Choose increment by impact:**
+  - `patch` — bug fix, docs, chores, refactors with no externally-visible change.
+  - `minor` — new user-visible feature or capability.
+  - `major` — breaking change to data, schema, or public contract.
+- `CURRENT_PROJECT_VERSION` always increments by ≥1 — App Store Connect rejects
+  uploads with a non-monotonic build number.
+
+The post-merge tag (`git tag v{version}` on the merge commit) is cut by the
+finalizer once the PR lands on `main`.
+
 ## Files to Update
 
 | File          | Field                                                       |
@@ -22,7 +42,7 @@ git diff vreader.xcodeproj/project.pbxproj | grep -E "MARKETING_VERSION|CURRENT_
 
 ## Bump Procedure
 
-1. **Edit ****`project.yml`** — change `MARKETING_VERSION` to the new version. Bump `CURRENT_PROJECT_VERSION` too (always increasing — App Store requires a higher build number than any previously-uploaded build).
+1. \*\*Edit \*\***`project.yml`** — change `MARKETING_VERSION` to the new version. Bump `CURRENT_PROJECT_VERSION` too (always increasing — App Store requires a higher build number than any previously-uploaded build).
 
 2. **Regenerate the Xcode project**:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Shared instructions for all AI agents (Claude, Codex, etc.).
   - Run `xcodebuild test -only-testing:vreaderTests` for unit test gates. Skip UI tests during development.
   - Default simulator: **iPhone 17 Pro** (Dynamic Island — catches safe area bugs).
   - **Verification harness** (DEBUG only): `vreader-debug://` URL scheme drives reset / seed / open / settle / snapshot / eval from `xcrun simctl openurl`, so verification runs don't need computer-use for reproduction or assertion. See `dev-docs/debug-bridge.md`.
+  - **Version bump per PR**: every PR must include a `chore: bump version to X.Y.Z` commit as its last commit before opening — patch for fixes/docs/chores, minor for new features, major for breaking changes. Tag is cut from the merge commit on `main` post-merge. See `.claude/rules/40-version-bump.md`.
   - **Task workflow** (three files, one flow):
     - `docs/tasks.md` — **inbox**. User writes free-form descriptions. Agent triages (classify only, do not fix or implement during triage). See `docs/tasks.md` for classification rules, deduplication, and triage record format.
     - `docs/bugs.md` — **bug tracker**. Something implemented but broken. Follow the bug fix workflow defined in `docs/bugs.md` (Understand → RED → GREEN → REFACTOR → Verify → Track).

--- a/project.yml
+++ b/project.yml
@@ -30,8 +30,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
         GENERATE_INFOPLIST_FILE: YES
-        CURRENT_PROJECT_VERSION: 2
-        MARKETING_VERSION: 3.10.1
+        CURRENT_PROJECT_VERSION: 3
+        MARKETING_VERSION: 3.10.2
         INFOPLIST_KEY_CFBundleDisplayName: vreader
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
         INFOPLIST_KEY_UISupportedInterfaceOrientations: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3760,7 +3760,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = vreader;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -3770,7 +3770,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.1;
+				MARKETING_VERSION = 3.10.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3914,7 +3914,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = vreader;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -3924,7 +3924,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.1;
+				MARKETING_VERSION = 3.10.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

Adds a project rule requiring every PR to land with a tail `chore: bump version to X.Y.Z` commit. Patch for fixes/docs/chores, minor for new features, major for breaking changes.

## Rationale

After PR #128 (WebDAV backup) and PR #129 (DebugBridge pointer) both landed without touching the version line, `MARKETING_VERSION` stayed at `0.1.0` until I bumped it manually in #130. Owning the version in each PR keeps that line honest without a separate release cadence.

## Test plan

- [x] AGENTS.md gets a one-line bullet next to the existing test/simulator/harness bullets
- [x] .claude/rules/40-version-bump.md gets a new `When to bump` section above the procedure
- [x] This PR follows the new rule — tail commit `chore: bump version to 3.10.2` (patch — docs/rule change only)
- [x] `xcodegen generate` clean; pbxproj diff matches; `** BUILD SUCCEEDED **`

🤖 Generated with [Claude Code](https://claude.com/claude-code)