### PR TITLE
feat(#47): WI-6 part 2 — lazy-download enqueue path

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 61
-        MARKETING_VERSION: 3.11.29
+        CURRENT_PROJECT_VERSION: 62
+        MARKETING_VERSION: 3.11.30
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -285,6 +285,7 @@
 		5FCD2C28554A736735DA6CBF /* fflate.js in Resources */ = {isa = PBXBuildFile; fileRef = A15103F3E39BB0F94806914C /* fflate.js */; };
 		5FE7F04D448C49D466F641FB /* LocatorNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C20D015AD61E29BEB57DC3 /* LocatorNormalizerTests.swift */; };
 		60044E9F6E34936F312FA826 /* TXTChapterContentLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529D0FB4C5C73B62F1C8D6D6 /* TXTChapterContentLoader.swift */; };
+		606A7D33F0DB5643859C0863 /* WebDAVDownloadRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBDB2B2562F5761C8D52153 /* WebDAVDownloadRequestBuilder.swift */; };
 		6070A8AF12AADF388F7C1383 /* V1toV2MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939BC09F1D771D2E22301ED3 /* V1toV2MigrationTests.swift */; };
 		60F28F11E8F15E0FFAF4922C /* LibraryBookItemFileStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4E5558CB75432C026267C1 /* LibraryBookItemFileStateTests.swift */; };
 		6173290A06E9E4303D363AE8 /* ReaderThemeCSSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DE298149C25261E2ECADA1 /* ReaderThemeCSSTests.swift */; };
@@ -326,6 +327,7 @@
 		6CC40A6DE2F14BB94A53006B /* FoliateMessageParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB35F648E8E697C82E4C41DE /* FoliateMessageParserTests.swift */; };
 		6CFD5F91EEF10C009963AEB0 /* TextReaderUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E25002586402AAE67B29CE6 /* TextReaderUIState.swift */; };
 		6D073A0311A72B82FEF65852 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC105D38A4A85CBCB79A772 /* KeychainService.swift */; };
+		6D6ADF2C31C5386957B6EF65 /* LazyDownloadEnqueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DF85A7A806124F57A8FB6E /* LazyDownloadEnqueueTests.swift */; };
 		6DC960D68C180A1078911388 /* EPUBWebViewBridgeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1920480AF349823757484C2D /* EPUBWebViewBridgeCoordinator.swift */; };
 		6E224708E01276C14273E2E6 /* BookOpenPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80D6D1B18008B168D01FFF2 /* BookOpenPerformanceTests.swift */; };
 		6E5022EE67C6ACC27F614E77 /* Locator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C567EE93DC61BBB63CEAC20 /* Locator.swift */; };
@@ -914,6 +916,7 @@
 		3C567EE93DC61BBB63CEAC20 /* Locator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locator.swift; sourceTree = "<group>"; };
 		3D70FBE6B4F5F9DDBA035D25 /* SPIKE_RESULTS.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = SPIKE_RESULTS.md; sourceTree = "<group>"; };
 		3DF47D926F78F13327F6770C /* OPDSParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSParser.swift; sourceTree = "<group>"; };
+		3EBDB2B2562F5761C8D52153 /* WebDAVDownloadRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVDownloadRequestBuilder.swift; sourceTree = "<group>"; };
 		3EC2FBB83EE7D774B3B5D5D3 /* epub.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = epub.js; sourceTree = "<group>"; };
 		3F47559B14E9DEE63DE613ED /* NativeTextPagedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTextPagedView.swift; sourceTree = "<group>"; };
 		400D03ADE39639337E9993C5 /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
@@ -1223,6 +1226,7 @@
 		A17676C4AE9DD328C39176D8 /* BackupDataCollectorRestorerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupDataCollectorRestorerTests.swift; sourceTree = "<group>"; };
 		A1A046B497B731C451670CED /* BookmarkPersisting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkPersisting.swift; sourceTree = "<group>"; };
 		A1E577DAF65D34544D713137 /* TombstoneStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TombstoneStoreTests.swift; sourceTree = "<group>"; };
+		A3DF85A7A806124F57A8FB6E /* LazyDownloadEnqueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyDownloadEnqueueTests.swift; sourceTree = "<group>"; };
 		A43A801A0876E2437CE63808 /* EncodingDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingDetector.swift; sourceTree = "<group>"; };
 		A43C03327815457BD7B01409 /* TXTBridgeShared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTBridgeShared.swift; sourceTree = "<group>"; };
 		A457F48D22CD5B4952817701 /* EPUBTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBTypes.swift; sourceTree = "<group>"; };
@@ -1678,6 +1682,7 @@
 				DDD987912F59B7B7CD80B064 /* SelectiveRestoreCoordinator.swift */,
 				9DAC16C19C7D4C72EFC950C9 /* WebDAVBlobStore.swift */,
 				4946129FECC6C9BA7A7F16A1 /* WebDAVClient.swift */,
+				3EBDB2B2562F5761C8D52153 /* WebDAVDownloadRequestBuilder.swift */,
 				D408C9CE57D4C437A72C0D18 /* WebDAVNetworkPolicy.swift */,
 				C3EF8CE8D52815CF5156953C /* WebDAVProvider.swift */,
 				CEBBF9A79AEFC8CDEE7B3302 /* WebDAVProviderFactory.swift */,
@@ -2594,6 +2599,7 @@
 				2F891C451718B4BC9AC7BCEC /* LazyDownloadBackgroundEventsTests.swift */,
 				67368B0914CFE12052417225 /* LazyDownloadCoordinatorTests.swift */,
 				E5D4DDB55DA30E015172A16D /* LazyDownloadDelegateStagingTests.swift */,
+				A3DF85A7A806124F57A8FB6E /* LazyDownloadEnqueueTests.swift */,
 				E124CB39746DB0B59D0390C3 /* LazyDownloadReattachTests.swift */,
 				5753714B6AF8A111E400D35A /* LazyDownloadTaskMetaTests.swift */,
 				4D9501ED4FB49C6035FDF5BB /* MockBackupProvider.swift */,
@@ -3282,6 +3288,7 @@
 				D0373F025DFBBEF9FAD19788 /* LazyDownloadBackgroundEventsTests.swift in Sources */,
 				63034CF313C6829AEA1C5278 /* LazyDownloadCoordinatorTests.swift in Sources */,
 				91B3A04F3B23BE09FCA9967C /* LazyDownloadDelegateStagingTests.swift in Sources */,
+				6D6ADF2C31C5386957B6EF65 /* LazyDownloadEnqueueTests.swift in Sources */,
 				2464151C976B35F68DD2169A /* LazyDownloadReattachTests.swift in Sources */,
 				7B1619D0A3AF6B77D0D4C7B0 /* LazyDownloadTaskMetaTests.swift in Sources */,
 				A8A3BDDF157E89577638C20F /* LegadoImporterTests.swift in Sources */,
@@ -3820,6 +3827,7 @@
 				4914FBDCD76FD1D972914081 /* VReaderAppDelegate.swift in Sources */,
 				539E581AA8A8427E199AC0A7 /* WebDAVBlobStore.swift in Sources */,
 				C5EEEAABF1F852CDABDA43F1 /* WebDAVClient.swift in Sources */,
+				606A7D33F0DB5643859C0863 /* WebDAVDownloadRequestBuilder.swift in Sources */,
 				069B04BFCB5D0D4FA8EA5972 /* WebDAVNetworkPolicy.swift in Sources */,
 				C64AA5071C05D395445A735D /* WebDAVProvider.swift in Sources */,
 				F2C53E71EFF6601811CE4003 /* WebDAVProviderFactory.swift in Sources */,
@@ -3950,13 +3958,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 62;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.29;
+				MARKETING_VERSION = 3.11.30;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4100,13 +4108,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 61;
+				CURRENT_PROJECT_VERSION = 62;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.11.29;
+				MARKETING_VERSION = 3.11.30;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Backup/BackgroundDownloadSession.swift
+++ b/vreader/Services/Backup/BackgroundDownloadSession.swift
@@ -32,9 +32,15 @@ struct LazyDownloadTaskDescriptor: Sendable, Equatable {
 protocol BackgroundDownloadSessioning: Sendable {
     /// All download tasks currently tracked by the underlying session.
     /// Called once at coordinator init to recover state from a session
-    /// that survived app termination. Future WIs (cancel, enqueue) will
-    /// add more methods.
+    /// that survived app termination.
     func allInFlightDownloads() async -> [LazyDownloadTaskDescriptor]
+
+    /// Starts a download task for `request` with the given persisted
+    /// `taskDescription` so the delegate can recover identity across
+    /// app termination. Returns the assigned task identifier so the
+    /// coordinator can track it. Production calls
+    /// `URLSessionDownloadTask.resume()`. Feature #47 WI-6.
+    func enqueueDownload(request: URLRequest, taskDescription: String) -> Int
 }
 
 /// Production wrapper around `URLSession.background(...)`. Owns the
@@ -72,5 +78,12 @@ final class URLSessionBackgroundSession: BackgroundDownloadSessioning, @unchecke
                 continuation.resume(returning: descriptors)
             }
         }
+    }
+
+    func enqueueDownload(request: URLRequest, taskDescription: String) -> Int {
+        let task = session.downloadTask(with: request)
+        task.taskDescription = taskDescription
+        task.resume()
+        return task.taskIdentifier
     }
 }

--- a/vreader/Services/Backup/LazyDownloadCoordinator.swift
+++ b/vreader/Services/Backup/LazyDownloadCoordinator.swift
@@ -190,6 +190,69 @@ final class LazyDownloadCoordinator {
         progressByKey.removeValue(forKey: fingerprintKey)
     }
 
+    // MARK: - Enqueue (feature #47 WI-6)
+
+    /// Outcome of an enqueue attempt. UI consumers branch on this:
+    /// `.started` → progress will follow; `.deferredWiFi` → show
+    /// "Waiting for Wi-Fi"; `.notReady` → coordinator wasn't built
+    /// with session+persistence (skeleton init).
+    enum EnqueueResult: Sendable, Equatable {
+        case started(taskIdentifier: Int)
+        case deferredWiFi
+        case notReady
+        case taskDescriptionEncodeFailed
+    }
+
+    /// Builds an authenticated request via `requestBuilder`, encodes the
+    /// fingerprint identity into `URLSessionDownloadTask.taskDescription`,
+    /// and starts the task on the underlying background URLSession.
+    /// Pre-conditions:
+    ///   - `policy.shouldStart()` must return true (caller checks the
+    ///     return value to surface "waiting for Wi-Fi" UX)
+    ///   - Coordinator must have been constructed with the
+    ///     session/persistence init (skeleton init returns `.notReady`)
+    ///
+    /// `prepareToDownload(fingerprintKey:)` is called for you so a
+    /// retry after a `.failed` outcome flips terminalKeys cleanly.
+    func enqueue(
+        fingerprintKey: String,
+        blobPath: String,
+        expectedSHA256: String,
+        expectedByteCount: Int64,
+        originalExtension: String,
+        requestBuilder: WebDAVDownloadRequestBuilder,
+        policy: WebDAVNetworkPolicy
+    ) -> EnqueueResult {
+        guard let session else { return .notReady }
+        guard policy.shouldStart() else { return .deferredWiFi }
+
+        let meta = LazyDownloadTaskMeta(
+            fingerprintKey: fingerprintKey,
+            blobPath: blobPath,
+            expectedSHA256: expectedSHA256,
+            expectedByteCount: expectedByteCount,
+            originalExtension: originalExtension
+        )
+        guard let encoded = meta.encodeAsTaskDescription() else {
+            return .taskDescriptionEncodeFailed
+        }
+
+        prepareToDownload(fingerprintKey: fingerprintKey)
+        let request = requestBuilder.authenticatedGETRequest(forBlobPath: blobPath)
+        let taskID = session.enqueueDownload(request: request, taskDescription: encoded)
+        // Seed indeterminate progress so the row shows a spinner
+        // immediately rather than after the first didWriteData callback.
+        progressByKey[fingerprintKey] = LazyDownloadProgress(
+            fingerprintKey: fingerprintKey,
+            bytesWritten: 0,
+            totalBytes: nil
+        )
+        log.info(
+            "enqueue: \(fingerprintKey, privacy: .private) → task #\(taskID, privacy: .public)"
+        )
+        return .started(taskIdentifier: taskID)
+    }
+
     // MARK: - Background-event handler invocation
 
     /// Called by `LazyDownloadDelegate.urlSessionDidFinishEvents` after

--- a/vreader/Services/Backup/WebDAVDownloadRequestBuilder.swift
+++ b/vreader/Services/Backup/WebDAVDownloadRequestBuilder.swift
@@ -1,0 +1,29 @@
+// Purpose: Builds the authenticated `URLRequest` the lazy-download
+// coordinator hands to its background URLSession. Pure utility — no
+// I/O, no actor. Reuses the credentials WebDAVClient already holds so
+// we don't fork the auth logic. Feature #47 WI-6 part 2.
+//
+// @coordinates-with: WebDAVClient.swift, LazyDownloadCoordinator.swift,
+//   BlobPath.swift, dev-docs/plans/20260503-feature-47-selective-picker-lazy-load.md
+
+import Foundation
+
+struct WebDAVDownloadRequestBuilder: Sendable {
+
+    private let client: WebDAVClient
+
+    init(client: WebDAVClient) {
+        self.client = client
+    }
+
+    /// Builds a GET URLRequest pointed at `blobPath` (relative to the
+    /// WebDAV server root) with the Authorization header pre-set. The
+    /// caller hands this to URLSession's `downloadTask(with:)` — the
+    /// background session takes the request as-is.
+    func authenticatedGETRequest(forBlobPath blobPath: String) -> URLRequest {
+        var request = URLRequest(url: client.buildURL(path: blobPath))
+        request.httpMethod = "GET"
+        request.setValue(client.authorizationHeader, forHTTPHeaderField: "Authorization")
+        return request
+    }
+}

--- a/vreaderTests/Services/Backup/LazyDownloadEnqueueTests.swift
+++ b/vreaderTests/Services/Backup/LazyDownloadEnqueueTests.swift
@@ -1,0 +1,201 @@
+// Purpose: Tests for the lazy-download enqueue path added in feature
+// #47 WI-6 part 2: WebDAVDownloadRequestBuilder builds the
+// authenticated GET request, LazyDownloadCoordinator.enqueue applies
+// the Wi-Fi-only policy gate + writes a fingerprint-bearing
+// taskDescription onto the URLSessionDownloadTask via the session
+// protocol seam.
+
+import Testing
+import Foundation
+@testable import vreader
+
+@MainActor
+@Suite("LazyDownloadCoordinator.enqueue — feature #47 WI-6")
+struct LazyDownloadEnqueueTests {
+
+    // Test seam re-using `MockBackgroundDownloadSession` from the
+    // reattach suite (defined in LazyDownloadReattachTests.swift).
+    // Add a controllable network policy seam here.
+    private final class StubMonitor: NetworkPathMonitoring, @unchecked Sendable {
+        var onPathChange: (@Sendable (WebDAVNetworkInterface) -> Void)?
+        func start() {}
+        func cancel() {}
+        func simulate(_ interface: WebDAVNetworkInterface) {
+            onPathChange?(interface)
+        }
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        let suite = "vreader.tests.\(UUID().uuidString)"
+        let d = UserDefaults(suiteName: suite)!
+        d.removePersistentDomain(forName: suite)
+        return d
+    }
+
+    private func makeRequestBuilder() -> WebDAVDownloadRequestBuilder {
+        let client = WebDAVClient(
+            serverURL: URL(string: "http://example.invalid")!,
+            username: "user",
+            password: "pass"
+        )
+        return WebDAVDownloadRequestBuilder(client: client)
+    }
+
+    private func makePolicy(
+        wifiOnly: Bool = true,
+        interface: WebDAVNetworkInterface = .wifi
+    ) async -> WebDAVNetworkPolicy {
+        let monitor = StubMonitor()
+        let defaults = makeDefaults()
+        defaults.set(wifiOnly, forKey: WebDAVNetworkPolicy.wifiOnlyKey)
+        let policy = WebDAVNetworkPolicy(defaults: defaults, monitor: monitor)
+        monitor.simulate(interface)
+        await Task.yield()
+        return policy
+    }
+
+    private func makeMeta(key: String = "epub:abc:1024") -> LazyDownloadTaskMeta {
+        LazyDownloadTaskMeta(
+            fingerprintKey: key,
+            blobPath: "VReader/books/epub/foo_1024.epub",
+            expectedSHA256: String(repeating: "a", count: 64),
+            expectedByteCount: 1024,
+            originalExtension: "epub"
+        )
+    }
+
+    // MARK: - Skeleton init returns notReady
+
+    @Test func enqueue_skeletonInit_returnsNotReady() async {
+        let coord = LazyDownloadCoordinator()
+        let policy = await makePolicy()
+        let result = coord.enqueue(
+            fingerprintKey: "k",
+            blobPath: "p",
+            expectedSHA256: String(repeating: "a", count: 64),
+            expectedByteCount: 1,
+            originalExtension: "epub",
+            requestBuilder: makeRequestBuilder(),
+            policy: policy
+        )
+        #expect(result == .notReady)
+    }
+
+    // MARK: - Wi-Fi gate
+
+    @Test func enqueue_wifiOnlyAndCellular_returnsDeferredWiFi() async throws {
+        let session = MockBackgroundDownloadSession(descriptors: [])
+        let persistence = try CollectionTestHelper.makePersistence()
+        let coord = LazyDownloadCoordinator(session: session, persistence: persistence)
+        await coord.waitForReattach()
+
+        let policy = await makePolicy(wifiOnly: true, interface: .cellular)
+
+        let result = coord.enqueue(
+            fingerprintKey: "k",
+            blobPath: "p",
+            expectedSHA256: String(repeating: "a", count: 64),
+            expectedByteCount: 1,
+            originalExtension: "epub",
+            requestBuilder: makeRequestBuilder(),
+            policy: policy
+        )
+        #expect(result == .deferredWiFi)
+        #expect(session.enqueuedRequests.isEmpty)
+        #expect(coord.progressByKey.isEmpty)
+    }
+
+    // MARK: - Happy path
+
+    @Test func enqueue_wifiAvailable_startsTaskAndSeedsProgress() async throws {
+        let session = MockBackgroundDownloadSession(descriptors: [])
+        let persistence = try CollectionTestHelper.makePersistence()
+        let coord = LazyDownloadCoordinator(session: session, persistence: persistence)
+        await coord.waitForReattach()
+
+        let policy = await makePolicy(wifiOnly: true, interface: .wifi)
+        let meta = makeMeta()
+
+        let result = coord.enqueue(
+            fingerprintKey: meta.fingerprintKey,
+            blobPath: meta.blobPath,
+            expectedSHA256: meta.expectedSHA256,
+            expectedByteCount: meta.expectedByteCount,
+            originalExtension: meta.originalExtension,
+            requestBuilder: makeRequestBuilder(),
+            policy: policy
+        )
+        if case .started(let id) = result {
+            #expect(id >= 100)
+        } else {
+            Issue.record("expected .started, got \(result)")
+        }
+        #expect(session.enqueuedRequests.count == 1)
+        let enqueued = session.enqueuedRequests[0]
+        // taskDescription round-trips into the same meta.
+        let decoded = try #require(LazyDownloadTaskMeta.decode(fromTaskDescription: enqueued.taskDescription))
+        #expect(decoded == meta)
+        // Authorization header set.
+        #expect(enqueued.request.value(forHTTPHeaderField: "Authorization")?.hasPrefix("Basic ") == true)
+        // URL points at the blob path.
+        #expect(enqueued.request.url?.absoluteString.contains("foo_1024.epub") == true)
+        // Progress seeded indeterminate so UI shows spinner instantly.
+        let p = coord.progressByKey[meta.fingerprintKey]
+        #expect(p?.bytesWritten == 0)
+        #expect(p?.totalBytes == nil)
+    }
+
+    // MARK: - Wi-Fi disabled, cellular OK
+
+    @Test func enqueue_wifiOnlyOff_andCellular_succeeds() async throws {
+        let session = MockBackgroundDownloadSession(descriptors: [])
+        let persistence = try CollectionTestHelper.makePersistence()
+        let coord = LazyDownloadCoordinator(session: session, persistence: persistence)
+        await coord.waitForReattach()
+
+        let policy = await makePolicy(wifiOnly: false, interface: .cellular)
+
+        let result = coord.enqueue(
+            fingerprintKey: "k",
+            blobPath: "p",
+            expectedSHA256: String(repeating: "a", count: 64),
+            expectedByteCount: 1,
+            originalExtension: "epub",
+            requestBuilder: makeRequestBuilder(),
+            policy: policy
+        )
+        if case .started = result {
+            // ok
+        } else {
+            Issue.record("expected .started, got \(result)")
+        }
+    }
+
+    // MARK: - Retry path: prepareToDownload clears terminal
+
+    @Test func enqueue_afterFailedOutcome_clearsTerminalAndStartsAgain() async throws {
+        let session = MockBackgroundDownloadSession(descriptors: [])
+        let persistence = try CollectionTestHelper.makePersistence()
+        let coord = LazyDownloadCoordinator(session: session, persistence: persistence)
+        await coord.waitForReattach()
+
+        // Simulate a previous failed download leaving terminal state.
+        coord.didFinishDownloadFailed(fingerprintKey: "k", reason: "network timeout")
+        #expect(coord.terminalKeys.contains("k"))
+
+        let policy = await makePolicy(wifiOnly: true, interface: .wifi)
+        _ = coord.enqueue(
+            fingerprintKey: "k",
+            blobPath: "p",
+            expectedSHA256: String(repeating: "a", count: 64),
+            expectedByteCount: 1,
+            originalExtension: "epub",
+            requestBuilder: makeRequestBuilder(),
+            policy: policy
+        )
+        // enqueue calls prepareToDownload internally — terminal cleared.
+        #expect(coord.terminalKeys.contains("k") == false)
+        #expect(coord.outcomes["k"] == nil)
+        #expect(coord.progressByKey["k"] != nil)
+    }
+}

--- a/vreaderTests/Services/Backup/LazyDownloadReattachTests.swift
+++ b/vreaderTests/Services/Backup/LazyDownloadReattachTests.swift
@@ -13,6 +13,9 @@ import SwiftData
 /// configure it before constructing the coordinator.
 final class MockBackgroundDownloadSession: BackgroundDownloadSessioning, @unchecked Sendable {
     private let descriptors: [LazyDownloadTaskDescriptor]
+    /// Records of every enqueueDownload call (request, taskDescription).
+    private(set) var enqueuedRequests: [(request: URLRequest, taskDescription: String)] = []
+    private var nextTaskID: Int = 100
 
     init(descriptors: [LazyDownloadTaskDescriptor]) {
         self.descriptors = descriptors
@@ -20,6 +23,13 @@ final class MockBackgroundDownloadSession: BackgroundDownloadSessioning, @unchec
 
     func allInFlightDownloads() async -> [LazyDownloadTaskDescriptor] {
         descriptors
+    }
+
+    func enqueueDownload(request: URLRequest, taskDescription: String) -> Int {
+        enqueuedRequests.append((request, taskDescription))
+        let id = nextTaskID
+        nextTaskID += 1
+        return id
     }
 }
 
@@ -46,6 +56,8 @@ final class GatedMockBackgroundDownloadSession: BackgroundDownloadSessioning, @u
         _ = await iter.next()
         return descriptors
     }
+
+    func enqueueDownload(request: URLRequest, taskDescription: String) -> Int { 0 }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary

Closes the back-end gap between row tap and active download.

- `WebDAVDownloadRequestBuilder` — pure utility for the auth'd GET request
- `BackgroundDownloadSessioning.enqueueDownload(...)` — production resumes the task
- `LazyDownloadCoordinator.enqueue(...)` — the entry point the row-tap observer calls; returns typed `EnqueueResult`
- 5 new tests (32 total across coordinator suites)

Refs #47

## Validation
- [x] 32/32 coordinator tests pass
- [x] App build green
- [ ] Picker UI + on-device verify is the final piece

## Type
- [x] Feature (#47 WI-6 part 2)