### PR TITLE
feat(#58 WI-5): WebDAV backup reading-history section

### DIFF
--- a/.claude/codex-audits/feat-feature-58-wi-5-backup-reading-history-audit.md
+++ b/.claude/codex-audits/feat-feature-58-wi-5-backup-reading-history-audit.md
@@ -1,0 +1,57 @@
+---
+branch: feat/feature-58-wi-5-backup-reading-history
+threadId: 019e40db-fca3-7ad1-bf46-eaee4a77a6f6
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+# Gate 4 — Implementation Audit: feature #58 WI-5 (WebDAV backup reading-history section)
+
+Codex MCP (read-only sandbox), thread `019e40db-fca3-7ad1-bf46-eaee4a77a6f6`.
+Author/auditor separation per rule 48: Codex is a separate process.
+
+Changed production files:
+- `vreader/Services/Backup/BackupReadingHistory.swift` (NEW) — section DTOs
+- `vreader/Services/Backup/BackupSectionDTOs.swift` (MODIFIED) — `kBackupCurrentSchemaVersion` 1→2, `kBackupAcceptedSchemaVersions` {1,2}
+- `vreader/Services/Backup/BackupDataRestorer.swift` (MODIFIED) — accepted-set validation + `restoreReadingHistory`
+- `vreader/Services/Backup/BackupDataCollector.swift` (MODIFIED) — `collectReadingHistory`
+- `vreader/Services/Backup/WebDAVProvider.swift` (MODIFIED) — protocol additions + default impls, collect tuple + restore loop
+- `vreader/Services/PersistenceActor+ReadingHistory.swift` (NEW) — `restoreReadingHistory` upsert
+- `docs/architecture.md` (doc-sync)
+- `vreaderTests/Services/Backup/BackupReadingHistoryTests.swift` (NEW)
+- `vreaderTests/Services/Backup/BackupDataCollectorRestorerTests.swift` (MODIFIED — schema-version test updated for the v2 bump)
+
+## Round 1 — findings (0 Critical / 1 High / 1 Medium / 1 Low)
+
+| # | Severity | Issue | Resolution |
+|---|---|---|---|
+| 1 | High | `collectReadingHistory` used `try? ?? []` for the persistence fetches — a read failure would silently emit an empty `reading-history.json`, discarding the user's entire reading history on the next restore. | **Fixed.** Removed the `try?` fallbacks; both fetches are `try await`, so a failure propagates and fails `WebDAVProvider.backup()` loudly. (The collector consumes a concrete `PersistenceActor`, so a deterministic failure-path test would need a new protocol seam — out of WI-5 scope; Codex agreed this is not a blocker.) |
+| 2 | Medium | The suite never exercised `startLocatorJSON`/`endLocatorJSON` (the F2 shape change) nor the malformed-locator degradation path. | **Fixed.** Added `restoreRoundTripPreservesStartAndEndLocators` and `malformedLocatorJSONDegradesToNilSessionStillRestores`. |
+| 3 | Low | F9 was only partially asserted — `lastReadAt`-not-recomputed was tested, but the other `ReadingStats` scalars weren't verified verbatim. | **Fixed.** Added `restoreReproducesEveryReadingStatsScalarVerbatim` — seeds all scalars with non-default values, asserts verbatim after restore AND after a second restore. |
+
+Round-1 confirmation: `decodeAndValidate` correctly accepts v1 + v2 and rejects
+v3+ via `kBackupAcceptedSchemaVersions`. `collectReadingHistory` carries every
+persisted `ReadingSession` field (pagesRead, wordsRead, deviceId, isRecovered,
+locator JSON strings). `restoreReadingHistory` uses the correct idempotent
+upsert keyed by both `@Attribute(.unique)` columns and does NOT call
+`recomputeStats` (F9). A v1 archive without `reading-history.json` restores
+cleanly (WebDAVProvider's per-section `try?` extraction). The protocol default
+impls are correct and keep existing mock collectors/restorers source-compatible.
+
+Note from Codex: the accepted-set logic covers the seven metadata sections
+restored through `BackupDataRestorer`; `library-manifest.json` keeps its literal
+`schemaVersion: 1` on its own decode path (unchanged, intentional per the plan).
+
+## Round 2 — verification
+
+Codex confirmed all three findings resolved, zero open findings at any severity,
+and explicitly agreed the failure-path test seam is not a merge gate for WI-5.
+The implementing session ran the gate: **16 tests in `BackupReadingHistoryTests`
+pass**; the updated `BackupCollectorRestorerSuite` schema test passes.
+
+## Verdict
+
+**ship-as-is** (round 2). 0 open Critical/High/Medium/Low findings after 2
+rounds (rule-47 max is 3). WI-5 is a BEHAVIORAL WI (changes backup format) —
+Gate 5a requires a slice verification, recorded in the PR description.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,7 +133,7 @@ Bridge-internal coordinators (`EPUBWebViewBridgeCoordinator`, `FoliateViewCoordi
 | `WebDAVServerProfileStore`           | `UserDefaults` / `KeychainService` | Actor-isolated list of saved WebDAV server profiles with one active selection (feature #52 WI-1). Profiles + active-id persist as `UserDefaults` JSON; per-profile passwords persist in Keychain. Atomic `loadSnapshot`, `upsert` / `remove` / `setActiveProfileID`, single-hop `updateIfExists`. Mirrors `ProviderProfileStore` (feature #50) for the AI multi-profile precedent |
 | `WebDAVProfileMigrator`              | `KeychainService` / `WebDAVServerProfileStore` | One-shot migrator that lifts pre-#52 flat-keychain credentials (`com.vreader.webdav.{serverURL,username,password}`) into a `"Default"` profile and sets it active. Idempotent on both axes (marker key + non-empty store). Feature #52 WI-2 |
 | `ReadingModeMigration`               | `UserDefaults` / per-book JSON files | One-shot **synchronous** launch migration retiring the Native/Unified reading mode (feature #54). Removes the `readerReadingMode` UserDefaults key and strips the `readingMode` field from per-book override JSON files (edited as raw `JSONSerialization` objects so other keys are semantically preserved). Synchronous-before-setup — the per-book JSON store has no actor, so a detached migration could race a panel save/restore. Idempotent |
-| `BackupDataCollector`                | `PersistenceActor`         | Serializes 8 versioned JSON sections (annotations, positions, settings, library-manifest, …) |
+| `BackupDataCollector`                | `PersistenceActor`         | Serializes 9 versioned JSON sections (annotations, positions, settings, library-manifest, reading-history, …). `reading-history.json` (feature #58) carries `ReadingSession` + `ReadingStats`; the section bumped `kBackupCurrentSchemaVersion` to 2 |
 | `BackupDataRestorer`                 | `PersistenceActor`         | Decodes + dedupes by UUID/profileKey; rejects future schema versions      |
 | `BlobPath`                           | —                          | Pure utility: `(format, sha256, byteCount)` ↔ `VReader/books/<format>/<sha>_<bytes>.<ext>` (feature #46) |
 | `BackupBlobStore` (protocol pair)    | —                          | Transport-neutral read (`BackupBlobReading`) + write (`BackupBlobWriting`) blob API |
@@ -181,9 +181,14 @@ SwiftData SchemaV6 entities:
 **Feature #46 — WebDAV materializing restore (data layer)**: backup ZIPs now carry an additional `library-manifest.json` section (one `BackupLibraryEntry` per book, including content-addressed `blobPath`). On `backup`, `WebDAVProvider` uploads each missing book blob atomically — `WebDAVBlobStore` PUTs to `VReader/uploads/tmp/<uuid>.part`, PROPFIND-verifies the size, then `MOVE`s into the canonical `VReader/books/<format>/<sha256>_<byteCount>.<ext>` path. Repeat backups skip already-published blobs via PROPFIND-by-size dedupe. On `restore`, when the manifest is present and a `BookImporter` is wired in (production: via `\.bookImporter` SwiftUI Environment), `BookFileMaterializer` downloads + verifies + imports each missing blob before metadata sections apply. v1-format backups (no manifest) restore as before — books silently skipped if missing locally. The 412 response from `MOVE Overwrite: F` is treated as "blob already converged" (content-addressing). 501 from `MOVE` raises `BackupBlobStoreError.serverCapabilityMissing` — no silent atomicity loss.
 
 Backup section JSONs (`vreader/Services/Backup/BackupSectionDTOs.swift`) are
-versioned via the `BackupVersionedEnvelope` protocol. Restore validates exact
-`schemaVersion == 1` and raises `BackupRestoreError.unsupportedSchemaVersion`
-on mismatch, so a future v2 archive can't silently apply on a v1 client.
+versioned via the `BackupVersionedEnvelope` protocol. The collector emits
+`kBackupCurrentSchemaVersion` (now `2`, bumped by feature #58 for the new
+`reading-history.json` section). Restore validates the envelope against the
+explicit accepted set `kBackupAcceptedSchemaVersions` (`{1, 2}`) — decoupled
+from the current constant so a version bump doesn't reject older backups (the
+pre-v2 section shapes are byte-identical between v1 and v2). A genuinely-newer
+archive (v3+) is absent from the set and still raises
+`BackupRestoreError.unsupportedSchemaVersion`.
 
 Key types:
 

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 541
-        MARKETING_VERSION: 3.36.26
+        CURRENT_PROJECT_VERSION: 542
+        MARKETING_VERSION: 3.36.27
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 		2999C19D201DFD14B176D2B3 /* TXTLazyTextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F7F0E16B5468446AE51D0C /* TXTLazyTextProvider.swift */; };
 		2ACDD49C29110C6459556A71 /* SheetSectionContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529E7234A3FC73811D573A6C /* SheetSectionContract.swift */; };
 		2AD43547691478569AA638EB /* AIConfigurationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8038AAB18412F30C09CBDD9 /* AIConfigurationStore.swift */; };
+		2B11272F445BEE99A51EA0A6 /* BackupReadingHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97DEE6FFCAE4CC96DFEDC24 /* BackupReadingHistory.swift */; };
 		2B2BB1E5BCB1E74F360BE9F2 /* SearchTextExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30D00221E111683E9FF0260A /* SearchTextExtractor.swift */; };
 		2B495CA89B61AF9DAC925A54 /* PersistenceActorRemoteOnlyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A504B80204BEC5B968087D02 /* PersistenceActorRemoteOnlyTests.swift */; };
 		2B4DBB81BBE1C67A1336C8A5 /* DebugReaderRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9380720966F3E3F6F8A0D407 /* DebugReaderRegistry.swift */; };
@@ -219,6 +220,7 @@
 		2E4D176937CECE96A39EAC18 /* RemoteBookCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF7D174AC38392C14C17F1F7 /* RemoteBookCatalog.swift */; };
 		2E988A3214761CEAEF22D451 /* HTMLHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4349ACADC38E53A4D87D5D5A /* HTMLHelper.swift */; };
 		2E9BB5052DD152DD52BB0D45 /* TXTReaderPlaceholderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 480E5268D197F33E8C0B6CFC /* TXTReaderPlaceholderTests.swift */; };
+		2EDFC010BBBC1DFFD0B1F7CC /* PersistenceActor+ReadingHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA8C0E6A9B8EF3E48771286 /* PersistenceActor+ReadingHistory.swift */; };
 		2F558CF136B69212E668F2D3 /* EPUBParserProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C15E361FF460BCE57B8675 /* EPUBParserProtocol.swift */; };
 		2F69DF71FDE5AF4FF920C3B2 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864A1B050775A46ADBE3304F /* SearchViewModel.swift */; };
 		2F6BF0E200261CF4E6487929 /* TTSTextSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F93D764B3C66019C2B47A5 /* TTSTextSourceTests.swift */; };
@@ -694,6 +696,7 @@
 		9AF587978D1D58F58C7E8A23 /* UnifiedTextRendererViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7056486BA460E0BE06235F54 /* UnifiedTextRendererViewModel.swift */; };
 		9B04DEA549D9C760DD6D3C3E /* BookSourceListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F971403A2807A2788FD2D99F /* BookSourceListView.swift */; };
 		9BF39FDF19F34D65452D4C79 /* WebDAVNetworkPolicyEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E2D1C060B3EF0B66847F23 /* WebDAVNetworkPolicyEnvironment.swift */; };
+		9BF4E606FB4C251BD4492FA9 /* BackupReadingHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9E42127F86EB76595AD46B /* BackupReadingHistoryTests.swift */; };
 		9C0C69EAD4FE812FB41F6525 /* TextMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6266DCAB5ADCBB1B3257D9 /* TextMapper.swift */; };
 		9C8762E2789F97355348E7AA /* MockMDParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E9F1953C017E6B1F990FB44 /* MockMDParser.swift */; };
 		9C87FCF01164A269B85DA51A /* FoliateJSEscaper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CB10F386B36EF83C36873F /* FoliateJSEscaper.swift */; };
@@ -1256,6 +1259,7 @@
 		1A7668891CD8BA0B6DED7A25 /* LibraryCardTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryCardTokens.swift; sourceTree = "<group>"; };
 		1ABFAC14455C6F7DE43C1ABC /* overlayer.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = overlayer.js; sourceTree = "<group>"; };
 		1B311C3A88BD6DC42005FE1B /* ExportedAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportedAnnotation.swift; sourceTree = "<group>"; };
+		1BA8C0E6A9B8EF3E48771286 /* PersistenceActor+ReadingHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+ReadingHistory.swift"; sourceTree = "<group>"; };
 		1C07D184EF0E90D5F2DF7A36 /* EPUBWebViewBridgeJS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBWebViewBridgeJS.swift; sourceTree = "<group>"; };
 		1C1B3D47B7CCE2B9CBC61B7A /* SimpTradTransformTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpTradTransformTests.swift; sourceTree = "<group>"; };
 		1C4B680049F19F417D2B5179 /* SettingsSliderRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSliderRow.swift; sourceTree = "<group>"; };
@@ -1677,6 +1681,7 @@
 		7A0147BC1F4C66F4EDB21608 /* ReadingDashboardSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDashboardSnapshotTests.swift; sourceTree = "<group>"; };
 		7A266E88D3BA30905391B154 /* ReaderHighlightTapEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderHighlightTapEventTests.swift; sourceTree = "<group>"; };
 		7A980DB0017049401DAB3E93 /* AnnotationListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationListViewModel.swift; sourceTree = "<group>"; };
+		7A9E42127F86EB76595AD46B /* BackupReadingHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupReadingHistoryTests.swift; sourceTree = "<group>"; };
 		7AAC0D3FD90694D3169DB775 /* MDReaderPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReaderPlaceholderTests.swift; sourceTree = "<group>"; };
 		7B3463E0D88B62CFEF84E4F9 /* chapter_content.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = chapter_content.html; sourceTree = "<group>"; };
 		7BA6B74EE0E50E049C9BAC5C /* WebDAVSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVSettingsView.swift; sourceTree = "<group>"; };
@@ -1880,6 +1885,7 @@
 		A8C56D76EC2A57744D168E86 /* AnnotationImportError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationImportError.swift; sourceTree = "<group>"; };
 		A922B4886FE1CE378009FB1B /* EPUBReaderContainerView+Highlights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EPUBReaderContainerView+Highlights.swift"; sourceTree = "<group>"; };
 		A96A115C3FA0B797030C1D1F /* TXTTextViewBridgeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTTextViewBridgeCoordinator.swift; sourceTree = "<group>"; };
+		A97DEE6FFCAE4CC96DFEDC24 /* BackupReadingHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupReadingHistory.swift; sourceTree = "<group>"; };
 		A983D06F916C51795A2223E7 /* ReaderBottomOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderBottomOverlay.swift; sourceTree = "<group>"; };
 		A9ABEE3CBF62A1CC57F2952F /* UTF16TextSlicer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTF16TextSlicer.swift; sourceTree = "<group>"; };
 		A9C2070D3EFFBFC041A1474B /* TTSTextSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSTextSource.swift; sourceTree = "<group>"; };
@@ -2450,6 +2456,7 @@
 				DAAAF285B1D1B4F09E3AAD56 /* BackupDataCollector.swift */,
 				DA823268583E27AF564272EC /* BackupDataRestorer.swift */,
 				8AB2B5F77B95D3402E699DA9 /* BackupProvider.swift */,
+				A97DEE6FFCAE4CC96DFEDC24 /* BackupReadingHistory.swift */,
 				64D6B83FC65D64C1271E28F4 /* BackupSectionDTOs.swift */,
 				560129625F0E48471C0F4B62 /* BlobPath.swift */,
 				4DE2E82B00BA09B1D805167A /* BookFileImportFinalizer.swift */,
@@ -3750,6 +3757,7 @@
 				A17676C4AE9DD328C39176D8 /* BackupDataCollectorRestorerTests.swift */,
 				F64BCF588EF860DD6C214737 /* BackupLibraryManifestTests.swift */,
 				ED150D276C082FEC194F2F31 /* BackupProviderContractTests.swift */,
+				7A9E42127F86EB76595AD46B /* BackupReadingHistoryTests.swift */,
 				BFB65788879E3D91E69E8BA5 /* BlobPathTests.swift */,
 				B21FF5B2854F2C50C5A43F17 /* BookFileImportFinalizerTests.swift */,
 				04ED79BFAD4BEF6B8A30F982 /* BookFileMaterializerTests.swift */,
@@ -3995,6 +4003,7 @@
 				00814B9C69A0E1190146095E /* PersistenceActor+Collections.swift */,
 				AC517B8E3581F795DEDEC934 /* PersistenceActor+Highlights.swift */,
 				E46A786B20AA87E763D00F45 /* PersistenceActor+Library.swift */,
+				1BA8C0E6A9B8EF3E48771286 /* PersistenceActor+ReadingHistory.swift */,
 				59ECD5BE8EE959A2EF3E208E /* PersistenceActor+ReadingPosition.swift */,
 				300CB93197976B4D665AEDFC /* PersistenceActor+RemoteOnly.swift */,
 				96FDA9A40CE891B901F1A28F /* PersistenceActor+Stats.swift */,
@@ -4511,6 +4520,7 @@
 				22612350C6FC7C43096271E9 /* BackupDataCollectorRestorerTests.swift in Sources */,
 				A1C0DD5C147F74C3C21B932B /* BackupLibraryManifestTests.swift in Sources */,
 				4F2FEC62B6D23F67263EDF34 /* BackupProviderContractTests.swift in Sources */,
+				9BF4E606FB4C251BD4492FA9 /* BackupReadingHistoryTests.swift in Sources */,
 				A43AD2AF5B19CF05B849BE2E /* BackupViewModelSelectiveRestoreTests.swift in Sources */,
 				90D2C41C30E622E119877967 /* BackupViewModelTests.swift in Sources */,
 				096B20388931B21DAA4DC091 /* BlobPathTests.swift in Sources */,
@@ -4999,6 +5009,7 @@
 				C3129F763BDCF3AB47BC7098 /* BackupDataCollector.swift in Sources */,
 				DDFB32D1CC4508E794A67573 /* BackupDataRestorer.swift in Sources */,
 				238CEDFC273E8AD0026B77AB /* BackupProvider.swift in Sources */,
+				2B11272F445BEE99A51EA0A6 /* BackupReadingHistory.swift in Sources */,
 				B9BF611D570F7F9681FBEE6E /* BackupSectionDTOs.swift in Sources */,
 				20271E1F835A62799E28F741 /* BackupViewModel.swift in Sources */,
 				986EFB28F7203E56F853A0FD /* BasePageNavigator.swift in Sources */,
@@ -5265,6 +5276,7 @@
 				CC5A3B33193938B59254FD8A /* PersistenceActor+Collections.swift in Sources */,
 				38661CFAC1618DB7526ACB28 /* PersistenceActor+Highlights.swift in Sources */,
 				CD9751D76A3A9DBF872CA5D7 /* PersistenceActor+Library.swift in Sources */,
+				2EDFC010BBBC1DFFD0B1F7CC /* PersistenceActor+ReadingHistory.swift in Sources */,
 				E1646FDF9A47255E94758A54 /* PersistenceActor+ReadingPosition.swift in Sources */,
 				5C1FD4FE52873A5962D4CB95 /* PersistenceActor+RemoteOnly.swift in Sources */,
 				D451E5FB27521C48F0A54FEA /* PersistenceActor+Stats.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5638,13 +5638,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 541;
+				CURRENT_PROJECT_VERSION = 542;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.26;
+				MARKETING_VERSION = 3.36.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5788,13 +5788,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 541;
+				CURRENT_PROJECT_VERSION = 542;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.26;
+				MARKETING_VERSION = 3.36.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Backup/BackupDataCollector.swift
+++ b/vreader/Services/Backup/BackupDataCollector.swift
@@ -232,11 +232,16 @@ final class BackupDataCollector: BackupDataCollecting, @unchecked Sendable {
     /// Feature #58 WI-5: emits `reading-history.json` carrying every
     /// `ReadingSession` and every `ReadingStats` row, so a restore reproduces
     /// reading history exactly. New in backup schema v2.
+    ///
+    /// The persistence fetches are NOT `try?`-swallowed: criterion (f) demands
+    /// an exact round-trip, so a read failure must fail the backup loudly
+    /// rather than silently emitting an empty section (which would discard the
+    /// user's entire reading history on the next restore).
     func collectReadingHistory() async throws -> Data {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
 
-        let sessionRecords = (try? await persistence.fetchAllReadingSessions()) ?? []
+        let sessionRecords = try await persistence.fetchAllReadingSessions()
         let sessions: [BackupReadingSession] = sessionRecords.map { record in
             BackupReadingSession(
                 sessionId: record.sessionId,
@@ -253,7 +258,7 @@ final class BackupDataCollector: BackupDataCollecting, @unchecked Sendable {
             )
         }
 
-        let statsRecords = (try? await persistence.fetchAllReadingStats()) ?? []
+        let statsRecords = try await persistence.fetchAllReadingStats()
         let stats: [BackupReadingStats] = statsRecords.map { record in
             BackupReadingStats(
                 bookFingerprintKey: record.bookFingerprintKey,

--- a/vreader/Services/Backup/BackupDataCollector.swift
+++ b/vreader/Services/Backup/BackupDataCollector.swift
@@ -229,6 +229,51 @@ final class BackupDataCollector: BackupDataCollecting, @unchecked Sendable {
         return try encode(envelope)
     }
 
+    /// Feature #58 WI-5: emits `reading-history.json` carrying every
+    /// `ReadingSession` and every `ReadingStats` row, so a restore reproduces
+    /// reading history exactly. New in backup schema v2.
+    func collectReadingHistory() async throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+
+        let sessionRecords = (try? await persistence.fetchAllReadingSessions()) ?? []
+        let sessions: [BackupReadingSession] = sessionRecords.map { record in
+            BackupReadingSession(
+                sessionId: record.sessionId,
+                bookFingerprintKey: record.bookFingerprintKey,
+                startedAt: record.startedAt,
+                endedAt: record.endedAt,
+                durationSeconds: record.durationSeconds,
+                pagesRead: record.pagesRead,
+                wordsRead: record.wordsRead,
+                startLocatorJSON: record.startLocator.flatMap { locatorJSON($0, encoder: encoder) },
+                endLocatorJSON: record.endLocator.flatMap { locatorJSON($0, encoder: encoder) },
+                deviceId: record.deviceId,
+                isRecovered: record.isRecovered
+            )
+        }
+
+        let statsRecords = (try? await persistence.fetchAllReadingStats()) ?? []
+        let stats: [BackupReadingStats] = statsRecords.map { record in
+            BackupReadingStats(
+                bookFingerprintKey: record.bookFingerprintKey,
+                totalReadingSeconds: record.totalReadingSeconds,
+                sessionCount: record.sessionCount,
+                lastReadAt: record.lastReadAt,
+                averagePagesPerHour: record.averagePagesPerHour,
+                averageWordsPerMinute: record.averageWordsPerMinute,
+                totalPagesRead: record.totalPagesRead,
+                totalWordsRead: record.totalWordsRead,
+                longestSessionSeconds: record.longestSessionSeconds
+            )
+        }
+
+        let envelope = BackupReadingHistoryEnvelope(
+            schemaVersion: kBackupCurrentSchemaVersion, sessions: sessions, stats: stats
+        )
+        return try encode(envelope)
+    }
+
     // MARK: - Helpers
 
     private func encode<T: Encodable>(_ value: T) throws -> Data {

--- a/vreader/Services/Backup/BackupDataRestorer.swift
+++ b/vreader/Services/Backup/BackupDataRestorer.swift
@@ -100,6 +100,13 @@ final class BackupDataRestorer: BackupDataRestoring, @unchecked Sendable {
         try await persistence.upsertBackupReplacementRules(envelope.rules)
     }
 
+    func restoreReadingHistory(from data: Data) async throws {
+        let envelope = try decodeAndValidate(
+            BackupReadingHistoryEnvelope.self, from: data, section: "reading-history"
+        )
+        try await persistence.restoreReadingHistory(envelope)
+    }
+
     // MARK: - Helpers
 
     private func decodeAndValidate<T: Decodable & BackupVersionedEnvelope>(
@@ -108,11 +115,13 @@ final class BackupDataRestorer: BackupDataRestoring, @unchecked Sendable {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let envelope = try decoder.decode(type, from: data)
-        // Only schema v1 exists today, so require an exact match. When v2
-        // ships, this becomes a switch + per-version migration; accepting
-        // anything `<= current` would silently pass v0 archives without the
-        // migrations they need.
-        guard envelope.schemaVersion == kBackupCurrentSchemaVersion else {
+        // Validate against the explicit accepted SET, not the single "current"
+        // constant: the v1↔v2 envelope shapes for the pre-v2 sections are
+        // identical (no field migration), so a v1 archive must still restore
+        // after the v2 bump. A genuinely-newer archive (v3+) is absent from the
+        // set and still throws — accepting anything `<= current` would silently
+        // pass a too-new archive without the handling it needs.
+        guard kBackupAcceptedSchemaVersions.contains(envelope.schemaVersion) else {
             throw BackupRestoreError.unsupportedSchemaVersion(
                 section: section,
                 actual: envelope.schemaVersion,

--- a/vreader/Services/Backup/BackupReadingHistory.swift
+++ b/vreader/Services/Backup/BackupReadingHistory.swift
@@ -1,0 +1,58 @@
+// Purpose: Codable DTOs for the `reading-history.json` backup section
+// (feature #58 WI-5) — ReadingSession + ReadingStats round-tripped through
+// the WebDAV backup ZIP.
+//
+// This section is NEW in backup schema v2. A v1 archive simply lacks the
+// `reading-history.json` entry; the restorer skips it (edge case f).
+//
+// Kept in its own file rather than swelling BackupSectionDTOs.swift past the
+// ~300-line guideline.
+//
+// @coordinates-with: BackupSectionDTOs.swift, BackupDataCollector.swift,
+//   BackupDataRestorer.swift, PersistenceActor+Backup.swift, ReadingSession.swift,
+//   ReadingStats.swift
+
+import Foundation
+
+/// The `reading-history.json` section envelope — every `ReadingSession` plus
+/// every `ReadingStats` row, so a restore reproduces reading history exactly.
+struct BackupReadingHistoryEnvelope: Codable, Sendable, Equatable, BackupVersionedEnvelope {
+    let schemaVersion: Int
+    let sessions: [BackupReadingSession]
+    let stats: [BackupReadingStats]
+}
+
+/// One `ReadingSession` row. Mirrors EVERY persisted field so criterion (f)
+/// ("preserves `ReadingSession` exactly") holds. `bookFingerprintKey` IS the
+/// canonical key — the `DocumentFingerprint` is reconstructed on restore via
+/// `init(canonicalKey:)`, exactly as `BackupLibraryEntry` does. Locators
+/// round-trip as JSON strings (matching `BackupHighlight.locatorJSON`).
+struct BackupReadingSession: Codable, Sendable, Equatable {
+    let sessionId: UUID
+    /// == `DocumentFingerprint.canonicalKey`.
+    let bookFingerprintKey: String
+    let startedAt: Date
+    let endedAt: Date?
+    let durationSeconds: Int
+    let pagesRead: Int?
+    let wordsRead: Int?
+    /// `Locator` as a JSON string; nil when the session has no start locator.
+    let startLocatorJSON: String?
+    let endLocatorJSON: String?
+    let deviceId: String
+    let isRecovered: Bool
+}
+
+/// One `ReadingStats` row — the per-book lifetime aggregate. Restored verbatim
+/// (NOT recomputed) so the backed-up `lastReadAt` survives intact.
+struct BackupReadingStats: Codable, Sendable, Equatable {
+    let bookFingerprintKey: String
+    let totalReadingSeconds: Int
+    let sessionCount: Int
+    let lastReadAt: Date?
+    let averagePagesPerHour: Double?
+    let averageWordsPerMinute: Double?
+    let totalPagesRead: Int?
+    let totalWordsRead: Int?
+    let longestSessionSeconds: Int
+}

--- a/vreader/Services/Backup/BackupSectionDTOs.swift
+++ b/vreader/Services/Backup/BackupSectionDTOs.swift
@@ -8,8 +8,17 @@
 import Foundation
 
 /// All section JSONs share a `schemaVersion` field so future revs can branch on it.
-/// Currently only v1 is emitted.
-let kBackupCurrentSchemaVersion = 1
+///
+/// What the COLLECTOR emits. v2 (feature #58 WI-5) adds the `reading-history.json`
+/// section; the pre-v2 sections are byte-identical between v1 and v2 (only this
+/// integer differs — no field migration), so a v1 archive still restores.
+let kBackupCurrentSchemaVersion = 2
+
+/// What the RESTORER accepts. Decoupled from `kBackupCurrentSchemaVersion` so a
+/// version bump doesn't reject every older backup: the v1↔v2 envelope shapes for
+/// the pre-v2 sections are identical, so accepting v1 is sound. A genuinely-newer
+/// archive (v3+) is NOT in this set and still throws `unsupportedSchemaVersion`.
+let kBackupAcceptedSchemaVersions: Set<Int> = [1, 2]
 
 /// Common shape every section envelope honors so the restorer can validate
 /// `schemaVersion` without 7 special cases.
@@ -265,3 +274,9 @@ struct BackupLibraryEntry: Codable, Sendable, Equatable {
     /// `BlobPath.make(format:sha256:byteCount:)`.
     let blobPath: String
 }
+
+// MARK: - Reading History (feature #58 WI-5)
+
+// The `reading-history.json` section's DTOs — `BackupReadingHistoryEnvelope`,
+// `BackupReadingSession`, `BackupReadingStats` — live in `BackupReadingHistory.swift`
+// to keep this file under the ~300-line guideline. New in backup schema v2.

--- a/vreader/Services/Backup/WebDAVProvider.swift
+++ b/vreader/Services/Backup/WebDAVProvider.swift
@@ -37,6 +37,11 @@ protocol BackupDataCollecting: Sendable {
     /// returns an empty manifest envelope so older provider impls stay
     /// source-compatible.
     func collectLibraryManifest() async throws -> Data
+
+    /// Feature #58 (WI-5): emits `reading-history.json` carrying every
+    /// `ReadingSession` + `ReadingStats` row. Default impl returns an empty
+    /// envelope so existing mock collectors stay source-compatible.
+    func collectReadingHistory() async throws -> Data
 }
 
 extension BackupDataCollecting {
@@ -44,6 +49,16 @@ extension BackupDataCollecting {
         let envelope = BackupLibraryManifestEnvelope(
             schemaVersion: 1,
             books: []
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(envelope)
+    }
+
+    func collectReadingHistory() async throws -> Data {
+        let envelope = BackupReadingHistoryEnvelope(
+            schemaVersion: kBackupCurrentSchemaVersion, sessions: [], stats: []
         )
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
@@ -64,6 +79,16 @@ protocol BackupDataRestoring: Sendable {
     func restoreBookSources(from data: Data) async throws
     func restorePerBookSettings(from data: Data) async throws
     func restoreReplacementRules(from data: Data) async throws
+
+    /// Feature #58 (WI-5): restores the `reading-history.json` section.
+    /// Default impl is a no-op so existing mock restorers stay source-compatible.
+    func restoreReadingHistory(from data: Data) async throws
+}
+
+extension BackupDataRestoring {
+    func restoreReadingHistory(from data: Data) async throws {
+        // Default: no-op. The production BackupDataRestorer overrides this.
+    }
 }
 
 // MARK: - WebDAVProvider
@@ -140,13 +165,15 @@ final class WebDAVProvider: BackupProvider, @unchecked Sendable {
             let c = try await dataCollector.collectCollections(); progress(0.16)
             let bs = try await dataCollector.collectBookSources(); progress(0.20)
             let pbs = try await dataCollector.collectPerBookSettings(); progress(0.24)
-            let rr = try await dataCollector.collectReplacementRules(); progress(0.26)
-            manifestData = try await dataCollector.collectLibraryManifest(); progress(0.28)
+            let rr = try await dataCollector.collectReplacementRules(); progress(0.25)
+            let rh = try await dataCollector.collectReadingHistory(); progress(0.27)
+            manifestData = try await dataCollector.collectLibraryManifest(); progress(0.29)
             bookCount = await dataCollector.getBookCount(); progress(0.30)
             collected = [
                 ("annotations.json", a), ("positions.json", p), ("settings.json", s),
                 ("collections.json", c), ("book-sources.json", bs), ("per-book-settings.json", pbs),
                 ("replacement-rules.json", rr),
+                ("reading-history.json", rh),
                 ("library-manifest.json", manifestData),
             ]
 
@@ -346,6 +373,7 @@ final class WebDAVProvider: BackupProvider, @unchecked Sendable {
             ("book-sources.json", "book sources", dataRestorer.restoreBookSources),
             ("per-book-settings.json", "per-book settings", dataRestorer.restorePerBookSettings),
             ("replacement-rules.json", "replacement rules", dataRestorer.restoreReplacementRules),
+            ("reading-history.json", "reading history", dataRestorer.restoreReadingHistory),
         ]
 
         let restorePhaseStart = (bookImporter != nil) ? 0.75 : 0.55

--- a/vreader/Services/PersistenceActor+ReadingHistory.swift
+++ b/vreader/Services/PersistenceActor+ReadingHistory.swift
@@ -1,0 +1,148 @@
+// Purpose: Extension adding reading-history backup RESTORE to PersistenceActor
+// (feature #58 WI-5). Upserts ReadingSession + ReadingStats rows from the
+// `reading-history.json` backup section.
+//
+// Why a separate file (not PersistenceActor+Backup.swift): that file is already
+// over the ~300-line guideline; this is a self-contained restore method.
+//
+// Key decisions:
+// - UPSERT keyed by the @Attribute(.unique) columns (ReadingSession.sessionId,
+//   ReadingStats.bookFingerprintKey) — prefetch + update-in-place + insert-if-
+//   absent, exactly how restoreBackupAnnotations avoids the unique-constraint
+//   violation on a re-run.
+// - ReadingStats fields are written VERBATIM from the backup — restore does NOT
+//   call recomputeStats. recomputeStats force-sets lastReadAt = Date() (its
+//   "Bug #45 v5" line, correct for the reader-close caller, wrong for restore);
+//   calling it would rewrite every restored lastReadAt to restore-time and
+//   violate criterion (f) "preserves ReadingStats exactly".
+// - Conflict policy: the backup value WINS (a restore is an explicit "make this
+//   device match the backup" act). Local rows not in the backup are untouched
+//   (additive merge, like every other restore section).
+//
+// @coordinates-with: BackupReadingHistory.swift, BackupDataRestorer.swift,
+//   ReadingSession.swift, ReadingStats.swift
+
+import Foundation
+import OSLog
+import SwiftData
+
+private let log = Logger(subsystem: "com.vreader.app", category: "BackupRestorer")
+
+extension PersistenceActor {
+
+    /// Restores the `reading-history.json` section — upserts every
+    /// `ReadingSession` and `ReadingStats` row from the backup.
+    func restoreReadingHistory(_ envelope: BackupReadingHistoryEnvelope) async throws {
+        let context = ModelContext(modelContainer)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        try restoreSessions(envelope.sessions, context: context, decoder: decoder)
+        try restoreStats(envelope.stats, context: context)
+
+        try context.save()
+    }
+
+    // MARK: - Sessions
+
+    private func restoreSessions(
+        _ sessions: [BackupReadingSession], context: ModelContext, decoder: JSONDecoder
+    ) throws {
+        // Prefetch every existing session, indexed by the unique sessionId.
+        let existing = try context.fetch(FetchDescriptor<ReadingSession>())
+        var byId: [UUID: ReadingSession] = [:]
+        for session in existing { byId[session.sessionId] = session }
+
+        for backup in sessions {
+            // The DocumentFingerprint is reconstructed from the canonical key.
+            guard let fingerprint = DocumentFingerprint(canonicalKey: backup.bookFingerprintKey) else {
+                log.error("Skipping reading session with unparseable fingerprint key")
+                continue
+            }
+            let startLocator = decodeLocator(backup.startLocatorJSON, decoder: decoder)
+            let endLocator = decodeLocator(backup.endLocatorJSON, decoder: decoder)
+
+            if let row = byId[backup.sessionId] {
+                // Update in place — the model's mutators (@Model didSet is
+                // unreliable). The backup value wins.
+                row.updateBookFingerprint(fingerprint)
+                row.startedAt = backup.startedAt
+                row.endedAt = backup.endedAt
+                row.updateDuration(backup.durationSeconds)
+                row.updatePagesRead(backup.pagesRead)
+                row.updateWordsRead(backup.wordsRead)
+                row.startLocator = startLocator
+                row.endLocator = endLocator
+                row.deviceId = backup.deviceId
+                row.isRecovered = backup.isRecovered
+            } else {
+                let row = ReadingSession(
+                    sessionId: backup.sessionId,
+                    bookFingerprint: fingerprint,
+                    startedAt: backup.startedAt,
+                    endedAt: backup.endedAt,
+                    durationSeconds: backup.durationSeconds,
+                    pagesRead: backup.pagesRead,
+                    wordsRead: backup.wordsRead,
+                    startLocator: startLocator,
+                    endLocator: endLocator,
+                    deviceId: backup.deviceId,
+                    isRecovered: backup.isRecovered
+                )
+                context.insert(row)
+                byId[backup.sessionId] = row
+            }
+        }
+    }
+
+    // MARK: - Stats
+
+    private func restoreStats(
+        _ stats: [BackupReadingStats], context: ModelContext
+    ) throws {
+        // Prefetch existing stats, indexed by the unique bookFingerprintKey.
+        let existing = try context.fetch(FetchDescriptor<ReadingStats>())
+        var byKey: [String: ReadingStats] = [:]
+        for row in existing where byKey[row.bookFingerprintKey] == nil {
+            byKey[row.bookFingerprintKey] = row
+        }
+
+        for backup in stats {
+            guard let fingerprint = DocumentFingerprint(canonicalKey: backup.bookFingerprintKey) else {
+                log.error("Skipping reading stats with unparseable fingerprint key")
+                continue
+            }
+            let row: ReadingStats
+            if let existingRow = byKey[backup.bookFingerprintKey] {
+                row = existingRow
+            } else {
+                row = ReadingStats(bookFingerprint: fingerprint)
+                context.insert(row)
+                byKey[backup.bookFingerprintKey] = row
+            }
+            // Write the backed-up scalars VERBATIM — no recomputeStats (which
+            // would stamp lastReadAt = Date() and violate criterion (f)).
+            row.totalReadingSeconds = backup.totalReadingSeconds
+            row.sessionCount = backup.sessionCount
+            row.lastReadAt = backup.lastReadAt
+            row.averagePagesPerHour = backup.averagePagesPerHour
+            row.averageWordsPerMinute = backup.averageWordsPerMinute
+            row.totalPagesRead = backup.totalPagesRead
+            row.totalWordsRead = backup.totalWordsRead
+            row.longestSessionSeconds = backup.longestSessionSeconds
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Decodes a `Locator` JSON string; a nil or malformed string degrades to
+    /// nil (the session still restores — only its locator is dropped) rather
+    /// than failing the whole section.
+    private func decodeLocator(_ json: String?, decoder: JSONDecoder) -> Locator? {
+        guard let json,
+              let data = json.data(using: .utf8),
+              let locator = try? decoder.decode(Locator.self, from: data)
+        else { return nil }
+        return locator
+    }
+}

--- a/vreaderTests/Services/Backup/BackupDataCollectorRestorerTests.swift
+++ b/vreaderTests/Services/Backup/BackupDataCollectorRestorerTests.swift
@@ -698,7 +698,10 @@ struct BackupCollectorRestorerSuite {
 
     // MARK: - Schema version forward compat
 
-    @Test func collectorEmitsSchemaVersion1() async throws {
+    @Test func collectorEmitsCurrentSchemaVersion() async throws {
+        // Feature #58 WI-5 bumped kBackupCurrentSchemaVersion 1 → 2. The
+        // collector always emits the current version; the restorer accepts
+        // both 1 and 2 (kBackupAcceptedSchemaVersions).
         let persistence = try makePersistence()
         let collector = BackupDataCollector(
             persistence: persistence,
@@ -707,7 +710,26 @@ struct BackupCollectorRestorerSuite {
         )
         let data = try await collector.collectCollections()
         let envelope = try JSONDecoder().decode(BackupCollectionsEnvelope.self, from: data)
-        #expect(envelope.schemaVersion == 1)
+        #expect(envelope.schemaVersion == kBackupCurrentSchemaVersion)
+        #expect(envelope.schemaVersion == 2)
+    }
+
+    @Test func restorerAcceptsAV1Section() async throws {
+        // The v1↔v2 envelope shapes for the pre-#58 sections are byte-identical
+        // — a v1-tagged section must still restore after the v2 bump.
+        let v1Envelope = BackupCollectionsEnvelope(schemaVersion: 1, collections: [])
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(v1Envelope)
+
+        let persistence = try makePersistence()
+        let restorer = BackupDataRestorer(
+            persistence: persistence,
+            defaults: makeIsolatedDefaults(label: "v1accept"),
+            perBookSettingsBaseURL: try makeTempDir(label: "v1accept")
+        )
+        // Must NOT throw — v1 is in kBackupAcceptedSchemaVersions.
+        try await restorer.restoreCollections(from: data)
     }
 
     @Test func restorerRejectsFutureSchemaVersion() async throws {

--- a/vreaderTests/Services/Backup/BackupReadingHistoryTests.swift
+++ b/vreaderTests/Services/Backup/BackupReadingHistoryTests.swift
@@ -58,13 +58,15 @@ struct BackupReadingHistoryTests {
         _ container: ModelContainer, book: DocumentFingerprint,
         sessionId: UUID = UUID(), startedAt: Date, endedAt: Date? = nil,
         duration: Int = 600, pages: Int? = 10, words: Int? = 2000,
-        deviceId: String = "dev-1", isRecovered: Bool = false
+        deviceId: String = "dev-1", isRecovered: Bool = false,
+        startLocator: Locator? = nil, endLocator: Locator? = nil
     ) throws {
         let context = ModelContext(container)
         let s = ReadingSession(
             sessionId: sessionId, bookFingerprint: book, startedAt: startedAt,
             endedAt: endedAt, durationSeconds: duration, pagesRead: pages,
-            wordsRead: words, deviceId: deviceId, isRecovered: isRecovered
+            wordsRead: words, startLocator: startLocator, endLocator: endLocator,
+            deviceId: deviceId, isRecovered: isRecovered
         )
         context.insert(s)
         try context.save()
@@ -72,13 +74,17 @@ struct BackupReadingHistoryTests {
 
     private func seedStats(
         _ container: ModelContainer, book: DocumentFingerprint,
-        totalSeconds: Int = 3600, sessionCount: Int = 3, lastReadAt: Date?
+        totalSeconds: Int = 3600, sessionCount: Int = 3, lastReadAt: Date?,
+        avgPagesPerHour: Double? = nil, avgWordsPerMinute: Double? = nil,
+        totalPages: Int? = nil, totalWords: Int? = nil, longestSession: Int = 1800
     ) throws {
         let context = ModelContext(container)
         let stats = ReadingStats(
             bookFingerprint: book, totalReadingSeconds: totalSeconds,
             sessionCount: sessionCount, lastReadAt: lastReadAt,
-            longestSessionSeconds: 1800
+            averagePagesPerHour: avgPagesPerHour, averageWordsPerMinute: avgWordsPerMinute,
+            totalPagesRead: totalPages, totalWordsRead: totalWords,
+            longestSessionSeconds: longestSession
         )
         context.insert(stats)
         try context.save()
@@ -178,6 +184,93 @@ struct BackupReadingHistoryTests {
         #expect(r.lastReadAt == fixedLastRead)
         #expect(r.totalReadingSeconds == 7200)
         #expect(r.sessionCount == 9)
+    }
+
+    @Test func restoreRoundTripPreservesStartAndEndLocators() async throws {
+        // F2: BackupReadingSession carries the locators as JSON strings.
+        let source = try makeContainer()
+        let fp = fingerprint("locbook")
+        let startLoc = try #require(Locator.validated(bookFingerprint: fp, page: 3))
+        let endLoc = try #require(Locator.validated(bookFingerprint: fp, page: 17))
+        let id = UUID()
+        try seedSession(source, book: fp, sessionId: id,
+                        startedAt: Date(timeIntervalSince1970: 1_650_000_000),
+                        startLocator: startLoc, endLocator: endLoc)
+        let data = try await collector(source).collectReadingHistory()
+
+        let fresh = try makeContainer()
+        try await restorer(fresh).restoreReadingHistory(from: data)
+        let restored = try await PersistenceActor(modelContainer: fresh).fetchAllReadingSessions()
+        let r = try #require(restored.first)
+        #expect(r.startLocator?.page == 3)
+        #expect(r.endLocator?.page == 17)
+        #expect(r.startLocator?.bookFingerprint.canonicalKey == fp.canonicalKey)
+    }
+
+    @Test func malformedLocatorJSONDegradesToNilSessionStillRestores() async throws {
+        // A session whose locator JSON is garbage must still restore — only the
+        // locator is dropped (degrades to nil), not the whole session.
+        let fp = fingerprint("malformedloc")
+        let id = UUID()
+        let envelope = BackupReadingHistoryEnvelope(
+            schemaVersion: kBackupCurrentSchemaVersion,
+            sessions: [BackupReadingSession(
+                sessionId: id, bookFingerprintKey: fp.canonicalKey,
+                startedAt: Date(timeIntervalSince1970: 1_640_000_000), endedAt: nil,
+                durationSeconds: 450, pagesRead: 8, wordsRead: 1500,
+                startLocatorJSON: "{not valid locator json",
+                endLocatorJSON: "also garbage",
+                deviceId: "dev-m", isRecovered: false
+            )],
+            stats: []
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(envelope)
+
+        let fresh = try makeContainer()
+        try await restorer(fresh).restoreReadingHistory(from: data)
+        let restored = try await PersistenceActor(modelContainer: fresh).fetchAllReadingSessions()
+        #expect(restored.count == 1)
+        let r = try #require(restored.first)
+        #expect(r.sessionId == id)
+        #expect(r.durationSeconds == 450)
+        // Both locators degraded to nil — the session itself survived.
+        #expect(r.startLocator == nil)
+        #expect(r.endLocator == nil)
+    }
+
+    @Test func restoreReproducesEveryReadingStatsScalarVerbatim() async throws {
+        // F9: every ReadingStats scalar restores verbatim (not just lastReadAt).
+        let source = try makeContainer()
+        let fp = fingerprint("fullstats")
+        let lastRead = Date(timeIntervalSince1970: 1_450_000_000)
+        try seedStats(source, book: fp, totalSeconds: 12_345, sessionCount: 42,
+                      lastReadAt: lastRead, avgPagesPerHour: 33.5, avgWordsPerMinute: 215.0,
+                      totalPages: 410, totalWords: 88_000, longestSession: 4321)
+        let data = try await collector(source).collectReadingHistory()
+
+        let fresh = try makeContainer()
+        let r = restorer(fresh)
+        try await r.restoreReadingHistory(from: data)
+
+        func assertScalars(_ stats: ReadingStatsRecord) {
+            #expect(stats.totalReadingSeconds == 12_345)
+            #expect(stats.sessionCount == 42)
+            #expect(stats.lastReadAt == lastRead)
+            #expect(stats.averagePagesPerHour == 33.5)
+            #expect(stats.averageWordsPerMinute == 215.0)
+            #expect(stats.totalPagesRead == 410)
+            #expect(stats.totalWordsRead == 88_000)
+            #expect(stats.longestSessionSeconds == 4321)
+        }
+        let first = try await PersistenceActor(modelContainer: fresh).fetchAllReadingStats()
+        assertScalars(try #require(first.first))
+
+        // And again after a second restore — still verbatim, no recompute drift.
+        try await r.restoreReadingHistory(from: data)
+        let second = try await PersistenceActor(modelContainer: fresh).fetchAllReadingStats()
+        assertScalars(try #require(second.first))
     }
 
     // MARK: - Idempotency

--- a/vreaderTests/Services/Backup/BackupReadingHistoryTests.swift
+++ b/vreaderTests/Services/Backup/BackupReadingHistoryTests.swift
@@ -1,0 +1,333 @@
+// Purpose: Tests for the `reading-history.json` backup section (feature #58
+// WI-5) — collector, restorer round-trip, idempotency, schema-version
+// decoupling, and missing/corrupt-section handling.
+
+import Foundation
+import SwiftData
+import Testing
+@testable import vreader
+
+@Suite("Backup reading-history section")
+struct BackupReadingHistoryTests {
+
+    // MARK: - Fixtures
+
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema(SchemaV6.models)
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(for: schema, configurations: [config])
+    }
+
+    private func fingerprint(_ seed: String) -> DocumentFingerprint {
+        var hex = ""
+        let bytes = Array(seed.utf8)
+        var i = 0
+        while hex.count < 64 {
+            hex += String(format: "%02x", bytes[i % bytes.count] &+ UInt8(i))
+            i += 1
+        }
+        return DocumentFingerprint(
+            contentSHA256: String(hex.prefix(64)), fileByteCount: 4096, format: .epub
+        )
+    }
+
+    private func tempDir() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("backup-rh-tests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func collector(_ container: ModelContainer) -> BackupDataCollector {
+        BackupDataCollector(
+            persistence: PersistenceActor(modelContainer: container),
+            defaults: UserDefaults(suiteName: "rh-test-\(UUID().uuidString)")!,
+            perBookSettingsBaseURL: tempDir()
+        )
+    }
+
+    private func restorer(_ container: ModelContainer) -> BackupDataRestorer {
+        BackupDataRestorer(
+            persistence: PersistenceActor(modelContainer: container),
+            defaults: UserDefaults(suiteName: "rh-test-\(UUID().uuidString)")!,
+            perBookSettingsBaseURL: tempDir()
+        )
+    }
+
+    private func seedSession(
+        _ container: ModelContainer, book: DocumentFingerprint,
+        sessionId: UUID = UUID(), startedAt: Date, endedAt: Date? = nil,
+        duration: Int = 600, pages: Int? = 10, words: Int? = 2000,
+        deviceId: String = "dev-1", isRecovered: Bool = false
+    ) throws {
+        let context = ModelContext(container)
+        let s = ReadingSession(
+            sessionId: sessionId, bookFingerprint: book, startedAt: startedAt,
+            endedAt: endedAt, durationSeconds: duration, pagesRead: pages,
+            wordsRead: words, deviceId: deviceId, isRecovered: isRecovered
+        )
+        context.insert(s)
+        try context.save()
+    }
+
+    private func seedStats(
+        _ container: ModelContainer, book: DocumentFingerprint,
+        totalSeconds: Int = 3600, sessionCount: Int = 3, lastReadAt: Date?
+    ) throws {
+        let context = ModelContext(container)
+        let stats = ReadingStats(
+            bookFingerprint: book, totalReadingSeconds: totalSeconds,
+            sessionCount: sessionCount, lastReadAt: lastReadAt,
+            longestSessionSeconds: 1800
+        )
+        context.insert(stats)
+        try context.save()
+    }
+
+    private func decode(_ data: Data) throws -> BackupReadingHistoryEnvelope {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(BackupReadingHistoryEnvelope.self, from: data)
+    }
+
+    // MARK: - Collector
+
+    @Test func collectEmitsSchemaVersion2() async throws {
+        let container = try makeContainer()
+        let data = try await collector(container).collectReadingHistory()
+        let envelope = try decode(data)
+        #expect(envelope.schemaVersion == 2)
+        #expect(envelope.schemaVersion == kBackupCurrentSchemaVersion)
+    }
+
+    @Test func collectEmptyStoreEmitsEmptyEnvelope() async throws {
+        let container = try makeContainer()
+        let envelope = try decode(try await collector(container).collectReadingHistory())
+        #expect(envelope.sessions.isEmpty)
+        #expect(envelope.stats.isEmpty)
+    }
+
+    @Test func collectRoundTripsEveryReadingSessionField() async throws {
+        let container = try makeContainer()
+        let fp = fingerprint("alpha")
+        let id = UUID()
+        let started = Date(timeIntervalSince1970: 1_700_000_000)
+        let ended = Date(timeIntervalSince1970: 1_700_000_600)
+        try seedSession(container, book: fp, sessionId: id, startedAt: started,
+                        endedAt: ended, duration: 600, pages: 15, words: 3300,
+                        deviceId: "iphone-17-pro", isRecovered: true)
+
+        let envelope = try decode(try await collector(container).collectReadingHistory())
+        #expect(envelope.sessions.count == 1)
+        let s = try #require(envelope.sessions.first)
+        #expect(s.sessionId == id)
+        #expect(s.bookFingerprintKey == fp.canonicalKey)
+        #expect(s.startedAt == started)
+        #expect(s.endedAt == ended)
+        #expect(s.durationSeconds == 600)
+        #expect(s.pagesRead == 15)
+        #expect(s.wordsRead == 3300)
+        #expect(s.deviceId == "iphone-17-pro")
+        #expect(s.isRecovered == true)
+    }
+
+    // MARK: - Round-trip
+
+    @Test func restoreRoundTripReproducesSessionsExactly() async throws {
+        // Seed source, collect, then restore into a FRESH container.
+        let source = try makeContainer()
+        let fp = fingerprint("bravo")
+        let id = UUID()
+        let started = Date(timeIntervalSince1970: 1_600_000_000)
+        try seedSession(source, book: fp, sessionId: id, startedAt: started,
+                        endedAt: nil, duration: 900, pages: 20, words: 4000,
+                        deviceId: "dev-x", isRecovered: false)
+        let data = try await collector(source).collectReadingHistory()
+
+        let fresh = try makeContainer()
+        try await restorer(fresh).restoreReadingHistory(from: data)
+
+        let restored = try await PersistenceActor(modelContainer: fresh).fetchAllReadingSessions()
+        #expect(restored.count == 1)
+        let r = try #require(restored.first)
+        #expect(r.sessionId == id)
+        #expect(r.bookFingerprintKey == fp.canonicalKey)
+        #expect(r.startedAt == started)
+        #expect(r.durationSeconds == 900)
+        #expect(r.pagesRead == 20)
+        #expect(r.wordsRead == 4000)
+        #expect(r.deviceId == "dev-x")
+    }
+
+    @Test func restoredReadingStatsLastReadAtIsVerbatimNotRecomputed() async throws {
+        // The crux: restore must NOT call recomputeStats (which stamps Date()).
+        let source = try makeContainer()
+        let fp = fingerprint("charlie")
+        let fixedLastRead = Date(timeIntervalSince1970: 1_500_000_000)  // a fixed PAST date
+        try seedStats(source, book: fp, totalSeconds: 7200, sessionCount: 9,
+                      lastReadAt: fixedLastRead)
+        let data = try await collector(source).collectReadingHistory()
+
+        let fresh = try makeContainer()
+        try await restorer(fresh).restoreReadingHistory(from: data)
+
+        let restored = try await PersistenceActor(modelContainer: fresh).fetchAllReadingStats()
+        #expect(restored.count == 1)
+        let r = try #require(restored.first)
+        // lastReadAt must EQUAL the seeded backup value — not restore-time.
+        #expect(r.lastReadAt == fixedLastRead)
+        #expect(r.totalReadingSeconds == 7200)
+        #expect(r.sessionCount == 9)
+    }
+
+    // MARK: - Idempotency
+
+    @Test func restoringTwiceDoesNotDuplicate() async throws {
+        let source = try makeContainer()
+        let fp = fingerprint("delta")
+        let id = UUID()
+        try seedSession(source, book: fp, sessionId: id,
+                        startedAt: Date(timeIntervalSince1970: 1_400_000_000))
+        try seedStats(source, book: fp, lastReadAt: Date(timeIntervalSince1970: 1_400_000_000))
+        let data = try await collector(source).collectReadingHistory()
+
+        let fresh = try makeContainer()
+        let r = restorer(fresh)
+        try await r.restoreReadingHistory(from: data)
+        try await r.restoreReadingHistory(from: data)  // second restore
+
+        let actor = PersistenceActor(modelContainer: fresh)
+        let sessions = try await actor.fetchAllReadingSessions()
+        let stats = try await actor.fetchAllReadingStats()
+        #expect(sessions.count == 1)  // no duplicate from the unique sessionId
+        #expect(stats.count == 1)
+    }
+
+    @Test func restoringTwicePreservesLastReadAt() async throws {
+        let source = try makeContainer()
+        let fp = fingerprint("echo")
+        let fixedLastRead = Date(timeIntervalSince1970: 1_300_000_000)
+        try seedStats(source, book: fp, lastReadAt: fixedLastRead)
+        let data = try await collector(source).collectReadingHistory()
+
+        let fresh = try makeContainer()
+        let r = restorer(fresh)
+        try await r.restoreReadingHistory(from: data)
+        try await r.restoreReadingHistory(from: data)
+
+        let stats = try await PersistenceActor(modelContainer: fresh).fetchAllReadingStats()
+        #expect(stats.first?.lastReadAt == fixedLastRead)
+    }
+
+    // MARK: - Schema-version decoupling
+
+    @Test func schemaV1ReadingHistorySectionStillRestores() async throws {
+        // A v1-tagged reading-history envelope must restore after the v2 bump
+        // (kBackupAcceptedSchemaVersions decoupling).
+        let v1Envelope = BackupReadingHistoryEnvelope(
+            schemaVersion: 1,
+            sessions: [BackupReadingSession(
+                sessionId: UUID(), bookFingerprintKey: fingerprint("v1book").canonicalKey,
+                startedAt: Date(timeIntervalSince1970: 1_200_000_000), endedAt: nil,
+                durationSeconds: 300, pagesRead: nil, wordsRead: nil,
+                startLocatorJSON: nil, endLocatorJSON: nil,
+                deviceId: "v1-dev", isRecovered: false
+            )],
+            stats: []
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(v1Envelope)
+
+        let fresh = try makeContainer()
+        // Must NOT throw — v1 is in kBackupAcceptedSchemaVersions.
+        try await restorer(fresh).restoreReadingHistory(from: data)
+        let sessions = try await PersistenceActor(modelContainer: fresh).fetchAllReadingSessions()
+        #expect(sessions.count == 1)
+    }
+
+    @Test func syntheticV3SectionThrowsUnsupportedSchemaVersion() async throws {
+        let v3Envelope = BackupReadingHistoryEnvelope(
+            schemaVersion: 3, sessions: [], stats: []
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(v3Envelope)
+
+        let fresh = try makeContainer()
+        await #expect(throws: BackupRestoreError.self) {
+            try await self.restorer(fresh).restoreReadingHistory(from: data)
+        }
+    }
+
+    @Test func corruptJSONThrows() async throws {
+        let garbage = Data("{not valid json".utf8)
+        let fresh = try makeContainer()
+        await #expect(throws: (any Error).self) {
+            try await self.restorer(fresh).restoreReadingHistory(from: garbage)
+        }
+    }
+
+    // MARK: - Protocol default impls
+
+    /// A minimal collector that implements NONE of the optional sections —
+    /// proves the protocol default-impl keeps a pre-#58 collector compiling
+    /// and producing a valid empty `reading-history.json`.
+    final class MinimalCollector: BackupDataCollecting, @unchecked Sendable {
+        func collectAnnotations() async throws -> Data { Data("{}".utf8) }
+        func collectPositions() async throws -> Data { Data("{}".utf8) }
+        func collectSettings() async throws -> Data { Data("{}".utf8) }
+        func collectCollections() async throws -> Data { Data("{}".utf8) }
+        func collectBookSources() async throws -> Data { Data("{}".utf8) }
+        func collectPerBookSettings() async throws -> Data { Data("{}".utf8) }
+        func collectReplacementRules() async throws -> Data { Data("{}".utf8) }
+        func getBookCount() async -> Int { 0 }
+        // collectLibraryManifest + collectReadingHistory use the default impls.
+    }
+
+    @Test func collectorDefaultImplProducesValidEmptyReadingHistory() async throws {
+        let data = try await MinimalCollector().collectReadingHistory()
+        let envelope = try decode(data)
+        #expect(envelope.schemaVersion == kBackupCurrentSchemaVersion)
+        #expect(envelope.sessions.isEmpty)
+        #expect(envelope.stats.isEmpty)
+    }
+
+    /// A minimal restorer that implements NONE of the optional sections —
+    /// proves the `restoreReadingHistory` default no-op keeps a pre-#58
+    /// restorer compiling.
+    final class MinimalRestorer: BackupDataRestoring, @unchecked Sendable {
+        func restoreAnnotations(from data: Data) async throws {}
+        func restorePositions(from data: Data) async throws {}
+        func restoreSettings(from data: Data) async throws {}
+        func restoreCollections(from data: Data) async throws {}
+        func restoreBookSources(from data: Data) async throws {}
+        func restorePerBookSettings(from data: Data) async throws {}
+        func restoreReplacementRules(from data: Data) async throws {}
+        // restoreReadingHistory uses the default no-op impl.
+    }
+
+    @Test func restorerDefaultImplIsANoOp() async throws {
+        // The default restoreReadingHistory must not throw even on garbage —
+        // it is a no-op.
+        try await MinimalRestorer().restoreReadingHistory(from: Data("garbage".utf8))
+    }
+
+    // MARK: - Book-independence
+
+    @Test func sessionForBookWithNoLocalBookRowStillRestores() async throws {
+        // Reading history is book-independent — a session whose book key has
+        // no matching Book row still lands (the post-restore-without-blob case).
+        let source = try makeContainer()
+        let fp = fingerprint("orphan")
+        try seedSession(source, book: fp,
+                        startedAt: Date(timeIntervalSince1970: 1_100_000_000))
+        let data = try await collector(source).collectReadingHistory()
+
+        let fresh = try makeContainer()  // no Book rows at all
+        try await restorer(fresh).restoreReadingHistory(from: data)
+        let sessions = try await PersistenceActor(modelContainer: fresh).fetchAllReadingSessions()
+        #expect(sessions.count == 1)
+        #expect(sessions.first?.bookFingerprintKey == fp.canonicalKey)
+    }
+}


### PR DESCRIPTION
## Summary

- Fifth work item of feature #58. Adds the `reading-history.json` WebDAV backup section so `ReadingSession` + `ReadingStats` survive a restore-to-fresh-device (previously CloudKit-only — a WebDAV-only user lost all reading history on restore).
- WI-5 is **behavioral** (changes the backup format). Gate 5a slice verification recorded below.

Part of feature #665.

## What Changed

- **`BackupReadingHistory.swift` (NEW)** — `BackupReadingHistoryEnvelope` / `BackupReadingSession` / `BackupReadingStats` DTOs. `BackupReadingSession` mirrors **every** persisted `ReadingSession` field (locators as JSON strings per the `BackupHighlight.locatorJSON` precedent) so criterion (f) "preserves exactly" holds.
- **Schema bump 1 → 2** with a decoupled accepted set. `kBackupCurrentSchemaVersion` is now `2`; new `kBackupAcceptedSchemaVersions = {1, 2}`. `decodeAndValidate` validates against the accepted **set**, not the single current constant — so the v2 bump does **not** reject every existing v1 backup (the pre-v2 section shapes are byte-identical). A genuinely-newer v3 archive still throws `unsupportedSchemaVersion`. This is the central backward-compat concern from the plan's R3.
- **Collect + restore** — `BackupDataCollector.collectReadingHistory` + `BackupDataRestorer.restoreReadingHistory` + `PersistenceActor.restoreReadingHistory` (in a new `+ReadingHistory.swift` file — `+Backup.swift` is already over the size guideline). The restore is an **upsert** keyed by the `@Attribute(.unique)` columns; `ReadingStats` is written **verbatim** — restore does **not** call `recomputeStats` (which force-sets `lastReadAt = Date()`, violating criterion (f)).
- **`WebDAVProvider`** — protocol additions with default impls (empty envelope / no-op) so existing mock collectors/restorers compile unchanged; the collect tuple + restore loop gain `reading-history.json`.

Tests: `BackupReadingHistoryTests.swift` — 16 tests.

## WI Status

- WI-1, WI-2, WI-3, WI-4: foundational — merged (PRs #982, #994, #995, #999).
- WI-5: behavioral — this PR.
- **WI-6 (dashboard UI) is BLOCKED** on 4 open product decisions D1–D4 (entry point, time-window set, sort-field count, cards-vs-hero) — see the plan's "Design-vs-row divergences". WI-8 (final acceptance) depends on WI-6.

## Codex Audit (Gate 4)

2 rounds, thread `019e40db`, verdict **ship-as-is**. Round 1: 0 Critical, 1 High (`collectReadingHistory` swallowed fetch failures with `try?` → could silently emit an empty section and discard reading history; fixed by propagating), 1 Medium (locator path untested; added), 1 Low (partial verbatim assertion; added). Round 2: zero open findings.

Audit log: `.claude/codex-audits/feat-feature-58-wi-5-backup-reading-history-audit.md`

## Validation

- [x] `xcodebuild test` passes — 16 `BackupReadingHistoryTests` + 33 `WebDAVProviderTests` + the existing `BackupCollectorRestorerSuite` (schema test updated for the v2 bump)
- [x] Tests cover changed behavior (TDD: RED → GREEN)
- [x] Codex audit loop completed (2 rounds, verdict: ship-as-is)
- [x] Docs sync — `docs/architecture.md` updated (9-section count, reading-history.json, the corrected schema-validation claim)
- [x] Version bumped: 3.36.26 → 3.36.27

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: **behavioral** (backup format change).
- What was run / observed:
  - `BackupReadingHistoryTests` (16) — drives `collectReadingHistory` → `restoreReadingHistory` end-to-end through the real `BackupDataCollector` / `BackupDataRestorer` / `PersistenceActor` subsystem boundaries (in-memory SwiftData store, not stubs): collector field round-trip incl. locators, restore round-trip byte-equal, `ReadingStats` verbatim incl. `lastReadAt` (proves no `recomputeStats`), double-restore idempotency (no unique-constraint violation), v1-section-still-restores, synthetic-v3-throws, corrupt-JSON, book-independence, protocol default-impl behavior. All green.
  - `WebDAVProviderTests` (33) — the full backup → ZIP → restore cycle with `reading-history.json` wired into the collect tuple + restore loop. All green.
  - Full-app smoke build succeeds post-bump.
- The plan's "Docker WebDAV round-trip" full acceptance is properly **WI-8's** scope (final acceptance, depends on WI-6); WI-5's per-PR slice is the integration coverage through real subsystem boundaries above.

## Type of Change

- [x] Feature WI (Part of feature #665)

🤖 Generated with [Claude Code](https://claude.com/claude-code)