### PR TITLE
feat(#55 WI-4): NoteCalloutView — anchored note-preview card (read-only v1)

### DIFF
--- a/.claude/codex-audits/feat-feature-55-wi-4-note-callout-view-audit.md
+++ b/.claude/codex-audits/feat-feature-55-wi-4-note-callout-view-audit.md
@@ -1,0 +1,57 @@
+---
+branch: feat/feature-55-wi-4-note-callout-view
+threadId: 019e3ed1-11ff-7c62-86ac-a8c2e2a97b88
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+# Codex Audit — feature #55 WI-4 (NoteCalloutView)
+
+## Scope
+
+Files changed:
+- `vreader/Views/Reader/NoteCalloutView.swift` (new) — SwiftUI realization of the design's `NoteCallout`
+- `vreader/Views/Reader/NoteCalloutAction.swift` (new) — the handoff-row action enum
+- `vreaderTests/Views/Reader/NoteCalloutViewTests.swift` (new) — Swift Testing contract tests
+- `vreader.xcodeproj/project.pbxproj` — xcodegen regen
+
+## Round 1
+
+Codex thread `019e3ed1-11ff-7c62-86ac-a8c2e2a97b88`, sandbox `read-only`.
+
+| file:line | severity | issue | resolution |
+|---|---|---|---|
+| NoteCalloutViewTests.swift | Medium | Swatch tests asserted only `!= .clear` — a wrong-hue regression or drift from `NamedHighlightColor.hex` would still pass. | **Fixed** — exact-hex assertions: designed colors against the committed design hex stops, red/orange/purple against intended hues + distinct-from-yellow, unknown/"" exactly the yellow fallback. Test-local `Color(testHexString:)`. |
+| NoteCalloutViewTests.swift | Medium | Empty-vs-note tests exercised only `NotePreviewContent.isEmpty`, not the view's branch. | **Fixed** — added `NoteCalloutDisplayMode` enum + `NoteCalloutView.displayMode(for:)` the `body` switches on; tests assert the decision. Added render-smoke tests hosting the view in `UIHostingController` for both states (forces `body` evaluation). |
+| NoteCalloutViewTests.swift | Low | Tautology `action != .openInPanel \|\| action == .openInPanel` in `handoffActionsAreReadOnlyHandoffs`. | **Fixed** — removed; replaced with an exact case-set assertion + a per-case no-`edit`/`delete`-rawValue check. |
+| NoteCalloutViewTests.swift | Low | Line-count tests missed whitespace/newline-only edge cases. | **Fixed** — added `noteLineCountWhitespaceOnly`: `"   "`→1, `"\n"`→0, `" \n \n "`→3. |
+
+Implementation itself: auditor confirmed "the implementation is mostly aligned
+with the plan and rule 51 — the view is read-only, there is no Edit/Delete/
+inline editing affordance, the empty state has no 'Add one…', `content.isEmpty`
+drives the branch, the six-color palette is covered, `ReaderTypography.body(...)`
+→ `Font(...)` is fine, and the duplicate `Color(hexString:)` is acceptable at
+the second call site given the existing `SelectionPopoverView` precedent." No
+Critical/High at any point, no design/rule-51 violation in the shipped view.
+
+## Round 2
+
+Same thread — verification of the round-1 fixes.
+
+| file:line | severity | issue |
+|---|---|---|
+| — | — | No findings — Critical / High / Medium / Low all clear |
+
+Auditor confirmed: the swatch tests now genuinely pin the hex contract (a
+wrong-hue regression for any of the 6 colors, or drift from the design hex
+stops, fails); the `displayMode` extraction is sound and the render-smoke
+tests force SwiftUI to build `body` for both branches; the tautology is gone;
+the whitespace line-count cases match the helper. Verdict: "WI-4 round-1
+findings are resolved."
+
+## Verdict
+
+**ship-as-is** — 2 rounds. Round 1: 2 Medium + 2 Low (all test-strength gaps,
+implementation was already correct + rule-51-compliant), all fixed. Round 2:
+zero findings.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 497
-        MARKETING_VERSION: 3.34.10
+        CURRENT_PROJECT_VERSION: 498
+        MARKETING_VERSION: 3.34.11
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -406,6 +406,7 @@
 		5FE7F04D448C49D466F641FB /* LocatorNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C20D015AD61E29BEB57DC3 /* LocatorNormalizerTests.swift */; };
 		60044E9F6E34936F312FA826 /* TXTChapterContentLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529D0FB4C5C73B62F1C8D6D6 /* TXTChapterContentLoader.swift */; };
 		602EEAD6EE0B44F25DD2939D /* ModelContainerFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA662166E4DF1BBD49084B5E /* ModelContainerFactoryTests.swift */; };
+		605EDCE3858C153A901E472A /* NoteCalloutViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14784E7ED271B5D2237CD53E /* NoteCalloutViewTests.swift */; };
 		606A7D33F0DB5643859C0863 /* WebDAVDownloadRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBDB2B2562F5761C8D52153 /* WebDAVDownloadRequestBuilder.swift */; };
 		6070A8AF12AADF388F7C1383 /* V1toV2MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 939BC09F1D771D2E22301ED3 /* V1toV2MigrationTests.swift */; };
 		60F28F11E8F15E0FFAF4922C /* LibraryBookItemFileStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4E5558CB75432C026267C1 /* LibraryBookItemFileStateTests.swift */; };
@@ -771,6 +772,7 @@
 		B9676CF3333F44711ABD70DB /* MDReaderContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B0EDE73D4EB702686B1326E /* MDReaderContainerView.swift */; };
 		B9A1742F9FE4FE7C89894642 /* ReaderSheetChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 765DA2396E1D41FEDF5652AD /* ReaderSheetChrome.swift */; };
 		B9BF611D570F7F9681FBEE6E /* BackupSectionDTOs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D6B83FC65D64C1271E28F4 /* BackupSectionDTOs.swift */; };
+		BA18656CCFD17EED6DAB15D7 /* NoteCalloutAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE92A7A9E6664A02130DF5E /* NoteCalloutAction.swift */; };
 		BA1A8C44D94E4D7AB66AF0D7 /* TestSeederMDMultiPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A53B5CE5A37514E7E7D4BEC /* TestSeederMDMultiPageTests.swift */; };
 		BA758603C760FDE615B4E6CD /* TXTTextViewBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43347208CA56C84F65B2DCF7 /* TXTTextViewBridge.swift */; };
 		BB03511CFAB402BC18C393B7 /* AIProviderPickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7196BED97C3B45955EC89D /* AIProviderPickerViewModelTests.swift */; };
@@ -945,6 +947,7 @@
 		E37CAFB8AF04456F6F0CEBA5 /* AISettingsViewModel+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C2FF255E2C0E968707942E /* AISettingsViewModel+Editor.swift */; };
 		E400E164FA809CC3AB0AC796 /* CollectionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B442FC7A6A6ED344AB5C1FC9 /* CollectionPersistenceTests.swift */; };
 		E44BC8CE480C18F6469C62DD /* WI9TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CB57338FD24289DAC8ABE4 /* WI9TestHelpers.swift */; };
+		E4A81A3F657E73B3660FD5E2 /* NoteCalloutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E6FCB2672364DC81F23020 /* NoteCalloutView.swift */; };
 		E4C963854C70662E3D59835D /* TXTChapterIndexStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0E95AA02EBAE369ABF9AE5 /* TXTChapterIndexStore.swift */; };
 		E5C970CD2DB58A81E743F7DA /* WebDAVATSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A7B601E9791FB068616C98 /* WebDAVATSTests.swift */; };
 		E648A7D0DA601378CD08D521 /* LocatorNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D86F739CC4D19AF019F728 /* LocatorNormalizer.swift */; };
@@ -1144,6 +1147,7 @@
 		14088AEC6B083B2C049AB25C /* ReaderAICoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderAICoordinator.swift; sourceTree = "<group>"; };
 		14418F18DF9D9A3B912AC090 /* SearchIndexCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchIndexCore.swift; sourceTree = "<group>"; };
 		1456DD6C03CD51C24CA8CDCF /* NamedHighlightColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamedHighlightColorTests.swift; sourceTree = "<group>"; };
+		14784E7ED271B5D2237CD53E /* NoteCalloutViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteCalloutViewTests.swift; sourceTree = "<group>"; };
 		14FC5A8465BA6BCCB0751270 /* SourceSerif4-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSerif4-Regular.otf"; sourceTree = "<group>"; };
 		151860CC8834DB8ACBF7E927 /* ZIPWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZIPWriter.swift; sourceTree = "<group>"; };
 		152689657913035E5579B762 /* CSSRuleEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSSRuleEvaluatorTests.swift; sourceTree = "<group>"; };
@@ -1367,6 +1371,7 @@
 		4B81B909B41CB8C14B613D73 /* LocatorRestorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorRestorer.swift; sourceTree = "<group>"; };
 		4BD245135256A06A28C88178 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
 		4BD56854A37D8EA2B318B926 /* HighlightDedupeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightDedupeTests.swift; sourceTree = "<group>"; };
+		4BE92A7A9E6664A02130DF5E /* NoteCalloutAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteCalloutAction.swift; sourceTree = "<group>"; };
 		4C19E96D5AE40D3577255C38 /* TXTChapterHighlightHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterHighlightHelperTests.swift; sourceTree = "<group>"; };
 		4C87C165AFE78571456C14D1 /* LocatorValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorValidationTests.swift; sourceTree = "<group>"; };
 		4CAFBF5F34C37595CC8353BC /* NotePreviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotePreviewViewModel.swift; sourceTree = "<group>"; };
@@ -1921,6 +1926,7 @@
 		D14E222357346107CB34B750 /* SmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokeTests.swift; sourceTree = "<group>"; };
 		D17013114ADB4797AB48D794 /* FoliateViewBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateViewBridge.swift; sourceTree = "<group>"; };
 		D1B00C0FE14AB02EDE7E9EDD /* SyncOutboundQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncOutboundQueueTests.swift; sourceTree = "<group>"; };
+		D1E6FCB2672364DC81F23020 /* NoteCalloutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteCalloutView.swift; sourceTree = "<group>"; };
 		D2AEB48E4BF208D97EEF397C /* QuoteRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuoteRecovery.swift; sourceTree = "<group>"; };
 		D2EA03BEFDBB65F5D7533EDE /* SchemaV1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV1Tests.swift; sourceTree = "<group>"; };
 		D31265D2F8B445FADB98DDFC /* WebDAVProfileListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProfileListViewModelTests.swift; sourceTree = "<group>"; };
@@ -2536,6 +2542,7 @@
 				69ECDAED09428E0C1CD6A724 /* HighlightRendererTests.swift */,
 				D5CE4AD339F8C68B973D9C88 /* NativeTextPagedIntegrationTests.swift */,
 				295669F5B358B6C7BE41952E /* NativeTextPaginatorTests.swift */,
+				14784E7ED271B5D2237CD53E /* NoteCalloutViewTests.swift */,
 				C60E543D08704FD376F94623 /* NotePreviewPresenterTests.swift */,
 				995F86ACEA8D1CC36B0BC1A7 /* PagedModeBug82Tests.swift */,
 				CB7EBD49DAE8D5F5BC4C7207 /* PageTurnAnimatorTests.swift */,
@@ -3026,6 +3033,8 @@
 				FC729E5B1BA7DC69B40D4929 /* NativeTextPageNavigator.swift */,
 				38E51E6D76FE0DDF87E537AB /* NativeTextPaginator.swift */,
 				E6D45B144AFD2D20CAEACC48 /* NoOpPersistenceStores.swift */,
+				4BE92A7A9E6664A02130DF5E /* NoteCalloutAction.swift */,
+				D1E6FCB2672364DC81F23020 /* NoteCalloutView.swift */,
 				1FC2F30305FBC69EE40A9454 /* NotePreviewContent.swift */,
 				325EA16A17752B40D178BD4A /* NotePreviewPresenter.swift */,
 				E9D4D088D34AA8A5692A991B /* PageTurnAnimator.swift */,
@@ -4436,6 +4445,7 @@
 				BE69CE7675864C497ACFC999 /* NamedHighlightColorTests.swift in Sources */,
 				036A7AA1F02D9219384C777A /* NativeTextPagedIntegrationTests.swift in Sources */,
 				4C5F7C805D7702035CEA5837 /* NativeTextPaginatorTests.swift in Sources */,
+				605EDCE3858C153A901E472A /* NoteCalloutViewTests.swift in Sources */,
 				12CA8217100DE141AA68CCBA /* NotePreviewPresenterTests.swift in Sources */,
 				11F6E86C1A0119FD5DF17AFD /* NotePreviewViewModelTests.swift in Sources */,
 				32C58BAAF2DB529049921D4D /* OPDSParserTests.swift in Sources */,
@@ -4908,6 +4918,8 @@
 				243DB71360738DB06D5813BF /* NativeTextPaginator.swift in Sources */,
 				D2997E6E5680E58471DAA777 /* NoOpPersistenceStores.swift in Sources */,
 				2C05C1DC5E7C1B7C7B438C2B /* NoOpSessionStore.swift in Sources */,
+				BA18656CCFD17EED6DAB15D7 /* NoteCalloutAction.swift in Sources */,
+				E4A81A3F657E73B3660FD5E2 /* NoteCalloutView.swift in Sources */,
 				ECA40D1E20A09D8AA9EB9AFC /* NotePreviewContent.swift in Sources */,
 				F438EA662DB1DF32BC7C88AF /* NotePreviewPresenter.swift in Sources */,
 				B4F810E90E92E0C3FEA06319 /* NotePreviewViewModel.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5302,13 +5302,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 497;
+				CURRENT_PROJECT_VERSION = 498;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.34.10;
+				MARKETING_VERSION = 3.34.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5452,13 +5452,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 497;
+				CURRENT_PROJECT_VERSION = 498;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.34.10;
+				MARKETING_VERSION = 3.34.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Views/Reader/NoteCalloutAction.swift
+++ b/vreader/Views/Reader/NoteCalloutAction.swift
@@ -1,0 +1,58 @@
+// Purpose: Feature #55 WI-4 — UI-presentation enum listing the handoff-row
+// action buttons in `NoteCalloutView`.
+//
+// The committed design bundle's `CalloutAction` row
+// (`dev-docs/designs/vreader-fidelity-v1/project/vreader-note-preview.jsx`)
+// depicts three actions — Edit / Share / Open-in-panel. v1 of feature #55
+// ships ONLY two:
+//   - **Edit** is omitted — the editor surface it opens is not a committed
+//     buildable design; per rule 51 it is a `BLOCKED: needs-design` slice
+//     (issue #914, plan §2.8). v1 is read-only preview.
+//   - **Delete** is NOT added — it was never in the design's `CalloutAction`
+//     row; adding it would be self-designed UI (plan §2.7.2, round-2 finding).
+//
+// Rendering a depicted 3-button row with 2 of its buttons is *narrower* than
+// the design, which rule 51 permits — it is not an invented surface.
+//
+// Distinct from any dispatch enum: this type is the *visual layout* — it pins
+// display order, labels, SF symbols, and accessibility identifiers against the
+// design bundle. A regression that adds Edit/Delete to v1, reorders, or
+// renames an accessibility identifier fails `NoteCalloutViewTests` before any
+// SwiftUI render runs.
+//
+// @coordinates-with: NoteCalloutView.swift, NotePreviewContent.swift
+
+import Foundation
+
+/// A handoff-row action button in the v1 `NoteCalloutView`. Order matches the
+/// depicted-and-shipped subset of the design's `CalloutAction` row.
+enum NoteCalloutAction: String, CaseIterable, Equatable {
+    /// Share the note — wired to the existing reader share path.
+    case share
+    /// Open the Annotations panel (Highlights tab) — posts `.readerOpenNotes`.
+    case openInPanel
+
+    /// The user-facing button label.
+    var label: String {
+        switch self {
+        case .share:       return "Share"
+        case .openInPanel: return "Open in panel"
+        }
+    }
+
+    /// SF Symbol for the button glyph.
+    var systemImage: String {
+        switch self {
+        case .share:       return "square.and.arrow.up"
+        case .openInPanel: return "highlighter"
+        }
+    }
+
+    /// Stable accessibility identifier — used by XCUITest verification.
+    var accessibilityIdentifier: String {
+        switch self {
+        case .share:       return "noteCalloutShare"
+        case .openInPanel: return "noteCalloutOpenInPanel"
+        }
+    }
+}

--- a/vreader/Views/Reader/NoteCalloutView.swift
+++ b/vreader/Views/Reader/NoteCalloutView.swift
@@ -1,0 +1,297 @@
+// Purpose: Feature #55 WI-4 — `NoteCalloutView`, the SwiftUI realization of
+// the committed design bundle's `NoteCallout`
+// (`dev-docs/designs/vreader-fidelity-v1/project/vreader-note-preview.jsx`).
+//
+// The anchored card a tap-on-annotated-text gesture reveals: a meta row
+// (color swatch + "NOTE"/"HIGHLIGHT" label + date + dismiss ×), a one-line
+// italic-serif excerpt of the highlighted passage with a color-tinted left
+// rule, the note body as the hero (Source Serif 4, scrollable, capped at the
+// design's 180pt), the empty/no-note state, and a handoff row.
+//
+// v1 ships read-only preview only:
+//   - Handoff row = Share + Open-in-panel (`NoteCalloutAction`). The design's
+//     `CalloutAction` row also depicts Edit; Edit is a `BLOCKED: needs-design`
+//     slice (issue #914, plan §2.8) and is omitted. Delete was never in the
+//     design (plan §2.7.2) and is not added. Rendering a depicted 3-button
+//     row with 2 of its buttons is narrower than the design — rule 51 permits.
+//   - No inline editing state.
+//
+// Key decisions:
+// - The view is purely presentational — all state lives in the parent; user
+//   taps funnel through `onAction` / `onDismiss`. Mirrors `SelectionPopoverView`.
+// - The swatch-color mapper covers the REAL stored highlight palette
+//   (yellow/green/blue/red/orange/purple — `HighlightListView.highlightColor`),
+//   not just the design's depicted 4-color subset (plan §2.1.1). A
+//   faithful-to-data extension: the swatch surface is designed, only the
+//   color set widens to what users actually have.
+// - `noteSwatchColor(for:)` and `noteLineCount(for:)` are `static` so the
+//   color contract and the line-count helper (the callout-vs-sheet decision
+//   input) are unit-testable with no SwiftUI render.
+// - Theming flows through `ReaderThemeV2` — light/dark parity falls out.
+//
+// @coordinates-with: NoteCalloutAction.swift, NotePreviewContent.swift,
+//   ReaderThemeV2.swift, ReaderTypography.swift, SelectionPopoverView.swift
+
+#if canImport(UIKit)
+import SwiftUI
+import UIKit
+
+/// Anchored note-preview card — the SwiftUI realization of the design's
+/// `NoteCallout`. Purely presentational; the parent owns presentation state.
+struct NoteCalloutView: View {
+
+    /// The note-preview content to render.
+    let content: NotePreviewContent
+
+    /// The reader theme driving ink / sub / rule / accent colors. Pass the
+    /// same `ReaderThemeV2` the rest of the reader chrome uses.
+    let theme: ReaderThemeV2
+
+    /// Funnel for the handoff-row actions (Share / Open-in-panel).
+    let onAction: (NoteCalloutAction) -> Void
+
+    /// Fired when the user taps the dismiss `×` (or the surrounding scrim,
+    /// which the presenter owns). Distinct from `onAction` so the parent can
+    /// dismiss with no side effect.
+    let onDismiss: () -> Void
+
+    /// The design's note-body `maxHeight` — past this the body scrolls.
+    private static let bodyMaxHeight: CGFloat = 180
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            metaRow
+            excerptRow
+            if content.isEmpty {
+                emptyStateRow
+            } else {
+                noteBody
+                Divider().background(Color(theme.ruleColor))
+                handoffRow
+            }
+        }
+        .padding(.vertical, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(cardBackground)
+                .shadow(color: .black.opacity(0.28), radius: 20, x: 0, y: 12)
+        )
+        .accessibilityIdentifier("noteCallout")
+    }
+
+    // MARK: - Subviews
+
+    private var metaRow: some View {
+        HStack(spacing: 8) {
+            // Color swatch — resolved from the real stored palette.
+            RoundedRectangle(cornerRadius: 2)
+                .fill(Self.noteSwatchColor(for: content.colorName))
+                .frame(width: 8, height: 8)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 2)
+                        .stroke(Self.noteSwatchColor(for: content.colorName).opacity(0.2),
+                                lineWidth: 2)
+                )
+            Text(content.isEmpty ? "HIGHLIGHT" : "NOTE")
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.8)
+                .foregroundColor(Color(theme.subColor))
+            Text("· \(Self.dateText(content.createdAt))")
+                .font(.system(size: 11))
+                .foregroundColor(Color(theme.subColor).opacity(0.7))
+            Spacer(minLength: 0)
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundColor(Color(theme.subColor))
+                    .frame(width: 22, height: 22)
+                    .background(Circle().fill(Color(theme.ruleColor).opacity(0.5)))
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss")
+            .accessibilityIdentifier("noteCalloutDismiss")
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 11)
+        .padding(.bottom, 8)
+    }
+
+    @ViewBuilder private var excerptRow: some View {
+        let excerpt = content.highlightedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !excerpt.isEmpty {
+            Text("\u{201C}\(excerpt)\u{201D}")
+                .font(Font(ReaderTypography.body(for: .sourceSerif4, size: 11.5)))
+                .italic()
+                .foregroundColor(Color(theme.subColor))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .padding(.leading, 10)
+                .overlay(alignment: .leading) {
+                    Rectangle()
+                        .fill(Self.noteSwatchColor(for: content.colorName))
+                        .frame(width: 2)
+                }
+                .padding(.leading, 14)
+                .padding(.trailing, 14)
+                .padding(.bottom, 10)
+                .accessibilityIdentifier("noteCalloutExcerpt")
+        }
+    }
+
+    /// The note body — the hero. Source Serif 4, scrollable, capped at 180pt.
+    private var noteBody: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            Text(content.note ?? "")
+                .font(Font(ReaderTypography.body(for: .sourceSerif4, size: 15)))
+                .foregroundColor(Color(theme.inkColor))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxHeight: Self.bodyMaxHeight)
+        .padding(.horizontal, 14)
+        .padding(.bottom, 12)
+        .accessibilityIdentifier("noteCalloutBody")
+    }
+
+    /// The empty/no-note state — the design's "No note attached." treatment.
+    /// v1 has no "Add one…" affordance (that opens the BLOCKED: needs-design
+    /// editor); the state still acknowledges the tap so it does not feel broken.
+    private var emptyStateRow: some View {
+        Text("No note attached.")
+            .font(Font(ReaderTypography.body(for: .sourceSerif4, size: 14)))
+            .italic()
+            .foregroundColor(Color(theme.subColor))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 14)
+            .padding(.top, 4)
+            .padding(.bottom, 14)
+            .accessibilityIdentifier("noteCalloutEmptyState")
+    }
+
+    private var handoffRow: some View {
+        HStack(spacing: 4) {
+            ForEach(NoteCalloutAction.allCases, id: \.self) { action in
+                Button {
+                    onAction(action)
+                } label: {
+                    VStack(spacing: 3) {
+                        Image(systemName: action.systemImage)
+                            .font(.system(size: 15, weight: .regular))
+                        Text(action.label)
+                            .font(Font(ReaderTypography.body(for: .inter, size: 10)))
+                            .fontWeight(.medium)
+                            .foregroundColor(Color(theme.subColor))
+                    }
+                    .foregroundColor(Color(theme.inkColor))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 6)
+                    .padding(.horizontal, 4)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier(action.accessibilityIdentifier)
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 6)
+    }
+
+    // MARK: - Theme-aware colors
+
+    private var cardBackground: Color {
+        // Design ships hardcoded #2a2724 (dark) / #fcf8f0 (light) for the
+        // callout surface — a floating element distinct from reader chrome.
+        if theme.isDark {
+            return Color(hexString: "#2a2724") ?? Color(theme.chromeColor)
+        } else {
+            return Color(hexString: "#fcf8f0") ?? Color(theme.chromeColor)
+        }
+    }
+
+    // MARK: - Testable statics
+
+    /// Resolves a stored highlight color name to the meta-row swatch color.
+    ///
+    /// Covers the REAL stored palette — `HighlightListView.highlightColor`
+    /// handles yellow/green/blue/red/orange/purple — not just the design's
+    /// depicted four. The four designed colors use the design's exact hex
+    /// stops (`NamedHighlightColor.hex`); the broader three
+    /// (red/orange/purple) map to their natural opaque hue. An unrecognized
+    /// value falls back to yellow — never `.clear`, never a crash.
+    static func noteSwatchColor(for storedColorName: String) -> Color {
+        let normalized = storedColorName.lowercased()
+        // Designed four — pinned to the committed design hex stops.
+        if let named = NamedHighlightColor.from(storageString: normalized),
+           let color = Color(hexString: named.hex) {
+            return color
+        }
+        // Broader stored palette the design did not depict, mapped to a
+        // faithful hue so a red/orange/purple highlight still gets its swatch.
+        switch normalized {
+        case "red":    return Color(hexString: "#e08585") ?? .red
+        case "orange": return Color(hexString: "#e8a85a") ?? .orange
+        case "purple": return Color(hexString: "#b48ce8") ?? .purple
+        default:
+            // Legacy hex / unknown / empty — fall back to the yellow swatch.
+            return Color(hexString: NamedHighlightColor.yellow.hex) ?? .yellow
+        }
+    }
+
+    /// Counts the newline-separated lines in a note body — the input the
+    /// callout-vs-sheet decision (`NotePreviewPresenter.form`) reads to pick
+    /// the roomier sheet for a long note. `nil`/empty → 0; a trailing newline
+    /// does not add a phantom line.
+    static func noteLineCount(for note: String?) -> Int {
+        guard let note, !note.isEmpty else { return 0 }
+        // Drop a single trailing newline so "a\nb\n" counts as 2, not 3.
+        var body = note
+        if body.hasSuffix("\n") { body.removeLast() }
+        if body.isEmpty { return 0 }
+        return body.split(separator: "\n", omittingEmptySubsequences: false).count
+    }
+
+    // MARK: - Private helpers
+
+    private static func dateText(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter.string(from: date)
+    }
+}
+
+// MARK: - Hex → SwiftUI Color (file-scoped helper)
+
+private extension Color {
+    /// Parses `#RRGGBB` / `#RRGGBBAA` into a `Color`. Returns nil for
+    /// malformed input. File-private — lift to a shared helper only when a
+    /// third call site appears (`SelectionPopoverView` has its own copy).
+    init?(hexString: String) {
+        var trimmed = hexString.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("#") { trimmed.removeFirst() }
+        guard trimmed.count == 6 || trimmed.count == 8,
+              let value = UInt32(trimmed, radix: 16) else {
+            return nil
+        }
+        let r, g, b, a: UInt32
+        if trimmed.count == 6 {
+            r = (value >> 16) & 0xff
+            g = (value >> 8) & 0xff
+            b = value & 0xff
+            a = 0xff
+        } else {
+            r = (value >> 24) & 0xff
+            g = (value >> 16) & 0xff
+            b = (value >> 8) & 0xff
+            a = value & 0xff
+        }
+        self = Color(
+            red: Double(r) / 255.0,
+            green: Double(g) / 255.0,
+            blue: Double(b) / 255.0,
+            opacity: Double(a) / 255.0
+        )
+    }
+}
+#endif

--- a/vreader/Views/Reader/NoteCalloutView.swift
+++ b/vreader/Views/Reader/NoteCalloutView.swift
@@ -36,6 +36,16 @@
 import SwiftUI
 import UIKit
 
+/// Which subtree the callout renders below the meta + excerpt rows.
+/// Extracted so the empty-vs-note branch decision is unit-testable without a
+/// SwiftUI render — the `body` switches on `displayMode`.
+enum NoteCalloutDisplayMode: Equatable {
+    /// No note body — the empty/no-note state ("No note attached.").
+    case empty
+    /// A note body — the note-body hero + the handoff row.
+    case note
+}
+
 /// Anchored note-preview card — the SwiftUI realization of the design's
 /// `NoteCallout`. Purely presentational; the parent owns presentation state.
 struct NoteCalloutView: View {
@@ -58,13 +68,21 @@ struct NoteCalloutView: View {
     /// The design's note-body `maxHeight` — past this the body scrolls.
     private static let bodyMaxHeight: CGFloat = 180
 
+    /// Which subtree to render — the empty/no-note state or the note hero +
+    /// handoff row. Driven by `content.isEmpty`. Unit-tested via
+    /// `NoteCalloutView.displayMode(for:)`.
+    private var displayMode: NoteCalloutDisplayMode {
+        Self.displayMode(for: content)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             metaRow
             excerptRow
-            if content.isEmpty {
+            switch displayMode {
+            case .empty:
                 emptyStateRow
-            } else {
+            case .note:
                 noteBody
                 Divider().background(Color(theme.ruleColor))
                 handoffRow
@@ -210,6 +228,14 @@ struct NoteCalloutView: View {
     }
 
     // MARK: - Testable statics
+
+    /// The subtree the callout renders for `content` — the empty/no-note
+    /// state when the content has no note body, the note hero + handoff row
+    /// otherwise. The `body`'s branch switches on this; exposed `static` so
+    /// the branch decision is unit-tested without a SwiftUI render.
+    static func displayMode(for content: NotePreviewContent) -> NoteCalloutDisplayMode {
+        content.isEmpty ? .empty : .note
+    }
 
     /// Resolves a stored highlight color name to the meta-row swatch color.
     ///

--- a/vreaderTests/Views/Reader/NoteCalloutViewTests.swift
+++ b/vreaderTests/Views/Reader/NoteCalloutViewTests.swift
@@ -1,0 +1,137 @@
+// Purpose: Feature #55 WI-4 — pins the visible-action contract and the
+// swatch-color mapping for `NoteCalloutView` against the committed design
+// bundle `dev-docs/designs/vreader-fidelity-v1/project/vreader-note-preview.jsx`.
+//
+// SwiftUI views are tested for behavior, not pixels (per .claude/rules/10-tdd.md).
+// `NoteCalloutView`'s testable surface:
+//   - `NoteCalloutAction` — the handoff-row action enum. The design's
+//     `CalloutAction` row depicts Edit / Share / Open-in-panel; v1 ships
+//     ONLY Share + Open-in-panel (Edit is the BLOCKED: needs-design slice,
+//     plan §2.8; Delete is never in the design, §2.7.2). A regression that
+//     adds Edit or Delete to v1, or reorders, fails here.
+//   - `noteSwatchColor(for:)` — maps a stored highlight color name to the
+//     meta-row swatch color. Covers the real stored palette
+//     (yellow/green/blue/red/orange/purple), not just the design's 4-color
+//     subset (plan §2.1.1).
+//   - the empty-vs-note branch is driven by `NotePreviewContent.isEmpty`.
+
+import Testing
+import Foundation
+import SwiftUI
+import CoreGraphics
+@testable import vreader
+
+@Suite("Feature #55 WI-4 — NoteCalloutView contract")
+struct NoteCalloutViewTests {
+
+    static let fp = DocumentFingerprint(
+        contentSHA256: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+        fileByteCount: 1024, format: .epub
+    )
+
+    private static func content(note: String?, color: String = "yellow") -> NotePreviewContent {
+        NotePreviewContent(
+            id: UUID(), note: note, highlightedText: "an excerpt",
+            colorName: color, createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            sourceRect: CGRect(x: 1, y: 2, width: 30, height: 14)
+        )
+    }
+
+    // MARK: - Handoff-action contract (v1 surface)
+
+    @Test("v1 handoff row has exactly 2 actions")
+    func handoffActionCount() {
+        #expect(NoteCalloutAction.allCases.count == 2)
+    }
+
+    @Test("v1 handoff row is Share then Open-in-panel — Edit + Delete omitted")
+    func handoffActionOrder() {
+        #expect(NoteCalloutAction.allCases == [.share, .openInPanel])
+    }
+
+    @Test("no handoff action is an edit or delete affordance")
+    func handoffActionsAreReadOnlyHandoffs() {
+        // The v1 callout is read-only — the Edit slice is BLOCKED: needs-design,
+        // Delete was never in the design. Guard against either being added.
+        for action in NoteCalloutAction.allCases {
+            #expect(action != .openInPanel || action == .openInPanel)  // tautology guard
+        }
+        // Concretely: the case set must be exactly {share, openInPanel}.
+        let cases = Set(NoteCalloutAction.allCases)
+        #expect(cases == [.share, .openInPanel])
+    }
+
+    @Test("each handoff action has a label and an SF symbol")
+    func handoffActionLabelsAndSymbols() {
+        #expect(NoteCalloutAction.share.label == "Share")
+        #expect(NoteCalloutAction.openInPanel.label == "Open in panel")
+        #expect(!NoteCalloutAction.share.systemImage.isEmpty)
+        #expect(!NoteCalloutAction.openInPanel.systemImage.isEmpty)
+    }
+
+    @Test("each handoff action has a stable accessibility identifier")
+    func handoffActionAccessibilityIdentifiers() {
+        #expect(NoteCalloutAction.share.accessibilityIdentifier == "noteCalloutShare")
+        #expect(NoteCalloutAction.openInPanel.accessibilityIdentifier == "noteCalloutOpenInPanel")
+    }
+
+    // MARK: - Swatch color mapping (real stored palette)
+
+    @Test(arguments: ["yellow", "green", "blue", "red", "orange", "purple"])
+    func swatchColorResolvesEveryStoredPaletteColor(_ name: String) {
+        // Every color a highlight can actually be stored as must resolve to a
+        // concrete swatch — not just the design's depicted 4 (plan §2.1.1).
+        let color = NoteCalloutView.noteSwatchColor(for: name)
+        // A resolved color is not the clear/no-op sentinel.
+        #expect(color != Color.clear)
+    }
+
+    @Test("an unknown stored color falls back, not crash")
+    func swatchColorUnknownColorFallsBack() {
+        let color = NoteCalloutView.noteSwatchColor(for: "chartreuse-legacy-hex")
+        #expect(color != Color.clear)
+    }
+
+    @Test("swatch mapping is case-insensitive on the stored name")
+    func swatchColorCaseInsensitive() {
+        #expect(NoteCalloutView.noteSwatchColor(for: "YELLOW")
+            == NoteCalloutView.noteSwatchColor(for: "yellow"))
+    }
+
+    // MARK: - Empty-vs-note branch (driven by NotePreviewContent.isEmpty)
+
+    @Test("a note-less content is the empty/no-note state")
+    func emptyStateBranchForNilNote() {
+        #expect(Self.content(note: nil).isEmpty == true)
+    }
+
+    @Test("a whitespace-only note is the empty/no-note state")
+    func emptyStateBranchForWhitespaceNote() {
+        #expect(Self.content(note: "   \n ").isEmpty == true)
+    }
+
+    @Test("a real note is the note state, not empty")
+    func noteStateBranchForRealNote() {
+        #expect(Self.content(note: "a real note").isEmpty == false)
+    }
+
+    // MARK: - Note line-count helper (callout-vs-sheet threshold input)
+
+    @Test("note line count counts newline-separated lines")
+    func noteLineCountCountsLines() {
+        #expect(NoteCalloutView.noteLineCount(for: "one") == 1)
+        #expect(NoteCalloutView.noteLineCount(for: "one\ntwo") == 2)
+        #expect(NoteCalloutView.noteLineCount(for: "a\nb\nc\nd\ne\nf\ng") == 7)
+    }
+
+    @Test("note line count of nil / empty is zero")
+    func noteLineCountNilOrEmpty() {
+        #expect(NoteCalloutView.noteLineCount(for: nil) == 0)
+        #expect(NoteCalloutView.noteLineCount(for: "") == 0)
+    }
+
+    @Test("a trailing newline does not add a phantom line")
+    func noteLineCountTrailingNewline() {
+        #expect(NoteCalloutView.noteLineCount(for: "one\ntwo\n") == 2)
+    }
+}

--- a/vreaderTests/Views/Reader/NoteCalloutViewTests.swift
+++ b/vreaderTests/Views/Reader/NoteCalloutViewTests.swift
@@ -18,8 +18,26 @@
 import Testing
 import Foundation
 import SwiftUI
+import UIKit
 import CoreGraphics
 @testable import vreader
+
+/// Test-local hex → Color parser, mirroring the production file-private one
+/// in `NoteCalloutView.swift` — lets the swatch tests assert exact-hex
+/// equality. Kept here (not lifted to a shared helper) because only the
+/// tests need to construct an expected color from a hex literal.
+private extension Color {
+    init(testHexString hex: String) {
+        var trimmed = hex
+        if trimmed.hasPrefix("#") { trimmed.removeFirst() }
+        let value = UInt32(trimmed, radix: 16) ?? 0
+        self = Color(
+            red: Double((value >> 16) & 0xff) / 255.0,
+            green: Double((value >> 8) & 0xff) / 255.0,
+            blue: Double(value & 0xff) / 255.0
+        )
+    }
+}
 
 @Suite("Feature #55 WI-4 — NoteCalloutView contract")
 struct NoteCalloutViewTests {
@@ -52,13 +70,15 @@ struct NoteCalloutViewTests {
     @Test("no handoff action is an edit or delete affordance")
     func handoffActionsAreReadOnlyHandoffs() {
         // The v1 callout is read-only — the Edit slice is BLOCKED: needs-design,
-        // Delete was never in the design. Guard against either being added.
-        for action in NoteCalloutAction.allCases {
-            #expect(action != .openInPanel || action == .openInPanel)  // tautology guard
-        }
-        // Concretely: the case set must be exactly {share, openInPanel}.
+        // Delete was never in the design. The case set must be EXACTLY
+        // {share, openInPanel}: no edit/delete affordance, ever.
         let cases = Set(NoteCalloutAction.allCases)
         #expect(cases == [.share, .openInPanel])
+        // No raw value collides with an edit/delete intent.
+        for action in NoteCalloutAction.allCases {
+            #expect(action.rawValue != "edit")
+            #expect(action.rawValue != "delete")
+        }
     }
 
     @Test("each handoff action has a label and an SF symbol")
@@ -77,42 +97,102 @@ struct NoteCalloutViewTests {
 
     // MARK: - Swatch color mapping (real stored palette)
 
-    @Test(arguments: ["yellow", "green", "blue", "red", "orange", "purple"])
-    func swatchColorResolvesEveryStoredPaletteColor(_ name: String) {
-        // Every color a highlight can actually be stored as must resolve to a
-        // concrete swatch — not just the design's depicted 4 (plan §2.1.1).
-        let color = NoteCalloutView.noteSwatchColor(for: name)
-        // A resolved color is not the clear/no-op sentinel.
-        #expect(color != Color.clear)
+    /// The four designed colors must resolve to the EXACT committed design
+    /// hex stops (`NamedHighlightColor.hex`) — a drift here breaks the
+    /// visual contract against the design bundle.
+    @Test(arguments: [
+        ("yellow", "#f0d25a"),
+        ("pink",   "#e88ca0"),
+        ("green",  "#8cc88c"),
+        ("blue",   "#8cb4e8"),
+    ])
+    func swatchColorMatchesDesignHexForDesignedColors(_ name: String, _ hex: String) {
+        #expect(NoteCalloutView.noteSwatchColor(for: name) == Color(testHexString: hex))
     }
 
-    @Test("an unknown stored color falls back, not crash")
-    func swatchColorUnknownColorFallsBack() {
-        let color = NoteCalloutView.noteSwatchColor(for: "chartreuse-legacy-hex")
-        #expect(color != Color.clear)
+    /// The broader stored palette (not depicted in the design) must each map
+    /// to their intended faithful hue — and crucially must NOT all collapse
+    /// to the yellow fallback (plan §2.1.1).
+    @Test(arguments: [
+        ("red",    "#e08585"),
+        ("orange", "#e8a85a"),
+        ("purple", "#b48ce8"),
+    ])
+    func swatchColorMatchesIntendedHueForBroaderPalette(_ name: String, _ hex: String) {
+        let resolved = NoteCalloutView.noteSwatchColor(for: name)
+        #expect(resolved == Color(testHexString: hex))
+        // Must be distinct from the yellow fallback — i.e. genuinely mapped.
+        #expect(resolved != NoteCalloutView.noteSwatchColor(for: "yellow"))
+    }
+
+    @Test("an unknown stored color falls back exactly to the yellow swatch")
+    func swatchColorUnknownColorFallsBackToYellow() {
+        #expect(NoteCalloutView.noteSwatchColor(for: "chartreuse-legacy-hex")
+            == NoteCalloutView.noteSwatchColor(for: "yellow"))
+        #expect(NoteCalloutView.noteSwatchColor(for: "")
+            == NoteCalloutView.noteSwatchColor(for: "yellow"))
     }
 
     @Test("swatch mapping is case-insensitive on the stored name")
     func swatchColorCaseInsensitive() {
         #expect(NoteCalloutView.noteSwatchColor(for: "YELLOW")
             == NoteCalloutView.noteSwatchColor(for: "yellow"))
+        #expect(NoteCalloutView.noteSwatchColor(for: "Red")
+            == NoteCalloutView.noteSwatchColor(for: "red"))
     }
 
-    // MARK: - Empty-vs-note branch (driven by NotePreviewContent.isEmpty)
+    // MARK: - Display-mode branch (the view's empty-vs-note subtree decision)
 
-    @Test("a note-less content is the empty/no-note state")
-    func emptyStateBranchForNilNote() {
-        #expect(Self.content(note: nil).isEmpty == true)
+    @Test("note-less content drives the empty display mode")
+    func displayModeEmptyForNilNote() {
+        #expect(NoteCalloutView.displayMode(for: Self.content(note: nil)) == .empty)
     }
 
-    @Test("a whitespace-only note is the empty/no-note state")
-    func emptyStateBranchForWhitespaceNote() {
-        #expect(Self.content(note: "   \n ").isEmpty == true)
+    @Test("whitespace-only note drives the empty display mode")
+    func displayModeEmptyForWhitespaceNote() {
+        #expect(NoteCalloutView.displayMode(for: Self.content(note: "   \n ")) == .empty)
     }
 
-    @Test("a real note is the note state, not empty")
-    func noteStateBranchForRealNote() {
-        #expect(Self.content(note: "a real note").isEmpty == false)
+    @Test("a real note drives the note display mode")
+    func displayModeNoteForRealNote() {
+        #expect(NoteCalloutView.displayMode(for: Self.content(note: "a real note")) == .note)
+    }
+
+    @Test("display mode tracks NotePreviewContent.isEmpty exactly")
+    func displayModeTracksIsEmpty() {
+        for note: String? in [nil, "", "  ", "real", "  padded  "] {
+            let c = Self.content(note: note)
+            let expected: NoteCalloutDisplayMode = c.isEmpty ? .empty : .note
+            #expect(NoteCalloutView.displayMode(for: c) == expected)
+        }
+    }
+
+    // MARK: - Render smoke (the view constructs for both states)
+
+    @MainActor
+    @Test("the callout view constructs for the empty state without crashing")
+    func renderSmokeEmptyState() {
+        let view = NoteCalloutView(
+            content: Self.content(note: nil), theme: .paper,
+            onAction: { _ in }, onDismiss: {}
+        )
+        // Hosting the view forces SwiftUI to evaluate `body` — a crash in the
+        // empty-branch subtree surfaces here.
+        let host = UIHostingController(rootView: view)
+        host.loadViewIfNeeded()
+        #expect(host.view != nil)
+    }
+
+    @MainActor
+    @Test("the callout view constructs for the note state without crashing")
+    func renderSmokeNoteState() {
+        let view = NoteCalloutView(
+            content: Self.content(note: "a note body"), theme: .paper,
+            onAction: { _ in }, onDismiss: {}
+        )
+        let host = UIHostingController(rootView: view)
+        host.loadViewIfNeeded()
+        #expect(host.view != nil)
     }
 
     // MARK: - Note line-count helper (callout-vs-sheet threshold input)
@@ -133,5 +213,16 @@ struct NoteCalloutViewTests {
     @Test("a trailing newline does not add a phantom line")
     func noteLineCountTrailingNewline() {
         #expect(NoteCalloutView.noteLineCount(for: "one\ntwo\n") == 2)
+    }
+
+    /// Whitespace/newline-only bodies — these are the inputs most likely to
+    /// diverge from `content.isEmpty` (which trims to empty) once the helper
+    /// feeds the callout-vs-sheet decision. A spaces-only body is one
+    /// non-empty visual line; a lone newline trims to zero lines.
+    @Test("note line count for whitespace-only / newline-only bodies")
+    func noteLineCountWhitespaceOnly() {
+        #expect(NoteCalloutView.noteLineCount(for: "   ") == 1)   // one spaces line
+        #expect(NoteCalloutView.noteLineCount(for: "\n") == 0)    // lone newline → 0
+        #expect(NoteCalloutView.noteLineCount(for: " \n \n ") == 3)
     }
 }


### PR DESCRIPTION
## Summary

- Adds `NoteCalloutView`, the SwiftUI realization of feature #55's committed design `NoteCallout`.
- v1 ships **read-only preview only** — no Edit, no Delete, no inline editing.

Part of feature #619.

## What Changed

- `NoteCalloutView` (`vreader/Views/Reader/NoteCalloutView.swift`) — the anchored note-preview card: meta row (color swatch + uppercase NOTE/HIGHLIGHT label + date + dismiss ×), one-line italic-serif excerpt with a color-tinted left rule, the note body as the hero (Source Serif 4 via `ReaderTypography`, scrollable, capped at the design's 180pt), the empty/no-note state, and a handoff row. `ReaderThemeV2`-themed — light/dark parity from the token set. Purely presentational; the parent owns presentation state (mirrors `SelectionPopoverView`).
- `NoteCalloutAction` (`vreader/Views/Reader/NoteCalloutAction.swift`) — the handoff-row action enum.
- A testable `NoteCalloutDisplayMode` + `NoteCalloutView.displayMode(for:)` (the `body` switches on it), and `static` `noteSwatchColor(for:)` / `noteLineCount(for:)` so the color contract, the branch decision, and the callout-vs-sheet line-count input are unit-tested with no SwiftUI render.

## Rule 51 — read-only v1

The committed design `vreader-note-preview.jsx`'s `CalloutAction` row depicts Edit / Share / Open-in-panel. v1 renders **only Share + Open-in-panel** (`NoteCalloutAction`):
- **Edit is omitted** — the editor surface it opens is not a committed buildable design; it is a `BLOCKED: needs-design` slice (issue **#914**, plan §2.8). v1 is read-only preview.
- **Delete is not added** — never in the design's row; adding it would be self-designed UI (plan §2.7.2).
- No inline editing state.

Rendering a depicted 3-button row with 2 of its buttons is *narrower* than the design — rule 51 permits that. The Codex audit (round 1) confirmed "no design or rule-51 violation in the shipped view code".

The swatch mapper covers the **real stored highlight palette** (yellow/green/blue/red/orange/purple — `HighlightListView.highlightColor`), not just the design's depicted 4: the 4 designed colors use the committed design hex stops (`NamedHighlightColor.hex`), red/orange/purple a faithful hue, unknown falls back to yellow (plan §2.1.1) — a faithful-to-data extension, not an invented surface.

## WI Status

- WI-4: behavioral — this PR.
- WI-1/2/3 (foundational): merged.
- Remaining: WI-5 (`NotePreviewSheetView` + `NotePreviewModifier` + `UIKitNotePreviewPresenter`), WI-6 (TXT/MD/PDF wiring), WI-7 (EPUB/Foliate wiring — final WI).

## Codex Audit (Gate 4)

Codex thread `019e3ed1-11ff-7c62-86ac-a8c2e2a97b88`, **2 rounds**, **ship-as-is**.
- Round 1: 0 Critical/High; 2 Medium + 2 Low — all test-strength gaps (the implementation was already correct + rule-51-compliant). Fixed: exact-hex swatch assertions (all 6 colors), a testable `displayMode` + render-smoke tests for the empty-vs-note branch, removed a tautology, added whitespace line-count cases.
- Round 2: zero findings.

Audit log: `.claude/codex-audits/feat-feature-55-wi-4-note-callout-view-audit.md`

## Validation

- [x] `NoteCalloutViewTests` — 19 tests, pass in isolation (`TEST SUCCEEDED`): handoff-action contract (exactly Share + Open-in-panel, no edit/delete), exact-hex swatch mapping over all 6 stored palette colors, the `displayMode` empty-vs-note branch, render-smoke (hosts the view for both states), the line-count helper boundaries.
- [x] Tests cover changed behavior (TDD: RED → GREEN → REFACTOR).
- [x] Codex audit loop completed (2 rounds, verdict: ship-as-is).
- [x] Docs sync — n/a (a single feature-local view, no service/notification/schema; the `architecture.md` note-preview entry lands with the final WI).
- [x] Version bumped: 3.34.8 → 3.34.11 (build 498).

Full-suite test gate: run on a dedicated simulator (separate DerivedData) — **597 suites pass, 0 real `✘` failures**, all 4 feature-#55 suites pass explicitly. The run's exit-65 is the known **Bug #221 / issue #849** flaky test-host crash (active fix worktree), which collateral-flags unrun suites — not a real failure.

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: behavioral, but `NoteCalloutView` is a standalone view **not yet wired into any reader container** — no container presents it until WI-6/WI-7's wiring. There is no device-reachable surface to slice-verify at this WI.
- Verified at the unit level: 19 contract tests including `UIHostingController` render-smoke tests that host the view for both the empty and note states (forces SwiftUI to evaluate `body`, surfacing any crash). Device verification of the on-screen callout happens at WI-6/WI-7 when a container presents it; the final WI carries the full acceptance pass + evidence file.

## Type of Change

- [x] Feature WI (Part of feature #619 — intermediate WI, plain prose, no `Refs`/`Fixes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)