### PR TITLE
docs: fill TBD commit SHAs + document PARTIALLY FIXED status

### DIFF
--- a/dev-docs/verification/feature-11-20260506b.md
+++ b/dev-docs/verification/feature-11-20260506b.md
@@ -2,7 +2,7 @@
 kind: feature
 id: 11
 status_target: VERIFIED
-commit_sha: TBD
+commit_sha: 4a5f79af59ed147cfdc405d6b3e72543630a9cfe
 app_version: 3.14.13 (build 122)
 date: 2026-05-06
 verifier: claude

--- a/dev-docs/verification/feature-21-20260506.md
+++ b/dev-docs/verification/feature-21-20260506.md
@@ -2,7 +2,7 @@
 kind: feature
 id: 21
 status_target: VERIFIED
-commit_sha: TBD
+commit_sha: 8671d5f83fb11d0b011cc542e296c22fc1dd70ba
 app_version: 3.14.16 (build 125)
 date: 2026-05-06
 verifier: claude

--- a/dev-docs/verification/feature-37-20260506.md
+++ b/dev-docs/verification/feature-37-20260506.md
@@ -2,7 +2,7 @@
 kind: feature
 id: 37
 status_target: VERIFIED
-commit_sha: TBD
+commit_sha: ee047769a434845131743fc7f2ec833a9999a56a
 app_version: 3.14.20 (build 129)
 date: 2026-05-06
 verifier: claude

--- a/dev-docs/verification/feature-44-20260506b.md
+++ b/dev-docs/verification/feature-44-20260506b.md
@@ -2,7 +2,7 @@
 kind: feature
 id: 44
 status_target: DONE
-commit_sha: TBD
+commit_sha: 4d47e1ec7a5bf08d2404b0832e0d567d25d1cd40
 app_version: 3.14.17 (build 126)
 date: 2026-05-06
 verifier: claude

--- a/docs/bugs.md
+++ b/docs/bugs.md
@@ -39,6 +39,7 @@ Track bugs here. Tell the agent "fix bug #N" to start a fix.
 - `TODO` — not started
 - `IN PROGRESS` — being worked on
 - `FIXED` — fix verified in working tree (not necessarily committed)
+- `PARTIALLY FIXED` — primary cause / mitigation shipped, but a documented follow-up scope remains tracked in the Notes column. Treat as a soft-FIXED that doesn't qualify for archive yet because the GH issue stays open until the remaining scope lands or is explicitly deferred.
 - `REOPENED` — previously fixed but regressed; link to original fix
 - `DUPLICATE` — duplicate of another bug; note `DUPLICATE OF #N`
 - `WONT FIX` — intentional behavior or out of scope

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 175
-        MARKETING_VERSION: 3.14.66
+        CURRENT_PROJECT_VERSION: 176
+        MARKETING_VERSION: 3.14.67
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4038,13 +4038,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 175;
+				CURRENT_PROJECT_VERSION = 176;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.66;
+				MARKETING_VERSION = 3.14.67;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4188,13 +4188,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 175;
+				CURRENT_PROJECT_VERSION = 176;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.66;
+				MARKETING_VERSION = 3.14.67;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
Audit pass found two metadata gaps:

1. **4 evidence files had `commit_sha: TBD` placeholders** that were never filled in. Each was created by a verify PR but the SHA was left as TBD because the agent at the time didn't know which SHA the merge would land at. Filled with the verify PR's merge-commit SHA (the canonical reachable SHA representing main's state when the verification result became canonical):
   - `feature-11-20260506b.md` → `4a5f79a` (PR #309)
   - `feature-21-20260506.md` → `8671d5f` (PR #315)
   - `feature-37-20260506.md` → `ee04776` (PR #327)
   - `feature-44-20260506b.md` → `4d47e1e` (PR #318)

2. **`docs/bugs.md` ## Statuses missed `PARTIALLY FIXED`**. Listed TODO / IN PROGRESS / FIXED / REOPENED / DUPLICATE / WONT FIX, but not PARTIALLY FIXED — even though that status is in active use for bugs #128 and #141 (mitigation shipped, follow-up scope tracked). Documented the meaning explicitly: primary cause shipped, GH issue stays open until remaining scope lands.

## Validation
- [x] No source code changed
- [x] After fix: zero `TBD` strings remain in evidence frontmatter
- [x] Version bumped 3.14.66 → 3.14.67 per per-PR rule