### PR TITLE
feat(#55 WI-6): wire note preview into TXT/MD/PDF + re-home #53 menu to long-press

### DIFF
--- a/.claude/codex-audits/feat-feature-55-wi-6-native-container-wiring-audit.md
+++ b/.claude/codex-audits/feat-feature-55-wi-6-native-container-wiring-audit.md
@@ -1,0 +1,87 @@
+---
+branch: feat/feature-55-wi-6-native-container-wiring
+threadId: 019e3f01-292e-7b00-bd23-3ff0bf5c88b7
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+# Gate 4 — Implementation Audit: feature #55 WI-6 (native TXT/MD/PDF note-preview wiring)
+
+WI-6 wires `NotePreviewModifier` into the three native reader containers
+(`TXTReaderContainerView`, `MDReaderContainerView`, `PDFReaderContainerView`)
+via the `notePreviewPresenterIfAvailable` attach helper, and re-homes feature
+#53's inline delete menu from the tap gesture to a `UILongPressGestureRecognizer`
+in the TXT non-chunked, chunked, and PDF bridges. A tap now opens the #55 note
+preview; a deliberate long-press opens #53's delete menu.
+
+## Round 1 — findings
+
+| file:line | severity | issue | fix |
+|---|---|---|---|
+| `TXTTextViewBridge.swift:102` / `TXTTextViewBridgeCoordinator.swift:307` / `TXTChunkedReaderBridge.swift:604` | High | The WI-6 long-press is added on the same `UITextView` surface as the system text-selection long-press, and the coordinator still unconditionally allows simultaneous recognition (`gestureRecognizerShouldRecognizeSimultaneously() == true`). A long-press on a highlighted passage fires `handleHighlightLongPress` AND lets UITextView proceed into selection / edit-menu — so "long-press opens only #53's delete menu" is not enforced for TXT/MD/chunked. | Make the custom long-press mutually exclusive with the built-in selection recognizer when the press lands on a persisted highlight. Gate recognition up front with a highlight hit-test (`gestureRecognizerShouldBegin`) and avoid unconditional simultaneous recognition for that path. |
+| `PDFViewBridge.swift:99` | Medium | PDF has the same arbitration problem — `gestureRecognizer(_:shouldRecognizeSimultaneouslyWith:)` returns `true` for everything, and `handleHighlightLongPress` fires on `.began` before PDFKit has necessarily established `currentSelection`. | Apply the same gesture arbitration as TXT. |
+| `Feature55NativeWiringTests.swift:27` | Low | The suite does not pin the behavior swap (tap must not call `present(...)`, long-press must be the only path that does). | Add a seam so coordinator-level tests can assert "tap posts notification only" and "long-press invokes presenter only". |
+
+### Round 1 resolutions
+
+- **High + Medium (gesture arbitration)** — fixed. Approach: instead of
+  no-op'ing inside the long-press handler, the recognizer is *gated* so it
+  never even begins on plain body text.
+  - `TXTBridgeShared.swift` — added `highlightLongPressName` (the
+    `UIGestureRecognizer.name` stamped on WI-6's long-press) and
+    `simultaneousRecognitionAllowed(for:)` (returns `false` only for the
+    highlight long-press).
+  - `TXTTextViewBridge.swift`, `TXTChunkedReaderBridge.swift`,
+    `PDFViewBridge.swift` — each stamps `highlightLongPress.name =
+    TXTBridgeShared.highlightLongPressName` in `makeUIView`.
+  - All three coordinators — `gestureRecognizer(_:shouldRecognizeSimultaneouslyWith:)`
+    now denies simultaneity when *either* side of the pair is the named
+    highlight long-press; the content-tap keeps the legacy `true`.
+  - All three coordinators — new `gestureRecognizerShouldBegin(_:)` runs the
+    SAME highlight hit-test the handler reuses (`resolveHighlightTap` /
+    `resolveChunkedHighlightTap` / `resolveHighlightTapEvent`) and returns
+    `true` only on a confirmed highlight hit. A long-press on plain text
+    never engages WI-6's recognizer → native text selection proceeds
+    undisturbed; on a highlight hit the recognizer begins AND is denied
+    simultaneity → UITextView/PDFKit never co-start a selection.
+- **Low (test seam)** — partially addressed in round 1 (8 arbitration tests
+  added); fully resolved in round 3 (see below).
+
+## Round 2 — findings
+
+| file:line | severity | issue | fix |
+|---|---|---|---|
+| `Feature55NativeWiringTests.swift:172` | Low | The new arbitration tests prove the named-recognizer policy and `gestureRecognizerShouldBegin` guards, but the suite still does not pin WI-6's core behavior swap: tap must post `.readerHighlightTapped` without invoking `present(...)`; long-press must be the path that invokes `present(...)`. A regression reintroducing menu-on-tap would still pass. | Add coordinator-level tests with a fake presenter + view-backed recognizers driving `handleContentTap` / `handleHighlightLongPress` directly. |
+
+Round 2 confirmed the round-1 High and Medium are resolved.
+
+### Round 2 resolution
+
+- **Low (behavior-swap seam)** — fixed. Added to `Feature55NativeWiringTests.swift`:
+  - `SpyHighlightActionPresenter: HighlightActionPresenting` — records
+    `present(...)` call count + last event.
+  - `FixedPointTap` / `FixedPointLongPress` — gesture-recognizer subclasses
+    overriding `location(in:)` (and `state` for the long-press) so the
+    coordinator handlers can be driven deterministically.
+  - 3 behavior tests: tap-on-highlight posts `.readerHighlightTapped` with
+    `presentCallCount == 0`; long-press-on-highlight calls `present` exactly
+    once; long-press in `.changed` state does not re-fire the menu.
+
+## Round 3 — verdict
+
+Zero open Critical/High/Medium/Low findings. The round-2 Low is resolved —
+the suite now directly pins the WI-6 behavior swap at the coordinator layer.
+
+## Summary verdict
+
+**ship-as-is.** Three audit rounds. Round 1 found a High + Medium
+gesture-arbitration gap (the re-homed long-press was not isolated from
+native text selection) and a Low test-seam gap; round 1 fixed the
+arbitration via a named recognizer + `gestureRecognizerShouldBegin`
+hit-test gate + name-aware non-simultaneous recognition. Round 2 confirmed
+the High/Medium fixes and refined the Low to require pinning the core
+tap→notification / long-press→menu behavior swap; round 2 added 3
+coordinator-level behavior tests. Round 3 is clean. WI-6's behavioral
+end-to-end (tap → preview, long-press → #53 menu on all 3 native formats)
+is exercised at Gate-5 device verification.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 501
-        MARKETING_VERSION: 3.34.14
+        CURRENT_PROJECT_VERSION: 502
+        MARKETING_VERSION: 3.34.15
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5330,13 +5330,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 501;
+				CURRENT_PROJECT_VERSION = 502;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.34.14;
+				MARKETING_VERSION = 3.34.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5480,13 +5480,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 501;
+				CURRENT_PROJECT_VERSION = 502;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.34.14;
+				MARKETING_VERSION = 3.34.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 		25327C608F6719156A58C8B3 /* LaunchHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62D7DA128D4B2AC1F362D571 /* LaunchHelper.swift */; };
 		2568348E9159667C4193A0B6 /* ProviderKindTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C46A3D7400CC956FA8D46D /* ProviderKindTests.swift */; };
 		25B106D034C16291C104D69E /* AnnotationsPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59ACCAF30F5092968415855 /* AnnotationsPanelView.swift */; };
+		25F62F5AD5DCD095108C303F /* NotePreviewContainerSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = F103A5AD9A3B7D6C4574482B /* NotePreviewContainerSupport.swift */; };
 		26285A9C2309CC149C5372DC /* AIConsentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C9AB72079AF7B2ACCAB516 /* AIConsentManager.swift */; };
 		2639375285887DD55F80815B /* SearchResultGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759C78EC56C473977FA14017 /* SearchResultGrouping.swift */; };
 		265B4C9C4B99A0500F0EC6B7 /* MDMetadataExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5D3F39FDBF4693D33D1BCB /* MDMetadataExtractor.swift */; };
@@ -276,6 +277,7 @@
 		3EA88656EFB66F3FFBAC7DC5 /* Feature41TTSAutoScrollVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40011CB1AB56C2F4DF2EE91 /* Feature41TTSAutoScrollVerificationTests.swift */; };
 		3EB8343FF1512E959CCEDD65 /* FoliateHighlightTapResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0461A65278F56C6D2271993 /* FoliateHighlightTapResolverTests.swift */; };
 		3EF51E3A99B073988655F8F8 /* LazyDownloadCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01041344F18D1DE82B7E100C /* LazyDownloadCoordinator.swift */; };
+		3F1B522B0BEB1A6FA5881A4C /* Feature55NativeWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4F8D4A29BBB0E68DEE76DC5 /* Feature55NativeWiringTests.swift */; };
 		3F690915D18151E5F28EFC40 /* ReaderMorePopoverParts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12841E371391B5AD20122A37 /* ReaderMorePopoverParts.swift */; };
 		3FB6C5452F598755573BFB4F /* TXTChapterStartDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EF994B8B9C677990960D7F2 /* TXTChapterStartDecorator.swift */; };
 		401E58831F4DC6EB06E53738 /* HTTPTTSConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C9907D3479515B56338825 /* HTTPTTSConfig.swift */; };
@@ -1750,6 +1752,7 @@
 		A457F48D22CD5B4952817701 /* EPUBTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBTypes.swift; sourceTree = "<group>"; };
 		A496DB7B37A1E68FA33AD5A3 /* JSONExportFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONExportFormatter.swift; sourceTree = "<group>"; };
 		A4D9A3C4C1072DA23511265D /* PDFReaderPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReaderPlaceholderTests.swift; sourceTree = "<group>"; };
+		A4F8D4A29BBB0E68DEE76DC5 /* Feature55NativeWiringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature55NativeWiringTests.swift; sourceTree = "<group>"; };
 		A504B80204BEC5B968087D02 /* PersistenceActorRemoteOnlyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceActorRemoteOnlyTests.swift; sourceTree = "<group>"; };
 		A5717B0EFF152D86D07C5C0D /* EPUBSelectionTokenCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBSelectionTokenCacheTests.swift; sourceTree = "<group>"; };
 		A579625590B25F81679F1EA0 /* ReaderNotificationModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderNotificationModifier.swift; sourceTree = "<group>"; };
@@ -2067,6 +2070,7 @@
 		F02AE770B22BFE6D2F175A1A /* TXTChapterIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterIndex.swift; sourceTree = "<group>"; };
 		F038832B6A3B0C184154B6AD /* PipelineTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipelineTypes.swift; sourceTree = "<group>"; };
 		F069A328AA628585D86B52B2 /* SyncStatusViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusViewTests.swift; sourceTree = "<group>"; };
+		F103A5AD9A3B7D6C4574482B /* NotePreviewContainerSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotePreviewContainerSupport.swift; sourceTree = "<group>"; };
 		F114D9F3F59EEF655D5327EA /* EPUBCoverParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBCoverParsingTests.swift; sourceTree = "<group>"; };
 		F16AF7EAA6EC1F1D0D126E75 /* BasePageNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePageNavigator.swift; sourceTree = "<group>"; };
 		F17C33D19BD1735676CA01BC /* TXTReaderContainerHighlightCoordinatorWiringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReaderContainerHighlightCoordinatorWiringTests.swift; sourceTree = "<group>"; };
@@ -2537,6 +2541,7 @@
 				A5717B0EFF152D86D07C5C0D /* EPUBSelectionTokenCacheTests.swift */,
 				003A86C3EF12A6B1DD4F5201 /* EPUBWebViewBridgeCoordinatorTests.swift */,
 				ABFBA14606BD14D14A8D5500 /* EPUBWebViewBridgeTests.swift */,
+				A4F8D4A29BBB0E68DEE76DC5 /* Feature55NativeWiringTests.swift */,
 				9CB5EAAB268616336D42EC30 /* FoliateHighlightRendererTests.swift */,
 				D712BAAF509AEBA3A3FB01C3 /* FoliateHighlightRestoreDispatcherTests.swift */,
 				58F5ACDA719E20E4BFA9BAB3 /* FoliateReaderContainerViewTests.swift */,
@@ -3047,6 +3052,7 @@
 				E6D45B144AFD2D20CAEACC48 /* NoOpPersistenceStores.swift */,
 				4BE92A7A9E6664A02130DF5E /* NoteCalloutAction.swift */,
 				D1E6FCB2672364DC81F23020 /* NoteCalloutView.swift */,
+				F103A5AD9A3B7D6C4574482B /* NotePreviewContainerSupport.swift */,
 				1FC2F30305FBC69EE40A9454 /* NotePreviewContent.swift */,
 				6079D3CCEC63C148A465889F /* NotePreviewModifier.swift */,
 				325EA16A17752B40D178BD4A /* NotePreviewPresenter.swift */,
@@ -4350,6 +4356,7 @@
 				8CAAA8CE24E5701C76A9A55F /* EncodingFixtureTests.swift in Sources */,
 				E7493CC6D24CE5FD1922F9D0 /* ErrorMessageAuditorTests.swift in Sources */,
 				700CFFEC7C74E0532A0271F4 /* ExportTestFixtures.swift in Sources */,
+				3F1B522B0BEB1A6FA5881A4C /* Feature55NativeWiringTests.swift in Sources */,
 				982FDBDA893DC7DA931711C7 /* FeatureFlagsTests.swift in Sources */,
 				2DB8779FF53587C400452428 /* FileAvailabilityStateMachineTests.swift in Sources */,
 				019FB8C5A2498141587A09A4 /* FileURLImportRouterTests.swift in Sources */,
@@ -4937,6 +4944,7 @@
 				2C05C1DC5E7C1B7C7B438C2B /* NoOpSessionStore.swift in Sources */,
 				BA18656CCFD17EED6DAB15D7 /* NoteCalloutAction.swift in Sources */,
 				E4A81A3F657E73B3660FD5E2 /* NoteCalloutView.swift in Sources */,
+				25F62F5AD5DCD095108C303F /* NotePreviewContainerSupport.swift in Sources */,
 				ECA40D1E20A09D8AA9EB9AFC /* NotePreviewContent.swift in Sources */,
 				C2ED2B756D3D12159172F5E1 /* NotePreviewModifier.swift in Sources */,
 				F438EA662DB1DF32BC7C88AF /* NotePreviewPresenter.swift in Sources */,

--- a/vreader/Views/Reader/MDReaderContainerView.swift
+++ b/vreader/Views/Reader/MDReaderContainerView.swift
@@ -105,6 +105,11 @@ struct MDReaderContainerView: View {
         // observes the notification and shows the sheet, mirroring
         // the TXT container's attachment from WI-7c2.
         .selectionPopoverPresenter(theme: settingsStore?.theme ?? .paper)
+        .notePreviewPresenterIfAvailable(
+            modelContainer: modelContainer,
+            bookFingerprintKey: viewModel.bookFingerprintKey,
+            theme: settingsStore?.theme ?? .paper
+        )
         .task {
             // PERF: open already called by MDReaderHost
             if viewModel.renderedText == nil {

--- a/vreader/Views/Reader/NotePreviewContainerSupport.swift
+++ b/vreader/Views/Reader/NotePreviewContainerSupport.swift
@@ -1,0 +1,50 @@
+// Purpose: Feature #55 WI-6/WI-7 — `notePreviewPresenterIfAvailable`, the
+// container-side attach helper for the tap-on-annotated-text note preview.
+//
+// The reader containers (`TXTReaderContainerView`, `MDReaderContainerView`,
+// `PDFReaderContainerView`, the EPUB / Foliate containers) carry an OPTIONAL
+// `ModelContainer` — `nil` in SwiftUI previews and some test harnesses. This
+// helper attaches `NotePreviewModifier` only when a real `ModelContainer` is
+// present, building the `PersistenceActor` (which conforms to `HighlightLookup`,
+// feature #55 WI-2) as the lookup. When the container is `nil` the view is
+// returned unchanged — the preview is simply inert in a preview/test context.
+//
+// Keeps each container's `body` to a single readable call rather than an
+// inline `if let` + `PersistenceActor(...)` construction repeated five times.
+//
+// @coordinates-with: NotePreviewModifier.swift, NotePreviewViewModel.swift,
+//   PersistenceActor+Highlights.swift (HighlightLookup conformance)
+
+#if canImport(UIKit)
+import SwiftUI
+import SwiftData
+import UIKit
+
+extension View {
+    /// Attaches the feature #55 note-preview presenter when `modelContainer`
+    /// is non-nil. The `PersistenceActor` built over the container is the
+    /// `HighlightLookup` the note-preview view model uses.
+    ///
+    /// `hostViewProvider` defaults to `{ nil }` — the v1 native + Foliate
+    /// containers present the preview via the bottom-sheet form
+    /// (`NotePreviewPresenter.resolvedForm` degrades a callout with no host).
+    @ViewBuilder
+    func notePreviewPresenterIfAvailable(
+        modelContainer: ModelContainer?,
+        bookFingerprintKey: String,
+        theme: ReaderThemeV2,
+        hostViewProvider: @escaping () -> UIView? = { nil }
+    ) -> some View {
+        if let modelContainer {
+            self.notePreviewPresenter(
+                highlightLookup: PersistenceActor(modelContainer: modelContainer),
+                bookFingerprintKey: bookFingerprintKey,
+                theme: theme,
+                hostViewProvider: hostViewProvider
+            )
+        } else {
+            self
+        }
+    }
+}
+#endif

--- a/vreader/Views/Reader/NotePreviewModifier.swift
+++ b/vreader/Views/Reader/NotePreviewModifier.swift
@@ -275,7 +275,9 @@ extension View {
     /// (via the UIKit presenter) or `NotePreviewSheetView` (via `.sheet`).
     ///
     /// `hostViewProvider` returns the container's content `UIView` — the
-    /// popover's anchor. WI-6/WI-7 wire this per format.
+    /// popover's anchor; returning `nil` makes the preview use the bottom-sheet
+    /// form (`NotePreviewPresenter.resolvedForm` degrades a callout with no
+    /// host).
     func notePreviewPresenter(
         viewModel: NotePreviewViewModel,
         theme: ReaderThemeV2,
@@ -289,6 +291,33 @@ extension View {
                 calloutPresenter: calloutPresenter,
                 hostViewProvider: hostViewProvider
             )
+        )
+    }
+
+    /// Feature #55 WI-6: container-friendly attach point. Builds the
+    /// `NotePreviewViewModel` from a `HighlightLookup` + the open book's
+    /// `fingerprintKey` — the reader containers have both in scope and would
+    /// otherwise hand-roll the view model. The modifier's `@State` keeps the
+    /// view model stable across renders.
+    ///
+    /// `hostViewProvider` defaults to `{ nil }` — the native containers
+    /// (TXT/MD/PDF) present the note preview via the bottom-sheet form in v1;
+    /// the anchored-callout-for-native enhancement (which needs a host-`UIView`
+    /// capture channel through the bridges) is a follow-up. Foliate likewise
+    /// has no anchor (`sourceRect == .zero`).
+    func notePreviewPresenter(
+        highlightLookup: any HighlightLookup,
+        bookFingerprintKey: String,
+        theme: ReaderThemeV2,
+        hostViewProvider: @escaping () -> UIView? = { nil }
+    ) -> some View {
+        notePreviewPresenter(
+            viewModel: NotePreviewViewModel(
+                persistence: highlightLookup,
+                bookFingerprintKey: bookFingerprintKey
+            ),
+            theme: theme,
+            hostViewProvider: hostViewProvider
         )
     }
 }

--- a/vreader/Views/Reader/PDFReaderContainerView.swift
+++ b/vreader/Views/Reader/PDFReaderContainerView.swift
@@ -132,6 +132,11 @@ struct PDFReaderContainerView: View {
                 bottomOverlay
             }
         }
+        .notePreviewPresenterIfAvailable(
+            modelContainer: modelContainer,
+            bookFingerprintKey: viewModel.bookFingerprintKey,
+            theme: settingsStore?.theme ?? .paper
+        )
         .task {
             viewModel.beginLoading()
         }

--- a/vreader/Views/Reader/PDFViewBridge.swift
+++ b/vreader/Views/Reader/PDFViewBridge.swift
@@ -94,12 +94,20 @@ struct PDFViewBridge: UIViewRepresentable {
 
         // Feature #55 WI-6: long-press gesture re-homing feature #53's inline
         // delete menu off the tap (the tap now opens the #55 note preview).
-        // `handleHighlightLongPress` no-ops unless the press lands on a
-        // persisted highlight annotation.
+        // The coordinator's `gestureRecognizerShouldBegin` runs the highlight
+        // hit-test up front, so this recognizer ONLY begins when the press
+        // lands on a persisted highlight annotation — a long-press on plain
+        // page content never engages it and proceeds into PDFKit's native
+        // text selection. When it DOES begin, the coordinator denies
+        // simultaneous recognition against PDFKit's selection long-press, so
+        // the highlight long-press opens only #53's menu (and PDFKit never
+        // establishes a `currentSelection` for that press). The `.name`
+        // lets the coordinator's delegate identify this recognizer.
         let highlightLongPress = UILongPressGestureRecognizer(
             target: context.coordinator,
             action: #selector(Coordinator.handleHighlightLongPress(_:))
         )
+        highlightLongPress.name = TXTBridgeShared.highlightLongPressName
         highlightLongPress.delegate = context.coordinator
         pdfView.addGestureRecognizer(highlightLongPress)
 
@@ -505,12 +513,41 @@ struct PDFViewBridge: UIViewRepresentable {
             return ReaderHighlightTapEvent(highlightID: highlightID, sourceRect: sourceRect)
         }
 
-        // Allow tap gesture to fire alongside PDFView's internal gestures
+        // Allow the tap gesture to fire alongside PDFView's internal
+        // gestures. Feature #55 WI-6: the highlight long-press is the
+        // exception — it is mutually exclusive with PDFKit's native
+        // text-selection long-press, so a long-press on a persisted
+        // highlight annotation opens ONLY #53's delete menu and PDFKit
+        // never establishes a `currentSelection` for that press.
         nonisolated func gestureRecognizer(
             _ gestureRecognizer: UIGestureRecognizer,
             shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
         ) -> Bool {
-            true
+            TXTBridgeShared.simultaneousRecognitionAllowed(for: gestureRecognizer.name)
+                && TXTBridgeShared.simultaneousRecognitionAllowed(
+                    for: otherGestureRecognizer.name)
+        }
+
+        /// Feature #55 WI-6: gates the highlight long-press recognizer with
+        /// the SAME hit-test the handler reuses, so it only *begins* when
+        /// the press lands on a persisted highlight annotation. A long-press
+        /// on plain page content never engages it — PDFKit's native
+        /// text-selection long-press proceeds undisturbed. Other recognizers
+        /// (the content-tap) keep UIKit's default begin behavior. Gating in
+        /// `shouldBegin` (rather than no-op'ing in the handler) is what
+        /// makes the highlight long-press win arbitration against PDFKit's
+        /// selection recognizer before any selection is established.
+        func gestureRecognizerShouldBegin(
+            _ gestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
+            guard gestureRecognizer.name == TXTBridgeShared.highlightLongPressName
+            else { return true }
+            guard let pdfView,
+                  pdfView.currentSelection == nil
+            else { return false }
+            return resolveHighlightTapEvent(
+                at: gestureRecognizer.location(in: pdfView)
+            ) != nil
         }
 
         deinit {

--- a/vreader/Views/Reader/PDFViewBridge.swift
+++ b/vreader/Views/Reader/PDFViewBridge.swift
@@ -92,6 +92,17 @@ struct PDFViewBridge: UIViewRepresentable {
         tapGesture.delegate = context.coordinator
         pdfView.addGestureRecognizer(tapGesture)
 
+        // Feature #55 WI-6: long-press gesture re-homing feature #53's inline
+        // delete menu off the tap (the tap now opens the #55 note preview).
+        // `handleHighlightLongPress` no-ops unless the press lands on a
+        // persisted highlight annotation.
+        let highlightLongPress = UILongPressGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handleHighlightLongPress(_:))
+        )
+        highlightLongPress.delegate = context.coordinator
+        pdfView.addGestureRecognizer(highlightLongPress)
+
         // Observe page changes
         NotificationCenter.default.addObserver(
             context.coordinator,
@@ -429,57 +440,69 @@ struct PDFViewBridge: UIViewRepresentable {
                 return
             }
 
-            // Feature #53 WI-6: check whether the tap hit an existing
-            // highlight annotation before falling through to the chrome-
-            // toggle path. If it did, post `.readerHighlightTapped` with
-            // the highlight's UUID + the annotation's bounds in PDFView
-            // coords for popover anchoring, and DO NOT also fire
-            // `.readerContentTapped` (which would toggle chrome and steal
-            // focus from the inline-menu that the tap is supposed to open).
-            if let pdfView,
-               let renderer = highlightRenderer,
-               !renderer.annotationMap.isEmpty {
-                let location = gesture.location(in: pdfView)
-                if let page = pdfView.page(for: location, nearest: false) {
-                    let pagePoint = pdfView.convert(location, to: page)
-                    if let highlightID = PDFHighlightTapResolver.resolveHighlightID(
-                        atPagePoint: pagePoint,
-                        onPage: page,
-                        annotationMap: renderer.annotationMap
-                    ) {
-                        // Compute screen rect for popover anchoring: pick
-                        // the first annotation whose bounds contain the
-                        // tap, convert its bounds to PDFView coords.
-                        var sourceRect: CGRect = .zero
-                        if let annotations = renderer.annotationMap[highlightID],
-                           let hit = annotations.first(where: { $0.page === page && $0.bounds.contains(pagePoint) }) {
-                            sourceRect = pdfView.convert(hit.bounds, from: page)
-                        }
-                        let event = ReaderHighlightTapEvent(
-                            highlightID: highlightID,
-                            sourceRect: sourceRect
-                        )
-                        NotificationCenter.default.post(
-                            name: .readerHighlightTapped, object: event
-                        )
-                        // Present the inline menu (Delete Highlight) when
-                        // a presenter is wired. nil presenter keeps the
-                        // notification-only mode for previews/test harnesses.
-                        if let presenter = highlightActionPresenter,
-                           let onAction = onHighlightTapAction {
-                            presenter.present(for: event, in: pdfView) { action in
-                                guard let action else { return }
-                                Task { @MainActor in
-                                    await onAction(action, highlightID)
-                                }
-                            }
-                        }
-                        return
-                    }
-                }
+            // Feature #53 WI-6 + feature #55 WI-6: check whether the tap hit
+            // an existing highlight annotation before the chrome-toggle path.
+            // If it did, post `.readerHighlightTapped` (which opens the #55
+            // note preview via `NotePreviewModifier`) and DO NOT fire
+            // `.readerContentTapped`. Feature #55 makes a single tap open the
+            // note preview — the #53 delete menu is re-homed to
+            // `handleHighlightLongPress`.
+            if let event = resolveHighlightTapEvent(at: gesture.location(in: pdfView ?? UIView())) {
+                NotificationCenter.default.post(
+                    name: .readerHighlightTapped, object: event
+                )
+                return
             }
 
             NotificationCenter.default.post(name: .readerContentTapped, object: nil)
+        }
+
+        /// Feature #55 WI-6: re-homes feature #53's inline delete menu from a
+        /// tap to a long-press for PDF (plan §2.7.2). Same hit-test, same
+        /// presenter, same `HighlightTapAction.delete` dispatch — only the
+        /// gesture moved. A tap now opens the #55 note preview.
+        @objc func handleHighlightLongPress(_ gesture: UILongPressGestureRecognizer) {
+            guard gesture.state == .began,
+                  let pdfView,
+                  pdfView.currentSelection == nil,
+                  let presenter = highlightActionPresenter,
+                  let onAction = onHighlightTapAction,
+                  let event = resolveHighlightTapEvent(at: gesture.location(in: pdfView))
+            else { return }
+            presenter.present(for: event, in: pdfView) { action in
+                guard let action else { return }
+                Task { @MainActor in
+                    await onAction(action, event.highlightID)
+                }
+            }
+        }
+
+        /// Resolves a point in `pdfView` coordinates to a `ReaderHighlightTapEvent`
+        /// when it lands on a persisted highlight annotation — the shared
+        /// hit-test for both the tap (chrome-toggle / #55 preview) and the
+        /// WI-6 long-press (#53 delete menu). Returns nil on a miss.
+        private func resolveHighlightTapEvent(at location: CGPoint) -> ReaderHighlightTapEvent? {
+            guard let pdfView,
+                  let renderer = highlightRenderer,
+                  !renderer.annotationMap.isEmpty,
+                  let page = pdfView.page(for: location, nearest: false)
+            else { return nil }
+            let pagePoint = pdfView.convert(location, to: page)
+            guard let highlightID = PDFHighlightTapResolver.resolveHighlightID(
+                atPagePoint: pagePoint,
+                onPage: page,
+                annotationMap: renderer.annotationMap
+            ) else { return nil }
+            // Screen rect for popover anchoring: the first annotation whose
+            // bounds contain the point, converted to PDFView coords.
+            var sourceRect: CGRect = .zero
+            if let annotations = renderer.annotationMap[highlightID],
+               let hit = annotations.first(where: {
+                   $0.page === page && $0.bounds.contains(pagePoint)
+               }) {
+                sourceRect = pdfView.convert(hit.bounds, from: page)
+            }
+            return ReaderHighlightTapEvent(highlightID: highlightID, sourceRect: sourceRect)
         }
 
         // Allow tap gesture to fire alongside PDFView's internal gestures

--- a/vreader/Views/Reader/TXTBridgeShared.swift
+++ b/vreader/Views/Reader/TXTBridgeShared.swift
@@ -6,6 +6,9 @@
 // - buildReaderEditMenu builds the shared Highlight, Add Note, Define, and Translate menu.
 // - postContentTappedNotification extracts the identical tap handler body.
 // - gestureRecognizerShouldRecognizeSimultaneously extracts the identical delegate answer.
+// - highlightLongPressName + simultaneousRecognitionAllowed gate feature #55 WI-6's
+//   long-press recognizer so it stays mutually exclusive with UITextView's native
+//   text-selection long-press when the press lands on a persisted highlight.
 //
 // @coordinates-with TXTTextViewBridge.swift, TXTChunkedReaderBridge.swift,
 //   ReaderNotifications.swift, DictionaryLookup.swift
@@ -14,6 +17,15 @@ import UIKit
 
 /// Shared utility functions for TXT/MD reader bridge coordinators.
 enum TXTBridgeShared {
+
+    /// `UIGestureRecognizer.name` stamped on feature #55 WI-6's highlight
+    /// long-press recognizer (TXT non-chunked, chunked, and PDF). The
+    /// coordinator's `UIGestureRecognizerDelegate` reads this name to (a)
+    /// gate `gestureRecognizerShouldBegin` with a highlight hit-test and
+    /// (b) deny simultaneous recognition against the native selection
+    /// long-press — so a long-press on a highlight opens ONLY feature
+    /// #53's delete menu, never the system text-selection / edit menu.
+    static let highlightLongPressName = "vreader.feature55.highlightLongPress"
 
     /// Posts a selection notification with text and UTF-16 range.
     /// For chunked readers, pass `chunkOffset` to convert chunk-local to document-global.
@@ -134,5 +146,25 @@ enum TXTBridgeShared {
     /// Shared gesture recognizer delegate answer — always allow simultaneous recognition.
     static func gestureRecognizerShouldRecognizeSimultaneously() -> Bool {
         true
+    }
+
+    /// Feature #55 WI-6 simultaneous-recognition policy. The tap recognizer
+    /// keeps the legacy "always allow" answer (it must coexist with
+    /// UITextView's own tap handling). The highlight long-press recognizer
+    /// — identified by `highlightLongPressName` — instead returns `false`
+    /// so it is mutually exclusive with the system text-selection
+    /// long-press: a deliberate long-press on a persisted highlight opens
+    /// feature #53's delete menu WITHOUT UITextView/PDFView also starting a
+    /// selection. (`gestureRecognizerShouldBegin` already keeps the
+    /// long-press from beginning on plain body text, so this denial only
+    /// ever applies on top of a confirmed highlight hit.)
+    ///
+    /// - Parameters:
+    ///   - gestureName: `gestureRecognizer.name` of the recognizer the
+    ///     delegate callback fired for.
+    /// - Returns: `false` only when the recognizer is WI-6's highlight
+    ///   long-press; `true` otherwise (the pre-WI-6 behavior).
+    static func simultaneousRecognitionAllowed(for gestureName: String?) -> Bool {
+        gestureName != highlightLongPressName
     }
 }

--- a/vreader/Views/Reader/TXTChunkedReaderBridge.swift
+++ b/vreader/Views/Reader/TXTChunkedReaderBridge.swift
@@ -154,6 +154,17 @@ struct TXTChunkedReaderBridge: UIViewRepresentable {
         tapRecognizer.delegate = context.coordinator
         tableView.addGestureRecognizer(tapRecognizer)
 
+        // Feature #55 WI-6: long-press gesture re-homing feature #53's inline
+        // delete menu off the tap (the tap now opens the #55 note preview).
+        // `handleHighlightLongPress` no-ops unless the press lands on a
+        // persisted highlight.
+        let highlightLongPress = UILongPressGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handleHighlightLongPress)
+        )
+        highlightLongPress.delegate = context.coordinator
+        tableView.addGestureRecognizer(highlightLongPress)
+
         // Restore scroll position — asyncAfter allows SwiftUI to size the table view
         // before scrolling. In makeUIView the view has no frame yet.
         // The coordinator retries if the view still has no valid frame (bug #23).
@@ -432,12 +443,13 @@ struct TXTChunkedReaderBridge: UIViewRepresentable {
         // MARK: - Content Tap (Toolbar Toggle / Tap-on-Highlight)
 
         @objc func handleContentTap(_ gesture: UITapGestureRecognizer) {
-            // Feature #53 WI-3: if the tap lands inside a persisted highlight
-            // range, fire `.readerHighlightTapped` (and present the inline
-            // menu when wired) instead of toggling chrome. The chunked path
-            // mirrors the non-chunked TXTTextViewBridge.Coordinator behavior
-            // — see `resolveHighlightTap` there. Lookup-empty short-circuit
-            // keeps non-WI-3 callers cost-free.
+            // Feature #53 WI-3 + feature #55 WI-6: if the tap lands inside a
+            // persisted highlight range, fire `.readerHighlightTapped`
+            // instead of toggling chrome. Feature #55 makes a single tap open
+            // the NOTE PREVIEW (via `NotePreviewModifier`) — so the tap
+            // handler no longer presents #53's delete menu; that menu is
+            // re-homed to `handleHighlightLongPress`. Lookup-empty
+            // short-circuit keeps non-highlight callers cost-free.
             if let tableView = gesture.view as? UITableView,
                !persistedHighlightLookup.isEmpty,
                let event = Self.resolveChunkedHighlightTap(
@@ -449,18 +461,35 @@ struct TXTChunkedReaderBridge: UIViewRepresentable {
                 NotificationCenter.default.post(
                     name: .readerHighlightTapped, object: event
                 )
-                if let presenter = highlightActionPresenter,
-                   let onAction = onHighlightTapAction {
-                    presenter.present(for: event, in: tableView) { action in
-                        guard let action else { return }
-                        Task { @MainActor in
-                            await onAction(action, event.highlightID)
-                        }
-                    }
-                }
                 return
             }
             TXTBridgeShared.postContentTappedNotification()
+        }
+
+        /// Feature #55 WI-6: re-homes feature #53's inline delete menu from a
+        /// tap to a long-press for the chunked TXT path (plan §2.7.2). Same
+        /// hit-test (`resolveChunkedHighlightTap`), same presenter, same
+        /// `HighlightTapAction.delete` dispatch — only the gesture moved. A
+        /// tap now opens the #55 note preview.
+        @objc func handleHighlightLongPress(_ gesture: UILongPressGestureRecognizer) {
+            guard gesture.state == .began,
+                  let tableView = gesture.view as? UITableView,
+                  !persistedHighlightLookup.isEmpty,
+                  let presenter = highlightActionPresenter,
+                  let onAction = onHighlightTapAction,
+                  let event = Self.resolveChunkedHighlightTap(
+                      gesture: gesture,
+                      in: tableView,
+                      chunkStartOffsets: chunkStartOffsets,
+                      lookup: persistedHighlightLookup
+                  )
+            else { return }
+            presenter.present(for: event, in: tableView) { action in
+                guard let action else { return }
+                Task { @MainActor in
+                    await onAction(action, event.highlightID)
+                }
+            }
         }
 
         // MARK: - Tap-on-Highlight Resolution (Feature #53 WI-3)
@@ -473,9 +502,13 @@ struct TXTChunkedReaderBridge: UIViewRepresentable {
         ///
         /// Extracted as static + internal so unit tests can drive it without
         /// going through a live `UITapGestureRecognizer`.
+        /// `gesture` is `UIGestureRecognizer` (the base type) so both the
+        /// tap recognizer (chrome-toggle / #55 note preview) and feature #55
+        /// WI-6's long-press recognizer (#53 delete menu) can drive the same
+        /// hit-test — both expose `location(in:)`.
         @MainActor
         static func resolveChunkedHighlightTap(
-            gesture: UITapGestureRecognizer,
+            gesture: UIGestureRecognizer,
             in tableView: UITableView,
             chunkStartOffsets: [Int],
             lookup: [PersistedHighlightLookupEntry]

--- a/vreader/Views/Reader/TXTChunkedReaderBridge.swift
+++ b/vreader/Views/Reader/TXTChunkedReaderBridge.swift
@@ -156,12 +156,19 @@ struct TXTChunkedReaderBridge: UIViewRepresentable {
 
         // Feature #55 WI-6: long-press gesture re-homing feature #53's inline
         // delete menu off the tap (the tap now opens the #55 note preview).
-        // `handleHighlightLongPress` no-ops unless the press lands on a
-        // persisted highlight.
+        // The coordinator's `gestureRecognizerShouldBegin` runs the highlight
+        // hit-test up front, so this recognizer ONLY begins when the press
+        // lands on a persisted highlight — a long-press on plain body text
+        // never engages it and proceeds into the cell UITextView's native
+        // text selection. When it DOES begin, the coordinator denies
+        // simultaneous recognition against the native selection long-press,
+        // so the highlight long-press opens only #53's menu. The `.name`
+        // lets the shared delegate identify this recognizer.
         let highlightLongPress = UILongPressGestureRecognizer(
             target: context.coordinator,
             action: #selector(Coordinator.handleHighlightLongPress)
         )
+        highlightLongPress.name = TXTBridgeShared.highlightLongPressName
         highlightLongPress.delegate = context.coordinator
         tableView.addGestureRecognizer(highlightLongPress)
 
@@ -605,7 +612,39 @@ struct TXTChunkedReaderBridge: UIViewRepresentable {
             _ gestureRecognizer: UIGestureRecognizer,
             shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
         ) -> Bool {
-            TXTBridgeShared.gestureRecognizerShouldRecognizeSimultaneously()
+            // Feature #55 WI-6: the highlight long-press is mutually
+            // exclusive with the cell UITextView's native text-selection
+            // long-press — a long-press on a persisted highlight opens ONLY
+            // #53's delete menu. The tap recognizer keeps the legacy
+            // "always simultaneous" answer.
+            guard TXTBridgeShared.simultaneousRecognitionAllowed(
+                    for: gestureRecognizer.name),
+                  TXTBridgeShared.simultaneousRecognitionAllowed(
+                    for: otherGestureRecognizer.name)
+            else { return false }
+            return TXTBridgeShared.gestureRecognizerShouldRecognizeSimultaneously()
+        }
+
+        /// Feature #55 WI-6: gates the highlight long-press recognizer with
+        /// the SAME hit-test the handler reuses, so it only *begins* when
+        /// the press lands on a persisted highlight. A long-press anywhere
+        /// else never engages it — the cell UITextView's native
+        /// text-selection long-press proceeds undisturbed. Other recognizers
+        /// (the content-tap) keep UIKit's default begin behavior.
+        func gestureRecognizerShouldBegin(
+            _ gestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
+            guard gestureRecognizer.name == TXTBridgeShared.highlightLongPressName
+            else { return true }
+            guard let tableView = gestureRecognizer.view as? UITableView,
+                  !persistedHighlightLookup.isEmpty
+            else { return false }
+            return Self.resolveChunkedHighlightTap(
+                gesture: gestureRecognizer,
+                in: tableView,
+                chunkStartOffsets: chunkStartOffsets,
+                lookup: persistedHighlightLookup
+            ) != nil
         }
 
         // MARK: - UITextViewDelegate

--- a/vreader/Views/Reader/TXTReaderContainerView.swift
+++ b/vreader/Views/Reader/TXTReaderContainerView.swift
@@ -274,6 +274,11 @@ struct TXTReaderContainerView: View {
         // WI-7c3..7c5 attach the same modifier to the chunked TXT /
         // MD / EPUB containers.
         .selectionPopoverPresenter(theme: settingsStore?.theme ?? .paper)
+        .notePreviewPresenterIfAvailable(
+            modelContainer: modelContainer,
+            bookFingerprintKey: viewModel.bookFingerprintKey,
+            theme: settingsStore?.theme ?? .paper
+        )
         .task {
             // PERF: open already called by TXTReaderHost — skip if content loaded
             if viewModel.textContent == nil && viewModel.currentChapterText == nil {

--- a/vreader/Views/Reader/TXTTextViewBridge.swift
+++ b/vreader/Views/Reader/TXTTextViewBridge.swift
@@ -93,6 +93,19 @@ struct TXTTextViewBridge: UIViewRepresentable {
         tapRecognizer.delegate = context.coordinator
         textView.addGestureRecognizer(tapRecognizer)
 
+        // Feature #55 WI-6: long-press gesture re-homing feature #53's inline
+        // delete menu off the tap (the tap now opens the #55 note preview).
+        // Fires alongside the tap + UITextView's own selection gestures;
+        // `handleHighlightLongPress` no-ops unless the press lands on a
+        // persisted highlight, so it does not disturb a long-press that
+        // starts a text selection on plain body text.
+        let highlightLongPress = UILongPressGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handleHighlightLongPress)
+        )
+        highlightLongPress.delegate = context.coordinator
+        textView.addGestureRecognizer(highlightLongPress)
+
         // Keep a weak ref for notification-driven highlight clear
         context.coordinator.activeTextView = textView
 

--- a/vreader/Views/Reader/TXTTextViewBridge.swift
+++ b/vreader/Views/Reader/TXTTextViewBridge.swift
@@ -95,14 +95,19 @@ struct TXTTextViewBridge: UIViewRepresentable {
 
         // Feature #55 WI-6: long-press gesture re-homing feature #53's inline
         // delete menu off the tap (the tap now opens the #55 note preview).
-        // Fires alongside the tap + UITextView's own selection gestures;
-        // `handleHighlightLongPress` no-ops unless the press lands on a
-        // persisted highlight, so it does not disturb a long-press that
-        // starts a text selection on plain body text.
+        // The coordinator's `gestureRecognizerShouldBegin` runs the highlight
+        // hit-test up front, so this recognizer ONLY begins when the press
+        // lands on a persisted highlight — a long-press on plain body text
+        // never engages it and proceeds straight into UITextView's native
+        // text selection. When it DOES begin (highlight hit), the coordinator
+        // denies simultaneous recognition against the system selection
+        // long-press, so the highlight long-press opens only #53's menu.
+        // The `.name` lets the shared delegate identify this recognizer.
         let highlightLongPress = UILongPressGestureRecognizer(
             target: context.coordinator,
             action: #selector(Coordinator.handleHighlightLongPress)
         )
+        highlightLongPress.name = TXTBridgeShared.highlightLongPressName
         highlightLongPress.delegate = context.coordinator
         textView.addGestureRecognizer(highlightLongPress)
 

--- a/vreader/Views/Reader/TXTTextViewBridgeCoordinator.swift
+++ b/vreader/Views/Reader/TXTTextViewBridgeCoordinator.swift
@@ -308,7 +308,40 @@ extension TXTTextViewBridge {
             _ gestureRecognizer: UIGestureRecognizer,
             shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
         ) -> Bool {
-            TXTBridgeShared.gestureRecognizerShouldRecognizeSimultaneously()
+            // Feature #55 WI-6: the highlight long-press is mutually
+            // exclusive with the native text-selection long-press — a
+            // long-press on a persisted highlight opens ONLY #53's delete
+            // menu, never UITextView's selection. The tap recognizer keeps
+            // the legacy "always simultaneous" answer. Either side of the
+            // pair being the highlight long-press denies simultaneity.
+            guard TXTBridgeShared.simultaneousRecognitionAllowed(
+                    for: gestureRecognizer.name),
+                  TXTBridgeShared.simultaneousRecognitionAllowed(
+                    for: otherGestureRecognizer.name)
+            else { return false }
+            return TXTBridgeShared.gestureRecognizerShouldRecognizeSimultaneously()
+        }
+
+        /// Feature #55 WI-6: gates the highlight long-press recognizer with
+        /// the SAME hit-test the handler reuses, so the recognizer only
+        /// *begins* when the press lands on a persisted highlight. A
+        /// long-press anywhere else never engages it — UITextView's native
+        /// text-selection long-press proceeds undisturbed. Recognizers
+        /// other than the named highlight long-press are unaffected (the
+        /// content-tap recognizer keeps UIKit's default begin behavior).
+        func gestureRecognizerShouldBegin(
+            _ gestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
+            guard gestureRecognizer.name == TXTBridgeShared.highlightLongPressName
+            else { return true }
+            guard let tv = gestureRecognizer.view as? UITextView,
+                  !persistedHighlightLookup.isEmpty
+            else { return false }
+            return Self.resolveHighlightTap(
+                tapPoint: gestureRecognizer.location(in: tv),
+                in: tv,
+                lookup: persistedHighlightLookup
+            ) != nil
         }
 
         // MARK: - Link Interaction Policy

--- a/vreader/Views/Reader/TXTTextViewBridgeCoordinator.swift
+++ b/vreader/Views/Reader/TXTTextViewBridgeCoordinator.swift
@@ -186,12 +186,13 @@ extension TXTTextViewBridge {
         // MARK: - Content Tap (Toolbar Toggle)
 
         @objc func handleContentTap(_ gesture: UITapGestureRecognizer) {
-            // Feature #53 WI-2: hit-test against persisted highlight ranges
-            // first. On hit, post `.readerHighlightTapped` and SKIP the
-            // chrome-toggle path so a tap on a highlight reliably opens the
-            // inline edit/delete menu (acceptance criterion d: "tapping
-            // non-highlighted text preserves existing scroll/chrome-toggle
-            // behavior" — symmetric: tapping a highlight overrides it).
+            // Feature #53 WI-2 + feature #55 WI-6: hit-test against persisted
+            // highlight ranges first. On hit, post `.readerHighlightTapped`
+            // and SKIP the chrome-toggle path. Feature #55 makes a single tap
+            // open the NOTE PREVIEW (via `NotePreviewModifier`, which observes
+            // `.readerHighlightTapped`) — so the tap handler no longer
+            // presents #53's delete menu. The #53 delete menu is re-homed to
+            // `handleHighlightLongPress` below.
             if let tv = gesture.view as? UITextView,
                !persistedHighlightLookup.isEmpty,
                let event = Self.resolveHighlightTap(
@@ -203,19 +204,6 @@ extension TXTTextViewBridge {
                     name: .readerHighlightTapped,
                     object: event
                 )
-                // WI-2b: present the inline edit/delete menu if wired.
-                // The presenter is fired on the active text view, which
-                // is in the responder chain and has a valid window for
-                // UIEditMenuInteraction.addInteraction.
-                if let presenter = highlightActionPresenter,
-                   let onAction = onHighlightTapAction {
-                    presenter.present(for: event, in: tv) { action in
-                        guard let action else { return }
-                        Task { @MainActor in
-                            await onAction(action, event.highlightID)
-                        }
-                    }
-                }
                 return
             }
             clearSearchHighlightIfTemporary()
@@ -223,6 +211,33 @@ extension TXTTextViewBridge {
                 rebuildHighlights(in: tv)
             }
             TXTBridgeShared.postContentTappedNotification()
+        }
+
+        /// Feature #55 WI-6: re-homes feature #53's inline delete menu from a
+        /// tap to a long-press. A tap now opens the #55 note preview; a
+        /// deliberate long-press on the same highlight opens #53's
+        /// `UIEditMenuInteraction` delete menu. Same hit-test, same presenter,
+        /// same `HighlightTapAction.delete` dispatch — only the triggering
+        /// gesture moved (plan §2.7.2). Fires on `.began` so the menu appears
+        /// as soon as the long-press is recognized.
+        @objc func handleHighlightLongPress(_ gesture: UILongPressGestureRecognizer) {
+            guard gesture.state == .began,
+                  let tv = gesture.view as? UITextView,
+                  !persistedHighlightLookup.isEmpty,
+                  let presenter = highlightActionPresenter,
+                  let onAction = onHighlightTapAction,
+                  let event = Self.resolveHighlightTap(
+                      tapPoint: gesture.location(in: tv),
+                      in: tv,
+                      lookup: persistedHighlightLookup
+                  )
+            else { return }
+            presenter.present(for: event, in: tv) { action in
+                guard let action else { return }
+                Task { @MainActor in
+                    await onAction(action, event.highlightID)
+                }
+            }
         }
 
         /// Resolves a tap into a `ReaderHighlightTapEvent` if the location

--- a/vreaderTests/Views/Reader/Feature55NativeWiringTests.swift
+++ b/vreaderTests/Views/Reader/Feature55NativeWiringTests.swift
@@ -1,0 +1,158 @@
+// Purpose: Feature #55 WI-6 — guards the native-container wiring of the
+// tap-on-annotated-text note preview (TXT / MD / PDF).
+//
+// WI-6's behavioral change is integration — `NotePreviewModifier` attached to
+// the three native containers, plus feature #53's delete menu re-homed from
+// the tap gesture to a `UILongPressGestureRecognizer` in the TXT / chunked /
+// PDF bridges. The end-to-end behavior (tap → preview; long-press → #53 menu)
+// is exercised at Gate 5 device verification. These unit tests guard the
+// pieces that CAN be verified without driving live UIKit gestures:
+//   - `notePreviewPresenterIfAvailable` attaches when a `ModelContainer` is
+//     present and is an inert no-op when it is `nil` (preview/test safety).
+//   - the resolution helpers the long-press handlers reuse still resolve a
+//     hit-test point — the long-press shares the SAME hit-test as the tap, so
+//     a regression in resolution would break both gestures.
+
+#if canImport(UIKit)
+import Testing
+import UIKit
+import SwiftUI
+import SwiftData
+import Foundation
+@testable import vreader
+
+@Suite("Feature #55 WI-6 — native container note-preview wiring")
+@MainActor
+struct Feature55NativeWiringTests {
+
+    // MARK: - notePreviewPresenterIfAvailable
+
+    @Test("notePreviewPresenterIfAvailable is an inert no-op with a nil container")
+    func attachHelperNoOpWhenContainerNil() {
+        // A nil ModelContainer (SwiftUI preview / some test harnesses) must
+        // not crash — the helper returns the view unchanged.
+        let view = Color.clear.notePreviewPresenterIfAvailable(
+            modelContainer: nil,
+            bookFingerprintKey: "epub:abc:1",
+            theme: .paper
+        )
+        let host = UIHostingController(rootView: view)
+        host.loadViewIfNeeded()
+        #expect(host.view != nil)
+    }
+
+    @Test("notePreviewPresenterIfAvailable attaches with a real container")
+    func attachHelperAttachesWhenContainerPresent() throws {
+        // An in-memory container — the helper builds the PersistenceActor
+        // lookup and attaches NotePreviewModifier.
+        let schema = Schema(SchemaV6.models)
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [config])
+        let view = Color.clear.notePreviewPresenterIfAvailable(
+            modelContainer: container,
+            bookFingerprintKey: "epub:abc:1",
+            theme: .paper
+        )
+        let host = UIHostingController(rootView: view)
+        host.loadViewIfNeeded()
+        #expect(host.view != nil)
+    }
+
+    // MARK: - The long-press shares the tap's hit-test (TXT non-chunked)
+
+    @Test("TXT highlight resolution — the hit-test the long-press reuses — resolves a hit")
+    func txtResolutionResolvesHitForLongPressPath() {
+        // `handleHighlightLongPress` calls `resolveHighlightTap(tapPoint:in:lookup:)`
+        // — the SAME resolution the tap handler uses. A point inside a
+        // persisted range must resolve to the highlight's event.
+        let tv = UITextView()
+        tv.attributedText = NSAttributedString(
+            string: "hello world",
+            attributes: [.font: UIFont.systemFont(ofSize: 16)]
+        )
+        tv.frame = CGRect(x: 0, y: 0, width: 800, height: 200)
+        tv.textContainer.lineFragmentPadding = 0
+        tv.textContainerInset = .zero
+        tv.layoutManager.ensureLayout(for: tv.textContainer)
+
+        let id = UUID()
+        let lookup = [PersistedHighlightLookupEntry(
+            id: id, range: NSRange(location: 6, length: 5)  // "world"
+        )]
+        let lm = tv.layoutManager
+        let glyphRange = lm.glyphRange(
+            forCharacterRange: NSRange(location: 6, length: 1), actualCharacterRange: nil
+        )
+        let charRect = lm.boundingRect(forGlyphRange: glyphRange, in: tv.textContainer)
+
+        let event = TXTTextViewBridge.Coordinator.resolveHighlightTap(
+            tapPoint: CGPoint(x: charRect.midX, y: charRect.midY),
+            in: tv,
+            lookup: lookup
+        )
+        #expect(event?.highlightID == id)
+    }
+
+    @Test("TXT highlight resolution misses plain text — long-press there no-ops")
+    func txtResolutionMissesPlainText() {
+        let tv = UITextView()
+        tv.attributedText = NSAttributedString(
+            string: "hello world",
+            attributes: [.font: UIFont.systemFont(ofSize: 16)]
+        )
+        tv.frame = CGRect(x: 0, y: 0, width: 800, height: 200)
+        tv.textContainer.lineFragmentPadding = 0
+        tv.textContainerInset = .zero
+        tv.layoutManager.ensureLayout(for: tv.textContainer)
+
+        // Lookup covers "world" [6,11); a tap at the very start ("h") misses.
+        let lookup = [PersistedHighlightLookupEntry(
+            id: UUID(), range: NSRange(location: 6, length: 5)
+        )]
+        let event = TXTTextViewBridge.Coordinator.resolveHighlightTap(
+            tapPoint: CGPoint(x: 1, y: 5),
+            in: tv,
+            lookup: lookup
+        )
+        #expect(event == nil)
+    }
+
+    // MARK: - Chunked resolution accepts the widened gesture type
+
+    @Test("chunked resolution's point overload still resolves after the UIGestureRecognizer widening")
+    func chunkedResolutionPointOverloadStillWorks() {
+        // WI-6 widened `resolveChunkedHighlightTap(gesture:)` from
+        // `UITapGestureRecognizer` to `UIGestureRecognizer` so the long-press
+        // can drive it. The point-based overload (used by tests + internally)
+        // is unaffected — guard that.
+        let tv = UITextView()
+        tv.attributedText = NSAttributedString(
+            string: "hello world",
+            attributes: [.font: UIFont.systemFont(ofSize: 16)]
+        )
+        tv.frame = CGRect(x: 0, y: 0, width: 800, height: 200)
+        tv.textContainer.lineFragmentPadding = 0
+        tv.textContainerInset = .zero
+        tv.layoutManager.ensureLayout(for: tv.textContainer)
+
+        let id = UUID()
+        let lookup = [PersistedHighlightLookupEntry(
+            id: id, range: NSRange(location: 6, length: 5)
+        )]
+        let lm = tv.layoutManager
+        let glyphRange = lm.glyphRange(
+            forCharacterRange: NSRange(location: 6, length: 1), actualCharacterRange: nil
+        )
+        let charRect = lm.boundingRect(forGlyphRange: glyphRange, in: tv.textContainer)
+
+        let event = TXTChunkedReaderBridge.Coordinator.resolveChunkedHighlightTap(
+            tapPointInCell: CGPoint(x: charRect.midX, y: charRect.midY),
+            in: tv,
+            chunkIndex: 0,
+            chunkStartOffsets: [0],
+            lookup: lookup
+        )
+        #expect(event?.highlightID == id)
+    }
+}
+#endif

--- a/vreaderTests/Views/Reader/Feature55NativeWiringTests.swift
+++ b/vreaderTests/Views/Reader/Feature55NativeWiringTests.swift
@@ -12,6 +12,11 @@
 //   - the resolution helpers the long-press handlers reuse still resolve a
 //     hit-test point — the long-press shares the SAME hit-test as the tap, so
 //     a regression in resolution would break both gestures.
+//   - gesture arbitration (Gate-4 audit fix): the long-press recognizer is
+//     named, gated by a highlight hit-test in `gestureRecognizerShouldBegin`,
+//     and denied simultaneous recognition against the native text-selection
+//     long-press — so a long-press on a highlight opens ONLY #53's menu and a
+//     long-press on plain text falls through to native selection.
 
 #if canImport(UIKit)
 import Testing
@@ -153,6 +158,231 @@ struct Feature55NativeWiringTests {
             lookup: lookup
         )
         #expect(event?.highlightID == id)
+    }
+
+    // MARK: - Gesture arbitration (Gate-4 audit fix — long-press isolation)
+
+    // WI-6's first cut added the long-press recognizer with an unconditional
+    // `shouldRecognizeSimultaneouslyWith == true`, so a long-press on a
+    // highlight fired BOTH #53's delete menu AND UITextView/PDFView's native
+    // text selection. The fix: a named recognizer + a hit-test in
+    // `gestureRecognizerShouldBegin` + a name-aware simultaneity policy.
+    // These tests pin that arbitration.
+
+    @Test("simultaneousRecognitionAllowed denies the highlight long-press, allows everything else")
+    func simultaneityPolicyDeniesHighlightLongPressOnly() {
+        // The highlight long-press must be mutually exclusive with the
+        // native selection long-press; the tap recognizer (and any unnamed
+        // recognizer) keeps the legacy "always simultaneous" answer.
+        #expect(
+            TXTBridgeShared.simultaneousRecognitionAllowed(
+                for: TXTBridgeShared.highlightLongPressName
+            ) == false
+        )
+        #expect(TXTBridgeShared.simultaneousRecognitionAllowed(for: nil) == true)
+        #expect(
+            TXTBridgeShared.simultaneousRecognitionAllowed(
+                for: "some.other.recognizer"
+            ) == true
+        )
+    }
+
+    @Test("TXT coordinator gestureRecognizerShouldBegin lets non-highlight recognizers begin")
+    func txtShouldBeginPassesThroughForNonHighlightRecognizers() {
+        // A recognizer that is NOT the named highlight long-press (e.g. the
+        // content-tap recognizer) keeps UIKit's default begin behavior —
+        // `gestureRecognizerShouldBegin` returns true without hit-testing.
+        let coordinator = TXTTextViewBridge.Coordinator(delegate: nil)
+        let tap = UITapGestureRecognizer()
+        #expect(coordinator.gestureRecognizerShouldBegin(tap) == true)
+    }
+
+    @Test("TXT coordinator gestureRecognizerShouldBegin blocks the highlight long-press with an empty lookup")
+    func txtShouldBeginBlocksHighlightLongPressWhenNoHighlights() {
+        // The named highlight long-press must NOT begin when there are no
+        // persisted highlights — a long-press on plain text falls through
+        // to UITextView's native selection instead of engaging #53's menu.
+        let coordinator = TXTTextViewBridge.Coordinator(delegate: nil)
+        coordinator.persistedHighlightLookup = []
+        let longPress = UILongPressGestureRecognizer()
+        longPress.name = TXTBridgeShared.highlightLongPressName
+        #expect(coordinator.gestureRecognizerShouldBegin(longPress) == false)
+    }
+
+    @Test("chunked coordinator gestureRecognizerShouldBegin lets non-highlight recognizers begin")
+    func chunkedShouldBeginPassesThroughForNonHighlightRecognizers() {
+        let coordinator = TXTChunkedReaderBridge.Coordinator(delegate: nil)
+        let tap = UITapGestureRecognizer()
+        #expect(coordinator.gestureRecognizerShouldBegin(tap) == true)
+    }
+
+    @Test("chunked coordinator gestureRecognizerShouldBegin blocks the highlight long-press with an empty lookup")
+    func chunkedShouldBeginBlocksHighlightLongPressWhenNoHighlights() {
+        let coordinator = TXTChunkedReaderBridge.Coordinator(delegate: nil)
+        coordinator.persistedHighlightLookup = []
+        let longPress = UILongPressGestureRecognizer()
+        longPress.name = TXTBridgeShared.highlightLongPressName
+        #expect(coordinator.gestureRecognizerShouldBegin(longPress) == false)
+    }
+
+    @Test("PDF coordinator gestureRecognizerShouldBegin lets non-highlight recognizers begin")
+    func pdfShouldBeginPassesThroughForNonHighlightRecognizers() {
+        let coordinator = PDFViewBridge.Coordinator()
+        let tap = UITapGestureRecognizer()
+        #expect(coordinator.gestureRecognizerShouldBegin(tap) == true)
+    }
+
+    @Test("PDF coordinator gestureRecognizerShouldBegin blocks the highlight long-press with no PDFView")
+    func pdfShouldBeginBlocksHighlightLongPressWhenNoRenderer() {
+        // With no attached PDFView (and therefore no renderer/annotations),
+        // the named highlight long-press must not begin — a long-press on
+        // the page falls through to PDFKit's native text selection.
+        let coordinator = PDFViewBridge.Coordinator()
+        let longPress = UILongPressGestureRecognizer()
+        longPress.name = TXTBridgeShared.highlightLongPressName
+        #expect(coordinator.gestureRecognizerShouldBegin(longPress) == false)
+    }
+
+    // MARK: - The WI-6 behavior swap itself (tap → notification; long-press → menu)
+
+    // The core WI-6 change: a tap on a highlight posts `.readerHighlightTapped`
+    // (the #55 note preview) and must NOT present feature #53's delete menu;
+    // the menu is re-homed to the long-press. These coordinator-level tests
+    // drive `handleContentTap` / `handleHighlightLongPress` directly with a
+    // fake presenter so a future regression that reintroduces menu-on-tap is
+    // caught — closing the round-2 Low test-seam finding.
+
+    /// Records every `present(...)` call so the test can assert the menu was
+    /// (or was not) shown without driving a live `UIEditMenuInteraction`.
+    @MainActor
+    final class SpyHighlightActionPresenter: HighlightActionPresenting {
+        private(set) var presentCallCount = 0
+        private(set) var lastEvent: ReaderHighlightTapEvent?
+        func present(
+            for event: ReaderHighlightTapEvent,
+            in view: UIView,
+            completion: @escaping @MainActor (HighlightTapAction?) -> Void
+        ) {
+            presentCallCount += 1
+            lastEvent = event
+            // Do not deliver an action — the test only cares that the menu
+            // would have been presented, not what the user picks.
+        }
+    }
+
+    /// `UITapGestureRecognizer` whose `location(in:)` is fixed so the
+    /// coordinator's gesture handlers resolve a deterministic point.
+    final class FixedPointTap: UITapGestureRecognizer {
+        var fixedPoint: CGPoint = .zero
+        override func location(in view: UIView?) -> CGPoint { fixedPoint }
+    }
+
+    /// `UILongPressGestureRecognizer` with a fixed point + a forced `state`
+    /// so `handleHighlightLongPress` (which gates on `.began`) can run.
+    final class FixedPointLongPress: UILongPressGestureRecognizer {
+        var fixedPoint: CGPoint = .zero
+        private var forcedState: UIGestureRecognizer.State = .began
+        override var state: UIGestureRecognizer.State {
+            get { forcedState }
+            set { forcedState = newValue }
+        }
+        override func location(in view: UIView?) -> CGPoint { fixedPoint }
+    }
+
+    /// Builds a laid-out UITextView + a lookup covering "world", returning
+    /// the textView, the highlight id, the lookup, and a point inside it.
+    private func makeHighlightedTextViewFixture() -> (
+        textView: UITextView, id: UUID,
+        lookup: [PersistedHighlightLookupEntry], hitPoint: CGPoint
+    ) {
+        let tv = UITextView()
+        tv.attributedText = NSAttributedString(
+            string: "hello world",
+            attributes: [.font: UIFont.systemFont(ofSize: 16)]
+        )
+        tv.frame = CGRect(x: 0, y: 0, width: 800, height: 200)
+        tv.textContainer.lineFragmentPadding = 0
+        tv.textContainerInset = .zero
+        tv.layoutManager.ensureLayout(for: tv.textContainer)
+        let id = UUID()
+        let lookup = [PersistedHighlightLookupEntry(
+            id: id, range: NSRange(location: 6, length: 5)  // "world"
+        )]
+        let lm = tv.layoutManager
+        let glyphRange = lm.glyphRange(
+            forCharacterRange: NSRange(location: 6, length: 1),
+            actualCharacterRange: nil
+        )
+        let charRect = lm.boundingRect(forGlyphRange: glyphRange, in: tv.textContainer)
+        return (tv, id, lookup, CGPoint(x: charRect.midX, y: charRect.midY))
+    }
+
+    @Test("TXT tap on a highlight posts .readerHighlightTapped and does NOT present the #53 menu")
+    func txtTapOnHighlightPostsNotificationOnly() async {
+        let fixture = makeHighlightedTextViewFixture()
+        let coordinator = TXTTextViewBridge.Coordinator(delegate: nil)
+        coordinator.persistedHighlightLookup = fixture.lookup
+        let spy = SpyHighlightActionPresenter()
+        coordinator.highlightActionPresenter = spy
+        coordinator.onHighlightTapAction = { _, _ in }
+
+        let tap = FixedPointTap()
+        tap.fixedPoint = fixture.hitPoint
+        fixture.textView.addGestureRecognizer(tap)  // populates `gesture.view`
+
+        nonisolated(unsafe) var postedID: UUID?
+        let token = NotificationCenter.default.addObserver(
+            forName: .readerHighlightTapped, object: nil, queue: nil
+        ) { note in
+            postedID = (note.object as? ReaderHighlightTapEvent)?.highlightID
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        coordinator.handleContentTap(tap)
+
+        // Tap fires the #55 preview notification, NOT #53's delete menu.
+        #expect(postedID == fixture.id)
+        #expect(spy.presentCallCount == 0)
+    }
+
+    @Test("TXT long-press on a highlight presents the #53 menu (the re-homed delete path)")
+    func txtLongPressOnHighlightPresentsMenu() {
+        let fixture = makeHighlightedTextViewFixture()
+        let coordinator = TXTTextViewBridge.Coordinator(delegate: nil)
+        coordinator.persistedHighlightLookup = fixture.lookup
+        let spy = SpyHighlightActionPresenter()
+        coordinator.highlightActionPresenter = spy
+        coordinator.onHighlightTapAction = { _, _ in }
+
+        let longPress = FixedPointLongPress()
+        longPress.fixedPoint = fixture.hitPoint
+        longPress.name = TXTBridgeShared.highlightLongPressName
+        fixture.textView.addGestureRecognizer(longPress)
+
+        coordinator.handleHighlightLongPress(longPress)
+
+        // The long-press is the path that opens #53's delete menu.
+        #expect(spy.presentCallCount == 1)
+        #expect(spy.lastEvent?.highlightID == fixture.id)
+    }
+
+    @Test("TXT long-press in the .changed state does not present (only .began fires the menu)")
+    func txtLongPressNonBeganStateDoesNotPresent() {
+        let fixture = makeHighlightedTextViewFixture()
+        let coordinator = TXTTextViewBridge.Coordinator(delegate: nil)
+        coordinator.persistedHighlightLookup = fixture.lookup
+        let spy = SpyHighlightActionPresenter()
+        coordinator.highlightActionPresenter = spy
+        coordinator.onHighlightTapAction = { _, _ in }
+
+        let longPress = FixedPointLongPress()
+        longPress.fixedPoint = fixture.hitPoint
+        longPress.name = TXTBridgeShared.highlightLongPressName
+        longPress.state = .changed  // continuation events must not re-fire
+        fixture.textView.addGestureRecognizer(longPress)
+
+        coordinator.handleHighlightLongPress(longPress)
+        #expect(spy.presentCallCount == 0)
     }
 }
 #endif


### PR DESCRIPTION
## Summary

- Wires feature #55's `NotePreviewModifier` into the three native reader containers (`TXTReaderContainerView`, `MDReaderContainerView`, `PDFReaderContainerView`) via the new `notePreviewPresenterIfAvailable` attach helper — a tap on annotated text now opens the inline note preview.
- Re-homes feature #53's inline delete menu from the tap gesture to a `UILongPressGestureRecognizer` in the TXT non-chunked, chunked, and PDF bridges, since the tap is now claimed by the #55 note preview.
- Isolates the re-homed long-press from native text selection so a long-press on a highlight opens ONLY #53's delete menu (Gate-4 audit fix).

Part of feature #619

## What Changed

- **`NotePreviewContainerSupport.swift`** (new) — `View.notePreviewPresenterIfAvailable(modelContainer:bookFingerprintKey:theme:hostViewProvider:)` `@ViewBuilder` helper. Attaches `NotePreviewModifier` only when a real `ModelContainer` is present (inert in SwiftUI previews / test harnesses), building `PersistenceActor` as the `HighlightLookup`.
- **`TXTReaderContainerView` / `MDReaderContainerView` / `PDFReaderContainerView`** — each attaches `.notePreviewPresenterIfAvailable(...)`.
- **`TXTTextViewBridge` / `TXTChunkedReaderBridge` / `PDFViewBridge`** — add a `UILongPressGestureRecognizer` for the re-homed #53 menu; the tap handlers no longer call `HighlightActionPresenting.present(...)` (they post `.readerHighlightTapped`).
- **Gesture arbitration** — the long-press recognizer is named (`TXTBridgeShared.highlightLongPressName`); each coordinator's `gestureRecognizerShouldBegin(_:)` runs the same highlight hit-test the handler reuses so the recognizer only begins on a confirmed highlight hit, and `gestureRecognizer(_:shouldRecognizeSimultaneouslyWith:)` denies simultaneity when either side is the named long-press. A long-press on plain text never engages WI-6's recognizer (native selection proceeds); on a highlight it begins AND blocks the native selection recognizer.

## WI Status

- WI-6: behavioral — this PR (native TXT/MD/PDF wiring)
- Remaining WIs: WI-7 (final — EPUB + Foliate wiring)
- Prior: WI-1..WI-5 merged (PRs #918, #923, #927, #931, #933)

## Codex Audit (Gate 4)

3 rounds, thread `019e3f01`, verdict **ship-as-is**.

- Round 1 — 1 High + 1 Medium (the re-homed long-press was not isolated from native text selection on TXT/MD/chunked + PDF; `shouldRecognizeSimultaneouslyWith` unconditionally `true`) + 1 Low (test seam). Fixed: named recognizer + `gestureRecognizerShouldBegin` hit-test gate + name-aware non-simultaneous recognition.
- Round 2 — High/Medium confirmed resolved; refined Low to require pinning the core tap→notification / long-press→menu behavior swap. Fixed: 3 coordinator-level behavior tests with a spy presenter.
- Round 3 — clean, zero open findings of any severity.

Audit log: `.claude/codex-audits/feat-feature-55-wi-6-native-container-wiring-audit.md`

## Validation

- [x] `xcodebuild test` passes (Gate 3 test gate) — feature-55 suites run in isolation: 67 tests / 5 suites pass; full `vreaderTests` shows 0 real `✘` failures + 0 crash markers (non-zero host exit is the known Bug #221 flake).
- [x] Tests cover changed behavior (TDD: RED → GREEN) — `Feature55NativeWiringTests` (18 tests): attach-helper no-op/attach, hit-test resolution, gesture-arbitration policy + `gestureRecognizerShouldBegin` gating, and the tap→notification / long-press→menu behavior swap.
- [x] Codex audit loop completed (3 rounds, verdict: ship-as-is)
- [x] Docs sync — n/a (wiring integration; no new service/notification/schema/pattern; the user-visible feature completes at WI-7)
- [x] Version bumped: 3.34.14 → 3.34.15

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: behavioral — the tap→preview / long-press→menu end-to-end across all three native formats is exercised at Gate-5 device verification (final-WI acceptance pass after WI-7).
- This PR's slice is verified by the coordinator-level behavior tests: with a real laid-out `UITextView` fixture, a tap whose point lands inside a persisted highlight posts `.readerHighlightTapped` and does NOT present the #53 menu; a `.began` long-press on the same highlight presents the menu exactly once; a `.changed` continuation does not re-fire it. Gesture arbitration (`gestureRecognizerShouldBegin` + simultaneity policy) verified for TXT non-chunked, chunked, and PDF coordinators.

## Type of Change

- [x] Feature WI (Part of feature #619)

🤖 Generated with [Claude Code](https://claude.com/claude-code)