### PR TITLE
feat(#42 WI-4): ReadiumDebugProbe — Readium-navigator eval/settle registration

### DIFF
--- a/.claude/codex-audits/feat-feature-42-wi4-readium-probe-audit.md
+++ b/.claude/codex-audits/feat-feature-42-wi4-readium-probe-audit.md
@@ -1,0 +1,34 @@
+---
+branch: feat/feature-42-wi4-readium-probe
+threadId: codex-exec-2026-05-29-wi4
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-29
+---
+
+# Codex Gate-4 audit — Feature #42 Phase-1 WI-4 (ReadiumDebugProbe)
+
+Foundational DEBUG-only WI: a Readium-navigator registration + JS-eval seam in the DebugBridge
+registry, so WI-5's `ReadiumEPUBHost` render is CU-free verifiable. Spike resolved Risk 5 —
+Readium 3.9 `EPUBNavigatorViewController` exposes a public `evaluateJavaScript(_:) async -> Result`
+(runs JS on the visible spine), so the probe uses a protocol seam (`ReadiumNavigatorEvaluating`,
+`evaluateJavaScriptValue -> Data` raw JSON, no Readium import in the registry) + key+token-guarded
+`setActiveReadiumNavigator`/`readiumNavigator`. Settle reuses `markReaderSettled`/`awaitReaderSettled`
+(WI-5 calls from `navigator(_:locationDidChange:)`). NO host/dispatch/engine wiring.
+
+## Round 1 — zero findings
+
+Codex verdict verbatim: "Findings: none. The key+token guard mirrors EPUB/Foliate, stale writes are
+rejected when `expectedReaderToken` is set, lookup requires both key and token, and the slot clears
+on active unregister plus reset. The seam stays protocol-based with no Readium import, returns raw
+JSON `Data` consistent with `DebugReaderProbe.evaluateJavaScript`, and remains MainActor-confined.
+DEBUG gating is clean. **WI-4 AUDIT: PASS (ship-as-is).**"
+
+## Notes
+
+`DebugReaderRegistry.swift` is now ~515 lines (was 461 pre-WI-4, already over the ~300 soft limit;
+Swift requires stored slots in the class, so accessor methods live in the sibling
+`ReadiumDebugProbe.swift` per the existing `+Settle.swift`/`+WebViewWait.swift` split). A
+registry-file split is pre-existing tech-debt, out of this WI's scope. 13 `ReadiumDebugProbeTests` +
+37 registry/settle regression pass; full build SUCCEEDED; Release gate `verify-release-no-debugbridge.sh`
+PASS (zero DebugBridge surface — all DEBUG-gated).

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 698
-        MARKETING_VERSION: 3.40.17
+        CURRENT_PROJECT_VERSION: 699
+        MARKETING_VERSION: 3.40.18
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		1A7E58193D247BB8900BA5B3 /* NSUKVSBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFFFEDEA99460D1154D19EE5 /* NSUKVSBridge.swift */; };
 		1AB8FC448D8F8A36717B4836 /* ReaderEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB775AC15594BEC89B477C3C /* ReaderEngine.swift */; };
 		1AC5FD48311C93B5CEB3702E /* BookImporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FBDC41C60328ED4FB8A197 /* BookImporterTests.swift */; };
+		1B2EF4DD9E11CE736EDCAC1E /* ReadiumDebugProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D9CA94F128FAAC004875F6C /* ReadiumDebugProbeTests.swift */; };
 		1B78DA4330A421FE2206B70C /* FoliateSearchAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8C36563D7885AD214F885A /* FoliateSearchAdapter.swift */; };
 		1BD4CC8621C43917629D4728 /* HighlightRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96BE19585BF1F4C8174F7219 /* HighlightRecord.swift */; };
 		1BE57FEAD56B11B8BB4F4B97 /* PillSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14FEA325D6BADCAF881358B5 /* PillSwitch.swift */; };
@@ -672,6 +673,7 @@
 		79ACFB3DD40281B2A3B9AE8B /* DebugSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94C32FCAEDE0062125F6A51E /* DebugSnapshot.swift */; };
 		7A2CAFE661BD03C0255C9DD7 /* Feature37PerBookSettingsVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB03A3F8DCE5FCBEC5458547 /* Feature37PerBookSettingsVerificationTests.swift */; };
 		7A3B9A992F12E5E187F0794E /* ReaderThemeMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A480E951C2CA72DB6A22C24 /* ReaderThemeMigrationTests.swift */; };
+		7A40E167BF58AD2D781145F4 /* ReadiumDebugProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = A36D2CA026CE5A5A63DFFE7F /* ReadiumDebugProbe.swift */; };
 		7A55E9D20DABD558C9D60473 /* LibraryContinueCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E09E65978F174E10780F7D3 /* LibraryContinueCard.swift */; };
 		7A90F0D9EB7A4F82D33EE237 /* FoliateSearchAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6DB55181F2F55D99D879507 /* FoliateSearchAdapterTests.swift */; };
 		7ACFB80A7A453D8665EA3E86 /* HighlightListViewModelFoliateOverlayStripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB34BDDB453BCFFA26B82E19 /* HighlightListViewModelFoliateOverlayStripTests.swift */; };
@@ -2036,6 +2038,7 @@
 		7D04AA64724C4F9A15869C20 /* BookmarkRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkRecord.swift; sourceTree = "<group>"; };
 		7D068D6691FC6690BF3341B1 /* footnotes.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = footnotes.js; sourceTree = "<group>"; };
 		7D44DAF36D098C9C9A7C102B /* LegadoImporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegadoImporterTests.swift; sourceTree = "<group>"; };
+		7D9CA94F128FAAC004875F6C /* ReadiumDebugProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumDebugProbeTests.swift; sourceTree = "<group>"; };
 		7D9CC8400AF6E7894D65B332 /* EPUBChapterWrapPendingTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBChapterWrapPendingTarget.swift; sourceTree = "<group>"; };
 		7DAC8E20A001D7803A16AAD1 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		7DBF9C3C1FBBCE4354F7DAAD /* DictionaryLookupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryLookupTests.swift; sourceTree = "<group>"; };
@@ -2244,6 +2247,7 @@
 		A1E577DAF65D34544D713137 /* TombstoneStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TombstoneStoreTests.swift; sourceTree = "<group>"; };
 		A26827F9E5CF8521F1152661 /* SelectionPopoverActionRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionPopoverActionRow.swift; sourceTree = "<group>"; };
 		A2D06EE3505728373BD89B04 /* StatsCustomRangePicker+Subviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsCustomRangePicker+Subviews.swift"; sourceTree = "<group>"; };
+		A36D2CA026CE5A5A63DFFE7F /* ReadiumDebugProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumDebugProbe.swift; sourceTree = "<group>"; };
 		A3D74F5FB31BAB5089EB5022 /* RealDebugBridgeContext+Eval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RealDebugBridgeContext+Eval.swift"; sourceTree = "<group>"; };
 		A3DF85A7A806124F57A8FB6E /* LazyDownloadEnqueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyDownloadEnqueueTests.swift; sourceTree = "<group>"; };
 		A43A801A0876E2437CE63808 /* EncodingDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingDetector.swift; sourceTree = "<group>"; };
@@ -3114,6 +3118,7 @@
 				EBB7506487E3EB33A54EB619 /* DebugReaderRegistry+Settle.swift */,
 				1351525282D8D0C13B726F85 /* DebugReaderRegistry+WebViewWait.swift */,
 				94C32FCAEDE0062125F6A51E /* DebugSnapshot.swift */,
+				A36D2CA026CE5A5A63DFFE7F /* ReadiumDebugProbe.swift */,
 				0378B284E969CD8625A89EA1 /* RealDebugBridgeContext.swift */,
 				B29B89D96641AE245EA38B05 /* RealDebugBridgeContext+AIAction.swift */,
 				A3D74F5FB31BAB5089EB5022 /* RealDebugBridgeContext+Eval.swift */,
@@ -3505,6 +3510,7 @@
 				1D2A77D93D9DC44E8512225A /* DebugReaderRegistrySettleEdgeCaseTests.swift */,
 				78BD4CC018110BC0C96E2788 /* DebugReaderRegistryTests.swift */,
 				BFA61DA459242CFDBBD809B7 /* DebugSnapshotTests.swift */,
+				7D9CA94F128FAAC004875F6C /* ReadiumDebugProbeTests.swift */,
 				C07FF4DC80918BEE43FF99D4 /* RealDebugBridgeContextTests.swift */,
 				39AAC3C08F3B56CA6863FEC3 /* SettleStubProbe.swift */,
 			);
@@ -5675,6 +5681,7 @@
 				6BCE6D641047BA2A3BAFDC14 /* ReadingStatsModelsTests.swift in Sources */,
 				7D0B1A054D3897CAD9D768A6 /* ReadingStatsTests.swift in Sources */,
 				800F472661AB1030CC54DB46 /* ReadingTimeFormatterTests.swift in Sources */,
+				1B2EF4DD9E11CE736EDCAC1E /* ReadiumDebugProbeTests.swift in Sources */,
 				792FA8647985692CC1ED5694 /* ReadiumOpenSmokeTests.swift in Sources */,
 				75F2C31298F0C62115778DED /* RealDebugBridgeContextTests.swift in Sources */,
 				6B7F71BDB5ECEA83F19496FC /* ReflowableTextSourceTests.swift in Sources */,
@@ -6322,6 +6329,7 @@
 				7F9B63BF3B9DCB2C4ED34710 /* ReadingStatsCustomRange.swift in Sources */,
 				8A1909A1927C0A98F6F8D6D0 /* ReadingStatsModels.swift in Sources */,
 				38F1AB473618B5EB717D05DE /* ReadingTimeFormatter.swift in Sources */,
+				7A40E167BF58AD2D781145F4 /* ReadiumDebugProbe.swift in Sources */,
 				3825952E33170D1AB08DECAE /* RealDebugBridgeContext+AIAction.swift in Sources */,
 				2DCCDBB57F5086AF49FF8D99 /* RealDebugBridgeContext+Eval.swift in Sources */,
 				213C32619E2ABE94230B020A /* RealDebugBridgeContext+Navigate.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6677,13 +6677,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 698;
+				CURRENT_PROJECT_VERSION = 699;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.40.17;
+				MARKETING_VERSION = 3.40.18;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6827,13 +6827,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 698;
+				CURRENT_PROJECT_VERSION = 699;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.40.17;
+				MARKETING_VERSION = 3.40.18;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/DebugBridge/DebugReaderRegistry.swift
+++ b/vreader/Services/DebugBridge/DebugReaderRegistry.swift
@@ -245,6 +245,44 @@ final class DebugReaderRegistry {
     var activeFoliateWebViewKeyInternal: String? { activeFoliateWebViewKey }
     #endif
 
+    /// Feature #42 Phase 1 (WI-4): weak side-channel ref to the active
+    /// Readium EPUB navigator, paired with the book's fingerprintKey + the
+    /// per-reader token. The Readium `EPUBNavigatorViewController` manages its
+    /// own (possibly multiple) internal WKWebView(s) — there is no single
+    /// app-owned webview to register like `EPUBWebViewBridge`/Foliate. So the
+    /// slot stores a `ReadiumNavigatorEvaluating` seam (which the navigator
+    /// conforms to in WI-5) and exposes JS eval through the navigator's public
+    /// `evaluateJavaScript` API (the WI-4 spike confirmed this exists in 3.9).
+    /// Same keyed + per-reader-token stale-write protection as the EPUB/Foliate
+    /// slots (bug #126 / #142). `AnyObject`-constrained so the registry can
+    /// hold it `weak` without keeping the navigator (a UIViewController) alive
+    /// past its host. The accessor methods live in `ReadiumDebugProbe.swift`
+    /// (a sibling extension); the stored properties live here because Swift
+    /// extensions cannot add stored properties.
+    private weak var activeReadiumNavigatorRef: ReadiumNavigatorEvaluating?
+    private var activeReadiumNavigatorKey: String?
+    private var activeReadiumNavigatorToken: UUID?
+
+    /// Internal accessors for the `ReadiumDebugProbe.swift` extension (Swift
+    /// extensions can read these but cannot declare the stored properties).
+    var readiumNavigatorRefInternal: ReadiumNavigatorEvaluating? {
+        get { activeReadiumNavigatorRef }
+        set { activeReadiumNavigatorRef = newValue }
+    }
+    var readiumNavigatorKeyInternal: String? {
+        get { activeReadiumNavigatorKey }
+        set { activeReadiumNavigatorKey = newValue }
+    }
+    var readiumNavigatorTokenInternal: UUID? {
+        get { activeReadiumNavigatorToken }
+        set { activeReadiumNavigatorToken = newValue }
+    }
+
+    /// Test seam — raw stored key without match checks (mirrors the
+    /// EPUB/Foliate `rawActive…KeyForTests`).
+    var rawActiveReadiumNavigatorKeyForTests: String? { activeReadiumNavigatorKey }
+    var rawActiveReadiumNavigatorTokenForTests: UUID? { activeReadiumNavigatorToken }
+
     /// Per-key waiters added by `awaitReader(fingerprintKey:timeout:)`.
     /// Each waiter carries a UUID token so timeouts remove by identity, not
     /// by first-match — eliminating the race where two callers waiting on
@@ -353,6 +391,17 @@ final class DebugReaderRegistry {
                 activeFoliateWebViewToken = nil
             }
             #endif
+            // Feature #42 (WI-4): drop the Readium navigator side-channel when
+            // its owning probe leaves. Not WebKit-gated — the navigator type
+            // comes from the Readium toolkit, available unconditionally in the
+            // target. Same posture as the EPUB/Foliate clears above: an
+            // outgoing book's navigator must not be matched against an incoming
+            // reader's key.
+            if activeReadiumNavigatorKey == reader.fingerprintKey {
+                activeReadiumNavigatorRef = nil
+                activeReadiumNavigatorKey = nil
+                activeReadiumNavigatorToken = nil
+            }
             // Bug #141: the leaving probe IS the active reader and
             // nothing replaced it — clear ALL render-settled state +
             // pending settle waiters for its key (no token preserved).
@@ -377,6 +426,11 @@ final class DebugReaderRegistry {
         activeFoliateWebViewKey = nil
         activeFoliateWebViewToken = nil
         #endif
+        // Feature #42 (WI-4): clear the Readium navigator slot too (not
+        // WebKit-gated — see the stored-property doc above).
+        activeReadiumNavigatorRef = nil
+        activeReadiumNavigatorKey = nil
+        activeReadiumNavigatorToken = nil
         let pendingByKey = waiters
         waiters = [:]
         for (key, bucket) in pendingByKey {

--- a/vreader/Services/DebugBridge/ReadiumDebugProbe.swift
+++ b/vreader/Services/DebugBridge/ReadiumDebugProbe.swift
@@ -1,0 +1,96 @@
+// Purpose: Feature #42 Phase 1 (WI-4) — DebugBridge probe support for the
+// Readium EPUB reader engine. Adds a token-guarded registry slot for the
+// active Readium navigator + a JS-eval seam so the Readium host (WI-5) can be
+// verified CU-free (`eval?bridge=epub`-style probes) exactly like the legacy
+// EPUBWebViewBridge / Foliate hosts.
+//
+// SPIKE RESULT (Risk 5 in the feature #42 plan): the Readium 3.9
+// `EPUBNavigatorViewController` is NOT a single app-owned WKWebView — it owns
+// its own (possibly multiple) internal spine webviews. But Readium 3.9 DOES
+// expose a clean public JS-eval surface:
+//
+//   public func evaluateJavaScript(_ script: String) async -> Result<Any, Error>
+//
+// which runs JS on the currently-visible HTML resource (the active spine
+// webview). So this probe does NOT need to reach Readium's internal webviews:
+// it stores a `ReadiumNavigatorEvaluating` seam (which WI-5 conforms the real
+// `EPUBNavigatorViewController` to via a thin adapter that JSON-serializes the
+// `Result<Any, Error>` value), and exposes JS eval through that. The settle
+// signal reuses the existing `markReaderSettled` / `awaitReaderSettled`
+// machinery (DebugReaderRegistry+Settle.swift) — WI-5's host calls
+// `markReaderSettled(for:token:)` from Readium's
+// `navigator(_:locationDidChange:)` delegate (the relocate-equivalent that
+// fires once a spine is rendered and the first location is reported).
+//
+// Wiring (WI-5): the Readium host registers its navigator on
+// `navigator(_:locationDidChange:)` (or first render) via
+// `setActiveReadiumNavigator(_:for:token:)`, and the eval-bridge handler reads
+// the navigator back with `readiumNavigator(for:token:)`. Same keyed +
+// per-reader-token stale-write guarding as the EPUB/Foliate slots
+// (bug #126 / #142) so a late callback from an outgoing reader cannot clobber
+// an incoming probe's binding.
+//
+// @coordinates-with DebugReaderRegistry.swift, DebugReaderRegistry+Settle.swift
+// DEBUG-only.
+
+#if DEBUG
+
+import Foundation
+
+/// Eval seam for the Readium EPUB navigator. WI-5 conforms the real
+/// `EPUBNavigatorViewController` to this with a thin adapter that calls the
+/// navigator's public `evaluateJavaScript(_:) async -> Result<Any, Error>`
+/// and JSON-serializes the success value into raw JSON bytes (mirroring
+/// `DebugReaderProbe.evaluateJavaScript`'s contract — `null`/`42`/`"hello"`/
+/// `[1,2]`/`{...}` serialized via JSONSerialization so the bridge can splat
+/// the value without double-encoding). `AnyObject`-constrained so the registry
+/// holds it `weak` (the navigator is a UIViewController; the registry must not
+/// keep it alive past its host). `@MainActor` because the navigator and its
+/// webviews are main-actor-isolated.
+@MainActor
+protocol ReadiumNavigatorEvaluating: AnyObject {
+    /// Evaluate `script` on the navigator's currently-visible spine HTML and
+    /// return the value as raw JSON bytes. Throws on eval failure (the value
+    /// is not representable, the spine is not loaded, etc.) so the bridge can
+    /// surface a clean `{"error": ...}` instead of crashing.
+    func evaluateJavaScriptValue(_ script: String) async throws -> Data
+}
+
+extension DebugReaderRegistry {
+
+    /// Register `navigator` as the active Readium EPUB navigator for
+    /// `fingerprintKey` + per-reader `token`. Rejected (silently) when an
+    /// `expectedReaderToken` is set and the incoming token doesn't match — the
+    /// call is a stale callback from an outgoing reader and must not clobber
+    /// the current reader's binding (bug #142 race). Mirrors
+    /// `setActiveEPUBWebView` / `setActiveFoliateWebView`.
+    func setActiveReadiumNavigator(
+        _ navigator: ReadiumNavigatorEvaluating,
+        for fingerprintKey: String,
+        token: UUID
+    ) {
+        if let expected = expectedReaderTokenForTests, expected != token {
+            return // stale callback; ignore
+        }
+        readiumNavigatorRefInternal = navigator
+        readiumNavigatorKeyInternal = fingerprintKey
+        readiumNavigatorTokenInternal = token
+    }
+
+    /// Return the active Readium navigator iff it was registered for the
+    /// requested `fingerprintKey` AND `token`. Returns nil when either fails
+    /// to match, or when the registered navigator was deallocated. The token
+    /// distinguishes a freshly-mounted reader from any leftover binding from a
+    /// same-key but earlier reader instance (bug #142 race). Mirrors
+    /// `epubWebView(for:token:)` / `foliateWebView(for:token:)`.
+    func readiumNavigator(
+        for fingerprintKey: String,
+        token: UUID
+    ) -> ReadiumNavigatorEvaluating? {
+        guard readiumNavigatorKeyInternal == fingerprintKey,
+              readiumNavigatorTokenInternal == token else { return nil }
+        return readiumNavigatorRefInternal
+    }
+}
+
+#endif

--- a/vreaderTests/Services/DebugBridge/ReadiumDebugProbeTests.swift
+++ b/vreaderTests/Services/DebugBridge/ReadiumDebugProbeTests.swift
@@ -1,0 +1,227 @@
+// Purpose: Feature #42 Phase 1 WI-4 — tests for the Readium DebugBridge probe
+// registry slot (`DebugReaderRegistry.setActiveReadiumNavigator(_:for:token:)`
+// / `readiumNavigator(for:token:)`) and the JS-eval feasibility spike (Risk 5).
+//
+// The Readium EPUB host (WI-5) renders via `EPUBNavigatorViewController`, which
+// owns its own (possibly multiple) internal WKWebView(s) — there is no single
+// app-owned webview to register like `EPUBWebViewBridge`. The spike resolved
+// that Readium 3.9 DOES expose a clean JS-eval surface:
+// `EPUBNavigatorViewController.evaluateJavaScript(_:) async -> Result<Any,Error>`
+// runs JS on the currently-visible spine HTML. So the probe stores a weak
+// reference to a `ReadiumNavigatorEvaluating` seam (which `EPUBNavigatorViewController`
+// conforms to in WI-5) and exposes the same keyed + per-reader-token guarding
+// as the EPUB/Foliate webview slots (bug #126 / #142). Settle reuses the
+// existing `markReaderSettled` / `awaitReaderSettled` machinery — WI-5's host
+// signals settle from Readium's `navigator(_:locationDidChange:)` delegate.
+//
+// Mirrors DebugReaderRegistryTests (EPUB/Foliate slots) + the settle suites.
+// DEBUG-only — the registry and its probe machinery are #if DEBUG.
+
+#if DEBUG
+
+import XCTest
+import Foundation
+@testable import vreader
+
+@MainActor
+final class ReadiumDebugProbeTests: XCTestCase {
+
+    /// Stable token for tests that don't exercise the bug #142 reopen race.
+    private let testToken = UUID()
+
+    override func setUp() {
+        super.setUp()
+        DebugReaderRegistry.shared.reset()
+    }
+
+    override func tearDown() {
+        DebugReaderRegistry.shared.reset()
+        super.tearDown()
+    }
+
+    // MARK: - Registration + keyed lookup (bug #126 parity)
+
+    func test_readiumNavigator_initiallyNil_forAnyKey() {
+        XCTAssertNil(DebugReaderRegistry.shared.readiumNavigator(for: "any-key", token: testToken))
+    }
+
+    func test_setActiveReadiumNavigator_returnsForMatchingKeyAndToken() {
+        let nav = FakeReadiumNavigator()
+        DebugReaderRegistry.shared.setActiveReadiumNavigator(nav, for: "k1", token: testToken)
+        XCTAssertTrue(DebugReaderRegistry.shared.readiumNavigator(for: "k1", token: testToken) === nav)
+    }
+
+    func test_setActiveReadiumNavigator_returnsNilForMismatchedKey() {
+        // Stale-protection: a navigator registered for an outgoing book must
+        // NOT be returned to a probe asking about a different book.
+        let nav = FakeReadiumNavigator()
+        DebugReaderRegistry.shared.setActiveReadiumNavigator(nav, for: "outgoing-book", token: testToken)
+        XCTAssertNil(DebugReaderRegistry.shared.readiumNavigator(for: "incoming-book", token: testToken))
+    }
+
+    func test_setActiveReadiumNavigator_replacesPreviousBinding() {
+        let navA = FakeReadiumNavigator()
+        let navB = FakeReadiumNavigator()
+        DebugReaderRegistry.shared.setActiveReadiumNavigator(navA, for: "k1", token: testToken)
+        DebugReaderRegistry.shared.setActiveReadiumNavigator(navB, for: "k2", token: testToken)
+        XCTAssertNil(DebugReaderRegistry.shared.readiumNavigator(for: "k1", token: testToken))
+        XCTAssertTrue(DebugReaderRegistry.shared.readiumNavigator(for: "k2", token: testToken) === navB)
+    }
+
+    // MARK: - Per-reader token disambiguation (bug #142 same-book reopen race)
+
+    func test_readiumNavigator_returnsNilForSameKeyDifferentToken() {
+        // A late didFinish/relocate from the outgoing reader re-registers
+        // under the same key but the old token; the new reader must NOT see it.
+        let outgoing = FakeReadiumNavigator()
+        let outgoingToken = UUID()
+        let incomingToken = UUID()
+        DebugReaderRegistry.shared.setActiveReadiumNavigator(outgoing, for: "k1", token: outgoingToken)
+        XCTAssertNil(DebugReaderRegistry.shared.readiumNavigator(for: "k1", token: incomingToken))
+    }
+
+    func test_setActiveReadiumNavigator_lateStaleCallbackCannotClobberCurrentReader() {
+        // Codex round-1 ordering test (bug #142): new reader mounts and sets
+        // its expected token; a stale callback from the outgoing reader fires
+        // AFTER and must be rejected, not clobber the current binding.
+        let oldNav = FakeReadiumNavigator()
+        let newNav = FakeReadiumNavigator()
+        let oldToken = UUID()
+        let newToken = UUID()
+
+        DebugReaderRegistry.shared.setExpectedReaderToken(newToken)
+        DebugReaderRegistry.shared.setActiveReadiumNavigator(newNav, for: "k1", token: newToken)
+        // Stale callback (outgoing token) arrives late.
+        DebugReaderRegistry.shared.setActiveReadiumNavigator(oldNav, for: "k1", token: oldToken)
+
+        XCTAssertTrue(
+            DebugReaderRegistry.shared.readiumNavigator(for: "k1", token: newToken) === newNav,
+            "Stale callback (outgoing token) must not clobber the current Readium binding"
+        )
+    }
+
+    // MARK: - Lifecycle clearing (unregister / reset)
+
+    func test_unregister_clearsReadiumNavigatorWhenKeyMatches() {
+        let nav = FakeReadiumNavigator()
+        let probe = ReadiumStubProbe(key: "k1", fmt: "epub")
+        DebugReaderRegistry.shared.register(probe)
+        DebugReaderRegistry.shared.setActiveReadiumNavigator(nav, for: "k1", token: testToken)
+        DebugReaderRegistry.shared.unregister(probe)
+        XCTAssertNil(DebugReaderRegistry.shared.readiumNavigator(for: "k1", token: testToken))
+    }
+
+    func test_reset_clearsReadiumNavigator() {
+        let nav = FakeReadiumNavigator()
+        DebugReaderRegistry.shared.setActiveReadiumNavigator(nav, for: "k1", token: testToken)
+        DebugReaderRegistry.shared.reset()
+        XCTAssertNil(DebugReaderRegistry.shared.readiumNavigator(for: "k1", token: testToken))
+        XCTAssertNil(DebugReaderRegistry.shared.rawActiveReadiumNavigatorKeyForTests)
+    }
+
+    func test_readiumBinding_isIndependentOfEPUBAndFoliateSlots() {
+        // Setting the Readium slot must not disturb the EPUB/Foliate slots
+        // and vice-versa — three independent reader-engine slots.
+        let nav = FakeReadiumNavigator()
+        DebugReaderRegistry.shared.setActiveReadiumNavigator(nav, for: "k1", token: testToken)
+        XCTAssertTrue(DebugReaderRegistry.shared.readiumNavigator(for: "k1", token: testToken) === nav)
+        #if canImport(WebKit)
+        XCTAssertNil(DebugReaderRegistry.shared.epubWebView(for: "k1", token: testToken))
+        XCTAssertNil(DebugReaderRegistry.shared.foliateWebView(for: "k1", token: testToken))
+        #endif
+    }
+
+    // MARK: - Eval feasibility spike (Risk 5): JS runs through the navigator
+
+    func test_evaluateJavaScript_throughRegisteredNavigator_returnsJSONBytes() async throws {
+        let nav = FakeReadiumNavigator()
+        nav.stubbedResultJSON = Data("42".utf8)
+        DebugReaderRegistry.shared.setActiveReadiumNavigator(nav, for: "k1", token: testToken)
+
+        let navigator = try XCTUnwrap(DebugReaderRegistry.shared.readiumNavigator(for: "k1", token: testToken))
+        let result = try await navigator.evaluateJavaScriptValue("1 + 41")
+        XCTAssertEqual(result, Data("42".utf8))
+        XCTAssertEqual(nav.lastScript, "1 + 41")
+    }
+
+    func test_evaluateJavaScript_propagatesNavigatorError() async {
+        let nav = FakeReadiumNavigator()
+        nav.shouldThrow = true
+        DebugReaderRegistry.shared.setActiveReadiumNavigator(nav, for: "k1", token: testToken)
+
+        let navigator = DebugReaderRegistry.shared.readiumNavigator(for: "k1", token: testToken)
+        XCTAssertNotNil(navigator)
+        do {
+            _ = try await navigator?.evaluateJavaScriptValue("boom")
+            XCTFail("expected the navigator's eval error to propagate")
+        } catch {
+            // expected — eval errors surface to the caller, no crash.
+        }
+    }
+
+    // MARK: - Settle reuse (markReaderSettled / awaitReaderSettled)
+    //
+    // WI-5's host signals settle from Readium's navigator(_:locationDidChange:)
+    // delegate. The probe path reuses the existing keyed+token settle machinery,
+    // so a Readium key participates exactly like an EPUB/Foliate key.
+
+    func test_readiumSettle_markThenAwait_resolvesForMatchingKeyToken() async throws {
+        let key = "epub:readium:1024"
+        let token = UUID()
+        DebugReaderRegistry.shared.markReaderSettled(for: key, token: token)
+        // Fast path — already settled.
+        try await DebugReaderRegistry.shared.awaitReaderSettled(for: key, token: token, timeout: 0.05)
+    }
+
+    func test_readiumSettle_awaitTimesOutWithoutMark() async {
+        let key = "epub:readium:512"
+        let token = UUID()
+        do {
+            try await DebugReaderRegistry.shared.awaitReaderSettled(for: key, token: token, timeout: 0.15)
+            XCTFail("expected settleTimeout")
+        } catch DebugReaderProbeError.settleTimeout {
+            // expected
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+}
+
+// MARK: - Test doubles
+
+/// Fake `ReadiumNavigatorEvaluating` standing in for `EPUBNavigatorViewController`.
+/// The real navigator conforms via a thin WI-5 adapter; the registry only needs
+/// the eval seam, so the slot is unit-testable without a live Readium publication.
+@MainActor
+private final class FakeReadiumNavigator: ReadiumNavigatorEvaluating {
+    var stubbedResultJSON = Data("null".utf8)
+    var shouldThrow = false
+    private(set) var lastScript: String?
+
+    func evaluateJavaScriptValue(_ script: String) async throws -> Data {
+        lastScript = script
+        if shouldThrow {
+            throw DebugReaderProbeError.evalUnsupported(format: "epub")
+        }
+        return stubbedResultJSON
+    }
+}
+
+@MainActor
+private final class ReadiumStubProbe: DebugReaderProbe {
+    let fingerprintKey: String
+    let format: String
+    var currentPositionString: String? = nil
+
+    init(key: String, fmt: String) {
+        self.fingerprintKey = key
+        self.format = fmt
+    }
+
+    func awaitSettle(timeout: TimeInterval) async throws {}
+    func evaluateJavaScript(_ script: String) async throws -> Data {
+        throw DebugReaderProbeError.evalUnsupported(format: format)
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary

Feature #42 Gate-3 **WI-4 (foundational, DEBUG-only)**: the verification probe for the Readium engine, so WI-5's render is CU-free verifiable. NO host/dispatch/engine wiring (WI-5's job).

**Spike resolved (Risk 5):** Readium 3.9's `EPUBNavigatorViewController` exposes a public `evaluateJavaScript(_:) async -> Result<Any,Error>` (runs JS on the visible spine) — no need to chase internal webviews. The probe uses a protocol seam so the registry stays Readium-free.

- `ReadiumDebugProbe.swift` (new): `ReadiumNavigatorEvaluating` protocol (`evaluateJavaScriptValue(_:) async throws -> Data`, raw JSON, consistent with `DebugReaderProbe.evaluateJavaScript`) + `DebugReaderRegistry.setActiveReadiumNavigator(_:for:token:)` / `readiumNavigator(for:token:)` — key+token stale-write guarded like `setActiveEPUBWebView`/`foliateWebView`. Settle reuses `markReaderSettled`/`awaitReaderSettled`. WI-5 registers from `navigator(_:locationDidChange:)`.

Part of feature #42 (WI-4 of the audited Phase-1 plan).

## Codex Audit (Gate 4)
1 round, **ship-as-is — zero findings**. Auditor confirmed key+token guarding (rejects stale writes, requires key+token, clears on unregister+reset), protocol seam with no Readium import, MainActor-confined, DEBUG-gated. Audit log: `.claude/codex-audits/feat-feature-42-wi4-readium-probe-audit.md`.

## Validation
- [x] ReadiumDebugProbeTests 13/13 + registry/settle regression 37/37
- [x] Full build SUCCEEDED; Release gate `verify-release-no-debugbridge.sh` PASS (zero DebugBridge surface)
- [x] Codex Gate-4 ship-as-is
- [x] Version bumped 3.40.17 → 3.40.18

## Gate 5a Verification
Foundational DEBUG-only WI (registry/probe infra, no user-observable behavior) → unit tests + audit sufficient; no device verification (rule 47 Gate-5 foundational tier).

## Type of Change
- [x] Feature WI (Part of feature #42)