### PR TITLE
chore: PreToolUse + Stop hooks for Codex audit merge gate

### DIFF
--- a/.claude/codex-audits/README.md
+++ b/.claude/codex-audits/README.md
@@ -1,0 +1,50 @@
+# Codex audit logs
+
+Each PR that ships Swift code under `vreader/` or `vreaderTests/` lands a Codex audit log here. The PreToolUse hook `.claude/hooks/check_codex_audit_artifact.sh` blocks `gh pr merge` for any branch without one.
+
+## Filename
+
+`<branch-with-slashes-replaced-by-hyphens>-audit.md`
+
+For branch `fix/issue-206-wire-lazy-download-finalizer` → file `fix-issue-206-wire-lazy-download-finalizer-audit.md`.
+
+## Required frontmatter
+
+```yaml
+---
+branch: <branch name, exactly as `git branch --show-current` returns>
+threadId: <Codex MCP thread id, or "manual-fallback">
+rounds: <integer ≥ 1>
+final_verdict: ship-as-is | follow-up-recommended | block-recommended
+date: YYYY-MM-DD
+---
+```
+
+The hook validates:
+
+- File exists at the expected path.
+- `branch:` value matches the current branch (catches stale logs from a renamed branch).
+- `final_verdict:` is one of the three allowed values.
+- `final_verdict: block-recommended` blocks the merge with the audit's reasoning.
+
+## Body
+
+Free-form Markdown, but the workflow rule (`.claude/rules/47-feature-workflow.md` Gate 4) requires:
+
+1. **Per-round findings** — each Codex round's findings, formatted as `file:line | severity | issue | fix`. Critical/High/Medium findings must be addressed before final verdict; Low findings can be accepted with rationale.
+2. **Resolution per finding** — fixed (with commit/file ref), accepted (with rationale), or deferred to follow-up bug (with bug id).
+3. **Final verdict statement** — one paragraph or sentence justifying the chosen `final_verdict`.
+
+For manual-fallback audits (Codex MCP unavailable), include a **Manual audit evidence** section instead of the Codex transcript, listing files read + symbols verified + edge cases checked.
+
+## When the hook can be bypassed
+
+- Branch only touches `docs/`, `dev-docs/`, `.claude/`, hook configs, or other non-Swift paths. The hook detects this via `git diff main..HEAD --name-only` and exits 0.
+- Branch is `main` / `master` itself (no merge from main into main).
+- An override is needed for an emergency ship — discuss with the user, then the user can comment `verdict: ship-as-is` in the audit log frontmatter even without a real Codex run.
+
+The Stop hook `.claude/hooks/check_audit_debt.sh` is a backstop — it scans recent merges on `main` and warns about Swift-touching merges that lack an audit log so the gap doesn't quietly carry over from a session where the PreToolUse hook didn't fire (e.g., merges that pre-date this hook framework).
+
+## Examples
+
+`fix-codex-audit-followup-audit.md` — bundle PR for bugs #117, #118, #119. 4 rounds, final verdict `ship-as-is`. Each round's findings + resolution documented.

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -163,6 +163,40 @@ If Codex MCP is unavailable, perform a manual audit:
 
 Read each changed file, analyze, fix Critical/High issues.
 
+#### 4g. Write the audit log artifact
+
+**Required before Phase 6.** The PreToolUse hook
+`.claude/hooks/check_codex_audit_artifact.sh` blocks `gh pr merge`
+without an audit log. Write the file BEFORE attempting the merge so
+the hook passes.
+
+Path: `.claude/codex-audits/<branch-with-slashes-replaced-by-hyphens>-audit.md`
+
+Required frontmatter:
+
+```markdown
+---
+branch: <current branch name, exactly as `git branch --show-current` returns>
+threadId: <Codex MCP thread id from the audit>
+rounds: <integer ≥ 1>
+final_verdict: ship-as-is | follow-up-recommended | block-recommended
+date: YYYY-MM-DD
+---
+```
+
+Body should include, at minimum:
+- Per-round findings (file:line | severity | issue | fix).
+- Resolution note for each finding (fixed, accepted with rationale, deferred to follow-up bug).
+- Summary verdict statement.
+
+Commit the audit log alongside the fix (same commit as the version
+bump or a dedicated `chore: codex audit log for ...` commit).
+
+If you used the manual fallback (4f) instead of Codex MCP, write the
+same file with `threadId: manual-fallback` and a "Manual audit
+evidence" body section per `.claude/rules/47-feature-workflow.md`'s
+manual-fallback requirements.
+
 ### Phase 5: Gate
 
 Run up to 3 attempts:

--- a/.claude/hooks/check_audit_debt.sh
+++ b/.claude/hooks/check_audit_debt.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Stop hook — surfaces "merged without Codex audit log" debt.
+#
+# Scans the last 5 merges on `main` (the typical session window) and
+# warns if any merged a feature/fix branch that touched Swift code
+# without a matching `.claude/codex-audits/<branch>-audit.md` file.
+# Catches the "ran the workflow but skipped Gate 4" pattern at session
+# end so the next session can backfill the audit if appropriate.
+#
+# Exits 0 always — informational only. The PreToolUse hook
+# `check_codex_audit_artifact.sh` is the actual block.
+#
+# Reads Stop JSON from stdin per Claude Code's hook spec.
+
+set -euo pipefail
+
+# Bail quietly if not in a git repo (don't break unrelated sessions).
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+cd "$PROJECT_DIR"
+if ! git rev-parse --git-dir >/dev/null 2>&1; then exit 0; fi
+
+# Find recent squash-merges on main. The default `gh pr merge --squash`
+# leaves "(#N)" in the commit subject. Walk the last few commits and
+# extract branch names from PR refs where possible.
+DEBT=""
+COUNT=0
+
+# Look at the last 5 commits on main, grab any squash-merge headers.
+while IFS=$'\t' read -r sha subject; do
+    # Skip merge commits without a PR marker. GitHub's squash-merge
+    # subjects end with " (#N)" — anchor to end so we don't pick up a
+    # bug-ref like "fix(#115):" earlier in the subject.
+    if [[ ! "$subject" =~ \(#([0-9]+)\)[[:space:]]*$ ]]; then continue; fi
+    PR_NUMBER="${BASH_REMATCH[1]}"
+
+    # Use gh to map PR number to its head branch name.
+    if ! command -v gh >/dev/null 2>&1; then continue; fi
+    BRANCH="$(gh pr view "$PR_NUMBER" --json headRefName -q '.headRefName' 2>/dev/null || true)"
+    if [[ -z "$BRANCH" ]]; then continue; fi
+
+    # Skip main / master self-merges and dependabot etc.
+    case "$BRANCH" in
+        main|master|dependabot/*) continue ;;
+    esac
+
+    # Did the PR touch Swift code? Use the parent commit's tree to
+    # diff the squashed commit against. If the merge was a squash, the
+    # commit's parent is the previous main HEAD.
+    PARENT="$(git rev-parse "$sha^" 2>/dev/null || true)"
+    if [[ -z "$PARENT" ]]; then continue; fi
+    if ! git diff "$PARENT".."$sha" --name-only 2>/dev/null | grep -qE '^(vreader/|vreaderTests/)'; then
+        continue
+    fi
+
+    # Look for matching audit log.
+    SAFE_BRANCH="${BRANCH//\//-}"
+    AUDIT_FILE="$PROJECT_DIR/.claude/codex-audits/${SAFE_BRANCH}-audit.md"
+    if [[ -f "$AUDIT_FILE" ]]; then continue; fi
+
+    DEBT+="  - ${sha:0:7} #${PR_NUMBER} (${BRANCH})"$'\n'
+    COUNT=$((COUNT + 1))
+done < <(git log --format='%H%x09%s' main -5 2>/dev/null)
+
+if [[ "$COUNT" -gt 0 ]]; then
+    cat >&2 <<EOF
+[codex-audit-debt-hook] Recent merges on main without audit logs:
+
+$DEBT
+These PRs touched Swift code but have no \`.claude/codex-audits/<branch>-audit.md\`.
+The PreToolUse hook \`check_codex_audit_artifact.sh\` blocks new merges
+without an audit, but doesn't catch ones that pre-date the hook. If
+you want to backfill: read the diff, run a Codex audit on it, and
+write the log under the branch name (with hyphens replacing slashes).
+EOF
+fi
+
+exit 0

--- a/.claude/hooks/check_codex_audit_artifact.sh
+++ b/.claude/hooks/check_codex_audit_artifact.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+# PreToolUse hook for the Bash tool.
+#
+# Purpose: blocks `gh pr merge` (and equivalents) unless there's a
+# Codex audit log at `.claude/codex-audits/<branch>-audit.md` for the
+# current branch with a final_verdict of `ship-as-is` or
+# `follow-up-recommended`. Catches the workflow gap where bug-fix PRs
+# merged to main without the Gate-4 audit step from
+# `.claude/rules/47-feature-workflow.md`.
+#
+# The audit file's required frontmatter:
+#
+#   ---
+#   branch: <current branch name>
+#   threadId: <Codex MCP thread id>
+#   rounds: <integer ≥ 1>
+#   final_verdict: ship-as-is | follow-up-recommended | block-recommended
+#   date: YYYY-MM-DD
+#   ---
+#
+# Exits 0 to allow, 2 (with message on stderr) to block.
+#
+# Escape hatch: meta-process / docs-only PRs that touch zero Swift
+# files don't need an audit. The hook detects this by checking
+# `git diff main..HEAD --name-only` — if nothing under
+# `vreader/` or `vreaderTests/` changed, allow without an audit.
+#
+# Reads PreToolUse JSON from stdin.
+
+set -euo pipefail
+
+INPUT="$(cat)"
+
+if ! command -v jq >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then
+    # Tool missing — fail open rather than block the agent.
+    exit 0
+fi
+
+TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // ""')"
+[[ "$TOOL_NAME" == "Bash" ]] || exit 0
+
+COMMAND="$(echo "$INPUT" | jq -r '.tool_input.command // ""')"
+
+# Match `gh pr merge` with any flags. Use a permissive regex so
+# `--squash`, `--rebase`, `--auto`, `--admin`, etc. all trigger.
+# Skip if the command is some other gh pr usage (view, list, comment).
+if ! echo "$COMMAND" | grep -qE '(^|[[:space:]])gh[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)'; then
+    exit 0
+fi
+
+# Resolve repo root + current branch.
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+cd "$REPO_ROOT"
+
+if ! BRANCH="$(git branch --show-current 2>/dev/null)" || [[ -z "$BRANCH" ]]; then
+    # Detached HEAD or non-git state — can't enforce, fail open.
+    exit 0
+fi
+
+# main / master never gets merged via `gh pr merge` from itself
+# (you'd be merging some OTHER PR). Skip the check.
+case "$BRANCH" in
+    main|master) exit 0 ;;
+esac
+
+# Detect docs/meta-only PRs that don't need a code audit.
+# Fail open if the diff command itself fails (no upstream main, etc.).
+SWIFT_TOUCHED="no"
+if CHANGED="$(git diff main..HEAD --name-only 2>/dev/null)"; then
+    if echo "$CHANGED" | grep -qE '^(vreader/|vreaderTests/)'; then
+        SWIFT_TOUCHED="yes"
+    fi
+fi
+if [[ "$SWIFT_TOUCHED" == "no" ]]; then
+    # Docs / hooks / config / rules only — audit not required.
+    exit 0
+fi
+
+# Audit file path.
+SAFE_BRANCH="${BRANCH//\//-}"
+AUDIT_FILE="$REPO_ROOT/.claude/codex-audits/${SAFE_BRANCH}-audit.md"
+
+if [[ ! -f "$AUDIT_FILE" ]]; then
+    cat >&2 <<EOF
+[codex-audit-merge-gate] BLOCKED.
+
+Branch \`$BRANCH\` touches Swift files but has no Codex audit log at:
+
+  $AUDIT_FILE
+
+Per .claude/rules/47-feature-workflow.md Gate 4 and the /fix-issue
+skill's Phase 4, every PR that ships Swift code must run through a
+Codex audit loop before merge. Two ways to proceed:
+
+  1. Run the audit. The cheap path:
+        a. mcp__plugin_codex-toolkit_codex__codex with sandbox=read-only
+           and a prompt that audits the diff vs main. Capture the
+           threadId from the response.
+        b. Iterate via codex-reply until the verdict is "ship-as-is"
+           or "follow-up-recommended" (with follow-ups filed as
+           separate bugs).
+        c. Write the log to:
+              $AUDIT_FILE
+           with frontmatter:
+              ---
+              branch: $BRANCH
+              threadId: <from step a>
+              rounds: <count>
+              final_verdict: ship-as-is | follow-up-recommended
+              date: $(date +%Y-%m-%d)
+              ---
+        d. git add + commit the audit log alongside the fix.
+        e. Retry the merge.
+
+  2. If the audit is genuinely impractical (Codex MCP is down and
+     can't be brought up), do a manual mini-audit per the
+     /fix-issue skill's fallback procedure and write the same file
+     with final_verdict + a "Manual audit evidence" section
+     replacing the Codex transcript. The hook accepts manual logs.
+EOF
+    exit 2
+fi
+
+# Validate the audit file's frontmatter.
+RESULT="$(AUDIT_FILE="$AUDIT_FILE" BRANCH="$BRANCH" python3 - <<'PYEOF'
+import os
+import re
+import sys
+
+path = os.environ["AUDIT_FILE"]
+branch = os.environ["BRANCH"]
+
+with open(path) as f:
+    content = f.read()
+
+m = re.match(r"^---\s*\n(.*?)\n---\s*\n", content, re.DOTALL)
+if not m:
+    print("error: missing or malformed frontmatter")
+    sys.exit(0)
+
+front = m.group(1)
+fields = {}
+for line in front.splitlines():
+    if ":" in line:
+        k, v = line.split(":", 1)
+        fields[k.strip()] = v.strip()
+
+if fields.get("branch", "") != branch:
+    print(f"error: frontmatter branch={fields.get('branch','')!r} doesn't match current branch {branch!r}")
+    sys.exit(0)
+
+verdict = fields.get("final_verdict", "")
+if verdict not in {"ship-as-is", "follow-up-recommended", "block-recommended"}:
+    print(f"error: final_verdict={verdict!r} must be one of ship-as-is, follow-up-recommended, block-recommended")
+    sys.exit(0)
+
+if verdict == "block-recommended":
+    print(f"block: final_verdict=block-recommended — Codex says don't merge")
+    sys.exit(0)
+
+print("ok")
+PYEOF
+)"
+
+case "$RESULT" in
+    ok)
+        exit 0
+        ;;
+    block:*)
+        cat >&2 <<EOF
+[codex-audit-merge-gate] BLOCKED.
+
+The Codex audit log at $AUDIT_FILE marks final_verdict=block-recommended.
+That's a hard "do not merge." Either:
+
+  1. Address the audit's blocking findings, run another round, update
+     the verdict to ship-as-is or follow-up-recommended.
+  2. Override only with explicit user authorization for an emergency
+     ship — discuss with the user before bypassing this hook.
+
+Verdict comment:
+  ${RESULT#block: }
+EOF
+        exit 2
+        ;;
+    error:*)
+        cat >&2 <<EOF
+[codex-audit-merge-gate] BLOCKED — audit log frontmatter invalid.
+
+  $AUDIT_FILE
+
+Reason: ${RESULT#error: }
+
+Required frontmatter:
+  ---
+  branch: $BRANCH
+  threadId: <Codex thread id>
+  rounds: <integer>
+  final_verdict: ship-as-is | follow-up-recommended | block-recommended
+  date: YYYY-MM-DD
+  ---
+
+Fix the file, retry the merge.
+EOF
+        exit 2
+        ;;
+    *)
+        # Unexpected python output — fail open with a stderr warning
+        # rather than block the agent on hook bugs.
+        echo "[codex-audit-merge-gate] python validator returned unexpected output: $RESULT" >&2
+        exit 0
+        ;;
+esac

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,16 @@
             "timeout": 30
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check_codex_audit_artifact.sh",
+            "timeout": 30
+          }
+        ]
       }
     ],
     "Stop": [
@@ -37,6 +47,11 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check_unfinished_verification.sh",
+            "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check_audit_debt.sh",
             "timeout": 15
           }
         ]


### PR DESCRIPTION
## Summary

Closes the workflow gap that let bug-fix PRs (#210, #212, #213, #214) merge to main without the Gate-4 Codex audit step from `.claude/rules/47-feature-workflow.md`. Subsequent post-merge audit caught 4 real issues (1 High, 3 Medium) — fixed in PR #219, but the prevention layer didn't exist yet.

Three defense layers:

### Layer 1 — PreToolUse hook (the actual block)

`.claude/hooks/check_codex_audit_artifact.sh` intercepts `gh pr merge` from the Bash tool. Blocks the merge if:

- Current branch touched Swift files (`vreader/`, `vreaderTests/`)
- AND `.claude/codex-audits/<branch-with-slashes-replaced-by-hyphens>-audit.md` doesn't exist
- OR the audit's `final_verdict` is `block-recommended`
- OR the frontmatter is malformed / branch mismatch

Docs / hooks / config-only branches are exempt — the hook detects this via `git diff main..HEAD --name-only`.

### Layer 2 — `/fix-issue` skill update

`fix-issue.md` Phase 4 gets a new section `4g. Write the audit log artifact` that documents the required path, required frontmatter, body sections, and manual-fallback variant. The next agent running the workflow writes the file without having to remember.

### Layer 3 — Stop hook (backstop)

`.claude/hooks/check_audit_debt.sh` scans the last 5 merges on main and warns about Swift-touching merges that lack an audit log. Catches gaps the PreToolUse hook didn't catch (merges that pre-date this hook framework). Smoke-tested against current main — correctly flags PRs #212, #213, #214 (the audit-less merges from earlier in this session).

## What's exempt from the block

Same as the rule says:
- `main` / `master` branches (no merge from main into main)
- Branches whose `git diff main..HEAD --name-only` returns no path under `vreader/` or `vreaderTests/`
- Branches with a valid audit log + verdict ∈ {ship-as-is, follow-up-recommended}

The hook does NOT exempt itself — but this PR is meta-process only (no Swift), so the hook correctly skips it and allows the merge. (Confirmed via smoke test.)

## New artifacts

- `.claude/codex-audits/` directory + README documenting the contract
- `.claude/codex-audits/fix-codex-audit-followup-audit.md` committed alongside PR #219 as the first reference example

## Smoke test results

PreToolUse hook tested against 4 paths:

| Scenario | Expected | Actual |
|---|---|---|
| No Swift in diff (this PR) | exit 0 (skip) | ✅ exit 0 |
| Swift in diff, no audit file | exit 2 (block) | ✅ exit 2 |
| Audit with malformed frontmatter | exit 2 (block) | ✅ exit 2 |
| Audit with branch mismatch | exit 2 (block) | ✅ exit 2 |
| Audit with `verdict=block-recommended` | exit 2 (block) | ✅ exit 2 |
| Audit with `verdict=ship-as-is` | exit 0 (allow) | ✅ exit 0 |

Stop hook tested:

```
[codex-audit-debt-hook] Recent merges on main without audit logs:
  - 2801936 #214 (fix/issue-205-materializer-orphan)
  - 29ba809 #213 (fix/issue-203-webdav-mkcol-temp)
  - 355b569 #212 (fix/issue-211-picker-refresh-library)
```

Correctly identifies the 3 most-recent audit-less merges. PRs #210, #215, #219 are correctly skipped (#210 outside the 5-commit window; #215 is docs-only; #219 has an audit log).

## Type of Change

- [x] Workflow / process improvement