### PR TITLE
feat(#47): WI-3b — reattach + reconcile + BackgroundDownloadSessioning

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 51
-        MARKETING_VERSION: 3.11.19
+        CURRENT_PROJECT_VERSION: 52
+        MARKETING_VERSION: 3.11.20
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		22612350C6FC7C43096271E9 /* BackupDataCollectorRestorerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17676C4AE9DD328C39176D8 /* BackupDataCollectorRestorerTests.swift */; };
 		238CEDFC273E8AD0026B77AB /* BackupProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB2B5F77B95D3402E699DA9 /* BackupProvider.swift */; };
 		243DB71360738DB06D5813BF /* NativeTextPaginator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E51E6D76FE0DDF87E537AB /* NativeTextPaginator.swift */; };
+		2464151C976B35F68DD2169A /* LazyDownloadReattachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E124CB39746DB0B59D0390C3 /* LazyDownloadReattachTests.swift */; };
 		250865E2A2A7BC3DE436183F /* PDFReaderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7F4F4B985D58E03A78680D /* PDFReaderViewModelTests.swift */; };
 		2509B7983AE76F5C85B71634 /* HighlightDedupeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD56854A37D8EA2B318B926 /* HighlightDedupeTests.swift */; };
 		252CB71020888B6952C2F69E /* ReaderBottomOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A983D06F916C51795A2223E7 /* ReaderBottomOverlay.swift */; };
@@ -226,6 +227,7 @@
 		4A8B2E9CC8837F5523420479 /* TXTTextViewBridgeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96A115C3FA0B797030C1D1F /* TXTTextViewBridgeCoordinator.swift */; };
 		4C47F172233199432FC289E3 /* ImportSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F84672A6E2EDD6E037AFD8 /* ImportSource.swift */; };
 		4C5F7C805D7702035CEA5837 /* NativeTextPaginatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295669F5B358B6C7BE41952E /* NativeTextPaginatorTests.swift */; };
+		4CACC9F4BA8C17144C30C113 /* BackgroundDownloadSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A04EAFA37410DA616E33D6 /* BackgroundDownloadSession.swift */; };
 		4CC9567091E0CABFDD800F6C /* AIConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52103AEAF5528A9DD58625E /* AIConfiguration.swift */; };
 		4CCBF4F6E186A7363A995303 /* ReaderContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB42EEEFFCAD8D654D57AE7 /* ReaderContainerView.swift */; };
 		4D4A49E8738329EC2B336683 /* TXTReaderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D998048CE6DE8DC3BC77C284 /* TXTReaderViewModelTests.swift */; };
@@ -1241,6 +1243,7 @@
 		B16D420A03BD524C247A78FB /* TXTReflowableTextSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReflowableTextSource.swift; sourceTree = "<group>"; };
 		B1DBBFF061B96088FFE84194 /* TXTService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTService.swift; sourceTree = "<group>"; };
 		B294CBB624E1CE03FEFA40E6 /* WebDAVProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProviderTests.swift; sourceTree = "<group>"; };
+		B2A04EAFA37410DA616E33D6 /* BackgroundDownloadSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundDownloadSession.swift; sourceTree = "<group>"; };
 		B2DB7F421D9D2E7492E12F89 /* ZIPReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZIPReader.swift; sourceTree = "<group>"; };
 		B34C87EDF46A4EFC99012268 /* AnnotationsPanelPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationsPanelPlaceholderTests.swift; sourceTree = "<group>"; };
 		B3987200016FB6CA3D063E44 /* LocatorCanonicalHashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorCanonicalHashTests.swift; sourceTree = "<group>"; };
@@ -1366,6 +1369,7 @@
 		E02C0C97FFE66E8DEC728D64 /* SyncRecordDTOs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncRecordDTOs.swift; sourceTree = "<group>"; };
 		E07FB35EC9805F51CAD10444 /* ThemeBackgroundStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeBackgroundStore.swift; sourceTree = "<group>"; };
 		E11E9DBFB16DA26DD0659851 /* AnnotationModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationModelTests.swift; sourceTree = "<group>"; };
+		E124CB39746DB0B59D0390C3 /* LazyDownloadReattachTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyDownloadReattachTests.swift; sourceTree = "<group>"; };
 		E12EBCB8CD58F740D9042C32 /* TXTTocRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTTocRule.swift; sourceTree = "<group>"; };
 		E19A1FE14FDE4829AF0F5913 /* TXTReaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReaderViewModel.swift; sourceTree = "<group>"; };
 		E1C9AB72079AF7B2ACCAB516 /* AIConsentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIConsentManager.swift; sourceTree = "<group>"; };
@@ -1626,6 +1630,7 @@
 		232456552E53357A5363638A /* Backup */ = {
 			isa = PBXGroup;
 			children = (
+				B2A04EAFA37410DA616E33D6 /* BackgroundDownloadSession.swift */,
 				837009678FE3EE7B38B7CD8B /* BackupBlobStore.swift */,
 				DAAAF285B1D1B4F09E3AAD56 /* BackupDataCollector.swift */,
 				DA823268583E27AF564272EC /* BackupDataRestorer.swift */,
@@ -2552,6 +2557,7 @@
 				04ED79BFAD4BEF6B8A30F982 /* BookFileMaterializerTests.swift */,
 				67368B0914CFE12052417225 /* LazyDownloadCoordinatorTests.swift */,
 				E5D4DDB55DA30E015172A16D /* LazyDownloadDelegateStagingTests.swift */,
+				E124CB39746DB0B59D0390C3 /* LazyDownloadReattachTests.swift */,
 				5753714B6AF8A111E400D35A /* LazyDownloadTaskMetaTests.swift */,
 				4D9501ED4FB49C6035FDF5BB /* MockBackupProvider.swift */,
 				D9A7B601E9791FB068616C98 /* WebDAVATSTests.swift */,
@@ -3231,6 +3237,7 @@
 				53DEE85CF4BDE11891B0E07A /* KeychainServiceTests.swift in Sources */,
 				63034CF313C6829AEA1C5278 /* LazyDownloadCoordinatorTests.swift in Sources */,
 				91B3A04F3B23BE09FCA9967C /* LazyDownloadDelegateStagingTests.swift in Sources */,
+				2464151C976B35F68DD2169A /* LazyDownloadReattachTests.swift in Sources */,
 				7B1619D0A3AF6B77D0D4C7B0 /* LazyDownloadTaskMetaTests.swift in Sources */,
 				A8A3BDDF157E89577638C20F /* LegadoImporterTests.swift in Sources */,
 				1FDAAAE256E0BFC292778111 /* LegadoRuleParserTests.swift in Sources */,
@@ -3429,6 +3436,7 @@
 				8E7482D250AFDBEF1803780A /* AppConfiguration.swift in Sources */,
 				0CDCF9DAE4BA56A30FA71097 /* AppLogger.swift in Sources */,
 				64709D1B5C006D3299C8ABAF /* AutoPageTurner.swift in Sources */,
+				4CACC9F4BA8C17144C30C113 /* BackgroundDownloadSession.swift in Sources */,
 				6274548A4C4DDC1FCA13397C /* BackgroundIndexingCoordinator.swift in Sources */,
 				CE3CD75789B4E025F0F87CF5 /* BackupBlobStore.swift in Sources */,
 				C3129F763BDCF3AB47BC7098 /* BackupDataCollector.swift in Sources */,
@@ -3886,13 +3894,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.19;
+				MARKETING_VERSION = 3.11.20;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4036,13 +4044,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 51;
+				CURRENT_PROJECT_VERSION = 52;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.19;
+				MARKETING_VERSION = 3.11.20;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Backup/BackgroundDownloadSession.swift
+++ b/vreader/Services/Backup/BackgroundDownloadSession.swift
@@ -1,0 +1,76 @@
+// Purpose: Test seam for the lazy-download coordinator's interaction
+// with `URLSession.background(...)`. The standard URLProtocol mock can't
+// model a background URLSession's persistence-across-launches semantics,
+// so we abstract just the surface the coordinator needs: enumeration of
+// in-flight tasks at launch (for reattach) and a value-type descriptor so
+// tests can construct fakes without instantiating real URLSessionDownloadTasks.
+//
+// Feature #47 WI-3b. Production wrapper holds the live URLSession and
+// connects the delegate at construction. Mock in tests synthesizes
+// descriptors directly.
+//
+// @coordinates-with: LazyDownloadCoordinator.swift, LazyDownloadDelegate.swift,
+//   LazyDownloadTaskMeta.swift,
+//   dev-docs/plans/20260503-feature-47-selective-picker-lazy-load.md
+
+import Foundation
+
+/// Snapshot of an in-flight download task as observed at coordinator init.
+/// Carries only what reattach actually needs — taskIdentifier (for collision
+/// resolution and logs) and the persisted `taskDescription` (decoded into
+/// `LazyDownloadTaskMeta` to recover identity). The real
+/// `URLSessionDownloadTask` continues to live inside the production
+/// session's runloop; subsequent delegate callbacks arrive via the normal
+/// path.
+struct LazyDownloadTaskDescriptor: Sendable, Equatable {
+    let taskIdentifier: Int
+    let taskDescription: String?
+}
+
+/// Test seam for the background URLSession. Production wraps a real
+/// `URLSession.background(...)`; tests inject a deterministic mock.
+protocol BackgroundDownloadSessioning: Sendable {
+    /// All download tasks currently tracked by the underlying session.
+    /// Called once at coordinator init to recover state from a session
+    /// that survived app termination. Future WIs (cancel, enqueue) will
+    /// add more methods.
+    func allInFlightDownloads() async -> [LazyDownloadTaskDescriptor]
+}
+
+/// Production wrapper around `URLSession.background(...)`. Owns the
+/// live session for the app's lifetime; the coordinator holds an instance
+/// via the protocol and never touches the underlying URLSession directly.
+final class URLSessionBackgroundSession: BackgroundDownloadSessioning, @unchecked Sendable {
+
+    private let session: URLSession
+
+    /// Creates a background URLSession with the specified identifier and
+    /// connects the delegate at construction (URLSession requires this —
+    /// the delegate cannot be replaced after).
+    /// `allowsCellularAccess = true` here because Wi-Fi-only gating lives
+    /// in `WebDAVNetworkPolicy` (WI-3c) — flipping this property mid-flight
+    /// causes URLSession to cancel rather than pause, which doesn't match
+    /// the UX we want.
+    init(identifier: String, delegate: URLSessionDownloadDelegate) {
+        let cfg = URLSessionConfiguration.background(withIdentifier: identifier)
+        cfg.isDiscretionary = true
+        cfg.sessionSendsLaunchEvents = true
+        cfg.allowsCellularAccess = true
+        self.session = URLSession(configuration: cfg, delegate: delegate, delegateQueue: nil)
+    }
+
+    func allInFlightDownloads() async -> [LazyDownloadTaskDescriptor] {
+        await withCheckedContinuation { continuation in
+            session.getAllTasks { tasks in
+                let descriptors = tasks.compactMap { task -> LazyDownloadTaskDescriptor? in
+                    guard task is URLSessionDownloadTask else { return nil }
+                    return LazyDownloadTaskDescriptor(
+                        taskIdentifier: task.taskIdentifier,
+                        taskDescription: task.taskDescription
+                    )
+                }
+                continuation.resume(returning: descriptors)
+            }
+        }
+    }
+}

--- a/vreader/Services/Backup/LazyDownloadCoordinator.swift
+++ b/vreader/Services/Backup/LazyDownloadCoordinator.swift
@@ -3,11 +3,15 @@
 // + completion events from a non-isolated `LazyDownloadDelegate` and
 // updates @Observable state that SwiftUI views can render.
 //
-// Feature #47 WI-3a — skeleton. WI-3b adds lifecycle persistence
-// (taskDescription mapping, getAllTasks reattach, crash recovery).
+// Feature #47 WI-3a + WI-3b. WI-3a shipped the skeleton + delegate hop.
+// WI-3b adds lifecycle persistence: at init, the coordinator reattaches
+// to any in-flight tasks the OS preserved across app termination and
+// reconciles persisted `.downloading` rows that have no live task by
+// flipping them to `.failed` (crash recovery).
 // WI-3c adds WebDAVNetworkPolicy for Wi-Fi-only gating.
 //
 // @coordinates-with: LazyDownloadDelegate.swift, LazyDownloadTaskMeta.swift,
+//   BackgroundDownloadSession.swift, PersistenceActor+RemoteOnly.swift,
 //   BookFileImportFinalizer.swift (future, WI-4a),
 //   WebDAVDownloadRequestBuilder.swift (future, request construction),
 //   dev-docs/plans/20260503-feature-47-selective-picker-lazy-load.md
@@ -15,6 +19,15 @@
 import Foundation
 import OSLog
 import Observation
+
+extension Notification.Name {
+    /// Posted when a book's `BookFileState` changes due to lazy-download
+    /// reconciliation, finalization, or failure. `userInfo` carries
+    /// `["fingerprintKey": String, "state": String]` (state is the
+    /// `BookFileState.rawValue`). Library rows observe this to refresh
+    /// without a full fetch.
+    static let bookFileStateDidChange = Notification.Name("vreader.backup.bookFileStateDidChange")
+}
 
 private let log = Logger(subsystem: "com.vreader.app", category: "LazyDownloadCoordinator")
 
@@ -61,7 +74,40 @@ final class LazyDownloadCoordinator {
     /// (`BookFileImportFinalizer` / `SelectiveRestoreCoordinator`).
     private(set) var terminalKeys: Set<String> = []
 
-    init() {}
+    /// True once `reattachAndReconcile()` has finished. Tests can `await`
+    /// this — production code never reads it.
+    private(set) var didCompleteReattach: Bool = false
+
+    private let session: (any BackgroundDownloadSessioning)?
+    private let persistence: PersistenceActor?
+
+    /// Skeleton init for tests that don't need lifecycle persistence
+    /// (WI-3a tests pass through this path).
+    init() {
+        self.session = nil
+        self.persistence = nil
+        self.didCompleteReattach = true
+    }
+
+    /// Production / WI-3b init. Triggers reattach + reconcile in a child
+    /// Task — callers can `await coordinator.waitForReattach()` to barrier
+    /// on completion in tests.
+    init(session: any BackgroundDownloadSessioning, persistence: PersistenceActor) {
+        self.session = session
+        self.persistence = persistence
+        Task { [weak self] in
+            await self?.reattachAndReconcile()
+        }
+    }
+
+    /// Test barrier — resumes once `reattachAndReconcile()` has finished.
+    /// Production callers don't need this; observers see `progressByKey`
+    /// update via @Observable as the OS delivers callbacks.
+    func waitForReattach() async {
+        while !didCompleteReattach {
+            await Task.yield()
+        }
+    }
 
     // MARK: - Delegate event handlers
 
@@ -140,5 +186,123 @@ final class LazyDownloadCoordinator {
         progressByKey = [:]
         outcomes = [:]
         terminalKeys = []
+    }
+
+    // MARK: - Reattach + reconcile (WI-3b)
+
+    /// Bootstraps coordinator state from the underlying background session
+    /// and persistence layer. Runs in the init Task; tests can barrier on
+    /// `waitForReattach()`. Logic:
+    ///
+    /// 1. Read every in-flight task descriptor from the session
+    ///    (suspension point — gated tests inject delegate events here
+    ///    to drive race scenarios).
+    /// 2. Read persisted `.downloading` fingerprintKeys. If the fetch
+    ///    fails, log and exit — production keeps running with stale
+    ///    state rather than stranding the coordinator.
+    /// 3. For each descriptor with a valid `LazyDownloadTaskMeta` whose
+    ///    persisted row is `.downloading` AND the key is not already in
+    ///    `terminalKeys`, seed `progressByKey` with an indeterminate
+    ///    spinner so the UI shows progress before the first real
+    ///    `didWriteData`. Tasks for non-`.downloading` rows are stale
+    ///    (OS-preserved past finalization) and ignored.
+    /// 4. Reconcile orphans: each persisted `.downloading` key not in
+    ///    the live set is flipped to `.failed` UNLESS the coordinator
+    ///    already has a `.completed` outcome for that key (a finish
+    ///    callback raced reattach and the WI-4a finalizer hasn't yet
+    ///    advanced persistence to `.local`). The `.completed` outcome
+    ///    stays — the finalizer will reconcile persistence next.
+    private func reattachAndReconcile() async {
+        guard let session, let persistence else {
+            didCompleteReattach = true
+            return
+        }
+        let descriptors = await session.allInFlightDownloads()
+        let persistedDownloading: [String]
+        do {
+            persistedDownloading = try await persistence.fingerprintKeys(withFileState: .downloading)
+        } catch {
+            log.error(
+                "reattach: fingerprintKeys(.downloading) fetch failed: \(String(describing: error), privacy: .private). Skipping reconcile this launch."
+            )
+            didCompleteReattach = true
+            return
+        }
+        let persistedDownloadingSet = Set(persistedDownloading)
+
+        // Seed progress only for live tasks whose persisted row is
+        // `.downloading`. Tasks that the OS preserved for already-final
+        // rows (`.local`, `.failed`, `.remoteOnly`, or deleted) are
+        // ignored here — they're stale and will be cancelled by the
+        // enqueue path (WI-4a) when it next runs, or simply complete
+        // into a coordinator that has no consumer for them. Tasks
+        // already in `terminalKeys` (a delegate event raced reattach
+        // and finished first) are also excluded so the row is treated
+        // as orphaned and reconciled to `.failed`.
+        var liveDownloadingKeys: Set<String> = []
+        for desc in descriptors {
+            guard let meta = LazyDownloadTaskMeta.decode(fromTaskDescription: desc.taskDescription) else {
+                continue
+            }
+            guard persistedDownloadingSet.contains(meta.fingerprintKey) else { continue }
+            guard !terminalKeys.contains(meta.fingerprintKey) else { continue }
+            liveDownloadingKeys.insert(meta.fingerprintKey)
+            progressByKey[meta.fingerprintKey] = LazyDownloadProgress(
+                fingerprintKey: meta.fingerprintKey,
+                bytesWritten: 0,
+                totalBytes: nil
+            )
+        }
+
+        for key in persistedDownloading where !liveDownloadingKeys.contains(key) {
+            // Don't overwrite a `.completed` outcome with `.failed`. The
+            // delegate's finish callback raced reattach and won — let
+            // WI-4a's finalizer advance persistence to `.local` next.
+            if case .completed = outcomes[key] { continue }
+            do {
+                try await persistence.setBookFileState(fingerprintKey: key, newState: .failed)
+            } catch {
+                // Row stays `.downloading` for this launch. We surface
+                // a `.failed` outcome anyway so the row's UI can offer
+                // a retry CTA — the next enqueue+finalize cycle will
+                // re-attempt the persistence write. Never strand a
+                // user-visible row silently.
+                log.error(
+                    "reconcile setBookFileState failed: \(key, privacy: .private) — \(String(describing: error), privacy: .private)"
+                )
+                terminalKeys.insert(key)
+                if outcomes[key] == nil {
+                    outcomes[key] = .failed(
+                        fingerprintKey: key,
+                        reason: "reconcile-persist-failed"
+                    )
+                }
+                continue
+            }
+            terminalKeys.insert(key)
+            // Don't overwrite an existing `.failed` outcome that carried
+            // a more specific reason (e.g. a real network error from a
+            // delegate event that raced reattach). Only fill in the
+            // termination-reason if no outcome exists yet.
+            if outcomes[key] == nil {
+                outcomes[key] = .failed(
+                    fingerprintKey: key,
+                    reason: "interrupted-by-app-termination"
+                )
+            }
+            NotificationCenter.default.post(
+                name: .bookFileStateDidChange,
+                object: nil,
+                userInfo: [
+                    "fingerprintKey": key,
+                    "state": BookFileState.failed.rawValue
+                ]
+            )
+            log.info(
+                "reconcile: \(key, privacy: .private) → .failed (no live task)"
+            )
+        }
+
+        didCompleteReattach = true
     }
 }

--- a/vreaderTests/Services/Backup/LazyDownloadReattachTests.swift
+++ b/vreaderTests/Services/Backup/LazyDownloadReattachTests.swift
@@ -1,0 +1,400 @@
+// Purpose: Tests for LazyDownloadCoordinator's reattach + reconcile
+// behavior at init — recovers in-flight task progress from the
+// background URLSession and flips orphaned `.downloading` rows to
+// `.failed` so the row UI surfaces a retry CTA. Feature #47 WI-3b.
+
+import Testing
+import Foundation
+import SwiftData
+@testable import vreader
+
+/// Hand-built mock for `BackgroundDownloadSessioning`. Stores a fixed
+/// list of descriptors that `allInFlightDownloads()` returns; tests
+/// configure it before constructing the coordinator.
+final class MockBackgroundDownloadSession: BackgroundDownloadSessioning, @unchecked Sendable {
+    private let descriptors: [LazyDownloadTaskDescriptor]
+
+    init(descriptors: [LazyDownloadTaskDescriptor]) {
+        self.descriptors = descriptors
+    }
+
+    func allInFlightDownloads() async -> [LazyDownloadTaskDescriptor] {
+        descriptors
+    }
+}
+
+/// Mock that suspends `allInFlightDownloads()` until `release()` is
+/// called. Used to drive deterministic races between coordinator-state
+/// mutations (didFinishDownload, didFinishDownloadFailed) and the
+/// reattach pass.
+final class GatedMockBackgroundDownloadSession: BackgroundDownloadSessioning, @unchecked Sendable {
+    private let descriptors: [LazyDownloadTaskDescriptor]
+    private let stream: AsyncStream<Void>
+    private let trigger: AsyncStream<Void>.Continuation
+
+    init(descriptors: [LazyDownloadTaskDescriptor]) {
+        self.descriptors = descriptors
+        var capture: AsyncStream<Void>.Continuation!
+        self.stream = AsyncStream<Void> { continuation in capture = continuation }
+        self.trigger = capture
+    }
+
+    func release() { trigger.yield() }
+
+    func allInFlightDownloads() async -> [LazyDownloadTaskDescriptor] {
+        var iter = stream.makeAsyncIterator()
+        _ = await iter.next()
+        return descriptors
+    }
+}
+
+@MainActor
+@Suite("LazyDownloadCoordinator — reattach + reconcile (WI-3b)")
+struct LazyDownloadReattachTests {
+
+    private func validSHA(_ char: Character) -> String { String(repeating: char, count: 64) }
+
+    private func makeMeta(key: String, sha: String, bytes: Int64 = 1024) -> LazyDownloadTaskMeta {
+        LazyDownloadTaskMeta(
+            fingerprintKey: key,
+            blobPath: "VReader/books/epub/\(sha)_\(bytes).epub",
+            expectedSHA256: sha,
+            expectedByteCount: bytes,
+            originalExtension: "epub"
+        )
+    }
+
+    private func makeRecord(
+        sha: String,
+        title: String = "Book",
+        fileState: BookFileState
+    ) -> BookRecord {
+        let fp = DocumentFingerprint(
+            contentSHA256: sha,
+            fileByteCount: 1024,
+            format: .epub
+        )
+        return BookRecord(
+            fingerprintKey: fp.canonicalKey,
+            title: title,
+            author: nil,
+            coverImagePath: nil,
+            fingerprint: fp,
+            provenance: ImportProvenance(
+                source: .filesApp,
+                importedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                originalURLBookmarkData: nil
+            ),
+            detectedEncoding: nil,
+            addedAt: Date(),
+            originalExtension: "epub",
+            fileState: fileState,
+            blobPath: "VReader/books/epub/\(sha)_1024.epub"
+        )
+    }
+
+    // MARK: - Reattach
+
+    @Test func reattach_emptySession_completesQuickly() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let session = MockBackgroundDownloadSession(descriptors: [])
+        let coord = LazyDownloadCoordinator(session: session, persistence: persistence)
+        await coord.waitForReattach()
+        #expect(coord.progressByKey.isEmpty)
+        #expect(coord.outcomes.isEmpty)
+    }
+
+    @Test func reattach_seedsIndeterminateProgressForLiveTasks() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let shaA = validSHA("a")
+        let shaB = validSHA("b")
+        // Persisted rows must already be `.downloading` for reattach to
+        // seed progress — stale OS tasks for non-`.downloading` rows are
+        // ignored (covered separately).
+        let recordA = makeRecord(sha: shaA, fileState: .downloading)
+        let recordB = makeRecord(sha: shaB, fileState: .downloading)
+        _ = try await persistence.insertBook(recordA)
+        _ = try await persistence.insertBook(recordB)
+
+        let metaA = makeMeta(key: recordA.fingerprintKey, sha: shaA)
+        let metaB = makeMeta(key: recordB.fingerprintKey, sha: shaB)
+        let descA = LazyDownloadTaskDescriptor(taskIdentifier: 1, taskDescription: metaA.encodeAsTaskDescription())
+        let descB = LazyDownloadTaskDescriptor(taskIdentifier: 2, taskDescription: metaB.encodeAsTaskDescription())
+        let session = MockBackgroundDownloadSession(descriptors: [descA, descB])
+
+        let coord = LazyDownloadCoordinator(session: session, persistence: persistence)
+        await coord.waitForReattach()
+
+        #expect(coord.progressByKey.count == 2)
+        // bytesWritten 0, totalBytes nil — UI shows indeterminate spinner
+        // until first real didWriteData callback arrives.
+        let pA = coord.progressByKey[recordA.fingerprintKey]
+        #expect(pA?.bytesWritten == 0)
+        #expect(pA?.totalBytes == nil)
+        let pB = coord.progressByKey[recordB.fingerprintKey]
+        #expect(pB?.bytesWritten == 0)
+        #expect(pB?.totalBytes == nil)
+    }
+
+    @Test func reattach_skipsTasksWithUndecodableDescription() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let descGarbage = LazyDownloadTaskDescriptor(taskIdentifier: 1, taskDescription: "garbage")
+        let descNil = LazyDownloadTaskDescriptor(taskIdentifier: 2, taskDescription: nil)
+        let session = MockBackgroundDownloadSession(descriptors: [descGarbage, descNil])
+
+        let coord = LazyDownloadCoordinator(session: session, persistence: persistence)
+        await coord.waitForReattach()
+
+        #expect(coord.progressByKey.isEmpty)
+    }
+
+    // MARK: - Reconcile
+
+    @Test func reconcile_orphanedDownloadingRow_flipsToFailed() async throws {
+        // Persistence has a `.downloading` row but the session has no
+        // matching live task — app crashed mid-flight.
+        let persistence = try CollectionTestHelper.makePersistence()
+        let orphan = makeRecord(sha: validSHA("a"), fileState: .downloading)
+        _ = try await persistence.insertBook(orphan)
+
+        let session = MockBackgroundDownloadSession(descriptors: [])
+
+        let coord = LazyDownloadCoordinator(session: session, persistence: persistence)
+        await coord.waitForReattach()
+
+        // Persistence flipped to .failed.
+        let downloadingKeys = try await persistence.fingerprintKeys(withFileState: .downloading)
+        #expect(downloadingKeys.isEmpty)
+        let failedKeys = try await persistence.fingerprintKeys(withFileState: .failed)
+        #expect(failedKeys == [orphan.fingerprintKey])
+
+        // Coordinator records a .failed outcome and marks the key terminal.
+        #expect(coord.terminalKeys.contains(orphan.fingerprintKey))
+        if case .failed(_, let reason) = coord.outcomes[orphan.fingerprintKey] {
+            #expect(reason == "interrupted-by-app-termination")
+        } else {
+            Issue.record("expected .failed outcome for orphan")
+        }
+    }
+
+    @Test func reconcile_liveDownloadingRow_isNotFlipped() async throws {
+        // Persistence has a `.downloading` row AND the session has a
+        // matching live task. Reconcile leaves the row alone — the live
+        // delegate callbacks will drive it to its real outcome.
+        let persistence = try CollectionTestHelper.makePersistence()
+        let sha = validSHA("a")
+        let live = makeRecord(sha: sha, fileState: .downloading)
+        _ = try await persistence.insertBook(live)
+
+        let liveMeta = makeMeta(key: live.fingerprintKey, sha: sha)
+        let liveDesc = LazyDownloadTaskDescriptor(
+            taskIdentifier: 1,
+            taskDescription: liveMeta.encodeAsTaskDescription()
+        )
+        let session = MockBackgroundDownloadSession(descriptors: [liveDesc])
+
+        let coord = LazyDownloadCoordinator(session: session, persistence: persistence)
+        await coord.waitForReattach()
+
+        let stillDownloading = try await persistence.fingerprintKeys(withFileState: .downloading)
+        #expect(stillDownloading == [live.fingerprintKey])
+        let failed = try await persistence.fingerprintKeys(withFileState: .failed)
+        #expect(failed.isEmpty)
+        // Coordinator seeded indeterminate progress, did NOT mark terminal.
+        #expect(coord.progressByKey[live.fingerprintKey] != nil)
+        #expect(coord.terminalKeys.contains(live.fingerprintKey) == false)
+    }
+
+    @Test func reconcile_postsBookFileStateDidChange() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let orphan = makeRecord(sha: validSHA("a"), fileState: .downloading)
+        _ = try await persistence.insertBook(orphan)
+
+        nonisolated(unsafe) var receivedKey: String?
+        nonisolated(unsafe) var receivedState: String?
+        let token = NotificationCenter.default.addObserver(
+            forName: .bookFileStateDidChange, object: nil, queue: nil
+        ) { note in
+            receivedKey = note.userInfo?["fingerprintKey"] as? String
+            receivedState = note.userInfo?["state"] as? String
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        let session = MockBackgroundDownloadSession(descriptors: [])
+        let coord = LazyDownloadCoordinator(session: session, persistence: persistence)
+        await coord.waitForReattach()
+
+        #expect(receivedKey == orphan.fingerprintKey)
+        #expect(receivedState == "failed")
+    }
+
+    @Test func reconcile_doesNotTouchLocalOrRemoteOnlyOrFailedRows() async throws {
+        // Only `.downloading` rows are reconciled. `.local`, `.remoteOnly`,
+        // `.failed`, `.missingRemote` rows must be left alone.
+        let persistence = try CollectionTestHelper.makePersistence()
+        let local = makeRecord(sha: validSHA("a"), fileState: .local)
+        let remote = makeRecord(sha: validSHA("b"), fileState: .remoteOnly)
+        let failed = makeRecord(sha: validSHA("c"), fileState: .failed)
+        let missing = makeRecord(sha: validSHA("d"), fileState: .missingRemote)
+        _ = try await persistence.insertBook(local)
+        _ = try await persistence.insertBook(remote)
+        _ = try await persistence.insertBook(failed)
+        _ = try await persistence.insertBook(missing)
+
+        let session = MockBackgroundDownloadSession(descriptors: [])
+        let coord = LazyDownloadCoordinator(session: session, persistence: persistence)
+        await coord.waitForReattach()
+
+        #expect(try await persistence.fingerprintKeys(withFileState: .local) == [local.fingerprintKey])
+        #expect(try await persistence.fingerprintKeys(withFileState: .remoteOnly) == [remote.fingerprintKey])
+        #expect(try await persistence.fingerprintKeys(withFileState: .failed) == [failed.fingerprintKey])
+        #expect(try await persistence.fingerprintKeys(withFileState: .missingRemote) == [missing.fingerprintKey])
+    }
+
+    @Test func reattach_mixedLiveAndOrphan_reconcilesOnlyOrphan() async throws {
+        // Persistence has TWO `.downloading` rows. Session has a live
+        // task for ONE of them. The other should be reconciled.
+        let persistence = try CollectionTestHelper.makePersistence()
+        let liveSHA = validSHA("a")
+        let orphanSHA = validSHA("b")
+        let live = makeRecord(sha: liveSHA, fileState: .downloading)
+        let orphan = makeRecord(sha: orphanSHA, fileState: .downloading)
+        _ = try await persistence.insertBook(live)
+        _ = try await persistence.insertBook(orphan)
+
+        let liveMeta = makeMeta(key: live.fingerprintKey, sha: liveSHA)
+        let liveDesc = LazyDownloadTaskDescriptor(
+            taskIdentifier: 1,
+            taskDescription: liveMeta.encodeAsTaskDescription()
+        )
+        let session = MockBackgroundDownloadSession(descriptors: [liveDesc])
+
+        let coord = LazyDownloadCoordinator(session: session, persistence: persistence)
+        await coord.waitForReattach()
+
+        let stillDownloading = try await persistence.fingerprintKeys(withFileState: .downloading)
+        #expect(stillDownloading == [live.fingerprintKey])
+        let failed = try await persistence.fingerprintKeys(withFileState: .failed)
+        #expect(failed == [orphan.fingerprintKey])
+        #expect(coord.progressByKey[live.fingerprintKey] != nil)
+        #expect(coord.terminalKeys.contains(orphan.fingerprintKey))
+    }
+
+    @Test func reattach_liveTaskForLocalRow_isIgnored() async throws {
+        // The OS handed us a live task whose persisted row is `.local`
+        // (already finalized). Don't seed progress, don't treat as
+        // orphan. The task will be cancelled by enqueue path later.
+        let persistence = try CollectionTestHelper.makePersistence()
+        let sha = validSHA("a")
+        let local = makeRecord(sha: sha, fileState: .local)
+        _ = try await persistence.insertBook(local)
+
+        let staleMeta = makeMeta(key: local.fingerprintKey, sha: sha)
+        let staleDesc = LazyDownloadTaskDescriptor(
+            taskIdentifier: 1,
+            taskDescription: staleMeta.encodeAsTaskDescription()
+        )
+        let session = MockBackgroundDownloadSession(descriptors: [staleDesc])
+
+        let coord = LazyDownloadCoordinator(session: session, persistence: persistence)
+        await coord.waitForReattach()
+
+        // No progress seeded; row stays `.local`.
+        #expect(coord.progressByKey.isEmpty)
+        #expect(try await persistence.fingerprintKeys(withFileState: .local) == [local.fingerprintKey])
+    }
+
+    @Test func reattach_liveTaskForFailedRow_isIgnored() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let sha = validSHA("a")
+        let failed = makeRecord(sha: sha, fileState: .failed)
+        _ = try await persistence.insertBook(failed)
+
+        let staleMeta = makeMeta(key: failed.fingerprintKey, sha: sha)
+        let staleDesc = LazyDownloadTaskDescriptor(
+            taskIdentifier: 1,
+            taskDescription: staleMeta.encodeAsTaskDescription()
+        )
+        let session = MockBackgroundDownloadSession(descriptors: [staleDesc])
+
+        let coord = LazyDownloadCoordinator(session: session, persistence: persistence)
+        await coord.waitForReattach()
+
+        #expect(coord.progressByKey.isEmpty)
+        #expect(try await persistence.fingerprintKeys(withFileState: .failed) == [failed.fingerprintKey])
+    }
+
+    // MARK: - Terminal-key races vs reattach
+
+    @Test func reattach_completedRaceDuringInit_doesNotOverwriteOutcome() async throws {
+        // didFinishDownload races reattach. Persistence still says
+        // .downloading because WI-4a's finalizer hasn't yet flipped it
+        // to .local. Reattach must NOT overwrite the .completed outcome
+        // with .failed and must NOT touch persistence (the finalizer
+        // owns that transition).
+        let persistence = try CollectionTestHelper.makePersistence()
+        let sha = validSHA("a")
+        let row = makeRecord(sha: sha, fileState: .downloading)
+        _ = try await persistence.insertBook(row)
+
+        let gatedSession = GatedMockBackgroundDownloadSession(descriptors: [])
+        let coord = LazyDownloadCoordinator(session: gatedSession, persistence: persistence)
+
+        // didFinishDownload runs before reattach observes anything.
+        coord.didFinishDownload(
+            fingerprintKey: row.fingerprintKey,
+            meta: makeMeta(key: row.fingerprintKey, sha: sha),
+            stagedURL: URL(fileURLWithPath: "/tmp/staged.epub")
+        )
+
+        gatedSession.release()
+        await coord.waitForReattach()
+
+        // .completed outcome preserved.
+        if case .completed = coord.outcomes[row.fingerprintKey] {
+            // ok
+        } else {
+            Issue.record("expected .completed outcome to survive reattach")
+        }
+        // Persistence still .downloading (WI-4a's finalizer will advance).
+        let downloading = try await persistence.fingerprintKeys(withFileState: .downloading)
+        #expect(downloading == [row.fingerprintKey])
+    }
+
+    @Test func reattach_failedRaceDuringInit_preservesSpecificReason() async throws {
+        // didFinishDownloadFailed races reattach with a specific reason
+        // ("network timeout"). Reattach reconciles persistence to
+        // .failed but must NOT overwrite the existing outcome.
+        let persistence = try CollectionTestHelper.makePersistence()
+        let sha = validSHA("a")
+        let row = makeRecord(sha: sha, fileState: .downloading)
+        _ = try await persistence.insertBook(row)
+
+        let gatedSession = GatedMockBackgroundDownloadSession(descriptors: [])
+        let coord = LazyDownloadCoordinator(session: gatedSession, persistence: persistence)
+
+        coord.didFinishDownloadFailed(fingerprintKey: row.fingerprintKey, reason: "network timeout")
+
+        gatedSession.release()
+        await coord.waitForReattach()
+
+        // Outcome reason preserved (more specific than termination).
+        if case .failed(_, let reason) = coord.outcomes[row.fingerprintKey] {
+            #expect(reason == "network timeout")
+        } else {
+            Issue.record("expected .failed outcome to survive reattach")
+        }
+        // Persistence flipped to .failed.
+        let failed = try await persistence.fingerprintKeys(withFileState: .failed)
+        #expect(failed == [row.fingerprintKey])
+    }
+
+    // MARK: - Skeleton init backward compat
+
+    @Test func skeletonInit_completesReattachImmediately() async {
+        let coord = LazyDownloadCoordinator()
+        await coord.waitForReattach()
+        #expect(coord.progressByKey.isEmpty)
+        #expect(coord.outcomes.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `BackgroundDownloadSessioning` protocol + `URLSessionBackgroundSession` production wrapper as the test seam for the background URLSession.
- `LazyDownloadCoordinator` gains a second init taking `(session, persistence)` that runs `reattachAndReconcile()` at boot — recovers in-flight task progress and flips orphaned `.downloading` rows to `.failed` so the row UI surfaces a retry CTA.
- Race-safe: gated tests pin that a `.completed` outcome from a delegate event that beats reattach is preserved (WI-4a's finalizer will advance persistence to `.local`); a `.failed` outcome with a specific reason isn't overwritten by the generic termination reason.
- 13 new reattach tests (incl. mixed live+orphan, stale tasks for non-`.downloading` rows, gated race scenarios). All 50 backup unit tests passing.

Refs #47

## What Changed

- New `BackgroundDownloadSession.swift` (~80 LOC): `BackgroundDownloadSessioning` protocol + `URLSessionBackgroundSession` wrapper + `LazyDownloadTaskDescriptor` value type
- Modified `LazyDownloadCoordinator.swift` (now ~280 LOC): second init, `reattachAndReconcile()`, `waitForReattach()` test barrier, `bookFileStateDidChange` notification
- New `LazyDownloadReattachTests.swift` (~280 LOC): `MockBackgroundDownloadSession` + `GatedMockBackgroundDownloadSession` + 13 tests
- Version 3.11.19 → 3.11.20 (build 52)

## Codex Audit

3 rounds. All High/Medium findings fixed:
- Round 1 (5 issues): terminal-key race, stale tasks for non-`.downloading` rows, swallowed fetch error, save-error stranding, missing tests
- Round 2 (3 issues): `.completed` race overwriting outcome, `.failed`-reason loss, persist-fail notification
- Round 3 (clean — 2 LOW follow-ups deferred to WI-7)

## Out of Scope

- `VReaderAppDelegate` adaptor + `handleEventsForBackgroundURLSession` (next PR)
- Cancel API for orphan tasks (WI-4a, with enqueue)

## Validation

- [x] 50/50 unit tests pass (`xcodebuild test -only-testing:vreaderTests/{LazyDownloadReattachTests,LazyDownloadCoordinatorTests,LazyDownloadTaskMetaTests,LazyDownloadDelegateStagingTests,PersistenceActorRemoteOnlyTests}`)
- [x] Reattach + reconcile race-safe under MainActor isolation
- [x] Skeleton init preserved for WI-3a backward compat
- [ ] Background-event app delegate hook (next PR)

## Type of Change

- [x] Feature (#47 WI-3b)