### PR TITLE
feat(#62 WI-2): annotations empty-state component + the three SVG art views

### DIFF
--- a/.claude/codex-audits/feat-feature-62-wi-2-annotations-empty-state-audit.md
+++ b/.claude/codex-audits/feat-feature-62-wi-2-annotations-empty-state-audit.md
@@ -1,0 +1,61 @@
+---
+branch: feat/feature-62-wi-2-annotations-empty-state
+threadId: 019e40a1-b13c-71a2-895f-df1f74878a7d
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+# Gate 4 — Implementation Audit — feature #62 WI-2
+
+The reusable annotations empty-state component + the three SVG art views.
+
+## Files audited
+
+- `vreader/Views/Reader/Annotations/AnnotationsEmptyStateArt.swift` (new)
+- `vreader/Views/Reader/Annotations/AnnotationsEmptyStateView.swift` (new)
+- `vreaderTests/Views/Reader/Annotations/AnnotationsEmptyStateArtTests.swift` (new)
+- `vreaderTests/Views/Reader/Annotations/AnnotationsEmptyStateViewTests.swift` (new)
+
+## Round 1 — findings
+
+| # | file:line | Severity | Issue | Resolution |
+|---|---|---|---|---|
+| 1 | AnnotationsEmptyStateView.swift title | Medium | Title used `.system(design: .serif)` instead of the repo's `ReaderTypography.body(for: .sourceSerif4, ...)` path — a design-fidelity miss vs the design's explicit "Source Serif 4" (rule 51). | **Fixed** — title now uses `Font(ReaderTypography.body(for: .sourceSerif4, size: 18))` + `.fontWeight(.semibold)`, the same path `ReaderSheetChrome` (17pt) and `ReaderSettingsPanel` (20pt) use. |
+| 2 | AnnotationsEmptyStateViewTests | Low | The suite did not assert `title`/`body` wiring; `accessibilityIdentifierRetained` only re-read the stored arg. | **Partially fixed** — added `titleAndBodyWired` (asserts `title`/`body_` carry the init args). The accessibility-modifier-application half is accepted — see Round 2. |
+| 3 | AnnotationsEmptyStateView.swift `invokeCTAForTesting` | Low | The hook bypassed the `cta &&` guard — would fire with `onCTA` non-nil but `ctaLabel` nil, when no button renders. | **Fixed** — hook now `guard hasCTA else { return }`; `invokeCTANoOpsWithoutLabel` test pins it. |
+
+No Critical or High findings.
+
+## Round 2 — verification + one accepted Low
+
+Codex re-read the fixes: Medium **complete** (Source Serif 4 path), CTA-hook
+Low **complete** (faithful `hasCTA`-gated proxy), title/body assertion
+**complete**.
+
+**One Low accepted with rationale:** `accessibilityIdentifierRetained` re-reads
+the stored `accessibilityIdentifier` property but does not prove the
+`.accessibilityIdentifier(...)` modifier is applied in `body` — if that
+modifier were removed, the test would still pass.
+
+- **Why accepted, not fixed**: asserting modifier application from a unit
+  test requires a view-inspection library (e.g. ViewInspector). The project
+  has **no third-party Swift packages** (`.claude/rules/50-codebase-conventions.md`
+  §10) — adding one for this single assertion is out of scope for a
+  foundational WI. The codebase precedent for view-construction tests is
+  `_ = view.body` + storing identifiers as configurable inputs (the
+  `BookDetailsSheet` / `SheetReSkinSnapshotTests` pattern), which this WI
+  follows.
+- **Where the gap closes**: the plan §5 already specifies a WI-5 XCUITest
+  (`Feature62AnnotationsSplitVerificationTests`) that resolves each
+  `*EmptyState` accessibility identifier end-to-end on the simulator —
+  that is the real assertion the modifier is applied. WI-2's job is the
+  component definition; WI-5 verifies it in situ.
+
+## Verdict
+
+**ship-as-is.** Two audit rounds. Round 1: 1 Medium + 2 Low. Round 2: Medium
++ both addressable Lows fixed; one Low accepted with rationale (no
+view-inspection library in the project; the modifier-application assertion
+lands in WI-5's XCUITest per plan §5). Zero open Critical/High/Medium. 12
+tests pass.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 528
-        MARKETING_VERSION: 3.36.13
+        CURRENT_PROJECT_VERSION: 529
+        MARKETING_VERSION: 3.36.14
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		26D79FC598918201D178F348 /* PersistenceActorEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2F1636BA674F5AF7A50902 /* PersistenceActorEnvironment.swift */; };
 		26E2B41897B117FD5976B75E /* MDTOCVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AECA1E4C104DEBC5FE30E61 /* MDTOCVerificationTests.swift */; };
 		270748270CF3E119F24D985F /* EPUBWebViewBridgeJS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C07D184EF0E90D5F2DF7A36 /* EPUBWebViewBridgeJS.swift */; };
+		2713737834498A013176EDD1 /* AnnotationsEmptyStateViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB5ABAAC55C4FF6C8B9A921 /* AnnotationsEmptyStateViewTests.swift */; };
 		276E47B44DB8004A3D700E05 /* LibraryProgressRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4104BB5FAFACC19E9FBB4D7 /* LibraryProgressRing.swift */; };
 		2775DDF52321F468CB58F795 /* BookmarkListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D432C9B43D1B6662B4605664 /* BookmarkListViewModel.swift */; };
 		28028B11FE1116819D5DE0FA /* ReaderHighlightTapEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A266E88D3BA30905391B154 /* ReaderHighlightTapEventTests.swift */; };
@@ -246,6 +247,7 @@
 		34B285C323BF6E55A25CC148 /* LocatorCanonicalHashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3987200016FB6CA3D063E44 /* LocatorCanonicalHashTests.swift */; };
 		34E33F3534FA3EB044406F2D /* TypographySettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF87AF7EE6B0FB8E4CC9332 /* TypographySettingsTests.swift */; };
 		34E5034ADB5725781C9CE5C8 /* PDFProgressHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A54A2C5DE8C1631C04BB2A1 /* PDFProgressHelper.swift */; };
+		34EBF21FA663958498E44A1C /* AnnotationsEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 976E7B190B979DD10D1FA253 /* AnnotationsEmptyStateView.swift */; };
 		3548ECB80E9BAC95250F69E5 /* TXTOffsetMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA7AE29709E497DBB6AF9DF /* TXTOffsetMapperTests.swift */; };
 		354E24A0B0A690869F8EFC5A /* TapZoneOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271BAF9BD03F619061BA4D96 /* TapZoneOverlay.swift */; };
 		357590BC921E8A3A0E7132F1 /* FoliateStyleMapperChapterStartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E3F274866072EA56D8C0B4 /* FoliateStyleMapperChapterStartTests.swift */; };
@@ -495,6 +497,7 @@
 		6FCF7DD822CCDC8C47899DF7 /* RealDebugBridgeContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0378B284E969CD8625A89EA1 /* RealDebugBridgeContext.swift */; };
 		6FF433287ABA2EEBDE2D5636 /* TXTViewConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48EFB2798AC0354FCC8D4A9B /* TXTViewConfig.swift */; };
 		700CFFEC7C74E0532A0271F4 /* ExportTestFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5CAE41C429B6868957C540 /* ExportTestFixtures.swift */; };
+		702EC14075E1461D4E563FD4 /* AnnotationsEmptyStateArtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22012CDD369E616CC9FD8075 /* AnnotationsEmptyStateArtTests.swift */; };
 		70C6F95011CBEC3AF8F1D44B /* TOCChapterProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E3AA514298AACD2F963913C /* TOCChapterProgress.swift */; };
 		70DA481383CC5F3047D96E83 /* CollectionSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02275826847D45CA3746D53D /* CollectionSidebar.swift */; };
 		71397E1DB2920A02C5CEE39E /* PDFPageNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103B5BF35C8DC9FB2BE4998F /* PDFPageNavigator.swift */; };
@@ -755,6 +758,7 @@
 		ADAA21CB04F57472C44679D5 /* UTF16TextSlicer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9ABEE3CBF62A1CC57F2952F /* UTF16TextSlicer.swift */; };
 		AE171BC364B973E0F52D1B96 /* BookFileMaterializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1889243163114A51950527F6 /* BookFileMaterializer.swift */; };
 		AE34D7222B4EAB4191316FD2 /* FoliateReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C919847EACB9AB94A03DF6E8 /* FoliateReaderViewModel.swift */; };
+		AECBF29963343401867CC3E7 /* AnnotationsEmptyStateArt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5103C436DB10DEF552018E57 /* AnnotationsEmptyStateArt.swift */; };
 		AECED765F5022DC96443D566 /* foliate-host.js in Resources */ = {isa = PBXBuildFile; fileRef = 8770E9DB2008B2B8B4B0A475 /* foliate-host.js */; };
 		AEEF0E0D791AC4AD073BD640 /* DebugReaderRegistrySettleCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCED323293B03B5DCEE7496 /* DebugReaderRegistrySettleCoreTests.swift */; };
 		AEFC819574E845429DFC9D78 /* ZIPReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2DB7F421D9D2E7492E12F89 /* ZIPReader.swift */; };
@@ -1257,6 +1261,7 @@
 		21BC5F159064D57CFAE2A676 /* MetadataExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataExtractorTests.swift; sourceTree = "<group>"; };
 		21CF1C76C54971B97341E5E9 /* FoliateHighlightRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightRenderer.swift; sourceTree = "<group>"; };
 		21DACD6747B01194396A1708 /* Feature55NotePreviewVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature55NotePreviewVerificationTests.swift; sourceTree = "<group>"; };
+		22012CDD369E616CC9FD8075 /* AnnotationsEmptyStateArtTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationsEmptyStateArtTests.swift; sourceTree = "<group>"; };
 		228F27716382F3B61E0E15C8 /* CollectionSidebarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSidebarTests.swift; sourceTree = "<group>"; };
 		22C20D015AD61E29BEB57DC3 /* LocatorNormalizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorNormalizerTests.swift; sourceTree = "<group>"; };
 		22C31D7BC3688FEB94A94EC8 /* CoverPickCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoverPickCoordinator.swift; sourceTree = "<group>"; };
@@ -1465,6 +1470,7 @@
 		50AA77FDB19CB7EDA69418C8 /* ReaderUnifiedCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderUnifiedCoordinator.swift; sourceTree = "<group>"; };
 		50CA80F28DFB8D0D4F4BEC25 /* BookSourceHTTPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSourceHTTPClientTests.swift; sourceTree = "<group>"; };
 		50E944C737D2389E8481C5AD /* SelectionPopoverActionRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionPopoverActionRouter.swift; sourceTree = "<group>"; };
+		5103C436DB10DEF552018E57 /* AnnotationsEmptyStateArt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationsEmptyStateArt.swift; sourceTree = "<group>"; };
 		510A755F74250CC74B14021D /* TXTReaderViewModelContinuousTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReaderViewModelContinuousTests.swift; sourceTree = "<group>"; };
 		513AE679E0A5DBFFBB0AF6BD /* MDReaderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReaderViewModelTests.swift; sourceTree = "<group>"; };
 		515AB3C2D2185F41DAFD8D16 /* LegadoRuleParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegadoRuleParser.swift; sourceTree = "<group>"; };
@@ -1718,6 +1724,7 @@
 		8B1AC5E9F599CDA7123547F2 /* AnnotationAnchor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationAnchor.swift; sourceTree = "<group>"; };
 		8B6366DF3AEECBB9C55151DA /* TextReaderUIStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextReaderUIStateTests.swift; sourceTree = "<group>"; };
 		8B9ADBAD743C25C15A97EA59 /* SimpTradDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpTradDictionary.swift; sourceTree = "<group>"; };
+		8BB5ABAAC55C4FF6C8B9A921 /* AnnotationsEmptyStateViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationsEmptyStateViewTests.swift; sourceTree = "<group>"; };
 		8C6266DCAB5ADCBB1B3257D9 /* TextMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextMapper.swift; sourceTree = "<group>"; };
 		8C6686ECBBE526053A51CBA2 /* ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
 		8C9E438077E6D10199BA12CE /* OPDSBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSBrowserView.swift; sourceTree = "<group>"; };
@@ -1763,6 +1770,7 @@
 		96E6FA59B833AC785C70A7A8 /* LibraryTouchTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryTouchTargetTests.swift; sourceTree = "<group>"; };
 		96FDA9A40CE891B901F1A28F /* PersistenceActor+Stats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+Stats.swift"; sourceTree = "<group>"; };
 		9750B9E9047FB0E0C59DA940 /* HighlightLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightLookup.swift; sourceTree = "<group>"; };
+		976E7B190B979DD10D1FA253 /* AnnotationsEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationsEmptyStateView.swift; sourceTree = "<group>"; };
 		9773A45B1D89408E85D126BA /* MDReflowableTextSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReflowableTextSource.swift; sourceTree = "<group>"; };
 		9776A011745AF967BBAB2A4C /* FoliateTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateTypes.swift; sourceTree = "<group>"; };
 		97EE89998FF9D71667B4B83C /* FoliateSelectionDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateSelectionDispatcherTests.swift; sourceTree = "<group>"; };
@@ -3541,6 +3549,8 @@
 		C4B34F5EFDC2D208F4FD5709 /* Annotations */ = {
 			isa = PBXGroup;
 			children = (
+				22012CDD369E616CC9FD8075 /* AnnotationsEmptyStateArtTests.swift */,
+				8BB5ABAAC55C4FF6C8B9A921 /* AnnotationsEmptyStateViewTests.swift */,
 				BB4782896641E1278B54C247 /* AnnotationsSheetRouteTests.swift */,
 				3E3B2EC2A68566A49EFF1271 /* AnnotationStreamBuilderTests.swift */,
 			);
@@ -4087,6 +4097,8 @@
 		F4ACA835EC4499ADB826DDF8 /* Annotations */ = {
 			isa = PBXGroup;
 			children = (
+				5103C436DB10DEF552018E57 /* AnnotationsEmptyStateArt.swift */,
+				976E7B190B979DD10D1FA253 /* AnnotationsEmptyStateView.swift */,
 				003C8D1A2BD41B14B248D7E7 /* AnnotationsSheetRoute.swift */,
 				6C930176EDA59BA6AE769B8C /* AnnotationStreamBuilder.swift */,
 				FCC8C2B2EE71211499AA0EE4 /* AnnotationStreamItem.swift */,
@@ -4407,6 +4419,8 @@
 				CC774F69EFD8E1BD204DD515 /* AnnotationListViewModelTests.swift in Sources */,
 				762B3F65978080FE7D26BF4C /* AnnotationModelTests.swift in Sources */,
 				CF05CA23E2BC20BDB676DDE3 /* AnnotationStreamBuilderTests.swift in Sources */,
+				702EC14075E1461D4E563FD4 /* AnnotationsEmptyStateArtTests.swift in Sources */,
+				2713737834498A013176EDD1 /* AnnotationsEmptyStateViewTests.swift in Sources */,
 				66EF1425722B3E84E4902AEC /* AnnotationsPanelViewTests.swift in Sources */,
 				1C047439042E40ABD9D6DFA7 /* AnnotationsSheetRouteTests.swift in Sources */,
 				CAF37A53ACA1334F8A0AD2A4 /* AnthropicProviderStreamingTests.swift in Sources */,
@@ -4881,6 +4895,8 @@
 				8F002C822102F0A088F31A06 /* AnnotationRecord.swift in Sources */,
 				68F25FD5B04A5CE2EC41E895 /* AnnotationStreamBuilder.swift in Sources */,
 				A50497A14DDBBD85C999A424 /* AnnotationStreamItem.swift in Sources */,
+				AECBF29963343401867CC3E7 /* AnnotationsEmptyStateArt.swift in Sources */,
+				34EBF21FA663958498E44A1C /* AnnotationsEmptyStateView.swift in Sources */,
 				25B106D034C16291C104D69E /* AnnotationsPanelView.swift in Sources */,
 				C90F581D922CB5FC37C94EFA /* AnnotationsSheetRoute.swift in Sources */,
 				FFC1BF2B3E0963AAD120E93E /* AnthropicProvider+Streaming.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5526,13 +5526,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 528;
+				CURRENT_PROJECT_VERSION = 529;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.13;
+				MARKETING_VERSION = 3.36.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5676,13 +5676,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 528;
+				CURRENT_PROJECT_VERSION = 529;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.13;
+				MARKETING_VERSION = 3.36.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Views/Reader/Annotations/AnnotationsEmptyStateArt.swift
+++ b/vreader/Views/Reader/Annotations/AnnotationsEmptyStateArt.swift
@@ -1,0 +1,178 @@
+// Purpose: Feature #62 WI-2 — the three annotations empty-state SVG
+// illustrations, reproduced as SwiftUI shape views.
+//
+// The committed design (`dev-docs/designs/vreader-fidelity-v1/project/
+// vreader-annotations.jsx` — `EmptyTOCArt` / `EmptyBookmarkArt` /
+// `EmptyHighlightsArt`) draws each empty state as a 96×96 SVG built
+// from abstracted in-app objects (a page, a bookmarked book, a
+// highlighted passage). Rule 51 requires the designed surface — these
+// replace the plain `ContentUnavailableView` the legacy list views
+// used.
+//
+// Each is a pure `View` taking a `ReaderThemeV2`; the JSX `art`
+// functions take `t` and draw with `t.rule` / `t.sub` / `t.accent` /
+// `t.isDark`. No data, no behavior — pure geometry. Coordinates are
+// transcribed 1:1 from the JSX `viewBox="0 0 96 96"` paths and laid out
+// inside a `GeometryReader`-free fixed 96×96 canvas (the design fixes
+// the size; `AnnotationsEmptyStateView` frames it).
+//
+// @coordinates-with: AnnotationsEmptyStateView.swift, ReaderThemeV2.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-annotations.jsx`
+
+import SwiftUI
+
+/// The 96×96 design canvas all three illustrations draw inside.
+private let artCanvas: CGFloat = 96
+
+// MARK: - EmptyTOCArt
+
+/// Empty Contents tab — a dashed page outline with text lines and a
+/// single accent dot. JSX `EmptyTOCArt`.
+struct EmptyTOCArt: View {
+    let theme: ReaderThemeV2
+
+    var body: some View {
+        ZStack {
+            // <rect x=14 y=14 w=68 h=68 rx=4 dashed stroke=rule>
+            RoundedRectangle(cornerRadius: 4)
+                .stroke(
+                    Color(theme.ruleColor),
+                    style: StrokeStyle(lineWidth: 1.5, dash: [3, 3])
+                )
+                .frame(width: 68, height: 68)
+                .position(x: 14 + 34, y: 14 + 34)
+            // <path d="M28 32h26 M28 42h32 M28 52h22 M28 62h28"> text lines
+            textLines
+                .stroke(
+                    Color(theme.subColor).opacity(0.5),
+                    style: StrokeStyle(lineWidth: 2, lineCap: .round)
+                )
+            // <circle cx=68 cy=32 r=5 fill=accent opacity=.85>
+            Circle()
+                .fill(Color(theme.accentColor).opacity(0.85))
+                .frame(width: 10, height: 10)
+                .position(x: 68, y: 32)
+        }
+        .frame(width: artCanvas, height: artCanvas)
+    }
+
+    private var textLines: Path {
+        var p = Path()
+        for (y, width) in [(32.0, 26.0), (42.0, 32.0), (52.0, 22.0), (62.0, 28.0)] {
+            p.move(to: CGPoint(x: 28, y: y))
+            p.addLine(to: CGPoint(x: 28 + width, y: y))
+        }
+        return p
+    }
+}
+
+// MARK: - EmptyBookmarkArt
+
+/// Empty Bookmarks tab — a paper card with faint text lines and an
+/// accent bookmark ribbon. JSX `EmptyBookmarkArt`.
+struct EmptyBookmarkArt: View {
+    let theme: ReaderThemeV2
+
+    var body: some View {
+        ZStack {
+            // <rect x=20 y=14 w=56 h=72 rx=3 fill=card stroke=rule>
+            RoundedRectangle(cornerRadius: 3)
+                .fill(cardFill)
+                .frame(width: 56, height: 72)
+                .position(x: 20 + 28, y: 14 + 36)
+            RoundedRectangle(cornerRadius: 3)
+                .stroke(Color(theme.ruleColor), lineWidth: 1.5)
+                .frame(width: 56, height: 72)
+                .position(x: 20 + 28, y: 14 + 36)
+            // text lines
+            textLines
+                .stroke(
+                    Color(theme.subColor).opacity(0.35),
+                    style: StrokeStyle(lineWidth: 1.5, lineCap: .round)
+                )
+            // <path d="M52 6v32l8-6 8 6V6z" fill=accent> bookmark ribbon
+            bookmarkRibbon
+                .fill(Color(theme.accentColor).opacity(0.95))
+        }
+        .frame(width: artCanvas, height: artCanvas)
+    }
+
+    /// `t.isDark ? '#2a2724' : '#fcf8f0'` — the page card fill.
+    private var cardFill: Color {
+        theme.isDark
+            ? Color(red: 0x2a / 255, green: 0x27 / 255, blue: 0x24 / 255)
+            : Color(red: 0xfc / 255, green: 0xf8 / 255, blue: 0xf0 / 255)
+    }
+
+    private var textLines: Path {
+        var p = Path()
+        for (y, width) in [(26.0, 36.0), (36.0, 32.0), (46.0, 28.0), (56.0, 34.0), (66.0, 22.0)] {
+            p.move(to: CGPoint(x: 30, y: y))
+            p.addLine(to: CGPoint(x: 30 + width, y: y))
+        }
+        return p
+    }
+
+    private var bookmarkRibbon: Path {
+        // M52 6 v32 l8-6 l8 6 V6 z
+        var p = Path()
+        p.move(to: CGPoint(x: 52, y: 6))
+        p.addLine(to: CGPoint(x: 52, y: 38))
+        p.addLine(to: CGPoint(x: 60, y: 32))
+        p.addLine(to: CGPoint(x: 68, y: 38))
+        p.addLine(to: CGPoint(x: 68, y: 6))
+        p.closeSubpath()
+        return p
+    }
+}
+
+// MARK: - EmptyHighlightsArt
+
+/// Empty Highlights/Notes surface — three bars (the top one accent-tinted)
+/// and an accent highlighter pen. JSX `EmptyHighlightsArt`.
+struct EmptyHighlightsArt: View {
+    let theme: ReaderThemeV2
+
+    var body: some View {
+        ZStack {
+            // <rect x=12 y=20 w=72 h=14 rx=3 fill=accent33> — highlighted bar
+            RoundedRectangle(cornerRadius: 3)
+                .fill(Color(theme.accentColor).opacity(0.2))
+                .frame(width: 72, height: 14)
+                .position(x: 12 + 36, y: 20 + 7)
+            // <rect x=12 y=42 w=56 h=14 rx=3 fill=faint>
+            RoundedRectangle(cornerRadius: 3)
+                .fill(faintFill)
+                .frame(width: 56, height: 14)
+                .position(x: 12 + 28, y: 42 + 7)
+            // <rect x=12 y=64 w=64 h=14 rx=3 fill=faint>
+            RoundedRectangle(cornerRadius: 3)
+                .fill(faintFill)
+                .frame(width: 64, height: 14)
+                .position(x: 12 + 32, y: 64 + 7)
+            // <path d="M70 6l10 10-30 30-12 2 2-12z" fill=accent> — pen
+            highlighterPen
+                .fill(Color(theme.accentColor).opacity(0.9))
+        }
+        .frame(width: artCanvas, height: artCanvas)
+    }
+
+    /// `t.isDark ? 'rgba(255,255,255,0.07)' : 'rgba(0,0,0,0.06)'`.
+    private var faintFill: Color {
+        theme.isDark
+            ? Color.white.opacity(0.07)
+            : Color.black.opacity(0.06)
+    }
+
+    private var highlighterPen: Path {
+        // M70 6 l10 10 l-30 30 l-12 2 l2-12 z
+        var p = Path()
+        p.move(to: CGPoint(x: 70, y: 6))
+        p.addLine(to: CGPoint(x: 80, y: 16))
+        p.addLine(to: CGPoint(x: 50, y: 46))
+        p.addLine(to: CGPoint(x: 38, y: 48))
+        p.addLine(to: CGPoint(x: 40, y: 36))
+        p.closeSubpath()
+        return p
+    }
+}

--- a/vreader/Views/Reader/Annotations/AnnotationsEmptyStateView.swift
+++ b/vreader/Views/Reader/Annotations/AnnotationsEmptyStateView.swift
@@ -66,8 +66,11 @@ struct AnnotationsEmptyStateView: View {
     }
 
     /// Test-only hook: invokes the CTA action so a unit test can pin the
-    /// closure wiring without a tap-gesture render path.
+    /// closure wiring without a tap-gesture render path. Gated on
+    /// `hasCTA` so it is a faithful proxy for "tap the visible CTA" — it
+    /// no-ops when no button is rendered (label or action absent).
     func invokeCTAForTesting() {
+        guard hasCTA else { return }
         onCTA?()
     }
 
@@ -78,7 +81,8 @@ struct AnnotationsEmptyStateView: View {
                 .opacity(0.85)
 
             Text(title)
-                .font(.system(size: 18, weight: .semibold, design: .serif))
+                .font(Font(ReaderTypography.body(for: .sourceSerif4, size: 18)))
+                .fontWeight(.semibold)
                 .foregroundStyle(Color(theme.inkColor))
                 .multilineTextAlignment(.center)
 

--- a/vreader/Views/Reader/Annotations/AnnotationsEmptyStateView.swift
+++ b/vreader/Views/Reader/Annotations/AnnotationsEmptyStateView.swift
@@ -1,0 +1,120 @@
+// Purpose: Feature #62 WI-2 — the shared annotations empty-state view.
+//
+// Reproduces the committed design's `EmptyState` component
+// (`dev-docs/designs/vreader-fidelity-v1/project/vreader-annotations.jsx`):
+// a centred 96×96 art illustration, a serif title, a body paragraph,
+// and an OPTIONAL accent-pill CTA button. The four annotations list
+// surfaces — `TOCSheet`'s Contents/Bookmarks tabs and `HighlightsSheet`'s
+// filters — reuse it for their empty states, replacing the plain
+// `ContentUnavailableView` the legacy list views used (rule 51 — the
+// designed surface).
+//
+// `accessibilityIdentifier` is a configurable input so WI-5 can re-home
+// the legacy `tocEmptyState` / `bookmarkEmptyState` XCUITest identifiers
+// onto this view when the legacy views are deleted.
+//
+// @coordinates-with: AnnotationsEmptyStateArt.swift, TOCSheet.swift,
+//   HighlightsSheet.swift, ReaderThemeV2.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-annotations.jsx`
+
+import SwiftUI
+
+/// The design's `EmptyState` — centred art + serif title + body + an
+/// optional accent CTA. Pure presentation; the CTA action is injected.
+struct AnnotationsEmptyStateView: View {
+    /// Visual-identity-v2 theme tokens.
+    let theme: ReaderThemeV2
+    /// Stable accessibility identifier for XCUITest lookup.
+    let accessibilityIdentifier: String
+    /// The empty-state illustration (one of the three `Empty*Art` views).
+    let art: AnyView
+    /// Serif heading.
+    let title: String
+    /// Supporting paragraph.
+    let body_: String
+    /// CTA button label — when nil, no CTA is shown.
+    let ctaLabel: String?
+    /// SF Symbol drawn before the CTA label.
+    let ctaSystemImage: String?
+    /// CTA tap action.
+    let onCTA: (() -> Void)?
+
+    init(
+        theme: ReaderThemeV2,
+        accessibilityIdentifier: String,
+        art: AnyView,
+        title: String,
+        body: String,
+        ctaLabel: String? = nil,
+        ctaSystemImage: String? = nil,
+        onCTA: (() -> Void)? = nil
+    ) {
+        self.theme = theme
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.art = art
+        self.title = title
+        self.body_ = body
+        self.ctaLabel = ctaLabel
+        self.ctaSystemImage = ctaSystemImage
+        self.onCTA = onCTA
+    }
+
+    /// True when a CTA button is part of the composition — the design's
+    /// `cta && ...` guard. Both a label and an action must be supplied.
+    var hasCTA: Bool {
+        ctaLabel != nil && onCTA != nil
+    }
+
+    /// Test-only hook: invokes the CTA action so a unit test can pin the
+    /// closure wiring without a tap-gesture render path.
+    func invokeCTAForTesting() {
+        onCTA?()
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            art
+                .frame(width: 96, height: 96)
+                .opacity(0.85)
+
+            Text(title)
+                .font(.system(size: 18, weight: .semibold, design: .serif))
+                .foregroundStyle(Color(theme.inkColor))
+                .multilineTextAlignment(.center)
+
+            Text(body_)
+                .font(.system(size: 13))
+                .foregroundStyle(Color(theme.subColor))
+                .multilineTextAlignment(.center)
+                .lineSpacing(3)
+                .frame(maxWidth: 280)
+
+            if hasCTA, let ctaLabel, let onCTA {
+                Button(action: onCTA) {
+                    HStack(spacing: 6) {
+                        if let ctaSystemImage {
+                            Image(systemName: ctaSystemImage)
+                                .font(.system(size: 13, weight: .bold))
+                        }
+                        Text(ctaLabel)
+                            .font(.system(size: 12.5, weight: .semibold))
+                    }
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 8)
+                    .background(
+                        Capsule().fill(Color(theme.accentColor))
+                    )
+                }
+                .buttonStyle(.plain)
+                .padding(.top, 4)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, 36)
+        .padding(.top, 24)
+        .padding(.bottom, 56)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+}

--- a/vreaderTests/Views/Reader/Annotations/AnnotationsEmptyStateArtTests.swift
+++ b/vreaderTests/Views/Reader/Annotations/AnnotationsEmptyStateArtTests.swift
@@ -1,0 +1,45 @@
+// Purpose: Feature #62 WI-2 — pins that the three annotations
+// empty-state SVG illustrations build for every theme.
+//
+// `EmptyTOCArt` / `EmptyBookmarkArt` / `EmptyHighlightsArt` are the
+// design's empty-state illustrations (`vreader-annotations.jsx`)
+// reproduced as SwiftUI `Shape`/`Path` views. They are pure geometry —
+// no data, no behavior — but they read `ReaderThemeV2` tokens
+// (`accent` / `sub` / `rule` / `isDark`), so the #60 "a re-skin must
+// not drop wiring" regression lesson applies: each art view must build
+// for all five themes.
+//
+// @coordinates-with: AnnotationsEmptyStateArt.swift, ReaderThemeV2.swift
+
+import Testing
+import SwiftUI
+@testable import vreader
+
+@Suite("Feature #62 — Annotations empty-state art")
+@MainActor
+struct AnnotationsEmptyStateArtTests {
+
+    @Test("EmptyTOCArt builds for every theme")
+    func emptyTOCArtBuildsForEveryTheme() {
+        for theme in ReaderThemeV2.allCases {
+            let art = EmptyTOCArt(theme: theme)
+            _ = art.body
+        }
+    }
+
+    @Test("EmptyBookmarkArt builds for every theme")
+    func emptyBookmarkArtBuildsForEveryTheme() {
+        for theme in ReaderThemeV2.allCases {
+            let art = EmptyBookmarkArt(theme: theme)
+            _ = art.body
+        }
+    }
+
+    @Test("EmptyHighlightsArt builds for every theme")
+    func emptyHighlightsArtBuildsForEveryTheme() {
+        for theme in ReaderThemeV2.allCases {
+            let art = EmptyHighlightsArt(theme: theme)
+            _ = art.body
+        }
+    }
+}

--- a/vreaderTests/Views/Reader/Annotations/AnnotationsEmptyStateViewTests.swift
+++ b/vreaderTests/Views/Reader/Annotations/AnnotationsEmptyStateViewTests.swift
@@ -1,0 +1,135 @@
+// Purpose: Feature #62 WI-2 — pins `AnnotationsEmptyStateView`'s
+// composition.
+//
+// `AnnotationsEmptyStateView` is the design's `EmptyState` component
+// (`vreader-annotations.jsx`): a centred art illustration + serif title
+// + body + an OPTIONAL CTA button. The four annotations list surfaces
+// (`TOCSheet`'s Contents/Bookmarks tabs, `HighlightsSheet`'s filters)
+// reuse it for their empty states.
+//
+// The contract these tests guard: the CTA is part of the composition
+// iff a CTA closure + label are supplied (the design's `cta && ...`),
+// the configurable accessibility identifier is applied (so the
+// existing XCUITest `tocEmptyState` / `bookmarkEmptyState` identifier
+// strings keep resolving once the legacy views are deleted in WI-5),
+// and the view builds for every theme.
+//
+// @coordinates-with: AnnotationsEmptyStateView.swift,
+//   AnnotationsEmptyStateArt.swift, ReaderThemeV2.swift
+
+import Testing
+import SwiftUI
+@testable import vreader
+
+@Suite("Feature #62 — AnnotationsEmptyStateView")
+@MainActor
+struct AnnotationsEmptyStateViewTests {
+
+    @Test("Builds for every theme")
+    func buildsForEveryTheme() {
+        for theme in ReaderThemeV2.allCases {
+            let view = AnnotationsEmptyStateView(
+                theme: theme,
+                accessibilityIdentifier: "tocEmptyState",
+                art: AnyView(EmptyTOCArt(theme: theme)),
+                title: "No table of contents",
+                body: "This book doesn't ship a TOC."
+            )
+            _ = view.body
+        }
+    }
+
+    @Test("hasCTA is false when no CTA closure is supplied")
+    func hasCTAFalseWithoutClosure() {
+        let view = AnnotationsEmptyStateView(
+            theme: .paper,
+            accessibilityIdentifier: "bookmarkEmptyState",
+            art: AnyView(EmptyBookmarkArt(theme: .paper)),
+            title: "No bookmarks yet",
+            body: "Tap the bookmark icon to save your place."
+        )
+        #expect(view.hasCTA == false)
+    }
+
+    @Test("hasCTA is true when a CTA label + closure are supplied")
+    func hasCTATrueWithClosure() {
+        let view = AnnotationsEmptyStateView(
+            theme: .paper,
+            accessibilityIdentifier: "tocEmptyState",
+            art: AnyView(EmptyTOCArt(theme: .paper)),
+            title: "No table of contents",
+            body: "Use Search to jump to a passage.",
+            ctaLabel: "Open Search",
+            ctaSystemImage: "magnifyingglass",
+            onCTA: {}
+        )
+        #expect(view.hasCTA)
+    }
+
+    @Test("CTA closure is invoked on tap")
+    func ctaClosureInvoked() {
+        var fired = false
+        let view = AnnotationsEmptyStateView(
+            theme: .paper,
+            accessibilityIdentifier: "tocEmptyState",
+            art: AnyView(EmptyTOCArt(theme: .paper)),
+            title: "No table of contents",
+            body: "Use Search to jump to a passage.",
+            ctaLabel: "Open Search",
+            ctaSystemImage: "magnifyingglass",
+            onCTA: { fired = true }
+        )
+        view.invokeCTAForTesting()
+        #expect(fired)
+    }
+
+    @Test("Builds with a CTA for every theme")
+    func buildsWithCTAForEveryTheme() {
+        for theme in ReaderThemeV2.allCases {
+            let view = AnnotationsEmptyStateView(
+                theme: theme,
+                accessibilityIdentifier: "tocEmptyState",
+                art: AnyView(EmptyTOCArt(theme: theme)),
+                title: "No table of contents",
+                body: "Use Search.",
+                ctaLabel: "Open Search",
+                ctaSystemImage: "magnifyingglass",
+                onCTA: {}
+            )
+            _ = view.body
+        }
+    }
+
+    @Test("The configured accessibility identifier is retained")
+    func accessibilityIdentifierRetained() {
+        // WI-5 re-homes the legacy `tocEmptyState` / `bookmarkEmptyState`
+        // XCUITest identifiers onto this view — the identifier must be a
+        // configurable input the test can read back.
+        let toc = AnnotationsEmptyStateView(
+            theme: .paper,
+            accessibilityIdentifier: "tocEmptyState",
+            art: AnyView(EmptyTOCArt(theme: .paper)),
+            title: "t", body: "b"
+        )
+        let bm = AnnotationsEmptyStateView(
+            theme: .paper,
+            accessibilityIdentifier: "bookmarkEmptyState",
+            art: AnyView(EmptyBookmarkArt(theme: .paper)),
+            title: "t", body: "b"
+        )
+        #expect(toc.accessibilityIdentifier == "tocEmptyState")
+        #expect(bm.accessibilityIdentifier == "bookmarkEmptyState")
+    }
+
+    @Test("Builds with a CJK title and body")
+    func buildsWithCJKText() {
+        let view = AnnotationsEmptyStateView(
+            theme: .dark,
+            accessibilityIdentifier: "highlightsEmptyState",
+            art: AnyView(EmptyHighlightsArt(theme: .dark)),
+            title: "暂无高亮或笔记",
+            body: "长按任意段落即可高亮或添加笔记。"
+        )
+        _ = view.body
+    }
+}

--- a/vreaderTests/Views/Reader/Annotations/AnnotationsEmptyStateViewTests.swift
+++ b/vreaderTests/Views/Reader/Annotations/AnnotationsEmptyStateViewTests.swift
@@ -132,4 +132,39 @@ struct AnnotationsEmptyStateViewTests {
         )
         _ = view.body
     }
+
+    @Test("title and body are wired from the init arguments")
+    func titleAndBodyWired() {
+        // The design's EmptyState renders the supplied title + body —
+        // pin that they are carried onto the view, not dropped or
+        // swapped (a value-type View's testable contract).
+        let view = AnnotationsEmptyStateView(
+            theme: .sepia,
+            accessibilityIdentifier: "tocEmptyState",
+            art: AnyView(EmptyTOCArt(theme: .sepia)),
+            title: "No table of contents",
+            body: "This book doesn't ship a TOC."
+        )
+        #expect(view.title == "No table of contents")
+        #expect(view.body_ == "This book doesn't ship a TOC.")
+    }
+
+    @Test("invokeCTAForTesting no-ops when no CTA label is supplied")
+    func invokeCTANoOpsWithoutLabel() {
+        // The hook is gated on hasCTA — an action with no label means no
+        // button renders, so the hook must not fire (faithful proxy for
+        // "tap the visible CTA").
+        var fired = false
+        let view = AnnotationsEmptyStateView(
+            theme: .paper,
+            accessibilityIdentifier: "tocEmptyState",
+            art: AnyView(EmptyTOCArt(theme: .paper)),
+            title: "t", body: "b",
+            ctaLabel: nil,
+            onCTA: { fired = true }
+        )
+        #expect(view.hasCTA == false)
+        view.invokeCTAForTesting()
+        #expect(fired == false)
+    }
 }


### PR DESCRIPTION
## Summary

- WI-2 of feature #62 (annotations panel split). Ships the **reusable empty-state component + the three SVG art illustrations** the design specifies — foundational tier, no caller yet.

Part of feature #801.

## What Changed

New files under `vreader/Views/Reader/Annotations/`:

- **`AnnotationsEmptyStateArt.swift`** — `EmptyTOCArt` / `EmptyBookmarkArt` / `EmptyHighlightsArt`, the design's 96×96 SVG illustrations (`vreader-annotations.jsx`) reproduced as SwiftUI `Path`/`Shape` views. Coordinates transcribed 1:1 from the JSX `viewBox`; pure geometry, theme tokens only (`accent` / `sub` / `rule` / `isDark`).
- **`AnnotationsEmptyStateView.swift`** — the design's `EmptyState` component: centred 96×96 art + serif title + body + an OPTIONAL accent-pill CTA. Replaces the plain `ContentUnavailableView` the legacy list views used (rule 51 — the designed surface). `accessibilityIdentifier` is a configurable input so WI-5 can re-home the legacy `tocEmptyState` / `bookmarkEmptyState` XCUITest identifiers.

Tests (`vreaderTests/Views/Reader/Annotations/`): `AnnotationsEmptyStateArtTests` (each art builds for all 5 themes) + `AnnotationsEmptyStateViewTests` (builds with/without a CTA for every theme; `hasCTA` reflects the label+closure; CTA closure fires; the hook is `hasCTA`-gated; `title`/`body` wired; a11y id retained; CJK title/body) — 12 tests.

## WI Status

- WI-1: foundational — merged (#974, v3.36.13).
- WI-2: **foundational** — this PR. No caller yet; WI-3 (`TOCSheet`) + WI-4 (`HighlightsSheet`) consume these.
- Remaining: WI-3 `TOCSheet`, WI-4 `HighlightsSheet`, WI-5 rewire + deletions (final).

## Codex Audit (Gate 4)

Codex MCP thread `019e40a1`, 2 rounds, verdict **ship-as-is**. Round 1: 1 Medium (title used `.system(design:.serif)` not the repo's `ReaderTypography.body(for:.sourceSerif4,...)` path) + 2 Low (test gaps; `invokeCTAForTesting` not `hasCTA`-gated) — Medium + both addressable Lows fixed. **One Low accepted with rationale**: asserting `.accessibilityIdentifier()` modifier *application* from a unit test needs a view-inspection library; the project has no third-party packages (rule 50 §10) — the end-to-end identifier-resolution assertion lands in WI-5's `Feature62…VerificationTests` XCUITest per plan §5.

Audit log: `.claude/codex-audits/feat-feature-62-wi-2-annotations-empty-state-audit.md`

## Validation

- [x] `xcodebuild build` succeeds with WI-2's code.
- [x] WI-2's two suites pass **12/12** — verified isolated.
- [x] Tests cover changed behavior (TDD: RED → GREEN → REFACTOR).
- [x] Codex audit loop completed (2 rounds, verdict: ship-as-is; one Low accepted with rationale).
- [x] Docs sync — n/a (pure SwiftUI value-type views in the feature-local directory; no new service/notification/`@Model`).
- [x] Version bumped: 3.36.13 → 3.36.14.

**Full-suite note**: as in PR #974, the shared simulator is under heavy multi-agent contention. WI-2 adds **only 2 new files + 2 test files in the feature-local directory — zero edits to any existing source file** — so it cannot regress existing suites; the build-clean + 12-test-green + Codex audit cover the foundational-WI Gate-5 bar.

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: **foundational** — pure SwiftUI value-type views, no user-observable behavior (no caller yet; consumed by WI-3/WI-4). Unit tests + Gate-4 audit are sufficient per rule 47; no device verification required (the no-regression component-slice pattern feature #60 WI-7a used).
- Run: `xcodebuild build` succeeds; the two WI-2 suites pass 12/12.

## Type of Change

- [x] Feature WI (Part of feature #801 — intermediate WI, plain-prose reference per rule 47)

🤖 Generated with [Claude Code](https://claude.com/claude-code)