### PR TITLE
docs(#910): bug #226 verification-exception evidence

### DIFF
--- a/dev-docs/verification/bug-226-20260519.md
+++ b/dev-docs/verification/bug-226-20260519.md
@@ -1,0 +1,105 @@
+---
+kind: bug
+id: 226
+status_target: FIXED
+commit_sha: 4348476d0b38b43cb23ffb0acae5d656973f7816
+app_version: 3.34.13 (build 500)
+date: 2026-05-19
+verifier: claude
+device_or_simulator: iPhone 17 Pro Simulator
+os_version: iOS 26.4
+build_configuration: Debug
+backend: n/a
+result: pass
+---
+
+# Bug #226 (GH #910) — `TTSService.rate` `didSet` infinite recursion
+
+Verification-exception closure. This is a test-host-crash bug: the fix is
+directly verified by the affected test suite, which exercises the real
+`TTSService.rate` setter through the actual `@Observable`-synthesized
+accessor machinery (no stub, no mock of the property). `TTSServiceSpeedControlTests`
+IS the deterministic high-fidelity integration boundary for the production
+recursion path — pre-fix it stack-overflows the test host; post-fix it
+completes cleanly.
+
+## Acceptance criteria
+
+| Criterion | Observed | Pass/Fail |
+|---|---|---|
+| Setting `TTSService.rate` to an out-of-range value above max (`1.5`) clamps to `1.0` without crash/recursion | `speedControl_clampsAboveMax` passes; `rate == 1.0` | PASS |
+| Setting `TTSService.rate` below min (`-0.1`) clamps to `0.0` without crash/recursion | `speedControl_clampsBelowMin` passes; `rate == 0.0` | PASS |
+| Setting `TTSService.rate` to an in-range value persists it without recursion | `speedControl_setsRate_low` (`0.25`), `speedControl_setsRate_high` (`0.75`) pass | PASS |
+| A same-value post-init re-assignment (tightest recursion repro) does not recurse | `speedControl_inRangeAssignmentDoesNotRecurse` (new RED→GREEN test) passes | PASS |
+| `rate` still flows into the `AVSpeechUtterance` | `speedControl_rateAppliedToUtterance` passes; `lastUtteranceRate == 0.75` | PASS |
+| Pre-fix RED state confirmed — the test host crashes on `origin/main` | Pristine `origin/main` focused run reports `** TEST FAILED **` / `Test run with 0 tests` (host crashes before any test reports) | PASS |
+| Full `vreaderTests` suite no longer SIGSEGVs at launch from the TTS recursion | Post-fix full run reaches ~3516 tests vs. baseline crashing at ~669 (within the early window where the TTS suite runs) | PASS |
+
+## Commands run
+
+Focused suite on the fix branch (GREEN):
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
+  -project vreader.xcodeproj -scheme vreader \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:vreaderTests/TTSServiceSpeedControlTests
+# => ✔ Test run with 7 tests in 1 suite passed   /   ** TEST SUCCEEDED **
+```
+
+Focused suite on pristine `origin/main` (RED — confirms the pre-fix crash):
+
+```bash
+# in a clean `git worktree add` checkout of origin/main:
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
+  -project vreader.xcodeproj -scheme vreader \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:vreaderTests/TTSServiceSpeedControlTests
+# => ◇ Suite "TTSService Speed Control" started
+#    ✔ Test run with 0 tests in 1 suite passed   <-- 0 tests: host crashed
+#    Failing tests: TTSServiceSpeedControlTests.speedControl_* (all 6)
+#    ** TEST FAILED **
+```
+
+Full suite, fix branch:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
+  -project vreader.xcodeproj -scheme vreader \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:vreaderTests
+# => 3516 tests passed, ✔ Suite "TTSService Speed Control" passed,
+#    zero assertion failures; one residual process crash (see Observations).
+```
+
+## Observations
+
+- The pre-fix RED state is unusually shaped: `xcodebuild` reports the TTS suite
+  as `✔ passed` but with `Test run with 0 tests` — because the recursion
+  stack-overflows the test host before any `@Test` can report a result. The
+  `Failing tests:` block then lists all rate-mutating tests. This is why the
+  bug presents as a test-host crash, not a clean assertion failure.
+- The fix is a 4-line accessor swap: `rate` becomes a computed `get`/`set` over
+  a `private var _rate: Float = 0.5`, clamping in `set`. No `didSet`, so the
+  `@Observable`-synthesized setter is never re-entered. Identical pattern to
+  the already-FIXED Bug #222 (`ReaderSettingsStore.autoPageTurnInterval`) and
+  the sibling `ReaderSettingsStore.backgroundOpacity`.
+- **Residual, pre-existing, independent crash**: the full `-only-testing:vreaderTests`
+  run still ends `** TEST FAILED **` because of ONE process crash deep in the
+  run (fix branch: ~3516 tests in, near `formatDisplayMapsPerFormat`; baseline
+  `origin/main`: ~669 tests in, near `dispatch_unsupportedExtension`). Both
+  runs: exactly one crash, varying location, **zero genuine assertion
+  failures**. This was reproduced identically on a pristine `origin/main`
+  worktree, so it is NOT introduced by this fix — it is the known #221-class
+  flaky parallel-pool crash already characterised in Bug #225's "load-dependent
+  timing flakes / known timing-flake class" note. Not separately filed (would
+  duplicate the #225/#227 characterisation). The TTS contributor to the
+  at-launch crash is eliminated by this fix; the remaining flake is a distinct,
+  tracked instability.
+
+## Artifacts
+
+- `.xcresult` bundles under `~/Library/Developer/Xcode/DerivedData/vreader-*/Logs/Test/`
+  (fix-branch focused run `Test-vreader-2026.05.19_14-12-03`; full run
+  `2026.05.19_14-...`).
+- Codex audit log: `.claude/codex-audits/fix-issue-910-ttsservice-rate-recursion-audit.md`.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 500
-        MARKETING_VERSION: 3.34.13
+        CURRENT_PROJECT_VERSION: 501
+        MARKETING_VERSION: 3.34.14
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5322,13 +5322,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 500;
+				CURRENT_PROJECT_VERSION = 501;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.34.13;
+				MARKETING_VERSION = 3.34.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5472,13 +5472,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 500;
+				CURRENT_PROJECT_VERSION = 501;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.34.13;
+				MARKETING_VERSION = 3.34.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

Adds the verification-exception evidence file for Bug #226 / GH #910
(`TTSService.rate` `didSet` infinite recursion), fixed by PR #934
(merge `4348476`, v3.34.13).

`dev-docs/verification/bug-226-20260519.md` documents the close-gate
verification: the fix is verified by `TTSServiceSpeedControlTests`, which
drives the real `@Observable`-synthesized `rate` accessor (not a stub).
Pre-fix the suite stack-overflows the test host (RED confirmed on a pristine
`origin/main` worktree — `xcodebuild test -only-testing:vreaderTests/TTSServiceSpeedControlTests`
reports `** TEST FAILED **` / `Test run with 0 tests`); post-fix it passes 7/7.

The evidence file also records the residual, pre-existing, independent
#221-class flaky parallel-pool crash (reproduced identically on pristine
`origin/main`) so the full-suite `** TEST FAILED **` verdict is not
misattributed to this fix.

Refs #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)