### PR TITLE
docs(#60): fix revision-history numbering in feature-60 plan

### DIFF
--- a/dev-docs/plans/20260515-feature-60-visual-identity-v2.md
+++ b/dev-docs/plans/20260515-feature-60-visual-identity-v2.md
@@ -544,20 +544,6 @@ category 2 (PLANNED feature with plan doc → Gate 3).
   `Equatable + Sendable` only (not `Codable`). Test catalogue
   expanded to 8 NamedHighlightColor tests + 3 SelectionPopoverAction
   tests + 2 AccentColor tests.
-- 2026-05-16 v4: WI-5 shipped (Gate 3 + Gate 4). Codex thread
-  `019e2e0a-cce5-76f0-97d8-f2d794d71b6e`, 2 rounds, final verdict
-  `ship-as-is`. Round 1 caught: (a) WI-5 was incomplete for MD —
-  blockquote bodies and fenced-code backgrounds still hard-coded
-  `UIColor.secondaryLabel` / `.secondarySystemBackground` (Medium —
-  fixed by extending `MDRenderConfig` with `secondaryColor` +
-  `codeBackgroundColor` fields plumbed from
-  `theme.asV2.subColor` / `.paperColor`); (b) alpha-only assertions
-  for `uiSecondaryTextColor` (Low — fixed by full RGB+alpha
-  pinning). Round 2: clean. Residual renderer-level test gap
-  (Codex flagged as "not a finding") closed inline by adding two
-  injection tests proving the new MDRenderConfig fields propagate.
-  20+ V2/renderer tests pass; 34 existing MD renderer tests
-  continue passing.
 - 2026-05-16 v3: WI-4 shipped (Gate 3 + Gate 4). Codex thread
   `019e2de0-9d1a-72d2-860d-f371205cd7bb`, 3 rounds, final verdict
   `ship-as-is`. Round 1 caught: (a) CSS url(...) escape gap +
@@ -575,7 +561,21 @@ category 2 (PLANNED feature with plan doc → Gate 3).
   header + method doc (Low — fixed). Round 3: clean. 19 V2 CSS
   tests pass; 2 pre-existing AZW3 TTS failures tracked at Bug #200
   are out of WI-4 scope.
-- 2026-05-16 v4: **WI-6 split into WI-6a + WI-6b**. WI-6a (foundational
+- 2026-05-16 v4: WI-5 shipped (Gate 3 + Gate 4). Codex thread
+  `019e2e0a-cce5-76f0-97d8-f2d794d71b6e`, 2 rounds, final verdict
+  `ship-as-is`. Round 1 caught: (a) WI-5 was incomplete for MD —
+  blockquote bodies and fenced-code backgrounds still hard-coded
+  `UIColor.secondaryLabel` / `.secondarySystemBackground` (Medium —
+  fixed by extending `MDRenderConfig` with `secondaryColor` +
+  `codeBackgroundColor` fields plumbed from
+  `theme.asV2.subColor` / `.paperColor`); (b) alpha-only assertions
+  for `uiSecondaryTextColor` (Low — fixed by full RGB+alpha
+  pinning). Round 2: clean. Residual renderer-level test gap
+  (Codex flagged as "not a finding") closed inline by adding two
+  injection tests proving the new MDRenderConfig fields propagate.
+  20+ V2/renderer tests pass; 34 existing MD renderer tests
+  continue passing.
+- 2026-05-16 v5: **WI-6 split into WI-6a + WI-6b**. WI-6a (foundational
   button-slot enum contract — `ReaderTopChromeSlot`, `ReaderBottomChromeButton`,
   accessibility-identifier contracts, accent-slot predicate; 7
   contract tests in `ReaderChromeButtonContractTests`) ships

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 391
-        MARKETING_VERSION: 3.23.14
+        CURRENT_PROJECT_VERSION: 392
+        MARKETING_VERSION: 3.23.15
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4578,13 +4578,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 391;
+				CURRENT_PROJECT_VERSION = 392;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.23.14;
+				MARKETING_VERSION = 3.23.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4728,13 +4728,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 391;
+				CURRENT_PROJECT_VERSION = 392;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.23.14;
+				MARKETING_VERSION = 3.23.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

The feature #60 plan's revision history had two entries both labeled `v4`, and `v3` (WI-4) was listed *after* `v4` (WI-5) — confusing for a versioned doc that gates a 10-WI feature.

Reordered so WI-4 precedes WI-5 (their actual ship order) and renumbered: `v3` = WI-4, `v4` = WI-5, `v5` = WI-6 split. **Entry content is unchanged** — pure ordering + label fix.

Refs #718

## Validation

- [x] Plan-doc only — no Swift / test changes (the hook for audit-log artifacts does not fire)
- [x] Version bumped to 3.23.15 / build 392