### PR TITLE
docs(bug #200): verification-exception evidence for GH #737 close

### DIFF
--- a/dev-docs/verification/bug-200-20260516.md
+++ b/dev-docs/verification/bug-200-20260516.md
@@ -1,0 +1,93 @@
+---
+kind: bug
+id: 200
+status_target: FIXED
+commit_sha: 3eba83c17fa7ea176a1052befc8e78910c9d1bee
+app_version: 3.23.13 (build 390)
+date: 2026-05-16
+verifier: claude (bugfix-cron)
+device_or_simulator: iPhone 17 Pro Simulator
+os_version: iOS 26.5
+build_configuration: Debug
+backend: n/a (pure-test fix)
+result: pass
+---
+
+# Bug #200 / GH #737 — verification-exception close-gate
+
+## Why exception path
+
+This bug is a pure-test fix: stale assertions in `BookFormatAZW3Tests.swift`
+that contradicted the post-PR-#644 capability contract (`.tts` cap-gated off
+AZW3 because `ReaderAICoordinator.loadBookTextContent` has no AZW3/MOBI case
+→ silent TTS failure). The "failure mode" being fixed is a unit-test
+assertion mismatch, not a runtime symptom — no production code changed,
+no user-observable behavior changed, no device repro is possible because
+the assertion never ran on-device.
+
+The high-fidelity test path qualifying this for `verification-exception`:
+
+- `capabilitiesDoesNotSupportTTSUntilFoliateWiringShips`
+  (`vreaderTests/Models/BookFormatAZW3Tests.swift:102-121`) — calls
+  `BookFormat.azw3.capabilities`, which is the convenience property
+  production view-models and host dispatchers use to resolve capabilities.
+  Implementation at `vreader/Models/BookFormat.swift:38-40` is a one-line
+  pass-through to `FormatCapabilities.capabilities(for: .azw3)` — same
+  factory the production code calls.
+- `capabilitiesMatchSimpleEPUBExceptTTS`
+  (`vreaderTests/Models/BookFormatAZW3Tests.swift:155-169`) — pins the
+  documented diff (`azw3Caps.union(.tts) == epubCaps` AND
+  `!azw3Caps.contains(.tts)`).
+
+Both tests call real factory methods through real `BookFormat` enum cases
+— no stubs, no mocks. The assertions hold ⟺ the production capability
+contract holds.
+
+## Acceptance criteria
+
+| Criterion | Observed | Pass/Fail |
+|---|---|---|
+| (a) `BookFormatAZW3Tests` runs cleanly against the post-PR-#644 capability set | `xcodebuild test -only-testing:vreaderTests/BookFormatAZW3Tests` → 25/25 pass on commit `3eba83c` | **PASS** |
+| (b) AZW3 does NOT advertise `.tts` capability via production resolution path | `BookFormat.azw3.capabilities` returns a set where `.tts ∉ caps` | **PASS** |
+| (c) AZW3 capability set differs from EPUB-simple by exactly `{.tts}` | `azw3Caps.union(.tts) == epubCaps` is true; `azw3Caps == epubCaps` is false | **PASS** |
+| (d) Convenience wrapper stays aligned with the factory | `BookFormat.azw3.capabilities == FormatCapabilities.capabilities(for: .azw3)` (existing cross-link test at line 178-183) | **PASS** |
+
+## Commands run
+
+```bash
+# Test gate — single suite (post-fix)
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
+  -project vreader.xcodeproj -scheme vreader \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:vreaderTests/BookFormatAZW3Tests
+# → ** TEST SUCCEEDED ** (25/25)
+
+# Smoke build at bumped version
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build \
+  -project vreader.xcodeproj -scheme vreader \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+# → ** BUILD SUCCEEDED **
+```
+
+## Observations
+
+- The inverted assertions complement (not duplicate) the canonical
+  `azw3_doesNotSupportTTS` regression guard in `FormatCapabilitiesTests`.
+  Codex Round 1 caught the original test as a strict duplicate; Round 2
+  confirmed the convenience-property routing differentiates the two
+  exercise paths.
+- Full vreaderTests run on the merge commit shows 5 pre-existing flaky
+  failures in `ReaderAuditFix` / `SearchWiring` /
+  `TXTReaderViewModel` (notification-timing/indexer-race integration
+  tests) — all 3 suites pass in isolation. None are related to this
+  fix and none are introduced by it.
+- No production code changed in this PR — bumping `MARKETING_VERSION`
+  is mandatory per rule 40 even for test-only fixes (every PR ships a
+  version bump).
+
+## Artifacts
+
+- `.claude/codex-audits/fix-issue-737-bookformat-azw3-tts-stale-audit.md` —
+  2-round Codex audit log (thread `019e2e1d`).
+- PR #756 (squash-merged at `3eba83c`).
+- Tag `v3.23.13` on `main`.


### PR DESCRIPTION
## Summary

Adds `dev-docs/verification/bug-200-20260516.md` — the verification-exception evidence file required to close GH #737 per AGENTS.md close-gate rule.

Bug #200 was a pure-test fix (assertion inversion). The inverted tests ARE the high-fidelity verification path through real `BookFormat.azw3.capabilities` and `FormatCapabilities.capabilities(for:)` factory — qualifying for the `verification-exception` close path.

Refs #737

## Type of Change

- [x] Docs only — verification evidence trail