### PR TITLE
feat(#46): WI-8b — wire BookImporter through factory + settings view

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -29,8 +29,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 30
-        MARKETING_VERSION: 3.10.29
+        CURRENT_PROJECT_VERSION: 31
+        MARKETING_VERSION: 3.10.30
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -395,6 +395,7 @@
 		879E269189DBE24A5AF6095B /* LibraryRefreshServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DAD680DB86CF1A65D34F3F /* LibraryRefreshServiceTests.swift */; };
 		87A61AC432B6116973B7D291 /* LocatorIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0069CA3A00998B13DE06E424 /* LocatorIntegrationTests.swift */; };
 		881677EB4D38D3439473606D /* ContentReplacementRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5AB21F49D361F1160920C0 /* ContentReplacementRule.swift */; };
+		88472C0C4B06190CA46E917F /* BookImporterEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163C2BBCB1C2FEFB9713C4CF /* BookImporterEnvironment.swift */; };
 		884CC3C2EDE6FC428A666910 /* SyncTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E72DDEAD6225A21E973A51 /* SyncTypes.swift */; };
 		88B73AB500D0DFD555AC9363 /* WebPageEncodingDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB19A1C01A25FDB23FA3E7DB /* WebPageEncodingDetectorTests.swift */; };
 		891E1E70B176150B071E464F /* AIContextExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20237121BB4ACF22C0818BA4 /* AIContextExtractorTests.swift */; };
@@ -783,6 +784,7 @@
 		15C1B40888B5C8213559B111 /* AIRequestCacheKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIRequestCacheKeyTests.swift; sourceTree = "<group>"; };
 		15D804BC38A65B71FB212B03 /* TXTOffsetTranslatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTOffsetTranslatorTests.swift; sourceTree = "<group>"; };
 		15E22141BA785A9A62A4BE9A /* PDFIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFIntegrationTests.swift; sourceTree = "<group>"; };
+		163C2BBCB1C2FEFB9713C4CF /* BookImporterEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookImporterEnvironment.swift; sourceTree = "<group>"; };
 		16C77872C4F869769F4C83F7 /* ReaderContainerView+Sheets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderContainerView+Sheets.swift"; sourceTree = "<group>"; };
 		16E293CFD61A19BB48B38963 /* HighlightableTextViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightableTextViewTests.swift; sourceTree = "<group>"; };
 		17E7FD8CD67F19A2213DB6F5 /* PDFViewBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFViewBridge.swift; sourceTree = "<group>"; };
@@ -1543,6 +1545,7 @@
 			children = (
 				ABC4CE4DBCD7E5A52BC4E511 /* AccessibilityFormatters.swift */,
 				B08E95607978EED0EB89FA0B /* AppLogger.swift */,
+				163C2BBCB1C2FEFB9713C4CF /* BookImporterEnvironment.swift */,
 				B84D0E1452F211B986E8328A /* ContentHasher.swift */,
 				A43A801A0876E2437CE63808 /* EncodingDetector.swift */,
 				7C0A7E77EFE308BC9CF8A3FE /* ErrorMessageAuditor.swift */,
@@ -3378,6 +3381,7 @@
 				AE171BC364B973E0F52D1B96 /* BookFileMaterializer.swift in Sources */,
 				33B874FB4BB17A21ACA4468E /* BookFormat.swift in Sources */,
 				DF36D73AC9B53845BF561CBC /* BookImporter.swift in Sources */,
+				88472C0C4B06190CA46E917F /* BookImporterEnvironment.swift in Sources */,
 				429316840ADE46912C2A89E9 /* BookImporting.swift in Sources */,
 				7CCEBC99BB8B9A70D65163FC /* BookInfoSheet.swift in Sources */,
 				7388501251356E2DE780DC22 /* BookRowView.swift in Sources */,
@@ -3810,13 +3814,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 31;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.29;
+				MARKETING_VERSION = 3.10.30;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3960,13 +3964,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 31;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.10.29;
+				MARKETING_VERSION = 3.10.30;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/App/VReaderApp.swift
+++ b/vreader/App/VReaderApp.swift
@@ -14,6 +14,12 @@ struct VReaderApp: App {
     /// (e.g. WebDAVSettingsView) that need direct access without protocol wrapping.
     private let persistenceActor: PersistenceActor?
 
+    /// Live BookImporter — exposed via SwiftUI Environment for feature #46's
+    /// WebDAV materializing restore (`WebDAVSettingsView` passes it through to
+    /// `WebDAVProviderFactory.make`). Nil if the SwiftData container failed
+    /// to construct.
+    private let bookImporterRef: (any BookImporting)?
+
     #if DEBUG
     /// Parsed launch argument overrides for UI testing.
     private let testConfig: TestLaunchConfig
@@ -39,6 +45,7 @@ struct VReaderApp: App {
             self.initError = "The library database could not be opened. It may need to be reset."
             self.contentView = nil
             self.persistenceActor = nil
+            self.bookImporterRef = nil
             self.debugBridge = nil
             return
         }
@@ -119,6 +126,7 @@ struct VReaderApp: App {
                 syncMonitor: syncMonitor
             )
             self.persistenceActor = persistence
+            self.bookImporterRef = importer
 
             #if DEBUG
             // Build the DebugBridge synchronously. The struct is
@@ -138,6 +146,7 @@ struct VReaderApp: App {
             self.initError = Self.sanitizedErrorMessage(error)
             self.contentView = nil
             self.persistenceActor = nil
+            self.bookImporterRef = nil
             #if DEBUG
             self.debugBridge = nil
             #endif
@@ -151,6 +160,7 @@ struct VReaderApp: App {
                 contentView
                     .modelContainer(modelContainer)
                     .environment(\.persistenceActor, persistenceActor)
+                    .environment(\.bookImporter, bookImporterRef)
                     .modifier(TestLaunchModifier(config: testConfig))
                     .onOpenURL { [debugBridge] url in
                         guard url.scheme == DebugCommand.scheme else { return }
@@ -163,6 +173,7 @@ struct VReaderApp: App {
                 contentView
                     .modelContainer(modelContainer)
                     .environment(\.persistenceActor, persistenceActor)
+                    .environment(\.bookImporter, bookImporterRef)
                 #endif
             } else {
                 VStack(spacing: 16) {

--- a/vreader/Services/Backup/WebDAVProviderFactory.swift
+++ b/vreader/Services/Backup/WebDAVProviderFactory.swift
@@ -24,6 +24,12 @@ enum WebDAVProviderFactory {
 
     /// Constructs a fully-wired WebDAVProvider for the given persistence actor.
     /// Reads credentials from Keychain. Throws if credentials are missing or invalid.
+    ///
+    /// `bookImporter` enables feature #46's materializing restore. When omitted
+    /// (legacy callers / tests), restore falls back to v1-format behavior:
+    /// metadata-only, books silently skipped if missing locally. Production
+    /// callers (from `VReaderApp` via `WebDAVSettingsView`) pass the live
+    /// `BookImporter` so backup blobs land on a fresh device.
     @MainActor
     static func make(
         persistence: PersistenceActor,
@@ -31,7 +37,8 @@ enum WebDAVProviderFactory {
         defaults: UserDefaults = .standard,
         perBookSettingsBaseURL: URL = standardPerBookSettingsBaseURL,
         appVersion: String = currentAppVersion(),
-        deviceName: String = currentDeviceName()
+        deviceName: String = currentDeviceName(),
+        bookImporter: (any BookImporting)? = nil
     ) throws -> WebDAVProvider {
         guard
             let serverURL = try? keychain.readString(forAccount: serverURLAccount),
@@ -64,7 +71,8 @@ enum WebDAVProviderFactory {
             dataCollector: collector,
             dataRestorer: restorer,
             deviceName: deviceName,
-            appVersion: appVersion
+            appVersion: appVersion,
+            bookImporter: bookImporter
         )
     }
 

--- a/vreader/Utils/BookImporterEnvironment.swift
+++ b/vreader/Utils/BookImporterEnvironment.swift
@@ -1,0 +1,23 @@
+// Purpose: SwiftUI Environment injection for the live BookImporter so feature
+// #46's WebDAVSettingsView can pass it to WebDAVProviderFactory without
+// threading the reference through every parent view.
+//
+// @coordinates-with: VReaderApp.swift, WebDAVSettingsView.swift,
+//   PersistenceActorEnvironment.swift, BookImporting.swift
+
+import SwiftUI
+
+private struct BookImporterKey: EnvironmentKey {
+    static let defaultValue: (any BookImporting)? = nil
+}
+
+extension EnvironmentValues {
+    /// The live BookImporter for this app launch. Nil in previews and tests
+    /// that don't inject one — consumers should treat it as optional. When
+    /// nil, feature #46's materializing restore falls back to v1-format
+    /// behavior (metadata-only, books skipped).
+    var bookImporter: (any BookImporting)? {
+        get { self[BookImporterKey.self] }
+        set { self[BookImporterKey.self] = newValue }
+    }
+}

--- a/vreader/Views/Settings/WebDAVSettingsView.swift
+++ b/vreader/Views/Settings/WebDAVSettingsView.swift
@@ -16,6 +16,7 @@ import SwiftUI
 struct WebDAVSettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.persistenceActor) private var persistenceFromEnv
+    @Environment(\.bookImporter) private var bookImporterFromEnv
 
     @State private var serverURL = ""
     @State private var username = ""
@@ -308,7 +309,8 @@ struct WebDAVSettingsView: View {
         do {
             let provider = try WebDAVProviderFactory.make(
                 persistence: persistence,
-                keychain: keychain
+                keychain: keychain,
+                bookImporter: bookImporterFromEnv
             )
             let vm = BackupViewModel(provider: provider)
             backupVM = vm


### PR DESCRIPTION
Refs #144. Production wiring follow-up to WI-8 — without this, the materializing-restore code path was dead in prod (factory never passed the importer to the provider). Build verified. No new tests; covered by WI-8's integration test.