### PR TITLE
feat(#42 WI-2): VReaderLocator envelope + additive SchemaV8 migration

### DIFF
--- a/.claude/codex-audits/feat-feature-42-wi2-vreaderlocator-audit.md
+++ b/.claude/codex-audits/feat-feature-42-wi2-vreaderlocator-audit.md
@@ -1,0 +1,31 @@
+---
+branch: feat/feature-42-wi2-vreaderlocator
+threadId: codex-exec-2026-05-29-wi2
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-29
+---
+
+# Codex Gate-4 audit — Feature #42 Phase-1 WI-2 (VReaderLocator + SchemaV8)
+
+Foundational WI: `VReaderLocator` value-type envelope (Codable/Equatable/Sendable; `ReaderLocatorEngine`
+enum; `readiumLocatorJSON: String?` so no Readium dependency; `canonicalHash` mirrors
+`AnnotationAnchor.anchorHash`) + additive SchemaV8 (`ReadingPosition.vreaderLocatorData: Data?`, raw
+Data per Highlight.anchorData precedent; lightweight migration, all entry points wired). No
+engine/dispatch/flag/Readium change.
+
+## Round 1 — 1 High + 1 Medium
+
+| file:line | severity | issue | resolution |
+|---|---|---|---|
+| vreaderTests/Models/Migration/V6toV7MigrationTests.swift:31,37 + V5toV6MigrationTests.swift:34 | High | Pre-existing migration tests asserted "SchemaV7 is the plan tail" + "schemas.count == 7"; appending SchemaV8 breaks them → unit gate fails. (The implementing agent ran only its own focused tests, missing these.) | **Fixed** — `migrationPlanIncludesV7AtIndex6` (asserts V7 at index 6, not "last" — stable as new schemas land; the tail assertion is owned by SchemaV8MigrationTests), `migrationPlanLengthIsEight` (count == 8), V5toV6 count → 8. Re-ran all 5 migration/locator suites: 46/46 green. |
+| docs/architecture.md:12,37,211,213 | Medium | Architecture docs still said live `VReaderApp` uses SchemaV7 / plan ends at V7 — schema/docs-sync violation. | **Fixed** — SchemaV7 → SchemaV8 (system diagram, VReaderApp line, Data Layer heading, migration-plan chain) + documented `ReadingPosition.vreaderLocatorData` + the `VReaderLocator` envelope (raw `Data?`, lightweight migration). |
+
+## Verdict
+
+Round 1: 1 High (stale migration assertions — fixed) + 1 Medium (architecture docs-sync — fixed).
+Production WI-2 scope confirmed clean by the auditor: "V8 is wired into the migration plan and live
+container, the additive optional `Data?` column is the right SwiftData lightweight-migration shape,
+`VReaderLocator` is value-only/Sendable with deterministic sorted-key SHA-256 hashing, and the diff
+does not introduce Readium imports, engine dispatch, or flag changes." **Verdict: ship-as-is.** 46
+tests green; full build SUCCEEDED.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ VReader is an iOS e-book reader built with SwiftUI + SwiftData. It supports TXT,
 ```
 ┌──────────────────────────────────────────────────────┐
 │                    VReaderApp                         │
-│  SwiftData SchemaV7 · PersistenceActor · BookImporter│
+│  SwiftData SchemaV8 · PersistenceActor · BookImporter│
 └─────────────────────┬────────────────────────────────┘
                       │
           ┌───────────┴───────────┐
@@ -34,7 +34,7 @@ VReader is an iOS e-book reader built with SwiftUI + SwiftData. It supports TXT,
 
 ### 1. App Layer (`vreader/App/`)
 
-- `VReaderApp.swift` — SwiftData `ModelContainer` init (SchemaV7), migration plan (V1→V2→V3→V4→V5→V6→V7), test seeding, error handling. Injects the live `PersistenceActor` into the SwiftUI environment via `\.persistenceActor` so settings sub-screens can construct backup providers without rewriting every parent's signature. Adopts `@UIApplicationDelegateAdaptor(VReaderAppDelegate.self)` for background-URLSession completion-handler delivery (feature #47).
+- `VReaderApp.swift` — SwiftData `ModelContainer` init (SchemaV8), migration plan (V1→V2→V3→V4→V5→V6→V7→V8), test seeding, error handling. Injects the live `PersistenceActor` into the SwiftUI environment via `\.persistenceActor` so settings sub-screens can construct backup providers without rewriting every parent's signature. Adopts `@UIApplicationDelegateAdaptor(VReaderAppDelegate.self)` for background-URLSession completion-handler delivery (feature #47).
 - `VReaderAppDelegate.swift` — `UIApplicationDelegate` adapter that captures `application(_:handleEventsForBackgroundURLSession:completionHandler:)` into a MainActor-isolated static dictionary keyed by URLSession identifier. The lazy-download coordinator retrieves and invokes the handler from `LazyDownloadDelegate.urlSessionDidFinishEvents` so iOS releases the app's background-launch grace period.
 
 ### 2. Library Layer (`vreader/Views/LibraryView.swift`, `vreader/ViewModels/LibraryViewModel.swift`)
@@ -208,9 +208,9 @@ Bridge-internal coordinators (`EPUBWebViewBridgeCoordinator`, `FoliateViewCoordi
 
 ### 6. Data Layer (`vreader/Models/`)
 
-SwiftData SchemaV7 entities:
+SwiftData SchemaV8 entities:
 
-- `Book` (fingerprintKey unique; gains `originalExtension: String?` in SchemaV5 for backup blob extension preservation; gains `fileState: String` and `blobPath: String?` in SchemaV6 for feature #47's lazy-load row state) → `ReadingPosition`, `Highlight`, `Bookmark`, `AnnotationNote`, `BookCollection`
+- `Book` (fingerprintKey unique; gains `originalExtension: String?` in SchemaV5 for backup blob extension preservation; gains `fileState: String` and `blobPath: String?` in SchemaV6 for feature #47's lazy-load row state) → `ReadingPosition` (gains `vreaderLocatorData: Data?` in SchemaV8 — feature #42's engine-agnostic `VReaderLocator` envelope, stored as raw JSON `Data?` mirroring `Highlight.anchorData`; additive/optional → lightweight migration, no stage), `Highlight`, `Bookmark`, `AnnotationNote`, `BookCollection`
 - `ReadingSession`, `ReadingStats`
 - `BookSource`, `ContentReplacementRule` (added in SchemaV4)
 - `ChapterTranslation` (added in SchemaV7 — feature #56 bilingual-reading persistent translation cache; independent entity, no `@Relationship` to `Book`; `lookupKey: String` is the `@Attribute(.unique)` dedupe key joined from `bookFingerprintKey` + `unitStorageKey` + `targetLanguage` + `providerProfileID` + `promptVersion`)

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 696
-        MARKETING_VERSION: 3.40.15
+        CURRENT_PROJECT_VERSION: 697
+        MARKETING_VERSION: 3.40.16
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 		35A3D4A4B62F808EF8874EEA /* FoliateBottomChromeSeek.swift in Sources */ = {isa = PBXBuildFile; fileRef = C78DF73C0577F734E90ACB70 /* FoliateBottomChromeSeek.swift */; };
 		3611C9D190CF99F46820B06E /* FoliateHighlightMutatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61992F892AF73F530F54DAC /* FoliateHighlightMutatorTests.swift */; };
 		3613DFF5007EAA0C4D5B2CEB /* HighlightPopoverDeleteConfirm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B94D8DF6728DEE93B09DE96 /* HighlightPopoverDeleteConfirm.swift */; };
+		36972763F4542783F654FB33 /* SchemaV8MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E644FA2FFCEBC9F45E1E6E /* SchemaV8MigrationTests.swift */; };
 		369D003DCE5F36A64E5C1C06 /* AIChatGeneralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90F4EB83CC68406DA14DD94 /* AIChatGeneralTests.swift */; };
 		36B37715BB3494F635566157 /* ImportJobQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117731FF4D8AE414141C5ECF /* ImportJobQueue.swift */; };
 		37128EB810887C2A4D36E99F /* VerificationSettingsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1C2AB4E9DBE8437C7C8CF8 /* VerificationSettingsHelper.swift */; };
@@ -505,6 +506,7 @@
 		5BCD69B7FFD787F33D6E0C8D /* AutoPageTurnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2396FE1BB03C2F3CEFAB8E2 /* AutoPageTurnerTests.swift */; };
 		5BF0D6683395428E016CBDC8 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD245135256A06A28C88178 /* SearchBar.swift */; };
 		5BF55452ABA60AB492B54C6D /* AIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02B540992E1F3C96A00723F /* AIProvider.swift */; };
+		5C14B5DA26C4FAD1CB15B31D /* VReaderLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6147C39C4171F0BFA004780E /* VReaderLocator.swift */; };
 		5C1FD4FE52873A5962D4CB95 /* PersistenceActor+RemoteOnly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300CB93197976B4D665AEDFC /* PersistenceActor+RemoteOnly.swift */; };
 		5C20BECE1338802F60F3E7B7 /* AITranslationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE29B97304B59C88E3F3F9CF /* AITranslationTests.swift */; };
 		5C4609A0AEAD65A12670FB78 /* DebugBridgeHighlightObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310813C564EF1BF86A13694E /* DebugBridgeHighlightObserverTests.swift */; };
@@ -540,6 +542,7 @@
 		633C51302507DA66A2EED1DF /* BilingualPillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8AF952035ED7A7AF46DE73A /* BilingualPillTests.swift */; };
 		6344AC26417E72E251541FE3 /* TestSeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0797CB73F5D8FDAF0B7298E /* TestSeeder.swift */; };
 		6357FCBADF316F72B24C3975 /* ProviderProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9893809AE39B5DF0233FEE42 /* ProviderProfile.swift */; };
+		637607A8DD0B3C23776A3002 /* SchemaV8.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CA82E6D9E86220E10B3728 /* SchemaV8.swift */; };
 		6385D414214525E5CF2C4C8E /* HighlightPopoverViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7747D7A10C50F43520FB5FF0 /* HighlightPopoverViewModel.swift */; };
 		646C642DA4E4DCFF2AFEB68A /* search_no_results.html in Resources */ = {isa = PBXBuildFile; fileRef = 84BAC2CBFB7F533857E6A65B /* search_no_results.html */; };
 		64709D1B5C006D3299C8ABAF /* AutoPageTurner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5401E10DDA195966ABD13F70 /* AutoPageTurner.swift */; };
@@ -555,6 +558,7 @@
 		65EB03B9632EFDE8EAF49ACC /* EPUBTextStripperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C842F00C6B506FC831E0347 /* EPUBTextStripperTests.swift */; };
 		65FC6B2A5172850AB0B7CA42 /* EPUBBilingualPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD58B3560B70B8E874D669C /* EPUBBilingualPipeline.swift */; };
 		65FDF3DF582C0F5E67305EED /* ReaderSettingsPanelReadingModeGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83246694DE80F5760F85506E /* ReaderSettingsPanelReadingModeGateTests.swift */; };
+		66588E6EE7A6E8D551B71492 /* VReaderLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19656D9EB4A4D95E03DD9354 /* VReaderLocatorTests.swift */; };
 		66BF815FA62FF51C7C0053ED /* ReaderContainerView+DebugBridgeSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B46A5F229515020166A545 /* ReaderContainerView+DebugBridgeSearch.swift */; };
 		66D2DC1C52A9CFA24FBB7E1F /* NativeTextPagedViewSideTapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7456EC54564FFE74772E88E8 /* NativeTextPagedViewSideTapTests.swift */; };
 		66EBE9BC48EBEA51AEC3B77C /* ReaderContainerView+SearchPollAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB186FF39C9836750BE4499 /* ReaderContainerView+SearchPollAction.swift */; };
@@ -1508,6 +1512,7 @@
 		1920480AF349823757484C2D /* EPUBWebViewBridgeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBWebViewBridgeCoordinator.swift; sourceTree = "<group>"; };
 		1923055CD55D02FA17D295ED /* BilingualAttributedStringComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualAttributedStringComposer.swift; sourceTree = "<group>"; };
 		19522F65C0947EFDCF9E4D2B /* TypographySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypographySettings.swift; sourceTree = "<group>"; };
+		19656D9EB4A4D95E03DD9354 /* VReaderLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderLocatorTests.swift; sourceTree = "<group>"; };
 		196BB1CA9C490A623D63EDE4 /* LibraryContainerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryContainerModel.swift; sourceTree = "<group>"; };
 		197B915C35BF54A48D2055CC /* DebugReaderRegistrySettleCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReaderRegistrySettleCleanupTests.swift; sourceTree = "<group>"; };
 		1987220FE3E8931D9F8185F2 /* BilingualPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualPill.swift; sourceTree = "<group>"; };
@@ -1905,6 +1910,7 @@
 		608AC905654D9F01D8A39855 /* FoliateChapterTextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateChapterTextProviderTests.swift; sourceTree = "<group>"; };
 		60D19CA6B370181C8BF08270 /* VReaderAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderAppDelegate.swift; sourceTree = "<group>"; };
 		60F442A575A04CD706CC53FE /* EPUBDebugBridgeHighlightJS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBDebugBridgeHighlightJS.swift; sourceTree = "<group>"; };
+		6147C39C4171F0BFA004780E /* VReaderLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderLocator.swift; sourceTree = "<group>"; };
 		6195F10A5C760B111459790C /* PollUntil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollUntil.swift; sourceTree = "<group>"; };
 		61C7310D3FF8C5778BFCB6E1 /* TXTAttributedStringBuilderChapterStartTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTAttributedStringBuilderChapterStartTests.swift; sourceTree = "<group>"; };
 		61D2ACCFF53EDBE89326A37F /* LocatorFactoryTXTChapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorFactoryTXTChapterTests.swift; sourceTree = "<group>"; };
@@ -2073,6 +2079,7 @@
 		83BA71E474E9C05E3689CF88 /* ReaderMorePopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderMorePopover.swift; sourceTree = "<group>"; };
 		83BCFD179C107F7E997AEB88 /* AnnotationImporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationImporterTests.swift; sourceTree = "<group>"; };
 		83BEF8E9F5CAD4246490C06D /* AISummaryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISummaryCard.swift; sourceTree = "<group>"; };
+		83CA82E6D9E86220E10B3728 /* SchemaV8.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV8.swift; sourceTree = "<group>"; };
 		83F36EF81271874A13417D45 /* OPDSEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSEntryView.swift; sourceTree = "<group>"; };
 		8404837D8FC686DDDB62EEC3 /* AccentColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccentColorTests.swift; sourceTree = "<group>"; };
 		847DD24E5292D6B493E29C15 /* BilingualPairing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualPairing.swift; sourceTree = "<group>"; };
@@ -2474,6 +2481,7 @@
 		D14E222357346107CB34B750 /* SmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokeTests.swift; sourceTree = "<group>"; };
 		D17013114ADB4797AB48D794 /* FoliateViewBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateViewBridge.swift; sourceTree = "<group>"; };
 		D1B00C0FE14AB02EDE7E9EDD /* SyncOutboundQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncOutboundQueueTests.swift; sourceTree = "<group>"; };
+		D1E644FA2FFCEBC9F45E1E6E /* SchemaV8MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV8MigrationTests.swift; sourceTree = "<group>"; };
 		D2AEB48E4BF208D97EEF397C /* QuoteRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuoteRecovery.swift; sourceTree = "<group>"; };
 		D2D8C2F300254BE19CB77776 /* ReadingStatsCustomRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsCustomRange.swift; sourceTree = "<group>"; };
 		D2EA03BEFDBB65F5D7533EDE /* SchemaV1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV1Tests.swift; sourceTree = "<group>"; };
@@ -2814,6 +2822,7 @@
 				22789AF01A93F31CDFDFB3F2 /* TranslationUnitIDTests.swift */,
 				8E6E8611E23F1BE57E84E732 /* TXTTextViewBridgeTests.swift */,
 				EEF87AF7EE6B0FB8E4CC9332 /* TypographySettingsTests.swift */,
+				19656D9EB4A4D95E03DD9354 /* VReaderLocatorTests.swift */,
 				AD90252EC7BC13BB04C75119 /* Migration */,
 			);
 			path = Models;
@@ -3560,6 +3569,7 @@
 				71A6667FB5A4B6534854FD37 /* SchemaV5.swift */,
 				8A9899D5096108025F3AA19C /* SchemaV6.swift */,
 				1DF155633B0D81B0E477E63C /* SchemaV7.swift */,
+				83CA82E6D9E86220E10B3728 /* SchemaV8.swift */,
 				DB16317C72EB6BBB61D77030 /* V1toV2Migration.swift */,
 			);
 			path = Migration;
@@ -4139,6 +4149,7 @@
 			isa = PBXGroup;
 			children = (
 				AEE844A76B8AFC7B1DC2E840 /* HighlightAnchorStorageTests.swift */,
+				D1E644FA2FFCEBC9F45E1E6E /* SchemaV8MigrationTests.swift */,
 				939BC09F1D771D2E22301ED3 /* V1toV2MigrationTests.swift */,
 				AD170A9C4FEB206D5F5F2157 /* V5toV6MigrationTests.swift */,
 				6832D0CE94B6D7181A2D82B0 /* V6toV7MigrationTests.swift */,
@@ -4566,6 +4577,7 @@
 				DEBCE9334037F29F612553D7 /* TranslationUnitID.swift */,
 				19522F65C0947EFDCF9E4D2B /* TypographySettings.swift */,
 				6A3131E83F93590395D14009 /* UnifiedEPUBLoadResult.swift */,
+				6147C39C4171F0BFA004780E /* VReaderLocator.swift */,
 				62043F4A2E7370252FDB1685 /* Migration */,
 			);
 			path = Models;
@@ -5673,6 +5685,7 @@
 				5B9209E7096FD5D30F56BA8F /* ResolveHighlightColorTests.swift in Sources */,
 				48C743A0324468FF7507F157 /* RuleEngineTests.swift in Sources */,
 				FD253FA0CEB159E2B1299BD4 /* SchemaV1Tests.swift in Sources */,
+				36972763F4542783F654FB33 /* SchemaV8MigrationTests.swift in Sources */,
 				0681EC94635E9BBB798AAB77 /* SearchHighlightDismissTests.swift in Sources */,
 				3821F3BE76B9BE588B9FA995 /* SearchHitToLocatorResolverTests.swift in Sources */,
 				9760CE8C8811986D6EEECF61 /* SearchIndexStoreTests.swift in Sources */,
@@ -5801,6 +5814,7 @@
 				0A866D2088849BF693C99A10 /* V5toV6MigrationTests.swift in Sources */,
 				4CCE624D88A6301BB7A2E18C /* V6toV7MigrationTests.swift in Sources */,
 				CFC40B5FB55F37C092A70338 /* VReaderAnnotationParserTests.swift in Sources */,
+				66588E6EE7A6E8D551B71492 /* VReaderLocatorTests.swift in Sources */,
 				CCCA05F0A380F2D77780D17C /* VerificationDebugBridgeHelperTests.swift in Sources */,
 				B7803B2BE60AEAE5CF7819C9 /* VerificationSettingsHelperTests.swift in Sources */,
 				8C5EFF0A113773C9FA1153E1 /* VoiceOverAuditTests.swift in Sources */,
@@ -6337,6 +6351,7 @@
 				0F753635DD7185A076DE4196 /* SchemaV5.swift in Sources */,
 				CDE29CE8275DB7E13C585E74 /* SchemaV6.swift in Sources */,
 				E63DABE52C00FAABF402B5A1 /* SchemaV7.swift in Sources */,
+				637607A8DD0B3C23776A3002 /* SchemaV8.swift in Sources */,
 				97731990DD3F91A22A6C9038 /* ScreenSpaceDemo.swift in Sources */,
 				793A39541D8253B1CA8984A5 /* ScrollProgressHelper.swift in Sources */,
 				5BF0D6683395428E016CBDC8 /* SearchBar.swift in Sources */,
@@ -6477,6 +6492,7 @@
 				85A712EBB7E4B4DF30EDEA13 /* VReaderAnnotationParser.swift in Sources */,
 				F10FCB9E3EC6862A640BD406 /* VReaderApp.swift in Sources */,
 				4914FBDCD76FD1D972914081 /* VReaderAppDelegate.swift in Sources */,
+				5C14B5DA26C4FAD1CB15B31D /* VReaderLocator.swift in Sources */,
 				539E581AA8A8427E199AC0A7 /* WebDAVBlobStore.swift in Sources */,
 				C5EEEAABF1F852CDABDA43F1 /* WebDAVClient.swift in Sources */,
 				606A7D33F0DB5643859C0863 /* WebDAVDownloadRequestBuilder.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6669,13 +6669,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 696;
+				CURRENT_PROJECT_VERSION = 697;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.40.15;
+				MARKETING_VERSION = 3.40.16;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6819,13 +6819,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 696;
+				CURRENT_PROJECT_VERSION = 697;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.40.15;
+				MARKETING_VERSION = 3.40.16;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/App/VReaderApp.swift
+++ b/vreader/App/VReaderApp.swift
@@ -81,7 +81,7 @@ struct VReaderApp: App {
         #endif
 
         do {
-            let schema = Schema(SchemaV7.models)
+            let schema = Schema(SchemaV8.models)
 
             #if DEBUG
             // Use in-memory store for UI testing to ensure clean state

--- a/vreader/Models/Migration/SchemaV1.swift
+++ b/vreader/Models/Migration/SchemaV1.swift
@@ -77,7 +77,7 @@ enum SchemaV1: VersionedSchema {
 /// infers the column addition automatically.
 enum VReaderMigrationPlan: SchemaMigrationPlan {
     static var schemas: [any VersionedSchema.Type] {
-        [SchemaV1.self, SchemaV2.self, SchemaV3.self, SchemaV4.self, SchemaV5.self, SchemaV6.self, SchemaV7.self]
+        [SchemaV1.self, SchemaV2.self, SchemaV3.self, SchemaV4.self, SchemaV5.self, SchemaV6.self, SchemaV7.self, SchemaV8.self]
     }
 
     static var stages: [MigrationStage] {

--- a/vreader/Models/Migration/SchemaV8.swift
+++ b/vreader/Models/Migration/SchemaV8.swift
@@ -1,0 +1,34 @@
+// Purpose: Schema version 8 — adds an additive optional `vreaderLocatorData:
+// Data?` column to ReadingPosition (Feature #42, WI-2), holding the JSON-encoded
+// VReaderLocator envelope. The migration is lightweight because the field is a
+// purely-additive optional with no backfill of existing rows; SwiftData's
+// implicit lightweight migration applies and no explicit MigrationStage is
+// required. The model SET is unchanged from V7 (no new @Model entity).
+//
+// @coordinates-with: SchemaV7.swift, ReadingPosition.swift, VReaderLocator.swift,
+//   dev-docs/plans/20260528-feature-42-readium-libmobi-reader-engine.md (WI-2)
+
+import Foundation
+import SwiftData
+
+/// Schema version 8: ReadingPosition gains the additive optional
+/// `vreaderLocatorData: Data?` column for the engine-agnostic locator envelope.
+enum SchemaV8: VersionedSchema {
+    static let versionIdentifier = Schema.Version(8, 0, 0)
+
+    static var models: [any PersistentModel.Type] {
+        [
+            Book.self,
+            ReadingPosition.self,
+            Bookmark.self,
+            Highlight.self,
+            AnnotationNote.self,
+            ReadingSession.self,
+            ReadingStats.self,
+            BookCollection.self,
+            BookSource.self,
+            ContentReplacementRule.self,
+            ChapterTranslation.self,
+        ]
+    }
+}

--- a/vreader/Models/ReadingPosition.swift
+++ b/vreader/Models/ReadingPosition.swift
@@ -1,5 +1,12 @@
 // Purpose: Stores the current reading position for a book.
 // Uses Locator for universal position representation.
+//
+// Key decisions:
+// - vreaderLocatorData is the SchemaV8 additive optional column holding the
+//   JSON-encoded VReaderLocator envelope (Feature #42). Stored as raw Data? to
+//   mirror Highlight.anchorData — a SwiftData-safe blob that legacy rows can
+//   lack without a decode crash. The legacy `locator` field is kept untouched
+//   for back-compat / dual-write during the two-engine era.
 
 import Foundation
 import SwiftData
@@ -12,6 +19,13 @@ final class ReadingPosition {
     /// Full locator for the current reading position.
     /// Mutate via `updateLocator(_:)` — SwiftData `didSet` is unreliable.
     private(set) var locator: Locator
+
+    /// Raw JSON bytes of the engine-agnostic `VReaderLocator` envelope (SchemaV8,
+    /// Feature #42). Stored as a simple Data? column — like Highlight.anchorData —
+    /// so legacy rows that predate the column read back as nil instead of
+    /// crashing. Decode with `VReaderLocator` for typed access. nil until a save
+    /// populates it (lazy dual-write; the legacy `locator` is always written too).
+    var vreaderLocatorData: Data?
 
     /// When the position was last updated.
     var updatedAt: Date

--- a/vreader/Models/VReaderLocator.swift
+++ b/vreader/Models/VReaderLocator.swift
@@ -1,0 +1,105 @@
+// Purpose: Durable, engine-agnostic reading-position envelope (Feature #42).
+// Wraps an engine's locator representation behind a vreader-owned value type so
+// saved positions survive an engine swap / re-conversion. Never persist a raw
+// engine-internal anchor — persist this envelope instead.
+//
+// Key decisions:
+// - Value type (Codable/Equatable/Sendable), NOT a @Model. Stored on
+//   ReadingPosition as raw `Data?` (SchemaV8), mirroring Highlight.anchorData's
+//   SwiftData-safe precedent — a Codable struct decoded with try? rather than a
+//   @Model column SwiftData would have to materialize.
+// - `engine` disambiguates which locator representation is authoritative during
+//   the two-engine era: `.epubWKWebView` (legacy `Locator`) vs `.readium`
+//   (`readiumLocatorJSON`, Readium's Locator serialized as plain JSON — so this
+//   type needs NO Readium dependency).
+// - `legacyLocator` carries the existing per-format `Locator` for back-compat /
+//   dual-write, so both engines persist through one envelope.
+// - `canonicalHash` mirrors Locator.canonicalHash / AnnotationAnchor.anchorHash:
+//   sorted-keys JSON, SHA-256, hex string. Deterministic + stable across
+//   encode/decode round-trips for dedup/sync keys.
+//
+// @coordinates-with: Locator.swift, ReadingPosition.swift, SchemaV8.swift
+
+import Foundation
+import CryptoKit
+
+/// Which reader engine produced the authoritative locator in a VReaderLocator.
+enum ReaderLocatorEngine: String, Codable, Hashable, Sendable, CaseIterable {
+    /// The legacy bespoke EPUBWebViewBridge engine — locator lives in `legacyLocator`.
+    case epubWKWebView
+    /// The Readium Swift Toolkit engine — locator lives in `readiumLocatorJSON`.
+    case readium
+}
+
+/// Durable engine-agnostic position envelope. Wraps an engine locator + survives
+/// re-conversion. Persisted as JSON-encoded `Data?` on `ReadingPosition`.
+struct VReaderLocator: Codable, Equatable, Sendable {
+    /// The book's `DocumentFingerprint.canonicalKey`.
+    let fingerprintKey: String
+
+    /// The book's original (imported) format.
+    let originalFormat: BookFormat
+
+    /// Which engine's locator is authoritative.
+    let engine: ReaderLocatorEngine
+
+    /// Readium's `Locator` serialized as JSON (stored as a plain String so this
+    /// type carries no Readium dependency). nil for the legacy engine.
+    let readiumLocatorJSON: String?
+
+    /// The existing per-format vreader `Locator`, for back-compat / dual-write.
+    /// nil when only a Readium locator is available.
+    let legacyLocator: Locator?
+
+    /// Envelope schema version (lets future fields evolve independently of the
+    /// SwiftData schema version).
+    let schemaVersion: Int
+
+    // MARK: - Init
+
+    init(
+        fingerprintKey: String,
+        originalFormat: BookFormat,
+        engine: ReaderLocatorEngine,
+        readiumLocatorJSON: String?,
+        legacyLocator: Locator?,
+        schemaVersion: Int = VReaderLocator.currentSchemaVersion
+    ) {
+        self.fingerprintKey = fingerprintKey
+        self.originalFormat = originalFormat
+        self.engine = engine
+        self.readiumLocatorJSON = readiumLocatorJSON
+        self.legacyLocator = legacyLocator
+        self.schemaVersion = schemaVersion
+    }
+
+    /// Current envelope schema version.
+    static let currentSchemaVersion = 1
+
+    // MARK: - Legacy wrapping
+
+    /// Wraps an existing `Locator` as a legacy-engine envelope. Derives
+    /// `fingerprintKey` and `originalFormat` from the locator's fingerprint, so
+    /// both engines persist through one model.
+    init(legacyLocator: Locator, schemaVersion: Int = VReaderLocator.currentSchemaVersion) {
+        self.fingerprintKey = legacyLocator.bookFingerprint.canonicalKey
+        self.originalFormat = legacyLocator.bookFingerprint.format
+        self.engine = .epubWKWebView
+        self.readiumLocatorJSON = nil
+        self.legacyLocator = legacyLocator
+        self.schemaVersion = schemaVersion
+    }
+
+    // MARK: - Canonical Hash
+
+    /// SHA-256 hash of the canonical (sorted-keys) JSON encoding. Deterministic
+    /// and stable across encode/decode round-trips. Used for dedup/sync keys.
+    var canonicalHash: String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        // VReaderLocator is always encodable (all fields are Codable value types).
+        let data = (try? encoder.encode(self)) ?? Data()
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/vreaderTests/Models/Migration/SchemaV8MigrationTests.swift
+++ b/vreaderTests/Models/Migration/SchemaV8MigrationTests.swift
@@ -1,0 +1,169 @@
+// Purpose: Tests for SchemaV8 migration — adds an additive optional
+// `vreaderLocatorData: Data?` column to ReadingPosition (Feature #42, WI-2)
+// holding the JSON-encoded VReaderLocator envelope. Stored as raw Data? to
+// mirror Highlight.anchorData's SwiftData-safe precedent. Purely-additive
+// optional field; SwiftData's implicit lightweight migration applies and
+// the explicit stages list stays empty.
+//
+// @coordinates-with: SchemaV7.swift, SchemaV8.swift, ReadingPosition.swift,
+//   VReaderLocator.swift, dev-docs/plans/20260528-feature-42-readium-libmobi-reader-engine.md (WI-2)
+
+import Testing
+import Foundation
+import SwiftData
+@testable import vreader
+
+@Suite("SchemaV8Migration")
+struct SchemaV8MigrationTests {
+
+    // MARK: - SchemaV8 structure
+
+    @Test func schemaV8VersionIsEightZeroZero() {
+        #expect(SchemaV8.versionIdentifier == Schema.Version(8, 0, 0))
+    }
+
+    @Test func schemaV8HasSameModelSetAsV7() {
+        // SchemaV8 is purely an additive-field change on ReadingPosition; the
+        // model SET is unchanged from V7 (no new @Model entity).
+        let v8Names = Set(SchemaV8.models.map { String(describing: $0) })
+        let v7Names = Set(SchemaV7.models.map { String(describing: $0) })
+        #expect(v8Names == v7Names)
+    }
+
+    @Test func migrationPlanIncludesV8AsLast() {
+        let last = VReaderMigrationPlan.schemas.last
+        #expect(last != nil)
+        #expect(String(describing: last!) == String(describing: SchemaV8.self))
+    }
+
+    @Test func migrationPlanLengthIsEight() {
+        #expect(VReaderMigrationPlan.schemas.count == 8)
+    }
+
+    @Test func migrationPlanHasNoExplicitStages() {
+        // V7→V8 adds one optional Data? field — implicit lightweight migration,
+        // no explicit stage required.
+        #expect(VReaderMigrationPlan.stages.isEmpty)
+    }
+
+    // MARK: - V7 row survives migration to V8, new field defaults nil
+
+    @Test func migratingExistingV7StoreOpensUnderV8AndPreservesLocator() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("v7v8-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storeURL = dir.appendingPathComponent("store.sqlite")
+
+        let fp = DocumentFingerprint(
+            contentSHA256: String(repeating: "e", count: 64),
+            fileByteCount: 2048,
+            format: .epub
+        )
+        let originalLocator = Locator(
+            bookFingerprint: fp, href: "ch3.xhtml",
+            progression: 0.33, totalProgression: 0.5,
+            cfi: nil, page: nil,
+            charOffsetUTF16: nil, charRangeStartUTF16: nil, charRangeEndUTF16: nil,
+            textQuote: nil, textContextBefore: nil, textContextAfter: nil
+        )
+        let originalHash = originalLocator.canonicalHash
+
+        // Write a ReadingPosition under V7.
+        do {
+            let v7 = try ModelContainer(
+                for: Schema(SchemaV7.models),
+                configurations: [ModelConfiguration(url: storeURL)]
+            )
+            let ctx = ModelContext(v7)
+            let position = ReadingPosition(locator: originalLocator, deviceId: "dev-1")
+            ctx.insert(position)
+            try ctx.save()
+        }
+
+        // Reopen under V8 with the migration plan.
+        let v8 = try ModelContainer(
+            for: Schema(SchemaV8.models),
+            migrationPlan: VReaderMigrationPlan.self,
+            configurations: [ModelConfiguration(url: storeURL)]
+        )
+        let ctx = ModelContext(v8)
+        let positions = try ctx.fetch(FetchDescriptor<ReadingPosition>())
+        #expect(positions.count == 1)
+        let migrated = try #require(positions.first)
+        // Original locator survived intact.
+        #expect(migrated.locator.canonicalHash == originalHash)
+        #expect(migrated.locator.href == "ch3.xhtml")
+        #expect(migrated.deviceId == "dev-1")
+        // New additive field defaults to nil for migrated rows.
+        #expect(migrated.vreaderLocatorData == nil)
+    }
+
+    // MARK: - V8 row can store + read back a VReaderLocator envelope
+
+    @Test func v8ReadingPositionStoresAndReadsBackVReaderLocator() throws {
+        let schema = Schema(SchemaV8.models)
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [config])
+        let context = ModelContext(container)
+
+        let fp = DocumentFingerprint(
+            contentSHA256: String(repeating: "f", count: 64),
+            fileByteCount: 4096,
+            format: .epub
+        )
+        let legacy = Locator(
+            bookFingerprint: fp, href: "ch1.xhtml",
+            progression: 0.1, totalProgression: nil,
+            cfi: nil, page: nil,
+            charOffsetUTF16: nil, charRangeStartUTF16: nil, charRangeEndUTF16: nil,
+            textQuote: nil, textContextBefore: nil, textContextAfter: nil
+        )
+        let envelope = VReaderLocator(
+            fingerprintKey: fp.canonicalKey, originalFormat: .epub,
+            engine: .readium,
+            readiumLocatorJSON: #"{"href":"ch1.xhtml","locations":{"progression":0.1}}"#,
+            legacyLocator: legacy, schemaVersion: 1
+        )
+
+        let position = ReadingPosition(locator: legacy, deviceId: "dev-2")
+        position.vreaderLocatorData = try JSONEncoder().encode(envelope)
+        context.insert(position)
+        try context.save()
+
+        let fetched = try #require(
+            try context.fetch(FetchDescriptor<ReadingPosition>()).first
+        )
+        let data = try #require(fetched.vreaderLocatorData)
+        let decoded = try JSONDecoder().decode(VReaderLocator.self, from: data)
+        #expect(decoded == envelope)
+        // Legacy locator still independently readable.
+        #expect(fetched.locator.href == "ch1.xhtml")
+    }
+
+    @Test func v8ReadingPositionDefaultsVReaderLocatorDataToNil() throws {
+        let schema = Schema(SchemaV8.models)
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: [config])
+        let context = ModelContext(container)
+
+        let fp = DocumentFingerprint(
+            contentSHA256: String(repeating: "0", count: 64),
+            fileByteCount: 10, format: .pdf
+        )
+        let locator = Locator(
+            bookFingerprint: fp, href: nil, progression: nil, totalProgression: nil,
+            cfi: nil, page: 3,
+            charOffsetUTF16: nil, charRangeStartUTF16: nil, charRangeEndUTF16: nil,
+            textQuote: nil, textContextBefore: nil, textContextAfter: nil
+        )
+        let position = ReadingPosition(locator: locator)
+        context.insert(position)
+        try context.save()
+
+        let fetched = try #require(
+            try context.fetch(FetchDescriptor<ReadingPosition>()).first
+        )
+        #expect(fetched.vreaderLocatorData == nil)
+    }
+}

--- a/vreaderTests/Models/Migration/V5toV6MigrationTests.swift
+++ b/vreaderTests/Models/Migration/V5toV6MigrationTests.swift
@@ -31,8 +31,8 @@ struct V5toV6MigrationTests {
     }
 
     @Test func migrationPlanLength() {
-        // V1, V2, V3, V4, V5, V6, V7 — seven schemas (V7 added by feature #56).
-        #expect(VReaderMigrationPlan.schemas.count == 7)
+        // V1…V8 — eight schemas (V8 added by feature #42, V7 by feature #56).
+        #expect(VReaderMigrationPlan.schemas.count == 8)
     }
 
     @Test func migrationPlanHasNoExplicitStages() {

--- a/vreaderTests/Models/Migration/V6toV7MigrationTests.swift
+++ b/vreaderTests/Models/Migration/V6toV7MigrationTests.swift
@@ -28,14 +28,17 @@ struct V6toV7MigrationTests {
         #expect(v7Names == expected)
     }
 
-    @Test func migrationPlanIncludesV7AsLast() {
-        let last = VReaderMigrationPlan.schemas.last
-        #expect(last != nil)
-        #expect(String(describing: last!) == String(describing: SchemaV7.self))
+    @Test func migrationPlanIncludesV7AtIndex6() {
+        // V7 is the 7th schema (index 6). It is no longer the tail — SchemaV8
+        // (feature #42) follows it; the tail assertion lives in
+        // SchemaV8MigrationTests so this stays stable as new schemas land.
+        #expect(VReaderMigrationPlan.schemas.count > 6)
+        #expect(String(describing: VReaderMigrationPlan.schemas[6]) == String(describing: SchemaV7.self))
     }
 
-    @Test func migrationPlanLengthIsSeven() {
-        #expect(VReaderMigrationPlan.schemas.count == 7)
+    @Test func migrationPlanLengthIsEight() {
+        // V1…V8 — eight schemas (V8 added by feature #42).
+        #expect(VReaderMigrationPlan.schemas.count == 8)
     }
 
     @Test func migrationPlanHasNoExplicitStages() {

--- a/vreaderTests/Models/VReaderLocatorTests.swift
+++ b/vreaderTests/Models/VReaderLocatorTests.swift
@@ -1,0 +1,218 @@
+// Purpose: Tests for VReaderLocator — the durable, engine-agnostic position
+// envelope introduced for Feature #42 (Readium reader engine). Covers Codable
+// round-trip, canonicalHash determinism/stability, the legacy-Locator wrapping
+// initializer, equality, and Unicode/CJK + nil-field edge cases.
+//
+// @coordinates-with: VReaderLocator.swift, Locator.swift, DocumentFingerprint.swift
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("VReaderLocator")
+struct VReaderLocatorTests {
+
+    // MARK: - Fixtures
+
+    private func makeFingerprint(
+        sha: String = String(repeating: "a", count: 64),
+        bytes: Int64 = 1024,
+        format: BookFormat = .epub
+    ) -> DocumentFingerprint {
+        DocumentFingerprint(contentSHA256: sha, fileByteCount: bytes, format: format)
+    }
+
+    private func makeLegacyLocator(
+        _ fp: DocumentFingerprint,
+        href: String = "chapter1.xhtml",
+        progression: Double = 0.25
+    ) -> Locator {
+        Locator(
+            bookFingerprint: fp, href: href,
+            progression: progression, totalProgression: nil,
+            cfi: nil, page: nil,
+            charOffsetUTF16: nil, charRangeStartUTF16: nil, charRangeEndUTF16: nil,
+            textQuote: nil, textContextBefore: nil, textContextAfter: nil
+        )
+    }
+
+    // MARK: - Codable round-trip
+
+    @Test func codableRoundTripWithAllFields() throws {
+        let fp = makeFingerprint()
+        let envelope = VReaderLocator(
+            fingerprintKey: fp.canonicalKey,
+            originalFormat: .epub,
+            engine: .readium,
+            readiumLocatorJSON: #"{"href":"ch1.xhtml","locations":{"progression":0.5}}"#,
+            legacyLocator: makeLegacyLocator(fp),
+            schemaVersion: 1
+        )
+        let data = try JSONEncoder().encode(envelope)
+        let decoded = try JSONDecoder().decode(VReaderLocator.self, from: data)
+        #expect(decoded == envelope)
+    }
+
+    @Test func codableRoundTripWithNilOptionalFields() throws {
+        let fp = makeFingerprint()
+        let envelope = VReaderLocator(
+            fingerprintKey: fp.canonicalKey,
+            originalFormat: .pdf,
+            engine: .epubWKWebView,
+            readiumLocatorJSON: nil,
+            legacyLocator: nil,
+            schemaVersion: 1
+        )
+        let data = try JSONEncoder().encode(envelope)
+        let decoded = try JSONDecoder().decode(VReaderLocator.self, from: data)
+        #expect(decoded == envelope)
+        #expect(decoded.readiumLocatorJSON == nil)
+        #expect(decoded.legacyLocator == nil)
+    }
+
+    // MARK: - canonicalHash
+
+    @Test func canonicalHashIsDeterministic() {
+        let fp = makeFingerprint()
+        let a = VReaderLocator(
+            fingerprintKey: fp.canonicalKey, originalFormat: .epub,
+            engine: .readium, readiumLocatorJSON: "{}",
+            legacyLocator: makeLegacyLocator(fp), schemaVersion: 1
+        )
+        let b = VReaderLocator(
+            fingerprintKey: fp.canonicalKey, originalFormat: .epub,
+            engine: .readium, readiumLocatorJSON: "{}",
+            legacyLocator: makeLegacyLocator(fp), schemaVersion: 1
+        )
+        #expect(a.canonicalHash == b.canonicalHash)
+    }
+
+    @Test func canonicalHashIsSHA256Hex() {
+        let fp = makeFingerprint()
+        let env = VReaderLocator(
+            fingerprintKey: fp.canonicalKey, originalFormat: .epub,
+            engine: .readium, readiumLocatorJSON: nil,
+            legacyLocator: nil, schemaVersion: 1
+        )
+        let hash = env.canonicalHash
+        #expect(hash.count == 64)
+        #expect(hash.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+    }
+
+    @Test func canonicalHashChangesWhenEngineChanges() {
+        let fp = makeFingerprint()
+        let readium = VReaderLocator(
+            fingerprintKey: fp.canonicalKey, originalFormat: .epub,
+            engine: .readium, readiumLocatorJSON: nil, legacyLocator: nil, schemaVersion: 1
+        )
+        let legacy = VReaderLocator(
+            fingerprintKey: fp.canonicalKey, originalFormat: .epub,
+            engine: .epubWKWebView, readiumLocatorJSON: nil, legacyLocator: nil, schemaVersion: 1
+        )
+        #expect(readium.canonicalHash != legacy.canonicalHash)
+    }
+
+    @Test func canonicalHashChangesWhenReadiumJSONChanges() {
+        let fp = makeFingerprint()
+        let a = VReaderLocator(
+            fingerprintKey: fp.canonicalKey, originalFormat: .epub,
+            engine: .readium, readiumLocatorJSON: #"{"progression":0.1}"#,
+            legacyLocator: nil, schemaVersion: 1
+        )
+        let b = VReaderLocator(
+            fingerprintKey: fp.canonicalKey, originalFormat: .epub,
+            engine: .readium, readiumLocatorJSON: #"{"progression":0.9}"#,
+            legacyLocator: nil, schemaVersion: 1
+        )
+        #expect(a.canonicalHash != b.canonicalHash)
+    }
+
+    // MARK: - Legacy Locator wrapping initializer
+
+    @Test func wrappingLegacyLocatorPopulatesFields() {
+        let fp = makeFingerprint(format: .epub)
+        let legacy = makeLegacyLocator(fp, href: "intro.xhtml", progression: 0.4)
+        let envelope = VReaderLocator(legacyLocator: legacy)
+
+        #expect(envelope.engine == .epubWKWebView)
+        #expect(envelope.legacyLocator == legacy)
+        #expect(envelope.readiumLocatorJSON == nil)
+        #expect(envelope.fingerprintKey == fp.canonicalKey)
+        #expect(envelope.originalFormat == .epub)
+    }
+
+    @Test func wrappingLegacyLocatorPreservesFormat() {
+        let fp = makeFingerprint(format: .txt)
+        let legacy = Locator(
+            bookFingerprint: fp, href: nil, progression: nil, totalProgression: nil,
+            cfi: nil, page: nil, charOffsetUTF16: 42,
+            charRangeStartUTF16: nil, charRangeEndUTF16: nil,
+            textQuote: nil, textContextBefore: nil, textContextAfter: nil
+        )
+        let envelope = VReaderLocator(legacyLocator: legacy)
+        #expect(envelope.originalFormat == .txt)
+        #expect(envelope.legacyLocator?.charOffsetUTF16 == 42)
+    }
+
+    // MARK: - Equality
+
+    @Test func equalEnvelopesAreEqual() {
+        let fp = makeFingerprint()
+        let a = VReaderLocator(legacyLocator: makeLegacyLocator(fp))
+        let b = VReaderLocator(legacyLocator: makeLegacyLocator(fp))
+        #expect(a == b)
+    }
+
+    @Test func differentSchemaVersionsAreNotEqual() {
+        let fp = makeFingerprint()
+        let a = VReaderLocator(
+            fingerprintKey: fp.canonicalKey, originalFormat: .epub,
+            engine: .readium, readiumLocatorJSON: nil, legacyLocator: nil, schemaVersion: 1
+        )
+        let b = VReaderLocator(
+            fingerprintKey: fp.canonicalKey, originalFormat: .epub,
+            engine: .readium, readiumLocatorJSON: nil, legacyLocator: nil, schemaVersion: 2
+        )
+        #expect(a != b)
+    }
+
+    // MARK: - Edge cases
+
+    @Test func emptyFingerprintKeyRoundTrips() throws {
+        let envelope = VReaderLocator(
+            fingerprintKey: "",
+            originalFormat: .epub, engine: .readium,
+            readiumLocatorJSON: nil, legacyLocator: nil, schemaVersion: 1
+        )
+        let data = try JSONEncoder().encode(envelope)
+        let decoded = try JSONDecoder().decode(VReaderLocator.self, from: data)
+        #expect(decoded == envelope)
+        // canonicalHash still well-formed.
+        #expect(envelope.canonicalHash.count == 64)
+    }
+
+    @Test func cjkAndUnicodeInReadiumJSONRoundTrips() throws {
+        let fp = makeFingerprint()
+        let json = "{\"text\":\"被讨厌的勇气 — émoji 🎉 \tcontrol\"}"
+        let envelope = VReaderLocator(
+            fingerprintKey: fp.canonicalKey, originalFormat: .epub,
+            engine: .readium, readiumLocatorJSON: json,
+            legacyLocator: nil, schemaVersion: 1
+        )
+        let data = try JSONEncoder().encode(envelope)
+        let decoded = try JSONDecoder().decode(VReaderLocator.self, from: data)
+        #expect(decoded.readiumLocatorJSON == json)
+        #expect(decoded == envelope)
+        // Hash stable across encode/decode round-trip.
+        #expect(decoded.canonicalHash == envelope.canonicalHash)
+    }
+
+    @Test func cjkInFingerprintKeyDoesNotBreakHash() {
+        let envelope = VReaderLocator(
+            fingerprintKey: "epub:被讨厌的勇气:1024",
+            originalFormat: .epub, engine: .readium,
+            readiumLocatorJSON: nil, legacyLocator: nil, schemaVersion: 1
+        )
+        #expect(envelope.canonicalHash.count == 64)
+    }
+}


### PR DESCRIPTION
## Summary

Feature #42 Gate-3 **WI-2 (foundational)**: the durable engine-agnostic locator envelope + its SwiftData migration. No Readium import, no engine/dispatch/flag change.

- `Models/VReaderLocator.swift` (new): `VReaderLocator` value type (Codable/Equatable/Sendable) wrapping `{fingerprintKey, originalFormat, engine, readiumLocatorJSON: String?, legacyLocator: Locator?, schemaVersion}` + `ReaderLocatorEngine` enum (.epubWKWebView/.readium). `readiumLocatorJSON` is a plain String → WI-2 needs NO Readium dependency. `canonicalHash` mirrors `AnnotationAnchor.anchorHash` (sorted-keys JSON → SHA-256).
- SchemaV8 (new): `ReadingPosition` gains `vreaderLocatorData: Data?` (raw Data, mirroring `Highlight.anchorData`; legacy `locator` untouched — dual-write/back-compat). Additive optional → **lightweight migration, no stage**. All entry points wired (schemas array, live container).

Part of feature #42 (WI-2 of the audited Phase-1 plan).

## Codex Audit (Gate 4)
1 round, ship-as-is. 1 High (appending V8 broke pre-existing V6toV7/V5toV6 "V7-is-tail/count-7" assertions → fixed: assert V7 at index 6 + count 8) + 1 Medium (architecture.md SchemaV7 → SchemaV8 docs-sync → fixed). Auditor confirmed the V8 lightweight-migration shape + VReaderLocator Sendable/hash correctness. Audit log: `.claude/codex-audits/feat-feature-42-wi2-vreaderlocator-audit.md`.

## Validation
- [x] 46/46 across VReaderLocatorTests + V1toV2/V5toV6/V6toV7/SchemaV8 migration suites
- [x] Full `xcodebuild build` SUCCEEDED
- [x] Codex Gate-4 ship-as-is
- [x] Docs-sync: architecture.md SchemaV8 + VReaderLocator (separate commit)
- [x] Version bumped 3.40.15 → 3.40.16

## Gate 5a Verification
Foundational WI (pure model + additive migration, no user-observable behavior) → unit/migration tests + audit sufficient; no device verification (rule 47 Gate-5 foundational tier). The V7→V8 migration is exercised by a real in-memory-ModelContainer test (data preserved, field defaults nil).

## Type of Change
- [x] Feature WI (Part of feature #42)