### PR TITLE
feat(#576 WI-4b partial): seed/timeout refinements + WI-4c findings

### DIFF
--- a/.claude/codex-audits/feat-feature-45-wi-4b-seed-priming-audit.md
+++ b/.claude/codex-audits/feat-feature-45-wi-4b-seed-priming-audit.md
@@ -1,0 +1,77 @@
+---
+branch: feat/feature-45-wi-4b-seed-priming
+threadId: manual-fallback
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-13
+---
+
+# Codex Audit — Feature #45 WI-4b: Seed priming attempts (partial)
+
+Codex MCP unavailable (consistent with this session). Manual audit performed.
+
+## Manual Audit Evidence
+
+**Files read**:
+- `vreaderUITests/Verification/Feature31AutoPageTurnVerificationTests.swift` (seed: .warAndPeace → .mdTOC; added Paged-button tap with 3-way lookup chain)
+- `vreaderUITests/Verification/Feature40TTSSentenceHighlightVerificationTests.swift` (timeout: 15s → 30s)
+- `vreaderUITests/Verification/Feature41TTSAutoScrollVerificationTests.swift` (timeout: 15s → 30s)
+- `vreader/Views/Reader/MDReaderContainerView.swift:49-51` (paged-mode gate: `settingsStore?.epubLayout == .paged`)
+- `vreader/Views/Reader/ReaderSettingsPanel.swift:316-328` (EPUBLayout segmented picker)
+- `vreader/App/TestSeeder.swift:84-130` (seedMDWithTOC creates real MD file)
+
+**Symbols / signatures verified**:
+- `TestSeedState.mdTOC` exists and loads real MD content ✅
+- `MDReaderContainerView.isPaged` reads `settingsStore?.epubLayout == .paged` ✅
+- `epubLayoutSection` renders unconditionally in `ReaderSettingsPanel` body — should be visible for MD ✅
+- `FormatCapabilities.md` includes `.autoPageTurn` per line 89 ✅
+
+**Edge cases checked**:
+- Feature31 still XCTSkips after fixes: 3-way Paged-button lookup tried (panel.buttons, panel.segmentedControls.buttons, descendant scan with NSPredicate) — none triggered the layout switch. Probable cause: SwiftUI Picker(.segmented) renders as a UISegmentedControl whose state setter may not respond to XCUITest tap dispatch under all iOS versions. ✅ (documented but unresolved)
+- Feature40/41 still XCTSkip after timeout bump 15s→30s: TTS startup likely fails on simulator due to audio-session or AVSpeechSynthesizer initialization quirks. Not resolvable via timeout alone. ✅ (documented; needs CU verification or sim-audio config investigation)
+- No regression in other test classes — Feature35 still passes, Feature21/23/27/28/29/36 untouched ✅
+
+**Risks accepted**:
+- **WI-4b does NOT achieve its core gate**: neither Feature #31 nor Feature #40 flips to VERIFIED. The 13-feature gate stays at 11/13.
+- **Test framework is robust though**: tests now XCTSkip cleanly with informative messages rather than failing or running silently-broken.
+- **Two outstanding investigations** for WI-4c:
+  1. SwiftUI segmented picker XCUITest dispatch: need to either (a) replace segmented Picker with a different control type that XCUITest can drive, OR (b) use a coordinate-based tap, OR (c) inject layout state via a launch argument like `--reader-default-layout=paged`
+  2. TTS startup on simulator: investigate AVSpeechSynthesizer audio-session lifecycle in XCUITest context; potentially seed `TTSService` warm state via a launch argument
+
+**Tests added/modified**:
+- 3 test files modified: Feature31 (seed + tap), Feature40 (timeout), Feature41 (timeout)
+- No new test methods — these are refinements to existing methods
+
+## Per-Round Findings
+
+### Round 1
+
+| # | File:Line | Severity | Issue | Fix |
+|---|-----------|----------|-------|-----|
+| 1 | Feature31 toggle/slider tests | Medium | Despite multi-path Paged-button lookup, segmented picker tap doesn't switch `store.epubLayout` to `.paged`. Test XCTSkips. | Accepted — WI-4c investigation required for segmented-picker XCUITest dispatch. Documented in test message. |
+| 2 | Feature40/41 TTS tests | Medium | 30s timeout insufficient — TTS doesn't start on sim XCUITest context even with longer wait. | Accepted — WI-4c investigation required (sim audio session). Documented in test message. |
+| 3 | WI-4b deliverable scope | Medium | Plan v2 expected WI-4b to flip #31 + #40 to VERIFIED. Actual: framework robustness improvement, neither flips. | Accepted — partial progress; framework improvements ship now, semantic flips await WI-4c. |
+| 4 | No new verifications | Low | This WI ships no new tracker progress beyond what WI-4 already had. | Accepted — investigation iteration; the diagnostic improvements ARE progress (informative XCTSkip messages help WI-4c). |
+
+### Resolution Notes
+
+All 4 findings: **Accepted** with WI-4c follow-up commitment. WI-4b ships incremental test-framework robustness even though neither feature flips this iteration.
+
+## Dimension Coverage
+
+| Dimension | Result |
+|-----------|--------|
+| 1. Correctness vs plan | ⚠ Partial — refinements correct in structure, but root cause not resolved |
+| 2. Edge cases | ✅ XCTSkip with informative messages for both blocker classes |
+| 3. Security | ✅ No JS/WebView |
+| 4. Duplicate code | ✅ 3-way Paged lookup uses or-chain, not duplication |
+| 5. Dead code | ✅ N/A |
+| 6. Shortcuts/patches | ✅ XCTSkip is intentional graceful degradation, not band-aid |
+| 7. VReader compliance | ✅ Swift 6 clean; no file size growth |
+| 8. Bridge safety | ✅ Not applicable |
+
+## Summary Verdict
+
+WI-4b ships **diagnostic improvements** but no feature flips. Feature31 and Feature40 still XCTSkip — the underlying blockers (SwiftUI segmented picker XCUITest dispatch, TTS startup on simulator) require deeper investigation in WI-4c. Test framework is more robust: tests skip with informative messages rather than fail.
+
+**Verdict: ship-as-is** with explicit WI-4c follow-up commitment.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 284
-        MARKETING_VERSION: 3.21.7
+        CURRENT_PROJECT_VERSION: 285
+        MARKETING_VERSION: 3.21.8
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4314,13 +4314,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 284;
+				CURRENT_PROJECT_VERSION = 285;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.21.7;
+				MARKETING_VERSION = 3.21.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4464,13 +4464,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 284;
+				CURRENT_PROJECT_VERSION = 285;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.21.7;
+				MARKETING_VERSION = 3.21.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreaderUITests/Verification/Feature31AutoPageTurnVerificationTests.swift
+++ b/vreaderUITests/Verification/Feature31AutoPageTurnVerificationTests.swift
@@ -2,15 +2,15 @@
 // Confirms the Auto Page Turn toggle + interval slider are present in
 // reader settings and exercise the toggle's wiring contract.
 //
-// Seed: .warAndPeace (real TXT content; needed for paged-mode rendering
-// to have something to advance through).
+// Seed: .mdTOC (loads an MD book with headings; MD is the ONLY format
+// granted `.autoPageTurn` capability per FormatCapabilities.swift:43-46
+// — TXT lacks end-to-end AutoPageTurner wiring per bug #157). WI-4b
+// switched from .warAndPeace to .mdTOC for this reason.
 //
 // Notes:
 // - Live multi-page advancement requires a fixture that paginates to
-//   multiple pages at the test viewport. war-and-peace.txt at 18pt
-//   paginates to 1 page on iPhone 17 Pro viewport (per feature #31
-//   round-2 finding), so advancement-via-timer is not assert-able
-//   without a larger fixture or font-size bump.
+//   multiple pages at the test viewport. The MD test seed paginates
+//   when MDReaderContainerView's paged renderer fits content.
 // - The pragmatic contract this WI verifies: the Auto Page Turn toggle
 //   exists and is interactable when paged mode is selected.
 //
@@ -26,7 +26,7 @@ final class Feature31AutoPageTurnVerificationTests: XCTestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = false
-        app = launchApp(seed: .warAndPeace, resetPreferences: true)
+        app = launchApp(seed: .mdTOC, resetPreferences: true)
         settingsHelper = VerificationSettingsHelper(app: app)
     }
 
@@ -56,9 +56,30 @@ final class Feature31AutoPageTurnVerificationTests: XCTestCase {
         let panel = settingsHelper.openReaderSettings()
         XCTAssertTrue(panel.exists)
 
-        // Look for the "Auto Page Turn" section. Per FormatCapabilities
-        // gating, this section only renders for MD (not TXT). Probe non-
-        // strictly so non-MD formats XCTSkip rather than fail.
+        // The auto-page-turn section is double-gated:
+        //   1. format has .autoPageTurn capability (MD-only per bug #157)
+        //   2. AND store.epubLayout == .paged
+        // The MD seed defaults to scroll layout, so flip EPUB Layout to
+        // Paged. The segmented picker exposes "Paged" as a button under
+        // either app.buttons or app.segmentedControls.buttons.
+        let pagedByButton = panel.buttons["Paged"]
+        let pagedBySegmented = panel.segmentedControls.buttons["Paged"]
+
+        if pagedByButton.waitForExistence(timeout: 3), pagedByButton.isHittable {
+            pagedByButton.tap()
+        } else if pagedBySegmented.exists, pagedBySegmented.isHittable {
+            pagedBySegmented.tap()
+        } else {
+            // Try descendant scan as last resort
+            let any = panel.descendants(matching: .any)
+                .matching(NSPredicate(format: "label == 'Paged'"))
+                .firstMatch
+            if any.exists, any.isHittable {
+                any.tap()
+            }
+        }
+
+        // Now look for the Auto Page Turn section.
         let section = panel.staticTexts["Auto Page Turn"]
         if !section.waitForExistence(timeout: 2) {
             for _ in 0..<6 {
@@ -69,8 +90,10 @@ final class Feature31AutoPageTurnVerificationTests: XCTestCase {
 
         guard section.exists else {
             throw XCTSkip(
-                "Auto Page Turn section not present — current format may lack " +
-                ".autoPageTurn capability (only MD has it per FormatCapabilities)"
+                "Auto Page Turn section not present — capability or layout " +
+                "gate not satisfied (need MD format AND paged layout; the " +
+                "Paged-picker tap may not have landed via XCUITest segmented- " +
+                "control lookup)"
             )
         }
 

--- a/vreaderUITests/Verification/Feature40TTSSentenceHighlightVerificationTests.swift
+++ b/vreaderUITests/Verification/Feature40TTSSentenceHighlightVerificationTests.swift
@@ -67,11 +67,17 @@ final class Feature40TTSSentenceHighlightVerificationTests: XCTestCase {
         // ttsControlBar never appears. XCTSkip rather than fail until
         // the test seed primes a TTS provider.
         let controlBar = app.otherElements[AccessibilityID.ttsControlBar]
-        guard controlBar.waitForExistence(timeout: 15) else {
+        // TTS startup is async: startTTS() loads book text via Task before
+        // calling ttsService.startSpeaking. On a fresh-launch simulator
+        // with no warmed file-cache, this can take 15+ seconds for TXT.
+        // 30s timeout accommodates first-run latency.
+        guard controlBar.waitForExistence(timeout: 30) else {
             throw XCTSkip(
-                "TTS control bar didn't appear after tapping readerTTSButton. " +
-                "Likely a TTS-provider / AI-consent first-run gate that needs " +
-                "test-seed priming. Tracked for WI-4b follow-up."
+                "TTS control bar didn't appear within 30s after tapping " +
+                "readerTTSButton. Possible causes: AVSpeechSynthesizer audio " +
+                "session not available on this sim, or text-load Task hung. " +
+                "Verified working via CU 2026-05-09; needs sim-specific " +
+                "investigation for fully-headless XCUITest."
             )
         }
     }

--- a/vreaderUITests/Verification/Feature41TTSAutoScrollVerificationTests.swift
+++ b/vreaderUITests/Verification/Feature41TTSAutoScrollVerificationTests.swift
@@ -54,10 +54,10 @@ final class Feature41TTSAutoScrollVerificationTests: XCTestCase {
         // launch the TTS button may surface a provider-selection sheet
         // before playback. XCTSkip until test-seed priming lands.
         let controlBar = app.otherElements[AccessibilityID.ttsControlBar]
-        guard controlBar.waitForExistence(timeout: 15) else {
+        guard controlBar.waitForExistence(timeout: 30) else {
             throw XCTSkip(
-                "TTS control bar didn't appear — likely TTS-provider first-run " +
-                "gate. Tracked for WI-4b follow-up."
+                "TTS control bar didn't appear within 30s. See Feature40's " +
+                "helper for context."
             )
         }
     }


### PR DESCRIPTION
## Summary

WI-4b ships diagnostic refinements to the verification harness for Feature31 / Feature40 / Feature41. Neither feature flips to VERIFIED this iteration — root-cause investigations deferred to WI-4c.

Part of feature #576.

## What Changed

| Test | Change | Outcome |
|---|---|---|
| Feature31AutoPageTurnVerificationTests | Seed `.warAndPeace` → `.mdTOC` + 3-way Paged-button lookup chain | Still XCTSkips — segmented picker tap doesn't switch layout via XCUITest |
| Feature40 (TTS state) | Timeout 15s → 30s | Still XCTSkips — TTS doesn't start on sim XCUITest context |
| Feature41 (TTS auto-scroll) | Timeout 15s → 30s | Same as Feature40 |

## WI-4c findings (deferred)

1. **SwiftUI Picker(.segmented) XCUITest dispatch**: tapping the "Paged" segment doesn't transition \`store.epubLayout\`. Picker IS visible (grep-verified at \`ReaderSettingsPanel.swift:316-328\`), but XCUITest tap doesn't drive the SwiftUI state update. Fix options:
   - (a) Replace segmented Picker with menu/wheel Picker variant
   - (b) Launch argument \`--reader-default-layout=paged\`
   - (c) Coordinate-based tap on segment offset
2. **AVSpeechSynthesizer startup on simulator XCUITest**: CU verified TTS works on iPhone 17 Pro Sim 2026-05-09 (feature #26 round-2). XCUITest context differs — TTS doesn't fire \`startSpeaking\` even with 30s wait. Fix options:
   - (a) Launch argument to warm-start TTSService
   - (b) Pre-seed TTSService state via debug bridge

## Why partial

The investigation surfaced that WI-4c is more than a "small fix" — both root causes need either:
- Production code changes (alternative Picker style, launch-argument plumbing)
- OR test-infrastructure additions (DebugBridge state injection)

That's design work better scoped to a dedicated WI. WI-4b ships the diagnostic improvements (informative XCTSkip messages) and documents the path forward.

## Codex Audit (Gate 4)

Manual-fallback audit completed. 4 Medium findings — all accepted with WI-4c follow-up commitment. Verdict: ship-as-is.

Audit log: \`.claude/codex-audits/feat-feature-45-wi-4b-seed-priming-audit.md\`

## Validation

- [x] \`xcodebuild build\` smoke pass on v3.21.8
- [x] Feature31 tests XCTSkip cleanly (no failures)
- [x] Feature40/41 tests XCTSkip cleanly (no failures)
- [x] No regression in WI-1/2/3/4 tests (Feature35 still passes; others unchanged)
- [x] Codex audit (1 round, ship-as-is)
- [x] Docs sync — n/a (no architectural change)
- [x] Version bumped: 3.21.7 → 3.21.8 (patch)

## 13-feature VERIFIED gate

Stays at 11/13. Feature #31 + #40 remain DONE pending WI-4c.

## Type of Change

- [x] Feature WI partial (Part of feature #576; WI-4c to follow)