### PR TITLE
docs: symmetric close-gate rule (bugs + features) + GH refs for #46/#47

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,10 @@ Shared instructions for all AI agents (Claude, Codex, etc.).
   - **Version bump per PR**: every PR must include a `chore: bump version to X.Y.Z` commit as its last commit before opening — patch for fixes/docs/chores, minor for new features, major for breaking changes. Tag is cut from the merge commit on `main` post-merge. See `.claude/rules/40-version-bump.md`.
   - **Docs sync per PR**: when a PR adds a service, schema, notification, environment key, or user-visible feature, update `docs/architecture.md` and/or `README.md` in the same PR (separate commit before the version bump). Triggers + checklist in `.claude/rules/24-doc-sync.md`.
   - **Merge gate — fix-or-implement**: a PR that references an open bug (`Refs #N` against `docs/bugs.md`) does not merge until that bug's status is `FIXED`. A PR that references an open feature does not merge until the feature reaches `DONE`. Tracker-only updates (re-classifying severity, correcting a recommendation, adding screenshots) ride along with the fix PR — they don't ship as standalone merges. Pure meta-process changes (rule additions, repo reorgs, tooling) are exempt because they don't reference a bug/feature row.
-  - **Close gate — device-verified**: a GitHub Issue does NOT close until the bug is **device-verified** (or, for non-UI bugs, end-to-end verified against a real environment — not just unit tests). `docs/bugs.md` status `FIXED` means "code shipped to main with passing tests"; that's the merge gate. Closing the GH issue requires a separate verification pass: install the new build on device/simulator, run the original repro, confirm the actual symptom is gone. The closure comment must cite the verification (commit SHA + what was tested + what was observed). Until then, the GH issue stays open with a "fixed in vX.Y.Z, awaiting verification" comment so the bug doesn't drop off the radar.
+  - **Close gate — verified, not just merged**: a GitHub Issue does NOT close until the work is end-to-end verified against a real environment — not just unit tests. Symmetric for both trackers:
+    - **Bugs**: `docs/bugs.md` status `FIXED` means "code shipped to main with passing tests" (the merge gate). Closing the GH issue requires a separate device-verification pass: install the new build on device/simulator, run the original repro, confirm the actual symptom is gone.
+    - **Features**: `docs/features.md` status `DONE` means "implementation merged with passing tests" (the merge gate). Closing the GH issue requires reaching status `VERIFIED`: every acceptance criterion exercised end-to-end (XCUITest + DebugBridge auto-verification, or an explicit on-device manual verification log) — for non-UI features, end-to-end against a real backend (e.g., backup → restore round-trip against a live WebDAV server, not just an in-memory mock).
+    - The closure comment must cite the verification (commit SHA + what was tested + what was observed). Until then, the GH issue stays open with a "shipped in vX.Y.Z, awaiting verification" comment so the work doesn't drop off the radar.
   - **Task workflow** (three files, one flow). The `## Rules` section at the top of each tracker is **binding** — it's the authoritative workflow for that file, not decorative prose:
     - `docs/tasks.md` — **inbox**. User writes free-form descriptions. Agent triages (classify only, do not fix or implement during triage). Classification rules, deduplication, and triage record format are at the top of the file.
     - `docs/bugs.md` — **bug tracker**. Something implemented but broken. Bug fix workflow (Understand → RED → GREEN → REFACTOR → Verify → Track) is at the top of the file.
@@ -41,11 +44,13 @@ Shared instructions for all AI agents (Claude, Codex, etc.).
     - **When to create**: High-severity bugs, release blockers, and major features (`Priority: High`). Do not mirror every tracker row.
     - **On create**: Add `GH: #123` to the Notes column in bugs.md/features.md. Use labels: `bug`/`feature`, `severity:high`/`severity:medium`.
     - **PRs use `Refs #N`**, not `Fixes #N` — prevents premature auto-close.
-    - **On resolve** (post-merge finalizer, do not close before merge):
-      1. Verify markdown status is updated (FIXED/DONE).
+    - **On resolve** (post-merge finalizer, do not close before merge AND do not close before verification — see "Close gate — verified, not just merged" above):
+      1. Verify markdown status is updated to terminal-verified state (`FIXED` then device-verified for bugs; `VERIFIED` for features).
       2. Verify fix is on `main`.
-      3. Post closure comment: commit SHA, test evidence, cause summary (bugs) or acceptance result (features).
-      4. Run `gh issue close #N`.
+      3. Run the verification pass (re-run repro for bugs; exercise acceptance criteria for features).
+      4. Post closure comment: commit SHA, what was tested, what was observed, cause summary (bugs) or acceptance result (features).
+      5. Run `gh issue close #N`.
+      Between merge and verification, leave the issue open with a "shipped in vX.Y.Z, awaiting verification" comment.
     - **Exception**: Small single-issue fixes may use `Fixes #N` in PR body for auto-close.
     - **Partial delivery**: Keep issue open. Use task checklist in issue body or split into follow-up issues.
 - AI coding tool auth:

--- a/docs/features.md
+++ b/docs/features.md
@@ -19,11 +19,12 @@ Track features to be implemented here. Must be planned before implementation.
 3. Tell the agent: "implement feature #N" to start implementation
 4. Agent updates Status when done
 
-- **GitHub Issue closure** (post-merge finalizer — see `AGENTS.md` for full policy):
-  - If the feature has a `GH: #N` in Notes, close the GitHub Issue only after:
-    1. All acceptance criteria met and status is DONE in this file.
-    2. Implementation is merged to `main`.
-    3. Closure comment posted with commit SHA and acceptance result.
+- **GitHub Issue closure** (post-merge + post-verification finalizer — see `AGENTS.md` "Close gate — verified, not just merged" for the symmetric bug + feature rule):
+  - If the feature has a `GH: #N` in Notes, close the GitHub Issue only after **both** of the following:
+    1. **Merged**: implementation is on `main` and status in this file is `DONE` (every acceptance criterion implemented + tests passing).
+    2. **Verified**: status in this file has advanced to `VERIFIED` — every acceptance criterion exercised end-to-end (XCUITest + DebugBridge auto-verification, or an explicit on-device manual verification log; for non-UI features, end-to-end against a real backend such as a live WebDAV server, not just an in-memory mock).
+  - Closure comment cites the verification: commit SHA, what was tested, what was observed, acceptance-criterion-by-acceptance-criterion result.
+  - Between merge and verification (status `DONE` but not yet `VERIFIED`): leave the GH issue open with a "shipped in vX.Y.Z, awaiting verification" comment so the work does not drop off the radar.
   - Partial delivery: keep GitHub Issue open; use checklist or split follow-ups.
   - PRs use `Refs #N`, not `Fixes #N` (prevents premature auto-close).
 
@@ -96,8 +97,8 @@ Before setting a feature to `PLANNED`, fill in these fields in a sub-section und
 | 43 | Extract and display cover images from EPUB/AZW3               | Library/*    | Medium   | DONE      | EPUB OPF + AZW3 MOBI header parsing. 46 tests. Bug #107 for white-edge padding. GH: #121                                                                                        |
 | 44 | DebugBridge — debug-only URL scheme + state dumper for autonomous testing | DevTools/*  | High | DONE | DEBUG-only `vreader-debug://` handler with 7 commands (reset/seed/theme/open/settle/snapshot/eval). Active-reader registry, fixture catalog, stable error codes, release-gate script. 93 unit tests. Doc at `docs/subsystems/debug-bridge.md`. Future: per-format settle hooks, real WKWebView evaluator on EPUB/AZW3, selection probe field. |
 | 45 | Verification harness sweep — retire the "Needs device verification" backlog | DevTools/* | High | PLANNED | XCUITest + DebugBridge recipes for 13 of 15 simulator-automatable backlog items. Adds VERIFIED status. Depends on #44. See plan below. |
-| 46 | WebDAV backup includes book files — materializing restore reconstructs library | Backup/* | High | PLANNED | Phase 1 of two-feature split. Adds `library-manifest.json` to the backup ZIP and uploads missing whole-file book blobs to `VReader/books/<format>/<sha256>_<byteCount>.<ext>` (content-addressed, deduped). Restore downloads every missing blob into the sandbox before applying metadata. Preserves the existing invariant that a `Book` row always points to a readable local file — no `BookFileState`, no remote-only rows, no UI redesign. See plan below. Phase 2 = feature #47. |
-| 47 | WebDAV restore — selective book picker + lazy-on-tap downloads | Backup/* | Medium | TODO | Phase 2 of feature #46. Introduces `BookFileState` (`local / remoteOnly / downloading / failed / missingRemote`), library rows for un-downloaded books with cloud icons, "Restore selectively…" picker against the manifest, on-tap blob fetch via `URLSessionConfiguration.isDiscretionary`, Wi-Fi-only cellular policy, "Clean unused remote files" GC action. Depends on feature #46 shipping the blob storage + manifest layout. See plan below. |
+| 46 | WebDAV backup includes book files — materializing restore reconstructs library | Backup/* | High | PLANNED | Phase 1 of two-feature split. Adds `library-manifest.json` to the backup ZIP and uploads missing whole-file book blobs to `VReader/books/<format>/<sha256>_<byteCount>.<ext>` (content-addressed, deduped). Restore downloads every missing blob into the sandbox before applying metadata. Preserves the existing invariant that a `Book` row always points to a readable local file — no `BookFileState`, no remote-only rows, no UI redesign. See plan below. Phase 2 = feature #47. GH: #144 |
+| 47 | WebDAV restore — selective book picker + lazy-on-tap downloads | Backup/* | Medium | PLANNED | Phase 2 of feature #46. Introduces `BookFileState` (`local / remoteOnly / downloading / failed / missingRemote`), library rows for un-downloaded books with cloud icons, "Restore selectively…" picker against the manifest, on-tap blob fetch via `URLSessionConfiguration.isDiscretionary`, Wi-Fi-only cellular policy, "Clean unused remote files" GC action. Depends on feature #46 shipping the blob storage + manifest layout. See plan below. GH: #145 |
 
 ### Feature #44 — DebugBridge — Plan
 

--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 14
-        MARKETING_VERSION: 3.10.13
+        CURRENT_PROJECT_VERSION: 15
+        MARKETING_VERSION: 3.10.14
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3766,13 +3766,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.13;
+				MARKETING_VERSION = 3.10.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3916,13 +3916,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.13;
+				MARKETING_VERSION = 3.10.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

- Renames the "Close gate" rule in AGENTS.md from "device-verified" (bug-only language) to "verified, not just merged" — symmetric for both trackers. Bugs close at FIXED + device-verified; features close at VERIFIED (every acceptance criterion exercised end-to-end), not at DONE.
- Updates `docs/features.md` "How to use" GH closure section to require status `VERIFIED` before closing the GH issue, mirroring the bug rule.
- Adds `GH: #144` to feature #46 and `GH: #145` to feature #47 in the tracker. Bumps feature #47 from `TODO` to `PLANNED` (its plan was added in PR #142).

Triggered by user instruction "if a feature is implemented, close the issue accordingly" — making explicit that "implemented" = verified end-to-end, not just merged with passing unit tests.

## What Changed

- `AGENTS.md`: "Close gate — verified, not just merged" rewrites the prior bug-only rule to cover both bugs and features. "On resolve" workflow updated to require verification pass before `gh issue close`.
- `docs/features.md`: "How to use" GH closure section requires VERIFIED + closure comment cites acceptance-criterion-by-criterion result. Tracker rows for #46 and #47 add GH refs and #47's status moves to PLANNED.
- `project.yml` / `pbxproj`: version bump to 3.10.14 (build 15).

## Why this is a meta-process change

Per AGENTS.md merge gate: "Pure meta-process changes (rule additions, repo reorgs, tooling) are exempt because they don't reference a bug/feature row." This PR adds a rule and tightens an existing one. The tracker-row updates (`GH:` notes for #46/#47, status TODO→PLANNED for #47) are tracker maintenance riding along with the rule change.

## Type of Change

- [x] Rule / workflow tightening
- [x] Tracker maintenance (GH refs)