### PR TITLE
feat(#56 WI-3): PerBookSettingsOverride bilingual fields

### DIFF
--- a/.claude/codex-audits/feat-56-wi-3-perbook-bilingual-audit.md
+++ b/.claude/codex-audits/feat-56-wi-3-perbook-bilingual-audit.md
@@ -1,0 +1,36 @@
+---
+branch: feat/56-wi-3-perbook-bilingual
+threadId: 019e415b-b395-72e0-bcab-8d5d48cf5cdf
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-20
+---
+
+# Codex Audit — feat/56-wi-3-perbook-bilingual
+
+**Feature**: #56 — bilingual reading mode (WI-3, foundational, XS).
+**Scope**: three optional bilingual fields added to `PerBookSettingsOverride`
+(`bilingualEnabled`, `bilingualTargetLanguage`, `bilingualGranularity`).
+**Auditor**: Codex (`mcp__plugin_codex-toolkit_codex__codex`), read-only sandbox.
+**Thread**: `019e415b-b395-72e0-bcab-8d5d48cf5cdf`. Gate 4 — implementation audit.
+
+## Round 1 — 0 findings
+
+Codex confirmed:
+
+- The implementation matches the plan exactly — `PerBookSettingsOverride` adds
+  only the three optional bilingual fields, appends the new `init` parameters
+  with `nil` defaults, and does **not** touch `ResolvedSettings` or
+  `resolve(...)`.
+- The backward-compat contract holds: missing optional keys decode as `nil`,
+  unknown keys are still ignored by the synthesized `Codable`, and both cases
+  are covered by tests.
+- The new `resolve_isUnaffectedByBilingualFields` test correctly protects the
+  requirement that bilingual state must not enter the typography resolution
+  path.
+
+No Critical/High/Medium/Low findings.
+
+## Disposition
+
+Final verdict: **ship-as-is**.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 554
-        MARKETING_VERSION: 3.37.8
+        CURRENT_PROJECT_VERSION: 555
+        MARKETING_VERSION: 3.37.9
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5622,13 +5622,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 554;
+				CURRENT_PROJECT_VERSION = 555;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.37.8;
+				MARKETING_VERSION = 3.37.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5772,13 +5772,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 554;
+				CURRENT_PROJECT_VERSION = 555;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.37.8;
+				MARKETING_VERSION = 3.37.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/PerBookSettings.swift
+++ b/vreader/Services/PerBookSettings.swift
@@ -28,18 +28,36 @@ struct PerBookSettingsOverride: Codable, Sendable, Equatable {
     var letterSpacing: CGFloat?
     var themeName: String?
 
+    /// Feature #56 — whether bilingual reading mode is on for this book.
+    /// `nil` (a pre-#56 file or a never-toggled book) means bilingual off.
+    var bilingualEnabled: Bool?
+
+    /// Feature #56 — the bilingual target language (one of `BILINGUAL_LANGS`,
+    /// e.g. `"Chinese"`). `nil` inherits the default.
+    var bilingualTargetLanguage: String?
+
+    /// Feature #56 — bilingual segmentation granularity (`"paragraph"` /
+    /// `"sentence"`). `nil` inherits the default.
+    var bilingualGranularity: String?
+
     init(
         fontSize: CGFloat? = nil,
         fontName: String? = nil,
         lineSpacing: CGFloat? = nil,
         letterSpacing: CGFloat? = nil,
-        themeName: String? = nil
+        themeName: String? = nil,
+        bilingualEnabled: Bool? = nil,
+        bilingualTargetLanguage: String? = nil,
+        bilingualGranularity: String? = nil
     ) {
         self.fontSize = fontSize
         self.fontName = fontName
         self.lineSpacing = lineSpacing
         self.letterSpacing = letterSpacing
         self.themeName = themeName
+        self.bilingualEnabled = bilingualEnabled
+        self.bilingualTargetLanguage = bilingualTargetLanguage
+        self.bilingualGranularity = bilingualGranularity
     }
 }
 

--- a/vreaderTests/Services/PerBookSettingsTests.swift
+++ b/vreaderTests/Services/PerBookSettingsTests.swift
@@ -379,6 +379,93 @@ struct PerBookSettingsTests {
         #expect(global.theme == .photo)
     }
 
+    // MARK: - Bilingual fields (feature #56 WI-3)
+
+    @Test func bilingualFields_defaultToNil() {
+        let override = PerBookSettingsOverride()
+        #expect(override.bilingualEnabled == nil)
+        #expect(override.bilingualTargetLanguage == nil)
+        #expect(override.bilingualGranularity == nil)
+    }
+
+    @Test func bilingualFields_savedAndRestored() throws {
+        let dir = try makeTempDir()
+        defer { cleanUp(dir) }
+        let key = "epub:11aabb00112233445566778899aabbccddeeff00112233445566778899aabbcc:4096"
+        let override = PerBookSettingsOverride(
+            bilingualEnabled: true,
+            bilingualTargetLanguage: "Chinese",
+            bilingualGranularity: "paragraph"
+        )
+        try PerBookSettingsStore.save(override, for: key, baseURL: dir)
+        let restored = try #require(PerBookSettingsStore.settings(for: key, baseURL: dir))
+        #expect(restored.bilingualEnabled == true)
+        #expect(restored.bilingualTargetLanguage == "Chinese")
+        #expect(restored.bilingualGranularity == "paragraph")
+    }
+
+    @Test func bilingualFields_coexistWithTypographyOverrides() throws {
+        let dir = try makeTempDir()
+        defer { cleanUp(dir) }
+        let key = "epub:22aabb00112233445566778899aabbccddeeff00112233445566778899aabbcc:8192"
+        let override = PerBookSettingsOverride(
+            fontSize: 22, themeName: "dark",
+            bilingualEnabled: true, bilingualTargetLanguage: "Japanese",
+            bilingualGranularity: "sentence"
+        )
+        try PerBookSettingsStore.save(override, for: key, baseURL: dir)
+        let restored = try #require(PerBookSettingsStore.settings(for: key, baseURL: dir))
+        #expect(restored.fontSize == 22)
+        #expect(restored.themeName == "dark")
+        #expect(restored.bilingualEnabled == true)
+        #expect(restored.bilingualTargetLanguage == "Japanese")
+        #expect(restored.bilingualGranularity == "sentence")
+    }
+
+    @Test func olderJSON_withoutBilingualKeys_decodesWithNilBilingualFields() throws {
+        // A pre-#56 per-book file has no bilingual keys — the synthesized
+        // Codable init must decode it with nil bilingual fields (bilingual off).
+        let dir = try makeTempDir()
+        defer { cleanUp(dir) }
+        let key = "epub:33aabb00112233445566778899aabbccddeeff00112233445566778899aabbcc:2048"
+        let legacyJSON = #"{"fontSize":20,"fontName":"Georgia","themeName":"sepia"}"#
+        let fileURL = dir.appendingPathComponent(
+            key.replacingOccurrences(of: ":", with: "_") + ".json")
+        try Data(legacyJSON.utf8).write(to: fileURL)
+
+        let restored = try #require(PerBookSettingsStore.settings(for: key, baseURL: dir))
+        #expect(restored.fontSize == 20)
+        #expect(restored.themeName == "sepia")
+        #expect(restored.bilingualEnabled == nil)
+        #expect(restored.bilingualTargetLanguage == nil)
+        #expect(restored.bilingualGranularity == nil)
+    }
+
+    @Test @MainActor func resolve_isUnaffectedByBilingualFields() {
+        // The bilingual fields are NOT part of ResolvedSettings — adding them
+        // must not change typography resolution.
+        let global = makeGlobalStore()
+        global.typography.fontSize = 18
+        let withoutBilingual = PerBookSettingsOverride(fontSize: 25)
+        let withBilingual = PerBookSettingsOverride(
+            fontSize: 25, bilingualEnabled: true,
+            bilingualTargetLanguage: "Korean", bilingualGranularity: "paragraph")
+        let a = PerBookSettingsStore.resolve(perBook: withoutBilingual, global: global)
+        let b = PerBookSettingsStore.resolve(perBook: withBilingual, global: global)
+        #expect(a == b)
+        #expect(b.fontSize == 25)
+    }
+
+    @Test func bilingualFields_codableRoundTripsInMemory() throws {
+        let override = PerBookSettingsOverride(
+            bilingualEnabled: false,
+            bilingualTargetLanguage: "Arabic",
+            bilingualGranularity: "sentence")
+        let data = try JSONEncoder().encode(override)
+        let decoded = try JSONDecoder().decode(PerBookSettingsOverride.self, from: data)
+        #expect(decoded == override)
+    }
+
     // MARK: - Helpers
 
     @MainActor


### PR DESCRIPTION
## WI-3 — PerBookSettingsOverride bilingual fields

Part of feature #56 (bilingual reading mode). Third of 16 work items per `dev-docs/plans/20260519-feature-56-bilingual-reading.md`. Foundational tier (XS) — no user-observable behavior, unit tests + audit suffice (Gate 5).

### What this adds

Three optional fields on `PerBookSettingsOverride` (`vreader/Services/PerBookSettings.swift`):

- `bilingualEnabled: Bool?` — whether bilingual mode is on for this book
- `bilingualTargetLanguage: String?` — the target language (a `BILINGUAL_LANGS` value, e.g. `"Chinese"`)
- `bilingualGranularity: String?` — `"paragraph"` / `"sentence"`

All optional and additive. The synthesized `Codable init(from:)` ignores unknown keys and supplies `nil` for missing optional keys, so a pre-#56 per-book JSON file decodes with `nil` bilingual fields (bilingual off). The new `init` parameters are appended with `nil` defaults. The bilingual fields are **not** part of `ResolvedSettings` — typography resolution is unaffected.

### Tests

Extends `PerBookSettingsTests`: new fields default `nil`; save/restore round-trip; coexist with typography overrides; older JSON without bilingual keys decodes with `nil` bilingual fields; `resolve()` output is byte-identical with vs without bilingual fields set (proves it stays out of the resolution path); in-memory `Codable` round-trip.

### Gates

- **Gate 3 (TDD)**: RED → GREEN → REFACTOR. `PerBookSettingsTests` passes on iPhone 17 Pro Simulator (full project compiles clean).
- **Gate 4 (Codex audit)**: 1 round, `final_verdict: ship-as-is`, zero findings. Log: `.claude/codex-audits/feat-56-wi-3-perbook-bilingual-audit.md`.
- **Gate 5**: foundational WI — no device verification required.
- **Docs sync**: not triggered — an additive optional field on an existing value type conforming to an already-documented pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
