### PR TITLE
feat(#47): WI-4a part 2 — RemoteBookCatalog

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 55
-        MARKETING_VERSION: 3.11.23
+        CURRENT_PROJECT_VERSION: 56
+        MARKETING_VERSION: 3.11.24
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		2DB8779FF53587C400452428 /* FileAvailabilityStateMachineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6362591D3F62B4BC84CE136A /* FileAvailabilityStateMachineTests.swift */; };
 		2DBB3E013C7117D610B1679F /* BookImporterOriginalExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B8562BBBE45039B72EAF9E5 /* BookImporterOriginalExtensionTests.swift */; };
 		2DDEE520E3606572AED3598F /* LibraryRefreshService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC254C94AE749FFA8AACCE4 /* LibraryRefreshService.swift */; };
+		2E4D176937CECE96A39EAC18 /* RemoteBookCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF7D174AC38392C14C17F1F7 /* RemoteBookCatalog.swift */; };
 		2E988A3214761CEAEF22D451 /* HTMLHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4349ACADC38E53A4D87D5D5A /* HTMLHelper.swift */; };
 		2E9BB5052DD152DD52BB0D45 /* TXTReaderPlaceholderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480E5268D197F33E8C0B6CFC /* TXTReaderPlaceholderTests.swift */; };
 		2F558CF136B69212E668F2D3 /* EPUBParserProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C15E361FF460BCE57B8675 /* EPUBParserProtocol.swift */; };
@@ -675,6 +676,7 @@
 		E82E02103AE2B5E39F5F6C66 /* LibraryEmptyStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292131FE5DD09EAEDDD3191C /* LibraryEmptyStateTests.swift */; };
 		E8353217B517055A09014AE7 /* EPUBTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A457F48D22CD5B4952817701 /* EPUBTypes.swift */; };
 		E9177AEFF47DA3EFEAC13C50 /* TXTChunkedLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A069D350D0DC6B4C000E1D43 /* TXTChunkedLoaderTests.swift */; };
+		E92C78246E46B2DFE76DE0A2 /* RemoteBookCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B006129C2FCEC99B9FBB91 /* RemoteBookCatalogTests.swift */; };
 		E92CBF70F353E737625B557F /* AIRequestCacheKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C1B40888B5C8213559B111 /* AIRequestCacheKeyTests.swift */; };
 		E963BC203166854BFF9C69A4 /* zip.js in Resources */ = {isa = PBXBuildFile; fileRef = DBA51F184E6AA5F2FD1F5456 /* zip.js */; };
 		E9AAB1E1CE8C74F9517CBEC3 /* SearchQueryExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C7229E97D0F8B543683A02 /* SearchQueryExecutor.swift */; };
@@ -1171,6 +1173,7 @@
 		939BC09F1D771D2E22301ED3 /* V1toV2MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V1toV2MigrationTests.swift; sourceTree = "<group>"; };
 		9452FAFFDEBDF03FF6CCEBB1 /* MDParserProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDParserProtocol.swift; sourceTree = "<group>"; };
 		94C32FCAEDE0062125F6A51E /* DebugSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSnapshot.swift; sourceTree = "<group>"; };
+		95B006129C2FCEC99B9FBB91 /* RemoteBookCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBookCatalogTests.swift; sourceTree = "<group>"; };
 		96A2FE9743AF484093A21969 /* TTSServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSServiceTests.swift; sourceTree = "<group>"; };
 		96BE19585BF1F4C8174F7219 /* HighlightRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightRecord.swift; sourceTree = "<group>"; };
 		96E10DBA312E3C1934B36E63 /* MockAnnotationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAnnotationStore.swift; sourceTree = "<group>"; };
@@ -1377,6 +1380,7 @@
 		DE2038A4D36C4355AC5C7BF5 /* SearchLocatorSliceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchLocatorSliceTests.swift; sourceTree = "<group>"; };
 		DE360E19106AAA7A1FCEEEB9 /* legado_source_minimal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = legado_source_minimal.json; sourceTree = "<group>"; };
 		DE5CAE41C429B6868957C540 /* ExportTestFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTestFixtures.swift; sourceTree = "<group>"; };
+		DF7D174AC38392C14C17F1F7 /* RemoteBookCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBookCatalog.swift; sourceTree = "<group>"; };
 		E026EDF24B39D1CD50B39389 /* CollectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionTests.swift; sourceTree = "<group>"; };
 		E02C0C97FFE66E8DEC728D64 /* SyncRecordDTOs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncRecordDTOs.swift; sourceTree = "<group>"; };
 		E07FB35EC9805F51CAD10444 /* ThemeBackgroundStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeBackgroundStore.swift; sourceTree = "<group>"; };
@@ -1656,6 +1660,7 @@
 				159BB4EBD79ECE6657D50EC1 /* LazyDownloadDelegate.swift */,
 				592405D887F7AE66A58FA8D9 /* LazyDownloadTaskMeta.swift */,
 				DB6CE81404902AB359536964 /* PROPFINDParser.swift */,
+				DF7D174AC38392C14C17F1F7 /* RemoteBookCatalog.swift */,
 				9DAC16C19C7D4C72EFC950C9 /* WebDAVBlobStore.swift */,
 				4946129FECC6C9BA7A7F16A1 /* WebDAVClient.swift */,
 				D408C9CE57D4C437A72C0D18 /* WebDAVNetworkPolicy.swift */,
@@ -2577,6 +2582,7 @@
 				E124CB39746DB0B59D0390C3 /* LazyDownloadReattachTests.swift */,
 				5753714B6AF8A111E400D35A /* LazyDownloadTaskMetaTests.swift */,
 				4D9501ED4FB49C6035FDF5BB /* MockBackupProvider.swift */,
+				95B006129C2FCEC99B9FBB91 /* RemoteBookCatalogTests.swift */,
 				D9A7B601E9791FB068616C98 /* WebDAVATSTests.swift */,
 				C3F1695C0E7481CB3EA2B8A3 /* WebDAVBackupIntegrationTests.swift */,
 				C74A4D9FF0F23D7D38DC185F /* WebDAVBlobStoreTests.swift */,
@@ -3338,6 +3344,7 @@
 				800F472661AB1030CC54DB46 /* ReadingTimeFormatterTests.swift in Sources */,
 				75F2C31298F0C62115778DED /* RealDebugBridgeContextTests.swift in Sources */,
 				6B7F71BDB5ECEA83F19496FC /* ReflowableTextSourceTests.swift in Sources */,
+				E92C78246E46B2DFE76DE0A2 /* RemoteBookCatalogTests.swift in Sources */,
 				0246F6958C782714D1E5FAB4 /* ReplacementTransformTests.swift in Sources */,
 				48C743A0324468FF7507F157 /* RuleEngineTests.swift in Sources */,
 				FD253FA0CEB159E2B1299BD4 /* SchemaV1Tests.swift in Sources */,
@@ -3689,6 +3696,7 @@
 				432C40433346C054B7EC5D07 /* ReduceMotionHelper.swift in Sources */,
 				A84E7CDEED71FF118D2DD7DC /* ReflowableTextSource.swift in Sources */,
 				909ADB564394665014A94D74 /* RegexRuleEvaluator.swift in Sources */,
+				2E4D176937CECE96A39EAC18 /* RemoteBookCatalog.swift in Sources */,
 				054050637EFD8ACE415BCF2E /* ReplacementRulesView.swift in Sources */,
 				8A5EFD4729B7E4BE9D2CA38E /* ReplacementTransform.swift in Sources */,
 				357C70E2DA8091ED4022D40E /* RuleEngine.swift in Sources */,
@@ -3918,13 +3926,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 55;
+				CURRENT_PROJECT_VERSION = 56;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.23;
+				MARKETING_VERSION = 3.11.24;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4068,13 +4076,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 55;
+				CURRENT_PROJECT_VERSION = 56;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.23;
+				MARKETING_VERSION = 3.11.24;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Backup/RemoteBookCatalog.swift
+++ b/vreader/Services/Backup/RemoteBookCatalog.swift
@@ -1,0 +1,92 @@
+// Purpose: Decodes a backup ZIP's `library-manifest.json` into the
+// `[BackupLibraryEntry]` rows the selective-restore picker (#47 WI-6)
+// shows the user, and that the lazy-download enqueue path (#47 WI-4b)
+// later consults to construct download URLs / record blobPath +
+// expectedSHA256 onto the inserted `.remoteOnly` rows.
+//
+// Single responsibility: extract + decode. Network I/O (downloading the
+// ZIP from WebDAV) lives in the caller — typically `WebDAVProvider`'s
+// existing fetch path so the catalog reuses the same auth + retry
+// surface as the restore-all flow.
+//
+// Feature #47 WI-4a.
+//
+// @coordinates-with: BackupSectionDTOs.swift (BackupLibraryEntry,
+//   BackupLibraryManifestEnvelope), ZIPWriter.swift (extractEntry),
+//   SelectiveRestoreCoordinator.swift (future, WI-4b consumer),
+//   dev-docs/plans/20260503-feature-47-selective-picker-lazy-load.md
+
+import Foundation
+import OSLog
+
+private let log = Logger(subsystem: "com.vreader.app", category: "RemoteBookCatalog")
+
+enum RemoteBookCatalogError: Error, Sendable, Equatable {
+    /// The backup ZIP does not contain a `library-manifest.json` entry.
+    /// Older (pre-#46) backups fall in this bucket and surface as a
+    /// "this backup has no recoverable book files" message in the UI.
+    case manifestMissing
+    /// The manifest entry exists but failed JSON decoding (corrupt
+    /// envelope, unknown schemaVersion, missing required fields).
+    case manifestUndecodable(reason: String)
+    /// The manifest decoded but its declared `schemaVersion` is newer
+    /// than this client supports.
+    case manifestSchemaVersionTooNew(saw: Int, supported: Int)
+
+    static func == (lhs: RemoteBookCatalogError, rhs: RemoteBookCatalogError) -> Bool {
+        switch (lhs, rhs) {
+        case (.manifestMissing, .manifestMissing): return true
+        case let (.manifestUndecodable(a), .manifestUndecodable(b)): return a == b
+        case let (.manifestSchemaVersionTooNew(la, lb), .manifestSchemaVersionTooNew(ra, rb)):
+            return la == ra && lb == rb
+        default: return false
+        }
+    }
+}
+
+/// Pure decoding utility — no I/O, no actor. Tests pass in canned ZIP
+/// bytes built with `ZIPWriter.createArchive`; production callers fetch
+/// the ZIP via the existing transport then hand the bytes here.
+enum RemoteBookCatalog {
+
+    /// Maximum schema version this client understands. Bumped together
+    /// with `BackupLibraryManifestEnvelope.schemaVersion` whenever the
+    /// shape changes incompatibly.
+    static let supportedSchemaVersion = 1
+
+    /// Filename inside the backup ZIP that carries the library
+    /// manifest. Mirrored from `WebDAVProvider`'s emit path.
+    static let manifestFilename = "library-manifest.json"
+
+    /// Decodes the library manifest from a backup ZIP. Returns the
+    /// list of book entries the user can selectively restore.
+    /// - Throws `RemoteBookCatalogError` for missing / undecodable /
+    ///   future-schema manifests; never returns nil + empty.
+    static func loadEntries(fromBackupZIP zipData: Data) throws -> [BackupLibraryEntry] {
+        let manifestData: Data
+        do {
+            manifestData = try ZIPWriter.extractEntry(named: manifestFilename, from: zipData)
+        } catch {
+            log.info("library-manifest.json missing — older backup, no books to restore")
+            throw RemoteBookCatalogError.manifestMissing
+        }
+
+        let envelope: BackupLibraryManifestEnvelope
+        do {
+            envelope = try JSONDecoder().decode(
+                BackupLibraryManifestEnvelope.self, from: manifestData
+            )
+        } catch {
+            throw RemoteBookCatalogError.manifestUndecodable(reason: "\(error)")
+        }
+
+        guard envelope.schemaVersion <= supportedSchemaVersion else {
+            throw RemoteBookCatalogError.manifestSchemaVersionTooNew(
+                saw: envelope.schemaVersion,
+                supported: supportedSchemaVersion
+            )
+        }
+
+        return envelope.books
+    }
+}

--- a/vreaderTests/Services/Backup/RemoteBookCatalogTests.swift
+++ b/vreaderTests/Services/Backup/RemoteBookCatalogTests.swift
@@ -1,0 +1,142 @@
+// Purpose: Tests for RemoteBookCatalog — decodes library-manifest.json
+// out of a backup ZIP into the [BackupLibraryEntry] rows the
+// selective-restore picker (#47 WI-6) shows. Feature #47 WI-4a.
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("RemoteBookCatalog — feature #47 WI-4a")
+struct RemoteBookCatalogTests {
+
+    // MARK: - Helpers
+
+    private static func makeEntry(
+        format: String = "epub",
+        sha: String = String(repeating: "a", count: 64),
+        bytes: Int64 = 1024,
+        title: String = "Book"
+    ) -> BackupLibraryEntry {
+        let path = BlobPath.make(
+            format: BookFormat(rawValue: format) ?? .epub,
+            sha256: sha,
+            byteCount: bytes
+        )
+        return BackupLibraryEntry(
+            fingerprintKey: "\(format):\(sha):\(bytes)",
+            format: format,
+            sha256: sha,
+            byteCount: bytes,
+            originalExtension: format,
+            title: title,
+            author: "A",
+            addedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            lastOpenedAt: nil,
+            blobPath: path
+        )
+    }
+
+    private static func makeManifestZIP(envelope: BackupLibraryManifestEnvelope) throws -> Data {
+        let json = try JSONEncoder().encode(envelope)
+        return try ZIPWriter.createArchive(entries: [
+            ZIPWriter.Entry(name: "library-manifest.json", data: json),
+            ZIPWriter.Entry(name: "metadata.json", data: Data("{}".utf8))
+        ])
+    }
+
+    private static func makeZIPWithoutManifest() throws -> Data {
+        try ZIPWriter.createArchive(entries: [
+            ZIPWriter.Entry(name: "metadata.json", data: Data("{}".utf8))
+        ])
+    }
+
+    // MARK: - Happy path
+
+    @Test func loadEntries_validManifestWithBooks_returnsAll() throws {
+        let entries = [
+            Self.makeEntry(sha: String(repeating: "a", count: 64), title: "A"),
+            Self.makeEntry(sha: String(repeating: "b", count: 64), title: "B"),
+            Self.makeEntry(sha: String(repeating: "c", count: 64), title: "C")
+        ]
+        let envelope = BackupLibraryManifestEnvelope(schemaVersion: 1, books: entries)
+        let zip = try Self.makeManifestZIP(envelope: envelope)
+
+        let decoded = try RemoteBookCatalog.loadEntries(fromBackupZIP: zip)
+        #expect(decoded.count == 3)
+        #expect(decoded.map(\.title) == ["A", "B", "C"])
+        #expect(decoded[0].fingerprintKey == entries[0].fingerprintKey)
+    }
+
+    @Test func loadEntries_validManifestWithEmptyBooks_returnsEmpty() throws {
+        let envelope = BackupLibraryManifestEnvelope(schemaVersion: 1, books: [])
+        let zip = try Self.makeManifestZIP(envelope: envelope)
+        let decoded = try RemoteBookCatalog.loadEntries(fromBackupZIP: zip)
+        #expect(decoded.isEmpty)
+    }
+
+    // MARK: - Error paths
+
+    @Test func loadEntries_zipWithoutManifest_throwsManifestMissing() throws {
+        let zip = try Self.makeZIPWithoutManifest()
+        do {
+            _ = try RemoteBookCatalog.loadEntries(fromBackupZIP: zip)
+            Issue.record("expected throw")
+        } catch let error as RemoteBookCatalogError {
+            #expect(error == .manifestMissing)
+        }
+    }
+
+    @Test func loadEntries_undecodableManifest_throwsManifestUndecodable() throws {
+        let zip = try ZIPWriter.createArchive(entries: [
+            ZIPWriter.Entry(name: "library-manifest.json", data: Data("not json".utf8))
+        ])
+        do {
+            _ = try RemoteBookCatalog.loadEntries(fromBackupZIP: zip)
+            Issue.record("expected throw")
+        } catch let RemoteBookCatalogError.manifestUndecodable(reason) {
+            #expect(!reason.isEmpty)
+        }
+    }
+
+    @Test func loadEntries_futureSchemaVersion_throwsSchemaVersionTooNew() throws {
+        // Hand-craft envelope JSON with a future schemaVersion. Direct
+        // struct init can't bypass the constant currentSchemaVersion.
+        let json = """
+        {"schemaVersion":99,"books":[]}
+        """.data(using: .utf8)!
+        let zip = try ZIPWriter.createArchive(entries: [
+            ZIPWriter.Entry(name: "library-manifest.json", data: json)
+        ])
+        do {
+            _ = try RemoteBookCatalog.loadEntries(fromBackupZIP: zip)
+            Issue.record("expected throw")
+        } catch let RemoteBookCatalogError.manifestSchemaVersionTooNew(saw, supported) {
+            #expect(saw == 99)
+            #expect(supported == RemoteBookCatalog.supportedSchemaVersion)
+        }
+    }
+
+    @Test func loadEntries_garbageZIPData_throwsManifestMissing() throws {
+        // A non-ZIP byte buffer should fail extractEntry and surface as
+        // manifestMissing — not a crash.
+        let bogus = Data(repeating: 0xAB, count: 100)
+        do {
+            _ = try RemoteBookCatalog.loadEntries(fromBackupZIP: bogus)
+            Issue.record("expected throw")
+        } catch let error as RemoteBookCatalogError {
+            #expect(error == .manifestMissing)
+        }
+    }
+
+    // MARK: - Constants
+
+    @Test func supportedSchemaVersionIsOne() {
+        #expect(RemoteBookCatalog.supportedSchemaVersion == 1)
+    }
+
+    @Test func manifestFilenameMatchesProducer() {
+        // WebDAVProvider emits "library-manifest.json" — keep the
+        // catalog reader in lock-step.
+        #expect(RemoteBookCatalog.manifestFilename == "library-manifest.json")
+    }
+}


### PR DESCRIPTION
## Summary

- Pure-decoding utility that extracts `library-manifest.json` from a backup ZIP and returns `[BackupLibraryEntry]` for the selective-restore picker (#47 WI-6) and lazy-download enqueue path (#47 WI-4b).
- 8 tests cover happy path, missing manifest, undecodable JSON, future schema, garbage ZIP.
- Closes WI-4a.

Refs #47

## What Changed

- New `RemoteBookCatalog.swift` (~95 LOC) — enum namespace + `loadEntries(fromBackupZIP:)` + 3-case error type
- New `RemoteBookCatalogTests.swift` (8 tests)
- Version 3.11.23 → 3.11.24 (build 56)

## Audit

Codex MCP unavailable. Manual mini-audit per `.claude/rules/47-feature-workflow.md` fallback in commit message.

## Validation

- [x] 8/8 tests pass

## Type of Change

- [x] Feature (#47 WI-4a part 2)