### PR TITLE
docs: link self-host recipe repo from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ VReader is a modern reading app designed for iPhone and iPad, built entirely by 
 
 ### Sync & Backup
 
-- **WebDAV backup** — Archive to any WebDAV server (Nutstore compatible)
+- **WebDAV backup** — Archive to any WebDAV server (Nutstore compatible). For a self-hosted Mac setup with iCloud Drive sync, see [`lllyys/vreader-webdav-host`](https://github.com/lllyys/vreader-webdav-host).
 - **Per-book settings** — Font, theme, spacing overrides per book (JSON-persisted)
 - **Theme backgrounds** — Custom background images via PhotosPicker with per-theme opacity
 

--- a/project.yml
+++ b/project.yml
@@ -30,8 +30,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
         GENERATE_INFOPLIST_FILE: YES
-        CURRENT_PROJECT_VERSION: 6
-        MARKETING_VERSION: 3.10.5
+        CURRENT_PROJECT_VERSION: 7
+        MARKETING_VERSION: 3.10.6
         INFOPLIST_KEY_CFBundleDisplayName: vreader
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
         INFOPLIST_KEY_UISupportedInterfaceOrientations: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3760,7 +3760,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = vreader;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -3770,7 +3770,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.5;
+				MARKETING_VERSION = 3.10.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3914,7 +3914,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 6;
+				CURRENT_PROJECT_VERSION = 7;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = vreader;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -3924,7 +3924,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.5;
+				MARKETING_VERSION = 3.10.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

One-line addition to the WebDAV backup feature in README pointing at the new companion repo `lllyys/vreader-webdav-host`.

## Context

The companion repo will hold the Mac-side self-host recipe (`rclone serve webdav` + launchd + iCloud Drive sync, Tailscale-fronted). Keeps server infra out of the iOS app source tree.

## Test plan

- [x] `xcodegen generate` clean
- [x] Tail commit: `chore: bump version to 3.10.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)