### PR TITLE
feat(#42 WI-3): add readiumEPUBEngine feature flag (default OFF)

### DIFF
--- a/.claude/codex-audits/feat-feature-42-wi3-flag-audit.md
+++ b/.claude/codex-audits/feat-feature-42-wi3-flag-audit.md
@@ -1,0 +1,28 @@
+---
+branch: feat/feature-42-wi3-flag
+threadId: codex-exec-2026-05-29-wi3
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-29
+---
+
+# Codex Gate-4 audit — Feature #42 Phase-1 WI-3 (readiumEPUBEngine flag)
+
+Foundational (tiny) WI: adds `FeatureFlagKey.readiumEPUBEngine` (default OFF in all environments) +
+`persistedFlags` membership + a convenience `var readiumEPUBEngine`. Dark — nothing reads it yet
+(the dispatcher branch is wired in WI-5). NO dispatch/host/engine change.
+
+## Round 1 — 0 High/Medium, 2 Low (fixed)
+
+| file:line | severity | issue | resolution |
+|---|---|---|---|
+| FeatureFlags.swift:9 | Low | Top-file comment listed persisted flags as aiAssistant + epubContinuousScroll only, omitting readiumEPUBEngine. | **Fixed** — added readiumEPUBEngine to the comment. |
+| FeatureFlags.swift:163 | Low | `setOverride` doc comment had the same stale list. | **Fixed** — added readiumEPUBEngine to the comment. |
+
+## Verdict
+
+Auditor: "enum case, exhaustive `defaultValue`, `persistedFlags`, and convenience accessor are wired
+consistently. Default is OFF for all environments. Grep found no other `FeatureFlagKey` count
+assertion or switch that would break. Diff scope is clean: only feature flag service/tests, no
+dispatcher/host/engine wiring." **WI-3 AUDIT: PASS (ship-as-is.)** FeatureFlagsTests 30/30 green
+(exhaustiveness count 5→6 + default-off-all-envs + override-can-enable); build SUCCEEDED.

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 697
-        MARKETING_VERSION: 3.40.16
+        CURRENT_PROJECT_VERSION: 698
+        MARKETING_VERSION: 3.40.17
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6669,13 +6669,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 697;
+				CURRENT_PROJECT_VERSION = 698;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.40.16;
+				MARKETING_VERSION = 3.40.17;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6819,13 +6819,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 697;
+				CURRENT_PROJECT_VERSION = 698;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.40.16;
+				MARKETING_VERSION = 3.40.17;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/FeatureFlags.swift
+++ b/vreader/Services/FeatureFlags.swift
@@ -6,7 +6,7 @@
 // - Reference type (class) so AIService/SyncService see live changes via .shared.
 // - Thread-safe via OSAllocatedUnfairLock (iOS 16+, os framework).
 // - `static let shared` singleton configured once at startup via configure(environment:).
-// - Persisted flags (`aiAssistant`, `epubContinuousScroll`) write their overrides
+// - Persisted flags (`aiAssistant`, `epubContinuousScroll`, `readiumEPUBEngine`) write their overrides
 //   to UserDefaults for cross-launch stickiness; see `persistedFlags`.
 // - Non-persisted overrides remain session-scoped.
 // - Convenience init(environment:) creates standalone instances for testing.
@@ -30,6 +30,16 @@ enum FeatureFlagKey: String, Sendable, CaseIterable {
     /// layout now flows continuously across chapters by default; the persisted
     /// override can still disable it per-user.
     case epubContinuousScroll
+    /// Feature #42 Phase 1: route EPUB rendering to the Readium Swift Toolkit
+    /// engine instead of the legacy `EPUBWebViewBridge`. Default OFF — the
+    /// Readium host (WI-5) is built behind this flag and `EPUBWebViewBridge`
+    /// stays the live default until full parity (incl. bilingual #56 +
+    /// continuous-scroll #71) is verified; only then does the WI-14 flip move
+    /// the default ON (human-gated G2). Persisted so the override sticks across
+    /// launches for testing + so it can be turned back OFF after the Readium
+    /// engine has written data (the dual-write to the legacy `Locator` keeps
+    /// that safe).
+    case readiumEPUBEngine
 }
 
 /// Runtime feature flags with environment-based defaults, override support,
@@ -55,7 +65,7 @@ nonisolated final class FeatureFlags: Sendable {
     private static let persistenceKeyPrefix = "com.vreader.featureFlags."
 
     /// Flags that are persisted to UserDefaults when overridden.
-    private static let persistedFlags: Set<FeatureFlagKey> = [.aiAssistant, .epubContinuousScroll]
+    private static let persistedFlags: Set<FeatureFlagKey> = [.aiAssistant, .epubContinuousScroll, .readiumEPUBEngine]
 
     // MARK: - Shared Singleton
 
@@ -142,10 +152,15 @@ nonisolated final class FeatureFlags: Sendable {
     /// (aiAssistant pattern) — a user/debug `false` override still disables it.
     var epubContinuousScroll: Bool { isEnabled(.epubContinuousScroll) }
 
+    /// Feature #42: render EPUB via the Readium engine. Default OFF (see the
+    /// enum doc + `defaultValue`); the Readium host is built behind this until
+    /// parity, then the WI-14 G2 flip moves it ON.
+    var readiumEPUBEngine: Bool { isEnabled(.readiumEPUBEngine) }
+
     // MARK: - Override Management
 
     /// Sets a runtime override for a feature flag.
-    /// Persisted flags (`aiAssistant`, `epubContinuousScroll` — see `persistedFlags`)
+    /// Persisted flags (`aiAssistant`, `epubContinuousScroll`, `readiumEPUBEngine` — see `persistedFlags`)
     /// are written to UserDefaults; others remain session-scoped.
     ///
     /// - Parameters:
@@ -214,6 +229,12 @@ nonisolated final class FeatureFlags: Sendable {
             // scroll-mode reading experience. Users can still disable it via the
             // persisted override (see the enum doc).
             return true
+        case .readiumEPUBEngine:
+            // Feature #42 Phase 1: default OFF in every environment —
+            // `EPUBWebViewBridge` stays the live EPUB engine until the Readium
+            // host reaches full parity (incl. #56 bilingual + #71 continuous
+            // scroll). The WI-14 flip (human-gated G2) moves this default ON.
+            return false
         }
     }
 }

--- a/vreaderTests/Services/FeatureFlagsTests.swift
+++ b/vreaderTests/Services/FeatureFlagsTests.swift
@@ -141,12 +141,36 @@ struct FeatureFlagsTests {
     // MARK: - Flag Enum
 
     @Test func flagKeysAreExhaustive() {
-        #expect(FeatureFlagKey.allCases.count == 5)
+        #expect(FeatureFlagKey.allCases.count == 6)
         #expect(FeatureFlagKey.allCases.contains(.aiAssistant))
         #expect(FeatureFlagKey.allCases.contains(.sync))
         #expect(FeatureFlagKey.allCases.contains(.searchIndexingVerboseLogs))
         #expect(FeatureFlagKey.allCases.contains(.bilingualReading))
         #expect(FeatureFlagKey.allCases.contains(.epubContinuousScroll))
+        #expect(FeatureFlagKey.allCases.contains(.readiumEPUBEngine))
+    }
+
+    // MARK: - Feature #42: readiumEPUBEngine
+
+    @Test func readiumEPUBEngineDefaultsOffInAllEnvironments() {
+        // Feature #42 Phase 1: default OFF everywhere — EPUBWebViewBridge stays
+        // the live EPUB engine until the Readium host reaches parity. The WI-14
+        // flip (human-gated G2) is what moves this default ON.
+        for env in AppEnvironment.allCases {
+            let flags = FeatureFlags(environment: env)
+            #expect(flags.readiumEPUBEngine == false)
+            #expect(flags.isEnabled(.readiumEPUBEngine) == false)
+        }
+    }
+
+    @Test func readiumEPUBEngineOverrideCanEnable() {
+        // The Readium host (WI-5+) is exercised in DEBUG/test by flipping this
+        // override ON; removing the override restores the default (OFF).
+        let flags = FeatureFlags(environment: .prod)
+        flags.setOverride(true, for: .readiumEPUBEngine)
+        #expect(flags.readiumEPUBEngine == true)
+        flags.removeOverride(for: .readiumEPUBEngine)
+        #expect(flags.readiumEPUBEngine == false)
     }
 
     // MARK: - Feature #71: epubContinuousScroll


### PR DESCRIPTION
## Summary

Feature #42 Gate-3 **WI-3 (foundational, tiny)**: the off-switch. Adds `FeatureFlagKey.readiumEPUBEngine` (default **OFF** in all environments) + `persistedFlags` membership + a convenience `var readiumEPUBEngine`. **Dark** — nothing reads it yet; WI-5 wires the `ReaderContainerView` dispatcher branch behind it. `EPUBWebViewBridge` stays the live EPUB engine until full parity; the WI-14 flip (human-gated G2) moves the default ON.

Part of feature #42 (WI-3 of the audited Phase-1 plan).

## Codex Audit (Gate 4)
1 round, **ship-as-is**. 0 High/Medium; 2 Low (stale persisted-flags doc comments → fixed). Auditor confirmed the flag is wired consistently (enum, exhaustive `defaultValue` OFF, `persistedFlags`, accessor), default OFF, and grep found no other `FeatureFlagKey` count/switch that breaks. Audit log: `.claude/codex-audits/feat-feature-42-wi3-flag-audit.md`.

## Validation
- [x] FeatureFlagsTests 30/30 (exhaustiveness 5→6 + default-off-all-envs + override-can-enable)
- [x] Build SUCCEEDED
- [x] Codex Gate-4 ship-as-is
- [x] Version bumped 3.40.16 → 3.40.17

## Gate 5a Verification
Foundational WI (flag only, dark — no user-observable behavior) → unit tests + audit sufficient; no device verification (rule 47 Gate-5 foundational tier).

## Type of Change
- [x] Feature WI (Part of feature #42)