### PR TITLE
chore: bump version to 3.36.20 — resolve 3.36.19 collision

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 534
-        MARKETING_VERSION: 3.36.19
+        CURRENT_PROJECT_VERSION: 535
+        MARKETING_VERSION: 3.36.20
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5578,13 +5578,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 534;
+				CURRENT_PROJECT_VERSION = 535;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.19;
+				MARKETING_VERSION = 3.36.20;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5728,13 +5728,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 534;
+				CURRENT_PROJECT_VERSION = 535;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.19;
+				MARKETING_VERSION = 3.36.20;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Why

PR #989 (`#62` WI-3) and PR #990 (`#64` WI-6) were prepared in parallel, both
against base version 3.36.18, and each shipped `MARKETING_VERSION 3.36.19` /
build 534. #989 merged first and its post-merge finalizer tagged that merge
commit `v3.36.19`. The #990 merge commit `eadccf2` then landed on `main` with a
**duplicate, non-monotonic** version line.

## Fix

Re-bump `main` to the next free patch — **3.36.20 / build 535** — so the build
number is monotonic again (App Store Connect rejects non-monotonic build
numbers). The `v3.36.20` tag is cut from this commit. The `#64` WI-6 merge
commit is intentionally **not** tagged — `v3.36.19` already belongs to #989's
`6c94b1e`.

This is the parallel-execution version-collision recovery from
`.claude/rules/48-parallel-execution.md` applied after the fact (the collision
surfaced at tag time, not merge time). Pure version-line correction — no code
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)