### PR TITLE
feat(#71 WI-5): EPUB continuous-scroll bridge plumbing

### DIFF
--- a/.claude/codex-audits/feat-feature-71-wi-5-bridge-plumbing-audit.md
+++ b/.claude/codex-audits/feat-feature-71-wi-5-bridge-plumbing-audit.md
@@ -1,0 +1,71 @@
+---
+branch: feat/feature-71-wi-5-bridge-plumbing
+threadId: 019e6541-13b3-7520-92d5-07446a5fb85e
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-05-27
+---
+
+# Codex Audit — Feature #71 WI-5 (EPUB continuous scroll — bridge plumbing)
+
+Wires the four foundational WIs (EPUBSpineWindow, EPUBChapterBodyRewriter,
+EPUBContinuousScrollJS, EPUBContinuousScrollCoordinator) into `EPUBWebViewBridge`:
+a `continuousScroll: EPUBContinuousScrollConfig?` input that, when non-nil,
+mode-branches script/handler injection (the section-aware observer replaces
+`progressTrackingJS`), parses the `continuousScrollHandler` JS message into
+`EPUBScrollBoundarySignal`, drives windowed whole-book progress, and attributes
+selections to their section href. Additive — nil config ⇒ the legacy
+one-chapter path is byte-identical.
+
+## Round 1 — 1 High / 1 Medium / 1 Low
+
+| file:line | severity | issue | resolution |
+|---|---|---|---|
+| EPUBHighlightJS.swift (selection JS) | **High** | Tagging the selection with the START section's `data-vreader-href` without clamping the range left a cross-divider drag with `endPath`/`endOffset` in the NEXT section — an invalid mixed-section anchor for per-section restore. | **Fixed.** The selection JS now resolves both start + end section ancestors; when they differ it clamps `range.setEnd(startSection, startSection.childNodes.length)` (the plan's [C1] clamp-to-start-section), re-reads `text`+`rect`, and rejects (no postMessage) if the clamp empties the selection. Legacy mode (both sections null) never runs the clamp. |
+| EPUBContinuousScrollBridge.swift:96 | Medium | `visibleSpineIndex` parse too permissive — `Int(d)` truncated `3.9`→3 and a bool-backed `NSNumber` (`true`) became `1`. | **Fixed.** `intValue` rejects bools, bool-backed `NSNumber` (`CFGetTypeID == CFBooleanGetTypeID`), and non-integral/non-finite Doubles (`d == d.rounded()`); `doubleValue` similarly rejects bools/non-finite. Added tests: `rejectsFractionalIndex`, `rejectsBoolIndex`, `rejectsBoolFraction`. |
+| EPUBWebViewBridge.swift:162 | Low | (round-1) Claimed `dismantleUIView` teardown asymmetry. | Initially mis-rebutted (I grepped the wrong files); resolved in round 2 — see below. |
+
+Round 1 confirmed clean: nil-config legacy path byte-identical; `progressTrackingJS`
+correctly replaced (not doubled) in continuous mode; `onProgressChange` before
+the `await handleBoundarySignal` is fine (progress derives from the current
+observer signal, not the post-mutation window); the `sectionHref` JS addition is
+injection-safe; the ungated Foundation-only helper file is fine.
+
+## Round 2 — Low (teardown, corrected)
+
+Codex corrected my round-1 rebuttal: `dismantleUIView` DOES exist (in
+`EPUBWebViewBridgeJS.swift`) and removed only the legacy handlers, so the new
+`continuousScrollHandler` teardown was genuinely missing.
+
+**Fixed.** `dismantleUIView` now also `removeScriptMessageHandler(forName:
+"continuousScrollHandler")` (unconditional, like the other handlers — a safe
+no-op in legacy mode where it was never registered). The bilingual enumerate
+handler teardown gap Codex also noted is **pre-existing** (Feature #56 WI-10,
+not WI-5) and left out to keep the WI-5 diff focused — noted for a separate
+cleanup.
+
+Round 2 confirmed both substantive fixes correct: the JS clamp produces a range
+ending inside one section (no leak into the next chapter) with the right
+degenerate reject; the parser hardening matches the bridge contract.
+
+## Round 3 — clean
+
+**Ship-as-is.** Teardown fix correct + symmetric; no remaining WI-5-specific
+blocker. Cross-section clamp aligned with the plan, parser hole closed, legacy
+path unchanged, handler set intact in both modes.
+
+## Summary
+
+3 rounds, 1 High + 1 Medium + 1 Low fixed, final verdict **ship-as-is**.
+
+## Gate-5a note (per-WI slice)
+
+WI-5 is behavioral but its runtime path is not reachable until WI-6 constructs
+the `EPUBContinuousScrollConfig` (coordinator + chapterBodyProvider + bootstrap).
+Pre-merge slice verification for WI-5 is therefore: (a) the pure logic
+(`EPUBScrollBoundarySignal.parse`, `windowedProgress`, section-href parsing)
+is unit-tested (`EPUBContinuousScrollBridgeTests`, 18 cases); (b) the full suite
+stays green (7254 tests, 0 failures), confirming the nil-config legacy path is
+behaviorally unchanged. End-to-end continuous-scroll behavior (the live observer
+→ window-transition → windowed-progress loop, and the cross-section selection
+clamp DOM behavior) is verified at WI-6 + the final-WI Gate-5b device pass.

--- a/project.yml
+++ b/project.yml
@@ -162,8 +162,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 660
-        MARKETING_VERSION: 3.39.39
+        CURRENT_PROJECT_VERSION: 661
+        MARKETING_VERSION: 3.39.40
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6540,13 +6540,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 660;
+				CURRENT_PROJECT_VERSION = 661;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.39.39;
+				MARKETING_VERSION = 3.39.40;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6690,13 +6690,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 660;
+				CURRENT_PROJECT_VERSION = 661;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.39.39;
+				MARKETING_VERSION = 3.39.40;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		141F45BA08B548F16178BED0 /* EPUBBilingualOrchestratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB4A7D407350F9C903A4A541 /* EPUBBilingualOrchestratorTests.swift */; };
 		14471AC7E32BFFD1BBAFB829 /* EPUBContinuousScrollJSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3985B5AA10C2F75D5A24CF3 /* EPUBContinuousScrollJSTests.swift */; };
 		1486C59650FEE786655A27F0 /* ReTranslateProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB32B8E264864D8B94DE2EC /* ReTranslateProgress.swift */; };
+		149A6822E6971C612A1D9CAA /* EPUBContinuousScrollBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = F05F28A8422C4AB0951D9586 /* EPUBContinuousScrollBridge.swift */; };
 		15560934D5C58CBA9C8A2AFD /* FoliatePositionRestoreController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86C32AA4EAE4EA8014E71A14 /* FoliatePositionRestoreController.swift */; };
 		1558B65D447DCD7705FE074C /* FoliateTTSAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C511C16F7FA93E91D703EE7 /* FoliateTTSAdapterTests.swift */; };
 		15755FFB1E8245ED4DF9DC72 /* Bug233AZW3SeedVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA7880EAC5DA9681AC6EF498 /* Bug233AZW3SeedVerificationTests.swift */; };
@@ -755,6 +756,7 @@
 		8D1AD9D6AB520C84D8FB8C5C /* ReTranslatePickerSheetParts.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFBB11138D2CD941FF1E509 /* ReTranslatePickerSheetParts.swift */; };
 		8D6ECB8A09289C09C71F2047 /* ModelContainerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4456336AA865CC6E79488325 /* ModelContainerFactory.swift */; };
 		8D9277E9CE45C89DFF9E268A /* TXTReaderContainerHighlightCoordinatorWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17C33D19BD1735676CA01BC /* TXTReaderContainerHighlightCoordinatorWiringTests.swift */; };
+		8D9AD3E7DBF75947649FCF4F /* EPUBContinuousScrollBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEE938E6CF2DEA2224E7E8D /* EPUBContinuousScrollBridgeTests.swift */; };
 		8DDE8D9EB1A613F6C2633FEE /* book_detail.html in Resources */ = {isa = PBXBuildFile; fileRef = D93B1B1740BEE1A1510B831A /* book_detail.html */; };
 		8E1191858A20241FD836F401 /* ProviderProfileMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E550B37E4C8E30F6A9238E2 /* ProviderProfileMigrator.swift */; };
 		8E153D7C3B713EDDBF484A24 /* AIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334D6D06A294323E149970E4 /* AIService.swift */; };
@@ -1742,6 +1744,7 @@
 		4C19E96D5AE40D3577255C38 /* TXTChapterHighlightHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterHighlightHelperTests.swift; sourceTree = "<group>"; };
 		4C87C165AFE78571456C14D1 /* LocatorValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorValidationTests.swift; sourceTree = "<group>"; };
 		4CC7EBBBE07E87F07CC0FE4F /* ReaderNotificationHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderNotificationHandlerTests.swift; sourceTree = "<group>"; };
+		4CEE938E6CF2DEA2224E7E8D /* EPUBContinuousScrollBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBContinuousScrollBridgeTests.swift; sourceTree = "<group>"; };
 		4CFB16A6AE1039A0BD5F36E3 /* ReaderSearchCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSearchCoordinatorTests.swift; sourceTree = "<group>"; };
 		4D4E5558CB75432C026267C1 /* LibraryBookItemFileStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryBookItemFileStateTests.swift; sourceTree = "<group>"; };
 		4D5CDE195E585067DE4D6124 /* AnnotationListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationListViewModelTests.swift; sourceTree = "<group>"; };
@@ -2610,6 +2613,7 @@
 		F0109C1BF00E2339347FEC04 /* EPUBWebViewBridgeEarlySettleFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBWebViewBridgeEarlySettleFallbackTests.swift; sourceTree = "<group>"; };
 		F02AE770B22BFE6D2F175A1A /* TXTChapterIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterIndex.swift; sourceTree = "<group>"; };
 		F038832B6A3B0C184154B6AD /* PipelineTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipelineTypes.swift; sourceTree = "<group>"; };
+		F05F28A8422C4AB0951D9586 /* EPUBContinuousScrollBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBContinuousScrollBridge.swift; sourceTree = "<group>"; };
 		F069A328AA628585D86B52B2 /* SyncStatusViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusViewTests.swift; sourceTree = "<group>"; };
 		F114D9F3F59EEF655D5327EA /* EPUBCoverParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBCoverParsingTests.swift; sourceTree = "<group>"; };
 		F16AF7EAA6EC1F1D0D126E75 /* BasePageNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePageNavigator.swift; sourceTree = "<group>"; };
@@ -3156,6 +3160,7 @@
 				4613C1666E0FA587EAA979C0 /* EPUBChapterBodyRewriterTests.swift */,
 				66440341C1BA8050AFD3A65C /* EPUBChapterNavigationRouterTests.swift */,
 				864BA35C7F82D6437278E5C6 /* EPUBChapterWrapPendingTargetTests.swift */,
+				4CEE938E6CF2DEA2224E7E8D /* EPUBContinuousScrollBridgeTests.swift */,
 				D83B95243CB982CBD7060B74 /* EPUBContinuousScrollCoordinatorTests.swift */,
 				D3985B5AA10C2F75D5A24CF3 /* EPUBContinuousScrollJSTests.swift */,
 				73A837FEAF314B6AC6ECFE2C /* EPUBDebugBridgeHighlightJSTests.swift */,
@@ -3706,6 +3711,7 @@
 				D4155E7139CA2623252814A6 /* EPUBChapterNavigationRouter.swift */,
 				DC089C251F85AABA6BF4C347 /* EPUBChapterResourceURL.swift */,
 				7D9CC8400AF6E7894D65B332 /* EPUBChapterWrapPendingTarget.swift */,
+				F05F28A8422C4AB0951D9586 /* EPUBContinuousScrollBridge.swift */,
 				F231D5A44103A0EF99F3EAB4 /* EPUBContinuousScrollCoordinator.swift */,
 				AD46F11BC7E87EC46B65BAF6 /* EPUBContinuousScrollJS.swift */,
 				60F442A575A04CD706CC53FE /* EPUBDebugBridgeHighlightJS.swift */,
@@ -5300,6 +5306,7 @@
 				1FDCE173037798993D15A8AC /* EPUBChapterNavigationRouterTests.swift in Sources */,
 				6179B1DCDC87E71E3A7218CC /* EPUBChapterWrapPendingTargetTests.swift in Sources */,
 				D19881EF60E15DFDCFF74173 /* EPUBComplexityClassifierTests.swift in Sources */,
+				8D9AD3E7DBF75947649FCF4F /* EPUBContinuousScrollBridgeTests.swift in Sources */,
 				BB8365401FF8C7F540E859AA /* EPUBContinuousScrollCoordinatorTests.swift in Sources */,
 				14471AC7E32BFFD1BBAFB829 /* EPUBContinuousScrollJSTests.swift in Sources */,
 				DA905A71521E684A242CDCAD /* EPUBCoverParsingTests.swift in Sources */,
@@ -5896,6 +5903,7 @@
 				10E1115017B00458750D678F /* EPUBChapterTextProvider.swift in Sources */,
 				D1FAFF6776C004BAC2173934 /* EPUBChapterWrapPendingTarget.swift in Sources */,
 				542FF947F7F993A2904D56C2 /* EPUBComplexityClassifier.swift in Sources */,
+				149A6822E6971C612A1D9CAA /* EPUBContinuousScrollBridge.swift in Sources */,
 				BEA7294536FB169F4C42A94A /* EPUBContinuousScrollCoordinator.swift in Sources */,
 				5750ED10A89C2B7BCD251C3C /* EPUBContinuousScrollJS.swift in Sources */,
 				1159169FBD348FB0518A7F68 /* EPUBDebugBridgeHighlightJS.swift in Sources */,

--- a/vreader/Views/Reader/EPUBContinuousScrollBridge.swift
+++ b/vreader/Views/Reader/EPUBContinuousScrollBridge.swift
@@ -1,0 +1,134 @@
+// Purpose: Feature #71 WI-5 — the bridge-side glue between the continuous-scroll
+// JS observer and `EPUBWebViewBridge`. Holds the value type the bridge accepts as
+// its `continuousScroll:` input (`EPUBContinuousScrollConfig`), the pure parser
+// for the `continuousScrollHandler` JS message (`EPUBScrollBoundarySignal.parse`),
+// and the windowed whole-book progress mapping (reusing `EPUBProgressCalculator`,
+// unchanged per the plan). The bridge's `makeUIView` branches on a non-nil config
+// to inject the section-aware observer (`EPUBContinuousScrollJS.continuousScrollObserverJS`)
+// in place of the single-document `progressTrackingJS`, register the
+// `continuousScrollHandler` channel, and route each boundary signal to the
+// `EPUBContinuousScrollCoordinator` (window transitions, WI-4) while feeding the
+// windowed spine-index + fraction to the existing `onProgressChange` contract.
+//
+// Pure + unit-testable (no live WKWebView): the parser + progress mapping are
+// exercised by `EPUBContinuousScrollBridgeTests`; the live observer/handler
+// injection is representable-context plumbing verified at Gate-5 (the WI-6
+// container wiring is what first drives a real continuous-scroll session).
+//
+// @coordinates-with: EPUBContinuousScrollCoordinator.swift (EPUBScrollBoundarySignal),
+//   EPUBContinuousScrollJS.swift, EPUBWebViewBridge.swift,
+//   EPUBWebViewBridgeCoordinator.swift, EPUBProgressCalculator.swift,
+//   dev-docs/plans/20260525-feature-71-epub-continuous-scroll.md (WI-5)
+
+import Foundation
+
+/// The `continuousScroll:` input on `EPUBWebViewBridge` (nil ⇒ the legacy
+/// one-chapter-per-`loadFileURL` path, byte-identical for paged + the existing
+/// single-chapter scroll behaviour). When non-nil, the bridge stitches a windowed
+/// multi-chapter DOM and drives it through `coordinator`.
+///
+/// Holds a reference to the `@MainActor` coordinator + the book's spine count
+/// (for the windowed progress mapping). Constructed by the WI-6 container, which
+/// owns the `chapterBodyProvider` + restore logic the coordinator is wired with.
+@MainActor
+struct EPUBContinuousScrollConfig {
+    /// The window-transition decision engine (WI-4). The bridge forwards every
+    /// parsed boundary signal to `coordinator.handleBoundarySignal(_:)`.
+    let coordinator: EPUBContinuousScrollCoordinator
+    /// Total spine items in the book — the denominator for whole-book progress.
+    let totalSpineCount: Int
+
+    init(coordinator: EPUBContinuousScrollCoordinator, totalSpineCount: Int) {
+        self.coordinator = coordinator
+        self.totalSpineCount = totalSpineCount
+    }
+
+    /// Whole-book progress for a boundary signal, reusing the existing EPUB
+    /// progress formula `(spineIndex + scrollFraction) / totalSpineItems`
+    /// (`EPUBProgressCalculator`, unchanged — the windowed `{visibleSpineIndex,
+    /// intraFraction}` simply feeds it). Instance convenience over the static.
+    func windowedProgress(for signal: EPUBScrollBoundarySignal) -> Double {
+        Self.windowedProgress(signal: signal, totalSpineCount: totalSpineCount)
+    }
+
+    /// Pure mapping (no coordinator access) so it is unit-testable without a
+    /// live coordinator. Guards a zero spine count (no divide-by-zero) and
+    /// clamps to 0...1 via `EPUBProgressCalculator`.
+    nonisolated static func windowedProgress(signal: EPUBScrollBoundarySignal, totalSpineCount: Int) -> Double {
+        EPUBProgressCalculator.progress(
+            spineIndex: signal.visibleSpineIndex,
+            scrollFraction: signal.intraFraction,
+            totalSpineItems: totalSpineCount
+        )
+    }
+}
+
+extension EPUBScrollBoundarySignal {
+
+    /// Parse a `continuousScrollHandler` JS-message body into a boundary signal.
+    ///
+    /// Shape (`EPUBContinuousScrollJS.continuousScrollObserverJS`):
+    /// `{ visibleSpineIndex: Int≥0, intraFraction: 0...1, nearTopBoundary: Bool,
+    ///    nearBottomBoundary: Bool }`. Returns nil when the body is not a
+    /// dictionary, `visibleSpineIndex` is missing / negative, or `intraFraction`
+    /// is missing. `intraFraction` is clamped to 0...1 (defensive against a JS
+    /// rounding overshoot). The boundary flags default to `false` when absent
+    /// (a missing flag means "not near that edge").
+    ///
+    /// JS booleans arrive over the WKScriptMessage bridge as `NSNumber`, so the
+    /// flag coercion accepts `Bool` or `NSNumber`; the numerics accept any
+    /// `NSNumber` (Int or integer-valued Double).
+    nonisolated static func parse(_ body: Any) -> EPUBScrollBoundarySignal? {
+        guard let dict = body as? [String: Any] else { return nil }
+        guard let visibleSpineIndex = intValue(dict["visibleSpineIndex"]), visibleSpineIndex >= 0 else {
+            return nil
+        }
+        guard let rawFraction = doubleValue(dict["intraFraction"]) else { return nil }
+        let intraFraction = min(max(rawFraction, 0), 1)
+        return EPUBScrollBoundarySignal(
+            visibleSpineIndex: visibleSpineIndex,
+            intraFraction: intraFraction,
+            nearTopBoundary: boolValue(dict["nearTopBoundary"]),
+            nearBottomBoundary: boolValue(dict["nearBottomBoundary"])
+        )
+    }
+
+    /// Strict integral coercion (Gate-4 round-1 Medium): a spine index must be a
+    /// non-bool, finite, *integral* number. Rejects a bool-backed `NSNumber`
+    /// (a JS `true` is not index 1) and a fractional Double (`3.9` is malformed,
+    /// not index 3) rather than silently coercing them.
+    private nonisolated static func intValue(_ any: Any?) -> Int? {
+        if any is Bool { return nil }
+        if let i = any as? Int { return i }
+        if let n = any as? NSNumber {
+            if CFGetTypeID(n) == CFBooleanGetTypeID() { return nil }
+            let d = n.doubleValue
+            guard d.isFinite, d == d.rounded() else { return nil }
+            return n.intValue
+        }
+        if let d = any as? Double {
+            guard d.isFinite, d == d.rounded() else { return nil }
+            return Int(d)
+        }
+        return nil
+    }
+
+    /// Finite Double coercion. Rejects a bool-backed `NSNumber` (a JS boolean is
+    /// not a fraction) so a malformed `intraFraction: true` isn't read as `1.0`.
+    private nonisolated static func doubleValue(_ any: Any?) -> Double? {
+        if any is Bool { return nil }
+        if let d = any as? Double { return d.isFinite ? d : nil }
+        if let n = any as? NSNumber {
+            if CFGetTypeID(n) == CFBooleanGetTypeID() { return nil }
+            return n.doubleValue.isFinite ? n.doubleValue : nil
+        }
+        if let i = any as? Int { return Double(i) }
+        return nil
+    }
+
+    private nonisolated static func boolValue(_ any: Any?) -> Bool {
+        if let b = any as? Bool { return b }
+        if let n = any as? NSNumber { return n.boolValue }
+        return false
+    }
+}

--- a/vreader/Views/Reader/EPUBHighlightBridge.swift
+++ b/vreader/Views/Reader/EPUBHighlightBridge.swift
@@ -19,6 +19,13 @@ struct EPUBSelectionMessage: Sendable {
     let selectedText: String
     let range: EPUBSerializedRange
     let sourceRect: CGRect
+    /// Feature #71 WI-5: in continuous-scroll mode the stitched DOM holds many
+    /// chapters, so a selection must be attributed to *its* section's href
+    /// (`closest('[data-vreader-spine-index]')`'s `data-vreader-href`), not the
+    /// global "current" chapter. The selection JS reports it; nil in legacy
+    /// single-chapter mode (no `data-vreader-href` ancestor) so the coordinator
+    /// falls back to `currentHref` — keeping the one-chapter path unchanged.
+    let sectionHref: String?
 }
 
 /// Bridge for EPUB text selection and highlight JS interop.
@@ -59,10 +66,17 @@ enum EPUBHighlightBridge {
             endOffset: endOffset
         )
 
+        // Feature #71 WI-5: optional section href (continuous-scroll attribution).
+        // Absent in legacy single-chapter mode; an empty string (degenerate
+        // clamp — selection start had no section ancestor) is treated as nil so
+        // the coordinator falls back to `currentHref`.
+        let sectionHref = (dict["sectionHref"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+
         return EPUBSelectionMessage(
             selectedText: selectedText,
             range: range,
-            sourceRect: CGRect(x: rectX, y: rectY, width: rectWidth, height: rectHeight)
+            sourceRect: CGRect(x: rectX, y: rectY, width: rectWidth, height: rectHeight),
+            sectionHref: sectionHref
         )
     }
 

--- a/vreader/Views/Reader/EPUBHighlightJS.swift
+++ b/vreader/Views/Reader/EPUBHighlightJS.swift
@@ -83,6 +83,33 @@ extension EPUBHighlightBridge {
                 if (!text || !text.trim()) return;
 
                 var rect = range.getBoundingClientRect();
+                // Feature #71 WI-5: attribute the selection to its section's href
+                // in continuous-scroll mode (the stitched DOM holds many chapters).
+                // closest('[data-vreader-href]') of the START / END containers'
+                // elements; both null in legacy single-chapter mode (no such
+                // ancestor) → Swift reads nil and falls back to the global
+                // currentHref, leaving the one-chapter path unchanged.
+                var startEl = range.startContainer.nodeType === 1
+                    ? range.startContainer
+                    : range.startContainer.parentElement;
+                var endEl = range.endContainer.nodeType === 1
+                    ? range.endContainer
+                    : range.endContainer.parentElement;
+                var startSection = startEl ? startEl.closest('[data-vreader-href]') : null;
+                var endSection = endEl ? endEl.closest('[data-vreader-href]') : null;
+                // Gate-2 [C1]: a drag can cross a chapter boundary in the stitched
+                // DOM. A mixed-section range (start in section A, end in B) can't be
+                // restored/painted per-section, so CLAMP the range to the END of the
+                // START section — the popover then operates on that single section's
+                // text. If the clamp empties the selection (degenerate), REJECT it
+                // (no popover). In legacy mode startSection/endSection are null so
+                // this never runs.
+                if (startSection && endSection && startSection !== endSection) {
+                    range.setEnd(startSection, startSection.childNodes.length);
+                    text = range.toString();
+                    if (!text || !text.trim()) return;
+                    rect = range.getBoundingClientRect();
+                }
                 var msg = {
                     selectedText: text,
                     startPath: getXPath(range.startContainer),
@@ -92,7 +119,8 @@ extension EPUBHighlightBridge {
                     rectX: rect.x,
                     rectY: rect.y,
                     rectWidth: rect.width,
-                    rectHeight: rect.height
+                    rectHeight: rect.height,
+                    sectionHref: startSection ? startSection.getAttribute('data-vreader-href') : null
                 };
                 window.webkit.messageHandlers.selectionChanged.postMessage(msg);
             }, 300);

--- a/vreader/Views/Reader/EPUBWebViewBridge.swift
+++ b/vreader/Views/Reader/EPUBWebViewBridge.swift
@@ -101,6 +101,14 @@ struct EPUBWebViewBridge: UIViewRepresentable {
     var pendingJS: String?
     /// Called after pendingJS has been evaluated so the container can clear state.
     var onPendingJSCompleted: (@MainActor () -> Void)?
+    /// Feature #71 WI-5: continuous cross-chapter scroll config. `nil` ⇒ the
+    /// legacy one-chapter-per-`loadFileURL` path (paged + the existing
+    /// single-chapter scroll behaviour), unchanged. When non-nil, `makeUIView`
+    /// injects the section-aware observer (in place of `progressTrackingJS`),
+    /// registers the `continuousScrollHandler` channel, and the coordinator
+    /// routes each boundary signal to `config.coordinator` (window transitions)
+    /// while feeding the windowed spine-index + fraction to `onProgressChange`.
+    var continuousScroll: EPUBContinuousScrollConfig?
     /// Whether paged layout is enabled (CSS multi-column pagination).
     var isPaged: Bool = false
     /// Page index to navigate to in paged mode (0-based).
@@ -136,15 +144,32 @@ struct EPUBWebViewBridge: UIViewRepresentable {
         )
         userContentController.addUserScript(preprocessScript)
 
-        // Add scroll progress tracking script (throttled)
-        let script = WKUserScript(
-            source: Self.progressTrackingJS,
-            injectionTime: .atDocumentEnd,
-            forMainFrameOnly: true
-        )
-        userContentController.addUserScript(script)
         let weakHandler = WeakScriptMessageHandler(context.coordinator)
-        userContentController.add(weakHandler, name: "progressHandler")
+        // Feature #71 WI-5: mode-branched scroll observer. In continuous-scroll
+        // mode the section-aware observer (reporting {visibleSpineIndex,
+        // intraFraction, nearTop/BottomBoundary}) REPLACES the single-document
+        // `progressTrackingJS` so the two don't both fire on the stitched
+        // bootstrap doc and race the windowed progress (Gate-2 round-1 [H3]).
+        // The nil-config (legacy paged + single-chapter scroll) path is byte-
+        // identical to before.
+        if continuousScroll != nil {
+            let observerScript = WKUserScript(
+                source: EPUBContinuousScrollJS.continuousScrollObserverJS,
+                injectionTime: .atDocumentEnd,
+                forMainFrameOnly: true
+            )
+            userContentController.addUserScript(observerScript)
+            userContentController.add(weakHandler, name: "continuousScrollHandler")
+        } else {
+            // Add scroll progress tracking script (throttled)
+            let script = WKUserScript(
+                source: Self.progressTrackingJS,
+                injectionTime: .atDocumentEnd,
+                forMainFrameOnly: true
+            )
+            userContentController.addUserScript(script)
+            userContentController.add(weakHandler, name: "progressHandler")
+        }
 
         // Add content tap tracking for toolbar toggle
         let tapScript = WKUserScript(
@@ -219,6 +244,7 @@ struct EPUBWebViewBridge: UIViewRepresentable {
         context.coordinator.isPaged = isPaged
         context.coordinator.previousIsPaged = isPaged
         context.coordinator.onPaginationReady = onPaginationReady
+        context.coordinator.continuousScroll = continuousScroll
         webView.navigationDelegate = context.coordinator
         webView.allowsBackForwardNavigationGestures = false
         webView.accessibilityIdentifier = "epubWebView"
@@ -243,6 +269,7 @@ struct EPUBWebViewBridge: UIViewRepresentable {
         context.coordinator.onPageDidFinishLoad = onPageDidFinishLoad
         context.coordinator.isPaged = isPaged
         context.coordinator.onPaginationReady = onPaginationReady
+        context.coordinator.continuousScroll = continuousScroll
 
         // Update scroll enabled state when layout mode changes
         webView.scrollView.isScrollEnabled = !isPaged

--- a/vreader/Views/Reader/EPUBWebViewBridgeCoordinator.swift
+++ b/vreader/Views/Reader/EPUBWebViewBridgeCoordinator.swift
@@ -92,6 +92,12 @@ extension EPUBWebViewBridge {
         var previousIsPaged = false
         /// Called when pagination is ready with total page count.
         var onPaginationReady: (@MainActor (Int) -> Void)?
+        /// Feature #71 WI-5: non-nil in continuous-scroll mode. The
+        /// `continuousScrollHandler` channel routes each boundary signal to
+        /// `config.coordinator` (window transitions) and feeds the windowed
+        /// whole-book progress to `onProgressChange`. Nil ⇒ legacy single-doc
+        /// `progressHandler` path.
+        var continuousScroll: EPUBContinuousScrollConfig?
         private let onProgressChange: @MainActor (Double) -> Void
         private let onLoadError: @MainActor (String) -> Void
 
@@ -173,10 +179,31 @@ extension EPUBWebViewBridge {
                 handleBilingualEnumerateMessage(message.body)
                 return
             }
+            if message.name == "continuousScrollHandler" {
+                handleContinuousScrollMessage(message.body)
+                return
+            }
             guard message.name == "progressHandler",
                   let progress = message.body as? Double else { return }
             Task { @MainActor in
                 onProgressChange(progress)
+            }
+        }
+
+        /// Feature #71 WI-5: parse a `continuousScrollHandler` boundary signal,
+        /// forward it to the window-transition coordinator (WI-4 — materialize /
+        /// evict adjacent chapters), and feed the windowed whole-book progress
+        /// (`(visibleSpineIndex + intraFraction)/spineCount`) to the existing
+        /// `onProgressChange` contract. No-op when the config is absent (the
+        /// channel is only registered in continuous mode, but the guard keeps a
+        /// stray message safe).
+        private func handleContinuousScrollMessage(_ body: Any) {
+            guard let config = continuousScroll,
+                  let signal = EPUBScrollBoundarySignal.parse(body) else { return }
+            let progress = config.windowedProgress(for: signal)
+            Task { @MainActor in
+                onProgressChange(progress)
+                await config.coordinator.handleBoundarySignal(signal)
             }
         }
 
@@ -219,7 +246,12 @@ extension EPUBWebViewBridge {
 
         private func handleSelectionMessage(_ body: Any) {
             guard let parsed = EPUBHighlightBridge.parseSelectionMessage(body) else { return }
-            let href = currentHref ?? ""
+            // Feature #71 WI-5: in continuous-scroll mode the selection JS reports
+            // the section's href (`closest('[data-vreader-href]')`); attribute the
+            // anchor to THAT section, not the global current chapter. Legacy
+            // single-chapter mode reports no section href → falls back to
+            // `currentHref` (unchanged behaviour).
+            let href = parsed.sectionHref ?? currentHref ?? ""
             let event = EPUBHighlightBridge.makeSelectionEvent(
                 selectedText: parsed.selectedText,
                 href: href,

--- a/vreader/Views/Reader/EPUBWebViewBridgeJS.swift
+++ b/vreader/Views/Reader/EPUBWebViewBridgeJS.swift
@@ -148,6 +148,13 @@ extension EPUBWebViewBridge {
         webView.configuration.userContentController.removeScriptMessageHandler(
             forName: "highlightTapHandler"
         )
+        // Feature #71 WI-5: matching teardown for the continuous-scroll observer
+        // handler (registered in makeUIView only in continuous mode). Removing
+        // an unregistered name is a safe no-op, so this is unconditional like the
+        // others — keeps the teardown symmetric with makeUIView (Gate-4 round-2).
+        webView.configuration.userContentController.removeScriptMessageHandler(
+            forName: "continuousScrollHandler"
+        )
     }
 
     // MARK: - JavaScript

--- a/vreaderTests/Views/Reader/EPUBContinuousScrollBridgeTests.swift
+++ b/vreaderTests/Views/Reader/EPUBContinuousScrollBridgeTests.swift
@@ -1,0 +1,170 @@
+// Purpose: Feature #71 WI-5 — unit tests for the bridge-side glue that wires the
+// continuous-scroll observer into `EPUBWebViewBridge`: the `continuousScrollHandler`
+// JS-message parser (`EPUBScrollBoundarySignal.parse`), the windowed-progress
+// mapping (`EPUBContinuousScrollConfig.windowedProgress`), and the section-scoped
+// selection href carried on `EPUBSelectionMessage`. All pure — no live WKWebView.
+//
+// @coordinates-with: EPUBContinuousScrollBridge.swift, EPUBContinuousScrollCoordinator.swift,
+//   EPUBHighlightBridge.swift, EPUBProgressCalculator.swift
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("EPUBContinuousScroll bridge glue (Feature #71 WI-5)")
+struct EPUBContinuousScrollBridgeTests {
+
+    // MARK: - EPUBScrollBoundarySignal.parse
+
+    private func body(
+        visible: Any? = 2,
+        intra: Any? = 0.5,
+        top: Any? = false,
+        bottom: Any? = true
+    ) -> [String: Any] {
+        var d: [String: Any] = [:]
+        if let visible { d["visibleSpineIndex"] = visible }
+        if let intra { d["intraFraction"] = intra }
+        if let top { d["nearTopBoundary"] = top }
+        if let bottom { d["nearBottomBoundary"] = bottom }
+        return d
+    }
+
+    @Test("parses a well-formed observer message")
+    func parsesValid() throws {
+        let signal = try #require(EPUBScrollBoundarySignal.parse(body()))
+        #expect(signal.visibleSpineIndex == 2)
+        #expect(signal.intraFraction == 0.5)
+        #expect(signal.nearTopBoundary == false)
+        #expect(signal.nearBottomBoundary == true)
+    }
+
+    @Test("clamps intraFraction into 0...1")
+    func clampsIntraFraction() throws {
+        let high = try #require(EPUBScrollBoundarySignal.parse(body(intra: 1.8)))
+        #expect(high.intraFraction == 1.0)
+        let low = try #require(EPUBScrollBoundarySignal.parse(body(intra: -0.3)))
+        #expect(low.intraFraction == 0.0)
+    }
+
+    @Test("coerces NSNumber bool flags (JS booleans arrive as NSNumber)")
+    func coercesNSNumberBools() throws {
+        let signal = try #require(EPUBScrollBoundarySignal.parse(
+            body(top: NSNumber(value: 1), bottom: NSNumber(value: 0))
+        ))
+        #expect(signal.nearTopBoundary == true)
+        #expect(signal.nearBottomBoundary == false)
+    }
+
+    @Test("coerces an integer-valued Double visibleSpineIndex")
+    func coercesDoubleIndex() throws {
+        let signal = try #require(EPUBScrollBoundarySignal.parse(body(visible: 3.0)))
+        #expect(signal.visibleSpineIndex == 3)
+    }
+
+    @Test("non-dictionary body is rejected")
+    func rejectsNonDict() {
+        #expect(EPUBScrollBoundarySignal.parse("not a dict") == nil)
+        #expect(EPUBScrollBoundarySignal.parse(42) == nil)
+    }
+
+    @Test("missing visibleSpineIndex is rejected")
+    func rejectsMissingIndex() {
+        #expect(EPUBScrollBoundarySignal.parse(body(visible: nil)) == nil)
+    }
+
+    @Test("missing intraFraction is rejected")
+    func rejectsMissingFraction() {
+        #expect(EPUBScrollBoundarySignal.parse(body(intra: nil)) == nil)
+    }
+
+    @Test("negative visibleSpineIndex is rejected (a section index can't be negative)")
+    func rejectsNegativeIndex() {
+        #expect(EPUBScrollBoundarySignal.parse(body(visible: -1)) == nil)
+    }
+
+    @Test("fractional visibleSpineIndex is rejected (3.9 is malformed, not index 3)")
+    func rejectsFractionalIndex() {
+        #expect(EPUBScrollBoundarySignal.parse(body(visible: 3.9)) == nil)
+    }
+
+    @Test("boolean visibleSpineIndex is rejected (a JS true is not index 1)")
+    func rejectsBoolIndex() {
+        #expect(EPUBScrollBoundarySignal.parse(body(visible: true)) == nil)
+        #expect(EPUBScrollBoundarySignal.parse(body(visible: NSNumber(value: true))) == nil)
+    }
+
+    @Test("boolean intraFraction is rejected (not coerced to 1.0)")
+    func rejectsBoolFraction() {
+        #expect(EPUBScrollBoundarySignal.parse(body(intra: true)) == nil)
+    }
+
+    @Test("missing boundary flags default to false (a missing flag means 'not near')")
+    func missingFlagsDefaultFalse() throws {
+        let signal = try #require(EPUBScrollBoundarySignal.parse(body(top: nil, bottom: nil)))
+        #expect(signal.nearTopBoundary == false)
+        #expect(signal.nearBottomBoundary == false)
+    }
+
+    // MARK: - windowedProgress
+
+    @Test("windowed progress maps (spineIndex + intraFraction) / spineCount")
+    func windowedProgressMapping() {
+        // spine 2 at 50% of a 10-chapter book → (2 + 0.5)/10 = 0.25
+        let signal = EPUBScrollBoundarySignal(
+            visibleSpineIndex: 2, intraFraction: 0.5,
+            nearTopBoundary: false, nearBottomBoundary: false
+        )
+        let p = EPUBContinuousScrollConfig.windowedProgress(signal: signal, totalSpineCount: 10)
+        #expect(abs(p - 0.25) < 1e-9)
+    }
+
+    @Test("windowed progress is clamped + safe for a zero spine count")
+    func windowedProgressGuards() {
+        let signal = EPUBScrollBoundarySignal(
+            visibleSpineIndex: 9, intraFraction: 1.0,
+            nearTopBoundary: false, nearBottomBoundary: false
+        )
+        // last chapter, fully scrolled, 10 chapters → 1.0
+        #expect(EPUBContinuousScrollConfig.windowedProgress(signal: signal, totalSpineCount: 10) == 1.0)
+        // zero spine count → 0 (no divide-by-zero)
+        #expect(EPUBContinuousScrollConfig.windowedProgress(signal: signal, totalSpineCount: 0) == 0.0)
+    }
+
+    // MARK: - section-scoped selection href (Gate-2 Critical [C1])
+
+    @Test("selection message carries the section href when present")
+    func selectionCarriesSectionHref() throws {
+        let dict: [String: Any] = [
+            "selectedText": "hello",
+            "startPath": "/p[1]/text()[1]", "endPath": "/p[1]/text()[1]",
+            "startOffset": 0, "endOffset": 5,
+            "sectionHref": "OEBPS/ch3.xhtml",
+        ]
+        let msg = try #require(EPUBHighlightBridge.parseSelectionMessage(dict))
+        #expect(msg.sectionHref == "OEBPS/ch3.xhtml")
+    }
+
+    @Test("selection message section href is nil in legacy single-chapter mode (key absent)")
+    func selectionSectionHrefNilWhenAbsent() throws {
+        let dict: [String: Any] = [
+            "selectedText": "hello",
+            "startPath": "/p[1]/text()[1]", "endPath": "/p[1]/text()[1]",
+            "startOffset": 0, "endOffset": 5,
+        ]
+        let msg = try #require(EPUBHighlightBridge.parseSelectionMessage(dict))
+        #expect(msg.sectionHref == nil)
+    }
+
+    @Test("empty sectionHref string is treated as nil (degenerate clamp → no section)")
+    func selectionEmptySectionHrefIsNil() throws {
+        let dict: [String: Any] = [
+            "selectedText": "hello",
+            "startPath": "/p[1]/text()[1]", "endPath": "/p[1]/text()[1]",
+            "startOffset": 0, "endOffset": 5,
+            "sectionHref": "",
+        ]
+        let msg = try #require(EPUBHighlightBridge.parseSelectionMessage(dict))
+        #expect(msg.sectionHref == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- Wires the four foundational WIs (EPUBSpineWindow, EPUBChapterBodyRewriter, EPUBContinuousScrollJS, EPUBContinuousScrollCoordinator) into `EPUBWebViewBridge` via an additive `continuousScroll: EPUBContinuousScrollConfig?` input.
- **nil config ⇒ the legacy one-chapter-per-`loadFileURL` path is byte-identical** (paged + single-chapter scroll unchanged).

Part of feature #1150

## What Changed

- **`EPUBContinuousScrollBridge.swift`** (new): `EPUBContinuousScrollConfig` (coordinator + spineCount + `windowedProgress`, reusing `EPUBProgressCalculator` unchanged) + `EPUBScrollBoundarySignal.parse` (strict — rejects non-dict / missing / negative / fractional / bool spine index + bool fraction; clamps `intraFraction` to 0...1; NSNumber/Bool coercion).
- **`EPUBWebViewBridge`**: mode-branched script/handler injection — continuous mode injects the section-aware observer + `continuousScrollHandler` in place of `progressTrackingJS`/`progressHandler` so they don't both fire/race on the stitched doc (Gate-2 [H3]).
- **`EPUBWebViewBridgeCoordinator`**: `handleContinuousScrollMessage` parses the signal, feeds windowed whole-book progress to `onProgressChange`, forwards to the WI-4 coordinator's `handleBoundarySignal`.
- **Section-scoped selection (Gate-2 [C1])**: the selection JS resolves start/end section ancestors, clamps a cross-divider drag to the start section (rejects if degenerate), reports the section's `data-vreader-href`; coordinator attributes the anchor to that section (falls back to `currentHref` in legacy mode). `EPUBSelectionMessage` gains `sectionHref`.
- **Teardown**: `dismantleUIView` symmetry for `continuousScrollHandler`.

## WI Status

- WI-5: **behavioral** — this PR. WI-1..4 merged.
- Remaining: WI-6 (container wiring: constructs the config + chapterBodyProvider + bootstrap/restore), WI-7 (bilingual section-scoping), WI-8 (docs).

## Codex Audit (Gate 4)

3 rounds → **ship-as-is**. R1: 1 High (cross-section selection clamp) + 1 Medium (parser hardening). R2: 1 Low (teardown symmetry, corrected). R3: clean. Audit log: `.claude/codex-audits/feat-feature-71-wi-5-bridge-plumbing-audit.md`

## Validation

- [x] `xcodebuild test -only-testing:vreaderTests` — 7254 tests, 0 failures
- [x] Tests cover changed behavior (TDD: RED → GREEN) — `EPUBContinuousScrollBridgeTests`, 18 cases (parser, windowed progress, section-href)
- [x] Codex audit loop completed (3 rounds, ship-as-is)
- [x] Docs sync — n/a (architecture.md update is WI-8 per the plan; no new @Model/service/bus-notification)
- [x] Version bumped: 3.39.39 → 3.39.40

## Gate 5a Verification (per-PR slice — pre-merge)

- Tier: **behavioral**, but WI-5's runtime path is only reachable once WI-6 constructs the `EPUBContinuousScrollConfig`. Pre-merge slice: (a) pure logic (`parse`, `windowedProgress`, section-href) unit-tested; (b) full suite green confirms the **nil-config legacy path is behaviorally unchanged** (regression safety). End-to-end continuous-scroll behavior + the cross-section clamp DOM behavior are verified at WI-6 + final-WI Gate-5b device pass.

## Type of Change

- [x] Feature WI (Part of feature #1150)