### PR TITLE
feat(#69 WI-4): AIAssistantViewModel scope wiring

### DIFF
--- a/.claude/codex-audits/feat-feature-69-wi-4-viewmodel-scope-wiring-audit.md
+++ b/.claude/codex-audits/feat-feature-69-wi-4-viewmodel-scope-wiring-audit.md
@@ -1,0 +1,58 @@
+---
+branch: feat/feature-69-wi-4-viewmodel-scope-wiring
+threadId: 019e3e57-f407-7ef0-b5fc-42a14cea23df
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+# Gate-4 Implementation Audit — Feature #69 WI-4
+
+WI-4: `AIAssistantViewModel` scope wiring — `contextExtractor` retyped
+to `any AIContextExtracting`, `summarize` carries `fullText` / `scope`
+/ `chapterBounds`, `selectedScope` observable + `setScope`.
+
+## Files audited
+
+- `vreader/ViewModels/AIAssistantViewModel.swift` (modified)
+- `vreader/Views/Reader/AISummaryTabView.swift` (modified — 1-line build fix)
+- `vreaderTests/ViewModels/AIAssistantViewModelScopeTests.swift` (new)
+- `vreaderTests/ViewModels/AIAssistantViewModelTests.swift` (test migration)
+- `vreaderTests/ViewModels/AIReaderIntegrationTests.swift` (test migration)
+- `vreaderTests/Views/Reader/AISummaryTabViewTests.swift` (test migration)
+
+## Round 1 — findings
+
+| file:line | severity | issue | resolution |
+|---|---|---|---|
+| `AIAssistantViewModelScopeTests.swift:205` | Medium | `setScopeDuringLoadingUpdatesScopeWithoutCorruptingState` did not exercise "during loading" — both the test and `AIAssistantViewModel` are `@MainActor`, so the `async let` child cannot preempt; `setScope` ran before `summarize` started. | **Fixed** — replaced with `setScopeDuringInFlightRequestDoesNotCorruptState` + a `GatedAIProvider` test double. The provider's `sendRequest` (off the MainActor) yields to an `entered` AsyncStream then blocks on a `release` stream; the test awaits `entered` (proving the request is genuinely in flight), asserts `.loading` + `.section`, mutates scope, asserts no second request, releases, awaits completion. |
+| `AIAssistantViewModelScopeTests.swift:218` | Low | The scope-regression suite pinned only `explain` and `vocabulary`; `translate` and `askQuestion` had no `RecordingExtractor`-backed forwarding assertion. | **Fixed** — added `translateStillUsesSectionScope` and `askQuestionStillUsesSectionScope`, asserting `.section` scope + `textContent`-as-`fullText` passthrough + `chapterBounds == nil`. |
+
+Clean in round 1: the production changes match plan §2.5/§2.6 —
+`contextExtractor` retyped to `any AIContextExtracting`, `summarize`
+requires `fullText` and carries `scope`/`chapterBounds`,
+`selectedScope`/`setScope` present, `performAction` forwards `fullText`
++ explicit `AIContextBudget.defaultMaxUTF16`, non-summarize paths
+preserve `.section`. The test-file `textContent:`→`fullText:` migration
+touched only `summarize(...)` calls.
+
+## Round 2 — verification
+
+Codex re-reviewed the test file: "Clean. No new Critical/High/Medium
+issues … The new in-flight test is materially sound … That removes the
+earlier actor-scheduling false positive … The non-summarize regression
+pins are now complete for the WI-4 contract."
+
+## Verdict
+
+**ship-as-is.** Zero open Critical/High/Medium findings after 2
+rounds. 14 scope tests pass + 51 tests across the 4 affected suites
+(`AIAssistantViewModelScope`, `AIAssistantViewModel`,
+`AIReaderIntegration`, `AISummaryTabView`).
+
+## Note — `AISummaryTabView.swift` build-fix
+
+WI-4 changed `summarize`'s signature, so `AISummaryTabView.runSummarize`
+(WI-5's file) needed a 1-line build fix: `textContent:` → `fullText:`,
+still passing the section content with the default `.section` scope —
+byte-identical pre-#69 behavior. WI-5 does the real chip-strip rework.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 483
-        MARKETING_VERSION: 3.33.5
+        CURRENT_PROJECT_VERSION: 484
+        MARKETING_VERSION: 3.33.6
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5198,13 +5198,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 483;
+				CURRENT_PROJECT_VERSION = 484;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.33.5;
+				MARKETING_VERSION = 3.33.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5348,13 +5348,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 483;
+				CURRENT_PROJECT_VERSION = 484;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.33.5;
+				MARKETING_VERSION = 3.33.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		2F558CF136B69212E668F2D3 /* EPUBParserProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C15E361FF460BCE57B8675 /* EPUBParserProtocol.swift */; };
 		2F69DF71FDE5AF4FF920C3B2 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864A1B050775A46ADBE3304F /* SearchViewModel.swift */; };
 		2FA04FC59FECB40C45FAD4D8 /* LocatorFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055FBEA382F82BE342A50C8E /* LocatorFactoryTests.swift */; };
+		2FAEAAB8498E00263D366E37 /* AIAssistantViewModelScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EE0734EE0796711AE09253D /* AIAssistantViewModelScopeTests.swift */; };
 		2FDBB9D830B8DC7FF418BD3D /* DebugSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA61DA459242CFDBBD809B7 /* DebugSnapshotTests.swift */; };
 		30043FDF6F3A8F38D2891AF1 /* ReaderContainerView+Sheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C77872C4F869769F4C83F7 /* ReaderContainerView+Sheets.swift */; };
 		301BA4423DE1212ADB315388 /* BookImporterAZW3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4962BEF634F94652553FC6BD /* BookImporterAZW3Tests.swift */; };
@@ -1156,6 +1157,7 @@
 		1D51DC243D8B3F2A404ABA38 /* ReaderSettingsPanelThemePickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsPanelThemePickerTests.swift; sourceTree = "<group>"; };
 		1D579834E6924BB521873C38 /* FormatCapabilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatCapabilitiesTests.swift; sourceTree = "<group>"; };
 		1EC15AFBBED7042657A406C9 /* OffsetMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffsetMap.swift; sourceTree = "<group>"; };
+		1EE0734EE0796711AE09253D /* AIAssistantViewModelScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAssistantViewModelScopeTests.swift; sourceTree = "<group>"; };
 		1F0072BB2EF5A87447A6101A /* ReaderSettingsThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsThemeTests.swift; sourceTree = "<group>"; };
 		1F3E6C42E1711EF70E585526 /* TXTViewConfigThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTViewConfigThemeTests.swift; sourceTree = "<group>"; };
 		1F9542255A6791C9BCB034DB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -2320,6 +2322,7 @@
 		31E042EB986C2221B3740C56 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				1EE0734EE0796711AE09253D /* AIAssistantViewModelScopeTests.swift */,
 				EA401D8FC3B4F17213528B27 /* AIAssistantViewModelTests.swift */,
 				B90F4EB83CC68406DA14DD94 /* AIChatGeneralTests.swift */,
 				E861A379A620B769CEA36300 /* AIChatViewModelTests.swift */,
@@ -4135,6 +4138,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2FAEAAB8498E00263D366E37 /* AIAssistantViewModelScopeTests.swift in Sources */,
 				8044960A1B045C48AAE88736 /* AIAssistantViewModelTests.swift in Sources */,
 				369D003DCE5F36A64E5C1C06 /* AIChatGeneralTests.swift in Sources */,
 				62BE094A6E99C25AD7880CE4 /* AIChatMessageRowTests.swift in Sources */,

--- a/vreader/ViewModels/AIAssistantViewModel.swift
+++ b/vreader/ViewModels/AIAssistantViewModel.swift
@@ -8,8 +8,17 @@
 // - Each action method resets state before starting.
 // - Streaming accumulates text chunks into responseText.
 // - Errors are mapped to user-friendly messages via AIError.localizedDescription.
+// - Summary scope (feature #69): `selectedScope` tracks the AI Summarize
+//   tab's scope chip; `summarize` takes the FULL flattened book text +
+//   scope + chapterBounds and forwards them to the extractor. The
+//   non-summarize actions (explain/translate/vocabulary/askQuestion) are
+//   selection-driven and always extract with `.section`.
+// - The context extractor is injected as `any AIContextExtracting` (a
+//   boundary protocol) so tests can record what scope/bounds/fullText
+//   the view model forwards.
 //
-// @coordinates-with: AIService.swift, AIAssistantView.swift
+// @coordinates-with: AIService.swift, AIContextExtracting.swift,
+//   SummaryScope.swift, ChapterBounds.swift, AISummaryTabView.swift
 
 import Foundation
 
@@ -40,10 +49,14 @@ final class AIAssistantViewModel {
     /// The action type of the current/last request.
     private(set) var currentAction: AIActionType?
 
+    /// The AI Summarize tab's selected scope chip. Defaults to `.section`
+    /// (the pre-feature-#69 behavior). Mutated only via `setScope`.
+    private(set) var selectedScope: SummaryScope = .section
+
     // MARK: - Dependencies
 
     private let aiService: AIService
-    private let contextExtractor: AIContextExtractor
+    private let contextExtractor: any AIContextExtracting
 
     // MARK: - Private
 
@@ -53,29 +66,49 @@ final class AIAssistantViewModel {
 
     init(
         aiService: AIService,
-        contextExtractor: AIContextExtractor = AIContextExtractor()
+        contextExtractor: any AIContextExtracting = AIContextExtractor()
     ) {
         self.aiService = aiService
         self.contextExtractor = contextExtractor
     }
 
+    // MARK: - Scope
+
+    /// Updates the Summarize tab's selected scope. Does NOT re-run the
+    /// summary — the user explicitly taps Summarize / Regenerate. Every
+    /// `AIAssistantViewModel` state change is a method (codebase convention).
+    func setScope(_ scope: SummaryScope) {
+        selectedScope = scope
+    }
+
     // MARK: - Actions
 
-    /// Summarizes the text around the given locator.
+    /// Summarizes the book at the given scope around the locator.
+    ///
+    /// `fullText` is the FULL flattened book text — NOT a section snippet.
+    /// It is intentionally non-defaulted: the Summarize call site must
+    /// pass the full text explicitly so a `.chapter` / `.bookSoFar` scope
+    /// can slice a meaningful span (defaulting it would re-introduce the
+    /// "scoped summary runs on a pre-extracted snippet" bug).
     func summarize(
         locator: Locator,
-        textContent: String,
-        format: BookFormat
+        fullText: String,
+        format: BookFormat,
+        scope: SummaryScope = .section,
+        chapterBounds: ChapterBounds? = nil
     ) async {
         await performAction(
             type: .summarize,
             locator: locator,
-            textContent: textContent,
-            format: format
+            fullText: fullText,
+            format: format,
+            scope: scope,
+            chapterBounds: chapterBounds
         )
     }
 
-    /// Explains the text around the given locator.
+    /// Explains the text around the given locator. Selection-driven —
+    /// always extracts with `.section` scope (out of feature #69's scope).
     func explain(
         locator: Locator,
         textContent: String,
@@ -84,12 +117,13 @@ final class AIAssistantViewModel {
         await performAction(
             type: .explain,
             locator: locator,
-            textContent: textContent,
+            fullText: textContent,
             format: format
         )
     }
 
-    /// Translates the text around the given locator.
+    /// Translates the text around the given locator. Selection-driven —
+    /// always extracts with `.section` scope.
     func translate(
         locator: Locator,
         textContent: String,
@@ -99,13 +133,14 @@ final class AIAssistantViewModel {
         await performAction(
             type: .translate,
             locator: locator,
-            textContent: textContent,
+            fullText: textContent,
             format: format,
             targetLanguage: targetLanguage
         )
     }
 
     /// Looks up vocabulary in the text around the given locator.
+    /// Selection-driven — always extracts with `.section` scope.
     func vocabulary(
         locator: Locator,
         textContent: String,
@@ -114,12 +149,13 @@ final class AIAssistantViewModel {
         await performAction(
             type: .vocabulary,
             locator: locator,
-            textContent: textContent,
+            fullText: textContent,
             format: format
         )
     }
 
     /// Answers a question about the text around the given locator.
+    /// Selection-driven — always extracts with `.section` scope.
     func askQuestion(
         question: String,
         locator: Locator,
@@ -129,7 +165,7 @@ final class AIAssistantViewModel {
         await performAction(
             type: .questionAnswer,
             locator: locator,
-            textContent: textContent,
+            fullText: textContent,
             format: format,
             userPrompt: question
         )
@@ -155,8 +191,10 @@ final class AIAssistantViewModel {
     private func performAction(
         type: AIActionType,
         locator: Locator,
-        textContent: String,
+        fullText: String,
         format: BookFormat,
+        scope: SummaryScope = .section,
+        chapterBounds: ChapterBounds? = nil,
         userPrompt: String? = nil,
         targetLanguage: String? = nil
     ) async {
@@ -168,10 +206,17 @@ final class AIAssistantViewModel {
         responseText = ""
         currentAction = type
 
+        // `contextExtractor` is `any AIContextExtracting`, so the 6-arg
+        // requirement is called with `maxUTF16` passed explicitly — a
+        // protocol-requirement default argument is not visible through
+        // the existential (see AIContextExtracting.swift).
         let context = contextExtractor.extractContext(
             locator: locator,
-            textContent: textContent,
-            format: format
+            fullText: fullText,
+            format: format,
+            scope: scope,
+            chapterBounds: chapterBounds,
+            maxUTF16: AIContextBudget.defaultMaxUTF16
         )
 
         guard !context.isEmpty else {

--- a/vreader/Views/Reader/AISummaryTabView.swift
+++ b/vreader/Views/Reader/AISummaryTabView.swift
@@ -294,9 +294,14 @@ struct AISummaryTabView: View {
             break
         }
         Task {
+            // Feature #69 WI-4: summarize now takes the full book text +
+            // a scope. WI-5 threads the real `loadedTextContent` and the
+            // scope-chip selection here; until then this passes the
+            // existing section content as `fullText` with the default
+            // `.section` scope — byte-identical to the pre-#69 behavior.
             await viewModel.summarize(
                 locator: locator,
-                textContent: textContent,
+                fullText: textContent,
                 format: format
             )
         }

--- a/vreaderTests/ViewModels/AIAssistantViewModelScopeTests.swift
+++ b/vreaderTests/ViewModels/AIAssistantViewModelScopeTests.swift
@@ -1,0 +1,402 @@
+// Purpose: Tests for AIAssistantViewModel's summary-scope wiring
+// (feature #69 WI-4) — the selectedScope observable, setScope, and the
+// scope / chapterBounds / fullText forwarded to AIContextExtracting.
+// Uses a recording AIContextExtracting conformer to assert the
+// extractor receives exactly what summarize(scope:) was given.
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("AIAssistantViewModel scope wiring")
+struct AIAssistantViewModelScopeTests {
+
+    // MARK: - Recording extractor
+
+    /// Records the arguments of the last `extractContext` call so a test
+    /// can assert what `AIAssistantViewModel` forwarded. Returns a
+    /// non-empty string so the view model proceeds past the empty-context
+    /// guard.
+    final class RecordingExtractor: AIContextExtracting, @unchecked Sendable {
+        struct Call: Sendable {
+            let fullText: String
+            let scope: SummaryScope
+            let chapterBounds: ChapterBounds?
+            let maxUTF16: Int
+        }
+        private let lock = NSLock()
+        private var _calls: [Call] = []
+        var calls: [Call] {
+            lock.lock(); defer { lock.unlock() }
+            return _calls
+        }
+        var lastCall: Call? { calls.last }
+
+        func extractContext(
+            locator: Locator, fullText: String, format: BookFormat,
+            scope: SummaryScope, chapterBounds: ChapterBounds?, maxUTF16: Int
+        ) -> String {
+            lock.lock()
+            _calls.append(Call(
+                fullText: fullText, scope: scope,
+                chapterBounds: chapterBounds, maxUTF16: maxUTF16
+            ))
+            lock.unlock()
+            return "EXTRACTED-CONTEXT"
+        }
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func makeViewModel(
+        extractor: any AIContextExtracting,
+        provider: StubAIProvider? = nil
+    ) -> (AIAssistantViewModel, StubAIProvider) {
+        let flags = FeatureFlags(environment: .prod)
+        flags.setOverride(true, for: .aiAssistant)
+        let stub = provider ?? StubAIProvider()
+        let service = AIService(
+            featureFlags: flags,
+            consentManager: WI11TestHelpers.makeConsentManager(hasConsent: true),
+            keychainService: WI11TestHelpers.makeKeychainService(),
+            provider: stub
+        )
+        let vm = AIAssistantViewModel(aiService: service, contextExtractor: extractor)
+        return (vm, stub)
+    }
+
+    private func okResponse() -> AIResponse {
+        AIResponse(
+            content: "summary text", actionType: .summarize,
+            promptVersion: "v1", createdAt: Date()
+        )
+    }
+
+    // MARK: - selectedScope default + setScope
+
+    @Test @MainActor func selectedScopeDefaultsToSection() {
+        let (vm, _) = makeViewModel(extractor: RecordingExtractor())
+        #expect(vm.selectedScope == .section)
+    }
+
+    @Test @MainActor func setScopeUpdatesSelectedScope() {
+        let (vm, _) = makeViewModel(extractor: RecordingExtractor())
+        vm.setScope(.chapter)
+        #expect(vm.selectedScope == .chapter)
+        vm.setScope(.bookSoFar)
+        #expect(vm.selectedScope == .bookSoFar)
+        vm.setScope(.section)
+        #expect(vm.selectedScope == .section)
+    }
+
+    @Test @MainActor func setScopeDoesNotStartARequest() {
+        // A bare setScope must not transition the state machine — the
+        // user explicitly taps Summarize/Regenerate to run.
+        let (vm, stub) = makeViewModel(extractor: RecordingExtractor())
+        vm.setScope(.chapter)
+        #expect(vm.state == .idle)
+        #expect(stub.sendRequestCallCount == 0)
+    }
+
+    // MARK: - summarize forwards scope + chapterBounds + fullText
+
+    @Test @MainActor func summarizeSectionForwardsSectionScope() async {
+        let extractor = RecordingExtractor()
+        let (vm, _) = makeViewModel(extractor: extractor, provider: {
+            let s = StubAIProvider(); s.stubbedResponse = okResponse(); return s
+        }())
+
+        await vm.summarize(
+            locator: WI11TestHelpers.makeLocator(),
+            fullText: "the full flattened book text",
+            format: .txt
+        )
+
+        #expect(extractor.lastCall?.scope == .section)
+        #expect(extractor.lastCall?.fullText == "the full flattened book text")
+        #expect(extractor.lastCall?.chapterBounds == nil)
+    }
+
+    @Test @MainActor func summarizeChapterForwardsScopeAndBounds() async {
+        let extractor = RecordingExtractor()
+        let (vm, _) = makeViewModel(extractor: extractor, provider: {
+            let s = StubAIProvider(); s.stubbedResponse = okResponse(); return s
+        }())
+        let bounds = ChapterBounds(startUTF16: 100, endUTF16: 2000)
+
+        await vm.summarize(
+            locator: WI11TestHelpers.makeLocator(),
+            fullText: "full book text here",
+            format: .txt,
+            scope: .chapter,
+            chapterBounds: bounds
+        )
+
+        #expect(extractor.lastCall?.scope == .chapter)
+        #expect(extractor.lastCall?.chapterBounds == bounds)
+        #expect(extractor.lastCall?.fullText == "full book text here")
+    }
+
+    @Test @MainActor func summarizeBookSoFarForwardsScope() async {
+        let extractor = RecordingExtractor()
+        let (vm, _) = makeViewModel(extractor: extractor, provider: {
+            let s = StubAIProvider(); s.stubbedResponse = okResponse(); return s
+        }())
+
+        await vm.summarize(
+            locator: WI11TestHelpers.makeLocator(),
+            fullText: "full book text",
+            format: .txt,
+            scope: .bookSoFar
+        )
+
+        #expect(extractor.lastCall?.scope == .bookSoFar)
+    }
+
+    @Test @MainActor func summarizeForwardsDefaultBudget() async {
+        // performAction passes AIContextBudget.defaultMaxUTF16 explicitly
+        // (a protocol-requirement default argument is invisible through
+        // the existential).
+        let extractor = RecordingExtractor()
+        let (vm, _) = makeViewModel(extractor: extractor, provider: {
+            let s = StubAIProvider(); s.stubbedResponse = okResponse(); return s
+        }())
+
+        await vm.summarize(
+            locator: WI11TestHelpers.makeLocator(),
+            fullText: "full book text",
+            format: .txt,
+            scope: .chapter,
+            chapterBounds: ChapterBounds(startUTF16: 0, endUTF16: 50)
+        )
+
+        #expect(extractor.lastCall?.maxUTF16 == AIContextBudget.defaultMaxUTF16)
+    }
+
+    // MARK: - summarize default scope is .section
+
+    @Test @MainActor func summarizeDefaultsToSectionScope() async {
+        // summarize with no explicit scope behaves as .section — the
+        // pre-#69 behavior.
+        let extractor = RecordingExtractor()
+        let (vm, _) = makeViewModel(extractor: extractor, provider: {
+            let s = StubAIProvider(); s.stubbedResponse = okResponse(); return s
+        }())
+
+        await vm.summarize(
+            locator: WI11TestHelpers.makeLocator(),
+            fullText: "full text",
+            format: .txt
+        )
+
+        #expect(extractor.lastCall?.scope == .section)
+    }
+
+    // MARK: - selectedScope changes during a genuine in-flight request
+
+    /// An AI provider whose `sendRequest` blocks until the test releases
+    /// it — so a test can prove a summarize call is GENUINELY in flight
+    /// (the request handler entered, then suspended) before mutating
+    /// scope. `sendRequest` runs off the MainActor, so the test (which is
+    /// `@MainActor`) can interleave a `setScope` call while it suspends.
+    ///
+    /// Two `AsyncStream`s coordinate it: the provider yields to `entered`
+    /// once `sendRequest` is reached, then awaits `release`; the test
+    /// awaits `entered`, mutates scope, then yields to `release`.
+    final class GatedAIProvider: AIProvider, @unchecked Sendable {
+        let providerName = "Gated"
+        private let response: AIResponse
+        private let enteredContinuation: AsyncStream<Void>.Continuation
+        private let releaseStream: AsyncStream<Void>
+
+        init(
+            response: AIResponse,
+            enteredContinuation: AsyncStream<Void>.Continuation,
+            releaseStream: AsyncStream<Void>
+        ) {
+            self.response = response
+            self.enteredContinuation = enteredContinuation
+            self.releaseStream = releaseStream
+        }
+
+        func sendRequest(_ request: AIRequest) async throws -> AIResponse {
+            enteredContinuation.yield(())        // signal: request in flight
+            enteredContinuation.finish()
+            var it = releaseStream.makeAsyncIterator()
+            _ = await it.next()                  // block until the test releases
+            return response
+        }
+
+        func streamRequest(_ request: AIRequest) -> AsyncThrowingStream<AIStreamChunk, Error> {
+            AsyncThrowingStream { $0.finish() }
+        }
+    }
+
+    @Test @MainActor func setScopeDuringInFlightRequestDoesNotCorruptState() async {
+        let extractor = RecordingExtractor()
+        let (enteredStream, enteredContinuation) = AsyncStream<Void>.makeStream()
+        let (releaseStream, releaseContinuation) = AsyncStream<Void>.makeStream()
+
+        let provider = GatedAIProvider(
+            response: okResponse(),
+            enteredContinuation: enteredContinuation,
+            releaseStream: releaseStream
+        )
+        // Build the view model directly (makeViewModel takes a StubAIProvider).
+        let flags = FeatureFlags(environment: .prod)
+        flags.setOverride(true, for: .aiAssistant)
+        let service = AIService(
+            featureFlags: flags,
+            consentManager: WI11TestHelpers.makeConsentManager(hasConsent: true),
+            keychainService: WI11TestHelpers.makeKeychainService(),
+            provider: provider
+        )
+        let vm = AIAssistantViewModel(aiService: service, contextExtractor: extractor)
+
+        // Start a .section summarize; it suspends inside the gated provider.
+        let summarizeTask = Task { @MainActor in
+            await vm.summarize(
+                locator: WI11TestHelpers.makeLocator(),
+                fullText: "full text", format: .txt, scope: .section
+            )
+        }
+
+        // Wait until the request is GENUINELY in flight (sendRequest entered).
+        var enteredIterator = enteredStream.makeAsyncIterator()
+        _ = await enteredIterator.next()
+
+        // The request is mid-flight: state is .loading, extractor already
+        // saw .section. Now flip the scope chip.
+        #expect(vm.state == .loading)
+        #expect(extractor.lastCall?.scope == .section)
+        vm.setScope(.bookSoFar)
+        #expect(vm.selectedScope == .bookSoFar)
+        // No second request was spawned by the scope change.
+        #expect(extractor.calls.count == 1)
+
+        // Release the gated provider; the request completes cleanly.
+        releaseContinuation.yield(())
+        releaseContinuation.finish()
+        await summarizeTask.value
+
+        #expect(vm.state == .complete)
+        #expect(vm.selectedScope == .bookSoFar)
+        // The completed request used the ORIGINAL .section scope.
+        #expect(extractor.calls.count == 1)
+        #expect(extractor.lastCall?.scope == .section)
+    }
+
+    // MARK: - explain / translate / vocabulary / askQuestion unaffected (regression pins)
+
+    @Test @MainActor func explainStillUsesSectionScope() async {
+        let extractor = RecordingExtractor()
+        let (vm, _) = makeViewModel(extractor: extractor, provider: {
+            let s = StubAIProvider(); s.stubbedResponse = AIResponse(
+                content: "explanation", actionType: .explain,
+                promptVersion: "v1", createdAt: Date()
+            ); return s
+        }())
+
+        await vm.explain(
+            locator: WI11TestHelpers.makeLocator(),
+            textContent: "selected passage to explain",
+            format: .txt
+        )
+
+        // explain is selection-driven and out of #69 scope — it still
+        // extracts with .section, and its existing textContent param.
+        #expect(extractor.lastCall?.scope == .section)
+        #expect(extractor.lastCall?.fullText == "selected passage to explain")
+        #expect(vm.currentAction == .explain)
+    }
+
+    @Test @MainActor func vocabularyStillUsesSectionScope() async {
+        let extractor = RecordingExtractor()
+        let (vm, _) = makeViewModel(extractor: extractor, provider: {
+            let s = StubAIProvider(); s.stubbedResponse = AIResponse(
+                content: "vocab", actionType: .vocabulary,
+                promptVersion: "v1", createdAt: Date()
+            ); return s
+        }())
+
+        await vm.vocabulary(
+            locator: WI11TestHelpers.makeLocator(),
+            textContent: "passage for vocabulary",
+            format: .txt
+        )
+
+        #expect(extractor.lastCall?.scope == .section)
+        #expect(vm.currentAction == .vocabulary)
+    }
+
+    @Test @MainActor func translateStillUsesSectionScope() async {
+        let extractor = RecordingExtractor()
+        let (vm, _) = makeViewModel(extractor: extractor, provider: {
+            let s = StubAIProvider(); s.stubbedResponse = AIResponse(
+                content: "翻译", actionType: .translate,
+                promptVersion: "v1", createdAt: Date()
+            ); return s
+        }())
+
+        await vm.translate(
+            locator: WI11TestHelpers.makeLocator(),
+            textContent: "passage to translate",
+            format: .txt,
+            targetLanguage: "Chinese"
+        )
+
+        // translate is selection-driven — still .section, still passes
+        // its textContent through as fullText.
+        #expect(extractor.lastCall?.scope == .section)
+        #expect(extractor.lastCall?.fullText == "passage to translate")
+        #expect(extractor.lastCall?.chapterBounds == nil)
+        #expect(vm.currentAction == .translate)
+    }
+
+    @Test @MainActor func askQuestionStillUsesSectionScope() async {
+        let extractor = RecordingExtractor()
+        let (vm, _) = makeViewModel(extractor: extractor, provider: {
+            let s = StubAIProvider(); s.stubbedResponse = AIResponse(
+                content: "answer", actionType: .questionAnswer,
+                promptVersion: "v1", createdAt: Date()
+            ); return s
+        }())
+
+        await vm.askQuestion(
+            question: "what does this mean?",
+            locator: WI11TestHelpers.makeLocator(),
+            textContent: "passage the question is about",
+            format: .txt
+        )
+
+        #expect(extractor.lastCall?.scope == .section)
+        #expect(extractor.lastCall?.fullText == "passage the question is about")
+        #expect(extractor.lastCall?.chapterBounds == nil)
+        #expect(vm.currentAction == .questionAnswer)
+    }
+
+    // MARK: - Empty fullText still produces a context error
+
+    @Test @MainActor func summarizeEmptyFullTextShowsContextError() async {
+        // The extractor returns "" for empty input; the view model maps
+        // an empty context to .error — an existing path, preserved.
+        let realExtractor = AIContextExtractor()
+        let (vm, stub) = makeViewModel(extractor: realExtractor, provider: {
+            let s = StubAIProvider(); s.stubbedResponse = okResponse(); return s
+        }())
+
+        await vm.summarize(
+            locator: WI11TestHelpers.makeLocator(),
+            fullText: "",
+            format: .txt,
+            scope: .chapter,
+            chapterBounds: ChapterBounds(startUTF16: 0, endUTF16: 100)
+        )
+
+        if case .error = vm.state {} else {
+            #expect(Bool(false), "empty fullText should yield .error")
+        }
+        #expect(stub.sendRequestCallCount == 0)
+    }
+}

--- a/vreaderTests/ViewModels/AIAssistantViewModelTests.swift
+++ b/vreaderTests/ViewModels/AIAssistantViewModelTests.swift
@@ -49,7 +49,7 @@ struct AIAssistantViewModelTests {
 
         await vm.summarize(
             locator: WI11TestHelpers.makeLocator(),
-            textContent: "Some text content for testing.",
+            fullText: "Some text content for testing.",
             format: .txt
         )
 
@@ -85,7 +85,7 @@ struct AIAssistantViewModelTests {
 
         await vm.summarize(
             locator: WI11TestHelpers.makeLocator(),
-            textContent: "Some text content for testing.",
+            fullText: "Some text content for testing.",
             format: .txt
         )
 
@@ -130,7 +130,7 @@ struct AIAssistantViewModelTests {
 
         await vm.summarize(
             locator: WI11TestHelpers.makeLocator(),
-            textContent: "", // empty!
+            fullText: "", // empty!
             format: .txt
         )
 
@@ -158,13 +158,13 @@ struct AIAssistantViewModelTests {
         let text = "Some text content for testing."
 
         // First call populates cache
-        await vm.summarize(locator: locator, textContent: text, format: .txt)
+        await vm.summarize(locator: locator, fullText: text, format: .txt)
         #expect(vm.state == .complete)
         #expect(stub.sendRequestCallCount == 1)
 
         // Reset and call again — should hit cache
         vm.reset()
-        await vm.summarize(locator: locator, textContent: text, format: .txt)
+        await vm.summarize(locator: locator, fullText: text, format: .txt)
         #expect(vm.state == .complete)
         #expect(vm.responseText == "Cached content")
         #expect(stub.sendRequestCallCount == 1, "Provider should not be called on cache hit")
@@ -185,7 +185,7 @@ struct AIAssistantViewModelTests {
 
         await vm.summarize(
             locator: WI11TestHelpers.makeLocator(),
-            textContent: "Some text content for testing.",
+            fullText: "Some text content for testing.",
             format: .txt
         )
         #expect(vm.state == .complete)

--- a/vreaderTests/ViewModels/AIReaderIntegrationTests.swift
+++ b/vreaderTests/ViewModels/AIReaderIntegrationTests.swift
@@ -55,7 +55,7 @@ struct AIReaderIntegrationTests {
 
         await vm.summarize(
             locator: WI11TestHelpers.makeLocator(),
-            textContent: "This is a long text about philosophy and nature.",
+            fullText: "This is a long text about philosophy and nature.",
             format: .txt
         )
 
@@ -78,7 +78,7 @@ struct AIReaderIntegrationTests {
 
         await vm.summarize(
             locator: WI11TestHelpers.makeLocator(),
-            textContent: "A long discussion about consciousness and its implications.",
+            fullText: "A long discussion about consciousness and its implications.",
             format: .txt
         )
 
@@ -96,7 +96,7 @@ struct AIReaderIntegrationTests {
 
         await vm.summarize(
             locator: WI11TestHelpers.makeLocator(),
-            textContent: "Some content for the AI to process.",
+            fullText: "Some content for the AI to process.",
             format: .txt
         )
 
@@ -123,7 +123,7 @@ struct AIReaderIntegrationTests {
         // Also verify the summarize call transitions to featureDisabled
         await vm.summarize(
             locator: WI11TestHelpers.makeLocator(),
-            textContent: "Text",
+            fullText: "Text",
             format: .txt
         )
         #expect(vm.state == .featureDisabled)
@@ -148,7 +148,7 @@ struct AIReaderIntegrationTests {
 
         await vm.summarize(
             locator: WI11TestHelpers.makeLocator(),
-            textContent: longContent,
+            fullText: longContent,
             format: .txt
         )
 
@@ -183,7 +183,7 @@ struct AIReaderIntegrationTests {
         // After request completes
         await vm.summarize(
             locator: WI11TestHelpers.makeLocator(),
-            textContent: "Some text for summarization.",
+            fullText: "Some text for summarization.",
             format: .txt
         )
 
@@ -214,7 +214,7 @@ struct AIReaderIntegrationTests {
 
         await vm.summarize(
             locator: WI11TestHelpers.makeLocator(),
-            textContent: "Some text.",
+            fullText: "Some text.",
             format: .txt
         )
 
@@ -241,7 +241,7 @@ struct AIReaderIntegrationTests {
 
         await vm.summarize(
             locator: WI11TestHelpers.makeLocator(),
-            textContent: "",
+            fullText: "",
             format: .txt
         )
 
@@ -260,7 +260,7 @@ struct AIReaderIntegrationTests {
 
         await vm.summarize(
             locator: WI11TestHelpers.makeLocator(),
-            textContent: "Some text",
+            fullText: "Some text",
             format: .txt
         )
 
@@ -282,7 +282,7 @@ struct AIReaderIntegrationTests {
 
         await vm.summarize(
             locator: WI11TestHelpers.makeLocator(format: .pdf),
-            textContent: "PDF page content about machine learning.",
+            fullText: "PDF page content about machine learning.",
             format: .pdf
         )
 
@@ -322,7 +322,7 @@ struct AIReaderIntegrationTests {
 
         await vm.summarize(
             locator: epubLocator,
-            textContent: "The EPUB chapter content with interesting topics.",
+            fullText: "The EPUB chapter content with interesting topics.",
             format: .epub
         )
 
@@ -345,7 +345,7 @@ struct AIReaderIntegrationTests {
 
         await vm.summarize(
             locator: WI11TestHelpers.makeLocator(),
-            textContent: "Some text",
+            fullText: "Some text",
             format: .txt
         )
         #expect(vm.state == .complete)

--- a/vreaderTests/Views/Reader/AISummaryTabViewTests.swift
+++ b/vreaderTests/Views/Reader/AISummaryTabViewTests.swift
@@ -206,7 +206,7 @@ struct AISummaryTabViewTests {
 
         await vm.summarize(
             locator: WI11TestHelpers.makeLocator(),
-            textContent: "Some text content for testing.",
+            fullText: "Some text content for testing.",
             format: .txt
         )
 
@@ -225,7 +225,7 @@ struct AISummaryTabViewTests {
 
         await vm.summarize(
             locator: WI11TestHelpers.makeLocator(),
-            textContent: "Some text content for testing.",
+            fullText: "Some text content for testing.",
             format: .txt
         )
 


### PR DESCRIPTION
## Summary

- WI-4 of feature #69 (AI Summarize scope selector).
- Wires the summary-scope plumbing through `AIAssistantViewModel`: `selectedScope` observable + `setScope`, `summarize` carries `fullText` / `scope` / `chapterBounds`, and `contextExtractor` is retyped to the `any AIContextExtracting` seam.
- No user-observable change yet — the scope chips that drive `setScope` are added in WI-5. `AISummaryTabView` still summarizes with `.section`.

Part of feature #69.

## What Changed

- `vreader/ViewModels/AIAssistantViewModel.swift` —
  - `contextExtractor` retyped from concrete `AIContextExtractor` to `any AIContextExtracting` (defaulted to `AIContextExtractor()` in init — production construction unchanged).
  - `summarize(locator:fullText:format:scope:chapterBounds:)` — `fullText` is **not** defaulted (the Summarize call site must pass the full book text explicitly so a scoped summary never runs on a pre-extracted snippet); `scope` / `chapterBounds` default to `.section` / `nil`.
  - `selectedScope: SummaryScope` observable (`private(set)`, default `.section`) + `setScope(_:)`. `setScope` updates selection only — it does **not** re-run the summary.
  - `performAction` forwards `scope` / `chapterBounds` / `fullText` and passes `AIContextBudget.defaultMaxUTF16` explicitly to the 6-arg protocol requirement.
  - `explain` / `translate` / `vocabulary` / `askQuestion` keep their `textContent` param, pass it as `fullText` with `scope:.section` — byte-identical behavior.
- `vreader/Views/Reader/AISummaryTabView.swift` — 1-line build-fix for the `summarize` signature change (`textContent:` → `fullText:`, still `.section`). WI-5 does the chip-strip rework.
- 14 new scope tests + the existing AI test suites migrated to the new signature.

## WI Status

- WI-1, WI-2, WI-3: foundational — merged (PRs #903, #906, #908).
- WI-4: ViewModel API wiring — this PR. No user-observable behavior yet (the chip strip is WI-5).
- Remaining: WI-5 (chip strip UI + `aiSheet` threading — final).

## Codex Audit (Gate 4)

2 rounds, thread `019e3e57`. Round 1 found 1 Medium + 1 Low — the in-flight-scope-change test was vacuous (actor scheduling meant `setScope` ran before `summarize` started), and `translate`/`askQuestion` lacked `RecordingExtractor`-backed regression pins. Both fixed: a `GatedAIProvider` test double that proves the request is genuinely in flight before the scope mutation, plus `translate`/`askQuestion` regression pins. Round 2 verified clean. Verdict: **ship-as-is**.

Audit log: `.claude/codex-audits/feat-feature-69-wi-4-viewmodel-scope-wiring-audit.md`

## Validation

- [x] `xcodebuild test` passes — 14 scope tests + 51 tests across `AIAssistantViewModel` / `AIReaderIntegration` / `AISummaryTabView` suites
- [x] Tests cover changed behavior (TDD: RED → GREEN)
- [x] Codex audit loop completed (2 rounds, verdict: ship-as-is)
- [x] Docs sync — n/a (ViewModel API change, no new documented service / notification / `@Model` / layer)
- [x] Version bumped: 3.33.5 → 3.33.6

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: WI-4 changes `AIAssistantViewModel`'s API + adds the `selectedScope` observable, but produces **no user-observable delta** — the chip strip (the observable surface) is WI-5; `AISummaryTabView` still summarizes with `.section`. Per the Gate 5 definition ("Foundational = no user-observable behavior"), unit tests + Gate 4 audit are sufficient here; the genuine behavioral verification happens at WI-5's final acceptance pass.
- 14 + 51 unit tests pass; smoke `xcodebuild build` succeeds.

## Type of Change

- [x] Feature WI (Part of feature #69 for this intermediate WI)