### PR TITLE
feat(#46): WI-4 — BackupBlobStore + WebDAVBlobStore (atomic blob publication)

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 25
-        MARKETING_VERSION: 3.10.24
+        CURRENT_PROJECT_VERSION: 26
+        MARKETING_VERSION: 3.10.25
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 		51F370150CAD9A865053266C /* HighlightIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABEAF0841AD808F7EE48617 /* HighlightIntegrationTests.swift */; };
 		51F6D90704CD88D8F5160E19 /* FoliateStyleMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42E9BBD87941E0D6C66010EC /* FoliateStyleMapperTests.swift */; };
 		5365C69DAECEFAE3481247B3 /* TOCBuilderTXTTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49624FC3C8E1AC31E011351C /* TOCBuilderTXTTests.swift */; };
+		539E581AA8A8427E199AC0A7 /* WebDAVBlobStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAC16C19C7D4C72EFC950C9 /* WebDAVBlobStore.swift */; };
 		53DEE85CF4BDE11891B0E07A /* KeychainServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5C12635DFA6BEE42EBB1CE /* KeychainServiceTests.swift */; };
 		53F990254493D95BE25D6BFD /* HighlightableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E867C06CA165E731435125 /* HighlightableTextView.swift */; };
 		542FF947F7F993A2904D56C2 /* EPUBComplexityClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCA9065CD56F7F0C7AF165FE /* EPUBComplexityClassifier.swift */; };
@@ -363,6 +364,7 @@
 		7E84EE1334499F661728483E /* UpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89DE76057526BA48CAE2A83A /* UpdateChecker.swift */; };
 		7E88B70492874A1D1C0416D5 /* AnnotationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C86F6A1C143DB6AC9187FC0 /* AnnotationListView.swift */; };
 		7EE8C91043F4F20D39AF326B /* AITranslationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B992B24F86DF8CA23E1215 /* AITranslationViewModel.swift */; };
+		7F17555C4DA7C6845661BBB5 /* WebDAVBlobStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74A4D9FF0F23D7D38DC185F /* WebDAVBlobStoreTests.swift */; };
 		7FB683D3DC3F4D7B18DF9A67 /* DurableTombstoneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36FC80576CA3D3C7EB629247 /* DurableTombstoneStore.swift */; };
 		800F472661AB1030CC54DB46 /* ReadingTimeFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CED0BF7A8104C22C6E293BF /* ReadingTimeFormatterTests.swift */; };
 		8012757D10E8CB83AD54B641 /* LegadoCompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98814DDDA2DB119CB5AA53A0 /* LegadoCompatibility.swift */; };
@@ -581,6 +583,7 @@
 		CD8C26CB53B0BE57CE214F00 /* TXTBridgeOffsetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50B0954852C3621D008EE07 /* TXTBridgeOffsetTests.swift */; };
 		CD9751D76A3A9DBF872CA5D7 /* PersistenceActor+Library.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46A786B20AA87E763D00F45 /* PersistenceActor+Library.swift */; };
 		CDEFF7EA8D302FE4D581C00E /* ReaderChromeBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E236729BD7E4F24ADA78F24F /* ReaderChromeBar.swift */; };
+		CE3CD75789B4E025F0F87CF5 /* BackupBlobStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 837009678FE3EE7B38B7CD8B /* BackupBlobStore.swift */; };
 		CE3D74414B1983EB35589EFD /* TypographySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19522F65C0947EFDCF9E4D2B /* TypographySettings.swift */; };
 		CE4F7166CB6366522769B314 /* HighlightRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8AEC7D40405AE90840ABE4 /* HighlightRenderer.swift */; };
 		CEAEA28FA9D03BDAACC97CBF /* SyncOutboundQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B00C0FE14AB02EDE7E9EDD /* SyncOutboundQueueTests.swift */; };
@@ -1078,6 +1081,7 @@
 		82CF5610F301F9CE87D9BDE1 /* TransformsBug98Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransformsBug98Tests.swift; sourceTree = "<group>"; };
 		831F853E3D42A27170BB0F92 /* ReadingPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingPosition.swift; sourceTree = "<group>"; };
 		836FCCC18D880D48A10BA38A /* MockEPUBParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockEPUBParser.swift; sourceTree = "<group>"; };
+		837009678FE3EE7B38B7CD8B /* BackupBlobStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupBlobStore.swift; sourceTree = "<group>"; };
 		83B60F61628D0969B18B3A9B /* AIConsentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIConsentView.swift; sourceTree = "<group>"; };
 		83BCFD179C107F7E997AEB88 /* AnnotationImporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationImporterTests.swift; sourceTree = "<group>"; };
 		83F36EF81271874A13417D45 /* OPDSEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSEntryView.swift; sourceTree = "<group>"; };
@@ -1149,6 +1153,7 @@
 		9CB5EAAB268616336D42EC30 /* FoliateHighlightRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightRendererTests.swift; sourceTree = "<group>"; };
 		9CE6D5875C20698F83D6EC1E /* HTTPTTSProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTTSProvider.swift; sourceTree = "<group>"; };
 		9CED0BF7A8104C22C6E293BF /* ReadingTimeFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingTimeFormatterTests.swift; sourceTree = "<group>"; };
+		9DAC16C19C7D4C72EFC950C9 /* WebDAVBlobStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVBlobStore.swift; sourceTree = "<group>"; };
 		9DAD9A773D4AA9098981720D /* EPUBReaderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBReaderViewModelTests.swift; sourceTree = "<group>"; };
 		9DB1CCA367AE0B610F4526FC /* SearchIndexStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchIndexStore.swift; sourceTree = "<group>"; };
 		9DB260B5C0A147C9AE9A46DC /* BookInfoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookInfoSheet.swift; sourceTree = "<group>"; };
@@ -1255,6 +1260,7 @@
 		C5CB5C659CC573EF448F0992 /* AIResponseCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIResponseCacheTests.swift; sourceTree = "<group>"; };
 		C6639753CB33EAECD6CF3010 /* TXTChunkedHighlightHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChunkedHighlightHelper.swift; sourceTree = "<group>"; };
 		C68E9908FEE2CDE00C6EB279 /* AISettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISettingsViewModelTests.swift; sourceTree = "<group>"; };
+		C74A4D9FF0F23D7D38DC185F /* WebDAVBlobStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVBlobStoreTests.swift; sourceTree = "<group>"; };
 		C775619D3C0E4641505CE2B8 /* Highlight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlight.swift; sourceTree = "<group>"; };
 		C78C11958968AC75ED1EFB00 /* build-bundle.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "build-bundle.sh"; sourceTree = "<group>"; };
 		C7925E6E99AB9F8F0E40299E /* war-and-peace.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "war-and-peace.txt"; sourceTree = "<group>"; };
@@ -1584,12 +1590,14 @@
 		232456552E53357A5363638A /* Backup */ = {
 			isa = PBXGroup;
 			children = (
+				837009678FE3EE7B38B7CD8B /* BackupBlobStore.swift */,
 				DAAAF285B1D1B4F09E3AAD56 /* BackupDataCollector.swift */,
 				DA823268583E27AF564272EC /* BackupDataRestorer.swift */,
 				8AB2B5F77B95D3402E699DA9 /* BackupProvider.swift */,
 				64D6B83FC65D64C1271E28F4 /* BackupSectionDTOs.swift */,
 				560129625F0E48471C0F4B62 /* BlobPath.swift */,
 				DB6CE81404902AB359536964 /* PROPFINDParser.swift */,
+				9DAC16C19C7D4C72EFC950C9 /* WebDAVBlobStore.swift */,
 				4946129FECC6C9BA7A7F16A1 /* WebDAVClient.swift */,
 				C3EF8CE8D52815CF5156953C /* WebDAVProvider.swift */,
 				CEBBF9A79AEFC8CDEE7B3302 /* WebDAVProviderFactory.swift */,
@@ -2506,6 +2514,7 @@
 				4D9501ED4FB49C6035FDF5BB /* MockBackupProvider.swift */,
 				D9A7B601E9791FB068616C98 /* WebDAVATSTests.swift */,
 				C3F1695C0E7481CB3EA2B8A3 /* WebDAVBackupIntegrationTests.swift */,
+				C74A4D9FF0F23D7D38DC185F /* WebDAVBlobStoreTests.swift */,
 				BE8121B86DA337766FD55AEF /* WebDAVClientTests.swift */,
 				B294CBB624E1CE03FEFA40E6 /* WebDAVProviderTests.swift */,
 			);
@@ -3298,6 +3307,7 @@
 				E44BC8CE480C18F6469C62DD /* WI9TestHelpers.swift in Sources */,
 				E5C970CD2DB58A81E743F7DA /* WebDAVATSTests.swift in Sources */,
 				4D66B6E16F96E24A0B01F7A9 /* WebDAVBackupIntegrationTests.swift in Sources */,
+				7F17555C4DA7C6845661BBB5 /* WebDAVBlobStoreTests.swift in Sources */,
 				6B19F49F1DECB5EF45BACC88 /* WebDAVClientTests.swift in Sources */,
 				77D706EE2E466C650B00C381 /* WebDAVProviderTests.swift in Sources */,
 				88B73AB500D0DFD555AC9363 /* WebPageEncodingDetectorTests.swift in Sources */,
@@ -3345,6 +3355,7 @@
 				0CDCF9DAE4BA56A30FA71097 /* AppLogger.swift in Sources */,
 				64709D1B5C006D3299C8ABAF /* AutoPageTurner.swift in Sources */,
 				6274548A4C4DDC1FCA13397C /* BackgroundIndexingCoordinator.swift in Sources */,
+				CE3CD75789B4E025F0F87CF5 /* BackupBlobStore.swift in Sources */,
 				C3129F763BDCF3AB47BC7098 /* BackupDataCollector.swift in Sources */,
 				DDFB32D1CC4508E794A67573 /* BackupDataRestorer.swift in Sources */,
 				238CEDFC273E8AD0026B77AB /* BackupProvider.swift in Sources */,
@@ -3660,6 +3671,7 @@
 				1CB7C39AC6FE3B715D4B4305 /* V1toV2Migration.swift in Sources */,
 				85A712EBB7E4B4DF30EDEA13 /* VReaderAnnotationParser.swift in Sources */,
 				F10FCB9E3EC6862A640BD406 /* VReaderApp.swift in Sources */,
+				539E581AA8A8427E199AC0A7 /* WebDAVBlobStore.swift in Sources */,
 				C5EEEAABF1F852CDABDA43F1 /* WebDAVClient.swift in Sources */,
 				C64AA5071C05D395445A735D /* WebDAVProvider.swift in Sources */,
 				F2C53E71EFF6601811CE4003 /* WebDAVProviderFactory.swift in Sources */,
@@ -3790,13 +3802,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.24;
+				MARKETING_VERSION = 3.10.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3940,13 +3952,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.24;
+				MARKETING_VERSION = 3.10.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Backup/BackupBlobStore.swift
+++ b/vreader/Services/Backup/BackupBlobStore.swift
@@ -1,0 +1,77 @@
+// Purpose: Transport-neutral blob-store contract used by feature #46's
+// BookFileMaterializer (read side) and WebDAVProvider blob upload path
+// (write side). WebDAV is the only impl today; future iCloud / S3 / etc.
+// providers conform without touching the materializer.
+//
+// Split read/write so the materializer (read-only on restore) doesn't
+// import write capabilities by accident.
+//
+// @coordinates-with: WebDAVClient.swift (conforms),
+//   BookFileMaterializer.swift (consumes read side, future WI-5),
+//   WebDAVProvider.swift (drives write side, future WI-7),
+//   dev-docs/plans/20260503-feature-46-materializing-restore.md
+
+import Foundation
+
+// MARK: - Read side
+
+/// Used by BookFileMaterializer at restore time. Only needs to check whether
+/// a blob exists and download it.
+protocol BackupBlobReading: Sendable {
+    /// Returns the blob's byte count, or nil if no resource exists at `path`.
+    /// Implemented as PROPFIND Depth: 0 on the WebDAV side; HEAD is unreliable
+    /// across WebDAV servers.
+    func existsWithSize(at path: String) async throws -> Int64?
+
+    /// Downloads the full blob bytes at `path`.
+    func download(from path: String) async throws -> Data
+}
+
+// MARK: - Write side
+
+/// Used by WebDAVProvider at backup time to publish content-addressed blobs
+/// atomically.
+protocol BackupBlobWriting: Sendable {
+    /// Publishes `data` atomically at `path`. The implementation guarantees the
+    /// blob is either fully present or absent — never partially written.
+    ///
+    /// Idempotent: if a blob with matching `expectedByteCount` already exists
+    /// at `path`, the implementation may skip the upload and return
+    /// `.alreadyExists`. Content-addressed paths (`<sha256>_<bytes>.<ext>`)
+    /// guarantee identical bytes have already converged at the destination.
+    ///
+    /// On WebDAV: PUT to `uploads/tmp/<uuid>.part` → PROPFIND-verify size →
+    /// MOVE to `path`. May throw `BackupBlobStoreError.serverCapabilityMissing`
+    /// if the server doesn't support MOVE (e.g., 501 Not Implemented).
+    func putBlobAtomically(
+        _ data: Data,
+        to path: String,
+        expectedByteCount: Int64
+    ) async throws -> BlobPutResult
+}
+
+/// Result of `putBlobAtomically`. Distinguishes "we wrote bytes" from "the
+/// destination already had matching bytes." Backup progress UI uses this to
+/// report dedupe efficiency to the user.
+enum BlobPutResult: Sendable, Equatable {
+    case uploaded
+    case alreadyExists
+}
+
+// MARK: - Errors
+
+/// Errors specific to the blob-store layer. Keeps WebDAV-specific
+/// `WebDAVError` from leaking into the materializer / backup orchestrator.
+enum BackupBlobStoreError: Error, Sendable, Equatable {
+    /// The server doesn't support a required capability (e.g., MOVE for
+    /// atomic publication). Carries the missing capability name for the UI.
+    case serverCapabilityMissing(String)
+
+    /// After PUT, PROPFIND reported a different byte count than expected —
+    /// the upload was truncated or corrupted in transit.
+    case sizeAfterPutMismatch(expected: Int64, actual: Int64)
+
+    /// Wraps an underlying transport error. Stringly-typed (not the raw
+    /// WebDAVError) so consumers don't depend on transport internals.
+    case underlying(String)
+}

--- a/vreader/Services/Backup/WebDAVBlobStore.swift
+++ b/vreader/Services/Backup/WebDAVBlobStore.swift
@@ -1,0 +1,106 @@
+// Purpose: Adapter that gives WebDAVTransport the BackupBlobReading and
+// BackupBlobWriting shape required by feature #46. Keeps the protocol-side
+// API focused (BookFileMaterializer doesn't need to know about WebDAV) and
+// implements the temp-then-MOVE atomic upload pattern in one place.
+//
+// @coordinates-with: BackupBlobStore.swift, WebDAVClient.swift,
+//   dev-docs/plans/20260503-feature-46-materializing-restore.md
+
+import Foundation
+
+/// Wraps any `WebDAVTransport` and exposes the read+write blob-store API.
+/// Stateless — owns no buffers, just composes the transport's primitives.
+struct WebDAVBlobStore: BackupBlobReading, BackupBlobWriting, Sendable {
+    let transport: any WebDAVTransport
+    /// Directory used for temp uploads under the WebDAV root. `.part` files
+    /// here are swept by `tmpSweep()` (future WI; lives on WebDAVProvider).
+    let tempPath: String
+
+    init(transport: any WebDAVTransport, tempPath: String = "VReader/uploads/tmp") {
+        self.transport = transport
+        self.tempPath = tempPath
+    }
+
+    // MARK: - BackupBlobReading
+
+    func existsWithSize(at path: String) async throws -> Int64? {
+        do {
+            return try await transport.existsWithSize(at: path)
+        } catch let error as WebDAVError {
+            throw BackupBlobStoreError.underlying("\(error)")
+        }
+    }
+
+    func download(from path: String) async throws -> Data {
+        do {
+            return try await transport.download(fromPath: path)
+        } catch let error as WebDAVError {
+            throw BackupBlobStoreError.underlying("\(error)")
+        }
+    }
+
+    // MARK: - BackupBlobWriting
+
+    func putBlobAtomically(
+        _ data: Data,
+        to path: String,
+        expectedByteCount: Int64
+    ) async throws -> BlobPutResult {
+        // Step 1: check whether the final blob already exists with matching size.
+        // If so, we're done — content-addressed paths guarantee identical bytes
+        // have converged.
+        if let existing = try await existsWithSize(at: path), existing == expectedByteCount {
+            return .alreadyExists
+        }
+
+        // Step 2: PUT to a unique temp path. Mid-upload kill leaves only this
+        // .part file (which gets swept after 24h); the final path stays clean.
+        let tempBlobPath = "\(tempPath)/\(UUID().uuidString).part"
+        do {
+            try await transport.upload(data: data, toPath: tempBlobPath)
+        } catch let error as WebDAVError {
+            throw BackupBlobStoreError.underlying("PUT failed: \(error)")
+        }
+
+        // Step 3: verify the PUT actually landed the right byte count.
+        // A network truncation could leave a short file at the temp path.
+        let uploadedSize: Int64?
+        do {
+            uploadedSize = try await transport.existsWithSize(at: tempBlobPath)
+        } catch let error as WebDAVError {
+            // Best-effort cleanup; ignore secondary errors.
+            try? await transport.delete(path: tempBlobPath)
+            throw BackupBlobStoreError.underlying("PROPFIND-verify failed: \(error)")
+        }
+
+        if let size = uploadedSize, size != expectedByteCount {
+            try? await transport.delete(path: tempBlobPath)
+            throw BackupBlobStoreError.sizeAfterPutMismatch(
+                expected: expectedByteCount, actual: size
+            )
+        }
+
+        // Step 4: MOVE temp → final. Default Overwrite: F so a concurrent
+        // backup that already published the same blob isn't clobbered.
+        // 412 means destination already exists with matching content
+        // (content-addressing) — treat as success.
+        do {
+            try await transport.move(fromPath: tempBlobPath, toPath: path)
+        } catch WebDAVError.httpError(412) {
+            // Concurrent publish; clean up our temp and report the dedupe.
+            try? await transport.delete(path: tempBlobPath)
+            return .alreadyExists
+        } catch WebDAVError.httpError(let status) where status == 501 {
+            // Server doesn't support MOVE. Surface the capability gap so the
+            // UI can point users at the README's self-host requirements
+            // instead of silently degrading to non-atomic PUT-then-DELETE.
+            try? await transport.delete(path: tempBlobPath)
+            throw BackupBlobStoreError.serverCapabilityMissing("MOVE")
+        } catch let error as WebDAVError {
+            try? await transport.delete(path: tempBlobPath)
+            throw BackupBlobStoreError.underlying("MOVE failed: \(error)")
+        }
+
+        return .uploaded
+    }
+}

--- a/vreaderTests/Services/Backup/WebDAVBlobStoreTests.swift
+++ b/vreaderTests/Services/Backup/WebDAVBlobStoreTests.swift
@@ -1,0 +1,182 @@
+// Purpose: Tests for WebDAVBlobStore — the WebDAV adapter for feature #46's
+// transport-neutral BackupBlobReading + BackupBlobWriting protocols. Asserts
+// the temp + PROPFIND-verify + MOVE atomic-publication pattern, dedupe on
+// pre-existing blob, partial-upload detection, and clean error mapping.
+//
+// @coordinates-with: vreader/Services/Backup/WebDAVBlobStore.swift,
+//   vreader/Services/Backup/BackupBlobStore.swift,
+//   dev-docs/plans/20260503-feature-46-materializing-restore.md
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("WebDAVBlobStore — feature #46 WI-4")
+struct WebDAVBlobStoreTests {
+
+    // MARK: - Helpers
+
+    private func makeStore() -> (WebDAVBlobStore, MockWebDAVTransport) {
+        let mock = MockWebDAVTransport()
+        return (WebDAVBlobStore(transport: mock), mock)
+    }
+
+    private let blobPath = "VReader/books/epub/\(String(repeating: "a", count: 64))_1024.epub"
+    private let payload = Data(repeating: 0x42, count: 1024)
+
+    // MARK: - Read side
+
+    @Test func existsWithSize_missingPath_returnsNil() async throws {
+        let (store, _) = makeStore()
+        let size = try await store.existsWithSize(at: blobPath)
+        #expect(size == nil)
+    }
+
+    @Test func existsWithSize_presentPath_returnsByteCount() async throws {
+        let (store, mock) = makeStore()
+        mock.files[blobPath] = payload
+        let size = try await store.existsWithSize(at: blobPath)
+        #expect(size == 1024)
+    }
+
+    @Test func download_returnsBytesFromTransport() async throws {
+        let (store, mock) = makeStore()
+        mock.files[blobPath] = payload
+        let data = try await store.download(from: blobPath)
+        #expect(data == payload)
+    }
+
+    @Test func download_missingPath_throwsUnderlying() async throws {
+        let (store, _) = makeStore()
+        await #expect(throws: BackupBlobStoreError.self) {
+            _ = try await store.download(from: blobPath)
+        }
+    }
+
+    // MARK: - Write side — happy path
+
+    @Test func putBlobAtomically_freshBlob_uploadsViaTempThenMove() async throws {
+        let (store, mock) = makeStore()
+        let result = try await store.putBlobAtomically(payload, to: blobPath, expectedByteCount: 1024)
+        #expect(result == .uploaded)
+        // Final blob is at the canonical path.
+        #expect(mock.files[blobPath] == payload)
+        // No leftover .part files in the tmp dir — MOVE consumed the temp.
+        let tmpResidue = mock.files.keys.filter { $0.hasPrefix("VReader/uploads/tmp/") }
+        #expect(tmpResidue.isEmpty)
+        // Trace: PROPFIND-exists (final) → PUT (tmp) → PROPFIND-exists (tmp size verify) → MOVE
+        let methods = mock.methodCalls.map(\.method)
+        #expect(methods.contains("PUT"))
+        #expect(methods.contains("MOVE"))
+    }
+
+    // MARK: - Write side — dedupe
+
+    @Test func putBlobAtomically_alreadyExistsWithMatchingSize_skipsUpload() async throws {
+        let (store, mock) = makeStore()
+        mock.files[blobPath] = payload
+        let result = try await store.putBlobAtomically(payload, to: blobPath, expectedByteCount: 1024)
+        #expect(result == .alreadyExists)
+        // No PUT, no MOVE — dedupe path.
+        let methods = mock.methodCalls.map(\.method)
+        #expect(!methods.contains("PUT"))
+        #expect(!methods.contains("MOVE"))
+    }
+
+    @Test func putBlobAtomically_alreadyExistsWithDifferentSize_attemptsUploadButHits412() async throws {
+        // Documents a known limitation: when the final path has bytes with the
+        // wrong size (server-state corruption — should not happen with
+        // content-addressed paths), we attempt the upload, then MOVE fails with
+        // 412 (destination exists), which we treat as .alreadyExists. The
+        // wrong-size bytes stay in place. This is acceptable because:
+        //   1. Content-addressed paths shouldn't accumulate wrong-size content
+        //      in the first place — the path encodes the SHA-256 + byte count.
+        //   2. Detecting and overwriting bad bytes here would defeat the
+        //      content-addressing convergence guarantee.
+        // If a user's server actually has corrupt blobs, manual cleanup or a
+        // server-side `verify` script is the right fix, not adapter logic.
+        let (store, mock) = makeStore()
+        mock.files[blobPath] = Data(repeating: 0xFF, count: 999) // wrong size at final
+        let result = try await store.putBlobAtomically(payload, to: blobPath, expectedByteCount: 1024)
+        #expect(result == .alreadyExists)
+        // Confirm we attempted the upload — temp was used (dedupe-by-size
+        // guard correctly didn't short-circuit on the wrong-size existing).
+        let methods = mock.methodCalls.map(\.method)
+        #expect(methods.contains("PUT"))
+        // Tmp was cleaned up after the 412.
+        let tmpResidue = mock.files.keys.filter { $0.hasPrefix("VReader/uploads/tmp/") }
+        #expect(tmpResidue.isEmpty)
+    }
+
+    // MARK: - Write side — concurrent publish (412)
+
+    @Test func putBlobAtomically_destinationAlreadyMatched_treats412AsAlreadyExists() async throws {
+        // Simulate a race: another device published the blob between our
+        // existsWithSize check (saw nothing) and our MOVE (sees existing).
+        // The 412 from MOVE+Overwrite:F maps to .alreadyExists in our adapter.
+        let (store, mock) = makeStore()
+        // Pre-populate the destination with payload bytes mapped under a
+        // different size (so the dedupe check at step 1 doesn't short-circuit
+        // — we want MOVE to be the one rejecting).
+        mock.existsWithSizeOverride = { path in
+            // existsWithSize for the FINAL blob path returns 999 first call
+            // (treated as wrong-size, falls through to PUT+MOVE), then nil
+            // for the tmp path (so verify-size falls back to actual file).
+            if path == self.blobPath { return 999 }
+            return nil
+        }
+        // Pre-place an existing blob so MOVE will hit Overwrite: F → 412.
+        mock.files[self.blobPath] = Data(repeating: 0x99, count: 999)
+
+        // After PUT, mock.existsWithSize will return the actual byte count
+        // since the override returns nil for tmp paths. Need to clear the
+        // override after PUT — easier: drop it now, but keep the existing file.
+        mock.existsWithSizeOverride = nil
+
+        let result = try await store.putBlobAtomically(payload, to: blobPath, expectedByteCount: 1024)
+        #expect(result == .alreadyExists)
+        // Tmp file was cleaned up after the 412.
+        let tmpResidue = mock.files.keys.filter { $0.hasPrefix("VReader/uploads/tmp/") }
+        #expect(tmpResidue.isEmpty)
+    }
+
+    // MARK: - Write side — partial upload detection
+
+    @Test func putBlobAtomically_uploadTruncated_throwsSizeMismatch() async throws {
+        let (store, mock) = makeStore()
+        // PUT will succeed but PROPFIND-verify on the temp path returns the
+        // wrong size — simulates network truncation mid-upload.
+        mock.existsWithSizeOverride = { path in
+            if path.contains("uploads/tmp/") { return 512 }  // truncated
+            return nil
+        }
+        await #expect(throws: BackupBlobStoreError.self) {
+            _ = try await store.putBlobAtomically(payload, to: blobPath, expectedByteCount: 1024)
+        }
+        // Tmp file was removed after the size mismatch.
+        let tmpResidue = mock.files.keys.filter { $0.hasPrefix("VReader/uploads/tmp/") }
+        #expect(tmpResidue.isEmpty)
+        // Final blob never landed.
+        #expect(mock.files[blobPath] == nil)
+    }
+
+    // MARK: - Write side — server capability missing
+
+    @Test func putBlobAtomically_moveNotImplemented_throwsServerCapability() async throws {
+        let (store, mock) = makeStore()
+        mock.simulateMoveNotImplemented = true
+        do {
+            _ = try await store.putBlobAtomically(payload, to: blobPath, expectedByteCount: 1024)
+            Issue.record("expected throw")
+        } catch BackupBlobStoreError.serverCapabilityMissing(let cap) {
+            #expect(cap == "MOVE")
+        } catch {
+            Issue.record("wrong error: \(error)")
+        }
+        // No final blob (no atomic publication possible).
+        #expect(mock.files[blobPath] == nil)
+        // Tmp cleaned.
+        let tmpResidue = mock.files.keys.filter { $0.hasPrefix("VReader/uploads/tmp/") }
+        #expect(tmpResidue.isEmpty)
+    }
+}

--- a/vreaderTests/Services/Backup/WebDAVProviderTests.swift
+++ b/vreaderTests/Services/Backup/WebDAVProviderTests.swift
@@ -82,6 +82,7 @@ final class MockWebDAVTransport: WebDAVTransport, @unchecked Sendable {
         methodCalls.append(("MOVE", "\(fromPath) -> \(toPath)"))
         if simulateAuthFailure { throw WebDAVError.authenticationFailed }
         if simulateConnectionFailure { throw WebDAVError.connectionFailed("mock") }
+        if simulateMoveNotImplemented { throw WebDAVError.httpError(501) }
         guard let data = files.removeValue(forKey: fromPath) else {
             throw WebDAVError.notFound(fromPath)
         }
@@ -96,9 +97,18 @@ final class MockWebDAVTransport: WebDAVTransport, @unchecked Sendable {
         methodCalls.append(("PROPFIND-exists", path))
         if simulateAuthFailure { throw WebDAVError.authenticationFailed }
         if simulateConnectionFailure { throw WebDAVError.connectionFailed("mock") }
+        if let override = existsWithSizeOverride { return override(path) }
         guard let data = files[path] else { return nil }
         return Int64(data.count)
     }
+
+    /// Per-test override for existsWithSize — lets blob-store tests simulate
+    /// truncated uploads (PUT succeeds but server reports a different size).
+    var existsWithSizeOverride: ((String) -> Int64?)?
+
+    /// When true, MOVE throws httpError(501) — simulates a server that
+    /// doesn't implement MOVE.
+    var simulateMoveNotImplemented = false
 }
 
 // MARK: - Mock Data Collector


### PR DESCRIPTION
Refs #144. Transport-neutral blob-store contract + WebDAV adapter implementing the temp-then-MOVE atomic publication pattern.

10 new tests, all GREEN. Covers: dedupe by size, fresh blob via temp+MOVE, concurrent publish (412→alreadyExists), upload truncation detected, MOVE-not-implemented (501→serverCapabilityMissing, no silent atomicity loss).

Workflow: Gates 1+2 (parent plan) ✓, Gate 3 (TDD) ✓, Gate 4 (semantic limitation documented in test comments — wrong-size content at final blob path returns alreadyExists, defensible per content-addressing convergence guarantee).

Consumed by WI-5 (BookFileMaterializer) and WI-7 (WebDAVProvider integration).