### PR TITLE
chore: bump version to 3.36.28 — resolve 3.36.27 collision

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 542
-        MARKETING_VERSION: 3.36.27
+        CURRENT_PROJECT_VERSION: 543
+        MARKETING_VERSION: 3.36.28
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5650,13 +5650,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 542;
+				CURRENT_PROJECT_VERSION = 543;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.27;
+				MARKETING_VERSION = 3.36.28;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5800,13 +5800,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 542;
+				CURRENT_PROJECT_VERSION = 543;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.36.27;
+				MARKETING_VERSION = 3.36.28;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Why

PR #1001 (`#58` WI-5) and PR #1002 (`#64` WI-9) were prepared in parallel, both
against base version 3.36.26, and each shipped `MARKETING_VERSION 3.36.27` /
build 542. #1001 merged first and its post-merge finalizer tagged that merge
commit `v3.36.27`. The #1002 merge commit `d7fd72b` then landed on `main` with
a **duplicate, non-monotonic** version line.

## Fix

Re-bump `main` to the next free patch — **3.36.28 / build 543** — so the build
number is monotonic again (App Store Connect rejects non-monotonic build
numbers). The `v3.36.28` tag is cut from this commit. The `#64` WI-9 merge
commit is intentionally **not** tagged — `v3.36.27` already belongs to #1001's
`664df40`.

This is the same parallel-execution version-collision recovery applied earlier
for the `v3.36.19` → `v3.36.20` collision (PR #992). Pure version-line
correction — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)