### PR TITLE
feat(#64 WI-8): migrate EPUB container to unified highlight popover

### DIFF
--- a/.claude/codex-audits/feat-feature-64-wi-8-epub-migration-audit.md
+++ b/.claude/codex-audits/feat-feature-64-wi-8-epub-migration-audit.md
@@ -1,0 +1,102 @@
+---
+branch: feat/feature-64-wi-8-epub-migration
+threadId: 019e40cf-b860-78f2-b398-c0bf7a292ecd
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+# Gate-4 Implementation Audit — Feature #64 WI-8 (EPUB container migration)
+
+## Scope
+
+WI-8 of the unified cross-format highlight-action popover — the third
+**behavioral** WI. Migrates the EPUB reader container off feature #55's
+`notePreviewPresenterIfAvailable` (the read-only note preview) onto the unified
+popover's `unifiedHighlightPopoverPresenterIfAvailable`.
+
+- `EPUBReaderContainerView.swift` (MOD) — swapped the attach to
+  `unifiedHighlightPopoverPresenterIfAvailable` passing `highlightCoordinator`
+  as the `mutating:` boundary.
+
+WI-8 is the simplest of the container migrations: a pure one-attach swap. The
+EPUB highlight tap arrives from a JS `highlightTapHandler` channel;
+`EPUBWebViewBridgeCoordinator.handleHighlightTapMessage` posts
+`.readerHighlightTapped` — the unified popover's trigger — and that path is
+unchanged by WI-8. Unlike WI-6 (TXT/MD) and WI-7 (PDF), there is no feature #53
+long-press `UIMenu` wiring to strip: feature #55 already removed it for the web
+host, so `EPUBWebViewBridge` never carried `highlightActionPresenter` /
+`onHighlightTapAction`.
+
+`Feature64EPUBMigrationTests.swift` (NEW) — 2 source-grep tests fencing the
+migration (container attaches `unifiedHighlightPopoverPresenterIfAvailable` with
+`mutating: highlightCoordinator`, not `notePreviewPresenterIfAvailable`).
+
+The feature #55 types are NOT deleted in WI-8 — plan §3.9 defers that to WI-10.
+`Feature55WebHostWiringTests.swift` was intentionally NOT deleted: it tests
+`NotePreviewPresenter`, a live type the still-un-migrated Foliate container
+(WI-9) depends on; it retires in WI-10 with the #55 family.
+
+## Round 1 — Codex `019e40cf-b860-78f2-b398-c0bf7a292ecd`
+
+**No blocking findings.** Codex confirmed each category clean:
+
+- **Correctness vs plan** — WI-8 implements §3.8 exactly: the attach swapped
+  from `notePreviewPresenterIfAvailable` to
+  `unifiedHighlightPopoverPresenterIfAvailable`, and `mutating: highlightCoordinator`
+  is the right EPUB mutation boundary (`HighlightCoordinator` is the production
+  `HighlightMutating` conformer).
+- **Trigger path unchanged** — `EPUBWebViewBridgeCoordinator.handleHighlightTapMessage`
+  still posts `.readerHighlightTapped`, and the new modifier still observes it.
+- **`highlightCoordinator` lifecycle** — safe. It is populated in `.task`; the
+  attach helper is inert when `mutating` is nil; the `@State` flip makes SwiftUI
+  recompute `body` and install the live modifier — the same late-assignment
+  pattern WI-6 used for TXT/MD.
+- **Concurrency / actor safety** — no new `@MainActor` / Sendable hazards.
+- **EPUB chapter handling** — omitting `chapter:` is correct; in this presenter
+  path `chapter` is only display metadata, and EPUB repaint scoping lives inside
+  `HighlightCoordinator.changeColor` via `ChapterScopedHighlightRenderer` /
+  `EPUBHighlightRenderer.currentChapterHref`, not via the modifier argument.
+- **Test coverage** — adequate for WI-8's narrow scope; keeping
+  `Feature55WebHostWiringTests` until WI-10 is the right call (Foliate still
+  depends on the #55 presenter).
+
+One finding:
+
+| # | File:line | Severity | Issue | Fix |
+|---|-----------|----------|-------|-----|
+| F1 | `EPUBReaderContainerView.swift:492` | Low | Stale feature #55 comment drift — the inline comment in `readerContent(...)` still said the EPUB highlight tap is re-homed to `NotePreviewModifier`, but WI-8 changed the attach to `HighlightPopoverModifier`. Code correct; comment misleading (rule-22 violation). | Rewrite the comment for the WI-8 behavior. |
+
+## Resolution
+
+- **F1** — rewrote the `readerContent(...)` comment to describe the current
+  feature #64 WI-8 behavior: the EPUB highlight tap still posts
+  `.readerHighlightTapped` (JS `highlightTapHandler` →
+  `EPUBWebViewBridgeCoordinator.handleHighlightTapMessage`), now observed by the
+  unified popover (`HighlightPopoverModifier`); and that there is no
+  EPUB-specific action presenter to wire (the web host never carried feature
+  #53's long-press inline menu).
+
+## Round 2 — Codex `019e40cf-b860-78f2-b398-c0bf7a292ecd` (re-audit of the fix)
+
+Verdict: **"The Low finding is resolved... There are no remaining open
+Critical/High/Medium findings for WI-8. No blocking findings."**
+
+## Verdict
+
+**ship-as-is** — 2 rounds (round 1 found zero production findings + 1 Low
+comment-sync; round 2 clean).
+
+## Gate-5a verification note
+
+WI-8 is behavioral. The Gate-5a XCUITest slice (create an EPUB highlight, tap
+it, assert the unified popover) depends on creating a highlight first via the
+in-app selection flow — blocked by the same pre-existing harness defect that
+blocked WI-6/WI-7 (**Bug #237 / GH #986** — a long-press in an XCUITest
+surfaces no "Highlight" affordance; reproduces on the repo's own unmodified
+gesture-verification tests on `origin/main`, independent of feature #64). WI-8's
+behavioral delta is verified by the unit-test layer: the 2
+`Feature64EPUBMigrationTests` source-grep fences, plus the unchanged EPUB
+highlight regression suites (`EPUBHighlightTapBridge`, `EPUBHighlightActions`,
+`EPUBHighlightBridge`, `Feature55WebHostWiringTests` — 38 tests green) and a
+clean full app build.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 540
-        MARKETING_VERSION: 3.36.25
+        CURRENT_PROJECT_VERSION: 541
+        MARKETING_VERSION: 3.36.26
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		1C78AB9020A2E03A196FA6A1 /* ChapterProgressCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 936C16A4F1B2B55E63922EE7 /* ChapterProgressCalculator.swift */; };
 		1C9B4E21A97013A7CC409925 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DAC8E20A001D7803A16AAD1 /* SearchView.swift */; };
 		1CB7C39AC6FE3B715D4B4305 /* V1toV2Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB16317C72EB6BBB61D77030 /* V1toV2Migration.swift */; };
+		1CE79EFAA809405FA4A0FA99 /* Feature64EPUBMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E89BEB1454E17061367313 /* Feature64EPUBMigrationTests.swift */; };
 		1D0B7D11E74A0E06F27A9F8B /* EPUBLayoutPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CF348591A8246AA1524CD10 /* EPUBLayoutPreference.swift */; };
 		1D504D1EB7BAFF76A2B9F001 /* HighlightActionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEF00B7A753219DC31C8AF7 /* HighlightActionPresenter.swift */; };
 		1D61E44D67F37555FDEA9B6C /* TXTFileLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B42D93C357CAAFB4261D93 /* TXTFileLoader.swift */; };
@@ -1984,6 +1985,7 @@
 		C2780A3796872F31F1666DA7 /* ReaderTOCBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTOCBuilder.swift; sourceTree = "<group>"; };
 		C2997AAAB34DF84E64DC0DB4 /* MOBICoverExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MOBICoverExtractor.swift; sourceTree = "<group>"; };
 		C2D49361893EE9956D6EC5DB /* TXTOffsetMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTOffsetMapper.swift; sourceTree = "<group>"; };
+		C2E89BEB1454E17061367313 /* Feature64EPUBMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature64EPUBMigrationTests.swift; sourceTree = "<group>"; };
 		C3C15E361FF460BCE57B8675 /* EPUBParserProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBParserProtocol.swift; sourceTree = "<group>"; };
 		C3EF8CE8D52815CF5156953C /* WebDAVProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProvider.swift; sourceTree = "<group>"; };
 		C3F1695C0E7481CB3EA2B8A3 /* WebDAVBackupIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVBackupIntegrationTests.swift; sourceTree = "<group>"; };
@@ -2681,6 +2683,7 @@
 				003A86C3EF12A6B1DD4F5201 /* EPUBWebViewBridgeCoordinatorTests.swift */,
 				ABFBA14606BD14D14A8D5500 /* EPUBWebViewBridgeTests.swift */,
 				3422A641DD03B2ACCB6645EA /* Feature55WebHostWiringTests.swift */,
+				C2E89BEB1454E17061367313 /* Feature64EPUBMigrationTests.swift */,
 				62B304D30B717A1AB66C2A5B /* Feature64PDFMigrationTests.swift */,
 				1E4E3B1DC47242FC7A17BD69 /* Feature64TXTMDMigrationTests.swift */,
 				469B267E0D3DB05D1D8F530A /* FoliateHighlightJSBridgeTests.swift */,
@@ -4588,6 +4591,7 @@
 				E7493CC6D24CE5FD1922F9D0 /* ErrorMessageAuditorTests.swift in Sources */,
 				700CFFEC7C74E0532A0271F4 /* ExportTestFixtures.swift in Sources */,
 				5263D4201B4ABDDE4DF5FC14 /* Feature55WebHostWiringTests.swift in Sources */,
+				1CE79EFAA809405FA4A0FA99 /* Feature64EPUBMigrationTests.swift in Sources */,
 				49247074A9377434E7854644 /* Feature64PDFMigrationTests.swift in Sources */,
 				FE6F700872F797C727EECB85 /* Feature64TXTMDMigrationTests.swift in Sources */,
 				982FDBDA893DC7DA931711C7 /* FeatureFlagsTests.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5626,13 +5626,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 540;
+				CURRENT_PROJECT_VERSION = 541;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.25;
+				MARKETING_VERSION = 3.36.26;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5776,13 +5776,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 540;
+				CURRENT_PROJECT_VERSION = 541;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.25;
+				MARKETING_VERSION = 3.36.26;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Views/Reader/EPUBReaderContainerView.swift
+++ b/vreader/Views/Reader/EPUBReaderContainerView.swift
@@ -323,15 +323,19 @@ struct EPUBReaderContainerView: View {
         .sheet(isPresented: $showNoteSheet) {
             noteInputSheet
         }
-        // Feature #55 WI-7: attach the tap-on-annotated-text note preview.
+        // Feature #64 WI-8: a tap on a persisted EPUB highlight opens the
+        // unified cross-format highlight-action popover (color / note / copy /
+        // share / delete) — superseding feature #55's read-only note preview.
         // EPUB highlight taps arrive from the JS `highlightTapHandler`
         // channel; `EPUBWebViewBridgeCoordinator.handleHighlightTapMessage`
-        // posts `.readerHighlightTapped`, which `NotePreviewModifier`
-        // (attached here) observes to present the note preview. Inert in
-        // SwiftUI previews / test harnesses where `modelContainer` is nil.
-        .notePreviewPresenterIfAvailable(
+        // posts `.readerHighlightTapped`, which `HighlightPopoverModifier`
+        // (attached here) observes. `mutating` is the EPUB `HighlightCoordinator`
+        // (over `EPUBHighlightRenderer`). Inert in SwiftUI previews / test
+        // harnesses where `modelContainer` is nil.
+        .unifiedHighlightPopoverPresenterIfAvailable(
             modelContainer: modelContainer,
             bookFingerprintKey: viewModel.bookFingerprintKey,
+            mutating: highlightCoordinator,
             theme: settingsStore?.theme ?? .paper
         )
         // Feature #60 WI-12 (#795): keep the Photo background-image data
@@ -485,12 +489,15 @@ struct EPUBReaderContainerView: View {
                 )
                 SelectionPopoverRequest.post(selection: info, requestToken: token)
             },
-            // Feature #55 WI-7: the EPUB highlight tap is re-homed to the
-            // #55 note preview (`NotePreviewModifier` on the container
-            // observes `.readerHighlightTapped`). The legacy #53 tap-time
-            // inline delete menu is dropped for EPUB v1 — so the bridge no
-            // longer takes a `highlightActionPresenter` / `onHighlightTapAction`.
-            // Highlight deletion stays reachable via the Annotations panel.
+            // Feature #64 WI-8: the EPUB highlight tap still posts
+            // `.readerHighlightTapped` (from the JS `highlightTapHandler`
+            // channel via `EPUBWebViewBridgeCoordinator.handleHighlightTapMessage`),
+            // now observed by the unified highlight-action popover
+            // (`HighlightPopoverModifier` on the container) — color / note /
+            // copy / share / delete. There is no EPUB-specific action
+            // presenter to wire: the web host never carried feature #53's
+            // long-press inline menu, so the bridge takes no
+            // `highlightActionPresenter` / `onHighlightTapAction`.
             onPageDidFinishLoad: { evaluateJS in
                 restoreHighlightsOnLoad(evaluateJS: evaluateJS)
             },

--- a/vreaderTests/Views/Reader/Feature64EPUBMigrationTests.swift
+++ b/vreaderTests/Views/Reader/Feature64EPUBMigrationTests.swift
@@ -1,0 +1,68 @@
+// Purpose: Feature #64 WI-8 — guards the migration of the EPUB reader
+// container from feature #55's `notePreviewPresenterIfAvailable` (the
+// read-only note preview) to the unified highlight-action popover's
+// `unifiedHighlightPopoverPresenterIfAvailable`.
+//
+// WI-8's behavioral change: a *tap* on an existing EPUB highlight opens the
+// unified highlight-action popover (color / note / copy / share / delete) —
+// NOT feature #55's read-only note callout. The EPUB highlight tap arrives
+// from the JS `highlightTapHandler` channel; `EPUBWebViewBridgeCoordinator`
+// posts `.readerHighlightTapped`, which the unified popover observes (the
+// same trigger feature #55 used). EPUB never carried feature #53's long-press
+// `UIMenu` (feature #55 already removed it for the web host), so — unlike
+// WI-6/WI-7 — there is no `highlightActionPresenter` / `onHighlightTapAction`
+// bridge wiring to strip; WI-8 is purely the attach swap.
+//
+// This source-grep test fences the WI-8 migration of `EPUBReaderContainerView`;
+// the end-to-end behavior (tap → unified popover) is exercised at Gate 5
+// device verification.
+
+#if canImport(UIKit)
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("Feature #64 WI-8 — EPUB container migration")
+@MainActor
+struct Feature64EPUBMigrationTests {
+
+    /// Repo root resolved by walking up from this test file:
+    /// `vreaderTests/Views/Reader/` → repo root.
+    private static func epubContainerSource(testFilePath: String = #filePath) throws -> String {
+        let repoRoot = URL(fileURLWithPath: testFilePath)
+            .deletingLastPathComponent()  // Reader/
+            .deletingLastPathComponent()  // Views/
+            .deletingLastPathComponent()  // vreaderTests/
+            .deletingLastPathComponent()  // repo root
+        let url = repoRoot
+            .appendingPathComponent("vreader/Views/Reader/EPUBReaderContainerView.swift")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    @Test("EPUB container attaches the unified popover, not feature #55's note preview")
+    func epubAttachesUnifiedHighlightPopoverPresenter() throws {
+        let source = try Self.epubContainerSource()
+        #expect(
+            source.contains("unifiedHighlightPopoverPresenterIfAvailable"),
+            "EPUBReaderContainerView must attach `unifiedHighlightPopoverPresenterIfAvailable` (feature #64 WI-8)."
+        )
+        #expect(
+            !source.contains("notePreviewPresenterIfAvailable"),
+            "EPUBReaderContainerView must no longer attach `notePreviewPresenterIfAvailable` — superseded by the unified popover (feature #64 WI-8)."
+        )
+    }
+
+    @Test("EPUB container passes its HighlightCoordinator as the mutating boundary")
+    func epubPassesHighlightCoordinatorAsMutating() throws {
+        let source = try Self.epubContainerSource()
+        // Pin the plan-critical `mutating:` boundary — the unified popover's
+        // color / note / delete actions are inert if `mutating` regresses to
+        // `nil` or the wrong object. EPUB's `HighlightMutating` is its
+        // `HighlightCoordinator` (over `EPUBHighlightRenderer`).
+        #expect(
+            source.contains("mutating: highlightCoordinator"),
+            "EPUBReaderContainerView must pass `mutating: highlightCoordinator` to the unified popover (feature #64 WI-8)."
+        )
+    }
+}
+#endif


### PR DESCRIPTION
Part of feature #822 — the unified cross-format highlight-action popover. This
is **WI-8**, the third behavioral WI (WI-6 migrated TXT/MD, WI-7 PDF).

## What this does

Migrates the EPUB reader container off feature #55's
`notePreviewPresenterIfAvailable` (the read-only note preview) onto the unified
popover's `unifiedHighlightPopoverPresenterIfAvailable`. A *tap* on a persisted
EPUB highlight now opens the unified highlight-action popover (color / note /
copy / share / delete).

## Changes

- **`EPUBReaderContainerView`** — swap the attach helper to
  `unifiedHighlightPopoverPresenterIfAvailable`, pass `highlightCoordinator`
  (over `EPUBHighlightRenderer`) as the `HighlightMutating` boundary. The stale
  feature #55 comment in `readerContent(...)` is rewritten to the WI-8 behavior
  (rule 22).

WI-8 is a pure one-attach swap — the simplest of the container migrations. The
EPUB highlight tap arrives from the JS `highlightTapHandler` channel;
`EPUBWebViewBridgeCoordinator.handleHighlightTapMessage` posts
`.readerHighlightTapped` (the unified popover's trigger) and that path is
unchanged. Unlike WI-6 (TXT/MD) and WI-7 (PDF), there is **no** feature #53
long-press `UIMenu` wiring to strip — feature #55 already removed it for the
web host, so `EPUBWebViewBridge` never carried `highlightActionPresenter` /
`onHighlightTapAction`.

- **Tests** — add `Feature64EPUBMigrationTests` (source-grep fences: the EPUB
  container attaches the unified popover with `mutating: highlightCoordinator`,
  not #55's `notePreviewPresenterIfAvailable`).

The feature #55 types are **not** deleted here — plan §3.9 defers that to
WI-10, after all 5 reader containers migrate. `Feature55WebHostWiringTests` is
intentionally kept: it tests `NotePreviewPresenter`, a live type the
still-un-migrated Foliate container (WI-9) depends on; it retires in WI-10.

## Gate 3 — TDD

RED: the 2 migration-guard tests fail on the unmodified EPUB source. GREEN:
both `Feature64EPUBMigrationTests` pass; 38 tests across the EPUB highlight
regression suites (`EPUBHighlightTapBridge`, `EPUBHighlightActions`,
`EPUBHighlightBridge`, `Feature55WebHostWiringTests`) green; full app build
succeeds.

## Gate 4 — Implementation audit

Codex `019e40cf`, 2 rounds, **ship-as-is**. Round 1 found zero production-code
correctness findings + 1 Low (a stale feature #55 comment); fixed by rewriting
it. Round 2 clean. Audit log:
`.claude/codex-audits/feat-feature-64-wi-8-epub-migration-audit.md`.

## Gate 5 — Verification

WI-8 is behavioral. The Gate-5a XCUITest slice (create an EPUB highlight, tap
it, assert the unified popover) depends on creating a highlight first — blocked
by the same pre-existing harness defect that blocked WI-6/WI-7
(**Bug #237 / GH #986** — a long-press in an XCUITest surfaces no "Highlight"
affordance; reproduces on the repo's own unmodified gesture-verification tests
on `origin/main`, independent of feature #64).

WI-8's behavioral delta is verified by the unit-test layer instead: the 2
`Feature64EPUBMigrationTests` source-grep fences, plus the unchanged EPUB
highlight regression suites and a clean full app build.

## Version

Patch bump to `3.36.26` (behavioral WI, not the final WI of the feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)