### PR TITLE
feat(#47): WI-5 part 1 — LibraryBookItem fileState helpers

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 57
-        MARKETING_VERSION: 3.11.25
+        CURRENT_PROJECT_VERSION: 58
+        MARKETING_VERSION: 3.11.26
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -285,6 +285,7 @@
 		5FE7F04D448C49D466F641FB /* LocatorNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C20D015AD61E29BEB57DC3 /* LocatorNormalizerTests.swift */; };
 		60044E9F6E34936F312FA826 /* TXTChapterContentLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529D0FB4C5C73B62F1C8D6D6 /* TXTChapterContentLoader.swift */; };
 		6070A8AF12AADF388F7C1383 /* V1toV2MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939BC09F1D771D2E22301ED3 /* V1toV2MigrationTests.swift */; };
+		60F28F11E8F15E0FFAF4922C /* LibraryBookItemFileStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4E5558CB75432C026267C1 /* LibraryBookItemFileStateTests.swift */; };
 		6173290A06E9E4303D363AE8 /* ReaderThemeCSSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DE298149C25261E2ECADA1 /* ReaderThemeCSSTests.swift */; };
 		61E01D7572FE7393220D499F /* MOBICoverExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2997AAAB34DF84E64DC0DB4 /* MOBICoverExtractor.swift */; };
 		61EBFF18AB67FAA5DD37BB2D /* TTSProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97DAB513E717D83CD9ED3F7 /* TTSProviderProtocol.swift */; };
@@ -968,6 +969,7 @@
 		4C19E96D5AE40D3577255C38 /* TXTChapterHighlightHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterHighlightHelperTests.swift; sourceTree = "<group>"; };
 		4C87C165AFE78571456C14D1 /* LocatorValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorValidationTests.swift; sourceTree = "<group>"; };
 		4CC7EBBBE07E87F07CC0FE4F /* ReaderNotificationHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderNotificationHandlerTests.swift; sourceTree = "<group>"; };
+		4D4E5558CB75432C026267C1 /* LibraryBookItemFileStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryBookItemFileStateTests.swift; sourceTree = "<group>"; };
 		4D5CDE195E585067DE4D6124 /* AnnotationListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationListViewModelTests.swift; sourceTree = "<group>"; };
 		4D9501ED4FB49C6035FDF5BB /* MockBackupProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackupProvider.swift; sourceTree = "<group>"; };
 		4DCA33DBE911B5B1B6425277 /* MDTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDTypesTests.swift; sourceTree = "<group>"; };
@@ -1527,6 +1529,7 @@
 				D4B4E4FB28FD82376AE20A4F /* DocumentFingerprintValidationTests.swift */,
 				1D579834E6924BB521873C38 /* FormatCapabilitiesTests.swift */,
 				FDFAF8770F91837F0B3793E1 /* ImportProvenanceTests.swift */,
+				4D4E5558CB75432C026267C1 /* LibraryBookItemFileStateTests.swift */,
 				770B26672B9E379E795E28E7 /* LibraryBookItemTests.swift */,
 				B3987200016FB6CA3D063E44 /* LocatorCanonicalHashTests.swift */,
 				61E8B92C301E5470AB98C87E /* LocatorTests.swift */,
@@ -3273,6 +3276,7 @@
 				7B1619D0A3AF6B77D0D4C7B0 /* LazyDownloadTaskMetaTests.swift in Sources */,
 				A8A3BDDF157E89577638C20F /* LegadoImporterTests.swift in Sources */,
 				1FDAAAE256E0BFC292778111 /* LegadoRuleParserTests.swift in Sources */,
+				60F28F11E8F15E0FFAF4922C /* LibraryBookItemFileStateTests.swift in Sources */,
 				EB3FFD36A03AA194F33246D4 /* LibraryBookItemTests.swift in Sources */,
 				73319DBA75C0F4352DDCD858 /* LibraryContextMenuTests.swift in Sources */,
 				879E269189DBE24A5AF6095B /* LibraryRefreshServiceTests.swift in Sources */,
@@ -3934,13 +3938,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 57;
+				CURRENT_PROJECT_VERSION = 58;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.25;
+				MARKETING_VERSION = 3.11.26;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4084,13 +4088,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 57;
+				CURRENT_PROJECT_VERSION = 58;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.25;
+				MARKETING_VERSION = 3.11.26;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Models/BookFileState.swift
+++ b/vreader/Models/BookFileState.swift
@@ -22,7 +22,7 @@ import Foundation
 /// The Book row exists for every book the user has imported or restored.
 /// `fileState` describes whether the bytes for that row are present
 /// locally, on a remote backup server only, mid-transfer, or unrecoverable.
-public enum BookFileState: String, Sendable, Codable, CaseIterable, Equatable {
+public enum BookFileState: String, Sendable, Codable, CaseIterable, Equatable, Hashable {
     /// Bytes are present at the sandbox URL; fingerprint was verified at import.
     case local
 

--- a/vreader/Models/LibraryBookItem.swift
+++ b/vreader/Models/LibraryBookItem.swift
@@ -26,6 +26,68 @@ struct LibraryBookItem: Sendable, Identifiable, Equatable, Hashable {
     var lastReadAt: Date?
     let averagePagesPerHour: Double?
     let averageWordsPerMinute: Double?
+    /// File-presence state (feature #47). Drives row UI: cloud icon for
+    /// `.remoteOnly`, spinner for `.downloading`, retry CTA for `.failed`.
+    let fileState: BookFileState
+    /// Server-side blob path on the WebDAV backup (feature #47). Nil for
+    /// books that have never been backed up.
+    let blobPath: String?
+
+    /// Explicit memberwise init with feature #47 defaults so existing
+    /// call sites that pre-date `fileState`/`blobPath` continue to
+    /// compile; new call sites pass the persisted values through.
+    init(
+        fingerprintKey: String,
+        title: String,
+        author: String?,
+        coverImagePath: String?,
+        format: String,
+        fileByteCount: Int64,
+        addedAt: Date,
+        lastOpenedAt: Date?,
+        isFavorite: Bool,
+        totalReadingSeconds: Int,
+        lastReadAt: Date? = nil,
+        averagePagesPerHour: Double?,
+        averageWordsPerMinute: Double?,
+        fileState: BookFileState = .local,
+        blobPath: String? = nil
+    ) {
+        self.fingerprintKey = fingerprintKey
+        self.title = title
+        self.author = author
+        self.coverImagePath = coverImagePath
+        self.format = format
+        self.fileByteCount = fileByteCount
+        self.addedAt = addedAt
+        self.lastOpenedAt = lastOpenedAt
+        self.isFavorite = isFavorite
+        self.totalReadingSeconds = totalReadingSeconds
+        self.lastReadAt = lastReadAt
+        self.averagePagesPerHour = averagePagesPerHour
+        self.averageWordsPerMinute = averageWordsPerMinute
+        self.fileState = fileState
+        self.blobPath = blobPath
+    }
+
+    // MARK: - File-state helpers (feature #47 WI-5)
+
+    /// True when the row's bytes are local and the reader can open
+    /// directly. Drives the Share menu visibility, the row tap target,
+    /// and the reader-open gate.
+    var isReadable: Bool { fileState == .local }
+
+    /// True when tapping the row should kick off a lazy download.
+    /// `.remoteOnly` and `.failed` qualify; `.downloading` does not
+    /// (already in flight); `.missingRemote` does not (server lost
+    /// the blob — needs re-upload, not re-download).
+    var needsDownload: Bool { fileState.canDownload }
+
+    /// True when the Share menu should be visible. Omitted for any
+    /// non-`.local` row — sharing a remote-only book has no bytes to
+    /// share, and sharing a downloading row would block on the
+    /// transfer with no useful UX.
+    var canShare: Bool { isReadable }
 
     // MARK: - Computed Display Properties
 

--- a/vreader/Services/PersistenceActor+Library.swift
+++ b/vreader/Services/PersistenceActor+Library.swift
@@ -42,7 +42,9 @@ extension PersistenceActor: LibraryPersisting {
                 totalReadingSeconds: stats?.totalReadingSeconds ?? 0,
                 lastReadAt: stats?.lastReadAt,
                 averagePagesPerHour: stats?.averagePagesPerHour,
-                averageWordsPerMinute: stats?.averageWordsPerMinute
+                averageWordsPerMinute: stats?.averageWordsPerMinute,
+                fileState: BookFileState(rawValue: book.fileState) ?? .local,
+                blobPath: book.blobPath
             )
         }
     }

--- a/vreaderTests/Models/LibraryBookItemFileStateTests.swift
+++ b/vreaderTests/Models/LibraryBookItemFileStateTests.swift
@@ -1,0 +1,148 @@
+// Purpose: Tests for the file-state helpers added to LibraryBookItem
+// in feature #47 WI-5: `isReadable`, `needsDownload`, `canShare`. These
+// drive row UI decisions (cloud icon vs spinner vs retry CTA), the
+// Share-menu visibility, and the reader-open gate.
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("LibraryBookItem.fileState helpers — feature #47 WI-5")
+struct LibraryBookItemFileStateTests {
+
+    private func makeItem(fileState: BookFileState, blobPath: String? = nil) -> LibraryBookItem {
+        LibraryBookItem(
+            fingerprintKey: "epub:abc:1024",
+            title: "T",
+            author: "A",
+            coverImagePath: nil,
+            format: "epub",
+            fileByteCount: 1024,
+            addedAt: Date(),
+            lastOpenedAt: nil,
+            isFavorite: false,
+            totalReadingSeconds: 0,
+            lastReadAt: nil,
+            averagePagesPerHour: nil,
+            averageWordsPerMinute: nil,
+            fileState: fileState,
+            blobPath: blobPath
+        )
+    }
+
+    // MARK: - isReadable
+
+    @Test func isReadable_trueOnlyForLocal() {
+        #expect(makeItem(fileState: .local).isReadable)
+        #expect(makeItem(fileState: .remoteOnly).isReadable == false)
+        #expect(makeItem(fileState: .downloading).isReadable == false)
+        #expect(makeItem(fileState: .failed).isReadable == false)
+        #expect(makeItem(fileState: .missingRemote).isReadable == false)
+    }
+
+    // MARK: - needsDownload
+
+    @Test func needsDownload_trueForRemoteOnlyAndFailed() {
+        #expect(makeItem(fileState: .remoteOnly).needsDownload)
+        #expect(makeItem(fileState: .failed).needsDownload)
+    }
+
+    @Test func needsDownload_falseForLocalDownloadingAndMissingRemote() {
+        #expect(makeItem(fileState: .local).needsDownload == false)
+        #expect(makeItem(fileState: .downloading).needsDownload == false)
+        #expect(makeItem(fileState: .missingRemote).needsDownload == false)
+    }
+
+    // MARK: - canShare
+
+    @Test func canShare_mirrorsIsReadable() {
+        // Sharing requires bytes — only `.local` rows can be shared.
+        // Pinned as a separate property because the Share menu code
+        // reads `canShare` semantically; if a future state allows
+        // streaming-share we'd diverge from `isReadable`.
+        for state in BookFileState.allCases {
+            let item = makeItem(fileState: state)
+            #expect(item.canShare == item.isReadable)
+        }
+    }
+
+    // MARK: - Default init still produces .local
+
+    @Test func defaultInit_assumesLocalNoBlobPath() {
+        // Backward-compat for call sites that pre-date #47.
+        let item = LibraryBookItem(
+            fingerprintKey: "k",
+            title: "T",
+            author: nil,
+            coverImagePath: nil,
+            format: "epub",
+            fileByteCount: 1,
+            addedAt: Date(),
+            lastOpenedAt: nil,
+            isFavorite: false,
+            totalReadingSeconds: 0,
+            averagePagesPerHour: nil,
+            averageWordsPerMinute: nil
+        )
+        #expect(item.fileState == .local)
+        #expect(item.blobPath == nil)
+        #expect(item.isReadable)
+    }
+
+    // MARK: - blobPath round-trips
+
+    @Test func blobPath_storedAndExposed() {
+        let item = makeItem(fileState: .remoteOnly, blobPath: "VReader/books/epub/foo_1024.epub")
+        #expect(item.blobPath == "VReader/books/epub/foo_1024.epub")
+    }
+}
+
+@Suite("PersistenceActor+Library — fileState projection (#47 WI-5)")
+struct PersistenceActorLibraryFileStateTests {
+
+    @Test func fetchAllLibraryBooks_carriesFileStateAndBlobPath() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+
+        let local = makeRecord(sha: String(repeating: "a", count: 64), fileState: .local, blobPath: nil)
+        let remote = makeRecord(sha: String(repeating: "b", count: 64), fileState: .remoteOnly, blobPath: "p1")
+        let failed = makeRecord(sha: String(repeating: "c", count: 64), fileState: .failed, blobPath: "p2")
+        _ = try await persistence.insertBook(local)
+        _ = try await persistence.insertBook(remote)
+        _ = try await persistence.insertBook(failed)
+
+        let items = try await persistence.fetchAllLibraryBooks()
+        let byKey = Dictionary(uniqueKeysWithValues: items.map { ($0.fingerprintKey, $0) })
+
+        #expect(byKey[local.fingerprintKey]?.fileState == .local)
+        #expect(byKey[local.fingerprintKey]?.blobPath == nil)
+        #expect(byKey[remote.fingerprintKey]?.fileState == .remoteOnly)
+        #expect(byKey[remote.fingerprintKey]?.blobPath == "p1")
+        #expect(byKey[failed.fingerprintKey]?.fileState == .failed)
+        #expect(byKey[failed.fingerprintKey]?.blobPath == "p2")
+    }
+
+    private func makeRecord(sha: String, fileState: BookFileState, blobPath: String?) -> BookRecord {
+        let fp = DocumentFingerprint(
+            contentSHA256: sha,
+            fileByteCount: 1024,
+            format: .epub
+        )
+        return BookRecord(
+            fingerprintKey: fp.canonicalKey,
+            title: "T",
+            author: nil,
+            coverImagePath: nil,
+            fingerprint: fp,
+            provenance: ImportProvenance(
+                source: .filesApp,
+                importedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                originalURLBookmarkData: nil
+            ),
+            detectedEncoding: nil,
+            addedAt: Date(),
+            originalExtension: "epub",
+            fileState: fileState,
+            blobPath: blobPath
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `fileState` + `blobPath` to `LibraryBookItem` plus 3 derived helpers (`isReadable`, `needsDownload`, `canShare`) that the row UI and reader open-flow gate will branch on in part 2.
- `PersistenceActor+Library.fetchAllLibraryBooks` projection updated.
- 7 tests + full build green.

Refs #47

## What Changed

- `LibraryBookItem.swift` — new fields + explicit init + helpers
- `PersistenceActor+Library.swift` — projection populates new fields
- `BookFileState.swift` — explicit `Hashable` conformance
- New `LibraryBookItemFileStateTests.swift` (7 tests)
- Version 3.11.25 → 3.11.26 (build 58)

## Audit

Codex MCP unavailable. Manual mini-audit per `.claude/rules/47-feature-workflow.md` fallback in commit message.

## Validation

- [x] 7/7 tests pass
- [x] `xcodebuild build` green (no regressions in other call sites)
- [ ] BookRowView + ReaderContainerView visual integration (part 2)

## Type of Change

- [x] Feature (#47 WI-5 part 1)