### PR TITLE
feat(#47): WI-2 — BookRecord + BackupBookProjection gain fileState/blobPath

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 45
-        MARKETING_VERSION: 3.11.13
+        CURRENT_PROJECT_VERSION: 46
+        MARKETING_VERSION: 3.11.14
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3842,13 +3842,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.13;
+				MARKETING_VERSION = 3.11.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3992,13 +3992,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.13;
+				MARKETING_VERSION = 3.11.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/PersistenceActor+Backup.swift
+++ b/vreader/Services/PersistenceActor+Backup.swift
@@ -31,6 +31,13 @@ struct BackupBookProjection: Sendable, Equatable {
     let author: String?
     let addedAt: Date
     let lastOpenedAt: Date?
+    /// Feature #47 WI-2: file-presence state for selective-restore /
+    /// lazy-download UI. Defaults to `.local` for V5-era rows that pre-date
+    /// SchemaV6 (the migration writes `"local"`).
+    let fileState: BookFileState
+    /// Server-side blob path when known (feature #47). Nil for `.local` rows
+    /// that have never been uploaded; populated for `.remoteOnly` rows.
+    let blobPath: String?
 }
 
 extension PersistenceActor {
@@ -61,7 +68,9 @@ extension PersistenceActor {
                 title: book.title,
                 author: book.author,
                 addedAt: book.addedAt,
-                lastOpenedAt: book.lastOpenedAt
+                lastOpenedAt: book.lastOpenedAt,
+                fileState: BookFileState(rawValue: book.fileState) ?? .local,
+                blobPath: book.blobPath
             )
         }
     }

--- a/vreader/Services/PersistenceActor.swift
+++ b/vreader/Services/PersistenceActor.swift
@@ -49,6 +49,15 @@ struct BookRecord: Sendable, Equatable {
     /// When the book was last opened. Read-only mirror of Book.lastOpenedAt;
     /// set by reader open flows, not by insertBook.
     let lastOpenedAt: Date?
+    /// File-presence state (feature #47 WI-1). Defaults to `.local` for
+    /// new imports; remote-only / downloading / failed states are written
+    /// by the lazy-download coordinator (#47 WI-3) and selective restore
+    /// (#47 WI-4).
+    let fileState: BookFileState
+    /// Server-side blob path on the WebDAV backup server (feature #47 WI-1).
+    /// Nil for local-only books that have never been uploaded; populated for
+    /// rows materialized from a backup or pending download.
+    let blobPath: String?
 
     init(
         fingerprintKey: String,
@@ -60,7 +69,9 @@ struct BookRecord: Sendable, Equatable {
         detectedEncoding: String?,
         addedAt: Date,
         originalExtension: String? = nil,
-        lastOpenedAt: Date? = nil
+        lastOpenedAt: Date? = nil,
+        fileState: BookFileState = .local,
+        blobPath: String? = nil
     ) {
         self.fingerprintKey = fingerprintKey
         self.title = title
@@ -72,6 +83,8 @@ struct BookRecord: Sendable, Equatable {
         self.addedAt = addedAt
         self.originalExtension = originalExtension
         self.lastOpenedAt = lastOpenedAt
+        self.fileState = fileState
+        self.blobPath = blobPath
     }
 }
 
@@ -131,6 +144,10 @@ actor PersistenceActor: BookPersisting {
             originalExtension: record.originalExtension
         )
         book.detectedEncoding = record.detectedEncoding
+        // Feature #47 WI-2: write fileState/blobPath if the record overrides
+        // the SwiftData defaults (.local / nil). Most callers use defaults.
+        book.fileState = record.fileState.rawValue
+        book.blobPath = record.blobPath
         context.insert(book)
 
         do {
@@ -175,7 +192,9 @@ actor PersistenceActor: BookPersisting {
             detectedEncoding: book.detectedEncoding,
             addedAt: book.addedAt,
             originalExtension: book.originalExtension,
-            lastOpenedAt: book.lastOpenedAt
+            lastOpenedAt: book.lastOpenedAt,
+            fileState: BookFileState(rawValue: book.fileState) ?? .local,
+            blobPath: book.blobPath
         )
     }
 }

--- a/vreaderTests/Services/Mocks/MockPersistenceActor.swift
+++ b/vreaderTests/Services/Mocks/MockPersistenceActor.swift
@@ -58,7 +58,9 @@ actor MockPersistenceActor: BookPersisting {
             detectedEncoding: book.detectedEncoding,
             addedAt: book.addedAt,
             originalExtension: book.originalExtension,
-            lastOpenedAt: book.lastOpenedAt
+            lastOpenedAt: book.lastOpenedAt,
+            fileState: book.fileState,
+            blobPath: book.blobPath
         )
         books[key] = book
     }


### PR DESCRIPTION
Refs #145. Sendable value-types expose the fileState + blobPath from WI-1 so phase-2 consumers can read them without crossing actor boundaries. 28 tests pass.