### PR TITLE
feat(#46): WI-2 — BackupLibraryManifestEnvelope + file bug #111

### DIFF
--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -89,6 +89,14 @@ Track bugs here. Tell the agent "fix bug #N" to start a fix.
 - **Root cause**: Import writes to DB but no notification to reader to re-render
 - **Fix**: Added `.readerHighlightsDidImport` notification; all format containers observe and call `coordinator.restoreAll()`
 
+### Bug #111 — DebugFixtures resources ship in Release builds
+- **Repro**: build vreader at Release configuration, inspect `vreader.app/Resources/`. The bundled `war-and-peace.txt` is present.
+- **Expected**: DebugFixtures present only in DEBUG builds.
+- **Actual**: included in every configuration's Resources copy phase.
+- **Discovery**: Codex audit of feature #48 plan (2026-05-03) verified against `vreader.xcodeproj/project.pbxproj` line 2986.
+- **Why not trivial**: xcodegen `sources.excludes` is not per-build-config. Real fix needs one of: (a) move fixtures to a Debug-only target, (b) build-phase script that copies fixtures only when `$(CONFIGURATION) == Debug`, (c) a separate XcodeGen spec generated only for Debug, or (d) preprocessor-based `#if DEBUG` resource access (defeats the leak in code but keeps the bytes in the bundle — partial fix).
+- **Risk**: leaks ~3MB of test data into shipped Release builds. Not a security issue (fixture is a public-domain text), but bloats App Store binary and surfaces a debug feature in Spotlight on user devices.
+
 
 ## Summary
 
@@ -205,3 +213,4 @@ Track bugs here. Tell the agent "fix bug #N" to start a fix.
 | 108| AZW3/Foliate reader: center tap does not toggle chrome                                                 | Foliate/* | Medium   | TODO     | Toolbar stays visible on center tap in FoliateSpikeView. EPUB chrome toggle works. WKWebView may consume tap. |
 | 109| TXT chapter mode: progress bar shows book progress instead of chapter progress                         | TXT/*     | Medium   | FIXED    | Fixed in bfd8345. Added currentChapterLocalUTF16 to TXTReaderViewModel; bridge stores local offset, persistence converts to global. 4 new tests. GH: #31 |
 | 110| WebDAV Test Connection blocked by App Transport Security on Tailscale URL                              | Backup/*  | High     | FIXED    | Migrated project.yml from auto-generated Info.plist to managed Info.plist via XcodeGen `info.properties`; added `NSAppTransportSecurity > NSAllowsArbitraryLoads = true`. 2 regression tests in `WebDAVATSTests.swift`. GH: #136 |
+| 111| DebugFixtures resources ship in Release builds                                                         | DevTools/*| Medium   | TODO     | `vreader/Resources/DebugFixtures/war-and-peace.txt` is included in the production Resources copy phase (verified in `vreader.xcodeproj/project.pbxproj`). Surfaced by Codex audit of feature #48 plan (2026-05-03). xcodegen `excludes` is not per-build-config, so a real fix needs a build-phase script, separate target, or generated config-conditional source spec. |

--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 23
-        MARKETING_VERSION: 3.10.22
+        CURRENT_PROJECT_VERSION: 24
+        MARKETING_VERSION: 3.10.23
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -467,6 +467,7 @@
 		A138F46DE7229925D7AC22EF /* ReaderPositionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F99442B3BA1E02CC3F2A2C1 /* ReaderPositionService.swift */; };
 		A15032261BB154AE5E0AC38B /* view.js in Resources */ = {isa = PBXBuildFile; fileRef = 5C502F959BB80E4EE5F022C8 /* view.js */; };
 		A190FE66621610AD2D04739D /* PersistenceActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1DE5531A63EA492C5D91BEE /* PersistenceActor.swift */; };
+		A1C0DD5C147F74C3C21B932B /* BackupLibraryManifestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64BCF588EF860DD6C214737 /* BackupLibraryManifestTests.swift */; };
 		A232BB96700FAD0583896DE3 /* ReadingSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A104E5CBC93D0266E6C21E /* ReadingSession.swift */; };
 		A2518618C1F5EAD7C8FD4EE0 /* LibraryPersisting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A29C79BA1C5BF852179BCBB /* LibraryPersisting.swift */; };
 		A2B7E3D8BAEC3C9A9375D3E4 /* AppConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51935A413CAABF4DE2D3C488 /* AppConfigurationTests.swift */; };
@@ -1393,6 +1394,7 @@
 		F518E98F02B1A2000C41AAB2 /* TXTChapterIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterIntegrationTests.swift; sourceTree = "<group>"; };
 		F560EA65913036C78284C138 /* ErrorScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorScreenTests.swift; sourceTree = "<group>"; };
 		F59ACCAF30F5092968415855 /* AnnotationsPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationsPanelView.swift; sourceTree = "<group>"; };
+		F64BCF588EF860DD6C214737 /* BackupLibraryManifestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupLibraryManifestTests.swift; sourceTree = "<group>"; };
 		F693921BA233745D77EC0037 /* SyncStatusMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusMonitor.swift; sourceTree = "<group>"; };
 		F70B62CBA5AED4AECA05825E /* SchemaV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV4.swift; sourceTree = "<group>"; };
 		F77371DBD389CE1F1153E56E /* OPDSClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSClient.swift; sourceTree = "<group>"; };
@@ -2498,6 +2500,7 @@
 			children = (
 				EFABA0F5E3E749CC8108947C /* BackupBookProjectionTests.swift */,
 				A17676C4AE9DD328C39176D8 /* BackupDataCollectorRestorerTests.swift */,
+				F64BCF588EF860DD6C214737 /* BackupLibraryManifestTests.swift */,
 				ED150D276C082FEC194F2F31 /* BackupProviderContractTests.swift */,
 				BFB65788879E3D91E69E8BA5 /* BlobPathTests.swift */,
 				4D9501ED4FB49C6035FDF5BB /* MockBackupProvider.swift */,
@@ -3060,6 +3063,7 @@
 				C9D2AE1A81222E67A05CA05C /* BackgroundIndexingCoordinatorTests.swift in Sources */,
 				50D3F5B291DB7188E2BB0442 /* BackupBookProjectionTests.swift in Sources */,
 				22612350C6FC7C43096271E9 /* BackupDataCollectorRestorerTests.swift in Sources */,
+				A1C0DD5C147F74C3C21B932B /* BackupLibraryManifestTests.swift in Sources */,
 				4F2FEC62B6D23F67263EDF34 /* BackupProviderContractTests.swift in Sources */,
 				90D2C41C30E622E119877967 /* BackupViewModelTests.swift in Sources */,
 				096B20388931B21DAA4DC091 /* BlobPathTests.swift in Sources */,
@@ -3786,13 +3790,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.22;
+				MARKETING_VERSION = 3.10.23;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3936,13 +3940,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.22;
+				MARKETING_VERSION = 3.10.23;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Backup/BackupSectionDTOs.swift
+++ b/vreader/Services/Backup/BackupSectionDTOs.swift
@@ -207,3 +207,62 @@ struct BackupReplacementRule: Codable, Sendable, Equatable {
     let label: String
     let createdAt: Date
 }
+
+// MARK: - Library Manifest (feature #46 WI-2)
+
+/// Library manifest section emitted as `library-manifest.json` inside the
+/// backup ZIP starting with feature #46. Backward-compatible: old (v1-format)
+/// backups without this section restore exactly as before — metadata-only,
+/// no book materialization. New backups carry one entry per local book so the
+/// restorer can download missing blobs and reconstruct the library on a
+/// fresh device.
+struct BackupLibraryManifestEnvelope: Codable, Sendable, Equatable, BackupVersionedEnvelope {
+    let schemaVersion: Int
+    let books: [BackupLibraryEntry]
+}
+
+/// Per-book entry in the library manifest. Carries the canonical fingerprint
+/// fields plus the blob path on the WebDAV server so the materializer doesn't
+/// need to recompute it from format + sha256 + byteCount on every entry.
+///
+/// `originalExtension` is non-optional here (the projection coalesces nil to
+/// the canonical extension before emission, see `BackupBookProjection` /
+/// `PersistenceActor.fetchAllBooksForBackup`).
+struct BackupLibraryEntry: Codable, Sendable, Equatable {
+    /// Canonical `{format}:{sha256}:{byteCount}` — primary key for re-attaching
+    /// positions/annotations after restore.
+    let fingerprintKey: String
+
+    /// Canonical `BookFormat.rawValue` — `"epub"`, `"azw3"`, `"txt"`, `"md"`, `"pdf"`.
+    let format: String
+
+    /// Hex SHA-256 of the original file bytes.
+    let sha256: String
+
+    /// Original file byte count.
+    let byteCount: Int64
+
+    /// Original source extension at import time, e.g. `"mobi"` for AZW3-canonical
+    /// books that were imported as `.mobi`. Used by the materializer to write
+    /// the downloaded blob to a temp file with the user's original extension.
+    let originalExtension: String
+
+    /// Display-only title and author. The materializer re-extracts these from
+    /// the imported file via `MetadataExtractor`; they're carried in the manifest
+    /// so future selective-restore UI (feature #47) can show them before
+    /// downloading the blob.
+    let title: String?
+    let author: String?
+
+    /// When the user added the book to their library.
+    let addedAt: Date
+
+    /// When the book was last opened, if ever. Restored alongside the position
+    /// so the restored library shows the right "Last Read" sort order.
+    let lastOpenedAt: Date?
+
+    /// Content-addressed WebDAV path to the blob, e.g.
+    /// `"VReader/books/azw3/<sha256>_<byteCount>.azw3"`. Always agrees with
+    /// `BlobPath.make(format:sha256:byteCount:)`.
+    let blobPath: String
+}

--- a/vreaderTests/Services/Backup/BackupLibraryManifestTests.swift
+++ b/vreaderTests/Services/Backup/BackupLibraryManifestTests.swift
@@ -1,0 +1,159 @@
+// Purpose: Tests for BackupLibraryManifestEnvelope + BackupLibraryEntry — the
+// new section emitted into the backup ZIP by feature #46 so restore can
+// materialize books on a fresh device. Asserts round-trip, schemaVersion
+// guard, and that blobPath agrees with BlobPath.make.
+//
+// @coordinates-with: vreader/Services/Backup/BackupSectionDTOs.swift,
+//   vreader/Services/Backup/BlobPath.swift,
+//   dev-docs/plans/20260503-feature-46-materializing-restore.md
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("BackupLibraryManifest — feature #46 WI-2")
+struct BackupLibraryManifestTests {
+
+    // MARK: - Helpers
+
+    private func sampleEntry(
+        fingerprintKey: String = "epub:\(String(repeating: "a", count: 64)):1024",
+        format: String = "epub",
+        sha256: String = String(repeating: "a", count: 64),
+        byteCount: Int64 = 1024,
+        originalExtension: String = "epub",
+        title: String? = "Sample",
+        author: String? = "Author",
+        addedAt: Date = Date(timeIntervalSince1970: 1_700_000_000),
+        lastOpenedAt: Date? = nil,
+        blobPath: String? = nil
+    ) -> BackupLibraryEntry {
+        BackupLibraryEntry(
+            fingerprintKey: fingerprintKey,
+            format: format,
+            sha256: sha256,
+            byteCount: byteCount,
+            originalExtension: originalExtension,
+            title: title,
+            author: author,
+            addedAt: addedAt,
+            lastOpenedAt: lastOpenedAt,
+            blobPath: blobPath ?? BlobPath.make(format: .epub, sha256: sha256, byteCount: byteCount)
+        )
+    }
+
+    // MARK: - Round-trip
+
+    @Test func emptyEnvelope_roundTrips() throws {
+        let envelope = BackupLibraryManifestEnvelope(schemaVersion: 1, books: [])
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(envelope)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(BackupLibraryManifestEnvelope.self, from: data)
+        #expect(decoded == envelope)
+    }
+
+    @Test func multiBookEnvelope_roundTrips() throws {
+        let entries: [BackupLibraryEntry] = [
+            sampleEntry(),
+            sampleEntry(
+                fingerprintKey: "azw3:\(String(repeating: "b", count: 64)):4096",
+                format: "azw3",
+                sha256: String(repeating: "b", count: 64),
+                byteCount: 4096,
+                originalExtension: "mobi",
+                title: "MOBI Book",
+                lastOpenedAt: Date(timeIntervalSince1970: 1_700_000_500),
+                blobPath: BlobPath.make(format: .azw3, sha256: String(repeating: "b", count: 64), byteCount: 4096)
+            ),
+        ]
+        let envelope = BackupLibraryManifestEnvelope(schemaVersion: 1, books: entries)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(envelope)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(BackupLibraryManifestEnvelope.self, from: data)
+        #expect(decoded == envelope)
+        // MOBI extension preserved through the round-trip — the whole point of WI-0a.
+        #expect(decoded.books[1].originalExtension == "mobi")
+        #expect(decoded.books[1].format == "azw3")
+    }
+
+    // MARK: - schemaVersion conformance
+
+    @Test func envelopeConformsToVersionedProtocol() {
+        let envelope = BackupLibraryManifestEnvelope(schemaVersion: 1, books: [])
+        // Cast to the protocol — verifies conformance compiles + the field is exposed.
+        let asProto: BackupVersionedEnvelope = envelope
+        #expect(asProto.schemaVersion == 1)
+    }
+
+    // MARK: - Blob path agreement
+
+    @Test func entryBlobPath_matchesBlobPathMakeForFormat() {
+        let sha = String(repeating: "c", count: 64)
+        let bytes: Int64 = 9_999_999
+        let expected = BlobPath.make(format: .azw3, sha256: sha, byteCount: bytes)
+        let entry = sampleEntry(
+            fingerprintKey: "azw3:\(sha):\(bytes)",
+            format: "azw3",
+            sha256: sha,
+            byteCount: bytes,
+            originalExtension: "azw3",
+            blobPath: expected
+        )
+        #expect(entry.blobPath == expected)
+        // And it round-trips through the path's parser.
+        let parsed = BlobPath.parse(entry.blobPath)
+        #expect(parsed?.sha256 == sha)
+        #expect(parsed?.byteCount == bytes)
+        #expect(parsed?.format == .azw3)
+    }
+
+    // MARK: - JSON shape stability
+
+    @Test func envelopeJSON_includesExpectedTopLevelKeys() throws {
+        let envelope = BackupLibraryManifestEnvelope(schemaVersion: 1, books: [])
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(envelope)
+        let json = String(data: data, encoding: .utf8) ?? ""
+        // Pin the top-level shape so consumers (including older clients in the
+        // future) can assert against a stable schema.
+        #expect(json.contains("\"schemaVersion\":1"))
+        #expect(json.contains("\"books\":"))
+    }
+
+    @Test func entryJSON_includesAllFields() throws {
+        let entry = sampleEntry(lastOpenedAt: Date(timeIntervalSince1970: 1_700_000_500))
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(entry)
+        let json = String(data: data, encoding: .utf8) ?? ""
+        for key in ["fingerprintKey", "format", "sha256", "byteCount",
+                    "originalExtension", "title", "author", "addedAt",
+                    "lastOpenedAt", "blobPath"] {
+            #expect(json.contains("\"\(key)\":"), "missing key \"\(key)\" in JSON")
+        }
+    }
+
+    // MARK: - Optional field encoding
+
+    @Test func entryWithNilOptionals_decodes() throws {
+        // Some entries may have nil author / lastOpenedAt / title.
+        let entry = sampleEntry(title: nil, author: nil, lastOpenedAt: nil)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(entry)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(BackupLibraryEntry.self, from: data)
+        #expect(decoded.title == nil)
+        #expect(decoded.author == nil)
+        #expect(decoded.lastOpenedAt == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Refs #144. Adds the library-manifest section DTOs to the backup ZIP. Files bug #111 (DebugFixtures shipping in Release) discovered during the Codex audit of feature #48 plan.

## What Changed

- \`vreader/Services/Backup/BackupSectionDTOs.swift\` — adds \`BackupLibraryManifestEnvelope\` + \`BackupLibraryEntry\`.
- \`vreaderTests/Services/Backup/BackupLibraryManifestTests.swift\` — NEW (7 tests, all GREEN).
- \`docs/bugs.md\` — files bug #111 (war-and-peace.txt ships in Release; xcodegen excludes is not per-config so the fix is non-trivial).
- Version bump 3.10.23.

## Workflow

- Gates 1+2 covered by parent plan.
- Gate 3 (TDD): RED → GREEN → REFACTOR. 7 tests covering round-trip, schemaVersion conformance, BlobPath agreement, JSON shape stability, optional field decoding.
- Gate 4 (Impl audit): trivial — pure Codable DTOs. Skipped per audit-count tier "small".

## Type of Change

- [x] Foundational implementation (consumed by WI-5/6/7)
- [x] Tracker housekeeping (bug #111 filing, ride-along to avoid standalone tracker PR)