### PR TITLE
docs: post-merge verification evidence for Bug #224 / GH #902

### DIFF
--- a/dev-docs/verification/bug-902-20260519.md
+++ b/dev-docs/verification/bug-902-20260519.md
@@ -1,0 +1,140 @@
+---
+kind: bug
+id: 902
+status_target: FIXED
+commit_sha: 49588a6d04809b5649532e3546ff9f7d95b7417f
+app_version: 3.34.5 (build 492)
+date: 2026-05-19
+verifier: claude
+device_or_simulator: iPhone 17 Pro Simulator
+os_version: iOS 26.5
+build_configuration: Debug
+backend: n/a
+result: pass
+---
+
+# Bug #224 / GH #902 — Post-merge verification
+
+Feature #63's v2 `SearchBar` re-skin gave `searchTextField` and
+`searchCancelButton` accessibility frames below the 44 pt HIG
+touch-target minimum. Fix shipped in PR #920 (merge commit
+`49588a6`); version tagged `v3.34.5` on `main` HEAD `a0b8e21`.
+
+## Verification method
+
+The failure mode — `XCUIApplication.performAccessibilityAudit`
+reporting `.hitRegion` ("Hit area is too small") on the SearchBar's
+interactive controls — is exercised by a **deterministic
+high-fidelity UITest** that drives the real subsystem: it runs
+`performAccessibilityAudit` (with `.hitRegion` active, no longer
+excluded as tracked debt) against the actual re-skinned `SearchBar`
+mounted in the running app. This is not a stubbed unit test — it
+launches the app, navigates to the reader, opens the search sheet,
+and audits the live accessibility tree. Verification-exception path
+per AGENTS.md "Close gate".
+
+Run against the merged `main` build (commit `49588a6` SearchBar fix,
+HEAD `a0b8e21`).
+
+## Acceptance criteria
+
+| # | Criterion (from Bug #224 / GH #902) | Observed | Result |
+|---|---|---|---|
+| 1 | The search `TextField` and the `Cancel` `Button` each have a >=44 pt tappable height. | `SearchBar.swift`'s `TextField` and `Button("Cancel")` each carry `.frame(minHeight: 44)` + `.contentShape(Rectangle())`. `performAccessibilityAudit` with `.hitRegion` active raises **no** "Hit area is too small" violation on either control — confirming both meet the 44 pt minimum. | pass |
+| 2 | `testSearchSheetAccessibilityAudit` passes with the `.hitRegion` exclusion removed. | `SearchSheetPlaceholderTests.testSearchSheetAccessibilityAudit` (and the mirror `GlobalAccessibilityAuditTests.testSearchSheetAudit`) no longer pass `excluding: .hitRegion`. Both run green on the merged `main` build: `Executed 2 tests, with 0 failures` / `** TEST SUCCEEDED **`. | pass |
+| 3 | The sizing change is checked against `dev-docs/designs/vreader-fidelity-v1` (rule 51 — visible UI change). | The design source `dev-docs/designs/vreader-fidelity-v1/project/vreader-search.jsx` draws the search bar as a flex row with `padding: '10px 14px'` around a 15 px-font input — a ~40 pt visible bar. Raising the *interactive controls'* hit/accessibility frames to the iOS 44 pt HIG minimum is a no-meaningful-visible-delta accessibility repair (rule-51 exempt). Codex design-parity verdict: exempt. | pass |
+
+## Commands run
+
+Simulator was rebooted fresh before the verification run (a prior
+run hit a `Timed out waiting for AX loaded notification` — the
+sim's Accessibility daemon needs a clean state for
+`performAccessibilityAudit`).
+
+```bash
+xcrun simctl shutdown all
+xcrun simctl boot "iPhone 17 Pro"
+xcrun simctl bootstatus "iPhone 17 Pro" -b
+```
+
+Checked out merged `main` (`a0b8e21`, includes SearchBar fix
+`49588a6`) and confirmed the fix is present:
+
+```bash
+git checkout -b verify-902-postmerge origin/main
+grep -c "minHeight: 44" vreader/Views/Search/SearchBar.swift          # -> 2
+grep -c "ignoringKeyboardElements" \
+  vreaderUITests/Helpers/AccessibilityAuditHelper.swift               # -> 4
+grep -c "excluding: .hitRegion" \
+  vreaderUITests/Search/SearchSheetPlaceholderTests.swift \
+  vreaderUITests/Accessibility/GlobalAccessibilityAuditTests.swift    # -> 0 / 0
+```
+
+Post-merge verification — both search-sheet accessibility audits:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
+  -project vreader.xcodeproj -scheme vreader \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:vreaderUITests/SearchSheetPlaceholderTests/testSearchSheetAccessibilityAudit \
+  -only-testing:vreaderUITests/GlobalAccessibilityAuditTests/testSearchSheetAudit
+# -> GlobalAccessibilityAuditTests testSearchSheetAudit            passed (14.281s)
+# -> SearchSheetPlaceholderTests testSearchSheetAccessibilityAudit passed  (9.938s)
+# -> Executed 2 tests, with 0 failures (0 unexpected)
+# -> ** TEST SUCCEEDED **
+```
+
+During the pre-merge gate, `testSearchSheetAccessibilityAudit` was
+also run 3/3 green and `testSearchSheetAudit` 3/3 green (iPhone 17
+Pro Simulator, iOS 26.5) to confirm determinism after the
+keyboard-chrome fix.
+
+## Observations
+
+- With the `.hitRegion` exclusion dropped, both search-sheet audits
+  initially flapped — not on the SearchBar, but on the system
+  software keyboard. The `SearchBar` auto-focuses its field, raising
+  the keyboard, and `performAccessibilityAudit` audits the **whole
+  app**, catching the keyboard's QuickType / predictive-text bar
+  (`TUIPredictionViewCell`, "missing useful accessibility
+  information") — an Apple keyboard-internal gap, not app-fixable.
+  Instrumented capture pinned the offending element frame at
+  `(0, 539, 134, 44)` vs. the keyboard frame `(0, 583, 402, 233)` —
+  the QuickType strip sits flush **above** `app.keyboards`' own
+  frame, so strict containment misses it.
+- The fix added an additive `ignoringKeyboardElements` option to
+  `auditCurrentScreen` with an `isSystemKeyboardChrome` vertical-band
+  classifier. After it, both audits pass deterministically (3/3 each
+  pre-merge, 1/1 post-merge in the combined run). The `.hitRegion`
+  check still fully covers the SearchBar controls — they sit near
+  the top of the sheet, far above the keyboard band, so a real
+  sub-44 pt SearchBar element would still fail.
+- The simulator's Accessibility subsystem is sensitive to repeated
+  test churn — a `Timed out waiting for AX loaded notification`
+  required a fresh `simctl boot` before the audit could run. Future
+  audit verifications should boot a clean simulator first.
+
+## Discovered separately (not part of this fix)
+
+- **`searchClearButton`** — the `xmark.circle.fill` clear button
+  shown only in the non-empty-query state — is also a sub-44 pt
+  touch target. Distinct sibling defect, out of #902's named scope
+  (#902's `performAccessibilityAudit` issue dump named only
+  `searchTextField` + `searchCancelButton`). To be filed as its own
+  bug. The current audit tests exercise the empty-query state, so
+  they do not reach it.
+- **Bug #225 / GH #910** — `TTSServiceSpeedControlTests` reliably
+  crashes the full `-only-testing:vreaderTests` run with a
+  stack-overflow (`TTSService.rate` `didSet` recursion). Pre-existing
+  on `origin/main`, unrelated to #902; skipped during this PR's unit
+  gate to isolate the fix.
+
+## Artifacts
+
+- `.xcresult` bundles under
+  `~/Library/Developer/Xcode/DerivedData/vreader-*/Logs/Test/` from
+  the verification run (transient).
+- Pre-merge diagnostic captures: instrumented `AUDIT_DEBUG` log lines
+  pinned the QuickType element frame; the audit's "Element
+  Screenshot" / "App Screenshot" attachments confirmed the search
+  bar renders correctly with no visible delta.


### PR DESCRIPTION
## Summary

Post-merge verification evidence for Bug #224 / GH #902 (SearchBar 44pt touch-target fix, shipped in PR #920 / v3.34.5).

`testSearchSheetAccessibilityAudit` and `testSearchSheetAudit` both pass on the merged `main` build (commit `49588a6`) with `.hitRegion` active — a deterministic high-fidelity check that the `searchTextField` and `searchCancelButton` touch targets meet the 44pt HIG minimum.

## What Changed

- Adds `dev-docs/verification/bug-902-20260519.md` — verification evidence file per `dev-docs/verification/SCHEMA.md`.

Refs #902

## Type of Change

- [x] Docs (verification evidence — `dev-docs/verification/*`, dev-only artifact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)