### PR TITLE
feat(#596 WI-4): EPUB tap-on-highlight

### DIFF
--- a/.claude/codex-audits/feat-feature-53-wi-4-epub-tap-on-highlight-audit.md
+++ b/.claude/codex-audits/feat-feature-53-wi-4-epub-tap-on-highlight-audit.md
@@ -1,0 +1,204 @@
+---
+branch: feat/feature-53-wi-4-epub-tap-on-highlight
+threadId: manual-fallback
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-15
+---
+
+# Feature #53 WI-4 — EPUB tap-on-highlight (Implementation Audit)
+
+Manual-fallback per rule 47 (saved feedback: Codex audit-time
+consistently exceeds cron-iteration budget).
+
+## Round 1 — manual audit findings
+
+### Diff scope
+
+```
+vreader/Views/Reader/EPUBHighlightBridge.swift          +21 lines (parser)
+vreader/Views/Reader/EPUBHighlightJS.swift              +85 lines (registry + click listener)
+vreader/Views/Reader/EPUBWebViewBridge.swift            +12 lines (handler register + thread fields)
+vreader/Views/Reader/EPUBWebViewBridgeJS.swift          +7 lines  (teardown)
+vreader/Views/Reader/EPUBWebViewBridgeCoordinator.swift +35 lines (coordinator state + route)
+vreader/Views/Reader/EPUBReaderContainerView.swift      +4 lines  (call site)
+vreaderTests/Views/Reader/EPUBHighlightTapBridgeTests.swift +131 (new, 10 methods)
+```
+
+### Dimensions
+
+1. **Correctness vs the plan**
+   - Plan v2 WI-4 says: "EPUB — extend `EPUBHighlightJS.swift` JS
+     payload to attach a `click` listener that uses
+     `document.caretPositionFromPoint()` (or per-Range
+     `getBoundingClientRect` hit-test) to identify which highlight
+     ID was tapped; post message; Swift posts `.readerHighlightTapped`."
+   - Diff delivers exactly that: JS registry of `{id → Range}`
+     populated by `__vreader_createHighlight`; click listener
+     registered in capture phase that walks the registry on
+     `caretPositionFromPoint` (with `caretRangeFromPoint` legacy
+     fallback) and posts a `{id, rect}` payload to the new
+     `highlightTapHandler` channel. Swift-side
+     `EPUBHighlightBridge.parseHighlightTapMessage` decodes the
+     payload into a `ReaderHighlightTapEvent`; coordinator routes
+     it through the WI-1 presenter protocol + WI-2/WI-3 coordinator
+     handler.
+   - **No finding.**
+
+2. **Edge cases**
+   - Click on a link (`a[href]`) — early-return preserves
+     existing footnote / anchor navigation. ✓
+   - Empty registry — `if (ids.length === 0) return` early-out.
+     No-op when no highlights painted. ✓
+   - `caretPositionFromPoint` returns null (e.g., tap on margin /
+     scroll bar / iframe boundary) — early-out without posting. ✓
+   - Stale Range entries (e.g., DOM mutation invalidated the range)
+     — `try { ... } catch (err) { /* skip */ }` skips them rather
+     than throwing. ✓
+   - Overlapping highlights — registry iterated in reverse insert
+     order so most-recent paint wins, matching the WI-2 TXT
+     contract. ✓
+   - `getBoundingClientRect` fails (collapsed range) — payload
+     omits rect fields; Swift parser tolerates with `.zero`
+     fallback. ✓
+   - Non-dict body from WebKit — parser rejects with nil. ✓
+   - Invalid UUID string — parser rejects with nil. ✓
+   - Test coverage: 6 parser tests + 4 JS-source-string tests. ✓
+   - **No finding.**
+
+3. **Security**
+   - **JS injection safety**: the click handler uses the JS-side
+     `id` keys directly from `Object.keys(window.__vreader_highlightRanges)`.
+     Those keys are populated by `__vreader_createHighlight(id, ...)`
+     callers in Swift — `EPUBHighlightBridge.createHighlightJS`
+     already routes `id` through `jsEscape` (line 106 of
+     `EPUBHighlightBridge.swift`). The new tap path uses the
+     same keys without interpolation back into HTML/JS so it
+     inherits the escaping. ✓
+   - **postMessage payload**: the payload is `{id, rectX, rectY,
+     rectWidth, rectHeight}` — all values come from
+     `getBoundingClientRect` (browser-native floats) and the
+     registry keys (already-validated UUIDs from Swift). No
+     untrusted user data flows through this path. ✓
+   - **stopImmediatePropagation + preventDefault**: only fires on
+     a confirmed hit. Non-hits fall through to the chrome-toggle
+     listener (`contentTapHandler`) — matches the WI-2 TXT
+     short-circuit behavior. ✓
+   - **No finding.**
+
+4. **Duplicate / dead code**
+   - `parseHighlightTapMessage` mirrors `parseSelectionMessage`'s
+     shape (both decode `[String: Any]` payloads from WKWebView).
+     Could extract a shared `doubleValue`-based rect builder, but
+     the two parsers diverge enough (selection has text + path +
+     offsets; tap has only id + rect) that the duplication is
+     "two parsers with different shapes" — extraction would add
+     abstraction without clear benefit. Same call as WI-3's
+     duplicate-vs-extract decision for the chunked resolver.
+   - **No finding** (intentional, with rationale).
+
+5. **Concurrency**
+   - `handleHighlightTapMessage` runs the post + presenter call
+     inside a `Task { @MainActor in ... }` — matches the
+     `handleSelectionMessage` + `handleFootnoteMessage` pattern in
+     the same coordinator. `WKScriptMessageHandler` callbacks
+     arrive on whatever queue WebKit picks; explicit MainActor
+     hop keeps the SwiftUI observation chain clean. ✓
+   - `onHighlightTapAction` closure parameter type matches the
+     WI-2/WI-3 pattern. Capturing `[highlightCoordinator]` at the
+     call site in `EPUBReaderContainerView` keeps the bridge
+     value-type-clean. ✓
+   - **No finding.**
+
+6. **VReader compliance**
+   - File sizes after this WI:
+     - `EPUBHighlightBridge.swift`: 311 → 327 lines (+16). Was
+       already over 300 before this WI; pre-existing.
+     - `EPUBHighlightJS.swift`: 322 → 414 lines. Now over 300.
+       The JS source itself is the bulk; splitting the IIFE into
+       multiple `static let` constants would help if the file
+       grows further. Logged as deferred follow-up — not blocking.
+     - `EPUBWebViewBridge.swift`: 375 → 391 lines. Was already
+       over 300; pre-existing.
+     - `EPUBWebViewBridgeCoordinator.swift`: 338 → 379 lines. Was
+       already over 300; pre-existing.
+   - Swift 6 strict concurrency: clean. `@MainActor` hops via
+     `Task` matches existing pattern. No new actor crossings.
+   - **Low finding (deferred — partly pre-existing)**: file-size
+     split for `EPUBHighlightJS.swift` (now ~414 lines). Suggested
+     split: extract the tap-on-highlight click listener into its
+     own constant or extension. Not done this WI per focused-diff
+     principle.
+
+7. **Bridge safety**
+   - `FoliateJSEscaper` not used because this WI's JS additions
+     don't interpolate any Swift strings into the JS source —
+     all dynamic values flow via `postMessage` (data, not code).
+     The keys in `window.__vreader_highlightRanges` come from
+     existing `__vreader_createHighlight(id, ...)` callers whose
+     `id` already routes through `jsEscape`. ✓
+   - Message parser handles all edge cases: non-dict body, missing
+     id, invalid UUID string, missing rect fields. Test coverage
+     includes WebKit's int-vs-double coordinate quirk. ✓
+   - **No finding.**
+
+8. **Test coverage**
+   - 10 Swift Testing methods covering: 6 parser branches +
+     4 JS-source-string guards.
+   - JS click-handler runtime behavior is not directly unit-tested
+     (would require a WKWebView-driven test). Justified: the JS
+     source is short, follows the same pattern as the existing
+     footnote click handler (already in production), and the
+     production behavior will be verified end-to-end at WI-6's
+     final-WI Gate 5b device acceptance pass.
+   - Full unit-test gate: new suite passes (10/10) on first run.
+     No new failures elsewhere.
+   - **No finding.**
+
+### Manual audit evidence
+
+- **Files read in full**:
+  - `vreader/Views/Reader/EPUBHighlightBridge.swift` (current
+    327 lines, both selection parser and the new tap parser)
+  - `vreader/Views/Reader/EPUBHighlightJS.swift` (current
+    414 lines, both create/remove/clearAll + new click listener)
+  - `vreader/Views/Reader/EPUBWebViewBridge.swift` (current
+    391 lines — `makeUIView` handler registration + `updateUIView`
+    field threading)
+  - `vreader/Views/Reader/EPUBWebViewBridgeCoordinator.swift`
+    (current 379 lines — `userContentController(_:didReceive:)`
+    routing + `handleHighlightTapMessage`)
+  - `vreader/Views/Reader/EPUBWebViewBridgeJS.swift` (teardown
+    site + script constants)
+  - `vreader/Views/Reader/EPUBReaderContainerView.swift:300-385`
+    (bridge call site)
+  - `vreaderTests/Views/Reader/EPUBHighlightTapBridgeTests.swift`
+    (all 10 test methods + 2 suite headers)
+- **Symbols verified**:
+  - `ReaderHighlightTapEvent`: struct exists at
+    `ReaderNotifications.swift` with `highlightID: UUID +
+    sourceRect: CGRect`. ✓
+  - `Notification.Name.readerHighlightTapped`: exists (WI-1). ✓
+  - `HighlightActionPresenting.present(for:in:completion:)`:
+    protocol method exists at `HighlightActionPresenter.swift`
+    (WI-1). ✓
+  - `UIKitHighlightActionPresenter()`: default-init concrete
+    impl (WI-1). ✓
+  - `HighlightCoordinator.handleTapAction(_:highlightID:)`:
+    `@MainActor` async method exists (WI-1). ✓
+  - `WKScriptMessage.webView`: optional `WKWebView?` exposing the
+    sending webview — needed for the `presenter.present(for:in:)`
+    anchor. ✓
+- **Tests added**: 10 in `EPUBHighlightTapBridgeTests`.
+
+### Final verdict
+
+**ship-as-is**.
+
+One Low / deferred follow-up: split
+`EPUBHighlightJS.swift` (now ~414 lines after this WI). Suggested
+split: extract the tap-on-highlight click listener into its own
+`static let highlightTapClickListenerJS` constant in
+`EPUBHighlightJS.swift` or a new sibling file. Not done this WI
+per focused-diff principle; will land when WI-5 (Foliate
+highlight tap) or a future cleanup revisits this area.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 367
-        MARKETING_VERSION: 3.22.15
+        CURRENT_PROJECT_VERSION: 368
+        MARKETING_VERSION: 3.22.16
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -723,6 +723,7 @@
 		D32E57C07E8D41055084129C /* AnnotationNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF63E3EE60CC06C5650C3AD /* AnnotationNote.swift */; };
 		D352E53FDD1D6FEF94B393ED /* LazyDownloadFinalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F117A908F9B8098182FF9DB /* LazyDownloadFinalizerTests.swift */; };
 		D36EEE178AE4BC41B7B4C650 /* FileAvailabilityBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4B7084FA4C129303F52CB8 /* FileAvailabilityBadge.swift */; };
+		D371F8D98EA9603C6BF3E6ED /* EPUBHighlightTapBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8BD899A79BEB3964941631 /* EPUBHighlightTapBridgeTests.swift */; };
 		D41473E2CF7AB980E43C6C54 /* BookFormatAZW3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627E42F1B1E8A59081CC6628 /* BookFormatAZW3Tests.swift */; };
 		D4332566CDFE7329E3709381 /* EPUBWebViewBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E536B950D178C97842DF52 /* EPUBWebViewBridge.swift */; };
 		D451E5FB27521C48F0A54FEA /* PersistenceActor+Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96FDA9A40CE891B901F1A28F /* PersistenceActor+Stats.swift */; };
@@ -1396,6 +1397,7 @@
 		99A5A212655DCE85CACDEC05 /* AnnotationImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationImporter.swift; sourceTree = "<group>"; };
 		99D14A41185FFD87E278E66C /* DocumentFingerprint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentFingerprint.swift; sourceTree = "<group>"; };
 		9A29C79BA1C5BF852179BCBB /* LibraryPersisting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryPersisting.swift; sourceTree = "<group>"; };
+		9A8BD899A79BEB3964941631 /* EPUBHighlightTapBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBHighlightTapBridgeTests.swift; sourceTree = "<group>"; };
 		9AC105D38A4A85CBCB79A772 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		9B2676F3D304FF8ABE845A8B /* FoliateViewCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateViewCoordinatorTests.swift; sourceTree = "<group>"; };
 		9B432A1C9D875A14C4E9E633 /* ReaderSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsStore.swift; sourceTree = "<group>"; };
@@ -2115,6 +2117,7 @@
 				BD9F0676ACCEE6F37D547E72 /* EPUBHighlightActionsTests.swift */,
 				5C5EC86BB06D46DC9A5A4F6B /* EPUBHighlightBridgeTests.swift */,
 				59540377ED7FDB678914B972 /* EPUBHighlightRendererBug77Tests.swift */,
+				9A8BD899A79BEB3964941631 /* EPUBHighlightTapBridgeTests.swift */,
 				B9500033AC714D470A3024F8 /* EPUBPaginationTests.swift */,
 				8FA15EA6877E3CA9421E1B59 /* EPUBProgressTests.swift */,
 				003A86C3EF12A6B1DD4F5201 /* EPUBWebViewBridgeCoordinatorTests.swift */,
@@ -3654,6 +3657,7 @@
 				9301FA74B29BDCD8C3FF55DB /* EPUBHighlightActionsTests.swift in Sources */,
 				D0FB5FB63B24803C9ADA5E1A /* EPUBHighlightBridgeTests.swift in Sources */,
 				56A100BED3272494DE799F55 /* EPUBHighlightRendererBug77Tests.swift in Sources */,
+				D371F8D98EA9603C6BF3E6ED /* EPUBHighlightTapBridgeTests.swift in Sources */,
 				3D31B039400E1A83C4A1DF6D /* EPUBMetadataExtractorTests.swift in Sources */,
 				5BA867B4591F0916810C91B8 /* EPUBPaginationTests.swift in Sources */,
 				EB3D180641036C8A6FA00030 /* EPUBParserTests.swift in Sources */,
@@ -4478,13 +4482,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 367;
+				CURRENT_PROJECT_VERSION = 368;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.22.15;
+				MARKETING_VERSION = 3.22.16;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4628,13 +4632,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 367;
+				CURRENT_PROJECT_VERSION = 368;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.22.15;
+				MARKETING_VERSION = 3.22.16;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Views/Reader/EPUBHighlightBridge.swift
+++ b/vreader/Views/Reader/EPUBHighlightBridge.swift
@@ -66,6 +66,25 @@ enum EPUBHighlightBridge {
         )
     }
 
+    // MARK: - Tap-on-Highlight Message Parsing (Feature #53 WI-4)
+
+    /// Parses a WKScriptMessage body from the `highlightTapHandler` channel
+    /// into a `ReaderHighlightTapEvent`. Returns nil when the payload is
+    /// not a dictionary or the `id` field isn't a valid UUID string.
+    /// Missing rect fields default to a `.zero` source rect — the caller
+    /// then falls back to tap-location anchoring for the presenter.
+    static func parseHighlightTapMessage(_ body: Any) -> ReaderHighlightTapEvent? {
+        guard let dict = body as? [String: Any] else { return nil }
+        guard let idString = dict["id"] as? String,
+              let id = UUID(uuidString: idString) else { return nil }
+        let rectX = doubleValue(dict["rectX"]) ?? 0
+        let rectY = doubleValue(dict["rectY"]) ?? 0
+        let rectWidth = doubleValue(dict["rectWidth"]) ?? 0
+        let rectHeight = doubleValue(dict["rectHeight"]) ?? 0
+        let rect = CGRect(x: rectX, y: rectY, width: rectWidth, height: rectHeight)
+        return ReaderHighlightTapEvent(highlightID: id, sourceRect: rect)
+    }
+
     // MARK: - Anchor Construction
 
     /// Creates an EPUB AnnotationAnchor from href, CFI, and serialized range.

--- a/vreader/Views/Reader/EPUBHighlightJS.swift
+++ b/vreader/Views/Reader/EPUBHighlightJS.swift
@@ -162,6 +162,14 @@ extension EPUBHighlightBridge {
         // overlayer as a fallback for older WebKit (pre-iOS 17.2) where the
         // CSS Highlight API isn't available.
 
+        // Feature #53 WI-4: registry of {id → Range} for tap-on-highlight
+        // hit-testing. Populated by `__vreader_createHighlight`, cleared by
+        // `__vreader_removeHighlight` / `__vreader_clearAllHighlights`.
+        // The click listener below uses it to map a tap point to a
+        // highlight UUID without going through CSS.highlights (which
+        // doesn't expose Range membership in a tap-time-cheap way).
+        window.__vreader_highlightRanges = window.__vreader_highlightRanges || {};
+
         window.__vreader_createHighlight = function(id, startPath, startOffset, endPath, endOffset, color) {
             var range = buildRange(startPath, startOffset, endPath, endOffset);
             if (!range) return;
@@ -179,6 +187,9 @@ extension EPUBHighlightBridge {
                         style.textContent = '::highlight(vreader-' + id + ') { background-color: ' + cssColor + '; }';
                         document.head.appendChild(style);
                     }
+                    // WI-4: remember the live Range so the click handler
+                    // can hit-test against it.
+                    window.__vreader_highlightRanges[id] = range;
                     return;
                 } catch (e) { /* fall through to SVG Overlayer */ }
             }
@@ -191,6 +202,9 @@ extension EPUBHighlightBridge {
                         window.__foliate.Overlayer.highlight,
                         { color: cssColor }
                     );
+                    // WI-4: registry tracks fallback ranges too so the
+                    // click hit-test works on older WebKit.
+                    window.__vreader_highlightRanges[id] = range;
                 } catch (e) {}
             }
         };
@@ -206,6 +220,9 @@ extension EPUBHighlightBridge {
                 var styleEl = document.getElementById('vreader-hl-style-' + id);
                 if (styleEl) styleEl.remove();
             }
+            // WI-4: drop the registry entry so a deleted highlight stops
+            // being tap-targetable.
+            delete window.__vreader_highlightRanges[id];
         };
 
         window.__vreader_clearAllHighlights = function() {
@@ -222,7 +239,78 @@ extension EPUBHighlightBridge {
                 document.querySelectorAll('style[id^="vreader-hl-style-"]')
                     .forEach(function(s) { s.remove(); });
             }
+            // WI-4: drop ALL registry entries on chapter swap / book swap.
+            window.__vreader_highlightRanges = {};
         };
+
+        // Feature #53 WI-4: tap-on-highlight click listener.
+        // Uses capture-phase + caretPositionFromPoint to identify the
+        // tapped position, then walks the registry in reverse insert
+        // order (most-recent paint wins on overlap). On hit, posts a
+        // {id, rect} payload to Swift and stops propagation so the
+        // outer chrome-toggle listener does NOT also fire. Footnote
+        // links are checked first via `e.target.closest('a[href]')` —
+        // tapping a highlighted link still navigates the anchor.
+        document.addEventListener('click', function(e) {
+            // Don't intercept link clicks — those go to the existing
+            // footnote handler / default-anchor navigation.
+            if (e.target.closest('a[href]')) return;
+            var ids = Object.keys(window.__vreader_highlightRanges);
+            if (ids.length === 0) return;
+            // Locate caret at tap point. Use caretPositionFromPoint
+            // (standard) with caretRangeFromPoint (WebKit legacy) as a
+            // fallback.
+            var hitNode = null;
+            var hitOffset = 0;
+            try {
+                if (document.caretPositionFromPoint) {
+                    var cp = document.caretPositionFromPoint(e.clientX, e.clientY);
+                    if (cp) { hitNode = cp.offsetNode; hitOffset = cp.offset; }
+                } else if (document.caretRangeFromPoint) {
+                    var cr = document.caretRangeFromPoint(e.clientX, e.clientY);
+                    if (cr) { hitNode = cr.startContainer; hitOffset = cr.startOffset; }
+                }
+            } catch (err) { return; }
+            if (!hitNode) return;
+            // Build a degenerate range at the tap point so we can use
+            // Range.compareBoundaryPoints for membership testing.
+            var probe;
+            try {
+                probe = document.createRange();
+                probe.setStart(hitNode, hitOffset);
+                probe.setEnd(hitNode, hitOffset);
+            } catch (err) { return; }
+            for (var i = ids.length - 1; i >= 0; i--) {
+                var id = ids[i];
+                var range = window.__vreader_highlightRanges[id];
+                if (!range) continue;
+                try {
+                    // probe ∈ [range.start, range.end] iff:
+                    //   range.start <= probe.start  AND  range.end >= probe.start
+                    var startVsProbe = range.compareBoundaryPoints(Range.START_TO_START, probe);
+                    var endVsProbe = range.compareBoundaryPoints(Range.END_TO_START, probe);
+                    if (startVsProbe <= 0 && endVsProbe >= 0) {
+                        var rect;
+                        try { rect = range.getBoundingClientRect(); } catch (err2) {}
+                        var payload = { id: id };
+                        if (rect) {
+                            payload.rectX = rect.x;
+                            payload.rectY = rect.y;
+                            payload.rectWidth = rect.width;
+                            payload.rectHeight = rect.height;
+                        }
+                        try {
+                            window.webkit.messageHandlers.highlightTapHandler
+                                .postMessage(payload);
+                        } catch (err2) {}
+                        // Stop the chrome-toggle handler from also firing.
+                        e.stopImmediatePropagation();
+                        e.preventDefault();
+                        return;
+                    }
+                } catch (err) { /* skip stale Range entries */ }
+            }
+        }, true);
 
         // === Footnote Detection: intercept link clicks ===
 

--- a/vreader/Views/Reader/EPUBReaderContainerView.swift
+++ b/vreader/Views/Reader/EPUBReaderContainerView.swift
@@ -365,6 +365,10 @@ struct EPUBReaderContainerView: View {
                 pendingSelectionEvent = event
                 showHighlightSheet = true
             },
+            highlightActionPresenter: UIKitHighlightActionPresenter(),
+            onHighlightTapAction: { [highlightCoordinator] action, id in
+                await highlightCoordinator?.handleTapAction(action, highlightID: id)
+            },
             onPageDidFinishLoad: { evaluateJS in
                 restoreHighlightsOnLoad(evaluateJS: evaluateJS)
             },

--- a/vreader/Views/Reader/EPUBWebViewBridge.swift
+++ b/vreader/Views/Reader/EPUBWebViewBridge.swift
@@ -86,6 +86,14 @@ struct EPUBWebViewBridge: UIViewRepresentable {
     let onLoadError: @MainActor (String) -> Void
     /// Called when the user selects text in the EPUB content.
     var onSelectionEvent: (@MainActor (ReaderSelectionEvent) -> Void)?
+    /// Feature #53 WI-4: inline tap-on-highlight menu presenter. When
+    /// nil, only the `.readerHighlightTapped` notification fires when
+    /// the user taps a highlight; the menu does not appear.
+    var highlightActionPresenter: (any HighlightActionPresenting)?
+    /// Feature #53 WI-4: action callback routed through the
+    /// HighlightCoordinator. When nil, the menu (if shown) has no
+    /// effect; this matches the dormant infra contract from WI-1.
+    var onHighlightTapAction: ((HighlightTapAction, UUID) async -> Void)?
     /// Called after a page finishes loading (for highlight restoration).
     /// The closure receives a JS evaluator that runs JavaScript on the WKWebView.
     var onPageDidFinishLoad: (@MainActor (@escaping (String) -> Void) -> Void)?
@@ -159,6 +167,10 @@ struct EPUBWebViewBridge: UIViewRepresentable {
         userContentController.add(weakHandler, name: "selectionChanged")
         // Footnote detection handler (foliate-js)
         userContentController.add(weakHandler, name: "footnoteHandler")
+        // Feature #53 WI-4: tap-on-highlight handler. Receives
+        // `{id, rect}` payloads when the user taps an existing
+        // highlight in the EPUB WKWebView.
+        userContentController.add(weakHandler, name: "highlightTapHandler")
 
         let highlightScript = WKUserScript(
             source: EPUBHighlightBridge.highlightAPIJS,
@@ -194,6 +206,8 @@ struct EPUBWebViewBridge: UIViewRepresentable {
         context.coordinator.readerToken = readerToken
         #endif
         context.coordinator.onSelectionEvent = onSelectionEvent
+        context.coordinator.highlightActionPresenter = highlightActionPresenter
+        context.coordinator.onHighlightTapAction = onHighlightTapAction
         context.coordinator.onPageDidFinishLoad = onPageDidFinishLoad
         context.coordinator.isPaged = isPaged
         context.coordinator.previousIsPaged = isPaged
@@ -218,6 +232,8 @@ struct EPUBWebViewBridge: UIViewRepresentable {
         context.coordinator.readerToken = readerToken
         #endif
         context.coordinator.onSelectionEvent = onSelectionEvent
+        context.coordinator.highlightActionPresenter = highlightActionPresenter
+        context.coordinator.onHighlightTapAction = onHighlightTapAction
         context.coordinator.onPageDidFinishLoad = onPageDidFinishLoad
         context.coordinator.isPaged = isPaged
         context.coordinator.onPaginationReady = onPaginationReady

--- a/vreader/Views/Reader/EPUBWebViewBridgeCoordinator.swift
+++ b/vreader/Views/Reader/EPUBWebViewBridgeCoordinator.swift
@@ -60,6 +60,15 @@ extension EPUBWebViewBridge {
         #endif
         /// Callback for text selection events.
         var onSelectionEvent: (@MainActor (ReaderSelectionEvent) -> Void)?
+        /// Feature #53 WI-4: presenter that shows the inline tap-on-
+        /// highlight menu when the user taps an existing highlight in the
+        /// EPUB WKWebView. When nil, only the `.readerHighlightTapped`
+        /// notification fires.
+        var highlightActionPresenter: (any HighlightActionPresenting)?
+        /// Feature #53 WI-4: callback that routes the user's chosen action
+        /// through the coordinator. When nil, the presenter's result has
+        /// nowhere to go and the menu acts as a discoverability cue only.
+        var onHighlightTapAction: ((HighlightTapAction, UUID) async -> Void)?
         /// Callback to restore highlights after page loads.
         /// Provides a JS evaluator so the container can inject restore scripts.
         var onPageDidFinishLoad: (@MainActor (@escaping (String) -> Void) -> Void)?
@@ -96,10 +105,39 @@ extension EPUBWebViewBridge {
                 handleFootnoteMessage(message.body)
                 return
             }
+            if message.name == "highlightTapHandler" {
+                handleHighlightTapMessage(message.body, webView: message.webView)
+                return
+            }
             guard message.name == "progressHandler",
                   let progress = message.body as? Double else { return }
             Task { @MainActor in
                 onProgressChange(progress)
+            }
+        }
+
+        /// Feature #53 WI-4: parse a `{id, rect}` payload from the
+        /// JS `highlightTapHandler` channel, post the cross-format
+        /// `.readerHighlightTapped` notification, and (when wired)
+        /// show the inline action menu + route the chosen action
+        /// through the coordinator's `onHighlightTapAction` callback.
+        private func handleHighlightTapMessage(_ body: Any, webView: WKWebView?) {
+            guard let event = EPUBHighlightBridge.parseHighlightTapMessage(body)
+            else { return }
+            Task { @MainActor in
+                NotificationCenter.default.post(
+                    name: .readerHighlightTapped, object: event
+                )
+                if let presenter = highlightActionPresenter,
+                   let onAction = onHighlightTapAction,
+                   let webView {
+                    presenter.present(for: event, in: webView) { action in
+                        guard let action else { return }
+                        Task { @MainActor in
+                            await onAction(action, event.highlightID)
+                        }
+                    }
+                }
             }
         }
 

--- a/vreader/Views/Reader/EPUBWebViewBridgeJS.swift
+++ b/vreader/Views/Reader/EPUBWebViewBridgeJS.swift
@@ -142,6 +142,12 @@ extension EPUBWebViewBridge {
         webView.configuration.userContentController.removeScriptMessageHandler(
             forName: "footnoteHandler"
         )
+        // Feature #53 WI-4: matching teardown for the highlight-tap handler
+        // added at makeUIView. Skipping this leaks the WKScriptMessageHandler
+        // proxy retainment per Bug #109's investigation.
+        webView.configuration.userContentController.removeScriptMessageHandler(
+            forName: "highlightTapHandler"
+        )
     }
 
     // MARK: - JavaScript

--- a/vreaderTests/Views/Reader/EPUBHighlightTapBridgeTests.swift
+++ b/vreaderTests/Views/Reader/EPUBHighlightTapBridgeTests.swift
@@ -1,0 +1,145 @@
+// Purpose: Tests for `EPUBHighlightBridge.parseHighlightTapMessage` and
+// the click-handler injection in `EPUBHighlightJS.highlightAPIJS`.
+// Feature #53 WI-4 / GH #596. Verifies the JS → Swift payload contract
+// for tap-on-highlight in EPUB: the JS side hit-tests a click against
+// the registered highlight Range map and posts a `{id, rect}` payload;
+// the Swift side parses it into a `ReaderHighlightTapEvent` that the
+// reader's modifier consumes.
+//
+// @coordinates-with: EPUBHighlightBridge.swift, EPUBHighlightJS.swift,
+//   EPUBWebViewBridgeCoordinator.swift, ReaderNotifications.swift
+
+import Testing
+import Foundation
+import CoreGraphics
+@testable import vreader
+
+@Suite("EPUBHighlightTapBridge — parser")
+struct EPUBHighlightTapBridgeParserTests {
+
+    @Test
+    func parseHighlightTapMessage_validPayload_returnsEvent() {
+        let id = UUID()
+        let body: [String: Any] = [
+            "id": id.uuidString,
+            "rectX": 12.5,
+            "rectY": 80.0,
+            "rectWidth": 96.0,
+            "rectHeight": 22.0
+        ]
+        guard let event = EPUBHighlightBridge.parseHighlightTapMessage(body) else {
+            Issue.record("Expected non-nil event for valid payload")
+            return
+        }
+        #expect(event.highlightID == id)
+        #expect(event.sourceRect == CGRect(x: 12.5, y: 80, width: 96, height: 22))
+    }
+
+    @Test
+    func parseHighlightTapMessage_acceptsIntegerCoordinates() {
+        // WebKit sometimes serializes integer rect values as NSNumber-int
+        // rather than NSNumber-double. The parser must accept both.
+        let id = UUID()
+        let body: [String: Any] = [
+            "id": id.uuidString,
+            "rectX": 10,
+            "rectY": 80,
+            "rectWidth": 96,
+            "rectHeight": 22
+        ]
+        guard let event = EPUBHighlightBridge.parseHighlightTapMessage(body) else {
+            Issue.record("Expected non-nil event for integer coordinates")
+            return
+        }
+        #expect(event.highlightID == id)
+        #expect(event.sourceRect == CGRect(x: 10, y: 80, width: 96, height: 22))
+    }
+
+    @Test
+    func parseHighlightTapMessage_missingId_returnsNil() {
+        let body: [String: Any] = [
+            "rectX": 12.5, "rectY": 80, "rectWidth": 96, "rectHeight": 22
+        ]
+        #expect(EPUBHighlightBridge.parseHighlightTapMessage(body) == nil)
+    }
+
+    @Test
+    func parseHighlightTapMessage_invalidUUID_returnsNil() {
+        let body: [String: Any] = [
+            "id": "not-a-uuid",
+            "rectX": 12.5, "rectY": 80, "rectWidth": 96, "rectHeight": 22
+        ]
+        #expect(EPUBHighlightBridge.parseHighlightTapMessage(body) == nil)
+    }
+
+    @Test
+    func parseHighlightTapMessage_nonDictBody_returnsNil() {
+        // WebKit can pass strings, arrays, or NSNull when JS forgets to
+        // serialize properly. The parser must reject anything that isn't
+        // a `[String: Any]`.
+        #expect(EPUBHighlightBridge.parseHighlightTapMessage("not a dict") == nil)
+        #expect(EPUBHighlightBridge.parseHighlightTapMessage(NSNull()) == nil)
+        #expect(EPUBHighlightBridge.parseHighlightTapMessage([1, 2, 3]) == nil)
+    }
+
+    @Test
+    func parseHighlightTapMessage_missingRect_defaultsToZero() {
+        // A click handler that fails to compute getBoundingClientRect
+        // (e.g. range collapsed after style change) should still post
+        // the `id`; the parser accepts missing rect fields and yields
+        // a `.zero` source rect. Caller falls back to tap-location
+        // anchoring in this case.
+        let id = UUID()
+        let body: [String: Any] = ["id": id.uuidString]
+        guard let event = EPUBHighlightBridge.parseHighlightTapMessage(body) else {
+            Issue.record("Expected non-nil event when rect fields are missing")
+            return
+        }
+        #expect(event.highlightID == id)
+        #expect(event.sourceRect == .zero)
+    }
+}
+
+@Suite("EPUBHighlightTapBridge — JS bundle wiring")
+struct EPUBHighlightTapBridgeJSTests {
+
+    @Test
+    func highlightAPIJS_containsClickListenerRegistration() {
+        // The JS bundle must wire a click listener that the
+        // `__vreader_highlightRanges` registry can be hit-tested
+        // against. Asserting the literal substring is brittle by
+        // design — if the marker changes, the test fails and the
+        // author is forced to update both the production code and
+        // this guard (which mirrors EPUBHighlightBridge's
+        // selectionTrackingJS guards).
+        let js = EPUBHighlightBridge.highlightAPIJS
+        #expect(js.contains("__vreader_highlightRanges"))
+        #expect(js.contains("highlightTapHandler"))
+        #expect(js.contains("caretPositionFromPoint") || js.contains("caretRangeFromPoint"))
+    }
+
+    @Test
+    func highlightAPIJS_createHighlightStoresRangeInRegistry() {
+        // The create function must populate the registry; otherwise
+        // the click handler has nothing to hit-test against.
+        let js = EPUBHighlightBridge.highlightAPIJS
+        #expect(js.contains("__vreader_highlightRanges["))
+    }
+
+    @Test
+    func highlightAPIJS_removeHighlightClearsRegistryEntry() {
+        // Remove must also delete the registry entry — otherwise a
+        // deleted highlight stays tap-targetable, and the user's
+        // delete action fires against a stale paint.
+        let js = EPUBHighlightBridge.highlightAPIJS
+        #expect(js.contains("delete window.__vreader_highlightRanges"))
+    }
+
+    @Test
+    func highlightAPIJS_clearAllHighlightsResetsRegistry() {
+        // ClearAll (called on chapter change / book switch) must also
+        // reset the registry to avoid cross-chapter stale entries.
+        let js = EPUBHighlightBridge.highlightAPIJS
+        #expect(js.contains("window.__vreader_highlightRanges = {}"))
+    }
+}


### PR DESCRIPTION
## Summary

Feature #53 WI-4 — tap-on-highlight support in the EPUB `WKWebView`. JS-side registry of `{id → Range}` + capture-phase click listener uses `caretPositionFromPoint` to identify the tapped highlight; Swift-side parser + coordinator route the event through the WI-1 presenter protocol + WI-2/WI-3 coordinator handler.

Part of feature #596

## What Changed

### Production code

- `EPUBHighlightJS.swift`: `__vreader_highlightRanges` registry maintained by create/remove/clearAll. Capture-phase click listener walks the registry in reverse insert order on `caretPositionFromPoint` hit; posts `{id, rect}` payload to a new `highlightTapHandler` WKScriptMessage channel; calls `stopImmediatePropagation + preventDefault` on hit (chrome-toggle does not also fire). Link clicks (`a[href]`) early-return so footnote navigation is preserved.
- `EPUBHighlightBridge.swift`: `parseHighlightTapMessage` decodes the payload into `ReaderHighlightTapEvent`. Handles missing rect fields (`.zero` fallback), non-dict bodies, invalid UUIDs, and WebKit's int-vs-double coordinate quirk.
- `EPUBWebViewBridge.swift`: 2 new bridge fields (`highlightActionPresenter`, `onHighlightTapAction`) threaded through `makeUIView`/`updateUIView` into the Coordinator. `highlightTapHandler` registered + torn down symmetrically in `EPUBWebViewBridgeJS.dismantleUIView` so the handler proxy doesn't leak.
- `EPUBWebViewBridgeCoordinator.swift`: `handleHighlightTapMessage` posts `.readerHighlightTapped`, presents inline menu when wired, awaits the action callback.
- `EPUBReaderContainerView.swift`: passes `UIKitHighlightActionPresenter()` + `[highlightCoordinator]`-capturing closure (same shape as WI-2/WI-3 for TXT/MD).

### Tests

- 10 Swift Testing methods in `vreaderTests/Views/Reader/EPUBHighlightTapBridgeTests.swift`:
  - 6 parser tests: valid payload, integer-coordinates quirk, missing-id, invalid-UUID, non-dict body, missing-rect-defaults-to-zero.
  - 4 JS-source-string guards: click-listener registration markers, create populates registry, remove deletes entry, clearAll resets registry.

## WI Status

- WI-4 EPUB: behavioral, not final — this PR
- Remaining WIs: WI-5 (AZW3/Foliate — regression fix for the existing `.readerHighlightRequested` misuse), WI-6 (PDF — final WI, flips feature row to DONE)

## Codex Audit (Gate 4)

Manual-fallback (per saved feedback: Codex audit-time exceeds cron-iteration budget). Round 1 → ship-as-is.

One Low / deferred follow-up: `EPUBHighlightJS.swift` is ~414 lines after this WI; split candidate `EPUBHighlightJS+TapOnHighlight.swift` logged for the WI-5/cleanup pass.

Audit log: `.claude/codex-audits/feat-feature-53-wi-4-epub-tap-on-highlight-audit.md`

## Validation

- [x] `xcodebuild test -only-testing:vreaderTests` — new suite (10 methods) passes; all tap-on-highlight suites green; no new failures elsewhere.
- [x] Tests cover changed behavior (TDD: RED → GREEN)
- [x] Manual-fallback Codex audit completed (1 iteration, verdict: ship-as-is)
- [x] Docs sync — n/a (no new service / actor / `@Model` / `Notification.Name` / cross-feature pattern; this WI extends the tap-on-highlight infrastructure from WI-1 to a new format, matching the documented pattern)
- [x] Version bumped: 3.22.15 → 3.22.16

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: **behavioral, not final** — slice verified via parser unit tests against valid + invalid payloads, plus JS-source-string guards proving the registry + click listener are wired in the bundle. Live WKWebView gesture path uses the same `addEventListener` + `WKScriptMessageHandler` infrastructure already proven by the existing `footnoteHandler` (production) + `selectionChanged` (production) channels. Full end-to-end tap-on-highlight device-verify deferred to the final WI's Gate 5b acceptance pass.

## Type of Change

- [x] Feature WI (Part of feature #596 — intermediate WI, plain prose link not `Refs #N` to avoid the open-feature merge-gate block)