### PR TITLE
docs(rules): codify 6-gate feature workflow + restore content lost in PR #148

### DIFF
--- a/.claude/rules/47-feature-workflow.md
+++ b/.claude/rules/47-feature-workflow.md
@@ -1,0 +1,154 @@
+# 47 — Feature Implementation Workflow
+
+Binding sequence for every feature implementation. Six gates, never skip one.
+
+> **Plan → Independent plan audit → TDD implementation → Implementation audit loop → Device/integration verification → Merge**
+
+This is a **gate model**, not a chronological task list. Each gate has an explicit acceptance bar; you do not enter the next gate until the current gate's bar is met. Multiple iterations within a gate are normal.
+
+## Gate 1 — Plan
+
+Write `dev-docs/plans/YYYYMMDD-feature-N-<slug>.md` covering, at minimum:
+
+- **Problem** — what user need this addresses (mirror or refine the row's `Problem` field).
+- **Surface area** — file-by-file with concrete signatures (which protocols, types, methods get added or modified). Includes a "files OUT of scope" subsection.
+- **Prior art / project precedent / rejected alternatives** — what existing patterns we're building on, what we considered and rejected, and why. **Research is part of the plan**, not a separate step.
+- **Work-item sequencing** — small, testable units (typically 1-15 WIs). Each WI is one PR's worth of work. Estimated PR size per WI.
+- **Test catalogue** — concrete test files, what each covers, including the audit-driven additions (corruption, partial failure, idempotency edge cases).
+- **Risks + mitigations** — known unknowns and how we'll handle them.
+- **Backward compat** — what happens to existing data / older clients / older backups when this ships.
+
+The features.md "Plan Template" fields (Problem, Scope, Edge Cases, Test plan, Acceptance criteria) live in the row; the implementation-detail plan in `dev-docs/plans/` expands on them with file paths, signatures, and sequencing.
+
+**Acceptance bar**: plan exists at the documented path; status moves to `PLANNED` only when this gate passes.
+
+## Gate 2 — Independent Plan Audit
+
+Send the plan to an independent AI auditor (not the same agent/model/context as the plan author). Codex MCP is the current default; Gemini, OpenCode, or any equivalent satisfies the gate. The invariant is **independence**, not the brand.
+
+Audit prompt must explicitly request:
+
+- **Model assumption verification** — do the SwiftData fields, enum cases, function signatures, file paths I named actually exist? (This catches the largest class of pre-implementation bugs.)
+- **Risks + missing edge cases** — what failure modes the plan misses.
+- **Protocol signature critique** — are new interfaces well-shaped, or do they leak implementation concerns?
+- **Concurrency hazards** — actor isolation, Sendable, race conditions in mutable state.
+- **Cohesion check** — is the WI split right, or are some WIs too big or too small?
+
+**Acceptance bar**:
+- Zero open Critical/High/Medium findings.
+- Low findings either fixed in the plan or explicitly accepted with rationale (in the plan's "Known limitations" or "Audit fixes applied" section).
+- **Maximum 3 audit rounds**. If unresolved findings remain after round 3, stop and escalate to the user — accept, defer, or redesign.
+
+Track audit rounds in the plan's revision history. The author rewrites the plan to address findings; the auditor re-reviews. Same loop until clean.
+
+**Why this gate exists**: Codex audits routinely catch 5-10 real bugs per round on non-trivial plans (compile-breaking model assumptions, missing preconditions, protocol shape mistakes). Skipping the audit shifts that cost into wasted implementation work.
+
+## Gate 3 — TDD Implementation
+
+Per work item:
+
+1. **RED** — write a failing test that captures the WI's behavior. See `.claude/rules/10-tdd.md` for pattern catalogue.
+2. **GREEN** — write minimal implementation to make the test pass.
+3. **REFACTOR** — clean up without changing behavior. Tests stay green.
+4. **PR** — small, focused PR per WI. Apply per-PR rules: docs sync (`24-doc-sync.md`), version bump (`40-version-bump.md`).
+
+Status: feature → `IN PROGRESS` when WI-1's PR opens.
+
+**Acceptance bar per WI**: tests pass under `xcodebuild test -only-testing:vreaderTests`; new code follows codebase conventions (`.claude/rules/50-codebase-conventions.md`).
+
+## Gate 4 — Implementation Audit Loop
+
+After implementation but before merge: independent audit of the changed files (read-only sandbox). This is what `/fix-issue` already runs.
+
+Audit prompt focuses on:
+
+- Correctness against the plan
+- Edge cases in the diff (boundary conditions, nil, Unicode/CJK, concurrent access)
+- Security (JS injection in evaluateJavaScript, WKWebView bridge safety, etc.)
+- Duplicate / dead code introduced
+- VReader compliance (Swift 6 concurrency, @MainActor correctness, file size <300 lines)
+- Bridge safety (FoliateJSEscaper for JS interpolation, message parser edge cases)
+
+**Acceptance bar**:
+- Zero open Critical/High/Medium findings.
+- Low findings fixed or explicitly accepted with rationale in the PR body.
+- **Maximum 3 audit-fix rounds**. After round 3, escalate.
+
+Same author/auditor separation as Gate 2.
+
+## Gate 5 — Device / Integration Verification
+
+For each PR before it merges:
+
+- **Foundational WIs** (DTOs, protocols, utilities, pure types — no user-observable behavior): unit + integration tests + audit are sufficient. No device verification required.
+- **Behavioral WIs** (anything that changes app behavior, persistence, networking, backup format, reader rendering, or UI flow): **slice verification** — exercise the slice end-to-end against the real environment available at this point. Run on iPhone 17 Pro Simulator with `vreader-debug://` harness; for backup/network features, against a real WebDAV server (or local Docker WebDAV equivalent); for reader features, with a fixture book.
+- **Final WI** (the one that completes the feature): full end-to-end acceptance pass — every acceptance criterion exercised. This is what flips the feature row from `DONE` to `VERIFIED`.
+
+Record slice verification in the PR description (what was run, what was observed). Record final acceptance verification in the PR description AND in the feature row's Notes.
+
+**Acceptance bar per PR**: every behavioral slice in the PR has been verified end-to-end at the level appropriate to its WI tier. Final WI requires full acceptance pass.
+
+## Gate 6 — Merge
+
+PR may merge when ALL of the following hold:
+
+- Tests pass (the merge gate from `AGENTS.md`).
+- Implementation audit loop is clean (Gate 4).
+- Device / integration verification is complete for the PR's tier (Gate 5).
+- Docs sync completed if triggered (`.claude/rules/24-doc-sync.md`).
+- Version bump committed as the last commit before opening the PR (`.claude/rules/40-version-bump.md`).
+- For PRs that reference an open bug/feature: the referenced row has reached its terminal status (`FIXED` for bugs, `DONE` for features) — the existing fix-or-implement merge gate.
+
+After merge:
+
+- Feature status moves to `DONE` only after **all** WIs are merged AND every acceptance criterion is implemented.
+- `VERIFIED` is a separate post-implementation status, set after Gate 5's final-WI acceptance pass lands and is recorded in the row.
+- GH issue closes per close-gate rule (closure comment cites the verification: commit SHA + what was tested + what was observed).
+
+## Audit count by feature size
+
+To keep the audit cost honest:
+
+| Size | WIs | Plan audits | PR audits |
+|------|-----|------------|-----------|
+| Small | 1 PR | 1 | 1 |
+| Medium | 2-4 WIs | 1 | 1 per WI |
+| Large | 5+ WIs | 1+ rounds (until clean) | 1 per WI; mechanical low-risk WIs that share the same surface MAY batch under one audit |
+
+If a feature is genuinely 10+ WIs, consider whether the plan should split into multiple features.
+
+## Author / auditor separation (invariant)
+
+The agent that writes the plan must NOT be the same agent that audits it. Today this happens by accident (Codex MCP is a separate process from the implementing Claude Code session). The rule preserves this invariant explicitly so a future single-agent setup doesn't degenerate into self-marking.
+
+If a future setup runs everything through one agent, the audit step requires invoking a different model/context boundary explicitly (e.g., a fresh subagent with read-only sandbox + explicit "audit, don't implement" framing).
+
+## Manual fallback when AI auditor unavailable
+
+When Codex / Gemini / equivalent is unavailable (network, quota, outage), do the audit manually AND record evidence in the plan or PR. Required `Manual Audit Evidence` section:
+
+- **Files read** (paths)
+- **Symbols / signatures verified** (which fields/types/enums you confirmed exist)
+- **Edge cases checked** (the list)
+- **Risks accepted** (with rationale)
+- **Tests added or intentionally deferred**
+
+Manual fallback is allowed only when the independent audit tool is genuinely unavailable, not just inconvenient. The audit step is non-negotiable; manual fallback is an evidence-bearing alternative, not a way to skip.
+
+## What this rule does NOT change
+
+- TDD discipline (`10-tdd.md`) is unchanged.
+- Per-PR Codex audit in `/fix-issue` skill is exactly Gate 4 — reference, don't duplicate.
+- Merge gate (fix-or-implement) and close gate (verified, not just merged) are unchanged — this rule names where they fit in the workflow.
+- Bug fix workflow (`docs/bugs.md` `## Rules`) is unchanged — bugs follow Understand → RED → GREEN → REFACTOR → Verify → Track. Bugs do NOT require a separate plan + plan audit (they're reactive); they do require the implementation audit loop and verification gates.
+
+## Worked example
+
+Feature #46 (WebDAV materializing restore, 11 WIs, High priority):
+
+- **Gate 1 (Plan)**: `dev-docs/plans/20260503-feature-46-materializing-restore.md` — drafted v1.
+- **Gate 2 (Plan audit)**: 2 Codex rounds. Round 1 found compile-breaking model assumptions (`Book.originalFilename` doesn't exist), missing `ImportSource.restore`, MOBI handling gap, idempotency hole in `BookImporter`, MOVE 501 silent fallback. Round 2 found `Book.fileExtension` also doesn't exist, weak `BackupBlobStore` signature, weak error shape. Plan v2 incorporates all findings.
+- **Gate 3 (TDD impl)**: 11 WIs sequenced (WI-0a model migration, WI-0b enum case, WI-1 BlobPath, etc.). Each ships its own PR.
+- **Gate 4 (Impl audit)**: per-PR via `/fix-issue` audit loop.
+- **Gate 5 (Verification)**: WI-0a, WI-0b, WI-1, WI-2 = foundational, no device verify. WI-7 (provider integration) = slice verify against Docker WebDAV. WI-10 (UI) = device verify on simulator. Final WI = full acceptance pass (backup → wipe → restore with positions/annotations).
+- **Gate 6 (Merge + close)**: each WI's PR merges through its own gate. Final WI moves feature row to `DONE`. After Gate 5 final acceptance pass: row → `VERIFIED`, GH #144 closes with citation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 Shared instructions for all AI agents (Claude, Codex, etc.).
 
 - You are an AI assistant working on the project.
-- **Read ************`docs/architecture.md`************ before making any code changes. Update it when adding new layers, patterns, services, or changing how components communicate.**
+- **Read `docs/architecture.md` before making any code changes. Update it when adding new layers, patterns, services, or changing how components communicate.**
 - Use English unless another language is requested.
 - Follow the working agreement:
   - Run `git status -sb` at session start.
@@ -12,11 +12,11 @@ Shared instructions for all AI agents (Claude, Codex, etc.).
   - Do not commit unless explicitly requested.
   - Keep code files under \~300 lines (split proactively).
   - Keep features local; avoid cross-feature imports unless truly shared.
-  - **Research before building**: For new features, search for industry best practices,  
-    established conventions, and proven solutions (web search, official docs, prior art in  
+  - **Research before building**: For new features, search for industry best practices,
+    established conventions, and proven solutions (web search, official docs, prior art in
     popular open-source projects). Don't invent when a well-tested pattern exists.
-  - **Edge cases are not optional**: Brainstorm as many edge cases as possible — empty input,  
-    null/undefined, max values, concurrent access, Unicode/CJK, RTL text, rapid repeated  
+  - **Edge cases are not optional**: Brainstorm as many edge cases as possible — empty input,
+    null/undefined, max values, concurrent access, Unicode/CJK, RTL text, rapid repeated
     actions, network failures, permission denials. Write tests for every one.
   - **Test-first is mandatory** for new behavior:
     - Write a failing test (RED), implement minimally (GREEN), refactor (REFACTOR).
@@ -24,27 +24,41 @@ Shared instructions for all AI agents (Claude, Codex, etc.).
     - Exceptions: CSS-only, docs, config. See `.claude/rules/10-tdd.md` for full scope.
   - Run `xcodebuild test -only-testing:vreaderTests` for unit test gates. Skip UI tests during development.
   - Default simulator: **iPhone 17 Pro** (Dynamic Island — catches safe area bugs).
-  - **Task workflow** (three files, one flow):
-    - `docs/tasks.md` — **inbox**. User writes free-form descriptions. Agent triages (classify only, do not fix or implement during triage). See `docs/tasks.md` for classification rules, deduplication, and triage record format.
-    - `docs/bugs.md` — **bug tracker**. Something implemented but broken. Follow the bug fix workflow defined in `docs/bugs.md` (Understand → RED → GREEN → REFACTOR → Verify → Track).
-    - `docs/features.md` — **feature tracker**. Something never implemented. Must be planned before implementation (Problem, Scope, Edge Cases, Test Plan, Acceptance Criteria). See `docs/features.md` for plan template and statuses.
+  - **Verification harness** (DEBUG only): `vreader-debug://` URL scheme drives reset / seed / open / settle / snapshot / eval from `xcrun simctl openurl`, so verification runs don't need computer-use for reproduction or assertion. See `docs/subsystems/debug-bridge.md`.
+  - **Version bump per PR**: every PR must include a `chore: bump version to X.Y.Z` commit as its last commit before opening — patch for fixes/docs/chores, minor for new features, major for breaking changes. Tag is cut from the merge commit on `main` post-merge. See `.claude/rules/40-version-bump.md`.
+  - **Docs sync per PR**: when a PR adds a service, schema, notification, environment key, or user-visible feature, update `docs/architecture.md` and/or `README.md` in the same PR (separate commit before the version bump). Triggers + checklist in `.claude/rules/24-doc-sync.md`.
+  - **Merge gate — fix-or-implement**: a PR that references an open bug (`Refs #N` against `docs/bugs.md`) does not merge until that bug's status is `FIXED`. A PR that references an open feature does not merge until the feature reaches `DONE`. Tracker-only updates (re-classifying severity, correcting a recommendation, adding screenshots) ride along with the fix PR — they don't ship as standalone merges. Pure meta-process changes (rule additions, repo reorgs, tooling) are exempt because they don't reference a bug/feature row.
+  - **Close gate — verified, not just merged**: a GitHub Issue does NOT close until the work is end-to-end verified against a real environment — not just unit tests. Symmetric for both trackers:
+    - **Bugs**: `docs/bugs.md` status `FIXED` means "code shipped to main with passing tests" (the merge gate). Closing the GH issue requires a separate device-verification pass: install the new build on device/simulator, run the original repro, confirm the actual symptom is gone.
+    - **Features**: `docs/features.md` status `DONE` means "implementation merged with passing tests" (the merge gate). Closing the GH issue requires reaching status `VERIFIED`: every acceptance criterion exercised end-to-end (XCUITest + DebugBridge auto-verification, or an explicit on-device manual verification log) — for non-UI features, end-to-end against a real backend (e.g., backup → restore round-trip against a live WebDAV server, not just an in-memory mock).
+    - The closure comment must cite the verification (commit SHA + what was tested + what was observed). Until then, the GH issue stays open with a "shipped in vX.Y.Z, awaiting verification" comment so the work doesn't drop off the radar.
+  - **Feature implementation workflow** (binding 6-gate sequence — never skip a gate). Full rule at `.claude/rules/47-feature-workflow.md`. Summary: Plan → Independent plan audit → TDD implementation → Implementation audit loop → Device/integration verification → Merge.
+  - **Task workflow** (three files, one flow). The `## Rules` section at the top of each tracker is **binding** — it's the authoritative workflow for that file, not decorative prose:
+    - `docs/tasks.md` — **inbox**. User writes free-form descriptions. Agent triages (classify only, do not fix or implement during triage). Classification rules, deduplication, and triage record format are at the top of the file.
+    - `docs/bugs.md` — **bug tracker**. Something implemented but broken. Bug fix workflow (Understand → RED → GREEN → REFACTOR → Verify → Track) is at the top of the file.
+    - `docs/features.md` — **feature tracker**. Something never implemented. Must be planned before implementation (Problem, Scope, Edge Cases, Test Plan, Acceptance Criteria). Plan template and statuses are at the top of the file.
   - **Key rules**:
     - Bugs vs features: broken implementation → `docs/bugs.md`; never implemented → `docs/features.md`. Never mix.
     - Triage is classification only — do not fix bugs or implement features during triage.
     - Features must reach `PLANNED` status before `IN PROGRESS`. Exception: features resolved incidentally by a bug fix.
-  - **GitHub Issues** (selective mirror, not full sync):
-    - **When to create**: High-severity bugs, release blockers, and major features (`Priority: High`). Do not mirror every tracker row.
-    - **On create**: Add `GH: #123` to the Notes column in bugs.md/features.md. Use labels: `bug`/`feature`, `severity:high`/`severity:medium`.
-    - **PRs use ********`Refs #N`**, not `Fixes #N` — prevents premature auto-close.
-    - **On resolve** (post-merge finalizer, do not close before merge):
-      1. Verify markdown status is updated (FIXED/DONE).
+  - **GitHub Issues** (asymmetric mirror — features track planning, bugs stay selective):
+    - **When to create — features**: every feature that reaches `PLANNED` status gets a GH issue. Trigger is mechanical (status = PLANNED + no `GH: #N` already in Notes → create). Idempotent: skip creation if `GH: #N` is already present. **Why mechanical not priority-based**: a `PLANNED` feature has problem + scope + edge cases + test plan + acceptance criteria — exactly the threshold where contributors benefit from a public handle for `Refs #N`, design discussion, and verification follow-up. Priority-based mirroring is leaky in this repo's history (medium features mirrored, some high ones not).
+    - **When to create — bugs**: stay selective. High-severity bugs, release blockers, externally reported regressions, or bugs that need public discussion. Do NOT mirror every bug row — bugs are reactive and most resolve in <1 PR; the GH overhead doesn't pay off.
+    - **When NOT to create (either tracker)**: status is `DEFERRED`, `WONT DO`, `DUPLICATE`, or feature was resolved incidentally by a bug fix.
+    - **Local-only escape hatch**: a feature that's planned but explicitly should not be mirrored to GH gets `Mirror: no` in the Notes column. The rule respects this and skips creation.
+    - **GH issue body = pointer, not second source of truth**: title `Feature #N: <short summary>` or `Bug #N: <short summary>`. Body has (1) short problem statement, (2) link back to the row + plan in `docs/features.md` / `docs/bugs.md`, (3) acceptance criteria copied once for readability, (4) explicit "Source of truth: `docs/features.md`" line. Design decisions and scope changes happen in the markdown tracker; GH comments that materially change scope must be ported back to the tracker in the same PR.
+    - **On create**: add `GH: #123` to the Notes column. Use labels: `bug` or `enhancement` (GitHub's "feature" label is named `enhancement`); plus `severity:high`/`severity:medium` if priority warrants.
+    - **PRs use `Refs #N`**, not `Fixes #N` — prevents premature auto-close.
+    - **On resolve** (post-merge finalizer, do not close before merge AND do not close before verification — see "Close gate — verified, not just merged" above):
+      1. Verify markdown status is updated to terminal-verified state (`FIXED` then device-verified for bugs; `VERIFIED` for features).
       2. Verify fix is on `main`.
-      3. Post closure comment: commit SHA, test evidence, cause summary (bugs) or acceptance result (features).
-      4. Run `gh issue close #N`.
+      3. Run the verification pass (re-run repro for bugs; exercise acceptance criteria for features).
+      4. Post closure comment: commit SHA, what was tested, what was observed, cause summary (bugs) or acceptance result (features).
+      5. Run `gh issue close #N`.
+      Between merge and verification, leave the issue open with a "shipped in vX.Y.Z, awaiting verification" comment.
     - **Exception**: Small single-issue fixes may use `Fixes #N` in PR body for auto-close.
     - **Partial delivery**: Keep issue open. Use task checklist in issue body or split into follow-up issues.
 - AI coding tool auth:
   - **Prefer subscription auth over API keys** for all AI coding tools (Claude Code, Codex CLI, Gemini CLI). Subscription plans are dramatically cheaper for sustained coding sessions — API billing can cost 10–30x more.
   - Claude Code: log in with Claude Max subscription. Codex CLI: `codex login` with ChatGPT Plus/Pro. Gemini CLI: Google account login.
   - API keys work as a fallback for light or automated usage.
-

--- a/docs/features.md
+++ b/docs/features.md
@@ -9,7 +9,7 @@ Track features to be implemented here. Must be planned before implementation.
 - **Bugs vs features**: If something was implemented but doesn't work correctly, it is a **bug** — track it in `docs/bugs.md`. If something was never implemented, it is a **feature** — track it here. Never mix them.
 - **Partial implementations**: If something is partially implemented, the broken part is a bug in `docs/bugs.md`; the missing capability is a feature here. Link them.
 - **Cross-links**: When a bug fix resolves a feature, update the feature status to `DONE` with note `Resolved by bug #N`. When a feature depends on a bug fix, use `TODO` status with note `Blocked by bug #N`.
-- **Plan before implementation**: Every feature must be planned before any code is written. Status must reach `PLANNED` before moving to `IN PROGRESS`. A plan requires the fields listed in the "Plan Template" section below.
+- **Plan before implementation**: Every feature must be planned before any code is written. Status must reach `PLANNED` before moving to `IN PROGRESS`. A plan requires the fields listed in the "Plan Template" section below. Implementation follows the binding 6-gate sequence in `.claude/rules/47-feature-workflow.md` (Plan → Independent plan audit → TDD implementation → Implementation audit loop → Device/integration verification → Merge); this file remains the status source of truth.
 - **Exception — resolved by bug fix**: If a bug fix incidentally delivers a feature, the feature may be set to `DONE` with `Resolved by bug #N` without a full plan. The bug's own cause/solution/lesson records serve as documentation.
 
 ## How to use

--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 17
-        MARKETING_VERSION: 3.10.16
+        CURRENT_PROJECT_VERSION: 18
+        MARKETING_VERSION: 3.10.17
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3766,13 +3766,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.16;
+				MARKETING_VERSION = 3.10.17;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3916,13 +3916,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.16;
+				MARKETING_VERSION = 3.10.17;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

Two related changes in one PR.

### 1. Codify the 6-gate feature implementation workflow

> **Plan → Independent plan audit → TDD implementation → Implementation audit loop → Device/integration verification → Merge**

Full rule at `.claude/rules/47-feature-workflow.md`. One-line pointer in `AGENTS.md`. One-sentence cross-reference in `docs/features.md`.

Reflects two design-review rounds with Codex MCP. Highlights:

- **Gate 1 (Plan)**: `dev-docs/plans/YYYYMMDD-feature-N-<slug>.md`. Research is part of the plan, not a separate gate.
- **Gate 2 (Plan audit)**: independent AI auditor (Codex/Gemini/equivalent — invariant is independence, not the brand). Acceptance bar: zero open Critical/High/Medium findings; Low fixed or explicitly accepted with rationale. Cap at 3 rounds.
- **Gate 3 (TDD)**: per WI — RED → GREEN → REFACTOR → small PR.
- **Gate 4 (Impl audit loop)**: what `/fix-issue` already runs. Same C/H/M bar, 3-round cap.
- **Gate 5 (Verification)**: **slice verification** — foundational WIs (DTOs, protocols, utilities) merge with unit tests + audit only; behavioral WIs verify against real environment; final WI requires full acceptance pass.
- **Gate 6 (Merge)**: standard merge gate + per-PR rules.

Plus invariants: author/auditor separation, manual fallback with required evidence section, audit count tiering by feature size.

### 2. Restore content silently reverted by PR #148

Discovered while preparing this PR: PR #148 (asymmetric mirror, v3.10.15) had a diff that **removed 20 lines and added 10**, silently reverting the merge gate, close gate, version-bump rule, docs-sync rule, verification-harness reference, AND tracker-binding language — while failing to actually add the asymmetric-mirror rule it claimed to add. Cause: edit operated on linter-mangled file content; the merge silently accepted a stale base.

This commit restores all of the above content AND properly lands the asymmetric mirror rule.

## What Changed

- `.claude/rules/47-feature-workflow.md` (NEW, ~150 lines)
- `AGENTS.md` — restored merge gate / close gate / verification harness / version bump / docs sync / tracker binding; properly added asymmetric mirror rule; added one-line pointer to new rule. Fixes linter-mangled `**Read **********` markdown artifacts.
- `docs/features.md` — one-sentence cross-reference in "How to use" section.
- `project.yml` / `pbxproj` — version bump to 3.10.17 (build 18).

## Validation

- [x] No code changed — pure docs / workflow rule
- [x] Workflow rule incorporates 2 Codex audit rounds
- [x] AGENTS.md content matches the union of every shipped rule (manual diff against ab5ce89 = PR #146 + asymmetric mirror addition + new workflow pointer)
- [x] Build smoke test: `xcodegen generate` regenerated pbxproj cleanly

## Type of Change

- [x] Workflow rule addition (new) + content restoration (regression fix)
- [x] Meta-process — exempt from merge gate per AGENTS.md