### PR TITLE
chore: bump version to 3.37.2 — resolve 3.37.1 collision

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 547
-        MARKETING_VERSION: 3.37.1
+        CURRENT_PROJECT_VERSION: 548
+        MARKETING_VERSION: 3.37.2
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5550,13 +5550,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 547;
+				CURRENT_PROJECT_VERSION = 548;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.37.1;
+				MARKETING_VERSION = 3.37.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5700,13 +5700,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 547;
+				CURRENT_PROJECT_VERSION = 548;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.37.1;
+				MARKETING_VERSION = 3.37.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
PR #1007 and PR #1008 both bumped to 3.37.1; #1007 merged first and the `v3.37.1` tag was cut on it. `main` ended with two commits carrying `MARKETING_VERSION: 3.37.1`. This bumps to the next free patch (3.37.2 / build 548) so the next tag is monotonic.

Pure meta/version chore — no bug/feature row referenced (exempt from the fix-or-implement merge gate per AGENTS.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)