### PR TITLE
feat(#718 WI-7c3): TXT chunked bridge swap — SelectionPopoverView replaces legacy UIMenu

### DIFF
--- a/.claude/codex-audits/feat-feature-60-wi-7c3-txt-chunked-popover-audit.md
+++ b/.claude/codex-audits/feat-feature-60-wi-7c3-txt-chunked-popover-audit.md
@@ -1,0 +1,88 @@
+---
+branch: feat/feature-60-wi-7c3-txt-chunked-popover
+threadId: 019e2ed2-a117-7653-84e2-4466013d7717
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-16
+---
+
+# Codex Audit — Feature #60 WI-7c3 TXT chunked bridge swap
+
+## Round 1 — 2 Lows
+
+### Low #1 — `TXTBridgeShared.buildReaderEditMenu` is dead after WI-7c3
+- **`vreader/Views/Reader/TXTBridgeShared.swift:51`** | Low
+  After WI-7c3 removes the chunked bridge caller, no production
+  call sites remain. The function and its AI-availability branch
+  are unexercised stale code.
+
+**Resolution**: Accepted with rationale, deferred to follow-up. The
+helper itself is dead in production, but `TXTBridgeSharedTests.swift`
+still has 3 tests that exercise it directly
+(`buildReaderEditMenuIncludesTranslateWhenAvailable`, `…
+OmitsTranslateWhenAIUnavailable`, `… PassesThroughSuggestedActions
+ForEmptyRange`). Removing the helper requires removing those tests
+too — widens WI-7c3's diff from "bridge swap + contract tests" into
+unrelated cleanup. MD doesn't use editMenuForTextIn at all, so
+WI-7c4 won't naturally retire the helper either; this needs a
+dedicated cleanup WI (or absorption into WI-7c5 if EPUB doesn't use
+it). Codex round 2 accepted: "I would keep it as an explicit
+follow-up cleanup item unless you want this PR to absorb that extra
+diff."
+
+### Low #2 — negative tag crash class
+- **`vreader/Views/Reader/TXTChunkedReaderBridge.swift:513,548`** | Low
+  The defensive "out-of-range tag falls back to 0" check only
+  handled `tag >= count`. A negative `textView.tag` would still
+  subscript `chunkStartOffsets` with a negative index and crash —
+  in both `textViewDidChangeSelection` (pre-existing, line 513)
+  and the new `editMenuForTextIn` post (line 548).
+
+**Resolution**: Fixed both sites with the clamped check
+`(chunkIndex >= 0 && chunkIndex < chunkStartOffsets.count) ? chunkStartOffsets[chunkIndex] : 0`. Pinned via a new
+`negativeTag` regression test (chunk-index = -1 falls back to offset
+0 without crashing). Codex round 2 accepted the line-513 sibling fix
+as reasonable scope: "It is the same bug class in the same coordinator
+and keeps `textViewDidChangeSelection` and `editMenuForTextIn`
+behavior symmetric."
+
+## Round 2 — clean
+
+Codex verified: "No new findings. The negative-tag fix is correct
+end-to-end... The chunked-TXT swap still matches the WI-7c2 producer
+contract, and the added defensive clamp does not alter normal
+runtime behavior where `cellForRowAt` assigns non-negative tags."
+
+## Verdict statement
+
+**ship-as-is** after round 1 (1 Low fixed, 1 Low deferred with
+rationale). Round 2 clean.
+
+All 8 audit dimensions clean:
+1. Correctness — chunked-TXT swap matches WI-7c2 producer contract; chunk-offset translation preserved via the existing `TXTBridgeShared.postSelectionNotification`'s `chunkOffset:` parameter.
+2. Edge cases — high-side overflow (covered), zero-offset chunk (covered), zero-length range (covered), negative tag (now covered).
+3. Security — none (pure SwiftUI/NotificationCenter).
+4. Duplicate code — pattern intentionally mirrors WI-7c2 with the chunk-offset extra step. Codex confirmed it's not worth extracting a shared helper given the divergence.
+5. Dead code — `buildReaderEditMenu` is now dead in production; deferred cleanup item.
+6. Shortcuts / patches — none.
+7. VReader compliance — `@MainActor` correctness preserved (coordinator method is `UITextViewDelegate`-implicit), Swift 6 satisfied, `TXTChunkedReaderBridge.swift` was already >300 lines pre-existing; +29 here doesn't change that.
+8. Bridge safety — `TXTBridgeShared.postSelectionNotification` handles UTF-16 + bounds for chunked NSRange via the chunkOffset translation.
+
+## Test results
+
+- 6 `TXTChunkedReaderBridgeEditMenuTests`: empty UIMenu return, popover-request post with chunk offset (200→206-211), chunk-zero correctness, zero-length no-post, out-of-range tag fallback, negative tag fallback. All pass.
+
+Full vreaderTests run pending; expected to be clean modulo the 2 pre-existing parallel-execution `ReplacementTransformTests` flakes documented in WI-7c2's audit log.
+
+## Strengths called out by Codex
+
+- The swap is correct against the WI-7c2 pattern: `editMenuForTextIn` now posts `.readerSelectionPopoverRequested` and suppresses the UIKit menu exactly as planned.
+- The chunk-offset math matches the legacy path because it still routes through `TXTBridgeShared.postSelectionNotification`, preserving the same UTF-16 bounds validation and global-range construction.
+- The container-side wiring is already in place (WI-7c2 attached the presenter to `TXTReaderContainerView`), so no extra integration work missing.
+- The contract tests cover the key slices: empty-menu suppression, chunk-offset translation, zero-offset, zero-length no-post, out-of-range and negative tag fallbacks.
+- Cell reuse / scroll drift: `cellForRowAt` reassigns `textView.tag` on every dequeue before the cell is interactive, so no realistic tag/offset drift regression.
+
+## Follow-up items
+
+1. **`buildReaderEditMenu` cleanup**: now dead in production. Remove the helper from `TXTBridgeShared.swift` + the 3 tests in `TXTBridgeSharedTests.swift` in a dedicated cleanup WI (or fold into WI-7c5 if EPUB doesn't introduce a new caller).
+2. **`applyHighlight` / `clearHighlight` negative-tag check** (line 604 area, in `TXTChunkedHighlightHelper.swift`): same bug class, different defensive shape (uses `guard ... else { return }`). Not addressed here; could be a small follow-up if it becomes a real concern.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 399
-        MARKETING_VERSION: 3.24.4
+        CURRENT_PROJECT_VERSION: 400
+        MARKETING_VERSION: 3.24.5
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		04759BE2CD3CA39424689484 /* AIResponseCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C18F1E19149F8DBAE36A31 /* AIResponseCache.swift */; };
 		05007F5C2D7687A1173C48CB /* ReaderSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B432A1C9D875A14C4E9E633 /* ReaderSettingsStore.swift */; };
 		054050637EFD8ACE415BCF2E /* ReplacementRulesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9584B44764B8D11C7CC9F6 /* ReplacementRulesView.swift */; };
+		0551D7B498604A2F477349A1 /* TXTChunkedReaderBridgeEditMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10B7F1A4BCC11533447A4829 /* TXTChunkedReaderBridgeEditMenuTests.swift */; };
 		05746231141B8C7001BEBDAD /* FoliateSelectionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF493E1A2F50B0916C76306D /* FoliateSelectionDispatcher.swift */; };
 		058C2F104DE6D10D81F907D9 /* AnnotationExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB9773A4631BEDEDD187F08 /* AnnotationExporterTests.swift */; };
 		05BE70789318FA085B9A735E /* AIChatViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E861A379A620B769CEA36300 /* AIChatViewModelTests.swift */; };
@@ -973,6 +974,7 @@
 		103B5BF35C8DC9FB2BE4998F /* PDFPageNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFPageNavigator.swift; sourceTree = "<group>"; };
 		10909449DAD59CD16EE53A7F /* CSSRuleEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSSRuleEvaluator.swift; sourceTree = "<group>"; };
 		10962D7E47EA2C6714E704CA /* MOBICoverExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MOBICoverExtractorTests.swift; sourceTree = "<group>"; };
+		10B7F1A4BCC11533447A4829 /* TXTChunkedReaderBridgeEditMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChunkedReaderBridgeEditMenuTests.swift; sourceTree = "<group>"; };
 		10C2FF255E2C0E968707942E /* AISettingsViewModel+Editor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AISettingsViewModel+Editor.swift"; sourceTree = "<group>"; };
 		10C9907D3479515B56338825 /* HTTPTTSConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTTSConfig.swift; sourceTree = "<group>"; };
 		10F8EE6C68FBB40F0A229AC0 /* utf16le_bom.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = utf16le_bom.txt; sourceTree = "<group>"; };
@@ -2262,6 +2264,7 @@
 				2B9AD84A4BE2CF0F8D59D9CC /* TXTChapterScrollOffsetTests.swift */,
 				FB9A749915A46E6DD506275A /* TXTChunkedBridgeHighlightTapTests.swift */,
 				C24D5425530ABBE0DDA4758F /* TXTChunkedHighlightDeferredTimerTests.swift */,
+				10B7F1A4BCC11533447A4829 /* TXTChunkedReaderBridgeEditMenuTests.swift */,
 				F213D0F6EFBD7D7088AAC40D /* TXTMDProgressTests.swift */,
 				F17C33D19BD1735676CA01BC /* TXTReaderContainerHighlightCoordinatorWiringTests.swift */,
 				7F71E759F980473A403CC70B /* TXTReaderContainerSearchHighlightWiringTests.swift */,
@@ -3996,6 +3999,7 @@
 				0A359570B32735E17EC5893F /* TXTChunkedBridgeHighlightTapTests.swift in Sources */,
 				23A8010F873969D18777639F /* TXTChunkedHighlightDeferredTimerTests.swift in Sources */,
 				E9177AEFF47DA3EFEAC13C50 /* TXTChunkedLoaderTests.swift in Sources */,
+				0551D7B498604A2F477349A1 /* TXTChunkedReaderBridgeEditMenuTests.swift in Sources */,
 				C81A31B52218576A75210100 /* TXTFileLoaderTests.swift in Sources */,
 				D9C467679B15F5EAA982BBF4 /* TXTLazyTextProviderTests.swift in Sources */,
 				7406A7805B98779AF9AA2F63 /* TXTMDProgressTests.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4646,13 +4646,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 399;
+				CURRENT_PROJECT_VERSION = 400;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.24.4;
+				MARKETING_VERSION = 3.24.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4796,13 +4796,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 399;
+				CURRENT_PROJECT_VERSION = 400;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.24.4;
+				MARKETING_VERSION = 3.24.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Views/Reader/TXTChunkedReaderBridge.swift
+++ b/vreader/Views/Reader/TXTChunkedReaderBridge.swift
@@ -510,7 +510,13 @@ struct TXTChunkedReaderBridge: UIViewRepresentable {
             let nsRange = textView.selectedRange
             guard nsRange.length > 0 else { return }
             let chunkIndex = textView.tag
-            let chunkOffset = chunkIndex < chunkStartOffsets.count ? chunkStartOffsets[chunkIndex] : 0
+            // Codex Gate 4 round 1 (Low) sibling of the editMenuForTextIn
+            // fix: clamp negative tags too. Pre-WI-7c3 this was only
+            // a class-of-bug concern; aligning the two sites keeps
+            // them symmetric.
+            let chunkOffset = (chunkIndex >= 0 && chunkIndex < chunkStartOffsets.count)
+                ? chunkStartOffsets[chunkIndex]
+                : 0
             // Convert chunk-local range to document-global UTF16Range
             let globalStart = chunkOffset + nsRange.location
             let globalEnd = globalStart + nsRange.length
@@ -524,17 +530,46 @@ struct TXTChunkedReaderBridge: UIViewRepresentable {
             editMenuForTextIn range: NSRange,
             suggestedActions: [UIMenuElement]
         ) -> UIMenu? {
-            let chunkIndex = textView.tag
-            let chunkOffset = chunkIndex < chunkStartOffsets.count ? chunkStartOffsets[chunkIndex] : 0
-            return TXTBridgeShared.buildReaderEditMenu(
-                range: range, textView: textView, suggestedActions: suggestedActions,
-                chunkOffset: chunkOffset,
-                isAITranslateAvailable: AIReaderAvailability.isAvailable(
-                    featureFlags: FeatureFlags.shared,
-                    keychainService: KeychainService(),
-                    consentManager: AIConsentManager()
+            // Feature #60 WI-7c3: chunked TXT bridge swap. Mirrors
+            // WI-7c2's non-chunked swap — post
+            // `.readerSelectionPopoverRequested` to the WI-7c1
+            // presenter and return an empty UIMenu to suppress the
+            // iOS surface. The chunked path differs only in needing
+            // a chunk-offset translation: local NSRange in the
+            // current `UITextView` (cell) → document-global UTF-16
+            // range. `TXTBridgeShared.postSelectionNotification`'s
+            // existing `chunkOffset:` parameter handles that.
+            //
+            // Why the `range.length > 0` guard: iOS calls this for
+            // caret placement (zero-length range) too; no popover
+            // should appear in that case. Returning the empty
+            // UIMenu unconditionally still suppresses iOS's default.
+            //
+            // The `textView.tag` carries the chunk index (set by
+            // `cellForRowAt`). Out-of-range tags fall back to
+            // offset 0 — defensive but should never fire in
+            // production.
+            if range.length > 0 {
+                let chunkIndex = textView.tag
+                // Codex Gate 4 round 1 (Low): clamp on both ends.
+                // `textView.tag` is `Int` and could in principle be
+                // negative; the existing high-side check
+                // `< chunkStartOffsets.count` doesn't protect
+                // against subscripting with a negative index (which
+                // would crash). In production `cellForRowAt`
+                // always sets a non-negative tag, but defensive
+                // coding earns its keep at the table-view boundary.
+                let chunkOffset = (chunkIndex >= 0 && chunkIndex < chunkStartOffsets.count)
+                    ? chunkStartOffsets[chunkIndex]
+                    : 0
+                TXTBridgeShared.postSelectionNotification(
+                    .readerSelectionPopoverRequested,
+                    from: textView,
+                    range: range,
+                    chunkOffset: chunkOffset
                 )
-            )
+            }
+            return UIMenu(children: [])
         }
 
         // Dynamic navigation (scrollToGlobalOffset) and highlight methods

--- a/vreaderTests/Views/Reader/TXTChunkedReaderBridgeEditMenuTests.swift
+++ b/vreaderTests/Views/Reader/TXTChunkedReaderBridgeEditMenuTests.swift
@@ -1,0 +1,187 @@
+// Purpose: Feature #60 WI-7c3 — pins the contract change in
+// `TXTChunkedReaderBridge.Coordinator.textView(_:editMenuForTextIn:
+// suggestedActions:)`. Mirrors WI-7c2's
+// `TXTTextViewBridgeEditMenuTests` for the chunked path. Pre-WI-7c3
+// the chunked coordinator returned the legacy
+// `TXTBridgeShared.buildReaderEditMenu` UIMenu with chunk-offset
+// math; post-WI-7c3 it posts `.readerSelectionPopoverRequested` with
+// the chunk-adjusted `TextSelectionInfo` and returns an empty
+// `UIMenu(children: [])` so the WI-7c1 presenter takes over.
+//
+// **Chunk offset matters**: the chunked path renders multiple
+// `UITextView`s side-by-side (one per chunk). Each textView's local
+// NSRange must be translated to the document-global UTF-16 offset
+// before downstream (highlight persistence, AI translate, etc.)
+// resolves it. The chunk index is carried in `textView.tag`; the
+// offset comes from `chunkStartOffsets[tag]`.
+
+#if canImport(UIKit)
+import Testing
+import Foundation
+import UIKit
+@testable import vreader
+
+@Suite(
+    "Feature #60 WI-7c3 — TXTChunkedReaderBridge.Coordinator editMenuForTextIn",
+    .serialized  // Shares NotificationCenter.default for
+                 // .readerSelectionPopoverRequested with sibling
+                 // WI-7c2 suite. Serialized within the suite to
+                 // avoid intra-suite cross-fire; queue:nil
+                 // synchronous delivery handles cross-suite.
+)
+@MainActor
+struct TXTChunkedReaderBridgeEditMenuTests {
+
+    private func makeTextView(text: String, chunkIndex: Int) -> UITextView {
+        let tv = UITextView()
+        tv.text = text
+        tv.tag = chunkIndex
+        return tv
+    }
+
+    @Test("editMenuForTextIn returns an empty UIMenu (suppresses iOS default + suggested actions)")
+    func returnsEmptyMenu() {
+        let coordinator = TXTChunkedReaderBridge.Coordinator(delegate: nil)
+        coordinator.chunkStartOffsets = [0, 100, 200]
+        let tv = makeTextView(text: "Hello World", chunkIndex: 0)
+        let range = NSRange(location: 0, length: 5)
+
+        let menu = coordinator.textView(tv, editMenuForTextIn: range, suggestedActions: [])
+
+        #expect(menu != nil)
+        #expect(menu?.children.isEmpty == true,
+                "WI-7c3: TXT chunked bridge must return an empty UIMenu after long-press — the SelectionPopoverView sheet replaces the in-textview menu.")
+    }
+
+    @Test("editMenuForTextIn posts .readerSelectionPopoverRequested with chunk-adjusted TextSelectionInfo")
+    func postsPopoverRequestWithChunkOffset() {
+        // Chunk 2 starts at document UTF-16 offset 200; selecting
+        // local range (6, 5) → "World" in "Hello World" must
+        // translate to global offsets (206, 211).
+        let coordinator = TXTChunkedReaderBridge.Coordinator(delegate: nil)
+        coordinator.chunkStartOffsets = [0, 100, 200]
+        let tv = makeTextView(text: "Hello World", chunkIndex: 2)
+        let range = NSRange(location: 6, length: 5)
+
+        nonisolated(unsafe) var received: TextSelectionInfo?
+        let observer = NotificationCenter.default.addObserver(
+            forName: .readerSelectionPopoverRequested, object: nil, queue: nil
+        ) { note in
+            received = note.object as? TextSelectionInfo
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        _ = coordinator.textView(tv, editMenuForTextIn: range, suggestedActions: [])
+
+        #expect(received?.selectedText == "World")
+        #expect(received?.startUTF16 == 206,
+                "Chunk offset 200 + local 6 = global 206")
+        #expect(received?.endUTF16 == 211,
+                "Chunk offset 200 + local 6 + length 5 = global 211")
+    }
+
+    @Test("editMenuForTextIn with chunk index 0 (no offset) posts correct global range")
+    func chunkZeroOffset() {
+        // Sanity: the first chunk has offset 0 — the post should
+        // mirror the local range exactly (not double-add).
+        let coordinator = TXTChunkedReaderBridge.Coordinator(delegate: nil)
+        coordinator.chunkStartOffsets = [0, 100]
+        let tv = makeTextView(text: "Hello World", chunkIndex: 0)
+        let range = NSRange(location: 0, length: 5)
+
+        nonisolated(unsafe) var received: TextSelectionInfo?
+        let observer = NotificationCenter.default.addObserver(
+            forName: .readerSelectionPopoverRequested, object: nil, queue: nil
+        ) { note in
+            received = note.object as? TextSelectionInfo
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        _ = coordinator.textView(tv, editMenuForTextIn: range, suggestedActions: [])
+
+        #expect(received?.selectedText == "Hello")
+        #expect(received?.startUTF16 == 0)
+        #expect(received?.endUTF16 == 5)
+    }
+
+    @Test("editMenuForTextIn with zero-length range posts nothing AND returns the empty menu")
+    func zeroLengthRange() {
+        let coordinator = TXTChunkedReaderBridge.Coordinator(delegate: nil)
+        coordinator.chunkStartOffsets = [0, 100]
+        let tv = makeTextView(text: "Hello", chunkIndex: 0)
+        let range = NSRange(location: 2, length: 0)
+
+        nonisolated(unsafe) var fired = false
+        let observer = NotificationCenter.default.addObserver(
+            forName: .readerSelectionPopoverRequested, object: nil, queue: nil
+        ) { _ in fired = true }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let menu = coordinator.textView(tv, editMenuForTextIn: range, suggestedActions: [])
+
+        #expect(menu != nil)
+        #expect(menu?.children.isEmpty == true)
+        #expect(!fired,
+                "Zero-length range (caret placement) must not post — popover is for selections.")
+    }
+
+    @Test("editMenuForTextIn with tag out of range falls back to offset 0 (defensive)")
+    func tagOutOfRange() {
+        // If textView.tag exceeds chunkStartOffsets count (shouldn't
+        // happen in practice but defensively pinned by the existing
+        // implementation), the offset falls back to 0 — the post
+        // should use the raw local range without a wrong chunk
+        // shift.
+        let coordinator = TXTChunkedReaderBridge.Coordinator(delegate: nil)
+        coordinator.chunkStartOffsets = [0, 100]
+        let tv = makeTextView(text: "Hello", chunkIndex: 99)  // out of range
+        let range = NSRange(location: 0, length: 5)
+
+        nonisolated(unsafe) var received: TextSelectionInfo?
+        let observer = NotificationCenter.default.addObserver(
+            forName: .readerSelectionPopoverRequested, object: nil, queue: nil
+        ) { note in
+            received = note.object as? TextSelectionInfo
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        _ = coordinator.textView(tv, editMenuForTextIn: range, suggestedActions: [])
+
+        #expect(received?.selectedText == "Hello")
+        #expect(received?.startUTF16 == 0,
+                "Out-of-range tag falls back to offset 0 (no spurious shift).")
+        #expect(received?.endUTF16 == 5)
+    }
+
+    @Test("editMenuForTextIn with negative tag falls back to offset 0 (does NOT crash)")
+    func negativeTag() {
+        // Codex Gate 4 round 1 (Low): textView.tag is Int and
+        // could in principle be negative; the previous bounds
+        // check only protected the high side. Clamping on both
+        // ends prevents a negative-index subscript crash. In
+        // production `cellForRowAt` always sets a non-negative
+        // tag — but pinning the defensive behavior here guards
+        // against a future regression where the tag isn't
+        // pre-initialized.
+        let coordinator = TXTChunkedReaderBridge.Coordinator(delegate: nil)
+        coordinator.chunkStartOffsets = [0, 100]
+        let tv = makeTextView(text: "Hello", chunkIndex: -1)
+        let range = NSRange(location: 0, length: 5)
+
+        nonisolated(unsafe) var received: TextSelectionInfo?
+        let observer = NotificationCenter.default.addObserver(
+            forName: .readerSelectionPopoverRequested, object: nil, queue: nil
+        ) { note in
+            received = note.object as? TextSelectionInfo
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        _ = coordinator.textView(tv, editMenuForTextIn: range, suggestedActions: [])
+
+        #expect(received?.selectedText == "Hello")
+        #expect(received?.startUTF16 == 0,
+                "Negative tag falls back to offset 0 (no negative-index crash).")
+        #expect(received?.endUTF16 == 5)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- TXT chunked bridge (UITableView of UITextView cells, >500K UTF-16 path) now posts `.readerSelectionPopoverRequested` on long-press selection and returns `UIMenu(children: [])` to suppress iOS. Mirrors WI-7c2 (PR #777) with the chunk-offset translation extra step.
- Defensive: clamp `chunkIndex` bounds check on both ends — negative tag falls back to offset 0 instead of crashing. Applied to both the new editMenuForTextIn post AND the pre-existing sibling `textViewDidChangeSelection` for symmetry.
- No container change needed — `TXTReaderContainerView` already attaches `.selectionPopoverPresenter(theme:)` (from WI-7c2); that wiring covers both chapter-based + chunked paths.

Part of feature #718.

## What Changed

- `vreader/Views/Reader/TXTChunkedReaderBridge.swift` — `editMenuForTextIn` swap + clamped chunk-index bounds in two sites.
- `vreaderTests/Views/Reader/TXTChunkedReaderBridgeEditMenuTests.swift` (NEW, 6 tests).

## WI Status

- WI-7c3: behavioral — TXT chunked. This PR.
- Remaining: WI-7c4 (MD bridge swap), WI-7c5 (EPUB bridge swap), WI-6b (chrome restructure), WI-8/9/10.

## Codex Audit (Gate 4)

Thread `019e2ed2-a117-7653-84e2-4466013d7717`, **2 rounds, final verdict: ship-as-is**.

- Round 1:
  - **Low**: `TXTBridgeShared.buildReaderEditMenu` is now dead in production (no callers remain after this WI). Accepted with rationale, deferred — the helper is still exercised by 3 tests in `TXTBridgeSharedTests.swift`; removing it would widen WI-7c3 into unrelated test deletion. MD doesn't use editMenuForTextIn at all, so a dedicated cleanup WI (or fold into WI-7c5) handles this.
  - **Low**: negative-tag crash class. Fixed both sibling sites (`textViewDidChangeSelection` line 513 pre-existing + new `editMenuForTextIn` line) with the clamped check `(chunkIndex >= 0 && chunkIndex < chunkStartOffsets.count) ? ... : 0`. Added `negativeTag` regression test.
- Round 2: clean.

Audit log: `.claude/codex-audits/feat-feature-60-wi-7c3-txt-chunked-popover-audit.md`

## Validation

- [x] `xcodebuild test -only-testing:vreaderTests/TXTChunkedReaderBridgeEditMenuTests` — 6/6 pass
- [x] Tests cover changed behavior (TDD: RED → GREEN — bridge contract pinned + chunk-offset translation + bounds)
- [x] Codex audit loop completed (2 rounds, ship-as-is)
- [x] Docs sync — n/a (no new service/notification/model; the notification this WI emits to was added in WI-7c1)
- [x] Version bumped: 3.24.4 → 3.24.5

## Gate 5a Verification (per-PR slice — pre-merge)

- **Tier**: behavioral.
- **Recorded**: `partial — bridge contract unit-tested; device verify deferred pending a chunked-triggering fixture`.

The behavior the chunked bridge contributes (editMenuForTextIn returns empty UIMenu + posts `.readerSelectionPopoverRequested`) is fully pinned by the 6 contract tests, including the chunked-specific chunk-offset translation (200 base + local 6,5 → global 206-211) and edge cases (zero-offset chunk, out-of-range tag, negative tag, zero-length range).

The device-visible end-to-end mechanism (notification → presenter → SelectionPopoverView sheet → action dispatch) is **identical** to WI-7c2 (PR #777) which IS device-verified — same notification name, same presenter modifier attached at the same container, same `TXTBridgeShared.postSelectionNotification` producer. The only chunked-specific path-difference is the chunk-offset translation, which is unit-pinned.

**Why device verify is `partial`**: the only available TXT fixture (`war-and-peace.txt`, 1705 bytes) is far below the chunked-path threshold (`largeFileThreshold = 500_000` UTF-16 in `TXTReaderContainerView.swift:44`). Without a chunked-triggering fixture, the simulator can't exercise the chunked path. Adding such a fixture is in itself outside WI-7c3's scope. Filing a follow-up to add a chunked-trigger fixture would close this gap.

## Type of Change

- [x] Feature WI (Part of feature #718)