### PR TITLE
chore: bump version to 3.34.5 — post-merge collision (#902)

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 491
-        MARKETING_VERSION: 3.34.4
+        CURRENT_PROJECT_VERSION: 492
+        MARKETING_VERSION: 3.34.5
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5270,13 +5270,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 491;
+				CURRENT_PROJECT_VERSION = 492;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.34.4;
+				MARKETING_VERSION = 3.34.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5420,13 +5420,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 491;
+				CURRENT_PROJECT_VERSION = 492;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.34.4;
+				MARKETING_VERSION = 3.34.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

PR #920 (Bug #224 / GH #902 — SearchBar touch-target fix) and PR #921 both bumped to `3.34.4 / 491` off the same `origin/main` baseline. PR #921 landed first and `v3.34.4` was tagged on its commit (`c6d0b79`). PR #920's squash-merge then rebased onto the new `main`, so #920's merge commit `49588a6` carries the SearchBar fix but produces **no version delta** (it targets the already-present 3.34.4/491). `main` HEAD therefore sits at an already-tagged version.

This bumps to `3.34.5 / 492` so the merged #902 fix has a unique version to tag (`v3.34.5`).

## What Changed

- `project.yml` — `MARKETING_VERSION` 3.34.4 → 3.34.5, `CURRENT_PROJECT_VERSION` 491 → 492.
- `vreader.xcodeproj/project.pbxproj` — regenerated via `xcodegen generate`.

## Validation

- [x] `xcodegen generate` run; both files updated
- [x] Smoke build passes (iPhone 17 Pro Simulator)

## Type of Change

- [x] Chore (version bump — post-merge collision resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)