### PR TITLE
docs(tasks): record feature #46 triage

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -40,6 +40,8 @@ Describe issues in plain text below. The agent will triage them.
 
 ## Triaged
 
+2026-05-03 | feature #46 | WebDAV restore leaves library empty — backup is metadata-only by design (`BackupDataCollector.swift:12` "Books that no longer exist on the restoring device are silently skipped"). Inspected the user's ZIP (`2026-05-03T08-07-21Z_cfaff06e.vreader.zip`): 8 JSON sections, `metadata.json` records `bookCount: 5`, `positions.json` has 5 entries keyed by fingerprint, but no book files. On a fresh / empty library, restoration finds no matching books and silently no-ops. New feature scope: include book bytes in the archive so restore reconstructs the library.
+
 2026-05-03 | DUPLICATE OF bug #110 | WebDAV Tailscale URL — same ATS issue captured in screenshot. FIXED in v3.10.9 (PR #139); end-to-end verified 2026-05-03 against rclone-backed `vreader-webdav-host` over Tailscale on simulator (build 10) — connection succeeds once system HTTP-proxy bypass includes `*.ts.net`. GH #136 closed.
 
 2026-05-03 | NO-ACTION | WebDAV localhost auth failed (earlier 401, then 502 over Tailscale) — root cause was a system HTTP proxy on the Mac (`127.0.0.1:7897`, ClashX/Surge-style) whose bypass list excluded `*.ts.net`. iOS Simulator inherits the Mac's proxy → URLSession funnelled Tailscale traffic through the proxy → 502 Bad Gateway. Localhost worked because it was already in the bypass list. Not a vreader bug — user-side network config. Resolution: add `*.ts.net` and `100.64.0.0/10` to the proxy bypass list. Stale Docker WebDAV container (`bytemark/webdav` on port 8080) was also masking the rclone server's creds — removed in same session.

--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 13
-        MARKETING_VERSION: 3.10.12
+        CURRENT_PROJECT_VERSION: 14
+        MARKETING_VERSION: 3.10.13
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3766,13 +3766,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.12;
+				MARKETING_VERSION = 3.10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3916,13 +3916,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.12;
+				MARKETING_VERSION = 3.10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

Records the inbox triage entry pointing to feature #46 (planned in PR #142). Was missed in that PR's commit set.

## What Changed

- `docs/tasks.md` — adds `2026-05-03 | feature #46 | WebDAV restore leaves library empty …` triage record to the Triaged section.
- Version bump to 3.10.13 (build 14).

## Type of Change

- [x] Tracker / inbox record only