### PR TITLE
chore: rewrite /fix-issue skill to align with current rules + close-gate

### DIFF
--- a/.claude/codex-audits/chore-skill-fix-issue-rewrite-audit.md
+++ b/.claude/codex-audits/chore-skill-fix-issue-rewrite-audit.md
@@ -1,0 +1,55 @@
+---
+branch: chore/skill-fix-issue-rewrite
+threadId: 019df5bc-0283-7ff3-aa70-e5e19384287d
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-05
+---
+
+# Codex audit: skill rewrite for `.claude/commands/fix-issue.md`
+
+## Scope
+
+Single-file change: `.claude/commands/fix-issue.md` (333 → 533 lines).
+Rewrite to align with current `AGENTS.md` + rules 40 (version bump),
+47 (feature workflow), 24 (docs sync), and 10 (TDD), and with the
+active hooks at `.claude/hooks/check_*.sh`.
+
+## Round 1
+
+Codex returned 6 findings.
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| `fix-issue.md:36–38` | Critical | Reintroduced an opt-out for the feature path ("user explicitly opts out and accepts the gate gap in writing"), contradicting rule 47's "binding for every feature, never skip a gate." | **Fixed**: removed the opt-out entirely. Replaced with hard "Always redirect features to `/feature-workflow`. STOP this pipeline. No user waiver bypasses Gates 2 or 5." |
+| `fix-issue.md:397–406` | High | Phase 9 verification-exception evidence file shape was wrong. I claimed `commands_run` lived in frontmatter, but `dev-docs/verification/SCHEMA.md` requires it as the body section `## Commands run`. | **Fixed**: replaced with the actual SCHEMA frontmatter (kind, id, status_target, commit_sha, app_version, date, verifier, device_or_simulator, os_version, build_configuration, backend, result) and added an explicit list of required body sections (`## Acceptance criteria`, `## Commands run`, `## Observations`, `## Artifacts`). |
+| `fix-issue.md:461–469` | High | Multi-issue parallel flow allowed each worktree-agent to run its own version bump and (implicitly) its own tag, with the comment "different MARKETING_VERSION values across worktrees are fine." Two parallel branches off the same `main` baseline can pick the same next version, and tagging from worktrees collides on `main`. | **Fixed in two passes**: (round 1) rewrote M3 with three integrator-controlled gates — version bump coordinated, PR merges sequential, tagging single-shot on `main`. (round 2) resolved residual contradiction (see below). |
+| `fix-issue.md:136–175` | Medium | Tool names referenced `mcp__codex__codex` and `mcp__codex__codex-reply`, but the installed Codex MCP server in this repo is `mcp__plugin_codex-toolkit_codex__codex` (and `-reply`). Following the skill literally would dead-end. | **Fixed**: `replace_all` swap to the actual installed names. |
+| `fix-issue.md:256–259` | Medium | Phase 6 flipped bug rows to `FIXED` after only tests + audit. `docs/bugs.md`'s binding workflow is "Understand → RED → GREEN → REFACTOR → **Verify** → Track" — Verify comes BEFORE Track. For UI/behavioral bugs, this means re-running the original repro is required before the FIXED flip, not deferred to Phase 9. | **Fixed**: inserted Phase 6a "Pre-FIXED verify (mandatory)" with three branches: UI/behavioral bugs re-run original repro on working-tree binary; data/persistence bugs re-run failing scenario; pure-logic bugs are gated by RED→GREEN already. The bug-tracker FIXED flip moved to Phase 6b and is gated on 6a passing. Phase 9 deep verification stays as a separate post-merge close-gate. |
+| `fix-issue.md:197–199` | Low | Said audit log "required before Phase 8 (PR creation)." The hook `check_codex_audit_artifact.sh` actually only blocks `gh pr merge`, not `gh pr create`. Misleading. | **Fixed**: reworded to "Required before merge; recommended before PR creation so review sees it." |
+
+## Round 2
+
+After fixes, Codex re-audited via `mcp__plugin_codex-toolkit_codex__codex-reply` on the same thread. 1 residual finding.
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| `fix-issue.md:516–524` | Medium | Internal contradiction in M3: the lead said agents run "Phases 0.5 → 8 (PR creation)" but item 1 said "stops just before Phase 7 and reports 'ready for bump.'" Cannot both be true. | **Fixed**: rewrote M3 lead to "Each worktree-agent runs **Phases 0.5 → 6c only**, then stops and reports 'ready for bump.' The integrator controls everything from Phase 7 onward." Item 1 then describes the resume-through-7→8 sequence. No remaining contradiction. |
+
+## Round 3 (verify only)
+
+Same thread, re-audit after the round-2 fix.
+
+> Final verdict: ship-as-is.
+>
+> I don't see remaining findings in the revised flow. The original six issues are fixed, and the last multi-issue sequencing contradiction is resolved: agents now stop at `Phase 6c`, and the integrator alone owns `Phases 7 → 9`, which is consistent with the version-bump rule, merge sequencing, and tag/finalizer handling.
+
+## Verdict
+
+**ship-as-is.** Seven findings total across two rounds, all addressed
+and re-verified. No code touched (Swift untouched), so the
+`check_codex_audit_artifact.sh` hook wouldn't have blocked the merge
+anyway — but the audit was run per the user's explicit instruction
+that "all the changes need to be audited, not just md files and code
+files." This audit log records that the MD-only diff was Codex-audited
+to a clean verdict before merge.

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -1,11 +1,13 @@
 ---
-description: End-to-end GitHub issue resolver — fetch, classify, fix, audit, PR
+description: End-to-end GitHub issue resolver — fetch, classify, fix, audit, gate, PR, and post-merge close
 argument-hint: "#123 [#456 ...]"
 ---
 
 # Fix Issue
 
-Resolve one or more GitHub issues end-to-end: fetch, classify, branch, fix with TDD, Codex audit loop, gate, and PR.
+Resolve one or more GitHub issues end-to-end: fetch, classify, branch, fix with
+TDD, Codex audit loop, test gate, docs-sync, version bump, PR, and post-merge
+close-gate finalizer.
 
 ## Input
 
@@ -13,23 +15,68 @@ Resolve one or more GitHub issues end-to-end: fetch, classify, branch, fix with 
 $ARGUMENTS
 ```
 
+## Scope
+
+| Issue type | Path inside this skill |
+|---|---|
+| Bug (label `bug` or body describes broken behavior) | Single-issue **Bug Pipeline** below |
+| Question (label `question`) | Inline answer + comment, no branch/PR |
+| Feature / enhancement | **REDIRECT** to `/feature-workflow` (see "Feature handling" below) |
+| Multiple issues at once | **Multi-Issue Pipeline** (one worktree per issue) |
+
+### Feature handling — read this before fixing a feature here
+
+`.claude/rules/47-feature-workflow.md` is **binding for every feature
+implementation**: Plan → Independent plan audit → TDD → Implementation
+audit → Device/integration verification → Merge. Six gates, never skip
+one. This skill cannot run Gate 2 (independent plan audit by a separate
+agent context) or Gate 5 (device/integration verification + evidence
+file) inline. Therefore:
+
+**Always redirect features to `/feature-workflow`. STOP this pipeline.**
+No user waiver bypasses Gates 2 or 5 — rule 47 is binding for every
+feature regardless of size. The old escape hatch (10+ files / 4+ work
+items) is gone; the previous "opt out in writing" is gone too.
+
+The skill's old `3b. Feature Path` is removed. Feature handling lives
+entirely in `/feature-workflow`.
+
+## Hooks you'll trip
+
+Three PreToolUse hooks gate this pipeline:
+
+| Hook | Triggers when | What it requires |
+|---|---|---|
+| `check_codex_audit_artifact.sh` | `gh pr merge` on a Swift-touching PR | `.claude/codex-audits/<branch>-audit.md` with valid `final_verdict` |
+| `check_gh_issue_mirror.sh` | `Edit/Write/MultiEdit` on `docs/{features,bugs}.md` | mirror-required rows must have `GH: #N` in Notes column |
+| `check_terminal_status_evidence.sh` | tracker flip to `VERIFIED` (features) or `FIXED` only on `docs/features.md` | matching `dev-docs/verification/<kind>-<id>-<YYYYMMDD>.md`. **Bug `FIXED` flips on `docs/bugs.md` are NOT hook-enforced** — verification is enforced at GH-issue-close time, not at row flip. |
+
+Plan around them; do not bypass.
+
 ## Pre-flight Checks
 
 1. **Parse arguments** — extract issue numbers (e.g. `#123`, `123`, `#123 #456`).
    - No arguments: print usage and STOP.
-2. **Check working tree** — run `git status --porcelain`. If dirty, do not revert unrelated changes; isolate your work with a branch.
-3. **Confirm branch** — run `git branch --show-current` and `git fetch origin`.
+2. **Check working tree** — `git status --porcelain`. If dirty, do not
+   revert unrelated changes; isolate your work with a new branch.
+3. **Confirm branch / sync** — `git branch --show-current` and
+   `git fetch origin`.
 
-## Single-Issue Pipeline
+---
 
-When exactly one issue number is provided, run phases 1-6 sequentially.
+# Single-Issue Bug Pipeline
+
+When exactly one issue is provided and it classifies as a bug, run
+phases 1-9 sequentially.
 
 ### Phase 0.5: Visual Reproduce (optional, for UI bugs)
 
-If the issue involves visual/UI behavior, use computer use + Simulator to reproduce before diving into code:
-- Use `sim-transfer` skill to push test files to the simulator.
-- Stream live logs: `SIMCTL spawn booted log stream --predicate 'subsystem == "com.vreader.app"' --debug`
-- Take screenshots as evidence. Batch actions with `computer_batch` — don't add unnecessary waits.
+For UI bugs, reproduce in Simulator before diving into code:
+- Use `sim-transfer` skill to push test files to the simulator (verify
+  the skill exists; if not, fall back to `xcrun simctl io booted addmedia`
+  / `simctl push`).
+- Stream live logs: `xcrun simctl spawn booted log stream --predicate 'subsystem == "com.vreader.app"' --debug`
+- Take screenshots as evidence. Batch UI actions with `computer_batch`.
 
 ### Phase 1: Fetch & Classify
 
@@ -38,58 +85,42 @@ gh issue view {N} --json number,title,body,labels,state,assignees
 ```
 
 - If issue not found or closed: warn user, ask whether to proceed, or STOP.
-- Classify by labels or body content:
+- Classify:
 
 | Classification | Trigger | Path |
-|---------------|---------|------|
-| Bug | label contains `bug`, or body mentions error/crash/broken | Bug path (Phase 3a) |
-| Feature | label contains `feature`/`enhancement` | Feature path (Phase 3b) |
-| Question | label contains `question` | Question path (Phase 3c) |
-| Ambiguous | no matching labels | Ask user to classify |
+|---|---|---|
+| Bug | label contains `bug`, or body mentions error/crash/broken | continue this pipeline |
+| Feature | label contains `feature`/`enhancement` | **redirect to `/feature-workflow`** and STOP |
+| Question | label contains `question` | jump to **Question Path** below |
+| Ambiguous | no matching labels | ask user to classify |
 
 ### Phase 2: Branch Setup
 
-- Generate slug from title: lowercase, strip non-ASCII, replace spaces with `-`, truncate to 40 chars.
-- Branch name: `fix/issue-{N}-{slug}` (bug) or `feat/issue-{N}-{slug}` (feature).
+- Slug from title: lowercase, strip non-ASCII, replace spaces with `-`,
+  truncate to 40 chars.
+- Branch name: `fix/issue-{N}-{slug}`.
 - If branch already exists: ask user — reuse or rename.
 - Create and checkout the branch.
+- **Tracker move**: edit `docs/bugs.md` row → status `IN PROGRESS`.
+  Reminder: the `check_gh_issue_mirror.sh` hook requires `GH: #N` in the
+  row's Notes column. The issue you're fixing already exists, so add
+  `GH: #{N}` to Notes if absent.
 
-### Phase 3: Resolve
+### Phase 3: Resolve (Bug)
 
-#### 3a. Bug Path
+No half measures. Follow the bug-fix workflow from `docs/bugs.md`:
 
-Follow the philosophy from `/fix` — no half measures.
-
-1. **Reproduce** — Read relevant code, trace call chain from symptom to root cause.
-2. **Diagnose** — Find root cause, check for similar patterns elsewhere.
-3. **RED** — Write a failing test capturing the bug (see `.claude/rules/10-tdd.md`):
+1. **Reproduce** — read relevant code, trace call chain symptom → root cause.
+2. **Diagnose** — find root cause; check for similar patterns elsewhere.
+3. **RED** — failing test capturing the bug per `.claude/rules/10-tdd.md`:
    - SwiftData bug → persistence test with in-memory container
    - WKWebView bridge bug → parser/coordinator unit test
    - ViewModel bug → Swift Testing async test with `@MainActor`
    - Utility bug → parameterized `@Test(arguments:)` covering the broken case
-4. **GREEN** — Fix the root cause with minimal, focused changes.
-5. **REFACTOR** — Clean up without changing behavior.
-
-#### 3b. Feature Path
-
-1. **Research** — Search for best practices, prior art, established patterns (AGENTS.md mandate).
-2. **Plan** — Design the implementation. If it would touch 10+ files or need 4+ work items, redirect to `/feature-workflow` and STOP this pipeline.
-3. **TDD implement** — RED/GREEN/REFACTOR per work item.
-4. **Edge cases** — Brainstorm and test: empty input, null, Unicode/CJK, rapid actions, concurrent access.
-
-#### 3c. Question Path
-
-1. **Research** — Read code and docs to compose a thorough answer.
-2. **Detect language** — Check the issue author's language from the issue title and body. Reply in the **same language** the author used.
-3. **Respond** — Post the answer as a comment:
-   ```bash
-   gh issue comment {N} --body "{answer in author's language}"
-   ```
-4. **STOP** — No branch, no PR needed. Clean up the branch if created.
+4. **GREEN** — fix the root cause with minimal, focused changes.
+5. **REFACTOR** — clean up without changing behavior; tests stay green.
 
 ### Phase 4: Codex Audit Loop (max 3 iterations)
-
-**Goal**: Targeted audit of changed files, not a generic sweep.
 
 #### 4a. Collect changed files
 
@@ -100,20 +131,22 @@ git diff main
 
 #### 4b. Initial audit via Codex MCP
 
-Use `ToolSearch` with query `+codex` to discover Codex tools.
+`ToolSearch` with query `+codex` to discover Codex tools.
 
-**Availability test** — before the real audit, send a short ping:
+**Availability test** — short ping first:
+
 ```
-mcp__codex__codex with:
+mcp__plugin_codex-toolkit_codex__codex with:
   prompt: "Respond with 'ok' if you can read this."
 ```
-If Codex does not respond or errors out, skip to **4f. Fallback** immediately.
 
-If Codex responds:
+If Codex does not respond, skip to **4f. Fallback** immediately. If it
+responds:
 
-**Audit prompt:**
+**Audit prompt**:
+
 ```
-mcp__codex__codex with:
+mcp__plugin_codex-toolkit_codex__codex with:
   sandbox: read-only
   prompt: |
     Audit these files changed for GitHub issue #{N}: {title}
@@ -133,11 +166,11 @@ mcp__codex__codex with:
 
 #### 4c. Parse & fix
 
-Fix **every** finding — Critical, High, Medium, and Low.
+Fix **every** finding — Critical, High, Medium, Low.
 
 #### 4d. Verify via Codex reply
 
-Use `mcp__codex__codex-reply` on the same thread:
+`mcp__plugin_codex-toolkit_codex__codex-reply` on the same thread:
 
 ```
 I fixed these issues: {list of fixes with file:line}
@@ -147,59 +180,53 @@ Updated diff: {git diff main --stat}
 
 #### 4e. Loop or exit
 
-- **Zero findings**: audit passes, exit loop.
-- **Any findings remain** and iteration < 3: fix everything and verify again.
-- 3 iterations reached with findings still open: STOP. Report all remaining issues.
+- Zero findings → audit passes, exit loop.
+- Findings remain and iteration < 3 → fix and re-verify.
+- 3 iterations with findings still open → STOP. Report remaining issues
+  to the user.
 
 #### 4f. Fallback — manual mini-audit
 
-If Codex MCP is unavailable, perform a manual audit:
-1. Logic & Correctness
-2. Duplication
-3. Dead Code
-4. Refactoring Debt
-5. Shortcuts & Patches
-6. Bridge Safety (JS injection, message parsing)
-
-Read each changed file, analyze, fix Critical/High issues.
+If Codex MCP is unavailable: read each changed file, audit dimensions
+1–8 above, fix Critical/High inline.
 
 #### 4g. Write the audit log artifact
 
-**Required before Phase 6.** The PreToolUse hook
-`.claude/hooks/check_codex_audit_artifact.sh` blocks `gh pr merge`
-without an audit log. Write the file BEFORE attempting the merge so
-the hook passes.
+**Required before merge; recommended before PR creation so review sees
+it.** `check_codex_audit_artifact.sh` blocks `gh pr merge` (not
+`gh pr create`) without an audit log. Write the file before attempting
+the merge so the hook passes.
 
 Path: `.claude/codex-audits/<branch-with-slashes-replaced-by-hyphens>-audit.md`
 
-Required frontmatter:
+Frontmatter (required):
 
 ```markdown
 ---
 branch: <current branch name, exactly as `git branch --show-current` returns>
-threadId: <Codex MCP thread id from the audit>
+threadId: <Codex MCP thread id>      # OR `manual-fallback` if 4f was used
 rounds: <integer ≥ 1>
 final_verdict: ship-as-is | follow-up-recommended | block-recommended
 date: YYYY-MM-DD
 ---
 ```
 
-Body should include, at minimum:
+Body:
 - Per-round findings (file:line | severity | issue | fix).
-- Resolution note for each finding (fixed, accepted with rationale, deferred to follow-up bug).
+- Resolution note for each finding (fixed / accepted with rationale /
+  deferred to follow-up bug).
 - Summary verdict statement.
+- If you used manual fallback, include a "Manual audit evidence" section
+  per `.claude/rules/47-feature-workflow.md`'s manual-fallback rules
+  (files read, symbols verified, edge cases checked, risks accepted).
 
-Commit the audit log alongside the fix (same commit as the version
-bump or a dedicated `chore: codex audit log for ...` commit).
+Commit the audit log alongside the fix, in its own commit
+(`chore: codex audit log for issue #{N}`) or folded into the relevant
+fix commit — but it must be on the branch before the PR opens.
 
-If you used the manual fallback (4f) instead of Codex MCP, write the
-same file with `threadId: manual-fallback` and a "Manual audit
-evidence" body section per `.claude/rules/47-feature-workflow.md`'s
-manual-fallback requirements.
+### Phase 5: Test Gate
 
-### Phase 5: Gate
-
-Run up to 3 attempts:
+Up to 3 attempts:
 
 ```bash
 DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
@@ -208,28 +235,105 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
   -only-testing:vreaderTests
 ```
 
-> **Note:** `xcodebuild` CLI builds to a different DerivedData than Xcode's Run button.
-> For debugger-attached builds or when `simctl install` installs a stale binary, use Xcode's
-> Run button (click via computer use) instead of `xcodebuild` + `simctl install`.
+> **Note**: `xcodebuild` CLI builds to a different DerivedData than
+> Xcode's Run button. For debugger-attached builds or when
+> `simctl install` installs a stale binary, use Xcode's Run button via
+> computer-use instead of `xcodebuild` + `simctl install`.
 >
-> **Never use `simctl uninstall`** — it wipes all user data (imported books, settings, reading positions).
-> Use `simctl install` to replace the binary while preserving data.
+> **Never use `simctl uninstall`** — it wipes all user data (imported
+> books, settings, reading positions). Use `simctl install` to replace
+> the binary while preserving data.
 
-- Pass: proceed to Phase 6.
-- Fail: read errors, fix, retry.
-- 3 failures: report errors, keep branch, STOP.
+- Pass → proceed.
+- Fail → read errors, fix, retry.
+- 3 failures → report, keep branch, STOP.
 
-Also verify:
-- Update `docs/bugs.md` status if fixing a tracked bug.
-- Update `docs/architecture.md` if component communication changed.
+### Phase 6: Tracker State + Docs Sync
 
-### Phase 6: Create PR
+#### 6a. Pre-FIXED verify (mandatory)
+
+The `docs/bugs.md` workflow is **Understand → RED → GREEN → REFACTOR
+→ Verify → Track**. "Verify" comes BEFORE "Track" (the FIXED flip).
+
+Run a lightweight pre-merge confirmation that the symptom is actually
+gone — not just that tests pass. This is distinct from the deep
+post-merge close-gate verification in Phase 9; that one runs against
+the merged build on `main`.
+
+- **UI / behavioral bugs**: re-run the original repro from the issue
+  body in the simulator with the working-tree binary
+  (`xcodebuild build` then launch via Xcode Run, or `simctl install`
+  the freshly built `.app`). Confirm the actual symptom is gone.
+- **Data / state / persistence bugs**: re-run the failing scenario
+  end-to-end (e.g., import → backup → wipe → restore) against the
+  working-tree binary. Confirm the broken state no longer reproduces.
+- **Pure-logic bugs reproducible by a unit test**: the RED→GREEN
+  transition in Phase 3 already establishes "Verify" — no extra step
+  needed.
+
+If pre-FIXED verify fails: the fix is incomplete. Loop back to Phase 3
+(or revert) — do NOT advance to Phase 6b.
+
+#### 6b. Bug tracker — FIXED flip
+
+`docs/bugs.md` row → status **`FIXED`** (only after 6a verify passed).
+The `check_terminal_status_evidence.sh` hook does NOT block bug
+`FIXED` flips — verification is enforced at issue-close time
+(Phase 9), not at this row flip. Add `GH: #{N}` to the row's Notes
+column if absent (`check_gh_issue_mirror.sh` will block otherwise).
+
+#### 6c. Docs sync (if triggered)
+
+Per `.claude/rules/24-doc-sync.md`:
+
+| If your fix touched | Update |
+|---|---|
+| New service / actor / `@Model` / `Notification.Name` / cross-feature pattern | `docs/architecture.md` |
+| User-visible behavior, tech stack, requirements, setup, ≥5-row tracker change | `README.md` |
+| Otherwise | nothing |
+
+If updates are needed, commit them in their own commit
+(`docs: update architecture.md for #{N} fix` etc.) **before** the
+version bump in Phase 7. Pure bug fixes with no architectural impact
+need nothing here.
+
+### Phase 7: Version Bump
+
+Per `.claude/rules/40-version-bump.md`. Mandatory tail commit before PR.
 
 ```bash
-gh pr create --title "{type}: {concise description}" --body "$(cat <<'EOF'
+# 1. Edit project.yml: bump MARKETING_VERSION (patch for bug fixes) and
+#    increment CURRENT_PROJECT_VERSION (always +1, monotonic).
+# 2. Regenerate the Xcode project:
+xcodegen generate
+
+# 3. Verify both files updated:
+grep -E "MARKETING_VERSION|CURRENT_PROJECT_VERSION" project.yml
+grep -E "MARKETING_VERSION =|CURRENT_PROJECT_VERSION =" vreader.xcodeproj/project.pbxproj
+
+# 4. Quick smoke build:
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build \
+    -project vreader.xcodeproj -scheme vreader \
+    -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+
+# 5. Commit (single commit, both files):
+git add project.yml vreader.xcodeproj/project.pbxproj
+git commit -m "chore: bump version to X.Y.Z"
+```
+
+For bug fixes, increment **patch**. The post-merge tag (`v X.Y.Z`) is
+cut from the merge commit on `main` after PR lands.
+
+### Phase 8: Create PR
+
+PR uses `Refs #N`, **not** `Fixes #N` (prevents premature auto-close —
+the GH issue stays open until verified, see Phase 9).
+
+```bash
+gh pr create --title "fix: {concise description}" --body "$(cat <<'EOF'
 ## Summary
 
-{1-3 bullet points describing what changed and why}
+{1-3 bullets describing what changed and why}
 
 Refs #{N}
 
@@ -239,71 +343,218 @@ Refs #{N}
 
 ## Codex Audit
 
-{audit summary — iterations run, findings fixed}
+{audit summary — iterations run, findings fixed, verdict}
+
+Audit log: `.claude/codex-audits/{branch-slug}-audit.md`
 
 ## Validation
 
 - [x] `xcodebuild test` passes
-- [x] Tests cover changed behavior (TDD)
-- [x] Codex audit loop completed ({M} iterations)
+- [x] Tests cover changed behavior (TDD: RED → GREEN)
+- [x] Codex audit loop completed ({M} iterations, verdict: {verdict})
+- [x] Docs sync — {architecture.md updated | README.md updated | n/a}
+- [x] Version bumped: {old} → {new}
+
+## Post-Merge Verification Plan
+
+Default path (device verification): {how the original repro will be re-run on simulator/device}.
+OR exception path (high-fidelity test): {test name + evidence file path}.
 
 ## Type of Change
 
-- [{x if bug}] Bug fix
-- [{x if feature}] Feature
+- [x] Bug fix (Refs #{N})
 EOF
 )"
 ```
 
 Report the PR URL to the user.
 
+### Phase 9: Post-Merge Finalizer (close gate)
+
+**Do NOT auto-`gh issue close`.** Per AGENTS.md "Close gate — verified,
+not just merged":
+
+#### 9a. Right after `gh pr merge`
+
+1. Apply the appropriate label to the GH issue:
+   - **Default — `awaiting-device-verification`**: failure can be
+     reproduced on a real device/sim. Most bugs.
+   - **Exception — `verification-exception`**: failure mode physically
+     cannot be device-reproduced (race conditions, fault-injection
+     paths, mid-MKCOL auth fails, concurrent restore picker, etc.).
+     Requires a deterministic high-fidelity integration test at real
+     subsystem boundaries (not casual stubs) + evidence file in
+     `dev-docs/verification/`.
+   - **Blocked — `verification-blocked`**: neither device repro nor
+     high-fidelity test is feasible yet (no harness exists). Keep open
+     with a follow-up to build the harness (potentially as a feature).
+
+2. Post a "shipped, awaiting verification" comment:
+
+   ```
+   gh issue comment {N} --body "Shipped in v{X.Y.Z} (commit {short-sha}). Awaiting {device-verification|verification-exception evidence}."
+   ```
+
+3. Tag is cut by the version-bump tag policy from `main`:
+
+   ```bash
+   git fetch origin
+   git checkout main && git pull
+   git tag v{X.Y.Z}        # only if not already tagged on the merge commit
+   git push origin --tags
+   ```
+
+#### 9b. Verification + closure
+
+For **device-verification** path:
+- Install the merged build on iPhone 17 Pro Simulator (or device).
+- Re-run the original repro from the issue body.
+- Confirm the symptom is gone.
+- Post closure comment with: commit SHA + what was tested + what was
+  observed.
+
+   ```
+   gh issue comment {N} --body "Verified on iPhone 17 Pro Simulator (commit {sha}). Re-ran the original repro: {what you did}. Observed: {what happened}. Symptom is gone."
+   gh issue close {N}
+   ```
+
+For **verification-exception** path:
+- Confirm a deterministic high-fidelity integration test covers the
+  failure path through real subsystem objects (`PersistenceActor`,
+  `BookFileMaterializer`, `WebDAVBlobStore`, etc. — not stubbed).
+  Casual unit tests with stubs do NOT qualify.
+- Write or update the evidence file at
+  `dev-docs/verification/bug-{N}-{YYYYMMDD}.md` per the schema in
+  `dev-docs/verification/SCHEMA.md`. Required frontmatter:
+
+   ```yaml
+   ---
+   kind: bug
+   id: {N}
+   status_target: FIXED
+   commit_sha: {40-hex of merge commit on main}
+   app_version: {MARKETING_VERSION (build CURRENT_PROJECT_VERSION)}
+   date: YYYY-MM-DD
+   verifier: <name or "claude">
+   device_or_simulator: <e.g. "iPhone 17 Pro Simulator">
+   os_version: <e.g. "iOS 26.4">
+   build_configuration: Debug | Release
+   backend: <e.g. "rclone WebDAV ~/vreader-webdav-data" or "n/a">
+   result: pass | partial | fail
+   ---
+   ```
+
+   Required body sections (the hook does not parse the body but rule
+   47 + SCHEMA both require them):
+
+   - `## Acceptance criteria` — table mapping each criterion to
+     observed behavior + pass/fail.
+   - `## Commands run` — fenced code blocks of the actual shell /
+     `simctl` / `xcrun` / test-invocation commands that exercised the
+     fix. Reproducible recipe.
+   - `## Observations` — narrative; what was surprising, what was
+     close to a regression.
+   - `## Artifacts` — paths to screenshots, log captures, `.xcresult`
+     bundles. Optional but strongly recommended.
+- Closure comment cites the test method + evidence file path:
+
+   ```
+   gh issue comment {N} --body "Verification exception: deterministic high-fidelity integration test {TestClass.testMethod} at {file:line} drives the same code path the production failure would hit. Evidence: dev-docs/verification/bug-{N}-{YYYYMMDD}.md."
+   gh issue close {N}
+   ```
+
+If `verification-blocked`: do not close. Add a follow-up task to build
+the missing harness and revisit when it lands.
+
 ---
 
-## Multi-Issue Pipeline
+# Question Path
+
+If Phase 1 classified the issue as `question`:
+
+1. **Research** — read code and docs to compose a thorough answer.
+2. **Detect language** — check the issue author's language from title
+   and body. Reply in the **same language** the author used.
+3. **Respond**:
+
+   ```bash
+   gh issue comment {N} --body "{answer in author's language}"
+   ```
+
+4. **STOP** — no branch, no PR, no version bump. If you created a
+   branch in Phase 2 by mistake, delete it. Question issues do not move
+   through the close gate.
+
+---
+
+# Multi-Issue Pipeline
 
 When multiple issue numbers are provided (e.g. `#123 #456 #789`).
 
-### M1: Fetch & Validate All
+### M1: Fetch & validate all
 
-Fetch all issues in parallel:
 ```bash
 gh issue view {N} --json number,title,body,labels,state
 ```
 
 - Filter out closed issues (warn user).
-- Filter out questions (handle inline with `gh issue comment`, no worktree needed).
-- Remaining issues proceed to worktree pipeline.
+- Filter out questions (handle inline with `gh issue comment`, no worktree).
+- Filter out features (redirect each to `/feature-workflow`).
+- Remaining bugs proceed to worktree pipeline.
 
-### M2: Create Worktrees
+### M2: Create worktrees
 
-For each issue, create an isolated git worktree:
 ```bash
 git worktree add .claude/worktrees/issue-{N} -b fix/issue-{N}-{slug} main
 ```
 
-### M3: Parallel Execution
+### M3: Parallel execution
 
-Spawn one Agent per issue, each running the **full single-issue pipeline** (Phases 1-6) inside its worktree directory.
+Per `.claude/rules/48-parallel-execution.md`, parallelism is an
+isolation tool first, speed tool second.
 
-### M4: Collect Results
+Each worktree-agent runs **Phases 0.5 → 6c only**, then stops and
+reports "ready for bump." The integrator (orchestrator agent or human)
+controls everything from Phase 7 onward, with three coordinated gates:
 
-After all agents complete, display a summary table:
+1. **Version bump is integrator-coordinated.** After all worktree-agents
+   stop at the end of Phase 6c, the integrator assigns sequential
+   `MARKETING_VERSION`s to the bug PRs in the order they will land,
+   then resumes each worktree-agent through Phases 7 → 8 (version
+   bump, then PR creation) with its assigned version. This avoids two
+   parallel branches picking the same next version off the same
+   `main` baseline.
+
+2. **PR merge order is sequential, not parallel.** After all worktrees
+   open PRs, the integrator merges them one at a time. Each PR is
+   rebased on `main` immediately before merge so it carries an
+   already-bumped version that doesn't collide with what just landed.
+
+3. **Tagging happens once, on `main`, after all merges land.** No
+   worktree tags. Worktree-agents NEVER run `git tag` or
+   `git push origin --tags`. The integrator tags `main` once per
+   merged version after the final merge.
+
+Phase 9 (post-merge finalizer + verification + closure) is serial:
+single simulator, no parallel device verification, run after all
+merges land in their assigned version order.
+
+### M4: Collect results
 
 ```
-| Issue | Status | Branch | PR |
-|-------|--------|--------|------|
-| #123  | Done   | fix/issue-123-slug | #45 |
-| #456  | Failed (gate) | fix/issue-456-slug | — |
+| Issue | Status | Branch | PR | Audit verdict | Tag |
+|-------|--------|--------|------|---------------|-----|
+| #123  | Merged, awaiting-device-verification | fix/issue-123-slug | #45 | ship-as-is | v3.13.6 |
+| #456  | Failed (gate) | fix/issue-456-slug | — | — | — |
 ```
 
-### M5: Cleanup Worktrees
+### M5: Cleanup worktrees
 
 ```bash
 # Remove successful worktrees
 git worktree remove .claude/worktrees/issue-{N}
 
-# Clean up stale DerivedData created by worktree builds
-# Each worktree creates its own DerivedData folder that persists after removal
+# Clean stale DerivedData (each worktree built its own ~5 GB DD)
 for dd in ~/Library/Developer/Xcode/DerivedData/vreader-*/; do
   wp=$(defaults read "$dd/info.plist" WorkspacePath 2>/dev/null)
   if [[ "$wp" == *".claude/worktrees/"* ]]; then
@@ -314,7 +565,7 @@ done
 # Remove empty worktree directories
 rm -rf .claude/worktrees/agent-*
 
-# Keep failed ones for investigation
+# Keep failed worktrees for investigation
 ```
 
 ---
@@ -322,12 +573,16 @@ rm -rf .claude/worktrees/agent-*
 ## Error Handling
 
 | Scenario | Action |
-|----------|--------|
+|---|---|
 | No arguments | Print usage, STOP |
 | Issue not found / closed | Warn, ask user |
+| Issue is a feature | Redirect to `/feature-workflow`, STOP |
 | Dirty working tree | Isolate with branch, don't revert unrelated changes |
 | No labels (ambiguous type) | Ask user to classify |
-| Codex MCP unavailable | Fall back to manual mini-audit |
-| Gate fails 3x | Report errors, keep branch, STOP |
-| Feature too large (10+ files) | Redirect to `/feature-workflow` |
+| Codex MCP unavailable | Use 4f manual fallback; mark audit log `threadId: manual-fallback` |
+| Test gate fails 3x | Report errors, keep branch, STOP |
+| `check_gh_issue_mirror.sh` blocks tracker edit | Add `GH: #N` to the row's Notes column, retry |
+| `check_codex_audit_artifact.sh` blocks `gh pr merge` | Verify the audit log file exists at the expected path with valid frontmatter |
+| `check_terminal_status_evidence.sh` blocks tracker edit | Only fires for features (`VERIFIED`) — bug `FIXED` is not gated. If you hit it, you're flipping a feature row; write the evidence file |
 | Branch already exists | Ask user: reuse or rename |
+| Verification reveals a regression | Reopen the issue, file a new bug, do NOT close |

--- a/project.yml
+++ b/project.yml
@@ -55,8 +55,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 82
-        MARKETING_VERSION: 3.13.5
+        CURRENT_PROJECT_VERSION: 83
+        MARKETING_VERSION: 3.13.6
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3998,13 +3998,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 82;
+				CURRENT_PROJECT_VERSION = 83;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.13.5;
+				MARKETING_VERSION = 3.13.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4148,13 +4148,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 82;
+				CURRENT_PROJECT_VERSION = 83;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.13.5;
+				MARKETING_VERSION = 3.13.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

- Rewrite `.claude/commands/fix-issue.md` to align with current AGENTS.md and rules 40 / 47 / 24 / 10.
- Add Phase 6a Pre-FIXED verify, Phase 7 Version Bump, Phase 9 Post-Merge Finalizer (close-gate workflow with the three verification labels).
- Remove feature path entirely — redirect-only to `/feature-workflow` (rule 47 is binding, no waivers).
- Fix multi-issue parallel coordination (worktree-agents stop at Phase 6c; integrator owns 7-9).

## What Changed

- `.claude/commands/fix-issue.md`: 333 → 533 lines. Major restructure.
- `.claude/codex-audits/chore-skill-fix-issue-rewrite-audit.md`: new audit log artifact.
- `project.yml` + `vreader.xcodeproj/project.pbxproj`: version bump 3.13.5 → 3.13.6 (build 82 → 83).

## Codex Audit

Two rounds, 7 findings total, all fixed; final verdict: **ship-as-is**.

- Round 1: 1 Critical (feature-path opt-out), 2 High (evidence-file shape, multi-issue parallel collision), 2 Medium (tool names, FIXED-flip ordering), 1 Low (audit-log timing wording).
- Round 2: 1 Medium (residual M3 contradiction).
- Round 3: clean.

Audit log: `.claude/codex-audits/chore-skill-fix-issue-rewrite-audit.md`.

## Validation

- [x] Codex audit loop completed (3 iterations including verify; verdict: ship-as-is)
- [x] No Swift touched — `xcodebuild test` not run
- [x] Docs sync — n/a (skill rewrite is meta-process; rule 24 triggers don't apply)
- [x] Version bumped: 3.13.5 → 3.13.6 (build 82 → 83)

## Type of Change

- [x] Meta-process (slash command rewrite)