### PR TITLE
chore: cron logging + watchdog reads prompts from files

### DIFF
--- a/.claude/cron-logs/.gitignore
+++ b/.claude/cron-logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/.claude/cron-prompts/bugfix.md
+++ b/.claude/cron-prompts/bugfix.md
@@ -1,0 +1,3 @@
+First, log the fire: run `mkdir -p .claude/cron-logs && echo "$(date -Iseconds) bugfix FIRED" >> .claude/cron-logs/bugfix.log`. Then perform the task below. At the end of this iteration, run `echo "$(date -Iseconds) bugfix ENDED <outcome>" >> .claude/cron-logs/bugfix.log` where <outcome> is one of: work_done | no_work_in_scope | blocked | error.
+
+Pick one open GitHub issue labeled `bug` from this repo (use `gh issue list --label bug --state open --json number,labels,title`). Prefer severity:high, then severity:medium, then others. Skip issues whose body or comments indicate they are blocked (waiting on fixture, multi-iteration scope, harness gap) — leave a one-line skip note in the issue and pick the next. Then run /fix-issue #N on the chosen issue.

--- a/.claude/cron-prompts/verify.md
+++ b/.claude/cron-prompts/verify.md
@@ -1,0 +1,5 @@
+First, log the fire: run `mkdir -p .claude/cron-logs && echo "$(date -Iseconds) verify FIRED" >> .claude/cron-logs/verify.log`. Then perform the task below. At the end of this iteration, run `echo "$(date -Iseconds) verify ENDED <outcome>" >> .claude/cron-logs/verify.log` where <outcome> is one of: work_done | no_work_in_scope | blocked | error.
+
+/loop pick up a feature from @/Users/ll/workspace/vreader/docs/features.md @/Users/ll/workspace/vreader/README.md  and github issue or pr and make a device verify plan and Carry out this plan, using computer use if it is needed.
+
+SCOPE: verification only. If you discover a bug during verification, FILE it (create a GH issue with the `bug` label and add a row in docs/bugs.md per the project's bug-tracker workflow) but DO NOT fix it — the bug-fix cron handles fixes. Stay strictly in verification scope this iteration.

--- a/.claude/cron-prompts/watchdog.md
+++ b/.claude/cron-prompts/watchdog.md
@@ -1,0 +1,18 @@
+First, log the fire: run `mkdir -p .claude/cron-logs && echo "$(date -Iseconds) watchdog FIRED" >> .claude/cron-logs/watchdog.log`. Then perform the renewal task. At the end, run `echo "$(date -Iseconds) watchdog ENDED <outcome>" >> .claude/cron-logs/watchdog.log` where <outcome> is one of: work_done | no_work_in_scope | blocked | error.
+
+WATCHDOG: Renew every session-only cron (including this watchdog itself) so they don't lapse on the 7-day auto-expire.
+
+Steps:
+1. Run CronList to enumerate the active crons.
+2. For each of the 3 expected crons (verify, bugfix, watchdog), check whether it's still scheduled. If yes and its next-fire is < 24h away from the 7-day expiry, treat as needing renewal. If you cannot tell the expiry, renew anyway — recreate is idempotent in effect.
+3. To renew: CronDelete the existing job, then CronCreate with the prompt read from the corresponding file:
+   - verify cron — every hour at :23 — prompt is the contents of `.claude/cron-prompts/verify.md`
+   - bugfix cron — every 2 hours at :47 — prompt is the contents of `.claude/cron-prompts/bugfix.md`
+   - watchdog cron — every day at 04:49 — prompt is the contents of `.claude/cron-prompts/watchdog.md`
+   For each, use the Read tool to load the prompt file, then pass that exact text as the `prompt` parameter to CronCreate.
+4. If a cron is missing from CronList entirely (not just near-expiry), recreate it with the same prompt and schedule.
+5. Outcome:
+   - `work_done` if you renewed at least one cron
+   - `no_work_in_scope` if all 3 crons are already scheduled and not near expiry
+   - `blocked` if you can't read a prompt file or CronCreate refuses
+   - `error` for unrecoverable failures

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 178
-        MARKETING_VERSION: 3.14.69
+        CURRENT_PROJECT_VERSION: 179
+        MARKETING_VERSION: 3.14.70
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4038,13 +4038,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 178;
+				CURRENT_PROJECT_VERSION = 179;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.69;
+				MARKETING_VERSION = 3.14.70;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4188,13 +4188,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 178;
+				CURRENT_PROJECT_VERSION = 179;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.69;
+				MARKETING_VERSION = 3.14.70;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
Adds per-fire logging + outcome-bucketing to the 3 session-only crons (verify hourly, bugfix every 2h, watchdog daily).

## Why
Previously: cron prompts embedded in the runtime only, invisible after session restart, no per-fire log. Hard to count cadence or audit outcomes (the user just asked 'how many times did the bug-fix cron run in 24h?' and I had to grep the conversation transcript).

## What changed
- New `.claude/cron-prompts/` with verify.md / bugfix.md / watchdog.md — the watchdog now reads its renewal prompts from these files instead of embedding verbatim text.
- New `.claude/cron-logs/` with .gitignore that ignores all logs but keeps the directory tracked. Each cron prepends a `FIRED` line and appends an `ENDED <outcome>` line — outcomes ∈ {work_done, no_work_in_scope, blocked, error}.
- Rotated the 3 crons (CronDelete + CronCreate). IDs changed; schedules unchanged.

## Validation
- [x] No source code changed; tooling-only
- [x] CronList confirms 3 new crons in place: 631ba416 (verify), f22d7195 (bugfix), 487922fb (watchdog)
- [x] Version bumped 3.14.69 → 3.14.70