### PR TITLE
docs: sync claude.ai/design AI Toggles handoff — resolves #1068

### DIFF
--- a/.claude/codex-audits/docs-ai-toggles-handoff-audit.md
+++ b/.claude/codex-audits/docs-ai-toggles-handoff-audit.md
@@ -1,0 +1,72 @@
+---
+branch: docs/ai-toggles-handoff
+threadId: manual-fallback
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-20
+---
+
+## Scope
+
+Syncs the claude.ai/design "VReader AI Toggles Canvas" handoff
+(chat9) into the `dev-docs/designs/vreader-fidelity-v1/` bundle.
+Touches the design bundle, plus `project.yml` / `project.pbxproj`
+(version bump 3.38.18/593 → 3.38.19/594).
+
+**No Swift source files changed.** The audit-gate hook fires on
+`project.pbxproj` — false positive of the Swift-file heuristic.
+Manual mini-audit.
+
+## Manual audit evidence
+
+### What changed and why
+
+Bundle sync (rsync, superset — nothing deleted): 4 new files —
+`VReader AI Toggles Canvas.html`, `ai-toggles-artboards.jsx`,
+`vreader-ai-toggles.jsx`, `chats/chat9.md`; `README.md` updated
+(chat count 8 → 9).
+
+The handoff delivers the committed design for `needs-design` issue
+**#1068** — two undesigned toggle rows in `SettingsView`'s AI
+section for feature **#67** (Settings re-skin). The two rows are
+the AI-master toggle ("Enable AI Assistant") and the
+Data-&-Privacy-consent toggle, both peers of the AI Provider row
+already shipped in feature #67 WI-5 (PR #1069).
+
+Canonical: variant A (tile-parity) — both render as
+`SettingsToggleRow` inside the AI group; master reuses the shipped
+AI Provider palette (`#8c2f2f` sparkle); consent adds a new tile
+color (`#4a6a8a`) with a `shield.checkmark` glyph. When AI is off,
+peer rows are *hidden* (height collapse) — not disabled / greyed.
+Variants B (master-as-section-header) and C (privacy callout card)
+are alternatives.
+
+### Correctness checks
+
+1. **#1068 is a real, open `needs-design` issue** — verified via
+   `gh issue view 1068`: OPEN, labels `enhancement` +
+   `needs-design`, title "Design needed: AI Assistant + Data &
+   Privacy toggle rows in SettingsView for feature #67".
+2. **Issue → feature linkage** — #1068's body names feature #67
+   (Settings re-skin). Feature #67's row in `docs/features.md`
+   carries no row-level `BLOCKED: needs-design (#1068)` annotation
+   (the toggle rows are a sub-affordance gap, not a row-level
+   block); no `docs/features.md` row is flipped here.
+3. **Issue closure** — PR uses `Resolves #1068` so the
+   `needs-design` issue auto-closes on merge (same precedent as
+   PRs #1037 / #1039 / #1060 / #972 / #956 / #930 / #869 / #848).
+4. **No Swift implemented** — design-delivery only. Building the
+   two toggle rows is gated feature-#67 feature-workflow work;
+   deliberately not in this PR.
+5. **Bundle-diff sanity** — `diff -rq` against the incoming
+   handoff matched exactly the 4 expected files (README + chat9 +
+   1 HTML + 2 JSX). No silent overwrites of existing canvases.
+6. **Version bump** — 3.38.19 / build 594 (patch — docs /
+   design-bundle sync). `xcodegen generate` confirmed both
+   `project.yml` and `project.pbxproj`. `xcodebuild build`
+   SUCCEEDED on iPhone 17 Pro Simulator (Debug).
+
+## Verdict
+
+ship-as-is — design-bundle sync + version bump. No Swift logic.
+Manual fallback used because there is nothing to send to Codex.

--- a/dev-docs/designs/vreader-fidelity-v1/README.md
+++ b/dev-docs/designs/vreader-fidelity-v1/README.md
@@ -6,7 +6,7 @@ A user mocked up designs in HTML/CSS/JS using an AI design tool, then exported t
 
 ## What you should do — IMPORTANT
 
-**Read the chat transcripts first.** There are 8 chat transcript(s) in `vreader-fidelity/chats/`. The transcripts show the full back-and-forth between the user and the design assistant — they tell you **what the user actually wants** and **where they landed** after iterating. Don't skip them. The final HTML files are the output, but the chat is where the intent lives.
+**Read the chat transcripts first.** There are 9 chat transcript(s) in `vreader-fidelity/chats/`. The transcripts show the full back-and-forth between the user and the design assistant — they tell you **what the user actually wants** and **where they landed** after iterating. Don't skip them. The final HTML files are the output, but the chat is where the intent lives.
 
 **Find the primary design file under `vreader-fidelity/project/` and read it top to bottom.** The chat transcripts will tell you which file the user was last iterating on. Then **follow its imports**: open every file it pulls in (shared components, CSS, scripts) so you understand how the pieces fit together before you start implementing.
 

--- a/dev-docs/designs/vreader-fidelity-v1/chats/chat9.md
+++ b/dev-docs/designs/vreader-fidelity-v1/chats/chat9.md
@@ -1,0 +1,93 @@
+# I don't have access to external links or the ability to browse GitHub. Could you share the content of the issue or describe what design topic you're working on
+
+_Started 2026-05-20 14:09 UTC_
+
+---
+
+## User
+
+https://github.com/lllyys/vreader/issues/1068
+
+## Assistant
+
+_[tool: list_files]_
+
+_[tool: web_fetch]_
+
+_[tool: read_file]_
+
+_[tool: read_file]_
+
+_[tool: grep]_
+
+_[tool: read_file]_
+
+_[tool: read_file]_
+
+_[tool: grep]_
+
+_[tool: grep]_
+
+_[tool: grep]_
+
+_[tool: read_file]_
+
+_[tool: grep]_
+
+_[tool: read_file]_
+
+_[tool: grep]_
+
+_[tool: grep]_
+
+_[tool: update_todos]_
+
+I have enough context. Here's my read on this:
+
+**The ask:** Two undesigned toggle rows in `SettingsView`'s AI section. Need to fit the existing colored-icon `SettingsRow` vocabulary (AI Provider already shipped at `#8c2f2f` sparkle) but reframe a toggle as the trailing affordance and make clear which is the section gate vs. which is a peer.
+
+**My system, declared up front:**
+- Match the existing `SettingsRow` tile (30×30 rounded tile, colored bg, white SF-symbol-ish glyph, 15px title, 11px detail)
+- Swap trailing `value + chevron` → existing `PillSwitch` (`#3a6a5a` on, neutral off)
+- Add `detail` subline on both rows — the master answers "what does this turn on?", the consent answers "what leaves the device?"
+- Master toggle = same `#8c2f2f` sparkle as AI Provider (it's the master switch for that color-coded group). Consent = a shield in `#4a6a8a` (slots cleanly between the existing blue `#3a8ac8` Cloud and the grey `#5a5a5a` Help icons)
+- When AI is off, peer rows (AI Provider + consent) disappear with a smooth height collapse — not greyed out, hidden, per the issue's spec
+
+**Three variants explored:**
+- **A · Tile-parity (canonical)** — both toggles look like SettingsRow + PillSwitch. Most consistent.
+- **B · Master-as-section-header** — promote AI Assistant out of the row group, into the section label. Sharper gate-vs-content hierarchy.
+- **C · Privacy-callout consent** — when on, consent row expands into a card with explicit "leaves device / stays local" two-column body. Heavier disclosure suited for the consent moment.
+
+_[tool: write_file]_
+
+_[tool: str_replace_edit]_
+
+Now the artboards file:
+
+_[tool: write_file]_
+
+_[tool: write_file]_
+
+_[tool: done]_
+
+_[tool: fork_verifier_agent]_
+
+Designed the two needs-design rows for #1068 as a canvas with three variants × four states each.
+
+**File:** `VReader AI Toggles Canvas.html`
+
+**The system** (declared up-front so it stays honest with WI-5):
+- 30×30 colored tile · white 17px glyph · 15px title · 11px detail subline · trailing `PillSwitch` (the same one used in `MiniRow` / `ReTranslate`)
+- Master toggle reuses the shipped AI Provider palette (`#8c2f2f` sparkle) — flipping it off communicates "the whole AI group goes dark"
+- Consent toggle adds one new tile color, `#4a6a8a`, slotted into the existing cool-blue family next to Cloud `#3a8ac8` and Folder `#7c6ad6`, plus a Shield SF-symbol-equivalent
+- Per the issue, peer rows are *hidden* when AI is off — not disabled / greyed
+
+**Three variants:**
+- **A · Tile-parity (canonical, recommended)** — both toggles render as `SettingsToggleRow`s inside the AI group, peers of the AI Provider row
+- **B · Master-as-section-header** — promote "Enable AI Assistant" into the section label as an inline switch; off-state shows a one-line caption
+- **C · Privacy-callout consent** — when AI is on, the consent toggle moves into a dedicated "Data & Privacy" card with a two-column "Sent to provider / Stays on device" body — heavier disclosure for the consent moment
+
+Each variant has artboards for AI off / on+consent off / on+consent on / dark, plus a row-specimen section showing the bare rows up close in paper and dark.
+
+Implementation surface is small — one new `SettingsToggleRow` view + a `shield.checkmark` SF symbol — and stays inside rule 51's anti-pattern table by reusing the shipped `SettingsRowPalette` rather than inventing new colored variants.
+

--- a/dev-docs/designs/vreader-fidelity-v1/project/VReader AI Toggles Canvas.html
+++ b/dev-docs/designs/vreader-fidelity-v1/project/VReader AI Toggles Canvas.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>VReader — #1068 AI toggle rows (canvas)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,300..900;1,8..60,300..900&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0; padding: 0; background: #f0eee9;
+    font-family: 'Inter', -apple-system, system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  .hide-scroll::-webkit-scrollbar { display: none; }
+  .hide-scroll { scrollbar-width: none; -ms-overflow-style: none; }
+  button { font-family: inherit; }
+  button:focus { outline: none; }
+  @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes popIn {
+    from { transform: translateY(8px) scale(0.96); opacity: 0; }
+    to   { transform: translateY(0) scale(1); opacity: 1; }
+  }
+  @keyframes slideUp {
+    from { transform: translateY(100%); }
+    to   { transform: translateY(0); }
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+</style>
+<template id="__bundler_thumbnail">
+  <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <rect width="200" height="200" fill="#1a1815"/>
+    <rect x="30" y="58" width="140" height="34" rx="8" fill="#fcf8f0"/>
+    <rect x="40" y="68" width="14" height="14" rx="4" fill="#8c2f2f"/>
+    <rect x="140" y="69" width="22" height="12" rx="6" fill="#3a6a5a"/>
+    <rect x="30" y="108" width="140" height="34" rx="8" fill="#fcf8f0"/>
+    <rect x="40" y="118" width="14" height="14" rx="4" fill="#4a6a8a"/>
+    <rect x="140" y="119" width="22" height="12" rx="6" fill="rgba(0,0,0,0.18)"/>
+    <text x="100" y="170" font-family="Inter, sans-serif" font-size="11" font-weight="600" fill="#d8d2c5" text-anchor="middle" letter-spacing="2">#1068</text>
+  </svg>
+</template>
+</head>
+<body>
+
+<div id="root"></div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<!-- Canvas + theme/icon/panels base -->
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="vreader-themes.jsx"></script>
+<script type="text/babel" src="vreader-icons.jsx"></script>
+<script type="text/babel" src="vreader-panels.jsx"></script>
+<!-- PillSwitch lives in vreader-retranslate.jsx -->
+<script type="text/babel" src="vreader-retranslate.jsx"></script>
+
+<!-- This issue's design -->
+<script type="text/babel" src="vreader-ai-toggles.jsx"></script>
+<script type="text/babel" src="ai-toggles-artboards.jsx"></script>
+
+<script type="text/babel">
+  const root = ReactDOM.createRoot(document.getElementById('root'));
+  root.render(<CanvasRoot/>);
+</script>
+</body>
+</html>

--- a/dev-docs/designs/vreader-fidelity-v1/project/ai-toggles-artboards.jsx
+++ b/dev-docs/designs/vreader-fidelity-v1/project/ai-toggles-artboards.jsx
@@ -1,0 +1,229 @@
+// Canvas artboards for issue #1068 — AI Assistant + Data & Privacy toggle rows.
+//
+// Shows the AI section in the SettingsSheet with three variant treatments
+// across the states the design must cover (per the issue):
+//   • AI off (default — only master toggle visible)
+//   • AI on + consent off
+//   • AI on + consent on
+//   • dark theme
+
+const PHONE_W = 402;
+const I_BOOK_PLACEHOLDER = { title: 'Pride and Prejudice', author: 'Jane Austen' };
+
+function PhoneFrame({ themeKey = 'paper', children, height = 720 }) {
+  const t = THEMES[themeKey];
+  return (
+    <div style={{
+      width: PHONE_W, height, position: 'relative', overflow: 'hidden',
+      background: t.bg, borderRadius: 18,
+      boxShadow: '0 0 0 1px rgba(255,255,255,0.04), 0 14px 40px rgba(0,0,0,0.35)',
+    }}>
+      {children}
+    </div>
+  );
+}
+
+// Renders the SettingsSheet in context, with one of the three AI-section
+// variants slotted in. The surrounding sections (profile card, Cloud & Sync)
+// are included as a reduced-fidelity wrapper so the AI section reads in its
+// real visual neighborhood — same idea as the #862 SettingsHeaderArtboard.
+function SettingsAIArtboard({ themeKey, variant, aiOn, consentOn }) {
+  const t = THEMES[themeKey];
+  const Variant = variant === 'A' ? AISectionVariantA
+                : variant === 'B' ? AISectionVariantB
+                : AISectionVariantC;
+  return (
+    <PhoneFrame themeKey={themeKey}>
+      <div style={{ position: 'absolute', inset: 0, background: t.bg }}/>
+      <Sheet theme={t} onClose={() => {}} height={720} title="Settings">
+        <div style={{ padding: '16px 18px 32px' }}>
+          {/* Reduced-fidelity profile card — anchors the AI section */}
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: 12,
+            padding: 14, borderRadius: 14, marginBottom: 18,
+            background: t.isDark ? 'rgba(255,255,255,0.04)' : '#fff',
+          }}>
+            <div style={{
+              width: 48, height: 48, borderRadius: 24,
+              background: `linear-gradient(135deg, ${t.accent}, #5a3a3a)`,
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              color: '#fff', fontFamily: '"Source Serif 4", Georgia, serif',
+              fontSize: 20, fontWeight: 600,
+            }}>L</div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 16, fontWeight: 600, color: t.ink }}>lllyys</div>
+              <div style={{ fontSize: 12, color: t.sub, marginTop: 1 }}>
+                152 books · 41h read this month
+              </div>
+            </div>
+          </div>
+
+          {/* Cloud & Sync — to show the AI section in its actual neighbor context */}
+          <div style={{ marginBottom: 18 }}>
+            <SectionLabel theme={t}>Cloud &amp; Sync</SectionLabel>
+            <div style={{
+              marginTop: 8, borderRadius: 14, overflow: 'hidden',
+              background: t.isDark ? 'rgba(255,255,255,0.04)' : '#fff',
+              boxShadow: t.isDark ? 'none' : '0 1px 0 rgba(0,0,0,0.04)',
+            }}>
+              <SettingsRow theme={t}
+                icon={<Icons.Cloud size={17} color="#fff" stroke={1.8}/>}
+                color="#3a8ac8" title="WebDAV backup"
+                detail="Nutstore · last sync 2h ago" value="On"/>
+              <SettingsRow theme={t}
+                icon={<Icons.Folder size={17} color="#fff" stroke={1.8}/>}
+                color="#7c6ad6" title="OPDS catalogs" value="3" last/>
+            </div>
+          </div>
+
+          {/* THE section under design */}
+          <Variant theme={t} aiOn={aiOn} consentOn={consentOn}/>
+        </div>
+      </Sheet>
+    </PhoneFrame>
+  );
+}
+
+// Bare-rows artboard — surfaces the individual SettingsToggleRow up close so
+// the row treatment can be evaluated on its own, free of sheet/chrome.
+function ToggleRowSpecArtboard({ themeKey }) {
+  const t = THEMES[themeKey];
+  return (
+    <div style={{
+      width: PHONE_W, padding: 24, background: t.bg,
+      borderRadius: 18, position: 'relative',
+      boxShadow: '0 0 0 1px rgba(255,255,255,0.04), 0 14px 40px rgba(0,0,0,0.35)',
+    }}>
+      <SectionLabel theme={t}>AI · master toggle</SectionLabel>
+      <div style={{
+        marginTop: 8, marginBottom: 22, borderRadius: 14, overflow: 'hidden',
+        background: t.isDark ? 'rgba(255,255,255,0.04)' : '#fff',
+        boxShadow: t.isDark ? 'none' : '0 1px 0 rgba(0,0,0,0.04)',
+      }}>
+        <SettingsToggleRow theme={t}
+          icon={<Icons.Sparkle size={17} color="#fff" stroke={1.8}/>}
+          color="#8c2f2f"
+          title="Enable AI Assistant"
+          detail="Translation, summarize, ask about the text"
+          on={false} last/>
+      </div>
+
+      <SectionLabel theme={t}>AI · master toggle, on</SectionLabel>
+      <div style={{
+        marginTop: 8, marginBottom: 22, borderRadius: 14, overflow: 'hidden',
+        background: t.isDark ? 'rgba(255,255,255,0.04)' : '#fff',
+        boxShadow: t.isDark ? 'none' : '0 1px 0 rgba(0,0,0,0.04)',
+      }}>
+        <SettingsToggleRow theme={t}
+          icon={<Icons.Sparkle size={17} color="#fff" stroke={1.8}/>}
+          color="#8c2f2f"
+          title="Enable AI Assistant"
+          detail="Translation, summarize, ask about the text"
+          on={true} last/>
+      </div>
+
+      <SectionLabel theme={t}>Consent toggle</SectionLabel>
+      <div style={{
+        marginTop: 8, borderRadius: 14, overflow: 'hidden',
+        background: t.isDark ? 'rgba(255,255,255,0.04)' : '#fff',
+        boxShadow: t.isDark ? 'none' : '0 1px 0 rgba(0,0,0,0.04)',
+      }}>
+        <SettingsToggleRow theme={t}
+          icon={<ShieldIcon size={17} color="#fff" stroke={1.8}/>}
+          color="#4a6a8a"
+          title="Allow AI data sharing"
+          detail="Send passages and chat history for better answers"
+          on={false}/>
+        <SettingsToggleRow theme={t}
+          icon={<ShieldIcon size={17} color="#fff" stroke={1.8}/>}
+          color="#4a6a8a"
+          title="Allow AI data sharing"
+          detail="Send passages and chat history for better answers"
+          on={true} last/>
+      </div>
+    </div>
+  );
+}
+
+// ════════════════════════════════════════════════════
+// CanvasRoot
+// ════════════════════════════════════════════════════
+function CanvasRoot() {
+  return (
+    <DesignCanvas>
+      {/* ───── Specimen — the bare row treatment ───── */}
+      <DCSection id="spec" title="#1068 — Row specimen"
+        subtitle="The two new row types in isolation: colored tile + PillSwitch trail. Same vocabulary as the AI Provider row WI-5 shipped (#8c2f2f sparkle), extended with a shield tile (#4a6a8a) for the privacy switch.">
+        <DCArtboard id="spec-paper" label="Specimen · paper" width={PHONE_W} height={560}>
+          <ToggleRowSpecArtboard themeKey="paper"/>
+        </DCArtboard>
+        <DCArtboard id="spec-dark" label="Specimen · dark" width={PHONE_W} height={560}>
+          <ToggleRowSpecArtboard themeKey="dark"/>
+        </DCArtboard>
+        <DCPostIt top={-30} right={40} rotate={2} width={240}>
+          <strong>Why a shield tile in this color?</strong><br/>
+          #4a6a8a lives next to the existing Cloud (#3a8ac8) and Folder (#7c6ad6) in the cool-blue family — reads as "system / safety" the same way #8c2f2f reads as "AI / energy".
+        </DCPostIt>
+      </DCSection>
+
+      {/* ───── Variant A — canonical ───── */}
+      <DCSection id="vA" title="A · Tile-parity (canonical)"
+        subtitle="Both toggles live as SettingsToggleRows inside the existing AI group, peers of the AI Provider row. Simplest fit for the surrounding vocabulary. When AI is off the peer rows are hidden, not greyed.">
+        <DCArtboard id="A-off" label="AI off (default)" width={PHONE_W} height={720}>
+          <SettingsAIArtboard themeKey="paper" variant="A" aiOn={false} consentOn={false}/>
+        </DCArtboard>
+        <DCArtboard id="A-on-cons-off" label="AI on · consent off" width={PHONE_W} height={720}>
+          <SettingsAIArtboard themeKey="paper" variant="A" aiOn={true} consentOn={false}/>
+        </DCArtboard>
+        <DCArtboard id="A-on-cons-on" label="AI on · consent on" width={PHONE_W} height={720}>
+          <SettingsAIArtboard themeKey="paper" variant="A" aiOn={true} consentOn={true}/>
+        </DCArtboard>
+        <DCArtboard id="A-dark" label="Dark · AI on · consent on" width={PHONE_W} height={720}>
+          <SettingsAIArtboard themeKey="dark" variant="A" aiOn={true} consentOn={true}/>
+        </DCArtboard>
+      </DCSection>
+
+      {/* ───── Variant B — master in header ───── */}
+      <DCSection id="vB" title="B · Master-as-section-header"
+        subtitle="“Enable AI Assistant” gets promoted into the section label as an inline switch. The gate isn’t a peer of what it gates — strongest hierarchy. Off state shows a one-line caption instead of empty space.">
+        <DCArtboard id="B-off" label="AI off" width={PHONE_W} height={720}>
+          <SettingsAIArtboard themeKey="paper" variant="B" aiOn={false} consentOn={false}/>
+        </DCArtboard>
+        <DCArtboard id="B-on-cons-off" label="AI on · consent off" width={PHONE_W} height={720}>
+          <SettingsAIArtboard themeKey="paper" variant="B" aiOn={true} consentOn={false}/>
+        </DCArtboard>
+        <DCArtboard id="B-on-cons-on" label="AI on · consent on" width={PHONE_W} height={720}>
+          <SettingsAIArtboard themeKey="paper" variant="B" aiOn={true} consentOn={true}/>
+        </DCArtboard>
+        <DCArtboard id="B-dark" label="Dark · AI on · consent on" width={PHONE_W} height={720}>
+          <SettingsAIArtboard themeKey="dark" variant="B" aiOn={true} consentOn={true}/>
+        </DCArtboard>
+        <DCPostIt top={-30} right={40} rotate={-2} width={240}>
+          <strong>Trade-off:</strong> visually distinguishes the gate, but breaks the "every section header is just a label" rule used everywhere else in Settings. Adopt only if we'd also section-gate Cloud & Sync.
+        </DCPostIt>
+      </DCSection>
+
+      {/* ───── Variant C — privacy callout ───── */}
+      <DCSection id="vC" title="C · Privacy-callout consent"
+        subtitle="When AI is on, the consent toggle moves out of the AI group into its own Data & Privacy section, presented as a card with an explicit two-column body that names what leaves the device and what stays local. Heavier disclosure for the consent moment.">
+        <DCArtboard id="C-off" label="AI off" width={PHONE_W} height={720}>
+          <SettingsAIArtboard themeKey="paper" variant="C" aiOn={false} consentOn={false}/>
+        </DCArtboard>
+        <DCArtboard id="C-on-cons-off" label="AI on · consent off" width={PHONE_W} height={720}>
+          <SettingsAIArtboard themeKey="paper" variant="C" aiOn={true} consentOn={false}/>
+        </DCArtboard>
+        <DCArtboard id="C-on-cons-on" label="AI on · consent on" width={PHONE_W} height={720}>
+          <SettingsAIArtboard themeKey="paper" variant="C" aiOn={true} consentOn={true}/>
+        </DCArtboard>
+        <DCArtboard id="C-dark" label="Dark · AI on · consent on" width={PHONE_W} height={720}>
+          <SettingsAIArtboard themeKey="dark" variant="C" aiOn={true} consentOn={true}/>
+        </DCArtboard>
+        <DCPostIt top={-30} right={40} rotate={2} width={240}>
+          <strong>Recommendation:</strong> ship A — peer-parity with the row WI-5 shipped, lowest implementation cost (just one new SettingsToggleRow variant + a Shield SF symbol). Hold C in reserve if the consent discussion in #67 surfaces stronger transparency requirements.
+        </DCPostIt>
+      </DCSection>
+    </DesignCanvas>
+  );
+}
+
+Object.assign(window, { CanvasRoot });

--- a/dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-toggles.jsx
+++ b/dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-toggles.jsx
@@ -1,0 +1,272 @@
+// Issue #1068 — Two SettingsView AI-section toggle rows that need a designed
+// treatment to match the colored-icon SettingsRow vocabulary shipped in WI-5
+// of feature #67.
+//
+// Rows in scope:
+//   • AI Assistant       (master gate — always visible)
+//   • Allow AI data sharing  (consent — only visible when AI Assistant is on)
+//
+// Shared vocabulary (matches existing SettingsRow):
+//   30×30 rounded tile · colored bg · white 17px Icons glyph · 15px title ·
+//   11px detail subline · trailing PillSwitch instead of value+chevron.
+
+// ────────────────────────────────────────────────────
+// Shield icon (privacy) — adds to existing Icons set
+// Same chroma/stroke vocabulary as the other line icons.
+// ────────────────────────────────────────────────────
+const ShieldIcon = ({ size = 17, color = '#fff', stroke = 1.8 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none"
+       stroke={color} strokeWidth={stroke} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 3l8 3v6c0 4.5-3.4 8.4-8 9-4.6-.6-8-4.5-8-9V6z"/>
+    <path d="M9 12l2 2 4-4"/>
+  </svg>
+);
+
+// ────────────────────────────────────────────────────
+// SettingsRow — colored-tile nav row (already shipped in WI-5 as
+// SettingsIconRow / SettingsRowPalette.aiProvider). Reproduced here for the
+// artboards; production uses the canonical SwiftUI version.
+// ────────────────────────────────────────────────────
+function SettingsRow({ theme: t, icon, color, title, detail, value, last }) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 12,
+      padding: '12px 14px', borderBottom: last ? 'none' : `0.5px solid ${t.rule}`,
+    }}>
+      <div style={{
+        width: 30, height: 30, borderRadius: 8, flexShrink: 0,
+        background: color, display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}>{icon}</div>
+      <div style={{ flex: 1 }}>
+        <div style={{ fontSize: 15, color: t.ink }}>{title}</div>
+        {detail && <div style={{ fontSize: 11, color: t.sub, marginTop: 1 }}>{detail}</div>}
+      </div>
+      {value && <div style={{ fontSize: 14, color: t.sub, marginRight: 4 }}>{value}</div>}
+      <Icons.Chevron size={13} color={t.sub} stroke={2}/>
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────────
+// SettingsToggleRow — colored-tile peer of SettingsRow with PillSwitch trail
+// ────────────────────────────────────────────────────
+function SettingsToggleRow({ theme: t, icon, color, title, detail, on, last, dimmed = false }) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 12,
+      padding: '12px 14px',
+      borderBottom: last ? 'none' : `0.5px solid ${t.rule}`,
+      opacity: dimmed ? 0.55 : 1,
+      transition: 'opacity 0.2s',
+    }}>
+      <div style={{
+        width: 30, height: 30, borderRadius: 8, flexShrink: 0,
+        background: color, display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}>{icon}</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 15, color: t.ink }}>{title}</div>
+        {detail && (
+          <div style={{
+            fontSize: 11, color: t.sub, marginTop: 2,
+            lineHeight: 1.35,
+          }}>{detail}</div>
+        )}
+      </div>
+      <PillSwitch on={!!on} theme={t}/>
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────────
+// VARIANT A — Tile-parity (canonical)
+// Both toggles render as SettingsToggleRows inside the same `AI` group as the
+// AI Provider row. When AI is off, AI Provider + consent are hidden.
+// ────────────────────────────────────────────────────
+function AISectionVariantA({ theme: t, aiOn, consentOn }) {
+  return (
+    <div>
+      <SectionLabel theme={t}>AI</SectionLabel>
+      <div style={{
+        marginTop: 8, borderRadius: 14, overflow: 'hidden',
+        background: t.isDark ? 'rgba(255,255,255,0.04)' : '#fff',
+        boxShadow: t.isDark ? 'none' : '0 1px 0 rgba(0,0,0,0.04)',
+      }}>
+        <SettingsToggleRow theme={t}
+          icon={<Icons.Sparkle size={17} color="#fff" stroke={1.8}/>}
+          color="#8c2f2f"
+          title="Enable AI Assistant"
+          detail="Translation, summarize, ask about the text"
+          on={aiOn}
+          last={!aiOn}/>
+        {aiOn && (
+          <React.Fragment>
+            <SettingsRow theme={t}
+              icon={<Icons.Sparkle size={17} color="#fff" stroke={1.8}/>}
+              color="#8c2f2f"
+              title="AI provider"
+              value="Claude"/>
+            <SettingsToggleRow theme={t}
+              icon={<ShieldIcon size={17} color="#fff" stroke={1.8}/>}
+              color="#4a6a8a"
+              title="Allow AI data sharing"
+              detail="Send passages and chat history for better answers"
+              on={consentOn}
+              last/>
+          </React.Fragment>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────────
+// VARIANT B — Master-as-section-header
+// "Enable AI Assistant" promoted out of the row group into the section label,
+// inline with a PillSwitch. The label *is* the master switch. Clearer
+// hierarchy: the gate isn't a peer of what it gates.
+// ────────────────────────────────────────────────────
+function AISectionVariantB({ theme: t, aiOn, consentOn }) {
+  return (
+    <div>
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        padding: '0 14px 0 4px',
+      }}>
+        <div style={{
+          fontSize: 11, fontWeight: 600, letterSpacing: 0.5,
+          textTransform: 'uppercase', color: t.sub,
+        }}>AI Assistant</div>
+        <PillSwitch on={aiOn} theme={t}/>
+      </div>
+      {aiOn ? (
+        <div style={{
+          marginTop: 8, borderRadius: 14, overflow: 'hidden',
+          background: t.isDark ? 'rgba(255,255,255,0.04)' : '#fff',
+          boxShadow: t.isDark ? 'none' : '0 1px 0 rgba(0,0,0,0.04)',
+        }}>
+          <SettingsRow theme={t}
+            icon={<Icons.Sparkle size={17} color="#fff" stroke={1.8}/>}
+            color="#8c2f2f"
+            title="AI provider"
+            value="Claude"/>
+          <SettingsToggleRow theme={t}
+            icon={<ShieldIcon size={17} color="#fff" stroke={1.8}/>}
+            color="#4a6a8a"
+            title="Allow AI data sharing"
+            detail="Send passages and chat history for better answers"
+            on={consentOn}
+            last/>
+        </div>
+      ) : (
+        <div style={{
+          marginTop: 8, padding: '14px 16px', borderRadius: 14,
+          background: t.isDark ? 'rgba(255,255,255,0.025)' : 'rgba(0,0,0,0.025)',
+          fontSize: 12.5, lineHeight: 1.45, color: t.sub,
+        }}>
+          AI features stay off across the whole app — no provider calls, no consent prompt, nothing to configure.
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ────────────────────────────────────────────────────
+// VARIANT C — Privacy-callout consent
+// Same canonical "AI Assistant" toggle row as A. When AI is on, the consent
+// row is replaced by a card with the toggle pinned top-right and a small
+// two-column body that names exactly what leaves vs. what stays local. Heavier
+// disclosure suited for a consent moment, lighter chrome the rest of the time.
+// ────────────────────────────────────────────────────
+function AISectionVariantC({ theme: t, aiOn, consentOn }) {
+  return (
+    <div>
+      <SectionLabel theme={t}>AI</SectionLabel>
+      <div style={{
+        marginTop: 8, borderRadius: 14, overflow: 'hidden',
+        background: t.isDark ? 'rgba(255,255,255,0.04)' : '#fff',
+        boxShadow: t.isDark ? 'none' : '0 1px 0 rgba(0,0,0,0.04)',
+      }}>
+        <SettingsToggleRow theme={t}
+          icon={<Icons.Sparkle size={17} color="#fff" stroke={1.8}/>}
+          color="#8c2f2f"
+          title="Enable AI Assistant"
+          detail="Translation, summarize, ask about the text"
+          on={aiOn}
+          last={!aiOn}/>
+        {aiOn && (
+          <SettingsRow theme={t}
+            icon={<Icons.Sparkle size={17} color="#fff" stroke={1.8}/>}
+            color="#8c2f2f"
+            title="AI provider"
+            value="Claude"
+            last/>
+        )}
+      </div>
+
+      {aiOn && (
+        <div style={{ marginTop: 14 }}>
+          <SectionLabel theme={t}>Data &amp; Privacy</SectionLabel>
+          <div style={{
+            marginTop: 8, padding: '14px 16px 16px', borderRadius: 14,
+            background: t.isDark ? 'rgba(255,255,255,0.04)' : '#fff',
+            boxShadow: t.isDark ? 'none' : '0 1px 0 rgba(0,0,0,0.04)',
+          }}>
+            <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
+              <div style={{
+                width: 30, height: 30, borderRadius: 8, flexShrink: 0, marginTop: 1,
+                background: '#4a6a8a',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+              }}>
+                <ShieldIcon size={17} color="#fff" stroke={1.8}/>
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 15, color: t.ink }}>Allow AI data sharing</div>
+                <div style={{ fontSize: 11.5, color: t.sub, marginTop: 2, lineHeight: 1.4 }}>
+                  Requests carry conversational context so the assistant remembers what you asked about.
+                </div>
+              </div>
+              <PillSwitch on={consentOn} theme={t}/>
+            </div>
+
+            <div style={{
+              marginTop: 12, paddingTop: 12,
+              borderTop: `0.5px solid ${t.rule}`,
+              display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14,
+            }}>
+              <div>
+                <div style={{
+                  fontSize: 10, letterSpacing: 0.6, textTransform: 'uppercase',
+                  color: t.sub, fontWeight: 600, marginBottom: 4,
+                }}>Sent to provider</div>
+                <div style={{ fontSize: 12, color: t.ink, lineHeight: 1.5 }}>
+                  Selected passages<br/>
+                  Active chat thread{consentOn && <br/>}
+                  {consentOn && <span>Prior questions in session</span>}
+                </div>
+              </div>
+              <div>
+                <div style={{
+                  fontSize: 10, letterSpacing: 0.6, textTransform: 'uppercase',
+                  color: t.sub, fontWeight: 600, marginBottom: 4,
+                }}>Stays on device</div>
+                <div style={{ fontSize: 12, color: t.ink, lineHeight: 1.5 }}>
+                  Library &amp; reading position<br/>
+                  Highlights &amp; notes<br/>
+                  Provider API keys
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+Object.assign(window, {
+  ShieldIcon,
+  SettingsToggleRow,
+  AISectionVariantA,
+  AISectionVariantB,
+  AISectionVariantC,
+});

--- a/project.yml
+++ b/project.yml
@@ -146,8 +146,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 593
-        MARKETING_VERSION: 3.38.18
+        CURRENT_PROJECT_VERSION: 594
+        MARKETING_VERSION: 3.38.19
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6230,13 +6230,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 593;
+				CURRENT_PROJECT_VERSION = 594;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.38.18;
+				MARKETING_VERSION = 3.38.19;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6380,13 +6380,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 593;
+				CURRENT_PROJECT_VERSION = 594;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.38.18;
+				MARKETING_VERSION = 3.38.19;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

Syncs the claude.ai/design **VReader AI Toggles Canvas** handoff (chat9) into the `dev-docs/designs/vreader-fidelity-v1/` bundle.

Resolves the `needs-design` issue:

- Resolves #1068 — AI Assistant + Data & Privacy toggle rows in SettingsView for feature #67

## What Changed

| File | Change |
|---|---|
| `dev-docs/designs/.../chats/chat9.md` | NEW — chat9 transcript (the #1068 design session) |
| `dev-docs/designs/.../project/VReader AI Toggles Canvas.html` | NEW — AI Toggles canvas (3 variants × 4 states) |
| `dev-docs/designs/.../project/vreader-ai-toggles.jsx` | NEW — component file |
| `dev-docs/designs/.../project/ai-toggles-artboards.jsx` | NEW — artboards |
| `dev-docs/designs/.../README.md` | chat count 8 → 9 |
| `project.yml` / `project.pbxproj` | version bump 3.38.18/593 → 3.38.19/594 |

## Design summary

Two undesigned toggle rows in `SettingsView`'s AI section. Both render as `SettingsToggleRow` (existing 30×30 colored-tile vocabulary from the shipped AI Provider row in feature #67 WI-5).

**Canonical — variant A (tile-parity)**:
- Master toggle "Enable AI Assistant" reuses the shipped AI Provider palette (`#8c2f2f` sparkle). Flipping it off communicates "the whole AI group goes dark".
- Consent toggle "Data & Privacy" adds one new tile color (`#4a6a8a`) with a `shield.checkmark` glyph, slotted into the existing cool-blue family (between Cloud `#3a8ac8` and Folder `#7c6ad6`).
- When AI is off, peer rows (AI Provider + Data & Privacy) are *hidden* with smooth height collapse — **not** disabled / greyed.

**Alternatives**:
- **B · Master-as-section-header**: promote "Enable AI Assistant" into the section label as an inline switch; off-state shows a one-line caption.
- **C · Privacy-callout consent**: when AI is on, the consent toggle moves into a dedicated "Data & Privacy" card with a two-column "Sent to provider / Stays on device" body — heavier disclosure for the consent moment.

Each variant has artboards for AI off / on+consent off / on+consent on / dark, plus a row-specimen up-close section in paper + dark.

## Validation

- [x] `xcodebuild build` SUCCEEDED on iPhone 17 Pro Sim (Debug)
- [x] Bundle diff against incoming handoff matched exactly the 4 expected files + README touch
- [x] No existing canvases overwritten
- [x] `#1068` confirmed as open `needs-design` issue via `gh issue view`
- [x] Audit log: `.claude/codex-audits/docs-ai-toggles-handoff-audit.md` (manual fallback — docs-only, no Swift)
- [x] Version bumped: 3.38.18 → 3.38.19

## Implementation status

**No Swift implementation in this PR.** Building the two toggle rows is gated feature-#67 feature-workflow work and proceeds under `/feature-workflow` when explicitly initiated.

## Type of Change

- [x] Documentation / design-bundle sync (Resolves #1068)