### PR TITLE
fix(commands): quote YAML description + clarify Phase 3 in file-bug/file-feature

### DIFF
--- a/.claude/commands/file-bug.md
+++ b/.claude/commands/file-bug.md
@@ -1,5 +1,5 @@
 ---
-description: Create a GH issue for a bug row in docs/bugs.md and stamp `GH: #N` into its Notes column
+description: "Create a GH issue for a bug row in docs/bugs.md and stamp `GH: #N` into its Notes column"
 argument-hint: "<bug-id>"
 ---
 
@@ -76,12 +76,16 @@ Capture the issue URL from stdout. Extract the issue number (last path segment o
 
 ## Phase 3 — Update the row
 
-Use the `Edit` tool to add `GH: #<issue-number>` to the row's Notes column. Two patterns to handle:
+Use the `Edit` tool to insert `GH: #<issue-number>` into the row's Notes column. Markdown table rows end with `|`, so the insertion always goes **before the trailing `|`**, separated from prior content by exactly one space.
 
-a. Notes ends with content (typical): append ` GH: #<N>` (with leading space).
-b. Notes ends with `|` and trailing whitespace: insert ` GH: #<N>` before the trailing `|`.
+The Edit's `old_string` is the original full row line. The `new_string` is the same line with `GH: #<N>` inserted into the Notes cell.
 
-The Edit's `old_string` should be the original full row line. The `new_string` is the same line with `GH: #<N>` appended in the Notes cell.
+Two surface patterns (both yield the same outcome — the only difference is what whitespace already exists before the trailing `|`):
+
+a. **Notes ends with non-space content** (typical): `... existing notes |` → `... existing notes GH: #<N> |` (one leading space before `GH:`).
+b. **Notes already has trailing whitespace before the `|`**: `... existing notes   |` → `... existing notes GH: #<N> |` (collapse the run of trailing spaces to one).
+
+Never put `GH: #<N>` after the trailing `|` — that puts it outside the table cell and the mirror hook won't see it.
 
 The `check_gh_issue_mirror.sh` PreToolUse hook will allow this edit because the new content carries `GH: #N`.
 

--- a/.claude/commands/file-feature.md
+++ b/.claude/commands/file-feature.md
@@ -1,5 +1,5 @@
 ---
-description: Create a GH issue for a feature row in docs/features.md and stamp `GH: #N` into its Notes column
+description: "Create a GH issue for a feature row in docs/features.md and stamp `GH: #N` into its Notes column"
 argument-hint: "<feature-id>"
 ---
 
@@ -66,10 +66,28 @@ Capture URL + extract issue number. Same failure-mode handling as `/file-bug` (n
 
 ## Phase 3 — Update the row
 
-Use the `Edit` tool to add `GH: #<issue-number>` to the Notes column. The `check_gh_issue_mirror.sh` PreToolUse hook will allow this edit because the new content carries `GH: #N`.
+Use the `Edit` tool to insert `GH: #<issue-number>` into the row's Notes column. Markdown table rows end with `|`, so the insertion always goes **before the trailing `|`**, separated from prior content by exactly one space.
 
-**Failure mode — issue created, row update failed**:
-Print the URL + the exact row line the user needs to write, exit nonzero.
+The Edit's `old_string` is the original full row line. The `new_string` is the same line with `GH: #<N>` inserted into the Notes cell.
+
+Two surface patterns (both yield the same outcome — the only difference is what whitespace already exists before the trailing `|`):
+
+a. **Notes ends with non-space content** (typical): `... existing notes |` → `... existing notes GH: #<N> |` (one leading space before `GH:`).
+b. **Notes already has trailing whitespace before the `|`**: `... existing notes   |` → `... existing notes GH: #<N> |` (collapse the run of trailing spaces to one).
+
+Never put `GH: #<N>` after the trailing `|` — that puts it outside the table cell and the mirror hook won't see it.
+
+The `check_gh_issue_mirror.sh` PreToolUse hook will allow this edit because the new content carries `GH: #N`.
+
+**Failure mode — issue created but row update failed**:
+This is the dangerous case. Print:
+```
+GH issue #<N> created at <URL>, but failed to update docs/features.md row.
+Manually add `GH: #<N>` to the Notes column of feature #<id>:
+
+  | <id> | ... | <status> | <existing notes> GH: #<N> |
+```
+Exit nonzero so the user sees the partial success.
 
 ## Phase 4 — Report
 

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 150
-        MARKETING_VERSION: 3.14.41
+        CURRENT_PROJECT_VERSION: 151
+        MARKETING_VERSION: 3.14.42
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4038,13 +4038,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 150;
+				CURRENT_PROJECT_VERSION = 151;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.41;
+				MARKETING_VERSION = 3.14.42;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4188,13 +4188,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 150;
+				CURRENT_PROJECT_VERSION = 151;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.41;
+				MARKETING_VERSION = 3.14.42;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

Two corrections to `.claude/commands/file-bug.md` and `.claude/commands/file-feature.md`:

1. **YAML frontmatter parse error** — `description: ... GH: #N ...` was unquoted, so YAML parsed `GH:` as a nested mapping key and rejected the file with `mapping values are not allowed in this context at line 1 column 75`. Fixed by double-quoting both descriptions.
2. **Phase 3 wording / parity** — file-bug's "append" was ambiguous (could be misread as appending after the row's trailing `|`), and file-feature's Phase 3 was a 2-line stub. Both now share parallel detail: explicit "before the trailing `|`" rule, two surface patterns (a/b for trailing-whitespace handling), an anti-pattern warning, and the full partial-success failure-mode block.

## Validation

- Ruby YAML.load parses both frontmatter blocks cleanly.
- Phase 3 sections diff-clean except for bug/feature noun + tracker filename.

## Type of Change

- [x] Bug fix (slash command frontmatter, broke `/file-bug` and `/file-feature`)
- [x] Documentation refinement (Phase 3 clarity + parity)