### PR TITLE
chore: add /cron-bootstrap slash command

### DIFF
--- a/.claude/commands/cron-bootstrap.md
+++ b/.claude/commands/cron-bootstrap.md
@@ -1,0 +1,44 @@
+---
+description: "Recreate the 3 session-only crons (verify, bugfix, watchdog) from `.claude/cron-prompts/`. Use after a Claude Code restart since the `durable` flag isn't honored by this runtime."
+---
+
+# /cron-bootstrap
+
+Re-bootstrap the verification + bug-fix + watchdog crons from the
+checked-in prompt files. Idempotent: if a cron is already present
+with the same prompt + schedule, it stays.
+
+## Steps
+
+1. Run `CronList` to see what's currently scheduled.
+
+2. For each of the 3 expected crons, check whether it's present.
+   If a cron with the same schedule + same first-line of prompt
+   exists, skip it. Otherwise, recreate.
+
+3. Recreation pattern — for each missing cron:
+   - Read the prompt from the corresponding file:
+     - verify cron — `23 * * * *` — `.claude/cron-prompts/verify.md`
+     - bugfix cron — `47 */2 * * *` — `.claude/cron-prompts/bugfix.md`
+     - watchdog cron — `49 4 * * *` — `.claude/cron-prompts/watchdog.md`
+   - Call `CronCreate` with `cron`, `recurring: true`, and the
+     prompt loaded verbatim from the file.
+
+4. Confirm with `CronList` again. Report the 3 IDs to the user.
+
+5. **Do NOT pass `durable: true`** — this runtime doesn't honor it
+   (it silently treats every job as session-only). Documenting it
+   here so future iterations don't waste a round trip.
+
+## Output
+
+A short confirmation:
+
+```
+Re-bootstrapped 3 crons:
+  <id-1> — verify, every hour at :23
+  <id-2> — bugfix, every 2h at :47
+  <id-3> — watchdog, daily at 04:49
+```
+
+If any cron was already present and skipped, say so explicitly.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 179
-        MARKETING_VERSION: 3.14.70
+        CURRENT_PROJECT_VERSION: 180
+        MARKETING_VERSION: 3.14.71
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4038,13 +4038,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 179;
+				CURRENT_PROJECT_VERSION = 180;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.70;
+				MARKETING_VERSION = 3.14.71;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4188,13 +4188,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 179;
+				CURRENT_PROJECT_VERSION = 180;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.70;
+				MARKETING_VERSION = 3.14.71;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
When VS Code (the GUI parent of Claude Code's terminal) restarts, the running `claude` process dies and all session-only crons go with it. Tried `durable: true` first — runtime ignored it (the response confirms "Session-only (not written to disk)" regardless), so persistence is unavailable from this version of the runtime.

`/cron-bootstrap` is the practical fallback: reads the 3 prompt files in `.claude/cron-prompts/` and recreates the verify + bugfix + watchdog crons in one command. Idempotent.

The command also documents the durable-flag finding inline so future iterations don't waste a round trip on it.

## Validation
- [x] No source code changed
- [x] Slash command registered (visible in skill list as `cron-bootstrap`)
- [x] Version bumped 3.14.70 → 3.14.71