### PR TITLE
docs(#44): round-14 verification — DebugBridge handlers PASS on v3.16.1

### DIFF
--- a/dev-docs/verification/artifacts/feature-44-r14/baseline-snapshot-20260512.json
+++ b/dev-docs/verification/artifacts/feature-44-r14/baseline-snapshot-20260512.json
@@ -1,0 +1,20 @@
+{
+  "currentBookId" : "epub:f284fd074ccd1d3c1a78985464d9e1be27975f4029f3c2ddef8428ca10684af4:2198",
+  "fontSize" : 18,
+  "format" : "epub",
+  "highlightCount" : 0,
+  "lastError" : null,
+  "partial" : [
+    "selection",
+    "position"
+  ],
+  "position" : null,
+  "renderPhase" : "idle",
+  "schemaVersion" : 2,
+  "selection" : null,
+  "settingsProvenance" : null,
+  "theme" : "dark",
+  "ts" : "2026-05-11T18:06:49Z",
+  "ttsOffsetUTF16" : null,
+  "ttsState" : null
+}

--- a/dev-docs/verification/artifacts/feature-44-r14/eval-epub-20260512.json
+++ b/dev-docs/verification/artifacts/feature-44-r14/eval-epub-20260512.json
@@ -1,0 +1,7 @@
+{
+  "bridge" : "epub",
+  "fingerprintKey" : "epub:f284fd074ccd1d3c1a78985464d9e1be27975f4029f3c2ddef8428ca10684af4:2198",
+  "format" : "epub",
+  "result" : "{\"title\":\"Chapter One\",\"scrollWidth\":980,\"clientWidth\":980,\"columnCount\":\"1\",\"bodyTextLen\":502}",
+  "ts" : "2026-05-11T18:07:06Z"
+}

--- a/dev-docs/verification/artifacts/feature-44-r14/settle-ready-20260512.json
+++ b/dev-docs/verification/artifacts/feature-44-r14/settle-ready-20260512.json
@@ -1,0 +1,7 @@
+{
+  "fingerprintKey" : "epub:f284fd074ccd1d3c1a78985464d9e1be27975f4029f3c2ddef8428ca10684af4:2198",
+  "format" : "epub",
+  "position" : null,
+  "token" : "verify-r14-settle",
+  "ts" : "2026-05-11T18:07:24Z"
+}

--- a/dev-docs/verification/feature-44-20260512-round14.md
+++ b/dev-docs/verification/feature-44-20260512-round14.md
@@ -1,0 +1,82 @@
+---
+kind: feature
+id: 44
+status_target: VERIFIED
+commit_sha: 9ef3970
+app_version: 3.16.1 (build 268)
+date: 2026-05-12
+verifier: claude
+device_or_simulator: iPhone 17 Simulator
+os_version: iOS 26.4
+build_configuration: Debug
+backend: n/a
+result: pass
+---
+
+# Feature #44 — DebugBridge round-14 guardrail (v3.16.1)
+
+Round-14 smoke pass to confirm the verification harness itself didn't
+regress after WI-6b (PR #540) + bug #171 fix (PR #541) + screenshot
+artifact (PR #542) landed. The DebugBridge handlers ARE the verification
+plumbing, so any regression here would silently break future verify-cron
+iterations.
+
+All 7 documented handlers verified end-to-end on v3.16.1 build 268
+(merge commit `9ef3970`, tag `v3.16.1`).
+
+## Acceptance criteria
+
+| Handler | URL | Expected outcome | Observed | Pass |
+|---|---|---|---|---|
+| `reset` | `vreader-debug://reset` | Clears active reader + library; no error response | URL accepted, no error | ✅ |
+| `seed` | `vreader-debug://seed?fixture=mini-epub3` | Imports mini-epub3 fixture into library | URL accepted; SwiftData ZBOOK row present with `ZFINGERPRINTKEY = epub:f284fd…2198` | ✅ |
+| `theme` | `vreader-debug://theme?mode=dark` | Sets active reader theme to dark | URL accepted; baseline snapshot reports `"theme": "dark"` | ✅ |
+| `snapshot` | `vreader-debug://snapshot?dest=verify-r14-baseline.json` | Writes JSON to Caches/DebugBridge/ | File written (463 B); contains all v2 schema fields (currentBookId, fontSize, format, highlightCount, lastError, partial, position, renderPhase, schemaVersion, selection, settingsProvenance, theme, ts, ttsOffsetUTF16, ttsState) | ✅ |
+| `open` | `vreader-debug://open?bookId=epub%3A…%3A2198` | Presents reader for the fingerprint-keyed book | URL accepted; settle then eval confirm reader presents (eval returns `title: "Chapter One"`, `bodyTextLen: 502`) | ✅ |
+| `settle` | `vreader-debug://settle?token=verify-r14-settle` | Waits for reader to settle then writes `ready-<token>.json` | File `ready-verify-r14-settle.json` written (209 B); contains fingerprintKey + format + token + ts | ✅ |
+| `eval` | `vreader-debug://eval?bridge=epub&js=<base64>` | Evaluates JS in epub WKWebView; writes `eval-epub.json` | File written; result JSON has `title: "Chapter One"`, `scrollWidth: 980`, `clientWidth: 980`, `columnCount: "1"`, `bodyTextLen: 502` | ✅ |
+
+## Commands run
+
+```bash
+# Reset library state
+xcrun simctl openurl booted "vreader-debug://reset"
+
+# Seed bundled EPUB fixture
+xcrun simctl openurl booted "vreader-debug://seed?fixture=mini-epub3"
+
+# Set theme to dark
+xcrun simctl openurl booted "vreader-debug://theme?mode=dark"
+
+# Snapshot baseline state (library-level)
+xcrun simctl openurl booted "vreader-debug://snapshot?dest=verify-r14-baseline.json"
+
+# Look up bookId from SwiftData store
+FP=$(sqlite3 "$CONTAINER/Library/Application Support/default.store" \
+  "SELECT ZFINGERPRINTKEY FROM ZBOOK WHERE ZFORMAT='epub' OR ZFORMAT1='epub' LIMIT 1;")
+URL_ENC=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$FP")
+
+# Open the EPUB
+xcrun simctl openurl booted "vreader-debug://open?bookId=$URL_ENC"
+
+# Wait for reader to settle
+xcrun simctl openurl booted "vreader-debug://settle?token=verify-r14-settle"
+
+# Eval JS in the live EPUB WKWebView (bug #171 cross-check)
+JS='(function(){var b=document.body;return JSON.stringify({title:document.title,scrollWidth:b.scrollWidth,clientWidth:b.clientWidth,columnCount:getComputedStyle(b).columnCount,bodyTextLen:(b.innerText||"").length});})()'
+JS_B64=$(printf '%s' "$JS" | base64)
+xcrun simctl openurl booted "vreader-debug://eval?bridge=epub&js=$JS_B64"
+```
+
+## Observations
+
+- All 7 handlers respond correctly. The bridge schemaVersion is still `2`. No silent regression after the three v3.16.x ships landed on main today.
+- `snapshot` schema covers the v2 contract verbatim — no new fields were added in this version cycle. (Future TODO if WI-7 lands: snapshot may want to expose `activeProfileID` for AI features, but that's out of scope.)
+- The eval probe doubles as a bug #171 cross-check: `columnCount: "1"` and `scrollWidth === clientWidth === 980` confirm the EPUB paged-mode single-column fix is still in force after the round-14 reset-then-seed cycle.
+- One non-bug quirk: `dest` parameter for `snapshot` and `token` parameter for `settle` differ; both must be filename basenames but the param NAMES are different. Already documented in `DebugCommand.swift`.
+
+## Artifacts
+
+- `dev-docs/verification/artifacts/feature-44-r14/baseline-snapshot-20260512.json` — snapshot handler output
+- `dev-docs/verification/artifacts/feature-44-r14/settle-ready-20260512.json` — settle handler output
+- `dev-docs/verification/artifacts/feature-44-r14/eval-epub-20260512.json` — eval handler output (with bug #171 cross-check fields)


### PR DESCRIPTION
## Summary

Round-14 guardrail verification of feature #44 (DebugBridge). All 7 documented handlers (reset, seed, theme, snapshot, open, settle, eval) pass on v3.16.1 build 268 (merge commit `9ef3970`) — confirms the verification harness itself didn't regress after today's three ships (WI-6b PR #540, bug #171 PR #541, verification artifact PR #542).

The `eval` probe doubles as a bug #171 cross-check: `getComputedStyle(body).columnCount === "1"` and `scrollWidth === clientWidth === 980` — the single-column paged-mode fix is still in force after a `reset → seed → open → settle` cycle.

Refs feature #44.

## Handler results

| Handler | Outcome |
|---|---|
| `reset` | accepted, no error |
| `seed?fixture=mini-epub3` | imported (ZBOOK row visible) |
| `theme?mode=dark` | accepted, snapshot reports `theme: "dark"` |
| `snapshot?dest=...` | wrote 463 B JSON with all v2 schema fields |
| `open?bookId=...` | reader presented |
| `settle?token=...` | wrote `ready-<token>.json` 209 B |
| `eval?bridge=epub&js=...` | wrote `eval-epub.json` with bug #171 cross-check fields |

## Artifacts

- `dev-docs/verification/feature-44-20260512-round14.md` — evidence file
- `dev-docs/verification/artifacts/feature-44-r14/{baseline-snapshot,settle-ready,eval-epub}-20260512.json` — handler outputs

## Type of Change

- [x] Documentation / verification only

🤖 Generated with [Claude Code](https://claude.com/claude-code)