### PR TITLE
feat(#596 WI-3): chunked TXT tap-on-highlight

### DIFF
--- a/.claude/codex-audits/feat-feature-53-wi-3-chunked-txt-tap-on-highlight-audit.md
+++ b/.claude/codex-audits/feat-feature-53-wi-3-chunked-txt-tap-on-highlight-audit.md
@@ -1,0 +1,180 @@
+---
+branch: feat/feature-53-wi-3-chunked-txt-tap-on-highlight
+threadId: manual-fallback
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-15
+---
+
+# Feature #53 WI-3 — chunked TXT tap-on-highlight (Implementation Audit)
+
+Per saved feedback memory: Codex audit-time consistently exceeds cron-
+iteration budget; manual-fallback per rule 47 is the documented
+alternative.
+
+## Round 1 — manual audit findings
+
+### Diff scope
+
+```
+vreader/Views/Reader/TXTChunkedReaderBridge.swift       +127 lines
+vreader/Views/Reader/TXTReaderContainerView.swift       +5 lines (chunked branch call site)
+vreaderTests/Views/Reader/TXTChunkedBridgeHighlightTapTests.swift  +175 (new)
+dev-docs/plans/20260515-feature-53-tap-on-highlight.md  +17 (revision history v2)
+```
+
+### Dimensions (severity / issue / fix)
+
+1. **Correctness vs the plan**
+   - Plan v2 specifies WI-3 = chunked TXT tap-on-highlight + audit that
+     MD's non-chunked path inherits WI-2/WI-2b. Diff delivers both:
+     (a) `TXTChunkedReaderBridge.Coordinator.resolveChunkedHighlightTap`
+     static (gesture + pure overloads) mirrors the non-chunked
+     `resolveHighlightTap` shape; (b) `handleContentTap` extended with
+     hit-test branch that posts `.readerHighlightTapped` + invokes
+     presenter when wired; (c) `TXTReaderContainerView.chunkedReaderContent`
+     passes the 3 new params (`persistedHighlightLookup`,
+     `highlightActionPresenter`, `onHighlightTapAction`) — same closure
+     wiring as the non-chunked branch at line 538.
+   - MD audit: `MDReaderContainerView.swift:321` uses
+     `TXTTextViewBridge` directly with the WI-2/WI-2b params already
+     wired (line 330–334 in current main). No change needed. ✓
+   - **No finding.**
+
+2. **Edge cases**
+   - Empty `lookup` → guard returns nil. ✓
+   - `chunkIndex` out of bounds (e.g. stale cell after chunks rebuild) →
+     range-check returns nil. ✓ Test `resolveChunkedHighlightTap_chunkIndexOutOfBounds_returnsNil`.
+   - Tap point not over any cell → `tableView.indexPathForRow(at:)`
+     returns nil → gesture overload returns nil (caller falls back to
+     chrome-toggle). ✓
+   - Cell exists but isn't a `ChunkedTextCell` (defensive guard for
+     reuse-pool corruption) → cast guard returns nil. ✓
+   - Global range straddles chunks (hit.range starts in chunk N-1 but
+     the tap lands in chunk N) → local slice clipped to
+     `[0, chunkLength)`; if the clipped length is zero (e.g. range
+     ended exactly at chunk boundary), returns nil. ✓ Test
+     `resolveChunkedHighlightTap_globalRangeStraddlesChunks_localSliceUsedForSourceRect`.
+   - **No finding.**
+
+3. **Security**
+   - No JS / no string interpolation into evaluateJavaScript. No
+     untrusted input crossing actor boundaries — `gesture.location(in:)`
+     and `tableView.indexPathForRow(at:)` are UIKit-internal.
+   - **No finding.**
+
+4. **Duplicate / dead code**
+   - `resolveChunkedHighlightTap` parallels the non-chunked
+     `resolveHighlightTap` in `TXTTextViewBridgeCoordinator.swift`.
+     Common math (inset adjustment, `characterIndex(for:)`,
+     `TextHighlightHitTester.hitTest`) could in principle be extracted
+     to a helper. Decided against: the two have different inputs
+     (chunked needs `chunkIndex + chunkStartOffsets`; non-chunked
+     doesn't) and different sourceRect computation (chunked must clip
+     to local slice; non-chunked uses the global range directly). The
+     duplication is "two callers with slightly different shapes" — the
+     extraction would add abstraction without clear benefit. Logged
+     for the WI-3 follow-up note in case future WIs add a third
+     caller.
+   - **No finding** (intentional duplication with rationale).
+
+5. **Concurrency**
+   - All new code is `@MainActor`-isolated.
+     `resolveChunkedHighlightTap` is `static @MainActor` (the
+     `characterIndex(for:)` / `boundingRect(forGlyphRange:)` UIKit
+     calls require main-actor isolation).
+   - `onHighlightTapAction` closure parameter type is
+     `((HighlightTapAction, UUID) async -> Void)?` — same shape as the
+     WI-2/WI-2b non-chunked bridge field. Sendable concerns handled
+     identically (closure-capture for `[highlightCoordinator]` at the
+     call site, await inside).
+   - **No finding.**
+
+6. **VReader compliance**
+   - **Pre-existing file-size concern**: `TXTChunkedReaderBridge.swift`
+     was ~430 lines before this WI; net additions take it to ~560.
+     Rule 50 guideline is ~300. Splitting is out of WI-3 scope
+     (focused-diff principle) and is a pre-existing condition, not
+     something this WI introduced. Logged as follow-up.
+   - Swift 6 strict concurrency: clean. `@MainActor` on the static
+     resolver, on the Coordinator class (inherited via NSObject +
+     UIKit delegate conformances), no actor-isolation crossings
+     introduced.
+   - **Low finding (deferred — pre-existing)**: file-size split for
+     `TXTChunkedReaderBridge.swift`. Suggested split:
+     `TXTChunkedReaderBridge+TapOnHighlight.swift` for the new
+     `handleContentTap` body + `resolveChunkedHighlightTap` static. NOT
+     done this WI; explicit follow-up in the row.
+
+7. **Bridge safety**
+   - No JS interpolation; not applicable.
+   - **No finding.**
+
+8. **Test coverage**
+   - 7 Swift Testing methods in `TXTChunkedBridgeHighlightTapTests`:
+     empty-lookup, hit-in-chunk-0, hit-in-chunk-2 (proves offset
+     addition), miss, chunkIndex-out-of-bounds, sourceRect-non-zero,
+     straddling-range-localslice. Covers the static resolver's
+     branches.
+   - No subscriber test for the chunked path (mirrors WI-2b for
+     non-chunked). Justified: the subscriber path (presenter +
+     callback routing) lives on `HighlightActionPresenting`, not on
+     the bridge — already covered by
+     `TXTBridgeHighlightTapSubscriberTests` (WI-2b). The chunked
+     bridge's `handleContentTap` delegates to that same presenter
+     protocol; no new shape to test.
+   - Full unit-test gate: `xcodebuild test -only-testing:vreaderTests`
+     reports the new suite passes. Pre-existing unrelated failures
+     in `BookFormatAZW3Tests` (bug #176 deferred) and
+     `SearchWiringTests`/`SearchViewModelTests` (flaky search) NOT
+     caused by this WI — confirmed by code-read: my diff doesn't
+     touch `BookFormat.swift`, `FormatCapabilities.swift`,
+     `SearchViewModel.swift`, or `SearchWiring.swift`.
+   - **No finding.**
+
+### Manual audit evidence
+
+- **Files read in full**:
+  - `vreader/Views/Reader/TXTChunkedReaderBridge.swift` (post-edit, all
+    557 lines)
+  - `vreader/Views/Reader/TXTReaderContainerView.swift:598-636`
+    (`chunkedReaderContent` body)
+  - `vreader/Views/Reader/TXTTextViewBridgeCoordinator.swift:220-285`
+    (the sister `resolveHighlightTap` implementation, for parity check)
+  - `vreaderTests/Views/Reader/TXTChunkedBridgeHighlightTapTests.swift`
+    (all 7 test methods + makeChunkFixture helper)
+- **Symbols verified**:
+  - `PersistedHighlightLookupEntry`: exists at
+    `TextHighlightHitTester.swift`; struct is `Sendable, Equatable`
+    with `id: UUID` + `range: NSRange`. ✓
+  - `TextHighlightHitTester.hitTest(charIndex:in:)`: exists; takes
+    `Int + [PersistedHighlightLookupEntry]`, returns
+    `PersistedHighlightLookupEntry?`. ✓
+  - `HighlightActionPresenting`: protocol exists at
+    `HighlightActionPresenter.swift` with the
+    `present(for:in:completion:)` signature my code uses. ✓
+  - `UIKitHighlightActionPresenter()`: default-init concrete impl. ✓
+  - `Notification.Name.readerHighlightTapped`: exists at
+    `ReaderNotifications.swift` (WI-1). ✓
+  - `HighlightTapAction.delete`: exists at
+    `HighlightTapAction.swift` (WI-1). ✓
+  - `HighlightCoordinator.handleTapAction(_:highlightID:)`:
+    `@MainActor` async method exists (WI-1). ✓
+- **Tests added**: 7 in `TXTChunkedBridgeHighlightTapTests`.
+- **Tests intentionally deferred**:
+  - Cross-format integration test deferred to final WI's Gate 5
+    device-verify per the plan.
+  - Subscriber-protocol test not duplicated for chunked (already
+    covered by WI-2b's `TXTBridgeHighlightTapSubscriberTests`).
+
+### Final verdict
+
+**ship-as-is** for the WI-3 deliverable.
+
+One Low / deferred / pre-existing follow-up logged for future tracker
+inclusion: file-size split for `TXTChunkedReaderBridge.swift` (rule 50,
+already over 300 LOC before this WI; this WI adds another ~100). Split
+candidate file: `TXTChunkedReaderBridge+TapOnHighlight.swift` for the
+new tap-on-highlight handler + resolver. Not done this WI per
+focused-diff principle; will land as part of a future WI that revisits
+the chunked bridge.

--- a/dev-docs/plans/20260515-feature-53-tap-on-highlight.md
+++ b/dev-docs/plans/20260515-feature-53-tap-on-highlight.md
@@ -291,3 +291,25 @@ Gate 3.
 ## Revision history
 
 - 2026-05-15 v1: initial draft + manual-fallback Gate 2 audit recorded inline.
+- 2026-05-15 v2: WI-3 scope clarification before Gate 3 starts. v1's text
+  for WI-3 was "MD — same pattern, via the chunked + non-chunked text
+  path". Reality discovered during WI-3 prep:
+  - `MDReaderContainerView.swift` uses `TXTTextViewBridge` directly
+    (line 321), so the non-chunked MD path already inherits WI-2's
+    tap-on-highlight wiring + WI-2b's `apply()`-path lookup-sync fix.
+    No new MD work needed for the non-chunked path.
+  - The **chunked** path uses a separate `TXTChunkedReaderBridge` for
+    TXT files > `largeFileThreshold` UTF-16 code units. This bridge
+    has no tap-on-highlight wiring as of WI-2b — its
+    `handleContentTap(_:)` only fires the toolbar-toggle
+    notification. Large TXT books therefore have **no** tap-on-
+    highlight support; this was always within WI-3's letter ("chunked
+    + non-chunked") but the row's "MD" label obscured it.
+  - MD does not use the chunked path (no `Chunked` references in
+    `MDReaderContainerView.swift`).
+  - Net: WI-3's real deliverable is the **chunked TXT tap-on-highlight
+    path** (TXTChunkedReaderBridge), plus an explicit MD audit
+    confirming the non-chunked MD path inherits WI-2/WI-2b. The row's
+    "MD" mention stays accurate for the non-chunked path; the chunked
+    work is the new code. WI-4 (EPUB), WI-5 (Foliate), WI-6 (PDF)
+    unchanged.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 363
-        MARKETING_VERSION: 3.22.11
+        CURRENT_PROJECT_VERSION: 364
+        MARKETING_VERSION: 3.22.12
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		095C1FEFA8400DD2F1A61CFF /* FileSizeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52DADD2C2FB6330070EA6DE /* FileSizeFormatter.swift */; };
 		096B20388931B21DAA4DC091 /* BlobPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB65788879E3D91E69E8BA5 /* BlobPathTests.swift */; };
 		099933954CB74FAE04C6B877 /* SearchLocatorSliceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2038A4D36C4355AC5C7BF5 /* SearchLocatorSliceTests.swift */; };
+		0A359570B32735E17EC5893F /* TXTChunkedBridgeHighlightTapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB9A749915A46E6DD506275A /* TXTChunkedBridgeHighlightTapTests.swift */; };
 		0A6A74D96B7763878D13CFDD /* LibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF473C04CE58CE0887DAA5A1 /* LibraryViewModel.swift */; };
 		0A866D2088849BF693C99A10 /* V5toV6MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD170A9C4FEB206D5F5F2157 /* V5toV6MigrationTests.swift */; };
 		0A998572897988CF581C77AE /* SourceSharingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317401FBAE274C615325BDBC /* SourceSharingServiceTests.swift */; };
@@ -1717,6 +1718,7 @@
 		FB17C932D5188B36F01F024A /* AnnotationExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationExporter.swift; sourceTree = "<group>"; };
 		FB5AB21F49D361F1160920C0 /* ContentReplacementRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentReplacementRule.swift; sourceTree = "<group>"; };
 		FB82BDFCDB76725A5586D5E0 /* Bookmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bookmark.swift; sourceTree = "<group>"; };
+		FB9A749915A46E6DD506275A /* TXTChunkedBridgeHighlightTapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChunkedBridgeHighlightTapTests.swift; sourceTree = "<group>"; };
 		FBC4E25069345D28610C64EC /* SearchTextNormalizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTextNormalizerTests.swift; sourceTree = "<group>"; };
 		FBD54F8887091F46753F09A4 /* DictionarySheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionarySheet.swift; sourceTree = "<group>"; };
 		FC283BCD7A6105F4CD210E9D /* FoliateReaderContainerView+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FoliateReaderContainerView+Navigation.swift"; sourceTree = "<group>"; };
@@ -2159,6 +2161,7 @@
 				4559FD0011E0F990013EAE48 /* TXTChapterHighlightCreationTests.swift */,
 				BE45EE49755FF9770DA61B12 /* TXTChapterHighlightRenderingTests.swift */,
 				2B9AD84A4BE2CF0F8D59D9CC /* TXTChapterScrollOffsetTests.swift */,
+				FB9A749915A46E6DD506275A /* TXTChunkedBridgeHighlightTapTests.swift */,
 				C24D5425530ABBE0DDA4758F /* TXTChunkedHighlightDeferredTimerTests.swift */,
 				F213D0F6EFBD7D7088AAC40D /* TXTMDProgressTests.swift */,
 				F17C33D19BD1735676CA01BC /* TXTReaderContainerHighlightCoordinatorWiringTests.swift */,
@@ -3847,6 +3850,7 @@
 				4A67A7ACD5E890A1AECA8854 /* TXTChapterIndexStoreTests.swift in Sources */,
 				DE866472346B3BC08D59D9E9 /* TXTChapterIntegrationTests.swift in Sources */,
 				AD73A09B36A45CB1F9E1B0D4 /* TXTChapterScrollOffsetTests.swift in Sources */,
+				0A359570B32735E17EC5893F /* TXTChunkedBridgeHighlightTapTests.swift in Sources */,
 				23A8010F873969D18777639F /* TXTChunkedHighlightDeferredTimerTests.swift in Sources */,
 				E9177AEFF47DA3EFEAC13C50 /* TXTChunkedLoaderTests.swift in Sources */,
 				C81A31B52218576A75210100 /* TXTFileLoaderTests.swift in Sources */,
@@ -4474,13 +4478,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 363;
+				CURRENT_PROJECT_VERSION = 364;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.22.11;
+				MARKETING_VERSION = 3.22.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4624,13 +4628,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 363;
+				CURRENT_PROJECT_VERSION = 364;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.22.11;
+				MARKETING_VERSION = 3.22.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Views/Reader/TXTChunkedReaderBridge.swift
+++ b/vreader/Views/Reader/TXTChunkedReaderBridge.swift
@@ -39,6 +39,19 @@ struct TXTChunkedReaderBridge: UIViewRepresentable {
     var highlightIsTemporary: Bool = true
     /// Persisted highlight ranges (document-global UTF-16) loaded from DB (bug #55).
     var persistedHighlights: [NSRange] = []
+    /// Persisted highlight lookup keyed by UUID — global UTF-16 ranges plus
+    /// their highlight IDs, used by the tap-on-highlight hit-tester.
+    /// Feature #53 WI-3. When empty, tap-on-highlight is dormant (the gesture
+    /// falls through to the existing chrome-toggle behavior).
+    var persistedHighlightLookup: [PersistedHighlightLookupEntry] = []
+    /// Presenter that shows the inline edit-menu when a tap resolves to a
+    /// highlight. Feature #53 WI-3. When nil, only the
+    /// `.readerHighlightTapped` notification fires.
+    var highlightActionPresenter: (any HighlightActionPresenting)?
+    /// Callback that routes the user's chosen action through the coordinator.
+    /// Feature #53 WI-3. When nil, presenter results have nowhere to go and
+    /// the menu only acts as a discoverability cue (no persistence change).
+    var onHighlightTapAction: ((HighlightTapAction, UUID) async -> Void)?
     /// Top safe-area inset applied to the UITableView's `contentInset.top` so
     /// the first chunk renders below the Dynamic Island. Bug #179 (mirrors
     /// the non-chunked path's same-named param). Default `0` preserves prior
@@ -71,6 +84,9 @@ struct TXTChunkedReaderBridge: UIViewRepresentable {
         context.coordinator.config = config
         context.coordinator.chunkStartOffsets = chunkStartOffsets
         context.coordinator.persistedHighlights = persistedHighlights
+        context.coordinator.persistedHighlightLookup = persistedHighlightLookup
+        context.coordinator.highlightActionPresenter = highlightActionPresenter
+        context.coordinator.onHighlightTapAction = onHighlightTapAction
         context.coordinator.delegate = delegate
 
         // Tap gesture for toolbar toggle
@@ -102,6 +118,12 @@ struct TXTChunkedReaderBridge: UIViewRepresentable {
 
     func updateUIView(_ tableView: UITableView, context: Context) {
         context.coordinator.delegate = delegate
+        // Feature #53 WI-3: refresh tap-on-highlight inputs every update so
+        // late-arriving highlights (created after the bridge was first
+        // installed) become tap-targetable as soon as the lookup grows.
+        context.coordinator.persistedHighlightLookup = persistedHighlightLookup
+        context.coordinator.highlightActionPresenter = highlightActionPresenter
+        context.coordinator.onHighlightTapAction = onHighlightTapAction
 
         // Bug #179: re-apply safe-area top inset on every update (rotation,
         // split-screen resize, etc. can change `proxy.safeAreaInsets.top`).
@@ -197,6 +219,13 @@ struct TXTChunkedReaderBridge: UIViewRepresentable {
         var chunkStartOffsets: [Int] = []
         /// Persisted highlight ranges (document-global UTF-16) from DB (bug #55).
         var persistedHighlights: [NSRange] = []
+        /// Lookup table (UUID, global UTF-16 range) used by the tap-on-
+        /// highlight hit-tester. Feature #53 WI-3.
+        var persistedHighlightLookup: [PersistedHighlightLookupEntry] = []
+        /// Presenter for the inline tap-on-highlight menu. Feature #53 WI-3.
+        var highlightActionPresenter: (any HighlightActionPresenting)?
+        /// Tap-action routing callback. Feature #53 WI-3.
+        var onHighlightTapAction: ((HighlightTapAction, UUID) async -> Void)?
         weak var delegate: TXTTextViewBridgeDelegate?
 
         /// LRU cache for attributed strings keyed by chunk index.
@@ -326,10 +355,131 @@ struct TXTChunkedReaderBridge: UIViewRepresentable {
             if !decelerate { reportScrollPosition(scrollView) }
         }
 
-        // MARK: - Content Tap (Toolbar Toggle)
+        // MARK: - Content Tap (Toolbar Toggle / Tap-on-Highlight)
 
         @objc func handleContentTap(_ gesture: UITapGestureRecognizer) {
+            // Feature #53 WI-3: if the tap lands inside a persisted highlight
+            // range, fire `.readerHighlightTapped` (and present the inline
+            // menu when wired) instead of toggling chrome. The chunked path
+            // mirrors the non-chunked TXTTextViewBridge.Coordinator behavior
+            // — see `resolveHighlightTap` there. Lookup-empty short-circuit
+            // keeps non-WI-3 callers cost-free.
+            if let tableView = gesture.view as? UITableView,
+               !persistedHighlightLookup.isEmpty,
+               let event = Self.resolveChunkedHighlightTap(
+                   gesture: gesture,
+                   in: tableView,
+                   chunkStartOffsets: chunkStartOffsets,
+                   lookup: persistedHighlightLookup
+               ) {
+                NotificationCenter.default.post(
+                    name: .readerHighlightTapped, object: event
+                )
+                if let presenter = highlightActionPresenter,
+                   let onAction = onHighlightTapAction {
+                    presenter.present(for: event, in: tableView) { action in
+                        guard let action else { return }
+                        Task { @MainActor in
+                            await onAction(action, event.highlightID)
+                        }
+                    }
+                }
+                return
+            }
             TXTBridgeShared.postContentTappedNotification()
+        }
+
+        // MARK: - Tap-on-Highlight Resolution (Feature #53 WI-3)
+
+        /// Resolves a gesture-driven tap into a `ReaderHighlightTapEvent`
+        /// by walking from `UITableView` → containing cell → embedded
+        /// `UITextView` → chunk-local char index → global char index →
+        /// `TextHighlightHitTester`. Returns nil when the tap misses every
+        /// persisted range (caller falls back to chrome-toggle).
+        ///
+        /// Extracted as static + internal so unit tests can drive it without
+        /// going through a live `UITapGestureRecognizer`.
+        @MainActor
+        static func resolveChunkedHighlightTap(
+            gesture: UITapGestureRecognizer,
+            in tableView: UITableView,
+            chunkStartOffsets: [Int],
+            lookup: [PersistedHighlightLookupEntry]
+        ) -> ReaderHighlightTapEvent? {
+            guard !lookup.isEmpty else { return nil }
+            let tapPointInTable = gesture.location(in: tableView)
+            guard let indexPath = tableView.indexPathForRow(at: tapPointInTable),
+                  let cell = tableView.cellForRow(at: indexPath) as? ChunkedTextCell
+            else { return nil }
+            let textView = cell.textContentView
+            let tapPointInCell = tableView.convert(tapPointInTable, to: textView)
+            return resolveChunkedHighlightTap(
+                tapPointInCell: tapPointInCell,
+                in: textView,
+                chunkIndex: indexPath.row,
+                chunkStartOffsets: chunkStartOffsets,
+                lookup: lookup
+            )
+        }
+
+        /// Pure-point overload. Tests construct a CGPoint + textView fixture
+        /// directly without driving through a UITableView. The chunk-offset
+        /// math is what's actually under test here — converting a
+        /// chunk-local character index into a document-global one before
+        /// hitting `TextHighlightHitTester`.
+        @MainActor
+        static func resolveChunkedHighlightTap(
+            tapPointInCell: CGPoint,
+            in textView: UITextView,
+            chunkIndex: Int,
+            chunkStartOffsets: [Int],
+            lookup: [PersistedHighlightLookupEntry]
+        ) -> ReaderHighlightTapEvent? {
+            guard !lookup.isEmpty else { return nil }
+            guard chunkIndex >= 0, chunkIndex < chunkStartOffsets.count else {
+                return nil
+            }
+            let chunkOffset = chunkStartOffsets[chunkIndex]
+            let inset = textView.textContainerInset
+            let containerPoint = CGPoint(
+                x: tapPointInCell.x - inset.left,
+                y: tapPointInCell.y - inset.top
+            )
+            let lm = textView.layoutManager
+            let chunkLocalCharIndex = lm.characterIndex(
+                for: containerPoint,
+                in: textView.textContainer,
+                fractionOfDistanceBetweenInsertionPoints: nil
+            )
+            let globalCharIndex = chunkOffset + chunkLocalCharIndex
+            guard let hit = TextHighlightHitTester.hitTest(
+                charIndex: globalCharIndex, in: lookup
+            ) else { return nil }
+            // The global range may straddle chunk boundaries; clip to this
+            // chunk's local extent so the source rect anchors above the
+            // visible slice in THIS cell, not above content the user can't
+            // see (which would put the menu off-screen).
+            let chunkLength = textView.textStorage.length
+            let localStart = max(0, hit.range.location - chunkOffset)
+            let localEnd = min(
+                chunkLength, hit.range.location + hit.range.length - chunkOffset
+            )
+            let localLen = localEnd - localStart
+            guard localLen > 0 else { return nil }
+            let localRange = NSRange(location: localStart, length: localLen)
+            let glyphRange = lm.glyphRange(
+                forCharacterRange: localRange, actualCharacterRange: nil
+            )
+            let containerRect = lm.boundingRect(
+                forGlyphRange: glyphRange, in: textView.textContainer
+            )
+            let viewRect = containerRect.offsetBy(
+                dx: inset.left, dy: inset.top
+            )
+            let windowRect = textView.convert(viewRect, to: nil)
+            return ReaderHighlightTapEvent(
+                highlightID: hit.id, sourceRect: windowRect
+            )
         }
 
         func gestureRecognizer(

--- a/vreader/Views/Reader/TXTReaderContainerView.swift
+++ b/vreader/Views/Reader/TXTReaderContainerView.swift
@@ -621,6 +621,11 @@ struct TXTReaderContainerView: View {
                 highlightRange: uiState.highlightRange,
                 highlightIsTemporary: uiState.highlightIsTemporary,
                 persistedHighlights: uiState.persistedHighlightRanges,
+                persistedHighlightLookup: uiState.persistedHighlightLookup,
+                highlightActionPresenter: UIKitHighlightActionPresenter(),
+                onHighlightTapAction: { [highlightCoordinator] action, id in
+                    await highlightCoordinator?.handleTapAction(action, highlightID: id)
+                },
                 safeAreaTopInset: ReaderSafeAreaResolver.topInsetWithFallback(proxy.safeAreaInsets.top)
             )
         }

--- a/vreaderTests/Views/Reader/TXTChunkedBridgeHighlightTapTests.swift
+++ b/vreaderTests/Views/Reader/TXTChunkedBridgeHighlightTapTests.swift
@@ -1,0 +1,210 @@
+// Purpose: Tests for `TXTChunkedReaderBridge.Coordinator.resolveChunkedHighlightTap`
+// (Feature #53 WI-3 / GH #596). Verifies the tap-point → chunk-local char-index →
+// global char-index → highlight-UUID pipeline produces correct
+// `ReaderHighlightTapEvent`s against a real `HighlightableTextView` fixture
+// when the persisted lookup is keyed against document-global UTF-16 ranges.
+//
+// @coordinates-with: TXTChunkedReaderBridge.swift, HighlightableTextView.swift,
+//   TextHighlightHitTester.swift, TXTTextViewBridge.swift (sister non-chunked path)
+
+#if canImport(UIKit)
+import Testing
+import UIKit
+import Foundation
+@testable import vreader
+
+@MainActor
+private func makeChunkFixture(text: String) -> UITextView {
+    let tv = UITextView()
+    tv.isEditable = false
+    tv.isSelectable = true
+    tv.attributedText = NSAttributedString(
+        string: text,
+        attributes: [.font: UIFont.systemFont(ofSize: 16)]
+    )
+    tv.frame = CGRect(x: 0, y: 0, width: 800, height: 200)
+    tv.textContainer.lineFragmentPadding = 0
+    tv.textContainerInset = .zero
+    tv.layoutManager.ensureLayout(for: tv.textContainer)
+    return tv
+}
+
+@Suite("TXTChunkedBridgeHighlightTap")
+struct TXTChunkedBridgeHighlightTapTests {
+
+    @Test @MainActor
+    func resolveChunkedHighlightTap_emptyLookup_returnsNil() {
+        let tv = makeChunkFixture(text: "hello world")
+        let result = TXTChunkedReaderBridge.Coordinator.resolveChunkedHighlightTap(
+            tapPointInCell: CGPoint(x: 10, y: 5),
+            in: tv,
+            chunkIndex: 0,
+            chunkStartOffsets: [0],
+            lookup: []
+        )
+        #expect(result == nil)
+    }
+
+    @Test @MainActor
+    func resolveChunkedHighlightTap_chunk0_pointInsideRange_returnsEvent() {
+        // Chunk 0 starts at global offset 0; chunk-local range [6, 11) is "world"
+        // and global range [6, 11) is the same. Tap inside should hit.
+        let tv = makeChunkFixture(text: "hello world")
+        let id = UUID()
+        let lookup = [PersistedHighlightLookupEntry(
+            id: id, range: NSRange(location: 6, length: 5)
+        )]
+        let lm = tv.layoutManager
+        let glyphRange = lm.glyphRange(
+            forCharacterRange: NSRange(location: 6, length: 1),
+            actualCharacterRange: nil
+        )
+        let charRect = lm.boundingRect(forGlyphRange: glyphRange, in: tv.textContainer)
+        let tapPoint = CGPoint(x: charRect.midX, y: charRect.midY)
+
+        let result = TXTChunkedReaderBridge.Coordinator.resolveChunkedHighlightTap(
+            tapPointInCell: tapPoint,
+            in: tv,
+            chunkIndex: 0,
+            chunkStartOffsets: [0],
+            lookup: lookup
+        )
+        #expect(result?.highlightID == id)
+        #expect(result?.sourceRect != .zero)
+    }
+
+    @Test @MainActor
+    func resolveChunkedHighlightTap_chunk2_addsChunkStartOffset() {
+        // Chunk 2 starts at global offset 100. Its local text is "hello world".
+        // The persisted highlight is at GLOBAL range [106, 111) (= chunk-local
+        // [6, 11) once 100 is subtracted). A tap inside the rendered "world"
+        // span should hit, proving the chunk-offset addition.
+        let tv = makeChunkFixture(text: "hello world")
+        let id = UUID()
+        let lookup = [PersistedHighlightLookupEntry(
+            id: id, range: NSRange(location: 106, length: 5)
+        )]
+        let lm = tv.layoutManager
+        let glyphRange = lm.glyphRange(
+            forCharacterRange: NSRange(location: 6, length: 1),
+            actualCharacterRange: nil
+        )
+        let charRect = lm.boundingRect(forGlyphRange: glyphRange, in: tv.textContainer)
+        let tapPoint = CGPoint(x: charRect.midX, y: charRect.midY)
+
+        let result = TXTChunkedReaderBridge.Coordinator.resolveChunkedHighlightTap(
+            tapPointInCell: tapPoint,
+            in: tv,
+            chunkIndex: 2,
+            chunkStartOffsets: [0, 50, 100],
+            lookup: lookup
+        )
+        #expect(result?.highlightID == id)
+    }
+
+    @Test @MainActor
+    func resolveChunkedHighlightTap_pointOutsideAllRanges_returnsNil() {
+        // Persisted range covers only "hello" (global [0, 5)). Tap over "world".
+        let tv = makeChunkFixture(text: "hello world")
+        let id = UUID()
+        let lookup = [PersistedHighlightLookupEntry(
+            id: id, range: NSRange(location: 0, length: 5)
+        )]
+        let lm = tv.layoutManager
+        let glyphRange = lm.glyphRange(
+            forCharacterRange: NSRange(location: 6, length: 1),
+            actualCharacterRange: nil
+        )
+        let charRect = lm.boundingRect(forGlyphRange: glyphRange, in: tv.textContainer)
+        let tapPoint = CGPoint(x: charRect.midX, y: charRect.midY)
+
+        let result = TXTChunkedReaderBridge.Coordinator.resolveChunkedHighlightTap(
+            tapPointInCell: tapPoint,
+            in: tv,
+            chunkIndex: 0,
+            chunkStartOffsets: [0],
+            lookup: lookup
+        )
+        #expect(result == nil)
+    }
+
+    @Test @MainActor
+    func resolveChunkedHighlightTap_chunkIndexOutOfBounds_returnsNil() {
+        // Defensive: if a tap arrives for a cell whose chunkIndex exceeds
+        // the offsets array length, we must NOT crash. Returns nil cleanly.
+        let tv = makeChunkFixture(text: "hello")
+        let id = UUID()
+        let lookup = [PersistedHighlightLookupEntry(
+            id: id, range: NSRange(location: 0, length: 5)
+        )]
+        let result = TXTChunkedReaderBridge.Coordinator.resolveChunkedHighlightTap(
+            tapPointInCell: CGPoint(x: 5, y: 5),
+            in: tv,
+            chunkIndex: 99,
+            chunkStartOffsets: [0, 10, 20],
+            lookup: lookup
+        )
+        #expect(result == nil)
+    }
+
+    @Test @MainActor
+    func resolveChunkedHighlightTap_returnsNonZeroSourceRect_forVisibleSpan() {
+        // Acceptance: sourceRect must be non-zero so the presenter has
+        // somewhere to anchor the menu.
+        let tv = makeChunkFixture(text: "hello world")
+        let id = UUID()
+        // Chunk 1 starts at global offset 50; local "hello" range = global [50, 55).
+        let lookup = [PersistedHighlightLookupEntry(
+            id: id, range: NSRange(location: 50, length: 5)
+        )]
+        let tapPoint = CGPoint(x: 5, y: 5)
+        guard let event = TXTChunkedReaderBridge.Coordinator.resolveChunkedHighlightTap(
+            tapPointInCell: tapPoint,
+            in: tv,
+            chunkIndex: 1,
+            chunkStartOffsets: [0, 50],
+            lookup: lookup
+        ) else {
+            Issue.record("Expected a hit for tap over 'hello' in chunk 1")
+            return
+        }
+        #expect(event.sourceRect.width > 0)
+        #expect(event.sourceRect.height > 0)
+    }
+
+    @Test @MainActor
+    func resolveChunkedHighlightTap_globalRangeStraddlesChunks_localSliceUsedForSourceRect() {
+        // Edge case: a persisted highlight at GLOBAL range [48, 56) spans
+        // the boundary between chunk 0 (offsets[0]=0, length 50) and chunk 1
+        // (offsets[1]=50). When the user taps inside the chunk-1 portion
+        // (global 50–55 → local 0–5 of "hello world"), the resolver must:
+        // (a) return the highlight's UUID, and
+        // (b) clip the sourceRect to the chunk-1 portion (local [0, 6))
+        //     so the popover anchors above the visible slice in this cell,
+        //     not above the missing pre-50 slice from chunk 0.
+        let tv = makeChunkFixture(text: "hello world")
+        let id = UUID()
+        let lookup = [PersistedHighlightLookupEntry(
+            id: id, range: NSRange(location: 48, length: 8)  // global [48, 56)
+        )]
+        let lm = tv.layoutManager
+        let glyphRange = lm.glyphRange(
+            forCharacterRange: NSRange(location: 2, length: 1),
+            actualCharacterRange: nil
+        )
+        let charRect = lm.boundingRect(forGlyphRange: glyphRange, in: tv.textContainer)
+        let tapPoint = CGPoint(x: charRect.midX, y: charRect.midY)
+
+        let result = TXTChunkedReaderBridge.Coordinator.resolveChunkedHighlightTap(
+            tapPointInCell: tapPoint,
+            in: tv,
+            chunkIndex: 1,
+            chunkStartOffsets: [0, 50],
+            lookup: lookup
+        )
+        #expect(result?.highlightID == id)
+        // Non-zero size proves clipping produced a valid local range.
+        #expect((result?.sourceRect.width ?? 0) > 0)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Feature #53 WI-3 — extends tap-on-highlight to the **chunked TXT path** (`TXTChunkedReaderBridge`), used by TXT files over the `largeFileThreshold` UTF-16 code-unit limit (~500K). MD's non-chunked path already inherited the WI-2 / WI-2b wiring via shared `TXTTextViewBridge`; the chunked path was the missed scope.

The plan's WI-3 row in `dev-docs/plans/20260515-feature-53-tap-on-highlight.md` is updated with a `v2` revision-history entry recording this scope clarification.

Part of feature #596

## What Changed

### Production code

- `TXTChunkedReaderBridge.swift`:
  - 3 new bridge fields (`persistedHighlightLookup`, `highlightActionPresenter`, `onHighlightTapAction`) propagated through `makeUIView` + `updateUIView` into the `Coordinator`.
  - `handleContentTap(_:)` extended: if the tap hits a persisted highlight, post `.readerHighlightTapped` and (when wired) present the inline menu + route the chosen `HighlightTapAction` through `HighlightCoordinator`. Misses fall through to the existing chrome-toggle notification.
  - New `static func resolveChunkedHighlightTap` with gesture and pure-CGPoint overloads. Math handles chunk-local → global UTF-16 conversion, chunk-bounds defense, and clipping when a global range straddles chunk boundaries.
- `TXTReaderContainerView.swift`:
  - `chunkedReaderContent` passes the 3 new params with the same closure shape as the non-chunked branch.

### Tests

- 7 Swift Testing methods in `vreaderTests/Views/Reader/TXTChunkedBridgeHighlightTapTests.swift`:
  - `resolveChunkedHighlightTap_emptyLookup_returnsNil`
  - `resolveChunkedHighlightTap_chunk0_pointInsideRange_returnsEvent`
  - `resolveChunkedHighlightTap_chunk2_addsChunkStartOffset` (proves chunk-offset addition)
  - `resolveChunkedHighlightTap_pointOutsideAllRanges_returnsNil`
  - `resolveChunkedHighlightTap_chunkIndexOutOfBounds_returnsNil`
  - `resolveChunkedHighlightTap_returnsNonZeroSourceRect_forVisibleSpan`
  - `resolveChunkedHighlightTap_globalRangeStraddlesChunks_localSliceUsedForSourceRect`

## WI Status

- WI-3: behavioral, not final — this PR
- Remaining WIs: WI-4 (EPUB), WI-5 (AZW3/Foliate — fixes existing `.readerHighlightRequested` misuse), WI-6 (PDF — final, flips feature row to DONE)

## Codex Audit (Gate 4)

Manual-fallback (per saved feedback: Codex audit-time consistently exceeds cron-iteration budget). Round 1 → ship-as-is. One Low / deferred / pre-existing follow-up: `TXTChunkedReaderBridge.swift` was over 300 LOC before this WI; split candidate `TXTChunkedReaderBridge+TapOnHighlight.swift` logged for a future WI revisit.

Audit log: `.claude/codex-audits/feat-feature-53-wi-3-chunked-txt-tap-on-highlight-audit.md`

## Validation

- [x] `xcodebuild test -only-testing:vreaderTests` — new suite (7 methods) passes; all tap-on-highlight suites pass (`UIKitHighlightActionPresenter`, `TXTChunkedBridgeHighlightTap`, `ReaderHighlightTapEvent`, `HighlightTapAction`, `TXTBridgeHighlightTap`, `TXTChunkedLoader`, `TXTChunkedHighlight — deferred auto-clear`). Pre-existing unrelated failures in `BookFormatAZW3Tests` (bug #176 deferred) and `Search*Tests` (flaky) confirmed not caused by this diff.
- [x] Tests cover changed behavior (TDD: RED → GREEN)
- [x] Manual-fallback Codex audit completed (1 iteration, verdict: ship-as-is)
- [x] Docs sync — n/a (no new service / actor / `@Model` / `Notification.Name` / cross-feature pattern; the chunked-bridge extension is an internal implementation detail of the already-documented tap-on-highlight feature)
- [x] Version bumped: 3.22.11 → 3.22.12

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: **behavioral, not final** — slice verified via unit tests against `HighlightableTextView` fixture covering the resolver's hit/miss/offset/bounds/straddle paths. Live UITableView gesture path uses the same `gesture.location(in:)` + `tableView.indexPathForRow(at:)` pattern already proven by WI-2's TXT non-chunked sister code on the same physical TXTBridgeShared infrastructure. Full chunked end-to-end device-verify deferred to final WI's Gate 5b acceptance pass.

## Type of Change

- [x] Feature WI (Part of feature #596 — intermediate WI, uses plain prose link not `Refs #N` to avoid the open-feature merge-gate block)