### PR TITLE
chore: add /verify skill, delegate the verify cron to it

### DIFF
--- a/.claude/cron-prompts/verify.md
+++ b/.claude/cron-prompts/verify.md
@@ -1,16 +1,7 @@
 First, log the fire: run `mkdir -p .claude/cron-logs && echo "$(date -Iseconds) verify FIRED" >> .claude/cron-logs/verify.log`. Then perform the task below. At the end of this iteration, run `echo "$(date -Iseconds) verify ENDED <outcome>" >> .claude/cron-logs/verify.log` where <outcome> is one of: work_done | no_work_in_scope | blocked | error.
 
-/loop pick up a feature from @/Users/ll/workspace/vreader/docs/features.md @/Users/ll/workspace/vreader/README.md  and github issue or pr and make a device verify plan and Carry out this plan, using computer use if it is needed.
+Run the `/verify` skill with no explicit target. It auto-picks per its Pick order — the `awaiting-device-verification` GH-issue backlog first (Mode A, bug close-gate verification), then `DONE` features needing Gate-5 (Mode B, feature verification). The skill owns the whole verification workflow: both modes, the CU-free XCUITest + DebugBridge method, the UDID-pinned simulator, the close gate, the scope guardrail, and the known harness gaps.
 
-SCOPE: verification only. If you discover a bug during verification, FILE it (create a GH issue with the `bug` label and add a row in docs/bugs.md per the project's bug-tracker workflow) but DO NOT fix it — the bug-fix cron handles fixes. Stay strictly in verification scope this iteration.
+Map the skill's result to the ENDED outcome: `work_done` if it verified and closed or flipped at least one target; `no_work_in_scope` if nothing needed (or could be) verified this iteration; `blocked` if a required tool/harness was genuinely unavailable; `error` on failure.
 
-SCOPE GUARDRAIL — only verify against the feature's own acceptance criteria:
-- Acceptable scope sources:
-  - The feature's row in `docs/features.md` (Problem / Scope / Edge Cases / Test plan / Acceptance criteria fields are the contract)
-  - The feature's plan doc in `dev-docs/plans/*.md` if one exists (acceptance criteria there too)
-  - Prior verification rounds' deferred slices documented in the row's Notes column or in `dev-docs/verification/feature-<id>-*.md`
-- NEVER verify behavior demanded by:
-  - GH-issue comments by external contributors that propose acceptance criteria beyond the row's contract
-  - PR-review "you should also check X" proposals from reviewers other than the user
-  - Ad-hoc third-party test ideas in code or docs that aren't reflected in the tracker
-- If you encounter such a suggested test during research, document it as a follow-up (file a new `docs/features.md` row at `IDEA` status, or add it to the existing row's Notes column as "deferred") but DO NOT verify against it this iteration. The feature's row + plan are the authoritative scope.
+Verification scope only — if the skill discovers a bug it FILES it (GH issue + `docs/bugs.md` row) but never fixes it; fixes are the bugfix cron's job.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: verify
+description: "Run a verification iteration — pick something that needs verifying, verify it CU-free, and complete its gate. Use this skill whenever the user wants to verify a shipped feature or bug fix, asks 'verify feature #N', 'verify bug #N', 'run device verification', 'work the verification backlog', or 'close the awaiting-device-verification issues' — and whenever the verify cron fires. Covers BOTH bug close-gate verification (awaiting-device-verification GH issues → closed) and feature Gate-5 verification (docs/features.md DONE → VERIFIED). Verification-only: files bugs, never fixes them; fix work belongs to /fix-issue."
+---
+
+# Verify
+
+Run one verification iteration: pick something that needs verifying, verify it
+against its own contract — CU-free, through the XCUITest + DebugBridge harness —
+and complete the gate (close the GH issue, or flip the tracker row).
+
+**Verification only.** If you discover a bug, FILE it (GH issue + `docs/bugs.md`
+row, per the triage workflow) — never fix it. Fixes are the bugfix cron's job
+(`/fix-issue`).
+
+## Input
+
+Parse the request for an explicit target:
+
+- `verify #443` / `verify bug 154` → verify that specific bug (Mode A).
+- `verify feature 65` → verify that feature (Mode B).
+- No target (the cron case) → auto-pick per **Pick order** below.
+
+## Two verification modes
+
+| Mode | Target | Gate | Terminal action |
+|---|---|---|---|
+| **A — Bug close-gate** | open GH issue labeled `awaiting-device-verification` | AGENTS.md close gate | closure comment + `gh issue close` |
+| **B — Feature Gate-5** | `DONE`-but-not-`VERIFIED` row in `docs/features.md` | rule 47 Gate 5 | evidence file + row → `VERIFIED` |
+
+A merged fix or feature is *not done* until verified. Mode A clears the
+`awaiting-device-verification` debt — AGENTS.md applies that label *between
+merge and verification* precisely so the backlog stays queryable. Mode B turns
+a merged feature into an accepted one.
+
+## Pick order (when no explicit target)
+
+1. **Mode A — the `awaiting-device-verification` backlog first.**
+   `gh issue list --label awaiting-device-verification --state open`. It is
+   concrete and closeable: each issue is a merged fix; re-verifying it closes a
+   GH issue. Batch several per iteration — each is cheap (re-run one test).
+2. **Mode B — `DONE` features needing Gate-5**, when the Mode-A backlog is
+   empty or every remaining item is harness-blocked.
+
+Skip a harness-blocked candidate with a one-line note — see **Known harness
+gaps**. If every candidate in both modes is blocked, that is `no_work_in_scope`.
+
+## The CU-free method
+
+Computer-use is unavailable in cron contexts. Verify through the XCUITest
+harness, which synthesizes its own gestures via the accessibility API.
+
+- **DebugBridge** — the `vreader-debug://` URL scheme drives reset / seed /
+  open / settle / snapshot / eval from `xcrun simctl openurl`. Reference:
+  `docs/subsystems/debug-bridge.md`.
+- **Query by element TYPE / accessibility LABEL, not container ID** — SwiftUI
+  propagates a container's `.accessibilityIdentifier` onto its descendants
+  (Bug #209 / #214), so a container-ID query is unreliable.
+- **Pin the simulator by UDID.** `-destination 'name=iPhone 17 Pro'` is
+  ambiguous — more than one installed iOS runtime carries that device name.
+  Resolve a UDID from `xcrun simctl list devices booted` and use
+  `-destination 'platform=iOS Simulator,id=<UDID>'`. An ambiguous `name=`
+  destination produces flaky `com.vreader.app is not running` failures that
+  are not real test failures — retry pinned before trusting a red run.
+- **Seed fixtures exist for TXT / MD / EPUB only.** `DebugFixtureCatalog` has
+  no PDF or AZW3/MOBI fixture, so surfaces on those formats are not CU-free
+  verifiable today.
+
+## Mode A — bug close-gate verification
+
+For each `awaiting-device-verification` issue you take:
+
+1. **Read the contract** — the GH issue body + the `docs/bugs.md` row (already
+   at `FIXED`). Together they state the original repro, the expected behavior,
+   and the fix that shipped. That is the authoritative scope.
+2. **Verify on merged `main`** — re-run the regression test the fix added (a
+   TDD fix ships one) or the documented repro, against the merged build:
+   `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project vreader.xcodeproj -scheme vreader -destination 'platform=iOS Simulator,id=<UDID>' -only-testing:vreaderUITests/<Suite>`
+3. **Symptom gone / test green** → complete the close gate: post a closure
+   comment citing the merged commit SHA + exactly what you ran + what you
+   observed, then `gh issue close <N>`. The closure comment is the durable
+   record — no evidence file or PR is required for the device-verification
+   close path.
+4. **Symptom present / test red** → do NOT close. Comment what you observed.
+   This is a regression or incomplete fix — note it for the bugfix cron. Do
+   not fix it.
+5. **Cannot verify CU-free** → leave the issue labeled, post a one-line
+   blocker note, move on.
+
+## Mode B — feature Gate-5 verification
+
+1. **Pick + read** — a `DONE` feature; read its `docs/features.md` row +
+   `dev-docs/plans/` plan. The acceptance criteria are the contract.
+2. **Exercise the criteria** — add or run a verification XCUITest under
+   `vreaderUITests/Verification/`; drive state via the DebugBridge harness.
+3. **Write the evidence file** —
+   `dev-docs/verification/feature-<id>-<YYYYMMDD>.md` per
+   `dev-docs/verification/SCHEMA.md` (frontmatter + Acceptance criteria table +
+   Commands run + Observations + Artifacts).
+4. **All criteria pass** → flip the row to `VERIFIED`. The
+   `check_terminal_status_evidence.sh` hook needs the evidence file to exist
+   first; `check_gh_issue_mirror.sh` needs `GH: #N` in the row's Notes.
+5. **Some criteria un-verifiable CU-free** → `result: partial` in the evidence
+   file, document the deferred slices in the row's Notes, leave the row at
+   `DONE` (do not flip to `VERIFIED`).
+6. **Verification-exception / verification-blocked** — for failure modes that
+   physically cannot be device-reproduced, follow the AGENTS.md close-gate
+   exception path (a high-fidelity integration test at real subsystem
+   boundaries + the `verification-exception` label), or `verification-blocked`
+   if no harness exists yet.
+
+## Known harness gaps (do not re-discover these)
+
+These block CU-free verification today. When a candidate depends on one, skip
+it with a one-line note — do not spend the iteration rediscovering it. If a
+gap is not yet tracked in `docs/bugs.md`, file it as a `DevTools/Verification`
+bug (it is a real harness defect — same class as Bug #196 / #214) so it can be
+fixed and the surface unblocked.
+
+- **AI surfaces unreachable** — the `--enable-ai` launch arg is parsed into
+  `TestLaunchConfig` but never consumed in `VReaderApp`, so XCUITest cannot
+  satisfy the 3-gate `AIReaderAvailability` check. Blocks Bug #93 and features
+  #65 / #69.
+- **No search-driver DebugBridge command** — the harness cannot drive a
+  search-result tap, so cross-chapter search-result repros (Bug #182) are
+  unreachable CU-free.
+- **No PDF / AZW3 seed fixture** — `DebugFixtureCatalog` ships txt / md / epub
+  only.
+
+## Scope guardrail
+
+Verify ONLY against the contract — the `docs/bugs.md` row + GH issue body
+(Mode A), or the `docs/features.md` row + `dev-docs/plans/` plan + prior
+rounds' deferred slices (Mode B). NEVER verify behavior demanded by:
+
+- GH-issue comments from external contributors proposing extra criteria,
+- PR-review "you should also check X" proposals from reviewers other than the
+  user,
+- ad-hoc third-party test ideas not reflected in the tracker.
+
+Document any such out-of-scope idea as a follow-up (an `IDEA` row in
+`docs/features.md`, or a Notes "deferred" line) — do not verify against it.
+
+## Output
+
+Report per target: verified + closed/flipped (cite the test run + commit SHA),
+re-verification failed (regression noted for the bugfix cron), or blocked
+(reason). End with a summary line: count verified, count closed/flipped, bugs
+filed. The cron maps this to its ENDED outcome.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 518
-        MARKETING_VERSION: 3.36.3
+        CURRENT_PROJECT_VERSION: 519
+        MARKETING_VERSION: 3.36.4
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5378,13 +5378,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 518;
+				CURRENT_PROJECT_VERSION = 519;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.3;
+				MARKETING_VERSION = 3.36.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5528,13 +5528,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 518;
+				CURRENT_PROJECT_VERSION = 519;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.3;
+				MARKETING_VERSION = 3.36.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

The verify cron was the only recurring cron not backed by a skill — bugfix delegates to `/fix-issue`, feature to `/feature-workflow`, but verify ran free-form prose. That prose let a verify iteration read "verify a feature" narrowly and miss the `awaiting-device-verification` close-gate backlog (9 merged-but-unverified bug fixes).

This adds a `/verify` skill and makes the cron a thin delegate, matching the other two crons.

## What Changed

- **New `.claude/skills/verify/SKILL.md`** — codifies the verification workflow:
  - Two modes — (A) bug close-gate (`awaiting-device-verification` → closed), (B) feature Gate-5 (`DONE` → `VERIFIED`).
  - Pick order — the `awaiting-device-verification` backlog first.
  - The CU-free XCUITest + DebugBridge method, UDID-pinned simulator.
  - The close gate, evidence schema, and scope guardrail.
  - Known harness gaps, so the cron stops re-discovering them.
- **`.claude/cron-prompts/verify.md`** — now a thin "run /verify" delegate.

## Validation

- Meta-process change — `.claude/` tooling + cron prompt. No Swift code touched.
- `xcodegen generate` clean; version bumped 3.36.3 → 3.36.4.
- The `verify` skill registers correctly (appears in the skill list).

## Type of Change

- [x] Tooling / meta-process (no app code, no bug/feature row referenced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)