### PR TITLE
chore: GH-issue-mirror enforcement hooks + slash commands

### DIFF
--- a/.claude/commands/file-bug.md
+++ b/.claude/commands/file-bug.md
@@ -1,0 +1,113 @@
+---
+description: Create a GH issue for a bug row in docs/bugs.md and stamp `GH: #N` into its Notes column
+argument-hint: "<bug-id>"
+---
+
+# File Bug Issue
+
+Create a GitHub issue mirroring an existing row in `docs/bugs.md`, then update that row's Notes column with `GH: #N` so the PreToolUse mirror hook stops blocking edits to it. Single tool flow that prevents the "issue created, row not updated" failure mode.
+
+## Input
+
+```text
+$ARGUMENTS
+```
+
+## Phase 0 — Pre-flight
+
+1. **Argument check**: parse `$ARGUMENTS` as a single integer bug ID.
+   - Empty / non-numeric → print usage:
+     `/file-bug <bug-id>  e.g. /file-bug 115`
+     and STOP.
+
+2. **`gh` auth check**: run `gh auth status` (any remote). If unauthenticated → print
+   `gh CLI is not authenticated. Run \`gh auth login\` first.` and STOP.
+
+3. **Repo check**: run `gh repo view --json nameWithOwner -q .nameWithOwner` from inside the project. If it errors → print `Not inside a GitHub repo (no upstream remote). gh repo set-default may help.` and STOP.
+
+4. **Row lookup**: `grep -n "^| <id>[ |]" docs/bugs.md | head -1`. If empty → print `Bug #<id> not found in docs/bugs.md` and STOP.
+
+5. **Existing-issue check**: read the matching row's Notes column. If it already contains `GH: #N`, print `Bug #<id> already has GH: #N — nothing to do.` and STOP cleanly (idempotent).
+
+## Phase 1 — Build the issue
+
+From the row, extract:
+- `title` (cell 2)
+- `area` (cell 3)
+- `priority` (cell 4)
+- `status` (cell 5)
+- `notes` (cell 6)
+
+Compose:
+- **Issue title**: `Bug #<id>: <title>`
+- **Labels**: `bug`. If priority is `High` add `severity:high`. If `Medium`, `severity:medium`. (If `Low`, no severity label.)
+- **Body** (heredoc):
+
+```
+**Tracker row**: `docs/bugs.md` #<id>
+**Source of truth**: docs/bugs.md
+**Severity**: <priority>
+**Status**: <status>
+**Area**: <area>
+
+## Description
+
+<notes>
+
+---
+
+This issue mirrors the bug-tracker row. Material design / scope changes happen in `docs/bugs.md`; GH comments that change scope must be ported back to the tracker in the same PR.
+```
+
+## Phase 2 — Create the issue
+
+Run:
+```sh
+gh issue create --title "<title>" --label "<labels>" --body "<body>"
+```
+
+Capture the issue URL from stdout. Extract the issue number (last path segment of the URL).
+
+**Failure modes** (all exit nonzero with the issue URL if it exists):
+- Network failure → re-run once after 3s; if still failing, print URL (if any) + error and STOP.
+- Rate limit → print `gh API rate-limited. Try again later.` and STOP.
+- Label not found → re-run with just `bug` label, warn the user that severity wasn't applied.
+- Duplicate issue (gh detected) → use the existing one, fall through to Phase 3.
+
+## Phase 3 — Update the row
+
+Use the `Edit` tool to add `GH: #<issue-number>` to the row's Notes column. Two patterns to handle:
+
+a. Notes ends with content (typical): append ` GH: #<N>` (with leading space).
+b. Notes ends with `|` and trailing whitespace: insert ` GH: #<N>` before the trailing `|`.
+
+The Edit's `old_string` should be the original full row line. The `new_string` is the same line with `GH: #<N>` appended in the Notes cell.
+
+The `check_gh_issue_mirror.sh` PreToolUse hook will allow this edit because the new content carries `GH: #N`.
+
+**Failure mode — issue created but row update failed**:
+This is the dangerous case. Print:
+```
+GH issue #<N> created at <URL>, but failed to update docs/bugs.md row.
+Manually add `GH: #<N>` to the Notes column of bug #<id>:
+
+  | <id> | ... | <status> | <existing notes> GH: #<N> |
+```
+Exit nonzero so the user sees the partial success.
+
+## Phase 4 — Report
+
+Print:
+```
+Filed bug #<id> as GH issue #<N>: <URL>
+```
+
+Done. Do NOT commit — the docs/bugs.md edit is staged but uncommitted; the user folds it into whatever PR is in flight.
+
+## Examples
+
+`/file-bug 115` → reads row #115 from docs/bugs.md, opens GH issue with bug + severity:high labels, stamps GH: #N onto the row.
+
+`/file-bug` → prints usage and stops.
+
+`/file-bug 999` (nonexistent) → prints "Bug #999 not found" and stops.

--- a/.claude/commands/file-feature.md
+++ b/.claude/commands/file-feature.md
@@ -1,0 +1,88 @@
+---
+description: Create a GH issue for a feature row in docs/features.md and stamp `GH: #N` into its Notes column
+argument-hint: "<feature-id>"
+---
+
+# File Feature Issue
+
+Create a GitHub issue mirroring an existing row in `docs/features.md`, then update that row's Notes column with `GH: #N`. Mirror of `/file-bug` for the features tracker.
+
+## Input
+
+```text
+$ARGUMENTS
+```
+
+## Phase 0 — Pre-flight
+
+1. **Argument check**: parse `$ARGUMENTS` as a single integer feature ID. Empty / non-numeric → print usage `/file-feature <id>` and STOP.
+
+2. **`gh` auth check**: `gh auth status`. If unauthenticated → print and STOP.
+
+3. **Repo check**: `gh repo view --json nameWithOwner -q .nameWithOwner`. If errors → print and STOP.
+
+4. **Row lookup**: `grep -n "^| <id>[ |]" docs/features.md | head -1`. If empty → STOP.
+
+5. **Mirror-required state check**: status must be one of `PLANNED`, `IN PROGRESS`, `DONE`, `VERIFIED`. If `TODO` (not yet planned), print `Feature #<id> is at TODO — promote to PLANNED first per AGENTS.md` and STOP.
+
+6. **Mirror: no escape**: if the Notes column contains `Mirror: no`, print `Feature #<id> is marked Mirror: no — skipping per row directive.` and STOP cleanly.
+
+7. **Existing-issue check**: if Notes already has `GH: #N`, print and STOP cleanly (idempotent).
+
+## Phase 1 — Build the issue
+
+From the row, extract `title` (cell 2), `area` (cell 3), `priority` (cell 4), `status` (cell 5), `notes` (cell 6).
+
+Compose:
+- **Issue title**: `Feature #<id>: <title>`
+- **Labels**: `enhancement`. If priority is `High` add `severity:high`. `Medium` → `severity:medium`. `Low` → no severity.
+- **Body** (heredoc):
+
+```
+**Tracker row**: `docs/features.md` #<id>
+**Source of truth**: docs/features.md
+**Priority**: <priority>
+**Status**: <status>
+**Area**: <area>
+
+## Description
+
+<notes>
+
+---
+
+This issue mirrors the feature-tracker row. The row is the source of truth — material design / scope changes happen in `docs/features.md`; GH comments that change scope must be ported back to the tracker in the same PR.
+
+If a Plan exists in `dev-docs/plans/` it is referenced from the row.
+```
+
+## Phase 2 — Create the issue
+
+```sh
+gh issue create --title "<title>" --label "<labels>" --body "<body>"
+```
+
+Capture URL + extract issue number. Same failure-mode handling as `/file-bug` (network retry once, rate-limit/label-missing/duplicate handling). On any partial-success (issue created but downstream fails), exit nonzero with the URL printed so the user can finish manually.
+
+## Phase 3 — Update the row
+
+Use the `Edit` tool to add `GH: #<issue-number>` to the Notes column. The `check_gh_issue_mirror.sh` PreToolUse hook will allow this edit because the new content carries `GH: #N`.
+
+**Failure mode — issue created, row update failed**:
+Print the URL + the exact row line the user needs to write, exit nonzero.
+
+## Phase 4 — Report
+
+```
+Filed feature #<id> as GH issue #<N>: <URL>
+```
+
+Done. Do NOT commit — the user folds the row edit into whatever PR is in flight.
+
+## Examples
+
+`/file-feature 47` → reads row #47, opens GH issue with `enhancement` + severity labels, stamps `GH: #N` onto the row.
+
+`/file-feature 50` (status TODO) → "promote to PLANNED first" message and stops.
+
+`/file-feature 51 Mirror: no` → not how arguments work; the `Mirror: no` directive lives in the row's Notes column and the command auto-detects it.

--- a/.claude/hooks/check_gh_issue_mirror.sh
+++ b/.claude/hooks/check_gh_issue_mirror.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+# PreToolUse hook for Edit / Write / MultiEdit tools.
+#
+# Purpose: blocks any tracker edit (docs/features.md, docs/bugs.md)
+# that adds OR materially edits a mirror-required row that lacks a
+# `GH: #N` cross-reference in its Notes column. Implements the
+# mechanical-mirror rule from AGENTS.md (every PLANNED+ feature, every
+# non-exempt bug → GH issue).
+#
+# Mirror-required state:
+#   features: PLANNED, IN PROGRESS, DONE, VERIFIED
+#   bugs:     anything not in {DUPLICATE, WONT FIX, WONT DO, DEFERRED}
+#
+# Escape hatches:
+#   features: `Mirror: no` anywhere in the Notes column
+#   bugs:     `Mirror: no — local-only` anywhere in Notes — narrower
+#             phrasing required so a copy-paste from features rule
+#             can't bypass; only valid with terminal non-actionable
+#             status. The hook here just checks the literal phrase;
+#             the policy guard is the AGENTS.md rule.
+#
+# Reads PreToolUse JSON from stdin. Exits 0 to allow, 2 to block.
+
+set -euo pipefail
+
+INPUT="$(cat)"
+
+if ! command -v jq >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then
+    exit 0
+fi
+
+TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // ""')"
+case "$TOOL_NAME" in
+    Edit|Write|MultiEdit) ;;
+    *) exit 0 ;;
+esac
+
+FILE_PATH="$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')"
+
+KIND=""
+case "$FILE_PATH" in
+    */docs/features.md) KIND="feature" ;;
+    */docs/bugs.md) KIND="bug" ;;
+    *) exit 0 ;;
+esac
+
+# Compute post-edit content via python (handles multi-line cleanly).
+new_content() {
+    case "$TOOL_NAME" in
+        Write)
+            echo "$INPUT" | jq -r '.tool_input.content // ""'
+            ;;
+        Edit)
+            HOOK_INPUT="$INPUT" HOOK_FILE="$FILE_PATH" python3 -c '
+import json, os, sys
+data = json.loads(os.environ["HOOK_INPUT"])
+old = data["tool_input"].get("old_string", "")
+new = data["tool_input"].get("new_string", "")
+try:
+    with open(os.environ["HOOK_FILE"]) as f:
+        content = f.read()
+except FileNotFoundError:
+    content = ""
+idx = content.find(old)
+if idx < 0:
+    sys.stdout.write(content)
+else:
+    sys.stdout.write(content[:idx] + new + content[idx + len(old):])
+'
+            ;;
+        MultiEdit)
+            HOOK_INPUT="$INPUT" HOOK_FILE="$FILE_PATH" python3 -c '
+import json, os, sys
+data = json.loads(os.environ["HOOK_INPUT"])
+edits = data["tool_input"].get("edits", [])
+try:
+    with open(os.environ["HOOK_FILE"]) as f:
+        content = f.read()
+except FileNotFoundError:
+    content = ""
+for e in edits:
+    old = e.get("old_string", "")
+    new = e.get("new_string", "")
+    idx = content.find(old)
+    if idx >= 0:
+        content = content[:idx] + new + content[idx + len(old):]
+sys.stdout.write(content)
+'
+            ;;
+    esac
+}
+
+OLD="$(cat "$FILE_PATH" 2>/dev/null || echo "")"
+NEW="$(new_content)"
+
+# Parse rows out of NEW + OLD, then identify mirror-required rows in
+# NEW that either (a) didn't exist in OLD, or (b) had different
+# status/notes than OLD. For each such row, require `GH: #N` (or the
+# kind-appropriate Mirror escape) in the Notes column.
+MISSING="$(KIND="$KIND" NEW_CONTENT="$NEW" OLD_CONTENT="$OLD" python3 <<'PYEOF'
+import os, re, sys
+
+KIND = os.environ["KIND"]
+
+# Mirror-required statuses per AGENTS.md.
+if KIND == "feature":
+    MIRROR_STATUSES = {"PLANNED", "IN PROGRESS", "DONE", "VERIFIED"}
+else:  # bug
+    EXEMPT_STATUSES = {"DUPLICATE", "WONT FIX", "WONT DO", "DEFERRED"}
+    MIRROR_STATUSES = None  # any status NOT in EXEMPT
+
+ID_RE = re.compile(r"^\| *(\d+) *\|")
+GH_RE = re.compile(r"GH:\s*#?\d+")
+MIRROR_NO_FEATURE = re.compile(r"Mirror:\s*no", re.IGNORECASE)
+MIRROR_NO_BUG = re.compile(r"Mirror:\s*no\s*[—-]\s*local-only", re.IGNORECASE)
+
+def parse_rows(content):
+    rows = {}
+    for line in content.splitlines():
+        m = ID_RE.match(line)
+        if not m:
+            continue
+        rid = m.group(1)
+        cells = [c.strip() for c in line.split("|")]
+        # Cells: ['', id, title, area, priority, status, notes, '']
+        if len(cells) < 7:
+            continue
+        status = cells[5] if len(cells) > 5 else ""
+        notes = cells[6] if len(cells) > 6 else ""
+        rows[rid] = (status, notes)
+    return rows
+
+def needs_mirror(status):
+    if KIND == "feature":
+        return status in MIRROR_STATUSES
+    else:
+        return status not in EXEMPT_STATUSES
+
+def has_gh_or_exempt(notes):
+    if GH_RE.search(notes):
+        return True
+    if KIND == "feature" and MIRROR_NO_FEATURE.search(notes):
+        return True
+    if KIND == "bug" and MIRROR_NO_BUG.search(notes):
+        return True
+    return False
+
+new_rows = parse_rows(os.environ["NEW_CONTENT"])
+old_rows = parse_rows(os.environ["OLD_CONTENT"])
+
+missing = []
+for rid, (status, notes) in new_rows.items():
+    if not needs_mirror(status):
+        continue
+    if has_gh_or_exempt(notes):
+        continue
+    # Material change check: row added (not in OLD), or status/notes
+    # changed vs OLD. Bare presence in OLD with identical fields
+    # bypasses (no edit-touch, no enforcement).
+    old = old_rows.get(rid)
+    if old is None:
+        # New row, mirror-required, no GH → block.
+        missing.append(rid)
+    elif old != (status, notes):
+        # Existing row touched (status or notes changed). Either way,
+        # if it's now mirror-required without GH, block. This is the
+        # "retroactive gap" case Codex called out.
+        missing.append(rid)
+
+if missing:
+    print(",".join(missing))
+PYEOF
+)"
+
+if [[ -z "$MISSING" ]]; then
+    exit 0
+fi
+
+cat >&2 <<EOF
+[gh-issue-mirror-hook] BLOCKED.
+
+The edit you're about to write touches mirror-required ${KIND} row(s) that lack
+a \`GH: #N\` cross-reference in their Notes column:
+
+EOF
+for rid in $(echo "$MISSING" | tr ',' ' '); do
+    echo "  - ${KIND} #${rid}" >&2
+done
+cat >&2 <<EOF
+
+Per AGENTS.md "GitHub Issues — mechanical mirror" rule: every
+mirror-required tracker row needs a paired GH issue. Two ways to
+proceed:
+
+  1. Run \`gh issue create --title "${KIND^} #N: <summary>" --label "${KIND}" \\
+       --body "..."\` then add \`GH: #<issue>\` to the Notes column.
+     Easiest path: use the slash command \`/file-${KIND}\` if available.
+  2. (Features only) Add \`Mirror: no\` to Notes if the row is
+     intentionally local-only.
+  3. (Bugs only, narrow) Add \`Mirror: no — local-only\` to Notes —
+     valid only with terminal non-actionable status, never \`TODO\`.
+EOF
+exit 2

--- a/.claude/hooks/check_unfinished_verification.sh
+++ b/.claude/hooks/check_unfinished_verification.sh
@@ -86,4 +86,81 @@ Note: this is a warning, not a block. The session may still end.
 EOF
 fi
 
+# --- Mirror debt scan (mechanical-mirror rule, AGENTS.md) ---
+# Both trackers: surface mirror-required rows that lack GH cross-refs.
+# Scoped to actionable debt per Codex's design recommendation:
+#   features: PLANNED / IN PROGRESS / DONE / VERIFIED without GH:#N
+#   bugs:     anything not in {DUPLICATE, WONT FIX, WONT DO, DEFERRED}
+#             without GH:#N AND without "Mirror: no" escape.
+
+if command -v python3 >/dev/null 2>&1; then
+    BUGS_FILE="$PROJECT_DIR/docs/bugs.md"
+    FEATURES_FILE="$PROJECT_DIR/docs/features.md"
+    MIRROR_DEBT="$(BUGS="$BUGS_FILE" FEATURES="$FEATURES_FILE" python3 <<'PYEOF'
+import os, re
+
+GH_RE = re.compile(r"GH:\s*#?\d+")
+MIRROR_NO_FEATURE = re.compile(r"Mirror:\s*no", re.IGNORECASE)
+MIRROR_NO_BUG = re.compile(r"Mirror:\s*no\s*[—-]\s*local-only", re.IGNORECASE)
+ID_RE = re.compile(r"^\| *(\d+) *\|")
+
+def scan(path, kind):
+    if not os.path.exists(path):
+        return []
+    out = []
+    with open(path) as f:
+        for line in f:
+            m = ID_RE.match(line)
+            if not m:
+                continue
+            rid = m.group(1)
+            cells = [c.strip() for c in line.split("|")]
+            if len(cells) < 7:
+                continue
+            status = cells[5]
+            notes = cells[6]
+            if kind == "feature":
+                if status not in {"PLANNED", "IN PROGRESS", "DONE", "VERIFIED"}:
+                    continue
+            else:
+                if status in {"DUPLICATE", "WONT FIX", "WONT DO", "DEFERRED", ""}:
+                    continue
+            if GH_RE.search(notes):
+                continue
+            if kind == "feature" and MIRROR_NO_FEATURE.search(notes):
+                continue
+            if kind == "bug" and MIRROR_NO_BUG.search(notes):
+                continue
+            out.append(rid)
+    return out
+
+bug_debt = scan(os.environ["BUGS"], "bug")
+feature_debt = scan(os.environ["FEATURES"], "feature")
+parts = []
+if bug_debt:
+    head = ", ".join(f"#{r}" for r in bug_debt[:8])
+    extra = "" if len(bug_debt) <= 8 else f" (+{len(bug_debt) - 8} more)"
+    parts.append(f"BUG-DEBT|{len(bug_debt)}|{head}{extra}")
+if feature_debt:
+    head = ", ".join(f"#{r}" for r in feature_debt[:8])
+    extra = "" if len(feature_debt) <= 8 else f" (+{len(feature_debt) - 8} more)"
+    parts.append(f"FEATURE-DEBT|{len(feature_debt)}|{head}{extra}")
+if parts:
+    print("\n".join(parts))
+PYEOF
+    )"
+
+    if [[ -n "$MIRROR_DEBT" ]]; then
+        echo "[mirror-debt-hook] Unmirrored tracker rows (per AGENTS.md mechanical-mirror rule):" >&2
+        echo "$MIRROR_DEBT" | while IFS='|' read -r kind count ids; do
+            label="${kind/-DEBT/}"
+            echo "  ${label} rows lacking GH:#N: ${count} — ${ids}" >&2
+        done
+        echo "" >&2
+        echo "Open a GH issue per row (or use \`/file-bug\` / \`/file-feature\` slash commands)" >&2
+        echo "and add \`GH: #N\` to the Notes column. \`Mirror: no\` (features) and" >&2
+        echo "\`Mirror: no — local-only\` (bugs only, terminal status) bypass." >&2
+    fi
+fi
+
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,11 @@
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check_terminal_status_evidence.sh",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check_gh_issue_mirror.sh",
+            "timeout": 30
           }
         ]
       }

--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 70
-        MARKETING_VERSION: 3.12.3
+        CURRENT_PROJECT_VERSION: 71
+        MARKETING_VERSION: 3.12.4
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3986,13 +3986,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 70;
+				CURRENT_PROJECT_VERSION = 71;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.12.3;
+				MARKETING_VERSION = 3.12.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4136,13 +4136,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 70;
+				CURRENT_PROJECT_VERSION = 71;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.12.3;
+				MARKETING_VERSION = 3.12.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
Same 3-layer pattern as verification hooks. PreToolUse blocks unmirrored mirror-required tracker edits; Stop hook surfaces historical debt; /file-bug + /file-feature slash commands handle the partial-success failure mode Codex flagged. See commit message for full design + test cases.