### PR TITLE
chore: bump cron cadence — bugfix hourly + feature every 2h

### DIFF
--- a/.claude/commands/cron-bootstrap.md
+++ b/.claude/commands/cron-bootstrap.md
@@ -18,10 +18,10 @@ with the same prompt + schedule, it stays.
 
 3. Recreation pattern — for each missing cron:
    - Read the prompt from the corresponding file:
-     - verify cron — `23 * * * *` — `.claude/cron-prompts/verify.md`
-     - bugfix cron — `47 */2 * * *` — `.claude/cron-prompts/bugfix.md`
-     - watchdog cron — `49 4 * * *` — `.claude/cron-prompts/watchdog.md`
-     - feature cron — `31 */3 * * *` — `.claude/cron-prompts/feature.md`
+     - verify cron — `9 * * * *` — `.claude/cron-prompts/verify.md`
+     - bugfix cron — `39 * * * *` — `.claude/cron-prompts/bugfix.md`
+     - watchdog cron — `54 4 * * *` — `.claude/cron-prompts/watchdog.md`
+     - feature cron — `24 */2 * * *` — `.claude/cron-prompts/feature.md`
    - Call `CronCreate` with `cron`, `recurring: true`, and the
      prompt loaded verbatim from the file.
 
@@ -31,13 +31,26 @@ with the same prompt + schedule, it stays.
    (it silently treats every job as session-only). Documenting it
    here so future iterations don't waste a round trip.
 
-## Why off-minute schedules
+## Why these schedules
 
-Each cron's minute is staggered (`:23`, `:31`, `:47`, `:49`) to keep
-fleet-wide load distributed and to avoid hot-minute coordination
-pile-ups (every user who asks "every hour" hits :00 by default; we
-deliberately don't). When editing a schedule, keep the off-minute
-property — don't snap to `:00` or `:30`.
+Each cron's minute is evenly staggered across the hour at ~15-minute
+intervals (`:09`, `:24`, `:39`, `:54`), keeping fleet-wide load
+distributed and avoiding hot-minute coordination pile-ups (every user
+who asks "every hour" hits :00 by default; we deliberately don't).
+
+**Cadences** (2026-05-12 bump — verify + bugfix are hourly, feature
+every 2h, watchdog daily). Verify and bugfix run hourly because both
+are productive cadences (verify ticks ship evidence files; bugfix
+ticks at least file/skip-note on the queue, and pick up real fixes
+whenever the queue refreshes). Feature runs every 2h because each
+tick can run a full 6-gate cycle that takes meaningful time. Watchdog
+runs daily — it's renewal + ghost-shell sweep, not productive work.
+
+When editing a schedule:
+- Keep the ~15-minute spacing — don't bunch into adjacent minutes.
+- Avoid `:00` and `:30` (fleet hot minutes).
+- Put the most frequent crons (verify, bugfix — both hourly) on the
+  even-15min slots so the gap between any two firings stays ≤ 30 min.
 
 ## Output
 
@@ -45,10 +58,10 @@ A short confirmation:
 
 ```
 Re-bootstrapped 4 crons:
-  <id-1> — verify, every hour at :23
-  <id-2> — bugfix, every 2h at :47
-  <id-3> — watchdog, daily at 04:49
-  <id-4> — feature, every 3h at :31
+  <id-1> — verify, every hour at :09
+  <id-2> — feature, every 2h at :24
+  <id-3> — bugfix, every hour at :39
+  <id-4> — watchdog, daily at 04:54
 ```
 
 If any cron was already present and skipped, say so explicitly.

--- a/.claude/cron-prompts/watchdog.md
+++ b/.claude/cron-prompts/watchdog.md
@@ -9,10 +9,10 @@ WATCHDOG: keep every session-only cron alive past the 7-day auto-expire AND swee
 2. For each of the 4 expected crons (verify, bugfix, watchdog, feature), check whether it's still scheduled. If yes and its next-fire is < 24h away from the 7-day expiry, treat as needing renewal. If you cannot tell the expiry, renew anyway — recreate is idempotent in effect.
 
 3. To renew: `CronDelete` the existing job, then `CronCreate` with the prompt read from the corresponding file:
-   - verify cron — `23 * * * *` — `.claude/cron-prompts/verify.md`
-   - bugfix cron — `47 */2 * * *` — `.claude/cron-prompts/bugfix.md`
-   - watchdog cron — `49 4 * * *` — `.claude/cron-prompts/watchdog.md`
-   - feature cron — `31 */3 * * *` — `.claude/cron-prompts/feature.md`
+   - verify cron — `9 * * * *` — `.claude/cron-prompts/verify.md`
+   - bugfix cron — `39 * * * *` — `.claude/cron-prompts/bugfix.md`
+   - watchdog cron — `54 4 * * *` — `.claude/cron-prompts/watchdog.md`
+   - feature cron — `24 */2 * * *` — `.claude/cron-prompts/feature.md`
    For each, use the `Read` tool to load the prompt file, then pass that exact text as the `prompt` parameter to `CronCreate`.
 
 4. If a cron is missing from `CronList` entirely (not just near-expiry), recreate it with the same prompt and schedule.


### PR DESCRIPTION
## Summary

Today's activity logs showed up to 4-hour gaps between productive cron firings. User asked to tighten cadence.

- **bugfix**: every 2h at :39 → **every hour at :39** (12 → 24/day)
- **feature**: every 3h at :24 → **every 2h at :24** (8 → 12/day)
- verify hourly at :09 unchanged
- watchdog daily at 04:54 unchanged

Total: 45 → 61 firings/day. Worst-case inter-tick gap shrinks ~3h → 30min (verify :09 + bugfix :39 alternate every 30min).

## Why these two lanes

- **verify** stays hourly — each tick is ~5-10 min, doubling risks overlap.
- **bugfix** mostly returns \`no_work_in_scope\` on a stable queue, but picks up real fixes immediately whenever new bugs land. Hourly catches them sooner with negligible cost.
- **feature** ticks ship real work (every recent tick shipped a WI or plan PR). 2h cadence keeps gates spaced enough for Codex audits between rounds without leaving multi-hour gaps.
- **watchdog** stays daily — renewal + ghost-shell sweep, not productive work.

## Applied to live runtime + docs

Session crons recreated via CronDelete + CronCreate. New IDs:
- \`480a326b\` — feature every 2h at :24
- \`af6fc05b\` — bugfix hourly at :39

\`cron-bootstrap.md\` + \`cron-prompts/watchdog.md\` updated so future bootstrap and watchdog renewal cycles use the new cadences too.

## Type of Change

- [x] Chore / scheduling tweak

🤖 Generated with [Claude Code](https://claude.com/claude-code)