### PR TITLE
feat(#71 WI-1): EPUBSpineWindow — materialized chapter-window value type

### DIFF
--- a/.claude/codex-audits/feat-feature-71-wi-1-spine-window-audit.md
+++ b/.claude/codex-audits/feat-feature-71-wi-1-spine-window-audit.md
@@ -1,0 +1,34 @@
+---
+branch: feat/feature-71-wi-1-spine-window
+threadId: 019e5fac-f489-7432-aeee-df81e22bacb2
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-25
+---
+
+# Gate-4 implementation audit — Feature #71 WI-1 (`EPUBSpineWindow`)
+
+Foundational first WI of feature #71 (EPUB scroll-mode continuous cross-chapter scroll). Pure value type modeling the materialized chapter window for continuous scroll — integer-range arithmetic, no UIKit, no I/O.
+
+Files audited:
+- `vreader/Views/Reader/EPUBSpineWindow.swift` (new)
+- `vreaderTests/Views/Reader/EPUBSpineWindowTests.swift` (new, 20 Swift Testing cases, all passing)
+- `vreader.xcodeproj/project.pbxproj` (xcodegen-regenerated registration)
+
+## Round 1 findings (Codex thread `019e5fac`)
+
+No Critical/High/Medium. 3 Low:
+
+| # | file:line | severity | issue | resolution |
+|---|---|---|---|---|
+| 1 | EPUBSpineWindow.swift `evictFarFromAnchor` | Low | Final `else { newLo += 1 }` unreachable under the invariant + `cap >= 1`; made the termination proof harder, left misleading dead code in the most delicate function | **Fixed** — collapsed to a true two-branch loop (`if newHi > anchor, distanceToHi >= distanceToLo \|\| newLo >= anchor { newHi -= 1 } else { newLo += 1 }`) with a comment proving each iteration shrinks the span by exactly one and never drops the anchor |
+| 2 | EPUBSpineWindowTests.swift | Low | Tie-break behind `distanceToHi >= distanceToLo` not pinned — a `>=`→`>` regression would still pass (maxSpan==1 collapses regardless) | **Fixed** — added `symmetric window evicting by one trims hi` (anchor 4, 3...5, maxSpan 2 → 3...4); a `>` regression would produce 4...5 and fail |
+| 3 | EPUBSpineWindowTests.swift | Low | Synthesized `Equatable` includes private `spineCount`; semantics undocumented/unpinned | **Fixed** — added `windows with the same visible range but different spineCount are unequal` pinning full-state equality (spineCount is load-bearing — it drives future `canExtendForward`/edge-clamp behavior) |
+
+## Round 2 (verification)
+
+All 3 fixes confirmed by Codex. Termination + invariant preservation re-verified for anchor at lo edge, hi edge, middle, and maxSpan==1. **Still-open findings: none.**
+
+## Verdict
+
+**ship-as-is.** No correctness bug against the WI-1 contract; the eviction loop preserves `0 <= lo <= anchor <= hi < spineCount` and terminates for all anchor positions. 20 unit tests green. Author/auditor separation satisfied (Codex is a separate process).

--- a/project.yml
+++ b/project.yml
@@ -146,8 +146,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 631
-        MARKETING_VERSION: 3.39.10
+        CURRENT_PROJECT_VERSION: 632
+        MARKETING_VERSION: 3.39.11
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -780,6 +780,7 @@
 		9584BA9E45DD2C0CE1061C02 /* BookSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66100437B6A815214E1D0004 /* BookSourceTests.swift */; };
 		9591198F5D4E6AFAA7662871 /* chapter_list_page2.html in Resources */ = {isa = PBXBuildFile; fileRef = C1455BB273A606F96B755C69 /* chapter_list_page2.html */; };
 		95D2D252390D26AFDBBAF43C /* SPIKE_RESULTS.md in Resources */ = {isa = PBXBuildFile; fileRef = 3D70FBE6B4F5F9DDBA035D25 /* SPIKE_RESULTS.md */; };
+		963BCA088CC585842A1B80B8 /* EPUBSpineWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9612DBF3E24AED99EFACC646 /* EPUBSpineWindowTests.swift */; };
 		964CEC849A9E722447081EF4 /* BilingualAttributedStringComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E6312BDB7B7B5A5672E68B /* BilingualAttributedStringComposerTests.swift */; };
 		966F8A5B17A489AC0E8E1F06 /* LibraryContainerCompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C43C404319C34029EB078C /* LibraryContainerCompositionTests.swift */; };
 		96B17941DBC83D6B8BB41FEF /* TXTChapterOverlayViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46230855AD50583047E521C5 /* TXTChapterOverlayViews.swift */; };
@@ -1174,6 +1175,7 @@
 		E378688E028925097D69864F /* LibraryView+Body.swift in Sources */ = {isa = PBXBuildFile; fileRef = 582AD3C3AF9773965AC0340F /* LibraryView+Body.swift */; };
 		E37CAFB8AF04456F6F0CEBA5 /* AISettingsViewModel+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10C2FF255E2C0E968707942E /* AISettingsViewModel+Editor.swift */; };
 		E400E164FA809CC3AB0AC796 /* CollectionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B442FC7A6A6ED344AB5C1FC9 /* CollectionPersistenceTests.swift */; };
+		E4066ED77CCB0AE0D1D082B5 /* EPUBSpineWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907EAD6F84813CDD693D9970 /* EPUBSpineWindow.swift */; };
 		E44BC8CE480C18F6469C62DD /* WI9TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3CB57338FD24289DAC8ABE4 /* WI9TestHelpers.swift */; };
 		E47B06C25D9525500CE31095 /* ReadingDashboardViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6635582524CF50059E66F973 /* ReadingDashboardViewTests.swift */; };
 		E4C963854C70662E3D59835D /* TXTChapterIndexStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0E95AA02EBAE369ABF9AE5 /* TXTChapterIndexStore.swift */; };
@@ -2057,6 +2059,7 @@
 		903D9FCA142155D5B65A5C18 /* Feature40TTSSentenceHighlightVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature40TTSSentenceHighlightVerificationTests.swift; sourceTree = "<group>"; };
 		904A30F4AD7E5862C2D3C955 /* EPUBBilingualJS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBBilingualJS.swift; sourceTree = "<group>"; };
 		907D934613DDAEA1F3055F82 /* EPUBReaderContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBReaderContainerView.swift; sourceTree = "<group>"; };
+		907EAD6F84813CDD693D9970 /* EPUBSpineWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBSpineWindow.swift; sourceTree = "<group>"; };
 		9081F5E7C359D5FB2661E7AC /* ReaderThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeTests.swift; sourceTree = "<group>"; };
 		90B380013D82DFFD0411633E /* EPUBReaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBReaderViewModel.swift; sourceTree = "<group>"; };
 		90EFFE1F64991A9192F31011 /* UpdateCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCheckerTests.swift; sourceTree = "<group>"; };
@@ -2084,6 +2087,7 @@
 		95B006129C2FCEC99B9FBB91 /* RemoteBookCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBookCatalogTests.swift; sourceTree = "<group>"; };
 		95B9ADB001D66D4A6EC07C9A /* VerificationDebugBridgeHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationDebugBridgeHelper.swift; sourceTree = "<group>"; };
 		95BF292C7F9DE8BB24E247E7 /* HighlightsSheet+Support.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HighlightsSheet+Support.swift"; sourceTree = "<group>"; };
+		9612DBF3E24AED99EFACC646 /* EPUBSpineWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBSpineWindowTests.swift; sourceTree = "<group>"; };
 		963BA5B346A86B1447A26EF5 /* GenerativeCoverViewStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerativeCoverViewStyleTests.swift; sourceTree = "<group>"; };
 		96A2462C6A873DEC45025230 /* TXTReaderViewModelChapterHeadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReaderViewModelChapterHeadingTests.swift; sourceTree = "<group>"; };
 		96A2FE9743AF484093A21969 /* TTSServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSServiceTests.swift; sourceTree = "<group>"; };
@@ -3103,6 +3107,7 @@
 				8FA15EA6877E3CA9421E1B59 /* EPUBProgressTests.swift */,
 				1F445E3A9D4CEEC79F674239 /* EPUBReaderHostLifecycleTests.swift */,
 				A5717B0EFF152D86D07C5C0D /* EPUBSelectionTokenCacheTests.swift */,
+				9612DBF3E24AED99EFACC646 /* EPUBSpineWindowTests.swift */,
 				003A86C3EF12A6B1DD4F5201 /* EPUBWebViewBridgeCoordinatorTests.swift */,
 				F0109C1BF00E2339347FEC04 /* EPUBWebViewBridgeEarlySettleFallbackTests.swift */,
 				ABFBA14606BD14D14A8D5500 /* EPUBWebViewBridgeTests.swift */,
@@ -3647,6 +3652,7 @@
 				A922B4886FE1CE378009FB1B /* EPUBReaderContainerView+Highlights.swift */,
 				B4FC46B472B8A5D69BD80220 /* EPUBReaderContainerView+Navigation.swift */,
 				A78743D11EADF7D49C2AD970 /* EPUBSelectionTokenCache.swift */,
+				907EAD6F84813CDD693D9970 /* EPUBSpineWindow.swift */,
 				C0E536B950D178C97842DF52 /* EPUBWebViewBridge.swift */,
 				1920480AF349823757484C2D /* EPUBWebViewBridgeCoordinator.swift */,
 				1C07D184EF0E90D5F2DF7A36 /* EPUBWebViewBridgeJS.swift */,
@@ -5229,6 +5235,7 @@
 				57C3A4ADBA966558416FB01C /* EPUBReaderHostLifecycleTests.swift in Sources */,
 				C320E44AF92161F0A556FDA7 /* EPUBReaderViewModelTests.swift in Sources */,
 				F889D8A73C4F04D6FA5CF12B /* EPUBSelectionTokenCacheTests.swift in Sources */,
+				963BCA088CC585842A1B80B8 /* EPUBSpineWindowTests.swift in Sources */,
 				B1EF7FB8170BAD9BFA1B5636 /* EPUBTextExtractorBilingualTests.swift in Sources */,
 				1EE68B75A44789E6789BA6EB /* EPUBTextExtractorTests.swift in Sources */,
 				65EB03B9632EFDE8EAF49ACC /* EPUBTextStripperTests.swift in Sources */,
@@ -5814,6 +5821,7 @@
 				7D0D6E22B259A33A6B27BAE9 /* EPUBReaderContainerView.swift in Sources */,
 				08F6B888EBC4D1ADDA3CC360 /* EPUBReaderViewModel.swift in Sources */,
 				02CBE47CFF27030CBBCF0B13 /* EPUBSelectionTokenCache.swift in Sources */,
+				E4066ED77CCB0AE0D1D082B5 /* EPUBSpineWindow.swift in Sources */,
 				E1863B0320B22A4E53575FBD /* EPUBTextExtractor.swift in Sources */,
 				C60601B9EF202F0983235144 /* EPUBTextStripper.swift in Sources */,
 				E8353217B517055A09014AE7 /* EPUBTypes.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6426,13 +6426,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 631;
+				CURRENT_PROJECT_VERSION = 632;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.39.10;
+				MARKETING_VERSION = 3.39.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6576,13 +6576,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 631;
+				CURRENT_PROJECT_VERSION = 632;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.39.10;
+				MARKETING_VERSION = 3.39.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Views/Reader/EPUBSpineWindow.swift
+++ b/vreader/Views/Reader/EPUBSpineWindow.swift
@@ -1,0 +1,126 @@
+// Purpose: Pure value type modeling the contiguous range of EPUB spine
+// items (chapters) currently materialized in the continuous-scroll
+// WKWebView document (feature #71 — EPUB scroll-mode continuous
+// cross-chapter scroll, WI-1).
+//
+// Background: in scroll mode the EPUB reader stitches a window of adjacent
+// chapters into ONE scrollable document and lazily extends / evicts that
+// window as the user scrolls (design §2.3: "render current chapter + ±1
+// chapter eagerly", with far-end eviction to bound WKWebView memory). This
+// type holds the window's bookkeeping as pure integer-range arithmetic so
+// the whole materialize / extend / evict policy is unit-testable without a
+// WKWebView (the bridge wiring lands in WI-4+).
+//
+// Key decisions:
+// - Non-empty invariant (Gate-2 round-1 finding [L1]): a valid window
+//   always satisfies `0 <= lo <= anchor <= hi < spineCount`. A book with
+//   `spineCount == 0` therefore has NO window — `initial(anchor:spineCount:)`
+//   returns nil and the container guards the empty case. This avoids an
+//   ambiguous "empty range" representation that the transition functions
+//   would otherwise have to special-case everywhere.
+// - `anchor` is the chapter the reader is currently reading; it is the
+//   fixed point eviction trims around (the far end from the anchor is
+//   trimmed first), so the user's current chapter is never evicted.
+// - All transitions are pure (`func` returning a new value), value-type
+//   `Equatable` — no shared mutable state, mirroring `EPUBChapterNavigationRouter`
+//   and `EPUBProgressCalculator`.
+//
+// @coordinates-with: EPUBContinuousScrollCoordinator.swift (WI-4 consumer),
+//   dev-docs/plans/20260525-feature-71-epub-continuous-scroll.md (WI-1)
+
+import Foundation
+
+/// The contiguous range of spine indices materialized in the continuous
+/// scroll document, anchored on the chapter the reader is reading.
+///
+/// Invariant (maintained by every initializer / transition):
+/// `0 <= lo <= anchor <= hi < spineCount`.
+struct EPUBSpineWindow: Equatable {
+
+    /// Lowest materialized spine index (inclusive).
+    private(set) var lo: Int
+    /// Highest materialized spine index (inclusive).
+    private(set) var hi: Int
+    /// The chapter the reader is currently reading. Eviction trims around
+    /// this point so it is never dropped from the window.
+    private(set) var anchor: Int
+
+    /// Total spine items in the book. Kept so the transitions can clamp at
+    /// the book edges without the caller re-passing it each time.
+    private let spineCount: Int
+
+    private init(lo: Int, hi: Int, anchor: Int, spineCount: Int) {
+        self.lo = lo
+        self.hi = hi
+        self.anchor = anchor
+        self.spineCount = spineCount
+    }
+
+    /// Builds the initial single-chapter window anchored on `anchor`.
+    ///
+    /// - Returns: `nil` when `spineCount <= 0` (an empty book has no
+    ///   window). Otherwise a `lo == hi == anchor` window with `anchor`
+    ///   clamped into `0..<spineCount`.
+    static func initial(anchor: Int, spineCount: Int) -> EPUBSpineWindow? {
+        guard spineCount > 0 else { return nil }
+        let clampedAnchor = min(max(anchor, 0), spineCount - 1)
+        return EPUBSpineWindow(
+            lo: clampedAnchor,
+            hi: clampedAnchor,
+            anchor: clampedAnchor,
+            spineCount: spineCount
+        )
+    }
+
+    /// Whether the window can grow toward the end of the book.
+    var canExtendForward: Bool { hi < spineCount - 1 }
+
+    /// Whether the window can grow toward the start of the book.
+    var canExtendBackward: Bool { lo > 0 }
+
+    /// Whether the given spine index is currently materialized.
+    func contains(_ index: Int) -> Bool { index >= lo && index <= hi }
+
+    /// Grows the window forward by one chapter, or returns `self` unchanged
+    /// when already at the last chapter.
+    func extendForward() -> EPUBSpineWindow {
+        guard canExtendForward else { return self }
+        return EPUBSpineWindow(lo: lo, hi: hi + 1, anchor: anchor, spineCount: spineCount)
+    }
+
+    /// Grows the window backward by one chapter, or returns `self` unchanged
+    /// when already at the first chapter.
+    func extendBackward() -> EPUBSpineWindow {
+        guard canExtendBackward else { return self }
+        return EPUBSpineWindow(lo: lo - 1, hi: hi, anchor: anchor, spineCount: spineCount)
+    }
+
+    /// Trims the window down to at most `maxSpan` chapters, removing whole
+    /// chapters from the end farther from the `anchor` first so the
+    /// reader's current chapter is always retained.
+    ///
+    /// - Parameter maxSpan: the maximum number of chapters to keep
+    ///   materialized (clamped to ≥ 1 — a window always keeps the anchor).
+    func evictFarFromAnchor(maxSpan: Int) -> EPUBSpineWindow {
+        let cap = max(maxSpan, 1)
+        var newLo = lo
+        var newHi = hi
+        while (newHi - newLo + 1) > cap {
+            // The window still spans more than one chapter (`cap >= 1` and
+            // the guard holds), so at least one side is strictly past the
+            // anchor and can be trimmed without dropping it. Trim the side
+            // farther from the anchor first; ties trim `hi` (so a symmetric
+            // window shrinks toward the start). Exactly one branch makes
+            // progress each iteration → the loop always terminates.
+            let distanceToLo = anchor - newLo
+            let distanceToHi = newHi - anchor
+            if newHi > anchor, distanceToHi >= distanceToLo || newLo >= anchor {
+                newHi -= 1
+            } else {
+                // `newLo < anchor` here: the only remaining trimmable side.
+                newLo += 1
+            }
+        }
+        return EPUBSpineWindow(lo: newLo, hi: newHi, anchor: anchor, spineCount: spineCount)
+    }
+}

--- a/vreaderTests/Views/Reader/EPUBSpineWindowTests.swift
+++ b/vreaderTests/Views/Reader/EPUBSpineWindowTests.swift
@@ -1,0 +1,219 @@
+// Purpose: Tests for EPUBSpineWindow — the pure value type modeling the
+// contiguous range of EPUB spine items (chapters) currently materialized
+// in the continuous-scroll WKWebView document (feature #71, WI-1).
+//
+// The window has a non-empty invariant (lo <= anchor <= hi, all in
+// 0..<spineCount) per Gate-2 round-1 finding [L1]: a spineCount == 0 book
+// has NO window (initial(anchor:spineCount:) returns nil); the container
+// guards the empty case. Transitions are pure integer-range arithmetic —
+// no UIKit, no I/O — so the whole window-management policy is unit-tested
+// here before any WKWebView wiring (WI-4+) consumes it.
+//
+// @coordinates-with: EPUBSpineWindow.swift,
+//   dev-docs/plans/20260525-feature-71-epub-continuous-scroll.md (WI-1)
+
+import Testing
+@testable import vreader
+
+@Suite("EPUBSpineWindow")
+struct EPUBSpineWindowTests {
+
+    // MARK: - initial(anchor:spineCount:)
+
+    @Test("empty book (spineCount 0) has no window")
+    func initialEmptyBookIsNil() {
+        #expect(EPUBSpineWindow.initial(anchor: 0, spineCount: 0) == nil)
+    }
+
+    @Test("single-chapter book windows 0...0 with anchor 0")
+    func initialSingleChapter() throws {
+        let window = try #require(EPUBSpineWindow.initial(anchor: 0, spineCount: 1))
+        #expect(window.lo == 0)
+        #expect(window.hi == 0)
+        #expect(window.anchor == 0)
+        #expect(window.canExtendForward == false)
+        #expect(window.canExtendBackward == false)
+    }
+
+    @Test("multi-chapter book windows anchor...anchor initially")
+    func initialMultiChapterIsSingletonAtAnchor() throws {
+        let window = try #require(EPUBSpineWindow.initial(anchor: 3, spineCount: 10))
+        #expect(window.lo == 3)
+        #expect(window.hi == 3)
+        #expect(window.anchor == 3)
+        #expect(window.canExtendForward == true)
+        #expect(window.canExtendBackward == true)
+    }
+
+    @Test("out-of-range anchor clamps into 0..<spineCount")
+    func initialClampsAnchor() throws {
+        let high = try #require(EPUBSpineWindow.initial(anchor: 99, spineCount: 5))
+        #expect(high.anchor == 4)
+        let low = try #require(EPUBSpineWindow.initial(anchor: -3, spineCount: 5))
+        #expect(low.anchor == 0)
+    }
+
+    // MARK: - canExtend flags at the book edges
+
+    @Test("anchor at last chapter cannot extend forward")
+    func cannotExtendForwardAtLastChapter() throws {
+        let window = try #require(EPUBSpineWindow.initial(anchor: 4, spineCount: 5))
+        #expect(window.canExtendForward == false)
+        #expect(window.canExtendBackward == true)
+    }
+
+    @Test("anchor at first chapter cannot extend backward")
+    func cannotExtendBackwardAtFirstChapter() throws {
+        let window = try #require(EPUBSpineWindow.initial(anchor: 0, spineCount: 5))
+        #expect(window.canExtendBackward == false)
+        #expect(window.canExtendForward == true)
+    }
+
+    // MARK: - extendForward / extendBackward
+
+    @Test("extendForward grows hi by one")
+    func extendForwardGrowsHi() throws {
+        let window = try #require(EPUBSpineWindow.initial(anchor: 2, spineCount: 10))
+        let extended = window.extendForward()
+        #expect(extended.lo == 2)
+        #expect(extended.hi == 3)
+        #expect(extended.anchor == 2)
+    }
+
+    @Test("extendBackward grows lo by one")
+    func extendBackwardGrowsLo() throws {
+        let window = try #require(EPUBSpineWindow.initial(anchor: 5, spineCount: 10))
+        let extended = window.extendBackward()
+        #expect(extended.lo == 4)
+        #expect(extended.hi == 5)
+        #expect(extended.anchor == 5)
+    }
+
+    @Test("extendForward at the last chapter is a no-op (clamps)")
+    func extendForwardClampsAtEnd() throws {
+        let window = try #require(EPUBSpineWindow.initial(anchor: 4, spineCount: 5))
+        let extended = window.extendForward()
+        #expect(extended == window)
+    }
+
+    @Test("extendBackward at the first chapter is a no-op (clamps)")
+    func extendBackwardClampsAtStart() throws {
+        let window = try #require(EPUBSpineWindow.initial(anchor: 0, spineCount: 5))
+        let extended = window.extendBackward()
+        #expect(extended == window)
+    }
+
+    @Test("repeated extendForward fills toward the last chapter then stops")
+    func repeatedExtendForwardFillsToEnd() throws {
+        var window = try #require(EPUBSpineWindow.initial(anchor: 0, spineCount: 3))
+        window = window.extendForward() // 0...1
+        window = window.extendForward() // 0...2
+        window = window.extendForward() // clamp, still 0...2
+        #expect(window.lo == 0)
+        #expect(window.hi == 2)
+        #expect(window.canExtendForward == false)
+    }
+
+    // MARK: - contains
+
+    @Test("contains reports membership across lo...hi")
+    func containsReportsMembership() throws {
+        var window = try #require(EPUBSpineWindow.initial(anchor: 5, spineCount: 10))
+        window = window.extendForward().extendBackward() // 4...6
+        #expect(window.contains(4))
+        #expect(window.contains(5))
+        #expect(window.contains(6))
+        #expect(window.contains(3) == false)
+        #expect(window.contains(7) == false)
+    }
+
+    // MARK: - evictFarFromAnchor(maxSpan:)
+
+    @Test("eviction is a no-op when span is within maxSpan")
+    func evictNoOpWithinMaxSpan() throws {
+        var window = try #require(EPUBSpineWindow.initial(anchor: 5, spineCount: 20))
+        window = window.extendForward().extendBackward() // 4...6, span 3
+        let evicted = window.evictFarFromAnchor(maxSpan: 3)
+        #expect(evicted == window)
+    }
+
+    @Test("eviction trims the end farther from the anchor first")
+    func evictTrimsFarEndFirst() throws {
+        // Anchor 6, window 4...8 (span 5). Anchor is 2 from lo, 2 from hi —
+        // symmetric. Extend forward once more: 4...9 (span 6), anchor 6 is
+        // 2 from lo(4), 3 from hi(9): hi is farther, so eviction trims hi.
+        var window = try #require(EPUBSpineWindow.initial(anchor: 6, spineCount: 20))
+        window = window.extendBackward().extendBackward() // 4...6
+            .extendForward().extendForward().extendForward() // 4...9
+        #expect(window.lo == 4 && window.hi == 9) // span 6
+        let evicted = window.evictFarFromAnchor(maxSpan: 5)
+        #expect(evicted.hi == 8) // far end (hi) trimmed
+        #expect(evicted.lo == 4)
+        #expect(evicted.contains(6)) // anchor stays inside
+    }
+
+    @Test("eviction keeps the anchor inside the window")
+    func evictKeepsAnchorInside() throws {
+        // Build a wide window anchored near lo so eviction must trim hi
+        // repeatedly without ever dropping the anchor.
+        var window = try #require(EPUBSpineWindow.initial(anchor: 1, spineCount: 30))
+        for _ in 0..<10 { window = window.extendForward() } // 1...11
+        let evicted = window.evictFarFromAnchor(maxSpan: 3)
+        #expect(evicted.contains(1))
+        #expect(evicted.hi - evicted.lo + 1 <= 3)
+        #expect(evicted.anchor == 1)
+    }
+
+    @Test("eviction trims lo when the anchor sits near hi")
+    func evictTrimsLoWhenAnchorNearHi() throws {
+        var window = try #require(EPUBSpineWindow.initial(anchor: 11, spineCount: 30))
+        for _ in 0..<10 { window = window.extendBackward() } // 1...11, anchor 11
+        let evicted = window.evictFarFromAnchor(maxSpan: 3)
+        #expect(evicted.contains(11))
+        #expect(evicted.hi == 11)
+        #expect(evicted.hi - evicted.lo + 1 <= 3)
+    }
+
+    @Test("eviction with maxSpan 1 collapses to the anchor")
+    func evictMaxSpanOneCollapsesToAnchor() throws {
+        var window = try #require(EPUBSpineWindow.initial(anchor: 4, spineCount: 10))
+        window = window.extendForward().extendBackward() // 3...5
+        let evicted = window.evictFarFromAnchor(maxSpan: 1)
+        #expect(evicted.lo == 4)
+        #expect(evicted.hi == 4)
+        #expect(evicted.anchor == 4)
+    }
+
+    @Test("symmetric window evicting by one trims hi (ties favor the start)")
+    func evictSymmetricTieTrimsHi() throws {
+        // Anchor 4, window 3...5 (span 3), anchor equidistant from both ends.
+        // Reducing maxSpan to 2 forces exactly one trim; the `>=` tie-break
+        // trims hi → 3...4. Pins the tie-break policy so a `>=`→`>` regression
+        // is caught (a `>` would trim lo → 4...5 instead).
+        var window = try #require(EPUBSpineWindow.initial(anchor: 4, spineCount: 10))
+        window = window.extendForward().extendBackward() // 3...5
+        let evicted = window.evictFarFromAnchor(maxSpan: 2)
+        #expect(evicted.lo == 3)
+        #expect(evicted.hi == 4)
+        #expect(evicted.anchor == 4)
+    }
+
+    // MARK: - Equatable
+
+    @Test("equality is full-state (same lo/hi/anchor and spineCount)")
+    func equatable() throws {
+        let a = try #require(EPUBSpineWindow.initial(anchor: 2, spineCount: 10)).extendForward()
+        let b = try #require(EPUBSpineWindow.initial(anchor: 2, spineCount: 10)).extendForward()
+        #expect(a == b)
+    }
+
+    @Test("windows with the same visible range but different spineCount are unequal")
+    func equatableIncludesSpineCount() throws {
+        // spineCount is load-bearing — it changes future canExtendForward /
+        // edge-clamp behavior — so two windows with identical lo/hi/anchor
+        // but different spineCount are intentionally NOT equal.
+        let a = try #require(EPUBSpineWindow.initial(anchor: 2, spineCount: 10))
+        let b = try #require(EPUBSpineWindow.initial(anchor: 2, spineCount: 20))
+        #expect(a != b)
+    }
+}


### PR DESCRIPTION
## Summary

Foundational first WI of feature #71 (EPUB scroll-mode continuous cross-chapter scroll). Adds `EPUBSpineWindow` — a pure value type modeling the contiguous range of EPUB spine items (chapters) materialized in the continuous-scroll WKWebView document, with the window materialize / extend / evict policy as testable integer-range arithmetic (no UIKit, no I/O, no WKWebView).

Part of feature #1150.

## What Changed

- `vreader/Views/Reader/EPUBSpineWindow.swift` (new) — non-empty invariant `0 <= lo <= anchor <= hi < spineCount`; `initial(anchor:spineCount:) -> EPUBSpineWindow?` (nil for empty books, clamps anchor); `extendForward`/`extendBackward` (clamp at edges); `evictFarFromAnchor(maxSpan:)` (trims the far end from the anchor first, never drops the anchor, terminates for all anchor positions); `contains`; `canExtendForward`/`canExtendBackward`.
- `vreaderTests/Views/Reader/EPUBSpineWindowTests.swift` (new) — 20 Swift Testing cases covering edges, eviction tie-break, full-state Equatable.
- `vreader.xcodeproj/project.pbxproj` — xcodegen registration.

## WI Status

- WI-1: **foundational** — this PR (pure type; no user-observable behavior → unit + audit sufficient per Gate 5).
- Remaining: WI-2 (`EPUBChapterBodyRewriter`), WI-3 (`EPUBContinuousScrollJS`), WI-4 (coordinator), WI-5 (bridge plumbing), WI-6 (container integration), WI-7 (bilingual section-scoping), WI-8 (final integration + acceptance).

## Codex Audit (Gate 4)

Thread `019e5fac`, 2 rounds, verdict **ship-as-is**. Zero Critical/High/Medium; 3 Low all fixed (collapsed an unreachable eviction branch, pinned the `>=` tie-break with a symmetric-window test, pinned full-state Equatable). Audit log: `.claude/codex-audits/feat-feature-71-wi-1-spine-window-audit.md`.

## Validation

- [x] `xcodebuild test -only-testing:vreaderTests` passes — **445 tests, 0 failures** (incl. all 20 EPUBSpineWindow cases). Note: xcodebuild stalled in post-test result-bundle teardown after reporting `vreaderTests.xctest passed`; a PID-keyed watchdog reaped the teardown stall — the test outcome itself is a clean pass.
- [x] Tests cover changed behavior (TDD: RED → GREEN → REFACTOR)
- [x] Codex audit loop completed (2 rounds, verdict: ship-as-is)
- [x] Docs sync — n/a (pure value type; no new service / @Model / notification / cross-feature pattern; architecture.md update lands in WI-8)
- [x] Version bumped: 3.39.10 → 3.39.11 (patch — foundational WI)

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: **foundational** (DTO/pure type, no user-observable behavior) — unit tests + Gate-4 audit sufficient; no device verification required.

## Type of Change

- [x] Feature WI (Part of feature #1150 — intermediate WI, plain prose to avoid tripping the open-feature merge gate)