### PR TITLE
feat(#65 WI-2): AI Chat tab-body re-skin

### DIFF
--- a/.claude/codex-audits/feat-feature-65-wi-2-chat-reskin-audit.md
+++ b/.claude/codex-audits/feat-feature-65-wi-2-chat-reskin-audit.md
@@ -1,0 +1,46 @@
+---
+branch: feat/feature-65-wi-2-chat-reskin
+threadId: 019e3bf8-cb4d-71d1-8bd9-6aefe24eb095
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+# Gate-4 implementation audit — feature #65 WI-2 (AI Chat tab-body re-skin)
+
+Independent Codex audit of the `feat/feature-65-wi-2-chat-reskin` diff
+against `main`. WI-2 re-skins the AI sheet's Chat tab body to the
+visual-identity-v2 design (`vreader-panels.jsx` `ChatView` / `ChatBubble`):
+new `AIChatMessageRow` (accent user bubble + sparkle-avatar serif row),
+a `theme: ReaderThemeV2 = .paper` additive parameter on `AIChatView`,
+and a pill input replacing the plain `TextField`.
+
+## Round 1 — thread 019e3bf8
+
+| # | file:line | severity | finding | resolution |
+|---|---|---|---|---|
+| 1 | AIChatView.swift:206 | Medium | The new input placeholder `"Ask about this book…"` is hardcoded, but `AIChatView` is reused by the Library general-chat sheet (`LibraryViewSheets.swift:97`, `bookFingerprint == nil`) — book-specific copy is wrong there, an out-of-scope user-visible regression. | **Fixed.** Added a `inputPlaceholder` computed property: `bookFingerprint != nil ? "Ask about this book…" : "Type a message…"`. `"Type a message…"` is the exact pre-WI-2 string restored from `main`, so general chat keeps its original neutral copy. Mirrors the existing `emptyStateView` book/no-book branch. |
+| 2 | AIChatMessageRowTests.swift:89 | Low | The `onlyUserRoleSelectsUserBubble` test + file-header claim an "exhaustiveness tripwire", but `allRoles` is hand-maintained `[.user, .assistant, .system]` — a new `ChatRole` would not fail it. | **Fixed.** Reworded the file-header doc and the inline comment to credit the production exhaustive `switch` in `AIChatMessageRow.form(for:)` as the real compile-time guard; the test honestly pins the 3-current-role split. (`ChatRole` lives in `ChatMessage.swift`, which the plan scopes out — so `CaseIterable` was not added; the rewording is the in-scope honest fix.) |
+| 3 | AIChatMessageRowTests.swift:45 | Low | Edge-case coverage omits RTL content that the WI-2 audit target calls out (empty/long/CJK are covered). | **Fixed.** Added an Arabic RTL string to the static `contentInputs` array, so the parameterized `rowBodyBuildsForEveryThemeRoleAndInput` test now materialises `body` for bidi content across all 5 `ReaderThemeV2` cases × 3 roles. Doc comment + the "four content inputs" count updated. |
+
+Round-1 verdict: `follow-up-recommended`. Clean checks: `AIChatViewModel`
+/ `ChatMessage` untouched, the old `ChatBubbleView` fully removed, the
+`theme` default compiles for omitted call sites, `#if canImport(UIKit)`
++ file-size limits respected, `UserBubbleShape`'s closed/clamped path
+math correct for tiny/empty bubbles.
+
+## Round 2 — codex-reply on 019e3bf8
+
+| # | file:line | severity | finding | resolution |
+|---|---|---|---|---|
+| 4 | AIChatMessageRowTests.swift:21 | Low | The file-header composition blurb still listed the inputs as "empty, long, CJK" after the RTL string was added. | **Fixed.** Updated the blurb to "(empty, long, CJK, RTL)". |
+
+Round 2 confirmed findings 1–3 are correctly and completely fixed —
+"that fully resolves the general-chat copy regression"; the test-comment
+rewording is "honest and in-scope"; the RTL coverage is real.
+
+## Resolution summary
+
+All 4 findings (1 Medium, 3 Low) across 2 rounds are fixed. No open
+Critical/High/Medium. Test gate: `AIChatMessageRowTests` `** TEST
+SUCCEEDED **` after the fixes. **Verdict: ship-as-is.**

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 456
-        MARKETING_VERSION: 3.30.5
+        CURRENT_PROJECT_VERSION: 457
+        MARKETING_VERSION: 3.30.6
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5070,13 +5070,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 456;
+				CURRENT_PROJECT_VERSION = 457;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.30.5;
+				MARKETING_VERSION = 3.30.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5220,13 +5220,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 456;
+				CURRENT_PROJECT_VERSION = 457;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.30.5;
+				MARKETING_VERSION = 3.30.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -357,6 +357,7 @@
 		5619DB9FC83E7182AE0EB63F /* PersistenceBookmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410BA6F21267316487DF58FC /* PersistenceBookmarkTests.swift */; };
 		563B878DD14F1699FFC52439 /* NavigationFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874E517A41CB3B9C7C5C8D3A /* NavigationFlowTests.swift */; };
 		56A100BED3272494DE799F55 /* EPUBHighlightRendererBug77Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59540377ED7FDB678914B972 /* EPUBHighlightRendererBug77Tests.swift */; };
+		56A9335B5F44D301240C81B7 /* AIChatMessageRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0216684C6AC6F1F2DA5EF4 /* AIChatMessageRow.swift */; };
 		57137EA065C2A4D12FFF3CBB /* BookSourceChapterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388862ACF8F83F9A1C8A6A6C /* BookSourceChapterListView.swift */; };
 		5774FF0387AC1349069791FE /* TextMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D7174921347E183EEB34A6 /* TextMapperTests.swift */; };
 		57E1462E66FEAA422A970FA5 /* AnthropicProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C6D6A8EC00DFFAC294DD87 /* AnthropicProvider.swift */; };
@@ -398,6 +399,7 @@
 		6225EFF6A5A33D3F2FD4DABF /* BookmarkListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256C28A508EAD4DB73B49DD4 /* BookmarkListViewModelTests.swift */; };
 		6254C228981BFCF2AC50B719 /* DictionarySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBD54F8887091F46753F09A4 /* DictionarySheet.swift */; };
 		6274548A4C4DDC1FCA13397C /* BackgroundIndexingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAA1482C17A94A21E44EFEB /* BackgroundIndexingCoordinator.swift */; };
+		62BE094A6E99C25AD7880CE4 /* AIChatMessageRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E1127A71F704F53ABC1B50 /* AIChatMessageRowTests.swift */; };
 		63034CF313C6829AEA1C5278 /* LazyDownloadCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67368B0914CFE12052417225 /* LazyDownloadCoordinatorTests.swift */; };
 		631E89297E6BE25DF74556B7 /* TXTStreamingOpenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7008A22A4FBE1574E8B9C8A4 /* TXTStreamingOpenTests.swift */; };
 		6344AC26417E72E251541FE3 /* TestSeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0797CB73F5D8FDAF0B7298E /* TestSeeder.swift */; };
@@ -1582,6 +1584,7 @@
 		939BC09F1D771D2E22301ED3 /* V1toV2MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V1toV2MigrationTests.swift; sourceTree = "<group>"; };
 		9452FAFFDEBDF03FF6CCEBB1 /* MDParserProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDParserProtocol.swift; sourceTree = "<group>"; };
 		94C32FCAEDE0062125F6A51E /* DebugSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSnapshot.swift; sourceTree = "<group>"; };
+		94E1127A71F704F53ABC1B50 /* AIChatMessageRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatMessageRowTests.swift; sourceTree = "<group>"; };
 		954E578C5D58FF04DD5D582F /* LibraryNavBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryNavBar.swift; sourceTree = "<group>"; };
 		95B006129C2FCEC99B9FBB91 /* RemoteBookCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBookCatalogTests.swift; sourceTree = "<group>"; };
 		95B9ADB001D66D4A6EC07C9A /* VerificationDebugBridgeHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationDebugBridgeHelper.swift; sourceTree = "<group>"; };
@@ -1721,6 +1724,7 @@
 		B94F43CFA9AC0D681C75333D /* PDFReaderContainerView+Highlights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PDFReaderContainerView+Highlights.swift"; sourceTree = "<group>"; };
 		B9500033AC714D470A3024F8 /* EPUBPaginationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBPaginationTests.swift; sourceTree = "<group>"; };
 		B9B13E64FBD9D9A3063AC677 /* TXTChapterContentLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterContentLoaderTests.swift; sourceTree = "<group>"; };
+		BA0216684C6AC6F1F2DA5EF4 /* AIChatMessageRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatMessageRow.swift; sourceTree = "<group>"; };
 		BAA008CC17CE7798B70F4E2D /* WebPageEncodingDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageEncodingDetector.swift; sourceTree = "<group>"; };
 		BB03A3F8DCE5FCBEC5458547 /* Feature37PerBookSettingsVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature37PerBookSettingsVerificationTests.swift; sourceTree = "<group>"; };
 		BB11ECCB50D770FE1E8F0B29 /* ReaderMorePopoverTTSGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderMorePopoverTTSGateTests.swift; sourceTree = "<group>"; };
@@ -2232,6 +2236,7 @@
 				C9EA3D76ECCD1B0E7205FBC4 /* BookRowViewVisualTests.swift */,
 				963BA5B346A86B1447A26EF5 /* GenerativeCoverViewStyleTests.swift */,
 				3C20894DFE22D83069C6D505 /* SheetReSkinSnapshotTests.swift */,
+				846B50E898E5A4755C819642 /* AI */,
 				BDA2CABDFE8AC4CE645BAD05 /* Library */,
 				3FEBC4F34FA9A312FFFA1513 /* Reader */,
 				919B4DAC1661AB6BF23A874A /* Search */,
@@ -2798,8 +2803,17 @@
 			isa = PBXGroup;
 			children = (
 				6A5928551FF9FBB8D2E87E6F /* AIAssistantView.swift */,
+				BA0216684C6AC6F1F2DA5EF4 /* AIChatMessageRow.swift */,
 				539FEE4A23AFA226048A12A4 /* AIChatView.swift */,
 				83B60F61628D0969B18B3A9B /* AIConsentView.swift */,
+			);
+			path = AI;
+			sourceTree = "<group>";
+		};
+		846B50E898E5A4755C819642 /* AI */ = {
+			isa = PBXGroup;
+			children = (
+				94E1127A71F704F53ABC1B50 /* AIChatMessageRowTests.swift */,
 			);
 			path = AI;
 			sourceTree = "<group>";
@@ -4030,6 +4044,7 @@
 			files = (
 				8044960A1B045C48AAE88736 /* AIAssistantViewModelTests.swift in Sources */,
 				369D003DCE5F36A64E5C1C06 /* AIChatGeneralTests.swift in Sources */,
+				62BE094A6E99C25AD7880CE4 /* AIChatMessageRowTests.swift in Sources */,
 				05BE70789318FA085B9A735E /* AIChatViewModelTests.swift in Sources */,
 				C81C50DAC16681379E93FC9D /* AIConfigurationTests.swift in Sources */,
 				CD104D016ED7015A7F8B42C7 /* AIConsentManagerTests.swift in Sources */,
@@ -4431,6 +4446,7 @@
 			files = (
 				384E9916435C82876752D9D9 /* AIAssistantView.swift in Sources */,
 				99456D2FCC39AA83E0B43C65 /* AIAssistantViewModel.swift in Sources */,
+				56A9335B5F44D301240C81B7 /* AIChatMessageRow.swift in Sources */,
 				8E936BF32CF0850398C9D742 /* AIChatView.swift in Sources */,
 				C8AC5FD914F26F89DA69AA8C /* AIChatViewModel.swift in Sources */,
 				4CC9567091E0CABFDD800F6C /* AIConfiguration.swift in Sources */,

--- a/vreader/Views/AI/AIChatMessageRow.swift
+++ b/vreader/Views/AI/AIChatMessageRow.swift
@@ -1,0 +1,192 @@
+// Purpose: Feature #65 WI-2 — the re-skinned AI chat message row.
+// Replaces the pre-v2 private `ChatBubbleView`
+// (`Color.blue.opacity(0.15)` / `Color.secondary.opacity(0.1)`
+// bubbles) with the design's two `ChatBubble` forms: an accent-filled
+// user bubble with an asymmetric corner, and a sparkle-avatar + serif
+// assistant/system row.
+//
+// Mirrors `dev-docs/designs/vreader-fidelity-v1/project/vreader-panels.jsx`
+// — the `ChatBubble` component (the `role === 'user'` accent bubble
+// branch and the sparkle-avatar non-user branch).
+//
+// Role routing is exposed through the pure static `form(for:)` mapper
+// + the `BubbleForm` enum (the `AISummaryTabView.section(for:)` /
+// `SearchView.contentState` precedent) so a re-skin regression that
+// forks or drops a role can be pinned without a SwiftUI render pass.
+//
+// @coordinates-with: AIChatView.swift, ChatMessage.swift,
+//   ReaderThemeV2.swift, ReaderTypography.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-panels.jsx`
+
+#if canImport(UIKit)
+import SwiftUI
+
+/// A single re-skinned chat message row — design `vreader-panels.jsx`
+/// `ChatBubble`. A `.user` message renders the accent bubble form; an
+/// `.assistant` / `.system` message renders the sparkle-avatar row form.
+struct AIChatMessageRow: View {
+
+    /// The chat message to render (its `role` selects the form).
+    let message: ChatMessage
+
+    /// Visual-identity-v2 theme tokens for the bubble surface + ink.
+    let theme: ReaderThemeV2
+
+    // MARK: - Bubble form
+
+    /// The two distinct visual forms the design's `ChatBubble` draws.
+    /// The design has exactly two branches — `role === 'user'` and
+    /// everything-else — so `.assistant` and `.system` share `.assistantRow`.
+    enum BubbleForm: Equatable {
+        /// Accent-filled bubble, right-aligned, asymmetric top-right corner.
+        case userBubble
+        /// Sparkle avatar + serif body row, left-aligned.
+        case assistantRow
+    }
+
+    /// Pure mapping from a message role to its bubble form. Exposed
+    /// `static` so the re-skin regression guard pins the role split
+    /// without a render pass (the `AISummaryTabView.section(for:)`
+    /// precedent).
+    static func form(for role: ChatRole) -> BubbleForm {
+        switch role {
+        case .user:               return .userBubble
+        // The design's non-user `ChatBubble` branch — `system` is the
+        // book-context-injection role and shares the assistant row.
+        case .assistant, .system: return .assistantRow
+        }
+    }
+
+    var body: some View {
+        switch Self.form(for: message.role) {
+        case .userBubble:    userBubble
+        case .assistantRow:  assistantRow
+        }
+    }
+
+    // MARK: - Forms
+
+    /// The accent user bubble — design `ChatBubble` `role === 'user'`.
+    /// Right-aligned, accent fill, white sans body, an asymmetric
+    /// top-right corner (`borderTopRightRadius: 6` against the 18pt
+    /// other corners).
+    @ViewBuilder
+    private var userBubble: some View {
+        HStack(spacing: 0) {
+            Spacer(minLength: 48)
+            Text(message.content)
+                .font(.system(size: 14))
+                .lineSpacing(2)
+                .foregroundStyle(.white)
+                .textSelection(.enabled)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(
+                    UserBubbleShape()
+                        .fill(Color(theme.accentColor))
+                )
+        }
+        .padding(.horizontal, 18)
+        .accessibilityIdentifier("chatBubble-\(message.role.rawValue)")
+    }
+
+    /// The sparkle-avatar assistant/system row — design `ChatBubble`
+    /// non-user branch. A 24pt accent-gradient sparkle avatar followed
+    /// by a serif body, left-aligned.
+    @ViewBuilder
+    private var assistantRow: some View {
+        HStack(alignment: .top, spacing: 8) {
+            sparkleAvatar
+            Text(message.content)
+                .font(Font(ReaderTypography.body(for: .sourceSerif4, size: 14.5)))
+                .lineSpacing(4)
+                .foregroundStyle(Color(theme.inkColor))
+                .textSelection(.enabled)
+                .padding(.vertical, 4)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Spacer(minLength: 32)
+        }
+        .padding(.horizontal, 18)
+        .accessibilityIdentifier("chatBubble-\(message.role.rawValue)")
+    }
+
+    /// The 24pt accent-gradient circle with a white sparkle — design
+    /// `ChatBubble`'s assistant avatar.
+    private var sparkleAvatar: some View {
+        Circle()
+            .fill(
+                LinearGradient(
+                    colors: [
+                        Color(theme.accentColor),
+                        Color(theme.accentColor).opacity(0.67),
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .frame(width: 24, height: 24)
+            .overlay(
+                Image(systemName: "sparkles")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.white)
+            )
+            .padding(.top, 2)
+            .accessibilityHidden(true)
+    }
+}
+
+// MARK: - User bubble shape
+
+/// The user bubble's asymmetric rounded rectangle — design `ChatBubble`
+/// `borderRadius: 18, borderTopRightRadius: 6`. SwiftUI exposes no
+/// per-corner radius on `RoundedRectangle`, so the path is built
+/// explicitly: 18pt on three corners, 6pt on the top-right.
+private struct UserBubbleShape: Shape {
+    private let largeRadius: CGFloat = 18
+    private let smallRadius: CGFloat = 6
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let r = largeRadius
+        let tr = smallRadius
+        // Clamp radii so a very short bubble (empty content) can't
+        // produce an inverted arc.
+        let maxR = min(rect.width, rect.height) / 2
+        let big = min(r, maxR)
+        let small = min(tr, maxR)
+
+        // Start after the top-left corner, walk clockwise.
+        path.move(to: CGPoint(x: rect.minX + big, y: rect.minY))
+        // Top edge → top-right (small radius).
+        path.addLine(to: CGPoint(x: rect.maxX - small, y: rect.minY))
+        path.addArc(
+            center: CGPoint(x: rect.maxX - small, y: rect.minY + small),
+            radius: small, startAngle: .degrees(-90), endAngle: .degrees(0),
+            clockwise: false
+        )
+        // Right edge → bottom-right (large radius).
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - big))
+        path.addArc(
+            center: CGPoint(x: rect.maxX - big, y: rect.maxY - big),
+            radius: big, startAngle: .degrees(0), endAngle: .degrees(90),
+            clockwise: false
+        )
+        // Bottom edge → bottom-left (large radius).
+        path.addLine(to: CGPoint(x: rect.minX + big, y: rect.maxY))
+        path.addArc(
+            center: CGPoint(x: rect.minX + big, y: rect.maxY - big),
+            radius: big, startAngle: .degrees(90), endAngle: .degrees(180),
+            clockwise: false
+        )
+        // Left edge → top-left (large radius).
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + big))
+        path.addArc(
+            center: CGPoint(x: rect.minX + big, y: rect.minY + big),
+            radius: big, startAngle: .degrees(180), endAngle: .degrees(270),
+            clockwise: false
+        )
+        path.closeSubpath()
+        return path
+    }
+}
+#endif

--- a/vreader/Views/AI/AIChatView.swift
+++ b/vreader/Views/AI/AIChatView.swift
@@ -203,7 +203,7 @@ struct AIChatView: View {
         Color(theme.ruleColor).frame(height: 0.5)
 
         HStack(spacing: 8) {
-            TextField("Ask about this book\u{2026}", text: $inputText, axis: .vertical)
+            TextField(inputPlaceholder, text: $inputText, axis: .vertical)
                 .lineLimit(1...5)
                 .font(.system(size: 14))
                 .foregroundStyle(Color(theme.inkColor))
@@ -242,6 +242,17 @@ struct AIChatView: View {
     }
 
     // MARK: - Private
+
+    /// The input placeholder mirrors the empty state's book/no-book
+    /// split: the reader AI-sheet chat (`bookFingerprint != nil`) uses
+    /// the design's book-specific copy; the Library general-chat sheet
+    /// (`bookFingerprint == nil`) keeps the neutral pre-v2 wording so
+    /// the WI-2 re-skin does not regress that reused surface.
+    private var inputPlaceholder: String {
+        viewModel.bookFingerprint != nil
+            ? "Ask about this book\u{2026}"
+            : "Type a message\u{2026}"
+    }
 
     private var canSend: Bool {
         !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty

--- a/vreader/Views/AI/AIChatView.swift
+++ b/vreader/Views/AI/AIChatView.swift
@@ -1,6 +1,14 @@
 // Purpose: Chat interface view for multi-turn AI conversations.
 // Displays message bubbles, text input, and loading/error states.
 //
+// Re-skinned for feature #65 visual-identity v2 (WI-2): the message
+// list renders the design's two `ChatBubble` forms via `AIChatMessageRow`
+// (accent user bubble + sparkle-avatar serif assistant row), and the
+// input bar is the design's rounded pill field with a circular send
+// button. The empty-state, error banner, auto-scroll, the bug-#94
+// keyboard handling, and the `clearHistory` toolbar button are
+// preserved unchanged.
+//
 // Key decisions:
 // - ScrollView + ForEach for message list with auto-scroll to bottom.
 // - Text input at bottom with send button.
@@ -8,8 +16,12 @@
 // - Loading indicator during requests.
 // - Error banner dismissible by tapping or sending next message.
 // - User messages right-aligned, assistant messages left-aligned.
+// - `theme` is additive with a `.paper` default so the call site stays
+//   non-breaking; `AIReaderPanel` passes the real theme it holds.
 //
-// @coordinates-with: AIChatViewModel.swift, ChatMessage.swift, AIReaderPanel.swift
+// @coordinates-with: AIChatViewModel.swift, ChatMessage.swift,
+//   AIChatMessageRow.swift, AIReaderPanel.swift, ReaderThemeV2.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-panels.jsx`
 
 #if canImport(UIKit)
 import SwiftUI
@@ -20,6 +32,10 @@ struct AIChatView: View {
     @Bindable var viewModel: AIChatViewModel
     @State private var inputText: String = ""
     @FocusState private var isInputFocused: Bool
+
+    /// Visual-identity-v2 theme tokens (feature #65 WI-2). Defaults to
+    /// `.paper` so existing callers / previews that omit it keep working.
+    var theme: ReaderThemeV2 = .paper
 
     var body: some View {
         VStack(spacing: 0) {
@@ -67,7 +83,7 @@ struct AIChatView: View {
                     }
 
                     ForEach(viewModel.messages) { message in
-                        ChatBubbleView(message: message)
+                        AIChatMessageRow(message: message, theme: theme)
                             .id(message.id)
                     }
 
@@ -177,35 +193,52 @@ struct AIChatView: View {
 
     // MARK: - Input Bar
 
+    /// The design's rounded pill input field with a circular send
+    /// button — `vreader-panels.jsx` `ChatView`'s input row. The
+    /// previous plain `TextField` + `arrow.up.circle.fill` button is
+    /// replaced; the multiline (`axis: .vertical`, `lineLimit(1...5)`)
+    /// behaviour and the bug-#94 focus / submit wiring are preserved.
     @ViewBuilder
     private var inputBar: some View {
-        Divider()
+        Color(theme.ruleColor).frame(height: 0.5)
 
         HStack(spacing: 8) {
-            TextField("Type a message\u{2026}", text: $inputText, axis: .vertical)
+            TextField("Ask about this book\u{2026}", text: $inputText, axis: .vertical)
                 .lineLimit(1...5)
+                .font(.system(size: 14))
+                .foregroundStyle(Color(theme.inkColor))
                 .textFieldStyle(.plain)
                 .focused($isInputFocused)
                 .onSubmit {
                     sendCurrentMessage()
                 }
+                .padding(.leading, 14)
+                .padding(.vertical, 6)
                 .accessibilityIdentifier("chatInputField")
 
             Button {
                 sendCurrentMessage()
             } label: {
-                Image(systemName: "arrow.up.circle.fill")
-                    .font(.title2)
-                    .foregroundStyle(
-                        canSend ? .blue : .gray.opacity(0.5)
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 32, height: 32)
+                    .background(
+                        Circle().fill(Color(sendButtonFillColor))
                     )
             }
+            .buttonStyle(.plain)
             .disabled(!canSend)
             .accessibilityIdentifier("chatSendButton")
             .accessibilityLabel("Send message")
         }
-        .padding(.horizontal)
-        .padding(.vertical, 8)
+        .padding(6)
+        .background(
+            Capsule().fill(Color(pillFillColor))
+        )
+        .padding(.horizontal, 14)
+        .padding(.top, 8)
+        .padding(.bottom, 16)
     }
 
     // MARK: - Private
@@ -215,54 +248,30 @@ struct AIChatView: View {
             && !viewModel.isLoading
     }
 
+    /// The pill's neutral wash — design `ChatView` input container.
+    private var pillFillColor: UIColor {
+        theme.isDark
+            ? UIColor.white.withAlphaComponent(0.06)
+            : UIColor.black.withAlphaComponent(0.04)
+    }
+
+    /// The send button's fill — accent when a message can be sent,
+    /// a neutral wash otherwise (design `ChatView`'s `draft.trim()`
+    /// conditional).
+    private var sendButtonFillColor: UIColor {
+        guard canSend else {
+            return theme.isDark
+                ? UIColor.white.withAlphaComponent(0.12)
+                : UIColor.black.withAlphaComponent(0.10)
+        }
+        return theme.accentColor
+    }
+
     private func sendCurrentMessage() {
         let text = inputText
         inputText = ""
         Task {
             await viewModel.sendMessage(text)
-        }
-    }
-}
-
-// MARK: - Chat Bubble View
-
-/// Individual chat message bubble.
-private struct ChatBubbleView: View {
-    let message: ChatMessage
-
-    var body: some View {
-        HStack {
-            if message.role == .user {
-                Spacer(minLength: 60)
-            }
-
-            VStack(alignment: message.role == .user ? .trailing : .leading, spacing: 4) {
-                Text(message.content)
-                    .font(.body)
-                    .textSelection(.enabled)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .background(bubbleBackground)
-                    .clipShape(RoundedRectangle(cornerRadius: 16))
-
-                Text(message.timestamp, style: .time)
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-            }
-
-            if message.role == .assistant || message.role == .system {
-                Spacer(minLength: 60)
-            }
-        }
-        .padding(.horizontal)
-        .accessibilityIdentifier("chatBubble-\(message.role.rawValue)")
-    }
-
-    private var bubbleBackground: some ShapeStyle {
-        if message.role == .user {
-            return Color.blue.opacity(0.15)
-        } else {
-            return Color.secondary.opacity(0.1)
         }
     }
 }

--- a/vreader/Views/Reader/AIReaderPanel.swift
+++ b/vreader/Views/Reader/AIReaderPanel.swift
@@ -18,6 +18,8 @@
 // - The Summarize tab body is the re-skinned `AISummaryTabView`
 //   (feature #65 WI-1) — its summary card's Share chip presents a
 //   `ShareActivityView` carrying the summary text.
+// - The Chat tab body is the re-skinned `AIChatView` (feature #65
+//   WI-2) — it takes the v2 `theme` for its bubble forms + pill input.
 // - Dismiss button always available (the header's close button).
 // - The feature-#50 in-reader provider picker is preserved — it sits in
 //   the custom header next to the close button so a user can still flip
@@ -128,7 +130,7 @@ struct AIReaderPanel: View {
                         format: format
                     )
                 case .chat:
-                    AIChatView(viewModel: chatViewModel)
+                    AIChatView(viewModel: chatViewModel, theme: theme)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/vreaderTests/Views/AI/AIChatMessageRowTests.swift
+++ b/vreaderTests/Views/AI/AIChatMessageRowTests.swift
@@ -13,11 +13,13 @@
 //     mapper from a `ChatRole` to the `BubbleForm` it renders. These
 //     tests pin that `.user` selects the accent bubble form and that
 //     `.assistant` / `.system` both select the sparkle-avatar row form
-//     — the design's two-branch split. A future role added without
-//     updating the mapper trips the exhaustiveness tripwire.
+//     — the design's two-branch split. The compile-time guard against
+//     a new unmapped `ChatRole` is the exhaustive `switch` in
+//     `form(for:)` itself; these tests pin the split for the three
+//     current roles.
 //
 //  2. Composition — SwiftUI is forced to materialise `body` for
-//     representative message inputs (empty, long, CJK) across every
+//     representative message inputs (empty, long, CJK, RTL) across every
 //     `ReaderThemeV2` case and both forms, so a re-skin regression that
 //     traps under a particular theme/role/input is caught without a
 //     render pass.
@@ -39,14 +41,15 @@ struct AIChatMessageRowTests {
     /// Representative message-content inputs the row must lay out:
     /// an empty string (an assistant message is appended empty before
     /// the first stream chunk arrives — `AIChatViewModel.sendMessage`),
-    /// a long multi-sentence string, and CJK text (no inter-word
-    /// spaces — exercises the wrapping path of both the accent bubble
-    /// and the serif assistant row).
+    /// a long multi-sentence string, CJK text (no inter-word spaces —
+    /// exercises the wrapping path of both forms), and an RTL Arabic
+    /// string (bidi text through the accent bubble + serif row).
     private static let contentInputs: [String] = [
         "",
         String(repeating: "Drawing on the book's context, here is a "
             + "focused answer to your question. ", count: 20),
         "根据这本书的语境，这是对你问题的一个有针对性的回答。",
+        "ما رأيك في هذا المقطع؟ هذا نص عربي يُكتب من اليمين إلى اليسار.",
     ]
 
     private static func message(_ role: ChatRole, _ content: String = "x") -> ChatMessage {
@@ -88,10 +91,11 @@ struct AIChatMessageRowTests {
 
     @Test("Only `.user` selects the user-bubble form — the role split is exact")
     func onlyUserRoleSelectsUserBubble() {
-        // Exhaustiveness tripwire: enumerate every `ChatRole`; exactly
+        // Pins the role split for the three current `ChatRole`s: exactly
         // one (`.user`) maps to `.userBubble`, the other two to
-        // `.assistantRow`. A new role added without updating the mapper
-        // diverges this and fails.
+        // `.assistantRow`. The compile-time guard for a *new* role is
+        // the exhaustive `switch` in `form(for:)`; `allRoles` here is
+        // hand-maintained and must be extended alongside any new case.
         let allRoles: [ChatRole] = [.user, .assistant, .system]
         let userBubbleRoles = allRoles.filter {
             AIChatMessageRow.form(for: $0) == .userBubble
@@ -113,7 +117,7 @@ struct AIChatMessageRowTests {
         // A re-skin regression that traps the row under a specific
         // theme/role/input (a token that traps, a layout that crashes
         // on empty content, a CJK wrapping fault) surfaces here. All
-        // five themes × three roles × three content inputs must
+        // five themes × three roles × four content inputs must
         // materialise `body` without trapping.
         for role in [ChatRole.user, .assistant, .system] {
             for content in Self.contentInputs {

--- a/vreaderTests/Views/AI/AIChatMessageRowTests.swift
+++ b/vreaderTests/Views/AI/AIChatMessageRowTests.swift
@@ -1,0 +1,188 @@
+// Purpose: Feature #65 WI-2 — composition + role-discrimination tests
+// for the re-skinned chat message row (`AIChatMessageRow`). The v2
+// re-skin replaces the private `ChatBubbleView` (`Color.blue.opacity`
+// /`Color.secondary.opacity` bubbles) with the design's two forms:
+// an accent user bubble with an asymmetric corner, and a sparkle-
+// avatar + serif assistant/system row.
+//
+// `AIChatMessageRow` is a pure presentational view. Its honest
+// unit-testable surface is two layers (the `AISummaryTabView` /
+// `SearchView.contentState` precedent):
+//
+//  1. Role routing — `AIChatMessageRow.form(for:)` is a pure static
+//     mapper from a `ChatRole` to the `BubbleForm` it renders. These
+//     tests pin that `.user` selects the accent bubble form and that
+//     `.assistant` / `.system` both select the sparkle-avatar row form
+//     — the design's two-branch split. A future role added without
+//     updating the mapper trips the exhaustiveness tripwire.
+//
+//  2. Composition — SwiftUI is forced to materialise `body` for
+//     representative message inputs (empty, long, CJK) across every
+//     `ReaderThemeV2` case and both forms, so a re-skin regression that
+//     traps under a particular theme/role/input is caught without a
+//     render pass.
+//
+// @coordinates-with: AIChatMessageRow.swift, ChatMessage.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-panels.jsx`
+
+import Testing
+import SwiftUI
+import Foundation
+@testable import vreader
+
+@Suite("AI Chat message row re-skin — feature #65 WI-2")
+@MainActor
+struct AIChatMessageRowTests {
+
+    // MARK: - Fixtures
+
+    /// Representative message-content inputs the row must lay out:
+    /// an empty string (an assistant message is appended empty before
+    /// the first stream chunk arrives — `AIChatViewModel.sendMessage`),
+    /// a long multi-sentence string, and CJK text (no inter-word
+    /// spaces — exercises the wrapping path of both the accent bubble
+    /// and the serif assistant row).
+    private static let contentInputs: [String] = [
+        "",
+        String(repeating: "Drawing on the book's context, here is a "
+            + "focused answer to your question. ", count: 20),
+        "根据这本书的语境，这是对你问题的一个有针对性的回答。",
+    ]
+
+    private static func message(_ role: ChatRole, _ content: String = "x") -> ChatMessage {
+        ChatMessage(role: role, content: content)
+    }
+
+    // MARK: - Role → form routing
+
+    @Test("A `.user` message selects the accent user-bubble form")
+    func userMessageSelectsUserBubbleForm() {
+        // The design's `ChatBubble` renders `role === 'user'` as an
+        // accent-filled bubble with an asymmetric corner. Pin that the
+        // role mapper routes `.user` to `.userBubble`.
+        #expect(AIChatMessageRow.form(for: .user) == .userBubble)
+    }
+
+    @Test("An `.assistant` message selects the sparkle-avatar row form")
+    func assistantMessageSelectsAssistantRowForm() {
+        // The design renders a non-user message as a sparkle avatar +
+        // serif body row. Pin `.assistant` → `.assistantRow`.
+        #expect(AIChatMessageRow.form(for: .assistant) == .assistantRow)
+    }
+
+    @Test("A `.system` message selects the sparkle-avatar row form")
+    func systemMessageSelectsAssistantRowForm() {
+        // `system` (book-context injection role) shares the design's
+        // non-user branch — it must NOT render as a user bubble.
+        #expect(AIChatMessageRow.form(for: .system) == .assistantRow)
+    }
+
+    @Test("`.assistant` and `.system` resolve to the same (non-user) form")
+    func assistantAndSystemShareTheNonUserForm() {
+        // The design has exactly two `ChatBubble` branches: `user` and
+        // everything-else. Pin that the two non-user roles collapse to
+        // one form so a re-skin can't accidentally fork them.
+        #expect(AIChatMessageRow.form(for: .assistant)
+            == AIChatMessageRow.form(for: .system))
+    }
+
+    @Test("Only `.user` selects the user-bubble form — the role split is exact")
+    func onlyUserRoleSelectsUserBubble() {
+        // Exhaustiveness tripwire: enumerate every `ChatRole`; exactly
+        // one (`.user`) maps to `.userBubble`, the other two to
+        // `.assistantRow`. A new role added without updating the mapper
+        // diverges this and fails.
+        let allRoles: [ChatRole] = [.user, .assistant, .system]
+        let userBubbleRoles = allRoles.filter {
+            AIChatMessageRow.form(for: $0) == .userBubble
+        }
+        #expect(userBubbleRoles == [.user])
+        let assistantRowRoles = allRoles.filter {
+            AIChatMessageRow.form(for: $0) == .assistantRow
+        }
+        #expect(Set(assistantRowRoles) == Set([.assistant, .system]))
+    }
+
+    // MARK: - Composition across themes (layout-trap regression guard)
+
+    @Test(
+        "The row body builds for every role + input across every theme",
+        arguments: ReaderThemeV2.allCases
+    )
+    func rowBodyBuildsForEveryThemeRoleAndInput(_ theme: ReaderThemeV2) {
+        // A re-skin regression that traps the row under a specific
+        // theme/role/input (a token that traps, a layout that crashes
+        // on empty content, a CJK wrapping fault) surfaces here. All
+        // five themes × three roles × three content inputs must
+        // materialise `body` without trapping.
+        for role in [ChatRole.user, .assistant, .system] {
+            for content in Self.contentInputs {
+                let row = AIChatMessageRow(
+                    message: Self.message(role, content),
+                    theme: theme
+                )
+                _ = row.body
+            }
+        }
+    }
+
+    @Test("The user-bubble form builds for an empty content string")
+    func userBubbleBuildsForEmptyContent() {
+        // Defensive: a user message is never appended empty by the VM,
+        // but the bubble must still compose around an empty string
+        // rather than trap.
+        let row = AIChatMessageRow(
+            message: Self.message(.user, ""),
+            theme: .paper
+        )
+        #expect(AIChatMessageRow.form(for: row.message.role) == .userBubble)
+        _ = row.body
+    }
+
+    @Test("The assistant-row form builds for an empty content string")
+    func assistantRowBuildsForEmptyContent() {
+        // `AIChatViewModel.sendMessage` appends an empty `.assistant`
+        // message and streams chunks into it — the row is rendered with
+        // "" before the first chunk lands. The sparkle avatar + serif
+        // body must compose around an empty string.
+        let row = AIChatMessageRow(
+            message: Self.message(.assistant, ""),
+            theme: .dark
+        )
+        #expect(AIChatMessageRow.form(for: row.message.role) == .assistantRow)
+        _ = row.body
+    }
+
+    @Test("The user-bubble form builds for a long multi-sentence message")
+    func userBubbleBuildsForLongContent() {
+        let long = String(
+            repeating: "What do you make of this passage and its irony? ",
+            count: 30
+        )
+        let row = AIChatMessageRow(
+            message: Self.message(.user, long),
+            theme: .sepia
+        )
+        _ = row.body
+    }
+
+    @Test("The assistant-row form builds for CJK content")
+    func assistantRowBuildsForCJKContent() {
+        // CJK has no inter-word spaces; the serif assistant body's
+        // wrapping must not trap. Pin composition under an OLED theme.
+        let row = AIChatMessageRow(
+            message: Self.message(.assistant, "这一行是小说的主题陈述，带着刻意的反讽。"),
+            theme: .oled
+        )
+        _ = row.body
+    }
+
+    @Test("The user-bubble form builds for CJK content")
+    func userBubbleBuildsForCJKContent() {
+        let row = AIChatMessageRow(
+            message: Self.message(.user, "你对这段话怎么看？"),
+            theme: .photo
+        )
+        _ = row.body
+    }
+}


### PR DESCRIPTION
## Summary

Re-skins the AI sheet's Chat tab body to visual-identity v2 — the second of feature #65's 3 work items.

Part of feature #65 (GH #823).

## What changed

- New `AIChatMessageRow` — the two designed `ChatBubble` forms: an accent-filled user bubble with an asymmetric top-right corner, and a sparkle-avatar + serif assistant/system row. Exposes a pure `form(for: ChatRole)` mapper.
- `AIChatView` — the private `ChatBubbleView` is replaced by `AIChatMessageRow`; the plain `TextField` + `arrow.up.circle.fill` becomes the design's rounded pill input + circular send button. Gains an additive `theme: ReaderThemeV2 = .paper` parameter. Empty-state, error banner, auto-scroll, the bug-#94 keyboard handling, and the `clearHistory` button are preserved.
- `AIReaderPanel` passes the real `theme` into `AIChatView`.
- Gate-4 fix: the input placeholder is now book-context-aware (`bookFingerprint != nil` → "Ask about this book...", else the pre-v2 "Type a message...") so the Library general-chat sheet is not regressed.

## WI status

- WI-1 (Summarize body) — merged (PR #870).
- WI-2 (Chat body) — this PR.
- WI-3 (Translate body — final WI) — remaining.

## Codex Audit (Gate 4)

Thread `019e3bf8` — 2 rounds. Round 1: 1 Medium (general-chat placeholder regression) + 3 Low (over-claimed test comment, missing RTL coverage). Round 2: clean. All 4 findings fixed. Verdict: **ship-as-is**.
Audit log: `.claude/codex-audits/feat-feature-65-wi-2-chat-reskin-audit.md`

## Validation

- [x] `AIChatMessageRowTests` green — 11 tests (5 themes x 3 roles x 4 inputs incl. CJK + Arabic RTL)
- [x] AI-family regression gate 95/95 across 8 suites
- [x] Codex audit loop complete (2 rounds, ship-as-is)
- [x] Version bumped: 3.30.5 -> 3.30.6
- [x] Docs sync — n/a (re-skin sub-views; no new service/model/notification)
- ⚠ Full `-only-testing:vreaderTests` gate: 2 pre-existing failures unrelated to WI-2 — a `DictionaryLookupTests` test-host crash and a `SelectiveRestoreCoordinatorTests` `NotificationCenter` state-leak — reproduced identically on a clean `main` baseline. WI-2's files are all AI-chat files; neither failing test touches them.

## Gate 5a Verification (per-PR slice)

Tier: behavioral, not final. Composition tests cover the `ChatRole` -> form mapper and `body` materialisation across 5 themes x 3 roles x 4 content inputs. Full end-to-end acceptance + the `Feature65AISheetTabBodyVerificationTests` XCUITest land with the final WI (WI-3).

## Type of Change

- [x] Feature WI (Part of feature #65 / GH #823)

🤖 Generated with [Claude Code](https://claude.com/claude-code)