### PR TITLE
feat(#46): WI-1 — BlobPath utility for content-addressed library blobs

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 22
-        MARKETING_VERSION: 3.10.21
+        CURRENT_PROJECT_VERSION: 23
+        MARKETING_VERSION: 3.10.22
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		08F7E1DE72FF450114142960 /* utf8_bom.txt in Resources */ = {isa = PBXBuildFile; fileRef = A84BF17CCCD4B376BDDF8CD1 /* utf8_bom.txt */; };
 		09122777AF5FD739850888CA /* LocatorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FC8555E3C352A0C95D6BFE9 /* LocatorFactory.swift */; };
 		095C1FEFA8400DD2F1A61CFF /* FileSizeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52DADD2C2FB6330070EA6DE /* FileSizeFormatter.swift */; };
+		096B20388931B21DAA4DC091 /* BlobPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB65788879E3D91E69E8BA5 /* BlobPathTests.swift */; };
 		099933954CB74FAE04C6B877 /* SearchLocatorSliceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2038A4D36C4355AC5C7BF5 /* SearchLocatorSliceTests.swift */; };
 		0A6A74D96B7763878D13CFDD /* LibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF473C04CE58CE0887DAA5A1 /* LibraryViewModel.swift */; };
 		0A998572897988CF581C77AE /* SourceSharingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317401FBAE274C615325BDBC /* SourceSharingServiceTests.swift */; };
@@ -145,6 +146,7 @@
 		2FDBB9D830B8DC7FF418BD3D /* DebugSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA61DA459242CFDBBD809B7 /* DebugSnapshotTests.swift */; };
 		30043FDF6F3A8F38D2891AF1 /* ReaderContainerView+Sheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C77872C4F869769F4C83F7 /* ReaderContainerView+Sheets.swift */; };
 		301BA4423DE1212ADB315388 /* BookImporterAZW3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4962BEF634F94652553FC6BD /* BookImporterAZW3Tests.swift */; };
+		30C1DE820BD42DAC78AC80FC /* BlobPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560129625F0E48471C0F4B62 /* BlobPath.swift */; };
 		30F629136C9EED9FCD557222 /* SmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D14E222357346107CB34B750 /* SmokeTests.swift */; };
 		3119890EAA98096C06AAF1E3 /* EPUBPreExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE8B867BCF9BCDCF23941DB /* EPUBPreExtractorTests.swift */; };
 		320025CDBC69B31CC1B4DEAA /* PDFReaderContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2BA1A05E4E36D5D7B2DCFD /* PDFReaderContainerView.swift */; };
@@ -953,6 +955,7 @@
 		544A2F3FF8BBB1C08DDCE02D /* PageNavigatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageNavigatorTests.swift; sourceTree = "<group>"; };
 		5487566F93AB8376D1BD1F1B /* EPUBFileLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBFileLoaderTests.swift; sourceTree = "<group>"; };
 		54F63868C11B04D324F09751 /* TTSControlBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSControlBar.swift; sourceTree = "<group>"; };
+		560129625F0E48471C0F4B62 /* BlobPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlobPath.swift; sourceTree = "<group>"; };
 		5639E3F809343C8CE5D7A020 /* PDFPasswordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFPasswordTests.swift; sourceTree = "<group>"; };
 		576F111E93E863C656BDEC70 /* SearchViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModelTests.swift; sourceTree = "<group>"; };
 		58CB10F386B36EF83C36873F /* FoliateJSEscaper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateJSEscaper.swift; sourceTree = "<group>"; };
@@ -1230,6 +1233,7 @@
 		BE8121B86DA337766FD55AEF /* WebDAVClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVClientTests.swift; sourceTree = "<group>"; };
 		BEAA04C3430C5B247FB86585 /* TXTChapterIndexBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterIndexBuilderTests.swift; sourceTree = "<group>"; };
 		BFA61DA459242CFDBBD809B7 /* DebugSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSnapshotTests.swift; sourceTree = "<group>"; };
+		BFB65788879E3D91E69E8BA5 /* BlobPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlobPathTests.swift; sourceTree = "<group>"; };
 		C00E5921EA2B5FE88656FED6 /* AnnotationsPanelViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationsPanelViewTests.swift; sourceTree = "<group>"; };
 		C07FF4DC80918BEE43FF99D4 /* RealDebugBridgeContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealDebugBridgeContextTests.swift; sourceTree = "<group>"; };
 		C0B1246EC0EE34D326231F60 /* SearchQueryExecutorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchQueryExecutorTests.swift; sourceTree = "<group>"; };
@@ -1582,6 +1586,7 @@
 				DA823268583E27AF564272EC /* BackupDataRestorer.swift */,
 				8AB2B5F77B95D3402E699DA9 /* BackupProvider.swift */,
 				64D6B83FC65D64C1271E28F4 /* BackupSectionDTOs.swift */,
+				560129625F0E48471C0F4B62 /* BlobPath.swift */,
 				DB6CE81404902AB359536964 /* PROPFINDParser.swift */,
 				4946129FECC6C9BA7A7F16A1 /* WebDAVClient.swift */,
 				C3EF8CE8D52815CF5156953C /* WebDAVProvider.swift */,
@@ -2494,6 +2499,7 @@
 				EFABA0F5E3E749CC8108947C /* BackupBookProjectionTests.swift */,
 				A17676C4AE9DD328C39176D8 /* BackupDataCollectorRestorerTests.swift */,
 				ED150D276C082FEC194F2F31 /* BackupProviderContractTests.swift */,
+				BFB65788879E3D91E69E8BA5 /* BlobPathTests.swift */,
 				4D9501ED4FB49C6035FDF5BB /* MockBackupProvider.swift */,
 				D9A7B601E9791FB068616C98 /* WebDAVATSTests.swift */,
 				C3F1695C0E7481CB3EA2B8A3 /* WebDAVBackupIntegrationTests.swift */,
@@ -3056,6 +3062,7 @@
 				22612350C6FC7C43096271E9 /* BackupDataCollectorRestorerTests.swift in Sources */,
 				4F2FEC62B6D23F67263EDF34 /* BackupProviderContractTests.swift in Sources */,
 				90D2C41C30E622E119877967 /* BackupViewModelTests.swift in Sources */,
+				096B20388931B21DAA4DC091 /* BlobPathTests.swift in Sources */,
 				C205A1413A59C630A10ECEB7 /* BookContentCacheTests.swift in Sources */,
 				D41473E2CF7AB980E43C6C54 /* BookFormatAZW3Tests.swift in Sources */,
 				2B9E39AC289E006A1A8B25AE /* BookFormatTests.swift in Sources */,
@@ -3341,6 +3348,7 @@
 				20271E1F835A62799E28F741 /* BackupViewModel.swift in Sources */,
 				986EFB28F7203E56F853A0FD /* BasePageNavigator.swift in Sources */,
 				D1F6F2B6287F6C78E947FFAE /* BilingualView.swift in Sources */,
+				30C1DE820BD42DAC78AC80FC /* BlobPath.swift in Sources */,
 				96F610A12CED33CA6B82C142 /* Book.swift in Sources */,
 				12EE1BD6335013980EFA3EC0 /* BookCardView.swift in Sources */,
 				AF32B348898F4110FED715F5 /* BookCollection.swift in Sources */,
@@ -3778,13 +3786,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.21;
+				MARKETING_VERSION = 3.10.22;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3928,13 +3936,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.21;
+				MARKETING_VERSION = 3.10.22;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Backup/BlobPath.swift
+++ b/vreader/Services/Backup/BlobPath.swift
@@ -1,0 +1,82 @@
+// Purpose: Maps (format, sha256, byteCount) ↔ WebDAV-safe blob path for
+// feature #46's content-addressed library blob store.
+//
+// Path layout: VReader/books/<format>/<sha256>_<byteCount>.<canonical-ext>
+//
+// Why not the raw fingerprintKey ("epub:abc:1024"): colons are not safe
+// across all WebDAV servers — Apache/mod_dav passes them through but some
+// proxies, S3-style adapters, and Windows-backed shares mangle them. The
+// blob path uses only [0-9a-f_./], leaves the canonical fingerprintKey
+// inside the manifest where it's pure data.
+//
+// Per-format subdirectory ("books/<format>/") keeps directory listings
+// bounded as the library grows — most WebDAV servers throttle enumeration
+// over ~1000 entries, and sharding by 5 known formats buys headroom.
+//
+// originalExtension is intentionally NOT in the blob path — different source
+// extensions (.mobi, .prc, .azw) for the same SHA-256 content collapse to
+// the same blob (canonical .azw3 extension). The original extension travels
+// in the library manifest, not the path.
+//
+// @coordinates-with: BackupBookProjection (PersistenceActor+Backup.swift),
+//   BackupLibraryManifestEnvelope (BackupSectionDTOs.swift, future WI-2),
+//   BookFileMaterializer (future WI-5),
+//   dev-docs/plans/20260503-feature-46-materializing-restore.md
+
+import Foundation
+
+enum BlobPath {
+
+    /// Top-level directory for content-addressed book blobs on the WebDAV
+    /// server. Pinned by `BlobPathTests.booksRootIsStable` — changing it
+    /// invalidates every previously-uploaded backup.
+    static let booksRoot = "VReader/books"
+
+    /// Builds the blob path for a (format, sha256, byteCount) triple.
+    ///
+    /// Returns: `"VReader/books/<format>/<sha256>_<byteCount>.<canonical-ext>"`
+    static func make(format: BookFormat, sha256: String, byteCount: Int64) -> String {
+        let formatStr = format.rawValue
+        let canonicalExt = format.fileExtensions.first ?? formatStr
+        return "\(booksRoot)/\(formatStr)/\(sha256)_\(byteCount).\(canonicalExt)"
+    }
+
+    /// Parses a blob path back into its components.
+    ///
+    /// Returns nil if the path doesn't match the expected layout, the format
+    /// segment is unknown, the SHA-256 isn't 64 hex chars, or the byte count
+    /// isn't a non-negative integer.
+    static func parse(_ path: String) -> (format: BookFormat, sha256: String, byteCount: Int64)? {
+        // Expected: "VReader/books/<format>/<sha256>_<byteCount>.<ext>"
+        let prefix = booksRoot + "/"
+        guard path.hasPrefix(prefix) else { return nil }
+        let trail = String(path.dropFirst(prefix.count))
+
+        let segments = trail.split(separator: "/", omittingEmptySubsequences: false)
+        guard segments.count == 2 else { return nil }
+        let formatSegment = String(segments[0])
+        let filename = String(segments[1])
+
+        guard let format = BookFormat(rawValue: formatSegment) else { return nil }
+
+        // Strip extension; rest must be "<sha256>_<byteCount>".
+        let nsFilename = filename as NSString
+        let stem = nsFilename.deletingPathExtension
+        guard !stem.isEmpty, stem != filename else { return nil }  // require an extension
+
+        let parts = stem.split(separator: "_", omittingEmptySubsequences: false)
+        guard parts.count == 2 else { return nil }
+        let sha = String(parts[0])
+        let byteStr = String(parts[1])
+
+        guard isValidSHA256Hex(sha), let bytes = Int64(byteStr), bytes >= 0 else { return nil }
+        return (format: format, sha256: sha, byteCount: bytes)
+    }
+
+    // MARK: - Helpers
+
+    private static func isValidSHA256Hex(_ s: String) -> Bool {
+        guard s.count == 64 else { return false }
+        return s.allSatisfy { $0.isHexDigit }
+    }
+}

--- a/vreaderTests/Services/Backup/BlobPathTests.swift
+++ b/vreaderTests/Services/Backup/BlobPathTests.swift
@@ -1,0 +1,132 @@
+// Purpose: Tests for BlobPath — content-addressed WebDAV path utility used by
+// feature #46 (WebDAV materializing restore). Asserts canonical layout, format
+// round-trip, and rejection of malformed inputs.
+//
+// @coordinates-with: vreader/Services/Backup/BlobPath.swift,
+//   dev-docs/plans/20260503-feature-46-materializing-restore.md
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("BlobPath — feature #46 WI-1")
+struct BlobPathTests {
+
+    // MARK: - make() — happy path per format
+
+    @Test func makeEpubPath() {
+        let path = BlobPath.make(
+            format: .epub,
+            sha256: String(repeating: "a", count: 64),
+            byteCount: 1024
+        )
+        #expect(path == "VReader/books/epub/\(String(repeating: "a", count: 64))_1024.epub")
+    }
+
+    @Test func makeAzw3Path() {
+        // MOBI/PRC/AZW collapse to canonical .azw3 — blob path uses .azw3
+        // regardless of original extension. originalExtension lives in the manifest.
+        let path = BlobPath.make(
+            format: .azw3,
+            sha256: String(repeating: "b", count: 64),
+            byteCount: 9_999_999
+        )
+        #expect(path == "VReader/books/azw3/\(String(repeating: "b", count: 64))_9999999.azw3")
+    }
+
+    @Test func makeTxtPath() {
+        let path = BlobPath.make(
+            format: .txt,
+            sha256: String(repeating: "c", count: 64),
+            byteCount: 14_059_220
+        )
+        #expect(path == "VReader/books/txt/\(String(repeating: "c", count: 64))_14059220.txt")
+    }
+
+    @Test func makeMdPath() {
+        let path = BlobPath.make(
+            format: .md,
+            sha256: String(repeating: "d", count: 64),
+            byteCount: 512
+        )
+        #expect(path == "VReader/books/md/\(String(repeating: "d", count: 64))_512.md")
+    }
+
+    @Test func makePdfPath() {
+        let path = BlobPath.make(
+            format: .pdf,
+            sha256: String(repeating: "e", count: 64),
+            byteCount: 1_048_576
+        )
+        #expect(path == "VReader/books/pdf/\(String(repeating: "e", count: 64))_1048576.pdf")
+    }
+
+    // MARK: - parse() — round trip
+
+    @Test(arguments: BookFormat.allCases) func roundTripPerFormat(_ format: BookFormat) throws {
+        let sha = String(repeating: "f", count: 64)
+        let bytes: Int64 = 65_537
+        let path = BlobPath.make(format: format, sha256: sha, byteCount: bytes)
+        let parsed = try #require(BlobPath.parse(path))
+        #expect(parsed.format == format)
+        #expect(parsed.sha256 == sha)
+        #expect(parsed.byteCount == bytes)
+    }
+
+    // MARK: - parse() — rejection
+
+    @Test func parseInvalidFormat_returnsNil() {
+        let bogus = "VReader/books/zzz/\(String(repeating: "a", count: 64))_1024.zzz"
+        #expect(BlobPath.parse(bogus) == nil)
+    }
+
+    @Test func parseShortSHA_returnsNil() {
+        // SHA-256 must be 64 hex chars. Anything shorter is invalid identity.
+        let short = "VReader/books/epub/abcd_1024.epub"
+        #expect(BlobPath.parse(short) == nil)
+    }
+
+    @Test func parseNonHexSHA_returnsNil() {
+        // 64 chars but not all hex — corrupt fingerprint, reject.
+        let nonHex = "VReader/books/epub/\(String(repeating: "z", count: 64))_1024.epub"
+        #expect(BlobPath.parse(nonHex) == nil)
+    }
+
+    @Test func parseMissingByteCount_returnsNil() {
+        let missing = "VReader/books/epub/\(String(repeating: "a", count: 64)).epub"
+        #expect(BlobPath.parse(missing) == nil)
+    }
+
+    @Test func parseNonNumericByteCount_returnsNil() {
+        let bad = "VReader/books/epub/\(String(repeating: "a", count: 64))_xyz.epub"
+        #expect(BlobPath.parse(bad) == nil)
+    }
+
+    @Test func parseWrongRoot_returnsNil() {
+        let wrong = "Other/path/epub/\(String(repeating: "a", count: 64))_1024.epub"
+        #expect(BlobPath.parse(wrong) == nil)
+    }
+
+    @Test func parseEmptyString_returnsNil() {
+        #expect(BlobPath.parse("") == nil)
+    }
+
+    // MARK: - Invariants
+
+    @Test func booksRootIsStable() {
+        // Servers cache and tools script against this prefix; changing it would
+        // break every previously-uploaded backup. Pin via test.
+        #expect(BlobPath.booksRoot == "VReader/books")
+    }
+
+    @Test func makeNeverContainsColons() {
+        // Colons in the canonical fingerprintKey ("epub:abc:1024") aren't
+        // safe across every WebDAV server. Blob path uses underscores.
+        let path = BlobPath.make(
+            format: .epub,
+            sha256: String(repeating: "a", count: 64),
+            byteCount: 1024
+        )
+        #expect(!path.contains(":"))
+    }
+}


### PR DESCRIPTION
## Summary

Refs #144. Adds \`BlobPath\` — pure value-type utility that maps \`(BookFormat, sha256, byteCount)\` ↔ a WebDAV-safe content-addressed path:

\`\`\`
VReader/books/<format>/<sha256>_<byteCount>.<canonical-ext>
\`\`\`

## What Changed

- \`vreader/Services/Backup/BlobPath.swift\` — NEW (~80 lines), pure enum with \`make\` + \`parse\`.
- \`vreaderTests/Services/Backup/BlobPathTests.swift\` — NEW (15 tests, all GREEN).
- Version bump 3.10.22.

## Why this layout

- **Avoids colons** — canonical \`fingerprintKey\` ("epub:abc:1024") isn't safe across all WebDAV servers.
- **Per-format subdirectory** — bounds directory enumeration as the library grows.
- **\`originalExtension\` NOT in path** — different source extensions for same SHA-256 content collapse to the same blob; original extension travels in the manifest.

## Workflow gates passed

- Gates 1+2 covered by parent plan.
- Gate 3 (TDD): RED → GREEN → REFACTOR. 15 tests, no mocks.
- Gate 4 (Impl audit): trivial — pure value type, parameterized exhaustive tests, no shared state. Skipped per audit-count tier "small".
- Gate 5 (Verification): N/A foundational; downstream WIs exercise via integration tests.

## Type of Change

- [x] Foundational implementation (consumed by WI-5/6/7)