### PR TITLE
feat(#68 WI-4): EPUB chapter-start drop-cap CSS rule

### DIFF
--- a/.claude/codex-audits/feat-feature-68-wi-4-epub-dropcap-css-audit.md
+++ b/.claude/codex-audits/feat-feature-68-wi-4-epub-dropcap-css-audit.md
@@ -1,0 +1,48 @@
+---
+branch: feat/feature-68-wi-4-epub-dropcap-css
+threadId: 019e3e00-1875-7053-890c-1fa9642f4651
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+## Scope
+
+Feature #68 (reader chapter-start typography) Gate-4 audit for WI-4 — the
+EPUB drop-cap CSS rule (mechanical "inject a CSS rule" WI). Changed files:
+
+- `vreader/Models/ReaderThemeV2+EPUBCSS.swift` — `epubOverrideCSS`
+  appends a `body > p:first-of-type::first-letter` drop-cap rule via a
+  new private `dropCapCSSRule(accent:)` helper.
+- `vreaderTests/Models/ReaderThemeV2EPUBCSSChapterStartTests.swift` (NEW).
+
+## Round 1 findings
+
+The **implementation was correct** (pinned `body > p:first-of-type::
+first-letter` child-combinator selector, design declarations, existing
+`h1..h6` rule untouched, accent path is internal-`UIColor`-only with no
+injection surface). Three **test-quality** findings:
+
+- **Medium** — selector / declaration assertions used loose substring
+  matching of the whole stylesheet, not the extracted drop-cap rule
+  block; a stray loose `p:first-of-type` rule would not fail the test.
+- **Medium** — no `!important`-on-every-declaration assertion; per-theme
+  accent verified only for Paper/Dark and matchable off the existing
+  link/selection accent rules.
+- **Low** — weak font-stack assertion (`contains("serif")` could match
+  unrelated rules).
+
+## Resolution
+
+`ReaderThemeV2EPUBCSSChapterStartTests.swift` rewritten with a
+`dropCapBlock(_:)` helper that extracts the rule body. `emitsPinnedSelector`
+now asserts every `p:first-of-type::first-letter` occurrence is preceded
+by `"body > "`; `singleFirstLetterRule` asserts exactly one
+`::first-letter` rule; `everyDeclarationImportant` splits the extracted
+block and asserts `!important` on each declaration; `perThemeAccentColor`
+iterates all 5 themes; `dropCapSerifFontStack` pins the exact
+`ReaderTypography.cssFontStack(for: .sourceSerif4)` string.
+
+## Round 2 verdict
+
+No remaining Critical/High/Medium findings. **ship-as-is.**

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 471
-        MARKETING_VERSION: 3.31.11
+        CURRENT_PROJECT_VERSION: 472
+        MARKETING_VERSION: 3.31.12
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		07DCB26CA703C2A38E135473 /* MDParserProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9452FAFFDEBDF03FF6CCEBB1 /* MDParserProtocol.swift */; };
 		080FFC22ED10E039095B0CDC /* AISummaryCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38799CD3E8349912E703D65 /* AISummaryCardTests.swift */; };
 		0855EB1652BB385895B9ABA6 /* ReaderThemeV2+EPUBCSS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B67894BA57026638D94B118 /* ReaderThemeV2+EPUBCSS.swift */; };
+		088A6BACBD0B52E1AD639B58 /* ReaderThemeV2EPUBCSSChapterStartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F2360F05D5C411D05806514 /* ReaderThemeV2EPUBCSSChapterStartTests.swift */; };
 		088EB6A1D2B736BB8B643B30 /* SimpTradTransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C1B3D47B7CCE2B9CBC61B7A /* SimpTradTransformTests.swift */; };
 		08C05E320FF9F6EFAAE34DA3 /* ImportErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 744CB6180C0CE88E75E124F3 /* ImportErrorTests.swift */; };
 		08D7E1736817CB7AA0695C3D /* ThemeBackgroundStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07FB35EC9805F51CAD10444 /* ThemeBackgroundStore.swift */; };
@@ -1526,6 +1527,7 @@
 		7DE6A4A50E59B50DE7574A87 /* paginator.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = paginator.js; sourceTree = "<group>"; };
 		7DEA283D3F2224EDC297B6E1 /* MDFileLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDFileLoader.swift; sourceTree = "<group>"; };
 		7F1BC0259A472381A819DF2A /* mobi.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = mobi.js; sourceTree = "<group>"; };
+		7F2360F05D5C411D05806514 /* ReaderThemeV2EPUBCSSChapterStartTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeV2EPUBCSSChapterStartTests.swift; sourceTree = "<group>"; };
 		7F71E759F980473A403CC70B /* TXTReaderContainerSearchHighlightWiringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReaderContainerSearchHighlightWiringTests.swift; sourceTree = "<group>"; };
 		7FC8555E3C352A0C95D6BFE9 /* LocatorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorFactory.swift; sourceTree = "<group>"; };
 		800ED346D9C0E17741704040 /* WebDAVServerProfileEditSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVServerProfileEditSheet.swift; sourceTree = "<group>"; };
@@ -2085,6 +2087,7 @@
 				2EDF15104F7C0B4EAC533454 /* ReaderEngineTests.swift */,
 				3A480E951C2CA72DB6A22C24 /* ReaderThemeMigrationTests.swift */,
 				9081F5E7C359D5FB2661E7AC /* ReaderThemeTests.swift */,
+				7F2360F05D5C411D05806514 /* ReaderThemeV2EPUBCSSChapterStartTests.swift */,
 				80381187837EB2DA41E98207 /* ReaderThemeV2Tests.swift */,
 				EC4FE169F0AC369FB30F888F /* ReadingModeTests.swift */,
 				EE41196788F697BB4ACD4B06 /* ReadingSessionTests.swift */,
@@ -4368,6 +4371,7 @@
 				6173290A06E9E4303D363AE8 /* ReaderThemeCSSTests.swift in Sources */,
 				7A3B9A992F12E5E187F0794E /* ReaderThemeMigrationTests.swift in Sources */,
 				CB432F27C324A4EBC3D1F327 /* ReaderThemeTests.swift in Sources */,
+				088A6BACBD0B52E1AD639B58 /* ReaderThemeV2EPUBCSSChapterStartTests.swift in Sources */,
 				AAE6B9BC238DD37272640F0E /* ReaderThemeV2Tests.swift in Sources */,
 				11F1D99E4B3412CE344A4F16 /* ReaderTypographyTests.swift in Sources */,
 				A3D6C41E3B9BAD5A458D4A7F /* ReadingModeMigrationTests.swift in Sources */,
@@ -5146,13 +5150,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 471;
+				CURRENT_PROJECT_VERSION = 472;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.31.11;
+				MARKETING_VERSION = 3.31.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5296,13 +5300,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 471;
+				CURRENT_PROJECT_VERSION = 472;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.31.11;
+				MARKETING_VERSION = 3.31.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Models/ReaderThemeV2+EPUBCSS.swift
+++ b/vreader/Models/ReaderThemeV2+EPUBCSS.swift
@@ -83,6 +83,15 @@ extension ReaderThemeV2 {
             for: self, url: backgroundImageURL, outerBG: outerBG
         )
 
+        // Feature #68: chapter-start drop-cap. `body > p:first-of-type`
+        // (child combinator) targets the first top-level <p> directly
+        // under <body> — exactly one drop-cap for the common flat-<p>
+        // EPUB shape; a section-wrapped first <p> is safely missed (no
+        // wrong drop-cap). `accent` is the theme's oxblood token,
+        // already computed above. The book's own <h1>..<h6> rule is
+        // untouched — no VReader heading is injected (no duplicate).
+        let dropCapRule = Self.dropCapCSSRule(accent: accent)
+
         // The style-id is "vreader-theme" (not "-v2") because
         // `EPUBWebViewBridgeJS.injectThemeCSSJS` extracts the inner CSS
         // and reinserts it under the fixed id "vreader-theme" so a
@@ -132,6 +141,7 @@ extension ReaderThemeV2 {
         }\
         a:link { color: \(accent) !important; text-decoration: underline; }\
         a:visited { color: \(sub) !important; text-decoration: underline; }\
+        \(dropCapRule)\
         img, svg, video { \
           max-width: 100% !important; \
           height: auto !important; \
@@ -162,6 +172,31 @@ extension ReaderThemeV2 {
     }
 
     // MARK: - Helpers
+
+    /// Feature #68: builds the chapter-start drop-cap CSS rule appended
+    /// to the EPUB override blob. The selector `body > p:first-of-type::
+    /// first-letter` uses the child combinator so it matches the first
+    /// `<p>` that is a *direct* child of `<body>` — exactly one drop-cap
+    /// for the flat-top-level-`<p>` EPUB shape. A `<p>` nested inside a
+    /// section wrapper is not matched (a safe miss — no wrong drop-cap).
+    /// Declarations mirror the design (`vreader-reader.jsx:383-390`) and
+    /// the `ChapterStartTypography` constants; `accent` is the theme's
+    /// oxblood token.
+    private static func dropCapCSSRule(accent: String) -> String {
+        let serifStack = ReaderTypography.cssFontStack(for: .sourceSerif4)
+        return """
+        body > p:first-of-type::first-letter { \
+          font-family: \(serifStack) !important; \
+          font-size: \(ChapterStartTypography.dropCapCSSFontSizeEm) !important; \
+          font-weight: 600 !important; \
+          line-height: 0.85 !important; \
+          float: left !important; \
+          margin-right: 0.06em !important; \
+          margin-top: 0.05em !important; \
+          color: \(accent) !important; \
+        }
+        """
+    }
 
     /// Photo-only: emits the `html { background-image: ... }` rule when
     /// the caller supplied a URL. Returns an empty string for all other

--- a/vreaderTests/Models/ReaderThemeV2EPUBCSSChapterStartTests.swift
+++ b/vreaderTests/Models/ReaderThemeV2EPUBCSSChapterStartTests.swift
@@ -1,0 +1,160 @@
+// Purpose: Feature #68 WI-4 — pins the chapter-start drop-cap rule
+// appended to `ReaderThemeV2.epubOverrideCSS`. Asserts the exact pinned
+// selector `body > p:first-of-type::first-letter` (the child combinator,
+// NOT a loose `p:first-of-type`), the design declarations with
+// `!important` on every one, per-theme accent color, and that the book's
+// own heading rule is preserved.
+//
+// Every selector / declaration assertion runs against the EXTRACTED
+// drop-cap rule block, not loose substrings of the whole stylesheet — so
+// a regression that emits a second loose `p:first-of-type::first-letter`
+// rule, or drops an `!important`, fails the test.
+//
+// @coordinates-with: ReaderThemeV2+EPUBCSS.swift, ChapterStartTypography.swift,
+//   ReaderTypography.swift
+
+#if canImport(UIKit)
+import Testing
+import UIKit
+@testable import vreader
+
+@Suite("ReaderThemeV2 EPUB CSS — chapter-start drop-cap (feature #68 WI-4)")
+struct ReaderThemeV2EPUBCSSChapterStartTests {
+
+    /// Collapses whitespace runs so block extraction + assertions stay
+    /// stable across re-indentation (CSS ignores internal whitespace).
+    private func normalize(_ css: String) -> String {
+        css.replacingOccurrences(
+            of: "\\s+", with: " ", options: .regularExpression
+        )
+    }
+
+    /// Extracts the `body > p:first-of-type::first-letter { ... }` rule
+    /// block (the `{...}` body) from the normalized CSS. Returns nil when
+    /// the rule is absent.
+    private func dropCapBlock(_ theme: ReaderThemeV2) -> String? {
+        let css = normalize(theme.epubOverrideCSS(fontSize: 18))
+        let selector = "body > p:first-of-type::first-letter {"
+        guard let selRange = css.range(of: selector) else { return nil }
+        guard let closeBrace = css[selRange.upperBound...].firstIndex(of: "}")
+        else { return nil }
+        return String(css[selRange.upperBound..<closeBrace])
+    }
+
+    @Test("emits exactly the pinned child-combinator drop-cap selector")
+    func emitsPinnedSelector() {
+        let css = normalize(ReaderThemeV2.paper.epubOverrideCSS(fontSize: 18))
+        #expect(css.contains("body > p:first-of-type::first-letter"),
+                "Drop-cap selector must use the child combinator")
+        // There must be NO loose `p:first-of-type::first-letter` rule —
+        // i.e. every occurrence of `p:first-of-type::first-letter` must be
+        // preceded by the `body > ` child combinator (R6 guard).
+        var searchStart = css.startIndex
+        while let r = css.range(of: "p:first-of-type::first-letter",
+                                range: searchStart..<css.endIndex) {
+            let prefixStart = css.index(r.lowerBound, offsetBy: -7,
+                                        limitedBy: css.startIndex) ?? css.startIndex
+            let prefix = String(css[prefixStart..<r.lowerBound])
+            #expect(prefix == "body > ",
+                    "Every p:first-of-type::first-letter must be a child-combinator selector — found a loose one")
+            searchStart = r.upperBound
+        }
+    }
+
+    @Test("only one ::first-letter rule is emitted")
+    func singleFirstLetterRule() {
+        let css = normalize(ReaderThemeV2.paper.epubOverrideCSS(fontSize: 18))
+        let count = css.components(separatedBy: "::first-letter").count - 1
+        #expect(count == 1, "Exactly one ::first-letter rule expected, found \(count)")
+    }
+
+    @Test("drop-cap rule block carries the design declarations with !important")
+    func dropCapDeclarations() throws {
+        let block = try #require(dropCapBlock(.paper),
+                                 "Drop-cap rule block must be present")
+        #expect(block.contains("font-size: 2.6em !important"))
+        #expect(block.contains("float: left !important"))
+        #expect(block.contains("font-weight: 600 !important"))
+        #expect(block.contains("line-height: 0.85 !important"))
+        #expect(block.contains("margin-right: 0.06em !important"))
+        #expect(block.contains("margin-top: 0.05em !important"))
+    }
+
+    @Test("every declaration in the drop-cap rule block carries !important")
+    func everyDeclarationImportant() throws {
+        let block = try #require(dropCapBlock(.paper))
+        // Each `;`-terminated declaration must contain `!important`.
+        let declarations = block.components(separatedBy: ";")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        for decl in declarations {
+            #expect(decl.contains("!important"),
+                    "Declaration <\(decl)> must carry !important")
+        }
+    }
+
+    @Test("drop-cap font-family is the Source Serif 4 stack")
+    func dropCapSerifFontStack() throws {
+        let block = try #require(dropCapBlock(.paper))
+        let expected = "font-family: \(ReaderTypography.cssFontStack(for: .sourceSerif4)) !important"
+        #expect(block.contains(expected),
+                "Drop-cap font-family must be the ReaderTypography Source Serif 4 stack")
+    }
+
+    @Test("drop-cap font-size is the ChapterStartTypography constant")
+    func dropCapFontSizeConstant() throws {
+        let block = try #require(dropCapBlock(.paper))
+        #expect(block.contains(
+            "font-size: \(ChapterStartTypography.dropCapCSSFontSizeEm) !important"))
+    }
+
+    @Test("every theme's drop-cap rule carries its own accent color with !important")
+    func perThemeAccentColor() throws {
+        // Expected accent rgb per theme (ReaderThemeV2.accentColor).
+        let expected: [ReaderThemeV2: String] = [
+            .paper: "rgb(140,47,47)",
+            .sepia: "rgb(122,58,31)",
+            .dark:  "rgb(214,136,90)",
+            .oled:  "rgb(214,136,90)",
+            .photo: "rgb(232,180,101)",
+        ]
+        for theme in ReaderThemeV2.allCases {
+            let block = try #require(dropCapBlock(theme),
+                                     "Theme \(theme) must emit the drop-cap rule")
+            let color = try #require(expected[theme])
+            #expect(block.contains("color: \(color) !important"),
+                    "Theme \(theme) drop-cap color must be \(color) with !important")
+        }
+    }
+
+    @Test("Paper and Dark drop-cap colors differ")
+    func dropCapColorVariesPerTheme() throws {
+        let paper = try #require(dropCapBlock(.paper))
+        let dark = try #require(dropCapBlock(.dark))
+        #expect(paper.contains("rgb(140,47,47)"))
+        #expect(dark.contains("rgb(214,136,90)"))
+        #expect(!paper.contains("rgb(214,136,90)"))
+    }
+
+    @Test("the book's own h1..h6 rule is still present — no heading regression")
+    func headingRulePreserved() {
+        let css = normalize(ReaderThemeV2.paper.epubOverrideCSS(fontSize: 18))
+        // The existing `h1,h2,h3,h4,h5,h6 { font-size: revert ... }` rule
+        // must remain — feature #68 does NOT restyle EPUB headings, and
+        // a VReader heading is never injected (no duplicate heading).
+        #expect(css.contains("h1,h2,h3,h4,h5,h6"),
+                "The book's own heading rule must be preserved (no EPUB heading restyle in v1)")
+        #expect(css.contains("font-size: revert"),
+                "h1..h6 font-size: revert must remain so book headings render at their own size")
+    }
+
+    @Test("all five themes emit the drop-cap rule")
+    func allThemesEmitDropCap() {
+        for theme in ReaderThemeV2.allCases {
+            let css = normalize(theme.epubOverrideCSS(fontSize: 18))
+            #expect(css.contains("body > p:first-of-type::first-letter"),
+                    "Theme \(theme) must emit the drop-cap rule")
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Part of feature #68 — reader chapter-start typography. **WI-4** brings the design's accent drop-cap to the **EPUB** renderer. A mechanical "inject a CSS rule" WI.

## What this WI does

`ReaderThemeV2.epubOverrideCSS` now appends a chapter-start drop-cap rule to the injected `<style id="vreader-theme">` blob via a new private `dropCapCSSRule(accent:)` helper.

The selector is the pinned **`body > p:first-of-type::first-letter`** — the child combinator matches the first `<p>` that is a direct child of `<body>`, so the common flat-top-level-`<p>` EPUB shape gets exactly one drop-cap; a `<p>` nested inside a section wrapper is safely missed (no wrong drop-cap) rather than mis-targeted (plan Risk R6 — a loose `p:first-of-type` would produce multiple drop-caps in nested markup).

Declarations mirror the design (`vreader-reader.jsx:383-390`): the Source Serif 4 stack, `2.6em` font-size, weight 600, line-height 0.85, `float: left`, small margins, and the theme's oxblood `accentColor` — every declaration `!important`. The `accent` string is already computed in `epubOverrideCSS` (used by `a:link`); the new rule reuses it.

The book's own `h1..h6 { font-size: revert }` rule is **untouched** — EPUB headings are NOT restyled and no VReader heading is injected (no duplicate next to the book's own `<h1>`; plan Risk R8). The rule rides the existing EPUB CSS injection pipe — no `EPUBWebViewBridge` or `EPUBReaderContainerView` change.

## Tier & verification (rule 47 Gate 5)

Behavioral WI — **slice verification**:

- **10 `ReaderThemeV2EPUBCSSChapterStartTests`** pass on iPhone 17 Pro Simulator. Every assertion runs against the **extracted** `body > p:first-of-type::first-letter { ... }` rule block, not loose stylesheet substrings: the child-combinator selector is pinned (every `p:first-of-type::first-letter` occurrence must be preceded by `body > `), exactly one `::first-letter` rule, `!important` on every declaration, per-theme accent across all 5 themes (Paper `rgb(140,47,47)`, Sepia `rgb(122,58,31)`, Dark/OLED `rgb(214,136,90)`, Photo `rgb(232,180,101)`), the exact `ReaderTypography.cssFontStack(for: .sourceSerif4)`, and the `h1..h6`-preserved invariant.
- No regression: the existing `EPUBThemeOverrideCSSV2Tests`, `ReaderThemeCSSTests`, `ReaderThemeV2Tests`, `ReaderAuditFix3Tests` all pass.
- Build succeeds; installed on iPhone 17 Pro Simulator.
- **EPUB-on-device drop-cap visual** is carried to **WI-6**'s final acceptance pass — `vreader-debug://open` did not navigate the EPUB into the reader on the shared simulator this session (the reader stayed on Library; `ready` reported `no active reader`), and computer-use returned `CU display unavailable` so the cover could not be tapped. WI-6's plan (§11) explicitly schedules a fixture EPUB for the acceptance pass. The drop-cap is a pure CSS-string addition fully covered by the 10 unit tests (selector, declarations, per-theme color) and rides the already-shipped, already-verified EPUB injection pipe.

## Gate-4 Codex audit

`.claude/codex-audits/feat-feature-68-wi-4-epub-dropcap-css-audit.md` — 2 rounds, final verdict **ship-as-is**. Round 1 confirmed the implementation correct and flagged 3 test-quality findings (loose substring matching, missing `!important`/per-theme coverage, weak font-stack assertion); round 2 confirmed the rewritten block-extraction tests.

## Plan

`dev-docs/plans/20260518-feature-68-chapter-start-typography.md` (v4) — §4.4 specifies WI-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)