### PR TITLE
feat(#56 WI-4): ChapterSegmenter + ChapterTranslationChunker + JSON-array translation contract

### DIFF
--- a/.claude/codex-audits/feat-56-wi-4-segmenter-chunker-audit.md
+++ b/.claude/codex-audits/feat-56-wi-4-segmenter-chunker-audit.md
@@ -1,0 +1,57 @@
+---
+branch: feat/56-wi-4-segmenter-chunker
+threadId: 019e4163-a631-77b2-b2cb-d85605b44240
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-20
+---
+
+# Codex Audit — feat/56-wi-4-segmenter-chunker
+
+**Feature**: #56 — bilingual reading mode (WI-4, foundational).
+**Scope**: three pure utilities — `ChapterSegmenter` (paragraph + CJK-aware
+sentence split), `ChapterTranslationChunker` (segment-boundary chunking),
+`TranslationChunkContract` (strict JSON-array prompt + decode), plus the
+`TranslationStyle` enum.
+**Auditor**: Codex (`mcp__plugin_codex-toolkit_codex__codex`), read-only sandbox.
+**Thread**: `019e4163-a631-77b2-b2cb-d85605b44240`. Gate 4 — implementation audit.
+
+## Round 1 — 3 findings (0 Critical, 0 High, 1 Medium, 2 Low)
+
+Codex confirmed `ChapterSegmenter`, `ChapterTranslationChunker`, and
+`TranslationStyle` match the plan; the chunker preserves the index-order
+invariant; `TranslationStyle` is not on `AIRequest`; the strict decoder
+correctly rejects non-array / numeric / nested-array / object / garbage.
+
+1. **Medium — `stripCodeFence` truncated on embedded backticks.** It searched
+   *backwards* for any `` ``` `` run, so a legitimate JSON string element
+   containing backticks (e.g. `["code: ```x```"]`) was truncated and then
+   mis-decoded, forcing unnecessary fallback retries.
+   **Fix**: rewrote `stripCodeFence` to split into lines, drop the opening
+   fence line, and drop the closing fence ONLY when the last non-blank line is
+   exactly `` ``` ``. Embedded backticks are left intact.
+
+2. **Low — decoder failure tests used `#expect(throws: (any Error).self)`** —
+   too weak for a strict-contract utility.
+   **Fix**: the tests now assert the specific `DecodeError` case —
+   `.countMismatch(expected:actual:)` / `.notAStringArray` (`DecodeError` is
+   `Equatable`).
+
+3. **Low — undocumented zero-budget coercion.** `chunk(...)` silently coerced
+   a non-positive `maxCharsPerChunk` to `1` with no documented contract or test.
+   **Fix**: documented the coercion in the `chunk(...)` doc comment; added
+   `zeroBudgetIsCoercedToOne_eachNonEmptySegmentOwnsAChunk` and
+   `negativeBudgetIsAlsoCoercedSafely` tests.
+
+Added tests: `decode_preservesBackticksInsideAJSONStringElement`,
+`decode_openingFenceWithNoClosingFenceStillDecodes`.
+
+## Round 2 — 0 findings
+
+Codex confirmed the round-1 Medium is genuinely resolved (`stripCodeFence` no
+longer corrupts an embedded-backtick payload and still strips a real fence),
+the Low findings are resolved, and no new Critical/High/Medium was introduced.
+
+## Disposition
+
+Zero Critical/High/Medium after round 2. Final verdict: **ship-as-is**.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 556
-        MARKETING_VERSION: 3.37.10
+        CURRENT_PROJECT_VERSION: 557
+        MARKETING_VERSION: 3.37.11
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 		3D31B039400E1A83C4A1DF6D /* EPUBMetadataExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F003D569BCC0F29113468A /* EPUBMetadataExtractorTests.swift */; };
 		3D32DA9E354C6BA5A74A09C6 /* Feature31AutoPageTurnVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6BE724AEC4E98F6180228E /* Feature31AutoPageTurnVerificationTests.swift */; };
 		3DE8687C45492DB6E076D65E /* QuoteRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AB43BED5AC7096E7278A16 /* QuoteRecoveryTests.swift */; };
+		3DED10DB4A0FA7B18DE2E431 /* TranslationChunkContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9BD495685BB360AF81EDAE3 /* TranslationChunkContract.swift */; };
 		3DF0D817A67D0CEBD6C9BEC3 /* LibraryStatsReading.swift in Sources */ = {isa = PBXBuildFile; fileRef = EABA033B2052115B50F445EF /* LibraryStatsReading.swift */; };
 		3DF1A5D2E40DE8AAF521BB8C /* TranslationPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B3F47E988913B477EACF93 /* TranslationPanel.swift */; };
 		3EA33E950536DAC4CF5AA2B2 /* BookFormatIsSupportedExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74BC81AA927F17D2572106F6 /* BookFormatIsSupportedExtensionTests.swift */; };
@@ -295,6 +296,7 @@
 		401E58831F4DC6EB06E53738 /* HTTPTTSConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C9907D3479515B56338825 /* HTTPTTSConfig.swift */; };
 		4036FC6433130C55784610E7 /* SettingsHeaderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56912BE618BA41A3B17325C5 /* SettingsHeaderViewModelTests.swift */; };
 		40479825289343F4985EF7C7 /* SelectiveRestorePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1A92ABEE677825BB310F05 /* SelectiveRestorePicker.swift */; };
+		4066570D77F8395FDF24C4A5 /* ChapterSegmenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0DD73D7B4AC6420A155014 /* ChapterSegmenter.swift */; };
 		408FD10C4D83D162C1A9D69C /* KeychainService+ProviderProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE50C2E67CBF0EB4747276C1 /* KeychainService+ProviderProfile.swift */; };
 		40B116973A4ED78C0B64F7E2 /* Feature35AnnotationsExportVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF06F0E93BCCA150869AE18 /* Feature35AnnotationsExportVerificationTests.swift */; };
 		4107A78DB0996F371F4B3C6F /* PhaseBMediumAuditTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E270DE50F23F6125F3151CA /* PhaseBMediumAuditTests.swift */; };
@@ -399,6 +401,7 @@
 		56A9335B5F44D301240C81B7 /* AIChatMessageRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0216684C6AC6F1F2DA5EF4 /* AIChatMessageRow.swift */; };
 		57119DB5AB6677FBB6AECF3C /* TXTReaderContainerViewChapterStartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DCDE7714C1D65B4D045D3B /* TXTReaderContainerViewChapterStartTests.swift */; };
 		57137EA065C2A4D12FFF3CBB /* BookSourceChapterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388862ACF8F83F9A1C8A6A6C /* BookSourceChapterListView.swift */; };
+		576856E9891C19D45A579DA5 /* ChapterTranslationChunker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E05A8F8B018491C86ABB86AD /* ChapterTranslationChunker.swift */; };
 		5774FF0387AC1349069791FE /* TextMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D7174921347E183EEB34A6 /* TextMapperTests.swift */; };
 		57E1462E66FEAA422A970FA5 /* AnthropicProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C6D6A8EC00DFFAC294DD87 /* AnthropicProvider.swift */; };
 		57EC7A5D9106FCA807028ADA /* Feature26TextToSpeechVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35597ECF4679E74A0019B17E /* Feature26TextToSpeechVerificationTests.swift */; };
@@ -600,6 +603,7 @@
 		83DAEE23928C668DA378F086 /* EPUBProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FA15EA6877E3CA9421E1B59 /* EPUBProgressTests.swift */; };
 		84A03EDA45DB68CE01456609 /* SwiftDataSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B682E216B5A24055B696F0 /* SwiftDataSessionStore.swift */; };
 		84FDAB02CDE741029EE927A8 /* FoliateHighlightJSBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = B75EC9C3C222236A27183F13 /* FoliateHighlightJSBridge.swift */; };
+		857DC0847676329528295DEE /* ChapterTranslationChunkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1B327713437D80D690ED9B /* ChapterTranslationChunkerTests.swift */; };
 		85A21D4B6B18C0523D26375A /* HighlightPaintColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1790A0CEB902B16952776EE4 /* HighlightPaintColorTests.swift */; };
 		85A712EBB7E4B4DF30EDEA13 /* VReaderAnnotationParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D036492CF6A9DB2DAFE010BC /* VReaderAnnotationParser.swift */; };
 		85C0767912F71AAE32E2335E /* ChapterStartTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA36CFAC187DC7B25B7A920 /* ChapterStartTypography.swift */; };
@@ -790,6 +794,7 @@
 		B0762A6794C5885FC94A2BF4 /* foliate-reader.html in Resources */ = {isa = PBXBuildFile; fileRef = 0B636D7823EE57464A4CE54D /* foliate-reader.html */; };
 		B086340BE996C111A4B374BD /* UnifiedMDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EF16A1A352B2C6BAE84556 /* UnifiedMDTests.swift */; };
 		B0EF6095B892F032F27CB690 /* LibraryAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24D3FC7488318277468A7F0 /* LibraryAccessibilityTests.swift */; };
+		B15D8D7E5117125033EC60A2 /* ChapterSegmenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999A100638E91D93F3353B66 /* ChapterSegmenterTests.swift */; };
 		B1B9E936492D58B0768C0785 /* TXTTextExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8707DA3A6FC024EAC4F63E76 /* TXTTextExtractorTests.swift */; };
 		B1BF1136437114637B9F8800 /* BookDetailsSheet+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F79D3BEB86E859FEF2D09E2A /* BookDetailsSheet+Actions.swift */; };
 		B1DFA851C827F5BB877DD2B8 /* ReadingSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41196788F697BB4ACD4B06 /* ReadingSessionTests.swift */; };
@@ -943,6 +948,7 @@
 		D29C82D5913FC18EE9DE0FBF /* LibraryFilterChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0985611CD6C8B63B73CEE2 /* LibraryFilterChips.swift */; };
 		D2A05D3F78803BFD1248FFC2 /* LegadoImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B58A3A5DB35DA47F032FCEB /* LegadoImporter.swift */; };
 		D2C79A37AD17134F89371C0A /* BookFileImportFinalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DE2E82B00BA09B1D805167A /* BookFileImportFinalizer.swift */; };
+		D2F8338EECC37FFDFAA09A67 /* TranslationChunkContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B0FE6ABBF2FE99E9903D79 /* TranslationChunkContractTests.swift */; };
 		D32E57C07E8D41055084129C /* AnnotationNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF63E3EE60CC06C5650C3AD /* AnnotationNote.swift */; };
 		D352E53FDD1D6FEF94B393ED /* LazyDownloadFinalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F117A908F9B8098182FF9DB /* LazyDownloadFinalizerTests.swift */; };
 		D36EEE178AE4BC41B7B4C650 /* FileAvailabilityBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4B7084FA4C129303F52CB8 /* FileAvailabilityBadge.swift */; };
@@ -1066,6 +1072,7 @@
 		F017AB8749D17949AC040CAA /* FoliateTOCConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91F653CA8E9B107CA2CA4CA /* FoliateTOCConverterTests.swift */; };
 		F064D551F461B2FA4C778D56 /* TXTOffsetTranslatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D804BC38A65B71FB212B03 /* TXTOffsetTranslatorTests.swift */; };
 		F0A36C4FB1AD5746B8636062 /* AIReaderPanelHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A46EC81A33304A8D024F7CA /* AIReaderPanelHeader.swift */; };
+		F0BC6912FD4F5217F53F37C7 /* TranslationStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53476F2A0426877FA297A911 /* TranslationStyle.swift */; };
 		F10FCB9E3EC6862A640BD406 /* VReaderApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605C9BAEA41B7C63D7E343B1 /* VReaderApp.swift */; };
 		F14370F35DEFDB725452B5CA /* SearchWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C47B0077BE4937C424FFBD9 /* SearchWiringTests.swift */; };
 		F14A4E744781186C72D46349 /* CustomCoverStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5CB381B25E50D44505CAAB3 /* CustomCoverStore.swift */; };
@@ -1370,6 +1377,7 @@
 		36FC80576CA3D3C7EB629247 /* DurableTombstoneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DurableTombstoneStore.swift; sourceTree = "<group>"; };
 		3743321B8FFE925BFB43D262 /* BackupViewModelSelectiveRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupViewModelSelectiveRestoreTests.swift; sourceTree = "<group>"; };
 		3753D7CD01EA589932DF780C /* ThemeBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeBackgroundView.swift; sourceTree = "<group>"; };
+		37B0FE6ABBF2FE99E9903D79 /* TranslationChunkContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationChunkContractTests.swift; sourceTree = "<group>"; };
 		37BC360E9ED3746C383D3F3F /* MDChapterStartDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDChapterStartDecoratorTests.swift; sourceTree = "<group>"; };
 		37DF69361FD0FBED7294C43E /* ImportProvenance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportProvenance.swift; sourceTree = "<group>"; };
 		388862ACF8F83F9A1C8A6A6C /* BookSourceChapterListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSourceChapterListView.swift; sourceTree = "<group>"; };
@@ -1465,6 +1473,7 @@
 		4946129FECC6C9BA7A7F16A1 /* WebDAVClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVClient.swift; sourceTree = "<group>"; };
 		49624FC3C8E1AC31E011351C /* TOCBuilderTXTTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOCBuilderTXTTests.swift; sourceTree = "<group>"; };
 		4962BEF634F94652553FC6BD /* BookImporterAZW3Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookImporterAZW3Tests.swift; sourceTree = "<group>"; };
+		4A1B327713437D80D690ED9B /* ChapterTranslationChunkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterTranslationChunkerTests.swift; sourceTree = "<group>"; };
 		4A3BC126A794F2C82F782E7D /* TXTTextChunkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTTextChunkerTests.swift; sourceTree = "<group>"; };
 		4A57E82A7221B36240E501FD /* AIConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIConfigurationTests.swift; sourceTree = "<group>"; };
 		4A888610BD2499B817A278EB /* SearchResultRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultRow.swift; sourceTree = "<group>"; };
@@ -1518,6 +1527,7 @@
 		529D0FB4C5C73B62F1C8D6D6 /* TXTChapterContentLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterContentLoader.swift; sourceTree = "<group>"; };
 		529E7234A3FC73811D573A6C /* SheetSectionContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetSectionContract.swift; sourceTree = "<group>"; };
 		533D2D4F8B5502E8D51A714E /* EPUBTextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBTextExtractor.swift; sourceTree = "<group>"; };
+		53476F2A0426877FA297A911 /* TranslationStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationStyle.swift; sourceTree = "<group>"; };
 		5350DA755A0BB669AE8D3FBD /* BackupViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupViewModelTests.swift; sourceTree = "<group>"; };
 		539FEE4A23AFA226048A12A4 /* AIChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatView.swift; sourceTree = "<group>"; };
 		53C43C404319C34029EB078C /* LibraryContainerCompositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryContainerCompositionTests.swift; sourceTree = "<group>"; };
@@ -1828,6 +1838,7 @@
 		98913241E6FA9EDD33571CB9 /* ChapterStartTypographyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterStartTypographyTests.swift; sourceTree = "<group>"; };
 		9893809AE39B5DF0233FEE42 /* ProviderProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderProfile.swift; sourceTree = "<group>"; };
 		995F86ACEA8D1CC36B0BC1A7 /* PagedModeBug82Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedModeBug82Tests.swift; sourceTree = "<group>"; };
+		999A100638E91D93F3353B66 /* ChapterSegmenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterSegmenterTests.swift; sourceTree = "<group>"; };
 		999E14A7BDE872FF420E5E37 /* ChapterTranslationRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterTranslationRecord.swift; sourceTree = "<group>"; };
 		99A5A212655DCE85CACDEC05 /* AnnotationImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationImporter.swift; sourceTree = "<group>"; };
 		99A967D9AB1E2A699112E0B1 /* SelectionPopoverActionRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionPopoverActionRowTests.swift; sourceTree = "<group>"; };
@@ -2046,6 +2057,7 @@
 		CD3507D70A2497BA857E5A49 /* plain_utf8.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = plain_utf8.txt; sourceTree = "<group>"; };
 		CD97F86BA5BFD30A9383B800 /* RemoteBookCatalogIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBookCatalogIntegrationTests.swift; sourceTree = "<group>"; };
 		CE0A04AB9B449BA91C980DCD /* Inter-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Inter-Medium.otf"; sourceTree = "<group>"; };
+		CE0DD73D7B4AC6420A155014 /* ChapterSegmenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterSegmenter.swift; sourceTree = "<group>"; };
 		CE2F1636BA674F5AF7A50902 /* PersistenceActorEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceActorEnvironment.swift; sourceTree = "<group>"; };
 		CE6E54A01DDA73FFC3343F8E /* BookFileStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFileStateTests.swift; sourceTree = "<group>"; };
 		CE7C16F12BA653A217A5439C /* ProviderProfileMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderProfileMigratorTests.swift; sourceTree = "<group>"; };
@@ -2132,6 +2144,7 @@
 		DF7D174AC38392C14C17F1F7 /* RemoteBookCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBookCatalog.swift; sourceTree = "<group>"; };
 		E026EDF24B39D1CD50B39389 /* CollectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionTests.swift; sourceTree = "<group>"; };
 		E02C0C97FFE66E8DEC728D64 /* SyncRecordDTOs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncRecordDTOs.swift; sourceTree = "<group>"; };
+		E05A8F8B018491C86ABB86AD /* ChapterTranslationChunker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterTranslationChunker.swift; sourceTree = "<group>"; };
 		E07FB35EC9805F51CAD10444 /* ThemeBackgroundStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeBackgroundStore.swift; sourceTree = "<group>"; };
 		E11E9DBFB16DA26DD0659851 /* AnnotationModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationModelTests.swift; sourceTree = "<group>"; };
 		E124CB39746DB0B59D0390C3 /* LazyDownloadReattachTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyDownloadReattachTests.swift; sourceTree = "<group>"; };
@@ -2176,6 +2189,7 @@
 		E861A379A620B769CEA36300 /* AIChatViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatViewModelTests.swift; sourceTree = "<group>"; };
 		E94F1579C79832BB2EEDEB05 /* TXTChapterIndexStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterIndexStoreTests.swift; sourceTree = "<group>"; };
 		E97DAB513E717D83CD9ED3F7 /* TTSProviderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSProviderProtocol.swift; sourceTree = "<group>"; };
+		E9BD495685BB360AF81EDAE3 /* TranslationChunkContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationChunkContract.swift; sourceTree = "<group>"; };
 		E9D4D088D34AA8A5692A991B /* PageTurnAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTurnAnimator.swift; sourceTree = "<group>"; };
 		EA0C50C474AA2F96C39AAC94 /* PaginationCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationCache.swift; sourceTree = "<group>"; };
 		EA0CD7509429C4B75ACB98F2 /* KeychainProviderProfileExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainProviderProfileExtensionTests.swift; sourceTree = "<group>"; };
@@ -3884,6 +3898,8 @@
 				1836AA0E3E80CADFB1B46834 /* AnthropicProviderStreamingTests.swift */,
 				E5892DBA34520F6BB7B8E5A3 /* AnthropicProviderTests.swift */,
 				32BC7A4A1B047A76FD209AB3 /* ChapterBoundsTests.swift */,
+				999A100638E91D93F3353B66 /* ChapterSegmenterTests.swift */,
+				4A1B327713437D80D690ED9B /* ChapterTranslationChunkerTests.swift */,
 				EA0CD7509429C4B75ACB98F2 /* KeychainProviderProfileExtensionTests.swift */,
 				C5C46A3D7400CC956FA8D46D /* ProviderKindTests.swift */,
 				CE7C16F12BA653A217A5439C /* ProviderProfileMigratorTests.swift */,
@@ -3891,6 +3907,7 @@
 				03E01318DE23F63217033B89 /* ProviderProfileTests.swift */,
 				4201BB3B1C117672C45389AE /* SummaryScopeResolverTests.swift */,
 				19CA966D3696877E6EB055EA /* SummaryScopeTests.swift */,
+				37B0FE6ABBF2FE99E9903D79 /* TranslationChunkContractTests.swift */,
 				9F2D542588B3156C4A282264 /* WI11TestHelpers.swift */,
 			);
 			path = AI;
@@ -4141,6 +4158,8 @@
 				B8C6D6A8EC00DFFAC294DD87 /* AnthropicProvider.swift */,
 				C682F2AF644C10CEC95208AE /* AnthropicProvider+Streaming.swift */,
 				A890F7C98CE159058714EE4D /* ChapterBounds.swift */,
+				CE0DD73D7B4AC6420A155014 /* ChapterSegmenter.swift */,
+				E05A8F8B018491C86ABB86AD /* ChapterTranslationChunker.swift */,
 				AE50C2E67CBF0EB4747276C1 /* KeychainService+ProviderProfile.swift */,
 				2652A8EB81DF49609A3EDAC8 /* ProviderKind.swift */,
 				9893809AE39B5DF0233FEE42 /* ProviderProfile.swift */,
@@ -4148,6 +4167,8 @@
 				C6E58A8977DC02FDA7235A9E /* ProviderProfileStore.swift */,
 				EA8C0234B383C8D2877E21CC /* SummaryScope.swift */,
 				BA838B4649351A656B259147 /* SummaryScopeResolver.swift */,
+				E9BD495685BB360AF81EDAE3 /* TranslationChunkContract.swift */,
+				53476F2A0426877FA297A911 /* TranslationStyle.swift */,
 				A9ABEE3CBF62A1CC57F2952F /* UTF16TextSlicer.swift */,
 			);
 			path = AI;
@@ -4550,7 +4571,9 @@
 				D5F2A02BCE68112C46DE47B6 /* ChapterBoundsTests.swift in Sources */,
 				48AC1E0108D690FE895D85BC /* ChapterCacheTests.swift in Sources */,
 				C618F3CA75B75B73513F8DE9 /* ChapterProgressCalculatorTests.swift in Sources */,
+				B15D8D7E5117125033EC60A2 /* ChapterSegmenterTests.swift in Sources */,
 				15A088563DCAA44A276CBC0A /* ChapterStartTypographyTests.swift in Sources */,
+				857DC0847676329528295DEE /* ChapterTranslationChunkerTests.swift in Sources */,
 				3987A922844B144661A868B8 /* ChapterTranslationRecordTests.swift in Sources */,
 				E19364EB475B945F4B96F3DB /* ChapterTranslationStoreTests.swift in Sources */,
 				2DA32CDB11AE06DBCF3E97DE /* CloudKitRecordMapperTests.swift in Sources */,
@@ -4909,6 +4932,7 @@
 				C65D7B190AC53E15002CBF0C /* TombstoneStoreTests.swift in Sources */,
 				20F2F4A5C2D3C0FCE92D7388 /* TransformsBug98Tests.swift in Sources */,
 				A94C7BEA198AF83B90936259 /* TranslateLanguageRailTests.swift in Sources */,
+				D2F8338EECC37FFDFAA09A67 /* TranslationChunkContractTests.swift in Sources */,
 				93594C6E4334738E8DB307A2 /* TranslationResultCardTests.swift in Sources */,
 				6BA8CF88EDCD7838E0944046 /* TranslationUnitIDTests.swift in Sources */,
 				09DBE45859D311C4D9B47B88 /* TypefacePillToggleTests.swift in Sources */,
@@ -5053,8 +5077,10 @@
 				6E9F7B63A2B0FCA6B4D97E33 /* ChapterBounds.swift in Sources */,
 				73BD04AA03871D2C0AF2D3CA /* ChapterCache.swift in Sources */,
 				1C78AB9020A2E03A196FA6A1 /* ChapterProgressCalculator.swift in Sources */,
+				4066570D77F8395FDF24C4A5 /* ChapterSegmenter.swift in Sources */,
 				85C0767912F71AAE32E2335E /* ChapterStartTypography.swift in Sources */,
 				9D28C839CBBFF9BC8727BAF0 /* ChapterTranslation.swift in Sources */,
+				576856E9891C19D45A579DA5 /* ChapterTranslationChunker.swift in Sources */,
 				4EFC0ADF77B237B9D1D37A2F /* ChapterTranslationRecord.swift in Sources */,
 				FB7EAB10F53380ED4FFAF9D1 /* ChapterTranslationStore.swift in Sources */,
 				F51F7B9360A990E857FE1373 /* ChatMessage.swift in Sources */,
@@ -5447,8 +5473,10 @@
 				DB49A43B0C365D8308D5D1BB /* TokenSpan.swift in Sources */,
 				7C55E0AC6A420DF9B2B81DDB /* TombstoneStore.swift in Sources */,
 				E11C399EFF99AF41282FF9C2 /* TranslateLanguageRail.swift in Sources */,
+				3DED10DB4A0FA7B18DE2E431 /* TranslationChunkContract.swift in Sources */,
 				3DF1A5D2E40DE8AAF521BB8C /* TranslationPanel.swift in Sources */,
 				46AE79F9CB6E8AAE304DE34A /* TranslationResultCard.swift in Sources */,
+				F0BC6912FD4F5217F53F37C7 /* TranslationStyle.swift in Sources */,
 				F3C36A4536E9CDB717877BFE /* TranslationUnitID.swift in Sources */,
 				00074EAF27B3E74401E41076 /* TypefacePillToggle.swift in Sources */,
 				CE3D74414B1983EB35589EFD /* TypographySettings.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5666,13 +5666,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 556;
+				CURRENT_PROJECT_VERSION = 557;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.37.10;
+				MARKETING_VERSION = 3.37.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5816,13 +5816,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 556;
+				CURRENT_PROJECT_VERSION = 557;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.37.10;
+				MARKETING_VERSION = 3.37.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/AI/ChapterSegmenter.swift
+++ b/vreader/Services/AI/ChapterSegmenter.swift
@@ -1,0 +1,77 @@
+// Purpose: Pure segmentation utility for feature #56 bilingual reading. Splits
+// a chapter's plain text into translation segments — either paragraphs or
+// sentences, selected by the book's `granularity` setting (design §2.2).
+//
+// Key decisions:
+// - Paragraph split is blank-line / block-boundary based: a single newline is
+//   a soft wrap (same paragraph), a blank line separates paragraphs.
+// - Sentence split uses `String.enumerateSubstrings(.bySentences)`, which is
+//   locale-aware and handles CJK fullwidth terminators (。！？) as well as
+//   Latin punctuation — no manual punctuation table.
+// - Every produced segment is whitespace-trimmed and empty segments dropped,
+//   so a translation request never carries a blank segment.
+//
+// @coordinates-with: ChapterTranslationChunker.swift,
+//   ChapterTranslationService.swift,
+//   dev-docs/plans/20260519-feature-56-bilingual-reading.md (WI-4)
+
+import Foundation
+
+/// Pure paragraph / sentence segmentation for chapter translation.
+enum ChapterSegmenter {
+
+    /// Splits chapter text into paragraphs. Paragraphs are separated by one or
+    /// more blank lines; a single line break inside a paragraph is a soft wrap
+    /// and does not split. Each paragraph is trimmed; empty ones are dropped.
+    static func paragraphs(in chapterText: String) -> [String] {
+        // Normalize line endings, then split on runs of >=2 newlines
+        // (a blank line — possibly with intervening whitespace).
+        let normalized = chapterText
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        let blankLineSplitter = try? NSRegularExpression(pattern: "\\n[ \\t]*\\n+")
+        let pieces: [String]
+        if let blankLineSplitter {
+            pieces = splitOnRegex(normalized, regex: blankLineSplitter)
+        } else {
+            pieces = normalized.components(separatedBy: "\n\n")
+        }
+        return pieces
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// Splits chapter text into sentences. CJK-aware via
+    /// `enumerateSubstrings(.bySentences)`. Each sentence is trimmed; empty
+    /// fragments are dropped.
+    static func sentences(in chapterText: String) -> [String] {
+        var result: [String] = []
+        let full = chapterText.startIndex..<chapterText.endIndex
+        chapterText.enumerateSubstrings(in: full, options: [.bySentences, .localized]) {
+            substring, _, _, _ in
+            guard let substring else { return }
+            let trimmed = substring.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                result.append(trimmed)
+            }
+        }
+        // `.bySentences` on a fragment with no terminal punctuation still
+        // yields the fragment; only a fully-empty input yields nothing.
+        return result
+    }
+
+    /// Splits `text` on every match of `regex`, returning the gaps.
+    private static func splitOnRegex(_ text: String, regex: NSRegularExpression) -> [String] {
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        var pieces: [String] = []
+        var cursor = 0
+        for match in regex.matches(in: text, range: fullRange) {
+            let gap = NSRange(location: cursor, length: match.range.location - cursor)
+            pieces.append(nsText.substring(with: gap))
+            cursor = match.range.location + match.range.length
+        }
+        pieces.append(nsText.substring(from: cursor))
+        return pieces
+    }
+}

--- a/vreader/Services/AI/ChapterTranslationChunker.swift
+++ b/vreader/Services/AI/ChapterTranslationChunker.swift
@@ -1,0 +1,73 @@
+// Purpose: Pure chunking utility for feature #56 bilingual reading. Groups
+// translation segment indices into chunks each under a provider character
+// budget, so a chapter that exceeds the provider's context window is sent as
+// several requests (edge case (a)).
+//
+// Key decisions:
+// - A segment is NEVER split across chunks — the response↔source mapping
+//   depends on a 1:1 segment correspondence within a chunk.
+// - One over-budget segment occupies its own chunk; recombination across
+//   chunks is the caller's job (`ChapterTranslationService`).
+// - The budget is a CHARACTER count (`String.count`), not a byte count —
+//   CJK text is multi-byte in UTF-8 but the provider window is token/char
+//   based and char count is the closer, format-agnostic proxy.
+//
+// @coordinates-with: ChapterSegmenter.swift, ChapterTranslationService.swift,
+//   dev-docs/plans/20260519-feature-56-bilingual-reading.md (WI-4)
+
+import Foundation
+
+/// Pure segment-boundary chunker for chapter translation.
+enum ChapterTranslationChunker {
+
+    /// Groups `segments` indices into chunks, each chunk's total character
+    /// count not exceeding `maxCharsPerChunk` — except a single segment that
+    /// is itself over budget, which occupies its own chunk.
+    ///
+    /// - Parameter maxCharsPerChunk: the per-chunk character budget; expected
+    ///   to be `> 0`. A non-positive budget is defensively coerced to `1`
+    ///   (every non-empty segment then gets its own chunk) so the function
+    ///   never divides by zero or loops — but callers should pass a real
+    ///   provider budget.
+    /// - Returns: an ordered array of index arrays. Flattening it yields
+    ///   `0..<segments.count` in order — every index appears exactly once.
+    static func chunk(segments: [String], maxCharsPerChunk: Int) -> [[Int]] {
+        guard !segments.isEmpty else { return [] }
+        let budget = max(1, maxCharsPerChunk)
+
+        var chunks: [[Int]] = []
+        var current: [Int] = []
+        var currentCount = 0
+
+        for (index, segment) in segments.enumerated() {
+            let segmentCount = segment.count
+
+            // An over-budget segment that would not fit even an empty chunk:
+            // flush the current chunk, then give the big segment its own.
+            if segmentCount > budget {
+                if !current.isEmpty {
+                    chunks.append(current)
+                    current = []
+                    currentCount = 0
+                }
+                chunks.append([index])
+                continue
+            }
+
+            // Adding this segment would overflow the current chunk → start one.
+            if !current.isEmpty && currentCount + segmentCount > budget {
+                chunks.append(current)
+                current = []
+                currentCount = 0
+            }
+
+            current.append(index)
+            currentCount += segmentCount
+        }
+
+        if !current.isEmpty {
+            chunks.append(current)
+        }
+        return chunks
+    }
+}

--- a/vreader/Services/AI/TranslationChunkContract.swift
+++ b/vreader/Services/AI/TranslationChunkContract.swift
@@ -1,0 +1,123 @@
+// Purpose: The strict JSON-array prompt + decode contract for feature #56
+// bilingual chapter translation. The model is instructed to return ONLY a JSON
+// array of N translated strings in source order; the decoder strictly
+// validates that the response is exactly that — N string elements.
+//
+// Key decisions:
+// - `AIRequest` has no API-level `response_format` field (verified), so the
+//   "return only a JSON array" contract is prompt-level + strict JSON decode
+//   (v4 Gate-2 finding F5 — rare-delimiter splitting was rejected because the
+//   model can reproduce any delimiter; a JSON-array schema is unambiguous).
+// - The decoder tolerates a leading/trailing ```json fence and surrounding
+//   whitespace (models add them), but is strict about the element count and
+//   that every element is a string — anything else throws so the caller
+//   (`ChapterTranslationService`) falls back to one-segment-per-request.
+// - `style` is folded into the prompt HERE and only here (Gate-2 round-2 N4).
+//
+// @coordinates-with: ChapterSegmenter.swift, ChapterTranslationChunker.swift,
+//   ChapterTranslationService.swift, TranslationStyle.swift,
+//   dev-docs/plans/20260519-feature-56-bilingual-reading.md (WI-4)
+
+import Foundation
+
+/// Builds the chunk translation prompt and strictly decodes the response.
+enum TranslationChunkContract {
+
+    /// A decode failure — surfaced so the service can fall back to a
+    /// one-segment-per-request retry.
+    enum DecodeError: Error, Equatable {
+        /// The response was not a JSON array of strings.
+        case notAStringArray
+        /// The array length did not equal the expected segment count.
+        case countMismatch(expected: Int, actual: Int)
+    }
+
+    /// Builds the `userPrompt` for one chunk of source segments. The model is
+    /// told to translate each segment into `targetLanguage` in the given
+    /// `style` and return ONLY a JSON array of exactly N strings, same order.
+    static func userPrompt(
+        segments: [String],
+        targetLanguage: String,
+        style: TranslationStyle
+    ) -> String {
+        let count = segments.count
+        let styleClause: String
+        switch style {
+        case .literal:
+            styleClause = "Use a LITERAL, word-for-word translation that stays "
+                + "close to the source sentence structure."
+        case .natural:
+            styleClause = "Use NATURAL, idiomatic \(targetLanguage) phrasing that "
+                + "reads fluently to a native speaker."
+        case .literary:
+            styleClause = "Use a LITERARY, polished translation with elevated, "
+                + "well-crafted \(targetLanguage) prose."
+        }
+
+        // Number the segments so the model's array ordering is unambiguous.
+        let numbered = segments.enumerated()
+            .map { "[\($0.offset)] \($0.element)" }
+            .joined(separator: "\n\n")
+
+        return """
+        Translate each of the following \(count) text segment(s) into \(targetLanguage).
+        \(styleClause)
+
+        Respond with ONLY a JSON array of exactly \(count) string(s) — the \
+        translation of each segment, in the same order. No commentary, no keys, \
+        no markdown — just the JSON array.
+
+        Source segments:
+        \(numbered)
+        """
+    }
+
+    /// Strictly decodes a model response into exactly `expectedCount`
+    /// translated strings. Tolerates a surrounding ```json fence and
+    /// whitespace; throws `DecodeError` on anything that is not a JSON array
+    /// of exactly that many string elements.
+    static func decode(_ raw: String, expectedCount: Int) throws -> [String] {
+        let cleaned = stripCodeFence(raw).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let data = cleaned.data(using: .utf8) else {
+            throw DecodeError.notAStringArray
+        }
+        let decoded: [String]
+        do {
+            decoded = try JSONDecoder().decode([String].self, from: data)
+        } catch {
+            // Decodes-but-not-as-[String] (object, number element, nested
+            // array, …) → not a string array.
+            throw DecodeError.notAStringArray
+        }
+        guard decoded.count == expectedCount else {
+            throw DecodeError.countMismatch(expected: expectedCount, actual: decoded.count)
+        }
+        return decoded
+    }
+
+    /// Removes a leading/trailing Markdown code fence (```json … ``` or ``` … ```).
+    ///
+    /// The closing fence is removed ONLY when the final non-whitespace line is
+    /// exactly ```` ``` ````. A bare ```` ``` ```` occurring *inside* the
+    /// payload (e.g. a JSON string element that literally contains backticks)
+    /// is left intact — searching backwards for any backtick run would
+    /// truncate such a legitimate payload (Gate-4 round-1 Medium).
+    private static func stripCodeFence(_ raw: String) -> String {
+        let text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard text.hasPrefix("```") else { return text }
+
+        var lines = text.components(separatedBy: "\n")
+        // Drop the opening fence line (``` or ```json). With no newline at all
+        // the input is just a lone fence — nothing to unwrap.
+        guard lines.count > 1 else { return text }
+        lines.removeFirst()
+
+        // Drop the closing fence only if the LAST non-blank line is exactly ```.
+        if let lastNonBlankIndex = lines.lastIndex(where: {
+            !$0.trimmingCharacters(in: .whitespaces).isEmpty
+        }), lines[lastNonBlankIndex].trimmingCharacters(in: .whitespaces) == "```" {
+            lines.removeSubrange(lastNonBlankIndex...)
+        }
+        return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/vreader/Services/AI/TranslationStyle.swift
+++ b/vreader/Services/AI/TranslationStyle.swift
@@ -1,0 +1,21 @@
+// Purpose: The re-translation style enum for feature #56 bilingual reading
+// (from `vreader-retranslate.jsx`). A pure prompt-construction input — it is
+// folded into the translation chunk prompt by `TranslationChunkContract`, and
+// is NEVER a wire field on `AIRequest` / `ResolvedAIProviderConfig`
+// (Gate-2 round-2 N4 — `style` lives only in the prompt).
+//
+// @coordinates-with: TranslationChunkContract.swift,
+//   ChapterTranslationService.swift, ChapterReTranslateViewModel.swift,
+//   dev-docs/plans/20260519-feature-56-bilingual-reading.md (WI-4)
+
+import Foundation
+
+/// How the translation should read — the re-translate picker's style choice.
+enum TranslationStyle: String, Sendable, CaseIterable, Codable {
+    /// Word-for-word faithful to the source structure.
+    case literal
+    /// Natural target-language phrasing (the bilingual-mode default).
+    case natural
+    /// Polished, literary target-language prose.
+    case literary
+}

--- a/vreaderTests/Services/AI/ChapterSegmenterTests.swift
+++ b/vreaderTests/Services/AI/ChapterSegmenterTests.swift
@@ -1,0 +1,112 @@
+// Purpose: Tests for ChapterSegmenter — paragraph + CJK-aware sentence
+// splitting for feature #56 bilingual reading.
+//
+// @coordinates-with: ChapterSegmenter.swift,
+//   dev-docs/plans/20260519-feature-56-bilingual-reading.md (WI-4)
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("ChapterSegmenter")
+struct ChapterSegmenterTests {
+
+    // MARK: - Paragraphs
+
+    @Test func paragraphs_emptyTextYieldsEmpty() {
+        #expect(ChapterSegmenter.paragraphs(in: "").isEmpty)
+    }
+
+    @Test func paragraphs_whitespaceOnlyYieldsEmpty() {
+        #expect(ChapterSegmenter.paragraphs(in: "   \n\n  \t ").isEmpty)
+    }
+
+    @Test func paragraphs_singleParagraph() {
+        let result = ChapterSegmenter.paragraphs(in: "Just one paragraph here.")
+        #expect(result == ["Just one paragraph here."])
+    }
+
+    @Test func paragraphs_blankLineSeparated() {
+        let text = "First paragraph.\n\nSecond paragraph.\n\nThird."
+        let result = ChapterSegmenter.paragraphs(in: text)
+        #expect(result == ["First paragraph.", "Second paragraph.", "Third."])
+    }
+
+    @Test func paragraphs_collapsesMultipleBlankLines() {
+        let text = "Alpha.\n\n\n\nBeta."
+        let result = ChapterSegmenter.paragraphs(in: text)
+        #expect(result == ["Alpha.", "Beta."])
+    }
+
+    @Test func paragraphs_trimsParagraphWhitespace() {
+        let text = "  Leading and trailing.  \n\n  Another.  "
+        let result = ChapterSegmenter.paragraphs(in: text)
+        #expect(result == ["Leading and trailing.", "Another."])
+    }
+
+    @Test func paragraphs_cjkBlankLineSeparated() {
+        let text = "第一段落。\n\n第二段落。"
+        let result = ChapterSegmenter.paragraphs(in: text)
+        #expect(result == ["第一段落。", "第二段落。"])
+    }
+
+    @Test func paragraphs_singleNewlineWithinParagraphIsNotABreak() {
+        // A soft line wrap (single \n) keeps the paragraph together;
+        // only a blank line separates paragraphs.
+        let text = "Line one\nstill same paragraph.\n\nNew paragraph."
+        let result = ChapterSegmenter.paragraphs(in: text)
+        #expect(result.count == 2)
+        #expect(result[1] == "New paragraph.")
+    }
+
+    // MARK: - Sentences
+
+    @Test func sentences_emptyTextYieldsEmpty() {
+        #expect(ChapterSegmenter.sentences(in: "").isEmpty)
+    }
+
+    @Test func sentences_latinSplit() {
+        let text = "First sentence. Second sentence! Third one?"
+        let result = ChapterSegmenter.sentences(in: text)
+        #expect(result.count == 3)
+        #expect(result[0].contains("First sentence"))
+        #expect(result[1].contains("Second sentence"))
+        #expect(result[2].contains("Third one"))
+    }
+
+    @Test func sentences_cjkSplit() {
+        // CJK uses fullwidth terminators 。！？ — enumerateSubstrings(.bySentences)
+        // is locale-aware and handles them.
+        let text = "第一句。第二句！第三句？"
+        let result = ChapterSegmenter.sentences(in: text)
+        #expect(result.count == 3)
+        #expect(result[0].contains("第一句"))
+        #expect(result[2].contains("第三句"))
+    }
+
+    @Test func sentences_mixedCJKAndLatin() {
+        let text = "This is English. 这是中文。Back to English!"
+        let result = ChapterSegmenter.sentences(in: text)
+        #expect(result.count == 3)
+    }
+
+    @Test func sentences_noTerminalPunctuation() {
+        // A run with no sentence terminator is still one segment.
+        let text = "a sentence fragment with no period"
+        let result = ChapterSegmenter.sentences(in: text)
+        #expect(result.count == 1)
+        #expect(result[0] == "a sentence fragment with no period")
+    }
+
+    @Test func sentences_trailingWhitespaceTrimmed() {
+        let text = "Sentence one.   "
+        let result = ChapterSegmenter.sentences(in: text)
+        #expect(result == ["Sentence one."])
+    }
+
+    @Test func sentences_dropsEmptySegments() {
+        let text = "Real sentence.\n\n\n"
+        let result = ChapterSegmenter.sentences(in: text)
+        #expect(result.allSatisfy { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })
+    }
+}

--- a/vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift
+++ b/vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift
@@ -1,0 +1,101 @@
+// Purpose: Tests for ChapterTranslationChunker — groups translation segment
+// indices into provider-budget-bounded chunks for feature #56 bilingual reading.
+//
+// @coordinates-with: ChapterTranslationChunker.swift,
+//   dev-docs/plans/20260519-feature-56-bilingual-reading.md (WI-4)
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("ChapterTranslationChunker")
+struct ChapterTranslationChunkerTests {
+
+    @Test func emptySegmentsYieldNoChunks() {
+        let chunks = ChapterTranslationChunker.chunk(segments: [], maxCharsPerChunk: 100)
+        #expect(chunks.isEmpty)
+    }
+
+    @Test func singleSmallSegmentIsOneChunk() {
+        let chunks = ChapterTranslationChunker.chunk(segments: ["hello"], maxCharsPerChunk: 100)
+        #expect(chunks == [[0]])
+    }
+
+    @Test func manyTinySegmentsPackIntoFewChunks() {
+        // 6 segments of 10 chars each, budget 25 → chunks of 2 ([0,1],[2,3],[4,5]).
+        let segments = Array(repeating: String(repeating: "x", count: 10), count: 6)
+        let chunks = ChapterTranslationChunker.chunk(segments: segments, maxCharsPerChunk: 25)
+        #expect(chunks == [[0, 1], [2, 3], [4, 5]])
+    }
+
+    @Test func segmentsNeverSplitAcrossChunks() {
+        // Every index appears exactly once, in order, with no index dropped.
+        let segments = (0..<20).map { String(repeating: "y", count: $0 % 7 + 1) }
+        let chunks = ChapterTranslationChunker.chunk(segments: segments, maxCharsPerChunk: 12)
+        let flattened = chunks.flatMap { $0 }
+        #expect(flattened == Array(0..<20))
+    }
+
+    @Test func oneOverBudgetSegmentGetsItsOwnChunk() {
+        // A segment larger than the whole budget cannot be split — it occupies
+        // its own chunk (edge case (a)). Recombination is the caller's job.
+        let segments = ["small", String(repeating: "z", count: 500), "tiny"]
+        let chunks = ChapterTranslationChunker.chunk(segments: segments, maxCharsPerChunk: 100)
+        #expect(chunks.contains([1]))
+        // The over-budget segment is isolated; small + tiny are not lost.
+        let flattened = chunks.flatMap { $0 }
+        #expect(Set(flattened) == [0, 1, 2])
+    }
+
+    @Test func consecutiveOverBudgetSegmentsEachGetOwnChunk() {
+        let big = String(repeating: "b", count: 200)
+        let segments = [big, big, big]
+        let chunks = ChapterTranslationChunker.chunk(segments: segments, maxCharsPerChunk: 100)
+        #expect(chunks == [[0], [1], [2]])
+    }
+
+    @Test func exactBoundary_segmentsSummingToExactlyBudgetShareAChunk() {
+        // Two 50-char segments, budget 100 → they fit together in one chunk.
+        let segments = [String(repeating: "a", count: 50), String(repeating: "b", count: 50)]
+        let chunks = ChapterTranslationChunker.chunk(segments: segments, maxCharsPerChunk: 100)
+        #expect(chunks == [[0, 1]])
+    }
+
+    @Test func exactBoundary_oneOverStartsANewChunk() {
+        // 50 + 51 = 101 > 100 → the 51-char segment starts a new chunk.
+        let segments = [String(repeating: "a", count: 50), String(repeating: "b", count: 51)]
+        let chunks = ChapterTranslationChunker.chunk(segments: segments, maxCharsPerChunk: 100)
+        #expect(chunks == [[0], [1]])
+    }
+
+    @Test func cjkCharactersCountedByCharacterNotByte() {
+        // CJK chars are multi-byte in UTF-8 but the budget is a CHARACTER count.
+        // 4 CJK chars × 3 segments, budget 8 chars → chunks of 2 segments.
+        let segments = Array(repeating: "你好世界", count: 3)
+        let chunks = ChapterTranslationChunker.chunk(segments: segments, maxCharsPerChunk: 8)
+        #expect(chunks == [[0, 1], [2]])
+    }
+
+    @Test func emptyStringSegmentsAreStillIndexed() {
+        // Empty segments cost 0 chars but still occupy an index.
+        let segments = ["", "", "real"]
+        let chunks = ChapterTranslationChunker.chunk(segments: segments, maxCharsPerChunk: 10)
+        let flattened = chunks.flatMap { $0 }
+        #expect(flattened == [0, 1, 2])
+    }
+
+    @Test func zeroBudgetIsCoercedToOne_eachNonEmptySegmentOwnsAChunk() {
+        // A non-positive budget is defensively coerced to 1 (documented) — the
+        // function never divides by zero or loops, and the flattening
+        // invariant still holds.
+        let segments = ["a", "b", "c"]
+        let chunks = ChapterTranslationChunker.chunk(segments: segments, maxCharsPerChunk: 0)
+        #expect(chunks.flatMap { $0 } == [0, 1, 2])
+        #expect(chunks.count == 3)
+    }
+
+    @Test func negativeBudgetIsAlsoCoercedSafely() {
+        let chunks = ChapterTranslationChunker.chunk(segments: ["x", "y"], maxCharsPerChunk: -5)
+        #expect(chunks.flatMap { $0 } == [0, 1])
+    }
+}

--- a/vreaderTests/Services/AI/TranslationChunkContractTests.swift
+++ b/vreaderTests/Services/AI/TranslationChunkContractTests.swift
@@ -1,0 +1,138 @@
+// Purpose: Tests for TranslationChunkContract — the strict JSON-array prompt +
+// decode contract for feature #56 bilingual reading. The model is instructed to
+// return ONLY a JSON array of N translated strings, same order; the decoder
+// strictly validates count + element type.
+//
+// @coordinates-with: TranslationChunkContract.swift,
+//   dev-docs/plans/20260519-feature-56-bilingual-reading.md (WI-4)
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("TranslationChunkContract")
+struct TranslationChunkContractTests {
+
+    // MARK: - Prompt builder
+
+    @Test func prompt_includesTargetLanguage() {
+        let prompt = TranslationChunkContract.userPrompt(
+            segments: ["Hello."], targetLanguage: "Chinese", style: .natural)
+        #expect(prompt.contains("Chinese"))
+    }
+
+    @Test func prompt_includesEverySourceSegment() {
+        let segments = ["First segment.", "Second segment.", "Third."]
+        let prompt = TranslationChunkContract.userPrompt(
+            segments: segments, targetLanguage: "Japanese", style: .natural)
+        for segment in segments {
+            #expect(prompt.contains(segment))
+        }
+    }
+
+    @Test func prompt_instructsJSONArrayOfExactCount() {
+        let prompt = TranslationChunkContract.userPrompt(
+            segments: ["a", "b", "c"], targetLanguage: "French", style: .natural)
+        // The prompt must demand a JSON array and state the exact element count.
+        #expect(prompt.lowercased().contains("json"))
+        #expect(prompt.contains("3"))
+    }
+
+    @Test func prompt_foldsInTranslationStyle() {
+        // The style is consumed ONLY here (Gate-2 round-2 N4) — it must appear
+        // in the prompt text, distinctly per style.
+        let literal = TranslationChunkContract.userPrompt(
+            segments: ["x"], targetLanguage: "German", style: .literal)
+        let literary = TranslationChunkContract.userPrompt(
+            segments: ["x"], targetLanguage: "German", style: .literary)
+        #expect(literal != literary)
+        #expect(literal.lowercased().contains("literal"))
+        #expect(literary.lowercased().contains("literary"))
+    }
+
+    // MARK: - Strict decode
+
+    @Test func decode_wellFormedArrayMapsInOrder() throws {
+        let json = #"["你好","世界","再见"]"#
+        let result = try TranslationChunkContract.decode(json, expectedCount: 3)
+        #expect(result == ["你好", "世界", "再见"])
+    }
+
+    @Test func decode_acceptsArrayWrappedInWhitespace() throws {
+        let json = "  \n [\"a\", \"b\"] \n  "
+        let result = try TranslationChunkContract.decode(json, expectedCount: 2)
+        #expect(result == ["a", "b"])
+    }
+
+    @Test func decode_stripsMarkdownCodeFence() throws {
+        // Models often wrap JSON in ```json ... ``` — the decoder tolerates it.
+        let json = "```json\n[\"alpha\", \"beta\"]\n```"
+        let result = try TranslationChunkContract.decode(json, expectedCount: 2)
+        #expect(result == ["alpha", "beta"])
+    }
+
+    @Test func decode_countMismatchTooFewThrowsCountMismatch() {
+        #expect(throws: TranslationChunkContract.DecodeError.countMismatch(expected: 3, actual: 1)) {
+            _ = try TranslationChunkContract.decode(#"["only one"]"#, expectedCount: 3)
+        }
+    }
+
+    @Test func decode_countMismatchTooManyThrowsCountMismatch() {
+        #expect(throws: TranslationChunkContract.DecodeError.countMismatch(expected: 2, actual: 4)) {
+            _ = try TranslationChunkContract.decode(#"["a","b","c","d"]"#, expectedCount: 2)
+        }
+    }
+
+    @Test func decode_nonStringElementThrowsNotAStringArray() {
+        // A numeric element is not a translated string.
+        #expect(throws: TranslationChunkContract.DecodeError.notAStringArray) {
+            _ = try TranslationChunkContract.decode(#"["ok", 42]"#, expectedCount: 2)
+        }
+    }
+
+    @Test func decode_nestedArrayThrowsNotAStringArray() {
+        #expect(throws: TranslationChunkContract.DecodeError.notAStringArray) {
+            _ = try TranslationChunkContract.decode(#"[["nested"], "b"]"#, expectedCount: 2)
+        }
+    }
+
+    @Test func decode_notAnArrayThrowsNotAStringArray() {
+        #expect(throws: TranslationChunkContract.DecodeError.notAStringArray) {
+            _ = try TranslationChunkContract.decode(#"{"text": "not an array"}"#, expectedCount: 1)
+        }
+    }
+
+    @Test func decode_garbageThrowsNotAStringArray() {
+        #expect(throws: TranslationChunkContract.DecodeError.notAStringArray) {
+            _ = try TranslationChunkContract.decode("this is not json at all", expectedCount: 1)
+        }
+    }
+
+    @Test func decode_emptyArrayWithExpectedZeroSucceeds() throws {
+        let result = try TranslationChunkContract.decode("[]", expectedCount: 0)
+        #expect(result.isEmpty)
+    }
+
+    @Test func decode_arrayWithEmptyStringElementsIsValid() throws {
+        // An empty translated string is a valid element (model returned "" for
+        // a blank source segment) — count still matters.
+        let result = try TranslationChunkContract.decode(#"["", "real", ""]"#, expectedCount: 3)
+        #expect(result == ["", "real", ""])
+    }
+
+    @Test func decode_preservesBackticksInsideAJSONStringElement() throws {
+        // A JSON string element that legitimately contains ``` must NOT be
+        // truncated by the code-fence stripper (Gate-4 round-1 Medium).
+        let json = "```json\n[\"code: ```x```\", \"plain\"]\n```"
+        let result = try TranslationChunkContract.decode(json, expectedCount: 2)
+        #expect(result == ["code: ```x```", "plain"])
+    }
+
+    @Test func decode_openingFenceWithNoClosingFenceStillDecodes() throws {
+        // A fenced payload with no trailing ``` line — the opening fence is
+        // dropped, the body still decodes.
+        let json = "```json\n[\"a\", \"b\"]"
+        let result = try TranslationChunkContract.decode(json, expectedCount: 2)
+        #expect(result == ["a", "b"])
+    }
+}


### PR DESCRIPTION
## WI-4 — ChapterSegmenter + ChapterTranslationChunker + JSON-array translation contract

Part of feature #56 (bilingual reading mode). Fourth of 16 work items per `dev-docs/plans/20260519-feature-56-bilingual-reading.md`. Foundational tier — three pure utilities, no user-observable behavior; unit tests + audit suffice (Gate 5).

### What this adds

- **`ChapterSegmenter`** (`vreader/Services/AI/ChapterSegmenter.swift`) — `paragraphs(in:)` (blank-line / block-boundary split; a single newline is a soft wrap, kept together) and `sentences(in:)` (CJK-aware via `String.enumerateSubstrings(.bySentences)` — handles `。！？` and Latin punctuation). Every segment trimmed; empty segments dropped. The book's `granularity` setting picks which one the translation service calls.
- **`ChapterTranslationChunker`** (`vreader/Services/AI/ChapterTranslationChunker.swift`) — `chunk(segments:maxCharsPerChunk:) -> [[Int]]` groups segment indices into provider-budget-bounded chunks. **Never splits a segment across chunks**; one over-budget segment occupies its own chunk (edge case (a)). Budget is a character count (CJK-correct), not a byte count. Flattening the output always yields `0..<segments.count` in order.
- **`TranslationChunkContract`** (`vreader/Services/AI/TranslationChunkContract.swift`) — the strict JSON-array prompt + decode contract. `userPrompt(...)` instructs the model to return ONLY a JSON array of exactly N translated strings in order, folding in the `TranslationStyle` (style is consumed here and only here — Gate-2 round-2 N4). `decode(...)` tolerates a ```json fence + whitespace but strictly validates the count and that every element is a string, throwing a typed `DecodeError` otherwise so the service can fall back to one-segment-per-request (v4 Gate-2 F5 — rare-delimiter splitting rejected because a model can reproduce any delimiter).
- **`TranslationStyle`** (`vreader/Services/AI/TranslationStyle.swift`) — `literal` / `natural` / `literary` enum (from `vreader-retranslate.jsx`). A pure prompt-construction input, never a wire field.

### Tests

- `ChapterSegmenterTests` — empty/whitespace/single/blank-line/collapsed-blank-lines/soft-wrap/CJK paragraphs; Latin + CJK + mixed sentences, no-terminal-punctuation, trimming.
- `ChapterTranslationChunkerTests` — empty, single, packing, never-split invariant, over-budget isolation, exact-boundary, CJK char-not-byte counting, empty-string segments, zero/negative-budget coercion.
- `TranslationChunkContractTests` — prompt includes language/segments/count/style; `decode` well-formed/fenced/whitespace, count-mismatch both ways, non-string element, nested array, non-array, garbage, empty-with-zero, empty-string elements, embedded backticks inside a JSON string, opening-fence-with-no-closing-fence.

### Gates

- **Gate 3 (TDD)**: RED → GREEN → REFACTOR. WI-4 suites pass on iPhone 17 Pro Simulator (44 tests, 3 suites green; full project compiles clean).
- **Gate 4 (Codex audit)**: 2 rounds, `final_verdict: ship-as-is`. Round 1 found 1 Medium (`stripCodeFence` truncating on embedded backticks) + 2 Low — all fixed; round 2 clean. Log: `.claude/codex-audits/feat-56-wi-4-segmenter-chunker-audit.md`.
- **Gate 5**: foundational WI — no device verification required.
- **Docs sync**: not triggered — pure utilities under an already-documented directory pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
