### PR TITLE
feat(#58 WI-2): ReadingStatsAggregator actor + PersistenceActor read methods

### DIFF
--- a/.claude/codex-audits/feat-feature-58-wi-2-stats-aggregator-audit.md
+++ b/.claude/codex-audits/feat-feature-58-wi-2-stats-aggregator-audit.md
@@ -1,0 +1,48 @@
+---
+branch: feat/feature-58-wi-2-stats-aggregator
+threadId: 019e40b9-4d10-7840-b198-707d9b8b71b2
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+# Gate 4 — Implementation Audit: feature #58 WI-2 (ReadingStatsAggregator)
+
+Codex MCP (read-only sandbox), thread `019e40b9-4d10-7840-b198-707d9b8b71b2`.
+Author/auditor separation per rule 48: Codex is a separate process from the
+implementing Claude Code session.
+
+Changed files:
+- `vreader/Services/Stats/ReadingStatsAggregator.swift` (NEW, ~160 lines) — the actor
+- `vreader/Services/PersistenceActor+Stats.swift` (MODIFIED +55) — `fetchAllReadingSessions` / `fetchAllReadingStats`
+- `docs/architecture.md` (+1, doc-sync)
+- `vreaderTests/Services/Stats/ReadingStatsAggregatorTests.swift` (NEW)
+- `vreaderTests/Services/Stats/PersistenceActorStatsReadTests.swift` (NEW)
+
+## Round 1 — findings (0 Critical / 1 High / 1 Medium / 0 Low)
+
+| # | Severity | File:line | Issue | Resolution |
+|---|---|---|---|---|
+| 1 | High | ReadingStatsAggregator.swift (computePerBook) | The per-book table was built only from `sessionsByKey`, so a live `Book` with zero sessions was omitted entirely — contradicts the plan's resolved edge case (a) ("zero-session book → still show a `0m` row"). | **Fixed.** `computePerBook` now builds rows from the UNION of every live `Book.fingerprintKey` and every session key (`Set(bookByKey.keys).union(sessionsByKey.keys)`). A live book with no sessions → a `0m` row, `lastReadAt` nil; an orphan session key still surfaces as a deleted-book row. Reading seconds / `lastReadAt` are still derived from `ReadingSession` rows ONLY — the F10 "never read `ReadingStats`" rule is preserved. |
+| 2 | Medium | ReadingStatsAggregatorTests.swift | Tests did not cover edge case (a), and never verified live-book `annotations`/`highlights` relationship counts despite the plan promising that coverage. | **Fixed.** Added `liveBookWithNoSessionsStillShownAsZeroRow` (seeds a Book with zero sessions, asserts the `0m` row) and `liveBookHighlightAndNoteCountsMatchRelationships` (seeds 3 `Highlight` + 2 `AnnotationNote` via the cascade relationship, asserts the counts). |
+
+Round-1 clean dimensions: the F8/F10 consistency model is correctly implemented
+— one actor-local `ModelContext`, no `ReadingStats` reads in `snapshot`, window
+bucketing by `startedAt`, `lastReadAt = max(endedAt ?? startedAt)`,
+`lifetimeTotalSeconds = sum(max(0, durationSeconds))`, `trackingSince =
+min(startedAt)`. No Swift 6 concurrency issues (actor isolation correct,
+`ModelContext` confined within the actor method, `@Sendable () -> Calendar`
+provider sound, no `@Model` leaks across the boundary).
+
+## Round 2 — verification
+
+Codex confirmed both findings resolved, zero open findings at any severity.
+Note: Codex could not re-run `xcodebuild test` (read-only sandbox). The
+implementing session ran the gate: **18 tests in 2 suites pass** under
+`xcodebuild test -only-testing:vreaderTests` on iPhone 17 Pro Simulator.
+
+## Verdict
+
+**ship-as-is** (round 2). 0 open Critical/High/Medium/Low findings after 2
+rounds (rule-47 max is 3). WI-2 is a foundational WI — an actor with no
+user-observable behavior; Gate 5a is satisfied by unit tests + this audit.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,6 +125,7 @@ Bridge-internal coordinators (`EPUBWebViewBridgeCoordinator`, `FoliateViewCoordi
 | `TTSService`                         | AVSpeechSynthesizer + HTTP | Read aloud with controls                                                  |
 | `BookContentCache`                   | In-memory                  | Text cache for AI context loading (TXT/MD only)                           |
 | `PreferenceStore`                    | UserDefaults               | Sort order, view mode persistence                                         |
+| `ReadingStatsAggregator`             | SwiftData (actor-isolated) | Reading-stats dashboard aggregator (feature #58). Sweeps `ReadingSession` + `Book` rows in one `ModelContext` pass and returns a `ReadingDashboardSnapshot` — per-window totals (today / 7d / 30d / 90d / 180d / 365d / all) + per-book breakdown. Derives every number from session rows, never from `ReadingStats`, so a stale stats cache cannot desync the dashboard. Holds a `@Sendable () -> Calendar` provider so window boundaries follow timezone/DST changes |
 | `CustomCoverStore`                   | JPEG files                 | Custom book cover images                                                  |
 | `WebDAVClient`                       | HTTP                       | Low-level WebDAV transport (PROPFIND/PUT/GET/DELETE/MKCOL/MOVE)           |
 | `WebDAVProvider`                     | `WebDAVClient`             | `BackupProvider` impl — backup/restore/list/delete over a WebDAV server   |

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 535
-        MARKETING_VERSION: 3.36.20
+        CURRENT_PROJECT_VERSION: 536
+        MARKETING_VERSION: 3.36.21
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -343,6 +343,7 @@
 		497BE2970C924807C3451FA0 /* fixed-layout.js in Resources */ = {isa = PBXBuildFile; fileRef = C47343EAD4CE63CDA1604255 /* fixed-layout.js */; };
 		49D992E6F2DAB74CCD4FDC68 /* TokenSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D944728B17A940A3716EA9 /* TokenSpanTests.swift */; };
 		49E7475E7118E6366C0530E5 /* PersistentSearchIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25EC6B4A507BE08D646A4AD /* PersistentSearchIndexTests.swift */; };
+		4A2E9C584A5BF628CDB9716A /* ReadingStatsAggregatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AB5B40BD735A699BB480DE /* ReadingStatsAggregatorTests.swift */; };
 		4A67A7ACD5E890A1AECA8854 /* TXTChapterIndexStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E94F1579C79832BB2EEDEB05 /* TXTChapterIndexStoreTests.swift */; };
 		4A87A6889CFFC099EE0AFBD6 /* SeriesTagPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58BA99C96063F3F0CA7A300 /* SeriesTagPersistenceTests.swift */; };
 		4A8B2E9CC8837F5523420479 /* TXTTextViewBridgeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96A115C3FA0B797030C1D1F /* TXTTextViewBridgeCoordinator.swift */; };
@@ -615,6 +616,7 @@
 		892A9F3136477F52D3AECE11 /* text-walker.js in Resources */ = {isa = PBXBuildFile; fileRef = 43CD38D8708AAE752995001B /* text-walker.js */; };
 		8A1909A1927C0A98F6F8D6D0 /* ReadingStatsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = F75548C00D82133FCD8F0DB3 /* ReadingStatsModels.swift */; };
 		8A3AE73DD5935F4E45882E38 /* AccessibilityFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC4CE4DBCD7E5A52BC4E511 /* AccessibilityFormatters.swift */; };
+		8A45E09F7832BE075BAF73D3 /* PersistenceActorStatsReadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D313521AE0A256629A2B0244 /* PersistenceActorStatsReadTests.swift */; };
 		8A5EFD4729B7E4BE9D2CA38E /* ReplacementTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF84D4FD4FAA3232D18AA96 /* ReplacementTransform.swift */; };
 		8AE1A6146EC01A464580BBA9 /* DeviceIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B8B24C49B7E5DCAC2B9667 /* DeviceIdentityTests.swift */; };
 		8B009CA87373EC45C1796A1B /* BookImporterNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319F6B718764EAF33C88ECC4 /* BookImporterNotificationTests.swift */; };
@@ -770,6 +772,7 @@
 		AF32B348898F4110FED715F5 /* BookCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F1C998AAACA679A10A86D2 /* BookCollection.swift */; };
 		AF710860E4C45D5A6750EC74 /* SourceSerif4-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 14FC5A8465BA6BCCB0751270 /* SourceSerif4-Regular.otf */; };
 		AF7D99D9C0CEA266BFD976B8 /* MetadataExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAE6C27BECED96A8DA016439 /* MetadataExtractor.swift */; };
+		AFA2A219EE9A27F09BF552D0 /* ReadingStatsAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DBD86DDBB52369C831FF078 /* ReadingStatsAggregator.swift */; };
 		AFBEC85BAAD8651B52E46DC5 /* TextHighlightRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7E3B8864B52047738D5006 /* TextHighlightRenderer.swift */; };
 		AFE6C4ADD50C68610CE76DA2 /* HighlightPopoverMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5725E598AB5CBA16440549D4 /* HighlightPopoverMode.swift */; };
 		B0762A6794C5885FC94A2BF4 /* foliate-reader.html in Resources */ = {isa = PBXBuildFile; fileRef = 0B636D7823EE57464A4CE54D /* foliate-reader.html */; };
@@ -1328,6 +1331,7 @@
 		30D00221E111683E9FF0260A /* SearchTextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTextExtractor.swift; sourceTree = "<group>"; };
 		317401FBAE274C615325BDBC /* SourceSharingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceSharingServiceTests.swift; sourceTree = "<group>"; };
 		319F6B718764EAF33C88ECC4 /* BookImporterNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookImporterNotificationTests.swift; sourceTree = "<group>"; };
+		31AB5B40BD735A699BB480DE /* ReadingStatsAggregatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsAggregatorTests.swift; sourceTree = "<group>"; };
 		31D94746694BD66410FDB471 /* BookDetailsMetadataRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailsMetadataRow.swift; sourceTree = "<group>"; };
 		325EA16A17752B40D178BD4A /* NotePreviewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotePreviewPresenter.swift; sourceTree = "<group>"; };
 		326632F80DB744679F67D712 /* OPDSCatalogListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSCatalogListTests.swift; sourceTree = "<group>"; };
@@ -1819,6 +1823,7 @@
 		9DAD9A773D4AA9098981720D /* EPUBReaderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBReaderViewModelTests.swift; sourceTree = "<group>"; };
 		9DB1CCA367AE0B610F4526FC /* SearchIndexStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchIndexStore.swift; sourceTree = "<group>"; };
 		9DB260B5C0A147C9AE9A46DC /* BookInfoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookInfoSheet.swift; sourceTree = "<group>"; };
+		9DBD86DDBB52369C831FF078 /* ReadingStatsAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsAggregator.swift; sourceTree = "<group>"; };
 		9E09E65978F174E10780F7D3 /* LibraryContinueCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryContinueCard.swift; sourceTree = "<group>"; };
 		9E4A364E7AFF2DD96244D639 /* WebDAVServerProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVServerProfile.swift; sourceTree = "<group>"; };
 		9EC7240FBC11713CD18A4812 /* AIEditorContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIEditorContextTests.swift; sourceTree = "<group>"; };
@@ -2040,6 +2045,7 @@
 		D2AEB48E4BF208D97EEF397C /* QuoteRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuoteRecovery.swift; sourceTree = "<group>"; };
 		D2EA03BEFDBB65F5D7533EDE /* SchemaV1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV1Tests.swift; sourceTree = "<group>"; };
 		D31265D2F8B445FADB98DDFC /* WebDAVProfileListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProfileListViewModelTests.swift; sourceTree = "<group>"; };
+		D313521AE0A256629A2B0244 /* PersistenceActorStatsReadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceActorStatsReadTests.swift; sourceTree = "<group>"; };
 		D363190FCDF47ED48A1D7BC1 /* ReaderLifecycleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderLifecycleHelper.swift; sourceTree = "<group>"; };
 		D36D5CFF47A223349C004E39 /* VReaderAnnotationParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderAnnotationParserTests.swift; sourceTree = "<group>"; };
 		D3A96C651E9CF9C1D386312A /* ReaderThemeV2+ColorScheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderThemeV2+ColorScheme.swift"; sourceTree = "<group>"; };
@@ -2980,6 +2986,7 @@
 		67F531F6D9472411F67DB007 /* Stats */ = {
 			isa = PBXGroup;
 			children = (
+				9DBD86DDBB52369C831FF078 /* ReadingStatsAggregator.swift */,
 				F75548C00D82133FCD8F0DB3 /* ReadingStatsModels.swift */,
 			);
 			path = Stats;
@@ -3513,7 +3520,9 @@
 		BDA487E6712963327F305795 /* Stats */ = {
 			isa = PBXGroup;
 			children = (
+				D313521AE0A256629A2B0244 /* PersistenceActorStatsReadTests.swift */,
 				7A0147BC1F4C66F4EDB21608 /* ReadingDashboardSnapshotTests.swift */,
+				31AB5B40BD735A699BB480DE /* ReadingStatsAggregatorTests.swift */,
 				3FB3C13EB1794A1F78C93D37 /* ReadingStatsModelsTests.swift */,
 			);
 			path = Stats;
@@ -4699,6 +4708,7 @@
 				0ADA2F00E5ABFEEF5328CE2F /* PerBookSettingsTests.swift in Sources */,
 				8F49E620D597517097E96AE7 /* PersistenceActor+HighlightLookupTests.swift in Sources */,
 				2B495CA89B61AF9DAC925A54 /* PersistenceActorRemoteOnlyTests.swift in Sources */,
+				8A45E09F7832BE075BAF73D3 /* PersistenceActorStatsReadTests.swift in Sources */,
 				5619DB9FC83E7182AE0EB63F /* PersistenceBookmarkTests.swift in Sources */,
 				DD32F48A384939AC2389DCAE /* PersistenceHighlightTests.swift in Sources */,
 				49E7475E7118E6366C0530E5 /* PersistentSearchIndexTests.swift in Sources */,
@@ -4742,6 +4752,7 @@
 				726DA1204DBFE8EBE5852764 /* ReadingProgressBarTests.swift in Sources */,
 				B1DFA851C827F5BB877DD2B8 /* ReadingSessionTests.swift in Sources */,
 				7E4274201E53904CDE46FC16 /* ReadingSessionTrackerTests.swift in Sources */,
+				4A2E9C584A5BF628CDB9716A /* ReadingStatsAggregatorTests.swift in Sources */,
 				6BCE6D641047BA2A3BAFDC14 /* ReadingStatsModelsTests.swift in Sources */,
 				7D0B1A054D3897CAD9D768A6 /* ReadingStatsTests.swift in Sources */,
 				800F472661AB1030CC54DB46 /* ReadingTimeFormatterTests.swift in Sources */,
@@ -5269,6 +5280,7 @@
 				A232BB96700FAD0583896DE3 /* ReadingSession.swift in Sources */,
 				E03FE4F3997CC67281E84F1E /* ReadingSessionTracker.swift in Sources */,
 				D49983BE0A1E6A803BF58B2E /* ReadingStats.swift in Sources */,
+				AFA2A219EE9A27F09BF552D0 /* ReadingStatsAggregator.swift in Sources */,
 				8A1909A1927C0A98F6F8D6D0 /* ReadingStatsModels.swift in Sources */,
 				38F1AB473618B5EB717D05DE /* ReadingTimeFormatter.swift in Sources */,
 				2DCCDBB57F5086AF49FF8D99 /* RealDebugBridgeContext+Eval.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5590,13 +5590,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 535;
+				CURRENT_PROJECT_VERSION = 536;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.20;
+				MARKETING_VERSION = 3.36.21;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5740,13 +5740,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 535;
+				CURRENT_PROJECT_VERSION = 536;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.20;
+				MARKETING_VERSION = 3.36.21;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/PersistenceActor+Stats.swift
+++ b/vreader/Services/PersistenceActor+Stats.swift
@@ -50,4 +50,59 @@ extension PersistenceActor {
         stats.lastReadAt = Date()
         try context.save()
     }
+
+    // MARK: - Read side (feature #58 WI-2)
+
+    /// Returns every `ReadingSession` row as a value-typed record.
+    ///
+    /// Used by the feature #58 WebDAV backup collector (WI-5). The reading-stats
+    /// dashboard aggregator does NOT consume this — it owns its own
+    /// `ModelContainer`/`ModelContext` pass so its snapshot stays internally
+    /// consistent. This exists so `collectReadingHistory` has a value-typed read
+    /// without the collector touching `@Model` rows directly.
+    func fetchAllReadingSessions() async throws -> [ReadingSessionRecord] {
+        let context = ModelContext(modelContainer)
+        let sessions = try context.fetch(FetchDescriptor<ReadingSession>())
+        return sessions.map { session in
+            ReadingSessionRecord(
+                sessionId: session.sessionId,
+                bookFingerprintKey: session.bookFingerprintKey,
+                startedAt: session.startedAt,
+                endedAt: session.endedAt,
+                durationSeconds: session.durationSeconds,
+                pagesRead: session.pagesRead,
+                wordsRead: session.wordsRead,
+                startLocator: session.startLocator,
+                endLocator: session.endLocator,
+                deviceId: session.deviceId,
+                isRecovered: session.isRecovered
+            )
+        }
+    }
+
+    /// Returns every `ReadingStats` row as a value-typed record.
+    ///
+    /// Deduplicates by `bookFingerprintKey` (first-wins), mirroring
+    /// `fetchAllLibraryBooks`'s duplicate-row data-integrity guard. Used by the
+    /// feature #58 WebDAV backup collector (WI-5).
+    func fetchAllReadingStats() async throws -> [ReadingStatsRecord] {
+        let context = ModelContext(modelContainer)
+        let rows = try context.fetch(FetchDescriptor<ReadingStats>())
+        var seen = Set<String>()
+        var records: [ReadingStatsRecord] = []
+        for stats in rows where seen.insert(stats.bookFingerprintKey).inserted {
+            records.append(ReadingStatsRecord(
+                bookFingerprintKey: stats.bookFingerprintKey,
+                totalReadingSeconds: stats.totalReadingSeconds,
+                sessionCount: stats.sessionCount,
+                lastReadAt: stats.lastReadAt,
+                averagePagesPerHour: stats.averagePagesPerHour,
+                averageWordsPerMinute: stats.averageWordsPerMinute,
+                totalPagesRead: stats.totalPagesRead,
+                totalWordsRead: stats.totalWordsRead,
+                longestSessionSeconds: stats.longestSessionSeconds
+            ))
+        }
+        return records
+    }
 }

--- a/vreader/Services/Stats/ReadingStatsAggregator.swift
+++ b/vreader/Services/Stats/ReadingStatsAggregator.swift
@@ -105,10 +105,19 @@ actor ReadingStatsAggregator {
 
     // MARK: - Per-book rows
 
-    /// Builds the per-book table for `window`: one row per distinct
-    /// `bookFingerprintKey` seen in the sessions, joined to its `Book` for the
-    /// title + cascade-scoped highlight/note counts. A key with no `Book` row
-    /// is a deleted book → `isDeleted`, title "(deleted)", zero counts.
+    /// Builds the per-book table for `window`: one row per book key in the
+    /// UNION of (every live `Book` key) and (every key seen in the sessions).
+    ///
+    /// - A live `Book` with sessions → title + cascade-scoped highlight/note
+    ///   counts + reading seconds derived from its sessions.
+    /// - A live `Book` with NO sessions → still shown as a `0m` row (plan
+    ///   edge case (a)) — `lastReadAt` nil, in-window seconds 0.
+    /// - A session key with no `Book` row → a deleted book: `isDeleted`,
+    ///   title "(deleted)", zero notes/highlights (cascade-deleted with the
+    ///   `Book`), reading seconds still derived from the surviving sessions.
+    ///
+    /// Reading seconds / `lastReadAt` are derived from `ReadingSession` rows
+    /// ONLY — `ReadingStats` is never read (the F10 consistency model).
     private func computePerBook(
         sessions: [ReadingSession], bookByKey: [String: Book],
         window: ReadingStatsWindow, sort: ReadingDashboardSort,
@@ -120,7 +129,13 @@ actor ReadingStatsAggregator {
             sessionsByKey[session.bookFingerprintKey, default: []].append(session)
         }
 
-        let rows = sessionsByKey.map { key, bookSessions -> PerBookStatsRow in
+        // The row set is the union of live-book keys and session keys: a live
+        // book with no sessions still gets a 0m row; an orphan session key
+        // (deleted book) still surfaces its history.
+        let allKeys = Set(bookByKey.keys).union(sessionsByKey.keys)
+
+        let rows = allKeys.map { key -> PerBookStatsRow in
+            let bookSessions = sessionsByKey[key] ?? []
             let inWindowSeconds = bookSessions
                 .filter { window.contains($0.startedAt, now: now, calendar: calendar) }
                 .reduce(0) { $0 + max(0, $1.durationSeconds) }

--- a/vreader/Services/Stats/ReadingStatsAggregator.swift
+++ b/vreader/Services/Stats/ReadingStatsAggregator.swift
@@ -1,0 +1,151 @@
+// Purpose: Actor that aggregates ReadingSession rows into a dashboard snapshot
+// for feature #58 (reading-time + activity dashboard).
+//
+// Key decisions:
+// - Actor-isolated so a sweep over a large session history runs OFF the main
+//   actor and never janks the UI.
+// - The snapshot is derived ENTIRELY from ReadingSession + Book rows in ONE
+//   ModelContext pass. It does NOT read ReadingStats — every displayed number
+//   (per-window totals, per-book reading-seconds, lastReadAt, lifetimeTotal,
+//   trackingSince) is computed from the session rows. ReadingStats is a derived
+//   cache for the Library list's sort only; recomputing from the source rows
+//   means a stale ReadingStats can never desync the dashboard, and there is no
+//   torn-read window vs a concurrent ReadingSessionTracker write.
+// - `calendarProvider` is a closure, not a stored Calendar, so a long-lived
+//   aggregator picks up a timezone/DST change on the NEXT snapshot.
+//
+// @coordinates-with: ReadingStatsModels.swift, ReadingSession.swift, Book.swift
+
+import Foundation
+import OSLog
+import SwiftData
+
+private let log = Logger(subsystem: "com.vreader.app", category: "ReadingStats")
+
+/// Aggregates `ReadingSession` rows into a `ReadingDashboardSnapshot`.
+actor ReadingStatsAggregator {
+    private let modelContainer: ModelContainer
+    private let calendarProvider: @Sendable () -> Calendar
+
+    /// - Parameters:
+    ///   - modelContainer: the SwiftData container (same one `PersistenceActor` uses).
+    ///   - calendarProvider: resolves the calendar/timezone per snapshot call.
+    ///     Defaults to `.current` so window boundaries follow the device.
+    init(
+        modelContainer: ModelContainer,
+        calendarProvider: @Sendable @escaping () -> Calendar = { .current }
+    ) {
+        self.modelContainer = modelContainer
+        self.calendarProvider = calendarProvider
+    }
+
+    /// Produces one consistent dashboard render.
+    ///
+    /// - Parameters:
+    ///   - window: which window the per-book table is computed for.
+    ///   - sort: the per-book table sort.
+    ///   - now: the reference instant — injectable for deterministic tests.
+    func snapshot(
+        window: ReadingStatsWindow,
+        sort: ReadingDashboardSort,
+        now: Date
+    ) async throws -> ReadingDashboardSnapshot {
+        let calendar = calendarProvider()
+        let context = ModelContext(modelContainer)
+
+        // ONE pass: fetch every session + every book.
+        let sessions = try context.fetch(FetchDescriptor<ReadingSession>())
+        let books = try context.fetch(FetchDescriptor<Book>())
+
+        // Index books by fingerprint key for the per-book join.
+        // First-wins on a duplicate key (mirrors PersistenceActor+Library's
+        // data-integrity guard against duplicate rows).
+        var bookByKey: [String: Book] = [:]
+        for book in books where bookByKey[book.fingerprintKey] == nil {
+            bookByKey[book.fingerprintKey] = book
+        }
+
+        let windowTotals = computeWindowTotals(sessions: sessions, now: now, calendar: calendar)
+        let perBook = computePerBook(
+            sessions: sessions, bookByKey: bookByKey,
+            window: window, sort: sort, now: now, calendar: calendar
+        )
+        let lifetimeTotalSeconds = sessions.reduce(0) { $0 + max(0, $1.durationSeconds) }
+        let trackingSince = sessions.map(\.startedAt).min()
+
+        log.info("dashboard snapshot: \(sessions.count) sessions, \(perBook.count) books, window=\(window.rawValue, privacy: .public)")
+
+        return ReadingDashboardSnapshot(
+            windowTotals: windowTotals,
+            activeWindow: window,
+            perBook: perBook,
+            lifetimeTotalSeconds: lifetimeTotalSeconds,
+            trackingSince: trackingSince
+        )
+    }
+
+    // MARK: - Window totals
+
+    /// Sums `durationSeconds` (clamped to ≥0) per window, bucketing each session
+    /// by whether its `startedAt` falls in the window's half-open `[start, now)`.
+    private func computeWindowTotals(
+        sessions: [ReadingSession], now: Date, calendar: Calendar
+    ) -> [WindowTotal] {
+        ReadingStatsWindow.allCases.map { window in
+            var totalSeconds = 0
+            var sessionCount = 0
+            for session in sessions
+            where window.contains(session.startedAt, now: now, calendar: calendar) {
+                totalSeconds += max(0, session.durationSeconds)
+                sessionCount += 1
+            }
+            return WindowTotal(window: window, totalSeconds: totalSeconds, sessionCount: sessionCount)
+        }
+    }
+
+    // MARK: - Per-book rows
+
+    /// Builds the per-book table for `window`: one row per distinct
+    /// `bookFingerprintKey` seen in the sessions, joined to its `Book` for the
+    /// title + cascade-scoped highlight/note counts. A key with no `Book` row
+    /// is a deleted book → `isDeleted`, title "(deleted)", zero counts.
+    private func computePerBook(
+        sessions: [ReadingSession], bookByKey: [String: Book],
+        window: ReadingStatsWindow, sort: ReadingDashboardSort,
+        now: Date, calendar: Calendar
+    ) -> [PerBookStatsRow] {
+        // Group sessions by book key.
+        var sessionsByKey: [String: [ReadingSession]] = [:]
+        for session in sessions {
+            sessionsByKey[session.bookFingerprintKey, default: []].append(session)
+        }
+
+        let rows = sessionsByKey.map { key, bookSessions -> PerBookStatsRow in
+            let inWindowSeconds = bookSessions
+                .filter { window.contains($0.startedAt, now: now, calendar: calendar) }
+                .reduce(0) { $0 + max(0, $1.durationSeconds) }
+            let lastReadAt = bookSessions
+                .map { $0.endedAt ?? $0.startedAt }
+                .max()
+
+            if let book = bookByKey[key] {
+                return PerBookStatsRow(
+                    id: key, bookFingerprintKey: key, title: book.title, isDeleted: false,
+                    readingSecondsInWindow: inWindowSeconds,
+                    notesCount: book.annotations.count,
+                    highlightsCount: book.highlights.count,
+                    lastReadAt: lastReadAt
+                )
+            } else {
+                // Deleted book: highlights/notes cascade-deleted with the Book.
+                return PerBookStatsRow(
+                    id: key, bookFingerprintKey: key, title: "(deleted)", isDeleted: true,
+                    readingSecondsInWindow: inWindowSeconds,
+                    notesCount: 0, highlightsCount: 0,
+                    lastReadAt: lastReadAt
+                )
+            }
+        }
+        return PerBookStatsRow.sorted(rows, by: sort)
+    }
+}

--- a/vreaderTests/Services/Stats/PersistenceActorStatsReadTests.swift
+++ b/vreaderTests/Services/Stats/PersistenceActorStatsReadTests.swift
@@ -1,0 +1,111 @@
+// Purpose: Tests for PersistenceActor's reading-history read methods
+// (fetchAllReadingSessions / fetchAllReadingStats) added in feature #58 WI-2.
+
+import Foundation
+import SwiftData
+import Testing
+@testable import vreader
+
+@Suite("PersistenceActor reading-history reads")
+struct PersistenceActorStatsReadTests {
+
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema(SchemaV6.models)
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(for: schema, configurations: [config])
+    }
+
+    private func fingerprint(_ seed: String) -> DocumentFingerprint {
+        var hex = ""
+        let bytes = Array(seed.utf8)
+        var i = 0
+        while hex.count < 64 {
+            hex += String(format: "%02x", bytes[i % bytes.count] &+ UInt8(i))
+            i += 1
+        }
+        return DocumentFingerprint(
+            contentSHA256: String(hex.prefix(64)), fileByteCount: 2048, format: .epub
+        )
+    }
+
+    @Test func fetchAllReadingSessionsEmptyStore() async throws {
+        let actor = PersistenceActor(modelContainer: try makeContainer())
+        let sessions = try await actor.fetchAllReadingSessions()
+        #expect(sessions.isEmpty)
+    }
+
+    @Test func fetchAllReadingSessionsProjectsEveryField() async throws {
+        let container = try makeContainer()
+        let fp = fingerprint("alpha")
+        let started = Date(timeIntervalSince1970: 1_000_000)
+        let ended = Date(timeIntervalSince1970: 1_000_600)
+        let context = ModelContext(container)
+        let session = ReadingSession(
+            bookFingerprint: fp, startedAt: started, endedAt: ended,
+            durationSeconds: 600, pagesRead: 12, wordsRead: 3400,
+            deviceId: "device-xyz", isRecovered: true
+        )
+        context.insert(session)
+        try context.save()
+
+        let actor = PersistenceActor(modelContainer: container)
+        let records = try await actor.fetchAllReadingSessions()
+        #expect(records.count == 1)
+        let r = try #require(records.first)
+        #expect(r.sessionId == session.sessionId)
+        #expect(r.bookFingerprintKey == fp.canonicalKey)
+        #expect(r.startedAt == started)
+        #expect(r.endedAt == ended)
+        #expect(r.durationSeconds == 600)
+        #expect(r.pagesRead == 12)
+        #expect(r.wordsRead == 3400)
+        #expect(r.deviceId == "device-xyz")
+        #expect(r.isRecovered == true)
+    }
+
+    @Test func fetchAllReadingStatsProjectsEveryField() async throws {
+        let container = try makeContainer()
+        let fp = fingerprint("bravo")
+        let lastRead = Date(timeIntervalSince1970: 2_000_000)
+        let context = ModelContext(container)
+        let stats = ReadingStats(
+            bookFingerprint: fp, totalReadingSeconds: 7200, sessionCount: 5,
+            lastReadAt: lastRead, averagePagesPerHour: 30.0, averageWordsPerMinute: 220.0,
+            totalPagesRead: 60, totalWordsRead: 26_400, longestSessionSeconds: 1800
+        )
+        context.insert(stats)
+        try context.save()
+
+        let actor = PersistenceActor(modelContainer: container)
+        let records = try await actor.fetchAllReadingStats()
+        #expect(records.count == 1)
+        let r = try #require(records.first)
+        #expect(r.bookFingerprintKey == fp.canonicalKey)
+        #expect(r.totalReadingSeconds == 7200)
+        #expect(r.sessionCount == 5)
+        #expect(r.lastReadAt == lastRead)
+        #expect(r.averagePagesPerHour == 30.0)
+        #expect(r.averageWordsPerMinute == 220.0)
+        #expect(r.totalPagesRead == 60)
+        #expect(r.totalWordsRead == 26_400)
+        #expect(r.longestSessionSeconds == 1800)
+    }
+
+    @Test func fetchAllReadingSessionsReturnsAllRows() async throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+        for i in 0..<5 {
+            context.insert(ReadingSession(
+                bookFingerprint: fingerprint("book\(i)"),
+                startedAt: Date(timeIntervalSince1970: Double(i) * 1000),
+                durationSeconds: 100 + i
+            ))
+        }
+        try context.save()
+
+        let actor = PersistenceActor(modelContainer: container)
+        let records = try await actor.fetchAllReadingSessions()
+        #expect(records.count == 5)
+        #expect(Set(records.map(\.durationSeconds)) == [100, 101, 102, 103, 104])
+    }
+}

--- a/vreaderTests/Services/Stats/ReadingStatsAggregatorTests.swift
+++ b/vreaderTests/Services/Stats/ReadingStatsAggregatorTests.swift
@@ -76,6 +76,32 @@ struct ReadingStatsAggregatorTests {
         ReadingStatsAggregator(modelContainer: container, calendarProvider: { Self.utcCalendar() })
     }
 
+    /// Attaches `n` highlights + `m` annotation notes to the existing Book row
+    /// for `fp` (via the cascade relationship). Must be called after `seedBook`.
+    private func seedAnnotations(
+        _ container: ModelContainer, fp: DocumentFingerprint,
+        highlights: Int, notes: Int
+    ) throws {
+        let context = ModelContext(container)
+        let key = fp.canonicalKey
+        let descriptor = FetchDescriptor<Book>(
+            predicate: #Predicate { $0.fingerprintKey == key }
+        )
+        let book = try #require(context.fetch(descriptor).first)
+        let locator = try #require(Locator.validated(bookFingerprint: fp, page: 1))
+        for _ in 0..<highlights {
+            let hl = Highlight(locator: locator, selectedText: "h")
+            hl.book = book
+            context.insert(hl)
+        }
+        for _ in 0..<notes {
+            let note = AnnotationNote(locator: locator, content: "n")
+            note.book = book
+            context.insert(note)
+        }
+        try context.save()
+    }
+
     // MARK: - Empty / basic
 
     @Test func emptyDatabaseYieldsAllZeroSnapshot() async throws {
@@ -167,6 +193,44 @@ struct ReadingStatsAggregatorTests {
         #expect(snap.total(for: .today).totalSeconds == 0)
         // But within 7d.
         #expect(snap.total(for: .last7Days).totalSeconds == 2400)
+    }
+
+    // MARK: - Zero-session live book (edge case a — Codex WI-2 audit finding)
+
+    @Test func liveBookWithNoSessionsStillShownAsZeroRow() async throws {
+        let container = try makeContainer()
+        let fp = fingerprint("zero")
+        // A live Book row but ZERO ReadingSession rows.
+        try seedBook(container, fp: fp, title: "Unread Book")
+
+        let snap = try await aggregator(container).snapshot(
+            window: .allTime, sort: .default, now: Self.now
+        )
+        // Plan edge case (a): the book is still shown, with 0m.
+        #expect(snap.perBook.count == 1)
+        let row = snap.perBook[0]
+        #expect(row.title == "Unread Book")
+        #expect(row.isDeleted == false)
+        #expect(row.readingSecondsInWindow == 0)
+        #expect(row.lastReadAt == nil)
+    }
+
+    @Test func liveBookHighlightAndNoteCountsMatchRelationships() async throws {
+        let container = try makeContainer()
+        let fp = fingerprint("annotated")
+        try seedBook(container, fp: fp, title: "Annotated Book")
+        try seedAnnotations(container, fp: fp, highlights: 3, notes: 2)
+        try seedSession(container, book: fp,
+                        startedAt: Self.now.addingTimeInterval(-3600), durationSeconds: 120)
+
+        let snap = try await aggregator(container).snapshot(
+            window: .allTime, sort: .default, now: Self.now
+        )
+        #expect(snap.perBook.count == 1)
+        let row = snap.perBook[0]
+        #expect(row.highlightsCount == 3)
+        #expect(row.notesCount == 2)
+        #expect(row.readingSecondsInWindow == 120)
     }
 
     // MARK: - Deleted book

--- a/vreaderTests/Services/Stats/ReadingStatsAggregatorTests.swift
+++ b/vreaderTests/Services/Stats/ReadingStatsAggregatorTests.swift
@@ -1,0 +1,322 @@
+// Purpose: Unit tests for ReadingStatsAggregator — time-window aggregation
+// over ReadingSession + Book rows. Feature #58 WI-2.
+
+import Foundation
+import SwiftData
+import Testing
+@testable import vreader
+
+@Suite("ReadingStatsAggregator")
+struct ReadingStatsAggregatorTests {
+
+    // MARK: - Fixtures
+
+    /// Fixed reference instant: 2026-05-19 14:30:00 UTC.
+    private static var now: Date {
+        var c = DateComponents()
+        c.year = 2026; c.month = 5; c.day = 19
+        c.hour = 14; c.minute = 30; c.second = 0
+        c.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }
+
+    private static func utcCalendar() -> Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }
+
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema(SchemaV6.models)
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(for: schema, configurations: [config])
+    }
+
+    /// A valid fingerprint with a distinct 64-lowercase-hex SHA per seed string.
+    /// The seed is hashed into the SHA so two different seeds → two different keys.
+    private func fingerprint(_ seed: String) -> DocumentFingerprint {
+        // Build 64 hex chars deterministically from the seed's bytes.
+        var hex = ""
+        let bytes = Array(seed.utf8)
+        var i = 0
+        while hex.count < 64 {
+            let byte = bytes[i % bytes.count] &+ UInt8(i)
+            hex += String(format: "%02x", byte)
+            i += 1
+        }
+        let sha = String(hex.prefix(64))
+        return DocumentFingerprint(contentSHA256: sha, fileByteCount: 1024, format: .epub)
+    }
+
+    /// Inserts a ReadingSession into a fresh context and saves.
+    private func seedSession(
+        _ container: ModelContainer, book: DocumentFingerprint,
+        startedAt: Date, durationSeconds: Int, endedAt: Date? = nil
+    ) throws {
+        let context = ModelContext(container)
+        let session = ReadingSession(
+            bookFingerprint: book, startedAt: startedAt,
+            endedAt: endedAt, durationSeconds: durationSeconds
+        )
+        context.insert(session)
+        try context.save()
+    }
+
+    private func seedBook(_ container: ModelContainer, fp: DocumentFingerprint, title: String) throws {
+        let context = ModelContext(container)
+        let provenance = ImportProvenance(
+            source: .localCopy, importedAt: Date(), originalURLBookmarkData: nil
+        )
+        let book = Book(fingerprint: fp, title: title, provenance: provenance)
+        context.insert(book)
+        try context.save()
+    }
+
+    private func aggregator(_ container: ModelContainer) -> ReadingStatsAggregator {
+        ReadingStatsAggregator(modelContainer: container, calendarProvider: { Self.utcCalendar() })
+    }
+
+    // MARK: - Empty / basic
+
+    @Test func emptyDatabaseYieldsAllZeroSnapshot() async throws {
+        let container = try makeContainer()
+        let snap = try await aggregator(container).snapshot(
+            window: .today, sort: .default, now: Self.now
+        )
+        #expect(snap.perBook.isEmpty)
+        #expect(snap.lifetimeTotalSeconds == 0)
+        #expect(snap.trackingSince == nil)
+        #expect(snap.windowTotals.allSatisfy { $0.totalSeconds == 0 && $0.sessionCount == 0 })
+        #expect(snap.windowTotals.count == 7)
+    }
+
+    @Test func singleSessionTodayCountsInEveryWindow() async throws {
+        let container = try makeContainer()
+        let fp = fingerprint("a")
+        try seedBook(container, fp: fp, title: "Book A")
+        // Session 1 hour ago, 600s.
+        try seedSession(container, book: fp,
+                        startedAt: Self.now.addingTimeInterval(-3600), durationSeconds: 600)
+
+        let snap = try await aggregator(container).snapshot(
+            window: .today, sort: .default, now: Self.now
+        )
+        // 1h ago is within today/7d/30d/.../all — all windows count it.
+        for window in ReadingStatsWindow.allCases {
+            #expect(snap.total(for: window).totalSeconds == 600,
+                    "window \(window.rawValue) should total 600s")
+            #expect(snap.total(for: window).sessionCount == 1)
+        }
+        #expect(snap.lifetimeTotalSeconds == 600)
+        #expect(snap.perBook.count == 1)
+        #expect(snap.perBook[0].title == "Book A")
+        #expect(snap.perBook[0].readingSecondsInWindow == 600)
+        #expect(snap.perBook[0].isDeleted == false)
+    }
+
+    @Test func sessionAtExact7dBoundaryCountsTowardWeek() async throws {
+        let container = try makeContainer()
+        let fp = fingerprint("b")
+        try seedBook(container, fp: fp, title: "Boundary Book")
+        // startedAt EXACTLY at now-7d — half-open [start, now) includes the start.
+        let weekStart = Self.now.addingTimeInterval(-7 * 86_400)
+        try seedSession(container, book: fp, startedAt: weekStart, durationSeconds: 300)
+
+        let snap = try await aggregator(container).snapshot(
+            window: .last7Days, sort: .default, now: Self.now
+        )
+        #expect(snap.total(for: .last7Days).totalSeconds == 300)
+        #expect(snap.total(for: .last7Days).sessionCount == 1)
+    }
+
+    @Test func sessionStartedBeforeWindowIsExcluded() async throws {
+        let container = try makeContainer()
+        let fp = fingerprint("c")
+        try seedBook(container, fp: fp, title: "Old Book")
+        // 8 days ago — outside the 7d window, inside 30d.
+        try seedSession(container, book: fp,
+                        startedAt: Self.now.addingTimeInterval(-8 * 86_400), durationSeconds: 500)
+
+        let snap = try await aggregator(container).snapshot(
+            window: .last7Days, sort: .default, now: Self.now
+        )
+        #expect(snap.total(for: .last7Days).totalSeconds == 0)
+        #expect(snap.total(for: .last30Days).totalSeconds == 500)
+        #expect(snap.total(for: .allTime).totalSeconds == 500)
+        // The per-book table (for last7Days) shows the book with 0s in-window.
+        #expect(snap.perBook.count == 1)
+        #expect(snap.perBook[0].readingSecondsInWindow == 0)
+    }
+
+    @Test func sessionCrossingMidnightBucketsByStartedAt() async throws {
+        let container = try makeContainer()
+        let fp = fingerprint("d")
+        try seedBook(container, fp: fp, title: "Midnight Reader")
+        // startedAt 23:50 YESTERDAY (UTC), endedAt 00:30 today. Now is 14:30 today.
+        let cal = Self.utcCalendar()
+        let todayMidnight = cal.startOfDay(for: Self.now)
+        let startedAt = todayMidnight.addingTimeInterval(-10 * 60)  // 23:50 yesterday
+        let endedAt = todayMidnight.addingTimeInterval(30 * 60)     // 00:30 today
+        try seedSession(container, book: fp, startedAt: startedAt,
+                        durationSeconds: 2400, endedAt: endedAt)
+
+        let snap = try await aggregator(container).snapshot(
+            window: .today, sort: .default, now: Self.now
+        )
+        // startedAt is yesterday → NOT in today (today = local-midnight..<now).
+        #expect(snap.total(for: .today).totalSeconds == 0)
+        // But within 7d.
+        #expect(snap.total(for: .last7Days).totalSeconds == 2400)
+    }
+
+    // MARK: - Deleted book
+
+    @Test func bookDeletedSessionsRemainShowsDeletedRowWithZeroCounts() async throws {
+        let container = try makeContainer()
+        let fp = fingerprint("e")
+        // Seed a session but NO Book row (the post-restore scenario).
+        try seedSession(container, book: fp,
+                        startedAt: Self.now.addingTimeInterval(-1800), durationSeconds: 900)
+
+        let snap = try await aggregator(container).snapshot(
+            window: .allTime, sort: .default, now: Self.now
+        )
+        #expect(snap.perBook.count == 1)
+        let row = snap.perBook[0]
+        #expect(row.isDeleted == true)
+        #expect(row.title == "(deleted)")
+        #expect(row.readingSecondsInWindow == 900)
+        // Highlights/notes cascade-deleted with the Book → counts are 0.
+        #expect(row.notesCount == 0)
+        #expect(row.highlightsCount == 0)
+    }
+
+    // MARK: - Per-window table
+
+    @Test func perBookTableReflectsTheRequestedWindow() async throws {
+        let container = try makeContainer()
+        let fp = fingerprint("f")
+        try seedBook(container, fp: fp, title: "Window Book")
+        // One session today (1h ago, 100s), one 20 days ago (200s).
+        try seedSession(container, book: fp,
+                        startedAt: Self.now.addingTimeInterval(-3600), durationSeconds: 100)
+        try seedSession(container, book: fp,
+                        startedAt: Self.now.addingTimeInterval(-20 * 86_400), durationSeconds: 200)
+
+        let todaySnap = try await aggregator(container).snapshot(
+            window: .today, sort: .default, now: Self.now
+        )
+        let monthSnap = try await aggregator(container).snapshot(
+            window: .last30Days, sort: .default, now: Self.now
+        )
+        // today's per-book row counts only the 100s session.
+        #expect(todaySnap.perBook[0].readingSecondsInWindow == 100)
+        // last30Days counts both → 300s.
+        #expect(monthSnap.perBook[0].readingSecondsInWindow == 300)
+    }
+
+    // MARK: - Corrupt / edge data
+
+    @Test func negativeDurationIsClampedToZero() async throws {
+        let container = try makeContainer()
+        let fp = fingerprint("g")
+        try seedBook(container, fp: fp, title: "Corrupt Book")
+        // ReadingSession clamps negatives at the model level — verify the
+        // aggregator's total reflects the clamped value (0), not a negative.
+        try seedSession(container, book: fp,
+                        startedAt: Self.now.addingTimeInterval(-600), durationSeconds: -999)
+
+        let snap = try await aggregator(container).snapshot(
+            window: .today, sort: .default, now: Self.now
+        )
+        #expect(snap.total(for: .today).totalSeconds == 0)
+        #expect(snap.lifetimeTotalSeconds == 0)
+    }
+
+    @Test func trackingSinceIsEarliestSessionStart() async throws {
+        let container = try makeContainer()
+        let fp = fingerprint("h")
+        try seedBook(container, fp: fp, title: "Tracked Book")
+        let oldest = Self.now.addingTimeInterval(-100 * 86_400)
+        try seedSession(container, book: fp, startedAt: oldest, durationSeconds: 60)
+        try seedSession(container, book: fp,
+                        startedAt: Self.now.addingTimeInterval(-3600), durationSeconds: 60)
+
+        let snap = try await aggregator(container).snapshot(
+            window: .allTime, sort: .default, now: Self.now
+        )
+        #expect(snap.trackingSince == oldest)
+    }
+
+    // MARK: - Consistency
+
+    @Test func perBookAllTimeSumEqualsAllTimeWindowTotal() async throws {
+        let container = try makeContainer()
+        let fpA = fingerprint("i"); let fpB = fingerprint("j")
+        try seedBook(container, fp: fpA, title: "Alpha")
+        try seedBook(container, fp: fpB, title: "Bravo")
+        try seedSession(container, book: fpA,
+                        startedAt: Self.now.addingTimeInterval(-3600), durationSeconds: 111)
+        try seedSession(container, book: fpA,
+                        startedAt: Self.now.addingTimeInterval(-7200), durationSeconds: 222)
+        try seedSession(container, book: fpB,
+                        startedAt: Self.now.addingTimeInterval(-1800), durationSeconds: 333)
+
+        let snap = try await aggregator(container).snapshot(
+            window: .allTime, sort: .default, now: Self.now
+        )
+        // The single-ModelContext-pass invariant: sum of per-book in-window
+        // seconds == the allTime window total.
+        let perBookSum = snap.perBook.reduce(0) { $0 + $1.readingSecondsInWindow }
+        #expect(perBookSum == snap.total(for: .allTime).totalSeconds)
+        #expect(perBookSum == 666)
+    }
+
+    @Test func thousandSessionsAggregateCorrectly() async throws {
+        let container = try makeContainer()
+        let fp = fingerprint("k")
+        try seedBook(container, fp: fp, title: "Long History")
+        let context = ModelContext(container)
+        for i in 0..<1000 {
+            // All within the last 365 days, 60s each.
+            let started = Self.now.addingTimeInterval(-Double(i % 300) * 86_400 - 3600)
+            context.insert(ReadingSession(
+                bookFingerprint: fp, startedAt: started, durationSeconds: 60
+            ))
+        }
+        try context.save()
+
+        let snap = try await aggregator(container).snapshot(
+            window: .last365Days, sort: .default, now: Self.now
+        )
+        // 1000 sessions × 60s, all within 365d.
+        #expect(snap.total(for: .last365Days).totalSeconds == 60_000)
+        #expect(snap.total(for: .last365Days).sessionCount == 1000)
+        #expect(snap.lifetimeTotalSeconds == 60_000)
+    }
+
+    @Test func sortIsAppliedToPerBookTable() async throws {
+        let container = try makeContainer()
+        let fpA = fingerprint("l"); let fpB = fingerprint("m")
+        try seedBook(container, fp: fpA, title: "Zeta")     // less reading
+        try seedBook(container, fp: fpB, title: "Aardvark") // more reading
+        try seedSession(container, book: fpA,
+                        startedAt: Self.now.addingTimeInterval(-3600), durationSeconds: 100)
+        try seedSession(container, book: fpB,
+                        startedAt: Self.now.addingTimeInterval(-3600), durationSeconds: 500)
+
+        // readingTime desc → Aardvark (500) first.
+        let byTime = try await aggregator(container).snapshot(
+            window: .allTime,
+            sort: ReadingDashboardSort(field: .readingTime, ascending: false), now: Self.now
+        )
+        #expect(byTime.perBook.map(\.title) == ["Aardvark", "Zeta"])
+
+        // title asc → Aardvark first (alphabetical).
+        let byTitle = try await aggregator(container).snapshot(
+            window: .allTime,
+            sort: ReadingDashboardSort(field: .title, ascending: true), now: Self.now
+        )
+        #expect(byTitle.perBook.map(\.title) == ["Aardvark", "Zeta"])
+    }
+}


### PR DESCRIPTION
## Summary

- Second work item of feature #58. Adds the `ReadingStatsAggregator` actor that builds a `ReadingDashboardSnapshot` from the existing `ReadingSession` / `Book` rows, plus two value-typed `PersistenceActor` read methods the WI-5 backup collector will consume.
- WI-2 is **foundational** — an actor with no user-observable behavior; Gate 5a is satisfied by unit tests + the Gate-4 audit.

Part of feature #665.

## What Changed

New `vreader/Services/Stats/ReadingStatsAggregator.swift`:
- `actor ReadingStatsAggregator` — `snapshot(window:sort:now:) async throws -> ReadingDashboardSnapshot`. Sweeps every `ReadingSession` + every `Book` in **one `ModelContext` pass** and derives all numbers from the session rows.
- **Consistency model (F8/F10)**: the aggregator NEVER reads `ReadingStats`. Per-window totals, per-book reading-seconds, `lastReadAt`, `lifetimeTotalSeconds`, `trackingSince` are all computed from `ReadingSession`. `ReadingStats` stays a derived cache for the Library list's sort only — so a stale stats row cannot desync the dashboard, and there's no torn-read window against a concurrent `ReadingSessionTracker` write.
- Holds a `@Sendable () -> Calendar` provider (not a stored `Calendar`) so window boundaries follow a timezone/DST change on the next snapshot.
- Per-book table = rows for the **union** of live `Book` keys and session keys: a live book with no sessions → a `0m` row (plan edge case (a)); an orphan session key (deleted book) → a `(deleted)` row with zero notes/highlights (cascade-deleted with the `Book`).

`vreader/Services/PersistenceActor+Stats.swift` (+55):
- `fetchAllReadingSessions()` / `fetchAllReadingStats()` — value-typed projections of the two tables for the WI-5 backup collector. `ReadingStats` deduped by key (first-wins).

Tests: `ReadingStatsAggregatorTests.swift` + `PersistenceActorStatsReadTests.swift` — 18 tests across 2 suites.

## WI Status

- WI-1: foundational — merged (PR #982).
- WI-2: foundational — this PR.
- Remaining: WI-3 (`ReadingTimeFormatter.formatDuration`), WI-4 (`ReadingDashboardViewModel`), WI-5 (WebDAV backup section). WI-6 (dashboard UI) is BLOCKED on 4 open product decisions.

## Codex Audit (Gate 4)

2 rounds, thread `019e40b9`, verdict **ship-as-is**. Round 1: 0 Critical / 1 High / 1 Medium — High was a zero-session live book omitted from the per-book table (plan edge case (a)); fixed by unioning the key sets. Medium was missing test coverage; fixed. Round 2: zero open findings.

Audit log: `.claude/codex-audits/feat-feature-58-wi-2-stats-aggregator-audit.md`

## Validation

- [x] `xcodebuild test` passes — 18 WI-2 tests in 2 suites (iPhone 17 Pro Simulator)
- [x] Tests cover changed behavior (TDD: RED → GREEN)
- [x] Codex audit loop completed (2 rounds, verdict: ship-as-is)
- [x] Docs sync — `docs/architecture.md` Services Layer table gains `ReadingStatsAggregator` (separate commit)
- [x] Version bumped: 3.36.20 → 3.36.21

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: **foundational** — an actor with no user-observable behavior. Unit + the Gate-4 audit are sufficient; no device verification required.
- What was run: the 18-test WI-2 suite on iPhone 17 Pro Simulator — all green. Smoke build of the full app succeeds post-bump.

## Type of Change

- [x] Feature WI (Part of feature #665)

🤖 Generated with [Claude Code](https://claude.com/claude-code)