### PR TITLE
docs(#56): post-implementation Gate-5b checkpoint

### DIFF
--- a/dev-docs/verification/feature-56-20260520.md
+++ b/dev-docs/verification/feature-56-20260520.md
@@ -1,0 +1,149 @@
+---
+kind: feature
+id: 56
+status_target: VERIFIED
+commit_sha: 5adc346b4c11bf32d52afcc7eed24c2c01a23316
+app_version: 3.38.0 (build 575)
+date: 2026-05-20
+verifier: claude (post-implementation checkpoint)
+device_or_simulator: iPhone 17 Pro Simulator (UDID 61149F0E + 1FAB9493 used across the 16-WI shipping arc)
+os_version: iOS 26
+build_configuration: Debug
+backend: n/a unit slices / real AI provider gated (see below)
+result: partial
+---
+
+# Feature #56 round-1 post-implementation checkpoint
+
+Feature #56 (bilingual reading mode) reached `DONE` on 2026-05-20 with
+WI-15 (PR #1042, merge `5adc346b`, tag `v3.38.0`). All 16 WIs are
+merged: WI-1..WI-15 inclusive of the WI-2.5 split and the WI-7a/WI-7b
+behavioural split.
+
+This file is the **first post-implementation verification checkpoint** —
+not the final acceptance pass. It documents what is verified at the
+unit / integration level today and what is gated on external
+infrastructure for the eventual `VERIFIED` flip.
+
+## Scope
+
+The full feature: chapter-bilingual mode (TXT/MD/EPUB interlinear + PDF
+below-page panel + AZW3/MOBI Foliate-bilingual), persistent chapter
+translation cache (`ChapterTranslationStore`), global "Translate entire
+book" coordinator + UI, per-chapter re-translation with provider
+override (`ChapterReTranslateViewModel` + `ReTranslatePickerSheet`),
+setup sheet, More-menu row, top-chrome bilingual pill.
+
+## Acceptance criteria (per `docs/features.md` row #56)
+
+| # | Criterion | Result | Observed |
+|---|-----------|--------|----------|
+| a | Bilingual mode toggle persists per book | **PASS** | `PerBookSettings` integration covered by WI-7a/7b unit tests (`BilingualReadingViewModel` toggle → `PerBookSettingsStore.setBilingualOn(true)`, restored on next book open). |
+| b | Current chapter translation renders inline within 10 seconds for a typical chapter | **GATED** — needs real AI provider | Test suites mock `AIService`; end-to-end timing against a real provider (OpenAI / Anthropic / OpenRouter / Azure) cannot be exercised CU-free without configured `ProviderProfileStore` credentials. The `--enable-ai` XCUITest launch arg is now wired (Bug #237 fix shipped 2026-05-20), but the launched test session has no provider profile by default. |
+| c | Cached translation loads immediately on next app open without an API call | **PASS** | `ChapterTranslationStore` SwiftData persistence covered by WI-6 / WI-7b unit tests (insert + canonical-key lookup round-trips through an in-memory `ModelContainer`); the production path uses the same store. The `ChapterTranslationPrefetcher` shipped in WI-10 reads the cache before touching `AIService`. |
+| d | Global "Translate entire book" shows confirmation with chapter count and can be cancelled | **PASS (UI) / GATED (timing)** | UI confirmation + cancellation flow covered by WI-14's `BookTranslationCoordinator` + `BookTranslationViewModel` unit tests (start / cancel / progress monotonic / cancel-mid-chapter). End-to-end timing against a real provider is the same gate as criterion (b). |
+| e | Per-chapter re-translate clears old cache and fetches fresh | **PASS** | WI-15 `ChapterReTranslateViewModelTests` (11 cases) covers: clear cache entry → `ChapterTranslationService.translateChapter` re-fired → new entry replaces old (timestamp + content). Provider override flow tested via mocked `ResolvedAIProviderConfig`. |
+| f | Provider override for re-translate does not change the global active provider | **PASS** | WI-15 explicit test (`ChapterReTranslateViewModelTests`) confirms `ProviderProfileStore.activeProfileID` is unchanged after a provider-override re-translate. The `ChapterReTranslateBoundaries.RetranslateProviderResolving` protocol intentionally takes the override as a parameter rather than mutating store state. |
+
+## Per-format slice coverage
+
+| Format | Interlinear/panel renderer | Host wiring | Setup sheet / pill | Status |
+|---|---|---|---|---|
+| TXT (chapter-paged) | WI-12a foundational + WI-12b live render | `TXTReaderContainerView+Bilingual` (WI-12a) | shared `BilingualSetupSheet`/`BilingualPill` (WI-9) | **PASS (unit + slice)** |
+| TXT (continuous-chaptered + chunked-large-file) | **deferred** by WI-12b | n/a yet | n/a yet | **partial — WI-12b documented limitation** |
+| MD (chapter-paged) | WI-12a + WI-12b | `MDReaderContainerView+Bilingual` | shared | **PASS (unit + slice)** |
+| MD (scroll mode) | **deferred** by WI-12b — same structural reason | n/a yet | n/a yet | **partial — WI-12b documented limitation** |
+| EPUB | WI-10 (`EPUBBilingualJS` + pipeline + orchestrator) | `EPUBReaderContainerView+Bilingual` | shared | **PASS (unit + slice)** |
+| AZW3 / MOBI | WI-11 (`FoliateBilingualJS` + pipeline + orchestrator + container view) | `FoliateBilingualContainerView` | shared | **PASS (unit + slice)** |
+| PDF | WI-13 (`PDFBilingualPanel` below-page) | `PDFReaderContainerView+Bilingual` | shared | **PASS (unit + slice)** |
+
+## Commands run
+
+The implementation arc is the authoritative evidence — every WI ran
+its own Gate 3 test gate + Gate 4 Codex audit + Gate 5a slice
+verification before merging. Per-WI evidence is in each PR's body
+and audit log:
+
+- PR #1030 / WI-8 — More-menu bilingual row + reTranslateChapter row
+- PR #1031 / WI-9 — `BilingualSetupSheet` + `BilingualPill`
+- PR #1034 / WI-10 — EPUB interlinear
+- PR #1035 / WI-11 — AZW3/MOBI Foliate interlinear
+- PR #1036 / WI-12a — TXT/MD host wiring foundational
+- PR #1038 / WI-12b — TXT/MD live render + offset routing
+- PR #1041 / WI-13 — PDF below-page bilingual panel
+- PR #1040 / WI-14 — global "Translate entire book"
+- PR #1042 / WI-15 — per-chapter re-translation
+
+Codex audits (Gate 4) for every WI clean — `ship-as-is` final verdict
+in every case. Full unit suite green at the v3.38.0 tip (6805 tests).
+
+```bash
+# Full unit suite at v3.38.0 (run by WI-15 agent, captured in PR #1042 body):
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
+  -project vreader.xcodeproj -scheme vreader \
+  -destination 'platform=iOS Simulator,id=61149F0E-DC18-4BE2-BB37-52659F1F4F62' \
+  -only-testing:vreaderTests
+# → 6805 tests, 0 failures (TEST SUCCEEDED)
+```
+
+## Observations
+
+- The 16-WI arc was implemented across roughly 9 hours wall clock by
+  10 successive worktree agents (WI-2.5 through WI-15), with
+  WI-13/WI-14 and WI-11/WI-12 running as disjoint-write-set parallel
+  pairs (rule 48 in action).
+- One mid-flight contamination incident (v3.37.18 → v3.37.19 hotfix
+  PR #1029) was traced to an earlier agent's cwd-drift writing WI-8
+  WIP files into the main checkout; subsequent agents adopted a
+  "`cd "$WORKTREE_PATH"` first" discipline that caught and prevented
+  the recurrence (the bugfix #957 agent self-corrected mid-flow).
+- Two follow-up scope gaps documented for later work:
+  1. TXT continuous-chaptered + chunked-large-file bilingual render
+     (WI-12b deferral — structurally separate composition).
+  2. MD scroll-mode bilingual render (same WI-12b deferral).
+  3. Top-level heading-paragraph over-translation alignment (WI-10's
+     known limitation).
+  4. ChapterReTranslateSwipeAction in `TOCListView` (WI-15 scope-note —
+     requires a `List` host; current `LazyVStack`-in-`ScrollView` does
+     not support `.swipeActions`; queued as follow-up `needs-design`
+     for the swipe affordance).
+
+## Artifacts
+
+Per-WI verification artifacts shipped under
+`dev-docs/verification/artifacts/feature-56-*` and inside each WI's
+PR body / audit log. Notable:
+
+- WI-9 Gate 5a: `feature-56/wi9-slice-reader-chrome-no-pill-20260520.png`
+- WI-11 Gate 5a: `feature-56-wi11-azw3-opened-20260520.png`
+- Each WI's PR body documents the slice verification observation.
+
+## Why `result: partial` and not `pass`
+
+Criterion (b) — "current chapter translation renders inline within 10
+seconds for a typical chapter" — is a real-provider end-to-end
+acceptance that cannot be exercised CU-free in this environment:
+
+- The `--enable-ai` launch arg now reaches the AI subsystem (Bug
+  #237's fix shipped earlier this session, v3.37.23).
+- But the XCUITest session starts with an empty
+  `ProviderProfileStore` — no API key is configured.
+- Configuring a real provider key would publish secrets to the
+  test environment (against `user_privacy` rules) and require
+  external infrastructure not available to autonomous cron sessions.
+
+This is the same class of gate the verify cron documented for
+Feature #26 ("VERIFIED gated solely on a live-HTTP-TTS-server
+integration test, standing external-infrastructure follow-up").
+
+**Recommended path to `VERIFIED`**: a user-driven verification round
+with a real provider profile configured (or a CI integration test
+against a fixture provider that returns canned translations against
+the same code path), exercising criteria (b) and (d) end-to-end. The
+unit + slice + integration coverage already in place is strong; the
+remaining gap is the integration with a real provider, not any code.
+
+Row status stays `DONE` per the binding rule 47 Gate 5 ("All criteria
+pass → flip the row to `VERIFIED`; some criteria un-verifiable
+CU-free → `result: partial` in the evidence file, document the
+deferred slices in the row's Notes, leave the row at `DONE`").

--- a/project.yml
+++ b/project.yml
@@ -134,7 +134,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
         CURRENT_PROJECT_VERSION: 577
-        MARKETING_VERSION: 3.38.0
+        MARKETING_VERSION: 3.38.1
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6108,7 +6108,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.38.0;
+				MARKETING_VERSION = 3.38.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6258,7 +6258,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.38.0;
+				MARKETING_VERSION = 3.38.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

Records feature #56's (bilingual reading mode) post-WI-15 state as a Gate-5b checkpoint. Row stays at `DONE` per rule 47 Gate 5's `result: partial` path — VERIFIED flip is gated on a real AI provider for criterion (b)'s end-to-end timing leg, which cannot be exercised CU-free in this autonomous harness.

Part of feature #56.

## What Changed

- New `dev-docs/verification/feature-56-20260520.md` — round-1 post-implementation checkpoint documenting which acceptance criteria are PASS at unit/integration level and which are GATED on external infrastructure.
- Patch version bump `v3.38.0` → `v3.38.1` (rule 40).

## Validation

Docs-only change. No code touched. The `vreader.xcodeproj/project.pbxproj` diff is purely from the `xcodegen generate` re-enumeration that came with the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)