### PR TITLE
docs(#60): mark WI-1b shipped in the plan

### DIFF
--- a/.claude/codex-audits/docs-feature-60-wi-1b-shipped-audit.md
+++ b/.claude/codex-audits/docs-feature-60-wi-1b-shipped-audit.md
@@ -1,0 +1,36 @@
+---
+branch: docs/feature-60-wi-1b-shipped
+threadId: manual-fallback
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-16
+---
+
+## Scope
+
+Updates the feature #60 plan to reflect WI-1b shipped (PR #778, v3.24.5). Touches `dev-docs/plans/20260515-feature-60-visual-identity-v2.md` (WI-1b table row + revision-history v9 entry) + `project.yml` / `project.pbxproj` (version bump 3.24.5/400 → 3.24.6/401).
+
+**No Swift source files changed.** The audit-gate hook fires on `project.pbxproj` in the diff — false positive of the Swift-file heuristic. Manual mini-audit.
+
+## Manual audit evidence
+
+### What changed and why
+
+- WI-1b table row: `Foundational — DEFERRED (manual-ops)` → `Behavioral — SHIPPED v3.24.5`. The reclassification Foundational → Behavioral is correct: when the plan first deferred WI-1b the `ReaderTypography` registry was dormant, but WI-4/5/7 have since merged and consume the registry + `cssFontStack` (verified earlier this session via `grep -rn "ReaderTypography\."` — hits in `ReaderSettingsStore`, `SelectionPopoverView`, `ReaderThemeV2+EPUBCSS`). Bundling the binaries therefore flips real rendering for users who select Source Serif 4 / Inter → behavioral.
+- Revision-history v9 entry records: the shipped state, the interactive-session discharge of the deferral, the OFL/RFN handling, the Gate-4 Codex rounds, the Gate-5a slice, and the downstream-gate lift (WI-5 typography device-verify no longer blocked).
+- Version-history numbering: the last numbered entry was `v8`; this adds `v9`. Monotonic. (The plan still carries the pre-existing duplicate-`v5` drift from parallel agents — out of scope here, flagged previously in PR #771's heads-up; not re-fixed as a drive-by.)
+
+### Correctness checks
+
+1. Facts in the new row/entry cross-checked against PR #778 (merged) and the WI-1b audit log `.claude/codex-audits/feat-feature-60-wi-1b-bundle-fonts-audit.md`: 7 faces, Source Serif 4.005 + Inter 4.1, both SIL OFL 1.1, Codex threads `019e2ed0`/`019e2ed5`, 2 rounds, ship-as-is — all consistent.
+2. The "~2.9 MB" font-binary size replaces the earlier "~180–320 KB" estimate (the deferred row's guess); 2.9 MB matches the actual staged size (`ls -la vreader/Resources/Fonts/`).
+3. Downstream-gate lift is accurate: with the binaries bundled, `ReaderTypography` resolves the real faces, so WI-5's typography device-verify can now confirm "Source Serif 4 renders".
+4. Version bump 3.24.6 / build 401; xcodegen regen confirmed.
+
+### Risks accepted
+
+None. Plan-doc + version-bump only.
+
+## Verdict
+
+ship-as-is — plan revision + version bump. No Swift logic. Manual fallback used because there is nothing to send to Codex.

--- a/dev-docs/plans/20260515-feature-60-visual-identity-v2.md
+++ b/dev-docs/plans/20260515-feature-60-visual-identity-v2.md
@@ -214,7 +214,7 @@ audit log + version bump per rule 40.
 | WI | Tier | What ships | Est PR size |
 |----|------|-----------|---------|
 | WI-1a | Foundational | `ReaderTypography` registry + extend `ReaderFontFamily` with `.sourceSerif4` / `.inter`. **No view change** — dormant infra. Tests: registry load, fontDescriptor availability, fallback chain. | ~6 files, ~250 LOC |
-| WI-1b | Foundational — **DEFERRED (manual-ops)** | Bundle the actual Source Serif 4 + Inter `.otf` binaries into `vreader/Resources/Fonts/` + `UIAppFonts` registration in the Info.plist. **Deferred 2026-05-16**: requires fetching external font assets + verifying their licenses (both are SIL OFL, but the OFL files must be vendored and the verification recorded) — out of cron-iteration scope (a cron session cannot safely fetch external binaries or make a licensing call). A human picks this up. Until WI-1b lands, `ReaderTypography.body(for:)` falls back to system fonts on device, so typography device-verification (WI-5 Gate 5a, Foliate font bundling, the final Gate 5b acceptance pass) cannot truly confirm "Source Serif 4 renders" — those verifications are gated on WI-1b. Tracked as GH #774. | font binaries (~180–320 KB) + Info.plist |
+| WI-1b | Behavioral — **SHIPPED v3.24.5** | Bundle the actual Source Serif 4 + Inter `.otf` binaries into `vreader/Resources/Fonts/` + `UIAppFonts` registration. **Shipped 2026-05-16** (PR #778): 7 faces — SourceSerif4 Regular/It/Bold/BoldIt (Source Serif 4.005) + Inter Regular/Medium/SemiBold (Inter 4.1); both SIL OFL 1.1, license texts vendored, fonts bundled unmodified (satisfies Source Serif 4's Reserved Font Name 'Source'). `ReaderTypography.body(for: .sourceSerif4 / .inter)` now resolves the real faces instead of the Georgia/system fallback. Reclassified Foundational → **Behavioral**: WI-4/5/7 (already merged) consume the registry + `cssFontStack`, so bundling the binaries flips real rendering for users who select Source Serif 4 / Inter. Gate 4: Codex 019e2ed0 + 019e2ed5, 2 rounds, ship-as-is. The deferral (external font fetch + OFL verification) was discharged in an interactive session — the user directed the fetch from official GitHub releases. **Unblocks** WI-5's typography Gate-5a device-verify, the Foliate font-bundling slice, and the Gate 5b acceptance pass. GH #774 closed. | font binaries (~2.9 MB) + Info.plist |
 | WI-2 | Foundational | Add `ReaderThemeV2` enum + 9-token surface. Migration alias on `ReaderTheme` so existing persisted choices still decode. **No view change** — dormant infra. Tests: token round-trip, isDark predicate, migration alias, accent contrast against ink (WCAG AA per theme). | ~4 files, ~300 LOC |
 | WI-3 | Foundational | Add `AccentColor`, `NamedHighlightColor`, `SelectionPopoverAction` types as UI-domain enums. **Additive only** (Codex Gate 2 finding): does NOT change the existing `Highlight.color` / `HighlightRecord.color` / backup DTO / export-import `String` schema. `NamedHighlightColor` raw values are semantic names; hex is a derived computed property. `SelectionPopoverAction` is `Equatable + Sendable` (NOT Codable — it's local-dispatch only, not persisted). `AccentColor` is a token-only struct with three named stops (light/warm-dark/photo). **No view change** — dormant infra. Tests: exhaustive switch, raw-value-is-semantic-name, derived-hex round-trip, compatibility (existing color strings remain storable + decodable to nil for unknown values), `from(storageString:)` round-trip. | ~3 files (4 if `NamedHighlightColor.swift` split out), ~150 LOC |
 | WI-4 | Behavioral | EPUB theme injection switches to `ReaderThemeV2`. `epubOverrideCSS` emits five-theme CSS + new token names. Existing EPUB books re-render with new visual tokens. Migration path: existing `epubTheme: .light/.sepia/.dark` continues to decode and maps to `.paper/.sepia/.dark`. Photo theme injects a `body { background-image: url(...) }` rule. Tests: CSS string assertions per theme + per-theme accent contrast. Device verify (Gate 5a): open mini-epub3 fixture per theme, confirm visually. | ~3 files, ~250 LOC |
@@ -746,3 +746,24 @@ category 2 (PLANNED feature with plan doc → Gate 3).
   final Gate 5b acceptance pass cannot confirm "Source Serif 4
   renders". Those verifications are now explicitly gated on WI-1b.
   Tracked as GH #774.
+- 2026-05-16 v9: **WI-1b SHIPPED (v3.24.5, PR #778).** The deferred
+  manual-ops step was discharged in an interactive `/feature-workflow`
+  session — the user directed fetching the binaries from the official
+  GitHub releases (`adobe-fonts/source-serif` 4.005, `rsms/inter`
+  4.1). 7 `.otf` faces vendored in `vreader/Resources/Fonts/`; both
+  SIL OFL 1.1 license texts committed alongside; `UIAppFonts`
+  registers all 7. Source Serif 4's Reserved Font Name 'Source' is
+  satisfied — fonts bundled verbatim under their original names (the
+  RFN only restricts modified derivatives). WI-1b **reclassified
+  Foundational → Behavioral**: when the plan first deferred it the
+  registry was dormant, but WI-4/5/7 have since merged and consume
+  `ReaderTypography` + `cssFontStack`, so bundling the binaries flips
+  real rendering. Gate 4: Codex `019e2ed0` + `019e2ed5`, 2 rounds,
+  ship-as-is (round 1: 1 High untracked-assets + 1 Low stale-comments;
+  round 2: 1 Low stale-header-ref; all fixed). Gate 5a slice: the
+  `bundledFace_resolvesByPostScriptName` parameterized test proves all
+  7 faces register + resolve via `UIFont(name:)` in the app-bundle
+  test host. **Downstream gate lifted** — WI-5's typography Gate-5a
+  device-verify, the Foliate font-bundling slice (Risk (c)), and the
+  Gate 5b acceptance pass are no longer blocked on WI-1b. GH #774
+  closed.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 400
-        MARKETING_VERSION: 3.24.5
+        CURRENT_PROJECT_VERSION: 401
+        MARKETING_VERSION: 3.24.6
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4686,13 +4686,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 400;
+				CURRENT_PROJECT_VERSION = 401;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.24.5;
+				MARKETING_VERSION = 3.24.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4836,13 +4836,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 400;
+				CURRENT_PROJECT_VERSION = 401;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.24.5;
+				MARKETING_VERSION = 3.24.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

WI-1b (Source Serif 4 + Inter font binaries) shipped in v3.24.5 (PR #778). This updates the feature #60 plan to match:

- WI-1b table row: `Foundational — DEFERRED (manual-ops)` → `Behavioral — SHIPPED v3.24.5`. Reclassified Behavioral because WI-4/5/7 (since merged) consume `ReaderTypography` — bundling the binaries flips real rendering.
- Revision-history v9 entry: records the shipped state, OFL/RFN handling, Gate-4 Codex rounds, and the downstream-gate lift.
- The WI-5 typography device-verify / Foliate font-bundling / Gate-5b gates were "blocked on WI-1b" — now lifted.

Part of feature #60 (GH #718).

## Codex Audit

`.claude/codex-audits/docs-feature-60-wi-1b-shipped-audit.md` — manual fallback (plan-doc only, no Swift logic), verdict: ship-as-is.

## Validation

- [x] Plan-doc only — no Swift source changes
- [x] Version bumped to 3.24.6 / build 401