### PR TITLE
feat(#69 WI-3): scope-aware AIContextExtractor + AIContextExtracting seam

### DIFF
--- a/.claude/codex-audits/feat-feature-69-wi-3-scoped-extractor-audit.md
+++ b/.claude/codex-audits/feat-feature-69-wi-3-scoped-extractor-audit.md
@@ -1,0 +1,49 @@
+---
+branch: feat/feature-69-wi-3-scoped-extractor
+threadId: 019e3e48-b1a7-7d21-a654-3c9dedd416ad
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+# Gate-4 Implementation Audit — Feature #69 WI-3
+
+WI-3: `AIContextExtracting` protocol + `AIContextBudget` constant +
+`AIContextExtractor` scope-aware extraction (`.section` / `.chapter` /
+`.bookSoFar`) + surrogate-safe UTF-16 slicing.
+
+## Files audited
+
+- `vreader/Services/AI/AIContextExtractor.swift` (modified)
+- `vreader/Services/AI/AIContextExtracting.swift` (new — split out)
+- `vreader/Services/AI/UTF16TextSlicer.swift` (new — split out)
+- `vreaderTests/Services/AI/AIContextExtractorScopedTests.swift` (new)
+
+## Round 1 — findings
+
+| file:line | severity | issue | resolution |
+|---|---|---|---|
+| `AIContextExtractor.swift:280` | Medium | The scoped TXT paths read only `locator.charOffsetUTF16`; a selection-anchored locator with `charRangeStartUTF16` but no `charOffsetUTF16` would make `.chapter` anchor to `chapStart` and `.bookSoFar` treat the whole text as "so far" — diverging from the legacy `.section` behavior and plan §2.3. | **Fixed** — added `resolvedOffsetUTF16(for:in:fallback:)`: resolves `charOffsetUTF16 ?? charRangeStartUTF16 ?? fallback`, clamps to `[0, utf16.count]`. Both scoped helpers now use it (`.chapter` window centers on it with `fallback: chapStart`; `.bookSoFar` uses `fallback: totalUTF16`). |
+| `AIContextExtractorScopedTests.swift:78` | Low | Over-budget chapter tests used uniform text + length-only assertions; `chapterScopeDoesNotSplitSurrogatePairs` used pre-aligned even bounds — a wrong centered/clamped window or broken snap logic could pass. | **Fixed** — over-budget chapter tests now use distinct marker segments (H/L/M/R/T) and assert the exact slice. Added `chapterScopeOverBudgetWindowClampsToRightEdge`, `chapterScopeOddBoundsOnSurrogateTextSnapToScalars` (odd bounds on emoji text), and `charRangeStartUTF16`-only regressions for both scoped paths. |
+| `AIContextExtractor.swift:1` | Low | The file grew to 366 lines, over the ~300-line guideline. | **Fixed** — split into three files: `AIContextExtractor.swift` (285 lines), `AIContextExtracting.swift` (budget constant + protocol + extension overload), `UTF16TextSlicer.swift` (the surrogate-safe slice / `scalarAlignedIndex`). |
+
+No Critical/High findings. The protocol shape matched plan §2.5, the
+legacy 3-arg `.section` shim is byte-identical, and the
+snap-up-start / snap-down-end slicing is sound (no path yields a lone
+surrogate or inverted range after clamping).
+
+## Round 2 — verification
+
+Codex re-reviewed all four files: "No new Critical/High/Medium
+findings … The offset handling is now coherent … That fixes the prior
+divergence for selection-anchored locators, and the new regression
+tests cover both `.bookSoFar` and over-budget `.chapter`. The slicer
+split is clean … the strengthened tests now exercise exact
+centered/clamped windows plus odd surrogate boundaries, which closes
+the main review gap."
+
+## Verdict
+
+**ship-as-is.** Zero open Critical/High/Medium findings after 2
+rounds. 40 extractor tests pass + 42 AI viewmodel/integration/chat/
+translation tests pass (no regression) under `xcodebuild test`.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 481
-        MARKETING_VERSION: 3.33.3
+        CURRENT_PROJECT_VERSION: 482
+        MARKETING_VERSION: 3.33.4
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5194,13 +5194,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 481;
+				CURRENT_PROJECT_VERSION = 482;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.33.3;
+				MARKETING_VERSION = 3.33.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5344,13 +5344,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 481;
+				CURRENT_PROJECT_VERSION = 482;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.33.3;
+				MARKETING_VERSION = 3.33.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -576,6 +576,7 @@
 		8B009CA87373EC45C1796A1B /* BookImporterNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319F6B718764EAF33C88ECC4 /* BookImporterNotificationTests.swift */; };
 		8B3D497F2C0DF268AE1FE653 /* legado_multiple_sources.json in Resources */ = {isa = PBXBuildFile; fileRef = 84E4ABD8F17B04EA35F23724 /* legado_multiple_sources.json */; };
 		8BBE50E626A6524E8C6DB59D /* SearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576F111E93E863C656BDEC70 /* SearchViewModelTests.swift */; };
+		8C0CD88AF5CB9D0509452BA0 /* AIContextExtracting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542F38CF85937EB04F013ABA /* AIContextExtracting.swift */; };
 		8C4E8905FFFF8DB6C6CC5B13 /* SelectionPopoverPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15BBF7DF0943B2AF47BA6E53 /* SelectionPopoverPresenterTests.swift */; };
 		8C5EFF0A113773C9FA1153E1 /* VoiceOverAuditTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED80D7FC768F4B87E7DB036A /* VoiceOverAuditTests.swift */; };
 		8CAAA8CE24E5701C76A9A55F /* EncodingFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C483C40C61CC5C3F7B66030 /* EncodingFixtureTests.swift */; };
@@ -623,6 +624,7 @@
 		97B638016DFAF03E25A21AB4 /* ReaderSettingsSheetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445A7C6C3D4466A57B29BDA8 /* ReaderSettingsSheetTests.swift */; };
 		97D9F118063EF7E6328A4E14 /* FileAvailabilityStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C13EA240083857EA527F89 /* FileAvailabilityStateMachine.swift */; };
 		97EF677CC2FCE1B5D4FD4047 /* SourceSharingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 199ADE9681576DB0AF6A6A94 /* SourceSharingService.swift */; };
+		98080594ED513CD2F999EF8C /* AIContextExtractorScopedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1368D4DA7FCD1EC48778531 /* AIContextExtractorScopedTests.swift */; };
 		982FDBDA893DC7DA931711C7 /* FeatureFlagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43EE33FE1EDFE9B393885110 /* FeatureFlagsTests.swift */; };
 		986AC8640BA33F3235A89D81 /* TOCProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83492717235FB856C8A06ED /* TOCProviderTests.swift */; };
 		986EFB28F7203E56F853A0FD /* BasePageNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16AF7EAA6EC1F1D0D126E75 /* BasePageNavigator.swift */; };
@@ -705,6 +707,7 @@
 		AD1910F64D226400933FDBA2 /* PDFHighlightRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8719A34DB441AF9DC6379DC9 /* PDFHighlightRenderer.swift */; };
 		AD27484127EA24D230616F48 /* TestConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B2824739E67F567813198E /* TestConstants.swift */; };
 		AD73A09B36A45CB1F9E1B0D4 /* TXTChapterScrollOffsetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9AD84A4BE2CF0F8D59D9CC /* TXTChapterScrollOffsetTests.swift */; };
+		ADAA21CB04F57472C44679D5 /* UTF16TextSlicer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9ABEE3CBF62A1CC57F2952F /* UTF16TextSlicer.swift */; };
 		AE171BC364B973E0F52D1B96 /* BookFileMaterializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1889243163114A51950527F6 /* BookFileMaterializer.swift */; };
 		AE34D7222B4EAB4191316FD2 /* FoliateReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C919847EACB9AB94A03DF6E8 /* FoliateReaderViewModel.swift */; };
 		AECED765F5022DC96443D566 /* foliate-host.js in Resources */ = {isa = PBXBuildFile; fileRef = 8770E9DB2008B2B8B4B0A475 /* foliate-host.js */; };
@@ -1376,6 +1379,7 @@
 		5401E10DDA195966ABD13F70 /* AutoPageTurner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoPageTurner.swift; sourceTree = "<group>"; };
 		54053616902DCBE161CD524D /* ReaderMoreMenuEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderMoreMenuEffect.swift; sourceTree = "<group>"; };
 		541D98DEB1DF611A369D7E54 /* TXTReaderContainerViewChineseConversionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReaderContainerViewChineseConversionTests.swift; sourceTree = "<group>"; };
+		542F38CF85937EB04F013ABA /* AIContextExtracting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIContextExtracting.swift; sourceTree = "<group>"; };
 		544A2F3FF8BBB1C08DDCE02D /* PageNavigatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageNavigatorTests.swift; sourceTree = "<group>"; };
 		5487566F93AB8376D1BD1F1B /* EPUBFileLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBFileLoaderTests.swift; sourceTree = "<group>"; };
 		54AC37DCD75A3993463AC297 /* WebDAVServerProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVServerProfileTests.swift; sourceTree = "<group>"; };
@@ -1711,6 +1715,7 @@
 		A922B4886FE1CE378009FB1B /* EPUBReaderContainerView+Highlights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EPUBReaderContainerView+Highlights.swift"; sourceTree = "<group>"; };
 		A96A115C3FA0B797030C1D1F /* TXTTextViewBridgeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTTextViewBridgeCoordinator.swift; sourceTree = "<group>"; };
 		A983D06F916C51795A2223E7 /* ReaderBottomOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderBottomOverlay.swift; sourceTree = "<group>"; };
+		A9ABEE3CBF62A1CC57F2952F /* UTF16TextSlicer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTF16TextSlicer.swift; sourceTree = "<group>"; };
 		A9EE79C451D86828387A1BEF /* MDIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDIntegrationTests.swift; sourceTree = "<group>"; };
 		AB0C783DCFD9CFDD8F488F80 /* AISettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISettingsViewModel.swift; sourceTree = "<group>"; };
 		AB12A029D167735B92A38BA7 /* AccessibilityAuditHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityAuditHelper.swift; sourceTree = "<group>"; };
@@ -1869,6 +1874,7 @@
 		D02B540992E1F3C96A00723F /* AIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProvider.swift; sourceTree = "<group>"; };
 		D036492CF6A9DB2DAFE010BC /* VReaderAnnotationParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderAnnotationParser.swift; sourceTree = "<group>"; };
 		D054A0A5EF2A48B83A3DFE53 /* SyncPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncPipeline.swift; sourceTree = "<group>"; };
+		D1368D4DA7FCD1EC48778531 /* AIContextExtractorScopedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIContextExtractorScopedTests.swift; sourceTree = "<group>"; };
 		D14E222357346107CB34B750 /* SmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokeTests.swift; sourceTree = "<group>"; };
 		D17013114ADB4797AB48D794 /* FoliateViewBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateViewBridge.swift; sourceTree = "<group>"; };
 		D1B00C0FE14AB02EDE7E9EDD /* SyncOutboundQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncOutboundQueueTests.swift; sourceTree = "<group>"; };
@@ -3555,6 +3561,7 @@
 			children = (
 				4A57E82A7221B36240E501FD /* AIConfigurationTests.swift */,
 				FFD1AE78FBFF38B3616352FF /* AIConsentManagerTests.swift */,
+				D1368D4DA7FCD1EC48778531 /* AIContextExtractorScopedTests.swift */,
 				20237121BB4ACF22C0818BA4 /* AIContextExtractorTests.swift */,
 				15C1B40888B5C8213559B111 /* AIRequestCacheKeyTests.swift */,
 				C5CB5C659CC573EF448F0992 /* AIResponseCacheTests.swift */,
@@ -3804,6 +3811,7 @@
 				C52103AEAF5528A9DD58625E /* AIConfiguration.swift */,
 				F8038AAB18412F30C09CBDD9 /* AIConfigurationStore.swift */,
 				E1C9AB72079AF7B2ACCAB516 /* AIConsentManager.swift */,
+				542F38CF85937EB04F013ABA /* AIContextExtracting.swift */,
 				42CFB0E94DE1D37E0FD2741B /* AIContextExtractor.swift */,
 				42C4804D4D5F435DF10014C5 /* AIError.swift */,
 				D02B540992E1F3C96A00723F /* AIProvider.swift */,
@@ -3821,6 +3829,7 @@
 				C6E58A8977DC02FDA7235A9E /* ProviderProfileStore.swift */,
 				EA8C0234B383C8D2877E21CC /* SummaryScope.swift */,
 				BA838B4649351A656B259147 /* SummaryScopeResolver.swift */,
+				A9ABEE3CBF62A1CC57F2952F /* UTF16TextSlicer.swift */,
 			);
 			path = AI;
 			sourceTree = "<group>";
@@ -4132,6 +4141,7 @@
 				05BE70789318FA085B9A735E /* AIChatViewModelTests.swift in Sources */,
 				C81C50DAC16681379E93FC9D /* AIConfigurationTests.swift in Sources */,
 				CD104D016ED7015A7F8B42C7 /* AIConsentManagerTests.swift in Sources */,
+				98080594ED513CD2F999EF8C /* AIContextExtractorScopedTests.swift in Sources */,
 				891E1E70B176150B071E464F /* AIContextExtractorTests.swift in Sources */,
 				37B8708ABD85D7635B98995F /* AIEditorContextTests.swift in Sources */,
 				BB03511CFAB402BC18C393B7 /* AIProviderPickerViewModelTests.swift in Sources */,
@@ -4557,6 +4567,7 @@
 				2AD43547691478569AA638EB /* AIConfigurationStore.swift in Sources */,
 				26285A9C2309CC149C5372DC /* AIConsentManager.swift in Sources */,
 				9E163090F48B7DA58DBF7EE1 /* AIConsentView.swift in Sources */,
+				8C0CD88AF5CB9D0509452BA0 /* AIContextExtracting.swift in Sources */,
 				B272D2C56AF8559115BBD8E3 /* AIContextExtractor.swift in Sources */,
 				D0E3C146DC0F8D0978B419E7 /* AIError.swift in Sources */,
 				5BF55452ABA60AB492B54C6D /* AIProvider.swift in Sources */,
@@ -5005,6 +5016,7 @@
 				46AE79F9CB6E8AAE304DE34A /* TranslationResultCard.swift in Sources */,
 				00074EAF27B3E74401E41076 /* TypefacePillToggle.swift in Sources */,
 				CE3D74414B1983EB35589EFD /* TypographySettings.swift in Sources */,
+				ADAA21CB04F57472C44679D5 /* UTF16TextSlicer.swift in Sources */,
 				B401D6506E193DB12661B33E /* UnifiedEPUBLoadResult.swift in Sources */,
 				39D1A8383CEBC235DDAA552F /* UnifiedPagedView.swift in Sources */,
 				DD1020F3F0A2D5BA7FFCB279 /* UnifiedScrollView.swift in Sources */,

--- a/vreader/Services/AI/AIContextExtracting.swift
+++ b/vreader/Services/AI/AIContextExtracting.swift
@@ -1,0 +1,69 @@
+// Purpose: The boundary protocol + UTF-16 budget constant for AI
+// context extraction. Extracted from AIContextExtractor (feature #69)
+// so AIAssistantViewModel can depend on the seam without pulling in the
+// concrete struct, and so the extractor file stays small.
+//
+// Key decisions:
+// - AIContextBudget.defaultMaxUTF16 is a named constant, NOT a Swift
+//   default argument on the protocol requirement: a protocol-requirement
+//   default argument is not visible through `any AIContextExtracting`.
+// - The protocol requirement takes maxUTF16 with NO default; a
+//   protocol-EXTENSION convenience overload (which IS dispatched through
+//   the existential) supplies the default budget.
+//
+// @coordinates-with: AIContextExtractor.swift, AIAssistantViewModel.swift,
+//   SummaryScope.swift, ChapterBounds.swift
+
+import Foundation
+
+/// The default UTF-16 context budget for scoped extraction.
+///
+/// A named constant rather than a Swift default argument on the
+/// `AIContextExtracting` protocol requirement: a protocol-requirement
+/// default argument is NOT visible through an existential
+/// (`any AIContextExtracting`), so callers that go through the
+/// existential supply this constant — either via the protocol-extension
+/// convenience overload or by passing it explicitly.
+enum AIContextBudget {
+    /// ~12 000 UTF-16 units. Conservative ceiling for a single AI request;
+    /// the provider still returns a clean error if the model rejects it.
+    static let defaultMaxUTF16 = 12_000
+}
+
+/// A seam for the AI context extractor so `AIAssistantViewModel` can
+/// depend on the boundary protocol rather than the concrete struct
+/// (the codebase's standard boundary-protocol move — `LibraryPersisting`,
+/// `BookImporting`). `Sendable`, so `any AIContextExtracting` is
+/// `Sendable` and a `@MainActor` view model can hold it cleanly.
+protocol AIContextExtracting: Sendable {
+    /// The single required entry point. `maxUTF16` is REQUIRED here
+    /// (no default argument) — a protocol-requirement default argument
+    /// does not survive through `any AIContextExtracting`.
+    func extractContext(
+        locator: Locator,
+        fullText: String,
+        format: BookFormat,
+        scope: SummaryScope,
+        chapterBounds: ChapterBounds?,
+        maxUTF16: Int
+    ) -> String
+}
+
+extension AIContextExtracting {
+    /// Convenience overload supplying `AIContextBudget.defaultMaxUTF16`.
+    /// A protocol-EXTENSION method IS dispatched through the existential,
+    /// so callers that don't care about the budget call this 5-arg form.
+    func extractContext(
+        locator: Locator,
+        fullText: String,
+        format: BookFormat,
+        scope: SummaryScope,
+        chapterBounds: ChapterBounds?
+    ) -> String {
+        extractContext(
+            locator: locator, fullText: fullText, format: format,
+            scope: scope, chapterBounds: chapterBounds,
+            maxUTF16: AIContextBudget.defaultMaxUTF16
+        )
+    }
+}

--- a/vreader/Services/AI/AIContextExtractor.swift
+++ b/vreader/Services/AI/AIContextExtractor.swift
@@ -1,5 +1,7 @@
 // Purpose: Extracts text around a locator position for AI context.
-// Handles different book formats (EPUB, PDF, TXT/MD) with format-specific logic.
+// Handles different book formats (EPUB, PDF, TXT/MD) with format-specific
+// logic, and — for the AI Summarize tab — scope-aware extraction
+// (Section / Chapter / Book-so-far) bounded by an explicit UTF-16 budget.
 //
 // Key decisions:
 // - Struct-based for Sendable compliance.
@@ -9,13 +11,24 @@
 // - For EPUB: uses href to identify the chapter, extracts around progression.
 // - Clamps out-of-bounds offsets instead of failing.
 // - Returns empty string for empty input (not an error).
+// - Scope-aware extraction (feature #69): the legacy
+//   extractContext(locator:textContent:format:) is a .section-delegating
+//   shim; the scoped entry point adds .chapter / .bookSoFar paths that
+//   slice the FULL flattened text by UTF-16 offsets via UTF16TextSlicer
+//   (surrogate-pair-safe). The budget is an explicit UTF-16-unit count
+//   (maxUTF16) — not an ambiguous "character" count.
+// - The scoped TXT helpers resolve the locator's UTF-16 offset with the
+//   same `charOffsetUTF16 ?? charRangeStartUTF16` fallback the legacy
+//   .section path uses, so all three scopes agree on "where the reader is".
 //
-// @coordinates-with: AIService.swift, Locator.swift
+// @coordinates-with: AIService.swift, Locator.swift, SummaryScope.swift,
+//   ChapterBounds.swift, SummaryScopeResolver.swift, UTF16TextSlicer.swift,
+//   AIContextExtracting.swift, AIAssistantViewModel.swift
 
 import Foundation
 
 /// Extracts text context around a reading position for AI requests.
-struct AIContextExtractor: Sendable {
+struct AIContextExtractor: Sendable, AIContextExtracting {
 
     /// Target number of characters to extract (approximately 500 words).
     let targetCharacterCount: Int
@@ -24,31 +37,124 @@ struct AIContextExtractor: Sendable {
         self.targetCharacterCount = targetCharacterCount
     }
 
-    /// Extracts context text from the given text units around the locator position.
+    // MARK: - Legacy entry point (.section shim)
+
+    /// Extracts context text from the given text units around the locator.
+    ///
+    /// Retained for callers that only need the current ~2500-char window
+    /// (the Chat tab's section context, etc.). Delegates to the scoped
+    /// entry point with `scope: .section`, so behavior is byte-identical
+    /// to the pre-feature-#69 implementation.
     ///
     /// - Parameters:
     ///   - locator: The reading position to center context around.
-    ///   - textContent: The full text content of the relevant section/chapter/page.
+    ///   - textContent: The text content of the relevant section/chapter/page.
     ///   - format: The book format, determining extraction strategy.
-    /// - Returns: Extracted text context, or empty string if no text available.
+    /// - Returns: Extracted text context, or empty string if no text.
     func extractContext(
         locator: Locator,
         textContent: String,
         format: BookFormat
     ) -> String {
-        guard !textContent.isEmpty else { return "" }
+        extractContext(
+            locator: locator,
+            fullText: textContent,
+            format: format,
+            scope: .section,
+            chapterBounds: nil,
+            maxUTF16: AIContextBudget.defaultMaxUTF16
+        )
+    }
 
-        switch format {
-        case .txt, .md:
-            return extractByCharOffset(locator: locator, text: textContent)
-        case .pdf:
-            return extractByPage(text: textContent)
-        case .epub, .azw3:
-            return extractByProgression(locator: locator, text: textContent)
+    // MARK: - Scoped entry point
+
+    /// Extracts context for an AI summary at the requested scope.
+    ///
+    /// - `.section` — the existing ~2500-char window around the locator.
+    ///   `maxUTF16` is unused for this scope (the window is bounded by
+    ///   `targetCharacterCount`); `fullText` may be the full text or a
+    ///   section snippet — `.section` re-extracts the same window either
+    ///   way, so the legacy snippet callers are unaffected.
+    /// - `.chapter` — the UTF-16 sub-sequence `[chapterBounds.start ..<
+    ///   chapterBounds.end]` of `fullText`. If that slice exceeds
+    ///   `maxUTF16`, a `maxUTF16`-wide window centered on the locator's
+    ///   offset (clamped within the chapter) is returned. A `nil`
+    ///   `chapterBounds` degrades to `.section`.
+    /// - `.bookSoFar` — the prefix `[0 ..< offset]`; if longer than
+    ///   `maxUTF16`, the LAST `maxUTF16` units before the offset
+    ///   (recency-biased).
+    ///
+    /// All slicing snaps to Unicode scalar boundaries (`UTF16TextSlicer`)
+    /// so a surrogate pair is never bisected.
+    ///
+    /// - Parameters:
+    ///   - locator: The reading position.
+    ///   - fullText: The FULL flattened book text (not a snippet) for
+    ///     `.chapter` / `.bookSoFar`.
+    ///   - format: The book format.
+    ///   - scope: How much of the book the summary should cover.
+    ///   - chapterBounds: The chapter span for `.chapter`; `nil` degrades
+    ///     `.chapter` to `.section`.
+    ///   - maxUTF16: The UTF-16-unit budget for `.chapter` / `.bookSoFar`.
+    /// - Returns: Extracted text, or `""` if no text is available.
+    func extractContext(
+        locator: Locator,
+        fullText: String,
+        format: BookFormat,
+        scope: SummaryScope,
+        chapterBounds: ChapterBounds?,
+        maxUTF16: Int = AIContextBudget.defaultMaxUTF16
+    ) -> String {
+        guard !fullText.isEmpty else { return "" }
+
+        switch scope {
+        case .section:
+            return extractSection(locator: locator, text: fullText, format: format)
+        case .chapter:
+            guard let bounds = chapterBounds else {
+                return extractSection(locator: locator, text: fullText, format: format)
+            }
+            return extractChapter(
+                locator: locator, text: fullText,
+                bounds: bounds, maxUTF16: maxUTF16
+            )
+        case .bookSoFar:
+            return extractBookSoFar(
+                locator: locator, text: fullText, maxUTF16: maxUTF16
+            )
         }
     }
 
-    // MARK: - Private
+    // MARK: - Locator offset resolution
+
+    /// Resolves the locator's UTF-16 offset into `text` for the scoped
+    /// TXT paths, using the same `charOffsetUTF16 ?? charRangeStartUTF16`
+    /// fallback the legacy `.section` path (`extractByCharOffset`) uses,
+    /// then clamps into `[0, utf16.count]`. `fallback` is returned when
+    /// the locator carries neither field.
+    private func resolvedOffsetUTF16(
+        for locator: Locator, in text: String, fallback: Int
+    ) -> Int {
+        let total = text.utf16.count
+        let raw = locator.charOffsetUTF16 ?? locator.charRangeStartUTF16 ?? fallback
+        return max(0, min(raw, total))
+    }
+
+    // MARK: - Section (existing per-format behavior)
+
+    /// The pre-feature-#69 per-format window extraction.
+    private func extractSection(
+        locator: Locator, text: String, format: BookFormat
+    ) -> String {
+        switch format {
+        case .txt, .md:
+            return extractByCharOffset(locator: locator, text: text)
+        case .pdf:
+            return extractByPage(text: text)
+        case .epub, .azw3:
+            return extractByProgression(locator: locator, text: text)
+        }
+    }
 
     /// Extracts context around a UTF-16 character offset (TXT/MD).
     private func extractByCharOffset(locator: Locator, text: String) -> String {
@@ -111,5 +217,69 @@ struct AIContextExtractor: Sendable {
         let endIndex = text.index(text.startIndex, offsetBy: endChar)
 
         return String(text[startIndex..<endIndex])
+    }
+
+    // MARK: - Chapter (feature #69)
+
+    /// Extracts the chapter-bounded slice. If the chapter exceeds
+    /// `maxUTF16`, returns a `maxUTF16`-wide window centered on the
+    /// locator's offset, clamped within the chapter.
+    private func extractChapter(
+        locator: Locator, text: String,
+        bounds: ChapterBounds, maxUTF16: Int
+    ) -> String {
+        let totalUTF16 = text.utf16.count
+        // Clamp the chapter span into the text.
+        let chapStart = max(0, min(bounds.startUTF16, totalUTF16))
+        let chapEnd = max(chapStart, min(bounds.endUTF16, totalUTF16))
+        let chapterLength = chapEnd - chapStart
+        guard chapterLength > 0 else { return "" }
+
+        // Whole chapter fits the budget — return it verbatim.
+        if maxUTF16 <= 0 || chapterLength <= maxUTF16 {
+            return UTF16TextSlicer.slice(text, fromUTF16: chapStart, toUTF16: chapEnd)
+        }
+
+        // Over budget: a maxUTF16-wide window centered on the locator,
+        // clamped to stay inside the chapter. The locator offset uses the
+        // same fallback as the .section path; default it to the chapter
+        // start so a locator with no offset summarizes the chapter's head.
+        let center = max(chapStart, min(
+            resolvedOffsetUTF16(for: locator, in: text, fallback: chapStart),
+            chapEnd
+        ))
+        let half = maxUTF16 / 2
+        var windowStart = max(chapStart, center - half)
+        var windowEnd = min(chapEnd, windowStart + maxUTF16)
+        // If we hit the chapter's right edge first, pull the start back.
+        windowStart = max(chapStart, windowEnd - maxUTF16)
+        windowEnd = min(chapEnd, windowStart + maxUTF16)
+        return UTF16TextSlicer.slice(text, fromUTF16: windowStart, toUTF16: windowEnd)
+    }
+
+    // MARK: - Book so far (feature #69)
+
+    /// Extracts the prefix from the book start up to the locator's
+    /// offset. If that prefix exceeds `maxUTF16`, returns the LAST
+    /// `maxUTF16` units before the offset (recency-biased — the text
+    /// nearest the reading position is the most relevant).
+    private func extractBookSoFar(
+        locator: Locator, text: String, maxUTF16: Int
+    ) -> String {
+        let totalUTF16 = text.utf16.count
+        // A locator with no offset means "no position" — treat the whole
+        // text as read so far (fallback = totalUTF16), matching how the
+        // reader's fallback path extracts from the start of the book.
+        let offset = resolvedOffsetUTF16(for: locator, in: text, fallback: totalUTF16)
+        guard offset > 0 else { return "" }
+
+        // Whole prefix fits the budget.
+        if maxUTF16 <= 0 || offset <= maxUTF16 {
+            return UTF16TextSlicer.slice(text, fromUTF16: 0, toUTF16: offset)
+        }
+
+        // Over budget: the last maxUTF16 units before the offset.
+        let start = offset - maxUTF16
+        return UTF16TextSlicer.slice(text, fromUTF16: start, toUTF16: offset)
     }
 }

--- a/vreader/Services/AI/UTF16TextSlicer.swift
+++ b/vreader/Services/AI/UTF16TextSlicer.swift
@@ -1,0 +1,68 @@
+// Purpose: Surrogate-pair-safe UTF-16 slicing of a String.
+// Extracted from AIContextExtractor (feature #69) so the slicing
+// utility is independently testable and the extractor stays small.
+//
+// Key decisions:
+// - Slicing snaps to Unicode scalar boundaries so a surrogate pair is
+//   never bisected — a lone surrogate / replacement character would
+//   corrupt the text sent to an AI provider.
+// - The start boundary snaps UP and the end boundary snaps DOWN, so the
+//   sliced UTF-16 length never exceeds the requested span (this matters
+//   for budget-bounded extraction windows).
+//
+// @coordinates-with: AIContextExtractor.swift
+
+import Foundation
+
+/// Surrogate-pair-safe UTF-16 slicing helpers.
+enum UTF16TextSlicer {
+
+    /// The direction a UTF-16 offset snaps when it lands inside a
+    /// surrogate pair.
+    enum SnapDirection {
+        /// Snap toward the end of the string (offset never shrinks).
+        case up
+        /// Snap toward the start of the string (offset never grows).
+        case down
+    }
+
+    /// Returns `text` sliced by UTF-16 offsets. The start boundary snaps
+    /// UP and the end boundary snaps DOWN to the nearest Unicode scalar
+    /// boundary, so a surrogate pair is never bisected AND the resulting
+    /// UTF-16 length never exceeds `toUTF16 - fromUTF16`. Offsets are
+    /// clamped to `[0, utf16.count]` internally.
+    static func slice(_ text: String, fromUTF16: Int, toUTF16: Int) -> String {
+        guard toUTF16 > fromUTF16 else { return "" }
+        guard let startIdx = scalarAlignedIndex(in: text, utf16Offset: fromUTF16, snap: .up),
+              let endIdx = scalarAlignedIndex(in: text, utf16Offset: toUTF16, snap: .down) else {
+            return ""
+        }
+        // Snapping can collapse a degenerate single-pair slice — guard
+        // against an inverted range.
+        guard startIdx <= endIdx else { return "" }
+        return String(text[startIdx..<endIdx])
+    }
+
+    /// Converts a UTF-16 offset to a `String.Index` aligned to a Unicode
+    /// scalar boundary. If the offset lands inside a surrogate pair, it
+    /// snaps in `snap`'s direction until it reaches a valid boundary, so
+    /// a slice never contains a lone surrogate / replacement character.
+    static func scalarAlignedIndex(
+        in text: String, utf16Offset: Int, snap: SnapDirection
+    ) -> String.Index? {
+        let utf16View = text.utf16
+        let clamped = max(0, min(utf16Offset, utf16View.count))
+        var idx = utf16View.index(utf16View.startIndex, offsetBy: clamped)
+        switch snap {
+        case .up:
+            while idx < utf16View.endIndex, idx.samePosition(in: text) == nil {
+                idx = utf16View.index(idx, offsetBy: 1)
+            }
+        case .down:
+            while idx > utf16View.startIndex, idx.samePosition(in: text) == nil {
+                idx = utf16View.index(idx, offsetBy: -1)
+            }
+        }
+        return idx.samePosition(in: text)
+    }
+}

--- a/vreaderTests/Services/AI/AIContextExtractorScopedTests.swift
+++ b/vreaderTests/Services/AI/AIContextExtractorScopedTests.swift
@@ -1,0 +1,421 @@
+// Purpose: Tests for AIContextExtractor's scope-aware extraction
+// (feature #69 WI-3) — the .section / .chapter / .bookSoFar paths,
+// the explicit UTF-16 budget, and surrogate-pair-safe slicing.
+// The legacy extractContext(locator:textContent:format:) is a
+// .section-delegating shim; this suite proves it stays byte-identical.
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("AIContextExtractor scoped extraction")
+struct AIContextExtractorScopedTests {
+
+    // MARK: - Helpers
+
+    private static let fp = DocumentFingerprint(
+        contentSHA256: "aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233",
+        fileByteCount: 8192,
+        format: .txt
+    )
+
+    private func locator(at offset: Int?) -> Locator {
+        Locator(
+            bookFingerprint: Self.fp,
+            href: nil, progression: nil, totalProgression: nil, cfi: nil,
+            page: nil, charOffsetUTF16: offset,
+            charRangeStartUTF16: nil, charRangeEndUTF16: nil,
+            textQuote: nil, textContextBefore: nil, textContextAfter: nil
+        )
+    }
+
+    // MARK: - .section: new path == legacy path (byte-identical)
+
+    @Test func sectionScopeMatchesLegacyEntryPoint() {
+        let text = String(repeating: "abcdefghij", count: 500)  // 5000 chars
+        let extractor = AIContextExtractor()
+        let loc = locator(at: 2500)
+
+        let legacy = extractor.extractContext(
+            locator: loc, textContent: text, format: .txt
+        )
+        let scoped = extractor.extractContext(
+            locator: loc, fullText: text, format: .txt,
+            scope: .section, chapterBounds: nil, maxUTF16: 12_000
+        )
+        #expect(scoped == legacy)
+        #expect(!scoped.isEmpty)
+    }
+
+    @Test func legacyEntryPointStillWorksUnchanged() {
+        let text = "Hello World"
+        let extractor = AIContextExtractor(targetCharacterCount: 100)
+        let result = extractor.extractContext(
+            locator: locator(at: 0), textContent: text, format: .txt
+        )
+        #expect(result == "Hello World")
+    }
+
+    // MARK: - .chapter: slices to bounds
+
+    @Test func chapterScopeSlicesToBounds() {
+        // 3000 chars; chapter span [1000, 2000) → exactly that slice.
+        let text = String(repeating: "x", count: 1000)
+            + String(repeating: "y", count: 1000)
+            + String(repeating: "z", count: 1000)
+        let extractor = AIContextExtractor()
+        let bounds = ChapterBounds(startUTF16: 1000, endUTF16: 2000)
+
+        let result = extractor.extractContext(
+            locator: locator(at: 1500), fullText: text, format: .txt,
+            scope: .chapter, chapterBounds: bounds, maxUTF16: 12_000
+        )
+        #expect(result == String(repeating: "y", count: 1000))
+    }
+
+    // MARK: - .chapter over maxUTF16: centered window within the chapter
+
+    @Test func chapterScopeOverBudgetTakesCenteredWindow() {
+        // Chapter [1000, 2000); maxUTF16 200; locator at 1500. Window
+        // centered on the locator → [1400, 1600). Marker segments prove
+        // the EXACT slice, not just the length.
+        let text = String(repeating: "H", count: 1000)   // [0,1000)
+            + String(repeating: "L", count: 400)         // [1000,1400)
+            + String(repeating: "M", count: 200)         // [1400,1600) ← window
+            + String(repeating: "R", count: 400)         // [1600,2000)
+            + String(repeating: "T", count: 1000)        // [2000,3000)
+        let extractor = AIContextExtractor()
+        let bounds = ChapterBounds(startUTF16: 1000, endUTF16: 2000)
+
+        let result = extractor.extractContext(
+            locator: locator(at: 1500), fullText: text, format: .txt,
+            scope: .chapter, chapterBounds: bounds, maxUTF16: 200
+        )
+        #expect(result == String(repeating: "M", count: 200))
+    }
+
+    @Test func chapterScopeOverBudgetWindowStaysInsideChapter() {
+        // Locator near the chapter start; the centered window must clamp
+        // to the chapter's left edge — [800, 1000), NOT spill before 800.
+        let text = String(repeating: "B", count: 800)    // [0,800)
+            + String(repeating: "W", count: 200)         // [800,1000) ← window
+            + String(repeating: "R", count: 1000)        // [1000,2000)
+        let extractor = AIContextExtractor()
+        let bounds = ChapterBounds(startUTF16: 800, endUTF16: 1800)
+
+        let result = extractor.extractContext(
+            locator: locator(at: 820), fullText: text, format: .txt,
+            scope: .chapter, chapterBounds: bounds, maxUTF16: 200
+        )
+        // Window clamps to the chapter's left edge: exactly the "W" run.
+        #expect(result == String(repeating: "W", count: 200))
+    }
+
+    @Test func chapterScopeOverBudgetWindowClampsToRightEdge() {
+        // Locator near the chapter end; the window must clamp to the
+        // chapter's right edge — [1600, 1800), NOT spill past 1800.
+        let text = String(repeating: "B", count: 1600)   // [0,1600)
+            + String(repeating: "W", count: 200)         // [1600,1800) ← window
+            + String(repeating: "A", count: 200)         // [1800,2000)
+        let extractor = AIContextExtractor()
+        let bounds = ChapterBounds(startUTF16: 800, endUTF16: 1800)
+
+        let result = extractor.extractContext(
+            locator: locator(at: 1790), fullText: text, format: .txt,
+            scope: .chapter, chapterBounds: bounds, maxUTF16: 200
+        )
+        #expect(result == String(repeating: "W", count: 200))
+    }
+
+    // MARK: - .chapter with nil bounds degrades to .section
+
+    @Test func chapterScopeWithNilBoundsDegradesToSection() {
+        let text = String(repeating: "abcdefghij", count: 500)
+        let extractor = AIContextExtractor()
+        let loc = locator(at: 2500)
+
+        let chapterNil = extractor.extractContext(
+            locator: loc, fullText: text, format: .txt,
+            scope: .chapter, chapterBounds: nil, maxUTF16: 12_000
+        )
+        let section = extractor.extractContext(
+            locator: loc, fullText: text, format: .txt,
+            scope: .section, chapterBounds: nil, maxUTF16: 12_000
+        )
+        #expect(chapterNil == section)
+    }
+
+    // MARK: - .bookSoFar: short prefix
+
+    @Test func bookSoFarShortPrefixTakesStartToOffset() {
+        let text = String(repeating: "p", count: 5000)
+        let extractor = AIContextExtractor()
+        // Offset 800, budget 12000 → prefix [0, 800).
+        let result = extractor.extractContext(
+            locator: locator(at: 800), fullText: text, format: .txt,
+            scope: .bookSoFar, chapterBounds: nil, maxUTF16: 12_000
+        )
+        #expect(result.utf16.count == 800)
+        #expect(result == String(repeating: "p", count: 800))
+    }
+
+    // MARK: - .bookSoFar over budget: last maxUTF16 units before the offset
+
+    @Test func bookSoFarOverBudgetTakesLastBudgetUnits() {
+        // Distinct halves so we can prove the recency bias.
+        let head = String(repeating: "H", count: 3000)
+        let tail = String(repeating: "T", count: 3000)
+        let text = head + tail   // offset 6000 worth
+        let extractor = AIContextExtractor()
+
+        // Locator at 6000 (end), budget 1000 → last 1000 units = all "T".
+        let result = extractor.extractContext(
+            locator: locator(at: 6000), fullText: text, format: .txt,
+            scope: .bookSoFar, chapterBounds: nil, maxUTF16: 1000
+        )
+        #expect(result.utf16.count == 1000)
+        #expect(result == String(repeating: "T", count: 1000))
+    }
+
+    // MARK: - Empty fullText
+
+    @Test func emptyFullTextReturnsEmptyForEveryScope() {
+        let extractor = AIContextExtractor()
+        for scope in SummaryScope.allCases {
+            let result = extractor.extractContext(
+                locator: locator(at: 0), fullText: "", format: .txt,
+                scope: scope,
+                chapterBounds: ChapterBounds(startUTF16: 0, endUTF16: 0),
+                maxUTF16: 12_000
+            )
+            #expect(result.isEmpty, "scope \(scope) on empty text → \"\"")
+        }
+    }
+
+    // MARK: - Locator offset 0
+
+    @Test func bookSoFarAtOffsetZeroReturnsEmpty() {
+        let text = String(repeating: "a", count: 1000)
+        let extractor = AIContextExtractor()
+        // Prefix [0, 0) is empty.
+        let result = extractor.extractContext(
+            locator: locator(at: 0), fullText: text, format: .txt,
+            scope: .bookSoFar, chapterBounds: nil, maxUTF16: 12_000
+        )
+        #expect(result.isEmpty)
+    }
+
+    // MARK: - Locator offset past utf16.count → clamp
+
+    @Test func bookSoFarOffsetPastEndClampsToFullText() {
+        let text = String(repeating: "a", count: 500)
+        let extractor = AIContextExtractor()
+        // Offset 99999 clamps to 500 → prefix is the whole text.
+        let result = extractor.extractContext(
+            locator: locator(at: 99_999), fullText: text, format: .txt,
+            scope: .bookSoFar, chapterBounds: nil, maxUTF16: 12_000
+        )
+        #expect(result == text)
+    }
+
+    @Test func chapterBoundsBeyondTextAreClamped() {
+        // Bounds end past the text length → slice clamps to the text end.
+        let text = String(repeating: "a", count: 500)
+        let extractor = AIContextExtractor()
+        let bounds = ChapterBounds(startUTF16: 100, endUTF16: 99_999)
+
+        let result = extractor.extractContext(
+            locator: locator(at: 200), fullText: text, format: .txt,
+            scope: .chapter, chapterBounds: bounds, maxUTF16: 12_000
+        )
+        #expect(result == String(repeating: "a", count: 400))  // [100, 500)
+    }
+
+    // MARK: - Zero-length chapter
+
+    @Test func zeroLengthChapterReturnsEmpty() {
+        let text = String(repeating: "a", count: 1000)
+        let extractor = AIContextExtractor()
+        let bounds = ChapterBounds(startUTF16: 400, endUTF16: 400)
+
+        let result = extractor.extractContext(
+            locator: locator(at: 400), fullText: text, format: .txt,
+            scope: .chapter, chapterBounds: bounds, maxUTF16: 12_000
+        )
+        #expect(result.isEmpty)
+    }
+
+    // MARK: - CJK / surrogate-pair text — no split surrogate at boundaries
+
+    @Test func chapterScopeDoesNotSplitSurrogatePairs() {
+        // Emoji are 2-UTF-16-unit surrogate pairs. A chapter slice whose
+        // bounds fall ON a pair boundary must yield valid scalars.
+        let emoji = "😀"
+        let text = String(repeating: emoji, count: 200)  // 400 UTF-16 units
+        let extractor = AIContextExtractor()
+        // [100, 300) — both bounds land between two emoji (even offsets).
+        let bounds = ChapterBounds(startUTF16: 100, endUTF16: 300)
+
+        let result = extractor.extractContext(
+            locator: locator(at: 200), fullText: text, format: .txt,
+            scope: .chapter, chapterBounds: bounds, maxUTF16: 12_000
+        )
+        // 200 UTF-16 units = 100 emoji, every scalar intact.
+        #expect(result.utf16.count == 200)
+        #expect(result == String(repeating: emoji, count: 100))
+        #expect(result.unicodeScalars.allSatisfy { $0 != "\u{FFFD}" })
+    }
+
+    @Test func bookSoFarOverBudgetDoesNotSplitSurrogatePairs() {
+        // Over-budget last-N truncation on emoji text: if maxUTF16 is odd
+        // it would bisect a surrogate pair — the extractor must not
+        // produce a replacement char / lone surrogate.
+        let emoji = "🎉"
+        let text = String(repeating: emoji, count: 300)  // 600 UTF-16 units
+        let extractor = AIContextExtractor()
+        // Offset 600 (end), odd budget 201 → must round to a safe boundary.
+        let result = extractor.extractContext(
+            locator: locator(at: 600), fullText: text, format: .txt,
+            scope: .bookSoFar, chapterBounds: nil, maxUTF16: 201
+        )
+        // No replacement char; result is a whole number of emoji.
+        #expect(result.unicodeScalars.allSatisfy { $0 != "\u{FFFD}" })
+        #expect(result.utf16.count % 2 == 0)
+        #expect(result.utf16.count <= 201)
+    }
+
+    @Test func chapterScopeOverBudgetCJKWindowIsValid() {
+        let cjk = "中"  // 1 UTF-16 unit
+        let text = String(repeating: cjk, count: 2000)
+        let extractor = AIContextExtractor()
+        let bounds = ChapterBounds(startUTF16: 0, endUTF16: 1500)
+
+        let result = extractor.extractContext(
+            locator: locator(at: 700), fullText: text, format: .txt,
+            scope: .chapter, chapterBounds: bounds, maxUTF16: 300
+        )
+        #expect(result.utf16.count == 300)
+        #expect(result.unicodeScalars.allSatisfy { $0 != "\u{FFFD}" })
+    }
+
+    @Test func chapterScopeOddBoundsOnSurrogateTextSnapToScalars() {
+        // Chapter bounds that land mid-surrogate-pair (odd offsets on
+        // emoji text). The slice must snap to scalar boundaries: start
+        // snaps UP, end snaps DOWN — yielding a whole number of emoji,
+        // no replacement char, length never exceeding the requested span.
+        let emoji = "🍎"                          // 2 UTF-16 units
+        let text = String(repeating: emoji, count: 200)  // 400 UTF-16 units
+        let extractor = AIContextExtractor()
+        // Odd bounds [101, 299) bisect pairs at both ends.
+        let bounds = ChapterBounds(startUTF16: 101, endUTF16: 299)
+
+        let result = extractor.extractContext(
+            locator: locator(at: 200), fullText: text, format: .txt,
+            scope: .chapter, chapterBounds: bounds, maxUTF16: 12_000
+        )
+        // start 101 snaps up to 102, end 299 snaps down to 298 → [102,298)
+        // = 196 UTF-16 units = 98 whole emoji.
+        #expect(result == String(repeating: emoji, count: 98))
+        #expect(result.unicodeScalars.allSatisfy { $0 != "\u{FFFD}" })
+        #expect(result.utf16.count <= 299 - 101)
+    }
+
+    // MARK: - Regression: locator with charRangeStartUTF16 but no charOffsetUTF16
+
+    @Test func bookSoFarUsesRangeStartWhenNoCharOffset() {
+        // A selection-anchored locator carries charRangeStartUTF16 but
+        // no charOffsetUTF16. The scoped path must resolve the offset
+        // via the same fallback the legacy .section path uses — so
+        // bookSoFar takes [0, rangeStart), not the whole text.
+        let text = String(repeating: "z", count: 5000)
+        let extractor = AIContextExtractor()
+        let loc = Locator(
+            bookFingerprint: Self.fp,
+            href: nil, progression: nil, totalProgression: nil, cfi: nil,
+            page: nil, charOffsetUTF16: nil,
+            charRangeStartUTF16: 1200, charRangeEndUTF16: 1210,
+            textQuote: nil, textContextBefore: nil, textContextAfter: nil
+        )
+        let result = extractor.extractContext(
+            locator: loc, fullText: text, format: .txt,
+            scope: .bookSoFar, chapterBounds: nil, maxUTF16: 12_000
+        )
+        #expect(result.utf16.count == 1200)
+    }
+
+    @Test func chapterUsesRangeStartWhenNoCharOffsetForCenteredWindow() {
+        // Same fallback for the over-budget chapter window: the centered
+        // window must center on charRangeStartUTF16 when charOffsetUTF16
+        // is nil.
+        let text = String(repeating: "H", count: 1400)   // [0,1400)
+            + String(repeating: "M", count: 200)         // [1400,1600) ← window
+            + String(repeating: "R", count: 1400)        // [1600,3000)
+        let extractor = AIContextExtractor()
+        let bounds = ChapterBounds(startUTF16: 1000, endUTF16: 2000)
+        let loc = Locator(
+            bookFingerprint: Self.fp,
+            href: nil, progression: nil, totalProgression: nil, cfi: nil,
+            page: nil, charOffsetUTF16: nil,
+            charRangeStartUTF16: 1500, charRangeEndUTF16: 1510,
+            textQuote: nil, textContextBefore: nil, textContextAfter: nil
+        )
+        let result = extractor.extractContext(
+            locator: loc, fullText: text, format: .txt,
+            scope: .chapter, chapterBounds: bounds, maxUTF16: 200
+        )
+        #expect(result == String(repeating: "M", count: 200))
+    }
+
+    // MARK: - Protocol conformance + AIContextBudget
+
+    @Test func extractorConformsToProtocol() {
+        let extractor: any AIContextExtracting = AIContextExtractor()
+        let result = extractor.extractContext(
+            locator: locator(at: 0), fullText: "hello", format: .txt,
+            scope: .section, chapterBounds: nil, maxUTF16: 100
+        )
+        #expect(!result.isEmpty)
+    }
+
+    @Test func protocolConvenienceOverloadSuppliesDefaultBudget() {
+        // The 5-arg protocol-extension overload supplies
+        // AIContextBudget.defaultMaxUTF16.
+        let extractor: any AIContextExtracting = AIContextExtractor()
+        let result = extractor.extractContext(
+            locator: locator(at: 0), fullText: "hello world", format: .txt,
+            scope: .section, chapterBounds: nil
+        )
+        #expect(!result.isEmpty)
+    }
+
+    @Test func defaultBudgetIsPositive() {
+        #expect(AIContextBudget.defaultMaxUTF16 > 0)
+    }
+
+    // MARK: - Non-summarize formats still use .section via the legacy shim
+
+    @Test func epubLegacyShimUnchanged() {
+        // .section on EPUB delegates to the progression path — the
+        // legacy 3-arg entry point must behave exactly as before #69.
+        let text = String(repeating: "e", count: 200)
+        let extractor = AIContextExtractor(targetCharacterCount: 40)
+        let loc = Locator(
+            bookFingerprint: DocumentFingerprint(
+                contentSHA256: Self.fp.contentSHA256,
+                fileByteCount: Self.fp.fileByteCount, format: .epub
+            ),
+            href: "ch1.xhtml", progression: 0.5, totalProgression: nil,
+            cfi: nil, page: nil, charOffsetUTF16: nil,
+            charRangeStartUTF16: nil, charRangeEndUTF16: nil,
+            textQuote: nil, textContextBefore: nil, textContextAfter: nil
+        )
+        let legacy = extractor.extractContext(
+            locator: loc, textContent: text, format: .epub
+        )
+        let scoped = extractor.extractContext(
+            locator: loc, fullText: text, format: .epub,
+            scope: .section, chapterBounds: nil, maxUTF16: 12_000
+        )
+        #expect(scoped == legacy)
+    }
+}


### PR DESCRIPTION
## Summary

- WI-3 of feature #69 (AI Summarize scope selector).
- Adds the scope-aware extraction behind the Section / Chapter / Book-so-far chips: a new `AIContextExtracting` protocol seam, the `AIContextBudget` constant, and `AIContextExtractor`'s scoped `extractContext(...)` with `.chapter` / `.bookSoFar` paths.
- The legacy 3-arg `extractContext(locator:textContent:format:)` becomes a byte-identical `.section`-delegating shim — no behavior change for existing callers (the chips aren't wired into the UI until WI-5).

Part of feature #69.

## What Changed

- `vreader/Services/AI/AIContextExtracting.swift` (new) — `AIContextBudget.defaultMaxUTF16` constant + the `AIContextExtracting` protocol (`Sendable`). The 6-arg requirement has no default `maxUTF16` (a protocol-requirement default argument is invisible through `any AIContextExtracting`); a protocol-extension 5-arg overload supplies the default.
- `vreader/Services/AI/UTF16TextSlicer.swift` (new) — surrogate-pair-safe UTF-16 slicing. The start boundary snaps **up** and the end snaps **down** to Unicode scalar boundaries, so a surrogate pair is never bisected and the slice never exceeds the requested span.
- `vreader/Services/AI/AIContextExtractor.swift` (modified) — conforms to `AIContextExtracting`; scope-aware `extractContext(...:scope:chapterBounds:maxUTF16:)`. `.section` reuses the existing per-format window; `.chapter` slices the chapter span (over-budget → a `maxUTF16`-wide window centered on the locator, clamped inside the chapter; `nil` bounds → degrade to `.section`); `.bookSoFar` takes the `[0, offset)` prefix (over-budget → the last `maxUTF16` units). Scoped TXT paths resolve the offset with the same `charOffsetUTF16 ?? charRangeStartUTF16` fallback the `.section` path uses. File split to stay under ~300 lines.
- 40 extractor tests (28 new scoped + 12 legacy regression).

## WI Status

- WI-1, WI-2: foundational — merged (PRs #903, #906).
- WI-3: foundational — this PR.
- Remaining: WI-4 (`AIAssistantViewModel` scope wiring), WI-5 (chip strip UI + threading — final).

## Codex Audit (Gate 4)

2 rounds, thread `019e3e48`. Round 1 found 1 Medium + 2 Low — the scoped paths ignored `charRangeStartUTF16` (diverging from `.section`), the over-budget tests used uniform text + length-only assertions, and the file grew past 300 lines. All fixed: shared offset resolver, marker-segment exact-slice tests + odd-surrogate-boundary + `charRangeStartUTF16`-only regressions, and a 3-file split. Round 2 verified clean. Verdict: **ship-as-is**.

Audit log: `.claude/codex-audits/feat-feature-69-wi-3-scoped-extractor-audit.md`

## Validation

- [x] `xcodebuild test` passes — 40 extractor tests + 42 AI viewmodel/integration/chat/translation tests (no regression)
- [x] Tests cover changed behavior (TDD: RED → GREEN)
- [x] Codex audit loop completed (2 rounds, verdict: ship-as-is)
- [x] Docs sync — n/a (internal protocol seam + utility, not a documented service / notification / `@Model` / layer; no user-visible change)
- [x] Version bumped: 3.33.3 → 3.33.4

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: foundational — extraction logic + protocol seam, no user-observable behavior (the scoped paths are not wired into the UI until WI-5). Unit tests + Gate 4 audit sufficient.
- 40 + 42 unit tests pass; smoke `xcodebuild build` succeeds.

## Type of Change

- [x] Feature WI (Part of feature #69 for this intermediate WI)