### PR TITLE
feat(#72 WI-0): hoist delegateTarget onto SpeechSynthesizing + generic delegate wiring

### DIFF
--- a/.claude/codex-audits/feat-feature-72-wi-0-speechsynthesizing-delegate-audit.md
+++ b/.claude/codex-audits/feat-feature-72-wi-0-speechsynthesizing-delegate-audit.md
@@ -1,0 +1,46 @@
+---
+branch: feat/feature-72-wi-0-speechsynthesizing-delegate
+threadId: 019e6396-7164-7931-bdd0-512c84f310e0
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-26
+---
+
+# Codex audit — Feature #72 WI-0 (SpeechSynthesizing.delegateTarget protocol hoist)
+
+Gate-4 audit (Codex MCP) of WI-0: hoist `delegateTarget` onto the
+`SpeechSynthesizing` protocol + wire it generically in `TTSService` (no
+type-casing), so the forthcoming `HTTPSpeechSynthesizer` adapter receives
+delegate callbacks.
+
+Files: `SpeechSynthesizing.swift`, `TTSService.swift`, `TTSServiceTests.swift`.
+
+## Round 1 — clean (no findings)
+
+Codex confirmed:
+- Behavior-identical for existing concrete paths — both `SystemSpeechSynthesizer`
+  (forwards into `AVSpeechSynthesizer.delegate`) and `XCUITestMockSpeechSynthesizer`
+  already exposed the same weak delegate slot; the generic `synthesizer.delegateTarget = self`
+  sets it exactly as the prior type-cast did. No path intentionally left the
+  delegate unset.
+- Ownership non-cyclic: `TTSService` strongly owns the synthesizer; conformers
+  weak-ref `delegateTarget`. No retain cycle.
+- No new isolation/Sendable issue: assignment in `TTSService.init` on MainActor;
+  protocol staying non-`@MainActor` is consistent with the existing abstraction.
+- `#if DEBUG` removal benign: the new unconditional line references no DEBUG-only
+  symbol; Release sets the delegate on `SystemSpeechSynthesizer` as before.
+- Test quality good: `init_wiresDelegateGenerically_forAnySynthesizer` proves a
+  plain mock now gets wired.
+
+Residual (not a finding): the protocol can't express `weak`, so a future
+conformer could implement `delegateTarget` as a strong ref — convention only.
+
+## Verification
+
+`TTSServiceStateTransitionTests` (10 tests incl. the new generic-wiring guard)
+pass; the protocol change compiles across all conformers (UDID-pinned,
+`-parallel-testing-enabled NO`).
+
+## Verdict
+
+**Ship-as-is.** No findings. Foundational refactor, behavior-preserving.

--- a/project.yml
+++ b/project.yml
@@ -162,8 +162,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 645
-        MARKETING_VERSION: 3.39.24
+        CURRENT_PROJECT_VERSION: 646
+        MARKETING_VERSION: 3.39.25
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6488,13 +6488,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 645;
+				CURRENT_PROJECT_VERSION = 646;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.39.24;
+				MARKETING_VERSION = 3.39.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6638,13 +6638,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 645;
+				CURRENT_PROJECT_VERSION = 646;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.39.24;
+				MARKETING_VERSION = 3.39.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/TTS/SpeechSynthesizing.swift
+++ b/vreader/Services/TTS/SpeechSynthesizing.swift
@@ -23,6 +23,14 @@ protocol SpeechSynthesizing: AnyObject {
     var isSpeaking: Bool { get }
     var isPaused: Bool { get }
 
+    /// The `AVSpeechSynthesizerDelegate` `TTSService` sets to receive progress
+    /// callbacks (`willSpeakRange` for highlight/scroll, `didFinish`,
+    /// `didCancel`). Feature #72 WI-0: hoisted from the concrete
+    /// `SystemSpeechSynthesizer` onto the protocol so `TTSService` can wire the
+    /// delegate for ANY synthesizer (the on-device synth, the XCUITest mock,
+    /// and the forthcoming `HTTPSpeechSynthesizer` adapter) without type-casing.
+    var delegateTarget: AVSpeechSynthesizerDelegate? { get set }
+
     func speak(_ utterance: SpeechUtteranceProtocol)
     @discardableResult func pauseSpeaking() -> Bool
     @discardableResult func continueSpeaking() -> Bool

--- a/vreader/Services/TTS/TTSService.swift
+++ b/vreader/Services/TTS/TTSService.swift
@@ -70,16 +70,13 @@ final class TTSService: NSObject {
         self.synthesizer = synthesizerFactory()
         super.init()
 
-        // Wire delegate to whichever concrete synthesizer was constructed.
-        if let system = synthesizer as? SystemSpeechSynthesizer {
-            system.delegateTarget = self
-        } else {
-            #if DEBUG
-            if let mock = synthesizer as? XCUITestMockSpeechSynthesizer {
-                mock.delegateTarget = self
-            }
-            #endif
-        }
+        // Feature #72 WI-0: wire the delegate generically via the protocol's
+        // `delegateTarget` — works for ANY `SpeechSynthesizing` (on-device,
+        // XCUITest mock, and the forthcoming HTTPSpeechSynthesizer adapter)
+        // without type-casing. Previously only `SystemSpeechSynthesizer` /
+        // `XCUITestMockSpeechSynthesizer` were special-cased, so a new adapter
+        // would silently receive no callbacks.
+        synthesizer.delegateTarget = self
     }
 
     /// Default synthesizer picker. Returns the XCUITest mock when the

--- a/vreaderTests/Services/TTSServiceTests.swift
+++ b/vreaderTests/Services/TTSServiceTests.swift
@@ -8,6 +8,7 @@
 
 import Testing
 import Foundation
+import AVFoundation
 @testable import vreader
 
 // MARK: - TTSService State Transition Tests
@@ -21,6 +22,18 @@ struct TTSServiceStateTransitionTests {
         service.startSpeaking(text: "Hello, world!", fromOffset: 5)
         #expect(service.state == .speaking)
         #expect(service.currentOffsetUTF16 == 5)
+    }
+
+    @Test @MainActor
+    func init_wiresDelegateGenerically_forAnySynthesizer() {
+        // Feature #72 WI-0: TTSService wires `delegateTarget` via the protocol
+        // for ANY conformer — not just System/XCUITestMock. A plain
+        // `MockSpeechSynthesizer` (neither special-cased type) must now receive
+        // the service as its delegate target. Pre-WI-0 the type-cased wiring
+        // left this nil; this guards the generic wiring the HTTP adapter needs.
+        let mock = MockSpeechSynthesizer()
+        let service = TTSService(synthesizerFactory: { mock })
+        #expect(mock.delegateTarget === service)
     }
 
     @Test @MainActor
@@ -424,6 +437,10 @@ final class MockSpeechSynthesizer: SpeechSynthesizing {
 
     var isSpeaking: Bool = false
     var isPaused: Bool = false
+
+    /// Feature #72 WI-0: the protocol now requires `delegateTarget`; TTSService
+    /// wires it generically, so this mock records what it was set to.
+    weak var delegateTarget: AVSpeechSynthesizerDelegate?
 
     func speak(_ utterance: SpeechUtteranceProtocol) {
         speakCalled = true


### PR DESCRIPTION
## Summary

WI-0 of feature #72 (HTTP cloud TTS integration). Foundational refactor: add `delegateTarget` to the `SpeechSynthesizing` protocol and wire it generically in `TTSService`, so the forthcoming `HTTPSpeechSynthesizer` adapter (WI-3) will receive `willSpeakRange`/`didFinish`/`didCancel` callbacks (Codex Gate-2 finding H2).

Part of feature #72

## What changed

- `SpeechSynthesizing` gains `var delegateTarget: AVSpeechSynthesizerDelegate? { get set }`.
- `TTSService.init` now does `synthesizer.delegateTarget = self` generically (was `as? SystemSpeechSynthesizer` / `as? XCUITestMockSpeechSynthesizer`). Behavior-identical for both existing conformers.
- Test `MockSpeechSynthesizer` gains the property; new `init_wiresDelegateGenerically_forAnySynthesizer` guards the generic wiring.

## Codex Audit (Gate 4)

Thread `019e6396`, **1 round, ship-as-is** — no findings. Confirmed behavior-identical for the concrete paths, non-cyclic ownership (weak delegate), no isolation issue, benign `#if DEBUG` removal.

## Validation

- [x] `TTSServiceStateTransitionTests` (10 tests incl. the new guard) pass; protocol change compiles across all conformers (UDID-pinned, parallel off).
- [x] Version bumped 3.39.24 → 3.39.25.

## Gate 5 (tier)

Foundational refactor, no user-observable change — unit + audit sufficient; no device verification required for this WI.

## Type of Change

- [x] Feature WI (Part of feature #72)

🤖 Generated with [Claude Code](https://claude.com/claude-code)