### PR TITLE
fix: codex-audit hook diffs against origin/main merge-base, not stale local main

### DIFF
--- a/.claude/hooks/check_codex_audit_artifact.sh
+++ b/.claude/hooks/check_codex_audit_artifact.sh
@@ -78,9 +78,22 @@ case "$BRANCH" in
 esac
 
 # Detect docs/meta-only PRs that don't need a code audit.
-# Fail open if the diff command itself fails (no upstream main, etc.).
+#
+# Diff against origin/main with a three-dot range (merge-base...HEAD),
+# NOT the local `main` ref. The local `main` ref is shared by every
+# worktree under one repo and is routinely stale — a two-dot
+# `git diff main..HEAD` from a worktree picks up Swift files from
+# OTHER PRs that merged into main after this branch forked, wrongly
+# flagging a docs-only PR as Swift-touching. `origin/main...HEAD`
+# (after a best-effort fetch) counts only the files THIS branch
+# changed since it diverged from origin/main.
+#
+# Fail open if the diff itself fails (offline, no upstream main, etc.).
 SWIFT_TOUCHED="no"
-if CHANGED="$(git diff main..HEAD --name-only 2>/dev/null)"; then
+git fetch origin main --quiet 2>/dev/null || true
+DIFF_BASE="origin/main"
+git rev-parse --verify --quiet origin/main >/dev/null 2>&1 || DIFF_BASE="main"
+if CHANGED="$(git diff "${DIFF_BASE}...HEAD" --name-only 2>/dev/null)"; then
     if echo "$CHANGED" | grep -qE '^(vreader/|vreaderTests/)'; then
         SWIFT_TOUCHED="yes"
     fi

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 484
-        MARKETING_VERSION: 3.33.6
+        CURRENT_PROJECT_VERSION: 485
+        MARKETING_VERSION: 3.33.7
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5198,13 +5198,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 484;
+				CURRENT_PROJECT_VERSION = 485;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.33.6;
+				MARKETING_VERSION = 3.33.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5348,13 +5348,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 484;
+				CURRENT_PROJECT_VERSION = 485;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.33.6;
+				MARKETING_VERSION = 3.33.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

- `check_codex_audit_artifact.sh` decided whether a PR is "Swift-touching" via `git diff main..HEAD`. The local `main` ref is shared across every worktree under one repo and is routinely stale.
- From a worktree branch, a two-dot diff against a stale `main` picks up Swift files from **other** PRs that merged into `main` after this branch forked — wrongly gating docs-only / meta-only PRs behind a Codex audit log they never needed.
- Fix: best-effort `git fetch origin main`, then diff with a three-dot range `origin/main...HEAD` (merge-base...HEAD) so only the files **this** branch changed since it diverged are counted. Falls back to local `main` when `origin/main` does not resolve (offline / no remote).

This is the second defect found in this hook. Defect #1 (resolving the repo from `$CLAUDE_PROJECT_DIR` instead of the invocation cwd) shipped in #898.

## What Changed

- `.claude/hooks/check_codex_audit_artifact.sh` — Swift-touch detection now uses `origin/main...HEAD` after a best-effort fetch, with a `main` fallback. Comment block expanded to explain the worktree-staleness rationale.

## Validation

- [x] `bash -n` syntax check passes
- [x] End-to-end hook test: simulated `gh pr merge` PreToolUse payload against this branch (only `.sh` changed) → exits 0 (allow), no false Swift-touch flag
- [x] `git diff origin/main...HEAD --name-only` correctly reports just the hook file
- [x] Smoke build `BUILD SUCCEEDED`
- [x] Version bumped: 3.33.6 → 3.33.7

## Type of Change

- [x] Tooling / meta-process fix (no bug/feature row referenced — exempt from the fix-or-implement merge gate per AGENTS.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)