### PR TITLE
feat(#69 WI-2): SummaryScopeResolver — TOC-to-ChapterBounds resolver

### DIFF
--- a/.claude/codex-audits/feat-feature-69-wi-2-summary-scope-resolver-audit.md
+++ b/.claude/codex-audits/feat-feature-69-wi-2-summary-scope-resolver-audit.md
@@ -1,0 +1,45 @@
+---
+branch: feat/feature-69-wi-2-summary-scope-resolver
+threadId: 019e3e3e-1c0f-7571-886b-f2dcfd0a5c34
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+# Gate-4 Implementation Audit — Feature #69 WI-2
+
+WI-2: `SummaryScopeResolver` — the pure TOC→`ChapterBounds` resolver
+behind the Chapter scope of the AI Summarize selector.
+
+## Files audited
+
+- `vreader/Services/AI/SummaryScopeResolver.swift` (new)
+- `vreaderTests/Services/AI/SummaryScopeResolverTests.swift` (new)
+
+## Round 1 — findings
+
+| file:line | severity | issue | resolution |
+|---|---|---|---|
+| `SummaryScopeResolver.swift:56` | Medium | The resolver returned `nil` when `totalTextLengthUTF16 <= 0`, but plan §2.4 reserves `nil` for "no usable chapter offsets" only — so Chapter scope degraded to Section in a case the plan says should still resolve. | **Fixed** — removed the total-length check from the `nil` gate. Non-final chapters resolve from the next chapter's start (unaffected by the total); the final chapter's end is the total, and `ChapterBounds`' clamping init collapses a degenerate total to an empty final-chapter span. Header + doc comment updated. |
+| `SummaryScopeResolverTests.swift:201` | Medium | `zeroTotalLengthReturnsNil` locked in the contract drift. | **Fixed** — replaced with `zeroTotalLengthStillResolvesFromAnchoredTOC` (zero total + anchored TOC → non-nil `ChapterBounds(3000,3000)`) and `shortTotalLengthResolvesNonFinalChapterNormally` (short total leaves non-final chapters unaffected). |
+| `SummaryScopeResolverTests.swift:212` | Low | The "CJK / surrogate-pair" test used hard-coded numbers + CJK titles — no real surrogate-pair exercise; false confidence about UTF-16. | **Fixed** — replaced with `surrogatePairOffsetsLandInExpectedChapter`: builds a real string of `😀` emoji (2-UTF-16-unit supplementary-plane pairs), derives every offset from `.utf16.count` on actual substrings, proves the locator lands in the expected span, sanity-asserts the offsets are even. |
+
+Clean in round 1: pre-first-entry → preamble span matches the plan,
+exact-boundary behavior correct, mixed anchored/unanchored TOC handling
+correct, the deliberate duplication of `TOCChapterProgress`'s loop is
+justified for a bounds-returning resolver (plan §3 rejected extending
+`TOCChapterProgress`), file size / concurrency / style fine.
+
+## Round 2 — verification
+
+Codex re-reviewed both files: "No new Critical/High/Medium issues. The
+nil contract now matches plan §2.4 … A zero or short
+`totalTextLengthUTF16` no longer degrades to `nil` … The tests now pin
+that behavior correctly … The surrogate-pair test is now materially
+better as well."
+
+## Verdict
+
+**ship-as-is.** Zero open Critical/High/Medium findings after 2
+rounds. 17 tests pass (`xcodebuild test
+-only-testing:vreaderTests/SummaryScopeResolverTests`).

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 480
-        MARKETING_VERSION: 3.33.2
+        CURRENT_PROJECT_VERSION: 481
+        MARKETING_VERSION: 3.33.3
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5182,13 +5182,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 480;
+				CURRENT_PROJECT_VERSION = 481;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.33.2;
+				MARKETING_VERSION = 3.33.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5332,13 +5332,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 480;
+				CURRENT_PROJECT_VERSION = 481;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.33.2;
+				MARKETING_VERSION = 3.33.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -328,6 +328,7 @@
 		4CC9567091E0CABFDD800F6C /* AIConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52103AEAF5528A9DD58625E /* AIConfiguration.swift */; };
 		4CCBF4F6E186A7363A995303 /* ReaderContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB42EEEFFCAD8D654D57AE7 /* ReaderContainerView.swift */; };
 		4D262FBAEBAC69E057B371DA /* SourceSerif4-It.otf in Resources */ = {isa = PBXBuildFile; fileRef = BDD31D89F9B0E622F58B6F5C /* SourceSerif4-It.otf */; };
+		4D323FB1DB077A50154AFC72 /* SummaryScopeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4201BB3B1C117672C45389AE /* SummaryScopeResolverTests.swift */; };
 		4D4A49E8738329EC2B336683 /* TXTReaderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D998048CE6DE8DC3BC77C284 /* TXTReaderViewModelTests.swift */; };
 		4D4D7B16BBA5732D1E6AB875 /* GenerativeCoverMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF66A8065E5B60907FB0A3C8 /* GenerativeCoverMetrics.swift */; };
 		4D66B6E16F96E24A0B01F7A9 /* WebDAVBackupIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F1695C0E7481CB3EA2B8A3 /* WebDAVBackupIntegrationTests.swift */; };
@@ -939,6 +940,7 @@
 		E82E02103AE2B5E39F5F6C66 /* LibraryEmptyStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292131FE5DD09EAEDDD3191C /* LibraryEmptyStateTests.swift */; };
 		E8353217B517055A09014AE7 /* EPUBTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A457F48D22CD5B4952817701 /* EPUBTypes.swift */; };
 		E85787191C94CB7BC2E8D3F2 /* SelectionPopoverActionRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99A967D9AB1E2A699112E0B1 /* SelectionPopoverActionRowTests.swift */; };
+		E86EC184E85E4C11143B1A14 /* SummaryScopeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA838B4649351A656B259147 /* SummaryScopeResolver.swift */; };
 		E88F2A1B4A4EEA858F2429DE /* ReaderTopChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82199531AD7036AB0F37C56C /* ReaderTopChrome.swift */; };
 		E9177AEFF47DA3EFEAC13C50 /* TXTChunkedLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A069D350D0DC6B4C000E1D43 /* TXTChunkedLoaderTests.swift */; };
 		E92C78246E46B2DFE76DE0A2 /* RemoteBookCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B006129C2FCEC99B9FBB91 /* RemoteBookCatalogTests.swift */; };
@@ -1274,6 +1276,7 @@
 		41D94EE13466B0286DEA2EA7 /* ReadingSessionTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingSessionTracker.swift; sourceTree = "<group>"; };
 		41DD0013DEFFC287885D1A48 /* KeyboardInteractionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardInteractionTests.swift; sourceTree = "<group>"; };
 		41F3E1A368720EFCB55A9582 /* SearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchService.swift; sourceTree = "<group>"; };
+		4201BB3B1C117672C45389AE /* SummaryScopeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryScopeResolverTests.swift; sourceTree = "<group>"; };
 		425139E8A71CE98208C8DF69 /* EPUBPreExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBPreExtractor.swift; sourceTree = "<group>"; };
 		425829C48779CD64EB0C5A05 /* PDFPasswordPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFPasswordPromptView.swift; sourceTree = "<group>"; };
 		428A4370B8DB59563F9EE768 /* PDFTextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFTextExtractor.swift; sourceTree = "<group>"; };
@@ -1769,6 +1772,7 @@
 		B9500033AC714D470A3024F8 /* EPUBPaginationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBPaginationTests.swift; sourceTree = "<group>"; };
 		B9B13E64FBD9D9A3063AC677 /* TXTChapterContentLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterContentLoaderTests.swift; sourceTree = "<group>"; };
 		BA0216684C6AC6F1F2DA5EF4 /* AIChatMessageRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatMessageRow.swift; sourceTree = "<group>"; };
+		BA838B4649351A656B259147 /* SummaryScopeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryScopeResolver.swift; sourceTree = "<group>"; };
 		BAA008CC17CE7798B70F4E2D /* WebPageEncodingDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageEncodingDetector.swift; sourceTree = "<group>"; };
 		BB03A3F8DCE5FCBEC5458547 /* Feature37PerBookSettingsVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature37PerBookSettingsVerificationTests.swift; sourceTree = "<group>"; };
 		BB053991F453CF13FC6E4CB9 /* MDReplacementRuleFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReplacementRuleFetcher.swift; sourceTree = "<group>"; };
@@ -3564,6 +3568,7 @@
 				CE7C16F12BA653A217A5439C /* ProviderProfileMigratorTests.swift */,
 				0125F1FAD971AFEE5D536AFD /* ProviderProfileStoreTests.swift */,
 				03E01318DE23F63217033B89 /* ProviderProfileTests.swift */,
+				4201BB3B1C117672C45389AE /* SummaryScopeResolverTests.swift */,
 				19CA966D3696877E6EB055EA /* SummaryScopeTests.swift */,
 				9F2D542588B3156C4A282264 /* WI11TestHelpers.swift */,
 			);
@@ -3815,6 +3820,7 @@
 				2E550B37E4C8E30F6A9238E2 /* ProviderProfileMigrator.swift */,
 				C6E58A8977DC02FDA7235A9E /* ProviderProfileStore.swift */,
 				EA8C0234B383C8D2877E21CC /* SummaryScope.swift */,
+				BA838B4649351A656B259147 /* SummaryScopeResolver.swift */,
 			);
 			path = AI;
 			sourceTree = "<group>";
@@ -4436,6 +4442,7 @@
 				30F629136C9EED9FCD557222 /* SmokeTests.swift in Sources */,
 				0A998572897988CF581C77AE /* SourceSharingServiceTests.swift in Sources */,
 				594A2BE63A5D10BAF70D604A /* StatusBarTintingTests.swift in Sources */,
+				4D323FB1DB077A50154AFC72 /* SummaryScopeResolverTests.swift in Sources */,
 				C52D4B03AE65EC124C626291 /* SummaryScopeTests.swift in Sources */,
 				1316119F5F616DBE405F7E38 /* SwiftDataSessionStoreTests.swift in Sources */,
 				BF9767FD9DB988B04F1B27D5 /* SyncConflictResolverTests.swift in Sources */,
@@ -4934,6 +4941,7 @@
 				97EF677CC2FCE1B5D4FD4047 /* SourceSharingService.swift in Sources */,
 				65E4EDF452B2195BA78BA7A3 /* SpeechSynthesizing.swift in Sources */,
 				2CD1D6C0686DD8C096580AB3 /* SummaryScope.swift in Sources */,
+				E86EC184E85E4C11143B1A14 /* SummaryScopeResolver.swift in Sources */,
 				84A03EDA45DB68CE01456609 /* SwiftDataSessionStore.swift in Sources */,
 				4FDDEB10D3E2014D806618AD /* SyncConflictResolver.swift in Sources */,
 				1FEEB14E71BC2235A040FAC9 /* SyncOutboundQueue.swift in Sources */,

--- a/vreader/Services/AI/SummaryScopeResolver.swift
+++ b/vreader/Services/AI/SummaryScopeResolver.swift
@@ -1,0 +1,102 @@
+// Purpose: Resolves the chapter span containing a reading position,
+// from a book's TOC entries — the Chapter scope of the AI Summarize
+// selector (feature #69).
+//
+// Key decisions:
+// - Pure, no I/O — converts (TOC entries, locator, total UTF-16 length)
+//   into a ChapterBounds?.
+// - Mirrors TOCChapterProgress's chapter-detection algorithm: a
+//   pre-first-entry offset is virtual chapter 0 (the preamble / front
+//   matter), spanning [0, firstStart). The final chapter ends at the
+//   total text length.
+// - Works purely in UTF-16 units (Locator.charOffsetUTF16) — the same
+//   coordinate space the TXT TOC entries and AIContextExtractor use.
+// - Defensively sorts the chapter-start offsets so an out-of-order TOC
+//   still resolves correctly.
+// - Returns nil only when no usable chapter offsets exist (empty TOC
+//   or every entry's locator lacks charOffsetUTF16) — the caller then
+//   degrades Chapter to Section. A short/zero total length is NOT a
+//   nil case: anchored TOC offsets still resolve; the final chapter's
+//   end is clamped to >= its start (ChapterBounds enforces this), so a
+//   degenerate total simply collapses the final chapter to an empty
+//   span, which AIContextExtractor handles as "".
+//
+// @coordinates-with: ChapterBounds.swift, TOCProvider.swift,
+//   TOCChapterProgress.swift, AIContextExtractor.swift
+
+import Foundation
+
+/// Resolves the TOC-chapter span containing a reading position.
+enum SummaryScopeResolver {
+
+    /// Returns the chapter span containing `locator`.
+    ///
+    /// The span for an offset BEFORE the first TOC entry is
+    /// `[0, firstEntryOffset)` — the book's preamble (front matter
+    /// before chapter 1) — mirroring how `TOCChapterProgress` treats a
+    /// pre-first-entry offset as virtual chapter 0. The final chapter
+    /// ends at `totalTextLengthUTF16`.
+    ///
+    /// A locator with no `charOffsetUTF16` is treated as offset `0`
+    /// (it has no position, so it falls into the preamble span).
+    ///
+    /// Returns `nil` only when no usable chapter offsets exist:
+    /// - the TOC is empty, or
+    /// - every entry's locator lacks `charOffsetUTF16` (EPUB-shaped
+    ///   TOCs are not char-offset-anchored).
+    ///
+    /// A short or zero `totalTextLengthUTF16` does NOT yield `nil` —
+    /// anchored offsets still resolve; the final chapter's end is
+    /// clamped to its start (a zero-length span) by `ChapterBounds`.
+    ///
+    /// - Parameters:
+    ///   - locator: the reading position to locate within the TOC.
+    ///   - tocEntries: the book's TOC entries (need not be sorted).
+    ///   - totalTextLengthUTF16: total UTF-16 length of the flattened text.
+    /// - Returns: the chapter span, or `nil` when Chapter scope cannot
+    ///   be resolved (the caller degrades to Section).
+    static func chapterBounds(
+        for locator: Locator,
+        tocEntries: [TOCEntry],
+        totalTextLengthUTF16: Int
+    ) -> ChapterBounds? {
+        guard !tocEntries.isEmpty else { return nil }
+
+        // Extract chapter-start UTF-16 offsets; an EPUB-shaped TOC whose
+        // entries carry no charOffsetUTF16 yields an empty list → nil.
+        // Defensive sort: an out-of-order TOC still resolves correctly.
+        let starts = tocEntries
+            .compactMap { $0.locator.charOffsetUTF16 }
+            .sorted()
+        guard let firstStart = starts.first else { return nil }
+
+        // A locator without an offset has no position — treat as 0.
+        let offset = locator.charOffsetUTF16 ?? 0
+
+        // Pre-first-entry offset → the preamble span [0, firstStart).
+        if offset < firstStart {
+            return ChapterBounds(startUTF16: 0, endUTF16: firstStart)
+        }
+
+        // Find the chapter whose [start, nextStart) contains `offset`.
+        var chapterIndex = 0
+        for (i, start) in starts.enumerated() {
+            if offset >= start {
+                chapterIndex = i
+            } else {
+                break
+            }
+        }
+
+        let chapterStart = starts[chapterIndex]
+        // A non-final chapter ends at the next chapter's start. The
+        // final chapter ends at the total text length; if that total
+        // is short/zero, `ChapterBounds` clamps the end up to the start
+        // (an empty final-chapter span), so this is never `nil`.
+        let chapterEnd = chapterIndex + 1 < starts.count
+            ? starts[chapterIndex + 1]
+            : totalTextLengthUTF16
+
+        return ChapterBounds(startUTF16: chapterStart, endUTF16: chapterEnd)
+    }
+}

--- a/vreaderTests/Services/AI/SummaryScopeResolverTests.swift
+++ b/vreaderTests/Services/AI/SummaryScopeResolverTests.swift
@@ -1,0 +1,275 @@
+// Purpose: Tests for SummaryScopeResolver — the pure TOC→ChapterBounds
+// resolver behind the Chapter scope of the AI Summarize selector
+// (feature #69 WI-2). Mirrors the chapter-detection algorithm of
+// TOCChapterProgress: pre-first-entry offset → preamble span
+// [0, firstStart); empty / non-anchored TOC → nil.
+
+import Testing
+@testable import vreader
+
+@Suite("SummaryScopeResolver")
+struct SummaryScopeResolverTests {
+
+    // MARK: - Helpers
+
+    private static let fp = DocumentFingerprint(
+        contentSHA256: "aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233",
+        fileByteCount: 4096,
+        format: .txt
+    )
+
+    /// A TXT locator at a UTF-16 char offset.
+    private func locator(at offset: Int?) -> Locator {
+        Locator(
+            bookFingerprint: Self.fp,
+            href: nil, progression: nil, totalProgression: nil, cfi: nil,
+            page: nil, charOffsetUTF16: offset,
+            charRangeStartUTF16: nil, charRangeEndUTF16: nil,
+            textQuote: nil, textContextBefore: nil, textContextAfter: nil
+        )
+    }
+
+    /// A TOC entry anchored at a UTF-16 char offset (or nil — EPUB-shaped).
+    private func tocEntry(_ title: String, charOffset: Int?) -> TOCEntry {
+        TOCEntry(title: title, level: 0, locator: locator(at: charOffset))
+    }
+
+    /// A three-chapter TXT TOC: chapters start at 100, 1000, 3000.
+    private var threeChapterTOC: [TOCEntry] {
+        [
+            tocEntry("Chapter 1", charOffset: 100),
+            tocEntry("Chapter 2", charOffset: 1000),
+            tocEntry("Chapter 3", charOffset: 3000),
+        ]
+    }
+
+    // MARK: - Locator inside chapter 1
+
+    @Test func offsetInChapterOneResolvesToFirstSpan() {
+        let bounds = SummaryScopeResolver.chapterBounds(
+            for: locator(at: 400),
+            tocEntries: threeChapterTOC,
+            totalTextLengthUTF16: 5000
+        )
+        #expect(bounds == ChapterBounds(startUTF16: 100, endUTF16: 1000))
+    }
+
+    // MARK: - Locator mid-book (chapter 2)
+
+    @Test func offsetMidBookResolvesToMiddleSpan() {
+        let bounds = SummaryScopeResolver.chapterBounds(
+            for: locator(at: 2000),
+            tocEntries: threeChapterTOC,
+            totalTextLengthUTF16: 5000
+        )
+        #expect(bounds == ChapterBounds(startUTF16: 1000, endUTF16: 3000))
+    }
+
+    // MARK: - Locator in the final chapter (end == total)
+
+    @Test func offsetInFinalChapterEndsAtTotalLength() {
+        let bounds = SummaryScopeResolver.chapterBounds(
+            for: locator(at: 4200),
+            tocEntries: threeChapterTOC,
+            totalTextLengthUTF16: 5000
+        )
+        #expect(bounds == ChapterBounds(startUTF16: 3000, endUTF16: 5000))
+    }
+
+    // MARK: - Pre-first-entry offset → preamble span [0, firstStart)
+
+    @Test func offsetBeforeFirstEntryResolvesToPreambleSpan() {
+        // Mirrors TOCChapterProgress: front matter before chapter 1
+        // is virtual chapter 0, spanning [0, firstStart).
+        let bounds = SummaryScopeResolver.chapterBounds(
+            for: locator(at: 40),
+            tocEntries: threeChapterTOC,
+            totalTextLengthUTF16: 5000
+        )
+        #expect(bounds == ChapterBounds(startUTF16: 0, endUTF16: 100))
+    }
+
+    @Test func offsetZeroResolvesToPreambleSpan() {
+        let bounds = SummaryScopeResolver.chapterBounds(
+            for: locator(at: 0),
+            tocEntries: threeChapterTOC,
+            totalTextLengthUTF16: 5000
+        )
+        #expect(bounds == ChapterBounds(startUTF16: 0, endUTF16: 100))
+    }
+
+    // MARK: - Offset exactly on a chapter boundary
+
+    @Test func offsetExactlyOnBoundaryBelongsToThatChapter() {
+        // Offset == chapter-2 start (1000) → resolves to chapter 2.
+        let bounds = SummaryScopeResolver.chapterBounds(
+            for: locator(at: 1000),
+            tocEntries: threeChapterTOC,
+            totalTextLengthUTF16: 5000
+        )
+        #expect(bounds == ChapterBounds(startUTF16: 1000, endUTF16: 3000))
+    }
+
+    @Test func offsetExactlyOnFirstEntryStartIsChapterOne() {
+        // Offset == first entry start (100) → chapter 1, not preamble.
+        let bounds = SummaryScopeResolver.chapterBounds(
+            for: locator(at: 100),
+            tocEntries: threeChapterTOC,
+            totalTextLengthUTF16: 5000
+        )
+        #expect(bounds == ChapterBounds(startUTF16: 100, endUTF16: 1000))
+    }
+
+    // MARK: - Single-chapter book
+
+    @Test func singleChapterBookSpansEntryStartToTotal() {
+        let toc = [tocEntry("Only Chapter", charOffset: 50)]
+        let bounds = SummaryScopeResolver.chapterBounds(
+            for: locator(at: 900),
+            tocEntries: toc,
+            totalTextLengthUTF16: 2000
+        )
+        #expect(bounds == ChapterBounds(startUTF16: 50, endUTF16: 2000))
+    }
+
+    @Test func singleChapterPreambleSpansZeroToEntryStart() {
+        let toc = [tocEntry("Only Chapter", charOffset: 50)]
+        let bounds = SummaryScopeResolver.chapterBounds(
+            for: locator(at: 10),
+            tocEntries: toc,
+            totalTextLengthUTF16: 2000
+        )
+        #expect(bounds == ChapterBounds(startUTF16: 0, endUTF16: 50))
+    }
+
+    // MARK: - Empty TOC → nil
+
+    @Test func emptyTOCReturnsNil() {
+        let bounds = SummaryScopeResolver.chapterBounds(
+            for: locator(at: 400),
+            tocEntries: [],
+            totalTextLengthUTF16: 5000
+        )
+        #expect(bounds == nil)
+    }
+
+    // MARK: - TOC entries with nil charOffsetUTF16 (EPUB-shaped) → nil
+
+    @Test func tocWithNoCharOffsetsReturnsNil() {
+        let toc = [
+            tocEntry("Chapter 1", charOffset: nil),
+            tocEntry("Chapter 2", charOffset: nil),
+        ]
+        let bounds = SummaryScopeResolver.chapterBounds(
+            for: locator(at: 400),
+            tocEntries: toc,
+            totalTextLengthUTF16: 5000
+        )
+        #expect(bounds == nil)
+    }
+
+    @Test func tocWithSomeCharOffsetsUsesOnlyAnchoredEntries() {
+        // Mixed TOC: only the anchored entries (200, 1500) form spans.
+        let toc = [
+            tocEntry("Anchored A", charOffset: 200),
+            tocEntry("Unanchored", charOffset: nil),
+            tocEntry("Anchored B", charOffset: 1500),
+        ]
+        let bounds = SummaryScopeResolver.chapterBounds(
+            for: locator(at: 800),
+            tocEntries: toc,
+            totalTextLengthUTF16: 4000
+        )
+        #expect(bounds == ChapterBounds(startUTF16: 200, endUTF16: 1500))
+    }
+
+    // MARK: - Locator with nil charOffsetUTF16 → treated as offset 0
+
+    @Test func locatorWithNoOffsetResolvesToPreamble() {
+        // A locator lacking charOffsetUTF16 has no position — treat as
+        // offset 0, which lands in the preamble span.
+        let bounds = SummaryScopeResolver.chapterBounds(
+            for: locator(at: nil),
+            tocEntries: threeChapterTOC,
+            totalTextLengthUTF16: 5000
+        )
+        #expect(bounds == ChapterBounds(startUTF16: 0, endUTF16: 100))
+    }
+
+    // MARK: - Short / zero total length is NOT a nil case
+
+    @Test func zeroTotalLengthStillResolvesFromAnchoredTOC() {
+        // Plan §2.4: nil is reserved for "no usable chapter offsets".
+        // A zero total length with anchored TOC offsets must still
+        // resolve — the final chapter collapses to an empty span
+        // (ChapterBounds clamps end up to start).
+        let bounds = SummaryScopeResolver.chapterBounds(
+            for: locator(at: 4200),
+            tocEntries: threeChapterTOC,
+            totalTextLengthUTF16: 0
+        )
+        // Locator 4200 is in the final chapter (start 3000); a zero
+        // total collapses [3000, 0] to the zero-length span [3000, 3000].
+        #expect(bounds == ChapterBounds(startUTF16: 3000, endUTF16: 3000))
+    }
+
+    @Test func shortTotalLengthResolvesNonFinalChapterNormally() {
+        // A short total length does not affect non-final chapters —
+        // their end comes from the next chapter's start, not the total.
+        let bounds = SummaryScopeResolver.chapterBounds(
+            for: locator(at: 400),
+            tocEntries: threeChapterTOC,
+            totalTextLengthUTF16: 10
+        )
+        #expect(bounds == ChapterBounds(startUTF16: 100, endUTF16: 1000))
+    }
+
+    // MARK: - Surrogate-pair (supplementary-plane) UTF-16 offsets
+
+    @Test func surrogatePairOffsetsLandInExpectedChapter() {
+        // The resolver works in UTF-16 units. Derive real offsets from a
+        // string containing supplementary-plane characters (emoji are
+        // 2 UTF-16 units each) and prove the locator lands in the right
+        // chapter span — a genuine UTF-16 test, not hard-coded numbers.
+        let emoji = "😀"                        // 1 Character, 2 UTF-16 units
+        let chapterOnePrefix = String(repeating: emoji, count: 50)   // 100 UTF-16
+        let chapterTwoBody = String(repeating: emoji, count: 80)     // 160 UTF-16
+        let fullText = chapterOnePrefix + chapterTwoBody             // 260 UTF-16
+
+        let chTwoStart = chapterOnePrefix.utf16.count                // 100
+        let total = fullText.utf16.count                            // 260
+        // A reading position 30 emoji into chapter two → 100 + 60 = 160.
+        let readingOffset = chTwoStart + String(repeating: emoji, count: 30).utf16.count
+
+        let toc = [
+            tocEntry("Chapter One", charOffset: 0),
+            tocEntry("Chapter Two", charOffset: chTwoStart),
+        ]
+        let bounds = SummaryScopeResolver.chapterBounds(
+            for: locator(at: readingOffset),
+            tocEntries: toc,
+            totalTextLengthUTF16: total
+        )
+        #expect(bounds == ChapterBounds(startUTF16: chTwoStart, endUTF16: total))
+        // Sanity: the offsets are even (each emoji is a 2-unit surrogate pair).
+        #expect(chTwoStart % 2 == 0)
+        #expect(readingOffset % 2 == 0)
+    }
+
+    // MARK: - Unsorted TOC entries
+
+    @Test func unsortedTOCEntriesAreSortedBeforeResolving() {
+        // Entries supplied out of order — resolver sorts the offsets.
+        let toc = [
+            tocEntry("Chapter 3", charOffset: 3000),
+            tocEntry("Chapter 1", charOffset: 100),
+            tocEntry("Chapter 2", charOffset: 1000),
+        ]
+        let bounds = SummaryScopeResolver.chapterBounds(
+            for: locator(at: 2000),
+            tocEntries: toc,
+            totalTextLengthUTF16: 5000
+        )
+        #expect(bounds == ChapterBounds(startUTF16: 1000, endUTF16: 3000))
+    }
+}


### PR DESCRIPTION
## Summary

- WI-2 of feature #69 (AI Summarize scope selector).
- Adds `SummaryScopeResolver` — a pure resolver that converts `(TOC entries, locator, total UTF-16 length)` into a `ChapterBounds?`, behind the **Chapter** scope.
- No behavior change yet — consumed by WI-3 (`AIContextExtractor`) and WI-5.

Part of feature #69.

## What Changed

- `vreader/Services/AI/SummaryScopeResolver.swift` — `enum SummaryScopeResolver` with one static `chapterBounds(for:tocEntries:totalTextLengthUTF16:)`. Mirrors `TOCChapterProgress`'s chapter-detection algorithm: a pre-first-entry offset maps to the preamble span `[0, firstStart)` (front matter = virtual chapter 0); the final chapter ends at the total text length. Defensively sorts the TOC offsets. Returns `nil` only when no usable chapter offsets exist (empty TOC, or every entry's locator lacks `charOffsetUTF16` — EPUB-shaped TOCs); a short/zero total length is **not** a `nil` case.
- 17 Swift Testing cases.

## WI Status

- WI-1: foundational — merged (PR #903).
- WI-2: foundational — this PR.
- Remaining: WI-3 (`AIContextExtractor` scoped extraction), WI-4 (`AIAssistantViewModel` wiring), WI-5 (chip strip UI + threading — final).

## Codex Audit (Gate 4)

2 rounds, thread `019e3e3e`. Round 1 found 2 Medium + 1 Low — the resolver returned `nil` on a zero/short total length (plan §2.4 reserves `nil` for "no usable chapter offsets" only), the tests locked in that drift, and the CJK test used hard-coded numbers. All fixed: nil gate corrected, two contract tests added, the surrogate-pair test rewritten to derive offsets from real emoji strings. Round 2 verified clean. Verdict: **ship-as-is**.

Audit log: `.claude/codex-audits/feat-feature-69-wi-2-summary-scope-resolver-audit.md`

## Validation

- [x] `xcodebuild test` passes — 17 tests in `SummaryScopeResolverTests` (TDD: RED → GREEN)
- [x] Codex audit loop completed (2 rounds, verdict: ship-as-is)
- [x] Docs sync — n/a (pure resolver utility, no service / notification / `@Model` / pattern)
- [x] Version bumped: 3.33.2 → 3.33.3

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: foundational — unit tests + Gate 4 audit sufficient, no device verification required (pure resolver, no user-observable behavior).
- 17 unit tests pass; smoke `xcodebuild build` succeeds.

## Type of Change

- [x] Feature WI (Part of feature #69 for this intermediate WI)