### PR TITLE
docs: triage bug #110 — WebDAV ATS blocks Tailscale URL (Refs #136)

### DIFF
--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -48,6 +48,15 @@ Track bugs here. Tell the agent "fix bug #N" to start a fix.
 <!-- For each TODO/IN PROGRESS/REOPENED bug, add a short entry here.
      Max 6 lines per bug. Remove on FIXED (move to archive). -->
 
+### Bug #110 — WebDAV Test Connection blocked by App Transport Security on Tailscale URL
+- **Repro**: Settings → WebDAV Backup → enter `http://<machine>.tail-XXXXX.ts.net:8080` + creds → tap Test Connection
+- **Expected**: HTTP 401 → "Authentication failed" (or success if creds valid)
+- **Actual**: "Connection error: The resource could not be loaded because the App Transport Security policy requires the use of a secure connection." (request never leaves the device)
+- **Root cause**: `project.yml` does not declare `NSAppTransportSecurity` exceptions. iOS ATS blocks HTTP to non-loopback hostnames. Localhost works because iOS treats loopback as exempt.
+- **Impact**: Tailscale-fronted use case (documented in WebDAVSettingsView footer + companion repo `vreader-webdav-host`) is broken. Plain HTTP to Nutstore/NextCloud/Synology over their public hostnames also fails for the same reason.
+- **Fix options**: (a) `NSAllowsLocalNetworking: YES` + per-domain `NSExceptionDomains` for `ts.net` — minimal exception, safest for App Store review; (b) `NSAllowsArbitraryLoads: YES` — broadest, but App Store may push back; (c) document HTTPS-only and ship with no ATS change. Recommend (a).
+- **Screenshots**: `docs/assets/images/clipboard-1777788873034-qu9x-1777788873038-void.png`
+
 ### Bug #103 — Cannot add highlight in native EPUB
 - **Repro**: Open EPUB in native reader, select text, tap Highlight
 - **Expected**: Highlight created and rendered in-page
@@ -204,3 +213,4 @@ Track bugs here. Tell the agent "fix bug #N" to start a fix.
 | 107| Cover images with light/white edges show visible "padding" in library grid                             | Library/* | Low      | TODO     | Cover art with white areas at edges blends into white page background, creating illusion of padding. Need auto-crop or contrast treatment. |
 | 108| AZW3/Foliate reader: center tap does not toggle chrome                                                 | Foliate/* | Medium   | TODO     | Toolbar stays visible on center tap in FoliateSpikeView. EPUB chrome toggle works. WKWebView may consume tap. |
 | 109| TXT chapter mode: progress bar shows book progress instead of chapter progress                         | TXT/*     | Medium   | FIXED    | Fixed in bfd8345. Added currentChapterLocalUTF16 to TXTReaderViewModel; bridge stores local offset, persistence converts to global. 4 new tests. GH: #31 |
+| 110| WebDAV Test Connection blocked by App Transport Security on Tailscale URL                              | Backup/*  | High     | TODO     | iOS ATS rejects plain HTTP to `*.ts.net` (and any non-loopback host). Test Connection on Tailscale URL fails with "The resource could not be loaded because the App Transport Security policy requires the use of a secure connection." Backup feature unusable over Tailscale despite being a documented use case. Fix: add NSAppTransportSecurity exception in project.yml (NSAllowsLocalNetworking + per-domain exception for `.ts.net`, OR NSAllowsArbitraryLoads with App Store-review caveat). GH: #136 |

--- a/project.yml
+++ b/project.yml
@@ -30,8 +30,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
         GENERATE_INFOPLIST_FILE: YES
-        CURRENT_PROJECT_VERSION: 7
-        MARKETING_VERSION: 3.10.6
+        CURRENT_PROJECT_VERSION: 8
+        MARKETING_VERSION: 3.10.7
         INFOPLIST_KEY_CFBundleDisplayName: vreader
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
         INFOPLIST_KEY_UISupportedInterfaceOrientations: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3760,7 +3760,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = vreader;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -3770,7 +3770,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.6;
+				MARKETING_VERSION = 3.10.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3914,7 +3914,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 8;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = vreader;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -3924,7 +3924,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.6;
+				MARKETING_VERSION = 3.10.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

Triage record for bug #110 + GH issue #136.

iOS ATS blocks plain HTTP to `*.ts.net` (and any non-loopback host). Test Connection on Tailscale URL fails before the request leaves the device. Localhost works because iOS exempts loopback.

## Triage outcome

- **Tailscale screenshot** → bug #110 (HIGH). Recorded with full Repro/Expected/Actual/Root-cause/Fix-options.
- **Localhost screenshot** → NO-ACTION. Server returned 401 to curl with the same creds → user-config issue (server htpasswd doesn't match typed creds).

## Test plan

- [x] Bug #110 row in summary table + Open Bug Detail entry
- [x] GH issue #136 created with severity:high label
- [x] Standalone `docs/Bug-webdav.md` removed (its screenshots are now referenced from the Open Bug Detail entry)
- [x] Tail commit: `chore: bump version to 3.10.7`

## Out of scope for this PR

The actual fix (NSAppTransportSecurity exception in project.yml) is a separate PR. This PR only records the triage.

Refs #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)