### PR TITLE
feat(skills): mirror 4 orchestration commands as auto-trigger skills

### DIFF
--- a/.claude/skills/feature-workflow/SKILL.md
+++ b/.claude/skills/feature-workflow/SKILL.md
@@ -1,0 +1,644 @@
+---
+name: feature-workflow
+description: "Run the binding 6-gate feature workflow end-to-end per rule 47 (Plan → Independent Plan Audit → TDD Implementation → Implementation Audit Loop → Device/Integration Verification → Merge). Use this skill whenever the user wants to implement a new feature in vreader, asks 'implement feature #N', 'work on feature 47', 'start the feature workflow', 'plan + build feature X', or describes building a new capability that doesn't yet exist. NOT for fixing broken implementations (that's fix-issue). The skill drives the row from `TODO` → `VERIFIED` through six gates that must never be skipped — author/auditor separation, evidence files, hook compliance are all binding."
+---
+
+# Feature Workflow (rule 47, six gates, never skip one)
+
+Drives a feature from `TODO` → `VERIFIED` through the binding 6-gate
+sequence in `.claude/rules/47-feature-workflow.md`:
+
+> Plan → Independent Plan Audit → TDD Implementation → Implementation
+> Audit Loop → Device/Integration Verification → Merge → (close gate)
+
+Each gate has an explicit **required artifact**, **author/auditor
+separation rule**, **tracker status transition**, **blocking hook**,
+and **exit criteria**. You don't enter the next gate until the current
+gate's exit criteria are met. Multiple iterations within a gate are
+normal.
+
+## Input
+
+Parse the user's request to extract a feature identifier — either a numeric id from
+`docs/features.md` (e.g. `48`) or a short slug (e.g. `materializing-restore`). If
+the user did not name a feature, list `TODO`/`PLANNED` candidates from `docs/features.md`
+and ask the user to pick.
+
+`$ARGUMENTS` is the feature identifier — either a numeric id from
+`docs/features.md` (e.g. `48`) or a short slug (e.g.
+`materializing-restore`). If empty, list `TODO`/`PLANNED` candidates
+from `docs/features.md` and ask the user to pick.
+
+## Scope guard — read this first
+
+This skill is for **features only** (capabilities never implemented).
+If the work is fixing a broken implementation, stop here and use
+`/fix-issue`. The bug-vs-feature distinction is binding per AGENTS.md;
+running a fix through this skill skips the bug-tracker workflow.
+
+## Hooks you'll trip
+
+| Hook | Triggers when | What it requires |
+|---|---|---|
+| `check_gh_issue_mirror.sh` | `Edit/Write/MultiEdit` on `docs/features.md` | mirror-required rows (`PLANNED`/`IN PROGRESS`/`DONE`/`VERIFIED`) must have `GH: #N` in Notes column |
+| `check_terminal_status_evidence.sh` | tracker flip to `VERIFIED` on `docs/features.md` | matching `dev-docs/verification/feature-<id>-<YYYYMMDD>.md` evidence file with valid frontmatter |
+| `check_codex_audit_artifact.sh` | `gh pr merge` on a Swift-touching PR | `.claude/codex-audits/<branch>-audit.md` with `final_verdict` ∈ {ship-as-is, follow-up-recommended} |
+
+Plan around them; do not bypass.
+
+## Pre-flight Checks
+
+1. **Resolve target**: parse `$ARGUMENTS` to a feature row in
+   `docs/features.md`. Read the row + any sub-section plan.
+2. **Working tree**: `git status --porcelain`. If dirty, isolate work
+   on a branch; do not revert unrelated changes.
+3. **Branch / sync**: `git fetch origin`. Confirm `main` is current.
+4. **Tracker baseline**: note the current row status. The skill's
+   transitions assume a starting status of `TODO` or `PLANNED`.
+   If already `IN PROGRESS`, resume at the appropriate gate.
+5. **Bug-vs-feature sanity check**: re-confirm this is a feature
+   (capability never implemented), not a bug (broken implementation).
+   If it's a bug → STOP, redirect to `/fix-issue`.
+
+---
+
+# Gate 1 — Plan
+
+| Field | Value |
+|---|---|
+| Required artifact | `dev-docs/plans/YYYYMMDD-feature-<id>-<slug>.md` with all required sections (see below) |
+| Owner / auditor | Author = orchestrator (or Planner subagent). No auditor — that's Gate 2. |
+| Status transition | row stays `TODO` until Gate 2 passes; then → `PLANNED` |
+| Blocking hook | `check_gh_issue_mirror.sh` fires on the `PLANNED` flip (must have `GH: #N` in row Notes; create the issue here) |
+| Exit criteria | Plan file exists at the documented path with all required sections filled in |
+
+**Required artifact**: `dev-docs/plans/YYYYMMDD-feature-<id>-<slug>.md`.
+
+**Required content** (rule 47 + features.md plan template):
+
+- **Problem** — user need this addresses (mirror or refine row's `Problem`).
+- **Surface area** — file-by-file with concrete signatures: which
+  protocols, types, methods get added or modified. Include a "files
+  OUT of scope" subsection.
+- **Prior art / project precedent / rejected alternatives** — what
+  existing patterns we're building on, what was considered and
+  rejected, and why. Research is part of the plan, not a separate
+  step.
+- **Work-item sequencing** — small, testable units (typically 1–15
+  WIs). Each WI is one PR's worth of work. Estimate PR size per WI.
+  **Mark each WI as foundational or behavioral** (see Gate 5).
+- **Test catalogue** — concrete test files, what each covers,
+  including audit-driven additions (corruption, partial failure,
+  idempotency edge cases).
+- **Risks + mitigations** — known unknowns and how we'll handle them.
+- **Backward compat** — what happens to existing data / older clients
+  / older backups when this ships.
+
+**Author**: this skill's orchestrator (or a Planner subagent).
+
+**Status transition**: row stays at `TODO` until Gate 2 passes; only
+then move to `PLANNED`. Per the mirror rule, `PLANNED` triggers GH
+issue creation if not already mirrored — `gh issue create` for
+`Feature #N: <summary>` with the `enhancement` label, then stamp
+`GH: #M` into the row's Notes column.
+
+**Exit criteria**: plan file exists at the documented path with all
+required sections filled in. Ready for independent audit.
+
+---
+
+# Gate 2 — Independent Plan Audit
+
+| Field | Value |
+|---|---|
+| Required artifact | Audit verdict captured inline in the plan file's revision history (Codex thread + rounds + verdict), OR a `Manual Audit Evidence` section when AI auditor unavailable |
+| Owner / auditor | Author = Gate 1 author. Auditor = **DIFFERENT agent context** (Codex MCP default, or fresh subagent with read-only sandbox + "audit, don't implement" framing). Author/auditor separation is mandatory per rule 48 |
+| Status transition | row → `PLANNED` only after this gate passes; that flip triggers GH issue creation if not already mirrored |
+| Blocking hook | `check_gh_issue_mirror.sh` on the `PLANNED` flip |
+| Exit criteria | Zero open Critical/High/Medium findings; Low findings fixed or accepted with rationale; **max 3 audit rounds** (escalate to user if not clean by round 3) |
+
+**Required artifact**: Codex (or equivalent independent agent) audit
+verdict captured inline in the plan file's revision history, OR a
+`Manual Audit Evidence` section if the AI auditor is unavailable.
+
+**Author/auditor separation**: the agent that wrote the plan must
+**not** audit it. Codex MCP being a separate process satisfies this
+by default. If a future setup runs everything through one agent, this
+gate requires invoking a different model/context boundary explicitly
+(e.g., a fresh subagent with read-only sandbox + explicit
+"audit, don't implement" framing). See `.claude/rules/48-parallel-execution.md`.
+
+## 2a. Codex MCP availability test
+
+Before the real audit, send a short ping:
+
+```
+mcp__plugin_codex-toolkit_codex__codex with:
+  prompt: "Respond with 'ok' if you can read this."
+```
+
+If Codex does not respond, skip to **2c. Manual fallback**.
+
+## 2b. Audit prompt (Codex available)
+
+```
+mcp__plugin_codex-toolkit_codex__codex with:
+  sandbox: read-only
+  prompt: |
+    Audit `dev-docs/plans/<plan-file>.md` for feature #<id>: <title>.
+
+    Focus areas — be direct, contradict if I'm wrong:
+    1. Model assumption verification — do the SwiftData fields, enum
+       cases, function signatures, file paths the plan names actually
+       exist in the current codebase? (This catches the largest class
+       of pre-implementation bugs.)
+    2. Risks + missing edge cases — what failure modes the plan misses.
+    3. Protocol signature critique — are new interfaces well-shaped,
+       or do they leak implementation concerns?
+    4. Concurrency hazards — actor isolation, Sendable, race conditions
+       in mutable state, @MainActor correctness.
+    5. Cohesion check — is the WI split right, or are some WIs too big
+       or too small?
+    6. Foundational-vs-behavioral classification — is each WI's tier
+       correct? (Foundational = DTOs/protocols/utilities, no user-observable
+       behavior. Behavioral = anything that changes app behavior, persistence,
+       networking, backup format, reader rendering, or UI flow.)
+
+    Report findings as: file:line | severity (Critical/High/Medium/Low) | issue | fix
+```
+
+## 2c. Manual fallback (Codex unavailable)
+
+Add a `Manual Audit Evidence` section to the plan with:
+- **Files read** (paths)
+- **Symbols / signatures verified** (which fields/types/enums you confirmed exist)
+- **Edge cases checked** (the list)
+- **Risks accepted** (with rationale)
+- **Tests added or intentionally deferred**
+
+Manual fallback is allowed only when the independent audit tool is
+genuinely unavailable, not just inconvenient. The audit step is
+non-negotiable; manual fallback is an evidence-bearing alternative.
+
+## 2d. Loop or exit
+
+Author rewrites the plan to address findings; auditor re-reviews.
+Track audit rounds in the plan's revision history.
+
+**Exit criteria**:
+- Zero open Critical/High/Medium findings.
+- Low findings either fixed or explicitly accepted with rationale in
+  the plan's "Known limitations" or "Audit fixes applied" section.
+- **Maximum 3 audit rounds.** If unresolved findings remain after
+  round 3, STOP and escalate to the user — accept, defer, or redesign.
+
+**Status transition**: row → `PLANNED` (mirror rule fires; create GH
+issue if not present, stamp `GH: #N` in Notes).
+
+> **Hard dependency**: Gate 3 cannot start on an unaudited plan.
+> Skipping Gate 2 and starting TDD anyway is the most likely failure
+> mode here. Don't.
+
+---
+
+# Gate 3 — TDD Implementation (per Work Item)
+
+| Field | Value |
+|---|---|
+| Required artifact | Per WI: failing test (RED), minimal impl (GREEN), refactored code (REFACTOR), per-WI PR with audit log + version bump |
+| Owner / auditor | Author = implementer (the agent driving this skill or a TDD-implementer subagent). The Codex audit *of this WI's PR* is **Gate 4**, with auditor != implementer. |
+| Status transition | When WI-1's PR opens, row → `IN PROGRESS` |
+| Blocking hook | `check_codex_audit_artifact.sh` blocks `gh pr merge` without audit log; `check_gh_issue_mirror.sh` blocks tracker edits without `GH: #N` |
+| Exit criteria | Per WI: tests green, Gate 4 audit clean, docs sync committed if triggered, version bump committed, PR opened with the right reference convention. **Gate 3 cannot start on an unaudited plan** — Gate 2 must have passed first |
+
+**Status transition**: when WI-1's PR opens, row → `IN PROGRESS`.
+
+For each Work Item, run the per-WI inner loop:
+
+## 3a. Branch + WI scaffold
+
+- Branch: `feat/feature-<id>-wi-<n>-<slug>` off `main`.
+- (No tracker move yet — already at `IN PROGRESS` from WI-1's PR.)
+
+## 3b. RED → GREEN → REFACTOR
+
+Per `.claude/rules/10-tdd.md`:
+1. **RED** — write a failing test that captures the WI's behavior.
+   - SwiftData boundary → persistence test with in-memory container
+   - WKWebView bridge → parser/coordinator unit test
+   - ViewModel → Swift Testing async test with `@MainActor`
+   - Pure utility → parameterized `@Test(arguments:)`
+2. **GREEN** — minimal implementation to make the test pass.
+3. **REFACTOR** — clean up without changing behavior. Tests stay green.
+
+Codebase conventions: see `.claude/rules/50-codebase-conventions.md`.
+File-size guideline: ~300 lines max.
+
+## 3c. Test gate
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
+  -project vreader.xcodeproj -scheme vreader \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:vreaderTests
+```
+
+Pass → continue. Fail → fix and retry. 3 failures → stop, report.
+
+> **Note**: `xcodebuild` CLI builds to a different DerivedData than
+> Xcode's Run button. **Never use `simctl uninstall`** — wipes user
+> data. Use `simctl install` to replace the binary.
+
+## 3d. Gate 4 — Implementation Audit (per-WI, inline)
+
+| Field | Value |
+|---|---|
+| Required artifact | `.claude/codex-audits/<branch>-audit.md` with valid frontmatter (branch, threadId, rounds, final_verdict, date) |
+| Owner / auditor | Author = WI implementer. Auditor = Codex MCP (or fresh subagent). Author/auditor separation per rule 48 |
+| Status transition | none — row stays `IN PROGRESS` |
+| Blocking hook | `check_codex_audit_artifact.sh` blocks `gh pr merge` without this file |
+| Exit criteria | Zero open Critical/High/Medium findings; **max 3 audit rounds** (escalate to user if not clean by round 3) |
+
+This is the same audit shape as `/fix-issue` Phase 4. Runs against the
+WI's PR before merge.
+
+### Collect changed files
+
+```bash
+git diff main --name-only
+git diff main
+```
+
+### Codex audit
+
+Same availability test as Gate 2a. If Codex available:
+
+```
+mcp__plugin_codex-toolkit_codex__codex with:
+  sandbox: read-only
+  prompt: |
+    Audit these files changed for feature #<id> WI-<n>: <title>
+    Files: {changed file list}
+    Diff summary: {git diff main --stat}
+    Focus:
+    1. Correctness vs the plan — does this WI deliver what the plan promised?
+    2. Edge cases — boundary conditions, nil, Unicode/CJK, concurrent access
+    3. Security — JS/CSS injection in evaluateJavaScript() and WKWebView bridges
+    4. Duplicate code — repeated logic that should be unified
+    5. Dead code — unused imports, unreachable branches, orphaned functions
+    6. Shortcuts & patches — workarounds, TODO markers, band-aids
+    7. VReader compliance — Swift 6 concurrency, @MainActor correctness,
+       SwiftData actor isolation, file size <300 lines
+    8. Bridge safety — FoliateJSEscaper used for all JS interpolation,
+       message parser handles edge cases
+    Report as: file:line | severity (Critical/High/Medium/Low) | issue | fix
+```
+
+Fix every finding. Then `mcp__plugin_codex-toolkit_codex__codex-reply`
+on the same thread to verify.
+
+If Codex unavailable: manual mini-audit (same dimensions 1–8, written
+into the audit log artifact with `threadId: manual-fallback`).
+
+### Audit log artifact (required before merge)
+
+Path: `.claude/codex-audits/<branch-with-slashes-replaced-by-hyphens>-audit.md`
+
+Frontmatter:
+
+```markdown
+---
+branch: <current branch name, exactly as `git branch --show-current` returns>
+threadId: <Codex MCP thread id>      # OR `manual-fallback`
+rounds: <integer ≥ 1>
+final_verdict: ship-as-is | follow-up-recommended | block-recommended
+date: YYYY-MM-DD
+---
+```
+
+Body:
+- Per-round findings (file:line | severity | issue | fix).
+- Resolution note for each finding (fixed / accepted / deferred).
+- Summary verdict statement.
+- Manual fallback section if applicable.
+
+Commit the audit log alongside the WI changes (own commit or folded
+into the relevant fix commit).
+
+**Exit criteria**: zero open Critical/High/Medium findings. **Max 3
+rounds** for this WI's audit; after round 3 escalate.
+
+## 3e. Docs sync (if triggered, before version bump)
+
+Per `.claude/rules/24-doc-sync.md`:
+
+| If this WI touched | Update |
+|---|---|
+| New service / actor / `@Model` / `Notification.Name` / cross-feature pattern | `docs/architecture.md` |
+| User-visible behavior, tech stack, requirements, setup, ≥5-row tracker change | `README.md` |
+| Otherwise | nothing |
+
+If updates needed: own commit (`docs: update architecture.md for
+feature #<id> WI-<n>`) **before** the version bump.
+
+## 3f. Version bump (mandatory)
+
+Per `.claude/rules/40-version-bump.md` — every WI's PR ends with one.
+
+```bash
+# Edit project.yml: bump MARKETING_VERSION + increment CURRENT_PROJECT_VERSION
+xcodegen generate
+grep -E "MARKETING_VERSION|CURRENT_PROJECT_VERSION" project.yml
+grep -E "MARKETING_VERSION =|CURRENT_PROJECT_VERSION =" vreader.xcodeproj/project.pbxproj
+
+# Smoke build
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build \
+    -project vreader.xcodeproj -scheme vreader \
+    -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+
+git add project.yml vreader.xcodeproj/project.pbxproj
+git commit -m "chore: bump version to X.Y.Z"
+```
+
+**Bump tier (deterministic per WI):**
+
+| WI tier | Bump |
+|---|---|
+| Foundational (no user-observable change) | `patch` |
+| Behavioral but not the final WI | `patch` |
+| Final WI of the feature (completes user-visible behavior) | `minor` (or `major` if the feature is a breaking change) |
+
+Every PR merge produces a tag — see Gate 6's tag step. The tag count
+across a multi-WI feature ≈ the WI count, because every PR carries a
+mandatory version bump per rule 40.
+
+## 3g. PR
+
+**Reference convention** (binding, derived from AGENTS.md merge gate):
+
+- **Intermediate WI PRs** (every WI except the final one): use plain
+  prose like `Part of feature #<feature-gh-issue>` in the body. **Do
+  NOT** use `Refs #N` or `Fixes #N` magic words. Reason: the merge
+  gate ("a PR that references an open feature does not merge until
+  the feature reaches `DONE`") would otherwise block every
+  intermediate WI's merge and force one giant PR. Plain prose
+  cross-links the PR to the feature without tripping the gate.
+- **Final WI PR** (the one whose merge brings the feature to `DONE`):
+  use `Refs #<feature-gh-issue>`. **Never** `Fixes #N` — the GH issue
+  stays open until Gate 5b post-merge acceptance lands; auto-close
+  is wrong here.
+
+```bash
+gh pr create --title "feat(#<feature-id> WI-<n>): <concise description>" --body "$(cat <<'EOF'
+## Summary
+
+{1-3 bullets describing what changed and why}
+
+{For intermediate WIs}: Part of feature #<feature-gh-issue>
+{For final WI only}: Refs #<feature-gh-issue>
+
+## What Changed
+
+{list of key changes}
+
+## WI Status
+
+- WI-<n>: {tier — foundational | behavioral} — this PR
+- Remaining WIs: {summary}
+
+## Codex Audit (Gate 4)
+
+{audit summary — iterations run, findings fixed, verdict}
+
+Audit log: `.claude/codex-audits/{branch-slug}-audit.md`
+
+## Validation
+
+- [x] `xcodebuild test` passes (Gate 3 test gate)
+- [x] Tests cover changed behavior (TDD: RED → GREEN)
+- [x] Codex audit loop completed ({M} iterations, verdict: {verdict})
+- [x] Docs sync — {architecture.md updated | README.md updated | n/a}
+- [x] Version bumped: {old} → {new}
+
+## Gate 5a Verification (per-PR slice — pre-merge)
+
+- Tier: {foundational — unit + integration sufficient | behavioral — slice verified end-to-end | final WI — pre-merge slice with `5b post-merge evidence file pending`}
+- {What was run, what was observed}
+
+## Type of Change
+
+- [x] Feature WI ({Part of feature #<feature-gh-issue> for intermediate WIs | Refs #<feature-gh-issue> for the final WI})
+EOF
+)"
+```
+
+---
+
+# Gate 5 — Device / Integration Verification
+
+| Field | Value |
+|---|---|
+| Required artifact | 5a: PR description "Gate 5a Verification" section per WI. 5b (final-WI only): `dev-docs/verification/feature-<id>-<YYYYMMDD>.md` per SCHEMA.md |
+| Owner / auditor | Author = verifier (orchestrator or designated subagent). 5b is "evidence-bearing"; SCHEMA result-field semantics gate any `VERIFIED` flip |
+| Status transition | 5a alone does NOT change status. After 5b lands with `result: pass`, row → `VERIFIED` |
+| Blocking hook | `check_terminal_status_evidence.sh` blocks the `VERIFIED` flip without 5b file present at the documented path |
+| Exit criteria | 5a: PR's slice verification recorded honestly; 5b: every acceptance criterion exercised end-to-end with `result: pass` (or `partial` / `fail` per SCHEMA semantics) |
+
+Gate 5 has two phases — **5a (pre-merge slice)** and **5b (post-merge
+final acceptance)** — because the SCHEMA.md evidence file requires the
+**merge-commit SHA on `main`**, which doesn't exist before the final
+WI's merge.
+
+## 5a. Pre-merge slice verification (per WI)
+
+| WI tier | Verification depth (pre-merge) | Where recorded |
+|---|---|---|
+| **Foundational** (DTOs, protocols, utilities, pure types — no user-observable behavior) | Unit + integration tests + Gate 4 audit are sufficient | PR description "Gate 5a Verification" line |
+| **Behavioral** (anything that changes app behavior, persistence, networking, backup format, reader rendering, or UI flow) | **Slice verification** — exercise the slice end-to-end against the real environment available at this point. iPhone 17 Pro Simulator with `vreader-debug://` harness; for backup/network features, against real WebDAV (or local Docker WebDAV); for reader features, with a fixture book. | PR description "Gate 5a Verification" section: what was run, what was observed |
+| **Final WI** (the one that completes the feature) | **Pre-merge slice** of the final acceptance criteria — exercise what's exercisable on the working-tree binary against the real backend. Defer anything that requires a merged-on-main build. | PR description "Gate 5a Verification" + a note "5b post-merge evidence file pending" |
+
+5a is the pre-merge gate that lets Gate 6 merge land. It is NOT the
+final acceptance pass.
+
+## 5b. Post-merge final acceptance (final WI only)
+
+After the final WI's PR merges, write the **structured evidence file**
+that flips the row to `VERIFIED`.
+
+Path: `dev-docs/verification/feature-<id>-<YYYYMMDD>.md` per
+`dev-docs/verification/SCHEMA.md`.
+
+**Required frontmatter**:
+
+```yaml
+---
+kind: feature
+id: <N>
+status_target: VERIFIED
+commit_sha: <40-hex of merge commit on main>
+app_version: <MARKETING_VERSION (build CURRENT_PROJECT_VERSION)>
+date: YYYY-MM-DD
+verifier: <name or "claude">
+device_or_simulator: <e.g. "iPhone 17 Pro Simulator">
+os_version: <e.g. "iOS 26.4">
+build_configuration: Debug | Release
+backend: <e.g. "rclone WebDAV ~/vreader-webdav-data" or "n/a">
+result: pass | partial | fail
+---
+```
+
+**Required body sections** (rule 47 + SCHEMA):
+
+- `## Acceptance criteria` — table mapping each criterion from the
+  plan to observed behavior + pass/fail.
+- `## Commands run` — fenced code blocks of the actual shell /
+  `simctl` / `xcrun` / curl commands used. Reproducible recipe.
+- `## Observations` — what surprised you, what was almost a
+  regression, what's brittle for next time.
+- `## Artifacts` — paths to screenshots, log captures, `.xcresult`
+  bundles. Optional but strongly recommended.
+
+**Result-field semantics** (binding):
+
+- `pass` — every acceptance criterion verified end-to-end. Tracker
+  may move to `VERIFIED`; GH issue may be closed.
+- `partial` — some criteria deferred. Tracker stays at `DONE`; a
+  follow-up evidence file is required.
+- `fail` — at least one criterion regressed. Tracker moves back to
+  `IN PROGRESS`; do NOT flip to `VERIFIED`.
+
+> **"Tooling unavailable" is NOT an acceptable deferral reason** unless
+> a specific tool is named and confirmed missing (e.g. `xcrun simctl`
+> returns "command not found", required device unavailable, Docker
+> WebDAV down). "I'll do it next session" is not a tool-unavailability
+> claim — it's a discipline lapse.
+
+---
+
+# Gate 6 — Merge
+
+| Field | Value |
+|---|---|
+| Required artifact | per WI: green PR ready to merge with audit log + version bump + Gate 5a slice noted in description |
+| Owner / auditor | Author = WI implementer. Merge gate enforced by AGENTS.md (fix-or-implement) + active hooks |
+| Status transition | per merge: not-final WI → row stays `IN PROGRESS`; final WI → row → `DONE`. (`VERIFIED` is a separate post-merge step, see Gate 5b.) |
+| Blocking hook | `check_codex_audit_artifact.sh` blocks `gh pr merge` without audit log |
+| Exit criteria | Squash merge succeeds; tag `v<X.Y.Z>` cut from the merge commit on `main`; status transitioned per the rules above |
+
+**A WI's PR may merge** when ALL hold:
+
+- Tests pass (Gate 3c).
+- Implementation audit loop is clean (Gate 3d / 4).
+- Audit log artifact exists at `.claude/codex-audits/<branch>-audit.md`
+  with valid frontmatter (`check_codex_audit_artifact.sh` will block
+  `gh pr merge` otherwise).
+- **Gate 5a slice verification** complete for the WI's tier and recorded
+  in the PR description. **5b post-merge evidence file is NOT required
+  pre-merge** — it's chicken-and-egg with the merge commit SHA.
+- Docs sync committed if triggered (Gate 3e).
+- Version bump committed as the last commit before opening the PR
+  (Gate 3f).
+- PR reference convention satisfied (Gate 3g): intermediate WIs use
+  `Part of feature #N` prose; only the final WI uses `Refs #N`.
+
+```bash
+gh pr merge <PR#> --squash --delete-branch
+```
+
+After EACH WI's merge (every PR carries its own version bump per
+rule 40, so every merge gets its own tag):
+
+```bash
+git checkout main && git pull origin main
+git tag v<X.Y.Z>          # the version this WI's PR bumped to
+git push origin v<X.Y.Z>
+```
+
+**Status transitions** (per merge):
+
+- WI lands but more remain → row stays `IN PROGRESS`.
+- **Final WI** lands → row → `DONE` (implemented; not yet verified).
+  This flip is what enables the Gate 5b post-merge evidence file to
+  reference the merge-commit SHA.
+- After Gate 5b evidence file lands with `result: pass` → row →
+  `VERIFIED` via a tracker edit. **`check_terminal_status_evidence.sh`
+  blocks this `VERIFIED` flip** if the evidence file isn't at
+  `dev-docs/verification/feature-<id>-<YYYYMMDD>.md`.
+
+---
+
+# Post-Merge Finalizer (close gate)
+
+**Do NOT auto-`gh issue close` on the GH issue when the final WI
+merges.** Per AGENTS.md "Close gate":
+
+## Right after final WI's `gh pr merge`
+
+1. Apply label to GH issue (if device-verifiable, default
+   `awaiting-device-verification`; otherwise pick from
+   `verification-exception` / `verification-blocked` per AGENTS.md).
+2. Post a "shipped, awaiting verification" comment:
+
+   ```
+   gh issue comment <feature-gh-issue> --body "Shipped in v<X.Y.Z> (commit <short-sha>). Awaiting Gate 5 final acceptance pass."
+   ```
+
+3. Tag is cut from the merge commit (per Gate 6's `git tag` step).
+
+## After Gate 5 final acceptance
+
+- For **device-verification** path:
+  - Install merged build on iPhone 17 Pro Sim (or device).
+  - Run every acceptance criterion from the plan.
+  - Record observations in `dev-docs/verification/feature-<id>-<YYYYMMDD>.md`.
+  - Post closure comment citing the evidence file:
+
+    ```
+    gh issue comment <feature-gh-issue> --body "VERIFIED on iPhone 17 Pro Simulator (commit <sha>). All acceptance criteria pass. Evidence: dev-docs/verification/feature-<id>-<YYYYMMDD>.md."
+    gh issue close <feature-gh-issue>
+    ```
+
+- For **non-device-reproducible** features (race conditions, fault
+  injection, etc.): close under `verification-exception` with a
+  high-fidelity integration test at real subsystem boundaries (not
+  stubs). Same evidence file, citation comment, then `gh issue close`.
+
+- For **verification-blocked** (no harness exists yet): keep open,
+  apply the label, file a follow-up to build the harness (potentially
+  as another feature).
+
+If verification reveals a regression: do NOT close. Move row back to
+`IN PROGRESS`, file a bug, fix, re-verify.
+
+---
+
+## Acceptance Contract
+
+The feature is "done" — i.e. row may flip to `VERIFIED` and GH issue
+may close — only when:
+
+1. All Work Items merged via Gate 6.
+2. Final WI's `dev-docs/verification/feature-<id>-<YYYYMMDD>.md` has
+   `result: pass` covering every acceptance criterion from the plan.
+3. Closure comment posted with commit SHA, what was tested, what was
+   observed.
+4. `gh issue close <feature-gh-issue>` executed.
+
+If uncertain at any gate: stop and ask. Don't guess your way past a
+gate — that's how rule 47 was tightened in the first place.
+
+## Error Handling
+
+| Scenario | Action |
+|---|---|
+| `$ARGUMENTS` is empty | List `TODO`/`PLANNED` candidates; ask user to pick |
+| Target is actually a bug | Redirect to `/fix-issue`; STOP |
+| Plan exists at `dev-docs/plans/...` from a prior run | Resume at the correct gate (re-run Gate 2 if plan changed; else continue) |
+| Codex MCP unavailable | Use manual fallback; mark audit log `threadId: manual-fallback` |
+| 3 audit rounds with findings still open (Gate 2 OR Gate 4) | STOP. Escalate to user — accept, defer, or redesign |
+| Test gate fails 3x | Report errors, keep branch, STOP |
+| `check_gh_issue_mirror.sh` blocks tracker edit | Add `GH: #N` to the row's Notes column, retry |
+| `check_codex_audit_artifact.sh` blocks `gh pr merge` | Verify the audit log file exists at the expected path with valid frontmatter |
+| `check_terminal_status_evidence.sh` blocks `VERIFIED` flip | Write the evidence file at `dev-docs/verification/feature-<id>-<YYYYMMDD>.md` first |
+| Gate 5 verification reveals a regression | Move row back to `IN PROGRESS`, file a bug, fix, re-verify. Do NOT close GH issue |
+| Branch already exists | Reuse if WI matches; else rename |

--- a/.claude/skills/file-bug/SKILL.md
+++ b/.claude/skills/file-bug/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: file-bug
+description: "Create a GitHub issue for a bug row in docs/bugs.md and stamp `GH: #N` into its Notes column. Use this skill whenever the user wants to file/mirror/create a GH issue for an existing bug row, or asks 'create issue for bug #N', 'file bug 115', 'mirror bug 42 to GH', 'this bug needs a GH issue'. Also trigger when the `check_gh_issue_mirror.sh` PreToolUse hook blocks an edit to a `docs/bugs.md` row because it lacks `GH: #N`. Stays strictly in the mirror-an-existing-row scope — do not use for triaging new bugs (that's the triage skill) or fixing bugs (that's fix-issue)."
+---
+
+# File Bug Issue
+
+Create a GitHub issue mirroring an existing row in `docs/bugs.md`, then update that row's Notes column with `GH: #N` so the PreToolUse mirror hook stops blocking edits to it. Single tool flow that prevents the "issue created, row not updated" failure mode.
+
+## Input
+
+Parse the user's request to extract a single integer bug ID (e.g. from `/file-bug 115`, `file bug #115`, or `mirror bug 115 to GH`). If the user did not name an ID, ask before proceeding.
+
+## Phase 0 — Pre-flight
+
+1. **Argument check**: parse `$ARGUMENTS` as a single integer bug ID.
+   - Empty / non-numeric → print usage:
+     `/file-bug <bug-id>  e.g. /file-bug 115`
+     and STOP.
+
+2. **`gh` auth check**: run `gh auth status` (any remote). If unauthenticated → print
+   `gh CLI is not authenticated. Run \`gh auth login\` first.` and STOP.
+
+3. **Repo check**: run `gh repo view --json nameWithOwner -q .nameWithOwner` from inside the project. If it errors → print `Not inside a GitHub repo (no upstream remote). gh repo set-default may help.` and STOP.
+
+4. **Row lookup**: `grep -n "^| <id>[ |]" docs/bugs.md | head -1`. If empty → print `Bug #<id> not found in docs/bugs.md` and STOP.
+
+5. **Existing-issue check**: read the matching row's Notes column. If it already contains `GH: #N`, print `Bug #<id> already has GH: #N — nothing to do.` and STOP cleanly (idempotent).
+
+## Phase 1 — Build the issue
+
+From the row, extract:
+- `title` (cell 2)
+- `area` (cell 3)
+- `priority` (cell 4)
+- `status` (cell 5)
+- `notes` (cell 6)
+
+Compose:
+- **Issue title**: `Bug #<id>: <title>`
+- **Labels**: `bug`. If priority is `High` add `severity:high`. If `Medium`, `severity:medium`. (If `Low`, no severity label.)
+- **Body** (heredoc):
+
+```
+**Tracker row**: `docs/bugs.md` #<id>
+**Source of truth**: docs/bugs.md
+**Severity**: <priority>
+**Status**: <status>
+**Area**: <area>
+
+## Description
+
+<notes>
+
+---
+
+This issue mirrors the bug-tracker row. Material design / scope changes happen in `docs/bugs.md`; GH comments that change scope must be ported back to the tracker in the same PR.
+```
+
+## Phase 2 — Create the issue
+
+Run:
+```sh
+gh issue create --title "<title>" --label "<labels>" --body "<body>"
+```
+
+Capture the issue URL from stdout. Extract the issue number (last path segment of the URL).
+
+**Failure modes** (all exit nonzero with the issue URL if it exists):
+- Network failure → re-run once after 3s; if still failing, print URL (if any) + error and STOP.
+- Rate limit → print `gh API rate-limited. Try again later.` and STOP.
+- Label not found → re-run with just `bug` label, warn the user that severity wasn't applied.
+- Duplicate issue (gh detected) → use the existing one, fall through to Phase 3.
+
+## Phase 3 — Update the row
+
+Use the `Edit` tool to insert `GH: #<issue-number>` into the row's Notes column. Markdown table rows end with `|`, so the insertion always goes **before the trailing `|`**, separated from prior content by exactly one space.
+
+The Edit's `old_string` is the original full row line. The `new_string` is the same line with `GH: #<N>` inserted into the Notes cell.
+
+Two surface patterns (both yield the same outcome — the only difference is what whitespace already exists before the trailing `|`):
+
+a. **Notes ends with non-space content** (typical): `... existing notes |` → `... existing notes GH: #<N> |` (one leading space before `GH:`).
+b. **Notes already has trailing whitespace before the `|`**: `... existing notes   |` → `... existing notes GH: #<N> |` (collapse the run of trailing spaces to one).
+
+Never put `GH: #<N>` after the trailing `|` — that puts it outside the table cell and the mirror hook won't see it.
+
+The `check_gh_issue_mirror.sh` PreToolUse hook will allow this edit because the new content carries `GH: #N`.
+
+**Failure mode — issue created but row update failed**:
+This is the dangerous case. Print:
+```
+GH issue #<N> created at <URL>, but failed to update docs/bugs.md row.
+Manually add `GH: #<N>` to the Notes column of bug #<id>:
+
+  | <id> | ... | <status> | <existing notes> GH: #<N> |
+```
+Exit nonzero so the user sees the partial success.
+
+## Phase 4 — Report
+
+Print:
+```
+Filed bug #<id> as GH issue #<N>: <URL>
+```
+
+Done. Do NOT commit — the docs/bugs.md edit is staged but uncommitted; the user folds it into whatever PR is in flight.
+
+## Examples
+
+`/file-bug 115` → reads row #115 from docs/bugs.md, opens GH issue with bug + severity:high labels, stamps GH: #N onto the row.
+
+`/file-bug` → prints usage and stops.
+
+`/file-bug 999` (nonexistent) → prints "Bug #999 not found" and stops.

--- a/.claude/skills/file-feature/SKILL.md
+++ b/.claude/skills/file-feature/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: file-feature
+description: "Create a GitHub issue for a feature row in docs/features.md and stamp `GH: #N` into its Notes column. Use this skill whenever the user wants to file/mirror/create a GH issue for an existing feature row, or asks 'create issue for feature #N', 'file feature 47', 'mirror feature 32 to GH', 'this feature needs a GH issue'. Also trigger when the `check_gh_issue_mirror.sh` PreToolUse hook blocks an edit to a `docs/features.md` row because it lacks `GH: #N`. Skip if status is `TODO` (promote to `PLANNED` first) or Notes contains `Mirror: no`."
+---
+
+# File Feature Issue
+
+Create a GitHub issue mirroring an existing row in `docs/features.md`, then update that row's Notes column with `GH: #N`. Mirror of `/file-bug` for the features tracker.
+
+## Input
+
+Parse the user's request to extract a single integer feature ID (e.g. from `/file-feature 47`, `file feature #47`, or `mirror feature 47 to GH`). If the user did not name an ID, ask before proceeding.
+
+## Phase 0 — Pre-flight
+
+1. **Argument check**: parse `$ARGUMENTS` as a single integer feature ID. Empty / non-numeric → print usage `/file-feature <id>` and STOP.
+
+2. **`gh` auth check**: `gh auth status`. If unauthenticated → print and STOP.
+
+3. **Repo check**: `gh repo view --json nameWithOwner -q .nameWithOwner`. If errors → print and STOP.
+
+4. **Row lookup**: `grep -n "^| <id>[ |]" docs/features.md | head -1`. If empty → STOP.
+
+5. **Mirror-required state check**: status must be one of `PLANNED`, `IN PROGRESS`, `DONE`, `VERIFIED`. If `TODO` (not yet planned), print `Feature #<id> is at TODO — promote to PLANNED first per AGENTS.md` and STOP.
+
+6. **Mirror: no escape**: if the Notes column contains `Mirror: no`, print `Feature #<id> is marked Mirror: no — skipping per row directive.` and STOP cleanly.
+
+7. **Existing-issue check**: if Notes already has `GH: #N`, print and STOP cleanly (idempotent).
+
+## Phase 1 — Build the issue
+
+From the row, extract `title` (cell 2), `area` (cell 3), `priority` (cell 4), `status` (cell 5), `notes` (cell 6).
+
+Compose:
+- **Issue title**: `Feature #<id>: <title>`
+- **Labels**: `enhancement`. If priority is `High` add `severity:high`. `Medium` → `severity:medium`. `Low` → no severity.
+- **Body** (heredoc):
+
+```
+**Tracker row**: `docs/features.md` #<id>
+**Source of truth**: docs/features.md
+**Priority**: <priority>
+**Status**: <status>
+**Area**: <area>
+
+## Description
+
+<notes>
+
+---
+
+This issue mirrors the feature-tracker row. The row is the source of truth — material design / scope changes happen in `docs/features.md`; GH comments that change scope must be ported back to the tracker in the same PR.
+
+If a Plan exists in `dev-docs/plans/` it is referenced from the row.
+```
+
+## Phase 2 — Create the issue
+
+```sh
+gh issue create --title "<title>" --label "<labels>" --body "<body>"
+```
+
+Capture URL + extract issue number. Same failure-mode handling as `/file-bug` (network retry once, rate-limit/label-missing/duplicate handling). On any partial-success (issue created but downstream fails), exit nonzero with the URL printed so the user can finish manually.
+
+## Phase 3 — Update the row
+
+Use the `Edit` tool to insert `GH: #<issue-number>` into the row's Notes column. Markdown table rows end with `|`, so the insertion always goes **before the trailing `|`**, separated from prior content by exactly one space.
+
+The Edit's `old_string` is the original full row line. The `new_string` is the same line with `GH: #<N>` inserted into the Notes cell.
+
+Two surface patterns (both yield the same outcome — the only difference is what whitespace already exists before the trailing `|`):
+
+a. **Notes ends with non-space content** (typical): `... existing notes |` → `... existing notes GH: #<N> |` (one leading space before `GH:`).
+b. **Notes already has trailing whitespace before the `|`**: `... existing notes   |` → `... existing notes GH: #<N> |` (collapse the run of trailing spaces to one).
+
+Never put `GH: #<N>` after the trailing `|` — that puts it outside the table cell and the mirror hook won't see it.
+
+The `check_gh_issue_mirror.sh` PreToolUse hook will allow this edit because the new content carries `GH: #N`.
+
+**Failure mode — issue created but row update failed**:
+This is the dangerous case. Print:
+```
+GH issue #<N> created at <URL>, but failed to update docs/features.md row.
+Manually add `GH: #<N>` to the Notes column of feature #<id>:
+
+  | <id> | ... | <status> | <existing notes> GH: #<N> |
+```
+Exit nonzero so the user sees the partial success.
+
+## Phase 4 — Report
+
+```
+Filed feature #<id> as GH issue #<N>: <URL>
+```
+
+Done. Do NOT commit — the user folds the row edit into whatever PR is in flight.
+
+## Examples
+
+`/file-feature 47` → reads row #47, opens GH issue with `enhancement` + severity labels, stamps `GH: #N` onto the row.
+
+`/file-feature 50` (status TODO) → "promote to PLANNED first" message and stops.
+
+`/file-feature 51 Mirror: no` → not how arguments work; the `Mirror: no` directive lives in the row's Notes column and the command auto-detects it.

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -1,0 +1,586 @@
+---
+name: fix-issue
+description: "End-to-end GitHub issue resolver — fetch, classify, branch, fix with TDD, Codex audit loop, test gate, docs-sync, version bump, PR, and post-merge close-gate finalizer. Use this skill whenever the user wants to fix a bug from a GH issue, asks 'fix issue #N', 'fix bug 115', 'work on issues #123 #456 #789', 'resolve this GH bug', or pastes a GH issue URL/number for resolution. Also handles `question`-labeled issues (inline answer + comment, no branch). REDIRECTS feature/enhancement issues to feature-workflow per rule 47. Supports both single-issue and multi-issue (worktree) pipelines."
+---
+
+# Fix Issue
+
+Resolve one or more GitHub issues end-to-end: fetch, classify, branch, fix with
+TDD, Codex audit loop, test gate, docs-sync, version bump, PR, and post-merge
+close-gate finalizer.
+
+## Input
+
+Parse the user's request to extract one or more issue numbers (e.g. `#123`, `123`, `#123 #456`). If no numbers were provided, print usage and STOP.
+
+## Scope
+
+| Issue type | Path inside this skill |
+|---|---|
+| Bug (label `bug` or body describes broken behavior) | Single-issue **Bug Pipeline** below |
+| Question (label `question`) | Inline answer + comment, no branch/PR |
+| Feature / enhancement | **REDIRECT** to `/feature-workflow` (see "Feature handling" below) |
+| Multiple issues at once | **Multi-Issue Pipeline** (one worktree per issue) |
+
+### Feature handling — read this before fixing a feature here
+
+`.claude/rules/47-feature-workflow.md` is **binding for every feature
+implementation**: Plan → Independent plan audit → TDD → Implementation
+audit → Device/integration verification → Merge. Six gates, never skip
+one. This skill cannot run Gate 2 (independent plan audit by a separate
+agent context) or Gate 5 (device/integration verification + evidence
+file) inline. Therefore:
+
+**Always redirect features to `/feature-workflow`. STOP this pipeline.**
+No user waiver bypasses Gates 2 or 5 — rule 47 is binding for every
+feature regardless of size. The old escape hatch (10+ files / 4+ work
+items) is gone; the previous "opt out in writing" is gone too.
+
+The skill's old `3b. Feature Path` is removed. Feature handling lives
+entirely in `/feature-workflow`.
+
+## Hooks you'll trip
+
+Three PreToolUse hooks gate this pipeline:
+
+| Hook | Triggers when | What it requires |
+|---|---|---|
+| `check_codex_audit_artifact.sh` | `gh pr merge` on a Swift-touching PR | `.claude/codex-audits/<branch>-audit.md` with valid `final_verdict` |
+| `check_gh_issue_mirror.sh` | `Edit/Write/MultiEdit` on `docs/{features,bugs}.md` | mirror-required rows must have `GH: #N` in Notes column |
+| `check_terminal_status_evidence.sh` | tracker flip to `VERIFIED` (features) or `FIXED` only on `docs/features.md` | matching `dev-docs/verification/<kind>-<id>-<YYYYMMDD>.md`. **Bug `FIXED` flips on `docs/bugs.md` are NOT hook-enforced** — verification is enforced at GH-issue-close time, not at row flip. |
+
+Plan around them; do not bypass.
+
+## Pre-flight Checks
+
+1. **Parse arguments** — extract issue numbers (e.g. `#123`, `123`, `#123 #456`).
+   - No arguments: print usage and STOP.
+2. **Check working tree** — `git status --porcelain`. If dirty, do not
+   revert unrelated changes; isolate your work with a new branch.
+3. **Confirm branch / sync** — `git branch --show-current` and
+   `git fetch origin`.
+
+---
+
+# Single-Issue Bug Pipeline
+
+When exactly one issue is provided and it classifies as a bug, run
+phases 1-9 sequentially.
+
+### Phase 0.5: Visual Reproduce (optional, for UI bugs)
+
+For UI bugs, reproduce in Simulator before diving into code:
+- Use `sim-transfer` skill to push test files to the simulator (verify
+  the skill exists; if not, fall back to `xcrun simctl io booted addmedia`
+  / `simctl push`).
+- Stream live logs: `xcrun simctl spawn booted log stream --predicate 'subsystem == "com.vreader.app"' --debug`
+- Take screenshots as evidence. Batch UI actions with `computer_batch`.
+
+### Phase 1: Fetch & Classify
+
+```bash
+gh issue view {N} --json number,title,body,labels,state,assignees
+```
+
+- If issue not found or closed: warn user, ask whether to proceed, or STOP.
+- Classify:
+
+| Classification | Trigger | Path |
+|---|---|---|
+| Bug | label contains `bug`, or body mentions error/crash/broken | continue this pipeline |
+| Feature | label contains `feature`/`enhancement` | **redirect to `/feature-workflow`** and STOP |
+| Question | label contains `question` | jump to **Question Path** below |
+| Ambiguous | no matching labels | ask user to classify |
+
+### Phase 2: Branch Setup
+
+- Slug from title: lowercase, strip non-ASCII, replace spaces with `-`,
+  truncate to 40 chars.
+- Branch name: `fix/issue-{N}-{slug}`.
+- If branch already exists: ask user — reuse or rename.
+- Create and checkout the branch.
+- **Tracker move**: edit `docs/bugs.md` row → status `IN PROGRESS`.
+  Reminder: the `check_gh_issue_mirror.sh` hook requires `GH: #N` in the
+  row's Notes column. The issue you're fixing already exists, so add
+  `GH: #{N}` to Notes if absent.
+
+### Phase 3: Resolve (Bug)
+
+No half measures. Follow the bug-fix workflow from `docs/bugs.md`:
+
+1. **Reproduce** — read relevant code, trace call chain symptom → root cause.
+2. **Diagnose** — find root cause; check for similar patterns elsewhere.
+3. **RED** — failing test capturing the bug per `.claude/rules/10-tdd.md`:
+   - SwiftData bug → persistence test with in-memory container
+   - WKWebView bridge bug → parser/coordinator unit test
+   - ViewModel bug → Swift Testing async test with `@MainActor`
+   - Utility bug → parameterized `@Test(arguments:)` covering the broken case
+4. **GREEN** — fix the root cause with minimal, focused changes.
+5. **REFACTOR** — clean up without changing behavior; tests stay green.
+
+### Phase 4: Codex Audit Loop (max 3 iterations)
+
+#### 4a. Collect changed files
+
+```bash
+git diff main --name-only
+git diff main
+```
+
+#### 4b. Initial audit via Codex MCP
+
+`ToolSearch` with query `+codex` to discover Codex tools.
+
+**Availability test** — short ping first:
+
+```
+mcp__plugin_codex-toolkit_codex__codex with:
+  prompt: "Respond with 'ok' if you can read this."
+```
+
+If Codex does not respond, skip to **4f. Fallback** immediately. If it
+responds:
+
+**Audit prompt**:
+
+```
+mcp__plugin_codex-toolkit_codex__codex with:
+  sandbox: read-only
+  prompt: |
+    Audit these files changed for GitHub issue #{N}: {title}
+    Files: {changed file list}
+    Diff summary: {git diff main --stat}
+    Focus:
+    1. Correctness & logic — does the fix actually solve the root cause?
+    2. Edge cases — boundary conditions, nil, Unicode/CJK, concurrent access
+    3. Security — JS/CSS injection safety in evaluateJavaScript() and WKWebView bridges
+    4. Duplicate code — repeated logic that should be unified
+    5. Dead code — unused imports, unreachable branches, orphaned functions
+    6. Shortcuts & patches — workarounds, TODO markers, band-aids
+    7. VReader compliance — Swift 6 concurrency, @MainActor correctness, SwiftData actor isolation, file size <300 lines
+    8. Bridge safety — FoliateJSEscaper used for all JS string interpolation, message parser handles all edge cases
+    Report as: file:line | severity (Critical/High/Medium/Low) | issue | fix
+```
+
+#### 4c. Parse & fix
+
+Fix **every** finding — Critical, High, Medium, Low.
+
+#### 4d. Verify via Codex reply
+
+`mcp__plugin_codex-toolkit_codex__codex-reply` on the same thread:
+
+```
+I fixed these issues: {list of fixes with file:line}
+Verify ALL fixes are correct. Check for new issues introduced by the fixes.
+Updated diff: {git diff main --stat}
+```
+
+#### 4e. Loop or exit
+
+- Zero findings → audit passes, exit loop.
+- Findings remain and iteration < 3 → fix and re-verify.
+- 3 iterations with findings still open → STOP. Report remaining issues
+  to the user.
+
+#### 4f. Fallback — manual mini-audit
+
+If Codex MCP is unavailable: read each changed file, audit dimensions
+1–8 above, fix Critical/High inline.
+
+#### 4g. Write the audit log artifact
+
+**Required before merge; recommended before PR creation so review sees
+it.** `check_codex_audit_artifact.sh` blocks `gh pr merge` (not
+`gh pr create`) without an audit log. Write the file before attempting
+the merge so the hook passes.
+
+Path: `.claude/codex-audits/<branch-with-slashes-replaced-by-hyphens>-audit.md`
+
+Frontmatter (required):
+
+```markdown
+---
+branch: <current branch name, exactly as `git branch --show-current` returns>
+threadId: <Codex MCP thread id>      # OR `manual-fallback` if 4f was used
+rounds: <integer ≥ 1>
+final_verdict: ship-as-is | follow-up-recommended | block-recommended
+date: YYYY-MM-DD
+---
+```
+
+Body:
+- Per-round findings (file:line | severity | issue | fix).
+- Resolution note for each finding (fixed / accepted with rationale /
+  deferred to follow-up bug).
+- Summary verdict statement.
+- If you used manual fallback, include a "Manual audit evidence" section
+  per `.claude/rules/47-feature-workflow.md`'s manual-fallback rules
+  (files read, symbols verified, edge cases checked, risks accepted).
+
+Commit the audit log alongside the fix, in its own commit
+(`chore: codex audit log for issue #{N}`) or folded into the relevant
+fix commit — but it must be on the branch before the PR opens.
+
+### Phase 5: Test Gate
+
+Up to 3 attempts:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
+  -project vreader.xcodeproj -scheme vreader \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:vreaderTests
+```
+
+> **Note**: `xcodebuild` CLI builds to a different DerivedData than
+> Xcode's Run button. For debugger-attached builds or when
+> `simctl install` installs a stale binary, use Xcode's Run button via
+> computer-use instead of `xcodebuild` + `simctl install`.
+>
+> **Never use `simctl uninstall`** — it wipes all user data (imported
+> books, settings, reading positions). Use `simctl install` to replace
+> the binary while preserving data.
+
+- Pass → proceed.
+- Fail → read errors, fix, retry.
+- 3 failures → report, keep branch, STOP.
+
+### Phase 6: Tracker State + Docs Sync
+
+#### 6a. Pre-FIXED verify (mandatory)
+
+The `docs/bugs.md` workflow is **Understand → RED → GREEN → REFACTOR
+→ Verify → Track**. "Verify" comes BEFORE "Track" (the FIXED flip).
+
+Run a lightweight pre-merge confirmation that the symptom is actually
+gone — not just that tests pass. This is distinct from the deep
+post-merge close-gate verification in Phase 9; that one runs against
+the merged build on `main`.
+
+- **UI / behavioral bugs**: re-run the original repro from the issue
+  body in the simulator with the working-tree binary
+  (`xcodebuild build` then launch via Xcode Run, or `simctl install`
+  the freshly built `.app`). Confirm the actual symptom is gone.
+- **Data / state / persistence bugs**: re-run the failing scenario
+  end-to-end (e.g., import → backup → wipe → restore) against the
+  working-tree binary. Confirm the broken state no longer reproduces.
+- **Pure-logic bugs reproducible by a unit test**: the RED→GREEN
+  transition in Phase 3 already establishes "Verify" — no extra step
+  needed.
+
+If pre-FIXED verify fails: the fix is incomplete. Loop back to Phase 3
+(or revert) — do NOT advance to Phase 6b.
+
+#### 6b. Bug tracker — FIXED flip
+
+`docs/bugs.md` row → status **`FIXED`** (only after 6a verify passed).
+The `check_terminal_status_evidence.sh` hook does NOT block bug
+`FIXED` flips — verification is enforced at issue-close time
+(Phase 9), not at this row flip. Add `GH: #{N}` to the row's Notes
+column if absent (`check_gh_issue_mirror.sh` will block otherwise).
+
+#### 6c. Docs sync (if triggered)
+
+Per `.claude/rules/24-doc-sync.md`:
+
+| If your fix touched | Update |
+|---|---|
+| New service / actor / `@Model` / `Notification.Name` / cross-feature pattern | `docs/architecture.md` |
+| User-visible behavior, tech stack, requirements, setup, ≥5-row tracker change | `README.md` |
+| Otherwise | nothing |
+
+If updates are needed, commit them in their own commit
+(`docs: update architecture.md for #{N} fix` etc.) **before** the
+version bump in Phase 7. Pure bug fixes with no architectural impact
+need nothing here.
+
+### Phase 7: Version Bump
+
+Per `.claude/rules/40-version-bump.md`. Mandatory tail commit before PR.
+
+```bash
+# 1. Edit project.yml: bump MARKETING_VERSION (patch for bug fixes) and
+#    increment CURRENT_PROJECT_VERSION (always +1, monotonic).
+# 2. Regenerate the Xcode project:
+xcodegen generate
+
+# 3. Verify both files updated:
+grep -E "MARKETING_VERSION|CURRENT_PROJECT_VERSION" project.yml
+grep -E "MARKETING_VERSION =|CURRENT_PROJECT_VERSION =" vreader.xcodeproj/project.pbxproj
+
+# 4. Quick smoke build:
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build \
+    -project vreader.xcodeproj -scheme vreader \
+    -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+
+# 5. Commit (single commit, both files):
+git add project.yml vreader.xcodeproj/project.pbxproj
+git commit -m "chore: bump version to X.Y.Z"
+```
+
+For bug fixes, increment **patch**. The post-merge tag (`v X.Y.Z`) is
+cut from the merge commit on `main` after PR lands.
+
+### Phase 8: Create PR
+
+PR uses `Refs #N`, **not** `Fixes #N` (prevents premature auto-close —
+the GH issue stays open until verified, see Phase 9).
+
+```bash
+gh pr create --title "fix: {concise description}" --body "$(cat <<'EOF'
+## Summary
+
+{1-3 bullets describing what changed and why}
+
+Refs #{N}
+
+## What Changed
+
+{list of key changes}
+
+## Codex Audit
+
+{audit summary — iterations run, findings fixed, verdict}
+
+Audit log: `.claude/codex-audits/{branch-slug}-audit.md`
+
+## Validation
+
+- [x] `xcodebuild test` passes
+- [x] Tests cover changed behavior (TDD: RED → GREEN)
+- [x] Codex audit loop completed ({M} iterations, verdict: {verdict})
+- [x] Docs sync — {architecture.md updated | README.md updated | n/a}
+- [x] Version bumped: {old} → {new}
+
+## Post-Merge Verification Plan
+
+Default path (device verification): {how the original repro will be re-run on simulator/device}.
+OR exception path (high-fidelity test): {test name + evidence file path}.
+
+## Type of Change
+
+- [x] Bug fix (Refs #{N})
+EOF
+)"
+```
+
+Report the PR URL to the user.
+
+### Phase 9: Post-Merge Finalizer (close gate)
+
+**Do NOT auto-`gh issue close`.** Per AGENTS.md "Close gate — verified,
+not just merged":
+
+#### 9a. Right after `gh pr merge`
+
+1. Apply the appropriate label to the GH issue:
+   - **Default — `awaiting-device-verification`**: failure can be
+     reproduced on a real device/sim. Most bugs.
+   - **Exception — `verification-exception`**: failure mode physically
+     cannot be device-reproduced (race conditions, fault-injection
+     paths, mid-MKCOL auth fails, concurrent restore picker, etc.).
+     Requires a deterministic high-fidelity integration test at real
+     subsystem boundaries (not casual stubs) + evidence file in
+     `dev-docs/verification/`.
+   - **Blocked — `verification-blocked`**: neither device repro nor
+     high-fidelity test is feasible yet (no harness exists). Keep open
+     with a follow-up to build the harness (potentially as a feature).
+
+2. Post a "shipped, awaiting verification" comment:
+
+   ```
+   gh issue comment {N} --body "Shipped in v{X.Y.Z} (commit {short-sha}). Awaiting {device-verification|verification-exception evidence}."
+   ```
+
+3. Tag is cut by the version-bump tag policy from `main`:
+
+   ```bash
+   git fetch origin
+   git checkout main && git pull
+   git tag v{X.Y.Z}        # only if not already tagged on the merge commit
+   git push origin --tags
+   ```
+
+#### 9b. Verification + closure
+
+For **device-verification** path:
+- Install the merged build on iPhone 17 Pro Simulator (or device).
+- Re-run the original repro from the issue body.
+- Confirm the symptom is gone.
+- Post closure comment with: commit SHA + what was tested + what was
+  observed.
+
+   ```
+   gh issue comment {N} --body "Verified on iPhone 17 Pro Simulator (commit {sha}). Re-ran the original repro: {what you did}. Observed: {what happened}. Symptom is gone."
+   gh issue close {N}
+   ```
+
+For **verification-exception** path:
+- Confirm a deterministic high-fidelity integration test covers the
+  failure path through real subsystem objects (`PersistenceActor`,
+  `BookFileMaterializer`, `WebDAVBlobStore`, etc. — not stubbed).
+  Casual unit tests with stubs do NOT qualify.
+- Write or update the evidence file at
+  `dev-docs/verification/bug-{N}-{YYYYMMDD}.md` per the schema in
+  `dev-docs/verification/SCHEMA.md`. Required frontmatter:
+
+   ```yaml
+   ---
+   kind: bug
+   id: {N}
+   status_target: FIXED
+   commit_sha: {40-hex of merge commit on main}
+   app_version: {MARKETING_VERSION (build CURRENT_PROJECT_VERSION)}
+   date: YYYY-MM-DD
+   verifier: <name or "claude">
+   device_or_simulator: <e.g. "iPhone 17 Pro Simulator">
+   os_version: <e.g. "iOS 26.4">
+   build_configuration: Debug | Release
+   backend: <e.g. "rclone WebDAV ~/vreader-webdav-data" or "n/a">
+   result: pass | partial | fail
+   ---
+   ```
+
+   Required body sections (the hook does not parse the body but rule
+   47 + SCHEMA both require them):
+
+   - `## Acceptance criteria` — table mapping each criterion to
+     observed behavior + pass/fail.
+   - `## Commands run` — fenced code blocks of the actual shell /
+     `simctl` / `xcrun` / test-invocation commands that exercised the
+     fix. Reproducible recipe.
+   - `## Observations` — narrative; what was surprising, what was
+     close to a regression.
+   - `## Artifacts` — paths to screenshots, log captures, `.xcresult`
+     bundles. Optional but strongly recommended.
+- Closure comment cites the test method + evidence file path:
+
+   ```
+   gh issue comment {N} --body "Verification exception: deterministic high-fidelity integration test {TestClass.testMethod} at {file:line} drives the same code path the production failure would hit. Evidence: dev-docs/verification/bug-{N}-{YYYYMMDD}.md."
+   gh issue close {N}
+   ```
+
+If `verification-blocked`: do not close. Add a follow-up task to build
+the missing harness and revisit when it lands.
+
+---
+
+# Question Path
+
+If Phase 1 classified the issue as `question`:
+
+1. **Research** — read code and docs to compose a thorough answer.
+2. **Detect language** — check the issue author's language from title
+   and body. Reply in the **same language** the author used.
+3. **Respond**:
+
+   ```bash
+   gh issue comment {N} --body "{answer in author's language}"
+   ```
+
+4. **STOP** — no branch, no PR, no version bump. If you created a
+   branch in Phase 2 by mistake, delete it. Question issues do not move
+   through the close gate.
+
+---
+
+# Multi-Issue Pipeline
+
+When multiple issue numbers are provided (e.g. `#123 #456 #789`).
+
+### M1: Fetch & validate all
+
+```bash
+gh issue view {N} --json number,title,body,labels,state
+```
+
+- Filter out closed issues (warn user).
+- Filter out questions (handle inline with `gh issue comment`, no worktree).
+- Filter out features (redirect each to `/feature-workflow`).
+- Remaining bugs proceed to worktree pipeline.
+
+### M2: Create worktrees
+
+```bash
+git worktree add .claude/worktrees/issue-{N} -b fix/issue-{N}-{slug} main
+```
+
+### M3: Parallel execution
+
+Per `.claude/rules/48-parallel-execution.md`, parallelism is an
+isolation tool first, speed tool second.
+
+Each worktree-agent runs **Phases 0.5 → 6c only**, then stops and
+reports "ready for bump." The integrator (orchestrator agent or human)
+controls everything from Phase 7 onward, with three coordinated gates:
+
+1. **Version bump is integrator-coordinated.** After all worktree-agents
+   stop at the end of Phase 6c, the integrator assigns sequential
+   `MARKETING_VERSION`s to the bug PRs in the order they will land,
+   then resumes each worktree-agent through Phases 7 → 8 (version
+   bump, then PR creation) with its assigned version. This avoids two
+   parallel branches picking the same next version off the same
+   `main` baseline.
+
+2. **PR merge order is sequential, not parallel.** After all worktrees
+   open PRs, the integrator merges them one at a time. Each PR is
+   rebased on `main` immediately before merge so it carries an
+   already-bumped version that doesn't collide with what just landed.
+
+3. **Tagging happens once, on `main`, after all merges land.** No
+   worktree tags. Worktree-agents NEVER run `git tag` or
+   `git push origin --tags`. The integrator tags `main` once per
+   merged version after the final merge.
+
+Phase 9 (post-merge finalizer + verification + closure) is serial:
+single simulator, no parallel device verification, run after all
+merges land in their assigned version order.
+
+### M4: Collect results
+
+```
+| Issue | Status | Branch | PR | Audit verdict | Tag |
+|-------|--------|--------|------|---------------|-----|
+| #123  | Merged, awaiting-device-verification | fix/issue-123-slug | #45 | ship-as-is | v3.13.6 |
+| #456  | Failed (gate) | fix/issue-456-slug | — | — | — |
+```
+
+### M5: Cleanup worktrees
+
+```bash
+# Remove successful worktrees
+git worktree remove .claude/worktrees/issue-{N}
+
+# Clean stale DerivedData (each worktree built its own ~5 GB DD)
+for dd in ~/Library/Developer/Xcode/DerivedData/vreader-*/; do
+  wp=$(defaults read "$dd/info.plist" WorkspacePath 2>/dev/null)
+  if [[ "$wp" == *".claude/worktrees/"* ]]; then
+    rm -rf "$dd"
+  fi
+done
+
+# Remove empty worktree directories
+rm -rf .claude/worktrees/agent-*
+
+# Keep failed worktrees for investigation
+```
+
+---
+
+## Error Handling
+
+| Scenario | Action |
+|---|---|
+| No arguments | Print usage, STOP |
+| Issue not found / closed | Warn, ask user |
+| Issue is a feature | Redirect to `/feature-workflow`, STOP |
+| Dirty working tree | Isolate with branch, don't revert unrelated changes |
+| No labels (ambiguous type) | Ask user to classify |
+| Codex MCP unavailable | Use 4f manual fallback; mark audit log `threadId: manual-fallback` |
+| Test gate fails 3x | Report errors, keep branch, STOP |
+| `check_gh_issue_mirror.sh` blocks tracker edit | Add `GH: #N` to the row's Notes column, retry |
+| `check_codex_audit_artifact.sh` blocks `gh pr merge` | Verify the audit log file exists at the expected path with valid frontmatter |
+| `check_terminal_status_evidence.sh` blocks tracker edit | Only fires for features (`VERIFIED`) — bug `FIXED` is not gated. If you hit it, you're flipping a feature row; write the evidence file |
+| Branch already exists | Ask user: reuse or rename |
+| Verification reveals a regression | Reopen the issue, file a new bug, do NOT close |

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 152
-        MARKETING_VERSION: 3.14.43
+        CURRENT_PROJECT_VERSION: 153
+        MARKETING_VERSION: 3.14.44
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4038,13 +4038,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 152;
+				CURRENT_PROJECT_VERSION = 153;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.43;
+				MARKETING_VERSION = 3.14.44;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4188,13 +4188,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 152;
+				CURRENT_PROJECT_VERSION = 153;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.43;
+				MARKETING_VERSION = 3.14.44;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

Adds 4 new skills under `.claude/skills/` mirroring the orchestration slash commands so they auto-trigger on natural-language requests instead of requiring an explicit `/`-prefixed invocation:

- `file-bug` — file/mirror a GH issue for a `docs/bugs.md` row
- `file-feature` — file/mirror a GH issue for a `docs/features.md` row
- `feature-workflow` — drive a feature through the binding 6-gate sequence (rule 47)
- `fix-issue` — end-to-end GH-issue resolver (single + multi-issue worktree pipelines)

## Conversion shape per skill

- `name: <command-name>` added
- `description:` expanded with explicit trigger phrases ("Use this skill whenever..."), quoted user-language patterns ('file bug 115', 'fix issue #340'), and skill scope guards (file-bug stays mirror-only and routes new bug triage to triage; fix-issue redirects feature/enhancement issues to feature-workflow per rule 47)
- `argument-hint:` dropped (skills handle natural input)
- `## Input` section replaces the `$ARGUMENTS` placeholder with parse-from-user-request guidance

## Why mirror, not link

Existing skills under `.claude/skills/` are self-contained (e.g. `triage`, `release-gate`, `planning`). Mirroring keeps that convention. Single-source-of-truth concerns can be addressed later by hierarchical splitting via `references/` if the larger two (`fix-issue` 600 lines, `feature-workflow` 650 lines) drift.

## Validation

- YAML frontmatter parses cleanly via `ruby -ryaml`.
- Body workflow content matches the source commands.
- Slash commands at `.claude/commands/<name>.md` are unchanged — explicit invocation still works.

## Type of Change

- [x] New skills (auto-trigger surface for orchestration commands)