### PR TITLE
feat(#46): WI-7 — WebDAVProvider.backup uploads book blobs atomically

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 28
-        MARKETING_VERSION: 3.10.27
+        CURRENT_PROJECT_VERSION: 29
+        MARKETING_VERSION: 3.10.28
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3810,13 +3810,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.27;
+				MARKETING_VERSION = 3.10.28;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3960,13 +3960,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.27;
+				MARKETING_VERSION = 3.10.28;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Backup/WebDAVProvider.swift
+++ b/vreader/Services/Backup/WebDAVProvider.swift
@@ -1,6 +1,11 @@
 // Purpose: BackupProvider conformance for WebDAV storage backends.
 // Creates ZIP backups of app data and uploads/downloads via WebDAVTransport.
 // Restore delegates to BackupDataRestoring protocol for persistence-layer writes.
+
+import OSLog
+
+private let log = Logger(subsystem: "com.vreader.app", category: "WebDAVProvider")
+
 //
 // Key decisions:
 // - Uses WebDAVTransport protocol for testability.
@@ -73,6 +78,15 @@ final class WebDAVProvider: BackupProvider, @unchecked Sendable {
     private let appVersion: String
     private let basePath = "VReader/backups"
 
+    /// Resolves the local sandbox URL for a (fingerprintKey, originalExtension)
+    /// — used by feature #46 (WI-7) to locate book bytes for blob upload.
+    /// Defaults to the production resolver shared with `BookFileMaterializer`.
+    private let sandboxResolver: SandboxURLResolver
+
+    /// Blob store wrapping the same transport. Used by feature #46 to publish
+    /// content-addressed book blobs atomically (PUT-tmp → PROPFIND-verify → MOVE).
+    private let blobStore: WebDAVBlobStore
+
     /// In-memory cache of known backup metadata, keyed by ID.
     private var metadataCache: [UUID: (metadata: BackupMetadata, remotePath: String)] = [:]
 
@@ -81,13 +95,16 @@ final class WebDAVProvider: BackupProvider, @unchecked Sendable {
         dataCollector: BackupDataCollecting,
         dataRestorer: BackupDataRestoring,
         deviceName: String,
-        appVersion: String
+        appVersion: String,
+        sandboxResolver: @escaping SandboxURLResolver = BookFileMaterializer.defaultSandboxResolver
     ) {
         self.transport = transport
         self.dataCollector = dataCollector
         self.dataRestorer = dataRestorer
         self.deviceName = deviceName
         self.appVersion = appVersion
+        self.sandboxResolver = sandboxResolver
+        self.blobStore = WebDAVBlobStore(transport: transport)
     }
 
     // MARK: - BackupProvider
@@ -95,28 +112,37 @@ final class WebDAVProvider: BackupProvider, @unchecked Sendable {
     func backup(progress: @Sendable (Double) -> Void) async throws -> BackupMetadata {
         progress(0.0)
 
-        // Phase 1: Collect data (0.0 → 0.4)
+        // Phase 1: Collect metadata sections + library manifest (0.0 → 0.30)
         let collected: [(String, Data)]
+        let manifestData: Data
+        let manifest: BackupLibraryManifestEnvelope
         let bookCount: Int
         do {
-            let a = try await dataCollector.collectAnnotations(); progress(0.06)
-            let p = try await dataCollector.collectPositions(); progress(0.12)
-            let s = try await dataCollector.collectSettings(); progress(0.18)
-            let c = try await dataCollector.collectCollections(); progress(0.24)
-            let bs = try await dataCollector.collectBookSources(); progress(0.30)
-            let pbs = try await dataCollector.collectPerBookSettings(); progress(0.35)
-            let rr = try await dataCollector.collectReplacementRules(); progress(0.38)
-            bookCount = await dataCollector.getBookCount(); progress(0.40)
+            let a = try await dataCollector.collectAnnotations(); progress(0.04)
+            let p = try await dataCollector.collectPositions(); progress(0.08)
+            let s = try await dataCollector.collectSettings(); progress(0.12)
+            let c = try await dataCollector.collectCollections(); progress(0.16)
+            let bs = try await dataCollector.collectBookSources(); progress(0.20)
+            let pbs = try await dataCollector.collectPerBookSettings(); progress(0.24)
+            let rr = try await dataCollector.collectReplacementRules(); progress(0.26)
+            manifestData = try await dataCollector.collectLibraryManifest(); progress(0.28)
+            bookCount = await dataCollector.getBookCount(); progress(0.30)
             collected = [
                 ("annotations.json", a), ("positions.json", p), ("settings.json", s),
                 ("collections.json", c), ("book-sources.json", bs), ("per-book-settings.json", pbs),
                 ("replacement-rules.json", rr),
+                ("library-manifest.json", manifestData),
             ]
+
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            manifest = (try? decoder.decode(BackupLibraryManifestEnvelope.self, from: manifestData))
+                ?? BackupLibraryManifestEnvelope(schemaVersion: 1, books: [])
         } catch {
             throw BackupError.archiveCreationFailed("Failed to collect data: \(error.localizedDescription)")
         }
 
-        // Phase 2: Create metadata and ZIP (0.4 → 0.5)
+        // Phase 2: Create metadata + ZIP (0.30 → 0.40)
         let backupId = UUID()
         let now = Date()
         let totalSize = Int64(collected.reduce(0) { $0 + $1.1.count })
@@ -138,19 +164,31 @@ final class WebDAVProvider: BackupProvider, @unchecked Sendable {
         guard let zipData = try? ZIPWriter.createArchive(entries: zipEntries) else {
             throw BackupError.archiveCreationFailed("Failed to create ZIP archive")
         }
-        progress(0.50)
+        progress(0.40)
 
-        // Phase 3: Upload to WebDAV (0.5 → 1.0)
-        let remotePath = makeRemotePath(id: backupId, date: now)
+        // Phase 3: Ensure server directory tree (0.40 → 0.45)
         do {
-            // Create each parent collection in turn — WebDAV MKCOL won't
-            // create intermediate directories on most servers, so a nested
-            // basePath like "VReader/backups" needs two MKCOLs.
             for ancestor in nestedAncestors(of: basePath) {
                 try await transport.createDirectory(path: ancestor)
             }
-            progress(0.55)
-            try await transport.upload(data: zipData, toPath: remotePath); progress(0.95)
+        } catch let error as WebDAVError {
+            throw BackupError.storageUnavailable("WebDAV mkdir failed: \(error)")
+        }
+        progress(0.45)
+
+        // Phase 4: Publish missing book blobs (0.45 → 0.85)
+        // Per feature #46: each book is uploaded as a content-addressed blob
+        // at VReader/books/<format>/<sha256>_<byteCount>.<ext>. PROPFIND-dedupe
+        // makes repeat backups cheap (only NEW books transfer bytes).
+        if !manifest.books.isEmpty {
+            try await uploadBlobs(manifest.books, progressBase: 0.45, progressSpan: 0.40, progress: progress)
+        }
+        progress(0.85)
+
+        // Phase 5: Upload metadata ZIP (0.85 → 1.0)
+        let remotePath = makeRemotePath(id: backupId, date: now)
+        do {
+            try await transport.upload(data: zipData, toPath: remotePath)
         } catch let error as WebDAVError {
             throw BackupError.storageUnavailable("WebDAV upload failed: \(error)")
         } catch {
@@ -160,6 +198,48 @@ final class WebDAVProvider: BackupProvider, @unchecked Sendable {
         metadataCache[backupId] = (metadata, remotePath)
         progress(1.0)
         return metadata
+    }
+
+    /// Uploads (or skips, if dedupe says they're already on the server) every
+    /// blob referenced by the manifest. Surfaces server-capability gaps as a
+    /// hard error so the user knows their server can't host atomic uploads.
+    private func uploadBlobs(
+        _ entries: [BackupLibraryEntry],
+        progressBase: Double,
+        progressSpan: Double,
+        progress: @Sendable (Double) -> Void
+    ) async throws {
+        // Books may share a parent directory; create them all idempotently.
+        // The blob path is "VReader/books/<format>/<sha256>_<byteCount>.<ext>"
+        // so we need at least "VReader/books" + per-format subdirs created.
+        var seenDirs: Set<String> = []
+        let count = max(entries.count, 1)
+        for (index, entry) in entries.enumerated() {
+            let dir = (entry.blobPath as NSString).deletingLastPathComponent
+            for ancestor in nestedAncestors(of: dir) where !seenDirs.contains(ancestor) {
+                seenDirs.insert(ancestor)
+                try? await transport.createDirectory(path: ancestor)
+            }
+
+            let localURL = sandboxResolver(entry.fingerprintKey, entry.originalExtension)
+            guard let bytes = try? Data(contentsOf: localURL) else {
+                log.error("Local blob missing for \(entry.fingerprintKey, privacy: .public) at \(localURL.path, privacy: .public); skipping upload")
+                progress(progressBase + progressSpan * Double(index + 1) / Double(count))
+                continue
+            }
+            do {
+                _ = try await blobStore.putBlobAtomically(
+                    bytes,
+                    to: entry.blobPath,
+                    expectedByteCount: entry.byteCount
+                )
+            } catch BackupBlobStoreError.serverCapabilityMissing(let cap) {
+                throw BackupError.storageUnavailable("Server doesn't support \(cap); cannot publish blobs atomically")
+            } catch {
+                throw BackupError.storageUnavailable("Blob upload failed for \(entry.fingerprintKey): \(error)")
+            }
+            progress(progressBase + progressSpan * Double(index + 1) / Double(count))
+        }
     }
 
     func restore(backupId: UUID, progress: @Sendable (Double) -> Void) async throws {

--- a/vreaderTests/Services/Backup/WebDAVProviderTests.swift
+++ b/vreaderTests/Services/Backup/WebDAVProviderTests.swift
@@ -5,6 +5,7 @@
 // @coordinates-with: WebDAVProvider.swift, WebDAVClient.swift, BackupProvider.swift
 
 import Testing
+import CryptoKit
 import Foundation
 @testable import vreader
 
@@ -109,6 +110,132 @@ final class MockWebDAVTransport: WebDAVTransport, @unchecked Sendable {
     /// When true, MOVE throws httpError(501) — simulates a server that
     /// doesn't implement MOVE.
     var simulateMoveNotImplemented = false
+}
+
+// MARK: - Feature #46 (WI-7) — provider backup integration with blob upload
+
+@Suite("WebDAVProvider — backup with library manifest (feature #46 WI-7)")
+struct WebDAVProviderBackupWithManifestTests {
+
+    /// Stub collector that returns a pre-baked manifest + minimal sections.
+    final class StubCollector: BackupDataCollecting, @unchecked Sendable {
+        let manifestEntries: [BackupLibraryEntry]
+        init(manifestEntries: [BackupLibraryEntry]) {
+            self.manifestEntries = manifestEntries
+        }
+        func collectAnnotations() async throws -> Data { Data("{}".utf8) }
+        func collectPositions() async throws -> Data { Data("{}".utf8) }
+        func collectSettings() async throws -> Data { Data("{}".utf8) }
+        func collectCollections() async throws -> Data { Data("{}".utf8) }
+        func collectBookSources() async throws -> Data { Data("{}".utf8) }
+        func collectPerBookSettings() async throws -> Data { Data("{}".utf8) }
+        func collectReplacementRules() async throws -> Data { Data("{}".utf8) }
+        func getBookCount() async -> Int { manifestEntries.count }
+        func collectLibraryManifest() async throws -> Data {
+            let envelope = BackupLibraryManifestEnvelope(schemaVersion: 1, books: manifestEntries)
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            return try encoder.encode(envelope)
+        }
+    }
+
+    final class NoopRestorer: BackupDataRestoring, @unchecked Sendable {
+        func restoreAnnotations(from data: Data) async throws {}
+        func restorePositions(from data: Data) async throws {}
+        func restoreSettings(from data: Data) async throws {}
+        func restoreCollections(from data: Data) async throws {}
+        func restoreBookSources(from data: Data) async throws {}
+        func restorePerBookSettings(from data: Data) async throws {}
+        func restoreReplacementRules(from data: Data) async throws {}
+    }
+
+    private static func entry(_ data: Data, format: BookFormat = .epub, originalExtension: String? = nil) -> BackupLibraryEntry {
+        let sha = Data(SHA256.hash(data: data)).map { String(format: "%02x", $0) }.joined()
+        let bytes = Int64(data.count)
+        let ext = originalExtension ?? format.fileExtensions.first ?? format.rawValue
+        return BackupLibraryEntry(
+            fingerprintKey: "\(format.rawValue):\(sha):\(bytes)",
+            format: format.rawValue,
+            sha256: sha,
+            byteCount: bytes,
+            originalExtension: ext,
+            title: "T",
+            author: nil,
+            addedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            lastOpenedAt: nil,
+            blobPath: BlobPath.make(format: format, sha256: sha, byteCount: bytes)
+        )
+    }
+
+    private static func makeRig(
+        entries: [(Data, BackupLibraryEntry)]
+    ) async throws -> (WebDAVProvider, MockWebDAVTransport, URL) {
+        let mock = MockWebDAVTransport()
+        // Sandbox dir with a file per entry, named by the resolver convention.
+        let sandbox = FileManager.default.temporaryDirectory
+            .appendingPathComponent("provider-sandbox-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)
+        for (data, entry) in entries {
+            let safeName = entry.fingerprintKey.replacingOccurrences(of: ":", with: "_")
+            let url = sandbox.appendingPathComponent(safeName).appendingPathExtension(entry.originalExtension)
+            try data.write(to: url)
+        }
+        let resolver: SandboxURLResolver = { fingerprintKey, originalExtension in
+            let safeName = fingerprintKey.replacingOccurrences(of: ":", with: "_")
+            return sandbox.appendingPathComponent(safeName).appendingPathExtension(originalExtension)
+        }
+        let provider = WebDAVProvider(
+            transport: mock,
+            dataCollector: StubCollector(manifestEntries: entries.map(\.1)),
+            dataRestorer: NoopRestorer(),
+            deviceName: "TestDevice",
+            appVersion: "test",
+            sandboxResolver: resolver
+        )
+        return (provider, mock, sandbox)
+    }
+
+    @Test func backup_withManifest_uploadsBlobsToCanonicalPaths() async throws {
+        let dataA = Data([0x50, 0x4B, 0x03, 0x04]) + Data(repeating: 0xA0, count: 200)
+        let dataB = Data([0x50, 0x4B, 0x03, 0x04]) + Data(repeating: 0xB0, count: 300)
+        let entryA = Self.entry(dataA, format: .epub)
+        let entryB = Self.entry(dataB, format: .epub)
+        let (provider, mock, _) = try await Self.makeRig(entries: [(dataA, entryA), (dataB, entryB)])
+
+        let metadata = try await provider.backup { _ in }
+        #expect(metadata.bookCount == 2)
+        // Blobs landed at the canonical content-addressed paths.
+        #expect(mock.files[entryA.blobPath] == dataA)
+        #expect(mock.files[entryB.blobPath] == dataB)
+        // Metadata ZIP also uploaded.
+        #expect(mock.files.keys.contains(where: { $0.contains(".vreader.zip") }))
+    }
+
+    @Test func backup_secondTime_dedupesBlobsViaPROPFIND() async throws {
+        let data = Data([0x50, 0x4B, 0x03, 0x04]) + Data(repeating: 0xCC, count: 256)
+        let entry = Self.entry(data, format: .epub)
+        let (provider, mock, _) = try await Self.makeRig(entries: [(data, entry)])
+
+        // First backup: blob is uploaded.
+        _ = try await provider.backup { _ in }
+        let firstPutCount = mock.methodCalls.filter { $0.method == "PUT" }.count
+
+        mock.methodCalls.removeAll()
+        // Second backup: blob already at canonical path, should be skipped.
+        _ = try await provider.backup { _ in }
+        let secondBlobPuts = mock.methodCalls
+            .filter { $0.method == "PUT" && $0.path == entry.blobPath }
+            .count
+        let secondTempPuts = mock.methodCalls
+            .filter { $0.method == "PUT" && $0.path.contains("uploads/tmp/") }
+            .count
+        // Confirms: first round had at least one PUT (temp blob upload).
+        #expect(firstPutCount >= 1)
+        // Second round: zero blob PUTs at the final path AND zero temp PUTs.
+        // The metadata ZIP still gets a PUT, but it's at the backups path.
+        #expect(secondBlobPuts == 0)
+        #expect(secondTempPuts == 0)
+    }
 }
 
 // MARK: - Mock Data Collector


### PR DESCRIPTION
Refs #144. Integrates BackupBlobStore into the backup flow. Each book gets bytes published atomically (temp PUT → PROPFIND-verify → MOVE). Repeat backups dedupe via PROPFIND. 2 new tests, all 35 provider suite tests GREEN.