### PR TITLE
feat(#58 WI-4): ReadingDashboardViewModel — window/sort state + persistence

### DIFF
--- a/.claude/codex-audits/feat-feature-58-wi-4-dashboard-viewmodel-audit.md
+++ b/.claude/codex-audits/feat-feature-58-wi-4-dashboard-viewmodel-audit.md
@@ -1,0 +1,46 @@
+---
+branch: feat/feature-58-wi-4-dashboard-viewmodel
+threadId: 019e40cb-56e6-7e23-81ff-29484ac51541
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+# Gate 4 — Implementation Audit: feature #58 WI-4 (ReadingDashboardViewModel)
+
+Codex MCP (read-only sandbox), thread `019e40cb-56e6-7e23-81ff-29484ac51541`.
+Author/auditor separation per rule 48: Codex is a separate process.
+
+Changed files:
+- `vreader/ViewModels/ReadingDashboardViewModel.swift` (NEW, ~120 lines) — the VM
+- `vreader/Services/Stats/ReadingStatsAggregator.swift` (MODIFIED) — adds `ReadingStatsAggregating` protocol, conforms the actor
+- `vreaderTests/ViewModels/ReadingDashboardViewModelTests.swift` (NEW)
+
+## Round 1 — findings (0 Critical / 1 High / 1 Medium / 0 Low)
+
+| # | Severity | Issue | Resolution |
+|---|---|---|---|
+| 1 | High | `refresh()` had no in-flight request tracking — overlapping `load()` / `selectWindow()` / `selectSort()` calls could complete out of order, letting a stale earlier result overwrite a newer snapshot while `activeWindow`/`sort` already point at newer state. | **Fixed.** `refresh()` claims a monotonic `latestRequestID`, captures `activeWindow`/`sort` into locals before the `await`, and after the aggregator returns (success OR catch) `guard requestID == latestRequestID else { return }` — a superseded request drops its result. |
+| 2 | Medium | The suite covered serialized happy-path/error cases but never overlapping refreshes, so the stale-result bug would ship undetected. | **Fixed.** Added `staleRefreshDoesNotOverwriteANewerSnapshot` — a `GatedAggregator` actor whose `snapshot` blocks on a per-window `CheckedContinuation` gate the test opens. The test starts request A (today) + request B (last30Days), releases the NEWER B first, then A, and asserts the VM keeps B's snapshot. Fails on pre-fix code, passes on the fix. |
+
+Round-1 confirmation: the VM otherwise matches the WI-4 contract — owns
+`activeWindow`/`sort`, drives the aggregator, exposes `snapshot`, persists+
+restores the sort under `stats.dashboardSort`, does NOT persist the window
+(fresh dashboard opens on "Today" — correct per the design). The corrupt-sort
+fallback and error-clears-after-success paths are correct. Swift 6 boundary is
+sound — calling an `async` method on an `any ReadingStatsAggregating & Sendable`
+from `@MainActor` is fine, and `actor ReadingStatsAggregator: ReadingStatsAggregating`
+conformance is correct. `private(set)` on the observable props is fine.
+
+## Round 2 — verification
+
+Codex confirmed both findings resolved, zero open findings at any severity, no
+remaining merge blocker. The implementing session ran the gate: **11 tests in 1
+suite pass** (`xcodebuild test`, iPhone 17 Pro Simulator).
+
+## Verdict
+
+**ship-as-is** (round 2). 0 open Critical/High/Medium/Low findings after 2
+rounds (rule-47 max is 3). WI-4 is a foundational WI — a ViewModel with no
+user-visible surface yet (the View is WI-6); Gate 5a is satisfied by unit
+tests + this audit.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 539
-        MARKETING_VERSION: 3.36.24
+        CURRENT_PROJECT_VERSION: 540
+        MARKETING_VERSION: 3.36.25
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5622,13 +5622,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 539;
+				CURRENT_PROJECT_VERSION = 540;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.24;
+				MARKETING_VERSION = 3.36.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5772,13 +5772,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 539;
+				CURRENT_PROJECT_VERSION = 540;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.24;
+				MARKETING_VERSION = 3.36.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -585,6 +585,7 @@
 		81498F908FAF97F421A3C35F /* AIReaderPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF113D7E83A1CE51F417258 /* AIReaderPanel.swift */; };
 		8178696A12B2FC6B462D9C3A /* LibraryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1563E77E28434568F45736 /* LibraryViewModelTests.swift */; };
 		818D42F1D3D6548605297F83 /* ReaderFormatHosts.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF23B1A0CC0BE35DF685C5FA /* ReaderFormatHosts.swift */; };
+		81A664E468D49A74D54DA6F6 /* ReadingDashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44B5BF67DD0616C80294ABC7 /* ReadingDashboardViewModel.swift */; };
 		81A875C50C5A9B68C2E415D1 /* TXTChapterIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = F02AE770B22BFE6D2F175A1A /* TXTChapterIndex.swift */; };
 		8211FDEF87BCA2DA4EBD357A /* BookSourceHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDE356D5C7D77EC05E82520 /* BookSourceHTTPClient.swift */; };
 		82152E9125D5620CACFCEFF3 /* ReaderSelectionEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7C59839A119870BE9B6FF9 /* ReaderSelectionEventTests.swift */; };
@@ -828,6 +829,7 @@
 		BC21F67D7A4B46F5E0DCDD0B /* BookSourcePipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 823A94AB15D85579FB0C8D5C /* BookSourcePipeline.swift */; };
 		BC8176068C3971A15B250D51 /* BookSourceRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50BDCA7532338D53368A59B /* BookSourceRules.swift */; };
 		BCC790D30A8ADB356EC0FC12 /* ReaderTheme+ToV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DC587ABC24E47B3D4A068F /* ReaderTheme+ToV2.swift */; };
+		BCD23D1F63752841E3A32F70 /* ReadingDashboardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8180BC93B7839BF9878114F1 /* ReadingDashboardViewModelTests.swift */; };
 		BCD2C70D406E07C400C83333 /* BookDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680EB356F2540A7274E57F1D /* BookDetailsViewModelTests.swift */; };
 		BCD417D086985BB3B6605499 /* progress.js in Resources */ = {isa = PBXBuildFile; fileRef = 2B41E933EF843E0AC73B3E37 /* progress.js */; };
 		BD2207EF713FA796A840EF15 /* TextHighlightHitTesterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AD0B57E130DE8620C8AEC4 /* TextHighlightHitTesterTests.swift */; };
@@ -1426,6 +1428,7 @@
 		4459ED2850B657C535C05F16 /* DebugPositionResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugPositionResolverTests.swift; sourceTree = "<group>"; };
 		445A7C6C3D4466A57B29BDA8 /* ReaderSettingsSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsSheetTests.swift; sourceTree = "<group>"; };
 		44AEA97F06DB06AEAFB526F1 /* HighlightPopoverModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPopoverModifier.swift; sourceTree = "<group>"; };
+		44B5BF67DD0616C80294ABC7 /* ReadingDashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDashboardViewModel.swift; sourceTree = "<group>"; };
 		44FC663099F4228086D7EA54 /* FoliateSpikeViewTTSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateSpikeViewTTSTests.swift; sourceTree = "<group>"; };
 		453A5F80C353442B3C88C611 /* HighlightPaintColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPaintColor.swift; sourceTree = "<group>"; };
 		4559FD0011E0F990013EAE48 /* TXTChapterHighlightCreationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterHighlightCreationTests.swift; sourceTree = "<group>"; };
@@ -1702,6 +1705,7 @@
 		80CB6321B674BB16BF0DEC55 /* legacy-backup-no-manifest.vreader.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = "legacy-backup-no-manifest.vreader.zip"; sourceTree = "<group>"; };
 		80ED96E0CBD0FFF1335B41D0 /* LibraryViewModelImportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModelImportTests.swift; sourceTree = "<group>"; };
 		815A2F870C4D8EC102254ACC /* PersistenceActor+Bookmarks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+Bookmarks.swift"; sourceTree = "<group>"; };
+		8180BC93B7839BF9878114F1 /* ReadingDashboardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDashboardViewModelTests.swift; sourceTree = "<group>"; };
 		81816D53162945723E79FB9B /* SyncOutboundQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncOutboundQueue.swift; sourceTree = "<group>"; };
 		8188B21271D103070EE8CDE6 /* SyncConflictResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncConflictResolver.swift; sourceTree = "<group>"; };
 		818F6161D2855C49A12AF5A6 /* TOCBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOCBuilder.swift; sourceTree = "<group>"; };
@@ -2539,6 +2543,7 @@
 				513AE679E0A5DBFFBB0AF6BD /* MDReaderViewModelTests.swift */,
 				7FE836F3F86B2666BF00B8E3 /* NotePreviewViewModelTests.swift */,
 				5D7F4F4B985D58E03A78680D /* PDFReaderViewModelTests.swift */,
+				8180BC93B7839BF9878114F1 /* ReadingDashboardViewModelTests.swift */,
 				576F111E93E863C656BDEC70 /* SearchViewModelTests.swift */,
 				55633F1E05B29D20C4A4D0D5 /* TXTReaderPositionBackCompatTests.swift */,
 				96A2462C6A873DEC45025230 /* TXTReaderViewModelChapterHeadingTests.swift */,
@@ -3382,6 +3387,7 @@
 				4CAFBF5F34C37595CC8353BC /* NotePreviewViewModel.swift */,
 				43D54AC9AD2556A67C96BD52 /* PDFReaderViewModel.swift */,
 				D363190FCDF47ED48A1D7BC1 /* ReaderLifecycleHelper.swift */,
+				44B5BF67DD0616C80294ABC7 /* ReadingDashboardViewModel.swift */,
 				864A1B050775A46ADBE3304F /* SearchViewModel.swift */,
 				E19A1FE14FDE4829AF0F5913 /* TXTReaderViewModel.swift */,
 				7056486BA460E0BE06235F54 /* UnifiedTextRendererViewModel.swift */,
@@ -4768,6 +4774,7 @@
 				AAE6B9BC238DD37272640F0E /* ReaderThemeV2Tests.swift in Sources */,
 				11F1D99E4B3412CE344A4F16 /* ReaderTypographyTests.swift in Sources */,
 				B4D2A7240900413D3A320FEA /* ReadingDashboardSnapshotTests.swift in Sources */,
+				BCD23D1F63752841E3A32F70 /* ReadingDashboardViewModelTests.swift in Sources */,
 				A3D6C41E3B9BAD5A458D4A7F /* ReadingModeMigrationTests.swift in Sources */,
 				726DA1204DBFE8EBE5852764 /* ReadingProgressBarTests.swift in Sources */,
 				B1DFA851C827F5BB877DD2B8 /* ReadingSessionTests.swift in Sources */,
@@ -5297,6 +5304,7 @@
 				E88F2A1B4A4EEA858F2429DE /* ReaderTopChrome.swift in Sources */,
 				A249585F7042937DAF795EBC /* ReaderTypography.swift in Sources */,
 				6EA1E4475CD190B3E9F9D370 /* ReaderUnifiedCoordinator.swift in Sources */,
+				81A664E468D49A74D54DA6F6 /* ReadingDashboardViewModel.swift in Sources */,
 				DF363EAF99EFB1FA7459795C /* ReadingModeMigration.swift in Sources */,
 				16E0E8B88F2913E822EA56C3 /* ReadingPosition.swift in Sources */,
 				EF1F3F42EE0664A058F2304D /* ReadingPositionPersisting.swift in Sources */,

--- a/vreader/Services/Stats/ReadingStatsAggregator.swift
+++ b/vreader/Services/Stats/ReadingStatsAggregator.swift
@@ -22,8 +22,17 @@ import SwiftData
 
 private let log = Logger(subsystem: "com.vreader.app", category: "ReadingStats")
 
+/// The boundary the dashboard ViewModel depends on, so tests can inject a mock.
+protocol ReadingStatsAggregating: Sendable {
+    func snapshot(
+        window: ReadingStatsWindow,
+        sort: ReadingDashboardSort,
+        now: Date
+    ) async throws -> ReadingDashboardSnapshot
+}
+
 /// Aggregates `ReadingSession` rows into a `ReadingDashboardSnapshot`.
-actor ReadingStatsAggregator {
+actor ReadingStatsAggregator: ReadingStatsAggregating {
     private let modelContainer: ModelContainer
     private let calendarProvider: @Sendable () -> Calendar
 

--- a/vreader/ViewModels/ReadingDashboardViewModel.swift
+++ b/vreader/ViewModels/ReadingDashboardViewModel.swift
@@ -45,6 +45,11 @@ final class ReadingDashboardViewModel {
     private let aggregator: any ReadingStatsAggregating
     private let preferenceStore: (any PreferenceStoring)?
 
+    /// Monotonic request counter. Each `refresh()` claims the next id; a result
+    /// is applied only if it is still the latest — so a slow earlier request
+    /// (e.g. an older window) can never overwrite a newer one's snapshot.
+    private var latestRequestID = 0
+
     /// `PreferenceStoring` key for the persisted dashboard sort.
     static let sortKey = "stats.dashboardSort"
 
@@ -88,13 +93,21 @@ final class ReadingDashboardViewModel {
     // MARK: - Private
 
     private func refresh() async {
+        latestRequestID += 1
+        let requestID = latestRequestID
+        let requestWindow = activeWindow
+        let requestSort = sort
         do {
             let result = try await aggregator.snapshot(
-                window: activeWindow, sort: sort, now: Date()
+                window: requestWindow, sort: requestSort, now: Date()
             )
+            // Drop the result if a newer refresh started while this one ran —
+            // a stale earlier request must not overwrite a fresher snapshot.
+            guard requestID == latestRequestID else { return }
             snapshot = result
             errorMessage = nil
         } catch {
+            guard requestID == latestRequestID else { return }
             log.error("dashboard snapshot failed: \(String(describing: error), privacy: .public)")
             snapshot = nil
             errorMessage = "Couldn't load reading stats. Pull to retry."

--- a/vreader/ViewModels/ReadingDashboardViewModel.swift
+++ b/vreader/ViewModels/ReadingDashboardViewModel.swift
@@ -1,0 +1,103 @@
+// Purpose: ViewModel for the reading-stats dashboard (feature #58).
+//
+// Owns the active time window + per-book sort, drives the ReadingStatsAggregator,
+// exposes the resulting snapshot, and persists the sort selection so it survives
+// app launches.
+//
+// Key decisions:
+// - @Observable + @MainActor for SwiftUI integration (mirrors LibraryViewModel).
+// - The aggregator is injected via the ReadingStatsAggregating protocol so tests
+//   substitute a mock.
+// - The sort persists via PreferenceStoring under "stats.dashboardSort", mirroring
+//   LibraryViewModel's "library.sortOrder" precedent. The window does NOT persist
+//   — a fresh dashboard always opens on "Today" (the default), matching the
+//   committed design's hero default.
+// - An aggregator failure surfaces as `errorMessage` rather than crashing.
+//
+// @coordinates-with: ReadingStatsAggregator.swift, ReadingStatsModels.swift,
+//   PreferenceStore.swift
+
+import Foundation
+import OSLog
+
+private let log = Logger(subsystem: "com.vreader.app", category: "ReadingStats")
+
+@Observable
+@MainActor
+final class ReadingDashboardViewModel {
+
+    // MARK: - Observable state
+
+    /// The most recent dashboard render, or nil before the first load / after an error.
+    private(set) var snapshot: ReadingDashboardSnapshot?
+
+    /// A user-facing error string when the last load failed; nil otherwise.
+    private(set) var errorMessage: String?
+
+    /// The window the per-book table is currently showing.
+    private(set) var activeWindow: ReadingStatsWindow = .today
+
+    /// The active per-book table sort. Restored from `PreferenceStoring` at init.
+    private(set) var sort: ReadingDashboardSort = .default
+
+    // MARK: - Dependencies
+
+    private let aggregator: any ReadingStatsAggregating
+    private let preferenceStore: (any PreferenceStoring)?
+
+    /// `PreferenceStoring` key for the persisted dashboard sort.
+    static let sortKey = "stats.dashboardSort"
+
+    // MARK: - Init
+
+    init(
+        aggregator: any ReadingStatsAggregating,
+        preferenceStore: (any PreferenceStoring)? = nil
+    ) {
+        self.aggregator = aggregator
+        self.preferenceStore = preferenceStore
+
+        // Restore the persisted sort; a missing or corrupt value falls back to default.
+        if let raw = preferenceStore?.string(forKey: Self.sortKey),
+           let restored = ReadingDashboardSort(storageString: raw) {
+            self.sort = restored
+        }
+    }
+
+    // MARK: - Loading
+
+    /// Loads (or reloads) the snapshot for the current window + sort.
+    /// On failure, populates `errorMessage` and leaves `snapshot` cleared.
+    func load() async {
+        await refresh()
+    }
+
+    /// Switches the active window and reloads the per-book table for it.
+    func selectWindow(_ window: ReadingStatsWindow) async {
+        activeWindow = window
+        await refresh()
+    }
+
+    /// Changes the per-book sort, persists it, and reloads the table.
+    func selectSort(_ newSort: ReadingDashboardSort) async {
+        sort = newSort
+        preferenceStore?.set(newSort.storageString, forKey: Self.sortKey)
+        await refresh()
+    }
+
+    // MARK: - Private
+
+    private func refresh() async {
+        do {
+            let result = try await aggregator.snapshot(
+                window: activeWindow, sort: sort, now: Date()
+            )
+            snapshot = result
+            errorMessage = nil
+        } catch {
+            log.error("dashboard snapshot failed: \(String(describing: error), privacy: .public)")
+            snapshot = nil
+            errorMessage = "Couldn't load reading stats. Pull to retry."
+        }
+    }
+}

--- a/vreaderTests/ViewModels/ReadingDashboardViewModelTests.swift
+++ b/vreaderTests/ViewModels/ReadingDashboardViewModelTests.swift
@@ -173,4 +173,68 @@ struct ReadingDashboardViewModelTests {
         #expect(vm.errorMessage == nil)
         #expect(vm.snapshot != nil)
     }
+
+    // MARK: - Out-of-order refresh (Codex WI-4 audit finding)
+
+    /// An aggregator where each call blocks on a per-call gate the test opens
+    /// explicitly — so the test controls completion ordering deterministically.
+    actor GatedAggregator: ReadingStatsAggregating {
+        private var gates: [ReadingStatsWindow: CheckedContinuation<Void, Never>] = [:]
+        private var pending: [ReadingStatsWindow: () -> Void] = [:]
+
+        /// Snapshots are keyed by window so the test can tell which one "won".
+        func snapshot(
+            window: ReadingStatsWindow, sort: ReadingDashboardSort, now: Date
+        ) async throws -> ReadingDashboardSnapshot {
+            // Block until the test releases this window's gate.
+            await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                if let release = pending.removeValue(forKey: window) {
+                    // The test already asked to release this window — go now.
+                    cont.resume()
+                    release()
+                } else {
+                    gates[window] = cont
+                }
+            }
+            return ReadingDashboardSnapshot(
+                windowTotals: [WindowTotal(window: window, totalSeconds: 0, sessionCount: 0)],
+                activeWindow: window, perBook: [],
+                lifetimeTotalSeconds: window == .today ? 1 : 2, trackingSince: nil
+            )
+        }
+
+        /// Releases the blocked `snapshot` call for `window` (or arms a release
+        /// if the call hasn't reached the gate yet).
+        func release(_ window: ReadingStatsWindow) {
+            if let cont = gates.removeValue(forKey: window) {
+                cont.resume()
+            } else {
+                pending[window] = {}
+            }
+        }
+    }
+
+    @Test func staleRefreshDoesNotOverwriteANewerSnapshot() async {
+        let agg = GatedAggregator()
+        let vm = ReadingDashboardViewModel(aggregator: agg, preferenceStore: MockPreferenceStore())
+
+        // Request A (today) starts and blocks on its gate.
+        async let requestA: Void = vm.load()
+        // Give A a turn to reach the aggregator gate.
+        await Task.yield()
+
+        // Request B (last30Days) starts and blocks on its gate.
+        async let requestB: Void = vm.selectWindow(.last30Days)
+        await Task.yield()
+
+        // Release the NEWER request (B) first, then the older one (A).
+        await agg.release(.last30Days)
+        _ = await requestB
+        await agg.release(.today)
+        _ = await requestA
+
+        // The VM must keep B's snapshot — the stale A result is dropped.
+        #expect(vm.activeWindow == .last30Days)
+        #expect(vm.snapshot?.activeWindow == .last30Days)
+    }
 }

--- a/vreaderTests/ViewModels/ReadingDashboardViewModelTests.swift
+++ b/vreaderTests/ViewModels/ReadingDashboardViewModelTests.swift
@@ -1,0 +1,176 @@
+// Purpose: Tests for ReadingDashboardViewModel — window/sort state, snapshot
+// loading, sort persistence, error handling. Feature #58 WI-4.
+
+import Foundation
+import Testing
+@testable import vreader
+
+@MainActor
+@Suite("ReadingDashboardViewModel")
+struct ReadingDashboardViewModelTests {
+
+    // MARK: - Test doubles
+
+    /// A mock aggregator that returns a canned snapshot (or throws).
+    final class MockAggregator: ReadingStatsAggregating, @unchecked Sendable {
+        var snapshotToReturn: ReadingDashboardSnapshot?
+        var errorToThrow: Error?
+        private(set) var callCount = 0
+        private(set) var lastWindow: ReadingStatsWindow?
+        private(set) var lastSort: ReadingDashboardSort?
+
+        func snapshot(
+            window: ReadingStatsWindow, sort: ReadingDashboardSort, now: Date
+        ) async throws -> ReadingDashboardSnapshot {
+            callCount += 1
+            lastWindow = window
+            lastSort = sort
+            if let errorToThrow { throw errorToThrow }
+            return snapshotToReturn ?? Self.emptySnapshot(activeWindow: window)
+        }
+
+        static func emptySnapshot(activeWindow: ReadingStatsWindow) -> ReadingDashboardSnapshot {
+            ReadingDashboardSnapshot(
+                windowTotals: [], activeWindow: activeWindow, perBook: [],
+                lifetimeTotalSeconds: 0, trackingSince: nil
+            )
+        }
+    }
+
+    struct SampleError: Error {}
+
+    private func row(_ key: String, title: String, seconds: Int) -> PerBookStatsRow {
+        PerBookStatsRow(
+            id: key, bookFingerprintKey: key, title: title, isDeleted: false,
+            readingSecondsInWindow: seconds, notesCount: 0, highlightsCount: 0, lastReadAt: nil
+        )
+    }
+
+    private func snapshot(
+        window: ReadingStatsWindow, rows: [PerBookStatsRow], lifetime: Int = 0
+    ) -> ReadingDashboardSnapshot {
+        ReadingDashboardSnapshot(
+            windowTotals: [WindowTotal(window: window, totalSeconds: lifetime, sessionCount: rows.count)],
+            activeWindow: window, perBook: rows,
+            lifetimeTotalSeconds: lifetime, trackingSince: nil
+        )
+    }
+
+    // MARK: - Initial load
+
+    @Test func initialLoadPopulatesSnapshot() async {
+        let agg = MockAggregator()
+        agg.snapshotToReturn = snapshot(
+            window: .today, rows: [row("a", title: "Book A", seconds: 100)], lifetime: 100
+        )
+        let vm = ReadingDashboardViewModel(aggregator: agg, preferenceStore: MockPreferenceStore())
+        await vm.load()
+
+        #expect(vm.snapshot != nil)
+        #expect(vm.snapshot?.perBook.count == 1)
+        #expect(vm.errorMessage == nil)
+        #expect(agg.callCount == 1)
+    }
+
+    @Test func defaultWindowIsTodayAndDefaultSortIsReadingTimeDesc() {
+        let vm = ReadingDashboardViewModel(
+            aggregator: MockAggregator(), preferenceStore: MockPreferenceStore()
+        )
+        #expect(vm.activeWindow == .today)
+        #expect(vm.sort == ReadingDashboardSort.default)
+    }
+
+    // MARK: - Window switching
+
+    @Test func selectingWindowReQueriesAndUpdatesActiveWindow() async {
+        let agg = MockAggregator()
+        let vm = ReadingDashboardViewModel(aggregator: agg, preferenceStore: MockPreferenceStore())
+        await vm.load()
+        #expect(agg.callCount == 1)
+
+        await vm.selectWindow(.last30Days)
+        #expect(vm.activeWindow == .last30Days)
+        #expect(agg.callCount == 2)
+        #expect(agg.lastWindow == .last30Days)
+    }
+
+    @Test func selectingTheSameWindowStillReQueries() async {
+        // Re-tapping the active window is harmless — it just refreshes.
+        let agg = MockAggregator()
+        let vm = ReadingDashboardViewModel(aggregator: agg, preferenceStore: MockPreferenceStore())
+        await vm.load()
+        await vm.selectWindow(.today)  // same as default
+        #expect(vm.activeWindow == .today)
+        #expect(agg.callCount == 2)
+    }
+
+    // MARK: - Sort
+
+    @Test func changingSortReQueriesWithTheNewSort() async {
+        let agg = MockAggregator()
+        let vm = ReadingDashboardViewModel(aggregator: agg, preferenceStore: MockPreferenceStore())
+        await vm.load()
+
+        let newSort = ReadingDashboardSort(field: .title, ascending: true)
+        await vm.selectSort(newSort)
+        #expect(vm.sort == newSort)
+        #expect(agg.lastSort == newSort)
+        #expect(agg.callCount == 2)
+    }
+
+    @Test func changingSortPersistsToPreferenceStore() async {
+        let store = MockPreferenceStore()
+        let agg = MockAggregator()
+        let vm = ReadingDashboardViewModel(aggregator: agg, preferenceStore: store)
+        await vm.load()
+
+        let newSort = ReadingDashboardSort(field: .highlights, ascending: false)
+        await vm.selectSort(newSort)
+        // Persisted under the documented key, as the storage string.
+        #expect(store.string(forKey: ReadingDashboardViewModel.sortKey) == newSort.storageString)
+    }
+
+    @Test func sortIsRestoredFromPreferenceStoreAtConstruction() {
+        let store = MockPreferenceStore()
+        let saved = ReadingDashboardSort(field: .notes, ascending: true)
+        store.set(saved.storageString, forKey: ReadingDashboardViewModel.sortKey)
+
+        let vm = ReadingDashboardViewModel(aggregator: MockAggregator(), preferenceStore: store)
+        #expect(vm.sort == saved)
+    }
+
+    @Test func corruptStoredSortFallsBackToDefault() {
+        let store = MockPreferenceStore()
+        store.setRaw("garbage:not-a-direction", forKey: ReadingDashboardViewModel.sortKey)
+
+        let vm = ReadingDashboardViewModel(aggregator: MockAggregator(), preferenceStore: store)
+        #expect(vm.sort == ReadingDashboardSort.default)
+    }
+
+    // MARK: - Error handling
+
+    @Test func aggregatorErrorSurfacesAsErrorMessageWithoutCrashing() async {
+        let agg = MockAggregator()
+        agg.errorToThrow = SampleError()
+        let vm = ReadingDashboardViewModel(aggregator: agg, preferenceStore: MockPreferenceStore())
+        await vm.load()
+
+        #expect(vm.errorMessage != nil)
+        #expect(vm.snapshot == nil)
+    }
+
+    @Test func errorMessageClearsAfterASuccessfulReload() async {
+        let agg = MockAggregator()
+        agg.errorToThrow = SampleError()
+        let vm = ReadingDashboardViewModel(aggregator: agg, preferenceStore: MockPreferenceStore())
+        await vm.load()
+        #expect(vm.errorMessage != nil)
+
+        // Recover: clear the error, return a snapshot.
+        agg.errorToThrow = nil
+        agg.snapshotToReturn = snapshot(window: .today, rows: [])
+        await vm.load()
+        #expect(vm.errorMessage == nil)
+        #expect(vm.snapshot != nil)
+    }
+}


### PR DESCRIPTION
## Summary

- Fourth work item of feature #58. Adds the `ReadingDashboardViewModel` — the `@MainActor @Observable` VM that owns the dashboard's window/sort state and drives the aggregator.
- WI-4 is **foundational** — a ViewModel with no user-visible surface yet (the View is WI-6); Gate 5a is satisfied by unit tests + the Gate-4 audit.

Part of feature #665.

## What Changed

New `vreader/ViewModels/ReadingDashboardViewModel.swift`:
- `@MainActor @Observable` VM — owns `activeWindow` + `sort`, drives the aggregator via `load()` / `selectWindow(_:)` / `selectSort(_:)`, exposes the `snapshot`, and surfaces an aggregator failure as `errorMessage` (no crash).
- The sort persists via `PreferenceStoring` under `"stats.dashboardSort"` (mirroring `LibraryViewModel`'s `"library.sortOrder"`) and is restored at construction; a corrupt stored value falls back to `.default`. The window does NOT persist — a fresh dashboard opens on "Today".
- **Out-of-order guard**: `refresh()` claims a monotonic `latestRequestID` and drops a superseded request's result, so rapid window/sort taps can't let a stale snapshot win (Codex Gate-4 finding).

`vreader/Services/Stats/ReadingStatsAggregator.swift`:
- Adds a `ReadingStatsAggregating` protocol (the boundary the VM depends on, so tests inject a mock); the actor conforms to it.

Tests: `ReadingDashboardViewModelTests.swift` — 11 tests including a deterministic out-of-order-refresh regression test with a gated aggregator.

## WI Status

- WI-1, WI-2, WI-3: foundational — merged (PRs #982, #994, #995).
- WI-4: foundational — this PR.
- Remaining: WI-5 (WebDAV backup section). WI-6 (dashboard UI) is BLOCKED on 4 open product decisions D1–D4.

## Codex Audit (Gate 4)

2 rounds, thread `019e40cb`, verdict **ship-as-is**. Round 1: 0 Critical, 1 High (out-of-order `refresh()` race — fixed with a monotonic request id), 1 Medium (missing concurrency test — added). Round 2: zero open findings.

Audit log: `.claude/codex-audits/feat-feature-58-wi-4-dashboard-viewmodel-audit.md`

## Validation

- [x] `xcodebuild test` passes — 11 WI-4 tests (iPhone 17 Pro Simulator)
- [x] Tests cover changed behavior (TDD: RED → GREEN)
- [x] Codex audit loop completed (2 rounds, verdict: ship-as-is)
- [x] Docs sync — n/a (a feature-#58-only ViewModel, not shared by ≥2 features)
- [x] Version bumped: 3.36.24 → 3.36.25

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: **foundational** — a ViewModel with no user-visible surface (the View is WI-6, BLOCKED on D1–D4). Unit + the Gate-4 audit are sufficient.
- What was run: the 11-test WI-4 suite on iPhone 17 Pro Simulator — all green. Full-app smoke build succeeds post-bump.

## Type of Change

- [x] Feature WI (Part of feature #665)

🤖 Generated with [Claude Code](https://claude.com/claude-code)