### PR TITLE
feat(#72 WI-2): HTTPTTSChunkPlayer — sequential AVAudioPlayer chunk queue

### DIFF
--- a/.claude/codex-audits/feat-feature-72-wi-2-chunk-player-audit.md
+++ b/.claude/codex-audits/feat-feature-72-wi-2-chunk-player-audit.md
@@ -1,0 +1,32 @@
+---
+branch: feat/feature-72-wi-2-chunk-player
+threadId: 019e63a1-d7f6-7641-8f3a-dba79360273c
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-05-26
+---
+
+# Codex audit — Feature #72 WI-2 (HTTPTTSChunkPlayer)
+
+Gate-4 audit (Codex MCP, 3 rounds) of the sequential audio-chunk playback queue.
+Files: `HTTPTTSChunkPlayer.swift` (new), `HTTPTTSChunkPlayerTests.swift` (new).
+
+## Round 1 — 2 High + 2 Medium
+| # | Sev | Finding | Resolution |
+|---|---|---|---|
+| 1 | High | Stale `onFinish` after `stop()`/`play()`-replace advances the queue / fires `onFinished` spuriously / skips chunk 0 of a new queue. | **Generation token** bumped on stop/play; `handleFinish(gen:)`/`handleFailure(gen:)` ignore stale gens; `detachCurrent()` nils old callbacks + stops. |
+| 2 | High | `onFinished` fired on drain even mid-stream (a short chunk finishing before the next arrives → premature finish). | **`inputComplete` flag + `markInputComplete()`**; `onFinished` only when drained AND input complete; `play(chunks:inputComplete:)`. |
+| 3 | Med | Stop/stale-finish test didn't assert `onFinished` stayed suppressed. | Test now asserts `finished == false` + added a replacement-queue stale-finish case. |
+| 4 | Med | `successfully: false` advanced as success (masks playback failure). | `SpeechAudioPlaying.onFailure`; `AVAudioPlayerBox` routes `flag==false` → onFailure → onError (no advance) + test. |
+
+## Round 2 — 1 Medium (new)
+| 5 | Med | `markInputComplete()` not idempotent — re-fires `onFinished` on repeated calls when already drained. | One-shot `completionDelivered` guard + `deliverCompletion()` at all 3 completion sites; reset on play/stop; idempotency test. |
+
+## Round 3 — clean
+No new issue. Generation-token stale protection holds; completion is one-shot.
+
+## Verification
+`HTTPTTSChunkPlayerTests` — 10 tests pass (UDID-pinned, `-parallel-testing-enabled NO`): sequential play, pause/resume, stop-then-stale-finish (no advance/finish), replacement-queue stale-finish, streaming drain-before-complete, markInputComplete-while-playing, idempotent completion, empty queue, build failure, unsuccessful-finish→onError.
+
+## Verdict
+**Ship-as-is.** No open findings after round 3. Does NOT manage AVAudioSession (TTSService owns it).

--- a/project.yml
+++ b/project.yml
@@ -162,8 +162,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 647
-        MARKETING_VERSION: 3.39.26
+        CURRENT_PROJECT_VERSION: 648
+        MARKETING_VERSION: 3.39.27
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -843,6 +843,7 @@
 		9F3CA2F590925EC1C4168656 /* TextTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F02593B096CB3A08EE4DAF /* TextTransform.swift */; };
 		9FCA583CDA52A7FB584260FA /* LocatorRestorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B81B909B41CB8C14B613D73 /* LocatorRestorer.swift */; };
 		A02EBB23E9A748965074B639 /* VReaderUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71DF9DC9E8F3CCA4BE321C47 /* VReaderUITests.swift */; };
+		A03DBE125D6347EB3A73527F /* HTTPTTSChunkPlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31257B79B3B1BE785EFD5C26 /* HTTPTTSChunkPlayerTests.swift */; };
 		A09073BC74E3E77CF9A05D7C /* FoliateSpikeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4BF5EAA27DC53FE80B55A4 /* FoliateSpikeView.swift */; };
 		A09FA8DF38589B83DA06D15C /* BookDetailsActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0FDBE03DFF8791C7027EEAD /* BookDetailsActionsTests.swift */; };
 		A0E678BE188639F7AD4A45C9 /* ReaderUnsupportedFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0459CAA7394555E5A8E17146 /* ReaderUnsupportedFormatTests.swift */; };
@@ -871,6 +872,7 @@
 		A3C805774A79231FF5DBC4EE /* TXTChapterModeHighlightVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74260B9D22ACF57F72090F9A /* TXTChapterModeHighlightVerificationTests.swift */; };
 		A3D6C41E3B9BAD5A458D4A7F /* ReadingModeMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5658424589A0D1017FDF72 /* ReadingModeMigrationTests.swift */; };
 		A43AD2AF5B19CF05B849BE2E /* BackupViewModelSelectiveRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3743321B8FFE925BFB43D262 /* BackupViewModelSelectiveRestoreTests.swift */; };
+		A48202EACCA0A4A642674E26 /* HTTPTTSChunkPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F701D2D5416A758988C808 /* HTTPTTSChunkPlayer.swift */; };
 		A485A4DAFF233AE87062C3F6 /* DeviceIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA4BF056E74D056492E5858 /* DeviceIdentity.swift */; };
 		A4A49ED0A6DF2433D8292FF3 /* BilingualOffsetRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B6FF7CD976BEA8E7BBA282 /* BilingualOffsetRouter.swift */; };
 		A4BA4366BC946C80885678AE /* Feature54ReadingModeRemovalVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC502E886EBA816F1DA34471 /* Feature54ReadingModeRemovalVerificationTests.swift */; };
@@ -1579,6 +1581,7 @@
 		3035E9BDF79106F058459E0D /* StatsCustomRangePickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsCustomRangePickerTests.swift; sourceTree = "<group>"; };
 		30D00221E111683E9FF0260A /* SearchTextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTextExtractor.swift; sourceTree = "<group>"; };
 		310813C564EF1BF86A13694E /* DebugBridgeHighlightObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugBridgeHighlightObserverTests.swift; sourceTree = "<group>"; };
+		31257B79B3B1BE785EFD5C26 /* HTTPTTSChunkPlayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTTSChunkPlayerTests.swift; sourceTree = "<group>"; };
 		317401FBAE274C615325BDBC /* SourceSharingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceSharingServiceTests.swift; sourceTree = "<group>"; };
 		319F6B718764EAF33C88ECC4 /* BookImporterNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookImporterNotificationTests.swift; sourceTree = "<group>"; };
 		31AB5B40BD735A699BB480DE /* ReadingStatsAggregatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsAggregatorTests.swift; sourceTree = "<group>"; };
@@ -1960,6 +1963,7 @@
 		77AEAE00997ED48B68EE20E6 /* Feature25TapZonesVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature25TapZonesVerificationTests.swift; sourceTree = "<group>"; };
 		78459E9C87CFFEA5BD741A5F /* SearchViewReskinTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewReskinTests.swift; sourceTree = "<group>"; };
 		78BD4CC018110BC0C96E2788 /* DebugReaderRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReaderRegistryTests.swift; sourceTree = "<group>"; };
+		78F701D2D5416A758988C808 /* HTTPTTSChunkPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTTSChunkPlayer.swift; sourceTree = "<group>"; };
 		791CB502C8B59E737F15E63C /* VerificationSettingsHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationSettingsHelperTests.swift; sourceTree = "<group>"; };
 		79E3E09003BD79ED972F15D6 /* ChapterTranslationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterTranslationStoreTests.swift; sourceTree = "<group>"; };
 		79F003D569BCC0F29113468A /* EPUBMetadataExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBMetadataExtractorTests.swift; sourceTree = "<group>"; };
@@ -2992,6 +2996,7 @@
 		348FFD7C230F685969954CD8 /* TTS */ = {
 			isa = PBXGroup;
 			children = (
+				31257B79B3B1BE785EFD5C26 /* HTTPTTSChunkPlayerTests.swift */,
 				E4F77761B8C991CC700BC01E /* HTTPTTSConfigStoreTests.swift */,
 				4E47FF2613D8D1B235852F68 /* HTTPTTSConfigTests.swift */,
 				0CDE700F3AC42B0D8AD377E1 /* HTTPTTSProviderTests.swift */,
@@ -4387,6 +4392,7 @@
 		D544B1FCA1D99EBC7EAE9F25 /* TTS */ = {
 			isa = PBXGroup;
 			children = (
+				78F701D2D5416A758988C808 /* HTTPTTSChunkPlayer.swift */,
 				10C9907D3479515B56338825 /* HTTPTTSConfig.swift */,
 				01CD66C1E52331AC245386C9 /* HTTPTTSConfigStore.swift */,
 				9CE6D5875C20698F83D6EC1E /* HTTPTTSProvider.swift */,
@@ -5345,6 +5351,7 @@
 				1E5332F73297C4DB6DF747BD /* FontSizeCalibratorTests.swift in Sources */,
 				67307D96FA4FE6F86F92B988 /* FormatCapabilitiesTests.swift in Sources */,
 				2CBF53D883E09532ABC29FE4 /* GenerativeCoverViewStyleTests.swift in Sources */,
+				A03DBE125D6347EB3A73527F /* HTTPTTSChunkPlayerTests.swift in Sources */,
 				599306799B2551F63E7C5BAE /* HTTPTTSConfigStoreTests.swift in Sources */,
 				43228D2AF27BDD7DDD6BB5AB /* HTTPTTSConfigTests.swift in Sources */,
 				FB4B2B41D865A14865DF4DE1 /* HTTPTTSProviderTests.swift in Sources */,
@@ -5947,6 +5954,7 @@
 				F4FE45E62955A90DF146DE4B /* GenerativeCoverStyle.swift in Sources */,
 				15BC7FE6B105319B5709C4A9 /* GenerativeCoverView.swift in Sources */,
 				2E988A3214761CEAEF22D451 /* HTMLHelper.swift in Sources */,
+				A48202EACCA0A4A642674E26 /* HTTPTTSChunkPlayer.swift in Sources */,
 				401E58831F4DC6EB06E53738 /* HTTPTTSConfig.swift in Sources */,
 				916CF15735E1F170E2CE4695 /* HTTPTTSConfigStore.swift in Sources */,
 				EF1B83368D1AE23FFD738752 /* HTTPTTSProvider.swift in Sources */,
@@ -6496,13 +6504,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 647;
+				CURRENT_PROJECT_VERSION = 648;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.39.26;
+				MARKETING_VERSION = 3.39.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6646,13 +6654,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 647;
+				CURRENT_PROJECT_VERSION = 648;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.39.26;
+				MARKETING_VERSION = 3.39.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/TTS/HTTPTTSChunkPlayer.swift
+++ b/vreader/Services/TTS/HTTPTTSChunkPlayer.swift
@@ -1,0 +1,237 @@
+// Purpose: Feature #72 WI-2 — sequential audio-chunk playback queue for the
+// HTTP cloud-TTS path. The `HTTPSpeechSynthesizer` adapter (WI-3) feeds it the
+// per-sentence audio `Data` chunks `HTTPTTSProvider.synthesizeChunked` returns
+// (streaming: chunks arrive over time); this plays them back-to-back via an
+// `AVAudioPlayer` (behind a `SpeechAudioPlaying` seam so the queue logic is
+// unit-testable without audio hardware), firing `onChunkStarted(index)` as each
+// chunk begins (the adapter turns that into a chunk-range `willSpeakRange`) and
+// `onFinished` once the LAST chunk of a COMPLETE input has played.
+//
+// Key decisions:
+// - **Audio session is NOT managed here** (Gate-2 M1): `TTSService` owns
+//   `AVAudioSession`. This player only plays/pauses/stops `AVAudioPlayer`s.
+// - **One `AVAudioPlayer` per chunk**, advanced on `audioPlayerDidFinishPlaying`.
+// - **Generation token** (Gate-4 round-1 H1): every chunk's `onFinish` closure
+//   captures the generation at start; `stop()`/`play()` bump it so a LATE finish
+//   from a stopped/replaced player can never advance the queue or fire
+//   `onFinished`. The old player's `onFinish` is also detached on stop/replace.
+// - **Drain ≠ complete** (Gate-4 round-1 H2): because chunks stream in via
+//   `enqueue`, draining the queue does NOT mean the input is done. `onFinished`
+//   fires only when the queue drains AND `markInputComplete()` has been called
+//   (or `play(chunks:)` declared the input already complete).
+// - **`SpeechAudioPlaying` seam** with explicit success/failure: a chunk that
+//   finishes UNsuccessfully routes to `onError` (Gate-4 round-1 M2), not a
+//   silent advance.
+//
+// @coordinates-with: HTTPSpeechSynthesizer.swift (WI-3 consumer),
+//   HTTPTTSProvider.swift (chunk source), TTSService.swift (audio session owner)
+
+import Foundation
+import AVFoundation
+import OSLog
+
+/// The audio-backend seam a `HTTPTTSChunkPlayer` plays one chunk through.
+/// Production wraps `AVAudioPlayer`; tests stub it to advance deterministically.
+@MainActor
+protocol SpeechAudioPlaying: AnyObject {
+    /// Invoked when this chunk's playback finishes SUCCESSFULLY (drives the
+    /// queue to the next chunk). Not called on `stop()`.
+    var onFinish: (() -> Void)? { get set }
+    /// Invoked when this chunk's playback finishes UNSUCCESSFULLY (decode /
+    /// playback error) — routes to the queue's error path, not an advance.
+    var onFailure: (() -> Void)? { get set }
+    func play()
+    func pause()
+    func resume()
+    func stop()
+}
+
+/// Plays a sequence of audio `Data` chunks back-to-back. `@MainActor`.
+@MainActor
+final class HTTPTTSChunkPlayer {
+
+    private static let log = Logger(subsystem: "com.vreader.app", category: "HTTPTTSChunkPlayer")
+
+    private let makePlayer: @MainActor (Data) throws -> SpeechAudioPlaying
+
+    private var queue: [Data] = []
+    private var index = 0
+    private var current: SpeechAudioPlaying?
+    /// Bumped on `stop()`/`play()` so a late `onFinish` from a stopped/replaced
+    /// player (which captured the prior generation) is ignored.
+    private var generation = 0
+    /// Whether all input chunks have been enqueued. `onFinished` fires only
+    /// when the queue drains AND this is true.
+    private var inputComplete = false
+    /// One-shot guard so `onFinished` fires at most once per playback
+    /// (Gate-4 round-2: a repeated `markInputComplete()` / a drain after a
+    /// already-completed run must not re-fire). Reset by `play()` / `stop()`.
+    private var completionDelivered = false
+
+    private(set) var isPlaying = false
+    private(set) var isPaused = false
+
+    /// Fired with the chunk index as each chunk's audio STARTS.
+    var onChunkStarted: ((Int) -> Void)?
+    /// Fired once the LAST chunk of a complete input has finished. NOT on stop.
+    var onFinished: (() -> Void)?
+    /// Fired on a chunk build failure or an unsuccessful playback finish.
+    var onError: ((Error) -> Void)?
+
+    enum PlaybackError: Error { case chunkPlaybackFailed }
+
+    init(makePlayer: @escaping @MainActor (Data) throws -> SpeechAudioPlaying = { data in
+        try AVAudioPlayerBox(data: data)
+    }) {
+        self.makePlayer = makePlayer
+    }
+
+    /// Plays `chunks` from the first. `inputComplete` (default true) means this
+    /// is the entire input — pass `false` when streaming chunks in via
+    /// `enqueue` + a later `markInputComplete()`.
+    func play(chunks: [Data], inputComplete: Bool = true) {
+        resetForNewPlayback()
+        queue = chunks
+        self.inputComplete = inputComplete
+        guard !queue.isEmpty else {
+            if inputComplete { deliverCompletion() }
+            return
+        }
+        startCurrent()
+    }
+
+    /// Appends a streamed chunk. If the queue had drained (idle, not stopped),
+    /// resumes from where it left off.
+    func enqueue(_ chunk: Data) {
+        queue.append(chunk)
+        if !isPlaying && !isPaused && index < queue.count {
+            startCurrent()
+        }
+    }
+
+    /// Signals that no more chunks will be enqueued. If the queue has already
+    /// drained, fires `onFinished` now; otherwise the last chunk's finish will.
+    func markInputComplete() {
+        inputComplete = true
+        if !isPlaying && !isPaused && index >= queue.count {
+            deliverCompletion()
+        }
+    }
+
+    func pause() {
+        guard isPlaying else { return }
+        current?.pause()
+        isPlaying = false
+        isPaused = true
+    }
+
+    func resume() {
+        guard isPaused else { return }
+        current?.resume()
+        isPaused = false
+        isPlaying = true
+    }
+
+    /// Stops + clears the queue. Idempotent. Never fires `onFinished`.
+    func stop() {
+        generation &+= 1
+        detachCurrent()
+        queue = []
+        index = 0
+        isPlaying = false
+        isPaused = false
+        inputComplete = false
+        completionDelivered = false
+    }
+
+    // MARK: - Private
+
+    /// Fires `onFinished` at most once per playback run.
+    private func deliverCompletion() {
+        guard !completionDelivered else { return }
+        completionDelivered = true
+        onFinished?()
+    }
+
+    private func resetForNewPlayback() {
+        generation &+= 1
+        detachCurrent()
+        index = 0
+        isPlaying = false
+        isPaused = false
+        completionDelivered = false
+    }
+
+    /// Detaches the current player's callbacks (so a stale finish can't fire)
+    /// and stops it.
+    private func detachCurrent() {
+        current?.onFinish = nil
+        current?.onFailure = nil
+        current?.stop()
+        current = nil
+    }
+
+    private func startCurrent() {
+        guard index < queue.count else {
+            isPlaying = false
+            if inputComplete { deliverCompletion() }
+            return
+        }
+        let gen = generation
+        do {
+            let player = try makePlayer(queue[index])
+            player.onFinish = { [weak self] in self?.handleFinish(gen: gen) }
+            player.onFailure = { [weak self] in self?.handleFailure(gen: gen) }
+            current = player
+            isPlaying = true
+            isPaused = false
+            player.play()
+            onChunkStarted?(index)
+        } catch {
+            Self.log.error("chunk \(self.index) playback build failed: \(String(describing: error), privacy: .public)")
+            isPlaying = false
+            onError?(error)
+        }
+    }
+
+    private func handleFinish(gen: Int) {
+        guard gen == generation else { return } // stale (stopped/replaced) → ignore
+        index += 1
+        current = nil
+        startCurrent()
+    }
+
+    private func handleFailure(gen: Int) {
+        guard gen == generation else { return }
+        Self.log.error("chunk \(self.index) playback finished unsuccessfully")
+        isPlaying = false
+        current = nil
+        onError?(PlaybackError.chunkPlaybackFailed)
+    }
+}
+
+/// Production `SpeechAudioPlaying` backed by `AVAudioPlayer`.
+@MainActor
+final class AVAudioPlayerBox: NSObject, SpeechAudioPlaying, AVAudioPlayerDelegate {
+    var onFinish: (() -> Void)?
+    var onFailure: (() -> Void)?
+    private let player: AVAudioPlayer
+
+    init(data: Data) throws {
+        player = try AVAudioPlayer(data: data)
+        super.init()
+        player.delegate = self
+        player.prepareToPlay()
+    }
+
+    func play() { player.play() }
+    func pause() { player.pause() }
+    func resume() { player.play() }
+    func stop() { player.stop() }
+
+    nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor in
+            if flag { self.onFinish?() } else { self.onFailure?() }
+        }
+    }
+}

--- a/vreaderTests/Services/TTS/HTTPTTSChunkPlayerTests.swift
+++ b/vreaderTests/Services/TTS/HTTPTTSChunkPlayerTests.swift
@@ -1,0 +1,200 @@
+// Purpose: Tests for HTTPTTSChunkPlayer (feature #72 WI-2) — sequential
+// audio-chunk playback queue. A stub `SpeechAudioPlaying` drives the queue
+// deterministically (no real AVAudioPlayer), pinning play-next / pause / resume
+// / stop / streaming-enqueue + the generation-token (stale-finish) and
+// input-complete (drain ≠ done) semantics from the Gate-4 round-1 fixes.
+//
+// @coordinates-with: HTTPTTSChunkPlayer.swift, GH #1174 (Feature #72)
+
+import Testing
+import Foundation
+@testable import vreader
+
+@MainActor
+@Suite("HTTPTTSChunkPlayer (Feature #72 WI-2)")
+struct HTTPTTSChunkPlayerTests {
+
+    @MainActor
+    final class StubPlayer: SpeechAudioPlaying {
+        var onFinish: (() -> Void)?
+        var onFailure: (() -> Void)?
+        private(set) var played = false
+        private(set) var paused = false
+        private(set) var resumed = false
+        private(set) var stopped = false
+        func play() { played = true }
+        func pause() { paused = true }
+        func resume() { resumed = true }
+        func stop() { stopped = true }
+        /// Simulate a successful finish (only advances if still attached).
+        func finish() { onFinish?() }
+        func failPlayback() { onFailure?() }
+    }
+
+    @MainActor
+    final class PlayerFactory {
+        private(set) var built: [StubPlayer] = []
+        var throwOnIndex: Int?
+        enum BuildError: Error { case failed }
+        func make(_ data: Data) throws -> SpeechAudioPlaying {
+            if let t = throwOnIndex, built.count == t { throw BuildError.failed }
+            let p = StubPlayer()
+            built.append(p)
+            return p
+        }
+    }
+
+    private func chunks(_ n: Int) -> [Data] { (0..<n).map { Data("chunk-\($0)".utf8) } }
+
+    @Test func playsChunksSequentiallyFiringStartedThenFinished() {
+        let factory = PlayerFactory()
+        var started: [Int] = []
+        var finished = false
+        let player = HTTPTTSChunkPlayer(makePlayer: factory.make)
+        player.onChunkStarted = { started.append($0) }
+        player.onFinished = { finished = true }
+
+        player.play(chunks: chunks(3))  // inputComplete defaults true
+        #expect(started == [0])
+        factory.built[0].finish()
+        #expect(started == [0, 1])
+        factory.built[1].finish()
+        #expect(started == [0, 1, 2])
+        #expect(finished == false)
+        factory.built[2].finish()
+        #expect(started == [0, 1, 2])
+        #expect(finished)
+        #expect(player.isPlaying == false)
+    }
+
+    @Test func pauseAndResumeMapToCurrentChunkPlayer() {
+        let factory = PlayerFactory()
+        let player = HTTPTTSChunkPlayer(makePlayer: factory.make)
+        player.play(chunks: chunks(2))
+        player.pause()
+        #expect(factory.built[0].paused)
+        #expect(player.isPaused && !player.isPlaying)
+        player.resume()
+        #expect(factory.built[0].resumed)
+        #expect(!player.isPaused && player.isPlaying)
+    }
+
+    // Gate-4 round-1 H1/M3: a late finish from a STOPPED player must NOT advance
+    // the queue NOR fire onFinished.
+    @Test func stop_thenStaleFinish_doesNotAdvanceNorFinish() {
+        let factory = PlayerFactory()
+        var finished = false
+        let player = HTTPTTSChunkPlayer(makePlayer: factory.make)
+        player.onFinished = { finished = true }
+        player.play(chunks: chunks(3))
+
+        player.stop()
+        #expect(factory.built[0].stopped)
+        #expect(player.isPlaying == false)
+
+        factory.built[0].finish()           // stale callback (detached + gen bumped)
+        #expect(factory.built.count == 1, "stale finish must not build a new chunk")
+        #expect(finished == false, "stale finish must not fire onFinished")
+    }
+
+    // Gate-4 round-1 H1: a stale finish from the OLD queue must not skip into a
+    // newly started (replacement) queue.
+    @Test func replacePlay_thenStaleFinishFromOldQueue_cannotSkipNewChunk0() {
+        let factory = PlayerFactory()
+        var started: [Int] = []
+        let player = HTTPTTSChunkPlayer(makePlayer: factory.make)
+        player.onChunkStarted = { started.append($0) }
+        player.play(chunks: chunks(2))      // builds player[0]
+        let stale = factory.built[0]
+
+        player.play(chunks: chunks(2))      // replace → builds player[1] (new chunk 0)
+        stale.finish()                      // stale finish from the replaced queue
+        // The new queue must still be at its chunk 0 (not skipped to chunk 1).
+        #expect(started == [0, 0], "replacement started chunk 0; stale finish must not advance it")
+    }
+
+    // Gate-4 round-1 H2: streaming — draining the queue is NOT completion;
+    // onFinished waits for markInputComplete().
+    @Test func streaming_drainBeforeInputComplete_doesNotFinishPrematurely() {
+        let factory = PlayerFactory()
+        var finished = false
+        let player = HTTPTTSChunkPlayer(makePlayer: factory.make)
+        player.onFinished = { finished = true }
+
+        player.play(chunks: chunks(1), inputComplete: false)  // streaming
+        factory.built[0].finish()           // queue drained, but input not complete
+        #expect(finished == false, "drain before input-complete must not finish")
+        #expect(player.isPlaying == false)
+
+        player.enqueue(Data("late".utf8))    // a late chunk resumes playback
+        #expect(factory.built.count == 2)
+        factory.built[1].finish()
+        #expect(finished == false)           // still not marked complete
+        player.markInputComplete()           // now done → fires
+        #expect(finished)
+    }
+
+    @Test func markInputComplete_whileStillPlaying_finishesOnLastChunk() {
+        let factory = PlayerFactory()
+        var finished = false
+        let player = HTTPTTSChunkPlayer(makePlayer: factory.make)
+        player.onFinished = { finished = true }
+        player.play(chunks: chunks(2), inputComplete: false)
+        player.markInputComplete()           // input done, but chunks still playing
+        #expect(finished == false)
+        factory.built[0].finish()
+        factory.built[1].finish()
+        #expect(finished, "onFinished fires once the last chunk finishes after input-complete")
+    }
+
+    // Gate-4 round-2: onFinished fires at most once even if markInputComplete()
+    // is called repeatedly after the queue has drained.
+    @Test func markInputComplete_isIdempotent_finishesOnce() {
+        let factory = PlayerFactory()
+        var finishCount = 0
+        let player = HTTPTTSChunkPlayer(makePlayer: factory.make)
+        player.onFinished = { finishCount += 1 }
+        player.play(chunks: chunks(1), inputComplete: false)
+        factory.built[0].finish()           // drained, not complete
+        player.markInputComplete()           // fires once
+        player.markInputComplete()           // must NOT re-fire
+        player.markInputComplete()
+        #expect(finishCount == 1)
+    }
+
+    @Test func emptyChunksWithInputComplete_firesFinishedImmediately() {
+        let factory = PlayerFactory()
+        var finished = false
+        let player = HTTPTTSChunkPlayer(makePlayer: factory.make)
+        player.onFinished = { finished = true }
+        player.play(chunks: [])
+        #expect(finished)
+        #expect(factory.built.isEmpty)
+    }
+
+    @Test func buildFailureFiresOnError_andStopsCleanly() {
+        let factory = PlayerFactory()
+        factory.throwOnIndex = 0
+        var errored = false
+        let player = HTTPTTSChunkPlayer(makePlayer: factory.make)
+        player.onError = { _ in errored = true }
+        player.play(chunks: chunks(2))
+        #expect(errored)
+        #expect(player.isPlaying == false)
+    }
+
+    // Gate-4 round-1 M2: an UNsuccessful finish routes to onError, not advance.
+    @Test func unsuccessfulFinish_firesOnError_doesNotAdvance() {
+        let factory = PlayerFactory()
+        var errored = false
+        var started: [Int] = []
+        let player = HTTPTTSChunkPlayer(makePlayer: factory.make)
+        player.onError = { _ in errored = true }
+        player.onChunkStarted = { started.append($0) }
+        player.play(chunks: chunks(2))
+        factory.built[0].failPlayback()
+        #expect(errored)
+        #expect(started == [0], "an unsuccessful finish must not advance to chunk 1")
+        #expect(player.isPlaying == false)
+    }
+}


### PR DESCRIPTION
## Summary
WI-2 of feature #72. Sequential audio-chunk playback queue (`HTTPTTSChunkPlayer`) for the cloud-TTS path: plays the per-sentence audio `Data` chunks back-to-back via `AVAudioPlayer` behind a `SpeechAudioPlaying` seam. Fires `onChunkStarted(index)` (→ WI-3 emits chunk-range `willSpeakRange`) and `onFinished` once a complete input drains. Does NOT manage `AVAudioSession` (TTSService owns it — Gate-2 M1).

Part of feature #72

## Codex Audit (Gate 4)
Thread `019e63a1`, **3 rounds, ship-as-is**. 2 High + 3 Medium resolved: stale-finish across stop/replace (generation token), drain≠complete for streaming (`inputComplete`/`markInputComplete`), `successfully:false`→onError, one-shot completion.

## Validation
- [x] `HTTPTTSChunkPlayerTests` — 10 tests pass (stub seam; covers stale-finish, replacement-queue, streaming drain, idempotent completion, unsuccessful finish). UDID-pinned, parallel off.
- [x] Version bumped 3.39.26 → 3.39.27.

## Gate 5 (tier)
Behavioral logic; unit + audit. The live AVAudioPlayer path is exercised end-to-end in WI-3/WI-4.

## Type of Change
- [x] Feature WI (Part of feature #72)

🤖 Generated with [Claude Code](https://claude.com/claude-code)