### PR TITLE
feat(#64 WI-5): UIKitHighlightPopoverPresenter test suite

### DIFF
--- a/.claude/codex-audits/feat-feature-64-wi-5-uikit-presenter-audit.md
+++ b/.claude/codex-audits/feat-feature-64-wi-5-uikit-presenter-audit.md
@@ -1,0 +1,46 @@
+---
+branch: feat/feature-64-wi-5-uikit-presenter
+threadId: 019e408e-f83a-7550-88d1-e65aa6548c45
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+# Gate-4 Implementation Audit — Feature #64 WI-5 (UIKitHighlightPopoverPresenter test suite)
+
+## Scope
+
+WI-5 of the unified cross-format highlight-action popover. **Test-only WI** — `UIKitHighlightPopoverPresenter` itself shipped in WI-4 (PR #971) for compile-order reasons (the WI-4 modifier could not compile without the concrete presenter); the plan §5 assigned "UIKit anchored-card presenter" to WI-5, so WI-5's deliverable is the dedicated test suite the plan §6 mandates.
+
+- `vreaderTests/Views/Reader/UIKitHighlightPopoverPresenterTests.swift` (NEW) — 8 tests.
+- The pbxproj regen registering the file. No production code changed.
+
+## Round 1 — Codex `019e408e-f83a-7550-88d1-e65aa6548c45`
+
+| # | File:line | Severity | Issue | Fix |
+|---|-----------|----------|-------|-----|
+| F1 | `UIKitHighlightPopoverPresenterTests.swift:117` | Medium | The same-`content.id` idempotence test used a *detached* `UIView`, so `presentCard` exited at the `nearestViewController` guard before reaching `.presenting` — the `presentCard` same-id fast-path was never exercised. Effectively a second idle-`updateCard` no-op test. | Drive a real presented state via a hosted `UIWindow` + root VC. |
+| F2 | `UIKitHighlightPopoverPresenterTests.swift:5` | Medium | The scope-note header overstated the limitation ("the process lacks a live hierarchy") — the test target is app-hosted and the repo already uses temporary `UIWindow` fixtures. | Reword honestly; add a hosted-window test for the present path. |
+| F3 | `UIKitHighlightPopoverPresenterTests.swift:58` | Low | `dismissCard_noCompletion_nothingPresented_doesNotCrash` was vacuous (`#expect(Bool(true))`). | Strengthen or fold into an observable assertion. |
+| F4 | `UIKitHighlightPopoverPresenterTests.swift:75` | Low | `updateCard_nothingPresented_isNoOp` likewise proved no postcondition. | Assert an observable idle-state invariant. |
+
+The auditor confirmed in round 1: the detached-view fallback test IS a genuine pipeline exercise; the suite is deterministic (no sleeps); deferring the full supersede path is defensible *as a scoping choice*; calling WI-5 a test-only WI is defensible.
+
+## Resolution
+
+The suite was rewritten with a `makeHostedAnchor()` helper building a real `UIWindow` + root `UIViewController` hosting the anchor `UIView`:
+
+- **F1** — `presentCard_sameContentID_isIdempotent_keepsSameHostingController` now drives a real present, captures `root.presentedViewController`, issues a second `presentCard` for the SAME id, and asserts `root.presentedViewController === firstHost` — genuinely exercising the `presentCard` same-id fast-path. Added `presentCard_hostedAnchor_presentsAHostingController`, `updateCard_whilePresented_keepsSameHostingController`, and `dismissCard_whilePresented_runsCompletionAfterDismissal` (waits on a `CheckedContinuation` resumed from the real modal-dismiss completion — not a sleep — and asserts `presentedViewController == nil` after).
+- **F2** — the scope-note header rewritten: it now states the app-hosted target lets the suite build a real `UIWindow` and exercise the *presented*-state contracts, listing exactly what it covers.
+- **F3** — the vacuous test deleted.
+- **F4** — `updateCard_nothingPresented_isNoOp_pipelineStaysIdle` now asserts an observable postcondition: a follow-up `dismissCard(completion:)` drains synchronously. The detached-view test similarly asserts pipeline reusability.
+
+8 tests pass.
+
+## Round 2 — Codex `019e408e-f83a-7550-88d1-e65aa6548c45` (re-audit of the fixes)
+
+Verdict: **"Confirmed: the two prior Medium findings and two prior Low findings are resolved."** Codex verified the hosted-window helper, the genuine same-`content.id` fast-path exercise, the accurate scope note, the removal of the vacuous `#expect(Bool(true))` tests, and the meaningful presented-state dismiss-completion coverage without sleeps. **No remaining open Critical/High/Medium findings.**
+
+## Verdict
+
+**ship-as-is** — 2 rounds (round 1 found 2 Medium + 2 Low, all test-quality — the suite over-relied on detached-view branches and had vacuous assertions; round 2 clean after a rewrite to real hosted-window present/dismiss/update assertions).

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 526
-        MARKETING_VERSION: 3.36.11
+        CURRENT_PROJECT_VERSION: 527
+        MARKETING_VERSION: 3.36.12
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -731,6 +731,7 @@
 		A6E44E99068166200DADB131 /* TXTTocRuleEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D8A001ABD732F1E2FF24463 /* TXTTocRuleEngine.swift */; };
 		A74E0B8A07E4DD90EB24B234 /* AIProviderPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43809A2F181DF2BBEAAD50C5 /* AIProviderPickerViewModel.swift */; };
 		A7C1006FE4BB21D62EA2C0AF /* TXTContinuousChunkBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EEEA47C4E7D01D716EF2A4 /* TXTContinuousChunkBuilderTests.swift */; };
+		A7E1B831AF2EA9403C7952B2 /* UIKitHighlightPopoverPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FD939A141F12D7003A40C3D /* UIKitHighlightPopoverPresenterTests.swift */; };
 		A84E7CDEED71FF118D2DD7DC /* ReflowableTextSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D4AD419DD1123CDA21CCD0 /* ReflowableTextSource.swift */; };
 		A8A3BDDF157E89577638C20F /* LegadoImporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D44DAF36D098C9C9A7C102B /* LegadoImporterTests.swift */; };
 		A94C7BEA198AF83B90936259 /* TranslateLanguageRailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94AF8D98E6FAD355A8B3416B /* TranslateLanguageRailTests.swift */; };
@@ -1593,6 +1594,7 @@
 		6F1F3EF7737CB98C28172050 /* FoliateHighlightRestoreDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightRestoreDispatcher.swift; sourceTree = "<group>"; };
 		6F2F6606E3464813A962D1E0 /* TextHighlightHitTester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextHighlightHitTester.swift; sourceTree = "<group>"; };
 		6FC5D3DF85816AC1F7B42E3D /* WebDAVProfileMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProfileMigrator.swift; sourceTree = "<group>"; };
+		6FD939A141F12D7003A40C3D /* UIKitHighlightPopoverPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitHighlightPopoverPresenterTests.swift; sourceTree = "<group>"; };
 		7008A22A4FBE1574E8B9C8A4 /* TXTStreamingOpenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTStreamingOpenTests.swift; sourceTree = "<group>"; };
 		7024E7AEAC9AEAA028952C46 /* ScrollProgressHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollProgressHelper.swift; sourceTree = "<group>"; };
 		7056486BA460E0BE06235F54 /* UnifiedTextRendererViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedTextRendererViewModel.swift; sourceTree = "<group>"; };
@@ -2709,6 +2711,7 @@
 				77A6970A21B903B77B011DE8 /* TXTTextViewBridgeEditMenuTests.swift */,
 				ABF97E254D3F3DCCDAEF6185 /* TXTTextViewBridgeSafeAreaInsetTests.swift */,
 				387A6B535C7DC06F9432C931 /* UIKitHighlightActionPresenterTests.swift */,
+				6FD939A141F12D7003A40C3D /* UIKitHighlightPopoverPresenterTests.swift */,
 				E1EF16A1A352B2C6BAE84556 /* UnifiedMDTests.swift */,
 				9F7F45FFFEE431C41E618EF2 /* UnifiedTextRendererTests.swift */,
 				F441EEB7BE4AC0F10768666C /* BookDetails */,
@@ -4763,6 +4766,7 @@
 				09DBE45859D311C4D9B47B88 /* TypefacePillToggleTests.swift in Sources */,
 				34E33F3534FA3EB044406F2D /* TypographySettingsTests.swift in Sources */,
 				7C7DCFFC62E02ED7C1370F3A /* UIKitHighlightActionPresenterTests.swift in Sources */,
+				A7E1B831AF2EA9403C7952B2 /* UIKitHighlightPopoverPresenterTests.swift in Sources */,
 				B086340BE996C111A4B374BD /* UnifiedMDTests.swift in Sources */,
 				58F98A74EEAB6D0C39616B5D /* UnifiedTextRendererTests.swift in Sources */,
 				D87DD538291695D66BDA19E7 /* UpdateCheckerTests.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5474,13 +5474,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 526;
+				CURRENT_PROJECT_VERSION = 527;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.11;
+				MARKETING_VERSION = 3.36.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5624,13 +5624,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 526;
+				CURRENT_PROJECT_VERSION = 527;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.11;
+				MARKETING_VERSION = 3.36.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreaderTests/Views/Reader/UIKitHighlightPopoverPresenterTests.swift
+++ b/vreaderTests/Views/Reader/UIKitHighlightPopoverPresenterTests.swift
@@ -1,0 +1,205 @@
+// Purpose: Feature #64 WI-5 — tests for `UIKitHighlightPopoverPresenter`, the
+// `UIPopoverPresentationController`-based realization of
+// `HighlightPopoverPresenting` for the anchored `.card` form.
+//
+// The app-hosted test target lets these tests build a real `UIWindow` + root
+// `UIViewController` and drive an actual present/dismiss/update cycle — so the
+// suite exercises the serialized pipeline's *presented*-state contracts, not
+// just the idle branches:
+//   - `presentCard` anchors a hosting controller as the root VC's
+//     `presentedViewController`.
+//   - `presentCard` for the SAME `content.id` is idempotent — it keeps the
+//     same hosting-controller instance (an in-place `updateCard`, R2-F6), NOT
+//     a dismiss-and-re-present.
+//   - `updateCard` keeps the same hosting-controller instance.
+//   - `dismissCard(completion:)` runs the completion after dismissal — and
+//     synchronously when nothing is presented.
+//   - the no-host-view fallback: a detached `UIView` has no
+//     `nearestViewController`, so `presentCard` surfaces nothing, fires
+//     `onDismiss`, and leaves the pipeline reusable.
+
+#if canImport(UIKit)
+import Testing
+import Foundation
+import CoreGraphics
+import UIKit
+import SwiftUI
+@testable import vreader
+
+@Suite("UIKitHighlightPopoverPresenter")
+@MainActor
+struct UIKitHighlightPopoverPresenterTests {
+
+    private let fingerprint = DocumentFingerprint(
+        contentSHA256: "uikit_presenter_sha_0000000000000000000000000000000000",
+        fileByteCount: 100, format: .epub
+    )
+
+    private func content(id: UUID = UUID()) -> HighlightPopoverContent {
+        HighlightPopoverContent(
+            id: id, note: "a note", highlightedText: "the passage",
+            colorName: "yellow", createdAt: Date(timeIntervalSince1970: 1),
+            chapter: "Ch. 1", sourceRect: CGRect(x: 1, y: 2, width: 30, height: 14),
+            anchor: nil
+        )
+    }
+
+    private func theme() -> ReaderThemeV2 { .paper }
+
+    /// Builds a key `UIWindow` with a root `UIViewController` whose view hosts
+    /// `anchorView` — so `anchorView.nearestViewController` resolves and the
+    /// presenter can actually present. Returns both for assertion + cleanup.
+    private func makeHostedAnchor() -> (window: UIWindow, root: UIViewController, anchor: UIView) {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 400, height: 800))
+        let root = UIViewController()
+        let anchor = UIView(frame: CGRect(x: 20, y: 40, width: 200, height: 30))
+        root.view.addSubview(anchor)
+        window.rootViewController = root
+        window.makeKeyAndVisible()
+        return (window, root, anchor)
+    }
+
+    // MARK: - dismissCard (idle)
+
+    @Test func dismissCard_nothingPresented_runsCompletionSynchronously() {
+        let presenter = UIKitHighlightPopoverPresenter()
+        var ran = false
+        presenter.dismissCard(completion: { ran = true })
+        // Nothing was presented — the completion drains synchronously.
+        #expect(ran)
+    }
+
+    @Test func dismissCard_multipleCompletions_allRunWhenIdle() {
+        let presenter = UIKitHighlightPopoverPresenter()
+        var count = 0
+        presenter.dismissCard(completion: { count += 1 })
+        presenter.dismissCard(completion: { count += 1 })
+        #expect(count == 2)
+    }
+
+    @Test func updateCard_nothingPresented_isNoOp_pipelineStaysIdle() {
+        let presenter = UIKitHighlightPopoverPresenter()
+        // No card presented — updateCard must be a safe no-op (R2-F6). The
+        // observable postcondition: the pipeline is still idle, so a
+        // subsequent dismissCard completion drains synchronously.
+        presenter.updateCard(
+            content: content(), mode: .editing, noteDraft: "draft", pressedColor: .pink
+        )
+        var ran = false
+        presenter.dismissCard(completion: { ran = true })
+        #expect(ran)
+    }
+
+    // MARK: - presentCard with no host view-controller
+
+    @Test func presentCard_detachedView_firesOnDismissAndStaysReusable() {
+        let presenter = UIKitHighlightPopoverPresenter()
+        let detached = UIView()  // not in any window / view-controller hierarchy
+        var dismissed = false
+        presenter.presentCard(
+            content(), theme: theme(), mode: .reading, noteDraft: "",
+            pressedColor: nil, in: detached,
+            onAction: { _ in }, onDraftChange: { _ in },
+            onDismiss: { dismissed = true }
+        )
+        // No `nearestViewController` → the presenter surfaces nothing and
+        // reports the dismissal so the modifier's sheet fallback covers it.
+        #expect(dismissed)
+        // The pipeline is back to idle — a follow-up dismissCard drains sync.
+        var ran = false
+        presenter.dismissCard(completion: { ran = true })
+        #expect(ran)
+    }
+
+    // MARK: - presentCard with a real hosted window
+
+    @Test func presentCard_hostedAnchor_presentsAHostingController() {
+        let (window, root, anchor) = makeHostedAnchor()
+        defer { window.isHidden = true }
+        let presenter = UIKitHighlightPopoverPresenter()
+
+        presenter.presentCard(
+            content(), theme: theme(), mode: .reading, noteDraft: "",
+            pressedColor: nil, in: anchor,
+            onAction: { _ in }, onDraftChange: { _ in }, onDismiss: {}
+        )
+
+        // The presenter anchors a UIHostingController as the root's
+        // presentedViewController (set synchronously even with animated: true).
+        #expect(root.presentedViewController is UIHostingController<HighlightActionCardView>)
+    }
+
+    @Test func presentCard_sameContentID_isIdempotent_keepsSameHostingController() {
+        let (window, root, anchor) = makeHostedAnchor()
+        defer { window.isHidden = true }
+        let presenter = UIKitHighlightPopoverPresenter()
+        let id = UUID()
+
+        presenter.presentCard(
+            content(id: id), theme: theme(), mode: .reading, noteDraft: "",
+            pressedColor: nil, in: anchor,
+            onAction: { _ in }, onDraftChange: { _ in }, onDismiss: {}
+        )
+        let firstHost = root.presentedViewController
+        #expect(firstHost != nil)
+
+        // A second presentCard for the SAME content.id must NOT dismiss +
+        // re-present — it routes to updateCard, keeping the same hosting
+        // controller instance (R2-F6 — no flicker, keyboard preserved).
+        presenter.presentCard(
+            content(id: id), theme: theme(), mode: .editing, noteDraft: "typed",
+            pressedColor: nil, in: anchor,
+            onAction: { _ in }, onDraftChange: { _ in }, onDismiss: {}
+        )
+        #expect(root.presentedViewController === firstHost)
+    }
+
+    @Test func updateCard_whilePresented_keepsSameHostingController() {
+        let (window, root, anchor) = makeHostedAnchor()
+        defer { window.isHidden = true }
+        let presenter = UIKitHighlightPopoverPresenter()
+        let id = UUID()
+
+        presenter.presentCard(
+            content(id: id), theme: theme(), mode: .reading, noteDraft: "",
+            pressedColor: nil, in: anchor,
+            onAction: { _ in }, onDraftChange: { _ in }, onDismiss: {}
+        )
+        let host = root.presentedViewController
+        #expect(host != nil)
+
+        // updateCard reassigns the hosting controller's rootView in place —
+        // the presented controller instance is unchanged.
+        presenter.updateCard(
+            content: content(id: id), mode: .confirmingDelete, noteDraft: "",
+            pressedColor: nil
+        )
+        #expect(root.presentedViewController === host)
+    }
+
+    @Test func dismissCard_whilePresented_runsCompletionAfterDismissal() async {
+        let (window, root, anchor) = makeHostedAnchor()
+        defer { window.isHidden = true }
+        let presenter = UIKitHighlightPopoverPresenter()
+
+        presenter.presentCard(
+            content(), theme: theme(), mode: .reading, noteDraft: "",
+            pressedColor: nil, in: anchor,
+            onAction: { _ in }, onDraftChange: { _ in }, onDismiss: {}
+        )
+        #expect(root.presentedViewController != nil)
+
+        // Wait on the completion itself — resumed from the real modal-dismiss
+        // completion, NOT a fixed sleep (rule 10: no bare Task.sleep for sync).
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            presenter.dismissCard(completion: { continuation.resume() })
+        }
+        // The dismissal completed and the card is gone.
+        #expect(root.presentedViewController == nil)
+        // The presenter is reusable — a follow-up dismissCard drains sync.
+        var ran = false
+        presenter.dismissCard(completion: { ran = true })
+        #expect(ran)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

- WI-5 of feature #64 — the unified cross-format highlight-action popover.
- **Test-only WI** — `UIKitHighlightPopoverPresenter` itself shipped in WI-4 (PR #971), because the WI-4 modifier could not compile without the concrete presenter. The plan §5 assigned "UIKit anchored-card presenter" to WI-5, so WI-5 delivers the dedicated test suite the plan §6 mandates for it.

Part of feature #822.

## What Changed

- `UIKitHighlightPopoverPresenterTests` (NEW, 8 tests) — drives a real `UIWindow` + root `UIViewController` (`makeHostedAnchor()` helper) so the suite exercises the serialized pipeline's *presented*-state contracts, not just the idle branches:
  - `presentCard` anchors a `UIHostingController` as the root's `presentedViewController`.
  - `presentCard` for the **same `content.id`** is idempotent — it keeps the same hosting-controller instance (an in-place `updateCard`, R2-F6), **not** a dismiss-and-re-present.
  - `updateCard` while presented keeps the same hosting-controller instance.
  - `dismissCard(completion:)` runs the completion after dismissal (waited on a `CheckedContinuation` resumed from the real modal-dismiss completion — not a `sleep`) — and synchronously when nothing is presented.
  - the no-host-view fallback: a detached `UIView` has no `nearestViewController`, so `presentCard` surfaces nothing, fires `onDismiss`, and leaves the pipeline reusable.

No production code changed.

## WI Status

- WI-5: foundational (test-only) — this PR.
- Done: WI-1 (#967), WI-2 (#969), WI-3 (#970), WI-4 (#971).
- Remaining: WI-6..9 (per-format container migration), WI-10 (#55/#53 teardown + final acceptance).

## Codex Audit (Gate 4)

Codex `019e408e`, 2 rounds, verdict **ship-as-is**.

- Round 1 found 2 Medium + 2 Low — all test-quality: the first draft over-relied on detached-`UIView` branches (so the `presentCard` same-id fast-path was never actually exercised), the scope-note header overstated the test-process limitation, and two tests were vacuous (`#expect(Bool(true))`).
- Fixed: rewrote the suite with a real hosted `UIWindow`; the same-id idempotence test now genuinely exercises the `.presenting` fast-path (`presentedViewController === firstHost`); the scope note is accurate; the vacuous tests replaced with observable postconditions.
- Round 2 re-audited the rewrite clean — no remaining open Critical/High/Medium findings.

Audit log: `.claude/codex-audits/feat-feature-64-wi-5-uikit-presenter-audit.md`

## Validation

- [x] `xcodebuild test` passes — 8 tests in `UIKitHighlightPopoverPresenterTests`
- [x] Tests cover the presenter's behavior (the presenter shipped + was audited in WI-4 `019e407f`; this WI adds its dedicated suite)
- [x] Codex audit loop completed (2 iterations, verdict: ship-as-is)
- [x] Docs sync — n/a (test-only)
- [x] Version bumped: 3.36.11 → 3.36.12

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: **foundational** (test-only) — the new suite is the verification. It exercises the serialized present/dismiss/update pipeline against a real hosted window. The presenter's behavior under a live reader chrome (a real anchored popover on a tapped highlight) is exercised end-to-end in WI-6's first behavioral slice verification.

## Type of Change

- [x] Feature WI (Part of feature #822)

🤖 Generated with [Claude Code](https://claude.com/claude-code)