### PR TITLE
docs: commit bilingual offline state design bundle (resolves needs-design #1024)

### DIFF
--- a/.claude/codex-audits/docs-bilingual-offline-handoff-audit.md
+++ b/.claude/codex-audits/docs-bilingual-offline-handoff-audit.md
@@ -1,0 +1,62 @@
+---
+branch: docs/bilingual-offline-handoff
+threadId: manual-fallback
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-20
+---
+
+## Scope
+
+Syncs the claude.ai/design "VReader Bilingual Offline Canvas" handoff
+into the `dev-docs/designs/vreader-fidelity-v1/` bundle. Touches the
+design bundle, plus `project.yml` / `project.pbxproj` (version bump
+3.37.27/573 → 3.37.28/574).
+
+**No Swift source files changed.** The audit-gate hook fires on
+`project.pbxproj` — false positive of the Swift-file heuristic. Manual
+mini-audit.
+
+## Manual audit evidence
+
+### What changed and why
+
+Bundle sync (rsync, superset — nothing deleted): 3 new files —
+`VReader Bilingual Offline Canvas.html`, `bilingual-offline-artboards.jsx`,
+`vreader-bilingual-offline.jsx`; `README.md` + `chats/chat7.md` updated.
+
+The handoff delivers the committed design for `needs-design` issue
+**#1024** — the **bilingual offline / "translation unavailable" inline
+state** for feature #56 (bilingual reading mode). Feature #56's plan
+(`dev-docs/plans/20260519-feature-56-bilingual-reading.md`, Decision 2
+edge case (c)) requires bilingual mode to show *something* when a
+chapter is not cached and the device is offline; the prior committed
+design bundles depicted no offline state. This handoff commits that
+surface.
+
+### Correctness checks
+
+1. **#1024 is a real, open `needs-design` issue** — verified via
+   `gh issue view 1024`: OPEN, labels `enhancement` + `needs-design`,
+   title "Design needed: bilingual offline / translation-unavailable
+   inline state for feature #56".
+2. **Issue → feature linkage** — #1024's body names feature #56 and
+   cites the plan's Decision-2 edge case (c). Feature #56's row in
+   `docs/features.md` carries no `BLOCKED: needs-design (#1024)`
+   annotation (the offline-state is a sub-affordance gap from #56's
+   plan, not a row-level block), so no `docs/features.md` row is
+   flipped here.
+3. **Issue closure** — PR uses `Resolves #1024` so the `needs-design`
+   issue auto-closes on merge (same precedent as PRs #1037 / #972 /
+   #956 / #930 / #869 / #848: a `needs-design` issue is resolved by
+   the design being committed).
+4. **No Swift implemented** — design-delivery only. Building the
+   offline state is gated feature-#56 feature-workflow work;
+   deliberately not in this PR.
+5. **Version bump** — 3.37.28 / build 574 (patch — docs / design-bundle
+   sync). `xcodegen generate` confirmed.
+
+## Verdict
+
+ship-as-is — design-bundle sync + version bump. No Swift logic. Manual
+fallback used because there is nothing to send to Codex.

--- a/dev-docs/designs/vreader-fidelity-v1/README.md
+++ b/dev-docs/designs/vreader-fidelity-v1/README.md
@@ -8,7 +8,7 @@ A user mocked up designs in HTML/CSS/JS using an AI design tool, then exported t
 
 **Read the chat transcripts first.** There are 7 chat transcript(s) in `vreader-fidelity/chats/`. The transcripts show the full back-and-forth between the user and the design assistant — they tell you **what the user actually wants** and **where they landed** after iterating. Don't skip them. The final HTML files are the output, but the chat is where the intent lives.
 
-**Read `vreader-fidelity/project/VReader PDF Translation Panel Canvas.html` in full.** The user had this file open when they triggered the handoff, so it's almost certainly the primary design they want built. Read it top to bottom — don't skim. Then **follow its imports**: open every file it pulls in (shared components, CSS, scripts) so you understand how the pieces fit together before you start implementing.
+**Read `vreader-fidelity/project/VReader Bilingual Offline Canvas.html` in full.** The user had this file open when they triggered the handoff, so it's almost certainly the primary design they want built. Read it top to bottom — don't skim. Then **follow its imports**: open every file it pulls in (shared components, CSS, scripts) so you understand how the pieces fit together before you start implementing.
 
 **If anything is ambiguous, ask the user to confirm before you start implementing.** It's much cheaper to clarify scope up front than to build the wrong thing.
 

--- a/dev-docs/designs/vreader-fidelity-v1/chats/chat7.md
+++ b/dev-docs/designs/vreader-fidelity-v1/chats/chat7.md
@@ -118,3 +118,64 @@ done？
 
 Yep — done. Canvas is live at **VReader PDF Translation Panel Canvas.html** with sections A (split, canonical), B (peek-sheet, alternative), and C (anatomy detail), covering all four states (default / loading / offline+retry / empty) plus collapsed and theme variants.
 
+## User
+
+https://github.com/lllyys/vreader/issues/1024
+
+## Assistant
+
+_[tool: read_file]_
+
+_[tool: grep]_
+
+_[tool: read_file]_
+
+_[tool: web_fetch]_
+
+_[tool: snip]_
+
+_[tool: update_todos]_
+
+_[tool: web_fetch]_
+
+Now I understand — **#1024 is the EPUB/reflowable inline offline state**, distinct from the PDF below-page panel I built for #1023. This one lives *inside* the paragraph-interlinear flow (`BilingualPageContent` in `vreader-bilingual.jsx`).
+
+Key constraints from the issue:
+- Must fit paragraph-interlinear layout without breaking source/translation rhythm
+- Must cover offline+uncached, retry affordance, **distinct from loading**
+
+Let me snip the prior #1023 work to make room and build.
+
+_[tool: write_file]_
+
+Reading the existing renderer, the translation block has a distinctive shell — left accent border (`borderLeft: 2px solid {accent}55`), indented padding, 88% font, sub color. The offline placeholder needs to **preserve that shell** so the rhythm continues; only its content changes.
+
+Committing to three approaches:
+- **A — Ghost placeholder + page banner (canonical)**: per-paragraph shell stays, content is a dim dashed bar (no per-paragraph copy); banner up top with retry. No copy repetition across N paragraphs.
+- **B — Inline italic copy**: explicit "Translation cached when online" inside each translation slot. Noisier but more explicit.
+- **C — Source-only collapse + banner**: translation slot vanishes; banner alone explains. Cleanest, but loses the bilingual rhythm.
+
+Plus a distinct **loading** state (shimmer bars in the slot) so users learn the difference.Now the artboards. I'll build a phone frame around the renderer with the existing reader chrome (top bar with title + bilingual pill, bottom progress).
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: done]_
+
+_[tool: fork_verifier_agent]_
+
+Built **VReader Bilingual Offline Canvas.html** for #1024.
+
+**System:** Every state preserves the existing translation block's shell (left accent border + indent + sub color) so the source/translation rhythm continues even when the translation is unavailable. Only the *content* of the slot varies.
+
+**Sections:**
+- **A — Ghost placeholder (canonical)**: dim dashed bar in the slot, glyph on first-of-page only, page banner carries copy once. 5 artboards: offline + retry / online / no-banner / dark / sepia+JP.
+- **B — Inline italic copy (alternative)**: explicit per-paragraph text. 3 artboards.
+- **C — Source-only collapse (rejected, for comparison)**: 2 artboards including the silent shipped fallback.
+- **L — Loading**: shimmer bars in the same shell, distinct from ghost. 3 artboards including a mixed cached/loading/offline page.
+- **M — Partial cache**: 2 artboards showing the ratio banner ("3 of 9 cached").
+- **D — Slot anatomy** + **Banner detail**: true-size side-by-side of every variant in paper + dark.
+
+Post-its recommend **A**. The banner has three distinct states (offline / partial / online+retry) — Retry CTA only appears once reachability returns, so users aren't tempted to spam it offline.
+

--- a/dev-docs/designs/vreader-fidelity-v1/project/VReader Bilingual Offline Canvas.html
+++ b/dev-docs/designs/vreader-fidelity-v1/project/VReader Bilingual Offline Canvas.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>VReader — Issue #1024 · Bilingual offline / translation-unavailable inline state</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,300..900;1,8..60,300..900&family=Inter:wght@300;400;500;600;700;800&family=Noto+Serif+SC:wght@400;500;600;700&family=Noto+Serif+JP:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0; padding: 0; background: #f0eee9;
+    font-family: 'Inter', -apple-system, system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  .hide-scroll::-webkit-scrollbar { display: none; }
+  .hide-scroll { scrollbar-width: none; -ms-overflow-style: none; }
+  button { font-family: inherit; }
+  button:focus { outline: none; }
+</style>
+<template id="__bundler_thumbnail">
+  <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <rect width="200" height="200" fill="#1a1815"/>
+    <rect x="40" y="36" width="120" height="6" rx="2" fill="#d8d2c5" opacity="0.85"/>
+    <rect x="40" y="48" width="100" height="4" rx="2" fill="#d8d2c5" opacity="0.6"/>
+    <rect x="40" y="56" width="90" height="4" rx="2" fill="#d8d2c5" opacity="0.6"/>
+    <rect x="46" y="68" width="2" height="22" fill="#d6885a" opacity="0.35"/>
+    <path d="M52 78 h84" stroke="#d8d2c5" stroke-width="1.4" stroke-dasharray="4 4" opacity="0.45"/>
+    <rect x="40" y="98" width="118" height="6" rx="2" fill="#d8d2c5" opacity="0.85"/>
+    <rect x="40" y="110" width="92" height="4" rx="2" fill="#d8d2c5" opacity="0.6"/>
+    <rect x="46" y="124" width="2" height="22" fill="#d6885a" opacity="0.35"/>
+    <path d="M52 134 h84" stroke="#d8d2c5" stroke-width="1.4" stroke-dasharray="4 4" opacity="0.45"/>
+    <text x="100" y="184" font-family="Inter, sans-serif" font-size="11" font-weight="600" fill="#d8d2c5" text-anchor="middle" letter-spacing="2">#1024 OFFLINE</text>
+  </svg>
+</template>
+</head>
+<body>
+
+<div id="root"></div>
+
+<!-- React + Babel -->
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<!-- Canvas + base tokens -->
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="vreader-themes.jsx"></script>
+
+<!-- New: the inline offline states + this canvas's artboards -->
+<script type="text/babel" src="vreader-bilingual-offline.jsx"></script>
+<script type="text/babel" src="bilingual-offline-artboards.jsx"></script>
+
+<script type="text/babel">
+  const root = ReactDOM.createRoot(document.getElementById('root'));
+  root.render(<CanvasRoot1024/>);
+</script>
+</body>
+</html>

--- a/dev-docs/designs/vreader-fidelity-v1/project/bilingual-offline-artboards.jsx
+++ b/dev-docs/designs/vreader-fidelity-v1/project/bilingual-offline-artboards.jsx
@@ -1,0 +1,402 @@
+// Canvas artboards for issue #1024 — bilingual offline / translation-unavailable inline state.
+//
+// Sections:
+//   A — Ghost placeholder (canonical). Per-paragraph ghost shell + page banner.
+//   B — Inline italic copy (alternative). Per-paragraph explicit text.
+//   C — Source-only collapse (rejected option, shown for comparison).
+//   L — Loading state, side-by-side with offline so the distinction is concrete.
+//   M — Mixed / partial cache state.
+//   D — State anatomy detail — true-size, every slot variant.
+
+const I1024_PHONE_W = 402;
+const I1024_PHONE_H = 740;
+
+// Sample source + translations (subset of vreader-data PP_PAGES, hand-paired).
+const I1024_SOURCE = [
+  'It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife.',
+  'However little known the feelings or views of such a man may be on his first entering a neighbourhood, this truth is so well fixed in the minds of the surrounding families, that he is considered as the rightful property of some one or other of their daughters.',
+  '"My dear Mr. Bennet," said his lady to him one day, "have you heard that Netherfield Park is let at last?"',
+  'Mr. Bennet replied that he had not. "But it is," returned she; "for Mrs. Long has just been here, and she told me all about it."',
+];
+const I1024_TR_CN = [
+  '凡是有钱的单身汉，总想娶位太太，这已经成了一条举世公认的真理。',
+  '这样的单身汉，每逢新搬到一个地方，四邻八舍虽然完全不了解他的性情如何，见解如何，可是，既然这样的一条真理早已在人们心目中根深蒂固，因此人们总是把他看作自己某一个女儿理所应得的一笔财产。',
+  '有一天，班纳特太太对她丈夫说："我的好老爷，尼日斐花园终于租出去了，你听说过没有？"',
+  '班纳特先生回答道，没有听说过。"的确租出去了，"她说，"朗格太太刚刚上这儿来过，她把这件事的底细，一五一十地告诉了我。"',
+];
+
+
+// Reader phone shell — top chrome (with bilingual pill), the page body
+// from BilingualPageContent_OfflineDemo, and a thin bottom strip with page
+// indicator. Lightweight, self-contained — doesn't pull in ReaderScreen.
+function I1024_Phone({ themeKey, children, height = I1024_PHONE_H, lang = 'Chinese' }) {
+  const t = THEMES[themeKey];
+  return (
+    <div style={{
+      width: I1024_PHONE_W, height, position: 'relative', overflow: 'hidden',
+      background: t.bg, borderRadius: 18,
+      boxShadow: '0 0 0 1px rgba(255,255,255,0.04), 0 14px 40px rgba(0,0,0,0.35)',
+    }}>
+      <I1024_TopChrome theme={t} lang={lang}/>
+      {children}
+      <I1024_BottomStrip theme={t}/>
+    </div>
+  );
+}
+
+function I1024_TopChrome({ theme: t, lang }) {
+  const glyph = lang === 'Chinese' ? '中'
+              : lang === 'Japanese' ? '日'
+              : lang === 'Korean' ? '한'
+              : lang === 'Arabic' ? 'ع' : 'Es';
+  const ff = lang === 'Chinese' || lang === 'Japanese' || lang === 'Korean'
+    ? '"Songti SC", "Source Han Serif", serif' : '"Inter", system-ui';
+  return (
+    <div style={{
+      position: 'absolute', top: 0, left: 0, right: 0,
+      paddingTop: 36, paddingBottom: 8, zIndex: 30,
+      background: t.chrome, borderBottom: `0.5px solid ${t.rule}`,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 14px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 2, color: t.accent, fontSize: 14, fontWeight: 500 }}>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+            strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 6l-6 6 6 6"/></svg>
+          <span>Library</span>
+        </div>
+        <div style={{
+          flex: 1, textAlign: 'center', padding: '0 8px',
+          overflow: 'hidden', whiteSpace: 'nowrap',
+          fontFamily: '"Source Serif 4", Georgia, serif',
+          fontSize: 13.5, fontWeight: 600, color: t.ink, fontStyle: 'italic',
+        }}>
+          <span>Pride and Prejudice</span>
+          {/* bilingual pill */}
+          <span style={{
+            display: 'inline-flex', alignItems: 'center', gap: 3,
+            padding: '2px 7px 2px 3px', borderRadius: 100, marginLeft: 6,
+            background: `${t.accent}1a`, color: t.accent,
+            fontStyle: 'normal', fontFamily: '"Inter", system-ui',
+            fontSize: 9.5, fontWeight: 600, verticalAlign: 'middle',
+          }}>
+            <span style={{
+              width: 14, height: 14, borderRadius: 7, background: t.accent,
+              display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+              color: '#fff', fontSize: 8, fontWeight: 700,
+            }}>EN</span>
+            <span style={{ opacity: 0.7, fontSize: 8 }}>↔</span>
+            <span style={{ fontFamily: ff, fontWeight: 700, fontSize: 11 }}>{glyph}</span>
+          </span>
+        </div>
+        <div style={{ display: 'flex', gap: 0, color: t.ink }}>
+          <div style={{ width: 32, height: 32, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round"><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.5-3.5"/></svg>
+          </div>
+          <div style={{ width: 32, height: 32, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <svg width="17" height="17" viewBox="0 0 24 24" fill="currentColor"><circle cx="5" cy="12" r="1.3"/><circle cx="12" cy="12" r="1.3"/><circle cx="19" cy="12" r="1.3"/></svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function I1024_BottomStrip({ theme: t }) {
+  return (
+    <div style={{
+      position: 'absolute', bottom: 0, left: 0, right: 0,
+      height: 30, display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontFamily: '"Inter", system-ui', fontSize: 10,
+      color: t.sub, opacity: 0.65, letterSpacing: 0.5,
+    }}>
+      <span>3 / 432</span>
+    </div>
+  );
+}
+
+
+// Build the paragraph spec for a given offline pattern.
+//   pattern: 'all-offline' | 'all-cached' | 'partial' | 'all-loading' | 'mixed'
+function makeParas(pattern) {
+  switch (pattern) {
+    case 'all-cached':  return I1024_SOURCE.map(t => ({ text: t, state: 'cached' }));
+    case 'all-offline': return I1024_SOURCE.map(t => ({ text: t, state: 'offline' }));
+    case 'all-loading': return I1024_SOURCE.map(t => ({ text: t, state: 'loading' }));
+    case 'partial':     return [
+      { text: I1024_SOURCE[0], state: 'cached' },
+      { text: I1024_SOURCE[1], state: 'cached' },
+      { text: I1024_SOURCE[2], state: 'offline' },
+      { text: I1024_SOURCE[3], state: 'offline' },
+    ];
+    case 'mixed':       return [
+      { text: I1024_SOURCE[0], state: 'cached' },
+      { text: I1024_SOURCE[1], state: 'loading' },
+      { text: I1024_SOURCE[2], state: 'offline' },
+      { text: I1024_SOURCE[3], state: 'offline' },
+    ];
+    default: return I1024_SOURCE.map(t => ({ text: t, state: 'cached' }));
+  }
+}
+
+
+// Approach-A artboard
+function A_Ghost({ themeKey, pattern = 'all-offline', pageStatus = 'offline', lang = 'Chinese' }) {
+  const t = THEMES[themeKey];
+  const paras = makeParas(pattern);
+  const cached = paras.filter(p => p.state === 'cached').length;
+  return (
+    <I1024_Phone themeKey={themeKey} lang={lang}>
+      <BilingualPageContent_OfflineDemo
+        theme={t} lang={lang}
+        fontSize={16} margin={22}
+        paragraphs={paras}
+        translations={lang === 'Chinese' ? I1024_TR_CN : undefined}
+        approach="A"
+        pageStatus={pageStatus}
+        cachedCount={cached} totalCount={paras.length}
+        chapter="Chapter 1"/>
+    </I1024_Phone>
+  );
+}
+
+// Approach-B artboard
+function B_InlineCopy({ themeKey, pattern = 'all-offline', pageStatus = 'none' }) {
+  const t = THEMES[themeKey];
+  const paras = makeParas(pattern);
+  return (
+    <I1024_Phone themeKey={themeKey}>
+      <BilingualPageContent_OfflineDemo
+        theme={t} lang="Chinese"
+        fontSize={16} margin={22}
+        paragraphs={paras}
+        translations={I1024_TR_CN}
+        approach="B"
+        pageStatus={pageStatus}
+        chapter="Chapter 1"/>
+    </I1024_Phone>
+  );
+}
+
+// Approach-C artboard (rejected option — source-only collapse + banner only)
+function C_Collapse({ themeKey, pattern = 'all-offline', pageStatus = 'offline' }) {
+  const t = THEMES[themeKey];
+  const paras = makeParas(pattern);
+  return (
+    <I1024_Phone themeKey={themeKey}>
+      <BilingualPageContent_OfflineDemo
+        theme={t} lang="Chinese"
+        fontSize={16} margin={22}
+        paragraphs={paras}
+        translations={I1024_TR_CN}
+        approach="C"
+        pageStatus={pageStatus}
+        chapter="Chapter 1"/>
+    </I1024_Phone>
+  );
+}
+
+// Side-by-side detail card. True-size slot variants stacked, so the
+// reviewer can see the rhythm difference at-a-glance.
+function StateAnatomy({ themeKey }) {
+  const t = THEMES[themeKey];
+  const fontSize = 16;
+  const SourcePara = ({ children }) => (
+    <p style={{
+      margin: 0,
+      fontFamily: '"Source Serif 4", Georgia, serif',
+      fontSize, lineHeight: 1.55, color: t.ink, textAlign: 'justify',
+    }}>{children}</p>
+  );
+  const rows = [
+    { key: 'cached',  label: 'Cached translation (baseline)',
+      note: 'Source paragraph followed by translation block with left-accent border. Every other state inherits this shell.',
+      slot: <BilingualCachedSlot theme={t} fontSize={fontSize} text={I1024_TR_CN[0]}/> },
+    { key: 'loading', label: 'Loading · in flight',
+      note: 'Shimmer bars in the same shell. Animation distinguishes it from offline — users learn the difference after seeing both once.',
+      slot: <BilingualLoadingSlot theme={t} fontSize={fontSize}/> },
+    { key: 'ghost-first', label: 'A · Ghost — first on page (with glyph)',
+      note: 'Dim border + cloud-off glyph + dashed bar. The glyph appears once per page so the user has a visual anchor without repetition.',
+      slot: <BilingualGhostSlot theme={t} fontSize={fontSize} withGlyph/> },
+    { key: 'ghost-bare', label: 'A · Ghost — subsequent (bare)',
+      note: 'No glyph. The accent border (dimmed to 33% alpha) is enough to maintain the rhythm.',
+      slot: <BilingualGhostSlot theme={t} fontSize={fontSize}/> },
+    { key: 'inline',  label: 'B · Inline italic copy',
+      note: 'One italic muted line per paragraph. More explicit; noisier when 8+ paragraphs are offline on one page.',
+      slot: <BilingualInlineCopySlot theme={t} fontSize={fontSize}/> },
+    { key: 'collapse', label: 'C · Source-only collapse',
+      note: 'Translation slot omitted entirely. Cleanest visually — but page looks identical to non-bilingual mode, which reads as "feature failed" right after toggling on.',
+      slot: null },
+  ];
+  return (
+    <div style={{
+      width: 760, padding: '24px 28px', background: t.bg,
+      borderRadius: 12, border: `0.5px solid ${t.rule}`,
+      display: 'flex', flexDirection: 'column', gap: 18,
+    }}>
+      {rows.map((r, i) => (
+        <div key={r.key} style={{
+          display: 'flex', alignItems: 'flex-start', gap: 22,
+          paddingBottom: 18,
+          borderBottom: i === rows.length - 1 ? 'none' : `0.5px dashed ${t.rule}`,
+        }}>
+          <div style={{ width: 220, flexShrink: 0 }}>
+            <div style={{
+              fontSize: 11, color: t.sub, letterSpacing: 0.6,
+              textTransform: 'uppercase', fontWeight: 600, marginBottom: 6,
+            }}>{r.key}</div>
+            <div style={{ fontSize: 13.5, color: t.ink, fontWeight: 500, marginBottom: 6, lineHeight: 1.3 }}>{r.label}</div>
+            <div style={{ fontSize: 11.5, color: t.sub, lineHeight: 1.5 }}>{r.note}</div>
+          </div>
+          <div style={{ flex: 1, padding: '0 8px' }}>
+            <SourcePara>{I1024_SOURCE[0]}</SourcePara>
+            {r.slot}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Banner-only zoomed comparison.
+function BannerDetail({ themeKey }) {
+  const t = THEMES[themeKey];
+  const rows = [
+    { status: 'offline', label: 'Offline · uncached', note: 'Default state during an offline reading session. Sub-color tray; no CTA — there\u2019s nothing the user can do until they reconnect.' },
+    { status: 'partial', label: 'Partial cache', note: 'When some paragraphs are cached but others aren\u2019t. Banner counts the ratio so the user understands gaps below are expected.' },
+    { status: 'online',  label: 'Back online · retry', note: 'Reachability has returned; explicit Retry CTA. Accent-tinted tray so it reads as actionable, not informational.' },
+  ];
+  return (
+    <div style={{
+      width: 520, padding: '22px 24px', background: t.bg,
+      borderRadius: 12, border: `0.5px solid ${t.rule}`,
+      display: 'flex', flexDirection: 'column', gap: 14,
+    }}>
+      {rows.map(r => (
+        <div key={r.status}>
+          <div style={{
+            fontSize: 11, color: t.sub, letterSpacing: 0.6,
+            textTransform: 'uppercase', fontWeight: 600, marginBottom: 8,
+          }}>{r.label}</div>
+          <BilingualPageBanner theme={t} status={r.status}
+            cached={3} total={9} onRetry={() => {}}/>
+          <div style={{ fontSize: 11.5, color: t.sub, lineHeight: 1.5, marginTop: 4 }}>{r.note}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+
+function CanvasRoot1024() {
+  return (
+    <DesignCanvas>
+      <DCSection id="intro" title="Bilingual offline · inline state · #1024"
+        subtitle="Inline within the paragraph-interlinear flow. Preserves the source/translation rhythm. Distinct from loading. Three approaches across themes + the partial / loading / online-retry states.">
+        <DCPostIt top={-30} right={40} rotate={-2} width={300}>
+          <b>Pick A (Ghost).</b> The shell-preserving placeholder + one
+          page-level banner is the right weight: the user understands once
+          (banner), then sees the missing-slot rhythm continue without
+          eight repetitions of the same copy.
+        </DCPostIt>
+      </DCSection>
+
+      <DCSection id="A" title="A — Ghost placeholder (canonical)"
+        subtitle="Same shell as the cached translation; content is a dim dashed bar. Page banner explains once. Glyph appears on the FIRST ghost only, as a visual anchor.">
+        <DCArtboard id="A1-offline" label="A1 · All offline + banner" width={I1024_PHONE_W} height={I1024_PHONE_H}>
+          <A_Ghost themeKey="paper" pattern="all-offline" pageStatus="offline"/>
+        </DCArtboard>
+        <DCArtboard id="A2-online-retry" label="A2 · Back online + retry CTA" width={I1024_PHONE_W} height={I1024_PHONE_H}>
+          <A_Ghost themeKey="paper" pattern="all-offline" pageStatus="online"/>
+        </DCArtboard>
+        <DCArtboard id="A3-no-banner" label="A3 · No banner — ghost-only" width={I1024_PHONE_W} height={I1024_PHONE_H}>
+          <A_Ghost themeKey="paper" pattern="all-offline" pageStatus="none"/>
+        </DCArtboard>
+        <DCArtboard id="A4-dark" label="A4 · Dark theme" width={I1024_PHONE_W} height={I1024_PHONE_H}>
+          <A_Ghost themeKey="dark" pattern="all-offline" pageStatus="offline"/>
+        </DCArtboard>
+        <DCArtboard id="A5-sepia-jp" label="A5 · Sepia + Japanese" width={I1024_PHONE_W} height={I1024_PHONE_H}>
+          <A_Ghost themeKey="sepia" pattern="all-offline" pageStatus="offline" lang="Japanese"/>
+        </DCArtboard>
+
+        <DCPostIt top={-30} right={40} rotate={2} width={260}>
+          The accent border dims to 33% alpha on ghost slots — same vocabulary
+          as the cached state, but visibly lower-stakes. The page banner is
+          the SINGLE place that carries copy; per-paragraph repetition is the
+          thing this approach exists to avoid.
+        </DCPostIt>
+      </DCSection>
+
+      <DCSection id="B" title="B — Inline italic copy (alternative)"
+        subtitle="Per-paragraph italic muted text inside the translation slot. More explicit; redundant when many paragraphs are offline.">
+        <DCArtboard id="B1-paper" label="B1 · All offline · paper" width={I1024_PHONE_W} height={I1024_PHONE_H}>
+          <B_InlineCopy themeKey="paper" pattern="all-offline"/>
+        </DCArtboard>
+        <DCArtboard id="B2-with-banner" label="B2 · Inline copy + banner (belt + braces)" width={I1024_PHONE_W} height={I1024_PHONE_H}>
+          <B_InlineCopy themeKey="paper" pattern="all-offline" pageStatus="offline"/>
+        </DCArtboard>
+        <DCArtboard id="B3-dark" label="B3 · Dark" width={I1024_PHONE_W} height={I1024_PHONE_H}>
+          <B_InlineCopy themeKey="dark" pattern="all-offline"/>
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection id="C" title="C — Source-only collapse (rejected, for comparison)"
+        subtitle="Translation slot omitted entirely. Visually cleanest but the page looks identical to non-bilingual mode — reads as &ldquo;feature failed&rdquo; right after the user toggles bilingual on.">
+        <DCArtboard id="C1-banner-only" label="C1 · Banner-only · source unchanged" width={I1024_PHONE_W} height={I1024_PHONE_H}>
+          <C_Collapse themeKey="paper" pattern="all-offline" pageStatus="offline"/>
+        </DCArtboard>
+        <DCArtboard id="C2-no-banner" label="C2 · No banner (silent — current shipped)" width={I1024_PHONE_W} height={I1024_PHONE_H}>
+          <C_Collapse themeKey="paper" pattern="all-offline" pageStatus="none"/>
+        </DCArtboard>
+
+        <DCPostIt top={-30} right={40} rotate={-2} width={240}>
+          C2 is what ships today (silent fallback per the issue). The whole
+          point of #1024 is that this state needs a visible affordance.
+        </DCPostIt>
+      </DCSection>
+
+      <DCSection id="L-loading" title="L — Loading state — distinct from offline"
+        subtitle="Shimmer bars in the same shell. Side-by-side so the difference (animated vs static, full bars vs dashed line) is unmistakable.">
+        <DCArtboard id="L1-loading-all" label="L1 · All loading" width={I1024_PHONE_W} height={I1024_PHONE_H}>
+          <A_Ghost themeKey="paper" pattern="all-loading" pageStatus="none"/>
+        </DCArtboard>
+        <DCArtboard id="L2-mixed" label="L2 · Mixed — cached + loading + offline" width={I1024_PHONE_W} height={I1024_PHONE_H}>
+          <A_Ghost themeKey="paper" pattern="mixed" pageStatus="partial"/>
+        </DCArtboard>
+        <DCArtboard id="L3-dark" label="L3 · Mixed · dark" width={I1024_PHONE_W} height={I1024_PHONE_H}>
+          <A_Ghost themeKey="dark" pattern="mixed" pageStatus="partial"/>
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection id="M-partial" title="M — Partial / mixed cache"
+        subtitle="When SOME paragraphs are cached and others aren&rsquo;t. Cached slots render normally; uncached use the ghost. Banner counts the ratio.">
+        <DCArtboard id="M1-partial" label="M1 · 2 of 4 cached" width={I1024_PHONE_W} height={I1024_PHONE_H}>
+          <A_Ghost themeKey="paper" pattern="partial" pageStatus="partial"/>
+        </DCArtboard>
+        <DCArtboard id="M2-partial-dark" label="M2 · Partial · dark" width={I1024_PHONE_W} height={I1024_PHONE_H}>
+          <A_Ghost themeKey="dark" pattern="partial" pageStatus="partial"/>
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection id="D-detail" title="D — Slot anatomy · true size"
+        subtitle="All six slot variants stacked over the same source paragraph so rhythm + weight are directly comparable.">
+        <DCArtboard id="D1-paper" label="States · paper" width={760} height={920}>
+          <StateAnatomy themeKey="paper"/>
+        </DCArtboard>
+        <DCArtboard id="D2-dark" label="States · dark" width={760} height={920}>
+          <StateAnatomy themeKey="dark"/>
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection id="D-banner" title="D — Banner variants · true size"
+        subtitle="The three banner states zoomed.">
+        <DCArtboard id="DB1-paper" label="Banners · paper" width={520} height={420}>
+          <BannerDetail themeKey="paper"/>
+        </DCArtboard>
+        <DCArtboard id="DB2-dark" label="Banners · dark" width={520} height={420}>
+          <BannerDetail themeKey="dark"/>
+        </DCArtboard>
+      </DCSection>
+    </DesignCanvas>
+  );
+}
+
+Object.assign(window, { CanvasRoot1024 });

--- a/dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual-offline.jsx
+++ b/dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual-offline.jsx
@@ -1,0 +1,358 @@
+// Bilingual offline / translation-unavailable inline state — issue #1024.
+//
+// PARENT FEATURE: #56 bilingual reading mode. Paragraph-interlinear renderer
+// (vreader-bilingual.jsx → BilingualPageContent) needs a visible state for:
+//   (c) chapter not cached + device offline.
+//
+// Current shipped behavior (per the issue): silent source-only fallback. This
+// design adds the visible affordance.
+//
+// CRITICAL CONSTRAINTS FROM THE ISSUE
+// - Inline within the interlinear flow, NOT a modal or sheet.
+// - Must preserve the source-paragraph + translation-paragraph rhythm.
+// - Distinct from "translation in progress" loading state.
+// - Retry affordance once back online (optional / could be automatic).
+//
+// SYSTEM
+// The existing translation block uses a left accent border + indent + sub
+// color + 0.88× font. Every state below INHERITS that shell so the eye sees
+// "translation slot is here" even when content is unavailable. The shell IS
+// the rhythm — we don't break it for any state.
+//
+// THREE APPROACHES
+//   A (canonical) — Ghost placeholder + page banner.
+//     Per-paragraph: shell stays; content is a dim dashed bar (~1 line tall).
+//     Page-top banner explains once; offers Retry when back online.
+//     Why canonical: copy isn't repeated across 8-12 paragraphs of a page.
+//
+//   B — Inline italic copy.
+//     Per-paragraph: shell stays; content is one italic muted line
+//     ("Translation will appear when online"). No banner needed.
+//     Why considered: more explicit; better for screen readers.
+//
+//   C — Source-only collapse + banner.
+//     Translation slot is omitted entirely. Banner is the only signal.
+//     Why considered: cleanest visually. Why not canonical: the user just
+//     toggled bilingual ON; a page that looks identical to non-bilingual
+//     reads as "feature failed".
+//
+// LOADING (distinct)
+//   - Shell stays; content is 2 shimmer bars. Header pill / banner indicates
+//     "translating…" so the user can tell it's transient.
+//
+// PARTIAL
+//   - Per-paragraph state. Cached paragraphs render normally; uncached use
+//     the ghost. Banner counts ("3 of 9 paragraphs translated").
+
+
+// ────────────────────────────────────────────────────
+// Shared shell — exact replica of BilingualPageContent's translation block.
+// Every state below wraps its content in this so the layout rhythm is
+// preserved across cached / uncached / loading / empty.
+// ────────────────────────────────────────────────────
+function BilingualSlot({ t, fontSize, isRTL = false, dim = false, children, style = {} }) {
+  const accentAlpha = dim ? `${t.accent}33` : `${t.accent}55`;
+  return (
+    <div style={{
+      margin: '6px 0 0',
+      borderLeft: isRTL ? 'none' : `2px solid ${accentAlpha}`,
+      borderRight: isRTL ? `2px solid ${accentAlpha}` : 'none',
+      paddingLeft:  isRTL ? 0 : fontSize * 0.7,
+      paddingRight: isRTL ? fontSize * 0.7 : 0,
+      direction: isRTL ? 'rtl' : 'ltr',
+      textAlign: isRTL ? 'right' : 'left',
+      ...style,
+    }}>{children}</div>
+  );
+}
+
+
+// ────────────────────────────────────────────────────
+// State 1 — Cached translation (the baseline; included so the canvas can
+//   show it side-by-side with the offline states for rhythm comparison).
+// ────────────────────────────────────────────────────
+function BilingualCachedSlot({ theme, fontSize, lang = 'Chinese', text, isRTL = false }) {
+  const t = theme;
+  const ff = (lang === 'Chinese' || lang === 'Japanese' || lang === 'Korean')
+    ? '"Songti SC", "Source Han Serif", serif'
+    : '"Source Serif 4", Georgia, serif';
+  return (
+    <BilingualSlot t={t} fontSize={fontSize} isRTL={isRTL}>
+      <p style={{
+        margin: 0, fontFamily: ff,
+        fontSize: fontSize * 0.88, lineHeight: 1.55, color: t.sub,
+      }}>{text}</p>
+    </BilingualSlot>
+  );
+}
+
+
+// ────────────────────────────────────────────────────
+// State 2 — Loading ("translating now"). Distinct shimmer bars so users
+//   learn the difference. Two bars on most paragraphs; the variability
+//   keeps it from reading like a UI element rather than "in-flight content".
+// ────────────────────────────────────────────────────
+function BilingualLoadingSlot({ theme, fontSize, isRTL = false, barWidths = ['92%', '54%'] }) {
+  const t = theme;
+  const shimmer = t.isDark
+    ? 'linear-gradient(90deg, rgba(255,255,255,0.04), rgba(255,255,255,0.12), rgba(255,255,255,0.04))'
+    : 'linear-gradient(90deg, rgba(20,14,4,0.04), rgba(20,14,4,0.10), rgba(20,14,4,0.04))';
+  return (
+    <BilingualSlot t={t} fontSize={fontSize} isRTL={isRTL}>
+      <style>{`@keyframes bShim { 0% { background-position: 100% 0; } 100% { background-position: -100% 0; } }`}</style>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 5, padding: '3px 0' }}>
+        {barWidths.map((w, i) => (
+          <div key={i} style={{
+            height: fontSize * 0.7, width: w, borderRadius: 3,
+            background: shimmer, backgroundSize: '200% 100%',
+            animation: 'bShim 1.4s ease-in-out infinite',
+          }}/>
+        ))}
+      </div>
+    </BilingualSlot>
+  );
+}
+
+
+// ────────────────────────────────────────────────────
+// State 3a — APPROACH A: Ghost placeholder.
+//   Same shell, dim accent border (33 instead of 55), single dashed line.
+//   NO copy. The page banner carries the explanation once.
+//   Optional cloud-off glyph on the FIRST instance of the page only — set
+//   `withGlyph` on that one and leave others bare.
+// ────────────────────────────────────────────────────
+function BilingualGhostSlot({ theme, fontSize, isRTL = false, withGlyph = false }) {
+  const t = theme;
+  const dashColor = t.isDark
+    ? 'rgba(255,255,255,0.16)'
+    : 'rgba(20,14,4,0.18)';
+  return (
+    <BilingualSlot t={t} fontSize={fontSize} isRTL={isRTL} dim>
+      <div style={{
+        height: fontSize * 0.88 * 1.55,  // matches one line of translation
+        display: 'flex', alignItems: 'center', gap: 8,
+        opacity: 0.85,
+      }}>
+        {withGlyph && (
+          <svg width={fontSize * 0.9} height={fontSize * 0.9} viewBox="0 0 24 24"
+            fill="none" stroke={t.sub} strokeWidth="1.6"
+            strokeLinecap="round" strokeLinejoin="round"
+            style={{ flexShrink: 0, opacity: 0.75 }}>
+            <path d="M7 18a4 4 0 010-8 6 6 0 0111.7 1.5A4 4 0 0118 18"/>
+            <path d="M3 3l18 18"/>
+          </svg>
+        )}
+        <div style={{
+          flex: 1, height: 0, minHeight: 1,
+          borderTop: `1px dashed ${dashColor}`,
+        }}/>
+      </div>
+    </BilingualSlot>
+  );
+}
+
+
+// ────────────────────────────────────────────────────
+// State 3b — APPROACH B: Inline italic copy.
+//   Same shell, italic muted line per paragraph. More explicit. Noisier
+//   when many paragraphs are offline — but better for screen readers and
+//   for users who only see one paragraph on screen.
+// ────────────────────────────────────────────────────
+function BilingualInlineCopySlot({ theme, fontSize, isRTL = false }) {
+  const t = theme;
+  return (
+    <BilingualSlot t={t} fontSize={fontSize} isRTL={isRTL} dim>
+      <p style={{
+        margin: 0,
+        fontFamily: '"Source Serif 4", Georgia, serif',
+        fontSize: fontSize * 0.78, lineHeight: 1.5,
+        fontStyle: 'italic', color: t.sub, opacity: 0.7,
+      }}>Translation will appear when back online</p>
+    </BilingualSlot>
+  );
+}
+
+
+// ────────────────────────────────────────────────────
+// State 4 — Page-level offline banner.
+//   Sits between the chapter heading and the first paragraph (or where the
+//   chapter heading would be on non-chapter-start pages). Two variants:
+//     status = 'offline' — generic "you're offline, translations cached"
+//     status = 'online'  — back online + Retry button (uncached chapters)
+//     status = 'partial' — some paragraphs translated, some not (mixed)
+// ────────────────────────────────────────────────────
+function BilingualPageBanner({ theme, status = 'offline', cached = 0, total = 0, onRetry }) {
+  const t = theme;
+  const isOffline = status === 'offline';
+  const isPartial = status === 'partial';
+  const isReady   = status === 'online';
+
+  const bg = t.isDark
+    ? (isReady ? `${t.accent}22` : 'rgba(255,255,255,0.045)')
+    : (isReady ? `${t.accent}14` : 'rgba(20,14,4,0.045)');
+
+  const Glyph = () => {
+    if (isReady) {
+      // cloud-on-line "ready" glyph
+      return (
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+          stroke={t.accent} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M7 18a4 4 0 010-8 6 6 0 0111.7 1.5A4 4 0 0118 18"/>
+          <path d="M9 13l2 2 4-4"/>
+        </svg>
+      );
+    }
+    return (
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+        stroke={t.sub} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M7 18a4 4 0 010-8 6 6 0 0111.7 1.5A4 4 0 0118 18"/>
+        <path d="M3 3l18 18"/>
+      </svg>
+    );
+  };
+
+  const label =
+    isReady   ? 'Back online — fetch translations'
+  : isPartial ? `Partial translation — ${cached} of ${total} cached`
+  :             'Bilingual mode · offline';
+  const detail =
+    isReady   ? 'Tap Retry to translate this chapter.'
+  : isPartial ? 'Missing paragraphs will fill in when you reconnect.'
+  :             'Translations will appear when you reconnect.';
+
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 10,
+      padding: '8px 12px', margin: '0 0 14px',
+      borderRadius: 10, background: bg,
+      border: isReady ? `0.5px solid ${t.accent}55` : `0.5px solid ${t.rule}`,
+    }}>
+      <div style={{
+        width: 22, height: 22, borderRadius: 11, flexShrink: 0,
+        background: isReady
+          ? `${t.accent}22`
+          : (t.isDark ? 'rgba(255,255,255,0.06)' : 'rgba(20,14,4,0.05)'),
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}>
+        <Glyph/>
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          fontSize: 11.5, color: t.ink, fontWeight: 600,
+          letterSpacing: 0.2, lineHeight: 1.2,
+        }}>{label}</div>
+        <div style={{
+          fontSize: 10.5, color: t.sub, marginTop: 2, lineHeight: 1.3,
+        }}>{detail}</div>
+      </div>
+      {isReady && (
+        <button onClick={onRetry} style={{
+          padding: '4px 10px', borderRadius: 100, border: 'none',
+          background: t.accent, color: '#fff', cursor: 'pointer',
+          fontFamily: 'inherit', fontSize: 11.5, fontWeight: 600,
+          flexShrink: 0,
+        }}>Retry</button>
+      )}
+    </div>
+  );
+}
+
+
+// ────────────────────────────────────────────────────
+// Renderer — drop-in replacement for BilingualPageContent that takes a
+// per-paragraph cache map. Used by every artboard so the variations stay
+// faithful to the production layout.
+//
+// paragraphs:    [{ text, state }]
+//   state ∈ 'cached' | 'offline' | 'loading'   (default 'cached')
+// approach:      'A' (ghost), 'B' (inline copy), 'C' (collapse → no slot)
+// pageStatus:    'offline' | 'partial' | 'online' | 'none'  — banner control
+// ────────────────────────────────────────────────────
+function BilingualPageContent_OfflineDemo({
+  theme, fontFamily = 'serif', fontSize = 17, lineHeight = 1.55, margin = 22,
+  lang = 'Chinese',
+  paragraphs, translations,
+  approach = 'A', pageStatus = 'offline',
+  cachedCount = 0, totalCount = 0,
+  chapter,
+}) {
+  const t = theme;
+  const ff = fontFamily === 'serif'
+    ? '"Source Serif 4", Georgia, "Times New Roman", serif'
+    : '"Inter", -apple-system, system-ui, sans-serif';
+  const isRTL = lang === 'Arabic';
+
+  // First ghost paragraph on the page carries the cloud-off glyph as a
+  // visual anchor; the rest are bare.
+  let ghostShown = false;
+
+  return (
+    <div style={{
+      position: 'absolute', top: 76, bottom: 56,
+      left: margin, right: margin, overflow: 'hidden',
+    }}>
+      {chapter && (
+        <div style={{
+          fontFamily: '"Source Serif 4", Georgia, serif',
+          fontSize: 13, color: t.sub, letterSpacing: 2,
+          textTransform: 'uppercase', textAlign: 'center',
+          marginBottom: 18, marginTop: 8, fontWeight: 500,
+        }}>{chapter}</div>
+      )}
+
+      {pageStatus !== 'none' && (
+        <BilingualPageBanner theme={t} status={pageStatus}
+          cached={cachedCount} total={totalCount} onRetry={() => {}}/>
+      )}
+
+      {paragraphs.map((para, i) => {
+        const state = para.state || 'cached';
+        const tr = translations && translations[i];
+        const firstGhost = state === 'offline' && !ghostShown;
+        if (state === 'offline') ghostShown = true;
+        return (
+          <div key={i} style={{ marginBottom: lineHeight * fontSize * 0.55 }}>
+            <p style={{
+              fontFamily: ff, fontSize, lineHeight, color: t.ink, margin: 0,
+              textIndent: i === 0 ? 0 : `${fontSize * 1.4}px`,
+              textAlign: 'justify', hyphens: 'auto',
+            }}>
+              {i === 0 && (
+                <span style={{
+                  fontFamily: '"Source Serif 4", Georgia, serif',
+                  fontSize: fontSize * 2.6, lineHeight: 0.85,
+                  float: 'left', marginRight: 6, marginTop: 4,
+                  color: t.accent, fontWeight: 600,
+                }}>{para.text[0]}</span>
+              )}
+              {i === 0 ? para.text.slice(1) : para.text}
+            </p>
+
+            {/* translation slot — varies by state and approach */}
+            {state === 'cached' && tr && (
+              <BilingualCachedSlot theme={t} fontSize={fontSize} lang={lang} text={tr} isRTL={isRTL}/>
+            )}
+            {state === 'loading' && (
+              <BilingualLoadingSlot theme={t} fontSize={fontSize} isRTL={isRTL}
+                barWidths={i % 2 ? ['88%', '64%'] : ['92%', '46%']}/>
+            )}
+            {state === 'offline' && approach === 'A' && (
+              <BilingualGhostSlot theme={t} fontSize={fontSize} isRTL={isRTL} withGlyph={firstGhost}/>
+            )}
+            {state === 'offline' && approach === 'B' && (
+              <BilingualInlineCopySlot theme={t} fontSize={fontSize} isRTL={isRTL}/>
+            )}
+            {/* approach C: nothing — source-only collapse */}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+
+Object.assign(window, {
+  BilingualSlot, BilingualCachedSlot, BilingualLoadingSlot,
+  BilingualGhostSlot, BilingualInlineCopySlot, BilingualPageBanner,
+  BilingualPageContent_OfflineDemo,
+});

--- a/project.yml
+++ b/project.yml
@@ -133,8 +133,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 573
-        MARKETING_VERSION: 3.37.27
+        CURRENT_PROJECT_VERSION: 574
+        MARKETING_VERSION: 3.37.28
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -5918,13 +5918,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 573;
+				CURRENT_PROJECT_VERSION = 574;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.37.27;
+				MARKETING_VERSION = 3.37.28;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6068,13 +6068,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 573;
+				CURRENT_PROJECT_VERSION = 574;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.37.27;
+				MARKETING_VERSION = 3.37.28;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

Syncs the claude.ai/design **VReader Bilingual Offline Canvas** handoff into `dev-docs/designs/vreader-fidelity-v1/`.

## What Changed

- **Design bundle** — 3 new files: `VReader Bilingual Offline Canvas.html`, `bilingual-offline-artboards.jsx`, `vreader-bilingual-offline.jsx`; `README.md` + `chats/chat7.md` updated.

## The design delivered

`needs-design` **#1024** — the **bilingual offline / "translation unavailable" inline state** for **feature #56** (bilingual reading mode). #56's plan Decision-2 edge case (c) requires bilingual mode to show *something* when a chapter is not cached and the device is offline; prior bundles depicted no offline state. This handoff commits it.

Feature #56's row stays as-is — sub-affordance gap from #56's plan, not a row-level block.

Resolves #1024

## Codex Audit

Manual fallback (docs / design-bundle sync, no Swift logic). Verdict: ship-as-is. Audit log: `.claude/codex-audits/docs-bilingual-offline-handoff-audit.md`

## Validation

- [x] #1024 verified OPEN + `needs-design` label
- [x] Superset sync — no bundle files deleted
- [x] Version bumped: 3.37.27 → 3.37.28

## Type of Change

- [x] Documentation / design handoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)