### PR TITLE
feat(#49): WI-1 — DebugSnapshot schema v2 + probe protocol v2

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 43
-        MARKETING_VERSION: 3.11.11
+        CURRENT_PROJECT_VERSION: 44
+        MARKETING_VERSION: 3.11.12
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3826,13 +3826,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 43;
+				CURRENT_PROJECT_VERSION = 44;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.11;
+				MARKETING_VERSION = 3.11.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3976,13 +3976,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 43;
+				CURRENT_PROJECT_VERSION = 44;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.11;
+				MARKETING_VERSION = 3.11.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/DebugBridge/DebugReaderRegistry.swift
+++ b/vreader/Services/DebugBridge/DebugReaderRegistry.swift
@@ -37,7 +37,57 @@ protocol DebugReaderProbe: AnyObject {
     /// JSONSerialization so the bridge can splat the value into eval
     /// output without double-encoding.
     func evaluateJavaScript(_ script: String) async throws -> Data
+
+    // MARK: - Schema v2 accessors (feature #49 WI-1)
+    //
+    // These are default-implemented so existing adopters (e.g.
+    // `DebugReaderProbeAdapter`) compile without changes. Per-format hosts
+    // override when they have richer state to surface (feature #50 will wire
+    // these for the per-format snapshot enrichment).
+
+    /// Current TTS state name (`DebugSnapshot.TTSStateValue`). Nil means no
+    /// TTS state available — either no service wired, or the host doesn't
+    /// surface TTS yet.
+    var currentTTSState: String? { get }
+
+    /// Current TTS UTF-16 offset within the active book. Nil when not in a
+    /// TTS-capable state.
+    var currentTTSOffsetUTF16: Int? { get }
+
+    /// Render phase name (`DebugSnapshot.RenderPhaseValue`). Default is
+    /// `idle`; per-format hosts override during loading / rendering / settle
+    /// transitions.
+    var currentRenderPhase: String { get }
+
+    /// Settings provenance — `"global"` or `"perBook"` from
+    /// `DebugSnapshot.SettingsProvenanceValue`. Nil when the host doesn't
+    /// surface this distinction yet.
+    var currentSettingsProvenance: String? { get }
 }
+
+// Default implementations so existing adopters compile without per-host
+// changes. Per-format hosts (TXT/EPUB/Foliate/PDF) override during
+// feature #50 to wire real values.
+extension DebugReaderProbe {
+    var currentTTSState: String? { nil }
+    var currentTTSOffsetUTF16: Int? { nil }
+    var currentRenderPhase: String { DebugSnapshot.RenderPhaseValue.idle }
+    var currentSettingsProvenance: String? { nil }
+}
+
+#if DEBUG
+// DEBUG-only mapping from TTSService.State to the snapshot wire value.
+// Lives next to the protocol because both are DEBUG-only.
+extension TTSService.State {
+    var publicName: String {
+        switch self {
+        case .idle:     return DebugSnapshot.TTSStateValue.idle
+        case .speaking: return DebugSnapshot.TTSStateValue.speaking
+        case .paused:   return DebugSnapshot.TTSStateValue.paused
+        }
+    }
+}
+#endif
 
 /// Errors thrown by `DebugReaderProbe.evaluateJavaScript`.
 enum DebugReaderProbeError: Error, Equatable {

--- a/vreader/Services/DebugBridge/DebugSnapshot.swift
+++ b/vreader/Services/DebugBridge/DebugSnapshot.swift
@@ -19,6 +19,8 @@ import Foundation
 /// authoritative.
 struct DebugSnapshot: Codable, Equatable {
     /// Schema version. Increment on field add/remove/semantics-change.
+    /// **v2 (feature #49 WI-1)**: adds `ttsState`, `ttsOffsetUTF16`,
+    /// `settingsProvenance`. Existing v1 fields unchanged.
     let schemaVersion: Int
     let ts: String
     let currentBookId: String?
@@ -28,8 +30,29 @@ struct DebugSnapshot: Codable, Equatable {
     let fontSize: Int?
     let selection: SelectionInfo?
     let highlightCount: Int
+    /// Render phase the active reader reports. Wire values are pinned to
+    /// match `RenderPhaseValue` constants below — `idle` is the canonical
+    /// "rendered + no in-flight work" state.
     let renderPhase: String
     let lastError: String?
+
+    // MARK: - Schema v2 additions (feature #49 WI-1)
+
+    /// Current TTS state ("idle" / "speaking" / "paused"). Nil if no TTS
+    /// service has yet been wired into the snapshot capture context.
+    let ttsState: String?
+
+    /// Current TTS UTF-16 offset within the active book. Nil when not in a
+    /// TTS-capable state, or when no service is wired. The deliberately
+    /// limited surface (no sentence index) is documented in feature #49's
+    /// plan as a phase-1 simplification.
+    let ttsOffsetUTF16: Int?
+
+    /// Whether the active reader's settings are sourced from per-book
+    /// overrides ("perBook") or the global store ("global"). Nil when no
+    /// reader is active or the provenance information isn't available.
+    let settingsProvenance: String?
+
     /// Field names whose nil value in this snapshot means "not yet
     /// implemented" rather than "no value". Empty/nil array means every
     /// nil field is authoritative.
@@ -37,13 +60,96 @@ struct DebugSnapshot: Codable, Equatable {
 
     /// Current schema version. Update with care — consumers may pin a
     /// version they recognize.
-    static let currentSchemaVersion = 1
+    static let currentSchemaVersion = 2
+
+    /// Stable wire values for `renderPhase`. Tests + consumers pin against
+    /// these constants instead of free-form strings.
+    enum RenderPhaseValue {
+        static let idle = "idle"
+        static let loading = "loading"
+        static let rendering = "rendering"
+        static let settled = "settled"
+    }
+
+    /// Stable wire values for `ttsState`. Mirrors `TTSService.State`'s
+    /// internal cases via the DEBUG-only `publicName` extension shipped
+    /// alongside this WI.
+    enum TTSStateValue {
+        static let idle = "idle"
+        static let speaking = "speaking"
+        static let paused = "paused"
+    }
+
+    /// Stable wire values for `settingsProvenance`.
+    enum SettingsProvenanceValue {
+        static let global = "global"
+        static let perBook = "perBook"
+    }
 
     /// Selected text in the active reader, if any.
     struct SelectionInfo: Codable, Equatable {
         let text: String
         let startOffset: Int
         let endOffset: Int
+    }
+
+    /// Explicit init with v2 fields defaulted so existing call sites don't
+    /// have to thread three new parameters through. New consumers (per-format
+    /// hosts in feature #50) populate the v2 fields by name.
+    init(
+        schemaVersion: Int,
+        ts: String,
+        currentBookId: String?,
+        format: String?,
+        position: String?,
+        theme: String?,
+        fontSize: Int?,
+        selection: SelectionInfo?,
+        highlightCount: Int,
+        renderPhase: String,
+        lastError: String?,
+        partial: [String]?,
+        ttsState: String? = nil,
+        ttsOffsetUTF16: Int? = nil,
+        settingsProvenance: String? = nil
+    ) {
+        self.schemaVersion = schemaVersion
+        self.ts = ts
+        self.currentBookId = currentBookId
+        self.format = format
+        self.position = position
+        self.theme = theme
+        self.fontSize = fontSize
+        self.selection = selection
+        self.highlightCount = highlightCount
+        self.renderPhase = renderPhase
+        self.lastError = lastError
+        self.partial = partial
+        self.ttsState = ttsState
+        self.ttsOffsetUTF16 = ttsOffsetUTF16
+        self.settingsProvenance = settingsProvenance
+    }
+
+    /// Decoder must accept v1 archives (which lack the v2 fields). Treat
+    /// missing v2 fields as nil so the schema-bump is read-compatible —
+    /// useful for tests that pin against a v1 fixture file.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.schemaVersion = try c.decode(Int.self, forKey: .schemaVersion)
+        self.ts = try c.decode(String.self, forKey: .ts)
+        self.currentBookId = try c.decodeIfPresent(String.self, forKey: .currentBookId)
+        self.format = try c.decodeIfPresent(String.self, forKey: .format)
+        self.position = try c.decodeIfPresent(String.self, forKey: .position)
+        self.theme = try c.decodeIfPresent(String.self, forKey: .theme)
+        self.fontSize = try c.decodeIfPresent(Int.self, forKey: .fontSize)
+        self.selection = try c.decodeIfPresent(SelectionInfo.self, forKey: .selection)
+        self.highlightCount = try c.decode(Int.self, forKey: .highlightCount)
+        self.renderPhase = try c.decode(String.self, forKey: .renderPhase)
+        self.lastError = try c.decodeIfPresent(String.self, forKey: .lastError)
+        self.partial = try c.decodeIfPresent([String].self, forKey: .partial)
+        self.ttsState = try c.decodeIfPresent(String.self, forKey: .ttsState)
+        self.ttsOffsetUTF16 = try c.decodeIfPresent(Int.self, forKey: .ttsOffsetUTF16)
+        self.settingsProvenance = try c.decodeIfPresent(String.self, forKey: .settingsProvenance)
     }
 
     /// Encoder configured for stable, byte-comparable output.
@@ -60,6 +166,7 @@ struct DebugSnapshot: Codable, Equatable {
     enum CodingKeys: String, CodingKey {
         case schemaVersion, ts, currentBookId, format, position, theme, fontSize
         case selection, highlightCount, renderPhase, lastError, partial
+        case ttsState, ttsOffsetUTF16, settingsProvenance
     }
 
     /// Custom encoder: emits every field, writing `null` for nil optionals
@@ -78,6 +185,10 @@ struct DebugSnapshot: Codable, Equatable {
         try c.encode(renderPhase, forKey: .renderPhase)
         try Self.encodeOptional(lastError, forKey: .lastError, in: &c)
         try Self.encodeOptional(partial, forKey: .partial, in: &c)
+        // v2 fields (feature #49 WI-1)
+        try Self.encodeOptional(ttsState, forKey: .ttsState, in: &c)
+        try Self.encodeOptional(ttsOffsetUTF16, forKey: .ttsOffsetUTF16, in: &c)
+        try Self.encodeOptional(settingsProvenance, forKey: .settingsProvenance, in: &c)
     }
 
     private static func encodeOptional<T: Encodable>(

--- a/vreaderTests/Services/DebugBridge/DebugSnapshotTests.swift
+++ b/vreaderTests/Services/DebugBridge/DebugSnapshotTests.swift
@@ -10,6 +10,155 @@ import XCTest
 
 final class DebugSnapshotTests: XCTestCase {
 
+    // MARK: - Feature #49 WI-1 schema v2
+
+    func test_currentSchemaVersion_isV2() {
+        // Tests + consumers pin on this constant when validating that they
+        // read a schema they understand.
+        XCTAssertEqual(DebugSnapshot.currentSchemaVersion, 2)
+    }
+
+    func test_v2Init_defaultsTtsAndProvenanceFieldsToNil() {
+        // Existing call sites construct snapshots without the v2 params;
+        // the explicit init's defaults must hold so we don't break them.
+        let snap = DebugSnapshot(
+            schemaVersion: 2,
+            ts: "2026-05-02T10:00:00Z",
+            currentBookId: nil,
+            format: nil,
+            position: nil,
+            theme: nil,
+            fontSize: nil,
+            selection: nil,
+            highlightCount: 0,
+            renderPhase: DebugSnapshot.RenderPhaseValue.idle,
+            lastError: nil,
+            partial: nil
+        )
+        XCTAssertNil(snap.ttsState)
+        XCTAssertNil(snap.ttsOffsetUTF16)
+        XCTAssertNil(snap.settingsProvenance)
+    }
+
+    func test_v2Init_acceptsAllNewFields() {
+        let snap = DebugSnapshot(
+            schemaVersion: 2,
+            ts: "2026-05-02T10:00:00Z",
+            currentBookId: "bk",
+            format: "txt",
+            position: "0",
+            theme: "light",
+            fontSize: 16,
+            selection: nil,
+            highlightCount: 0,
+            renderPhase: DebugSnapshot.RenderPhaseValue.idle,
+            lastError: nil,
+            partial: nil,
+            ttsState: DebugSnapshot.TTSStateValue.speaking,
+            ttsOffsetUTF16: 1024,
+            settingsProvenance: DebugSnapshot.SettingsProvenanceValue.perBook
+        )
+        XCTAssertEqual(snap.ttsState, "speaking")
+        XCTAssertEqual(snap.ttsOffsetUTF16, 1024)
+        XCTAssertEqual(snap.settingsProvenance, "perBook")
+    }
+
+    func test_encode_v2Snapshot_includesV2Keys() throws {
+        let snap = DebugSnapshot(
+            schemaVersion: 2,
+            ts: "2026-05-02T10:00:00Z",
+            currentBookId: "bk",
+            format: "txt",
+            position: "0",
+            theme: "light",
+            fontSize: 16,
+            selection: nil,
+            highlightCount: 0,
+            renderPhase: DebugSnapshot.RenderPhaseValue.idle,
+            lastError: nil,
+            partial: nil,
+            ttsState: DebugSnapshot.TTSStateValue.speaking,
+            ttsOffsetUTF16: 1024,
+            settingsProvenance: DebugSnapshot.SettingsProvenanceValue.perBook
+        )
+        let dict = try encodeAsDictionary(snap)
+        XCTAssertEqual(dict["ttsState"] as? String, "speaking")
+        XCTAssertEqual(dict["ttsOffsetUTF16"] as? Int, 1024)
+        XCTAssertEqual(dict["settingsProvenance"] as? String, "perBook")
+    }
+
+    func test_encode_v2DefaultsExplicitlyEmitNullForMissing() throws {
+        // Per the snapshot's existing convention, nil optional fields encode
+        // as JSON null (not "absent") so consumers distinguish "absent"
+        // from "unknown". Verify v2 fields honor this.
+        let snap = DebugSnapshot(
+            schemaVersion: 2,
+            ts: "t",
+            currentBookId: nil,
+            format: nil,
+            position: nil,
+            theme: nil,
+            fontSize: nil,
+            selection: nil,
+            highlightCount: 0,
+            renderPhase: DebugSnapshot.RenderPhaseValue.idle,
+            lastError: nil,
+            partial: nil
+        )
+        let data = try DebugSnapshot.encoder.encode(snap)
+        let json = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertTrue(json.contains("\"ttsState\" : null"), "ttsState should encode as null when nil")
+        XCTAssertTrue(json.contains("\"ttsOffsetUTF16\" : null"), "ttsOffsetUTF16 should encode as null when nil")
+        XCTAssertTrue(json.contains("\"settingsProvenance\" : null"), "settingsProvenance should encode as null when nil")
+    }
+
+    func test_decode_v1Archive_setsV2FieldsToNil() throws {
+        // Backward compat: a v1-format JSON snapshot (no v2 keys) must
+        // decode without error, with v2 fields set to nil. Useful for
+        // tests that pin against pre-v2 fixture files.
+        let v1JSON = """
+        {
+          "schemaVersion": 1,
+          "ts": "2026-05-02T10:00:00Z",
+          "currentBookId": null,
+          "format": null,
+          "position": null,
+          "theme": null,
+          "fontSize": null,
+          "selection": null,
+          "highlightCount": 0,
+          "renderPhase": "idle",
+          "lastError": null,
+          "partial": null
+        }
+        """
+        let data = Data(v1JSON.utf8)
+        let snap = try JSONDecoder().decode(DebugSnapshot.self, from: data)
+        XCTAssertEqual(snap.schemaVersion, 1)
+        XCTAssertNil(snap.ttsState)
+        XCTAssertNil(snap.ttsOffsetUTF16)
+        XCTAssertNil(snap.settingsProvenance)
+    }
+
+    func test_renderPhaseValue_constants() {
+        XCTAssertEqual(DebugSnapshot.RenderPhaseValue.idle, "idle")
+        XCTAssertEqual(DebugSnapshot.RenderPhaseValue.loading, "loading")
+        XCTAssertEqual(DebugSnapshot.RenderPhaseValue.rendering, "rendering")
+        XCTAssertEqual(DebugSnapshot.RenderPhaseValue.settled, "settled")
+    }
+
+    func test_ttsStateValue_constants() {
+        XCTAssertEqual(DebugSnapshot.TTSStateValue.idle, "idle")
+        XCTAssertEqual(DebugSnapshot.TTSStateValue.speaking, "speaking")
+        XCTAssertEqual(DebugSnapshot.TTSStateValue.paused, "paused")
+    }
+
+    func test_ttsServiceState_publicName_mapsToWireValues() {
+        XCTAssertEqual(TTSService.State.idle.publicName, DebugSnapshot.TTSStateValue.idle)
+        XCTAssertEqual(TTSService.State.speaking.publicName, DebugSnapshot.TTSStateValue.speaking)
+        XCTAssertEqual(TTSService.State.paused.publicName, DebugSnapshot.TTSStateValue.paused)
+    }
+
     // MARK: - Shape
 
     func test_encode_includesAllRequiredKeys() throws {
@@ -32,6 +181,8 @@ final class DebugSnapshotTests: XCTestCase {
             "schemaVersion", "ts", "currentBookId", "format", "position",
             "theme", "fontSize", "selection", "highlightCount",
             "renderPhase", "lastError", "partial",
+            // v2 (feature #49 WI-1)
+            "ttsState", "ttsOffsetUTF16", "settingsProvenance",
         ]
         XCTAssertEqual(Set(dict.keys), expectedKeys)
     }


### PR DESCRIPTION
Refs #171. Plan v4 WI-1: schemaVersion 1→2, +3 fields (ttsState, ttsOffsetUTF16, settingsProvenance), wire-value constants, v2-protocol-method default impls, v1-archive decode-compat. 10 new tests + existing tests pass.