### PR TITLE
feat(#718 WI-6c): reader More-menu anchored popover

### DIFF
--- a/.claude/codex-audits/feat-feature-60-wi-6c-reader-more-menu-audit.md
+++ b/.claude/codex-audits/feat-feature-60-wi-6c-reader-more-menu-audit.md
@@ -1,0 +1,58 @@
+---
+branch: feat/feature-60-wi-6c-reader-more-menu
+threadId: 019e306d-7abe-7401-aac9-ae2c0cf16607
+rounds: 2
+final_verdict: follow-up-recommended
+date: 2026-05-16
+---
+
+# Gate 4 — Codex implementation audit: feature #60 WI-6c (reader More-menu popover)
+
+Independent Codex MCP audit (`sandbox: read-only`) of the WI-6c diff:
+the reader "More" menu as an anchored popover (`ReaderMorePopover`),
+replacing the WI-6b interim `⋯` → settings-sheet wiring.
+
+## Round 1 — findings
+
+| file:line | severity | issue | fix |
+|---|---|---|---|
+| `ReaderMoreMenuRow.swift` / `ReaderMorePopover.swift` / `ReaderContainerView+Sheets.swift` | **High** | Bilingual row diverged from the committed design — `vreader-more.jsx` draws it as an inline toggle with active tint + "English ↔ Chinese" sub-detail; the implementation rendered it as a chevron tap row with static sub-detail. That is self-designed UI under rule 51. | **Fixed** — omitted the Bilingual row from WI-6c entirely; filed GH #790 (`needs-design`) for the row + its missing backing toggle feature. Popover now ships 5 designed-and-buildable rows. |
+| `ReaderMorePopover.swift:206` | **Medium** | `popoverBackground` branched only on `isDark`, so the Photo theme got opaque `#2a2724`; design note §2 specifies the translucent `rgba(20,16,12,0.92)` so the popover stays legible over an arbitrary background image. | **Fixed** — `popoverBackground` now branches on `theme.usesBackgroundImage` first → `Color(red:20/255,green:16/255,blue:12/255).opacity(0.92)`. The notch reuses the same accessor, so it stays in sync. |
+| `ReaderMorePopover.swift:103` | **Low** | The notch was a plain triangle `Shape`; the design draws a rotated square with a two-sided hairline. Fidelity regression. | **Fixed** — reverted to a 12×12 `Rectangle` with stroke, `.rotationEffect(.degrees(45))`, placed behind the card so only the two upward-pointing edges show (matching the design's `box-shadow: -1px -1px`). The triangle `Shape` removed. |
+| `ReaderContainerView.swift:149,202` | **Low** | `showMorePopover` was not cleared on every chrome-hide path — the "Hide toolbar" accessibility action calls `toggleChrome()` directly, leaving `showMorePopover == true`; re-showing chrome would resurrect the popover. | **Fixed** — `toggleChrome()` now clears `showMorePopover` whenever it hides the chrome. It is the single chrome-toggle path, so both the content-tap observer and the accessibility action are covered. |
+| `ReaderMorePopover.swift` | **Low** | File at 312 lines, over the ~300-line guideline. | **Fixed** — split: `ReaderMorePopover.swift` (main view, 229 lines) + new `ReaderMorePopoverParts.swift` (`ReaderMoreToggle` + `ReaderMoreMenuActionObservers` + the View extension, 97 lines). |
+
+No Critical findings. Round 1 also explicitly confirmed clean: the row
+order/divider/labels, the Book Details interim routing, the Share-sheet
+hookup, the auto-turn interval clamping, the notification round-trip
+(`ReaderMoreMenuRow.notification` ↔ `init?(notification:)`), and
+`.onReceive` observer lifecycle. No Swift 6 actor-isolation or
+retain-cycle problem found.
+
+## Round 2 — re-verification
+
+Codex re-audited the post-fix worktree: **zero findings**. All five
+round-1 findings confirmed resolved on disk — the Bilingual row removed
++ documented + pinned-absent by tests, the 5-notification surface
+consistent, the rotated-square notch restored, the Photo surface
+special-cased, `showMorePopover` cleared on chrome hide, and both files
+under the size guideline.
+
+## Resolution summary
+
+All 5 findings (1 High, 1 Medium, 3 Low) **fixed** in-branch before the
+final verdict — no accepted-with-rationale, no deferred. The deferred
+Bilingual row is the only product follow-up, tracked in **GH #790**
+(`needs-design` — needs a backing persistent-bilingual-mode feature +
+design confirmation before the row can be re-added). GH #789 separately
+tracks the undesigned Book Details destination sheet (the row ships,
+routing to the reader settings panel as the design prototype's own
+interim punt).
+
+## Final verdict
+
+**follow-up-recommended.** Codex round 2 returned zero findings and
+approves the Gate 4 audit for the shipped scope. The implementation has
+no blocker; the single follow-up — the deferred Bilingual row — is
+already filed as GH #790. WI-6c ships the 5 designed-and-buildable
+More-menu rows.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,10 +56,11 @@ VReader is an iOS e-book reader built with SwiftUI + SwiftData. It supports TXT,
 
 Reader chrome (Feature #60 WI-6b — visual-identity-v2) is two custom overlays, floating on top of content with no safe-area impact:
 
-- `ReaderTopChrome.swift` — top bar: `← Library | Title | Search Bookmark More`. Composed once in `ReaderContainerView`, format-agnostic.
+- `ReaderTopChrome.swift` — top bar: `← Library | Title | Search Bookmark More`. Composed once in `ReaderContainerView`, format-agnostic. The `⋯` More button toggles `ReaderMorePopover`.
 - `ReaderBottomChrome.swift` — bottom bar: progress scrubber + position labels + a Contents/Notes/Display/AI toolbar. Composed per paginated format (TXT/MD/EPUB/PDF), each passing its own seek closure; the toolbar posts `.readerOpen*` notifications that `ReaderContainerView` observes. Foliate (AZW3/MOBI) keeps its own bottom overlay.
+- `ReaderMorePopover.swift` — anchored More-menu popover (Feature #60 WI-6c), composed in `ReaderContainerView`'s chrome overlay. Six rows (Read aloud / Auto-turn / Bilingual | Book details / Share / Export); each posts a `.readerMore*` notification that `ReaderContainerView` observes.
 
-Slot/button identity lives in `ReaderChromeButton.swift` (`ReaderTopChromeSlot` / `ReaderBottomChromeButton`).
+Slot/button identity lives in `ReaderChromeButton.swift` (`ReaderTopChromeSlot` / `ReaderBottomChromeButton`); More-menu row identity lives in `ReaderMoreMenuRow.swift`.
 
 #### Format Hosts (`ReaderFormatHosts.swift`)
 
@@ -191,6 +192,12 @@ All cross-component communication uses NotificationCenter:
 | `.readerOpenNotes`             | nil                  | `ReaderBottomChrome` toolbar → ReaderContainerView (Feature #60 WI-6b — opens annotations panel on the Highlights tab) |
 | `.readerOpenDisplay`           | nil                  | `ReaderBottomChrome` toolbar → ReaderContainerView (Feature #60 WI-6b — opens reader settings) |
 | `.readerOpenAI`                | nil                  | `ReaderBottomChrome` toolbar → ReaderContainerView (Feature #60 WI-6b — opens the AI assistant when configured) |
+| `.readerMoreReadAloud`         | nil                  | `ReaderMorePopover` → ReaderContainerView (Feature #60 WI-6c — starts read-aloud / TTS) |
+| `.readerMoreToggleAutoTurn`    | nil                  | `ReaderMorePopover` → ReaderContainerView (Feature #60 WI-6c — flips `ReaderSettingsStore.autoPageTurn`) |
+| `.readerMoreBilingual`         | nil                  | `ReaderMorePopover` → ReaderContainerView (Feature #60 WI-6c — opens the AI assistant on its translate tab) |
+| `.readerMoreBookDetails`       | nil                  | `ReaderMorePopover` → ReaderContainerView (Feature #60 WI-6c — opens reader settings as the interim Book Details destination; real sheet undesigned, GH #789) |
+| `.readerMoreShareBook`         | nil                  | `ReaderMorePopover` → ReaderContainerView (Feature #60 WI-6c — presents the system share sheet for the book file) |
+| `.readerMoreExportAnnotations` | nil                  | `ReaderMorePopover` → ReaderContainerView (Feature #60 WI-6c — opens the annotations panel on the Highlights tab, which carries export) |
 | `.epubFootnoteDetected`        | footnote ref         | EPUB bridge → Container (footnote popup)                |
 | `.bookFileStateDidChange`      | `["fingerprintKey","state"]` | LazyDownloadCoordinator (reconcile) → LibraryView (refresh row, feature #47) |
 | `.libraryRowTappedWhileNotLocal` | `["fingerprintKey","fileState"]` | LibraryView → BookDownloadSheet (future, #47 WI-6) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,7 +58,7 @@ Reader chrome (Feature #60 WI-6b — visual-identity-v2) is two custom overlays,
 
 - `ReaderTopChrome.swift` — top bar: `← Library | Title | Search Bookmark More`. Composed once in `ReaderContainerView`, format-agnostic. The `⋯` More button toggles `ReaderMorePopover`.
 - `ReaderBottomChrome.swift` — bottom bar: progress scrubber + position labels + a Contents/Notes/Display/AI toolbar. Composed per paginated format (TXT/MD/EPUB/PDF), each passing its own seek closure; the toolbar posts `.readerOpen*` notifications that `ReaderContainerView` observes. Foliate (AZW3/MOBI) keeps its own bottom overlay.
-- `ReaderMorePopover.swift` — anchored More-menu popover (Feature #60 WI-6c), composed in `ReaderContainerView`'s chrome overlay. Six rows (Read aloud / Auto-turn / Bilingual | Book details / Share / Export); each posts a `.readerMore*` notification that `ReaderContainerView` observes.
+- `ReaderMorePopover.swift` — anchored More-menu popover (Feature #60 WI-6c), composed in `ReaderContainerView`'s chrome overlay. Five rows (Read aloud / Auto-turn | Book details / Share / Export); each posts a `.readerMore*` notification that `ReaderContainerView` observes. The design's sixth row (Bilingual) is deferred — GH #790.
 
 Slot/button identity lives in `ReaderChromeButton.swift` (`ReaderTopChromeSlot` / `ReaderBottomChromeButton`); More-menu row identity lives in `ReaderMoreMenuRow.swift`.
 
@@ -194,7 +194,6 @@ All cross-component communication uses NotificationCenter:
 | `.readerOpenAI`                | nil                  | `ReaderBottomChrome` toolbar → ReaderContainerView (Feature #60 WI-6b — opens the AI assistant when configured) |
 | `.readerMoreReadAloud`         | nil                  | `ReaderMorePopover` → ReaderContainerView (Feature #60 WI-6c — starts read-aloud / TTS) |
 | `.readerMoreToggleAutoTurn`    | nil                  | `ReaderMorePopover` → ReaderContainerView (Feature #60 WI-6c — flips `ReaderSettingsStore.autoPageTurn`) |
-| `.readerMoreBilingual`         | nil                  | `ReaderMorePopover` → ReaderContainerView (Feature #60 WI-6c — opens the AI assistant on its translate tab) |
 | `.readerMoreBookDetails`       | nil                  | `ReaderMorePopover` → ReaderContainerView (Feature #60 WI-6c — opens reader settings as the interim Book Details destination; real sheet undesigned, GH #789) |
 | `.readerMoreShareBook`         | nil                  | `ReaderMorePopover` → ReaderContainerView (Feature #60 WI-6c — presents the system share sheet for the book file) |
 | `.readerMoreExportAnnotations` | nil                  | `ReaderMorePopover` → ReaderContainerView (Feature #60 WI-6c — opens the annotations panel on the Highlights tab, which carries export) |

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 409
-        MARKETING_VERSION: 3.24.14
+        CURRENT_PROJECT_VERSION: 410
+        MARKETING_VERSION: 3.24.15
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -368,6 +368,7 @@
 		606A7D33F0DB5643859C0863 /* WebDAVDownloadRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBDB2B2562F5761C8D52153 /* WebDAVDownloadRequestBuilder.swift */; };
 		6070A8AF12AADF388F7C1383 /* V1toV2MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939BC09F1D771D2E22301ED3 /* V1toV2MigrationTests.swift */; };
 		60F28F11E8F15E0FFAF4922C /* LibraryBookItemFileStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4E5558CB75432C026267C1 /* LibraryBookItemFileStateTests.swift */; };
+		61303A8643869C6334AFB873 /* ReaderMorePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BA71E474E9C05E3689CF88 /* ReaderMorePopover.swift */; };
 		6173290A06E9E4303D363AE8 /* ReaderThemeCSSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DE298149C25261E2ECADA1 /* ReaderThemeCSSTests.swift */; };
 		61E01D7572FE7393220D499F /* MOBICoverExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2997AAAB34DF84E64DC0DB4 /* MOBICoverExtractor.swift */; };
 		61EBFF18AB67FAA5DD37BB2D /* TTSProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97DAB513E717D83CD9ED3F7 /* TTSProviderProtocol.swift */; };
@@ -382,6 +383,7 @@
 		646C642DA4E4DCFF2AFEB68A /* search_no_results.html in Resources */ = {isa = PBXBuildFile; fileRef = 84BAC2CBFB7F533857E6A65B /* search_no_results.html */; };
 		64709D1B5C006D3299C8ABAF /* AutoPageTurner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5401E10DDA195966ABD13F70 /* AutoPageTurner.swift */; };
 		64BF0E0C54C919613EFEECD9 /* search_results.html in Resources */ = {isa = PBXBuildFile; fileRef = E3D9BD563DBFE23CE71083C5 /* search_results.html */; };
+		6576F6FFA1D6D43249D02CA3 /* ReaderMoreMenuRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0357FF4CC21B381B9CA016 /* ReaderMoreMenuRowTests.swift */; };
 		65BA2B507A0D5555244C7F4C /* SearchTextNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E54B97E5C67533291971CA1D /* SearchTextNormalizer.swift */; };
 		65C927CBE6855076656719CE /* AccessibilityFormattersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 336495F8165F79A364CE9B09 /* AccessibilityFormattersTests.swift */; };
 		65E4EDF452B2195BA78BA7A3 /* SpeechSynthesizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D3EF2FFB105C9E0DF1EDF51 /* SpeechSynthesizing.swift */; };
@@ -392,6 +394,7 @@
 		672412B314F93503C6EC7BF9 /* BookSourcePipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62A3435893128F15D5FF2CF /* BookSourcePipelineTests.swift */; };
 		67307D96FA4FE6F86F92B988 /* FormatCapabilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D579834E6924BB521873C38 /* FormatCapabilitiesTests.swift */; };
 		67743AC3E0435050936B766D /* Inter-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = CE0A04AB9B449BA91C980DCD /* Inter-Medium.otf */; };
+		6794194B9848D3D96FF8B50F /* ReaderMorePopoverStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AACDA81E2AD2EF57B761722 /* ReaderMorePopoverStateTests.swift */; };
 		67F279A51B09B3CDD7BBA3A9 /* PDFPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5639E3F809343C8CE5D7A020 /* PDFPasswordTests.swift */; };
 		68334589D47C834C926DEF1C /* HighlightCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8271FD51C6DF16B39F398C99 /* HighlightCoordinator.swift */; };
 		683D526BEEDC434933BB7A22 /* TXTSearchTapHighlightNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D2913CF3E7A07D5115997B /* TXTSearchTapHighlightNavigationTests.swift */; };
@@ -451,6 +454,7 @@
 		76B75FF4AC85FDA4239E43DE /* ProviderProfileMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7C16F12BA653A217A5439C /* ProviderProfileMigratorTests.swift */; };
 		7778CE2B4527836E7E8B3FD7 /* PDFHighlightTapResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E21285A9149B2F11210A9430 /* PDFHighlightTapResolverTests.swift */; };
 		77922030EB933D898ED67C10 /* FoliateViewBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17013114ADB4797AB48D794 /* FoliateViewBridge.swift */; };
+		77B74C8406A03676DD48F636 /* ReaderMoreMenuRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2168679A3F58BF907CD746E0 /* ReaderMoreMenuRow.swift */; };
 		77D706EE2E466C650B00C381 /* WebDAVProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B294CBB624E1CE03FEFA40E6 /* WebDAVProviderTests.swift */; };
 		7872FD996BEB1009EFF26413 /* AnnotationEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EAE2660201ADC0B4272B9EE /* AnnotationEditSheet.swift */; };
 		78A8B8FE91360F619F57DDB1 /* ContentHasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84D0E1452F211B986E8328A /* ContentHasher.swift */; };
@@ -1067,6 +1071,7 @@
 		20EBB13D56BE43A552188D9F /* TapZoneConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapZoneConfig.swift; sourceTree = "<group>"; };
 		20F02593B096CB3A08EE4DAF /* TextTransform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextTransform.swift; sourceTree = "<group>"; };
 		21055A4DC487F0F56BA7C475 /* ThemeBackgroundTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeBackgroundTests.swift; sourceTree = "<group>"; };
+		2168679A3F58BF907CD746E0 /* ReaderMoreMenuRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderMoreMenuRow.swift; sourceTree = "<group>"; };
 		21B3F47E988913B477EACF93 /* TranslationPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationPanel.swift; sourceTree = "<group>"; };
 		21BC5F159064D57CFAE2A676 /* MetadataExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataExtractorTests.swift; sourceTree = "<group>"; };
 		21CF1C76C54971B97341E5E9 /* FoliateHighlightRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightRenderer.swift; sourceTree = "<group>"; };
@@ -1145,6 +1150,7 @@
 		398F1BAF549E7AC80E9CE320 /* ReadingSessionTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingSessionTrackerTests.swift; sourceTree = "<group>"; };
 		3A480E951C2CA72DB6A22C24 /* ReaderThemeMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeMigrationTests.swift; sourceTree = "<group>"; };
 		3AA4BF056E74D056492E5858 /* DeviceIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceIdentity.swift; sourceTree = "<group>"; };
+		3AACDA81E2AD2EF57B761722 /* ReaderMorePopoverStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderMorePopoverStateTests.swift; sourceTree = "<group>"; };
 		3AEB955B6E5713C9AB4D701E /* Feature34CollectionsVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature34CollectionsVerificationTests.swift; sourceTree = "<group>"; };
 		3B1563E77E28434568F45736 /* LibraryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModelTests.swift; sourceTree = "<group>"; };
 		3B6E69931BB43A61C776F63A /* InfoPlistDocumentTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoPlistDocumentTypesTests.swift; sourceTree = "<group>"; };
@@ -1285,6 +1291,7 @@
 		5A54A2C5DE8C1631C04BB2A1 /* PDFProgressHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFProgressHelper.swift; sourceTree = "<group>"; };
 		5ACAE6123700F7FA7AEB1DE7 /* FoliateSpikeView+Selection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FoliateSpikeView+Selection.swift"; sourceTree = "<group>"; };
 		5AF84D4FD4FAA3232D18AA96 /* ReplacementTransform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplacementTransform.swift; sourceTree = "<group>"; };
+		5B0357FF4CC21B381B9CA016 /* ReaderMoreMenuRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderMoreMenuRowTests.swift; sourceTree = "<group>"; };
 		5B58A3A5DB35DA47F032FCEB /* LegadoImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegadoImporter.swift; sourceTree = "<group>"; };
 		5B67894BA57026638D94B118 /* ReaderThemeV2+EPUBCSS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderThemeV2+EPUBCSS.swift"; sourceTree = "<group>"; };
 		5B8562BBBE45039B72EAF9E5 /* BookImporterOriginalExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookImporterOriginalExtensionTests.swift; sourceTree = "<group>"; };
@@ -1432,6 +1439,7 @@
 		836FCCC18D880D48A10BA38A /* MockEPUBParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockEPUBParser.swift; sourceTree = "<group>"; };
 		837009678FE3EE7B38B7CD8B /* BackupBlobStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupBlobStore.swift; sourceTree = "<group>"; };
 		83B60F61628D0969B18B3A9B /* AIConsentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIConsentView.swift; sourceTree = "<group>"; };
+		83BA71E474E9C05E3689CF88 /* ReaderMorePopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderMorePopover.swift; sourceTree = "<group>"; };
 		83BCFD179C107F7E997AEB88 /* AnnotationImporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationImporterTests.swift; sourceTree = "<group>"; };
 		83F36EF81271874A13417D45 /* OPDSEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSEntryView.swift; sourceTree = "<group>"; };
 		8404837D8FC686DDDB62EEC3 /* AccentColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccentColorTests.swift; sourceTree = "<group>"; };
@@ -2307,6 +2315,8 @@
 				EF9547D23D813327B536EAD5 /* ReaderBottomOverlayTests.swift */,
 				733D454ED427DA1631A63AC0 /* ReaderChromeButtonContractTests.swift */,
 				7A266E88D3BA30905391B154 /* ReaderHighlightTapEventTests.swift */,
+				5B0357FF4CC21B381B9CA016 /* ReaderMoreMenuRowTests.swift */,
+				3AACDA81E2AD2EF57B761722 /* ReaderMorePopoverStateTests.swift */,
 				4CC7EBBBE07E87F07CC0FE4F /* ReaderNotificationHandlerTests.swift */,
 				C8A63C748487B0E94CC5F70D /* ReaderSafeAreaResolverTests.swift */,
 				2B7C59839A119870BE9B6FF9 /* ReaderSelectionEventTests.swift */,
@@ -2721,6 +2731,8 @@
 				EAB42EEEFFCAD8D654D57AE7 /* ReaderContainerView.swift */,
 				16C77872C4F869769F4C83F7 /* ReaderContainerView+Sheets.swift */,
 				FF23B1A0CC0BE35DF685C5FA /* ReaderFormatHosts.swift */,
+				2168679A3F58BF907CD746E0 /* ReaderMoreMenuRow.swift */,
+				83BA71E474E9C05E3689CF88 /* ReaderMorePopover.swift */,
 				82BC782199D1750DA66D1BCC /* ReaderNotificationHandlers.swift */,
 				A579625590B25F81679F1EA0 /* ReaderNotificationModifier.swift */,
 				DDB7C7EC41A96F5D4B53E983 /* ReaderNotifications.swift */,
@@ -4044,6 +4056,8 @@
 				505E3728FE1C69A31079DA9B /* ReaderBottomOverlayTests.swift in Sources */,
 				DDC2FFE0C85D9860D7575983 /* ReaderChromeButtonContractTests.swift in Sources */,
 				28028B11FE1116819D5DE0FA /* ReaderHighlightTapEventTests.swift in Sources */,
+				6576F6FFA1D6D43249D02CA3 /* ReaderMoreMenuRowTests.swift in Sources */,
+				6794194B9848D3D96FF8B50F /* ReaderMorePopoverStateTests.swift in Sources */,
 				32F4E36941EDCA2C0D457777 /* ReaderNotificationHandlerTests.swift in Sources */,
 				A3B091692BEA8453C7246A12 /* ReaderPositionServiceTests.swift in Sources */,
 				82C88D9DAE83A1FF94B6BB3F /* ReaderSafeAreaResolverTests.swift in Sources */,
@@ -4478,6 +4492,8 @@
 				4CCBF4F6E186A7363A995303 /* ReaderContainerView.swift in Sources */,
 				818D42F1D3D6548605297F83 /* ReaderFormatHosts.swift in Sources */,
 				83920E15721D7860684628BE /* ReaderLifecycleHelper.swift in Sources */,
+				77B74C8406A03676DD48F636 /* ReaderMoreMenuRow.swift in Sources */,
+				61303A8643869C6334AFB873 /* ReaderMorePopover.swift in Sources */,
 				B69C0AB6A9AECC0E9A1A8692 /* ReaderNotificationHandlers.swift in Sources */,
 				EE0F8A75700F581D5E2D1F3E /* ReaderNotificationModifier.swift in Sources */,
 				5A94BE236411F0F7268F803F /* ReaderNotifications.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4802,13 +4802,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 409;
+				CURRENT_PROJECT_VERSION = 410;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.24.14;
+				MARKETING_VERSION = 3.24.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4952,13 +4952,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 409;
+				CURRENT_PROJECT_VERSION = 410;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.24.14;
+				MARKETING_VERSION = 3.24.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		3EA88656EFB66F3FFBAC7DC5 /* Feature41TTSAutoScrollVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40011CB1AB56C2F4DF2EE91 /* Feature41TTSAutoScrollVerificationTests.swift */; };
 		3EB8343FF1512E959CCEDD65 /* FoliateHighlightTapResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0461A65278F56C6D2271993 /* FoliateHighlightTapResolverTests.swift */; };
 		3EF51E3A99B073988655F8F8 /* LazyDownloadCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01041344F18D1DE82B7E100C /* LazyDownloadCoordinator.swift */; };
+		3F690915D18151E5F28EFC40 /* ReaderMorePopoverParts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12841E371391B5AD20122A37 /* ReaderMorePopoverParts.swift */; };
 		401E58831F4DC6EB06E53738 /* HTTPTTSConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C9907D3479515B56338825 /* HTTPTTSConfig.swift */; };
 		40479825289343F4985EF7C7 /* SelectiveRestorePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1A92ABEE677825BB310F05 /* SelectiveRestorePicker.swift */; };
 		408FD10C4D83D162C1A9D69C /* KeychainService+ProviderProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE50C2E67CBF0EB4747276C1 /* KeychainService+ProviderProfile.swift */; };
@@ -1021,6 +1022,7 @@
 		117731FF4D8AE414141C5ECF /* ImportJobQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportJobQueue.swift; sourceTree = "<group>"; };
 		11D4AD419DD1123CDA21CCD0 /* ReflowableTextSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflowableTextSource.swift; sourceTree = "<group>"; };
 		11F6250C22449E7E83591620 /* SyncStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusView.swift; sourceTree = "<group>"; };
+		12841E371391B5AD20122A37 /* ReaderMorePopoverParts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderMorePopoverParts.swift; sourceTree = "<group>"; };
 		13404BD286B135797ECF391A /* AccentColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccentColor.swift; sourceTree = "<group>"; };
 		138AEC5BBAD52B075096E5C8 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		13A1A428419630E618721E37 /* UnifiedTextRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedTextRenderer.swift; sourceTree = "<group>"; };
@@ -2733,6 +2735,7 @@
 				FF23B1A0CC0BE35DF685C5FA /* ReaderFormatHosts.swift */,
 				2168679A3F58BF907CD746E0 /* ReaderMoreMenuRow.swift */,
 				83BA71E474E9C05E3689CF88 /* ReaderMorePopover.swift */,
+				12841E371391B5AD20122A37 /* ReaderMorePopoverParts.swift */,
 				82BC782199D1750DA66D1BCC /* ReaderNotificationHandlers.swift */,
 				A579625590B25F81679F1EA0 /* ReaderNotificationModifier.swift */,
 				DDB7C7EC41A96F5D4B53E983 /* ReaderNotifications.swift */,
@@ -4494,6 +4497,7 @@
 				83920E15721D7860684628BE /* ReaderLifecycleHelper.swift in Sources */,
 				77B74C8406A03676DD48F636 /* ReaderMoreMenuRow.swift in Sources */,
 				61303A8643869C6334AFB873 /* ReaderMorePopover.swift in Sources */,
+				3F690915D18151E5F28EFC40 /* ReaderMorePopoverParts.swift in Sources */,
 				B69C0AB6A9AECC0E9A1A8692 /* ReaderNotificationHandlers.swift in Sources */,
 				EE0F8A75700F581D5E2D1F3E /* ReaderNotificationModifier.swift in Sources */,
 				5A94BE236411F0F7268F803F /* ReaderNotifications.swift in Sources */,

--- a/vreader/Views/Reader/ReaderContainerView+Sheets.swift
+++ b/vreader/Views/Reader/ReaderContainerView+Sheets.swift
@@ -220,11 +220,7 @@ extension ReaderContainerView {
     /// The popover already posted `row.notification` and dismissed
     /// itself; this is the host-side effect.
     ///
-    /// Two rows route to interim/adjacent destinations because their
-    /// designed destination is not a committed design:
-    ///   - `.bilingualMode` opens the AI assistant on its translate
-    ///     tab — the existing bilingual surface — gated on AI being
-    ///     configured (mirrors the bottom chrome's AI gate).
+    /// Interim/adjacent destinations:
     ///   - `.bookDetails` opens the reader settings panel as the
     ///     interim destination; the real Book Details sheet is
     ///     undesigned (design note §4) and tracked by GH #789.
@@ -240,12 +236,6 @@ extension ReaderContainerView {
             // `autoPageTurn` is live-applied by the paged TXT/MD
             // containers' `onChange` observers.
             settingsStore.autoPageTurn.toggle()
-        case .bilingualMode:
-            if resolvedAICoordinator.isAIAvailable {
-                ensureAIReady()
-                aiInitialTab = .translate
-                showAIPanel = true
-            }
         case .bookDetails:
             showSettings = true
         case .shareBook:

--- a/vreader/Views/Reader/ReaderContainerView+Sheets.swift
+++ b/vreader/Views/Reader/ReaderContainerView+Sheets.swift
@@ -1,8 +1,11 @@
 // Purpose: Sheets, deferred setup, and chrome overlay for ReaderContainerView.
-// Pure code extraction — no logic changes.
+// Also hosts the Feature #60 WI-6c More-menu popover composition
+// (`readerMorePopoverOverlay`) and its row-action router
+// (`handleMoreMenuAction`).
 //
 // @coordinates-with: ReaderContainerView.swift, ReaderTopChrome.swift,
-//   SearchView.swift, AIReaderPanel.swift, ReaderAICoordinator.swift,
+//   ReaderMorePopover.swift, ShareSheet.swift, SearchView.swift,
+//   AIReaderPanel.swift, ReaderAICoordinator.swift,
 //   ReaderSearchCoordinator.swift, BookContentCache.swift
 
 import SwiftUI
@@ -161,26 +164,96 @@ extension ReaderContainerView {
         }
     }
 
-    // MARK: - Custom Chrome Overlay (bug #62 v3, Feature #60 WI-6b)
+    // MARK: - Custom Chrome Overlay (bug #62 v3, Feature #60 WI-6b/WI-6c)
 
     /// Feature #60 WI-6b: the shared top reader chrome. The four shed
     /// actions (Contents / Notes / Display / AI) now live in
     /// `ReaderBottomChrome`, composed per-format inside each container.
-    /// `onMore` routes to the existing settings sheet as the interim
-    /// wiring — WI-6c swaps it for the anchored More popover.
+    /// WI-6c: `onMore` toggles the anchored `ReaderMorePopover` (the
+    /// WI-6b interim `⋯` → settings routing is removed); `moreActive`
+    /// draws the design's backdrop tint while the popover is open.
     var readerChromeOverlay: some View {
         ReaderTopChrome(
             theme: settingsStore.theme.asV2,
             title: book.title,
             bookmarked: false,
-            moreActive: false,
+            moreActive: showMorePopover,
             onBack: { dismiss() },
             onSearch: { showSearch = true },
             onBookmark: {
                 NotificationCenter.default.post(name: .readerBookmarkRequested, object: nil)
             },
-            onMore: { showSettings = true }
+            onMore: {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    showMorePopover.toggle()
+                }
+            }
         )
+    }
+
+    // MARK: - More-menu Popover (Feature #60 WI-6c)
+
+    /// The anchored More-menu popover, floating above the chrome.
+    /// Presented while `showMorePopover` is set; the host's
+    /// `.readerMoreMenuActionObservers` modifier handles row taps.
+    var readerMorePopoverOverlay: some View {
+        ReaderMorePopover(
+            theme: settingsStore.theme.asV2,
+            ttsPlaying: ttsService.state != .idle,
+            autoTurnOn: settingsStore.autoPageTurn,
+            autoTurnInterval: settingsStore.autoPageTurnInterval,
+            // The design anchors the popover just below the top chrome.
+            // Chrome height = the Dynamic-Island inset + the ~52pt
+            // button row; add a small gap so the notch tucks under the
+            // `⋯` button. The prototype's fixed `top: 92` is the
+            // equivalent for its fixed-height chrome.
+            topInset: ReaderSafeAreaResolver.windowSafeAreaTop + 56,
+            onClose: {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    showMorePopover = false
+                }
+            }
+        )
+    }
+
+    /// Routes a tapped More-menu row to the matching reader action.
+    /// The popover already posted `row.notification` and dismissed
+    /// itself; this is the host-side effect.
+    ///
+    /// Two rows route to interim/adjacent destinations because their
+    /// designed destination is not a committed design:
+    ///   - `.bilingualMode` opens the AI assistant on its translate
+    ///     tab — the existing bilingual surface — gated on AI being
+    ///     configured (mirrors the bottom chrome's AI gate).
+    ///   - `.bookDetails` opens the reader settings panel as the
+    ///     interim destination; the real Book Details sheet is
+    ///     undesigned (design note §4) and tracked by GH #789.
+    ///   - `.exportAnnotations` opens the annotations panel on the
+    ///     Highlights tab, which carries the existing export action —
+    ///     WI-6c ships no new export-picker UI.
+    func handleMoreMenuAction(_ row: ReaderMoreMenuRow) {
+        switch row {
+        case .readAloud:
+            startTTS()
+        case .autoTurnPages:
+            // The design draws an inline toggle; flipping
+            // `autoPageTurn` is live-applied by the paged TXT/MD
+            // containers' `onChange` observers.
+            settingsStore.autoPageTurn.toggle()
+        case .bilingualMode:
+            if resolvedAICoordinator.isAIAvailable {
+                ensureAIReady()
+                aiInitialTab = .translate
+                showAIPanel = true
+            }
+        case .bookDetails:
+            showSettings = true
+        case .shareBook:
+            showShareSheet = true
+        case .exportAnnotations:
+            annotationsPanelInitialTab = .highlights
+            showAnnotationsPanel = true
+        }
     }
 
     // MARK: - AI Sheet

--- a/vreader/Views/Reader/ReaderContainerView.swift
+++ b/vreader/Views/Reader/ReaderContainerView.swift
@@ -49,6 +49,13 @@ struct ReaderContainerView: View {
     /// `.highlights`.
     @State var annotationsPanelInitialTab: AnnotationsPanelTab = .toc
     @State var showSearch = false
+    /// Feature #60 WI-6c: whether the reader More-menu popover is
+    /// presented. The `⋯` button in `ReaderTopChrome` toggles it; the
+    /// popover floats in the chrome overlay anchored to that button.
+    @State var showMorePopover = false
+    /// Feature #60 WI-6c: whether the system share sheet for the book
+    /// file is presented — driven by the More-menu's "Share book" row.
+    @State var showShareSheet = false
     @State var showAIPanel = false
     @State var aiInitialTab: AIReaderTab = .summarize
     @State private var showDictionary = false
@@ -134,9 +141,25 @@ struct ReaderContainerView: View {
                 }
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
+
+            // Feature #60 WI-6c: the reader More-menu popover, anchored
+            // to the `⋯` button in the top chrome. Floats above all
+            // content + chrome; only present while the chrome is too,
+            // so hiding the chrome dismisses it.
+            if showMorePopover && isChromeVisible {
+                readerMorePopoverOverlay
+                    .transition(.opacity)
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .readerContentTapped)) { _ in
-            toggleChrome()
+            // A content tap toggles the chrome. If the More popover is
+            // open, the tap should dismiss it rather than (also)
+            // flipping the chrome out from under it.
+            if showMorePopover {
+                showMorePopover = false
+            } else {
+                toggleChrome()
+            }
         }
         // Feature #60 WI-6b: the shared `ReaderBottomChrome` toolbar
         // posts these instead of threading handler closures through
@@ -164,6 +187,15 @@ struct ReaderContainerView: View {
                 }
             }
         )
+        // Feature #60 WI-6c: the More-menu popover posts these six
+        // notifications; each maps 1:1 from a `ReaderMoreMenuRow`.
+        // Bundled into one modifier so `body` stays inside the
+        // type-checker's complexity budget (same reason as the WI-6b
+        // toolbar observers above). Action semantics live in
+        // `handleMoreMenuAction(_:)`.
+        .readerMoreMenuActionObservers { row in
+            handleMoreMenuAction(row)
+        }
         // Page turn from tap zones — handled by unified renderer directly.
         // Native mode bridges handle taps internally (center=chrome toggle).
         // Left/right zones only functional in unified paged mode. (bug #81)
@@ -348,6 +380,12 @@ struct ReaderContainerView: View {
             searchSheet
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
+        }
+        // Feature #60 WI-6c: the More-menu "Share book" row presents
+        // the system share sheet for the book file. Reuses the
+        // library's `ShareSheet` (book-file `UIActivityViewController`).
+        .sheet(isPresented: $showShareSheet) {
+            ShareSheet(book: book)
         }
         // Search setup deferred until search sheet opens (bug #64)
         .onChange(of: showSearch) { _, isShowing in

--- a/vreader/Views/Reader/ReaderContainerView.swift
+++ b/vreader/Views/Reader/ReaderContainerView.swift
@@ -187,12 +187,12 @@ struct ReaderContainerView: View {
                 }
             }
         )
-        // Feature #60 WI-6c: the More-menu popover posts these six
-        // notifications; each maps 1:1 from a `ReaderMoreMenuRow`.
-        // Bundled into one modifier so `body` stays inside the
-        // type-checker's complexity budget (same reason as the WI-6b
-        // toolbar observers above). Action semantics live in
-        // `handleMoreMenuAction(_:)`.
+        // Feature #60 WI-6c: the More-menu popover posts the five
+        // `.readerMore*` notifications; each maps 1:1 from a
+        // `ReaderMoreMenuRow`. Bundled into one modifier so `body`
+        // stays inside the type-checker's complexity budget (same
+        // reason as the WI-6b toolbar observers above). Action
+        // semantics live in `handleMoreMenuAction(_:)`.
         .readerMoreMenuActionObservers { row in
             handleMoreMenuAction(row)
         }
@@ -509,9 +509,18 @@ struct ReaderContainerView: View {
 
     /// Toggles chrome overlay visibility. Content is pixel-stable because we use
     /// a custom overlay (ReaderTopChrome) instead of the system nav bar.
+    ///
+    /// Feature #60 WI-6c: hiding the chrome also clears `showMorePopover`.
+    /// The popover only renders while the chrome does, so without this
+    /// a chrome-hide that bypasses the content-tap path (e.g. the
+    /// "Hide toolbar" accessibility action) would leave `showMorePopover`
+    /// set and resurrect the popover when the chrome reappears.
     private func toggleChrome() {
         withAnimation(.easeInOut(duration: 0.2)) {
             isChromeVisible.toggle()
+            if !isChromeVisible {
+                showMorePopover = false
+            }
         }
     }
 

--- a/vreader/Views/Reader/ReaderMoreMenuRow.swift
+++ b/vreader/Views/Reader/ReaderMoreMenuRow.swift
@@ -1,0 +1,173 @@
+// Purpose: Feature #60 WI-6c — row identity for the reader More-menu
+// popover (`ReaderMorePopover`). Centralising the row contract here
+// keeps the design's layout (order, divider, labels, icons, toggle vs
+// tap, state-driven sub-detail, accessibility ids, notification
+// routing) testable without depending on SwiftUI render machinery —
+// the same pattern `ReaderChromeButton` uses for the top/bottom
+// chrome.
+//
+// Design source:
+// `dev-docs/designs/vreader-fidelity-v1/project/vreader-more.jsx`
+// + `design-notes/reader-search-and-more-menu.md` §2.
+//
+// Routing note: each row maps 1:1 to a `Notification.Name` the
+// `ReaderMorePopover` posts and `ReaderContainerView` observes. Two
+// rows route to interim/adjacent destinations because their designed
+// destination is not yet a committed design:
+//   - `.bilingualMode` — the design draws a toggle, but inline
+//     bilingual rendering has no backing state; it routes to the AI
+//     assistant's translate tab (the existing bilingual surface), so
+//     it renders as a tap row, not a toggle.
+//   - `.bookDetails` — the Book Details sheet is undesigned (design
+//     note §4 defers it; GH #789 tracks it). It routes to the reader
+//     settings panel — the design prototype's own interim punt
+//     (`vreader-more.jsx` / `vreader-reader.jsx`:
+//     `onAction('details') → onOpenSettings`).
+
+import Foundation
+
+/// A row in the reader More-menu popover. `CaseIterable.allCases`
+/// returns the six rows in declared (top → bottom) order, matching
+/// `vreader-more.jsx`. `ReaderMorePopover` renders them via
+/// `ForEach(ReaderMoreMenuRow.allCases)`, inserting the hairline
+/// divider after `dividerAfter`.
+enum ReaderMoreMenuRow: String, CaseIterable, Equatable {
+    case readAloud
+    case autoTurnPages
+    case bilingualMode
+    case bookDetails
+    case shareBook
+    case exportAnnotations
+
+    /// The row after which the design draws its single hairline
+    /// divider — splitting the reading-controls cluster (Read aloud /
+    /// Auto-turn / Bilingual) from the book-action cluster (Book
+    /// details / Share / Export).
+    static let dividerAfter: ReaderMoreMenuRow = .bilingualMode
+
+    /// Notification posted on tap. `ReaderContainerView` observes all
+    /// six and runs the matching action. The popover does not thread
+    /// closures — posting keeps it composable in one place.
+    var notification: Notification.Name {
+        switch self {
+        case .readAloud:         return .readerMoreReadAloud
+        case .autoTurnPages:     return .readerMoreToggleAutoTurn
+        case .bilingualMode:     return .readerMoreBilingual
+        case .bookDetails:       return .readerMoreBookDetails
+        case .shareBook:         return .readerMoreShareBook
+        case .exportAnnotations: return .readerMoreExportAnnotations
+        }
+    }
+
+    /// The inverse of `notification` — resolves the row that posted a
+    /// given More-menu notification, or `nil` for an unrelated name.
+    /// `ReaderMoreMenuActionObservers` uses this to map an observed
+    /// notification back to its row in one funnel.
+    init?(notification: Notification.Name) {
+        guard let match = Self.allCases.first(where: { $0.notification == notification }) else {
+            return nil
+        }
+        self = match
+    }
+
+    /// Whether the row renders an inline iOS-style toggle switch
+    /// instead of a chevron. Only `autoTurnPages` is a real toggle —
+    /// it has backing state (`ReaderSettingsStore.autoPageTurn`). The
+    /// design also draws Bilingual as a toggle, but bilingual
+    /// rendering lives entirely in the AI translate panel with no
+    /// settings-level on/off state; WI-6c routes Bilingual to that
+    /// existing surface as a tap row rather than fabricating a toggle.
+    var isToggle: Bool {
+        self == .autoTurnPages
+    }
+
+    /// User-facing primary label. Matches the design bundle text.
+    var label: String {
+        switch self {
+        case .readAloud:         return "Read aloud"
+        case .autoTurnPages:     return "Auto-turn pages"
+        case .bilingualMode:     return "Bilingual mode"
+        case .bookDetails:       return "Book details"
+        case .shareBook:         return "Share book"
+        case .exportAnnotations: return "Export annotations"
+        }
+    }
+
+    /// SF Symbol rendered in the row's leading icon chip. Mapped to
+    /// the design's icon family: Volume → `speaker.wave.2`, Timer →
+    /// `timer`, Translate → `character.book.closed`, Info →
+    /// `info.circle`, Share → `square.and.arrow.up`, Download →
+    /// `arrow.down.doc`.
+    var systemImage: String {
+        switch self {
+        case .readAloud:         return "speaker.wave.2"
+        case .autoTurnPages:     return "timer"
+        case .bilingualMode:     return "character.book.closed"
+        case .bookDetails:       return "info.circle"
+        case .shareBook:         return "square.and.arrow.up"
+        case .exportAnnotations: return "arrow.down.doc"
+        }
+    }
+
+    /// Stable accessibility identifier for XCUITest + verify-cron
+    /// snapshots. Stable contract — do not rename without updating
+    /// every harness.
+    var accessibilityIdentifier: String {
+        switch self {
+        case .readAloud:         return "readerMoreReadAloud"
+        case .autoTurnPages:     return "readerMoreAutoTurn"
+        case .bilingualMode:     return "readerMoreBilingual"
+        case .bookDetails:       return "readerMoreBookDetails"
+        case .shareBook:         return "readerMoreShareBook"
+        case .exportAnnotations: return "readerMoreExportAnnotations"
+        }
+    }
+
+    // MARK: - State-driven secondary text
+
+    /// Secondary (sub-detail) line shown under the label, or `nil`
+    /// when the row has none. Mirrors the design's `Row sub={...}`
+    /// expressions in `vreader-more.jsx`, which update with reader
+    /// state.
+    ///
+    /// - Parameters:
+    ///   - ttsPlaying: whether read-aloud is currently speaking.
+    ///   - autoTurnOn: whether auto-page-turn is enabled.
+    ///   - autoTurnInterval: the auto-turn interval in seconds. Used
+    ///     only when `autoTurnOn` is true; rendered as a whole-second
+    ///     integer clamped to the design's 1...60 range.
+    func subDetail(
+        ttsPlaying: Bool, autoTurnOn: Bool, autoTurnInterval: Double
+    ) -> String? {
+        switch self {
+        case .readAloud:
+            return ttsPlaying
+                ? "Playing \u{00b7} System voice"
+                : "Start text-to-speech"
+        case .autoTurnPages:
+            guard autoTurnOn else { return "Off" }
+            let clamped = min(60, max(1, autoTurnInterval.rounded()))
+            return "Every \(Int(clamped))s"
+        case .bilingualMode:
+            return "Translate inline"
+        case .bookDetails:
+            return nil
+        case .shareBook:
+            return nil
+        case .exportAnnotations:
+            return "Markdown \u{00b7} JSON \u{00b7} VReader JSON"
+        }
+    }
+
+    /// Whether the row is in its accent-tinted "active" state — the
+    /// design lifts the icon chip to an accent tint for an active
+    /// row. Only the two stateful rows can be active.
+    func isActive(ttsPlaying: Bool, autoTurnOn: Bool) -> Bool {
+        switch self {
+        case .readAloud:     return ttsPlaying
+        case .autoTurnPages: return autoTurnOn
+        case .bilingualMode, .bookDetails, .shareBook, .exportAnnotations:
+            return false
+        }
+    }
+}

--- a/vreader/Views/Reader/ReaderMoreMenuRow.swift
+++ b/vreader/Views/Reader/ReaderMoreMenuRow.swift
@@ -10,14 +10,18 @@
 // `dev-docs/designs/vreader-fidelity-v1/project/vreader-more.jsx`
 // + `design-notes/reader-search-and-more-menu.md` §2.
 //
+// Scope note — Bilingual mode row omitted: `vreader-more.jsx` depicts
+// six rows; WI-6c ships five. The "Bilingual mode" row is deferred
+// because it has no backing surface — bilingual translation lives
+// entirely in the AI assistant's translate tab (`AITranslationViewModel`
+// + `BilingualView`), invoked per selection; there is no persistent
+// bilingual-mode toggle state. Rendering a fake toggle, or routing it
+// as a tap row, would both diverge from the designed toggle (rule 51,
+// self-designed UI). GH #790 tracks the backing feature + a design
+// confirmation before the row returns.
+//
 // Routing note: each row maps 1:1 to a `Notification.Name` the
-// `ReaderMorePopover` posts and `ReaderContainerView` observes. Two
-// rows route to interim/adjacent destinations because their designed
-// destination is not yet a committed design:
-//   - `.bilingualMode` — the design draws a toggle, but inline
-//     bilingual rendering has no backing state; it routes to the AI
-//     assistant's translate tab (the existing bilingual surface), so
-//     it renders as a tap row, not a toggle.
+// `ReaderMorePopover` posts and `ReaderContainerView` observes.
 //   - `.bookDetails` — the Book Details sheet is undesigned (design
 //     note §4 defers it; GH #789 tracks it). It routes to the reader
 //     settings panel — the design prototype's own interim punt
@@ -27,32 +31,33 @@
 import Foundation
 
 /// A row in the reader More-menu popover. `CaseIterable.allCases`
-/// returns the six rows in declared (top → bottom) order, matching
-/// `vreader-more.jsx`. `ReaderMorePopover` renders them via
+/// returns the five rows in declared (top → bottom) order, matching
+/// `vreader-more.jsx` minus the deferred Bilingual row (GH #790).
+/// `ReaderMorePopover` renders them via
 /// `ForEach(ReaderMoreMenuRow.allCases)`, inserting the hairline
 /// divider after `dividerAfter`.
 enum ReaderMoreMenuRow: String, CaseIterable, Equatable {
     case readAloud
     case autoTurnPages
-    case bilingualMode
     case bookDetails
     case shareBook
     case exportAnnotations
 
     /// The row after which the design draws its single hairline
     /// divider — splitting the reading-controls cluster (Read aloud /
-    /// Auto-turn / Bilingual) from the book-action cluster (Book
-    /// details / Share / Export).
-    static let dividerAfter: ReaderMoreMenuRow = .bilingualMode
+    /// Auto-turn) from the book-action cluster (Book details / Share /
+    /// Export). In the design the divider sits after Bilingual; with
+    /// that row deferred (GH #790) it sits after Auto-turn — still the
+    /// boundary between the two clusters.
+    static let dividerAfter: ReaderMoreMenuRow = .autoTurnPages
 
     /// Notification posted on tap. `ReaderContainerView` observes all
-    /// six and runs the matching action. The popover does not thread
+    /// five and runs the matching action. The popover does not thread
     /// closures — posting keeps it composable in one place.
     var notification: Notification.Name {
         switch self {
         case .readAloud:         return .readerMoreReadAloud
         case .autoTurnPages:     return .readerMoreToggleAutoTurn
-        case .bilingualMode:     return .readerMoreBilingual
         case .bookDetails:       return .readerMoreBookDetails
         case .shareBook:         return .readerMoreShareBook
         case .exportAnnotations: return .readerMoreExportAnnotations
@@ -71,12 +76,10 @@ enum ReaderMoreMenuRow: String, CaseIterable, Equatable {
     }
 
     /// Whether the row renders an inline iOS-style toggle switch
-    /// instead of a chevron. Only `autoTurnPages` is a real toggle —
-    /// it has backing state (`ReaderSettingsStore.autoPageTurn`). The
-    /// design also draws Bilingual as a toggle, but bilingual
-    /// rendering lives entirely in the AI translate panel with no
-    /// settings-level on/off state; WI-6c routes Bilingual to that
-    /// existing surface as a tap row rather than fabricating a toggle.
+    /// instead of a chevron. Only `autoTurnPages` is a toggle — it has
+    /// backing state (`ReaderSettingsStore.autoPageTurn`). (The design
+    /// also draws Bilingual as a toggle, but that row is deferred —
+    /// see the file header + GH #790.)
     var isToggle: Bool {
         self == .autoTurnPages
     }
@@ -86,7 +89,6 @@ enum ReaderMoreMenuRow: String, CaseIterable, Equatable {
         switch self {
         case .readAloud:         return "Read aloud"
         case .autoTurnPages:     return "Auto-turn pages"
-        case .bilingualMode:     return "Bilingual mode"
         case .bookDetails:       return "Book details"
         case .shareBook:         return "Share book"
         case .exportAnnotations: return "Export annotations"
@@ -95,14 +97,12 @@ enum ReaderMoreMenuRow: String, CaseIterable, Equatable {
 
     /// SF Symbol rendered in the row's leading icon chip. Mapped to
     /// the design's icon family: Volume → `speaker.wave.2`, Timer →
-    /// `timer`, Translate → `character.book.closed`, Info →
-    /// `info.circle`, Share → `square.and.arrow.up`, Download →
-    /// `arrow.down.doc`.
+    /// `timer`, Info → `info.circle`, Share → `square.and.arrow.up`,
+    /// Download → `arrow.down.doc`.
     var systemImage: String {
         switch self {
         case .readAloud:         return "speaker.wave.2"
         case .autoTurnPages:     return "timer"
-        case .bilingualMode:     return "character.book.closed"
         case .bookDetails:       return "info.circle"
         case .shareBook:         return "square.and.arrow.up"
         case .exportAnnotations: return "arrow.down.doc"
@@ -116,7 +116,6 @@ enum ReaderMoreMenuRow: String, CaseIterable, Equatable {
         switch self {
         case .readAloud:         return "readerMoreReadAloud"
         case .autoTurnPages:     return "readerMoreAutoTurn"
-        case .bilingualMode:     return "readerMoreBilingual"
         case .bookDetails:       return "readerMoreBookDetails"
         case .shareBook:         return "readerMoreShareBook"
         case .exportAnnotations: return "readerMoreExportAnnotations"
@@ -148,8 +147,6 @@ enum ReaderMoreMenuRow: String, CaseIterable, Equatable {
             guard autoTurnOn else { return "Off" }
             let clamped = min(60, max(1, autoTurnInterval.rounded()))
             return "Every \(Int(clamped))s"
-        case .bilingualMode:
-            return "Translate inline"
         case .bookDetails:
             return nil
         case .shareBook:
@@ -166,7 +163,7 @@ enum ReaderMoreMenuRow: String, CaseIterable, Equatable {
         switch self {
         case .readAloud:     return ttsPlaying
         case .autoTurnPages: return autoTurnOn
-        case .bilingualMode, .bookDetails, .shareBook, .exportAnnotations:
+        case .bookDetails, .shareBook, .exportAnnotations:
             return false
         }
     }

--- a/vreader/Views/Reader/ReaderMorePopover.swift
+++ b/vreader/Views/Reader/ReaderMorePopover.swift
@@ -1,0 +1,312 @@
+// Purpose: Feature #60 WI-6c — the reader More-menu popover. An
+// anchored popover from the `⋯` button in `ReaderTopChrome`, replacing
+// the WI-6b interim wiring (`⋯` → settings sheet). Six rows split by a
+// hairline divider: Read aloud / Auto-turn pages / Bilingual mode |
+// Book details / Share book / Export annotations.
+//
+// Layout pinned to the committed design bundle:
+// `dev-docs/designs/vreader-fidelity-v1/project/vreader-more.jsx`
+// (`MorePopover` + `ToggleSwitch`) and `design-notes/
+// reader-search-and-more-menu.md` §2 (width 268, radius 16, notch
+// pointing to the trigger, per-theme rendering for all 5 themes).
+//
+// Row identity, ordering, divider placement, labels, icons, toggle vs
+// tap, sub-detail text, and notification routing all live in
+// `ReaderMoreMenuRow` so the design contract is unit-testable without
+// a SwiftUI render path. This file is purely presentational — taps
+// post `ReaderMoreMenuRow.notification`; `ReaderContainerView`
+// observes them.
+//
+// @coordinates-with: ReaderMoreMenuRow.swift, ReaderTopChrome.swift,
+//   ReaderThemeV2.swift, ReaderContainerView+Sheets.swift,
+//   ReaderNotifications.swift
+
+#if canImport(UIKit)
+import SwiftUI
+
+/// Anchored More-menu popover (Feature #60 WI-6c). Composed in
+/// `ReaderContainerView`'s chrome overlay above `ReaderTopChrome`.
+/// The view owns no state — TTS / auto-turn state is passed in, and
+/// every tap is funnelled through a posted notification + the
+/// `onClose` callback.
+struct ReaderMorePopover: View {
+    /// Visual-identity-v2 theme tokens for the active book.
+    let theme: ReaderThemeV2
+    /// Whether read-aloud is currently speaking — drives the Read
+    /// aloud row's active tint + sub-detail.
+    let ttsPlaying: Bool
+    /// Whether auto-page-turn is enabled — drives the Auto-turn row's
+    /// toggle position, active tint, and sub-detail.
+    let autoTurnOn: Bool
+    /// Auto-turn interval in seconds — rendered in the Auto-turn
+    /// sub-detail ("Every Ns") when the toggle is on.
+    let autoTurnInterval: Double
+    /// Top inset (points) at which the popover floats — passed from
+    /// the host so the popover clears the top chrome. The design's
+    /// `top: 92` baseline is for the prototype's fixed-height chrome;
+    /// the production chrome height varies with the Dynamic Island
+    /// inset, so the host computes it.
+    let topInset: CGFloat
+    /// Called when the user dismisses the popover — backdrop tap or
+    /// after any row tap. The host clears its presentation flag.
+    let onClose: () -> Void
+
+    /// Design popover width (`vreader-more.jsx`: `width: 268`).
+    private let popoverWidth: CGFloat = 268
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            // Dim backdrop — transparent fill, taps anywhere outside
+            // the card close the popover. Matches the design's
+            // `onClick={onClose}` full-bleed layer.
+            Color.black.opacity(0.001)
+                .ignoresSafeArea()
+                .contentShape(Rectangle())
+                .onTapGesture(perform: onClose)
+                .accessibilityIdentifier("readerMorePopoverBackdrop")
+
+            popoverCard
+                .padding(.top, topInset)
+                .padding(.trailing, 14)
+        }
+        .accessibilityIdentifier("readerMorePopover")
+    }
+
+    // MARK: - Popover card
+
+    private var popoverCard: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(ReaderMoreMenuRow.allCases.enumerated()), id: \.element) { _, row in
+                rowButton(row)
+                if row == ReaderMoreMenuRow.dividerAfter {
+                    divider
+                }
+            }
+        }
+        .padding(.vertical, 6)
+        .frame(width: popoverWidth)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(popoverBackground)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(Color(theme.ruleColor), lineWidth: 0.5)
+        )
+        // Notch behind the card: it pokes above the top edge as the
+        // pointer; the card's own surface covers its base, so no
+        // clipping or selective border is needed.
+        .background(alignment: .top) { notch }
+        .shadow(color: .black.opacity(0.28), radius: 18, x: 0, y: 12)
+    }
+
+    /// The small triangular beak that points up toward the `⋯`
+    /// trigger. `vreader-more.jsx` draws this as a rotated square
+    /// (`top: -6, right: 24`); a triangle is the equivalent SwiftUI
+    /// idiom and avoids clipping the base behind the card.
+    private var notch: some View {
+        ReaderMorePopoverNotch()
+            .fill(popoverBackground)
+            .frame(width: 16, height: 8)
+            // Right-align under the `⋯` button: 24pt from the card's
+            // trailing edge per the design, minus half the notch width.
+            .frame(width: popoverWidth, alignment: .trailing)
+            .padding(.trailing, 16)
+            .offset(y: -7)
+            .allowsHitTesting(false)
+    }
+
+    private var divider: some View {
+        Color(theme.ruleColor)
+            .frame(height: 0.5)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 4)
+    }
+
+    // MARK: - Rows
+
+    private func rowButton(_ row: ReaderMoreMenuRow) -> some View {
+        let active = row.isActive(ttsPlaying: ttsPlaying, autoTurnOn: autoTurnOn)
+        let sub = row.subDetail(
+            ttsPlaying: ttsPlaying,
+            autoTurnOn: autoTurnOn,
+            autoTurnInterval: autoTurnInterval
+        )
+        return Button {
+            // Post first, then dismiss — the host's notification
+            // observer and the popover teardown are independent.
+            NotificationCenter.default.post(name: row.notification, object: nil)
+            onClose()
+        } label: {
+            HStack(spacing: 12) {
+                iconChip(for: row, active: active)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(row.label)
+                        .font(.system(size: 14.5, weight: .medium))
+                        .foregroundStyle(Color(theme.inkColor))
+                        .lineLimit(1)
+                    if let sub {
+                        Text(sub)
+                            .font(.system(size: 11))
+                            .foregroundStyle(Color(theme.subColor))
+                            .lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 0)
+                trailingAccessory(for: row)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 11)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(row.accessibilityIdentifier)
+    }
+
+    /// 28×28 rounded icon chip. Per the design, an active row lifts
+    /// the chip to a faint accent tint; otherwise it's a neutral
+    /// low-contrast fill.
+    private func iconChip(for row: ReaderMoreMenuRow, active: Bool) -> some View {
+        let accent = Color(theme.accentColor)
+        let chipFill: Color = active
+            ? accent.opacity(theme.isDark ? 0.20 : 0.10)
+            : (theme.isDark
+                ? Color.white.opacity(0.05)
+                : Color.black.opacity(0.04))
+        return RoundedRectangle(cornerRadius: 8)
+            .fill(chipFill)
+            .frame(width: 28, height: 28)
+            .overlay(
+                Image(systemName: row.systemImage)
+                    .font(.system(size: 15, weight: .regular))
+                    .foregroundStyle(active ? accent : Color(theme.inkColor))
+            )
+    }
+
+    /// Trailing accessory: an inline toggle switch for the toggle row
+    /// (Auto-turn), a chevron for tap rows.
+    @ViewBuilder
+    private func trailingAccessory(for row: ReaderMoreMenuRow) -> some View {
+        if row.isToggle {
+            ReaderMoreToggle(isOn: autoTurnOn, theme: theme)
+        } else {
+            Image(systemName: "chevron.right")
+                .font(.system(size: 13, weight: .bold))
+                .foregroundStyle(Color(theme.subColor))
+        }
+    }
+
+    // MARK: - Theme-aware surface
+
+    /// Popover surface fill. The design ships hardcoded `#2a2724`
+    /// (dark family) / `#fcf8f0` (light family), distinct from the
+    /// reader chrome tint so the popover reads as a floating element.
+    /// Mapped through `isDark` so all 5 themes pick the right surface
+    /// — the same projection `SelectionPopoverView` uses.
+    private var popoverBackground: Color {
+        theme.isDark
+            ? Color(red: 0x2a / 255, green: 0x27 / 255, blue: 0x24 / 255)
+            : Color(red: 0xfc / 255, green: 0xf8 / 255, blue: 0xf0 / 255)
+    }
+}
+
+// MARK: - Popover notch
+
+/// Upward-pointing triangular beak for the More popover. Apex at top
+/// center, base along the bottom edge — drawn behind the card so its
+/// base tucks under the card surface.
+private struct ReaderMorePopoverNotch: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.midX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        path.closeSubpath()
+        return path
+    }
+}
+
+// MARK: - Inline toggle switch
+
+/// Small iOS-style toggle rendered in the Auto-turn row, matching
+/// `vreader-more.jsx`'s `ToggleSwitch` (34×20 track, green `#3a6a5a`
+/// when on). Presentational only — the row's tap posts the toggle
+/// notification; the host flips the backing setting and the new
+/// `isOn` flows back in.
+private struct ReaderMoreToggle: View {
+    let isOn: Bool
+    let theme: ReaderThemeV2
+
+    var body: some View {
+        Capsule()
+            .fill(trackColor)
+            .frame(width: 34, height: 20)
+            .overlay(alignment: isOn ? .trailing : .leading) {
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: 16, height: 16)
+                    .shadow(color: .black.opacity(0.2), radius: 1, x: 0, y: 1)
+                    .padding(.horizontal, 2)
+            }
+            .animation(.easeInOut(duration: 0.15), value: isOn)
+            .accessibilityHidden(true)
+    }
+
+    private var trackColor: Color {
+        isOn
+            ? Color(red: 0x3a / 255, green: 0x6a / 255, blue: 0x5a / 255)
+            : (theme.isDark
+                ? Color.white.opacity(0.12)
+                : Color.black.opacity(0.12))
+    }
+}
+
+// MARK: - More-menu action observers
+
+/// Feature #60 WI-6c: bundles the six More-menu notification
+/// observers into a single modifier, mirroring `ReaderToolbarActionObservers`
+/// (WI-6b). `ReaderContainerView` applies it as one `.modifier(...)`
+/// rather than six chained `.onReceive`s — its `body` is already near
+/// the Swift type-checker's expression-complexity ceiling.
+///
+/// Each observer maps its notification back to the `ReaderMoreMenuRow`
+/// that posted it via `ReaderMoreMenuRow(notification:)` (the inverse
+/// of `.notification`) and hands the row to a single
+/// `(ReaderMoreMenuRow) -> Void` callback, so the host has one action
+/// funnel instead of six.
+struct ReaderMoreMenuActionObservers: ViewModifier {
+    let onAction: (ReaderMoreMenuRow) -> Void
+
+    func body(content: Content) -> some View {
+        // SwiftUI `.onReceive` needs one publisher per concrete name —
+        // a dynamic set can't be observed — but each routes through the
+        // inverse initializer so the row resolution is single-sourced
+        // and round-trip-tested.
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .readerMoreReadAloud), perform: dispatch)
+            .onReceive(NotificationCenter.default.publisher(for: .readerMoreToggleAutoTurn), perform: dispatch)
+            .onReceive(NotificationCenter.default.publisher(for: .readerMoreBilingual), perform: dispatch)
+            .onReceive(NotificationCenter.default.publisher(for: .readerMoreBookDetails), perform: dispatch)
+            .onReceive(NotificationCenter.default.publisher(for: .readerMoreShareBook), perform: dispatch)
+            .onReceive(NotificationCenter.default.publisher(for: .readerMoreExportAnnotations), perform: dispatch)
+    }
+
+    /// Resolves the posting row from the notification name and fires
+    /// the action funnel. An unrecognised name (no matching row) is
+    /// ignored.
+    private func dispatch(_ notification: Notification) {
+        guard let row = ReaderMoreMenuRow(notification: notification.name) else { return }
+        onAction(row)
+    }
+}
+
+extension View {
+    /// Attaches the six More-menu action observers (Feature #60
+    /// WI-6c). See `ReaderMoreMenuActionObservers`.
+    func readerMoreMenuActionObservers(
+        onAction: @escaping (ReaderMoreMenuRow) -> Void
+    ) -> some View {
+        modifier(ReaderMoreMenuActionObservers(onAction: onAction))
+    }
+}
+#endif

--- a/vreader/Views/Reader/ReaderMorePopover.swift
+++ b/vreader/Views/Reader/ReaderMorePopover.swift
@@ -1,25 +1,27 @@
 // Purpose: Feature #60 WI-6c — the reader More-menu popover. An
 // anchored popover from the `⋯` button in `ReaderTopChrome`, replacing
-// the WI-6b interim wiring (`⋯` → settings sheet). Six rows split by a
-// hairline divider: Read aloud / Auto-turn pages / Bilingual mode |
-// Book details / Share book / Export annotations.
+// the WI-6b interim wiring (`⋯` → settings sheet). Five rows split by a
+// hairline divider: Read aloud / Auto-turn pages | Book details /
+// Share book / Export annotations. (The design's sixth row, Bilingual
+// mode, is deferred — GH #790 — see `ReaderMoreMenuRow`'s header.)
 //
 // Layout pinned to the committed design bundle:
 // `dev-docs/designs/vreader-fidelity-v1/project/vreader-more.jsx`
-// (`MorePopover` + `ToggleSwitch`) and `design-notes/
-// reader-search-and-more-menu.md` §2 (width 268, radius 16, notch
-// pointing to the trigger, per-theme rendering for all 5 themes).
+// (`MorePopover`) and `design-notes/reader-search-and-more-menu.md`
+// §2 (width 268, radius 16, notch pointing to the trigger, per-theme
+// rendering for all 5 themes).
 //
 // Row identity, ordering, divider placement, labels, icons, toggle vs
 // tap, sub-detail text, and notification routing all live in
 // `ReaderMoreMenuRow` so the design contract is unit-testable without
-// a SwiftUI render path. This file is purely presentational — taps
-// post `ReaderMoreMenuRow.notification`; `ReaderContainerView`
-// observes them.
+// a SwiftUI render path. The notch / toggle / observer-modifier
+// helpers live in `ReaderMorePopoverParts.swift`. This file is purely
+// presentational — taps post `ReaderMoreMenuRow.notification`;
+// `ReaderContainerView` observes them.
 //
-// @coordinates-with: ReaderMoreMenuRow.swift, ReaderTopChrome.swift,
-//   ReaderThemeV2.swift, ReaderContainerView+Sheets.swift,
-//   ReaderNotifications.swift
+// @coordinates-with: ReaderMoreMenuRow.swift, ReaderMorePopoverParts.swift,
+//   ReaderTopChrome.swift, ReaderThemeV2.swift,
+//   ReaderContainerView+Sheets.swift, ReaderNotifications.swift
 
 #if canImport(UIKit)
 import SwiftUI
@@ -53,12 +55,15 @@ struct ReaderMorePopover: View {
 
     /// Design popover width (`vreader-more.jsx`: `width: 268`).
     private let popoverWidth: CGFloat = 268
+    /// Edge length of the design's rotated-square notch
+    /// (`vreader-more.jsx`: `width: 12, height: 12`).
+    private let notchSize: CGFloat = 12
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
-            // Dim backdrop — transparent fill, taps anywhere outside
-            // the card close the popover. Matches the design's
-            // `onClick={onClose}` full-bleed layer.
+            // Dim backdrop — near-transparent fill, taps anywhere
+            // outside the card close the popover. Matches the design's
+            // full-bleed `onClick={onClose}` layer.
             Color.black.opacity(0.001)
                 .ignoresSafeArea()
                 .contentShape(Rectangle())
@@ -93,26 +98,31 @@ struct ReaderMorePopover: View {
             RoundedRectangle(cornerRadius: 16)
                 .stroke(Color(theme.ruleColor), lineWidth: 0.5)
         )
-        // Notch behind the card: it pokes above the top edge as the
-        // pointer; the card's own surface covers its base, so no
-        // clipping or selective border is needed.
-        .background(alignment: .top) { notch }
+        // Notch behind the card: a rotated square whose top half pokes
+        // above the card edge as the pointer; the card's own surface +
+        // border cover its bottom half, so the only visible notch
+        // edges are the two pointing up — matching the design's
+        // two-sided hairline (`box-shadow: -1px -1px`).
+        .background(alignment: .topTrailing) { notch }
         .shadow(color: .black.opacity(0.28), radius: 18, x: 0, y: 12)
     }
 
-    /// The small triangular beak that points up toward the `⋯`
-    /// trigger. `vreader-more.jsx` draws this as a rotated square
-    /// (`top: -6, right: 24`); a triangle is the equivalent SwiftUI
-    /// idiom and avoids clipping the base behind the card.
+    /// The rotated-square notch that points up toward the `⋯` trigger.
+    /// `vreader-more.jsx`: a 12×12 square, `transform: rotate(45deg)`,
+    /// `top: -6, right: 24`.
     private var notch: some View {
-        ReaderMorePopoverNotch()
+        Rectangle()
             .fill(popoverBackground)
-            .frame(width: 16, height: 8)
-            // Right-align under the `⋯` button: 24pt from the card's
-            // trailing edge per the design, minus half the notch width.
-            .frame(width: popoverWidth, alignment: .trailing)
-            .padding(.trailing, 16)
-            .offset(y: -7)
+            .overlay(
+                Rectangle().stroke(Color(theme.ruleColor), lineWidth: 0.5)
+            )
+            .frame(width: notchSize, height: notchSize)
+            .rotationEffect(.degrees(45))
+            // `right: 24` from the card's trailing edge to the notch
+            // center; the rotated square is `notchSize` wide, so its
+            // leading offset is 24 − notchSize/2 from the trailing
+            // inset. `top: -6` lifts it half-out of the card.
+            .offset(x: -(24 - notchSize / 2), y: -6)
             .allowsHitTesting(false)
     }
 
@@ -199,114 +209,21 @@ struct ReaderMorePopover: View {
     // MARK: - Theme-aware surface
 
     /// Popover surface fill. The design ships hardcoded `#2a2724`
-    /// (dark family) / `#fcf8f0` (light family), distinct from the
-    /// reader chrome tint so the popover reads as a floating element.
-    /// Mapped through `isDark` so all 5 themes pick the right surface
-    /// — the same projection `SelectionPopoverView` uses.
+    /// (dark / OLED family) / `#fcf8f0` (Paper / Sepia family) for the
+    /// popover surface, distinct from the reader chrome tint so the
+    /// popover reads as a floating element. The Photo theme uses a
+    /// translucent dark fill (`rgba(20,16,12,0.92)`, design note §2)
+    /// so the popover stays legible over an arbitrary background
+    /// image without depending on a backdrop blur.
     private var popoverBackground: Color {
-        theme.isDark
+        if theme.usesBackgroundImage {
+            // Photo theme — design-specified translucent surface.
+            return Color(red: 20 / 255, green: 16 / 255, blue: 12 / 255)
+                .opacity(0.92)
+        }
+        return theme.isDark
             ? Color(red: 0x2a / 255, green: 0x27 / 255, blue: 0x24 / 255)
             : Color(red: 0xfc / 255, green: 0xf8 / 255, blue: 0xf0 / 255)
-    }
-}
-
-// MARK: - Popover notch
-
-/// Upward-pointing triangular beak for the More popover. Apex at top
-/// center, base along the bottom edge — drawn behind the card so its
-/// base tucks under the card surface.
-private struct ReaderMorePopoverNotch: Shape {
-    func path(in rect: CGRect) -> Path {
-        var path = Path()
-        path.move(to: CGPoint(x: rect.midX, y: rect.minY))
-        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
-        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
-        path.closeSubpath()
-        return path
-    }
-}
-
-// MARK: - Inline toggle switch
-
-/// Small iOS-style toggle rendered in the Auto-turn row, matching
-/// `vreader-more.jsx`'s `ToggleSwitch` (34×20 track, green `#3a6a5a`
-/// when on). Presentational only — the row's tap posts the toggle
-/// notification; the host flips the backing setting and the new
-/// `isOn` flows back in.
-private struct ReaderMoreToggle: View {
-    let isOn: Bool
-    let theme: ReaderThemeV2
-
-    var body: some View {
-        Capsule()
-            .fill(trackColor)
-            .frame(width: 34, height: 20)
-            .overlay(alignment: isOn ? .trailing : .leading) {
-                Circle()
-                    .fill(Color.white)
-                    .frame(width: 16, height: 16)
-                    .shadow(color: .black.opacity(0.2), radius: 1, x: 0, y: 1)
-                    .padding(.horizontal, 2)
-            }
-            .animation(.easeInOut(duration: 0.15), value: isOn)
-            .accessibilityHidden(true)
-    }
-
-    private var trackColor: Color {
-        isOn
-            ? Color(red: 0x3a / 255, green: 0x6a / 255, blue: 0x5a / 255)
-            : (theme.isDark
-                ? Color.white.opacity(0.12)
-                : Color.black.opacity(0.12))
-    }
-}
-
-// MARK: - More-menu action observers
-
-/// Feature #60 WI-6c: bundles the six More-menu notification
-/// observers into a single modifier, mirroring `ReaderToolbarActionObservers`
-/// (WI-6b). `ReaderContainerView` applies it as one `.modifier(...)`
-/// rather than six chained `.onReceive`s — its `body` is already near
-/// the Swift type-checker's expression-complexity ceiling.
-///
-/// Each observer maps its notification back to the `ReaderMoreMenuRow`
-/// that posted it via `ReaderMoreMenuRow(notification:)` (the inverse
-/// of `.notification`) and hands the row to a single
-/// `(ReaderMoreMenuRow) -> Void` callback, so the host has one action
-/// funnel instead of six.
-struct ReaderMoreMenuActionObservers: ViewModifier {
-    let onAction: (ReaderMoreMenuRow) -> Void
-
-    func body(content: Content) -> some View {
-        // SwiftUI `.onReceive` needs one publisher per concrete name —
-        // a dynamic set can't be observed — but each routes through the
-        // inverse initializer so the row resolution is single-sourced
-        // and round-trip-tested.
-        content
-            .onReceive(NotificationCenter.default.publisher(for: .readerMoreReadAloud), perform: dispatch)
-            .onReceive(NotificationCenter.default.publisher(for: .readerMoreToggleAutoTurn), perform: dispatch)
-            .onReceive(NotificationCenter.default.publisher(for: .readerMoreBilingual), perform: dispatch)
-            .onReceive(NotificationCenter.default.publisher(for: .readerMoreBookDetails), perform: dispatch)
-            .onReceive(NotificationCenter.default.publisher(for: .readerMoreShareBook), perform: dispatch)
-            .onReceive(NotificationCenter.default.publisher(for: .readerMoreExportAnnotations), perform: dispatch)
-    }
-
-    /// Resolves the posting row from the notification name and fires
-    /// the action funnel. An unrecognised name (no matching row) is
-    /// ignored.
-    private func dispatch(_ notification: Notification) {
-        guard let row = ReaderMoreMenuRow(notification: notification.name) else { return }
-        onAction(row)
-    }
-}
-
-extension View {
-    /// Attaches the six More-menu action observers (Feature #60
-    /// WI-6c). See `ReaderMoreMenuActionObservers`.
-    func readerMoreMenuActionObservers(
-        onAction: @escaping (ReaderMoreMenuRow) -> Void
-    ) -> some View {
-        modifier(ReaderMoreMenuActionObservers(onAction: onAction))
     }
 }
 #endif

--- a/vreader/Views/Reader/ReaderMorePopoverParts.swift
+++ b/vreader/Views/Reader/ReaderMorePopoverParts.swift
@@ -1,0 +1,97 @@
+// Purpose: Feature #60 WI-6c — supporting parts for the reader
+// More-menu popover: the inline toggle switch rendered in the
+// Auto-turn row, and the `ReaderMoreMenuActionObservers` modifier that
+// bundles the five More-menu notification observers for the host.
+// Split out of `ReaderMorePopover.swift` to keep both files under the
+// ~300-line guideline.
+//
+// @coordinates-with: ReaderMorePopover.swift, ReaderMoreMenuRow.swift,
+//   ReaderThemeV2.swift, ReaderContainerView+Sheets.swift,
+//   ReaderNotifications.swift
+
+#if canImport(UIKit)
+import SwiftUI
+
+// MARK: - Inline toggle switch
+
+/// Small iOS-style toggle rendered in the Auto-turn row, matching
+/// `vreader-more.jsx`'s `ToggleSwitch` (34×20 track, green `#3a6a5a`
+/// when on). Presentational only — the row's tap posts the toggle
+/// notification; the host flips the backing setting and the new
+/// `isOn` flows back in.
+struct ReaderMoreToggle: View {
+    let isOn: Bool
+    let theme: ReaderThemeV2
+
+    var body: some View {
+        Capsule()
+            .fill(trackColor)
+            .frame(width: 34, height: 20)
+            .overlay(alignment: isOn ? .trailing : .leading) {
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: 16, height: 16)
+                    .shadow(color: .black.opacity(0.2), radius: 1, x: 0, y: 1)
+                    .padding(.horizontal, 2)
+            }
+            .animation(.easeInOut(duration: 0.15), value: isOn)
+            .accessibilityHidden(true)
+    }
+
+    private var trackColor: Color {
+        isOn
+            ? Color(red: 0x3a / 255, green: 0x6a / 255, blue: 0x5a / 255)
+            : (theme.isDark
+                ? Color.white.opacity(0.12)
+                : Color.black.opacity(0.12))
+    }
+}
+
+// MARK: - More-menu action observers
+
+/// Feature #60 WI-6c: bundles the five More-menu notification
+/// observers into a single modifier, mirroring `ReaderToolbarActionObservers`
+/// (WI-6b). `ReaderContainerView` applies it as one `.modifier(...)`
+/// rather than five chained `.onReceive`s — its `body` is already near
+/// the Swift type-checker's expression-complexity ceiling.
+///
+/// Each observer maps its notification back to the `ReaderMoreMenuRow`
+/// that posted it via `ReaderMoreMenuRow(notification:)` (the inverse
+/// of `.notification`) and hands the row to a single
+/// `(ReaderMoreMenuRow) -> Void` callback, so the host has one action
+/// funnel instead of five.
+struct ReaderMoreMenuActionObservers: ViewModifier {
+    let onAction: (ReaderMoreMenuRow) -> Void
+
+    func body(content: Content) -> some View {
+        // SwiftUI `.onReceive` needs one publisher per concrete name —
+        // a dynamic set can't be observed — but each routes through the
+        // inverse initializer so the row resolution is single-sourced
+        // and round-trip-tested.
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .readerMoreReadAloud), perform: dispatch)
+            .onReceive(NotificationCenter.default.publisher(for: .readerMoreToggleAutoTurn), perform: dispatch)
+            .onReceive(NotificationCenter.default.publisher(for: .readerMoreBookDetails), perform: dispatch)
+            .onReceive(NotificationCenter.default.publisher(for: .readerMoreShareBook), perform: dispatch)
+            .onReceive(NotificationCenter.default.publisher(for: .readerMoreExportAnnotations), perform: dispatch)
+    }
+
+    /// Resolves the posting row from the notification name and fires
+    /// the action funnel. An unrecognised name (no matching row) is
+    /// ignored.
+    private func dispatch(_ notification: Notification) {
+        guard let row = ReaderMoreMenuRow(notification: notification.name) else { return }
+        onAction(row)
+    }
+}
+
+extension View {
+    /// Attaches the five More-menu action observers (Feature #60
+    /// WI-6c). See `ReaderMoreMenuActionObservers`.
+    func readerMoreMenuActionObservers(
+        onAction: @escaping (ReaderMoreMenuRow) -> Void
+    ) -> some View {
+        modifier(ReaderMoreMenuActionObservers(onAction: onAction))
+    }
+}
+#endif

--- a/vreader/Views/Reader/ReaderNotifications.swift
+++ b/vreader/Views/Reader/ReaderNotifications.swift
@@ -76,7 +76,7 @@ extension Notification.Name {
     static let readerOpenDisplay = Notification.Name("vreader.readerOpenDisplay")
     static let readerOpenAI = Notification.Name("vreader.readerOpenAI")
     /// Feature #60 WI-6c: posted by the reader More-menu popover
-    /// (`ReaderMorePopover`) when the user taps one of its six rows.
+    /// (`ReaderMorePopover`) when the user taps one of its five rows.
     /// `ReaderContainerView` observes these and runs the matching
     /// action. Posting (rather than threading closures through the
     /// shared `ReaderTopChrome` and per-format hosts) keeps the
@@ -85,14 +85,12 @@ extension Notification.Name {
     ///
     /// `.readerMoreToggleAutoTurn` flips `ReaderSettingsStore.autoPageTurn`
     /// (the only row with real backing state — the design draws it as
-    /// a toggle). `.readerMoreBilingual` opens the AI assistant on its
-    /// translate tab — the existing bilingual surface.
-    /// `.readerMoreBookDetails` opens the reader settings panel as the
-    /// interim destination (the real Book Details sheet is undesigned —
-    /// GH #789).
+    /// a toggle). `.readerMoreBookDetails` opens the reader settings
+    /// panel as the interim destination (the real Book Details sheet
+    /// is undesigned — GH #789). The design's Bilingual row is
+    /// deferred (GH #790) — no notification for it.
     static let readerMoreReadAloud = Notification.Name("vreader.readerMoreReadAloud")
     static let readerMoreToggleAutoTurn = Notification.Name("vreader.readerMoreToggleAutoTurn")
-    static let readerMoreBilingual = Notification.Name("vreader.readerMoreBilingual")
     static let readerMoreBookDetails = Notification.Name("vreader.readerMoreBookDetails")
     static let readerMoreShareBook = Notification.Name("vreader.readerMoreShareBook")
     static let readerMoreExportAnnotations = Notification.Name("vreader.readerMoreExportAnnotations")

--- a/vreader/Views/Reader/ReaderNotifications.swift
+++ b/vreader/Views/Reader/ReaderNotifications.swift
@@ -75,6 +75,27 @@ extension Notification.Name {
     static let readerOpenNotes = Notification.Name("vreader.readerOpenNotes")
     static let readerOpenDisplay = Notification.Name("vreader.readerOpenDisplay")
     static let readerOpenAI = Notification.Name("vreader.readerOpenAI")
+    /// Feature #60 WI-6c: posted by the reader More-menu popover
+    /// (`ReaderMorePopover`) when the user taps one of its six rows.
+    /// `ReaderContainerView` observes these and runs the matching
+    /// action. Posting (rather than threading closures through the
+    /// shared `ReaderTopChrome` and per-format hosts) keeps the
+    /// popover composable in one place. Each maps 1:1 from a
+    /// `ReaderMoreMenuRow` case via `ReaderMoreMenuRow.notification`.
+    ///
+    /// `.readerMoreToggleAutoTurn` flips `ReaderSettingsStore.autoPageTurn`
+    /// (the only row with real backing state — the design draws it as
+    /// a toggle). `.readerMoreBilingual` opens the AI assistant on its
+    /// translate tab — the existing bilingual surface.
+    /// `.readerMoreBookDetails` opens the reader settings panel as the
+    /// interim destination (the real Book Details sheet is undesigned —
+    /// GH #789).
+    static let readerMoreReadAloud = Notification.Name("vreader.readerMoreReadAloud")
+    static let readerMoreToggleAutoTurn = Notification.Name("vreader.readerMoreToggleAutoTurn")
+    static let readerMoreBilingual = Notification.Name("vreader.readerMoreBilingual")
+    static let readerMoreBookDetails = Notification.Name("vreader.readerMoreBookDetails")
+    static let readerMoreShareBook = Notification.Name("vreader.readerMoreShareBook")
+    static let readerMoreExportAnnotations = Notification.Name("vreader.readerMoreExportAnnotations")
     /// Posted when a footnote link is detected in EPUB content (foliate-js).
     /// Object is [String: String] with "href" and "text" keys.
     static let epubFootnoteDetected = Notification.Name("vreader.epubFootnoteDetected")

--- a/vreader/Views/Reader/ReaderTopChrome.swift
+++ b/vreader/Views/Reader/ReaderTopChrome.swift
@@ -9,13 +9,14 @@
 //   ← Library  |  Title (italic, centered)  |  🔍  📑  ⋯
 //
 // The four shed actions (Contents / Notes / Display / AI) move to
-// `ReaderBottomChrome`. The ⋯ More button's anchored popover lands in
-// WI-6c; until then the caller routes ⋯ to the existing settings
-// sheet.
+// `ReaderBottomChrome`. The ⋯ More button toggles the anchored
+// `ReaderMorePopover` (Feature #60 WI-6c) via its `onMore` closure;
+// `moreActive` draws the design's backdrop tint while it is open.
 //
 // @coordinates-with: ReaderBottomChrome.swift, ReaderChromeButton.swift,
 //   ReaderThemeV2.swift, ReaderSafeAreaResolver.swift,
-//   ReaderContainerView+Sheets.swift (composition site)
+//   ReaderMorePopover.swift, ReaderContainerView+Sheets.swift
+//   (composition site)
 
 import SwiftUI
 

--- a/vreaderTests/Views/Reader/ReaderMoreMenuRowTests.swift
+++ b/vreaderTests/Views/Reader/ReaderMoreMenuRowTests.swift
@@ -1,0 +1,198 @@
+// Purpose: Feature #60 WI-6c — pins the reader More-menu popover's
+// row → action/notification routing contract. `ReaderMorePopover`
+// renders these rows declaratively and `ReaderContainerView` observes
+// the posted notifications; a swapped mapping would silently open the
+// wrong surface, so the contract is pinned here before any SwiftUI
+// render path runs.
+//
+// Design source:
+// `dev-docs/designs/vreader-fidelity-v1/project/vreader-more.jsx`
+// + `design-notes/reader-search-and-more-menu.md` §2.
+//
+// @coordinates-with: ReaderMoreMenuRow.swift, ReaderMorePopover.swift,
+//   ReaderNotifications.swift
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("Feature #60 WI-6c — ReaderMoreMenuRow contract")
+struct ReaderMoreMenuRowTests {
+
+    // MARK: - Cardinality + order
+
+    @Test("Menu has exactly 6 rows")
+    func rowCount() {
+        #expect(ReaderMoreMenuRow.allCases.count == 6)
+    }
+
+    @Test("Row order matches the design bundle (vreader-more.jsx)")
+    func rowOrder() {
+        // Mirrors `vreader-more.jsx` top → bottom: Read aloud /
+        // Auto-turn pages / Bilingual mode / (divider) / Book details
+        // / Share book / Export annotations.
+        #expect(ReaderMoreMenuRow.allCases == [
+            .readAloud, .autoTurnPages, .bilingualMode,
+            .bookDetails, .shareBook, .exportAnnotations,
+        ])
+    }
+
+    // MARK: - Divider placement
+
+    @Test("Divider sits after Bilingual mode (before Book details)")
+    func dividerPlacement() {
+        // The design draws one hairline divider between the
+        // reading-controls cluster and the book-action cluster.
+        #expect(ReaderMoreMenuRow.dividerAfter == .bilingualMode)
+    }
+
+    // MARK: - Toggle vs tap rows
+
+    @Test("Auto-turn pages is the only toggle row")
+    func toggleRowIdentity() {
+        // `vreader-more.jsx` draws a ToggleSwitch on Auto-turn and on
+        // Bilingual. Auto-turn has real backing state
+        // (`ReaderSettingsStore.autoPageTurn`); Bilingual has none —
+        // bilingual rendering lives entirely in the AI translate
+        // panel, so WI-6c routes Bilingual as a tap row to that
+        // existing surface rather than fabricating a toggle with no
+        // on/off state. Pin: exactly one toggle row, and it's
+        // Auto-turn.
+        #expect(ReaderMoreMenuRow.autoTurnPages.isToggle)
+        #expect(!ReaderMoreMenuRow.readAloud.isToggle)
+        #expect(!ReaderMoreMenuRow.bilingualMode.isToggle)
+        #expect(!ReaderMoreMenuRow.bookDetails.isToggle)
+        #expect(!ReaderMoreMenuRow.shareBook.isToggle)
+        #expect(!ReaderMoreMenuRow.exportAnnotations.isToggle)
+        #expect(ReaderMoreMenuRow.allCases.filter(\.isToggle).count == 1)
+    }
+
+    // MARK: - Row → notification routing (exhaustive)
+
+    @Test("Read aloud routes to .readerMoreReadAloud")
+    func readAloudRoutes() {
+        #expect(ReaderMoreMenuRow.readAloud.notification == .readerMoreReadAloud)
+    }
+
+    @Test("Auto-turn pages routes to .readerMoreToggleAutoTurn")
+    func autoTurnRoutes() {
+        #expect(ReaderMoreMenuRow.autoTurnPages.notification == .readerMoreToggleAutoTurn)
+    }
+
+    @Test("Bilingual mode routes to .readerMoreBilingual")
+    func bilingualRoutes() {
+        #expect(ReaderMoreMenuRow.bilingualMode.notification == .readerMoreBilingual)
+    }
+
+    @Test("Book details routes to .readerMoreBookDetails")
+    func bookDetailsRoutes() {
+        // Destination Book Details sheet is undesigned (design note
+        // §4); GH #789 tracks it. WI-6c routes the row to the existing
+        // reader settings panel — the design prototype's own interim
+        // punt (`vreader-more.jsx`/`vreader-reader.jsx`:
+        // `onAction('details') → onOpenSettings`). The notification is
+        // the seam; the container picks the interim destination.
+        #expect(ReaderMoreMenuRow.bookDetails.notification == .readerMoreBookDetails)
+    }
+
+    @Test("Share book routes to .readerMoreShareBook")
+    func shareBookRoutes() {
+        #expect(ReaderMoreMenuRow.shareBook.notification == .readerMoreShareBook)
+    }
+
+    @Test("Export annotations routes to .readerMoreExportAnnotations")
+    func exportAnnotationsRoutes() {
+        #expect(ReaderMoreMenuRow.exportAnnotations.notification == .readerMoreExportAnnotations)
+    }
+
+    @Test("Every row maps to a distinct notification")
+    func everyRowMapsToDistinctNotification() {
+        // Exhaustive over the enum — a future 7th row without a
+        // mapping, or a duplicated mapping, fails here.
+        let names = ReaderMoreMenuRow.allCases.map(\.notification)
+        #expect(Set(names).count == ReaderMoreMenuRow.allCases.count)
+    }
+
+    @Test("All More-menu notifications are namespaced under vreader.")
+    func notificationsAreNamespaced() {
+        for row in ReaderMoreMenuRow.allCases {
+            #expect(row.notification.rawValue.hasPrefix("vreader."))
+        }
+    }
+
+    // MARK: - Inverse routing (notification → row)
+
+    @Test("Each row round-trips through notification and back")
+    func notificationRoundTrips() {
+        // `ReaderMoreMenuActionObservers` resolves a tapped row from
+        // the observed notification name via `init?(notification:)`.
+        // A drift between `.notification` and the inverse breaks the
+        // popover's action funnel — pin the round-trip exhaustively.
+        for row in ReaderMoreMenuRow.allCases {
+            #expect(ReaderMoreMenuRow(notification: row.notification) == row)
+        }
+    }
+
+    @Test("An unrelated notification name resolves to nil")
+    func unrelatedNotificationIsNil() {
+        // The observer modifier ignores names that aren't More-menu
+        // rows. A non-More notification (or a typo'd name) must not
+        // resolve to a row.
+        #expect(ReaderMoreMenuRow(notification: .readerOpenContents) == nil)
+        #expect(ReaderMoreMenuRow(notification: Notification.Name("vreader.bogus")) == nil)
+    }
+
+    // MARK: - Display strings
+
+    @Test("Each row carries a non-empty label")
+    func labelsNonEmpty() {
+        for row in ReaderMoreMenuRow.allCases {
+            #expect(!row.label.isEmpty, "row \(row) has empty label")
+        }
+    }
+
+    @Test("Row labels match the design bundle text")
+    func labelsMatchDesign() {
+        #expect(ReaderMoreMenuRow.readAloud.label == "Read aloud")
+        #expect(ReaderMoreMenuRow.autoTurnPages.label == "Auto-turn pages")
+        #expect(ReaderMoreMenuRow.bilingualMode.label == "Bilingual mode")
+        #expect(ReaderMoreMenuRow.bookDetails.label == "Book details")
+        #expect(ReaderMoreMenuRow.shareBook.label == "Share book")
+        #expect(ReaderMoreMenuRow.exportAnnotations.label == "Export annotations")
+    }
+
+    @Test("Each row carries a non-empty SF Symbol name")
+    func symbolNamesNonEmpty() {
+        for row in ReaderMoreMenuRow.allCases {
+            #expect(!row.systemImage.isEmpty, "row \(row) has empty systemImage")
+        }
+    }
+
+    @Test("SF Symbol names are well-formed (no whitespace, no leading dot)")
+    func symbolNamesWellFormed() {
+        for row in ReaderMoreMenuRow.allCases {
+            #expect(!row.systemImage.contains(" "), "row \(row) systemImage has a space")
+            #expect(!row.systemImage.hasPrefix("."), "row \(row) systemImage starts with '.'")
+        }
+    }
+
+    // MARK: - Stable accessibility identifiers
+
+    @Test("Each row exposes a stable accessibility identifier")
+    func accessibilityIdentifiers() {
+        // XCUITest + verify-cron snapshots look these up. Stable
+        // contract — do not rename without updating every harness.
+        #expect(ReaderMoreMenuRow.readAloud.accessibilityIdentifier == "readerMoreReadAloud")
+        #expect(ReaderMoreMenuRow.autoTurnPages.accessibilityIdentifier == "readerMoreAutoTurn")
+        #expect(ReaderMoreMenuRow.bilingualMode.accessibilityIdentifier == "readerMoreBilingual")
+        #expect(ReaderMoreMenuRow.bookDetails.accessibilityIdentifier == "readerMoreBookDetails")
+        #expect(ReaderMoreMenuRow.shareBook.accessibilityIdentifier == "readerMoreShareBook")
+        #expect(ReaderMoreMenuRow.exportAnnotations.accessibilityIdentifier == "readerMoreExportAnnotations")
+    }
+
+    @Test("Accessibility identifiers are all distinct")
+    func accessibilityIdentifiersDistinct() {
+        let ids = ReaderMoreMenuRow.allCases.map(\.accessibilityIdentifier)
+        #expect(Set(ids).count == ReaderMoreMenuRow.allCases.count)
+    }
+}

--- a/vreaderTests/Views/Reader/ReaderMoreMenuRowTests.swift
+++ b/vreaderTests/Views/Reader/ReaderMoreMenuRowTests.swift
@@ -7,7 +7,10 @@
 //
 // Design source:
 // `dev-docs/designs/vreader-fidelity-v1/project/vreader-more.jsx`
-// + `design-notes/reader-search-and-more-menu.md` §2.
+// + `design-notes/reader-search-and-more-menu.md` §2. The design
+// depicts six rows; WI-6c ships five — the Bilingual row is deferred
+// (GH #790, no backing toggle state). These tests pin the shipped
+// five-row contract.
 //
 // @coordinates-with: ReaderMoreMenuRow.swift, ReaderMorePopover.swift,
 //   ReaderNotifications.swift
@@ -21,46 +24,50 @@ struct ReaderMoreMenuRowTests {
 
     // MARK: - Cardinality + order
 
-    @Test("Menu has exactly 6 rows")
+    @Test("Menu has exactly 5 rows (design's 6 minus deferred Bilingual)")
     func rowCount() {
-        #expect(ReaderMoreMenuRow.allCases.count == 6)
+        #expect(ReaderMoreMenuRow.allCases.count == 5)
     }
 
     @Test("Row order matches the design bundle (vreader-more.jsx)")
     func rowOrder() {
-        // Mirrors `vreader-more.jsx` top → bottom: Read aloud /
-        // Auto-turn pages / Bilingual mode / (divider) / Book details
-        // / Share book / Export annotations.
+        // Mirrors `vreader-more.jsx` top → bottom minus the deferred
+        // Bilingual row (GH #790): Read aloud / Auto-turn pages /
+        // (divider) / Book details / Share book / Export annotations.
         #expect(ReaderMoreMenuRow.allCases == [
-            .readAloud, .autoTurnPages, .bilingualMode,
+            .readAloud, .autoTurnPages,
             .bookDetails, .shareBook, .exportAnnotations,
         ])
     }
 
+    @Test("Bilingual mode is not a shipped row (deferred — GH #790)")
+    func bilingualRowAbsent() {
+        // The design's Bilingual row has no backing toggle state;
+        // shipping it would be self-designed UI (rule 51). Pin its
+        // absence so a future re-add is a deliberate, tested change.
+        #expect(!ReaderMoreMenuRow.allCases.contains { $0.rawValue == "bilingualMode" })
+    }
+
     // MARK: - Divider placement
 
-    @Test("Divider sits after Bilingual mode (before Book details)")
+    @Test("Divider sits after Auto-turn pages (before Book details)")
     func dividerPlacement() {
         // The design draws one hairline divider between the
-        // reading-controls cluster and the book-action cluster.
-        #expect(ReaderMoreMenuRow.dividerAfter == .bilingualMode)
+        // reading-controls cluster and the book-action cluster. In the
+        // design it follows Bilingual; with that row deferred it
+        // follows Auto-turn — still the cluster boundary.
+        #expect(ReaderMoreMenuRow.dividerAfter == .autoTurnPages)
     }
 
     // MARK: - Toggle vs tap rows
 
     @Test("Auto-turn pages is the only toggle row")
     func toggleRowIdentity() {
-        // `vreader-more.jsx` draws a ToggleSwitch on Auto-turn and on
-        // Bilingual. Auto-turn has real backing state
-        // (`ReaderSettingsStore.autoPageTurn`); Bilingual has none —
-        // bilingual rendering lives entirely in the AI translate
-        // panel, so WI-6c routes Bilingual as a tap row to that
-        // existing surface rather than fabricating a toggle with no
-        // on/off state. Pin: exactly one toggle row, and it's
-        // Auto-turn.
+        // `vreader-more.jsx` draws a ToggleSwitch on Auto-turn. It has
+        // real backing state (`ReaderSettingsStore.autoPageTurn`).
+        // Pin: exactly one toggle row, and it's Auto-turn.
         #expect(ReaderMoreMenuRow.autoTurnPages.isToggle)
         #expect(!ReaderMoreMenuRow.readAloud.isToggle)
-        #expect(!ReaderMoreMenuRow.bilingualMode.isToggle)
         #expect(!ReaderMoreMenuRow.bookDetails.isToggle)
         #expect(!ReaderMoreMenuRow.shareBook.isToggle)
         #expect(!ReaderMoreMenuRow.exportAnnotations.isToggle)
@@ -77,11 +84,6 @@ struct ReaderMoreMenuRowTests {
     @Test("Auto-turn pages routes to .readerMoreToggleAutoTurn")
     func autoTurnRoutes() {
         #expect(ReaderMoreMenuRow.autoTurnPages.notification == .readerMoreToggleAutoTurn)
-    }
-
-    @Test("Bilingual mode routes to .readerMoreBilingual")
-    func bilingualRoutes() {
-        #expect(ReaderMoreMenuRow.bilingualMode.notification == .readerMoreBilingual)
     }
 
     @Test("Book details routes to .readerMoreBookDetails")
@@ -107,8 +109,8 @@ struct ReaderMoreMenuRowTests {
 
     @Test("Every row maps to a distinct notification")
     func everyRowMapsToDistinctNotification() {
-        // Exhaustive over the enum — a future 7th row without a
-        // mapping, or a duplicated mapping, fails here.
+        // Exhaustive over the enum — a future row without a mapping,
+        // or a duplicated mapping, fails here.
         let names = ReaderMoreMenuRow.allCases.map(\.notification)
         #expect(Set(names).count == ReaderMoreMenuRow.allCases.count)
     }
@@ -155,7 +157,6 @@ struct ReaderMoreMenuRowTests {
     func labelsMatchDesign() {
         #expect(ReaderMoreMenuRow.readAloud.label == "Read aloud")
         #expect(ReaderMoreMenuRow.autoTurnPages.label == "Auto-turn pages")
-        #expect(ReaderMoreMenuRow.bilingualMode.label == "Bilingual mode")
         #expect(ReaderMoreMenuRow.bookDetails.label == "Book details")
         #expect(ReaderMoreMenuRow.shareBook.label == "Share book")
         #expect(ReaderMoreMenuRow.exportAnnotations.label == "Export annotations")
@@ -184,7 +185,6 @@ struct ReaderMoreMenuRowTests {
         // contract — do not rename without updating every harness.
         #expect(ReaderMoreMenuRow.readAloud.accessibilityIdentifier == "readerMoreReadAloud")
         #expect(ReaderMoreMenuRow.autoTurnPages.accessibilityIdentifier == "readerMoreAutoTurn")
-        #expect(ReaderMoreMenuRow.bilingualMode.accessibilityIdentifier == "readerMoreBilingual")
         #expect(ReaderMoreMenuRow.bookDetails.accessibilityIdentifier == "readerMoreBookDetails")
         #expect(ReaderMoreMenuRow.shareBook.accessibilityIdentifier == "readerMoreShareBook")
         #expect(ReaderMoreMenuRow.exportAnnotations.accessibilityIdentifier == "readerMoreExportAnnotations")

--- a/vreaderTests/Views/Reader/ReaderMorePopoverStateTests.swift
+++ b/vreaderTests/Views/Reader/ReaderMorePopoverStateTests.swift
@@ -79,19 +79,6 @@ struct ReaderMorePopoverStateTests {
         #expect(high == "Every 60s")
     }
 
-    // MARK: - Bilingual mode
-
-    @Test("Bilingual sub-detail is the static translate prompt")
-    func bilingualSub() {
-        // WI-6c routes Bilingual to the AI translate panel (an
-        // existing surface) rather than a fabricated toggle, so the
-        // sub-detail is the static prompt — no on/off variant.
-        let sub = ReaderMoreMenuRow.bilingualMode.subDetail(
-            ttsPlaying: false, autoTurnOn: false, autoTurnInterval: 30
-        )
-        #expect(sub == "Translate inline")
-    }
-
     // MARK: - Book actions (static / nil sub-detail)
 
     @Test("Book details has no sub-detail")
@@ -144,7 +131,7 @@ struct ReaderMorePopoverStateTests {
 
     @Test("Static rows are never active")
     func staticRowsNeverActive() {
-        for row in [ReaderMoreMenuRow.bilingualMode, .bookDetails, .shareBook, .exportAnnotations] {
+        for row in [ReaderMoreMenuRow.bookDetails, .shareBook, .exportAnnotations] {
             #expect(!row.isActive(ttsPlaying: true, autoTurnOn: true), "row \(row) should not be active")
         }
     }

--- a/vreaderTests/Views/Reader/ReaderMorePopoverStateTests.swift
+++ b/vreaderTests/Views/Reader/ReaderMorePopoverStateTests.swift
@@ -1,0 +1,151 @@
+// Purpose: Feature #60 WI-6c — pins the More-menu popover's
+// state-driven sub-detail text. `vreader-more.jsx` updates each
+// designed row's secondary line as state changes ("Off" → "Every
+// 30s", "Start text-to-speech" → "Playing · System voice"). The
+// pure mapping is pinned here so a render regression is caught
+// without a SwiftUI host.
+//
+// Design source:
+// `dev-docs/designs/vreader-fidelity-v1/project/vreader-more.jsx`
+// (the `Row sub={...}` expressions) +
+// `design-notes/reader-search-and-more-menu.md` §2.
+//
+// @coordinates-with: ReaderMorePopover.swift, ReaderMoreMenuRow.swift
+
+import Testing
+@testable import vreader
+
+@Suite("Feature #60 WI-6c — ReaderMorePopover sub-detail text")
+struct ReaderMorePopoverStateTests {
+
+    // MARK: - Read aloud
+
+    @Test("Read aloud sub-detail is the idle prompt when TTS is not playing")
+    func readAloudSubIdle() {
+        let sub = ReaderMoreMenuRow.readAloud.subDetail(
+            ttsPlaying: false, autoTurnOn: false, autoTurnInterval: 30
+        )
+        #expect(sub == "Start text-to-speech")
+    }
+
+    @Test("Read aloud sub-detail reflects the playing state")
+    func readAloudSubPlaying() {
+        let sub = ReaderMoreMenuRow.readAloud.subDetail(
+            ttsPlaying: true, autoTurnOn: false, autoTurnInterval: 30
+        )
+        #expect(sub == "Playing \u{00b7} System voice")
+    }
+
+    // MARK: - Auto-turn pages
+
+    @Test("Auto-turn sub-detail is Off when disabled")
+    func autoTurnSubOff() {
+        let sub = ReaderMoreMenuRow.autoTurnPages.subDetail(
+            ttsPlaying: false, autoTurnOn: false, autoTurnInterval: 30
+        )
+        #expect(sub == "Off")
+    }
+
+    @Test("Auto-turn sub-detail shows the interval when enabled")
+    func autoTurnSubOn() {
+        let sub = ReaderMoreMenuRow.autoTurnPages.subDetail(
+            ttsPlaying: false, autoTurnOn: true, autoTurnInterval: 30
+        )
+        #expect(sub == "Every 30s")
+    }
+
+    @Test("Auto-turn interval is rounded to a whole-second label")
+    func autoTurnSubRoundsInterval() {
+        // `ReaderSettingsStore.autoPageTurnInterval` is a TimeInterval
+        // (Double, clamped 1...60). The design's label is "Every Ns" —
+        // an integer. A 12.5s interval must not render "Every 12.5s".
+        let sub = ReaderMoreMenuRow.autoTurnPages.subDetail(
+            ttsPlaying: false, autoTurnOn: true, autoTurnInterval: 12.5
+        )
+        #expect(sub == "Every 13s")
+    }
+
+    @Test("Auto-turn interval clamps to the design's 1...60 range")
+    func autoTurnSubClampsInterval() {
+        // Defensive: a drifted/out-of-range stored interval still
+        // renders a sane label rather than "Every 0s" / "Every 999s".
+        let low = ReaderMoreMenuRow.autoTurnPages.subDetail(
+            ttsPlaying: false, autoTurnOn: true, autoTurnInterval: 0
+        )
+        let high = ReaderMoreMenuRow.autoTurnPages.subDetail(
+            ttsPlaying: false, autoTurnOn: true, autoTurnInterval: 999
+        )
+        #expect(low == "Every 1s")
+        #expect(high == "Every 60s")
+    }
+
+    // MARK: - Bilingual mode
+
+    @Test("Bilingual sub-detail is the static translate prompt")
+    func bilingualSub() {
+        // WI-6c routes Bilingual to the AI translate panel (an
+        // existing surface) rather than a fabricated toggle, so the
+        // sub-detail is the static prompt — no on/off variant.
+        let sub = ReaderMoreMenuRow.bilingualMode.subDetail(
+            ttsPlaying: false, autoTurnOn: false, autoTurnInterval: 30
+        )
+        #expect(sub == "Translate inline")
+    }
+
+    // MARK: - Book actions (static / nil sub-detail)
+
+    @Test("Book details has no sub-detail")
+    func bookDetailsNoSub() {
+        let sub = ReaderMoreMenuRow.bookDetails.subDetail(
+            ttsPlaying: false, autoTurnOn: false, autoTurnInterval: 30
+        )
+        #expect(sub == nil)
+    }
+
+    @Test("Share book has no sub-detail")
+    func shareBookNoSub() {
+        let sub = ReaderMoreMenuRow.shareBook.subDetail(
+            ttsPlaying: false, autoTurnOn: false, autoTurnInterval: 30
+        )
+        #expect(sub == nil)
+    }
+
+    @Test("Export annotations sub-detail lists the formats")
+    func exportSub() {
+        let sub = ReaderMoreMenuRow.exportAnnotations.subDetail(
+            ttsPlaying: false, autoTurnOn: false, autoTurnInterval: 30
+        )
+        #expect(sub == "Markdown \u{00b7} JSON \u{00b7} VReader JSON")
+    }
+
+    // MARK: - Active (accent-tinted) state
+
+    @Test("Read aloud row is active only while TTS is playing")
+    func readAloudActive() {
+        // The design accent-tints the icon background of an active
+        // row. Read aloud is active iff TTS is playing.
+        #expect(ReaderMoreMenuRow.readAloud.isActive(
+            ttsPlaying: true, autoTurnOn: false
+        ))
+        #expect(!ReaderMoreMenuRow.readAloud.isActive(
+            ttsPlaying: false, autoTurnOn: false
+        ))
+    }
+
+    @Test("Auto-turn row is active only while the toggle is on")
+    func autoTurnActive() {
+        #expect(ReaderMoreMenuRow.autoTurnPages.isActive(
+            ttsPlaying: false, autoTurnOn: true
+        ))
+        #expect(!ReaderMoreMenuRow.autoTurnPages.isActive(
+            ttsPlaying: false, autoTurnOn: false
+        ))
+    }
+
+    @Test("Static rows are never active")
+    func staticRowsNeverActive() {
+        for row in [ReaderMoreMenuRow.bilingualMode, .bookDetails, .shareBook, .exportAnnotations] {
+            #expect(!row.isActive(ttsPlaying: true, autoTurnOn: true), "row \(row) should not be active")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Ships the reader "More" menu as the designed anchored popover (`ReaderMorePopover`), replacing the WI-6b interim wiring (top-chrome `⋯` → settings sheet).
- The `⋯` button toggles a 268pt popover anchored under it; each menu row routes to an existing reader surface via a `.readerMore*` notification.
- Layout pinned to the committed design bundle `dev-docs/designs/vreader-fidelity-v1/project/vreader-more.jsx` + `design-notes/reader-search-and-more-menu.md` §2.

Part of feature #718.

## What Changed

- **`ReaderMoreMenuRow.swift`** (new) — the testable row contract: order, divider placement, labels, SF symbols, toggle-vs-tap, state-driven `subDetail` text, `isActive`, accessibility ids, and 1:1 notification routing (`row → .readerMore*` + the inverse `init?(notification:)`). Same pattern as `ReaderChromeButton`.
- **`ReaderMorePopover.swift`** (new) — presentational SwiftUI popover faithful to `vreader-more.jsx`: 268pt card, 16pt radius, rotated-square notch, per-theme surface (all 5 themes, Photo translucent), inline toggle for Auto-turn. Taps post `ReaderMoreMenuRow.notification`; no closure threading.
- **`ReaderMorePopoverParts.swift`** (new) — `ReaderMoreToggle` + `ReaderMoreMenuActionObservers` modifier + the `readerMoreMenuActionObservers` View extension (split out to keep both files under ~300 lines).
- **`ReaderNotifications.swift`** — 5 new `.readerMore*` names.
- **`ReaderTopChrome.swift`** — `onMore` toggles the popover; `moreActive` reflects it (header comment updated; no behavior change to the chrome itself).
- **`ReaderContainerView` + `+Sheets`** — `@State showMorePopover` / `showShareSheet`; composes `readerMorePopoverOverlay`; `.readerMoreMenuActionObservers` modifier; a `ShareSheet` `.sheet`; `handleMoreMenuAction` routes the rows; a content tap dismisses the popover instead of toggling chrome when it's open; `toggleChrome()` clears `showMorePopover` on chrome-hide.

### Menu rows (5 shipped, design's 6 minus deferred Bilingual)

| Row | Routes to |
|---|---|
| Read aloud | `startTTS()` (existing TTS path) |
| Auto-turn pages (toggle) | flips `ReaderSettingsStore.autoPageTurn` (live-applied by paged TXT/MD) |
| Book details | reader settings panel — **interim** destination; the real Book Details sheet is undesigned (design note §4), filed as **GH #789** |
| Share book | `ShareSheet` (system share sheet for the book file) |
| Export annotations | annotations panel on the Highlights tab, which carries the existing export action |

### Rule 51 (no self-designed UI)

- The More-menu popover **is** designed (`vreader-more.jsx` + design note §2) — built faithfully.
- **Book details** — the row is designed; its destination sheet is NOT (design note §4 defers it). Filed **GH #789** `needs-design`. The row routes to the reader settings panel, mirroring the design prototype's own interim punt (`vreader-reader.jsx`: `onAction('details') → onOpenSettings`) — not a self-invented destination.
- **Bilingual mode** — the design draws this as a toggle, but there is no backing persistent bilingual-mode state (bilingual translation lives only in the AI translate panel, per selection). Rendering a fake toggle or a divergent tap row would both be self-designed UI. Per rule 51 the row is **deferred**: filed **GH #790** `needs-design` for the row + its missing backing feature; the popover ships the other 5 designed-and-buildable rows.

## WI Status

- WI-6c: behavioral — this PR.
- Remaining feature #60 WIs: WI-8 (Library cards), WI-9 (Library container), WI-10 (sheets/covers/status bar — final), plus the WI-7c series.

## Codex Audit (Gate 4)

2 rounds, verdict **follow-up-recommended**. Round 1: 1 High + 1 Medium + 3 Low — all fixed:
- High — Bilingual row diverged from the designed toggle → row deferred + GH #790 filed.
- Medium — `popoverBackground` now special-cases the Photo theme to the design note's `rgba(20,16,12,0.92)`.
- Low — notch reverted from an interim triangle to the design's rotated square.
- Low — `toggleChrome()` clears `showMorePopover` on chrome-hide (closes a stale-state resurrection via the "Hide toolbar" accessibility action).
- Low — `ReaderMorePopover.swift` split into two files (size guideline).

Round 2: zero findings. The only follow-up is GH #790 (the deferred Bilingual row).

Audit log: `.claude/codex-audits/feat-feature-60-wi-6c-reader-more-menu-audit.md`

## Validation

- [x] `xcodebuild build` passes (iPhone 17 Pro Simulator, v3.24.14).
- [x] Tests cover changed behavior — new `ReaderMoreMenuRowTests` (24 tests: order, divider, toggle, exhaustive row→notification routing + inverse round-trip, labels, symbols, accessibility ids) + `ReaderMorePopoverStateTests` (9 tests: state-driven sub-detail + active state). Reader-chrome suites run in isolation: `ReaderMoreMenuRowTests` + `ReaderMorePopoverStateTests` + `ReaderBottomChromeTests` + `ReaderChromeButtonContractTests` + `SelectionPopoverActionRowTests` = 53 tests green.
- [x] Codex audit loop completed (2 rounds, follow-up-recommended).
- [x] Docs sync — `architecture.md` (Notification Bus table + Chrome section).
- [x] Version bumped: 3.24.13 → 3.24.14.

> Note: a parallel WI-9 worktree also bumps to 3.24.14 — expected; the orchestrator will rebase one PR and re-bump before merge.

## Gate 5a Verification (per-PR slice — pre-merge)

Tier: **behavioral**. **Pending — orchestrator.** Per the WI-6c brief, device/integration verification (Gate 5a) is handled by the orchestrator, not this PR.

## Type of Change

- [x] Feature WI (Part of feature #718)
