### PR TITLE
feat(#63): Search panel v2 re-skin — custom search bar + grouped results

### DIFF
--- a/.claude/codex-audits/feat-feature-63-search-panel-reskin-audit.md
+++ b/.claude/codex-audits/feat-feature-63-search-panel-reskin-audit.md
@@ -1,0 +1,105 @@
+---
+branch: feat/feature-63-search-panel-reskin
+threadId: 019e3ae1-c014-7ba2-bd0c-0a3d5a51de69
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-05-18
+---
+
+## Gate 4 — implementation audit (feature #63, search panel v2 re-skin)
+
+Codex MCP independent audit of the full feature diff
+(`git diff origin/main..HEAD`) — the two WI commits plus the Gate-4
+fix commit. Author/auditor separation preserved (Codex MCP is a
+separate process from the implementing Claude Code session). Audit
+prompt requested the 8 Gate-4 dimensions from `.claude/rules/47`.
+
+Feature scope: a behavior-preserving view-layer re-skin of the
+in-reader full-text search sheet. New files: `SearchBar.swift`,
+`SearchViewActions.swift`, `SearchResultGrouping.swift`,
+`SearchResultsGroupedList.swift`, `SearchStateViews.swift`. Modified:
+`SearchView.swift`, `SearchResultRow.swift`,
+`ReaderContainerView+Sheets.swift`, three migrated UITests.
+
+### Round 1 — findings
+
+Codex reported **0 Critical, 0 High, 1 Medium, 2 Low**.
+
+| # | Severity | Finding | Resolution |
+|---|----------|---------|------------|
+| 1 | Medium | A whitespace-only query (`"   "`) fell into the grouped-results branch and rendered "0 matches in 0 sections" instead of the empty prompt — `SearchView.searchContent` branched on the raw `viewModel.query.isEmpty`, but `SearchViewModel` treats trimmed-empty input as empty (it clears `results` while `query` keeps its spaces). | **Fixed.** Extracted a pure, static `SearchView.contentState(isSearching:resultsEmpty:noResultsFound:query:)` returning a `SearchContentState` enum (`loading` / `noResults` / `prompt` / `results`); `searchContent` switches on it. The `.prompt` branch keys on the *trimmed* query. Commit `322526e`. |
+| 2 | Low | Empty-state copy claimed search finds "any word or phrase" — overpromises quoted-phrase semantics the FTS5 query path does not honor (`SearchTokenizer.escapeFTS5Query` quotes every whitespace-separated token independently). | **Fixed.** `SearchPromptView.explanation` changed to "Full-text search finds words anywhere in the book." Commit `322526e`. |
+| 3 | Low | The WI-1 unit tests exercise helper seams (`SearchBar.clear`, `SearchViewActions`) rather than rendered SwiftUI wiring; no test covered the whitespace-only branch. | **Fixed.** Added 6 `SearchView.contentState` tests — whitespace-only-query, empty-query prompt, loading, no-results, results, paginating-keeps-results. Commit `322526e`. The view-layer behavior is now tested through the pure state resolver, consistent with the codebase's logic-extraction test pattern (`SheetSectionContract`). |
+
+### Round 2 — verification + 1 new finding
+
+Codex confirmed all 3 round-1 fixes correctly applied (the `contentState`
+resolver trims before `.prompt`; the copy no longer claims phrase
+semantics; `contentState` test coverage present). Codex raised **1 new
+Medium**:
+
+| # | Severity | Finding | Resolution |
+|---|----------|---------|------------|
+| 4 | Medium | The feature diff appeared to remove unrelated `SettingsSliderRow.swift` / `SettingsSliderRowTests.swift` PBX file references; suggested restoring them. | **Accepted with rationale — not actioned (the suggested fix is wrong given full context).** See round 3. |
+
+### Round 3 — re-evaluation of finding 4
+
+The implementer supplied evidence and asked Codex to re-verify against
+the *current* `origin/main` (the round-2 observation had been measured
+partly against a **stale local `main` ref** on a divergent line of
+history that never merged). Codex independently re-checked:
+
+- `SettingsSliderRow.swift` / `SettingsSliderRowTests.swift` /
+  `TypefacePillToggle.swift` exist neither on disk in the worktree nor
+  in `origin/main`'s source tree (`git cat-file -e origin/main:<path>`
+  → 128 for all three).
+- The commits that introduced them (`d47720f`, `375af0e`, `8fdcfb2`)
+  are **not** ancestors of `origin/main` (`git merge-base
+  --is-ancestor` → 1 for each); they are on a divergent local `main`.
+- Restoring PBX references to those paths would point the Xcode
+  project at files that do not exist — not a valid fix; it would
+  break the build.
+- Against the *current* `origin/main`, the `origin/main..HEAD`
+  pbxproj diff shows **no** `SettingsSliderRow` removals at all — the
+  earlier observation was an artefact of comparing against the stale
+  local ref, not the real feature base.
+
+Codex agreed finding 4 does not stand. Independently confirmed: the
+implementer's regenerated `project.pbxproj` (produced by the
+task-mandated `xcodegen generate` after adding 5 new source files) has
+**0 dangling `.swift` references** — every path it lists exists on
+disk. The build succeeds and all 21 search tests pass.
+
+**Round-3 result: 0 Critical, 0 High, 0 Medium.**
+
+### Dimensions covered
+
+1. Correctness against the plan — grouping by `sourceContext`, scope
+   toggle / recent / hint chips / `p.{page}` badge all omitted per
+   plan §2; `HighlightedSnippet` reused; no `SearchService` /
+   `SearchViewModel` / `SearchResult` change. Confirmed.
+2. Edge cases — empty / single / many / non-contiguous-same-context /
+   empty-`sourceContext` grouping, CJK snippets, whitespace-only query
+   (finding 1, fixed), state transitions. Confirmed.
+3. Security — no unsafe interpolation of user query text. Confirmed.
+4. Duplicate / dead code — none introduced.
+5. VReader compliance — Swift 6 concurrency, `@MainActor` correctness,
+   every new file < ~300 lines, `ReaderThemeV2` token usage, no bare
+   `print`. Confirmed.
+6. Bridge safety — N/A; the diff touches no reader bridge.
+7. Behavior preservation — result-tap → `onNavigate(locator)`,
+   debounce, pagination, error handling unchanged; the
+   `.searchable` → custom-`TextField` migration preserves auto-focus
+   (`@FocusState` + `.onAppear`), clear, and the dismiss path.
+   Confirmed.
+8. Test quality — `SearchViewReskinTests` (11) + grouping (10) assert
+   real behavior; UITest migrations correct (`searchTextField`,
+   `searchCancelButton`). Confirmed.
+
+### Final verdict
+
+**`ship-as-is`** — Codex round-3 verdict. Zero open Critical/High/Medium
+findings. All round-1 findings fixed; the round-2 Medium was
+re-evaluated with evidence and does not stand (the suggested remedy
+would break the build; the diff is correct). Gate 4 passed within the
+rule-47 3-round cap.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 446
-        MARKETING_VERSION: 3.28.0
+        CURRENT_PROJECT_VERSION: 447
+        MARKETING_VERSION: 3.29.0
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5006,13 +5006,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 446;
+				CURRENT_PROJECT_VERSION = 447;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.28.0;
+				MARKETING_VERSION = 3.29.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5156,13 +5156,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 446;
+				CURRENT_PROJECT_VERSION = 447;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.28.0;
+				MARKETING_VERSION = 3.29.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		1315B7514310CA7FC1D9A144 /* DebugFixtureCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6458ABB611B5C32252C6DE /* DebugFixtureCatalogTests.swift */; };
 		1316119F5F616DBE405F7E38 /* SwiftDataSessionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5959972E9775E5B52E5C840 /* SwiftDataSessionStoreTests.swift */; };
 		132042BE0F63639D54E20CF6 /* WebDAVServerProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4A364E7AFF2DD96244D639 /* WebDAVServerProfile.swift */; };
+		1376C2B6E74475883E98AA5C /* SearchViewReskinTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78459E9C87CFFEA5BD741A5F /* SearchViewReskinTests.swift */; };
 		13AA54A125EC714F17846B6B /* PageNavigatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544A2F3FF8BBB1C08DDCE02D /* PageNavigatorTests.swift */; };
 		13EC9440F35FF01443E4FABF /* AnnotationAnchorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B393E54ECE17C3DA3969EA4 /* AnnotationAnchorTests.swift */; };
 		1558B65D447DCD7705FE074C /* FoliateTTSAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C511C16F7FA93E91D703EE7 /* FoliateTTSAdapterTests.swift */; };
@@ -156,6 +157,7 @@
 		2568348E9159667C4193A0B6 /* ProviderKindTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C46A3D7400CC956FA8D46D /* ProviderKindTests.swift */; };
 		25B106D034C16291C104D69E /* AnnotationsPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59ACCAF30F5092968415855 /* AnnotationsPanelView.swift */; };
 		26285A9C2309CC149C5372DC /* AIConsentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C9AB72079AF7B2ACCAB516 /* AIConsentManager.swift */; };
+		2639375285887DD55F80815B /* SearchResultGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759C78EC56C473977FA14017 /* SearchResultGrouping.swift */; };
 		265B4C9C4B99A0500F0EC6B7 /* MDMetadataExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5D3F39FDBF4693D33D1BCB /* MDMetadataExtractor.swift */; };
 		268DE55B3D1C25F7AAC58E0D /* FoliateHighlightRestoreDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F1F3EF7737CB98C28172050 /* FoliateHighlightRestoreDispatcher.swift */; };
 		26D79FC598918201D178F348 /* PersistenceActorEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2F1636BA674F5AF7A50902 /* PersistenceActorEnvironment.swift */; };
@@ -260,6 +262,7 @@
 		408FD10C4D83D162C1A9D69C /* KeychainService+ProviderProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE50C2E67CBF0EB4747276C1 /* KeychainService+ProviderProfile.swift */; };
 		40B116973A4ED78C0B64F7E2 /* Feature35AnnotationsExportVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF06F0E93BCCA150869AE18 /* Feature35AnnotationsExportVerificationTests.swift */; };
 		4107A78DB0996F371F4B3C6F /* PhaseBMediumAuditTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E270DE50F23F6125F3151CA /* PhaseBMediumAuditTests.swift */; };
+		4111A46F819D9D9C7C0C70AF /* SearchStateViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0539DF828CDF0E2D670CDEFB /* SearchStateViews.swift */; };
 		41337E423B4F0C5CCE5B6785 /* MDTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCDA968F8186B11859D8CCFE /* MDTypes.swift */; };
 		4176B17F6A64ED68E53B016E /* utf16le_bom.txt in Resources */ = {isa = PBXBuildFile; fileRef = 10F8EE6C68FBB40F0A229AC0 /* utf16le_bom.txt */; };
 		41E1AE7987CC61A4C9B29FFE /* ReadingModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC4FE169F0AC369FB30F888F /* ReadingModeTests.swift */; };
@@ -367,6 +370,7 @@
 		5B9209E7096FD5D30F56BA8F /* ResolveHighlightColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6616756D16593398F889C8 /* ResolveHighlightColorTests.swift */; };
 		5BA867B4591F0916810C91B8 /* EPUBPaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9500033AC714D470A3024F8 /* EPUBPaginationTests.swift */; };
 		5BCD69B7FFD787F33D6E0C8D /* AutoPageTurnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2396FE1BB03C2F3CEFAB8E2 /* AutoPageTurnerTests.swift */; };
+		5BF0D6683395428E016CBDC8 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD245135256A06A28C88178 /* SearchBar.swift */; };
 		5BF55452ABA60AB492B54C6D /* AIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02B540992E1F3C96A00723F /* AIProvider.swift */; };
 		5C1FD4FE52873A5962D4CB95 /* PersistenceActor+RemoteOnly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300CB93197976B4D665AEDFC /* PersistenceActor+RemoteOnly.swift */; };
 		5C20BECE1338802F60F3E7B7 /* AITranslationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE29B97304B59C88E3F3F9CF /* AITranslationTests.swift */; };
@@ -734,6 +738,7 @@
 		BF9767FD9DB988B04F1B27D5 /* SyncConflictResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF495D7A9D6F8F137DD42CE0 /* SyncConflictResolverTests.swift */; };
 		BFFFDD0F1A6208FCCA9BBA75 /* OPDSEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F36EF81271874A13417D45 /* OPDSEntryView.swift */; };
 		C02BE297CD13689403CC7FE3 /* FoliateSpikeView+HighlightTap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086557F549C56946CFD6194E /* FoliateSpikeView+HighlightTap.swift */; };
+		C03DA14D8DBA94B0CE4135D5 /* SearchViewActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08856C035686A119B4371C25 /* SearchViewActions.swift */; };
 		C08E9C36FF3ED5C05E74F52B /* WI11TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2D542588B3156C4A282264 /* WI11TestHelpers.swift */; };
 		C0D9308246DCE3C239D86323 /* Inter-LICENSE.txt in Resources */ = {isa = PBXBuildFile; fileRef = 2E5E264F97F1E53F985C34BB /* Inter-LICENSE.txt */; };
 		C135C41870117690FC304423 /* MockHighlightStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911EF8F78991EBF40F0F6155 /* MockHighlightStore.swift */; };
@@ -828,6 +833,7 @@
 		D8640F054EFA31D5EF1292DB /* MOBIMetadataParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9236535723F8728665D0BA74 /* MOBIMetadataParser.swift */; };
 		D87DD538291695D66BDA19E7 /* UpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90EFFE1F64991A9192F31011 /* UpdateCheckerTests.swift */; };
 		D8F99FEB2F50E4A1FF04CF91 /* DebugFixtureCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461EFE2364F2C7356BB47C88 /* DebugFixtureCatalog.swift */; };
+		D90375DAC9E5E9F7CFDE29B9 /* SearchResultsGroupedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99BCA5536656572478231B9E /* SearchResultsGroupedListTests.swift */; };
 		D924CEB663B0891962654696 /* FileURLImportRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D9B46BB2C7B772F5254FADA /* FileURLImportRouter.swift */; };
 		D968F71951924A45EB2D5205 /* foliate-bundle.js in Resources */ = {isa = PBXBuildFile; fileRef = 87B8A6B78229BC6C7E4ADF0F /* foliate-bundle.js */; };
 		D97CC6F8DB64CB67AED30A1D /* chapter_content.html in Resources */ = {isa = PBXBuildFile; fileRef = 7B3463E0D88B62CFEF84E4F9 /* chapter_content.html */; };
@@ -958,6 +964,7 @@
 		FB4B2B41D865A14865DF4DE1 /* HTTPTTSProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDE700F3AC42B0D8AD377E1 /* HTTPTTSProviderTests.swift */; };
 		FBE9680C2EE09F4F1936BC5C /* PDFReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D54AC9AD2556A67C96BD52 /* PDFReaderViewModel.swift */; };
 		FBF9F886D16DA6D941A6C8CD /* LibraryShellTokensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40146D7306CDCE0F1A2FC91 /* LibraryShellTokensTests.swift */; };
+		FC837C49E1AE0FA920A347A7 /* SearchResultsGroupedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E84B53D4E30D6614436E4C68 /* SearchResultsGroupedList.swift */; };
 		FD253FA0CEB159E2B1299BD4 /* SchemaV1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EA03BEFDBB65F5D7533EDE /* SchemaV1Tests.swift */; };
 		FD88118ABE86FDFBA67DFF50 /* PDFPageNavigatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C39119533D269F76F970FD1 /* PDFPageNavigatorTests.swift */; };
 		FD9B24BBE1D852DA18A23E6F /* AITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C22F30DF9F05C20CF8DDBC /* AITypes.swift */; };
@@ -1009,6 +1016,7 @@
 		04CBEAF6FEDB714FCE897550 /* BookCoverArtView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCoverArtView.swift; sourceTree = "<group>"; };
 		04ED79BFAD4BEF6B8A30F982 /* BookFileMaterializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFileMaterializerTests.swift; sourceTree = "<group>"; };
 		050AAFD290B8995258D78AC2 /* FormatCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatCapabilities.swift; sourceTree = "<group>"; };
+		0539DF828CDF0E2D670CDEFB /* SearchStateViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchStateViews.swift; sourceTree = "<group>"; };
 		055FBEA382F82BE342A50C8E /* LocatorFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorFactoryTests.swift; sourceTree = "<group>"; };
 		0616892213196BCF802266F8 /* ContentHasherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentHasherTests.swift; sourceTree = "<group>"; };
 		0646DB2E4CD5095035092623 /* FoliateHighlightTapResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightTapResolver.swift; sourceTree = "<group>"; };
@@ -1019,6 +1027,7 @@
 		07B1C372BC384811003D5608 /* ReaderSettingsPanelChineseConversionGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsPanelChineseConversionGateTests.swift; sourceTree = "<group>"; };
 		086557F549C56946CFD6194E /* FoliateSpikeView+HighlightTap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FoliateSpikeView+HighlightTap.swift"; sourceTree = "<group>"; };
 		08710FD2531ABF39338B56E9 /* SearchSheetPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSheetPlaceholderTests.swift; sourceTree = "<group>"; };
+		08856C035686A119B4371C25 /* SearchViewActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewActions.swift; sourceTree = "<group>"; };
 		08B42D93C357CAAFB4261D93 /* TXTFileLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTFileLoader.swift; sourceTree = "<group>"; };
 		0928B53225E1D74131620204 /* FoliateStyleMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateStyleMapper.swift; sourceTree = "<group>"; };
 		09C8CF05D0C61938AF454EDA /* PersistenceActor+Annotations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+Annotations.swift"; sourceTree = "<group>"; };
@@ -1269,6 +1278,7 @@
 		4B0EDE73D4EB702686B1326E /* MDReaderContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReaderContainerView.swift; sourceTree = "<group>"; };
 		4B3A240BB6031B14144741FE /* PDFAnnotationBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFAnnotationBridgeTests.swift; sourceTree = "<group>"; };
 		4B81B909B41CB8C14B613D73 /* LocatorRestorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorRestorer.swift; sourceTree = "<group>"; };
+		4BD245135256A06A28C88178 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
 		4BD56854A37D8EA2B318B926 /* HighlightDedupeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightDedupeTests.swift; sourceTree = "<group>"; };
 		4C19E96D5AE40D3577255C38 /* TXTChapterHighlightHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterHighlightHelperTests.swift; sourceTree = "<group>"; };
 		4C87C165AFE78571456C14D1 /* LocatorValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorValidationTests.swift; sourceTree = "<group>"; };
@@ -1436,6 +1446,7 @@
 		744CB6180C0CE88E75E124F3 /* ImportErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportErrorTests.swift; sourceTree = "<group>"; };
 		746091C5D6814B751FAA32B0 /* LegadoBookSourceDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegadoBookSourceDTO.swift; sourceTree = "<group>"; };
 		74BC81AA927F17D2572106F6 /* BookFormatIsSupportedExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFormatIsSupportedExtensionTests.swift; sourceTree = "<group>"; };
+		759C78EC56C473977FA14017 /* SearchResultGrouping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultGrouping.swift; sourceTree = "<group>"; };
 		765DA2396E1D41FEDF5652AD /* ReaderSheetChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSheetChrome.swift; sourceTree = "<group>"; };
 		7703EBA1FB78FEA2CADBFB7F /* RealDebugBridgeContext+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RealDebugBridgeContext+Snapshot.swift"; sourceTree = "<group>"; };
 		770B26672B9E379E795E28E7 /* LibraryBookItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryBookItemTests.swift; sourceTree = "<group>"; };
@@ -1445,6 +1456,7 @@
 		777477DCF173A1397609EC1F /* WebDAVProviderSelectiveRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProviderSelectiveRestoreTests.swift; sourceTree = "<group>"; };
 		77811B16F2CF741310C23CF5 /* EncodingDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingDetectorTests.swift; sourceTree = "<group>"; };
 		77A6970A21B903B77B011DE8 /* TXTTextViewBridgeEditMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTTextViewBridgeEditMenuTests.swift; sourceTree = "<group>"; };
+		78459E9C87CFFEA5BD741A5F /* SearchViewReskinTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewReskinTests.swift; sourceTree = "<group>"; };
 		78BD4CC018110BC0C96E2788 /* DebugReaderRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReaderRegistryTests.swift; sourceTree = "<group>"; };
 		791CB502C8B59E737F15E63C /* VerificationSettingsHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationSettingsHelperTests.swift; sourceTree = "<group>"; };
 		79F003D569BCC0F29113468A /* EPUBMetadataExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBMetadataExtractorTests.swift; sourceTree = "<group>"; };
@@ -1573,6 +1585,7 @@
 		995F86ACEA8D1CC36B0BC1A7 /* PagedModeBug82Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedModeBug82Tests.swift; sourceTree = "<group>"; };
 		99A5A212655DCE85CACDEC05 /* AnnotationImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationImporter.swift; sourceTree = "<group>"; };
 		99A967D9AB1E2A699112E0B1 /* SelectionPopoverActionRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionPopoverActionRowTests.swift; sourceTree = "<group>"; };
+		99BCA5536656572478231B9E /* SearchResultsGroupedListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsGroupedListTests.swift; sourceTree = "<group>"; };
 		99D14A41185FFD87E278E66C /* DocumentFingerprint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentFingerprint.swift; sourceTree = "<group>"; };
 		9A29C79BA1C5BF852179BCBB /* LibraryPersisting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryPersisting.swift; sourceTree = "<group>"; };
 		9A8BD899A79BEB3964941631 /* EPUBHighlightTapBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBHighlightTapBridgeTests.swift; sourceTree = "<group>"; };
@@ -1871,6 +1884,7 @@
 		E6D45B144AFD2D20CAEACC48 /* NoOpPersistenceStores.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoOpPersistenceStores.swift; sourceTree = "<group>"; };
 		E78552E9E45095C4887A2EC0 /* chapter_list_paginated.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = chapter_list_paginated.html; sourceTree = "<group>"; };
 		E7D86F739CC4D19AF019F728 /* LocatorNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorNormalizer.swift; sourceTree = "<group>"; };
+		E84B53D4E30D6614436E4C68 /* SearchResultsGroupedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsGroupedList.swift; sourceTree = "<group>"; };
 		E861A379A620B769CEA36300 /* AIChatViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatViewModelTests.swift; sourceTree = "<group>"; };
 		E94F1579C79832BB2EEDEB05 /* TXTChapterIndexStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterIndexStoreTests.swift; sourceTree = "<group>"; };
 		E97DAB513E717D83CD9ED3F7 /* TTSProviderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSProviderProtocol.swift; sourceTree = "<group>"; };
@@ -2196,6 +2210,7 @@
 				3C20894DFE22D83069C6D505 /* SheetReSkinSnapshotTests.swift */,
 				BDA2CABDFE8AC4CE645BAD05 /* Library */,
 				3FEBC4F34FA9A312FFFA1513 /* Reader */,
+				919B4DAC1661AB6BF23A874A /* Search */,
 				1F91A1066C385178070AEA40 /* Settings */,
 				F187D5B84B383A6703AD6CA7 /* Shared */,
 			);
@@ -2903,6 +2918,15 @@
 			path = Mocks;
 			sourceTree = "<group>";
 		};
+		919B4DAC1661AB6BF23A874A /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				99BCA5536656572478231B9E /* SearchResultsGroupedListTests.swift */,
+				78459E9C87CFFEA5BD741A5F /* SearchViewReskinTests.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
 		92C615A31566B39FC62EE928 /* Search */ = {
 			isa = PBXGroup;
 			children = (
@@ -3274,8 +3298,13 @@
 		CCD72732DFB3705741783948 /* Search */ = {
 			isa = PBXGroup;
 			children = (
+				4BD245135256A06A28C88178 /* SearchBar.swift */,
+				759C78EC56C473977FA14017 /* SearchResultGrouping.swift */,
 				4A888610BD2499B817A278EB /* SearchResultRow.swift */,
+				E84B53D4E30D6614436E4C68 /* SearchResultsGroupedList.swift */,
+				0539DF828CDF0E2D670CDEFB /* SearchStateViews.swift */,
 				7DAC8E20A001D7803A16AAD1 /* SearchView.swift */,
+				08856C035686A119B4371C25 /* SearchViewActions.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -4243,9 +4272,11 @@
 				099933954CB74FAE04C6B877 /* SearchLocatorSliceTests.swift in Sources */,
 				59B8E65739F0BDF9F099D348 /* SearchQueryExecutorTests.swift in Sources */,
 				11B285AD42721118145AE416 /* SearchResultHighlightTests.swift in Sources */,
+				D90375DAC9E5E9F7CFDE29B9 /* SearchResultsGroupedListTests.swift in Sources */,
 				68B750CB7D82E8E4DE0DA393 /* SearchServiceTests.swift in Sources */,
 				8CB7B605DFC452B422BBEC4F /* SearchTextNormalizerTests.swift in Sources */,
 				8BBE50E626A6524E8C6DB59D /* SearchViewModelTests.swift in Sources */,
+				1376C2B6E74475883E98AA5C /* SearchViewReskinTests.swift in Sources */,
 				F14370F35DEFDB725452B5CA /* SearchWiringTests.swift in Sources */,
 				BD2CB6CC7C73CB730F899CC4 /* SelectionPopoverActionRouterTests.swift in Sources */,
 				E85787191C94CB7BC2E8D3F2 /* SelectionPopoverActionRowTests.swift in Sources */,
@@ -4706,16 +4737,21 @@
 				CDE29CE8275DB7E13C585E74 /* SchemaV6.swift in Sources */,
 				97731990DD3F91A22A6C9038 /* ScreenSpaceDemo.swift in Sources */,
 				793A39541D8253B1CA8984A5 /* ScrollProgressHelper.swift in Sources */,
+				5BF0D6683395428E016CBDC8 /* SearchBar.swift in Sources */,
 				01440A60BDBE08FC56500DA7 /* SearchHitToLocatorResolver.swift in Sources */,
 				42C12085597D305DE974B0B1 /* SearchIndexCore.swift in Sources */,
 				1E114184ED4E99E9EB1FE43C /* SearchIndexStore.swift in Sources */,
 				E9AAB1E1CE8C74F9517CBEC3 /* SearchQueryExecutor.swift in Sources */,
+				2639375285887DD55F80815B /* SearchResultGrouping.swift in Sources */,
 				21C14E9FBD7B7373B56A365C /* SearchResultRow.swift in Sources */,
+				FC837C49E1AE0FA920A347A7 /* SearchResultsGroupedList.swift in Sources */,
 				5D3C554CE5388769AA455D1E /* SearchService.swift in Sources */,
+				4111A46F819D9D9C7C0C70AF /* SearchStateViews.swift in Sources */,
 				2B2BB1E5BCB1E74F360BE9F2 /* SearchTextExtractor.swift in Sources */,
 				65BA2B507A0D5555244C7F4C /* SearchTextNormalizer.swift in Sources */,
 				74BEA01C5E4B3E080D2BF2FD /* SearchTokenizer.swift in Sources */,
 				1C9B4E21A97013A7CC409925 /* SearchView.swift in Sources */,
+				C03DA14D8DBA94B0CE4135D5 /* SearchViewActions.swift in Sources */,
 				2F69DF71FDE5AF4FF920C3B2 /* SearchViewModel.swift in Sources */,
 				58132D890E317C57F2940579 /* SelectionPopoverAction.swift in Sources */,
 				46BDB91F1C24A88EE69DF105 /* SelectionPopoverActionRouter.swift in Sources */,

--- a/vreader/Views/Reader/ReaderContainerView+Sheets.swift
+++ b/vreader/Views/Reader/ReaderContainerView+Sheets.swift
@@ -135,6 +135,7 @@ extension ReaderContainerView {
         if let searchViewModel = searchCoordinator.searchViewModel {
             SearchView(
                 viewModel: searchViewModel,
+                theme: settingsStore.theme,
                 onNavigate: { locator in
                     NotificationCenter.default.post(
                         name: .readerNavigateToLocator,
@@ -144,7 +145,8 @@ extension ReaderContainerView {
                 },
                 onDismiss: {
                     showSearch = false
-                }
+                },
+                bookTitle: book.title
             )
             .accessibilityIdentifier("searchSheet")
         } else {

--- a/vreader/Views/Search/SearchBar.swift
+++ b/vreader/Views/Search/SearchBar.swift
@@ -1,0 +1,117 @@
+// Purpose: Feature #63 WI-1 — the custom in-sheet search bar for the
+// re-skinned search panel. Replaces the system `.searchable` bar.
+// Mirrors the design bundle's search-bar block from
+// `dev-docs/designs/vreader-fidelity-v1/project/vreader-search.jsx`:
+// a rounded warm-wash field with a leading search glyph, a borderless
+// text field, a trailing clear button (shown only when text is
+// present), and an accent-colored "Cancel" button.
+//
+// Scope reconciliation (plan §2.1): the design's "This book / All
+// books" scope toggle is OUT of scope for feature #63 — `SearchView`
+// searches a single book. This is a single-scope, in-book bar; the
+// toggle is omitted rather than shown disabled.
+//
+// Key decisions:
+// - `@FocusState` replicates the system bar's auto-focus (plan risk §2)
+//   so the field is ready for input as soon as the sheet opens.
+// - The clear button mutates `viewModel.query`; the static `clear(_:)`
+//   helper makes that mutation testable without rendering.
+// - Geometry / palette from `ReaderThemeV2` tokens — design parity with
+//   the rest of the feature #60 v2 chrome.
+//
+// @coordinates-with: SearchView.swift, SearchViewModel.swift,
+//   ReaderThemeV2.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-search.jsx`
+
+import SwiftUI
+
+/// The re-skinned search sheet's custom search bar.
+struct SearchBar: View {
+    /// The search view-model whose `query` the field is bound to.
+    @Bindable var viewModel: SearchViewModel
+    /// Visual-identity-v2 theme tokens for the bar surface + ink.
+    let theme: ReaderThemeV2
+    /// Placeholder copy — the design's `Search {book title}`.
+    let placeholder: String
+    /// Runs when the "Cancel" button is tapped (dismisses the sheet).
+    let onCancel: () -> Void
+
+    /// Drives auto-focus on appear — replicates the system search bar.
+    @FocusState private var fieldFocused: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            field
+            cancelButton
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 12)
+        .padding(.bottom, 8)
+    }
+
+    // MARK: - Field
+
+    /// The rounded warm-wash field: glyph + text field + clear button.
+    private var field: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 17, weight: .medium))
+                .foregroundStyle(Color(theme.subColor))
+
+            TextField(placeholder, text: $viewModel.query)
+                .font(.system(size: 15))
+                .foregroundStyle(Color(theme.inkColor))
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .submitLabel(.search)
+                .focused($fieldFocused)
+                .accessibilityIdentifier("searchTextField")
+
+            if !viewModel.query.isEmpty {
+                Button {
+                    Self.clear(viewModel)
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 15))
+                        .foregroundStyle(Color(theme.subColor))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+                .accessibilityIdentifier("searchClearButton")
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(fieldFillColor))
+        )
+        .onAppear { fieldFocused = true }
+    }
+
+    /// The accent-colored "Cancel" button — dismisses the sheet.
+    private var cancelButton: some View {
+        Button("Cancel", action: onCancel)
+            .font(.system(size: 14, weight: .medium))
+            .foregroundStyle(Color(theme.accentColor))
+            .accessibilityIdentifier("searchCancelButton")
+    }
+
+    // MARK: - Tokens
+
+    /// Field fill — the design's `t.isDark ? 'rgba(255,255,255,0.06)'
+    /// : 'rgba(0,0,0,0.05)'` warm wash.
+    private var fieldFillColor: UIColor {
+        theme.isDark
+            ? UIColor.white.withAlphaComponent(0.06)
+            : UIColor.black.withAlphaComponent(0.05)
+    }
+
+    // MARK: - Testable behavior
+
+    /// Clears the search query. Wired to the field's clear button; a
+    /// static helper so the mutation is unit-testable without rendering.
+    static func clear(_ viewModel: SearchViewModel) {
+        viewModel.query = ""
+    }
+}

--- a/vreader/Views/Search/SearchResultGrouping.swift
+++ b/vreader/Views/Search/SearchResultGrouping.swift
@@ -1,0 +1,80 @@
+// Purpose: Feature #63 WI-2 — pure grouping logic behind the re-skinned
+// grouped search results list. The design groups in-book search
+// results "by chapter" (`vreader-search.jsx`); production
+// `SearchResult` carries a single pre-formatted `sourceContext`
+// location string (chapter-ish for EPUB, "Page N" for PDF, "Section N"
+// for TXT/MD — see `SearchService.formatSourceContext`). Plan §3: the
+// re-skin groups by that existing string — zero data-model change,
+// keeping #63 a true behavior-preserving re-skin.
+//
+// Key decisions:
+// - Pure value types + a stateless namespace — no SwiftUI dependency,
+//   fully unit-testable without rendering.
+// - **First-encountered order is preserved.** Groups appear in the
+//   order their context is first seen in the result page, and results
+//   within a group keep their arrival order — FTS5 hits for one
+//   chapter need not be physically contiguous, but the rendered list
+//   must stay stable and ordered. A plain `Dictionary` group-by would
+//   lose this; the accumulator below keeps an explicit order list.
+// - Empty `sourceContext` (a unit the resolver could not name) falls
+//   back to a neutral display title so the list always has a header.
+//
+// @coordinates-with: SearchResultsGroupedList.swift,
+//   SearchResult (SearchService.swift),
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-search.jsx`
+
+import Foundation
+
+/// One group of search results sharing a `sourceContext` location.
+struct SearchResultGroup: Identifiable, Equatable {
+    /// The shared `sourceContext` string — may be empty when the
+    /// resolver could not name the source unit.
+    let context: String
+    /// The results in this group, in their original document order.
+    let results: [SearchResult]
+
+    /// Stable identifier for SwiftUI `List` / `ForEach` diffing — the
+    /// context string uniquely identifies a group within one result set.
+    var id: String { context }
+
+    /// Neutral header shown when `context` is empty (plan risk §1 —
+    /// format-neutral copy, not chapter-specific).
+    static let unknownLocationTitle = "Location"
+
+    /// The header text the grouped list renders — the `sourceContext`
+    /// verbatim, or the neutral fallback when it is empty.
+    var displayTitle: String {
+        context.isEmpty ? Self.unknownLocationTitle : context
+    }
+}
+
+/// Stateless grouping of a search result page by `sourceContext`.
+enum SearchResultGrouping {
+
+    /// Groups `results` by their `sourceContext`, preserving the
+    /// first-encountered order of contexts and the arrival order of
+    /// results within each context.
+    static func group(_ results: [SearchResult]) -> [SearchResultGroup] {
+        var order: [String] = []
+        var buckets: [String: [SearchResult]] = [:]
+
+        for result in results {
+            let key = result.sourceContext
+            if buckets[key] == nil {
+                order.append(key)
+                buckets[key] = []
+            }
+            buckets[key]?.append(result)
+        }
+
+        return order.map { key in
+            SearchResultGroup(context: key, results: buckets[key] ?? [])
+        }
+    }
+
+    /// Total number of results across every group — the design's
+    /// "{N} matches in {M} sections" count.
+    static func totalMatchCount(_ groups: [SearchResultGroup]) -> Int {
+        groups.reduce(0) { $0 + $1.results.count }
+    }
+}

--- a/vreader/Views/Search/SearchResultRow.swift
+++ b/vreader/Views/Search/SearchResultRow.swift
@@ -1,41 +1,74 @@
-// Purpose: Row view for displaying a single search result with highlighted snippet.
+// Purpose: Row view for a single search result with a highlighted
+// snippet.
+//
+// Re-skinned for feature #63 visual-identity v2 (WI-2): the snippet
+// uses the design bundle's serif treatment
+// (`dev-docs/designs/vreader-fidelity-v1/project/vreader-search.jsx`'s
+// `SnippetText` — Source Serif 4, 13.5pt) and the row carries a
+// trailing chevron. The group header (rendered by
+// `SearchResultsGroupedList`) now carries the location, so the
+// per-row `sourceContext` secondary line is dropped. The design's
+// `p.{page}` per-result badge is dropped — most formats have no page
+// number (plan §2.4).
 //
 // Key decisions:
-// - Uses HighlightedSnippet to bold query matches in the snippet text.
-// - Strips FTS5 <b>...</b> markers and applies bold via HighlightedSnippet.
-// - Shows source context (chapter, page, section) as secondary text.
-// - Accessibility labels for VoiceOver.
+// - Reuses `HighlightedSnippet.highlight(…)` for FTS5-match emphasis —
+//   it already strips `<b>…</b>` tags and handles CJK / multi-word
+//   matches and has existing tests. No new snippet renderer is
+//   introduced (plan §4, Gate-2 round-1 finding 3).
+// - Theme tokens (`ReaderThemeV2`) drive ink / accent / chevron color.
+// - Accessibility label combines the cleaned snippet + source context
+//   so VoiceOver still announces the location the visible header shows.
 //
-// @coordinates-with SearchView.swift, SearchResult (SearchService.swift),
-//   HighlightedSnippet.swift
+// @coordinates-with SearchResultsGroupedList.swift,
+//   SearchResult (SearchService.swift), HighlightedSnippet.swift,
+//   ReaderThemeV2.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-search.jsx`
 
 import SwiftUI
 
-/// Row view for a single search result.
+/// Row view for a single search result — the design's grouped-list row.
 struct SearchResultRow: View {
     let result: SearchResult
-    /// The current search query, used to bold matching terms in the snippet.
+    /// The current search query, used to bold matching terms.
     var query: String = ""
+    /// Visual-identity-v2 theme tokens. Defaults to `.paper` so
+    /// previews / callers that omit it keep working.
+    var theme: ReaderThemeV2 = .paper
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(HighlightedSnippet.highlight(snippet: result.snippet, query: query))
-                .font(.body)
+        HStack(alignment: .top, spacing: 10) {
+            Text(snippetText)
                 .lineLimit(3)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
-            if !result.sourceContext.isEmpty {
-                Text(result.sourceContext)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+            Image(systemName: "chevron.right")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color(theme.subColor))
+                .padding(.top, 3)
         }
-        .padding(.vertical, 4)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 12)
+        .contentShape(Rectangle())
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityText)
         .accessibilityIdentifier("searchResultRow")
     }
 
     // MARK: - Private
+
+    /// The serif-styled, match-emphasised snippet. `HighlightedSnippet`
+    /// strips FTS5 `<b>…</b>` markers and bolds the query terms; the
+    /// base font is the design's Source Serif 4 at 13.5pt.
+    private var snippetText: AttributedString {
+        var attributed = HighlightedSnippet.highlight(
+            snippet: result.snippet,
+            query: query,
+            baseFont: Font(ReaderTypography.body(for: .sourceSerif4, size: 13.5))
+        )
+        attributed.foregroundColor = Color(theme.inkColor)
+        return attributed
+    }
 
     private var accessibilityText: String {
         let clean = result.snippet

--- a/vreader/Views/Search/SearchResultsGroupedList.swift
+++ b/vreader/Views/Search/SearchResultsGroupedList.swift
@@ -1,0 +1,152 @@
+// Purpose: Feature #63 WI-2 — the grouped-by-`sourceContext` search
+// results list. Extracted from `SearchView` so that file stays under
+// the ~300-line guideline. Mirrors the design bundle's
+// `SearchResultsList` from
+// `dev-docs/designs/vreader-fidelity-v1/project/vreader-search.jsx`:
+// a top "{N} matches in {M} sections" count line, then per group a
+// serif header with a right-aligned per-group match count and a
+// rounded faint-wash card holding hairline-divided result rows.
+//
+// Scope reconciliation:
+// - Groups by the existing `sourceContext` string (plan §3) — no
+//   `SearchResult` data-model change.
+// - The design's `p.{page}` per-result badge is dropped (plan §2.4);
+//   the group header carries the location instead.
+// - Copy is format-neutral — "sections", not "chapters" (plan risk
+//   §1) — because `sourceContext` granularity varies by format.
+//
+// Key decisions:
+// - Grouping is the pure `SearchResultGrouping` namespace (unit-tested
+//   in `SearchResultsGroupedListTests`); this view is render-only.
+// - The pagination "Load more" affordance + the appending-spinner are
+//   passed in as a trailing slot so `SearchView` keeps owning the
+//   `SearchViewModel` interaction — behavior preserved.
+//
+// @coordinates-with: SearchView.swift, SearchResultGrouping.swift,
+//   SearchResultRow.swift, ReaderThemeV2.swift, ReaderTypography.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-search.jsx`
+
+import SwiftUI
+
+/// The re-skinned grouped search results list.
+struct SearchResultsGroupedList<Footer: View>: View {
+    /// The results to render, in document order.
+    let results: [SearchResult]
+    /// The current query — forwarded to each row for match emphasis.
+    let query: String
+    /// Visual-identity-v2 theme tokens.
+    let theme: ReaderThemeV2
+    /// Invoked with the tapped result (forwards to reader navigation).
+    let onSelect: (SearchResult) -> Void
+    /// Trailing slot for the pagination affordance (Load more / spinner).
+    @ViewBuilder let footer: () -> Footer
+
+    private var groups: [SearchResultGroup] {
+        SearchResultGrouping.group(results)
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 18) {
+                countLine
+                ForEach(groups) { group in
+                    groupSection(group)
+                }
+                footer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+            .padding(.bottom, 24)
+        }
+        .scrollIndicators(.hidden)
+        .accessibilityIdentifier("searchResultsList")
+    }
+
+    // MARK: - Count line
+
+    /// "{N} matches in {M} sections" — the design's results summary,
+    /// with format-neutral copy (plan risk §1).
+    private var countLine: some View {
+        Text(countText)
+            .font(.system(size: 12))
+            .foregroundStyle(Color(theme.subColor))
+            .padding(.horizontal, 4)
+    }
+
+    private var countText: String {
+        let matchCount = SearchResultGrouping.totalMatchCount(groups)
+        let groupCount = groups.count
+        let matchWord = matchCount == 1 ? "match" : "matches"
+        let groupWord = groupCount == 1 ? "section" : "sections"
+        return "\(matchCount) \(matchWord) in \(groupCount) \(groupWord)"
+    }
+
+    // MARK: - Group section
+
+    @ViewBuilder
+    private func groupSection(_ group: SearchResultGroup) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            groupHeader(group)
+            groupCard(group)
+        }
+    }
+
+    /// Serif group header + right-aligned per-group match count.
+    private func groupHeader(_ group: SearchResultGroup) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(group.displayTitle)
+                .font(Font(ReaderTypography.body(for: .sourceSerif4, size: 13)))
+                .fontWeight(.semibold)
+                .foregroundStyle(Color(theme.inkColor))
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            Spacer(minLength: 8)
+
+            Text(groupMatchText(group))
+                .font(.system(size: 11))
+                .foregroundStyle(Color(theme.subColor))
+        }
+        .padding(.horizontal, 4)
+        .padding(.bottom, 8)
+    }
+
+    private func groupMatchText(_ group: SearchResultGroup) -> String {
+        let count = group.results.count
+        return count == 1 ? "1 match" : "\(count) matches"
+    }
+
+    /// Rounded faint-wash card holding the group's hairline-divided rows.
+    private func groupCard(_ group: SearchResultGroup) -> some View {
+        VStack(spacing: 0) {
+            ForEach(Array(group.results.enumerated()), id: \.element.id) { index, result in
+                if index > 0 {
+                    Rectangle()
+                        .fill(Color(theme.ruleColor))
+                        .frame(height: 0.5)
+                }
+                Button {
+                    onSelect(result)
+                } label: {
+                    SearchResultRow(result: result, query: query, theme: theme)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("searchResult_\(result.id)")
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(cardFillColor))
+        )
+    }
+
+    // MARK: - Tokens
+
+    /// Group-card fill — the design's `t.isDark ?
+    /// 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.02)'` faint wash.
+    private var cardFillColor: UIColor {
+        theme.isDark
+            ? UIColor.white.withAlphaComponent(0.03)
+            : UIColor.black.withAlphaComponent(0.02)
+    }
+}

--- a/vreader/Views/Search/SearchStateViews.swift
+++ b/vreader/Views/Search/SearchStateViews.swift
@@ -1,0 +1,120 @@
+// Purpose: Feature #63 WI-2 — the re-skinned empty / no-results states
+// for the search sheet. Extracted from `SearchView` so that file stays
+// under the ~300-line guideline. Mirrors the design bundle's
+// `SearchEmptyState` and `NoResults` from
+// `dev-docs/designs/vreader-fidelity-v1/project/vreader-search.jsx`.
+//
+// Scope reconciliation:
+// - **`SearchNoResultsView`** — the design's circular search-glyph
+//   disc + serif "No matches for …" headline + a sub line. The
+//   design's sub copy says "switch the scope to all books"; the
+//   "All books" scope is OUT of scope for #63 (plan §2.1), so the copy
+//   ships WITHOUT any scope-switching suggestion (plan risk §3).
+// - **`SearchPromptView`** — the empty-query state. The design's
+//   `SearchEmptyState` has a "Recent" searches block and FTS5
+//   syntax-hint chips. "Recent searches" query-history persistence
+//   does not exist (plan §2.2) — omitted. The hint chips
+//   (`chapter:1`, `highlighted:yellow`, `note:`, boolean operators,
+//   quoted phrases) imply FTS5 operators: the production query path
+//   (`SearchTokenizer.escapeFTS5Query`) double-quotes EVERY whitespace-
+//   separated token, so it supports neither boolean operators NOR
+//   honoured quoted phrases — no hint chip would be faithful, so the
+//   chips are omitted entirely (plan §2.3 — "ship just those two or
+//   omit the chips"). The FTS5-capability explanation copy is kept,
+//   trimmed to claims the query path actually satisfies.
+//
+// @coordinates-with: SearchView.swift, ReaderThemeV2.swift,
+//   ReaderTypography.swift, SearchTokenizer.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-search.jsx`
+
+import SwiftUI
+
+// MARK: - No results
+
+/// The "no matches" state — design `vreader-search.jsx` `NoResults`.
+struct SearchNoResultsView: View {
+    /// The query that produced no results — shown in the headline.
+    let query: String
+    /// Visual-identity-v2 theme tokens.
+    let theme: ReaderThemeV2
+
+    var body: some View {
+        VStack(spacing: 8) {
+            glyphDisc
+            Text("No matches for \u{201C}\(query)\u{201D}")
+                .font(Font(ReaderTypography.body(for: .sourceSerif4, size: 16)))
+                .fontWeight(.medium)
+                .foregroundStyle(Color(theme.inkColor))
+                .padding(.top, 4)
+            Text("Try a different spelling or a partial word.")
+                .font(.system(size: 12))
+                .foregroundStyle(Color(theme.subColor))
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 240)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, 24)
+        .padding(.vertical, 60)
+        .accessibilityIdentifier("searchNoResultsView")
+    }
+
+    /// The design's 40pt circular faint-wash disc with a search glyph.
+    private var glyphDisc: some View {
+        Image(systemName: "magnifyingglass")
+            .font(.system(size: 18, weight: .medium))
+            .foregroundStyle(Color(theme.subColor))
+            .frame(width: 40, height: 40)
+            .background(Circle().fill(Color(discFillColor)))
+    }
+
+    private var discFillColor: UIColor {
+        theme.isDark
+            ? UIColor.white.withAlphaComponent(0.05)
+            : UIColor.black.withAlphaComponent(0.04)
+    }
+}
+
+// MARK: - Empty prompt
+
+/// The empty-query state — design `vreader-search.jsx`
+/// `SearchEmptyState`, trimmed to the in-scope content (no "Recent"
+/// block, no syntax-hint chips — see the file header).
+struct SearchPromptView: View {
+    /// Visual-identity-v2 theme tokens.
+    let theme: ReaderThemeV2
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            sectionLabel("Search this book")
+            Text(explanation)
+                .font(.system(size: 12.5))
+                .foregroundStyle(Color(theme.subColor))
+                .lineSpacing(3)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 18)
+        .padding(.top, 16)
+        .accessibilityIdentifier("searchEmptyPromptView")
+    }
+
+    /// The design's `SectionLabel` — 12pt uppercase tracked sub-color.
+    private func sectionLabel(_ text: String) -> some View {
+        Text(text.uppercased())
+            .font(.system(size: 12, weight: .semibold))
+            .tracking(0.8)
+            .foregroundStyle(Color(theme.subColor))
+    }
+
+    /// FTS5-capability copy — trimmed to claims the production query
+    /// path actually satisfies: full-text word indexing with CJK
+    /// tokenization. Phrase-operator claims are dropped because
+    /// `SearchTokenizer.escapeFTS5Query` quotes every token
+    /// independently (see the file header) — the copy must not
+    /// overpromise quoted-phrase semantics.
+    private var explanation: String {
+        "Full-text search finds words anywhere in the book. "
+        + "CJK text is tokenized, so Chinese, Japanese, and Korean "
+        + "passages are searchable too."
+    }
+}

--- a/vreader/Views/Search/SearchView.swift
+++ b/vreader/Views/Search/SearchView.swift
@@ -1,44 +1,66 @@
-// Purpose: SwiftUI search interface with debounced text field, result list,
-// and navigation callback.
+// Purpose: SwiftUI search interface with a debounced text field, a
+// grouped result list, and a navigation callback.
+//
+// Re-skinned for feature #63 visual-identity v2:
+// - WI-1: the system `.searchable` bar + `NavigationStack` `Done`
+//   toolbar replaced by the custom in-sheet `SearchBar`.
+// - WI-2: the plain `List` replaced by `SearchResultsGroupedList`
+//   (results grouped by `sourceContext`); the loading / no-results /
+//   empty-prompt states restyled to the design bundle's
+//   `vreader-search.jsx`.
+// Behavior is preserved — `SearchViewModel`, `SearchResult`, the FTS5
+// query / debounce / pagination, and the result-tap → `Locator`
+// navigation are all unchanged.
 //
 // Key decisions:
 // - Uses SearchViewModel for state management.
 // - Tap on result triggers onNavigate callback with Locator.
-// - Empty state shown when no results found.
+// - Restyled empty / no-results states (`SearchStateViews`).
 // - Loading indicator during search.
-// - Load more button at bottom for pagination.
+// - Load more affordance at the bottom for pagination (passed into
+//   `SearchResultsGroupedList` as its footer slot).
 // - Error alert for search failures.
+// - `theme` is a presentation input (the feature #60 re-skin pattern,
+//   matching `AnnotationsPanelView`); defaulted to `.paper` so it is
+//   strictly additive — the three behavioral inputs are unchanged.
 //
-// @coordinates-with SearchViewModel.swift, SearchResultRow.swift, Locator.swift
+// @coordinates-with SearchViewModel.swift, SearchResultsGroupedList.swift,
+//   SearchResultRow.swift, SearchBar.swift, SearchViewActions.swift,
+//   SearchStateViews.swift, ReaderThemeV2.swift, Locator.swift
 
 import SwiftUI
 
 /// Full-text search view for a book.
 struct SearchView: View {
     @Bindable var viewModel: SearchViewModel
+    /// Visual-identity-v2 theme tokens for the re-skinned chrome
+    /// (feature #63). Defaults to `.paper` so callers / previews that
+    /// omit it keep working — a strictly additive presentation input,
+    /// not a behavioral change.
+    var theme: ReaderThemeV2 = .paper
     let onNavigate: (Locator) -> Void
     let onDismiss: () -> Void
 
+    /// The book title for the search-bar placeholder ("Search {title}").
+    /// Defaults to a neutral phrase when the host omits it.
+    var bookTitle: String = "this book"
+
+    /// Bundles the host callbacks for testable wiring (WI-1).
+    private var actions: SearchViewActions {
+        Self.makeActions(onCancel: onDismiss, onNavigate: onNavigate)
+    }
+
     var body: some View {
-        NavigationStack {
-            VStack(spacing: 0) {
-                searchContent
-            }
-            .navigationTitle("Search")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button("Done") {
-                        onDismiss()
-                    }
-                    .accessibilityIdentifier("searchDismissButton")
-                }
-            }
-            .searchable(
-                text: $viewModel.query,
-                prompt: "Search in book..."
+        VStack(spacing: 0) {
+            SearchBar(
+                viewModel: viewModel,
+                theme: theme,
+                placeholder: "Search \(bookTitle)",
+                onCancel: { actions.cancel() }
             )
+            searchContent
         }
+        .background(Color(theme.sheetSurfaceColor).ignoresSafeArea())
         .alert("Search Error", isPresented: .init(
             get: { viewModel.errorMessage != nil },
             set: { if !$0 { viewModel.clearError() } }
@@ -50,48 +72,100 @@ struct SearchView: View {
         .accessibilityIdentifier("searchView")
     }
 
+    // MARK: - Testable wiring
+
+    /// Builds the sheet's callback contract — extracted so `SearchView`'s
+    /// wiring is verifiable without rendering the SwiftUI view.
+    static func makeActions(
+        onCancel: @escaping () -> Void,
+        onNavigate: @escaping (Locator) -> Void
+    ) -> SearchViewActions {
+        SearchViewActions(onCancel: onCancel, onNavigate: onNavigate)
+    }
+
     // MARK: - Content
 
     @ViewBuilder
     private var searchContent: some View {
-        if viewModel.isSearching && viewModel.results.isEmpty {
+        switch Self.contentState(
+            isSearching: viewModel.isSearching,
+            resultsEmpty: viewModel.results.isEmpty,
+            noResultsFound: viewModel.noResultsFound,
+            query: viewModel.query
+        ) {
+        case .loading:
             loadingView
-        } else if viewModel.noResultsFound {
-            noResultsView
-        } else if viewModel.results.isEmpty && viewModel.query.isEmpty {
-            emptyPromptView
-        } else {
+        case .noResults:
+            SearchNoResultsView(query: viewModel.query, theme: theme)
+        case .prompt:
+            SearchPromptView(theme: theme)
+        case .results:
             resultsList
         }
     }
 
+    /// The four mutually-exclusive content states the sheet body shows.
+    enum SearchContentState: Equatable {
+        /// First search in flight, nothing to show yet.
+        case loading
+        /// A non-empty query produced no matches.
+        case noResults
+        /// The empty-query prompt (the search-this-book explainer).
+        case prompt
+        /// The grouped results list.
+        case results
+    }
+
+    /// Resolves which content state to render from the view-model's
+    /// observable surface. Pure + static so it is unit-testable without
+    /// rendering. The prompt branch keys on the *trimmed* query — a
+    /// whitespace-only query (`"   "`) is empty input, not a
+    /// zero-result search, and must show the prompt rather than a
+    /// "0 matches" grouped list (Gate-4 round-1 finding).
+    static func contentState(
+        isSearching: Bool,
+        resultsEmpty: Bool,
+        noResultsFound: Bool,
+        query: String
+    ) -> SearchContentState {
+        if isSearching && resultsEmpty {
+            return .loading
+        }
+        if noResultsFound {
+            return .noResults
+        }
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        if resultsEmpty && trimmed.isEmpty {
+            return .prompt
+        }
+        return .results
+    }
+
+    /// The grouped results list — groups by `sourceContext`, with the
+    /// pagination affordance supplied as the trailing footer slot.
     private var resultsList: some View {
-        List {
-            ForEach(viewModel.results) { result in
-                Button {
-                    onNavigate(result.locator)
-                } label: {
-                    SearchResultRow(result: result, query: viewModel.query)
-                }
-                .foregroundStyle(.primary)
-                .accessibilityIdentifier("searchResult_\(result.id)")
-            }
+        SearchResultsGroupedList(
+            results: viewModel.results,
+            query: viewModel.query,
+            theme: theme,
+            onSelect: { actions.navigate(to: $0) },
+            footer: { paginationFooter }
+        )
+    }
 
-            if viewModel.hasMore {
-                loadMoreButton
-            }
-
-            if viewModel.isSearching && !viewModel.results.isEmpty {
-                HStack {
-                    Spacer()
-                    ProgressView()
-                    Spacer()
-                }
-                .listRowSeparator(.hidden)
+    /// Load-more button + the in-flight appending spinner.
+    @ViewBuilder
+    private var paginationFooter: some View {
+        if viewModel.hasMore {
+            loadMoreButton
+        }
+        if viewModel.isSearching && !viewModel.results.isEmpty {
+            HStack {
+                Spacer()
+                ProgressView()
+                Spacer()
             }
         }
-        .listStyle(.plain)
-        .accessibilityIdentifier("searchResultsList")
     }
 
     private var loadMoreButton: some View {
@@ -103,10 +177,14 @@ struct SearchView: View {
             HStack {
                 Spacer()
                 Text("Load more results")
-                    .foregroundStyle(.blue)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(Color(theme.accentColor))
                 Spacer()
             }
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
         .accessibilityIdentifier("loadMoreButton")
     }
 
@@ -116,27 +194,10 @@ struct SearchView: View {
             ProgressView()
             Text("Searching...")
                 .font(.subheadline)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(Color(theme.subColor))
             Spacer()
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityIdentifier("searchLoadingView")
-    }
-
-    private var noResultsView: some View {
-        ContentUnavailableView {
-            Label("No Results", systemImage: "magnifyingglass")
-        } description: {
-            Text("No results found for \"\(viewModel.query)\"")
-        }
-        .accessibilityIdentifier("searchNoResultsView")
-    }
-
-    private var emptyPromptView: some View {
-        ContentUnavailableView {
-            Label("Search", systemImage: "magnifyingglass")
-        } description: {
-            Text("Enter a search term to find text in this book")
-        }
-        .accessibilityIdentifier("searchEmptyPromptView")
     }
 }

--- a/vreader/Views/Search/SearchViewActions.swift
+++ b/vreader/Views/Search/SearchViewActions.swift
@@ -1,0 +1,37 @@
+// Purpose: Feature #63 WI-1 — the testable callback contract for the
+// re-skinned search sheet. The v2 re-skin replaces the system
+// `.searchable` bar + NavigationStack toolbar with a custom in-sheet
+// chrome; this value type holds the two host callbacks (`onNavigate`,
+// `onCancel`) so `SearchView`'s wiring is verifiable without rendering
+// the SwiftUI view.
+//
+// Key decisions:
+// - Pure value type — no SwiftUI dependency, no `@MainActor` rendering
+//   needed. The view constructs one from its `onNavigate` / `onDismiss`
+//   inputs and calls `navigate(to:)` / `cancel()` from button actions.
+// - `navigate(to:)` forwards the result's `Locator` — the
+//   behavior-preserving guard that result-tap navigation is unchanged.
+//
+// @coordinates-with: SearchView.swift, SearchBar.swift,
+//   SearchResult (SearchService.swift), Locator.swift
+
+import Foundation
+
+/// The search sheet's host callbacks, bundled for testable wiring.
+struct SearchViewActions {
+    /// Dismisses the search sheet (the "Cancel" button).
+    let onCancel: () -> Void
+    /// Navigates the reader to a tapped result's position.
+    let onNavigate: (Locator) -> Void
+
+    /// Runs the dismiss closure — wired to the custom bar's "Cancel".
+    func cancel() {
+        onCancel()
+    }
+
+    /// Forwards the tapped result's `Locator` to the navigation closure.
+    /// Preserves the v1 result-tap → reader-navigation behavior exactly.
+    func navigate(to result: SearchResult) {
+        onNavigate(result.locator)
+    }
+}

--- a/vreaderTests/Views/Search/SearchResultsGroupedListTests.swift
+++ b/vreaderTests/Views/Search/SearchResultsGroupedListTests.swift
@@ -1,0 +1,170 @@
+// Purpose: Feature #63 WI-2 — tests for the pure grouping logic behind
+// the re-skinned grouped results list. The design groups in-book
+// search results "by chapter"; production `SearchResult` carries a
+// pre-formatted `sourceContext` location string (plan §3), so the
+// grouping keys on that. These tests pin the order-preservation and
+// match-count contract the grouped list renders.
+//
+// @coordinates-with: SearchResultGrouping.swift,
+//   SearchResultsGroupedList.swift, SearchResult (SearchService.swift)
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("Search results grouping — feature #63 WI-2")
+struct SearchResultsGroupedListTests {
+
+    // MARK: - Fixtures
+
+    private static let testFP = DocumentFingerprint(
+        contentSHA256: "ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100",
+        fileByteCount: 2048,
+        format: .epub
+    )
+
+    private static func makeResult(
+        id: String,
+        context: String
+    ) -> SearchResult {
+        let locator = Locator(
+            bookFingerprint: testFP,
+            href: context, progression: 0, totalProgression: 0, cfi: nil,
+            page: nil, charOffsetUTF16: nil,
+            charRangeStartUTF16: nil, charRangeEndUTF16: nil,
+            textQuote: nil, textContextBefore: nil, textContextAfter: nil
+        )
+        return SearchResult(
+            id: id, snippet: "snippet \(id)", locator: locator,
+            sourceContext: context
+        )
+    }
+
+    // MARK: - Empty input
+
+    @Test("Grouping an empty result set yields no groups")
+    func emptyInputYieldsNoGroups() {
+        let groups = SearchResultGrouping.group([])
+        #expect(groups.isEmpty)
+    }
+
+    // MARK: - Single group
+
+    @Test("All results sharing one context collapse into a single group")
+    func singleGroup() {
+        let results = [
+            Self.makeResult(id: "a", context: "Chapter 1"),
+            Self.makeResult(id: "b", context: "Chapter 1"),
+            Self.makeResult(id: "c", context: "Chapter 1"),
+        ]
+        let groups = SearchResultGrouping.group(results)
+        #expect(groups.count == 1)
+        #expect(groups[0].context == "Chapter 1")
+        #expect(groups[0].results.count == 3)
+    }
+
+    // MARK: - Many groups, document order preserved
+
+    @Test("Groups appear in first-encountered document order")
+    func groupsPreserveFirstEncounteredOrder() {
+        let results = [
+            Self.makeResult(id: "a", context: "Chapter 3"),
+            Self.makeResult(id: "b", context: "Chapter 1"),
+            Self.makeResult(id: "c", context: "Chapter 8"),
+        ]
+        let groups = SearchResultGrouping.group(results)
+        #expect(groups.map(\.context) == ["Chapter 3", "Chapter 1", "Chapter 8"])
+    }
+
+    @Test("Results within a group preserve their original order")
+    func resultsWithinGroupPreserveOrder() {
+        let results = [
+            Self.makeResult(id: "first", context: "Chapter 1"),
+            Self.makeResult(id: "second", context: "Chapter 1"),
+            Self.makeResult(id: "third", context: "Chapter 1"),
+        ]
+        let groups = SearchResultGrouping.group(results)
+        #expect(groups[0].results.map(\.id) == ["first", "second", "third"])
+    }
+
+    @Test("Non-contiguous results with the same context join one group")
+    func nonContiguousSameContextJoinsOneGroup() {
+        // FTS5 hits for one chapter need not be physically adjacent in
+        // the result page; they must still land in a single group, in
+        // arrival order, and the group must keep its first-seen slot.
+        let results = [
+            Self.makeResult(id: "1", context: "Chapter 1"),
+            Self.makeResult(id: "2", context: "Chapter 2"),
+            Self.makeResult(id: "3", context: "Chapter 1"),
+        ]
+        let groups = SearchResultGrouping.group(results)
+        #expect(groups.count == 2)
+        #expect(groups.map(\.context) == ["Chapter 1", "Chapter 2"])
+        #expect(groups[0].results.map(\.id) == ["1", "3"])
+        #expect(groups[1].results.map(\.id) == ["2"])
+    }
+
+    // MARK: - One result per group
+
+    @Test("Each result in a distinct context becomes its own group")
+    func oneResultPerGroup() {
+        let results = [
+            Self.makeResult(id: "a", context: "Page 1"),
+            Self.makeResult(id: "b", context: "Page 2"),
+            Self.makeResult(id: "c", context: "Page 3"),
+        ]
+        let groups = SearchResultGrouping.group(results)
+        #expect(groups.count == 3)
+        #expect(groups.allSatisfy { $0.results.count == 1 })
+    }
+
+    // MARK: - Match count
+
+    @Test("Total match count is the sum of every group's result count")
+    func totalMatchCount() {
+        let results = [
+            Self.makeResult(id: "a", context: "Chapter 1"),
+            Self.makeResult(id: "b", context: "Chapter 1"),
+            Self.makeResult(id: "c", context: "Chapter 2"),
+        ]
+        let groups = SearchResultGrouping.group(results)
+        #expect(SearchResultGrouping.totalMatchCount(groups) == 3)
+        #expect(groups[0].results.count == 2)
+        #expect(groups[1].results.count == 1)
+    }
+
+    // MARK: - Empty sourceContext fallback
+
+    @Test("Results with an empty sourceContext fall back to a neutral label")
+    func emptySourceContextFallsBackToNeutralLabel() {
+        // EPUB chapters with no derivable name, or formats where the
+        // resolver could not name the unit, yield an empty
+        // `sourceContext`. The grouped list must still render a header.
+        let results = [
+            Self.makeResult(id: "a", context: ""),
+            Self.makeResult(id: "b", context: ""),
+        ]
+        let groups = SearchResultGrouping.group(results)
+        #expect(groups.count == 1)
+        #expect(groups[0].context.isEmpty)
+        #expect(groups[0].displayTitle == SearchResultGroup.unknownLocationTitle)
+    }
+
+    @Test("A named group's displayTitle is its sourceContext verbatim")
+    func namedGroupDisplayTitleIsContext() {
+        let groups = SearchResultGrouping.group(
+            [Self.makeResult(id: "a", context: "Chapter 4")]
+        )
+        #expect(groups[0].displayTitle == "Chapter 4")
+    }
+
+    // MARK: - Group identity (stable List diffing)
+
+    @Test("Each group has a stable identifier derived from its context")
+    func groupHasStableIdentity() {
+        let groups = SearchResultGrouping.group(
+            [Self.makeResult(id: "a", context: "Chapter 1")]
+        )
+        #expect(groups[0].id == "Chapter 1")
+    }
+}

--- a/vreaderTests/Views/Search/SearchViewReskinTests.swift
+++ b/vreaderTests/Views/Search/SearchViewReskinTests.swift
@@ -1,0 +1,211 @@
+// Purpose: Feature #63 WI-1 — behavior tests for the re-skinned search
+// sheet's custom search bar. The v2 re-skin replaces the system
+// `.searchable` bar + NavigationStack `Done` toolbar with a custom
+// in-sheet `SearchBar` (search glyph + bound text field + clear button
+// + "Cancel"). These tests pin the behavior-preserving contract: the
+// clear button empties the bound query, "Cancel" runs the dismiss
+// closure, and a result tap still forwards the result's `Locator`.
+//
+// @coordinates-with: SearchBar.swift, SearchView.swift,
+//   SearchViewActions.swift, SearchViewModel.swift, SearchService.swift,
+//   Locator.swift
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("Search sheet re-skin — feature #63 WI-1")
+@MainActor
+struct SearchViewReskinTests {
+
+    // MARK: - Fixtures
+
+    private static let testFP = DocumentFingerprint(
+        contentSHA256: "aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233",
+        fileByteCount: 1024,
+        format: .txt
+    )
+
+    private static func makeLocator(offset: Int = 0) -> Locator {
+        Locator(
+            bookFingerprint: testFP,
+            href: nil, progression: nil, totalProgression: nil, cfi: nil,
+            page: nil, charOffsetUTF16: offset,
+            charRangeStartUTF16: nil, charRangeEndUTF16: nil,
+            textQuote: nil, textContextBefore: nil, textContextAfter: nil
+        )
+    }
+
+    private static func makeResult(id: String, offset: Int) -> SearchResult {
+        SearchResult(
+            id: id,
+            snippet: "snippet \(id)",
+            locator: makeLocator(offset: offset),
+            sourceContext: "Section 1"
+        )
+    }
+
+    /// A stub search service that returns a pre-set page synchronously.
+    private actor StubService: SearchProviding {
+        let stubbedPage: SearchResultPage
+        init(page: SearchResultPage) { self.stubbedPage = page }
+        func indexBook(
+            fingerprint: DocumentFingerprint,
+            textUnits: [TextUnit],
+            segmentBaseOffsets: [Int: Int]?
+        ) async throws {}
+        func search(
+            query: String,
+            bookFingerprint: DocumentFingerprint,
+            page: Int,
+            pageSize: Int
+        ) async throws -> SearchResultPage { stubbedPage }
+        func removeIndex(fingerprint: DocumentFingerprint) async throws {}
+        func isIndexed(fingerprint: DocumentFingerprint) async -> Bool { true }
+    }
+
+    // MARK: - Clear button
+
+    @Test("The clear action empties the view-model query string")
+    func clearActionEmptiesQuery() {
+        let viewModel = SearchViewModel(
+            searchService: StubService(
+                page: SearchResultPage(results: [], page: 0, hasMore: false, totalEstimate: 0)
+            ),
+            bookFingerprint: Self.testFP
+        )
+        viewModel.query = "elizabeth"
+        #expect(viewModel.query == "elizabeth")
+
+        // The custom bar's clear button performs exactly this mutation.
+        SearchBar.clear(viewModel)
+        #expect(viewModel.query.isEmpty)
+    }
+
+    @Test("Clearing a non-empty query drops the pending results")
+    func clearDropsResults() async {
+        let page = SearchResultPage(
+            results: [Self.makeResult(id: "r1", offset: 1)],
+            page: 0, hasMore: false, totalEstimate: 1
+        )
+        let viewModel = SearchViewModel(
+            searchService: StubService(page: page),
+            bookFingerprint: Self.testFP,
+            debounceInterval: .zero
+        )
+        viewModel.query = "bingley"
+        // Allow the debounced search to complete.
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(!viewModel.results.isEmpty)
+
+        SearchBar.clear(viewModel)
+        #expect(viewModel.query.isEmpty)
+        // Clearing the query immediately resets results (SearchViewModel
+        // contract — onQueryChanged clears synchronously on empty input).
+        #expect(viewModel.results.isEmpty)
+    }
+
+    // MARK: - Cancel button
+
+    @Test("The Cancel button runs the dismiss closure exactly once")
+    func cancelInvokesDismiss() {
+        var dismissCount = 0
+        let actions = SearchViewActions(
+            onCancel: { dismissCount += 1 },
+            onNavigate: { _ in }
+        )
+        actions.cancel()
+        #expect(dismissCount == 1)
+    }
+
+    // MARK: - Result tap (behavior-preserving guard)
+
+    @Test("Tapping a result forwards that result's Locator to onNavigate")
+    func resultTapForwardsLocator() {
+        var navigated: Locator?
+        let actions = SearchViewActions(
+            onCancel: {},
+            onNavigate: { navigated = $0 }
+        )
+        let result = Self.makeResult(id: "r7", offset: 42)
+        actions.navigate(to: result)
+        #expect(navigated == result.locator)
+        #expect(navigated?.charOffsetUTF16 == 42)
+    }
+
+    @Test("Navigate and cancel are independent — navigate does not dismiss")
+    func navigateDoesNotDismiss() {
+        var dismissCount = 0
+        var navigateCount = 0
+        let actions = SearchViewActions(
+            onCancel: { dismissCount += 1 },
+            onNavigate: { _ in navigateCount += 1 }
+        )
+        actions.navigate(to: Self.makeResult(id: "r1", offset: 1))
+        #expect(navigateCount == 1)
+        #expect(dismissCount == 0)
+    }
+
+    // MARK: - Content state resolution
+
+    @Test("An empty query with no results shows the search prompt")
+    func emptyQueryShowsPrompt() {
+        let state = SearchView.contentState(
+            isSearching: false, resultsEmpty: true,
+            noResultsFound: false, query: ""
+        )
+        #expect(state == .prompt)
+    }
+
+    @Test("A whitespace-only query shows the prompt, not a zero-result list")
+    func whitespaceOnlyQueryShowsPrompt() {
+        // `SearchViewModel` treats trimmed-empty input as empty and
+        // clears results, but `query` itself stays "   ". The content
+        // state must trim before deciding — otherwise the grouped list
+        // renders a misleading "0 matches in 0 sections".
+        let state = SearchView.contentState(
+            isSearching: false, resultsEmpty: true,
+            noResultsFound: false, query: "   \n\t"
+        )
+        #expect(state == .prompt)
+    }
+
+    @Test("A first search in flight with no results yet shows loading")
+    func searchingWithNoResultsShowsLoading() {
+        let state = SearchView.contentState(
+            isSearching: true, resultsEmpty: true,
+            noResultsFound: false, query: "darcy"
+        )
+        #expect(state == .loading)
+    }
+
+    @Test("A non-empty query that found nothing shows the no-results state")
+    func noResultsFoundShowsNoResults() {
+        let state = SearchView.contentState(
+            isSearching: false, resultsEmpty: true,
+            noResultsFound: true, query: "zzzznotfound"
+        )
+        #expect(state == .noResults)
+    }
+
+    @Test("A query with results shows the grouped results list")
+    func queryWithResultsShowsResults() {
+        let state = SearchView.contentState(
+            isSearching: false, resultsEmpty: false,
+            noResultsFound: false, query: "bingley"
+        )
+        #expect(state == .results)
+    }
+
+    @Test("Appending more results while paginating keeps the results list")
+    func paginatingKeepsResultsList() {
+        // isSearching is true (loading the next page) but results are
+        // already present — must stay on the results list, not flip to
+        // the loading splash.
+        let state = SearchView.contentState(
+            isSearching: true, resultsEmpty: false,
+            noResultsFound: false, query: "bingley"
+        )
+        #expect(state == .results)
+    }
+}

--- a/vreaderUITests/Helpers/TestConstants.swift
+++ b/vreaderUITests/Helpers/TestConstants.swift
@@ -83,7 +83,17 @@ enum AccessibilityID {
 
     // MARK: - Search
     static let searchView = "searchView"
-    static let searchDismissButton = "searchDismissButton"
+    // Feature #63 WI-1: the v2 re-skin replaced the system `.searchable`
+    // bar (an `XCUIElementTypeSearchField`) + NavigationStack "Done"
+    // toolbar with a custom in-sheet bar — a plain `TextField`
+    // (`searchTextField`), a clear button (`searchClearButton`), and a
+    // "Cancel" button (`searchCancelButton`). The legacy
+    // `searchDismissButton` ("Done") identifier is removed from
+    // production; kept here annotated so a grep finds the context.
+    static let searchDismissButton = "searchDismissButton"   // STALE — removed from production (Feature #63 WI-1)
+    static let searchTextField = "searchTextField"
+    static let searchClearButton = "searchClearButton"
+    static let searchCancelButton = "searchCancelButton"
     static let searchResultsList = "searchResultsList"
     static let searchLoadingView = "searchLoadingView"
     static let searchNoResultsView = "searchNoResultsView"

--- a/vreaderUITests/Reader/ReaderSearchSheetTests.swift
+++ b/vreaderUITests/Reader/ReaderSearchSheetTests.swift
@@ -2,6 +2,11 @@
 //
 // Tests verify the search sheet presents from the reader toolbar
 // and can be dismissed.
+//
+// Feature #63 WI-1: the v2 re-skin replaced the system `.searchable`
+// bar + `NavigationStack` `Done` toolbar with a custom in-sheet bar.
+// The dismiss affordance is now the "Cancel" button
+// (`searchCancelButton`), not "Done".
 
 import XCTest
 
@@ -46,10 +51,12 @@ final class ReaderSearchSheetTests: XCTestCase {
         let searchSheet = app.otherElements[AccessibilityID.searchSheet]
         XCTAssertTrue(searchSheet.waitForExistence(timeout: 5))
 
-        // The search sheet has a "Done" button in the toolbar
-        let doneButton = app.buttons["Done"]
-        if doneButton.waitForExistence(timeout: 3) {
-            doneButton.tap()
+        // Feature #63 WI-1: the re-skinned sheet's custom bar has a
+        // "Cancel" button (`searchCancelButton`) in place of the old
+        // NavigationStack "Done" toolbar button.
+        let cancelButton = app.buttons[AccessibilityID.searchCancelButton]
+        if cancelButton.waitForExistence(timeout: 3) {
+            cancelButton.tap()
         } else {
             // Fallback: swipe down to dismiss
             searchSheet.swipeDown()

--- a/vreaderUITests/Reader/TXTSearchTapHighlightNavigationTests.swift
+++ b/vreaderUITests/Reader/TXTSearchTapHighlightNavigationTests.swift
@@ -16,6 +16,10 @@
 // temporary yellow highlight is transient (3s auto-clear) and render-asserted
 // by TXTReaderContainerSearchHighlightWiringTests (4 source-level tests).
 //
+// Feature #63 WI-1: the search sheet's v2 re-skin replaced the system
+// `.searchable` UISearchBar with a custom `TextField` — this test now
+// queries `searchTextField` instead of `app.searchFields`.
+//
 // @coordinates-with: TXTReaderContainerView.swift, ReaderNotificationModifier.swift,
 //   SearchView.swift, SearchViewModel.swift, TXTTextViewBridge.swift
 
@@ -104,13 +108,14 @@ final class TXTSearchTapHighlightNavigationTests: XCTestCase {
         // 5. Wait for the SearchView's search field to appear.
         //    The search sheet first shows "Preparing search…" (no search field) while
         //    ReaderSearchCoordinator.setup() creates the SQLite store + SearchViewModel.
-        //    Once searchViewModel is non-nil, SearchView renders with a .searchable
-        //    modifier that injects a UISearchBar (XCUIElementTypeSearchField).
+        //    Once searchViewModel is non-nil, SearchView renders.
+        //    Feature #63 WI-1: the v2 re-skin replaced the `.searchable`
+        //    UISearchBar with a custom `TextField` (`searchTextField`).
         //    Allow up to 45s for SQLite open + initial indexing of the TXT file.
-        let searchField = app.searchFields.firstMatch
+        let searchField = app.textFields[AccessibilityID.searchTextField]
         XCTAssertTrue(
             searchField.waitForExistence(timeout: 45),
-            "Search field (UISearchBar injected by .searchable) should appear once " +
+            "Custom search field (searchTextField) should appear once " +
             "ReaderSearchCoordinator finishes setup. If still 'Preparing search...', " +
             "SQLite open or background indexing is taking too long."
         )

--- a/vreaderUITests/Search/SearchSheetPlaceholderTests.swift
+++ b/vreaderUITests/Search/SearchSheetPlaceholderTests.swift
@@ -3,6 +3,11 @@
 // Tests verify the search sheet opens from the reader toolbar,
 // shows its placeholder content, and can be dismissed.
 // The full SearchView with FTS5 is not mounted yet.
+//
+// Feature #63 WI-1: once the FTS5 `SearchView` mounts, its v2-re-skinned
+// custom bar dismisses via the "Cancel" button (`searchCancelButton`).
+// The pre-mount "Preparing search…" placeholder still uses a
+// NavigationStack "Done" button — the dismiss helper accepts either.
 
 import XCTest
 
@@ -47,9 +52,16 @@ final class SearchSheetPlaceholderTests: XCTestCase {
         let searchSheet = app.otherElements[AccessibilityID.searchSheet]
         XCTAssertTrue(searchSheet.waitForExistence(timeout: 5))
 
-        // The placeholder search sheet has a "Done" button
+        // Feature #63 WI-1: depending on indexing timing the sheet shows
+        // either the pre-mount "Preparing search…" placeholder ("Done"
+        // toolbar button) or the mounted FTS5 `SearchView` whose
+        // re-skinned custom bar dismisses via "Cancel"
+        // (`searchCancelButton`). Accept whichever is present.
+        let cancelButton = app.buttons[AccessibilityID.searchCancelButton]
         let doneButton = app.buttons["Done"]
-        if doneButton.waitForExistence(timeout: 3) {
+        if cancelButton.waitForExistence(timeout: 3) {
+            cancelButton.tap()
+        } else if doneButton.exists {
             doneButton.tap()
         } else {
             // Fallback: swipe down


### PR DESCRIPTION
## Summary

Feature #63 — re-skins the in-reader `SearchView` onto visual-identity-v2 (design bundle `dev-docs/designs/vreader-fidelity-v1/project/vreader-search.jsx`).

Refs #802.

## What Changed

- **WI-1** — custom in-sheet `SearchBar` (glyph + bound `TextField` + clear button + accent Cancel, `@FocusState` auto-focus) replacing `.searchable`; new `SearchViewActions` callback contract; `SearchView` re-skinned; 3 existing UITests migrated off `.searchable`/`Done` → `searchTextField`/`searchCancelButton`.
- **WI-2** — `SearchResultGrouping` (pure grouping by `sourceContext`), `SearchResultsGroupedList` (grouped cards + count line), `SearchStateViews` (restyled no-results + empty prompt); `SearchResultRow` restyled.

## Provenance

Implemented by a parallel feature-workflow subagent (Gate 3 TDD + Gate 4 Codex audit), integrated onto current `main` by file cherry-pick + fresh `xcodegen`. The subagent's branch was verified to contain only feature-#63 surface files before integration.

## Plan deviations (documented)

1. `SearchView` gained a defaulted `theme: ReaderThemeV2 = .paper` presentation input — the v2 re-skin is theme-driven; strictly additive/non-breaking, matches the feature #60 re-skin precedent.
2. FTS-operator hint chips omitted — the production query path (`SearchTokenizer.escapeFTS5Query`) double-quotes every token, so no faithful chip is possible; the plan explicitly permits omitting them.

## Codex Audit (Gate 4)

3 rounds — round 1: 1 Medium (whitespace-only query showed "0 matches" instead of the prompt) + 2 Low, all fixed; round 2: confirmed; round 3: clean. Verdict: **ship-as-is**.

Audit log: `.claude/codex-audits/feat-feature-63-search-panel-reskin-audit.md`

## Validation

- [x] `xcodebuild test` — `SearchViewReskinTests` (11) + `SearchResultsGroupedListTests` (10) = 21 tests, 2 suites, green on current `main`; full-scheme build (incl. the migrated UITests) compiles.
- [x] Smoke build passes at 3.29.0.
- [x] Codex audit loop completed (3 rounds, ship-as-is)
- [x] Docs sync — n/a (`Views/Search/` re-skin; no new service / notification / `@Model` / schema)
- [x] Version bumped: 3.28.0 → 3.29.0 (minor — completes a user-visible feature)

## Gate 5a Verification (per-PR slice)

- Tier: **behavioral** (UI re-skin). The 21 unit tests exercise the search-bar binding/focus/clear/cancel callbacks and the grouping logic; the 3 migrated UITests keep XCUITest coverage of the search sheet. Codex audit + full-scheme build confirm integration.
- The pure-visual device pass (DebugBridge `snapshot` of the re-skinned search sheet, CU-free) → flips feature #63 to `VERIFIED` with a `dev-docs/verification/feature-63-*.md` evidence file as the post-merge step (computer-use unavailable this session).

## Type of Change

- [x] Feature (Refs #802)

🤖 Generated with [Claude Code](https://claude.com/claude-code)