### PR TITLE
feat(#718 WI-9): library container re-skin — nav bar, rail, chips, search

### DIFF
--- a/.claude/codex-audits/feat-feature-60-wi-9-library-container-audit.md
+++ b/.claude/codex-audits/feat-feature-60-wi-9-library-container-audit.md
@@ -1,0 +1,113 @@
+---
+branch: feat/feature-60-wi-9-library-container
+threadId: 019e306e-45b9-7d71-956c-4b69c8f27f75
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-05-16
+---
+
+# Codex Gate 4 audit — feature #60 WI-9 (Library container re-skin)
+
+Independent implementation audit (Codex MCP, `read-only` sandbox,
+`model_reasoning_effort: high`) of the WI-9 Library-container re-skin.
+WI-9 re-skins `LibraryView`'s container chrome to the committed design
+`dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx`
+(`LibraryScreen`): warm-paper shell, pill-button nav bar, 36pt Source
+Serif 4 title + subtitle, toggleable search bar, filter-chip row,
+Continue-reading rail, grid/list bodies.
+
+## Round 1 — initial audit
+
+0 Critical, 2 High, 2 Medium, 1 Low.
+
+- **High #1 — list-mode swipe-to-delete dropped.** The new `listBody`
+  used `LazyVStack` (`Button` + `contextMenu` only); the pre-#60
+  `List`-based list had `.swipeActions(edge: .trailing)`. Swipe-delete
+  was a real behavior regression.
+- **High #2 — sort UI vanished.** The pre-#60 toolbar's `sortPicker`
+  (bound to `viewModel.sortOrder`) had no replacement; `viewModel.sortOrder`
+  still existed but no user path could change it. The design's
+  `GridView` "All books / Recent ⌄" header was also missing.
+- **Medium #3 — empty-library state lost the nav actions.** The empty
+  branch bypassed `libraryContent`, so Settings / OPDS / Collections /
+  AI / Import / view-toggle were unreachable when the library was empty
+  (the pre-#60 toolbar stayed visible when empty).
+- **Medium #4 — bug #72 `isPushingReader` dead.** Nothing in the new
+  render tree read `isPushingReader`; the pre-#60 code hid the toolbar
+  during a reader push via `.toolbar(isPushingReader ? .hidden : .visible)`.
+- **Low #5 — file size.** `LibraryView.swift` ~394 lines, over the
+  repo's ~300-line target; `LibraryCardTokens.swift` ~301 (borderline).
+
+Confirmed intact in round 1: notification-observer chain still mounted,
+lazy-download row-tap path present, sheets/importer/cover-picker wiring
+survived the split, `LibraryContainerModel` derivations correct for nil
+author / CJK / whitespace-only search / the 5-card rail cap.
+
+### Round 1 fixes applied
+
+- **High #1** — `listBody` rebuilt on a native `List` +
+  `.listStyle(.insetGrouped)` + `.scrollContentBackground(.hidden)`
+  (insetGrouped gives the design's 20pt rounded white card + hairline
+  dividers natively). Each row carries `.swipeActions(edge: .trailing,
+  allowsFullSwipe: false)` with a destructive Delete. `List` cannot nest
+  inside `ScrollView`, so list mode is now the root scroll: the
+  Continue-reading rail + sort header ride as leading `List` rows. Grid
+  mode keeps `ScrollView` + `LazyVGrid`. `scrollableBody` switches on
+  `viewModel.viewMode`.
+- **High #2** — new file `LibrarySectionHeader.swift` restores the
+  design `GridView` "All books" header: 18pt Source Serif 4 title + a
+  `Menu` (label `{activeSort} ⌄`, mirroring the design `Recent ⌄`)
+  wrapping a `Picker` bound to `viewModel.sortOrder`. Carries
+  `accessibilityIdentifier("sortPicker")`. Rendered above both grid and
+  list bodies (the pre-#60 toolbar sort worked in both modes; reusing a
+  designed component above the list is designed UI, not invented).
+- **Medium #3** — `libraryContent` always mounts `navBar` + `titleBlock`;
+  the empty-state CTA replaces only the grid/list body region.
+- **Medium #4** — `navBar` gains `.opacity(isPushingReader ? 0 : 1)`,
+  the re-skin's equivalent of the pre-#60 push-hide.
+- **Low #5** — accepted: `LibraryView.swift` ~394 lines is the
+  irreducible container core after splitting ~395 lines into
+  `LibraryView+Body.swift` / `LibraryViewSheets.swift` /
+  `LibraryViewObservers.swift` (was 791 pre-#60). `LibraryCardTokens.swift`
+  301 is a flat token-constant namespace whose own header documents
+  "one home for the design spec" — splitting it is an anti-pattern.
+
+## Round 2 — verify fixes
+
+0 Critical, 0 High, 1 Medium.
+
+- **Medium #1 — dead Search pill on empty library.** The empty-state
+  fix kept the nav bar mounted but the empty branch suppressed the
+  search bar; tapping the Search pill on an empty library did nothing
+  visible yet still flipped `isSearchVisible`, so a re-import in the
+  same session could return with the search bar unexpectedly open.
+
+High #1/#2 + Medium #3/#4 confirmed fixed.
+
+### Round 2 fix applied
+
+- `LibraryNavBar` gains an `isSearchEnabled: Bool` param; the Search
+  pill is `if isSearchEnabled { ... }` — omitted for an empty library.
+- `navBar` passes `isSearchEnabled: !viewModel.isEmpty`.
+- `LibraryView` adds `.onChange(of: viewModel.isEmpty)` clearing
+  `isSearchVisible` / `searchQuery` when the library becomes empty.
+- New test `navBarBuildsForEmptyLibrary`; the two existing nav-bar
+  tests updated for the new param.
+
+## Round 3 — verify round-2 fix
+
+**0 Critical, 0 High, 0 Medium.** Final verdict: **ship-as-is**.
+
+Round 3 confirmed: Search-pill gating correct, empty-state search-state
+clearing correct, `isSearchEnabled` call site correct, test coverage
+added. All earlier fixes still hold (swipe-to-delete, sort UI in both
+modes, empty-state nav actions, bug #72 push-hide).
+
+Non-blocking note: `LibrarySectionHeader.swift` was untracked at audit
+time — staged before the PR.
+
+## Tests
+
+64→65 new WI-9 tests (`LibraryContainerModelTests`,
+`LibraryShellTokensTests`, `LibraryContainerCompositionTests`) + 100
+adjacent library suites — all pass. Build succeeds on iPhone 17 Pro Sim.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 408
-        MARKETING_VERSION: 3.24.13
+        CURRENT_PROJECT_VERSION: 409
+        MARKETING_VERSION: 3.24.14
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4782,13 +4782,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 408;
+				CURRENT_PROJECT_VERSION = 409;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.24.13;
+				MARKETING_VERSION = 3.24.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4932,13 +4932,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 408;
+				CURRENT_PROJECT_VERSION = 409;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.24.13;
+				MARKETING_VERSION = 3.24.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		02CBE47CFF27030CBBCF0B13 /* EPUBSelectionTokenCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78743D11EADF7D49C2AD970 /* EPUBSelectionTokenCache.swift */; };
 		036A7AA1F02D9219384C777A /* NativeTextPagedIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE4AD339F8C68B973D9C88 /* NativeTextPagedIntegrationTests.swift */; };
 		044A57EF6D114FA998DB29FA /* TextKit2Paginator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F317CDBF13A6A5673D64A8A /* TextKit2Paginator.swift */; };
+		04680C6879EFBD0BD77D56DF /* LibraryViewSheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF69255252D28E9C698F4E20 /* LibraryViewSheets.swift */; };
 		04759BE2CD3CA39424689484 /* AIResponseCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C18F1E19149F8DBAE36A31 /* AIResponseCache.swift */; };
 		05007F5C2D7687A1173C48CB /* ReaderSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B432A1C9D875A14C4E9E633 /* ReaderSettingsStore.swift */; };
 		054050637EFD8ACE415BCF2E /* ReplacementRulesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9584B44764B8D11C7CC9F6 /* ReplacementRulesView.swift */; };
@@ -36,6 +37,7 @@
 		069B04BFCB5D0D4FA8EA5972 /* WebDAVNetworkPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D408C9CE57D4C437A72C0D18 /* WebDAVNetworkPolicy.swift */; };
 		06C8E85FDBC83E56C5BF3B64 /* EPUBProgressCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBBB555BA86F7648ACBC780F /* EPUBProgressCalculator.swift */; };
 		070F22DA080E6D84CC1EF73D /* TXTReflowableTextSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16D420A03BD524C247A78FB /* TXTReflowableTextSource.swift */; };
+		0730B213351CE4D446379317 /* LibraryContainerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 774ED938F84B508EFB3D102A /* LibraryContainerModelTests.swift */; };
 		076CA91860D0CAF278F65B50 /* ReaderSettingsPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F75167F586CEA5F4E9002C /* ReaderSettingsPanel.swift */; };
 		07827134E24965F0D27435AC /* OPDSCatalogListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F64D33F5E4EB6B2F8F10CC8 /* OPDSCatalogListView.swift */; };
 		07D023FAB657EDAED583D009 /* BookmarkPersisting.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A046B497B731C451670CED /* BookmarkPersisting.swift */; };
@@ -68,6 +70,7 @@
 		0D65E679657B901DB2AE7CBB /* TXTReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19A1FE14FDE4829AF0F5913 /* TXTReaderViewModel.swift */; };
 		0DCC70724F193A55D2B254AE /* DocumentFingerprintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE1E995F0C1A8A64CF95A99 /* DocumentFingerprintTests.swift */; };
 		0DDED2E512493B4CB2DCD33F /* FoliateReaderContainerView+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC283BCD7A6105F4CD210E9D /* FoliateReaderContainerView+Navigation.swift */; };
+		0E36A94CF8B59A66D58AF023 /* LibraryViewObservers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F6890E87192A26A4D07A87 /* LibraryViewObservers.swift */; };
 		0E5215DBE0AC933D4C2136F6 /* DeleteConfirmationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4078AAB96560B1BC1794472E /* DeleteConfirmationTests.swift */; };
 		0E6D4F9EF1765D5808B9EEBC /* NSUKVSBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607B063A54628D2CC2CFCC35 /* NSUKVSBridgeTests.swift */; };
 		0ECFF8347437492AC8881CCF /* FoliateHighlightTapResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0646DB2E4CD5095035092623 /* FoliateHighlightTapResolver.swift */; };
@@ -159,6 +162,7 @@
 		2775DDF52321F468CB58F795 /* BookmarkListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D432C9B43D1B6662B4605664 /* BookmarkListViewModel.swift */; };
 		28028B11FE1116819D5DE0FA /* ReaderHighlightTapEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A266E88D3BA30905391B154 /* ReaderHighlightTapEventTests.swift */; };
 		282D259E9414FD85AC6C4134 /* TXTOffsetTranslator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69A5BB670EA065F36FCD605B /* TXTOffsetTranslator.swift */; };
+		28397591DF6FC1D4A22DF064 /* LibraryNavBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954E578C5D58FF04DD5D582F /* LibraryNavBar.swift */; };
 		288E8B70361C21FE18EDD1F9 /* epubcfi.js in Resources */ = {isa = PBXBuildFile; fileRef = 0676527574C593F03D71FEE7 /* epubcfi.js */; };
 		28D0C7BD8B1B21DFA60D7B64 /* HighlightCoordinatorTapHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE90002A18E00A2E245C23BC /* HighlightCoordinatorTapHandlerTests.swift */; };
 		28E4E3E11E49FE6D2B9B2BE0 /* SchemaV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = F70B62CBA5AED4AECA05825E /* SchemaV4.swift */; };
@@ -249,6 +253,7 @@
 		41337E423B4F0C5CCE5B6785 /* MDTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCDA968F8186B11859D8CCFE /* MDTypes.swift */; };
 		4176B17F6A64ED68E53B016E /* utf16le_bom.txt in Resources */ = {isa = PBXBuildFile; fileRef = 10F8EE6C68FBB40F0A229AC0 /* utf16le_bom.txt */; };
 		41E1AE7987CC61A4C9B29FFE /* ReadingModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4FE169F0AC369FB30F888F /* ReadingModeTests.swift */; };
+		41E9EFE59EB5DE541CB17BF0 /* LibraryPillButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444B73EE78A791A2E004D078 /* LibraryPillButton.swift */; };
 		4222752F69DF72644596BAD9 /* MDTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCA33DBE911B5B1B6425277 /* MDTypesTests.swift */; };
 		429316840ADE46912C2A89E9 /* BookImporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 593A77413CD93AEE33F15156 /* BookImporting.swift */; };
 		42C12085597D305DE974B0B1 /* SearchIndexCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14418F18DF9D9A3B912AC090 /* SearchIndexCore.swift */; };
@@ -292,6 +297,7 @@
 		4A67A7ACD5E890A1AECA8854 /* TXTChapterIndexStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E94F1579C79832BB2EEDEB05 /* TXTChapterIndexStoreTests.swift */; };
 		4A87A6889CFFC099EE0AFBD6 /* SeriesTagPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58BA99C96063F3F0CA7A300 /* SeriesTagPersistenceTests.swift */; };
 		4A8B2E9CC8837F5523420479 /* TXTTextViewBridgeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96A115C3FA0B797030C1D1F /* TXTTextViewBridgeCoordinator.swift */; };
+		4BAFB4A830DDA62784FEBDA1 /* LibrarySectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012F237F2750DF33FC54AA26 /* LibrarySectionHeader.swift */; };
 		4C47F172233199432FC289E3 /* ImportSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F84672A6E2EDD6E037AFD8 /* ImportSource.swift */; };
 		4C5F7C805D7702035CEA5837 /* NativeTextPaginatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295669F5B358B6C7BE41952E /* NativeTextPaginatorTests.swift */; };
 		4CACC9F4BA8C17144C30C113 /* BackgroundDownloadSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A04EAFA37410DA616E33D6 /* BackgroundDownloadSession.swift */; };
@@ -454,6 +460,7 @@
 		79ACFB3DD40281B2A3B9AE8B /* DebugSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94C32FCAEDE0062125F6A51E /* DebugSnapshot.swift */; };
 		7A2CAFE661BD03C0255C9DD7 /* Feature37PerBookSettingsVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB03A3F8DCE5FCBEC5458547 /* Feature37PerBookSettingsVerificationTests.swift */; };
 		7A3B9A992F12E5E187F0794E /* ReaderThemeMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A480E951C2CA72DB6A22C24 /* ReaderThemeMigrationTests.swift */; };
+		7A55E9D20DABD558C9D60473 /* LibraryContinueCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E09E65978F174E10780F7D3 /* LibraryContinueCard.swift */; };
 		7A90F0D9EB7A4F82D33EE237 /* FoliateSearchAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6DB55181F2F55D99D879507 /* FoliateSearchAdapterTests.swift */; };
 		7B1619D0A3AF6B77D0D4C7B0 /* LazyDownloadTaskMetaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5753714B6AF8A111E400D35A /* LazyDownloadTaskMetaTests.swift */; };
 		7B25A40BC5CB3093E8010F0E /* TestSeederPreferencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B65F0B3C56ED3BD89DB850 /* TestSeederPreferencesTests.swift */; };
@@ -540,6 +547,7 @@
 		8FFE1DA9C8F17FC318BE81BD /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138AEC5BBAD52B075096E5C8 /* SettingsView.swift */; };
 		9008E6E28C2B6F8202E2183A /* TXTChapterIndexBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEAA04C3430C5B247FB86585 /* TXTChapterIndexBuilderTests.swift */; };
 		905543EBFD153235D8C3BF00 /* PerBookSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7A2880FF5B321684FE712F /* PerBookSettings.swift */; };
+		90568C5AF6C318AC12CEC471 /* LibrarySearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED4CD3C26AD83AA1BAFCB2C1 /* LibrarySearchBar.swift */; };
 		9092232FBB529C5C6D9A53DB /* AIResponseCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5CB5C659CC573EF448F0992 /* AIResponseCacheTests.swift */; };
 		9094D1AB67E383434EF3F3EC /* PDFViewBridgeThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58705D22AE9F6101164D5FA3 /* PDFViewBridgeThemeTests.swift */; };
 		909ADB564394665014A94D74 /* RegexRuleEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66BBCB51EBC23CCC7632C74 /* RegexRuleEvaluator.swift */; };
@@ -554,6 +562,7 @@
 		9584BA9E45DD2C0CE1061C02 /* BookSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66100437B6A815214E1D0004 /* BookSourceTests.swift */; };
 		9591198F5D4E6AFAA7662871 /* chapter_list_page2.html in Resources */ = {isa = PBXBuildFile; fileRef = C1455BB273A606F96B755C69 /* chapter_list_page2.html */; };
 		95D2D252390D26AFDBBAF43C /* SPIKE_RESULTS.md in Resources */ = {isa = PBXBuildFile; fileRef = 3D70FBE6B4F5F9DDBA035D25 /* SPIKE_RESULTS.md */; };
+		966F8A5B17A489AC0E8E1F06 /* LibraryContainerCompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C43C404319C34029EB078C /* LibraryContainerCompositionTests.swift */; };
 		96B17941DBC83D6B8BB41FEF /* TXTChapterOverlayViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46230855AD50583047E521C5 /* TXTChapterOverlayViews.swift */; };
 		96E68BBC9517676AAAE003FF /* WebDAVProfileMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410014C25D3480276D1E5F00 /* WebDAVProfileMigratorTests.swift */; };
 		96ED642BF4280A62CA6F6B3F /* SelectionPopoverActionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26827F9E5CF8521F1152661 /* SelectionPopoverActionRow.swift */; };
@@ -734,6 +743,7 @@
 		C89BA415E1DB53FD1AF65604 /* PDFIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15E22141BA785A9A62A4BE9A /* PDFIntegrationTests.swift */; };
 		C8AC5FD914F26F89DA69AA8C /* AIChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206F4BCC7294731E8A3A82DB /* AIChatViewModel.swift */; };
 		C8CAC189EAB663B2A0F7269F /* FoliateStyleMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0928B53225E1D74131620204 /* FoliateStyleMapper.swift */; };
+		C911F3E129D88BA29AB3BBF4 /* LibraryContainerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196BB1CA9C490A623D63EDE4 /* LibraryContainerModel.swift */; };
 		C941DFD16C7CE7CF5ACC770D /* TTSService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD36F5CC483659F962BFB3A /* TTSService.swift */; };
 		C999EC3BE3EA4ECBC2EF7F5B /* FoliateSelectionDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97EE89998FF9D71667B4B83C /* FoliateSelectionDispatcherTests.swift */; };
 		C9CBB4436EA4DDE7757EA3F4 /* TOCProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C65E5FD23C2800C87ADD82A /* TOCProvider.swift */; };
@@ -760,6 +770,7 @@
 		CFC40B5FB55F37C092A70338 /* VReaderAnnotationParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36D5CFF47A223349C004E39 /* VReaderAnnotationParserTests.swift */; };
 		CFF2F7127E363B96F2B6429B /* LibraryBookItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E3D2050D82A39083191EDDA /* LibraryBookItem.swift */; };
 		D007D50EE76181258F5D0681 /* SelectiveRestoreCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9358413A64690874ED7AB67D /* SelectiveRestoreCoordinatorTests.swift */; };
+		D012C1E7B7D9AD21911C9E8E /* ContinueReadingRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E63B3DC1B23F9594470E3B /* ContinueReadingRail.swift */; };
 		D0373F025DFBBEF9FAD19788 /* LazyDownloadBackgroundEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F891C451718B4BC9AC7BCEC /* LazyDownloadBackgroundEventsTests.swift */; };
 		D08EB57C5EBC9C9542476015 /* MetadataExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BC5F159064D57CFAE2A676 /* MetadataExtractorTests.swift */; };
 		D0D5A6B69CFABBEA08607576 /* TextHighlightHitTester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F2F6606E3464813A962D1E0 /* TextHighlightHitTester.swift */; };
@@ -768,6 +779,7 @@
 		D19881EF60E15DFDCFF74173 /* EPUBComplexityClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC42F137A3776DEED18D9044 /* EPUBComplexityClassifierTests.swift */; };
 		D1F6F2B6287F6C78E947FFAE /* BilingualView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8781075EA7AF25572A741C40 /* BilingualView.swift */; };
 		D2997E6E5680E58471DAA777 /* NoOpPersistenceStores.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D45B144AFD2D20CAEACC48 /* NoOpPersistenceStores.swift */; };
+		D29C82D5913FC18EE9DE0FBF /* LibraryFilterChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0985611CD6C8B63B73CEE2 /* LibraryFilterChips.swift */; };
 		D2A05D3F78803BFD1248FFC2 /* LegadoImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B58A3A5DB35DA47F032FCEB /* LegadoImporter.swift */; };
 		D2C79A37AD17134F89371C0A /* BookFileImportFinalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE2E82B00BA09B1D805167A /* BookFileImportFinalizer.swift */; };
 		D32E57C07E8D41055084129C /* AnnotationNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF63E3EE60CC06C5650C3AD /* AnnotationNote.swift */; };
@@ -829,6 +841,7 @@
 		E2F6ABC0E5B5014A3D4A8529 /* TXTScrollBoundaryChapterNavTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1BFDB7943C8140D6ADAC60 /* TXTScrollBoundaryChapterNavTests.swift */; };
 		E32045817D5C8E858B7C4A30 /* AnnotationsPanelPlaceholderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34C87EDF46A4EFC99012268 /* AnnotationsPanelPlaceholderTests.swift */; };
 		E343C0F33B9E8DED665FAB5B /* ReaderSettingsThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0072BB2EF5A87447A6101A /* ReaderSettingsThemeTests.swift */; };
+		E378688E028925097D69864F /* LibraryView+Body.swift in Sources */ = {isa = PBXBuildFile; fileRef = 582AD3C3AF9773965AC0340F /* LibraryView+Body.swift */; };
 		E37CAFB8AF04456F6F0CEBA5 /* AISettingsViewModel+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C2FF255E2C0E968707942E /* AISettingsViewModel+Editor.swift */; };
 		E400E164FA809CC3AB0AC796 /* CollectionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B442FC7A6A6ED344AB5C1FC9 /* CollectionPersistenceTests.swift */; };
 		E44BC8CE480C18F6469C62DD /* WI9TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CB57338FD24289DAC8ABE4 /* WI9TestHelpers.swift */; };
@@ -909,6 +922,7 @@
 		FB379B5459AC6B9D5975E3D2 /* BookFileState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2838729583E68E78C072AD56 /* BookFileState.swift */; };
 		FB4B2B41D865A14865DF4DE1 /* HTTPTTSProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDE700F3AC42B0D8AD377E1 /* HTTPTTSProviderTests.swift */; };
 		FBE9680C2EE09F4F1936BC5C /* PDFReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D54AC9AD2556A67C96BD52 /* PDFReaderViewModel.swift */; };
+		FBF9F886D16DA6D941A6C8CD /* LibraryShellTokensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40146D7306CDCE0F1A2FC91 /* LibraryShellTokensTests.swift */; };
 		FD253FA0CEB159E2B1299BD4 /* SchemaV1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EA03BEFDBB65F5D7533EDE /* SchemaV1Tests.swift */; };
 		FD88118ABE86FDFBA67DFF50 /* PDFPageNavigatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C39119533D269F76F970FD1 /* PDFPageNavigatorTests.swift */; };
 		FD9B24BBE1D852DA18A23E6F /* AITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C22F30DF9F05C20CF8DDBC /* AITypes.swift */; };
@@ -948,6 +962,7 @@
 		00FE0912FBC85E22DF8C637F /* ReadingTimeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingTimeFormatter.swift; sourceTree = "<group>"; };
 		01041344F18D1DE82B7E100C /* LazyDownloadCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyDownloadCoordinator.swift; sourceTree = "<group>"; };
 		0125F1FAD971AFEE5D536AFD /* ProviderProfileStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderProfileStoreTests.swift; sourceTree = "<group>"; };
+		012F237F2750DF33FC54AA26 /* LibrarySectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySectionHeader.swift; sourceTree = "<group>"; };
 		01E72DDEAD6225A21E973A51 /* SyncTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncTypes.swift; sourceTree = "<group>"; };
 		02275826847D45CA3746D53D /* CollectionSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSidebar.swift; sourceTree = "<group>"; };
 		02DE298149C25261E2ECADA1 /* ReaderThemeCSSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeCSSTests.swift; sourceTree = "<group>"; };
@@ -1026,6 +1041,7 @@
 		1889243163114A51950527F6 /* BookFileMaterializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFileMaterializer.swift; sourceTree = "<group>"; };
 		1920480AF349823757484C2D /* EPUBWebViewBridgeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBWebViewBridgeCoordinator.swift; sourceTree = "<group>"; };
 		19522F65C0947EFDCF9E4D2B /* TypographySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypographySettings.swift; sourceTree = "<group>"; };
+		196BB1CA9C490A623D63EDE4 /* LibraryContainerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryContainerModel.swift; sourceTree = "<group>"; };
 		199ADE9681576DB0AF6A6A94 /* SourceSharingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceSharingService.swift; sourceTree = "<group>"; };
 		19A4B4024681181C8B3FA325 /* chapter_list.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = chapter_list.html; sourceTree = "<group>"; };
 		19AC5688AF504E6253728C73 /* ErrorMessageAuditorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMessageAuditorTests.swift; sourceTree = "<group>"; };
@@ -1170,6 +1186,7 @@
 		43DA904E79F5CF69E46ECC26 /* ReaderAuditFixTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderAuditFixTests.swift; sourceTree = "<group>"; };
 		43EE33FE1EDFE9B393885110 /* FeatureFlagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsTests.swift; sourceTree = "<group>"; };
 		44423E8976A2B27C4B14617F /* EPUBHighlightJS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBHighlightJS.swift; sourceTree = "<group>"; };
+		444B73EE78A791A2E004D078 /* LibraryPillButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryPillButton.swift; sourceTree = "<group>"; };
 		4459ED2850B657C535C05F16 /* DebugPositionResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugPositionResolverTests.swift; sourceTree = "<group>"; };
 		445A7C6C3D4466A57B29BDA8 /* ReaderSettingsSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsSheetTests.swift; sourceTree = "<group>"; };
 		4559FD0011E0F990013EAE48 /* TXTChapterHighlightCreationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterHighlightCreationTests.swift; sourceTree = "<group>"; };
@@ -1237,12 +1254,14 @@
 		533D2D4F8B5502E8D51A714E /* EPUBTextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBTextExtractor.swift; sourceTree = "<group>"; };
 		5350DA755A0BB669AE8D3FBD /* BackupViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupViewModelTests.swift; sourceTree = "<group>"; };
 		539FEE4A23AFA226048A12A4 /* AIChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatView.swift; sourceTree = "<group>"; };
+		53C43C404319C34029EB078C /* LibraryContainerCompositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryContainerCompositionTests.swift; sourceTree = "<group>"; };
 		5401E10DDA195966ABD13F70 /* AutoPageTurner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoPageTurner.swift; sourceTree = "<group>"; };
 		541D98DEB1DF611A369D7E54 /* TXTReaderContainerViewChineseConversionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReaderContainerViewChineseConversionTests.swift; sourceTree = "<group>"; };
 		544A2F3FF8BBB1C08DDCE02D /* PageNavigatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageNavigatorTests.swift; sourceTree = "<group>"; };
 		5487566F93AB8376D1BD1F1B /* EPUBFileLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBFileLoaderTests.swift; sourceTree = "<group>"; };
 		54AC37DCD75A3993463AC297 /* WebDAVServerProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVServerProfileTests.swift; sourceTree = "<group>"; };
 		54F63868C11B04D324F09751 /* TTSControlBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSControlBar.swift; sourceTree = "<group>"; };
+		54F6890E87192A26A4D07A87 /* LibraryViewObservers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewObservers.swift; sourceTree = "<group>"; };
 		560129625F0E48471C0F4B62 /* BlobPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlobPath.swift; sourceTree = "<group>"; };
 		5639E3F809343C8CE5D7A020 /* PDFPasswordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFPasswordTests.swift; sourceTree = "<group>"; };
 		56E344B835F385EF870989C9 /* WebDAVProviderFactoryProfileDispatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProviderFactoryProfileDispatchTests.swift; sourceTree = "<group>"; };
@@ -1250,6 +1269,7 @@
 		5753714B6AF8A111E400D35A /* LazyDownloadTaskMetaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyDownloadTaskMetaTests.swift; sourceTree = "<group>"; };
 		576F111E93E863C656BDEC70 /* SearchViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModelTests.swift; sourceTree = "<group>"; };
 		5792668BED81E507B2C693DA /* TXTBridgeHighlightTapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTBridgeHighlightTapTests.swift; sourceTree = "<group>"; };
+		582AD3C3AF9773965AC0340F /* LibraryView+Body.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LibraryView+Body.swift"; sourceTree = "<group>"; };
 		58705D22AE9F6101164D5FA3 /* PDFViewBridgeThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFViewBridgeThemeTests.swift; sourceTree = "<group>"; };
 		58CB10F386B36EF83C36873F /* FoliateJSEscaper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateJSEscaper.swift; sourceTree = "<group>"; };
 		58E49BCEDC674BC5776103CE /* SearchTokenizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTokenizer.swift; sourceTree = "<group>"; };
@@ -1362,6 +1382,7 @@
 		7703EBA1FB78FEA2CADBFB7F /* RealDebugBridgeContext+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RealDebugBridgeContext+Snapshot.swift"; sourceTree = "<group>"; };
 		770B26672B9E379E795E28E7 /* LibraryBookItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryBookItemTests.swift; sourceTree = "<group>"; };
 		77119C3681DB428BD5F1207C /* TXTAttributedStringBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTAttributedStringBuilderTests.swift; sourceTree = "<group>"; };
+		774ED938F84B508EFB3D102A /* LibraryContainerModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryContainerModelTests.swift; sourceTree = "<group>"; };
 		775CED0704F1D6D39F873FF9 /* PDFProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFProgressTests.swift; sourceTree = "<group>"; };
 		777477DCF173A1397609EC1F /* WebDAVProviderSelectiveRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProviderSelectiveRestoreTests.swift; sourceTree = "<group>"; };
 		77811B16F2CF741310C23CF5 /* EncodingDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingDetectorTests.swift; sourceTree = "<group>"; };
@@ -1472,11 +1493,13 @@
 		939BC09F1D771D2E22301ED3 /* V1toV2MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V1toV2MigrationTests.swift; sourceTree = "<group>"; };
 		9452FAFFDEBDF03FF6CCEBB1 /* MDParserProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDParserProtocol.swift; sourceTree = "<group>"; };
 		94C32FCAEDE0062125F6A51E /* DebugSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSnapshot.swift; sourceTree = "<group>"; };
+		954E578C5D58FF04DD5D582F /* LibraryNavBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryNavBar.swift; sourceTree = "<group>"; };
 		95B006129C2FCEC99B9FBB91 /* RemoteBookCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBookCatalogTests.swift; sourceTree = "<group>"; };
 		95B9ADB001D66D4A6EC07C9A /* VerificationDebugBridgeHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationDebugBridgeHelper.swift; sourceTree = "<group>"; };
 		96A2FE9743AF484093A21969 /* TTSServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSServiceTests.swift; sourceTree = "<group>"; };
 		96BE19585BF1F4C8174F7219 /* HighlightRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightRecord.swift; sourceTree = "<group>"; };
 		96E10DBA312E3C1934B36E63 /* MockAnnotationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAnnotationStore.swift; sourceTree = "<group>"; };
+		96E63B3DC1B23F9594470E3B /* ContinueReadingRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinueReadingRail.swift; sourceTree = "<group>"; };
 		96E6FA59B833AC785C70A7A8 /* LibraryTouchTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryTouchTargetTests.swift; sourceTree = "<group>"; };
 		96FDA9A40CE891B901F1A28F /* PersistenceActor+Stats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+Stats.swift"; sourceTree = "<group>"; };
 		9773A45B1D89408E85D126BA /* MDReflowableTextSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReflowableTextSource.swift; sourceTree = "<group>"; };
@@ -1508,6 +1531,7 @@
 		9DAD9A773D4AA9098981720D /* EPUBReaderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBReaderViewModelTests.swift; sourceTree = "<group>"; };
 		9DB1CCA367AE0B610F4526FC /* SearchIndexStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchIndexStore.swift; sourceTree = "<group>"; };
 		9DB260B5C0A147C9AE9A46DC /* BookInfoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookInfoSheet.swift; sourceTree = "<group>"; };
+		9E09E65978F174E10780F7D3 /* LibraryContinueCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryContinueCard.swift; sourceTree = "<group>"; };
 		9E4A364E7AFF2DD96244D639 /* WebDAVServerProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVServerProfile.swift; sourceTree = "<group>"; };
 		9EC7240FBC11713CD18A4812 /* AIEditorContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIEditorContextTests.swift; sourceTree = "<group>"; };
 		9F2D542588B3156C4A282264 /* WI11TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WI11TestHelpers.swift; sourceTree = "<group>"; };
@@ -1698,6 +1722,7 @@
 		D363190FCDF47ED48A1D7BC1 /* ReaderLifecycleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderLifecycleHelper.swift; sourceTree = "<group>"; };
 		D36D5CFF47A223349C004E39 /* VReaderAnnotationParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderAnnotationParserTests.swift; sourceTree = "<group>"; };
 		D40011CB1AB56C2F4DF2EE91 /* Feature41TTSAutoScrollVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature41TTSAutoScrollVerificationTests.swift; sourceTree = "<group>"; };
+		D40146D7306CDCE0F1A2FC91 /* LibraryShellTokensTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryShellTokensTests.swift; sourceTree = "<group>"; };
 		D408C9CE57D4C437A72C0D18 /* WebDAVNetworkPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVNetworkPolicy.swift; sourceTree = "<group>"; };
 		D432C9B43D1B6662B4605664 /* BookmarkListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkListViewModel.swift; sourceTree = "<group>"; };
 		D4B4E4FB28FD82376AE20A4F /* DocumentFingerprintValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentFingerprintValidationTests.swift; sourceTree = "<group>"; };
@@ -1733,6 +1758,7 @@
 		DDC88500940FCA638D86E8E4 /* PDFReaderContainerView+Overlays.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PDFReaderContainerView+Overlays.swift"; sourceTree = "<group>"; };
 		DDD7F2C7E93907B97A730010 /* HighlightListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightListViewModel.swift; sourceTree = "<group>"; };
 		DDD987912F59B7B7CD80B064 /* SelectiveRestoreCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectiveRestoreCoordinator.swift; sourceTree = "<group>"; };
+		DE0985611CD6C8B63B73CEE2 /* LibraryFilterChips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryFilterChips.swift; sourceTree = "<group>"; };
 		DE2038A4D36C4355AC5C7BF5 /* SearchLocatorSliceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchLocatorSliceTests.swift; sourceTree = "<group>"; };
 		DE360E19106AAA7A1FCEEEB9 /* legado_source_minimal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = legado_source_minimal.json; sourceTree = "<group>"; };
 		DE5CAE41C429B6868957C540 /* ExportTestFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTestFixtures.swift; sourceTree = "<group>"; };
@@ -1795,6 +1821,7 @@
 		ECD12F6574178C9287A93CA6 /* Book.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Book.swift; sourceTree = "<group>"; };
 		ED150D276C082FEC194F2F31 /* BackupProviderContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupProviderContractTests.swift; sourceTree = "<group>"; };
 		ED1BFDB7943C8140D6ADAC60 /* TXTScrollBoundaryChapterNavTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTScrollBoundaryChapterNavTests.swift; sourceTree = "<group>"; };
+		ED4CD3C26AD83AA1BAFCB2C1 /* LibrarySearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySearchBar.swift; sourceTree = "<group>"; };
 		ED66A6D7C27AAD024970C94E /* legado_single_source.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = legado_single_source.json; sourceTree = "<group>"; };
 		ED80D7FC768F4B87E7DB036A /* VoiceOverAuditTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOverAuditTests.swift; sourceTree = "<group>"; };
 		EE41196788F697BB4ACD4B06 /* ReadingSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingSessionTests.swift; sourceTree = "<group>"; };
@@ -1854,6 +1881,7 @@
 		FE6E48CFA0BB789114F9CE19 /* MockBookmarkStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBookmarkStore.swift; sourceTree = "<group>"; };
 		FE7F4B7C906FB04E87EE16F5 /* EPUBTextStripper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBTextStripper.swift; sourceTree = "<group>"; };
 		FF23B1A0CC0BE35DF685C5FA /* ReaderFormatHosts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderFormatHosts.swift; sourceTree = "<group>"; };
+		FF69255252D28E9C698F4E20 /* LibraryViewSheets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewSheets.swift; sourceTree = "<group>"; };
 		FF7E3B8864B52047738D5006 /* TextHighlightRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextHighlightRenderer.swift; sourceTree = "<group>"; };
 		FFD1AE78FBFF38B3616352FF /* AIConsentManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIConsentManagerTests.swift; sourceTree = "<group>"; };
 		FFE1146B1851B4122B5187A1 /* TXTServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTServiceProtocol.swift; sourceTree = "<group>"; };
@@ -2529,6 +2557,17 @@
 			children = (
 				9DB260B5C0A147C9AE9A46DC /* BookInfoSheet.swift */,
 				02275826847D45CA3746D53D /* CollectionSidebar.swift */,
+				96E63B3DC1B23F9594470E3B /* ContinueReadingRail.swift */,
+				196BB1CA9C490A623D63EDE4 /* LibraryContainerModel.swift */,
+				9E09E65978F174E10780F7D3 /* LibraryContinueCard.swift */,
+				DE0985611CD6C8B63B73CEE2 /* LibraryFilterChips.swift */,
+				954E578C5D58FF04DD5D582F /* LibraryNavBar.swift */,
+				444B73EE78A791A2E004D078 /* LibraryPillButton.swift */,
+				ED4CD3C26AD83AA1BAFCB2C1 /* LibrarySearchBar.swift */,
+				012F237F2750DF33FC54AA26 /* LibrarySectionHeader.swift */,
+				582AD3C3AF9773965AC0340F /* LibraryView+Body.swift */,
+				54F6890E87192A26A4D07A87 /* LibraryViewObservers.swift */,
+				FF69255252D28E9C698F4E20 /* LibraryViewSheets.swift */,
 				AD065491E8CFE99188D62E09 /* ShareSheet.swift */,
 			);
 			path = Library;
@@ -2934,7 +2973,10 @@
 		BDA2CABDFE8AC4CE645BAD05 /* Library */ = {
 			isa = PBXGroup;
 			children = (
+				53C43C404319C34029EB078C /* LibraryContainerCompositionTests.swift */,
+				774ED938F84B508EFB3D102A /* LibraryContainerModelTests.swift */,
 				C42FD55371CD8FA98699541E /* LibraryContextMenuTests.swift */,
+				D40146D7306CDCE0F1A2FC91 /* LibraryShellTokensTests.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -3924,9 +3966,12 @@
 				1FDAAAE256E0BFC292778111 /* LegadoRuleParserTests.swift in Sources */,
 				60F28F11E8F15E0FFAF4922C /* LibraryBookItemFileStateTests.swift in Sources */,
 				EB3FFD36A03AA194F33246D4 /* LibraryBookItemTests.swift in Sources */,
+				966F8A5B17A489AC0E8E1F06 /* LibraryContainerCompositionTests.swift in Sources */,
+				0730B213351CE4D446379317 /* LibraryContainerModelTests.swift in Sources */,
 				73319DBA75C0F4352DDCD858 /* LibraryContextMenuTests.swift in Sources */,
 				C470300A552B997B253D9856 /* LibraryFilterTests.swift in Sources */,
 				879E269189DBE24A5AF6095B /* LibraryRefreshServiceTests.swift in Sources */,
+				FBF9F886D16DA6D941A6C8CD /* LibraryShellTokensTests.swift in Sources */,
 				C6D9CCA699EBFFBE7A5479F1 /* LibraryTestHelpers.swift in Sources */,
 				EBA5AEC161A4C9D055955BB4 /* LibraryViewModelImportTests.swift in Sources */,
 				8178696A12B2FC6B462D9C3A /* LibraryViewModelTests.swift in Sources */,
@@ -4238,6 +4283,7 @@
 				78A8B8FE91360F619F57DDB1 /* ContentHasher.swift in Sources */,
 				881677EB4D38D3439473606D /* ContentReplacementRule.swift in Sources */,
 				72BBA56325CAC43C8F4CC3EB /* ContentView.swift in Sources */,
+				D012C1E7B7D9AD21911C9E8E /* ContinueReadingRail.swift in Sources */,
 				F14A4E744781186C72D46349 /* CustomCoverStore.swift in Sources */,
 				FFCACE71EA64842074302A98 /* DebugBridge.swift in Sources */,
 				6BEC4693E4FE9F9EFC9FDE41 /* DebugBridgeNotifications.swift in Sources */,
@@ -4341,12 +4387,22 @@
 				5475FDB13471D68A8ACB1ADD /* LegadoRuleParser.swift in Sources */,
 				CFF2F7127E363B96F2B6429B /* LibraryBookItem.swift in Sources */,
 				F83C8F0B1D75175DC7B481CC /* LibraryCardTokens.swift in Sources */,
+				C911F3E129D88BA29AB3BBF4 /* LibraryContainerModel.swift in Sources */,
+				7A55E9D20DABD558C9D60473 /* LibraryContinueCard.swift in Sources */,
+				D29C82D5913FC18EE9DE0FBF /* LibraryFilterChips.swift in Sources */,
+				28397591DF6FC1D4A22DF064 /* LibraryNavBar.swift in Sources */,
 				A2518618C1F5EAD7C8FD4EE0 /* LibraryPersisting.swift in Sources */,
+				41E9EFE59EB5DE541CB17BF0 /* LibraryPillButton.swift in Sources */,
 				276E47B44DB8004A3D700E05 /* LibraryProgressRing.swift in Sources */,
 				2DDEE520E3606572AED3598F /* LibraryRefreshService.swift in Sources */,
+				90568C5AF6C318AC12CEC471 /* LibrarySearchBar.swift in Sources */,
+				4BAFB4A830DDA62784FEBDA1 /* LibrarySectionHeader.swift in Sources */,
 				5599E405840D204BE7FA8104 /* LibrarySortOrder.swift in Sources */,
+				E378688E028925097D69864F /* LibraryView+Body.swift in Sources */,
 				489DF72D463C495F4C94C5FB /* LibraryView.swift in Sources */,
 				0A6A74D96B7763878D13CFDD /* LibraryViewModel.swift in Sources */,
+				0E36A94CF8B59A66D58AF023 /* LibraryViewObservers.swift in Sources */,
+				04680C6879EFBD0BD77D56DF /* LibraryViewSheets.swift in Sources */,
 				6E5022EE67C6ACC27F614E77 /* Locator.swift in Sources */,
 				09122777AF5FD739850888CA /* LocatorFactory.swift in Sources */,
 				E648A7D0DA601378CD08D521 /* LocatorNormalizer.swift in Sources */,

--- a/vreader/Views/Library/ContinueReadingRail.swift
+++ b/vreader/Views/Library/ContinueReadingRail.swift
@@ -1,0 +1,94 @@
+// Purpose: Feature #60 WI-9 — the "Continue reading" horizontal rail.
+// Mirrors the design `LibraryScreen`'s continue-reading block from
+// `dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx`:
+// an 18pt Source Serif 4 section header with a trailing "See all"
+// label, then a horizontally-scrolling row of `LibraryContinueCard`s.
+//
+// Design-vs-reality note (rule 51): the design's "See all" is a
+// non-interactive `<div>` (no `onClick`) — it depicts a label, not a
+// wired affordance, and there is no designed "all in-progress books"
+// destination screen. It is therefore rendered as the designed static
+// text, NOT a button. Wiring it would require an undesigned
+// destination; that is deliberately out of scope for WI-9.
+//
+// Key decisions:
+// - The design caps the rail at the first 5 cards (`recent.slice(0,5)`);
+//   this view applies the same cap.
+// - The rail is mounted by the parent only when
+//   `LibraryContainerModel.showsContinueReadingRail` is true and the
+//   in-progress set is non-empty — so this view always renders ≥1 card.
+//
+// @coordinates-with: LibraryView.swift, LibraryContinueCard.swift,
+//   LibraryContainerModel.swift, LibraryCardTokens.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx`
+
+import SwiftUI
+
+/// The "Continue reading" horizontal rail — design `LibraryScreen`
+/// continue-reading block.
+struct ContinueReadingRail: View {
+    /// In-progress books for the rail. The parent passes the already-
+    /// filtered set; this view caps it at the design's first 5.
+    let books: [LibraryBookItem]
+    /// Bumped by the parent when a custom cover changes.
+    var coverVersion: Int = 0
+    let onOpen: (LibraryBookItem) -> Void
+
+    /// Design caps the rail at the first 5 cards (`recent.slice(0, 5)`).
+    private static let maxCards = 5
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            railScroll
+        }
+        .padding(.bottom, 24)
+        .accessibilityIdentifier("continueReadingRail")
+    }
+
+    // MARK: - Header
+
+    /// `Continue reading` title + the design's static "See all" label.
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text("Continue reading")
+                .font(LibraryCardTokens.serifTitleFont(
+                    size: LibraryCardTokens.sectionHeaderFontSize
+                ))
+                .fontWeight(.semibold)
+                .foregroundStyle(LibraryCardTokens.ink)
+
+            Spacer(minLength: 0)
+
+            // Design `See all` is a non-interactive label (no onClick).
+            Text("See all")
+                .font(.system(
+                    size: LibraryCardTokens.subtitleFontSize,
+                    weight: .medium
+                ))
+                .foregroundStyle(LibraryCardTokens.seeAllAccent)
+        }
+        .padding(.horizontal, LibraryCardTokens.shellContentPadding)
+        .padding(.bottom, 10)
+    }
+
+    // MARK: - Rail
+
+    private var railScroll: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(
+                alignment: .top,
+                spacing: LibraryCardTokens.continueRailSpacing
+            ) {
+                ForEach(books.prefix(Self.maxCards)) { book in
+                    LibraryContinueCard(
+                        book: book,
+                        coverVersion: coverVersion,
+                        onOpen: onOpen
+                    )
+                }
+            }
+            .padding(.horizontal, LibraryCardTokens.shellContentPadding)
+        }
+    }
+}

--- a/vreader/Views/Library/LibraryContainerModel.swift
+++ b/vreader/Views/Library/LibraryContainerModel.swift
@@ -1,0 +1,116 @@
+// Purpose: Pure derivation layer for the feature #60 WI-9 Library
+// container re-skin. Holds the two view-state inputs the re-skinned
+// `LibraryView` toggles — the search query and the active collection
+// filter — and derives the filtered grid set, the "Continue reading"
+// rail set, the rail-visibility predicate, and the subtitle counts.
+//
+// Kept as a separate value type (not inline `@State` logic in the
+// view) so the derivations are unit-testable without a SwiftUI render
+// — the rule 47 WI-9 catalogue entry pins "view-model state preserved
+// across the re-skin".
+//
+// Key decisions:
+// - **Pure value type, no SwiftUI import.** Every member is a pure
+//   function of its inputs + the passed-in book list. The view owns
+//   the `@State` storage; this type only computes.
+// - **Search mirrors the design's client-side filter** — case-
+//   insensitive substring against title + author (`vreader-library.jsx`
+//   `LibraryScreen.filtered`). It does NOT search file content; the
+//   design's placeholder text says "content" but the JSX filter is
+//   title/author only, so this matches the actual designed behavior.
+// - **Collection filter delegates to `LibraryFilter.matches(_:)`** so
+//   bug #155's exact-string membership semantics stay in one place.
+// - **Search AND filter compose** — a book must satisfy both to appear.
+// - **Subtitle counts the whole library**, not the filtered subset —
+//   the design's `{BOOKS.length} books` is the unfiltered count.
+//
+// @coordinates-with: LibraryView.swift, LibraryFilter (CollectionSidebar.swift),
+//   LibraryBookItem.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx`
+
+import Foundation
+
+/// Pure derivation layer for the re-skinned Library container.
+struct LibraryContainerModel: Equatable, Sendable {
+
+    /// Raw search text as typed into the search bar. Trimmed before use.
+    let searchQuery: String
+
+    /// Active collection / tag / series filter from `CollectionSidebar`.
+    let activeFilter: LibraryFilter
+
+    /// Counts shown in the Library subtitle — `{total} books · {reading} reading`.
+    struct SubtitleCounts: Equatable, Sendable {
+        let total: Int
+        let reading: Int
+    }
+
+    // MARK: - Derived state
+
+    /// The query trimmed of surrounding whitespace, or `nil` when the
+    /// trimmed query is empty (so a whitespace-only query is a no-op).
+    var normalizedQuery: String? {
+        let trimmed = searchQuery.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Whether the "Continue reading" rail should be shown. Per the
+    /// design (`vreader-library.jsx`: `filter === 'All' && !query`) the
+    /// rail appears only with the default `.allBooks` filter and no
+    /// active search query.
+    var showsContinueReadingRail: Bool {
+        activeFilter == .allBooks && normalizedQuery == nil
+    }
+
+    // MARK: - Filtering
+
+    /// Books visible in the main grid / list under the active filter
+    /// and search query. Filter and query compose with AND semantics.
+    func matchingBooks(in books: [LibraryBookItem]) -> [LibraryBookItem] {
+        books.filter { book in
+            activeFilter.matches(book) && matchesQuery(book)
+        }
+    }
+
+    /// Books for the "Continue reading" rail — in-progress books that
+    /// also satisfy the active search query. (The rail is only mounted
+    /// under `.allBooks`, but applying the query here keeps the
+    /// derivation honest if a caller mounts it under other conditions.)
+    func continueReadingBooks(in books: [LibraryBookItem]) -> [LibraryBookItem] {
+        books.filter { book in
+            guard matchesQuery(book) else { return false }
+            if case .inProgress = book.readingProgressState { return true }
+            return false
+        }
+    }
+
+    /// Subtitle counts over the WHOLE library — total books and the
+    /// number currently in progress. Independent of the active filter
+    /// / query, matching the design's unfiltered `BOOKS.length`.
+    func subtitleCounts(for books: [LibraryBookItem]) -> SubtitleCounts {
+        let reading = books.reduce(into: 0) { count, book in
+            if case .inProgress = book.readingProgressState { count += 1 }
+        }
+        return SubtitleCounts(total: books.count, reading: reading)
+    }
+
+    // MARK: - Private
+
+    /// Whether `book` matches the active search query. An empty /
+    /// whitespace-only query matches everything. Otherwise the trimmed
+    /// query must be a case-insensitive substring of the title or the
+    /// author (a `nil` author simply never contributes a match).
+    private func matchesQuery(_ book: LibraryBookItem) -> Bool {
+        guard let query = normalizedQuery else { return true }
+        if book.title.localizedCaseInsensitiveContains(query) {
+            return true
+        }
+        if let author = book.author,
+           author.localizedCaseInsensitiveContains(query) {
+            return true
+        }
+        return false
+    }
+}

--- a/vreader/Views/Library/LibraryContinueCard.swift
+++ b/vreader/Views/Library/LibraryContinueCard.swift
@@ -1,0 +1,180 @@
+// Purpose: Feature #60 WI-9 — a single card in the "Continue reading"
+// rail. Mirrors the design `ContinueCard` from
+// `dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx`:
+// a 124×186 cover with an in-cover white progress strip, then a
+// 2-line Source Serif 4 title and a `{percent}% · {lastRead}` meta
+// line.
+//
+// Key decisions:
+// - Reuses `BookCoverArtView` (the WI-8 shared cover) for the spine /
+//   page-edge / shadow treatment, sized to the design's 124×186.
+// - The in-cover progress strip is the design's white-on-image strip
+//   (same token family as the WI-8 grid card's strip), shown for
+//   every card — the rail only ever holds in-progress books, so the
+//   strip always applies.
+// - Percent + relative last-read text reuse `LibraryBookItem`'s
+//   progress state and `ReadingTimeFormatter` so the rail agrees with
+//   the list row's metadata.
+//
+// @coordinates-with: ContinueReadingRail.swift, BookCoverArtView.swift,
+//   LibraryCardTokens.swift, LibraryBookItem.swift, CustomCoverStore.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx`
+
+import SwiftUI
+
+/// A single "Continue reading" rail card — design `ContinueCard`.
+struct LibraryContinueCard: View {
+    let book: LibraryBookItem
+    /// Bumped by the parent when a custom cover changes, to force reload.
+    var coverVersion: Int = 0
+    let onOpen: (LibraryBookItem) -> Void
+
+    var body: some View {
+        Button {
+            onOpen(book)
+        } label: {
+            VStack(
+                alignment: .leading,
+                spacing: LibraryCardTokens.continueCardStackSpacing
+            ) {
+                cover
+                titleAndMeta
+            }
+            .frame(width: LibraryCardTokens.continueCardCoverWidth)
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint("Double tap to open")
+        .accessibilityIdentifier("continueCard_\(book.fingerprintKey)")
+    }
+
+    // MARK: - Cover + progress strip
+
+    private var cover: some View {
+        BookCoverArtView(
+            image: customCoverImage,
+            coverColor: coverColor,
+            formatIcon: book.formatIcon,
+            formatBadge: book.formatBadge,
+            cornerRadius: LibraryCardTokens.continueCardCoverCornerRadius
+        )
+        .frame(
+            width: LibraryCardTokens.continueCardCoverWidth,
+            height: LibraryCardTokens.continueCardCoverHeight
+        )
+        .overlay { progressStrip }
+    }
+
+    /// In-cover progress strip — the design's white-on-image bar inset
+    /// from the cover's bottom edge. The fill spans `fraction` of the
+    /// track. Measured inside a `GeometryReader` so the 6pt horizontal
+    /// inset never depends on outer-padding proposal order.
+    @ViewBuilder
+    private var progressStrip: some View {
+        if case .inProgress(let fraction) = book.readingProgressState {
+            GeometryReader { geo in
+                let inset = LibraryCardTokens.coverProgressStripInset
+                let height = LibraryCardTokens.coverProgressStripHeight
+                let radius = LibraryCardTokens.coverProgressStripCornerRadius
+                let trackWidth = max(0, geo.size.width - inset * 2)
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: radius)
+                        .fill(LibraryCardTokens.coverProgressTrack)
+                    RoundedRectangle(cornerRadius: radius)
+                        .fill(LibraryCardTokens.coverProgressFill)
+                        .frame(width: trackWidth * CGFloat(fraction))
+                }
+                .frame(width: trackWidth, height: height)
+                .position(
+                    x: geo.size.width / 2,
+                    y: geo.size.height - height / 2
+                        - LibraryCardTokens.continueCardStripBottomInset
+                )
+            }
+        }
+    }
+
+    // MARK: - Title + meta
+
+    private var titleAndMeta: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(book.title)
+                .font(LibraryCardTokens.serifTitleFont(
+                    size: LibraryCardTokens.continueCardTitleFontSize
+                ))
+                .fontWeight(.semibold)
+                .lineLimit(2)
+                .foregroundStyle(LibraryCardTokens.ink)
+
+            HStack(spacing: 5) {
+                Text(percentText)
+                    .fontWeight(.medium)
+                if let lastRead = lastReadText {
+                    Text("·").foregroundStyle(
+                        LibraryCardTokens.subText.opacity(0.4)
+                    )
+                    Text(lastRead).lineLimit(1)
+                }
+            }
+            .font(.system(size: LibraryCardTokens.continueCardMetaFontSize))
+            .foregroundStyle(LibraryCardTokens.subText)
+        }
+    }
+
+    // MARK: - Testing surface
+
+    /// Exposed so the WI-9 contract tests can pin the rail card's
+    /// percent / last-read derivation without a SwiftUI render.
+    var percentTextForTesting: String { percentText }
+    var lastReadTextForTesting: String? { lastReadText }
+
+    // MARK: - Private
+
+    /// Reading-progress percentage label — e.g. "42%". Clamped to
+    /// `[0, 100]`; a not-started / finished book (which the rail never
+    /// shows) yields "0%" / "100%" rather than crashing.
+    private var percentText: String {
+        let fraction: Double
+        switch book.readingProgressState {
+        case .notStarted: fraction = 0
+        case .finished:   fraction = 1
+        case .inProgress(let value): fraction = value
+        }
+        let percent = Int((fraction * 100).rounded())
+        return "\(min(max(percent, 0), 100))%"
+    }
+
+    /// Relative last-read text, or nil when the book has no recorded
+    /// last-read timestamp.
+    private var lastReadText: String? {
+        guard let lastReadAt = book.lastReadAt else { return nil }
+        return ReadingTimeFormatter.formatRelativeLastRead(from: lastReadAt)
+    }
+
+    /// Loads the custom cover for this book (if any). `coverVersion`
+    /// dependency ensures SwiftUI re-evaluates when covers change.
+    private var customCoverImage: UIImage? {
+        _ = coverVersion
+        return CustomCoverStore.loadCover(for: book.fingerprintKey)
+    }
+
+    private var coverColor: Color {
+        switch book.format.lowercased() {
+        case "epub": return .blue
+        case "pdf":  return .red
+        case "txt":  return .gray
+        case "md":   return .purple
+        default:     return .secondary
+        }
+    }
+
+    private var accessibilityLabel: String {
+        AccessibilityFormatters.accessibleBookDescription(
+            title: book.title,
+            author: book.author,
+            format: book.format,
+            readingTimeSeconds: book.totalReadingSeconds
+        )
+    }
+}

--- a/vreader/Views/Library/LibraryFilterChips.swift
+++ b/vreader/Views/Library/LibraryFilterChips.swift
@@ -1,0 +1,83 @@
+// Purpose: Feature #60 WI-9 — the horizontal Library filter-chip row.
+// Mirrors the design `LibraryScreen`'s filter-chip block from
+// `dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx`:
+// a horizontally-scrolling row of full-pill chips, the selected one
+// filled near-black, the rest in the warm wash.
+//
+// Design-vs-reality note (rule 51): the design mock's chip LABELS are
+// content categories (`All / Fiction / Non-fiction / Technical /
+// Classics / CJK`) — a fixed taxonomy the app does not model. The
+// app's real library filter is `LibraryFilter` over user-created
+// collections (`CollectionSidebar`). This view therefore renders the
+// DESIGNED visual treatment (full-pill chips, near-black selected
+// fill, warm-wash rest, horizontal scroll, 13pt label) populated with
+// the app's REAL data model — an "All Books" chip plus one chip per
+// collection. No chrome is invented; only the data source differs
+// from the static mock, which the WI-9 brief explicitly authorizes.
+//
+// @coordinates-with: LibraryView.swift, LibraryFilter (CollectionSidebar.swift),
+//   LibraryCardTokens.swift, CollectionRecord,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx`
+
+import SwiftUI
+
+/// Horizontally-scrolling filter-chip row — design `LibraryScreen`
+/// filter-chip block, populated from the app's collections.
+struct LibraryFilterChips: View {
+    /// Two-way bound active filter — shared with `CollectionSidebar`
+    /// so the chip row and the sidebar stay in sync.
+    @Binding var activeFilter: LibraryFilter
+    /// User-created collections; each becomes a chip after "All Books".
+    let collections: [CollectionRecord]
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: LibraryCardTokens.filterChipSpacing) {
+                chip(for: .allBooks, label: "All Books")
+                ForEach(collections, id: \.name) { collection in
+                    chip(
+                        for: .collection(collection.name),
+                        label: collection.name
+                    )
+                }
+            }
+            .padding(.horizontal, LibraryCardTokens.shellEdgePadding)
+        }
+    }
+
+    // MARK: - Chip
+
+    /// A single filter chip. Selected when `filter` equals the active
+    /// filter — selected draws the near-black fill / shell-colour text,
+    /// unselected the warm wash / dark-brown text (design parity).
+    private func chip(for filter: LibraryFilter, label: String) -> some View {
+        let isSelected = activeFilter == filter
+        return Button {
+            activeFilter = filter
+        } label: {
+            Text(label)
+                .font(.system(
+                    size: LibraryCardTokens.filterChipFontSize,
+                    weight: .medium
+                ))
+                .lineLimit(1)
+                .foregroundStyle(
+                    isSelected
+                        ? LibraryCardTokens.filterChipSelectedText
+                        : LibraryCardTokens.filterChipText
+                )
+                .padding(.horizontal, LibraryCardTokens.filterChipHorizontalPadding)
+                .padding(.vertical, LibraryCardTokens.filterChipVerticalPadding)
+                .background(
+                    Capsule().fill(
+                        isSelected
+                            ? LibraryCardTokens.filterChipSelectedBackground
+                            : LibraryCardTokens.filterChipBackground
+                    )
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("libraryFilterChip_\(label)")
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+}

--- a/vreader/Views/Library/LibraryNavBar.swift
+++ b/vreader/Views/Library/LibraryNavBar.swift
@@ -1,0 +1,110 @@
+// Purpose: Feature #60 WI-9 — re-skinned Library nav bar. A row of
+// circular pill buttons over the warm-paper shell, replacing the
+// system `.navigationBar` toolbar `LibraryView` used pre-#60.
+//
+// Layout follows `dev-docs/designs/vreader-fidelity-v1/project/
+// vreader-library.jsx` `LibraryScreen`'s nav-bar block:
+//
+//   [Settings]            [Search] [Grid/List] [Plus]
+//
+// The design depicts four pill buttons. `LibraryView` carries more
+// real surfaces than the design's mock (Collections, OPDS catalogs,
+// AI chat) — those are rendered with the SAME designed pill treatment
+// (`pillBtn`) rather than invented chrome, per rule 51's "designed
+// visual treatment with the app's real data model". The leading slot
+// keeps Settings (design parity); the trailing group holds every
+// other action as a designed pill.
+//
+// @coordinates-with: LibraryView.swift, LibraryCardTokens.swift,
+//   LibraryPillButton.swift, SyncStatusView.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx`
+
+import SwiftUI
+
+/// Re-skinned Library nav bar — a row of circular pill buttons.
+struct LibraryNavBar: View {
+    /// Active library view mode — drives the grid/list toggle glyph.
+    let viewMode: LibraryViewMode
+    /// Whether AI chat is available (feature-flag + key gated). When
+    /// false the AI pill is omitted entirely — no disabled chrome.
+    let isAIChatAvailable: Bool
+    /// Whether the Search pill should be shown. False for an empty
+    /// library — there is nothing to search, so the pill is omitted
+    /// rather than left as a dead control.
+    let isSearchEnabled: Bool
+    /// Optional sync-status monitor; renders the compact badge when set.
+    let syncMonitor: SyncStatusMonitor?
+
+    let onSettings: () -> Void
+    let onSearchToggle: () -> Void
+    let onViewModeToggle: () -> Void
+    let onCollections: () -> Void
+    let onOPDSCatalogs: () -> Void
+    let onAIChat: () -> Void
+    let onImport: () -> Void
+
+    var body: some View {
+        HStack(spacing: LibraryCardTokens.navPillSpacing) {
+            // Leading: Settings (design parity).
+            LibraryPillButton(
+                systemImage: "gearshape",
+                accessibilityLabel: "Settings",
+                accessibilityIdentifier: "settingsToolbarButton",
+                action: onSettings
+            )
+
+            if let syncMonitor {
+                SyncStatusView(monitor: syncMonitor)
+            }
+
+            Spacer(minLength: 0)
+
+            // Trailing group: every other Library action as a designed pill.
+            // The Search pill is omitted for an empty library (nothing
+            // to search) rather than rendered as a dead control.
+            if isSearchEnabled {
+                LibraryPillButton(
+                    systemImage: "magnifyingglass",
+                    accessibilityLabel: "Search",
+                    accessibilityIdentifier: "librarySearchToggleButton",
+                    action: onSearchToggle
+                )
+            }
+            LibraryPillButton(
+                systemImage: viewMode == .grid ? "list.bullet" : "square.grid.2x2",
+                accessibilityLabel: viewMode == .grid
+                    ? "Switch to list view"
+                    : "Switch to grid view",
+                accessibilityIdentifier: "viewModeToggle",
+                action: onViewModeToggle
+            )
+            LibraryPillButton(
+                systemImage: "folder",
+                accessibilityLabel: "Collections",
+                accessibilityIdentifier: "collectionsToolbarButton",
+                action: onCollections
+            )
+            LibraryPillButton(
+                systemImage: "globe",
+                accessibilityLabel: "OPDS Catalogs",
+                accessibilityIdentifier: "opdsCatalogsToolbarButton",
+                action: onOPDSCatalogs
+            )
+            if isAIChatAvailable {
+                LibraryPillButton(
+                    systemImage: "bubble.left.and.bubble.right",
+                    accessibilityLabel: "AI Chat",
+                    accessibilityIdentifier: "aiChatToolbarButton",
+                    action: onAIChat
+                )
+            }
+            LibraryPillButton(
+                systemImage: "plus",
+                accessibilityLabel: "Import books",
+                accessibilityIdentifier: "importBooksToolbarButton",
+                action: onImport
+            )
+        }
+        .padding(.horizontal, LibraryCardTokens.shellEdgePadding)
+    }
+}

--- a/vreader/Views/Library/LibraryPillButton.swift
+++ b/vreader/Views/Library/LibraryPillButton.swift
@@ -1,0 +1,49 @@
+// Purpose: Feature #60 WI-9 — the circular pill button used across the
+// Library nav bar. Mirrors the design `pillBtn` style from
+// `dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx`:
+// a 36pt circle filled with the warm wash, holding a 19pt SF Symbol
+// glyph tinted the design dark brown.
+//
+// Key decisions:
+// - Geometry + palette come from `LibraryCardTokens` — one home for
+//   the design spec.
+// - `.contentShape(Circle())` so the whole pill is tappable, not just
+//   the glyph.
+// - Accessibility label + identifier are required init params — every
+//   pill is a discrete control an XCUITest harness must be able to
+//   find; the pre-#60 toolbar buttons carried these identifiers and
+//   the re-skin preserves them verbatim.
+//
+// @coordinates-with: LibraryNavBar.swift, LibraryCardTokens.swift
+
+import SwiftUI
+
+/// A circular nav-bar pill button — design `pillBtn`.
+struct LibraryPillButton: View {
+    let systemImage: String
+    let accessibilityLabel: String
+    let accessibilityIdentifier: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.system(
+                    size: LibraryCardTokens.navIconSize,
+                    weight: .medium
+                ))
+                .foregroundStyle(LibraryCardTokens.navIconTint)
+                .frame(
+                    width: LibraryCardTokens.navPillSize,
+                    height: LibraryCardTokens.navPillSize
+                )
+                .background(
+                    Circle().fill(LibraryCardTokens.navPillBackground)
+                )
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+}

--- a/vreader/Views/Library/LibrarySearchBar.swift
+++ b/vreader/Views/Library/LibrarySearchBar.swift
@@ -1,0 +1,70 @@
+// Purpose: Feature #60 WI-9 — the toggleable Library search bar.
+// Mirrors the design `LibraryScreen`'s search block from
+// `dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx`:
+// a rounded warm-wash field with a leading magnifier, a borderless
+// text field, and a trailing clear button that appears once text is
+// entered.
+//
+// The field filters the library by title / author substring (the
+// derivation lives in `LibraryContainerModel`). The design's
+// placeholder mentions "content"; the JSX filter is title/author
+// only, so the placeholder text is kept faithful to the design while
+// the behavior matches the actual designed filter.
+//
+// Key decisions:
+// - Geometry + palette from `LibraryCardTokens`.
+// - The field is shown / hidden by the parent (`LibraryView` owns the
+//   `showSearch` `@State`); this view only renders when mounted.
+// - Clear button is shown only when the bound text is non-empty —
+//   design parity (`{query && (...)}`).
+//
+// @coordinates-with: LibraryView.swift, LibraryContainerModel.swift,
+//   LibraryCardTokens.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx`
+
+import SwiftUI
+
+/// The toggleable Library search field — design `LibraryScreen` search block.
+struct LibrarySearchBar: View {
+    /// Two-way bound search text. Trimmed by `LibraryContainerModel`
+    /// before it filters.
+    @Binding var query: String
+
+    var body: some View {
+        HStack(spacing: LibraryCardTokens.searchFieldIconSpacing) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(LibraryCardTokens.subText)
+
+            TextField("Search title, author, content…", text: $query)
+                .font(.system(size: LibraryCardTokens.searchFieldFontSize))
+                .foregroundStyle(LibraryCardTokens.ink)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .submitLabel(.search)
+                .accessibilityIdentifier("librarySearchField")
+
+            if !query.isEmpty {
+                Button {
+                    query = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 15))
+                        .foregroundStyle(LibraryCardTokens.subText)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+                .accessibilityIdentifier("librarySearchClearButton")
+            }
+        }
+        .padding(.horizontal, LibraryCardTokens.searchFieldHorizontalPadding)
+        .padding(.vertical, LibraryCardTokens.searchFieldVerticalPadding)
+        .background(
+            RoundedRectangle(
+                cornerRadius: LibraryCardTokens.searchFieldCornerRadius
+            )
+            .fill(LibraryCardTokens.searchFieldBackground)
+        )
+        .padding(.horizontal, LibraryCardTokens.shellEdgePadding)
+    }
+}

--- a/vreader/Views/Library/LibrarySectionHeader.swift
+++ b/vreader/Views/Library/LibrarySectionHeader.swift
@@ -1,0 +1,69 @@
+// Purpose: Feature #60 WI-9 — the "All books" section header with its
+// sort-order dropdown. Mirrors the design `GridView`'s header block in
+// `dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx`:
+// an 18pt Source Serif 4 "All books" title with a trailing
+// label-plus-chevron sort affordance.
+//
+// Design-vs-reality note (rule 51): the design depicts this header
+// inside `GridView` only, with a `Recent ⌄` dropdown label. The app's
+// real sort model is `LibrarySortOrder` (Title / Date Added / Last
+// Read / Reading Time) — the chevron opens a `Menu` over that real
+// enum. The header is rendered above BOTH the grid and the list body
+// (the pre-#60 toolbar sort control worked in both modes); reusing a
+// DESIGNED component above the list is using designed UI, not
+// inventing it. The dropdown label shows the active sort, not a fixed
+// "Recent" string, so it reflects real state.
+//
+// @coordinates-with: LibraryView.swift, LibrarySortOrder.swift,
+//   LibraryViewModel.swift, LibraryCardTokens.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx`
+
+import SwiftUI
+
+/// The "All books" section header + sort-order dropdown — design
+/// `GridView` header block.
+struct LibrarySectionHeader: View {
+    /// Two-way bound sort order — drives the dropdown label and the
+    /// `LibraryViewModel`'s re-sort + persistence (bug #75).
+    @Binding var sortOrder: LibrarySortOrder
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text("All books")
+                .font(LibraryCardTokens.serifTitleFont(
+                    size: LibraryCardTokens.sectionHeaderFontSize
+                ))
+                .fontWeight(.semibold)
+                .foregroundStyle(LibraryCardTokens.ink)
+                .accessibilityAddTraits(.isHeader)
+
+            Spacer(minLength: 0)
+
+            sortMenu
+        }
+        .padding(.horizontal, LibraryCardTokens.shellContentPadding)
+        .padding(.bottom, 14)
+    }
+
+    /// The sort dropdown — design `Recent ⌄` affordance, wired to the
+    /// app's `LibrarySortOrder`.
+    private var sortMenu: some View {
+        Menu {
+            Picker("Sort By", selection: $sortOrder) {
+                ForEach(LibrarySortOrder.allCases) { order in
+                    Text(order.label).tag(order)
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text(sortOrder.label)
+                    .font(.system(size: LibraryCardTokens.subtitleFontSize))
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 12, weight: .semibold))
+            }
+            .foregroundStyle(LibraryCardTokens.subText)
+        }
+        .accessibilityLabel("Sort books")
+        .accessibilityIdentifier("sortPicker")
+    }
+}

--- a/vreader/Views/Library/LibraryView+Body.swift
+++ b/vreader/Views/Library/LibraryView+Body.swift
@@ -1,0 +1,255 @@
+// Purpose: Feature #60 WI-9 — the grid / list body, empty state, and
+// per-book context menu for the re-skinned `LibraryView`. Split out of
+// `LibraryView.swift` to keep each file near the ~300-line guideline
+// (rule 50 §9). The split mirrors `ReaderContainerView` ↔
+// `ReaderContainerView+Sheets.swift`.
+//
+// Behavior is preserved verbatim from the pre-#60 `LibraryView`: the
+// 3-column grid, the rounded list card, list-mode swipe-to-delete, the
+// empty-state CTA, and the Info / Share / Set-Cover / Remove-Cover /
+// Add-to-Collection / Delete context menu (feature #47 share gating +
+// bug #85 collections submenu + bug #155 in-memory refresh).
+//
+// Key decision: list mode is a native `List` (insetGrouped style) so
+// `.swipeActions` swipe-to-delete survives the re-skin. `List` cannot
+// nest inside a `ScrollView`, so the Continue-reading rail + the "All
+// books" sort header are list rows at the top of the `List` in list
+// mode. Grid mode keeps a `ScrollView` + `LazyVGrid`.
+//
+// @coordinates-with: LibraryView.swift, BookCardView.swift,
+//   BookRowView.swift, LibrarySectionHeader.swift, ContinueReadingRail.swift,
+//   LibraryCardTokens.swift, CustomCoverStore.swift,
+//   AccessibilityFormatters.swift, PersistenceActor+Collections.swift
+
+import SwiftUI
+
+extension LibraryView {
+
+    // MARK: - Grid body
+
+    /// 3-column generative-cover grid — design `GridView`'s
+    /// `repeat(3, 1fr)` with the design's `22px 14px` gaps.
+    var gridBody: some View {
+        LazyVGrid(
+            columns: Array(
+                repeating: GridItem(.flexible(), spacing: 14),
+                count: 3
+            ),
+            spacing: 22
+        ) {
+            ForEach(displayedBooks) { book in
+                Button {
+                    openBook(book)
+                } label: {
+                    BookCardView(book: book, coverVersion: coverVersion)
+                }
+                .buttonStyle(.plain)
+                .contextMenu {
+                    bookContextMenu(for: book)
+                }
+                .accessibilityIdentifier("bookCard_\(book.fingerprintKey)")
+                .accessibilityLabel(AccessibilityFormatters.accessibleBookDescription(
+                    title: book.title,
+                    author: book.author,
+                    format: book.format,
+                    readingTimeSeconds: book.totalReadingSeconds
+                ))
+                .accessibilityHint("Double tap to open")
+            }
+        }
+        .padding(.horizontal, LibraryCardTokens.shellContentPadding)
+    }
+
+    // MARK: - List body
+
+    /// Rounded white list card — design `ListView`. A native `List`
+    /// with the inset-grouped style gives the design's 20pt-radius
+    /// `#fff` card + hairline dividers natively, and — unlike a
+    /// `LazyVStack` — keeps `.swipeActions` swipe-to-delete working.
+    /// The rail + sort header ride as leading rows because `List`
+    /// cannot nest inside a `ScrollView`.
+    var listBody: some View {
+        List {
+            if hasContinueReadingRail {
+                continueReadingRail
+                    .listRowInsets(EdgeInsets())
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+            }
+
+            LibrarySectionHeader(sortOrder: $viewModel.sortOrder)
+                .listRowInsets(EdgeInsets())
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+
+            Section {
+                ForEach(displayedBooks) { book in
+                    listRow(for: book)
+                }
+            }
+            .listRowBackground(LibraryCardTokens.listCardBackground)
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .scrollDismissesKeyboard(.immediately)
+    }
+
+    /// One list row — the WI-8 `BookRowView` wrapped with the open tap,
+    /// the context menu, and the trailing swipe-to-delete action.
+    private func listRow(for book: LibraryBookItem) -> some View {
+        Button {
+            openBook(book)
+        } label: {
+            BookRowView(book: book, coverVersion: coverVersion)
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            bookContextMenu(for: book)
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button(role: .destructive) {
+                bookToDelete = book
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+            .accessibilityIdentifier("bookRowDelete_\(book.fingerprintKey)")
+        }
+        .accessibilityIdentifier("bookRow_\(book.fingerprintKey)")
+        .accessibilityLabel(AccessibilityFormatters.accessibleBookDescription(
+            title: book.title,
+            author: book.author,
+            format: book.format,
+            readingTimeSeconds: book.totalReadingSeconds
+        ))
+        .accessibilityHint("Double tap to open")
+    }
+
+    /// Whether the Continue-reading rail should render — used by
+    /// `listBody` to decide whether to emit the rail row.
+    private var hasContinueReadingRail: Bool {
+        guard containerModel.showsContinueReadingRail else { return false }
+        return !containerModel.continueReadingBooks(in: viewModel.books).isEmpty
+    }
+
+    // MARK: - Empty state
+
+    /// Empty-library onboarding CTA — re-skinned to the warm-paper
+    /// palette + Source Serif 4 headline.
+    var emptyState: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "books.vertical")
+                .font(.system(size: 64))
+                .foregroundStyle(LibraryCardTokens.subText)
+                .accessibilityHidden(true)
+
+            Text("Your Library is Empty")
+                .font(LibraryCardTokens.serifTitleFont(size: 22))
+                .fontWeight(.semibold)
+                .foregroundStyle(LibraryCardTokens.ink)
+
+            Text("Import books to start reading. Supports EPUB, PDF, TXT, and Markdown formats.")
+                .font(.body)
+                .foregroundStyle(LibraryCardTokens.subText)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+
+            Button {
+                isShowingImporter = true
+            } label: {
+                Label("Import Books", systemImage: "plus.circle.fill")
+                    .font(.headline)
+                    .frame(minHeight: 44)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(LibraryCardTokens.accent)
+            .accessibilityIdentifier("importBooksButton")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("emptyLibraryState")
+    }
+
+    // MARK: - Context menu
+
+    /// Per-book long-press context menu — Info / Share / Set Cover /
+    /// Remove Cover / Add to Collection / Delete. Preserved verbatim
+    /// from the pre-#60 `LibraryView`.
+    @ViewBuilder
+    func bookContextMenu(for book: LibraryBookItem) -> some View {
+        Button {
+            bookForInfo = book
+        } label: {
+            Label("Info", systemImage: "info.circle")
+        }
+
+        // Share gated by feature #47 WI-5: only `.local` rows have
+        // bytes to share. Non-`.local` rows omit the item rather than
+        // showing it disabled.
+        if book.canShare {
+            Button {
+                bookToShare = book
+            } label: {
+                Label("Share", systemImage: "square.and.arrow.up")
+            }
+        }
+
+        Divider()
+
+        Button {
+            bookForCover = book
+        } label: {
+            Label("Set Cover", systemImage: "photo")
+        }
+
+        if CustomCoverStore.hasCover(for: book.fingerprintKey) {
+            Button(role: .destructive) {
+                try? CustomCoverStore.removeCover(for: book.fingerprintKey)
+                coverVersion += 1
+            } label: {
+                Label("Remove Cover", systemImage: "photo.badge.minus")
+            }
+        }
+
+        Divider()
+
+        // Add to Collection submenu (bug #85)
+        Menu {
+            if collectionRecords.isEmpty {
+                Text("No collections yet")
+            } else {
+                ForEach(collectionRecords, id: \.name) { collection in
+                    Button {
+                        addBook(book, toCollection: collection.name)
+                    } label: {
+                        Label(collection.name, systemImage: "folder")
+                    }
+                }
+            }
+        } label: {
+            Label("Add to Collection", systemImage: "folder.badge.plus")
+        }
+
+        Divider()
+
+        Button(role: .destructive) {
+            bookToDelete = book
+        } label: {
+            Label("Delete", systemImage: "trash")
+        }
+    }
+
+    /// Adds a book to a collection, then refreshes both the collection
+    /// records and `viewModel.books` so the in-memory
+    /// `LibraryBookItem.collectionNames` is current (bug #155).
+    private func addBook(_ book: LibraryBookItem, toCollection name: String) {
+        Task {
+            let persistence = PersistenceActor(modelContainer: modelContext.container)
+            try? await persistence.addBookToCollection(
+                bookFingerprintKey: book.fingerprintKey,
+                collectionName: name
+            )
+            collectionRecords = (try? await persistence.fetchAllCollections()) ?? []
+            await viewModel.refresh(force: true)
+        }
+    }
+}

--- a/vreader/Views/Library/LibraryViewObservers.swift
+++ b/vreader/Views/Library/LibraryViewObservers.swift
@@ -1,0 +1,175 @@
+// Purpose: Feature #60 WI-9 — the notification-observer chain for the
+// re-skinned `LibraryView`. Extracted into a dedicated `ViewModifier`
+// because applying every `.onReceive` inline pushes the `LibraryView`
+// body past the Swift type-checker's complexity ceiling.
+//
+// Behavior is preserved verbatim from the pre-#60 `LibraryView`:
+// - Feature #47 WI-6 lazy-download row-tap handler.
+// - `.readerDidClose` → in-memory last-read update (bug #45 v4).
+// - `.bookFileStateDidChange` → force-refresh (bug #115 / #47 WI-4b).
+// - `.bookDidImport` → force-refresh (bug #197).
+// - DEBUG: `.debugBridgeOpenBook` / `.debugBridgeLibraryChanged`
+//   (feature #44 DebugBridge).
+//
+// @coordinates-with: LibraryView.swift, LibraryViewModel.swift,
+//   LazyDownloadCoordinator.swift, WebDAVProviderFactory.swift,
+//   ReaderNotifications.swift, DebugBridgeNotifications.swift
+
+import SwiftUI
+import OSLog
+
+private let log = Logger(subsystem: "com.vreader.app", category: "LibraryViewObservers")
+
+/// The notification-observer chain for the re-skinned `LibraryView`.
+struct LibraryViewObservers: ViewModifier {
+    @Environment(\.lazyDownloadCoordinator) private var lazyDownloadCoordinator
+    @Environment(\.webDAVNetworkPolicy) private var webDAVNetworkPolicy
+
+    let viewModel: LibraryViewModel
+    @Binding var bookForDownloadSheet: LibraryBookItem?
+    @Binding var isPushingReader: Bool
+    @Binding var navigationPath: NavigationPath
+
+    func body(content: Content) -> some View {
+        content
+            // Feature #47 WI-6: row tap on a non-`.local` row → kick off
+            // a lazy download. Posted from `LibraryView.openBook(_:)`.
+            .onReceive(NotificationCenter.default.publisher(for: .libraryRowTappedWhileNotLocal)) { notification in
+                handleRowTapWhileNotLocal(notification)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .readerDidClose)) { notification in
+                // Bug #45 v4: update in-memory lastReadAt and re-sort
+                // immediately. Do NOT call loadBooks() — it re-fetches
+                // from DB before recomputeStats() commits, overwriting
+                // the in-memory fix.
+                if let key = notification.object as? String {
+                    viewModel.markBookAsJustRead(fingerprintKey: key)
+                } else {
+                    Task { await viewModel.refresh(force: true) }
+                }
+            }
+            // Bug #115 (#47 WI-4b): when the lazy-download finalizer
+            // flips a row from `.remoteOnly` to `.local`, refresh the
+            // library so the row reflects the new state immediately.
+            .onReceive(NotificationCenter.default.publisher(for: .bookFileStateDidChange)) { _ in
+                Task { await viewModel.refresh(force: true) }
+            }
+            // Bug #197: BookImporter posts `.bookDidImport` after every
+            // import. The Share-Sheet / system-Open-in path does not
+            // call `loadBooks()` directly, so this keeps the library in
+            // sync without a cold launch.
+            .onReceive(NotificationCenter.default.publisher(for: .bookDidImport)) { _ in
+                Task { await viewModel.refresh(force: true) }
+            }
+            .modifier(LibraryDebugBridgeObservers(
+                viewModel: viewModel,
+                isPushingReader: $isPushingReader,
+                navigationPath: $navigationPath
+            ))
+    }
+
+    // MARK: - Feature #47 lazy-download row-tap
+
+    /// Handles a tap on a non-`.local` row by enqueuing a lazy
+    /// download. Mirrors the pre-#60 `LibraryView` handler verbatim;
+    /// errors surface through `viewModel.setError`.
+    private func handleRowTapWhileNotLocal(_ notification: Notification) {
+        log.info("rowTap observer fired")
+        guard let key = notification.userInfo?["fingerprintKey"] as? String else {
+            log.error("rowTap observer: missing fingerprintKey in userInfo")
+            return
+        }
+        guard let book = viewModel.books.first(where: { $0.fingerprintKey == key }) else {
+            log.error("rowTap observer: book not found in viewModel.books for key=\(key, privacy: .public)")
+            return
+        }
+        guard book.needsDownload else {
+            log.error("rowTap observer: book.needsDownload=false for fileState=\(book.fileState.rawValue, privacy: .public)")
+            return
+        }
+        guard let blobPath = book.blobPath else {
+            log.error("rowTap observer: book.blobPath is nil for \(key, privacy: .public)")
+            return
+        }
+        guard let coordinator = lazyDownloadCoordinator else {
+            log.error("rowTap observer: lazyDownloadCoordinator is nil from Environment")
+            return
+        }
+        guard let policy = webDAVNetworkPolicy else {
+            log.error("rowTap observer: webDAVNetworkPolicy is nil from Environment")
+            return
+        }
+        log.info("rowTap observer: all guards passed; coordinator + policy + blobPath OK")
+        // fingerprintKey shape: "<format>:<sha256>:<byteCount>"
+        let parts = book.fingerprintKey.split(separator: ":", maxSplits: 2, omittingEmptySubsequences: false)
+        guard parts.count == 3, let bytes = Int64(parts[2]) else { return }
+        let sha = String(parts[1])
+        let ext = (BookFormat(rawValue: book.format)?.fileExtensions.first) ?? book.format
+        Task {
+            let builder: WebDAVDownloadRequestBuilder
+            do {
+                builder = try await WebDAVProviderFactory.makeRequestBuilder(
+                    profileStore: WebDAVServerProfileStore.shared
+                )
+            } catch {
+                viewModel.setError("Cannot start download: \(error.localizedDescription)")
+                return
+            }
+            let result = coordinator.enqueue(
+                fingerprintKey: book.fingerprintKey,
+                blobPath: blobPath,
+                expectedSHA256: sha,
+                expectedByteCount: bytes,
+                originalExtension: ext,
+                requestBuilder: builder,
+                policy: policy
+            )
+            switch result {
+            case .deferredWiFi:
+                viewModel.setError("Wi-Fi only — turn on the toggle in Backup settings to allow cellular.")
+            case .notReady:
+                viewModel.setError("Lazy-download coordinator unavailable.")
+            case .taskDescriptionEncodeFailed:
+                viewModel.setError("Internal error encoding download task.")
+            case .started:
+                bookForDownloadSheet = book
+            }
+        }
+    }
+}
+
+/// DEBUG-only DebugBridge observers — split into a separate modifier so
+/// the `#if DEBUG` guard wraps a single, self-contained surface (rule
+/// 50 §11: DEBUG-only code in dedicated `#if DEBUG` blocks).
+private struct LibraryDebugBridgeObservers: ViewModifier {
+    let viewModel: LibraryViewModel
+    @Binding var isPushingReader: Bool
+    @Binding var navigationPath: NavigationPath
+
+    func body(content: Content) -> some View {
+        #if DEBUG
+        content
+            // Feature #44 DebugBridge — vreader-debug://open posts this
+            // so automated tests can navigate without tapping. Refresh
+            // viewModel.books FIRST so a rapid seed → open finds the
+            // freshly-imported book.
+            .onReceive(NotificationCenter.default.publisher(for: .debugBridgeOpenBook)) { notification in
+                guard let key = notification.userInfo?["fingerprintKey"] as? String else { return }
+                Task {
+                    await viewModel.loadBooks()
+                    guard let book = viewModel.books.first(where: { $0.fingerprintKey == key })
+                    else { return }
+                    isPushingReader = true
+                    navigationPath.append(book)
+                }
+            }
+            // The bridge's reset/seed mutate SwiftData directly; refresh
+            // the in-memory books array so the UI reflects the new state.
+            .onReceive(NotificationCenter.default.publisher(for: .debugBridgeLibraryChanged)) { _ in
+                Task { await viewModel.refresh(force: true) }
+            }
+        #else
+        content
+        #endif
+    }
+}

--- a/vreader/Views/Library/LibraryViewSheets.swift
+++ b/vreader/Views/Library/LibraryViewSheets.swift
@@ -1,0 +1,220 @@
+// Purpose: Feature #60 WI-9 — the sheet / alert / importer modifier
+// chain for the re-skinned `LibraryView`. Extracted into a dedicated
+// `ViewModifier` because applying all of these inline pushes the
+// `LibraryView` body past the Swift type-checker's complexity ceiling.
+//
+// Behavior is preserved verbatim from the pre-#60 `LibraryView`: the
+// delete-confirmation alert, the error alert, the Info / Share /
+// Download / Settings / AI-chat / OPDS-catalog / collections sheets,
+// the `.fileImporter`, the `.photosPicker`, and the OPDS-download
+// notification observer that re-imports a downloaded catalog book.
+//
+// @coordinates-with: LibraryView.swift, LibraryViewModel.swift,
+//   BookInfoSheet.swift, ShareSheet.swift, BookDownloadSheet.swift,
+//   SettingsView.swift, AIChatView.swift, OPDSCatalogListView.swift,
+//   CollectionSidebar.swift, CustomCoverStore.swift
+
+import SwiftUI
+import PhotosUI
+
+/// The sheet / alert / importer chain for the re-skinned `LibraryView`.
+struct LibraryViewSheets: ViewModifier {
+    @Environment(\.modelContext) private var modelContext
+
+    let viewModel: LibraryViewModel
+
+    @Binding var bookToDelete: LibraryBookItem?
+    @Binding var bookForInfo: LibraryBookItem?
+    @Binding var bookToShare: LibraryBookItem?
+    @Binding var bookForDownloadSheet: LibraryBookItem?
+    @Binding var isShowingImporter: Bool
+    @Binding var isShowingSettings: Bool
+    @Binding var isShowingAIChat: Bool
+    @Binding var isShowingOPDSCatalogs: Bool
+    @Binding var isShowingCollections: Bool
+    @Binding var activeFilter: LibraryFilter
+    @Binding var collectionRecords: [CollectionRecord]
+    @Binding var allTags: [String]
+    @Binding var allSeries: [String]
+    @Binding var coverPickerItem: PhotosPickerItem?
+    @Binding var bookForCover: LibraryBookItem?
+    @Binding var isShowingCoverPicker: Bool
+    @Binding var coverVersion: Int
+    /// Resolved lazily by the parent so multi-turn chat history survives
+    /// sheet dismiss / re-present (bug #93).
+    let resolvedGeneralChatVM: AIChatViewModel
+
+    func body(content: Content) -> some View {
+        content
+            .modifier(LibraryAlerts(
+                viewModel: viewModel,
+                bookToDelete: $bookToDelete
+            ))
+            .sheet(item: $bookForInfo) { book in
+                BookInfoSheet(book: book)
+            }
+            .sheet(item: $bookToShare) { book in
+                ShareSheet(book: book)
+            }
+            .sheet(item: $bookForDownloadSheet) { book in
+                BookDownloadSheet(book: book, presentedBook: $bookForDownloadSheet)
+            }
+            .sheet(isPresented: $isShowingSettings) {
+                SettingsView()
+            }
+            .sheet(isPresented: $isShowingAIChat) {
+                aiChatSheet
+            }
+            .sheet(isPresented: $isShowingOPDSCatalogs) {
+                opdsCatalogsSheet
+            }
+            .sheet(isPresented: $isShowingCollections) {
+                collectionsSheet
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .opdsBookDownloaded)) { notification in
+                if let url = notification.userInfo?["url"] as? URL {
+                    Task { await viewModel.importFiles([url]) }
+                }
+            }
+            .fileImporter(
+                isPresented: $isShowingImporter,
+                allowedContentTypes: LibraryView.importableTypes,
+                allowsMultipleSelection: true
+            ) { result in
+                switch result {
+                case .success(let urls):
+                    Task { await viewModel.importFiles(urls) }
+                case .failure(let error):
+                    viewModel.setError(ErrorMessageAuditor.sanitize(error))
+                }
+            }
+            .photosPicker(
+                isPresented: $isShowingCoverPicker,
+                selection: $coverPickerItem,
+                matching: .images
+            )
+            // Present picker after bookForCover is set (waits for context
+            // menu dismiss). (bug #80)
+            .onChange(of: bookForCover) { _, newBook in
+                if newBook != nil {
+                    isShowingCoverPicker = true
+                }
+            }
+            .onChange(of: coverPickerItem) { _, newItem in
+                guard let item = newItem, let book = bookForCover else { return }
+                Task {
+                    if let data = try? await item.loadTransferable(type: Data.self),
+                       let image = UIImage(data: data) {
+                        try? CustomCoverStore.saveCover(image, for: book.fingerprintKey)
+                        coverVersion += 1
+                    }
+                    coverPickerItem = nil
+                    bookForCover = nil
+                    isShowingCoverPicker = false
+                }
+            }
+    }
+
+    // MARK: - Sheets
+
+    private var aiChatSheet: some View {
+        NavigationStack {
+            AIChatView(viewModel: resolvedGeneralChatVM)
+                .navigationTitle("AI Chat")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button("Done") {
+                            isShowingAIChat = false
+                        }
+                        .accessibilityIdentifier("aiChatDoneButton")
+                    }
+                }
+        }
+    }
+
+    private var opdsCatalogsSheet: some View {
+        NavigationStack {
+            OPDSCatalogListView()
+                .navigationTitle("OPDS Catalogs")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button("Done") {
+                            isShowingOPDSCatalogs = false
+                        }
+                        .accessibilityIdentifier("opdsCatalogsDoneButton")
+                    }
+                }
+        }
+    }
+
+    private var collectionsSheet: some View {
+        CollectionSidebar(
+            activeFilter: $activeFilter,
+            collections: collectionRecords,
+            allTags: allTags,
+            allSeries: allSeries,
+            onCreateCollection: { name in
+                let persistence = PersistenceActor(modelContainer: modelContext.container)
+                _ = try? await persistence.createCollection(name: name)
+                collectionRecords = (try? await persistence.fetchAllCollections()) ?? []
+            },
+            onDeleteCollection: { name in
+                // Bug #129: propagate the throw so CollectionSidebar can
+                // surface failures via its existing alert path. Refresh
+                // the records list either way (success or failure).
+                let persistence = PersistenceActor(modelContainer: modelContext.container)
+                defer {
+                    Task { @MainActor in
+                        collectionRecords = (try? await persistence.fetchAllCollections()) ?? []
+                    }
+                }
+                try await persistence.deleteCollection(name: name)
+            }
+        )
+    }
+}
+
+/// The delete-confirmation + error alerts — split into its own
+/// modifier so the sheet chain above stays under the type-check ceiling.
+private struct LibraryAlerts: ViewModifier {
+    let viewModel: LibraryViewModel
+    @Binding var bookToDelete: LibraryBookItem?
+
+    func body(content: Content) -> some View {
+        content
+            .alert("Error", isPresented: hasError) {
+                Button("OK") { viewModel.clearError() }
+            } message: {
+                Text(viewModel.errorMessage ?? "")
+            }
+            .alert(
+                "Delete Book",
+                isPresented: .init(
+                    get: { bookToDelete != nil },
+                    set: { if !$0 { bookToDelete = nil } }
+                )
+            ) {
+                Button("Cancel", role: .cancel) { bookToDelete = nil }
+                Button("Delete", role: .destructive) {
+                    if let book = bookToDelete {
+                        let key = book.fingerprintKey
+                        bookToDelete = nil
+                        Task { await viewModel.deleteBook(fingerprintKey: key) }
+                    }
+                }
+            } message: {
+                if let book = bookToDelete {
+                    Text("Are you sure you want to delete \"\(book.title)\"? This cannot be undone.")
+                }
+            }
+    }
+
+    private var hasError: Binding<Bool> {
+        Binding(
+            get: { viewModel.errorMessage != nil },
+            set: { if !$0 { viewModel.clearError() } }
+        )
+    }
+}

--- a/vreader/Views/LibraryCardTokens.swift
+++ b/vreader/Views/LibraryCardTokens.swift
@@ -1,5 +1,6 @@
 // Purpose: Feature #60 visual-identity v2 — Library-screen design tokens
-// for the grid card (`BookCardView`) and list row (`BookRowView`).
+// for the grid card (`BookCardView`), the list row (`BookRowView`), and
+// the Library container shell (`LibraryView` re-skin, WI-9).
 //
 // The Library is always presented in the warm-paper light palette in
 // the committed design bundle (it is not theme-switchable like the
@@ -84,6 +85,41 @@ enum LibraryCardTokens {
     /// The ring's swept arc uses `accent` (oxblood).
     static let progressRingTrack = rgb(0x3c, 0x28, 0x14, alpha: 0.12)
 
+    // MARK: - Container shell palette (feature #60 WI-9)
+
+    /// Library shell background — the warm paper `#f7f4ee`. A different
+    /// shade from `ReaderThemeV2.paper` (`#f4eee0`); the Library is not
+    /// theme-switchable, so this is the one Library backdrop.
+    static let shellBackground = rgb(0xf7, 0xf4, 0xee)
+
+    /// Nav-bar pill button fill — `rgba(60,40,20,0.06)` warm wash.
+    /// Shared by the search-field container and the unselected filter
+    /// chip (the design uses the same wash for all three).
+    static let navPillBackground = rgb(0x3c, 0x28, 0x14, alpha: 0.06)
+
+    /// Nav-bar icon tint — the design dark brown `#3a2913`.
+    static let navIconTint = rgb(0x3a, 0x29, 0x13)
+
+    /// Selected filter-chip fill — the design near-black `#1d1a14`
+    /// (identical to `ink`; aliased for call-site clarity).
+    static let filterChipSelectedBackground = ink
+
+    /// Unselected filter-chip fill — the warm wash (same as `navPillBackground`).
+    static let filterChipBackground = navPillBackground
+
+    /// Selected filter-chip text — the warm-paper shell colour `#f7f4ee`.
+    static let filterChipSelectedText = shellBackground
+
+    /// Unselected filter-chip text — the design dark brown `#3a2913`.
+    static let filterChipText = navIconTint
+
+    /// Search-field container fill — the warm wash (same as `navPillBackground`).
+    static let searchFieldBackground = navPillBackground
+
+    /// "See all" affordance colour on the Continue-reading header —
+    /// the design oxblood accent.
+    static let seeAllAccent = accent
+
     // MARK: - Layout constants
 
     /// Cover corner radius for the grid card. Design `BookCover` is
@@ -144,6 +180,80 @@ enum LibraryCardTokens {
     static let progressRingSize: CGFloat = 30
     static let progressRingInset: CGFloat = 3
     static let progressRingLineWidth: CGFloat = 2
+
+    // MARK: - Container shell layout (feature #60 WI-9)
+
+    /// Nav-bar pill button — design `pillBtn`: a 36pt square with an
+    /// 18pt radius (a full circle).
+    static let navPillSize: CGFloat = 36
+    static let navPillCornerRadius: CGFloat = 18
+
+    /// Nav-bar icon point size — design `Icons.* size={19}`.
+    static let navIconSize: CGFloat = 19
+
+    /// Gap between the trailing nav-bar pill buttons — design `gap: 8`.
+    static let navPillSpacing: CGFloat = 8
+
+    /// Library title point size — design `fontSize: 36` Source Serif 4.
+    static let titleFontSize: CGFloat = 36
+
+    /// Section-header point size — `Continue reading` / `All books`
+    /// headers, design `fontSize: 18` Source Serif 4.
+    static let sectionHeaderFontSize: CGFloat = 18
+
+    /// Subtitle point size — `{N} books · {M} reading`, design `13`.
+    static let subtitleFontSize: CGFloat = 13
+
+    /// Filter chip — design: `borderRadius: 100` (a full pill),
+    /// `padding: 6px 12px`, `fontSize: 13`.
+    static let filterChipCornerRadius: CGFloat = 100
+    static let filterChipFontSize: CGFloat = 13
+    static let filterChipHorizontalPadding: CGFloat = 12
+    static let filterChipVerticalPadding: CGFloat = 6
+
+    /// Gap between filter chips — design `gap: 6`.
+    static let filterChipSpacing: CGFloat = 6
+
+    /// Continue-reading card cover — design `ContinueCard`:
+    /// `BookCover` at `124 × 186` (a 2:3 portrait), `radius: 5`.
+    static let continueCardCoverWidth: CGFloat = 124
+    static let continueCardCoverHeight: CGFloat = 186
+    static let continueCardCoverCornerRadius: CGFloat = 5
+
+    /// Continue-reading card title point size — design `13.5`.
+    static let continueCardTitleFontSize: CGFloat = 13.5
+
+    /// Continue-reading card metadata point size — design `11`.
+    static let continueCardMetaFontSize: CGFloat = 11
+
+    /// Gap between cover and the title/meta block in a Continue card —
+    /// design `gap: 10`.
+    static let continueCardStackSpacing: CGFloat = 10
+
+    /// Gap between Continue-reading cards in the rail — design `gap: 14`.
+    static let continueRailSpacing: CGFloat = 14
+
+    /// Search-field container — design: `borderRadius: 12`,
+    /// `padding: 10px 14px`, leading-icon gap `8`.
+    static let searchFieldCornerRadius: CGFloat = 12
+    static let searchFieldHorizontalPadding: CGFloat = 14
+    static let searchFieldVerticalPadding: CGFloat = 10
+    static let searchFieldIconSpacing: CGFloat = 8
+
+    /// Search-field text point size — design `fontSize: 15`.
+    static let searchFieldFontSize: CGFloat = 15
+
+    /// Standard content horizontal inset — the design uses `18` for the
+    /// nav bar / chips / search / list card and `22` for the title /
+    /// section headers / grid. Both are exposed so each surface reads
+    /// its own design value.
+    static let shellEdgePadding: CGFloat = 18
+    static let shellContentPadding: CGFloat = 22
+
+    /// In-cover progress strip for the Continue card — design
+    /// `ContinueCard`: a 2.5pt-tall bar inset 6pt horizontally, 5pt up
+    /// from the bottom, 2pt corner radius.
+    static let continueCardStripBottomInset: CGFloat = 5
 
     // MARK: - Serif title font
 

--- a/vreader/Views/LibraryView.swift
+++ b/vreader/Views/LibraryView.swift
@@ -1,25 +1,36 @@
-// Purpose: Main library view displaying the user's book collection.
-// Supports grid/list toggle, sorting, pull-to-refresh, swipe-to-delete,
-// context menu with Info/Share/Delete, empty state with onboarding CTA,
-// general AI chat entry point (WI-013), and OPDS catalog browsing (WI-C04).
+// Purpose: Main library view displaying the user's book collection,
+// re-skinned for feature #60 visual identity v2 (WI-9 — container pass).
+//
+// The container shell follows the design `LibraryScreen` in
+// `dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx`:
+// a warm-paper backdrop, a row of circular pill buttons in place of
+// the system toolbar, a 36pt Source Serif 4 title with a `{N} books ·
+// {M} reading` subtitle, a toggleable search bar, a horizontal
+// filter-chip row, a "Continue reading" rail, and the grid/list body.
+//
+// Behavior is preserved verbatim across the re-skin — feature #47
+// lazy-download row taps, OPDS catalogs, AI chat, collections, the
+// context menu, cover picker, pull-to-refresh, swipe-to-delete, the
+// empty state, and every bug-fix `.onReceive` observer still work.
 //
 // Key decisions:
-// - Uses .refreshable for pull-to-refresh (delegates to ViewModel throttle).
-// - Grid uses adaptive columns for responsive layout.
-// - Sort picker and view mode toggle in toolbar.
-// - Empty state shown when library is empty.
-// - Context menu provides Info, Share, Set Cover, Remove Cover, and Delete actions.
-// - Custom covers via PhotosPicker; stored/loaded through CustomCoverStore.
-// - Delete via context menu (grid) and swipe actions (list).
-// - AI chat button shown conditionally (feature flag + API key).
-// - OPDS catalog button opens catalog management sheet.
+// - The system `.navigationBar` toolbar is replaced by `LibraryNavBar`
+//   (designed pill buttons). The `NavigationStack` is kept only for
+//   the push-to-reader destination; its bar is hidden.
+// - Search / filter derivations live in `LibraryContainerModel` (a
+//   pure value type) so they are unit-testable without a render.
+// - The sheet / alert / importer chain and the notification-observer
+//   chain are extracted into `LibraryViewSheets` / `LibraryViewObservers`
+//   view modifiers — the body would otherwise exceed the Swift
+//   type-checker's complexity ceiling.
 //
 // @coordinates-with: LibraryViewModel.swift, BookCardView.swift, BookRowView.swift,
-//   ReaderContainerView.swift, BookInfoSheet.swift, SettingsView.swift, AIChatView.swift,
-//   CustomCoverStore.swift, OPDSCatalogListView.swift
+//   LibraryNavBar.swift, LibrarySearchBar.swift, LibraryFilterChips.swift,
+//   ContinueReadingRail.swift, LibraryContainerModel.swift,
+//   LibraryViewSheets.swift, LibraryViewObservers.swift,
+//   ReaderContainerView.swift
 
 import SwiftUI
-import Combine
 import OSLog
 
 private let log = Logger(subsystem: "com.vreader.app", category: "LibraryView")
@@ -28,41 +39,48 @@ import UniformTypeIdentifiers
 
 /// Main library view for the book collection.
 struct LibraryView: View {
-    @Environment(\.modelContext) private var modelContext
-    @Environment(\.lazyDownloadCoordinator) private var lazyDownloadCoordinator
-    @Environment(\.webDAVNetworkPolicy) private var webDAVNetworkPolicy
-    @State private var viewModel: LibraryViewModel
-    @State private var bookToDelete: LibraryBookItem?
-    @State private var bookForInfo: LibraryBookItem?
-    @State private var bookToShare: LibraryBookItem?
+    // NOTE: several `@State` / `@Environment` members below are
+    // `internal` (no `private`) rather than `private` so the
+    // `LibraryView+Body.swift` extension file (grid / list / context
+    // menu) can read them. This mirrors `ReaderContainerView`'s split
+    // with `ReaderContainerView+Sheets.swift`.
+    @Environment(\.modelContext) var modelContext
+    @State var viewModel: LibraryViewModel
+    @State var bookToDelete: LibraryBookItem?
+    @State var bookForInfo: LibraryBookItem?
+    @State var bookToShare: LibraryBookItem?
     /// Bound to BookDownloadSheet — set when the user taps a non-`.local`
     /// row, cleared on success/cancel. Feature #47 WI-6.
     @State private var bookForDownloadSheet: LibraryBookItem?
-    @State private var isShowingImporter = false
+    @State var isShowingImporter = false
     @State private var isShowingSettings = false
     @State private var isShowingAIChat = false
     /// Bug #93: cache the general-chat VM across sheet open/close cycles
     /// so multi-turn history is preserved when the user dismisses and
     /// re-opens the chat. Created lazily on first sheet open and reused
-    /// for the rest of the LibraryView's lifetime. Same pattern as
-    /// `ReaderAICoordinator` ownership in `ReaderContainerView`.
+    /// for the rest of the LibraryView's lifetime.
     @State private var generalChatVM: AIChatViewModel?
     @State private var isShowingOPDSCatalogs = false
     @State private var isShowingCollections = false
     @State private var activeFilter: LibraryFilter = .allBooks
-    @State private var collectionRecords: [CollectionRecord] = []
+    /// Feature #60 WI-9: raw search text. Empty unless the search bar
+    /// is open and the user has typed. `LibraryContainerModel` trims it.
+    @State private var searchQuery: String = ""
+    /// Feature #60 WI-9: whether the toggleable search bar is shown.
+    @State private var isSearchVisible: Bool = false
+    @State var collectionRecords: [CollectionRecord] = []
     @State private var allTags: [String] = []
     @State private var allSeries: [String] = []
     /// Fingerprint keys of books with new chapters detected by UpdateChecker (D07a).
     @State private var booksWithUpdates: Set<String> = []
     @State private var coverPickerItem: PhotosPickerItem?
-    @State private var bookForCover: LibraryBookItem?
+    @State var bookForCover: LibraryBookItem?
     @State private var isShowingCoverPicker = false
     /// Incremented when a custom cover is set or removed, to force card/row views to reload.
-    @State private var coverVersion: Int = 0
-    /// Tracks NavigationStack path so the library toolbar can hide during push transitions.
+    @State var coverVersion: Int = 0
+    /// Tracks NavigationStack path so the library chrome can hide during push transitions.
     @State private var navigationPath = NavigationPath()
-    /// Set before appending to navigationPath so the toolbar hides before the push animation starts (bug #72).
+    /// Set before appending to navigationPath so the chrome hides before the push animation starts (bug #72).
     @State private var isPushingReader = false
     let syncMonitor: SyncStatusMonitor?
 
@@ -73,24 +91,21 @@ struct LibraryView: View {
 
     var body: some View {
         NavigationStack(path: $navigationPath) {
-            Group {
+            ZStack {
+                LibraryCardTokens.shellBackground
+                    .ignoresSafeArea()
+
                 if viewModel.isInitialLoad {
                     ProgressView()
                         .controlSize(.large)
                         .accessibilityIdentifier("libraryLoadingIndicator")
-                } else if viewModel.isEmpty {
-                    emptyState
                 } else {
-                    bookCollection
+                    libraryContent
                 }
             }
-            .navigationTitle("Library")
+            .navigationBarHidden(true)
             .navigationDestination(for: LibraryBookItem.self) { book in
                 ReaderContainerView(book: book)
-            }
-            .toolbar(isPushingReader ? .hidden : .visible, for: .navigationBar)
-            .toolbar {
-                if !isPushingReader { toolbarContent }
             }
             .refreshable {
                 await viewModel.refresh()
@@ -98,294 +113,63 @@ struct LibraryView: View {
             }
             .task {
                 await viewModel.loadBooks()
-                // Load collections eagerly for context menu "Add to Collection" (bug #85)
+                // Load collections eagerly for the chip row + context
+                // menu "Add to Collection" (bug #85; feature #60 WI-9).
                 let persistence = PersistenceActor(modelContainer: modelContext.container)
                 collectionRecords = (try? await persistence.fetchAllCollections()) ?? []
             }
-            // Feature #47 WI-6: row tap on a non-`.local` row → kick
-            // off lazy download. The notification is posted from
-            // `openBook(_:)` (LibraryView.swift:openBook) when the
-            // user taps a remote-only / failed row. We look up the
-            // matching book in viewModel.books, build a request via
-            // saved Keychain credentials, and call enqueue. Errors
-            // surface as the existing viewModel.errorMessage banner.
-            .onReceive(NotificationCenter.default.publisher(for: .libraryRowTappedWhileNotLocal)) { notification in
-                log.info("rowTap observer fired")
-                guard let key = notification.userInfo?["fingerprintKey"] as? String else {
-                    log.error("rowTap observer: missing fingerprintKey in userInfo")
-                    return
-                }
-                guard let book = viewModel.books.first(where: { $0.fingerprintKey == key }) else {
-                    log.error("rowTap observer: book not found in viewModel.books for key=\(key, privacy: .public)")
-                    return
-                }
-                guard book.needsDownload else {
-                    log.error("rowTap observer: book.needsDownload=false for fileState=\(book.fileState.rawValue, privacy: .public)")
-                    return
-                }
-                guard let blobPath = book.blobPath else {
-                    log.error("rowTap observer: book.blobPath is nil for \(key, privacy: .public)")
-                    return
-                }
-                guard let coordinator = lazyDownloadCoordinator else {
-                    log.error("rowTap observer: lazyDownloadCoordinator is nil from Environment")
-                    return
-                }
-                guard let policy = webDAVNetworkPolicy else {
-                    log.error("rowTap observer: webDAVNetworkPolicy is nil from Environment")
-                    return
-                }
-                log.info("rowTap observer: all guards passed; coordinator + policy + blobPath OK")
-                // fingerprintKey shape: "<format>:<sha256>:<byteCount>"
-                let parts = book.fingerprintKey.split(separator: ":", maxSplits: 2, omittingEmptySubsequences: false)
-                guard parts.count == 3,
-                      let bytes = Int64(parts[2]) else { return }
-                let sha = String(parts[1])
-                let ext = (BookFormat(rawValue: book.format)?.fileExtensions.first) ?? book.format
-                // WI-5: route through the profile-store-backed factory
-                // variant from WI-3. The async hop spawns into a Task —
-                // notification observers are sync but the factory hop is
-                // cheap (one actor read of the active profile +
-                // password). `coordinator.enqueue` is also called from
-                // inside the Task for the same reason.
-                Task {
-                    let builder: WebDAVDownloadRequestBuilder
-                    do {
-                        builder = try await WebDAVProviderFactory.makeRequestBuilder(
-                            profileStore: WebDAVServerProfileStore.shared
-                        )
-                    } catch {
-                        viewModel.setError("Cannot start download: \(error.localizedDescription)")
-                        return
-                    }
-                    let result = coordinator.enqueue(
-                        fingerprintKey: book.fingerprintKey,
-                        blobPath: blobPath,
-                        expectedSHA256: sha,
-                        expectedByteCount: bytes,
-                        originalExtension: ext,
-                        requestBuilder: builder,
-                        policy: policy
-                    )
-                    switch result {
-                    case .deferredWiFi:
-                        viewModel.setError("Wi-Fi only — turn on the toggle in Backup settings to allow cellular.")
-                    case .notReady:
-                        viewModel.setError("Lazy-download coordinator unavailable.")
-                    case .taskDescriptionEncodeFailed:
-                        viewModel.setError("Internal error encoding download task.")
-                    case .started:
-                        // Surface the sheet so the user sees progress.
-                        bookForDownloadSheet = book
-                    }
-                }
-            }
-            .onReceive(NotificationCenter.default.publisher(for: .readerDidClose)) { notification in
-                // Bug #45 v4: Update in-memory lastReadAt and re-sort immediately.
-                // Do NOT call loadBooks() — it re-fetches from DB before
-                // recomputeStats() commits, overwriting the in-memory fix.
-                if let key = notification.object as? String {
-                    viewModel.markBookAsJustRead(fingerprintKey: key)
-                } else {
-                    Task { await viewModel.refresh(force: true) }
-                }
-            }
-            // Bug #115 (#47 WI-4b): when the lazy-download finalizer flips
-            // a row from `.remoteOnly` to `.local`, refresh the library so
-            // the row reflects the new state immediately. Without this,
-            // the picker-restored row stays gray until app relaunch even
-            // though the file has been downloaded and the DB row updated.
-            // Force-refresh bypasses the 5s throttle — a single tap-driven
-            // download isn't a polling burst.
-            .onReceive(NotificationCenter.default.publisher(for: .bookFileStateDidChange)) { _ in
-                Task { await viewModel.refresh(force: true) }
-            }
-            // Bug #197: BookImporter posts `.bookDidImport` after every import
-            // (new + duplicate). The in-app Files-picker path already calls
-            // `loadBooks()` directly so this is redundant there, but the
-            // Share Sheet / system-Open-in path (FileURLImportRouter,
-            // Feature #59 WI-2) does not — that path previously left the
-            // library out-of-sync until next cold launch. Wrapped in a
-            // ViewModifier because adding it inline pushed the body past
-            // the Swift type-checker's complexity limit.
-            .modifier(BookDidImportRefresher(viewModel: viewModel))
-            #if DEBUG
-            // Feature #44 DebugBridge — vreader-debug://open posts this so
-            // automated tests can navigate to a specific book without
-            // tapping. The bridge has already verified the book exists in
-            // persistence. We refresh viewModel.books FIRST so a rapid
-            // seed → open sequence finds the freshly-imported book — the
-            // bridge serializes its own commands but does not wait for
-            // SwiftUI to propagate libraryChanged refreshes.
-            .onReceive(NotificationCenter.default.publisher(for: .debugBridgeOpenBook)) { notification in
-                guard let key = notification.userInfo?["fingerprintKey"] as? String else { return }
-                Task {
-                    await viewModel.loadBooks()
-                    guard let book = viewModel.books.first(where: { $0.fingerprintKey == key })
-                    else { return }
-                    isPushingReader = true
-                    navigationPath.append(book)
-                }
-            }
-            // The bridge's reset/seed mutate SwiftData directly, bypassing
-            // LibraryViewModel's import path. Refresh the in-memory books
-            // array so the UI reflects the new state for snapshot/observe
-            // consumers that don't go through .onReceive(openBook).
-            .onReceive(NotificationCenter.default.publisher(for: .debugBridgeLibraryChanged)) { _ in
-                Task { await viewModel.refresh(force: true) }
-            }
-            #endif
-            // Reset toolbar visibility when returning from reader (bug #72)
             .onChange(of: navigationPath) { _, newPath in
+                // Reset chrome visibility when returning from reader (bug #72)
                 if newPath.isEmpty { isPushingReader = false }
             }
-            .alert("Error", isPresented: hasError) {
-                Button("OK") { viewModel.clearError() }
-            } message: {
-                Text(viewModel.errorMessage ?? "")
-            }
-            .alert(
-                "Delete Book",
-                isPresented: .init(
-                    get: { bookToDelete != nil },
-                    set: { if !$0 { bookToDelete = nil } }
-                )
-            ) {
-                Button("Cancel", role: .cancel) { bookToDelete = nil }
-                Button("Delete", role: .destructive) {
-                    if let book = bookToDelete {
-                        let key = book.fingerprintKey
-                        bookToDelete = nil
-                        Task { await viewModel.deleteBook(fingerprintKey: key) }
-                    }
-                }
-            } message: {
-                if let book = bookToDelete {
-                    Text("Are you sure you want to delete \"\(book.title)\"? This cannot be undone.")
+            .onChange(of: viewModel.isEmpty) { _, isEmpty in
+                // When the last book is removed, the Search pill is
+                // dropped from the nav bar — clear any open search so
+                // a re-import in the same session doesn't return with
+                // the search bar unexpectedly expanded (Gate 4 round 2).
+                if isEmpty {
+                    isSearchVisible = false
+                    searchQuery = ""
                 }
             }
-            .sheet(item: $bookForInfo) { book in
-                BookInfoSheet(book: book)
-            }
-            .sheet(item: $bookToShare) { book in
-                ShareSheet(book: book)
-            }
-            .sheet(item: $bookForDownloadSheet) { book in
-                BookDownloadSheet(book: book, presentedBook: $bookForDownloadSheet)
-            }
-            .sheet(isPresented: $isShowingSettings) {
-                SettingsView()
-            }
-            .sheet(isPresented: $isShowingAIChat) {
-                NavigationStack {
-                    AIChatView(viewModel: resolvedGeneralChatVM)
-                        .navigationTitle("AI Chat")
-                        .navigationBarTitleDisplayMode(.inline)
-                        .toolbar {
-                            ToolbarItem(placement: .topBarLeading) {
-                                Button("Done") {
-                                    isShowingAIChat = false
-                                }
-                                .accessibilityIdentifier("aiChatDoneButton")
-                            }
-                        }
-                }
-            }
-            .sheet(isPresented: $isShowingOPDSCatalogs) {
-                NavigationStack {
-                    OPDSCatalogListView()
-                        .navigationTitle("OPDS Catalogs")
-                        .navigationBarTitleDisplayMode(.inline)
-                        .toolbar {
-                            ToolbarItem(placement: .topBarLeading) {
-                                Button("Done") {
-                                    isShowingOPDSCatalogs = false
-                                }
-                                .accessibilityIdentifier("opdsCatalogsDoneButton")
-                            }
-                        }
-                }
-            }
-            .sheet(isPresented: $isShowingCollections) {
-                CollectionSidebar(
-                    activeFilter: $activeFilter,
-                    collections: collectionRecords,
-                    allTags: allTags,
-                    allSeries: allSeries,
-                    onCreateCollection: { name in
-                        let persistence = PersistenceActor(modelContainer: modelContext.container)
-                        _ = try? await persistence.createCollection(name: name)
-                        collectionRecords = (try? await persistence.fetchAllCollections()) ?? []
-                    },
-                    onDeleteCollection: { name in
-                        // Bug #129: propagate the throw so CollectionSidebar
-                        // can surface failures via its existing alert path.
-                        // Refresh the records list either way (success or
-                        // failure) so the sidebar reflects current SwiftData
-                        // truth even on error.
-                        let persistence = PersistenceActor(modelContainer: modelContext.container)
-                        defer {
-                            Task { @MainActor in
-                                collectionRecords = (try? await persistence.fetchAllCollections()) ?? []
-                            }
-                        }
-                        try await persistence.deleteCollection(name: name)
-                    }
-                )
-            }
-            .onReceive(NotificationCenter.default.publisher(for: .opdsBookDownloaded)) { notification in
-                if let url = notification.userInfo?["url"] as? URL {
-                    Task { await viewModel.importFiles([url]) }
-                }
-            }
-            .fileImporter(
-                isPresented: $isShowingImporter,
-                allowedContentTypes: Self.importableTypes,
-                allowsMultipleSelection: true
-            ) { result in
-                switch result {
-                case .success(let urls):
-                    Task { await viewModel.importFiles(urls) }
-                case .failure(let error):
-                    viewModel.setError(ErrorMessageAuditor.sanitize(error))
-                }
-            }
-            .photosPicker(
-                isPresented: $isShowingCoverPicker,
-                selection: $coverPickerItem,
-                matching: .images
-            )
-            // Present picker after bookForCover is set (waits for context menu dismiss). (bug #80)
-            .onChange(of: bookForCover) { _, newBook in
-                if newBook != nil {
-                    isShowingCoverPicker = true
-                }
-            }
-            .onChange(of: coverPickerItem) { _, newItem in
-                guard let item = newItem, let book = bookForCover else { return }
-                Task {
-                    if let data = try? await item.loadTransferable(type: Data.self),
-                       let image = UIImage(data: data) {
-                        try? CustomCoverStore.saveCover(image, for: book.fingerprintKey)
-                        coverVersion += 1
-                    }
-                    coverPickerItem = nil
-                    bookForCover = nil
-                    isShowingCoverPicker = false
-                }
-            }
+            .modifier(LibraryViewObservers(
+                viewModel: viewModel,
+                bookForDownloadSheet: $bookForDownloadSheet,
+                isPushingReader: $isPushingReader,
+                navigationPath: $navigationPath
+            ))
+            .modifier(LibraryViewSheets(
+                viewModel: viewModel,
+                bookToDelete: $bookToDelete,
+                bookForInfo: $bookForInfo,
+                bookToShare: $bookToShare,
+                bookForDownloadSheet: $bookForDownloadSheet,
+                isShowingImporter: $isShowingImporter,
+                isShowingSettings: $isShowingSettings,
+                isShowingAIChat: $isShowingAIChat,
+                isShowingOPDSCatalogs: $isShowingOPDSCatalogs,
+                isShowingCollections: $isShowingCollections,
+                activeFilter: $activeFilter,
+                collectionRecords: $collectionRecords,
+                allTags: $allTags,
+                allSeries: $allSeries,
+                coverPickerItem: $coverPickerItem,
+                bookForCover: $bookForCover,
+                isShowingCoverPicker: $isShowingCoverPicker,
+                coverVersion: $coverVersion,
+                resolvedGeneralChatVM: resolvedGeneralChatVM
+            ))
         }
     }
 
     // MARK: - Constants
 
-    private static let importableTypes: [UTType] = {
+    static let importableTypes: [UTType] = {
         var types: [UTType] = [.epub, .pdf, .plainText]
         if let md = UTType("net.daringfireball.markdown") {
             types.append(md)
         }
-        // AZW3/MOBI — no system UTType, use generic binary data
-        // Users can import .azw3/.mobi files via "All Files" or share sheet
+        // AZW3/MOBI — no system UTType, use generic binary data.
         if let mobi = UTType("com.amazon.mobi8-ebook") {
             types.append(mobi)
         }
@@ -394,298 +178,192 @@ struct LibraryView: View {
         return types
     }()
 
-    // MARK: - Subviews
+    // MARK: - Container composition (feature #60 WI-9)
 
+    /// The re-skinned container shell — nav bar, title, subtitle,
+    /// optional search bar, filter chips, then the scrollable region
+    /// holding the optional Continue-reading rail + the grid/list body.
+    ///
+    /// The nav bar + title stay mounted for the empty-library state so
+    /// the user keeps access to Settings / OPDS / Collections / AI /
+    /// Import (the pre-#60 toolbar stayed visible when empty too). The
+    /// search bar and filter chips are suppressed when empty — there is
+    /// nothing to search or filter — but the empty-state CTA replaces
+    /// the grid / list body.
+    private var libraryContent: some View {
+        VStack(spacing: 0) {
+            navBar
+            titleBlock
+
+            if viewModel.isEmpty {
+                emptyState
+            } else {
+                if isSearchVisible {
+                    LibrarySearchBar(query: $searchQuery)
+                        .padding(.bottom, 12)
+                }
+                LibraryFilterChips(
+                    activeFilter: $activeFilter,
+                    collections: collectionRecords
+                )
+                .padding(.bottom, 14)
+
+                scrollableBody
+            }
+        }
+    }
+
+    /// Pure derivation layer for the current search + filter state.
+    /// Not `private` — `LibraryView+Body.swift` (the grid/list/context-
+    /// menu extension) reads it.
+    var containerModel: LibraryContainerModel {
+        LibraryContainerModel(
+            searchQuery: searchQuery,
+            activeFilter: activeFilter
+        )
+    }
+
+    /// Books visible in the grid / list under the active filter + query.
+    /// Not `private` — consumed by `LibraryView+Body.swift`.
+    var displayedBooks: [LibraryBookItem] {
+        containerModel.matchingBooks(in: viewModel.books)
+    }
+
+    /// The re-skinned nav-bar pill row. Hidden during a reader push
+    /// (`isPushingReader`) so the custom chrome does not flicker over
+    /// the push transition — the re-skin's equivalent of bug #72's
+    /// pre-#60 `.toolbar(isPushingReader ? .hidden : .visible)`.
+    private var navBar: some View {
+        LibraryNavBar(
+            viewMode: viewModel.viewMode,
+            isAIChatAvailable: isAIChatAvailable,
+            isSearchEnabled: !viewModel.isEmpty,
+            syncMonitor: syncMonitor,
+            onSettings: { isShowingSettings = true },
+            onSearchToggle: {
+                isSearchVisible.toggle()
+                // Clearing the query on collapse keeps the grid from
+                // staying filtered by a no-longer-visible search.
+                if !isSearchVisible { searchQuery = "" }
+            },
+            onViewModeToggle: { viewModel.toggleViewMode() },
+            onCollections: { openCollections() },
+            onOPDSCatalogs: { isShowingOPDSCatalogs = true },
+            onAIChat: { isShowingAIChat = true },
+            onImport: { isShowingImporter = true }
+        )
+        .padding(.top, 6)
+        .opacity(isPushingReader ? 0 : 1)
+    }
+
+    /// 36pt Source Serif 4 "Library" title + the `{N} books · {M} reading`
+    /// taupe subtitle — design `LibraryScreen` title block.
+    private var titleBlock: some View {
+        let counts = containerModel.subtitleCounts(for: viewModel.books)
+        return VStack(alignment: .leading, spacing: 0) {
+            Text("Library")
+                .font(LibraryCardTokens.serifTitleFont(
+                    size: LibraryCardTokens.titleFontSize
+                ))
+                .fontWeight(.semibold)
+                .foregroundStyle(LibraryCardTokens.ink)
+                .padding(.top, 12)
+                .padding(.bottom, 8)
+                .accessibilityAddTraits(.isHeader)
+
+            Text(subtitleText(for: counts))
+                .font(.system(size: LibraryCardTokens.subtitleFontSize))
+                .foregroundStyle(LibraryCardTokens.subText)
+                .padding(.bottom, 16)
+                .accessibilityIdentifier("librarySubtitle")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, LibraryCardTokens.shellContentPadding)
+    }
+
+    /// The `{N} books · {M} reading` subtitle string. Pluralized so a
+    /// single-book library doesn't read "1 books".
+    private func subtitleText(
+        for counts: LibraryContainerModel.SubtitleCounts
+    ) -> String {
+        let bookWord = counts.total == 1 ? "book" : "books"
+        return "\(counts.total) \(bookWord) · \(counts.reading) reading"
+    }
+
+    /// The scrollable region — the optional Continue-reading rail and
+    /// the "All books" sort header above the grid / list body. Grid
+    /// mode scrolls via a `ScrollView` + `LazyVGrid`; list mode is a
+    /// native `List` (so `.swipeActions` swipe-to-delete survives the
+    /// re-skin — see `LibraryView+Body.swift`).
     @ViewBuilder
-    private var bookCollection: some View {
+    private var scrollableBody: some View {
         switch viewModel.viewMode {
         case .grid:
-            gridView
+            ScrollView {
+                VStack(spacing: 0) {
+                    continueReadingRail
+                    LibrarySectionHeader(sortOrder: $viewModel.sortOrder)
+                    gridBody
+                }
+                .padding(.bottom, 24)
+            }
+            .scrollDismissesKeyboard(.immediately)
         case .list:
-            listView
+            listBody
         }
     }
 
-    /// Bug #155: books visible under the active sidebar filter. The grid and
-    /// list bodies iterate this rather than `viewModel.books` directly so that
-    /// selecting a collection in `CollectionSidebar` actually narrows the
-    /// shown list. Computing here (not in the view model) keeps the filter a
-    /// pure view-state concern — the model still owns the full set + sort.
-    private var displayedBooks: [LibraryBookItem] {
-        viewModel.books.filter { activeFilter.matches($0) }
-    }
-
-    private var gridView: some View {
-        ScrollView {
-            LazyVGrid(
-                columns: Array(repeating: GridItem(.flexible(), spacing: 12), count: 3),
-                spacing: 16
-            ) {
-                ForEach(displayedBooks) { book in
-                    Button {
-                        openBook(book)
-                    } label: {
-                        BookCardView(book: book, coverVersion: coverVersion)
-                    }
-                    .buttonStyle(.plain)
-                    .contextMenu {
-                        bookContextMenu(for: book)
-                    }
-                    .accessibilityIdentifier("bookCard_\(book.fingerprintKey)")
-                    .accessibilityLabel(AccessibilityFormatters.accessibleBookDescription(
-                        title: book.title,
-                        author: book.author,
-                        format: book.format,
-                        readingTimeSeconds: book.totalReadingSeconds
-                    ))
-                    .accessibilityHint("Double tap to open")
-                }
-            }
-            .padding()
-        }
-    }
-
-    private var listView: some View {
-        List {
-            ForEach(displayedBooks) { book in
-                Button {
-                    openBook(book)
-                } label: {
-                    BookRowView(book: book, coverVersion: coverVersion)
-                }
-                .contextMenu {
-                    bookContextMenu(for: book)
-                }
-                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                    deleteButton(for: book)
-                }
-                .accessibilityIdentifier("bookRow_\(book.fingerprintKey)")
-                .accessibilityLabel(AccessibilityFormatters.accessibleBookDescription(
-                    title: book.title,
-                    author: book.author,
-                    format: book.format,
-                    readingTimeSeconds: book.totalReadingSeconds
-                ))
-                .accessibilityHint("Double tap to open")
-            }
-        }
-        .listStyle(.plain)
-    }
-
-    private var emptyState: some View {
-        VStack(spacing: 20) {
-            Image(systemName: "books.vertical")
-                .font(.system(size: 64))
-                .foregroundStyle(.secondary)
-                .accessibilityHidden(true)
-
-            Text("Your Library is Empty")
-                .font(.title2)
-                .fontWeight(.semibold)
-
-            Text("Import books to start reading. Supports EPUB, PDF, TXT, and Markdown formats.")
-                .font(.body)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 40)
-
-            Button {
-                isShowingImporter = true
-            } label: {
-                Label("Import Books", systemImage: "plus.circle.fill")
-                    .font(.headline)
-                    .frame(minHeight: 44)
-            }
-            .buttonStyle(.borderedProminent)
-            .accessibilityIdentifier("importBooksButton")
-        }
-        .accessibilityElement(children: .contain)
-        .accessibilityIdentifier("emptyLibraryState")
-    }
-
-    @ToolbarContentBuilder
-    private var toolbarContent: some ToolbarContent {
-        ToolbarItem(placement: .topBarLeading) {
-            Button {
-                isShowingSettings = true
-            } label: {
-                Image(systemName: "gearshape")
-            }
-            .accessibilityLabel("Settings")
-            .accessibilityIdentifier("settingsToolbarButton")
-        }
-
-        if let syncMonitor {
-            ToolbarItem(placement: .topBarLeading) {
-                SyncStatusView(monitor: syncMonitor)
-            }
-        }
-
-        if isAIChatAvailable {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    isShowingAIChat = true
-                } label: {
-                    Image(systemName: "bubble.left.and.bubble.right")
-                }
-                .accessibilityLabel("AI Chat")
-                .accessibilityIdentifier("aiChatToolbarButton")
-            }
-        }
-
-        ToolbarItem(placement: .topBarTrailing) {
-            Button {
-                Task {
-                    let persistence = PersistenceActor(modelContainer: modelContext.container)
-                    collectionRecords = (try? await persistence.fetchAllCollections()) ?? []
-                    allTags = (try? await persistence.fetchAllTags()) ?? []
-                    allSeries = (try? await persistence.fetchAllSeriesNames()) ?? []
-                    isShowingCollections = true
-                }
-            } label: {
-                Image(systemName: "folder")
-            }
-            .accessibilityLabel("Collections")
-            .accessibilityIdentifier("collectionsToolbarButton")
-        }
-
-        ToolbarItem(placement: .topBarTrailing) {
-            Button {
-                isShowingOPDSCatalogs = true
-            } label: {
-                Image(systemName: "globe")
-            }
-            .accessibilityLabel("OPDS Catalogs")
-            .accessibilityIdentifier("opdsCatalogsToolbarButton")
-        }
-
-        ToolbarItem(placement: .topBarTrailing) {
-            Button {
-                isShowingImporter = true
-            } label: {
-                Image(systemName: "plus")
-            }
-            .accessibilityLabel("Import books")
-            .accessibilityIdentifier("importBooksToolbarButton")
-        }
-
-        ToolbarItem(placement: .topBarTrailing) {
-            Button {
-                viewModel.toggleViewMode()
-            } label: {
-                Image(systemName: viewModel.viewMode == .grid
-                    ? "list.bullet"
-                    : "square.grid.2x2")
-            }
-            .accessibilityLabel(viewModel.viewMode == .grid
-                ? "Switch to list view"
-                : "Switch to grid view")
-            .accessibilityIdentifier("viewModeToggle")
-        }
-
-        ToolbarItem(placement: .topBarTrailing) {
-            Menu {
-                Picker("Sort By", selection: $viewModel.sortOrder) {
-                    ForEach(LibrarySortOrder.allCases) { order in
-                        Text(order.label).tag(order)
-                    }
-                }
-            } label: {
-                Image(systemName: "arrow.up.arrow.down")
-            }
-            .accessibilityLabel("Sort books")
-            .accessibilityIdentifier("sortPicker")
-        }
-    }
-
-    // MARK: - Context Menu
-
+    /// The Continue-reading rail — shown only under `.allBooks` with no
+    /// query (design parity) AND when at least one book is in progress.
     @ViewBuilder
-    private func bookContextMenu(for book: LibraryBookItem) -> some View {
-        Button {
-            bookForInfo = book
-        } label: {
-            Label("Info", systemImage: "info.circle")
-        }
-
-        // Share gated by feature #47 WI-5: only `.local` rows have
-        // bytes to share. Remote-only / downloading / failed / missing
-        // rows omit the menu item rather than showing it disabled —
-        // less noise in the menu, fewer "why is this greyed out?"
-        // questions.
-        if book.canShare {
-            Button {
-                bookToShare = book
-            } label: {
-                Label("Share", systemImage: "square.and.arrow.up")
+    var continueReadingRail: some View {
+        if containerModel.showsContinueReadingRail {
+            let inProgress = containerModel
+                .continueReadingBooks(in: viewModel.books)
+            if !inProgress.isEmpty {
+                ContinueReadingRail(
+                    books: sortedContinueReading(inProgress),
+                    coverVersion: coverVersion,
+                    onOpen: openBook
+                )
             }
         }
-
-        Divider()
-
-        Button {
-            bookForCover = book
-        } label: {
-            Label("Set Cover", systemImage: "photo")
-        }
-
-        if CustomCoverStore.hasCover(for: book.fingerprintKey) {
-            Button(role: .destructive) {
-                try? CustomCoverStore.removeCover(for: book.fingerprintKey)
-                coverVersion += 1
-            } label: {
-                Label("Remove Cover", systemImage: "photo.badge.minus")
-            }
-        }
-
-        Divider()
-
-        // Add to Collection submenu (bug #85)
-        Menu {
-            if collectionRecords.isEmpty {
-                Text("No collections yet")
-            } else {
-                ForEach(collectionRecords, id: \.name) { collection in
-                    Button {
-                        Task {
-                            let persistence = PersistenceActor(modelContainer: modelContext.container)
-                            try? await persistence.addBookToCollection(
-                                bookFingerprintKey: book.fingerprintKey,
-                                collectionName: collection.name
-                            )
-                            collectionRecords = (try? await persistence.fetchAllCollections()) ?? []
-                            // Bug #155: also refresh viewModel.books so the
-                            // in-memory `LibraryBookItem.collectionNames` is
-                            // current — otherwise tapping the collection in
-                            // the sidebar filter shows an empty list because
-                            // the stale row still has `collectionNames: []`.
-                            await viewModel.refresh(force: true)
-                        }
-                    } label: {
-                        Label(collection.name, systemImage: "folder")
-                    }
-                }
-            }
-        } label: {
-            Label("Add to Collection", systemImage: "folder.badge.plus")
-        }
-
-        Divider()
-
-        deleteButton(for: book)
     }
 
-    private func deleteButton(for book: LibraryBookItem) -> some View {
-        Button(role: .destructive) {
-            bookToDelete = book
-        } label: {
-            Label("Delete", systemImage: "trash")
+    /// Continue-reading cards ordered most-recently-read first — the
+    /// design sorts the rail by `lastRead`. Books with no last-read
+    /// timestamp sort after those that have one.
+    private func sortedContinueReading(
+        _ books: [LibraryBookItem]
+    ) -> [LibraryBookItem] {
+        books.sorted { lhs, rhs in
+            switch (lhs.lastReadAt, rhs.lastReadAt) {
+            case let (l?, r?): return l > r
+            case (_?, nil):    return true
+            case (nil, _?):    return false
+            case (nil, nil):
+                return lhs.title.localizedCaseInsensitiveCompare(rhs.title)
+                    == .orderedAscending
+            }
+        }
+    }
+
+    // MARK: - Collections
+
+    /// Loads tags / series / collections, then presents the sidebar.
+    private func openCollections() {
+        Task {
+            let persistence = PersistenceActor(modelContainer: modelContext.container)
+            collectionRecords = (try? await persistence.fetchAllCollections()) ?? []
+            allTags = (try? await persistence.fetchAllTags()) ?? []
+            allSeries = (try? await persistence.fetchAllSeriesNames()) ?? []
+            isShowingCollections = true
         }
     }
 
     // MARK: - AI Chat
 
-    /// Whether the AI chat button should be visible in the toolbar.
+    /// Whether the AI chat button should be visible in the nav bar.
     private var isAIChatAvailable: Bool {
         AIReaderAvailability.isAvailable(
             featureFlags: FeatureFlags.shared,
@@ -694,14 +372,8 @@ struct LibraryView: View {
         )
     }
 
-    /// Bug #93: lazily resolves the general-chat VM, caching it in `@State`
-    /// so it survives sheet dismiss/re-present. SwiftUI re-runs the
-    /// `.sheet { ... }` closure each time the sheet is shown — the
-    /// pre-fix path always produced a fresh VM with empty messages, so
-    /// closing and reopening the sheet wiped multi-turn history.
-    /// Mirrors the existing `resolvedAICoordinator` lazy-cache pattern
-    /// in `ReaderContainerView`. The async dispatch keeps SwiftUI from
-    /// observing a state mutation during view body evaluation.
+    /// Bug #93: lazily resolves the general-chat VM, caching it in
+    /// `@State` so it survives sheet dismiss/re-present.
     private var resolvedGeneralChatVM: AIChatViewModel {
         if let existing = generalChatVM { return existing }
         let vm = makeGeneralChatViewModel()
@@ -712,12 +384,6 @@ struct LibraryView: View {
     }
 
     /// Creates an AIChatViewModel for general (non-book) chat.
-    ///
-    /// Feature #50 WI-5: AIService now dispatches on the active
-    /// `ProviderProfile` via `ProviderProfileStore.shared`. The shared
-    /// store is mandatory in production (Gate-2 round-2 finding [2]) —
-    /// constructing a separate store would re-introduce lost-update races
-    /// across the Settings VM, AIService actor, and the in-reader picker.
     private func makeGeneralChatViewModel() -> AIChatViewModel {
         let service = AIService(
             featureFlags: FeatureFlags.shared,
@@ -731,24 +397,18 @@ struct LibraryView: View {
     // MARK: - Update Checker (D07a)
 
     /// Checks enabled BookSources for new chapters on tracked books.
-    /// Populates `booksWithUpdates` with fingerprint keys of updated books.
     private func checkForBookSourceUpdates() async {
         // TODO: Wire up once books track their source URL and chapter count.
-        // For now, this is a no-op infrastructure hook for pull-to-refresh.
-        // When book-to-source linking is implemented, iterate over source-linked
-        // books and call UpdateChecker.checkForUpdates() for each.
+        // For now this is a no-op infrastructure hook for pull-to-refresh.
     }
 
     // MARK: - Navigation (bug #72)
 
-    /// Hides the library toolbar before pushing to the reader,
-    /// eliminating the toolbar flash during the push animation.
-    /// Feature #47 WI-5 gate: only `.local` rows open the reader.
-    /// Tapping a non-`.local` row posts a notification that the
-    /// download sheet (WI-6) listens for; until that ships, taps on
-    /// remote rows are silent so the user doesn't see a broken
-    /// reader-open path.
-    private func openBook(_ book: LibraryBookItem) {
+    /// Hides the library chrome before pushing to the reader. Feature
+    /// #47 WI-5 gate: only `.local` rows open the reader; tapping a
+    /// non-`.local` row posts a notification the observer listens for.
+    /// Not `private` — `LibraryView+Body.swift`'s grid/list buttons call it.
+    func openBook(_ book: LibraryBookItem) {
         log.info("openBook: \(book.fingerprintKey, privacy: .public) fileState=\(book.fileState.rawValue, privacy: .public) isReadable=\(book.isReadable, privacy: .public)")
         guard book.isReadable else {
             log.info("openBook: posting libraryRowTappedWhileNotLocal for \(book.fingerprintKey, privacy: .public)")
@@ -764,28 +424,5 @@ struct LibraryView: View {
         }
         isPushingReader = true
         navigationPath.append(book)
-    }
-
-    // MARK: - Helpers
-
-    private var hasError: Binding<Bool> {
-        Binding(
-            get: { viewModel.errorMessage != nil },
-            set: { if !$0 { viewModel.clearError() } }
-        )
-    }
-}
-
-/// Bug #197: observer for `.bookDidImport`, force-refreshing the library
-/// view's books array. Lives as a separate ViewModifier so the parent body's
-/// `.onReceive` chain stays under the Swift type-checker's complexity ceiling.
-private struct BookDidImportRefresher: ViewModifier {
-    let viewModel: LibraryViewModel
-
-    func body(content: Content) -> some View {
-        content
-            .onReceive(NotificationCenter.default.publisher(for: .bookDidImport)) { _ in
-                Task { await viewModel.refresh(force: true) }
-            }
     }
 }

--- a/vreaderTests/Views/Library/LibraryContainerCompositionTests.swift
+++ b/vreaderTests/Views/Library/LibraryContainerCompositionTests.swift
@@ -1,0 +1,329 @@
+// Purpose: Composition + view-model-state-preservation tests for the
+// feature #60 WI-9 Library-container re-skin. These pin the rule 47
+// WI-9 catalogue entry — "view-model state preserved across the
+// re-skin (sort order, filter chip selection, view-mode toggle)" —
+// and confirm the new container component views build for the edge
+// cases (no books, no author, every format, CJK).
+//
+// These are structural assertions, NOT pixel snapshots.
+//
+// @coordinates-with: LibraryViewModel.swift, LibraryNavBar.swift,
+//   LibraryFilterChips.swift, LibraryContinueCard.swift,
+//   ContinueReadingRail.swift, LibrarySearchBar.swift
+
+import Testing
+import SwiftUI
+import Foundation
+@testable import vreader
+
+@Suite("LibraryContainer composition — feature #60 WI-9")
+@MainActor
+struct LibraryContainerCompositionTests {
+
+    // MARK: - Helpers
+
+    private func book(
+        key: String = "epub:abc:1024",
+        title: String = "Test Book",
+        author: String? = "An Author",
+        format: String = "epub",
+        progress: Double? = nil,
+        lastReadAt: Date? = nil
+    ) -> LibraryBookItem {
+        LibraryBookItem(
+            fingerprintKey: key,
+            title: title,
+            author: author,
+            coverImagePath: nil,
+            format: format,
+            fileByteCount: 1024,
+            addedAt: Date(timeIntervalSince1970: 0),
+            lastOpenedAt: nil,
+            isFavorite: false,
+            totalReadingSeconds: 0,
+            lastReadAt: lastReadAt,
+            averagePagesPerHour: nil,
+            averageWordsPerMinute: nil,
+            progressFraction: progress
+        )
+    }
+
+    private func makeViewModel(
+        preferenceStore: (any PreferenceStoring)? = nil
+    ) -> LibraryViewModel {
+        LibraryViewModel(
+            persistence: MockLibraryPersistence(),
+            preferenceStore: preferenceStore
+        )
+    }
+
+    // MARK: - View-model state preserved (rule 47 WI-9 catalogue)
+
+    @Test("View-mode toggle still flips grid ↔ list after the re-skin")
+    func viewModeTogglePreserved() {
+        let vm = makeViewModel()
+        #expect(vm.viewMode == .grid)
+        vm.toggleViewMode()
+        #expect(vm.viewMode == .list)
+        vm.toggleViewMode()
+        #expect(vm.viewMode == .grid)
+    }
+
+    @Test("Sort order is still settable + persisted after the re-skin")
+    func sortOrderPreserved() {
+        let store = MockPreferenceStore()
+        let vm = makeViewModel(preferenceStore: store)
+        vm.sortOrder = .lastReadAt
+        #expect(vm.sortOrder == .lastReadAt)
+        // The re-skin must not break bug #75 persistence.
+        #expect(store.string(forKey: LibraryViewModel.sortOrderKey) == "lastReadAt")
+    }
+
+    @Test("View mode is restored from the preference store")
+    func viewModeRestoredFromStore() {
+        let store = MockPreferenceStore()
+        store.set("list", forKey: LibraryViewModel.viewModeKey)
+        let vm = makeViewModel(preferenceStore: store)
+        #expect(vm.viewMode == .list)
+    }
+
+    // MARK: - Filter chip selection (LibraryFilter is the data model)
+
+    @Test("Filter chips bind to LibraryFilter — All Books default")
+    func filterChipDefaultIsAllBooks() {
+        var filter: LibraryFilter = .allBooks
+        let binding = Binding(get: { filter }, set: { filter = $0 })
+        let chips = LibraryFilterChips(
+            activeFilter: binding, collections: []
+        )
+        // The view builds; the bound filter is the default.
+        _ = chips.body
+        #expect(filter == .allBooks)
+    }
+
+    @Test("Filter chips render one chip per collection without crashing")
+    func filterChipsRenderCollections() {
+        var filter: LibraryFilter = .collection("Sci-Fi")
+        let binding = Binding(get: { filter }, set: { filter = $0 })
+        let chips = LibraryFilterChips(
+            activeFilter: binding,
+            collections: [
+                CollectionRecord(name: "Sci-Fi", createdAt: Date(), bookCount: 3),
+                CollectionRecord(name: "Classics", createdAt: Date(), bookCount: 1),
+            ]
+        )
+        _ = chips.body
+        #expect(filter == .collection("Sci-Fi"))
+    }
+
+    @Test("Filter chips handle a collection name with CJK characters")
+    func filterChipsHandleCJKCollectionName() {
+        var filter: LibraryFilter = .allBooks
+        let binding = Binding(get: { filter }, set: { filter = $0 })
+        let chips = LibraryFilterChips(
+            activeFilter: binding,
+            collections: [CollectionRecord(name: "科幻小说", createdAt: Date(), bookCount: 2)]
+        )
+        _ = chips.body
+        #expect(filter == .allBooks)
+    }
+
+    // MARK: - Nav bar composition
+
+    @Test("Nav bar builds with AI chat + search available")
+    func navBarBuildsWithAIChat() {
+        let bar = LibraryNavBar(
+            viewMode: .grid,
+            isAIChatAvailable: true,
+            isSearchEnabled: true,
+            syncMonitor: nil,
+            onSettings: {}, onSearchToggle: {}, onViewModeToggle: {},
+            onCollections: {}, onOPDSCatalogs: {}, onAIChat: {}, onImport: {}
+        )
+        _ = bar.body
+    }
+
+    @Test("Nav bar builds with AI chat unavailable (pill omitted)")
+    func navBarBuildsWithoutAIChat() {
+        let bar = LibraryNavBar(
+            viewMode: .list,
+            isAIChatAvailable: false,
+            isSearchEnabled: true,
+            syncMonitor: nil,
+            onSettings: {}, onSearchToggle: {}, onViewModeToggle: {},
+            onCollections: {}, onOPDSCatalogs: {}, onAIChat: {}, onImport: {}
+        )
+        _ = bar.body
+    }
+
+    @Test("Nav bar builds for an empty library (search pill omitted)")
+    func navBarBuildsForEmptyLibrary() {
+        let bar = LibraryNavBar(
+            viewMode: .grid,
+            isAIChatAvailable: true,
+            isSearchEnabled: false,
+            syncMonitor: nil,
+            onSettings: {}, onSearchToggle: {}, onViewModeToggle: {},
+            onCollections: {}, onOPDSCatalogs: {}, onAIChat: {}, onImport: {}
+        )
+        _ = bar.body
+    }
+
+    @Test("Pill button builds for every nav-bar glyph")
+    func pillButtonBuildsForEveryGlyph() {
+        for glyph in ["gearshape", "magnifyingglass", "list.bullet",
+                      "square.grid.2x2", "folder", "globe",
+                      "bubble.left.and.bubble.right", "plus"] {
+            let pill = LibraryPillButton(
+                systemImage: glyph,
+                accessibilityLabel: "L",
+                accessibilityIdentifier: "id",
+                action: {}
+            )
+            _ = pill.body
+        }
+    }
+
+    // MARK: - Continue card composition
+
+    @Test("Continue card percent text rounds the progress fraction")
+    func continueCardPercentText() {
+        let card = LibraryContinueCard(
+            book: book(progress: 0.426), onOpen: { _ in }
+        )
+        #expect(card.percentTextForTesting == "43%")
+    }
+
+    @Test("Continue card percent text clamps an over-unity fraction")
+    func continueCardPercentClamps() {
+        // The rail should never hold a finished book, but the percent
+        // helper must not over-report if it ever receives one.
+        let card = LibraryContinueCard(
+            book: book(progress: 1.5), onOpen: { _ in }
+        )
+        #expect(card.percentTextForTesting == "100%")
+    }
+
+    @Test("Continue card last-read text is nil without a timestamp")
+    func continueCardLastReadNilWithoutTimestamp() {
+        let card = LibraryContinueCard(
+            book: book(progress: 0.5, lastReadAt: nil), onOpen: { _ in }
+        )
+        #expect(card.lastReadTextForTesting == nil)
+    }
+
+    @Test("Continue card last-read text is present with a timestamp")
+    func continueCardLastReadPresentWithTimestamp() {
+        let card = LibraryContinueCard(
+            book: book(progress: 0.5, lastReadAt: Date()),
+            onOpen: { _ in }
+        )
+        #expect(card.lastReadTextForTesting != nil)
+    }
+
+    @Test("Continue card builds for a book with no author")
+    func continueCardBuildsWithoutAuthor() {
+        let card = LibraryContinueCard(
+            book: book(author: nil, progress: 0.3), onOpen: { _ in }
+        )
+        _ = card.body
+    }
+
+    @Test("Continue card builds for a CJK title")
+    func continueCardBuildsForCJKTitle() {
+        let card = LibraryContinueCard(
+            book: book(title: "三体", author: "刘慈欣", progress: 0.7),
+            onOpen: { _ in }
+        )
+        _ = card.body
+    }
+
+    // MARK: - Continue rail composition
+
+    @Test("Continue rail builds with a single in-progress book")
+    func continueRailBuildsWithOneBook() {
+        let rail = ContinueReadingRail(
+            books: [book(progress: 0.5)], onOpen: { _ in }
+        )
+        _ = rail.body
+    }
+
+    @Test("Continue rail builds with more than the 5-card cap")
+    func continueRailBuildsBeyondCap() {
+        let many = (0..<9).map {
+            book(key: "epub:k\($0):1", title: "Book \($0)", progress: 0.4)
+        }
+        let rail = ContinueReadingRail(books: many, onOpen: { _ in })
+        _ = rail.body
+    }
+
+    // MARK: - Search bar composition
+
+    @Test("Search bar builds with an empty query (no clear button)")
+    func searchBarBuildsEmpty() {
+        var query = ""
+        let binding = Binding(get: { query }, set: { query = $0 })
+        let bar = LibrarySearchBar(query: binding)
+        _ = bar.body
+    }
+
+    @Test("Search bar builds with a non-empty query (clear button shown)")
+    func searchBarBuildsWithQuery() {
+        var query = "tolstoy"
+        let binding = Binding(get: { query }, set: { query = $0 })
+        let bar = LibrarySearchBar(query: binding)
+        _ = bar.body
+    }
+
+    // MARK: - Sort header (Gate 4 finding — sort affordance preserved)
+
+    @Test("Section header builds + binds to LibrarySortOrder")
+    func sectionHeaderBindsToSortOrder() {
+        var order: LibrarySortOrder = .title
+        let binding = Binding(get: { order }, set: { order = $0 })
+        let header = LibrarySectionHeader(sortOrder: binding)
+        _ = header.body
+        #expect(order == .title)
+    }
+
+    @Test("Section header builds for every sort order")
+    func sectionHeaderBuildsForEverySortOrder() {
+        for order in LibrarySortOrder.allCases {
+            var current = order
+            let binding = Binding(get: { current }, set: { current = $0 })
+            let header = LibrarySectionHeader(sortOrder: binding)
+            _ = header.body
+        }
+    }
+
+    @Test("Sort order label is non-empty for every case (dropdown text)")
+    func sortOrderLabelsNonEmpty() {
+        // The header's dropdown shows `sortOrder.label`; an empty label
+        // would render a blank affordance.
+        for order in LibrarySortOrder.allCases {
+            #expect(!order.label.isEmpty)
+        }
+    }
+
+    // MARK: - Sort still settable through the bound order (regression)
+
+    @Test("Sort order set through the binding persists + re-sorts")
+    func sortOrderSetThroughBindingWorks() {
+        // The Gate 4 audit flagged that the toolbar sort vanished. The
+        // re-skin routes sort through `LibrarySectionHeader`'s bound
+        // `viewModel.sortOrder`; this confirms a change through that
+        // exact path still re-sorts + persists (bug #75).
+        let store = MockPreferenceStore()
+        let vm = makeViewModel(preferenceStore: store)
+        let header = LibrarySectionHeader(sortOrder: Binding(
+            get: { vm.sortOrder },
+            set: { vm.sortOrder = $0 }
+        ))
+        _ = header.body
+        // Drive the binding the way the Menu's Picker would.
+        vm.sortOrder = .totalReadingTime
+        #expect(vm.sortOrder == .totalReadingTime)
+        #expect(store.string(forKey: LibraryViewModel.sortOrderKey)
+                == "totalReadingTime")
+    }
+}

--- a/vreaderTests/Views/Library/LibraryContainerModelTests.swift
+++ b/vreaderTests/Views/Library/LibraryContainerModelTests.swift
@@ -1,0 +1,273 @@
+// Purpose: Contract tests for the feature #60 WI-9 Library-container
+// re-skin. `LibraryContainerModel` is the pure derivation layer the
+// re-skinned `LibraryView` reads — search filtering, the active
+// collection filter, the "Continue reading" rail set, and the
+// subtitle counts. Testing it here pins the view-model-state-preserved
+// invariant (rule 47 Gate 5 WI-9 catalogue entry) without a SwiftUI
+// render.
+//
+// Design source: `dev-docs/designs/vreader-fidelity-v1/project/
+// vreader-library.jsx` — `LibraryScreen`'s `filtered` / `reading`
+// derivations + the `{N} books · {M} reading` subtitle.
+//
+// @coordinates-with: LibraryContainerModel.swift, LibraryView.swift,
+//   LibraryFilter (CollectionSidebar.swift), LibraryBookItem.swift
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("LibraryContainerModel — feature #60 WI-9")
+struct LibraryContainerModelTests {
+
+    // MARK: - Helpers
+
+    private func book(
+        key: String,
+        title: String = "Untitled",
+        author: String? = nil,
+        progress: Double? = nil,
+        collections: [String] = []
+    ) -> LibraryBookItem {
+        LibraryBookItem(
+            fingerprintKey: key,
+            title: title,
+            author: author,
+            coverImagePath: nil,
+            format: "epub",
+            fileByteCount: 1024,
+            addedAt: Date(timeIntervalSince1970: 0),
+            lastOpenedAt: nil,
+            isFavorite: false,
+            totalReadingSeconds: 0,
+            averagePagesPerHour: nil,
+            averageWordsPerMinute: nil,
+            collectionNames: collections,
+            progressFraction: progress
+        )
+    }
+
+    private var sample: [LibraryBookItem] {
+        [
+            book(key: "epub:a:1", title: "Pride and Prejudice",
+                 author: "Jane Austen", progress: 0.4),
+            book(key: "epub:b:2", title: "Moby Dick",
+                 author: "Herman Melville", progress: nil),
+            book(key: "epub:c:3", title: "War and Peace",
+                 author: "Leo Tolstoy", progress: 1.0),
+            book(key: "epub:d:4", title: "Crime and Punishment",
+                 author: "Fyodor Dostoevsky", progress: 0.85,
+                 collections: ["Classics"]),
+        ]
+    }
+
+    // MARK: - Search filtering (design `filtered` derivation)
+
+    @Test("Empty query returns every book under the .allBooks filter")
+    func emptyQueryReturnsAll() {
+        let model = LibraryContainerModel(
+            searchQuery: "", activeFilter: .allBooks
+        )
+        #expect(model.matchingBooks(in: sample).count == 4)
+    }
+
+    @Test("Query matches book titles case-insensitively")
+    func queryMatchesTitle() {
+        let model = LibraryContainerModel(
+            searchQuery: "pride", activeFilter: .allBooks
+        )
+        let result = model.matchingBooks(in: sample)
+        #expect(result.count == 1)
+        #expect(result.first?.title == "Pride and Prejudice")
+    }
+
+    @Test("Query matches author names case-insensitively")
+    func queryMatchesAuthor() {
+        let model = LibraryContainerModel(
+            searchQuery: "TOLSTOY", activeFilter: .allBooks
+        )
+        let result = model.matchingBooks(in: sample)
+        #expect(result.count == 1)
+        #expect(result.first?.title == "War and Peace")
+    }
+
+    @Test("Query with no match returns an empty set")
+    func queryNoMatchReturnsEmpty() {
+        let model = LibraryContainerModel(
+            searchQuery: "zzzzz", activeFilter: .allBooks
+        )
+        #expect(model.matchingBooks(in: sample).isEmpty)
+    }
+
+    @Test("Whitespace-only query is treated as no query")
+    func whitespaceQueryIgnored() {
+        let model = LibraryContainerModel(
+            searchQuery: "   ", activeFilter: .allBooks
+        )
+        #expect(model.matchingBooks(in: sample).count == 4)
+    }
+
+    @Test("Query is trimmed before matching")
+    func queryTrimmedBeforeMatch() {
+        let model = LibraryContainerModel(
+            searchQuery: "  moby  ", activeFilter: .allBooks
+        )
+        #expect(model.matchingBooks(in: sample).count == 1)
+    }
+
+    @Test("Query matches a CJK title")
+    func queryMatchesCJK() {
+        let cjk = [book(key: "epub:x:9", title: "红楼梦", author: "曹雪芹")]
+        let model = LibraryContainerModel(
+            searchQuery: "红楼", activeFilter: .allBooks
+        )
+        #expect(model.matchingBooks(in: cjk).count == 1)
+    }
+
+    @Test("Query against a book with a nil author does not crash")
+    func queryHandlesNilAuthor() {
+        let model = LibraryContainerModel(
+            searchQuery: "dick", activeFilter: .allBooks
+        )
+        let result = model.matchingBooks(in: sample)
+        #expect(result.count == 1)
+        #expect(result.first?.title == "Moby Dick")
+    }
+
+    // MARK: - Collection filter (preserves bug #155 behavior)
+
+    @Test("Collection filter narrows to that collection's members")
+    func collectionFilterNarrows() {
+        let model = LibraryContainerModel(
+            searchQuery: "", activeFilter: .collection("Classics")
+        )
+        let result = model.matchingBooks(in: sample)
+        #expect(result.count == 1)
+        #expect(result.first?.title == "Crime and Punishment")
+    }
+
+    @Test("Search query and collection filter compose (AND)")
+    func searchAndFilterCompose() {
+        let model = LibraryContainerModel(
+            searchQuery: "war", activeFilter: .collection("Classics")
+        )
+        // "War and Peace" matches the query but is NOT in Classics;
+        // "Crime and Punishment" is in Classics but doesn't match "war".
+        #expect(model.matchingBooks(in: sample).isEmpty)
+    }
+
+    // MARK: - Continue-reading rail (design `reading` derivation)
+
+    @Test("Continue-reading rail holds only in-progress books")
+    func continueRailOnlyInProgress() {
+        let model = LibraryContainerModel(
+            searchQuery: "", activeFilter: .allBooks
+        )
+        let rail = model.continueReadingBooks(in: sample)
+        // 0.4 and 0.85 are in progress; nil (not started) and 1.0
+        // (finished) are excluded.
+        #expect(rail.count == 2)
+        #expect(rail.allSatisfy {
+            if case .inProgress = $0.readingProgressState { return true }
+            return false
+        })
+    }
+
+    @Test("Continue-reading rail excludes finished and not-started books")
+    func continueRailExcludesTerminal() {
+        let model = LibraryContainerModel(
+            searchQuery: "", activeFilter: .allBooks
+        )
+        let railKeys = Set(model.continueReadingBooks(in: sample)
+            .map(\.fingerprintKey))
+        #expect(!railKeys.contains("epub:b:2"))   // not started
+        #expect(!railKeys.contains("epub:c:3"))   // finished
+    }
+
+    @Test("Continue-reading rail is empty when nothing is in progress")
+    func continueRailEmptyWhenNoneInProgress() {
+        let noneReading = [
+            book(key: "epub:a:1", progress: nil),
+            book(key: "epub:b:2", progress: 1.0),
+        ]
+        let model = LibraryContainerModel(
+            searchQuery: "", activeFilter: .allBooks
+        )
+        #expect(model.continueReadingBooks(in: noneReading).isEmpty)
+    }
+
+    @Test("Continue-reading rail respects the active search query")
+    func continueRailRespectsQuery() {
+        let model = LibraryContainerModel(
+            searchQuery: "pride", activeFilter: .allBooks
+        )
+        let rail = model.continueReadingBooks(in: sample)
+        #expect(rail.count == 1)
+        #expect(rail.first?.title == "Pride and Prejudice")
+    }
+
+    // MARK: - Rail visibility (design: rail only on .allBooks + no query)
+
+    @Test("Rail is visible only under .allBooks with no query")
+    func railVisibleOnlyAllBooksNoQuery() {
+        #expect(LibraryContainerModel(
+            searchQuery: "", activeFilter: .allBooks
+        ).showsContinueReadingRail)
+    }
+
+    @Test("Rail is hidden when a search query is active")
+    func railHiddenWithQuery() {
+        #expect(!LibraryContainerModel(
+            searchQuery: "pride", activeFilter: .allBooks
+        ).showsContinueReadingRail)
+    }
+
+    @Test("Rail is hidden when a collection filter is active")
+    func railHiddenWithCollectionFilter() {
+        #expect(!LibraryContainerModel(
+            searchQuery: "", activeFilter: .collection("Classics")
+        ).showsContinueReadingRail)
+    }
+
+    @Test("Whitespace-only query still shows the rail")
+    func railVisibleWithWhitespaceQuery() {
+        #expect(LibraryContainerModel(
+            searchQuery: "   ", activeFilter: .allBooks
+        ).showsContinueReadingRail)
+    }
+
+    // MARK: - Subtitle counts (design `{N} books · {M} reading`)
+
+    @Test("Subtitle counts total books and in-progress books")
+    func subtitleCounts() {
+        let model = LibraryContainerModel(
+            searchQuery: "", activeFilter: .allBooks
+        )
+        let counts = model.subtitleCounts(for: sample)
+        #expect(counts.total == 4)
+        #expect(counts.reading == 2)   // 0.4 and 0.85
+    }
+
+    @Test("Subtitle counts the full library, not the filtered subset")
+    func subtitleCountsFullLibrary() {
+        // Even with a query/filter that narrows the grid, the subtitle
+        // reflects the whole library — matches the design, where
+        // `BOOKS.length` is the unfiltered count.
+        let model = LibraryContainerModel(
+            searchQuery: "pride", activeFilter: .collection("Classics")
+        )
+        let counts = model.subtitleCounts(for: sample)
+        #expect(counts.total == 4)
+        #expect(counts.reading == 2)
+    }
+
+    @Test("Subtitle of an empty library is zero / zero")
+    func subtitleEmptyLibrary() {
+        let model = LibraryContainerModel(
+            searchQuery: "", activeFilter: .allBooks
+        )
+        let counts = model.subtitleCounts(for: [])
+        #expect(counts.total == 0)
+        #expect(counts.reading == 0)
+    }
+}

--- a/vreaderTests/Views/Library/LibraryShellTokensTests.swift
+++ b/vreaderTests/Views/Library/LibraryShellTokensTests.swift
@@ -1,0 +1,180 @@
+// Purpose: Contract tests for the feature #60 WI-9 Library-container
+// shell tokens — the warm-paper background, nav-bar pill metrics, and
+// filter-chip palette added to `LibraryCardTokens` for the container
+// re-skin. Structural / token assertions only, not pixel snapshots.
+//
+// Design source: `dev-docs/designs/vreader-fidelity-v1/project/
+// vreader-library.jsx` — `LibraryScreen` (`#f7f4ee` shell, `pillBtn`),
+// filter-chip block, search-bar block.
+//
+// @coordinates-with: LibraryCardTokens.swift, LibraryNavBar.swift,
+//   LibraryFilterChips.swift, LibrarySearchBar.swift
+
+import Testing
+import SwiftUI
+import Foundation
+@testable import vreader
+
+@Suite("LibraryShellTokens — feature #60 WI-9")
+@MainActor
+struct LibraryShellTokensTests {
+
+    // MARK: - Shell background (design `#f7f4ee`)
+
+    @Test("Shell background is the design warm paper #f7f4ee")
+    func shellBackgroundMatchesDesign() {
+        assertColor(LibraryCardTokens.shellBackground,
+                    rgb: (0xf7, 0xf4, 0xee))
+    }
+
+    @Test("Shell background differs from the reader paper stop")
+    func shellBackgroundDistinctFromReaderPaper() {
+        // The file header documents the Library shell (#f7f4ee) is a
+        // different shade from `ReaderThemeV2.paper` (#f4eee0). Pin the
+        // distinction so a future refactor doesn't collapse them.
+        let shell = LibraryCardTokens.shellBackground
+            .resolve(in: EnvironmentValues())
+        let readerPaper = ReaderThemeV2.paper.backgroundColor
+        var rpR: CGFloat = 0, rpG: CGFloat = 0, rpB: CGFloat = 0, rpA: CGFloat = 0
+        readerPaper.getRed(&rpR, green: &rpG, blue: &rpB, alpha: &rpA)
+        let differs = abs(Double(shell.red) - Double(rpR)) > 0.001
+            || abs(Double(shell.green) - Double(rpG)) > 0.001
+            || abs(Double(shell.blue) - Double(rpB)) > 0.001
+        #expect(differs)
+    }
+
+    // MARK: - Nav-bar pill button (design `pillBtn`)
+
+    @Test("Nav-bar pill button is the design's 36pt square")
+    func pillButtonSizeMatchesDesign() {
+        #expect(LibraryCardTokens.navPillSize == 36)
+    }
+
+    @Test("Nav-bar pill corner radius is half the size (full capsule)")
+    func pillButtonIsFullCapsule() {
+        // Design: `borderRadius: 18` on a 36pt box — a circle.
+        #expect(LibraryCardTokens.navPillCornerRadius
+                == LibraryCardTokens.navPillSize / 2)
+    }
+
+    @Test("Nav-bar pill fill is the design warm wash rgba(60,40,20,0.06)")
+    func pillButtonFillMatchesDesign() {
+        assertColor(LibraryCardTokens.navPillBackground,
+                    rgb: (0x3c, 0x28, 0x14), alpha: 0.06)
+    }
+
+    @Test("Nav-bar icon tint is the design dark brown #3a2913")
+    func pillIconTintMatchesDesign() {
+        assertColor(LibraryCardTokens.navIconTint,
+                    rgb: (0x3a, 0x29, 0x13))
+    }
+
+    // MARK: - Title typography (design 36pt Source Serif 4)
+
+    @Test("Library title uses the design 36pt size")
+    func titleFontSizeMatchesDesign() {
+        #expect(LibraryCardTokens.titleFontSize == 36)
+    }
+
+    @Test("Section-header title uses the design 18pt size")
+    func sectionHeaderFontSizeMatchesDesign() {
+        // `Continue reading` + `All books` headers — design `fontSize: 18`.
+        #expect(LibraryCardTokens.sectionHeaderFontSize == 18)
+    }
+
+    @Test("Subtitle uses the design 13pt size")
+    func subtitleFontSizeMatchesDesign() {
+        #expect(LibraryCardTokens.subtitleFontSize == 13)
+    }
+
+    // MARK: - Filter chip (design filter-chip block)
+
+    @Test("Filter chip is a full pill — design borderRadius:100")
+    func filterChipIsPill() {
+        #expect(LibraryCardTokens.filterChipCornerRadius >= 100)
+    }
+
+    @Test("Selected filter chip fill is the design near-black ink")
+    func selectedChipFillMatchesDesign() {
+        // Design: selected chip `background: #1d1a14` — the ink token.
+        assertColor(LibraryCardTokens.filterChipSelectedBackground,
+                    rgb: (0x1d, 0x1a, 0x14))
+    }
+
+    @Test("Unselected filter chip fill is the warm wash")
+    func unselectedChipFillMatchesDesign() {
+        assertColor(LibraryCardTokens.filterChipBackground,
+                    rgb: (0x3c, 0x28, 0x14), alpha: 0.06)
+    }
+
+    @Test("Selected filter chip text is the warm-paper shell colour")
+    func selectedChipTextMatchesDesign() {
+        // Design: selected chip `color: #f7f4ee`.
+        assertColor(LibraryCardTokens.filterChipSelectedText,
+                    rgb: (0xf7, 0xf4, 0xee))
+    }
+
+    @Test("Filter chip text uses the design 13pt size")
+    func filterChipFontSizeMatchesDesign() {
+        #expect(LibraryCardTokens.filterChipFontSize == 13)
+    }
+
+    // MARK: - Continue card (design ContinueCard 124×186)
+
+    @Test("Continue card cover width matches design 124pt")
+    func continueCardWidthMatchesDesign() {
+        #expect(LibraryCardTokens.continueCardCoverWidth == 124)
+    }
+
+    @Test("Continue card cover height matches design 186pt")
+    func continueCardHeightMatchesDesign() {
+        #expect(LibraryCardTokens.continueCardCoverHeight == 186)
+    }
+
+    @Test("Continue card cover is the design 2:3 portrait proportion")
+    func continueCardCoverIsPortrait() {
+        let ratio = LibraryCardTokens.continueCardCoverWidth
+            / LibraryCardTokens.continueCardCoverHeight
+        #expect(ratio < 1.0)
+        // 124/186 == 2/3 exactly.
+        #expect(abs(Double(ratio) - 2.0 / 3.0) < 0.0001)
+    }
+
+    @Test("Continue card title uses the design 13.5pt size")
+    func continueCardTitleFontSizeMatchesDesign() {
+        #expect(LibraryCardTokens.continueCardTitleFontSize == 13.5)
+    }
+
+    // MARK: - Search bar (design search-bar block)
+
+    @Test("Search field fill is the design warm wash rgba(60,40,20,0.06)")
+    func searchFieldFillMatchesDesign() {
+        assertColor(LibraryCardTokens.searchFieldBackground,
+                    rgb: (0x3c, 0x28, 0x14), alpha: 0.06)
+    }
+
+    @Test("Search field corner radius matches design borderRadius:12")
+    func searchFieldCornerRadiusMatchesDesign() {
+        #expect(LibraryCardTokens.searchFieldCornerRadius == 12)
+    }
+
+    // MARK: - Color assertion helper
+
+    private func assertColor(
+        _ color: Color,
+        rgb expected: (Int, Int, Int),
+        alpha: Double = 1.0,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+        let resolved = color.resolve(in: EnvironmentValues())
+        let r = Int((resolved.red * 255).rounded())
+        let g = Int((resolved.green * 255).rounded())
+        let b = Int((resolved.blue * 255).rounded())
+        #expect(r == expected.0, "red", sourceLocation: sourceLocation)
+        #expect(g == expected.1, "green", sourceLocation: sourceLocation)
+        #expect(b == expected.2, "blue", sourceLocation: sourceLocation)
+        let a = Double(resolved.opacity)
+        #expect(abs(a - alpha) < 0.02, "alpha",
+                sourceLocation: sourceLocation)
+    }
+}


### PR DESCRIPTION
## Summary

- Re-skins `LibraryView`'s container chrome to the feature #60 visual identity v2 design (`dev-docs/designs/vreader-fidelity-v1/project/vreader-library.jsx` `LibraryScreen`): warm-paper `#f7f4ee` shell, circular pill-button nav bar, 36pt Source Serif 4 "Library" title + "{N} books · {M} reading" subtitle, toggleable search bar, horizontal filter-chip row, "Continue reading" rail, and the "All books" sort header.
- All pre-#60 behavior is preserved — re-skin only, zero functionality removed.
- `LibraryView.swift` (was 791 lines) split into focused files; new container component views added.

Part of feature #718

## What Changed

**New container component views** (`vreader/Views/Library/`):
- `LibraryNavBar` + `LibraryPillButton` — the designed circular pill-button nav bar (Settings / Search / grid-list toggle / Collections / OPDS / AI / Import).
- `LibrarySearchBar` — the toggleable warm-wash search field (filters title/author).
- `LibraryFilterChips` — the horizontal filter-chip row.
- `ContinueReadingRail` + `LibraryContinueCard` — the "Continue reading" rail (124×186 cards, 5-card cap, in-cover progress strip).
- `LibrarySectionHeader` — the "All books" header with the sort-order dropdown.
- `LibraryContainerModel` — a pure derivation value type (search filter, continue-reading rail set, subtitle counts) — unit-testable without a render.

**`LibraryView.swift` split** (rule 50):
- `LibraryView+Body.swift` — grid/list bodies, empty state, per-book context menu.
- `LibraryViewSheets.swift` / `LibraryViewObservers.swift` — the extracted sheet/alert and notification-observer modifier chains (the body would otherwise exceed the Swift type-checker's complexity ceiling).

**`LibraryCardTokens.swift`** — extended with container-shell tokens (warm-paper background, pill metrics, filter-chip palette, Continue-card geometry, search-field tokens).

**Design-vs-reality calls (rule 51)** — no UI invented:
- The design mock's filter chips are a fixed taxonomy (`Fiction/Technical/CJK/…`) the app doesn't model. The **designed chip visual treatment** is populated from the app's **real `LibraryFilter` collections** instead — designed UI, real data model.
- The design's "See all" rail label is a non-interactive `<div>` (no `onClick`) — rendered as the designed static text, not a wired button (there is no designed destination screen).
- The sort affordance is the design `GridView`'s "All books / Recent ⌄" header, wired to the app's real `LibrarySortOrder`; rendered above both grid and list bodies (the pre-#60 toolbar sort worked in both modes).

## WI Status

- WI-9: behavioral — this PR. Library container re-skin pass 2.
- Remaining WIs: WI-10 (final — sheet re-skins + generative-cover fallback + status-bar tinting; flips feature row to DONE).

## Codex Audit (Gate 4)

3 rounds, thread `019e306e`, final verdict **ship-as-is** (zero open Critical/High/Medium).

- **Round 1** — 2 High, 2 Medium, 1 Low. High: list-mode swipe-to-delete was dropped (the new list used `LazyVStack`, losing `.swipeActions`); the sort UI vanished (no replacement for the pre-#60 `sortPicker`). Medium: the empty-library state lost the nav actions; bug #72's `isPushingReader` was dead. All fixed — `listBody` rebuilt on a native `List` + `.insetGrouped` with `.swipeActions`; `LibrarySectionHeader` restores the bound sort `Menu`; the nav bar stays mounted when empty; `isPushingReader` gates nav-bar opacity.
- **Round 2** — 1 Medium: the empty-library Search pill was a dead control. Fixed — `LibraryNavBar.isSearchEnabled` omits the pill when empty; `.onChange(of: viewModel.isEmpty)` clears `isSearchVisible`/`searchQuery`.
- **Round 3** — 0 findings. Clean.

Audit log: `.claude/codex-audits/feat-feature-60-wi-9-library-container-audit.md`

## Validation

- [x] `xcodebuild test` passes (Gate 3 test gate) — 171 tests across 11 suites (65 new WI-9 + 106 adjacent library suites), run in isolation per the pre-existing `TTSServiceSpeedControlTests` flake guidance.
- [x] Tests cover changed behavior (TDD: RED → GREEN) — `LibraryContainerModelTests` (search/filter/rail/subtitle derivations + edge cases: empty, nil author, CJK, whitespace-only query, over-unity progress, 5-card cap), `LibraryShellTokensTests` (design-token assertions), `LibraryContainerCompositionTests` (view-model-state preservation: sort/view-mode/filter + component composition).
- [x] Codex audit loop completed (3 iterations, verdict: ship-as-is)
- [x] Docs sync — n/a. A view re-skin: no new service / schema / notification / environment key / cross-feature pattern. `docs/architecture.md`'s Library Layer section ("Grid/list view with sort... Context menu... Collections sidebar, OPDS catalog, AI chat entry points") remains accurate. No user-visible *feature* added (existing screen re-skinned), so `README.md` is unchanged.
- [x] Version bumped: 3.24.13 → 3.24.14 (patch — behavioral but not the final WI)

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: **behavioral** — slice verification (rail scroll, filter-chip toggle, grid↔list toggle, search) is owed by the orchestrator on iPhone 17 Pro Simulator with the `vreader-debug://` harness.
- This subagent's scope ended at Gate 4 + version bump + PR open. **Gate 5a device verification is pending — orchestrator owns it.** Pre-merge evidence: build succeeds on iPhone 17 Pro Sim; the 171-test suite (including `LibraryContainerCompositionTests` view-model-state-preservation tests) passes.

## Type of Change

- [x] Feature WI (Part of feature #718 — intermediate WI)