### PR TITLE
chore: bump version to 3.34.4 — post-merge collision (#57 WI-3 / #55 WI-1)

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 490
-        MARKETING_VERSION: 3.34.3
+        CURRENT_PROJECT_VERSION: 491
+        MARKETING_VERSION: 3.34.4
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5270,13 +5270,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 490;
+				CURRENT_PROJECT_VERSION = 491;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.34.3;
+				MARKETING_VERSION = 3.34.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5420,13 +5420,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 490;
+				CURRENT_PROJECT_VERSION = 491;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.34.3;
+				MARKETING_VERSION = 3.34.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

Feature #57 WI-3 (PR #919) and feature #55 WI-1 (PR #918) both branched off `main` at 3.34.2 and independently bumped to **3.34.3 / build 490**. #918 merged first and took the `v3.34.3` tag; #919 merged second carrying the same version line — a non-monotonic collision on `main`.

This PR bumps `main` to **3.34.4 / build 491** so the version is monotonic again and a clean `v3.34.4` tag can be cut from the merge commit.

Pure meta/version chore — references no bug/feature row, so the fix-or-implement merge gate does not apply (per AGENTS.md "Pure meta-process changes ... are exempt").

## Type of Change

- [x] Chore (version bump)