### PR TITLE
feat(#718 WI-7c5a): typed SelectionPopoverRequestPayload + request-token plumbing

### DIFF
--- a/.claude/codex-audits/feat-feature-60-wi-7c5a-token-payload-audit.md
+++ b/.claude/codex-audits/feat-feature-60-wi-7c5a-token-payload-audit.md
@@ -1,0 +1,89 @@
+---
+branch: feat/feature-60-wi-7c5a-token-payload
+threadId: 019e2f21-e10c-7240-9d3a-9e7232062f78
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-16
+---
+
+# Codex Audit — Feature #60 WI-7c5a typed payload + request-token plumbing
+
+## Round 1 — 2 Lows
+
+### Low #1 — `requestToken` pass-through untested
+- **`vreaderTests/Views/Reader/TXTBridgeSharedTests.swift`** | Low
+  The new `requestToken` parameter on
+  `TXTBridgeShared.postSelectionNotification` is never exercised by
+  a test. No production TXT/MD caller passes a non-nil token, so a
+  future regression in the helper's delegation to
+  `SelectionPopoverRequest.post(selection:requestToken:)` would go
+  uncaught.
+
+**Resolution**: Fixed. Added
+`postSelectionNotificationPassesThroughRequestToken()` —
+calls `postSelectionNotification(.readerSelectionPopoverRequested,
+from:, range:, requestToken: token)` and asserts
+`SelectionPopoverRequest.payload(from:)?.requestToken == token` plus
+the selection round-trip. New test passes; TXTBridgeShared suite is
+6 tests, all green.
+
+### Low #2 — stale `ReaderNotifications.swift` companion comment
+- **`vreader/Views/Reader/ReaderNotifications.swift:130`** | Low
+  The `readerSelectionPopoverRequested` doc comment still said the
+  notification `object` is a `TextSelectionInfo` — WI-7c5a changed
+  the primary wire shape to `SelectionPopoverRequestPayload`.
+
+**Resolution**: Fixed. Comment now documents the
+`SelectionPopoverRequestPayload` object (selection + optional
+`requestToken`) and the legacy bare-`TextSelectionInfo`
+compatibility via `SelectionPopoverRequest.payload(from:)`.
+
+## Round 2 — clean
+
+Codex verified both fixes: *"No findings. Both Round 2 fixes are
+correct. … WI-7c5a looks clean for merge."*
+
+## Accepted with rationale (not blocking)
+
+- **`requestToken` speculative generality on
+  `postSelectionNotification`**: no current caller passes it
+  non-nil (TXT/MD pass nil; EPUB WI-7c5b does not route through
+  this helper). Codex round 1: *"acceptable speculative generality
+  in this case because it is internal, small, and explicitly
+  called for by the plan; I would keep it, just pin it with the
+  missing test"* — the test was added (Low #1 fix).
+- **Test-file size**: `SelectionPopoverActionRouterTests.swift`
+  (319 lines) and `SelectionPopoverPresenterTests.swift`
+  (306 lines) are marginally over the repo's ~300-line guideline.
+  Accepted: cohesive single-contract Swift Testing suites;
+  splitting would scatter one notification contract across files,
+  and the ~300 guideline targets production-code readability.
+  Codex: *"I would not block on that alone."*
+
+## Verdict statement
+
+**ship-as-is** after round 1 (2 Lows both fixed). Round 2 clean.
+
+All 8 audit dimensions clean:
+1. Correctness — matches the plan v10 WI-7c5a spec exactly (typed `SelectionPopoverRequestPayload`, `post(...requestToken:)`, `payload(from:)` migration-safe, `route(action:payload:)`, `postSelectionNotification` delegation, `nextPending(after:currentPayload:)`).
+2. Edge cases — nil token, legacy-bare-`TextSelectionInfo` migration branch, `makeUserInfo` nil-vs-empty-dict, the `.readerSelectionPopoverRequested` name branch — all covered by tests.
+3. Security — none (pure NotificationCenter, in-process).
+4. Duplicate code — `makeUserInfo` is the right factoring for the token+color userInfo assembly; no other dup.
+5. Dead code — none. `requestToken` param accepted as plan-mandated speculative generality, now test-pinned.
+6. Shortcuts / patches — none.
+7. VReader compliance — Swift 6 satisfied (`nonisolated` on `payload(from:)` so the synchronous NotificationCenter observer closure can call it without "sending note risks data races"); `@MainActor` correctness preserved on `post`; all touched runtime files <300 lines.
+8. Bridge safety — N/A (no JS). The router still posts a bare `TextSelectionInfo` as the action notification's `object`, so `ReaderNotificationModifier` + `ReaderContainerView` consumers are unaffected — Codex confirmed.
+
+## Test results
+
+- WI-7c5a's 6 affected suites: 40 tests pass (SelectionPopoverPresenterTests, SelectionPopoverRequestPayloadTests, SelectionPopoverDismissPolicyTests, SelectionPopoverActionRouterTests, TXTTextViewBridgeEditMenuTests, TXTChunkedReaderBridgeEditMenuTests) + TXTBridgeShared 6 tests.
+- Full `vreaderTests` gate: WI-7c5a code clean; the only full-gate failures were the pre-existing parallel-execution flakes (`ReplacementTransformTests`, `CoverLifecycleTests`) — confirmed pass in isolation (17/17). Same flake class documented in WI-7c2's audit log.
+
+## Strengths called out by Codex
+
+- The routed action notifications still carry bare `TextSelectionInfo` objects, so `ReaderNotificationModifier` and `ReaderContainerView` remain compatible — the wire-format change is contained to `.readerSelectionPopoverRequested`.
+- `payload(from:)` is migration-safe — a producer still posting a bare `TextSelectionInfo` decodes as a tokenless payload, so the contract change is not a flag-day break.
+
+## Follow-up items
+
+None. WI-7c5b (EPUB producer/consumer swap) consumes this token plumbing — next WI.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 404
-        MARKETING_VERSION: 3.24.9
+        CURRENT_PROJECT_VERSION: 405
+        MARKETING_VERSION: 3.24.10
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4690,13 +4690,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 404;
+				CURRENT_PROJECT_VERSION = 405;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.24.9;
+				MARKETING_VERSION = 3.24.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4840,13 +4840,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 404;
+				CURRENT_PROJECT_VERSION = 405;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.24.9;
+				MARKETING_VERSION = 3.24.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Views/Reader/ReaderNotifications.swift
+++ b/vreader/Views/Reader/ReaderNotifications.swift
@@ -127,10 +127,15 @@ extension Notification.Name {
     /// finishes a long-press selection. The
     /// `SelectionPopoverPresenterModifier` observes this and presents
     /// `SelectionPopoverView` (WI-7a) as a SwiftUI sheet; actions
-    /// route through `SelectionPopoverActionRouter` (WI-7b). The
-    /// notification's `object` is the `TextSelectionInfo` payload.
-    /// Bridges should suppress their legacy `UIMenu` when they post
-    /// this (the swap lands per-bridge in WI-7c2..7c5).
+    /// route through `SelectionPopoverActionRouter` (WI-7b). Bridges
+    /// should suppress their legacy `UIMenu` when they post this
+    /// (the swap landed per-bridge across WI-7c2..7c5).
+    ///
+    /// WI-7c5a: the notification's `object` is a
+    /// `SelectionPopoverRequestPayload` (`selection` +
+    /// optional `requestToken`). A producer that still posts a bare
+    /// `TextSelectionInfo` decodes as a tokenless payload —
+    /// `SelectionPopoverRequest.payload(from:)` handles both shapes.
     static let readerSelectionPopoverRequested = Notification.Name("vreader.readerSelectionPopoverRequested")
 }
 

--- a/vreader/Views/Reader/SelectionPopoverActionRouter.swift
+++ b/vreader/Views/Reader/SelectionPopoverActionRouter.swift
@@ -63,30 +63,43 @@ enum SelectionPopoverActionRouter {
     /// `userInfo` fall back to the default `"yellow"` color in the
     /// downstream pipeline; new observers (WI-7c forward) can
     /// honor the chosen color.
+    ///
+    /// **WI-7c5a**: takes a `SelectionPopoverRequestPayload` rather
+    /// than a bare `TextSelectionInfo`. When the payload carries a
+    /// `requestToken`, it rides the action notification's `userInfo`
+    /// under `"selectionRequestToken"` as a `UUID` — letting EPUB
+    /// (WI-7c5b) resolve which cached selection an action belongs
+    /// to. The posted `object` stays a bare `TextSelectionInfo` so
+    /// the TXT / MD `ReaderNotificationModifier` consumers are
+    /// unaffected. A tokenless payload (TXT / MD / chunked) attaches
+    /// no token key.
     @discardableResult
     static func route(
         action: SelectionPopoverAction,
-        selection: TextSelectionInfo,
+        payload: SelectionPopoverRequestPayload,
         notificationCenter: NotificationCenter = .default
     ) -> Result {
+        let selection = payload.selection
         switch action {
         case .highlight(let color):
             notificationCenter.post(
                 name: .readerHighlightRequested,
                 object: selection,
-                userInfo: ["color": color.rawValue]
+                userInfo: makeUserInfo(token: payload.requestToken, color: color.rawValue)
             )
             return .dispatched(.readerHighlightRequested)
         case .note:
             notificationCenter.post(
                 name: .readerAnnotationRequested,
-                object: selection
+                object: selection,
+                userInfo: makeUserInfo(token: payload.requestToken, color: nil)
             )
             return .dispatched(.readerAnnotationRequested)
         case .translate:
             notificationCenter.post(
                 name: .readerTranslateRequested,
-                object: selection
+                object: selection,
+                userInfo: makeUserInfo(token: payload.requestToken, color: nil)
             )
             return .dispatched(.readerTranslateRequested)
         case .askAI, .read:
@@ -97,5 +110,20 @@ enum SelectionPopoverActionRouter {
             // a later WI of feature #60.
             return .deferredNotYetWired(action)
         }
+    }
+
+    /// Build the action notification's `userInfo`, attaching the
+    /// request token and/or color only when present. Returns `nil`
+    /// when neither applies — preserving the pre-WI-7c5a contract
+    /// that a tokenless `.note` / `.translate` posts no `userInfo`
+    /// at all.
+    private static func makeUserInfo(
+        token: UUID?,
+        color: String?
+    ) -> [AnyHashable: Any]? {
+        var info: [AnyHashable: Any] = [:]
+        if let token { info["selectionRequestToken"] = token }
+        if let color { info["color"] = color }
+        return info.isEmpty ? nil : info
     }
 }

--- a/vreader/Views/Reader/SelectionPopoverPresenter.swift
+++ b/vreader/Views/Reader/SelectionPopoverPresenter.swift
@@ -15,11 +15,18 @@
 //
 // **Why parse + post helpers in a small enum**: mirrors the
 // `FoliateSelectionDispatcher` / `FoliateMessageParser` pattern so
-// bridges have a single typed entry point (`post(selection:on:)`)
-// and observers have a single typed read point
-// (`selection(from:)`). Keeps the wire format local to the
-// presenter and trivially unit-testable without SwiftUI / sheet
-// lifecycle integration.
+// bridges have a single typed entry point
+// (`post(selection:on:requestToken:)`) and observers have a single
+// typed read point (`payload(from:)`). Keeps the wire format local
+// to the presenter and trivially unit-testable without SwiftUI /
+// sheet lifecycle integration.
+//
+// **WI-7c5a**: the notification `object` is a typed
+// `SelectionPopoverRequestPayload` (selection + optional
+// `requestToken`), not a bare `TextSelectionInfo`. The token lets
+// EPUB (WI-7c5b) round-trip a non-UTF-16 selection identity.
+// `payload(from:)` still decodes a legacy bare `TextSelectionInfo`
+// as a tokenless payload, so the change is not a flag-day break.
 //
 // @coordinates-with: SelectionPopoverView.swift,
 //   SelectionPopoverActionRouter.swift,
@@ -28,6 +35,28 @@
 
 #if canImport(UIKit)
 import SwiftUI
+
+// MARK: - Request payload (wire format — WI-7c5a)
+
+/// Typed payload carried as `notification.object` on
+/// `.readerSelectionPopoverRequested`. Bundles the long-press
+/// `selection` with an optional `requestToken`.
+///
+/// **Why the token**: TXT / MD / chunked all anchor a selection by
+/// UTF-16 offsets (`TextSelectionInfo.startUTF16` / `.endUTF16`), so
+/// the selection *is* its own identity. EPUB (WI-7c5b) anchors by a
+/// DOM-path `EPUBSerializedRange` that `TextSelectionInfo` cannot
+/// carry — so the EPUB container mints a `UUID` per selection,
+/// stashes the real `ReaderSelectionEvent` under it, and posts the
+/// token here. The token round-trips through
+/// `SelectionPopoverActionRouter` into the action notification's
+/// `userInfo`, letting the EPUB consumer resolve which cached
+/// selection an action belongs to. TXT / MD / chunked leave it
+/// `nil`; the token is dormant for them.
+struct SelectionPopoverRequestPayload: Equatable, Sendable {
+    let selection: TextSelectionInfo
+    let requestToken: UUID?
+}
 
 // MARK: - Request helper (wire format)
 
@@ -40,25 +69,48 @@ import SwiftUI
 enum SelectionPopoverRequest {
 
     /// Post a `.readerSelectionPopoverRequested` notification carrying
-    /// the long-press selection as `notification.object`. Bridges
-    /// call this immediately after their UIKit selection finalises
-    /// (and before they would have built the legacy `UIMenu`).
+    /// a `SelectionPopoverRequestPayload` as `notification.object`.
+    /// Bridges call this immediately after their UIKit selection
+    /// finalises (and before they would have built the legacy
+    /// `UIMenu`). `requestToken` defaults to `nil` — only EPUB
+    /// (WI-7c5b) supplies one.
     static func post(
         selection: TextSelectionInfo,
-        on notificationCenter: NotificationCenter = .default
+        on notificationCenter: NotificationCenter = .default,
+        requestToken: UUID? = nil
     ) {
+        let payload = SelectionPopoverRequestPayload(
+            selection: selection,
+            requestToken: requestToken
+        )
         notificationCenter.post(
             name: .readerSelectionPopoverRequested,
-            object: selection
+            object: payload
         )
     }
 
-    /// Extract the `TextSelectionInfo` payload from a notification.
-    /// Returns nil if `notification.object` isn't the expected
-    /// shape — defensive against a bridge mis-posting during
-    /// development, not a runtime error.
-    static func selection(from notification: Notification) -> TextSelectionInfo? {
-        notification.object as? TextSelectionInfo
+    /// Extract the `SelectionPopoverRequestPayload` from a
+    /// notification. Migration-safe: a producer that still posts a
+    /// bare `TextSelectionInfo` (the pre-WI-7c5a wire shape) decodes
+    /// as a tokenless payload. Returns nil if `notification.object`
+    /// is neither shape — defensive against a bridge mis-posting
+    /// during development, not a runtime error.
+    ///
+    /// `nonisolated`: a pure parse over `Sendable` inputs/outputs
+    /// (`SelectionPopoverRequestPayload` + `TextSelectionInfo` are
+    /// both `Sendable`). It must be callable from a synchronous
+    /// `NotificationCenter` observer closure — a non-isolated
+    /// `@Sendable` context — without "sending `note` risks data
+    /// races". The enclosing enum stays `@MainActor` for `post`,
+    /// whose callers are all main-actor bridges.
+    nonisolated static func payload(from notification: Notification) -> SelectionPopoverRequestPayload? {
+        if let payload = notification.object as? SelectionPopoverRequestPayload {
+            return payload
+        }
+        if let selection = notification.object as? TextSelectionInfo {
+            return SelectionPopoverRequestPayload(selection: selection, requestToken: nil)
+        }
+        return nil
     }
 }
 
@@ -72,19 +124,19 @@ enum SelectionPopoverDismissPolicy {
 
     /// What value `pending` should take after `router.route(...)`
     /// returns `result`. `nil` clears the sheet (dispatched);
-    /// returning the same `currentSelection` keeps it open
+    /// returning the same `currentPayload` keeps it open
     /// (deferred — see plan v8 / Codex Gate 4 round 1 Medium:
     /// `.askAI` / `.read` have no production pipeline yet, auto-
     /// dismissing would silently swallow the tap).
     static func nextPending(
         after result: SelectionPopoverActionRouter.Result,
-        currentSelection: TextSelectionInfo
-    ) -> TextSelectionInfo? {
+        currentPayload: SelectionPopoverRequestPayload
+    ) -> SelectionPopoverRequestPayload? {
         switch result {
         case .dispatched:
             return nil
         case .deferredNotYetWired:
-            return currentSelection
+            return currentPayload
         }
     }
 }
@@ -103,7 +155,7 @@ enum SelectionPopoverDismissPolicy {
 /// WI-7c2..7c5.
 private struct SelectionPopoverPresenterModifier: ViewModifier {
     let theme: ReaderThemeV2
-    @State private var pending: TextSelectionInfo?
+    @State private var pending: SelectionPopoverRequestPayload?
 
     /// Maps `pending != nil` to a `Bool` binding the sheet API
     /// requires. Setting to `false` clears the pending state —
@@ -123,10 +175,10 @@ private struct SelectionPopoverPresenterModifier: ViewModifier {
             .onReceive(
                 NotificationCenter.default.publisher(for: .readerSelectionPopoverRequested)
             ) { note in
-                guard let selection = SelectionPopoverRequest.selection(from: note) else {
+                guard let payload = SelectionPopoverRequest.payload(from: note) else {
                     return
                 }
-                pending = selection
+                pending = payload
             }
             .sheet(isPresented: isPresentedBinding) {
                 sheetContent
@@ -135,18 +187,18 @@ private struct SelectionPopoverPresenterModifier: ViewModifier {
 
     @ViewBuilder
     private var sheetContent: some View {
-        if let selection = pending {
+        if let payload = pending {
             SelectionPopoverView(
-                selectionText: selection.selectedText,
+                selectionText: payload.selection.selectedText,
                 theme: theme,
                 onAction: { action in
                     let result = SelectionPopoverActionRouter.route(
                         action: action,
-                        selection: selection
+                        payload: payload
                     )
                     pending = SelectionPopoverDismissPolicy.nextPending(
                         after: result,
-                        currentSelection: selection
+                        currentPayload: payload
                     )
                 },
                 onClose: { pending = nil }

--- a/vreader/Views/Reader/TXTBridgeShared.swift
+++ b/vreader/Views/Reader/TXTBridgeShared.swift
@@ -17,12 +17,22 @@ enum TXTBridgeShared {
 
     /// Posts a selection notification with text and UTF-16 range.
     /// For chunked readers, pass `chunkOffset` to convert chunk-local to document-global.
+    ///
+    /// WI-7c5a: for `.readerSelectionPopoverRequested`, the wire
+    /// format is a typed `SelectionPopoverRequestPayload` — this
+    /// helper delegates to `SelectionPopoverRequest.post(...)` so
+    /// that enum stays the single owner of the popover wire format.
+    /// `requestToken` defaults to `nil` (TXT / MD / chunked never
+    /// supply one — only EPUB's WI-7c5b producer does, and it does
+    /// not route through this helper). For every other notification
+    /// name the object remains a bare `TextSelectionInfo`.
     @MainActor
     static func postSelectionNotification(
         _ name: Notification.Name,
         from textView: UITextView,
         range: NSRange,
-        chunkOffset: Int = 0
+        chunkOffset: Int = 0,
+        requestToken: UUID? = nil
     ) {
         guard range.location != NSNotFound,
               range.location >= 0,
@@ -37,7 +47,11 @@ enum TXTBridgeShared {
             startUTF16: chunkOffset + range.location,
             endUTF16: chunkOffset + range.location + range.length
         )
-        NotificationCenter.default.post(name: name, object: info)
+        if name == .readerSelectionPopoverRequested {
+            SelectionPopoverRequest.post(selection: info, requestToken: requestToken)
+        } else {
+            NotificationCenter.default.post(name: name, object: info)
+        }
     }
 
     /// Builds the shared edit menu with Highlight, Add Note, Define, and

--- a/vreader/Views/Reader/TXTTextViewBridgeCoordinator.swift
+++ b/vreader/Views/Reader/TXTTextViewBridgeCoordinator.swift
@@ -340,11 +340,11 @@ extension TXTTextViewBridge {
             // range→TextSelectionInfo extraction with UTF-16 + bounds
             // validation matching UITextView delegate semantics —
             // duplicating that contract on the producer side would
-            // drift. The presenter still parses via
-            // SelectionPopoverRequest.selection(from:) which reads
-            // `notification.object as? TextSelectionInfo` — the same
-            // wire shape both helpers produce. (When WI-7c3..7c5
-            // land, all 4 bridges share this single producer path.)
+            // drift. WI-7c5a: that helper now delegates to
+            // SelectionPopoverRequest.post for the popover name, so
+            // the object is a typed SelectionPopoverRequestPayload
+            // (tokenless for TXT); the presenter parses it via
+            // SelectionPopoverRequest.payload(from:).
             if range.length > 0 {
                 TXTBridgeShared.postSelectionNotification(
                     .readerSelectionPopoverRequested,

--- a/vreaderTests/Views/Reader/SelectionPopoverActionRouterTests.swift
+++ b/vreaderTests/Views/Reader/SelectionPopoverActionRouterTests.swift
@@ -1,24 +1,30 @@
-// Purpose: Feature #60 WI-7b — pins the routing contract between
-// `SelectionPopoverAction` (the dispatch enum from WI-3) and the
-// existing reader-bridge notification surface
+// Purpose: Feature #60 WI-7b + WI-7c5a — pins the routing contract
+// between `SelectionPopoverAction` (the dispatch enum from WI-3) and
+// the existing reader-bridge notification surface
 // (`.readerHighlightRequested`, `.readerAnnotationRequested`,
 // `.readerTranslateRequested`).
 //
-// The router is the pure-logic glue that the future WI-7c production
-// view (which captures the long-press selection and presents
-// `SelectionPopoverView` from WI-7a) will call when the user taps a
-// row in the popover. Keeping the mapping in a static helper —
-// rather than inside a SwiftUI view body or coordinator — lets the
-// contract be tested without touching UIKit or NotificationCenter
-// globals.
+// The router is the pure-logic glue that the WI-7c production views
+// call when the user taps a row in the popover. Keeping the mapping
+// in a static helper — rather than inside a SwiftUI view body or
+// coordinator — lets the contract be tested without touching UIKit
+// or NotificationCenter globals.
+//
+// **WI-7c5a contract change**: `route` now takes a
+// `SelectionPopoverRequestPayload` (selection + optional
+// `requestToken`) instead of a bare `TextSelectionInfo`. When the
+// payload carries a token, the router attaches it to the action
+// notification's `userInfo["selectionRequestToken"]` as a `UUID` so
+// a format with a non-UTF-16 anchor model (EPUB — WI-7c5b) can
+// resolve which cached selection the action belongs to. The posted
+// `object` stays a bare `TextSelectionInfo` so the existing TXT/MD
+// `ReaderNotificationModifier` consumers are unaffected.
 //
 // **Deferred actions (`.askAI`, `.read`)**: feature #60's plan ships
 // the View + router + WI-7c wiring sequentially. `.askAI` and
-// `.read` have no production consumer yet (no `.readerAskAIRequested`
-// or `.readerReadAloudRequested` exists in `ReaderNotifications`).
-// The router returns `.deferredNotYetWired` rather than silently
-// no-opping, so test runs and future audits can prove a regression
-// would surface (instead of hiding behind a `default: break`).
+// `.read` have no production consumer yet. The router returns
+// `.deferredNotYetWired` rather than silently no-opping, so test
+// runs and future audits can prove a regression would surface.
 
 import Testing
 import Foundation
@@ -38,6 +44,16 @@ struct SelectionPopoverActionRouterTests {
         )
     }
 
+    /// Tokenless payload — the TXT/MD/chunked producer shape.
+    private func makePayload() -> SelectionPopoverRequestPayload {
+        SelectionPopoverRequestPayload(selection: makeSelection(), requestToken: nil)
+    }
+
+    /// Tokened payload — the EPUB producer shape (WI-7c5b).
+    private func makeTokenedPayload(_ token: UUID) -> SelectionPopoverRequestPayload {
+        SelectionPopoverRequestPayload(selection: makeSelection(), requestToken: token)
+    }
+
     /// Isolated NotificationCenter (not `.default`) so tests don't
     /// observe spurious traffic from concurrent app state.
     private func makeIsolatedCenter() -> NotificationCenter {
@@ -51,7 +67,7 @@ struct SelectionPopoverActionRouterTests {
         let center = makeIsolatedCenter()
         let result = SelectionPopoverActionRouter.route(
             action: .note,
-            selection: makeSelection(),
+            payload: makePayload(),
             notificationCenter: center
         )
         #expect(result == .dispatched(.readerAnnotationRequested))
@@ -62,14 +78,14 @@ struct SelectionPopoverActionRouterTests {
         let center = makeIsolatedCenter()
         let askResult = SelectionPopoverActionRouter.route(
             action: .askAI,
-            selection: makeSelection(),
+            payload: makePayload(),
             notificationCenter: center
         )
         #expect(askResult == .deferredNotYetWired(.askAI))
 
         let readResult = SelectionPopoverActionRouter.route(
             action: .read,
-            selection: makeSelection(),
+            payload: makePayload(),
             notificationCenter: center
         )
         #expect(readResult == .deferredNotYetWired(.read))
@@ -82,7 +98,7 @@ struct SelectionPopoverActionRouterTests {
         let received = try captureNotification(name: .readerHighlightRequested) { center in
             _ = SelectionPopoverActionRouter.route(
                 action: .highlight(.yellow),
-                selection: makeSelection(),
+                payload: makePayload(),
                 notificationCenter: center
             )
         }
@@ -98,7 +114,7 @@ struct SelectionPopoverActionRouterTests {
         let received = try captureNotification(name: .readerHighlightRequested) { center in
             _ = SelectionPopoverActionRouter.route(
                 action: .highlight(.pink),
-                selection: makeSelection(),
+                payload: makePayload(),
                 notificationCenter: center
             )
         }
@@ -110,7 +126,7 @@ struct SelectionPopoverActionRouterTests {
         let received = try captureNotification(name: .readerHighlightRequested) { center in
             _ = SelectionPopoverActionRouter.route(
                 action: .highlight(.green),
-                selection: makeSelection(),
+                payload: makePayload(),
                 notificationCenter: center
             )
         }
@@ -122,7 +138,7 @@ struct SelectionPopoverActionRouterTests {
         let received = try captureNotification(name: .readerHighlightRequested) { center in
             _ = SelectionPopoverActionRouter.route(
                 action: .highlight(.blue),
-                selection: makeSelection(),
+                payload: makePayload(),
                 notificationCenter: center
             )
         }
@@ -131,19 +147,19 @@ struct SelectionPopoverActionRouterTests {
 
     // MARK: - Note + Translate routing
 
-    @Test("note posts .readerAnnotationRequested with selection (no userInfo)")
+    @Test("note posts .readerAnnotationRequested with selection (no userInfo for a tokenless payload)")
     func noteRoutes() throws {
         let received = try captureNotification(name: .readerAnnotationRequested) { center in
             _ = SelectionPopoverActionRouter.route(
                 action: .note,
-                selection: makeSelection(),
+                payload: makePayload(),
                 notificationCenter: center
             )
         }
         let info = try #require(received.object as? TextSelectionInfo)
         #expect(info.selectedText == "the rapidity of the infection")
-        // Note has no color/userInfo — pure object payload.
-        #expect(received.userInfo == nil || received.userInfo?["color"] == nil)
+        // Tokenless payload + no color → no userInfo at all.
+        #expect(received.userInfo == nil)
     }
 
     @Test("translate posts .readerTranslateRequested with selection")
@@ -151,12 +167,73 @@ struct SelectionPopoverActionRouterTests {
         let received = try captureNotification(name: .readerTranslateRequested) { center in
             _ = SelectionPopoverActionRouter.route(
                 action: .translate,
-                selection: makeSelection(),
+                payload: makePayload(),
                 notificationCenter: center
             )
         }
         let info = try #require(received.object as? TextSelectionInfo)
         #expect(info.endUTF16 == 1053)
+    }
+
+    // MARK: - Request-token pass-through (WI-7c5a)
+
+    @Test("highlight with a tokened payload attaches selectionRequestToken (UUID) to userInfo")
+    func highlightCarriesRequestToken() throws {
+        let requestToken = UUID()
+        let received = try captureNotification(name: .readerHighlightRequested) { center in
+            _ = SelectionPopoverActionRouter.route(
+                action: .highlight(.yellow),
+                payload: makeTokenedPayload(requestToken),
+                notificationCenter: center
+            )
+        }
+        // The token rides as a `UUID` — not a String — because the
+        // notification is in-process; there is no Codable boundary.
+        #expect(received.userInfo?["selectionRequestToken"] as? UUID == requestToken)
+        // The color contract is unaffected by the token.
+        #expect(received.userInfo?["color"] as? String == "yellow")
+    }
+
+    @Test("note with a tokened payload attaches selectionRequestToken to userInfo")
+    func noteCarriesRequestToken() throws {
+        let requestToken = UUID()
+        let received = try captureNotification(name: .readerAnnotationRequested) { center in
+            _ = SelectionPopoverActionRouter.route(
+                action: .note,
+                payload: makeTokenedPayload(requestToken),
+                notificationCenter: center
+            )
+        }
+        #expect(received.userInfo?["selectionRequestToken"] as? UUID == requestToken)
+    }
+
+    @Test("translate with a tokened payload attaches selectionRequestToken to userInfo")
+    func translateCarriesRequestToken() throws {
+        let requestToken = UUID()
+        let received = try captureNotification(name: .readerTranslateRequested) { center in
+            _ = SelectionPopoverActionRouter.route(
+                action: .translate,
+                payload: makeTokenedPayload(requestToken),
+                notificationCenter: center
+            )
+        }
+        #expect(received.userInfo?["selectionRequestToken"] as? UUID == requestToken)
+    }
+
+    @Test("a tokenless payload attaches NO selectionRequestToken key")
+    func tokenlessPayloadOmitsTokenKey() throws {
+        // Negative pin: TXT/MD/chunked producers pass a nil token;
+        // the router must not invent a key. EPUB's WI-7c5b consumer
+        // distinguishes "this action belongs to my cached selection"
+        // by the presence of the key.
+        let received = try captureNotification(name: .readerHighlightRequested) { center in
+            _ = SelectionPopoverActionRouter.route(
+                action: .highlight(.yellow),
+                payload: makePayload(),
+                notificationCenter: center
+            )
+        }
+        #expect(received.userInfo?["selectionRequestToken"] == nil)
     }
 
     // MARK: - Deferred .askAI / .read do not post
@@ -167,7 +244,7 @@ struct SelectionPopoverActionRouterTests {
         let fired = noRoutedNotificationFires(on: center) {
             _ = SelectionPopoverActionRouter.route(
                 action: .askAI,
-                selection: makeSelection(),
+                payload: makePayload(),
                 notificationCenter: center
             )
         }
@@ -180,7 +257,7 @@ struct SelectionPopoverActionRouterTests {
         let fired = noRoutedNotificationFires(on: center) {
             _ = SelectionPopoverActionRouter.route(
                 action: .read,
-                selection: makeSelection(),
+                payload: makePayload(),
                 notificationCenter: center
             )
         }

--- a/vreaderTests/Views/Reader/SelectionPopoverPresenterTests.swift
+++ b/vreaderTests/Views/Reader/SelectionPopoverPresenterTests.swift
@@ -1,19 +1,27 @@
-// Purpose: Feature #60 WI-7c1 — pins the cross-boundary contract for
-// the `.readerSelectionPopoverRequested` notification and the parse
-// helper that turns the raw `Notification` into a typed
-// `TextSelectionInfo`. The SwiftUI sheet lifecycle inside
-// `SelectionPopoverPresenterModifier` is integration / device-verify
-// territory (sheet presents/dismisses are SwiftUI side-effects that
-// don't unit-test cleanly). The unit-test surface this file pins is
-// the public wire format that bridge swaps (WI-7c2–WI-7c5) will post
-// onto.
+// Purpose: Feature #60 WI-7c1 + WI-7c5a — pins the cross-boundary
+// contract for the `.readerSelectionPopoverRequested` notification
+// and the parse helper that turns the raw `Notification` into a
+// typed `SelectionPopoverRequestPayload`. The SwiftUI sheet
+// lifecycle inside `SelectionPopoverPresenterModifier` is
+// integration / device-verify territory (sheet presents/dismisses
+// are SwiftUI side-effects that don't unit-test cleanly). The
+// unit-test surface this file pins is the public wire format that
+// bridge swaps (WI-7c2–WI-7c5) post onto.
+//
+// **WI-7c5a contract change**: the notification `object` is now a
+// `SelectionPopoverRequestPayload { selection, requestToken }`
+// rather than a bare `TextSelectionInfo`. The token lets EPUB
+// (WI-7c5b) round-trip a non-UTF-16 selection identity through the
+// popover action pipeline. `payload(from:)` replaces the old
+// `selection(from:)` and is migration-safe: a producer that still
+// posts a bare `TextSelectionInfo` decodes as a tokenless payload.
 //
 // **Why a parse helper on the modifier's enum and not free-floating
 // on `Notification`**: keeps the contract local to the presenter,
 // mirroring `FoliateSelectionDispatcher.notificationUserInfo` /
 // `FoliateMessageParser.parseSelection`. Bridges post via the
-// helper's `post(selection:on:)`; tests read it back via
-// `selection(from:)`.
+// helper's `post(selection:on:requestToken:)`; tests read it back
+// via `payload(from:)`.
 
 #if canImport(UIKit)
 import Testing
@@ -49,21 +57,57 @@ struct SelectionPopoverPresenterTests {
         )
     }
 
-    @Test("selection(from:) round-trips the posted TextSelectionInfo")
+    @Test("payload(from:) round-trips a posted SelectionPopoverRequestPayload")
     func roundTrip() {
-        let info = makeSelection()
+        let payload = SelectionPopoverRequestPayload(
+            selection: makeSelection(),
+            requestToken: nil
+        )
         let note = Notification(
             name: .readerSelectionPopoverRequested,
-            object: info,
+            object: payload,
             userInfo: nil
         )
-        let parsed = SelectionPopoverRequest.selection(from: note)
-        #expect(parsed?.selectedText == "the rapidity of the infection")
-        #expect(parsed?.startUTF16 == 1024)
-        #expect(parsed?.endUTF16 == 1053)
+        let parsed = SelectionPopoverRequest.payload(from: note)
+        #expect(parsed?.selection.selectedText == "the rapidity of the infection")
+        #expect(parsed?.selection.startUTF16 == 1024)
+        #expect(parsed?.selection.endUTF16 == 1053)
+        #expect(parsed?.requestToken == nil)
     }
 
-    @Test("selection(from:) returns nil when object is not TextSelectionInfo")
+    @Test("payload(from:) carries the requestToken when one was posted")
+    func roundTripWithToken() {
+        let token = UUID()
+        let payload = SelectionPopoverRequestPayload(
+            selection: makeSelection(),
+            requestToken: token
+        )
+        let note = Notification(
+            name: .readerSelectionPopoverRequested,
+            object: payload,
+            userInfo: nil
+        )
+        let parsed = SelectionPopoverRequest.payload(from: note)
+        #expect(parsed?.requestToken == token)
+    }
+
+    @Test("payload(from:) wraps a legacy bare TextSelectionInfo with a nil token")
+    func legacyBareSelectionDecodes() {
+        // Migration tolerance: a producer (or test) that posts a
+        // bare `TextSelectionInfo` — the pre-WI-7c5a wire shape —
+        // must still decode, as a tokenless request. This keeps
+        // the WI-7c5a contract change from being a flag-day break.
+        let note = Notification(
+            name: .readerSelectionPopoverRequested,
+            object: makeSelection(text: "legacy", start: 1, end: 7),
+            userInfo: nil
+        )
+        let parsed = SelectionPopoverRequest.payload(from: note)
+        #expect(parsed?.selection.selectedText == "legacy")
+        #expect(parsed?.requestToken == nil)
+    }
+
+    @Test("payload(from:) returns nil when object is not a recognised shape")
     func wrongObjectType() {
         // A bridge that mis-posts (e.g., string instead of struct)
         // must not crash the presenter. Returning nil lets the
@@ -75,22 +119,22 @@ struct SelectionPopoverPresenterTests {
             object: "wrong-shape",
             userInfo: nil
         )
-        #expect(SelectionPopoverRequest.selection(from: note) == nil)
+        #expect(SelectionPopoverRequest.payload(from: note) == nil)
     }
 
-    @Test("selection(from:) returns nil when object is nil")
+    @Test("payload(from:) returns nil when object is nil")
     func nilObject() {
         let note = Notification(
             name: .readerSelectionPopoverRequested,
             object: nil,
             userInfo: nil
         )
-        #expect(SelectionPopoverRequest.selection(from: note) == nil)
+        #expect(SelectionPopoverRequest.payload(from: note) == nil)
     }
 
     // MARK: - Post helper
 
-    @Test("post(selection:on:) posts on the named notification with TextSelectionInfo as object")
+    @Test("post(selection:on:) posts a payload with a nil token")
     func postRoundTrip() throws {
         let center = NotificationCenter()
         var captured: Notification?
@@ -106,10 +150,35 @@ struct SelectionPopoverPresenterTests {
 
         let note = try #require(captured)
         #expect(note.name == .readerSelectionPopoverRequested)
-        let parsed = try #require(SelectionPopoverRequest.selection(from: note))
-        #expect(parsed.selectedText == "hello")
-        #expect(parsed.startUTF16 == 5)
-        #expect(parsed.endUTF16 == 10)
+        let parsed = try #require(SelectionPopoverRequest.payload(from: note))
+        #expect(parsed.selection.selectedText == "hello")
+        #expect(parsed.selection.startUTF16 == 5)
+        #expect(parsed.selection.endUTF16 == 10)
+        #expect(parsed.requestToken == nil)
+    }
+
+    @Test("post(selection:on:requestToken:) posts a payload carrying the token")
+    func postWithToken() throws {
+        let center = NotificationCenter()
+        var captured: Notification?
+        let observer = center.addObserver(
+            forName: .readerSelectionPopoverRequested,
+            object: nil,
+            queue: nil
+        ) { note in captured = note }
+        defer { center.removeObserver(observer) }
+
+        let requestToken = UUID()
+        SelectionPopoverRequest.post(
+            selection: makeSelection(text: "epub para", start: 0, end: 9),
+            on: center,
+            requestToken: requestToken
+        )
+
+        let note = try #require(captured)
+        let parsed = try #require(SelectionPopoverRequest.payload(from: note))
+        #expect(parsed.selection.selectedText == "epub para")
+        #expect(parsed.requestToken == requestToken)
     }
 
     @Test("post(selection:on:) with empty text still emits — caller decides downstream filtering")
@@ -133,69 +202,105 @@ struct SelectionPopoverPresenterTests {
     }
 }
 
+// MARK: - Request payload value semantics (WI-7c5a)
+
+@Suite("Feature #60 WI-7c5a — SelectionPopoverRequestPayload value semantics")
+@MainActor
+struct SelectionPopoverRequestPayloadTests {
+
+    private func makeSelection(_ text: String = "abc") -> TextSelectionInfo {
+        TextSelectionInfo(selectedText: text, startUTF16: 0, endUTF16: text.utf16.count)
+    }
+
+    @Test("Two payloads with the same selection + token are Equatable-equal")
+    func equalWhenSameTokenAndSelection() {
+        let token = UUID()
+        let a = SelectionPopoverRequestPayload(selection: makeSelection(), requestToken: token)
+        let b = SelectionPopoverRequestPayload(selection: makeSelection(), requestToken: token)
+        #expect(a == b)
+    }
+
+    @Test("Payloads with different tokens are not equal")
+    func unequalWhenDifferentToken() {
+        let a = SelectionPopoverRequestPayload(selection: makeSelection(), requestToken: UUID())
+        let b = SelectionPopoverRequestPayload(selection: makeSelection(), requestToken: UUID())
+        #expect(a != b)
+    }
+
+    @Test("A nil-token payload differs from an otherwise-identical tokened payload")
+    func nilTokenDiffersFromTokened() {
+        let tokenless = SelectionPopoverRequestPayload(selection: makeSelection(), requestToken: nil)
+        let tokened = SelectionPopoverRequestPayload(selection: makeSelection(), requestToken: UUID())
+        #expect(tokenless != tokened)
+    }
+}
+
 // MARK: - Dismiss policy (Codex Gate 4 round 1, Medium)
 
 @Suite("Feature #60 WI-7c1 — SelectionPopoverDismissPolicy")
 @MainActor
 struct SelectionPopoverDismissPolicyTests {
 
-    private func makeSelection() -> TextSelectionInfo {
-        TextSelectionInfo(
-            selectedText: "the rapidity of the infection",
-            startUTF16: 0,
-            endUTF16: 29
+    private func makePayload() -> SelectionPopoverRequestPayload {
+        SelectionPopoverRequestPayload(
+            selection: TextSelectionInfo(
+                selectedText: "the rapidity of the infection",
+                startUTF16: 0,
+                endUTF16: 29
+            ),
+            requestToken: nil
         )
     }
 
-    @Test(".dispatched clears the pending selection (sheet dismisses)")
+    @Test(".dispatched clears the pending payload (sheet dismisses)")
     func dispatchedDismisses() {
-        let selection = makeSelection()
+        let payload = makePayload()
         let result = SelectionPopoverActionRouter.Result.dispatched(.readerHighlightRequested)
         let next = SelectionPopoverDismissPolicy.nextPending(
             after: result,
-            currentSelection: selection
+            currentPayload: payload
         )
         #expect(next == nil)
     }
 
     @Test(".dispatched on any reader notification clears (not coupled to a specific name)")
     func dispatchedAnyName() {
-        let selection = makeSelection()
+        let payload = makePayload()
         // Sanity: the dismiss policy is "any dispatch dismisses" —
         // not "only highlight dismisses". Note + Translate routes
         // should also dismiss when WI-7b's deferred cases eventually
         // shrink to zero.
         #expect(SelectionPopoverDismissPolicy.nextPending(
             after: .dispatched(.readerAnnotationRequested),
-            currentSelection: selection
+            currentPayload: payload
         ) == nil)
         #expect(SelectionPopoverDismissPolicy.nextPending(
             after: .dispatched(.readerTranslateRequested),
-            currentSelection: selection
+            currentPayload: payload
         ) == nil)
     }
 
     @Test(".deferredNotYetWired(.askAI) keeps the sheet open (no production pipeline yet)")
     func deferredAskAIKeepsOpen() {
-        let selection = makeSelection()
+        let payload = makePayload()
         let next = SelectionPopoverDismissPolicy.nextPending(
             after: .deferredNotYetWired(.askAI),
-            currentSelection: selection
+            currentPayload: payload
         )
         // Auto-dismiss on a deferred action would silently swallow
         // the tap. The contract pins: keep the sheet open until the
         // pipeline lands (router result flips to `.dispatched`).
-        #expect(next == selection)
+        #expect(next == payload)
     }
 
     @Test(".deferredNotYetWired(.read) keeps the sheet open")
     func deferredReadKeepsOpen() {
-        let selection = makeSelection()
+        let payload = makePayload()
         let next = SelectionPopoverDismissPolicy.nextPending(
             after: .deferredNotYetWired(.read),
-            currentSelection: selection
+            currentPayload: payload
         )
-        #expect(next == selection)
+        #expect(next == payload)
     }
 }
 #endif

--- a/vreaderTests/Views/Reader/TXTBridgeSharedTests.swift
+++ b/vreaderTests/Views/Reader/TXTBridgeSharedTests.swift
@@ -100,23 +100,26 @@ struct TXTBridgeSharedTests {
         #expect(received?.selectedText == "")
     }
 
-    // MARK: - postSelectionNotification on .readerSelectionPopoverRequested (WI-7c2)
+    // MARK: - postSelectionNotification on .readerSelectionPopoverRequested (WI-7c2 / WI-7c5a)
 
     /// Feature #60 WI-7c2: the TXT non-chunked bridge swaps its
     /// `editMenuForTextIn` from `buildReaderEditMenu` to a single
     /// `postSelectionNotification(.readerSelectionPopoverRequested, ...)`
-    /// + empty UIMenu return. Reuses the existing generic
-    /// post helper so no new method is needed — but pin that the
-    /// shape downstream presenter expects (`TextSelectionInfo` as
-    /// `notification.object`) actually arrives on this notification
-    /// name. The `SelectionPopoverPresenterModifier` from WI-7c1
-    /// reads via `notification.object as? TextSelectionInfo`.
+    /// + empty UIMenu return.
+    ///
+    /// WI-7c5a contract change: on `.readerSelectionPopoverRequested`
+    /// the helper now delegates to `SelectionPopoverRequest.post`, so
+    /// `notification.object` is a typed `SelectionPopoverRequestPayload`
+    /// (tokenless when no `requestToken` is passed). Pin that the
+    /// presenter-facing shape — readable via
+    /// `SelectionPopoverRequest.payload(from:)` — arrives intact, and
+    /// that a TXT producer leaves `requestToken` nil.
     @Test @MainActor func postSelectionNotificationOnPopoverRequestRoundTrips() async {
         let tv = UITextView()
         tv.text = "Hello World"
         let range = NSRange(location: 6, length: 5)
 
-        nonisolated(unsafe) var received: TextSelectionInfo?
+        nonisolated(unsafe) var received: SelectionPopoverRequestPayload?
         // queue: nil → synchronous in-thread delivery on the same
         // thread that posts. The post is `@MainActor`, observer set
         // up on MainActor, so the observer body runs synchronously
@@ -125,7 +128,7 @@ struct TXTBridgeSharedTests {
         let observer = NotificationCenter.default.addObserver(
             forName: .readerSelectionPopoverRequested, object: nil, queue: nil
         ) { note in
-            received = note.object as? TextSelectionInfo
+            received = SelectionPopoverRequest.payload(from: note)
         }
         defer { NotificationCenter.default.removeObserver(observer) }
 
@@ -134,10 +137,44 @@ struct TXTBridgeSharedTests {
         )
 
         #expect(received != nil,
-                "WI-7c2: posting on .readerSelectionPopoverRequested must carry TextSelectionInfo so the WI-7c1 presenter can parse it.")
-        #expect(received?.selectedText == "World")
-        #expect(received?.startUTF16 == 6)
-        #expect(received?.endUTF16 == 11)
+                "WI-7c5a: posting on .readerSelectionPopoverRequested must carry a SelectionPopoverRequestPayload so the presenter can parse it.")
+        #expect(received?.selection.selectedText == "World")
+        #expect(received?.selection.startUTF16 == 6)
+        #expect(received?.selection.endUTF16 == 11)
+        #expect(received?.requestToken == nil,
+                "A TXT producer passes no requestToken — the token is EPUB-only (WI-7c5b).")
+    }
+
+    /// Feature #60 WI-7c5a / Codex Gate 4 round 1 (Low): pin the
+    /// `requestToken` pass-through. No production TXT/MD caller
+    /// passes a token today (the token is EPUB-only), so without
+    /// this test a future regression in the helper's delegation to
+    /// `SelectionPopoverRequest.post(selection:requestToken:)` would
+    /// go uncaught.
+    @Test @MainActor func postSelectionNotificationPassesThroughRequestToken() async {
+        let tv = UITextView()
+        tv.text = "Hello World"
+        let range = NSRange(location: 6, length: 5)
+
+        nonisolated(unsafe) var received: SelectionPopoverRequestPayload?
+        let observer = NotificationCenter.default.addObserver(
+            forName: .readerSelectionPopoverRequested, object: nil, queue: nil
+        ) { note in
+            received = SelectionPopoverRequest.payload(from: note)
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let requestToken = UUID()
+        TXTBridgeShared.postSelectionNotification(
+            .readerSelectionPopoverRequested,
+            from: tv,
+            range: range,
+            requestToken: requestToken
+        )
+
+        #expect(received?.selection.selectedText == "World")
+        #expect(received?.requestToken == requestToken,
+                "WI-7c5a: postSelectionNotification must forward requestToken into the posted payload.")
     }
 
     // MARK: - buildReaderEditMenu

--- a/vreaderTests/Views/Reader/TXTChunkedReaderBridgeEditMenuTests.swift
+++ b/vreaderTests/Views/Reader/TXTChunkedReaderBridgeEditMenuTests.swift
@@ -67,7 +67,8 @@ struct TXTChunkedReaderBridgeEditMenuTests {
         let observer = NotificationCenter.default.addObserver(
             forName: .readerSelectionPopoverRequested, object: nil, queue: nil
         ) { note in
-            received = note.object as? TextSelectionInfo
+            // WI-7c5a: object is a typed `SelectionPopoverRequestPayload`.
+            received = SelectionPopoverRequest.payload(from: note)?.selection
         }
         defer { NotificationCenter.default.removeObserver(observer) }
 
@@ -93,7 +94,8 @@ struct TXTChunkedReaderBridgeEditMenuTests {
         let observer = NotificationCenter.default.addObserver(
             forName: .readerSelectionPopoverRequested, object: nil, queue: nil
         ) { note in
-            received = note.object as? TextSelectionInfo
+            // WI-7c5a: object is a typed `SelectionPopoverRequestPayload`.
+            received = SelectionPopoverRequest.payload(from: note)?.selection
         }
         defer { NotificationCenter.default.removeObserver(observer) }
 
@@ -141,7 +143,8 @@ struct TXTChunkedReaderBridgeEditMenuTests {
         let observer = NotificationCenter.default.addObserver(
             forName: .readerSelectionPopoverRequested, object: nil, queue: nil
         ) { note in
-            received = note.object as? TextSelectionInfo
+            // WI-7c5a: object is a typed `SelectionPopoverRequestPayload`.
+            received = SelectionPopoverRequest.payload(from: note)?.selection
         }
         defer { NotificationCenter.default.removeObserver(observer) }
 
@@ -172,7 +175,8 @@ struct TXTChunkedReaderBridgeEditMenuTests {
         let observer = NotificationCenter.default.addObserver(
             forName: .readerSelectionPopoverRequested, object: nil, queue: nil
         ) { note in
-            received = note.object as? TextSelectionInfo
+            // WI-7c5a: object is a typed `SelectionPopoverRequestPayload`.
+            received = SelectionPopoverRequest.payload(from: note)?.selection
         }
         defer { NotificationCenter.default.removeObserver(observer) }
 

--- a/vreaderTests/Views/Reader/TXTTextViewBridgeEditMenuTests.swift
+++ b/vreaderTests/Views/Reader/TXTTextViewBridgeEditMenuTests.swift
@@ -12,8 +12,11 @@
 // 1. Return value is a UIMenu with zero visible elements (iOS shows
 //    nothing in place of the old menu).
 // 2. Side-effect: `.readerSelectionPopoverRequested` fires with the
-//    correct `TextSelectionInfo` payload so the presenter sheet can
-//    appear.
+//    correct selection so the presenter sheet can appear.
+//
+// WI-7c5a note: the notification object is now a typed
+// `SelectionPopoverRequestPayload`; the test reads the selection
+// back via `SelectionPopoverRequest.payload(from:)`.
 
 #if canImport(UIKit)
 import Testing
@@ -71,7 +74,9 @@ struct TXTTextViewBridgeEditMenuTests {
         let observer = NotificationCenter.default.addObserver(
             forName: .readerSelectionPopoverRequested, object: nil, queue: nil
         ) { note in
-            received = note.object as? TextSelectionInfo
+            // WI-7c5a: object is a typed `SelectionPopoverRequestPayload`
+            // — unwrap to the selection.
+            received = SelectionPopoverRequest.payload(from: note)?.selection
         }
         defer { NotificationCenter.default.removeObserver(observer) }
 


### PR DESCRIPTION
## Summary

- Foundational WI for the EPUB SelectionPopover swap (WI-7c5b).
- EPUB's selection model (`EPUBSerializedRange`, DOM-path) can't ride `TextSelectionInfo`'s UTF-16-offset shape — so the popover infrastructure gains an opaque `requestToken` a format can use to round-trip its own selection identity.
- **No production behavior change**: TXT/MD/chunked producers pass a nil token; the token is dormant until EPUB (WI-7c5b) supplies one.

Part of feature #718 (Feature #60 visual identity v2).

## What Changed

- New `SelectionPopoverRequestPayload { selection: TextSelectionInfo, requestToken: UUID? }` (Equatable + Sendable) — now the `.readerSelectionPopoverRequested` notification `object`.
- `SelectionPopoverRequest.post(selection:on:requestToken:)` builds + posts the payload. `payload(from:)` replaces `selection(from:)`, migration-safe (decodes a legacy bare `TextSelectionInfo` as a tokenless payload). `payload(from:)` is `nonisolated` so a synchronous NotificationCenter observer closure can call it without tripping Swift 6 "sending note risks data races".
- `SelectionPopoverActionRouter.route(action:payload:)` — attaches `userInfo["selectionRequestToken"]` as a `UUID` when the payload carries a token; still posts a bare `TextSelectionInfo` as `object` so `ReaderNotificationModifier` consumers are unaffected.
- `TXTBridgeShared.postSelectionNotification(...requestToken:)` — for `.readerSelectionPopoverRequested` delegates to `SelectionPopoverRequest.post`, keeping that enum the single owner of the popover wire format.
- `SelectionPopoverDismissPolicy` + `SelectionPopoverPresenterModifier` migrated to the payload type.

## WI Status

- WI-7c5a (foundational): this PR — typed payload + token plumbing
- WI-7c5b (behavioral): next — EPUB producer/consumer swap, consumes this token plumbing
- Plan v10 documents the WI-7c5a/b split (Gate 2 audited, Codex thread 019e2ef9, 3 rounds clean)

## Codex Audit (Gate 4)

Thread `019e2f21`, **2 rounds, ship-as-is**.

- Round 1: 2 Lows — untested `requestToken` pass-through (→ new `TXTBridgeShared` test), stale `ReaderNotifications.swift` comment (→ updated).
- Round 2: **"No findings. … WI-7c5a looks clean for merge."**

Audit log: `.claude/codex-audits/feat-feature-60-wi-7c5a-token-payload-audit.md`

## Validation

- [x] `xcodebuild test` — 40 popover-surface tests pass across 6 suites + TXTBridgeShared (6)
- [x] Tests cover changed behavior (TDD: RED → GREEN) — new payload/token suites + migrated edit-menu suites
- [x] Codex audit loop completed (2 rounds, verdict: ship-as-is)
- [x] Docs sync — n/a (no new service/`@Model`; the `.readerSelectionPopoverRequested` notification already exists in architecture.md; its object-shape change is an internal wire-format detail)
- [x] Version bumped: 3.24.9 → 3.24.10

Full `vreaderTests` gate: WI-7c5a code clean; the only full-gate failures were the documented pre-existing parallel-execution flakes (`ReplacementTransformTests`, `CoverLifecycleTests`) — confirmed pass in isolation (17/17).

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: **foundational** — structural refactor of internal popover types; no user-observable delta on any of the 4 already-swapped TXT/MD paths (all 4 producers pass a nil token, the popover presents identically). Unit + integration tests + Gate 4 audit are sufficient per the rule 47 Gate 5 matrix.

## Type of Change

- [x] Feature WI (Part of feature #718; intermediate WI — WI-7c5b still pending)