### PR TITLE
chore: bump version to 3.24.6 (post WI-1b/WI-7c3 version collision)

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 400
-        MARKETING_VERSION: 3.24.5
+        CURRENT_PROJECT_VERSION: 401
+        MARKETING_VERSION: 3.24.6
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4690,13 +4690,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 400;
+				CURRENT_PROJECT_VERSION = 401;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.24.5;
+				MARKETING_VERSION = 3.24.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4840,13 +4840,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 400;
+				CURRENT_PROJECT_VERSION = 401;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.24.5;
+				MARKETING_VERSION = 3.24.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

WI-1b (PR #778, font binaries) and WI-7c3 (PR #779, TXT chunked popover swap) both branched off main at 3.24.4/399 and bumped to 3.24.5/400 independently. PR #778 merged first and tagged v3.24.5 on its merge commit \`bf9efc3\`; PR #779 squashed at the same 3.24.5/400 version.

This bumps main forward to 3.24.6/401 so the state on main is properly versioned and so WI-7c3's distinct deliverable can get its own tag (v3.24.6).

## Type of Change

- [x] Chore (version bump only — no code change)

## Validation

- [x] `xcodegen generate` regenerated pbxproj