### PR TITLE
refactor: consolidate FoliateTTSAdapter.escapeForJS into FoliateJSEscaper

### DIFF
--- a/.claude/codex-audits/refactor-consolidate-foliatets-jsescape-audit.md
+++ b/.claude/codex-audits/refactor-consolidate-foliatets-jsescape-audit.md
@@ -1,0 +1,39 @@
+---
+branch: refactor/consolidate-foliatets-jsescape
+threadId: manual-fallback
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-06
+---
+
+## Manual audit evidence
+
+Follow-up consolidation to bug #135. Manual audit performed.
+
+### Files changed
+
+| File | Change |
+|---|---|
+| `vreader/Services/Foliate/FoliateTTSAdapter.swift` | Two call sites delegate to `FoliateJSEscaper.escapeForJSString`; the private duplicate `escapeForJS` removed. |
+
+### Why fix
+
+Same incomplete-escape pattern as bug #135 (which fixed the EPUB-side `jsEscape`). `FoliateTTSAdapter.escapeForJS` covered only `\\`, `'`, `\n`, `\r` — missing `\t`, U+2028, U+2029.
+
+Inputs to `initTTSJS` (granularity: "word"/"sentence") and `setMarkJS` (numeric string from Intl.Segmenter) are constrained today, so this is **not an active vulnerability** — purely consolidation against a future change that might pass user-controlled input through these helpers.
+
+### What I deliberately did NOT change
+
+- The two function signatures (`initTTSJS`, `setMarkJS`).
+- The interpolation patterns (single-quoted JS strings).
+- Existing tests: `FoliateTTSAdapterTests` continues to pass; assertions don't depend on which characters get escaped.
+
+### Edge cases checked
+
+- **Build**: clean.
+- **Tests**: `FoliateTTSAdapterTests` passes unchanged.
+- **Other call sites of removed `escapeForJS`**: grep returned only the two `static func ...JS` sites within the same file. Both updated.
+
+### Verdict
+
+**ship-as-is**. Two-line consolidation + 1-block deletion. No behavior change for current inputs (constrained); strict superset of escapes for any future input.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 112
-        MARKETING_VERSION: 3.14.3
+        CURRENT_PROJECT_VERSION: 113
+        MARKETING_VERSION: 3.14.4
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4026,13 +4026,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 112;
+				CURRENT_PROJECT_VERSION = 113;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.3;
+				MARKETING_VERSION = 3.14.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4176,13 +4176,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 112;
+				CURRENT_PROJECT_VERSION = 113;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.3;
+				MARKETING_VERSION = 3.14.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Foliate/FoliateTTSAdapter.swift
+++ b/vreader/Services/Foliate/FoliateTTSAdapter.swift
@@ -32,7 +32,7 @@ enum FoliateTTSAdapter {
     /// - Parameter granularity: Segmentation level ("word" or "sentence").
     /// - Returns: JavaScript string to evaluate in WKWebView.
     static func initTTSJS(granularity: String) -> String {
-        let escaped = escapeForJS(granularity)
+        let escaped = FoliateJSEscaper.escapeForJSString(granularity)
         return "readerAPI.initTTS('\(escaped)')"
     }
 
@@ -58,7 +58,7 @@ enum FoliateTTSAdapter {
     /// - Parameter mark: The mark name (numeric string from Intl.Segmenter).
     /// - Returns: JavaScript string to evaluate in WKWebView.
     static func setMarkJS(mark: String) -> String {
-        let escaped = escapeForJS(mark)
+        let escaped = FoliateJSEscaper.escapeForJSString(mark)
         return "readerAPI.tts.setMark('\(escaped)')"
     }
 
@@ -78,15 +78,12 @@ enum FoliateTTSAdapter {
 
     // MARK: - Private Helpers
 
-    /// Escape a string for safe embedding in a single-quoted JS string literal.
-    /// Handles backslashes, single quotes, and newlines.
-    private static func escapeForJS(_ value: String) -> String {
-        value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "'", with: "\\'")
-            .replacingOccurrences(of: "\n", with: "\\n")
-            .replacingOccurrences(of: "\r", with: "\\r")
-    }
+    // Note: prior in-file `escapeForJS` removed in favor of the shared
+    // `FoliateJSEscaper.escapeForJSString` (single source of truth, also
+    // covers `\t`, U+2028, U+2029 — see bug #135 for the EPUB-side fix
+    // that established this pattern). Inputs to `initTTSJS` and
+    // `setMarkJS` are constrained today, so this is consolidation rather
+    // than an active vulnerability fix.
 
     /// Parse a single mark dictionary into a FoliateTTSMark.
     /// Returns nil if any required field is missing or has wrong type.


### PR DESCRIPTION
## Summary

Follow-up to bug #135. Same incomplete-escape pattern was hiding in \`FoliateTTSAdapter.escapeForJS\` (covers \`\\\\\`, \`'\`, \`\\n\`, \`\\r\`; misses \`\\t\`, U+2028, U+2029).

Inputs to its two call sites (\`initTTSJS\` granularity = \"word\"/\"sentence\", \`setMarkJS\` numeric mark string) are constrained today, so this is **not an active vulnerability** — purely consolidation against a future change that passes user-controlled input through these helpers.

## What Changed

- \`vreader/Services/Foliate/FoliateTTSAdapter.swift\`: both call sites delegate to \`FoliateJSEscaper.escapeForJSString\`; private duplicate \`escapeForJS\` removed.
- Version bump 3.14.3 → 3.14.4.

## Codex Audit

Manual-fallback. Audit log: \`.claude/codex-audits/refactor-consolidate-foliatets-jsescape-audit.md\`. Verdict: ship-as-is.

## Validation

- [x] Smoke build PASS.
- [x] All FoliateTTSAdapterTests pass unchanged.
- [x] Grep confirmed `escapeForJS` had only two callers in the file; both updated.

## Type of Change

- [x] Refactor / consolidation (follow-up to bug #135)