### PR TITLE
feat(#47): WI-4a part 1 — extract BookFileImportFinalizer

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 54
-        MARKETING_VERSION: 3.11.22
+        CURRENT_PROJECT_VERSION: 55
+        MARKETING_VERSION: 3.11.23
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -616,6 +616,7 @@
 		D1F6F2B6287F6C78E947FFAE /* BilingualView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8781075EA7AF25572A741C40 /* BilingualView.swift */; };
 		D2997E6E5680E58471DAA777 /* NoOpPersistenceStores.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D45B144AFD2D20CAEACC48 /* NoOpPersistenceStores.swift */; };
 		D2A05D3F78803BFD1248FFC2 /* LegadoImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B58A3A5DB35DA47F032FCEB /* LegadoImporter.swift */; };
+		D2C79A37AD17134F89371C0A /* BookFileImportFinalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE2E82B00BA09B1D805167A /* BookFileImportFinalizer.swift */; };
 		D32E57C07E8D41055084129C /* AnnotationNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF63E3EE60CC06C5650C3AD /* AnnotationNote.swift */; };
 		D36EEE178AE4BC41B7B4C650 /* FileAvailabilityBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4B7084FA4C129303F52CB8 /* FileAvailabilityBadge.swift */; };
 		D41473E2CF7AB980E43C6C54 /* BookFormatAZW3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627E42F1B1E8A59081CC6628 /* BookFormatAZW3Tests.swift */; };
@@ -708,6 +709,7 @@
 		F333DF8A66B96E51CC5CF97B /* AlertDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 667AC3E733DFC3883BC89D39 /* AlertDialogTests.swift */; };
 		F3958B26AAD50F2152E03AEB /* TTSControlBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F63868C11B04D324F09751 /* TTSControlBar.swift */; };
 		F3AA4FF7E6B3938E23EAF863 /* FoliateTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9776A011745AF967BBAB2A4C /* FoliateTypes.swift */; };
+		F437CE5879D0238AC5523F52 /* BookFileImportFinalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21FF5B2854F2C50C5A43F17 /* BookFileImportFinalizerTests.swift */; };
 		F51F7B9360A990E857FE1373 /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6686ECBBE526053A51CBA2 /* ChatMessage.swift */; };
 		F5A31837AE39AA372B31F1B5 /* LocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E8B92C301E5470AB98C87E /* LocatorTests.swift */; };
 		F6F40F9E52D3ED8B95323D65 /* epub.js in Resources */ = {isa = PBXBuildFile; fileRef = 3EC2FBB83EE7D774B3B5D5D3 /* epub.js */; };
@@ -965,6 +967,7 @@
 		4D5CDE195E585067DE4D6124 /* AnnotationListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationListViewModelTests.swift; sourceTree = "<group>"; };
 		4D9501ED4FB49C6035FDF5BB /* MockBackupProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackupProvider.swift; sourceTree = "<group>"; };
 		4DCA33DBE911B5B1B6425277 /* MDTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDTypesTests.swift; sourceTree = "<group>"; };
+		4DE2E82B00BA09B1D805167A /* BookFileImportFinalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFileImportFinalizer.swift; sourceTree = "<group>"; };
 		4E141EA554A8E0C1C3B36250 /* FoliateReaderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateReaderViewModelTests.swift; sourceTree = "<group>"; };
 		4E25002586402AAE67B29CE6 /* TextReaderUIState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextReaderUIState.swift; sourceTree = "<group>"; };
 		4E318ED286636BD43CD865D3 /* empty.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = empty.txt; sourceTree = "<group>"; };
@@ -1248,6 +1251,7 @@
 		B10A08E980C92248337462DF /* LocatorRestorerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorRestorerTests.swift; sourceTree = "<group>"; };
 		B16D420A03BD524C247A78FB /* TXTReflowableTextSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReflowableTextSource.swift; sourceTree = "<group>"; };
 		B1DBBFF061B96088FFE84194 /* TXTService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTService.swift; sourceTree = "<group>"; };
+		B21FF5B2854F2C50C5A43F17 /* BookFileImportFinalizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFileImportFinalizerTests.swift; sourceTree = "<group>"; };
 		B294CBB624E1CE03FEFA40E6 /* WebDAVProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProviderTests.swift; sourceTree = "<group>"; };
 		B2A04EAFA37410DA616E33D6 /* BackgroundDownloadSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundDownloadSession.swift; sourceTree = "<group>"; };
 		B2B73649BCBDBE8A99B210A9 /* WebDAVNetworkPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVNetworkPolicyTests.swift; sourceTree = "<group>"; };
@@ -1646,6 +1650,7 @@
 				8AB2B5F77B95D3402E699DA9 /* BackupProvider.swift */,
 				64D6B83FC65D64C1271E28F4 /* BackupSectionDTOs.swift */,
 				560129625F0E48471C0F4B62 /* BlobPath.swift */,
+				4DE2E82B00BA09B1D805167A /* BookFileImportFinalizer.swift */,
 				1889243163114A51950527F6 /* BookFileMaterializer.swift */,
 				01041344F18D1DE82B7E100C /* LazyDownloadCoordinator.swift */,
 				159BB4EBD79ECE6657D50EC1 /* LazyDownloadDelegate.swift */,
@@ -2564,6 +2569,7 @@
 				F64BCF588EF860DD6C214737 /* BackupLibraryManifestTests.swift */,
 				ED150D276C082FEC194F2F31 /* BackupProviderContractTests.swift */,
 				BFB65788879E3D91E69E8BA5 /* BlobPathTests.swift */,
+				B21FF5B2854F2C50C5A43F17 /* BookFileImportFinalizerTests.swift */,
 				04ED79BFAD4BEF6B8A30F982 /* BookFileMaterializerTests.swift */,
 				2F891C451718B4BC9AC7BCEC /* LazyDownloadBackgroundEventsTests.swift */,
 				67368B0914CFE12052417225 /* LazyDownloadCoordinatorTests.swift */,
@@ -3161,6 +3167,7 @@
 				90D2C41C30E622E119877967 /* BackupViewModelTests.swift in Sources */,
 				096B20388931B21DAA4DC091 /* BlobPathTests.swift in Sources */,
 				C205A1413A59C630A10ECEB7 /* BookContentCacheTests.swift in Sources */,
+				F437CE5879D0238AC5523F52 /* BookFileImportFinalizerTests.swift in Sources */,
 				45284DB279AD41866D7B0157 /* BookFileMaterializerTests.swift in Sources */,
 				EA8B5924DDF7844635BF8610 /* BookFileStateTests.swift in Sources */,
 				D41473E2CF7AB980E43C6C54 /* BookFormatAZW3Tests.swift in Sources */,
@@ -3465,6 +3472,7 @@
 				12EE1BD6335013980EFA3EC0 /* BookCardView.swift in Sources */,
 				AF32B348898F4110FED715F5 /* BookCollection.swift in Sources */,
 				BB796644EE14228057D77738 /* BookContentCache.swift in Sources */,
+				D2C79A37AD17134F89371C0A /* BookFileImportFinalizer.swift in Sources */,
 				AE171BC364B973E0F52D1B96 /* BookFileMaterializer.swift in Sources */,
 				FB379B5459AC6B9D5975E3D2 /* BookFileState.swift in Sources */,
 				33B874FB4BB17A21ACA4468E /* BookFormat.swift in Sources */,
@@ -3910,13 +3918,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 54;
+				CURRENT_PROJECT_VERSION = 55;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.22;
+				MARKETING_VERSION = 3.11.23;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4060,13 +4068,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 54;
+				CURRENT_PROJECT_VERSION = 55;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.22;
+				MARKETING_VERSION = 3.11.23;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Backup/BookFileImportFinalizer.swift
+++ b/vreader/Services/Backup/BookFileImportFinalizer.swift
@@ -1,0 +1,116 @@
+// Purpose: Shared verify + import + fingerprint-check pipeline that
+// both `BookFileMaterializer` (restore-all path, in-memory `Data`) and
+// the lazy-download coordinator (#47 WI-4b enqueue path, file-URL via
+// background URLSession) call once their bytes have landed on disk.
+//
+// Extracted from `BookFileMaterializer.materializeOne` (steps 4 + 6 + 7).
+// The materializer keeps the download / byte-count / temp-write steps;
+// the finalizer takes a localTempURL that already carries the right
+// originalExtension and runs:
+//   - Streaming SHA-256 verify against `entry.sha256`
+//   - `BookImporter.importFile(at:source:)` with `.restore`
+//   - Resulting `fingerprintKey` vs `entry.fingerprintKey` match
+//
+// Caller owns localTempURL lifetime (cleanup after finalize returns).
+//
+// Feature #47 WI-4a.
+//
+// @coordinates-with: BookFileMaterializer.swift,
+//   BookImporting.swift, BackupSectionDTOs.swift,
+//   LazyDownloadCoordinator.swift (future, WI-4b consumer),
+//   dev-docs/plans/20260503-feature-47-selective-picker-lazy-load.md
+
+import CryptoKit
+import Foundation
+import OSLog
+
+private let log = Logger(subsystem: "com.vreader.app", category: "BookFileImportFinalizer")
+
+struct BookFileImportFinalizer: Sendable {
+
+    private let importer: any BookImporting
+
+    init(importer: any BookImporting) {
+        self.importer = importer
+    }
+
+    /// Finalizes a downloaded blob: verify SHA-256, import via
+    /// `BookImporter`, verify the resulting fingerprint matches the
+    /// manifest entry. Caller must:
+    ///   - Ensure `localTempURL` carries the bytes claimed by `entry`.
+    ///   - Have written the file with the correct `originalExtension`
+    ///     so `BookImporter` can derive format from the path.
+    ///   - Clean up `localTempURL` after this returns (success or fail).
+    func finalize(localTempURL: URL, entry: BackupLibraryEntry) async -> MaterializeResult {
+        // SHA-256 verify on the file. Streaming so very-large blobs
+        // don't spike memory in the lazy-download path.
+        let downloadedHash: String
+        do {
+            downloadedHash = try Self.localFileSHA256(at: localTempURL)
+        } catch {
+            return MaterializeResult(
+                entry: entry,
+                outcome: .importFailed("sha256-read-failed: \(error)")
+            )
+        }
+        if downloadedHash != entry.sha256 {
+            return MaterializeResult(
+                entry: entry,
+                outcome: .sha256Mismatch(expected: entry.sha256, actual: downloadedHash)
+            )
+        }
+
+        // Import via the production importer (re-extracts metadata,
+        // saves cover, fires indexing notification, applies dedupe).
+        let importResult: ImportResult
+        do {
+            importResult = try await importer.importFile(at: localTempURL, source: .restore)
+        } catch let importErr as ImportError {
+            return MaterializeResult(entry: entry, outcome: .importFailed("\(importErr)"))
+        } catch {
+            return MaterializeResult(entry: entry, outcome: .importFailed("\(error)"))
+        }
+
+        // Verify fingerprint match — catches extension/format confusion
+        // (e.g. AZW3 bytes labelled .epub) where BookImporter would
+        // compute a different fingerprintKey from the bytes than what
+        // the manifest claimed.
+        guard importResult.fingerprintKey == entry.fingerprintKey else {
+            return MaterializeResult(
+                entry: entry,
+                outcome: .fingerprintMismatchAfterImport(
+                    expected: entry.fingerprintKey,
+                    actual: importResult.fingerprintKey
+                )
+            )
+        }
+
+        return MaterializeResult(
+            entry: entry,
+            outcome: .downloaded(fingerprintKey: importResult.fingerprintKey)
+        )
+    }
+
+    // MARK: - Hashing
+
+    /// Streaming SHA-256 of a local file. Returns lowercase hex.
+    /// Static so `BookFileMaterializer` can reuse it post-extraction
+    /// for its preflight rehash without depending on a finalizer
+    /// instance.
+    static func localFileSHA256(at url: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        let chunkSize = 64 * 1024
+        while true {
+            let chunk = try handle.read(upToCount: chunkSize) ?? Data()
+            if chunk.isEmpty { break }
+            hasher.update(data: chunk)
+        }
+        return Self.hexString(Data(hasher.finalize()))
+    }
+
+    private static func hexString(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/vreader/Services/Backup/BookFileMaterializer.swift
+++ b/vreader/Services/Backup/BookFileMaterializer.swift
@@ -61,6 +61,7 @@ final class BookFileMaterializer: Sendable {
 
     private let blobStore: any BackupBlobReading
     private let importer: any BookImporting
+    private let finalizer: BookFileImportFinalizer
     private let resolveSandboxURL: SandboxURLResolver
     private let tempDirectory: URL
 
@@ -72,6 +73,7 @@ final class BookFileMaterializer: Sendable {
     ) {
         self.blobStore = blobStore
         self.importer = importer
+        self.finalizer = BookFileImportFinalizer(importer: importer)
         self.tempDirectory = tempDirectory
         self.resolveSandboxURL = resolveSandboxURL
     }
@@ -173,16 +175,7 @@ final class BookFileMaterializer: Sendable {
             )
         }
 
-        // Step 4: SHA-256 check (catches corruption that slipped past size).
-        let downloadedHash = sha256Hex(of: bytes)
-        if downloadedHash != entry.sha256 {
-            return MaterializeResult(
-                entry: entry,
-                outcome: .sha256Mismatch(expected: entry.sha256, actual: downloadedHash)
-            )
-        }
-
-        // Step 5: write to a temp file with originalExtension so BookImporter
+        // Step 4: write to a temp file with originalExtension so BookImporter
         // can derive format from the extension. Path includes the SHA-256 to
         // stay unique across concurrent restores.
         let tempURL: URL
@@ -202,41 +195,12 @@ final class BookFileMaterializer: Sendable {
         }
         defer { try? FileManager.default.removeItem(at: tempURL) }
 
-        // Step 6: import via the production importer (re-extracts metadata,
-        // saves cover, fires indexing notification, applies dedupe).
-        let importResult: ImportResult
-        do {
-            importResult = try await importer.importFile(at: tempURL, source: .restore)
-        } catch let importErr as ImportError {
-            return MaterializeResult(
-                entry: entry,
-                outcome: .importFailed("\(importErr)")
-            )
-        } catch {
-            return MaterializeResult(
-                entry: entry,
-                outcome: .importFailed("\(error)")
-            )
-        }
-
-        // Step 7: verify the import landed at the manifest's fingerprint.
-        // Catches extension/format confusion: if BookImporter detected a
-        // different format from the bytes than the manifest claimed, the
-        // resulting fingerprintKey won't match.
-        guard importResult.fingerprintKey == entry.fingerprintKey else {
-            return MaterializeResult(
-                entry: entry,
-                outcome: .fingerprintMismatchAfterImport(
-                    expected: entry.fingerprintKey,
-                    actual: importResult.fingerprintKey
-                )
-            )
-        }
-
-        return MaterializeResult(
-            entry: entry,
-            outcome: .downloaded(fingerprintKey: importResult.fingerprintKey)
-        )
+        // Steps 5-7 (SHA verify + import + fingerprint match) are shared
+        // with the lazy-download path (#47 WI-4b) and live in the
+        // finalizer. The finalizer re-hashes the file rather than
+        // trusting an in-memory hash so both paths share identical
+        // verification semantics.
+        return await finalizer.finalize(localTempURL: tempURL, entry: entry)
     }
 
     // MARK: - Hashing helpers
@@ -254,12 +218,6 @@ final class BookFileMaterializer: Sendable {
             hasher.update(data: chunk)
         }
         return hexString(Data(hasher.finalize()))
-    }
-
-    /// SHA-256 of an in-memory byte buffer. Used for downloaded blobs which
-    /// are already fully resident.
-    private func sha256Hex(of data: Data) -> String {
-        hexString(Data(SHA256.hash(data: data)))
     }
 
     private func hexString(_ data: Data) -> String {

--- a/vreaderTests/Services/Backup/BookFileImportFinalizerTests.swift
+++ b/vreaderTests/Services/Backup/BookFileImportFinalizerTests.swift
@@ -1,0 +1,162 @@
+// Purpose: Tests for BookFileImportFinalizer — the shared verify +
+// import + fingerprint-check pipeline used by both restore-all
+// (`BookFileMaterializer`) and lazy-download (#47 WI-4b enqueue path).
+// Feature #47 WI-4a.
+
+import Testing
+import Foundation
+import CryptoKit
+@testable import vreader
+
+@Suite("BookFileImportFinalizer — feature #47 WI-4a")
+struct BookFileImportFinalizerTests {
+
+    // MARK: - Helpers
+
+    private static func sha256Hex(_ data: Data) -> String {
+        Data(SHA256.hash(data: data)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func makeSandboxDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("finalizer_sandbox_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private static func makeTempFile(data: Data, ext: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("finalizer_\(UUID().uuidString)")
+            .appendingPathExtension(ext)
+        try data.write(to: url)
+        return url
+    }
+
+    /// Minimal EPUB-ish bytes: ZIP magic (0x50 0x4B 0x03 0x04) + payload.
+    /// BookImporter's format detection accepts this and computes a
+    /// stable fingerprint — same trick the materializer test suite uses.
+    private static func makeEPUBData() -> Data {
+        Data([0x50, 0x4B, 0x03, 0x04]) + Data(repeating: 0x42, count: 1024)
+    }
+
+    private static func makeEntry(
+        data: Data,
+        format: BookFormat = .epub,
+        originalExtension: String? = nil
+    ) -> BackupLibraryEntry {
+        let sha = sha256Hex(data)
+        let bytes = Int64(data.count)
+        let ext = originalExtension ?? format.fileExtensions.first ?? format.rawValue
+        return BackupLibraryEntry(
+            fingerprintKey: "\(format.rawValue):\(sha):\(bytes)",
+            format: format.rawValue,
+            sha256: sha,
+            byteCount: bytes,
+            originalExtension: ext,
+            title: "T",
+            author: "A",
+            addedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            lastOpenedAt: nil,
+            blobPath: BlobPath.make(format: format, sha256: sha, byteCount: bytes)
+        )
+    }
+
+    private static func makeFinalizer() async throws -> (BookFileImportFinalizer, URL) {
+        let sandbox = try makeSandboxDir()
+        let mockPersistence = MockPersistenceActor()
+        let importer = BookImporter(persistence: mockPersistence, sandboxBooksDirectory: sandbox)
+        return (BookFileImportFinalizer(importer: importer), sandbox)
+    }
+
+    // MARK: - Happy path
+
+    @Test func finalize_validEPUB_returnsDownloadedWithFingerprint() async throws {
+        let data = Self.makeEPUBData()
+        let entry = Self.makeEntry(data: data)
+        let tempURL = try Self.makeTempFile(data: data, ext: entry.originalExtension)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let (finalizer, _) = try await Self.makeFinalizer()
+        let result = await finalizer.finalize(localTempURL: tempURL, entry: entry)
+
+        switch result.outcome {
+        case .downloaded(let key):
+            #expect(key == entry.fingerprintKey)
+        default:
+            Issue.record("expected .downloaded outcome, got \(result.outcome)")
+        }
+    }
+
+    // MARK: - SHA-256 verification
+
+    @Test func finalize_corruptedBytes_returnsSHA256Mismatch() async throws {
+        let realData = Self.makeEPUBData()
+        let entry = Self.makeEntry(data: realData)
+        // Write different bytes than what the entry's SHA expects.
+        let corrupted = Data(repeating: 0xFF, count: realData.count)
+        let tempURL = try Self.makeTempFile(data: corrupted, ext: entry.originalExtension)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let (finalizer, _) = try await Self.makeFinalizer()
+        let result = await finalizer.finalize(localTempURL: tempURL, entry: entry)
+
+        if case .sha256Mismatch(let expected, let actual) = result.outcome {
+            #expect(expected == entry.sha256)
+            #expect(actual != expected)
+        } else {
+            Issue.record("expected .sha256Mismatch, got \(result.outcome)")
+        }
+    }
+
+    // MARK: - Missing file
+
+    @Test func finalize_missingTempFile_returnsImportFailed() async throws {
+        let entry = Self.makeEntry(data: Self.makeEPUBData())
+        let bogus = FileManager.default.temporaryDirectory
+            .appendingPathComponent("does_not_exist_\(UUID().uuidString).epub")
+
+        let (finalizer, _) = try await Self.makeFinalizer()
+        let result = await finalizer.finalize(localTempURL: bogus, entry: entry)
+
+        if case .importFailed(let msg) = result.outcome {
+            #expect(msg.contains("sha256-read-failed"))
+        } else {
+            Issue.record("expected .importFailed (sha256-read-failed), got \(result.outcome)")
+        }
+    }
+
+    // MARK: - Caller owns lifetime
+
+    @Test func finalize_doesNotDeleteTempFile() async throws {
+        let data = Self.makeEPUBData()
+        let entry = Self.makeEntry(data: data)
+        let tempURL = try Self.makeTempFile(data: data, ext: entry.originalExtension)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let (finalizer, _) = try await Self.makeFinalizer()
+        _ = await finalizer.finalize(localTempURL: tempURL, entry: entry)
+
+        // Caller (lazy coordinator / materializer) owns cleanup. Finalizer
+        // must not touch the temp file — that would race the materializer's
+        // existing `defer { remove tempURL }`.
+        #expect(FileManager.default.fileExists(atPath: tempURL.path))
+    }
+
+    // MARK: - Static SHA helper
+
+    @Test func localFileSHA256_matchesInMemoryHash() throws {
+        let data = Data((0..<10_000).map { UInt8($0 % 256) })
+        let url = try Self.makeTempFile(data: data, ext: "bin")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let expected = Self.sha256Hex(data)
+        let actual = try BookFileImportFinalizer.localFileSHA256(at: url)
+        #expect(actual == expected)
+    }
+
+    @Test func localFileSHA256_emptyFile_matches() throws {
+        let url = try Self.makeTempFile(data: Data(), ext: "bin")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let actual = try BookFileImportFinalizer.localFileSHA256(at: url)
+        #expect(actual == Self.sha256Hex(Data()))
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts SHA-256 verify + BookImporter call + fingerprint match check from `BookFileMaterializer.materializeOne` into a shared `BookFileImportFinalizer` so the lazy-download enqueue path (WI-4b) and restore-all path use identical verification semantics.
- Behavior-preserving refactor: 10 existing materializer tests pass + 6 new finalizer tests.

Refs #47

## What Changed

- New `BookFileImportFinalizer.swift` (~110 LOC) — `Sendable` struct, streaming SHA-256, caller owns temp lifetime
- Modified `BookFileMaterializer.swift` — `materializeOne` delegates steps 5-7 to finalizer
- New `BookFileImportFinalizerTests.swift` — 6 tests
- Version 3.11.22 → 3.11.23 (build 55)

## Audit

Codex MCP unavailable. Manual mini-audit per `.claude/rules/47-feature-workflow.md` fallback in commit message.

## Validation

- [x] 10/10 existing `BookFileMaterializerTests` pass (regression protection)
- [x] 6/6 new `BookFileImportFinalizerTests` pass

## Type of Change

- [x] Refactor (extraction in service of #47 WI-4a)