### PR TITLE
feat(#491 WI-3): route EPUB font size through FontSizeCalibrator

### DIFF
--- a/.claude/codex-audits/feat-feature-70-wi-3-epub-routing-audit.md
+++ b/.claude/codex-audits/feat-feature-70-wi-3-epub-routing-audit.md
@@ -1,0 +1,48 @@
+---
+branch: feat/feature-70-wi-3-epub-routing
+threadId: 019e3f41-0ee5-7042-9256-fcabd98dd7f2
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+# Codex audit log — Feature #70 (GH #491) WI-3 — route EPUB font size through FontSizeCalibrator
+
+Gate 4 (implementation audit) of the 6-gate feature workflow. Independent
+auditor: Codex MCP, thread `019e3f41`. Read-only sandbox.
+
+Audited diff: `vreader/Views/Reader/EPUBReaderContainerView.swift`,
+`vreaderTests/Models/ReaderThemeV2EPUBCSSCalibrationTests.swift`.
+
+## Round 1 findings
+
+0 Critical / 0 High / 0 Medium / 1 Low. Codex confirmed the one-line routing
+change matched the plan (`fontSize:` argument only, `letterSpacing` untouched,
+`$0` correctly the unwrapped `ReaderSettingsStore`, `.epub` calibrator path
+clamping to `12...64`, scope tight, Bug #57 selectors intact).
+
+| # | File | Severity | Finding | Resolution |
+|---|---|---|---|---|
+| 1 | `vreaderTests/Models/ReaderThemeV2EPUBCSSCalibrationTests.swift` | Low | The WI-3 tests built CSS directly via `ReaderThemeV2.epubOverrideCSS(fontSize: calibrated)` — they validated the calibrator + `epubOverrideCSS`, but did NOT exercise the actual `EPUBReaderContainerView` call site. A regression of that call site back to the raw `$0.typography.fontSize` would still pass every test. | Extracted a pure static helper `EPUBReaderContainerView.calibratedEPUBFontSize(for:)` returning `store.calibrator.calibratedSize(forUnified: store.typography.fontSize, target: .epub)`; the `epubOverrideCSS` call site now calls `Self.calibratedEPUBFontSize(for: $0)`. Added two tests (`containerHelperRoutesThroughCalibratorEpubTarget`, `containerHelperValueDiffersFromRawUnified`) that construct a real `@MainActor` `ReaderSettingsStore` and assert the helper returns the calibrated `.epub` value across 12/18/24/40/64 — a regression to the raw unified value is now caught. |
+
+Round-1 verdict: follow-up-recommended.
+
+## Round 2 re-review
+
+Codex re-read the fix commit and confirmed:
+
+- The round-1 Low is resolved. `EPUBReaderContainerView` exposes one pure
+  helper; the live production `epubOverrideCSS` call site uses that exact
+  helper; `rg` shows no parallel production path (the only non-test use is
+  that call site).
+- The new tests correctly exercise the helper on a real `@MainActor`
+  `ReaderSettingsStore`, verify `.epub` calibration across multiple values,
+  and assert the value differs from the raw unified `24`.
+- No new issues; scope tight; the helper body still routes through the
+  calibrator; the Bug #57 no-regression coverage remains intact.
+
+Round-2 verdict: **ship-as-is**.
+
+## Outcome
+
+Zero open Critical/High/Medium findings after 2 rounds. Gate 4 passes for WI-3.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 507
-        MARKETING_VERSION: 3.35.1
+        CURRENT_PROJECT_VERSION: 508
+        MARKETING_VERSION: 3.35.2
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5362,13 +5362,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 507;
+				CURRENT_PROJECT_VERSION = 508;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.35.1;
+				MARKETING_VERSION = 3.35.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5512,13 +5512,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 507;
+				CURRENT_PROJECT_VERSION = 508;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.35.1;
+				MARKETING_VERSION = 3.35.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -542,6 +542,7 @@
 		7E1AD7E1C555FE37FB7EC7FA /* DebugPositionResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D9F7749E205C92E5346FAE /* DebugPositionResolver.swift */; };
 		7E4274201E53904CDE46FC16 /* ReadingSessionTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398F1BAF549E7AC80E9CE320 /* ReadingSessionTrackerTests.swift */; };
 		7E4E6AF24C7B32B3C62953F9 /* AIProviderEditSheet+Sections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C23761CBD69F0641A15F71 /* AIProviderEditSheet+Sections.swift */; };
+		7E5B7EA85345570160FFB2BD /* ReaderThemeV2EPUBCSSCalibrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F771364B47585A44CCA66EA4 /* ReaderThemeV2EPUBCSSCalibrationTests.swift */; };
 		7E767F5BB300F8588492BD31 /* AISummaryTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F691E61DE6E713DE4FD47733 /* AISummaryTabView.swift */; };
 		7E84EE1334499F661728483E /* UpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89DE76057526BA48CAE2A83A /* UpdateChecker.swift */; };
 		7E88B70492874A1D1C0416D5 /* AnnotationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C86F6A1C143DB6AC9187FC0 /* AnnotationListView.swift */; };
@@ -2104,6 +2105,7 @@
 		F693921BA233745D77EC0037 /* SyncStatusMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusMonitor.swift; sourceTree = "<group>"; };
 		F70B62CBA5AED4AECA05825E /* SchemaV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV4.swift; sourceTree = "<group>"; };
 		F7672B4D5423E0D3AAE16343 /* MDReaderReplacementRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReaderReplacementRulesTests.swift; sourceTree = "<group>"; };
+		F771364B47585A44CCA66EA4 /* ReaderThemeV2EPUBCSSCalibrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeV2EPUBCSSCalibrationTests.swift; sourceTree = "<group>"; };
 		F77371DBD389CE1F1153E56E /* OPDSClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSClient.swift; sourceTree = "<group>"; };
 		F7968DAA000D9F45677960BA /* TTSHighlightCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSHighlightCoordinatorTests.swift; sourceTree = "<group>"; };
 		F79D3BEB86E859FEF2D09E2A /* BookDetailsSheet+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BookDetailsSheet+Actions.swift"; sourceTree = "<group>"; };
@@ -2192,6 +2194,7 @@
 				2EDF15104F7C0B4EAC533454 /* ReaderEngineTests.swift */,
 				3A480E951C2CA72DB6A22C24 /* ReaderThemeMigrationTests.swift */,
 				9081F5E7C359D5FB2661E7AC /* ReaderThemeTests.swift */,
+				F771364B47585A44CCA66EA4 /* ReaderThemeV2EPUBCSSCalibrationTests.swift */,
 				7F2360F05D5C411D05806514 /* ReaderThemeV2EPUBCSSChapterStartTests.swift */,
 				80381187837EB2DA41E98207 /* ReaderThemeV2Tests.swift */,
 				EE41196788F697BB4ACD4B06 /* ReadingSessionTests.swift */,
@@ -4545,6 +4548,7 @@
 				6173290A06E9E4303D363AE8 /* ReaderThemeCSSTests.swift in Sources */,
 				7A3B9A992F12E5E187F0794E /* ReaderThemeMigrationTests.swift in Sources */,
 				CB432F27C324A4EBC3D1F327 /* ReaderThemeTests.swift in Sources */,
+				7E5B7EA85345570160FFB2BD /* ReaderThemeV2EPUBCSSCalibrationTests.swift in Sources */,
 				088A6BACBD0B52E1AD639B58 /* ReaderThemeV2EPUBCSSChapterStartTests.swift in Sources */,
 				AAE6B9BC238DD37272640F0E /* ReaderThemeV2Tests.swift in Sources */,
 				11F1D99E4B3412CE344A4F16 /* ReaderTypographyTests.swift in Sources */,

--- a/vreader/Views/Reader/EPUBReaderContainerView.swift
+++ b/vreader/Views/Reader/EPUBReaderContainerView.swift
@@ -402,7 +402,14 @@ struct EPUBReaderContainerView: View {
                 // off the stored theme — Paper / Sepia / Dark / OLED / Photo.
                 themeCSS: settingsStore.map {
                     $0.theme.epubOverrideCSS(
-                        fontSize: $0.typography.fontSize,
+                        // Feature #70 WI-3: route the EPUB body font size
+                        // through the calibrator's `.epub` target so EPUB
+                        // (CSS px in a WKWebView) renders at a size
+                        // perceptually consistent with TXT (the anchor) at
+                        // the same slider value. The calibrator clamps the
+                        // result to the 12...64 text band.
+                        fontSize: $0.calibrator.calibratedSize(
+                            forUnified: $0.typography.fontSize, target: .epub),
                         lineHeight: $0.typography.lineSpacing,
                         letterSpacing: $0.typography.cjkSpacing ? $0.typography.fontSize * 0.05 / $0.typography.fontSize : 0,
                         fontFamily: $0.typography.fontFamily,

--- a/vreader/Views/Reader/EPUBReaderContainerView.swift
+++ b/vreader/Views/Reader/EPUBReaderContainerView.swift
@@ -26,6 +26,19 @@ struct EPUBReaderContainerView: View {
     /// Bug #142: per-reader instance token paired with fingerprintKey.
     var readerToken: UUID?
 
+    /// Feature #70 WI-3: the EPUB body font size the container injects into
+    /// `epubOverrideCSS`, routed through the calibrator's `.epub` target so
+    /// EPUB (CSS px in a WKWebView) renders at a size perceptually consistent
+    /// with TXT (the calibration anchor) at the same slider value.
+    ///
+    /// Extracted as a pure static helper so the WI-3 routing seam is directly
+    /// unit-testable — a regression to the raw `typography.fontSize` is caught
+    /// here, not silently passed by a test that builds CSS directly.
+    static func calibratedEPUBFontSize(for store: ReaderSettingsStore) -> CGFloat {
+        store.calibrator.calibratedSize(
+            forUnified: store.typography.fontSize, target: .epub)
+    }
+
     /// OPF directory — spine hrefs are resolved relative to this.
     @State var resourceBase: URL?
     /// Extracted root directory — passed to WKWebView for file access.
@@ -403,13 +416,12 @@ struct EPUBReaderContainerView: View {
                 themeCSS: settingsStore.map {
                     $0.theme.epubOverrideCSS(
                         // Feature #70 WI-3: route the EPUB body font size
-                        // through the calibrator's `.epub` target so EPUB
-                        // (CSS px in a WKWebView) renders at a size
-                        // perceptually consistent with TXT (the anchor) at
-                        // the same slider value. The calibrator clamps the
-                        // result to the 12...64 text band.
-                        fontSize: $0.calibrator.calibratedSize(
-                            forUnified: $0.typography.fontSize, target: .epub),
+                        // through the calibrator's `.epub` target (see
+                        // `calibratedEPUBFontSize(for:)`) so EPUB (CSS px in
+                        // a WKWebView) renders at a size perceptually
+                        // consistent with TXT (the anchor) at the same
+                        // slider value. Clamped to the 12...64 text band.
+                        fontSize: Self.calibratedEPUBFontSize(for: $0),
                         lineHeight: $0.typography.lineSpacing,
                         letterSpacing: $0.typography.cjkSpacing ? $0.typography.fontSize * 0.05 / $0.typography.fontSize : 0,
                         fontFamily: $0.typography.fontFamily,

--- a/vreaderTests/Models/ReaderThemeV2EPUBCSSCalibrationTests.swift
+++ b/vreaderTests/Models/ReaderThemeV2EPUBCSSCalibrationTests.swift
@@ -124,5 +124,37 @@ struct ReaderThemeV2EPUBCSSCalibrationTests {
         }
     }
 
+    // MARK: - WI-3 routing seam (the actual EPUBReaderContainerView wiring)
+
+    /// `EPUBReaderContainerView.calibratedEPUBFontSize(for:)` is the pure
+    /// helper the container's `epubOverrideCSS` call site uses. It MUST
+    /// return the calibrator's `.epub` mapping of the store's unified font
+    /// size — a regression to the raw `typography.fontSize` is caught here.
+    @Test @MainActor func containerHelperRoutesThroughCalibratorEpubTarget() {
+        let store = ReaderSettingsStore(
+            defaults: UserDefaults(suiteName: "EPUBCSSCalibTests-\(UUID().uuidString)")!
+        )
+        for unified in [CGFloat(12), 18, 24, 40, 64] {
+            store.typography.fontSize = unified
+            let helperValue = EPUBReaderContainerView.calibratedEPUBFontSize(for: store)
+            let expected = store.calibrator.calibratedSize(forUnified: unified, target: .epub)
+            #expect(helperValue == expected)
+        }
+    }
+
+    /// The container helper's value is the *calibrated* value, NOT the raw
+    /// unified `typography.fontSize` — for a non-`1.0` `.epub` multiplier the
+    /// two differ.
+    @Test @MainActor func containerHelperValueDiffersFromRawUnified() {
+        let store = ReaderSettingsStore(
+            defaults: UserDefaults(suiteName: "EPUBCSSCalibTests-\(UUID().uuidString)")!
+        )
+        store.typography.fontSize = 24
+        let helperValue = EPUBReaderContainerView.calibratedEPUBFontSize(for: store)
+        // Shipped .epub multiplier is > 1.0.
+        #expect(helperValue != 24)
+        #expect(helperValue == store.calibrator.calibratedSize(forUnified: 24, target: .epub))
+    }
+
     #endif
 }

--- a/vreaderTests/Models/ReaderThemeV2EPUBCSSCalibrationTests.swift
+++ b/vreaderTests/Models/ReaderThemeV2EPUBCSSCalibrationTests.swift
@@ -1,0 +1,128 @@
+// Purpose: Tests for feature #70 WI-3 — the EPUB path feeds the calibrated
+// `.epub` font-size value into `ReaderThemeV2.epubOverrideCSS`. Verifies the
+// calibrated value reaches the injected CSS AND that Bug #57's cascade-
+// neutralization selectors are NOT regressed (the literal "no regression in
+// bug #57" acceptance item).
+
+import Testing
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+@testable import vreader
+
+@Suite("ReaderThemeV2EPUBCSSCalibration")
+struct ReaderThemeV2EPUBCSSCalibrationTests {
+
+    #if canImport(UIKit)
+
+    private let calibrator = FontSizeCalibrator()
+
+    // MARK: - Calibrated value reaches the injected CSS
+
+    /// `epubOverrideCSS` emits `font-size: <value>px` for the value it is
+    /// given — and when fed the calibrator's `.epub` mapping, that calibrated
+    /// value (not the raw unified value) is what lands in the CSS.
+    @Test func epubOverrideCSSEmitsCalibratedFontSize() {
+        let unified: CGFloat = 24
+        let calibrated = calibrator.calibratedSize(forUnified: unified, target: .epub)
+        let css = ReaderThemeV2.paper.epubOverrideCSS(fontSize: calibrated)
+        // epubOverrideCSS formats the size as "%.1f".
+        let expected = "font-size: \(String(format: "%.1f", calibrated))px"
+        #expect(css.contains(expected))
+    }
+
+    /// For a non-`1.0` EPUB multiplier, the injected `html, body` font-size is
+    /// the *calibrated* value — strictly larger than the raw unified value
+    /// would have produced (the shipped `.epub` multiplier is `> 1.0`).
+    @Test func injectedFontSizeIsCalibratedNotRawUnified() {
+        let unified: CGFloat = 24
+        let calibrated = calibrator.calibratedSize(forUnified: unified, target: .epub)
+        // Shipped .epub multiplier is > 1.0, so the calibrated value differs
+        // from the raw unified value.
+        #expect(calibrated != unified)
+        let css = ReaderThemeV2.paper.epubOverrideCSS(fontSize: calibrated)
+        let rawString = "font-size: \(String(format: "%.1f", unified))px"
+        let calibratedString = "font-size: \(String(format: "%.1f", calibrated))px"
+        #expect(css.contains(calibratedString))
+        // The raw unified value must NOT appear as the html,body font-size.
+        #expect(!css.contains(rawString))
+    }
+
+    // MARK: - Bug #57 no-regression (the real selectors)
+
+    /// Bug #57's cascade neutralization for the enumerated text elements must
+    /// still be present — `font-size: inherit !important` inside the
+    /// `p, div, span, li, td, th, dd, dt, blockquote, figcaption` rule.
+    @Test func bug57TextElementInheritRuleStillPresent() {
+        let css = ReaderThemeV2.paper.epubOverrideCSS(fontSize: 24)
+        #expect(css.contains("p, div, span, li, td, th, dd, dt, blockquote, figcaption"))
+        // The enumerated-text-element rule flattens font-size.
+        #expect(css.contains("font-size: inherit !important"))
+    }
+
+    /// Bug #57: headings keep the book's own relative sizing via
+    /// `font-size: revert !important` inside the `h1..h6` rule.
+    @Test func bug57HeadingRevertRuleStillPresent() {
+        let css = ReaderThemeV2.paper.epubOverrideCSS(fontSize: 24)
+        #expect(css.contains("h1,h2,h3,h4,h5,h6"))
+        #expect(css.contains("font-size: revert !important"))
+    }
+
+    /// Bug #57: the `body *` universal selector applies to `font-family`
+    /// ONLY — it must NOT carry a `font-size` declaration. This guards
+    /// against the v1-plan mis-statement (`body * { font-size: inherit }`).
+    @Test func bug57BodyUniversalSelectorIsFontFamilyOnly() {
+        let css = ReaderThemeV2.paper.epubOverrideCSS(fontSize: 24)
+        #expect(css.contains("body * { "))
+        #expect(css.contains("font-family: inherit !important"))
+        // Extract the `body * { ... }` rule and assert it has no font-size.
+        if let range = css.range(of: "body * { ") {
+            let afterSelector = css[range.upperBound...]
+            if let endBrace = afterSelector.range(of: "}") {
+                let ruleBody = afterSelector[..<endBrace.lowerBound]
+                #expect(!ruleBody.contains("font-size"))
+            } else {
+                Issue.record("body * rule has no closing brace")
+            }
+        } else {
+            Issue.record("body * selector not found")
+        }
+    }
+
+    // MARK: - Boundary calibrated values
+
+    /// A calibrated value at the clamp edges still produces valid CSS with a
+    /// `font-size: <n>px` declaration.
+    @Test func boundaryCalibratedValuesProduceValidCSS() {
+        for unified in [CGFloat(12), 64] {
+            let calibrated = calibrator.calibratedSize(forUnified: unified, target: .epub)
+            let css = ReaderThemeV2.paper.epubOverrideCSS(fontSize: calibrated)
+            #expect(css.contains("font-size: \(String(format: "%.1f", calibrated))px"))
+            // Calibrated EPUB value stays within the text band 12...64.
+            #expect(calibrated >= 12 && calibrated <= 64)
+        }
+    }
+
+    /// The calibrated EPUB value at the maximum unified size (64) is clamped
+    /// to the text band — it never exceeds 64, so the injected CSS never
+    /// requests an out-of-band size.
+    @Test func calibratedEPUBValueAtMaxIsClampedToTextBand() {
+        let calibrated = calibrator.calibratedSize(forUnified: 64, target: .epub)
+        #expect(calibrated == 64)
+        let css = ReaderThemeV2.paper.epubOverrideCSS(fontSize: calibrated)
+        #expect(css.contains("font-size: 64.0px"))
+    }
+
+    /// The EPUB target's calibrated mapping is consistent across themes —
+    /// `epubOverrideCSS` font-size does not depend on the theme.
+    @Test func calibratedFontSizeIsThemeIndependent() {
+        let calibrated = calibrator.calibratedSize(forUnified: 30, target: .epub)
+        let sizeString = "font-size: \(String(format: "%.1f", calibrated))px"
+        for theme in [ReaderThemeV2.paper, .sepia, .dark, .oled, .photo] {
+            #expect(theme.epubOverrideCSS(fontSize: calibrated).contains(sizeString))
+        }
+    }
+
+    #endif
+}


### PR DESCRIPTION
## Summary

Part of feature #70 (GH #491) — Cross-format font-size perceptual calibration.

WI-3 routes the EPUB reader's injected-CSS body font size through the WI-1
`FontSizeCalibrator`'s `.epub` target.

## What this WI changes

- `EPUBReaderContainerView`
  - Adds a pure static helper `calibratedEPUBFontSize(for store:)` that
    returns `store.calibrator.calibratedSize(forUnified: store.typography.fontSize, target: .epub)`.
  - The `epubOverrideCSS` call site now passes `Self.calibratedEPUBFontSize(for: $0)`
    as the `fontSize:` argument instead of the raw `$0.typography.fontSize`.

EPUB renders as CSS px inside a `WKWebView`; routing the injected
`html, body { font-size }` through the calibrator's `.epub` target makes EPUB
render at a size perceptually consistent with TXT (the calibration anchor) at
the same slider value. The calibrator clamps the EPUB result to the `12...64`
text band.

The `letterSpacing` line (which divides `fontSize` by itself producing a
constant `0.05`) is left untouched — it does not depend on the calibrated
value (out of scope per the plan).

**Bug #57 is orthogonal and untouched.** WI-3 does not modify
`ReaderThemeV2+EPUBCSS.swift`, so Bug #57's cascade-neutralization rules —
`p, div, span, li, td, th, dd, dt, blockquote, figcaption { font-size: inherit !important }`
and `h1..h6 { font-size: revert !important }` — still flatten the EPUB internal
cascade. Feature #70 only re-anchors the cross-renderer baseline.

## Tests

- `ReaderThemeV2EPUBCSSCalibrationTests` (10, Swift Testing) — the calibrated
  `.epub` value reaches the injected `html, body` font-size CSS and the raw
  unified value does NOT; explicit no-regression-vs-Bug-#57 assertions on the
  **real** selectors (the enumerated-text-element `font-size: inherit`, the
  `h1..h6 font-size: revert`, and that `body *` is font-family-only — never
  font-size); and two tests that exercise the actual routing seam —
  `calibratedEPUBFontSize(for:)` on a real `@MainActor` `ReaderSettingsStore`.
  Scoped run `ReaderThemeV2EPUBCSSCalibrationTests` +
  `EPUBThemeOverrideCSSV2Tests` → **TEST SUCCEEDED**, 28/28 (the pre-existing
  EPUB CSS suite stays green — no Bug #57 regression).

## Test gate note

`xcodebuild test -only-testing:vreaderTests` reports `** TEST FAILED **`, but
the failures are pre-existing test-infrastructure flakiness unrelated to this
PR: (1) the GH #849 flaky test-host crash; (2) `DebugReaderRegistryAwaitReaderTests`
singleton-isolation flakiness (the suite name literally references Bug #228 —
`bug228_concurrentResetOnSiblingRegistry`). `DebugReaderRegistryAwaitReaderTests`
**passes when run alone serially** (6/6, TEST SUCCEEDED) — it only fails under
cross-suite parallel execution. WI-3 touches only `EPUBReaderContainerView`'s
font-size routing — it cannot affect `DebugReaderRegistry`. The
`ReaderThemeV2EPUBCSSCalibration` suite passes cleanly in every run.

## Gate 4 — implementation audit

Codex thread `019e3f41`, 2 rounds, **ship-as-is**. Round 1: 0 Critical/High/
Medium, 1 Low (the WI-3 tests didn't exercise the actual call-site routing) —
fixed by extracting the testable `calibratedEPUBFontSize(for:)` helper. Round
2: ship-as-is. Full log: `.claude/codex-audits/feat-feature-70-wi-3-epub-routing-audit.md`.

## Gate 5 — slice verification

Behavioral WI. **EPUB slice verified end-to-end on iPhone 17 Pro Simulator**
(`1FAB9493…`, DEBUG build of this branch, `vreader-debug://` harness):

1. `reset` → `seed mini-epub3` → `theme mode=light fontSize=30` → `open` →
   `settle` → `ready-*.json` reports `format: epub` with no error; `snapshot`
   confirms `currentBookId` set, `format: epub`.
2. `eval getComputedStyle(document.body).fontSize` → **`33.599998px`** — this
   is exactly the **calibrated `.epub` value** (`30 × 1.12 = 33.6`, `%.1f`
   CSS-formatted). The raw unified value would have been `30px`. This proves
   end-to-end that the WI-3 calibrator routing reaches the actual rendered
   EPUB CSS.
3. `eval getComputedStyle(<p>).fontSize` → **`33.599998px`** — identical to
   the body, confirming **Bug #57's cascade-flattening is NOT regressed**:
   the enumerated text element `<p>` inherits the single calibrated injected
   size and does not compound.
4. On-screen render shows the mini-epub3 fixture with the calibrated font
   size and the chapter-start drop-cap — EPUB renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
