### PR TITLE
feat(#47): WI-3b finisher — VReaderAppDelegate background-event bridge

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,8 @@ VReader is an iOS e-book reader built with SwiftUI + SwiftData. It supports TXT,
 
 ### 1. App Layer (`vreader/App/`)
 
-- `VReaderApp.swift` — SwiftData `ModelContainer` init (SchemaV5), migration plan (V1→V2→V3→V4→V5), test seeding, error handling. Injects the live `PersistenceActor` into the SwiftUI environment via `\.persistenceActor` so settings sub-screens can construct backup providers without rewriting every parent's signature.
+- `VReaderApp.swift` — SwiftData `ModelContainer` init (SchemaV6), migration plan (V1→V2→V3→V4→V5→V6), test seeding, error handling. Injects the live `PersistenceActor` into the SwiftUI environment via `\.persistenceActor` so settings sub-screens can construct backup providers without rewriting every parent's signature. Adopts `@UIApplicationDelegateAdaptor(VReaderAppDelegate.self)` for background-URLSession completion-handler delivery (feature #47).
+- `VReaderAppDelegate.swift` — `UIApplicationDelegate` adapter that captures `application(_:handleEventsForBackgroundURLSession:completionHandler:)` into a MainActor-isolated static dictionary keyed by URLSession identifier. The lazy-download coordinator retrieves and invokes the handler from `LazyDownloadDelegate.urlSessionDidFinishEvents` so iOS releases the app's background-launch grace period.
 
 ### 2. Library Layer (`vreader/Views/LibraryView.swift`, `vreader/ViewModels/LibraryViewModel.swift`)
 

--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 52
-        MARKETING_VERSION: 3.11.20
+        CURRENT_PROJECT_VERSION: 53
+        MARKETING_VERSION: 3.11.21
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 		48A22C07CC24A5D79F564EAC /* BookSourceReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E1D54FF8AE0329DA462E95B /* BookSourceReaderView.swift */; };
 		48AC1E0108D690FE895D85BC /* ChapterCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87C8250CCE8B0B8C1AD2ED9 /* ChapterCacheTests.swift */; };
 		48C743A0324468FF7507F157 /* RuleEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1A348FFCBCC9C7A5360C28 /* RuleEngineTests.swift */; };
+		4914FBDCD76FD1D972914081 /* VReaderAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D19CA6B370181C8BF08270 /* VReaderAppDelegate.swift */; };
 		4930168887D85648F1EDA897 /* MigrationFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E394527455B13D1EE9B06A9 /* MigrationFixtures.swift */; };
 		497BE2970C924807C3451FA0 /* fixed-layout.js in Resources */ = {isa = PBXBuildFile; fileRef = C47343EAD4CE63CDA1604255 /* fixed-layout.js */; };
 		49D992E6F2DAB74CCD4FDC68 /* TokenSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D944728B17A940A3716EA9 /* TokenSpanTests.swift */; };
@@ -605,6 +606,7 @@
 		CEAEA28FA9D03BDAACC97CBF /* SyncOutboundQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B00C0FE14AB02EDE7E9EDD /* SyncOutboundQueueTests.swift */; };
 		CFC40B5FB55F37C092A70338 /* VReaderAnnotationParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36D5CFF47A223349C004E39 /* VReaderAnnotationParserTests.swift */; };
 		CFF2F7127E363B96F2B6429B /* LibraryBookItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E3D2050D82A39083191EDDA /* LibraryBookItem.swift */; };
+		D0373F025DFBBEF9FAD19788 /* LazyDownloadBackgroundEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F891C451718B4BC9AC7BCEC /* LazyDownloadBackgroundEventsTests.swift */; };
 		D08EB57C5EBC9C9542476015 /* MetadataExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC5F159064D57CFAE2A676 /* MetadataExtractorTests.swift */; };
 		D0E3C146DC0F8D0978B419E7 /* AIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C4804D4D5F435DF10014C5 /* AIError.swift */; };
 		D0FB5FB63B24803C9ADA5E1A /* EPUBHighlightBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C5EC86BB06D46DC9A5A4F6B /* EPUBHighlightBridgeTests.swift */; };
@@ -868,6 +870,7 @@
 		2ED1C14FB27E5FF826BA26AF /* vreaderUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = vreaderUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2ED5B25F56B248FE8953B5A1 /* ChangeTokenStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeTokenStoreTests.swift; sourceTree = "<group>"; };
 		2F317CDBF13A6A5673D64A8A /* TextKit2Paginator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextKit2Paginator.swift; sourceTree = "<group>"; };
+		2F891C451718B4BC9AC7BCEC /* LazyDownloadBackgroundEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyDownloadBackgroundEventsTests.swift; sourceTree = "<group>"; };
 		300CB93197976B4D665AEDFC /* PersistenceActor+RemoteOnly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+RemoteOnly.swift"; sourceTree = "<group>"; };
 		30D00221E111683E9FF0260A /* SearchTextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTextExtractor.swift; sourceTree = "<group>"; };
 		317401FBAE274C615325BDBC /* SourceSharingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceSharingServiceTests.swift; sourceTree = "<group>"; };
@@ -1025,6 +1028,7 @@
 		5FDB1CD71ED267C2FD85F325 /* MDMetadataExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDMetadataExtractorTests.swift; sourceTree = "<group>"; };
 		605C9BAEA41B7C63D7E343B1 /* VReaderApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderApp.swift; sourceTree = "<group>"; };
 		607B063A54628D2CC2CFCC35 /* NSUKVSBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSUKVSBridgeTests.swift; sourceTree = "<group>"; };
+		60D19CA6B370181C8BF08270 /* VReaderAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderAppDelegate.swift; sourceTree = "<group>"; };
 		61D944728B17A940A3716EA9 /* TokenSpanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSpanTests.swift; sourceTree = "<group>"; };
 		61DB3214E22D83E3A8E19212 /* FoliateJSEscaperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateJSEscaperTests.swift; sourceTree = "<group>"; };
 		61E8B92C301E5470AB98C87E /* LocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorTests.swift; sourceTree = "<group>"; };
@@ -1531,6 +1535,7 @@
 				2CB31146A831DACE67C50F08 /* AppConfiguration.swift */,
 				A0797CB73F5D8FDAF0B7298E /* TestSeeder.swift */,
 				605C9BAEA41B7C63D7E343B1 /* VReaderApp.swift */,
+				60D19CA6B370181C8BF08270 /* VReaderAppDelegate.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -2555,6 +2560,7 @@
 				ED150D276C082FEC194F2F31 /* BackupProviderContractTests.swift */,
 				BFB65788879E3D91E69E8BA5 /* BlobPathTests.swift */,
 				04ED79BFAD4BEF6B8A30F982 /* BookFileMaterializerTests.swift */,
+				2F891C451718B4BC9AC7BCEC /* LazyDownloadBackgroundEventsTests.swift */,
 				67368B0914CFE12052417225 /* LazyDownloadCoordinatorTests.swift */,
 				E5D4DDB55DA30E015172A16D /* LazyDownloadDelegateStagingTests.swift */,
 				E124CB39746DB0B59D0390C3 /* LazyDownloadReattachTests.swift */,
@@ -3235,6 +3241,7 @@
 				5128BF72998C4F697D2A6A84 /* ImportProvenanceTests.swift in Sources */,
 				298EB8447E1427B7FE4CE0F9 /* JSONExportTests.swift in Sources */,
 				53DEE85CF4BDE11891B0E07A /* KeychainServiceTests.swift in Sources */,
+				D0373F025DFBBEF9FAD19788 /* LazyDownloadBackgroundEventsTests.swift in Sources */,
 				63034CF313C6829AEA1C5278 /* LazyDownloadCoordinatorTests.swift in Sources */,
 				91B3A04F3B23BE09FCA9967C /* LazyDownloadDelegateStagingTests.swift in Sources */,
 				2464151C976B35F68DD2169A /* LazyDownloadReattachTests.swift in Sources */,
@@ -3763,6 +3770,7 @@
 				1CB7C39AC6FE3B715D4B4305 /* V1toV2Migration.swift in Sources */,
 				85A712EBB7E4B4DF30EDEA13 /* VReaderAnnotationParser.swift in Sources */,
 				F10FCB9E3EC6862A640BD406 /* VReaderApp.swift in Sources */,
+				4914FBDCD76FD1D972914081 /* VReaderAppDelegate.swift in Sources */,
 				539E581AA8A8427E199AC0A7 /* WebDAVBlobStore.swift in Sources */,
 				C5EEEAABF1F852CDABDA43F1 /* WebDAVClient.swift in Sources */,
 				C64AA5071C05D395445A735D /* WebDAVProvider.swift in Sources */,
@@ -3894,13 +3902,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.20;
+				MARKETING_VERSION = 3.11.21;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4044,13 +4052,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.20;
+				MARKETING_VERSION = 3.11.21;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/App/VReaderApp.swift
+++ b/vreader/App/VReaderApp.swift
@@ -4,6 +4,13 @@ import SwiftData
 @main
 @MainActor
 struct VReaderApp: App {
+    /// Captures `application(_:handleEventsForBackgroundURLSession:completionHandler:)`
+    /// so the lazy-download coordinator can invoke the handler when its
+    /// background URLSession finishes delivering queued events.
+    /// SwiftUI's App lifecycle doesn't expose this hook directly.
+    /// Feature #47 WI-3b.
+    @UIApplicationDelegateAdaptor(VReaderAppDelegate.self) private var appDelegate
+
     private let modelContainer: ModelContainer?
     private let initError: String?
     /// Cached content view to avoid recreating the ViewModel on every `body` evaluation.

--- a/vreader/App/VReaderAppDelegate.swift
+++ b/vreader/App/VReaderAppDelegate.swift
@@ -1,0 +1,75 @@
+// Purpose: UIApplicationDelegate adapter that captures the
+// `handleEventsForBackgroundURLSession` completion handler so the
+// LazyDownloadCoordinator can invoke it from
+// `urlSessionDidFinishEvents(forBackgroundURLSession:)`. iOS will
+// suspend the app's background-launch grace period until the handler
+// runs, so dropping it leaks battery and orphans pending events.
+//
+// SwiftUI's `App` lifecycle doesn't expose this hook, so we bridge it
+// via `@UIApplicationDelegateAdaptor(VReaderAppDelegate.self)` in
+// `VReaderApp`.
+//
+// Feature #47 WI-3b.
+//
+// @coordinates-with: VReaderApp.swift, LazyDownloadCoordinator.swift,
+//   LazyDownloadDelegate.swift,
+//   dev-docs/plans/20260503-feature-47-selective-picker-lazy-load.md
+
+import UIKit
+import OSLog
+
+private let log = Logger(subsystem: "com.vreader.app", category: "VReaderAppDelegate")
+
+final class VReaderAppDelegate: NSObject, UIApplicationDelegate {
+
+    /// Background-event completion handlers keyed by URLSession identifier.
+    /// MainActor-isolated because reads/writes happen from the
+    /// UIApplicationDelegate callback (UIKit guarantees main thread) and
+    /// the LazyDownloadCoordinator (`@MainActor`). Static so the
+    /// coordinator can retrieve handlers without holding a reference to
+    /// the adapter instance — `@UIApplicationDelegateAdaptor` doesn't
+    /// expose its instance through SwiftUI Environment.
+    @MainActor
+    static var backgroundCompletionHandlers: [String: () -> Void] = [:]
+
+    /// iOS calls this on the main thread when relaunching the app to
+    /// deliver background download events. Stores the handler
+    /// synchronously — an async hop here can race
+    /// `urlSessionDidFinishEvents` and lose the handler, leaking iOS's
+    /// background-launch grace period.
+    func application(
+        _ application: UIApplication,
+        handleEventsForBackgroundURLSession identifier: String,
+        completionHandler: @escaping () -> Void
+    ) {
+        MainActor.assumeIsolated {
+            Self.storeBackgroundHandler(completionHandler, for: identifier)
+        }
+    }
+
+    /// Stores a completion handler for `identifier`. If a handler for the
+    /// same identifier is already present (rare — would mean iOS
+    /// delivered a second handoff for the same session events without
+    /// the previous one being released), invokes the old handler before
+    /// replacing it so the previous run doesn't leak the grace period.
+    @MainActor
+    static func storeBackgroundHandler(_ handler: @escaping () -> Void, for identifier: String) {
+        if let previous = backgroundCompletionHandlers[identifier] {
+            log.error(
+                "duplicate handleEventsForBackgroundURLSession for \(identifier, privacy: .public); invoking previous handler before replace"
+            )
+            previous()
+        }
+        backgroundCompletionHandlers[identifier] = handler
+    }
+
+    /// Removes and returns the handler for the given identifier. Called
+    /// by `LazyDownloadCoordinator.didFinishBackgroundEvents` from the
+    /// `URLSessionDelegate.urlSessionDidFinishEvents` hop. Returns nil
+    /// if no handler was registered (events arrived without a fresh
+    /// app launch — normal during foreground operation).
+    @MainActor
+    static func takeBackgroundHandler(for identifier: String) -> (() -> Void)? {
+        backgroundCompletionHandlers.removeValue(forKey: identifier)
+    }
+}

--- a/vreader/Services/Backup/LazyDownloadCoordinator.swift
+++ b/vreader/Services/Backup/LazyDownloadCoordinator.swift
@@ -181,6 +181,37 @@ final class LazyDownloadCoordinator {
         progressByKey.removeValue(forKey: fingerprintKey)
     }
 
+    // MARK: - Background-event handler invocation
+
+    /// Called by `LazyDownloadDelegate.urlSessionDidFinishEvents` after
+    /// iOS has finished delivering all queued background events for the
+    /// session. Retrieves the stored UIApplicationDelegate completion
+    /// handler (registered when iOS relaunched the app via
+    /// `application(_:handleEventsForBackgroundURLSession:completionHandler:)`)
+    /// and invokes it. iOS will not release the app's background-launch
+    /// grace period until the handler runs.
+    ///
+    /// `handlerProvider` is injected only in tests — production reads
+    /// `VReaderAppDelegate.takeBackgroundHandler(for:)`.
+    func didFinishBackgroundEvents(
+        sessionIdentifier: String,
+        handlerProvider: ((String) -> (() -> Void)?)? = nil
+    ) {
+        let take = handlerProvider ?? { id in
+            VReaderAppDelegate.takeBackgroundHandler(for: id)
+        }
+        guard let handler = take(sessionIdentifier) else {
+            log.info(
+                "didFinishBackgroundEvents: no handler for session \(sessionIdentifier, privacy: .public) (foreground events?)"
+            )
+            return
+        }
+        handler()
+        log.info(
+            "didFinishBackgroundEvents: invoked handler for session \(sessionIdentifier, privacy: .public)"
+        )
+    }
+
     /// Test seam — wipes all coordinator state. Production never calls this.
     func reset() {
         progressByKey = [:]

--- a/vreader/Services/Backup/LazyDownloadDelegate.swift
+++ b/vreader/Services/Backup/LazyDownloadDelegate.swift
@@ -101,6 +101,25 @@ final class LazyDownloadDelegate: NSObject, URLSessionDownloadDelegate, @uncheck
         }
     }
 
+    /// Called by URLSession when all background events for the session
+    /// have been delivered. Forwards to the coordinator if alive, but
+    /// ALWAYS invokes the stored UIApplicationDelegate completion
+    /// handler — iOS will not release the app's background-launch grace
+    /// period until that handler runs, even if the coordinator was
+    /// torn down (test harness, app shutting down, etc.).
+    func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+        let identifier = session.configuration.identifier ?? ""
+        Task { @MainActor [weak coordinator] in
+            if let coordinator {
+                coordinator.didFinishBackgroundEvents(sessionIdentifier: identifier)
+            } else {
+                // Coordinator is gone — invoke the AppDelegate handler
+                // directly so iOS doesn't leak the grace period.
+                VReaderAppDelegate.takeBackgroundHandler(for: identifier)?()
+            }
+        }
+    }
+
     /// Task completed (success or error). Errors here mean the task itself
     /// failed (network, server 4xx/5xx, cancelled).
     func urlSession(

--- a/vreaderTests/Services/Backup/LazyDownloadBackgroundEventsTests.swift
+++ b/vreaderTests/Services/Backup/LazyDownloadBackgroundEventsTests.swift
@@ -1,0 +1,121 @@
+// Purpose: Tests for the background-event handler bridge between iOS's
+// `application(_:handleEventsForBackgroundURLSession:completionHandler:)`,
+// `VReaderAppDelegate`, and the lazy-download coordinator. Feature #47
+// WI-3b. iOS will not release the app's background-launch grace period
+// until the handler runs, so dropping it leaks battery and orphans
+// pending events.
+
+import Testing
+import Foundation
+@testable import vreader
+
+@MainActor
+@Suite("VReaderAppDelegate — background event handler storage")
+struct VReaderAppDelegateTests {
+
+    @Test func takeBackgroundHandler_unknownIdentifier_returnsNil() {
+        let id = UUID().uuidString
+        #expect(VReaderAppDelegate.takeBackgroundHandler(for: id) == nil)
+    }
+
+    @Test func storeAndRetrieve_returnsSameHandler() async {
+        let id = UUID().uuidString
+        var didFire = false
+        VReaderAppDelegate.backgroundCompletionHandlers[id] = { didFire = true }
+        let handler = VReaderAppDelegate.takeBackgroundHandler(for: id)
+        #expect(handler != nil)
+        handler?()
+        #expect(didFire)
+        // Removed after take.
+        #expect(VReaderAppDelegate.backgroundCompletionHandlers[id] == nil)
+    }
+
+    @Test func multipleSessionIdentifiers_storedIndependently() {
+        let idA = UUID().uuidString
+        let idB = UUID().uuidString
+        var firedA = false
+        var firedB = false
+        VReaderAppDelegate.backgroundCompletionHandlers[idA] = { firedA = true }
+        VReaderAppDelegate.backgroundCompletionHandlers[idB] = { firedB = true }
+
+        VReaderAppDelegate.takeBackgroundHandler(for: idA)?()
+        #expect(firedA)
+        #expect(firedB == false)
+
+        VReaderAppDelegate.takeBackgroundHandler(for: idB)?()
+        #expect(firedB)
+    }
+
+    @Test func storeBackgroundHandler_duplicateIdentifier_invokesPreviousBeforeReplace() {
+        // iOS shouldn't deliver two handoffs for the same session
+        // identifier, but if it does, dropping the previous handler
+        // would leak iOS's background-launch grace period for that run.
+        // The store must invoke the previous handler before overwriting.
+        let id = UUID().uuidString
+        var firedFirst = false
+        var firedSecond = false
+        VReaderAppDelegate.storeBackgroundHandler({ firedFirst = true }, for: id)
+        VReaderAppDelegate.storeBackgroundHandler({ firedSecond = true }, for: id)
+        // First handler invoked during replace.
+        #expect(firedFirst)
+        // Second handler stored, awaiting urlSessionDidFinishEvents.
+        #expect(firedSecond == false)
+        VReaderAppDelegate.takeBackgroundHandler(for: id)?()
+        #expect(firedSecond)
+    }
+}
+
+@MainActor
+@Suite("LazyDownloadCoordinator.didFinishBackgroundEvents")
+struct LazyDownloadBackgroundEventsTests {
+
+    @Test func invokesProvidedHandler() {
+        let coord = LazyDownloadCoordinator()
+        var fired = false
+        coord.didFinishBackgroundEvents(
+            sessionIdentifier: "com.test.session",
+            handlerProvider: { id in
+                #expect(id == "com.test.session")
+                return { fired = true }
+            }
+        )
+        #expect(fired)
+    }
+
+    @Test func missingHandler_doesNotCrash() {
+        let coord = LazyDownloadCoordinator()
+        // Foreground events arriving without a fresh app-launch handoff
+        // is normal — the no-op path must not assert/crash.
+        coord.didFinishBackgroundEvents(
+            sessionIdentifier: "no.such.session",
+            handlerProvider: { _ in nil }
+        )
+    }
+
+    @Test func handlerIsInvokedExactlyOnce() {
+        let coord = LazyDownloadCoordinator()
+        var fireCount = 0
+        coord.didFinishBackgroundEvents(
+            sessionIdentifier: "x",
+            handlerProvider: { _ in { fireCount += 1 } }
+        )
+        #expect(fireCount == 1)
+    }
+
+    @Test func defaultProvider_readsFromAppDelegate() {
+        // Without `handlerProvider`, the coordinator must consult
+        // `VReaderAppDelegate.takeBackgroundHandler(for:)` — the
+        // production wiring iOS uses to release background grace.
+        let id = "com.vreader.test.session.\(UUID().uuidString)"
+        var fired = false
+        VReaderAppDelegate.backgroundCompletionHandlers[id] = { fired = true }
+
+        let coord = LazyDownloadCoordinator()
+        coord.didFinishBackgroundEvents(sessionIdentifier: id)
+
+        #expect(fired)
+        // Handler removed after invocation so a second event doesn't
+        // double-fire it.
+        #expect(VReaderAppDelegate.backgroundCompletionHandlers[id] == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- Wires iOS's `application(_:handleEventsForBackgroundURLSession:completionHandler:)` through `VReaderAppDelegate` to `LazyDownloadCoordinator.didFinishBackgroundEvents`.
- iOS won't release the app's background-launch grace period until the stored handler runs, so this is mandatory for backgrounded lazy-downloads.
- Closes WI-3b. Next: WI-3c (Wi-Fi-only network policy).

Refs #47

## What Changed

- New `VReaderAppDelegate.swift` (~70 LOC) — UIApplicationDelegate adapter with MainActor-isolated static dict
- `VReaderApp.swift` — `@UIApplicationDelegateAdaptor(VReaderAppDelegate.self)`
- `LazyDownloadDelegate.urlSessionDidFinishEvents` — forwards to coordinator OR invokes AppDelegate directly if coordinator is gone
- `LazyDownloadCoordinator.didFinishBackgroundEvents` — takes handler, invokes once; `handlerProvider` test seam
- `docs/architecture.md` App Layer section updated
- Version 3.11.20 → 3.11.21 (build 53)

## Codex Audit

2 rounds. All High/Medium fixed:
- Round 1: async storage race (could drop handler), coordinator-nil drops handler, duplicate identifier overwrite, test gap, docs
- Round 2: clean

## Validation

- [x] 35/35 backup tests pass

## Type of Change

- [x] Feature (#47 WI-3b finisher)