### PR TITLE
feat(#64 WI-3): HighlightCoordinator color/note mutations for unified popover

### DIFF
--- a/.claude/codex-audits/feat-feature-64-wi-3-coordinator-mutations-audit.md
+++ b/.claude/codex-audits/feat-feature-64-wi-3-coordinator-mutations-audit.md
@@ -1,0 +1,45 @@
+---
+branch: feat/feature-64-wi-3-coordinator-mutations
+threadId: 019e4069-65e1-7701-b5e8-f6cdc18d0307
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+# Gate-4 Implementation Audit — Feature #64 WI-3 (HighlightCoordinator color/note mutations)
+
+## Scope
+
+WI-3 of the unified cross-format highlight-action popover. Adds the two highlight mutations the popover drives:
+
+- `vreader/Views/Reader/HighlightCoordinator.swift` (MOD) — `changeColor(highlightID:to:)` + `updateNote(highlightID:note:)`, both returning the typed `HighlightMutationOutcome`. Plus the static `normalizedNote(_:)`. Existing methods untouched.
+- `vreader/Views/Reader/HighlightRenderer.swift` (MOD) — new refinement protocol `ChapterScopedHighlightRenderer: HighlightRenderer` with `var currentChapterHref: String? { get }`.
+- `vreader/Views/Reader/EPUBHighlightRenderer.swift` (MOD) — conforms `EPUBHighlightRenderer` to `ChapterScopedHighlightRenderer`.
+- `vreaderTests/Views/Reader/HighlightCoordinatorMutationTests.swift` (NEW) — 15 tests.
+
+## Round 1 — Codex `019e4069-65e1-7701-b5e8-f6cdc18d0307`
+
+Three findings — all the same root cause (the post-mutation re-fetch swallowing errors):
+
+| # | File:line | Severity | Issue | Fix |
+|---|-----------|----------|-------|-----|
+| F1 | `HighlightCoordinator.swift:159` (changeColor) + `:188` (updateNote) | **Medium** | The post-mutation `refetchHighlight(_:)` helper used `try?` over `fetchHighlights`, so a *generic fetch failure* after a *successful write* returned `nil` → mapped to `.notFound`. Violates R1-5: a read failure after a successful write must be `.failed`, not "record deleted, dismiss the popover". | Fetch explicitly in a do/catch; map `throw` → `.failed`; map only "fetched OK but no matching id" → `.notFound`. |
+| F2 | `HighlightCoordinator.swift:164` (changeColor) | **Medium** | `changeColor` repainted via `restoreAll(forHref:)`, which swallows its *own* `fetchHighlights` failure and no-ops — so `changeColor` could return `.success(record)` while the page repaint silently never happened. Breaks §3.4's "persist, then repaint" contract. | Repaint from the already-fetched `records` directly via `renderer.restore(records:forHref:using:)` — the re-fetch already carries the new color. |
+| F3 | `HighlightCoordinatorMutationTests.swift:171` | Low | The mock could not fail `fetchHighlights`, so the F1/F2 paths were untested. | Add a mock mode where `fetchHighlights` throws after a successful mutation; assert `.failed` + no repaint. |
+
+The auditor confirmed everything else clean in round 1: `ChapterScopedHighlightRenderer` is the right abstraction (narrow, read-only, exposes existing renderer state, makes the href-capture fix testable without binding the coordinator to `EPUBHighlightRenderer`); the EPUB race test is meaningful and deterministic (mutates `currentHref` during the awaited persistence call, asserts the value actually threaded into `restore(...forHref:)`, proving pre-await capture).
+
+## Resolution
+
+- **F1 + F2** — removed the `refetchHighlight(_:)` helper. Both `changeColor` and `updateNote` now fetch explicitly inside a do/catch: a `fetchHighlights` throw → `.failed`; only a clean fetch with no matching id → `.notFound`. `changeColor` repaints from the already-fetched `records` directly via `renderer.restore(records:forHref: capturedHref, using: nil)` — the repaint is only reached on a successful fetch, so a `.success` return always implies a repaint was driven.
+- **F3** — added a `fetchThrowsAfterMutation` mock mode + 4 new tests: `changeColor_refetchThrowsAfterSuccess_returnsFailed` (asserts `.failed` + `renderer.restoreCalls == 0`), `changeColor_recordGoneOnCleanRefetch_returnsNotFound`, `updateNote_refetchThrowsAfterSuccess_returnsFailed`, `updateNote_recordGoneOnCleanRefetch_returnsNotFound`.
+
+WI-3 test gate re-ran: 23 tests pass (15 mutation + 8 coordinator).
+
+## Round 2 — Codex `019e4069-65e1-7701-b5e8-f6cdc18d0307` (re-audit of the fixes)
+
+Verdict: **"No findings. The three prior findings are resolved."** Codex verified the explicit do/catch fetch with correct `.failed`/`.notFound` mapping, the direct repaint from fetched records, and the 4 new failure-split tests. **No remaining open Critical/High/Medium findings.**
+
+## Verdict
+
+**ship-as-is** — 2 rounds (round 1 caught the re-fetch error-swallowing bug, fixed by an explicit do/catch + a direct repaint; round 2 clean).

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 524
-        MARKETING_VERSION: 3.36.9
+        CURRENT_PROJECT_VERSION: 525
+        MARKETING_VERSION: 3.36.10
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -888,6 +888,7 @@
 		CEAEA28FA9D03BDAACC97CBF /* SyncOutboundQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B00C0FE14AB02EDE7E9EDD /* SyncOutboundQueueTests.swift */; };
 		CFC40B5FB55F37C092A70338 /* VReaderAnnotationParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36D5CFF47A223349C004E39 /* VReaderAnnotationParserTests.swift */; };
 		CFF2F7127E363B96F2B6429B /* LibraryBookItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E3D2050D82A39083191EDDA /* LibraryBookItem.swift */; };
+		CFF91208E4CD56126CC9FB8D /* HighlightCoordinatorMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1700C3F11D9ECDDBC750B939 /* HighlightCoordinatorMutationTests.swift */; };
 		D007D50EE76181258F5D0681 /* SelectiveRestoreCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9358413A64690874ED7AB67D /* SelectiveRestoreCoordinatorTests.swift */; };
 		D012C1E7B7D9AD21911C9E8E /* ContinueReadingRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E63B3DC1B23F9594470E3B /* ContinueReadingRail.swift */; };
 		D0373F025DFBBEF9FAD19788 /* LazyDownloadBackgroundEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F891C451718B4BC9AC7BCEC /* LazyDownloadBackgroundEventsTests.swift */; };
@@ -1192,6 +1193,7 @@
 		16C23761CBD69F0641A15F71 /* AIProviderEditSheet+Sections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AIProviderEditSheet+Sections.swift"; sourceTree = "<group>"; };
 		16C77872C4F869769F4C83F7 /* ReaderContainerView+Sheets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderContainerView+Sheets.swift"; sourceTree = "<group>"; };
 		16E293CFD61A19BB48B38963 /* HighlightableTextViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightableTextViewTests.swift; sourceTree = "<group>"; };
+		1700C3F11D9ECDDBC750B939 /* HighlightCoordinatorMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightCoordinatorMutationTests.swift; sourceTree = "<group>"; };
 		1790A0CEB902B16952776EE4 /* HighlightPaintColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPaintColorTests.swift; sourceTree = "<group>"; };
 		17E7FD8CD67F19A2213DB6F5 /* PDFViewBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFViewBridge.swift; sourceTree = "<group>"; };
 		181E14C009F03D7B2EE1F117 /* StatusBarTintingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarTintingTests.swift; sourceTree = "<group>"; };
@@ -2605,6 +2607,7 @@
 				44FC663099F4228086D7EA54 /* FoliateSpikeViewTTSTests.swift */,
 				9B2676F3D304FF8ABE845A8B /* FoliateViewCoordinatorTests.swift */,
 				16E293CFD61A19BB48B38963 /* HighlightableTextViewTests.swift */,
+				1700C3F11D9ECDDBC750B939 /* HighlightCoordinatorMutationTests.swift */,
 				EE90002A18E00A2E245C23BC /* HighlightCoordinatorTapHandlerTests.swift */,
 				2724D3C50EDE1DC1DA43BB5F /* HighlightCoordinatorTests.swift */,
 				FABEAF0841AD808F7EE48617 /* HighlightIntegrationTests.swift */,
@@ -4456,6 +4459,7 @@
 				43228D2AF27BDD7DDD6BB5AB /* HTTPTTSConfigTests.swift in Sources */,
 				FB4B2B41D865A14865DF4DE1 /* HTTPTTSProviderTests.swift in Sources */,
 				9D982FAFD79829613C2EFECB /* HighlightAnchorStorageTests.swift in Sources */,
+				CFF91208E4CD56126CC9FB8D /* HighlightCoordinatorMutationTests.swift in Sources */,
 				28D0C7BD8B1B21DFA60D7B64 /* HighlightCoordinatorTapHandlerTests.swift in Sources */,
 				514822215748FA807FA36FE2 /* HighlightCoordinatorTests.swift in Sources */,
 				2509B7983AE76F5C85B71634 /* HighlightDedupeTests.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5426,13 +5426,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 524;
+				CURRENT_PROJECT_VERSION = 525;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.9;
+				MARKETING_VERSION = 3.36.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5576,13 +5576,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 524;
+				CURRENT_PROJECT_VERSION = 525;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.9;
+				MARKETING_VERSION = 3.36.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Views/Reader/EPUBHighlightRenderer.swift
+++ b/vreader/Views/Reader/EPUBHighlightRenderer.swift
@@ -94,4 +94,14 @@ final class EPUBHighlightRenderer: HighlightRenderer {
         }
     }
 }
+
+// MARK: - ChapterScopedHighlightRenderer (Feature #64 WI-3)
+
+extension EPUBHighlightRenderer: ChapterScopedHighlightRenderer {
+    /// The chapter href the popover's recolor path captures before its
+    /// persistence `await`. Surfaces the existing mutable `currentHref`
+    /// through the protocol so `HighlightCoordinator.changeColor` does not
+    /// depend on the concrete renderer type (R1-4).
+    var currentChapterHref: String? { currentHref }
+}
 #endif

--- a/vreader/Views/Reader/HighlightCoordinator.swift
+++ b/vreader/Views/Reader/HighlightCoordinator.swift
@@ -122,5 +122,102 @@ final class HighlightCoordinator {
             }
         }
     }
+
+    // MARK: - Feature #64 — unified highlight-action popover mutations
+
+    /// Feature #64 WI-3 — persists a new highlight color, then repaints the
+    /// rendered highlight via the format's `HighlightRenderer`.
+    ///
+    /// Returns a typed `HighlightMutationOutcome` so the popover presenter can
+    /// distinguish a deleted-record race (→ dismiss) from a generic failure
+    /// (→ keep the popover open, no local mutation). `PersistenceActor`
+    /// throws a distinct `PersistenceError.recordNotFound`.
+    ///
+    /// EPUB href-race (R1-4): when the renderer is chapter-scoped (the EPUB
+    /// renderer), its `currentChapterHref` is captured BEFORE the persistence
+    /// `await` and threaded into `restoreAll(forHref:)`.
+    /// `EPUBHighlightRenderer.restore` resolves `href ?? currentHref` and
+    /// `currentHref` is a mutable `var` — across the `await`, a racing
+    /// chapter-nav could mutate it and repaint the wrong chapter. Capturing it
+    /// up front is the Bug #103 immutable-href pattern. The capture goes
+    /// through `ChapterScopedHighlightRenderer`, not a concrete-type cast, so
+    /// it is unit-testable with a fake. Non-EPUB renderers (TXT/MD/PDF) are
+    /// not chapter-scoped — they ignore the href and get `forHref: nil`.
+    func changeColor(highlightID: UUID, to color: String) async -> HighlightMutationOutcome {
+        // Capture the chapter context at call time, before the await.
+        let capturedHref = (renderer as? any ChapterScopedHighlightRenderer)?.currentChapterHref
+
+        do {
+            try await persistence.updateHighlightColor(highlightId: highlightID, color: color)
+        } catch let error as PersistenceError {
+            if case .recordNotFound = error { return .notFound }
+            return .failed
+        } catch {
+            return .failed
+        }
+
+        // Re-fetch to get the persisted post-mutation state AND the records to
+        // repaint from. A fetch failure here is a generic failure (`.failed`),
+        // NOT a deleted-record race — only a successful fetch with no matching
+        // id means the record was concurrently deleted (R1-5).
+        let records: [HighlightRecord]
+        do {
+            records = try await persistence.fetchHighlights(forBookWithKey: bookFingerprintKey)
+        } catch {
+            return .failed
+        }
+        guard let record = records.first(where: { $0.highlightId == highlightID }) else {
+            return .notFound
+        }
+        // Repaint from the already-fetched records directly, so the repaint
+        // is not silently dropped by `restoreAll`'s own fetch (which swallows
+        // failures). The re-fetch above already carries the new color.
+        renderer.restore(records: records, forHref: capturedHref, using: nil)
+        return .success(record)
+    }
+
+    /// Feature #64 WI-3 — persists a note edit on a highlight. No
+    /// reader-surface repaint — the note is not drawn on the page, so the
+    /// only UI to refresh is the popover card itself (handled by the caller).
+    ///
+    /// A trimmed-empty draft (`nil` / `""` / all-whitespace) is normalized to
+    /// `nil` before persisting, so a note "cleared" to whitespace stores as no
+    /// note and the popover flips to the empty state. Returns the typed
+    /// outcome for the same reason as `changeColor`.
+    func updateNote(highlightID: UUID, note: String?) async -> HighlightMutationOutcome {
+        let normalized = HighlightCoordinator.normalizedNote(note)
+
+        do {
+            try await persistence.updateHighlightNote(highlightId: highlightID, note: normalized)
+        } catch let error as PersistenceError {
+            if case .recordNotFound = error { return .notFound }
+            return .failed
+        } catch {
+            return .failed
+        }
+
+        // Re-fetch to get the persisted post-mutation record. Same R1-5
+        // discipline as `changeColor`: a fetch throw is `.failed`; only a
+        // successful fetch with no match is `.notFound`.
+        let records: [HighlightRecord]
+        do {
+            records = try await persistence.fetchHighlights(forBookWithKey: bookFingerprintKey)
+        } catch {
+            return .failed
+        }
+        guard let record = records.first(where: { $0.highlightId == highlightID }) else {
+            return .notFound
+        }
+        return .success(record)
+    }
+
+    /// Normalizes a note draft: an all-whitespace (or empty / nil) draft
+    /// becomes `nil`; a non-empty draft is preserved verbatim (including its
+    /// own surrounding whitespace).
+    static func normalizedNote(_ note: String?) -> String? {
+        guard let note else { return nil }
+        let trimmed = note.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : note
+    }
 }
 #endif

--- a/vreader/Views/Reader/HighlightRenderer.swift
+++ b/vreader/Views/Reader/HighlightRenderer.swift
@@ -59,3 +59,18 @@ extension HighlightRenderer {
         restore(records: records, forHref: nil, using: nil)
     }
 }
+
+/// A `HighlightRenderer` whose restore is scoped to a current chapter href.
+///
+/// Feature #64 WI-3: only the EPUB renderer filters highlights by chapter on
+/// restore. `HighlightCoordinator.changeColor` captures the chapter context
+/// through this protocol — not via a concrete `EPUBHighlightRenderer` cast —
+/// so the href-capture race fix (R1-4) is testable with a fake conformer
+/// instead of the real WKWebView-bound renderer.
+@MainActor
+protocol ChapterScopedHighlightRenderer: HighlightRenderer {
+    /// The href of the chapter currently rendered. `changeColor` reads this
+    /// BEFORE its persistence `await` so a racing chapter-nav cannot redirect
+    /// the post-mutation repaint to the wrong chapter.
+    var currentChapterHref: String? { get }
+}

--- a/vreaderTests/Views/Reader/HighlightCoordinatorMutationTests.swift
+++ b/vreaderTests/Views/Reader/HighlightCoordinatorMutationTests.swift
@@ -1,0 +1,422 @@
+// Purpose: Feature #64 WI-3 — tests for `HighlightCoordinator.changeColor`
+// and `HighlightCoordinator.updateNote`, the two highlight mutations the
+// unified highlight-action popover drives.
+//
+// Covers: a successful recolor → `.success` + the renderer repainted; a
+// successful note save → `.success`; a `PersistenceError.recordNotFound`
+// thrown by the persistence layer → `.notFound`; a generic throw →
+// `.failed`; the EPUB href-capture race (R1-4) — `changeColor` for an EPUB
+// renderer captures `currentHref` BEFORE the persistence `await` and calls
+// `restoreAll(forHref:)` with the captured value, even when a racing
+// chapter-nav mutates `currentHref` mid-await; a trimmed-empty note draft
+// normalized to `nil` before persisting.
+
+#if canImport(UIKit)
+import Testing
+import Foundation
+@testable import vreader
+
+// MARK: - Helpers
+
+private let mutTestFP = DocumentFingerprint(
+    contentSHA256: "mutation_test_sha_000000000000000000000000000000000000",
+    fileByteCount: 100, format: .epub
+)
+
+private func mutLocator() -> Locator {
+    Locator.validated(bookFingerprint: mutTestFP, href: "ch1.xhtml", progression: 0.5)!
+}
+
+private func mutRecord(
+    id: UUID = UUID(), color: String = "yellow", note: String? = nil
+) -> HighlightRecord {
+    HighlightRecord(
+        highlightId: id, locator: mutLocator(), anchor: nil, profileKey: "k",
+        selectedText: "the passage", color: color, note: note,
+        createdAt: Date(timeIntervalSince1970: 1), updatedAt: Date(timeIntervalSince1970: 2)
+    )
+}
+
+// MARK: - Mock renderer
+
+@MainActor
+private final class MutMockRenderer: HighlightRenderer {
+    var restoreCalls = 0
+    var lastRestoreHref: String?
+    var lastRestoredRecords: [HighlightRecord]?
+
+    func apply(record: HighlightRecord) {}
+    func remove(id: UUID) {}
+    func restore(
+        records: [HighlightRecord], forHref href: String?, using evaluator: ((String) -> Void)?
+    ) {
+        restoreCalls += 1
+        lastRestoreHref = href
+        lastRestoredRecords = records
+    }
+}
+
+/// A chapter-scoped renderer fake mirroring the real `EPUBHighlightRenderer`'s
+/// mutable chapter href. The injected race (see `MutMockPersistence.armRace`)
+/// flips `currentHref` while the persistence `await` is in flight, so the test
+/// can prove `changeColor` captured the pre-await value.
+@MainActor
+private final class MutMockEPUBRenderer: ChapterScopedHighlightRenderer {
+    var currentHref: String?
+    var currentChapterHref: String? { currentHref }
+    var restoreCalls = 0
+    var lastRestoreHref: String?
+
+    func apply(record: HighlightRecord) {}
+    func remove(id: UUID) {}
+    func restore(
+        records: [HighlightRecord], forHref href: String?, using evaluator: ((String) -> Void)?
+    ) {
+        restoreCalls += 1
+        lastRestoreHref = href
+    }
+}
+
+// MARK: - Mock persistence
+
+/// A `HighlightPersisting` mock whose mutation methods can succeed, throw a
+/// distinct `PersistenceError.recordNotFound`, or throw a generic error. It
+/// records the last color/note persisted and, optionally, mutates an
+/// injected EPUB renderer's `currentHref` from inside `updateHighlightColor`
+/// to simulate a chapter-nav racing the persistence `await`.
+private actor MutMockPersistence: HighlightPersisting {
+    enum Mode: Sendable { case success, recordNotFound, genericFailure }
+
+    private var mode: Mode = .success
+    private(set) var lastColor: String?
+    private(set) var lastNoteWasSet = false
+    private(set) var lastNote: String?
+    private var stored: [UUID: HighlightRecord] = [:]
+    /// When true, the mutation itself succeeds but the post-mutation
+    /// `fetchHighlights` throws — the "read failure after a successful write"
+    /// path that must map to `.failed`, not `.notFound`.
+    private var fetchThrowsAfterMutation = false
+
+    /// When set, `updateHighlightColor` flips this renderer's `currentHref`
+    /// to `raceHref` before returning — the racing chapter-nav.
+    private var raceRenderer: MutMockEPUBRenderer?
+    private var raceHref: String?
+
+    func setMode(_ m: Mode) { mode = m }
+    func setFetchThrowsAfterMutation(_ value: Bool) { fetchThrowsAfterMutation = value }
+    func seed(_ record: HighlightRecord) { stored[record.highlightId] = record }
+
+    func armRace(renderer: MutMockEPUBRenderer, toHref href: String) {
+        raceRenderer = renderer
+        raceHref = href
+    }
+
+    func addHighlight(
+        locator: Locator, selectedText: String, color: String,
+        note: String?, toBookWithKey key: String
+    ) async throws -> HighlightRecord {
+        fatalError("unused in WI-3 mutation tests")
+    }
+
+    func addHighlight(
+        locator: Locator, anchor: AnnotationAnchor?, selectedText: String,
+        color: String, note: String?, toBookWithKey key: String
+    ) async throws -> HighlightRecord {
+        fatalError("unused in WI-3 mutation tests")
+    }
+
+    func removeHighlight(highlightId: UUID) async throws {}
+
+    func updateHighlightNote(highlightId: UUID, note: String?) async throws {
+        switch mode {
+        case .recordNotFound:
+            throw PersistenceError.recordNotFound("Highlight \(highlightId)")
+        case .genericFailure:
+            throw NSError(domain: "test", code: 99)
+        case .success:
+            lastNoteWasSet = true
+            lastNote = note
+            if var rec = stored[highlightId] {
+                rec = HighlightRecord(
+                    highlightId: rec.highlightId, locator: rec.locator, anchor: rec.anchor,
+                    profileKey: rec.profileKey, selectedText: rec.selectedText,
+                    color: rec.color, note: note, createdAt: rec.createdAt,
+                    updatedAt: Date(timeIntervalSince1970: 999)
+                )
+                stored[highlightId] = rec
+            }
+        }
+    }
+
+    func updateHighlightColor(highlightId: UUID, color: String) async throws {
+        // Simulate a racing chapter-nav mutating the renderer's currentHref
+        // while this persistence call is in flight.
+        if let renderer = raceRenderer, let href = raceHref {
+            await MainActor.run { renderer.currentHref = href }
+        }
+        switch mode {
+        case .recordNotFound:
+            throw PersistenceError.recordNotFound("Highlight \(highlightId)")
+        case .genericFailure:
+            throw NSError(domain: "test", code: 99)
+        case .success:
+            lastColor = color
+            if var rec = stored[highlightId] {
+                rec = HighlightRecord(
+                    highlightId: rec.highlightId, locator: rec.locator, anchor: rec.anchor,
+                    profileKey: rec.profileKey, selectedText: rec.selectedText,
+                    color: color, note: rec.note, createdAt: rec.createdAt,
+                    updatedAt: Date(timeIntervalSince1970: 999)
+                )
+                stored[highlightId] = rec
+            }
+        }
+    }
+
+    func fetchHighlights(forBookWithKey key: String) async throws -> [HighlightRecord] {
+        if fetchThrowsAfterMutation { throw NSError(domain: "test", code: 7) }
+        return Array(stored.values)
+    }
+}
+
+// MARK: - Tests
+
+@Suite("HighlightCoordinator mutations")
+struct HighlightCoordinatorMutationTests {
+
+    // MARK: changeColor
+
+    @Test @MainActor func changeColor_success_returnsSuccessAndRepaints() async {
+        let renderer = MutMockRenderer()
+        let persistence = MutMockPersistence()
+        let record = mutRecord(color: "yellow")
+        await persistence.seed(record)
+        let coordinator = HighlightCoordinator(
+            renderer: renderer, persistence: persistence, bookFingerprintKey: "book-1"
+        )
+
+        let outcome = await coordinator.changeColor(highlightID: record.highlightId, to: "pink")
+
+        guard case let .success(returned) = outcome else {
+            Issue.record("expected .success, got \(outcome)")
+            return
+        }
+        #expect(returned.color == "pink")
+        #expect(await persistence.lastColor == "pink")
+        #expect(renderer.restoreCalls == 1)
+    }
+
+    @Test @MainActor func changeColor_recordNotFound_returnsNotFound() async {
+        let renderer = MutMockRenderer()
+        let persistence = MutMockPersistence()
+        await persistence.setMode(.recordNotFound)
+        let coordinator = HighlightCoordinator(
+            renderer: renderer, persistence: persistence, bookFingerprintKey: "book-1"
+        )
+        let outcome = await coordinator.changeColor(highlightID: UUID(), to: "pink")
+        #expect(outcome == .notFound)
+        // No repaint when the record is gone.
+        #expect(renderer.restoreCalls == 0)
+    }
+
+    @Test @MainActor func changeColor_genericFailure_returnsFailed() async {
+        let renderer = MutMockRenderer()
+        let persistence = MutMockPersistence()
+        await persistence.setMode(.genericFailure)
+        let coordinator = HighlightCoordinator(
+            renderer: renderer, persistence: persistence, bookFingerprintKey: "book-1"
+        )
+        let outcome = await coordinator.changeColor(highlightID: UUID(), to: "pink")
+        #expect(outcome == .failed)
+        #expect(renderer.restoreCalls == 0)
+    }
+
+    /// R1-5: a read failure AFTER a successful color write must surface as
+    /// `.failed`, not `.notFound` — the write landed; only the re-fetch broke.
+    /// Treating it as `.notFound` would wrongly dismiss the popover and the
+    /// page repaint would not be driven.
+    @Test @MainActor func changeColor_refetchThrowsAfterSuccess_returnsFailed() async {
+        let renderer = MutMockRenderer()
+        let persistence = MutMockPersistence()
+        let record = mutRecord(color: "yellow")
+        await persistence.seed(record)
+        await persistence.setFetchThrowsAfterMutation(true)
+        let coordinator = HighlightCoordinator(
+            renderer: renderer, persistence: persistence, bookFingerprintKey: "book-1"
+        )
+        let outcome = await coordinator.changeColor(highlightID: record.highlightId, to: "pink")
+        #expect(outcome == .failed)
+        // The repaint cannot be driven without the re-fetched records.
+        #expect(renderer.restoreCalls == 0)
+    }
+
+    /// R1-5: a color write that succeeds but whose record is genuinely gone
+    /// on a clean re-fetch (no fetch error) → `.notFound`.
+    @Test @MainActor func changeColor_recordGoneOnCleanRefetch_returnsNotFound() async {
+        let renderer = MutMockRenderer()
+        let persistence = MutMockPersistence()
+        // Nothing seeded — the write "succeeds" (mock mode .success) but the
+        // re-fetch returns an empty list with no matching id.
+        let coordinator = HighlightCoordinator(
+            renderer: renderer, persistence: persistence, bookFingerprintKey: "book-1"
+        )
+        let outcome = await coordinator.changeColor(highlightID: UUID(), to: "pink")
+        #expect(outcome == .notFound)
+        #expect(renderer.restoreCalls == 0)
+    }
+
+    /// R1-4: for an EPUB renderer, `changeColor` must capture `currentHref`
+    /// BEFORE the persistence `await` and call `restoreAll(forHref:)` with the
+    /// captured value — so a racing chapter-nav that mutates `currentHref`
+    /// mid-await cannot repaint the wrong chapter.
+    @Test @MainActor func changeColor_epub_capturesHrefBeforeAwait() async {
+        let renderer = MutMockEPUBRenderer()
+        renderer.currentHref = "chapter-3.xhtml"  // the chapter on screen at tap
+        let persistence = MutMockPersistence()
+        let record = mutRecord(color: "yellow")
+        await persistence.seed(record)
+        // Arm the race: the persistence call flips currentHref to a different
+        // chapter while it is in flight.
+        await persistence.armRace(renderer: renderer, toHref: "chapter-9.xhtml")
+        let coordinator = HighlightCoordinator(
+            renderer: renderer, persistence: persistence, bookFingerprintKey: "book-1"
+        )
+
+        let outcome = await coordinator.changeColor(highlightID: record.highlightId, to: "blue")
+
+        guard case .success = outcome else {
+            Issue.record("expected .success, got \(outcome)")
+            return
+        }
+        #expect(renderer.restoreCalls == 1)
+        // The repaint must use the href captured at call time, NOT the
+        // chapter-9 value the race wrote during the await.
+        #expect(renderer.lastRestoreHref == "chapter-3.xhtml")
+    }
+
+    /// For a non-EPUB renderer, `changeColor` passes `forHref: nil` — the
+    /// TXT/MD/PDF renderers ignore the href.
+    @Test @MainActor func changeColor_nonEPUB_passesNilHref() async {
+        let renderer = MutMockRenderer()
+        let persistence = MutMockPersistence()
+        let record = mutRecord()
+        await persistence.seed(record)
+        let coordinator = HighlightCoordinator(
+            renderer: renderer, persistence: persistence, bookFingerprintKey: "book-1"
+        )
+        _ = await coordinator.changeColor(highlightID: record.highlightId, to: "green")
+        #expect(renderer.lastRestoreHref == nil)
+    }
+
+    // MARK: updateNote
+
+    @Test @MainActor func updateNote_success_returnsSuccessNoRepaint() async {
+        let renderer = MutMockRenderer()
+        let persistence = MutMockPersistence()
+        let record = mutRecord(note: "old note")
+        await persistence.seed(record)
+        let coordinator = HighlightCoordinator(
+            renderer: renderer, persistence: persistence, bookFingerprintKey: "book-1"
+        )
+
+        let outcome = await coordinator.updateNote(
+            highlightID: record.highlightId, note: "new note"
+        )
+
+        guard case let .success(returned) = outcome else {
+            Issue.record("expected .success, got \(outcome)")
+            return
+        }
+        #expect(returned.note == "new note")
+        // A note edit is invisible on the page — no reader-surface repaint.
+        #expect(renderer.restoreCalls == 0)
+    }
+
+    @Test @MainActor func updateNote_recordNotFound_returnsNotFound() async {
+        let renderer = MutMockRenderer()
+        let persistence = MutMockPersistence()
+        await persistence.setMode(.recordNotFound)
+        let coordinator = HighlightCoordinator(
+            renderer: renderer, persistence: persistence, bookFingerprintKey: "book-1"
+        )
+        let outcome = await coordinator.updateNote(highlightID: UUID(), note: "n")
+        #expect(outcome == .notFound)
+    }
+
+    @Test @MainActor func updateNote_genericFailure_returnsFailed() async {
+        let renderer = MutMockRenderer()
+        let persistence = MutMockPersistence()
+        await persistence.setMode(.genericFailure)
+        let coordinator = HighlightCoordinator(
+            renderer: renderer, persistence: persistence, bookFingerprintKey: "book-1"
+        )
+        let outcome = await coordinator.updateNote(highlightID: UUID(), note: "n")
+        #expect(outcome == .failed)
+    }
+
+    /// R1-5: a read failure AFTER a successful note write surfaces as
+    /// `.failed`, not `.notFound`.
+    @Test @MainActor func updateNote_refetchThrowsAfterSuccess_returnsFailed() async {
+        let renderer = MutMockRenderer()
+        let persistence = MutMockPersistence()
+        let record = mutRecord(note: "old")
+        await persistence.seed(record)
+        await persistence.setFetchThrowsAfterMutation(true)
+        let coordinator = HighlightCoordinator(
+            renderer: renderer, persistence: persistence, bookFingerprintKey: "book-1"
+        )
+        let outcome = await coordinator.updateNote(highlightID: record.highlightId, note: "new")
+        #expect(outcome == .failed)
+    }
+
+    /// R1-5: a note write that succeeds but whose record is gone on a clean
+    /// re-fetch → `.notFound`.
+    @Test @MainActor func updateNote_recordGoneOnCleanRefetch_returnsNotFound() async {
+        let renderer = MutMockRenderer()
+        let persistence = MutMockPersistence()
+        let coordinator = HighlightCoordinator(
+            renderer: renderer, persistence: persistence, bookFingerprintKey: "book-1"
+        )
+        let outcome = await coordinator.updateNote(highlightID: UUID(), note: "n")
+        #expect(outcome == .notFound)
+    }
+
+    /// A trimmed-empty draft (nil / "" / "   " / "\n\n") is normalized to
+    /// `nil` before persisting — so a note "cleared" to whitespace stores as
+    /// no note, and the popover flips to the empty state.
+    @Test(arguments: [nil, "", "   ", "\n\n", "\t \n"])
+    @MainActor func updateNote_trimmedEmptyDraft_persistsNil(_ draft: String?) async {
+        let renderer = MutMockRenderer()
+        let persistence = MutMockPersistence()
+        let record = mutRecord(note: "had a note")
+        await persistence.seed(record)
+        let coordinator = HighlightCoordinator(
+            renderer: renderer, persistence: persistence, bookFingerprintKey: "book-1"
+        )
+
+        let outcome = await coordinator.updateNote(highlightID: record.highlightId, note: draft)
+
+        guard case let .success(returned) = outcome else {
+            Issue.record("expected .success, got \(outcome)")
+            return
+        }
+        #expect(await persistence.lastNoteWasSet == true)
+        #expect(await persistence.lastNote == nil)
+        #expect(returned.note == nil)
+    }
+
+    @Test @MainActor func updateNote_realNoteNotNormalized() async {
+        let renderer = MutMockRenderer()
+        let persistence = MutMockPersistence()
+        let record = mutRecord(note: nil)
+        await persistence.seed(record)
+        let coordinator = HighlightCoordinator(
+            renderer: renderer, persistence: persistence, bookFingerprintKey: "book-1"
+        )
+        _ = await coordinator.updateNote(highlightID: record.highlightId, note: "  real note  ")
+        // Whitespace is preserved on a non-empty note — only an all-whitespace
+        // draft normalizes to nil.
+        #expect(await persistence.lastNote == "  real note  ")
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- WI-3 of feature #64 — the unified cross-format highlight-action popover.
- Adds `changeColor` + `updateNote` to `HighlightCoordinator`, both returning the typed `HighlightMutationOutcome`. Foundational tier — no container wired, no user-observable behavior change.

Part of feature #822.

## What Changed

- `HighlightCoordinator.changeColor(highlightID:to:)` (NEW method) — persists a new color, then repaints the rendered highlight from the re-fetched records. **EPUB href-race fix (R1-4)**: captures the renderer's chapter href BEFORE the persistence `await` and threads it into the repaint, so a racing chapter-nav cannot redirect the repaint to the wrong chapter.
- `HighlightCoordinator.updateNote(highlightID:note:)` (NEW method) — persists a note edit; no reader-surface repaint (the note is not drawn on the page). A trimmed-empty draft normalizes to `nil` so a whitespace-cleared note flips the popover to the empty state.
- Both return `HighlightMutationOutcome` (R1-5): `PersistenceError.recordNotFound` OR a successful write whose record is gone on a clean re-fetch → `.notFound`; any other error including a re-fetch throw after a successful write → `.failed`; otherwise `.success(record)`.
- `ChapterScopedHighlightRenderer` (NEW protocol) — a narrow read-only refinement of `HighlightRenderer` exposing `currentChapterHref`. `EPUBHighlightRenderer` conforms; `changeColor` captures the href through this protocol, **not** a concrete `EPUBHighlightRenderer` cast, so the href-capture race fix is unit-testable with a fake renderer.

## WI Status

- WI-3: foundational — this PR.
- Done: WI-1 (foundational types + view model, #967), WI-2 (form-decision presenter, #969).
- Remaining: WI-4 (SwiftUI card+sheet views + modifier), WI-5 (UIKit anchored presenter), WI-6..9 (per-format container migration), WI-10 (#55/#53 teardown + final acceptance).

## Codex Audit (Gate 4)

Codex `019e4069`, 2 rounds, verdict **ship-as-is**.

- Round 1 found 2 Medium + 1 Low, all the same root cause: the post-mutation re-fetch helper used `try?`, collapsing a *generic fetch failure after a successful write* into `.notFound` (it should be `.failed` per R1-5), and `changeColor` routed the repaint through `restoreAll` which swallows its own fetch failure (so a `.success` could be returned without the page repainting).
- Fixed: explicit do/catch fetch with correct `.failed`/`.notFound` mapping; `changeColor` repaints from the already-fetched records directly; 4 new failure-split tests added.
- Round 2 re-audited the fixes clean — no remaining open Critical/High/Medium findings.

Audit log: `.claude/codex-audits/feat-feature-64-wi-3-coordinator-mutations-audit.md`

## Validation

- [x] `xcodebuild test` passes — 23 tests across `HighlightCoordinatorMutationTests` (15, incl. the EPUB href-capture race, the recordNotFound/generic/refetch-throw outcome splits, the trimmed-empty-note normalization) + `HighlightCoordinatorTests` (8, no regression). The EPUB renderer Bug-77 + renderer suites also re-run green.
- [x] Tests cover changed behavior (TDD: RED → GREEN)
- [x] Codex audit loop completed (2 iterations, verdict: ship-as-is)
- [x] Docs sync — n/a (`ChapterScopedHighlightRenderer` is a refinement of the already-documented `HighlightRenderer` protocol — a conforming code path, not a new renderer adapter; it falsifies no `architecture.md` claim. The Highlight System table's stated facts remain true. WI-10 runs the feature-wide rule-24 pre-PR self-check.)
- [x] Version bumped: 3.36.9 → 3.36.10

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: **foundational** — unit + integration tests + Gate-4 audit are sufficient. No reader container is wired. The 15-test mutation suite exercises every outcome branch (success / notFound / failed including the post-write-fetch-throw case) and the EPUB href-capture race deterministically (a mock that flips `currentHref` mid-`await` and asserts the captured pre-await value threaded into the repaint).

## Type of Change

- [x] Feature WI (Part of feature #822)

🤖 Generated with [Claude Code](https://claude.com/claude-code)