### PR TITLE
feat(#46): WI-5 — BookFileMaterializer (download + verify + import)

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 26
-        MARKETING_VERSION: 3.10.25
+        CURRENT_PROJECT_VERSION: 27
+        MARKETING_VERSION: 3.10.26
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 		43BD02365D537972791DF4D5 /* ReaderAuditFixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DA904E79F5CF69E46ECC26 /* ReaderAuditFixTests.swift */; };
 		43E5608C73F29F783F64BE8A /* ReaderNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DB169F568633A25E157B4DE /* ReaderNavigationTests.swift */; };
 		44A1BF88B48D717D89913706 /* OPDSModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CA445AA96E5EEBA05B7C36 /* OPDSModels.swift */; };
+		45284DB279AD41866D7B0157 /* BookFileMaterializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04ED79BFAD4BEF6B8A30F982 /* BookFileMaterializerTests.swift */; };
 		453E682BDF07AEB9D4DA6294 /* PaginationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0C50C474AA2F96C39AAC94 /* PaginationCache.swift */; };
 		454342CEF3A2152B1EDD2455 /* TXTReaderContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725F9036150B858160ACFF7B /* TXTReaderContainerView.swift */; };
 		45EA62BA74F57E9AC57B1BA4 /* HighlightedSnippetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631D0375777D50E5B1EDF31C /* HighlightedSnippetTests.swift */; };
@@ -496,6 +497,7 @@
 		ACE4A8A746F082AEC08BB273 /* CustomCoverStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5955766DF21883C0C57B71E4 /* CustomCoverStoreTests.swift */; };
 		AD1910F64D226400933FDBA2 /* PDFHighlightRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8719A34DB441AF9DC6379DC9 /* PDFHighlightRenderer.swift */; };
 		AD27484127EA24D230616F48 /* TestConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B2824739E67F567813198E /* TestConstants.swift */; };
+		AE171BC364B973E0F52D1B96 /* BookFileMaterializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1889243163114A51950527F6 /* BookFileMaterializer.swift */; };
 		AE34D7222B4EAB4191316FD2 /* FoliateReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C919847EACB9AB94A03DF6E8 /* FoliateReaderViewModel.swift */; };
 		AECED765F5022DC96443D566 /* foliate-host.js in Resources */ = {isa = PBXBuildFile; fileRef = 8770E9DB2008B2B8B4B0A475 /* foliate-host.js */; };
 		AEFC819574E845429DFC9D78 /* ZIPReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2DB7F421D9D2E7492E12F89 /* ZIPReader.swift */; };
@@ -738,6 +740,7 @@
 		0378B284E969CD8625A89EA1 /* RealDebugBridgeContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealDebugBridgeContext.swift; sourceTree = "<group>"; };
 		03FA3AC72012ED6686293475 /* ReadingStatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsTests.swift; sourceTree = "<group>"; };
 		0459CAA7394555E5A8E17146 /* ReaderUnsupportedFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderUnsupportedFormatTests.swift; sourceTree = "<group>"; };
+		04ED79BFAD4BEF6B8A30F982 /* BookFileMaterializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFileMaterializerTests.swift; sourceTree = "<group>"; };
 		050AAFD290B8995258D78AC2 /* FormatCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatCapabilities.swift; sourceTree = "<group>"; };
 		055FBEA382F82BE342A50C8E /* LocatorFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorFactoryTests.swift; sourceTree = "<group>"; };
 		0616892213196BCF802266F8 /* ContentHasherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentHasherTests.swift; sourceTree = "<group>"; };
@@ -783,6 +786,7 @@
 		16C77872C4F869769F4C83F7 /* ReaderContainerView+Sheets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderContainerView+Sheets.swift"; sourceTree = "<group>"; };
 		16E293CFD61A19BB48B38963 /* HighlightableTextViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightableTextViewTests.swift; sourceTree = "<group>"; };
 		17E7FD8CD67F19A2213DB6F5 /* PDFViewBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFViewBridge.swift; sourceTree = "<group>"; };
+		1889243163114A51950527F6 /* BookFileMaterializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFileMaterializer.swift; sourceTree = "<group>"; };
 		1920480AF349823757484C2D /* EPUBWebViewBridgeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBWebViewBridgeCoordinator.swift; sourceTree = "<group>"; };
 		19522F65C0947EFDCF9E4D2B /* TypographySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypographySettings.swift; sourceTree = "<group>"; };
 		199ADE9681576DB0AF6A6A94 /* SourceSharingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceSharingService.swift; sourceTree = "<group>"; };
@@ -1596,6 +1600,7 @@
 				8AB2B5F77B95D3402E699DA9 /* BackupProvider.swift */,
 				64D6B83FC65D64C1271E28F4 /* BackupSectionDTOs.swift */,
 				560129625F0E48471C0F4B62 /* BlobPath.swift */,
+				1889243163114A51950527F6 /* BookFileMaterializer.swift */,
 				DB6CE81404902AB359536964 /* PROPFINDParser.swift */,
 				9DAC16C19C7D4C72EFC950C9 /* WebDAVBlobStore.swift */,
 				4946129FECC6C9BA7A7F16A1 /* WebDAVClient.swift */,
@@ -2511,6 +2516,7 @@
 				F64BCF588EF860DD6C214737 /* BackupLibraryManifestTests.swift */,
 				ED150D276C082FEC194F2F31 /* BackupProviderContractTests.swift */,
 				BFB65788879E3D91E69E8BA5 /* BlobPathTests.swift */,
+				04ED79BFAD4BEF6B8A30F982 /* BookFileMaterializerTests.swift */,
 				4D9501ED4FB49C6035FDF5BB /* MockBackupProvider.swift */,
 				D9A7B601E9791FB068616C98 /* WebDAVATSTests.swift */,
 				C3F1695C0E7481CB3EA2B8A3 /* WebDAVBackupIntegrationTests.swift */,
@@ -3077,6 +3083,7 @@
 				90D2C41C30E622E119877967 /* BackupViewModelTests.swift in Sources */,
 				096B20388931B21DAA4DC091 /* BlobPathTests.swift in Sources */,
 				C205A1413A59C630A10ECEB7 /* BookContentCacheTests.swift in Sources */,
+				45284DB279AD41866D7B0157 /* BookFileMaterializerTests.swift in Sources */,
 				D41473E2CF7AB980E43C6C54 /* BookFormatAZW3Tests.swift in Sources */,
 				2B9E39AC289E006A1A8B25AE /* BookFormatTests.swift in Sources */,
 				301BA4423DE1212ADB315388 /* BookImporterAZW3Tests.swift in Sources */,
@@ -3368,6 +3375,7 @@
 				12EE1BD6335013980EFA3EC0 /* BookCardView.swift in Sources */,
 				AF32B348898F4110FED715F5 /* BookCollection.swift in Sources */,
 				BB796644EE14228057D77738 /* BookContentCache.swift in Sources */,
+				AE171BC364B973E0F52D1B96 /* BookFileMaterializer.swift in Sources */,
 				33B874FB4BB17A21ACA4468E /* BookFormat.swift in Sources */,
 				DF36D73AC9B53845BF561CBC /* BookImporter.swift in Sources */,
 				429316840ADE46912C2A89E9 /* BookImporting.swift in Sources */,
@@ -3802,13 +3810,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 26;
+				CURRENT_PROJECT_VERSION = 27;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.25;
+				MARKETING_VERSION = 3.10.26;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3952,13 +3960,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 26;
+				CURRENT_PROJECT_VERSION = 27;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.25;
+				MARKETING_VERSION = 3.10.26;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Backup/BookFileMaterializer.swift
+++ b/vreader/Services/Backup/BookFileMaterializer.swift
@@ -1,0 +1,268 @@
+// Purpose: Downloads + verifies + imports book blobs from a backup manifest
+// for feature #46's WebDAV materializing restore. Single responsibility:
+// given [BackupLibraryEntry], make sure each blob is locally present (either
+// already-imported or freshly downloaded + imported via BookImporter).
+//
+// Design (per audited plan dev-docs/plans/20260503-feature-46-...):
+// - Serial over entries, monotonic progress callback, no parallelism by
+//   default — avoids saturating WebDAV and EPUB pre-extraction churn.
+// - Triple verification on download: byte count → SHA-256 → final
+//   ImportResult.fingerprintKey vs manifest.fingerprintKey. The byte-count
+//   check is cheap; SHA-256 catches in-flight corruption; the
+//   import-fingerprint check catches extension/format confusion.
+// - Preflight rehash on existing local files. BookImporter.atomicCopyToSandbox
+//   trusts an existing final file without verifying its bytes; if a prior
+//   crashed import left corrupt content there, the materializer re-downloads
+//   rather than silently registering a row pointing at bad bytes.
+//
+// @coordinates-with: BackupBlobStore.swift, BookImporting (BookImporter),
+//   BackupLibraryEntry (BackupSectionDTOs.swift),
+//   dev-docs/plans/20260503-feature-46-materializing-restore.md
+
+import CryptoKit
+import Foundation
+import OSLog
+
+private let log = Logger(subsystem: "com.vreader.app", category: "BookFileMaterializer")
+
+/// Per-entry outcome from `materialize`. Caller (WebDAVProvider.restore)
+/// aggregates these into a `BackupError.materializePartiallyFailed` if any
+/// downloads/imports failed; happy-path entries proceed to metadata restore.
+struct MaterializeResult: Sendable {
+    let entry: BackupLibraryEntry
+    let outcome: Outcome
+
+    enum Outcome: Sendable, Equatable {
+        case alreadyLocal                                     // hash verified
+        case downloaded(fingerprintKey: String)
+        case downloadFailed(BackupBlobStoreError)
+        case sizeAfterDownloadMismatch(expected: Int64, actual: Int64)
+        case sha256Mismatch(expected: String, actual: String)
+        case importFailed(String)                              // ImportError stringified
+        case fingerprintMismatchAfterImport(expected: String, actual: String)
+    }
+
+    /// True for `.alreadyLocal` and `.downloaded`. False otherwise.
+    var isSuccess: Bool {
+        switch outcome {
+        case .alreadyLocal, .downloaded: return true
+        default: return false
+        }
+    }
+}
+
+/// Resolves the local sandbox URL for a fingerprint key — mirrors
+/// `LibraryBookItem.resolvedFileURL`'s convention (colons → underscores)
+/// without depending on a SwiftData entity. Injected so tests can use a
+/// throw-away temp directory.
+typealias SandboxURLResolver = @Sendable (_ fingerprintKey: String, _ originalExtension: String) -> URL
+
+final class BookFileMaterializer: Sendable {
+
+    private let blobStore: any BackupBlobReading
+    private let importer: any BookImporting
+    private let resolveSandboxURL: SandboxURLResolver
+    private let tempDirectory: URL
+
+    init(
+        blobStore: any BackupBlobReading,
+        importer: any BookImporting,
+        tempDirectory: URL,
+        resolveSandboxURL: @escaping SandboxURLResolver = BookFileMaterializer.defaultSandboxResolver
+    ) {
+        self.blobStore = blobStore
+        self.importer = importer
+        self.tempDirectory = tempDirectory
+        self.resolveSandboxURL = resolveSandboxURL
+    }
+
+    // MARK: - Default resolver
+
+    /// Mirrors `LibraryBookItem.resolvedFileURL`: Application Support /
+    /// ImportedBooks / `<fingerprintKey-with-colons-as-underscores>.<ext>`.
+    static let defaultSandboxResolver: SandboxURLResolver = { fingerprintKey, originalExtension in
+        let booksDir = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("ImportedBooks", isDirectory: true)
+        let safeName = fingerprintKey.replacingOccurrences(of: ":", with: "_")
+        return booksDir
+            .appendingPathComponent(safeName)
+            .appendingPathExtension(originalExtension)
+    }
+
+    // MARK: - Classify
+
+    /// Splits entries into (alreadyLocal, needsDownload). For an entry whose
+    /// resolved sandbox URL exists locally, hashes the file and verifies
+    /// SHA-256 against the manifest — mismatch counts as needsDownload.
+    func classify(
+        _ entries: [BackupLibraryEntry]
+    ) async -> (alreadyLocal: [BackupLibraryEntry], needsDownload: [BackupLibraryEntry]) {
+        var alreadyLocal: [BackupLibraryEntry] = []
+        var needsDownload: [BackupLibraryEntry] = []
+        for entry in entries {
+            let localURL = resolveSandboxURL(entry.fingerprintKey, entry.originalExtension)
+            if FileManager.default.fileExists(atPath: localURL.path),
+               let localHash = try? localFileSHA256(at: localURL),
+               localHash == entry.sha256 {
+                alreadyLocal.append(entry)
+            } else {
+                needsDownload.append(entry)
+            }
+        }
+        return (alreadyLocal, needsDownload)
+    }
+
+    // MARK: - Materialize
+
+    /// Downloads + verifies + imports each entry serially. Reports progress
+    /// 0...1 across the batch.
+    func materialize(
+        _ entries: [BackupLibraryEntry],
+        progress: @Sendable (Double) -> Void
+    ) async -> [MaterializeResult] {
+        var results: [MaterializeResult] = []
+        results.reserveCapacity(entries.count)
+        progress(0.0)
+        guard !entries.isEmpty else {
+            progress(1.0)
+            return results
+        }
+        for (index, entry) in entries.enumerated() {
+            let result = await materializeOne(entry)
+            results.append(result)
+            progress(Double(index + 1) / Double(entries.count))
+        }
+        return results
+    }
+
+    // MARK: - Per-entry algorithm
+
+    private func materializeOne(_ entry: BackupLibraryEntry) async -> MaterializeResult {
+        let localURL = resolveSandboxURL(entry.fingerprintKey, entry.originalExtension)
+
+        // Step 1: existing local file → preflight hash.
+        if FileManager.default.fileExists(atPath: localURL.path) {
+            if let localHash = try? localFileSHA256(at: localURL), localHash == entry.sha256 {
+                return MaterializeResult(entry: entry, outcome: .alreadyLocal)
+            }
+            // Corrupt local file (wrong bytes for the fingerprint). Remove
+            // before download — BookImporter would otherwise trust the
+            // existing file at the final path without rehashing.
+            try? FileManager.default.removeItem(at: localURL)
+        }
+
+        // Step 2: download.
+        let bytes: Data
+        do {
+            bytes = try await blobStore.download(from: entry.blobPath)
+        } catch let error as BackupBlobStoreError {
+            return MaterializeResult(entry: entry, outcome: .downloadFailed(error))
+        } catch {
+            return MaterializeResult(
+                entry: entry,
+                outcome: .downloadFailed(.underlying("\(error)"))
+            )
+        }
+
+        // Step 3: byte-count check (cheap, catches truncation).
+        if Int64(bytes.count) != entry.byteCount {
+            return MaterializeResult(
+                entry: entry,
+                outcome: .sizeAfterDownloadMismatch(expected: entry.byteCount, actual: Int64(bytes.count))
+            )
+        }
+
+        // Step 4: SHA-256 check (catches corruption that slipped past size).
+        let downloadedHash = sha256Hex(of: bytes)
+        if downloadedHash != entry.sha256 {
+            return MaterializeResult(
+                entry: entry,
+                outcome: .sha256Mismatch(expected: entry.sha256, actual: downloadedHash)
+            )
+        }
+
+        // Step 5: write to a temp file with originalExtension so BookImporter
+        // can derive format from the extension. Path includes the SHA-256 to
+        // stay unique across concurrent restores.
+        let tempURL: URL
+        do {
+            try FileManager.default.createDirectory(
+                at: tempDirectory, withIntermediateDirectories: true
+            )
+            tempURL = tempDirectory
+                .appendingPathComponent("restore_\(entry.sha256)")
+                .appendingPathExtension(entry.originalExtension)
+            try bytes.write(to: tempURL)
+        } catch {
+            return MaterializeResult(
+                entry: entry,
+                outcome: .importFailed("temp write failed: \(error)")
+            )
+        }
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        // Step 6: import via the production importer (re-extracts metadata,
+        // saves cover, fires indexing notification, applies dedupe).
+        let importResult: ImportResult
+        do {
+            importResult = try await importer.importFile(at: tempURL, source: .restore)
+        } catch let importErr as ImportError {
+            return MaterializeResult(
+                entry: entry,
+                outcome: .importFailed("\(importErr)")
+            )
+        } catch {
+            return MaterializeResult(
+                entry: entry,
+                outcome: .importFailed("\(error)")
+            )
+        }
+
+        // Step 7: verify the import landed at the manifest's fingerprint.
+        // Catches extension/format confusion: if BookImporter detected a
+        // different format from the bytes than the manifest claimed, the
+        // resulting fingerprintKey won't match.
+        guard importResult.fingerprintKey == entry.fingerprintKey else {
+            return MaterializeResult(
+                entry: entry,
+                outcome: .fingerprintMismatchAfterImport(
+                    expected: entry.fingerprintKey,
+                    actual: importResult.fingerprintKey
+                )
+            )
+        }
+
+        return MaterializeResult(
+            entry: entry,
+            outcome: .downloaded(fingerprintKey: importResult.fingerprintKey)
+        )
+    }
+
+    // MARK: - Hashing helpers
+
+    /// Streaming SHA-256 of a local file (chunked so very-large blobs don't
+    /// spike memory). Returns lowercase hex matching `entry.sha256` format.
+    private func localFileSHA256(at url: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        let chunkSize = 64 * 1024
+        while true {
+            let chunk = try handle.read(upToCount: chunkSize) ?? Data()
+            if chunk.isEmpty { break }
+            hasher.update(data: chunk)
+        }
+        return hexString(Data(hasher.finalize()))
+    }
+
+    /// SHA-256 of an in-memory byte buffer. Used for downloaded blobs which
+    /// are already fully resident.
+    private func sha256Hex(of data: Data) -> String {
+        hexString(Data(SHA256.hash(data: data)))
+    }
+
+    private func hexString(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/vreaderTests/Services/Backup/BookFileMaterializerTests.swift
+++ b/vreaderTests/Services/Backup/BookFileMaterializerTests.swift
@@ -1,0 +1,339 @@
+// Purpose: Tests for BookFileMaterializer — feature #46's restore-side
+// download + verify + import orchestrator. Uses a stub BackupBlobReading +
+// a wrapping BookImporter so the materializer's logic is exercised without
+// real WebDAV or SwiftData.
+//
+// @coordinates-with: vreader/Services/Backup/BookFileMaterializer.swift,
+//   vreader/Services/Backup/BackupBlobStore.swift,
+//   dev-docs/plans/20260503-feature-46-materializing-restore.md
+
+import Testing
+import Foundation
+import CryptoKit
+@testable import vreader
+
+@Suite("BookFileMaterializer — feature #46 WI-5")
+struct BookFileMaterializerTests {
+
+    // MARK: - Stub blob reader
+
+    /// Collects progress callbacks from the @Sendable closure into an array.
+    /// Actor-isolated because the materializer's progress callback is @Sendable
+    /// and may fire from any context.
+    actor ProgressCollector {
+        private(set) var values: [Double] = []
+        func record(_ value: Double) { values.append(value) }
+    }
+
+    actor StubBlobReader: BackupBlobReading {
+        var blobs: [String: Data] = [:]
+        var downloadError: BackupBlobStoreError?
+
+        func setBlob(_ data: Data, at path: String) {
+            blobs[path] = data
+        }
+
+        func setDownloadError(_ error: BackupBlobStoreError?) {
+            downloadError = error
+        }
+
+        func existsWithSize(at path: String) async throws -> Int64? {
+            guard let data = blobs[path] else { return nil }
+            return Int64(data.count)
+        }
+
+        func download(from path: String) async throws -> Data {
+            if let error = downloadError { throw error }
+            guard let data = blobs[path] else {
+                throw BackupBlobStoreError.underlying("not found: \(path)")
+            }
+            return data
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func sha256Hex(_ data: Data) -> String {
+        Data(SHA256.hash(data: data)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("matz_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private static func makeSandboxDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sandbox_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Builds a manifest entry for `data` of the given format. Computes a
+    /// real SHA-256 and BlobPath so tests aren't full of magic constants.
+    private static func makeEntry(
+        data: Data,
+        format: BookFormat = .epub,
+        originalExtension: String? = nil
+    ) -> BackupLibraryEntry {
+        let sha = sha256Hex(data)
+        let bytes = Int64(data.count)
+        let ext = originalExtension ?? format.fileExtensions.first ?? format.rawValue
+        return BackupLibraryEntry(
+            fingerprintKey: "\(format.rawValue):\(sha):\(bytes)",
+            format: format.rawValue,
+            sha256: sha,
+            byteCount: bytes,
+            originalExtension: ext,
+            title: "T",
+            author: "A",
+            addedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            lastOpenedAt: nil,
+            blobPath: BlobPath.make(format: format, sha256: sha, byteCount: bytes)
+        )
+    }
+
+    /// Returns (materializer, blobReader, importer, sandboxDir, tempDir).
+    private static func makeRig() async throws -> (BookFileMaterializer, StubBlobReader, MockPersistenceActor, URL, URL) {
+        let blobReader = StubBlobReader()
+        let mockPersistence = MockPersistenceActor()
+        let sandbox = try makeSandboxDir()
+        let temp = try makeTempDir()
+        let importer = BookImporter(persistence: mockPersistence, sandboxBooksDirectory: sandbox)
+
+        // Sandbox resolver mirrors LibraryBookItem's convention but rooted at
+        // our test sandbox dir — keeps tests isolated from
+        // Application Support (which the production resolver targets).
+        let resolver: SandboxURLResolver = { fingerprintKey, originalExtension in
+            let safeName = fingerprintKey.replacingOccurrences(of: ":", with: "_")
+            return sandbox.appendingPathComponent(safeName).appendingPathExtension(originalExtension)
+        }
+
+        let materializer = BookFileMaterializer(
+            blobStore: blobReader,
+            importer: importer,
+            tempDirectory: temp,
+            resolveSandboxURL: resolver
+        )
+        return (materializer, blobReader, mockPersistence, sandbox, temp)
+    }
+
+    // MARK: - Empty input
+
+    @Test func materialize_emptyEntries_returnsEmptyAndCallsProgress() async throws {
+        let (materializer, _, _, _, _) = try await Self.makeRig()
+        let collector = ProgressCollector()
+        let results = await materializer.materialize([]) { value in
+            Task { await collector.record(value) }
+        }
+        // Drain the inflight Tasks before reading.
+        await Task.yield()
+        await Task.yield()
+        #expect(results.isEmpty)
+        let updates = await collector.values
+        #expect(updates.contains(0.0))
+        #expect(updates.contains(1.0))
+    }
+
+    // MARK: - Happy path: fresh download
+
+    @Test func materialize_singleMissingEntry_downloadsAndImports() async throws {
+        let (materializer, blobReader, mock, _, _) = try await Self.makeRig()
+        let payload = Data(repeating: 0x42, count: 1024)  // EPUB-ish bytes
+        // Real ZIP magic so BookImporter accepts the file as EPUB.
+        let epubBytes = Data([0x50, 0x4B, 0x03, 0x04]) + payload
+        let entry = Self.makeEntry(data: epubBytes, format: .epub)
+        await blobReader.setBlob(epubBytes, at: entry.blobPath)
+
+        let results = await materializer.materialize([entry]) { _ in }
+        #expect(results.count == 1)
+        switch results[0].outcome {
+        case .downloaded(let key):
+            #expect(key == entry.fingerprintKey)
+        default:
+            Issue.record("expected .downloaded, got \(results[0].outcome)")
+        }
+        // Persisted via importer.
+        let stored = await mock.book(forKey: entry.fingerprintKey)
+        #expect(stored != nil)
+        #expect(stored?.originalExtension == "epub")
+    }
+
+    // MARK: - Already-local skip
+
+    @Test func materialize_existingLocalFileWithMatchingHash_skipsDownload() async throws {
+        let (materializer, blobReader, _, sandbox, _) = try await Self.makeRig()
+        let payload = Data([0x50, 0x4B, 0x03, 0x04]) + Data(repeating: 0xAB, count: 512)
+        let entry = Self.makeEntry(data: payload, format: .epub)
+        // Pre-place the file at the resolved sandbox location with matching
+        // bytes — materializer should hash + skip download.
+        let safeName = entry.fingerprintKey.replacingOccurrences(of: ":", with: "_")
+        let localURL = sandbox.appendingPathComponent(safeName).appendingPathExtension(entry.originalExtension)
+        try payload.write(to: localURL)
+
+        let results = await materializer.materialize([entry]) { _ in }
+        #expect(results.count == 1)
+        #expect(results[0].outcome == .alreadyLocal)
+        // Blob was not requested — we never called download.
+        let stored = await blobReader.blobs
+        #expect(stored.isEmpty)
+    }
+
+    // MARK: - Corrupt local file (preflight rehash catches it)
+
+    @Test func materialize_corruptLocalFile_redownloadsClean() async throws {
+        let (materializer, blobReader, _, sandbox, _) = try await Self.makeRig()
+        let goodPayload = Data([0x50, 0x4B, 0x03, 0x04]) + Data(repeating: 0xCC, count: 256)
+        let entry = Self.makeEntry(data: goodPayload, format: .epub)
+        // Pre-place a CORRUPT file at the resolved sandbox location (right
+        // size, wrong bytes) — without preflight rehash, BookImporter
+        // would trust this file. Materializer should detect mismatch + remove.
+        let safeName = entry.fingerprintKey.replacingOccurrences(of: ":", with: "_")
+        let localURL = sandbox.appendingPathComponent(safeName).appendingPathExtension(entry.originalExtension)
+        let corrupt = Data([0x50, 0x4B, 0x03, 0x04]) + Data(repeating: 0x00, count: 256)
+        try corrupt.write(to: localURL)
+        await blobReader.setBlob(goodPayload, at: entry.blobPath)
+
+        let results = await materializer.materialize([entry]) { _ in }
+        #expect(results.count == 1)
+        switch results[0].outcome {
+        case .downloaded:
+            break  // expected
+        default:
+            Issue.record("expected .downloaded after preflight detected corrupt local, got \(results[0].outcome)")
+        }
+    }
+
+    // MARK: - Download failure
+
+    @Test func materialize_downloadFailure_returnsDownloadFailed() async throws {
+        let (materializer, blobReader, _, _, _) = try await Self.makeRig()
+        let entry = Self.makeEntry(data: Data([0x50, 0x4B, 0x03, 0x04, 0xAB]), format: .epub)
+        await blobReader.setDownloadError(.underlying("network timeout"))
+
+        let results = await materializer.materialize([entry]) { _ in }
+        switch results[0].outcome {
+        case .downloadFailed:
+            break  // expected
+        default:
+            Issue.record("expected .downloadFailed, got \(results[0].outcome)")
+        }
+    }
+
+    // MARK: - Size mismatch on download
+
+    @Test func materialize_downloadSizeMismatch_returnsSizeMismatch() async throws {
+        let (materializer, blobReader, _, _, _) = try await Self.makeRig()
+        // Build entry claiming a specific size, then return wrong-sized bytes.
+        let manifestPayload = Data([0x50, 0x4B, 0x03, 0x04]) + Data(repeating: 0xEE, count: 1024)
+        let entry = Self.makeEntry(data: manifestPayload, format: .epub)
+        // Server returns truncated bytes.
+        let truncated = Data(manifestPayload.prefix(100))
+        await blobReader.setBlob(truncated, at: entry.blobPath)
+
+        let results = await materializer.materialize([entry]) { _ in }
+        switch results[0].outcome {
+        case .sizeAfterDownloadMismatch(let expected, let actual):
+            #expect(expected == Int64(manifestPayload.count))
+            #expect(actual == Int64(truncated.count))
+        default:
+            Issue.record("expected .sizeAfterDownloadMismatch, got \(results[0].outcome)")
+        }
+    }
+
+    // MARK: - SHA-256 mismatch (size matches, bytes differ)
+
+    @Test func materialize_sha256Mismatch_returnsHashError() async throws {
+        let (materializer, blobReader, _, _, _) = try await Self.makeRig()
+        let manifestPayload = Data([0x50, 0x4B, 0x03, 0x04]) + Data(repeating: 0x11, count: 1024)
+        let entry = Self.makeEntry(data: manifestPayload, format: .epub)
+        // Server returns SAME-size but DIFFERENT bytes.
+        let tampered = Data([0x50, 0x4B, 0x03, 0x04]) + Data(repeating: 0x22, count: 1024)
+        await blobReader.setBlob(tampered, at: entry.blobPath)
+
+        let results = await materializer.materialize([entry]) { _ in }
+        switch results[0].outcome {
+        case .sha256Mismatch(let expected, let actual):
+            #expect(expected == entry.sha256)
+            #expect(actual == Self.sha256Hex(tampered))
+        default:
+            Issue.record("expected .sha256Mismatch, got \(results[0].outcome)")
+        }
+    }
+
+    // MARK: - MOBI extension preservation
+
+    @Test func materialize_mobiUnderAzw3_writesTempWithMobiExtension() async throws {
+        let (materializer, blobReader, mock, _, temp) = try await Self.makeRig()
+        // MOBI/PRC/AZW collapse to canonical .azw3 in BookFormat. The manifest
+        // carries originalExtension = "mobi" so the materializer writes the
+        // temp blob with .mobi extension; BookImporter resolves format by
+        // extension and accepts it as .azw3.
+        let mobiBytes = Data([0x00, 0x00, 0x42, 0x4F, 0x4F, 0x4B, 0x4D, 0x4F, 0x42, 0x49])  // "BOOKMOBI" header
+        let entry = Self.makeEntry(data: mobiBytes, format: .azw3, originalExtension: "mobi")
+        await blobReader.setBlob(mobiBytes, at: entry.blobPath)
+
+        let results = await materializer.materialize([entry]) { _ in }
+        #expect(results.count == 1)
+        switch results[0].outcome {
+        case .downloaded:
+            // Verify the imported book's originalExtension survived.
+            let stored = await mock.book(forKey: entry.fingerprintKey)
+            #expect(stored?.originalExtension == "mobi")
+            #expect(stored?.fingerprint.format == .azw3)
+        default:
+            Issue.record("expected .downloaded for MOBI as .azw3, got \(results[0].outcome)")
+        }
+        // Temp file was cleaned up after import.
+        let leftover = (try? FileManager.default.contentsOfDirectory(atPath: temp.path)) ?? []
+        #expect(leftover.isEmpty)
+    }
+
+    // MARK: - Classify
+
+    @Test func classify_partitionsCorrectly() async throws {
+        let (materializer, _, _, sandbox, _) = try await Self.makeRig()
+        let dataA = Data([0x50, 0x4B, 0x03, 0x04]) + Data(repeating: 0x01, count: 100)
+        let dataB = Data([0x50, 0x4B, 0x03, 0x04]) + Data(repeating: 0x02, count: 200)
+        let entryA = Self.makeEntry(data: dataA, format: .epub)
+        let entryB = Self.makeEntry(data: dataB, format: .epub)
+
+        // Place entryA locally; entryB is missing.
+        let safeNameA = entryA.fingerprintKey.replacingOccurrences(of: ":", with: "_")
+        let localA = sandbox.appendingPathComponent(safeNameA).appendingPathExtension(entryA.originalExtension)
+        try dataA.write(to: localA)
+
+        let (alreadyLocal, needsDownload) = await materializer.classify([entryA, entryB])
+        #expect(alreadyLocal.map(\.fingerprintKey) == [entryA.fingerprintKey])
+        #expect(needsDownload.map(\.fingerprintKey) == [entryB.fingerprintKey])
+    }
+
+    // MARK: - Progress monotonicity
+
+    @Test func materialize_threeEntries_progressMonotonicAndEndsAtOne() async throws {
+        let (materializer, blobReader, _, _, _) = try await Self.makeRig()
+        var entries: [BackupLibraryEntry] = []
+        for i in 0..<3 {
+            let bytes = Data([0x50, 0x4B, 0x03, 0x04]) + Data(repeating: UInt8(i), count: 32 + i)
+            let e = Self.makeEntry(data: bytes, format: .epub)
+            await blobReader.setBlob(bytes, at: e.blobPath)
+            entries.append(e)
+        }
+        let collector = ProgressCollector()
+        let results = await materializer.materialize(entries) { value in
+            Task { await collector.record(value) }
+        }
+        // Drain inflight Task.appends.
+        for _ in 0..<10 { await Task.yield() }
+        #expect(results.count == 3)
+        let updates = await collector.values
+        #expect(updates.first == 0.0)
+        #expect(updates.last == 1.0)
+        // Monotonic non-decreasing.
+        for i in 1..<updates.count {
+            #expect(updates[i] >= updates[i - 1])
+        }
+    }
+}


### PR DESCRIPTION
Refs #144. Centerpiece of restore: serial download + triple verification (size, SHA-256, post-import fingerprint) + import via BookImporter.

Catches BookImporter.atomicCopyToSandbox's idempotency hole via preflight rehash on existing local files.

10 new tests, all GREEN. Covers: alreadyLocal hash match, corrupt-local redownload, download failure, size mismatch, SHA-256 mismatch, MOBI extension preservation through temp file, classify, progress monotonicity.

Workflow: Gates 1+2 (parent plan) ✓, Gate 3 ✓, Gate 4 (audit) skipped per medium-tier — substantive findings would have surfaced via existing audited contracts (BackupBlobStore, BookImporting).

Consumed by WI-7 (WebDAVProvider restore integration).