### PR TITLE
feat(#64 WI-4): SwiftUI card+sheet views + modifier for unified popover

### DIFF
--- a/.claude/codex-audits/feat-feature-64-wi-4-card-views-audit.md
+++ b/.claude/codex-audits/feat-feature-64-wi-4-card-views-audit.md
@@ -1,0 +1,52 @@
+---
+branch: feat/feature-64-wi-4-card-views
+threadId: 019e407f-e49d-7ec0-966a-f3e83c7cae97
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+# Gate-4 Implementation Audit — Feature #64 WI-4 (SwiftUI card+sheet views + modifier + Foliate JS bridge)
+
+## Scope
+
+WI-4 of the unified cross-format highlight-action popover — the largest WI. 8 new production files + 1 modified:
+
+- `FoliateHighlightJSBridge.swift` (NEW) — pure-logic Foliate recolor/delete notification poster.
+- `HighlightActionCardSubviews.swift` (NEW) — shared subviews + the `HighlightPopoverSwatch` color mapper.
+- `HighlightPopoverDeleteConfirm.swift` (NEW) — the inline delete-confirm subview (split for the 300-line guideline).
+- `HighlightActionCardView.swift` (NEW) — the SwiftUI view (card + sheet shells, the 3 note modes, the controlled `HighlightNoteDraftEditor`).
+- `HighlightPopoverActionRouter.swift` (NEW) — `@MainActor @Observable` state + dispatch core.
+- `HighlightPopoverModifier.swift` (NEW) — the `HighlightPopoverPresenting` protocol, parse helper, share types.
+- `HighlightPopoverModifierBody.swift` (NEW) — the `HighlightPopoverModifier` `ViewModifier` + attach helpers.
+- `UIKitHighlightPopoverPresenter.swift` (NEW) — the `UIPopoverPresentationController`-based presenter (serialized pipeline; idempotent in-place `updateCard`).
+- `HighlightCoordinator.swift` (MOD) — the `HighlightMutating` protocol + `deleteHighlight` + the conformance.
+
+Plus 3 new test files (`FoliateHighlightJSBridgeTests`, `HighlightPopoverActionRouterTests`, `HighlightActionCardViewTests`).
+
+## Round 1 — Codex `019e407f-e49d-7ec0-966a-f3e83c7cae97`
+
+| # | File:line | Severity | Issue | Fix |
+|---|-----------|----------|-------|-----|
+| F1 | `HighlightPopoverActionRouter.swift:114` + `HighlightPopoverModifierBody.swift:111` | **High** | `share` set the share item immediately after `dismiss()`, while the card was dismissed with no completion — reintroducing the modal-collision feature #55 guarded against. R2-F7 not fully satisfied on the card path. | Stage share presentation behind a real dismiss completion. |
+| F2 | `HighlightCoordinator.swift:246` + `HighlightPopoverActionRouter.swift:152` | Medium | `confirmDelete` / `deleteHighlight` collapsed every failure into `false`, so a concurrent-deletion race (`recordNotFound`) left the popover open over a record that no longer exists — inconsistent with the typed recolor/save handling. | Make `deleteHighlight` return a typed `HighlightMutationOutcome`; dismiss on `.notFound`. |
+| F3 | `HighlightPopoverModifierBody.swift:84/117` + `UIKitHighlightPopoverPresenter.swift:121` | Low | (a) `resolvedForm` recomputes from persisted `content.note`, not the live `noteDraft` — an anchored card never degrades to the sheet mid-edit. (b) `pressedColor` was never threaded through `presentCard`/`updateCard` — the card lost the design's transient swatch press feedback. | (a) reroute on the live draft; (b) thread `pressedColor`. |
+
+The auditor confirmed everything else structurally sound in round 1: the Foliate bridge posts the right notifications/keys in the right order, the non-`.epub` skip is safe, `@MainActor` coverage is correct, R2-F6's same-`content.id` in-place `rootView` update is implemented the right way.
+
+## Resolution
+
+- **F1 (High)** — the router's `route(.share)` now records `pendingShareText` (not a share item) + clears `content`. The modifier's `routePresentation()` nil-branch calls a new `tearDownSurfaces(then:)` that dismisses whichever surface is up and runs the completion from the surface's REAL dismissal (sheet → `.sheet`'s `onDismiss` via a stashed `pendingPostSheetDismiss`; card → `dismissCard(completion:)`). The modifier-owned `@State shareItem` is set only inside that completion — so the `UIActivityViewController` is presented strictly after the popover has fully dismissed.
+- **F2 (Medium)** — `HighlightCoordinator.deleteHighlight` now returns `HighlightMutationOutcome`: a fetch throw → `.failed`, no matching record → `.notFound`, `removeHighlight` throwing `recordNotFound` → `.notFound`, generic → `.failed`, success → `.success(record)`. The `HighlightMutating` protocol's signature changed to match. The router's `handleConfirmDelete` dismisses on `.success`/`.notFound`, stays open (→ reading) only on `.failed`. New tests: 3 coordinator-level + 2 router-level.
+- **F3a (Low)** — accepted, NOT changed, with rationale: re-routing card→sheet mid-edit would tear down the anchored card while the keyboard is up — a worse UX than a presentation-stable form. The form is decided once at present time from the stored note; the next tap re-decides. Plan known-limitation L2 already accepts the card-vs-sheet axis as fidelity, not correctness.
+- **F3b (Low)** — fixed: `presentCard` / `updateCard` now take a `pressedColor` parameter; the UIKit presenter threads it into `HighlightActionCardView`; the modifier's `syncLiveCard` runs on `onChange(of: router.pressedColor)`.
+
+51 tests pass across the 3 WI-4 suites + `HighlightCoordinatorMutationTests` + `HighlightCoordinatorTests`.
+
+## Round 2 — Codex `019e407f-e49d-7ec0-966a-f3e83c7cae97` (re-audit of the fixes)
+
+Verdict: **"Confirmed."** Codex verified: the High is resolved (share now waits for a real dismissal completion); the Medium is resolved (`deleteHighlight` typed, the router dismisses on `.success`/`.notFound`); the pressedColor Low is fixed (threaded through the protocol + UIKit presenter); and accepting the live-draft form-selection Low with the stated rationale is "reasonable — a documented fidelity limitation rather than a correctness defect". **No remaining open Critical/High/Medium findings.**
+
+## Verdict
+
+**ship-as-is** — 2 rounds (round 1 found 1 High + 1 Medium + 1 Low; the High share-modal-collision + Medium delete-typing fixed, the pressedColor Low fixed, the live-draft-form Low accepted with rationale; round 2 clean).

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 525
-        MARKETING_VERSION: 3.36.10
+        CURRENT_PROJECT_VERSION: 526
+        MARKETING_VERSION: 3.36.11
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		01FEDA4DD8F5A3BFA56F275D /* DocumentFingerprintValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B4E4FB28FD82376AE20A4F /* DocumentFingerprintValidationTests.swift */; };
 		0246F6958C782714D1E5FAB4 /* ReplacementTransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8045B5C97D76DA514B27B577 /* ReplacementTransformTests.swift */; };
 		02CBE47CFF27030CBBCF0B13 /* EPUBSelectionTokenCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78743D11EADF7D49C2AD970 /* EPUBSelectionTokenCache.swift */; };
+		0355A26EEC17FC8847311896 /* HighlightPopoverActionRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726B2271F9C320E40AA66D67 /* HighlightPopoverActionRouter.swift */; };
 		036A7AA1F02D9219384C777A /* NativeTextPagedIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE4AD339F8C68B973D9C88 /* NativeTextPagedIntegrationTests.swift */; };
 		044A57EF6D114FA998DB29FA /* TextKit2Paginator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F317CDBF13A6A5673D64A8A /* TextKit2Paginator.swift */; };
 		04680C6879EFBD0BD77D56DF /* LibraryViewSheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF69255252D28E9C698F4E20 /* LibraryViewSheets.swift */; };
@@ -248,6 +249,7 @@
 		354E24A0B0A690869F8EFC5A /* TapZoneOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271BAF9BD03F619061BA4D96 /* TapZoneOverlay.swift */; };
 		357590BC921E8A3A0E7132F1 /* FoliateStyleMapperChapterStartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E3F274866072EA56D8C0B4 /* FoliateStyleMapperChapterStartTests.swift */; };
 		357C70E2DA8091ED4022D40E /* RuleEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647BF55A1C20635AD7062973 /* RuleEngine.swift */; };
+		3613DFF5007EAA0C4D5B2CEB /* HighlightPopoverDeleteConfirm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B94D8DF6728DEE93B09DE96 /* HighlightPopoverDeleteConfirm.swift */; };
 		369D003DCE5F36A64E5C1C06 /* AIChatGeneralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90F4EB83CC68406DA14DD94 /* AIChatGeneralTests.swift */; };
 		36B37715BB3494F635566157 /* ImportJobQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117731FF4D8AE414141C5ECF /* ImportJobQueue.swift */; };
 		37128EB810887C2A4D36E99F /* VerificationSettingsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1C2AB4E9DBE8437C7C8CF8 /* VerificationSettingsHelper.swift */; };
@@ -522,6 +524,7 @@
 		77922030EB933D898ED67C10 /* FoliateViewBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17013114ADB4797AB48D794 /* FoliateViewBridge.swift */; };
 		77B74C8406A03676DD48F636 /* ReaderMoreMenuRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2168679A3F58BF907CD746E0 /* ReaderMoreMenuRow.swift */; };
 		77D706EE2E466C650B00C381 /* WebDAVProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B294CBB624E1CE03FEFA40E6 /* WebDAVProviderTests.swift */; };
+		7845E001F6CBB7CE601704AF /* HighlightPopoverModifierBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5009D3D555DF12B60ACC2D88 /* HighlightPopoverModifierBody.swift */; };
 		7872FD996BEB1009EFF26413 /* AnnotationEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EAE2660201ADC0B4272B9EE /* AnnotationEditSheet.swift */; };
 		78A8B8FE91360F619F57DDB1 /* ContentHasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84D0E1452F211B986E8328A /* ContentHasher.swift */; };
 		792681509B48600C93D01C39 /* ReaderTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4581A94B5099D15743DC02F3 /* ReaderTheme.swift */; };
@@ -578,6 +581,7 @@
 		83920E15721D7860684628BE /* ReaderLifecycleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D363190FCDF47ED48A1D7BC1 /* ReaderLifecycleHelper.swift */; };
 		83DAEE23928C668DA378F086 /* EPUBProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FA15EA6877E3CA9421E1B59 /* EPUBProgressTests.swift */; };
 		84A03EDA45DB68CE01456609 /* SwiftDataSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B682E216B5A24055B696F0 /* SwiftDataSessionStore.swift */; };
+		84FDAB02CDE741029EE927A8 /* FoliateHighlightJSBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75EC9C3C222236A27183F13 /* FoliateHighlightJSBridge.swift */; };
 		85A21D4B6B18C0523D26375A /* HighlightPaintColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1790A0CEB902B16952776EE4 /* HighlightPaintColorTests.swift */; };
 		85A712EBB7E4B4DF30EDEA13 /* VReaderAnnotationParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D036492CF6A9DB2DAFE010BC /* VReaderAnnotationParser.swift */; };
 		85C0767912F71AAE32E2335E /* ChapterStartTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA36CFAC187DC7B25B7A920 /* ChapterStartTypography.swift */; };
@@ -807,6 +811,7 @@
 		BCD417D086985BB3B6605499 /* progress.js in Resources */ = {isa = PBXBuildFile; fileRef = 2B41E933EF843E0AC73B3E37 /* progress.js */; };
 		BD2207EF713FA796A840EF15 /* TextHighlightHitTesterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AD0B57E130DE8620C8AEC4 /* TextHighlightHitTesterTests.swift */; };
 		BD2CB6CC7C73CB730F899CC4 /* SelectionPopoverActionRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6079B8DCE357DF6EDBD75F9 /* SelectionPopoverActionRouterTests.swift */; };
+		BDADBC7F8C9300E0DF6E8F60 /* HighlightPopoverActionRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA1F6F765714110EBCCF24B /* HighlightPopoverActionRouterTests.swift */; };
 		BDCFAEB3BDC0697448C8EF46 /* AccessibilityAuditHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12A029D167735B92A38BA7 /* AccessibilityAuditHelper.swift */; };
 		BE476BD45B5DABF049AAC45F /* AISettingsViewModelEditorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295EA8A8C9A0188CCD2416B4 /* AISettingsViewModelEditorTests.swift */; };
 		BE69CE7675864C497ACFC999 /* NamedHighlightColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1456DD6C03CD51C24CA8CDCF /* NamedHighlightColorTests.swift */; };
@@ -841,6 +846,7 @@
 		C52D4B03AE65EC124C626291 /* SummaryScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19CA966D3696877E6EB055EA /* SummaryScopeTests.swift */; };
 		C535579CBC09F0C9E79EBB6F /* TXTChapterOffsetIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FBA8CFEF94EDBE0398AC4A /* TXTChapterOffsetIndexTests.swift */; };
 		C545A7D59A2D63CC5B1DF45B /* OPDSParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF47D926F78F13327F6770C /* OPDSParser.swift */; };
+		C57845DF5A192CA91CE07FED /* HighlightActionCardViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB42619D63C6DB1728CE74D0 /* HighlightActionCardViewTests.swift */; };
 		C59B87F85C20B1B2D9DDC387 /* SyncStatusMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F693921BA233745D77EC0037 /* SyncStatusMonitor.swift */; };
 		C5EEEAABF1F852CDABDA43F1 /* WebDAVClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4946129FECC6C9BA7A7F16A1 /* WebDAVClient.swift */; };
 		C60601B9EF202F0983235144 /* EPUBTextStripper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7F4B7C906FB04E87EE16F5 /* EPUBTextStripper.swift */; };
@@ -873,6 +879,7 @@
 		CC46DEE722313420D6F150ED /* TXTAttributedStringBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77119C3681DB428BD5F1207C /* TXTAttributedStringBuilderTests.swift */; };
 		CC5A3B33193938B59254FD8A /* PersistenceActor+Collections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00814B9C69A0E1190146095E /* PersistenceActor+Collections.swift */; };
 		CC774F69EFD8E1BD204DD515 /* AnnotationListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5CDE195E585067DE4D6124 /* AnnotationListViewModelTests.swift */; };
+		CCADB57440392A88FAEAFBAF /* HighlightActionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A24122FDBAEA4D6DBE9465 /* HighlightActionCardView.swift */; };
 		CCC8728E1750053B1F454A32 /* PageTurnAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D4D088D34AA8A5692A991B /* PageTurnAnimator.swift */; };
 		CCCA05F0A380F2D77780D17C /* VerificationDebugBridgeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C215281F33EFC48463EA8E24 /* VerificationDebugBridgeHelperTests.swift */; };
 		CCEBC3A6E01BAEF55DC2F666 /* TTSHighlightCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7968DAA000D9F45677960BA /* TTSHighlightCoordinatorTests.swift */; };
@@ -897,6 +904,7 @@
 		D0E3C146DC0F8D0978B419E7 /* AIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C4804D4D5F435DF10014C5 /* AIError.swift */; };
 		D0FB5FB63B24803C9ADA5E1A /* EPUBHighlightBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C5EC86BB06D46DC9A5A4F6B /* EPUBHighlightBridgeTests.swift */; };
 		D19881EF60E15DFDCFF74173 /* EPUBComplexityClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC42F137A3776DEED18D9044 /* EPUBComplexityClassifierTests.swift */; };
+		D1A367426DB437420A23C030 /* HighlightPopoverModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44AEA97F06DB06AEAFB526F1 /* HighlightPopoverModifier.swift */; };
 		D1D006F9999F547388B9AE59 /* NotePreviewSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9773C1416AE3316A965288 /* NotePreviewSheetView.swift */; };
 		D265D45BCD1884BF67E03DF9 /* TXTReaderViewModelContinuousTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510A755F74250CC74B14021D /* TXTReaderViewModelContinuousTests.swift */; };
 		D2997E6E5680E58471DAA777 /* NoOpPersistenceStores.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D45B144AFD2D20CAEACC48 /* NoOpPersistenceStores.swift */; };
@@ -941,6 +949,7 @@
 		DBFD718C101EE9B752D9C205 /* WebDAVProviderFactoryProfileDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E344B835F385EF870989C9 /* WebDAVProviderFactoryProfileDispatchTests.swift */; };
 		DCB3DF75803B93E9AFB05F1D /* FormatCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050AAFD290B8995258D78AC2 /* FormatCapabilities.swift */; };
 		DCE7A66917407F83D657A63B /* FoliateURLSchemeHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 432F646AE5FB7BFD06470EB5 /* FoliateURLSchemeHandlerTests.swift */; };
+		DD040D904159CBFF9C5B03F2 /* FoliateHighlightJSBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 469B267E0D3DB05D1D8F530A /* FoliateHighlightJSBridgeTests.swift */; };
 		DD1020F3F0A2D5BA7FFCB279 /* UnifiedScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0753D8C40DFE06B0323EE5B /* UnifiedScrollView.swift */; };
 		DD273808CA81E259EAC3F7C5 /* LocatorRestorerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10A08E980C92248337462DF /* LocatorRestorerTests.swift */; };
 		DD32F48A384939AC2389DCAE /* PersistenceHighlightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDD43BA2EC5C331FDF3A703 /* PersistenceHighlightTests.swift */; };
@@ -976,6 +985,7 @@
 		E44BC8CE480C18F6469C62DD /* WI9TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CB57338FD24289DAC8ABE4 /* WI9TestHelpers.swift */; };
 		E4A81A3F657E73B3660FD5E2 /* NoteCalloutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E6FCB2672364DC81F23020 /* NoteCalloutView.swift */; };
 		E4C963854C70662E3D59835D /* TXTChapterIndexStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0E95AA02EBAE369ABF9AE5 /* TXTChapterIndexStore.swift */; };
+		E5A530D53A57B6CC92665E4C /* HighlightActionCardSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6E02E23F3C9B74668C4264F /* HighlightActionCardSubviews.swift */; };
 		E5C970CD2DB58A81E743F7DA /* WebDAVATSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A7B601E9791FB068616C98 /* WebDAVATSTests.swift */; };
 		E648A7D0DA601378CD08D521 /* LocatorNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D86F739CC4D19AF019F728 /* LocatorNormalizer.swift */; };
 		E680070CD53FCEA3C6BF55AC /* ChineseConversionPickerGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 716F291DCD758F0EA738422F /* ChineseConversionPickerGateTests.swift */; };
@@ -1070,6 +1080,7 @@
 		FD253FA0CEB159E2B1299BD4 /* SchemaV1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EA03BEFDBB65F5D7533EDE /* SchemaV1Tests.swift */; };
 		FD88118ABE86FDFBA67DFF50 /* PDFPageNavigatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C39119533D269F76F970FD1 /* PDFPageNavigatorTests.swift */; };
 		FD9B24BBE1D852DA18A23E6F /* AITypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C22F30DF9F05C20CF8DDBC /* AITypes.swift */; };
+		FE054F2D4C15B2BE95EFE3F0 /* UIKitHighlightPopoverPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CA57AE61E378A1980BFF60 /* UIKitHighlightPopoverPresenter.swift */; };
 		FE244DEB01C2A5C716D1B5C7 /* LibraryDynamicTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77D3287AEC40129E6AA379F /* LibraryDynamicTypeTests.swift */; };
 		FEA105C28C0D03B8EDF2D6EF /* MOBICoverExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10962D7E47EA2C6714E704CA /* MOBICoverExtractorTests.swift */; };
 		FEA5EBDFE175E51BC5B93022 /* ReaderContainerViewEngineDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A84982F334E70A0D71A44893 /* ReaderContainerViewEngineDispatchTests.swift */; };
@@ -1272,6 +1283,7 @@
 		2A513D5E8C4467B8FE45E0AC /* AnnotationRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationRecord.swift; sourceTree = "<group>"; };
 		2B41E933EF843E0AC73B3E37 /* progress.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = progress.js; sourceTree = "<group>"; };
 		2B7C59839A119870BE9B6FF9 /* ReaderSelectionEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSelectionEventTests.swift; sourceTree = "<group>"; };
+		2B94D8DF6728DEE93B09DE96 /* HighlightPopoverDeleteConfirm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPopoverDeleteConfirm.swift; sourceTree = "<group>"; };
 		2B98DA0DED4325E7AE1BEF59 /* DebugReaderProbeAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReaderProbeAdapter.swift; sourceTree = "<group>"; };
 		2B9AD84A4BE2CF0F8D59D9CC /* TXTChapterScrollOffsetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterScrollOffsetTests.swift; sourceTree = "<group>"; };
 		2BDD46A11977588A65892AB2 /* FoliateTOCConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateTOCConverter.swift; sourceTree = "<group>"; };
@@ -1377,6 +1389,7 @@
 		4456336AA865CC6E79488325 /* ModelContainerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelContainerFactory.swift; sourceTree = "<group>"; };
 		4459ED2850B657C535C05F16 /* DebugPositionResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugPositionResolverTests.swift; sourceTree = "<group>"; };
 		445A7C6C3D4466A57B29BDA8 /* ReaderSettingsSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsSheetTests.swift; sourceTree = "<group>"; };
+		44AEA97F06DB06AEAFB526F1 /* HighlightPopoverModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPopoverModifier.swift; sourceTree = "<group>"; };
 		44FC663099F4228086D7EA54 /* FoliateSpikeViewTTSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateSpikeViewTTSTests.swift; sourceTree = "<group>"; };
 		453A5F80C353442B3C88C611 /* HighlightPaintColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPaintColor.swift; sourceTree = "<group>"; };
 		4559FD0011E0F990013EAE48 /* TXTChapterHighlightCreationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterHighlightCreationTests.swift; sourceTree = "<group>"; };
@@ -1388,6 +1401,7 @@
 		46221600B62F5482365B0484 /* AIAssistantViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAssistantViewModel.swift; sourceTree = "<group>"; };
 		46230855AD50583047E521C5 /* TXTChapterOverlayViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterOverlayViews.swift; sourceTree = "<group>"; };
 		4630258E354B2D34ADB23182 /* WebDAVProfileListViewModelEditorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProfileListViewModelEditorTests.swift; sourceTree = "<group>"; };
+		469B267E0D3DB05D1D8F530A /* FoliateHighlightJSBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightJSBridgeTests.swift; sourceTree = "<group>"; };
 		46BCC142F6FF2ABE9B5BA64B /* PositionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionPersistenceTests.swift; sourceTree = "<group>"; };
 		46C22F30DF9F05C20CF8DDBC /* AITypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AITypes.swift; sourceTree = "<group>"; };
 		470BBE13ED7BCDD6E60D3400 /* SchemaV3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV3.swift; sourceTree = "<group>"; };
@@ -1438,6 +1452,7 @@
 		4F8AEC7D40405AE90840ABE4 /* HighlightRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightRenderer.swift; sourceTree = "<group>"; };
 		4FA36CFAC187DC7B25B7A920 /* ChapterStartTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterStartTypography.swift; sourceTree = "<group>"; };
 		4FE8B867BCF9BCDCF23941DB /* EPUBPreExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBPreExtractorTests.swift; sourceTree = "<group>"; };
+		5009D3D555DF12B60ACC2D88 /* HighlightPopoverModifierBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPopoverModifierBody.swift; sourceTree = "<group>"; };
 		506F86FDA1498276D10E5E7B /* FoliateViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateViewCoordinator.swift; sourceTree = "<group>"; };
 		50AA77FDB19CB7EDA69418C8 /* ReaderUnifiedCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderUnifiedCoordinator.swift; sourceTree = "<group>"; };
 		50CA80F28DFB8D0D4F4BEC25 /* BookSourceHTTPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSourceHTTPClientTests.swift; sourceTree = "<group>"; };
@@ -1588,6 +1603,7 @@
 		71FBA8CFEF94EDBE0398AC4A /* TXTChapterOffsetIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterOffsetIndexTests.swift; sourceTree = "<group>"; };
 		7205862B286DDE2DD2233F6D /* TXTChunkedReaderBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChunkedReaderBridge.swift; sourceTree = "<group>"; };
 		725F9036150B858160ACFF7B /* TXTReaderContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReaderContainerView.swift; sourceTree = "<group>"; };
+		726B2271F9C320E40AA66D67 /* HighlightPopoverActionRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPopoverActionRouter.swift; sourceTree = "<group>"; };
 		72B8B24C49B7E5DCAC2B9667 /* DeviceIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceIdentityTests.swift; sourceTree = "<group>"; };
 		733D454ED427DA1631A63AC0 /* ReaderChromeButtonContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderChromeButtonContractTests.swift; sourceTree = "<group>"; };
 		73B902CC4D30A1A392CFA4EA /* Feature11EPUBHighlightVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature11EPUBHighlightVerificationTests.swift; sourceTree = "<group>"; };
@@ -1828,6 +1844,7 @@
 		AC517B8E3581F795DEDEC934 /* PersistenceActor+Highlights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+Highlights.swift"; sourceTree = "<group>"; };
 		AD065491E8CFE99188D62E09 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
 		AD170A9C4FEB206D5F5F2157 /* V5toV6MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V5toV6MigrationTests.swift; sourceTree = "<group>"; };
+		ADA1F6F765714110EBCCF24B /* HighlightPopoverActionRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPopoverActionRouterTests.swift; sourceTree = "<group>"; };
 		AE0CDD04120BFF39B61E8418 /* BackgroundIndexingCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundIndexingCoordinatorTests.swift; sourceTree = "<group>"; };
 		AE29B97304B59C88E3F3F9CF /* AITranslationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AITranslationTests.swift; sourceTree = "<group>"; };
 		AE50C2E67CBF0EB4747276C1 /* KeychainService+ProviderProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeychainService+ProviderProfile.swift"; sourceTree = "<group>"; };
@@ -1864,6 +1881,7 @@
 		B6CC92F8C2796AB46E2B5E21 /* CloudKitClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudKitClient.swift; sourceTree = "<group>"; };
 		B6CE6EA4B82CC966077E656F /* BookmarkListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkListView.swift; sourceTree = "<group>"; };
 		B6DAD680DB86CF1A65D34F3F /* LibraryRefreshServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryRefreshServiceTests.swift; sourceTree = "<group>"; };
+		B75EC9C3C222236A27183F13 /* FoliateHighlightJSBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightJSBridge.swift; sourceTree = "<group>"; };
 		B811BD48F552B167D438BFCF /* BookModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookModelTests.swift; sourceTree = "<group>"; };
 		B849723B3079FB8F3F4A7961 /* PDFHighlightIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFHighlightIntegrationTests.swift; sourceTree = "<group>"; };
 		B84D0E1452F211B986E8328A /* ContentHasher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentHasher.swift; sourceTree = "<group>"; };
@@ -1931,6 +1949,7 @@
 		C76B2024F008B3A41C030585 /* ReaderBottomChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderBottomChrome.swift; sourceTree = "<group>"; };
 		C775619D3C0E4641505CE2B8 /* Highlight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlight.swift; sourceTree = "<group>"; };
 		C78C11958968AC75ED1EFB00 /* build-bundle.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "build-bundle.sh"; sourceTree = "<group>"; };
+		C7CA57AE61E378A1980BFF60 /* UIKitHighlightPopoverPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitHighlightPopoverPresenter.swift; sourceTree = "<group>"; };
 		C80D6D1B18008B168D01FFF2 /* BookOpenPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookOpenPerformanceTests.swift; sourceTree = "<group>"; };
 		C85205257E8103AA80C08BAB /* BookmarkFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkFeedbackTests.swift; sourceTree = "<group>"; };
 		C8A63C748487B0E94CC5F70D /* ReaderSafeAreaResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSafeAreaResolverTests.swift; sourceTree = "<group>"; };
@@ -1997,6 +2016,7 @@
 		D52DADD2C2FB6330070EA6DE /* FileSizeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSizeFormatter.swift; sourceTree = "<group>"; };
 		D5C26DE0705F29A16D1919F5 /* OPDSParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSParserTests.swift; sourceTree = "<group>"; };
 		D5CE4AD339F8C68B973D9C88 /* NativeTextPagedIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTextPagedIntegrationTests.swift; sourceTree = "<group>"; };
+		D6A24122FDBAEA4D6DBE9465 /* HighlightActionCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightActionCardView.swift; sourceTree = "<group>"; };
 		D6D8E56C3937A3FF796151EB /* CollectionTestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionTestHelper.swift; sourceTree = "<group>"; };
 		D712BAAF509AEBA3A3FB01C3 /* FoliateHighlightRestoreDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightRestoreDispatcherTests.swift; sourceTree = "<group>"; };
 		D721FA5AC22C4EBD49791B48 /* TTSHighlightCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSHighlightCoordinator.swift; sourceTree = "<group>"; };
@@ -2017,6 +2037,7 @@
 		DADECFF5C347B6D68C1A8529 /* EPUBTextExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBTextExtractorTests.swift; sourceTree = "<group>"; };
 		DAF6B274A7CA4B3240E60E9F /* BookDownloadSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDownloadSheet.swift; sourceTree = "<group>"; };
 		DB16317C72EB6BBB61D77030 /* V1toV2Migration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V1toV2Migration.swift; sourceTree = "<group>"; };
+		DB42619D63C6DB1728CE74D0 /* HighlightActionCardViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightActionCardViewTests.swift; sourceTree = "<group>"; };
 		DB61A191698AD787CC1CCB2F /* AISummaryScopeChipStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISummaryScopeChipStrip.swift; sourceTree = "<group>"; };
 		DB6CE81404902AB359536964 /* PROPFINDParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PROPFINDParser.swift; sourceTree = "<group>"; };
 		DBA51F184E6AA5F2FD1F5456 /* zip.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = zip.js; sourceTree = "<group>"; };
@@ -2135,6 +2156,7 @@
 		F64BCF588EF860DD6C214737 /* BackupLibraryManifestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupLibraryManifestTests.swift; sourceTree = "<group>"; };
 		F691E61DE6E713DE4FD47733 /* AISummaryTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISummaryTabView.swift; sourceTree = "<group>"; };
 		F693921BA233745D77EC0037 /* SyncStatusMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusMonitor.swift; sourceTree = "<group>"; };
+		F6E02E23F3C9B74668C4264F /* HighlightActionCardSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightActionCardSubviews.swift; sourceTree = "<group>"; };
 		F70B62CBA5AED4AECA05825E /* SchemaV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV4.swift; sourceTree = "<group>"; };
 		F7672B4D5423E0D3AAE16343 /* MDReaderReplacementRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReaderReplacementRulesTests.swift; sourceTree = "<group>"; };
 		F771364B47585A44CCA66EA4 /* ReaderThemeV2EPUBCSSCalibrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeV2EPUBCSSCalibrationTests.swift; sourceTree = "<group>"; };
@@ -2598,6 +2620,7 @@
 				ABFBA14606BD14D14A8D5500 /* EPUBWebViewBridgeTests.swift */,
 				A4F8D4A29BBB0E68DEE76DC5 /* Feature55NativeWiringTests.swift */,
 				3422A641DD03B2ACCB6645EA /* Feature55WebHostWiringTests.swift */,
+				469B267E0D3DB05D1D8F530A /* FoliateHighlightJSBridgeTests.swift */,
 				9CB5EAAB268616336D42EC30 /* FoliateHighlightRendererTests.swift */,
 				D712BAAF509AEBA3A3FB01C3 /* FoliateHighlightRestoreDispatcherTests.swift */,
 				58F5ACDA719E20E4BFA9BAB3 /* FoliateReaderContainerViewTests.swift */,
@@ -2607,11 +2630,13 @@
 				44FC663099F4228086D7EA54 /* FoliateSpikeViewTTSTests.swift */,
 				9B2676F3D304FF8ABE845A8B /* FoliateViewCoordinatorTests.swift */,
 				16E293CFD61A19BB48B38963 /* HighlightableTextViewTests.swift */,
+				DB42619D63C6DB1728CE74D0 /* HighlightActionCardViewTests.swift */,
 				1700C3F11D9ECDDBC750B939 /* HighlightCoordinatorMutationTests.swift */,
 				EE90002A18E00A2E245C23BC /* HighlightCoordinatorTapHandlerTests.swift */,
 				2724D3C50EDE1DC1DA43BB5F /* HighlightCoordinatorTests.swift */,
 				FABEAF0841AD808F7EE48617 /* HighlightIntegrationTests.swift */,
 				1790A0CEB902B16952776EE4 /* HighlightPaintColorTests.swift */,
+				ADA1F6F765714110EBCCF24B /* HighlightPopoverActionRouterTests.swift */,
 				8D93AA422199A410F2161589 /* HighlightPopoverContentTests.swift */,
 				F219E7D85B8713E9A5736E2E /* HighlightPopoverModeTests.swift */,
 				6AA1E6FB5ADF99CF8CEB51FF /* HighlightPopoverPresenterTests.swift */,
@@ -3092,6 +3117,7 @@
 				1920480AF349823757484C2D /* EPUBWebViewBridgeCoordinator.swift */,
 				1C07D184EF0E90D5F2DF7A36 /* EPUBWebViewBridgeJS.swift */,
 				DCC4E330CF0A4F1EBF039346 /* FoliateCoordinatorBox.swift */,
+				B75EC9C3C222236A27183F13 /* FoliateHighlightJSBridge.swift */,
 				21CF1C76C54971B97341E5E9 /* FoliateHighlightRenderer.swift */,
 				6F1F3EF7737CB98C28172050 /* FoliateHighlightRestoreDispatcher.swift */,
 				CF65A328F9A79571A5164390 /* FoliateReaderContainerView.swift */,
@@ -3104,11 +3130,17 @@
 				D17013114ADB4797AB48D794 /* FoliateViewBridge.swift */,
 				506F86FDA1498276D10E5E7B /* FoliateViewCoordinator.swift */,
 				D9E867C06CA165E731435125 /* HighlightableTextView.swift */,
+				F6E02E23F3C9B74668C4264F /* HighlightActionCardSubviews.swift */,
+				D6A24122FDBAEA4D6DBE9465 /* HighlightActionCardView.swift */,
 				3FEF00B7A753219DC31C8AF7 /* HighlightActionPresenter.swift */,
 				8271FD51C6DF16B39F398C99 /* HighlightCoordinator.swift */,
 				453A5F80C353442B3C88C611 /* HighlightPaintColor.swift */,
+				726B2271F9C320E40AA66D67 /* HighlightPopoverActionRouter.swift */,
 				7F9577DDE6531E6726A79862 /* HighlightPopoverContent.swift */,
+				2B94D8DF6728DEE93B09DE96 /* HighlightPopoverDeleteConfirm.swift */,
 				5725E598AB5CBA16440549D4 /* HighlightPopoverMode.swift */,
+				44AEA97F06DB06AEAFB526F1 /* HighlightPopoverModifier.swift */,
+				5009D3D555DF12B60ACC2D88 /* HighlightPopoverModifierBody.swift */,
 				275E627BA853004639B3E531 /* HighlightPopoverPresenter.swift */,
 				4F8AEC7D40405AE90840ABE4 /* HighlightRenderer.swift */,
 				4B0EDE73D4EB702686B1326E /* MDReaderContainerView.swift */,
@@ -3180,6 +3212,7 @@
 				43347208CA56C84F65B2DCF7 /* TXTTextViewBridge.swift */,
 				A96A115C3FA0B797030C1D1F /* TXTTextViewBridgeCoordinator.swift */,
 				48EFB2798AC0354FCC8D4A9B /* TXTViewConfig.swift */,
+				C7CA57AE61E378A1980BFF60 /* UIKitHighlightPopoverPresenter.swift */,
 				AE94CCB00EEB04990AC71435 /* UIKitNotePreviewPresenter.swift */,
 				F82AD6F50703DBCA984EBAAC /* UnifiedPagedView.swift */,
 				A0753D8C40DFE06B0323EE5B /* UnifiedScrollView.swift */,
@@ -4433,6 +4466,7 @@
 				982FDBDA893DC7DA931711C7 /* FeatureFlagsTests.swift in Sources */,
 				2DB8779FF53587C400452428 /* FileAvailabilityStateMachineTests.swift in Sources */,
 				019FB8C5A2498141587A09A4 /* FileURLImportRouterTests.swift in Sources */,
+				DD040D904159CBFF9C5B03F2 /* FoliateHighlightJSBridgeTests.swift in Sources */,
 				F30E23AC6F6159FB814A7C7D /* FoliateHighlightRendererTests.swift in Sources */,
 				32B7B523223C7D83ED40A208 /* FoliateHighlightRestoreDispatcherTests.swift in Sources */,
 				3EB8343FF1512E959CCEDD65 /* FoliateHighlightTapResolverTests.swift in Sources */,
@@ -4458,6 +4492,7 @@
 				2CBF53D883E09532ABC29FE4 /* GenerativeCoverViewStyleTests.swift in Sources */,
 				43228D2AF27BDD7DDD6BB5AB /* HTTPTTSConfigTests.swift in Sources */,
 				FB4B2B41D865A14865DF4DE1 /* HTTPTTSProviderTests.swift in Sources */,
+				C57845DF5A192CA91CE07FED /* HighlightActionCardViewTests.swift in Sources */,
 				9D982FAFD79829613C2EFECB /* HighlightAnchorStorageTests.swift in Sources */,
 				CFF91208E4CD56126CC9FB8D /* HighlightCoordinatorMutationTests.swift in Sources */,
 				28D0C7BD8B1B21DFA60D7B64 /* HighlightCoordinatorTapHandlerTests.swift in Sources */,
@@ -4466,6 +4501,7 @@
 				51F370150CAD9A865053266C /* HighlightIntegrationTests.swift in Sources */,
 				FB0BC111F33D81D4E93A031F /* HighlightListViewModelTests.swift in Sources */,
 				85A21D4B6B18C0523D26375A /* HighlightPaintColorTests.swift in Sources */,
+				BDADBC7F8C9300E0DF6E8F60 /* HighlightPopoverActionRouterTests.swift in Sources */,
 				E6C56F9303728C59E448F0E6 /* HighlightPopoverActionTests.swift in Sources */,
 				F3E08AC82699CE045DD5B98A /* HighlightPopoverContentTests.swift in Sources */,
 				18587C0846741F3EB4670793 /* HighlightPopoverModeTests.swift in Sources */,
@@ -4920,6 +4956,7 @@
 				095C1FEFA8400DD2F1A61CFF /* FileSizeFormatter.swift in Sources */,
 				D924CEB663B0891962654696 /* FileURLImportRouter.swift in Sources */,
 				301498E0C7A6CBC1E7E8DF49 /* FoliateCoordinatorBox.swift in Sources */,
+				84FDAB02CDE741029EE927A8 /* FoliateHighlightJSBridge.swift in Sources */,
 				11268CE0083F01ADC27C5C6B /* FoliateHighlightRenderer.swift in Sources */,
 				268DE55B3D1C25F7AAC58E0D /* FoliateHighlightRestoreDispatcher.swift in Sources */,
 				0ECFF8347437492AC8881CCF /* FoliateHighlightTapResolver.swift in Sources */,
@@ -4954,6 +4991,8 @@
 				E7EF2F892419DE80C3FC8B3B /* HTTPTTSSettingsView.swift in Sources */,
 				FA8BF5E0D98277BECAFB70CA /* HapticFeedback.swift in Sources */,
 				A957D0C3F823092026646570 /* Highlight.swift in Sources */,
+				E5A530D53A57B6CC92665E4C /* HighlightActionCardSubviews.swift in Sources */,
+				CCADB57440392A88FAEAFBAF /* HighlightActionCardView.swift in Sources */,
 				1D504D1EB7BAFF76A2B9F001 /* HighlightActionPresenter.swift in Sources */,
 				68334589D47C834C926DEF1C /* HighlightCoordinator.swift in Sources */,
 				0C04B6441DD521F888F59DBD /* HighlightListView.swift in Sources */,
@@ -4962,8 +5001,12 @@
 				E6CEF5EE777A90FFBBB2C26A /* HighlightPaintColor.swift in Sources */,
 				1F3F0A67EB5D7AEC3B11D3C3 /* HighlightPersisting.swift in Sources */,
 				9D63AB1D5AFB8A4094E2A386 /* HighlightPopoverAction.swift in Sources */,
+				0355A26EEC17FC8847311896 /* HighlightPopoverActionRouter.swift in Sources */,
 				75FB6C4CEAA85621B51537C6 /* HighlightPopoverContent.swift in Sources */,
+				3613DFF5007EAA0C4D5B2CEB /* HighlightPopoverDeleteConfirm.swift in Sources */,
 				AFE6C4ADD50C68610CE76DA2 /* HighlightPopoverMode.swift in Sources */,
+				D1A367426DB437420A23C030 /* HighlightPopoverModifier.swift in Sources */,
+				7845E001F6CBB7CE601704AF /* HighlightPopoverModifierBody.swift in Sources */,
 				D7398F637BABFC8724717B40 /* HighlightPopoverPresenter.swift in Sources */,
 				6385D414214525E5CF2C4C8E /* HighlightPopoverViewModel.swift in Sources */,
 				1BD4CC8621C43917629D4728 /* HighlightRecord.swift in Sources */,
@@ -5242,6 +5285,7 @@
 				46AE79F9CB6E8AAE304DE34A /* TranslationResultCard.swift in Sources */,
 				00074EAF27B3E74401E41076 /* TypefacePillToggle.swift in Sources */,
 				CE3D74414B1983EB35589EFD /* TypographySettings.swift in Sources */,
+				FE054F2D4C15B2BE95EFE3F0 /* UIKitHighlightPopoverPresenter.swift in Sources */,
 				2D9E7771E15DA101401537FA /* UIKitNotePreviewPresenter.swift in Sources */,
 				ADAA21CB04F57472C44679D5 /* UTF16TextSlicer.swift in Sources */,
 				B401D6506E193DB12661B33E /* UnifiedEPUBLoadResult.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5470,13 +5470,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 525;
+				CURRENT_PROJECT_VERSION = 526;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.10;
+				MARKETING_VERSION = 3.36.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5620,13 +5620,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 525;
+				CURRENT_PROJECT_VERSION = 526;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.10;
+				MARKETING_VERSION = 3.36.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Views/Reader/FoliateHighlightJSBridge.swift
+++ b/vreader/Views/Reader/FoliateHighlightJSBridge.swift
@@ -1,0 +1,111 @@
+// Purpose: Feature #64 WI-4 — `FoliateHighlightJSBridge`, the pure-logic
+// helper that posts the Foliate recolor / delete JS-notification pairs for
+// the unified highlight-action popover.
+//
+// Foliate (AZW3/MOBI) has NO `HighlightRenderer` conformer —
+// `FoliateHighlightRenderer` is a `struct` with only `static` JS-builder
+// methods. Foliate highlight visuals are driven entirely by `NotificationCenter`
+// messages keyed on CFI, observed inside `FoliateSpikeView.Coordinator`
+// (the `.foliateRequestAnnotationJSCreate` / `Delete` observers). So the
+// unified popover's Foliate path does NOT go through `HighlightCoordinator`;
+// it posts those notifications instead.
+//
+// This bridge owns the "extract the CFI from a record's `.epub` anchor + post
+// the right pair of notifications" logic so it is unit-testable with a
+// `NotificationCenter` spy — no `WKWebView`.
+//
+// Key decisions:
+// - `@MainActor` — `NotificationCenter.post` for reader-UI events is driven
+//   on the main actor, consistent with the rest of the reader bus.
+// - The CFI is recovered from `HighlightRecord.anchor`'s `.epub` case
+//   (`AnnotationAnchor.epub(href:cfi:serializedRange:)` carries the CFI —
+//   AZW3/MOBI highlights store the `.epub` anchor because Foliate-js is
+//   CFI-based). A record whose `anchor` is not `.epub` (legacy / corrupt)
+//   skips the JS repaint with an OSLog warning — no crash, no force-unwrap.
+//   The next book reopen repaints from persistence.
+// - `recolor` posts delete-then-create — Foliate-js replaces an annotation
+//   that way. `delete` posts BOTH `.readerHighlightRemoved` (UUID — keeps
+//   the panel/list in sync) AND `.foliateRequestAnnotationJSDelete` (CFI —
+//   strips the SVG overlay immediately).
+//
+// @coordinates-with: FoliateSpikeView.swift (the JS observers),
+//   FoliateHighlightRenderer.swift, HighlightRecord.swift,
+//   AnnotationAnchor.swift, ReaderNotifications.swift
+//   (.foliateRequestAnnotationJSCreate / Delete, .readerHighlightRemoved)
+
+#if canImport(UIKit)
+import Foundation
+import OSLog
+
+/// Posts the Foliate recolor / delete JS-notification pairs for the unified
+/// highlight-action popover. Pure logic — testable with a NotificationCenter
+/// spy, no `WKWebView`.
+@MainActor
+struct FoliateHighlightJSBridge {
+
+    private let notificationCenter: NotificationCenter
+    private let log = Logger(subsystem: "com.vreader.app", category: "FoliateHighlightJSBridge")
+
+    init(notificationCenter: NotificationCenter = .default) {
+        self.notificationCenter = notificationCenter
+    }
+
+    /// Repaints a recolored highlight in the Foliate WKWebView: posts
+    /// `.foliateRequestAnnotationJSDelete` then `.foliateRequestAnnotationJSCreate`
+    /// (delete-then-create — how Foliate-js replaces an annotation) with the
+    /// CFI from the record's `.epub` anchor, the new color, and the book key.
+    ///
+    /// A record whose `anchor` is not `.epub` (legacy / corrupt) skips the JS
+    /// repaint with a logged warning — the recolor still persisted; the next
+    /// book reopen repaints from persistence.
+    func recolor(record: HighlightRecord, to color: String, fingerprintKey: String) {
+        guard let cfi = Self.cfi(from: record.anchor) else {
+            log.warning("recolor skipped — record has no .epub anchor CFI")
+            return
+        }
+        notificationCenter.post(
+            name: .foliateRequestAnnotationJSDelete,
+            object: nil,
+            userInfo: ["cfi": cfi, "fingerprintKey": fingerprintKey]
+        )
+        notificationCenter.post(
+            name: .foliateRequestAnnotationJSCreate,
+            object: nil,
+            userInfo: ["cfi": cfi, "color": color, "fingerprintKey": fingerprintKey]
+        )
+    }
+
+    /// Removes a deleted highlight from the Foliate WKWebView: posts
+    /// `.readerHighlightRemoved` (the highlight's UUID string — keeps the
+    /// Annotations panel / list in sync) AND, when the record carries an
+    /// `.epub` anchor CFI, `.foliateRequestAnnotationJSDelete` (strips the
+    /// SVG overlay immediately).
+    ///
+    /// `.readerHighlightRemoved` is posted unconditionally so the panel
+    /// updates even for a legacy non-`.epub`-anchored record; only the JS
+    /// overlay strip is skipped (with a logged warning) in that case.
+    func delete(record: HighlightRecord, fingerprintKey: String) {
+        notificationCenter.post(
+            name: .readerHighlightRemoved,
+            object: record.highlightId.uuidString
+        )
+        guard let cfi = Self.cfi(from: record.anchor) else {
+            log.warning("delete — SVG overlay strip skipped (record has no .epub anchor CFI)")
+            return
+        }
+        notificationCenter.post(
+            name: .foliateRequestAnnotationJSDelete,
+            object: nil,
+            userInfo: ["cfi": cfi, "fingerprintKey": fingerprintKey]
+        )
+    }
+
+    /// Extracts the CFI from an anchor's `.epub` case. Returns `nil` for any
+    /// other anchor case, a `nil` anchor, or an empty CFI — the caller skips
+    /// the JS repaint rather than posting a no-op notification.
+    static func cfi(from anchor: AnnotationAnchor?) -> String? {
+        guard case let .epub(_, cfi, _) = anchor, !cfi.isEmpty else { return nil }
+        return cfi
+    }
+}
+#endif

--- a/vreader/Views/Reader/HighlightActionCardSubviews.swift
+++ b/vreader/Views/Reader/HighlightActionCardSubviews.swift
@@ -1,0 +1,248 @@
+// Purpose: Feature #64 WI-4 — the shared subviews of the unified
+// highlight-action popover: meta row, excerpt strip, note region (reading /
+// empty / editing), color row, action row, delete-confirmation.
+//
+// `HighlightActionCardView` (the outer shells — anchored card + bottom sheet)
+// composes these. Split into their own file because `HighlightActionCardView`
+// + these subviews together exceed the ~300-line guideline.
+//
+// Layout pinned to the committed design bundle
+// `dev-docs/designs/vreader-fidelity-v1/project/vreader-highlight-popover.jsx`
+// (`HPMetaRow` / `HPExcerpt` / `HPNoteRegion` / `HPColorRow` / `HPActionRow` /
+// `HPDeleteConfirm`).
+//
+// All subviews are purely presentational — every piece of state (`mode`,
+// `noteDraft`, `pressedColor`) lives in the parent; user taps funnel through
+// a single `(HighlightPopoverAction) -> Void` callback.
+//
+// @coordinates-with: HighlightActionCardView.swift, HighlightPopoverContent.swift,
+//   HighlightPopoverMode.swift, HighlightPopoverAction.swift,
+//   NamedHighlightColor.swift, ReaderThemeV2.swift, ReaderTypography.swift
+
+#if canImport(UIKit)
+import SwiftUI
+import UIKit
+
+// MARK: - Swatch color resolution
+
+/// Resolves a stored highlight color name to the popover's swatch `Color`.
+/// The 4 named picker colors map to `NamedHighlightColor.hex`; any legacy /
+/// unknown value (older hex, a future custom color) falls back to yellow —
+/// mirroring `HighlightPaintColor` / `FoliateHighlightRenderer.foliateColor`.
+enum HighlightPopoverSwatch {
+    static func color(for storedName: String) -> Color {
+        let named = NamedHighlightColor.from(storageString: storedName) ?? .yellow
+        return Color(readerHexString: named.hex) ?? .yellow
+    }
+}
+
+// MARK: - Meta row
+
+/// Color swatch · "HIGHLIGHT" label · optional chapter/date · close ✕.
+struct HighlightPopoverMetaRow: View {
+    let content: HighlightPopoverContent
+    let theme: ReaderThemeV2
+    let onDismiss: () -> Void
+
+    private var metaText: String? {
+        var parts: [String] = []
+        if let chapter = content.chapter, !chapter.isEmpty { parts.append(chapter) }
+        parts.append(Self.dateFormatter.string(from: content.createdAt))
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }()
+
+    var body: some View {
+        HStack(spacing: 8) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(HighlightPopoverSwatch.color(for: content.colorName))
+                .frame(width: 9, height: 9)
+            Text("Highlight")
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.8)
+                .textCase(.uppercase)
+                .foregroundColor(Color(theme.subColor))
+            if let metaText {
+                Text("· \(metaText)")
+                    .font(.system(size: 11))
+                    .foregroundColor(Color(theme.subColor).opacity(0.7))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            Spacer(minLength: 0)
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(Color(theme.subColor))
+                    .frame(width: 24, height: 24)
+                    .background(
+                        Circle().fill(
+                            Color(theme.isDark
+                                ? UIColor.white.withAlphaComponent(0.08)
+                                : UIColor.black.withAlphaComponent(0.05))
+                        )
+                    )
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss")
+            .accessibilityIdentifier("highlightPopoverClose")
+        }
+        .padding(EdgeInsets(top: 11, leading: 14, bottom: 8, trailing: 12))
+    }
+}
+
+// MARK: - Excerpt strip
+
+/// The highlighted passage — italic serif, colored left bar, 2-line clamp.
+struct HighlightPopoverExcerpt: View {
+    let content: HighlightPopoverContent
+    let theme: ReaderThemeV2
+
+    var body: some View {
+        if !content.highlightedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            HStack(alignment: .top, spacing: 10) {
+                RoundedRectangle(cornerRadius: 1.5)
+                    .fill(HighlightPopoverSwatch.color(for: content.colorName))
+                    .frame(width: 3)
+                Text("\u{201C}\(content.highlightedText)\u{201D}")
+                    .font(Font(ReaderTypography.body(for: .sourceSerif4, size: 12.5)))
+                    .italic()
+                    .foregroundColor(Color(theme.inkColor).opacity(0.85))
+                    .lineLimit(2)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .accessibilityIdentifier("highlightPopoverExcerpt")
+            }
+            .padding(EdgeInsets(top: 0, leading: 14, bottom: 10, trailing: 14))
+        }
+    }
+}
+
+// MARK: - Color row
+
+/// The 4-color palette + selected ring + transient press feedback.
+struct HighlightPopoverColorRow: View {
+    let content: HighlightPopoverContent
+    let theme: ReaderThemeV2
+    let pressedColor: NamedHighlightColor?
+    let onAction: (HighlightPopoverAction) -> Void
+
+    private var currentColor: NamedHighlightColor {
+        NamedHighlightColor.from(storageString: content.colorName) ?? .yellow
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(NamedHighlightColor.allCases, id: \.self) { color in
+                colorButton(color)
+            }
+            Spacer(minLength: 0)
+            Text("Color")
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.5)
+                .textCase(.uppercase)
+                .foregroundColor(Color(theme.subColor))
+        }
+        .padding(EdgeInsets(top: 4, leading: 14, bottom: 10, trailing: 14))
+    }
+
+    private func colorButton(_ color: NamedHighlightColor) -> some View {
+        let isCurrent = color == currentColor
+        let isPressed = color == pressedColor
+        return Button {
+            onAction(.changeColor(color))
+        } label: {
+            Circle()
+                .fill(Color(readerHexString: color.hex) ?? .yellow)
+                .frame(width: 30, height: 30)
+                .overlay(
+                    Circle().stroke(
+                        isCurrent ? Color(theme.accentColor) : Color.white.opacity(0.45),
+                        lineWidth: isCurrent ? 2.5 : 2
+                    )
+                )
+                .overlay(
+                    Group {
+                        if isCurrent {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 9, weight: .bold))
+                                .foregroundColor(.black.opacity(0.55))
+                        }
+                    }
+                )
+                .scaleEffect(isPressed ? 0.94 : (isCurrent ? 1.06 : 1.0))
+                .shadow(color: .black.opacity(0.18), radius: 1.5, x: 0, y: 1)
+                .frame(width: 36, height: 36)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(color.rawValue.capitalized) highlight")
+        .accessibilityIdentifier("highlightPopoverColor-\(color.rawValue)")
+    }
+}
+
+// MARK: - Action row
+
+/// Copy · Share · Delete — destructive ink on Delete only.
+struct HighlightPopoverActionRow: View {
+    let theme: ReaderThemeV2
+    let onAction: (HighlightPopoverAction) -> Void
+
+    private var dangerColor: Color {
+        Color(theme.isDark
+            ? UIColor(red: 0.91, green: 0.56, blue: 0.56, alpha: 1)
+            : UIColor(red: 0.66, green: 0.23, blue: 0.23, alpha: 1))
+    }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            actionButton("Copy", systemImage: "doc.on.doc",
+                         tint: Color(theme.inkColor), action: .copy,
+                         identifier: "highlightPopoverCopy")
+            actionButton("Share", systemImage: "square.and.arrow.up",
+                         tint: Color(theme.inkColor), action: .share,
+                         identifier: "highlightPopoverShare")
+            actionButton("Delete", systemImage: "trash",
+                         tint: dangerColor, action: .requestDelete,
+                         identifier: "highlightPopoverDelete")
+        }
+        .padding(EdgeInsets(top: 6, leading: 6, bottom: 8, trailing: 6))
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(Color(theme.ruleColor))
+                .frame(height: 0.5)
+        }
+    }
+
+    private func actionButton(
+        _ label: String, systemImage: String, tint: Color,
+        action: HighlightPopoverAction, identifier: String
+    ) -> some View {
+        Button {
+            onAction(action)
+        } label: {
+            VStack(spacing: 4) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 16))
+                Text(label)
+                    .font(.system(size: 10.5, weight: .semibold))
+            }
+            .foregroundColor(tint)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+            .padding(.horizontal, 4)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(identifier)
+    }
+}
+
+#endif

--- a/vreader/Views/Reader/HighlightActionCardView.swift
+++ b/vreader/Views/Reader/HighlightActionCardView.swift
@@ -1,0 +1,264 @@
+// Purpose: Feature #64 WI-4 — `HighlightActionCardView`, the SwiftUI
+// realization of the unified highlight-action popover. One view, two outer
+// shells: the anchored card (`.card`) and the bottom sheet (`.sheet`); the
+// shared content subviews live in `HighlightActionCardSubviews.swift`.
+//
+// Layout pinned to `dev-docs/designs/vreader-fidelity-v1/project/
+// vreader-highlight-popover.jsx` (`HighlightActionCard` + `HighlightActionSheet`).
+//
+// Purely presentational — `mode`, `noteDraft`, and `pressedColor` all live in
+// the parent (`HighlightPopoverModifier`), and user taps funnel through a
+// single `(HighlightPopoverAction) -> Void`. The note editor is a *controlled*
+// component (R1-6): the draft is `noteDraft` + `onDraftChange`, not a private
+// `@State`, so a rapid second tap on a different highlight never shows the
+// previous highlight's stale draft.
+//
+// @coordinates-with: HighlightActionCardSubviews.swift,
+//   HighlightPopoverContent.swift, HighlightPopoverMode.swift,
+//   HighlightPopoverAction.swift, HighlightPopoverModifier.swift,
+//   ReaderThemeV2.swift, ReaderTypography.swift
+
+#if canImport(UIKit)
+import SwiftUI
+import UIKit
+
+/// The unified highlight-action popover view.
+struct HighlightActionCardView: View {
+    let content: HighlightPopoverContent
+    let theme: ReaderThemeV2
+    /// The card's interaction sub-state.
+    let mode: HighlightPopoverMode
+    /// `.card` (anchored, with notch) or `.sheet` (bottom) outer shell.
+    let form: HighlightPopoverForm
+    /// Presenter-owned note-editor draft (R1-6 — a controlled component).
+    let noteDraft: String
+    /// Transient press feedback on a color circle.
+    let pressedColor: NamedHighlightColor?
+    let onAction: (HighlightPopoverAction) -> Void
+    let onDraftChange: (String) -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        switch form {
+        case .card:
+            cardShell
+        case .sheet:
+            sheetShell
+        }
+    }
+
+    // MARK: - Outer shells
+
+    private var cardShell: some View {
+        cardContent
+            .frame(width: 320)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(surfaceColor)
+                    .shadow(color: .black.opacity(0.28), radius: 20, x: 0, y: 14)
+            )
+            .accessibilityIdentifier("highlightPopoverCard")
+    }
+
+    private var sheetShell: some View {
+        VStack(spacing: 0) {
+            // Drag handle.
+            RoundedRectangle(cornerRadius: 3)
+                .fill(Color(theme.isDark
+                    ? UIColor.white.withAlphaComponent(0.18)
+                    : UIColor.black.withAlphaComponent(0.12)))
+                .frame(width: 36, height: 5)
+                .padding(.top, 6)
+            cardContent
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 18)
+                .fill(surfaceColor)
+        )
+        .accessibilityIdentifier("highlightPopoverSheet")
+    }
+
+    // MARK: - Shared content
+
+    @ViewBuilder
+    private var cardContent: some View {
+        VStack(spacing: 0) {
+            HighlightPopoverMetaRow(content: content, theme: theme, onDismiss: onDismiss)
+            HighlightPopoverExcerpt(content: content, theme: theme)
+
+            if mode == .confirmingDelete {
+                HighlightPopoverDeleteConfirm(theme: theme, onAction: onAction)
+            } else {
+                noteRegion
+                if mode != .editing {
+                    HighlightPopoverColorRow(
+                        content: content, theme: theme,
+                        pressedColor: pressedColor, onAction: onAction
+                    )
+                    HighlightPopoverActionRow(theme: theme, onAction: onAction)
+                }
+            }
+        }
+    }
+
+    // MARK: - Note region (reading / empty / editing)
+
+    @ViewBuilder
+    private var noteRegion: some View {
+        switch mode {
+        case .editing:
+            editingNote
+        case .reading, .confirmingDelete:
+            if content.isEmpty {
+                emptyNote
+            } else {
+                readingNote
+            }
+        }
+    }
+
+    private var editingNote: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HighlightNoteDraftEditor(
+                draft: noteDraft,
+                theme: theme,
+                onDraftChange: onDraftChange
+            )
+            HStack(spacing: 4) {
+                Spacer(minLength: 0)
+                Button {
+                    onAction(.cancelEdit)
+                } label: {
+                    Text("Cancel")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(Color(theme.subColor))
+                        .padding(.vertical, 6)
+                        .padding(.horizontal, 12)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("highlightPopoverEditCancel")
+                Button {
+                    onAction(.saveNote(noteDraft))
+                } label: {
+                    Text("Save")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.white)
+                        .padding(.vertical, 6)
+                        .padding(.horizontal, 14)
+                        .background(RoundedRectangle(cornerRadius: 8).fill(Color(theme.accentColor)))
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("highlightPopoverEditSave")
+            }
+            .padding(.top, 6)
+        }
+        .padding(EdgeInsets(top: 0, leading: 12, bottom: 10, trailing: 12))
+    }
+
+    private var emptyNote: some View {
+        Button {
+            onAction(.beginEdit)
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "plus")
+                    .font(.system(size: 11, weight: .medium))
+                Text("Add a note…")
+                    .font(Font(ReaderTypography.body(for: .sourceSerif4, size: 13)))
+                    .italic()
+            }
+            .foregroundColor(Color(theme.subColor))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(EdgeInsets(top: 10, leading: 12, bottom: 10, trailing: 12))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(style: StrokeStyle(lineWidth: 1, dash: [3]))
+                    .foregroundColor(Color(theme.ruleColor))
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(EdgeInsets(top: 0, leading: 12, bottom: 10, trailing: 12))
+        .accessibilityIdentifier("highlightPopoverAddNote")
+    }
+
+    private var readingNote: some View {
+        Button {
+            onAction(.beginEdit)
+        } label: {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(content.note ?? "")
+                    .font(Font(ReaderTypography.body(for: .sourceSerif4, size: 14)))
+                    .foregroundColor(Color(theme.inkColor))
+                    .lineLimit(6)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                HStack {
+                    Text("Tap to edit")
+                        .font(.system(size: 10.5, weight: .semibold))
+                        .tracking(0.6)
+                        .textCase(.uppercase)
+                        .foregroundColor(Color(theme.subColor))
+                    Spacer(minLength: 0)
+                    Image(systemName: "pencil")
+                        .font(.system(size: 11))
+                        .foregroundColor(Color(theme.subColor))
+                }
+            }
+            .padding(EdgeInsets(top: 8, leading: 12, bottom: 10, trailing: 12))
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color(theme.isDark
+                        ? UIColor.white.withAlphaComponent(0.035)
+                        : UIColor.black.withAlphaComponent(0.025)))
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(EdgeInsets(top: 0, leading: 12, bottom: 10, trailing: 12))
+        .accessibilityIdentifier("highlightPopoverReadingNote")
+    }
+
+    // MARK: - Colors
+
+    private var surfaceColor: Color {
+        Color(theme.isDark
+            ? UIColor(red: 0.165, green: 0.153, blue: 0.141, alpha: 1)   // #2a2724
+            : UIColor(red: 0.988, green: 0.973, blue: 0.941, alpha: 1))  // #fcf8f0
+    }
+}
+
+/// The inline note-editor textarea — a controlled `TextEditor`. The draft is
+/// owned by the presenter (`HighlightPopoverModifier`) and flows in via
+/// `draft` + out via `onDraftChange`, so a rapid highlight swap or a
+/// successful save never shows a stale draft (R1-6).
+struct HighlightNoteDraftEditor: View {
+    let draft: String
+    let theme: ReaderThemeV2
+    let onDraftChange: (String) -> Void
+
+    var body: some View {
+        TextEditor(text: Binding(
+            get: { draft },
+            set: { onDraftChange($0) }
+        ))
+        .font(Font(ReaderTypography.body(for: .sourceSerif4, size: 14)))
+        .foregroundColor(Color(theme.inkColor))
+        .scrollContentBackground(.hidden)
+        .frame(minHeight: 84, maxHeight: 132)
+        .padding(EdgeInsets(top: 8, leading: 10, bottom: 8, trailing: 10))
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color(theme.isDark
+                    ? UIColor.white.withAlphaComponent(0.05)
+                    : UIColor.black.withAlphaComponent(0.035)))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color(theme.accentColor).opacity(0.27), lineWidth: 1)
+        )
+        .accessibilityIdentifier("highlightPopoverNoteEditor")
+    }
+}
+#endif

--- a/vreader/Views/Reader/HighlightCoordinator.swift
+++ b/vreader/Views/Reader/HighlightCoordinator.swift
@@ -20,6 +20,23 @@
 #if canImport(UIKit)
 import Foundation
 
+/// Feature #64 — the highlight-mutation boundary the unified highlight-action
+/// popover's router dispatches through. A protocol (not the concrete
+/// `HighlightCoordinator`) so `HighlightPopoverActionRouter` is unit-testable
+/// with a fake. `HighlightCoordinator` is the production conformer.
+@MainActor
+protocol HighlightMutating: AnyObject {
+    /// Persists a new color and repaints the rendered highlight.
+    func changeColor(highlightID: UUID, to color: String) async -> HighlightMutationOutcome
+    /// Persists a note edit (no reader-surface repaint).
+    func updateNote(highlightID: UUID, note: String?) async -> HighlightMutationOutcome
+    /// Deletes a highlight from persistence and clears its rendered visual.
+    /// Returns a typed outcome: `.success` (record carries the deleted
+    /// highlight), `.notFound` (already gone — a concurrent-deletion race),
+    /// `.failed` (a generic persistence error).
+    func deleteHighlight(highlightID: UUID) async -> HighlightMutationOutcome
+}
+
 /// Coordinates highlight create/delete/restore across persistence and rendering.
 @MainActor
 final class HighlightCoordinator {
@@ -219,5 +236,53 @@ final class HighlightCoordinator {
         let trimmed = note.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : note
     }
+
+    /// Feature #64 WI-3/WI-4 — deletes a highlight from persistence and clears
+    /// its rendered visual via the `.readerHighlightRemoved` notification
+    /// (the existing Bug #78 visual-clear pipeline).
+    ///
+    /// Returns a typed `HighlightMutationOutcome` so the popover presenter
+    /// routes consistently with `changeColor` / `updateNote` (R1-5): the
+    /// record is fetched up front so a concurrent-deletion race is
+    /// `.notFound` (the popover dismisses) rather than collapsing into a
+    /// generic failure that wrongly keeps a stale surface open. A genuine
+    /// persistence error is `.failed` — the popover stays, no UI alert (the
+    /// same precedent as `handleTapAction`).
+    ///
+    /// This is the unified popover's `confirmDelete` path — it supersedes the
+    /// feature #53 `handleTapAction(.delete)` route (removed in WI-10).
+    func deleteHighlight(highlightID: UUID) async -> HighlightMutationOutcome {
+        // Fetch the record up front — both to return it on `.success` and to
+        // distinguish "already gone" (.notFound) from a fetch failure.
+        let records: [HighlightRecord]
+        do {
+            records = try await persistence.fetchHighlights(forBookWithKey: bookFingerprintKey)
+        } catch {
+            return .failed
+        }
+        guard let record = records.first(where: { $0.highlightId == highlightID }) else {
+            return .notFound
+        }
+        do {
+            try await persistence.removeHighlight(highlightId: highlightID)
+        } catch let error as PersistenceError {
+            if case .recordNotFound = error { return .notFound }
+            return .failed
+        } catch {
+            return .failed
+        }
+        NotificationCenter.default.post(
+            name: .readerHighlightRemoved,
+            object: highlightID.uuidString
+        )
+        return .success(record)
+    }
 }
+
+// MARK: - HighlightMutating (Feature #64)
+
+/// `HighlightCoordinator` is the production conformer of the popover's
+/// highlight-mutation boundary. `changeColor` / `updateNote` / `deleteHighlight`
+/// are already defined above — this declares the conformance.
+extension HighlightCoordinator: HighlightMutating {}
 #endif

--- a/vreader/Views/Reader/HighlightPopoverActionRouter.swift
+++ b/vreader/Views/Reader/HighlightPopoverActionRouter.swift
@@ -1,0 +1,203 @@
+// Purpose: Feature #64 WI-4 — `HighlightPopoverActionRouter`, the
+// `@MainActor @Observable` state + dispatch core of the unified
+// highlight-action popover.
+//
+// The SwiftUI `HighlightPopoverModifier` is a thin observer of this router:
+// the router owns the popover's interaction state (`content`, `mode`,
+// `noteDraft`, `pressedColor`, `shareItem`) and routes every
+// `HighlightPopoverAction`. Extracting the state + dispatch into an
+// `@Observable` class — instead of burying it in a `ViewModifier` body — makes
+// the whole action contract unit-testable with no SwiftUI render scaffolding
+// (the same rationale as feature #60's `SelectionPopoverActionRouter`).
+//
+// Key decisions:
+// - Format-agnostic: every mutation routes through ONE `HighlightMutating`
+//   boundary. Non-Foliate formats inject a `HighlightCoordinator`; the Foliate
+//   format injects its own `HighlightMutating` conformer (WI-9). The router
+//   never branches on format.
+// - The note draft is router-owned (`noteDraft`), reset on `present` (a
+//   highlight swap) and re-seeded from the note on `beginEdit` (R1-6) — so a
+//   rapid second tap never shows the previous highlight's stale draft.
+// - `HighlightMutationOutcome` routing (R1-5 / §2.6): `.success` → refresh the
+//   on-screen content from the returned record (+ return to reading after a
+//   save); `.notFound` → dismiss; `.failed` → stay open, no local mutation.
+// - Copy / Share are host-view-independent: Copy writes `UIPasteboard`; Share
+//   sets `shareItem` (the modifier presents it via `.sheet(item:)`). Both
+//   dismiss the popover first (R2-F7).
+//
+// @coordinates-with: HighlightCoordinator.swift (HighlightMutating),
+//   HighlightPopoverContent.swift, HighlightPopoverMode.swift,
+//   HighlightPopoverAction.swift, HighlightPopoverPresenter.swift,
+//   HighlightPopoverModifier.swift
+
+#if canImport(UIKit)
+import Foundation
+import UIKit
+
+/// State + dispatch core of the unified highlight-action popover.
+@Observable
+@MainActor
+final class HighlightPopoverActionRouter {
+
+    /// The popover content currently on screen, or `nil` when dismissed.
+    private(set) var content: HighlightPopoverContent?
+    /// The card's interaction sub-state.
+    private(set) var mode: HighlightPopoverMode = .reading
+    /// The router-owned note-editor draft (R1-6 — a controlled value).
+    private(set) var noteDraft: String = ""
+    /// Transient press feedback on a color circle.
+    private(set) var pressedColor: NamedHighlightColor?
+    /// Set by a `.share` action — the excerpt text to share. The modifier
+    /// observes this, tears the popover down with a real dismiss completion,
+    /// and only THEN presents the system share sheet (so two modals never
+    /// stack — R2-F7). `nil` ⇒ no share pending.
+    private(set) var pendingShareText: String?
+
+    /// True while a popover is presented.
+    var isPresented: Bool { content != nil }
+
+    private let mutating: any HighlightMutating
+
+    init(mutating: any HighlightMutating) {
+        self.mutating = mutating
+    }
+
+    // MARK: - Presentation
+
+    /// Presents (or replaces) the popover for `content`. Always resets the
+    /// interaction state: `mode` → `.reading`, `noteDraft` → `""` — so a rapid
+    /// second tap on a different highlight never carries the prior highlight's
+    /// stale draft or editing mode (R1-6).
+    func present(_ content: HighlightPopoverContent) {
+        self.content = content
+        mode = .reading
+        noteDraft = ""
+        pressedColor = nil
+    }
+
+    /// Dismisses the popover and resets the interaction state.
+    func dismiss() {
+        content = nil
+        mode = .reading
+        noteDraft = ""
+        pressedColor = nil
+    }
+
+    /// Updates the router-owned draft as the user types — the modifier's
+    /// `onDraftChange` funnel.
+    func updateDraft(_ draft: String) {
+        noteDraft = draft
+    }
+
+    // MARK: - Action dispatch
+
+    /// Routes a `HighlightPopoverAction` emitted by the popover view.
+    func route(_ action: HighlightPopoverAction) async {
+        guard let current = content else { return }
+        switch action {
+        case .beginEdit:
+            noteDraft = current.note ?? ""
+            mode = .editing
+        case .cancelEdit:
+            // `cancelEdit` doubles as the delete-confirm "Cancel" — both
+            // return the card to the reading mode.
+            mode = .reading
+        case let .changeColor(color):
+            await handleChangeColor(color, current: current)
+        case let .saveNote(draft):
+            await handleSaveNote(draft, current: current)
+        case .requestDelete:
+            mode = .confirmingDelete
+        case .confirmDelete:
+            await handleConfirmDelete(current: current)
+        case .copy:
+            UIPasteboard.general.string = current.highlightedText
+            dismiss()
+        case .share:
+            // Record the share text and tear the popover content down. The
+            // modifier observes `pendingShareText`, dismisses the popover
+            // surface with a real completion, and only then presents the
+            // share sheet — so two modals never stack (R2-F7). `dismiss()`
+            // is called AFTER capturing the text because it clears state.
+            let text = current.highlightedText
+            dismiss()
+            pendingShareText = text
+        }
+    }
+
+    /// Clears the pending-share text. The modifier calls this once it has
+    /// consumed `pendingShareText` (after the popover dismissal completes and
+    /// the share sheet is presented).
+    func clearPendingShare() {
+        pendingShareText = nil
+    }
+
+    // MARK: - Outcome handling
+
+    private func handleChangeColor(
+        _ color: NamedHighlightColor, current: HighlightPopoverContent
+    ) async {
+        pressedColor = color
+        let outcome = await mutating.changeColor(
+            highlightID: current.id, to: color.rawValue
+        )
+        pressedColor = nil
+        applyOutcome(outcome)
+    }
+
+    private func handleSaveNote(
+        _ draft: String, current: HighlightPopoverContent
+    ) async {
+        let outcome = await mutating.updateNote(highlightID: current.id, note: draft)
+        switch outcome {
+        case let .success(record):
+            refreshContent(from: record)
+            mode = .reading
+        case .notFound:
+            dismiss()
+        case .failed:
+            // Keep the editor open so the user can retry.
+            break
+        }
+    }
+
+    private func handleConfirmDelete(current: HighlightPopoverContent) async {
+        let outcome = await mutating.deleteHighlight(highlightID: current.id)
+        switch outcome {
+        case .success, .notFound:
+            // `.success` — deleted; `.notFound` — already gone (a concurrent-
+            // deletion race). Either way the highlight no longer exists, so
+            // the popover dismisses.
+            dismiss()
+        case .failed:
+            // A genuine persistence failure keeps the popover (and the
+            // highlight) — return to the reading mode out of the confirm
+            // sub-state so the user can retry.
+            mode = .reading
+        }
+    }
+
+    /// Applies a mutation outcome that does not itself change the mode
+    /// (recolor): refresh on `.success`, dismiss on `.notFound`, no-op on
+    /// `.failed`.
+    private func applyOutcome(_ outcome: HighlightMutationOutcome) {
+        switch outcome {
+        case let .success(record):
+            refreshContent(from: record)
+        case .notFound:
+            dismiss()
+        case .failed:
+            break
+        }
+    }
+
+    /// Rebuilds `content` from a mutated record, preserving the original tap's
+    /// `sourceRect` + `chapter` so the popover stays anchored in place.
+    private func refreshContent(from record: HighlightRecord) {
+        guard let current = content else { return }
+        content = HighlightPopoverPresenter.content(
+            for: record, sourceRect: current.sourceRect, chapter: current.chapter
+        )
+    }
+}
+#endif

--- a/vreader/Views/Reader/HighlightPopoverDeleteConfirm.swift
+++ b/vreader/Views/Reader/HighlightPopoverDeleteConfirm.swift
@@ -1,0 +1,81 @@
+// Purpose: Feature #64 WI-4 — `HighlightPopoverDeleteConfirm`, the inline
+// delete-confirmation sub-state of the unified highlight-action popover.
+//
+// Replaces the color + action rows in place when the card's `mode` is
+// `.confirmingDelete`. Split into its own file from
+// `HighlightActionCardSubviews.swift` to keep both files under the ~300-line
+// guideline.
+//
+// Layout pinned to `dev-docs/designs/vreader-fidelity-v1/project/
+// vreader-highlight-popover.jsx` (`HPDeleteConfirm`).
+//
+// @coordinates-with: HighlightActionCardView.swift, HighlightActionCardSubviews.swift,
+//   HighlightPopoverAction.swift, ReaderThemeV2.swift
+
+#if canImport(UIKit)
+import SwiftUI
+import UIKit
+
+/// Inline delete-confirmation — replaces the color + action rows.
+struct HighlightPopoverDeleteConfirm: View {
+    let theme: ReaderThemeV2
+    let onAction: (HighlightPopoverAction) -> Void
+
+    private var dangerColor: Color {
+        Color(theme.isDark
+            ? UIColor(red: 0.91, green: 0.56, blue: 0.56, alpha: 1)
+            : UIColor(red: 0.66, green: 0.23, blue: 0.23, alpha: 1))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Delete this highlight?")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(Color(theme.inkColor))
+                .padding(.bottom, 4)
+            Text("The color, the note, and the underline come off the page. Can't be undone.")
+                .font(.system(size: 11.5))
+                .foregroundColor(Color(theme.subColor))
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.bottom, 10)
+            HStack(spacing: 8) {
+                Button {
+                    onAction(.cancelEdit)
+                } label: {
+                    Text("Cancel")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(Color(theme.inkColor))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color(theme.ruleColor), lineWidth: 0.5)
+                        )
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("highlightPopoverCancelDelete")
+                Button {
+                    onAction(.confirmDelete)
+                } label: {
+                    Text("Delete")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                        .background(RoundedRectangle(cornerRadius: 8).fill(dangerColor))
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("highlightPopoverConfirmDelete")
+            }
+        }
+        .padding(EdgeInsets(top: 12, leading: 14, bottom: 14, trailing: 14))
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(Color(theme.ruleColor))
+                .frame(height: 0.5)
+        }
+    }
+}
+#endif

--- a/vreader/Views/Reader/HighlightPopoverModifier.swift
+++ b/vreader/Views/Reader/HighlightPopoverModifier.swift
@@ -1,0 +1,123 @@
+// Purpose: Feature #64 WI-4 — the unified highlight-action popover's SwiftUI
+// driver: `HighlightPopoverPresenting` (the anchored-card presenter protocol),
+// `HighlightPopoverRequest` (the `.readerHighlightTapped` parse helper),
+// `HighlightShareItem` + `HighlightActivityView` (the host-view-independent
+// share channel), and `HighlightPopoverModifier` (the `ViewModifier`).
+//
+// The modifier observes `.readerHighlightTapped`, drives a
+// `HighlightPopoverViewModel`, routes the published content to the anchored
+// presenter (`.card`) or a SwiftUI `.sheet` (`.sheet`), owns the
+// presenter-owned `mode` / `noteDraft` / `shareItem` `@State`, and dispatches
+// `HighlightPopoverAction`s into `HighlightCoordinator` / the Foliate JS
+// bridge / `UIPasteboard` / the share sheet.
+//
+// Supersedes feature #55's `NotePreviewModifier` (deleted in WI-10). The
+// `HighlightPopoverPresenting` protocol is consumed here and realized by
+// `UIKitHighlightPopoverPresenter` in WI-5.
+//
+// Key decisions:
+// - The note draft is presenter-owned (`@State noteDraft`), reset whenever
+//   the editor opens or the presented highlight swaps (R1-6).
+// - `updateCard` is called whenever `mode` / `noteDraft` / `content` change
+//   while the anchored card is live — an in-place `rootView` reassignment, no
+//   dismiss+re-present, so the keyboard is preserved (R2-F6).
+// - Share goes through a SwiftUI `.sheet(item:)` hosting `HighlightActivityView`
+//   — host-view-independent, so it works whether or not a container supplies
+//   a `hostViewProvider` (R2-F7).
+//
+// @coordinates-with: HighlightPopoverViewModel.swift, HighlightActionCardView.swift,
+//   HighlightPopoverPresenter.swift, HighlightCoordinator.swift,
+//   FoliateHighlightJSBridge.swift, UIKitHighlightPopoverPresenter.swift (WI-5),
+//   ReaderNotifications.swift (.readerHighlightTapped)
+
+#if canImport(UIKit)
+import SwiftUI
+import SwiftData
+import UIKit
+
+// MARK: - Anchored-card presenter protocol
+
+/// Presents the anchored `.card` form of the unified highlight popover.
+/// Protocol so `HighlightPopoverModifier` is unit-testable against a fake;
+/// realized by `UIKitHighlightPopoverPresenter` (WI-5).
+///
+/// R2-F6: the card is an *interactive* surface — while it stays on screen the
+/// `mode` flips reading↔editing↔confirmingDelete, the `noteDraft` updates on
+/// every keystroke, and after a recolor/save the `content` is rebuilt. So the
+/// protocol exposes an explicit idempotent `updateCard` (an in-place
+/// `rootView` reassignment, no modal transition) rather than forcing a
+/// dismiss-and-re-present on every change.
+@MainActor
+protocol HighlightPopoverPresenting: AnyObject {
+    /// Presents the anchored card. If a card is already presented for the
+    /// same highlight (`content.id`), this is treated as an `updateCard`
+    /// (idempotent — no flicker, keyboard preserved). A different `content.id`
+    /// supersedes the prior card.
+    func presentCard(
+        _ content: HighlightPopoverContent,
+        theme: ReaderThemeV2,
+        mode: HighlightPopoverMode,
+        noteDraft: String,
+        pressedColor: NamedHighlightColor?,
+        in view: UIView,
+        onAction: @escaping (HighlightPopoverAction) -> Void,
+        onDraftChange: @escaping (String) -> Void,
+        onDismiss: @escaping () -> Void
+    )
+
+    /// Updates the live card's `mode` / `noteDraft` / `content` /
+    /// `pressedColor` in place by reassigning the hosting controller's
+    /// `rootView` — NO dismiss, NO re-present. A no-op if no card is currently
+    /// presented. `pressedColor` carries the design's transient swatch press
+    /// feedback into the anchored card.
+    func updateCard(
+        content: HighlightPopoverContent,
+        mode: HighlightPopoverMode,
+        noteDraft: String,
+        pressedColor: NamedHighlightColor?
+    )
+
+    /// Dismisses a currently-presented card, if any. `completion` runs after
+    /// the dismissal finishes — or synchronously when nothing is presented.
+    func dismissCard(completion: (@MainActor () -> Void)?)
+}
+
+extension HighlightPopoverPresenting {
+    /// Dismiss with no completion — the common case.
+    func dismissCard() { dismissCard(completion: nil) }
+}
+
+// MARK: - Request parse helper
+
+/// Pure-logic helper for parsing the `.readerHighlightTapped` notification.
+enum HighlightPopoverRequest {
+    /// Extracts the `ReaderHighlightTapEvent` from a `.readerHighlightTapped`
+    /// notification. Returns `nil` for a mis-posted / nil object — defensive.
+    nonisolated static func event(from notification: Notification) -> ReaderHighlightTapEvent? {
+        notification.object as? ReaderHighlightTapEvent
+    }
+}
+
+// MARK: - Share channel
+
+/// A tiny `Identifiable` wrapper around the text to share — drives the
+/// modifier's `.sheet(item:)` share channel (R2-F7).
+struct HighlightShareItem: Identifiable, Equatable {
+    let id = UUID()
+    let text: String
+}
+
+/// `UIViewControllerRepresentable` wrapping `UIActivityViewController` — the
+/// host-view-independent share channel. SwiftUI owns the presentation, so it
+/// works whether or not a container supplies a `hostViewProvider`. Mirrors
+/// `ShareSheet.swift`'s `ShareActivityView`.
+struct HighlightActivityView: UIViewControllerRepresentable {
+    let activityItems: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ controller: UIActivityViewController, context: Context) {}
+}
+#endif

--- a/vreader/Views/Reader/HighlightPopoverModifierBody.swift
+++ b/vreader/Views/Reader/HighlightPopoverModifierBody.swift
@@ -1,0 +1,294 @@
+// Purpose: Feature #64 WI-4 — `HighlightPopoverModifier` (the SwiftUI
+// `ViewModifier` driving the unified highlight-action popover) and its
+// container-side attach helpers.
+//
+// Lives alongside `HighlightPopoverModifier.swift` (the protocol + parse
+// helper + share types) — split so each file stays under the ~300-line
+// guideline. `HighlightPopoverModifier` here is the actual `ViewModifier`.
+//
+// Flow:
+//   .readerHighlightTapped  →  HighlightPopoverViewModel.handleTap  (async
+//        lookup, out-of-order-guarded)  →  publishes HighlightPopoverContent
+//   →  HighlightPopoverActionRouter.present  (takes over interaction state)
+//   →  routed to the anchored `HighlightPopoverPresenting` card (.card) or a
+//      SwiftUI `.sheet` (.sheet) per `HighlightPopoverPresenter.resolvedForm`.
+//
+// Two state holders, disjoint jobs: the view model owns the *lookup*; the
+// router owns the *interaction* (mode / draft / outcome routing). The modifier
+// bridges them and drives the anchored presenter's `presentCard` /
+// `updateCard` / `dismissCard`.
+//
+// Supersedes feature #55's `NotePreviewModifier` (deleted in WI-10).
+//
+// @coordinates-with: HighlightPopoverModifier.swift, HighlightPopoverViewModel.swift,
+//   HighlightPopoverActionRouter.swift, HighlightActionCardView.swift,
+//   HighlightPopoverPresenter.swift, UIKitHighlightPopoverPresenter.swift (WI-5)
+
+#if canImport(UIKit)
+import SwiftUI
+import SwiftData
+import UIKit
+
+// MARK: - The ViewModifier
+
+struct HighlightPopoverModifier: ViewModifier {
+
+    /// Owns the async highlight lookup + the out-of-order tap guard.
+    @State private var viewModel: HighlightPopoverViewModel
+    /// Owns the popover's interaction state + action dispatch.
+    @State private var router: HighlightPopoverActionRouter
+    /// The anchored-card presenter (the `.card` form). Injected for testing.
+    @State private var cardPresenter: any HighlightPopoverPresenting
+    /// Drives the SwiftUI `.sheet` form (the `.sheet` form). `nil` ⇒ no sheet.
+    @State private var sheetContent: HighlightPopoverContent?
+    /// Drives the share `.sheet(item:)`. Modifier-owned (NOT router-owned) and
+    /// set only AFTER the popover surface has finished dismissing, so the
+    /// share sheet never collides with the popover's own dismissal (R2-F7).
+    @State private var shareItem: HighlightShareItem?
+    /// An action to run from the popover-sheet's real `onDismiss` — used to
+    /// present the share sheet only once the popover sheet has fully
+    /// dismissed. `nil` ⇒ a plain dismissal.
+    @State private var pendingPostSheetDismiss: (@MainActor () -> Void)?
+
+    let theme: ReaderThemeV2
+    /// Optional chapter/location string for the meta row.
+    let chapter: String?
+    /// Resolves the reader's content `UIView` — the anchored card's
+    /// `sourceView`. `nil` (or a `{ nil }` provider) ⇒ the sheet form.
+    let hostViewProvider: () -> UIView?
+
+    init(
+        viewModel: HighlightPopoverViewModel,
+        router: HighlightPopoverActionRouter,
+        cardPresenter: any HighlightPopoverPresenting,
+        theme: ReaderThemeV2,
+        chapter: String?,
+        hostViewProvider: @escaping () -> UIView?
+    ) {
+        _viewModel = State(initialValue: viewModel)
+        _router = State(initialValue: router)
+        _cardPresenter = State(initialValue: cardPresenter)
+        self.theme = theme
+        self.chapter = chapter
+        self.hostViewProvider = hostViewProvider
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .onReceive(
+                NotificationCenter.default.publisher(for: .readerHighlightTapped)
+            ) { note in
+                guard let event = HighlightPopoverRequest.event(from: note) else { return }
+                Task { await viewModel.handleTap(event, chapter: chapter) }
+            }
+            .onChange(of: viewModel.presented) { _, newValue in
+                if let newValue {
+                    router.present(newValue)
+                } else {
+                    router.dismiss()
+                }
+            }
+            .onChange(of: router.content) { _, _ in routePresentation() }
+            .onChange(of: router.mode) { _, _ in syncLiveCard() }
+            .onChange(of: router.noteDraft) { _, _ in syncLiveCard() }
+            .onChange(of: router.pressedColor) { _, _ in syncLiveCard() }
+            .sheet(item: $sheetContent, onDismiss: { sheetDidDismiss() }) { content in
+                HighlightActionCardView(
+                    content: content,
+                    theme: theme,
+                    mode: router.mode,
+                    form: .sheet,
+                    noteDraft: router.noteDraft,
+                    pressedColor: router.pressedColor,
+                    onAction: { action in Task { await dispatch(action) } },
+                    onDraftChange: { router.updateDraft($0) },
+                    onDismiss: { dismissEverything() }
+                )
+                .presentationDetents([.fraction(0.5), .large])
+                .presentationDragIndicator(.visible)
+            }
+            .sheet(item: $shareItem) { item in
+                HighlightActivityView(activityItems: [item.text])
+            }
+    }
+
+    // MARK: - Presentation routing
+
+    /// Routes the router's current `content` to the anchored card or the
+    /// sheet. `nil` tears down whichever surface is up — and, when a share is
+    /// pending, presents the share sheet only from the surface's REAL
+    /// dismissal completion so two modals never stack (R2-F7).
+    private func routePresentation() {
+        guard let content = router.content else {
+            tearDownSurfaces {
+                if let text = router.pendingShareText {
+                    router.clearPendingShare()
+                    shareItem = HighlightShareItem(text: text)
+                }
+            }
+            return
+        }
+        let host = hostViewProvider()
+        let lineCount = content.note?
+            .components(separatedBy: .newlines).count ?? 0
+        let form = HighlightPopoverPresenter.resolvedForm(
+            for: content,
+            isVoiceOverRunning: UIAccessibility.isVoiceOverRunning,
+            noteLineCount: lineCount,
+            hasHostView: host != nil
+        )
+        switch form {
+        case .sheet:
+            cardPresenter.dismissCard()
+            sheetContent = content
+        case .card:
+            guard let host else {
+                // resolvedForm returns .card only when hasHostView — defensive.
+                sheetContent = content
+                return
+            }
+            sheetContent = nil
+            cardPresenter.presentCard(
+                content,
+                theme: theme,
+                mode: router.mode,
+                noteDraft: router.noteDraft,
+                pressedColor: router.pressedColor,
+                in: host,
+                onAction: { action in Task { await dispatch(action) } },
+                onDraftChange: { router.updateDraft($0) },
+                onDismiss: { dismissEverything() }
+            )
+        }
+    }
+
+    /// Pushes a `mode` / `noteDraft` / `pressedColor` change into the live
+    /// anchored card via `updateCard` — an in-place `rootView` reassignment,
+    /// NOT a dismiss + re-present, so the keyboard is preserved (R2-F6). The
+    /// `.sheet` form re-renders itself from the `@State`, so no explicit hook
+    /// is needed there.
+    private func syncLiveCard() {
+        guard let content = router.content, sheetContent == nil else { return }
+        cardPresenter.updateCard(
+            content: content, mode: router.mode, noteDraft: router.noteDraft,
+            pressedColor: router.pressedColor
+        )
+    }
+
+    // MARK: - Surface teardown (completion-aware)
+
+    /// Tears down whichever popover surface is currently up and runs
+    /// `completion` from the surface's REAL dismissal completion — so a
+    /// follow-up surface (the share sheet) is presented only after the popover
+    /// has fully dismissed, never stacking two modals.
+    ///
+    /// - Sheet form: stash `completion` in `pendingPostSheetDismiss` and clear
+    ///   `sheetContent`. SwiftUI fires the `.sheet`'s `onDismiss` →
+    ///   `sheetDidDismiss`, which runs the stashed action.
+    /// - Card form (or nothing presented): `dismissCard(completion:)` runs the
+    ///   completion from the popover's real dismiss completion — or
+    ///   synchronously when nothing is presented.
+    private func tearDownSurfaces(then completion: @escaping @MainActor () -> Void) {
+        if sheetContent != nil {
+            pendingPostSheetDismiss = completion
+            sheetContent = nil
+        } else {
+            cardPresenter.dismissCard(completion: completion)
+        }
+    }
+
+    /// Fired by the popover `.sheet`'s `onDismiss` — the real completion hook.
+    /// Runs any stashed post-dismiss action (share follow-up); otherwise it is
+    /// a plain dismissal.
+    private func sheetDidDismiss() {
+        let action = pendingPostSheetDismiss
+        pendingPostSheetDismiss = nil
+        action?()
+    }
+
+    // MARK: - Action dispatch
+
+    private func dispatch(_ action: HighlightPopoverAction) async {
+        await router.route(action)
+        // A `.success` recolor / save rebuilt `router.content`; the live card
+        // refresh rides `onChange(of: router.content)` → `routePresentation`.
+        // A `.share` cleared `router.content` + set `pendingShareText`;
+        // `routePresentation`'s nil-branch tears the surface down and presents
+        // the share sheet from the real dismiss completion.
+    }
+
+    /// Tears down every popover surface and the view-model + router state.
+    /// Used by plain-dismiss paths (× button, scrim tap, sheet drag-down).
+    private func dismissEverything() {
+        sheetContent = nil
+        pendingPostSheetDismiss = nil
+        cardPresenter.dismissCard()
+        router.dismiss()
+        viewModel.dismiss()
+    }
+}
+
+// MARK: - Attach helpers
+
+extension View {
+    /// Feature #64 WI-4 — attach the unified highlight-action popover to a
+    /// reader container. The modifier observes `.readerHighlightTapped`,
+    /// resolves the tapped highlight, and presents the anchored card or the
+    /// bottom sheet.
+    func unifiedHighlightPopoverPresenter(
+        viewModel: HighlightPopoverViewModel,
+        router: HighlightPopoverActionRouter,
+        cardPresenter: any HighlightPopoverPresenting = UIKitHighlightPopoverPresenter(),
+        theme: ReaderThemeV2,
+        chapter: String? = nil,
+        hostViewProvider: @escaping () -> UIView?
+    ) -> some View {
+        modifier(
+            HighlightPopoverModifier(
+                viewModel: viewModel,
+                router: router,
+                cardPresenter: cardPresenter,
+                theme: theme,
+                chapter: chapter,
+                hostViewProvider: hostViewProvider
+            )
+        )
+    }
+
+    /// Feature #64 WI-4 — container-friendly attach point. Builds the
+    /// `HighlightPopoverViewModel` (over the `PersistenceActor` `HighlightLookup`)
+    /// and the `HighlightPopoverActionRouter` (over the supplied
+    /// `HighlightMutating`) when `modelContainer` is non-nil; otherwise the
+    /// view is returned unchanged (inert in a SwiftUI preview / test).
+    ///
+    /// `mutating` is the format's highlight-mutation boundary — a
+    /// `HighlightCoordinator` for the `HighlightRenderer`-backed formats, the
+    /// Foliate mutator for AZW3/MOBI (WI-9). `hostViewProvider` defaults to
+    /// `{ nil }` — a container that passes `{ nil }` gets the bottom-sheet
+    /// form (`resolvedForm` degrades the card with no host).
+    @ViewBuilder
+    func unifiedHighlightPopoverPresenterIfAvailable(
+        modelContainer: ModelContainer?,
+        bookFingerprintKey: String,
+        mutating: (any HighlightMutating)?,
+        theme: ReaderThemeV2,
+        chapter: String? = nil,
+        hostViewProvider: @escaping () -> UIView? = { nil }
+    ) -> some View {
+        if let modelContainer, let mutating {
+            self.unifiedHighlightPopoverPresenter(
+                viewModel: HighlightPopoverViewModel(
+                    persistence: PersistenceActor(modelContainer: modelContainer),
+                    bookFingerprintKey: bookFingerprintKey
+                ),
+                router: HighlightPopoverActionRouter(mutating: mutating),
+                theme: theme,
+                chapter: chapter,
+                hostViewProvider: hostViewProvider
+            )
+        } else {
+            self
+        }
+    }
+}
+#endif

--- a/vreader/Views/Reader/UIKitHighlightPopoverPresenter.swift
+++ b/vreader/Views/Reader/UIKitHighlightPopoverPresenter.swift
@@ -1,0 +1,261 @@
+// Purpose: Feature #64 WI-4/WI-5 — `UIKitHighlightPopoverPresenter`, the
+// `UIPopoverPresentationController`-based realization of
+// `HighlightPopoverPresenting` for the anchored `.card` form.
+//
+// A SwiftUI `.popover` cannot anchor to a raw `CGRect` (it needs a SwiftUI
+// source view), so the anchored card is presented by a UIKit presenter that
+// anchors a `UIHostingController` (hosting `HighlightActionCardView`) as a
+// `.popover`-style `modalPresentationStyle` whose
+// `popoverPresentationController.sourceView` is the reader's content `UIView`
+// and `sourceRect` is the tap's `sourceRect`. Mirrors feature #55's
+// `UIKitNotePreviewPresenter`.
+//
+// R2-F6 — the card is interactive, so this presenter carries an explicit
+// idempotent `updateCard`: it reassigns the held `UIHostingController.rootView`
+// in place (a cheap SwiftUI diff, no modal transition, keyboard preserved)
+// rather than forcing a dismiss-and-re-present on every `mode` / `noteDraft`
+// change. A `presentCard` for an already-presented same-`content.id` is itself
+// treated as an `updateCard`.
+//
+// A single serialized present/dismiss pipeline (idle / presenting /
+// dismissing) guards modal collisions under rapid taps — only the latest
+// stashed request is honored.
+//
+// @coordinates-with: HighlightActionCardView.swift, HighlightPopoverContent.swift,
+//   HighlightPopoverMode.swift, HighlightPopoverModifier.swift
+//   (HighlightPopoverPresenting)
+
+#if canImport(UIKit)
+import UIKit
+import SwiftUI
+
+/// `UIPopoverPresentationController`-based realization of
+/// `HighlightPopoverPresenting`. Serialized present/dismiss; in-place
+/// `updateCard`.
+@MainActor
+final class UIKitHighlightPopoverPresenter: NSObject, HighlightPopoverPresenting {
+
+    /// A present request — stashed while the pipeline is busy.
+    private struct CardRequest {
+        let content: HighlightPopoverContent
+        let theme: ReaderThemeV2
+        let mode: HighlightPopoverMode
+        let noteDraft: String
+        let pressedColor: NamedHighlightColor?
+        let view: UIView
+        let onAction: (HighlightPopoverAction) -> Void
+        let onDraftChange: (String) -> Void
+        let onDismiss: () -> Void
+    }
+
+    private enum Phase { case idle, presenting, dismissing }
+
+    private var phase: Phase = .idle
+    /// The hosting controller of the presented card. Weak — the presenting
+    /// view-controller hierarchy retains it while presented.
+    private weak var presentedHost: UIHostingController<HighlightActionCardView>?
+    /// The `content.id` of the live card — `presentCard` for the same id is
+    /// an `updateCard`.
+    private var presentedContentID: UUID?
+    /// The live card's action / draft / dismiss callbacks — reused by
+    /// `updateCard` so an in-place `rootView` swap keeps the same funnels.
+    private var liveCallbacks: (
+        onAction: (HighlightPopoverAction) -> Void,
+        onDraftChange: (String) -> Void,
+        onDismiss: () -> Void
+    )?
+    private var liveTheme: ReaderThemeV2?
+    private var popoverDelegate: HighlightPopoverDelegate?
+    /// The LATEST present request stashed while the pipeline is busy.
+    private var pendingRequest: CardRequest?
+    private var pendingDismissCompletions: [@MainActor () -> Void] = []
+
+    // MARK: - HighlightPopoverPresenting
+
+    func presentCard(
+        _ content: HighlightPopoverContent,
+        theme: ReaderThemeV2,
+        mode: HighlightPopoverMode,
+        noteDraft: String,
+        pressedColor: NamedHighlightColor?,
+        in view: UIView,
+        onAction: @escaping (HighlightPopoverAction) -> Void,
+        onDraftChange: @escaping (String) -> Void,
+        onDismiss: @escaping () -> Void
+    ) {
+        // Idempotent: a present for the already-live highlight is an update,
+        // not a dismiss-re-present (R2-F6 — no flicker, keyboard preserved).
+        if phase == .presenting, presentedContentID == content.id {
+            updateCard(
+                content: content, mode: mode, noteDraft: noteDraft,
+                pressedColor: pressedColor
+            )
+            return
+        }
+        let request = CardRequest(
+            content: content, theme: theme, mode: mode, noteDraft: noteDraft,
+            pressedColor: pressedColor, view: view, onAction: onAction,
+            onDraftChange: onDraftChange, onDismiss: onDismiss
+        )
+        switch phase {
+        case .idle:
+            performPresent(request)
+        case .presenting:
+            // A different highlight supersedes — dismiss, then present.
+            pendingRequest = request
+            beginDismiss()
+        case .dismissing:
+            pendingRequest = request
+        }
+    }
+
+    func updateCard(
+        content: HighlightPopoverContent,
+        mode: HighlightPopoverMode,
+        noteDraft: String,
+        pressedColor: NamedHighlightColor?
+    ) {
+        // In-place `rootView` reassignment — no dismiss, no re-present. A
+        // no-op when nothing is presented.
+        guard phase == .presenting,
+              let host = presentedHost,
+              let callbacks = liveCallbacks,
+              let theme = liveTheme else { return }
+        presentedContentID = content.id
+        host.rootView = HighlightActionCardView(
+            content: content, theme: theme, mode: mode, form: .card,
+            noteDraft: noteDraft, pressedColor: pressedColor,
+            onAction: callbacks.onAction,
+            onDraftChange: callbacks.onDraftChange,
+            onDismiss: callbacks.onDismiss
+        )
+    }
+
+    func dismissCard(completion: (@MainActor () -> Void)?) {
+        if let completion { pendingDismissCompletions.append(completion) }
+        switch phase {
+        case .idle:
+            pendingRequest = nil
+            drainCompletions()
+        case .presenting:
+            pendingRequest = nil
+            beginDismiss()
+        case .dismissing:
+            pendingRequest = nil
+        }
+    }
+
+    // MARK: - Pipeline
+
+    private func beginDismiss() {
+        guard let host = presentedHost else {
+            phase = .idle
+            drainPipeline()
+            return
+        }
+        phase = .dismissing
+        presentedHost = nil
+        presentedContentID = nil
+        liveCallbacks = nil
+        liveTheme = nil
+        popoverDelegate = nil
+        host.dismiss(animated: true) { [weak self] in
+            self?.phase = .idle
+            self?.drainPipeline()
+        }
+    }
+
+    private func drainPipeline() {
+        drainCompletions()
+        guard let request = pendingRequest else { return }
+        pendingRequest = nil
+        performPresent(request)
+    }
+
+    private func drainCompletions() {
+        let completions = pendingDismissCompletions
+        pendingDismissCompletions.removeAll()
+        completions.forEach { $0() }
+    }
+
+    private func performPresent(_ request: CardRequest) {
+        guard let presenter = request.view.nearestViewController else {
+            phase = .idle
+            request.onDismiss()
+            return
+        }
+        let card = HighlightActionCardView(
+            content: request.content, theme: request.theme,
+            mode: request.mode, form: .card,
+            noteDraft: request.noteDraft, pressedColor: request.pressedColor,
+            onAction: request.onAction,
+            onDraftChange: request.onDraftChange,
+            onDismiss: request.onDismiss
+        )
+        let host = UIHostingController(rootView: card)
+        host.modalPresentationStyle = .popover
+        host.preferredContentSize = Self.cardContentSize
+        host.view.backgroundColor = .clear
+
+        guard let popover = host.popoverPresentationController else {
+            phase = .idle
+            request.onDismiss()
+            return
+        }
+        popover.sourceView = request.view
+        popover.sourceRect = request.content.sourceRect
+        popover.permittedArrowDirections = [.up, .down]
+        popover.backgroundColor = .clear
+
+        let delegate = HighlightPopoverDelegate(onDismiss: { [weak self] in
+            guard let self else { return }
+            if self.phase != .dismissing {
+                self.presentedHost = nil
+                self.presentedContentID = nil
+                self.liveCallbacks = nil
+                self.liveTheme = nil
+                self.popoverDelegate = nil
+                self.phase = .idle
+                self.drainPipeline()
+            }
+            request.onDismiss()
+        })
+        popover.delegate = delegate
+
+        presentedHost = host
+        presentedContentID = request.content.id
+        liveCallbacks = (request.onAction, request.onDraftChange, request.onDismiss)
+        liveTheme = request.theme
+        popoverDelegate = delegate
+        phase = .presenting
+        presenter.present(host, animated: true)
+    }
+
+    /// The anchored card's preferred content size. Width matches the design's
+    /// `cardW` (320pt); height is a comfortable cap — the card's note body
+    /// clamps inside `HighlightActionCardView`.
+    private static let cardContentSize = CGSize(width: 320, height: 380)
+}
+
+/// `UIPopoverPresentationControllerDelegate` keeping the popover anchored even
+/// on compact width, and reporting an interactive dismissal.
+private final class HighlightPopoverDelegate: NSObject, UIPopoverPresentationControllerDelegate {
+    private let onDismiss: @MainActor () -> Void
+
+    init(onDismiss: @escaping @MainActor () -> Void) {
+        self.onDismiss = onDismiss
+    }
+
+    func adaptivePresentationStyle(
+        for controller: UIPresentationController,
+        traitCollection: UITraitCollection
+    ) -> UIModalPresentationStyle {
+        .none
+    }
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        let onDismiss = self.onDismiss
+        MainActor.assumeIsolated { onDismiss() }
+    }
+}
+#endif

--- a/vreaderTests/Views/Reader/FoliateHighlightJSBridgeTests.swift
+++ b/vreaderTests/Views/Reader/FoliateHighlightJSBridgeTests.swift
@@ -1,0 +1,192 @@
+// Purpose: Feature #64 WI-4 — tests for `FoliateHighlightJSBridge`, the
+// pure-logic helper that posts the Foliate recolor / delete JS-notification
+// pairs for the unified highlight-action popover.
+//
+// Foliate (AZW3/MOBI) has no `HighlightRenderer` conformer — its highlight
+// visuals are driven entirely by `NotificationCenter` messages keyed on CFI.
+// This bridge owns the "extract the CFI from a record's `.epub` anchor +
+// post the right notifications" logic so it is unit-testable with a
+// NotificationCenter spy, no `WKWebView`.
+//
+// Covers: recolor → posts `.foliateRequestAnnotationJSDelete` then
+// `.foliateRequestAnnotationJSCreate` with the CFI + the new color +
+// fingerprintKey; delete → posts BOTH `.readerHighlightRemoved` (UUID) and
+// `.foliateRequestAnnotationJSDelete` (CFI); a record with a non-`.epub`
+// anchor (legacy/corrupt) → no JS post, no crash.
+
+#if canImport(UIKit)
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("FoliateHighlightJSBridge")
+struct FoliateHighlightJSBridgeTests {
+
+    private let fingerprint = DocumentFingerprint(
+        contentSHA256: "foliate_bridge_sha_00000000000000000000000000000000000",
+        fileByteCount: 100, format: .azw3
+    )
+
+    private func epubAnchorRecord(
+        id: UUID = UUID(), cfi: String = "epubcfi(/6/4!/4/2/2)", color: String = "yellow"
+    ) -> HighlightRecord {
+        let anchor = AnnotationAnchor.epub(
+            href: "", cfi: cfi,
+            serializedRange: EPUBSerializedRange(
+                startContainerPath: "", startOffset: 0, endContainerPath: "", endOffset: 0
+            )
+        )
+        let locator = Locator.validated(bookFingerprint: fingerprint, cfi: cfi)!
+        return HighlightRecord(
+            highlightId: id, locator: locator, anchor: anchor, profileKey: "k",
+            selectedText: "passage", color: color, note: nil,
+            createdAt: Date(timeIntervalSince1970: 1), updatedAt: Date(timeIntervalSince1970: 2)
+        )
+    }
+
+    private func textAnchorRecord(id: UUID = UUID()) -> HighlightRecord {
+        let anchor = AnnotationAnchor.text(sourceUnitId: "u1", startUTF16: 0, endUTF16: 5)
+        let locator = Locator.validated(bookFingerprint: fingerprint, charOffsetUTF16: 0)!
+        return HighlightRecord(
+            highlightId: id, locator: locator, anchor: anchor, profileKey: "k",
+            selectedText: "passage", color: "yellow", note: nil,
+            createdAt: Date(timeIntervalSince1970: 1), updatedAt: Date(timeIntervalSince1970: 2)
+        )
+    }
+
+    /// Collects posted notifications synchronously for assertion. Observers
+    /// are torn down by an explicit `stop()` (called from the test) rather
+    /// than a `deinit` — a `nonisolated deinit` cannot touch this
+    /// `@MainActor`-isolated type's stored tokens under Swift 6.
+    @MainActor
+    private final class NotificationSpy {
+        struct Captured { let name: Notification.Name; let object: Any?; let userInfo: [AnyHashable: Any]? }
+        private(set) var captured: [Captured] = []
+        private var tokens: [NSObjectProtocol] = []
+
+        init(_ names: [Notification.Name]) {
+            for name in names {
+                let token = NotificationCenter.default.addObserver(
+                    forName: name, object: nil, queue: nil
+                ) { [weak self] note in
+                    self?.captured.append(
+                        Captured(name: name, object: note.object, userInfo: note.userInfo)
+                    )
+                }
+                tokens.append(token)
+            }
+        }
+
+        /// Removes every observer. Each test calls this via `defer` so the
+        /// global `NotificationCenter` is not left with stale observers.
+        func stop() {
+            tokens.forEach { NotificationCenter.default.removeObserver($0) }
+            tokens.removeAll()
+        }
+    }
+
+    // MARK: - Recolor
+
+    @Test @MainActor func recolor_postsDeleteThenCreateWithCFIAndColor() {
+        let spy = NotificationSpy([
+            .foliateRequestAnnotationJSDelete, .foliateRequestAnnotationJSCreate
+        ])
+        defer { spy.stop() }
+        let record = epubAnchorRecord(cfi: "epubcfi(/6/4!/8)", color: "yellow")
+        let bridge = FoliateHighlightJSBridge()
+
+        bridge.recolor(record: record, to: "pink", fingerprintKey: "book-key")
+
+        #expect(spy.captured.count == 2)
+        // Delete first, create second — Foliate-js replaces an annotation by
+        // delete-then-create.
+        #expect(spy.captured[0].name == .foliateRequestAnnotationJSDelete)
+        #expect(spy.captured[1].name == .foliateRequestAnnotationJSCreate)
+
+        let deleteInfo = spy.captured[0].userInfo
+        #expect(deleteInfo?["cfi"] as? String == "epubcfi(/6/4!/8)")
+        #expect(deleteInfo?["fingerprintKey"] as? String == "book-key")
+
+        let createInfo = spy.captured[1].userInfo
+        #expect(createInfo?["cfi"] as? String == "epubcfi(/6/4!/8)")
+        #expect(createInfo?["color"] as? String == "pink")
+        #expect(createInfo?["fingerprintKey"] as? String == "book-key")
+    }
+
+    @Test @MainActor func recolor_nonEPUBAnchor_postsNothing() {
+        let spy = NotificationSpy([
+            .foliateRequestAnnotationJSDelete, .foliateRequestAnnotationJSCreate
+        ])
+        defer { spy.stop() }
+        let record = textAnchorRecord()
+        let bridge = FoliateHighlightJSBridge()
+
+        // A legacy/corrupt record whose anchor is not `.epub` — recolor still
+        // "succeeds" upstream, but the JS repaint is skipped (no crash).
+        bridge.recolor(record: record, to: "blue", fingerprintKey: "book-key")
+
+        #expect(spy.captured.isEmpty)
+    }
+
+    @Test @MainActor func recolor_nilAnchor_postsNothing() {
+        let spy = NotificationSpy([
+            .foliateRequestAnnotationJSDelete, .foliateRequestAnnotationJSCreate
+        ])
+        defer { spy.stop() }
+        let locator = Locator.validated(bookFingerprint: fingerprint, cfi: "x")!
+        let record = HighlightRecord(
+            highlightId: UUID(), locator: locator, anchor: nil, profileKey: "k",
+            selectedText: "p", color: "yellow", note: nil,
+            createdAt: Date(timeIntervalSince1970: 1), updatedAt: Date(timeIntervalSince1970: 2)
+        )
+        let bridge = FoliateHighlightJSBridge()
+        bridge.recolor(record: record, to: "green", fingerprintKey: "book-key")
+        #expect(spy.captured.isEmpty)
+    }
+
+    // MARK: - Delete
+
+    @Test @MainActor func delete_postsRemovedAndJSDeleteWithCFI() {
+        let spy = NotificationSpy([
+            .readerHighlightRemoved, .foliateRequestAnnotationJSDelete
+        ])
+        defer { spy.stop() }
+        let id = UUID()
+        let record = epubAnchorRecord(id: id, cfi: "epubcfi(/6/10!/2)")
+        let bridge = FoliateHighlightJSBridge()
+
+        bridge.delete(record: record, fingerprintKey: "book-key")
+
+        #expect(spy.captured.count == 2)
+        // .readerHighlightRemoved keeps the panel/list in sync (UUID string);
+        // .foliateRequestAnnotationJSDelete strips the SVG overlay (CFI).
+        let removed = spy.captured.first { $0.name == .readerHighlightRemoved }
+        #expect(removed?.object as? String == id.uuidString)
+
+        let jsDelete = spy.captured.first { $0.name == .foliateRequestAnnotationJSDelete }
+        #expect(jsDelete?.userInfo?["cfi"] as? String == "epubcfi(/6/10!/2)")
+        #expect(jsDelete?.userInfo?["fingerprintKey"] as? String == "book-key")
+    }
+
+    /// A delete on a non-`.epub`-anchored record still posts
+    /// `.readerHighlightRemoved` (so the panel updates) but skips the JS
+    /// overlay strip — the record reopens repainted from persistence.
+    @Test @MainActor func delete_nonEPUBAnchor_postsRemovedOnlyNoJS() {
+        let spy = NotificationSpy([
+            .readerHighlightRemoved, .foliateRequestAnnotationJSDelete
+        ])
+        defer { spy.stop() }
+        let id = UUID()
+        let record = textAnchorRecord(id: id)
+        let bridge = FoliateHighlightJSBridge()
+
+        bridge.delete(record: record, fingerprintKey: "book-key")
+
+        let removed = spy.captured.filter { $0.name == .readerHighlightRemoved }
+        let jsDelete = spy.captured.filter { $0.name == .foliateRequestAnnotationJSDelete }
+        #expect(removed.count == 1)
+        #expect(removed.first?.object as? String == id.uuidString)
+        #expect(jsDelete.isEmpty)
+    }
+}
+#endif

--- a/vreaderTests/Views/Reader/HighlightActionCardViewTests.swift
+++ b/vreaderTests/Views/Reader/HighlightActionCardViewTests.swift
@@ -1,0 +1,44 @@
+// Purpose: Feature #64 WI-4 — tests for the testable pure logic of the
+// unified highlight-action popover views: `HighlightPopoverSwatch.color`,
+// the stored-color-name → swatch mapper.
+//
+// The SwiftUI view bodies (`HighlightActionCardView` + its subviews) are
+// purely presentational and exercised end-to-end in the Gate-5 slice
+// verification (WI-6..10); the unit-testable surface is the swatch mapper,
+// which must cover the real stored palette plus legacy / unknown fallback.
+
+#if canImport(UIKit)
+import Testing
+import SwiftUI
+import UIKit
+@testable import vreader
+
+@Suite("HighlightActionCardView — swatch mapper")
+struct HighlightActionCardViewTests {
+
+    /// The 4 named picker colors map to `NamedHighlightColor.hex` exactly.
+    @Test(arguments: [
+        ("yellow", NamedHighlightColor.yellow),
+        ("pink",   NamedHighlightColor.pink),
+        ("green",  NamedHighlightColor.green),
+        ("blue",   NamedHighlightColor.blue),
+    ])
+    func swatch_namedColors_mapToHex(_ stored: String, _ expected: NamedHighlightColor) {
+        let resolved = HighlightPopoverSwatch.color(for: stored)
+        let expectedColor = Color(readerHexString: expected.hex)
+        #expect(expectedColor != nil)
+        #expect(resolved == expectedColor)
+    }
+
+    /// A legacy / unknown stored value (older hex, empty, a future custom
+    /// color) falls back to yellow — mirroring `HighlightPaintColor` /
+    /// `FoliateHighlightRenderer.foliateColor`.
+    @Test(arguments: ["#ff00ff", "", "purple", "orange", "  ", "YELLOW"])
+    func swatch_unknownStoredValue_fallsBackToYellow(_ stored: String) {
+        // "YELLOW" is also unknown — `NamedHighlightColor.from` is
+        // case-sensitive (the storage schema is always lowercased).
+        let resolved = HighlightPopoverSwatch.color(for: stored)
+        #expect(resolved == Color(readerHexString: NamedHighlightColor.yellow.hex))
+    }
+}
+#endif

--- a/vreaderTests/Views/Reader/HighlightCoordinatorMutationTests.swift
+++ b/vreaderTests/Views/Reader/HighlightCoordinatorMutationTests.swift
@@ -125,7 +125,19 @@ private actor MutMockPersistence: HighlightPersisting {
         fatalError("unused in WI-3 mutation tests")
     }
 
-    func removeHighlight(highlightId: UUID) async throws {}
+    private(set) var removeCallCount = 0
+
+    func removeHighlight(highlightId: UUID) async throws {
+        switch mode {
+        case .recordNotFound:
+            throw PersistenceError.recordNotFound("Highlight \(highlightId)")
+        case .genericFailure:
+            throw NSError(domain: "test", code: 99)
+        case .success:
+            removeCallCount += 1
+            stored[highlightId] = nil
+        }
+    }
 
     func updateHighlightNote(highlightId: UUID, note: String?) async throws {
         switch mode {
@@ -417,6 +429,53 @@ struct HighlightCoordinatorMutationTests {
         // Whitespace is preserved on a non-empty note — only an all-whitespace
         // draft normalizes to nil.
         #expect(await persistence.lastNote == "  real note  ")
+    }
+
+    // MARK: deleteHighlight (Feature #64 WI-4)
+
+    @Test @MainActor func deleteHighlight_success_returnsSuccessAndRemoves() async {
+        let renderer = MutMockRenderer()
+        let persistence = MutMockPersistence()
+        let record = mutRecord()
+        await persistence.seed(record)
+        let coordinator = HighlightCoordinator(
+            renderer: renderer, persistence: persistence, bookFingerprintKey: "book-1"
+        )
+        let outcome = await coordinator.deleteHighlight(highlightID: record.highlightId)
+        guard case let .success(returned) = outcome else {
+            Issue.record("expected .success, got \(outcome)")
+            return
+        }
+        #expect(returned.highlightId == record.highlightId)
+        #expect(await persistence.removeCallCount == 1)
+    }
+
+    /// A delete on a highlight that no longer exists → `.notFound` (the
+    /// up-front fetch finds no matching record).
+    @Test @MainActor func deleteHighlight_recordGone_returnsNotFound() async {
+        let renderer = MutMockRenderer()
+        let persistence = MutMockPersistence()  // nothing seeded
+        let coordinator = HighlightCoordinator(
+            renderer: renderer, persistence: persistence, bookFingerprintKey: "book-1"
+        )
+        let outcome = await coordinator.deleteHighlight(highlightID: UUID())
+        #expect(outcome == .notFound)
+        #expect(await persistence.removeCallCount == 0)
+    }
+
+    /// A generic persistence failure on the remove call → `.failed`.
+    @Test @MainActor func deleteHighlight_removeThrowsGeneric_returnsFailed() async {
+        let renderer = MutMockRenderer()
+        let persistence = MutMockPersistence()
+        let record = mutRecord()
+        await persistence.seed(record)
+        await persistence.setMode(.genericFailure)
+        let coordinator = HighlightCoordinator(
+            renderer: renderer, persistence: persistence, bookFingerprintKey: "book-1"
+        )
+        // The up-front fetch also fails under .genericFailure → .failed.
+        let outcome = await coordinator.deleteHighlight(highlightID: record.highlightId)
+        #expect(outcome == .failed)
     }
 }
 #endif

--- a/vreaderTests/Views/Reader/HighlightPopoverActionRouterTests.swift
+++ b/vreaderTests/Views/Reader/HighlightPopoverActionRouterTests.swift
@@ -1,0 +1,304 @@
+// Purpose: Feature #64 WI-4 — tests for `HighlightPopoverActionRouter`, the
+// `@MainActor @Observable` state + dispatch core of the unified
+// highlight-action popover. The SwiftUI `HighlightPopoverModifier` is a thin
+// observer of this router; the router holds the popover's `mode` / `noteDraft`
+// / `pressedColor` / `shareItem` state and routes every `HighlightPopoverAction`.
+//
+// Covers the plan §6 `HighlightPopoverModifier` matrix at the testable core:
+// changeColor → the mutating boundary's changeColor (or the Foliate bridge);
+// saveNote → updateNote; copy → pasteboard; share → shareItem set + popover
+// dismissed; requestDelete → mode becomes confirmingDelete; confirmDelete →
+// delete; .notFound outcome → dismiss; .failed → stays open, no local
+// mutation; cancelEdit → mode back to reading; beginEdit → editing + draft
+// seeded from the note; the presenter-owned noteDraft resets on a highlight
+// swap.
+
+#if canImport(UIKit)
+import Testing
+import Foundation
+import CoreGraphics
+import UIKit
+@testable import vreader
+
+// MARK: - Helpers
+
+private let routerFP = DocumentFingerprint(
+    contentSHA256: "router_test_sha_0000000000000000000000000000000000000000",
+    fileByteCount: 100, format: .epub
+)
+
+@MainActor
+private func routerContent(
+    id: UUID = UUID(), note: String? = nil, color: String = "yellow"
+) -> HighlightPopoverContent {
+    HighlightPopoverContent(
+        id: id, note: note, highlightedText: "the passage", colorName: color,
+        createdAt: Date(timeIntervalSince1970: 1), chapter: "Ch. 1",
+        sourceRect: CGRect(x: 1, y: 2, width: 30, height: 14), anchor: nil
+    )
+}
+
+@MainActor
+private func routerRecord(
+    id: UUID, note: String? = nil, color: String = "pink"
+) -> HighlightRecord {
+    let locator = Locator.validated(bookFingerprint: routerFP, cfi: "x")!
+    return HighlightRecord(
+        highlightId: id, locator: locator, anchor: nil, profileKey: "k",
+        selectedText: "the passage", color: color, note: note,
+        createdAt: Date(timeIntervalSince1970: 1), updatedAt: Date(timeIntervalSince1970: 2)
+    )
+}
+
+/// A `HighlightMutating` mock recording every call + returning a scripted
+/// outcome.
+@MainActor
+private final class MutatingMock: HighlightMutating {
+    var changeColorCalls: [(id: UUID, color: String)] = []
+    var updateNoteCalls: [(id: UUID, note: String?)] = []
+    var deleteCalls: [UUID] = []
+    var colorOutcome: HighlightMutationOutcome = .failed
+    var noteOutcome: HighlightMutationOutcome = .failed
+    var deleteOutcome: HighlightMutationOutcome = .failed
+
+    func changeColor(highlightID: UUID, to color: String) async -> HighlightMutationOutcome {
+        changeColorCalls.append((highlightID, color))
+        return colorOutcome
+    }
+
+    func updateNote(highlightID: UUID, note: String?) async -> HighlightMutationOutcome {
+        updateNoteCalls.append((highlightID, note))
+        return noteOutcome
+    }
+
+    func deleteHighlight(highlightID: UUID) async -> HighlightMutationOutcome {
+        deleteCalls.append(highlightID)
+        return deleteOutcome
+    }
+}
+
+// MARK: - Tests
+
+@Suite("HighlightPopoverActionRouter")
+@MainActor
+struct HighlightPopoverActionRouterTests {
+
+    private func makeRouter(
+        mutating: MutatingMock = MutatingMock()
+    ) -> HighlightPopoverActionRouter {
+        // The router is format-agnostic — it dispatches every action through
+        // one `HighlightMutating` boundary. Non-Foliate formats inject a
+        // `HighlightCoordinator`; the Foliate format injects its own
+        // `HighlightMutating` conformer (WI-9). The router never branches on
+        // format itself.
+        HighlightPopoverActionRouter(mutating: mutating)
+    }
+
+    // MARK: Mode transitions
+
+    @Test func requestDelete_entersConfirmingDelete() async {
+        let router = makeRouter()
+        router.present(routerContent())
+        await router.route(.requestDelete)
+        #expect(router.mode == .confirmingDelete)
+    }
+
+    @Test func cancelEdit_returnsToReading() async {
+        let router = makeRouter()
+        router.present(routerContent(note: "a note"))
+        await router.route(.beginEdit)
+        #expect(router.mode == .editing)
+        await router.route(.cancelEdit)
+        #expect(router.mode == .reading)
+    }
+
+    @Test func beginEdit_entersEditingAndSeedsDraftFromNote() async {
+        let router = makeRouter()
+        router.present(routerContent(note: "existing note"))
+        await router.route(.beginEdit)
+        #expect(router.mode == .editing)
+        #expect(router.noteDraft == "existing note")
+    }
+
+    @Test func beginEdit_emptyNote_seedsEmptyDraft() async {
+        let router = makeRouter()
+        router.present(routerContent(note: nil))
+        await router.route(.beginEdit)
+        #expect(router.noteDraft == "")
+    }
+
+    // MARK: changeColor
+
+    @Test func changeColor_success_callsMutatingAndRefreshesContent() async {
+        let mutating = MutatingMock()
+        let id = UUID()
+        mutating.colorOutcome = .success(routerRecord(id: id, color: "green"))
+        let router = makeRouter(mutating: mutating)
+        router.present(routerContent(id: id, color: "yellow"))
+
+        await router.route(.changeColor(.green))
+
+        #expect(mutating.changeColorCalls.count == 1)
+        #expect(mutating.changeColorCalls.first?.color == "green")
+        // A success refreshes the on-screen content with the new color.
+        #expect(router.content?.colorName == "green")
+        #expect(router.isPresented)
+    }
+
+    @Test func changeColor_notFound_dismisses() async {
+        let mutating = MutatingMock()
+        mutating.colorOutcome = .notFound
+        let router = makeRouter(mutating: mutating)
+        router.present(routerContent())
+        await router.route(.changeColor(.blue))
+        #expect(!router.isPresented)
+    }
+
+    @Test func changeColor_failed_staysOpenContentUnchanged() async {
+        let mutating = MutatingMock()
+        mutating.colorOutcome = .failed
+        let router = makeRouter(mutating: mutating)
+        router.present(routerContent(color: "yellow"))
+        await router.route(.changeColor(.pink))
+        #expect(router.isPresented)
+        // A failure makes no local mutation.
+        #expect(router.content?.colorName == "yellow")
+    }
+
+    // MARK: saveNote
+
+    @Test func saveNote_success_callsUpdateNoteRefreshesAndReturnsToReading() async {
+        let mutating = MutatingMock()
+        let id = UUID()
+        mutating.noteOutcome = .success(routerRecord(id: id, note: "saved note"))
+        let router = makeRouter(mutating: mutating)
+        router.present(routerContent(id: id, note: nil))
+        await router.route(.beginEdit)
+
+        await router.route(.saveNote("saved note"))
+
+        #expect(mutating.updateNoteCalls.count == 1)
+        #expect(mutating.updateNoteCalls.first?.note == "saved note")
+        #expect(router.content?.note == "saved note")
+        // A successful save returns the card to the reading mode.
+        #expect(router.mode == .reading)
+    }
+
+    @Test func saveNote_failed_staysInEditing() async {
+        let mutating = MutatingMock()
+        mutating.noteOutcome = .failed
+        let router = makeRouter(mutating: mutating)
+        router.present(routerContent(note: "old"))
+        await router.route(.beginEdit)
+        await router.route(.saveNote("new draft"))
+        // A failed save keeps the editor open so the user can retry.
+        #expect(router.mode == .editing)
+        #expect(router.isPresented)
+    }
+
+    @Test func saveNote_notFound_dismisses() async {
+        let mutating = MutatingMock()
+        mutating.noteOutcome = .notFound
+        let router = makeRouter(mutating: mutating)
+        router.present(routerContent())
+        await router.route(.beginEdit)
+        await router.route(.saveNote("x"))
+        #expect(!router.isPresented)
+    }
+
+    // MARK: confirmDelete
+
+    @Test func confirmDelete_success_deletesAndDismisses() async {
+        let mutating = MutatingMock()
+        let id = UUID()
+        mutating.deleteOutcome = .success(routerRecord(id: id))
+        let router = makeRouter(mutating: mutating)
+        router.present(routerContent(id: id))
+        await router.route(.requestDelete)
+        await router.route(.confirmDelete)
+        #expect(mutating.deleteCalls == [id])
+        #expect(!router.isPresented)
+    }
+
+    /// A concurrent-deletion race (`.notFound`) on confirmDelete also
+    /// dismisses — the highlight no longer exists.
+    @Test func confirmDelete_notFound_dismisses() async {
+        let mutating = MutatingMock()
+        mutating.deleteOutcome = .notFound
+        let router = makeRouter(mutating: mutating)
+        router.present(routerContent())
+        await router.route(.requestDelete)
+        await router.route(.confirmDelete)
+        #expect(!router.isPresented)
+    }
+
+    /// A genuine persistence failure on confirmDelete keeps the popover and
+    /// returns the card to the reading mode out of the confirm sub-state.
+    @Test func confirmDelete_failed_staysOpenReturnsToReading() async {
+        let mutating = MutatingMock()
+        mutating.deleteOutcome = .failed
+        let router = makeRouter(mutating: mutating)
+        router.present(routerContent())
+        await router.route(.requestDelete)
+        #expect(router.mode == .confirmingDelete)
+        await router.route(.confirmDelete)
+        #expect(router.isPresented)
+        #expect(router.mode == .reading)
+    }
+
+    // MARK: copy & share
+
+    @Test func copy_putsExcerptOnPasteboardAndDismisses() async {
+        let router = makeRouter()
+        router.present(routerContent())
+        await router.route(.copy)
+        #expect(UIPasteboard.general.string == "the passage")
+        #expect(!router.isPresented)
+    }
+
+    @Test func share_setsPendingShareTextWithExcerptAndDismisses() async {
+        let router = makeRouter()
+        router.present(routerContent())
+        await router.route(.share)
+        // The router records the share text; the modifier consumes it AFTER
+        // the popover surface has dismissed (so two modals never stack).
+        #expect(router.pendingShareText == "the passage")
+        #expect(!router.isPresented)
+    }
+
+    @Test func clearPendingShare_clearsTheText() async {
+        let router = makeRouter()
+        router.present(routerContent())
+        await router.route(.share)
+        #expect(router.pendingShareText != nil)
+        router.clearPendingShare()
+        #expect(router.pendingShareText == nil)
+    }
+
+    // MARK: presenter-owned draft reset on a highlight swap
+
+    @Test func present_differentHighlight_resetsDraftAndMode() async {
+        let router = makeRouter()
+        router.present(routerContent(id: UUID(), note: "first note"))
+        await router.route(.beginEdit)
+        router.updateDraft("a half-typed edit")
+        #expect(router.noteDraft == "a half-typed edit")
+
+        // A rapid second tap on a DIFFERENT highlight must not carry the
+        // stale draft or the editing mode.
+        router.present(routerContent(id: UUID(), note: "second note"))
+        #expect(router.mode == .reading)
+        #expect(router.noteDraft == "")
+    }
+
+    @Test func dismiss_clearsPresentedAndResetsState() async {
+        let router = makeRouter()
+        router.present(routerContent(note: "n"))
+        await router.route(.beginEdit)
+        router.dismiss()
+        #expect(!router.isPresented)
+        #expect(router.content == nil)
+        #expect(router.mode == .reading)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- WI-4 of feature #64 — the unified cross-format highlight-action popover. The largest WI: it lands the full popover machine.
- Adds the SwiftUI views (card + sheet), the `@Observable` state+dispatch router, the UIKit anchored presenter, the `HighlightPopoverModifier`, and the Foliate JS bridge. Foundational tier — no reader container is wired yet, so **no user-observable behavior change**.

Part of feature #822.

## What Changed

- **`HighlightActionCardView` + `HighlightActionCardSubviews` + `HighlightPopoverDeleteConfirm`** — the SwiftUI realization of the committed design (`vreader-highlight-popover.jsx`): the anchored `HighlightActionCard` + the bottom `HighlightActionSheet`, over shared subviews (meta row, excerpt, 3-mode note region, color row, action row, delete-confirm). The note editor (`HighlightNoteDraftEditor`) is a **controlled component** (R1-6) — the draft is presenter-owned, never a private `@State`.
- **`HighlightPopoverActionRouter`** — `@MainActor @Observable` state + dispatch core. Owns `content`/`mode`/`noteDraft`/`pressedColor`; `route(_:)` dispatches every `HighlightPopoverAction`. Format-agnostic — dispatches through one `HighlightMutating` boundary. `HighlightMutationOutcome` routing (R1-5): `.success` → refresh, `.notFound` → dismiss, `.failed` → stay open.
- **`HighlightPopoverModifier` + `HighlightPopoverModifierBody`** — the `HighlightPopoverPresenting` protocol and the `ViewModifier` driving it. Observes `.readerHighlightTapped`, bridges the view model (lookup) and the router (interaction), routes to the anchored card or a SwiftUI `.sheet`. Share goes through a **host-view-independent** `.sheet(item:)` (R2-F7), presented only after the popover's real dismiss completion.
- **`UIKitHighlightPopoverPresenter`** — `UIPopoverPresentationController` realization. Serialized present/dismiss pipeline; idempotent `updateCard` reassigns the hosting controller's `rootView` in place — no modal transition, keyboard preserved (R2-F6).
- **`FoliateHighlightJSBridge`** — pure-logic Foliate recolor (delete-then-create) / delete (`.readerHighlightRemoved` + JS delete) notification poster, keyed on the CFI from a record's `.epub` anchor.
- **`HighlightCoordinator`** — adds the `HighlightMutating` protocol + `deleteHighlight` (returning the typed `HighlightMutationOutcome`) + the conformance.

### Two intentional plan refinements

1. The plan §3.6 nominally assigns `UIKitHighlightPopoverPresenter` to WI-5, but the WI-4 modifier cannot compile without the concrete presenter — so the full presenter ships here. WI-5 hardens it with the dedicated serialized-pipeline test suite.
2. The router is **format-agnostic** over one `HighlightMutating` protocol — cleaner than the plan's `coordinator: nil ⇒ Foliate` branching (the Foliate format injects its own `HighlightMutating` conformer in WI-9). Same spirit as WI-3's `ChapterScopedHighlightRenderer`.

## WI Status

- WI-4: foundational — this PR.
- Done: WI-1 (#967), WI-2 (#969), WI-3 (#970).
- Remaining: WI-5 (UIKit presenter hardening + test suite), WI-6..9 (per-format container migration), WI-10 (#55/#53 teardown + final acceptance).

## Codex Audit (Gate 4)

Codex `019e407f`, 2 rounds, verdict **ship-as-is**.

- Round 1: 1 High + 1 Medium + 1 Low. **High** — `share` set the share item before the popover finished dismissing (modal collision). **Medium** — `deleteHighlight` collapsed every failure into `Bool false`, so a concurrent-deletion race left a stale popover open. **Low (a)** — `resolvedForm` read the persisted note not the live draft; **Low (b)** — `pressedColor` not threaded to the anchored card.
- Fixed: share now staged behind a real dismiss completion (`tearDownSurfaces`); `deleteHighlight` returns the typed `HighlightMutationOutcome`; `pressedColor` threaded through `presentCard`/`updateCard`.
- **Accepted Low (a)**: `resolvedForm` stays presentation-stable (decided once from the stored note at tap time). Re-routing card→sheet mid-edit would tear down the anchored card while the keyboard is up — a worse UX. Codex confirmed this is "a documented fidelity limitation rather than a correctness defect". Plan known-limitation L2 already accepts the card-vs-sheet axis as fidelity.
- Round 2 re-audited the fixes clean — no remaining open Critical/High/Medium findings.

Audit log: `.claude/codex-audits/feat-feature-64-wi-4-card-views-audit.md`

## Validation

- [x] `xcodebuild test` passes — 51 tests across `FoliateHighlightJSBridgeTests` (6, incl. the delete-then-create order + the non-`.epub`-anchor skip), `HighlightPopoverActionRouterTests` (the full §6 action matrix at the testable core, incl. the outcome routing + the presenter-owned-draft reset on a highlight swap), `HighlightActionCardViewTests` (the swatch mapper incl. legacy fallback), `HighlightCoordinatorMutationTests` (+3 new `deleteHighlight` tests), `HighlightCoordinatorTests` (no regression)
- [x] Tests cover changed behavior (TDD: RED → GREEN)
- [x] Codex audit loop completed (2 iterations, verdict: ship-as-is)
- [x] Docs sync — n/a (the new stack belongs to one feature; `architecture.md` names neither the old nor new highlight-tap stack — rule 24's ≥2-feature trigger does not fire. WI-10 runs the feature-wide rule-24 pre-PR self-check per plan §7.)
- [x] Version bumped: 3.36.10 → 3.36.11

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: **foundational** — unit + integration tests + Gate-4 audit are sufficient. No reader container is wired (the attach helpers `unifiedHighlightPopoverPresenter` / `...IfAvailable` exist but are not yet called by any container — that is WI-6..9). The 51-test suite exercises the router's full action dispatch, the Foliate bridge's notification pairs, and the swatch mapper. The SwiftUI view bodies + the UIKit presenter's live presentation are exercised end-to-end in WI-6's first behavioral slice verification.

## Type of Change

- [x] Feature WI (Part of feature #822)

🤖 Generated with [Claude Code](https://claude.com/claude-code)