### PR TITLE
feat(#49): WI-7b — RealDebugBridgeContext.open() rewrite

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 47
-        MARKETING_VERSION: 3.11.15
+        CURRENT_PROJECT_VERSION: 48
+        MARKETING_VERSION: 3.11.16
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3854,13 +3854,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 47;
+				CURRENT_PROJECT_VERSION = 48;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.15;
+				MARKETING_VERSION = 3.11.16;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4004,13 +4004,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 47;
+				CURRENT_PROJECT_VERSION = 48;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.15;
+				MARKETING_VERSION = 3.11.16;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/DebugBridge/DebugBridge.swift
+++ b/vreader/Services/DebugBridge/DebugBridge.swift
@@ -108,6 +108,12 @@ final class DebugBridge {
                 return "bridge.evalUnsupported: \(fmt)"
             case .evalFailed(let msg):
                 return "bridge.evalFailed: \(msg)"
+            case .invalidPosition(let format, let position, let reason):
+                return "bridge.invalidPosition: \(format) \(position) — \(reason)"
+            case .openPositionUnsupportedInUnifiedMode(let format):
+                return "bridge.openPositionUnsupportedInUnifiedMode: \(format)"
+            case .openAwaitReaderTimeout(let key):
+                return "bridge.openAwaitReaderTimeout: \(key)"
             }
         default:
             return "unknown: \(String(describing: type(of: error)))"

--- a/vreader/Services/DebugBridge/RealDebugBridgeContext.swift
+++ b/vreader/Services/DebugBridge/RealDebugBridgeContext.swift
@@ -26,6 +26,16 @@ enum DebugBridgeContextError: Error, Equatable {
     case settleTimeout
     case evalUnsupported(format: String)
     case evalFailed(String)
+    /// Feature #49 WI-7b: position string didn't match the format's expected
+    /// shape. Carries the format + raw position + a human-readable reason.
+    case invalidPosition(format: String, position: String, reason: String)
+    /// Feature #49 WI-7b: opening at a specific position is only supported
+    /// in native-mode for now. Unified-renderer mode (TXT/MD/EPUB through
+    /// the unified text renderer) doesn't have a stable seek API yet.
+    case openPositionUnsupportedInUnifiedMode(format: String)
+    /// Feature #49 WI-7b: awaitReader timed out waiting for a reader matching
+    /// `fingerprintKey` to register after the open notification was posted.
+    case openAwaitReaderTimeout(fingerprintKey: String)
 }
 
 /// Production DebugBridgeContext. Each handler is a thin wrapper over
@@ -107,19 +117,81 @@ final class RealDebugBridgeContext: DebugBridgeContext {
     /// instead of opening at the wrong place. v1 will resolve position to
     /// a Locator and pass it to the reader.
     func open(bookId: String, position: String?) async throws {
-        if position != nil {
-            throw DebugBridgeContextError.notImplemented(command: "open.position")
-        }
+        // Step 1: book lookup — validate before any side effect (the v3 plan's
+        // "validate before posting notification" rule, Round-2 audit fix #3).
         let books = try await persistence.fetchAllLibraryBooks()
-        guard books.contains(where: { $0.fingerprintKey == bookId }) else {
+        guard let book = books.first(where: { $0.fingerprintKey == bookId }) else {
             throw DebugBridgeContextError.bookNotFound(bookId)
         }
+
+        // Step 2: position parse + format check (only when caller supplied
+        // a position). Resolver returns typed DebugPosition or throws
+        // invalidPositionForFormat → wrap as bridge-level invalidPosition.
+        let resolvedPosition: DebugPosition?
+        if let position {
+            do {
+                resolvedPosition = try DebugPositionResolver.resolve(position, format: book.format)
+            } catch let DebugPositionResolverError.invalidPositionForFormat(format, raw, reason) {
+                throw DebugBridgeContextError.invalidPosition(
+                    format: format,
+                    position: raw,
+                    reason: reason
+                )
+            } catch let DebugPositionResolverError.unknownFormat(format) {
+                throw DebugBridgeContextError.invalidPosition(
+                    format: format,
+                    position: position,
+                    reason: "Unknown book format."
+                )
+            } catch let DebugPositionResolverError.formatUnsupported(format) {
+                throw DebugBridgeContextError.openPositionUnsupportedInUnifiedMode(format: format)
+            }
+
+            // Step 3: unified-mode guard (per v3 plan Round-2 audit fix #3).
+            // Native-mode has reader-host seek paths; unified-mode (the unified
+            // text renderer that may consolidate TXT/MD/EPUB) doesn't have a
+            // stable seek API. Reject early so verification flows fail loudly.
+            let store = ReaderSettingsStore(defaults: userDefaults)
+            if store.readingMode == .unified,
+               let format = BookFormat(rawValue: book.format) {
+                let caps = FormatCapabilities.capabilities(for: format)
+                // Only formats whose unified-mode path supports seek are exempt.
+                // Today: PDF stays native-only; TXT/MD/EPUB unified mode lacks
+                // seek; AZW3 only renders in native (Foliate spike).
+                _ = caps  // capability table currently has no seek bit; gate by mode alone.
+                throw DebugBridgeContextError.openPositionUnsupportedInUnifiedMode(format: book.format)
+            }
+        } else {
+            resolvedPosition = nil
+        }
+
+        // Step 4: post notification — opens the reader. Library navigation
+        // observes `.debugBridgeOpenBook` and pushes the matching book.
         NotificationCenter.default.post(
             name: .debugBridgeOpenBook,
             object: nil,
             userInfo: ["fingerprintKey": bookId]
         )
         log.info("open: posted notification for \(bookId, privacy: .public)")
+
+        // Step 5: when a position was supplied, await the reader to register
+        // and then dispatch the seek. The actual seek implementation lives in
+        // per-format hosts (feature #50 WI-7b's host-side seekStrategy).
+        // For now, we just resolve the await — host-side seek wiring is a
+        // follow-up that consumes `resolvedPosition`.
+        if resolvedPosition != nil {
+            do {
+                let probe = try await DebugReaderRegistry.shared.awaitReader(
+                    fingerprintKey: bookId,
+                    timeout: 10.0
+                )
+                log.info("open: awaitReader resolved for \(probe.fingerprintKey, privacy: .public)")
+                // Seek dispatch deferred to feature #50 (per-format hosts populate
+                // a seek strategy on the probe; the bridge calls it here).
+            } catch DebugReaderRegistryError.awaitReaderTimeout(let key) {
+                throw DebugBridgeContextError.openAwaitReaderTimeout(fingerprintKey: key)
+            }
+        }
     }
 
     /// Set reader theme + optional font size. Mutates a transient

--- a/vreaderTests/Services/DebugBridge/RealDebugBridgeContextTests.swift
+++ b/vreaderTests/Services/DebugBridge/RealDebugBridgeContextTests.swift
@@ -459,15 +459,25 @@ final class RealDebugBridgeContextTests: XCTestCase {
     }
 
     @MainActor
-    func test_open_withNonNilPosition_throwsNotImplemented() async throws {
-        // v0 rejects position rather than silently ignoring it. Repros that
-        // depend on opening at a specific location fail loudly instead of
-        // opening at the wrong place.
-        let key = try await CollectionTestHelper.insertBook(
-            persistence: persistence,
-            title: "Openable",
-            sha: String(repeating: "9", count: 64)
+    func test_open_withInvalidEpubPosition_throwsInvalidPosition() async throws {
+        // Feature #49 WI-7b: position is now parsed via DebugPositionResolver.
+        // EPUB requires a non-empty CFI; empty string → invalidPosition.
+        let fp = DocumentFingerprint(
+            contentSHA256: String(repeating: "9", count: 64),
+            fileByteCount: 1024,
+            format: .epub
         )
+        let record = BookRecord(
+            fingerprintKey: fp.canonicalKey,
+            title: "Openable",
+            author: nil,
+            coverImagePath: nil,
+            fingerprint: fp,
+            provenance: CollectionTestHelper.makeProvenance(),
+            detectedEncoding: nil,
+            addedAt: Date()
+        )
+        _ = try await persistence.insertBook(record)
 
         let context = RealDebugBridgeContext(
             persistence: persistence,
@@ -475,23 +485,35 @@ final class RealDebugBridgeContextTests: XCTestCase {
             userDefaults: defaults
         )
         do {
-            try await context.open(bookId: key, position: "epubcfi(/6/4)")
-            XCTFail("expected notImplemented for non-nil position")
-        } catch DebugBridgeContextError.notImplemented(let cmd) {
-            XCTAssertEqual(cmd, "open.position")
+            try await context.open(bookId: fp.canonicalKey, position: "")
+            XCTFail("expected invalidPosition for empty EPUB position")
+        } catch DebugBridgeContextError.invalidPosition(let format, _, _) {
+            XCTAssertEqual(format, "epub")
         } catch {
-            XCTFail("expected notImplemented, got \(error)")
+            XCTFail("expected invalidPosition, got \(error)")
         }
     }
 
     @MainActor
-    func test_open_nonNilPosition_doesNotPostNotification() async throws {
-        // Verify the position-rejected case doesn't leak a partial side effect.
-        let key = try await CollectionTestHelper.insertBook(
-            persistence: persistence,
-            title: "Openable",
-            sha: String(repeating: "8", count: 64)
+    func test_open_invalidPosition_doesNotPostNotification() async throws {
+        // Verify the position-validation-rejected case doesn't leak a partial
+        // side effect. Notification is posted only AFTER position validation.
+        let fp = DocumentFingerprint(
+            contentSHA256: String(repeating: "8", count: 64),
+            fileByteCount: 1024,
+            format: .pdf
         )
+        let record = BookRecord(
+            fingerprintKey: fp.canonicalKey,
+            title: "Openable",
+            author: nil,
+            coverImagePath: nil,
+            fingerprint: fp,
+            provenance: CollectionTestHelper.makeProvenance(),
+            detectedEncoding: nil,
+            addedAt: Date()
+        )
+        _ = try await persistence.insertBook(record)
 
         let exp = expectation(description: "no notification expected")
         exp.isInverted = true
@@ -510,9 +532,10 @@ final class RealDebugBridgeContextTests: XCTestCase {
             userDefaults: defaults
         )
         do {
-            try await context.open(bookId: key, position: "p:42")
+            // Negative page rejected by resolver → never reaches notification.
+            try await context.open(bookId: fp.canonicalKey, position: "-1")
             XCTFail("expected throw")
-        } catch DebugBridgeContextError.notImplemented {
+        } catch DebugBridgeContextError.invalidPosition {
             // expected
         }
         await fulfillment(of: [exp], timeout: 0.5)


### PR DESCRIPTION
Refs #171. open(bookId:position:) now validates BEFORE posting notification (book lookup → resolver → unified-mode guard → post → awaitReader). Per-format seek dispatch deferred to #50. 4 open() tests pass.