### PR TITLE
feat(#64 WI-9): migrate Foliate (AZW3/MOBI) container to unified highlight popover

### DIFF
--- a/.claude/codex-audits/feat-feature-64-wi-9-foliate-migration-audit.md
+++ b/.claude/codex-audits/feat-feature-64-wi-9-foliate-migration-audit.md
@@ -1,0 +1,121 @@
+---
+branch: feat/feature-64-wi-9-foliate-migration
+threadId: 019e40dc-f938-70a3-adc5-b1454ac8afc9
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-19
+---
+
+# Gate-4 Implementation Audit — Feature #64 WI-9 (Foliate / AZW3-MOBI container migration)
+
+## Scope
+
+WI-9 of the unified cross-format highlight-action popover — the fourth (and
+highest-risk) **behavioral** WI. Migrates the Foliate (AZW3/MOBI) reader
+container off feature #55's `notePreviewPresenterIfAvailable` (the read-only
+note preview) onto the unified popover's `unifiedHighlightPopoverPresenterIfAvailable`.
+
+- `FoliateHighlightMutator.swift` (NEW) — the Foliate-specific `HighlightMutating`
+  conformer (`@MainActor final class`), composing `HighlightPersisting` (persist)
+  + `FoliateHighlightJSBridge` (live SVG-overlay repaint via the CFI-keyed
+  `.foliateRequestAnnotationJS*` notification pair).
+- `FoliateSpikeView.swift` (MOD) — added a `@State highlightMutator`, built in a
+  new `.task`; swapped the attach to `unifiedHighlightPopoverPresenterIfAvailable`
+  passing `highlightMutator` as the `mutating:` boundary.
+
+`Feature64FoliateMigrationTests.swift` (NEW, 2 source-grep fences) +
+`FoliateHighlightMutatorTests.swift` (NEW, 12 tests).
+
+### Plan / implementation divergence (audited + accepted)
+
+Plan §3.7 originally specified the unified popover's modifier with TWO
+parameters — `coordinator: HighlightCoordinator?` + `foliateBridge:
+FoliateHighlightJSBridge?`. WI-4 (shipped) made a deliberate refinement: the
+modifier/router is format-agnostic over ONE `HighlightMutating` protocol
+(`mutating: (any HighlightMutating)?`). TXT/MD/PDF/EPUB pass `HighlightCoordinator`
+(a conformer). `FoliateHighlightJSBridge` is NOT a conformer (it only posts JS
+notifications — it does not persist), so the WI-4 refinement pushed the
+"compose persistence + JS bridge into one `HighlightMutating` conformer"
+responsibility into WI-9. WI-9 therefore adds `FoliateHighlightMutator` — more
+than the plan's literal "~60 LOC, `FoliateSpikeView.swift` only" scope, but the
+direct downstream consequence of the WI-4 single-protocol refinement.
+
+Codex round 1 explicitly assessed and **accepted** this: *"The design
+divergence is sound and faithful to the plan's intent. The WI-4 refinement to a
+single `HighlightMutating` boundary makes `FoliateHighlightMutator` the right
+composition point; it preserves the plan's rejection of routing Foliate through
+`HighlightCoordinator`"* (plan §5 R1-3/R2-2 — `HighlightCoordinator` requires a
+`HighlightRenderer` Foliate lacks).
+
+## Round 1 — Codex `019e40dc-f938-70a3-adc5-b1454ac8afc9`
+
+**No blocking findings** — Critical / High / Medium all none. Codex verified:
+
+- The divergence is sound and faithful to the plan's intent (see above).
+- `FoliateHighlightMutator` matches `HighlightCoordinator`'s outcome mapping,
+  including the R1-5 fetch discipline in code.
+- `deleteHighlight` does NOT double-post `.readerHighlightRemoved` — the bridge
+  owns that post.
+- `updateNote` triggers no Foliate JS notification (a note is not drawn).
+- The Foliate JS path stays notification-driven and escapes at the unchanged
+  `FoliateHighlightRenderer` / `FoliateJSEscaper` boundary.
+- `FoliateSpikeView` wiring is lifecycle-safe for the production case (the
+  modifier is inert until `highlightMutator` is set; the `@State` flip reattaches
+  the live popover path).
+- Concurrency shape acceptable: `@MainActor` mutator, `Sendable` `HighlightPersisting`,
+  expected actor hops.
+
+Two findings:
+
+| # | File:line | Severity | Issue | Fix |
+|---|-----------|----------|-------|-----|
+| F1 | `FoliateHighlightMutator.swift:102` | Low | `changeColor` repainted via `jsBridge.recolor` passing the caller's `color` argument, not the re-fetched `record.color` — weakened the "repaint from post-mutation state" invariant (equal in normal use). | Pass `record.color`. |
+| F2 | `FoliateHighlightMutatorTests.swift` | Low | The tests did not directly fence the plan-critical R1-5 branches for the new mutator — write-succeeds-then-fetch-throws (`.failed`), write-succeeds-then-clean-fetch-misses (`.notFound`), delete remove-failure after a successful up-front fetch. Highest-risk WI — exactly the regressions to fence. | Add explicit R1-5 branch tests. |
+
+## Resolution
+
+- **F1** — `changeColor` now passes `record.color` (the re-fetched persisted
+  color) to `jsBridge.recolor`; the invariant is explicit in the code comment.
+- **F2** — `FoliateHighlightMutatorTests` grew 7 → 12 tests. The `FakePersistence`
+  fake gained two independent knobs — `setFetchThrowsAfterMutation` (mutation
+  succeeds, post-mutation `fetchHighlights` throws) and `dropFromFetch` (mutation
+  writes the record but `fetchHighlights` excludes its id — a concurrent-deletion
+  race). 5 new tests fence the R1-5 branches across `changeColor` / `updateNote`
+  / `deleteHighlight`, including the "write landed but refetch failed → `.failed`,
+  not `.notFound`" distinction and the delete-sequencing races.
+
+## Round 2 — Codex `019e40dc-f938-70a3-adc5-b1454ac8afc9` (re-audit of the fixes)
+
+Verdict: **"Both Low findings are resolved... No remaining open Critical/High/Medium
+findings for WI-9. No blocking findings."**
+
+## Verdict
+
+**ship-as-is** — 2 rounds (round 1 found zero production correctness findings +
+2 Lows; round 2 clean).
+
+## Cross-test NotificationCenter pollution — fixed during implementation
+
+The first draft of `FoliateHighlightMutatorTests` spied on
+`NotificationCenter.default`. Under Swift Testing's parallel execution, one
+test's `recolor`/`delete` posts leaked into another test's spy (3 tests failed
+with foreign captures — the Bug #225 class). Fixed before the audit: the test
+injects an isolated `NotificationCenter()` per test into the
+`FoliateHighlightJSBridge` (via `FoliateHighlightMutator(... jsBridge:)`) and
+spies on that same isolated center — so a test sees ONLY its own mutator's posts.
+
+## Gate-5a verification note
+
+WI-9 is behavioral. The Gate-5a XCUITest slice (create an AZW3/MOBI highlight,
+tap it, recolor → confirm the overlay color changes; delete → confirm the
+overlay clears) depends on creating a highlight first. The same pre-existing
+XCUITest harness defect that blocked WI-6/7/8 (**Bug #237 / GH #986** — a
+long-press in an XCUITest surfaces no "Highlight" affordance; reproduces on the
+repo's own unmodified gesture-verification tests on `origin/main`, independent
+of feature #64) applies. WI-9's behavioral delta is verified by the unit-test
+layer: the 12 `FoliateHighlightMutatorTests` (the full `changeColor` /
+`updateNote` / `deleteHighlight` outcome matrix including the R1-5 races, with a
+`NotificationCenter` spy proving the recolor / delete JS-overlay pairs fire
+correctly), the 2 `Feature64FoliateMigrationTests` source-grep fences, the
+unchanged `FoliateHighlightJSBridge` / `FoliateSpikeViewTap` regression suites,
+and a clean full app build.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 541
-        MARKETING_VERSION: 3.36.26
+        CURRENT_PROJECT_VERSION: 542
+        MARKETING_VERSION: 3.36.27
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		297A0059E0ECEEFA691E839C /* FoliateMessageParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36EE33B24FB16F8AC319BDB2 /* FoliateMessageParser.swift */; };
 		298EB8447E1427B7FE4CE0F9 /* JSONExportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA638212AA92F9FF855ABC2 /* JSONExportTests.swift */; };
 		2999C19D201DFD14B176D2B3 /* TXTLazyTextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F7F0E16B5468446AE51D0C /* TXTLazyTextProvider.swift */; };
+		29B5552598092B0BE25D9FF5 /* Feature64FoliateMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A3C9C74AEB817E120ACDAF9 /* Feature64FoliateMigrationTests.swift */; };
 		2ACDD49C29110C6459556A71 /* SheetSectionContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529E7234A3FC73811D573A6C /* SheetSectionContract.swift */; };
 		2AD43547691478569AA638EB /* AIConfigurationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8038AAB18412F30C09CBDD9 /* AIConfigurationStore.swift */; };
 		2B2BB1E5BCB1E74F360BE9F2 /* SearchTextExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30D00221E111683E9FF0260A /* SearchTextExtractor.swift */; };
@@ -207,6 +208,7 @@
 		2CBF53D883E09532ABC29FE4 /* GenerativeCoverViewStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 963BA5B346A86B1447A26EF5 /* GenerativeCoverViewStyleTests.swift */; };
 		2CD1D6C0686DD8C096580AB3 /* SummaryScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA8C0234B383C8D2877E21CC /* SummaryScope.swift */; };
 		2D1E2FD1F2B6D51EC62EBB60 /* BookSourceHTTPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50CA80F28DFB8D0D4F4BEC25 /* BookSourceHTTPClientTests.swift */; };
+		2D73988936C9A657637B8154 /* FoliateHighlightMutator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC51E5F1213D2B1363C13D5 /* FoliateHighlightMutator.swift */; };
 		2D8D59A6A41D0A2D5AB16741 /* ReaderAuditFix2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD76366E51B98FEE9E53DB3C /* ReaderAuditFix2Tests.swift */; };
 		2D9E7771E15DA101401537FA /* UIKitNotePreviewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE94CCB00EEB04990AC71435 /* UIKitNotePreviewPresenter.swift */; };
 		2DA2E5132AD7271040AB6B4C /* HighlightRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69ECDAED09428E0C1CD6A724 /* HighlightRendererTests.swift */; };
@@ -254,6 +256,7 @@
 		354E24A0B0A690869F8EFC5A /* TapZoneOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271BAF9BD03F619061BA4D96 /* TapZoneOverlay.swift */; };
 		357590BC921E8A3A0E7132F1 /* FoliateStyleMapperChapterStartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E3F274866072EA56D8C0B4 /* FoliateStyleMapperChapterStartTests.swift */; };
 		357C70E2DA8091ED4022D40E /* RuleEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647BF55A1C20635AD7062973 /* RuleEngine.swift */; };
+		3611C9D190CF99F46820B06E /* FoliateHighlightMutatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61992F892AF73F530F54DAC /* FoliateHighlightMutatorTests.swift */; };
 		3613DFF5007EAA0C4D5B2CEB /* HighlightPopoverDeleteConfirm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B94D8DF6728DEE93B09DE96 /* HighlightPopoverDeleteConfirm.swift */; };
 		369D003DCE5F36A64E5C1C06 /* AIChatGeneralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90F4EB83CC68406DA14DD94 /* AIChatGeneralTests.swift */; };
 		36B37715BB3494F635566157 /* ImportJobQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117731FF4D8AE414141C5ECF /* ImportJobQueue.swift */; };
@@ -1465,6 +1468,7 @@
 		4B0EDE73D4EB702686B1326E /* MDReaderContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReaderContainerView.swift; sourceTree = "<group>"; };
 		4B3A240BB6031B14144741FE /* PDFAnnotationBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFAnnotationBridgeTests.swift; sourceTree = "<group>"; };
 		4B81B909B41CB8C14B613D73 /* LocatorRestorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorRestorer.swift; sourceTree = "<group>"; };
+		4BC51E5F1213D2B1363C13D5 /* FoliateHighlightMutator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightMutator.swift; sourceTree = "<group>"; };
 		4BD245135256A06A28C88178 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
 		4BD56854A37D8EA2B318B926 /* HighlightDedupeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightDedupeTests.swift; sourceTree = "<group>"; };
 		4BE92A7A9E6664A02130DF5E /* NoteCalloutAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteCalloutAction.swift; sourceTree = "<group>"; };
@@ -1620,6 +1624,7 @@
 		69C7229E97D0F8B543683A02 /* SearchQueryExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchQueryExecutor.swift; sourceTree = "<group>"; };
 		69ECDAED09428E0C1CD6A724 /* HighlightRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightRendererTests.swift; sourceTree = "<group>"; };
 		6A3131E83F93590395D14009 /* UnifiedEPUBLoadResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedEPUBLoadResult.swift; sourceTree = "<group>"; };
+		6A3C9C74AEB817E120ACDAF9 /* Feature64FoliateMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature64FoliateMigrationTests.swift; sourceTree = "<group>"; };
 		6A5928551FF9FBB8D2E87E6F /* AIAssistantView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAssistantView.swift; sourceTree = "<group>"; };
 		6AA1E6FB5ADF99CF8CEB51FF /* HighlightPopoverPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPopoverPresenterTests.swift; sourceTree = "<group>"; };
 		6B04729AD87389C9ECEB13CE /* HighlightRecordAnchorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightRecordAnchorTests.swift; sourceTree = "<group>"; };
@@ -1867,6 +1872,7 @@
 		A504B80204BEC5B968087D02 /* PersistenceActorRemoteOnlyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceActorRemoteOnlyTests.swift; sourceTree = "<group>"; };
 		A5717B0EFF152D86D07C5C0D /* EPUBSelectionTokenCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBSelectionTokenCacheTests.swift; sourceTree = "<group>"; };
 		A579625590B25F81679F1EA0 /* ReaderNotificationModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderNotificationModifier.swift; sourceTree = "<group>"; };
+		A61992F892AF73F530F54DAC /* FoliateHighlightMutatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightMutatorTests.swift; sourceTree = "<group>"; };
 		A694EB7A8BB6138115DAB32E /* tts.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = tts.js; sourceTree = "<group>"; };
 		A6DB55181F2F55D99D879507 /* FoliateSearchAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateSearchAdapterTests.swift; sourceTree = "<group>"; };
 		A6F1C998AAACA679A10A86D2 /* BookCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCollection.swift; sourceTree = "<group>"; };
@@ -2684,9 +2690,11 @@
 				ABFBA14606BD14D14A8D5500 /* EPUBWebViewBridgeTests.swift */,
 				3422A641DD03B2ACCB6645EA /* Feature55WebHostWiringTests.swift */,
 				C2E89BEB1454E17061367313 /* Feature64EPUBMigrationTests.swift */,
+				6A3C9C74AEB817E120ACDAF9 /* Feature64FoliateMigrationTests.swift */,
 				62B304D30B717A1AB66C2A5B /* Feature64PDFMigrationTests.swift */,
 				1E4E3B1DC47242FC7A17BD69 /* Feature64TXTMDMigrationTests.swift */,
 				469B267E0D3DB05D1D8F530A /* FoliateHighlightJSBridgeTests.swift */,
+				A61992F892AF73F530F54DAC /* FoliateHighlightMutatorTests.swift */,
 				9CB5EAAB268616336D42EC30 /* FoliateHighlightRendererTests.swift */,
 				D712BAAF509AEBA3A3FB01C3 /* FoliateHighlightRestoreDispatcherTests.swift */,
 				58F5ACDA719E20E4BFA9BAB3 /* FoliateReaderContainerViewTests.swift */,
@@ -3195,6 +3203,7 @@
 				1C07D184EF0E90D5F2DF7A36 /* EPUBWebViewBridgeJS.swift */,
 				DCC4E330CF0A4F1EBF039346 /* FoliateCoordinatorBox.swift */,
 				B75EC9C3C222236A27183F13 /* FoliateHighlightJSBridge.swift */,
+				4BC51E5F1213D2B1363C13D5 /* FoliateHighlightMutator.swift */,
 				21CF1C76C54971B97341E5E9 /* FoliateHighlightRenderer.swift */,
 				6F1F3EF7737CB98C28172050 /* FoliateHighlightRestoreDispatcher.swift */,
 				CF65A328F9A79571A5164390 /* FoliateReaderContainerView.swift */,
@@ -4592,12 +4601,14 @@
 				700CFFEC7C74E0532A0271F4 /* ExportTestFixtures.swift in Sources */,
 				5263D4201B4ABDDE4DF5FC14 /* Feature55WebHostWiringTests.swift in Sources */,
 				1CE79EFAA809405FA4A0FA99 /* Feature64EPUBMigrationTests.swift in Sources */,
+				29B5552598092B0BE25D9FF5 /* Feature64FoliateMigrationTests.swift in Sources */,
 				49247074A9377434E7854644 /* Feature64PDFMigrationTests.swift in Sources */,
 				FE6F700872F797C727EECB85 /* Feature64TXTMDMigrationTests.swift in Sources */,
 				982FDBDA893DC7DA931711C7 /* FeatureFlagsTests.swift in Sources */,
 				2DB8779FF53587C400452428 /* FileAvailabilityStateMachineTests.swift in Sources */,
 				019FB8C5A2498141587A09A4 /* FileURLImportRouterTests.swift in Sources */,
 				DD040D904159CBFF9C5B03F2 /* FoliateHighlightJSBridgeTests.swift in Sources */,
+				3611C9D190CF99F46820B06E /* FoliateHighlightMutatorTests.swift in Sources */,
 				F30E23AC6F6159FB814A7C7D /* FoliateHighlightRendererTests.swift in Sources */,
 				32B7B523223C7D83ED40A208 /* FoliateHighlightRestoreDispatcherTests.swift in Sources */,
 				3EB8343FF1512E959CCEDD65 /* FoliateHighlightTapResolverTests.swift in Sources */,
@@ -5102,6 +5113,7 @@
 				D924CEB663B0891962654696 /* FileURLImportRouter.swift in Sources */,
 				301498E0C7A6CBC1E7E8DF49 /* FoliateCoordinatorBox.swift in Sources */,
 				84FDAB02CDE741029EE927A8 /* FoliateHighlightJSBridge.swift in Sources */,
+				2D73988936C9A657637B8154 /* FoliateHighlightMutator.swift in Sources */,
 				11268CE0083F01ADC27C5C6B /* FoliateHighlightRenderer.swift in Sources */,
 				268DE55B3D1C25F7AAC58E0D /* FoliateHighlightRestoreDispatcher.swift in Sources */,
 				0ECFF8347437492AC8881CCF /* FoliateHighlightTapResolver.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5638,13 +5638,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 541;
+				CURRENT_PROJECT_VERSION = 542;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.26;
+				MARKETING_VERSION = 3.36.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5788,13 +5788,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 541;
+				CURRENT_PROJECT_VERSION = 542;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.26;
+				MARKETING_VERSION = 3.36.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Views/Reader/FoliateHighlightMutator.swift
+++ b/vreader/Views/Reader/FoliateHighlightMutator.swift
@@ -1,0 +1,167 @@
+// Purpose: Feature #64 WI-9 — `FoliateHighlightMutator`, the `HighlightMutating`
+// conformer that wires the unified highlight-action popover to the Foliate
+// (AZW3/MOBI) reader container.
+//
+// Foliate has NO `HighlightRenderer` conformer — `FoliateHighlightRenderer` is
+// a `struct` with only `static` JS-builder methods, and Foliate highlight
+// visuals are driven by `NotificationCenter` messages keyed on CFI. So the
+// Foliate container cannot reuse `HighlightCoordinator` (which requires a
+// `HighlightRenderer`) as the unified popover's `mutating:` boundary.
+//
+// `FoliateHighlightMutator` is the Foliate-specific `HighlightMutating`
+// conformer. It composes two pieces:
+//   - `HighlightPersisting` — persists the color / note / delete, returning
+//     the same typed `HighlightMutationOutcome` as `HighlightCoordinator`
+//     (`.success` / `.notFound` / `.failed`), with the same R1-5 fetch
+//     discipline (a post-mutation fetch throw is `.failed`, only a successful
+//     fetch with no matching id is `.notFound`).
+//   - `FoliateHighlightJSBridge` — repaints the live WKWebView SVG overlay via
+//     the CFI-keyed `.foliateRequestAnnotationJS*` notification pair.
+//
+// Why a separate type and not `HighlightCoordinator`: plan §5 rejected routing
+// Foliate through `HighlightCoordinator` (R1-3 / R2-2) — constructing one
+// requires a `HighlightRenderer` Foliate does not have.
+//
+// @coordinates-with: HighlightCoordinator.swift (the `HighlightMutating`
+//   protocol + the persistence pattern this mirrors), FoliateHighlightJSBridge.swift,
+//   HighlightPersisting.swift, FoliateSpikeView.swift (the consumer)
+
+#if canImport(UIKit)
+import Foundation
+
+/// The Foliate (AZW3/MOBI) `HighlightMutating` conformer for the unified
+/// highlight-action popover — persistence via `HighlightPersisting` + live
+/// overlay repaint via `FoliateHighlightJSBridge`.
+@MainActor
+final class FoliateHighlightMutator {
+    private let persistence: any HighlightPersisting
+    private let bookFingerprintKey: String
+    private let jsBridge: FoliateHighlightJSBridge
+
+    init(
+        persistence: any HighlightPersisting,
+        bookFingerprintKey: String,
+        jsBridge: FoliateHighlightJSBridge = FoliateHighlightJSBridge()
+    ) {
+        self.persistence = persistence
+        self.bookFingerprintKey = bookFingerprintKey
+        self.jsBridge = jsBridge
+    }
+
+    /// The result of `refetch` — either the post-mutation record, or the
+    /// `HighlightMutationOutcome` to return verbatim. A dedicated enum (not
+    /// `Result`) because `Result`'s failure type must be an `Error` and
+    /// `HighlightMutationOutcome` is not.
+    private enum RefetchResult {
+        case found(HighlightRecord)
+        case outcome(HighlightMutationOutcome)
+    }
+
+    /// Re-fetches the book's highlights after a mutation and returns the one
+    /// matching `highlightID`. Mirrors `HighlightCoordinator`'s R1-5 discipline:
+    /// a fetch throw is a generic `.failed`; only a successful fetch with no
+    /// match is `.notFound` (a concurrent-deletion race).
+    private func refetch(_ highlightID: UUID) async -> RefetchResult {
+        let records: [HighlightRecord]
+        do {
+            records = try await persistence.fetchHighlights(forBookWithKey: bookFingerprintKey)
+        } catch {
+            return .outcome(.failed)
+        }
+        guard let record = records.first(where: { $0.highlightId == highlightID }) else {
+            return .outcome(.notFound)
+        }
+        return .found(record)
+    }
+}
+
+// MARK: - HighlightMutating
+
+extension FoliateHighlightMutator: HighlightMutating {
+
+    /// Persists a new highlight color, then repaints the Foliate WKWebView
+    /// overlay via `FoliateHighlightJSBridge.recolor` (the CFI-keyed
+    /// delete-then-create JS pair). Returns a typed outcome so the popover
+    /// distinguishes a deleted-record race (→ dismiss) from a generic failure
+    /// (→ keep the popover open).
+    func changeColor(highlightID: UUID, to color: String) async -> HighlightMutationOutcome {
+        do {
+            try await persistence.updateHighlightColor(highlightId: highlightID, color: color)
+        } catch let error as PersistenceError {
+            if case .recordNotFound = error { return .notFound }
+            return .failed
+        } catch {
+            return .failed
+        }
+
+        switch await refetch(highlightID) {
+        case let .outcome(outcome):
+            return outcome
+        case let .found(record):
+            // Repaint the live overlay from the re-fetched record's OWN color,
+            // not the caller's `color` argument — the repaint must reflect
+            // post-mutation persisted state (the two are equal in normal use,
+            // but this keeps the invariant explicit).
+            jsBridge.recolor(
+                record: record, to: record.color, fingerprintKey: bookFingerprintKey
+            )
+            return .success(record)
+        }
+    }
+
+    /// Persists a note edit. No overlay repaint — a note is not drawn on the
+    /// page, so the only UI to refresh is the popover card (handled by the
+    /// caller). A trimmed-empty draft normalizes to `nil`.
+    func updateNote(highlightID: UUID, note: String?) async -> HighlightMutationOutcome {
+        let normalized = HighlightCoordinator.normalizedNote(note)
+
+        do {
+            try await persistence.updateHighlightNote(highlightId: highlightID, note: normalized)
+        } catch let error as PersistenceError {
+            if case .recordNotFound = error { return .notFound }
+            return .failed
+        } catch {
+            return .failed
+        }
+
+        switch await refetch(highlightID) {
+        case let .outcome(outcome):
+            return outcome
+        case let .found(record):
+            return .success(record)
+        }
+    }
+
+    /// Deletes a highlight from persistence, then strips the Foliate overlay
+    /// via `FoliateHighlightJSBridge.delete` — which posts BOTH
+    /// `.readerHighlightRemoved` (UUID — keeps the Annotations panel in sync)
+    /// AND `.foliateRequestAnnotationJSDelete` (CFI — clears the SVG overlay).
+    /// The record is fetched up front so a concurrent-deletion race is
+    /// `.notFound` rather than collapsing into a generic `.failed`.
+    func deleteHighlight(highlightID: UUID) async -> HighlightMutationOutcome {
+        // Fetch up front — to return the record on `.success` and to
+        // distinguish "already gone" (.notFound) from a fetch failure.
+        let record: HighlightRecord
+        switch await refetch(highlightID) {
+        case let .outcome(outcome):
+            return outcome
+        case let .found(fetched):
+            record = fetched
+        }
+
+        do {
+            try await persistence.removeHighlight(highlightId: highlightID)
+        } catch let error as PersistenceError {
+            if case .recordNotFound = error { return .notFound }
+            return .failed
+        } catch {
+            return .failed
+        }
+
+        // The bridge owns the `.readerHighlightRemoved` post — the mutator does
+        // NOT post it itself (that would double-fire and desync the panel).
+        jsBridge.delete(record: record, fingerprintKey: bookFingerprintKey)
+        return .success(record)
+    }
+}
+#endif

--- a/vreader/Views/Reader/FoliateSpikeView.swift
+++ b/vreader/Views/Reader/FoliateSpikeView.swift
@@ -31,6 +31,12 @@ struct FoliateSpikeView: View {
     @State private var isBookReady = false
     @State private var bookTitle = ""
     @State private var errorMessage: String?
+    /// Feature #64 WI-9: the Foliate `HighlightMutating` boundary for the
+    /// unified highlight-action popover. Built in `.task` (the model container
+    /// + fingerprintKey are available then). Foliate has no `HighlightRenderer`,
+    /// so this is `FoliateHighlightMutator` (persistence + JS bridge), not a
+    /// `HighlightCoordinator`. The attach helper is inert until it is non-nil.
+    @State private var highlightMutator: FoliateHighlightMutator?
     @Environment(\.modelContext) private var modelContext
 
     /// Feature #70 WI-4: the default unified font size used when no
@@ -101,18 +107,33 @@ struct FoliateSpikeView: View {
         .foliateHighlightTapHandler(fingerprintKey: fingerprintKey)
         .foliateSelectionHandler(fingerprintKey: fingerprintKey)
         .foliateHighlightRestoreHandler(fingerprintKey: fingerprintKey)
-        // Feature #55 WI-7: attach the tap-on-annotated-text note preview.
-        // `foliateHighlightTapHandler` posts `.readerHighlightTapped` when
-        // the user taps an AZW3/MOBI highlight; `NotePreviewModifier`
-        // (attached here) observes it to present the note preview. The
-        // Foliate event carries `sourceRect == .zero`, so the preview
-        // resolves to the bottom-sheet form. Inert in previews / test
-        // harnesses where the model container is unavailable.
-        .notePreviewPresenterIfAvailable(
+        // Feature #64 WI-9: a tap on a persisted AZW3/MOBI highlight opens the
+        // unified cross-format highlight-action popover (color / note / copy /
+        // share / delete) — superseding feature #55's read-only note preview.
+        // `foliateHighlightTapHandler` posts `.readerHighlightTapped` when the
+        // user taps a highlight; `HighlightPopoverModifier` (attached here)
+        // observes it. The Foliate event carries `sourceRect == .zero`, so the
+        // popover resolves to the bottom-sheet form. `mutating` is the
+        // `FoliateHighlightMutator` (Foliate has no `HighlightRenderer`, so it
+        // composes persistence + the JS-overlay bridge). Inert in previews /
+        // test harnesses where the mutator is nil.
+        .unifiedHighlightPopoverPresenterIfAvailable(
             modelContainer: modelContext.container,
             bookFingerprintKey: fingerprintKey ?? "",
+            mutating: highlightMutator,
             theme: settingsStore?.theme ?? .paper
         )
+        .task {
+            // Build the Foliate highlight-mutation boundary once. The
+            // `@State` flip makes SwiftUI recompute `body` and install the
+            // live popover modifier (the helper is inert while it is nil) —
+            // the same late-assignment pattern the native containers use.
+            guard highlightMutator == nil, let key = fingerprintKey else { return }
+            highlightMutator = FoliateHighlightMutator(
+                persistence: PersistenceActor(modelContainer: modelContext.container),
+                bookFingerprintKey: key
+            )
+        }
         .onReceive(NotificationCenter.default.publisher(for: .readerBookmarkRequested)) { _ in
             guard let key = fingerprintKey,
                   let fp = DocumentFingerprint(canonicalKey: key) else { return }

--- a/vreaderTests/Views/Reader/Feature64FoliateMigrationTests.swift
+++ b/vreaderTests/Views/Reader/Feature64FoliateMigrationTests.swift
@@ -1,0 +1,73 @@
+// Purpose: Feature #64 WI-9 — guards the migration of the Foliate (AZW3/MOBI)
+// reader container from feature #55's `notePreviewPresenterIfAvailable` (the
+// read-only note preview) to the unified highlight-action popover's
+// `unifiedHighlightPopoverPresenterIfAvailable`.
+//
+// WI-9's behavioral change: a *tap* on an existing AZW3/MOBI highlight opens
+// the unified highlight-action popover (color / note / copy / share / delete)
+// — NOT feature #55's read-only note callout. The Foliate highlight tap
+// arrives from the JS `foliateHighlightTapHandler`, which posts
+// `.readerHighlightTapped` (the unified popover's trigger, unchanged).
+//
+// Foliate has no `HighlightRenderer` conformer, so — unlike WI-6/7/8 — it
+// cannot pass a `HighlightCoordinator` as the popover's `mutating:` boundary.
+// WI-9 introduces `FoliateHighlightMutator` (a `HighlightMutating` conformer
+// composing `HighlightPersisting` + `FoliateHighlightJSBridge`); the Foliate
+// container passes that as `mutating:`. This source-grep test fences the WI-9
+// migration of `FoliateSpikeView`; the end-to-end behavior (tap → unified
+// popover) is exercised at Gate 5 device verification.
+
+#if canImport(UIKit)
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("Feature #64 WI-9 — Foliate container migration")
+@MainActor
+struct Feature64FoliateMigrationTests {
+
+    /// Repo root resolved by walking up from this test file:
+    /// `vreaderTests/Views/Reader/` → repo root.
+    private static func foliateContainerSource(testFilePath: String = #filePath) throws -> String {
+        let repoRoot = URL(fileURLWithPath: testFilePath)
+            .deletingLastPathComponent()  // Reader/
+            .deletingLastPathComponent()  // Views/
+            .deletingLastPathComponent()  // vreaderTests/
+            .deletingLastPathComponent()  // repo root
+        let url = repoRoot
+            .appendingPathComponent("vreader/Views/Reader/FoliateSpikeView.swift")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    @Test("Foliate container attaches the unified popover, not feature #55's note preview")
+    func foliateAttachesUnifiedHighlightPopoverPresenter() throws {
+        let source = try Self.foliateContainerSource()
+        #expect(
+            source.contains("unifiedHighlightPopoverPresenterIfAvailable"),
+            "FoliateSpikeView must attach `unifiedHighlightPopoverPresenterIfAvailable` (feature #64 WI-9)."
+        )
+        #expect(
+            !source.contains("notePreviewPresenterIfAvailable"),
+            "FoliateSpikeView must no longer attach `notePreviewPresenterIfAvailable` — superseded by the unified popover (feature #64 WI-9)."
+        )
+    }
+
+    @Test("Foliate container passes a FoliateHighlightMutator as the mutating boundary")
+    func foliatePassesFoliateHighlightMutatorAsMutating() throws {
+        let source = try Self.foliateContainerSource()
+        // Pin the plan-critical `mutating:` boundary — the unified popover's
+        // color / note / delete actions are inert if `mutating` regresses to
+        // `nil`. Foliate has no `HighlightRenderer`, so its `HighlightMutating`
+        // is the WI-9 `FoliateHighlightMutator` (persistence + JS bridge), not
+        // a `HighlightCoordinator`.
+        #expect(
+            source.contains("FoliateHighlightMutator"),
+            "FoliateSpikeView must build a `FoliateHighlightMutator` as the unified popover's `mutating:` boundary (feature #64 WI-9)."
+        )
+        #expect(
+            source.contains("mutating:"),
+            "FoliateSpikeView must pass a `mutating:` boundary to the unified popover (feature #64 WI-9)."
+        )
+    }
+}
+#endif

--- a/vreaderTests/Views/Reader/FoliateHighlightMutatorTests.swift
+++ b/vreaderTests/Views/Reader/FoliateHighlightMutatorTests.swift
@@ -1,0 +1,462 @@
+// Purpose: Feature #64 WI-9 — tests for `FoliateHighlightMutator`, the
+// `HighlightMutating` conformer that wires the unified highlight-action
+// popover to the Foliate (AZW3/MOBI) container.
+//
+// Foliate has no `HighlightRenderer` conformer, so it cannot reuse
+// `HighlightCoordinator` (which requires one). `FoliateHighlightMutator`
+// composes two pieces: it persists the color / note / delete via
+// `HighlightPersisting` (returning the same typed `HighlightMutationOutcome`
+// as `HighlightCoordinator` — `.success` / `.notFound` / `.failed`), and it
+// repaints the live WKWebView overlay via `FoliateHighlightJSBridge` (the
+// CFI-keyed `.foliateRequestAnnotationJS*` notification pair).
+//
+// Covers, with a fake `HighlightPersisting` + a `NotificationCenter` spy:
+//   - changeColor → persists the color, re-fetches, posts the recolor JS pair
+//     (delete-then-create), returns `.success(record)`.
+//   - changeColor on a deleted record → `.notFound`, no JS post.
+//   - changeColor with a generic persistence failure → `.failed`, no JS post.
+//   - updateNote → persists the note, returns `.success`, NO JS post (a note
+//     is not drawn on the page).
+//   - updateNote whitespace-only draft → normalized to nil.
+//   - deleteHighlight → persists the removal, posts `.readerHighlightRemoved`
+//     + the JS overlay-strip, returns `.success(record)`.
+//   - deleteHighlight on an already-gone record → `.notFound`, no posts.
+
+#if canImport(UIKit)
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("Feature #64 WI-9 — FoliateHighlightMutator")
+@MainActor
+struct FoliateHighlightMutatorTests {
+
+    private static let fingerprint = DocumentFingerprint(
+        contentSHA256: "foliate_mutator_sha_0000000000000000000000000000000000",
+        fileByteCount: 100, format: .azw3
+    )
+    private static let bookKey = fingerprint.canonicalKey
+
+    private func epubAnchorRecord(
+        id: UUID, cfi: String = "epubcfi(/6/4!/4/2/2)",
+        color: String = "yellow", note: String? = nil
+    ) -> HighlightRecord {
+        let anchor = AnnotationAnchor.epub(
+            href: "", cfi: cfi,
+            serializedRange: EPUBSerializedRange(
+                startContainerPath: "", startOffset: 0, endContainerPath: "", endOffset: 0
+            )
+        )
+        let locator = Locator.validated(bookFingerprint: Self.fingerprint, cfi: cfi)!
+        return HighlightRecord(
+            highlightId: id, locator: locator, anchor: anchor, profileKey: "k",
+            selectedText: "passage", color: color, note: note,
+            createdAt: Date(timeIntervalSince1970: 1), updatedAt: Date(timeIntervalSince1970: 2)
+        )
+    }
+
+    // MARK: - Fake HighlightPersisting
+
+    /// A `HighlightPersisting` fake whose mutation methods succeed, throw a
+    /// distinct `PersistenceError.recordNotFound`, or throw a generic error.
+    /// Mirrors the WI-3 `MutMockPersistence` shape.
+    private actor FakePersistence: HighlightPersisting {
+        enum Mode: Sendable { case success, recordNotFound, genericFailure }
+
+        private var mode: Mode = .success
+        private var stored: [UUID: HighlightRecord] = [:]
+        private(set) var lastColor: String?
+        private(set) var lastNote: String?
+        private(set) var lastNoteWasSet = false
+        private(set) var removeCallCount = 0
+        /// When true, the mutation itself succeeds but the post-mutation
+        /// `fetchHighlights` throws — the R1-5 "read failure after a
+        /// successful write" path, which must map to `.failed`, NOT `.notFound`.
+        private var fetchThrowsAfterMutation = false
+        /// IDs the mutation still writes to `stored` but `fetchHighlights`
+        /// excludes — simulates a concurrent deletion racing the mutation's
+        /// `await`, so the clean re-fetch misses the record → `.notFound`.
+        private var droppedFromFetch: Set<UUID> = []
+
+        func setMode(_ m: Mode) { mode = m }
+        func seed(_ record: HighlightRecord) { stored[record.highlightId] = record }
+        func setFetchThrowsAfterMutation(_ value: Bool) { fetchThrowsAfterMutation = value }
+        func dropFromFetch(_ id: UUID) { droppedFromFetch.insert(id) }
+
+        func addHighlight(
+            locator: Locator, selectedText: String, color: String,
+            note: String?, toBookWithKey key: String
+        ) async throws -> HighlightRecord { fatalError("unused") }
+
+        func addHighlight(
+            locator: Locator, anchor: AnnotationAnchor?, selectedText: String,
+            color: String, note: String?, toBookWithKey key: String
+        ) async throws -> HighlightRecord { fatalError("unused") }
+
+        func removeHighlight(highlightId: UUID) async throws {
+            switch mode {
+            case .recordNotFound:
+                throw PersistenceError.recordNotFound("Highlight \(highlightId)")
+            case .genericFailure:
+                throw NSError(domain: "test", code: 99)
+            case .success:
+                removeCallCount += 1
+                stored[highlightId] = nil
+            }
+        }
+
+        func updateHighlightNote(highlightId: UUID, note: String?) async throws {
+            switch mode {
+            case .recordNotFound:
+                throw PersistenceError.recordNotFound("Highlight \(highlightId)")
+            case .genericFailure:
+                throw NSError(domain: "test", code: 99)
+            case .success:
+                lastNoteWasSet = true
+                lastNote = note
+                if let rec = stored[highlightId] {
+                    stored[highlightId] = HighlightRecord(
+                        highlightId: rec.highlightId, locator: rec.locator, anchor: rec.anchor,
+                        profileKey: rec.profileKey, selectedText: rec.selectedText,
+                        color: rec.color, note: note, createdAt: rec.createdAt,
+                        updatedAt: Date(timeIntervalSince1970: 999)
+                    )
+                }
+            }
+        }
+
+        func updateHighlightColor(highlightId: UUID, color: String) async throws {
+            switch mode {
+            case .recordNotFound:
+                throw PersistenceError.recordNotFound("Highlight \(highlightId)")
+            case .genericFailure:
+                throw NSError(domain: "test", code: 99)
+            case .success:
+                lastColor = color
+                if let rec = stored[highlightId] {
+                    stored[highlightId] = HighlightRecord(
+                        highlightId: rec.highlightId, locator: rec.locator, anchor: rec.anchor,
+                        profileKey: rec.profileKey, selectedText: rec.selectedText,
+                        color: color, note: rec.note, createdAt: rec.createdAt,
+                        updatedAt: Date(timeIntervalSince1970: 999)
+                    )
+                }
+            }
+        }
+
+        func fetchHighlights(forBookWithKey key: String) async throws -> [HighlightRecord] {
+            if case .genericFailure = mode { throw NSError(domain: "test", code: 77) }
+            if fetchThrowsAfterMutation { throw NSError(domain: "test", code: 77) }
+            return stored.values.filter { !droppedFromFetch.contains($0.highlightId) }
+        }
+    }
+
+    // MARK: - NotificationCenter spy
+
+    /// Collects posted notifications synchronously on a *caller-supplied*
+    /// `NotificationCenter`. Each test passes its own isolated center (NOT
+    /// `.default`) so concurrently-running tests cannot cross-pollinate posts
+    /// — the Bug #225 class. Torn down by an explicit `stop()` (a `nonisolated
+    /// deinit` cannot touch this `@MainActor` type's stored tokens under
+    /// Swift 6).
+    private final class NotificationSpy {
+        struct Captured { let name: Notification.Name; let object: Any? }
+        private(set) var captured: [Captured] = []
+        private let center: NotificationCenter
+        private var tokens: [NSObjectProtocol] = []
+
+        init(center: NotificationCenter, names: [Notification.Name]) {
+            self.center = center
+            for name in names {
+                tokens.append(center.addObserver(
+                    forName: name, object: nil, queue: nil
+                ) { [weak self] note in
+                    self?.captured.append(Captured(name: name, object: note.object))
+                })
+            }
+        }
+        func stop() {
+            tokens.forEach { center.removeObserver($0) }
+            tokens.removeAll()
+        }
+        func count(_ name: Notification.Name) -> Int {
+            captured.filter { $0.name == name }.count
+        }
+    }
+
+    /// Builds a mutator whose `FoliateHighlightJSBridge` posts onto the given
+    /// isolated `NotificationCenter` — so the test's `NotificationSpy` sees
+    /// ONLY this mutator's posts.
+    private func makeMutator(
+        persistence: FakePersistence, center: NotificationCenter
+    ) -> FoliateHighlightMutator {
+        FoliateHighlightMutator(
+            persistence: persistence,
+            bookFingerprintKey: Self.bookKey,
+            jsBridge: FoliateHighlightJSBridge(notificationCenter: center)
+        )
+    }
+
+    // MARK: - changeColor
+
+    @Test("changeColor persists the color, posts the recolor JS pair, returns .success")
+    func changeColorSuccessPersistsAndRepaints() async {
+        let id = UUID()
+        let persistence = FakePersistence()
+        await persistence.seed(epubAnchorRecord(id: id, color: "yellow"))
+        // Isolated center — concurrently-running tests must not see each other's posts.
+        let center = NotificationCenter()
+        let mutator = makeMutator(persistence: persistence, center: center)
+
+        let spy = NotificationSpy(center: center, names: [
+            .foliateRequestAnnotationJSDelete, .foliateRequestAnnotationJSCreate
+        ])
+        defer { spy.stop() }
+
+        let outcome = await mutator.changeColor(highlightID: id, to: "pink")
+
+        // The color is persisted.
+        #expect(await persistence.lastColor == "pink")
+        // The post-mutation record is returned on `.success`.
+        if case let .success(record) = outcome {
+            #expect(record.highlightId == id)
+            #expect(record.color == "pink")
+        } else {
+            Issue.record("expected .success, got \(outcome)")
+        }
+        // The Foliate overlay is repainted via the recolor JS pair
+        // (delete-then-create).
+        #expect(spy.count(.foliateRequestAnnotationJSDelete) == 1)
+        #expect(spy.count(.foliateRequestAnnotationJSCreate) == 1)
+    }
+
+    @Test("changeColor on a deleted record returns .notFound and posts no JS")
+    func changeColorRecordNotFound() async {
+        let persistence = FakePersistence()
+        await persistence.setMode(.recordNotFound)
+        // Isolated center — concurrently-running tests must not see each other's posts.
+        let center = NotificationCenter()
+        let mutator = makeMutator(persistence: persistence, center: center)
+
+        let spy = NotificationSpy(center: center, names: [
+            .foliateRequestAnnotationJSDelete, .foliateRequestAnnotationJSCreate
+        ])
+        defer { spy.stop() }
+
+        let outcome = await mutator.changeColor(highlightID: UUID(), to: "pink")
+        #expect(outcome == .notFound)
+        #expect(spy.captured.isEmpty)
+    }
+
+    @Test("changeColor with a generic persistence failure returns .failed and posts no JS")
+    func changeColorGenericFailure() async {
+        let persistence = FakePersistence()
+        await persistence.setMode(.genericFailure)
+        // Isolated center — concurrently-running tests must not see each other's posts.
+        let center = NotificationCenter()
+        let mutator = makeMutator(persistence: persistence, center: center)
+
+        let spy = NotificationSpy(center: center, names: [
+            .foliateRequestAnnotationJSDelete, .foliateRequestAnnotationJSCreate
+        ])
+        defer { spy.stop() }
+
+        let outcome = await mutator.changeColor(highlightID: UUID(), to: "pink")
+        #expect(outcome == .failed)
+        #expect(spy.captured.isEmpty)
+    }
+
+    // MARK: - updateNote
+
+    @Test("updateNote persists the note, returns .success, posts NO JS")
+    func updateNoteSuccessNoRepaint() async {
+        let id = UUID()
+        let persistence = FakePersistence()
+        await persistence.seed(epubAnchorRecord(id: id))
+        // Isolated center — concurrently-running tests must not see each other's posts.
+        let center = NotificationCenter()
+        let mutator = makeMutator(persistence: persistence, center: center)
+
+        let spy = NotificationSpy(center: center, names: [
+            .foliateRequestAnnotationJSDelete, .foliateRequestAnnotationJSCreate,
+            .readerHighlightRemoved
+        ])
+        defer { spy.stop() }
+
+        let outcome = await mutator.updateNote(highlightID: id, note: "a thought")
+        #expect(await persistence.lastNote == "a thought")
+        if case let .success(record) = outcome {
+            #expect(record.highlightId == id)
+        } else {
+            Issue.record("expected .success, got \(outcome)")
+        }
+        // A note is not drawn on the page — no overlay repaint.
+        #expect(spy.captured.isEmpty)
+    }
+
+    @Test("updateNote normalizes a whitespace-only draft to nil")
+    func updateNoteWhitespaceNormalizedToNil() async {
+        let id = UUID()
+        let persistence = FakePersistence()
+        await persistence.seed(epubAnchorRecord(id: id))
+        // Isolated center — concurrently-running tests must not see each other's posts.
+        let center = NotificationCenter()
+        let mutator = makeMutator(persistence: persistence, center: center)
+
+        _ = await mutator.updateNote(highlightID: id, note: "   \n  ")
+        #expect(await persistence.lastNoteWasSet == true)
+        #expect(await persistence.lastNote == nil)
+    }
+
+    // MARK: - deleteHighlight
+
+    @Test("deleteHighlight persists the removal, posts removed + JS-strip, returns .success")
+    func deleteHighlightSuccess() async {
+        let id = UUID()
+        let persistence = FakePersistence()
+        await persistence.seed(epubAnchorRecord(id: id, cfi: "epubcfi(/6/10!/2)"))
+        // Isolated center — concurrently-running tests must not see each other's posts.
+        let center = NotificationCenter()
+        let mutator = makeMutator(persistence: persistence, center: center)
+
+        let spy = NotificationSpy(center: center, names: [
+            .readerHighlightRemoved, .foliateRequestAnnotationJSDelete
+        ])
+        defer { spy.stop() }
+
+        let outcome = await mutator.deleteHighlight(highlightID: id)
+
+        #expect(await persistence.removeCallCount == 1)
+        if case let .success(record) = outcome {
+            #expect(record.highlightId == id)
+        } else {
+            Issue.record("expected .success, got \(outcome)")
+        }
+        // `.readerHighlightRemoved` keeps the panel in sync; the JS-strip
+        // clears the SVG overlay.
+        #expect(spy.count(.readerHighlightRemoved) == 1)
+        #expect(spy.count(.foliateRequestAnnotationJSDelete) == 1)
+        // The removal posts `.readerHighlightRemoved` exactly once (the bridge
+        // owns that post — the mutator must not double-fire it).
+    }
+
+    @Test("deleteHighlight on an already-gone record returns .notFound and posts nothing")
+    func deleteHighlightAlreadyGone() async {
+        // The fake has no seeded record — the up-front fetch finds nothing.
+        let persistence = FakePersistence()
+        // Isolated center — concurrently-running tests must not see each other's posts.
+        let center = NotificationCenter()
+        let mutator = makeMutator(persistence: persistence, center: center)
+
+        let spy = NotificationSpy(center: center, names: [
+            .readerHighlightRemoved, .foliateRequestAnnotationJSDelete
+        ])
+        defer { spy.stop() }
+
+        let outcome = await mutator.deleteHighlight(highlightID: UUID())
+        #expect(outcome == .notFound)
+        #expect(await persistence.removeCallCount == 0)
+        #expect(spy.captured.isEmpty)
+    }
+
+    // MARK: - R1-5 fetch discipline (highest-risk WI — fenced explicitly)
+
+    @Test("changeColor: write succeeds then the re-fetch throws → .failed, not .notFound")
+    func changeColorWriteSucceedsThenFetchThrows() async {
+        let id = UUID()
+        let persistence = FakePersistence()
+        await persistence.seed(epubAnchorRecord(id: id))
+        // The color write succeeds; only the post-mutation fetch throws.
+        await persistence.setFetchThrowsAfterMutation(true)
+        let center = NotificationCenter()
+        let mutator = makeMutator(persistence: persistence, center: center)
+        let spy = NotificationSpy(center: center, names: [
+            .foliateRequestAnnotationJSDelete, .foliateRequestAnnotationJSCreate
+        ])
+        defer { spy.stop() }
+
+        let outcome = await mutator.changeColor(highlightID: id, to: "pink")
+        // A read failure after a successful write is a generic failure — NOT
+        // a deleted-record race (R1-5).
+        #expect(outcome == .failed)
+        #expect(await persistence.lastColor == "pink")  // the write DID land
+        #expect(spy.captured.isEmpty)                   // no repaint on failure
+    }
+
+    @Test("changeColor: write succeeds then a clean re-fetch misses the record → .notFound")
+    func changeColorWriteSucceedsThenCleanFetchMisses() async {
+        let id = UUID()
+        let persistence = FakePersistence()
+        await persistence.seed(epubAnchorRecord(id: id))
+        // The write succeeds, but a concurrent deletion drops the record from
+        // the fetch set — a clean fetch with no match.
+        await persistence.dropFromFetch(id)
+        let center = NotificationCenter()
+        let mutator = makeMutator(persistence: persistence, center: center)
+        let spy = NotificationSpy(center: center, names: [
+            .foliateRequestAnnotationJSDelete, .foliateRequestAnnotationJSCreate
+        ])
+        defer { spy.stop() }
+
+        let outcome = await mutator.changeColor(highlightID: id, to: "pink")
+        #expect(outcome == .notFound)
+        #expect(spy.captured.isEmpty)
+    }
+
+    @Test("updateNote: write succeeds then the re-fetch throws → .failed, not .notFound")
+    func updateNoteWriteSucceedsThenFetchThrows() async {
+        let id = UUID()
+        let persistence = FakePersistence()
+        await persistence.seed(epubAnchorRecord(id: id))
+        await persistence.setFetchThrowsAfterMutation(true)
+        let center = NotificationCenter()
+        let mutator = makeMutator(persistence: persistence, center: center)
+
+        let outcome = await mutator.updateNote(highlightID: id, note: "a thought")
+        #expect(outcome == .failed)
+        #expect(await persistence.lastNote == "a thought")  // the write DID land
+    }
+
+    @Test("deleteHighlight: up-front fetch throws → .failed, the remove is not attempted")
+    func deleteHighlightFetchThrows() async {
+        let id = UUID()
+        let persistence = FakePersistence()
+        await persistence.seed(epubAnchorRecord(id: id))
+        // The up-front fetch throws before the remove is reached.
+        await persistence.setFetchThrowsAfterMutation(true)
+        let center = NotificationCenter()
+        let mutator = makeMutator(persistence: persistence, center: center)
+        let spy = NotificationSpy(center: center, names: [
+            .readerHighlightRemoved, .foliateRequestAnnotationJSDelete
+        ])
+        defer { spy.stop() }
+
+        let outcome = await mutator.deleteHighlight(highlightID: id)
+        // A fetch failure up front is `.failed` — and the removal must NOT be
+        // attempted (the record was never confirmed to exist).
+        #expect(outcome == .failed)
+        #expect(await persistence.removeCallCount == 0)
+        #expect(spy.captured.isEmpty)
+    }
+
+    @Test("deleteHighlight: the remove throws recordNotFound after a successful fetch → .notFound")
+    func deleteHighlightRemoveRecordNotFound() async {
+        let id = UUID()
+        let persistence = FakePersistence()
+        await persistence.seed(epubAnchorRecord(id: id))
+        // The up-front fetch finds the record, but `removeHighlight` then
+        // throws `recordNotFound` — a concurrent deletion between the two.
+        await persistence.setMode(.recordNotFound)
+        let center = NotificationCenter()
+        let mutator = makeMutator(persistence: persistence, center: center)
+        let spy = NotificationSpy(center: center, names: [
+            .readerHighlightRemoved, .foliateRequestAnnotationJSDelete
+        ])
+        defer { spy.stop() }
+
+        let outcome = await mutator.deleteHighlight(highlightID: id)
+        #expect(outcome == .notFound)
+        #expect(spy.captured.isEmpty)  // no overlay strip on a notFound race
+    }
+}
+#endif


### PR DESCRIPTION
Part of feature #822 — the unified cross-format highlight-action popover. This
is **WI-9**, the fourth and highest-risk behavioral WI (WI-6 TXT/MD, WI-7 PDF,
WI-8 EPUB). It completes the per-format container migration; WI-10 is the final
WI (teardown of the superseded #55/#53 families + acceptance).

## What this does

Migrates the Foliate (AZW3/MOBI) reader container off feature #55's
`notePreviewPresenterIfAvailable` (the read-only note preview) onto the unified
popover's `unifiedHighlightPopoverPresenterIfAvailable`. A *tap* on a persisted
AZW3/MOBI highlight now opens the unified highlight-action popover (color /
note / copy / share / delete).

## Why a new `HighlightMutating` conformer

Foliate has **no `HighlightRenderer` conformer** — `FoliateHighlightRenderer`
is a static-method `struct`; Foliate highlight visuals are driven by
`NotificationCenter` messages keyed on CFI. So Foliate cannot pass a
`HighlightCoordinator` (which requires a `HighlightRenderer`) as the unified
popover's `mutating:` boundary, as TXT/MD/PDF/EPUB do.

WI-9 introduces **`FoliateHighlightMutator`** — the Foliate-specific
`HighlightMutating` conformer. It composes two pieces:
- `HighlightPersisting` — persists the color / note / delete, returning the
  typed `HighlightMutationOutcome` (`.success` / `.notFound` / `.failed`) with
  the same R1-5 fetch discipline as `HighlightCoordinator` (a post-mutation
  fetch throw is `.failed`; only a successful fetch with no matching id is
  `.notFound`).
- `FoliateHighlightJSBridge` — repaints the live WKWebView SVG overlay via the
  CFI-keyed `.foliateRequestAnnotationJS*` notification pair.

`updateNote` does **not** repaint (a note is not drawn on the page);
`deleteHighlight` delegates the `.readerHighlightRemoved` post to the bridge
(no double-fire).

### Plan / implementation divergence (audited + accepted)

Plan §3.7 originally specified the unified popover's modifier with separate
`coordinator: HighlightCoordinator?` + `foliateBridge: FoliateHighlightJSBridge?`
parameters. WI-4's shipped refinement made the router format-agnostic over ONE
`HighlightMutating` protocol — which pushed the "compose persistence + JS
bridge" responsibility into WI-9's `FoliateHighlightMutator`. The Gate-4 audit
explicitly assessed and accepted this as sound and faithful to plan §5's
rejection of routing Foliate through `HighlightCoordinator` (R1-3/R2-2 — that
requires a `HighlightRenderer` Foliate lacks).

## Changes

- **`FoliateHighlightMutator.swift`** (NEW) — the conformer described above.
- **`FoliateSpikeView.swift`** — add a `@State highlightMutator`, built in a
  new `.task`; swap the attach to `unifiedHighlightPopoverPresenterIfAvailable`
  passing it as `mutating:`. The existing
  `.foliateRequestAnnotationJSCreate/Delete` observers are untouched.
- **Tests** — `FoliateHighlightMutatorTests` (12 tests — the full
  `changeColor` / `updateNote` / `deleteHighlight` outcome matrix including the
  R1-5 races, with a `NotificationCenter` spy on an isolated per-test center
  proving the recolor / delete JS-overlay pairs fire correctly) +
  `Feature64FoliateMigrationTests` (2 source-grep fences).

## Gate 3 — TDD

RED: the 2 migration-guard tests fail on the unmodified Foliate source. GREEN:
all 14 WI-9 tests pass; the Foliate regression suites
(`FoliateHighlightJSBridge`, `FoliateSpikeViewTap`) green; full app build
succeeds.

## Gate 4 — Implementation audit

Codex `019e40dc`, 2 rounds, **ship-as-is**. Round 1 found zero production-code
correctness findings + 2 Lows (repaint-from-persisted-color; R1-5 branch
coverage), both fixed. Round 2 clean. Audit log:
`.claude/codex-audits/feat-feature-64-wi-9-foliate-migration-audit.md`.

Also fixed during implementation: an early test draft spied on
`NotificationCenter.default` and suffered cross-test pollution under parallel
execution (the Bug #225 class) — fixed by injecting an isolated
`NotificationCenter` per test.

## Gate 5 — Verification

WI-9 is behavioral. The Gate-5a XCUITest slice (create an AZW3/MOBI highlight,
tap it, recolor / delete, confirm the overlay) depends on creating a highlight
first — blocked by the same pre-existing harness defect that blocked WI-6/7/8
(**Bug #237 / GH #986** — a long-press in an XCUITest surfaces no "Highlight"
affordance; reproduces on the repo's own unmodified gesture-verification tests
on `origin/main`, independent of feature #64).

WI-9's behavioral delta is verified by the unit-test layer instead: the 12
`FoliateHighlightMutatorTests` (full outcome matrix + R1-5 races + the
`NotificationCenter` spy on the recolor/delete JS pairs), the 2
`Feature64FoliateMigrationTests` fences, the unchanged Foliate regression
suites, and a clean full app build.

## Doc-sync

WI-9 does not touch `docs/architecture.md` — the feature-#64 doc-sync (the
highlight-system section + README) is consolidated into WI-10 (the final WI),
per the plan, so the whole `HighlightPopover*` / `HighlightMutating` subsystem
is documented as one coherent update rather than churned per-WI.

## Version

Patch bump to `3.36.27` (behavioral WI, not the final WI of the feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)