### PR TITLE
feat(#72 WI-1): HTTPTTSConfigStore — load persisted config + Keychain API key

### DIFF
--- a/.claude/codex-audits/feat-feature-72-wi-1-config-store-audit.md
+++ b/.claude/codex-audits/feat-feature-72-wi-1-config-store-audit.md
@@ -1,0 +1,36 @@
+---
+branch: feat/feature-72-wi-1-config-store
+threadId: 019e639b-b8ca-71b3-b32a-6c494a5daecf
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-26
+---
+
+# Codex audit — Feature #72 WI-1 (HTTPTTSConfigStore loader)
+
+Gate-4 audit (Codex MCP) of WI-1: centralized loader for the persisted HTTP
+cloud-TTS config (UserDefaults `httpTTSConfig` + Keychain
+`com.vreader.httpTTS.apiKey`) behind a testable seam.
+
+Files: `HTTPTTSConfigStore.swift` (new), `HTTPTTSConfigStoreTests.swift` (new).
+
+## Round 1 — clean (no findings)
+
+Codex verified against the writer (`HTTPTTSSettingsView`):
+- `configKey` + `keychainAccount` match exactly; the blank-apiKey-in-UserDefaults
+  convention (key lives only in Keychain) is correctly mirrored.
+- `HTTPTTSKeychainReading.readString(forAccount:)` matches
+  `KeychainService.readString(forAccount:)`; the conformance seam is sound.
+- `loadValidConfig()` correctly returns nil for unconfigured / invalid-endpoint /
+  missing-keychain-key (→ empty apiKey → `validate()` rejects) cases.
+- No Sendable/concurrency issue; tests use an isolated UserDefaults suite + stub
+  keychain and cover the missing-key→invalid path.
+
+## Verification
+
+`HTTPTTSConfigStoreTests` — 6 tests pass (UDID-pinned, `-parallel-testing-enabled NO`).
+
+## Verdict
+
+**Ship-as-is.** No findings. Foundational loader; the WI-3 adapter selection
+will consume `loadValidConfig()`.

--- a/project.yml
+++ b/project.yml
@@ -162,8 +162,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 646
-        MARKETING_VERSION: 3.39.25
+        CURRENT_PROJECT_VERSION: 647
+        MARKETING_VERSION: 3.39.26
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -482,6 +482,7 @@
 		58F98A74EEAB6D0C39616B5D /* UnifiedTextRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7F45FFFEE431C41E618EF2 /* UnifiedTextRendererTests.swift */; };
 		594A2BE63A5D10BAF70D604A /* StatusBarTintingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 181E14C009F03D7B2EE1F117 /* StatusBarTintingTests.swift */; };
 		594C442CEEA499384283D6B7 /* SelectiveRestoreCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD987912F59B7B7CD80B064 /* SelectiveRestoreCoordinator.swift */; };
+		599306799B2551F63E7C5BAE /* HTTPTTSConfigStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F77761B8C991CC700BC01E /* HTTPTTSConfigStoreTests.swift */; };
 		59B8E65739F0BDF9F099D348 /* SearchQueryExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B1246EC0EE34D326231F60 /* SearchQueryExecutorTests.swift */; };
 		59C50A731FA0022482A38792 /* WCAGContrastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2A16647F198641F11AC9C1 /* WCAGContrastTests.swift */; };
 		59C9A1E6BDF49D30D5CCAC18 /* ChapterReTranslateBoundaries.swift in Sources */ = {isa = PBXBuildFile; fileRef = E739E292953914C4E51D47EB /* ChapterReTranslateBoundaries.swift */; };
@@ -773,6 +774,7 @@
 		909ADB564394665014A94D74 /* RegexRuleEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66BBCB51EBC23CCC7632C74 /* RegexRuleEvaluator.swift */; };
 		90D2C41C30E622E119877967 /* BackupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5350DA755A0BB669AE8D3FBD /* BackupViewModelTests.swift */; };
 		915C38C106026EB4386107C5 /* FoliateChapterTextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF17767136D4087D5F38F901 /* FoliateChapterTextProvider.swift */; };
+		916CF15735E1F170E2CE4695 /* HTTPTTSConfigStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CD66C1E52331AC245386C9 /* HTTPTTSConfigStore.swift */; };
 		91B218D155D6760DBC8D733A /* EPUBReaderContainerView+Highlights.swift in Sources */ = {isa = PBXBuildFile; fileRef = A922B4886FE1CE378009FB1B /* EPUBReaderContainerView+Highlights.swift */; };
 		91B3A04F3B23BE09FCA9967C /* LazyDownloadDelegateStagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D4DDB55DA30E015172A16D /* LazyDownloadDelegateStagingTests.swift */; };
 		91B6BC18F3DE3D9A54B7C30B /* FontSizeCalibrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE9DA4CCA7E942838A838495 /* FontSizeCalibrator.swift */; };
@@ -1353,6 +1355,7 @@
 		0125F1FAD971AFEE5D536AFD /* ProviderProfileStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderProfileStoreTests.swift; sourceTree = "<group>"; };
 		012F237F2750DF33FC54AA26 /* LibrarySectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySectionHeader.swift; sourceTree = "<group>"; };
 		016383B776469400B2DAA64F /* BilingualDisplaySegmentMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualDisplaySegmentMapTests.swift; sourceTree = "<group>"; };
+		01CD66C1E52331AC245386C9 /* HTTPTTSConfigStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTTSConfigStore.swift; sourceTree = "<group>"; };
 		01E72DDEAD6225A21E973A51 /* SyncTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncTypes.swift; sourceTree = "<group>"; };
 		02275826847D45CA3746D53D /* CollectionSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSidebar.swift; sourceTree = "<group>"; };
 		02DE298149C25261E2ECADA1 /* ReaderThemeCSSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeCSSTests.swift; sourceTree = "<group>"; };
@@ -2517,6 +2520,7 @@
 		E46AADA707F0E3AF7E8AB297 /* vreaderTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = vreaderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E49486599FAD7ED74521BC9C /* BilingualSetupSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualSetupSheetTests.swift; sourceTree = "<group>"; };
 		E4A1E377D377C7BFEE10AE14 /* HighlightAnnotationCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightAnnotationCardTests.swift; sourceTree = "<group>"; };
+		E4F77761B8C991CC700BC01E /* HTTPTTSConfigStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTTSConfigStoreTests.swift; sourceTree = "<group>"; };
 		E4FA2EE6CBC53444A8E0E900 /* Inter-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Inter-Regular.otf"; sourceTree = "<group>"; };
 		E50B0954852C3621D008EE07 /* TXTBridgeOffsetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTBridgeOffsetTests.swift; sourceTree = "<group>"; };
 		E50BDCA7532338D53368A59B /* BookSourceRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSourceRules.swift; sourceTree = "<group>"; };
@@ -2988,6 +2992,7 @@
 		348FFD7C230F685969954CD8 /* TTS */ = {
 			isa = PBXGroup;
 			children = (
+				E4F77761B8C991CC700BC01E /* HTTPTTSConfigStoreTests.swift */,
 				4E47FF2613D8D1B235852F68 /* HTTPTTSConfigTests.swift */,
 				0CDE700F3AC42B0D8AD377E1 /* HTTPTTSProviderTests.swift */,
 				13D1E2EE401D4C3053FB687A /* MockURLSession.swift */,
@@ -4383,6 +4388,7 @@
 			isa = PBXGroup;
 			children = (
 				10C9907D3479515B56338825 /* HTTPTTSConfig.swift */,
+				01CD66C1E52331AC245386C9 /* HTTPTTSConfigStore.swift */,
 				9CE6D5875C20698F83D6EC1E /* HTTPTTSProvider.swift */,
 				5D3EF2FFB105C9E0DF1EDF51 /* SpeechSynthesizing.swift */,
 				D721FA5AC22C4EBD49791B48 /* TTSHighlightCoordinator.swift */,
@@ -5339,6 +5345,7 @@
 				1E5332F73297C4DB6DF747BD /* FontSizeCalibratorTests.swift in Sources */,
 				67307D96FA4FE6F86F92B988 /* FormatCapabilitiesTests.swift in Sources */,
 				2CBF53D883E09532ABC29FE4 /* GenerativeCoverViewStyleTests.swift in Sources */,
+				599306799B2551F63E7C5BAE /* HTTPTTSConfigStoreTests.swift in Sources */,
 				43228D2AF27BDD7DDD6BB5AB /* HTTPTTSConfigTests.swift in Sources */,
 				FB4B2B41D865A14865DF4DE1 /* HTTPTTSProviderTests.swift in Sources */,
 				C57845DF5A192CA91CE07FED /* HighlightActionCardViewTests.swift in Sources */,
@@ -5941,6 +5948,7 @@
 				15BC7FE6B105319B5709C4A9 /* GenerativeCoverView.swift in Sources */,
 				2E988A3214761CEAEF22D451 /* HTMLHelper.swift in Sources */,
 				401E58831F4DC6EB06E53738 /* HTTPTTSConfig.swift in Sources */,
+				916CF15735E1F170E2CE4695 /* HTTPTTSConfigStore.swift in Sources */,
 				EF1B83368D1AE23FFD738752 /* HTTPTTSProvider.swift in Sources */,
 				E7EF2F892419DE80C3FC8B3B /* HTTPTTSSettingsView.swift in Sources */,
 				FA8BF5E0D98277BECAFB70CA /* HapticFeedback.swift in Sources */,
@@ -6488,13 +6496,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 646;
+				CURRENT_PROJECT_VERSION = 647;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.39.25;
+				MARKETING_VERSION = 3.39.26;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6638,13 +6646,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 646;
+				CURRENT_PROJECT_VERSION = 647;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.39.25;
+				MARKETING_VERSION = 3.39.26;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/TTS/HTTPTTSConfigStore.swift
+++ b/vreader/Services/TTS/HTTPTTSConfigStore.swift
@@ -1,0 +1,65 @@
+// Purpose: Feature #72 WI-1 — load the persisted HTTP cloud-TTS configuration
+// (UserDefaults `httpTTSConfig`, config minus API key) and inject the API key
+// from the Keychain (account `com.vreader.httpTTS.apiKey`), so the live TTS
+// pipeline (`TTSService.defaultSynthesizer()`, WI-3) can decide whether a valid
+// cloud provider is configured. The persistence shape mirrors
+// `HTTPTTSSettingsView`'s save/load exactly (same keys + Keychain account).
+//
+// Key decisions:
+// - Reads through a `HTTPTTSKeychainReading` seam (prod: `KeychainService`) +
+//   an injected `UserDefaults`, so the loader is unit-testable without touching
+//   the real Keychain / standard defaults.
+// - `load()` returns the persisted config with the Keychain key spliced back in
+//   (it may still be invalid — caller checks `validate()`); `loadValidConfig()`
+//   is the selection predicate (`validate() == .valid`).
+//
+// @coordinates-with: HTTPTTSConfig.swift, HTTPTTSSettingsView.swift (the writer),
+//   KeychainService.swift, TTSService.swift (WI-3 consumer)
+
+import Foundation
+
+/// The Keychain read surface `HTTPTTSConfigStore` needs — a seam so tests can
+/// stub the API-key read without the real Keychain.
+protocol HTTPTTSKeychainReading {
+    func readString(forAccount account: String) throws -> String?
+}
+
+extension KeychainService: HTTPTTSKeychainReading {}
+
+/// Loads the persisted `HTTPTTSConfig` + its Keychain-stored API key.
+struct HTTPTTSConfigStore {
+
+    /// UserDefaults key holding the JSON-encoded config (API key blanked).
+    /// Must match `HTTPTTSSettingsView.configKey`.
+    static let configKey = "httpTTSConfig"
+    /// Keychain account holding the API key. Must match
+    /// `HTTPTTSSettingsView.keychainAccount`.
+    static let keychainAccount = "com.vreader.httpTTS.apiKey"
+
+    private let defaults: UserDefaults
+    private let keychain: HTTPTTSKeychainReading
+
+    init(defaults: UserDefaults = .standard, keychain: HTTPTTSKeychainReading = KeychainService()) {
+        self.defaults = defaults
+        self.keychain = keychain
+    }
+
+    /// The persisted config with the Keychain API key spliced in, or `nil` when
+    /// no config has been saved. The returned config may be INVALID — the
+    /// caller calls `validate()` (or uses `loadValidConfig()`).
+    func load() -> HTTPTTSConfig? {
+        guard let data = defaults.data(forKey: Self.configKey),
+              var config = try? JSONDecoder().decode(HTTPTTSConfig.self, from: data)
+        else { return nil }
+        config.apiKey = (try? keychain.readString(forAccount: Self.keychainAccount)) ?? ""
+        return config
+    }
+
+    /// The persisted config IFF it validates as `.valid` — the predicate
+    /// `TTSService.defaultSynthesizer()` (WI-3) uses to select the cloud
+    /// synthesizer over the on-device one. `nil` when unconfigured or invalid.
+    func loadValidConfig() -> HTTPTTSConfig? {
+        guard let config = load(), config.validate() == .valid else { return nil }
+        return config
+    }
+}

--- a/vreaderTests/Services/TTS/HTTPTTSConfigStoreTests.swift
+++ b/vreaderTests/Services/TTS/HTTPTTSConfigStoreTests.swift
@@ -1,0 +1,84 @@
+// Purpose: Tests for HTTPTTSConfigStore (feature #72 WI-1) — loading the
+// persisted HTTP cloud-TTS config + splicing in the Keychain API key, and the
+// `loadValidConfig()` selection predicate. Uses an isolated UserDefaults suite
+// + a stub keychain so no real Keychain / standard defaults are touched.
+//
+// @coordinates-with: HTTPTTSConfigStore.swift, HTTPTTSConfig.swift, GH #1174
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("HTTPTTSConfigStore (Feature #72 WI-1)")
+struct HTTPTTSConfigStoreTests {
+
+    private struct StubKeychain: HTTPTTSKeychainReading {
+        let value: String?
+        func readString(forAccount account: String) throws -> String? { value }
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        let suite = "http-tts-store-\(UUID().uuidString)"
+        let d = UserDefaults(suiteName: suite)!
+        d.removePersistentDomain(forName: suite)
+        return d
+    }
+
+    /// Persists a config the way `HTTPTTSSettingsView.saveConfig` does: JSON
+    /// with the API key blanked (the real key lives in the Keychain).
+    private func persist(_ config: HTTPTTSConfig, to defaults: UserDefaults) {
+        var stored = config
+        stored.apiKey = ""
+        let data = try! JSONEncoder().encode(stored)
+        defaults.set(data, forKey: HTTPTTSConfigStore.configKey)
+    }
+
+    private func validConfig() -> HTTPTTSConfig {
+        HTTPTTSConfig(endpoint: "https://tts.example.com/v1/speak",
+                      apiKey: "REAL-KEY", voice: "en-US-JennyNeural",
+                      provider: .azure(region: "eastus"))
+    }
+
+    @Test func load_returnsNilWhenNothingPersisted() {
+        let store = HTTPTTSConfigStore(defaults: makeDefaults(), keychain: StubKeychain(value: nil))
+        #expect(store.load() == nil)
+    }
+
+    @Test func load_returnsConfigWithKeychainKeySpliced() {
+        let defaults = makeDefaults()
+        persist(validConfig(), to: defaults)
+        let store = HTTPTTSConfigStore(defaults: defaults, keychain: StubKeychain(value: "REAL-KEY"))
+        let loaded = store.load()
+        #expect(loaded?.endpoint == "https://tts.example.com/v1/speak")
+        #expect(loaded?.voice == "en-US-JennyNeural")
+        #expect(loaded?.apiKey == "REAL-KEY", "the API key must come from the Keychain, not UserDefaults")
+    }
+
+    @Test func loadValidConfig_returnsConfigWhenValid() {
+        let defaults = makeDefaults()
+        persist(validConfig(), to: defaults)
+        let store = HTTPTTSConfigStore(defaults: defaults, keychain: StubKeychain(value: "REAL-KEY"))
+        #expect(store.loadValidConfig()?.validate() == .valid)
+    }
+
+    @Test func loadValidConfig_returnsNilWhenKeychainKeyMissing() {
+        // Config persisted but the Keychain has no key → apiKey "" → invalid.
+        let defaults = makeDefaults()
+        persist(validConfig(), to: defaults)
+        let store = HTTPTTSConfigStore(defaults: defaults, keychain: StubKeychain(value: nil))
+        #expect(store.load()?.apiKey == "")
+        #expect(store.loadValidConfig() == nil)
+    }
+
+    @Test func loadValidConfig_returnsNilWhenEndpointInvalid() {
+        let defaults = makeDefaults()
+        persist(HTTPTTSConfig(endpoint: "not-a-url", apiKey: "k", voice: "v"), to: defaults)
+        let store = HTTPTTSConfigStore(defaults: defaults, keychain: StubKeychain(value: "k"))
+        #expect(store.loadValidConfig() == nil)
+    }
+
+    @Test func loadValidConfig_returnsNilWhenUnconfigured() {
+        let store = HTTPTTSConfigStore(defaults: makeDefaults(), keychain: StubKeychain(value: "k"))
+        #expect(store.loadValidConfig() == nil)
+    }
+}


### PR DESCRIPTION
## Summary
WI-1 of feature #72. A testable loader (`HTTPTTSConfigStore`) for the persisted HTTP cloud-TTS config (UserDefaults `httpTTSConfig` + Keychain `com.vreader.httpTTS.apiKey`), behind a `HTTPTTSKeychainReading` seam. `loadValidConfig()` is the `validate() == .valid` selection predicate WI-3 will use.

Part of feature #72

## Validation
- [x] `HTTPTTSConfigStoreTests` — 6 tests pass (isolated UserDefaults suite + stub keychain; covers missing-key→invalid).
- [x] Codex Gate-4 `019e639b`, 1 round, ship-as-is — keys/convention match `HTTPTTSSettingsView` exactly.
- [x] Version bumped 3.39.25 → 3.39.26.

## Gate 5 (tier)
Foundational, pure-ish loader — unit + audit sufficient; no device verification.

## Type of Change
- [x] Feature WI (Part of feature #72)

🤖 Generated with [Claude Code](https://claude.com/claude-code)