### PR TITLE
feat(#56 WI-7a): BilingualReadingViewModel persistence/state core

### DIFF
--- a/.claude/codex-audits/feat-56-wi-7a-bilingual-vm-core-audit.md
+++ b/.claude/codex-audits/feat-56-wi-7a-bilingual-vm-core-audit.md
@@ -1,0 +1,54 @@
+---
+branch: feat/56-wi-7a-bilingual-vm-core
+threadId: 019e4187-9943-7013-9a96-59dbab8e4b60
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-20
+---
+
+# Codex Audit — feat/56-wi-7a-bilingual-vm-core
+
+**Feature**: #56 — bilingual reading mode (WI-7a, foundational).
+**Scope**: `BilingualReadingViewModel`'s persistence/state core — the per-book
+on/off toggle backed by `PerBookSettings`, target language + granularity, the
+per-unit translation dictionary, the first-enable setup-sheet flag.
+**Auditor**: Codex (`mcp__plugin_codex-toolkit_codex__codex`), read-only sandbox.
+**Thread**: `019e4187-9943-7013-9a96-59dbab8e4b60`. Gate 4 — implementation audit.
+
+## Round 1 — 2 findings (0 Critical, 0 High, 0 Medium, 2 Low)
+
+Codex confirmed:
+
+- **Scope is clean for WI-7a** — no notification posting, no prefetch logic,
+  no `ChapterTextProviding` injection, no trigger behavior leaked from WI-7b.
+- The persistence read-modify-write preserves the typography fields correctly
+  (`PerBookSettingsStore.save` uses atomic writes; for a `@MainActor` VM doing
+  local file IO the read-modify-write is sufficient).
+- The setup-sheet logic is correct for fresh / already-configured /
+  configured-then-disabled books — `hasBeenConfigured` keys on the presence of
+  any bilingual key, not just `bilingualEnabled == true`.
+- The init fallback for an invalid stored granularity (`?? .paragraph`) is safe.
+- Strict concurrency is fine; `project.pbxproj` wiring is correct.
+
+The 2 Low findings are both missing **test coverage** of correct-but-unpinned
+behavior — no production-code change:
+
+1. **Low — no reload-from-disk test** for "configured-then-disabled book does
+   not re-raise the setup sheet on re-enable" (the existing test only proved
+   same-instance behavior after `dismissSetupSheet()`).
+   **Fix**: added `configuredThenDisabledBook_doesNotReRaiseSetupSheetOnReEnable`
+   — pre-writes `PerBookSettingsOverride(bilingualEnabled: false,
+   bilingualTargetLanguage: "Chinese")`, inits a fresh VM, `setEnabled(true)`,
+   asserts `needsSetupSheet == false`.
+
+2. **Low — no garbage/future-value granularity test.**
+   **Fix**: added `garbageStoredGranularity_fallsBackToParagraph` — pre-writes
+   `bilingualGranularity: "future-value"`, asserts the VM inits with
+   `granularity == .paragraph`.
+
+## Disposition
+
+Zero Critical/High/Medium. Both Low findings were test-coverage-only (the
+production code Codex reviewed is unchanged — the two tests pin
+correct-as-audited behavior, so no re-audit is required). Final verdict:
+**ship-as-is**.

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 559
-        MARKETING_VERSION: 3.37.13
+        CURRENT_PROJECT_VERSION: 560
+        MARKETING_VERSION: 3.37.14
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		1C78AB9020A2E03A196FA6A1 /* ChapterProgressCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 936C16A4F1B2B55E63922EE7 /* ChapterProgressCalculator.swift */; };
 		1C9B4E21A97013A7CC409925 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DAC8E20A001D7803A16AAD1 /* SearchView.swift */; };
 		1CB7C39AC6FE3B715D4B4305 /* V1toV2Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB16317C72EB6BBB61D77030 /* V1toV2Migration.swift */; };
+		1CCB3788E601D7B7118A521E /* BilingualReadingViewModelCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 430863C3C57C6B3DF1567626 /* BilingualReadingViewModelCoreTests.swift */; };
 		1CE79EFAA809405FA4A0FA99 /* Feature64EPUBMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E89BEB1454E17061367313 /* Feature64EPUBMigrationTests.swift */; };
 		1D0B7D11E74A0E06F27A9F8B /* EPUBLayoutPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CF348591A8246AA1524CD10 /* EPUBLayoutPreference.swift */; };
 		1D61E44D67F37555FDEA9B6C /* TXTFileLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B42D93C357CAAFB4261D93 /* TXTFileLoader.swift */; };
@@ -233,6 +234,7 @@
 		31F5B5AEC09F731ACEB8A46E /* Feature63SearchPanelVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1332F42A0C57EA1D1F37D9C0 /* Feature63SearchPanelVerificationTests.swift */; };
 		320025CDBC69B31CC1B4DEAA /* PDFReaderContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2BA1A05E4E36D5D7B2DCFD /* PDFReaderContainerView.swift */; };
 		3217F149B278D3D88B6AC17F /* AISummaryTabViewScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC9AC43028A99A994A7747B /* AISummaryTabViewScopeTests.swift */; };
+		32A02A2EECC7FFE73EEFC242 /* BilingualReadingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620691FAD37A902412F57F42 /* BilingualReadingViewModel.swift */; };
 		32B7B523223C7D83ED40A208 /* FoliateHighlightRestoreDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D712BAAF509AEBA3A3FB01C3 /* FoliateHighlightRestoreDispatcherTests.swift */; };
 		32C58BAAF2DB529049921D4D /* OPDSParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C26DE0705F29A16D1919F5 /* OPDSParserTests.swift */; };
 		32D0866BC61D79BCAEF0A525 /* SyncServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB81DF32070BCFB6D8653800 /* SyncServiceTests.swift */; };
@@ -1430,6 +1432,7 @@
 		42C4804D4D5F435DF10014C5 /* AIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIError.swift; sourceTree = "<group>"; };
 		42CFB0E94DE1D37E0FD2741B /* AIContextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIContextExtractor.swift; sourceTree = "<group>"; };
 		42E9BBD87941E0D6C66010EC /* FoliateStyleMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateStyleMapperTests.swift; sourceTree = "<group>"; };
+		430863C3C57C6B3DF1567626 /* BilingualReadingViewModelCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualReadingViewModelCoreTests.swift; sourceTree = "<group>"; };
 		43249E51E02F89BD8EAA7288 /* TXTLazyTextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTLazyTextProviderTests.swift; sourceTree = "<group>"; };
 		432F646AE5FB7BFD06470EB5 /* FoliateURLSchemeHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateURLSchemeHandlerTests.swift; sourceTree = "<group>"; };
 		43347208CA56C84F65B2DCF7 /* TXTTextViewBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTTextViewBridge.swift; sourceTree = "<group>"; };
@@ -1610,6 +1613,7 @@
 		61DB3214E22D83E3A8E19212 /* FoliateJSEscaperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateJSEscaperTests.swift; sourceTree = "<group>"; };
 		61E8B92C301E5470AB98C87E /* LocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorTests.swift; sourceTree = "<group>"; };
 		61F262AA54C2BFE60CA2B871 /* LegadoRuleParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegadoRuleParserTests.swift; sourceTree = "<group>"; };
+		620691FAD37A902412F57F42 /* BilingualReadingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualReadingViewModel.swift; sourceTree = "<group>"; };
 		62569DC663E2BDD2DC0155C3 /* SearchHighlightDismissTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHighlightDismissTests.swift; sourceTree = "<group>"; };
 		627E42F1B1E8A59081CC6628 /* BookFormatAZW3Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFormatAZW3Tests.swift; sourceTree = "<group>"; };
 		62B304D30B717A1AB66C2A5B /* Feature64PDFMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature64PDFMigrationTests.swift; sourceTree = "<group>"; };
@@ -2572,6 +2576,7 @@
 				4D5CDE195E585067DE4D6124 /* AnnotationListViewModelTests.swift */,
 				3743321B8FFE925BFB43D262 /* BackupViewModelSelectiveRestoreTests.swift */,
 				5350DA755A0BB669AE8D3FBD /* BackupViewModelTests.swift */,
+				430863C3C57C6B3DF1567626 /* BilingualReadingViewModelCoreTests.swift */,
 				256C28A508EAD4DB73B49DD4 /* BookmarkListViewModelTests.swift */,
 				4E141EA554A8E0C1C3B36250 /* FoliateReaderViewModelTests.swift */,
 				275DFDD33FCF69E75F251F27 /* HighlightListViewModelTests.swift */,
@@ -3398,6 +3403,7 @@
 				82B992B24F86DF8CA23E1215 /* AITranslationViewModel.swift */,
 				7A980DB0017049401DAB3E93 /* AnnotationListViewModel.swift */,
 				5E72779818424BCA8025B0A0 /* BackupViewModel.swift */,
+				620691FAD37A902412F57F42 /* BilingualReadingViewModel.swift */,
 				D432C9B43D1B6662B4605664 /* BookmarkListViewModel.swift */,
 				90B380013D82DFFD0411633E /* EPUBReaderViewModel.swift */,
 				C919847EACB9AB94A03DF6E8 /* FoliateReaderViewModel.swift */,
@@ -4555,6 +4561,7 @@
 				9BF4E606FB4C251BD4492FA9 /* BackupReadingHistoryTests.swift in Sources */,
 				A43AD2AF5B19CF05B849BE2E /* BackupViewModelSelectiveRestoreTests.swift in Sources */,
 				90D2C41C30E622E119877967 /* BackupViewModelTests.swift in Sources */,
+				1CCB3788E601D7B7118A521E /* BilingualReadingViewModelCoreTests.swift in Sources */,
 				096B20388931B21DAA4DC091 /* BlobPathTests.swift in Sources */,
 				24537AC8998113A9C739DBD6 /* BookCardViewVisualTests.swift in Sources */,
 				C205A1413A59C630A10ECEB7 /* BookContentCacheTests.swift in Sources */,
@@ -5051,6 +5058,7 @@
 				B9BF611D570F7F9681FBEE6E /* BackupSectionDTOs.swift in Sources */,
 				20271E1F835A62799E28F741 /* BackupViewModel.swift in Sources */,
 				986EFB28F7203E56F853A0FD /* BasePageNavigator.swift in Sources */,
+				32A02A2EECC7FFE73EEFC242 /* BilingualReadingViewModel.swift in Sources */,
 				30C1DE820BD42DAC78AC80FC /* BlobPath.swift in Sources */,
 				96F610A12CED33CA6B82C142 /* Book.swift in Sources */,
 				12EE1BD6335013980EFA3EC0 /* BookCardView.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5690,13 +5690,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 559;
+				CURRENT_PROJECT_VERSION = 560;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.37.13;
+				MARKETING_VERSION = 3.37.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5840,13 +5840,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 559;
+				CURRENT_PROJECT_VERSION = 560;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.37.13;
+				MARKETING_VERSION = 3.37.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/ViewModels/BilingualReadingViewModel.swift
+++ b/vreader/ViewModels/BilingualReadingViewModel.swift
@@ -1,0 +1,145 @@
+// Purpose: Owns bilingual-reading state for the open book (feature #56).
+//
+// WI-7a — the persistence/state CORE only: the per-book on/off toggle backed
+// by `PerBookSettings`, the target language + granularity, the per-unit
+// translation dictionary, and the first-enable setup-sheet flag. WI-7b adds
+// the behavioral layer (the `.readerPositionDidChange`-driven prefetch
+// trigger, epoch/cancellation, `.readerBilingualDidChange` posting, the
+// injected `ChapterTextProviding`).
+//
+// Key decisions:
+// - `@Observable @MainActor` like every reader view model.
+// - The toggle / language / granularity persist through `PerBookSettingsStore`
+//   — a read-modify-write that PRESERVES the file's typography fields (the
+//   bilingual fields are additive — WI-3).
+// - The setup sheet (design §2.2) is raised the FIRST time the user enables
+//   bilingual mode for a book; a book already enabled from a prior session
+//   (persistence loaded `isEnabled == true` at init) does NOT re-raise it.
+// - Disabling clears `translationsByUnit` (a re-enable re-fetches fresh).
+//
+// @coordinates-with: PerBookSettings.swift, TranslationUnitID.swift,
+//   ChapterTranslationService.swift,
+//   dev-docs/plans/20260519-feature-56-bilingual-reading.md (WI-7a)
+
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class BilingualReadingViewModel {
+
+    /// The book this view model is bound to (`DocumentFingerprint.canonicalKey`).
+    let bookFingerprintKey: String
+
+    /// Where per-book override JSON files live.
+    private let perBookBaseURL: URL
+
+    /// Whether bilingual mode is on for this book.
+    private(set) var isEnabled: Bool
+
+    /// The bilingual target language (a `BILINGUAL_LANGS` value). Defaults to
+    /// Chinese (design §2.2).
+    private(set) var targetLanguage: String
+
+    /// The segmentation granularity. Defaults to paragraph (design §2.2).
+    private(set) var granularity: TranslationGranularity
+
+    /// Per-unit cached translations — `unit → [translated segment]`.
+    private(set) var translationsByUnit: [TranslationUnitID: [String]] = [:]
+
+    /// `true` when the first-enable setup sheet should be presented.
+    private(set) var needsSetupSheet: Bool = false
+
+    /// Default bilingual target language (design §2.2).
+    static let defaultTargetLanguage = "Chinese"
+
+    init(bookFingerprintKey: String, perBookBaseURL: URL) {
+        self.bookFingerprintKey = bookFingerprintKey
+        self.perBookBaseURL = perBookBaseURL
+
+        let override = PerBookSettingsStore.settings(
+            for: bookFingerprintKey, baseURL: perBookBaseURL)
+        self.isEnabled = override?.bilingualEnabled ?? false
+        self.targetLanguage = override?.bilingualTargetLanguage ?? Self.defaultTargetLanguage
+        self.granularity = TranslationGranularity(
+            rawValue: override?.bilingualGranularity ?? "") ?? .paragraph
+    }
+
+    // MARK: - Toggle
+
+    /// Enables / disables bilingual mode for this book and persists the change.
+    /// The first time it is enabled the setup sheet is raised; disabling clears
+    /// the per-unit translation cache.
+    func setEnabled(_ enabled: Bool) {
+        guard enabled != isEnabled else { return }
+        if enabled && !hasBeenConfigured {
+            needsSetupSheet = true
+        }
+        isEnabled = enabled
+        if !enabled {
+            translationsByUnit.removeAll()
+        }
+        persist()
+    }
+
+    /// Sets the target language and persists it.
+    func setTargetLanguage(_ language: String) {
+        guard language != targetLanguage else { return }
+        targetLanguage = language
+        // A language change invalidates the cached translations.
+        translationsByUnit.removeAll()
+        persist()
+    }
+
+    /// Sets the segmentation granularity and persists it.
+    func setGranularity(_ newGranularity: TranslationGranularity) {
+        guard newGranularity != granularity else { return }
+        granularity = newGranularity
+        translationsByUnit.removeAll()
+        persist()
+    }
+
+    // MARK: - Setup sheet
+
+    /// Marks the first-enable setup sheet as dismissed.
+    func dismissSetupSheet() {
+        needsSetupSheet = false
+    }
+
+    // MARK: - Translations
+
+    /// The cached translation segments for a unit, or `nil` if not yet fetched.
+    func translations(for unit: TranslationUnitID) -> [String]? {
+        translationsByUnit[unit]
+    }
+
+    /// Stores translation segments for a unit.
+    func setTranslations(_ segments: [String], for unit: TranslationUnitID) {
+        translationsByUnit[unit] = segments
+    }
+
+    // MARK: - Private
+
+    /// Whether the book has ever been configured for bilingual mode — true if
+    /// a per-book file already carries a bilingual key. Used to decide whether
+    /// the first-enable setup sheet should appear.
+    private var hasBeenConfigured: Bool {
+        let override = PerBookSettingsStore.settings(
+            for: bookFingerprintKey, baseURL: perBookBaseURL)
+        return override?.bilingualEnabled != nil
+            || override?.bilingualTargetLanguage != nil
+            || override?.bilingualGranularity != nil
+    }
+
+    /// Read-modify-writes the per-book override file, preserving any
+    /// typography fields already present (the bilingual fields are additive).
+    private func persist() {
+        var override = PerBookSettingsStore.settings(
+            for: bookFingerprintKey, baseURL: perBookBaseURL) ?? PerBookSettingsOverride()
+        override.bilingualEnabled = isEnabled
+        override.bilingualTargetLanguage = targetLanguage
+        override.bilingualGranularity = granularity.rawValue
+        try? PerBookSettingsStore.save(
+            override, for: bookFingerprintKey, baseURL: perBookBaseURL)
+    }
+}

--- a/vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift
+++ b/vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift
@@ -1,0 +1,254 @@
+// Purpose: Tests for BilingualReadingViewModel's WI-7a persistence/state core
+// for feature #56 bilingual reading — toggle persists to PerBookSettings,
+// holds translationsByUnit, exposes isEnabled / targetLanguage / granularity,
+// raises needsSetupSheet on the first enable only.
+//
+// @coordinates-with: BilingualReadingViewModel.swift,
+//   dev-docs/plans/20260519-feature-56-bilingual-reading.md (WI-7a)
+
+import Testing
+import Foundation
+@testable import vreader
+
+@MainActor
+@Suite("BilingualReadingViewModel — persistence/state core (WI-7a)")
+struct BilingualReadingViewModelCoreTests {
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BilingualVMCore-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private static let bookKey = "epub:aa00112233445566778899aabbccddeeff00112233445566778899aabbccdd:1024"
+
+    // MARK: - Initial state
+
+    @Test func freshBook_startsDisabledWithDefaults() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let vm = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        #expect(vm.isEnabled == false)
+        #expect(vm.targetLanguage == "Chinese")     // design default
+        #expect(vm.granularity == .paragraph)        // design default
+        #expect(vm.translationsByUnit.isEmpty)
+        #expect(vm.needsSetupSheet == false)
+    }
+
+    @Test func loadsPersistedEnabledStateOnInit() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        // Pre-write a per-book override with bilingual on.
+        try PerBookSettingsStore.save(
+            PerBookSettingsOverride(
+                bilingualEnabled: true,
+                bilingualTargetLanguage: "Japanese",
+                bilingualGranularity: "sentence"),
+            for: Self.bookKey, baseURL: dir)
+
+        let vm = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        #expect(vm.isEnabled == true)
+        #expect(vm.targetLanguage == "Japanese")
+        #expect(vm.granularity == .sentence)
+    }
+
+    @Test func olderPerBookFileWithoutBilingualKeys_startsDisabled() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        // A pre-#56 file (typography only, no bilingual keys).
+        try PerBookSettingsStore.save(
+            PerBookSettingsOverride(fontSize: 20, themeName: "dark"),
+            for: Self.bookKey, baseURL: dir)
+        let vm = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        #expect(vm.isEnabled == false)
+    }
+
+    // MARK: - Toggle persistence
+
+    @Test func enabling_persistsToPerBookSettings() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let vm = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        vm.setEnabled(true)
+
+        // A fresh VM reads the persisted state back.
+        let reloaded = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        #expect(reloaded.isEnabled == true)
+    }
+
+    @Test func disabling_persistsToPerBookSettings() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try PerBookSettingsStore.save(
+            PerBookSettingsOverride(bilingualEnabled: true),
+            for: Self.bookKey, baseURL: dir)
+        let vm = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        vm.setEnabled(false)
+
+        let reloaded = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        #expect(reloaded.isEnabled == false)
+    }
+
+    @Test func toggleDoesNotClobberTypographyOverrides() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        // Existing typography override.
+        try PerBookSettingsStore.save(
+            PerBookSettingsOverride(fontSize: 23, themeName: "sepia"),
+            for: Self.bookKey, baseURL: dir)
+        let vm = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        vm.setEnabled(true)
+
+        // The typography fields survive the bilingual toggle write.
+        let persisted = PerBookSettingsStore.settings(for: Self.bookKey, baseURL: dir)
+        #expect(persisted?.fontSize == 23)
+        #expect(persisted?.themeName == "sepia")
+        #expect(persisted?.bilingualEnabled == true)
+    }
+
+    @Test func settingTargetLanguage_persists() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let vm = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        vm.setTargetLanguage("Korean")
+        let reloaded = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        #expect(reloaded.targetLanguage == "Korean")
+    }
+
+    @Test func settingGranularity_persists() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let vm = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        vm.setGranularity(.sentence)
+        let reloaded = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        #expect(reloaded.granularity == .sentence)
+    }
+
+    // MARK: - Setup sheet
+
+    @Test func firstEnable_raisesNeedsSetupSheet() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let vm = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        #expect(vm.needsSetupSheet == false)
+        vm.setEnabled(true)
+        #expect(vm.needsSetupSheet == true)
+    }
+
+    @Test func secondEnable_doesNotRaiseSetupSheetAgain() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let vm = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        vm.setEnabled(true)        // first enable
+        vm.dismissSetupSheet()      // user completes setup
+        vm.setEnabled(false)
+        vm.setEnabled(true)        // re-enable
+        #expect(vm.needsSetupSheet == false)
+    }
+
+    @Test func aBookAlreadyConfigured_doesNotRaiseSetupSheetOnInit() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        // The book was configured in a prior session — bilingual already on.
+        try PerBookSettingsStore.save(
+            PerBookSettingsOverride(bilingualEnabled: true, bilingualTargetLanguage: "Chinese"),
+            for: Self.bookKey, baseURL: dir)
+        let vm = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        // Already on from persistence — no setup sheet on launch.
+        #expect(vm.needsSetupSheet == false)
+    }
+
+    @Test func dismissSetupSheet_clearsTheFlag() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let vm = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        vm.setEnabled(true)
+        #expect(vm.needsSetupSheet == true)
+        vm.dismissSetupSheet()
+        #expect(vm.needsSetupSheet == false)
+    }
+
+    @Test func configuredThenDisabledBook_doesNotReRaiseSetupSheetOnReEnable() throws {
+        // Reload-from-disk variant: a book configured in a prior session but
+        // persisted as DISABLED must not re-raise the setup sheet when the
+        // user toggles it back on — `hasBeenConfigured` keys on the presence
+        // of any bilingual key, not on `bilingualEnabled == true`.
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try PerBookSettingsStore.save(
+            PerBookSettingsOverride(
+                bilingualEnabled: false, bilingualTargetLanguage: "Chinese"),
+            for: Self.bookKey, baseURL: dir)
+        let vm = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        vm.setEnabled(true)
+        #expect(vm.needsSetupSheet == false)
+    }
+
+    // MARK: - Granularity back-compat
+
+    @Test func garbageStoredGranularity_fallsBackToParagraph() throws {
+        // A per-book file carrying an unknown/future granularity string must
+        // decode to the safe .paragraph default, not crash or stay nil.
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try PerBookSettingsStore.save(
+            PerBookSettingsOverride(
+                bilingualEnabled: true, bilingualGranularity: "future-value"),
+            for: Self.bookKey, baseURL: dir)
+        let vm = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        #expect(vm.granularity == .paragraph)
+    }
+
+    // MARK: - translationsByUnit
+
+    @Test func translationsByUnit_canBeStoredAndReadByUnit() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let vm = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        let unit = TranslationUnitID(kind: .epubHref, value: "ch1.xhtml")
+        vm.setTranslations(["你好", "世界"], for: unit)
+        #expect(vm.translationsByUnit[unit] == ["你好", "世界"])
+        #expect(vm.translations(for: unit) == ["你好", "世界"])
+    }
+
+    @Test func translations_forUncachedUnit_isNil() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let vm = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        let unit = TranslationUnitID(kind: .epubHref, value: "missing.xhtml")
+        #expect(vm.translations(for: unit) == nil)
+    }
+
+    @Test func disabling_clearsTranslationsByUnit() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let vm = BilingualReadingViewModel(
+            bookFingerprintKey: Self.bookKey, perBookBaseURL: dir)
+        vm.setEnabled(true)
+        vm.setTranslations(["译"], for: TranslationUnitID(kind: .epubHref, value: "a"))
+        #expect(vm.translationsByUnit.isEmpty == false)
+        vm.setEnabled(false)
+        #expect(vm.translationsByUnit.isEmpty)
+    }
+}


### PR DESCRIPTION
## WI-7a — BilingualReadingViewModel persistence/state core

Part of feature #56 (bilingual reading mode). WI-7a of 16 work items per `dev-docs/plans/20260519-feature-56-bilingual-reading.md`. WI-7 was split (Gate-2 round-1 M1): WI-7a is the pure persistence/state core (foundational — no observable behavior); WI-7b adds the trigger + notification + prefetch (behavioral). Unit tests + audit suffice (Gate 5).

### What this adds

`BilingualReadingViewModel` (`@Observable @MainActor`) — the WI-7a core:

- `isEnabled` / `targetLanguage` (default `"Chinese"`) / `granularity` (default `.paragraph`) — loaded from `PerBookSettings` at init. A garbage/future stored granularity string falls back to `.paragraph`.
- `setEnabled` / `setTargetLanguage` / `setGranularity` — each persists through `PerBookSettingsStore` via a read-modify-write that **preserves the file's typography fields** (the bilingual fields are additive — WI-3). A language / granularity change clears the per-unit translation cache.
- `needsSetupSheet` — raised the **first** time the user enables bilingual mode for a book (design §2.2); a book already configured in a prior session (a per-book file already carries a bilingual key — even if disabled) does **not** re-raise it. `dismissSetupSheet()` clears the flag.
- `translationsByUnit: [TranslationUnitID: [String]]` — per-unit cached translations; `setTranslations` / `translations(for:)`; disabling clears it.

No notification posting, no prefetch, no `ChapterTextProviding` injection — those are WI-7b.

### Tests

`BilingualReadingViewModelCoreTests` (17) — fresh-book defaults; loads persisted enabled/language/granularity; a pre-#56 file (no bilingual keys) starts disabled; enable/disable persist and survive a fresh VM; the toggle does not clobber typography overrides; language/granularity persist; first enable raises `needsSetupSheet`, a second enable does not, a configured-from-persistence book does not raise it on init, a configured-then-disabled book does not re-raise on re-enable; `dismissSetupSheet` clears the flag; a garbage stored granularity falls back to `.paragraph`; `translationsByUnit` store/read; disabling clears it.

### Gates

- **Gate 3 (TDD)**: RED → GREEN → REFACTOR. WI-7a suite passes on iPhone 17 Pro Simulator (full project compiles clean).
- **Gate 4 (Codex audit)**: 1 round, `final_verdict: ship-as-is`, zero Critical/High/Medium. 2 Low (test-coverage-only — implementation correct as audited) fixed. Log: `.claude/codex-audits/feat-56-wi-7a-bilingual-vm-core-audit.md`.
- **Gate 5**: foundational WI — no device verification required.
- **Docs sync**: not triggered — a feature-#56-local ViewModel, not a cross-feature shared component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
