### PR TITLE
feat(#47): WI-3c — WebDAVNetworkPolicy Wi-Fi-only gate

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 53
-        MARKETING_VERSION: 3.11.21
+        CURRENT_PROJECT_VERSION: 54
+        MARKETING_VERSION: 3.11.22
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		058C2F104DE6D10D81F907D9 /* AnnotationExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB9773A4631BEDEDD187F08 /* AnnotationExporterTests.swift */; };
 		05BE70789318FA085B9A735E /* AIChatViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E861A379A620B769CEA36300 /* AIChatViewModelTests.swift */; };
 		0681EC94635E9BBB798AAB77 /* SearchHighlightDismissTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62569DC663E2BDD2DC0155C3 /* SearchHighlightDismissTests.swift */; };
+		069B04BFCB5D0D4FA8EA5972 /* WebDAVNetworkPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D408C9CE57D4C437A72C0D18 /* WebDAVNetworkPolicy.swift */; };
 		06C8E85FDBC83E56C5BF3B64 /* EPUBProgressCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBBB555BA86F7648ACBC780F /* EPUBProgressCalculator.swift */; };
 		070F22DA080E6D84CC1EF73D /* TXTReflowableTextSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16D420A03BD524C247A78FB /* TXTReflowableTextSource.swift */; };
 		076CA91860D0CAF278F65B50 /* ReaderSettingsPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F75167F586CEA5F4E9002C /* ReaderSettingsPanel.swift */; };
@@ -82,6 +83,7 @@
 		1AC5FD48311C93B5CEB3702E /* BookImporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FBDC41C60328ED4FB8A197 /* BookImporterTests.swift */; };
 		1B78DA4330A421FE2206B70C /* FoliateSearchAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8C36563D7885AD214F885A /* FoliateSearchAdapter.swift */; };
 		1BD4CC8621C43917629D4728 /* HighlightRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96BE19585BF1F4C8174F7219 /* HighlightRecord.swift */; };
+		1C44F27B696718DDCDCD8942 /* WebDAVNetworkPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B73649BCBDBE8A99B210A9 /* WebDAVNetworkPolicyTests.swift */; };
 		1C78AB9020A2E03A196FA6A1 /* ChapterProgressCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 936C16A4F1B2B55E63922EE7 /* ChapterProgressCalculator.swift */; };
 		1C9B4E21A97013A7CC409925 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DAC8E20A001D7803A16AAD1 /* SearchView.swift */; };
 		1CB7C39AC6FE3B715D4B4305 /* V1toV2Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB16317C72EB6BBB61D77030 /* V1toV2Migration.swift */; };
@@ -1248,6 +1250,7 @@
 		B1DBBFF061B96088FFE84194 /* TXTService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTService.swift; sourceTree = "<group>"; };
 		B294CBB624E1CE03FEFA40E6 /* WebDAVProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProviderTests.swift; sourceTree = "<group>"; };
 		B2A04EAFA37410DA616E33D6 /* BackgroundDownloadSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundDownloadSession.swift; sourceTree = "<group>"; };
+		B2B73649BCBDBE8A99B210A9 /* WebDAVNetworkPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVNetworkPolicyTests.swift; sourceTree = "<group>"; };
 		B2DB7F421D9D2E7492E12F89 /* ZIPReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZIPReader.swift; sourceTree = "<group>"; };
 		B34C87EDF46A4EFC99012268 /* AnnotationsPanelPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationsPanelPlaceholderTests.swift; sourceTree = "<group>"; };
 		B3987200016FB6CA3D063E44 /* LocatorCanonicalHashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorCanonicalHashTests.swift; sourceTree = "<group>"; };
@@ -1338,6 +1341,7 @@
 		D2EA03BEFDBB65F5D7533EDE /* SchemaV1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV1Tests.swift; sourceTree = "<group>"; };
 		D363190FCDF47ED48A1D7BC1 /* ReaderLifecycleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderLifecycleHelper.swift; sourceTree = "<group>"; };
 		D36D5CFF47A223349C004E39 /* VReaderAnnotationParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderAnnotationParserTests.swift; sourceTree = "<group>"; };
+		D408C9CE57D4C437A72C0D18 /* WebDAVNetworkPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVNetworkPolicy.swift; sourceTree = "<group>"; };
 		D432C9B43D1B6662B4605664 /* BookmarkListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkListViewModel.swift; sourceTree = "<group>"; };
 		D4B4E4FB28FD82376AE20A4F /* DocumentFingerprintValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentFingerprintValidationTests.swift; sourceTree = "<group>"; };
 		D52DADD2C2FB6330070EA6DE /* FileSizeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSizeFormatter.swift; sourceTree = "<group>"; };
@@ -1649,6 +1653,7 @@
 				DB6CE81404902AB359536964 /* PROPFINDParser.swift */,
 				9DAC16C19C7D4C72EFC950C9 /* WebDAVBlobStore.swift */,
 				4946129FECC6C9BA7A7F16A1 /* WebDAVClient.swift */,
+				D408C9CE57D4C437A72C0D18 /* WebDAVNetworkPolicy.swift */,
 				C3EF8CE8D52815CF5156953C /* WebDAVProvider.swift */,
 				CEBBF9A79AEFC8CDEE7B3302 /* WebDAVProviderFactory.swift */,
 				151860CC8834DB8ACBF7E927 /* ZIPWriter.swift */,
@@ -2570,6 +2575,7 @@
 				C3F1695C0E7481CB3EA2B8A3 /* WebDAVBackupIntegrationTests.swift */,
 				C74A4D9FF0F23D7D38DC185F /* WebDAVBlobStoreTests.swift */,
 				BE8121B86DA337766FD55AEF /* WebDAVClientTests.swift */,
+				B2B73649BCBDBE8A99B210A9 /* WebDAVNetworkPolicyTests.swift */,
 				B294CBB624E1CE03FEFA40E6 /* WebDAVProviderTests.swift */,
 			);
 			path = Backup;
@@ -3398,6 +3404,7 @@
 				4D66B6E16F96E24A0B01F7A9 /* WebDAVBackupIntegrationTests.swift in Sources */,
 				7F17555C4DA7C6845661BBB5 /* WebDAVBlobStoreTests.swift in Sources */,
 				6B19F49F1DECB5EF45BACC88 /* WebDAVClientTests.swift in Sources */,
+				1C44F27B696718DDCDCD8942 /* WebDAVNetworkPolicyTests.swift in Sources */,
 				77D706EE2E466C650B00C381 /* WebDAVProviderTests.swift in Sources */,
 				88B73AB500D0DFD555AC9363 /* WebPageEncodingDetectorTests.swift in Sources */,
 				E153024C836519993C468665 /* ZIPReaderTests.swift in Sources */,
@@ -3773,6 +3780,7 @@
 				4914FBDCD76FD1D972914081 /* VReaderAppDelegate.swift in Sources */,
 				539E581AA8A8427E199AC0A7 /* WebDAVBlobStore.swift in Sources */,
 				C5EEEAABF1F852CDABDA43F1 /* WebDAVClient.swift in Sources */,
+				069B04BFCB5D0D4FA8EA5972 /* WebDAVNetworkPolicy.swift in Sources */,
 				C64AA5071C05D395445A735D /* WebDAVProvider.swift in Sources */,
 				F2C53E71EFF6601811CE4003 /* WebDAVProviderFactory.swift in Sources */,
 				671D7F1B0A003041831E308E /* WebDAVSettingsView.swift in Sources */,
@@ -3902,13 +3910,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.21;
+				MARKETING_VERSION = 3.11.22;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4052,13 +4060,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.21;
+				MARKETING_VERSION = 3.11.22;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Backup/WebDAVNetworkPolicy.swift
+++ b/vreader/Services/Backup/WebDAVNetworkPolicy.swift
@@ -1,0 +1,149 @@
+// Purpose: Wi-Fi-only gate for lazy book-blob downloads. Owns a single
+// `NWPathMonitor` and publishes the current interface kind so the
+// lazy-download coordinator (and "Restore all" UI) can defer
+// transfers to Wi-Fi when the user has opted in.
+//
+// Why not URLSession.allowsCellularAccess: setting that flag to false
+// CANCELS the task when the interface flips to cellular mid-flight
+// instead of pausing it. We want pause-and-resume semantics, so we set
+// `allowsCellularAccess = true` on the background session and gate at
+// the enqueue layer (WI-4a) using `policy.shouldStart()`.
+//
+// Feature #47 WI-3c.
+//
+// @coordinates-with: LazyDownloadCoordinator.swift,
+//   BackgroundDownloadSession.swift,
+//   dev-docs/plans/20260503-feature-47-selective-picker-lazy-load.md
+
+import Foundation
+import Network
+import OSLog
+import Observation
+
+private let log = Logger(subsystem: "com.vreader.app", category: "WebDAVNetworkPolicy")
+
+/// Current network interface for downloads. `.unknown` is the initial
+/// state before NWPathMonitor's first callback lands.
+enum WebDAVNetworkInterface: String, Sendable, Equatable {
+    case unknown
+    case none
+    case cellular
+    case wifi
+}
+
+/// Test seam for `NWPathMonitor`. Production wraps the real monitor;
+/// tests inject a controllable fake that fires path-change events on
+/// demand.
+protocol NetworkPathMonitoring: AnyObject, Sendable {
+    /// Closure fired when the path interface changes. The closure is
+    /// invoked on an unspecified queue — implementations should hop to
+    /// the consumer's actor before mutating state.
+    var onPathChange: (@Sendable (WebDAVNetworkInterface) -> Void)? { get set }
+    func start()
+    func cancel()
+}
+
+/// Production implementation backed by `NWPathMonitor`. Single instance
+/// owned by `WebDAVNetworkPolicy`; cancelled on deinit.
+final class ProductionNetworkPathMonitor: NetworkPathMonitoring, @unchecked Sendable {
+    private let monitor: NWPathMonitor
+    private let queue: DispatchQueue
+    var onPathChange: (@Sendable (WebDAVNetworkInterface) -> Void)?
+
+    init() {
+        self.monitor = NWPathMonitor()
+        self.queue = DispatchQueue(label: "com.vreader.app.WebDAVNetworkPolicy.monitor")
+    }
+
+    func start() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            let interface = Self.classify(path)
+            self?.onPathChange?(interface)
+        }
+        monitor.start(queue: queue)
+    }
+
+    func cancel() {
+        monitor.cancel()
+    }
+
+    deinit { monitor.cancel() }
+
+    private static func classify(_ path: NWPath) -> WebDAVNetworkInterface {
+        guard path.status == .satisfied else { return .none }
+        if path.usesInterfaceType(.wifi) || path.usesInterfaceType(.wiredEthernet) {
+            return .wifi
+        }
+        if path.usesInterfaceType(.cellular) {
+            return .cellular
+        }
+        // Loopback or unknown — treat as Wi-Fi-equivalent (typical for
+        // simulator + tethered testing). Cellular remains the only
+        // restricted case under wifiOnly.
+        return .wifi
+    }
+}
+
+/// MainActor-isolated, observable Wi-Fi-only gate. Persists the
+/// `wifiOnly` toggle in UserDefaults so the user's preference survives
+/// app launches.
+@MainActor
+@Observable
+final class WebDAVNetworkPolicy {
+
+    /// Default-true: download books only on Wi-Fi unless the user
+    /// explicitly opts in to cellular.
+    static let wifiOnlyKey = "com.vreader.webdav.wifiOnly"
+
+    /// Most recent interface from the path monitor. `.unknown` until
+    /// the first path-change callback lands.
+    private(set) var currentInterface: WebDAVNetworkInterface = .unknown
+
+    /// User preference. Reads from UserDefaults on construction;
+    /// writes propagate to UserDefaults synchronously. Default true
+    /// when the key is missing.
+    var wifiOnly: Bool {
+        didSet {
+            defaults.set(wifiOnly, forKey: Self.wifiOnlyKey)
+            log.info("wifiOnly = \(self.wifiOnly, privacy: .public)")
+        }
+    }
+
+    private let defaults: UserDefaults
+    private let monitor: any NetworkPathMonitoring
+
+    init(defaults: UserDefaults = .standard, monitor: (any NetworkPathMonitoring)? = nil) {
+        self.defaults = defaults
+        // Default true if the key has never been written.
+        if defaults.object(forKey: Self.wifiOnlyKey) == nil {
+            self.wifiOnly = true
+            defaults.set(true, forKey: Self.wifiOnlyKey)
+        } else {
+            self.wifiOnly = defaults.bool(forKey: Self.wifiOnlyKey)
+        }
+        self.monitor = monitor ?? ProductionNetworkPathMonitor()
+        self.monitor.onPathChange = { [weak self] interface in
+            Task { @MainActor [weak self] in
+                self?.currentInterface = interface
+            }
+        }
+        self.monitor.start()
+    }
+
+    deinit {
+        monitor.cancel()
+    }
+
+    /// Returns true when downloads may start now. Used by the enqueue
+    /// path (WI-4a) and by "Restore all" guards.
+    /// - `wifiOnly == false` → always true.
+    /// - `wifiOnly == true && interface == .wifi` → true.
+    /// - `wifiOnly == true && interface in [.cellular, .none, .unknown]` → false.
+    ///   (`.unknown` defaults to false because we haven't yet observed
+    ///   the interface and shouldn't risk burning cellular on a wrong
+    ///   guess; the first path-change tick lands fast in practice.)
+    func shouldStart() -> Bool {
+        if !wifiOnly { return true }
+        return currentInterface == .wifi
+    }
+}

--- a/vreaderTests/Services/Backup/WebDAVNetworkPolicyTests.swift
+++ b/vreaderTests/Services/Backup/WebDAVNetworkPolicyTests.swift
@@ -1,0 +1,145 @@
+// Purpose: Tests for WebDAVNetworkPolicy — the wifiOnly preference,
+// path-change handling, and the shouldStart() gate the lazy-download
+// coordinator and "Restore all" UI consult before initiating
+// transfers. Feature #47 WI-3c.
+
+import Testing
+import Foundation
+@testable import vreader
+
+/// Hand-built mock path monitor. Tests configure the initial path,
+/// construct a policy with this monitor, then call `simulate(_:)` to
+/// drive transitions.
+final class MockNetworkPathMonitor: NetworkPathMonitoring, @unchecked Sendable {
+    var onPathChange: (@Sendable (WebDAVNetworkInterface) -> Void)?
+    private(set) var didStart = false
+    private(set) var didCancel = false
+
+    func start() { didStart = true }
+    func cancel() { didCancel = true }
+    func simulate(_ interface: WebDAVNetworkInterface) { onPathChange?(interface) }
+}
+
+@MainActor
+@Suite("WebDAVNetworkPolicy — feature #47 WI-3c")
+struct WebDAVNetworkPolicyTests {
+
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "vreader.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    // MARK: - Initial state
+
+    @Test func defaults_wifiOnlyTrue_whenKeyMissing() {
+        let defaults = makeDefaults()
+        let monitor = MockNetworkPathMonitor()
+        let policy = WebDAVNetworkPolicy(defaults: defaults, monitor: monitor)
+        #expect(policy.wifiOnly == true)
+        // Persisted so the next launch reads true even if the user
+        // never touched the toggle.
+        #expect(defaults.bool(forKey: WebDAVNetworkPolicy.wifiOnlyKey) == true)
+    }
+
+    @Test func defaults_readsExistingFalseFromUserDefaults() {
+        let defaults = makeDefaults()
+        defaults.set(false, forKey: WebDAVNetworkPolicy.wifiOnlyKey)
+        let policy = WebDAVNetworkPolicy(defaults: defaults, monitor: MockNetworkPathMonitor())
+        #expect(policy.wifiOnly == false)
+    }
+
+    @Test func currentInterface_startsAsUnknown() {
+        let policy = WebDAVNetworkPolicy(defaults: makeDefaults(), monitor: MockNetworkPathMonitor())
+        #expect(policy.currentInterface == .unknown)
+    }
+
+    @Test func init_startsTheMonitor() {
+        let monitor = MockNetworkPathMonitor()
+        _ = WebDAVNetworkPolicy(defaults: makeDefaults(), monitor: monitor)
+        #expect(monitor.didStart)
+    }
+
+    // MARK: - wifiOnly mutation persists
+
+    @Test func writingWifiOnly_persistsToDefaults() {
+        let defaults = makeDefaults()
+        let policy = WebDAVNetworkPolicy(defaults: defaults, monitor: MockNetworkPathMonitor())
+        policy.wifiOnly = false
+        #expect(defaults.bool(forKey: WebDAVNetworkPolicy.wifiOnlyKey) == false)
+    }
+
+    // MARK: - Path-change updates currentInterface
+
+    @Test func pathChange_updatesCurrentInterface() async {
+        let monitor = MockNetworkPathMonitor()
+        let policy = WebDAVNetworkPolicy(defaults: makeDefaults(), monitor: monitor)
+        monitor.simulate(.wifi)
+        // pathChange handler hops to MainActor via Task — yield once
+        // so the assignment lands before assertions.
+        await Task.yield()
+        #expect(policy.currentInterface == .wifi)
+
+        monitor.simulate(.cellular)
+        await Task.yield()
+        #expect(policy.currentInterface == .cellular)
+    }
+
+    // MARK: - shouldStart() truth table
+
+    @Test func shouldStart_wifiOnlyFalse_alwaysTrue() async {
+        let defaults = makeDefaults()
+        defaults.set(false, forKey: WebDAVNetworkPolicy.wifiOnlyKey)
+        let monitor = MockNetworkPathMonitor()
+        let policy = WebDAVNetworkPolicy(defaults: defaults, monitor: monitor)
+        // Even on cellular / no network / unknown.
+        #expect(policy.shouldStart())
+        monitor.simulate(.cellular); await Task.yield()
+        #expect(policy.shouldStart())
+        monitor.simulate(.none); await Task.yield()
+        #expect(policy.shouldStart())
+    }
+
+    @Test func shouldStart_wifiOnlyTrue_andWifi_returnsTrue() async {
+        let monitor = MockNetworkPathMonitor()
+        let policy = WebDAVNetworkPolicy(defaults: makeDefaults(), monitor: monitor)
+        monitor.simulate(.wifi); await Task.yield()
+        #expect(policy.shouldStart())
+    }
+
+    @Test func shouldStart_wifiOnlyTrue_andCellular_returnsFalse() async {
+        let monitor = MockNetworkPathMonitor()
+        let policy = WebDAVNetworkPolicy(defaults: makeDefaults(), monitor: monitor)
+        monitor.simulate(.cellular); await Task.yield()
+        #expect(policy.shouldStart() == false)
+    }
+
+    @Test func shouldStart_wifiOnlyTrue_andNoNetwork_returnsFalse() async {
+        let monitor = MockNetworkPathMonitor()
+        let policy = WebDAVNetworkPolicy(defaults: makeDefaults(), monitor: monitor)
+        monitor.simulate(.none); await Task.yield()
+        #expect(policy.shouldStart() == false)
+    }
+
+    @Test func shouldStart_wifiOnlyTrue_andUnknown_returnsFalse() {
+        // Conservative: don't initiate downloads before the first
+        // path-change tick lands.
+        let policy = WebDAVNetworkPolicy(defaults: makeDefaults(), monitor: MockNetworkPathMonitor())
+        #expect(policy.currentInterface == .unknown)
+        #expect(policy.shouldStart() == false)
+    }
+
+    // MARK: - Toggle flips outcome under fixed interface
+
+    @Test func wifiOnlyToggle_changesShouldStartWhenOnCellular() async {
+        let monitor = MockNetworkPathMonitor()
+        let policy = WebDAVNetworkPolicy(defaults: makeDefaults(), monitor: monitor)
+        monitor.simulate(.cellular); await Task.yield()
+        #expect(policy.shouldStart() == false)
+        policy.wifiOnly = false
+        #expect(policy.shouldStart())
+        policy.wifiOnly = true
+        #expect(policy.shouldStart() == false)
+    }
+}


### PR DESCRIPTION
## Summary

- NWPathMonitor-backed `WebDAVNetworkPolicy` (`@MainActor @Observable`) with `wifiOnly` UserDefault toggle (default true) and `shouldStart() -> Bool` gate the enqueue path (WI-4a) and "Restore all" UI consult.
- 12 unit tests cover the truth table, persistence, path-change handling, and toggle reactivity.
- Closes WI-3c.

Refs #47

## What Changed

- New `WebDAVNetworkPolicy.swift` (~155 LOC) — policy + `NetworkPathMonitoring` protocol + production wrapper
- New `WebDAVNetworkPolicyTests.swift` (12 tests with `MockNetworkPathMonitor`)
- Version 3.11.21 → 3.11.22 (build 54)

## Audit

Codex MCP disconnected mid-audit. Manual mini-audit applied per `.claude/rules/47-feature-workflow.md` fallback — evidence in commit message.

## Validation

- [x] 12/12 policy tests pass
- [ ] No consumer yet — wiring lands in WI-4a (enqueue) and WI-6 (settings UI)

## Type of Change

- [x] Feature (#47 WI-3c)