### PR TITLE
fix(verification/#7): correct production-code paths in evidence file

### DIFF
--- a/dev-docs/verification/feature-7-20260507.md
+++ b/dev-docs/verification/feature-7-20260507.md
@@ -9,7 +9,7 @@ verifier: claude
 device_or_simulator: iPhone 17 Pro Simulator
 os_version: iOS 26.4.1
 build_configuration: Debug
-backend: in-process production `BookmarkFeedback` with `UIImpactFeedbackGenerator(.light)` — pure haptic surface, no mocks
+backend: in-process production `HapticFeedbackProvider` (`UIImpactFeedbackGenerator(.light)`) wired through `ReaderNotificationHandlers.handleBookmarkRequest` — pure haptic surface, no mocks (test uses `MockHapticProvider` to count calls)
 result: partial
 ---
 
@@ -108,9 +108,17 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
   - `vreaderTests/Views/Reader/BookmarkFeedbackTests.swift`
     (`BookmarkFeedback` — 5 tests)
 - Production code:
-  - `vreader/Views/Reader/BookmarkFeedback.swift` (or whichever
-    file declares the `BookmarkFeedback` type that wraps
+  - `vreader/Services/HapticFeedback.swift` — defines
+    `HapticFeedbackProviding` protocol + `HapticFeedbackProvider`
+    class (the production implementation that wraps
     `UIImpactFeedbackGenerator(.light)`)
+  - `vreader/Views/Reader/ReaderNotificationHandlers.swift` —
+    contains `handleBookmarkRequest`, which receives an
+    `(any HapticFeedbackProviding)?` and calls
+    `triggerLightImpact()` on the success path. (The test file
+    `BookmarkFeedbackTests` has the test-suite name "BookmarkFeedback"
+    after the *behaviour*, not after a same-named source type;
+    there is no `BookmarkFeedback.swift`.)
 - Cross-references:
   - feature #1 (Edit and delete bookmarks — same `BookmarkFeedback`
     surface; haptic is one slice of #1's 6-suite CRUD evidence)

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 173
-        MARKETING_VERSION: 3.14.64
+        CURRENT_PROJECT_VERSION: 174
+        MARKETING_VERSION: 3.14.65
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4038,13 +4038,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 173;
+				CURRENT_PROJECT_VERSION = 174;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.64;
+				MARKETING_VERSION = 3.14.65;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4188,13 +4188,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 173;
+				CURRENT_PROJECT_VERSION = 174;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.64;
+				MARKETING_VERSION = 3.14.65;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
Audit pass found that `dev-docs/verification/feature-7-20260507.md` (filed earlier today) cited `vreader/Views/Reader/BookmarkFeedback.swift` as the production type. **That file does not exist.**

Real production wiring (verified by reading the test file's `@coordinates-with` header and grepping the codebase):

| Test claim | Real production code |
|---|---|
| BookmarkFeedback type | Doesn't exist as a type or file |
| Haptic implementation | `vreader/Services/HapticFeedback.swift` — `HapticFeedbackProviding` protocol + `HapticFeedbackProvider` class |
| Wiring point | `vreader/Views/Reader/ReaderNotificationHandlers.swift` — `handleBookmarkRequest` dispatches to haptic provider on success |

The `@Suite("BookmarkFeedback")` name in the test file is a *behaviour* descriptor, not a type name. Test uses `MockHapticProvider` against the real `HapticFeedbackProviding` protocol.

Slice claims (5 tests pinning haptic-fire on add / no-fire on error / no-debounce / .light intensity) all stand — only the production-code reference was wrong.

## Validation
- [x] No source code changed; evidence-file accuracy fix
- [x] Version bumped 3.14.64 → 3.14.65 per per-PR rule