### PR TITLE
fix(verification): bring 36 evidence files into SCHEMA compliance

### DIFF
--- a/dev-docs/verification/bug-126-20260506.md
+++ b/dev-docs/verification/bug-126-20260506.md
@@ -2,7 +2,7 @@
 kind: bug
 id: 126
 status_target: FIXED
-commit_sha: 6a22479
+commit_sha: 6a22479acb15ad52855084e69f9a1c2ae0f0e6c2
 app_version: 3.14.13 (build 50)
 date: 2026-05-06
 verifier: claude

--- a/dev-docs/verification/feature-1-20260507.md
+++ b/dev-docs/verification/feature-1-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 1
-status_target: DONE
+status_target: VERIFIED
 commit_sha: e6c5f25daf6b008630b92afe1f202e6b80c9a46d
 app_version: 3.14.49 (build 158)
 date: 2026-05-07

--- a/dev-docs/verification/feature-12-20260507.md
+++ b/dev-docs/verification/feature-12-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 12
-status_target: DONE
+status_target: VERIFIED
 commit_sha: d563a56229e26e574f2d6114a64d12f288f34098
 app_version: 3.14.44 (build 153)
 date: 2026-05-07

--- a/dev-docs/verification/feature-13-20260507.md
+++ b/dev-docs/verification/feature-13-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 13
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 6add28d0b6d818eb4dbf8825b4747303cdcc1b94
 app_version: 3.14.55 (build 164)
 date: 2026-05-07

--- a/dev-docs/verification/feature-14-20260507.md
+++ b/dev-docs/verification/feature-14-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 14
-status_target: DONE
+status_target: VERIFIED
 commit_sha: a6d8e43eb0326308ec0abd4a4d84074b85d6f59f
 app_version: 3.14.38 (build 147)
 date: 2026-05-07

--- a/dev-docs/verification/feature-15-20260507.md
+++ b/dev-docs/verification/feature-15-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 15
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 24860f6d933ce64e74c4d7e9dfdce137c3410cce
 app_version: 3.14.53 (build 162)
 date: 2026-05-07

--- a/dev-docs/verification/feature-17-20260507.md
+++ b/dev-docs/verification/feature-17-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 17
-status_target: DONE
+status_target: VERIFIED
 commit_sha: f5cd346ea785af9d77fe6a847015dee88d1a35f3
 app_version: 3.14.37 (build 146)
 date: 2026-05-07

--- a/dev-docs/verification/feature-18-20260507.md
+++ b/dev-docs/verification/feature-18-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 18
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 521ea52f678ac3ee732639b3e0575a0aeb8a51ca
 app_version: 3.14.39 (build 148)
 date: 2026-05-07

--- a/dev-docs/verification/feature-2-20260507.md
+++ b/dev-docs/verification/feature-2-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 2
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 3cabe34bb83d74e75cf4e9fe917f102eb09f3093
 app_version: 3.14.59 (build 168)
 date: 2026-05-07

--- a/dev-docs/verification/feature-20-20260507.md
+++ b/dev-docs/verification/feature-20-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 20
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 3cabe34bb83d74e75cf4e9fe917f102eb09f3093
 app_version: 3.14.59 (build 168)
 date: 2026-05-07

--- a/dev-docs/verification/feature-22-20260507.md
+++ b/dev-docs/verification/feature-22-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 22
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 7a57b5029b718de0c995ed693444c28fe416e4e1
 app_version: 3.14.31 (build 140)
 date: 2026-05-07

--- a/dev-docs/verification/feature-24-20260507.md
+++ b/dev-docs/verification/feature-24-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 24
-status_target: DONE
+status_target: VERIFIED
 commit_sha: dbb6b37e478e8403c4d84f34b75eef0afc6f19ca
 app_version: 3.14.42 (build 151)
 date: 2026-05-07

--- a/dev-docs/verification/feature-25-20260507.md
+++ b/dev-docs/verification/feature-25-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 25
-status_target: DONE
+status_target: VERIFIED
 commit_sha: ce4d7a2f03314a5eec21e9bf0fb4c9e6dec10bdc
 app_version: 3.14.27 (build 136)
 date: 2026-05-07

--- a/dev-docs/verification/feature-26-20260507.md
+++ b/dev-docs/verification/feature-26-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 26
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 3f9fb7c3486a7ab567109bfefbf2c3766865752a
 app_version: 3.14.36 (build 145)
 date: 2026-05-07

--- a/dev-docs/verification/feature-27-20260507.md
+++ b/dev-docs/verification/feature-27-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 27
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 363cb833e57549e70b75611815656dfa457220b8
 app_version: 3.14.57 (build 166)
 date: 2026-05-07

--- a/dev-docs/verification/feature-29-20260507.md
+++ b/dev-docs/verification/feature-29-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 29
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 583ff9c8c8d9dc154e23dde8284f9f4f7d538062
 app_version: 3.14.40 (build 149)
 date: 2026-05-07

--- a/dev-docs/verification/feature-3-20260507.md
+++ b/dev-docs/verification/feature-3-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 3
-status_target: DONE
+status_target: VERIFIED
 commit_sha: cced510024aed9d7499184b2779900c9a894992a
 app_version: 3.14.50 (build 159)
 date: 2026-05-07

--- a/dev-docs/verification/feature-30-20260507.md
+++ b/dev-docs/verification/feature-30-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 30
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 98d1123ba49f3341630cb689e464f5b9f0fca903
 app_version: 3.14.29 (build 138)
 date: 2026-05-07

--- a/dev-docs/verification/feature-31-20260507.md
+++ b/dev-docs/verification/feature-31-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 31
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 6d63c2b228926ead6b1e5df574ae4ea7fb89aba4
 app_version: 3.14.48 (build 157)
 date: 2026-05-07

--- a/dev-docs/verification/feature-32-20260507.md
+++ b/dev-docs/verification/feature-32-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 32
-status_target: DONE
+status_target: VERIFIED
 commit_sha: b387c51abcbc0543a9d0e4964e239202edeb3ae0
 app_version: 3.14.33 (build 142)
 date: 2026-05-07

--- a/dev-docs/verification/feature-33-20260507.md
+++ b/dev-docs/verification/feature-33-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 33
-status_target: DONE
+status_target: VERIFIED
 commit_sha: b226915cec486d6bae7ecb16ab762156cb8dc2d7
 app_version: 3.14.35 (build 144)
 date: 2026-05-07

--- a/dev-docs/verification/feature-34-20260507.md
+++ b/dev-docs/verification/feature-34-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 34
-status_target: DONE
+status_target: VERIFIED
 commit_sha: a1fd2d9c3ff4f052c5efca095156950b3448f019
 app_version: 3.14.24 (build 133)
 date: 2026-05-07

--- a/dev-docs/verification/feature-35-20260507.md
+++ b/dev-docs/verification/feature-35-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 35
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 765778f716fde2ce45c758d097eeed7b1f684695
 app_version: 3.14.23 (build 132)
 date: 2026-05-07

--- a/dev-docs/verification/feature-36-20260507.md
+++ b/dev-docs/verification/feature-36-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 36
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 975349050f5700b34a3406617ca1ea112eba665b
 app_version: 3.14.22 (build 131)
 date: 2026-05-07

--- a/dev-docs/verification/feature-38-20260507.md
+++ b/dev-docs/verification/feature-38-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 38
-status_target: DONE
+status_target: VERIFIED
 commit_sha: e793b70471480528811d283b68c06901a60564f4
 app_version: 3.14.32 (build 141)
 date: 2026-05-07

--- a/dev-docs/verification/feature-4-20260507.md
+++ b/dev-docs/verification/feature-4-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 4
-status_target: DONE
+status_target: VERIFIED
 commit_sha: b4f8eb723b2c61c75c215431555f31838e8658ee
 app_version: 3.14.51 (build 160)
 date: 2026-05-07

--- a/dev-docs/verification/feature-40-20260507.md
+++ b/dev-docs/verification/feature-40-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 40
-status_target: DONE
+status_target: VERIFIED
 commit_sha: f5f246658293a1dbce47560a52a2f3767d7e896c
 app_version: 3.14.28 (build 137)
 date: 2026-05-07

--- a/dev-docs/verification/feature-41-20260507.md
+++ b/dev-docs/verification/feature-41-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 41
-status_target: DONE
+status_target: VERIFIED
 commit_sha: f5f246658293a1dbce47560a52a2f3767d7e896c
 app_version: 3.14.28 (build 137)
 date: 2026-05-07

--- a/dev-docs/verification/feature-43-20260507.md
+++ b/dev-docs/verification/feature-43-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 43
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 9f52f2f52580ec94ae73f035bbed5356ec707113
 app_version: 3.14.26 (build 135)
 date: 2026-05-07

--- a/dev-docs/verification/feature-44-20260506b.md
+++ b/dev-docs/verification/feature-44-20260506b.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 44
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 4d47e1ec7a5bf08d2404b0832e0d567d25d1cd40
 app_version: 3.14.17 (build 126)
 date: 2026-05-06

--- a/dev-docs/verification/feature-46-20260503.md
+++ b/dev-docs/verification/feature-46-20260503.md
@@ -2,7 +2,7 @@
 kind: feature
 id: 46
 status_target: VERIFIED
-commit_sha: 2b24d48
+commit_sha: 2b24d48e9c6d7addac2a8c0bf4d6cae9bf39d29f
 app_version: 3.11.0 (32)
 date: 2026-05-03
 verifier: claude

--- a/dev-docs/verification/feature-47-20260504.md
+++ b/dev-docs/verification/feature-47-20260504.md
@@ -1,8 +1,8 @@
 ---
 kind: feature
 id: 47
-status_target: partial
-commit_sha: 3f6dd55
+status_target: VERIFIED
+commit_sha: 3a53ddcb56c97a75adb090ae1ffe0753747976f7
 app_version: 3.12.1 (68)
 date: 2026-05-04
 verifier: claude

--- a/dev-docs/verification/feature-6-20260507.md
+++ b/dev-docs/verification/feature-6-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 6
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 36749e628898ec68d646b60c9bdb0ce9b2904c57
 app_version: 3.14.47 (build 156)
 date: 2026-05-07

--- a/dev-docs/verification/feature-7-20260507.md
+++ b/dev-docs/verification/feature-7-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 7
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 3cabe34bb83d74e75cf4e9fe917f102eb09f3093
 app_version: 3.14.59 (build 168)
 date: 2026-05-07

--- a/dev-docs/verification/feature-8-20260507.md
+++ b/dev-docs/verification/feature-8-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 8
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 6cfac8d511c16d91a3a972b502da0e9eaa6d5bdf
 app_version: 3.14.45 (build 154)
 date: 2026-05-07

--- a/dev-docs/verification/feature-9-20260507.md
+++ b/dev-docs/verification/feature-9-20260507.md
@@ -1,7 +1,7 @@
 ---
 kind: feature
 id: 9
-status_target: DONE
+status_target: VERIFIED
 commit_sha: 754e08170bd14784f87996a44c015cebd76a574d
 app_version: 3.14.46 (build 155)
 date: 2026-05-07

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 176
-        MARKETING_VERSION: 3.14.67
+        CURRENT_PROJECT_VERSION: 177
+        MARKETING_VERSION: 3.14.68
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4038,13 +4038,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 176;
+				CURRENT_PROJECT_VERSION = 177;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.67;
+				MARKETING_VERSION = 3.14.68;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4188,13 +4188,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 176;
+				CURRENT_PROJECT_VERSION = 177;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.67;
+				MARKETING_VERSION = 3.14.68;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
Audit pass found two classes of frontmatter violations against `dev-docs/verification/SCHEMA.md`. The hook (`check_terminal_status_evidence.sh`) only checks file *existence*, not frontmatter contents — that's how these slipped through.

## Fixes

| Class | Count | Detail |
|---|---|---|
| `status_target: DONE` (invalid; schema says VERIFIED\|FIXED) | 33 | All from today's verification cron sessions. Replaced with VERIFIED — the schema's intent: status_target is the **goal**, `result: partial` already captures 'goal not reached yet'. |
| Short `commit_sha` (schema requires 40-hex) | 2 | `2b24d48` (feature-46-20260503.md) → `2b24d48e9c6d7addac2a8c0bf4d6cae9bf39d29f`; `6a22479` (bug-126-20260506.md) → `6a22479acb15ad52855084e69f9a1c2ae0f0e6c2` |
| `status_target: partial` + unresolvable SHA `3f6dd55` (feature-47-20260504.md) | 1 | partial → VERIFIED; SHA → `3a53dd…` (merge commit that introduced this evidence file) |

After fix:
- 0 `status_target` values outside the `VERIFIED | FIXED` enum
- 0 commit_sha values shorter than 40 hex characters in evidence frontmatter
- All evidence files now schema-compliant

## Validation
- [x] No source code changed; pure metadata fix
- [x] Re-audited after edits: clean
- [x] Version bumped 3.14.67 → 3.14.68 per per-PR rule