### PR TITLE
feat(#60 WI-3): foundational popover types (AccentColor, NamedHighlightColor, SelectionPopoverAction)

### DIFF
--- a/.claude/codex-audits/feat-feature-60-wi-3-popover-types-audit.md
+++ b/.claude/codex-audits/feat-feature-60-wi-3-popover-types-audit.md
@@ -1,0 +1,80 @@
+---
+branch: feat/feature-60-wi-3-popover-types
+threadId: 019e2d7a-7159-7b70-a703-4a2ac399ea88
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-05-16
+---
+
+# Codex Gate 4 implementation audit — Feature #60 WI-3 (foundational popover types)
+
+Per `.claude/rules/47-feature-workflow.md` Gate 4. Audit of the three
+new value types lifted out of WI-4 (SelectionPopover) so the popover
+view in later WIs is authored against a stable, audited surface.
+
+## Scope
+
+Branch: `feat/feature-60-wi-3-popover-types`
+
+Files changed (all new):
+
+- `vreader/Models/NamedHighlightColor.swift`
+- `vreader/Models/SelectionPopoverAction.swift`
+- `vreader/Models/AccentColor.swift`
+- `vreaderTests/Models/NamedHighlightColorTests.swift`
+- `vreaderTests/Models/SelectionPopoverActionTests.swift`
+- `vreaderTests/Models/AccentColorTests.swift`
+
+Plan reference: `dev-docs/plans/20260515-feature-60-visual-identity-v2.md`.
+
+## Round 1 findings
+
+Zero Critical / High / Medium. Three Low findings + one plan-doc drift note.
+
+| # | file:line | severity | issue | resolution |
+|---|---|---|---|---|
+| 1 | `vreaderTests/Models/NamedHighlightColorTests.swift:7` | Low | Header comment claimed the compatibility test "proves the storage boundary is preserved" but the test only exercises `from(storageString:)` on literals — does not touch `Highlight.color`, `HighlightRecord.color`, backup DTO encode/decode, or export/import DTOs. | **Reworded** the header to say the test pins decode behavior, not storage-boundary preservation. The storage guarantee lives in the design of those files (still raw `String`) and in Codex Gate 2 plan audit. |
+| 2 | `vreaderTests/Models/NamedHighlightColorTests.swift:91` | Low | Detailed comment block above `compatibility_existingStorageStringsRemainValidAndUnaltered` over-claimed in the same way. | **Reworded** to "pin the decode contract of `from(storageString:)`", added an explicit caveat that schema narrowing is caught by Gate 2 plan audit, not this unit test. |
+| 3 | `vreaderTests/Models/AccentColorTests.swift:17` | Low | Pins hex values but didn't pin enum exhaustiveness — a future fourth case wouldn't fail the existing tests. | **Added** `CaseIterable` conformance to `AccentColor` + two new tests: `allCases_containsExactlyThreeStops` and `exhaustiveSwitch_handlesEveryStop`. |
+| — | `dev-docs/plans/20260515-feature-60-visual-identity-v2.md:257` | Note (non-blocking) | Plan doc still showed `NamedHighlightColor.yellow.hex == "#fff3a3"` — outdated against the design bundle (`#f0d25a`). | **Fixed** to `#f0d25a`, added the other three colors inline. |
+
+## Round 2 findings
+
+Zero Critical / High / Medium. One Low.
+
+| # | file:line | severity | issue | resolution |
+|---|---|---|---|---|
+| 1 | `dev-docs/plans/20260515-feature-60-visual-identity-v2.md:261` | Low | WI-3 test-catalog bullet still described a compatibility test that round-trips through `Highlight.color = ... → fetch → from(storageString:)`. Actual test is decode-only. | **Reworded** to "Decode-contract pin" matching what the implementation does, with explicit caveat that storage-type narrowing is caught by Gate 2 plan audit. |
+
+## Round 3 verification
+
+Codex final verdict (quoted from thread `019e2d7a-7159-7b70-a703-4a2ac399ea88`):
+
+> Gate 4 final verdict: clean. Zero open Critical/High/Medium findings,
+> and no remaining Low findings in the audited WI-3 implementation
+> files. The final plan wording now matches the implemented
+> `NamedHighlightColor` test, the additive storage boundary remains
+> intact, and the type/test surfaces are consistent with the revised
+> plan v2.
+
+## Cross-checks performed by Codex
+
+- Hex drift: `SelectionPopover.colorMap` in `dev-docs/designs/vreader-fidelity-v1/project/vreader-reader.jsx:441` matches `NamedHighlightColor` (`yellow #f0d25a`, `pink #e88ca0`, `green #8cc88c`, `blue #8cb4e8`).
+- AccentColor stops match Feature #60's row in `docs/features.md:101` (`#8c2f2f` / `#d6885a` / `#e8b465`).
+- Storage boundary preserved: `Highlight.color`, `HighlightRecord.color`, `BackupHighlight.color`, and `ExportedAnnotation.color` all remain raw `String` / `String?`.
+
+## Test gate
+
+```
+xcodebuild test -only-testing:vreaderTests/NamedHighlightColorTests \
+                -only-testing:vreaderTests/SelectionPopoverActionTests \
+                -only-testing:vreaderTests/AccentColorTests
+```
+
+Result: 15 tests in 3 suites, all passing. ** TEST SUCCEEDED **
+
+Broader `vreaderTests` suite shows pre-existing failures (BookFormatAZW3Tests = Bug #200; BookSourceHTTPClientTests + ReplacementTransformTests untouched by this diff) — none introduced by WI-3.
+
+## Summary verdict
+
+**Ship-as-is.** Gate 4 clean after 3 rounds; all Low findings closed with reworded test comments + plan doc, plus the AccentColor exhaustiveness pins. No code-correctness issues, no storage-boundary changes, no Swift 6 concurrency issues, no security surface.

--- a/dev-docs/plans/20260515-feature-60-visual-identity-v2.md
+++ b/dev-docs/plans/20260515-feature-60-visual-identity-v2.md
@@ -50,6 +50,20 @@ persistence, search, WebDAV, or AI is in scope.
   `case highlight(NamedHighlightColor) | note | translate | askAI | read`.
   `NamedHighlightColor` is one of yellow/pink/green/blue (the row
   contract specifies four).
+- **`vreader/Models/NamedHighlightColor.swift`** (new) —
+  `enum NamedHighlightColor: String, Codable, CaseIterable, Sendable`
+  with `rawValue` = semantic name (`"yellow"|"pink"|"green"|"blue"`).
+  Derived `hex` property (computed, not the rawValue) returns the
+  design bundle's exact hex values per `vreader-reader.jsx:SelectionPopover`
+  (`#f0d25a` / `#e88ca0` / `#8cc88c` / `#8cb4e8`). **Additive only**: this is
+  a UI-domain enum. It does NOT replace the existing `String color`
+  schema in `Highlight.color` / `HighlightRecord.color` / backup DTOs
+  / export-import payloads — those continue to store raw strings.
+  Conversion helpers: `init?(rawValue:)` (the Codable default) and
+  `static func from(storageString:) -> Self?` (best-effort decode of
+  the existing yellow-default + future named colors). Codex Gate 2
+  finding (round 1, High): keep additive, do not narrow the existing
+  String boundary.
 - **`vreader/Views/Reader/SelectionPopoverView.swift`** (new) —
   SwiftUI view that REPLACES the current `HighlightableTextView`
   4-item UIMenu for the **new-selection-from-long-press** flow only.
@@ -200,7 +214,7 @@ audit log + version bump per rule 40.
 |----|------|-----------|---------|
 | WI-1 | Foundational | Bundle Source Serif 4 + Inter fonts in `vreader/Resources/Fonts/`. Add `ReaderTypography` registry. Extend `ReaderFontFamily` with `.sourceSerif4` and `.inter`. **No view change** — dormant infra. Tests: registry load, fontDescriptor availability, fallback chain. | ~6 files, ~250 LOC (font binary excluded) |
 | WI-2 | Foundational | Add `ReaderThemeV2` enum + 9-token surface. Migration alias on `ReaderTheme` so existing persisted choices still decode. **No view change** — dormant infra. Tests: token round-trip, isDark predicate, migration alias, accent contrast against ink (WCAG AA per theme). | ~4 files, ~300 LOC |
-| WI-3 | Foundational | Add `AccentColor`, `NamedHighlightColor`, `SelectionPopoverAction` types. **No view change** — dormant infra. Tests: enum exhaustiveness, Codable round-trip. | ~3 files, ~120 LOC |
+| WI-3 | Foundational | Add `AccentColor`, `NamedHighlightColor`, `SelectionPopoverAction` types as UI-domain enums. **Additive only** (Codex Gate 2 finding): does NOT change the existing `Highlight.color` / `HighlightRecord.color` / backup DTO / export-import `String` schema. `NamedHighlightColor` raw values are semantic names; hex is a derived computed property. `SelectionPopoverAction` is `Equatable + Sendable` (NOT Codable — it's local-dispatch only, not persisted). `AccentColor` is a token-only struct with three named stops (light/warm-dark/photo). **No view change** — dormant infra. Tests: exhaustive switch, raw-value-is-semantic-name, derived-hex round-trip, compatibility (existing color strings remain storable + decodable to nil for unknown values), `from(storageString:)` round-trip. | ~3 files (4 if `NamedHighlightColor.swift` split out), ~150 LOC |
 | WI-4 | Behavioral | EPUB theme injection switches to `ReaderThemeV2`. `epubOverrideCSS` emits five-theme CSS + new token names. Existing EPUB books re-render with new visual tokens. Migration path: existing `epubTheme: .light/.sepia/.dark` continues to decode and maps to `.paper/.sepia/.dark`. Photo theme injects a `body { background-image: url(...) }` rule. Tests: CSS string assertions per theme + per-theme accent contrast. Device verify (Gate 5a): open mini-epub3 fixture per theme, confirm visually. | ~3 files, ~250 LOC |
 | WI-5 | Behavioral | TXT + MD theme injection switches to `ReaderThemeV2`. `TXTViewConfig` reads `ReaderTypography.body(for:)` instead of hard-coded Georgia. Tests: config round-trip, attributed-string font resolution. Device verify (Gate 5a): open seeded MD multi-page fixture per theme. | ~4 files, ~220 LOC |
 | WI-6 | Behavioral | Reader chrome re-skin (top bar + bottom bar + page indicator + scrubber) shared across TXT/MD/EPUB containers. Edges-tap-flip / middle-tap-toggle-chrome convention. **Cross-ref**: aligns with feature #25 tap zones; verify whether bug #165 closes as a side effect (file follow-up if not). Tests: chrome-toggle gesture routing; tap-zone hit-test boundaries (33% / 33% / 33% split per design). Device verify: tap each zone, confirm advance / toggle / advance behavior. | ~6 files, ~400 LOC |
@@ -237,10 +251,21 @@ not counted; ~5MB asset).
 
 ### WI-3 (foundational popover types)
 
-- `NamedHighlightColorTests` — exhaustive switch (compile-time
-  guarantee), Codable round-trip, hex value round-trip.
-- `SelectionPopoverActionTests` — Sendable + Equatable, exhaustive
-  switch for the WI-7 handler.
+- `NamedHighlightColorTests`:
+  - **exhaustive switch** (compile-time guarantee via CaseIterable count).
+  - **raw value is semantic name** — `NamedHighlightColor.yellow.rawValue == "yellow"`, etc. Pinned because the rawValue IS the storage contract for the UI domain.
+  - **derived hex** — `NamedHighlightColor.yellow.hex == "#f0d25a"` and the other three colors pinned to the exact design bundle values (`pink #e88ca0`, `green #8cc88c`, `blue #8cb4e8`).
+  - **Codable round-trip** through the semantic-name rawValue.
+  - **`from(storageString:)` happy path** — passing `"yellow"` returns `.yellow`; passing `"pink"`/`"green"`/`"blue"` returns the matching case.
+  - **`from(storageString:)` unknown input** — passing `"red"`, `""`, `"#ff0000"`, `nil`-equivalent returns nil (does NOT coerce or default to `.yellow`; that's the caller's policy decision).
+  - **Decode-contract pin** (Codex Gate 2 finding, Medium): `from(storageString:)` classifies historical and future raw `Highlight.color` strings correctly — `"yellow"`/`"pink"`/`"green"`/`"blue"` decode to the matching case; legacy hex (e.g. `"#fff3a3"`), empty string, and future custom names decode to `nil` (no silent coercion). Note: this is a decode-contract pin only; storage-type narrowing of `Highlight.color` / `HighlightRecord.color` / `BackupHighlight.color` / `ExportedAnnotation.color` is caught by Codex Gate 2 plan audit, not by the unit test.
+- `SelectionPopoverActionTests`:
+  - **Sendable + Equatable** (compile-time + behavior).
+  - **exhaustive switch** for the WI-7 handler.
+  - `SelectionPopoverAction` is intentionally NOT `Codable` (per Codex Gate 2 round 1: local dispatch only, not serialized).
+- `AccentColorTests`:
+  - Three named stops produce three distinct hex values matching the design (`#8c2f2f` / `#d6885a` / `#e8b465`).
+  - Sendable conformance (compile-time).
 
 ### WI-4 (EPUB theme injection)
 
@@ -496,3 +521,17 @@ category 2 (PLANNED feature with plan doc → Gate 3).
 
 - 2026-05-15 v1: initial draft + manual-fallback Gate 2 audit
   recorded inline.
+- 2026-05-16 v2: WI-3 section revised after Codex Gate 2 round 1
+  found 1 High (additive vs schema-narrowing risk over existing
+  `String`-typed `Highlight.color` boundary) + 1 Medium (test
+  catalogue should emphasize semantic-name rawValue + compatibility
+  with existing strings, not hex round-trip). Codex thread
+  `019e2d67-9219-71f1-9bda-ffaf13cb4e75`. Plan now specifies
+  `NamedHighlightColor` as a UI-domain additive enum with
+  `from(storageString:)` decoder and a derived `hex` property,
+  leaving `Highlight.color` / `HighlightRecord.color` / backup
+  DTOs / export-import payloads on the existing raw-`String`
+  schema. `SelectionPopoverAction` confirmed as
+  `Equatable + Sendable` only (not `Codable`). Test catalogue
+  expanded to 8 NamedHighlightColor tests + 3 SelectionPopoverAction
+  tests + 2 AccentColor tests.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 381
-        MARKETING_VERSION: 3.23.4
+        CURRENT_PROJECT_VERSION: 382
+        MARKETING_VERSION: 3.23.5
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -185,6 +185,7 @@
 		320025CDBC69B31CC1B4DEAA /* PDFReaderContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2BA1A05E4E36D5D7B2DCFD /* PDFReaderContainerView.swift */; };
 		32C58BAAF2DB529049921D4D /* OPDSParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C26DE0705F29A16D1919F5 /* OPDSParserTests.swift */; };
 		32D0866BC61D79BCAEF0A525 /* SyncServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB81DF32070BCFB6D8653800 /* SyncServiceTests.swift */; };
+		32D7C0D02816850ACA1BD3E9 /* SelectionPopoverActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6114D9038B37A9B437BDC9 /* SelectionPopoverActionTests.swift */; };
 		32F4E36941EDCA2C0D457777 /* ReaderNotificationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC7EBBBE07E87F07CC0FE4F /* ReaderNotificationHandlerTests.swift */; };
 		33226957615967F3FE36DD40 /* BookDownloadSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF6B274A7CA4B3240E60E9F /* BookDownloadSheet.swift */; };
 		33B874FB4BB17A21ACA4468E /* BookFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C3ECA5E8F6419DB347F2E4 /* BookFormat.swift */; };
@@ -268,6 +269,7 @@
 		48C743A0324468FF7507F157 /* RuleEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1A348FFCBCC9C7A5360C28 /* RuleEngineTests.swift */; };
 		4914FBDCD76FD1D972914081 /* VReaderAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60D19CA6B370181C8BF08270 /* VReaderAppDelegate.swift */; };
 		4930168887D85648F1EDA897 /* MigrationFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E394527455B13D1EE9B06A9 /* MigrationFixtures.swift */; };
+		495502CCD0035DB7C8AE37DA /* AccentColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8404837D8FC686DDDB62EEC3 /* AccentColorTests.swift */; };
 		497BE2970C924807C3451FA0 /* fixed-layout.js in Resources */ = {isa = PBXBuildFile; fileRef = C47343EAD4CE63CDA1604255 /* fixed-layout.js */; };
 		49D992E6F2DAB74CCD4FDC68 /* TokenSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D944728B17A940A3716EA9 /* TokenSpanTests.swift */; };
 		49E7475E7118E6366C0530E5 /* PersistentSearchIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25EC6B4A507BE08D646A4AD /* PersistentSearchIndexTests.swift */; };
@@ -314,6 +316,7 @@
 		57137EA065C2A4D12FFF3CBB /* BookSourceChapterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388862ACF8F83F9A1C8A6A6C /* BookSourceChapterListView.swift */; };
 		5774FF0387AC1349069791FE /* TextMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D7174921347E183EEB34A6 /* TextMapperTests.swift */; };
 		57E1462E66FEAA422A970FA5 /* AnthropicProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C6D6A8EC00DFFAC294DD87 /* AnthropicProvider.swift */; };
+		58132D890E317C57F2940579 /* SelectionPopoverAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5825B20D8E48C77A28E061A /* SelectionPopoverAction.swift */; };
 		581D8C5F46D4CAAD4DA31EF8 /* FoliateViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506F86FDA1498276D10E5E7B /* FoliateViewCoordinator.swift */; };
 		5895F86BFE58FBFBAA7D8424 /* SyncStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F6250C22449E7E83591620 /* SyncStatusView.swift */; };
 		58C066AA53EC9D61B9960E9B /* WebDAVServerProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54AC37DCD75A3993463AC297 /* WebDAVServerProfileTests.swift */; };
@@ -542,6 +545,7 @@
 		99A9048ACF04CA7FADB5F331 /* AIAssistantStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B35AC90256B2F4A696E3D2 /* AIAssistantStateTests.swift */; };
 		99B6840F5C6B54842C465F64 /* OPDSBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C9E438077E6D10199BA12CE /* OPDSBrowserView.swift */; };
 		9ADB90C99DECE18FE058ECD9 /* BookmarkRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D04AA64724C4F9A15869C20 /* BookmarkRecord.swift */; };
+		9AEE4782EDC4308FAA289B3B /* AccentColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13404BD286B135797ECF391A /* AccentColor.swift */; };
 		9AF587978D1D58F58C7E8A23 /* UnifiedTextRendererViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7056486BA460E0BE06235F54 /* UnifiedTextRendererViewModel.swift */; };
 		9B04DEA549D9C760DD6D3C3E /* BookSourceListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F971403A2807A2788FD2D99F /* BookSourceListView.swift */; };
 		9BF39FDF19F34D65452D4C79 /* WebDAVNetworkPolicyEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E2D1C060B3EF0B66847F23 /* WebDAVNetworkPolicyEnvironment.swift */; };
@@ -649,6 +653,7 @@
 		BD2207EF713FA796A840EF15 /* TextHighlightHitTesterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AD0B57E130DE8620C8AEC4 /* TextHighlightHitTesterTests.swift */; };
 		BDCFAEB3BDC0697448C8EF46 /* AccessibilityAuditHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12A029D167735B92A38BA7 /* AccessibilityAuditHelper.swift */; };
 		BE476BD45B5DABF049AAC45F /* AISettingsViewModelEditorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295EA8A8C9A0188CCD2416B4 /* AISettingsViewModelEditorTests.swift */; };
+		BE69CE7675864C497ACFC999 /* NamedHighlightColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1456DD6C03CD51C24CA8CDCF /* NamedHighlightColorTests.swift */; };
 		BF078E02438CF936C70DE746 /* SearchSheetPlaceholderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08710FD2531ABF39338B56E9 /* SearchSheetPlaceholderTests.swift */; };
 		BF7CA157DAD1516A4667641D /* TXTChunkedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02AA769AEDBC25CEA896348 /* TXTChunkedLoader.swift */; };
 		BF9767FD9DB988B04F1B27D5 /* SyncConflictResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF495D7A9D6F8F137DD42CE0 /* SyncConflictResolverTests.swift */; };
@@ -750,6 +755,7 @@
 		D9C467679B15F5EAA982BBF4 /* TXTLazyTextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43249E51E02F89BD8EAA7288 /* TXTLazyTextProviderTests.swift */; };
 		DA095389BA6B62A7BDC8FFB0 /* ProviderProfileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E58A8977DC02FDA7235A9E /* ProviderProfileStore.swift */; };
 		DA591D01C344F30E712DC755 /* HighlightTapActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E21EE7F803135D340D7F507 /* HighlightTapActionTests.swift */; };
+		DA5EF0C28F9B3F8C71A6E9C5 /* NamedHighlightColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBAA3F90BD69DDACBE195884 /* NamedHighlightColor.swift */; };
 		DA905A71521E684A242CDCAD /* EPUBCoverParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F114D9F3F59EEF655D5327EA /* EPUBCoverParsingTests.swift */; };
 		DADE03AB3940ED9668FEF1B9 /* AIProviderPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 064AE6DC1BC56B9DD7CCA796 /* AIProviderPicker.swift */; };
 		DB124C9ED4026899BA0EFB2F /* ReplacementRulesViewBannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E509DAF691A7E473603452A /* ReplacementRulesViewBannerTests.swift */; };
@@ -944,11 +950,13 @@
 		117731FF4D8AE414141C5ECF /* ImportJobQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportJobQueue.swift; sourceTree = "<group>"; };
 		11D4AD419DD1123CDA21CCD0 /* ReflowableTextSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflowableTextSource.swift; sourceTree = "<group>"; };
 		11F6250C22449E7E83591620 /* SyncStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusView.swift; sourceTree = "<group>"; };
+		13404BD286B135797ECF391A /* AccentColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccentColor.swift; sourceTree = "<group>"; };
 		138AEC5BBAD52B075096E5C8 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		13A1A428419630E618721E37 /* UnifiedTextRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedTextRenderer.swift; sourceTree = "<group>"; };
 		13D1E2EE401D4C3053FB687A /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
 		14088AEC6B083B2C049AB25C /* ReaderAICoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderAICoordinator.swift; sourceTree = "<group>"; };
 		14418F18DF9D9A3B912AC090 /* SearchIndexCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchIndexCore.swift; sourceTree = "<group>"; };
+		1456DD6C03CD51C24CA8CDCF /* NamedHighlightColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamedHighlightColorTests.swift; sourceTree = "<group>"; };
 		151860CC8834DB8ACBF7E927 /* ZIPWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZIPWriter.swift; sourceTree = "<group>"; };
 		152689657913035E5579B762 /* CSSRuleEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSSRuleEvaluatorTests.swift; sourceTree = "<group>"; };
 		159BB4EBD79ECE6657D50EC1 /* LazyDownloadDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyDownloadDelegate.swift; sourceTree = "<group>"; };
@@ -1214,6 +1222,7 @@
 		5E270DE50F23F6125F3151CA /* PhaseBMediumAuditTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhaseBMediumAuditTests.swift; sourceTree = "<group>"; };
 		5E3AA514298AACD2F963913C /* TOCChapterProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOCChapterProgress.swift; sourceTree = "<group>"; };
 		5E3D2050D82A39083191EDDA /* LibraryBookItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryBookItem.swift; sourceTree = "<group>"; };
+		5E6114D9038B37A9B437BDC9 /* SelectionPopoverActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionPopoverActionTests.swift; sourceTree = "<group>"; };
 		5E72779818424BCA8025B0A0 /* BackupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupViewModel.swift; sourceTree = "<group>"; };
 		5E868FB040D93F83C745083C /* Feature36OPDSVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature36OPDSVerificationTests.swift; sourceTree = "<group>"; };
 		5EB15AD471389C6DEDDD0286 /* ReaderAuditFix3Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderAuditFix3Tests.swift; sourceTree = "<group>"; };
@@ -1334,6 +1343,7 @@
 		83B60F61628D0969B18B3A9B /* AIConsentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIConsentView.swift; sourceTree = "<group>"; };
 		83BCFD179C107F7E997AEB88 /* AnnotationImporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationImporterTests.swift; sourceTree = "<group>"; };
 		83F36EF81271874A13417D45 /* OPDSEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSEntryView.swift; sourceTree = "<group>"; };
+		8404837D8FC686DDDB62EEC3 /* AccentColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccentColorTests.swift; sourceTree = "<group>"; };
 		84BAC2CBFB7F533857E6A65B /* search_no_results.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = search_no_results.html; sourceTree = "<group>"; };
 		84E4ABD8F17B04EA35F23724 /* legado_multiple_sources.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = legado_multiple_sources.json; sourceTree = "<group>"; };
 		851277A5872045D4D935CE2B /* DictionaryLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryLookup.swift; sourceTree = "<group>"; };
@@ -1496,6 +1506,7 @@
 		B4FC46B472B8A5D69BD80220 /* EPUBReaderContainerView+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EPUBReaderContainerView+Navigation.swift"; sourceTree = "<group>"; };
 		B501E24B36BF00B609B04BF3 /* ReaderSearchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSearchCoordinator.swift; sourceTree = "<group>"; };
 		B56E5394E251AA0C42AE3557 /* TOCChapterProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOCChapterProgressTests.swift; sourceTree = "<group>"; };
+		B5825B20D8E48C77A28E061A /* SelectionPopoverAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionPopoverAction.swift; sourceTree = "<group>"; };
 		B58BA99C96063F3F0CA7A300 /* SeriesTagPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeriesTagPersistenceTests.swift; sourceTree = "<group>"; };
 		B6A063C8B833826A5B14CB9A /* Feature23TXTTocVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature23TXTTocVerificationTests.swift; sourceTree = "<group>"; };
 		B6CC92F8C2796AB46E2B5E21 /* CloudKitClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudKitClient.swift; sourceTree = "<group>"; };
@@ -1621,6 +1632,7 @@
 		DB16317C72EB6BBB61D77030 /* V1toV2Migration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V1toV2Migration.swift; sourceTree = "<group>"; };
 		DB6CE81404902AB359536964 /* PROPFINDParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PROPFINDParser.swift; sourceTree = "<group>"; };
 		DBA51F184E6AA5F2FD1F5456 /* zip.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = zip.js; sourceTree = "<group>"; };
+		DBAA3F90BD69DDACBE195884 /* NamedHighlightColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamedHighlightColor.swift; sourceTree = "<group>"; };
 		DBBB555BA86F7648ACBC780F /* EPUBProgressCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBProgressCalculator.swift; sourceTree = "<group>"; };
 		DC606D4AF30DF956E04C13DF /* LibrarySortOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySortOrder.swift; sourceTree = "<group>"; };
 		DC6BE724AEC4E98F6180228E /* Feature31AutoPageTurnVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature31AutoPageTurnVerificationTests.swift; sourceTree = "<group>"; };
@@ -1778,6 +1790,7 @@
 		0B012D36F10FD0A92C516160 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				8404837D8FC686DDDB62EEC3 /* AccentColorTests.swift */,
 				6B393E54ECE17C3DA3969EA4 /* AnnotationAnchorTests.swift */,
 				E11E9DBFB16DA26DD0659851 /* AnnotationModelTests.swift */,
 				CE6E54A01DDA73FFC3343F8E /* BookFileStateTests.swift */,
@@ -1798,11 +1811,13 @@
 				61E8B92C301E5470AB98C87E /* LocatorTests.swift */,
 				4C87C165AFE78571456C14D1 /* LocatorValidationTests.swift */,
 				F8DEE3B767FC8F7457067C11 /* MutationDriftTests.swift */,
+				1456DD6C03CD51C24CA8CDCF /* NamedHighlightColorTests.swift */,
 				9081F5E7C359D5FB2661E7AC /* ReaderThemeTests.swift */,
 				EC4FE169F0AC369FB30F888F /* ReadingModeTests.swift */,
 				EE41196788F697BB4ACD4B06 /* ReadingSessionTests.swift */,
 				03FA3AC72012ED6686293475 /* ReadingStatsTests.swift */,
 				D2EA03BEFDBB65F5D7533EDE /* SchemaV1Tests.swift */,
+				5E6114D9038B37A9B437BDC9 /* SelectionPopoverActionTests.swift */,
 				61D944728B17A940A3716EA9 /* TokenSpanTests.swift */,
 				8E6E8611E23F1BE57E84E732 /* TXTTextViewBridgeTests.swift */,
 				EEF87AF7EE6B0FB8E4CC9332 /* TypographySettingsTests.swift */,
@@ -3003,6 +3018,7 @@
 		D5F7C95CAE9759233D092954 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				13404BD286B135797ECF391A /* AccentColor.swift */,
 				8B1AC5E9F599CDA7123547F2 /* AnnotationAnchor.swift */,
 				ABF63E3EE60CC06C5650C3AD /* AnnotationNote.swift */,
 				ECD12F6574178C9287A93CA6 /* Book.swift */,
@@ -3025,11 +3041,13 @@
 				5E3D2050D82A39083191EDDA /* LibraryBookItem.swift */,
 				DC606D4AF30DF956E04C13DF /* LibrarySortOrder.swift */,
 				3C567EE93DC61BBB63CEAC20 /* Locator.swift */,
+				DBAA3F90BD69DDACBE195884 /* NamedHighlightColor.swift */,
 				4581A94B5099D15743DC02F3 /* ReaderTheme.swift */,
 				1B2B480AC630357CC08475F4 /* ReadingMode.swift */,
 				831F853E3D42A27170BB0F92 /* ReadingPosition.swift */,
 				38A104E5CBC93D0266E6C21E /* ReadingSession.swift */,
 				8A12A0D94CF17D48152929F0 /* ReadingStats.swift */,
+				B5825B20D8E48C77A28E061A /* SelectionPopoverAction.swift */,
 				20EBB13D56BE43A552188D9F /* TapZoneConfig.swift */,
 				686E0EE508E85349AED791BE /* TokenSpan.swift */,
 				19522F65C0947EFDCF9E4D2B /* TypographySettings.swift */,
@@ -3612,6 +3630,7 @@
 				3400D16324A8EFC7298B2B15 /* AISettingsViewModelMultiProfileTests.swift in Sources */,
 				9E2DE265BDC2515E4572714B /* AISettingsViewModelTests.swift in Sources */,
 				5C20BECE1338802F60F3E7B7 /* AITranslationTests.swift in Sources */,
+				495502CCD0035DB7C8AE37DA /* AccentColorTests.swift in Sources */,
 				65C927CBE6855076656719CE /* AccessibilityFormattersTests.swift in Sources */,
 				13EC9440F35FF01443E4FABF /* AnnotationAnchorTests.swift in Sources */,
 				058C2F104DE6D10D81F907D9 /* AnnotationExporterTests.swift in Sources */,
@@ -3784,6 +3803,7 @@
 				6C4BDAADD228F84C65CE3CE6 /* ModeSwitchPersistenceTests.swift in Sources */,
 				0CAEEF69ACEA07AE0DEC346E /* MutationDriftTests.swift in Sources */,
 				0E6D4F9EF1765D5808B9EEBC /* NSUKVSBridgeTests.swift in Sources */,
+				BE69CE7675864C497ACFC999 /* NamedHighlightColorTests.swift in Sources */,
 				036A7AA1F02D9219384C777A /* NativeTextPagedIntegrationTests.swift in Sources */,
 				4C5F7C805D7702035CEA5837 /* NativeTextPaginatorTests.swift in Sources */,
 				32C58BAAF2DB529049921D4D /* OPDSParserTests.swift in Sources */,
@@ -3849,6 +3869,7 @@
 				8CB7B605DFC452B422BBEC4F /* SearchTextNormalizerTests.swift in Sources */,
 				8BBE50E626A6524E8C6DB59D /* SearchViewModelTests.swift in Sources */,
 				F14370F35DEFDB725452B5CA /* SearchWiringTests.swift in Sources */,
+				32D7C0D02816850ACA1BD3E9 /* SelectionPopoverActionTests.swift in Sources */,
 				D007D50EE76181258F5D0681 /* SelectiveRestoreCoordinatorTests.swift in Sources */,
 				4A87A6889CFFC099EE0AFBD6 /* SeriesTagPersistenceTests.swift in Sources */,
 				088EB6A1D2B736BB8B643B30 /* SimpTradTransformTests.swift in Sources */,
@@ -3973,6 +3994,7 @@
 				B463893D3C3558483F25BDCF /* AISettingsViewModel.swift in Sources */,
 				7EE8C91043F4F20D39AF326B /* AITranslationViewModel.swift in Sources */,
 				FD9B24BBE1D852DA18A23E6F /* AITypes.swift in Sources */,
+				9AEE4782EDC4308FAA289B3B /* AccentColor.swift in Sources */,
 				8A3AE73DD5935F4E45882E38 /* AccessibilityFormatters.swift in Sources */,
 				19A48F5C5BC46818F3CC10BB /* AddNoteSheet.swift in Sources */,
 				21145D281B373D2D3262E65F /* AnnotationAnchor.swift in Sources */,
@@ -4162,6 +4184,7 @@
 				15C15DFE4818EDE663481250 /* MarkdownExportFormatter.swift in Sources */,
 				AF7D99D9C0CEA266BFD976B8 /* MetadataExtractor.swift in Sources */,
 				1A7E58193D247BB8900BA5B3 /* NSUKVSBridge.swift in Sources */,
+				DA5EF0C28F9B3F8C71A6E9C5 /* NamedHighlightColor.swift in Sources */,
 				7621CBAFA9E36EEA60633869 /* NativeTextPageNavigator.swift in Sources */,
 				9322D9DEBD7A9423DACA12DF /* NativeTextPagedView.swift in Sources */,
 				243DB71360738DB06D5813BF /* NativeTextPaginator.swift in Sources */,
@@ -4266,6 +4289,7 @@
 				74BEA01C5E4B3E080D2BF2FD /* SearchTokenizer.swift in Sources */,
 				1C9B4E21A97013A7CC409925 /* SearchView.swift in Sources */,
 				2F69DF71FDE5AF4FF920C3B2 /* SearchViewModel.swift in Sources */,
+				58132D890E317C57F2940579 /* SelectionPopoverAction.swift in Sources */,
 				594C442CEEA499384283D6B7 /* SelectiveRestoreCoordinator.swift in Sources */,
 				40479825289343F4985EF7C7 /* SelectiveRestorePicker.swift in Sources */,
 				8FFE1DA9C8F17FC318BE81BD /* SettingsView.swift in Sources */,
@@ -4510,13 +4534,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 381;
+				CURRENT_PROJECT_VERSION = 382;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.23.4;
+				MARKETING_VERSION = 3.23.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4660,13 +4684,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 381;
+				CURRENT_PROJECT_VERSION = 382;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.23.4;
+				MARKETING_VERSION = 3.23.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Models/AccentColor.swift
+++ b/vreader/Models/AccentColor.swift
@@ -1,0 +1,39 @@
+// Purpose: Three-stop oxblood/warm accent palette pinned to Feature
+// #60's visual identity (WI-3 foundational types). One restrained hue
+// per context — applied across chrome (buttons, selection emphasis,
+// primary actions) so the visual identity stays coherent across the
+// app instead of drifting per-screen.
+//
+// Stops per `docs/features.md` row #60:
+//   `.light`    → `#8c2f2f` (oxblood, default chrome accent)
+//   `.warmDark` → `#d6885a` (warm rose, dark-mode chrome accent)
+//   `.photo`    → `#e8b465` (photo-frame highlight, used on imagery)
+//
+// Key decisions:
+// - Modeled as an enum, not a static struct of colors, so adding a
+//   fourth stop in a future iteration is a compiler-enforced churn.
+// - Hex is exposed as a string and resolved to a `Color` / `UIColor`
+//   at the call site, mirroring how `NamedHighlightColor.hex` works.
+//   Keeping this layer SwiftUI-free lets the type compile in test
+//   targets without importing SwiftUI just to assert hex values.
+// - Sendable conformance is explicit (and tested compile-time) so
+//   future additions can't quietly leak a reference type.
+//
+// @coordinates-with: SelectionPopover view (WI-4), NavBar/chrome
+//   (WI-1), highlight glow renderer (WI-2)
+
+import Foundation
+
+enum AccentColor: Sendable, CaseIterable {
+    case light
+    case warmDark
+    case photo
+
+    var hex: String {
+        switch self {
+        case .light:    return "#8c2f2f"
+        case .warmDark: return "#d6885a"
+        case .photo:    return "#e8b465"
+        }
+    }
+}

--- a/vreader/Models/NamedHighlightColor.swift
+++ b/vreader/Models/NamedHighlightColor.swift
@@ -1,0 +1,55 @@
+// Purpose: UI-domain enum naming the four highlight colors offered in
+// Feature #60's SelectionPopover (WI-3 foundational types). Strictly
+// additive over the existing raw-`String` `Highlight.color` schema —
+// storage continues to be raw `String` per `Highlight.swift`,
+// `HighlightRecord.swift`, backup DTOs, and ExportedAnnotation. This
+// type is the *display/picker* domain. Hex stops are pinned to the
+// committed design bundle (`dev-docs/designs/vreader-fidelity-v1/`).
+//
+// Key decisions:
+// - `rawValue` is the semantic name ("yellow"/"pink"/"green"/"blue")
+//   so `Codable` round-trips emit a stable string and Swift-driven
+//   filtering by name reads naturally. Hex is derived, not stored.
+// - `from(storageString:)` returns `nil` for any unknown input — no
+//   silent coercion to `.yellow`. The caller decides the fallback.
+//   This pin protects the storage boundary: a legacy hex value or a
+//   user-defined custom color from a future feature MUST remain
+//   recognizable as "not in this picker" so callers can branch.
+// - Sendable + Codable + CaseIterable conformances are explicit so
+//   adding a non-Sendable associated value later breaks the build.
+//
+// @coordinates-with: SelectionPopoverAction.swift, Highlight.swift
+//   (storage boundary), HighlightRecord.swift, BackupSectionDTOs.swift,
+//   ExportedAnnotation.swift
+
+import Foundation
+
+enum NamedHighlightColor: String, Codable, CaseIterable, Sendable {
+    case yellow
+    case pink
+    case green
+    case blue
+
+    /// Hex stops pinned to `dev-docs/designs/vreader-fidelity-v1/project/vreader-reader.jsx`
+    /// `SelectionPopover` `colorMap`. Drift here breaks the visual
+    /// contract against the committed design.
+    var hex: String {
+        switch self {
+        case .yellow: return "#f0d25a"
+        case .pink:   return "#e88ca0"
+        case .green:  return "#8cc88c"
+        case .blue:   return "#8cb4e8"
+        }
+    }
+
+    /// Best-effort decoder from the raw storage string used by
+    /// `Highlight.color`. Case-sensitive and no whitespace trimming —
+    /// the storage schema has always been the lowercased semantic name
+    /// (default `"yellow"`), so tolerating drift here would hide bugs.
+    /// Returns `nil` for any value not in the named picker (legacy hex,
+    /// empty string, future user-defined colors). The caller decides
+    /// whether to fall back to a default or surface the raw value.
+    static func from(storageString: String) -> NamedHighlightColor? {
+        NamedHighlightColor(rawValue: storageString)
+    }
+}

--- a/vreader/Models/SelectionPopoverAction.swift
+++ b/vreader/Models/SelectionPopoverAction.swift
@@ -1,0 +1,31 @@
+// Purpose: Payload shape emitted by Feature #60's SelectionPopover
+// (WI-3 foundational types). One enum value per user-tappable button
+// in the popover: 4 named highlight colors + note + translate +
+// askAI + read. Consumed by the WI-7 handler that routes the action
+// to the existing highlight/note/translate/AI/TTS pipelines.
+//
+// Key decisions:
+// - Local-dispatch only. Intentionally NOT `Codable` — serialized
+//   payloads would invite a persistence schema commitment we don't
+//   need for the in-view callback chain, and would force every future
+//   action to be bridge-stable. The reader bridge contracts already
+//   own their own serialized shapes; SelectionPopoverAction is the
+//   UI-level handoff that lives entirely on the main actor.
+// - `Equatable` + `Sendable` make the type easy to assert against in
+//   tests and safe to carry across `MainActor`-isolated callback
+//   boundaries.
+// - `.highlight` carries `NamedHighlightColor` so the WI-7 routing
+//   handler sees the chosen color directly without re-decoding.
+//
+// @coordinates-with: NamedHighlightColor.swift, SelectionPopover view
+//   (WI-4), tap-action router (WI-7)
+
+import Foundation
+
+enum SelectionPopoverAction: Equatable, Sendable {
+    case highlight(NamedHighlightColor)
+    case note
+    case translate
+    case askAI
+    case read
+}

--- a/vreaderTests/Models/AccentColorTests.swift
+++ b/vreaderTests/Models/AccentColorTests.swift
@@ -1,0 +1,64 @@
+// Purpose: Tests for `AccentColor` — the three-stop oxblood token for
+// Feature #60's visual identity (WI-3). One restrained hue applied
+// across chrome (buttons, selection emphasis, primary actions).
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("AccentColor — Feature #60 WI-3")
+struct AccentColorTests {
+
+    /// Three named stops pinned to the design bundle's exact values per
+    /// the row description in `docs/features.md` row #60:
+    /// `#8c2f2f` (light) / `#d6885a` (warm-dark) / `#e8b465` (photo).
+    /// Each stop is the accent color for the named context. If these
+    /// drift, the visual identity drifts.
+    @Test
+    func threeStops_matchDesignHexValues() {
+        #expect(AccentColor.light.hex == "#8c2f2f")
+        #expect(AccentColor.warmDark.hex == "#d6885a")
+        #expect(AccentColor.photo.hex == "#e8b465")
+    }
+
+    /// Sendable conformance is compile-time enforced via this generic
+    /// helper. If `AccentColor` is later changed to a class or absorbs a
+    /// non-Sendable property, this will fail to compile.
+    @Test
+    func sendable_conformance_isAvailable() {
+        func requireSendable<T: Sendable>(_ value: T) -> T { value }
+        let accent = AccentColor.light
+        let echoed = requireSendable(accent)
+        #expect(echoed.hex == accent.hex)
+    }
+
+    /// Pins the "exactly three stops" contract. A future fourth case
+    /// would silently miss the hex-value test (which only asserts the
+    /// three named stops). This test forces the author of a fourth
+    /// stop to extend both `allCases` and the exhaustive-switch
+    /// helper below, surfacing the change at review time.
+    @Test
+    func allCases_containsExactlyThreeStops() {
+        let cases = AccentColor.allCases
+        #expect(cases.count == 3)
+        #expect(Set(cases) == [.light, .warmDark, .photo])
+    }
+
+    /// Compile-time exhaustiveness check — the switch will fail to
+    /// compile if a future case is added without updating this
+    /// helper. The body asserts only that each case yields a
+    /// non-empty hex string; the real value is the compiler check.
+    @Test
+    func exhaustiveSwitch_handlesEveryStop() {
+        func label(for accent: AccentColor) -> String {
+            switch accent {
+            case .light:    return accent.hex
+            case .warmDark: return accent.hex
+            case .photo:    return accent.hex
+            }
+        }
+        for accent in AccentColor.allCases {
+            #expect(!label(for: accent).isEmpty)
+        }
+    }
+}

--- a/vreaderTests/Models/NamedHighlightColorTests.swift
+++ b/vreaderTests/Models/NamedHighlightColorTests.swift
@@ -1,0 +1,133 @@
+// Purpose: Tests for `NamedHighlightColor` — UI-domain enum for the four
+// named highlight colors in Feature #60's SelectionPopover (WI-3).
+//
+// Additive over the existing raw-`String` `Highlight.color` schema; this
+// type does NOT replace the storage boundary in `Highlight.swift` /
+// `HighlightRecord.swift` / `BackupSectionDTOs.swift` / `ExportedAnnotation.swift`.
+// The compatibility test below pins `from(storageString:)` decode
+// behavior — it is NOT a guarantee that the storage types stay raw
+// `String`. The storage-boundary guarantee lives in the design of
+// those files (still raw `String` as of this WI) and in Codex Gate 2
+// round 1's plan audit, which would catch a future schema narrowing.
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("NamedHighlightColor — Feature #60 WI-3")
+struct NamedHighlightColorTests {
+
+    // MARK: - Exhaustive switch (compile-time guarantee via CaseIterable)
+
+    @Test
+    func allCases_containsExactlyFourColors() {
+        let cases = NamedHighlightColor.allCases
+        #expect(cases.count == 4)
+        #expect(Set(cases) == [.yellow, .pink, .green, .blue])
+    }
+
+    // MARK: - rawValue is the semantic name (storage contract)
+
+    @Test
+    func rawValue_isSemanticName_forEachCase() {
+        #expect(NamedHighlightColor.yellow.rawValue == "yellow")
+        #expect(NamedHighlightColor.pink.rawValue == "pink")
+        #expect(NamedHighlightColor.green.rawValue == "green")
+        #expect(NamedHighlightColor.blue.rawValue == "blue")
+    }
+
+    // MARK: - Derived hex per design bundle
+
+    /// Hex values pinned from
+    /// `dev-docs/designs/vreader-fidelity-v1/project/vreader-reader.jsx`
+    /// `SelectionPopover` `colorMap`. A drift in these breaks the visual
+    /// contract against the design — the test catches it.
+    @Test
+    func hex_matchesDesignBundle_forEachCase() {
+        #expect(NamedHighlightColor.yellow.hex == "#f0d25a")
+        #expect(NamedHighlightColor.pink.hex == "#e88ca0")
+        #expect(NamedHighlightColor.green.hex == "#8cc88c")
+        #expect(NamedHighlightColor.blue.hex == "#8cb4e8")
+    }
+
+    // MARK: - Codable round-trip via semantic-name rawValue
+
+    @Test
+    func codable_roundTrip_preservesEnumViaSemanticName() throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        for color in NamedHighlightColor.allCases {
+            let data = try encoder.encode(color)
+            let decoded = try decoder.decode(NamedHighlightColor.self, from: data)
+            #expect(decoded == color)
+        }
+    }
+
+    @Test
+    func codable_encodesAsSemanticNameString() throws {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(NamedHighlightColor.pink)
+        let asString = try #require(String(data: data, encoding: .utf8))
+        #expect(asString == "\"pink\"")
+    }
+
+    // MARK: - from(storageString:) — best-effort decoder
+
+    @Test
+    func fromStorageString_happyPath_returnsMatchingCase() {
+        #expect(NamedHighlightColor.from(storageString: "yellow") == .yellow)
+        #expect(NamedHighlightColor.from(storageString: "pink") == .pink)
+        #expect(NamedHighlightColor.from(storageString: "green") == .green)
+        #expect(NamedHighlightColor.from(storageString: "blue") == .blue)
+    }
+
+    @Test
+    func fromStorageString_unknownInput_returnsNil_noCoercion() {
+        // Per Codex Gate 2 round 1: the decoder must NOT default unknown
+        // values to `.yellow`. The caller decides whether to fall back.
+        #expect(NamedHighlightColor.from(storageString: "red") == nil)
+        #expect(NamedHighlightColor.from(storageString: "") == nil)
+        #expect(NamedHighlightColor.from(storageString: "#ff0000") == nil)
+        #expect(NamedHighlightColor.from(storageString: "YELLOW") == nil) // case-sensitive
+        #expect(NamedHighlightColor.from(storageString: " yellow ") == nil) // no trimming
+    }
+
+    // MARK: - Compatibility with existing Highlight.color string schema
+
+    /// Per Codex Gate 2 round 1 (High finding): `NamedHighlightColor` is
+    /// strictly additive — it does NOT change `Highlight.color` /
+    /// `HighlightRecord.color` / backup DTO / export-import payload
+    /// schemas. Those continue to be raw `String`. This test pins the
+    /// **decode contract** of `from(storageString:)` so the named
+    /// picker correctly classifies legacy and future strings:
+    /// 1. Unknown raw strings (legacy hex, empty, custom future name)
+    ///    decode to nil — the caller must decide the fallback.
+    /// 2. The "yellow" sentinel (the historical default used by every
+    ///    existing highlight in persistence) decodes to `.yellow`.
+    /// Note: this is a decode-contract pin, not a guarantee that
+    /// `Highlight.color` will remain `String`. Schema narrowing of
+    /// the storage types is caught by Codex Gate 2 plan audit, not
+    /// by this unit test.
+    @Test
+    func compatibility_existingStorageStringsRemainValidAndUnaltered() {
+        let storageStrings: [(input: String, expectedDecode: NamedHighlightColor?)] = [
+            // Historical default used since the first highlights shipped.
+            ("yellow", .yellow),
+            // New named colors landing post-WI-7.
+            ("pink",  .pink),
+            ("green", .green),
+            ("blue",  .blue),
+            // Hypothetical legacy hex stored before the named scheme.
+            ("#fff3a3", nil),
+            // An empty string from a corrupted import.
+            ("",       nil),
+            // A user-defined custom color from a future feature.
+            ("custom-mauve", nil),
+        ]
+        for (input, expected) in storageStrings {
+            let decoded = NamedHighlightColor.from(storageString: input)
+            #expect(decoded == expected,
+                    "from(storageString: \"\(input)\") = \(String(describing: decoded)) — expected \(String(describing: expected))")
+        }
+    }
+}

--- a/vreaderTests/Models/SelectionPopoverActionTests.swift
+++ b/vreaderTests/Models/SelectionPopoverActionTests.swift
@@ -1,0 +1,80 @@
+// Purpose: Tests for `SelectionPopoverAction` — the payload shape emitted
+// by Feature #60's SelectionPopover (WI-3). Local-dispatch only;
+// intentionally NOT `Codable` (per Codex Gate 2 round 1: serialized
+// payload would invite a persistence schema commitment we don't need
+// for the in-view callback chain).
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("SelectionPopoverAction — Feature #60 WI-3")
+struct SelectionPopoverActionTests {
+
+    // MARK: - Equatable behavior
+
+    /// The 5 design cases — highlight(yellow|pink|green|blue), note,
+    /// translate, askAI, read — must compare correctly for Equatable.
+    /// `.highlight(...)` distinguishes by the inner `NamedHighlightColor`.
+    @Test
+    func equatable_distinguishesAllCases() {
+        let cases: [SelectionPopoverAction] = [
+            .highlight(.yellow),
+            .highlight(.pink),
+            .highlight(.green),
+            .highlight(.blue),
+            .note,
+            .translate,
+            .askAI,
+            .read,
+        ]
+        // Each case equals itself.
+        for c in cases {
+            #expect(c == c)
+        }
+        // No two distinct cases are equal.
+        for i in 0..<cases.count {
+            for j in 0..<cases.count where i != j {
+                #expect(cases[i] != cases[j])
+            }
+        }
+    }
+
+    // MARK: - Exhaustive switch (the WI-7 handler will rely on this)
+
+    /// A test that switches over every case forces the compiler to flag
+    /// missing cases when the enum grows. The body asserts only that
+    /// each case maps to a non-empty label — the real value is the
+    /// compile-time exhaustiveness check.
+    @Test
+    func exhaustiveSwitch_handlesEveryCase() {
+        func label(for action: SelectionPopoverAction) -> String {
+            switch action {
+            case .highlight(let color): return "highlight(\(color.rawValue))"
+            case .note: return "note"
+            case .translate: return "translate"
+            case .askAI: return "askAI"
+            case .read: return "read"
+            }
+        }
+        let samples: [SelectionPopoverAction] = [
+            .highlight(.yellow), .note, .translate, .askAI, .read,
+        ]
+        for action in samples {
+            #expect(!label(for: action).isEmpty)
+        }
+    }
+
+    // MARK: - Sendable (compile-time conformance check)
+
+    /// If `SelectionPopoverAction` accidentally captures a non-Sendable
+    /// associated value (e.g. a reference type) in the future, this
+    /// generic helper that requires `Sendable` will fail to compile.
+    @Test
+    func sendable_conformance_isAvailable() {
+        func requireSendable<T: Sendable>(_ value: T) -> T { value }
+        let action = SelectionPopoverAction.highlight(.green)
+        let echoed = requireSendable(action)
+        #expect(echoed == action)
+    }
+}


### PR DESCRIPTION
## Summary

Lifts three foundational value types out of WI-4 (SelectionPopover) so the popover view in later WIs is authored against a stable, audited surface. All three are strictly additive — no existing schema, storage type, or `String` field is touched.

Part of feature #718.

## What Changed

- **`NamedHighlightColor`** — UI-domain enum with cases `.yellow`/`.pink`/`.green`/`.blue`. Semantic-name `rawValue`, hex pinned to the committed design bundle (`#f0d25a`/`#e88ca0`/`#8cc88c`/`#8cb4e8`). `from(storageString:) -> Self?` returns nil on unknown input (no silent coercion to `.yellow`).
- **`SelectionPopoverAction`** — enum with `.highlight(NamedHighlightColor)`, `.note`, `.translate`, `.askAI`, `.read`. Equatable + Sendable. Intentionally NOT Codable (local dispatch only).
- **`AccentColor`** — three-stop oxblood palette (`.light`/`.warmDark`/`.photo` → `#8c2f2f`/`#d6885a`/`#e8b465`). CaseIterable + Sendable + exhaustive switch test.

Storage boundary preserved: `Highlight.color`, `HighlightRecord.color`, `BackupHighlight.color`, `ExportedAnnotation.color` all remain raw `String`/`String?`.

Plan: `dev-docs/plans/20260515-feature-60-visual-identity-v2.md`.

## WI Status

- WI-3: foundational — this PR.
- Remaining WIs (1, 2, 4, 5, 6, 7, 8, 9): the new typography stack, palette tokens, chrome redesigns, SelectionPopover view + tap-action router, and the visual identity sweep. Each ships its own PR.

## Codex Audit (Gate 4)

3 rounds, final verdict: **ship-as-is**. Zero open Critical/High/Medium findings. Round 1 surfaced 3 Lows (test-comment overreach + missing AccentColor exhaustiveness pin) and 1 plan-doc drift note (stale `#fff3a3` hex). All addressed in rounds 2-3.

Audit log: `.claude/codex-audits/feat-feature-60-wi-3-popover-types-audit.md` (thread `019e2d7a-7159-7b70-a703-4a2ac399ea88`).

## Validation

- [x] `xcodebuild test` on the 3 new suites: 15 tests, all passing (Gate 3 test gate).
- [x] Tests cover changed behavior (TDD: RED → GREEN).
- [x] Codex audit loop completed (3 iterations, verdict: ship-as-is).
- [x] Docs sync — n/a (foundational dormant infra; no new service / @Model / notification / cross-feature pattern).
- [x] Version bumped: 3.23.4 → 3.23.5 (patch — foundational WI per rule 47 + rule 40).

## Gate 5a Verification (per-PR slice — pre-merge)

- **Tier**: foundational. These are pure value types not yet wired to any UI surface. Unit + integration tests are sufficient; no device verification required.
- The three types compile, all 15 unit tests pass, and the broader build smoke (`xcodebuild build`) succeeds at v3.23.5. The slice is verified at the level appropriate to its WI tier.

## Type of Change

- [x] Feature WI (Part of feature #718)