### PR TITLE
feat(#46): WI-0b — add ImportSource.restore case

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 21
-        MARKETING_VERSION: 3.10.20
+        CURRENT_PROJECT_VERSION: 22
+        MARKETING_VERSION: 3.10.21
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3778,13 +3778,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.20;
+				MARKETING_VERSION = 3.10.21;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3928,13 +3928,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.20;
+				MARKETING_VERSION = 3.10.21;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Models/ImportSource.swift
+++ b/vreader/Models/ImportSource.swift
@@ -6,4 +6,8 @@ enum ImportSource: String, Codable, Hashable, Sendable, CaseIterable {
     case shareSheet
     case icloudDrive
     case localCopy
+    /// Materialized from a WebDAV backup blob (feature #46). Distinguished from
+    /// user-driven imports so the materializer can suppress "added" UX signals
+    /// when a fresh device restores 100 books at once.
+    case restore
 }

--- a/vreaderTests/Models/ImportProvenanceTests.swift
+++ b/vreaderTests/Models/ImportProvenanceTests.swift
@@ -17,8 +17,24 @@ struct ImportProvenanceTests {
         }
     }
 
-    @Test func importSourceHasFourCases() {
-        #expect(ImportSource.allCases.count == 4)
+    @Test func importSourceHasFiveCases() {
+        // .restore added in feature #46 WI-0b. Tracks every source path so backup
+        // materializing-restore can be distinguished from user-driven imports.
+        #expect(ImportSource.allCases.count == 5)
+    }
+
+    @Test func importSourceContainsRestoreCase() {
+        // Backup restore needs its own provenance so we can distinguish a book
+        // that arrived via WebDAV restore from one the user imported themselves.
+        #expect(ImportSource.allCases.contains(.restore))
+    }
+
+    @Test func importSourceRestoreRoundTripsAsRestore() throws {
+        // String rawValue for `.restore` must be stable — older clients that
+        // see this case need to either decode it or fail predictably.
+        let data = try JSONEncoder().encode(ImportSource.restore)
+        let decoded = try JSONDecoder().decode(ImportSource.self, from: data)
+        #expect(decoded == .restore)
     }
 
     // MARK: - Codable Round-Trip


### PR DESCRIPTION
## Summary

Foundational precondition for feature #46 (WebDAV materializing restore). Refs #144.

Adds \`.restore\` case to \`ImportSource\` so the future materializer can mark books from backup blobs distinctly from user-driven imports. No call sites branch on it yet — pre-shipping keeps the materializer (WI-6) PR focused on its actual logic.

## What Changed

- \`vreader/Models/ImportSource.swift\` — adds 5th case: \`.restore\` with comment.
- \`vreaderTests/Models/ImportProvenanceTests.swift\` — 3 new tests (count→5, contains restore, Codable round-trip). 11 total tests in the suite pass.
- Version bump to 3.10.21 (build 22).

## Workflow gates passed

- Gates 1+2 covered by WI-0a's parent plan.
- Gate 3 (TDD): RED → GREEN, all 11 tests pass.
- Gate 4 (Impl audit): trivial (single-case enum with stable rawValue + matching tests). Skipped per audit-count tier "small" in \`.claude/rules/47-feature-workflow.md\`.
- Gate 5 (Verification): N/A foundational — no user-observable behavior.

## Type of Change

- [x] Foundational implementation (precondition for WI-6 materializer)