### PR TITLE
feat(#46): WI-6 — BackupDataCollector emits library-manifest.json

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 27
-        MARKETING_VERSION: 3.10.26
+        CURRENT_PROJECT_VERSION: 28
+        MARKETING_VERSION: 3.10.27
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3810,13 +3810,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.26;
+				MARKETING_VERSION = 3.10.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3960,13 +3960,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 27;
+				CURRENT_PROJECT_VERSION = 28;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.26;
+				MARKETING_VERSION = 3.10.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Backup/BackupDataCollector.swift
+++ b/vreader/Services/Backup/BackupDataCollector.swift
@@ -201,6 +201,34 @@ final class BackupDataCollector: BackupDataCollecting, @unchecked Sendable {
         ((try? await persistence.fetchAllLibraryBooks()) ?? []).count
     }
 
+    func collectLibraryManifest() async throws -> Data {
+        let projections = (try? await persistence.fetchAllBooksForBackup()) ?? []
+        let entries: [BackupLibraryEntry] = projections.compactMap { projection in
+            guard let format = BookFormat(rawValue: projection.format) else {
+                log.error("Skipping projection with unknown format \(projection.format, privacy: .public)")
+                return nil
+            }
+            return BackupLibraryEntry(
+                fingerprintKey: projection.fingerprintKey,
+                format: projection.format,
+                sha256: projection.sha256,
+                byteCount: projection.byteCount,
+                originalExtension: projection.originalExtension,
+                title: projection.title,
+                author: projection.author,
+                addedAt: projection.addedAt,
+                lastOpenedAt: projection.lastOpenedAt,
+                blobPath: BlobPath.make(
+                    format: format,
+                    sha256: projection.sha256,
+                    byteCount: projection.byteCount
+                )
+            )
+        }
+        let envelope = BackupLibraryManifestEnvelope(schemaVersion: 1, books: entries)
+        return try encode(envelope)
+    }
+
     // MARK: - Helpers
 
     private func encode<T: Encodable>(_ value: T) throws -> Data {

--- a/vreader/Services/Backup/WebDAVProvider.swift
+++ b/vreader/Services/Backup/WebDAVProvider.swift
@@ -25,6 +25,26 @@ protocol BackupDataCollecting: Sendable {
     func collectPerBookSettings() async throws -> Data
     func collectReplacementRules() async throws -> Data
     func getBookCount() async -> Int
+
+    /// Feature #46 (WI-6): emits `library-manifest.json` carrying one
+    /// `BackupLibraryEntry` per local book. Allows the restorer (WI-7+)
+    /// to download missing book blobs on a fresh device. Default impl
+    /// returns an empty manifest envelope so older provider impls stay
+    /// source-compatible.
+    func collectLibraryManifest() async throws -> Data
+}
+
+extension BackupDataCollecting {
+    func collectLibraryManifest() async throws -> Data {
+        let envelope = BackupLibraryManifestEnvelope(
+            schemaVersion: 1,
+            books: []
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(envelope)
+    }
 }
 
 // MARK: - BackupDataRestoring Protocol

--- a/vreaderTests/Services/Backup/BackupDataCollectorRestorerTests.swift
+++ b/vreaderTests/Services/Backup/BackupDataCollectorRestorerTests.swift
@@ -10,6 +10,92 @@ import Foundation
 import SwiftData
 @testable import vreader
 
+// MARK: - Library Manifest collection (feature #46 WI-6)
+
+@Suite("BackupDataCollector — collectLibraryManifest (feature #46 WI-6)")
+struct BackupDataCollectorLibraryManifestTests {
+
+    private func makeCollector(persistence: PersistenceActor) -> BackupDataCollector {
+        BackupDataCollector(
+            persistence: persistence,
+            defaults: UserDefaults(suiteName: "manifest-test-\(UUID().uuidString)")!,
+            perBookSettingsBaseURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("pbs-\(UUID().uuidString)", isDirectory: true)
+        )
+    }
+
+    @Test func emptyLibrary_emitsEmptyManifest() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let collector = makeCollector(persistence: persistence)
+        let data = try await collector.collectLibraryManifest()
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let envelope = try decoder.decode(BackupLibraryManifestEnvelope.self, from: data)
+        #expect(envelope.schemaVersion == 1)
+        #expect(envelope.books.isEmpty)
+    }
+
+    @Test func multipleBooks_emitsOneEntryPerBook_withCorrectBlobPath() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let collector = makeCollector(persistence: persistence)
+        let key1 = try await CollectionTestHelper.insertBook(
+            persistence: persistence,
+            title: "Alice",
+            sha: String(repeating: "a", count: 64),
+            byteCount: 1024
+        )
+        let key2 = try await CollectionTestHelper.insertBook(
+            persistence: persistence,
+            title: "MOBI Book",
+            sha: String(repeating: "b", count: 64),
+            byteCount: 4096
+        )
+
+        let data = try await collector.collectLibraryManifest()
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let envelope = try decoder.decode(BackupLibraryManifestEnvelope.self, from: data)
+        #expect(envelope.books.count == 2)
+        let keys = envelope.books.map(\.fingerprintKey)
+        #expect(keys == keys.sorted())
+        #expect(Set(keys) == Set([key1, key2]))
+        for entry in envelope.books {
+            guard let format = BookFormat(rawValue: entry.format) else {
+                Issue.record("unknown format \(entry.format)")
+                continue
+            }
+            let expected = BlobPath.make(format: format, sha256: entry.sha256, byteCount: entry.byteCount)
+            #expect(entry.blobPath == expected)
+        }
+    }
+
+    @Test func mobiBook_preservesOriginalExtensionInManifest() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let collector = makeCollector(persistence: persistence)
+        let sha = String(repeating: "c", count: 64)
+        let fp = DocumentFingerprint(contentSHA256: sha, fileByteCount: 8192, format: .azw3)
+        let record = BookRecord(
+            fingerprintKey: fp.canonicalKey,
+            title: "Old Kindle Book",
+            author: nil,
+            coverImagePath: nil,
+            fingerprint: fp,
+            provenance: CollectionTestHelper.makeProvenance(),
+            detectedEncoding: nil,
+            addedAt: Date(),
+            originalExtension: "mobi"
+        )
+        _ = try await persistence.insertBook(record)
+        let data = try await collector.collectLibraryManifest()
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let envelope = try decoder.decode(BackupLibraryManifestEnvelope.self, from: data)
+        #expect(envelope.books.count == 1)
+        #expect(envelope.books[0].originalExtension == "mobi")
+        #expect(envelope.books[0].format == "azw3")
+    }
+}
+
 @Suite("BackupDataCollector + BackupDataRestorer")
 struct BackupCollectorRestorerSuite {
 


### PR DESCRIPTION
Refs #144. Adds collectLibraryManifest() — uses WI-0a's projection + WI-1's BlobPath + WI-2's envelope. Protocol default impl returns empty envelope for source-compat with existing test fakes. 3 new tests, all GREEN.