### PR TITLE
feat(#49): WI-7a — DebugPositionResolver + awaitReader primitive

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 46
-        MARKETING_VERSION: 3.11.14
+        CURRENT_PROJECT_VERSION: 47
+        MARKETING_VERSION: 3.11.15
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -241,6 +241,7 @@
 		5168983F9EDD267778A9EEC9 /* TXTChapterIndexBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3910DCA9C9F588B700679D76 /* TXTChapterIndexBuilder.swift */; };
 		51F370150CAD9A865053266C /* HighlightIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABEAF0841AD808F7EE48617 /* HighlightIntegrationTests.swift */; };
 		51F6D90704CD88D8F5160E19 /* FoliateStyleMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42E9BBD87941E0D6C66010EC /* FoliateStyleMapperTests.swift */; };
+		52E5D3598F1520AEF23442C7 /* DebugPositionResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4459ED2850B657C535C05F16 /* DebugPositionResolverTests.swift */; };
 		5365C69DAECEFAE3481247B3 /* TOCBuilderTXTTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49624FC3C8E1AC31E011351C /* TOCBuilderTXTTests.swift */; };
 		539E581AA8A8427E199AC0A7 /* WebDAVBlobStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAC16C19C7D4C72EFC950C9 /* WebDAVBlobStore.swift */; };
 		53DEE85CF4BDE11891B0E07A /* KeychainServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5C12635DFA6BEE42EBB1CE /* KeychainServiceTests.swift */; };
@@ -361,6 +362,7 @@
 		7D8D8CAA59DB81F80A9BEE72 /* TextKit2PaginatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E368FCB9544C39958CDC31CE /* TextKit2PaginatorTests.swift */; };
 		7DF8F36BD048FEAAF1571CAD /* LibraryEdgeCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6F33EB7EFB0D7C9001E3A2 /* LibraryEdgeCaseTests.swift */; };
 		7E14E9F4DB1451B47A4DDC9E /* AIServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB9DBE73613A6499D43B18C /* AIServiceTests.swift */; };
+		7E1AD7E1C555FE37FB7EC7FA /* DebugPositionResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D9F7749E205C92E5346FAE /* DebugPositionResolver.swift */; };
 		7E4274201E53904CDE46FC16 /* ReadingSessionTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398F1BAF549E7AC80E9CE320 /* ReadingSessionTrackerTests.swift */; };
 		7E84EE1334499F661728483E /* UpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89DE76057526BA48CAE2A83A /* UpdateChecker.swift */; };
 		7E88B70492874A1D1C0416D5 /* AnnotationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C86F6A1C143DB6AC9187FC0 /* AnnotationListView.swift */; };
@@ -382,6 +384,7 @@
 		81A875C50C5A9B68C2E415D1 /* TXTChapterIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = F02AE770B22BFE6D2F175A1A /* TXTChapterIndex.swift */; };
 		8211FDEF87BCA2DA4EBD357A /* BookSourceHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDE356D5C7D77EC05E82520 /* BookSourceHTTPClient.swift */; };
 		82152E9125D5620CACFCEFF3 /* ReaderSelectionEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7C59839A119870BE9B6FF9 /* ReaderSelectionEventTests.swift */; };
+		835978FC77015C0004328BAD /* DebugReaderRegistryAwaitReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85C4EC2BEDD3FD73FFBF56B8 /* DebugReaderRegistryAwaitReaderTests.swift */; };
 		83920E15721D7860684628BE /* ReaderLifecycleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D363190FCDF47ED48A1D7BC1 /* ReaderLifecycleHelper.swift */; };
 		83DAEE23928C668DA378F086 /* EPUBProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FA15EA6877E3CA9421E1B59 /* EPUBProgressTests.swift */; };
 		84A03EDA45DB68CE01456609 /* SwiftDataSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B682E216B5A24055B696F0 /* SwiftDataSessionStore.swift */; };
@@ -909,6 +912,7 @@
 		43DA904E79F5CF69E46ECC26 /* ReaderAuditFixTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderAuditFixTests.swift; sourceTree = "<group>"; };
 		43EE33FE1EDFE9B393885110 /* FeatureFlagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsTests.swift; sourceTree = "<group>"; };
 		44423E8976A2B27C4B14617F /* EPUBHighlightJS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBHighlightJS.swift; sourceTree = "<group>"; };
+		4459ED2850B657C535C05F16 /* DebugPositionResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugPositionResolverTests.swift; sourceTree = "<group>"; };
 		445A7C6C3D4466A57B29BDA8 /* ReaderSettingsSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsSheetTests.swift; sourceTree = "<group>"; };
 		456FDDA03D7DEF3A4AEB01DB /* TOCBuilderMDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOCBuilderMDTests.swift; sourceTree = "<group>"; };
 		4581A94B5099D15743DC02F3 /* ReaderTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTheme.swift; sourceTree = "<group>"; };
@@ -1098,7 +1102,9 @@
 		84BAC2CBFB7F533857E6A65B /* search_no_results.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = search_no_results.html; sourceTree = "<group>"; };
 		84E4ABD8F17B04EA35F23724 /* legado_multiple_sources.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = legado_multiple_sources.json; sourceTree = "<group>"; };
 		851277A5872045D4D935CE2B /* DictionaryLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryLookup.swift; sourceTree = "<group>"; };
+		85C4EC2BEDD3FD73FFBF56B8 /* DebugReaderRegistryAwaitReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReaderRegistryAwaitReaderTests.swift; sourceTree = "<group>"; };
 		864A1B050775A46ADBE3304F /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
+		86D9F7749E205C92E5346FAE /* DebugPositionResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugPositionResolver.swift; sourceTree = "<group>"; };
 		8707DA3A6FC024EAC4F63E76 /* TXTTextExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTTextExtractorTests.swift; sourceTree = "<group>"; };
 		8719A34DB441AF9DC6379DC9 /* PDFHighlightRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFHighlightRenderer.swift; sourceTree = "<group>"; };
 		874E517A41CB3B9C7C5C8D3A /* NavigationFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationFlowTests.swift; sourceTree = "<group>"; };
@@ -1701,6 +1707,7 @@
 				CA44E51EB0E783E5A874DA11 /* DebugBridgeNotifications.swift */,
 				DD2C3A426BB929B2462E439E /* DebugCommand.swift */,
 				461EFE2364F2C7356BB47C88 /* DebugFixtureCatalog.swift */,
+				86D9F7749E205C92E5346FAE /* DebugPositionResolver.swift */,
 				2B98DA0DED4325E7AE1BEF59 /* DebugReaderProbeAdapter.swift */,
 				9380720966F3E3F6F8A0D407 /* DebugReaderRegistry.swift */,
 				94C32FCAEDE0062125F6A51E /* DebugSnapshot.swift */,
@@ -1911,6 +1918,8 @@
 				CC7163F03E397567941D174D /* DebugBridgeTests.swift */,
 				9279142901B3666BD14E0B20 /* DebugCommandTests.swift */,
 				9B6458ABB611B5C32252C6DE /* DebugFixtureCatalogTests.swift */,
+				4459ED2850B657C535C05F16 /* DebugPositionResolverTests.swift */,
+				85C4EC2BEDD3FD73FFBF56B8 /* DebugReaderRegistryAwaitReaderTests.swift */,
 				78BD4CC018110BC0C96E2788 /* DebugReaderRegistryTests.swift */,
 				BFA61DA459242CFDBBD809B7 /* DebugSnapshotTests.swift */,
 				C07FF4DC80918BEE43FF99D4 /* RealDebugBridgeContextTests.swift */,
@@ -3138,6 +3147,8 @@
 				20A406327C10BC9CBAB7D9D8 /* DebugBridgeTests.swift in Sources */,
 				0B598B705531647D3BC5BC60 /* DebugCommandTests.swift in Sources */,
 				1315B7514310CA7FC1D9A144 /* DebugFixtureCatalogTests.swift in Sources */,
+				52E5D3598F1520AEF23442C7 /* DebugPositionResolverTests.swift in Sources */,
+				835978FC77015C0004328BAD /* DebugReaderRegistryAwaitReaderTests.swift in Sources */,
 				7153BC66A08A1652A8D15A03 /* DebugReaderRegistryTests.swift in Sources */,
 				2FDBB9D830B8DC7FF418BD3D /* DebugSnapshotTests.swift in Sources */,
 				8AE1A6146EC01A464580BBA9 /* DeviceIdentityTests.swift in Sources */,
@@ -3442,6 +3453,7 @@
 				6BEC4693E4FE9F9EFC9FDE41 /* DebugBridgeNotifications.swift in Sources */,
 				80C8BBADB032CF847DC6CE17 /* DebugCommand.swift in Sources */,
 				D8F99FEB2F50E4A1FF04CF91 /* DebugFixtureCatalog.swift in Sources */,
+				7E1AD7E1C555FE37FB7EC7FA /* DebugPositionResolver.swift in Sources */,
 				6B0F05AB79459B346E22C825 /* DebugReaderProbeAdapter.swift in Sources */,
 				2B4DBB81BBE1C67A1336C8A5 /* DebugReaderRegistry.swift in Sources */,
 				79ACFB3DD40281B2A3B9AE8B /* DebugSnapshot.swift in Sources */,
@@ -3842,13 +3854,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 46;
+				CURRENT_PROJECT_VERSION = 47;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.14;
+				MARKETING_VERSION = 3.11.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3992,13 +4004,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 46;
+				CURRENT_PROJECT_VERSION = 47;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.14;
+				MARKETING_VERSION = 3.11.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/DebugBridge/DebugPositionResolver.swift
+++ b/vreader/Services/DebugBridge/DebugPositionResolver.swift
@@ -1,0 +1,105 @@
+// Purpose: Pure value-type parser that turns the `?position=<value>` URL
+// parameter from `vreader-debug://open` into a typed `DebugPosition` per
+// book format. Native-mode-only — unified-renderer mode is rejected at the
+// call site (RealDebugBridgeContext.open).
+//
+// DEBUG-only. No OS dependencies, no actor isolation; safe to call from
+// any context.
+//
+// @coordinates-with: DebugCommand.swift (URL grammar),
+//   RealDebugBridgeContext.swift (consumer),
+//   dev-docs/plans/20260503-feature-48-debugbridge-probe-completion.md (#49 WI-7)
+
+#if DEBUG
+
+import Foundation
+
+/// Typed position payload after parsing the per-format `position` string.
+/// The bridge hands this to the active reader's `seekStrategy` (per-format
+/// hosts populate `seekStrategy` in feature #50; the resolver itself is
+/// host-agnostic).
+enum DebugPosition: Equatable, Sendable {
+    /// TXT / MD: 0-based UTF-16 character offset within the document.
+    case charOffsetUTF16(Int)
+    /// EPUB: opaque CFI string (validated only for non-emptiness here;
+    /// real CFI parsing happens inside the EPUB bridge).
+    case epubCFI(String)
+    /// AZW3: opaque CFI-like string handed to Foliate-js.
+    case foliateCFI(String)
+    /// PDF: 1-based page number.
+    case pdfPage(Int)
+}
+
+/// Errors thrown by `DebugPositionResolver.resolve(_:format:)`.
+enum DebugPositionResolverError: Error, Equatable {
+    /// Format string didn't match any supported `BookFormat` raw value.
+    case unknownFormat(String)
+    /// Position string didn't match the format's expected shape.
+    case invalidPositionForFormat(format: String, position: String, reason: String)
+    /// Format is recognized but `position` not yet supported (e.g., MD same
+    /// as TXT — handled by mapping).
+    case formatUnsupported(format: String)
+}
+
+/// Pure parser. Stateless; tests construct it directly.
+enum DebugPositionResolver {
+
+    /// Resolve a `position` string against a book format.
+    /// - Parameters:
+    ///   - position: Raw URL-decoded string from the `?position=` param.
+    ///   - format: BookFormat raw value ("txt", "md", "epub", "azw3", "pdf").
+    /// - Returns: Typed `DebugPosition`.
+    /// - Throws: `DebugPositionResolverError` on shape mismatch.
+    static func resolve(_ position: String, format: String) throws -> DebugPosition {
+        guard let bookFormat = BookFormat(rawValue: format.lowercased()) else {
+            throw DebugPositionResolverError.unknownFormat(format)
+        }
+        switch bookFormat {
+        case .txt, .md:
+            // Both formats use UTF-16 character offsets. Accept positive
+            // integers (and zero) only — negative offsets are invalid.
+            guard let offset = Int(position), offset >= 0 else {
+                throw DebugPositionResolverError.invalidPositionForFormat(
+                    format: format,
+                    position: position,
+                    reason: "Expected non-negative UTF-16 character offset (e.g. \"42\")."
+                )
+            }
+            return .charOffsetUTF16(offset)
+        case .epub:
+            // EPUB CFI strings start with "epubcfi(" or are the simpler
+            // "href#fragment" form. We don't validate the full CFI grammar
+            // here — the EPUB bridge does that — just reject empty input.
+            guard !position.isEmpty else {
+                throw DebugPositionResolverError.invalidPositionForFormat(
+                    format: format,
+                    position: position,
+                    reason: "EPUB position must not be empty."
+                )
+            }
+            return .epubCFI(position)
+        case .azw3:
+            // AZW3 → Foliate-js CFI. Same shape rejection as EPUB.
+            guard !position.isEmpty else {
+                throw DebugPositionResolverError.invalidPositionForFormat(
+                    format: format,
+                    position: position,
+                    reason: "AZW3 position must not be empty."
+                )
+            }
+            return .foliateCFI(position)
+        case .pdf:
+            // PDF page numbers are 1-based.
+            guard let page = Int(position), page >= 1 else {
+                throw DebugPositionResolverError.invalidPositionForFormat(
+                    format: format,
+                    position: position,
+                    reason: "Expected 1-based page number (e.g. \"3\")."
+                )
+            }
+            return .pdfPage(page)
+        }
+    }
+}
+
+#endif

--- a/vreader/Services/DebugBridge/DebugReaderRegistry.swift
+++ b/vreader/Services/DebugBridge/DebugReaderRegistry.swift
@@ -17,7 +17,7 @@ import Foundation
 /// presenting view; the registry holds a weak reference to avoid retain
 /// cycles. AnyObject required so weakness is meaningful.
 @MainActor
-protocol DebugReaderProbe: AnyObject {
+protocol DebugReaderProbe: AnyObject, Sendable {
     /// Canonical fingerprint key of the book currently displayed.
     var fingerprintKey: String { get }
     /// Format name as used in DebugSnapshot ("txt", "md", "pdf", "epub", "azw3").
@@ -95,12 +95,29 @@ enum DebugReaderProbeError: Error, Equatable {
     case settleTimeout
 }
 
+/// Errors thrown by `DebugReaderRegistry.awaitReader`.
+enum DebugReaderRegistryError: Error, Equatable {
+    /// No reader matching the requested fingerprintKey registered before
+    /// the timeout expired.
+    case awaitReaderTimeout(fingerprintKey: String)
+}
+
 /// App-process registry of the currently-active reader. Single-entry: the
 /// app pushes one reader at a time, so newer registrations replace older.
 @MainActor
 final class DebugReaderRegistry {
     static let shared = DebugReaderRegistry()
     private weak var activeReader: AnyObject?
+
+    /// Per-key waiters added by `awaitReader(fingerprintKey:timeout:)`.
+    /// Each waiter carries a UUID token so timeouts remove by identity, not
+    /// by first-match — eliminating the race where two callers waiting on
+    /// the same key with different timeouts resume the wrong continuation.
+    private struct Waiter {
+        let token: UUID
+        let continuation: CheckedContinuation<DebugReaderProbe, Error>
+    }
+    private var waiters: [String: [Waiter]] = [:]
 
     private init() {}
 
@@ -110,8 +127,17 @@ final class DebugReaderRegistry {
     }
 
     /// Register `reader` as the active reader. Replaces any previous entry.
+    /// Resumes every awaiter whose `fingerprintKey` matches.
     func register(_ reader: DebugReaderProbe) {
         activeReader = reader
+        // Resume all waiters whose key matches the new reader's key.
+        let key = reader.fingerprintKey
+        if let bucket = waiters[key], !bucket.isEmpty {
+            waiters[key] = nil
+            for waiter in bucket {
+                waiter.continuation.resume(returning: reader)
+            }
+        }
     }
 
     /// Clear the registry if the given probe is the current entry.
@@ -124,8 +150,76 @@ final class DebugReaderRegistry {
     }
 
     /// Test seam — clear all state. Production paths use unregister.
+    /// Cancels every pending waiter with timeout for clean teardown.
     func reset() {
         activeReader = nil
+        let pendingByKey = waiters
+        waiters = [:]
+        for (key, bucket) in pendingByKey {
+            for waiter in bucket {
+                waiter.continuation.resume(
+                    throwing: DebugReaderRegistryError.awaitReaderTimeout(fingerprintKey: key)
+                )
+            }
+        }
+    }
+
+    /// Wait for a reader matching `fingerprintKey` to register.
+    ///
+    /// If a matching reader is already active, returns it immediately. Otherwise
+    /// suspends until a matching `register(_:)` call resumes the waiter or the
+    /// timeout fires. Token-based waiter ownership ensures concurrent waiters
+    /// on the same key with different timeouts each resume their OWN continuation.
+    ///
+    /// - Parameters:
+    ///   - fingerprintKey: The book's canonical fingerprint key.
+    ///   - timeout: How long to wait before throwing `awaitReaderTimeout`.
+    /// - Throws: `DebugReaderRegistryError.awaitReaderTimeout(fingerprintKey:)`
+    ///   if no matching reader registers in time.
+    func awaitReader(
+        fingerprintKey: String,
+        timeout: TimeInterval
+    ) async throws -> DebugReaderProbe {
+        // Fast path: a matching reader is already registered.
+        if let probe = current, probe.fingerprintKey == fingerprintKey {
+            return probe
+        }
+
+        let token = UUID()
+        let timeoutTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            await self?.removeAndTimeout(fingerprintKey: fingerprintKey, token: token)
+        }
+
+        do {
+            return try await withCheckedThrowingContinuation { continuation in
+                let waiter = Waiter(token: token, continuation: continuation)
+                waiters[fingerprintKey, default: []].append(waiter)
+            }
+        } catch {
+            timeoutTask.cancel()
+            throw error
+        }
+    }
+
+    /// Internal: remove a specific waiter (by token) and resume it with a
+    /// timeout error. Identified by token so concurrent waiters on the same
+    /// key don't resume each other's continuations.
+    private func removeAndTimeout(fingerprintKey: String, token: UUID) {
+        guard var bucket = waiters[fingerprintKey],
+              let idx = bucket.firstIndex(where: { $0.token == token }) else {
+            return
+        }
+        let waiter = bucket.remove(at: idx)
+        if bucket.isEmpty {
+            waiters[fingerprintKey] = nil
+        } else {
+            waiters[fingerprintKey] = bucket
+        }
+        waiter.continuation.resume(
+            throwing: DebugReaderRegistryError.awaitReaderTimeout(fingerprintKey: fingerprintKey)
+        )
     }
 }
 

--- a/vreaderTests/Services/DebugBridge/DebugPositionResolverTests.swift
+++ b/vreaderTests/Services/DebugBridge/DebugPositionResolverTests.swift
@@ -1,0 +1,103 @@
+// Purpose: Tests for DebugPositionResolver — pure parser that turns
+// `?position=<value>` strings into typed DebugPosition values per book
+// format. Feature #49 WI-7a.
+
+#if DEBUG
+
+import XCTest
+@testable import vreader
+
+final class DebugPositionResolverTests: XCTestCase {
+
+    // MARK: - TXT / MD (UTF-16 offsets)
+
+    func test_resolve_txt_validOffset_returnsCharOffset() throws {
+        let pos = try DebugPositionResolver.resolve("1024", format: "txt")
+        XCTAssertEqual(pos, .charOffsetUTF16(1024))
+    }
+
+    func test_resolve_md_acceptsSameShapeAsTxt() throws {
+        let pos = try DebugPositionResolver.resolve("0", format: "md")
+        XCTAssertEqual(pos, .charOffsetUTF16(0))
+    }
+
+    func test_resolve_txt_negativeOffset_throws() {
+        XCTAssertThrowsError(try DebugPositionResolver.resolve("-1", format: "txt")) { error in
+            guard case DebugPositionResolverError.invalidPositionForFormat(let format, let position, _) = error else {
+                XCTFail("expected invalidPositionForFormat, got \(error)")
+                return
+            }
+            XCTAssertEqual(format, "txt")
+            XCTAssertEqual(position, "-1")
+        }
+    }
+
+    func test_resolve_txt_nonNumeric_throws() {
+        XCTAssertThrowsError(try DebugPositionResolver.resolve("foo", format: "txt"))
+    }
+
+    // MARK: - EPUB (CFI)
+
+    func test_resolve_epub_cfiString_returnsEpubCFI() throws {
+        let cfi = "epubcfi(/6/4!/4/1:0)"
+        let pos = try DebugPositionResolver.resolve(cfi, format: "epub")
+        XCTAssertEqual(pos, .epubCFI(cfi))
+    }
+
+    func test_resolve_epub_emptyString_throws() {
+        XCTAssertThrowsError(try DebugPositionResolver.resolve("", format: "epub"))
+    }
+
+    // MARK: - AZW3 (Foliate CFI)
+
+    func test_resolve_azw3_cfiString_returnsFoliateCFI() throws {
+        let cfi = "epubcfi(/6/12!/4/3)"
+        let pos = try DebugPositionResolver.resolve(cfi, format: "azw3")
+        XCTAssertEqual(pos, .foliateCFI(cfi))
+    }
+
+    func test_resolve_azw3_emptyString_throws() {
+        XCTAssertThrowsError(try DebugPositionResolver.resolve("", format: "azw3"))
+    }
+
+    // MARK: - PDF (1-based page)
+
+    func test_resolve_pdf_validPage_returnsPdfPage() throws {
+        let pos = try DebugPositionResolver.resolve("3", format: "pdf")
+        XCTAssertEqual(pos, .pdfPage(3))
+    }
+
+    func test_resolve_pdf_pageZero_throws() {
+        XCTAssertThrowsError(try DebugPositionResolver.resolve("0", format: "pdf")) { error in
+            guard case DebugPositionResolverError.invalidPositionForFormat = error else {
+                XCTFail("expected invalidPositionForFormat, got \(error)")
+                return
+            }
+        }
+    }
+
+    func test_resolve_pdf_negativePage_throws() {
+        XCTAssertThrowsError(try DebugPositionResolver.resolve("-1", format: "pdf"))
+    }
+
+    // MARK: - Unknown format
+
+    func test_resolve_unknownFormat_throws() {
+        XCTAssertThrowsError(try DebugPositionResolver.resolve("anything", format: "xyz")) { error in
+            guard case DebugPositionResolverError.unknownFormat(let f) = error else {
+                XCTFail("expected unknownFormat, got \(error)")
+                return
+            }
+            XCTAssertEqual(f, "xyz")
+        }
+    }
+
+    // MARK: - Case insensitivity
+
+    func test_resolve_uppercaseFormat_normalizesToLowercase() throws {
+        let pos = try DebugPositionResolver.resolve("42", format: "TXT")
+        XCTAssertEqual(pos, .charOffsetUTF16(42))
+    }
+}
+
+#endif

--- a/vreaderTests/Services/DebugBridge/DebugReaderRegistryAwaitReaderTests.swift
+++ b/vreaderTests/Services/DebugBridge/DebugReaderRegistryAwaitReaderTests.swift
@@ -1,0 +1,183 @@
+// Purpose: Tests for DebugReaderRegistry.awaitReader — covers the 5-case
+// race matrix the v3/v4 plan called out (feature #49 WI-7a):
+//   1. Reader already registered — fast-path returns immediately.
+//   2. Reader registers AFTER awaiter installs — awaiter resumes.
+//   3. Awaiter times out before any matching reader registers.
+//   4. Two awaiters with different timeouts — token-based ownership ensures
+//      neither resumes the other's continuation.
+//   5. Multiple awaiters on the same key — all resume on a single register.
+//
+// All assertions use Swift Testing's #expect for clarity. Tests run on
+// MainActor because the registry is @MainActor.
+
+#if DEBUG
+
+import Testing
+import Foundation
+@testable import vreader
+
+@MainActor
+@Suite("DebugReaderRegistry.awaitReader — feature #49 WI-7a")
+struct DebugReaderRegistryAwaitReaderTests {
+
+    /// Test-only fake probe satisfying the protocol.
+    final class FakeProbe: DebugReaderProbe {
+        let fingerprintKey: String
+        let format: String
+        var currentPositionString: String? = nil
+
+        init(fingerprintKey: String, format: String = "txt") {
+            self.fingerprintKey = fingerprintKey
+            self.format = format
+        }
+
+        func awaitSettle(timeout: TimeInterval) async throws {}
+        func evaluateJavaScript(_ script: String) async throws -> Data {
+            throw DebugReaderProbeError.evalUnsupported(format: format)
+        }
+    }
+
+    private func makeRegistry() -> DebugReaderRegistry {
+        DebugReaderRegistry.shared.reset()
+        return DebugReaderRegistry.shared
+    }
+
+    // MARK: - Case 1: fast path (reader already registered)
+
+    @Test func case1_alreadyRegistered_returnsImmediately() async throws {
+        let registry = makeRegistry()
+        let probe = FakeProbe(fingerprintKey: "txt:abc:1024")
+        registry.register(probe)
+
+        let resolved = try await registry.awaitReader(
+            fingerprintKey: "txt:abc:1024",
+            timeout: 5.0
+        )
+        #expect(resolved.fingerprintKey == "txt:abc:1024")
+    }
+
+    // MARK: - Case 2: register after await installs
+
+    @Test func case2_registerAfterInstall_resumesWaiter() async throws {
+        let registry = makeRegistry()
+        let probe = FakeProbe(fingerprintKey: "txt:def:2048")
+
+        // Schedule the register on next runloop turn so the await call
+        // installs first. Using Task.detached so it runs concurrently
+        // with the await.
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 50_000_000) // 50ms
+            registry.register(probe)
+        }
+
+        let resolved = try await registry.awaitReader(
+            fingerprintKey: "txt:def:2048",
+            timeout: 2.0
+        )
+        #expect(resolved.fingerprintKey == "txt:def:2048")
+    }
+
+    // MARK: - Case 3: timeout
+
+    @Test func case3_noMatchingReader_throwsTimeout() async throws {
+        let registry = makeRegistry()
+
+        do {
+            _ = try await registry.awaitReader(
+                fingerprintKey: "nonexistent",
+                timeout: 0.2
+            )
+            Issue.record("expected timeout")
+        } catch DebugReaderRegistryError.awaitReaderTimeout(let key) {
+            #expect(key == "nonexistent")
+        } catch {
+            Issue.record("wrong error: \(error)")
+        }
+    }
+
+    // MARK: - Case 4: two waiters, different timeouts (token isolation)
+
+    @Test func case4_twoWaitersDifferentTimeouts_eachResumesOwnContinuation() async throws {
+        let registry = makeRegistry()
+        let probe = FakeProbe(fingerprintKey: "txt:ghi:512")
+
+        // Waiter A times out first (short), waiter B times out later (long).
+        // We DON'T register a probe — both should time out independently
+        // without resuming each other.
+        async let resultA: Result<DebugReaderProbe, Error> = {
+            do {
+                let p = try await registry.awaitReader(fingerprintKey: "txt:ghi:512", timeout: 0.15)
+                return .success(p)
+            } catch {
+                return .failure(error)
+            }
+        }()
+        async let resultB: Result<DebugReaderProbe, Error> = {
+            do {
+                let p = try await registry.awaitReader(fingerprintKey: "txt:ghi:512", timeout: 0.30)
+                return .success(p)
+            } catch {
+                return .failure(error)
+            }
+        }()
+
+        let (a, b) = await (resultA, resultB)
+
+        // Both should time out (no register occurred).
+        switch a {
+        case .success: Issue.record("waiter A should have timed out")
+        case .failure(let e):
+            #expect((e as? DebugReaderRegistryError) == .awaitReaderTimeout(fingerprintKey: "txt:ghi:512"))
+        }
+        switch b {
+        case .success: Issue.record("waiter B should have timed out")
+        case .failure(let e):
+            #expect((e as? DebugReaderRegistryError) == .awaitReaderTimeout(fingerprintKey: "txt:ghi:512"))
+        }
+        _ = probe // keep alive (not registered)
+    }
+
+    // MARK: - Case 5: multiple waiters, single register resumes all
+
+    @Test func case5_multipleWaiters_singleRegisterResumesAll() async throws {
+        let registry = makeRegistry()
+        let probe = FakeProbe(fingerprintKey: "txt:jkl:256")
+
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 50_000_000) // 50ms
+            registry.register(probe)
+        }
+
+        async let r1 = try registry.awaitReader(fingerprintKey: "txt:jkl:256", timeout: 2.0)
+        async let r2 = try registry.awaitReader(fingerprintKey: "txt:jkl:256", timeout: 2.0)
+
+        let (p1, p2) = try await (r1, r2)
+        #expect(p1.fingerprintKey == "txt:jkl:256")
+        #expect(p2.fingerprintKey == "txt:jkl:256")
+    }
+
+    // MARK: - Reset cancels pending waiters
+
+    @Test func reset_cancelsPendingWaitersWithTimeoutError() async throws {
+        let registry = makeRegistry()
+
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            registry.reset()
+        }
+
+        do {
+            _ = try await registry.awaitReader(
+                fingerprintKey: "will-never-register",
+                timeout: 5.0
+            )
+            Issue.record("expected timeout from reset")
+        } catch DebugReaderRegistryError.awaitReaderTimeout {
+            // expected — reset cancels with the same error type
+        } catch {
+            Issue.record("wrong error: \(error)")
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
Refs #171. Two new primitives (DebugPositionResolver + DebugReaderRegistry.awaitReader with token-based waiter ownership). 18 tests GREEN including the 5-case race matrix. Foundation for WI-7b (open() rewrite).