### PR TITLE
docs(cron): add 4th feature cron + rule-49 ghost-shell sweep to watchdog

### DIFF
--- a/.claude/commands/cron-bootstrap.md
+++ b/.claude/commands/cron-bootstrap.md
@@ -1,10 +1,10 @@
 ---
-description: "Recreate the 3 session-only crons (verify, bugfix, watchdog) from `.claude/cron-prompts/`. Use after a Claude Code restart since the `durable` flag isn't honored by this runtime."
+description: "Recreate the 4 session-only crons (verify, bugfix, watchdog, feature) from `.claude/cron-prompts/`. Use after a Claude Code restart since the `durable` flag isn't honored by this runtime."
 ---
 
 # /cron-bootstrap
 
-Re-bootstrap the verification + bug-fix + watchdog crons from the
+Re-bootstrap the verification + bug-fix + watchdog + feature-implementation crons from the
 checked-in prompt files. Idempotent: if a cron is already present
 with the same prompt + schedule, it stays.
 
@@ -12,7 +12,7 @@ with the same prompt + schedule, it stays.
 
 1. Run `CronList` to see what's currently scheduled.
 
-2. For each of the 3 expected crons, check whether it's present.
+2. For each of the 4 expected crons, check whether it's present.
    If a cron with the same schedule + same first-line of prompt
    exists, skip it. Otherwise, recreate.
 
@@ -21,24 +21,34 @@ with the same prompt + schedule, it stays.
      - verify cron — `23 * * * *` — `.claude/cron-prompts/verify.md`
      - bugfix cron — `47 */2 * * *` — `.claude/cron-prompts/bugfix.md`
      - watchdog cron — `49 4 * * *` — `.claude/cron-prompts/watchdog.md`
+     - feature cron — `31 */3 * * *` — `.claude/cron-prompts/feature.md`
    - Call `CronCreate` with `cron`, `recurring: true`, and the
      prompt loaded verbatim from the file.
 
-4. Confirm with `CronList` again. Report the 3 IDs to the user.
+4. Confirm with `CronList` again. Report the 4 IDs to the user.
 
 5. **Do NOT pass `durable: true`** — this runtime doesn't honor it
    (it silently treats every job as session-only). Documenting it
    here so future iterations don't waste a round trip.
+
+## Why off-minute schedules
+
+Each cron's minute is staggered (`:23`, `:31`, `:47`, `:49`) to keep
+fleet-wide load distributed and to avoid hot-minute coordination
+pile-ups (every user who asks "every hour" hits :00 by default; we
+deliberately don't). When editing a schedule, keep the off-minute
+property — don't snap to `:00` or `:30`.
 
 ## Output
 
 A short confirmation:
 
 ```
-Re-bootstrapped 3 crons:
+Re-bootstrapped 4 crons:
   <id-1> — verify, every hour at :23
   <id-2> — bugfix, every 2h at :47
   <id-3> — watchdog, daily at 04:49
+  <id-4> — feature, every 3h at :31
 ```
 
 If any cron was already present and skipped, say so explicitly.

--- a/.claude/cron-prompts/feature.md
+++ b/.claude/cron-prompts/feature.md
@@ -1,0 +1,5 @@
+First, log the fire: run `mkdir -p .claude/cron-logs && echo "$(date -Iseconds) feature FIRED" >> .claude/cron-logs/feature.log`. Then perform the task below. At the end of this iteration, run `echo "$(date -Iseconds) feature ENDED <outcome>" >> .claude/cron-logs/feature.log` where <outcome> is one of: work_done | no_work_in_scope | blocked | error.
+
+Select a feature to implement from GitHub issues or local tasks, and use /feature-workflow to implement the feature.
+
+SCOPE: feature implementation only. Per `.claude/rules/47-feature-workflow.md`, `/feature-workflow` is the binding 6-gate sequence (Plan → Independent plan audit → TDD → Implementation audit → Device/integration verification → Merge); never skip a gate. If no feature is at PLANNED status with a ready dev-docs/plans/* document, log `no_work_in_scope` and stop — do not pick a TODO/IDEA-level feature and start drafting a plan inside this iteration; that's planning work, not implementation.

--- a/.claude/cron-prompts/watchdog.md
+++ b/.claude/cron-prompts/watchdog.md
@@ -1,18 +1,53 @@
-First, log the fire: run `mkdir -p .claude/cron-logs && echo "$(date -Iseconds) watchdog FIRED" >> .claude/cron-logs/watchdog.log`. Then perform the renewal task. At the end, run `echo "$(date -Iseconds) watchdog ENDED <outcome>" >> .claude/cron-logs/watchdog.log` where <outcome> is one of: work_done | no_work_in_scope | blocked | error.
+First, log the fire: run `mkdir -p .claude/cron-logs && echo "$(date -Iseconds) watchdog FIRED" >> .claude/cron-logs/watchdog.log`. Then perform the renewal + sweep tasks. At the end, run `echo "$(date -Iseconds) watchdog ENDED <outcome>" >> .claude/cron-logs/watchdog.log` where <outcome> is one of: work_done | no_work_in_scope | blocked | error.
 
-WATCHDOG: Renew every session-only cron (including this watchdog itself) so they don't lapse on the 7-day auto-expire.
+WATCHDOG: keep every session-only cron alive past the 7-day auto-expire AND sweep for rule-49 ghost background shells.
 
-Steps:
-1. Run CronList to enumerate the active crons.
-2. For each of the 3 expected crons (verify, bugfix, watchdog), check whether it's still scheduled. If yes and its next-fire is < 24h away from the 7-day expiry, treat as needing renewal. If you cannot tell the expiry, renew anyway — recreate is idempotent in effect.
-3. To renew: CronDelete the existing job, then CronCreate with the prompt read from the corresponding file:
-   - verify cron — every hour at :23 — prompt is the contents of `.claude/cron-prompts/verify.md`
-   - bugfix cron — every 2 hours at :47 — prompt is the contents of `.claude/cron-prompts/bugfix.md`
-   - watchdog cron — every day at 04:49 — prompt is the contents of `.claude/cron-prompts/watchdog.md`
-   For each, use the Read tool to load the prompt file, then pass that exact text as the `prompt` parameter to CronCreate.
-4. If a cron is missing from CronList entirely (not just near-expiry), recreate it with the same prompt and schedule.
-5. Outcome:
-   - `work_done` if you renewed at least one cron
-   - `no_work_in_scope` if all 3 crons are already scheduled and not near expiry
-   - `blocked` if you can't read a prompt file or CronCreate refuses
-   - `error` for unrecoverable failures
+## Part 1 — Cron renewal
+
+1. Run `CronList` to enumerate the active crons.
+
+2. For each of the 4 expected crons (verify, bugfix, watchdog, feature), check whether it's still scheduled. If yes and its next-fire is < 24h away from the 7-day expiry, treat as needing renewal. If you cannot tell the expiry, renew anyway — recreate is idempotent in effect.
+
+3. To renew: `CronDelete` the existing job, then `CronCreate` with the prompt read from the corresponding file:
+   - verify cron — `23 * * * *` — `.claude/cron-prompts/verify.md`
+   - bugfix cron — `47 */2 * * *` — `.claude/cron-prompts/bugfix.md`
+   - watchdog cron — `49 4 * * *` — `.claude/cron-prompts/watchdog.md`
+   - feature cron — `31 */3 * * *` — `.claude/cron-prompts/feature.md`
+   For each, use the `Read` tool to load the prompt file, then pass that exact text as the `prompt` parameter to `CronCreate`.
+
+4. If a cron is missing from `CronList` entirely (not just near-expiry), recreate it with the same prompt and schedule.
+
+## Part 2 — Rule-49 ghost-shell sweep
+
+`.claude/rules/49-background-shells.md` codifies the anti-patterns that produced the 2026-05-10 3-hour ghost-shell incident: `pgrep -f "<toolname>"` polling loops keyed on a class of work get re-armed by unrelated later invocations. The watchdog is the right place to sweep for these post-hoc.
+
+5. Scan for orphan ghost-poll patterns:
+
+   ```bash
+   ps -eo pid,etime,command | grep -E "pgrep -f .xcodebuild|pgrep -f .simctl|while .*pgrep|until .*pgrep|until [^;]*sleep [0-9]+; *done|while [^;]*sleep [0-9]+; *done" | grep -v grep
+   ```
+
+   For each match capture: PID, ETIME (process age), full command.
+
+6. Decision per match (use ETIME as the gate; format is `[[DD-]HH:]MM:SS`):
+   - **ETIME < 10 minutes**: likely a legitimate in-flight wait. Skip silently.
+   - **ETIME 10 minutes – 1 hour**: log as `suspicious` in `.claude/cron-logs/watchdog.log` (PID, command, age). Do NOT kill — the operator may be running a long test on purpose.
+   - **ETIME > 1 hour**: log as `ghost` AND kill with `kill <pid>` (TERM, not KILL-9). If still alive after 5 s, escalate to `kill -9 <pid>`. Print every kill action to stdout so it surfaces in cron telemetry.
+
+7. Also scan for stale `xcodebuild test` or `xcrun simctl` processes that have been running > 30 min — these can also become orphaned across sessions:
+
+   ```bash
+   ps -eo pid,etime,command | grep -E "xcodebuild test|xcrun simctl" | grep -v grep
+   ```
+
+   Same decision matrix as step 6 (skip < 10 min, suspicious 10–60 min, ghost > 1h).
+
+## Part 3 — Outcome
+
+8. Outcome:
+   - `work_done` if you renewed at least one cron OR killed at least one ghost shell
+   - `no_work_in_scope` if all 4 crons are scheduled, not near expiry, and no ghost shells were found
+   - `blocked` if you can't read a prompt file or `CronCreate` refuses
+   - `error` for unrecoverable failures (e.g., the sweep `ps` itself failed)
+
+   In any case, log to `.claude/cron-logs/watchdog.log` the counts: `crons_renewed=N ghost_shells_killed=M suspicious_shells_logged=K`.


### PR DESCRIPTION
## Summary

Three updates landing together — all about cron lifecycle after rule 49 (PR #506) was merged.

1. **New cron prompt** at \`.claude/cron-prompts/feature.md\` — 3h feature-implementation /loop (\`31 */3 * * *\`). Ties into \`/feature-workflow\`, with explicit guard against starting plan-level work inside an implementation iteration.
2. **\`/cron-bootstrap\` updated** — bootstraps 4 crons instead of 3. Off-minute discipline note added.
3. **Watchdog updated**:
   - Part 1 renews 4 crons (was 3).
   - Part 2 sweeps for rule-49 ghost-shell anti-patterns: orphan \`pgrep -f\` polling loops + stale \`xcodebuild\`/\`simctl\` processes. ETIME-based decision matrix: skip < 10 min, log "suspicious" 10–60 min, log + kill (TERM then KILL-9) > 1 h.
   - Fixes "everyi" typo.

## What this closes

Rule 49 (PR #506) codified the ghost-shell anti-patterns from the 2026-05-10 incident (3-hour orphan polls). This PR closes the loop: the rule prevents the pattern in new code; the watchdog catches anything that slips through and reaps it.

## Type of Change

- [x] Documentation / cron infrastructure (no Swift code touched)