### PR TITLE
feat(#46): WI-3 — WebDAVClient gains MOVE + existsWithSize

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 24
-        MARKETING_VERSION: 3.10.23
+        CURRENT_PROJECT_VERSION: 25
+        MARKETING_VERSION: 3.10.24
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3790,13 +3790,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.23;
+				MARKETING_VERSION = 3.10.24;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3940,13 +3940,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.23;
+				MARKETING_VERSION = 3.10.24;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Backup/WebDAVClient.swift
+++ b/vreader/Services/Backup/WebDAVClient.swift
@@ -56,6 +56,27 @@ protocol WebDAVTransport: Sendable {
     func listDirectory(path: String) async throws -> [WebDAVEntry]
     func createDirectory(path: String) async throws
     func testConnection() async throws
+
+    // MARK: Feature #46 (WI-3) — atomic blob publication primitives
+
+    /// Atomically renames `fromPath` to `toPath` via WebDAV `MOVE` (RFC 4918 §9.9).
+    ///
+    /// Used by feature #46's `BookFileMaterializer` to publish content-addressed
+    /// blobs after a temp upload, so the final blob path is either fully present
+    /// or absent — never half-written.
+    ///
+    /// `Overwrite: F` so a pre-existing blob at the destination is preserved
+    /// (content-addressing guarantees identical bytes already converged there).
+    /// Throws `WebDAVError.httpError(412)` when the destination already exists.
+    func move(fromPath: String, toPath: String) async throws
+
+    /// Returns the resource's byte count, or nil if it doesn't exist (404).
+    ///
+    /// Implemented as `PROPFIND Depth: 0` rather than `HEAD` because some
+    /// WebDAV servers don't expose `getcontentlength` on HEAD responses.
+    /// Used by feature #46 to dedupe blob uploads — if the server already has
+    /// the blob with matching size, skip the PUT.
+    func existsWithSize(at path: String) async throws -> Int64?
 }
 
 // MARK: - WebDAVClient
@@ -169,6 +190,33 @@ struct WebDAVClient: Sendable {
         var request = URLRequest(url: buildURL(path: normalized))
         request.httpMethod = "MKCOL"
         request.setValue(authorizationHeader, forHTTPHeaderField: "Authorization")
+        return request
+    }
+
+    /// Builds a MOVE request (RFC 4918 §9.9). Requires `Destination` header
+    /// set to an absolute URL on the same server. `Overwrite: F` by default
+    /// so the operation fails (412 Precondition Failed) if the destination
+    /// already exists — desirable for content-addressed publication where
+    /// identical bytes have already converged at the destination.
+    func buildMOVERequest(fromPath: String, toPath: String, overwrite: Bool = false) -> URLRequest {
+        var request = URLRequest(url: buildURL(path: fromPath))
+        request.httpMethod = "MOVE"
+        request.setValue(authorizationHeader, forHTTPHeaderField: "Authorization")
+        request.setValue(buildURL(path: toPath).absoluteString, forHTTPHeaderField: "Destination")
+        request.setValue(overwrite ? "T" : "F", forHTTPHeaderField: "Overwrite")
+        return request
+    }
+
+    /// Builds a `PROPFIND Depth: 0` request for a single resource — used to
+    /// check existence + read `getcontentlength` without enumerating children.
+    /// Same XML body as the directory PROPFIND for consistency.
+    func buildPROPFINDExistsRequest(path: String) -> URLRequest {
+        var request = URLRequest(url: buildURL(path: path))
+        request.httpMethod = "PROPFIND"
+        request.setValue(authorizationHeader, forHTTPHeaderField: "Authorization")
+        request.setValue("0", forHTTPHeaderField: "Depth")
+        request.setValue("application/xml", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Data(Self.propfindBody.utf8)
         return request
     }
 
@@ -288,6 +336,45 @@ extension WebDAVClient: WebDAVTransport {
             throw WebDAVError.connectionFailed("Invalid response")
         }
         try Self.checkHTTPStatus(httpResponse.statusCode, url: request.url!)
+    }
+
+    // MARK: Feature #46 (WI-3) — atomic blob publication primitives
+
+    func move(fromPath: String, toPath: String) async throws {
+        let request = buildMOVERequest(fromPath: fromPath, toPath: toPath, overwrite: false)
+        let (_, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw WebDAVError.connectionFailed("Invalid response")
+        }
+        // 201 Created and 204 No Content are the documented MOVE successes.
+        // 412 Precondition Failed (destination already exists with Overwrite: F)
+        // is mapped to httpError so the caller (BackupBlobStore.putBlobAtomically)
+        // can recognize "destination already converged" and treat it as success.
+        try Self.checkHTTPStatus(httpResponse.statusCode, url: request.url!)
+    }
+
+    func existsWithSize(at path: String) async throws -> Int64? {
+        let request = buildPROPFINDExistsRequest(path: path)
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw WebDAVError.connectionFailed("Invalid response")
+        }
+        // 404 → resource doesn't exist; this is the cheap "is there a blob"
+        // signal the materializer needs and is NOT an error condition.
+        if httpResponse.statusCode == 404 {
+            return nil
+        }
+        try Self.checkHTTPStatus(httpResponse.statusCode, url: request.url!)
+        let entries = try Self.parsePROPFINDResponse(data)
+        // Depth: 0 should return exactly one response (the resource itself).
+        // If the server returns multiple anyway (some implementations include
+        // children even at Depth: 0), the first non-directory entry is ours.
+        if let first = entries.first(where: { !$0.isDirectory }) {
+            return first.contentLength
+        }
+        // Resource exists but isn't a file (could be a collection) — treat
+        // as not-a-blob, return nil. Caller can decide to upload anyway.
+        return nil
     }
 }
 

--- a/vreaderTests/Services/Backup/WebDAVClientTests.swift
+++ b/vreaderTests/Services/Backup/WebDAVClientTests.swift
@@ -244,6 +244,51 @@ struct WebDAVClientTests {
         #expect(request.value(forHTTPHeaderField: "Authorization") != nil)
     }
 
+    // MARK: - MOVE + PROPFIND-exists (feature #46 WI-3)
+
+    @Test func buildMOVERequest_hasCorrectMethodAndDestination() {
+        let client = makeClient()
+        let request = client.buildMOVERequest(
+            fromPath: "VReader/uploads/tmp/abc.part",
+            toPath: "VReader/books/epub/sha_1024.epub"
+        )
+        #expect(request.httpMethod == "MOVE")
+        #expect(request.value(forHTTPHeaderField: "Authorization") != nil)
+        let dest = request.value(forHTTPHeaderField: "Destination") ?? ""
+        // Destination is an absolute URL on the same server (RFC 4918 §10.3).
+        #expect(dest == "https://dav.example.com/dav/VReader/books/epub/sha_1024.epub")
+        // Default Overwrite: F so a pre-existing destination is preserved
+        // (content-addressing means identical bytes already converged).
+        #expect(request.value(forHTTPHeaderField: "Overwrite") == "F")
+    }
+
+    @Test func buildMOVERequest_overwriteTrue_setsOverwriteHeader() {
+        let client = makeClient()
+        let request = client.buildMOVERequest(
+            fromPath: "from",
+            toPath: "to",
+            overwrite: true
+        )
+        #expect(request.value(forHTTPHeaderField: "Overwrite") == "T")
+    }
+
+    @Test func buildPROPFINDExistsRequest_usesDepthZero() {
+        // Depth: 0 distinguishes "tell me about THIS resource" from the
+        // existing buildPROPFINDRequest which uses Depth: 1 to enumerate
+        // children. Used by `existsWithSize` to cheaply check a single blob.
+        let client = makeClient()
+        let request = client.buildPROPFINDExistsRequest(
+            path: "VReader/books/epub/sha_1024.epub"
+        )
+        #expect(request.httpMethod == "PROPFIND")
+        #expect(request.value(forHTTPHeaderField: "Depth") == "0")
+        #expect(request.value(forHTTPHeaderField: "Authorization") != nil)
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/xml")
+        // Body asks for getcontentlength + getlastmodified + resourcetype.
+        let body = request.httpBody.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+        #expect(body.contains("<D:getcontentlength/>"))
+    }
+
     // MARK: - HTTP Status Handling
 
     @Test func checkStatus_200_succeeds() throws {

--- a/vreaderTests/Services/Backup/WebDAVProviderTests.swift
+++ b/vreaderTests/Services/Backup/WebDAVProviderTests.swift
@@ -75,6 +75,30 @@ final class MockWebDAVTransport: WebDAVTransport, @unchecked Sendable {
         if simulateAuthFailure { throw WebDAVError.authenticationFailed }
         if simulateConnectionFailure { throw WebDAVError.connectionFailed("mock") }
     }
+
+    // MARK: Feature #46 (WI-3) — atomic blob publication primitives
+
+    func move(fromPath: String, toPath: String) async throws {
+        methodCalls.append(("MOVE", "\(fromPath) -> \(toPath)"))
+        if simulateAuthFailure { throw WebDAVError.authenticationFailed }
+        if simulateConnectionFailure { throw WebDAVError.connectionFailed("mock") }
+        guard let data = files.removeValue(forKey: fromPath) else {
+            throw WebDAVError.notFound(fromPath)
+        }
+        // Overwrite: F semantics — fail if destination already exists.
+        guard files[toPath] == nil else {
+            throw WebDAVError.httpError(412)
+        }
+        files[toPath] = data
+    }
+
+    func existsWithSize(at path: String) async throws -> Int64? {
+        methodCalls.append(("PROPFIND-exists", path))
+        if simulateAuthFailure { throw WebDAVError.authenticationFailed }
+        if simulateConnectionFailure { throw WebDAVError.connectionFailed("mock") }
+        guard let data = files[path] else { return nil }
+        return Int64(data.count)
+    }
 }
 
 // MARK: - Mock Data Collector


### PR DESCRIPTION
## Summary

Refs #144. Two new transport primitives required by feature #46's atomic-blob publication pattern:

- \`move(fromPath:toPath:)\` — RFC 4918 §9.9 MOVE with \`Destination\` header, default \`Overwrite: F\`.
- \`existsWithSize(at:)\` — \`PROPFIND Depth: 0\`. Returns byte count or nil if 404.

## Why

Per the Codex audit on the parent plan: HEAD is unreliable across WebDAV servers; PROPFIND is the portable existence check. \`Overwrite: F\` is right because content-addressing means identical bytes already converged at the destination — 412 from a pre-existing destination maps to success at the materializer layer.

## Tests

3 new request-builder tests + \`MockWebDAVTransport\` conformance update. All 62 tests across \`WebDAVClientTests\` + \`WebDAVProviderTests\` pass.

## Workflow gates

- Gates 1+2 covered by parent plan.
- Gate 3 (TDD): RED → GREEN at request-builder level (matches existing test style; URLSession mocking would be a separate WI).
- Gate 4 (Impl audit): trivial — symmetric with existing PROPFIND builder, MOVE is a single new request shape. Skipped per audit-count tier "small".
- Gate 5 (Verification): N/A foundational; consumed by WI-4 + WI-7.

## Type of Change

- [x] Foundational implementation (consumed by WI-4 BackupBlobStore + WI-7 WebDAVProvider integration)