### PR TITLE
feat(#47): WI-6 part 1 — WebDAVProvider.loadManifest + restoreSelectively

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 60
-        MARKETING_VERSION: 3.11.28
+        CURRENT_PROJECT_VERSION: 61
+        MARKETING_VERSION: 3.11.29
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		357C70E2DA8091ED4022D40E /* RuleEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647BF55A1C20635AD7062973 /* RuleEngine.swift */; };
 		369D003DCE5F36A64E5C1C06 /* AIChatGeneralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90F4EB83CC68406DA14DD94 /* AIChatGeneralTests.swift */; };
 		36B37715BB3494F635566157 /* ImportJobQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117731FF4D8AE414141C5ECF /* ImportJobQueue.swift */; };
+		371BDEC687E965D30E539A94 /* WebDAVProviderSelectiveRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777477DCF173A1397609EC1F /* WebDAVProviderSelectiveRestoreTests.swift */; };
 		378FF0B45CF9F05579644D1B /* ReaderAnnotationsPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4846E32490F4D5FFC0A366EF /* ReaderAnnotationsPanelTests.swift */; };
 		381D47129E7564BFBE0B26EB /* ThemeBackgroundTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21055A4DC487F0F56BA7C475 /* ThemeBackgroundTests.swift */; };
 		3821F3BE76B9BE588B9FA995 /* SearchHitToLocatorResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9102277C4126793229AEEB9 /* SearchHitToLocatorResolverTests.swift */; };
@@ -1094,6 +1095,7 @@
 		770B26672B9E379E795E28E7 /* LibraryBookItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryBookItemTests.swift; sourceTree = "<group>"; };
 		77119C3681DB428BD5F1207C /* TXTAttributedStringBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTAttributedStringBuilderTests.swift; sourceTree = "<group>"; };
 		775CED0704F1D6D39F873FF9 /* PDFProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFProgressTests.swift; sourceTree = "<group>"; };
+		777477DCF173A1397609EC1F /* WebDAVProviderSelectiveRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProviderSelectiveRestoreTests.swift; sourceTree = "<group>"; };
 		77811B16F2CF741310C23CF5 /* EncodingDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingDetectorTests.swift; sourceTree = "<group>"; };
 		78BD4CC018110BC0C96E2788 /* DebugReaderRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReaderRegistryTests.swift; sourceTree = "<group>"; };
 		79F003D569BCC0F29113468A /* EPUBMetadataExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBMetadataExtractorTests.swift; sourceTree = "<group>"; };
@@ -2603,6 +2605,7 @@
 				C74A4D9FF0F23D7D38DC185F /* WebDAVBlobStoreTests.swift */,
 				BE8121B86DA337766FD55AEF /* WebDAVClientTests.swift */,
 				B2B73649BCBDBE8A99B210A9 /* WebDAVNetworkPolicyTests.swift */,
+				777477DCF173A1397609EC1F /* WebDAVProviderSelectiveRestoreTests.swift */,
 				B294CBB624E1CE03FEFA40E6 /* WebDAVProviderTests.swift */,
 			);
 			path = Backup;
@@ -3438,6 +3441,7 @@
 				7F17555C4DA7C6845661BBB5 /* WebDAVBlobStoreTests.swift in Sources */,
 				6B19F49F1DECB5EF45BACC88 /* WebDAVClientTests.swift in Sources */,
 				1C44F27B696718DDCDCD8942 /* WebDAVNetworkPolicyTests.swift in Sources */,
+				371BDEC687E965D30E539A94 /* WebDAVProviderSelectiveRestoreTests.swift in Sources */,
 				77D706EE2E466C650B00C381 /* WebDAVProviderTests.swift in Sources */,
 				88B73AB500D0DFD555AC9363 /* WebPageEncodingDetectorTests.swift in Sources */,
 				E153024C836519993C468665 /* ZIPReaderTests.swift in Sources */,
@@ -3946,13 +3950,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 60;
+				CURRENT_PROJECT_VERSION = 61;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.28;
+				MARKETING_VERSION = 3.11.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4096,13 +4100,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 60;
+				CURRENT_PROJECT_VERSION = 61;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.28;
+				MARKETING_VERSION = 3.11.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Backup/WebDAVProvider.swift
+++ b/vreader/Services/Backup/WebDAVProvider.swift
@@ -385,6 +385,142 @@ final class WebDAVProvider: BackupProvider, @unchecked Sendable {
         return try? decoder.decode(BackupLibraryManifestEnvelope.self, from: data)
     }
 
+    // MARK: - Selective restore (feature #47 WI-6)
+
+    /// Fetches the backup ZIP for `backupId` and decodes its
+    /// `library-manifest.json` into the entries the picker UI shows.
+    /// - Returns nil for older backups (pre-#46) that don't carry a
+    ///   manifest — the UI displays "this backup has no recoverable
+    ///   book files; only metadata will restore".
+    /// - Throws `BackupError.backupNotFound` / `.storageUnavailable` /
+    ///   `.archiveCorrupted` for transport + ZIP errors.
+    func loadManifest(backupId: UUID) async throws -> [BackupLibraryEntry]? {
+        let zipData = try await fetchBackupZIP(backupId: backupId)
+        do {
+            return try RemoteBookCatalog.loadEntries(fromBackupZIP: zipData)
+        } catch RemoteBookCatalogError.manifestMissing {
+            return nil
+        } catch let error as RemoteBookCatalogError {
+            throw BackupError.archiveCorrupted("manifest decode failed: \(error)")
+        }
+    }
+
+    /// Picker-driven restore: preplant unselected manifest entries as
+    /// `.remoteOnly` rows, materialize the selected subset via the
+    /// existing `BookFileMaterializer`, then apply the metadata
+    /// sections present in the ZIP. Reading positions reattach to BOTH
+    /// `.local` and `.remoteOnly` rows by fingerprintKey.
+    /// - Throws `BackupError.backupNotFound` if the backup ID isn't
+    ///   known, `.archiveCorrupted` if the ZIP doesn't carry a
+    ///   manifest (caller should have checked via `loadManifest` first),
+    ///   `.restorePartiallyFailed` if some materializations failed.
+    /// - `persistence` is passed explicitly because `BookImporter`'s
+    ///   reference to it is private; the caller (BackupViewModel)
+    ///   already holds the live `PersistenceActor`.
+    func restoreSelectively(
+        backupId: UUID,
+        selectedKeys: Set<String>,
+        persistence: PersistenceActor,
+        progress: @Sendable (Double) -> Void
+    ) async throws -> SelectiveRestoreSummary {
+        guard let importer = bookImporter else {
+            throw BackupError.storageUnavailable("BookImporter not configured")
+        }
+        progress(0.0)
+        let zipData = try await fetchBackupZIP(backupId: backupId)
+        progress(0.10)
+
+        let manifest: [BackupLibraryEntry]
+        do {
+            manifest = try RemoteBookCatalog.loadEntries(fromBackupZIP: zipData)
+        } catch RemoteBookCatalogError.manifestMissing {
+            throw BackupError.archiveCorrupted(
+                "backup has no library-manifest.json — restore selectively requires a feature-#46+ backup"
+            )
+        } catch let error as RemoteBookCatalogError {
+            throw BackupError.archiveCorrupted("manifest decode failed: \(error)")
+        }
+        progress(0.15)
+
+        let materializer = BookFileMaterializer(
+            blobStore: blobStore,
+            importer: importer,
+            tempDirectory: materializeTempDirectory,
+            resolveSandboxURL: sandboxResolver
+        )
+
+        let coordinator = SelectiveRestoreCoordinator(
+            materializer: materializer,
+            persistence: persistence,
+            dataRestorer: dataRestorer
+        )
+
+        let sections = Self.extractMetadataSections(from: zipData)
+
+        let summary = try await coordinator.restoreSelectively(
+            manifest: manifest,
+            selectedKeys: selectedKeys,
+            metadataSections: sections,
+            progress: { fraction in
+                // 0.15..1.0 reserved for coordinator (preplant +
+                // materialize + metadata).
+                progress(0.15 + fraction * 0.85)
+            }
+        )
+
+        // Surface partial materialize failures the same way restore-all
+        // does so the BackupViewModel UX is uniform.
+        let failedTitles = summary.materialized
+            .filter { !$0.isSuccess }
+            .map { $0.entry.title ?? $0.entry.fingerprintKey }
+        if !failedTitles.isEmpty {
+            throw BackupError.restorePartiallyFailed(
+                "books not materialized: \(failedTitles.joined(separator: ", "))"
+            )
+        }
+        return summary
+    }
+
+    /// Cache-aware ZIP fetch shared by `loadManifest` and `restoreSelectively`.
+    private func fetchBackupZIP(backupId: UUID) async throws -> Data {
+        let remotePath: String
+        if let cached = metadataCache[backupId] {
+            remotePath = cached.remotePath
+        } else {
+            _ = try await listBackups()
+            guard let cached = metadataCache[backupId] else {
+                throw BackupError.backupNotFound(backupId)
+            }
+            remotePath = cached.remotePath
+        }
+        do {
+            return try await transport.download(fromPath: remotePath)
+        } catch let error as WebDAVError {
+            if case .notFound = error {
+                throw BackupError.backupNotFound(backupId)
+            }
+            throw BackupError.storageUnavailable("Download failed: \(error)")
+        }
+    }
+
+    /// Pulls each metadata section out of the ZIP into a
+    /// `SelectiveRestoreMetadataSections` value the coordinator
+    /// consumes. Missing sections are nil and skipped.
+    private static func extractMetadataSections(from zipData: Data) -> SelectiveRestoreMetadataSections {
+        func read(_ name: String) -> Data? {
+            try? ZIPWriter.extractEntry(named: name, from: zipData)
+        }
+        return SelectiveRestoreMetadataSections(
+            annotations: read("annotations.json"),
+            positions: read("positions.json"),
+            settings: read("settings.json"),
+            collections: read("collections.json"),
+            bookSources: read("book-sources.json"),
+            perBookSettings: read("per-book-settings.json"),
+            replacementRules: read("replacement-rules.json")
+        )
+    }
+
     func listBackups() async throws -> [BackupMetadata] {
         let entries: [WebDAVEntry]
         do {

--- a/vreaderTests/Services/Backup/WebDAVProviderSelectiveRestoreTests.swift
+++ b/vreaderTests/Services/Backup/WebDAVProviderSelectiveRestoreTests.swift
@@ -1,0 +1,105 @@
+// Purpose: Tests for WebDAVProvider.loadManifest + restoreSelectively
+// added in feature #47 WI-6 part 1. Reuses MockWebDAVTransport and
+// the StubCollector / NoopRestorer pattern from
+// WebDAVProviderTests.swift. Feature #47 WI-6 part 1.
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("WebDAVProvider — loadManifest + restoreSelectively (WI-6)")
+struct WebDAVProviderSelectiveRestoreTests {
+
+    private final class TestBundleAnchor {}
+
+    private static func loadLegacyZIPFixture() throws -> Data {
+        let bundle = Bundle(for: TestBundleAnchor.self)
+        let url = try #require(bundle.url(
+            forResource: "legacy-backup-no-manifest",
+            withExtension: "vreader.zip"
+        ))
+        return try Data(contentsOf: url)
+    }
+
+    /// Builds a provider whose mock transport already has the legacy
+    /// fixture pre-staged at a backup path. Returns the path so tests
+    /// can drive listBackups()-derived backupId lookups.
+    private static func makeProviderWithLegacyBackup() async throws -> (WebDAVProvider, MockWebDAVTransport) {
+        let zipData = try loadLegacyZIPFixture()
+        let path = "VReader/backups/2026-05-03T08-07-21Z_cfaff06e.vreader.zip"
+        let mock = MockWebDAVTransport()
+        mock.files[path] = zipData
+
+        let mockPersistence = MockPersistenceActor()
+        let importer = BookImporter(
+            persistence: mockPersistence,
+            sandboxBooksDirectory: FileManager.default.temporaryDirectory
+        )
+
+        let provider = WebDAVProvider(
+            transport: mock,
+            dataCollector: WebDAVProviderBackupWithManifestTests.StubCollector(manifestEntries: []),
+            dataRestorer: WebDAVProviderBackupWithManifestTests.NoopRestorer(),
+            deviceName: "TestDevice",
+            appVersion: "test",
+            bookImporter: importer
+        )
+        return (provider, mock)
+    }
+
+    // MARK: - loadManifest
+
+    @Test func loadManifest_legacyBackupWithoutManifest_returnsNil() async throws {
+        let (provider, _) = try await Self.makeProviderWithLegacyBackup()
+        let backups = try await provider.listBackups()
+        let backup = try #require(backups.first)
+        let manifest = try await provider.loadManifest(backupId: backup.id)
+        #expect(manifest == nil)
+    }
+
+    @Test func loadManifest_unknownBackupId_throwsBackupNotFound() async throws {
+        let (provider, _) = try await Self.makeProviderWithLegacyBackup()
+        do {
+            _ = try await provider.loadManifest(backupId: UUID())
+            Issue.record("expected throw")
+        } catch let error as BackupError {
+            if case .backupNotFound = error {
+                // ok
+            } else {
+                Issue.record("expected backupNotFound, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - restoreSelectively
+
+    @Test func restoreSelectively_legacyBackup_throwsArchiveCorrupted() async throws {
+        // Legacy backups don't carry library-manifest.json. The
+        // restoreSelectively API requires a #46+ backup; legacy ZIPs
+        // surface as archiveCorrupted with a clear message.
+        let (provider, _) = try await Self.makeProviderWithLegacyBackup()
+        let backups = try await provider.listBackups()
+        let backup = try #require(backups.first)
+
+        let mockPersistence = MockPersistenceActor()
+        let modelContainer = try CollectionTestHelper.makeContainer()
+        let realPersistence = PersistenceActor(modelContainer: modelContainer)
+        _ = mockPersistence  // unused — kept for symmetry
+
+        do {
+            _ = try await provider.restoreSelectively(
+                backupId: backup.id,
+                selectedKeys: [],
+                persistence: realPersistence,
+                progress: { _ in }
+            )
+            Issue.record("expected throw")
+        } catch let error as BackupError {
+            if case .archiveCorrupted(let msg) = error {
+                #expect(msg.contains("library-manifest.json"))
+            } else {
+                Issue.record("expected archiveCorrupted, got \(error)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

WebDAVProvider-side wiring of selective restore — the picker UI (part 2) consumes these.

- `loadManifest(backupId:) -> [BackupLibraryEntry]?`
- `restoreSelectively(backupId:selectedKeys:persistence:progress:) -> SelectiveRestoreSummary`

3 unit tests + reuses the legacy ZIP fixture from WI-7.

Refs #47

## Validation
- [x] 3/3 selective-restore tests pass
- [x] App build green
- [ ] Picker UI part 2 + on-device verify next

## Type
- [x] Feature (#47 WI-6 part 1)