### PR TITLE
verify(#247): verification-exception evidence for WebDAV restore title round-trip

### DIFF
--- a/dev-docs/verification/bug-247-20260526.md
+++ b/dev-docs/verification/bug-247-20260526.md
@@ -1,0 +1,77 @@
+---
+kind: bug
+id: 247
+status_target: FIXED
+commit_sha: 781726a2c2ef221bc3d097560bbf69a0f792e4b4
+app_version: 3.39.22 (build 643)
+date: 2026-05-26
+verifier: claude
+device_or_simulator: iPhone 17 Pro Simulator
+os_version: iOS 26.4
+build_configuration: Debug
+backend: in-memory ModelContainer (SchemaV7) + BackupBlobReading stub (only the network/blob layer is stubbed)
+result: pass
+---
+
+# Bug #247 — WebDAV restore loses book titles (verification-exception close)
+
+Close-gate verification for Bug #247 (GH #1074): restored TXT/MD/PDF books
+showed `restore_<sha256>` (the content-addressed temp filename) as the title
+instead of the original book name.
+
+## Why the verification-exception path
+
+The failure mode physically cannot be reproduced on a device CU-free without a
+live WebDAV server hosting a real backup to restore from — the restore path
+(`BackupBlobReader` → `BookFileMaterializer` → `BookImporter` →
+`MetadataExtractor` → `PersistenceActor`) only runs against a populated remote.
+Per AGENTS.md "Close gate — verified, not just merged", this closes under the
+**verification-exception** path: a deterministic high-fidelity integration test
+drives the SAME code paths the production failure would hit, with only the
+network/blob layer stubbed.
+
+## Acceptance criteria
+
+| # | Criterion | How verified | Result |
+|---|---|---|---|
+| 1 | Restored TXT keeps its original (manifest) title, not `restore_<sha>` | `BookFileMaterializerTitleRestoreIntegrationTests.restoreTXT_preservesManifestTitle` — real materialize→import→SwiftData-write; asserts stored title == "A Tale of Two Cities" AND `!hasPrefix("restore_")` | **PASS** |
+| 2 | Restored MD keeps its title | `restoreMD_preservesManifestTitle` — asserts "Architecture Notes", no `restore_` prefix | **PASS** |
+| 3 | Restored PDF (empty embedded metadata) keeps its title | `restorePDF_preservesManifestTitle` — asserts "User Manual v3" | **PASS** |
+| 4 | Multiple restored books each keep their own title (no cross-contamination) | `restoreMultipleBooks_eachKeepsItsOwnTitle` — asserts per-book titles | **PASS** |
+
+All 6 tests in the suite pass.
+
+## Commands run
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
+  -project vreader.xcodeproj -scheme vreader \
+  -destination 'platform=iOS Simulator,id=61149F0E-DC18-4BE2-BB37-52659F1F4F62' \
+  -only-testing:vreaderTests/BookFileMaterializerTitleRestoreIntegrationTests \
+  -parallel-testing-enabled NO
+```
+
+Result:
+
+```
+✔ Test run with 6 tests in 1 suite passed after 0.091 seconds.
+** TEST SUCCEEDED **
+```
+
+## Observations
+
+- The test is genuinely high-fidelity: REAL `PersistenceActor` (in-memory
+  `ModelContainer`, production `SchemaV7`), REAL `BookImporter` with REAL
+  `MetadataExtractor`s, REAL `BookFileMaterializer`. Only `BackupBlobReading`
+  (the network/blob fetch) is stubbed — everything from manifest-driven
+  download → SHA verify → import → SwiftData write runs production code. This is
+  exactly the "drives the same code paths the production failure would hit"
+  bar the verification-exception path requires (not a casual stub).
+- TXT and MD have no embedded title metadata (filename-derived), and PDF here
+  has empty embedded metadata — the three formats the bug named — so the test
+  covers the precise failure surface.
+
+## Artifacts
+
+- Test suite: `vreaderTests/Services/Backup/BookFileMaterializerTitleRestoreIntegrationTests.swift`
+- Run log: `/tmp/bug247-test.log`

--- a/project.yml
+++ b/project.yml
@@ -162,8 +162,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 643
-        MARKETING_VERSION: 3.39.22
+        CURRENT_PROJECT_VERSION: 644
+        MARKETING_VERSION: 3.39.23
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6488,13 +6488,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 643;
+				CURRENT_PROJECT_VERSION = 644;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.39.22;
+				MARKETING_VERSION = 3.39.23;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6638,13 +6638,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 643;
+				CURRENT_PROJECT_VERSION = 644;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.39.22;
+				MARKETING_VERSION = 3.39.23;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

Records the verification-exception evidence for Bug #247 (WebDAV restore losing book titles, FIXED v3.38.31) and clears its close-gate.

Refs #1074

## Verification (exception path)

The symptom can't be reproduced on a device CU-free without a live WebDAV server. Per AGENTS.md's close-gate exception, `BookFileMaterializerTitleRestoreIntegrationTests` drives the SAME code paths the production failure would hit — REAL `PersistenceActor` (in-memory SchemaV7), REAL `BookImporter` + `MetadataExtractor`s, REAL `BookFileMaterializer`; only `BackupBlobReading` (network/blob) is stubbed. 6 tests pass: TXT/MD/PDF restore each preserve the manifest title (not `restore_<sha>`), and multiple books keep distinct titles.

Evidence: `dev-docs/verification/bug-247-20260526.md`.

## Validation

- [x] `BookFileMaterializerTitleRestoreIntegrationTests` — 6 tests, 0 failures (UDID-pinned, parallel off).
- [x] Version bumped 3.39.22 → 3.39.23.

## Type of Change

- [x] Verification evidence (Refs #1074) — no production code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)