### PR TITLE
chore: bump version to 3.36.24 — resolve WI-4 / #997 version collision

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 538
-        MARKETING_VERSION: 3.36.23
+        CURRENT_PROJECT_VERSION: 539
+        MARKETING_VERSION: 3.36.24
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5614,13 +5614,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 538;
+				CURRENT_PROJECT_VERSION = 539;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.23;
+				MARKETING_VERSION = 3.36.24;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5764,13 +5764,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 538;
+				CURRENT_PROJECT_VERSION = 539;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.23;
+				MARKETING_VERSION = 3.36.24;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

- Feature #62 WI-4 (PR #996) and feature #64 WI-7 (PR #997) both merged at `MARKETING_VERSION 3.36.23` / build 538 in parallel. The tag `v3.36.23` was cut for #997, leaving `main`'s HEAD carrying a non-monotonic version.
- This bumps `main` to `3.36.24` / build 539 so the version line is monotonic and the next PR has a clean base.

## Type of Change

- [x] Chore — pure version-correction meta-fix. References no bug/feature row, so it is exempt from the fix-or-implement merge gate (AGENTS.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)