### PR TITLE
docs(sim-drive-fallback): add concurrency-with-other-sessions section

### DIFF
--- a/.claude/skills/sim-drive-fallback/SKILL.md
+++ b/.claude/skills/sim-drive-fallback/SKILL.md
@@ -183,6 +183,35 @@ If a verification target falls into the ❌ row, mark the slice as
 **verification-blocked** with the tooling-gap reason — it's not a code
 regression, and CU coming back online is the resolution path.
 
+## Concurrency with other sessions
+
+Unlike CU MCP (which serializes desktop access — second session gets
+denied at `request_access` time), this toolkit has no lock. Every
+tool goes straight to a macOS-native subsystem, so multiple Claude
+Code sessions can use it at the same time. The catch: writes share
+global state, so concurrent writers race.
+
+| Operation | Subsystem | Concurrent sessions |
+|---|---|---|
+| `simctl io … screenshot` | CoreSimulator IPC | ✅ each gets own snapshot |
+| `osascript` AX query | Accessibility API | ✅ read-only |
+| `clickat.swift` / `dragat.swift` | HID event tap (global) | ⚠️ events go to the frontmost window NOW — concurrent sessions race |
+| `set the clipboard` + `cmd+V` | NSPasteboard + global keystroke | ⚠️ last writer wins on the clipboard |
+
+Two practical implications:
+- **CGEventPost targets the frontmost window.** If another app comes
+  forward between your AX-query (which fixes coords against the
+  Simulator) and your `clickat.swift`, the click lands in that other
+  app. Bring Simulator forward (`open -a Simulator`) right before any
+  CGEventPost sequence if you suspect drift.
+- **For overlapping cron iterations** (vreader has 4 — verify, bugfix,
+  watchdog, feature), if two ever both drive the sim at the same time,
+  clicks and clipboard state will interleave. The OS won't error;
+  you'll just get non-deterministic output. If this becomes routine
+  (it hasn't yet), serialize sim driving with a `flock /tmp/sim-drive.lock`
+  wrapper around each CGEventPost sequence — cheap fix, preserves the
+  read paths' concurrency.
+
 ## Origin + reference verifications
 
 - `dev-docs/verification/feature-38-20260510-round3.md` — first round


### PR DESCRIPTION
## Summary

Adds a 29-line \"Concurrency with other sessions\" section to the sim-drive-fallback skill (`.claude/skills/sim-drive-fallback/SKILL.md`).

Triggered by the question: CU MCP doesn't allow multiple concurrent sessions — does the CU-substitute toolkit?

## What's documented

Comparison table for each toolkit operation under concurrent sessions:

| Operation | Subsystem | Concurrent sessions |
|---|---|---|
| \`simctl io … screenshot\` | CoreSimulator IPC | ✅ each gets own snapshot |
| \`osascript\` AX query | Accessibility API | ✅ read-only |
| \`clickat.swift\` / \`dragat.swift\` | HID event tap (global) | ⚠️ events go to frontmost window NOW |
| \`set the clipboard\` + \`cmd+V\` | NSPasteboard + global keystroke | ⚠️ last writer wins |

Two practical notes:
1. CGEventPost targets the **frontmost** window. If another app comes forward between the AX-query (which fixes mac-space coords against the Simulator) and the click, the click lands in that other app. Mitigation: `open -a Simulator` right before any CGEventPost sequence.
2. vreader's 4 crons (verify / bugfix / watchdog / feature) haven't bitten this yet (sequential firing), but if they ever overlap and both drive the sim, clicks and clipboard state will interleave. Cheap fix when needed: `flock /tmp/sim-drive.lock` wrapper around each CGEventPost sequence — preserves the read paths' concurrency without locking everything.

## File size

SKILL.md: 216 → 245 lines (still well under the 500-line scannability target).

## Type of Change

- [x] Docs-only addition to existing skill (no code change)