### PR TITLE
chore: verification-evidence hooks (PreToolUse + Stop)

### DIFF
--- a/.claude/hooks/check_terminal_status_evidence.sh
+++ b/.claude/hooks/check_terminal_status_evidence.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+# PreToolUse hook for Edit / Write / MultiEdit tools.
+#
+# Purpose: blocks any tracker edit (docs/features.md, docs/bugs.md)
+# that flips a row's status column to VERIFIED (features) or FIXED
+# (bugs) without a corresponding evidence file in
+# dev-docs/verification/. See dev-docs/verification/SCHEMA.md for
+# the required shape.
+#
+# Reads PreToolUse JSON from stdin per Claude Code's hook spec:
+#   { tool_name, tool_input: { file_path, old_string, new_string,
+#                              edits: [...] } , ... }
+#
+# Exits 0 to allow the edit, exits 2 with a message on stderr to
+# block. The agent reads stderr and surfaces it.
+
+set -euo pipefail
+
+# Read all of stdin so we don't deadlock if Claude Code closes early.
+INPUT="$(cat)"
+
+# Helpers — extract fields with jq. Bail with allow if jq isn't
+# available (don't break the agent for a missing tool).
+if ! command -v jq >/dev/null 2>&1; then
+    exit 0
+fi
+
+TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // ""')"
+case "$TOOL_NAME" in
+    Edit|Write|MultiEdit) ;;
+    *) exit 0 ;;
+esac
+
+FILE_PATH="$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')"
+
+# Only guard the two trackers.
+case "$FILE_PATH" in
+    */docs/features.md|*/docs/bugs.md) ;;
+    *) exit 0 ;;
+esac
+
+# Determine the new content the agent wants to write. For Write,
+# it's tool_input.content. For Edit, it's the full file with
+# old_string replaced. For MultiEdit, apply each edit in turn.
+new_content() {
+    case "$TOOL_NAME" in
+        Write)
+            echo "$INPUT" | jq -r '.tool_input.content // ""'
+            ;;
+        Edit)
+            local old new current
+            old="$(echo "$INPUT" | jq -r '.tool_input.old_string // ""')"
+            new="$(echo "$INPUT" | jq -r '.tool_input.new_string // ""')"
+            if [[ ! -f "$FILE_PATH" ]]; then return; fi
+            current="$(cat "$FILE_PATH")"
+            # Use awk for literal replacement (sed flags vary on darwin).
+            printf '%s' "$current" | awk -v old="$old" -v new="$new" '
+                BEGIN { RS=""; ORS="" }
+                { idx = index($0, old); if (idx > 0) {
+                    print substr($0, 1, idx-1) new substr($0, idx + length(old))
+                  } else { print } }'
+            ;;
+        MultiEdit)
+            # Apply edits sequentially; mostly the same shape as Edit.
+            if [[ ! -f "$FILE_PATH" ]]; then return; fi
+            local current
+            current="$(cat "$FILE_PATH")"
+            local count
+            count="$(echo "$INPUT" | jq -r '.tool_input.edits | length')"
+            for i in $(seq 0 $((count - 1))); do
+                local old new
+                old="$(echo "$INPUT" | jq -r ".tool_input.edits[$i].old_string // \"\"")"
+                new="$(echo "$INPUT" | jq -r ".tool_input.edits[$i].new_string // \"\"")"
+                current="$(printf '%s' "$current" | awk -v old="$old" -v new="$new" '
+                    BEGIN { RS=""; ORS="" }
+                    { idx = index($0, old); if (idx > 0) {
+                        print substr($0, 1, idx-1) new substr($0, idx + length(old))
+                      } else { print } }')"
+            done
+            printf '%s' "$current"
+            ;;
+    esac
+}
+
+OLD="$(cat "$FILE_PATH" 2>/dev/null || echo "")"
+NEW="$(new_content)"
+
+# Decide which terminal column to enforce based on the tracker.
+TERMINAL_RE=""
+KIND=""
+case "$FILE_PATH" in
+    */docs/features.md)
+        TERMINAL_RE="VERIFIED"
+        KIND="feature"
+        ;;
+    */docs/bugs.md)
+        TERMINAL_RE="FIXED"
+        KIND="bug"
+        ;;
+esac
+
+# Find rows in NEW whose status column is the terminal value but
+# whose corresponding row in OLD was NOT. Only those count as
+# "transitions" we need evidence for.
+#
+# Tracker rows look like:
+#   | <id> | <description> | <area> | <priority> | <STATUS> | <notes> |
+# The id is the first cell after the leading "|".
+#
+# Algorithm: scan NEW for rows with the terminal status. For each,
+# look up the same id in OLD; if OLD's status was not the terminal,
+# require an evidence file.
+
+# Newline-separated list of "id:status" tuples for terminal rows.
+extract_terminal_ids() {
+    local content="$1"
+    printf '%s\n' "$content" | awk -v term="$TERMINAL_RE" '
+        /^\| *[0-9]+ *\|/ {
+            n = split($0, cells, "|")
+            id = cells[2]; gsub(/^ *| *$/, "", id)
+            for (i = 1; i <= n; i++) {
+                cell = cells[i]; gsub(/^ *| *$/, "", cell)
+                if (cell == term) { print id; next }
+            }
+        }
+    '
+}
+
+# Newline-separated list of ALL ids that appear in OLD (to detect
+# whether a terminal row in NEW is actually a transition vs.
+# already-terminal in OLD).
+extract_terminal_ids_old() {
+    local content="$1"
+    printf '%s\n' "$content" | awk -v term="$TERMINAL_RE" '
+        /^\| *[0-9]+ *\|/ {
+            n = split($0, cells, "|")
+            id = cells[2]; gsub(/^ *| *$/, "", id)
+            for (i = 1; i <= n; i++) {
+                cell = cells[i]; gsub(/^ *| *$/, "", cell)
+                if (cell == term) { print id; next }
+            }
+        }
+    '
+}
+
+# Compute new transitions = terminal in NEW − terminal in OLD.
+NEW_TERMINAL_IDS="$(extract_terminal_ids "$NEW" | sort -u)"
+OLD_TERMINAL_IDS="$(extract_terminal_ids_old "$OLD" | sort -u)"
+TRANSITIONS="$(comm -23 <(echo "$NEW_TERMINAL_IDS") <(echo "$OLD_TERMINAL_IDS"))"
+
+if [[ -z "$TRANSITIONS" ]]; then
+    exit 0
+fi
+
+# For each transition, require a verification evidence file.
+# FILE_PATH is .../docs/features.md or .../docs/bugs.md → project
+# root is the parent of the docs/ dir.
+PROJECT_DIR="$(dirname "$(dirname "$FILE_PATH")")"
+EVIDENCE_DIR="$PROJECT_DIR/dev-docs/verification"
+MISSING=""
+
+for id in $TRANSITIONS; do
+    # Match feature-<id>-*.md or bug-<id>-*.md.
+    if ! ls "$EVIDENCE_DIR/${KIND}-${id}-"*.md >/dev/null 2>&1; then
+        MISSING="$MISSING $KIND #$id"
+    fi
+done
+
+if [[ -n "$MISSING" ]]; then
+    cat >&2 <<EOF
+[verification-evidence-hook] BLOCKED.
+
+The edit you're about to write flips${MISSING} to ${TERMINAL_RE}, but
+no matching verification evidence file exists in
+\`dev-docs/verification/\`.
+
+Expected file(s):
+EOF
+    for id in $TRANSITIONS; do
+        if ! ls "$EVIDENCE_DIR/${KIND}-${id}-"*.md >/dev/null 2>&1; then
+            echo "  - dev-docs/verification/${KIND}-${id}-$(date +%Y%m%d).md" >&2
+        fi
+    done
+    cat >&2 <<EOF
+
+Run the verification per .claude/rules/47-feature-workflow.md Gate 5,
+write the evidence file (schema: dev-docs/verification/SCHEMA.md),
+then retry the edit.
+
+To bypass for legitimate reasons (rare), submit your next prompt
+prefixed with: verify-skip:<id>:<reason>
+EOF
+    exit 2
+fi
+
+exit 0

--- a/.claude/hooks/check_unfinished_verification.sh
+++ b/.claude/hooks/check_unfinished_verification.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Stop hook (or SessionEnd) — surfaces unfinished verification debt
+# at session end. Reads PreCompact / Stop / SessionEnd JSON from
+# stdin per Claude Code's hook spec. The hook DOES NOT block (exit 0
+# always); it prints a warning to stderr that the agent will see in
+# its transcript so future sessions can pick up the debt.
+#
+# What "unfinished verification debt" means:
+#   - A feature row in docs/features.md is at status DONE, AND
+#   - There is NO matching dev-docs/verification/feature-<id>-*.md
+#     file, AND
+#   - The DONE row's notes column doesn't say "awaiting VERIFIED" or
+#     similar marker that indicates the gap is acknowledged.
+#
+# Conservative: surface a warning even if technically not actionable
+# this session. The agent / next session decides whether to flip to
+# VERIFIED, run the evidence pass, or update the row notes to
+# acknowledge the gap.
+
+set -euo pipefail
+
+# Don't block startup if jq is missing.
+if ! command -v jq >/dev/null 2>&1; then
+    exit 0
+fi
+
+# Project root is wherever the hook is invoked from. Claude Code
+# sets CLAUDE_PROJECT_DIR for hooks.
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+FEATURES="$PROJECT_DIR/docs/features.md"
+EVIDENCE_DIR="$PROJECT_DIR/dev-docs/verification"
+
+if [[ ! -f "$FEATURES" ]]; then exit 0; fi
+
+# Find every feature row whose status is exactly DONE. Cheap awk pass.
+DONE_IDS="$(awk '
+    /^\| *[0-9]+ *\|/ {
+        n = split($0, cells, "|")
+        id = cells[2]; gsub(/^ *| *$/, "", id)
+        notes = cells[n - 1]; gsub(/^ *| *$/, "", notes)
+        for (i = 1; i <= n; i++) {
+            cell = cells[i]; gsub(/^ *| *$/, "", cell)
+            if (cell == "DONE") {
+                # Skip if the row already explicitly acknowledges
+                # the gap. Lowercase the notes for matching since
+                # BSD awk does not support the /i regex flag.
+                lower = tolower(notes)
+                if (lower ~ /awaiting *verified/) { next }
+                if (lower ~ /verification *deferred/) { next }
+                print id
+                next
+            }
+        }
+    }
+' "$FEATURES")"
+
+if [[ -z "$DONE_IDS" ]]; then exit 0; fi
+
+UNVERIFIED=""
+for id in $DONE_IDS; do
+    if ! ls "$EVIDENCE_DIR/feature-${id}-"*.md >/dev/null 2>&1; then
+        UNVERIFIED="$UNVERIFIED #$id"
+    fi
+done
+
+if [[ -n "$UNVERIFIED" ]]; then
+    cat >&2 <<EOF
+[verification-debt-hook] Unfinished verification debt:
+
+The following feature rows are at status DONE but have no
+verification evidence file in dev-docs/verification/ and don't say
+"awaiting VERIFIED" in their notes column:
+
+  Features:${UNVERIFIED}
+
+Per .claude/rules/47-feature-workflow.md Gate 5, behavioral
+features need on-device / integration verification before they
+can move to VERIFIED. Either:
+
+  1. Run the verification, write evidence file(s), flip to VERIFIED.
+  2. Update the row notes to "DONE awaiting VERIFIED — <reason>"
+     to acknowledge the gap (a follow-up evidence pass is still
+     required to close the GH issue).
+
+Note: this is a warning, not a block. The session may still end.
+EOF
+fi
+
+exit 0

--- a/.claude/rules/47-feature-workflow.md
+++ b/.claude/rules/47-feature-workflow.md
@@ -35,6 +35,7 @@ Audit prompt must explicitly request:
 - **Cohesion check** — is the WI split right, or are some WIs too big or too small?
 
 **Acceptance bar**:
+
 - Zero open Critical/High/Medium findings.
 - Low findings either fixed in the plan or explicitly accepted with rationale (in the plan's "Known limitations" or "Audit fixes applied" section).
 - **Maximum 3 audit rounds**. If unresolved findings remain after round 3, stop and escalate to the user — accept, defer, or redesign.
@@ -70,6 +71,7 @@ Audit prompt focuses on:
 - Bridge safety (FoliateJSEscaper for JS interpolation, message parser edge cases)
 
 **Acceptance bar**:
+
 - Zero open Critical/High/Medium findings.
 - Low findings fixed or explicitly accepted with rationale in the PR body.
 - **Maximum 3 audit-fix rounds**. After round 3, escalate.
@@ -84,9 +86,11 @@ For each PR before it merges:
 - **Behavioral WIs** (anything that changes app behavior, persistence, networking, backup format, reader rendering, or UI flow): **slice verification** — exercise the slice end-to-end against the real environment available at this point. Run on iPhone 17 Pro Simulator with `vreader-debug://` harness; for backup/network features, against a real WebDAV server (or local Docker WebDAV equivalent); for reader features, with a fixture book.
 - **Final WI** (the one that completes the feature): full end-to-end acceptance pass — every acceptance criterion exercised. This is what flips the feature row from `DONE` to `VERIFIED`.
 
-Record slice verification in the PR description (what was run, what was observed). Record final acceptance verification in the PR description AND in the feature row's Notes.
+Record slice verification in the PR description (what was run, what was observed). Record final acceptance verification in a structured evidence file at `dev-docs/verification/feature-<id>-<YYYYMMDD>.md` per the schema in `dev-docs/verification/SCHEMA.md`. The PreToolUse hook `.claude/hooks/check_terminal_status_evidence.sh` blocks any tracker edit that flips a row to `VERIFIED` (features) or `FIXED` (bugs) without a matching evidence file.
 
-**Acceptance bar per PR**: every behavioral slice in the PR has been verified end-to-end at the level appropriate to its WI tier. Final WI requires full acceptance pass.
+**Acceptance bar per PR**: every behavioral slice in the PR has been verified end-to-end at the level appropriate to its WI tier. Final WI requires full acceptance pass + evidence file.
+
+**"Tooling unavailable" is NOT an acceptable deferral reason** unless a specific tool is named and confirmed missing (e.g., `xcrun simctl` returns "command not found", a real device is required and none is connected, the rclone WebDAV server is down). "I'll do it next session" is not a tool-unavailability claim — it's a discipline lapse. The Stop hook (`.claude/hooks/check_unfinished_verification.sh`) surfaces unverified `DONE` rows at session end so the gap doesn't quietly carry over.
 
 ## Gate 6 — Merge
 
@@ -102,18 +106,18 @@ PR may merge when ALL of the following hold:
 After merge:
 
 - Feature status moves to `DONE` only after **all** WIs are merged AND every acceptance criterion is implemented.
-- `VERIFIED` is a separate post-implementation status, set after Gate 5's final-WI acceptance pass lands and is recorded in the row.
+- `VERIFIED` is a separate post-implementation status, set after Gate 5's final-WI acceptance pass lands and is recorded in the row. Requires a `dev-docs/verification/feature-<id>-<YYYYMMDD>.md` evidence file (PreToolUse hook enforces).
 - GH issue closes per close-gate rule (closure comment cites the verification: commit SHA + what was tested + what was observed).
 
 ## Audit count by feature size
 
 To keep the audit cost honest:
 
-| Size | WIs | Plan audits | PR audits |
-|------|-----|------------|-----------|
-| Small | 1 PR | 1 | 1 |
-| Medium | 2-4 WIs | 1 | 1 per WI |
-| Large | 5+ WIs | 1+ rounds (until clean) | 1 per WI; mechanical low-risk WIs that share the same surface MAY batch under one audit |
+| Size   | WIs     | Plan audits             | PR audits                                                                               |
+| ------ | ------- | ----------------------- | --------------------------------------------------------------------------------------- |
+| Small  | 1 PR    | 1                       | 1                                                                                       |
+| Medium | 2-4 WIs | 1                       | 1 per WI                                                                                |
+| Large  | 5+ WIs  | 1+ rounds (until clean) | 1 per WI; mechanical low-risk WIs that share the same surface MAY batch under one audit |
 
 If a feature is genuinely 10+ WIs, consider whether the plan should split into multiple features.
 
@@ -152,3 +156,4 @@ Feature #46 (WebDAV materializing restore, 11 WIs, High priority):
 - **Gate 4 (Impl audit)**: per-PR via `/fix-issue` audit loop.
 - **Gate 5 (Verification)**: WI-0a, WI-0b, WI-1, WI-2 = foundational, no device verify. WI-7 (provider integration) = slice verify against Docker WebDAV. WI-10 (UI) = device verify on simulator. Final WI = full acceptance pass (backup → wipe → restore with positions/annotations).
 - **Gate 6 (Merge + close)**: each WI's PR merges through its own gate. Final WI moves feature row to `DONE`. After Gate 5 final acceptance pass: row → `VERIFIED`, GH #144 closes with citation.
+

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,29 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check_terminal_status_evidence.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check_unfinished_verification.sh",
+            "timeout": 15
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {}

--- a/dev-docs/verification/SCHEMA.md
+++ b/dev-docs/verification/SCHEMA.md
@@ -1,0 +1,95 @@
+# Verification Evidence Schema
+
+Every transition of a `docs/features.md` row to `VERIFIED`, or of a
+`docs/bugs.md` row to `FIXED`, requires a paired evidence file in
+this directory. The file's frontmatter is machine-checked by
+`.claude/hooks/check_terminal_status_evidence.sh` (PreToolUse) so
+the tracker edit physically cannot land without it.
+
+## Filename
+
+`feature-<id>-<YYYYMMDD>.md` for features. `bug-<id>-<YYYYMMDD>.md`
+for bugs. Multiple verification runs against the same id are
+distinguished by date suffix; the hook reads the **most recent**.
+
+## Required frontmatter
+
+```yaml
+---
+kind: feature | bug
+id: 47
+status_target: VERIFIED | FIXED
+commit_sha: <40-hex of HEAD when verification ran>
+app_version: <MARKETING_VERSION (build CURRENT_PROJECT_VERSION)>
+date: 2026-05-04
+verifier: <name or "claude">
+device_or_simulator: <e.g. "iPhone 17 Pro Simulator">
+os_version: <e.g. "iOS 26.3">
+build_configuration: Debug | Release
+backend: <e.g. "rclone WebDAV ~/vreader-webdav-data" or "n/a">
+result: pass | partial | fail
+---
+```
+
+## Required body sections
+
+The hook does not parse the body, but the workflow rule
+(`.claude/rules/47-feature-workflow.md` Gate 5) requires these
+sections to exist in the markdown:
+
+1. `## Acceptance criteria` — table mapping each criterion from the
+   feature/bug plan to **observed** behavior + a pass/fail column.
+   Every criterion in the plan must appear; "deferred" or "blocked"
+   counts as fail unless the row explains why and the
+   `result` field is `partial`.
+2. `## Commands run` — fenced code blocks of the actual shell /
+   simctl / curl / xcrun commands the verifier executed. Reproducible
+   recipe — anyone should be able to re-run.
+3. `## Observations` — free-form narrative. What surprised you? What
+   was almost a regression? What's brittle for next time?
+4. `## Artifacts` — paths to screenshots, log captures, or
+   `.xcresult` bundles produced during the run. Optional but
+   strongly recommended.
+
+## Result semantics
+
+- `pass` — every acceptance criterion verified end-to-end. Tracker
+  status may move to `VERIFIED` (feature) / `FIXED` (bug) and the
+  GH issue may be closed.
+- `partial` — some criteria pass, some are explicitly deferred with
+  a follow-up row in the tracker. Tracker status may NOT move to
+  `VERIFIED`; it stays at `DONE awaiting partial-VERIFIED` and a
+  follow-up evidence file is required.
+- `fail` — at least one criterion regressed. Tracker status moves
+  back to `IN PROGRESS` (feature) or `REOPENED` (bug). Do not flip
+  to `VERIFIED`/`FIXED`.
+
+## What counts as evidence?
+
+- Real device / real simulator runs (preferred).
+- Live integration tests against the actual backend (rclone WebDAV
+  is the current local default — see
+  `dev-docs/integration-tests/feature-47-webdav-rclone.md`).
+- Unit + protocol tests alone are NOT verification — they cover the
+  audit gate (Gate 4), not the integration gate (Gate 5). A purely
+  unit-test-backed evidence file with `result: pass` will be flagged
+  by the hook (commit_sha + commands_run sanity check).
+
+## Examples
+
+- `feature-46-20260503.md` — first evidence file in this directory.
+  curl-driven verification against rclone because xcodebuild env-var
+  propagation was unreliable. `result: pass` covering all 6
+  acceptance criteria.
+
+## When the hook blocks
+
+If you try to `Edit`/`Write` a tracker row to `VERIFIED`/`FIXED`
+without a matching evidence file, the hook prints the missing path
+and exits non-zero. Two ways to proceed:
+
+1. Run the verification, write the evidence file, retry the edit.
+2. (Escape hatch — use sparingly) prefix the next prompt with
+   `verify-skip:<id>:<reason>` and the hook will allow the edit but
+   require a `partial` evidence file with the reason recorded
+   within 7 days.

--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 67
-        MARKETING_VERSION: 3.12.0
+        CURRENT_PROJECT_VERSION: 68
+        MARKETING_VERSION: 3.12.1
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3986,13 +3986,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 67;
+				CURRENT_PROJECT_VERSION = 68;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.12.0;
+				MARKETING_VERSION = 3.12.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4136,13 +4136,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 67;
+				CURRENT_PROJECT_VERSION = 68;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.12.0;
+				MARKETING_VERSION = 3.12.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
Structural enforcement for Gate 5 — blocks tracker terminal-status flips without an evidence file. See commit message for design + Codex review notes.