### PR TITLE
feat(#46): WI-0a — Book.originalExtension + BackupBookProjection

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ VReader is an iOS e-book reader built with SwiftUI + SwiftData. It supports TXT,
 ```
 ┌──────────────────────────────────────────────────────┐
 │                    VReaderApp                         │
-│  SwiftData SchemaV4 · PersistenceActor · BookImporter│
+│  SwiftData SchemaV5 · PersistenceActor · BookImporter│
 └─────────────────────┬────────────────────────────────┘
                       │
           ┌───────────┴───────────┐
@@ -34,7 +34,7 @@ VReader is an iOS e-book reader built with SwiftUI + SwiftData. It supports TXT,
 
 ### 1. App Layer (`vreader/App/`)
 
-- `VReaderApp.swift` — SwiftData `ModelContainer` init (SchemaV4), migration plan (V1→V2→V3→V4), test seeding, error handling. Injects the live `PersistenceActor` into the SwiftUI environment via `\.persistenceActor` so settings sub-screens can construct backup providers without rewriting every parent's signature.
+- `VReaderApp.swift` — SwiftData `ModelContainer` init (SchemaV5), migration plan (V1→V2→V3→V4→V5), test seeding, error handling. Injects the live `PersistenceActor` into the SwiftUI environment via `\.persistenceActor` so settings sub-screens can construct backup providers without rewriting every parent's signature.
 
 ### 2. Library Layer (`vreader/Views/LibraryView.swift`, `vreader/ViewModels/LibraryViewModel.swift`)
 
@@ -118,11 +118,13 @@ Bridge-internal coordinators (`EPUBWebViewBridgeCoordinator`, `FoliateViewCoordi
 
 ### 6. Data Layer (`vreader/Models/`)
 
-SwiftData SchemaV4 entities:
+SwiftData SchemaV5 entities:
 
-- `Book` (fingerprintKey unique) → `ReadingPosition`, `Highlight`, `Bookmark`, `AnnotationNote`, `BookCollection`
+- `Book` (fingerprintKey unique; gains `originalExtension: String?` in SchemaV5 for backup blob extension preservation) → `ReadingPosition`, `Highlight`, `Bookmark`, `AnnotationNote`, `BookCollection`
 - `ReadingSession`, `ReadingStats`
 - `BookSource`, `ContentReplacementRule` (added in SchemaV4)
+
+`PersistenceActor.fetchAllBooksForBackup() -> [BackupBookProjection]` (in `PersistenceActor+Backup.swift`) returns a Sendable value-type view of every book — used by feature #46's WebDAV backup to emit `library-manifest.json` without leaking `@Model` instances across the actor boundary. Legacy V4 rows (no `originalExtension`) coalesce to the canonical extension for their format.
 
 Backup section JSONs (`vreader/Services/Backup/BackupSectionDTOs.swift`) are
 versioned via the `BackupVersionedEnvelope` protocol. Restore validates exact

--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 20
-        MARKETING_VERSION: 3.10.19
+        CURRENT_PROJECT_VERSION: 21
+        MARKETING_VERSION: 3.10.20
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		0E5215DBE0AC933D4C2136F6 /* DeleteConfirmationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4078AAB96560B1BC1794472E /* DeleteConfirmationTests.swift */; };
 		0E6D4F9EF1765D5808B9EEBC /* NSUKVSBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607B063A54628D2CC2CFCC35 /* NSUKVSBridgeTests.swift */; };
 		0EFA98D7C252D06AD3A254A9 /* ReadingProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A7FC6A70A060CD5E43602E /* ReadingProgressBar.swift */; };
+		0F753635DD7185A076DE4196 /* SchemaV5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A6667FB5A4B6534854FD37 /* SchemaV5.swift */; };
 		10835FE4B33B176F7668ADF7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1F9542255A6791C9BCB034DB /* Assets.xcassets */; };
 		10D0E47D5358AADBB9223B9D /* legado_source_with_unknown_fields.json in Resources */ = {isa = PBXBuildFile; fileRef = 6B4F95A22D8731A420F20CB2 /* legado_source_with_unknown_fields.json */; };
 		11268CE0083F01ADC27C5C6B /* FoliateHighlightRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CF1C76C54971B97341E5E9 /* FoliateHighlightRenderer.swift */; };
@@ -134,6 +135,7 @@
 		2DA2E5132AD7271040AB6B4C /* HighlightRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69ECDAED09428E0C1CD6A724 /* HighlightRendererTests.swift */; };
 		2DA32CDB11AE06DBCF3E97DE /* CloudKitRecordMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED53A6DC10398667F3DC883 /* CloudKitRecordMapperTests.swift */; };
 		2DB8779FF53587C400452428 /* FileAvailabilityStateMachineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6362591D3F62B4BC84CE136A /* FileAvailabilityStateMachineTests.swift */; };
+		2DBB3E013C7117D610B1679F /* BookImporterOriginalExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B8562BBBE45039B72EAF9E5 /* BookImporterOriginalExtensionTests.swift */; };
 		2DDEE520E3606572AED3598F /* LibraryRefreshService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC254C94AE749FFA8AACCE4 /* LibraryRefreshService.swift */; };
 		2E988A3214761CEAEF22D451 /* HTMLHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4349ACADC38E53A4D87D5D5A /* HTMLHelper.swift */; };
 		2E9BB5052DD152DD52BB0D45 /* TXTReaderPlaceholderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480E5268D197F33E8C0B6CFC /* TXTReaderPlaceholderTests.swift */; };
@@ -229,6 +231,7 @@
 		50214665FE48786605E6CF7E /* EPUBHighlightBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435C00E099B7F5D7A7821FDC /* EPUBHighlightBridge.swift */; };
 		505E3728FE1C69A31079DA9B /* ReaderBottomOverlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF9547D23D813327B536EAD5 /* ReaderBottomOverlayTests.swift */; };
 		50837395A5CDCDFC14CF2B64 /* PDFPasswordPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425829C48779CD64EB0C5A05 /* PDFPasswordPromptView.swift */; };
+		50D3F5B291DB7188E2BB0442 /* BackupBookProjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFABA0F5E3E749CC8108947C /* BackupBookProjectionTests.swift */; };
 		5128BF72998C4F697D2A6A84 /* ImportProvenanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDFAF8770F91837F0B3793E1 /* ImportProvenanceTests.swift */; };
 		514822215748FA807FA36FE2 /* HighlightCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2724D3C50EDE1DC1DA43BB5F /* HighlightCoordinatorTests.swift */; };
 		5168983F9EDD267778A9EEC9 /* TXTChapterIndexBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3910DCA9C9F588B700679D76 /* TXTChapterIndexBuilder.swift */; };
@@ -963,6 +966,7 @@
 		5A54A2C5DE8C1631C04BB2A1 /* PDFProgressHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFProgressHelper.swift; sourceTree = "<group>"; };
 		5AF84D4FD4FAA3232D18AA96 /* ReplacementTransform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplacementTransform.swift; sourceTree = "<group>"; };
 		5B58A3A5DB35DA47F032FCEB /* LegadoImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegadoImporter.swift; sourceTree = "<group>"; };
+		5B8562BBBE45039B72EAF9E5 /* BookImporterOriginalExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookImporterOriginalExtensionTests.swift; sourceTree = "<group>"; };
 		5BB9773A4631BEDEDD187F08 /* AnnotationExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationExporterTests.swift; sourceTree = "<group>"; };
 		5C0C66947C5376BF1D53A893 /* EPUBParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBParserTests.swift; sourceTree = "<group>"; };
 		5C502F959BB80E4EE5F022C8 /* view.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = view.js; sourceTree = "<group>"; };
@@ -1026,6 +1030,7 @@
 		7008A22A4FBE1574E8B9C8A4 /* TXTStreamingOpenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTStreamingOpenTests.swift; sourceTree = "<group>"; };
 		7024E7AEAC9AEAA028952C46 /* ScrollProgressHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollProgressHelper.swift; sourceTree = "<group>"; };
 		7056486BA460E0BE06235F54 /* UnifiedTextRendererViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedTextRendererViewModel.swift; sourceTree = "<group>"; };
+		71A6667FB5A4B6534854FD37 /* SchemaV5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV5.swift; sourceTree = "<group>"; };
 		71DF9DC9E8F3CCA4BE321C47 /* VReaderUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderUITests.swift; sourceTree = "<group>"; };
 		7205862B286DDE2DD2233F6D /* TXTChunkedReaderBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChunkedReaderBridge.swift; sourceTree = "<group>"; };
 		725F9036150B858160ACFF7B /* TXTReaderContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReaderContainerView.swift; sourceTree = "<group>"; };
@@ -1367,6 +1372,7 @@
 		EEDD43BA2EC5C331FDF3A703 /* PersistenceHighlightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceHighlightTests.swift; sourceTree = "<group>"; };
 		EEF87AF7EE6B0FB8E4CC9332 /* TypographySettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypographySettingsTests.swift; sourceTree = "<group>"; };
 		EF9547D23D813327B536EAD5 /* ReaderBottomOverlayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderBottomOverlayTests.swift; sourceTree = "<group>"; };
+		EFABA0F5E3E749CC8108947C /* BackupBookProjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupBookProjectionTests.swift; sourceTree = "<group>"; };
 		EFB9DBE73613A6499D43B18C /* AIServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIServiceTests.swift; sourceTree = "<group>"; };
 		EFBB0C08584916E384BA26E6 /* FoliateTTSAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateTTSAdapter.swift; sourceTree = "<group>"; };
 		F02AE770B22BFE6D2F175A1A /* TXTChapterIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterIndex.swift; sourceTree = "<group>"; };
@@ -1941,6 +1947,7 @@
 				F379B3EEC02DC574C73F4323 /* SchemaV2.swift */,
 				470BBE13ED7BCDD6E60D3400 /* SchemaV3.swift */,
 				F70B62CBA5AED4AECA05825E /* SchemaV4.swift */,
+				71A6667FB5A4B6534854FD37 /* SchemaV5.swift */,
 				DB16317C72EB6BBB61D77030 /* V1toV2Migration.swift */,
 			);
 			path = Migration;
@@ -2413,6 +2420,7 @@
 			children = (
 				E2396FE1BB03C2F3CEFAB8E2 /* AutoPageTurnerTests.swift */,
 				4962BEF634F94652553FC6BD /* BookImporterAZW3Tests.swift */,
+				5B8562BBBE45039B72EAF9E5 /* BookImporterOriginalExtensionTests.swift */,
 				C0FBDC41C60328ED4FB8A197 /* BookImporterTests.swift */,
 				B442FC7A6A6ED344AB5C1FC9 /* CollectionPersistenceTests.swift */,
 				D6D8E56C3937A3FF796151EB /* CollectionTestHelper.swift */,
@@ -2483,6 +2491,7 @@
 		D18FC2F3DB2B1B40D884B7A1 /* Backup */ = {
 			isa = PBXGroup;
 			children = (
+				EFABA0F5E3E749CC8108947C /* BackupBookProjectionTests.swift */,
 				A17676C4AE9DD328C39176D8 /* BackupDataCollectorRestorerTests.swift */,
 				ED150D276C082FEC194F2F31 /* BackupProviderContractTests.swift */,
 				4D9501ED4FB49C6035FDF5BB /* MockBackupProvider.swift */,
@@ -3043,6 +3052,7 @@
 				A2B7E3D8BAEC3C9A9375D3E4 /* AppConfigurationTests.swift in Sources */,
 				5BCD69B7FFD787F33D6E0C8D /* AutoPageTurnerTests.swift in Sources */,
 				C9D2AE1A81222E67A05CA05C /* BackgroundIndexingCoordinatorTests.swift in Sources */,
+				50D3F5B291DB7188E2BB0442 /* BackupBookProjectionTests.swift in Sources */,
 				22612350C6FC7C43096271E9 /* BackupDataCollectorRestorerTests.swift in Sources */,
 				4F2FEC62B6D23F67263EDF34 /* BackupProviderContractTests.swift in Sources */,
 				90D2C41C30E622E119877967 /* BackupViewModelTests.swift in Sources */,
@@ -3050,6 +3060,7 @@
 				D41473E2CF7AB980E43C6C54 /* BookFormatAZW3Tests.swift in Sources */,
 				2B9E39AC289E006A1A8B25AE /* BookFormatTests.swift in Sources */,
 				301BA4423DE1212ADB315388 /* BookImporterAZW3Tests.swift in Sources */,
+				2DBB3E013C7117D610B1679F /* BookImporterOriginalExtensionTests.swift in Sources */,
 				1AC5FD48311C93B5CEB3702E /* BookImporterTests.swift in Sources */,
 				3C6784421BC6B3DD6F1D3C16 /* BookModelTests.swift in Sources */,
 				6E224708E01276C14273E2E6 /* BookOpenPerformanceTests.swift in Sources */,
@@ -3549,6 +3560,7 @@
 				209CA5025D6BC048CCAE4012 /* SchemaV2.swift in Sources */,
 				7517791F2112F0367A462A10 /* SchemaV3.swift in Sources */,
 				28E4E3E11E49FE6D2B9B2BE0 /* SchemaV4.swift in Sources */,
+				0F753635DD7185A076DE4196 /* SchemaV5.swift in Sources */,
 				97731990DD3F91A22A6C9038 /* ScreenSpaceDemo.swift in Sources */,
 				793A39541D8253B1CA8984A5 /* ScrollProgressHelper.swift in Sources */,
 				01440A60BDBE08FC56500DA7 /* SearchHitToLocatorResolver.swift in Sources */,
@@ -3766,13 +3778,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.19;
+				MARKETING_VERSION = 3.10.20;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3916,13 +3928,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.19;
+				MARKETING_VERSION = 3.10.20;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/App/VReaderApp.swift
+++ b/vreader/App/VReaderApp.swift
@@ -45,7 +45,7 @@ struct VReaderApp: App {
         #endif
 
         do {
-            let schema = Schema(SchemaV4.models)
+            let schema = Schema(SchemaV5.models)
 
             #if DEBUG
             // Use in-memory store for UI testing to ensure clean state

--- a/vreader/Models/Book.swift
+++ b/vreader/Models/Book.swift
@@ -49,6 +49,11 @@ final class Book {
     /// Stored for consistent reopen without re-detection.
     var detectedEncoding: String?
 
+    /// Original file extension at import time (e.g. "mobi", "prc", "azw" for AZW3-canonical books).
+    /// Nil for legacy rows imported before SchemaV5; the backup projection coalesces nil into
+    /// the canonical extension. New imports always populate this from the source URL.
+    var originalExtension: String?
+
     // MARK: - Import Provenance
 
     var provenance: ImportProvenance
@@ -100,7 +105,8 @@ final class Book {
         provenance: ImportProvenance,
         addedAt: Date = Date(),
         isFavorite: Bool = false,
-        tags: [String] = []
+        tags: [String] = [],
+        originalExtension: String? = nil
     ) {
         self.fingerprintKey = fingerprint.canonicalKey
         self.fingerprint = fingerprint
@@ -115,6 +121,7 @@ final class Book {
         self.addedAt = addedAt
         self.isFavorite = isFavorite
         self.tags = tags
+        self.originalExtension = originalExtension
         self.bookmarks = []
         self.highlights = []
         self.annotations = []

--- a/vreader/Models/Migration/SchemaV1.swift
+++ b/vreader/Models/Migration/SchemaV1.swift
@@ -77,7 +77,7 @@ enum SchemaV1: VersionedSchema {
 /// infers the column addition automatically.
 enum VReaderMigrationPlan: SchemaMigrationPlan {
     static var schemas: [any VersionedSchema.Type] {
-        [SchemaV1.self, SchemaV2.self, SchemaV3.self, SchemaV4.self]
+        [SchemaV1.self, SchemaV2.self, SchemaV3.self, SchemaV4.self, SchemaV5.self]
     }
 
     static var stages: [MigrationStage] {

--- a/vreader/Models/Migration/SchemaV5.swift
+++ b/vreader/Models/Migration/SchemaV5.swift
@@ -1,0 +1,29 @@
+// Purpose: Schema version 5 — adds Book.originalExtension to support feature #46
+// (WebDAV materializing restore). Optional String field defaults to nil for legacy
+// rows; lightweight migration applies automatically because the field is additive.
+//
+// @coordinates-with: SchemaV4.swift, Book.swift,
+//   dev-docs/plans/20260503-feature-46-materializing-restore.md
+
+import Foundation
+import SwiftData
+
+/// Schema version 5: adds Book.originalExtension for backup blob extension preservation.
+enum SchemaV5: VersionedSchema {
+    static let versionIdentifier = Schema.Version(5, 0, 0)
+
+    static var models: [any PersistentModel.Type] {
+        [
+            Book.self,
+            ReadingPosition.self,
+            Bookmark.self,
+            Highlight.self,
+            AnnotationNote.self,
+            ReadingSession.self,
+            ReadingStats.self,
+            BookCollection.self,
+            BookSource.self,
+            ContentReplacementRule.self,
+        ]
+    }
+}

--- a/vreader/Services/BookImporter.swift
+++ b/vreader/Services/BookImporter.swift
@@ -187,6 +187,12 @@ final class BookImporter: BookImporting, Sendable {
         )
 
         // Step 11: Persist book record
+        // Preserve the source URL's extension so backup → restore can reconstruct
+        // it on a fresh device. Particularly matters for MOBI/PRC/AZW which all
+        // collapse to canonical BookFormat.azw3 — without this, restore loses
+        // the user's original extension.
+        let pathExt = fileURL.pathExtension.lowercased()
+        let originalExt: String? = pathExt.isEmpty ? nil : pathExt
         let record = BookRecord(
             fingerprintKey: fingerprintKey,
             title: metadata.title,
@@ -195,7 +201,8 @@ final class BookImporter: BookImporting, Sendable {
             fingerprint: fingerprint,
             provenance: provenance,
             detectedEncoding: detectedEncoding,
-            addedAt: Date()
+            addedAt: Date(),
+            originalExtension: originalExt
         )
 
         let persisted: BookRecord

--- a/vreader/Services/PersistenceActor+Backup.swift
+++ b/vreader/Services/PersistenceActor+Backup.swift
@@ -1,16 +1,70 @@
 // Purpose: Backup-only fetch/upsert helpers for entities that don't have a
-// dedicated PersistenceActor extension elsewhere (BookSource, ContentReplacementRule).
+// dedicated PersistenceActor extension elsewhere (BookSource, ContentReplacementRule),
+// plus BackupBookProjection — a Sendable value-type view of Book for the
+// library manifest (feature #46).
 //
 // These methods exist to keep the BackupDataCollector / BackupDataRestorer
 // off raw ModelContext while preserving actor isolation.
 //
 // @coordinates-with: BackupDataCollector.swift, BackupDataRestorer.swift,
-//   BookSource.swift, ContentReplacementRule.swift
+//   BookSource.swift, ContentReplacementRule.swift, Book.swift
 
 import Foundation
 import SwiftData
 
+// MARK: - Library Manifest Projection (feature #46 WI-0a)
+
+/// Sendable value-type projection of Book exposing the raw fingerprint fields
+/// needed by BackupDataCollector.collectLibraryManifest. Avoids leaking
+/// SwiftData @Model instances across the actor boundary.
+///
+/// `originalExtension` is non-optional in the projection: legacy rows missing
+/// the field are coalesced to the canonical extension for their format
+/// (e.g. all .azw3-formatted books default to "azw3").
+struct BackupBookProjection: Sendable, Equatable {
+    let fingerprintKey: String
+    let format: String           // canonical BookFormat.rawValue
+    let sha256: String
+    let byteCount: Int64
+    let originalExtension: String
+    let title: String?
+    let author: String?
+    let addedAt: Date
+    let lastOpenedAt: Date?
+}
+
 extension PersistenceActor {
+
+    // MARK: - Library Manifest
+
+    /// Returns every Book as a BackupBookProjection, sorted by fingerprintKey
+    /// for deterministic output across runs. Used by feature #46's
+    /// BackupDataCollector to emit `library-manifest.json` without leaking
+    /// @Model instances across the actor boundary.
+    func fetchAllBooksForBackup() throws -> [BackupBookProjection] {
+        let context = ModelContext(modelContainer)
+        let descriptor = FetchDescriptor<Book>(
+            sortBy: [SortDescriptor(\.fingerprintKey)]
+        )
+        let books = try context.fetch(descriptor)
+        return books.map { book in
+            // Coalesce nil originalExtension (legacy V4 rows) to the canonical
+            // extension for the format. Avoids forcing every consumer to
+            // handle the optional separately.
+            let canonicalExt = BookFormat(rawValue: book.format)?.fileExtensions.first ?? book.format
+            return BackupBookProjection(
+                fingerprintKey: book.fingerprintKey,
+                format: book.format,
+                sha256: book.fingerprint.contentSHA256,
+                byteCount: book.fingerprint.fileByteCount,
+                originalExtension: book.originalExtension ?? canonicalExt,
+                title: book.title,
+                author: book.author,
+                addedAt: book.addedAt,
+                lastOpenedAt: book.lastOpenedAt
+            )
+        }
+    }
 
     // MARK: - Book Sources
 

--- a/vreader/Services/PersistenceActor.swift
+++ b/vreader/Services/PersistenceActor.swift
@@ -43,6 +43,36 @@ struct BookRecord: Sendable, Equatable {
     let provenance: ImportProvenance
     let detectedEncoding: String?
     let addedAt: Date
+    /// Original file extension at import time (e.g. "mobi" for AZW3-canonical books).
+    /// Optional for legacy callers; set on new imports from the source URL.
+    let originalExtension: String?
+    /// When the book was last opened. Read-only mirror of Book.lastOpenedAt;
+    /// set by reader open flows, not by insertBook.
+    let lastOpenedAt: Date?
+
+    init(
+        fingerprintKey: String,
+        title: String,
+        author: String?,
+        coverImagePath: String?,
+        fingerprint: DocumentFingerprint,
+        provenance: ImportProvenance,
+        detectedEncoding: String?,
+        addedAt: Date,
+        originalExtension: String? = nil,
+        lastOpenedAt: Date? = nil
+    ) {
+        self.fingerprintKey = fingerprintKey
+        self.title = title
+        self.author = author
+        self.coverImagePath = coverImagePath
+        self.fingerprint = fingerprint
+        self.provenance = provenance
+        self.detectedEncoding = detectedEncoding
+        self.addedAt = addedAt
+        self.originalExtension = originalExtension
+        self.lastOpenedAt = lastOpenedAt
+    }
 }
 
 /// Actor-isolated persistence layer for SwiftData writes.
@@ -97,7 +127,8 @@ actor PersistenceActor: BookPersisting {
             author: record.author,
             coverImagePath: record.coverImagePath,
             provenance: record.provenance,
-            addedAt: record.addedAt
+            addedAt: record.addedAt,
+            originalExtension: record.originalExtension
         )
         book.detectedEncoding = record.detectedEncoding
         context.insert(book)
@@ -142,7 +173,9 @@ actor PersistenceActor: BookPersisting {
             fingerprint: book.fingerprint,
             provenance: book.provenance,
             detectedEncoding: book.detectedEncoding,
-            addedAt: book.addedAt
+            addedAt: book.addedAt,
+            originalExtension: book.originalExtension,
+            lastOpenedAt: book.lastOpenedAt
         )
     }
 }

--- a/vreaderTests/Services/Backup/BackupBookProjectionTests.swift
+++ b/vreaderTests/Services/Backup/BackupBookProjectionTests.swift
@@ -1,0 +1,152 @@
+// Purpose: Tests for BackupBookProjection + PersistenceActor.fetchAllBooksForBackup().
+// Feature #46 WI-0a: foundational projection that BackupDataCollector.collectLibraryManifest
+// will use to emit library-manifest.json without leaking SwiftData @Model instances.
+//
+// @coordinates-with: vreader/Services/PersistenceActor+Backup.swift,
+//   vreader/Models/Book.swift, dev-docs/plans/20260503-feature-46-materializing-restore.md
+
+import Testing
+import Foundation
+import SwiftData
+@testable import vreader
+
+@Suite("BackupBookProjection — feature #46 WI-0a")
+struct BackupBookProjectionTests {
+
+    // MARK: - Helpers
+
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema(SchemaV5.models)
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(for: schema, configurations: [config])
+    }
+
+    private func makePersistence() throws -> PersistenceActor {
+        PersistenceActor(modelContainer: try makeContainer())
+    }
+
+    private func makeFingerprint(
+        sha: String,
+        byteCount: Int64 = 1024,
+        format: BookFormat = .epub
+    ) -> DocumentFingerprint {
+        DocumentFingerprint(contentSHA256: sha, fileByteCount: byteCount, format: format)
+    }
+
+    private func makeRecord(
+        sha: String,
+        format: BookFormat = .epub,
+        title: String = "Test",
+        author: String? = nil,
+        addedAt: Date = Date(timeIntervalSince1970: 1_700_000_000),
+        lastOpenedAt: Date? = nil,
+        originalExtension: String? = nil
+    ) -> BookRecord {
+        let fp = makeFingerprint(sha: sha, format: format)
+        return BookRecord(
+            fingerprintKey: fp.canonicalKey,
+            title: title,
+            author: author,
+            coverImagePath: nil,
+            fingerprint: fp,
+            provenance: ImportProvenance(source: .filesApp, importedAt: addedAt, originalURLBookmarkData: nil),
+            detectedEncoding: nil,
+            addedAt: addedAt,
+            originalExtension: originalExtension,
+            lastOpenedAt: lastOpenedAt
+        )
+    }
+
+    // MARK: - Empty library
+
+    @Test func fetchAllBooksForBackup_emptyLibrary_returnsEmpty() async throws {
+        let persistence = try makePersistence()
+        let projections = try await persistence.fetchAllBooksForBackup()
+        #expect(projections.isEmpty)
+    }
+
+    // MARK: - Single book — happy path
+
+    @Test func fetchAllBooksForBackup_singleEpub_populatesAllFields() async throws {
+        let persistence = try makePersistence()
+        let sha = String(repeating: "a", count: 64)
+        let added = Date(timeIntervalSince1970: 1_700_000_000)
+        let record = makeRecord(
+            sha: sha,
+            format: .epub,
+            title: "Alice",
+            author: "Carroll",
+            addedAt: added,
+            originalExtension: "epub"
+        )
+        _ = try await persistence.insertBook(record)
+
+        let projections = try await persistence.fetchAllBooksForBackup()
+        #expect(projections.count == 1)
+
+        let p = projections[0]
+        #expect(p.fingerprintKey == "epub:\(sha):1024")
+        #expect(p.format == "epub")
+        #expect(p.sha256 == sha)
+        #expect(p.byteCount == 1024)
+        #expect(p.title == "Alice")
+        #expect(p.author == "Carroll")
+        #expect(p.addedAt == added)
+        #expect(p.lastOpenedAt == nil)
+        #expect(p.originalExtension == "epub")
+    }
+
+    // MARK: - Original extension preserves MOBI under .azw3 canonical
+
+    @Test func fetchAllBooksForBackup_mobiUnderAzw3_preservesOriginalExtension() async throws {
+        let persistence = try makePersistence()
+        let sha = String(repeating: "b", count: 64)
+        let record = makeRecord(
+            sha: sha,
+            format: .azw3,
+            title: "Old MOBI",
+            originalExtension: "mobi"
+        )
+        _ = try await persistence.insertBook(record)
+
+        let projections = try await persistence.fetchAllBooksForBackup()
+        #expect(projections.count == 1)
+        // Canonical format stays azw3 (DocumentFingerprint uses BookFormat enum which collapses MOBI/PRC/AZW into .azw3).
+        #expect(projections[0].format == "azw3")
+        // Original extension preserved so restore can write the right .ext to the temp file.
+        #expect(projections[0].originalExtension == "mobi")
+    }
+
+    // MARK: - Migration default for legacy rows missing originalExtension
+
+    @Test func fetchAllBooksForBackup_legacyRowMissingOriginalExtension_defaultsToCanonical() async throws {
+        let persistence = try makePersistence()
+        let sha = String(repeating: "c", count: 64)
+        // Insert with originalExtension = nil — simulates legacy V4 row migrated to V5.
+        let record = makeRecord(sha: sha, format: .pdf, originalExtension: nil)
+        _ = try await persistence.insertBook(record)
+
+        let projections = try await persistence.fetchAllBooksForBackup()
+        #expect(projections.count == 1)
+        // Projection coalesces nil into the canonical extension for the format.
+        #expect(projections[0].originalExtension == "pdf")
+    }
+
+    // MARK: - Multiple books
+
+    @Test func fetchAllBooksForBackup_multipleBooks_returnsAllSorted() async throws {
+        let persistence = try makePersistence()
+        let sha1 = String(repeating: "1", count: 64)
+        let sha2 = String(repeating: "2", count: 64)
+        let sha3 = String(repeating: "3", count: 64)
+        _ = try await persistence.insertBook(makeRecord(sha: sha1, format: .epub, title: "B1"))
+        _ = try await persistence.insertBook(makeRecord(sha: sha2, format: .txt, title: "B2"))
+        _ = try await persistence.insertBook(makeRecord(sha: sha3, format: .pdf, title: "B3"))
+
+        let projections = try await persistence.fetchAllBooksForBackup()
+        #expect(projections.count == 3)
+        // Stable sort by fingerprintKey so output is deterministic across runs.
+        let keys = projections.map(\.fingerprintKey)
+        #expect(keys == keys.sorted())
+    }
+}

--- a/vreaderTests/Services/BookImporterOriginalExtensionTests.swift
+++ b/vreaderTests/Services/BookImporterOriginalExtensionTests.swift
@@ -1,0 +1,148 @@
+// Purpose: Tests for BookImporter persisting the source URL's pathExtension into
+// the new Book.originalExtension field. Feature #46 WI-0a — required so that
+// when a backup ZIP later restores a book, the materializer can write the blob
+// to a temp file with the correct extension (e.g. ".mobi" for MOBI books that
+// import as canonical .azw3 format).
+//
+// @coordinates-with: vreader/Services/BookImporter.swift,
+//   vreader/Models/Book.swift, vreader/Services/PersistenceActor.swift
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("BookImporter — originalExtension (feature #46 WI-0a)")
+struct BookImporterOriginalExtensionTests {
+
+    // MARK: - Helpers
+
+    private func makeTempFile(suffix: String, content: Data = Data([0x50, 0x4B, 0x03, 0x04])) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+        let url = dir.appendingPathComponent("test_\(UUID().uuidString)\(suffix)")
+        try content.write(to: url)
+        return url
+    }
+
+    private func makeSandboxDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sandbox_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func makeImporter() async throws -> (BookImporter, MockPersistenceActor, URL) {
+        let mock = MockPersistenceActor()
+        let sandbox = try makeSandboxDir()
+        return (
+            BookImporter(persistence: mock, sandboxBooksDirectory: sandbox),
+            mock,
+            sandbox
+        )
+    }
+
+    // MARK: - Standard formats — extension matches canonical
+
+    @Test func importEpub_persistsEpubExtension() async throws {
+        let fileURL = try makeTempFile(suffix: ".epub")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let (importer, mock, _) = try await makeImporter()
+        let result = try await importer.importFile(at: fileURL, source: .filesApp)
+
+        let stored = await mock.book(forKey: result.fingerprintKey)
+        #expect(stored?.originalExtension == "epub")
+    }
+
+    @Test func importPdf_persistsPdfExtension() async throws {
+        let fileURL = try makeTempFile(suffix: ".pdf", content: Data("%PDF-1.4 fake".utf8))
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let (importer, mock, _) = try await makeImporter()
+        let result = try await importer.importFile(at: fileURL, source: .filesApp)
+
+        let stored = await mock.book(forKey: result.fingerprintKey)
+        #expect(stored?.originalExtension == "pdf")
+    }
+
+    // MARK: - MOBI under canonical .azw3 — extension preservation is the WHOLE point
+
+    @Test func importMobi_persistsMobiExtension_evenThoughCanonicalIsAzw3() async throws {
+        // MOBI/PRC/AZW are all imported as canonical BookFormat.azw3.
+        // Without originalExtension preservation, restore loses the .mobi extension
+        // and the materializer would write the temp blob as .azw3 — which works
+        // but loses information about the original file the user imported.
+        let fileURL = try makeTempFile(suffix: ".mobi", content: Data([0x00, 0x00, 0x42, 0x4F, 0x4F, 0x4B, 0x4D, 0x4F, 0x42, 0x49]))
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let (importer, mock, _) = try await makeImporter()
+        let result = try await importer.importFile(at: fileURL, source: .filesApp)
+
+        let stored = await mock.book(forKey: result.fingerprintKey)
+        // Canonical format collapses to azw3 (BookFormat.azw3.fileExtensions == ["azw3","azw","mobi","prc"]).
+        #expect(stored?.fingerprint.format == .azw3)
+        // But the original source extension is preserved so restore can reconstruct the .mobi filename.
+        #expect(stored?.originalExtension == "mobi")
+    }
+
+    // MARK: - Case normalization
+
+    @Test func importUppercaseExtension_lowercasesIt() async throws {
+        // Filesystems may surface uppercase extensions. The blob path layout is
+        // case-sensitive on most servers, so we normalize to lowercase here so
+        // dedupe-by-fingerprint at upload time is deterministic.
+        let fileURL = try makeTempFile(suffix: ".EPUB")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let (importer, mock, _) = try await makeImporter()
+        let result = try await importer.importFile(at: fileURL, source: .filesApp)
+
+        let stored = await mock.book(forKey: result.fingerprintKey)
+        #expect(stored?.originalExtension == "epub")
+    }
+
+    // MARK: - Re-import preserves first observed extension
+
+    @Test func reimportSameContent_preservesOriginalExtension() async throws {
+        // Codex audit (Gate 4) flagged: when a user re-imports the same content
+        // with a different source extension (e.g., first imported as .mobi, then
+        // again as .azw3), the first import's extension is the user's first
+        // observed truth and must not be overwritten. Production
+        // PersistenceActor.replaceProvenance only mutates provenance — verify
+        // the mock matches that semantic.
+        let mobiURL = try makeTempFile(suffix: ".mobi", content: Data([0x00, 0x00, 0x42, 0x4F, 0x4F, 0x4B, 0x4D, 0x4F, 0x42, 0x49]))
+        defer { try? FileManager.default.removeItem(at: mobiURL) }
+
+        let (importer, mock, _) = try await makeImporter()
+        let firstResult = try await importer.importFile(at: mobiURL, source: .filesApp)
+        #expect(firstResult.isDuplicate == false)
+
+        // Copy the same bytes into a different file with .azw3 extension.
+        let azw3URL = mobiURL.deletingPathExtension().appendingPathExtension("azw3")
+        try FileManager.default.copyItem(at: mobiURL, to: azw3URL)
+        defer { try? FileManager.default.removeItem(at: azw3URL) }
+
+        let secondResult = try await importer.importFile(at: azw3URL, source: .shareSheet)
+        #expect(secondResult.isDuplicate == true)
+
+        // Stored extension should still be the first import's extension.
+        let stored = await mock.book(forKey: secondResult.fingerprintKey)
+        #expect(stored?.originalExtension == "mobi")
+    }
+
+    // MARK: - Multi-dot filename takes only last extension
+
+    @Test func multiDotFilename_takesOnlyLastExtension() async throws {
+        // Path("book.v1.EPUB").pathExtension == "EPUB" (only the last segment).
+        // After lowercasing → "epub". Confirms standard URL behavior.
+        let dir = FileManager.default.temporaryDirectory
+        let url = dir.appendingPathComponent("book.v1.EPUB")
+        try Data([0x50, 0x4B, 0x03, 0x04]).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let (importer, mock, _) = try await makeImporter()
+        let result = try await importer.importFile(at: url, source: .filesApp)
+
+        let stored = await mock.book(forKey: result.fingerprintKey)
+        #expect(stored?.originalExtension == "epub")
+    }
+}

--- a/vreaderTests/Services/CollectionTestHelper.swift
+++ b/vreaderTests/Services/CollectionTestHelper.swift
@@ -7,9 +7,10 @@ import SwiftData
 /// Shared test helpers for collection persistence tests.
 enum CollectionTestHelper {
 
-    /// Creates an in-memory ModelContainer with SchemaV3 for testing.
+    /// Creates an in-memory ModelContainer with the latest schema for testing.
+    /// Bumped to SchemaV5 in feature #46 WI-0a (added Book.originalExtension).
     static func makeContainer() throws -> ModelContainer {
-        let schema = Schema(SchemaV3.models)
+        let schema = Schema(SchemaV5.models)
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         return try ModelContainer(for: schema, configurations: [config])
     }

--- a/vreaderTests/Services/Mocks/MockPersistenceActor.swift
+++ b/vreaderTests/Services/Mocks/MockPersistenceActor.swift
@@ -56,7 +56,9 @@ actor MockPersistenceActor: BookPersisting {
             fingerprint: book.fingerprint,
             provenance: provenance,
             detectedEncoding: book.detectedEncoding,
-            addedAt: book.addedAt
+            addedAt: book.addedAt,
+            originalExtension: book.originalExtension,
+            lastOpenedAt: book.lastOpenedAt
         )
         books[key] = book
     }


### PR DESCRIPTION
## Summary

Foundational precondition for feature #46 (WebDAV materializing restore). Plan at \`dev-docs/plans/20260503-feature-46-materializing-restore.md\`. Refs #144.

## What this WI delivers

1. **\`Book.originalExtension: String?\`** — new SwiftData field (lightweight migration via SchemaV5).
2. **\`BackupBookProjection\`** — new Sendable value type in \`PersistenceActor+Backup.swift\` exposing the raw fingerprint fields needed by the future \`collectLibraryManifest()\` emitter without leaking @Model instances.
3. **\`PersistenceActor.fetchAllBooksForBackup() -> [BackupBookProjection]\`** — sorted by fingerprintKey for deterministic output. Coalesces nil \`originalExtension\` into \`BookFormat.fileExtensions.first\`.
4. **\`BookRecord\`** struct gains \`originalExtension\` + \`lastOpenedAt\` (with explicit init for source-compat).
5. **\`BookImporter\`** writes \`fileURL.pathExtension.lowercased()\` on every new import. Empty extension → nil. Duplicate-import path leaves existing extension alone (first observation wins).
6. **\`SchemaV5\`** mirrors V4's model list at version 5.0.0. \`VReaderMigrationPlan\` adds it; \`VReaderApp\` uses \`Schema(SchemaV5.models)\`.

Known limitation (documented in plan): legacy MOBI/PRC/AZW books default to "azw3" because the source extension was never persisted before this WI.

## Workflow gates passed

- **Gate 1 (Plan)**: \`dev-docs/plans/20260503-feature-46-materializing-restore.md\` (already on main from PR #149)
- **Gate 2 (Plan audit)**: 2 Codex rounds (recorded in plan)
- **Gate 3 (TDD)**: RED → GREEN → REFACTOR. 11 new tests, all GREEN. 36 total tests in touched suites pass.
- **Gate 4 (Impl audit)**: 1 Codex round on the diff. Findings:
  - Mock dropped new fields on \`replaceProvenance\` → **FIXED** (this commit)
  - \`docs/architecture.md\` stale (still said SchemaV4) → **FIXED** (this commit)
  - No on-disk V4→V5 migration test → **ACCEPTED** with rationale: the repo's existing V1→V4 migrations don't have explicit on-disk fixture tests either; a true migration fixture test is shared test infrastructure that should ship as a separate feature once and apply to all schemas. File as follow-up.
- **Gate 5 (Verification)**: not applicable for foundational WI (no user-observable behavior); slice verify on later behavioral WIs.
- **Docs sync** (per \`.claude/rules/24-doc-sync.md\`): \`docs/architecture.md\` updated for SchemaV5, \`originalExtension\`, \`BackupBookProjection\`.

## Tests

- \`BackupBookProjectionTests\` (5 tests): empty library, single EPUB happy path, MOBI-under-AZW3 extension preservation, legacy nil coalesce to canonical, multi-book sorted output.
- \`BookImporterOriginalExtensionTests\` (6 tests, includes 2 added per Codex audit): EPUB/PDF/MOBI happy paths, uppercase normalization, multi-dot filename normalization, re-import preserves first observed extension.
- \`MockPersistenceActor.replaceProvenance\` fixed to preserve the new fields.
- All 36 tests in touched suites GREEN. Pre-existing ~20 failures in the full unit suite are unrelated (per conversation history).

## Type of Change

- [x] Foundational implementation (no user-visible behavior alone; unblocks WI-0b → WI-10)

## Notes

- Version bump: patch (3.10.20). Foundational schema/projection work, no user-visible feature yet.
- Branch was rebased onto latest main before PR open.