### PR TITLE
chore: bump version to 3.31.14 post-WI-5 collision

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 473
-        MARKETING_VERSION: 3.31.13
+        CURRENT_PROJECT_VERSION: 474
+        MARKETING_VERSION: 3.31.14
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5146,13 +5146,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 473;
+				CURRENT_PROJECT_VERSION = 474;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.31.13;
+				MARKETING_VERSION = 3.31.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5296,13 +5296,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 473;
+				CURRENT_PROJECT_VERSION = 474;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.31.13;
+				MARKETING_VERSION = 3.31.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
Feature #54 WI-5 (PR #893) and feature #68 WI-5 (PR #892) both bumped to `MARKETING_VERSION: 3.31.13` / `CURRENT_PROJECT_VERSION: 473` concurrently and merged back-to-back. The `v3.31.13` tag landed on #892's merge commit; #893's merge carries the same version line.

This bumps `project.yml` to `3.31.14` / build `474` (and regenerates `pbxproj`) so `main` carries a unique, monotonic version and the next release tag is unambiguous. Pure version chore — no code change, no tracker-row reference.

Same corrective pattern as commit `a6103e5` ("chore: bump version to 3.24.6 post-WI-1b/WI-7c3 collision").

🤖 Generated with [Claude Code](https://claude.com/claude-code)