### PR TITLE
verify(#64): Gate-5b partial — F#64 blocked by CU outage + XCUITest sandbox (v3.38.24)

### DIFF
--- a/.claude/codex-audits/verify-feature-64-gate-5b-partial-audit.md
+++ b/.claude/codex-audits/verify-feature-64-gate-5b-partial-audit.md
@@ -1,0 +1,37 @@
+# Codex Gate-4 audit — verify(#64) Gate-5b partial PR
+
+Thread: `019e461e-51fb-7180-bbd0-c936e5d66e0a`
+Date: 2026-05-20
+Verdict: `ship-as-is`
+
+## Diff under audit
+
+- `dev-docs/verification/feature-64-20260520.md` (+274) — Gate-5b acceptance evidence file, `result: partial`.
+- `project.yml` + `vreader.xcodeproj/project.pbxproj` (version bump 3.38.22 → 3.38.23).
+
+Refs #822.
+
+## Findings
+
+Zero Critical / High / Medium / Low findings against this PR.
+
+### Honesty
+> "the evidence is appropriately conservative. It clearly separates what was actually verified from what was blocked, and it labels the TXT bridge and unit-test results as supporting-only, not Gate-5 acceptance."
+
+### Completeness
+> "the plan for Feature #64 has 8 acceptance criteria, not 10, in the final Gate-5 section. The evidence table covers all 8; criterion 1 is reasonably expanded into 5 per-format rows."
+
+### Hook compliance
+> "filename matches `feature-<id>-<YYYYMMDD>.md`, frontmatter contains all required fields, and the required body sections are present per schema."
+
+### Misclassification risk
+> "I do not see a credible path where this should have flipped the row to `VERIFIED`. The file explicitly says `result: partial`, keeps the row at `DONE`, and keeps GH #822 open with `awaiting-device-verification`."
+
+## Follow-up filing (auditor recommendation)
+
+- **Do NOT file** for CU outage — environment/hardware availability, not a product defect.
+- **Do NOT file** for XCUITest in-runner sandbox block — already tracked in Bug #240 / #242.
+- **Do NOT file** for stale `ImportedBooks/` clutter — shared-simulator hygiene / verification-process contamination; better handled by cron prompt / simctl reset discipline.
+- **File a NEW bug** for the EPUB DebugReaderRegistry / WebView registration race if not already tracked. Distinct from #240/#242 because it affects the host-side DebugBridge path too, not just the sandboxed in-runner path, and blocks EPUB verification even when the bridge command is issued successfully.
+
+Follow-up is OUT of this PR's scope. Recorded here for the next iteration to act on.

--- a/dev-docs/verification/feature-64-20260520.md
+++ b/dev-docs/verification/feature-64-20260520.md
@@ -1,0 +1,274 @@
+---
+kind: feature
+id: 64
+status_target: VERIFIED
+commit_sha: 3015c4bc927e18c55d57486689447c63238a8bb1
+app_version: 3.38.22 (build 597)
+date: 2026-05-20
+verifier: claude
+device_or_simulator: iPhone 17 Pro Simulator (UDID 1FAB9493-B97E-48F0-96C7-44A8E5AAA21E)
+os_version: iOS 26.5
+build_configuration: Debug
+backend: n/a
+result: partial
+---
+
+## Summary
+
+Feature #64 (Unified cross-format highlight-action popover) — Gate-5b acceptance
+verification attempt against v3.38.22 (build 597). The verification harness for
+this feature is structurally constrained today by three compounding blockers
+that prevent end-to-end tap-on-highlight popover acceptance:
+
+1. **CU display unavailable** (Bug-class: CU outage). `mcp__computer-use__screenshot`
+   returns `CU display unavailable` consistently across the session (3 retries
+   spaced at 10s, 30s, 45s, 60s). CU is the path the user's verification
+   instructions designate for tapping on the highlighted region and observing
+   the unified popover render.
+2. **XCUITest in-runner DebugBridge blocked by sandbox** (Bug #240b / #242,
+   both FIXED-as-documented). `xcrun simctl openurl` from inside the XCUITest
+   runner exits 72 with NSPOSIXErrorDomain 61 "Connection refused"; the runner
+   sandbox cannot reach the host's CoreSimulatorService XPC endpoint. The
+   `XCUITest` `Feature64TXTHighlightPopoverVerificationTests` is the only
+   XCUITest the project carries for Feature #64; it explicitly
+   `XCTSkipUnless(bridgeReachable())`-skips when the bridge channel is
+   unreachable from inside the runner.
+3. **`Feature64TXTHighlightPopoverVerificationTests` library-state precondition
+   broken**. The test fails at `tapBook(titled: "Position Test Book", ...)`
+   with "Could not find book 'Position Test Book' in library" after 6 swipe
+   attempts. The shared simulator's `ImportedBooks/` carries ≥12 stale fixture
+   files from previous sessions (multiple agents work this UDID for parallel
+   verification runs); the seed re-imports the position-test fixture but the
+   library scroll-to-find loop cannot reach it amid the clutter.
+
+The DebugBridge highlight-driver itself works (Bug #237/#220 fix) — verified
+end-to-end via host-side `xcrun simctl openurl` for TXT, with
+`highlightCount: 1` confirmed in the post-create snapshot. EPUB harness
+attempted but raced against the EPUB WebView registration (DebugReaderRegistry
+empty when the URL fired — "no active EPUB WebView registered" in the logs).
+PDF, AZW3, and MD have no Feature 64-specific XCUITest harness, by design
+(the design carries through unit-level migration tests).
+
+All 64 Feature 64 unit + migration + popover-logic tests pass cleanly
+(`Feature64TXTMDMigrationTests`, `Feature64EPUBMigrationTests`,
+`Feature64PDFMigrationTests`, `Feature64FoliateMigrationTests`,
+`HighlightPopoverViewModelTests`, `HighlightPopoverActionRouterTests`,
+`HighlightCoordinatorMutationTests` — 64 tests, 7 suites, all green in 0.127s).
+These prove the wiring is correct on all 5 formats (TXT/MD/EPUB/PDF/AZW3-Foliate)
+at the layer below the device-tap behavior. They are sufficient for Gate-4
+audit-pass but do NOT substitute for Gate-5 device verification — `partial`
+classification holds.
+
+Per `dev-docs/verification/SCHEMA.md`, `result: partial` keeps the tracker at
+`DONE awaiting partial-VERIFIED` — the row does NOT flip to `VERIFIED`, and
+GH #822 stays open with the existing `awaiting-device-verification` label.
+
+## Acceptance criteria
+
+| # | Criterion | Observed | Pass/Fail |
+|---|-----------|----------|-----------|
+| 1 | Tap-on-highlight opens unified popover on TXT | Cannot exercise tap (CU display unavailable; XCUITest fails at library precondition before reaching tap) | DEFERRED |
+| 1 | Tap-on-highlight opens unified popover on MD | No XCUITest harness for MD; CU unavailable | DEFERRED |
+| 1 | Tap-on-highlight opens unified popover on PDF | No XCUITest harness for PDF; CU unavailable | DEFERRED |
+| 1 | Tap-on-highlight opens unified popover on EPUB | EPUB DebugReaderRegistry race (no WebView registered when URL fires); CU unavailable | DEFERRED |
+| 1 | Tap-on-highlight opens unified popover on AZW3 | No XCUITest harness for AZW3; AZW3 cannot use DebugBridge `highlight` URL (TXT/MD/EPUB only — PDF/AZW3 not wired in observer); CU unavailable | DEFERRED |
+| 2 | Popover shows correct excerpt, color swatch, note | Cannot observe popover (CU + XCUITest blockers) | DEFERRED |
+| 3 | Color change persists + repaints | Cannot exercise (no popover access) | DEFERRED |
+| 4 | Note edit Save persists; reopen shows note; clear+save → empty state | Cannot exercise (no popover access) | DEFERRED |
+| 5 | Copy puts excerpt on pasteboard; Share opens system share sheet | Cannot exercise (no popover access) | DEFERRED |
+| 6 | Delete confirm → Confirm removes from persistence + clears render | Cannot exercise (no popover access) | DEFERRED |
+| 7 | Long note + VoiceOver → bottom-sheet form | Cannot exercise (no popover access; VoiceOver needs CU) | DEFERRED |
+| 8 | Light + dark themes both render correctly | Cannot exercise (no popover access) | DEFERRED |
+| — | DebugBridge highlight-driver creates highlight on TXT | `highlightCount: 0 → 1` after `vreader-debug://highlight?start=0&end=20&color=yellow`; log: `txt highlight observer: created start=0 end=20 color=yellow` | PASS (supporting evidence only — does not satisfy any acceptance criterion) |
+| — | DebugBridge highlight-driver fires observer on EPUB | Log: `epub highlight observer: start=10 end=30 color=pink ... no active EPUB WebView registered` — bridge wired but EPUB WKWebView not registered with `DebugReaderRegistry` before the URL fires; fixture mini-epub3 race | PARTIAL (observer wired, registration race) |
+| — | All Feature 64 unit + migration + popover-logic tests | 64 tests / 7 suites, all green in 0.127s (TXTMDMigration, EPUBMigration, PDFMigration, FoliateMigration, HighlightPopoverViewModel, HighlightPopoverActionRouter, HighlightCoordinatorMutation) | PASS (Gate-4 audit-pass evidence, not Gate-5) |
+
+## Commands run
+
+```bash
+UDID=1FAB9493-B97E-48F0-96C7-44A8E5AAA21E
+APP="/Users/ll/Library/Developer/Xcode/DerivedData/vreader-cqtadlidjtwhvielqbjxurumifyb/Build/Products/Debug-iphonesimulator/vreader.app"
+
+# 1. Build + install + grant URL-scheme approval
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build \
+    -project vreader.xcodeproj -scheme vreader -configuration Debug \
+    -destination "platform=iOS Simulator,id=$UDID" \
+    -derivedDataPath /Users/ll/Library/Developer/Xcode/DerivedData/vreader-cqtadlidjtwhvielqbjxurumifyb
+xcrun simctl install "$UDID" "$APP"
+scripts/grant-debug-scheme-approval.sh "$UDID"
+
+# 2. TXT bridge highlight-create — PASS
+xcrun simctl launch "$UDID" com.vreader.app
+xcrun simctl openurl "$UDID" 'vreader-debug://reset'
+xcrun simctl openurl "$UDID" 'vreader-debug://seed?fixture=war-and-peace'
+KEY="txt:bd8285a80f01df96dedd20a02178043afb85c0b499127e300baf57b7f1ed7508:1705"
+ENCODED=$(printf '%s' "$KEY" | sed 's/:/%3A/g')
+xcrun simctl openurl "$UDID" "vreader-debug://open?bookId=$ENCODED"
+xcrun simctl openurl "$UDID" 'vreader-debug://settle?token=t1'
+xcrun simctl openurl "$UDID" 'vreader-debug://highlight?start=0&end=20&color=yellow'
+xcrun simctl openurl "$UDID" 'vreader-debug://snapshot?dest=snap-txt-h1.json'
+# Result: highlightCount: 1, lastError: null, format: txt
+
+# 3. EPUB bridge highlight-create — observer fires but WebView not registered (race)
+xcrun simctl openurl "$UDID" 'vreader-debug://reset'
+xcrun simctl openurl "$UDID" 'vreader-debug://seed?fixture=mini-epub3'
+EPUB_KEY="epub:f284fd074ccd1d3c1a78985464d9e1be27975f4029f3c2ddef8428ca10684af4:2198"
+EPUB_ENC=$(printf '%s' "$EPUB_KEY" | sed 's/:/%3A/g')
+xcrun simctl openurl "$UDID" "vreader-debug://open?bookId=$EPUB_ENC"
+xcrun simctl openurl "$UDID" 'vreader-debug://settle?token=eb1'  # 30s settle timeout
+xcrun simctl openurl "$UDID" 'vreader-debug://highlight?start=10&end=30&color=pink'
+# Log: "epub highlight observer: ... no active EPUB WebView registered"
+# Snapshot: highlightCount: 0
+
+# 4. XCUITest Feature 64 (TXT only) — FAIL on library precondition
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
+    -project vreader.xcodeproj -scheme vreader \
+    -destination "platform=iOS Simulator,id=$UDID" \
+    -only-testing:vreaderUITests/Feature64TXTHighlightPopoverVerificationTests \
+    -parallel-testing-enabled NO
+# Failure: "Could not find book 'Position Test Book' in library" at line 72 (tapBook)
+# Cause: cluttered ImportedBooks/ from prior sessions confuses the swipe-to-find loop
+
+# 5. Feature 64 unit + migration + popover tests — PASS
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
+    -project vreader.xcodeproj -scheme vreader \
+    -destination "platform=iOS Simulator,id=$UDID" \
+    -only-testing:vreaderTests/Feature64TXTMDMigrationTests \
+    -only-testing:vreaderTests/Feature64EPUBMigrationTests \
+    -only-testing:vreaderTests/Feature64FoliateMigrationTests \
+    -only-testing:vreaderTests/Feature64PDFMigrationTests \
+    -only-testing:vreaderTests/HighlightPopoverViewModelTests \
+    -only-testing:vreaderTests/HighlightPopoverActionRouterTests \
+    -only-testing:vreaderTests/HighlightCoordinatorMutationTests \
+    -parallel-testing-enabled NO
+# Result: 64 tests / 7 suites, all green in 0.127s. ** TEST SUCCEEDED **
+```
+
+## Observations
+
+### CU outage — primary blocker
+
+CU display has been flapping since the morning (per user instructions —
+"Screen Sharing Virtual Display" path fails; "UGREEN HDMI dummy plug" path
+works when present). Today the dummy plug appears to be unplugged or the
+session is stuck on the Screen Sharing path. Retries at +10s, +30s, +45s,
++60s all returned `CU display unavailable`. CU is the path the user's
+verification recipe designates for the actual tap-on-highlight gesture and
+the screenshot of the rendered popover. There is no alternative observation
+surface — `DebugSnapshot` has no popover-state field (verified by reading
+`vreader/Services/DebugBridge/DebugSnapshot.swift`; the snapshot includes
+`currentBookId / format / position / theme / fontSize / selection /
+highlightCount / renderPhase / lastError / ttsState / ttsOffsetUTF16 /
+settingsProvenance` but no popover/sheet visibility marker).
+
+### XCUITest test failed at library precondition
+
+`Feature64TXTHighlightPopoverVerificationTests.testTapOnHighlightOpensUnifiedPopover()`
+failed at `tapBook(titled: "Position Test Book", in: app)` (line 72, the very
+first action) with "Could not find book 'Position Test Book' in library"
+after the helper's 6-swipe scroll attempts.
+
+Investigation: `vreader/App/TestSeeder.swift:35-82` (`seedPositionTest`)
+calls `clearAllBooks(persistence:)` and then inserts a single `BookRecord`
+for "Position Test Book". `clearAllBooks` only clears the persistence DB —
+it does NOT delete the files in `Library/Application Support/ImportedBooks/`.
+On the verifier UDID I am sharing with the f62-agent and other agents, the
+`ImportedBooks/` directory carries 12+ stale fixture files from prior
+sessions (visible TXT, EPUB, MD, AZW3 files with `0000000000…` synthetic
+fingerprints from test seeds + real-hash fixtures from real seeds). On app
+launch the file-discovery + re-import path re-creates BookRecords for those
+orphans (the books re-appear in the library). With 12+ books in the library,
+the `tapBook` helper's 6-swipe scroll loop cannot reach the freshly-seeded
+"Position Test Book" deterministically.
+
+This is a verification-harness issue, NOT a Feature 64 product defect. Even
+if XCUITest had found the book, the test would then `XCTSkipUnless(bridgeReachable())`
+per Bug #240b/#242 (NSPOSIXErrorDomain 61 — runner sandbox blocks
+`simctl openurl`), so the popover-opening tap behavior would still not
+have been exercised by the in-runner path.
+
+### EPUB WebView registration race
+
+Sequence observed on mini-epub3 fixture:
+1. `vreader-debug://open?bookId=epub:f284...:2198` → `open: posted notification for ...`
+2. `vreader-debug://settle?token=eb1` → ERROR: `settle: ready-epub-v1.json with error=settle timeout` (30 s timeout)
+3. Snapshot confirms `currentBookId: epub:..., format: epub` — EPUB IS open.
+4. `vreader-debug://highlight?start=10&end=30&color=pink` →
+   - `epub highlight observer: start=10 end=30 color=pink fingerprint=epub:...`
+   - **`epub highlight observer: no active EPUB WebView registered for epub:...`**
+   - `highlight: posted notification start=10 end=30 color=pink` (notification fired anyway)
+5. `highlightCount` remains 0 after the URL.
+
+Per `vreader/Views/Reader/EPUBReaderContainerView+DebugBridgeHighlight.swift`,
+the EPUB observer resolves the active WebView via `DebugReaderRegistry.shared
+.epubWebView(for: fingerprintKey, token: ...)`. Per Bug #126 (FIXED), the
+EPUB WebView registers itself with `DebugReaderRegistry` in
+`EPUBWebViewBridgeCoordinator.webView(_:didFinish:)` — i.e., **only after the
+EPUB page-load completes**. On mini-epub3 this completion never seems to
+fire within the test window (settle times out at 30 s, observed twice in
+this session). Without registration, the EPUB highlight URL is a no-op
+silently from the user's POV (the snapshot doesn't even reflect a
+`lastError`; only the OSLog reveals the race).
+
+This is a different-from-#220 bridge race — not a structural sandbox issue,
+just a fixture-load race where the EPUB never reaches `didFinish` quickly
+enough for the test sequence to consume. Filed below as a candidate
+follow-up.
+
+### TXT bridge harness works
+
+The TXT path proves the highlight-driver works end-to-end via host-side
+`simctl openurl` — `highlightCount: 0 → 1` after the URL, with the log
+showing `txt highlight observer: created start=0 end=20 color=yellow`. This
+unblocks any future verification iteration that has CU available.
+
+### Acceptance criteria 1 — gesture-tap to popover surface
+
+This is the single most important acceptance criterion (every other
+criterion is downstream of "the popover is visible at all"). It physically
+cannot be exercised today without either:
+- CU display (for a real tap gesture + screenshot of the popover), OR
+- An in-runner XCUITest path that creates the highlight (only the bridge
+  driver does this, blocked by Bug #240b/#242), then taps the rendered
+  region and asserts on the `highlightPopoverSheet` AX identifier (which
+  the existing test does — but cannot reach because of the library
+  precondition + bridge sandbox).
+
+A workaround would be to extend `DebugSnapshot` with a `popover` block
+(format, content id, mode, presence of `highlightActionCard` /
+`highlightPopoverSheet` AX identifier) — a tracker entry for that would
+move this from `partial` to a CU-free verifiable path. Not in scope here.
+
+### Why not flip the row to VERIFIED
+
+Per `dev-docs/verification/SCHEMA.md`:
+> `partial` — some criteria pass, some are explicitly deferred with a
+> follow-up row in the tracker. Tracker status may NOT move to `VERIFIED`;
+> it stays at `DONE awaiting partial-VERIFIED` and a follow-up evidence
+> file is required.
+
+Zero of the 8 acceptance criteria are observably PASS in this verification
+run. Every criterion is DEFERRED on tooling. The supporting evidence
+(bridge works on TXT; all unit tests green) confirms the *implementation*
+is in good shape — but it doesn't substitute for the device acceptance pass
+the rule mandates. Row stays at `DONE`. GH #822 stays OPEN with
+`awaiting-device-verification`.
+
+## Artifacts
+
+None for this run — CU is unavailable so no screenshots can be captured.
+Supporting log excerpts are inline in the "Observations" section.
+
+## Follow-up
+
+1. Re-run this verification when CU display is restored (`mcp__computer-use__screenshot`
+   returns image instead of `CU display unavailable`). Recipe in "Commands
+   run" above is the start; tap-on-highlight at the rendered region + CU
+   screenshot of the popover + criterion-by-criterion exercise is the
+   remainder.
+2. EPUB DebugReaderRegistry race on mini-epub3 (no WebView registered when
+   the highlight URL fires) — separate issue to consider filing if it
+   blocks future verifications.
+3. Verifier-UDID `ImportedBooks/` clutter from prior sessions confounds
+   `tapBook(titled:)` swipe-find — consider a `vreader-debug://reset?wipe-files=true`
+   variant or a sim-erase pre-step in the cron prompt.

--- a/project.yml
+++ b/project.yml
@@ -146,8 +146,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 597
-        MARKETING_VERSION: 3.38.22
+        CURRENT_PROJECT_VERSION: 598
+        MARKETING_VERSION: 3.38.23
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/project.yml
+++ b/project.yml
@@ -146,8 +146,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 598
-        MARKETING_VERSION: 3.38.23
+        CURRENT_PROJECT_VERSION: 599
+        MARKETING_VERSION: 3.38.24
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6234,13 +6234,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 597;
+				CURRENT_PROJECT_VERSION = 598;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.38.22;
+				MARKETING_VERSION = 3.38.23;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6384,13 +6384,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 597;
+				CURRENT_PROJECT_VERSION = 598;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.38.22;
+				MARKETING_VERSION = 3.38.23;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6234,13 +6234,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 598;
+				CURRENT_PROJECT_VERSION = 599;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.38.23;
+				MARKETING_VERSION = 3.38.24;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6384,13 +6384,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 598;
+				CURRENT_PROJECT_VERSION = 599;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.38.23;
+				MARKETING_VERSION = 3.38.24;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

Feature #64 (Unified cross-format highlight-action popover) Gate-5b acceptance verification attempt against v3.38.22 → bumped to v3.38.24. Three compounding tooling blockers prevent end-to-end tap-on-highlight popover acceptance; the implementation itself shows no defects (TXT bridge harness works; 64 unit / migration / popover tests all green).

**Result: `partial`** — per `dev-docs/verification/SCHEMA.md`, the row stays at `DONE awaiting partial-VERIFIED`. The tracker row is NOT flipped to `VERIFIED`. GH #822 stays open with `awaiting-device-verification`.

## Blockers

1. **CU display unavailable** — `mcp__computer-use__screenshot` returned `CU display unavailable` consistently across 4 retries (10s / 30s / 45s / 60s). CU is the path the user's verification recipe designates for the tap-on-highlight gesture and the popover screenshot.
2. **XCUITest in-runner DebugBridge blocked by sandbox** — Bug #240b / #242 (FIXED-as-documentation). `xcrun simctl openurl` from inside the XCUITest runner exits 72 with NSPOSIXErrorDomain 61. The Feature 64 XCUITest carries an `XCTSkipUnless(bridgeReachable())` guard for exactly this case.
3. **`Feature64TXTHighlightPopoverVerificationTests` library precondition broken** — `tapBook(titled: "Position Test Book", ...)` fails after 6 swipe attempts because the shared simulator's `ImportedBooks/` carries ≥12 stale fixture files from prior agents' sessions; the seed re-imports the position-test fixture but the swipe-find loop cannot reach it amid the clutter.

## Supporting evidence verified inline

- **TXT bridge highlight-driver works end-to-end** via host-side `simctl openurl`. `highlightCount: 0 → 1` confirmed in the post-create snapshot; OSLog showed `txt highlight observer: created start=0 end=20 color=yellow`.
- **EPUB bridge harness wired but raced** against EPUB WebView registration with `DebugReaderRegistry` — observed `epub highlight observer: ... no active EPUB WebView registered for epub:...` on mini-epub3 fixture. The bridge fires correctly; the WebView simply isn't in the registry yet (page-load hasn't completed). Distinct from Bug #240b/#242 — this affects the host-driven path too, not just the runner sandbox.
- **All 64 Feature 64 unit + migration + popover-logic tests pass** (TXTMDMigration, EPUBMigration, PDFMigration, FoliateMigration, HighlightPopoverViewModel, HighlightPopoverActionRouter, HighlightCoordinatorMutation — 7 suites, 0.127s, all green).

## Codex Gate-4 audit

Thread `019e461e-51fb-7180-bbd0-c936e5d66e0a`, 1 round, verdict **`ship-as-is`**. Zero Critical/High/Medium/Low findings against this PR. Audit log committed at `.claude/codex-audits/verify-feature-64-gate-5b-partial-audit.md`. Auditor's only follow-up: file a NEW bug for the EPUB DebugReaderRegistry registration race observed in the EPUB verification attempt (out of this PR's scope; recorded in the audit log).

## Files

- `dev-docs/verification/feature-64-20260520.md` (NEW, +274) — Gate-5b acceptance evidence per SCHEMA.
- `.claude/codex-audits/verify-feature-64-gate-5b-partial-audit.md` (NEW, +37) — audit log.
- `project.yml` + `vreader.xcodeproj/project.pbxproj` — version bump 3.38.22 → 3.38.24 (two patch bumps because the audit-log commit landed between the first bump and the tail).

## Test plan

- [x] Codex Gate-4 audit clean (zero findings, ship-as-is).
- [x] Feature 64 unit + migration + popover tests green (64 tests / 7 suites / 0.127s).
- [x] Evidence file frontmatter + body sections match `dev-docs/verification/SCHEMA.md`.
- [x] `docs/features.md` row #64 NOT flipped (partial mandates DONE).
- [x] GH #822 NOT closed (partial mandates open + `awaiting-device-verification`).

Refs #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)