### PR TITLE
chore: bump version to 3.32.2 (post-merge collision)

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 476
-        MARKETING_VERSION: 3.32.1
+        CURRENT_PROJECT_VERSION: 477
+        MARKETING_VERSION: 3.32.2
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5146,13 +5146,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 476;
+				CURRENT_PROJECT_VERSION = 477;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.32.1;
+				MARKETING_VERSION = 3.32.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5296,13 +5296,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 476;
+				CURRENT_PROJECT_VERSION = 477;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.32.1;
+				MARKETING_VERSION = 3.32.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
PR #899 (Gate-1+2 plans) and PR #898 (codex-audit hook fix) both branched from 3.32.0 and independently bumped to 3.32.1. #898 merged first and holds the v3.32.1 tag, leaving #899's merge commit on main with a duplicate version. This bumps main to 3.32.2 / build 477 so the version line is monotonic again — the same post-collision correction pattern as the earlier 3.24.6 bump.

Version-only change: project.yml and the regenerated pbxproj. No other files.