### PR TITLE
feat(#42 WI-1): add Readium Swift Toolkit SPM dep + open-smoke test

### DIFF
--- a/.claude/codex-audits/feat-feature-42-wi1-spm-readium-audit.md
+++ b/.claude/codex-audits/feat-feature-42-wi1-spm-readium-audit.md
@@ -1,0 +1,28 @@
+---
+branch: feat/feature-42-wi1-spm-readium
+threadId: codex-exec-2026-05-29-wi1
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-29
+---
+
+# Codex Gate-4 audit — Feature #42 Phase-1 WI-1 (add Readium SPM + open-smoke test)
+
+Foundational WI: adds the Readium Swift Toolkit (3.9.0, exact-pinned) SPM dependency
+(ReadiumShared + ReadiumStreamer + ReadiumNavigator; no ReadiumLCP, no GCDWebServer adapter)
++ a genuine open-smoke test (`AssetRetriever` → `PublicationOpener` parses the bundled
+`mini-epub3.epub`, asserts readingOrder + metadata title). No dispatch/flag/engine change.
+
+## Round 1 — 1 High + 1 Low
+
+| file:line | severity | issue | resolution |
+|---|---|---|---|
+| project.yml (vreaderTests) / ReadiumOpenSmokeTests.swift:17 | High | The Readium products were declared only on the `vreader` app target; the test target imports `ReadiumShared`/`ReadiumStreamer` but its `packageProductDependencies` was empty — fragile (relied on host-app transitive exposure, can fail to compile). | **Fixed** — added `ReadiumShared` + `ReadiumStreamer` to the `vreaderTests` target deps in project.yml; regenerated; pbxproj now carries the test-target package deps (20 refs). Re-ran the focused test: `** TEST SUCCEEDED **` 2/2. |
+| Package.resolved:31 | Low | `GCDWebServer` is resolved as a transitive package even though its adapter product is not linked. Expected from Readium's manifest (it's a package-level dep of the toolkit); not linked into the binary. | **Accepted** — not linked (no GCDWebServer product in the app or test target); resolving-but-not-linking is inherent to Readium's package graph. Recorded for the security-review trail. |
+
+## Verdict
+
+Round 1: 1 High (fixed — test-target deps) + 1 Low (accepted — transitive GCDWebServer not linked).
+Readium 3.9.0 product names confirmed correct against the package manifest. Scope clean (no
+ReaderContainerView/ReaderEngine/FeatureFlags/engine changes). Smoke test is a genuine parse, not
+a mock; DEBUG-gated. **Verdict: ship-as-is.** Focused test 2/2 green; build SUCCEEDED.

--- a/project.yml
+++ b/project.yml
@@ -11,6 +11,17 @@ settings:
     SWIFT_VERSION: "6.0"
     SWIFT_STRICT_CONCURRENCY: complete
 
+# Feature #42 (Readium reader engine, Phase 1 WI-1): the Readium Swift Toolkit
+# (BSD-3-Clause) is vreader's first third-party SPM dependency. Phase 1 opens
+# EPUB publications via AssetRetriever + PublicationOpener (Readium 3.x) — no
+# app-owned HTTP-server adapter. Only ReadiumShared (model/Locator) +
+# ReadiumStreamer (parsing/opening) + ReadiumNavigator (rendering) are linked;
+# ReadiumLCP and the GCDWebServer adapter are intentionally NOT linked.
+packages:
+  Readium:
+    url: https://github.com/readium/swift-toolkit
+    exactVersion: "3.9.0"
+
 targets:
   vreader:
     type: application
@@ -50,6 +61,18 @@ targets:
           # into the BUILT Info.plist so the vreader-debug:// URL scheme actually
           # registers with iOS.
           - "SupportingFiles/DebugBridge.plist"
+    dependencies:
+      # Feature #42 Phase 1: Readium Swift Toolkit products. ReadiumShared
+      # supplies the Locator/Publication model; ReadiumStreamer supplies
+      # AssetRetriever / PublicationOpener / DefaultPublicationParser (opening);
+      # ReadiumNavigator supplies EPUBNavigatorViewController (rendering, used
+      # from WI-5). No GCDWebServer adapter, no ReadiumLCP.
+      - package: Readium
+        product: ReadiumShared
+      - package: Readium
+        product: ReadiumStreamer
+      - package: Readium
+        product: ReadiumNavigator
     preBuildScripts:
       # Bug #111: Copy DebugFixtures into the bundle ONLY when building Debug.
       # Release builds get nothing — verified by running `find vreader.app -name

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 695
-        MARKETING_VERSION: 3.40.14
+        CURRENT_PROJECT_VERSION: 696
+        MARKETING_VERSION: 3.40.15
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/project.yml
+++ b/project.yml
@@ -310,6 +310,14 @@ targets:
           - "ViewModels/LibraryViewModelPersistenceTests.swift"
     dependencies:
       - target: vreader
+      # Feature #42 WI-1: the Readium open-smoke test imports ReadiumShared +
+      # ReadiumStreamer directly, so the test target must link them explicitly
+      # (relying on host-app transitive exposure is fragile — Gate-4 audit).
+      # ReadiumNavigator stays app-only (the test doesn't render).
+      - package: Readium
+        product: ReadiumShared
+      - package: Readium
+        product: ReadiumStreamer
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.tests

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -282,6 +282,7 @@
 		31F5B5AEC09F731ACEB8A46E /* Feature63SearchPanelVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1332F42A0C57EA1D1F37D9C0 /* Feature63SearchPanelVerificationTests.swift */; };
 		320025CDBC69B31CC1B4DEAA /* PDFReaderContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2BA1A05E4E36D5D7B2DCFD /* PDFReaderContainerView.swift */; };
 		3217F149B278D3D88B6AC17F /* AISummaryTabViewScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC9AC43028A99A994A7747B /* AISummaryTabViewScopeTests.swift */; };
+		324C39E083F8BC2E929BB4F3 /* ReadiumShared in Frameworks */ = {isa = PBXBuildFile; productRef = 8C7CAF7AA1A6A8C127B15373 /* ReadiumShared */; };
 		32A02A2EECC7FFE73EEFC242 /* BilingualReadingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620691FAD37A902412F57F42 /* BilingualReadingViewModel.swift */; };
 		32B7B523223C7D83ED40A208 /* FoliateHighlightRestoreDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D712BAAF509AEBA3A3FB01C3 /* FoliateHighlightRestoreDispatcherTests.swift */; };
 		32C58BAAF2DB529049921D4D /* OPDSParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C26DE0705F29A16D1919F5 /* OPDSParserTests.swift */; };
@@ -1027,6 +1028,7 @@
 		BF9767FD9DB988B04F1B27D5 /* SyncConflictResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF495D7A9D6F8F137DD42CE0 /* SyncConflictResolverTests.swift */; };
 		BFC53CAC354993C719CE862D /* EPUBWebViewEvaluatorHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B5C3B574FE1EBD73201C8C2 /* EPUBWebViewEvaluatorHandle.swift */; };
 		BFFFDD0F1A6208FCCA9BBA75 /* OPDSEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F36EF81271874A13417D45 /* OPDSEntryView.swift */; };
+		C010AB44C037B67E5A65B50A /* ReadiumStreamer in Frameworks */ = {isa = PBXBuildFile; productRef = EA3051FC39A4EA8313F32F9D /* ReadiumStreamer */; };
 		C02BE297CD13689403CC7FE3 /* FoliateSpikeView+HighlightTap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086557F549C56946CFD6194E /* FoliateSpikeView+HighlightTap.swift */; };
 		C03DA14D8DBA94B0CE4135D5 /* SearchViewActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08856C035686A119B4371C25 /* SearchViewActions.swift */; };
 		C08E9C36FF3ED5C05E74F52B /* WI11TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2D542588B3156C4A282264 /* WI11TestHelpers.swift */; };
@@ -2734,6 +2736,15 @@
 				6A1321CE165723A3531ECCE5 /* ReadiumShared in Frameworks */,
 				FF9EB4889B98DA03A72C6AFE /* ReadiumStreamer in Frameworks */,
 				8657F27C8CB44F8E8771FAA0 /* ReadiumNavigator in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E538CDA4EA1A3B840235B865 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				324C39E083F8BC2E929BB4F3 /* ReadiumShared in Frameworks */,
+				C010AB44C037B67E5A65B50A /* ReadiumStreamer in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5058,6 +5069,7 @@
 			buildPhases = (
 				49EC308C9C6E9ED9728F9D89 /* Sources */,
 				C1B1FD0761D48AFD59BD8BA7 /* Resources */,
+				E538CDA4EA1A3B840235B865 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -5066,6 +5078,8 @@
 			);
 			name = vreaderTests;
 			packageProductDependencies = (
+				8C7CAF7AA1A6A8C127B15373 /* ReadiumShared */,
+				EA3051FC39A4EA8313F32F9D /* ReadiumStreamer */,
 			);
 			productName = vreaderTests;
 			productReference = E46AADA707F0E3AF7E8AB297 /* vreaderTests.xctest */;
@@ -6865,10 +6879,20 @@
 			package = D7AA73DC59084585FC730EDE /* XCRemoteSwiftPackageReference "swift-toolkit" */;
 			productName = ReadiumNavigator;
 		};
+		8C7CAF7AA1A6A8C127B15373 /* ReadiumShared */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D7AA73DC59084585FC730EDE /* XCRemoteSwiftPackageReference "swift-toolkit" */;
+			productName = ReadiumShared;
+		};
 		BD4466456EBD017A56F147F0 /* ReadiumShared */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D7AA73DC59084585FC730EDE /* XCRemoteSwiftPackageReference "swift-toolkit" */;
 			productName = ReadiumShared;
+		};
+		EA3051FC39A4EA8313F32F9D /* ReadiumStreamer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D7AA73DC59084585FC730EDE /* XCRemoteSwiftPackageReference "swift-toolkit" */;
+			productName = ReadiumStreamer;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -574,6 +574,7 @@
 		68BEE555698E2ECAE8536655 /* MDReaderReplacementRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7672B4D5423E0D3AAE16343 /* MDReaderReplacementRulesTests.swift */; };
 		68F25FD5B04A5CE2EC41E895 /* AnnotationStreamBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C930176EDA59BA6AE769B8C /* AnnotationStreamBuilder.swift */; };
 		691280DF99A2E74DE49D6D94 /* SettingsIconRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C994418AB3E9CCF1914CA9 /* SettingsIconRowTests.swift */; };
+		6A1321CE165723A3531ECCE5 /* ReadiumShared in Frameworks */ = {isa = PBXBuildFile; productRef = BD4466456EBD017A56F147F0 /* ReadiumShared */; };
 		6A82598FAC95114A1E5CF06B /* footnotes.js in Resources */ = {isa = PBXBuildFile; fileRef = 7D068D6691FC6690BF3341B1 /* footnotes.js */; };
 		6AD3803A580B3AEB73E77AA1 /* BookRowViewVisualTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EA3D76ECCD1B0E7205FBC4 /* BookRowViewVisualTests.swift */; };
 		6B0F05AB79459B346E22C825 /* DebugReaderProbeAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B98DA0DED4325E7AE1BEF59 /* DebugReaderProbeAdapter.swift */; };
@@ -660,6 +661,7 @@
 		78D60642EBBFC160B21C140F /* StatsTimeWindowBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19BCC62165C1D43307C2778F /* StatsTimeWindowBarTests.swift */; };
 		78DD5C0C8082DE162A83B0A9 /* BookTranslationProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC65B4AF0602473F3F11C161 /* BookTranslationProgress.swift */; };
 		792681509B48600C93D01C39 /* ReaderTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4581A94B5099D15743DC02F3 /* ReaderTheme.swift */; };
+		792FA8647985692CC1ED5694 /* ReadiumOpenSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3101BC67249AD8280F55AFA /* ReadiumOpenSmokeTests.swift */; };
 		793A39541D8253B1CA8984A5 /* ScrollProgressHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7024E7AEAC9AEAA028952C46 /* ScrollProgressHelper.swift */; };
 		794FD606545B9368CD9CF18F /* legado_source_minimal.json in Resources */ = {isa = PBXBuildFile; fileRef = DE360E19106AAA7A1FCEEEB9 /* legado_source_minimal.json */; };
 		79ACFB3DD40281B2A3B9AE8B /* DebugSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94C32FCAEDE0062125F6A51E /* DebugSnapshot.swift */; };
@@ -727,6 +729,7 @@
 		860C6626A5AC805B4C622E70 /* EPUBFileLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5487566F93AB8376D1BD1F1B /* EPUBFileLoaderTests.swift */; };
 		8617A3EAA2D7BEB5AEE82047 /* DebugReaderRegistry+WebViewWait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1351525282D8D0C13B726F85 /* DebugReaderRegistry+WebViewWait.swift */; };
 		863103455E8B23D20B97F192 /* EPUBHighlightRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3650C684EB90A5D7E2F8059A /* EPUBHighlightRenderer.swift */; };
+		8657F27C8CB44F8E8771FAA0 /* ReadiumNavigator in Frameworks */ = {isa = PBXBuildFile; productRef = 486194008CF2C34F53F2B60B /* ReadiumNavigator */; };
 		869CA53E6485C219A21E048C /* chapter_list_paginated.html in Resources */ = {isa = PBXBuildFile; fileRef = E78552E9E45095C4887A2EC0 /* chapter_list_paginated.html */; };
 		86A548B15E20C496319D524B /* TestSeederMDMultiPagePaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEB28B2CAB1481C73FBE351 /* TestSeederMDMultiPagePaginationTests.swift */; };
 		86AB97CD6CC05A3EEADE5F00 /* MDAttributedStringRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36686A80222AD7613951C900 /* MDAttributedStringRenderer.swift */; };
@@ -1346,6 +1349,7 @@
 		FF361AAF1D317E6C783E9E98 /* PersistenceActorReadingWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C238AE2F5B4FE9D769CD29 /* PersistenceActorReadingWindowTests.swift */; };
 		FF8D6FA65D0840E3F87E5701 /* TXTChunkedHighlightHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6639753CB33EAECD6CF3010 /* TXTChunkedHighlightHelper.swift */; };
 		FF9607783B575CF7715CAAC0 /* Bug93GeneralChatPersistenceVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00DE93DBD2142D882858486F /* Bug93GeneralChatPersistenceVerificationTests.swift */; };
+		FF9EB4889B98DA03A72C6AFE /* ReadiumStreamer in Frameworks */ = {isa = PBXBuildFile; productRef = 0148A3222F2C6F8DDB3154EA /* ReadiumStreamer */; };
 		FFA194178E9956EF14C4B8DD /* overlayer.js in Resources */ = {isa = PBXBuildFile; fileRef = 1ABFAC14455C6F7DE43C1ABC /* overlayer.js */; };
 		FFA99A696DC411A0D8A0C969 /* ChapterReTranslateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFE15DA4C0FC8B57E3B4728B /* ChapterReTranslateViewModel.swift */; };
 		FFC1BF2B3E0963AAD120E93E /* AnthropicProvider+Streaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = C682F2AF644C10CEC95208AE /* AnthropicProvider+Streaming.swift */; };
@@ -2380,6 +2384,7 @@
 		C2997AAAB34DF84E64DC0DB4 /* MOBICoverExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MOBICoverExtractor.swift; sourceTree = "<group>"; };
 		C2D49361893EE9956D6EC5DB /* TXTOffsetMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTOffsetMapper.swift; sourceTree = "<group>"; };
 		C2E89BEB1454E17061367313 /* Feature64EPUBMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature64EPUBMigrationTests.swift; sourceTree = "<group>"; };
+		C3101BC67249AD8280F55AFA /* ReadiumOpenSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumOpenSmokeTests.swift; sourceTree = "<group>"; };
 		C344E898312308F197E6EF5E /* BookTranslationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookTranslationViewModel.swift; sourceTree = "<group>"; };
 		C3C15E361FF460BCE57B8675 /* EPUBParserProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBParserProtocol.swift; sourceTree = "<group>"; };
 		C3EF8CE8D52815CF5156953C /* WebDAVProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProvider.swift; sourceTree = "<group>"; };
@@ -2720,6 +2725,19 @@
 		FFD1AE78FBFF38B3616352FF /* AIConsentManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIConsentManagerTests.swift; sourceTree = "<group>"; };
 		FFE1146B1851B4122B5187A1 /* TXTServiceProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTServiceProtocol.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		37D2002EDDBE5FC1D6B197AE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6A1321CE165723A3531ECCE5 /* ReadiumShared in Frameworks */,
+				FF9EB4889B98DA03A72C6AFE /* ReadiumStreamer in Frameworks */,
+				8657F27C8CB44F8E8771FAA0 /* ReadiumNavigator in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		05198A5DC2B193BFACC2EFF5 /* Fixtures */ = {
@@ -3151,6 +3169,7 @@
 				ED6B181E2C41086F3E3943C3 /* BilingualParagraphRangesTests.swift */,
 				59C9E78D6768871560C6C7CB /* ChapterTextProviderTests.swift */,
 				608AC905654D9F01D8A39855 /* FoliateChapterTextProviderTests.swift */,
+				C3101BC67249AD8280F55AFA /* ReadiumOpenSmokeTests.swift */,
 				BFC96A0B7273BB922335B1B0 /* TXTLoaderBackedChapterTextProviderTests.swift */,
 			);
 			path = Reader;
@@ -5060,6 +5079,7 @@
 				50BDD7D268D53AEC3863C4E2 /* Sources */,
 				0EB4E7C1282F0082F0677DA7 /* Inject DebugBridge URL types (DEBUG only) */,
 				AAE6A9967BDF359CCF50BD13 /* Resources */,
+				37D2002EDDBE5FC1D6B197AE /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -5067,6 +5087,9 @@
 			);
 			name = vreader;
 			packageProductDependencies = (
+				BD4466456EBD017A56F147F0 /* ReadiumShared */,
+				0148A3222F2C6F8DDB3154EA /* ReadiumStreamer */,
+				486194008CF2C34F53F2B60B /* ReadiumNavigator */,
 			);
 			productName = vreader;
 			productReference = C8E7C46539D19C4B3CFCD766 /* vreader.app */;
@@ -5095,6 +5118,9 @@
 			);
 			mainGroup = E630D3048A0AF78632A66A2B;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				D7AA73DC59084585FC730EDE /* XCRemoteSwiftPackageReference "swift-toolkit" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 1DC89D462A6E6000C5FE89F8 /* Products */;
 			projectDirPath = "";
@@ -5623,6 +5649,7 @@
 				6BCE6D641047BA2A3BAFDC14 /* ReadingStatsModelsTests.swift in Sources */,
 				7D0B1A054D3897CAD9D768A6 /* ReadingStatsTests.swift in Sources */,
 				800F472661AB1030CC54DB46 /* ReadingTimeFormatterTests.swift in Sources */,
+				792FA8647985692CC1ED5694 /* ReadiumOpenSmokeTests.swift in Sources */,
 				75F2C31298F0C62115778DED /* RealDebugBridgeContextTests.swift in Sources */,
 				6B7F71BDB5ECEA83F19496FC /* ReflowableTextSourceTests.swift in Sources */,
 				C65606FD56FC3CE3BF958B71 /* RemoteBookCatalogIntegrationTests.swift in Sources */,
@@ -6815,6 +6842,35 @@
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		D7AA73DC59084585FC730EDE /* XCRemoteSwiftPackageReference "swift-toolkit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/readium/swift-toolkit";
+			requirement = {
+				kind = exactVersion;
+				version = 3.9.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		0148A3222F2C6F8DDB3154EA /* ReadiumStreamer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D7AA73DC59084585FC730EDE /* XCRemoteSwiftPackageReference "swift-toolkit" */;
+			productName = ReadiumStreamer;
+		};
+		486194008CF2C34F53F2B60B /* ReadiumNavigator */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D7AA73DC59084585FC730EDE /* XCRemoteSwiftPackageReference "swift-toolkit" */;
+			productName = ReadiumNavigator;
+		};
+		BD4466456EBD017A56F147F0 /* ReadiumShared */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D7AA73DC59084585FC730EDE /* XCRemoteSwiftPackageReference "swift-toolkit" */;
+			productName = ReadiumShared;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 129D78E813BC175F78820E46 /* Project object */;
 }

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6653,13 +6653,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 695;
+				CURRENT_PROJECT_VERSION = 696;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.40.14;
+				MARKETING_VERSION = 3.40.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6803,13 +6803,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 695;
+				CURRENT_PROJECT_VERSION = 696;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.40.14;
+				MARKETING_VERSION = 3.40.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/vreader.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,87 @@
+{
+  "originHash" : "23270f8ef23c776eff1a6fc9efd508cd849cbbdb4c250e4acbb3faa0ae922cf5",
+  "pins" : [
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "f2a627b84c1ff96f21ac2fcb623ab36142dd5512",
+        "version" : "1.10.0"
+      }
+    },
+    {
+      "identity" : "differencekit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ra1028/DifferenceKit.git",
+      "state" : {
+        "revision" : "073b9671ce2b9b5b96398611427a1f929927e428",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "fuzi",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/readium/Fuzi.git",
+      "state" : {
+        "revision" : "347aab158ff8894966ff80469b384bb5337928cd",
+        "version" : "4.0.0"
+      }
+    },
+    {
+      "identity" : "gcdwebserver",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/readium/GCDWebServer.git",
+      "state" : {
+        "revision" : "584db89a4c3c3be27206cce6afde037b2b6e38d8",
+        "version" : "4.0.1"
+      }
+    },
+    {
+      "identity" : "sqlite.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stephencelis/SQLite.swift.git",
+      "state" : {
+        "revision" : "964c300fb0736699ce945c9edb56ecd62eba27a3",
+        "version" : "0.16.0"
+      }
+    },
+    {
+      "identity" : "swift-toolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/readium/swift-toolkit",
+      "state" : {
+        "revision" : "de07026e9f825a5791f27a7ac4cd6bb1a784ab8d",
+        "version" : "3.9.0"
+      }
+    },
+    {
+      "identity" : "swiftsoup",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scinfu/SwiftSoup.git",
+      "state" : {
+        "revision" : "49dcadd93161f4a44b4994d3a3e8de9f085aface",
+        "version" : "2.13.5"
+      }
+    },
+    {
+      "identity" : "zip",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/marmelroy/Zip.git",
+      "state" : {
+        "revision" : "67fa55813b9e7b3b9acee9c0ae501def28746d76",
+        "version" : "2.1.2"
+      }
+    },
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/readium/ZIPFoundation.git",
+      "state" : {
+        "revision" : "adb49c8bfe060cc187370b12fa081012a6440b86",
+        "version" : "3.0.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/vreaderTests/Services/Reader/ReadiumOpenSmokeTests.swift
+++ b/vreaderTests/Services/Reader/ReadiumOpenSmokeTests.swift
@@ -1,0 +1,109 @@
+// Purpose: Feature #42 Phase 1 WI-1 smoke test — proves the Readium Swift
+// Toolkit links into the test/app target and that a real EPUB opens through
+// the Readium 3.x opening flow (AssetRetriever → PublicationOpener with
+// DefaultPublicationParser). This is a genuine open (no mock): it parses the
+// bundled `mini-epub3.epub` DebugFixture and asserts the resulting
+// Publication exposes a non-empty reading order (spine) and a metadata title.
+//
+// WI-1 is dependency + smoke only: no dispatch change, no feature flag, no
+// reader host. Those land in later WIs.
+//
+// @coordinates-with: project.yml (Readium SPM dependency)
+
+#if DEBUG
+
+import Testing
+import Foundation
+import ReadiumShared
+import ReadiumStreamer
+@testable import vreader
+
+@Suite("ReadiumOpenSmoke")
+struct ReadiumOpenSmokeTests {
+
+    /// Resolves the bundled `mini-epub3.epub` DebugFixture (DEBUG-only — copied
+    /// into the app bundle's `DebugFixtures/` subdirectory by project.yml's
+    /// pre-build script; the test target is hosted in the app, so `Bundle.main`
+    /// resolves to the app bundle). Mirrors the `mini-azw3` fixture precedent
+    /// in MOBIMetadataParserTests.
+    private func miniEPUBURL() throws -> URL {
+        try #require(
+            Bundle.main.url(
+                forResource: "mini-epub3",
+                withExtension: "epub",
+                subdirectory: RealDebugBridgeContext.fixtureBundleSubdirectory
+            ),
+            "mini-epub3.epub must be bundled under DebugFixtures/ in DEBUG builds"
+        )
+    }
+
+    /// Copies the fixture to a fresh temp file so Readium opens a plain on-disk
+    /// file URL (independent of bundle-resource read constraints). Returns the
+    /// temp file's `FileURL` (an `AbsoluteURL`).
+    private func tempFixtureFileURL() throws -> FileURL {
+        let src = try miniEPUBURL()
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("readium-smoke-\(UUID().uuidString).epub")
+        try FileManager.default.copyItem(at: src, to: tmp)
+        return try #require(FileURL(url: tmp), "temp fixture path must form a FileURL")
+    }
+
+    /// Builds the canonical Readium 3.x opener (matches the toolkit TestApp's
+    /// `Readium` wiring): a DefaultHTTPClient feeding an AssetRetriever and a
+    /// DefaultPublicationParser. No GCDWebServer adapter, no LCP.
+    private func makeOpener() -> (AssetRetriever, PublicationOpener) {
+        let httpClient = DefaultHTTPClient()
+        let assetRetriever = AssetRetriever(httpClient: httpClient)
+        let opener = PublicationOpener(
+            parser: DefaultPublicationParser(
+                httpClient: httpClient,
+                assetRetriever: assetRetriever,
+                pdfFactory: DefaultPDFDocumentFactory()
+            )
+        )
+        return (assetRetriever, opener)
+    }
+
+    // MARK: - Happy path
+
+    @Test func opensBundledEPUB_yieldsReadingOrderAndTitle() async throws {
+        let fileURL = try tempFixtureFileURL()
+        defer { try? FileManager.default.removeItem(at: fileURL.url) }
+
+        let (assetRetriever, opener) = makeOpener()
+
+        let asset = try await assetRetriever.retrieve(url: fileURL).get()
+        let publication = try await opener.open(
+            asset: asset,
+            allowUserInteraction: false
+        ).get()
+
+        // Proves the toolkit linked + parsed a real EPUB: spine + title present.
+        #expect(!publication.readingOrder.isEmpty,
+                "Readium must parse a non-empty reading order (spine) from mini-epub3")
+        let title = publication.metadata.title
+        #expect(title?.isEmpty == false,
+                "Readium must surface a non-empty metadata title (mini-epub3 has dc:title)")
+        #expect(title == "VReader Mini EPUB Fixture",
+                "mini-epub3's dc:title must round-trip through Readium's metadata")
+    }
+
+    // MARK: - Edge case — nonexistent file fails cleanly (no crash)
+
+    @Test func opensMissingFile_failsWithoutCrashing() async throws {
+        let missing = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("readium-smoke-missing-\(UUID().uuidString).epub")
+        let fileURL = try #require(FileURL(url: missing))
+        let (assetRetriever, _) = makeOpener()
+
+        let result = await assetRetriever.retrieve(url: fileURL)
+        switch result {
+        case .success:
+            Issue.record("Retrieving a nonexistent EPUB must not succeed")
+        case .failure:
+            break // expected — error surfaced, no crash
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary

Feature #42 Gate-3 **WI-1 (foundational)**: add the Readium Swift Toolkit (3.9.0, BSD-3) SPM dependency + a genuine open-smoke test. **No dispatch / flag / engine change** — the EPUB engine is untouched; this only lands the dependency + proves a publication opens.

- `project.yml`: top-level `packages: Readium` (url `readium/swift-toolkit`, `exactVersion: 3.9.0`) → `vreader` target links **ReadiumShared + ReadiumStreamer + ReadiumNavigator**; `vreaderTests` links ReadiumShared + ReadiumStreamer (Gate-4 fix). NO ReadiumLCP, NO GCDWebServer adapter (Readium 3.x opens via `AssetRetriever`/`PublicationOpener`). `Package.resolved` committed.
- `vreaderTests/Services/Reader/ReadiumOpenSmokeTests.swift` (Swift Testing, DEBUG-gated): opens bundled `mini-epub3.epub` via `AssetRetriever` → `PublicationOpener(parser: DefaultPublicationParser(...))`, asserts non-empty readingOrder + metadata title; + a missing-file edge case.

Part of feature #42 (first of the audited 14-WI Phase-1 plan).

## Codex Audit (Gate 4)
1 round, ship-as-is. 1 High (test target didn't link Readium products → fixed: added to `vreaderTests`) + 1 Low (GCDWebServer resolved-but-not-linked transitively — accepted, inherent to Readium's package graph). Readium 3.9.0 product names verified. Scope clean (no engine/flag/dispatch changes). Audit log: `.claude/codex-audits/feat-feature-42-wi1-spm-readium-audit.md`.

## Validation
- [x] `xcodebuild build` SUCCEEDED (Readium links into the app)
- [x] `ReadiumOpenSmokeTests` 2/2 green (genuine open, not a mock)
- [x] Codex Gate-4 ship-as-is
- [x] Version bumped 3.40.14 → 3.40.15

## Gate 5a Verification
Foundational WI (dependency + smoke test, no user-observable behavior) → unit/integration test + audit sufficient; no device verification required (rule 47 Gate-5 foundational tier).

## Type of Change
- [x] Feature WI (Part of feature #42)