### PR TITLE
feat(#55 WI-2): PersistenceActor.highlight(withID:) + HighlightLookup conformance

### DIFF
--- a/.claude/codex-audits/feat-feature-55-wi-2-persistence-highlight-lookup-audit.md
+++ b/.claude/codex-audits/feat-feature-55-wi-2-persistence-highlight-lookup-audit.md
@@ -1,0 +1,48 @@
+---
+branch: feat/feature-55-wi-2-persistence-highlight-lookup
+threadId: 019e3ead-426e-7ba0-b567-a817499f5ff8
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+# Codex Audit — feature #55 WI-2 (PersistenceActor single-highlight lookup)
+
+## Scope
+
+Files changed (3), diff = single commit HEAD vs merge-base `1ada88f`:
+- `vreader/Services/PersistenceActor+Highlights.swift` (+31) — `highlight(withID:forBookWithKey:)` + `extension PersistenceActor: HighlightLookup {}`
+- `vreaderTests/Services/PersistenceActor+HighlightLookupTests.swift` (new) — Swift Testing tests
+- `vreader.xcodeproj/project.pbxproj` — xcodegen regen registering the new test file
+
+## Round 1
+
+Codex thread `019e3ead-426e-7ba0-b567-a817499f5ff8`, sandbox `read-only`.
+
+| file:line | severity | issue | resolution |
+|---|---|---|---|
+| — | — | No findings — Critical / High / Medium / Low all clear | n/a |
+
+Auditor confirmed:
+- The fetch is a dedicated `FetchDescriptor<Highlight>` with the intended
+  compound predicate `highlight.highlightId == highlightID && highlight.book?.fingerprintKey == bookKey`
+  — scopes the lookup to `(highlightId, book.fingerprintKey)`, prevents
+  cross-book leakage, and an orphaned highlight (`book == nil`) cannot match
+  because the optional-chain comparison evaluates false.
+- The captured locals (`let highlightID = id` / `let bookKey = key`) are the
+  standard SwiftData / Swift 6-safe predicate-capture pattern.
+- `fetchLimit = 1` keeps this on the single-row path — not materializing the
+  whole book's highlight set (plan §2.4 / §6 R-1).
+- Tests cover the WI's behavioral cases: found record, unknown id,
+  non-existent book key, cross-book isolation (two books, same highlight id
+  queried under the wrong key), nil-note round-trip, broader-palette colors,
+  and the protocol-existential path.
+
+Noted: the auditor did not run `xcodebuild test` in the read-only sandbox — this
+is a source audit. The WI-2 test gate (`PersistenceActorHighlightLookupTests`,
+7 tests / 9 cases) was run separately by the implementer and passed
+(`TEST SUCCEEDED`).
+
+## Verdict
+
+**ship-as-is** — zero findings at any severity after 1 round.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 492
-        MARKETING_VERSION: 3.34.5
+        CURRENT_PROJECT_VERSION: 493
+        MARKETING_VERSION: 3.34.6
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -604,6 +604,7 @@
 		8F002C822102F0A088F31A06 /* AnnotationRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A513D5E8C4467B8FE45E0AC /* AnnotationRecord.swift */; };
 		8F202DA6CCCB6E1D83E7DC01 /* SyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC12F17B1F2EDD25E25B114C /* SyncService.swift */; };
 		8F280281FE847272C7E64547 /* CollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E026EDF24B39D1CD50B39389 /* CollectionTests.swift */; };
+		8F49E620D597517097E96AE7 /* PersistenceActor+HighlightLookupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D54435E0293B133D7C4ECE /* PersistenceActor+HighlightLookupTests.swift */; };
 		8FFE1DA9C8F17FC318BE81BD /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138AEC5BBAD52B075096E5C8 /* SettingsView.swift */; };
 		9008E6E28C2B6F8202E2183A /* TXTChapterIndexBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEAA04C3430C5B247FB86585 /* TXTChapterIndexBuilderTests.swift */; };
 		905543EBFD153235D8C3BF00 /* PerBookSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7A2880FF5B321684FE712F /* PerBookSettings.swift */; };
@@ -1618,6 +1619,7 @@
 		87DA305663C991FC6F15F80E /* ImportJobQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportJobQueueTests.swift; sourceTree = "<group>"; };
 		87DF28B0149478FEC7B8EC4E /* search.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = search.js; sourceTree = "<group>"; };
 		87ECE13E023EB87748CF6B7B /* MOBIMetadataParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MOBIMetadataParserTests.swift; sourceTree = "<group>"; };
+		88D54435E0293B133D7C4ECE /* PersistenceActor+HighlightLookupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+HighlightLookupTests.swift"; sourceTree = "<group>"; };
 		89DE76057526BA48CAE2A83A /* UpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateChecker.swift; sourceTree = "<group>"; };
 		8A12A0D94CF17D48152929F0 /* ReadingStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStats.swift; sourceTree = "<group>"; };
 		8A1A348FFCBCC9C7A5360C28 /* RuleEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleEngineTests.swift; sourceTree = "<group>"; };
@@ -3433,6 +3435,7 @@
 				21BC5F159064D57CFAE2A676 /* MetadataExtractorTests.swift */,
 				544A2F3FF8BBB1C08DDCE02D /* PageNavigatorTests.swift */,
 				272182B2C311AE5E968D314C /* PerBookSettingsTests.swift */,
+				88D54435E0293B133D7C4ECE /* PersistenceActor+HighlightLookupTests.swift */,
 				A504B80204BEC5B968087D02 /* PersistenceActorRemoteOnlyTests.swift */,
 				410BA6F21267316487DF58FC /* PersistenceBookmarkTests.swift */,
 				EEDD43BA2EC5C331FDF3A703 /* PersistenceHighlightTests.swift */,
@@ -4436,6 +4439,7 @@
 				A2C6C1BBE3492F53D5C4BEB4 /* PagedModeBug82Tests.swift in Sources */,
 				468BC9EB876942D28F071E57 /* PaginationCacheTests.swift in Sources */,
 				0ADA2F00E5ABFEEF5328CE2F /* PerBookSettingsTests.swift in Sources */,
+				8F49E620D597517097E96AE7 /* PersistenceActor+HighlightLookupTests.swift in Sources */,
 				2B495CA89B61AF9DAC925A54 /* PersistenceActorRemoteOnlyTests.swift in Sources */,
 				5619DB9FC83E7182AE0EB63F /* PersistenceBookmarkTests.swift in Sources */,
 				DD32F48A384939AC2389DCAE /* PersistenceHighlightTests.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5274,13 +5274,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 492;
+				CURRENT_PROJECT_VERSION = 493;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.34.5;
+				MARKETING_VERSION = 3.34.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5424,13 +5424,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 492;
+				CURRENT_PROJECT_VERSION = 493;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.34.5;
+				MARKETING_VERSION = 3.34.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/PersistenceActor+Highlights.swift
+++ b/vreader/Services/PersistenceActor+Highlights.swift
@@ -143,6 +143,32 @@ extension PersistenceActor: HighlightPersisting {
             .map { highlightToRecord($0) }
     }
 
+    /// Fetches a single highlight by id, scoped to the book identified by
+    /// `key`. Returns `nil` when no highlight with that id belongs to that
+    /// book — feature #55's note-preview tap path.
+    ///
+    /// A dedicated single-row fetch with a predicate on `highlightId` AND the
+    /// owning book's `fingerprintKey`: the note-preview path fires on every
+    /// annotated-text tap, so it must not page the whole book's highlight set
+    /// into memory (plan §2.4 / §6 R-1). The `(id, key)` scoping makes a
+    /// lookup unable to leak a highlight from a different book.
+    func highlight(withID id: UUID, forBookWithKey key: String) async throws -> HighlightRecord? {
+        let context = ModelContext(modelContainer)
+        let highlightID = id
+        let bookKey = key
+        let predicate = #Predicate<Highlight> { highlight in
+            highlight.highlightId == highlightID
+                && highlight.book?.fingerprintKey == bookKey
+        }
+        var descriptor = FetchDescriptor<Highlight>(predicate: predicate)
+        descriptor.fetchLimit = 1
+
+        guard let highlight = try context.fetch(descriptor).first else {
+            return nil
+        }
+        return highlightToRecord(highlight)
+    }
+
     /// Total count of all highlights in the library, across all books.
     /// Single aggregate query — does not materialize any record.
     func countAllHighlights() async throws -> Int {
@@ -167,3 +193,8 @@ extension PersistenceActor: HighlightPersisting {
         )
     }
 }
+
+// Feature #55: `highlight(withID:forBookWithKey:)` above satisfies the
+// `HighlightLookup` boundary protocol, letting `NotePreviewViewModel` (WI-3)
+// be unit-tested against a mock instead of a live actor.
+extension PersistenceActor: HighlightLookup {}

--- a/vreaderTests/Services/PersistenceActor+HighlightLookupTests.swift
+++ b/vreaderTests/Services/PersistenceActor+HighlightLookupTests.swift
@@ -1,0 +1,164 @@
+// Purpose: Tests for feature #55 WI-2 — `PersistenceActor.highlight(withID:
+// forBookWithKey:)`, the single-highlight lookup the note-preview path uses,
+// and `PersistenceActor`'s `HighlightLookup` conformance.
+//
+// Covers: a found highlight round-trips; an unknown id → nil; a highlight
+// under book A is not returned for book B's key (the (id, bookKey) scoping);
+// `note` round-trips both a non-nil note and a nil note; a broader-palette
+// color (red/orange/purple) round-trips its `color`.
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("PersistenceActor — HighlightLookup")
+struct PersistenceActorHighlightLookupTests {
+
+    private func makeLocator(key: String, offset: Int = 0) -> Locator {
+        let fp = DocumentFingerprint(canonicalKey: key)
+            ?? CollectionTestHelper.makeBogusFingerprint(seed: key)
+        return Locator.validated(
+            bookFingerprint: fp,
+            charOffsetUTF16: offset,
+            charRangeStartUTF16: offset,
+            charRangeEndUTF16: offset + 10
+        )!
+    }
+
+    // MARK: - Found / not-found
+
+    @Test func highlightWithID_returnsInsertedRecord() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let key = try await CollectionTestHelper.insertBook(persistence: persistence)
+        let inserted = try await persistence.addHighlight(
+            locator: makeLocator(key: key, offset: 50),
+            selectedText: "the passage", color: "yellow",
+            note: "my note", toBookWithKey: key
+        )
+
+        let fetched = try await persistence.highlight(
+            withID: inserted.highlightId, forBookWithKey: key
+        )
+
+        let unwrapped = try #require(fetched)
+        #expect(unwrapped.highlightId == inserted.highlightId)
+        #expect(unwrapped.selectedText == "the passage")
+        #expect(unwrapped.color == "yellow")
+        #expect(unwrapped.note == "my note")
+    }
+
+    @Test func highlightWithID_unknownID_returnsNil() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let key = try await CollectionTestHelper.insertBook(persistence: persistence)
+
+        let fetched = try await persistence.highlight(
+            withID: UUID(), forBookWithKey: key
+        )
+        #expect(fetched == nil)
+    }
+
+    @Test func highlightWithID_missingBookKey_returnsNil() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let key = try await CollectionTestHelper.insertBook(persistence: persistence)
+        let inserted = try await persistence.addHighlight(
+            locator: makeLocator(key: key, offset: 10),
+            selectedText: "x", color: "yellow", note: nil, toBookWithKey: key
+        )
+
+        // The highlight exists, but a key for a book that was never inserted
+        // must not surface it.
+        let bogusKey = CollectionTestHelper.makeFingerprint(
+            sha: String(repeating: "f", count: 64), byteCount: 9, format: .epub
+        ).canonicalKey
+        let fetched = try await persistence.highlight(
+            withID: inserted.highlightId, forBookWithKey: bogusKey
+        )
+        #expect(fetched == nil)
+    }
+
+    // MARK: - Cross-book isolation
+
+    @Test func highlightWithID_isScopedToOwningBook() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let keyA = try await CollectionTestHelper.insertBook(
+            persistence: persistence, title: "Book A",
+            sha: String(repeating: "a", count: 64), byteCount: 1024
+        )
+        let keyB = try await CollectionTestHelper.insertBook(
+            persistence: persistence, title: "Book B",
+            sha: String(repeating: "b", count: 64), byteCount: 2048
+        )
+
+        let inA = try await persistence.addHighlight(
+            locator: makeLocator(key: keyA, offset: 30),
+            selectedText: "from A", color: "green", note: "A note",
+            toBookWithKey: keyA
+        )
+
+        // Same highlight id, but queried under book B's key → must be nil.
+        let leaked = try await persistence.highlight(
+            withID: inA.highlightId, forBookWithKey: keyB
+        )
+        #expect(leaked == nil)
+
+        // And it is still found under its own book.
+        let found = try await persistence.highlight(
+            withID: inA.highlightId, forBookWithKey: keyA
+        )
+        #expect(found?.highlightId == inA.highlightId)
+    }
+
+    // MARK: - Note round-trip
+
+    @Test func highlightWithID_roundTripsNilNote() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let key = try await CollectionTestHelper.insertBook(persistence: persistence)
+        let inserted = try await persistence.addHighlight(
+            locator: makeLocator(key: key, offset: 70),
+            selectedText: "no note here", color: "blue",
+            note: nil, toBookWithKey: key
+        )
+
+        let fetched = try await persistence.highlight(
+            withID: inserted.highlightId, forBookWithKey: key
+        )
+        #expect(fetched?.note == nil)
+    }
+
+    // MARK: - Broader-palette color round-trip
+
+    @Test(arguments: ["red", "orange", "purple"])
+    func highlightWithID_roundTripsBroaderPaletteColor(_ color: String) async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let key = try await CollectionTestHelper.insertBook(persistence: persistence)
+        let inserted = try await persistence.addHighlight(
+            locator: makeLocator(key: key, offset: 90),
+            selectedText: "colored", color: color,
+            note: "n", toBookWithKey: key
+        )
+
+        let fetched = try await persistence.highlight(
+            withID: inserted.highlightId, forBookWithKey: key
+        )
+        #expect(fetched?.color == color)
+    }
+
+    // MARK: - HighlightLookup conformance
+
+    @Test func persistenceActorConformsToHighlightLookup() async throws {
+        let persistence = try CollectionTestHelper.makePersistence()
+        let key = try await CollectionTestHelper.insertBook(persistence: persistence)
+        let inserted = try await persistence.addHighlight(
+            locator: makeLocator(key: key, offset: 5),
+            selectedText: "via protocol", color: "yellow",
+            note: "p", toBookWithKey: key
+        )
+
+        // Exercise the lookup through the protocol existential.
+        let lookup: any HighlightLookup = persistence
+        let fetched = try await lookup.highlight(
+            withID: inserted.highlightId, forBookWithKey: key
+        )
+        #expect(fetched?.highlightId == inserted.highlightId)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the single-highlight lookup feature #55's note-preview tap path uses, and conforms `PersistenceActor` to the WI-1 `HighlightLookup` protocol.
- No user-observable behavior — foundational tier.

Part of feature #619.

## What Changed

- `PersistenceActor.highlight(withID:forBookWithKey:)` (`vreader/Services/PersistenceActor+Highlights.swift`) — a dedicated single-row `FetchDescriptor<Highlight>` with a predicate on `highlightId` AND the owning book's `fingerprintKey`. The `(id, bookKey)` scoping makes a lookup unable to leak a highlight from another book; an orphaned highlight (`book == nil`) cannot match. `fetchLimit = 1` keeps it on the single-row path — the note-preview path fires on every annotated-text tap and must not page the whole book's highlight set (plan §2.4 / §6 R-1).
- `extension PersistenceActor: HighlightLookup {}` — the new method satisfies the WI-1 boundary protocol, so WI-3's `NotePreviewViewModel` is unit-testable against a mock.

## WI Status

- WI-2: foundational — this PR.
- WI-1: foundational — merged (PR #918, v3.34.3).
- Remaining: WI-3 (`NotePreviewViewModel`), WI-4/5 (callout + sheet views + UIKit rect-anchored presenter), WI-6 (TXT/MD/PDF wiring), WI-7 (EPUB/Foliate wiring — final WI).

## Codex Audit (Gate 4)

Codex thread `019e3ead-426e-7ba0-b567-a817499f5ff8`, 1 round, **ship-as-is** — zero findings at any severity. Auditor confirmed the compound predicate correctly scopes `(highlightId, book.fingerprintKey)`, prevents cross-book leakage, an orphaned highlight cannot match, the SwiftData-safe local capture pattern, and `fetchLimit = 1` on the single-row path.

Audit log: `.claude/codex-audits/feat-feature-55-wi-2-persistence-highlight-lookup-audit.md`

## Validation

- [x] `PersistenceActorHighlightLookupTests` — 7 tests / 9 cases, pass in isolation (`TEST SUCCEEDED`): found record, unknown id, non-existent book key, cross-book isolation, nil-note round-trip, broader-palette colors, protocol-existential path.
- [x] Tests cover changed behavior (TDD: RED → GREEN → REFACTOR).
- [x] Codex audit loop completed (1 round, verdict: ship-as-is).
- [x] Docs sync — n/a (foundational; no behavior, no notification; the `architecture.md` note-preview entry lands with the behavioral WIs that introduce the user-visible surface).
- [x] Version bumped: 3.34.3 → 3.34.6 (build 493).

Full-suite test gate note: the `vreaderTests` full-suite run is currently hitting **Bug #221 / issue #849** (known flaky test-host `signal kill` crash, active fix worktree). Across the WI-2 full-suite run: **595 suites pass, 0 real `✘` test failures** — both the `PersistenceActor — HighlightLookup` and `NotePreviewPresenter` suites pass explicitly; the host crash collateral-flags unrun suites. WI-2 changes one persistence method + one test file, with no test-host impact.

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: foundational — unit/integration tests + Codex audit sufficient, no device verification required.
- Run: `PersistenceActorHighlightLookupTests` (7 tests / 9 cases) green in isolation; smoke `xcodebuild build` succeeds at v3.34.6.

## Type of Change

- [x] Feature WI (Part of feature #619 — intermediate WI, plain prose, no `Refs`/`Fixes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)