### PR TITLE
feat(#55 WI-3): NotePreviewViewModel — out-of-order-safe tap-to-note view model

### DIFF
--- a/.claude/codex-audits/feat-feature-55-wi-3-note-preview-viewmodel-audit.md
+++ b/.claude/codex-audits/feat-feature-55-wi-3-note-preview-viewmodel-audit.md
@@ -1,0 +1,56 @@
+---
+branch: feat/feature-55-wi-3-note-preview-viewmodel
+threadId: 019e3eb6-6e89-7481-801e-1b7d12b3bf17
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+# Codex Audit — feature #55 WI-3 (NotePreviewViewModel)
+
+## Scope
+
+Files changed:
+- `vreader/ViewModels/NotePreviewViewModel.swift` (new, 89 LOC) — `@Observable @MainActor` view model
+- `vreaderTests/ViewModels/NotePreviewViewModelTests.swift` (new) — Swift Testing tests with a gated mock `HighlightLookup`
+- `vreader.xcodeproj/project.pbxproj` — xcodegen regen
+
+## Round 1
+
+Codex thread `019e3eb6-6e89-7481-801e-1b7d12b3bf17`, sandbox `read-only`.
+
+| file:line | severity | issue | resolution |
+|---|---|---|---|
+| NotePreviewViewModelTests.swift | Medium | The out-of-order guard was proven on the success path only — not on the throw / nil early-return branches. A regression that cleared `presented` before the stale-token check in `catch` or the nil path would still pass. | **Fixed** — added two gated race tests: `handleTap_outOfOrder_olderThrowingLookupDoesNotClearNewer()` and `handleTap_outOfOrder_olderNilLookupDoesNotClearNewer()`. The mock gained `armFirstCallGate(throwsOnRelease:)` so the gated first call can throw on release. Both assert the newer tap's card survives. |
+| NotePreviewViewModelTests.swift | Low | The mock ignored `forBookWithKey`, so `bookFingerprintKey` forwarding was untested — a meaningful coverage gap given book-scoping prevents cross-book leakage. | **Fixed** — the mock gained `expectedKey` / `requireKey(_:)` / `receivedKeys`. New test `handleTap_forwardsBookFingerprintKeyToLookup()` asserts the positive case (record surfaces + `receivedKeys.last`) and the negative case (a wrong-book view model gets nil). |
+
+Implementation itself: auditor confirmed the monotonic-token guard is correct
+(tap A token 1, tap B token 2 — B publishes, A on resume fails the guard and
+cannot overwrite B; the `catch` clears only when the token is still latest);
+the `@MainActor` story is correct (`&+=` + capture with no intervening await,
+the equality check detects mutation during the suspension; `&+=` wrap
+acceptable; `any HighlightLookup` storage fine since the protocol is
+`Sendable`); `dismiss()` bumping the token is sufficient against the
+in-flight-resurrect race. No Critical/High at any point.
+
+## Round 2
+
+Same thread — verification of the round-1 test additions.
+
+| file:line | severity | issue |
+|---|---|---|
+| — | — | No findings — Critical / High / Medium / Low all clear |
+
+Auditor confirmed: the two new gated race tests are deterministic (same
+gated-continuation mechanism as the success-path test) and genuinely exercise
+the stale-token guard on the throw and nil early-return branches; the mock's
+`firstCallThrows` / `throwAfterGate` handling has no double-resume or
+leaked-continuation bug (`throwAfterGate` is copied to a local before
+suspension; both continuations are resumed at most once and nulled
+immediately); the key-forwarding test proves forwarding via both the positive
+and negative cases. Verdict: "the round-1 fixes are adequate."
+
+## Verdict
+
+**ship-as-is** — 2 rounds. Round 1: 1 Medium + 1 Low (both test-coverage gaps,
+implementation was already correct), both fixed. Round 2: zero findings.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 494
-        MARKETING_VERSION: 3.34.7
+        CURRENT_PROJECT_VERSION: 495
+        MARKETING_VERSION: 3.34.8
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		11B285AD42721118145AE416 /* SearchResultHighlightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8FC6D57843EAC26DB980D3 /* SearchResultHighlightTests.swift */; };
 		11B8725D271BA1A6E934FE7E /* Feature21PaginatedModeVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E1C8AE0369E1F8B43876A5F /* Feature21PaginatedModeVerificationTests.swift */; };
 		11F1D99E4B3412CE344A4F16 /* ReaderTypographyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269FC4F03B9C8640776D702F /* ReaderTypographyTests.swift */; };
+		11F6E86C1A0119FD5DF17AFD /* NotePreviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FE836F3F86B2666BF00B8E3 /* NotePreviewViewModelTests.swift */; };
 		125813F7383D3CDDC7CED668 /* MDFileLoaderRenderConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0512E109135C8C9B111A12 /* MDFileLoaderRenderConfigTests.swift */; };
 		129358092754DD095B2008B2 /* MockTXTService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3D8B3D17D6551C053F12355 /* MockTXTService.swift */; };
 		12CA8217100DE141AA68CCBA /* NotePreviewPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C60E543D08704FD376F94623 /* NotePreviewPresenterTests.swift */; };
@@ -748,6 +749,7 @@
 		B43AA88511EE1FDB4E5D0565 /* AISummaryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BEF8E9F5CAD4246490C06D /* AISummaryCard.swift */; };
 		B463893D3C3558483F25BDCF /* AISettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0C783DCFD9CFDD8F488F80 /* AISettingsViewModel.swift */; };
 		B47FA1294B60A0652B9F0BCA /* FoliateReaderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E141EA554A8E0C1C3B36250 /* FoliateReaderViewModelTests.swift */; };
+		B4F810E90E92E0C3FEA06319 /* NotePreviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CAFBF5F34C37595CC8353BC /* NotePreviewViewModel.swift */; };
 		B5114E58420F95EFB408CA82 /* ReaderSettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A86CD6BD10792F5107FFB5A /* ReaderSettingsStoreTests.swift */; };
 		B5EED69421D1469D01B8C392 /* ReaderSettingsPanelTapZonesGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0024CBCAE4AC02A47B58AE48 /* ReaderSettingsPanelTapZonesGateTests.swift */; };
 		B5FEE27BBCF7231BC8F25242 /* MDReplacementRuleFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9EF707655DE949BB9C51A96 /* MDReplacementRuleFetcherTests.swift */; };
@@ -1365,6 +1367,7 @@
 		4BD56854A37D8EA2B318B926 /* HighlightDedupeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightDedupeTests.swift; sourceTree = "<group>"; };
 		4C19E96D5AE40D3577255C38 /* TXTChapterHighlightHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterHighlightHelperTests.swift; sourceTree = "<group>"; };
 		4C87C165AFE78571456C14D1 /* LocatorValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorValidationTests.swift; sourceTree = "<group>"; };
+		4CAFBF5F34C37595CC8353BC /* NotePreviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotePreviewViewModel.swift; sourceTree = "<group>"; };
 		4CC7EBBBE07E87F07CC0FE4F /* ReaderNotificationHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderNotificationHandlerTests.swift; sourceTree = "<group>"; };
 		4D4E5558CB75432C026267C1 /* LibraryBookItemFileStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryBookItemFileStateTests.swift; sourceTree = "<group>"; };
 		4D5CDE195E585067DE4D6124 /* AnnotationListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationListViewModelTests.swift; sourceTree = "<group>"; };
@@ -1575,6 +1578,7 @@
 		7F2360F05D5C411D05806514 /* ReaderThemeV2EPUBCSSChapterStartTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeV2EPUBCSSChapterStartTests.swift; sourceTree = "<group>"; };
 		7F71E759F980473A403CC70B /* TXTReaderContainerSearchHighlightWiringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReaderContainerSearchHighlightWiringTests.swift; sourceTree = "<group>"; };
 		7FC8555E3C352A0C95D6BFE9 /* LocatorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorFactory.swift; sourceTree = "<group>"; };
+		7FE836F3F86B2666BF00B8E3 /* NotePreviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotePreviewViewModelTests.swift; sourceTree = "<group>"; };
 		800ED346D9C0E17741704040 /* WebDAVServerProfileEditSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVServerProfileEditSheet.swift; sourceTree = "<group>"; };
 		80381187837EB2DA41E98207 /* ReaderThemeV2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeV2Tests.swift; sourceTree = "<group>"; };
 		8045B5C97D76DA514B27B577 /* ReplacementTransformTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplacementTransformTests.swift; sourceTree = "<group>"; };
@@ -2381,6 +2385,7 @@
 				3B1563E77E28434568F45736 /* LibraryViewModelTests.swift */,
 				82D271B91E1F8A6374667C5E /* MDReaderViewModelChapterStartTests.swift */,
 				513AE679E0A5DBFFBB0AF6BD /* MDReaderViewModelTests.swift */,
+				7FE836F3F86B2666BF00B8E3 /* NotePreviewViewModelTests.swift */,
 				5D7F4F4B985D58E03A78680D /* PDFReaderViewModelTests.swift */,
 				576F111E93E863C656BDEC70 /* SearchViewModelTests.swift */,
 				55633F1E05B29D20C4A4D0D5 /* TXTReaderPositionBackCompatTests.swift */,
@@ -3171,6 +3176,7 @@
 				7118F4AADFF2F866BAE6E377 /* HighlightTapAction.swift */,
 				CF473C04CE58CE0887DAA5A1 /* LibraryViewModel.swift */,
 				68BB90FF5CA185660AAE66BD /* MDReaderViewModel.swift */,
+				4CAFBF5F34C37595CC8353BC /* NotePreviewViewModel.swift */,
 				43D54AC9AD2556A67C96BD52 /* PDFReaderViewModel.swift */,
 				D363190FCDF47ED48A1D7BC1 /* ReaderLifecycleHelper.swift */,
 				864A1B050775A46ADBE3304F /* SearchViewModel.swift */,
@@ -4428,6 +4434,7 @@
 				036A7AA1F02D9219384C777A /* NativeTextPagedIntegrationTests.swift in Sources */,
 				4C5F7C805D7702035CEA5837 /* NativeTextPaginatorTests.swift in Sources */,
 				12CA8217100DE141AA68CCBA /* NotePreviewPresenterTests.swift in Sources */,
+				11F6E86C1A0119FD5DF17AFD /* NotePreviewViewModelTests.swift in Sources */,
 				32C58BAAF2DB529049921D4D /* OPDSParserTests.swift in Sources */,
 				CBF9C34C3E23A55FD82B726D /* PDFAnnotationBridgeTests.swift in Sources */,
 				ED9650F4A937ED6D04E2E416 /* PDFHighlightIntegrationTests.swift in Sources */,
@@ -4900,6 +4907,7 @@
 				2C05C1DC5E7C1B7C7B438C2B /* NoOpSessionStore.swift in Sources */,
 				ECA40D1E20A09D8AA9EB9AFC /* NotePreviewContent.swift in Sources */,
 				F438EA662DB1DF32BC7C88AF /* NotePreviewPresenter.swift in Sources */,
+				B4F810E90E92E0C3FEA06319 /* NotePreviewViewModel.swift in Sources */,
 				99B6840F5C6B54842C465F64 /* OPDSBrowserView.swift in Sources */,
 				07827134E24965F0D27435AC /* OPDSCatalogListView.swift in Sources */,
 				2051294D05C42778582C8172 /* OPDSClient.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5286,13 +5286,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 494;
+				CURRENT_PROJECT_VERSION = 495;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.34.7;
+				MARKETING_VERSION = 3.34.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5436,13 +5436,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 494;
+				CURRENT_PROJECT_VERSION = 495;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.34.7;
+				MARKETING_VERSION = 3.34.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/ViewModels/NotePreviewViewModel.swift
+++ b/vreader/ViewModels/NotePreviewViewModel.swift
@@ -1,0 +1,89 @@
+// Purpose: Feature #55 WI-3 — `NotePreviewViewModel`, the view model behind
+// the tap-on-annotated-text note preview. Consumes a `.readerHighlightTapped`
+// event, looks the tapped highlight up via `HighlightLookup`, and publishes
+// the `NotePreviewContent` a preview surface (`NoteCallout` / `NotePreviewSheet`)
+// renders.
+//
+// Key decisions:
+// - `@Observable @MainActor` — the codebase convention for reader-side view
+//   models (`HighlightListViewModel`, `LibraryViewModel`).
+// - Persistence is the `HighlightLookup` boundary protocol, not a concrete
+//   actor, so the view model is unit-testable with a mock.
+// - `handleTap` is `async` and crosses the `PersistenceActor` boundary. Two
+//   rapid taps can have their lookups finish out of order. A monotonic
+//   `latestTapToken` guards this: `handleTap` captures the token before the
+//   `await` and publishes `presented` only if the captured token is still the
+//   latest afterward — so the newest tap always wins, and an older slow
+//   lookup is silently discarded. `dismiss()` bumps the token too, so a
+//   lookup that was in flight when the user dismissed cannot resurrect a card.
+// - A deleted-race (the highlight was removed between paint and tap) resolves
+//   to `nil` and is a no-op — `presented` stays clear.
+//
+// @coordinates-with: HighlightLookup.swift, NotePreviewContent.swift,
+//   NotePreviewPresenter.swift, ReaderNotifications.swift (ReaderHighlightTapEvent)
+
+import Foundation
+import OSLog
+
+/// View model for the tap-on-annotated-text note preview.
+@Observable
+@MainActor
+final class NotePreviewViewModel {
+
+    /// The note-preview content currently presented, or `nil` when nothing is
+    /// shown. A preview surface observes this to mount/dismiss itself.
+    private(set) var presented: NotePreviewContent?
+
+    private let persistence: any HighlightLookup
+    private let bookFingerprintKey: String
+    private let log = Logger(subsystem: "com.vreader.app", category: "NotePreview")
+
+    /// Monotonic tap token. Incremented on every `handleTap` and every
+    /// `dismiss`. A `handleTap` publishes its result only if the token it
+    /// captured before its `await` is still the latest — guards out-of-order
+    /// async lookups so the newest tap always wins.
+    private var latestTapToken: UInt64 = 0
+
+    init(persistence: any HighlightLookup, bookFingerprintKey: String) {
+        self.persistence = persistence
+        self.bookFingerprintKey = bookFingerprintKey
+    }
+
+    /// Handles a `.readerHighlightTapped` event: looks up the tapped highlight
+    /// and publishes its note-preview content. Out-of-order safe — only the
+    /// newest tap's result is published.
+    func handleTap(_ event: ReaderHighlightTapEvent) async {
+        latestTapToken &+= 1
+        let myToken = latestTapToken
+
+        let record: HighlightRecord?
+        do {
+            record = try await persistence.highlight(
+                withID: event.highlightID, forBookWithKey: bookFingerprintKey
+            )
+        } catch {
+            log.error("highlight lookup failed: \(String(describing: error), privacy: .public)")
+            // A failed lookup behaves like a not-found: only clear if this is
+            // still the latest tap, so it can't wipe a newer tap's result.
+            if myToken == latestTapToken { presented = nil }
+            return
+        }
+
+        // A newer tap (or a dismiss) superseded this one — discard the result.
+        guard myToken == latestTapToken else { return }
+
+        guard let record else {
+            // Deleted-race: the highlight was removed between paint and tap.
+            presented = nil
+            return
+        }
+        presented = NotePreviewPresenter.content(for: record, sourceRect: event.sourceRect)
+    }
+
+    /// Dismisses the preview. Bumps the tap token so a lookup that is still in
+    /// flight cannot resurrect a card after the user dismissed.
+    func dismiss() {
+        latestTapToken &+= 1
+        presented = nil
+    }
+}

--- a/vreaderTests/ViewModels/NotePreviewViewModelTests.swift
+++ b/vreaderTests/ViewModels/NotePreviewViewModelTests.swift
@@ -1,0 +1,227 @@
+// Purpose: Tests for feature #55 WI-3 — `NotePreviewViewModel`, the
+// `@Observable @MainActor` view model that consumes a `.readerHighlightTapped`
+// event, looks the tapped highlight up via `HighlightLookup`, and publishes
+// `NotePreviewContent` for the preview surfaces.
+//
+// Covers: handleTap with a found highlight publishes content; an unknown id
+// leaves `presented` nil (deleted-race no-op); a throwing lookup does not
+// crash; `dismiss` clears; the monotonic-tap-token out-of-order guard — a
+// slow older lookup must NOT overwrite a newer tap's result; a tap after a
+// dismiss does not resurrect a card.
+
+import Testing
+import Foundation
+import CoreGraphics
+@testable import vreader
+
+// MARK: - Mock HighlightLookup
+
+/// A `HighlightLookup` mock whose `highlight(withID:forBookWithKey:)` resolves
+/// from a seeded table. Optionally gates the FIRST lookup behind a continuation
+/// so the out-of-order test can hold an older tap mid-flight while a newer tap
+/// completes — and can throw on demand.
+private actor MockHighlightLookup: HighlightLookup {
+    private var byID: [UUID: HighlightRecord] = [:]
+    private var shouldThrow = false
+
+    /// When set, the FIRST `highlight(...)` call awaits this gate before
+    /// returning. Used to force out-of-order completion deterministically.
+    private var firstCallGate: CheckedContinuation<Void, Never>?
+    private var firstCallArmed = false
+    private var firstCallSeen = false
+    private var firstCallWaiter: CheckedContinuation<Void, Never>?
+
+    func seed(_ record: HighlightRecord) {
+        byID[record.highlightId] = record
+    }
+
+    func setThrowing(_ value: Bool) {
+        shouldThrow = value
+    }
+
+    /// Arm the first-call gate. The first `highlight(...)` call will block
+    /// until `releaseFirstCall()` is invoked.
+    func armFirstCallGate() {
+        firstCallArmed = true
+    }
+
+    /// Resume the gated first call.
+    func releaseFirstCall() {
+        firstCallGate?.resume()
+        firstCallGate = nil
+    }
+
+    /// Suspends until the first gated call has actually entered `highlight(...)`.
+    func awaitFirstCallEntered() async {
+        if firstCallSeen { return }
+        await withCheckedContinuation { firstCallWaiter = $0 }
+    }
+
+    func highlight(withID id: UUID, forBookWithKey key: String) async throws -> HighlightRecord? {
+        if firstCallArmed {
+            firstCallArmed = false
+            firstCallSeen = true
+            firstCallWaiter?.resume()
+            firstCallWaiter = nil
+            await withCheckedContinuation { firstCallGate = $0 }
+        }
+        if shouldThrow { throw NSError(domain: "test", code: 1) }
+        return byID[id]
+    }
+}
+
+// MARK: - Helpers
+
+@MainActor
+private func makeRecord(
+    id: UUID = UUID(),
+    note: String?,
+    color: String = "yellow",
+    fp: DocumentFingerprint
+) -> HighlightRecord {
+    let locator = Locator(
+        bookFingerprint: fp,
+        href: "ch1.xhtml", progression: 0.5, totalProgression: nil,
+        cfi: "/6/4", page: nil,
+        charOffsetUTF16: nil, charRangeStartUTF16: nil, charRangeEndUTF16: nil,
+        textQuote: nil, textContextBefore: nil, textContextAfter: nil
+    )
+    return HighlightRecord(
+        highlightId: id, locator: locator, anchor: nil, profileKey: "key",
+        selectedText: "the passage", color: color, note: note,
+        createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+        updatedAt: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+}
+
+private let testFP = DocumentFingerprint(
+    contentSHA256: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+    fileByteCount: 1024, format: .epub
+)
+
+private func tapEvent(for id: UUID, rect: CGRect = CGRect(x: 1, y: 2, width: 30, height: 14))
+    -> ReaderHighlightTapEvent {
+    ReaderHighlightTapEvent(highlightID: id, sourceRect: rect)
+}
+
+// MARK: - Tests
+
+@Suite("NotePreviewViewModel")
+@MainActor
+struct NotePreviewViewModelTests {
+
+    @Test func handleTap_foundHighlight_publishesContent() async {
+        let lookup = MockHighlightLookup()
+        let record = makeRecord(note: "my note body", fp: testFP)
+        await lookup.seed(record)
+
+        let vm = NotePreviewViewModel(persistence: lookup, bookFingerprintKey: "book-1")
+        await vm.handleTap(tapEvent(for: record.highlightId))
+
+        #expect(vm.presented?.id == record.highlightId)
+        #expect(vm.presented?.note == "my note body")
+        #expect(vm.presented?.isEmpty == false)
+    }
+
+    @Test func handleTap_noteNilHighlight_publishesEmptyContent() async {
+        let lookup = MockHighlightLookup()
+        let record = makeRecord(note: nil, fp: testFP)
+        await lookup.seed(record)
+
+        let vm = NotePreviewViewModel(persistence: lookup, bookFingerprintKey: "book-1")
+        await vm.handleTap(tapEvent(for: record.highlightId))
+
+        // A note-less highlight still acknowledges the tap — the empty state.
+        #expect(vm.presented?.id == record.highlightId)
+        #expect(vm.presented?.isEmpty == true)
+    }
+
+    @Test func handleTap_unknownID_leavesPresentedNil() async {
+        let lookup = MockHighlightLookup()  // nothing seeded
+        let vm = NotePreviewViewModel(persistence: lookup, bookFingerprintKey: "book-1")
+        await vm.handleTap(tapEvent(for: UUID()))
+        #expect(vm.presented == nil)
+    }
+
+    @Test func handleTap_lookupThrows_doesNotCrashAndPresentedNil() async {
+        let lookup = MockHighlightLookup()
+        await lookup.setThrowing(true)
+        let vm = NotePreviewViewModel(persistence: lookup, bookFingerprintKey: "book-1")
+        await vm.handleTap(tapEvent(for: UUID()))
+        #expect(vm.presented == nil)
+    }
+
+    @Test func dismiss_clearsPresented() async {
+        let lookup = MockHighlightLookup()
+        let record = makeRecord(note: "note", fp: testFP)
+        await lookup.seed(record)
+        let vm = NotePreviewViewModel(persistence: lookup, bookFingerprintKey: "book-1")
+        await vm.handleTap(tapEvent(for: record.highlightId))
+        #expect(vm.presented != nil)
+
+        vm.dismiss()
+        #expect(vm.presented == nil)
+    }
+
+    @Test func handleTap_secondTap_replacesFirst() async {
+        let lookup = MockHighlightLookup()
+        let first = makeRecord(note: "first note", fp: testFP)
+        let second = makeRecord(note: "second note", fp: testFP)
+        await lookup.seed(first)
+        await lookup.seed(second)
+        let vm = NotePreviewViewModel(persistence: lookup, bookFingerprintKey: "book-1")
+
+        await vm.handleTap(tapEvent(for: first.highlightId))
+        #expect(vm.presented?.id == first.highlightId)
+        await vm.handleTap(tapEvent(for: second.highlightId))
+        #expect(vm.presented?.id == second.highlightId)
+    }
+
+    /// The core out-of-order guard: an OLDER tap whose lookup is slow must NOT
+    /// overwrite a NEWER tap's already-published result.
+    @Test func handleTap_outOfOrder_olderSlowLookupDoesNotOverwriteNewer() async {
+        let lookup = MockHighlightLookup()
+        let older = makeRecord(note: "OLD note", fp: testFP)
+        let newer = makeRecord(note: "NEW note", fp: testFP)
+        await lookup.seed(older)
+        await lookup.seed(newer)
+        let vm = NotePreviewViewModel(persistence: lookup, bookFingerprintKey: "book-1")
+
+        // Arm the gate so the FIRST lookup (the older tap) blocks mid-flight.
+        await lookup.armFirstCallGate()
+        let olderTask = Task { await vm.handleTap(tapEvent(for: older.highlightId)) }
+        await lookup.awaitFirstCallEntered()  // older tap is now suspended in the lookup
+
+        // The newer tap runs to completion while the older is parked.
+        await vm.handleTap(tapEvent(for: newer.highlightId))
+        #expect(vm.presented?.id == newer.highlightId)
+
+        // Release the older tap — its result must be discarded (token stale).
+        await lookup.releaseFirstCall()
+        await olderTask.value
+
+        #expect(vm.presented?.id == newer.highlightId)
+        #expect(vm.presented?.note == "NEW note")
+    }
+
+    /// A `handleTap` whose lookup is in flight when `dismiss()` is called must
+    /// not resurrect a card after the dismiss.
+    @Test func handleTap_inFlightThenDismiss_doesNotResurrect() async {
+        let lookup = MockHighlightLookup()
+        let record = makeRecord(note: "should not appear", fp: testFP)
+        await lookup.seed(record)
+        let vm = NotePreviewViewModel(persistence: lookup, bookFingerprintKey: "book-1")
+
+        await lookup.armFirstCallGate()
+        let tapTask = Task { await vm.handleTap(tapEvent(for: record.highlightId)) }
+        await lookup.awaitFirstCallEntered()
+
+        // Dismiss while the lookup is parked.
+        vm.dismiss()
+        // Release the parked lookup — it must NOT publish (token bumped by dismiss).
+        await lookup.releaseFirstCall()
+        await tapTask.value
+
+        #expect(vm.presented == nil)
+    }
+}

--- a/vreaderTests/ViewModels/NotePreviewViewModelTests.swift
+++ b/vreaderTests/ViewModels/NotePreviewViewModelTests.swift
@@ -24,12 +24,22 @@ private actor MockHighlightLookup: HighlightLookup {
     private var byID: [UUID: HighlightRecord] = [:]
     private var shouldThrow = false
 
+    /// When non-nil, every `highlight(...)` call only returns a seeded record
+    /// if the received `forBookWithKey` equals this — otherwise returns nil.
+    /// Lets a test prove the view model forwards its `bookFingerprintKey`.
+    private var expectedKey: String?
+    /// Every `forBookWithKey` value the view model passed, in call order.
+    private(set) var receivedKeys: [String] = []
+
     /// When set, the FIRST `highlight(...)` call awaits this gate before
     /// returning. Used to force out-of-order completion deterministically.
     private var firstCallGate: CheckedContinuation<Void, Never>?
     private var firstCallArmed = false
     private var firstCallSeen = false
     private var firstCallWaiter: CheckedContinuation<Void, Never>?
+    /// When true, the gated first call throws after being released — lets the
+    /// out-of-order tests exercise the stale-token guard on the throw path.
+    private var firstCallThrows = false
 
     func seed(_ record: HighlightRecord) {
         byID[record.highlightId] = record
@@ -39,10 +49,17 @@ private actor MockHighlightLookup: HighlightLookup {
         shouldThrow = value
     }
 
+    /// Require every lookup to receive exactly `key` as `forBookWithKey`.
+    func requireKey(_ key: String) {
+        expectedKey = key
+    }
+
     /// Arm the first-call gate. The first `highlight(...)` call will block
-    /// until `releaseFirstCall()` is invoked.
-    func armFirstCallGate() {
+    /// until `releaseFirstCall()` is invoked. When `throwsOnRelease` is true,
+    /// that gated call throws after release; otherwise it returns normally.
+    func armFirstCallGate(throwsOnRelease: Bool = false) {
         firstCallArmed = true
+        firstCallThrows = throwsOnRelease
     }
 
     /// Resume the gated first call.
@@ -58,14 +75,18 @@ private actor MockHighlightLookup: HighlightLookup {
     }
 
     func highlight(withID id: UUID, forBookWithKey key: String) async throws -> HighlightRecord? {
+        receivedKeys.append(key)
+        var throwAfterGate = false
         if firstCallArmed {
             firstCallArmed = false
             firstCallSeen = true
+            throwAfterGate = firstCallThrows
             firstCallWaiter?.resume()
             firstCallWaiter = nil
             await withCheckedContinuation { firstCallGate = $0 }
         }
-        if shouldThrow { throw NSError(domain: "test", code: 1) }
+        if throwAfterGate || shouldThrow { throw NSError(domain: "test", code: 1) }
+        if let expectedKey, key != expectedKey { return nil }
         return byID[id]
     }
 }
@@ -202,6 +223,78 @@ struct NotePreviewViewModelTests {
 
         #expect(vm.presented?.id == newer.highlightId)
         #expect(vm.presented?.note == "NEW note")
+    }
+
+    /// Stale-token guard on the THROW early-return path: an older tap whose
+    /// gated lookup THROWS after a newer tap published must not clear the
+    /// newer tap's result.
+    @Test func handleTap_outOfOrder_olderThrowingLookupDoesNotClearNewer() async {
+        let lookup = MockHighlightLookup()
+        let newer = makeRecord(note: "NEW note", fp: testFP)
+        await lookup.seed(newer)
+        let vm = NotePreviewViewModel(persistence: lookup, bookFingerprintKey: "book-1")
+
+        // Older tap's lookup is gated AND will throw on release.
+        await lookup.armFirstCallGate(throwsOnRelease: true)
+        let olderTask = Task { await vm.handleTap(tapEvent(for: UUID())) }
+        await lookup.awaitFirstCallEntered()
+
+        // Newer tap completes and publishes.
+        await vm.handleTap(tapEvent(for: newer.highlightId))
+        #expect(vm.presented?.id == newer.highlightId)
+
+        // Release the older tap — its lookup throws; the stale-token check in
+        // `catch` must stop it from clearing the newer card.
+        await lookup.releaseFirstCall()
+        await olderTask.value
+        #expect(vm.presented?.id == newer.highlightId)
+    }
+
+    /// Stale-token guard on the NIL early-return path: an older tap whose
+    /// gated lookup resolves to `nil` (deleted race) after a newer tap
+    /// published must not clear the newer tap's result.
+    @Test func handleTap_outOfOrder_olderNilLookupDoesNotClearNewer() async {
+        let lookup = MockHighlightLookup()
+        let newer = makeRecord(note: "NEW note", fp: testFP)
+        await lookup.seed(newer)
+        let vm = NotePreviewViewModel(persistence: lookup, bookFingerprintKey: "book-1")
+
+        // Older tap targets an UNSEEDED id → its gated lookup returns nil.
+        await lookup.armFirstCallGate()
+        let olderTask = Task { await vm.handleTap(tapEvent(for: UUID())) }
+        await lookup.awaitFirstCallEntered()
+
+        await vm.handleTap(tapEvent(for: newer.highlightId))
+        #expect(vm.presented?.id == newer.highlightId)
+
+        await lookup.releaseFirstCall()
+        await olderTask.value
+        #expect(vm.presented?.id == newer.highlightId)
+    }
+
+    /// The view model must forward its `bookFingerprintKey` into the lookup —
+    /// the scoping that prevents a tap from surfacing another book's highlight.
+    @Test func handleTap_forwardsBookFingerprintKeyToLookup() async {
+        let lookup = MockHighlightLookup()
+        let record = makeRecord(note: "scoped note", fp: testFP)
+        await lookup.seed(record)
+        // The mock only returns the record when the RIGHT key is passed.
+        await lookup.requireKey("the-open-book")
+
+        let rightVM = NotePreviewViewModel(
+            persistence: lookup, bookFingerprintKey: "the-open-book"
+        )
+        await rightVM.handleTap(tapEvent(for: record.highlightId))
+        #expect(rightVM.presented?.id == record.highlightId)
+        let keys = await lookup.receivedKeys
+        #expect(keys.last == "the-open-book")
+
+        // A view model scoped to a DIFFERENT book must not surface it.
+        let wrongVM = NotePreviewViewModel(
+            persistence: lookup, bookFingerprintKey: "some-other-book"
+        )
+        await wrongVM.handleTap(tapEvent(for: record.highlightId))
+        #expect(wrongVM.presented == nil)
     }
 
     /// A `handleTap` whose lookup is in flight when `dismiss()` is called must


### PR DESCRIPTION
## Summary

- Adds `NotePreviewViewModel`, the `@Observable @MainActor` view model behind feature #55's tap-on-annotated-text note preview.
- No user-observable behavior — foundational tier (no view consumes it until WI-5 wires the presenter).

Part of feature #619.

## What Changed

- `NotePreviewViewModel` (`vreader/ViewModels/NotePreviewViewModel.swift`):
  - `handleTap(_ event: ReaderHighlightTapEvent) async` — looks the tapped highlight up via the WI-1 `HighlightLookup` boundary protocol and publishes `NotePreviewContent` via `NotePreviewPresenter`.
  - **Out-of-order guard** (plan §2.2.1, risk R-8): `handleTap` is async and crosses the `PersistenceActor` boundary; two rapid taps can finish out of order. A monotonic `latestTapToken` is incremented per tap, captured before the `await`, and the result is published only if the captured token is still latest — so the newest tap always wins and an older slow lookup is discarded. The guard holds on the throw and nil early-return paths too.
  - `dismiss()` bumps the token, so a lookup in flight when the user dismisses cannot resurrect a card.
  - A deleted-race (highlight removed between paint and tap) and a throwing lookup both resolve to a no-op.

## WI Status

- WI-3: foundational — this PR.
- WI-1 (types), WI-2 (persistence lookup): merged.
- Remaining: WI-4/5 (callout + sheet views + UIKit rect-anchored presenter), WI-6 (TXT/MD/PDF wiring), WI-7 (EPUB/Foliate wiring — final WI).

## Codex Audit (Gate 4)

Codex thread `019e3eb6-6e89-7481-801e-1b7d12b3bf17`, **2 rounds**, **ship-as-is**.
- Round 1: 1 Medium + 1 Low — both test-coverage gaps (the implementation was already correct). Fixed: added two gated race tests for the stale-token guard on the throw and nil early-return branches, and made the mock validate `bookFingerprintKey` (with a positive + negative forwarding test).
- Round 2: zero findings — "the round-1 fixes are adequate". Auditor confirmed the monotonic-token guard is correct, the `@MainActor` story is sound (`&+=` + capture with no intervening await), `dismiss()` token-bump prevents the resurrect race, and the gated mock deterministically forces out-of-order completion.

Audit log: `.claude/codex-audits/feat-feature-55-wi-3-note-preview-viewmodel-audit.md`

## Validation

- [x] `NotePreviewViewModelTests` — 11 tests, pass in isolation (`TEST SUCCEEDED`): found/empty-note/unknown-id/throwing-lookup/dismiss/second-tap-replace, the out-of-order guard (success + throw + nil branches), in-flight-then-dismiss, and `bookFingerprintKey` forwarding.
- [x] Tests cover changed behavior (TDD: RED → GREEN → REFACTOR).
- [x] Codex audit loop completed (2 rounds, verdict: ship-as-is).
- [x] Docs sync — n/a (foundational; `NotePreviewViewModel` is feature-#55-local, not a ≥2-feature shared ViewModel — no `architecture.md` trigger; the note-preview entry lands with the behavioral WIs).
- [x] Version bumped: 3.34.6 → 3.34.8 (build 495).

Full-suite test gate note: run on a **dedicated** simulator (`61149F0E`, separate DerivedData) to avoid contention with a concurrent agent's UI-test run. Result: **596 suites pass, 0 real `✘` test failures** — all 3 feature-#55 suites (`NotePreviewViewModel`, `NotePreviewPresenter`, `PersistenceActor — HighlightLookup`) pass explicitly. The run's exit-65 is the known **Bug #221 / issue #849** flaky test-host `signal kill` crash (active fix worktree), which collateral-flags unrun suites; it is not a real failure and WI-3 adds no test-host-affecting code.

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: foundational — unit tests + Codex audit sufficient, no device verification required.
- Run: `NotePreviewViewModelTests` (11 tests) green in isolation; smoke `xcodebuild build` succeeds at v3.34.8.

## Type of Change

- [x] Feature WI (Part of feature #619 — intermediate WI, plain prose, no `Refs`/`Fixes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)