### PR TITLE
chore: add sim-drive-fallback skill for driving Simulator when CU is unavailable

### DIFF
--- a/.claude/skills/sim-drive-fallback/SKILL.md
+++ b/.claude/skills/sim-drive-fallback/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: sim-drive-fallback
+description: Drive the iOS Simulator when computer-use can't — for bypassing CU outages, not diagnosing them (use `/cu-diagnose` for diagnosis). Trigger when `mcp__computer-use__screenshot` returns `CU display unavailable`, when the user mentions "CU fallback", "CU substitute", or "drive sim without computer-use", or when continuing a verification that was previously blocked by a CU outage.
+---
+
+# Sim Drive Fallback
+
+CU MCP capture occasionally returns `"CU display unavailable"` on this
+host even when a real monitor is attached and `screencapture -x`
+succeeds at the OS level. This skill is the working substitute — the
+subset of touch gestures that the iOS Simulator translates from mac
+mouse/keyboard events posted via CGEventPost. Enough for most
+single-tap / SwiftUI-sheet-drag / TextField-paste verifications.
+
+## When to use
+
+- A verify-cron iteration calls `mcp__computer-use__screenshot` and
+  gets `CU display unavailable` (despite `request_access` returning a
+  successful grant for Simulator).
+- A user task mentions "CU substitute", "CU fallback", "drive the sim
+  without computer-use", or "verify without CU".
+- You need to verify a UI-gesture-driven bug fix or feature acceptance
+  criterion and the primary CU path is out.
+- You're picking up a verification that a prior cron iteration marked
+  `blocked: CU display unavailable` — the workflow may now be possible
+  through this toolkit even though CU itself is still down.
+
+Do NOT use this for: rubber-band overscroll, long-press → context
+menu, multi-touch / pinch, or anything requiring continuous WKWebView
+touch-drag — those don't translate via CGEventPost. See "Capability
+bounds" below.
+
+## The toolchain
+
+In typical order of use for one verification slice:
+
+### 1. Capture — `xcrun simctl io booted screenshot <abs_path>`
+
+```bash
+xcrun simctl io booted screenshot /Users/ll/workspace/vreader/dev-docs/verification/artifacts/<filename>.png
+```
+
+Goes through CoreSimulator directly; survives any CU MCP outage.
+
+**Always use an absolute path.** `simctl io` resolves relative paths
+against an unpredictable cwd and may silently write to the wrong
+location.
+
+### 2. Element location — `osascript` accessibility tree query
+
+```bash
+osascript <<'EOF'
+tell application "System Events"
+    tell process "Simulator"
+        try
+            set kids to entire contents of window 1
+            repeat with k in kids
+                try
+                    set kDesc to description of k
+                    set kPos to position of k
+                    set kSize to size of k
+                    if (kDesc as string) is not "" then
+                        log "elem: '" & (kDesc as string) & "' pos=(" & (item 1 of kPos as string) & "," & (item 2 of kPos as string) & ") size=" & (item 1 of kSize as string) & "x" & (item 2 of kSize as string)
+                    end if
+                end try
+            end repeat
+        end try
+    end tell
+end tell
+EOF
+```
+
+Returns each accessibility element's **mac-space** coordinates
+(`position`, `size`) and description string. This is the bedrock —
+every click/drag uses these mac coords directly without any sim-coord
+conversion math, which sidesteps bezel / title-bar / sheet-presentation
+y-offset uncertainty.
+
+Filter with `grep` for the element you want — the raw tree can return
+hundreds of `group` nodes; element descriptions like `"Settings"`,
+`"Add bookmark"`, `"Enable AI Assistant"`, `"Done"` are the useful
+handles. SwiftUI exposes form labels, toggle row titles, and button
+titles as `description`. `switch` (for `Toggle`), `Picker` segments,
+and `Sheet Grabber` show up by role-name when their description is
+empty.
+
+### 3. Single tap — `clickat.swift`
+
+```bash
+swift /Users/ll/workspace/vreader/.claude/skills/sim-drive-fallback/scripts/clickat.swift <mac_x> <mac_y>
+```
+
+mouseDown → 50ms → mouseUp. Translates cleanly to an iOS touch for:
+Settings buttons, Toggle switches, segmented controls, list rows,
+picker selections, sheet Done buttons, in-sheet rows.
+
+Click center for an element at `position=(px, py)` size `(w, h)` is
+`(px + w/2, py + h/2)`.
+
+### 4. Drag — `dragat.swift`
+
+```bash
+swift /Users/ll/workspace/vreader/.claude/skills/sim-drive-fallback/scripts/dragat.swift <x1> <y1> <x2> <y2>
+```
+
+mouseDown → 10 intermediate mouseDragged events (20ms apart) → mouseUp.
+The intermediate moves matter — without them, iOS quantizes the motion
+to a single touch.
+
+Works for **SwiftUI `.sheet()` content scroll** (Reading Settings,
+Filter, Add Collection sheet, etc.) and **sheet grabber expand** (drag
+the grabber upward to grow the sheet from half-height to full).
+
+**Does NOT translate** to WKWebView touch-drag — EPUB content scroll,
+EPUB rubber-band overscroll, Foliate page advance. The mouse drag
+never enters the web view's touch handler; you'll see the cursor move
+but get no scroll/bounce response in the rendered document.
+
+### 5. Text entry — clipboard + cmd+V
+
+```bash
+osascript -e 'set the clipboard to "the literal text"'
+swift /Users/ll/workspace/vreader/.claude/skills/sim-drive-fallback/scripts/clickat.swift <field_x> <field_y>   # focus
+swift /Users/ll/workspace/vreader/.claude/skills/sim-drive-fallback/scripts/pastekey.swift                      # paste
+```
+
+Simulator shares the mac clipboard. The cmd+V combo posts via
+CGEventPost while Simulator is frontmost; the focused TextField
+receives the paste. Verified working on collection-name fields, search
+fields, etc.
+
+Caveat: `SecureField` may swallow synthetic cmd+V on some iOS
+versions. For passwords, document as `verification-blocked` rather
+than work around.
+
+## Canonical workflow — "tap → verify"
+
+For the common "tap a UI control, screenshot to verify the state
+change" slice:
+
+1. Screenshot baseline: `xcrun simctl io booted screenshot <baseline>.png`.
+2. AX-query for the target element's description; note its
+   `position` and `size` in mac-space.
+3. Compute click center `(cx, cy) = (px + w/2, py + h/2)`.
+4. Run the `clickat.swift` command from the "Single tap" section above with `<cx> <cy>` substituted in.
+5. `sleep 1` — let the UI settle. Sheet transitions and SwiftUI
+   re-renders can take 200–500ms.
+6. `xcrun simctl io booted screenshot <after>.png` — capture the new
+   state.
+7. (Optional) AX-query the changed element to verify state
+   programmatically (e.g., `switch` role + `on/off` value, or the
+   presence of a previously-hidden section).
+
+## Worked example — bug #169 verification (the canonical reference)
+
+Bug #169 was verified end-to-end via this stack: AX-query to find the
+Settings gear and the AI-Assistant `switch`, three `clickat.swift`
+taps (open Settings, toggle off, toggle on), three `simctl io
+screenshot` captures between taps. Result: API Key / Provider
+Configuration / Data & Privacy sections appeared and disappeared in
+lock-step with the toggle in a single sheet session. See
+`dev-docs/verification/bug-169-20260511.md` for full coords + the
+3-screenshot proof chain — the canonical reference for any
+"settings toggle reveals section" verification.
+
+## Capability bounds
+
+| Gesture | Works? | Notes |
+| --- | --- | --- |
+| Single tap (button / toggle / picker / row) | ✅ | CGEventPost mouseDown+Up translates 1:1 to iOS touch. The bulk of verifications fit here. |
+| SwiftUI sheet content scroll | ✅ | Use `dragat.swift` inside the sheet body. Finger-up drag scrolls content up; finger-down drag scrolls content down. |
+| Sheet grabber expand (half → full height) | ✅ | Drag the `Sheet Grabber` element upward. |
+| TextField paste (cmd+V) | ✅ | Mac clipboard shared; `pastekey.swift` inserts into focused field. |
+| Drag inside scroll view to trigger overscroll bounce | ⚠️ | Drag translates, but iOS rubber-band requires sustained dwell at edge AND scrollable content. With `scrollHeight == innerHeight` (e.g., short EPUB chapter), no bounce is possible. |
+| Long-press → context menu | ❌ | `mouseDown + sleep + mouseUp` reads as a single tap, not a sustained iOS touch. The release fires the gesture recognizer's tap path before the long-press timer matures. |
+| Multi-touch / pinch / two-finger swipe | ❌ | CGEventPost has no multi-finger primitive. |
+| Double-tap with timing | ⚠️ | Two `clickat.swift` invocations can simulate, but iOS gesture recognizer rejects if the inter-tap gap is wrong. Single-tap-only is safer. |
+| WKWebView touch-drag (EPUB content scroll) | ❌ | Mouse drag never enters the web view's touch handler; only native UIScrollView gestures respond. |
+| EPUB / Foliate page advance via drag | ❌ | Same root cause as WKWebView touch-drag. |
+| Hardware key (volume, home, side button) | ❌ | Use `xcrun simctl io booted hardware` / Hardware menu instead — out of scope for this skill. |
+
+If a verification target falls into the ❌ row, mark the slice as
+**verification-blocked** with the tooling-gap reason — it's not a code
+regression, and CU coming back online is the resolution path.
+
+## Origin + reference verifications
+
+- `dev-docs/verification/feature-38-20260510-round3.md` — first round
+  that switched from CU MCP to this stack (TOC tap-to-navigate slice).
+  Documents the AX-query technique.
+- `dev-docs/verification/bug-169-20260511.md` — full end-to-end
+  verification of bug #169 (AI Settings toggle re-render). 3
+  screenshots in the same Settings sheet proving the toggle ON→OFF→ON
+  cycle works. Closest canonical reference for "tap + sheet + toggle +
+  verify".
+
+## What this skill does NOT include
+
+- Does not fix CU MCP (workaround, not repair — `/cu-diagnose` handles diagnosis).
+- Does not record screen video (use sequential screenshots).
+- Does not control hardware keys, rotation, or background-app states (those go through `xcrun simctl` directly).
+
+## Quick reference card
+
+`SKILL=/Users/ll/workspace/vreader/.claude/skills/sim-drive-fallback/scripts`
+
+```bash
+xcrun simctl io booted screenshot /absolute/path/output.png   # capture
+swift "$SKILL/clickat.swift" <cx> <cy>                        # tap
+swift "$SKILL/dragat.swift" <x1> <y1> <x2> <y2>               # drag (SwiftUI sheets only)
+osascript -e 'set the clipboard to "the text"' && swift "$SKILL/pastekey.swift"   # paste into focused TextField
+```
+
+For element coordinates use the `osascript` AX-tree query in section
+**The toolchain → Element location** above; the same snippet, no need
+to duplicate it here.

--- a/.claude/skills/sim-drive-fallback/scripts/clickat.swift
+++ b/.claude/skills/sim-drive-fallback/scripts/clickat.swift
@@ -1,0 +1,30 @@
+// clickat.swift — single tap at mac-space (x, y) via CGEventPost.
+//
+// Usage: swift clickat.swift <x> <y>
+//
+// Posts leftMouseDown → 50ms → leftMouseUp at the given mac-space
+// coordinates. The iOS Simulator translates this to a single iOS touch
+// at the corresponding sim-space point (CoreSimulator handles the
+// coordinate mapping). Works for buttons, toggles, segmented controls,
+// list rows, picker selections, sheet Done buttons, context-menu items.
+//
+// Coordinates come from `osascript … System Events → process "Simulator"
+// → position` queries (mac-space). Use the AX-tree element's
+// (position.x + size.width/2, position.y + size.height/2) for the click
+// center.
+
+import Foundation
+import CoreGraphics
+
+let args = CommandLine.arguments
+guard args.count >= 3, let x = Double(args[1]), let y = Double(args[2]) else {
+    FileHandle.standardError.write("usage: swift clickat.swift <x> <y>\n".data(using: .utf8)!)
+    exit(1)
+}
+let point = CGPoint(x: x, y: y)
+let down = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left)
+let up = CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left)
+down?.post(tap: .cghidEventTap)
+usleep(50_000)
+up?.post(tap: .cghidEventTap)
+print("clicked at \(x),\(y)")

--- a/.claude/skills/sim-drive-fallback/scripts/dragat.swift
+++ b/.claude/skills/sim-drive-fallback/scripts/dragat.swift
@@ -1,0 +1,59 @@
+// dragat.swift — drag from (x1, y1) to (x2, y2) via CGEventPost.
+//
+// Usage: swift dragat.swift <x1> <y1> <x2> <y2>
+//
+// Posts mouseMoved → leftMouseDown → 10 intermediate mouseDragged
+// events spaced 20ms apart → leftMouseUp. The intermediate moves are
+// what makes iOS interpret this as a scroll/drag rather than a tap
+// with a long path — without them, the simulator's gesture recognizer
+// quantizes the motion to a single touch event.
+//
+// Works for:
+//   - SwiftUI .sheet content scroll (Reading Settings, Filter, etc.)
+//   - Sheet grabber expand (drag the grabber upward)
+//   - Library scroll, list view scroll
+//
+// Does NOT work for:
+//   - WKWebView touch-drag (EPUB content scroll, Foliate page advance,
+//     EPUB rubber-band overscroll). Mouse drag isn't routed into the
+//     web view's touch handler — only native UIScrollView gestures
+//     respond.
+//
+// Coordinate space is mac-space, same as clickat.swift.
+
+import Cocoa
+import CoreGraphics
+
+guard CommandLine.arguments.count >= 5,
+      let x1 = Double(CommandLine.arguments[1]),
+      let y1 = Double(CommandLine.arguments[2]),
+      let x2 = Double(CommandLine.arguments[3]),
+      let y2 = Double(CommandLine.arguments[4]) else {
+    FileHandle.standardError.write("usage: swift dragat.swift <x1> <y1> <x2> <y2>\n".data(using: .utf8)!)
+    exit(2)
+}
+
+let p1 = CGPoint(x: x1, y: y1)
+let p2 = CGPoint(x: x2, y: y2)
+
+let move = CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: p1, mouseButton: .left)
+move?.post(tap: .cghidEventTap)
+usleep(50_000)
+
+let down = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDown, mouseCursorPosition: p1, mouseButton: .left)
+down?.post(tap: .cghidEventTap)
+usleep(50_000)
+
+let steps = 10
+for i in 1...steps {
+    let t = Double(i) / Double(steps)
+    let x = x1 + (x2 - x1) * t
+    let y = y1 + (y2 - y1) * t
+    let drag = CGEvent(mouseEventSource: nil, mouseType: .leftMouseDragged, mouseCursorPosition: CGPoint(x: x, y: y), mouseButton: .left)
+    drag?.post(tap: .cghidEventTap)
+    usleep(20_000)
+}
+
+let up = CGEvent(mouseEventSource: nil, mouseType: .leftMouseUp, mouseCursorPosition: p2, mouseButton: .left)
+up?.post(tap: .cghidEventTap)
+print("dragged \(x1),\(y1) → \(x2),\(y2)")

--- a/.claude/skills/sim-drive-fallback/scripts/pastekey.swift
+++ b/.claude/skills/sim-drive-fallback/scripts/pastekey.swift
@@ -1,0 +1,42 @@
+// pastekey.swift — send cmd+V to whatever is currently focused.
+//
+// Usage: swift pastekey.swift
+//
+// Posts cmd-down → V-down → 50ms → V-up → cmd-up via CGEventPost.
+// The Mac clipboard is shared with the iOS Simulator, so:
+//
+//   osascript -e 'set the clipboard to "the text"'
+//   swift clickat.swift <field_x> <field_y>   # focus the TextField
+//   swift pastekey.swift                      # paste
+//
+// Works in SwiftUI `TextField`. Does NOT work reliably in SecureField
+// — that view swallows synthetic cmd+V on some iOS versions.
+//
+// Why CGEvent rather than `xcrun simctl io booted type` — that
+// command doesn't exist; `simctl` has no text-entry primitive. The
+// only headless paths are the AX inspector (not scriptable) or the
+// shared clipboard + paste combo. This skill picks the latter.
+
+import Cocoa
+import CoreGraphics
+
+let src = CGEventSource(stateID: .hidSystemState)
+
+// macOS virtual keycodes: Command = 0x37, V = 0x09.
+let cmdDown = CGEvent(keyboardEventSource: src, virtualKey: 0x37, keyDown: true)
+cmdDown?.flags = .maskCommand
+cmdDown?.post(tap: .cghidEventTap)
+
+let vDown = CGEvent(keyboardEventSource: src, virtualKey: 0x09, keyDown: true)
+vDown?.flags = .maskCommand
+vDown?.post(tap: .cghidEventTap)
+usleep(50_000)
+
+let vUp = CGEvent(keyboardEventSource: src, virtualKey: 0x09, keyDown: false)
+vUp?.flags = .maskCommand
+vUp?.post(tap: .cghidEventTap)
+
+let cmdUp = CGEvent(keyboardEventSource: src, virtualKey: 0x37, keyDown: false)
+cmdUp?.post(tap: .cghidEventTap)
+
+print("cmd+V sent")


### PR DESCRIPTION
## Summary

Adds a new skill at `.claude/skills/sim-drive-fallback/` that captures the toolchain established in earlier verify-cron iterations for driving the iOS Simulator when `mcp__computer-use__screenshot` returns \`CU display unavailable\` despite a real display attached and \`screencapture -x\` working. Sister skill to \`/cu-diagnose\` (which diagnoses why CU is broken) — this one is the working bypass.

## Components

- **SKILL.md** (216 lines): when to use, toolchain (capture / AX-query / tap / drag / paste), canonical workflow, bug-169 reference, full capability-bounds table (10 gestures ✅/⚠️/❌ with the why for each)
- **scripts/clickat.swift** (30 LOC): CGEventPost mouseDown+Up tap
- **scripts/dragat.swift** (59 LOC): mouseDown + 10 intermediate mouseDragged + mouseUp; works for SwiftUI sheets, NOT for WKWebView touch-drag
- **scripts/pastekey.swift** (42 LOC): cmd+V via CGEvent for TextField paste (uses shared Mac clipboard via osascript)

## Codex Audit

Thread \`019e1662-0267-7251-846a-d75297fa01d0\`. 3 rounds.

**Round 1** (Mini, 4 pillars): 1 High + 7 Medium + 1 Low. All fixed:
- High: overloaded description → rewrote to ~45 words, trigger-focused, explicit \`/cu-diagnose\` disambiguation
- Medium: \`\$CLAUDE_PLUGIN_ROOT\` invocation incorrect for skills → dropped
- Medium: content repetition across frontmatter / "When to use" / Quick Reference Card → collapsed
- Medium: bug-169 worked example used placeholders → compressed from 30 lines to 7-line pointer to evidence file
- Medium: \`/cu-diagnose\` mis-labeled as a sister skill → corrected (it's a command at \`.claude/commands/cu-diagnose.md\`)
- Plus minor cleanups (file-size discipline, anti-duplication)

**Round 2**: 1 residual Medium (placeholder in canonical workflow) → fixed (now points back to the canonical \`clickat.swift\` invocation in the toolchain section).

**Round 3**: **ship-as-is**.

Net: SKILL.md 264 → 216 lines (~18% reduction).

## End-to-end verification

This skill was effectively pre-verified earlier in the same session: bug #169 (AI Settings toggle re-render) was closed using exactly this toolkit — 3 screenshots in lock-step showing the toggle ON→OFF→ON cycle in a single Settings sheet, no kill+relaunch needed. Evidence file: \`dev-docs/verification/bug-169-20260511.md\`.

## Type of Change

- [x] Documentation / skill addition (no code change to vreader app)