### PR TITLE
feat(#49): WI-0 — grammar reconciliation (reject legacy ?cfi=)

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 42
-        MARKETING_VERSION: 3.11.10
+        CURRENT_PROJECT_VERSION: 43
+        MARKETING_VERSION: 3.11.11
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3826,13 +3826,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.10;
+				MARKETING_VERSION = 3.11.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3976,13 +3976,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 43;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.10;
+				MARKETING_VERSION = 3.11.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/DebugBridge/DebugCommand.swift
+++ b/vreader/Services/DebugBridge/DebugCommand.swift
@@ -12,7 +12,11 @@ import Foundation
 ///
 /// - `reset` — wipe library and reset settings.
 /// - `seed?fixture=<name>` — seed a bundled fixture book.
-/// - `open?bookId=<uuid>[&cfi=<position>]` — open a book at an optional position.
+/// - `open?bookId=<uuid>[&position=<value>]` — open a book at an optional
+///   position. Position format depends on the book format; a future feature
+///   #49 WI ships a `DebugPositionResolver` for native-mode TXT/EPUB/PDF.
+///   The legacy `?cfi=<value>` parameter is rejected — feature #49 WI-0
+///   reconciled the grammar to use `position` consistently across all formats.
 /// - `theme?mode=<dark|light>[&fontSize=<int>]` — set appearance state.
 /// - `settle?token=<id>` — write `Caches/ready-<id>.json` after layout settles.
 /// - `snapshot?dest=<file>` — write semantic state JSON to the app container.
@@ -75,8 +79,15 @@ extension DebugCommand {
             let bookId = try requireParam("bookId", in: params)
             // Parameter is named `position` to match the documented grammar
             // and the public `DebugCommand.open(bookId:position:)` shape.
-            // (Earlier draft used `cfi`; renamed for consistency with the
-            // doc and the universal-position concept used elsewhere.)
+            // Reject the legacy `cfi` parameter explicitly so any caller still
+            // using the old grammar gets a clear error rather than silently
+            // opening at the start (feature #49 WI-0 grammar reconciliation).
+            if params["cfi"] != nil {
+                throw DebugCommandError.invalidParam(
+                    "cfi",
+                    reason: "Use 'position' — 'cfi' was renamed in feature #49 WI-0 grammar reconciliation"
+                )
+            }
             let position = nonEmpty(params["position"])
             return .open(bookId: bookId, position: position)
 

--- a/vreaderTests/Services/DebugBridge/DebugCommandTests.swift
+++ b/vreaderTests/Services/DebugBridge/DebugCommandTests.swift
@@ -70,6 +70,39 @@ final class DebugCommandTests: XCTestCase {
         XCTAssertEqual(cmd, .open(bookId: bookId, position: nil))
     }
 
+    // MARK: - feature #49 WI-0 grammar reconciliation
+
+    func test_parse_openWithLegacyCFIParam_throwsInvalidParam() {
+        // The legacy `cfi=` parameter was renamed to `position=` in feature
+        // #49's grammar-reconciliation WI. Any caller still using `cfi` must
+        // get a clear error rather than silently opening at the start —
+        // otherwise verification flows that pass `cfi=...` would think the
+        // open succeeded when actually the position was dropped.
+        let bookId = "550e8400-e29b-41d4-a716-446655440000"
+        let url = URL(string: "vreader-debug://open?bookId=\(bookId)&cfi=foo")!
+        XCTAssertThrowsError(try DebugCommand.parse(url)) { error in
+            guard case DebugCommandError.invalidParam(let name, _) = error else {
+                XCTFail("expected invalidParam, got \(error)")
+                return
+            }
+            XCTAssertEqual(name, "cfi")
+        }
+    }
+
+    func test_parse_openWithCFIAndPosition_throwsInvalidParam() {
+        // If both `cfi` and `position` are supplied, the legacy `cfi` still
+        // takes precedence as the rejection — caller must remove `cfi`.
+        let bookId = "550e8400-e29b-41d4-a716-446655440000"
+        let url = URL(string: "vreader-debug://open?bookId=\(bookId)&cfi=foo&position=bar")!
+        XCTAssertThrowsError(try DebugCommand.parse(url)) { error in
+            guard case DebugCommandError.invalidParam(let name, _) = error else {
+                XCTFail("expected invalidParam, got \(error)")
+                return
+            }
+            XCTAssertEqual(name, "cfi")
+        }
+    }
+
     func test_parse_openMissingBookId_throwsMissingParam() {
         let url = URL(string: "vreader-debug://open")!
         XCTAssertThrowsError(try DebugCommand.parse(url)) { error in


### PR DESCRIPTION
Refs #171. Plan v4 WI-0: DocC update + parser explicitly rejects `cfi=` parameter. 2 new regression tests + existing tests pass.