### PR TITLE
docs(#44): round-13 guardrail re-verify — DebugBridge handlers PASS on v3.15.2

### DIFF
--- a/dev-docs/verification/feature-44-20260512-round13.md
+++ b/dev-docs/verification/feature-44-20260512-round13.md
@@ -1,0 +1,148 @@
+---
+kind: feature
+id: 44
+status_target: DONE
+commit_sha: fadb280
+app_version: 3.15.2 (build 264)
+date: 2026-05-12
+verifier: claude
+device_or_simulator: iPhone 17 Simulator (FDF2EA2A-532E-48D4-9022-ADEB6CD053CC)
+os_version: iOS 26.4
+build_configuration: Debug
+backend: bundled DebugFixtures (war-and-peace.txt, mini-epub3.epub, mini-azw3.azw3)
+result: pass
+---
+
+## Summary
+
+Round-13 quick-smoke re-verification of feature #44 (DebugBridge) on
+merged-main `fadb280` (v3.15.2, build 264). All 7 URL handlers
+exercised end-to-end to validate no regression since round-12
+(2026-05-10 against `41067e5` / v3.14.123).
+
+This round is a **guardrail re-verification**, not a status-flip. Feature
+#44 stays `DONE` per the row's gating on bug #141 SETTLE portion (the
+`awaitSettle` 100ms placeholder + per-bridge ready-signal work — separate
+work tracked in bug #141's REMAINING half). The current round confirms
+the recently-shipped multi-provider AI WI-6a (PR #533, commit 3a54513,
+v3.15.0), the AGENTS docs pointer (PR #535, v3.15.1), and the feature
+#21 round-2 paged-mode verification (PR #536, v3.15.2) did not regress
+the DebugBridge surface.
+
+## Acceptance criteria
+
+| Handler | Test | Observed | Result |
+|---|---|---|---|
+| `reset` | `vreader-debug://reset` | Library cleared (verified via subsequent `sqlite3 ZBOOK` query returning only freshly seeded rows) | PASS |
+| `seed?fixture=<name>` | 3 fixtures: `war-and-peace`, `mini-epub3`, `mini-azw3` | `ZBOOK` rows: `txt:ab0252...:1708` (war-and-peace), `epub:f284fd...:2198` (VReader Mini EPUB Fixture), `azw3:fadbaa...:128650` (The Masque of the Red Death) — all 3 fingerprint keys present with correct format prefix + canonical SHA256 + byte count | PASS |
+| `theme?mode=dark&fontSize=18` | URL fired before any book open | Post-open snapshot: `theme: "dark"`, `fontSize: 18` | PASS |
+| `snapshot?dest=<file>` | Multiple snapshots (pre-launch, post-launch-pre-open, post-open) | Valid `schemaVersion: 2` JSON written to `Library/Caches/DebugBridge/`. All 14 documented fields present (currentBookId, format, theme, fontSize, position, selection, highlightCount, lastError, partial, renderPhase, settingsProvenance, ts, ttsOffsetUTF16, ttsState). Pre-open: `currentBookId: null, format: null, renderPhase: "idle"`. Post-open: `currentBookId: "epub:f284fd...:2198", format: "epub"`. | PASS |
+| `open?bookId=<key>` | Open mini-epub3 by canonical key (URL-encoded) | Snapshot post-open shows `currentBookId` set + `format: "epub"`, transitioning from pre-open null state | PASS |
+| `settle?token=r13t1` | Token-keyed ready signal | `ready-r13t1.json` written: `{fingerprintKey, format: "epub", position: null, token: "r13t1", ts: "2026-05-11T16:01:03Z"}` | PASS (settle write — bug #141 SETTLE portion `awaitSettle 100ms placeholder + per-bridge ready signal` REMAINS DEFERRED; this round only re-validates the write path, not the SETTLE semantics) |
+| `eval?bridge=epub&js=<base64>` (Native mode) | JS probe against EPUB while in Native mode (Reading Mode pref = `native`) | `eval-epub.json` returns `{"result": "{\"title\":\"Chapter One\",\"paragraphCount\":3,\"readyState\":\"complete\"}"}` — real DOM state from the WKWebView bridge | PASS |
+| Release-build absence-gate | Not re-exercised; covered by round-5 evidence on v3.13.18; same `verify-release-no-debugbridge.sh` gate remains in repo | N/A | PASS (round-5 cross-ref) |
+
+## Commands run
+
+```bash
+SIM=FDF2EA2A-532E-48D4-9022-ADEB6CD053CC  # iPhone 17, iOS 26.4
+DATA=$(xcrun simctl get_app_container $SIM com.vreader.app data)
+
+# Boot + launch
+xcrun simctl boot $SIM
+sleep 8
+xcrun simctl launch $SIM com.vreader.app
+
+# Handler 1-3: reset + seed × 3
+xcrun simctl openurl $SIM "vreader-debug://reset"
+xcrun simctl openurl $SIM "vreader-debug://seed?fixture=war-and-peace"
+xcrun simctl openurl $SIM "vreader-debug://seed?fixture=mini-epub3"
+xcrun simctl openurl $SIM "vreader-debug://seed?fixture=mini-azw3"
+
+# Verify seeded rows
+sqlite3 "$DATA/Library/Application Support/default.store" "SELECT ZFINGERPRINTKEY, ZTITLE FROM ZBOOK;"
+
+# Handler 4: theme
+xcrun simctl openurl $SIM "vreader-debug://theme?mode=dark&fontSize=18"
+
+# Handler 5: snapshot (pre-open)
+xcrun simctl openurl $SIM "vreader-debug://snapshot?dest=r13snap"
+cat "$DATA/Library/Caches/DebugBridge/r13snap"
+
+# Handler 6: open mini-epub3
+EPUB_KEY="epub:f284fd074ccd1d3c1a78985464d9e1be27975f4029f3c2ddef8428ca10684af4:2198"
+ENCODED_KEY=$(printf %s "$EPUB_KEY" | python3 -c 'import sys,urllib.parse; print(urllib.parse.quote(sys.stdin.read()))')
+xcrun simctl openurl $SIM "vreader-debug://open?bookId=$ENCODED_KEY"
+
+# Handler 7: settle
+xcrun simctl openurl $SIM "vreader-debug://settle?token=r13t1"
+cat "$DATA/Library/Caches/DebugBridge/ready-r13t1.json"
+
+# Handler 8: snapshot (post-open)
+xcrun simctl openurl $SIM "vreader-debug://snapshot?dest=r13post"
+cat "$DATA/Library/Caches/DebugBridge/r13post"
+
+# Handler 9: eval (EPUB Native mode)
+JS='JSON.stringify({title: document.title, paragraphCount: document.querySelectorAll("p").length, readyState: document.readyState})'
+ENCODED=$(printf %s "$JS" | base64 | tr -d '\n')
+xcrun simctl openurl $SIM "vreader-debug://eval?bridge=epub&js=$ENCODED"
+cat "$DATA/Library/Caches/DebugBridge/eval-epub.json"
+```
+
+## Observations
+
+- **Snapshot `dest` parameter does not auto-append `.json`.** I passed
+  `dest=r13snap`, `r13-after-seed`, `r13post`; the handler wrote the
+  files literally under those names (no `.json` suffix). The eval
+  handler does write `eval-<bridge>.json` — but snapshot writes the
+  basename verbatim. Tested side-effect-free guideline for verification:
+  pass the suffix explicitly if you want the convention (`dest=r13.json`),
+  otherwise be ready to find the file under the literal name. Not a
+  defect — it matches `DebugCommand.swift`'s `validateBasename` accepting
+  any conforming basename.
+- **Seed handler requires the app to be running.** Initial reset+seed
+  attempts before `simctl launch` produced no rows in `ZBOOK`. After
+  the explicit launch + sleep 3, seeds persisted as expected. This
+  matches the design: DebugBridge handlers run inside the app via
+  `.onOpenURL` (bug #123 fix), so the app process must be active.
+  Re-verifying this is the right `seed`-handler contract.
+- **No regression observed since round-12.** Same handler set, same
+  shapes, same JSON schemas. The recently-shipped feature #50 WI-6a +
+  feature #21 round-2 verification PRs did not touch DebugBridge code
+  paths (`vreader/Services/DebugBridge/*.swift` last modified in
+  commits pre-2026-05-10).
+- **Bug #141 SETTLE remains the gate to feature #44 VERIFIED.** This
+  round's settle handler write test only validates the file-write +
+  fingerprint-fields contract (PASS); the actual `awaitSettle 100ms
+  placeholder + per-bridge ready signal` semantics — i.e., the part
+  that makes `settle` actually wait for the renderer to be ready
+  rather than a fixed 100ms — is unchanged from when bug #141 was
+  partially fixed in PR #311. Until that work lands, feature #44
+  stays `DONE` and not `VERIFIED`.
+
+## Artifacts
+
+No screenshots this round (snapshot JSON evidence is sufficient for a
+guardrail re-verification). The snapshot + eval JSON outputs are inline
+in the test recipe above.
+
+## Disposition
+
+Feature #44 row stays at `DONE`. Round-13 PASS confirms the guardrail
+contract: all 7 DebugBridge URL handlers work on merged-main v3.15.2.
+Future regression in DebugBridge (e.g., during a refactor or
+unrelated PR) would surface here.
+
+VERIFIED still requires bug #141 SETTLE portion to ship + verify
+end-to-end. No new GH issue needed — bug #141 already tracks the
+remaining work.
+
+## Cross-references
+
+- `dev-docs/verification/feature-44-20260510-round12.md` — previous PASS
+  guardrail (v3.14.123)
+- `dev-docs/verification/feature-44-20260509-round11.md` — closed
+  eval-Foliate portion against bundled mini-azw3
+- `docs/subsystems/debug-bridge.md` — DebugBridge handler spec
+- Bug #141 — REMAINING SETTLE portion
+- GH #352 — feature mirror

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 264
-        MARKETING_VERSION: 3.15.2
+        CURRENT_PROJECT_VERSION: 265
+        MARKETING_VERSION: 3.15.3
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4146,13 +4146,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 264;
+				CURRENT_PROJECT_VERSION = 265;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.15.2;
+				MARKETING_VERSION = 3.15.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4296,13 +4296,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 264;
+				CURRENT_PROJECT_VERSION = 265;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.15.2;
+				MARKETING_VERSION = 3.15.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

Round-13 guardrail re-verification of feature #44 (DebugBridge). All 7 URL handlers exercised end-to-end on merged-main `fadb280` (v3.15.2). Same shape as round-12 — no regression since the recent shipped work (feature #50 WI-6a, AGENTS docs pointer, feature #21 round-2).

Refs #352

## What was verified

| Handler | Result |
|---|---|
| `reset` | PASS |
| `seed × 3 fixtures` (war-and-peace, mini-epub3, mini-azw3) | PASS — all 3 ZBOOK rows with correct fingerprintKey |
| `theme?mode=dark&fontSize=18` | PASS — snapshot confirms |
| `snapshot?dest=X` | PASS — schemaVersion 2, all 14 fields present |
| `open?bookId=<key>` | PASS — post-open snapshot shows currentBookId + format set |
| `settle?token=X` | PASS (file-write contract; SETTLE semantics still gated on bug #141 remaining work) |
| `eval?bridge=epub&js=<base64>` (Native mode) | PASS — `{"title":"Chapter One","paragraphCount":3,"readyState":"complete"}` |

## Disposition

Feature #44 stays at `DONE`. This is a guardrail re-verification, not a status flip. VERIFIED still requires bug #141 SETTLE portion (`awaitSettle 100ms placeholder + per-bridge ready signal`) — separate work tracked in bug #141 REMAINING.

## Type of Change

- [x] Documentation / verification evidence (no Swift code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)