### PR TITLE
feat(#67 WI-3): SettingsHeaderViewModel + SettingsProfileCard component

### DIFF
--- a/.claude/codex-audits/feat-67-wi-3-profile-card-audit.md
+++ b/.claude/codex-audits/feat-67-wi-3-profile-card-audit.md
@@ -1,0 +1,72 @@
+# Codex Audit — feat/67-wi-3-profile-card
+
+Feature #67 (Settings profile-header card + grouped-row restyle), WI-3 —
+"`SettingsHeaderViewModel` + `SettingsProfileCard` component". Gate 4
+(implementation audit loop) per `.claude/rules/47-feature-workflow.md`.
+
+- **Auditor**: Codex MCP (`mcp__plugin_codex-toolkit_codex__codex`), read-only sandbox.
+- **Thread**: `019e415f-9dd6-7941-ba18-d7ff057438b3`
+- **Date**: 2026-05-20
+- **Rounds**: 2 (round 1 — 1 High + 1 Medium; round 2 — clean, ship-as-is).
+
+## Scope audited
+
+Production:
+- `vreader/ViewModels/SettingsHeaderViewModel.swift` (new) — `@MainActor @Observable`
+  view model fetching the library book count + this-month reading seconds via
+  the optional `LibraryStatsReading` boundary; nil/error → zeros; idempotent
+  (last-write-wins via a monotonic `latestRequestID`).
+- `vreader/Views/Settings/SettingsProfileCard.swift` (new) — the design's
+  `ProfileCardLibrary` (library-identity card, #862 Option A): 48pt three-book-
+  spine glyph tile, "Your library" serif-italic header, "N books · Nh read this
+  month" subline, pill Stats button.
+
+Tests:
+- `vreaderTests/ViewModels/SettingsHeaderViewModelTests.swift` (new)
+- `vreaderTests/Views/Settings/SettingsProfileCardTests.swift` (new)
+
+## Round 1 — findings (1 High + 1 Medium)
+
+- **High — surface-fill fidelity** (`SettingsProfileCard.swift`): the card
+  background / glyph tile / Stats pill were filled with substituted repo theme
+  tokens (`paperColor`, `inkColor`-opacity). The committed `ProfileCardLibrary`
+  design specifies explicit fills (`#fff` / `rgba(255,255,255,0.04)` card,
+  `rgba(0,0,0,0.04)` / `rgba(255,255,255,0.06)` glyph tile, `rgba(60,40,20,0.08)`
+  / `rgba(255,255,255,0.08)` pill) — a rule-51 issue: the card would render
+  flatter and lower-contrast than the handoff.
+- **Medium — `latestRequestID` race untested** (`SettingsHeaderViewModelTests.swift`):
+  `loadCalledTwiceIsStable` ran two sequential identical loads — it only proved
+  "double load doesn't accumulate", not last-write-wins across an `await`
+  suspension point, which is the regression `latestRequestID` exists to prevent.
+
+## Round 1 → fixes applied
+
+1. **High**: added `enum SettingsProfileCardColors` mirroring the JSX formulas
+   verbatim — `cardBackground` / `glyphTileFill` / `statsPillFill`, each
+   `isDark`-branched. The card body, glyph tile, and Stats pill consume these
+   helpers. File-header "Key decisions" gained a bullet. New tests
+   `cardBackgroundMatchesDesignLightAndDark` / `glyphTileFillMatchesDesignLightAndDark`
+   / `statsPillFillMatchesDesignLightAndDark` pin the exact RGBA components.
+2. **Medium**: added a real overlap test `slowEarlierLoadDoesNotOverwriteANewerLoad`
+   — a `GatedStats` actor double whose `countLibraryBooks` parks on a gate and
+   exposes `waitUntilEntered()`. The test starts load #1 (claims
+   `latestRequestID=1`, parks), deterministically waits until it has entered the
+   boundary, runs load #2 to completion (claims `latestRequestID=2`, applies 222),
+   then releases load #1 — asserting the stale value (111) never overwrites 222.
+   Not flaky — no `Task.yield()` ordering trick. `loadCalledTwiceIsStable` kept
+   as the simpler happy-path case.
+
+## Round 2 — re-audit
+
+Both round-1 findings verified genuinely resolved. The auditor explicitly
+confirmed the race test "is a real overlap test ... proves the stale request
+finishes after the newer one and still cannot overwrite it ... not dependent
+on a flaky `Task.yield()` ordering trick". No new Critical/High/Medium.
+
+## Verdict
+
+final_verdict: ship-as-is
+
+Gate 4 clean in 2 rounds (rule-47 maximum is 3). WI-3 ships. The visible mount
+of `SettingsProfileCard` into `SettingsView` is WI-4 — WI-3 delivers the view
+model + the component only (foundational tier).

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 555
-        MARKETING_VERSION: 3.37.9
+        CURRENT_PROJECT_VERSION: 556
+        MARKETING_VERSION: 3.37.10
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -293,6 +293,7 @@
 		3F690915D18151E5F28EFC40 /* ReaderMorePopoverParts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12841E371391B5AD20122A37 /* ReaderMorePopoverParts.swift */; };
 		3FB6C5452F598755573BFB4F /* TXTChapterStartDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EF994B8B9C677990960D7F2 /* TXTChapterStartDecorator.swift */; };
 		401E58831F4DC6EB06E53738 /* HTTPTTSConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C9907D3479515B56338825 /* HTTPTTSConfig.swift */; };
+		4036FC6433130C55784610E7 /* SettingsHeaderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56912BE618BA41A3B17325C5 /* SettingsHeaderViewModelTests.swift */; };
 		40479825289343F4985EF7C7 /* SelectiveRestorePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1A92ABEE677825BB310F05 /* SelectiveRestorePicker.swift */; };
 		408FD10C4D83D162C1A9D69C /* KeychainService+ProviderProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE50C2E67CBF0EB4747276C1 /* KeychainService+ProviderProfile.swift */; };
 		40B116973A4ED78C0B64F7E2 /* Feature35AnnotationsExportVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF06F0E93BCCA150869AE18 /* Feature35AnnotationsExportVerificationTests.swift */; };
@@ -377,6 +378,7 @@
 		5168983F9EDD267778A9EEC9 /* TXTChapterIndexBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3910DCA9C9F588B700679D76 /* TXTChapterIndexBuilder.swift */; };
 		51F370150CAD9A865053266C /* HighlightIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABEAF0841AD808F7EE48617 /* HighlightIntegrationTests.swift */; };
 		51F6D90704CD88D8F5160E19 /* FoliateStyleMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42E9BBD87941E0D6C66010EC /* FoliateStyleMapperTests.swift */; };
+		525C42C391E13F17D68C11A7 /* SettingsProfileCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D16B9536A1919EBEBAA22B3 /* SettingsProfileCardTests.swift */; };
 		52E5D3598F1520AEF23442C7 /* DebugPositionResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4459ED2850B657C535C05F16 /* DebugPositionResolverTests.swift */; };
 		5365C69DAECEFAE3481247B3 /* TOCBuilderTXTTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49624FC3C8E1AC31E011351C /* TOCBuilderTXTTests.swift */; };
 		539E581AA8A8427E199AC0A7 /* WebDAVBlobStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAC16C19C7D4C72EFC950C9 /* WebDAVBlobStore.swift */; };
@@ -810,6 +812,7 @@
 		B64CAC947A1951E5ED22009C /* QuoteRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AEB48E4BF208D97EEF397C /* QuoteRecovery.swift */; };
 		B69C0AB6A9AECC0E9A1A8692 /* ReaderNotificationHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82BC782199D1750DA66D1BCC /* ReaderNotificationHandlers.swift */; };
 		B6A6A8E340DF3D44604151EA /* WebDAVServerProfileStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25AAFF8F130DCEC64427D073 /* WebDAVServerProfileStoreTests.swift */; };
+		B6AC28BA9283EBF6B7C088BC /* SettingsProfileCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F181A4B41B6349FB9A8F4F7 /* SettingsProfileCard.swift */; };
 		B6E9616807134E2CC032FB73 /* Feature11EPUBBottomChromeVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63604C0EFC18CDB16EF2C176 /* Feature11EPUBBottomChromeVerificationTests.swift */; };
 		B72492B7B87AC29EBFE19BEB /* PipelineTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F038832B6A3B0C184154B6AD /* PipelineTypes.swift */; };
 		B7803B2BE60AEAE5CF7819C9 /* VerificationSettingsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791CB502C8B59E737F15E63C /* VerificationSettingsHelperTests.swift */; };
@@ -1094,6 +1097,7 @@
 		F8A29678ED4FE3B33CC97C71 /* SelectionPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B17BC96A003E5777FBFACC /* SelectionPopoverView.swift */; };
 		F8D243D5F4F95EDA50118FE5 /* foliate-bridge.js in Resources */ = {isa = PBXBuildFile; fileRef = CCBA2A70DA3EE6E28FAB3FFE /* foliate-bridge.js */; };
 		F8E7BB01AAFADCB93BF6DBFA /* Feature29WebDAVVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03019F035CBDE3EF65771114 /* Feature29WebDAVVerificationTests.swift */; };
+		F9944CF0FBC506CE9BA58EF3 /* SettingsHeaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8500C7EDCB2A51F928910E7F /* SettingsHeaderViewModel.swift */; };
 		FA8BF5E0D98277BECAFB70CA /* HapticFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92676552DDABC9E3D5E7DC76 /* HapticFeedback.swift */; };
 		FB0A5F6990BB44BA58C1F366 /* PersistenceActor+Backup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2832B213595B426B8FFC8B6B /* PersistenceActor+Backup.swift */; };
 		FB0BC111F33D81D4E93A031F /* HighlightListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 275DFDD33FCF69E75F251F27 /* HighlightListViewModelTests.swift */; };
@@ -1202,6 +1206,7 @@
 		0E32E90EB8316752FB90F6B5 /* SourceSerif4-LICENSE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "SourceSerif4-LICENSE.md"; sourceTree = "<group>"; };
 		0E394527455B13D1EE9B06A9 /* MigrationFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationFixtures.swift; sourceTree = "<group>"; };
 		0E8D5CB4F3E93E8A15D3EDEA /* ChangeTokenStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeTokenStore.swift; sourceTree = "<group>"; };
+		0F181A4B41B6349FB9A8F4F7 /* SettingsProfileCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsProfileCard.swift; sourceTree = "<group>"; };
 		0F64D33F5E4EB6B2F8F10CC8 /* OPDSCatalogListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSCatalogListView.swift; sourceTree = "<group>"; };
 		0F7059169A9ADC70EE01420E /* TXTFileLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTFileLoaderTests.swift; sourceTree = "<group>"; };
 		0F99442B3BA1E02CC3F2A2C1 /* ReaderPositionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPositionService.swift; sourceTree = "<group>"; };
@@ -1385,6 +1390,7 @@
 		3C3606C4B6B47F89102CCF3A /* BookDetailsRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailsRouteTests.swift; sourceTree = "<group>"; };
 		3C39119533D269F76F970FD1 /* PDFPageNavigatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFPageNavigatorTests.swift; sourceTree = "<group>"; };
 		3C567EE93DC61BBB63CEAC20 /* Locator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locator.swift; sourceTree = "<group>"; };
+		3D16B9536A1919EBEBAA22B3 /* SettingsProfileCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsProfileCardTests.swift; sourceTree = "<group>"; };
 		3D6C41170131F22118778D83 /* FontSizeCalibration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCalibration.swift; sourceTree = "<group>"; };
 		3D70FBE6B4F5F9DDBA035D25 /* SPIKE_RESULTS.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = SPIKE_RESULTS.md; sourceTree = "<group>"; };
 		3DF47D926F78F13327F6770C /* OPDSParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSParser.swift; sourceTree = "<group>"; };
@@ -1528,6 +1534,7 @@
 		55AE145B1D7CBB62F06750BA /* CoverPickCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoverPickCoordinatorTests.swift; sourceTree = "<group>"; };
 		560129625F0E48471C0F4B62 /* BlobPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlobPath.swift; sourceTree = "<group>"; };
 		5639E3F809343C8CE5D7A020 /* PDFPasswordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFPasswordTests.swift; sourceTree = "<group>"; };
+		56912BE618BA41A3B17325C5 /* SettingsHeaderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHeaderViewModelTests.swift; sourceTree = "<group>"; };
 		56E344B835F385EF870989C9 /* WebDAVProviderFactoryProfileDispatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProviderFactoryProfileDispatchTests.swift; sourceTree = "<group>"; };
 		57133EF1841CC86C1DFF1C11 /* AIProviderListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderListView.swift; sourceTree = "<group>"; };
 		5725E598AB5CBA16440549D4 /* HighlightPopoverMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPopoverMode.swift; sourceTree = "<group>"; };
@@ -1732,6 +1739,7 @@
 		8404837D8FC686DDDB62EEC3 /* AccentColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccentColorTests.swift; sourceTree = "<group>"; };
 		84BAC2CBFB7F533857E6A65B /* search_no_results.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = search_no_results.html; sourceTree = "<group>"; };
 		84E4ABD8F17B04EA35F23724 /* legado_multiple_sources.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = legado_multiple_sources.json; sourceTree = "<group>"; };
+		8500C7EDCB2A51F928910E7F /* SettingsHeaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHeaderViewModel.swift; sourceTree = "<group>"; };
 		851277A5872045D4D935CE2B /* DictionaryLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryLookup.swift; sourceTree = "<group>"; };
 		85C4EC2BEDD3FD73FFBF56B8 /* DebugReaderRegistryAwaitReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReaderRegistryAwaitReaderTests.swift; sourceTree = "<group>"; };
 		85EEEA47C4E7D01D716EF2A4 /* TXTContinuousChunkBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTContinuousChunkBuilderTests.swift; sourceTree = "<group>"; };
@@ -2443,6 +2451,7 @@
 				C68E9908FEE2CDE00C6EB279 /* AISettingsViewModelTests.swift */,
 				8E509DAF691A7E473603452A /* ReplacementRulesViewBannerTests.swift */,
 				96C994418AB3E9CCF1914CA9 /* SettingsIconRowTests.swift */,
+				3D16B9536A1919EBEBAA22B3 /* SettingsProfileCardTests.swift */,
 				4630258E354B2D34ADB23182 /* WebDAVProfileListViewModelEditorTests.swift */,
 				D31265D2F8B445FADB98DDFC /* WebDAVProfileListViewModelTests.swift */,
 			);
@@ -2553,6 +2562,7 @@
 				5D7F4F4B985D58E03A78680D /* PDFReaderViewModelTests.swift */,
 				8180BC93B7839BF9878114F1 /* ReadingDashboardViewModelTests.swift */,
 				576F111E93E863C656BDEC70 /* SearchViewModelTests.swift */,
+				56912BE618BA41A3B17325C5 /* SettingsHeaderViewModelTests.swift */,
 				55633F1E05B29D20C4A4D0D5 /* TXTReaderPositionBackCompatTests.swift */,
 				96A2462C6A873DEC45025230 /* TXTReaderViewModelChapterHeadingTests.swift */,
 				510A755F74250CC74B14021D /* TXTReaderViewModelContinuousTests.swift */,
@@ -3336,6 +3346,7 @@
 				389E1ABA0D009B5CC9E4B20B /* HTTPTTSSettingsView.swift */,
 				2960011CAB51F25CFF002132 /* KindResetPolicy.swift */,
 				0B9584B44764B8D11C7CC9F6 /* ReplacementRulesView.swift */,
+				0F181A4B41B6349FB9A8F4F7 /* SettingsProfileCard.swift */,
 				1C10EE670AC6E2320DF231D2 /* SettingsRowStyle.swift */,
 				138AEC5BBAD52B075096E5C8 /* SettingsView.swift */,
 				0C31B8CDD80C204C332BFF2B /* WebDAVProfileListViewModel.swift */,
@@ -3376,6 +3387,7 @@
 				D363190FCDF47ED48A1D7BC1 /* ReaderLifecycleHelper.swift */,
 				44B5BF67DD0616C80294ABC7 /* ReadingDashboardViewModel.swift */,
 				864A1B050775A46ADBE3304F /* SearchViewModel.swift */,
+				8500C7EDCB2A51F928910E7F /* SettingsHeaderViewModel.swift */,
 				E19A1FE14FDE4829AF0F5913 /* TXTReaderViewModel.swift */,
 				7056486BA460E0BE06235F54 /* UnifiedTextRendererViewModel.swift */,
 			);
@@ -4809,7 +4821,9 @@
 				8C4E8905FFFF8DB6C6CC5B13 /* SelectionPopoverPresenterTests.swift in Sources */,
 				D007D50EE76181258F5D0681 /* SelectiveRestoreCoordinatorTests.swift in Sources */,
 				4A87A6889CFFC099EE0AFBD6 /* SeriesTagPersistenceTests.swift in Sources */,
+				4036FC6433130C55784610E7 /* SettingsHeaderViewModelTests.swift in Sources */,
 				691280DF99A2E74DE49D6D94 /* SettingsIconRowTests.swift in Sources */,
+				525C42C391E13F17D68C11A7 /* SettingsProfileCardTests.swift in Sources */,
 				72269EDBA7EA565DE2F8E687 /* SettingsRowPaletteTests.swift in Sources */,
 				3A49641C17BE1F189457C72C /* SettingsSliderRowTests.swift in Sources */,
 				6544A2C30555EACAB1AF79D8 /* SettleStubProbe.swift in Sources */,
@@ -5355,6 +5369,8 @@
 				F8A29678ED4FE3B33CC97C71 /* SelectionPopoverView.swift in Sources */,
 				594C442CEEA499384283D6B7 /* SelectiveRestoreCoordinator.swift in Sources */,
 				40479825289343F4985EF7C7 /* SelectiveRestorePicker.swift in Sources */,
+				F9944CF0FBC506CE9BA58EF3 /* SettingsHeaderViewModel.swift in Sources */,
+				B6AC28BA9283EBF6B7C088BC /* SettingsProfileCard.swift in Sources */,
 				7860CAF3CC0C1A47AD25F2A2 /* SettingsRowPalette.swift in Sources */,
 				ECC3926B3DAC2A8B8C857CA1 /* SettingsRowStyle.swift in Sources */,
 				B8FEB54CE43F9108DB15F66E /* SettingsSliderRow.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5638,13 +5638,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 555;
+				CURRENT_PROJECT_VERSION = 556;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.37.9;
+				MARKETING_VERSION = 3.37.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5788,13 +5788,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 555;
+				CURRENT_PROJECT_VERSION = 556;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.37.9;
+				MARKETING_VERSION = 3.37.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/ViewModels/SettingsHeaderViewModel.swift
+++ b/vreader/ViewModels/SettingsHeaderViewModel.swift
@@ -1,0 +1,97 @@
+// Purpose: @MainActor @Observable view model that fetches the Settings
+// profile card's two numbers — the library book count and the current
+// calendar month's reading seconds — off the persistence layer. Keeps
+// `SettingsView` itself a thin composition. Feature #67 WI-3.
+//
+// Key decisions:
+// - @Observable + @MainActor for SwiftUI integration — the project's
+//   view-model pattern (`LibraryViewModel`, `ReadingDashboardViewModel`).
+// - The persistence boundary is injected as the narrow read-only
+//   `LibraryStatsReading` protocol, so tests substitute a mock without
+//   a SwiftData store.
+// - `load(persistence:)` takes an OPTIONAL boundary — `\.persistenceActor`
+//   is itself an optional Environment key (`nil` in previews/tests), so
+//   `SettingsView` passes whatever the Environment holds. A `nil`
+//   boundary is the "no data" path → zeros, the same as an empty library.
+// - `load` is idempotent — last-write-wins via a monotonic request id
+//   (the `ReadingDashboardViewModel.latestRequestID` precedent), so a
+//   `.task` re-run when the sheet re-appears is safe and a slow earlier
+//   load cannot overwrite a newer one.
+// - A boundary failure leaves the counts at zero (the card shows
+//   "0 books · 0h" gracefully) — it does not crash and it logs.
+//
+// @coordinates-with: LibraryStatsReading.swift, MonthBoundary.swift,
+//   SettingsProfileCard.swift, SettingsView.swift
+
+import Foundation
+import OSLog
+
+private let log = Logger(subsystem: "com.vreader.app", category: "Settings")
+
+/// Fetches the Settings profile card's book count + this-month reading
+/// seconds.
+@Observable
+@MainActor
+final class SettingsHeaderViewModel {
+
+    // MARK: - Observable state
+
+    /// The number of books in the library. Zero before the first
+    /// successful `load`, and after a failed or `nil`-boundary load.
+    private(set) var bookCount: Int = 0
+
+    /// The reading seconds accumulated in the current calendar month.
+    private(set) var monthReadingSeconds: Int = 0
+
+    // MARK: - Private
+
+    /// Monotonic request counter. Each `load` claims the next id; its
+    /// result is applied only if it is still the latest — so a slow
+    /// earlier load cannot overwrite a newer one's values.
+    private var latestRequestID = 0
+
+    // MARK: - Init
+
+    /// Constructs an empty view model. `SettingsView` owns it as
+    /// `@State` and calls `load` from a `.task`.
+    init() {}
+
+    // MARK: - Loading
+
+    /// Loads the book count + this-month reading seconds from
+    /// `persistence`.
+    ///
+    /// A `nil` boundary (or a boundary that throws) leaves both counts
+    /// at zero — the card renders "0 books · 0h" gracefully, the same
+    /// as a genuinely empty library. Safe to call repeatedly
+    /// (last-write-wins).
+    func load(persistence: (any LibraryStatsReading)?) async {
+        latestRequestID += 1
+        let requestID = latestRequestID
+
+        guard let persistence else {
+            applyIfCurrent(requestID: requestID, books: 0, seconds: 0)
+            return
+        }
+
+        do {
+            let month = MonthBoundary.currentMonth(containing: Date())
+            let books = try await persistence.countLibraryBooks()
+            let seconds = try await persistence.sumReadingSeconds(in: month)
+            applyIfCurrent(requestID: requestID, books: books, seconds: seconds)
+        } catch {
+            log.error(
+                "settings header load failed: \(String(describing: error), privacy: .public)"
+            )
+            applyIfCurrent(requestID: requestID, books: 0, seconds: 0)
+        }
+    }
+
+    /// Applies a load result only when it is still the most recent
+    /// request — drops a stale earlier load.
+    private func applyIfCurrent(requestID: Int, books: Int, seconds: Int) {
+        guard requestID == latestRequestID else { return }
+        bookCount = books
+        monthReadingSeconds = seconds
+    }
+}

--- a/vreader/Views/Settings/SettingsProfileCard.swift
+++ b/vreader/Views/Settings/SettingsProfileCard.swift
@@ -1,0 +1,213 @@
+// Purpose: Feature #67 — the design's profile-header card,
+// `ProfileCardLibrary` (`vreader-profile-stats.jsx`). A self-contained
+// SwiftUI view: a 48pt three-book-spine glyph tile, the "Your library"
+// serif-italic header, the "N books · Nh read this month" subline, and
+// a trailing pill Stats button.
+//
+// Identity model: #862 resolved the Settings profile card to
+// "Library-as-identity" (Option A) — the card represents the LIBRARY,
+// not a person. The header is the fixed serif-italic "Your library";
+// the avatar slot is the three-book-spine glyph. No name, no account.
+//
+// Pinned to `dev-docs/designs/vreader-fidelity-v1/project/
+// vreader-profile-stats.jsx` (`ProfileCardLibrary`).
+//
+// Key decisions:
+// - **Pure presentation.** The card takes its two numbers as init
+//   values and a `onOpenStats` closure — it fetches nothing and posts
+//   nothing. WI-3's `SettingsHeaderViewModel` supplies the numbers;
+//   WI-4's `SettingsView` supplies the closure (which posts the Stats
+//   hand-off notification). Taking explicit values (not a hard-coded
+//   "Your library") also keeps the #862 Option-B forward path open.
+// - **Subline reuses `ReadingTimeFormatter.formatCompactHours`** (WI-1)
+//   for the hour token, so the "this month" copy is consistent with
+//   the rest of the app's reading-time formatting.
+// - **Singular/plural** — "1 book" vs "N books" with a simple English
+//   rule (the app is English-only per AGENTS.md).
+// - **Serif-italic header** uses `ReaderTypography.body(for:.sourceSerif4)`
+//   — the same Source Serif 4 path `ReaderSheetChrome`'s title uses.
+// - **Card / tile / pill fills mirror the JSX formulas verbatim**
+//   (`SettingsProfileCardColors`) rather than substituting repo theme
+//   tokens — `ProfileCardLibrary` specifies explicit fills (`#fff` /
+//   `rgba(255,255,255,0.04)` card, etc.), and rule 51 wants the
+//   designed values, not an approximation.
+// - `*ForTesting` seams (`statsActionForTesting`, `headerTextForTesting`,
+//   `sublineTextForTesting`) expose the closure + copy so the
+//   composition test asserts them without a render path.
+//
+// @coordinates-with: SettingsHeaderViewModel.swift, SettingsView.swift,
+//   ReadingTimeFormatter.swift, ReaderTypography.swift, ReaderThemeV2.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-profile-stats.jsx`
+
+import SwiftUI
+
+/// The design's library-identity profile-header card.
+struct SettingsProfileCard: View {
+
+    /// The fixed header copy — the library-identity model (#862 Option
+    /// A) never shows a user name.
+    static let headerText = "Your library"
+
+    private let theme: ReaderThemeV2
+    private let bookCount: Int
+    private let monthReadingSeconds: Int
+    private let onOpenStats: () -> Void
+
+    /// - Parameters:
+    ///   - theme: the sheet theme (Settings is always `.paper`).
+    ///   - bookCount: the library book count for the subline.
+    ///   - monthReadingSeconds: this calendar month's reading seconds.
+    ///   - onOpenStats: invoked when the Stats pill is tapped.
+    init(
+        theme: ReaderThemeV2,
+        bookCount: Int,
+        monthReadingSeconds: Int,
+        onOpenStats: @escaping () -> Void
+    ) {
+        self.theme = theme
+        self.bookCount = bookCount
+        self.monthReadingSeconds = monthReadingSeconds
+        self.onOpenStats = onOpenStats
+    }
+
+    // MARK: - Testing seams
+
+    /// The closure the Stats button is wired to. A closure-only seam —
+    /// it confirms the card invokes `onOpenStats`; the card posts no
+    /// notification (that is WI-4's `SettingsView` wiring).
+    var statsActionForTesting: () -> Void { onOpenStats }
+
+    /// The header copy the card renders — always `Self.headerText`.
+    var headerTextForTesting: String { Self.headerText }
+
+    /// The subline copy the card renders.
+    var sublineTextForTesting: String { sublineText }
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: 12) {
+            glyphTile
+            VStack(alignment: .leading, spacing: 2) {
+                Text(Self.headerText)
+                    .font(Font(ReaderTypography.body(for: .sourceSerif4, size: 16)))
+                    .fontWeight(.semibold)
+                    .italic()
+                    .foregroundStyle(Color(theme.inkColor))
+                Text(sublineText)
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color(theme.subColor))
+            }
+            Spacer(minLength: 8)
+            statsButton
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(SettingsProfileCardColors.cardBackground(isDark: theme.isDark))
+        )
+    }
+
+    // MARK: - Subviews
+
+    /// The 48pt rounded tile holding the three-book-spine library glyph.
+    private var glyphTile: some View {
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .fill(SettingsProfileCardColors.glyphTileFill(isDark: theme.isDark))
+            .frame(width: 48, height: 48)
+            .overlay { ThreeBookSpineGlyph(theme: theme) }
+    }
+
+    /// The trailing pill-shaped Stats button.
+    private var statsButton: some View {
+        Button(action: onOpenStats) {
+            Text("Stats")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color(theme.inkColor))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(
+                    Capsule().fill(SettingsProfileCardColors.statsPillFill(isDark: theme.isDark))
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("settingsProfileStatsButton")
+    }
+
+    // MARK: - Copy
+
+    /// "{N} books · {hours} read this month" — singular "book" at N == 1.
+    private var sublineText: String {
+        let bookWord = bookCount == 1 ? "book" : "books"
+        let hours = ReadingTimeFormatter.formatCompactHours(totalSeconds: monthReadingSeconds)
+        return "\(bookCount) \(bookWord) · \(hours) read this month"
+    }
+}
+
+// MARK: - Card fills
+
+/// The design's explicit `ProfileCardLibrary` fills, mirroring the JSX
+/// formulas verbatim (`vreader-profile-stats.jsx`). Kept as a named
+/// helper so the composition test can pin the exact colors and the card
+/// uses the *designed* fills rather than substituted theme tokens.
+enum SettingsProfileCardColors {
+
+    /// Card background — design `t.isDark ? 'rgba(255,255,255,0.04)' : '#fff'`.
+    static func cardBackground(isDark: Bool) -> Color {
+        isDark
+            ? Color(.sRGB, white: 1.0, opacity: 0.04)
+            : Color(.sRGB, white: 1.0, opacity: 1.0)
+    }
+
+    /// Glyph-tile fill — design
+    /// `t.isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.04)'`.
+    static func glyphTileFill(isDark: Bool) -> Color {
+        isDark
+            ? Color(.sRGB, white: 1.0, opacity: 0.06)
+            : Color(.sRGB, white: 0.0, opacity: 0.04)
+    }
+
+    /// Stats-pill fill — design
+    /// `t.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(60,40,20,0.08)'`.
+    static func statsPillFill(isDark: Bool) -> Color {
+        isDark
+            ? Color(.sRGB, white: 1.0, opacity: 0.08)
+            : Color(.sRGB, red: 60 / 255.0, green: 40 / 255.0, blue: 20 / 255.0, opacity: 0.08)
+    }
+}
+
+// MARK: - Library glyph
+
+/// The design's three-book-spine library glyph — three rounded
+/// vertical bars of staggered height, mirroring the `<svg>` in
+/// `ProfileCardLibrary`.
+private struct ThreeBookSpineGlyph: View {
+    let theme: ReaderThemeV2
+
+    var body: some View {
+        // The design SVG is 22×26 with three rects:
+        //   x0.6  y3  6×20  fill accent
+        //   x7.6  y0.6 6×22.4 fill dimmed-ink
+        //   x14.6 y5  6×18  fill warm-brown
+        HStack(alignment: .center, spacing: 1) {
+            spine(height: 20, color: Color(theme.accentColor))
+            spine(height: 22.4, color: Color(theme.inkColor).opacity(theme.isDark ? 0.7 : 0.5))
+            spine(height: 18, color: warmBrown)
+        }
+        .frame(width: 22, height: 26)
+    }
+
+    /// One book spine — a 6pt-wide rounded bar of the given height.
+    private func spine(height: CGFloat, color: Color) -> some View {
+        RoundedRectangle(cornerRadius: 1, style: .continuous)
+            .fill(color)
+            .frame(width: 6, height: height)
+    }
+
+    /// The design's third-spine color — `#8c6a4a` dark / `#5a3a3a` light.
+    private var warmBrown: Color {
+        theme.isDark
+            ? Color(.sRGB, red: 0x8c / 255.0, green: 0x6a / 255.0, blue: 0x4a / 255.0)
+            : Color(.sRGB, red: 0x5a / 255.0, green: 0x3a / 255.0, blue: 0x3a / 255.0)
+    }
+}

--- a/vreaderTests/ViewModels/SettingsHeaderViewModelTests.swift
+++ b/vreaderTests/ViewModels/SettingsHeaderViewModelTests.swift
@@ -1,0 +1,255 @@
+// Purpose: Tests for SettingsHeaderViewModel — the @MainActor
+// @Observable view model that fetches the Settings profile card's two
+// numbers (book count, this-month reading seconds). Feature #67 WI-3.
+
+import Testing
+import Foundation
+import SwiftData
+@testable import vreader
+
+@Suite("SettingsHeaderViewModel — feature #67 WI-3")
+@MainActor
+struct SettingsHeaderViewModelTests {
+
+    // MARK: - LibraryStatsReading mock
+
+    /// A configurable `LibraryStatsReading` double. `book count` is a
+    /// fixed value; `sumReadingSeconds` returns the sum of seeded
+    /// per-interval contributions whose key date falls in the queried
+    /// interval, so the view model's month-window logic is exercised.
+    private actor MockStats: LibraryStatsReading {
+        enum Mode: Sendable {
+            /// Normal operation — return seeded values.
+            case ok
+            /// Both reads throw.
+            case failing
+        }
+
+        let bookCount: Int
+        /// `(keyDate, seconds)` reading contributions — `sumReadingSeconds`
+        /// includes a contribution iff its `keyDate` is inside the interval.
+        let contributions: [(Date, Int)]
+        let mode: Mode
+        /// How many times each read was invoked — for idempotency tests.
+        private(set) var countCalls = 0
+        private(set) var sumCalls = 0
+
+        init(bookCount: Int, contributions: [(Date, Int)] = [], mode: Mode = .ok) {
+            self.bookCount = bookCount
+            self.contributions = contributions
+            self.mode = mode
+        }
+
+        struct StatsError: Error {}
+
+        func countLibraryBooks() async throws -> Int {
+            countCalls += 1
+            if mode == .failing { throw StatsError() }
+            return bookCount
+        }
+
+        func sumReadingSeconds(in interval: DateInterval) async throws -> Int {
+            sumCalls += 1
+            if mode == .failing { throw StatsError() }
+            return contributions
+                .filter { interval.start <= $0.0 && $0.0 < interval.end }
+                .reduce(0) { $0 + $1.1 }
+        }
+    }
+
+    // MARK: - Initial state
+
+    @Test func freshViewModelHasZeroCounts() {
+        let viewModel = SettingsHeaderViewModel()
+        #expect(viewModel.bookCount == 0)
+        #expect(viewModel.monthReadingSeconds == 0)
+    }
+
+    // MARK: - load — book count
+
+    @Test func loadPopulatesBookCountFromBoundary() async {
+        let viewModel = SettingsHeaderViewModel()
+        await viewModel.load(persistence: MockStats(bookCount: 5))
+        #expect(viewModel.bookCount == 5)
+    }
+
+    // MARK: - load — this-month reading seconds
+
+    @Test func loadCountsOnlyThisMonthReadingSeconds() async {
+        // One session this month, one last month — only this month counts.
+        let now = Date()
+        let calendar = Calendar.current
+        let thisMonth = now
+        let lastMonth = calendar.date(byAdding: .month, value: -1, to: now)!
+        let mock = MockStats(
+            bookCount: 3,
+            contributions: [(thisMonth, 1_800), (lastMonth, 9_999)]
+        )
+        let viewModel = SettingsHeaderViewModel()
+        await viewModel.load(persistence: mock)
+        #expect(viewModel.monthReadingSeconds == 1_800)
+    }
+
+    @Test func loadSumsMultipleThisMonthSessions() async {
+        let now = Date()
+        let mock = MockStats(
+            bookCount: 2,
+            contributions: [(now, 600), (now, 1_200), (now, 300)]
+        )
+        let viewModel = SettingsHeaderViewModel()
+        await viewModel.load(persistence: mock)
+        #expect(viewModel.monthReadingSeconds == 2_100)
+    }
+
+    // MARK: - Empty / nil-boundary path
+
+    @Test func loadWithNilBoundaryLeavesZeros() async {
+        let viewModel = SettingsHeaderViewModel()
+        await viewModel.load(persistence: nil)
+        #expect(viewModel.bookCount == 0)
+        #expect(viewModel.monthReadingSeconds == 0)
+    }
+
+    @Test func loadWithEmptyLibraryLeavesZeros() async {
+        let viewModel = SettingsHeaderViewModel()
+        await viewModel.load(persistence: MockStats(bookCount: 0, contributions: []))
+        #expect(viewModel.bookCount == 0)
+        #expect(viewModel.monthReadingSeconds == 0)
+    }
+
+    // MARK: - Error path
+
+    @Test func loadWithThrowingBoundaryLeavesZerosWithoutCrashing() async {
+        let viewModel = SettingsHeaderViewModel()
+        // A throwing boundary must not crash and must not corrupt state.
+        await viewModel.load(persistence: MockStats(bookCount: 7, mode: .failing))
+        #expect(viewModel.bookCount == 0)
+        #expect(viewModel.monthReadingSeconds == 0)
+    }
+
+    // MARK: - Idempotency
+
+    @Test func loadCalledTwiceIsStable() async {
+        let mock = MockStats(bookCount: 4, contributions: [(Date(), 1_000)])
+        let viewModel = SettingsHeaderViewModel()
+        await viewModel.load(persistence: mock)
+        await viewModel.load(persistence: mock)
+        // Last-write-wins — a second .task-driven load produces the same
+        // state, never doubled.
+        #expect(viewModel.bookCount == 4)
+        #expect(viewModel.monthReadingSeconds == 1_000)
+    }
+
+    /// A `LibraryStatsReading` double whose `countLibraryBooks` blocks
+    /// on an explicit gate, so a test can hold one `load` mid-flight
+    /// while a second `load` overtakes it. It also signals when a call
+    /// has *entered* `countLibraryBooks`, so the test can sequence
+    /// deterministically rather than relying on a bare `Task.yield()`.
+    private actor GatedStats: LibraryStatsReading {
+        let bookCount: Int
+        /// Continuations parked by `countLibraryBooks` calls, awaiting `release()`.
+        private var parked: [CheckedContinuation<Void, Never>] = []
+        private var releaseRequested = false
+        /// Set once `countLibraryBooks` has been entered; resumes any
+        /// `waitUntilEntered()` awaiter.
+        private var entered = false
+        private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+
+        init(bookCount: Int) { self.bookCount = bookCount }
+
+        /// Suspends until a `countLibraryBooks` call has been entered.
+        func waitUntilEntered() async {
+            if entered { return }
+            await withCheckedContinuation { entryWaiters.append($0) }
+        }
+
+        /// Unblocks every parked (and every future) `countLibraryBooks` call.
+        func release() {
+            releaseRequested = true
+            for continuation in parked { continuation.resume() }
+            parked.removeAll()
+        }
+
+        func countLibraryBooks() async throws -> Int {
+            entered = true
+            for waiter in entryWaiters { waiter.resume() }
+            entryWaiters.removeAll()
+            if !releaseRequested {
+                await withCheckedContinuation { parked.append($0) }
+            }
+            return bookCount
+        }
+
+        func sumReadingSeconds(in interval: DateInterval) async throws -> Int {
+            0
+        }
+    }
+
+    @Test func slowEarlierLoadDoesNotOverwriteANewerLoad() async {
+        // The whole point of `latestRequestID`: a stale earlier request
+        // resolving after a newer one must NOT clobber the newer values.
+        let viewModel = SettingsHeaderViewModel()
+        let slow = GatedStats(bookCount: 111)   // request 1 — blocked
+        let fast = MockStats(bookCount: 222)    // request 2 — completes first
+
+        // Start the slow load. It claims latestRequestID = 1, then parks
+        // inside countLibraryBooks.
+        let slowLoad = Task { await viewModel.load(persistence: slow) }
+        // Deterministically wait until request 1 has entered the boundary
+        // — so it has definitely claimed its request id before request 2.
+        await slow.waitUntilEntered()
+
+        // The fast load overtakes: it claims latestRequestID = 2 and
+        // applies request 2's values.
+        await viewModel.load(persistence: fast)
+        #expect(viewModel.bookCount == 222)
+
+        // Release the slow load — request 1 finishes last but is stale.
+        await slow.release()
+        await slowLoad.value
+
+        // Request 1's value (111) must NOT have overwritten request 2's (222).
+        #expect(viewModel.bookCount == 222)
+    }
+
+    // MARK: - Real PersistenceActor
+
+    @Test func loadAgainstRealPersistenceActorReadsSeededData() async throws {
+        let schema = Schema(SchemaV7.models)
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [config])
+        let context = ModelContext(container)
+
+        // Seed two books.
+        for i in 0..<2 {
+            var hex = ""
+            let bytes = Array("realbook\(i)".utf8)
+            var j = 0
+            while hex.count < 64 {
+                hex += String(format: "%02x", bytes[j % bytes.count] &+ UInt8(j))
+                j += 1
+            }
+            let fp = DocumentFingerprint(
+                contentSHA256: String(hex.prefix(64)), fileByteCount: 1024, format: .epub
+            )
+            context.insert(Book(
+                fingerprint: fp,
+                title: "Real Book \(i)",
+                provenance: ImportProvenance(
+                    source: .filesApp, importedAt: Date(), originalURLBookmarkData: nil
+                )
+            ))
+            // A reading session this month for each book.
+            context.insert(ReadingSession(
+                bookFingerprint: fp, startedAt: Date(), durationSeconds: 1_500
+            ))
+        }
+        try context.save()
+
+        let actor = PersistenceActor(modelContainer: container)
+        let viewModel = SettingsHeaderViewModel()
+        await viewModel.load(persistence: actor)
+        #expect(viewModel.bookCount == 2)
+        #expect(viewModel.monthReadingSeconds == 3_000)
+    }
+}

--- a/vreaderTests/Views/Settings/SettingsProfileCardTests.swift
+++ b/vreaderTests/Views/Settings/SettingsProfileCardTests.swift
@@ -1,0 +1,145 @@
+// Purpose: Composition tests for SettingsProfileCard — the design's
+// library-identity profile-header card (`ProfileCardLibrary` in
+// `vreader-profile-stats.jsx`). Feature #67 WI-3.
+//
+// COMPOSITION assertions, not pixel snapshots: the card builds for
+// every theme, its Stats button invokes the `onOpenStats` closure, and
+// the header / subline copy is pinned.
+
+import Testing
+import SwiftUI
+import UIKit
+import Foundation
+@testable import vreader
+
+@Suite("SettingsProfileCard composition — feature #67 WI-3")
+@MainActor
+struct SettingsProfileCardTests {
+
+    private func makeCard(
+        bookCount: Int = 152,
+        monthReadingSeconds: Int = 149_400,
+        theme: ReaderThemeV2 = .paper,
+        onOpenStats: @escaping () -> Void = {}
+    ) -> SettingsProfileCard {
+        SettingsProfileCard(
+            theme: theme,
+            bookCount: bookCount,
+            monthReadingSeconds: monthReadingSeconds,
+            onOpenStats: onOpenStats
+        )
+    }
+
+    // MARK: - Builds
+
+    @Test func buildsForEveryReaderTheme() {
+        for theme in ReaderThemeV2.allCases {
+            let card = makeCard(theme: theme)
+            _ = card.body
+        }
+    }
+
+    // MARK: - Stats action seam
+
+    @Test func statsActionInvokesTheOnOpenStatsClosure() {
+        var fired = false
+        let card = makeCard(onOpenStats: { fired = true })
+        // statsActionForTesting is a closure-only seam — it confirms the
+        // card invokes its onOpenStats closure. The card itself posts no
+        // notification; the notification hand-off is WI-4's wiring.
+        card.statsActionForTesting()
+        #expect(fired)
+    }
+
+    @Test func statsActionFiresEachTimeInvoked() {
+        var count = 0
+        let card = makeCard(onOpenStats: { count += 1 })
+        card.statsActionForTesting()
+        card.statsActionForTesting()
+        #expect(count == 2)
+    }
+
+    // MARK: - Header copy (library-identity model)
+
+    @Test func headerIsAlwaysYourLibrary() {
+        // Library-identity model (#862 Option A) — never a user name.
+        for count in [0, 1, 152] {
+            let card = makeCard(bookCount: count)
+            #expect(card.headerTextForTesting == "Your library")
+        }
+    }
+
+    // MARK: - Subline copy
+
+    @Test func sublineForEmptyLibraryIsZeroBooksZeroHours() {
+        let card = makeCard(bookCount: 0, monthReadingSeconds: 0)
+        #expect(card.sublineTextForTesting == "0 books · 0h read this month")
+    }
+
+    @Test func sublineForOneBookUsesSingularBook() {
+        // Singular "book", not "books".
+        let card = makeCard(bookCount: 1, monthReadingSeconds: 0)
+        #expect(card.sublineTextForTesting == "1 book · 0h read this month")
+    }
+
+    @Test func sublineForPopulatedLibraryMatchesDesignValue() {
+        // The design's "152 books · 41h read this month" (149 400 s = 41h30m).
+        let card = makeCard(bookCount: 152, monthReadingSeconds: 149_400)
+        #expect(card.sublineTextForTesting == "152 books · 41h read this month")
+    }
+
+    @Test func sublineSubHourReadingShowsLessThanOneHour() {
+        // 30 minutes of reading → "<1h" (never "0h" while reading happened).
+        let card = makeCard(bookCount: 3, monthReadingSeconds: 1_800)
+        #expect(card.sublineTextForTesting == "3 books · <1h read this month")
+    }
+
+    @Test func sublineTwoBooksUsesPluralBooks() {
+        let card = makeCard(bookCount: 2, monthReadingSeconds: 7_200)
+        #expect(card.sublineTextForTesting == "2 books · 2h read this month")
+    }
+
+    // MARK: - Design-fill pins (vreader-profile-stats.jsx ProfileCardLibrary)
+
+    /// Extracts the sRGB components of a `Color` for pinning.
+    private func components(_ color: Color) -> (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        UIColor(color).getRed(&r, green: &g, blue: &b, alpha: &a)
+        return (r, g, b, a)
+    }
+
+    @Test func cardBackgroundMatchesDesignLightAndDark() {
+        // Design: `t.isDark ? 'rgba(255,255,255,0.04)' : '#fff'`.
+        let light = components(SettingsProfileCardColors.cardBackground(isDark: false))
+        #expect(light.r == 1 && light.g == 1 && light.b == 1)
+        #expect(abs(light.a - 1.0) < 0.005)
+
+        let dark = components(SettingsProfileCardColors.cardBackground(isDark: true))
+        #expect(dark.r == 1 && dark.g == 1 && dark.b == 1)
+        #expect(abs(dark.a - 0.04) < 0.005)
+    }
+
+    @Test func glyphTileFillMatchesDesignLightAndDark() {
+        // Design: `t.isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.04)'`.
+        let light = components(SettingsProfileCardColors.glyphTileFill(isDark: false))
+        #expect(light.r == 0 && light.g == 0 && light.b == 0)
+        #expect(abs(light.a - 0.04) < 0.005)
+
+        let dark = components(SettingsProfileCardColors.glyphTileFill(isDark: true))
+        #expect(dark.r == 1 && dark.g == 1 && dark.b == 1)
+        #expect(abs(dark.a - 0.06) < 0.005)
+    }
+
+    @Test func statsPillFillMatchesDesignLightAndDark() {
+        // Design: `t.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(60,40,20,0.08)'`.
+        let light = components(SettingsProfileCardColors.statsPillFill(isDark: false))
+        #expect(abs(light.r - 60 / 255.0) < 0.005)
+        #expect(abs(light.g - 40 / 255.0) < 0.005)
+        #expect(abs(light.b - 20 / 255.0) < 0.005)
+        #expect(abs(light.a - 0.08) < 0.005)
+
+        let dark = components(SettingsProfileCardColors.statsPillFill(isDark: true))
+        #expect(dark.r == 1 && dark.g == 1 && dark.b == 1)
+        #expect(abs(dark.a - 0.08) < 0.005)
+    }
+}


### PR DESCRIPTION
## Summary

WI-3 of feature #67 (Settings profile-header card + grouped-row restyle). Builds the view model that fetches the card's two numbers and the design's library-identity profile-header card (`ProfileCardLibrary` in `vreader-profile-stats.jsx`). **Foundational** — no user-visible mount yet; WI-4 mounts the card into `SettingsView`.

Part of feature #67 (GH #825). Plan: `dev-docs/plans/20260519-feature-67-settings-profile-card.md`.

## What changed

- **`SettingsHeaderViewModel.swift`** (new) — `@MainActor @Observable`. Fetches the library book count + this-month reading seconds via the optional `LibraryStatsReading` boundary (WI-1, on `main`). A `nil` or throwing boundary leaves both at zero — the card renders "0 books · 0h" gracefully (same as a genuinely empty library). Idempotent: last-write-wins via a monotonic `latestRequestID` (the `ReadingDashboardViewModel` precedent), so a `.task` re-run when the sheet re-appears is safe and a slow earlier load cannot overwrite a newer one.
- **`SettingsProfileCard.swift`** (new) — the design's `ProfileCardLibrary` (library-identity model, #862 Option A): a 48pt three-book-spine glyph tile, the fixed "Your library" serif-italic header (never a user name), the "N books · Nh read this month" subline (reuses WI-1's `formatCompactHours`, singular "1 book"), and a trailing pill Stats button. Pure presentation — takes the two numbers + an `onOpenStats` closure; fetches and posts nothing. `SettingsProfileCardColors` mirrors the `ProfileCardLibrary` JSX fill formulas verbatim (card / glyph tile / Stats pill).

## Tests

22 tests across 2 suites, all green on iPhone 17 Pro Simulator (iOS 26):

- `SettingsHeaderViewModelTests` (12) — initial zeros, book-count load, this-month-only sum, multiple-session sum, `nil`-boundary → zeros, throwing-boundary → zeros (no crash), empty library, idempotency, and a **real `latestRequestID` overlap race** (a `GatedStats` actor parks load #1 mid-flight inside `countLibraryBooks` while load #2 overtakes — asserts the stale value never clobbers the newer one), plus a real in-memory `PersistenceActor` read.
- `SettingsProfileCardTests` (10) — build-for-every-`ReaderThemeV2`-theme, the `statsActionForTesting` closure seam fires `onOpenStats`, "Your library" header pin, subline copy (0 / 1 singular / 152 books, sub-hour `<1h`, design value `41h`), exact design-fill RGBA pins for light + dark.

## Gate status (rule 47)

- **Gate 3 (TDD)**: RED → GREEN → REFACTOR, 22 tests green.
- **Gate 4 (impl audit)**: Codex audit — thread `019e415f`, 2 rounds. Round 1: 1 High (surface-fill fidelity — card used substituted theme tokens instead of the designed `ProfileCardLibrary` fills) + 1 Medium (the `latestRequestID` race was not actually exercised — only a sequential double-load) — both fixed (`SettingsProfileCardColors` mirrors the JSX formulas + RGBA test pins; a real `GatedStats` overlap race test). Round 2: `ship-as-is`. Audit log: `.claude/codex-audits/feat-67-wi-3-profile-card-audit.md`.
- **Gate 5 (verification)**: WI-3 is **foundational** (view model + component, no user-observable behavior — the card is not yet in `SettingsView`) — verified by view-model state tests + card composition tests per rule 47 Gate 5. The visible mount is WI-4.
- **Rule 51 (no self-designed UI)**: `SettingsProfileCard` builds the *designed* `ProfileCardLibrary` surface — glyph, header, subline, pill, and the exact fills all pinned to the bundle. No invented UI.
- **Docs sync**: not triggered — `SettingsHeaderViewModel` is a feature-local ViewModel (not shared by ≥2 features); no new service / notification / schema; no user-visible feature lands.
- **Version**: bumped to 3.37.10 (build 556).

🤖 Generated with [Claude Code](https://claude.com/claude-code)