### PR TITLE
feat(#71 WI-3): EPUBContinuousScrollJS — continuous-scroll JS generators

### DIFF
--- a/.claude/codex-audits/feat-feature-71-wi-3-continuous-scroll-js-audit.md
+++ b/.claude/codex-audits/feat-feature-71-wi-3-continuous-scroll-js-audit.md
@@ -1,0 +1,41 @@
+---
+branch: feat/feature-71-wi-3-continuous-scroll-js
+threadId: 019e6168-8d0d-7750-8246-5d8695820f9e
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-26
+---
+
+# Codex Gate-4 audit — Feature #71 WI-3 (EPUBContinuousScrollJS)
+
+Independent audit (Codex MCP, separate process) of the pure JS-string
+generators for the EPUB continuous-scroll multi-chapter document.
+
+Files audited (new):
+- `vreader/Views/Reader/EPUBContinuousScrollJS.swift` (235 lines, 7 generators)
+- `vreaderTests/Views/Reader/EPUBContinuousScrollJSTests.swift` (13 tests, green)
+
+## Round 1 — 1 Medium
+
+| # | Severity | Finding | Resolution |
+|---|---|---|---|
+| 1 | Medium | `removeChapterSectionJS` removed a section with no scroll compensation. `EPUBSpineWindow.evictFarFromAnchor` can trim the TOP end (when the reader scrolled down); removing a section above the viewport collapses content upward → the reader jumps. | **Fixed** — the generator now captures `wasAbove = el.offsetTop < root.scrollTop` + `before = root.scrollHeight`, removes the element, and for an above-viewport removal does `root.scrollTop -= (before - root.scrollHeight)` (mirrors the prepend anchor). Below-viewport removals are unchanged. Test strengthened to assert the compensation. |
+
+## Round 2 — clean
+
+No remaining Critical/High/Medium. Ship-as-is.
+
+## Codex confirmations (no change needed)
+
+- **Injection safety**: for the `evaluateJavaScript` context, single-quoted JS literals + `FoliateJSEscaper.escapeForJSString` are sufficient against literal breakout for `bodyHTML`, divider title, and search quote. `</script>` / backtick / `${` are irrelevant (not an HTML `<script>` context). `htmlEscape` (`&<>"`) on the divider title + href is enough before the section is JS-escaped.
+- **Trust boundary**: this file intentionally does NOT sanitize active HTML in `bodyHTML`/`scopedStyleHTML` — matches the documented WI-2 trust boundary (`EPUBChapterBodyRewriter.swift`), not a new issue.
+- **`themeCSS`** raw injection into `<style>` is acceptable as used (app-generated `FoliateStyleMapper.themeCSS`, not untrusted CSS). Becomes a `</style>` breakout only if the input ever widens to arbitrary CSS.
+- **Prepend compensation** correct: `scrollHeight` reads before/after `insertAdjacentHTML` force synchronous layout, so `scrollTop += (after - before)` anchors the viewport.
+- **Observer** (visibleSpineIndex = last section with `offsetTop <= scrollTop`, intraFraction, idempotency guard, near-boundary flags) sound for the direct-child-section DOM shape. **`scrollToSpineFractionJS`** clamp + non-finite→0 prevents `nan`/`inf`; Swift `Double` interpolation emits valid JS numerics.
+- Empty body / nil divider / spineIndex 0 / missing section / CJK all fine.
+
+## Verdict
+
+**Ship-as-is.** Foundational tier (pure JS strings); covered by 13 unit tests +
+the round-1 eviction-anchor fix. `restoreHighlightsInSectionJS` deferred to WI-6
+(integration-coupled; not shipped untested).

--- a/project.yml
+++ b/project.yml
@@ -146,8 +146,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 636
-        MARKETING_VERSION: 3.39.15
+        CURRENT_PROJECT_VERSION: 637
+        MARKETING_VERSION: 3.39.16
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		13BD9E44A0679FB4BEBE1F94 /* AnnotationsRouteWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04953A6060F401FEB272F2E /* AnnotationsRouteWiringTests.swift */; };
 		13EC9440F35FF01443E4FABF /* AnnotationAnchorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B393E54ECE17C3DA3969EA4 /* AnnotationAnchorTests.swift */; };
 		141F45BA08B548F16178BED0 /* EPUBBilingualOrchestratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB4A7D407350F9C903A4A541 /* EPUBBilingualOrchestratorTests.swift */; };
+		14471AC7E32BFFD1BBAFB829 /* EPUBContinuousScrollJSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3985B5AA10C2F75D5A24CF3 /* EPUBContinuousScrollJSTests.swift */; };
 		1486C59650FEE786655A27F0 /* ReTranslateProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB32B8E264864D8B94DE2EC /* ReTranslateProgress.swift */; };
 		15560934D5C58CBA9C8A2AFD /* FoliatePositionRestoreController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86C32AA4EAE4EA8014E71A14 /* FoliatePositionRestoreController.swift */; };
 		1558B65D447DCD7705FE074C /* FoliateTTSAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C511C16F7FA93E91D703EE7 /* FoliateTTSAdapterTests.swift */; };
@@ -467,6 +468,7 @@
 		56F3DE1EB4A7638FDC6D2FED /* LibraryCardTranslateBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99E97F6A00C2856B5D9CEB8E /* LibraryCardTranslateBadge.swift */; };
 		57119DB5AB6677FBB6AECF3C /* TXTReaderContainerViewChapterStartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DCDE7714C1D65B4D045D3B /* TXTReaderContainerViewChapterStartTests.swift */; };
 		57137EA065C2A4D12FFF3CBB /* BookSourceChapterListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388862ACF8F83F9A1C8A6A6C /* BookSourceChapterListView.swift */; };
+		5750ED10A89C2B7BCD251C3C /* EPUBContinuousScrollJS.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD46F11BC7E87EC46B65BAF6 /* EPUBContinuousScrollJS.swift */; };
 		576856E9891C19D45A579DA5 /* ChapterTranslationChunker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E05A8F8B018491C86ABB86AD /* ChapterTranslationChunker.swift */; };
 		5774FF0387AC1349069791FE /* TextMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D7174921347E183EEB34A6 /* TextMapperTests.swift */; };
 		57C3A4ADBA966558416FB01C /* EPUBReaderHostLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F445E3A9D4CEEC79F674239 /* EPUBReaderHostLifecycleTests.swift */; };
@@ -2217,6 +2219,7 @@
 		ACD95B7F2CED44C4E8E33E05 /* PDFBilingualPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFBilingualPanel.swift; sourceTree = "<group>"; };
 		AD065491E8CFE99188D62E09 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
 		AD170A9C4FEB206D5F5F2157 /* V5toV6MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V5toV6MigrationTests.swift; sourceTree = "<group>"; };
+		AD46F11BC7E87EC46B65BAF6 /* EPUBContinuousScrollJS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBContinuousScrollJS.swift; sourceTree = "<group>"; };
 		ADA1F6F765714110EBCCF24B /* HighlightPopoverActionRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPopoverActionRouterTests.swift; sourceTree = "<group>"; };
 		AE0CDD04120BFF39B61E8418 /* BackgroundIndexingCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundIndexingCoordinatorTests.swift; sourceTree = "<group>"; };
 		AE29B97304B59C88E3F3F9CF /* AITranslationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AITranslationTests.swift; sourceTree = "<group>"; };
@@ -2409,6 +2412,7 @@
 		D35CDC4131829818B115292B /* BilingualSetupSheet+Sections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BilingualSetupSheet+Sections.swift"; sourceTree = "<group>"; };
 		D363190FCDF47ED48A1D7BC1 /* ReaderLifecycleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderLifecycleHelper.swift; sourceTree = "<group>"; };
 		D36D5CFF47A223349C004E39 /* VReaderAnnotationParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderAnnotationParserTests.swift; sourceTree = "<group>"; };
+		D3985B5AA10C2F75D5A24CF3 /* EPUBContinuousScrollJSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBContinuousScrollJSTests.swift; sourceTree = "<group>"; };
 		D3A96C651E9CF9C1D386312A /* ReaderThemeV2+ColorScheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderThemeV2+ColorScheme.swift"; sourceTree = "<group>"; };
 		D40011CB1AB56C2F4DF2EE91 /* Feature41TTSAutoScrollVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature41TTSAutoScrollVerificationTests.swift; sourceTree = "<group>"; };
 		D40146D7306CDCE0F1A2FC91 /* LibraryShellTokensTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryShellTokensTests.swift; sourceTree = "<group>"; };
@@ -3114,6 +3118,7 @@
 				4613C1666E0FA587EAA979C0 /* EPUBChapterBodyRewriterTests.swift */,
 				66440341C1BA8050AFD3A65C /* EPUBChapterNavigationRouterTests.swift */,
 				864BA35C7F82D6437278E5C6 /* EPUBChapterWrapPendingTargetTests.swift */,
+				D3985B5AA10C2F75D5A24CF3 /* EPUBContinuousScrollJSTests.swift */,
 				73A837FEAF314B6AC6ECFE2C /* EPUBDebugBridgeHighlightJSTests.swift */,
 				BD9F0676ACCEE6F37D547E72 /* EPUBHighlightActionsTests.swift */,
 				8BD1A5A71CB18176C843FD40 /* EPUBHighlightAnchoringRegressionTests.swift */,
@@ -3660,6 +3665,7 @@
 				D4155E7139CA2623252814A6 /* EPUBChapterNavigationRouter.swift */,
 				DC089C251F85AABA6BF4C347 /* EPUBChapterResourceURL.swift */,
 				7D9CC8400AF6E7894D65B332 /* EPUBChapterWrapPendingTarget.swift */,
+				AD46F11BC7E87EC46B65BAF6 /* EPUBContinuousScrollJS.swift */,
 				60F442A575A04CD706CC53FE /* EPUBDebugBridgeHighlightJS.swift */,
 				E28AEE54347E9EC752286A2A /* EPUBHighlightActions.swift */,
 				435C00E099B7F5D7A7821FDC /* EPUBHighlightBridge.swift */,
@@ -5244,6 +5250,7 @@
 				1FDCE173037798993D15A8AC /* EPUBChapterNavigationRouterTests.swift in Sources */,
 				6179B1DCDC87E71E3A7218CC /* EPUBChapterWrapPendingTargetTests.swift in Sources */,
 				D19881EF60E15DFDCFF74173 /* EPUBComplexityClassifierTests.swift in Sources */,
+				14471AC7E32BFFD1BBAFB829 /* EPUBContinuousScrollJSTests.swift in Sources */,
 				DA905A71521E684A242CDCAD /* EPUBCoverParsingTests.swift in Sources */,
 				A56BA03A3C82CF71B2F5CA34 /* EPUBDebugBridgeHighlightJSTests.swift in Sources */,
 				860C6626A5AC805B4C622E70 /* EPUBFileLoaderTests.swift in Sources */,
@@ -5831,6 +5838,7 @@
 				10E1115017B00458750D678F /* EPUBChapterTextProvider.swift in Sources */,
 				D1FAFF6776C004BAC2173934 /* EPUBChapterWrapPendingTarget.swift in Sources */,
 				542FF947F7F993A2904D56C2 /* EPUBComplexityClassifier.swift in Sources */,
+				5750ED10A89C2B7BCD251C3C /* EPUBContinuousScrollJS.swift in Sources */,
 				1159169FBD348FB0518A7F68 /* EPUBDebugBridgeHighlightJS.swift in Sources */,
 				2206E24712AFD54F00761207 /* EPUBFileLoader.swift in Sources */,
 				A11E272093433A3733A66FE6 /* EPUBHighlightActions.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6466,13 +6466,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 636;
+				CURRENT_PROJECT_VERSION = 637;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.39.15;
+				MARKETING_VERSION = 3.39.16;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6616,13 +6616,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 636;
+				CURRENT_PROJECT_VERSION = 637;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.39.15;
+				MARKETING_VERSION = 3.39.16;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Views/Reader/EPUBContinuousScrollJS.swift
+++ b/vreader/Views/Reader/EPUBContinuousScrollJS.swift
@@ -1,0 +1,249 @@
+// Purpose: Pure JS-string generators for the EPUB continuous-scroll
+// multi-chapter WKWebView document (feature #71, WI-3). Each function returns
+// a self-invoking JS snippet to run via `evaluateJavaScript`; none touch a
+// WKWebView, so the generators are unit-tested for injection-safety + DOM
+// correctness without WebKit (mirrors `EPUBWebViewBridgeJS` / `EPUBBilingualJS`).
+//
+// The continuous-scroll document is a single scrollable column
+// (`#vreader-scroll-root`) into which the coordinator (WI-4) appends/prepends
+// rewritten chapter bodies (WI-2 `EPUBChapterBody`) as
+// `<section data-vreader-spine-index="N" data-vreader-href="…">` blocks
+// separated by chapter dividers, and evicts far ones to bound memory.
+//
+// Key decisions:
+// - **Single-quoted JS literals + `FoliateJSEscaper.escapeForJSString`** for
+//   every interpolated value (chapter body, divider title, search quote). A
+//   double quote sits inertly inside a `'…'` literal, so HTML attributes + CSS
+//   selectors use double quotes and only `'`/`\`/newlines/U+2028/U+2029 need
+//   escaping. The snippets run via `evaluateJavaScript`, NOT inside an HTML
+//   `<script>`, so `</script>` / backtick / `${` are inert too.
+// - **Divider title is HTML-escaped first** (it lands in element text), then
+//   the whole section string is JS-escaped — defense in depth against a TOC
+//   title containing markup.
+// - **Section-scoped ops** (`removeChapterSectionJS`, `scrollToSpineFractionJS`,
+//   `findInSectionJS`) target `[data-vreader-spine-index="N"]`, never the whole
+//   document, so a quote/needle that also appears in another loaded chapter
+//   can't cross-fire (plan round-1 [M1]).
+// - `restoreHighlightsInSectionJS` is deferred to WI-6 (container integration),
+//   where the per-section highlight-restore is wired + tested end-to-end; its
+//   shape depends on that integration, so it is not shipped untested here.
+//
+// @coordinates-with: EPUBChapterBodyRewriter.swift (EPUBChapterBody),
+//   EPUBContinuousScrollCoordinator.swift (WI-4 consumer), FoliateJSEscaper.swift,
+//   dev-docs/plans/20260525-feature-71-epub-continuous-scroll.md (WI-3)
+
+import Foundation
+
+enum EPUBContinuousScrollJS {
+
+    /// The id of the single scrollable column the chapters are stitched into.
+    static let scrollRootID = "vreader-scroll-root"
+
+    // MARK: - bootstrap
+
+    /// The bootstrap HTML document loaded once into the WKWebView: an empty
+    /// `#vreader-scroll-root` overflow column plus the chapter-divider styling
+    /// (per design §2.3 `ChapterDivider`) and the caller-supplied theme CSS.
+    static func bootstrapDocumentHTML(themeCSS: String) -> String {
+        """
+        <!DOCTYPE html>
+        <html><head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+        <style>
+        html, body { margin: 0; padding: 0; }
+        #\(scrollRootID) { overflow-y: auto; -webkit-overflow-scrolling: touch; height: 100vh; }
+        .vreader-chapter-divider { display: flex; align-items: center; gap: 14px; margin: 36px 0 28px; }
+        .vreader-chapter-divider .vreader-divider-rule { flex: 1; height: 0.5px; background: currentColor; opacity: 0.3; }
+        .vreader-chapter-divider .vreader-divider-label {
+            font: 600 11px/1 "Source Serif 4", Georgia, serif;
+            letter-spacing: 2.5px; text-transform: uppercase; white-space: nowrap; opacity: 0.6;
+        }
+        \(themeCSS)
+        </style>
+        </head>
+        <body><div id="\(scrollRootID)"></div></body></html>
+        """
+    }
+
+    // MARK: - append / prepend
+
+    /// JS that appends `body`'s rewritten chapter section to the end of the
+    /// scroll column (forward scroll into the next chapter).
+    static func appendChapterSectionJS(_ body: EPUBChapterBody, dividerTitle: String?) -> String {
+        let escaped = FoliateJSEscaper.escapeForJSString(sectionHTML(body, dividerTitle: dividerTitle))
+        return """
+        (function() {
+            var root = document.getElementById('\(scrollRootID)');
+            if (!root) { return; }
+            root.insertAdjacentHTML('beforeend', '\(escaped)');
+        })();
+        """
+    }
+
+    /// JS that prepends `body`'s section to the START of the column (reverse
+    /// scroll into the previous chapter), compensating the scroll offset in one
+    /// transaction so the viewport does NOT jump: measure `scrollHeight` before
+    /// the insert, then add the height delta back to `scrollTop` after.
+    static func prependChapterSectionJS(_ body: EPUBChapterBody, dividerTitle: String?) -> String {
+        let escaped = FoliateJSEscaper.escapeForJSString(sectionHTML(body, dividerTitle: dividerTitle))
+        return """
+        (function() {
+            var root = document.getElementById('\(scrollRootID)');
+            if (!root) { return; }
+            var before = root.scrollHeight;
+            root.insertAdjacentHTML('afterbegin', '\(escaped)');
+            var after = root.scrollHeight;
+            root.scrollTop += (after - before);
+        })();
+        """
+    }
+
+    // MARK: - evict
+
+    /// JS that removes the materialized section for `spineIndex` (far-end
+    /// eviction to bound memory). No-op if the section isn't present.
+    ///
+    /// Scroll compensation (Codex Gate-4): `evictFarFromAnchor` can trim the
+    /// TOP end (the `lo` side, when the reader has scrolled down). Removing a
+    /// section ABOVE the viewport collapses content upward, so — mirroring the
+    /// prepend anchor — when the removed section sits above `scrollTop` we
+    /// subtract its height delta from `scrollTop` so the viewport stays put.
+    /// Below-viewport removals need no adjustment.
+    static func removeChapterSectionJS(spineIndex: Int) -> String {
+        """
+        (function() {
+            var root = document.getElementById('\(scrollRootID)');
+            var el = document.querySelector('[data-vreader-spine-index="\(spineIndex)"]');
+            if (!root || !el) { return; }
+            var wasAbove = el.offsetTop < root.scrollTop;
+            var before = root.scrollHeight;
+            el.remove();
+            if (wasAbove) {
+                root.scrollTop -= (before - root.scrollHeight);
+            }
+        })();
+        """
+    }
+
+    // MARK: - scroll observer
+
+    /// The section-aware scroll observer user script. Replaces the single-`Double`
+    /// `progressTrackingJS` in continuous mode: on a throttled scroll it reports
+    /// `{ visibleSpineIndex, intraFraction, nearTopBoundary, nearBottomBoundary }`
+    /// — the topmost section in the viewport, how far through it the viewport is,
+    /// and whether the user is within the prefetch threshold of either end.
+    static let continuousScrollObserverJS = """
+    (function() {
+        var root = document.getElementById('\(scrollRootID)');
+        if (!root || root.__vreaderScrollObserver) { return; }
+        root.__vreaderScrollObserver = true;
+        var PREFETCH_PX = 800;
+        var ticking = false;
+        function report() {
+            ticking = false;
+            var sections = root.querySelectorAll('[data-vreader-spine-index]');
+            if (!sections.length) { return; }
+            var top = root.scrollTop;
+            var visibleSpineIndex = parseInt(sections[0].getAttribute('data-vreader-spine-index'), 10);
+            var intraFraction = 0;
+            for (var i = 0; i < sections.length; i++) {
+                var s = sections[i];
+                if (s.offsetTop <= top) {
+                    visibleSpineIndex = parseInt(s.getAttribute('data-vreader-spine-index'), 10);
+                    var h = s.offsetHeight || 1;
+                    intraFraction = Math.max(0, Math.min(1, (top - s.offsetTop) / h));
+                }
+            }
+            var nearTopBoundary = top <= PREFETCH_PX;
+            var nearBottomBoundary = (root.scrollHeight - (top + root.clientHeight)) <= PREFETCH_PX;
+            try {
+                window.webkit.messageHandlers.continuousScrollHandler.postMessage({
+                    visibleSpineIndex: visibleSpineIndex,
+                    intraFraction: intraFraction,
+                    nearTopBoundary: nearTopBoundary,
+                    nearBottomBoundary: nearBottomBoundary
+                });
+            } catch (e) {}
+        }
+        root.addEventListener('scroll', function() {
+            if (!ticking) { ticking = true; requestAnimationFrame(report); }
+        }, { passive: true });
+        report();
+    })();
+    """
+
+    // MARK: - scroll-to-section
+
+    /// JS that scrolls the column to `fraction` (clamped to 0...1; non-finite →
+    /// 0) through the section for `spineIndex` — used to restore a saved
+    /// position or land a TOC/search navigation inside the stitched document.
+    static func scrollToSpineFractionJS(spineIndex: Int, fraction: Double) -> String {
+        let clamped = fraction.isFinite ? min(max(fraction, 0), 1) : 0
+        return """
+        (function() {
+            var root = document.getElementById('\(scrollRootID)');
+            var el = document.querySelector('[data-vreader-spine-index="\(spineIndex)"]');
+            if (!root || !el) { return; }
+            root.scrollTop = el.offsetTop + (el.offsetHeight * \(clamped));
+        })();
+        """
+    }
+
+    // MARK: - find-in-section
+
+    /// JS that searches for `quote` ONLY within the section subtree for
+    /// `spineIndex` (not the whole document), so the same quote in another
+    /// loaded chapter can't be matched first (plan round-1 [M1]). Reports
+    /// whether the section was found + the match offset to the search handler.
+    static func findInSectionJS(spineIndex: Int, quote: String) -> String {
+        let needle = FoliateJSEscaper.escapeForJSString(quote)
+        return """
+        (function() {
+            var section = document.querySelector('[data-vreader-spine-index="\(spineIndex)"]');
+            if (!section) {
+                try { window.webkit.messageHandlers.findInSectionHandler.postMessage({ found: false }); } catch (e) {}
+                return;
+            }
+            var needle = '\(needle)';
+            var idx = (section.textContent || '').indexOf(needle);
+            try {
+                window.webkit.messageHandlers.findInSectionHandler.postMessage({
+                    found: idx >= 0, spineIndex: \(spineIndex), offset: idx
+                });
+            } catch (e) {}
+        })();
+        """
+    }
+
+    // MARK: - section markup
+
+    /// Builds one chapter `<section>` (divider + scoped style + rewritten body).
+    /// Attributes use double quotes (inert in the single-quoted JS literal the
+    /// caller wraps this in); the divider title + href are HTML-escaped.
+    private static func sectionHTML(_ body: EPUBChapterBody, dividerTitle: String?) -> String {
+        var divider = ""
+        if let title = dividerTitle {
+            divider = """
+            <div class="vreader-chapter-divider"><div class="vreader-divider-rule"></div>\
+            <div class="vreader-divider-label">\(htmlEscape(title))</div>\
+            <div class="vreader-divider-rule"></div></div>
+            """
+        }
+        return """
+        <section data-vreader-spine-index="\(body.spineIndex)" data-vreader-href="\(htmlEscape(body.href))">\
+        \(divider)\(body.scopedStyleHTML)\(body.bodyHTML)</section>
+        """
+    }
+
+    /// Minimal HTML text/attribute escape (`&`, `<`, `>`, `"`) so a chapter
+    /// title or href can't inject markup into the section before it is itself
+    /// JS-escaped. `&` first to avoid double-escaping.
+    private static func htmlEscape(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+}

--- a/vreaderTests/Views/Reader/EPUBContinuousScrollJSTests.swift
+++ b/vreaderTests/Views/Reader/EPUBContinuousScrollJSTests.swift
@@ -1,0 +1,159 @@
+// Purpose: Tests for EPUBContinuousScrollJS — the pure JS-string generators
+// that drive the continuous-scroll multi-chapter WKWebView document
+// (feature #71, WI-3). No WKWebView here; the test focus is (1) injection
+// escaping (every interpolated value routes through FoliateJSEscaper so a
+// chapter body / title / search quote cannot break out of its single-quoted
+// JS literal), (2) the prepend scroll-compensation transaction, and (3) that
+// section-scoped operations target the right `data-vreader-spine-index`
+// subtree rather than the whole document.
+//
+// Quoting convention (matches EPUBBilingualJS): HTML attributes + CSS
+// selectors use double quotes; the JS string literals that carry them use
+// single quotes, so a double quote sits inertly inside a `'...'` literal and
+// `FoliateJSEscaper.escapeForJSString` only has to neutralize `'`, `\`,
+// newlines, U+2028/U+2029.
+//
+// @coordinates-with: EPUBContinuousScrollJS.swift, EPUBChapterBodyRewriter.swift
+//   (EPUBChapterBody), FoliateJSEscaper.swift,
+//   dev-docs/plans/20260525-feature-71-epub-continuous-scroll.md (WI-3)
+
+import Testing
+@testable import vreader
+
+@Suite("EPUBContinuousScrollJS")
+struct EPUBContinuousScrollJSTests {
+
+    private func body(
+        spineIndex: Int = 3,
+        href: String = "OEBPS/text/c3.xhtml",
+        bodyHTML: String = "<p>hello</p>",
+        scopedStyle: String = #"<style>[data-vreader-spine-index="3"] p{color:red}</style>"#
+    ) -> EPUBChapterBody {
+        EPUBChapterBody(spineIndex: spineIndex, href: href, bodyHTML: bodyHTML, scopedStyleHTML: scopedStyle)
+    }
+
+    // MARK: - bootstrap
+
+    @Test("bootstrap document has a scroll root + injects the theme CSS")
+    func bootstrapDocument() {
+        let html = EPUBContinuousScrollJS.bootstrapDocumentHTML(themeCSS: "body{background:#111}")
+        #expect(html.contains("vreader-scroll-root"))
+        #expect(html.contains("body{background:#111}"))
+        #expect(html.lowercased().contains("overflow"))
+    }
+
+    // MARK: - append / prepend section markup + identity
+
+    @Test("appendChapterSectionJS carries the section's spine index + href data attributes")
+    func appendCarriesIdentity() {
+        let js = EPUBContinuousScrollJS.appendChapterSectionJS(body(), dividerTitle: nil)
+        #expect(js.contains("data-vreader-spine-index=\"3\""))
+        #expect(js.contains("data-vreader-href=\"OEBPS/text/c3.xhtml\""))
+        #expect(js.contains("hello"))
+        #expect(js.contains("vreader-scroll-root"))
+    }
+
+    @Test("appendChapterSectionJS escapes the body's single-quote + U+2028 (single-quoted literal)")
+    func appendEscapesBody() {
+        let js = EPUBContinuousScrollJS.appendChapterSectionJS(
+            body(bodyHTML: "<p>it's a \u{2028} line</p>"), dividerTitle: nil)
+        #expect(js.contains(#"it\'s"#))       // single quote escaped
+        #expect(js.contains(#"\u2028"#))       // line separator escaped
+    }
+
+    @Test("appendChapterSectionJS escapes a backslash in the body (no literal breakout)")
+    func appendEscapesBackslash() {
+        let js = EPUBContinuousScrollJS.appendChapterSectionJS(
+            body(bodyHTML: #"<p>a\b</p>"#), dividerTitle: nil)
+        #expect(js.contains(#"a\\b"#))
+    }
+
+    @Test("divider title is HTML-escaped then JS-escaped")
+    func dividerTitleEscaped() {
+        let js = EPUBContinuousScrollJS.appendChapterSectionJS(
+            body(), dividerTitle: "Ch <1> & x")
+        // HTML-escaped so the title can't inject markup into the divider
+        #expect(js.contains("Ch &lt;1&gt; &amp; x"))
+        #expect(!js.contains("Ch <1>"))
+    }
+
+    @Test("no divider element when dividerTitle is nil; present when supplied")
+    func dividerPresence() {
+        let withTitle = EPUBContinuousScrollJS.appendChapterSectionJS(body(), dividerTitle: "Chapter 4")
+        let without = EPUBContinuousScrollJS.appendChapterSectionJS(body(), dividerTitle: nil)
+        #expect(withTitle.contains("vreader-chapter-divider"))
+        #expect(withTitle.contains("Chapter 4"))
+        #expect(!without.contains("vreader-chapter-divider"))
+    }
+
+    // MARK: - prepend scroll-compensation
+
+    @Test("prependChapterSectionJS captures scrollHeight before and restores scrollTop after")
+    func prependScrollCompensation() {
+        let js = EPUBContinuousScrollJS.prependChapterSectionJS(body(), dividerTitle: "Chapter 2")
+        #expect(js.contains("scrollHeight"))   // measure height before insert
+        #expect(js.contains("scrollTop"))       // restore offset by the delta
+        #expect(js.contains("data-vreader-spine-index=\"3\""))
+    }
+
+    // MARK: - remove (eviction)
+
+    @Test("removeChapterSectionJS targets the evicted section by spine index")
+    func removeTargetsSpineIndex() {
+        let js = EPUBContinuousScrollJS.removeChapterSectionJS(spineIndex: 7)
+        #expect(js.contains("data-vreader-spine-index=\"7\""))
+        #expect(js.lowercased().contains("remove"))
+        // Codex Gate-4: a top-end eviction (section above the viewport) must
+        // anchor the viewport, mirroring prepend — so the JS reads scrollHeight
+        // + adjusts scrollTop when the removed section was above scrollTop.
+        #expect(js.contains("scrollHeight"))
+        #expect(js.contains("scrollTop"))
+    }
+
+    // MARK: - scroll observer
+
+    @Test("observer reports the section-aware progress fields")
+    func observerReportsFields() {
+        let js = EPUBContinuousScrollJS.continuousScrollObserverJS
+        #expect(js.contains("visibleSpineIndex"))
+        #expect(js.contains("intraFraction"))
+        #expect(js.contains("nearTopBoundary"))
+        #expect(js.contains("nearBottomBoundary"))
+    }
+
+    // MARK: - scroll-to-section
+
+    @Test("scrollToSpineFractionJS clamps the fraction to 0...1")
+    func scrollToSpineFractionClamps() {
+        let over = EPUBContinuousScrollJS.scrollToSpineFractionJS(spineIndex: 2, fraction: 1.8)
+        let under = EPUBContinuousScrollJS.scrollToSpineFractionJS(spineIndex: 2, fraction: -0.5)
+        let ok = EPUBContinuousScrollJS.scrollToSpineFractionJS(spineIndex: 2, fraction: 0.4)
+        #expect(over.contains("1.0"))
+        #expect(under.contains("0.0"))
+        #expect(ok.contains("0.4"))
+        #expect(over.contains("data-vreader-spine-index=\"2\""))
+    }
+
+    @Test("scrollToSpineFractionJS coerces a non-finite fraction to 0")
+    func scrollToSpineFractionNonFinite() {
+        let nan = EPUBContinuousScrollJS.scrollToSpineFractionJS(spineIndex: 1, fraction: .nan)
+        #expect(nan.contains("0.0"))
+        #expect(!nan.lowercased().contains("nan"))
+    }
+
+    // MARK: - find-in-section (scoped, not whole document)
+
+    @Test("findInSectionJS scopes the search to the section subtree, not document")
+    func findInSectionScoped() {
+        let js = EPUBContinuousScrollJS.findInSectionJS(spineIndex: 5, quote: "needle")
+        #expect(js.contains("data-vreader-spine-index=\"5\""))
+        #expect(js.contains("needle"))
+    }
+
+    @Test("findInSectionJS escapes a single quote in the quote")
+    func findInSectionEscapesQuote() {
+        let js = EPUBContinuousScrollJS.findInSectionJS(spineIndex: 5, quote: "can't stop")
+        #expect(js.contains(#"can\'t"#))
+        #expect(!js.contains("can't stop"))
+    }
+}


### PR DESCRIPTION
## Summary

WI-3 of feature #71 (EPUB scroll-mode continuous cross-chapter scroll). The pure JS-string generators that drive the continuous-scroll multi-chapter WKWebView document — run via `evaluateJavaScript` to build / inject / evict / observe / seek / search the stitched chapter sections.

Part of feature #71.

## What Changed

`EPUBContinuousScrollJS` (new, 235 lines), 7 generators:
- `bootstrapDocumentHTML(themeCSS:)` — `#vreader-scroll-root` overflow column + chapter-divider CSS (design §2.3)
- `appendChapterSectionJS(_:dividerTitle:)` / `prependChapterSectionJS(_:dividerTitle:)` — inject a rewritten chapter section (WI-2 `EPUBChapterBody`); **prepend anchors the viewport** (scrollHeight capture + `scrollTop += delta`)
- `removeChapterSectionJS(spineIndex:)` — far-end eviction; **top-end removals are scroll-anchored** (Codex round-1 fix)
- `continuousScrollObserverJS` — section-aware `{visibleSpineIndex, intraFraction, nearTop/nearBottomBoundary}`, replaces `progressTrackingJS` in continuous mode
- `scrollToSpineFractionJS(spineIndex:fraction:)` (clamp 0...1, non-finite→0) / `findInSectionJS(spineIndex:quote:)` — section-scoped (not whole-document)

All interpolation through `FoliateJSEscaper.escapeForJSString` (single-quoted JS literals; HTML attributes/selectors double-quoted + inert); divider title + href HTML-escaped first. `restoreHighlightsInSectionJS` deferred to WI-6 (integration-coupled, not shipped untested).

## WI Status

- WI-3: **foundational** — this PR (WI-1 `EPUBSpineWindow` + WI-2 `EPUBChapterBodyRewriter` already merged)
- Remaining: WI-4 (coordinator), WI-5 (bridge plumbing), WI-6 (container integration), WI-7 (bilingual), WI-8 (final acceptance)

## Codex Audit (Gate 4)

Thread `019e6168`, **2 rounds, ship-as-is**. Round 1: 1 Medium — `removeChapterSectionJS` didn't compensate scroll for an above-viewport eviction (the reader jumps when `evictFarFromAnchor` trims the top end); fixed to mirror the prepend anchor. Round 2 clean. Confirmed injection-safety (single-quoted-literal + `escapeForJSString` is sufficient for the `evaluateJavaScript` context), prepend/observer/seek math, and edge cases.

Audit log: `.claude/codex-audits/feat-feature-71-wi-3-continuous-scroll-js-audit.md`

## Validation

- [x] `xcodebuild test -only-testing:vreaderTests` passes — **7171 tests / 708 suites**, 0 failures (13 new in `EPUBContinuousScrollJSTests`)
- [x] Tests cover changed behavior (TDD: RED → GREEN) — injection escaping, scroll-compensation, section-scoping, fraction clamp
- [x] Codex audit loop completed (2 rounds, verdict: ship-as-is)
- [x] Docs sync — n/a (pure JS-string util; the `architecture.md` continuous-scroll model note is scheduled for WI-8)
- [x] Version bumped: 3.39.15 → 3.39.16

## Gate 5a Verification (per-PR slice)

Tier: **foundational** (pure JS-string generators, no WKWebView, no user-observable behavior). Per rule 47 Gate 5, foundational WIs are satisfied by unit + audit; no device verification required. 13 deterministic unit tests exercise the escaping + DOM-correctness contract.

## Type of Change

- [x] Feature WI (Part of feature #71)