### PR TITLE
feat(#576 WI-4d partial): VerificationDebugBridgeHelper.ttsAction helper + simctl-from-sandbox blocker documented

### DIFF
--- a/.claude/codex-audits/feat-45-wi-4d-tts-test-refactor-audit.md
+++ b/.claude/codex-audits/feat-45-wi-4d-tts-test-refactor-audit.md
@@ -1,0 +1,101 @@
+---
+branch: feat/45-wi-4d-tts-test-refactor
+threadId: manual-fallback
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-14
+---
+
+# Feature #45 WI-4d — TTS test refactor helper method (audit log, PARTIAL)
+
+## Context
+
+WI-4d set out to refactor Feature40/41 XCUITest verification tests to use
+`vreader-debug://tts?action=start` instead of `ttsButton.tap()`, leveraging
+WI-4c-b's shipped URL handler. Investigation revealed a simctl-from-XCUITest
+-sandbox URL delivery blocker (documented in the plan doc). WI-4d was
+re-scoped to ship only the clean helper abstraction; the test refactors
+are deferred to a future WI-4e pending the routing question.
+
+## Codex availability
+
+Codex MCP unavailable this session (`stream disconnected before completion`
+across all calls today). Manual fallback per rule 47.
+
+## Files audited
+
+| File | Purpose | Audit |
+|---|---|---|
+| `vreaderUITests/Verification/Helpers/VerificationDebugBridgeHelper.swift` | added `ttsAction(_:)` + `DebugCommand.ttsURL(action:)` | reviewed |
+| `dev-docs/plans/20260513-feature-45-verification-harness-sweep.md` | appended WI-4d plan + Gate 2 audit + PARTIAL outcome | reviewed |
+
+## Manual audit evidence
+
+### Files read
+
+- `vreaderUITests/Verification/Helpers/VerificationDebugBridgeHelper.swift`
+  (full, post-edit). Confirmed `ttsAction` follows the exact same pattern
+  as `seedFixture` / `settleApp` / `snapshotApp`:
+  fail-on-construction-failure + `send(url)`. Symmetric with peer methods.
+- `DebugCommand` enum's new `ttsURL(action:)` mirrors `seedURL(fixture:)` /
+  `settleURL(token:)` / `snapshotURL(dest:)` shape: URLComponents +
+  vreader-debug scheme + matching host + single queryItem.
+- `vreader/Services/DebugBridge/DebugCommand.swift` already parses
+  `vreader-debug://tts?action=<action>` correctly (shipped in WI-4c-b,
+  with 4 unit tests in DebugCommandTests).
+
+### Symbols verified
+
+- `URL(string:)` initializer pattern: matches existing `resetURL` shape.
+- `XCTFail` import: indirectly via `XCTest` already imported at file head.
+- `send(_:)` private method: existing, takes a `URL`, fire-and-forget via
+  posix_spawn.
+
+### Edge cases checked
+
+1. **`action: ""`** (empty): `URLQueryItem(name: "action", value: "")` → URL
+   constructed but production handler will reject "" as `invalidParam(action,
+   reason: "expected start|stop, got ")`. Helper does its job; production
+   surfaces the error.
+2. **`action: "garbage"`** (invalid): URL constructed; production handler
+   raises `invalidParam`. Same as above.
+3. **`action: "start"` / `action: "stop"`** (valid): URL constructed
+   correctly, parses to `.tts(action: "start"/"stop")` in production.
+4. **`xcrun simctl` exec failure** (the discovered blocker): silent — fire-
+   and-forget pattern. Documented in plan doc; not fixed in this WI.
+5. **Calling `ttsAction` when no reader is mounted**: production observer
+   in ReaderContainerView only attaches when the View is in the hierarchy.
+   Notification fires but no observer → no-op. Defensive, no crash.
+
+### Risks accepted
+
+- **Helper compiles + ships, but no XCUITest exercises the new path yet** —
+  acceptable because the helper is additive (zero behavioral risk in
+  Release; XCUITest-only file) and unblocks future iterations once the
+  simctl routing question is resolved.
+- **Tests still XCTSkip on AVSpeech audio session** — pre-existing behavior,
+  not introduced by this WI. Documented in plan doc as deferred to WI-4e.
+
+### VReader compliance
+
+- Swift 6 strict concurrency: clean (helper is an iOS test target,
+  XCUITest classes are MainActor-bound naturally).
+- File size: VerificationDebugBridgeHelper.swift grew from 200 → 220 lines.
+  Well under 300.
+- Bridge safety: not applicable (this is a TEST helper, not a JS/WKWebView
+  bridge).
+
+## Findings
+
+| # | Severity | Issue | Resolution |
+|---|---|---|---|
+| 1 | n/a | Method follows established peer-helper pattern exactly | n/a |
+| 2 | n/a | Documented simctl-from-sandbox blocker thoroughly in plan doc with three concrete unblock paths | acknowledged in plan |
+
+## Final verdict
+
+**ship-as-is** — additive helper method that follows existing patterns 1:1.
+Compiles, doesn't change any test behavior, leaves the test refactors clearly
+documented as deferred to a future WI-4e pending the simctl-from-sandbox
+investigation. Net: small forward progress on the harness's surface area,
+zero regression risk.

--- a/dev-docs/plans/20260513-feature-45-verification-harness-sweep.md
+++ b/dev-docs/plans/20260513-feature-45-verification-harness-sweep.md
@@ -1014,3 +1014,231 @@ Codex MCP unavailable this session (`stream disconnected before completion` on e
 5. Existing snapshot tests (`test_snapshot_withoutActiveReader_*`, `test_snapshot_withActiveReader_*`, `test_snapshot_withActiveReaderAndPosition_*`) updated for the new partial-array members.
 6. `xcodebuild test -only-testing:vreaderTests` green.
 
+
+---
+
+## WI-4d — Refactor Feature40/41 XCUITest verification to use DebugBridge TTS URL (2026-05-14)
+
+### Problem
+
+WI-4c-b shipped `vreader-debug://tts?action=start` (the URL handler that drives
+the production AVSpeechSynthesizer in a way XCUITest can reach), and WI-4c-c
+wired `ttsState`/`ttsOffsetUTF16` into `DebugSnapshot`. The remaining work is
+to actually USE these in the XCUITest verification tests for features #40 and
+#41, which still XCTSkip on the `ttsButton.tap()` path because AVSpeechSynthesizer
+won't activate its audio session under XCUITest's runner-test split.
+
+Both tests currently flow: tap reader → `ttsButton.tap()` → wait 30s for
+`ttsControlBar` → XCTSkip when it never appears. After this WI the flow becomes:
+tap reader → fire `vreader-debug://tts?action=start` → wait 5s for
+`ttsControlBar` → snapshot to confirm `ttsState == "speaking"` and
+`ttsOffsetUTF16 > 0`.
+
+### Scope
+
+1. `vreaderUITests/Verification/Helpers/VerificationDebugBridgeHelper.swift`:
+   add `func ttsAction(_ action: String)` method that fires
+   `vreader-debug://tts?action=<action>` (mirrors `seedFixture`/`settleApp`
+   shape). Add `DebugCommand.ttsURL(action:)` static helper.
+2. `vreaderUITests/Verification/Feature40TTSSentenceHighlightVerificationTests.swift`:
+   replace `ttsButton.tap()` path with `bridgeHelper.ttsAction("start")`.
+   Drop the AVSpeech XCTSkip. Reduce control-bar timeout from 30s to 5s
+   (the URL path is synchronous; the bar appears within ~1s once the URL
+   fires per WI-4c-b spike-0).
+3. `vreaderUITests/Verification/Feature41TTSAutoScrollVerificationTests.swift`:
+   same refactor pattern.
+
+**Files OUT of scope:**
+
+- `Feature31AutoPageTurnVerificationTests.swift` — already refactored in
+  WI-4c-a to use `LaunchArgs.readerLayoutPaged`. Its remaining XCTSkip is
+  a defensive fallback for "section not present" — out of scope to touch.
+- Production code (DebugCommand, ReaderContainerView observer) — already
+  shipped in WI-4c-b.
+- `RealDebugBridgeContext+Snapshot.swift` and `DebugReaderProbeAdapter.swift`
+  — already shipped in WI-4c-c.
+- TTS-stop test paths — feature #40/#41 acceptance criteria don't require
+  testing stop; existing tests don't exercise it.
+
+### Prior art / project precedent
+
+- `seedFixture(named:)` and `settleApp(token:)` in `VerificationDebugBridgeHelper`
+  — exact precedent for "fire-and-observe" URL helper methods. `ttsAction`
+  follows the same shape.
+- WI-4c-b's `DebugCommand.parse` already accepts `action=start|stop` and
+  routes through `.debugBridgeTTSCommand`; consumer side is wired.
+- WI-4c-b spike-0 verified the URL drives real AVSpeech successfully under
+  the same iOS Simulator XCUITest would use.
+
+### Work-item sequencing
+
+Single WI. 3 files modified (helper + 2 tests). PR size: ~60-80 LOC.
+
+### Test catalogue
+
+- `Feature40TTSSentenceHighlightVerificationTests.verify_feature_40_tts_state_reported_after_start`:
+  RED (pre-WI-4d): XCTSkips on AVSpeech session. GREEN: asserts
+  `snapshot["ttsState"] != "idle"` within 5s of firing the URL.
+- `Feature40TTSSentenceHighlightVerificationTests.verify_feature_40_tts_offset_advances_during_playback`:
+  same RED→GREEN; the offset-advancement check now actually runs.
+- `Feature41TTSAutoScrollVerificationTests.verify_feature_41_tts_control_bar_visible_during_playback`:
+  RED→GREEN.
+- `Feature41TTSAutoScrollVerificationTests.verify_feature_41_tts_autoscroll_position_advances`:
+  RED→GREEN.
+
+No new unit tests — `DebugCommand.parse` for `tts?action=start` is already
+covered by `DebugCommandTests` (WI-4c-b shipped 4 cases).
+
+### Risks + mitigations
+
+- **Risk**: the test app launches `--reset-preferences` so any pre-existing
+  TTS provider config is wiped. `startTTS()` may surface a provider-selection
+  sheet on first activation. **Mitigation**: the spike-0 path used the URL
+  AFTER the reader was loaded; that code path goes through `startTTS()` which
+  reads `ttsService` directly. The provider-selection sheet was a finding
+  about the BUTTON-tap path going through a different flow. The URL path
+  bypasses that. If the test still fails, the symptom would be "URL fires
+  but ttsControlBar never appears" — we'd then need to investigate the
+  observer side. Spike-0 evidence suggests this won't reproduce.
+- **Risk**: AccessibilityID.ttsControlBar may rename. **Mitigation**:
+  AccessibilityID is the single source of truth used across production and
+  tests; refactoring would propagate automatically.
+- **Risk**: XCUITest's container-path lookup may break post-launch.
+  **Mitigation**: `VerificationDebugBridgeHelper.appDataContainerPath()`
+  is already used by all snapshot reads; this WI doesn't change that path.
+
+### Backward compat
+
+- All changes are additive (one new helper method) or test-only refactors.
+- No production-code change.
+
+### Edge cases
+
+- TTS already speaking (idempotent start): `ttsService.startSpeaking` is
+  guarded by `state != .idle` in production. The URL handler calls
+  `startTTS()` which reads `ttsService.state` first. No double-start.
+- URL fires before reader has loaded the book: spike-0's reader-tap pattern
+  is preserved (`tapFirstBook` + `waitForExistence(readerBackButton)`)
+  before firing the URL.
+
+### Gate
+
+- `xcodebuild test -only-testing:vreaderUITests/Feature40TTSSentenceHighlightVerificationTests`
+  passes without XCTSkip (both methods).
+- `xcodebuild test -only-testing:vreaderUITests/Feature41TTSAutoScrollVerificationTests`
+  passes without XCTSkip (both methods).
+- `xcodebuild test -only-testing:vreaderTests` stays green (unit test
+  surface unchanged).
+
+### Acceptance criteria
+
+1. `VerificationDebugBridgeHelper.ttsAction(_:)` method exists; fires
+   `vreader-debug://tts?action=<action>` via `xcrun simctl openurl booted`.
+2. `DebugCommand.ttsURL(action:)` static helper constructs the URL.
+3. Feature40 + Feature41 tests use `bridgeHelper.ttsAction("start")`
+   instead of `ttsButton.tap()`.
+4. Both tests' `XCTSkip` branches for AVSpeech audio session are removed
+   (the defensive `Reader TTS button not present` skip stays — that's a
+   genuine accessibility surface check).
+5. Control-bar timeout reduced 30s → 5s.
+6. Both XCUITest verification tests pass without XCTSkip on iPhone 17 Pro Sim.
+
+### Gate 2 — Independent audit (manual fallback)
+
+Codex MCP unavailable this session (`stream disconnected before completion`
+across the day). Manual fallback per rule 47.
+
+**Files read:**
+- `vreaderUITests/Verification/Helpers/VerificationDebugBridgeHelper.swift`
+  (full, 200 lines)
+- `vreaderUITests/Verification/Feature40TTSSentenceHighlightVerificationTests.swift`
+  (full, 153 lines)
+- `vreaderUITests/Verification/Feature41TTSAutoScrollVerificationTests.swift`
+  (full)
+- `vreader/Services/DebugBridge/DebugCommand.swift` (already includes
+  the `tts(action:)` case from WI-4c-b, lines 130-145)
+- `vreader/Views/Reader/ReaderContainerView.swift` (already observes
+  `.debugBridgeTTSCommand` from WI-4c-b)
+
+**Symbols verified:**
+- `xcrun simctl openurl booted <url>` is the same mechanism `seedFixture`
+  uses — proven to work for DebugBridge URLs in WI-4c-b spike-0. ✓
+- `DebugCommand.parse("vreader-debug://tts?action=start")` returns
+  `.tts(action: "start")` — verified in `DebugCommandTests` (WI-4c-b). ✓
+- `AccessibilityID.ttsControlBar` is the canonical identifier used by
+  `TTSControlBar.swift` and current tests. ✓
+
+**Edge cases checked:**
+1. URL fires before book reader loads → existing tests already wait on
+   `readerBackButton.waitForExistence(timeout: 15)` before any action. ✓
+2. URL fires twice (test reruns): production `startTTS()` is idempotent
+   on `state != .idle`. ✓
+3. Test setup `--reset-preferences` wipes any TTS-provider state: the URL
+   path doesn't depend on user-config; uses default AVSpeech. ✓
+4. Helper method missing the URL construction: `DebugCommand.ttsURL` is
+   a new static func; covered by RED step (writing the test before the
+   helper).
+
+**Risks accepted:**
+- None Critical/High. Single risk Low: the 5s control-bar timeout may be
+  slightly aggressive for slow CI runners; production URL fires within
+  1s per spike-0, so 5s has 5× headroom.
+
+**Verdict:** ship-as-is. WI is mechanical refactor that follows existing
+helper patterns and is gated by clear XCUITest assertions.
+
+### WI-4d outcome (2026-05-14) — PARTIAL
+
+**Shipped:** `VerificationDebugBridgeHelper.ttsAction(_:)` + `DebugCommand.ttsURL(action:)`. Clean abstraction parallel to `seedFixture` / `settleApp` / `snapshotApp`. Compiles, doesn't change any test behavior on its own.
+
+**Deferred:** the Feature40/41 test refactors. Investigation revealed an
+infrastructure blocker that's broader than WI-4d's scope:
+
+**Blocker — simctl-from-XCUITest-runner-sandbox URL delivery is unreliable.**
+The VerificationDebugBridgeHelper.send() method spawns `/usr/bin/xcrun simctl
+openurl booted <url>` via posix_spawn. But `/usr/bin/xcrun` is on the host
+Mac filesystem, not inside the iOS Simulator sandbox where the XCUITest
+runner-app runs. posix_spawn from the runner sandbox can't reach the host
+binary, so the URL never fires.
+
+Evidence:
+1. Manual repro from a Mac terminal (outside XCUITest) — TTS URL delivers
+   successfully (`ttsState: "speaking"` in post-fire snapshot, confirmed
+   in this session 2026-05-14 ~02:48).
+2. XCUITest test using `bridgeHelper.ttsAction("start")` — no app behavior
+   observed; `ttsControlBar.waitForExistence(timeout: 5)` fails.
+3. Other tests that use `bridgeHelper.settleApp` happen to also have a
+   fallback `waitForExistence` on a non-settle UI element, so the settle
+   failure is masked — they appear to pass without proving simctl URL
+   delivery from sandbox actually works.
+
+This is a foundational infrastructure problem that affects ALL XCUITest
+verification tests that try to drive DebugBridge URLs from inside the
+test. It's broader than WI-4d, and fixing it requires one of:
+
+- **(a)** Move simctl invocations to the host side via a pre-test script
+  + IPC mechanism (XCTAttachment, a shared file watcher). Significant
+  infrastructure work.
+- **(b)** Replace simctl with an in-app URL-firing mechanism (e.g., a
+  test-only HTTP endpoint inside the test app that the runner POSTs to,
+  bridging back to the DebugBridge URL handler).
+- **(c)** Mock `AVSpeechSynthesizer` via a test-only `SpeechSynthesizing`
+  adapter (the original WI-4c plan's fallback option). Bypasses the
+  URL-delivery question entirely.
+
+Acting on any of these is a separate WI (likely a feature-class one).
+Out of scope for this iteration.
+
+**Status:** Feature #45 IN PROGRESS. Helper method shipped. Feature40/41
+test refactors deferred to WI-4e (TBD) pending the simctl-from-sandbox
+investigation. Both test files reverted to their pre-WI-4d state (still
+XCTSkip on AVSpeech audio session). Helper method is harmless (additive
+only) and unblocks future work once the routing question is resolved.
+
+**Acceptance criteria (revised):**
+
+1. ~~Feature40 + Feature41 tests use `bridgeHelper.ttsAction("start")` instead of `ttsButton.tap()`~~ — DEFERRED
+2. ~~Both XCUITest verification tests pass without XCTSkip~~ — DEFERRED
+3. `VerificationDebugBridgeHelper.ttsAction(_:)` method exists, compiles, follows the established fire-and-observe helper pattern — DONE
+4. `DebugCommand.ttsURL(action:)` static helper constructs the URL — DONE
+5. `xcodebuild build-for-testing` succeeds — DONE

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 312
-        MARKETING_VERSION: 3.21.35
+        CURRENT_PROJECT_VERSION: 313
+        MARKETING_VERSION: 3.21.36
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4326,13 +4326,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 312;
+				CURRENT_PROJECT_VERSION = 313;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.21.35;
+				MARKETING_VERSION = 3.21.36;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4476,13 +4476,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 312;
+				CURRENT_PROJECT_VERSION = 313;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.21.35;
+				MARKETING_VERSION = 3.21.36;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreaderUITests/Verification/Helpers/VerificationDebugBridgeHelper.swift
+++ b/vreaderUITests/Verification/Helpers/VerificationDebugBridgeHelper.swift
@@ -86,6 +86,20 @@ struct VerificationDebugBridgeHelper {
         send(url)
     }
 
+    /// Fire `vreader-debug://tts?action=<action>` to drive the production
+    /// AVSpeechSynthesizer without going through the readerTTSButton tap path
+    /// (which fails under XCUITest because the audio session activation
+    /// requirement breaks across the runner-test split — see feature #45
+    /// WI-4c-b spike-0 evidence). Fire-and-observe: caller waits for
+    /// `ttsControlBar` or snapshot to reflect the state change.
+    func ttsAction(_ action: String) {
+        guard let url = DebugCommand.ttsURL(action: action) else {
+            XCTFail("VerificationDebugBridgeHelper: could not construct TTS URL for action '\(action)'")
+            return
+        }
+        send(url)
+    }
+
     /// Read the snapshot JSON written by `vreader-debug://snapshot?dest=<dest>`.
     /// Returns the parsed dictionary, or nil if the file is absent or malformed.
     func readSnapshot(dest: String) -> [String: Any]? {
@@ -126,6 +140,14 @@ struct VerificationDebugBridgeHelper {
             c.scheme = "vreader-debug"
             c.host = "snapshot"
             c.queryItems = [URLQueryItem(name: "dest", value: dest)]
+            return c.url
+        }
+
+        static func ttsURL(action: String) -> URL? {
+            var c = URLComponents()
+            c.scheme = "vreader-debug"
+            c.host = "tts"
+            c.queryItems = [URLQueryItem(name: "action", value: action)]
             return c.url
         }
     }


### PR DESCRIPTION
## Summary

Add `VerificationDebugBridgeHelper.ttsAction(_:)` following the established peer-helper pattern. PARTIAL — this WI also set out to refactor Feature40/41 verification tests but found a simctl-from-XCUITest-runner-sandbox URL-delivery blocker that's broader than WI-4d's scope.

Refs #576

## What Changed

- `vreaderUITests/Verification/Helpers/VerificationDebugBridgeHelper.swift`: add `ttsAction(_:)` method + `DebugCommand.ttsURL(action:)` static. Symmetric with `seedFixture` / `settleApp` / `snapshotApp` pattern.
- `dev-docs/plans/20260513-feature-45-verification-harness-sweep.md`: append WI-4d plan + Gate 2 audit + PARTIAL outcome documenting the simctl blocker with 3 unblock paths.
- `.claude/codex-audits/feat-45-wi-4d-tts-test-refactor-audit.md`: manual-fallback audit log (Codex MCP unavailable all session), verdict ship-as-is.

## Blocker found during WI-4d

The `VerificationDebugBridgeHelper.send()` method spawns `/usr/bin/xcrun simctl openurl booted <url>` via posix_spawn. `/usr/bin/xcrun` exists on the host Mac, NOT inside the iOS Simulator sandbox where the XCUITest runner-app runs. posix_spawn from the runner can't reach the host binary, so the URL never fires.

Manual repro from a Mac terminal (outside XCUITest): `vreader-debug://tts?action=start` delivers correctly — confirmed today's 02:48 session, snapshot shows `ttsState: "speaking"` and `ttsOffsetUTF16: 35`. XCUITest test using `bridgeHelper.ttsAction("start")`: `ttsControlBar.waitForExistence(timeout: 5)` fails.

Existing tests using `bridgeHelper.settleApp` happen to have a `waitForExistence` fallback on a non-settle UI element that masks the settle failure — they appear to pass without actually proving simctl URL delivery from sandbox works.

Three unblock paths documented in the plan doc (all feature-class scope, not bugfix scope):
- (a) Host-side simctl invocation via XCTAttachment / file-watcher IPC
- (b) In-app HTTP endpoint that the runner POSTs to, bridging back to DebugBridge
- (c) Mock `SpeechSynthesizing` adapter (the original WI-4c plan's fallback option)

## Codex Audit

Codex MCP unavailable this session (`stream disconnected before completion` on every call all day). Manual-fallback audit per rule 47:
- Files read, symbols verified, 5 edge cases checked.
- Verdict: **ship-as-is** (1 round).

Audit log: `.claude/codex-audits/feat-45-wi-4d-tts-test-refactor-audit.md`

## Validation

- [x] `xcodebuild build-for-testing` succeeds
- [x] `xcodebuild test -only-testing:vreaderTests` Swift Testing run: 805/805 pass; XCTest pre-existing flakes unchanged
- [x] Helper method follows established pattern 1:1 (additive, zero behavioral risk)
- [x] No production code change
- [x] Codex audit — manual fallback, ship-as-is
- [x] Docs sync — n/a (no new service/notification/pattern; UI-test-only helper)
- [x] Version bumped: 3.21.35 → 3.21.36

## Post-Merge Verification Plan

Foundational WI (test-target helper only; no user-observable behavior change). Verification-exception applies — the helper compiles + is symmetric with peer methods; behavioral verification happens in future WI-4e when the simctl-from-sandbox blocker is resolved.

## Type of Change

- [x] Feature WI (Part of feature #576)