### PR TITLE
feat(#718 WI-11): 5-theme reader settings picker — ReaderThemeV2 migration

### DIFF
--- a/.claude/codex-audits/feat-feature-60-wi-11-five-theme-picker-audit.md
+++ b/.claude/codex-audits/feat-feature-60-wi-11-five-theme-picker-audit.md
@@ -1,0 +1,95 @@
+---
+branch: feat/feature-60-wi-11-five-theme-picker
+threadId: 019e30fd-3424-7a90-ba6d-b0f1ddde2a80
+rounds: 2
+final_verdict: follow-up-recommended
+date: 2026-05-16
+---
+
+## Gate 4 — Codex implementation audit, feature #60 WI-11
+
+WI-11 is the final work item of feature #60 (visual identity v2). It
+migrates `ReaderSettingsStore.theme` from the legacy 3-case
+`ReaderTheme` enum to the 5-case `ReaderThemeV2`, making all 5 themes
+(Paper / Sepia / Dark / OLED / Photo) user-selectable, with
+backward-compatible decoding of existing persisted choices.
+
+Codex MCP, read-only sandbox. Thread `019e30fd-3424-7a90-ba6d-b0f1ddde2a80`.
+
+## Round 1
+
+Findings:
+
+- **High** — Photo theme is user-selectable but EPUB cannot render the
+  user-picked photo background image (`ReaderThemeV2+EPUBCSS.swift`
+  `backgroundImageRule` is dormant; `EPUBReaderContainerView` passes
+  `backgroundImageURL: nil`; the EPUB webview's opaque `html`
+  background occludes `ThemeBackgroundView` behind it).
+- **Low** — the 5-theme picker is close to the design but not literal:
+  the selected swatch dropped the design's second outer ring, and the
+  Photo swatch used a flat fill instead of the design's diagonal
+  gradient.
+
+Backward-compat decode, strict no-clobber handling, `theme`/`asV2`
+migration, DebugBridge producer/observer compatibility, Swift 6
+concurrency, and legacy `ReaderTheme` retention were all confirmed
+correct.
+
+## Round 1 → fixes applied
+
+- **Low (fixed)** — `ReaderSettingsPanel.themeSwatch` rewritten to
+  match the design literally: the selected swatch now gets the
+  design's two-ring treatment (a 2.5pt accent ring hugging the tile +
+  a 1.5pt outer band in `sheetTheme.sheetSurfaceColor` — the design's
+  `0 0 0 2.5px accent, 0 0 0 4px surface` box-shadow; `sheetSurfaceColor`
+  is exactly the design's `t.isDark ? '#222020' : '#fcf8f0'`), and the
+  Photo swatch uses `photoSwatchGradient` — a 135° `LinearGradient`
+  from `#3a2818` to `#1a1410`, the design's exact
+  `linear-gradient(135deg, #3a2818, #1a1410)`.
+- **High** — pushed back with scope evidence: the EPUB photo-image-CSS
+  injection is a *pre-existing WI-4 deferral*, not a WI-11 regression.
+  The `backgroundImageRule` doc comment (shipped in WI-4) explicitly
+  states the WKWebView read-access plumbing "ships in a later WI;
+  until then callers pass `backgroundImageURL: nil` and this branch
+  stays dormant." WI-11's brief scoped Photo to "make it selectable +
+  engage the existing `ThemeBackgroundStore` flow + do NOT invent UI"
+  — it did not scope the `allowingReadAccessTo` security-boundary work.
+  WI-11 broke nothing: `EPUBReaderContainerView` passed
+  `backgroundImageURL: nil` before WI-11 and still does.
+
+## Round 2
+
+- **High → resolved.** Codex agreed: "The EPUB custom-photo backdrop
+  gap is a pre-existing WI-4 deferral, not a WI-11 regression... For
+  WI-11 specifically, the right disposition is follow-up, not blocker."
+- **Low → resolved.** "The Low finding on picker fidelity is resolved
+  by the current `themeSwatch` implementation."
+- **Medium (new)** — plan/code source-of-truth mismatch: the feature
+  plan stated EPUB Photo "injects a background image via local file
+  URL" as if it were live, while the shipped code documents the branch
+  as deferred.
+
+## Round 2 → fixes applied
+
+- **Medium (fixed)** — `dev-docs/plans/20260515-feature-60-visual-identity-v2.md`
+  "Reader-engine theme injection updates > EPUB" bullet updated to
+  state the EPUB Photo background-image branch ships deferred, with
+  the WKWebView `allowingReadAccessTo` blocker spelled out and the
+  follow-up issue cited. A WI-11 revision-history entry was added.
+- **Follow-up filed** — **GH #795** ("EPUB Photo theme: render
+  user-picked background image inside the WKWebView") tracks wiring
+  the Photo theme's `ThemeBackgroundStore` image into EPUB rendering
+  (copy/symlink under the EPUB extraction root, or widen WKWebView
+  read access). Refs #718.
+
+## Disposition
+
+- Critical: none. High: none open (round-1 High re-classified as a
+  pre-existing WI-4 deferral and tracked as GH #795). Medium: none
+  open (round-2 Medium fixed via the plan update). Low: none open
+  (round-1 Low fixed).
+- Gate 4 acceptance bar (zero open Critical/High/Medium) met. The
+  single Low was fixed; the follow-up (GH #795) is for a pre-existing
+  deferral outside WI-11's scope, recorded per rule 47.
+
+Final verdict: `follow-up-recommended` (follow-up = GH #795).

--- a/dev-docs/plans/20260515-feature-60-visual-identity-v2.md
+++ b/dev-docs/plans/20260515-feature-60-visual-identity-v2.md
@@ -145,7 +145,17 @@ persistence, search, WebDAV, or AI is in scope.
 - **EPUB** (`vreader/Models/ReaderTheme.swift:epubOverrideCSS`,
   `vreader/Views/Reader/EPUBReaderContainerView.swift:329` themed
   background flow) — emit the new five-theme CSS. Photo-theme CSS
-  injects a background image via local file URL.
+  *can* inject a background image via local file URL
+  (`ReaderThemeV2+EPUBCSS.backgroundImageRule`), but that branch
+  ships **deferred**: `EPUBWebViewBridge`'s `allowingReadAccessTo`
+  is scoped to the EPUB extraction root, so a `file://` URL into
+  `ThemeBackgroundStore` (Application Support) is refused by
+  WKWebView. WI-4 ships the dormant branch (callers pass
+  `backgroundImageURL: nil`); WI-11 makes the Photo theme
+  user-selectable with its token surface rendering correctly on
+  every format, and the EPUB photo *image* backdrop is tracked as
+  a follow-up (**GH #795**) — copy/symlink the image under the EPUB
+  root before injection, or widen WKWebView read access.
 - **TXT/MD** (`vreader/Models/TXTViewConfig.swift` →
   `TXTAttributedStringBuilder`) — bundle the new fonts; replace
   hard-coded `Georgia` resolution with `ReaderTypography.body(for:)`.
@@ -1069,3 +1079,27 @@ category 2 (PLANNED feature with plan doc → Gate 3).
   `progress === 0 → "{n} pages"` branch is intentionally rendered as
   the format chip alone: `LibraryBookItem` carries no page count, and
   substituting a different metric would be self-designed UI.
+- 2026-05-16 WI-11: **5-theme settings picker — final WI gap closer.**
+  WI-2 shipped the 5-case `ReaderThemeV2` model and WI-4/WI-5 routed
+  reader rendering through it, but the user-facing theme SETTING
+  (`ReaderSettingsStore.theme`) stayed on the legacy 3-case
+  `ReaderTheme`, so `ReaderSettingsPanel`'s picker iterated
+  `ReaderTheme.allCases` — only 3 swatches, OLED + Photo unreachable.
+  WI-11 migrates `ReaderSettingsStore.theme` to `ReaderThemeV2`, adds
+  the backward-compat string decoders `ReaderThemeV2(legacyOrNew:)`
+  (non-throwing, default fallback — for the UserDefaults load) and
+  `ReaderThemeV2(recognized:)` (strict, nil on unknown — so an
+  unrecognized per-book `themeName` doesn't clobber the live theme),
+  and switches the picker to all 5 `ReaderThemeV2` swatches per the
+  design's `ReaderSettingsSheet`. `PDFViewBridge` + the DebugBridge
+  `theme` command/snapshot migrate to `ReaderThemeV2` for the type
+  change. Codex Gate 4 thread `019e30fd-3424-7a90-ba6d-b0f1ddde2a80`,
+  2 rounds, final verdict `follow-up-recommended`. Round 1 raised the
+  EPUB Photo background-image gap as High; round 2 agreed it is a
+  pre-existing WI-4 deferral (not a WI-11 regression — the EPUB CSS
+  `background-image` branch was dormant before WI-11) and downgraded
+  to a tracked follow-up (**GH #795**). Round-1 Low (picker not
+  literal to the design) fixed: the swatch now uses the design's
+  two-ring selected treatment + the 135° Photo gradient. Round-2
+  Medium (plan/code mismatch on the EPUB Photo claim) fixed by this
+  revision (see "Reader-engine theme injection updates > EPUB").

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 411
-        MARKETING_VERSION: 3.25.0
+        CURRENT_PROJECT_VERSION: 412
+        MARKETING_VERSION: 3.26.0
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -4846,13 +4846,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 411;
+				CURRENT_PROJECT_VERSION = 412;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.25.0;
+				MARKETING_VERSION = 3.26.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4996,13 +4996,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 411;
+				CURRENT_PROJECT_VERSION = 412;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.25.0;
+				MARKETING_VERSION = 3.26.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -208,6 +208,7 @@
 		32D7C0D02816850ACA1BD3E9 /* SelectionPopoverActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6114D9038B37A9B437BDC9 /* SelectionPopoverActionTests.swift */; };
 		32F4E36941EDCA2C0D457777 /* ReaderNotificationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC7EBBBE07E87F07CC0FE4F /* ReaderNotificationHandlerTests.swift */; };
 		33226957615967F3FE36DD40 /* BookDownloadSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF6B274A7CA4B3240E60E9F /* BookDownloadSheet.swift */; };
+		33860D7733C6A776E4E7E451 /* ReaderSettingsPanelThemePickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D51DC243D8B3F2A404ABA38 /* ReaderSettingsPanelThemePickerTests.swift */; };
 		33B874FB4BB17A21ACA4468E /* BookFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41C3ECA5E8F6419DB347F2E4 /* BookFormat.swift */; };
 		3400D16324A8EFC7298B2B15 /* AISettingsViewModelMultiProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85E36013A798EB205697B9A /* AISettingsViewModelMultiProfileTests.swift */; };
 		345A4B6E5A4A3A6F96F6B85D /* LocatorFactoryTXTChapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D2ACCFF53EDBE89326A37F /* LocatorFactoryTXTChapterTests.swift */; };
@@ -1071,6 +1072,7 @@
 		1C07D184EF0E90D5F2DF7A36 /* EPUBWebViewBridgeJS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBWebViewBridgeJS.swift; sourceTree = "<group>"; };
 		1C1B3D47B7CCE2B9CBC61B7A /* SimpTradTransformTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpTradTransformTests.swift; sourceTree = "<group>"; };
 		1CF348591A8246AA1524CD10 /* EPUBLayoutPreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBLayoutPreference.swift; sourceTree = "<group>"; };
+		1D51DC243D8B3F2A404ABA38 /* ReaderSettingsPanelThemePickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsPanelThemePickerTests.swift; sourceTree = "<group>"; };
 		1D579834E6924BB521873C38 /* FormatCapabilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatCapabilitiesTests.swift; sourceTree = "<group>"; };
 		1EC15AFBBED7042657A406C9 /* OffsetMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffsetMap.swift; sourceTree = "<group>"; };
 		1F0072BB2EF5A87447A6101A /* ReaderSettingsThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsThemeTests.swift; sourceTree = "<group>"; };
@@ -2348,6 +2350,7 @@
 				07B1C372BC384811003D5608 /* ReaderSettingsPanelChineseConversionGateTests.swift */,
 				83246694DE80F5760F85506E /* ReaderSettingsPanelReadingModeGateTests.swift */,
 				0024CBCAE4AC02A47B58AE48 /* ReaderSettingsPanelTapZonesGateTests.swift */,
+				1D51DC243D8B3F2A404ABA38 /* ReaderSettingsPanelThemePickerTests.swift */,
 				63E4737FA3A880C3CC2BA07D /* ReadingProgressBarTests.swift */,
 				BE6616756D16593398F889C8 /* ResolveHighlightColorTests.swift */,
 				62569DC663E2BDD2DC0155C3 /* SearchHighlightDismissTests.swift */,
@@ -4099,6 +4102,7 @@
 				E2D367FAF3E72F3B5B4D3BDD /* ReaderSettingsPanelChineseConversionGateTests.swift in Sources */,
 				65FDF3DF582C0F5E67305EED /* ReaderSettingsPanelReadingModeGateTests.swift in Sources */,
 				B5EED69421D1469D01B8C392 /* ReaderSettingsPanelTapZonesGateTests.swift in Sources */,
+				33860D7733C6A776E4E7E451 /* ReaderSettingsPanelThemePickerTests.swift in Sources */,
 				B5114E58420F95EFB408CA82 /* ReaderSettingsStoreTests.swift in Sources */,
 				6173290A06E9E4303D363AE8 /* ReaderThemeCSSTests.swift in Sources */,
 				7A3B9A992F12E5E187F0794E /* ReaderThemeMigrationTests.swift in Sources */,

--- a/vreader/Models/ReaderTheme+ToV2.swift
+++ b/vreader/Models/ReaderTheme+ToV2.swift
@@ -1,35 +1,81 @@
-// Purpose: Feature #60 WI-4 — legacy `ReaderTheme` → `ReaderThemeV2`
-// projection. Lets WI-4+ call sites (EPUB CSS, TXT/MD theme) drive
-// the new 5-token surface while `ReaderSettingsStore.theme` still
-// stores the 3-case legacy enum, until a later WI migrates the
-// settings type itself.
+// Purpose: Feature #60 — legacy `ReaderTheme` ↔ `ReaderThemeV2` bridge.
+// Two faces of the same migration:
 //
-// Why this is a `var` and not a `init?(legacy:)`:
-// - The mapping is total (every legacy case has a V2 home), so an
-//   optional return would be misleading.
-// - Codable already handles persisted-string migration via the
-//   legacy "light" alias in `ReaderThemeV2.init(from:)`. This file
-//   covers the type-level projection used by code that holds a
-//   `ReaderTheme` value at runtime.
+//  1. `ReaderTheme.asV2` (WI-4) — type-level projection used by
+//     code that holds a legacy `ReaderTheme` value at runtime.
+//  2. `ReaderThemeV2(legacyOrNew:)` (WI-11) — non-throwing string
+//     mapper. WI-11 migrates `ReaderSettingsStore.theme` to
+//     `ReaderThemeV2`; the UserDefaults `readerTheme` key and the
+//     per-book `themeName` field both carry bare rawValue strings
+//     (not JSON-wrapped), so the `Codable` decoder is awkward at
+//     those call sites. This is the single source of truth for
+//     "interpret a stored theme string".
 //
-// Mapping (matches the Codable alias):
-//   .light → .paper
-//   .sepia → .sepia
-//   .dark  → .dark
+// Mapping (matches the Codable alias in `ReaderThemeV2.init(from:)`):
+//   legacy "light" → .paper
+//   legacy "sepia" → .sepia  (same name in V2)
+//   legacy "dark"  → .dark   (same name in V2)
 //
-// OLED and Photo have no legacy equivalent — they are reachable only
-// via the V2-aware settings path that ships in a later WI.
+// `ReaderTheme.asV2` stays a `var` (not `init?(legacy:)`) because the
+// legacy→V2 mapping is total — an optional return would be misleading.
+// OLED and Photo have no legacy equivalent; before WI-11 they were
+// reachable only by the V2-aware reader-engine paths, and from WI-11
+// onward also by the 5-theme settings picker.
 
 import Foundation
 
 extension ReaderTheme {
-    /// V2 projection of this legacy theme. Used by WI-4+ injection
-    /// paths while `ReaderSettingsStore.theme` is still 3-case typed.
+    /// V2 projection of this legacy theme. Used by injection paths
+    /// (EPUB CSS, TXT/MD theme) and by the WI-11 backward-compat
+    /// decode in `ReaderThemeV2(legacyOrNew:)`.
     var asV2: ReaderThemeV2 {
         switch self {
         case .light: return .paper
         case .sepia: return .sepia
         case .dark:  return .dark
+        }
+    }
+}
+
+extension ReaderThemeV2 {
+    /// Maps a stored theme string — a new `ReaderThemeV2` rawValue, a
+    /// legacy `ReaderTheme` rawValue, `nil`, or an unknown value — to a
+    /// `ReaderThemeV2`. Feature #60 WI-11 backward-compat decode.
+    ///
+    /// Resolution order:
+    ///  1. New rawValue (`paper` / `sepia` / `dark` / `oled` / `photo`).
+    ///  2. Legacy `ReaderTheme` rawValue (`light` → `.paper`; `sepia` /
+    ///     `dark` already covered by step 1, so this only fires for
+    ///     `light`).
+    ///  3. `nil` or unknown → `.default` (`.paper`).
+    ///
+    /// Non-throwing on purpose: every call site (UserDefaults load,
+    /// per-book `themeName` apply) already owns a fallback policy, and
+    /// the policy is uniformly "fall back to the default theme". The
+    /// throwing `Codable` decoder remains for JSON-wrapped values; this
+    /// agrees with it for every value the decoder accepts.
+    init(legacyOrNew raw: String?) {
+        self = ReaderThemeV2(recognized: raw) ?? .default
+    }
+
+    /// Strict counterpart of `init(legacyOrNew:)`: returns `nil` for an
+    /// unknown or `nil` string instead of falling back to `.default`.
+    /// Used where the caller must NOT clobber existing state on a
+    /// corrupt value — e.g. `ReaderSettingsStore.applyResolvedSettings`
+    /// only assigns the theme when the per-book `themeName` is a
+    /// recognized value, leaving the live theme untouched otherwise.
+    ///
+    /// Recognizes the same set as `init(legacyOrNew:)`: the 5 new
+    /// rawValues plus the legacy `ReaderTheme` rawValue `light`
+    /// (`sepia` / `dark` are shared names).
+    init?(recognized raw: String?) {
+        guard let raw else { return nil }
+        if let v2 = ReaderThemeV2(rawValue: raw) {
+            self = v2
+        } else if let legacy = ReaderTheme(rawValue: raw) {
+            self = legacy.asV2
+        } else {
+            return nil
         }
     }
 }

--- a/vreader/Services/DebugBridge/DebugBridgeNotifications.swift
+++ b/vreader/Services/DebugBridge/DebugBridgeNotifications.swift
@@ -31,7 +31,11 @@ extension Notification.Name {
     /// readers a chance to pick up the change too.
     ///
     /// userInfo:
-    /// - `"mode"`: String — "dark" or "light" (ReaderTheme.rawValue)
+    /// - `"mode"`: String — a `ReaderThemeV2` rawValue. The bridge's
+    ///   two-valued `ThemeMode` posts `"dark"` or `"paper"` (Feature
+    ///   #60 WI-11 migrated the reader theme to `ReaderThemeV2`); a
+    ///   legacy `"light"` from an older sender still decodes via
+    ///   `ReaderThemeV2(recognized:)` on the observer side.
     /// - `"fontSize"`: Int? — optional new font size, present only when
     ///   the bridge command included a fontSize parameter.
     static let debugBridgeThemeChanged = Notification.Name("vreader.debugBridge.themeChanged")

--- a/vreader/Services/DebugBridge/RealDebugBridgeContext+Snapshot.swift
+++ b/vreader/Services/DebugBridge/RealDebugBridgeContext+Snapshot.swift
@@ -89,12 +89,11 @@ extension RealDebugBridgeContext {
         return dir
     }
 
-    fileprivate func themeName(from theme: ReaderTheme) -> String {
-        switch theme {
-        case .light: return "light"
-        case .sepia: return "sepia"
-        case .dark: return "dark"
-        }
+    /// The snapshot's `theme` string. Feature #60 WI-11: `theme` is a
+    /// `ReaderThemeV2`; its rawValue is the canonical name
+    /// (`paper` / `sepia` / `dark` / `oled` / `photo`).
+    fileprivate func themeName(from theme: ReaderThemeV2) -> String {
+        theme.rawValue
     }
 
     fileprivate func totalHighlightCount() async throws -> Int {

--- a/vreader/Services/DebugBridge/RealDebugBridgeContext.swift
+++ b/vreader/Services/DebugBridge/RealDebugBridgeContext.swift
@@ -220,7 +220,10 @@ final class RealDebugBridgeContext: DebugBridgeContext {
     /// reopen — out of scope for v0.)
     func theme(mode: DebugCommand.ThemeMode, fontSize: Int?) async throws {
         let store = ReaderSettingsStore(defaults: userDefaults)
-        let target: ReaderTheme = (mode == .dark) ? .dark : .light
+        // Feature #60 WI-11: `store.theme` is `ReaderThemeV2`. The
+        // bridge's two-valued `ThemeMode` maps `.dark` → `.dark` and
+        // `.light` → `.paper` (the V2 light-family theme).
+        let target: ReaderThemeV2 = (mode == .dark) ? .dark : .paper
         if store.theme != target {
             store.theme = target
         }

--- a/vreader/Services/ReaderSettingsStore.swift
+++ b/vreader/Services/ReaderSettingsStore.swift
@@ -16,7 +16,13 @@ final class ReaderSettingsStore {
     static let autoPageTurnIntervalKey = "readerAutoPageTurnInterval"
     static let pageTurnAnimationKey = "readerPageTurnAnimation"
     static let chineseConversionKey = "readerChineseConversion"
-    var theme: ReaderTheme { didSet { guard !suppressPersistence else { return }; defaults.set(theme.rawValue, forKey: Self.themeKey) } }
+    /// The reader color theme. Feature #60 WI-11: migrated from the
+    /// legacy 3-case `ReaderTheme` to the 5-case `ReaderThemeV2`
+    /// (Paper / Sepia / Dark / OLED / Photo) so all 5 themes are
+    /// user-selectable. Persisted as the V2 rawValue; legacy values
+    /// (`light` / `sepia` / `dark`) still decode via
+    /// `ReaderThemeV2(legacyOrNew:)`.
+    var theme: ReaderThemeV2 { didSet { guard !suppressPersistence else { return }; defaults.set(theme.rawValue, forKey: Self.themeKey) } }
     var readingMode: ReadingMode { didSet { guard !suppressPersistence else { return }; defaults.set(readingMode.rawValue, forKey: Self.readingModeKey) } }
     var epubLayout: EPUBLayoutPreference { didSet { guard !suppressPersistence else { return }; defaults.set(epubLayout.rawValue, forKey: Self.epubLayoutKey) } }
     /// Whether auto page turning is enabled (Issue 9).
@@ -66,8 +72,13 @@ final class ReaderSettingsStore {
 
     // MARK: - Loaders (single source of truth for init + reconcile)
 
-    private static func loadTheme(_ defaults: UserDefaults) -> ReaderTheme {
-        ReaderTheme(rawValue: defaults.string(forKey: themeKey) ?? "") ?? .default
+    /// Feature #60 WI-11: decodes the persisted theme via
+    /// `ReaderThemeV2(legacyOrNew:)` so a `readerTheme` value written by
+    /// a pre-WI-11 build (legacy `ReaderTheme` rawValue) still resolves
+    /// — `light` → `.paper`, `sepia` / `dark` unchanged. A missing or
+    /// unknown value falls back to `.default` (`.paper`).
+    private static func loadTheme(_ defaults: UserDefaults) -> ReaderThemeV2 {
+        ReaderThemeV2(legacyOrNew: defaults.string(forKey: themeKey))
     }
     private static func loadReadingMode(_ defaults: UserDefaults) -> ReadingMode {
         ReadingMode(rawValue: defaults.string(forKey: readingModeKey) ?? "") ?? .native
@@ -139,7 +150,11 @@ final class ReaderSettingsStore {
     func applyResolvedSettings(_ resolved: ResolvedSettings) {
         suppressPersistence = true
         defer { suppressPersistence = false }
-        if let t = ReaderTheme(rawValue: resolved.themeName), t != theme { theme = t }
+        // Feature #60 WI-11: decode the per-book `themeName` via the
+        // strict `ReaderThemeV2(recognized:)` so a legacy value
+        // (`light` → `.paper`) still applies, while an unknown / corrupt
+        // value leaves the live theme untouched (no silent reset).
+        if let t = ReaderThemeV2(recognized: resolved.themeName), t != theme { theme = t }
         if let m = ReadingMode(rawValue: resolved.readingMode), m != readingMode { readingMode = m }
         if resolved.fontSize != typography.fontSize { typography.fontSize = resolved.fontSize }
         if resolved.lineSpacing != typography.lineSpacing { typography.lineSpacing = resolved.lineSpacing }
@@ -157,17 +172,14 @@ final class ReaderSettingsStore {
     var uiFont: UIFont {
         ReaderTypography.body(for: typography.fontFamily, size: typography.fontSize)
     }
-    // Feature #60 WI-5: route TXT/MD reader colors through
-    // `ReaderThemeV2`'s token surface. `theme.asV2` projects the
-    // legacy 3-case enum (.light → .paper, .sepia → .sepia, .dark →
-    // .dark) so existing persisted settings keep working; the
-    // 5-token surface (`backgroundColor` / `inkColor` / `subColor`)
-    // replaces the legacy 3-color palette so TXT and MD pick up
-    // the new visual identity. EPUB went through the same
-    // projection in WI-4.
-    var uiBackgroundColor: UIColor { theme.asV2.backgroundColor }
-    var uiTextColor: UIColor { theme.asV2.inkColor }
-    var uiSecondaryTextColor: UIColor { theme.asV2.subColor }
+    // Feature #60 WI-5/WI-11: TXT/MD reader colors come straight from
+    // `ReaderThemeV2`'s token surface. WI-11 migrated `theme` itself to
+    // `ReaderThemeV2`, so these accessors read its 5-token surface
+    // (`backgroundColor` / `inkColor` / `subColor`) directly — no
+    // `asV2` projection needed.
+    var uiBackgroundColor: UIColor { theme.backgroundColor }
+    var uiTextColor: UIColor { theme.inkColor }
+    var uiSecondaryTextColor: UIColor { theme.subColor }
     var lineSpacingPoints: CGFloat { typography.fontSize * (typography.lineSpacing - 1.0) }
     var cjkLetterSpacing: CGFloat { typography.cjkSpacing ? typography.fontSize * 0.05 : 0 }
     #endif
@@ -176,13 +188,12 @@ final class ReaderSettingsStore {
         // Feature #60 WI-5: thread the V2 token surface through the
         // Markdown renderer so blockquotes and code-block backgrounds
         // pick up per-theme colors instead of platform defaults.
-        let v2 = theme.asV2
-        return MDRenderConfig(
+        MDRenderConfig(
             fontSize: typography.fontSize,
             lineSpacing: lineSpacingPoints,
             textColor: uiTextColor,
-            secondaryColor: v2.subColor,
-            codeBackgroundColor: v2.paperColor
+            secondaryColor: theme.subColor,
+            codeBackgroundColor: theme.paperColor
         )
     }
     var txtViewConfig: TXTViewConfig {

--- a/vreader/Views/Reader/EPUBReaderContainerView+Navigation.swift
+++ b/vreader/Views/Reader/EPUBReaderContainerView+Navigation.swift
@@ -21,7 +21,7 @@ extension EPUBReaderContainerView {
     @ViewBuilder
     var bottomOverlay: some View {
         ReaderBottomChrome(
-            theme: settingsStore?.theme.asV2 ?? .paper,
+            theme: settingsStore?.theme ?? .paper,
             progress: $readingProgress,
             onSeek: { handleProgressSeek($0) },
             discreteSteps: epubDiscreteSteps,

--- a/vreader/Views/Reader/EPUBReaderContainerView.swift
+++ b/vreader/Views/Reader/EPUBReaderContainerView.swift
@@ -263,7 +263,7 @@ struct EPUBReaderContainerView: View {
         // consistent with TXT/MD losing the iOS-default Copy when
         // their empty `UIMenu` returned).
         .selectionPopoverPresenter(
-            theme: settingsStore?.theme.asV2 ?? .paper,
+            theme: settingsStore?.theme ?? .paper,
             // WI-7c5b: drop the cached selection when the popover
             // closes without an action — keeps the single-entry
             // cache from holding a stale `ReaderSelectionEvent`
@@ -339,21 +339,19 @@ struct EPUBReaderContainerView: View {
             EPUBWebViewBridge(
                 contentURL: contentURL,
                 baseDirectory: accessRoot,
-                // Feature #60 WI-4: route through ReaderThemeV2's 5-token
-                // surface. `ReaderSettingsStore.theme` is still the
-                // legacy 3-case enum at this point; `asV2` projects
-                // light → paper while preserving sepia/dark, so existing
-                // user settings keep their books rendering without an
-                // explicit migration write.
+                // Feature #60 WI-4/WI-11: route through ReaderThemeV2's
+                // 5-token surface. WI-11 migrated `ReaderSettingsStore.theme`
+                // to `ReaderThemeV2`, so `epubOverrideCSS` is read directly
+                // off the stored theme — Paper / Sepia / Dark / OLED / Photo.
                 themeCSS: settingsStore.map {
-                    $0.theme.asV2.epubOverrideCSS(
+                    $0.theme.epubOverrideCSS(
                         fontSize: $0.typography.fontSize,
                         lineHeight: $0.typography.lineSpacing,
                         letterSpacing: $0.typography.cjkSpacing ? $0.typography.fontSize * 0.05 / $0.typography.fontSize : 0,
                         fontFamily: $0.typography.fontFamily
                     )
                 },
-                themeBackgroundColor: settingsStore?.theme.asV2.backgroundColor,
+                themeBackgroundColor: settingsStore?.theme.backgroundColor,
                 safeAreaTopInset: proxy.safeAreaInsets.top,
                 scrollFraction: seekScrollFraction,
                 currentHref: viewModel.currentPosition?.href,

--- a/vreader/Views/Reader/FoliateReaderContainerView.swift
+++ b/vreader/Views/Reader/FoliateReaderContainerView.swift
@@ -182,7 +182,7 @@ struct FoliateReaderContainerView: View {
                     fontSize: Int(store.typography.fontSize),
                     lineHeight: Double(store.typography.lineSpacing),
                     fontFamily: nil,
-                    textColor: Self.cssColor(store.theme.textColor),
+                    textColor: Self.cssColor(store.theme.inkColor),
                     backgroundColor: Self.cssColor(store.theme.backgroundColor)
                 )
             },

--- a/vreader/Views/Reader/MDReaderContainerView.swift
+++ b/vreader/Views/Reader/MDReaderContainerView.swift
@@ -76,7 +76,7 @@ struct MDReaderContainerView: View {
                 // labels + Contents/Notes/Display/AI toolbar) replaces
                 // the legacy ReadingProgressBar + ReaderBottomOverlay.
                 ReaderBottomChrome(
-                    theme: settingsStore?.theme.asV2 ?? .paper,
+                    theme: settingsStore?.theme ?? .paper,
                     progress: $uiState.readingProgress,
                     onSeek: { seekValue in
                         let charOffset = ScrollProgressHelper.charOffsetFromProgress(
@@ -97,7 +97,7 @@ struct MDReaderContainerView: View {
         // `.readerSelectionPopoverRequested` in WI-7c2; this modifier
         // observes the notification and shows the sheet, mirroring
         // the TXT container's attachment from WI-7c2.
-        .selectionPopoverPresenter(theme: settingsStore?.theme.asV2 ?? .paper)
+        .selectionPopoverPresenter(theme: settingsStore?.theme ?? .paper)
         .task {
             // PERF: open already called by MDReaderHost
             if viewModel.renderedText == nil {

--- a/vreader/Views/Reader/PDFReaderContainerView+Overlays.swift
+++ b/vreader/Views/Reader/PDFReaderContainerView+Overlays.swift
@@ -68,7 +68,7 @@ extension PDFReaderContainerView {
     @ViewBuilder
     var bottomOverlay: some View {
         ReaderBottomChrome(
-            theme: settingsStore?.theme.asV2 ?? .paper,
+            theme: settingsStore?.theme ?? .paper,
             progress: $readingProgress,
             onSeek: { seekValue in
                 let targetPage = PDFProgressHelper.pageForSeekValue(

--- a/vreader/Views/Reader/PDFReaderContainerView.swift
+++ b/vreader/Views/Reader/PDFReaderContainerView.swift
@@ -34,9 +34,10 @@ struct PDFReaderContainerView: View {
     var modelContainer: ModelContainer?
     var ttsService: TTSService?
     /// Bug #198: settings store threaded so the PDFView gutter background can
-    /// flip to match the current ReaderTheme (Light / Sepia / Dark). Optional
-    /// to preserve source-compatibility for existing callers; nil means the
-    /// bridge falls back to PDFKit's default gutter color.
+    /// flip to match the current reader theme (Feature #60 WI-11: the
+    /// 5-theme `ReaderThemeV2` — Paper / Sepia / Dark / OLED / Photo).
+    /// Optional to preserve source-compatibility for existing callers; nil
+    /// means the bridge falls back to PDFKit's default gutter color.
     var settingsStore: ReaderSettingsStore?
 
     @State var password: String = ""

--- a/vreader/Views/Reader/PDFViewBridge.swift
+++ b/vreader/Views/Reader/PDFViewBridge.swift
@@ -46,7 +46,9 @@ struct PDFViewBridge: UIViewRepresentable {
     /// caller that hasn't been wired through. Page-interior pixels are still
     /// rendered by PDFKit from the source PDF (white for typical text PDFs);
     /// inverting page colors in dark mode is a separate feature.
-    var theme: ReaderTheme?
+    /// The reader color theme — drives the PDF gutter background tint.
+    /// Feature #60 WI-11: migrated from the legacy `ReaderTheme`.
+    var theme: ReaderThemeV2?
     /// Feature #53 WI-6: optional inline-menu presenter. When non-nil + a
     /// highlight tap resolves, `handleTap` presents the menu anchored to
     /// the tapped annotation's bounds. When nil, the bridge still posts
@@ -279,15 +281,16 @@ struct PDFViewBridge: UIViewRepresentable {
 
     // MARK: - Theme application (bug #198)
 
-    /// Sets `pdfView.backgroundColor` from the supplied `ReaderTheme`'s
-    /// `backgroundColor` palette so the gutter area surrounding the rendered
-    /// PDF page reflects Light / Sepia / Dark instead of staying on PDFKit's
-    /// default light gray. Pure helper — testable without a real
-    /// UIViewRepresentable construction. Does NOT invert the rendered page
-    /// pixels; PDFKit continues to draw the source PDF's own colors (typically
-    /// white pages with black text). Inverting the page interior in dark
-    /// theme is a separate feature.
-    static func applyThemeBackground(to pdfView: PDFView, theme: ReaderTheme) {
+    /// Sets `pdfView.backgroundColor` from the supplied `ReaderThemeV2`'s
+    /// `backgroundColor` token so the gutter area surrounding the rendered
+    /// PDF page reflects the reader theme (Paper / Sepia / Dark / OLED /
+    /// Photo) instead of staying on PDFKit's default light gray. Pure
+    /// helper — testable without a real UIViewRepresentable construction.
+    /// Does NOT invert the rendered page pixels; PDFKit continues to draw
+    /// the source PDF's own colors (typically white pages with black
+    /// text). Inverting the page interior in dark theme is a separate
+    /// feature. (Feature #60 WI-11: migrated from the legacy `ReaderTheme`.)
+    static func applyThemeBackground(to pdfView: PDFView, theme: ReaderThemeV2) {
         pdfView.backgroundColor = theme.backgroundColor
     }
 
@@ -300,9 +303,9 @@ struct PDFViewBridge: UIViewRepresentable {
     /// `pdfView.backgroundColor` directly.
     static func applyThemeIfChanged(
         pdfView: PDFView,
-        theme: ReaderTheme?,
-        lastAppliedTheme: ReaderTheme?
-    ) -> ReaderTheme? {
+        theme: ReaderThemeV2?,
+        lastAppliedTheme: ReaderThemeV2?
+    ) -> ReaderThemeV2? {
         guard let theme, lastAppliedTheme != theme else { return lastAppliedTheme }
         applyThemeBackground(to: pdfView, theme: theme)
         return theme
@@ -331,7 +334,8 @@ struct PDFViewBridge: UIViewRepresentable {
         var isSearchHighlighting: Bool = false
         /// Bug #198: tracks the last applied reader theme so updateUIView only
         /// re-applies `applyThemeBackground` when the user actually switched.
-        var lastAppliedTheme: ReaderTheme?
+        /// Feature #60 WI-11: migrated from the legacy `ReaderTheme`.
+        var lastAppliedTheme: ReaderThemeV2?
         /// Feature #53 WI-6: weak reference to the renderer that owns the
         /// `[UUID: [PDFAnnotation]]` map. handleTap consults this to detect
         /// taps on highlight annotations and post `.readerHighlightTapped`

--- a/vreader/Views/Reader/ReaderBottomOverlay.swift
+++ b/vreader/Views/Reader/ReaderBottomOverlay.swift
@@ -46,12 +46,14 @@ struct ReaderBottomOverlay: View {
 
     // MARK: - Theme Colors
 
+    // Feature #60 WI-11: `theme` is `ReaderThemeV2`; `subColor` is the
+    // V2 token for secondary text. Fallback uses `ReaderThemeV2.default`.
     private var secondaryColor: Color {
-        Color(settingsStore?.theme.secondaryTextColor ?? ReaderTheme.default.secondaryTextColor)
+        Color(settingsStore?.theme.subColor ?? ReaderThemeV2.default.subColor)
     }
 
     private var backgroundColor: Color {
-        Color(settingsStore?.theme.backgroundColor ?? ReaderTheme.default.backgroundColor).opacity(0.92)
+        Color(settingsStore?.theme.backgroundColor ?? ReaderThemeV2.default.backgroundColor).opacity(0.92)
     }
 
     // MARK: - Formatting

--- a/vreader/Views/Reader/ReaderContainerView+Sheets.swift
+++ b/vreader/Views/Reader/ReaderContainerView+Sheets.swift
@@ -174,7 +174,7 @@ extension ReaderContainerView {
     /// draws the design's backdrop tint while the popover is open.
     var readerChromeOverlay: some View {
         ReaderTopChrome(
-            theme: settingsStore.theme.asV2,
+            theme: settingsStore.theme,
             title: book.title,
             bookmarked: false,
             moreActive: showMorePopover,
@@ -198,7 +198,7 @@ extension ReaderContainerView {
     /// `.readerMoreMenuActionObservers` modifier handles row taps.
     var readerMorePopoverOverlay: some View {
         ReaderMorePopover(
-            theme: settingsStore.theme.asV2,
+            theme: settingsStore.theme,
             ttsPlaying: ttsService.state != .idle,
             autoTurnOn: settingsStore.autoPageTurn,
             autoTurnInterval: settingsStore.autoPageTurnInterval,
@@ -269,7 +269,7 @@ extension ReaderContainerView {
                 textContent: ai.currentTextContent,
                 format: resolvedBookFormat,
                 onDismiss: { showAIPanel = false },
-                theme: settingsStore.theme.asV2,
+                theme: settingsStore.theme,
                 initialTab: aiInitialTab
             )
             .presentationDetents([.medium, .large])

--- a/vreader/Views/Reader/ReaderContainerView.swift
+++ b/vreader/Views/Reader/ReaderContainerView.swift
@@ -208,9 +208,9 @@ struct ReaderContainerView: View {
         // theme. `preferredColorScheme` resolves to `.dark` for the
         // dark-family themes (Dark / OLED / Photo) so the status-bar
         // text stays light-on-dark, and `.light` for Paper / Sepia so
-        // it stays dark-on-light. The legacy 3-case `ReaderTheme` is
-        // projected through `asV2`.
-        .preferredColorScheme(settingsStore.theme.asV2.preferredColorScheme)
+        // it stays dark-on-light. WI-11 migrated `theme` to
+        // `ReaderThemeV2`, so the token is read directly.
+        .preferredColorScheme(settingsStore.theme.preferredColorScheme)
         .ignoresSafeArea(edges: .top)
         .sheet(isPresented: $showAIPanel, onDismiss: { aiInitialTab = .summarize }) { aiSheet }
         .onReceive(NotificationCenter.default.publisher(for: .readerDefineRequested)) { notification in
@@ -272,9 +272,14 @@ struct ReaderContainerView: View {
                 baseURL: Self.perBookSettingsBaseURL
             )
             // Theme: skip when per-book themeName is explicitly set.
+            // Feature #60 WI-11: decode the bridge's `mode` string via
+            // `ReaderThemeV2(recognized:)` — it accepts both the new
+            // rawValues the bridge now posts (`paper` / `dark`) and a
+            // legacy `light` from any older notification, and yields
+            // nil for an unrecognized string (no clobber).
             if perBook?.themeName == nil,
                let modeRaw = userInfo["mode"] as? String,
-               let theme = ReaderTheme(rawValue: modeRaw),
+               let theme = ReaderThemeV2(recognized: modeRaw),
                settingsStore.theme != theme {
                 settingsStore.theme = theme
             }
@@ -369,7 +374,7 @@ struct ReaderContainerView: View {
                 modelContainer: modelContext.container,
                 tocEntries: tocEntries,
                 currentLocator: currentLocator,
-                theme: settingsStore.theme.asV2,
+                theme: settingsStore.theme,
                 initialTab: annotationsPanelInitialTab,
                 onNavigate: { locator in
                     NotificationCenter.default.post(

--- a/vreader/Views/Reader/ReaderSettingsPanel.swift
+++ b/vreader/Views/Reader/ReaderSettingsPanel.swift
@@ -221,14 +221,31 @@ struct ReaderSettingsPanel: View {
         }
     }
 
+    /// The Photo swatch's preview fill — the design renders the Photo
+    /// theme's chip as a 135° diagonal gradient (`vreader-panels.jsx`:
+    /// `linear-gradient(135deg, #3a2818, #1a1410)`) rather than a flat
+    /// color, since the real Photo theme shows a user image.
+    private static let photoSwatchGradient = LinearGradient(
+        colors: [
+            Color(red: 0x3a / 255, green: 0x28 / 255, blue: 0x18 / 255),
+            Color(red: 0x1a / 255, green: 0x14 / 255, blue: 0x10 / 255),
+        ],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
     /// One theme swatch — the design's rounded-square chip
     /// (`vreader-panels.jsx` `ReaderSettingsSheet` theme selector):
-    /// a 12pt-radius tile filled with the theme background, an `Aa`
-    /// glyph (or a photo glyph for the Photo theme), the theme name
-    /// below, and a ring on the selected tile. Per the design, the
-    /// selected ring uses the *sheet's* accent (`t.accent`) and the
-    /// caption colour uses the sheet's `sub` token — consistent
-    /// across all swatches regardless of which theme each depicts.
+    /// a 12pt-radius tile filled with the theme background (a diagonal
+    /// gradient for the Photo theme), an `Aa` glyph (or a photo glyph
+    /// for the Photo theme), the theme name below, and — on the
+    /// selected tile — the design's two-ring treatment: a 2.5pt accent
+    /// ring hugging the tile plus a 1.5pt outer band in the sheet's
+    /// surface color (the design's `0 0 0 2.5px accent, 0 0 0 4px
+    /// surface` box-shadow). Per the design the selected ring uses the
+    /// *sheet's* accent (`t.accent`) and the caption colour uses the
+    /// sheet's `sub` token — consistent across all swatches regardless
+    /// of which theme each depicts.
     @ViewBuilder
     private func themeSwatch(_ theme: ReaderThemeV2) -> some View {
         let isSelected = store.theme == theme
@@ -236,29 +253,21 @@ struct ReaderSettingsPanel: View {
             store.theme = theme
         } label: {
             VStack(spacing: 6) {
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(Color(theme.backgroundColor))
+                themeSwatchTile(theme)
                     .aspectRatio(1, contentMode: .fit)
+                    // Outer band — the design's second box-shadow ring
+                    // in the sheet surface color (`0 0 0 4px surface`).
+                    // Only drawn when selected; the 1.5pt padding makes
+                    // room for it so the tile size stays constant.
+                    .padding(1.5)
                     .overlay {
-                        if theme.usesBackgroundImage {
-                            Image(systemName: "photo")
-                                .font(.system(size: 18, weight: .medium))
-                                .foregroundStyle(Color(theme.accentColor))
-                        } else {
-                            Text("Aa")
-                                .font(Font(ReaderTypography.body(for: .sourceSerif4, size: 20)))
-                                .fontWeight(.semibold)
-                                .foregroundStyle(Color(theme.inkColor))
+                        if isSelected {
+                            RoundedRectangle(cornerRadius: 13.5)
+                                .strokeBorder(
+                                    Color(sheetTheme.sheetSurfaceColor),
+                                    lineWidth: 1.5
+                                )
                         }
-                    }
-                    .overlay {
-                        RoundedRectangle(cornerRadius: 12)
-                            .strokeBorder(
-                                isSelected
-                                    ? Color(sheetTheme.accentColor)
-                                    : Color(sheetTheme.ruleColor),
-                                lineWidth: isSelected ? 2.5 : 0.5
-                            )
                     }
 
                 Text(Self.themeDisplayName(theme))
@@ -270,6 +279,47 @@ struct ReaderSettingsPanel: View {
         .buttonStyle(.plain)
         .accessibilityLabel("\(Self.themeDisplayName(theme)) theme")
         .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+
+    /// The inner tile of a theme swatch — the 12pt-radius filled chip
+    /// with the `Aa`/photo glyph and the selected/unselected hairline
+    /// ring (the design's first box-shadow: `0 0 0 2.5px accent` when
+    /// selected, `inset 0 0 0 0.5px rule` otherwise).
+    @ViewBuilder
+    private func themeSwatchTile(_ theme: ReaderThemeV2) -> some View {
+        let isSelected = store.theme == theme
+        RoundedRectangle(cornerRadius: 12)
+            .fill(swatchTileShading(theme))
+            .overlay {
+                if theme.usesBackgroundImage {
+                    Image(systemName: "photo")
+                        .font(.system(size: 18, weight: .medium))
+                        .foregroundStyle(Color(theme.accentColor))
+                } else {
+                    Text("Aa")
+                        .font(Font(ReaderTypography.body(for: .sourceSerif4, size: 20)))
+                        .fontWeight(.semibold)
+                        .foregroundStyle(Color(theme.inkColor))
+                }
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(
+                        isSelected
+                            ? Color(sheetTheme.accentColor)
+                            : Color(sheetTheme.ruleColor),
+                        lineWidth: isSelected ? 2.5 : 0.5
+                    )
+            }
+    }
+
+    /// Fill for a swatch tile — the theme background for the four flat
+    /// themes; the design's 135° diagonal gradient for the Photo theme.
+    private func swatchTileShading(_ theme: ReaderThemeV2) -> AnyShapeStyle {
+        if theme.usesBackgroundImage {
+            return AnyShapeStyle(Self.photoSwatchGradient)
+        }
+        return AnyShapeStyle(Color(theme.backgroundColor))
     }
 
     // MARK: - Theme Background (A04, feature #32)

--- a/vreader/Views/Reader/ReaderSettingsPanel.swift
+++ b/vreader/Views/Reader/ReaderSettingsPanel.swift
@@ -15,11 +15,13 @@
 // - Presented as a sheet from the reader bottom chrome's Display button.
 // - All changes apply immediately (no "save" button needed).
 // - Preview text updates live as settings change.
-// - Theme picker uses colored circles (light/sepia/dark).
+// - Theme picker (feature #60 WI-11) shows all 5 `ReaderThemeV2`
+//   themes (Paper / Sepia / Dark / OLED / Photo) as rounded-square
+//   swatches per `vreader-panels.jsx`'s `ReaderSettingsSheet`.
 // - Compact layout suitable for half-sheet presentation.
 //
 // @coordinates-with: ReaderSettingsStore.swift, ReaderContainerView.swift,
-//   ReaderSheetChrome.swift, SheetSectionContract.swift
+//   ReaderSheetChrome.swift, SheetSectionContract.swift, ReaderThemeV2.swift
 
 import PhotosUI
 import SwiftUI
@@ -57,10 +59,11 @@ struct ReaderSettingsPanel: View {
     /// Bug #134: surface theme-background load/save/remove failures.
     @State private var backgroundErrorMessage: String?
 
-    /// The design theme for the sheet chrome — projected from the
-    /// reader's current `ReaderTheme` so the Display sheet's surface
-    /// tint follows the book's theme.
-    private var sheetTheme: ReaderThemeV2 { store.theme.asV2 }
+    /// The design theme for the sheet chrome — the reader's current
+    /// `ReaderThemeV2` so the Display sheet's surface tint follows the
+    /// book's theme. (Feature #60 WI-11: `store.theme` is now
+    /// `ReaderThemeV2`, so no `asV2` projection is needed.)
+    private var sheetTheme: ReaderThemeV2 { store.theme }
 
     /// The re-skinned panel's `ReaderSheetChrome` title — exposed for
     /// the WI-10 composition test.
@@ -187,44 +190,86 @@ struct ReaderSettingsPanel: View {
 
     // MARK: - Theme
 
+    /// The themes the picker offers — Feature #60 WI-11: all 5
+    /// `ReaderThemeV2` cases (Paper / Sepia / Dark / OLED / Photo), in
+    /// the design bundle's `THEMES` declaration order. Exposed
+    /// `static` for the WI-11 composition-contract test (same pattern
+    /// as `shouldShowReadingModeSection`).
+    static var themePickerThemes: [ReaderThemeV2] { ReaderThemeV2.allCases }
+
+    /// Human label for a theme swatch caption — matches the design
+    /// bundle's `name` field (`vreader-themes.jsx`).
+    static func themeDisplayName(_ theme: ReaderThemeV2) -> String {
+        switch theme {
+        case .paper: return "Paper"
+        case .sepia: return "Sepia"
+        case .dark:  return "Dark"
+        case .oled:  return "OLED"
+        case .photo: return "Photo"
+        }
+    }
+
     @ViewBuilder
     private var themeSection: some View {
         Section("Theme") {
-            HStack(spacing: 20) {
-                Spacer()
-                ForEach(ReaderTheme.allCases, id: \.self) { theme in
-                    themeCircle(theme)
+            HStack(spacing: 10) {
+                ForEach(Self.themePickerThemes, id: \.self) { theme in
+                    themeSwatch(theme)
                 }
-                Spacer()
             }
             .padding(.vertical, 8)
         }
     }
 
+    /// One theme swatch — the design's rounded-square chip
+    /// (`vreader-panels.jsx` `ReaderSettingsSheet` theme selector):
+    /// a 12pt-radius tile filled with the theme background, an `Aa`
+    /// glyph (or a photo glyph for the Photo theme), the theme name
+    /// below, and a ring on the selected tile. Per the design, the
+    /// selected ring uses the *sheet's* accent (`t.accent`) and the
+    /// caption colour uses the sheet's `sub` token — consistent
+    /// across all swatches regardless of which theme each depicts.
     @ViewBuilder
-    private func themeCircle(_ theme: ReaderTheme) -> some View {
+    private func themeSwatch(_ theme: ReaderThemeV2) -> some View {
+        let isSelected = store.theme == theme
         Button {
             store.theme = theme
         } label: {
             VStack(spacing: 6) {
-                Circle()
+                RoundedRectangle(cornerRadius: 12)
                     .fill(Color(theme.backgroundColor))
-                    .overlay(
-                        Circle().stroke(
-                            store.theme == theme ? Color.accentColor : Color.gray.opacity(0.3),
-                            lineWidth: store.theme == theme ? 3 : 1
-                        )
-                    )
-                    .frame(width: 44, height: 44)
+                    .aspectRatio(1, contentMode: .fit)
+                    .overlay {
+                        if theme.usesBackgroundImage {
+                            Image(systemName: "photo")
+                                .font(.system(size: 18, weight: .medium))
+                                .foregroundStyle(Color(theme.accentColor))
+                        } else {
+                            Text("Aa")
+                                .font(Font(ReaderTypography.body(for: .sourceSerif4, size: 20)))
+                                .fontWeight(.semibold)
+                                .foregroundStyle(Color(theme.inkColor))
+                        }
+                    }
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 12)
+                            .strokeBorder(
+                                isSelected
+                                    ? Color(sheetTheme.accentColor)
+                                    : Color(sheetTheme.ruleColor),
+                                lineWidth: isSelected ? 2.5 : 0.5
+                            )
+                    }
 
-                Text(theme.rawValue.capitalized)
+                Text(Self.themeDisplayName(theme))
                     .font(.caption2)
-                    .foregroundStyle(store.theme == theme ? .primary : .secondary)
+                    .fontWeight(isSelected ? .semibold : .regular)
+                    .foregroundStyle(Color(sheetTheme.subColor))
             }
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("\(theme.rawValue) theme")
-        .accessibilityAddTraits(store.theme == theme ? [.isSelected] : [])
+        .accessibilityLabel("\(Self.themeDisplayName(theme)) theme")
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
     }
 
     // MARK: - Theme Background (A04, feature #32)

--- a/vreader/Views/Reader/ReadingProgressBar.swift
+++ b/vreader/Views/Reader/ReadingProgressBar.swift
@@ -65,7 +65,9 @@ struct ReadingProgressBar: View {
 
     private var secondaryColor: Color {
         if let store = settingsStore {
-            return Color(store.theme.secondaryTextColor)
+            // Feature #60 WI-11: `theme` is `ReaderThemeV2`; `subColor`
+            // is the V2 token equivalent of the legacy `secondaryTextColor`.
+            return Color(store.theme.subColor)
         }
         return .secondary
     }

--- a/vreader/Views/Reader/TTSControlBar.swift
+++ b/vreader/Views/Reader/TTSControlBar.swift
@@ -71,12 +71,14 @@ struct TTSControlBar: View {
 
     // MARK: - Theme Colors
 
+    // Feature #60 WI-11: `theme` is `ReaderThemeV2`; `subColor` is the
+    // V2 token for secondary text. Fallback uses `ReaderThemeV2.default`.
     private var secondaryColor: Color {
-        Color(settingsStore?.theme.secondaryTextColor ?? ReaderTheme.default.secondaryTextColor)
+        Color(settingsStore?.theme.subColor ?? ReaderThemeV2.default.subColor)
     }
 
     private var backgroundColor: Color {
-        Color(settingsStore?.theme.backgroundColor ?? ReaderTheme.default.backgroundColor)
+        Color(settingsStore?.theme.backgroundColor ?? ReaderThemeV2.default.backgroundColor)
             .opacity(0.95)
     }
 

--- a/vreader/Views/Reader/TXTChapterOverlayViews.swift
+++ b/vreader/Views/Reader/TXTChapterOverlayViews.swift
@@ -33,7 +33,8 @@ struct ChapterTitleOverlay: View {
     }
 
     private var backgroundColor: Color {
-        Color(settingsStore?.theme.backgroundColor ?? ReaderTheme.default.backgroundColor)
+        // Feature #60 WI-11: `theme` is `ReaderThemeV2`.
+        Color(settingsStore?.theme.backgroundColor ?? ReaderThemeV2.default.backgroundColor)
     }
 }
 #endif

--- a/vreader/Views/Reader/TXTReaderContainerView.swift
+++ b/vreader/Views/Reader/TXTReaderContainerView.swift
@@ -176,7 +176,7 @@ struct TXTReaderContainerView: View {
                 // chapter position is surfaced in the leading label.
                 if hasChapterDisplay {
                     ReaderBottomChrome(
-                        theme: settingsStore?.theme.asV2 ?? .paper,
+                        theme: settingsStore?.theme ?? .paper,
                         progress: $chapterScrollFraction,
                         onSeek: { seekValue in
                             guard let chapters = viewModel.chapterIndex?.chapters,
@@ -192,7 +192,7 @@ struct TXTReaderContainerView: View {
                     )
                 } else {
                     ReaderBottomChrome(
-                        theme: settingsStore?.theme.asV2 ?? .paper,
+                        theme: settingsStore?.theme ?? .paper,
                         progress: $chapterScrollFraction,
                         onSeek: { seekValue in
                             // If TOC entries exist, seek within current chapter
@@ -220,12 +220,12 @@ struct TXTReaderContainerView: View {
         // bridge (TXTTextViewBridgeCoordinator) posts
         // `.readerSelectionPopoverRequested` from
         // `editMenuForTextIn`; this modifier observes the
-        // notification and shows the sheet. Theme comes from the
-        // legacy `ReaderTheme` projected through `.asV2`; falls back
-        // to `.paper` when no settings store is wired (preview /
-        // tests). WI-7c3..7c5 attach the same modifier to the
-        // chunked TXT / MD / EPUB containers.
-        .selectionPopoverPresenter(theme: settingsStore?.theme.asV2 ?? .paper)
+        // notification and shows the sheet. Theme is the store's
+        // `ReaderThemeV2` (WI-11 migrated the type); falls back to
+        // `.paper` when no settings store is wired (preview / tests).
+        // WI-7c3..7c5 attach the same modifier to the chunked TXT /
+        // MD / EPUB containers.
+        .selectionPopoverPresenter(theme: settingsStore?.theme ?? .paper)
         .task {
             // PERF: open already called by TXTReaderHost — skip if content loaded
             if viewModel.textContent == nil && viewModel.currentChapterText == nil {

--- a/vreaderTests/Models/ReaderThemeMigrationTests.swift
+++ b/vreaderTests/Models/ReaderThemeMigrationTests.swift
@@ -148,5 +148,70 @@ struct ReaderThemeMigrationTests {
             )
         }
     }
+
+    // MARK: - `init(legacyOrNew:)` — Feature #60 WI-11
+    //
+    // WI-11 migrates `ReaderSettingsStore.theme` to `ReaderThemeV2`.
+    // Settings persistence (UserDefaults `readerTheme` key) and the
+    // per-book `themeName` field both carry bare rawValue strings — not
+    // JSON-wrapped — so the `Codable` decoder (which works on a
+    // `singleValueContainer`) is awkward at those call sites. WI-11
+    // adds a non-throwing string mapper that is the single source of
+    // truth for "interpret a stored theme string": new names, the
+    // legacy `ReaderTheme` names, and `nil`/unknown → `.default`.
+
+    /// New rawValues map to themselves.
+    @Test
+    func legacyOrNew_newNames_mapToSelf() {
+        for theme in ReaderThemeV2.allCases {
+            #expect(ReaderThemeV2(legacyOrNew: theme.rawValue) == theme)
+        }
+    }
+
+    /// Legacy `ReaderTheme` rawValue `"light"` migrates to `.paper`.
+    @Test
+    func legacyOrNew_legacyLight_yieldsPaper() {
+        #expect(ReaderThemeV2(legacyOrNew: "light") == .paper)
+    }
+
+    /// Legacy `"sepia"` / `"dark"` keep their identity (same name in V2).
+    @Test
+    func legacyOrNew_legacySepiaDark_preserveIdentity() {
+        #expect(ReaderThemeV2(legacyOrNew: "sepia") == .sepia)
+        #expect(ReaderThemeV2(legacyOrNew: "dark") == .dark)
+    }
+
+    /// An unknown string falls back to `.default` (`.paper`) — the
+    /// non-throwing mapper is for call sites that already own a
+    /// fallback policy (UserDefaults / per-book themeName).
+    @Test
+    func legacyOrNew_unknown_fallsBackToDefault() {
+        #expect(ReaderThemeV2(legacyOrNew: "chartreuse") == .default)
+        #expect(ReaderThemeV2(legacyOrNew: "chartreuse") == .paper)
+    }
+
+    /// An empty string falls back to `.default`.
+    @Test
+    func legacyOrNew_emptyString_fallsBackToDefault() {
+        #expect(ReaderThemeV2(legacyOrNew: "") == .default)
+    }
+
+    /// `nil` (no persisted value at all) falls back to `.default`.
+    @Test
+    func legacyOrNew_nil_fallsBackToDefault() {
+        #expect(ReaderThemeV2(legacyOrNew: nil) == .default)
+    }
+
+    /// The legacy-OR-new mapper agrees with the `Codable` decoder for
+    /// every value the decoder accepts — they must not drift apart.
+    @Test
+    func legacyOrNew_agreesWithCodableDecoder() throws {
+        for raw in ["paper", "sepia", "dark", "oled", "photo", "light"] {
+            let viaCodable = try JSONDecoder().decode(
+                ReaderThemeV2.self, from: Data("\"\(raw)\"".utf8)
+            )
+            #expect(ReaderThemeV2(legacyOrNew: raw) == viaCodable)
+        }
+    }
 }
 #endif

--- a/vreaderTests/Models/StatusBarTintingTests.swift
+++ b/vreaderTests/Models/StatusBarTintingTests.swift
@@ -80,8 +80,12 @@ struct StatusBarTintingTests {
 
     @Test("Legacy ReaderTheme projects to a color scheme via asV2")
     func legacyThemeProjectsToColorScheme() {
-        // `ReaderSettingsStore.theme` is still the 3-case legacy enum;
-        // the reader container reads `theme.asV2.preferredColorScheme`.
+        // The legacy `ReaderTheme.asV2` projection is retained as the
+        // backward-compat decode bridge — `ReaderThemeV2(legacyOrNew:)`
+        // routes legacy persisted values through it. (Feature #60 WI-11
+        // migrated `ReaderSettingsStore.theme` itself to `ReaderThemeV2`,
+        // so the reader container now reads `theme.preferredColorScheme`
+        // directly; this test still pins the legacy projection.)
         #expect(ReaderTheme.light.asV2.preferredColorScheme == .light)
         #expect(ReaderTheme.sepia.asV2.preferredColorScheme == .light)
         #expect(ReaderTheme.dark.asV2.preferredColorScheme == .dark)

--- a/vreaderTests/Services/DebugBridge/RealDebugBridgeContextTests.swift
+++ b/vreaderTests/Services/DebugBridge/RealDebugBridgeContextTests.swift
@@ -247,7 +247,9 @@ final class RealDebugBridgeContextTests: XCTestCase {
 
     @MainActor
     func test_theme_lightModeSetsThemeInUserDefaults() async throws {
-        // Pre-set to dark so we can verify mode=light flips it back
+        // Pre-set to dark so we can verify mode=light flips it back.
+        // Feature #60 WI-11: `store.theme` is `ReaderThemeV2`; the
+        // bridge's `.light` mode maps to the `.paper` theme.
         let pre = ReaderSettingsStore(defaults: defaults)
         pre.theme = .dark
 
@@ -259,7 +261,7 @@ final class RealDebugBridgeContextTests: XCTestCase {
         try await context.theme(mode: .light, fontSize: nil)
 
         let store = ReaderSettingsStore(defaults: defaults)
-        XCTAssertEqual(store.theme, .light)
+        XCTAssertEqual(store.theme, .paper)
     }
 
     @MainActor
@@ -315,7 +317,9 @@ final class RealDebugBridgeContextTests: XCTestCase {
 
         try await context.theme(mode: .light, fontSize: nil)
         await fulfillment(of: [exp], timeout: 2.0)
-        XCTAssertEqual(receivedMode, "light")
+        // Feature #60 WI-11: the bridge posts the `ReaderThemeV2`
+        // rawValue; `.light` mode → the `.paper` theme.
+        XCTAssertEqual(receivedMode, "paper")
     }
 
     @MainActor

--- a/vreaderTests/Services/PerBookSettingsTests.swift
+++ b/vreaderTests/Services/PerBookSettingsTests.swift
@@ -104,7 +104,7 @@ struct PerBookSettingsTests {
     @Test @MainActor func resolvedSettings_usesPerBook_whenSet() {
         let global = makeGlobalStore()
         global.typography.fontSize = 18
-        global.theme = .light
+        global.theme = .paper
         let perBook = PerBookSettingsOverride(fontSize: 26, themeName: "dark")
         let resolved = PerBookSettingsStore.resolve(perBook: perBook, global: global)
         #expect(resolved.fontSize == 26)
@@ -129,13 +129,15 @@ struct PerBookSettingsTests {
         global.typography.fontSize = 18
         global.typography.lineSpacing = 1.4
         global.typography.fontFamily = .system
-        global.theme = .light
+        global.theme = .paper
         let perBook = PerBookSettingsOverride(fontSize: 28)
         let resolved = PerBookSettingsStore.resolve(perBook: perBook, global: global)
         #expect(resolved.fontSize == 28)
         #expect(resolved.lineSpacing == 1.4)
         #expect(resolved.fontName == "system")
-        #expect(resolved.themeName == "light")
+        // Feature #60 WI-11: `global.theme` is `ReaderThemeV2`; its
+        // rawValue for `.paper` is "paper".
+        #expect(resolved.themeName == "paper")
     }
 
     @Test @MainActor func resolvedSettings_allFieldsOverridden() {
@@ -143,7 +145,7 @@ struct PerBookSettingsTests {
         global.typography.fontSize = 18
         global.typography.lineSpacing = 1.4
         global.typography.fontFamily = .system
-        global.theme = .light
+        global.theme = .paper
         global.readingMode = .native
         let perBook = PerBookSettingsOverride(
             fontSize: 30, fontName: "serif", lineSpacing: 2.0,
@@ -216,7 +218,7 @@ struct PerBookSettingsTests {
         store.typography.fontSize = 18
         store.typography.lineSpacing = 1.4
         store.typography.fontFamily = .system
-        store.theme = .light
+        store.theme = .paper
         store.readingMode = .native
 
         let resolved = ResolvedSettings(
@@ -237,7 +239,7 @@ struct PerBookSettingsTests {
         let defaults = UserDefaults(suiteName: suiteName)!
         let store = ReaderSettingsStore(defaults: defaults)
         store.typography.fontSize = 18
-        store.theme = .light
+        store.theme = .paper
         // Explicit set: ReaderSettingsStore only writes a key to UserDefaults
         // when the property is explicitly assigned. The defaults assertion
         // below ("readingMode is 'native' after apply") only makes sense if
@@ -258,8 +260,10 @@ struct PerBookSettingsTests {
         #expect(store.typography.fontSize == 30)
         #expect(store.theme == .dark)
 
-        // But UserDefaults should still have the original global values
-        #expect(defaults.string(forKey: ReaderSettingsStore.themeKey) == "light")
+        // But UserDefaults should still have the original global values.
+        // Feature #60 WI-11: the global theme was set to `.paper`
+        // (ReaderThemeV2), so the persisted rawValue is "paper".
+        #expect(defaults.string(forKey: ReaderSettingsStore.themeKey) == "paper")
         #expect(defaults.string(forKey: ReaderSettingsStore.readingModeKey) == "native")
     }
 
@@ -277,6 +281,89 @@ struct PerBookSettingsTests {
 
         #expect(store.typography.fontSize == 20)
         #expect(store.theme == .sepia)
+    }
+
+    // MARK: - Feature #60 WI-11: per-book themeName round-trip
+
+    /// A per-book `themeName` carrying any of the 5 `ReaderThemeV2`
+    /// rawValues — including OLED and Photo — must apply onto the
+    /// store. WI-11 makes those themes user-selectable, so a per-book
+    /// override can legitimately carry them.
+    @Test @MainActor func applyResolvedSettings_allFiveV2Themes() {
+        for theme in ReaderThemeV2.allCases {
+            let store = makeGlobalStore()
+            store.theme = .paper
+            let resolved = ResolvedSettings(
+                fontSize: store.typography.fontSize,
+                fontName: store.typography.fontFamily.rawValue,
+                lineSpacing: store.typography.lineSpacing,
+                letterSpacing: 0,
+                themeName: theme.rawValue, readingMode: store.readingMode.rawValue
+            )
+            store.applyResolvedSettings(resolved)
+            #expect(store.theme == theme,
+                    "per-book themeName '\(theme.rawValue)' must apply onto the store")
+        }
+    }
+
+    /// A per-book override written before WI-11 carries a legacy
+    /// `ReaderTheme` rawValue ("light" / "sepia" / "dark"). Resolving
+    /// it must migrate "light" → `.paper` and preserve sepia / dark.
+    @Test @MainActor func applyResolvedSettings_legacyThemeNamesMigrate() {
+        let cases: [(legacy: String, expected: ReaderThemeV2)] = [
+            ("light", .paper), ("sepia", .sepia), ("dark", .dark),
+        ]
+        for c in cases {
+            let store = makeGlobalStore()
+            store.theme = .oled  // start somewhere distinct
+            let resolved = ResolvedSettings(
+                fontSize: store.typography.fontSize,
+                fontName: store.typography.fontFamily.rawValue,
+                lineSpacing: store.typography.lineSpacing,
+                letterSpacing: 0,
+                themeName: c.legacy, readingMode: store.readingMode.rawValue
+            )
+            store.applyResolvedSettings(resolved)
+            #expect(store.theme == c.expected,
+                    "legacy per-book themeName '\(c.legacy)' must migrate to \(c.expected.rawValue)")
+        }
+    }
+
+    /// An unknown / corrupt per-book `themeName` leaves the store's
+    /// current theme untouched — `applyResolvedSettings` only assigns
+    /// on a confident decode (no silent reset to default).
+    @Test @MainActor func applyResolvedSettings_unknownThemeName_leavesThemeUntouched() {
+        let store = makeGlobalStore()
+        store.theme = .dark
+        let resolved = ResolvedSettings(
+            fontSize: store.typography.fontSize,
+            fontName: store.typography.fontFamily.rawValue,
+            lineSpacing: store.typography.lineSpacing,
+            letterSpacing: 0,
+            themeName: "chartreuse", readingMode: store.readingMode.rawValue
+        )
+        store.applyResolvedSettings(resolved)
+        #expect(store.theme == .dark,
+                "an unknown per-book themeName must not clobber the live theme")
+    }
+
+    /// End-to-end: save a per-book override carrying a V2-only theme
+    /// (Photo), read it back, resolve it onto a global store.
+    @Test @MainActor func perBookSettings_photoTheme_savesResolvesEndToEnd() throws {
+        let dir = try makeTempDir()
+        defer { cleanUp(dir) }
+        let key = "epub:ffff000000000000000000000000000000000000000000000000000000000000:777"
+        let override = PerBookSettingsOverride(themeName: ReaderThemeV2.photo.rawValue)
+        try PerBookSettingsStore.save(override, for: key, baseURL: dir)
+        let restored = try #require(PerBookSettingsStore.settings(for: key, baseURL: dir))
+        #expect(restored.themeName == "photo")
+
+        let global = makeGlobalStore()
+        global.theme = .paper
+        let resolved = PerBookSettingsStore.resolve(perBook: restored, global: global)
+        #expect(resolved.themeName == "photo")
+        global.applyResolvedSettings(resolved)
+        #expect(global.theme == .photo)
     }
 
     // MARK: - Helpers

--- a/vreaderTests/Services/ReaderSettingsStoreTests.swift
+++ b/vreaderTests/Services/ReaderSettingsStoreTests.swift
@@ -8,7 +8,10 @@ import UIKit
     private func makeStore() -> ReaderSettingsStore {
         ReaderSettingsStore(defaults: UserDefaults(suiteName: "RSS-\(UUID().uuidString)")!)
     }
-    @Test func defaultTheme() { #expect(makeStore().theme == .light) }
+    // Feature #60 WI-11: `ReaderSettingsStore.theme` is `ReaderThemeV2`.
+    // The default theme is `.paper` (was the legacy `ReaderTheme.light`,
+    // which the migration alias maps to `.paper`).
+    @Test func defaultTheme() { #expect(makeStore().theme == .paper) }
     @Test func defaultTypography() { let s = makeStore(); #expect(s.typography.fontSize == 18) }
     #if canImport(UIKit)
     @Test func uiFontForSystemFamily() { #expect(makeStore().uiFont.pointSize == 18) }
@@ -31,7 +34,7 @@ import UIKit
     @Test func cjkLetterSpacingWhenDisabled() { var s = makeStore(); s.typography.cjkSpacing = false; #expect(s.cjkLetterSpacing == 0) }
     #endif
     @Test func themeChangeUpdatesColors() {
-        var s = makeStore(); s.theme = .light
+        var s = makeStore(); s.theme = .paper
         #if canImport(UIKit)
         let l = s.uiBackgroundColor; s.theme = .dark; #expect(l != s.uiBackgroundColor)
         #endif
@@ -39,7 +42,37 @@ import UIKit
     @Test func invalidThemeRawValueFallsBackToDefault() {
         let n = "RSS-c-\(UUID().uuidString)"; let d = UserDefaults(suiteName: n)!
         d.set("neon", forKey: ReaderSettingsStore.themeKey)
-        #expect(ReaderSettingsStore(defaults: d).theme == .light); d.removePersistentDomain(forName: n)
+        #expect(ReaderSettingsStore(defaults: d).theme == .paper); d.removePersistentDomain(forName: n)
+    }
+    // Feature #60 WI-11: existing users have `readerTheme` persisted as
+    // a legacy `ReaderTheme` rawValue. The store must decode those.
+    @Test func legacyLightRawValueDecodesToPaper() {
+        let n = "RSS-leg-l-\(UUID().uuidString)"; let d = UserDefaults(suiteName: n)!
+        d.set("light", forKey: ReaderSettingsStore.themeKey)
+        #expect(ReaderSettingsStore(defaults: d).theme == .paper); d.removePersistentDomain(forName: n)
+    }
+    @Test func legacySepiaRawValueDecodesToSepia() {
+        let n = "RSS-leg-s-\(UUID().uuidString)"; let d = UserDefaults(suiteName: n)!
+        d.set("sepia", forKey: ReaderSettingsStore.themeKey)
+        #expect(ReaderSettingsStore(defaults: d).theme == .sepia); d.removePersistentDomain(forName: n)
+    }
+    @Test func legacyDarkRawValueDecodesToDark() {
+        let n = "RSS-leg-d-\(UUID().uuidString)"; let d = UserDefaults(suiteName: n)!
+        d.set("dark", forKey: ReaderSettingsStore.themeKey)
+        #expect(ReaderSettingsStore(defaults: d).theme == .dark); d.removePersistentDomain(forName: n)
+    }
+    // Feature #60 WI-11: all 5 ReaderThemeV2 cases round-trip through
+    // UserDefaults — OLED and Photo are now user-selectable.
+    @Test func allFiveThemesRoundTripThroughUserDefaults() {
+        for theme in ReaderThemeV2.allCases {
+            let n = "RSS-5-\(theme.rawValue)-\(UUID().uuidString)"
+            let d = UserDefaults(suiteName: n)!
+            var s1 = ReaderSettingsStore(defaults: d); s1.theme = theme
+            #expect(d.string(forKey: ReaderSettingsStore.themeKey) == theme.rawValue)
+            #expect(ReaderSettingsStore(defaults: d).theme == theme,
+                    "theme \(theme.rawValue) must survive a persistence round-trip")
+            d.removePersistentDomain(forName: n)
+        }
     }
     @Test func settingsStore_defaultsToDisabled() { #expect(makeStore().useCustomBackground == false) }
     @Test func settingsStore_defaultBackgroundOpacity() { #expect(abs(makeStore().backgroundOpacity - 0.15) < 0.001) }
@@ -82,6 +115,8 @@ import UIKit
 
         // Per-book-active session mutates live store via the resolver
         // (which suppresses persistence so defaults stays at "dark").
+        // Feature #60 WI-11: a per-book override carrying the LEGACY
+        // themeName "light" still resolves — it migrates to `.paper`.
         let resolvedAsLight = ResolvedSettings(
             fontSize: s.typography.fontSize, fontName: s.typography.fontFamily.rawValue,
             lineSpacing: s.typography.lineSpacing,
@@ -89,7 +124,7 @@ import UIKit
             themeName: "light", readingMode: s.readingMode.rawValue
         )
         s.applyResolvedSettings(resolvedAsLight)
-        #expect(s.theme == .light, "per-book override has been applied to live store")
+        #expect(s.theme == .paper, "legacy per-book themeName 'light' migrates to .paper")
 
         // Per-book disable: file deleted, then reconcile.
         s.reconcileFromDefaults()

--- a/vreaderTests/Services/TXTViewConfigThemeTests.swift
+++ b/vreaderTests/Services/TXTViewConfigThemeTests.swift
@@ -2,9 +2,9 @@
 // `ReaderSettingsStore.txtViewConfig` and `mdRenderConfig` render
 // TXT and MD content with the WI-2 `ReaderThemeV2` token surface
 // (Paper / Sepia / Dark / OLED / Photo), not the legacy
-// `ReaderTheme`'s 3-color palette. Consumes `theme.asV2` so users
-// on the legacy 3-case enum still see the new visual identity until
-// a later WI migrates the settings type itself.
+// `ReaderTheme`'s 3-color palette. WI-11 migrated
+// `ReaderSettingsStore.theme` itself to `ReaderThemeV2`, so these
+// configs read its tokens directly.
 
 #if canImport(UIKit)
 import Testing
@@ -33,7 +33,7 @@ struct TXTViewConfigThemeTests {
     // MARK: - txtViewConfig.backgroundColor → V2 outer bg
 
     @Test @MainActor func txtViewConfig_lightTheme_usesV2PaperOuterBg() {
-        var s = makeStore(); s.theme = .light
+        var s = makeStore(); s.theme = .paper
         // Paper outer bg: 0xf4eee0 = (244, 238, 224)
         let bg = rgbInts(s.txtViewConfig.backgroundColor)
         #expect(bg == (244, 238, 224),
@@ -59,7 +59,7 @@ struct TXTViewConfigThemeTests {
     // MARK: - txtViewConfig.textColor → V2 ink
 
     @Test @MainActor func txtViewConfig_lightTheme_usesV2PaperInk() {
-        var s = makeStore(); s.theme = .light
+        var s = makeStore(); s.theme = .paper
         // Paper ink: 0x1d1a14 = (29, 26, 20)
         let ink = rgbInts(s.txtViewConfig.textColor)
         #expect(ink == (29, 26, 20),
@@ -83,7 +83,7 @@ struct TXTViewConfigThemeTests {
     // MARK: - mdRenderConfig parallels txtViewConfig
 
     @Test @MainActor func mdRenderConfig_lightTheme_usesV2PaperInk() {
-        var s = makeStore(); s.theme = .light
+        var s = makeStore(); s.theme = .paper
         let ink = rgbInts(s.mdRenderConfig.textColor)
         #expect(ink == (29, 26, 20),
                 "MDRenderConfig.textColor must mirror txtViewConfig (both go through ReaderThemeV2.inkColor)")
@@ -112,7 +112,7 @@ struct TXTViewConfigThemeTests {
     }
 
     @Test @MainActor func uiSecondaryTextColor_lightTheme_usesV2SubRGBA() {
-        var s = makeStore(); s.theme = .light
+        var s = makeStore(); s.theme = .paper
         let c = rgba(s.uiSecondaryTextColor)
         // Paper sub: ink-RGB (29,26,20) + alpha 0.55
         #expect(c.r == 29 && c.g == 26 && c.b == 20,
@@ -134,7 +134,7 @@ struct TXTViewConfigThemeTests {
     // MARK: - MDRenderConfig secondary + code-block colors (WI-5 round-1 fix)
 
     @Test @MainActor func mdRenderConfig_lightTheme_secondaryAndCodeBg() {
-        var s = makeStore(); s.theme = .light
+        var s = makeStore(); s.theme = .paper
         let cfg = s.mdRenderConfig
         // secondaryColor → V2 subColor (paper ink + alpha 0.55)
         let sec = rgba(cfg.secondaryColor)

--- a/vreaderTests/Views/Reader/PDFViewBridgeThemeTests.swift
+++ b/vreaderTests/Views/Reader/PDFViewBridgeThemeTests.swift
@@ -1,8 +1,14 @@
 // Purpose: Tests for PDFViewBridge's theme-background application — bug #198 / GH #710.
-// Confirms PDFView.backgroundColor is set from ReaderTheme.backgroundColor so the
-// page-area gutter flips to dark when the user picks Dark theme (was silently no-op
-// before the fix). Tests the static helper, not the full UIViewRepresentable
+// Confirms PDFView.backgroundColor is set from the reader theme's backgroundColor so
+// the page-area gutter flips to dark when the user picks a dark theme (was silently
+// no-op before the fix). Tests the static helper, not the full UIViewRepresentable
 // construction, so they remain fast and don't need a UIScene environment.
+//
+// Feature #60 WI-11: `PDFViewBridge`'s theme parameter migrated from the legacy
+// 3-case `ReaderTheme` to the 5-case `ReaderThemeV2` along with
+// `ReaderSettingsStore.theme`. These tests track that — `.paper` replaces the
+// legacy `.light`, and the gutter colour now comes from `ReaderThemeV2`'s
+// `backgroundColor` token.
 
 #if canImport(UIKit)
 import Testing
@@ -18,7 +24,7 @@ struct PDFViewBridgeThemeTests {
         let pdfView = PDFView()
         pdfView.backgroundColor = .white  // simulates default
         PDFViewBridge.applyThemeBackground(to: pdfView, theme: .dark)
-        #expect(pdfView.backgroundColor == ReaderTheme.dark.backgroundColor,
+        #expect(pdfView.backgroundColor == ReaderThemeV2.dark.backgroundColor,
                 "Dark theme must set PDFView.backgroundColor to the dark palette")
     }
 
@@ -27,37 +33,55 @@ struct PDFViewBridgeThemeTests {
         let pdfView = PDFView()
         pdfView.backgroundColor = .white
         PDFViewBridge.applyThemeBackground(to: pdfView, theme: .sepia)
-        #expect(pdfView.backgroundColor == ReaderTheme.sepia.backgroundColor)
+        #expect(pdfView.backgroundColor == ReaderThemeV2.sepia.backgroundColor)
     }
 
     @Test
-    func applyThemeBackground_light_setsLightBackgroundColor() {
+    func applyThemeBackground_paper_setsPaperBackgroundColor() {
         let pdfView = PDFView()
-        pdfView.backgroundColor = .red  // any non-light color
-        PDFViewBridge.applyThemeBackground(to: pdfView, theme: .light)
-        #expect(pdfView.backgroundColor == ReaderTheme.light.backgroundColor)
+        pdfView.backgroundColor = .red  // any non-paper color
+        PDFViewBridge.applyThemeBackground(to: pdfView, theme: .paper)
+        #expect(pdfView.backgroundColor == ReaderThemeV2.paper.backgroundColor)
     }
 
     @Test
-    func applyThemeBackground_dark_thenLight_flipsBack() {
-        // Regression guard: re-applying Light after Dark must actually flip
+    func applyThemeBackground_oled_setsOLEDBackgroundColor() {
+        // OLED is one of the two themes WI-11 makes user-selectable —
+        // confirm the gutter honours it (pure black surround).
+        let pdfView = PDFView()
+        pdfView.backgroundColor = .white
+        PDFViewBridge.applyThemeBackground(to: pdfView, theme: .oled)
+        #expect(pdfView.backgroundColor == ReaderThemeV2.oled.backgroundColor)
+    }
+
+    @Test
+    func applyThemeBackground_photo_setsPhotoBackgroundColor() {
+        let pdfView = PDFView()
+        pdfView.backgroundColor = .white
+        PDFViewBridge.applyThemeBackground(to: pdfView, theme: .photo)
+        #expect(pdfView.backgroundColor == ReaderThemeV2.photo.backgroundColor)
+    }
+
+    @Test
+    func applyThemeBackground_dark_thenPaper_flipsBack() {
+        // Regression guard: re-applying Paper after Dark must actually flip
         // BACK (no sticky state). Mirrors the user's bug-report flow:
-        // Light → Sepia → Dark should also work in reverse Dark → Light.
+        // Paper → Sepia → Dark should also work in reverse Dark → Paper.
         let pdfView = PDFView()
         PDFViewBridge.applyThemeBackground(to: pdfView, theme: .dark)
-        #expect(pdfView.backgroundColor == ReaderTheme.dark.backgroundColor)
-        PDFViewBridge.applyThemeBackground(to: pdfView, theme: .light)
-        #expect(pdfView.backgroundColor == ReaderTheme.light.backgroundColor)
+        #expect(pdfView.backgroundColor == ReaderThemeV2.dark.backgroundColor)
+        PDFViewBridge.applyThemeBackground(to: pdfView, theme: .paper)
+        #expect(pdfView.backgroundColor == ReaderThemeV2.paper.backgroundColor)
     }
 
     @Test
-    func darkThemeBackground_isNotEqualToLight() {
+    func darkThemeBackground_isNotEqualToPaper() {
         // Sanity guard: the bug was Dark looking identical to Light because
-        // nothing themed the PDFView. After the fix, the three theme colors
+        // nothing themed the PDFView. After the fix, the theme colors
         // must each be distinct so the user's eye can tell them apart.
-        #expect(ReaderTheme.dark.backgroundColor != ReaderTheme.light.backgroundColor)
-        #expect(ReaderTheme.dark.backgroundColor != ReaderTheme.sepia.backgroundColor)
-        #expect(ReaderTheme.light.backgroundColor != ReaderTheme.sepia.backgroundColor)
+        #expect(ReaderThemeV2.dark.backgroundColor != ReaderThemeV2.paper.backgroundColor)
+        #expect(ReaderThemeV2.dark.backgroundColor != ReaderThemeV2.sepia.backgroundColor)
+        #expect(ReaderThemeV2.paper.backgroundColor != ReaderThemeV2.sepia.backgroundColor)
     }
 
     @Test
@@ -71,45 +95,45 @@ struct PDFViewBridgeThemeTests {
         // assignment; this test covers the gated dispatch and the
         // last-applied threading the bridge actually performs.
         let pdfView = PDFView()
-        var lastApplied: ReaderTheme?
+        var lastApplied: ReaderThemeV2?
 
-        // Initial mount with Light: applied + last-applied advances to Light.
+        // Initial mount with Paper: applied + last-applied advances to Paper.
         lastApplied = PDFViewBridge.applyThemeIfChanged(
-            pdfView: pdfView, theme: .light, lastAppliedTheme: lastApplied
+            pdfView: pdfView, theme: .paper, lastAppliedTheme: lastApplied
         )
-        #expect(pdfView.backgroundColor == ReaderTheme.light.backgroundColor)
-        #expect(lastApplied == .light)
+        #expect(pdfView.backgroundColor == ReaderThemeV2.paper.backgroundColor)
+        #expect(lastApplied == .paper)
 
         // Redundant update with same theme: short-circuit, no reapply.
         // Sentinel: pre-set a distinct color and confirm it survives.
         pdfView.backgroundColor = .red
         lastApplied = PDFViewBridge.applyThemeIfChanged(
-            pdfView: pdfView, theme: .light, lastAppliedTheme: lastApplied
+            pdfView: pdfView, theme: .paper, lastAppliedTheme: lastApplied
         )
         #expect(pdfView.backgroundColor == .red,
                 "Same-theme update must short-circuit and not reapply")
-        #expect(lastApplied == .light)
+        #expect(lastApplied == .paper)
 
         // User switches to Dark mid-session: reapplies.
         lastApplied = PDFViewBridge.applyThemeIfChanged(
             pdfView: pdfView, theme: .dark, lastAppliedTheme: lastApplied
         )
-        #expect(pdfView.backgroundColor == ReaderTheme.dark.backgroundColor)
+        #expect(pdfView.backgroundColor == ReaderThemeV2.dark.backgroundColor)
         #expect(lastApplied == .dark)
 
-        // Switch to Sepia: reapplies.
+        // Switch to OLED — a WI-11-unblocked theme — reapplies.
         lastApplied = PDFViewBridge.applyThemeIfChanged(
-            pdfView: pdfView, theme: .sepia, lastAppliedTheme: lastApplied
+            pdfView: pdfView, theme: .oled, lastAppliedTheme: lastApplied
         )
-        #expect(pdfView.backgroundColor == ReaderTheme.sepia.backgroundColor)
-        #expect(lastApplied == .sepia)
+        #expect(pdfView.backgroundColor == ReaderThemeV2.oled.backgroundColor)
+        #expect(lastApplied == .oled)
 
-        // Switch back to Light: reapplies (no sticky state across the cycle).
+        // Switch back to Paper: reapplies (no sticky state across the cycle).
         lastApplied = PDFViewBridge.applyThemeIfChanged(
-            pdfView: pdfView, theme: .light, lastAppliedTheme: lastApplied
+            pdfView: pdfView, theme: .paper, lastAppliedTheme: lastApplied
         )
-        #expect(pdfView.backgroundColor == ReaderTheme.light.backgroundColor)
-        #expect(lastApplied == .light)
+        #expect(pdfView.backgroundColor == ReaderThemeV2.paper.backgroundColor)
+        #expect(lastApplied == .paper)
 
         // Nil theme on a fresh PDFView (preview / ad-hoc harness): no-op,
         // last-applied stays nil so the bridge keeps PDFKit's default gutter.

--- a/vreaderTests/Views/Reader/ReaderSettingsPanelThemePickerTests.swift
+++ b/vreaderTests/Views/Reader/ReaderSettingsPanelThemePickerTests.swift
@@ -1,0 +1,69 @@
+// Purpose: Composition-contract tests for the `ReaderSettingsPanel`
+// theme picker — Feature #60 WI-11. WI-11 migrates
+// `ReaderSettingsStore.theme` to `ReaderThemeV2` and switches the
+// picker to iterate `ReaderThemeV2.allCases` so all 5 themes
+// (Paper / Sepia / Dark / OLED / Photo) become user-selectable. The
+// pre-WI-11 picker iterated the legacy 3-case `ReaderTheme.allCases`,
+// leaving OLED and Photo unreachable — that gap closed acceptance
+// criterion (c) of feature #60.
+//
+// These tests pin the picker's data source via a testable static
+// helper (`ReaderSettingsPanel.themePickerThemes`) — the same
+// composition-test pattern as `ReaderSettingsPanelReadingModeGateTests`
+// (`shouldShowReadingModeSection`). SwiftUI body rendering is not
+// pixel-tested; the contract is "the picker offers exactly these 5
+// themes, in the design's order".
+//
+// @coordinates-with: vreader/Views/Reader/ReaderSettingsPanel.swift,
+//   vreader/Models/ReaderThemeV2.swift
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("ReaderSettingsPanel theme picker (Feature #60 WI-11)")
+struct ReaderSettingsPanelThemePickerTests {
+
+    /// The picker must offer all 5 `ReaderThemeV2` cases — including
+    /// OLED and Photo, which the legacy 3-case picker could not reach.
+    @Test func picker_offersAllFiveThemes() {
+        let themes = ReaderSettingsPanel.themePickerThemes
+        #expect(themes.count == 5)
+        #expect(Set(themes) == Set(ReaderThemeV2.allCases))
+    }
+
+    /// OLED and Photo are the two themes WI-11 specifically unblocks —
+    /// guard them explicitly so a regression that drops either is loud.
+    @Test func picker_includesOLEDAndPhoto() {
+        let themes = ReaderSettingsPanel.themePickerThemes
+        #expect(themes.contains(.oled))
+        #expect(themes.contains(.photo))
+    }
+
+    /// Picker order tracks the design bundle's `THEMES` declaration
+    /// order (`vreader-themes.jsx`): paper, sepia, dark, oled, photo —
+    /// which is exactly `ReaderThemeV2.allCases`.
+    @Test func picker_orderMatchesDesignBundle() {
+        #expect(
+            ReaderSettingsPanel.themePickerThemes
+                == [.paper, .sepia, .dark, .oled, .photo]
+        )
+    }
+
+    /// Every offered theme has a non-empty human label for the swatch
+    /// caption (Paper / Sepia / Dark / OLED / Photo per the design).
+    @Test func picker_everyThemeHasADisplayName() {
+        for theme in ReaderSettingsPanel.themePickerThemes {
+            #expect(!ReaderSettingsPanel.themeDisplayName(theme).isEmpty)
+        }
+    }
+
+    /// The display names match the design bundle's `name` fields.
+    @Test func picker_displayNamesMatchDesign() {
+        #expect(ReaderSettingsPanel.themeDisplayName(.paper) == "Paper")
+        #expect(ReaderSettingsPanel.themeDisplayName(.sepia) == "Sepia")
+        #expect(ReaderSettingsPanel.themeDisplayName(.dark) == "Dark")
+        #expect(ReaderSettingsPanel.themeDisplayName(.oled) == "OLED")
+        #expect(ReaderSettingsPanel.themeDisplayName(.photo) == "Photo")
+    }
+}

--- a/vreaderTests/Views/SheetReSkinSnapshotTests.swift
+++ b/vreaderTests/Views/SheetReSkinSnapshotTests.swift
@@ -165,9 +165,10 @@ struct SheetReSkinSnapshotTests {
     @Test("Display sheet builds re-skinned for every reader theme")
     func displayPanelBuildsForEveryTheme() {
         // The Display sheet's chrome surface follows the book theme;
-        // it must build for all 5 (the legacy 3-case ReaderTheme
-        // projects onto a subset, but the chrome must not crash).
-        for theme in ReaderTheme.allCases {
+        // it must build for all 5 `ReaderThemeV2` themes (Feature #60
+        // WI-11 made `ReaderSettingsStore.theme` the 5-case enum and
+        // the picker offers all 5).
+        for theme in ReaderThemeV2.allCases {
             let store = ReaderSettingsStore()
             store.theme = theme
             let panel = ReaderSettingsPanel(store: store)


### PR DESCRIPTION
## Summary

Feature #60 (visual identity v2) **WI-11 — the FINAL work item**. Closes acceptance criterion (c) — "All 5 themes render correctly including Photo" — by making **OLED and Photo user-reachable**.

Before WI-11 the 5-theme MODEL (`ReaderThemeV2`) shipped in WI-2 and reader RENDERING routed through it (WI-4/WI-5), but the user-facing theme SETTING (`ReaderSettingsStore.theme`) was still the legacy 3-case `ReaderTheme` enum, and `ReaderSettingsPanel`'s theme picker iterated `ReaderTheme.allCases` — only 3 swatches. OLED and Photo had no selection path. WI-11 closes that gap.

## What Changed

- **`ReaderSettingsStore.theme` migrates** from `ReaderTheme` to the 5-case `ReaderThemeV2` (Paper / Sepia / Dark / OLED / Photo). All `theme.asV2` projection callsites collapse to `theme` (it IS `ReaderThemeV2` now).
- **Backward-compatible decoding** — two new initializers in `ReaderTheme+ToV2.swift`:
  - `ReaderThemeV2(legacyOrNew:)` — non-throwing, falls back to `.default`. Used by `loadTheme` (UserDefaults `readerTheme` load).
  - `ReaderThemeV2(recognized:)` — strict, returns `nil` on unknown. Used by `applyResolvedSettings` so an unrecognized per-book `themeName` does **not** clobber the live theme.
  - Both map legacy `ReaderTheme` rawValues: `light` → `.paper`, `sepia`/`dark` unchanged. Existing `readerTheme` UserDefaults values and per-book `themeName` JSON written by a pre-WI-11 build still resolve. They agree with the existing `ReaderThemeV2` `Codable` decoder.
- **`ReaderSettingsPanel.themeSection`** iterates `ReaderThemeV2.allCases` — 5 rounded-square swatches per the design bundle's `ReaderSettingsSheet` theme selector (`Aa` glyph / photo glyph, the design's two-ring selected treatment, the 135° Photo gradient).
- **Photo theme** engages the existing `ThemeBackgroundStore` custom-background flow (keyed by `theme.rawValue`); no new picker UI — the panel's existing `themeBackgroundSection` `PhotosPicker` (system chrome) handles the image.
- **`PDFViewBridge`** theme parameter migrates to `ReaderThemeV2` (PDF gutter background tint).
- **DebugBridge** `theme` command + snapshot migrate to `ReaderThemeV2` (the `.light` bridge mode maps to the `.paper` theme; the `themeChanged` notification payload + observer handle both new + legacy values).

## WI Status

WI-11 is the **final WI** of feature #60. Behavioral WI (changes user-facing theme selection). `Refs #718`.

## Codex Audit (Gate 4)

Codex MCP, read-only sandbox, thread `019e30fd-3424-7a90-ba6d-b0f1ddde2a80`, **2 rounds**, final verdict **`follow-up-recommended`**. Log committed at `.claude/codex-audits/feat-feature-60-wi-11-five-theme-picker-audit.md`.

- **Round 1 Low (fixed)** — picker not literal to the design. `themeSwatch` rewritten: selected swatch gets the design's two-ring treatment (2.5pt accent ring + 1.5pt outer surface-color band — the `0 0 0 2.5px accent, 0 0 0 4px surface` box-shadow); Photo swatch uses the design's 135° `linear-gradient(#3a2818, #1a1410)`.
- **Round 1 High → resolved** — the EPUB Photo background-*image* gap (the user's photo not rendering inside the WKWebView). Codex round 2 confirmed this is a **pre-existing WI-4 deferral**, not a WI-11 regression: the EPUB-CSS `background-image` branch was already dormant (blocked on WKWebView `allowingReadAccessTo` scope), and `EPUBReaderContainerView` passed `backgroundImageURL: nil` before WI-11 and still does. The Photo theme's *token surface* renders correctly on every format. Tracked as follow-up **GH #795**.
- **Round 2 Medium (fixed)** — plan/code source-of-truth mismatch (the feature plan claimed EPUB Photo image injection was live). Plan updated to reflect the deferral + cite #795.
- Zero open Critical/High/Medium. Gate 4 acceptance bar met.

## Validation

`xcodebuild build` succeeds. Test gate run via `xcodebuild test` on iPhone 17 Pro Simulator.

WI-11 + adjacent suites — **all pass** (run with `-parallel-testing-enabled NO`):
- WI-11 core: `ReaderSettingsStore`, `PerBookSettings`, `ReaderThemeMigration` (new `legacyOrNew`/`recognized` tests), `ReaderSettingsPanelThemePicker` (new — 5 composition-contract tests), `PDFViewBridgeTheme` (migrated), `TXTViewConfig/MDRenderConfig`.
- Adjacent: `ReaderThemeV2`, `ReaderTheme`, the 3 `ReaderSettingsPanel` gate suites, `SheetReSkinSnapshot`, `StatusBarTinting`, `RealDebugBridgeContext` (35), `EPUBWebViewBridge`, `PhaseBMediumAudit`. 142+ tests green.

Tests cover: backward-compat decode (`light`/`sepia`/`dark` → `.paper`/`.sepia`/`.dark`, new names → self, unknown/nil → `.default` or nil); all 5 `ReaderThemeV2` cases round-trip through UserDefaults; per-book `themeName` round-trip for the 5 cases + legacy values; an unknown per-book `themeName` leaves the live theme untouched; the panel picker exposes all 5 (composition contract via `ReaderSettingsPanel.themePickerThemes`).

Known pre-existing flake: a full `vreaderTests` run crashes on `TTSServiceSpeedControlTests` / `BookSourceHTTPClientTests` (parallel-execution runner crash — unrelated to WI-11), taking unrelated suites down as collateral. Confirmed by isolated re-runs that every WI-11 + adjacent suite passes (the WI-8/9/10 precedent). The Swift Testing portion of the full serial run reports "984 tests in 104 suites passed."

## Gate 5 Verification

Pending — orchestrator owns Gate 5b full-acceptance pass. WI-11 is the final WI; flipping feature #60's row to `VERIFIED` requires the full acceptance pass (every criterion exercised) + the `dev-docs/verification/feature-60-*.md` evidence file.

## Type of Change

Behavioral — user-visible theme selection. Minor version bump (3.25.0 → **3.26.0**, build 411 → **412**) — WI-11 completes feature #60's user-visible criterion (c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)