### PR TITLE
feat(#47): WI-5 part 2 — BookRowView state badge + LibraryView gates

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 58
-        MARKETING_VERSION: 3.11.26
+        CURRENT_PROJECT_VERSION: 59
+        MARKETING_VERSION: 3.11.27
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3938,13 +3938,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 58;
+				CURRENT_PROJECT_VERSION = 59;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.26;
+				MARKETING_VERSION = 3.11.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4088,13 +4088,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 58;
+				CURRENT_PROJECT_VERSION = 59;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.26;
+				MARKETING_VERSION = 3.11.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Backup/LazyDownloadCoordinator.swift
+++ b/vreader/Services/Backup/LazyDownloadCoordinator.swift
@@ -27,6 +27,15 @@ extension Notification.Name {
     /// `BookFileState.rawValue`). Library rows observe this to refresh
     /// without a full fetch.
     static let bookFileStateDidChange = Notification.Name("vreader.backup.bookFileStateDidChange")
+
+    /// Posted when the user taps a library row whose `fileState` isn't
+    /// `.local`. The picker / download-sheet UI (#47 WI-6) observes this
+    /// to surface the right CTA (kick off lazy download for `.remoteOnly`
+    /// or `.failed`, show "downloading" status for `.downloading`,
+    /// explain "blob lost" for `.missingRemote`). Until WI-6 ships
+    /// the sheet, the LibraryView no-ops silently after posting.
+    /// `userInfo`: `["fingerprintKey": String, "fileState": String]`.
+    static let libraryRowTappedWhileNotLocal = Notification.Name("vreader.backup.libraryRowTappedWhileNotLocal")
 }
 
 private let log = Logger(subsystem: "com.vreader.app", category: "LazyDownloadCoordinator")

--- a/vreader/Views/BookRowView.swift
+++ b/vreader/Views/BookRowView.swift
@@ -58,10 +58,11 @@ struct BookRowView: View {
 
             // Reading metadata
             VStack(alignment: .trailing, spacing: 2) {
-                // Format badge
-                Text(book.formatBadge)
-                    .font(.caption2)
-                    .fontWeight(.semibold)
+                // Format badge OR file-state indicator (feature #47).
+                // Non-`.local` rows replace the format badge with a
+                // status icon so the user immediately sees the row is
+                // remote / downloading / failed.
+                fileStateBadge
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
                     .background(formatColor.opacity(0.15))
@@ -87,6 +88,45 @@ struct BookRowView: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint("Double tap to open")
+    }
+
+    // MARK: - File-state badge (feature #47 WI-5)
+
+    /// Replaces the format badge for non-`.local` rows so the user
+    /// sees the row's transfer state at a glance. Display logic:
+    ///   - `.local` → format badge ("EPUB", "PDF", …)
+    ///   - `.remoteOnly` → cloud + "Remote"
+    ///   - `.downloading` → arrow.down.circle + "Downloading"
+    ///   - `.failed` → exclamationmark.icloud + "Retry"
+    ///   - `.missingRemote` → xmark.icloud + "Missing"
+    @ViewBuilder
+    private var fileStateBadge: some View {
+        switch book.fileState {
+        case .local:
+            Text(book.formatBadge)
+                .font(.caption2)
+                .fontWeight(.semibold)
+        case .remoteOnly:
+            Label("Remote", systemImage: "cloud")
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .labelStyle(.titleAndIcon)
+        case .downloading:
+            Label("Downloading", systemImage: "arrow.down.circle")
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .labelStyle(.titleAndIcon)
+        case .failed:
+            Label("Retry", systemImage: "exclamationmark.icloud")
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .labelStyle(.titleAndIcon)
+        case .missingRemote:
+            Label("Missing", systemImage: "xmark.icloud")
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .labelStyle(.titleAndIcon)
+        }
     }
 
     // MARK: - Private

--- a/vreader/Views/LibraryView.swift
+++ b/vreader/Views/LibraryView.swift
@@ -476,10 +476,17 @@ struct LibraryView: View {
             Label("Info", systemImage: "info.circle")
         }
 
-        Button {
-            bookToShare = book
-        } label: {
-            Label("Share", systemImage: "square.and.arrow.up")
+        // Share gated by feature #47 WI-5: only `.local` rows have
+        // bytes to share. Remote-only / downloading / failed / missing
+        // rows omit the menu item rather than showing it disabled —
+        // less noise in the menu, fewer "why is this greyed out?"
+        // questions.
+        if book.canShare {
+            Button {
+                bookToShare = book
+            } label: {
+                Label("Share", systemImage: "square.and.arrow.up")
+            }
         }
 
         Divider()
@@ -580,7 +587,23 @@ struct LibraryView: View {
 
     /// Hides the library toolbar before pushing to the reader,
     /// eliminating the toolbar flash during the push animation.
+    /// Feature #47 WI-5 gate: only `.local` rows open the reader.
+    /// Tapping a non-`.local` row posts a notification that the
+    /// download sheet (WI-6) listens for; until that ships, taps on
+    /// remote rows are silent so the user doesn't see a broken
+    /// reader-open path.
     private func openBook(_ book: LibraryBookItem) {
+        guard book.isReadable else {
+            NotificationCenter.default.post(
+                name: .libraryRowTappedWhileNotLocal,
+                object: nil,
+                userInfo: [
+                    "fingerprintKey": book.fingerprintKey,
+                    "fileState": book.fileState.rawValue
+                ]
+            )
+            return
+        }
         isPushingReader = true
         navigationPath.append(book)
     }


### PR DESCRIPTION
## Summary

UI integration of the file-state helpers:
- BookRowView: state badge for non-`.local` rows
- LibraryView: Share menu gated, reader-open gated (posts notification for WI-6 download sheet)
- New `libraryRowTappedWhileNotLocal` notification name

Refs #47

## Validation
- [x] `xcodebuild build` green
- [x] WI-5 part 1 unit tests cover helpers; UI is conditional rendering on top
- [ ] Visual verify lands in WI-7 acceptance pass

## Type
- [x] Feature (#47 WI-5 part 2)