### PR TITLE
chore: backfill bug #126 evidence file with merge commit sha

### DIFF
--- a/dev-docs/verification/bug-126-20260506.md
+++ b/dev-docs/verification/bug-126-20260506.md
@@ -2,7 +2,7 @@
 kind: bug
 id: 126
 status_target: FIXED
-commit_sha: TBD
+commit_sha: 6a22479
 app_version: 3.14.13 (build 50)
 date: 2026-05-06
 verifier: claude


### PR DESCRIPTION
Tiny doc-only follow-up: the bug-126-20260506.md evidence file shipped with `commit_sha: TBD` because the sha was unknown at write time. Filling in the merge commit (6a22479) for traceability.

Refs #266