### PR TITLE
refactor(#44): remove dead notImplemented helper from RealDebugBridgeContext

### DIFF
--- a/.claude/codex-audits/refactor-44-remove-dead-notimplemented-helper-audit.md
+++ b/.claude/codex-audits/refactor-44-remove-dead-notimplemented-helper-audit.md
@@ -1,0 +1,52 @@
+---
+branch: refactor/44-remove-dead-notimplemented-helper
+threadId: manual-fallback
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-06
+---
+
+## Manual audit evidence
+
+Tiny dead-code removal. Manual audit performed.
+
+### Files read
+
+- `vreader/Services/DebugBridge/RealDebugBridgeContext.swift` (changed) — full file. Was 247 lines, now 240.
+- All references to `notImplemented` across `vreader/` and `vreaderTests/` (5 hits — see grep below).
+
+### What was removed
+
+Lines 129–134 (now removed):
+
+```swift
+// MARK: - Stubs (filled in by later WI-5 commits)
+
+private func notImplemented(_ command: String) -> Error {
+    log.notice("\(command, privacy: .public): not yet implemented")
+    return DebugBridgeContextError.notImplemented(command: command)
+}
+```
+
+Plus the now-orphaned `// MARK:` heading.
+
+### Why dead
+
+- The helper function was added in feature #44 WI-5 as a placeholder for stubbed commands ("filled in by later WI-5 commits").
+- All 7 commands (reset, seed, open, theme, settle, snapshot, eval) shipped without ever calling this helper. Each command directly returned a typed error or wrote a sentinel.
+- Cross-module grep confirms zero call sites: 5 hits for `notImplemented` are split between the enum case `.notImplemented(command:)` (still used by error-string mapping in `DebugBridge.swift:99` and the test in `DebugBridgeTests.swift:110-111`) and the now-removed helper. The enum case stays — it's still wire-compatible if a future stubbed command needs to be added.
+
+### What I deliberately did NOT change
+
+- `DebugBridgeContextError.notImplemented(command: String)` enum case — still used by error mapping. Removing it would require updating `DebugBridge.swift` and the test. Out of scope.
+- `bridge.notImplemented:` error string format — same reasoning.
+
+### Edge cases checked
+
+- **Test impact**: full DebugBridge test suite (38 tests) still passes post-removal.
+- **Build impact**: clean build succeeded.
+- **LOC impact**: main file 247 → 240 lines (still under 300, criterion (g) preserved).
+
+### Verdict
+
+**ship-as-is**. 7-line dead-code removal. Behavior unchanged. No new abstractions, no risk.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 103
-        MARKETING_VERSION: 3.13.26
+        CURRENT_PROJECT_VERSION: 104
+        MARKETING_VERSION: 3.13.27
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4026,13 +4026,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.13.26;
+				MARKETING_VERSION = 3.13.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4176,13 +4176,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.13.26;
+				MARKETING_VERSION = 3.13.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/DebugBridge/RealDebugBridgeContext.swift
+++ b/vreader/Services/DebugBridge/RealDebugBridgeContext.swift
@@ -126,13 +126,6 @@ final class RealDebugBridgeContext: DebugBridgeContext {
     /// can read it without an isolation hop.
     nonisolated static let fixtureBundleSubdirectory = "DebugFixtures"
 
-    // MARK: - Stubs (filled in by later WI-5 commits)
-
-    private func notImplemented(_ command: String) -> Error {
-        log.notice("\(command, privacy: .public): not yet implemented")
-        return DebugBridgeContextError.notImplemented(command: command)
-    }
-
     /// Verify the book exists and post a notification for LibraryView to
     /// push it onto the navigation stack. Throws `bookNotFound` if no book
     /// in the library has the given fingerprint key.


### PR DESCRIPTION
## Summary

Tiny dead-code removal. Helper \`private func notImplemented(_ command:)\` was a WI-5 placeholder that all 7 DebugBridge commands shipped without ever calling. Cross-module grep finds zero call sites. The enum case \`DebugBridgeContextError.notImplemented(command:)\` stays (still used by error-string mapping).

Refs #244

## What Changed

- \`vreader/Services/DebugBridge/RealDebugBridgeContext.swift\` — removed 7 lines (helper + orphaned MARK heading).
- Version bump 3.13.26 → 3.13.27.

Main file: 247 → 240 lines.

## Codex Audit

Manual-fallback. Audit log: \`.claude/codex-audits/refactor-44-remove-dead-notimplemented-helper-audit.md\`. Verdict: ship-as-is.

## Validation

- [x] Smoke build PASS.
- [x] All 38 DebugBridge tests pass post-removal.
- [x] Cross-module grep confirms helper had zero call sites.
- [x] Enum case + error-string format preserved.

## Type of Change

- [x] Refactor / dead-code removal (Refs #244)