### PR TITLE
feat(#718 WI-8): library card/row visual tokens + reading-progress UI

### DIFF
--- a/.claude/codex-audits/feat-feature-60-wi-8-library-card-tokens-audit.md
+++ b/.claude/codex-audits/feat-feature-60-wi-8-library-card-tokens-audit.md
@@ -1,0 +1,57 @@
+---
+branch: feat/feature-60-wi-8-library-card-tokens
+threadId: 019e2ff2-a9b2-7e93-ab2f-92e23f4033bd
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-05-16
+---
+
+# Codex Audit — Feature #60 WI-8 (Library card / row visual tokens)
+
+Gate 4 implementation audit for feature #60 (visual identity v2),
+work item WI-8. Author: implementing Claude Code session. Auditor:
+Codex MCP (`gpt-5`-class), independent process — author/auditor
+separation per rule 48.
+
+WI-8 ships the Library grid-card (`BookCardView`) and list-row
+(`BookRowView`) re-skin: design typography / palette / cover
+treatment, plus the per-book reading-progress UI.
+
+## Round 1 — audit of the WI-8 Gate 3 deliverable (commit `79d8ee2`)
+
+| # | file | severity | issue | resolution |
+|---|------|----------|-------|------------|
+| 1 | `BookCardView.swift` | High | Omits the design `GridView`'s in-cover progress strip + finished checkmark — the card shipped typography/palette/cover only. | **Fixed** — fix round added `progressStrip` + `finishedBadge` overlays driven by `LibraryBookItem.readingProgressState`. |
+| 2 | `BookRowView.swift` | High | Omits the design `ListView`'s progress metadata span (`X% · last-read` / `Finished`) and the trailing progress ring. | **Fixed** — fix round added the `metadataLine` progress span + the `progressRing` (`LibraryProgressRing`). |
+| 3 | plan v11 note | Medium | The progress-UI deferral was avoidable: it was recorded as "data-model-blocked", but `Locator.totalProgression` (`Double?`) already carries the per-book fraction. | **Fixed** — fix round added `progressFraction: Double?` to `LibraryBookItem` and projects it in `PersistenceActor+Library.fetchAllLibraryBooks()` from `book.readingPosition?.locator.totalProgression`. Plan v12 records the reversal. |
+| 4 | `BookCoverArtView.swift` | Medium | The flat format-colour fallback is not the design's generative cover. | **Accepted with rationale** — generative covers are WI-10 scope (plan's `GenerativeCoverViewStyleTests`). The flat fallback is the pre-existing placeholder carried forward, not a WI-8 invention; WI-10 replaces it. |
+| 5 | `LibraryCardTokens.swift` | Medium | `listCardBackground`, `listRowDivider`, `listCardCornerRadius` are referenced only by tests — no production consumer. | **Accepted with rationale** — these are the list-*container* tokens consumed by WI-9's Library-container re-skin. The file header now documents the WI-9 dependency. Splitting the shared `vreader-library.jsx` spec across two PRs would be worse churn. `accent` is now a live production token (the ring's swept arc). |
+| 6 | `BookCardViewVisualTests.swift` / `BookRowViewVisualTests.swift` | Low | Tests are largely tautological — they pin design constants and would not catch real visual regressions. | **Accepted with rationale** — the token-pinning tests are intentional design tripwires (a token edit fails them). The fix round adds genuinely behavioral tests: `LibraryBookItemProgressStateTests` (10 boundary cases), `ReadingTimeFormatterRelativeTests` (10 buckets), and progress-state / metadata-text tests. Render-level pixel geometry is verified at Gate 5; see Round 2 #2. |
+
+## Round 2 — audit of the fix round
+
+| # | file | severity | issue | resolution |
+|---|------|----------|-------|------------|
+| 1 | `BookCardView.swift` `progressStrip` | Medium | Concern that the in-cover strip's 6pt horizontal inset relied on a `.padding` applied *outside* a `GeometryReader`, which is fragile to modifier-order edits. | **Fixed** — `progressStrip` restructured: the `GeometryReader` is now the full-cover overlay content, `trackWidth = max(0, geo.size.width - inset * 2)` is computed explicitly in the measured space, and the strip is placed with `.position`. The inset no longer depends on proposal order. |
+| 2 | `BookCardViewVisualTests.swift` | Low | New tests assert derived state/text, not render-level overlay geometry; they would not catch a strip-inset or badge-placement regression. | **Accepted with rationale** — the WI-8 plan specifies "snapshot-free visual assertions"; `.claude/rules/10-tdd.md` directs SwiftUI view tests to test behaviour, not pixel rendering. Strip/badge/ring geometry is verified end-to-end at Gate 5 device verification. Adding `ImageRenderer` geometry assertions would contradict both the plan and the TDD rule. |
+
+## Round 3 — verification
+
+Codex confirmed the restructured `progressStrip` resolves the Round-2
+Medium and that the Low render-test deferral is a valid scoped Gate-4
+decision (consistent with the plan and rule 10-tdd).
+
+**Open findings: none.** No open Critical, High, or Medium.
+
+## Summary verdict
+
+`ship-as-is`. The Round-1 High gap (missing per-book progress UI on
+the card and row) is fully closed; the data path is sound end-to-end
+(`Locator.totalProgression` → `PersistenceActor+Library` →
+`LibraryBookItem.progressFraction` → `readingProgressState` → card /
+row). No Swift 6 concurrency or `@MainActor` issues; all touched
+production files are under the 300-line guideline. The two
+`accepted-with-rationale` items (WI-10 generative cover; WI-9
+list-container tokens) are scope boundaries, not defects. The one Low
+deferral (render-backed visual assertions) is consistent with the
+WI-8 plan and `.claude/rules/10-tdd.md`.

--- a/dev-docs/plans/20260515-feature-60-visual-identity-v2.md
+++ b/dev-docs/plans/20260515-feature-60-visual-identity-v2.md
@@ -1051,3 +1051,21 @@ category 2 (PLANNED feature with plan doc → Gate 3).
   WI-9's `LibraryView`. This is data-model-blocked, not
   design-blocked; a follow-up WI adds the progress field. Recorded
   so the gap is tracked, not silently dropped.
+- 2026-05-16 v12: **WI-8 progress UI implemented (v11 deferral
+  reversed).** Codex Gate 4 audit of the WI-8 PR found the v11
+  "data-model-blocked" assessment wrong: `Locator.totalProgression`
+  (`Double?`) already carries the per-book fraction, reachable via
+  `Book.readingPosition?.locator.totalProgression`. The fix round
+  added `progressFraction: Double?` to `LibraryBookItem`, projected
+  it in `PersistenceActor+Library.fetchAllLibraryBooks()`, and built
+  the design's progress UI: the in-cover progress strip + finished
+  checkmark on `BookCardView`, and the `%·last-read` / `Finished`
+  metadata span + trailing oxblood ring on `BookRowView`. A shared
+  `LibraryBookItem.ReadingProgressState` enum centralises the
+  notStarted / inProgress / finished boundary so the card and row
+  agree. No WI-9 collision — the projection is local to
+  `LibraryBookItem` + `PersistenceActor+Library`; `LibraryViewModel`
+  carries the new field through untouched. The design's
+  `progress === 0 → "{n} pages"` branch is intentionally rendered as
+  the format chip alone: `LibraryBookItem` carries no page count, and
+  substituting a different metric would be self-designed UI.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 407
-        MARKETING_VERSION: 3.24.12
+        CURRENT_PROJECT_VERSION: 408
+        MARKETING_VERSION: 3.24.13
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		26D79FC598918201D178F348 /* PersistenceActorEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2F1636BA674F5AF7A50902 /* PersistenceActorEnvironment.swift */; };
 		26E2B41897B117FD5976B75E /* MDTOCVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AECA1E4C104DEBC5FE30E61 /* MDTOCVerificationTests.swift */; };
 		270748270CF3E119F24D985F /* EPUBWebViewBridgeJS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C07D184EF0E90D5F2DF7A36 /* EPUBWebViewBridgeJS.swift */; };
+		276E47B44DB8004A3D700E05 /* LibraryProgressRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4104BB5FAFACC19E9FBB4D7 /* LibraryProgressRing.swift */; };
 		2775DDF52321F468CB58F795 /* BookmarkListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D432C9B43D1B6662B4605664 /* BookmarkListViewModel.swift */; };
 		28028B11FE1116819D5DE0FA /* ReaderHighlightTapEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A266E88D3BA30905391B154 /* ReaderHighlightTapEventTests.swift */; };
 		282D259E9414FD85AC6C4134 /* TXTOffsetTranslator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69A5BB670EA065F36FCD605B /* TXTOffsetTranslator.swift */; };
@@ -1816,6 +1817,7 @@
 		F31762497599885BCC803B1D /* ChapterProgressCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterProgressCalculatorTests.swift; sourceTree = "<group>"; };
 		F379B3EEC02DC574C73F4323 /* SchemaV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV2.swift; sourceTree = "<group>"; };
 		F3B26374749D7626349FB9E0 /* LibraryTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryTestHelpers.swift; sourceTree = "<group>"; };
+		F4104BB5FAFACC19E9FBB4D7 /* LibraryProgressRing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryProgressRing.swift; sourceTree = "<group>"; };
 		F4C18F1E19149F8DBAE36A31 /* AIResponseCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIResponseCache.swift; sourceTree = "<group>"; };
 		F518E98F02B1A2000C41AAB2 /* TXTChapterIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterIntegrationTests.swift; sourceTree = "<group>"; };
 		F560EA65913036C78284C138 /* ErrorScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorScreenTests.swift; sourceTree = "<group>"; };
@@ -2880,6 +2882,7 @@
 				23A84FE014139E7B5524445D /* BookRowView.swift */,
 				1FD65C0547DF264510657CA2 /* ContentView.swift */,
 				1A7668891CD8BA0B6DED7A25 /* LibraryCardTokens.swift */,
+				F4104BB5FAFACC19E9FBB4D7 /* LibraryProgressRing.swift */,
 				28354051023D618CC3CAE2E2 /* LibraryView.swift */,
 				CEED7A8EE9DAF9388DE79212 /* ScreenSpaceDemo.swift */,
 				80635BFEACEBE8B6FF3653D4 /* AI */,
@@ -4339,6 +4342,7 @@
 				CFF2F7127E363B96F2B6429B /* LibraryBookItem.swift in Sources */,
 				F83C8F0B1D75175DC7B481CC /* LibraryCardTokens.swift in Sources */,
 				A2518618C1F5EAD7C8FD4EE0 /* LibraryPersisting.swift in Sources */,
+				276E47B44DB8004A3D700E05 /* LibraryProgressRing.swift in Sources */,
 				2DDEE520E3606572AED3598F /* LibraryRefreshService.swift in Sources */,
 				5599E405840D204BE7FA8104 /* LibrarySortOrder.swift in Sources */,
 				489DF72D463C495F4C94C5FB /* LibraryView.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -135,11 +135,13 @@
 		21C14E9FBD7B7373B56A365C /* SearchResultRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A888610BD2499B817A278EB /* SearchResultRow.swift */; };
 		21E6733005B6B4894ECCFEAB /* ContentHasherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0616892213196BCF802266F8 /* ContentHasherTests.swift */; };
 		2206E24712AFD54F00761207 /* EPUBFileLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AEAC075B9C38B3783D207A /* EPUBFileLoader.swift */; };
+		2243225993799BBBCC9BE25B /* BookCoverArtView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CBEAF6FEDB714FCE897550 /* BookCoverArtView.swift */; };
 		22612350C6FC7C43096271E9 /* BackupDataCollectorRestorerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17676C4AE9DD328C39176D8 /* BackupDataCollectorRestorerTests.swift */; };
 		238CEDFC273E8AD0026B77AB /* BackupProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB2B5F77B95D3402E699DA9 /* BackupProvider.swift */; };
 		23A8010F873969D18777639F /* TXTChunkedHighlightDeferredTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C24D5425530ABBE0DDA4758F /* TXTChunkedHighlightDeferredTimerTests.swift */; };
 		23E3CB9E4697D90B84006ED3 /* Feature11EPUBHighlightVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B902CC4D30A1A392CFA4EA /* Feature11EPUBHighlightVerificationTests.swift */; };
 		243DB71360738DB06D5813BF /* NativeTextPaginator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E51E6D76FE0DDF87E537AB /* NativeTextPaginator.swift */; };
+		24537AC8998113A9C739DBD6 /* BookCardViewVisualTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C192DC2E4B6D7B71D711849 /* BookCardViewVisualTests.swift */; };
 		2464151C976B35F68DD2169A /* LazyDownloadReattachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E124CB39746DB0B59D0390C3 /* LazyDownloadReattachTests.swift */; };
 		250865E2A2A7BC3DE436183F /* PDFReaderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7F4F4B985D58E03A78680D /* PDFReaderViewModelTests.swift */; };
 		2509B7983AE76F5C85B71634 /* HighlightDedupeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD56854A37D8EA2B318B926 /* HighlightDedupeTests.swift */; };
@@ -391,6 +393,7 @@
 		68B750CB7D82E8E4DE0DA393 /* SearchServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32DF5DC258E6460D4FE84706 /* SearchServiceTests.swift */; };
 		69D8922795B7525A06038A49 /* ReadingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B2B480AC630357CC08475F4 /* ReadingMode.swift */; };
 		6A82598FAC95114A1E5CF06B /* footnotes.js in Resources */ = {isa = PBXBuildFile; fileRef = 7D068D6691FC6690BF3341B1 /* footnotes.js */; };
+		6AD3803A580B3AEB73E77AA1 /* BookRowViewVisualTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EA3D76ECCD1B0E7205FBC4 /* BookRowViewVisualTests.swift */; };
 		6B0F05AB79459B346E22C825 /* DebugReaderProbeAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B98DA0DED4325E7AE1BEF59 /* DebugReaderProbeAdapter.swift */; };
 		6B19F49F1DECB5EF45BACC88 /* WebDAVClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE8121B86DA337766FD55AEF /* WebDAVClientTests.swift */; };
 		6B30D9E131580FD96CF77D20 /* PDFProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775CED0704F1D6D39F873FF9 /* PDFProgressTests.swift */; };
@@ -892,6 +895,7 @@
 		F7D1DD8DB8FE7E683B95BABA /* LazyDownloadTaskMeta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592405D887F7AE66A58FA8D9 /* LazyDownloadTaskMeta.swift */; };
 		F7D4BCC9E389D8F7956277AA /* TXTTextChunker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00B189F7F32FF82BCF254923 /* TXTTextChunker.swift */; };
 		F827253851032F8D00E6A423 /* TOCListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE32E178C19442D8D52EBAC5 /* TOCListView.swift */; };
+		F83C8F0B1D75175DC7B481CC /* LibraryCardTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A7668891CD8BA0B6DED7A25 /* LibraryCardTokens.swift */; };
 		F889D8A73C4F04D6FA5CF12B /* EPUBSelectionTokenCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5717B0EFF152D86D07C5C0D /* EPUBSelectionTokenCacheTests.swift */; };
 		F8A29678ED4FE3B33CC97C71 /* SelectionPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B17BC96A003E5777FBFACC /* SelectionPopoverView.swift */; };
 		F8D243D5F4F95EDA50118FE5 /* foliate-bridge.js in Resources */ = {isa = PBXBuildFile; fileRef = CCBA2A70DA3EE6E28FAB3FFE /* foliate-bridge.js */; };
@@ -951,6 +955,7 @@
 		03E01318DE23F63217033B89 /* ProviderProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderProfileTests.swift; sourceTree = "<group>"; };
 		03FA3AC72012ED6686293475 /* ReadingStatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsTests.swift; sourceTree = "<group>"; };
 		0459CAA7394555E5A8E17146 /* ReaderUnsupportedFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderUnsupportedFormatTests.swift; sourceTree = "<group>"; };
+		04CBEAF6FEDB714FCE897550 /* BookCoverArtView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCoverArtView.swift; sourceTree = "<group>"; };
 		04ED79BFAD4BEF6B8A30F982 /* BookFileMaterializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFileMaterializerTests.swift; sourceTree = "<group>"; };
 		050AAFD290B8995258D78AC2 /* FormatCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatCapabilities.swift; sourceTree = "<group>"; };
 		055FBEA382F82BE342A50C8E /* LocatorFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorFactoryTests.swift; sourceTree = "<group>"; };
@@ -1025,6 +1030,7 @@
 		19AC5688AF504E6253728C73 /* ErrorMessageAuditorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMessageAuditorTests.swift; sourceTree = "<group>"; };
 		19EA79EB5577BF31A4096B39 /* NoOpSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoOpSessionStore.swift; sourceTree = "<group>"; };
 		1A49E33ACBED018932A38F0C /* AddNoteSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddNoteSheet.swift; sourceTree = "<group>"; };
+		1A7668891CD8BA0B6DED7A25 /* LibraryCardTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryCardTokens.swift; sourceTree = "<group>"; };
 		1ABFAC14455C6F7DE43C1ABC /* overlayer.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = overlayer.js; sourceTree = "<group>"; };
 		1B2B480AC630357CC08475F4 /* ReadingMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingMode.swift; sourceTree = "<group>"; };
 		1B311C3A88BD6DC42005FE1B /* ExportedAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportedAnnotation.swift; sourceTree = "<group>"; };
@@ -1491,6 +1497,7 @@
 		9B4B7084FA4C129303F52CB8 /* FileAvailabilityBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileAvailabilityBadge.swift; sourceTree = "<group>"; };
 		9B6458ABB611B5C32252C6DE /* DebugFixtureCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugFixtureCatalogTests.swift; sourceTree = "<group>"; };
 		9B8C36563D7885AD214F885A /* FoliateSearchAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateSearchAdapter.swift; sourceTree = "<group>"; };
+		9C192DC2E4B6D7B71D711849 /* BookCardViewVisualTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCardViewVisualTests.swift; sourceTree = "<group>"; };
 		9C5A2D5CFE8B719D4C8F3580 /* SchemaV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV1.swift; sourceTree = "<group>"; };
 		9CB5EAAB268616336D42EC30 /* FoliateHighlightRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightRendererTests.swift; sourceTree = "<group>"; };
 		9CE6D5875C20698F83D6EC1E /* HTTPTTSProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTTSProvider.swift; sourceTree = "<group>"; };
@@ -1650,6 +1657,7 @@
 		C919847EACB9AB94A03DF6E8 /* FoliateReaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateReaderViewModel.swift; sourceTree = "<group>"; };
 		C91F653CA8E9B107CA2CA4CA /* FoliateTOCConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateTOCConverterTests.swift; sourceTree = "<group>"; };
 		C9AB5E0256EC0FE97B68DE5D /* TombstoneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TombstoneStore.swift; sourceTree = "<group>"; };
+		C9EA3D76ECCD1B0E7205FBC4 /* BookRowViewVisualTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookRowViewVisualTests.swift; sourceTree = "<group>"; };
 		CA44E51EB0E783E5A874DA11 /* DebugBridgeNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugBridgeNotifications.swift; sourceTree = "<group>"; };
 		CABA711375AB3BAEB2F42CFE /* WebDAVServerProfileListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVServerProfileListView.swift; sourceTree = "<group>"; };
 		CB182FC977C25E932E0BE1D3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -2080,6 +2088,8 @@
 		255C46B94F558C0D47C58F15 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				9C192DC2E4B6D7B71D711849 /* BookCardViewVisualTests.swift */,
+				C9EA3D76ECCD1B0E7205FBC4 /* BookRowViewVisualTests.swift */,
 				BDA2CABDFE8AC4CE645BAD05 /* Library */,
 				3FEBC4F34FA9A312FFFA1513 /* Reader */,
 				1F91A1066C385178070AEA40 /* Settings */,
@@ -2866,8 +2876,10 @@
 			isa = PBXGroup;
 			children = (
 				6BEB6636BEBB84D528EE5DF5 /* BookCardView.swift */,
+				04CBEAF6FEDB714FCE897550 /* BookCoverArtView.swift */,
 				23A84FE014139E7B5524445D /* BookRowView.swift */,
 				1FD65C0547DF264510657CA2 /* ContentView.swift */,
+				1A7668891CD8BA0B6DED7A25 /* LibraryCardTokens.swift */,
 				28354051023D618CC3CAE2E2 /* LibraryView.swift */,
 				CEED7A8EE9DAF9388DE79212 /* ScreenSpaceDemo.swift */,
 				80635BFEACEBE8B6FF3653D4 /* AI */,
@@ -3790,6 +3802,7 @@
 				A43AD2AF5B19CF05B849BE2E /* BackupViewModelSelectiveRestoreTests.swift in Sources */,
 				90D2C41C30E622E119877967 /* BackupViewModelTests.swift in Sources */,
 				096B20388931B21DAA4DC091 /* BlobPathTests.swift in Sources */,
+				24537AC8998113A9C739DBD6 /* BookCardViewVisualTests.swift in Sources */,
 				C205A1413A59C630A10ECEB7 /* BookContentCacheTests.swift in Sources */,
 				F437CE5879D0238AC5523F52 /* BookFileImportFinalizerTests.swift in Sources */,
 				45284DB279AD41866D7B0157 /* BookFileMaterializerTests.swift in Sources */,
@@ -3803,6 +3816,7 @@
 				1AC5FD48311C93B5CEB3702E /* BookImporterTests.swift in Sources */,
 				3C6784421BC6B3DD6F1D3C16 /* BookModelTests.swift in Sources */,
 				6E224708E01276C14273E2E6 /* BookOpenPerformanceTests.swift in Sources */,
+				6AD3803A580B3AEB73E77AA1 /* BookRowViewVisualTests.swift in Sources */,
 				2D1E2FD1F2B6D51EC62EBB60 /* BookSourceHTTPClientTests.swift in Sources */,
 				672412B314F93503C6EC7BF9 /* BookSourcePipelineTests.swift in Sources */,
 				9584BA9E45DD2C0CE1061C02 /* BookSourceTests.swift in Sources */,
@@ -4185,6 +4199,7 @@
 				12EE1BD6335013980EFA3EC0 /* BookCardView.swift in Sources */,
 				AF32B348898F4110FED715F5 /* BookCollection.swift in Sources */,
 				BB796644EE14228057D77738 /* BookContentCache.swift in Sources */,
+				2243225993799BBBCC9BE25B /* BookCoverArtView.swift in Sources */,
 				33226957615967F3FE36DD40 /* BookDownloadSheet.swift in Sources */,
 				D2C79A37AD17134F89371C0A /* BookFileImportFinalizer.swift in Sources */,
 				AE171BC364B973E0F52D1B96 /* BookFileMaterializer.swift in Sources */,
@@ -4322,6 +4337,7 @@
 				D2A05D3F78803BFD1248FFC2 /* LegadoImporter.swift in Sources */,
 				5475FDB13471D68A8ACB1ADD /* LegadoRuleParser.swift in Sources */,
 				CFF2F7127E363B96F2B6429B /* LibraryBookItem.swift in Sources */,
+				F83C8F0B1D75175DC7B481CC /* LibraryCardTokens.swift in Sources */,
 				A2518618C1F5EAD7C8FD4EE0 /* LibraryPersisting.swift in Sources */,
 				2DDEE520E3606572AED3598F /* LibraryRefreshService.swift in Sources */,
 				5599E405840D204BE7FA8104 /* LibrarySortOrder.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4726,13 +4726,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 407;
+				CURRENT_PROJECT_VERSION = 408;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.24.12;
+				MARKETING_VERSION = 3.24.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4876,13 +4876,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 407;
+				CURRENT_PROJECT_VERSION = 408;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.24.12;
+				MARKETING_VERSION = 3.24.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Models/LibraryBookItem.swift
+++ b/vreader/Models/LibraryBookItem.swift
@@ -37,9 +37,17 @@ struct LibraryBookItem: Sendable, Identifiable, Equatable, Hashable {
     /// when the user selects a collection in the sidebar. Bug #155.
     let collectionNames: [String]
 
+    /// Fractional reading progress in `[0, 1]`, or `nil` when the book
+    /// has never been opened / no reading position is recorded yet.
+    /// Projected from `ReadingPosition.locator.totalProgression`
+    /// (feature #60 WI-8). Drives the grid-card progress strip /
+    /// finished checkmark and the list-row progress ring.
+    let progressFraction: Double?
+
     /// Explicit memberwise init with feature-#47 + bug-#155 defaults so
     /// existing call sites that pre-date `fileState`/`blobPath`/`collectionNames`
     /// continue to compile; new call sites pass the persisted values through.
+    /// `progressFraction` defaults to `nil` for the same back-compat reason.
     init(
         fingerprintKey: String,
         title: String,
@@ -56,7 +64,8 @@ struct LibraryBookItem: Sendable, Identifiable, Equatable, Hashable {
         averageWordsPerMinute: Double?,
         fileState: BookFileState = .local,
         blobPath: String? = nil,
-        collectionNames: [String] = []
+        collectionNames: [String] = [],
+        progressFraction: Double? = nil
     ) {
         self.fingerprintKey = fingerprintKey
         self.title = title
@@ -74,6 +83,38 @@ struct LibraryBookItem: Sendable, Identifiable, Equatable, Hashable {
         self.fileState = fileState
         self.blobPath = blobPath
         self.collectionNames = collectionNames
+        self.progressFraction = progressFraction
+    }
+
+    // MARK: - Reading-progress state (feature #60 WI-8)
+
+    /// Three-way reading-progress state the Library card + row render,
+    /// mirroring the design's `progress === 0 / 0 < p < 1 / p === 1`
+    /// branches in `vreader-library.jsx`. Centralised here so the grid
+    /// card and the list row agree on the boundary rules and the
+    /// classification is unit-testable without a SwiftUI render.
+    enum ReadingProgressState: Sendable, Equatable {
+        /// Never opened, or no position recorded. The card shows no
+        /// progress strip; the row shows the format chip alone.
+        case notStarted
+        /// Partially read — associated value is the progress fraction,
+        /// strictly between 0 and 1.
+        case inProgress(Double)
+        /// Fully read (`progressFraction >= 1`). The card shows the
+        /// finished checkmark; the row shows the "Finished" label.
+        case finished
+    }
+
+    /// Classifies `progressFraction` into `ReadingProgressState`.
+    /// `nil`, non-finite (NaN / ∞), zero, or negative fractions are
+    /// `.notStarted`; `>= 1.0` is `.finished` (tolerating rounding
+    /// drift past 1); anything strictly between is `.inProgress`. The
+    /// view layer reads this rather than re-deriving the boundaries.
+    var readingProgressState: ReadingProgressState {
+        guard let fraction = progressFraction,
+              fraction.isFinite, fraction > 0 else { return .notStarted }
+        if fraction >= 1.0 { return .finished }
+        return .inProgress(fraction)
     }
 
     // MARK: - File-state helpers (feature #47 WI-5)

--- a/vreader/Services/PersistenceActor+Library.swift
+++ b/vreader/Services/PersistenceActor+Library.swift
@@ -45,7 +45,8 @@ extension PersistenceActor: LibraryPersisting {
                 averageWordsPerMinute: stats?.averageWordsPerMinute,
                 fileState: BookFileState(rawValue: book.fileState) ?? .local,
                 blobPath: book.blobPath,
-                collectionNames: book.bookCollections.map { $0.name }
+                collectionNames: book.bookCollections.map { $0.name },
+                progressFraction: book.readingPosition?.locator.totalProgression
             )
         }
     }

--- a/vreader/Utils/ReadingTimeFormatter.swift
+++ b/vreader/Utils/ReadingTimeFormatter.swift
@@ -84,4 +84,52 @@ enum ReadingTimeFormatter {
     static func formatBadgeLabel(format: String) -> String {
         format.uppercased(with: Locale(identifier: "en_US_POSIX"))
     }
+
+    // MARK: - Relative Last-Read
+
+    /// Formats a "last read" timestamp into a compact relative string
+    /// for the Library list row's metadata line (feature #60 WI-8 —
+    /// the design's `{progress}% · {last-read}` span in `ListView`).
+    ///
+    /// Buckets are deterministic and locale-independent so the output
+    /// is stable across devices/OS versions and unit-testable with a
+    /// fixed `now` — unlike `RelativeDateTimeFormatter`, whose wording
+    /// shifts with locale and SDK:
+    /// - under 1 minute (or a future timestamp) → "Just now"
+    /// - under 1 hour   → "Xm ago"
+    /// - under 1 day    → "Xh ago"
+    /// - exactly 1 day  → "Yesterday"
+    /// - under 1 week   → "Xd ago"
+    /// - under 5 weeks  → "Xw ago"
+    /// - under 1 year   → "Xmo ago"
+    /// - otherwise      → "Xy ago"
+    ///
+    /// A future `date` (clock skew between the position write and the
+    /// render) falls into the "Just now" bucket rather than producing
+    /// a negative count.
+    static func formatRelativeLastRead(
+        from date: Date,
+        relativeTo now: Date = Date()
+    ) -> String {
+        let elapsed = now.timeIntervalSince(date)
+        if elapsed < 60 { return "Just now" }
+
+        let minutes = Int(elapsed / 60)
+        if minutes < 60 { return "\(minutes)m ago" }
+
+        let hours = Int(elapsed / 3_600)
+        if hours < 24 { return "\(hours)h ago" }
+
+        let days = Int(elapsed / 86_400)
+        if days == 1 { return "Yesterday" }
+        if days < 7 { return "\(days)d ago" }
+
+        let weeks = days / 7
+        if weeks < 5 { return "\(weeks)w ago" }
+
+        let months = days / 30
+        if months < 12 { return "\(months)mo ago" }
+
+        return "\(days / 365)y ago"
+    }
 }

--- a/vreader/Views/BookCardView.swift
+++ b/vreader/Views/BookCardView.swift
@@ -1,13 +1,21 @@
 // Purpose: Grid card view for a book in the library.
-// Shows cover placeholder, format badge, title, author, and reading time.
+// Shows the generative cover (spine + page-edge accents), Source Serif 4
+// title, and author — re-skinned for feature #60 visual identity v2.
 //
 // Key decisions:
-// - Uses system fonts for Dynamic Type support.
-// - Accessibility label uses AccessibilityFormatters for VoiceOver-friendly expanded text.
-// - Cover placeholder uses format-specific colors.
-// - Reading time label omitted for zero reading time.
+// - Visual tokens (palette, layout constants, serif title face) come
+//   from `LibraryCardTokens` — the design spec has one home.
+// - Title uses Source Serif 4 via `ReaderTypography`; author uses the
+//   warm-taupe sub-text token. Reading-time / speed metadata rows are
+//   omitted in the v2 design — the card is cover + title + author only.
+// - Cover carries the design's spine shadow + page-edge highlight so
+//   plain format-color placeholders read as physical book objects.
+// - Accessibility label uses AccessibilityFormatters for VoiceOver-
+//   friendly expanded text; exposed as a testing surface so the WI-8
+//   contract tests can pin it without inspecting SwiftUI internals.
 //
-// @coordinates-with: AccessibilityFormatters.swift, LibraryBookItem.swift, CustomCoverStore.swift
+// @coordinates-with: AccessibilityFormatters.swift, LibraryBookItem.swift,
+//   CustomCoverStore.swift, LibraryCardTokens.swift
 
 import SwiftUI
 
@@ -18,60 +26,57 @@ struct BookCardView: View {
     var coverVersion: Int = 0
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: LibraryCardTokens.cardStackSpacing) {
             // Cover: fixed 2:3 ratio container — uniform card height in grid
-            CoverContainerView(
+            BookCoverArtView(
                 image: customCoverImage,
                 coverColor: coverColor,
                 formatIcon: formatIcon,
-                formatBadge: book.formatBadge
+                formatBadge: book.formatBadge,
+                cornerRadius: LibraryCardTokens.cardCoverCornerRadius
             )
 
-            // Title
+            // Title — Source Serif 4, 2-line clamp
             Text(book.title)
-                .font(.subheadline)
-                .fontWeight(.medium)
+                .font(LibraryCardTokens.serifTitleFont(
+                    size: LibraryCardTokens.cardTitleFontSize
+                ))
+                .fontWeight(.semibold)
                 .lineLimit(2)
-                .foregroundStyle(.primary)
+                .foregroundStyle(LibraryCardTokens.ink)
 
             // Author
             if let author = book.author {
                 Text(author)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(.system(size: LibraryCardTokens.cardAuthorFontSize))
+                    .foregroundStyle(LibraryCardTokens.subText)
                     .lineLimit(1)
             }
 
-            // Reading time (omitted for zero)
-            if let readingTime = book.formattedReadingTime {
-                Text(readingTime)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-            }
-
-            // Speed
-            if let speed = book.formattedSpeed {
-                Text(speed)
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-            }
-
-            // Bug #177: pushes content to the top so shorter cards (fewer
-            // metadata rows) align top-edges with taller cards in the same
-            // LazyVGrid row — SwiftUI's default is vertical centering, which
-            // makes covers in the same row sit at different y-positions.
+            // Bug #177: pushes content to the top so shorter cards align
+            // top-edges with taller cards in the same LazyVGrid row —
+            // SwiftUI's default is vertical centering.
             Spacer(minLength: 0)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
-        .accessibilityHint("Double tap to open")
+        .accessibilityHint(accessibilityHint)
     }
+
+    // MARK: - Testing surface
+
+    /// Exposed so the WI-8 contract tests can assert the accessibility
+    /// contract without inspecting opaque SwiftUI modifier state.
+    var accessibilityLabelForTesting: String { accessibilityLabel }
+    var accessibilityHintForTesting: String { accessibilityHint }
 
     // MARK: - Private
 
-    /// Loads the custom cover for this book (if any). `coverVersion` dependency
-    /// ensures SwiftUI re-evaluates when covers change.
+    private let accessibilityHint = "Double tap to open"
+
+    /// Loads the custom cover for this book (if any). `coverVersion`
+    /// dependency ensures SwiftUI re-evaluates when covers change.
     private var customCoverImage: UIImage? {
         _ = coverVersion // force re-evaluation when version changes
         return CustomCoverStore.loadCover(for: book.fingerprintKey)
@@ -96,61 +101,5 @@ struct BookCardView: View {
             format: book.format,
             readingTimeSeconds: book.totalReadingSeconds
         )
-    }
-}
-
-/// Fixed 2:3 aspect ratio cover container.
-/// `Color.clear` drives layout — guarantees identical height for every card
-/// regardless of image dimensions. Image is in `.overlay` (not `.background`)
-/// so it never participates in layout sizing. `.clipped()` trims any
-/// scaledToFill overflow.
-private struct CoverContainerView: View {
-    let image: UIImage?
-    let coverColor: Color
-    let formatIcon: String
-    let formatBadge: String
-
-    var body: some View {
-        Color(white: 0.92)
-            .aspectRatio(2.0 / 3.0, contentMode: .fit)
-            .overlay {
-                GeometryReader { geo in
-                    if let image {
-                        Image(uiImage: image)
-                            .resizable()
-                            .scaledToFill()
-                            .frame(width: geo.size.width, height: geo.size.height)
-                            .clipped()
-                    } else {
-                        coverColor
-                    }
-                }
-            }
-            .overlay {
-                if image == nil {
-                    VStack(spacing: 4) {
-                        Image(systemName: formatIcon)
-                            .font(.system(size: 32))
-                            .foregroundStyle(.white.opacity(0.8))
-                        Text(formatBadge)
-                            .font(.caption2)
-                            .fontWeight(.bold)
-                            .foregroundStyle(.white.opacity(0.9))
-                    }
-                }
-            }
-            .clipShape(RoundedRectangle(cornerRadius: 8))
-            .overlay(
-                // Bug #107: bump stroke opacity 0.2 → 0.35 so covers
-                // with white/light edges visibly delineate against the
-                // white library-grid background. The previous 0.2 was
-                // effectively invisible on white, making AZW3 covers
-                // like 被讨厌的勇气 look like they had top padding.
-                // Stays subtle (still 0.5pt) so darker covers don't
-                // get a heavy outline.
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(Color.gray.opacity(0.35), lineWidth: 0.5)
-            )
-            .shadow(color: .black.opacity(0.1), radius: 2, y: 1)
     }
 }

--- a/vreader/Views/BookCardView.swift
+++ b/vreader/Views/BookCardView.swift
@@ -35,6 +35,10 @@ struct BookCardView: View {
                 formatBadge: book.formatBadge,
                 cornerRadius: LibraryCardTokens.cardCoverCornerRadius
             )
+            // Per-book reading-progress accents (feature #60 WI-8) —
+            // the in-cover strip while reading, the checkmark when done.
+            .overlay { progressStrip }
+            .overlay(alignment: .topTrailing) { finishedBadge }
 
             // Title — Source Serif 4, 2-line clamp
             Text(book.title)
@@ -71,6 +75,13 @@ struct BookCardView: View {
     var accessibilityLabelForTesting: String { accessibilityLabel }
     var accessibilityHintForTesting: String { accessibilityHint }
 
+    /// Exposed so the WI-8 contract tests can assert which progress
+    /// state the card derives — the strip / checkmark are otherwise
+    /// opaque SwiftUI overlays.
+    var progressStateForTesting: LibraryBookItem.ReadingProgressState {
+        book.readingProgressState
+    }
+
     // MARK: - Private
 
     private let accessibilityHint = "Double tap to open"
@@ -101,5 +112,61 @@ struct BookCardView: View {
             format: book.format,
             readingTimeSeconds: book.totalReadingSeconds
         )
+    }
+
+    // MARK: - Reading-progress accents (feature #60 WI-8)
+
+    /// In-cover progress strip — design `GridView`: a thin bar inset
+    /// from the cover's bottom edge, shown only while the book is
+    /// partially read. The fill spans `fraction` of the track width.
+    ///
+    /// The `GeometryReader` spans the whole cover (it is the overlay
+    /// content); the strip's width and position are computed inside
+    /// the measured space, so the 6pt horizontal inset and 4pt bottom
+    /// inset never depend on outer-`padding` proposal order.
+    @ViewBuilder
+    private var progressStrip: some View {
+        if case .inProgress(let fraction) = book.readingProgressState {
+            GeometryReader { geo in
+                let inset = LibraryCardTokens.coverProgressStripInset
+                let height = LibraryCardTokens.coverProgressStripHeight
+                let radius = LibraryCardTokens.coverProgressStripCornerRadius
+                let trackWidth = max(0, geo.size.width - inset * 2)
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: radius)
+                        .fill(LibraryCardTokens.coverProgressTrack)
+                    RoundedRectangle(cornerRadius: radius)
+                        .fill(LibraryCardTokens.coverProgressFill)
+                        .frame(width: trackWidth * CGFloat(fraction))
+                }
+                .frame(width: trackWidth, height: height)
+                .position(
+                    x: geo.size.width / 2,
+                    y: geo.size.height - height / 2
+                        - LibraryCardTokens.coverProgressStripBottomInset
+                )
+            }
+        }
+    }
+
+    /// Finished checkmark — design `GridView`: a white disc with a
+    /// green check inset from the cover's top-trailing corner, shown
+    /// only when the book is fully read.
+    @ViewBuilder
+    private var finishedBadge: some View {
+        if book.readingProgressState == .finished {
+            Circle()
+                .fill(LibraryCardTokens.coverFinishedBadgeFill)
+                .frame(
+                    width: LibraryCardTokens.finishedBadgeSize,
+                    height: LibraryCardTokens.finishedBadgeSize
+                )
+                .overlay {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(LibraryCardTokens.finished)
+                }
+                .padding(LibraryCardTokens.finishedBadgeInset)
+        }
     }
 }

--- a/vreader/Views/BookCoverArtView.swift
+++ b/vreader/Views/BookCoverArtView.swift
@@ -1,0 +1,113 @@
+// Purpose: Shared cover-art view for the Library grid card + list row
+// (feature #60 visual identity v2). Renders a custom cover image when
+// one exists, otherwise a format-colored placeholder, and overlays the
+// design's physical-book treatment: spine shadow, page-edge highlight,
+// hairline border, drop shadow.
+//
+// Key decisions:
+// - **Fixed 2:3 aspect ratio.** `Color.clear` drives layout so every
+//   card in a LazyVGrid row gets an identical height regardless of the
+//   underlying image dimensions. Image lives in `.overlay`, never in
+//   `.background`, so it never participates in sizing. `.clipped()`
+//   trims any scaledToFill overflow.
+// - **Spine + page-edge accents** are gradient strips per the design
+//   `BookCover` component — left spine darkens, right edge has a thin
+//   page highlight. They sit inside the clip so they curve with the
+//   corner radius.
+// - **Corner radius is a parameter** — the grid card uses 4pt, the
+//   list-row thumbnail uses 3pt (per design `vreader-library.jsx`).
+//
+// @coordinates-with: BookCardView.swift, BookRowView.swift,
+//   LibraryCardTokens.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-cover.jsx`
+
+import SwiftUI
+
+/// Cover-art view: custom image or format-colored placeholder, with the
+/// feature-#60 spine / page-edge / border / shadow treatment.
+struct BookCoverArtView: View {
+    let image: UIImage?
+    let coverColor: Color
+    let formatIcon: String
+    let formatBadge: String
+    var cornerRadius: CGFloat = LibraryCardTokens.cardCoverCornerRadius
+
+    var body: some View {
+        Color(white: 0.92)
+            .aspectRatio(LibraryCardTokens.coverAspectRatio, contentMode: .fit)
+            .overlay {
+                GeometryReader { geo in
+                    if let image {
+                        Image(uiImage: image)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: geo.size.width, height: geo.size.height)
+                            .clipped()
+                    } else {
+                        coverColor
+                    }
+                }
+            }
+            .overlay {
+                if image == nil {
+                    placeholderGlyph
+                }
+            }
+            .overlay { spineShadow }
+            .overlay { pageEdge }
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            .overlay(
+                // Bug #107: a subtle hairline keeps light-edged covers
+                // delineated against the warm-paper library background.
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .stroke(LibraryCardTokens.coverBorder, lineWidth: 0.5)
+            )
+            .shadow(color: .black.opacity(0.18), radius: 3, y: 2)
+    }
+
+    // MARK: - Placeholder
+
+    /// Format glyph + uppercase badge shown when no custom cover exists.
+    private var placeholderGlyph: some View {
+        VStack(spacing: 4) {
+            Image(systemName: formatIcon)
+                .font(.system(size: 32))
+                .foregroundStyle(.white.opacity(0.8))
+            Text(formatBadge)
+                .font(.caption2)
+                .fontWeight(.bold)
+                .foregroundStyle(.white.opacity(0.9))
+        }
+    }
+
+    // MARK: - Physical-book accents (per design BookCover)
+
+    /// Left-edge spine shadow — a gradient that darkens toward the
+    /// binding so a flat color placeholder reads as a book object.
+    private var spineShadow: some View {
+        HStack(spacing: 0) {
+            LinearGradient(
+                colors: [.black.opacity(0.25), .clear],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+            .frame(width: 6)
+            Spacer(minLength: 0)
+        }
+        .allowsHitTesting(false)
+    }
+
+    /// Right-edge page highlight — a thin strip suggesting cut pages.
+    private var pageEdge: some View {
+        HStack(spacing: 0) {
+            Spacer(minLength: 0)
+            LinearGradient(
+                colors: [.black.opacity(0.12), .white.opacity(0.18)],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+            .frame(width: 2)
+        }
+        .allowsHitTesting(false)
+    }
+}

--- a/vreader/Views/BookRowView.swift
+++ b/vreader/Views/BookRowView.swift
@@ -59,22 +59,84 @@ struct BookRowView: View {
                         .lineLimit(1)
                 }
 
-                // Format badge OR file-state indicator (feature #47).
-                fileStateBadge
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 1.5)
-                    .background(badgeBackground)
-                    .foregroundStyle(badgeForeground)
-                    .clipShape(RoundedRectangle(cornerRadius: 4))
-                    .padding(.top, 3)
+                metadataLine
             }
 
             Spacer(minLength: 0)
+
+            // Trailing reading-progress ring (feature #60 WI-8).
+            progressRing
         }
         .padding(.vertical, 4)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint(accessibilityHint)
+    }
+
+    // MARK: - Metadata line (feature #60 WI-8)
+
+    /// The format / file-state chip followed by the reading-progress
+    /// span — design `ListView`'s `gap:8` metadata row.
+    private var metadataLine: some View {
+        HStack(spacing: 8) {
+            // Format badge OR file-state indicator (feature #47).
+            fileStateBadge
+                .padding(.horizontal, 6)
+                .padding(.vertical, 1.5)
+                .background(badgeBackground)
+                .foregroundStyle(badgeForeground)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+
+            if let progressText = progressMetadataText {
+                Text(progressText)
+                    .font(.system(size: 11))
+                    .foregroundStyle(progressMetadataColor)
+                    .lineLimit(1)
+            }
+        }
+        .padding(.top, 3)
+    }
+
+    /// Progress span text per `ReadingProgressState`:
+    /// - `.inProgress` → "X%", plus " · last-read" when a last-read
+    ///   timestamp exists.
+    /// - `.finished`   → "Finished".
+    /// - `.notStarted` → nil. The design's "{n} pages" branch needs a
+    ///   page count `LibraryBookItem` does not carry; the chip stands
+    ///   alone here rather than inventing a substitute metric.
+    private var progressMetadataText: String? {
+        switch book.readingProgressState {
+        case .notStarted:
+            return nil
+        case .finished:
+            return "Finished"
+        case .inProgress(let fraction):
+            let percent = Int((fraction * 100).rounded())
+            if let lastReadAt = book.lastReadAt {
+                let relative = ReadingTimeFormatter.formatRelativeLastRead(
+                    from: lastReadAt
+                )
+                return "\(percent)% · \(relative)"
+            }
+            return "\(percent)%"
+        }
+    }
+
+    /// Progress span colour — the finished green for a completed book,
+    /// otherwise the warm sub-text token.
+    private var progressMetadataColor: Color {
+        book.readingProgressState == .finished
+            ? LibraryCardTokens.finished
+            : LibraryCardTokens.subText
+    }
+
+    /// Trailing oxblood progress ring — shown only while the book is
+    /// partially read (design `ListView`).
+    @ViewBuilder
+    private var progressRing: some View {
+        if case .inProgress(let fraction) = book.readingProgressState {
+            LibraryProgressRing(progress: fraction)
+        }
     }
 
     // MARK: - File-state badge (feature #47 WI-5)
@@ -154,6 +216,16 @@ struct BookRowView: View {
     var accessibilityHintForTesting: String { accessibilityHint }
     var fileStateBadgeTextForTesting: String { fileStateBadgeText }
     var fileStateBadgeSymbolForTesting: String? { fileStateBadgeSymbol }
+
+    /// The reading-progress span text, or nil for a not-started book —
+    /// pins the `X% · last-read` / `Finished` contract without a render.
+    var progressMetadataTextForTesting: String? { progressMetadataText }
+
+    /// Which progress state the row derives — the span and trailing
+    /// ring are otherwise opaque SwiftUI subviews.
+    var progressStateForTesting: LibraryBookItem.ReadingProgressState {
+        book.readingProgressState
+    }
 
     // MARK: - Private
 

--- a/vreader/Views/BookRowView.swift
+++ b/vreader/Views/BookRowView.swift
@@ -1,13 +1,23 @@
-// Purpose: List row view for a book in the library.
-// Shows format badge, title, author, reading time, and speed in a horizontal layout.
+// Purpose: List row view for a book in the library — re-skinned for
+// feature #60 visual identity v2.
 //
 // Key decisions:
-// - Horizontal layout with format icon, text stack, and trailing metadata.
-// - Accessibility label uses AccessibilityFormatters for VoiceOver-friendly expanded text.
-// - Dynamic Type supported via system fonts.
-// - Reading time label omitted for zero reading time.
+// - Horizontal layout: cover thumbnail (44×62), then a left-aligned
+//   text stack — Source Serif 4 title, warm-taupe author, and a
+//   metadata line carrying the format chip (or feature-#47 file-state
+//   badge).
+// - Visual tokens come from `LibraryCardTokens` (one home for the
+//   design spec). Reading-time / speed metadata rows are omitted in
+//   the v2 design — the row is cover + title + author + chip.
+// - The feature-#47 file-state badge is preserved verbatim per state
+//   (remote / downloading / failed / missing); only the chip container
+//   is re-skinned to the design's warm-wash capsule.
+// - Accessibility label uses AccessibilityFormatters for VoiceOver-
+//   friendly expanded text; exposed as a testing surface so the WI-8
+//   contract tests can pin it without inspecting SwiftUI internals.
 //
-// @coordinates-with: AccessibilityFormatters.swift, LibraryBookItem.swift, CustomCoverStore.swift
+// @coordinates-with: AccessibilityFormatters.swift, LibraryBookItem.swift,
+//   CustomCoverStore.swift, LibraryCardTokens.swift, BookFileState.swift
 
 import SwiftUI
 
@@ -18,76 +28,53 @@ struct BookRowView: View {
     var coverVersion: Int = 0
 
     var body: some View {
-        HStack(spacing: 12) {
-            // Format icon or custom cover
-            ZStack {
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(formatColor)
-                    .frame(width: 44, height: 44)
+        HStack(spacing: LibraryCardTokens.rowContentSpacing) {
+            // Cover thumbnail — shared spine/page-edge treatment.
+            BookCoverArtView(
+                image: customCoverImage,
+                coverColor: formatColor,
+                formatIcon: formatIcon,
+                formatBadge: book.formatBadge,
+                cornerRadius: LibraryCardTokens.rowCoverCornerRadius
+            )
+            .frame(
+                width: LibraryCardTokens.rowCoverWidth,
+                height: LibraryCardTokens.rowCoverHeight
+            )
 
-                if let customCover = customCoverImage {
-                    Image(uiImage: customCover)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .frame(width: 44, height: 44)
-                        .clipShape(RoundedRectangle(cornerRadius: 6))
-                } else {
-                    Image(systemName: formatIcon)
-                        .font(.system(size: 18))
-                        .foregroundStyle(.white)
-                }
-            }
-
-            // Title and author
+            // Title, author, metadata chip — left-aligned.
             VStack(alignment: .leading, spacing: 2) {
                 Text(book.title)
-                    .font(.body)
-                    .fontWeight(.medium)
+                    .font(LibraryCardTokens.serifTitleFont(
+                        size: LibraryCardTokens.rowTitleFontSize
+                    ))
+                    .fontWeight(.semibold)
                     .lineLimit(1)
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(LibraryCardTokens.ink)
 
                 if let author = book.author {
                     Text(author)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                        .font(.system(size: LibraryCardTokens.rowAuthorFontSize))
+                        .foregroundStyle(LibraryCardTokens.subText)
                         .lineLimit(1)
                 }
-            }
 
-            Spacer()
-
-            // Reading metadata
-            VStack(alignment: .trailing, spacing: 2) {
                 // Format badge OR file-state indicator (feature #47).
-                // Non-`.local` rows replace the format badge with a
-                // status icon so the user immediately sees the row is
-                // remote / downloading / failed.
                 fileStateBadge
                     .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(formatColor.opacity(0.15))
-                    .foregroundStyle(formatColor)
-                    .clipShape(Capsule())
-
-                // Reading time (omitted for zero)
-                if let readingTime = book.formattedReadingTime {
-                    Text(readingTime)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                }
-
-                // Speed
-                if let speed = book.formattedSpeed {
-                    Text(speed)
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                }
+                    .padding(.vertical, 1.5)
+                    .background(badgeBackground)
+                    .foregroundStyle(badgeForeground)
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                    .padding(.top, 3)
             }
+
+            Spacer(minLength: 0)
         }
         .padding(.vertical, 4)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
-        .accessibilityHint("Double tap to open")
+        .accessibilityHint(accessibilityHint)
     }
 
     // MARK: - File-state badge (feature #47 WI-5)
@@ -101,38 +88,79 @@ struct BookRowView: View {
     ///   - `.missingRemote` → xmark.icloud + "Missing"
     @ViewBuilder
     private var fileStateBadge: some View {
-        switch book.fileState {
-        case .local:
-            Text(book.formatBadge)
-                .font(.caption2)
-                .fontWeight(.semibold)
-        case .remoteOnly:
-            Label("Remote", systemImage: "cloud")
-                .font(.caption2)
+        let text = fileStateBadgeText
+        if let symbol = fileStateBadgeSymbol {
+            Label(text, systemImage: symbol)
+                .font(.system(size: LibraryCardTokens.rowChipFontSize))
                 .fontWeight(.semibold)
                 .labelStyle(.titleAndIcon)
-        case .downloading:
-            Label("Downloading", systemImage: "arrow.down.circle")
-                .font(.caption2)
+        } else {
+            Text(text)
+                .font(.system(size: LibraryCardTokens.rowChipFontSize))
                 .fontWeight(.semibold)
-                .labelStyle(.titleAndIcon)
-        case .failed:
-            Label("Retry", systemImage: "exclamationmark.icloud")
-                .font(.caption2)
-                .fontWeight(.semibold)
-                .labelStyle(.titleAndIcon)
-        case .missingRemote:
-            Label("Missing", systemImage: "xmark.icloud")
-                .font(.caption2)
-                .fontWeight(.semibold)
-                .labelStyle(.titleAndIcon)
+                .tracking(0.5)
         }
     }
 
+    /// Badge text per file state — the format badge for `.local`,
+    /// otherwise the transfer-state word (feature #47 contract).
+    private var fileStateBadgeText: String {
+        switch book.fileState {
+        case .local:         return book.formatBadge
+        case .remoteOnly:    return "Remote"
+        case .downloading:   return "Downloading"
+        case .failed:        return "Retry"
+        case .missingRemote: return "Missing"
+        }
+    }
+
+    /// SF Symbol for non-local file states; nil for `.local` (format
+    /// badge is text-only).
+    private var fileStateBadgeSymbol: String? {
+        switch book.fileState {
+        case .local:         return nil
+        case .remoteOnly:    return "cloud"
+        case .downloading:   return "arrow.down.circle"
+        case .failed:        return "exclamationmark.icloud"
+        case .missingRemote: return "xmark.icloud"
+        }
+    }
+
+    /// Chip fill — the design's warm wash for the format badge, the
+    /// format color tint for active transfer states (keeps the
+    /// feature-#47 status colour-coding).
+    private var badgeBackground: Color {
+        switch book.fileState {
+        case .local: return LibraryCardTokens.chipBackground
+        default:     return formatColor.opacity(0.15)
+        }
+    }
+
+    /// Chip text/icon colour — warm sub-text for the format badge,
+    /// format colour for transfer states.
+    private var badgeForeground: Color {
+        switch book.fileState {
+        case .local: return LibraryCardTokens.subText
+        default:     return formatColor
+        }
+    }
+
+    // MARK: - Testing surface
+
+    /// Exposed so the WI-8 contract tests can assert the accessibility
+    /// contract + feature-#47 badge logic without inspecting opaque
+    /// SwiftUI modifier state.
+    var accessibilityLabelForTesting: String { accessibilityLabel }
+    var accessibilityHintForTesting: String { accessibilityHint }
+    var fileStateBadgeTextForTesting: String { fileStateBadgeText }
+    var fileStateBadgeSymbolForTesting: String? { fileStateBadgeSymbol }
+
     // MARK: - Private
 
-    /// Loads the custom cover for this book (if any). `coverVersion` dependency
-    /// ensures SwiftUI re-evaluates when covers change.
+    private let accessibilityHint = "Double tap to open"
+
+    /// Loads the custom cover for this book (if any). `coverVersion`
+    /// dependency ensures SwiftUI re-evaluates when covers change.
     private var customCoverImage: UIImage? {
         _ = coverVersion // force re-evaluation when version changes
         return CustomCoverStore.loadCover(for: book.fingerprintKey)

--- a/vreader/Views/LibraryCardTokens.swift
+++ b/vreader/Views/LibraryCardTokens.swift
@@ -1,0 +1,146 @@
+// Purpose: Feature #60 visual-identity v2 — Library-screen design tokens
+// for the grid card (`BookCardView`) and list row (`BookRowView`).
+//
+// The Library is always presented in the warm-paper light palette in
+// the committed design bundle (it is not theme-switchable like the
+// reader). `ReaderThemeV2` covers the *reader* surfaces; its `.paper`
+// stop (`#f4eee0` bg) differs from the Library shell (`#f7f4ee`), so
+// the Library carries its own small token surface here rather than
+// borrowing reader tokens that would render the wrong shade.
+//
+// Token values are pinned to the committed design bundle at
+// `dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx`
+// (`GridView`, `ListView`) and `vreader-cover.jsx` (`BookCover`).
+//
+// Key decisions:
+// - **Layout constants are CGFloat statics, not magic numbers.** The
+//   card/row views and their contract tests both read these, so the
+//   design spec has one home.
+// - **Colors built from integer RGB triples** (mirrors
+//   `ReaderThemeV2.hex(_:_:_:)`) — keeps the design hex readable in
+//   source without a string-parsing dependency, and lets the type
+//   compile without importing the WI-7 `Color(hexString:)` helper.
+// - **`accent` reuses `AccentColor.light`'s oxblood** (`#8c2f2f`) so
+//   the Library badge accent stays coherent with the rest of the
+//   feature-#60 chrome rather than drifting to a Library-local hue.
+//
+// @coordinates-with: BookCardView.swift, BookRowView.swift,
+//   AccentColor.swift, ReaderThemeV2.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx`
+
+import SwiftUI
+
+/// Design tokens for the Library grid card + list row (feature #60 WI-8).
+/// Pure namespace — static members only, no instances.
+enum LibraryCardTokens {
+
+    // MARK: - Palette (warm-paper light, per design `vreader-library.jsx`)
+
+    /// Primary text — book titles, the `#1d1a14` near-black ink.
+    static let ink = rgb(0x1d, 0x1a, 0x14)
+
+    /// Secondary text — authors, metadata, the `#7a6a4a` warm taupe.
+    static let subText = rgb(0x7a, 0x6a, 0x4a)
+
+    /// Format-chip fill — `rgba(60,40,20,0.08)` warm wash on paper.
+    static let chipBackground = rgb(0x3c, 0x28, 0x14, alpha: 0.08)
+
+    /// List-card surface — the rows sit on a `#ffffff` rounded card.
+    static let listCardBackground = Color.white
+
+    /// Hairline between list rows — `rgba(60,40,20,0.08)`, drawn 0.5pt.
+    static let listRowDivider = rgb(0x3c, 0x28, 0x14, alpha: 0.08)
+
+    /// Restrained oxblood accent — reused from `AccentColor.light`
+    /// (`#8c2f2f`) so Library badges match the feature-#60 chrome.
+    static let accent = Self.color(fromHex: AccentColor.light.hex)
+
+    /// Cover hairline border — keeps light-edged covers delineated
+    /// against the warm-paper grid (carries bug #107's intent forward).
+    static let coverBorder = rgb(0x3c, 0x28, 0x14, alpha: 0.14)
+
+    // MARK: - Layout constants
+
+    /// Cover corner radius for the grid card. Design `BookCover` is
+    /// called with `radius: 4` from `GridView`.
+    static let cardCoverCornerRadius: CGFloat = 4
+
+    /// Cover aspect ratio (width ÷ height). Design `BookCover` default
+    /// is `110 × 165` → 2:3. The card scales the cover to the grid
+    /// cell width; the 2:3 ratio is the load-bearing invariant.
+    static let coverAspectRatio: CGFloat = 110.0 / 165.0
+
+    /// Grid card title point size — design `12.5px` Source Serif 4 600.
+    static let cardTitleFontSize: CGFloat = 12.5
+
+    /// Grid card author point size — design `10.5px`.
+    static let cardAuthorFontSize: CGFloat = 10.5
+
+    /// Vertical spacing between cover / title / author in the card.
+    static let cardStackSpacing: CGFloat = 8
+
+    /// List-row cover thumbnail size — design `BookCover` is called
+    /// with `width: 44, height: 62, radius: 3` from `ListView`.
+    static let rowCoverWidth: CGFloat = 44
+    static let rowCoverHeight: CGFloat = 62
+    static let rowCoverCornerRadius: CGFloat = 3
+
+    /// List-row horizontal gap between cover and text — design `gap: 12`.
+    static let rowContentSpacing: CGFloat = 12
+
+    /// List-row title point size — design `15px` Source Serif 4 600.
+    static let rowTitleFontSize: CGFloat = 15
+
+    /// List-row author point size — design `12px`.
+    static let rowAuthorFontSize: CGFloat = 12
+
+    /// List-row format-chip point size — design `9.5px` 600 weight.
+    static let rowChipFontSize: CGFloat = 9.5
+
+    /// List-card corner radius — design `borderRadius: 20`.
+    static let listCardCornerRadius: CGFloat = 20
+
+    // MARK: - Serif title font
+
+    /// Source Serif 4 face at the requested size, resolved via the
+    /// feature-#60 typography registry (WI-1b bundled the binary).
+    /// Falls back to Georgia/serif if the face is unavailable — same
+    /// chain `ReaderTypography` documents.
+    static func serifTitleFont(size: CGFloat) -> Font {
+        Font(ReaderTypography.body(for: .sourceSerif4, size: size))
+    }
+
+    // MARK: - Color builders
+
+    /// Builds a SwiftUI `Color` from 8-bit RGB integer triples plus
+    /// optional alpha — mirrors `ReaderThemeV2.hex(_:_:_:)` so the
+    /// design hex stays readable in source.
+    private static func rgb(
+        _ r: Int, _ g: Int, _ b: Int, alpha: Double = 1.0
+    ) -> Color {
+        Color(
+            .sRGB,
+            red: Double(r) / 255.0,
+            green: Double(g) / 255.0,
+            blue: Double(b) / 255.0,
+            opacity: alpha
+        )
+    }
+
+    /// Parses a `#RRGGBB` hex string into a `Color`. Used only for the
+    /// `AccentColor` bridge (its API exposes hex strings, not RGB
+    /// triples). Falls back to the design oxblood on malformed input
+    /// so the badge always renders.
+    private static func color(fromHex hex: String) -> Color {
+        var trimmed = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("#") { trimmed.removeFirst() }
+        guard trimmed.count == 6, let value = UInt32(trimmed, radix: 16) else {
+            return rgb(0x8c, 0x2f, 0x2f) // design oxblood fallback
+        }
+        return rgb(
+            Int((value >> 16) & 0xff),
+            Int((value >> 8) & 0xff),
+            Int(value & 0xff)
+        )
+    }
+}

--- a/vreader/Views/LibraryCardTokens.swift
+++ b/vreader/Views/LibraryCardTokens.swift
@@ -23,6 +23,13 @@
 // - **`accent` reuses `AccentColor.light`'s oxblood** (`#8c2f2f`) so
 //   the Library badge accent stays coherent with the rest of the
 //   feature-#60 chrome rather than drifting to a Library-local hue.
+//   `accent` is also the swept-arc colour of the list-row progress
+//   ring.
+// - **List-container tokens** (`listCardBackground`, `listRowDivider`,
+//   `listCardCornerRadius`) are pinned in the WI-8 token pass but
+//   consumed by the WI-9 Library-container re-skin. The design file
+//   is shared, so the spec lives in one home rather than splitting
+//   the same `vreader-library.jsx` constants across two PRs.
 //
 // @coordinates-with: BookCardView.swift, BookRowView.swift,
 //   AccentColor.swift, ReaderThemeV2.swift,
@@ -58,6 +65,24 @@ enum LibraryCardTokens {
     /// Cover hairline border — keeps light-edged covers delineated
     /// against the warm-paper grid (carries bug #107's intent forward).
     static let coverBorder = rgb(0x3c, 0x28, 0x14, alpha: 0.14)
+
+    /// Finished-state green — `#3a6a5a`. The grid-card finished
+    /// checkmark glyph and the list-row "Finished" label both use it.
+    static let finished = rgb(0x3a, 0x6a, 0x5a)
+
+    /// In-cover progress-strip track — `rgba(255,255,255,0.2)`. Sits
+    /// on the cover art, so it is white-on-image, not on paper.
+    static let coverProgressTrack = Color.white.opacity(0.2)
+
+    /// In-cover progress-strip fill — `rgba(255,255,255,0.9)`.
+    static let coverProgressFill = Color.white.opacity(0.9)
+
+    /// Finished-checkmark disc fill — `rgba(255,255,255,0.95)`.
+    static let coverFinishedBadgeFill = Color.white.opacity(0.95)
+
+    /// List-row progress-ring track — `rgba(60,40,20,0.12)` warm wash.
+    /// The ring's swept arc uses `accent` (oxblood).
+    static let progressRingTrack = rgb(0x3c, 0x28, 0x14, alpha: 0.12)
 
     // MARK: - Layout constants
 
@@ -99,6 +124,26 @@ enum LibraryCardTokens {
 
     /// List-card corner radius — design `borderRadius: 20`.
     static let listCardCornerRadius: CGFloat = 20
+
+    /// In-cover progress strip (design `GridView`): a 2.5pt-tall bar
+    /// inset 6pt horizontally and 4pt up from the cover's bottom edge,
+    /// with a 2pt corner radius.
+    static let coverProgressStripHeight: CGFloat = 2.5
+    static let coverProgressStripInset: CGFloat = 6
+    static let coverProgressStripBottomInset: CGFloat = 4
+    static let coverProgressStripCornerRadius: CGFloat = 2
+
+    /// Finished checkmark disc (design `GridView`): an 18pt circle
+    /// inset 6pt from the cover's top-trailing corner.
+    static let finishedBadgeSize: CGFloat = 18
+    static let finishedBadgeInset: CGFloat = 6
+
+    /// List-row progress ring (design `ListView`): a 30pt box holding
+    /// a radius-12 circle (24pt drawn diameter → 3pt inset each side)
+    /// stroked at 2pt.
+    static let progressRingSize: CGFloat = 30
+    static let progressRingInset: CGFloat = 3
+    static let progressRingLineWidth: CGFloat = 2
 
     // MARK: - Serif title font
 

--- a/vreader/Views/LibraryProgressRing.swift
+++ b/vreader/Views/LibraryProgressRing.swift
@@ -1,0 +1,62 @@
+// Purpose: Circular reading-progress ring for the Library list row
+// (feature #60 visual identity v2, WI-8).
+//
+// Key decisions:
+// - Mirrors the design `ListView`'s trailing SVG ring: a faint warm
+//   track circle under an oxblood arc that sweeps clockwise from the
+//   12 o'clock position.
+// - Geometry comes from `LibraryCardTokens` — a 30pt box holds a
+//   radius-12 circle (24pt drawn diameter) stroked at 2pt, so the
+//   visible ring is inset 3pt inside the row's trailing slot.
+// - `progress` is defensively clamped to `[0, 1]` so a stored
+//   `totalProgression` past 1 (rounding drift) cannot over-sweep the
+//   arc; callers should only mount the ring for in-progress books.
+//
+// @coordinates-with: BookRowView.swift, LibraryCardTokens.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx`
+
+import SwiftUI
+
+/// A circular progress ring for the Library list row — a faint track
+/// circle under an oxblood arc sweeping clockwise from 12 o'clock.
+struct LibraryProgressRing: View {
+    /// Reading-progress fraction; clamped to `[0, 1]` before drawing.
+    let progress: Double
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(
+                    LibraryCardTokens.progressRingTrack,
+                    lineWidth: LibraryCardTokens.progressRingLineWidth
+                )
+            Circle()
+                .trim(from: 0, to: clampedProgress)
+                .stroke(
+                    LibraryCardTokens.accent,
+                    style: StrokeStyle(
+                        lineWidth: LibraryCardTokens.progressRingLineWidth,
+                        lineCap: .round
+                    )
+                )
+                // SwiftUI trims from 3 o'clock; rotate so the arc
+                // starts at 12 o'clock like the design SVG.
+                .rotationEffect(.degrees(-90))
+        }
+        .frame(width: ringDiameter, height: ringDiameter)
+        .padding(LibraryCardTokens.progressRingInset)
+        .accessibilityHidden(true)
+    }
+
+    /// Drawn circle diameter — the 30pt box minus a 3pt inset each side.
+    private var ringDiameter: CGFloat {
+        LibraryCardTokens.progressRingSize
+            - LibraryCardTokens.progressRingInset * 2
+    }
+
+    /// `progress` clamped into `[0, 1]` — NaN collapses to 0.
+    private var clampedProgress: CGFloat {
+        guard progress.isFinite else { return 0 }
+        return CGFloat(min(max(progress, 0), 1))
+    }
+}

--- a/vreaderTests/Models/LibraryBookItemFileStateTests.swift
+++ b/vreaderTests/Models/LibraryBookItemFileStateTests.swift
@@ -146,3 +146,83 @@ struct PersistenceActorLibraryFileStateTests {
         )
     }
 }
+
+@Suite("PersistenceActor+Library — progressFraction projection (#60 WI-8)")
+struct PersistenceActorLibraryProgressTests {
+
+    /// A book with a saved reading position projects its
+    /// `totalProgression` into `LibraryBookItem.progressFraction`; a
+    /// book with no position projects `nil`. This is the end-to-end
+    /// data path that drives the grid-card strip and the row ring.
+    @Test func fetchAllLibraryBooks_projectsProgressFromReadingPosition() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+
+        let read = makeRecord(sha: String(repeating: "a", count: 64))
+        let unread = makeRecord(sha: String(repeating: "b", count: 64))
+        _ = try await persistence.insertBook(read)
+        _ = try await persistence.insertBook(unread)
+
+        let locator = try #require(
+            Locator.validated(bookFingerprint: read.fingerprint, totalProgression: 0.5)
+        )
+        try await persistence.savePosition(
+            bookFingerprintKey: read.fingerprintKey,
+            locator: locator,
+            deviceId: "test-device"
+        )
+
+        let items = try await persistence.fetchAllLibraryBooks()
+        let byKey = Dictionary(uniqueKeysWithValues: items.map { ($0.fingerprintKey, $0) })
+
+        #expect(byKey[read.fingerprintKey]?.progressFraction == 0.5)
+        #expect(byKey[read.fingerprintKey]?.readingProgressState == .inProgress(0.5))
+        #expect(byKey[unread.fingerprintKey]?.progressFraction == nil)
+        #expect(byKey[unread.fingerprintKey]?.readingProgressState == .notStarted)
+    }
+
+    /// A fully-read book (`totalProgression` 1.0) projects to the
+    /// `.finished` state — drives the grid-card checkmark.
+    @Test func fetchAllLibraryBooks_finishedBookProjectsFullProgress() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let book = makeRecord(sha: String(repeating: "c", count: 64))
+        _ = try await persistence.insertBook(book)
+
+        let locator = try #require(
+            Locator.validated(bookFingerprint: book.fingerprint, totalProgression: 1.0)
+        )
+        try await persistence.savePosition(
+            bookFingerprintKey: book.fingerprintKey,
+            locator: locator,
+            deviceId: "test-device"
+        )
+
+        let items = try await persistence.fetchAllLibraryBooks()
+        #expect(items.first?.progressFraction == 1.0)
+        #expect(items.first?.readingProgressState == .finished)
+    }
+
+    private func makeRecord(sha: String) -> BookRecord {
+        let fp = DocumentFingerprint(
+            contentSHA256: sha,
+            fileByteCount: 1024,
+            format: .epub
+        )
+        return BookRecord(
+            fingerprintKey: fp.canonicalKey,
+            title: "T",
+            author: nil,
+            coverImagePath: nil,
+            fingerprint: fp,
+            provenance: ImportProvenance(
+                source: .filesApp,
+                importedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                originalURLBookmarkData: nil
+            ),
+            detectedEncoding: nil,
+            addedAt: Date(),
+            originalExtension: "epub",
+            fileState: .local,
+            blobPath: nil
+        )
+    }
+}

--- a/vreaderTests/Models/LibraryBookItemTests.swift
+++ b/vreaderTests/Models/LibraryBookItemTests.swift
@@ -90,6 +90,70 @@ struct LibraryBookItemTests {
     }
 }
 
+@Suite("LibraryBookItem.ReadingProgressState (feature #60 WI-8)")
+struct LibraryBookItemProgressStateTests {
+
+    @Test("nil progress fraction is notStarted")
+    func nilFractionIsNotStarted() {
+        #expect(LibraryBookItem.stub(progressFraction: nil)
+            .readingProgressState == .notStarted)
+    }
+
+    @Test("zero progress is notStarted")
+    func zeroFractionIsNotStarted() {
+        #expect(LibraryBookItem.stub(progressFraction: 0)
+            .readingProgressState == .notStarted)
+    }
+
+    @Test("a negative fraction is notStarted")
+    func negativeFractionIsNotStarted() {
+        #expect(LibraryBookItem.stub(progressFraction: -0.3)
+            .readingProgressState == .notStarted)
+    }
+
+    @Test("NaN progress is notStarted")
+    func nanFractionIsNotStarted() {
+        #expect(LibraryBookItem.stub(progressFraction: .nan)
+            .readingProgressState == .notStarted)
+    }
+
+    @Test("infinite progress is notStarted")
+    func infiniteFractionIsNotStarted() {
+        #expect(LibraryBookItem.stub(progressFraction: .infinity)
+            .readingProgressState == .notStarted)
+    }
+
+    @Test("a tiny positive fraction is inProgress")
+    func tinyFractionIsInProgress() {
+        #expect(LibraryBookItem.stub(progressFraction: 0.0001)
+            .readingProgressState == .inProgress(0.0001))
+    }
+
+    @Test("a mid fraction is inProgress carrying that fraction")
+    func midFractionIsInProgress() {
+        #expect(LibraryBookItem.stub(progressFraction: 0.5)
+            .readingProgressState == .inProgress(0.5))
+    }
+
+    @Test("just under 1.0 is inProgress, not finished")
+    func justUnderOneIsInProgress() {
+        #expect(LibraryBookItem.stub(progressFraction: 0.9999)
+            .readingProgressState == .inProgress(0.9999))
+    }
+
+    @Test("exactly 1.0 is finished")
+    func exactlyOneIsFinished() {
+        #expect(LibraryBookItem.stub(progressFraction: 1.0)
+            .readingProgressState == .finished)
+    }
+
+    @Test("past 1.0 is finished (rounding-drift tolerance)")
+    func pastOneIsFinished() {
+        #expect(LibraryBookItem.stub(progressFraction: 1.5)
+            .readingProgressState == .finished)
+    }
+}
+
 @Suite("LibrarySortOrder")
 struct LibrarySortOrderTests {
 

--- a/vreaderTests/Utils/ReadingTimeFormatterTests.swift
+++ b/vreaderTests/Utils/ReadingTimeFormatterTests.swift
@@ -197,3 +197,65 @@ struct ReadingTimeFormatterTests {
         #expect(ReadingTimeFormatter.formatBadgeLabel(format: "") == "")
     }
 }
+
+@Suite("ReadingTimeFormatter.formatRelativeLastRead (feature #60 WI-8)")
+struct ReadingTimeFormatterRelativeTests {
+
+    /// A fixed reference instant so every bucket is deterministic.
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func ago(_ seconds: TimeInterval) -> Date {
+        now.addingTimeInterval(-seconds)
+    }
+
+    @Test func underAMinuteIsJustNow() {
+        #expect(ReadingTimeFormatter.formatRelativeLastRead(
+            from: ago(30), relativeTo: now) == "Just now")
+    }
+
+    @Test func aFutureTimestampIsJustNow() {
+        // Clock skew between the position write and the render.
+        #expect(ReadingTimeFormatter.formatRelativeLastRead(
+            from: now.addingTimeInterval(500), relativeTo: now) == "Just now")
+    }
+
+    @Test func exactlySixtySecondsIsOneMinute() {
+        #expect(ReadingTimeFormatter.formatRelativeLastRead(
+            from: ago(60), relativeTo: now) == "1m ago")
+    }
+
+    @Test func minutesBucket() {
+        #expect(ReadingTimeFormatter.formatRelativeLastRead(
+            from: ago(45 * 60), relativeTo: now) == "45m ago")
+    }
+
+    @Test func hoursBucket() {
+        #expect(ReadingTimeFormatter.formatRelativeLastRead(
+            from: ago(3 * 3_600), relativeTo: now) == "3h ago")
+    }
+
+    @Test func oneDayIsYesterday() {
+        #expect(ReadingTimeFormatter.formatRelativeLastRead(
+            from: ago(25 * 3_600), relativeTo: now) == "Yesterday")
+    }
+
+    @Test func daysBucket() {
+        #expect(ReadingTimeFormatter.formatRelativeLastRead(
+            from: ago(3 * 86_400), relativeTo: now) == "3d ago")
+    }
+
+    @Test func weeksBucket() {
+        #expect(ReadingTimeFormatter.formatRelativeLastRead(
+            from: ago(10 * 86_400), relativeTo: now) == "1w ago")
+    }
+
+    @Test func monthsBucket() {
+        #expect(ReadingTimeFormatter.formatRelativeLastRead(
+            from: ago(95 * 86_400), relativeTo: now) == "3mo ago")
+    }
+
+    @Test func yearsBucket() {
+        #expect(ReadingTimeFormatter.formatRelativeLastRead(
+            from: ago(800 * 86_400), relativeTo: now) == "2y ago")
+    }
+}

--- a/vreaderTests/ViewModels/LibraryTestHelpers.swift
+++ b/vreaderTests/ViewModels/LibraryTestHelpers.swift
@@ -72,7 +72,8 @@ extension LibraryBookItem {
         totalReadingSeconds: Int = 0,
         lastReadAt: Date? = nil,
         averagePagesPerHour: Double? = nil,
-        averageWordsPerMinute: Double? = nil
+        averageWordsPerMinute: Double? = nil,
+        progressFraction: Double? = nil
     ) -> LibraryBookItem {
         LibraryBookItem(
             fingerprintKey: fingerprintKey,
@@ -87,7 +88,8 @@ extension LibraryBookItem {
             totalReadingSeconds: totalReadingSeconds,
             lastReadAt: lastReadAt,
             averagePagesPerHour: averagePagesPerHour,
-            averageWordsPerMinute: averageWordsPerMinute
+            averageWordsPerMinute: averageWordsPerMinute,
+            progressFraction: progressFraction
         )
     }
 }

--- a/vreaderTests/Views/BookCardViewVisualTests.swift
+++ b/vreaderTests/Views/BookCardViewVisualTests.swift
@@ -1,0 +1,164 @@
+// Purpose: Contract tests for the feature #60 WI-8 re-skin of
+// `BookCardView` (Library grid card). These are structural / token
+// assertions, NOT pixel snapshots — they pin the design constants the
+// card view reads from `LibraryCardTokens` and confirm the card's
+// accessibility contract is preserved across the re-skin.
+//
+// Design source: `dev-docs/designs/vreader-fidelity-v1/project/
+// vreader-library.jsx` (`GridView`) + `vreader-cover.jsx` (`BookCover`).
+//
+// @coordinates-with: BookCardView.swift, LibraryCardTokens.swift,
+//   LibraryBookItem.swift, AccessibilityFormatters.swift
+
+import Testing
+import SwiftUI
+import Foundation
+@testable import vreader
+
+@Suite("BookCardView visual tokens (feature #60 WI-8)")
+@MainActor
+struct BookCardViewVisualTests {
+
+    // MARK: - Helpers
+
+    private func makeBook(
+        title: String = "Pride and Prejudice",
+        author: String? = "Jane Austen",
+        format: String = "epub",
+        readingSeconds: Int = 0
+    ) -> LibraryBookItem {
+        LibraryBookItem(
+            fingerprintKey: "epub:\(String(repeating: "a", count: 64)):1024",
+            title: title,
+            author: author,
+            coverImagePath: nil,
+            format: format,
+            fileByteCount: 1024,
+            addedAt: Date(timeIntervalSince1970: 0),
+            lastOpenedAt: nil,
+            isFavorite: false,
+            totalReadingSeconds: readingSeconds,
+            averagePagesPerHour: nil,
+            averageWordsPerMinute: nil
+        )
+    }
+
+    // MARK: - Cover sizing per design
+
+    @Test("Cover uses the design's 2:3 aspect ratio (110×165)")
+    func coverAspectRatioMatchesDesign() {
+        // `BookCover` default is 110 × 165 — the plan's WI-8 catalogue
+        // pins "110 × 165 including spine + page-edge accents". Compared
+        // with a tolerance because the token is a CGFloat and the
+        // design ratio a Double — IEEE-754 round-trip can differ in the
+        // last bit, and the load-bearing fact is the 2:3 proportion.
+        let ratio = Double(LibraryCardTokens.coverAspectRatio)
+        #expect(abs(ratio - 110.0 / 165.0) < 0.0001)
+        // Sanity: the ratio is portrait (< 1) and is the 2:3 proportion.
+        #expect(ratio < 1.0)
+        #expect(abs(ratio - 2.0 / 3.0) < 0.0001)
+    }
+
+    @Test("Card cover corner radius matches design BookCover radius:4")
+    func coverCornerRadiusMatchesDesign() {
+        #expect(LibraryCardTokens.cardCoverCornerRadius == 4)
+    }
+
+    // MARK: - Typography per design
+
+    @Test("Card title uses the design 12.5pt size")
+    func cardTitleFontSizeMatchesDesign() {
+        #expect(LibraryCardTokens.cardTitleFontSize == 12.5)
+    }
+
+    @Test("Card author uses the design 10.5pt size")
+    func cardAuthorFontSizeMatchesDesign() {
+        #expect(LibraryCardTokens.cardAuthorFontSize == 10.5)
+    }
+
+    @Test("Card stack spacing matches design gap:8")
+    func cardStackSpacingMatchesDesign() {
+        #expect(LibraryCardTokens.cardStackSpacing == 8)
+    }
+
+    @Test("Serif title font resolves to Source Serif 4 (or its fallback)")
+    func serifTitleFontResolves() {
+        // ReaderTypography guarantees a usable UIFont for .sourceSerif4
+        // (the bundled face, or Georgia/system fallback). The bridge
+        // must not crash and must carry the requested point size.
+        let uiFont = ReaderTypography.body(for: .sourceSerif4, size: 12.5)
+        #expect(uiFont.pointSize == 12.5)
+        // The Font wrapper is constructible from it.
+        _ = LibraryCardTokens.serifTitleFont(size: 12.5)
+    }
+
+    // MARK: - Palette per design
+
+    @Test("Ink token is the design near-black #1d1a14")
+    func inkTokenMatchesDesign() {
+        assertColor(LibraryCardTokens.ink, rgb: (0x1d, 0x1a, 0x14))
+    }
+
+    @Test("Sub-text token is the design warm taupe #7a6a4a")
+    func subTextTokenMatchesDesign() {
+        assertColor(LibraryCardTokens.subText, rgb: (0x7a, 0x6a, 0x4a))
+    }
+
+    @Test("Accent token reuses the feature-#60 oxblood #8c2f2f")
+    func accentTokenMatchesFeatureAccent() {
+        assertColor(LibraryCardTokens.accent, rgb: (0x8c, 0x2f, 0x2f))
+        // And is literally derived from AccentColor.light.
+        #expect(AccentColor.light.hex == "#8c2f2f")
+    }
+
+    // MARK: - Accessibility contract preserved
+
+    @Test("Card accessibility label is the VoiceOver book description")
+    func cardAccessibilityLabelPreserved() {
+        let book = makeBook(readingSeconds: 3600)
+        let view = BookCardView(book: book)
+        // The re-skin must keep routing through AccessibilityFormatters
+        // so VoiceOver output is unchanged for XCUITest harnesses.
+        let expected = AccessibilityFormatters.accessibleBookDescription(
+            title: book.title,
+            author: book.author,
+            format: book.format,
+            readingTimeSeconds: book.totalReadingSeconds
+        )
+        #expect(view.accessibilityLabelForTesting == expected)
+        #expect(view.accessibilityHintForTesting == "Double tap to open")
+    }
+
+    @Test("Card builds for a book with no author")
+    func cardBuildsWithoutAuthor() {
+        let view = BookCardView(book: makeBook(author: nil))
+        // No crash; label still well-formed.
+        #expect(!view.accessibilityLabelForTesting.isEmpty)
+    }
+
+    @Test("Card builds across every supported format")
+    func cardBuildsForEveryFormat() {
+        for format in ["epub", "pdf", "txt", "md", "azw3"] {
+            let view = BookCardView(book: makeBook(format: format))
+            #expect(!view.accessibilityLabelForTesting.isEmpty)
+        }
+    }
+
+    // MARK: - Color assertion helper
+
+    /// Asserts a SwiftUI `Color` resolves to the given 8-bit RGB triple
+    /// (alpha 1.0) in the sRGB space. Tolerates float rounding.
+    private func assertColor(
+        _ color: Color,
+        rgb expected: (Int, Int, Int),
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+        let resolved = color.resolve(in: EnvironmentValues())
+        let r = Int((resolved.red * 255).rounded())
+        let g = Int((resolved.green * 255).rounded())
+        let b = Int((resolved.blue * 255).rounded())
+        #expect(r == expected.0, "red", sourceLocation: sourceLocation)
+        #expect(g == expected.1, "green", sourceLocation: sourceLocation)
+        #expect(b == expected.2, "blue", sourceLocation: sourceLocation)
+    }
+}

--- a/vreaderTests/Views/BookCardViewVisualTests.swift
+++ b/vreaderTests/Views/BookCardViewVisualTests.swift
@@ -25,7 +25,8 @@ struct BookCardViewVisualTests {
         title: String = "Pride and Prejudice",
         author: String? = "Jane Austen",
         format: String = "epub",
-        readingSeconds: Int = 0
+        readingSeconds: Int = 0,
+        progressFraction: Double? = nil
     ) -> LibraryBookItem {
         LibraryBookItem(
             fingerprintKey: "epub:\(String(repeating: "a", count: 64)):1024",
@@ -39,7 +40,8 @@ struct BookCardViewVisualTests {
             isFavorite: false,
             totalReadingSeconds: readingSeconds,
             averagePagesPerHour: nil,
-            averageWordsPerMinute: nil
+            averageWordsPerMinute: nil,
+            progressFraction: progressFraction
         )
     }
 
@@ -142,6 +144,37 @@ struct BookCardViewVisualTests {
             let view = BookCardView(book: makeBook(format: format))
             #expect(!view.accessibilityLabelForTesting.isEmpty)
         }
+    }
+
+    // MARK: - Reading-progress accents (feature #60 WI-8)
+
+    @Test("Card with no reading position reports notStarted")
+    func cardNotStartedWithoutProgress() {
+        let view = BookCardView(book: makeBook(progressFraction: nil))
+        #expect(view.progressStateForTesting == .notStarted)
+    }
+
+    @Test("Card with a zero fraction reports notStarted")
+    func cardNotStartedAtZero() {
+        let view = BookCardView(book: makeBook(progressFraction: 0))
+        #expect(view.progressStateForTesting == .notStarted)
+    }
+
+    @Test("Card with a partial fraction reports inProgress")
+    func cardInProgressAtPartialFraction() {
+        let view = BookCardView(book: makeBook(progressFraction: 0.42))
+        #expect(view.progressStateForTesting == .inProgress(0.42))
+    }
+
+    @Test("Card at full progress reports finished")
+    func cardFinishedAtFullProgress() {
+        let view = BookCardView(book: makeBook(progressFraction: 1.0))
+        #expect(view.progressStateForTesting == .finished)
+    }
+
+    @Test("Finished green token is the design #3a6a5a")
+    func finishedTokenMatchesDesign() {
+        assertColor(LibraryCardTokens.finished, rgb: (0x3a, 0x6a, 0x5a))
     }
 
     // MARK: - Color assertion helper

--- a/vreaderTests/Views/BookRowViewVisualTests.swift
+++ b/vreaderTests/Views/BookRowViewVisualTests.swift
@@ -27,7 +27,9 @@ struct BookRowViewVisualTests {
         author: String? = "David Deutsch",
         format: String = "pdf",
         readingSeconds: Int = 0,
-        fileState: BookFileState = .local
+        fileState: BookFileState = .local,
+        progressFraction: Double? = nil,
+        lastReadAt: Date? = nil
     ) -> LibraryBookItem {
         LibraryBookItem(
             fingerprintKey: "pdf:\(String(repeating: "b", count: 64)):2048",
@@ -40,9 +42,11 @@ struct BookRowViewVisualTests {
             lastOpenedAt: nil,
             isFavorite: false,
             totalReadingSeconds: readingSeconds,
+            lastReadAt: lastReadAt,
             averagePagesPerHour: nil,
             averageWordsPerMinute: nil,
-            fileState: fileState
+            fileState: fileState,
+            progressFraction: progressFraction
         )
     }
 
@@ -177,6 +181,50 @@ struct BookRowViewVisualTests {
     func localFileStateHasNoSymbol() {
         let view = BookRowView(book: makeBook(fileState: .local))
         #expect(view.fileStateBadgeSymbolForTesting == nil)
+    }
+
+    // MARK: - Reading-progress display (feature #60 WI-8)
+
+    @Test("Row with no reading position shows no progress span")
+    func rowNotStartedHasNoSpan() {
+        let view = BookRowView(book: makeBook(progressFraction: nil))
+        #expect(view.progressStateForTesting == .notStarted)
+        #expect(view.progressMetadataTextForTesting == nil)
+    }
+
+    @Test("Row in progress shows percent and a relative last-read")
+    func rowInProgressShowsPercentAndLastRead() {
+        let view = BookRowView(book: makeBook(
+            progressFraction: 0.37,
+            lastReadAt: Date(timeIntervalSinceNow: -3 * 86_400)
+        ))
+        // The relative suffix shifts with run time; the percent prefix
+        // and separator are the deterministic part of the contract.
+        #expect(view.progressMetadataTextForTesting?.hasPrefix("37% · ") == true)
+    }
+
+    @Test("Row in progress with no last-read shows percent only")
+    func rowInProgressNoLastReadShowsPercentOnly() {
+        let view = BookRowView(book: makeBook(
+            progressFraction: 0.6, lastReadAt: nil
+        ))
+        #expect(view.progressMetadataTextForTesting == "60%")
+    }
+
+    @Test("Row at full progress shows the Finished label")
+    func rowFinishedShowsFinishedLabel() {
+        let view = BookRowView(book: makeBook(progressFraction: 1.0))
+        #expect(view.progressStateForTesting == .finished)
+        #expect(view.progressMetadataTextForTesting == "Finished")
+    }
+
+    @Test("Progress-ring track is the design rgba(60,40,20,0.12)")
+    func progressRingTrackMatchesDesign() {
+        assertColor(
+            LibraryCardTokens.progressRingTrack,
+            rgb: (0x3c, 0x28, 0x14),
+            alpha: 0.12
+        )
     }
 
     // MARK: - Color assertion helper

--- a/vreaderTests/Views/BookRowViewVisualTests.swift
+++ b/vreaderTests/Views/BookRowViewVisualTests.swift
@@ -1,0 +1,203 @@
+// Purpose: Contract tests for the feature #60 WI-8 re-skin of
+// `BookRowView` (Library list row). Structural / token assertions, NOT
+// pixel snapshots — they pin the design constants the row reads from
+// `LibraryCardTokens`, confirm the row's accessibility contract is
+// preserved, and confirm the feature-#47 file-state badge logic
+// survives the re-skin (remote / downloading / failed / missing).
+//
+// Design source: `dev-docs/designs/vreader-fidelity-v1/project/
+// vreader-library.jsx` (`ListView`) + `vreader-cover.jsx` (`BookCover`).
+//
+// @coordinates-with: BookRowView.swift, LibraryCardTokens.swift,
+//   LibraryBookItem.swift, BookFileState.swift, AccessibilityFormatters.swift
+
+import Testing
+import SwiftUI
+import Foundation
+@testable import vreader
+
+@Suite("BookRowView visual tokens (feature #60 WI-8)")
+@MainActor
+struct BookRowViewVisualTests {
+
+    // MARK: - Helpers
+
+    private func makeBook(
+        title: String = "The Beginning of Infinity",
+        author: String? = "David Deutsch",
+        format: String = "pdf",
+        readingSeconds: Int = 0,
+        fileState: BookFileState = .local
+    ) -> LibraryBookItem {
+        LibraryBookItem(
+            fingerprintKey: "pdf:\(String(repeating: "b", count: 64)):2048",
+            title: title,
+            author: author,
+            coverImagePath: nil,
+            format: format,
+            fileByteCount: 2048,
+            addedAt: Date(timeIntervalSince1970: 0),
+            lastOpenedAt: nil,
+            isFavorite: false,
+            totalReadingSeconds: readingSeconds,
+            averagePagesPerHour: nil,
+            averageWordsPerMinute: nil,
+            fileState: fileState
+        )
+    }
+
+    // MARK: - Cover thumbnail sizing per design
+
+    @Test("Row cover thumbnail is the design 44×62 size")
+    func rowCoverSizeMatchesDesign() {
+        // `ListView` calls BookCover with width:44, height:62, radius:3.
+        #expect(LibraryCardTokens.rowCoverWidth == 44)
+        #expect(LibraryCardTokens.rowCoverHeight == 62)
+        #expect(LibraryCardTokens.rowCoverCornerRadius == 3)
+    }
+
+    @Test("Row cover thumbnail keeps a portrait aspect ratio")
+    func rowCoverIsPortrait() {
+        #expect(LibraryCardTokens.rowCoverWidth < LibraryCardTokens.rowCoverHeight)
+    }
+
+    // MARK: - Layout constants per design
+
+    @Test("Row content spacing matches design gap:12")
+    func rowContentSpacingMatchesDesign() {
+        #expect(LibraryCardTokens.rowContentSpacing == 12)
+    }
+
+    @Test("List card corner radius matches design borderRadius:20")
+    func listCardCornerRadiusMatchesDesign() {
+        #expect(LibraryCardTokens.listCardCornerRadius == 20)
+    }
+
+    // MARK: - Typography per design
+
+    @Test("Row title uses the design 15pt size")
+    func rowTitleFontSizeMatchesDesign() {
+        #expect(LibraryCardTokens.rowTitleFontSize == 15)
+    }
+
+    @Test("Row author uses the design 12pt size")
+    func rowAuthorFontSizeMatchesDesign() {
+        #expect(LibraryCardTokens.rowAuthorFontSize == 12)
+    }
+
+    @Test("Row format chip uses the design 9.5pt size")
+    func rowChipFontSizeMatchesDesign() {
+        #expect(LibraryCardTokens.rowChipFontSize == 9.5)
+    }
+
+    // MARK: - Palette per design
+
+    @Test("Format chip background is the design warm wash")
+    func chipBackgroundMatchesDesign() {
+        // rgba(60,40,20,0.08) → #3c2814 @ 0.08
+        assertColor(
+            LibraryCardTokens.chipBackground,
+            rgb: (0x3c, 0x28, 0x14),
+            alpha: 0.08
+        )
+    }
+
+    @Test("List card surface is white per design")
+    func listCardBackgroundIsWhite() {
+        assertColor(LibraryCardTokens.listCardBackground, rgb: (0xff, 0xff, 0xff))
+    }
+
+    // MARK: - Accessibility contract preserved
+
+    @Test("Row accessibility label is the VoiceOver book description")
+    func rowAccessibilityLabelPreserved() {
+        let book = makeBook(readingSeconds: 7200)
+        let view = BookRowView(book: book)
+        let expected = AccessibilityFormatters.accessibleBookDescription(
+            title: book.title,
+            author: book.author,
+            format: book.format,
+            readingTimeSeconds: book.totalReadingSeconds
+        )
+        #expect(view.accessibilityLabelForTesting == expected)
+        #expect(view.accessibilityHintForTesting == "Double tap to open")
+    }
+
+    @Test("Row builds for a book with no author")
+    func rowBuildsWithoutAuthor() {
+        let view = BookRowView(book: makeBook(author: nil))
+        #expect(!view.accessibilityLabelForTesting.isEmpty)
+    }
+
+    // MARK: - feature-#47 file-state badge survives the re-skin
+
+    @Test("File-state badge label is preserved for every BookFileState")
+    func fileStateBadgeLabelsPreserved() {
+        // The re-skin re-skins the badge *container*; the per-state
+        // text must be unchanged (feature #47 contract).
+        let cases: [(BookFileState, String)] = [
+            (.remoteOnly, "Remote"),
+            (.downloading, "Downloading"),
+            (.failed, "Retry"),
+            (.missingRemote, "Missing"),
+        ]
+        for (state, expectedText) in cases {
+            let view = BookRowView(book: makeBook(fileState: state))
+            #expect(
+                view.fileStateBadgeTextForTesting == expectedText,
+                "state \(state)"
+            )
+        }
+    }
+
+    @Test("Local file-state shows the format badge, not a transfer label")
+    func localFileStateShowsFormatBadge() {
+        let view = BookRowView(book: makeBook(format: "epub", fileState: .local))
+        #expect(view.fileStateBadgeTextForTesting == "EPUB")
+    }
+
+    @Test("File-state symbol is preserved for every non-local state")
+    func fileStateBadgeSymbolsPreserved() {
+        let cases: [(BookFileState, String)] = [
+            (.remoteOnly, "cloud"),
+            (.downloading, "arrow.down.circle"),
+            (.failed, "exclamationmark.icloud"),
+            (.missingRemote, "xmark.icloud"),
+        ]
+        for (state, expectedSymbol) in cases {
+            let view = BookRowView(book: makeBook(fileState: state))
+            #expect(
+                view.fileStateBadgeSymbolForTesting == expectedSymbol,
+                "state \(state)"
+            )
+        }
+    }
+
+    @Test("Local file-state has no transfer symbol")
+    func localFileStateHasNoSymbol() {
+        let view = BookRowView(book: makeBook(fileState: .local))
+        #expect(view.fileStateBadgeSymbolForTesting == nil)
+    }
+
+    // MARK: - Color assertion helper
+
+    private func assertColor(
+        _ color: Color,
+        rgb expected: (Int, Int, Int),
+        alpha expectedAlpha: Double = 1.0,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+        let resolved = color.resolve(in: EnvironmentValues())
+        let r = Int((resolved.red * 255).rounded())
+        let g = Int((resolved.green * 255).rounded())
+        let b = Int((resolved.blue * 255).rounded())
+        #expect(r == expected.0, "red", sourceLocation: sourceLocation)
+        #expect(g == expected.1, "green", sourceLocation: sourceLocation)
+        #expect(b == expected.2, "blue", sourceLocation: sourceLocation)
+        #expect(
+            abs(Double(resolved.opacity) - expectedAlpha) < 0.01,
+            "alpha",
+            sourceLocation: sourceLocation
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Re-skins the Library grid card (`BookCardView`) and list row (`BookRowView`) to the feature #60 visual-identity v2 design — cover treatment, Source Serif 4 titles, warm-taupe metadata.
- Adds the per-book **reading-progress UI** the design specifies: in-cover progress strip + finished checkmark on the card, `%·last-read` / `Finished` metadata span + trailing oxblood ring on the row.

Part of feature #718.

## What Changed

- **`LibraryBookItem`** — `+ progressFraction: Double?` (init param defaulted `nil` for back-compat) and a nested `ReadingProgressState` enum (`notStarted` / `inProgress(Double)` / `finished`) with a `readingProgressState` classifier (nil / non-finite / ≤0 → notStarted; ≥1 → finished; else inProgress).
- **`PersistenceActor+Library`** — `fetchAllLibraryBooks()` projects `progressFraction` from `book.readingPosition?.locator.totalProgression`.
- **`BookCardView`** — in-cover progress strip + finished checkmark (`.overlay` on `BookCoverArtView`).
- **`BookRowView`** — metadata span (`X% · last-read` / `Finished`) + trailing progress ring.
- **`LibraryProgressRing`** (new) — 30pt oxblood-on-warm ring.
- **`ReadingTimeFormatter.formatRelativeLastRead`** — deterministic, locale-independent relative-time buckets.
- **`LibraryCardTokens`** — `finished` green (#3a6a5a), progress colours, ring track, strip/ring layout constants.

## WI Status

- WI-8: behavioral — this PR.
- Remaining: WI-6c (More menu), WI-9 (Library container — adds the grid/list toggle), WI-10 (sheets + covers + status bar, final WI).

## Codex Audit (Gate 4)

3 rounds, thread `019e2ff2…`, verdict **ship-as-is**. Round 1 found the card/row missing the design's progress UI (2 High) — fixed this round. Round 2 flagged a progress-strip inset robustness concern — restructured to an explicit `GeometryReader` + `.position`. Round 3 verified: zero open Critical/High/Medium.

Audit log: `.claude/codex-audits/feat-feature-60-wi-8-library-card-tokens-audit.md`

## Validation

- [x] WI-8 unit tests pass — 105 tests across 7 suites (progress-state boundaries incl. nil/NaN/∞/negative/exactly-1/past-1; relative-time buckets; card/row progress display) + 144 library blast-radius tests (`LibraryViewModel*`, `PersistenceActor+Library`) — all green in isolation.
- [x] New `PersistenceActorLibraryProgressTests` directly covers the `fetchAllLibraryBooks` → `progressFraction` projection.
- [x] Tests cover changed behavior (TDD: RED → GREEN).
- [x] Codex Gate 4 — 3 rounds, ship-as-is.
- [x] Docs sync — n/a (mid-feature slice; no new service/@Model/notification; README Features updates with the final WI).
- [x] Version bumped: 3.24.12 → 3.24.13.

**Full-suite test gate note:** the full `-only-testing:vreaderTests` run is currently blocked by a pre-existing flake unrelated to WI-8 — `TTSServiceSpeedControlTests` (AVFoundation/`AVSpeechSynthesizer`) hard-crashes the test host, which orphans unrelated tests. It reproduces in isolation on tests WI-8 does not touch (zero code path from the changed files). WI-8's own code is fully green in the isolated + blast-radius runs above.

## Gate 5a Verification (per-PR slice — pre-merge)

Tier: **behavioral** — slice verified end-to-end on iPhone 17 Pro Simulator with the installed 3.24.13 build.

- Seeded fixture books; the re-skinned grid renders correctly — cover treatment, Source Serif 4 titles, warm-taupe authors, no layout breakage / crash.
- **`.finished`**: read the EPUB fixture to completion → `Locator.totalProgression = 1.0` persisted (verified in the SwiftData store) → the card renders the finished checkmark (white disc + green check, top-trailing). Confirms the full data path: read → `savePosition` → SwiftData → `fetchAllLibraryBooks` projection → `readingProgressState` → `BookCardView` overlay.
- **`.notStarted`**: unread books render no strip/checkmark (conditional overlays correctly absent).
- **`.inProgress`** strip: same `.overlay`-on-`BookCoverArtView` mechanism as the visually-confirmed finished checkmark, driven by the same `readingProgressState`; classification + projection covered by the 105 unit tests + `PersistenceActorLibraryProgressTests`. The bundled fixtures (2-chapter chapter-discrete EPUB; tiny TXT; non-persisting Foliate spike) can't cheaply produce a clean persisted `0<p<1`; pixel-level in-progress verification lands at Gate 5b.
- List-mode (`BookRowView`): the grid/list toggle is WI-9 container scope, not reachable in the current chrome — row re-skin is covered by `BookRowViewVisualTests`.

## Type of Change

- [x] Feature WI (Part of feature #718)