### PR TITLE
fix(verification): correct fabricated production-code paths in 6 evidence files

### DIFF
--- a/dev-docs/verification/feature-29-20260507.md
+++ b/dev-docs/verification/feature-29-20260507.md
@@ -171,7 +171,6 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
   - `vreaderTests/Services/Backup/WebDAVProviderSelectiveRestoreTests.swift` (covered separately as feature #46/#47 slice)
   - `vreaderTests/Services/Backup/WebDAVBlobStoreTests.swift`
   - `vreaderTests/Services/Backup/WebDAVATSTests.swift`
-  - `vreaderTests/Services/Backup/ZIPWriterTests.swift`
   - `vreaderTests/Services/Backup/BlobPathTests.swift`
   - `vreaderTests/Services/Backup/BackupLibraryManifestTests.swift`
   - `vreaderTests/Services/Backup/BackupBookProjectionTests.swift`
@@ -185,8 +184,8 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
   - `vreader/Services/Backup/WebDAVBlobStore.swift`
   - `vreader/Services/Backup/ZIPWriter.swift`
   - `vreader/Services/Backup/BlobPath.swift`
-  - `vreader/Services/Backup/BackupLibraryManifest.swift`
-  - `vreader/Services/Backup/BackupBookProjection.swift`
+  - `vreader/Services/Backup/BackupSectionDTOs.swift` — declares `BackupLibraryManifestEnvelope` (the on-the-wire JSON envelope) plus `BackupBookEntry` and the per-section payload DTOs the manifest contains
+  - `vreader/Services/PersistenceActor+Backup.swift` — declares `struct BackupBookProjection` (the actor-owned read-only book snapshot the collector writes into the manifest)
   - `vreader/Views/Settings/WebDAVSettingsView.swift` (UI)
 - Cross-references:
   - feature #46 (materializing restore — extends the same WebDAV core)

--- a/dev-docs/verification/feature-34-20260507.md
+++ b/dev-docs/verification/feature-34-20260507.md
@@ -150,6 +150,6 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
   - `vreaderTests/Models/CollectionTests.swift`
 - Production code:
   - `vreader/Models/BookCollection.swift`
-  - `vreader/Services/Persistence/PersistenceActor+Collections.swift`
+  - `vreader/Services/PersistenceActor+Collections.swift`
   - `vreader/Models/Book.swift` (series fields)
-  - `vreader/Schemas/SchemaV6.swift`
+  - `vreader/Models/Migration/SchemaV6.swift`

--- a/dev-docs/verification/feature-41-20260507.md
+++ b/dev-docs/verification/feature-41-20260507.md
@@ -31,8 +31,8 @@ auto-scroll-specific acceptance criteria.
 |---|---|---|
 | `updateHighlight` sets `uiState.scrollToOffset` to the **start of the current sentence** while TTS is speaking | `updateHighlight sets highlightRange when TTS is speaking` (`TTSHighlightCoordinatorTests.swift:74-90`) — asserts `scrollToOffset != nil` AND traces production code at `TTSHighlightCoordinator.swift:66`: `uiState.scrollToOffset = range.location` (NOT a word-level position; sentence-anchored) | pass |
 | Auto-scroll target is the sentence start, not the word start | inspection of `TTSHighlightCoordinator.updateHighlight` line 66 — `scrollToOffset = range.location` where `range` is the sentence range from the binary search; not the word offset that came from TTS. This means the reader stays anchored at sentence boundaries even as TTS narrates word-by-word | passes-by-inspection |
-| Auto-scroll integrates with `TXTTextViewBridge.onChange(of: ttsService)` (TXT path) | code-read at `vreader/Views/Reader/Bridges/TXTTextViewBridge.swift` (TXT host wires `onChange` to call `coordinator.updateHighlight`) — confirmed wired; not unit-tested | passes-by-inspection |
-| Auto-scroll integrates with `MDReaderHost.onChange(of: ttsService)` (MD path) | code-read at `vreader/Views/Reader/MDReaderHost.swift` — same wiring pattern as TXT | passes-by-inspection |
+| Auto-scroll integrates with `TXTTextViewBridge.onChange(of: ttsService)` (TXT path) | code-read at `vreader/Views/Reader/TXTTextViewBridge.swift` (TXT host wires `onChange` to call `coordinator.updateHighlight`) — confirmed wired; not unit-tested | passes-by-inspection |
+| Auto-scroll integrates with `MDReaderHost.onChange(of: ttsService)` (MD path) | code-read at `vreader/Views/Reader/ReaderFormatHosts.swift` (the file that declares `MDReaderHost: View`) — same wiring pattern as TXT | passes-by-inspection |
 | EPUB / AZW3 / PDF auto-scroll is INTENTIONALLY out of scope (web views + PDFKit don't share TextKit's scroll surface) | documented at `TTSHighlightCoordinator.swift:9` ("TXT/MD only — EPUB/PDF deferred") | passes-by-inspection (intentional scope) |
 | Same 9-test coverage as feature #40 (tokenizer + range lookup + UI state update) | see `feature-40-20260507.md` — same coordinator | pass |
 | End-to-end UI: real TTS playback → SwiftUI `.onChange` observer → coordinator → `TXTTextViewBridge` scrolls the table view to the new offset | DEFERRED (no display, no audio session, no UI gesture path) | deferred |
@@ -97,7 +97,9 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
 - Production code:
   - `vreader/Services/TTS/TTSHighlightCoordinator.swift:66`
     (`scrollToOffset = range.location` — the auto-scroll target)
-  - `vreader/Views/Reader/Bridges/TXTTextViewBridge.swift` (TXT
-    host's `onChange` consumer)
-  - `vreader/Views/Reader/MDReaderHost.swift` (MD host's `onChange`
-    consumer)
+  - `vreader/Views/Reader/TXTTextViewBridge.swift` (TXT host's
+    `onChange` consumer)
+  - `vreader/Views/Reader/ReaderFormatHosts.swift` — declares
+    `MDReaderHost: View` (the MD host's `onChange` consumer lives
+    inside this file alongside `TXTReaderHost`, `EPUBReaderHost`,
+    `PDFReaderHost`, `FoliateReaderHost`)

--- a/dev-docs/verification/feature-6-20260507.md
+++ b/dev-docs/verification/feature-6-20260507.md
@@ -149,7 +149,7 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
 - Production code:
   - `vreader/Services/PreferenceStore.swift`
   - `vreader/ViewModels/LibraryViewModel.swift`
-  - `vreader/Views/Library/LibraryView.swift` (sort picker UI)
+  - `vreader/Views/LibraryView.swift` (sort picker UI)
 - Cross-references:
   - feature #19 (DUPLICATE of #6 — display-mode persistence merged here)
   - feature #20 (sort-order reset — bundled into this feature's surface)

--- a/dev-docs/verification/feature-8-20260507.md
+++ b/dev-docs/verification/feature-8-20260507.md
@@ -129,10 +129,17 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
 - Production code:
   - `vreader/Views/Reader/ReadingProgressBar.swift` (shared SwiftUI view)
   - Per-format wiring at:
-    - `vreader/Views/Reader/TXTReaderHost.swift` / `TXTTextViewBridge.swift` (continuous)
-    - `vreader/Views/Reader/MDReaderHost.swift` (continuous)
-    - `vreader/Views/Reader/PDFReaderContainerView.swift` + `PDFProgressHelper.swift` (page-based)
-    - `vreader/Views/Reader/EPUBReaderHost.swift` (chapter+progression via Foliate Locator)
+    - `vreader/Views/Reader/ReaderFormatHosts.swift` — declares
+      `TXTReaderHost`, `MDReaderHost`, `EPUBReaderHost`,
+      `PDFReaderHost`, `FoliateReaderHost` (all the host structs
+      live in this single file)
+    - `vreader/Views/Reader/TXTTextViewBridge.swift` (continuous
+      scroll-offset → progress fraction)
+    - `vreader/Views/Reader/PDFReaderContainerView.swift` +
+      `vreader/Views/Reader/PDFProgressHelper.swift` (page-based)
+    - EPUB chapter+progression flows through Foliate's Locator
+      (chapterIndex + chapterProgression); the host struct in
+      ReaderFormatHosts.swift wires it into `ReadingProgressBar`
 - Cross-references:
   - feature #11 (EPUB rendering — provides EPUB Locator with totalProgression)
   - feature #17 (PDF — covered separately, includes PDF position service)

--- a/dev-docs/verification/feature-9-20260507.md
+++ b/dev-docs/verification/feature-9-20260507.md
@@ -120,7 +120,7 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
     LibraryBookItem.resolvedFileURL, ShareSheet.shareItems)
 - Production code:
   - `vreader/Views/Library/BookInfoSheet.swift`
-  - `vreader/Views/Library/LibraryView.swift` (context-menu wiring)
+  - `vreader/Views/LibraryView.swift` (context-menu wiring)
   - `vreader/Models/LibraryBookItem.swift` (resolvedFileURL)
 - Cross-references:
   - feature #6 (library preferences — shared PhotosPicker for Set Cover)

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 174
-        MARKETING_VERSION: 3.14.65
+        CURRENT_PROJECT_VERSION: 175
+        MARKETING_VERSION: 3.14.66
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4038,13 +4038,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 174;
+				CURRENT_PROJECT_VERSION = 175;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.65;
+				MARKETING_VERSION = 3.14.66;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4188,13 +4188,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 174;
+				CURRENT_PROJECT_VERSION = 175;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.65;
+				MARKETING_VERSION = 3.14.66;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
Audit pass found 11 path references across 6 evidence files (#6, #8, #9, #29, #34, #41) that don't exist now AND didn't exist at the recorded `commit_sha` (verified via `git show <sha>:<path>`). Each was a plausible-sounding but invented filename — likely produced when earlier verification cron sessions paraphrased the test file's surface without checking the actual production layout.

## Corrections

| Feature | Was (fabricated) | Reality |
|---|---|---|
| #6, #9 | `vreader/Views/Library/LibraryView.swift` | `vreader/Views/LibraryView.swift` (no `Library/` subdir) |
| #8 | `TXTReaderHost.swift`, `MDReaderHost.swift`, `EPUBReaderHost.swift` as separate files | all 5 host structs declared in `vreader/Views/Reader/ReaderFormatHosts.swift` |
| #29 | `vreader/Services/Backup/BackupBookProjection.swift` | `struct BackupBookProjection` in `vreader/Services/PersistenceActor+Backup.swift` |
| #29 | `vreader/Services/Backup/BackupLibraryManifest.swift` | `BackupLibraryManifestEnvelope` in `vreader/Services/Backup/BackupSectionDTOs.swift` |
| #29 | `vreaderTests/Services/Backup/ZIPWriterTests.swift` | doesn't exist; ZIPWriter exercise is via gated `WebDAVBackupIntegrationTests` |
| #34 | `vreader/Schemas/SchemaV6.swift` | `vreader/Models/Migration/SchemaV6.swift` |
| #34 | `vreader/Services/Persistence/PersistenceActor+Collections.swift` | `vreader/Services/PersistenceActor+Collections.swift` (no `Persistence/` subdir) |
| #41 | `vreader/Views/Reader/Bridges/TXTTextViewBridge.swift` | `vreader/Views/Reader/TXTTextViewBridge.swift` (no `Bridges/` subdir) |
| #41 | `vreader/Views/Reader/MDReaderHost.swift` | `vreader/Views/Reader/ReaderFormatHosts.swift` |

## Slice claims unchanged

All test counts, suite names, and what-was-covered claims still stand. Only the production-code path references were wrong — they were navigation aids, not load-bearing test results.

## Validation
- [x] No source code changed; evidence-file accuracy fix
- [x] Re-verified after edits: zero remaining `vreader[Tests]?/...` paths in updated files that fail to resolve
- [x] Version bumped 3.14.65 → 3.14.66 per per-PR rule