### PR TITLE
docs(feature-workflow): row-level PLANNED is not a stop signal

### DIFF
--- a/.claude/commands/feature-workflow.md
+++ b/.claude/commands/feature-workflow.md
@@ -52,9 +52,32 @@ Plan around them; do not bypass.
 2. **Working tree**: `git status --porcelain`. If dirty, isolate work
    on a branch; do not revert unrelated changes.
 3. **Branch / sync**: `git fetch origin`. Confirm `main` is current.
-4. **Tracker baseline**: note the current row status. The skill's
-   transitions assume a starting status of `TODO` or `PLANNED`.
-   If already `IN PROGRESS`, resume at the appropriate gate.
+4. **Tracker baseline + entry-gate selection**: note the current row
+   status, then check whether `dev-docs/plans/*-feature-<id>-*.md`
+   exists. The two artifacts can disagree (the row's `PLANNED` may
+   have been set on the lighter row-template definition: Problem/
+   Scope/Edge Cases filled in). The combination decides where to
+   enter:
+
+   | Row status | `dev-docs/plans/*-feature-<id>-*.md` present? | Enter at |
+   |---|---|---|
+   | `TODO` | no | **Gate 1** (write the plan) |
+   | `TODO` | yes (drafted ahead, not yet audited) | **Gate 2** |
+   | `PLANNED` | no | **Gate 1** (drawing up the plan IS the work — do not bail out) |
+   | `PLANNED` | yes, no audit revision history | **Gate 2** |
+   | `PLANNED` | yes, audited (revision history shows clean Gate 2) | **Gate 3** |
+   | `IN PROGRESS` | yes (assumed) | **resume next pending WI / re-enter Gate 4 if a WI is mid-audit** |
+   | `DONE` | yes | **Gate 5b** (post-merge final acceptance) |
+   | `VERIFIED` | yes | already complete; nothing to do |
+
+   **Do not stop because the plan doc is missing.** Drawing up the
+   `dev-docs/plans/` doc is Gate 1's deliverable, not a precondition.
+   A row already at `PLANNED` whose dev-docs plan doesn't exist
+   means: row-level template was filled, full implementation plan
+   wasn't lifted yet — lift it now (Gate 1), audit it (Gate 2),
+   then proceed. Only TODO/IDEA-level rows whose row-template
+   itself is empty (no Problem/Scope/Edge Cases at all) need
+   triage before Gate 1 is meaningful — those redirect to /triage.
 5. **Bug-vs-feature sanity check**: re-confirm this is a feature
    (capability never implemented), not a bug (broken implementation).
    If it's a bug → STOP, redirect to `/fix-issue`.
@@ -67,7 +90,7 @@ Plan around them; do not bypass.
 |---|---|
 | Required artifact | `dev-docs/plans/YYYYMMDD-feature-<id>-<slug>.md` with all required sections (see below) |
 | Owner / auditor | Author = orchestrator (or Planner subagent). No auditor — that's Gate 2. |
-| Status transition | row stays `TODO` until Gate 2 passes; then → `PLANNED` |
+| Status transition | If row was `TODO`: stays `TODO` through Gate 1; flips to `PLANNED` only after Gate 2 passes. If row was already `PLANNED` (row-template definition filled but no plan doc): stays `PLANNED` — do NOT regress to `TODO`. The plan doc fills in what was missing |
 | Blocking hook | `check_gh_issue_mirror.sh` fires on the `PLANNED` flip (must have `GH: #N` in row Notes; create the issue here) |
 | Exit criteria | Plan file exists at the documented path with all required sections filled in |
 

--- a/.claude/cron-prompts/feature.md
+++ b/.claude/cron-prompts/feature.md
@@ -2,4 +2,13 @@ First, log the fire: run `mkdir -p .claude/cron-logs && echo "$(date -Iseconds) 
 
 Select a feature to implement from GitHub issues or local tasks, and use /feature-workflow to implement the feature.
 
-SCOPE: feature implementation only. Per `.claude/rules/47-feature-workflow.md`, `/feature-workflow` is the binding 6-gate sequence (Plan → Independent plan audit → TDD → Implementation audit → Device/integration verification → Merge); never skip a gate. If no feature is at PLANNED status with a ready dev-docs/plans/* document, log `no_work_in_scope` and stop — do not pick a TODO/IDEA-level feature and start drafting a plan inside this iteration; that's planning work, not implementation.
+SCOPE: feature implementation only. Per `.claude/rules/47-feature-workflow.md`, `/feature-workflow` is the binding 6-gate sequence (Plan → Independent plan audit → TDD → Implementation audit → Device/integration verification → Merge); never skip a gate.
+
+PICK ORDER (highest priority first):
+
+1. **`IN PROGRESS` features** with at least one merged WI — resume next pending WI.
+2. **`PLANNED` features with a `dev-docs/plans/*-feature-<id>-*.md` doc** — Gate 1 already passed; enter at Gate 2 (if not yet audited) or Gate 3 (if audited and clean).
+3. **`PLANNED` features without a dev-docs/plans doc** — row-template definition was filled but full implementation plan was never lifted. Drawing up the plan doc IS this iteration's work (Gate 1 → Gate 2 → first WI of Gate 3 if time allows). Per the user-confirmed framing, "the plan must be drawn up before reaching Gate 1" — that means write it now, do not bail out.
+4. **`TODO` features** — only if their row already has Problem/Scope/Edge Cases/Test plan/Acceptance criteria filled in (i.e., they're effectively `PLANNED`-equivalent and the status flip was just missed). Otherwise skip — those need triage first, which is `/triage` work, not feature-workflow work.
+
+If no feature qualifies under categories 1–4, log `no_work_in_scope` and stop. Do NOT invent scope or pick an `IDEA`-level / empty-row entry.

--- a/.claude/skills/feature-workflow/SKILL.md
+++ b/.claude/skills/feature-workflow/SKILL.md
@@ -53,9 +53,32 @@ Plan around them; do not bypass.
 2. **Working tree**: `git status --porcelain`. If dirty, isolate work
    on a branch; do not revert unrelated changes.
 3. **Branch / sync**: `git fetch origin`. Confirm `main` is current.
-4. **Tracker baseline**: note the current row status. The skill's
-   transitions assume a starting status of `TODO` or `PLANNED`.
-   If already `IN PROGRESS`, resume at the appropriate gate.
+4. **Tracker baseline + entry-gate selection**: note the current row
+   status, then check whether `dev-docs/plans/*-feature-<id>-*.md`
+   exists. The two artifacts can disagree (the row's `PLANNED` may
+   have been set on the lighter row-template definition: Problem/
+   Scope/Edge Cases filled in). The combination decides where to
+   enter:
+
+   | Row status | `dev-docs/plans/*-feature-<id>-*.md` present? | Enter at |
+   |---|---|---|
+   | `TODO` | no | **Gate 1** (write the plan) |
+   | `TODO` | yes (drafted ahead, not yet audited) | **Gate 2** |
+   | `PLANNED` | no | **Gate 1** (drawing up the plan IS the work — do not bail out) |
+   | `PLANNED` | yes, no audit revision history | **Gate 2** |
+   | `PLANNED` | yes, audited (revision history shows clean Gate 2) | **Gate 3** |
+   | `IN PROGRESS` | yes (assumed) | **resume next pending WI / re-enter Gate 4 if a WI is mid-audit** |
+   | `DONE` | yes | **Gate 5b** (post-merge final acceptance) |
+   | `VERIFIED` | yes | already complete; nothing to do |
+
+   **Do not stop because the plan doc is missing.** Drawing up the
+   `dev-docs/plans/` doc is Gate 1's deliverable, not a precondition.
+   A row already at `PLANNED` whose dev-docs plan doesn't exist
+   means: row-level template was filled, full implementation plan
+   wasn't lifted yet — lift it now (Gate 1), audit it (Gate 2),
+   then proceed. Only TODO/IDEA-level rows whose row-template
+   itself is empty (no Problem/Scope/Edge Cases at all) need
+   triage before Gate 1 is meaningful — those redirect to /triage.
 5. **Bug-vs-feature sanity check**: re-confirm this is a feature
    (capability never implemented), not a bug (broken implementation).
    If it's a bug → STOP, redirect to `/fix-issue`.
@@ -68,7 +91,7 @@ Plan around them; do not bypass.
 |---|---|
 | Required artifact | `dev-docs/plans/YYYYMMDD-feature-<id>-<slug>.md` with all required sections (see below) |
 | Owner / auditor | Author = orchestrator (or Planner subagent). No auditor — that's Gate 2. |
-| Status transition | row stays `TODO` until Gate 2 passes; then → `PLANNED` |
+| Status transition | If row was `TODO`: stays `TODO` through Gate 1; flips to `PLANNED` only after Gate 2 passes. If row was already `PLANNED` (row-template definition filled but no plan doc): stays `PLANNED` — do NOT regress to `TODO`. The plan doc fills in what was missing |
 | Blocking hook | `check_gh_issue_mirror.sh` fires on the `PLANNED` flip (must have `GH: #N` in row Notes; create the issue here) |
 | Exit criteria | Plan file exists at the documented path with all required sections filled in |
 

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 241
-        MARKETING_VERSION: 3.14.132
+        CURRENT_PROJECT_VERSION: 242
+        MARKETING_VERSION: 3.14.133
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4078,13 +4078,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 241;
+				CURRENT_PROJECT_VERSION = 242;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.132;
+				MARKETING_VERSION = 3.14.133;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4228,13 +4228,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 241;
+				CURRENT_PROJECT_VERSION = 242;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.14.132;
+				MARKETING_VERSION = 3.14.133;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

When the cron-driven feature-implementation iteration ran today against `docs/features.md`, it bailed out with `no_work_in_scope` because no `PLANNED` feature had a `dev-docs/plans/*-feature-<id>-*.md` doc — even though four features (#42, #45, #49, #50) had row-level Plan template fields filled in.

That bail-out was wrong. Drawing up the dev-docs plan IS Gate 1's deliverable, not a precondition. The user-confirmed framing: "Gate 1 requires a plan; this plan must be drawn up before reaching Gate 1, rather than saying there is no plan right from the start and then coming to a halt."

## What Changed

**`.claude/skills/feature-workflow/SKILL.md` + `.claude/commands/feature-workflow.md`** (near-verbatim duplicates):

- **Pre-flight check 4** replaced single-line "if IN PROGRESS, resume" with a 7-row decision table covering every (row-status × plan-doc-presence) combination and where each enters the workflow.
- Explicit guidance: **"Do not stop because the plan doc is missing."**
- Status-transition row of Gate 1 clarified: a row already at `PLANNED` (row-template filled) must NOT regress to `TODO` when it enters Gate 1 — drawing up the doc fills in what the row didn't capture.

**`.claude/cron-prompts/feature.md`**:

- Strict bail-out paragraph replaced with a 4-tier pick order:
  1. `IN PROGRESS` features with merged WIs — resume next pending WI
  2. `PLANNED` + dev-docs plan doc exists → enter at Gate 2 or 3
  3. `PLANNED` + no dev-docs plan doc → **drawing up the plan IS this iteration's work**
  4. `TODO` features whose row-template is fully filled (PLANNED-equivalent) — proceed
- `no_work_in_scope` only fires when none of tiers 1–4 qualify.

## Why this is doc-only / meta-process

No Swift changes. No tracker mutations. Per AGENTS.md merge-gate exemption ("Pure meta-process changes — rule additions, repo reorgs, tooling — are exempt because they don't reference a bug/feature row"), this PR doesn't reference an open bug or feature row.

## Validation

- [x] No Swift touched → `check_codex_audit_artifact.sh` not triggered
- [x] No tracker edit → mirror/evidence hooks not triggered
- [x] `xcodegen generate` clean; pbxproj updated with new version
- [x] Version bumped: 3.14.132 → 3.14.133 (build 242)

## Type of Change

- [x] Documentation / meta-process (rule definition update)