### PR TITLE
feat(#46): WI-8 — WebDAVProvider.restore materializes books from manifest

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 29
-        MARKETING_VERSION: 3.10.28
+        CURRENT_PROJECT_VERSION: 30
+        MARKETING_VERSION: 3.10.29
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3810,13 +3810,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.28;
+				MARKETING_VERSION = 3.10.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3960,13 +3960,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.28;
+				MARKETING_VERSION = 3.10.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Backup/WebDAVProvider.swift
+++ b/vreader/Services/Backup/WebDAVProvider.swift
@@ -83,8 +83,19 @@ final class WebDAVProvider: BackupProvider, @unchecked Sendable {
     /// Defaults to the production resolver shared with `BookFileMaterializer`.
     private let sandboxResolver: SandboxURLResolver
 
+    /// Optional importer used by feature #46 (WI-8) to materialize books
+    /// from manifest blobs during restore. Nil → manifest-extended restore
+    /// is skipped (v1-format backups still restore as today).
+    private let bookImporter: (any BookImporting)?
+
+    /// Temp directory for restore-side blob downloads before BookImporter
+    /// adopts them. Created under `FileManager.default.temporaryDirectory`
+    /// by default.
+    private let materializeTempDirectory: URL
+
     /// Blob store wrapping the same transport. Used by feature #46 to publish
-    /// content-addressed book blobs atomically (PUT-tmp → PROPFIND-verify → MOVE).
+    /// content-addressed book blobs atomically (PUT-tmp → PROPFIND-verify → MOVE)
+    /// and to read blobs during materializing restore.
     private let blobStore: WebDAVBlobStore
 
     /// In-memory cache of known backup metadata, keyed by ID.
@@ -96,7 +107,10 @@ final class WebDAVProvider: BackupProvider, @unchecked Sendable {
         dataRestorer: BackupDataRestoring,
         deviceName: String,
         appVersion: String,
-        sandboxResolver: @escaping SandboxURLResolver = BookFileMaterializer.defaultSandboxResolver
+        sandboxResolver: @escaping SandboxURLResolver = BookFileMaterializer.defaultSandboxResolver,
+        bookImporter: (any BookImporting)? = nil,
+        materializeTempDirectory: URL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VReaderRestore", isDirectory: true)
     ) {
         self.transport = transport
         self.dataCollector = dataCollector
@@ -104,6 +118,8 @@ final class WebDAVProvider: BackupProvider, @unchecked Sendable {
         self.deviceName = deviceName
         self.appVersion = appVersion
         self.sandboxResolver = sandboxResolver
+        self.bookImporter = bookImporter
+        self.materializeTempDirectory = materializeTempDirectory
         self.blobStore = WebDAVBlobStore(transport: transport)
     }
 
@@ -291,11 +307,37 @@ final class WebDAVProvider: BackupProvider, @unchecked Sendable {
 
         progress(0.55)
 
-        // Apply restored data to local database via BackupDataRestoring delegate.
-        // Each file is optional — missing entries are silently skipped (forward compatibility).
-        // Each tuple: (zip filename, user-facing section label, restore fn).
-        // The label is what shows up in BackupError.restorePartiallyFailed —
-        // it must not leak internal filenames.
+        // Phase A — feature #46 (WI-8): if the ZIP carries library-manifest.json
+        // AND this provider was constructed with a BookImporter, materialize
+        // missing book blobs into the local sandbox BEFORE applying metadata
+        // sections. Older v1-format backups (no manifest) skip this phase
+        // and restore exactly as today.
+        var materializeFailedTitles: [String] = []
+        if let importer = bookImporter,
+           let manifestData = try? ZIPWriter.extractEntry(named: "library-manifest.json", from: zipData),
+           let manifest = decodeManifest(manifestData),
+           !manifest.books.isEmpty {
+            let materializer = BookFileMaterializer(
+                blobStore: blobStore,
+                importer: importer,
+                tempDirectory: materializeTempDirectory,
+                resolveSandboxURL: sandboxResolver
+            )
+            let results = await materializer.materialize(
+                manifest.books
+            ) { fraction in
+                // Allocate 0.55 → 0.75 to materialization. The remaining
+                // metadata-section restore consumes 0.75 → 1.0.
+                progress(0.55 + 0.20 * fraction)
+            }
+            for result in results where !result.isSuccess {
+                materializeFailedTitles.append(result.entry.title ?? result.entry.fingerprintKey)
+            }
+        }
+
+        // Phase B — apply restored data to local database via BackupDataRestoring.
+        // Each file is optional; missing entries are silently skipped.
+        // Per-section errors don't abort the loop.
         let restoreFiles: [(filename: String, label: String, fn: (Data) async throws -> Void)] = [
             ("annotations.json", "annotations", dataRestorer.restoreAnnotations),
             ("positions.json", "reading positions", dataRestorer.restorePositions),
@@ -306,6 +348,8 @@ final class WebDAVProvider: BackupProvider, @unchecked Sendable {
             ("replacement-rules.json", "replacement rules", dataRestorer.restoreReplacementRules),
         ]
 
+        let restorePhaseStart = (bookImporter != nil) ? 0.75 : 0.55
+        let restorePhaseSpan = 1.0 - restorePhaseStart
         let totalFiles = Double(restoreFiles.count)
         var failedLabels: [String] = []
         for (index, item) in restoreFiles.enumerated() {
@@ -313,20 +357,32 @@ final class WebDAVProvider: BackupProvider, @unchecked Sendable {
                 do {
                     try await item.fn(entryData)
                 } catch {
-                    // Per-section restore errors don't abort the loop —
-                    // restoring the remaining sections is more useful than
-                    // bailing out and leaving the user with a half-applied
-                    // archive that's hard to reason about.
                     failedLabels.append(item.label)
                 }
             }
-            progress(0.55 + 0.40 * Double(index + 1) / totalFiles)
+            progress(restorePhaseStart + restorePhaseSpan * Double(index + 1) / totalFiles)
         }
 
         progress(1.0)
+
+        // Surface partial failures from EITHER phase so the user knows what
+        // didn't make it. Materialization failures are reported separately
+        // from metadata-section failures (different failure classes).
+        if !materializeFailedTitles.isEmpty {
+            throw BackupError.restorePartiallyFailed(
+                "books not materialized: \(materializeFailedTitles.joined(separator: ", "))"
+                + (failedLabels.isEmpty ? "" : "; sections: \(failedLabels.joined(separator: ", "))")
+            )
+        }
         if !failedLabels.isEmpty {
             throw BackupError.restorePartiallyFailed(failedLabels.joined(separator: ", "))
         }
+    }
+
+    private func decodeManifest(_ data: Data) -> BackupLibraryManifestEnvelope? {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(BackupLibraryManifestEnvelope.self, from: data)
     }
 
     func listBackups() async throws -> [BackupMetadata] {

--- a/vreaderTests/Services/Backup/WebDAVProviderTests.swift
+++ b/vreaderTests/Services/Backup/WebDAVProviderTests.swift
@@ -236,6 +236,98 @@ struct WebDAVProviderBackupWithManifestTests {
         #expect(secondBlobPuts == 0)
         #expect(secondTempPuts == 0)
     }
+
+    // MARK: - Feature #46 (WI-8) — restore materializes blobs when manifest present
+
+    @Test func restore_withManifestAndImporter_materializesMissingBooks() async throws {
+        let dataA = Data([0x50, 0x4B, 0x03, 0x04]) + Data(repeating: 0xA1, count: 256)
+        let dataB = Data([0x50, 0x4B, 0x03, 0x04]) + Data(repeating: 0xB1, count: 384)
+        let entryA = Self.entry(dataA, format: .epub)
+        let entryB = Self.entry(dataB, format: .epub)
+
+        // Backup: first build the ZIP + upload blobs to a server using a
+        // backup-side rig (separate sandbox containing the source files).
+        let (backupProvider, backupTransport, _) = try await Self.makeRig(
+            entries: [(dataA, entryA), (dataB, entryB)]
+        )
+        _ = try await backupProvider.backup { _ in }
+
+        // Restore-side: fresh empty sandbox, inject the production
+        // BookImporter+MockPersistenceActor so we can verify books land.
+        let restoreSandbox = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restore-sandbox-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: restoreSandbox, withIntermediateDirectories: true)
+        let mockPersistence = MockPersistenceActor()
+        let bookImporter = BookImporter(persistence: mockPersistence, sandboxBooksDirectory: restoreSandbox)
+
+        let restoreResolver: SandboxURLResolver = { fingerprintKey, originalExtension in
+            let safeName = fingerprintKey.replacingOccurrences(of: ":", with: "_")
+            return restoreSandbox.appendingPathComponent(safeName).appendingPathExtension(originalExtension)
+        }
+
+        // Use the SAME mock transport (so the blobs uploaded in backup phase
+        // are visible to restore). Also replay listBackups to populate the
+        // metadataCache before calling restore.
+        let restoreProvider = WebDAVProvider(
+            transport: backupTransport,
+            dataCollector: StubCollector(manifestEntries: []),  // unused in restore
+            dataRestorer: NoopRestorer(),
+            deviceName: "TestDevice",
+            appVersion: "test",
+            sandboxResolver: restoreResolver,
+            bookImporter: bookImporter,
+            materializeTempDirectory: FileManager.default.temporaryDirectory
+                .appendingPathComponent("restore-temp-\(UUID().uuidString)")
+        )
+        let backups = try await restoreProvider.listBackups()
+        guard let backupId = backups.first?.id else {
+            Issue.record("no backup metadata returned")
+            return
+        }
+
+        try await restoreProvider.restore(backupId: backupId) { _ in }
+
+        // Both books were imported into MockPersistenceActor.
+        let storedA = await mockPersistence.book(forKey: entryA.fingerprintKey)
+        let storedB = await mockPersistence.book(forKey: entryB.fingerprintKey)
+        #expect(storedA != nil)
+        #expect(storedB != nil)
+        #expect(storedA?.originalExtension == entryA.originalExtension)
+    }
+
+    @Test func restore_v1FormatBackup_skipsMaterializationGracefully() async throws {
+        // Build a v1-format ZIP (no library-manifest.json). Restore should
+        // succeed without trying to materialize anything, even with an
+        // importer wired in.
+        let mock = MockWebDAVTransport()
+        let collector = StubCollector(manifestEntries: [])
+        // Provider that DOES inject an importer — but the backup ZIP it
+        // produces will still include library-manifest.json (with empty books).
+        // To simulate a true v1 format, we backup with the empty-manifest path
+        // then verify restore doesn't crash + doesn't try to fetch any blobs.
+        let restoreSandbox = FileManager.default.temporaryDirectory
+            .appendingPathComponent("v1-sandbox-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: restoreSandbox, withIntermediateDirectories: true)
+        let mockPersistence = MockPersistenceActor()
+        let bookImporter = BookImporter(persistence: mockPersistence, sandboxBooksDirectory: restoreSandbox)
+        let provider = WebDAVProvider(
+            transport: mock,
+            dataCollector: collector,
+            dataRestorer: NoopRestorer(),
+            deviceName: "TestDevice",
+            appVersion: "test",
+            bookImporter: bookImporter
+        )
+
+        // Empty backup (no books → empty manifest).
+        let metadata = try await provider.backup { _ in }
+        try await provider.restore(backupId: metadata.id) { _ in }
+        // Restore completed without error and didn't try to materialize.
+        let materializeCalls = mock.methodCalls.filter {
+            $0.path.hasPrefix("VReader/books/")
+        }
+        #expect(materializeCalls.isEmpty)
+    }
 }
 
 // MARK: - Mock Data Collector


### PR DESCRIPTION
Refs #144. Closes the backup→restore round-trip. When manifest + importer present, restore materializes blobs before applying metadata. v1-format backups still restore as before. 2 new tests, all 37 provider tests GREEN.