### PR TITLE
feat: Feature #48 WI-3 — chapter-local selection → global locator

### DIFF
--- a/.claude/codex-audits/feat-feature-48-wi-3-creation-translation-audit.md
+++ b/.claude/codex-audits/feat-feature-48-wi-3-creation-translation-audit.md
@@ -1,0 +1,55 @@
+---
+branch: feat/feature-48-wi-3-creation-translation
+threadId: manual-fallback
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-12
+---
+
+# Codex Audit — Feature #48 WI-3
+
+**Codex MCP unavailable (stream disconnected)**. Manual fallback audit per `.claude/rules/47-feature-workflow.md`.
+
+## Manual Audit Evidence
+
+**Files read:**
+- `vreader/Services/Locator/LocatorFactory.swift` (lines 150–190)
+- `vreader/Views/Reader/ReaderNotificationHandlers.swift` (lines 35–68)
+- `vreader/Views/Reader/TXTReaderContainerView.swift` (lines 403–440, 619–646)
+
+**Symbols verified:**
+- `LocatorFactory.txtChapterRange(fingerprint:chapterLocalStart:chapterLocalEnd:chapterText:chapterGlobalStart:)` — added correctly
+- `TXTReaderContainerView.makeLocatorForTXT(fingerprint:localStart:localEnd:chapterText:chapterGlobalStart:isChapterMode:)` — added as static seam
+- `ReaderNotificationDeps.locatorFactory: @MainActor (...)` — changed from `@Sendable` correctly
+- `makeNotificationDeps()` closure — captures `viewModel` directly, dispatches through `makeLocatorForTXT`
+
+**Edge cases checked:**
+- `txtChapterRange`: negative `chapterLocalStart` → nil ✓
+- `txtChapterRange`: inverted range (`end < start`) → nil ✓
+- `txtChapterRange`: `end > chapterText.utf16.count` → nil ✓
+- `txtChapterRange`: `chapterGlobalStart = 0` → identity (local == global) ✓
+- `makeLocatorForTXT`: `isChapterMode=true, chapterText=nil` → nil (fixed post-audit) ✓
+- `makeLocatorForTXT`: `isChapterMode=false` → delegates to `txtRange` (passthrough) ✓
+- `@MainActor` call sites: `ReaderNotificationModifier` handlers are `@MainActor` via SwiftUI ✓
+- `viewModel` capture in closure: `viewModel` is `@MainActor @Observable`, safe to capture in `@MainActor` closure ✓
+
+**Risks accepted:**
+- None.
+
+## Round 1 Findings
+
+| # | Severity | Finding | Location | Fix |
+|---|----------|---------|----------|-----|
+| 1 | Low | `makeLocatorForTXT` with `isChapterMode=true, chapterText=nil` fell through to `txtRange`, treating chapter-local offsets as global | `TXTReaderContainerView.swift:631` | Changed to `guard let text = chapterText else { return nil }` — returns nil instead of wrong locator |
+
+## Resolution
+
+- Finding 1 (Low): Fixed. `isChapterMode=true` with nil `chapterText` now returns nil rather than a malformed global-offset locator.
+
+## Summary Verdict
+
+Round 1: 1 Low finding, fixed. Round 2 (verbal review): no new issues from the fix — `guard nil return` is idiomatic and safe.
+
+All 8 WI-3 tests pass (5 `LocatorFactoryTXTChapterTests` + 3 `TXTChapterHighlightCreationTests`).
+
+**Verdict: ship-as-is**

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 275
-        MARKETING_VERSION: 3.19.0
+        CURRENT_PROJECT_VERSION: 276
+        MARKETING_VERSION: 3.20.0
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		054050637EFD8ACE415BCF2E /* ReplacementRulesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9584B44764B8D11C7CC9F6 /* ReplacementRulesView.swift */; };
 		058C2F104DE6D10D81F907D9 /* AnnotationExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB9773A4631BEDEDD187F08 /* AnnotationExporterTests.swift */; };
 		05BE70789318FA085B9A735E /* AIChatViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E861A379A620B769CEA36300 /* AIChatViewModelTests.swift */; };
+		066EB86763E7D6B0068732DB /* TXTChapterHighlightCreationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4559FD0011E0F990013EAE48 /* TXTChapterHighlightCreationTests.swift */; };
 		0681EC94635E9BBB798AAB77 /* SearchHighlightDismissTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62569DC663E2BDD2DC0155C3 /* SearchHighlightDismissTests.swift */; };
 		069B04BFCB5D0D4FA8EA5972 /* WebDAVNetworkPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D408C9CE57D4C437A72C0D18 /* WebDAVNetworkPolicy.swift */; };
 		06C8E85FDBC83E56C5BF3B64 /* EPUBProgressCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBBB555BA86F7648ACBC780F /* EPUBProgressCalculator.swift */; };
@@ -168,6 +169,7 @@
 		33226957615967F3FE36DD40 /* BookDownloadSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF6B274A7CA4B3240E60E9F /* BookDownloadSheet.swift */; };
 		33B874FB4BB17A21ACA4468E /* BookFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C3ECA5E8F6419DB347F2E4 /* BookFormat.swift */; };
 		3400D16324A8EFC7298B2B15 /* AISettingsViewModelMultiProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85E36013A798EB205697B9A /* AISettingsViewModelMultiProfileTests.swift */; };
+		345A4B6E5A4A3A6F96F6B85D /* LocatorFactoryTXTChapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D2ACCFF53EDBE89326A37F /* LocatorFactoryTXTChapterTests.swift */; };
 		34B285C323BF6E55A25CC148 /* LocatorCanonicalHashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3987200016FB6CA3D063E44 /* LocatorCanonicalHashTests.swift */; };
 		34E33F3534FA3EB044406F2D /* TypographySettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF87AF7EE6B0FB8E4CC9332 /* TypographySettingsTests.swift */; };
 		34E5034ADB5725781C9CE5C8 /* PDFProgressHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A54A2C5DE8C1631C04BB2A1 /* PDFProgressHelper.swift */; };
@@ -1013,6 +1015,7 @@
 		44423E8976A2B27C4B14617F /* EPUBHighlightJS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBHighlightJS.swift; sourceTree = "<group>"; };
 		4459ED2850B657C535C05F16 /* DebugPositionResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugPositionResolverTests.swift; sourceTree = "<group>"; };
 		445A7C6C3D4466A57B29BDA8 /* ReaderSettingsSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsSheetTests.swift; sourceTree = "<group>"; };
+		4559FD0011E0F990013EAE48 /* TXTChapterHighlightCreationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterHighlightCreationTests.swift; sourceTree = "<group>"; };
 		456FDDA03D7DEF3A4AEB01DB /* TOCBuilderMDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOCBuilderMDTests.swift; sourceTree = "<group>"; };
 		4581A94B5099D15743DC02F3 /* ReaderTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTheme.swift; sourceTree = "<group>"; };
 		4598235F83FFA792CE2338F9 /* LibraryDarkModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryDarkModeTests.swift; sourceTree = "<group>"; };
@@ -1119,6 +1122,7 @@
 		605C9BAEA41B7C63D7E343B1 /* VReaderApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderApp.swift; sourceTree = "<group>"; };
 		607B063A54628D2CC2CFCC35 /* NSUKVSBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSUKVSBridgeTests.swift; sourceTree = "<group>"; };
 		60D19CA6B370181C8BF08270 /* VReaderAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderAppDelegate.swift; sourceTree = "<group>"; };
+		61D2ACCFF53EDBE89326A37F /* LocatorFactoryTXTChapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorFactoryTXTChapterTests.swift; sourceTree = "<group>"; };
 		61D944728B17A940A3716EA9 /* TokenSpanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSpanTests.swift; sourceTree = "<group>"; };
 		61DB3214E22D83E3A8E19212 /* FoliateJSEscaperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateJSEscaperTests.swift; sourceTree = "<group>"; };
 		61E8B92C301E5470AB98C87E /* LocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorTests.swift; sourceTree = "<group>"; };
@@ -1984,6 +1988,7 @@
 				8B6366DF3AEECBB9C55151DA /* TextReaderUIStateTests.swift */,
 				82CF5610F301F9CE87D9BDE1 /* TransformsBug98Tests.swift */,
 				47AA8588621686E377D9D496 /* TXTBridgeSharedTests.swift */,
+				4559FD0011E0F990013EAE48 /* TXTChapterHighlightCreationTests.swift */,
 				BE45EE49755FF9770DA61B12 /* TXTChapterHighlightRenderingTests.swift */,
 				2B9AD84A4BE2CF0F8D59D9CC /* TXTChapterScrollOffsetTests.swift */,
 				C24D5425530ABBE0DDA4758F /* TXTChunkedHighlightDeferredTimerTests.swift */,
@@ -2116,6 +2121,7 @@
 			isa = PBXGroup;
 			children = (
 				055FBEA382F82BE342A50C8E /* LocatorFactoryTests.swift */,
+				61D2ACCFF53EDBE89326A37F /* LocatorFactoryTXTChapterTests.swift */,
 				22C20D015AD61E29BEB57DC3 /* LocatorNormalizerTests.swift */,
 				B10A08E980C92248337462DF /* LocatorRestorerTests.swift */,
 			);
@@ -3489,6 +3495,7 @@
 				EBA5AEC161A4C9D055955BB4 /* LibraryViewModelImportTests.swift in Sources */,
 				8178696A12B2FC6B462D9C3A /* LibraryViewModelTests.swift in Sources */,
 				34B285C323BF6E55A25CC148 /* LocatorCanonicalHashTests.swift in Sources */,
+				345A4B6E5A4A3A6F96F6B85D /* LocatorFactoryTXTChapterTests.swift in Sources */,
 				2FA04FC59FECB40C45FAD4D8 /* LocatorFactoryTests.swift in Sources */,
 				87A61AC432B6116973B7D291 /* LocatorIntegrationTests.swift in Sources */,
 				5FE7F04D448C49D466F641FB /* LocatorNormalizerTests.swift in Sources */,
@@ -3603,6 +3610,7 @@
 				CD8C26CB53B0BE57CE214F00 /* TXTBridgeOffsetTests.swift in Sources */,
 				85C11C4F2CA49FF77D34BBFB /* TXTBridgeSharedTests.swift in Sources */,
 				BBBE35ADD567E0153A2F244D /* TXTChapterContentLoaderTests.swift in Sources */,
+				066EB86763E7D6B0068732DB /* TXTChapterHighlightCreationTests.swift in Sources */,
 				0C5A7F2FA0B3A33625E34506 /* TXTChapterHighlightHelperTests.swift in Sources */,
 				07D9566A77C228AC6FB1B699 /* TXTChapterHighlightRenderingTests.swift in Sources */,
 				9008E6E28C2B6F8202E2183A /* TXTChapterIndexBuilderTests.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4194,13 +4194,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 275;
+				CURRENT_PROJECT_VERSION = 276;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.19.0;
+				MARKETING_VERSION = 3.20.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4344,13 +4344,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 275;
+				CURRENT_PROJECT_VERSION = 276;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.19.0;
+				MARKETING_VERSION = 3.20.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Locator/LocatorFactory.swift
+++ b/vreader/Services/Locator/LocatorFactory.swift
@@ -149,6 +149,43 @@ enum LocatorFactory {
         )
     }
 
+    // MARK: - TXT Chapter Range
+
+    /// Creates a locator for a selection within a specific TXT chapter.
+    /// Translates chapter-local UTF-16 offsets to global offsets via `chapterGlobalStart`.
+    /// Extracts quote/context from chapter text at the chapter-local offsets.
+    ///
+    /// Returns `nil` when: range is inverted, `chapterLocalStart < 0`, `chapterGlobalStart < 0`,
+    /// or `chapterLocalEnd > chapterText.utf16.count`.
+    static func txtChapterRange(
+        fingerprint: DocumentFingerprint,
+        chapterLocalStart: Int,
+        chapterLocalEnd: Int,
+        chapterText: String,
+        chapterGlobalStart: Int
+    ) -> Locator? {
+        guard chapterLocalStart >= 0,
+              chapterGlobalStart >= 0,
+              chapterLocalEnd >= chapterLocalStart,
+              chapterLocalEnd <= chapterText.utf16.count else { return nil }
+
+        let globalStart = chapterGlobalStart + chapterLocalStart
+        let globalEnd = chapterGlobalStart + chapterLocalEnd
+        let length = chapterLocalEnd - chapterLocalStart
+
+        let ctx = extractContext(from: chapterText, at: chapterLocalStart, length: length)
+
+        return Locator.validated(
+            bookFingerprint: fingerprint,
+            charOffsetUTF16: globalStart,
+            charRangeStartUTF16: globalStart,
+            charRangeEndUTF16: globalEnd,
+            textQuote: nonEmpty(ctx.quote),
+            textContextBefore: nonEmpty(ctx.contextBefore),
+            textContextAfter: nonEmpty(ctx.contextAfter)
+        )
+    }
+
     // MARK: - MD Position (alias for TXT offset logic on rendered text)
 
     /// Creates a locator for an MD cursor position in rendered text.

--- a/vreader/Views/Reader/ReaderNotificationHandlers.swift
+++ b/vreader/Views/Reader/ReaderNotificationHandlers.swift
@@ -36,7 +36,7 @@ struct ReaderNotificationDeps {
     let bookmarkPersistence: any BookmarkPersisting
     let highlightPersistence: any HighlightPersisting
     let annotationPersistence: any AnnotationPersisting
-    let locatorFactory: @Sendable (DocumentFingerprint, Int, Int, String?) -> Locator?
+    let locatorFactory: @MainActor (DocumentFingerprint, Int, Int, String?) -> Locator?
     let sourceText: @MainActor () -> String?
     let makeCurrentLocator: @MainActor () -> Locator
     let onNavigate: @MainActor (Int) -> Void
@@ -49,7 +49,7 @@ struct ReaderNotificationDeps {
         bookmarkPersistence: any BookmarkPersisting,
         highlightPersistence: any HighlightPersisting,
         annotationPersistence: any AnnotationPersisting,
-        locatorFactory: @Sendable @escaping (DocumentFingerprint, Int, Int, String?) -> Locator?,
+        locatorFactory: @MainActor @escaping (DocumentFingerprint, Int, Int, String?) -> Locator?,
         sourceText: @MainActor @escaping () -> String?,
         makeCurrentLocator: @MainActor @escaping () -> Locator,
         onNavigate: @MainActor @escaping (Int) -> Void,

--- a/vreader/Views/Reader/TXTReaderContainerView.swift
+++ b/vreader/Views/Reader/TXTReaderContainerView.swift
@@ -410,8 +410,18 @@ struct TXTReaderContainerView: View {
             bookmarkPersistence: container.map { PersistenceActor(modelContainer: $0) } ?? NoOpBookmarkStore(),
             highlightPersistence: container.map { PersistenceActor(modelContainer: $0) } ?? NoOpHighlightStore(),
             annotationPersistence: container.map { PersistenceActor(modelContainer: $0) } ?? NoOpAnnotationStore(),
-            locatorFactory: { fp, start, end, text in
-                LocatorFactory.txtRange(fingerprint: fp, charRangeStartUTF16: start, charRangeEndUTF16: end, sourceText: text)
+            locatorFactory: { [viewModel] fp, start, end, _ in
+                let chapters = viewModel.chapterIndex?.chapters ?? []
+                let idx = viewModel.currentChapterIdx
+                let chapter = idx >= 0 && idx < chapters.count ? chapters[idx] : nil
+                return Self.makeLocatorForTXT(
+                    fingerprint: fp,
+                    localStart: start,
+                    localEnd: end,
+                    chapterText: viewModel.currentChapterText,
+                    chapterGlobalStart: chapter?.globalStartUTF16 ?? 0,
+                    isChapterMode: viewModel.isChapterMode
+                )
             },
             sourceText: { [viewModel] in viewModel.textContent },
             makeCurrentLocator: { [viewModel] in viewModel.makeLocator() },
@@ -604,6 +614,36 @@ struct TXTReaderContainerView: View {
             chapterIndex: chapterIndex,
             chapters: chapters
         )
+    }
+
+    /// WI-3: Builds a Locator from a selection notification.
+    /// In chapter mode, translates chapter-local offsets to global via txtChapterRange.
+    /// In continuous mode, delegates directly to txtRange.
+    /// Extracted as a static seam for unit testability (mirrors WI-2's chapterScrubberGlobalOffset pattern).
+    static func makeLocatorForTXT(
+        fingerprint: DocumentFingerprint,
+        localStart: Int,
+        localEnd: Int,
+        chapterText: String?,
+        chapterGlobalStart: Int,
+        isChapterMode: Bool
+    ) -> Locator? {
+        if isChapterMode {
+            guard let text = chapterText else { return nil }
+            return LocatorFactory.txtChapterRange(
+                fingerprint: fingerprint,
+                chapterLocalStart: localStart,
+                chapterLocalEnd: localEnd,
+                chapterText: text,
+                chapterGlobalStart: chapterGlobalStart
+            )
+        } else {
+            return LocatorFactory.txtRange(
+                fingerprint: fingerprint,
+                charRangeStartUTF16: localStart,
+                charRangeEndUTF16: localEnd
+            )
+        }
     }
 
     /// Finds the chunk index containing the given character offset.

--- a/vreaderTests/Services/Locator/LocatorFactoryTXTChapterTests.swift
+++ b/vreaderTests/Services/Locator/LocatorFactoryTXTChapterTests.swift
@@ -1,0 +1,88 @@
+// Purpose: Tests for LocatorFactory.txtChapterRange — chapter-local → global locator creation.
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("LocatorFactory.txtChapterRange")
+struct LocatorFactoryTXTChapterTests {
+
+    private static let fingerprint = DocumentFingerprint(
+        contentSHA256: "c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+        fileByteCount: 512,
+        format: .txt
+    )
+
+    // "abcdefghij" — 10 ASCII characters, 10 UTF-16 code units
+    private static let chapterText = "abcdefghij"
+
+    @Test func txtChapterRange_extractsQuoteFromChapterText() {
+        // local [3,7) → "defg", globalStart=1000 → globals [1003, 1007)
+        let locator = LocatorFactory.txtChapterRange(
+            fingerprint: Self.fingerprint,
+            chapterLocalStart: 3,
+            chapterLocalEnd: 7,
+            chapterText: Self.chapterText,
+            chapterGlobalStart: 1000
+        )
+        #expect(locator != nil)
+        #expect(locator?.charRangeStartUTF16 == 1003)
+        #expect(locator?.charRangeEndUTF16 == 1007)
+        #expect(locator?.textQuote == "defg")
+    }
+
+    @Test func txtChapterRange_handlesInvertedRange() {
+        // inverted local [5,3) → nil
+        let locator = LocatorFactory.txtChapterRange(
+            fingerprint: Self.fingerprint,
+            chapterLocalStart: 5,
+            chapterLocalEnd: 3,
+            chapterText: Self.chapterText,
+            chapterGlobalStart: 1000
+        )
+        #expect(locator == nil)
+    }
+
+    @Test func txtChapterRange_zeroGlobalStartIsIdentity() {
+        // globalStart=0 → offsets equal chapter-local offsets (same as txtRange)
+        let locator = LocatorFactory.txtChapterRange(
+            fingerprint: Self.fingerprint,
+            chapterLocalStart: 2,
+            chapterLocalEnd: 5,
+            chapterText: Self.chapterText,
+            chapterGlobalStart: 0
+        )
+        let txtLocator = LocatorFactory.txtRange(
+            fingerprint: Self.fingerprint,
+            charRangeStartUTF16: 2,
+            charRangeEndUTF16: 5,
+            sourceText: Self.chapterText
+        )
+        #expect(locator?.charRangeStartUTF16 == txtLocator?.charRangeStartUTF16)
+        #expect(locator?.charRangeEndUTF16 == txtLocator?.charRangeEndUTF16)
+        #expect(locator?.textQuote == txtLocator?.textQuote)
+    }
+
+    @Test func txtChapterRange_rejectsNegativeStart() {
+        let locator = LocatorFactory.txtChapterRange(
+            fingerprint: Self.fingerprint,
+            chapterLocalStart: -1,
+            chapterLocalEnd: 5,
+            chapterText: Self.chapterText,
+            chapterGlobalStart: 1000
+        )
+        #expect(locator == nil)
+    }
+
+    @Test func txtChapterRange_rejectsEndBeyondChapterText() {
+        // chapterText has 10 UTF-16 units; end=11 exceeds it
+        let locator = LocatorFactory.txtChapterRange(
+            fingerprint: Self.fingerprint,
+            chapterLocalStart: 0,
+            chapterLocalEnd: 11,
+            chapterText: Self.chapterText,
+            chapterGlobalStart: 1000
+        )
+        #expect(locator == nil)
+    }
+}

--- a/vreaderTests/Views/Reader/TXTChapterHighlightCreationTests.swift
+++ b/vreaderTests/Views/Reader/TXTChapterHighlightCreationTests.swift
@@ -1,0 +1,81 @@
+// Purpose: Tests for Feature #48 WI-3 — chapter-local → global locator translation in
+// TXTReaderContainerView's locatorFactory closure.
+//
+// Verifies that in chapter mode, the locatorFactory translates chapter-local selection
+// offsets to global UTF-16 offsets via LocatorFactory.txtChapterRange.
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("TXTReaderContainerView - WI-3 creation translation")
+@MainActor
+struct TXTChapterHighlightCreationTests {
+
+    private static let fingerprint = DocumentFingerprint(
+        contentSHA256: "d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5",
+        fileByteCount: 2048,
+        format: .txt
+    )
+
+    // Chapter text: "hello world selected word goodbye" — 34 UTF-16 code units
+    // "selected w" starts at local offset 12 (after "hello world "), length 10
+    // Positions 12-21 (0-based, 10 chars): s,e,l,e,c,t,e,d,' ',w = "selected w"
+    private static let chapterText = "hello world selected word goodbye"
+    private static let localStart = 12
+    private static let localEnd = 22  // exclusive, covers 10 chars "selected w"
+
+    @Test func chapterModeLocatorIsGlobal_highlightPath() {
+        // Chapter 1: globalStart=1000, text = chapterText
+        // local [12,22) → globals [1012, 1022), quote = "selected wo"
+        let locator = TXTReaderContainerView.makeLocatorForTXT(
+            fingerprint: Self.fingerprint,
+            localStart: Self.localStart,
+            localEnd: Self.localEnd,
+            chapterText: Self.chapterText,
+            chapterGlobalStart: 1000,
+            isChapterMode: true
+        )
+        #expect(locator != nil)
+        #expect(locator?.charRangeStartUTF16 == 1012)
+        #expect(locator?.charRangeEndUTF16 == 1022)
+        #expect(locator?.textQuote == "selected w")
+    }
+
+    @Test func continuousModeLocatorIsPassthrough() {
+        // In continuous mode (no chapter), offsets are global directly.
+        // makeLocatorForTXT with isChapterMode=false + no chapter args
+        // should produce same result as LocatorFactory.txtRange.
+        let locator = TXTReaderContainerView.makeLocatorForTXT(
+            fingerprint: Self.fingerprint,
+            localStart: 12,
+            localEnd: 22,
+            chapterText: nil,
+            chapterGlobalStart: 0,
+            isChapterMode: false
+        )
+        let expected = LocatorFactory.txtRange(
+            fingerprint: Self.fingerprint,
+            charRangeStartUTF16: 12,
+            charRangeEndUTF16: 22
+        )
+        #expect(locator?.charRangeStartUTF16 == expected?.charRangeStartUTF16)
+        #expect(locator?.charRangeEndUTF16 == expected?.charRangeEndUTF16)
+    }
+
+    @Test func chapterModeLocatorIsGlobal_addNotePath() {
+        // Verifies the same seam covers the Add Note path — the locatorFactory closure
+        // is shared between highlight-requested and add-note-save paths.
+        // Chapter 0: globalStart=0 → offsets are identity (no translation).
+        let locator = TXTReaderContainerView.makeLocatorForTXT(
+            fingerprint: Self.fingerprint,
+            localStart: 5,
+            localEnd: 10,
+            chapterText: Self.chapterText,
+            chapterGlobalStart: 0,
+            isChapterMode: true
+        )
+        #expect(locator?.charRangeStartUTF16 == 5)
+        #expect(locator?.charRangeEndUTF16 == 10)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `LocatorFactory.txtChapterRange`: translates chapter-local UTF-16 selection offsets to global offsets with quote/context extracted from chapter text
- Changes `locatorFactory` annotation from `@Sendable` → `@MainActor` in `ReaderNotificationDeps` (enables viewModel capture; all call sites already `@MainActor`)
- Adds `TXTReaderContainerView.makeLocatorForTXT` static seam (testable dispatch: chapter mode → `txtChapterRange`, continuous → `txtRange`)
- Rebuilds `makeNotificationDeps` locatorFactory closure to capture `viewModel` and dispatch through `makeLocatorForTXT` — fixes chapter-local offsets being stored as global for both highlight-requested and add-note paths

Refs #554

## What Changed

- `LocatorFactory.swift`: new `txtChapterRange(fingerprint:chapterLocalStart:chapterLocalEnd:chapterText:chapterGlobalStart:)` with bounds validation
- `ReaderNotificationHandlers.swift`: `@Sendable` → `@MainActor` on `locatorFactory` property and init parameter
- `TXTReaderContainerView.swift`: `makeLocatorForTXT` static helper + rebuilt locatorFactory closure

## Codex Audit

Manual fallback (Codex MCP stream disconnected). 1 round. 1 Low finding: `makeLocatorForTXT` with `isChapterMode=true, chapterText=nil` originally fell through to `txtRange` treating local offsets as global — fixed to return `nil` instead.

Audit log: `.claude/codex-audits/feat-feature-48-wi-3-creation-translation-audit.md`

## Validation

- [x] `xcodebuild test` passes (8 WI-3 tests: 5 factory unit + 3 creation translation)
- [x] Tests cover changed behavior (TDD: RED → GREEN)
- [x] Manual audit loop completed (1 round, 1 Low finding fixed, verdict: ship-as-is)
- [x] Docs sync — n/a (no new service/actor/notification/user-visible feature)
- [x] Version bumped: 3.19.0 → 3.20.0

## Post-Merge Verification Plan

Exception path: `TXTChapterHighlightCreationTests.chapterModeLocatorIsGlobal_highlightPath` drives the exact same code path (`makeLocatorForTXT` → `txtChapterRange`) that the production failure (chapter-local offsets stored as global) would hit. Real end-to-end verification (long-press → Highlight in war-and-peace.txt chapter mode → close/reopen → paint persists) is the WI-3 close-gate test, deferred to post-merge device verification.

## Type of Change

- [x] New feature WI (Refs #554, Feature #48 WI-3 — final WI)