### PR TITLE
feat(#47): WI-3b foundation — PersistenceActor+RemoteOnly helpers

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 50
-        MARKETING_VERSION: 3.11.18
+        CURRENT_PROJECT_VERSION: 51
+        MARKETING_VERSION: 3.11.19
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		2999C19D201DFD14B176D2B3 /* TXTLazyTextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F7F0E16B5468446AE51D0C /* TXTLazyTextProvider.swift */; };
 		2AD43547691478569AA638EB /* AIConfigurationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8038AAB18412F30C09CBDD9 /* AIConfigurationStore.swift */; };
 		2B2BB1E5BCB1E74F360BE9F2 /* SearchTextExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30D00221E111683E9FF0260A /* SearchTextExtractor.swift */; };
+		2B495CA89B61AF9DAC925A54 /* PersistenceActorRemoteOnlyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A504B80204BEC5B968087D02 /* PersistenceActorRemoteOnlyTests.swift */; };
 		2B4DBB81BBE1C67A1336C8A5 /* DebugReaderRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9380720966F3E3F6F8A0D407 /* DebugReaderRegistry.swift */; };
 		2B9E39AC289E006A1A8B25AE /* BookFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED83105BFA1AA160A12D158 /* BookFormatTests.swift */; };
 		2C05C1DC5E7C1B7C7B438C2B /* NoOpSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19EA79EB5577BF31A4096B39 /* NoOpSessionStore.swift */; };
@@ -269,6 +270,7 @@
 		5BA867B4591F0916810C91B8 /* EPUBPaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9500033AC714D470A3024F8 /* EPUBPaginationTests.swift */; };
 		5BCD69B7FFD787F33D6E0C8D /* AutoPageTurnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2396FE1BB03C2F3CEFAB8E2 /* AutoPageTurnerTests.swift */; };
 		5BF55452ABA60AB492B54C6D /* AIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02B540992E1F3C96A00723F /* AIProvider.swift */; };
+		5C1FD4FE52873A5962D4CB95 /* PersistenceActor+RemoteOnly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300CB93197976B4D665AEDFC /* PersistenceActor+RemoteOnly.swift */; };
 		5C20BECE1338802F60F3E7B7 /* AITranslationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE29B97304B59C88E3F3F9CF /* AITranslationTests.swift */; };
 		5D0737B628F92C5588E95081 /* SyncRecordDTOs.swift in Sources */ = {isa = PBXBuildFile; fileRef = E02C0C97FFE66E8DEC728D64 /* SyncRecordDTOs.swift */; };
 		5D3C554CE5388769AA455D1E /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41F3E1A368720EFCB55A9582 /* SearchService.swift */; };
@@ -864,6 +866,7 @@
 		2ED1C14FB27E5FF826BA26AF /* vreaderUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = vreaderUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2ED5B25F56B248FE8953B5A1 /* ChangeTokenStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeTokenStoreTests.swift; sourceTree = "<group>"; };
 		2F317CDBF13A6A5673D64A8A /* TextKit2Paginator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextKit2Paginator.swift; sourceTree = "<group>"; };
+		300CB93197976B4D665AEDFC /* PersistenceActor+RemoteOnly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+RemoteOnly.swift"; sourceTree = "<group>"; };
 		30D00221E111683E9FF0260A /* SearchTextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTextExtractor.swift; sourceTree = "<group>"; };
 		317401FBAE274C615325BDBC /* SourceSharingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceSharingServiceTests.swift; sourceTree = "<group>"; };
 		32DF5DC258E6460D4FE84706 /* SearchServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchServiceTests.swift; sourceTree = "<group>"; };
@@ -1201,6 +1204,7 @@
 		A457F48D22CD5B4952817701 /* EPUBTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBTypes.swift; sourceTree = "<group>"; };
 		A496DB7B37A1E68FA33AD5A3 /* JSONExportFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONExportFormatter.swift; sourceTree = "<group>"; };
 		A4D9A3C4C1072DA23511265D /* PDFReaderPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReaderPlaceholderTests.swift; sourceTree = "<group>"; };
+		A504B80204BEC5B968087D02 /* PersistenceActorRemoteOnlyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceActorRemoteOnlyTests.swift; sourceTree = "<group>"; };
 		A579625590B25F81679F1EA0 /* ReaderNotificationModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderNotificationModifier.swift; sourceTree = "<group>"; };
 		A694EB7A8BB6138115DAB32E /* tts.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = tts.js; sourceTree = "<group>"; };
 		A6DB55181F2F55D99D879507 /* FoliateSearchAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateSearchAdapterTests.swift; sourceTree = "<group>"; };
@@ -2487,6 +2491,7 @@
 				21BC5F159064D57CFAE2A676 /* MetadataExtractorTests.swift */,
 				544A2F3FF8BBB1C08DDCE02D /* PageNavigatorTests.swift */,
 				272182B2C311AE5E968D314C /* PerBookSettingsTests.swift */,
+				A504B80204BEC5B968087D02 /* PersistenceActorRemoteOnlyTests.swift */,
 				410BA6F21267316487DF58FC /* PersistenceBookmarkTests.swift */,
 				EEDD43BA2EC5C331FDF3A703 /* PersistenceHighlightTests.swift */,
 				3629EA1FD0AAF0E1E903AC4E /* ReaderPositionServiceTests.swift */,
@@ -2741,6 +2746,7 @@
 				AC517B8E3581F795DEDEC934 /* PersistenceActor+Highlights.swift */,
 				E46A786B20AA87E763D00F45 /* PersistenceActor+Library.swift */,
 				59ECD5BE8EE959A2EF3E208E /* PersistenceActor+ReadingPosition.swift */,
+				300CB93197976B4D665AEDFC /* PersistenceActor+RemoteOnly.swift */,
 				96FDA9A40CE891B901F1A28F /* PersistenceActor+Stats.swift */,
 				292EB76312E500AFAC065E1F /* PreferenceStore.swift */,
 				0F99442B3BA1E02CC3F2A2C1 /* ReaderPositionService.swift */,
@@ -3281,6 +3287,7 @@
 				A2C6C1BBE3492F53D5C4BEB4 /* PagedModeBug82Tests.swift in Sources */,
 				468BC9EB876942D28F071E57 /* PaginationCacheTests.swift in Sources */,
 				0ADA2F00E5ABFEEF5328CE2F /* PerBookSettingsTests.swift in Sources */,
+				2B495CA89B61AF9DAC925A54 /* PersistenceActorRemoteOnlyTests.swift in Sources */,
 				5619DB9FC83E7182AE0EB63F /* PersistenceBookmarkTests.swift in Sources */,
 				DD32F48A384939AC2389DCAE /* PersistenceHighlightTests.swift in Sources */,
 				49E7475E7118E6366C0530E5 /* PersistentSearchIndexTests.swift in Sources */,
@@ -3615,6 +3622,7 @@
 				38661CFAC1618DB7526ACB28 /* PersistenceActor+Highlights.swift in Sources */,
 				CD9751D76A3A9DBF872CA5D7 /* PersistenceActor+Library.swift in Sources */,
 				E1646FDF9A47255E94758A54 /* PersistenceActor+ReadingPosition.swift in Sources */,
+				5C1FD4FE52873A5962D4CB95 /* PersistenceActor+RemoteOnly.swift in Sources */,
 				D451E5FB27521C48F0A54FEA /* PersistenceActor+Stats.swift in Sources */,
 				A190FE66621610AD2D04739D /* PersistenceActor.swift in Sources */,
 				26D79FC598918201D178F348 /* PersistenceActorEnvironment.swift in Sources */,
@@ -3878,13 +3886,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.18;
+				MARKETING_VERSION = 3.11.19;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4028,13 +4036,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.18;
+				MARKETING_VERSION = 3.11.19;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/PersistenceActor+RemoteOnly.swift
+++ b/vreader/Services/PersistenceActor+RemoteOnly.swift
@@ -1,0 +1,97 @@
+// Purpose: Extension adding fileState/blobPath query + mutation helpers
+// used by the lazy-download coordinator (#47 WI-3) and the selective
+// restore flow (#47 WI-4). Lives next to PersistenceActor so it can read
+// `modelContainer` directly without exposing it more widely.
+//
+// @coordinates-with: PersistenceActor.swift, Book.swift, BookFileState.swift,
+//   LazyDownloadCoordinator.swift (future, WI-3b reattach),
+//   SelectiveRestoreCoordinator.swift (future, WI-4b)
+
+import Foundation
+import SwiftData
+
+extension PersistenceActor {
+
+    /// Returns the fingerprint keys of all books currently in the given
+    /// file-presence state. Used at coordinator init to find `.downloading`
+    /// rows that crashed mid-flight (`reconcileDownloadingRowsAgainst`) and
+    /// by selective-restore views to count outstanding remoteOnly books.
+    func fingerprintKeys(withFileState state: BookFileState) async throws -> [String] {
+        let context = ModelContext(modelContainer)
+        let raw = state.rawValue
+        let predicate = #Predicate<Book> { $0.fileState == raw }
+        let descriptor = FetchDescriptor<Book>(predicate: predicate)
+        return try context.fetch(descriptor).map { $0.fingerprintKey }
+    }
+
+    /// Updates the fileState for a single book. Used by the lazy-download
+    /// coordinator on enqueue (`.remoteOnly` → `.downloading`),
+    /// finalization (`.downloading` → `.local`), failure (`.downloading` →
+    /// `.failed`), and reconciliation at launch.
+    func setBookFileState(fingerprintKey key: String, newState: BookFileState) async throws {
+        let context = ModelContext(modelContainer)
+        let predicate = #Predicate<Book> { $0.fingerprintKey == key }
+        var descriptor = FetchDescriptor<Book>(predicate: predicate)
+        descriptor.fetchLimit = 1
+        guard let book = try context.fetch(descriptor).first else {
+            throw PersistenceError.recordNotFound(key)
+        }
+        book.fileState = newState.rawValue
+        try context.save()
+    }
+
+    /// Updates the blob path for a single book. Used by selective-restore
+    /// when materializing remoteOnly rows from a backup manifest, and by
+    /// the lazy-download finalizer when promoting `.downloading` → `.local`
+    /// (which sets `blobPath` to nil — the bytes are now local).
+    func setBlobPath(fingerprintKey key: String, blobPath: String?) async throws {
+        let context = ModelContext(modelContainer)
+        let predicate = #Predicate<Book> { $0.fingerprintKey == key }
+        var descriptor = FetchDescriptor<Book>(predicate: predicate)
+        descriptor.fetchLimit = 1
+        guard let book = try context.fetch(descriptor).first else {
+            throw PersistenceError.recordNotFound(key)
+        }
+        book.blobPath = blobPath
+        try context.save()
+    }
+
+    /// Bulk-inserts remoteOnly book records produced by the selective
+    /// restore flow. Each record's `fileState` is forced to `.remoteOnly`
+    /// regardless of what the caller passed — this method is the single
+    /// entry point the catalog uses, so the invariant lives here.
+    /// Idempotent: a record whose fingerprintKey already exists locally is
+    /// left alone. We never downgrade an existing `.local` book to
+    /// `.remoteOnly`.
+    ///
+    /// **Partial-success semantics**: each record is persisted in its own
+    /// transaction (delegated to `insertBook`). If a later record throws —
+    /// e.g. a fingerprintKey/canonical-key mismatch surfaced as
+    /// `PersistenceError.invalidContent` — earlier records remain
+    /// persisted. Callers that need all-or-nothing semantics must wrap
+    /// this in their own validation pass before calling. This is acceptable
+    /// for the selective-restore flow because the catalog validates the
+    /// manifest before constructing records.
+    func insertRemoteOnlyBookRecords(_ records: [BookRecord]) async throws {
+        guard !records.isEmpty else { return }
+        for record in records {
+            let coerced = BookRecord(
+                fingerprintKey: record.fingerprintKey,
+                title: record.title,
+                author: record.author,
+                coverImagePath: record.coverImagePath,
+                fingerprint: record.fingerprint,
+                provenance: record.provenance,
+                detectedEncoding: record.detectedEncoding,
+                addedAt: record.addedAt,
+                originalExtension: record.originalExtension,
+                lastOpenedAt: record.lastOpenedAt,
+                fileState: .remoteOnly,
+                blobPath: record.blobPath
+            )
+            // insertBook is idempotent: returns existing local row unchanged
+            // if the key collides. That preserves the don't-downgrade rule.
+            _ = try await insertBook(coerced)
+        }
+    }
+}

--- a/vreaderTests/Services/PersistenceActorRemoteOnlyTests.swift
+++ b/vreaderTests/Services/PersistenceActorRemoteOnlyTests.swift
@@ -1,0 +1,192 @@
+// Purpose: Tests for PersistenceActor+RemoteOnly extension — fileState
+// queries, fileState/blobPath mutations, and bulk insertion of remoteOnly
+// rows used by the selective-restore flow. Feature #47 WI-3b foundation.
+
+import Testing
+import Foundation
+import SwiftData
+@testable import vreader
+
+@Suite("PersistenceActor+RemoteOnly — feature #47 WI-3b")
+struct PersistenceActorRemoteOnlyTests {
+
+    private func makeRecord(
+        sha: String,
+        title: String = "Remote Book",
+        fileState: BookFileState = .remoteOnly,
+        blobPath: String? = "VReader/books/epub/\(String(repeating: "a", count: 64))_1024.epub"
+    ) -> BookRecord {
+        let fp = DocumentFingerprint(
+            contentSHA256: sha,
+            fileByteCount: 1024,
+            format: .epub
+        )
+        return BookRecord(
+            fingerprintKey: fp.canonicalKey,
+            title: title,
+            author: nil,
+            coverImagePath: nil,
+            fingerprint: fp,
+            provenance: ImportProvenance(
+                source: .filesApp,
+                importedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                originalURLBookmarkData: nil
+            ),
+            detectedEncoding: nil,
+            addedAt: Date(),
+            originalExtension: "epub",
+            fileState: fileState,
+            blobPath: blobPath
+        )
+    }
+
+    // MARK: - fingerprintKeys(withFileState:)
+
+    @Test func fingerprintKeysWithFileState_emptyDB_returnsEmpty() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let keys = try await persistence.fingerprintKeys(withFileState: .remoteOnly)
+        #expect(keys.isEmpty)
+    }
+
+    @Test func fingerprintKeysWithFileState_filtersOnlyMatching() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let local = makeRecord(sha: String(repeating: "a", count: 64), fileState: .local, blobPath: nil)
+        let remote1 = makeRecord(sha: String(repeating: "b", count: 64), fileState: .remoteOnly)
+        let remote2 = makeRecord(sha: String(repeating: "c", count: 64), fileState: .remoteOnly)
+        let downloading = makeRecord(sha: String(repeating: "d", count: 64), fileState: .downloading)
+        _ = try await persistence.insertBook(local)
+        _ = try await persistence.insertBook(remote1)
+        _ = try await persistence.insertBook(remote2)
+        _ = try await persistence.insertBook(downloading)
+
+        let remoteKeys = try await persistence.fingerprintKeys(withFileState: .remoteOnly)
+        #expect(Set(remoteKeys) == Set([remote1.fingerprintKey, remote2.fingerprintKey]))
+
+        let downloadingKeys = try await persistence.fingerprintKeys(withFileState: .downloading)
+        #expect(downloadingKeys == [downloading.fingerprintKey])
+
+        let failedKeys = try await persistence.fingerprintKeys(withFileState: .failed)
+        #expect(failedKeys.isEmpty)
+    }
+
+    // MARK: - setBookFileState(fingerprintKey:newState:)
+
+    @Test func setBookFileState_changesPersistedState() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let record = makeRecord(sha: String(repeating: "a", count: 64), fileState: .remoteOnly)
+        _ = try await persistence.insertBook(record)
+
+        try await persistence.setBookFileState(fingerprintKey: record.fingerprintKey, newState: .downloading)
+
+        let downloading = try await persistence.fingerprintKeys(withFileState: .downloading)
+        #expect(downloading == [record.fingerprintKey])
+        let remoteOnly = try await persistence.fingerprintKeys(withFileState: .remoteOnly)
+        #expect(remoteOnly.isEmpty)
+    }
+
+    @Test func setBookFileState_unknownKey_throwsRecordNotFound() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        do {
+            try await persistence.setBookFileState(fingerprintKey: "nope:nope:0", newState: .failed)
+            Issue.record("expected throw")
+        } catch let PersistenceError.recordNotFound(key) {
+            #expect(key == "nope:nope:0")
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - setBlobPath(fingerprintKey:blobPath:)
+
+    @Test func setBlobPath_persistsValue() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let record = makeRecord(sha: String(repeating: "a", count: 64), fileState: .local, blobPath: nil)
+        _ = try await persistence.insertBook(record)
+
+        let path = "VReader/books/epub/foo_2048.epub"
+        try await persistence.setBlobPath(fingerprintKey: record.fingerprintKey, blobPath: path)
+
+        let fetched = try await persistence.findBook(byFingerprintKey: record.fingerprintKey)
+        #expect(fetched?.blobPath == path)
+    }
+
+    @Test func setBlobPath_nilClearsPath() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let record = makeRecord(sha: String(repeating: "a", count: 64), fileState: .remoteOnly, blobPath: "p")
+        _ = try await persistence.insertBook(record)
+
+        try await persistence.setBlobPath(fingerprintKey: record.fingerprintKey, blobPath: nil)
+
+        let fetched = try await persistence.findBook(byFingerprintKey: record.fingerprintKey)
+        #expect(fetched?.blobPath == nil)
+    }
+
+    @Test func setBlobPath_unknownKey_throwsRecordNotFound() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        do {
+            try await persistence.setBlobPath(fingerprintKey: "nope:nope:0", blobPath: "p")
+            Issue.record("expected throw")
+        } catch let PersistenceError.recordNotFound(key) {
+            #expect(key == "nope:nope:0")
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - insertRemoteOnlyBookRecords
+
+    @Test func insertRemoteOnly_insertsAllAsRemoteOnly() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let r1 = makeRecord(sha: String(repeating: "a", count: 64), title: "A")
+        let r2 = makeRecord(sha: String(repeating: "b", count: 64), title: "B")
+        let r3 = makeRecord(sha: String(repeating: "c", count: 64), title: "C")
+
+        try await persistence.insertRemoteOnlyBookRecords([r1, r2, r3])
+
+        let keys = try await persistence.fingerprintKeys(withFileState: .remoteOnly)
+        #expect(Set(keys) == Set([r1.fingerprintKey, r2.fingerprintKey, r3.fingerprintKey]))
+    }
+
+    @Test func insertRemoteOnly_isIdempotentWithExistingLocalBooks() async throws {
+        // If a remoteOnly insert collides with an existing local book,
+        // the local row wins — never downgrade .local to .remoteOnly.
+        let persistence = try CollectionTestHelper.makePersistence()
+        let sha = String(repeating: "a", count: 64)
+        let local = makeRecord(sha: sha, title: "Local", fileState: .local, blobPath: nil)
+        _ = try await persistence.insertBook(local)
+
+        let remote = makeRecord(sha: sha, title: "Remote", fileState: .remoteOnly)
+        try await persistence.insertRemoteOnlyBookRecords([remote])
+
+        let fetched = try await persistence.findBook(byFingerprintKey: local.fingerprintKey)
+        #expect(fetched?.fileState == .local)
+        #expect(fetched?.title == "Local")
+    }
+
+    @Test func insertRemoteOnly_emptyArray_noOps() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        try await persistence.insertRemoteOnlyBookRecords([])
+        let allRemote = try await persistence.fingerprintKeys(withFileState: .remoteOnly)
+        #expect(allRemote.isEmpty)
+    }
+
+    @Test func insertRemoteOnly_coercesCallerFileStateToRemoteOnly() async throws {
+        // Pin the coercion invariant: even if the caller passed `.local`,
+        // `.downloading`, or `.failed`, the row lands as `.remoteOnly`.
+        // The catalog is the only entry point for this method, and it must
+        // not be possible to bypass the coercion.
+        let persistence = try CollectionTestHelper.makePersistence()
+        let local = makeRecord(sha: String(repeating: "a", count: 64), fileState: .local, blobPath: "p1")
+        let downloading = makeRecord(sha: String(repeating: "b", count: 64), fileState: .downloading, blobPath: "p2")
+        let failed = makeRecord(sha: String(repeating: "c", count: 64), fileState: .failed, blobPath: "p3")
+
+        try await persistence.insertRemoteOnlyBookRecords([local, downloading, failed])
+
+        let remoteKeys = try await persistence.fingerprintKeys(withFileState: .remoteOnly)
+        #expect(Set(remoteKeys) == Set([local.fingerprintKey, downloading.fingerprintKey, failed.fingerprintKey]))
+
+        // Coerced rows kept their blob paths.
+        let fetched = try await persistence.findBook(byFingerprintKey: local.fingerprintKey)
+        #expect(fetched?.blobPath == "p1")
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `PersistenceActor+RemoteOnly.swift` with 4 helpers needed by the lazy-download coordinator (#47 WI-3b reattach/reconcile) and the selective-restore flow (#47 WI-4b): `fingerprintKeys(withFileState:)`, `setBookFileState(fingerprintKey:newState:)`, `setBlobPath(fingerprintKey:blobPath:)`, `insertRemoteOnlyBookRecords(_:)`.
- 11 unit tests — incl. coercion invariant, idempotent vs existing local row, missing-key throws, partial-success semantics documented.

Refs #47

## What Changed

- New `PersistenceActor+RemoteOnly.swift` (~80 LOC)
- New `PersistenceActorRemoteOnlyTests.swift` (~190 LOC)
- Version 3.11.18 → 3.11.19 (build 51)

## Codex Audit

Round 1: 2 LOW findings. Both addressed:
- Added explicit coercion test (caller's `.local`/`.downloading`/`.failed` all land as `.remoteOnly`).
- Documented partial-success semantics on `insertRemoteOnlyBookRecords` (per-record transactions; catalog must pre-validate).

## Validation

- [x] `xcodebuild test -only-testing:vreaderTests/PersistenceActorRemoteOnlyTests` passes (11/11)
- [x] Tests assert observable persisted state (not call counts)
- [x] Doesn't touch any production code path yet — purely additive helpers

## Type of Change

- [x] Feature (foundation for #47 WI-3b)