### PR TITLE
feat(#47): WI-4b — SelectiveRestoreCoordinator

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 56
-        MARKETING_VERSION: 3.11.24
+        CURRENT_PROJECT_VERSION: 57
+        MARKETING_VERSION: 3.11.25
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -269,6 +269,7 @@
 		581D8C5F46D4CAAD4DA31EF8 /* FoliateViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506F86FDA1498276D10E5E7B /* FoliateViewCoordinator.swift */; };
 		5895F86BFE58FBFBAA7D8424 /* SyncStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F6250C22449E7E83591620 /* SyncStatusView.swift */; };
 		58F98A74EEAB6D0C39616B5D /* UnifiedTextRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7F45FFFEE431C41E618EF2 /* UnifiedTextRendererTests.swift */; };
+		594C442CEEA499384283D6B7 /* SelectiveRestoreCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD987912F59B7B7CD80B064 /* SelectiveRestoreCoordinator.swift */; };
 		59B8E65739F0BDF9F099D348 /* SearchQueryExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B1246EC0EE34D326231F60 /* SearchQueryExecutorTests.swift */; };
 		59C50A731FA0022482A38792 /* WCAGContrastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2A16647F198641F11AC9C1 /* WCAGContrastTests.swift */; };
 		5A39B7FF78E085A0F6696BE6 /* CSSRuleEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152689657913035E5579B762 /* CSSRuleEvaluatorTests.swift */; };
@@ -609,6 +610,7 @@
 		CEAEA28FA9D03BDAACC97CBF /* SyncOutboundQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B00C0FE14AB02EDE7E9EDD /* SyncOutboundQueueTests.swift */; };
 		CFC40B5FB55F37C092A70338 /* VReaderAnnotationParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36D5CFF47A223349C004E39 /* VReaderAnnotationParserTests.swift */; };
 		CFF2F7127E363B96F2B6429B /* LibraryBookItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E3D2050D82A39083191EDDA /* LibraryBookItem.swift */; };
+		D007D50EE76181258F5D0681 /* SelectiveRestoreCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9358413A64690874ED7AB67D /* SelectiveRestoreCoordinatorTests.swift */; };
 		D0373F025DFBBEF9FAD19788 /* LazyDownloadBackgroundEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F891C451718B4BC9AC7BCEC /* LazyDownloadBackgroundEventsTests.swift */; };
 		D08EB57C5EBC9C9542476015 /* MetadataExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC5F159064D57CFAE2A676 /* MetadataExtractorTests.swift */; };
 		D0E3C146DC0F8D0978B419E7 /* AIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C4804D4D5F435DF10014C5 /* AIError.swift */; };
@@ -1167,6 +1169,7 @@
 		92676552DDABC9E3D5E7DC76 /* HapticFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticFeedback.swift; sourceTree = "<group>"; };
 		9279142901B3666BD14E0B20 /* DebugCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugCommandTests.swift; sourceTree = "<group>"; };
 		92AB43BED5AC7096E7278A16 /* QuoteRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuoteRecoveryTests.swift; sourceTree = "<group>"; };
+		9358413A64690874ED7AB67D /* SelectiveRestoreCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectiveRestoreCoordinatorTests.swift; sourceTree = "<group>"; };
 		936C16A4F1B2B55E63922EE7 /* ChapterProgressCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterProgressCalculator.swift; sourceTree = "<group>"; };
 		9380720966F3E3F6F8A0D407 /* DebugReaderRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReaderRegistry.swift; sourceTree = "<group>"; };
 		93955827511F55BEEFCA2307 /* BookSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSource.swift; sourceTree = "<group>"; };
@@ -1377,6 +1380,7 @@
 		DDB7C7EC41A96F5D4B53E983 /* ReaderNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderNotifications.swift; sourceTree = "<group>"; };
 		DDC88500940FCA638D86E8E4 /* PDFReaderContainerView+Overlays.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PDFReaderContainerView+Overlays.swift"; sourceTree = "<group>"; };
 		DDD7F2C7E93907B97A730010 /* HighlightListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightListViewModel.swift; sourceTree = "<group>"; };
+		DDD987912F59B7B7CD80B064 /* SelectiveRestoreCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectiveRestoreCoordinator.swift; sourceTree = "<group>"; };
 		DE2038A4D36C4355AC5C7BF5 /* SearchLocatorSliceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchLocatorSliceTests.swift; sourceTree = "<group>"; };
 		DE360E19106AAA7A1FCEEEB9 /* legado_source_minimal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = legado_source_minimal.json; sourceTree = "<group>"; };
 		DE5CAE41C429B6868957C540 /* ExportTestFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTestFixtures.swift; sourceTree = "<group>"; };
@@ -1661,6 +1665,7 @@
 				592405D887F7AE66A58FA8D9 /* LazyDownloadTaskMeta.swift */,
 				DB6CE81404902AB359536964 /* PROPFINDParser.swift */,
 				DF7D174AC38392C14C17F1F7 /* RemoteBookCatalog.swift */,
+				DDD987912F59B7B7CD80B064 /* SelectiveRestoreCoordinator.swift */,
 				9DAC16C19C7D4C72EFC950C9 /* WebDAVBlobStore.swift */,
 				4946129FECC6C9BA7A7F16A1 /* WebDAVClient.swift */,
 				D408C9CE57D4C437A72C0D18 /* WebDAVNetworkPolicy.swift */,
@@ -2583,6 +2588,7 @@
 				5753714B6AF8A111E400D35A /* LazyDownloadTaskMetaTests.swift */,
 				4D9501ED4FB49C6035FDF5BB /* MockBackupProvider.swift */,
 				95B006129C2FCEC99B9FBB91 /* RemoteBookCatalogTests.swift */,
+				9358413A64690874ED7AB67D /* SelectiveRestoreCoordinatorTests.swift */,
 				D9A7B601E9791FB068616C98 /* WebDAVATSTests.swift */,
 				C3F1695C0E7481CB3EA2B8A3 /* WebDAVBackupIntegrationTests.swift */,
 				C74A4D9FF0F23D7D38DC185F /* WebDAVBlobStoreTests.swift */,
@@ -3358,6 +3364,7 @@
 				8CB7B605DFC452B422BBEC4F /* SearchTextNormalizerTests.swift in Sources */,
 				8BBE50E626A6524E8C6DB59D /* SearchViewModelTests.swift in Sources */,
 				F14370F35DEFDB725452B5CA /* SearchWiringTests.swift in Sources */,
+				D007D50EE76181258F5D0681 /* SelectiveRestoreCoordinatorTests.swift in Sources */,
 				4A87A6889CFFC099EE0AFBD6 /* SeriesTagPersistenceTests.swift in Sources */,
 				088EB6A1D2B736BB8B643B30 /* SimpTradTransformTests.swift in Sources */,
 				30F629136C9EED9FCD557222 /* SmokeTests.swift in Sources */,
@@ -3719,6 +3726,7 @@
 				74BEA01C5E4B3E080D2BF2FD /* SearchTokenizer.swift in Sources */,
 				1C9B4E21A97013A7CC409925 /* SearchView.swift in Sources */,
 				2F69DF71FDE5AF4FF920C3B2 /* SearchViewModel.swift in Sources */,
+				594C442CEEA499384283D6B7 /* SelectiveRestoreCoordinator.swift in Sources */,
 				8FFE1DA9C8F17FC318BE81BD /* SettingsView.swift in Sources */,
 				EBB6F00E3C34370C7C2CB369 /* ShareSheet.swift in Sources */,
 				6BA38351098A88991EC589D3 /* SimpTradDictionary.swift in Sources */,
@@ -3926,13 +3934,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 56;
+				CURRENT_PROJECT_VERSION = 57;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.24;
+				MARKETING_VERSION = 3.11.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4076,13 +4084,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 56;
+				CURRENT_PROJECT_VERSION = 57;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.24;
+				MARKETING_VERSION = 3.11.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Backup/SelectiveRestoreCoordinator.swift
+++ b/vreader/Services/Backup/SelectiveRestoreCoordinator.swift
@@ -1,0 +1,196 @@
+// Purpose: Orchestrator for the selective-restore flow (#47 WI-4b).
+// Given the manifest of a backup and the user's selected fingerprint
+// keys, this coordinator:
+//
+//   1. Pre-plants every UNSELECTED entry as a `.remoteOnly` row in
+//      persistence so it shows up in the library immediately. The
+//      lazy-download coordinator (#47 WI-3) will fetch the bytes on
+//      first tap.
+//   2. Materializes (downloads + verifies + imports) every SELECTED
+//      entry via the existing `BookFileMaterializer`. Each successful
+//      import lands as a `.local` row.
+//   3. Runs metadata restore via the existing `BackupDataRestoring`
+//      path so reading positions, annotations, collections, etc.
+//      reattach to BOTH `.local` and `.remoteOnly` rows by
+//      fingerprintKey.
+//
+// Phases report progress 0...1 with a fixed weighting (0.10 / 0.75 /
+// 0.15). The coordinator does NOT fetch the manifest itself —
+// `RemoteBookCatalog.loadEntries(fromBackupZIP:)` does that, and the
+// caller (BackupViewModel / WebDAVProvider.restoreSelectively) hands
+// the decoded list in.
+//
+// @coordinates-with: BookFileMaterializer.swift,
+//   PersistenceActor+RemoteOnly.swift, RemoteBookCatalog.swift,
+//   WebDAVProvider.swift (BackupDataRestoring),
+//   BackupSectionDTOs.swift,
+//   dev-docs/plans/20260503-feature-47-selective-picker-lazy-load.md
+
+import Foundation
+import OSLog
+
+private let log = Logger(subsystem: "com.vreader.app", category: "SelectiveRestoreCoordinator")
+
+/// Bytes carried by `restoreSelectively`'s metadata-restore phase.
+/// Each section is optional because older backups may omit some
+/// sections (e.g. `replacementRules` was added later).
+struct SelectiveRestoreMetadataSections: Sendable {
+    var annotations: Data?
+    var positions: Data?
+    var settings: Data?
+    var collections: Data?
+    var bookSources: Data?
+    var perBookSettings: Data?
+    var replacementRules: Data?
+
+    init(
+        annotations: Data? = nil,
+        positions: Data? = nil,
+        settings: Data? = nil,
+        collections: Data? = nil,
+        bookSources: Data? = nil,
+        perBookSettings: Data? = nil,
+        replacementRules: Data? = nil
+    ) {
+        self.annotations = annotations
+        self.positions = positions
+        self.settings = settings
+        self.collections = collections
+        self.bookSources = bookSources
+        self.perBookSettings = perBookSettings
+        self.replacementRules = replacementRules
+    }
+}
+
+/// Per-coordinator outcome. Aggregates per-entry materialize results
+/// + the count of pre-planted remote-only rows so callers can show a
+/// summary ("2 imported · 3 marked for download").
+struct SelectiveRestoreSummary: Sendable {
+    let materialized: [MaterializeResult]
+    let remoteOnlyPreplantedKeys: [String]
+
+    var localCount: Int { materialized.filter { $0.isSuccess }.count }
+    var remoteOnlyCount: Int { remoteOnlyPreplantedKeys.count }
+}
+
+struct SelectiveRestoreCoordinator: Sendable {
+
+    private let materializer: BookFileMaterializer
+    private let persistence: PersistenceActor
+    private let dataRestorer: any BackupDataRestoring
+
+    init(
+        materializer: BookFileMaterializer,
+        persistence: PersistenceActor,
+        dataRestorer: any BackupDataRestoring
+    ) {
+        self.materializer = materializer
+        self.persistence = persistence
+        self.dataRestorer = dataRestorer
+    }
+
+    /// Runs the three-phase selective restore. Caller is responsible
+    /// for fetching the backup ZIP and decoding the manifest via
+    /// `RemoteBookCatalog.loadEntries(fromBackupZIP:)` first.
+    ///
+    /// - Parameters:
+    ///   - manifest: every entry in the backup's library manifest.
+    ///   - selectedKeys: the subset the user chose to materialize
+    ///     immediately. Keys not in this set are pre-planted as
+    ///     `.remoteOnly` rows.
+    ///   - metadataSections: bytes for each restore section
+    ///     (annotations, positions, etc.). Sections present in the
+    ///     backup ZIP but not in this struct are skipped.
+    ///   - progress: 0.0 → 1.0 callback. Phase weights:
+    ///     0.10 preplant, 0.75 materialize, 0.15 metadata restore.
+    func restoreSelectively(
+        manifest: [BackupLibraryEntry],
+        selectedKeys: Set<String>,
+        metadataSections: SelectiveRestoreMetadataSections,
+        progress: @Sendable (Double) -> Void
+    ) async throws -> SelectiveRestoreSummary {
+        progress(0.0)
+
+        // Phase 1 — preplant remote-only rows.
+        let unselected = manifest.filter { !selectedKeys.contains($0.fingerprintKey) }
+        let preplantedKeys = unselected.map(\.fingerprintKey)
+        if !unselected.isEmpty {
+            let records = unselected.map { Self.makeRemoteOnlyRecord(from: $0) }
+            try await persistence.insertRemoteOnlyBookRecords(records)
+        }
+        progress(0.10)
+        log.info(
+            "preplanted \(unselected.count) remoteOnly row(s); \(selectedKeys.count) selected for materialization"
+        )
+
+        // Phase 2 — materialize selected entries.
+        let selected = manifest.filter { selectedKeys.contains($0.fingerprintKey) }
+        let materializeResults: [MaterializeResult]
+        if selected.isEmpty {
+            materializeResults = []
+            progress(0.85)
+        } else {
+            materializeResults = await materializer.materialize(selected) { sub in
+                // Map sub-progress 0..1 → 0.10..0.85.
+                progress(0.10 + sub * 0.75)
+            }
+        }
+
+        // Phase 3 — metadata restore. Sections present get applied;
+        // missing sections are no-op'd. Reading positions land on the
+        // entries we just inserted (local + remoteOnly) by fingerprintKey.
+        try await applyMetadataSections(metadataSections)
+        progress(1.0)
+
+        return SelectiveRestoreSummary(
+            materialized: materializeResults,
+            remoteOnlyPreplantedKeys: preplantedKeys
+        )
+    }
+
+    // MARK: - Phase 3 helper
+
+    private func applyMetadataSections(_ sections: SelectiveRestoreMetadataSections) async throws {
+        if let data = sections.annotations { try await dataRestorer.restoreAnnotations(from: data) }
+        if let data = sections.positions { try await dataRestorer.restorePositions(from: data) }
+        if let data = sections.settings { try await dataRestorer.restoreSettings(from: data) }
+        if let data = sections.collections { try await dataRestorer.restoreCollections(from: data) }
+        if let data = sections.bookSources { try await dataRestorer.restoreBookSources(from: data) }
+        if let data = sections.perBookSettings { try await dataRestorer.restorePerBookSettings(from: data) }
+        if let data = sections.replacementRules { try await dataRestorer.restoreReplacementRules(from: data) }
+    }
+
+    // MARK: - Manifest → BookRecord
+
+    /// Maps a manifest entry into a `BookRecord` for the persistence
+    /// layer. `fileState` is set to `.remoteOnly` (the bulk-insert
+    /// coerces it anyway, but being explicit at the call site reads
+    /// cleaner and matches the intent). `provenance.source = .restore`.
+    static func makeRemoteOnlyRecord(from entry: BackupLibraryEntry) -> BookRecord {
+        let format = BookFormat(rawValue: entry.format) ?? .epub
+        let fp = DocumentFingerprint(
+            contentSHA256: entry.sha256,
+            fileByteCount: entry.byteCount,
+            format: format
+        )
+        let provenance = ImportProvenance(
+            source: .restore,
+            importedAt: Date(),
+            originalURLBookmarkData: nil
+        )
+        return BookRecord(
+            fingerprintKey: entry.fingerprintKey,
+            title: entry.title ?? "Untitled",
+            author: entry.author,
+            coverImagePath: nil,
+            fingerprint: fp,
+            provenance: provenance,
+            detectedEncoding: nil,
+            addedAt: entry.addedAt,
+            originalExtension: entry.originalExtension,
+            lastOpenedAt: entry.lastOpenedAt,
+            fileState: .remoteOnly,
+            blobPath: entry.blobPath
+        )
+    }
+}

--- a/vreaderTests/Services/Backup/SelectiveRestoreCoordinatorTests.swift
+++ b/vreaderTests/Services/Backup/SelectiveRestoreCoordinatorTests.swift
@@ -1,0 +1,289 @@
+// Purpose: Tests for SelectiveRestoreCoordinator — the 3-phase
+// orchestrator (preplant remoteOnly → materialize selected → restore
+// metadata) for the picker-driven restore flow. Feature #47 WI-4b.
+
+import Testing
+import Foundation
+import CryptoKit
+@testable import vreader
+
+@Suite("SelectiveRestoreCoordinator — feature #47 WI-4b")
+struct SelectiveRestoreCoordinatorTests {
+
+    // MARK: - Mocks
+
+    actor StubBlobReader: BackupBlobReading {
+        var blobs: [String: Data] = [:]
+        func setBlob(_ data: Data, at path: String) { blobs[path] = data }
+        func existsWithSize(at path: String) async throws -> Int64? {
+            blobs[path].map { Int64($0.count) }
+        }
+        func download(from path: String) async throws -> Data {
+            guard let d = blobs[path] else {
+                throw BackupBlobStoreError.underlying("not found: \(path)")
+            }
+            return d
+        }
+    }
+
+    actor RecordingDataRestorer: BackupDataRestoring {
+        private(set) var calls: [String] = []
+        func restoreAnnotations(from data: Data) async throws { calls.append("annotations:\(data.count)") }
+        func restorePositions(from data: Data) async throws { calls.append("positions:\(data.count)") }
+        func restoreSettings(from data: Data) async throws { calls.append("settings:\(data.count)") }
+        func restoreCollections(from data: Data) async throws { calls.append("collections:\(data.count)") }
+        func restoreBookSources(from data: Data) async throws { calls.append("bookSources:\(data.count)") }
+        func restorePerBookSettings(from data: Data) async throws { calls.append("perBookSettings:\(data.count)") }
+        func restoreReplacementRules(from data: Data) async throws { calls.append("replacementRules:\(data.count)") }
+        func recordedCalls() -> [String] { calls }
+    }
+
+    // MARK: - Helpers
+
+    private static func sha256Hex(_ data: Data) -> String {
+        Data(SHA256.hash(data: data)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("selrestore_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private static func makeEntry(
+        title: String,
+        bytes: Data
+    ) -> BackupLibraryEntry {
+        let sha = sha256Hex(bytes)
+        return BackupLibraryEntry(
+            fingerprintKey: "epub:\(sha):\(bytes.count)",
+            format: "epub",
+            sha256: sha,
+            byteCount: Int64(bytes.count),
+            originalExtension: "epub",
+            title: title,
+            author: "A",
+            addedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            lastOpenedAt: nil,
+            blobPath: BlobPath.make(format: .epub, sha256: sha, byteCount: Int64(bytes.count))
+        )
+    }
+
+    private static func makeEPUBBytes(seed: UInt8) -> Data {
+        Data([0x50, 0x4B, 0x03, 0x04]) + Data(repeating: seed, count: 1024)
+    }
+
+    /// Returns (coordinator, persistence, dataRestorer, blobReader).
+    private static func makeRig() async throws -> (
+        SelectiveRestoreCoordinator,
+        PersistenceActor,
+        RecordingDataRestorer,
+        StubBlobReader
+    ) {
+        let blobReader = StubBlobReader()
+        let persistence = try CollectionTestHelper.makePersistence()
+        let sandbox = try makeTempDir()
+        let temp = try makeTempDir()
+        let importer = BookImporter(persistence: persistence, sandboxBooksDirectory: sandbox)
+        let resolver: SandboxURLResolver = { fingerprintKey, ext in
+            let safe = fingerprintKey.replacingOccurrences(of: ":", with: "_")
+            return sandbox.appendingPathComponent(safe).appendingPathExtension(ext)
+        }
+        let materializer = BookFileMaterializer(
+            blobStore: blobReader,
+            importer: importer,
+            tempDirectory: temp,
+            resolveSandboxURL: resolver
+        )
+        let dataRestorer = RecordingDataRestorer()
+        let coordinator = SelectiveRestoreCoordinator(
+            materializer: materializer,
+            persistence: persistence,
+            dataRestorer: dataRestorer
+        )
+        return (coordinator, persistence, dataRestorer, blobReader)
+    }
+
+    // MARK: - Acceptance: 5-entry manifest, pick 2
+
+    @Test func restoreSelectively_pick2of5_yields2localPlus3remoteOnly() async throws {
+        let (coordinator, persistence, _, blobReader) = try await Self.makeRig()
+        let entries = (0..<5).map { i in
+            Self.makeEntry(title: "Book \(i)", bytes: Self.makeEPUBBytes(seed: UInt8(i)))
+        }
+        // Stage blobs so the materializer can fetch the selected ones.
+        for entry in entries {
+            await blobReader.setBlob(Self.makeEPUBBytes(seed: UInt8(entries.firstIndex(where: { $0.fingerprintKey == entry.fingerprintKey })!)), at: entry.blobPath)
+        }
+
+        let selected: Set<String> = [entries[1].fingerprintKey, entries[3].fingerprintKey]
+        let summary = try await coordinator.restoreSelectively(
+            manifest: entries,
+            selectedKeys: selected,
+            metadataSections: SelectiveRestoreMetadataSections(),
+            progress: { _ in }
+        )
+
+        #expect(summary.localCount == 2)
+        #expect(summary.remoteOnlyCount == 3)
+
+        // Verify persistence shape: 2 .local, 3 .remoteOnly, total 5.
+        let localKeys = try await persistence.fingerprintKeys(withFileState: .local)
+        let remoteKeys = try await persistence.fingerprintKeys(withFileState: .remoteOnly)
+        #expect(localKeys.count == 2)
+        #expect(Set(remoteKeys) == Set([entries[0], entries[2], entries[4]].map(\.fingerprintKey)))
+    }
+
+    // MARK: - Phase ordering / progress
+
+    @Test func progress_movesMonotonically_through3Phases() async throws {
+        let (coordinator, _, _, blobReader) = try await Self.makeRig()
+        let entry = Self.makeEntry(title: "X", bytes: Self.makeEPUBBytes(seed: 1))
+        await blobReader.setBlob(Self.makeEPUBBytes(seed: 1), at: entry.blobPath)
+
+        actor Collector { var values: [Double] = []; func record(_ v: Double) { values.append(v) } }
+        let collector = Collector()
+
+        _ = try await coordinator.restoreSelectively(
+            manifest: [entry],
+            selectedKeys: [entry.fingerprintKey],
+            metadataSections: SelectiveRestoreMetadataSections(),
+            progress: { v in Task { await collector.record(v) } }
+        )
+        await Task.yield()
+        await Task.yield()
+        let values = await collector.values
+        #expect(values.first == 0.0)
+        #expect(values.last == 1.0)
+        // Monotonic non-decreasing.
+        for i in 1..<values.count {
+            #expect(values[i] >= values[i - 1])
+        }
+    }
+
+    // MARK: - All-remoteOnly + all-selected edges
+
+    @Test func restoreSelectively_emptySelection_allBecomeRemoteOnly() async throws {
+        let (coordinator, persistence, _, _) = try await Self.makeRig()
+        let entries = (0..<3).map { i in
+            Self.makeEntry(title: "B\(i)", bytes: Self.makeEPUBBytes(seed: UInt8(i)))
+        }
+        let summary = try await coordinator.restoreSelectively(
+            manifest: entries,
+            selectedKeys: [],
+            metadataSections: SelectiveRestoreMetadataSections(),
+            progress: { _ in }
+        )
+        #expect(summary.localCount == 0)
+        #expect(summary.remoteOnlyCount == 3)
+        let remoteKeys = try await persistence.fingerprintKeys(withFileState: .remoteOnly)
+        #expect(Set(remoteKeys) == Set(entries.map(\.fingerprintKey)))
+    }
+
+    @Test func restoreSelectively_emptyManifest_succeedsAndRestoresMetadata() async throws {
+        let (coordinator, persistence, dataRestorer, _) = try await Self.makeRig()
+        let summary = try await coordinator.restoreSelectively(
+            manifest: [],
+            selectedKeys: [],
+            metadataSections: SelectiveRestoreMetadataSections(
+                positions: Data("{}".utf8)
+            ),
+            progress: { _ in }
+        )
+        #expect(summary.localCount == 0)
+        #expect(summary.remoteOnlyCount == 0)
+        let remote = try await persistence.fingerprintKeys(withFileState: .remoteOnly)
+        #expect(remote.isEmpty)
+        let calls = await dataRestorer.recordedCalls()
+        #expect(calls.contains(where: { $0.hasPrefix("positions:") }))
+    }
+
+    // MARK: - Metadata restore phase
+
+    @Test func metadataSections_eachPresentInvokesCorrespondingRestorer() async throws {
+        let (coordinator, _, dataRestorer, _) = try await Self.makeRig()
+        let sections = SelectiveRestoreMetadataSections(
+            annotations: Data("a".utf8),
+            positions: Data("p".utf8),
+            settings: Data("s".utf8),
+            collections: Data("c".utf8),
+            bookSources: Data("bs".utf8),
+            perBookSettings: Data("pbs".utf8),
+            replacementRules: Data("rr".utf8)
+        )
+        _ = try await coordinator.restoreSelectively(
+            manifest: [],
+            selectedKeys: [],
+            metadataSections: sections,
+            progress: { _ in }
+        )
+        let calls = await dataRestorer.recordedCalls()
+        #expect(calls.contains("annotations:1"))
+        #expect(calls.contains("positions:1"))
+        #expect(calls.contains("settings:1"))
+        #expect(calls.contains("collections:1"))
+        #expect(calls.contains("bookSources:2"))
+        #expect(calls.contains("perBookSettings:3"))
+        #expect(calls.contains("replacementRules:2"))
+    }
+
+    @Test func metadataSections_missingSection_skipsRestorerCall() async throws {
+        let (coordinator, _, dataRestorer, _) = try await Self.makeRig()
+        // Only positions present.
+        _ = try await coordinator.restoreSelectively(
+            manifest: [],
+            selectedKeys: [],
+            metadataSections: SelectiveRestoreMetadataSections(positions: Data("p".utf8)),
+            progress: { _ in }
+        )
+        let calls = await dataRestorer.recordedCalls()
+        #expect(calls == ["positions:1"])
+    }
+
+    // MARK: - Don't downgrade existing local rows
+
+    @Test func restoreSelectively_existingLocalEntry_isPreserved() async throws {
+        let (coordinator, persistence, _, _) = try await Self.makeRig()
+        let entry = Self.makeEntry(title: "Already Here", bytes: Self.makeEPUBBytes(seed: 7))
+        // Pre-insert as a local row.
+        let existingRecord = BookRecord(
+            fingerprintKey: entry.fingerprintKey,
+            title: "Existing Local",
+            author: nil,
+            coverImagePath: nil,
+            fingerprint: DocumentFingerprint(
+                contentSHA256: entry.sha256,
+                fileByteCount: entry.byteCount,
+                format: .epub
+            ),
+            provenance: ImportProvenance(
+                source: .filesApp,
+                importedAt: Date(),
+                originalURLBookmarkData: nil
+            ),
+            detectedEncoding: nil,
+            addedAt: Date(),
+            originalExtension: "epub",
+            fileState: .local,
+            blobPath: nil
+        )
+        _ = try await persistence.insertBook(existingRecord)
+
+        // User does NOT select it (so it would be preplanted as remoteOnly).
+        let summary = try await coordinator.restoreSelectively(
+            manifest: [entry],
+            selectedKeys: [],
+            metadataSections: SelectiveRestoreMetadataSections(),
+            progress: { _ in }
+        )
+        // Coordinator reports 1 preplanted (intent), but persistence
+        // didn't downgrade — insertRemoteOnlyBookRecords is idempotent
+        // vs existing local rows (verified in WI-3b foundation tests).
+        #expect(summary.remoteOnlyCount == 1)
+        let local = try await persistence.fingerprintKeys(withFileState: .local)
+        #expect(local == [entry.fingerprintKey])
+        let remote = try await persistence.fingerprintKeys(withFileState: .remoteOnly)
+        #expect(remote.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- 3-phase orchestrator (preplant `.remoteOnly` → materialize selected → restore metadata) for the picker-driven restore flow.
- 7 tests cover the 5-of-2 acceptance scenario and edge cases. Closes WI-4b.

Refs #47

## What Changed

- New `SelectiveRestoreCoordinator.swift` (~200 LOC)
- New `SelectiveRestoreCoordinatorTests.swift` (7 tests)
- Version 3.11.24 → 3.11.25 (build 57)

## Audit

Codex MCP unavailable. Manual mini-audit per `.claude/rules/47-feature-workflow.md` fallback in commit message.

## Validation

- [x] 7/7 tests pass
- [ ] WebDAVProvider integration + UI consumer land in WI-6

## Type of Change

- [x] Feature (#47 WI-4b)