### PR TITLE
docs: bug #123 device-verification evidence

### DIFF
--- a/dev-docs/verification/bug-123-20260505.md
+++ b/dev-docs/verification/bug-123-20260505.md
@@ -1,0 +1,87 @@
+---
+kind: bug
+id: 123
+status_target: FIXED
+commit_sha: 935d93cb6c2ff06dc26e27ba7041d523217a4510
+app_version: 3.13.11 (88)
+date: 2026-05-05
+verifier: claude
+device_or_simulator: iPhone 17 Pro Simulator
+os_version: iOS 26.4
+build_configuration: Debug
+backend: n/a
+result: pass
+---
+
+# Bug #123 verification — DebugBridge URL scheme approval blocked first openurl
+
+## Acceptance criteria
+
+| # | Criterion | Observed | Pass |
+|---|-----------|----------|------|
+| 1 | Re-run the original repro from issue #243: `simctl openurl booted vreader-debug://reset` against a freshly-built merged-main app, with the grant script invoked once. | Handler fired. Log line: `2026-05-05 11:51:46.210506+0800 vreader: [com.vreader.app:DebugBridge] reset: removed 0 book(s)`. (0 because library was already empty from earlier testing — the handler still ran and reported the count.) | ✅ |
+| 2 | The grant script (`scripts/grant-debug-scheme-approval.sh`) is idempotent and writes the expected approval entry to the simulator's `schemeapproval.plist`. | `Granted: vreader-debug:// → com.vreader.app on 61149F0E-DC18-4BE2-BB37-52659F1F4F62`. Plist entry verified via `PlistBuddy Print` after run. | ✅ |
+| 3 | The verifier (`scripts/verify-debug-has-debugbridge.sh`) checks both bug #121 (bundle URL-scheme registration) and bug #123 (LaunchServices approval) gates. | `OK: vreader-debug URL scheme registered in Debug Info.plist` + `OK: 61149F0E…: vreader-debug pre-granted in LaunchServices` + `PASS: DebugBridge URL scheme is registered (bug #121) and pre-approved on all booted simulators (bug #123)`. Exit 0. | ✅ |
+| 4 | The grant script rejects path-traversal / shell-metachar UDID args. | `'../etc/passwd'` → exit 1 with "invalid UDID format" error. `'abc'"; rm -rf /tmp'` → same. Empty UDID → same. | ✅ |
+| 5 | The verifier returns exit 1 with a `Run:` hint when approval is missing on a booted simulator. | After deleting the approval entry: `WARN: 61149F0E…: vreader-debug not granted in LaunchServices (bug #123) / Run: scripts/grant-debug-scheme-approval.sh 61149F0E-...`. Exit 1. | ✅ |
+
+## Commands run
+
+Build merged main and install:
+
+```bash
+git checkout main && git pull
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build \
+    -project vreader.xcodeproj -scheme vreader \
+    -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+    -configuration Debug
+xcrun simctl install booted /path/to/vreader.app
+```
+
+Pre-grant approval and verify both gates:
+
+```bash
+scripts/grant-debug-scheme-approval.sh
+scripts/verify-debug-has-debugbridge.sh
+```
+
+Re-run the original bug #123 repro:
+
+```bash
+xcrun simctl spawn booted log stream --predicate 'process == "vreader"' --level=debug > /tmp/sim-log-final-verify.txt 2>&1 &
+xcrun simctl launch booted com.vreader.app
+xcrun simctl openurl booted "vreader-debug://reset"
+# Watch for: vreader: [com.vreader.app:DebugBridge] reset: removed N book(s)
+```
+
+Adversarial smoke tests of grant script:
+
+```bash
+scripts/grant-debug-scheme-approval.sh "../etc/passwd"            # rejected
+scripts/grant-debug-scheme-approval.sh "abc'\"; rm -rf /tmp"     # rejected
+scripts/grant-debug-scheme-approval.sh ""                         # rejected
+scripts/grant-debug-scheme-approval.sh "00000000-0000-0000-0000-000000000000"  # device dir not found
+```
+
+Verifier with approval missing:
+
+```bash
+/usr/libexec/PlistBuddy -c "Delete :'com.apple.CoreSimulator.CoreSimulatorBridge-->vreader-debug'" \
+    "$HOME/Library/Developer/CoreSimulator/Devices/<UDID>/data/Library/Preferences/com.apple.launchservices.schemeapproval.plist"
+scripts/verify-debug-has-debugbridge.sh
+# → exit 1 + Run: hint
+```
+
+## Observations
+
+- Once the approval entry is in place, subsequent `simctl openurl` calls bypass the prompt entirely — the handler fires within ~3ms (`11:51:46.207 openurl request → 11:51:46.210 handler log`).
+- The approval entry survives `simctl install` (binary replacement preserving user data), confirming it's not bundle-scoped.
+- The verifier is now the single command an automated harness can run before a verification batch — it tells the operator exactly which simulator needs the grant script and prints the exact command to run.
+- Pre-existing test failures (FoliateViewCoordinator, HighlightIntegration, PerBookSettings, SchemaV1, TOCChapterProgress, TXTBridgeShared, TXTChapterContentLoader) are unrelated to this fix and existed before this branch — none touch `VReaderApp.swift`, `VReaderAppDelegate.swift`, or the new scripts.
+
+## Artifacts
+
+- Codex audit log: `.claude/codex-audits/fix-issue-243-debugbridge-onopenurl-handler-audit.md`
+- Live log capture from successful repro: `/tmp/sim-log-final-verify.txt` (ephemeral; the grep'd `DebugBridge:` line is quoted in criterion 1 above)
+- PR: #246 (squash-merged to main)
+- Tag: `v3.13.11` on commit `935d93cb`


### PR DESCRIPTION
## Summary

Add `dev-docs/verification/bug-123-20260505.md` — device-verification evidence file required by the close gate for bug #123 (GH #243). Re-runs the original repro against the merged-main v3.13.11 build with the grant script invoked once; handler fires correctly, both verifier gates pass, adversarial smoke tests reject malformed UDIDs.

Result: **pass**.

Refs #243

## Type of Change

- [x] Documentation (verification evidence — required by AGENTS.md "Close gate — verified, not just merged")