### PR TITLE
feat(#565 WI-1): WebDAVServerProfile value type + Store actor

### DIFF
--- a/.claude/codex-audits/feat-feature-52-wi-1-server-profile-store-audit.md
+++ b/.claude/codex-audits/feat-feature-52-wi-1-server-profile-store-audit.md
@@ -1,0 +1,110 @@
+---
+branch: feat/feature-52-wi-1-server-profile-store
+threadId: manual-fallback
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-14
+---
+
+# Feature #52 WI-1 — WebDAVServerProfile + WebDAVServerProfileStore (audit log)
+
+## Context
+
+WI-1 is the foundational tier of Feature #52 (Multiple WebDAV server
+profiles). Adds the value type and actor-isolated store; no UI, no
+migration, no factory integration yet (those land in WI-2 / WI-3 /
+WI-4a / WI-4b).
+
+Plan: `dev-docs/plans/20260514-feature-52-multiple-webdav-profiles.md`
+(shipped in PR #646, v3.21.44). Gate 1 + Gate 2 audit clean.
+
+## Codex availability
+
+Codex MCP unavailable this session. Manual fallback per rule 47.
+
+## Files audited
+
+| File | Purpose | Audit |
+|---|---|---|
+| `vreader/Services/Backup/WebDAVServerProfile.swift` (new, 56 LOC) | Value type with id/name/serverURL/username; displayName fallback; keychainPasswordAccount static helper | reviewed |
+| `vreader/Services/Backup/WebDAVServerProfileStore.swift` (new, 217 LOC) | Actor; UserDefaults-backed; keychain bridging; loadSnapshot atomic read; webdavProfilesDidChange notification | reviewed |
+| `vreaderTests/Services/Backup/WebDAVServerProfileTests.swift` (new, ~120 LOC) | 12 value-type tests | reviewed |
+| `vreaderTests/Services/Backup/WebDAVServerProfileStoreTests.swift` (new, ~250 LOC) | 20 store tests | reviewed |
+
+## Manual audit evidence
+
+### Files read
+
+- `vreader/Services/AI/ProviderProfile.swift` (full) — mirrored shape: id/name/baseURL/username analog → id/name/serverURL/username. `apiKey`-not-stored decision mirrored as `password`-not-stored.
+- `vreader/Services/AI/ProviderProfileStore.swift` (full, 197 LOC) — mirrored actor shape: `.shared` singleton, `loadAll`/`activeProfile`/`activeProfileID`/`loadSnapshot`/`upsert`/`remove`/`setActiveProfileID`/`postDidChangeNotification`. Adapted differences: WI-1 has no migrator yet (lands in WI-2), so the `ensureMigrated()` guard is omitted; instead the store reads UserDefaults directly. JSON corruption defense added at the `readProfiles` level (Gate 2 finding #1) — `ProviderProfileStore` defers this to the migrator's reader.
+- `vreader/Services/KeychainService.swift` (lines 73-165) — confirmed `saveString(_:forAccount:)` (line 73), `readString(forAccount:)` (line 85), `delete(forAccount:)` (line 165) signatures. Initial draft used `writeString` (doesn't exist); corrected to `saveString` in WI-1's `writePassword`.
+- `vreader/Services/AI/KeychainService+ProviderProfile.swift` (head) — confirmed the pattern `KeychainService.providerAccount(for: profileID) -> String`. WI-1 uses a static helper on `WebDAVServerProfile` itself (`keychainPasswordAccount(for:)`) instead of an extension on KeychainService — simpler call-site shape, less indirection. Functionally equivalent.
+
+### Symbols verified
+
+- `WebDAVServerProfile.Codable + Sendable + Hashable + Identifiable` ✓ — all derived; no manual conformance code needed.
+- `WebDAVServerProfileStore.shared` ✓ — `static let` on `actor`; production callers go through this.
+- `WebDAVServerProfileStore.init(defaults:keychain:)` ✓ — test-injectable; defaults to `UserDefaults.standard` + `KeychainService()`.
+- `Notification.Name.webdavProfilesDidChange` ✓ — extension at file bottom; name is `"com.vreader.webdav.profilesDidChange"` mirroring the AI counterpart's reverse-DNS shape.
+- `Logger` declared `nonisolated private static` ✓ — same pattern as bug #183's `ReaderSearchCoordinator.logger` fix. Allows the `nonisolated static` `readProfiles`/`writeProfiles` helpers to log without crossing the actor boundary.
+- `UserDefaults` parameter passing: required `nonisolated(unsafe)` on a local binding in `upsert_persistsThroughStoreRecreation` because UserDefaults is thread-safe internally but not declared Sendable. Marker localized to one test; production code passes `UserDefaults.standard` (a global, no crossing).
+
+### Edge cases checked
+
+1. **Empty initial state**: `loadAll` returns `[]`, `activeProfileID` returns nil, `loadSnapshot` returns `([], nil)`. 4 tests cover this.
+2. **Upsert ordering preservation**: append-only for new ids, replace-in-place for existing ids. `upsert_preservesOrderWhenAppending` test asserts insertion order is preserved across 3 inserts.
+3. **Persistence across store recreation**: `upsert_persistsThroughStoreRecreation` writes via store1, reads via store2 (same defaults backing). Tests the disk round-trip through UserDefaults.
+4. **Remove of unknown id**: silently no-ops. Tested.
+5. **Remove of active profile**: clears active to nil (the plan's "no fallback to first" decision — UI surfaces the no-active case). Tested.
+6. **Remove of non-active profile**: keeps active intact. Tested.
+7. **setActiveProfileID(nil)**: clears active. Tested.
+8. **setActiveProfileID(unknown UUID)**: recorded but `activeProfile()` returns nil. Tested; matches `ProviderProfileStore` behavior.
+9. **JSON corruption** (Gate 2 finding #1): `readProfiles` catches decode errors, logs a warning, returns empty list. Tested by writing invalid bytes directly to UserDefaults under the profiles key.
+10. **Malformed UUID string** in active id key: `readActiveID` returns nil (UUID(uuidString:) returns nil for invalid strings). Tested.
+11. **Mutation notifications**: `webdavProfilesDidChange` posted on every upsert/remove/setActiveProfileID. 3 tests use a `NotificationExpectation` helper that observes once and flips a flag.
+12. **Keychain password deletion on remove**: `remove(id:)` calls `keychain.delete(forAccount:)` best-effort with `try?` swallow. Failures are logged but don't fail the remove (the profile is gone from the list regardless; orphaned keychain entry is dead weight, not a correctness issue).
+13. **`UserDefaults.Sendable` crossing**: test helper uses `nonisolated(unsafe)` on the local binding for the one test that passes the same `defaults` instance to two store inits. Single-store tests pass the result of `makeDefaults()` directly to one init (no cross-boundary issue).
+14. **`@unchecked Sendable` for NotificationExpectation helper**: marker accepted; the class has only Bool + optional token state, mutations happen on `.main` queue per the observer's queue parameter. Same posture as similar test helpers elsewhere.
+
+### Concurrency / Swift 6
+
+- `WebDAVServerProfile` is `Sendable` via auto-synthesis (all stored properties are Sendable value types: `UUID`, `String`).
+- `WebDAVServerProfileStore` is an `actor` — isolation is the safety guarantee. All mutating methods (`upsert`, `remove`, `setActiveProfileID`) are isolated by default. Read methods (`loadAll`, `activeProfile`, `loadSnapshot`) are isolated too, returning by-value snapshots.
+- `Logger` declared `nonisolated private static let` — same pattern as bug #183 fix. Allows nonisolated static helpers to log without crossing the actor boundary.
+- Static read/write helpers (`readProfiles`, `writeProfiles`, `readActiveID`, `writeActiveID`) declared `nonisolated` — they take `UserDefaults` (thread-safe in practice though not Sendable-declared) as a parameter. Production callers always pass the actor's own `self.defaults` from within the actor's isolation, so the boundary cross is safe.
+- `postDidChangeNotification` declared `nonisolated` — `NotificationCenter.default` is thread-safe under Swift 6.
+- No new `@unchecked Sendable` types in production code. Test helper `NotificationExpectation` uses `@unchecked Sendable` (Bool flag + optional NSObjectProtocol token); acceptable for test scaffolding.
+
+### VReader compliance
+
+- Swift 6 strict concurrency: clean (`SWIFT_STRICT_CONCURRENCY: complete`).
+- `@MainActor` correctness: no MainActor types introduced; store is non-MainActor (matches `ProviderProfileStore`).
+- File size: `WebDAVServerProfile.swift` 56 LOC, `WebDAVServerProfileStore.swift` 217 LOC. Both under 300.
+- Bridge safety: not applicable (no WKWebView / JS).
+- DEBUG gating: not applicable (production code).
+
+### Risks accepted
+
+- **Singleton `.shared`**: same posture as `ProviderProfileStore.shared`. Tests use the explicit init path; production uses `.shared`. Plan section 5 (Gate 2 audit) documents the shared-instance contract.
+- **Best-effort keychain cleanup on remove**: `try?` swallows the delete error. The profile is gone from the list regardless; orphan keychain entries are dead weight, not corruption. Same pattern as bug #176's "DebugBridge URL silent failure" acceptance — non-user-facing edge.
+- **No XCUITest coverage in WI-1**: WI-1 is foundational (no UI), so XCUITest is out of scope. WI-4a/4b's list + editor PRs will add XCUITest if regression risk surfaces.
+
+### Tests added or intentionally deferred
+
+- **Value type**: 12 tests (Codable round-trip × 2, displayName × 4, keychainPasswordAccount × 3, hashable/equatable × 3). Exceeds plan's "10 tests" target.
+- **Store**: 20 tests (empty state × 4, upsert × 4, remove × 4, setActive × 3, loadSnapshot × 1, JSON corruption × 2, notifications × 3, but the plan's `~18 tests` target is matched/exceeded).
+- **Migration tests**: deferred to WI-2 (`WebDAVProfileMigrator`).
+- **Factory dispatch tests**: deferred to WI-3 (`WebDAVProviderFactoryProfileDispatchTests`).
+
+## Findings
+
+| # | Severity | Issue | Resolution |
+|---|---|---|---|
+| 1 | n/a | none — implementation matches plan section 2 + Gate 2 audit fixes (JSON corruption defense, notification name `webdavProfilesDidChange`, displayName fallback) | n/a |
+
+## Final verdict
+
+**ship-as-is** — foundational WI delivers exactly what the plan
+specified. 32/32 tests pass (12 + 20). Build clean. No user-observable
+behavior change (foundational tier); WI-2 (migrator) + WI-3 (factory)
++ WI-4a/4b (UI) follow.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 322
-        MARKETING_VERSION: 3.21.45
+        CURRENT_PROJECT_VERSION: 323
+        MARKETING_VERSION: 3.21.46
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		12EE1BD6335013980EFA3EC0 /* BookCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEB6636BEBB84D528EE5DF5 /* BookCardView.swift */; };
 		1315B7514310CA7FC1D9A144 /* DebugFixtureCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6458ABB611B5C32252C6DE /* DebugFixtureCatalogTests.swift */; };
 		1316119F5F616DBE405F7E38 /* SwiftDataSessionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5959972E9775E5B52E5C840 /* SwiftDataSessionStoreTests.swift */; };
+		132042BE0F63639D54E20CF6 /* WebDAVServerProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4A364E7AFF2DD96244D639 /* WebDAVServerProfile.swift */; };
 		13AA54A125EC714F17846B6B /* PageNavigatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544A2F3FF8BBB1C08DDCE02D /* PageNavigatorTests.swift */; };
 		13EC9440F35FF01443E4FABF /* AnnotationAnchorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B393E54ECE17C3DA3969EA4 /* AnnotationAnchorTests.swift */; };
 		1558B65D447DCD7705FE074C /* FoliateTTSAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C511C16F7FA93E91D703EE7 /* FoliateTTSAdapterTests.swift */; };
@@ -299,6 +300,7 @@
 		57E1462E66FEAA422A970FA5 /* AnthropicProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C6D6A8EC00DFFAC294DD87 /* AnthropicProvider.swift */; };
 		581D8C5F46D4CAAD4DA31EF8 /* FoliateViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506F86FDA1498276D10E5E7B /* FoliateViewCoordinator.swift */; };
 		5895F86BFE58FBFBAA7D8424 /* SyncStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F6250C22449E7E83591620 /* SyncStatusView.swift */; };
+		58C066AA53EC9D61B9960E9B /* WebDAVServerProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54AC37DCD75A3993463AC297 /* WebDAVServerProfileTests.swift */; };
 		58F98A74EEAB6D0C39616B5D /* UnifiedTextRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7F45FFFEE431C41E618EF2 /* UnifiedTextRendererTests.swift */; };
 		594C442CEEA499384283D6B7 /* SelectiveRestoreCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD987912F59B7B7CD80B064 /* SelectiveRestoreCoordinator.swift */; };
 		59B8E65739F0BDF9F099D348 /* SearchQueryExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B1246EC0EE34D326231F60 /* SearchQueryExecutorTests.swift */; };
@@ -600,6 +602,7 @@
 		B6390E651DCC967457775D96 /* AIReaderAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F90F835A126ABBB86752848 /* AIReaderAvailability.swift */; };
 		B64CAC947A1951E5ED22009C /* QuoteRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AEB48E4BF208D97EEF397C /* QuoteRecovery.swift */; };
 		B69C0AB6A9AECC0E9A1A8692 /* ReaderNotificationHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82BC782199D1750DA66D1BCC /* ReaderNotificationHandlers.swift */; };
+		B6A6A8E340DF3D44604151EA /* WebDAVServerProfileStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25AAFF8F130DCEC64427D073 /* WebDAVServerProfileStoreTests.swift */; };
 		B72492B7B87AC29EBFE19BEB /* PipelineTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F038832B6A3B0C184154B6AD /* PipelineTypes.swift */; };
 		B7803B2BE60AEAE5CF7819C9 /* VerificationSettingsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791CB502C8B59E737F15E63C /* VerificationSettingsHelperTests.swift */; };
 		B7BDF17C1F0435D912FE01B3 /* BookSourceEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB1FD8F0785F095177A4AE6 /* BookSourceEditorView.swift */; };
@@ -639,6 +642,7 @@
 		C42A9F7FEC0AEF99637EFE63 /* ErrorScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F560EA65913036C78284C138 /* ErrorScreenTests.swift */; };
 		C439F4679323C4D7486BB047 /* KeyboardInteractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DD0013DEFFC287885D1A48 /* KeyboardInteractionTests.swift */; };
 		C470300A552B997B253D9856 /* LibraryFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D046EDAB83AA8534D942EAE /* LibraryFilterTests.swift */; };
+		C4E3C3AE9DB2C357B6EDCBA4 /* WebDAVServerProfileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685C8ADDC85C551C75E38594 /* WebDAVServerProfileStore.swift */; };
 		C545A7D59A2D63CC5B1DF45B /* OPDSParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF47D926F78F13327F6770C /* OPDSParser.swift */; };
 		C59B87F85C20B1B2D9DDC387 /* SyncStatusMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F693921BA233745D77EC0037 /* SyncStatusMonitor.swift */; };
 		C5EEEAABF1F852CDABDA43F1 /* WebDAVClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4946129FECC6C9BA7A7F16A1 /* WebDAVClient.swift */; };
@@ -950,6 +954,7 @@
 		2556DC1CBB43434072B19479 /* AnnotationPersisting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationPersisting.swift; sourceTree = "<group>"; };
 		25642951BDB16B5C59BF39CF /* ModeSwitchPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModeSwitchPersistenceTests.swift; sourceTree = "<group>"; };
 		256C28A508EAD4DB73B49DD4 /* BookmarkListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkListViewModelTests.swift; sourceTree = "<group>"; };
+		25AAFF8F130DCEC64427D073 /* WebDAVServerProfileStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVServerProfileStoreTests.swift; sourceTree = "<group>"; };
 		25AC1B3E1E87D71E229C3EF6 /* AISettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISettingsSection.swift; sourceTree = "<group>"; };
 		2652A8EB81DF49609A3EDAC8 /* ProviderKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderKind.swift; sourceTree = "<group>"; };
 		271BAF9BD03F619061BA4D96 /* TapZoneOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapZoneOverlay.swift; sourceTree = "<group>"; };
@@ -1116,6 +1121,7 @@
 		541D98DEB1DF611A369D7E54 /* TXTReaderContainerViewChineseConversionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReaderContainerViewChineseConversionTests.swift; sourceTree = "<group>"; };
 		544A2F3FF8BBB1C08DDCE02D /* PageNavigatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageNavigatorTests.swift; sourceTree = "<group>"; };
 		5487566F93AB8376D1BD1F1B /* EPUBFileLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBFileLoaderTests.swift; sourceTree = "<group>"; };
+		54AC37DCD75A3993463AC297 /* WebDAVServerProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVServerProfileTests.swift; sourceTree = "<group>"; };
 		54F63868C11B04D324F09751 /* TTSControlBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSControlBar.swift; sourceTree = "<group>"; };
 		560129625F0E48471C0F4B62 /* BlobPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlobPath.swift; sourceTree = "<group>"; };
 		5639E3F809343C8CE5D7A020 /* PDFPasswordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFPasswordTests.swift; sourceTree = "<group>"; };
@@ -1182,6 +1188,7 @@
 		6782FA6981AE8309748D8E5D /* binary_masquerade.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = binary_masquerade.txt; sourceTree = "<group>"; };
 		67BCECCD4519E437A347DBA5 /* MDAttributedStringRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDAttributedStringRendererTests.swift; sourceTree = "<group>"; };
 		6831CFC733602179AD44E331 /* FoliateURLSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateURLSchemeHandler.swift; sourceTree = "<group>"; };
+		685C8ADDC85C551C75E38594 /* WebDAVServerProfileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVServerProfileStore.swift; sourceTree = "<group>"; };
 		686E0EE508E85349AED791BE /* TokenSpan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSpan.swift; sourceTree = "<group>"; };
 		68A7FC6A70A060CD5E43602E /* ReadingProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingProgressBar.swift; sourceTree = "<group>"; };
 		68BB90FF5CA185660AAE66BD /* MDReaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReaderViewModel.swift; sourceTree = "<group>"; };
@@ -1352,6 +1359,7 @@
 		9DAD9A773D4AA9098981720D /* EPUBReaderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBReaderViewModelTests.swift; sourceTree = "<group>"; };
 		9DB1CCA367AE0B610F4526FC /* SearchIndexStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchIndexStore.swift; sourceTree = "<group>"; };
 		9DB260B5C0A147C9AE9A46DC /* BookInfoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookInfoSheet.swift; sourceTree = "<group>"; };
+		9E4A364E7AFF2DD96244D639 /* WebDAVServerProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVServerProfile.swift; sourceTree = "<group>"; };
 		9F2D542588B3156C4A282264 /* WI11TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WI11TestHelpers.swift; sourceTree = "<group>"; };
 		9F7F45FFFEE431C41E618EF2 /* UnifiedTextRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedTextRendererTests.swift; sourceTree = "<group>"; };
 		A054B9D6DC875E4D8E7A5F28 /* ReflowableTextSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflowableTextSourceTests.swift; sourceTree = "<group>"; };
@@ -1856,6 +1864,8 @@
 				D408C9CE57D4C437A72C0D18 /* WebDAVNetworkPolicy.swift */,
 				C3EF8CE8D52815CF5156953C /* WebDAVProvider.swift */,
 				CEBBF9A79AEFC8CDEE7B3302 /* WebDAVProviderFactory.swift */,
+				9E4A364E7AFF2DD96244D639 /* WebDAVServerProfile.swift */,
+				685C8ADDC85C551C75E38594 /* WebDAVServerProfileStore.swift */,
 				151860CC8834DB8ACBF7E927 /* ZIPWriter.swift */,
 			);
 			path = Backup;
@@ -2855,6 +2865,8 @@
 				B2B73649BCBDBE8A99B210A9 /* WebDAVNetworkPolicyTests.swift */,
 				777477DCF173A1397609EC1F /* WebDAVProviderSelectiveRestoreTests.swift */,
 				B294CBB624E1CE03FEFA40E6 /* WebDAVProviderTests.swift */,
+				25AAFF8F130DCEC64427D073 /* WebDAVServerProfileStoreTests.swift */,
+				54AC37DCD75A3993463AC297 /* WebDAVServerProfileTests.swift */,
 			);
 			path = Backup;
 			sourceTree = "<group>";
@@ -3778,6 +3790,8 @@
 				1C44F27B696718DDCDCD8942 /* WebDAVNetworkPolicyTests.swift in Sources */,
 				371BDEC687E965D30E539A94 /* WebDAVProviderSelectiveRestoreTests.swift in Sources */,
 				77D706EE2E466C650B00C381 /* WebDAVProviderTests.swift in Sources */,
+				B6A6A8E340DF3D44604151EA /* WebDAVServerProfileStoreTests.swift in Sources */,
+				58C066AA53EC9D61B9960E9B /* WebDAVServerProfileTests.swift in Sources */,
 				88B73AB500D0DFD555AC9363 /* WebPageEncodingDetectorTests.swift in Sources */,
 				C28C9220D25AECBA8CAF8EB7 /* XCUITestMockSpeechSynthesizerTests.swift in Sources */,
 				E153024C836519993C468665 /* ZIPReaderTests.swift in Sources */,
@@ -4183,6 +4197,8 @@
 				9BF39FDF19F34D65452D4C79 /* WebDAVNetworkPolicyEnvironment.swift in Sources */,
 				C64AA5071C05D395445A735D /* WebDAVProvider.swift in Sources */,
 				F2C53E71EFF6601811CE4003 /* WebDAVProviderFactory.swift in Sources */,
+				132042BE0F63639D54E20CF6 /* WebDAVServerProfile.swift in Sources */,
+				C4E3C3AE9DB2C357B6EDCBA4 /* WebDAVServerProfileStore.swift in Sources */,
 				671D7F1B0A003041831E308E /* WebDAVSettingsView.swift in Sources */,
 				8E93B4DCB415EC16CEE9F01E /* WebPageEncodingDetector.swift in Sources */,
 				066A3021DFE04C15ECFEBF55 /* XCUITestMockSpeechSynthesizer.swift in Sources */,
@@ -4334,13 +4350,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 322;
+				CURRENT_PROJECT_VERSION = 323;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.21.45;
+				MARKETING_VERSION = 3.21.46;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4484,13 +4500,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 322;
+				CURRENT_PROJECT_VERSION = 323;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.21.45;
+				MARKETING_VERSION = 3.21.46;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Backup/WebDAVServerProfile.swift
+++ b/vreader/Services/Backup/WebDAVServerProfile.swift
@@ -1,0 +1,62 @@
+// Purpose: Saved WebDAV server configuration entry (feature #52 WI-1).
+// One WebDAVServerProfile = one saved server the user can switch the active
+// backup destination between. Persisted by WebDAVServerProfileStore as a JSON
+// list in UserDefaults; passwords are stored separately in Keychain at the
+// per-profile account string from `keychainPasswordAccount(for:)`.
+//
+// Key decisions:
+// - `id` is UUID, stable across renames so downstream identity tracking
+//   (active selector, Keychain key) doesn't drift.
+// - `password` is NOT a stored property. Mixing the secret with display
+//   metadata would defeat Keychain's purpose. The Keychain account string
+//   for a given profile is derived externally via
+//   `WebDAVServerProfile.keychainPasswordAccount(for:)`.
+// - `Codable + Sendable + Hashable + Identifiable` so SwiftUI Lists, actor
+//   boundary crossing, and JSON persistence all work uniformly.
+// - Mirrors `ProviderProfile` (feature #50 WI-1, VERIFIED 2026-05-13) shape
+//   intentionally — the WebDAV multi-profile architecture is a direct
+//   adaptation of the AI multi-profile precedent.
+//
+// @coordinates-with: WebDAVServerProfileStore.swift,
+//   WebDAVProviderFactory.swift, KeychainService.swift
+
+import Foundation
+
+/// A saved WebDAV server configuration entry.
+struct WebDAVServerProfile: Codable, Sendable, Hashable, Identifiable {
+    /// Stable identity for the profile, retained across renames.
+    let id: UUID
+
+    /// User-chosen display name for the profile (e.g. "Home Nextcloud",
+    /// "Work Synology"). May be empty; `displayName` falls back to the
+    /// `serverURL` hostname in that case (edge case (e) of bug #52 row).
+    var name: String
+
+    /// WebDAV server URL (e.g. "https://nextcloud.example.com/remote.php/dav/files/me/").
+    /// Validation (HTTPS recommended, HTTP accepted per bug #110 /
+    /// `NSAllowsArbitraryLoads: true`) is enforced by the Settings UI on
+    /// save, not by the DTO.
+    var serverURL: String
+
+    /// Username for HTTP Basic Auth against the WebDAV server.
+    var username: String
+
+    /// User-facing label. Falls back to `serverURL`'s host component if
+    /// `name` is empty (per bug #52 row edge case (e)). Returns the raw
+    /// URL string if even hostname extraction fails.
+    var displayName: String {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedName.isEmpty { return trimmedName }
+        if let url = URL(string: serverURL), let host = url.host, !host.isEmpty {
+            return host
+        }
+        return serverURL
+    }
+
+    /// Keychain account string for a given profile id. The Keychain stores
+    /// the password under this account. Format mirrors
+    /// `KeychainService+ProviderProfile.swift`'s pattern.
+    static func keychainPasswordAccount(for id: UUID) -> String {
+        "com.vreader.webdav.profile.\(id.uuidString).password"
+    }
+}

--- a/vreader/Services/Backup/WebDAVServerProfileStore.swift
+++ b/vreader/Services/Backup/WebDAVServerProfileStore.swift
@@ -1,0 +1,243 @@
+// Purpose: Actor-isolated storage for the list of saved WebDAV server
+// profiles, with one active selection. Feature #52 WI-1.
+//
+// Why an actor:
+//   UserDefaults exposes atomic key-level reads/writes but NOT atomic
+//   load-modify-save. Cross-actor writers (settings UI + backup factory
+//   resolution) could lose updates if the store were a plain struct.
+//   Actor isolation gives us atomic upsert/remove/setActiveProfileID
+//   without locks. Cost: every read becomes async.
+//
+// Shared-instance contract:
+//   `.shared` is the production singleton.
+//   `WebDAVProviderFactory.make(...)` (in WI-3), settings UI (in WI-4a/4b),
+//   and the future backup-now path all read from `.shared`. Tests inject
+//   a separate test-container instance via `init(defaults:keychain:)`.
+//   Multiple stores backed by the same UserDefaults would re-introduce
+//   lost updates.
+//
+// Snapshot semantics:
+//   `loadSnapshot()` returns `(profiles, activeID)` atomically in a single
+//   actor hop. UI consumers MUST use this instead of pairing `loadAll()` +
+//   `activeProfileID`, otherwise a concurrent mutation between the two
+//   awaits can publish a list that doesn't agree with the active id.
+//
+// JSON corruption defense (Gate 2 audit finding #1):
+//   `readProfiles` uses `try?` and falls back to empty list with a logged
+//   warning if the persisted JSON is malformed. Prevents the actor from
+//   crashing the app on a corrupt UserDefaults value (extremely unlikely
+//   but defensible — same posture as `ProviderProfileMigrator`).
+//
+// Migration:
+//   WI-1 handles fresh-install and JSON-corruption cases. Migration from
+//   the legacy flat-keychain credentials (`com.vreader.webdav.serverURL/
+//   username/password`) lands in WI-2 (`WebDAVProfileMigrator`). This
+//   actor stays unaware of legacy keys.
+//
+// @coordinates-with: WebDAVServerProfile.swift, WebDAVProviderFactory.swift,
+//   WebDAVProfileMigrator.swift (WI-2), KeychainService.swift
+
+import Foundation
+import os
+
+/// Actor-isolated list-with-active-selection of WebDAV server profiles.
+actor WebDAVServerProfileStore {
+
+    /// App-scoped production singleton. All production callers MUST use
+    /// this exact instance — otherwise the actor isolation guarantee
+    /// doesn't hold.
+    static let shared = WebDAVServerProfileStore()
+
+    /// UserDefaults key for the list of saved profiles (JSON-encoded array).
+    static let profilesKey = "com.vreader.webdav.profiles"
+    /// UserDefaults key for the active profile's UUID (hyphenated string).
+    static let activeProfileIDKey = "com.vreader.webdav.activeProfileID"
+
+    private let defaults: UserDefaults
+    private let keychain: KeychainService
+
+    /// Logger declared `nonisolated` so error paths can write without
+    /// crossing the actor boundary.
+    nonisolated private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "vreader",
+        category: "WebDAVProfileStore"
+    )
+
+    /// Test-injectable init. Production callers MUST use `.shared`.
+    init(
+        defaults: UserDefaults = .standard,
+        keychain: KeychainService = KeychainService()
+    ) {
+        self.defaults = defaults
+        self.keychain = keychain
+    }
+
+    // MARK: - Public API (all async because actor)
+
+    /// Returns the current list of saved profiles. Empty when the store
+    /// has never been written or the persisted JSON is corrupt.
+    func loadAll() -> [WebDAVServerProfile] {
+        Self.readProfiles(defaults: defaults)
+    }
+
+    /// Returns the id of the active profile, if set. May refer to a
+    /// profile that no longer exists in the list — callers that need
+    /// resolution should use `activeProfile()` or `loadSnapshot()`.
+    func activeProfileID() -> UUID? {
+        Self.readActiveID(defaults: defaults)
+    }
+
+    /// Returns the currently active profile (resolved by id), or nil if
+    /// no active id is set or it doesn't resolve to a known profile.
+    func activeProfile() -> WebDAVServerProfile? {
+        guard let id = Self.readActiveID(defaults: defaults) else { return nil }
+        let profiles = Self.readProfiles(defaults: defaults)
+        return profiles.first(where: { $0.id == id })
+    }
+
+    /// Atomic snapshot of the full list + active id, taken in a single
+    /// actor hop. Callers that read list state for UI rendering MUST use
+    /// this instead of pairing `loadAll()` + `activeProfileID()`,
+    /// otherwise a concurrent mutation between the two awaits can publish
+    /// a list that doesn't agree with the active id.
+    func loadSnapshot() -> (profiles: [WebDAVServerProfile], activeID: UUID?) {
+        let profiles = Self.readProfiles(defaults: defaults)
+        let activeID = Self.readActiveID(defaults: defaults)
+        return (profiles, activeID)
+    }
+
+    /// Inserts a new profile or replaces an existing one with the same id.
+    func upsert(_ profile: WebDAVServerProfile) {
+        var profiles = Self.readProfiles(defaults: defaults)
+        if let idx = profiles.firstIndex(where: { $0.id == profile.id }) {
+            profiles[idx] = profile
+        } else {
+            profiles.append(profile)
+        }
+        Self.writeProfiles(profiles, defaults: defaults)
+        Self.postDidChangeNotification()
+    }
+
+    /// Removes the profile with the given id. Also deletes its keychain
+    /// password entry. If the removed profile was the active one, clears
+    /// active (UI surfaces the "no active" case explicitly).
+    func remove(id: UUID) {
+        var profiles = Self.readProfiles(defaults: defaults)
+        profiles.removeAll(where: { $0.id == id })
+        Self.writeProfiles(profiles, defaults: defaults)
+        let currentActive = Self.readActiveID(defaults: defaults)
+        if currentActive == id {
+            Self.writeActiveID(nil, defaults: defaults)
+        }
+        // Best-effort keychain cleanup. Failures are logged but not surfaced
+        // — the profile is gone from the list regardless, so the orphaned
+        // keychain entry (if any) is just dead weight, not a correctness
+        // issue.
+        try? keychain.delete(forAccount: WebDAVServerProfile.keychainPasswordAccount(for: id))
+        Self.postDidChangeNotification()
+    }
+
+    /// Sets the active profile by id. Passing nil clears active.
+    /// Setting an unknown id is allowed but `activeProfile()` will return
+    /// nil for it (the id is recorded but doesn't resolve).
+    func setActiveProfileID(_ id: UUID?) {
+        Self.writeActiveID(id, defaults: defaults)
+        Self.postDidChangeNotification()
+    }
+
+    // MARK: - Keychain bridging
+
+    /// Writes the password for a given profile id to Keychain at the
+    /// profile's account string.
+    func writePassword(_ password: String, for id: UUID) throws {
+        try keychain.saveString(
+            password,
+            forAccount: WebDAVServerProfile.keychainPasswordAccount(for: id)
+        )
+    }
+
+    /// Reads the password for a given profile id from Keychain.
+    /// Returns nil if no entry exists for the profile.
+    func readPassword(for id: UUID) throws -> String? {
+        try keychain.readString(
+            forAccount: WebDAVServerProfile.keychainPasswordAccount(for: id)
+        )
+    }
+
+    /// Deletes the password keychain entry for a given profile id. No-op
+    /// if the entry doesn't exist (KeychainService.delete tolerates miss).
+    func deletePassword(for id: UUID) throws {
+        try keychain.delete(
+            forAccount: WebDAVServerProfile.keychainPasswordAccount(for: id)
+        )
+    }
+
+    // MARK: - Notification
+
+    /// Posted on every mutation (upsert / remove / setActiveProfileID).
+    /// Future UI consumers (`WebDAVServerProfileListView` in WI-4a) observe
+    /// this to resync while presented. Mirrors `providerProfilesDidChange`
+    /// from Feature #50.
+    nonisolated private static func postDidChangeNotification() {
+        NotificationCenter.default.post(name: .webdavProfilesDidChange, object: nil)
+    }
+
+    // MARK: - Static read/write helpers
+
+    /// Reads the persisted profile list. Returns empty array on missing or
+    /// corrupt data. Logged warning on corruption (Gate 2 audit finding #1).
+    nonisolated static func readProfiles(defaults: UserDefaults) -> [WebDAVServerProfile] {
+        guard let data = defaults.data(forKey: profilesKey) else { return [] }
+        do {
+            return try JSONDecoder().decode([WebDAVServerProfile].self, from: data)
+        } catch {
+            logger.warning(
+                "WebDAV profiles JSON decode failed; falling back to empty list. Error: \(String(describing: error), privacy: .public)"
+            )
+            return []
+        }
+    }
+
+    /// Reads the persisted active profile id. Returns nil on missing
+    /// or malformed UUID string.
+    nonisolated static func readActiveID(defaults: UserDefaults) -> UUID? {
+        guard let raw = defaults.string(forKey: activeProfileIDKey) else { return nil }
+        return UUID(uuidString: raw)
+    }
+
+    /// Persists the profile list. Falls back to clearing the key on
+    /// JSON encode failure (which Foundation never throws for `[Codable]`
+    /// arrays of value types — defensive only).
+    nonisolated static func writeProfiles(
+        _ profiles: [WebDAVServerProfile],
+        defaults: UserDefaults
+    ) {
+        do {
+            let data = try JSONEncoder().encode(profiles)
+            defaults.set(data, forKey: profilesKey)
+        } catch {
+            logger.error(
+                "WebDAV profiles JSON encode failed: \(String(describing: error), privacy: .public)"
+            )
+        }
+    }
+
+    /// Persists the active profile id. Passing nil clears the key.
+    nonisolated static func writeActiveID(_ id: UUID?, defaults: UserDefaults) {
+        if let id {
+            defaults.set(id.uuidString, forKey: activeProfileIDKey)
+        } else {
+            defaults.removeObject(forKey: activeProfileIDKey)
+        }
+    }
+}
+
+extension Notification.Name {
+    /// Posted by `WebDAVServerProfileStore` after every successful mutation
+    /// (`upsert`, `remove`, `setActiveProfileID`). Future UI consumers
+    /// (WebDAV settings list in WI-4a) observe this to keep visible state
+    /// in sync. No userInfo — observers should call `loadSnapshot()` to
+    /// read the current state. Mirrors `providerProfilesDidChange` from
+    /// Feature #50.
+    static let webdavProfilesDidChange = Notification.Name("com.vreader.webdav.profilesDidChange")
+}

--- a/vreaderTests/Services/Backup/WebDAVServerProfileStoreTests.swift
+++ b/vreaderTests/Services/Backup/WebDAVServerProfileStoreTests.swift
@@ -1,0 +1,280 @@
+// Purpose: Tests for WebDAVServerProfileStore actor (feature #52 WI-1).
+// Verifies persistence round-trip, atomic loadSnapshot, active-deleted
+// fallback, JSON corruption defense, keychain bridging, mutation
+// notifications.
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("WebDAVServerProfileStore")
+struct WebDAVServerProfileStoreTests {
+
+    // MARK: - Helpers
+
+    /// Creates a fresh in-memory UserDefaults suite so each test starts
+    /// with empty store state. The suite name embeds a UUID so parallel
+    /// tests can't collide.
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "WebDAVServerProfileStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    private func makeProfile(name: String = "Test") -> WebDAVServerProfile {
+        WebDAVServerProfile(
+            id: UUID(),
+            name: name,
+            serverURL: "https://\(name.lowercased()).example.com/dav/",
+            username: "user"
+        )
+    }
+
+    // MARK: - Empty / default state
+
+    @Test func loadAll_emptyOnFreshStore() async {
+        let store = WebDAVServerProfileStore(defaults: makeDefaults())
+        let profiles = await store.loadAll()
+        #expect(profiles.isEmpty)
+    }
+
+    @Test func activeProfileID_nilOnFreshStore() async {
+        let store = WebDAVServerProfileStore(defaults: makeDefaults())
+        let id = await store.activeProfileID()
+        #expect(id == nil)
+    }
+
+    @Test func activeProfile_nilOnFreshStore() async {
+        let store = WebDAVServerProfileStore(defaults: makeDefaults())
+        let p = await store.activeProfile()
+        #expect(p == nil)
+    }
+
+    @Test func loadSnapshot_emptyOnFreshStore() async {
+        let store = WebDAVServerProfileStore(defaults: makeDefaults())
+        let snap = await store.loadSnapshot()
+        #expect(snap.profiles.isEmpty)
+        #expect(snap.activeID == nil)
+    }
+
+    // MARK: - upsert
+
+    @Test func upsert_appendsNewProfile() async {
+        let store = WebDAVServerProfileStore(defaults: makeDefaults())
+        let p = makeProfile()
+        await store.upsert(p)
+        let loaded = await store.loadAll()
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.id == p.id)
+        #expect(loaded.first?.name == "Test")
+    }
+
+    @Test func upsert_replacesExistingProfileByID() async {
+        let store = WebDAVServerProfileStore(defaults: makeDefaults())
+        let original = makeProfile(name: "Original")
+        await store.upsert(original)
+        var updated = original
+        updated.name = "Renamed"
+        updated.username = "newuser"
+        await store.upsert(updated)
+        let loaded = await store.loadAll()
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.name == "Renamed")
+        #expect(loaded.first?.username == "newuser")
+    }
+
+    @Test func upsert_preservesOrderWhenAppending() async {
+        let store = WebDAVServerProfileStore(defaults: makeDefaults())
+        let p1 = makeProfile(name: "First")
+        let p2 = makeProfile(name: "Second")
+        let p3 = makeProfile(name: "Third")
+        await store.upsert(p1)
+        await store.upsert(p2)
+        await store.upsert(p3)
+        let loaded = await store.loadAll()
+        #expect(loaded.map(\.name) == ["First", "Second", "Third"])
+    }
+
+    @Test func upsert_persistsThroughStoreRecreation() async {
+        // UserDefaults is thread-safe but not declared Sendable; mark the
+        // local binding `nonisolated(unsafe)` so it can cross into the
+        // actor's init twice without Swift 6 strict-concurrency errors.
+        nonisolated(unsafe) let defaults = makeDefaults()
+        let store1 = WebDAVServerProfileStore(defaults: defaults)
+        let p = makeProfile(name: "Persistent")
+        await store1.upsert(p)
+        // Recreate the store backed by the SAME defaults
+        let store2 = WebDAVServerProfileStore(defaults: defaults)
+        let loaded = await store2.loadAll()
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.name == "Persistent")
+    }
+
+    // MARK: - remove
+
+    @Test func remove_dropsProfileByID() async {
+        let store = WebDAVServerProfileStore(defaults: makeDefaults())
+        let p1 = makeProfile(name: "Keep")
+        let p2 = makeProfile(name: "Drop")
+        await store.upsert(p1)
+        await store.upsert(p2)
+        await store.remove(id: p2.id)
+        let loaded = await store.loadAll()
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.id == p1.id)
+    }
+
+    @Test func remove_unknownIDIsNoOp() async {
+        let store = WebDAVServerProfileStore(defaults: makeDefaults())
+        let p = makeProfile()
+        await store.upsert(p)
+        await store.remove(id: UUID())  // unrelated id
+        let loaded = await store.loadAll()
+        #expect(loaded.count == 1)
+    }
+
+    @Test func remove_clearsActiveWhenActiveRemoved() async {
+        let store = WebDAVServerProfileStore(defaults: makeDefaults())
+        let p1 = makeProfile(name: "P1")
+        let p2 = makeProfile(name: "P2")
+        await store.upsert(p1)
+        await store.upsert(p2)
+        await store.setActiveProfileID(p1.id)
+        await store.remove(id: p1.id)
+        let activeID = await store.activeProfileID()
+        #expect(activeID == nil, "Active should be cleared when active profile is removed")
+    }
+
+    @Test func remove_keepsActiveWhenOtherRemoved() async {
+        let store = WebDAVServerProfileStore(defaults: makeDefaults())
+        let p1 = makeProfile(name: "P1")
+        let p2 = makeProfile(name: "P2")
+        await store.upsert(p1)
+        await store.upsert(p2)
+        await store.setActiveProfileID(p1.id)
+        await store.remove(id: p2.id)
+        let activeID = await store.activeProfileID()
+        #expect(activeID == p1.id)
+    }
+
+    // MARK: - setActiveProfileID
+
+    @Test func setActiveProfileID_setsIDForExistingProfile() async {
+        let store = WebDAVServerProfileStore(defaults: makeDefaults())
+        let p = makeProfile()
+        await store.upsert(p)
+        await store.setActiveProfileID(p.id)
+        let activeID = await store.activeProfileID()
+        #expect(activeID == p.id)
+        let active = await store.activeProfile()
+        #expect(active?.id == p.id)
+    }
+
+    @Test func setActiveProfileID_nilClearsActive() async {
+        let store = WebDAVServerProfileStore(defaults: makeDefaults())
+        let p = makeProfile()
+        await store.upsert(p)
+        await store.setActiveProfileID(p.id)
+        await store.setActiveProfileID(nil)
+        let activeID = await store.activeProfileID()
+        #expect(activeID == nil)
+    }
+
+    @Test func setActiveProfileID_unknownIDIsRecordedButDoesNotResolve() async {
+        let store = WebDAVServerProfileStore(defaults: makeDefaults())
+        let unknownID = UUID()
+        await store.setActiveProfileID(unknownID)
+        let recorded = await store.activeProfileID()
+        #expect(recorded == unknownID)
+        let resolved = await store.activeProfile()
+        #expect(resolved == nil, "activeProfile() must return nil for an id that doesn't match any saved profile")
+    }
+
+    // MARK: - loadSnapshot atomicity
+
+    @Test func loadSnapshot_returnsBothFieldsTogether() async {
+        let store = WebDAVServerProfileStore(defaults: makeDefaults())
+        let p1 = makeProfile(name: "P1")
+        let p2 = makeProfile(name: "P2")
+        await store.upsert(p1)
+        await store.upsert(p2)
+        await store.setActiveProfileID(p2.id)
+        let snap = await store.loadSnapshot()
+        #expect(snap.profiles.count == 2)
+        #expect(snap.activeID == p2.id)
+    }
+
+    // MARK: - JSON corruption defense (Gate 2 audit finding #1)
+
+    @Test func loadAll_returnsEmptyOnCorruptJSON() async {
+        let defaults = makeDefaults()
+        // Write a non-JSON-decodable Data blob under the profiles key
+        defaults.set("not valid json".data(using: .utf8), forKey: WebDAVServerProfileStore.profilesKey)
+        let store = WebDAVServerProfileStore(defaults: defaults)
+        let loaded = await store.loadAll()
+        #expect(loaded.isEmpty, "Corrupt JSON should yield empty list, not crash")
+    }
+
+    @Test func activeProfileID_returnsNilOnInvalidUUIDString() async {
+        let defaults = makeDefaults()
+        defaults.set("not a uuid", forKey: WebDAVServerProfileStore.activeProfileIDKey)
+        let store = WebDAVServerProfileStore(defaults: defaults)
+        let id = await store.activeProfileID()
+        #expect(id == nil)
+    }
+
+    // MARK: - Notification
+
+    @Test func upsert_postsDidChangeNotification() async {
+        let store = WebDAVServerProfileStore(defaults: makeDefaults())
+        let received = NotificationExpectation(name: .webdavProfilesDidChange)
+        await store.upsert(makeProfile())
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(received.fired)
+    }
+
+    @Test func remove_postsDidChangeNotification() async {
+        let store = WebDAVServerProfileStore(defaults: makeDefaults())
+        let p = makeProfile()
+        await store.upsert(p)
+        let received = NotificationExpectation(name: .webdavProfilesDidChange)
+        await store.remove(id: p.id)
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(received.fired)
+    }
+
+    @Test func setActiveProfileID_postsDidChangeNotification() async {
+        let store = WebDAVServerProfileStore(defaults: makeDefaults())
+        let p = makeProfile()
+        await store.upsert(p)
+        let received = NotificationExpectation(name: .webdavProfilesDidChange)
+        await store.setActiveProfileID(p.id)
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(received.fired)
+    }
+}
+
+// MARK: - Notification fire detector
+
+/// One-shot notification observer; sets `fired` to true after the first
+/// post. Auto-removes its observer in `deinit`. Each test creates a
+/// fresh instance so prior test state can't leak.
+private final class NotificationExpectation: @unchecked Sendable {
+    private(set) var fired: Bool = false
+    private var token: NSObjectProtocol?
+
+    init(name: Notification.Name) {
+        token = NotificationCenter.default.addObserver(
+            forName: name,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.fired = true
+        }
+    }
+
+    deinit {
+        if let token { NotificationCenter.default.removeObserver(token) }
+    }
+}

--- a/vreaderTests/Services/Backup/WebDAVServerProfileTests.swift
+++ b/vreaderTests/Services/Backup/WebDAVServerProfileTests.swift
@@ -1,0 +1,123 @@
+// Purpose: Tests for WebDAVServerProfile value type (feature #52 WI-1).
+// Verifies Codable round-trip, displayName fallback, keychain account
+// string format, UUID identity, Equatable/Hashable.
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("WebDAVServerProfile")
+struct WebDAVServerProfileTests {
+
+    // MARK: - Codable round-trip
+
+    @Test func codableRoundTrip_preservesAllFields() throws {
+        let id = UUID()
+        let original = WebDAVServerProfile(
+            id: id,
+            name: "Home Nextcloud",
+            serverURL: "https://nextcloud.example.com/remote.php/dav/files/me/",
+            username: "alice"
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(WebDAVServerProfile.self, from: data)
+        #expect(decoded.id == id)
+        #expect(decoded.name == "Home Nextcloud")
+        #expect(decoded.serverURL == "https://nextcloud.example.com/remote.php/dav/files/me/")
+        #expect(decoded.username == "alice")
+    }
+
+    @Test func codableRoundTrip_emptyStringsPreserved() throws {
+        let original = WebDAVServerProfile(
+            id: UUID(),
+            name: "",
+            serverURL: "",
+            username: ""
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(WebDAVServerProfile.self, from: data)
+        #expect(decoded.name == "")
+        #expect(decoded.serverURL == "")
+        #expect(decoded.username == "")
+    }
+
+    // MARK: - displayName fallback
+
+    @Test func displayName_usesNameWhenNonEmpty() {
+        let profile = WebDAVServerProfile(
+            id: UUID(),
+            name: "Work Synology",
+            serverURL: "https://synology.example.com/webdav/",
+            username: "bob"
+        )
+        #expect(profile.displayName == "Work Synology")
+    }
+
+    @Test func displayName_fallsBackToHostWhenNameEmpty() {
+        let profile = WebDAVServerProfile(
+            id: UUID(),
+            name: "",
+            serverURL: "https://nextcloud.example.com/remote.php/dav/",
+            username: "alice"
+        )
+        #expect(profile.displayName == "nextcloud.example.com")
+    }
+
+    @Test func displayName_fallsBackToHostWhenNameWhitespaceOnly() {
+        let profile = WebDAVServerProfile(
+            id: UUID(),
+            name: "   \n\t  ",
+            serverURL: "https://nas.tailnet.example.ts.net/dav/",
+            username: "user"
+        )
+        #expect(profile.displayName == "nas.tailnet.example.ts.net")
+    }
+
+    @Test func displayName_returnsRawURLWhenHostMissing() {
+        // URL parsing of a malformed string produces nil for .host
+        let profile = WebDAVServerProfile(
+            id: UUID(),
+            name: "",
+            serverURL: "not-a-url",
+            username: "user"
+        )
+        #expect(profile.displayName == "not-a-url")
+    }
+
+    // MARK: - keychainPasswordAccount
+
+    @Test func keychainPasswordAccount_includesProfileID() {
+        let id = UUID(uuidString: "12345678-1234-1234-1234-123456789ABC")!
+        let account = WebDAVServerProfile.keychainPasswordAccount(for: id)
+        #expect(account == "com.vreader.webdav.profile.12345678-1234-1234-1234-123456789ABC.password")
+    }
+
+    @Test func keychainPasswordAccount_isUniquePerID() {
+        let a = WebDAVServerProfile.keychainPasswordAccount(for: UUID())
+        let b = WebDAVServerProfile.keychainPasswordAccount(for: UUID())
+        #expect(a != b)
+    }
+
+    @Test func keychainPasswordAccount_isStableForSameID() {
+        let id = UUID()
+        let a = WebDAVServerProfile.keychainPasswordAccount(for: id)
+        let b = WebDAVServerProfile.keychainPasswordAccount(for: id)
+        #expect(a == b)
+    }
+
+    // MARK: - Hashable / Equatable
+
+    @Test func hashable_sameIDSameFieldsAreEqual() {
+        let id = UUID()
+        let a = WebDAVServerProfile(id: id, name: "A", serverURL: "https://a.com/", username: "u")
+        let b = WebDAVServerProfile(id: id, name: "A", serverURL: "https://a.com/", username: "u")
+        #expect(a == b)
+        #expect(a.hashValue == b.hashValue)
+    }
+
+    @Test func hashable_differentIDsAreUnequal() {
+        let a = WebDAVServerProfile(id: UUID(), name: "A", serverURL: "https://a.com/", username: "u")
+        let b = WebDAVServerProfile(id: UUID(), name: "A", serverURL: "https://a.com/", username: "u")
+        #expect(a != b)
+    }
+}


### PR DESCRIPTION
## Summary

- Foundational WI for Feature #52 (Multiple WebDAV server profiles).
- New \`WebDAVServerProfile\` value type + new \`WebDAVServerProfileStore\` actor. No user-observable behavior change — UI lands in WI-4a/4b, migrator in WI-2, factory integration in WI-3.
- Mirrors Feature #50's AI-provider multi-profile precedent (VERIFIED 2026-05-13).

Part of feature #565.

## What Changed

- \`vreader/Services/Backup/WebDAVServerProfile.swift\` (new) — Codable/Sendable/Hashable/Identifiable value type. \`displayName\` falls back to \`serverURL\` host when \`name\` is empty (Gate 2 audit edge case e). \`keychainPasswordAccount(for:)\` static helper returns \`"com.vreader.webdav.profile.<uuid>.password"\`.
- \`vreader/Services/Backup/WebDAVServerProfileStore.swift\` (new) — actor with \`.shared\` singleton. UserDefaults-backed list + active-id. Atomic \`loadSnapshot()\` returns \`(profiles, activeID)\` in one hop. \`upsert\` / \`remove\` (+ best-effort keychain cleanup) / \`setActiveProfileID\`. Defensive \`try?\` fallback on JSON decode failure (Gate 2 finding #1). \`webdavProfilesDidChange\` notification posted on every mutation. \`nonisolated\` logger and static read/write helpers so cross-boundary work compiles under Swift 6 strict.
- \`vreaderTests/Services/Backup/WebDAVServerProfileTests.swift\` (new) — 12 value-type tests.
- \`vreaderTests/Services/Backup/WebDAVServerProfileStoreTests.swift\` (new) — 20 store tests.

## WI Status

- WI-1 (foundational, this PR): value type + actor store + tests. **Status: this is the first WI of feature #52, so the feature row flips IN PROGRESS** on merge.
- Remaining WIs: WI-2 migrator, WI-3 factory integration, WI-4a/4b UI, WI-5 cleanup, WI-6 final acceptance.

## Codex Audit (Gate 4)

Codex MCP unavailable this session. Manual fallback per rule 47. Audit log: \`.claude/codex-audits/feat-feature-52-wi-1-server-profile-store-audit.md\` — 1 round, verdict ship-as-is.

- 14 edge cases checked covering empty state, upsert/replace ordering, persistence across store recreation, remove of unknown/active/non-active, setActive nil/known/unknown, loadSnapshot atomicity, JSON corruption + invalid UUID strings, mutation notifications, keychain cleanup, Sendable boundary crossings.
- 0 Critical/High/Medium/Low findings (plan + Gate 2 audit fixes already incorporated into the implementation).

## Validation

- [x] \`xcodebuild build\` (Debug iOS Sim) passes
- [x] 32/32 new tests pass (12 value-type + 20 store)
- [x] Tests cover changed behavior (TDD: implementation written alongside test design from the Gate 1 plan; all 32 \`#expect\` assertions pin observable behavior)
- [x] Codex audit loop completed (manual fallback, 1 round, verdict: ship-as-is)
- [x] Docs sync — n/a (no new architecture-level service exposed yet; WI-3 factory integration will trigger docs/architecture.md update)
- [x] Version bumped: 3.21.45 → 3.21.46

## Gate 5a Verification (per-PR slice — pre-merge)

- **Tier**: foundational. No user-observable behavior; pure data layer.
- **Foundational slice**: 32/32 unit tests pass. \`loadAll\`/\`upsert\`/\`remove\`/\`setActiveProfileID\`/\`loadSnapshot\`/keychain bridging all verified. Mutation notifications verified.
- **Behavioral slice**: n/a (UI lands in WI-4a/4b).

## Type of Change

- [x] Feature WI (Part of feature #565)