### PR TITLE
feat(#71 WI-4): EPUBContinuousScrollCoordinator — window-transition decision logic

### DIFF
--- a/.claude/codex-audits/feat-feature-71-wi-4-continuous-scroll-coordinator-audit.md
+++ b/.claude/codex-audits/feat-feature-71-wi-4-continuous-scroll-coordinator-audit.md
@@ -1,0 +1,57 @@
+---
+branch: feat/feature-71-wi-4-continuous-scroll-coordinator
+threadId: 019e62b4-072d-7292-b275-f86057f56e2b
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-05-26
+---
+
+# Codex audit — Feature #71 WI-4 (EPUBContinuousScrollCoordinator)
+
+Independent Gate-4 audit (Codex MCP, separate process) of WI-4 of feature #71
+(EPUB continuous cross-chapter scroll): the `@MainActor` host-side
+window-transition coordinator.
+
+Files audited:
+- `vreader/Views/Reader/EPUBContinuousScrollCoordinator.swift` (new — WI-4 deliverable)
+- `vreader/Views/Reader/EPUBSpineWindow.swift` (added `reanchored(to:)`)
+- `vreaderTests/Views/Reader/EPUBContinuousScrollCoordinatorTests.swift` (new)
+- `vreaderTests/Views/Reader/EPUBSpineWindowTests.swift` (added `reanchored` tests)
+
+## Round 1 — 1 High + 1 Medium
+
+| # | Severity | Finding | Resolution |
+|---|---|---|---|
+| 1 | High | `handle(_:)` re-anchored the shared `window` BEFORE the in-flight guard and before any successful eval. Two consequences: (a) `window`'s anchor mutated on provider/eval failure (contract breach — "window must not advance on failure"); (b) a same-generation duplicate signal arriving mid-flight could change the anchor, and when the first task resumed, `extend*()` + `evictIfNeeded()` ran against the mutated anchor — evicting the just-appended chapter instead of the far end. | **Fixed.** In-flight guard now runs FIRST (a duplicate in-flight signal mutates nothing). Re-anchoring is now a LOCAL snapshot (`let anchored = window.reanchored(to:)`); direction/target are decided from `anchored`; the shared `window` is committed as `anchored.extendForward()/.extendBackward()` ONLY after a successful eval, then eviction runs around that committed anchor. Failed / no-op / blocked signals never mutate `window`. |
+| 2 | Medium | Tests missed the highest-risk regression: anchor mutation during a failed or in-flight materialization, and the "evict-eval-failure leaves the window un-trimmed" catalogue item. | **Fixed.** Added 3 behavior tests: `test_evaluatorThrows_anchorAlsoUnchanged` (full-state `window == original` when the signal's visible index differs from the anchor and eval throws), `test_duplicateInFlight_differentVisible_cannotChangeEvictedSide` (gated provider — a duplicate in flight carrying a different visible index cannot flip eviction to the appended side: `removed(0) && !removed(3)`), `test_evictEvalFails_leavesWindowUntrimmed` (`throwOnRemove` — append commits, trim does not). |
+
+Codex confirmed everything else sound in round 1: `EPUBSpineWindow` + its tests
+are clean, the generation re-check placement is right, `defer` is safe, and the
+eviction-index computation (`(window.lo...window.hi).filter { !trimmed.contains($0) }`)
+is correct for contiguous windows.
+
+## Round 2 — clean
+
+Codex re-read the updated files: **both findings resolved, no new issue
+introduced.** Specifically confirmed:
+- In-flight guard first → duplicate same-generation signals are a true no-op.
+- Local re-anchor + commit-only-on-success fixes the failure/no-op contract breach.
+- Committing `anchored.extend*()` is safe: under `@MainActor` the only way
+  `window` could differ by commit time is a generation-changing
+  `bumpGeneration()`/`reset(to:)`, which the post-await `generation == gen`
+  checks already catch.
+- Dropping the persistent re-anchor on no-op signals is NOT a correctness
+  problem — anchor only matters for eviction, which only runs during a
+  materialization that recomputes `anchored` from the fresh incoming signal.
+
+## Verification
+
+- Focused unit gate (UDID-pinned iPhone 17 Pro Sim, parallel off):
+  `EPUBContinuousScrollCoordinatorTests` (13 tests) + `EPUBSpineWindowTests`
+  (25 tests, incl. 5 new `reanchored`) — **0 failures**.
+
+## Verdict
+
+**Ship-as-is.** No open Critical/High/Medium after round 2. WI-4 is pure
+host-side decision logic + a pure `EPUBSpineWindow` transition; no live
+WKWebView (that is WI-5), no UI (rule 51 N/A).

--- a/project.yml
+++ b/project.yml
@@ -146,8 +146,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 639
-        MARKETING_VERSION: 3.39.18
+        CURRENT_PROJECT_VERSION: 640
+        MARKETING_VERSION: 3.39.19
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -974,6 +974,7 @@
 		BB76E4E9F07F901B637B765D /* FoliateSectionExtracting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D4531EECE31C6D46B963F9 /* FoliateSectionExtracting.swift */; };
 		BB78719479F4E97EF0274C8A /* MDReplacementRuleFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB053991F453CF13FC6E4CB9 /* MDReplacementRuleFetcher.swift */; };
 		BB796644EE14228057D77738 /* BookContentCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA7D3015199ADD4017465DC4 /* BookContentCache.swift */; };
+		BB8365401FF8C7F540E859AA /* EPUBContinuousScrollCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83B95243CB982CBD7060B74 /* EPUBContinuousScrollCoordinatorTests.swift */; };
 		BBBE35ADD567E0153A2F244D /* TXTChapterContentLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B13E64FBD9D9A3063AC677 /* TXTChapterContentLoaderTests.swift */; };
 		BBD66D4BA45254B25A30640F /* BilingualLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35ACE50FE5717CCC34553EA7 /* BilingualLanguage.swift */; };
 		BBF57D9DB0812B5253D353A5 /* AnnotationListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A980DB0017049401DAB3E93 /* AnnotationListViewModel.swift */; };
@@ -993,6 +994,7 @@
 		BDCFAEB3BDC0697448C8EF46 /* AccessibilityAuditHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB12A029D167735B92A38BA7 /* AccessibilityAuditHelper.swift */; };
 		BE476BD45B5DABF049AAC45F /* AISettingsViewModelEditorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295EA8A8C9A0188CCD2416B4 /* AISettingsViewModelEditorTests.swift */; };
 		BE69CE7675864C497ACFC999 /* NamedHighlightColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1456DD6C03CD51C24CA8CDCF /* NamedHighlightColorTests.swift */; };
+		BEA7294536FB169F4C42A94A /* EPUBContinuousScrollCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F231D5A44103A0EF99F3EAB4 /* EPUBContinuousScrollCoordinator.swift */; };
 		BF078E02438CF936C70DE746 /* SearchSheetPlaceholderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08710FD2531ABF39338B56E9 /* SearchSheetPlaceholderTests.swift */; };
 		BF7CA157DAD1516A4667641D /* TXTChunkedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02AA769AEDBC25CEA896348 /* TXTChunkedLoader.swift */; };
 		BF9767FD9DB988B04F1B27D5 /* SyncConflictResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF495D7A9D6F8F137DD42CE0 /* SyncConflictResolverTests.swift */; };
@@ -2434,6 +2436,7 @@
 		D712BAAF509AEBA3A3FB01C3 /* FoliateHighlightRestoreDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightRestoreDispatcherTests.swift; sourceTree = "<group>"; };
 		D721FA5AC22C4EBD49791B48 /* TTSHighlightCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSHighlightCoordinator.swift; sourceTree = "<group>"; };
 		D83492717235FB856C8A06ED /* TOCProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOCProviderTests.swift; sourceTree = "<group>"; };
+		D83B95243CB982CBD7060B74 /* EPUBContinuousScrollCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBContinuousScrollCoordinatorTests.swift; sourceTree = "<group>"; };
 		D8F7F0E16B5468446AE51D0C /* TXTLazyTextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTLazyTextProvider.swift; sourceTree = "<group>"; };
 		D8F93D764B3C66019C2B47A5 /* TTSTextSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSTextSourceTests.swift; sourceTree = "<group>"; };
 		D9258C4CB71408907084E12F /* FoliateSpikeThemeCSSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateSpikeThemeCSSTests.swift; sourceTree = "<group>"; };
@@ -2588,6 +2591,7 @@
 		F1B78961833B958737E550A6 /* FoliateBottomChromeLabels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateBottomChromeLabels.swift; sourceTree = "<group>"; };
 		F213D0F6EFBD7D7088AAC40D /* TXTMDProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTMDProgressTests.swift; sourceTree = "<group>"; };
 		F219E7D85B8713E9A5736E2E /* HighlightPopoverModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPopoverModeTests.swift; sourceTree = "<group>"; };
+		F231D5A44103A0EF99F3EAB4 /* EPUBContinuousScrollCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBContinuousScrollCoordinator.swift; sourceTree = "<group>"; };
 		F2EFEE7A0EC5352A0BB1A994 /* utf16be_bom.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = utf16be_bom.txt; sourceTree = "<group>"; };
 		F31762497599885BCC803B1D /* ChapterProgressCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterProgressCalculatorTests.swift; sourceTree = "<group>"; };
 		F379B3EEC02DC574C73F4323 /* SchemaV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV2.swift; sourceTree = "<group>"; };
@@ -3121,6 +3125,7 @@
 				4613C1666E0FA587EAA979C0 /* EPUBChapterBodyRewriterTests.swift */,
 				66440341C1BA8050AFD3A65C /* EPUBChapterNavigationRouterTests.swift */,
 				864BA35C7F82D6437278E5C6 /* EPUBChapterWrapPendingTargetTests.swift */,
+				D83B95243CB982CBD7060B74 /* EPUBContinuousScrollCoordinatorTests.swift */,
 				D3985B5AA10C2F75D5A24CF3 /* EPUBContinuousScrollJSTests.swift */,
 				73A837FEAF314B6AC6ECFE2C /* EPUBDebugBridgeHighlightJSTests.swift */,
 				BD9F0676ACCEE6F37D547E72 /* EPUBHighlightActionsTests.swift */,
@@ -3668,6 +3673,7 @@
 				D4155E7139CA2623252814A6 /* EPUBChapterNavigationRouter.swift */,
 				DC089C251F85AABA6BF4C347 /* EPUBChapterResourceURL.swift */,
 				7D9CC8400AF6E7894D65B332 /* EPUBChapterWrapPendingTarget.swift */,
+				F231D5A44103A0EF99F3EAB4 /* EPUBContinuousScrollCoordinator.swift */,
 				AD46F11BC7E87EC46B65BAF6 /* EPUBContinuousScrollJS.swift */,
 				60F442A575A04CD706CC53FE /* EPUBDebugBridgeHighlightJS.swift */,
 				E28AEE54347E9EC752286A2A /* EPUBHighlightActions.swift */,
@@ -5253,6 +5259,7 @@
 				1FDCE173037798993D15A8AC /* EPUBChapterNavigationRouterTests.swift in Sources */,
 				6179B1DCDC87E71E3A7218CC /* EPUBChapterWrapPendingTargetTests.swift in Sources */,
 				D19881EF60E15DFDCFF74173 /* EPUBComplexityClassifierTests.swift in Sources */,
+				BB8365401FF8C7F540E859AA /* EPUBContinuousScrollCoordinatorTests.swift in Sources */,
 				14471AC7E32BFFD1BBAFB829 /* EPUBContinuousScrollJSTests.swift in Sources */,
 				DA905A71521E684A242CDCAD /* EPUBCoverParsingTests.swift in Sources */,
 				A56BA03A3C82CF71B2F5CA34 /* EPUBDebugBridgeHighlightJSTests.swift in Sources */,
@@ -5841,6 +5848,7 @@
 				10E1115017B00458750D678F /* EPUBChapterTextProvider.swift in Sources */,
 				D1FAFF6776C004BAC2173934 /* EPUBChapterWrapPendingTarget.swift in Sources */,
 				542FF947F7F993A2904D56C2 /* EPUBComplexityClassifier.swift in Sources */,
+				BEA7294536FB169F4C42A94A /* EPUBContinuousScrollCoordinator.swift in Sources */,
 				5750ED10A89C2B7BCD251C3C /* EPUBContinuousScrollJS.swift in Sources */,
 				1159169FBD348FB0518A7F68 /* EPUBDebugBridgeHighlightJS.swift in Sources */,
 				2206E24712AFD54F00761207 /* EPUBFileLoader.swift in Sources */,
@@ -6470,13 +6478,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 639;
+				CURRENT_PROJECT_VERSION = 640;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.39.18;
+				MARKETING_VERSION = 3.39.19;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6620,13 +6628,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 639;
+				CURRENT_PROJECT_VERSION = 640;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.39.18;
+				MARKETING_VERSION = 3.39.19;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Views/Reader/EPUBContinuousScrollCoordinator.swift
+++ b/vreader/Views/Reader/EPUBContinuousScrollCoordinator.swift
@@ -1,0 +1,212 @@
+// Purpose: Host-side window-transition decision logic for the EPUB
+// continuous-scroll multi-chapter document (feature #71, WI-4). Owns the
+// current `EPUBSpineWindow` and, on each `EPUBScrollBoundarySignal` from the
+// in-page scroll observer (`EPUBContinuousScrollJS.continuousScrollObserverJS`),
+// decides whether to materialize the next/previous chapter and which far-end
+// chapters to evict — emitting the corresponding section JS through an
+// injected async-throwing evaluator. No live WKWebView here; the bridge
+// wiring lands in WI-5, so the whole policy is unit-testable with a recording
+// stub evaluator + a stub chapter-body provider.
+//
+// Key decisions (carry the Gate-2 audit findings):
+// - **Async-throwing evaluator** (`evaluate: @MainActor (String) async throws
+//   -> Void`) — round-1 [H4]: a `(String) -> Void` closure cannot observe a
+//   failed JS insert, but the policy REQUIRES "window state must not advance
+//   if the DOM insert failed". The window mutates ONLY after a successful
+//   `evaluate`.
+// - **Generation token** (`UUID`, bumped via `bumpGeneration()` /
+//   `reset(to:)` on mode-switch / reopen / book-change) — round-1 [H4]: a
+//   stale `chapterBodyProvider` task that resolves AFTER a switch is
+//   discarded (its post-await generation check fails) so it never evals or
+//   mutates the new window.
+// - **One materialization in flight per generation** — the idempotency guard:
+//   a duplicate boundary signal arriving while a fetch+append is in flight is
+//   ignored (no double-append). Tied to the generation so a post-`bump`
+//   signal is NOT blocked by the prior generation's in-flight marker.
+// - **Re-anchor to `visibleSpineIndex`** every signal (pure bookkeeping, no
+//   DOM): `EPUBSpineWindow.reanchored(to:)` moves the eviction anchor to the
+//   chapter the reader is actually in, so far-end eviction trims the chapters
+//   behind/ahead of the reader — not the freshly-appended chapter.
+//
+// @coordinates-with: EPUBSpineWindow.swift, EPUBContinuousScrollJS.swift,
+//   EPUBChapterBodyRewriter.swift (EPUBChapterBody),
+//   EPUBWebViewBridge.swift (WI-5 caller),
+//   dev-docs/plans/20260525-feature-71-epub-continuous-scroll.md (WI-4)
+
+import Foundation
+import OSLog
+
+/// The parsed boundary signal posted by the continuous-scroll observer user
+/// script. WI-5 decodes the `continuousScrollHandler` message into this;
+/// WI-4's coordinator consumes it to decide window transitions.
+struct EPUBScrollBoundarySignal: Equatable {
+    /// The topmost spine index currently in the viewport.
+    let visibleSpineIndex: Int
+    /// How far through the visible section the viewport is (0...1).
+    let intraFraction: Double
+    /// The viewport is within the prefetch threshold of the column top.
+    let nearTopBoundary: Bool
+    /// The viewport is within the prefetch threshold of the column bottom.
+    let nearBottomBoundary: Bool
+}
+
+/// `@MainActor` coordinator that turns boundary signals into materialize /
+/// evict decisions over an `EPUBSpineWindow`, emitting section JS through an
+/// async-throwing evaluator. The window mutates only after a successful eval.
+@MainActor
+final class EPUBContinuousScrollCoordinator {
+
+    private static let log = Logger(subsystem: "com.vreader.app", category: "EPUBContinuousScroll")
+
+    /// The currently-materialized chapter window. Mutated only after a
+    /// successful section eval (extend/evict) or via re-anchor bookkeeping.
+    private(set) var window: EPUBSpineWindow
+
+    /// The current generation token. A materialization captures this at start
+    /// and discards itself if it changes (mode-switch / reopen / book-change).
+    private(set) var generation = UUID()
+
+    /// The generation whose materialization is currently in flight (`nil` when
+    /// idle). Gates re-entrancy: a second signal for the SAME generation is
+    /// ignored while one is in flight, but a post-`bump` signal is not.
+    private var inFlightGeneration: UUID?
+
+    /// Max chapters kept materialized; the far-from-anchor end is evicted past
+    /// this. Starts at 5 per the plan's memory budget (tuned in WI-6/WI-8).
+    private let maxSpan: Int
+
+    /// Supplies a rewritten chapter body for a spine index (WI-2 output).
+    private let chapterBodyProvider: @MainActor (Int) async throws -> EPUBChapterBody
+
+    /// Runs a JS snippet against the document; throws on failure so the window
+    /// does not advance past a failed insert.
+    private let evaluate: @MainActor (String) async throws -> Void
+
+    /// Optional divider title for a spine index (chapter heading). `nil` ⇒ no
+    /// divider. WI-6 supplies the TOC-title lookup; WI-4 defaults to none.
+    private let dividerTitleProvider: @MainActor (Int) -> String?
+
+    init(
+        window: EPUBSpineWindow,
+        maxSpan: Int = 5,
+        chapterBodyProvider: @escaping @MainActor (Int) async throws -> EPUBChapterBody,
+        evaluate: @escaping @MainActor (String) async throws -> Void,
+        dividerTitleProvider: @escaping @MainActor (Int) -> String? = { _ in nil }
+    ) {
+        self.window = window
+        self.maxSpan = max(maxSpan, 1)
+        self.chapterBodyProvider = chapterBodyProvider
+        self.evaluate = evaluate
+        self.dividerTitleProvider = dividerTitleProvider
+    }
+
+    // MARK: - Generation control
+
+    /// Bumps the generation token so any in-flight materialization is
+    /// discarded before it can eval or mutate. Call on a live mode-switch.
+    func bumpGeneration() {
+        generation = UUID()
+    }
+
+    /// Replaces the window (e.g., a position-restore bootstrap window) and
+    /// bumps the generation so a stale in-flight task does not mutate the new
+    /// window.
+    func reset(to window: EPUBSpineWindow) {
+        self.window = window
+        bumpGeneration()
+    }
+
+    // MARK: - Signal handling
+
+    /// Processes one boundary signal: re-anchors to the visible chapter, then
+    /// — if the viewport is near a book-interior edge — materializes the
+    /// next/previous chapter and evicts the far end. A no-op at a book edge or
+    /// when no boundary is near. Re-entrant-safe: one materialization per
+    /// generation in flight.
+    func handle(_ signal: EPUBScrollBoundarySignal) async {
+        // One materialization per generation in flight (idempotency). Checked
+        // FIRST so a duplicate signal arriving mid-flight is a complete no-op —
+        // it must not mutate any shared state (incl. the eviction anchor).
+        guard inFlightGeneration != generation else { return }
+
+        // Re-anchor to the reader's visible chapter, but only as a LOCAL
+        // snapshot — `window` (shared state) is committed solely after a
+        // successful eval below, so a failed / no-op / blocked signal never
+        // mutates the window or its eviction anchor (Gate-4 round-1 High).
+        let anchored = window.reanchored(to: signal.visibleSpineIndex)
+
+        let direction: Direction
+        if signal.nearBottomBoundary, anchored.canExtendForward {
+            direction = .forward
+        } else if signal.nearTopBoundary, anchored.canExtendBackward {
+            direction = .backward
+        } else {
+            return // at a book edge, or no boundary near → nothing to do
+        }
+
+        let gen = generation
+        inFlightGeneration = gen
+        defer { if inFlightGeneration == gen { inFlightGeneration = nil } }
+
+        let targetIndex = direction == .forward ? anchored.hi + 1 : anchored.lo - 1
+
+        // 1. Fetch the rewritten chapter body (may suspend).
+        let body: EPUBChapterBody
+        do {
+            body = try await chapterBodyProvider(targetIndex)
+        } catch {
+            Self.log.error("chapterBodyProvider failed for spine \(targetIndex): \(String(describing: error), privacy: .public)")
+            return // window NOT advanced
+        }
+
+        // Discard if a switch/reopen happened while we were fetching.
+        guard generation == gen else { return }
+
+        // 2. Emit the section JS — window advances ONLY on a successful eval.
+        let title = dividerTitleProvider(targetIndex)
+        let js = direction == .forward
+            ? EPUBContinuousScrollJS.appendChapterSectionJS(body, dividerTitle: title)
+            : EPUBContinuousScrollJS.prependChapterSectionJS(body, dividerTitle: title)
+        do {
+            try await evaluate(js)
+        } catch {
+            Self.log.error("section eval failed for spine \(targetIndex): \(String(describing: error), privacy: .public)")
+            return // window NOT advanced
+        }
+
+        // Re-check after the eval await before mutating.
+        guard generation == gen else { return }
+
+        // 3. Commit the re-anchored + extended window together (only now), then
+        //    evict the far end past maxSpan around the freshly-committed anchor.
+        window = direction == .forward ? anchored.extendForward() : anchored.extendBackward()
+        await evictIfNeeded(gen: gen)
+    }
+
+    // MARK: - Eviction
+
+    /// Trims the window to `maxSpan`, emitting a remove-section JS for each
+    /// evicted spine index. If a remove eval fails the window is left
+    /// un-trimmed (a degraded, still-correct state — extra memory, not a
+    /// wrong render).
+    private func evictIfNeeded(gen: UUID) async {
+        let trimmed = window.evictFarFromAnchor(maxSpan: maxSpan)
+        guard trimmed != window else { return }
+
+        let evicted = (window.lo...window.hi).filter { !trimmed.contains($0) }
+        for index in evicted {
+            guard generation == gen else { return }
+            do {
+                try await evaluate(EPUBContinuousScrollJS.removeChapterSectionJS(spineIndex: index))
+            } catch {
+                Self.log.error("evict eval failed for spine \(index): \(String(describing: error), privacy: .public)")
+                return // leave the window un-trimmed; do not mutate on failure
+            }
+        }
+
+        guard generation == gen else { return }
+        window = trimmed
+    }
+
+    private enum Direction { case forward, backward }
+}

--- a/vreader/Views/Reader/EPUBSpineWindow.swift
+++ b/vreader/Views/Reader/EPUBSpineWindow.swift
@@ -123,4 +123,20 @@ struct EPUBSpineWindow: Equatable {
         }
         return EPUBSpineWindow(lo: newLo, hi: newHi, anchor: anchor, spineCount: spineCount)
     }
+
+    /// Returns a copy with the `anchor` moved to `newAnchor`, clamped into the
+    /// currently-materialized `lo...hi` range (the reader can only be "in" a
+    /// chapter that is materialized). The visible range (`lo`/`hi`) is
+    /// unchanged — re-anchoring is pure bookkeeping, no DOM change.
+    ///
+    /// The continuous-scroll coordinator (WI-4) re-anchors to the observer's
+    /// reported `visibleSpineIndex` on each boundary signal so that far-end
+    /// eviction trims the chapters farthest from where the reader actually is.
+    /// Without this, a fixed open-position anchor would make forward eviction
+    /// drop the freshly-appended chapter ahead of a forward-scrolling reader.
+    func reanchored(to newAnchor: Int) -> EPUBSpineWindow {
+        let clamped = min(max(newAnchor, lo), hi)
+        guard clamped != anchor else { return self }
+        return EPUBSpineWindow(lo: lo, hi: hi, anchor: clamped, spineCount: spineCount)
+    }
 }

--- a/vreaderTests/Views/Reader/EPUBContinuousScrollCoordinatorTests.swift
+++ b/vreaderTests/Views/Reader/EPUBContinuousScrollCoordinatorTests.swift
@@ -1,0 +1,358 @@
+// Purpose: Tests for EPUBContinuousScrollCoordinator — the @MainActor
+// window-transition decision logic for the EPUB continuous-scroll document
+// (feature #71, WI-4). No live WKWebView: a recording stub evaluator + a stub
+// chapter-body provider stand in for the bridge, so the whole
+// materialize / evict / generation policy is exercised here.
+//
+// Focus (the WI-4 test catalogue):
+//   - nearBottom at hi<spineCount-1 ⇒ extend forward + emit ONE append;
+//   - a duplicate signal while a materialization is IN FLIGHT does NOT
+//     double-append (idempotency, gated provider);
+//   - nearTop at lo>0 ⇒ prepend;
+//   - at the last / first chapter ⇒ no-op (no JS);
+//   - partial failure: provider throws OR evaluator throws ⇒ window does NOT
+//     advance;
+//   - stale generation: a provider task resolving after bumpGeneration() is
+//     discarded (no eval, no mutate);
+//   - eviction emits a remove JS for the trimmed spine index;
+//   - sequential forward signals advance the window consistently.
+//
+// @coordinates-with: EPUBContinuousScrollCoordinator.swift,
+//   EPUBSpineWindow.swift, EPUBContinuousScrollJS.swift,
+//   EPUBChapterBodyRewriter.swift (EPUBChapterBody)
+
+import XCTest
+@testable import vreader
+
+@MainActor
+final class EPUBContinuousScrollCoordinatorTests: XCTestCase {
+
+    // MARK: - Test doubles
+
+    /// Records the JS emitted to the (stub) WKWebView and can be told to fail.
+    @MainActor
+    private final class RecordingEvaluator {
+        private(set) var scripts: [String] = []
+        var shouldThrow = false
+        /// Throw only on a remove-section (eviction) eval — lets a test assert
+        /// the window is left un-trimmed when eviction fails after a successful
+        /// append.
+        var throwOnRemove = false
+        enum EvalError: Error { case failed }
+
+        func eval(_ js: String) async throws {
+            if shouldThrow { throw EvalError.failed }
+            if throwOnRemove, js.contains(".remove()") { throw EvalError.failed }
+            scripts.append(js)
+        }
+
+        var appendCount: Int { scripts.filter { $0.contains("beforeend") }.count }
+        var prependCount: Int { scripts.filter { $0.contains("afterbegin") }.count }
+        func appendTargets(_ index: Int) -> Bool {
+            scripts.contains { $0.contains("beforeend") && $0.contains("data-vreader-spine-index=\"\(index)\"") }
+        }
+        func removed(_ index: Int) -> Bool {
+            scripts.contains { $0.contains(".remove()") && $0.contains("data-vreader-spine-index=\"\(index)\"") }
+        }
+    }
+
+    /// A provider whose `provide(_:)` suspends until `release(with:)` is called
+    /// — lets a test pause a materialization mid-flight to drive the
+    /// idempotency + stale-generation cases deterministically.
+    @MainActor
+    private final class GatedBodyProvider {
+        private var continuation: CheckedContinuation<EPUBChapterBody, Error>?
+        let called: XCTestExpectation
+        private(set) var lastRequestedIndex: Int?
+
+        init(called: XCTestExpectation) { self.called = called }
+
+        func provide(_ index: Int) async throws -> EPUBChapterBody {
+            lastRequestedIndex = index
+            called.fulfill()
+            return try await withCheckedThrowingContinuation { self.continuation = $0 }
+        }
+
+        func release(with body: EPUBChapterBody) {
+            continuation?.resume(returning: body)
+            continuation = nil
+        }
+    }
+
+    private func body(_ index: Int) -> EPUBChapterBody {
+        EPUBChapterBody(
+            spineIndex: index,
+            href: "OEBPS/text/c\(index).xhtml",
+            bodyHTML: "<p>chapter \(index)</p>",
+            scopedStyleHTML: ""
+        )
+    }
+
+    private func signal(
+        visible: Int,
+        top: Bool = false,
+        bottom: Bool = false
+    ) -> EPUBScrollBoundarySignal {
+        EPUBScrollBoundarySignal(
+            visibleSpineIndex: visible,
+            intraFraction: 0,
+            nearTopBoundary: top,
+            nearBottomBoundary: bottom
+        )
+    }
+
+    /// Builds a coordinator with an instant (non-suspending) body provider.
+    private func makeCoordinator(
+        window: EPUBSpineWindow,
+        maxSpan: Int,
+        evaluator: RecordingEvaluator,
+        providerThrows: Bool = false
+    ) -> EPUBContinuousScrollCoordinator {
+        EPUBContinuousScrollCoordinator(
+            window: window,
+            maxSpan: maxSpan,
+            chapterBodyProvider: { [unowned self] index in
+                if providerThrows { throw RecordingEvaluator.EvalError.failed }
+                return self.body(index)
+            },
+            evaluate: { try await evaluator.eval($0) }
+        )
+    }
+
+    // MARK: - Extend forward
+
+    func test_nearBottom_extendsForward_emitsOneAppend() async throws {
+        let window = try XCTUnwrap(EPUBSpineWindow.initial(anchor: 0, spineCount: 5))
+        let evaluator = RecordingEvaluator()
+        let coord = makeCoordinator(window: window, maxSpan: 5, evaluator: evaluator)
+
+        await coord.handle(signal(visible: 0, bottom: true))
+
+        XCTAssertTrue(coord.window.contains(1), "window should have grown to include spine 1")
+        XCTAssertEqual(evaluator.appendCount, 1, "exactly one append should be emitted")
+        XCTAssertTrue(evaluator.appendTargets(1), "the append should materialize spine 1")
+        XCTAssertEqual(evaluator.prependCount, 0)
+    }
+
+    // MARK: - Extend backward
+
+    func test_nearTop_extendsBackward_emitsPrepend() async throws {
+        // Mid-book singleton window 3...3, anchor 3.
+        let window = try XCTUnwrap(EPUBSpineWindow.initial(anchor: 3, spineCount: 10))
+        let evaluator = RecordingEvaluator()
+        let coord = makeCoordinator(window: window, maxSpan: 5, evaluator: evaluator)
+
+        await coord.handle(signal(visible: 3, top: true))
+
+        XCTAssertTrue(coord.window.contains(2), "window should have grown to include spine 2")
+        XCTAssertEqual(evaluator.prependCount, 1)
+        XCTAssertEqual(evaluator.appendCount, 0)
+    }
+
+    // MARK: - Book-edge no-ops
+
+    func test_atLastChapter_nearBottom_isNoOp() async throws {
+        let window = try XCTUnwrap(EPUBSpineWindow.initial(anchor: 4, spineCount: 5)) // hi == last
+        let evaluator = RecordingEvaluator()
+        let coord = makeCoordinator(window: window, maxSpan: 5, evaluator: evaluator)
+
+        await coord.handle(signal(visible: 4, bottom: true))
+
+        XCTAssertEqual(coord.window, window, "window must not change at the last chapter")
+        XCTAssertTrue(evaluator.scripts.isEmpty, "no JS should be emitted")
+    }
+
+    func test_atFirstChapter_nearTop_isNoOp() async throws {
+        let window = try XCTUnwrap(EPUBSpineWindow.initial(anchor: 0, spineCount: 5)) // lo == 0
+        let evaluator = RecordingEvaluator()
+        let coord = makeCoordinator(window: window, maxSpan: 5, evaluator: evaluator)
+
+        await coord.handle(signal(visible: 0, top: true))
+
+        XCTAssertEqual(coord.window, window)
+        XCTAssertTrue(evaluator.scripts.isEmpty)
+    }
+
+    // MARK: - Partial failure — window must not advance
+
+    func test_evaluatorThrows_windowDoesNotAdvance() async throws {
+        let window = try XCTUnwrap(EPUBSpineWindow.initial(anchor: 0, spineCount: 5))
+        let evaluator = RecordingEvaluator()
+        evaluator.shouldThrow = true
+        let coord = makeCoordinator(window: window, maxSpan: 5, evaluator: evaluator)
+
+        await coord.handle(signal(visible: 0, bottom: true))
+
+        XCTAssertEqual(coord.window, window, "a failed eval must not advance the window")
+        XCTAssertTrue(evaluator.scripts.isEmpty)
+    }
+
+    func test_providerThrows_windowDoesNotAdvance() async throws {
+        let window = try XCTUnwrap(EPUBSpineWindow.initial(anchor: 0, spineCount: 5))
+        let evaluator = RecordingEvaluator()
+        let coord = makeCoordinator(window: window, maxSpan: 5, evaluator: evaluator, providerThrows: true)
+
+        await coord.handle(signal(visible: 0, bottom: true))
+
+        XCTAssertEqual(coord.window, window, "a failed chapter fetch must not advance the window")
+        XCTAssertTrue(evaluator.scripts.isEmpty)
+    }
+
+    // MARK: - Idempotency — duplicate signal in flight
+
+    func test_duplicateSignalWhileInFlight_doesNotDoubleAppend() async throws {
+        let window = try XCTUnwrap(EPUBSpineWindow.initial(anchor: 0, spineCount: 5))
+        let evaluator = RecordingEvaluator()
+        let providerCalled = expectation(description: "first provider call")
+        let gated = GatedBodyProvider(called: providerCalled)
+        let coord = EPUBContinuousScrollCoordinator(
+            window: window, maxSpan: 5,
+            chapterBodyProvider: { try await gated.provide($0) },
+            evaluate: { try await evaluator.eval($0) }
+        )
+
+        // First signal starts a materialization that suspends at the provider.
+        let first = Task { await coord.handle(self.signal(visible: 0, bottom: true)) }
+        await fulfillment(of: [providerCalled], timeout: 2)
+
+        // A duplicate signal arrives WHILE the first is in flight → ignored.
+        await coord.handle(signal(visible: 0, bottom: true))
+
+        // Release the first; it appends exactly once.
+        gated.release(with: body(1))
+        await first.value
+
+        XCTAssertEqual(evaluator.appendCount, 1, "an in-flight duplicate must not double-append")
+        XCTAssertTrue(coord.window.contains(1))
+    }
+
+    // MARK: - Stale generation
+
+    func test_staleGeneration_inFlightTaskDiscarded() async throws {
+        let window = try XCTUnwrap(EPUBSpineWindow.initial(anchor: 0, spineCount: 5))
+        let evaluator = RecordingEvaluator()
+        let providerCalled = expectation(description: "provider call")
+        let gated = GatedBodyProvider(called: providerCalled)
+        let coord = EPUBContinuousScrollCoordinator(
+            window: window, maxSpan: 5,
+            chapterBodyProvider: { try await gated.provide($0) },
+            evaluate: { try await evaluator.eval($0) }
+        )
+
+        let task = Task { await coord.handle(self.signal(visible: 0, bottom: true)) }
+        await fulfillment(of: [providerCalled], timeout: 2)
+
+        // A mode-switch / reopen bumps the generation while the fetch is in
+        // flight — the resolving task must discard itself.
+        coord.bumpGeneration()
+        gated.release(with: body(1))
+        await task.value
+
+        XCTAssertEqual(coord.window, window, "a stale generation must not mutate the window")
+        XCTAssertTrue(evaluator.scripts.isEmpty, "a stale generation must not emit JS")
+    }
+
+    // MARK: - Eviction
+
+    func test_eviction_emitsRemoveForTrimmedSpine() async throws {
+        // Window 0...2, anchor 2 (reader at chapter 2). maxSpan 3.
+        let window = try XCTUnwrap(EPUBSpineWindow.initial(anchor: 2, spineCount: 10))
+            .extendBackward().extendBackward() // 0...2, anchor 2
+        let evaluator = RecordingEvaluator()
+        let coord = makeCoordinator(window: window, maxSpan: 3, evaluator: evaluator)
+
+        // Reader at chapter 2 hits the bottom → append 3 → span 4 > 3 →
+        // evict the far-from-anchor (behind) chapter 0.
+        await coord.handle(signal(visible: 2, bottom: true))
+
+        XCTAssertTrue(evaluator.appendTargets(3), "spine 3 should be appended")
+        XCTAssertTrue(evaluator.removed(0), "the far-behind spine 0 should be removed")
+        XCTAssertTrue(coord.window.contains(3))
+        XCTAssertFalse(coord.window.contains(0), "evicted spine 0 should leave the window")
+    }
+
+    // MARK: - Sequential advancement
+
+    func test_sequentialForwardSignals_advanceConsistently() async throws {
+        let window = try XCTUnwrap(EPUBSpineWindow.initial(anchor: 0, spineCount: 10))
+        let evaluator = RecordingEvaluator()
+        let coord = makeCoordinator(window: window, maxSpan: 10, evaluator: evaluator) // no eviction
+
+        await coord.handle(signal(visible: 0, bottom: true)) // → +1
+        await coord.handle(signal(visible: 1, bottom: true)) // → +2
+        await coord.handle(signal(visible: 2, bottom: true)) // → +3
+
+        XCTAssertEqual(evaluator.appendCount, 3)
+        XCTAssertTrue(coord.window.contains(3))
+        XCTAssertFalse(coord.window.contains(4))
+    }
+
+    // MARK: - Gate-4 round-1: failure must not mutate the anchor
+
+    func test_evaluatorThrows_anchorAlsoUnchanged() async throws {
+        // Window 0...2, anchor 0. A signal whose visibleSpineIndex (2) differs
+        // from the current anchor must NOT move the anchor when the eval fails:
+        // the whole window (incl. anchor) is full-state equal to the original.
+        let window = try XCTUnwrap(EPUBSpineWindow.initial(anchor: 0, spineCount: 6))
+            .extendForward().extendForward() // 0...2, anchor 0
+        let evaluator = RecordingEvaluator()
+        evaluator.shouldThrow = true
+        let coord = makeCoordinator(window: window, maxSpan: 5, evaluator: evaluator)
+
+        await coord.handle(signal(visible: 2, bottom: true))
+
+        XCTAssertEqual(coord.window, window, "a failed eval must not move the eviction anchor")
+        XCTAssertTrue(evaluator.scripts.isEmpty)
+    }
+
+    func test_duplicateInFlight_differentVisible_cannotChangeEvictedSide() async throws {
+        // Window 0...2, anchor 2 (reader at chapter 2), maxSpan 3. The first
+        // signal (visible 2, bottom) will append 3 then evict the far-behind
+        // chapter 0. A duplicate arriving in flight carries visible 0 — if the
+        // guard leaked, it would re-anchor to 0 and evict the just-appended 3
+        // instead. The in-flight guard must make the duplicate a full no-op.
+        let window = try XCTUnwrap(EPUBSpineWindow.initial(anchor: 2, spineCount: 10))
+            .extendBackward().extendBackward() // 0...2, anchor 2
+        let evaluator = RecordingEvaluator()
+        let providerCalled = expectation(description: "provider call")
+        let gated = GatedBodyProvider(called: providerCalled)
+        let coord = EPUBContinuousScrollCoordinator(
+            window: window, maxSpan: 3,
+            chapterBodyProvider: { try await gated.provide($0) },
+            evaluate: { try await evaluator.eval($0) }
+        )
+
+        let first = Task { await coord.handle(self.signal(visible: 2, bottom: true)) }
+        await fulfillment(of: [providerCalled], timeout: 2)
+
+        // Duplicate in flight, DIFFERENT visible index — must be ignored.
+        await coord.handle(signal(visible: 0, bottom: true))
+
+        gated.release(with: body(3))
+        await first.value
+
+        XCTAssertTrue(evaluator.removed(0), "should evict the far-behind chapter 0 (anchor 2)")
+        XCTAssertFalse(evaluator.removed(3), "must NOT evict the freshly-appended chapter 3")
+        XCTAssertTrue(coord.window.contains(3))
+        XCTAssertFalse(coord.window.contains(0))
+    }
+
+    func test_evictEvalFails_leavesWindowUntrimmed() async throws {
+        // Append succeeds, the subsequent remove (eviction) eval throws → the
+        // window is left un-trimmed (degraded, still-correct: extra memory, not
+        // a wrong render). The just-appended chapter is retained.
+        let window = try XCTUnwrap(EPUBSpineWindow.initial(anchor: 2, spineCount: 10))
+            .extendBackward().extendBackward() // 0...2, anchor 2
+        let evaluator = RecordingEvaluator()
+        evaluator.throwOnRemove = true
+        let coord = makeCoordinator(window: window, maxSpan: 3, evaluator: evaluator)
+
+        await coord.handle(signal(visible: 2, bottom: true))
+
+        XCTAssertTrue(evaluator.appendTargets(3), "the append should have succeeded")
+        XCTAssertTrue(coord.window.contains(3), "appended chapter retained")
+        XCTAssertTrue(coord.window.contains(0), "failed eviction leaves chapter 0 in the window")
+        XCTAssertEqual(coord.window, window.reanchored(to: 2).extendForward(),
+                       "window committed the append but not the failed trim")
+    }
+}

--- a/vreaderTests/Views/Reader/EPUBSpineWindowTests.swift
+++ b/vreaderTests/Views/Reader/EPUBSpineWindowTests.swift
@@ -216,4 +216,51 @@ struct EPUBSpineWindowTests {
         let b = try #require(EPUBSpineWindow.initial(anchor: 2, spineCount: 20))
         #expect(a != b)
     }
+
+    // MARK: - reanchored(to:) (WI-4 dependency)
+
+    @Test("reanchored moves the anchor within the materialized range")
+    func reanchoredMovesAnchor() throws {
+        // Window 2...5 (anchor 2). The reader scrolls into chapter 4.
+        let window = try #require(EPUBSpineWindow.initial(anchor: 2, spineCount: 10))
+            .extendForward().extendForward().extendForward() // 2...5
+        let moved = window.reanchored(to: 4)
+        #expect(moved.anchor == 4)
+        #expect(moved.lo == 2)   // visible range unchanged
+        #expect(moved.hi == 5)
+    }
+
+    @Test("reanchored clamps a too-high target down to hi")
+    func reanchoredClampsHigh() throws {
+        let window = try #require(EPUBSpineWindow.initial(anchor: 1, spineCount: 10))
+            .extendForward() // 1...2
+        #expect(window.reanchored(to: 99).anchor == 2)
+    }
+
+    @Test("reanchored clamps a too-low target up to lo")
+    func reanchoredClampsLow() throws {
+        let window = try #require(EPUBSpineWindow.initial(anchor: 4, spineCount: 10))
+            .extendBackward() // 3...4
+        #expect(window.reanchored(to: -5).anchor == 3)
+    }
+
+    @Test("reanchored to the current anchor returns an equal window")
+    func reanchoredNoOp() throws {
+        let window = try #require(EPUBSpineWindow.initial(anchor: 3, spineCount: 10)).extendForward()
+        #expect(window.reanchored(to: 3) == window)
+    }
+
+    @Test("reanchored then evict trims the side farther from the new anchor")
+    func reanchoredThenEvictTrimsBehindReader() throws {
+        // 0...3 with anchor 0; reader has scrolled to chapter 3. Re-anchoring
+        // to 3 then evicting to span 2 must drop the chapters BEHIND the
+        // reader (0, 1), not the chapter the reader is on.
+        let window = try #require(EPUBSpineWindow.initial(anchor: 0, spineCount: 10))
+            .extendForward().extendForward().extendForward() // 0...3
+        let evicted = window.reanchored(to: 3).evictFarFromAnchor(maxSpan: 2)
+        #expect(evicted.contains(3))           // reader's chapter retained
+        #expect(evicted.contains(2))
+        #expect(evicted.contains(0) == false)  // far-behind chapter dropped
+        #expect(evicted.contains(1) == false)
+    }
 }


### PR DESCRIPTION
## Summary

WI-4 of feature #71 (EPUB continuous cross-chapter scroll): the `@MainActor` host-side coordinator that turns `EPUBScrollBoundarySignal`s into materialize/evict decisions over `EPUBSpineWindow`, emitting section JS through an injected **async-throwing** evaluator. No live WKWebView (that is WI-5) — pure decision logic, unit-tested with a recording stub evaluator + stub chapter-body provider.

Part of feature #71

## What Changed

- **New** `vreader/Views/Reader/EPUBContinuousScrollCoordinator.swift` — owns the `EPUBSpineWindow`; on each boundary signal decides extend-forward / extend-backward / no-op, fetches the chapter body, emits append/prepend JS, and evicts the far end. Key invariants:
  - window mutates **only after a successful eval** (a failed provider/eval does not advance the window);
  - a **generation token** (bumped on mode-switch/reopen via `bumpGeneration()`/`reset(to:)`) discards stale in-flight tasks;
  - **one materialization per generation in flight** (a duplicate signal mid-flight is a complete no-op);
  - re-anchors to `visibleSpineIndex` so far-end eviction trims **behind** the reader.
- **New** `EPUBScrollBoundarySignal` value type (consumed here; produced by WI-5's `continuousScrollHandler` parse).
- **Modified** `EPUBSpineWindow.swift` — added a pure `reanchored(to:)` transition (+ 5 tests).

## Codex Audit (Gate 4)

Thread `019e62b4`, **2 rounds, ship-as-is**. Round 1: 1 High (re-anchor mutated the shared `window` before commit → a duplicate in-flight signal could mis-evict the just-appended chapter) + 1 Medium (missing failure/evict tests). Both fixed: re-anchor is now a local snapshot committed only on a successful eval; 3 regression tests added. Round 2 clean. Log: `.claude/codex-audits/feat-feature-71-wi-4-continuous-scroll-coordinator-audit.md`.

## Validation

- [x] `EPUBContinuousScrollCoordinatorTests` (13 tests) + `EPUBSpineWindowTests` (25, incl. 5 new `reanchored`) — **0 failures** (UDID-pinned, `-parallel-testing-enabled NO`).
- [x] Codex Gate-4 clean (2 rounds, ship-as-is).
- [x] Version bumped 3.39.18 → 3.39.19 (patch — behavioral, non-final WI).
- [ ] **Full `vreaderTests` gate**: ran green except the *known pre-existing* `CoverLifecycleTests`/`SelectiveRestoreCoordinatorTests` parallel-execution flake (documented in Bug #207 notes). **Re-run `-parallel-testing-enabled NO` before merge** to confirm clean.

## Gate 5 (verification tier)

Foundational/behavioral **logic** WI — no user-observable behavior yet (coordinator not wired into any runtime path until WI-5). Unit + Codex audit are sufficient per rule 47's foundational tier; no device verification required for this WI.

## Type of Change

- [x] Feature WI (Part of feature #71 — intermediate WI, no `Refs`/`Fixes` per the workflow's merge-gate rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)