### PR TITLE
feat(#42 WI-5): ReadiumEPUBHost — render EPUB via Readium Navigator behind the flag

### DIFF
--- a/.claude/codex-audits/feat-feature-42-wi5-readium-host-audit.md
+++ b/.claude/codex-audits/feat-feature-42-wi5-readium-host-audit.md
@@ -1,0 +1,66 @@
+---
+branch: feat/feature-42-wi5-readium-host
+threadId: codex-exec-readonly
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-05-29
+---
+
+# Gate-4 Implementation Audit — Feature #42 WI-5 (ReadiumEPUBHost)
+
+Independent Codex audit (`codex exec --sandbox read-only`) of the first
+behavioral WI of feature #42 Phase 1: render an EPUB via the Readium Swift
+Toolkit `EPUBNavigatorViewController`, selected only when the default-OFF
+`FeatureFlags.readiumEPUBEngine` is ON. Author = implementing Claude Code
+session; auditor = separate `codex exec` process (rule-48 author/auditor
+separation preserved).
+
+Changed files audited:
+- `vreader/ViewModels/ReadiumEPUBReaderViewModel.swift`
+- `vreader/Views/Reader/ReadiumEPUBHost.swift`
+- `vreader/Services/DebugBridge/ReadiumDebugProbe.swift`
+- `vreader/Services/DebugBridge/DebugReaderRegistry.swift`
+- `vreader/Views/Reader/ReaderContainerView.swift`
+- `vreader/Models/ReaderEngine.swift`
+- `vreaderTests/Views/Reader/ReadiumEPUBHostTests.swift`
+- `vreaderTests/.../ReaderEngineTests.swift`, `ReaderContainerViewEngineDispatchTests.swift`
+
+## Round 1 — 1 High / 2 Medium (found on the initial implementation)
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| ReadiumEPUBHost.swift:~75 | **High** | No teardown on disappear (bug #252 class): navigator/publication leak, DebugBridge registry slot never cleared. The legacy EPUB/Foliate slots are cleared by `DebugReaderRegistry.unregister(_:)`, but the Readium host registers no `DebugReaderProbe`, so that path never fires for it. | FIXED — host `.onDisappear` → `viewModel.close()` (releases the `Publication`); `dismantleUIViewController` → `coordinator.detach()` clears the registry slot (DEBUG) via new `clearActiveReadiumNavigator(for:token:)` and drops the navigator delegate/ref. |
+| ReadiumEPUBHost.swift:~103 | **Medium** | Navigator-init throw returned a blank `UIViewController()` while VM state stayed renderable → blank page, no error view. | FIXED — init throw routes into host state via `markNavigatorInitFailed(_:)` (deferred to the next main-actor turn), so the host's `.failed` error view renders. |
+| ReaderContainerView.swift:~735 | **Medium** | DEBUG eval format-gate keyed on `book.format` (parallel String `@Model` column) instead of the canonical `fingerprint.format` (bug #246/#1072 hardened the dispatcher to read `fingerprint.format`; the eval gate must agree). | FIXED — added `resolvedFingerprintFormat` (parses `book.fingerprintKey`, falls back to `book.format`); the eval-gate routes on it for `.epub`/`.azw3`. |
+
+## Round 2 — 1 High / 2 Medium (NEW, found on the round-1 fixes)
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| ReadiumEPUBReaderViewModel.swift:54 | **High** | `close()` did not stop an in-flight `open()`; a dismiss-during-open could resume after `close()` and assign `.ready(publication)`, re-leaking a fresh `Publication` into a closed VM. | FIXED — added `@MainActor private var isClosed`; `close()` sets it before clearing state, and `open()` re-checks `guard !isClosed` at entry and after every `await` before mutating `state`. |
+| ReadiumDebugProbe.swift:~107 | **Medium** | `clearActiveReadiumNavigator` cleared settle state without preserving the incoming `expectedReaderToken` — in a same-book quick reopen, outgoing reader A's detach wiped incoming reader B's settle state (unlike `unregister(_:)`). | FIXED — added internal `expectedReaderTokenInternal` accessor; the clear now passes `preservingToken: expected == token ? nil : expected`, matching `unregister(_:)`'s semantics. |
+| ReadiumEPUBHost.swift:~115 | **Medium** | `onNavigatorInitFailure` stored as a non-`@Sendable` function value, captured into `Task { @MainActor }` under `SWIFT_STRICT_CONCURRENCY = complete` — latent sendability hazard. | FIXED — type is now `(@MainActor @Sendable (String) -> Void)?`; capturing `[weak viewModel]` (main-actor-isolated class) into a main-actor-isolated `@Sendable` closure is sound. Build passes under `complete`. |
+
+## Round 3 — clean
+
+**No Critical/High/Medium findings.** All three round-2 fixes confirmed
+resolved:
+- HIGH close/open race — `open()` checks `isClosed` at entry + after each
+  suspension before mutating state; `close()` sets `isClosed` first.
+- MEDIUM settle preservation — `preservingToken: expected == token ? nil :
+  expected` matches `unregister(_:)` for last-reader / incoming-reader /
+  nil-expected cases.
+- MEDIUM strict concurrency — `(@MainActor @Sendable (String) -> Void)?` with
+  `[weak viewModel]` is sound (captured VM is main-actor isolated; closure
+  executes on `MainActor`).
+
+## Verdict
+
+**ship-as-is.** Three audit rounds, zero open Critical/High/Medium. Regression
+tests added for every behavioral fix (`open_afterClose_isNoOp`,
+`clearActiveReadiumNavigator_preservesIncomingTokenSettleState`,
+`clearActiveReadiumNavigator_clearsOwnSettleWhenLastReader`,
+`markNavigatorInitFailed_setsFailedWithMessage`, `close_resetsToLoading`,
+`clearActiveReadiumNavigator_clearsMatchingSlot`,
+`clearActiveReadiumNavigator_ignoresNonMatchingKey`). Focused test gate green
+(42 tests, 3 suites).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,8 +72,14 @@ JSON files.
   bilingual wrapper from feature #56 WI-11 sits between the dispatcher
   and `FoliateSpikeView`, adding the bilingual VM / orchestrator / setup-
   sheet wiring without modifying the spike itself).
-- `resolve(format:)` maps `.epub` to `.epubWKWebView` unconditionally;
-  feature #42 will later route EPUB to `.foliateWeb` behind a flag.
+- `resolve(format:)` maps `.epub` to `.epubWKWebView` unconditionally (it
+  stays the pure format→default-engine map). Feature #42 (Phase 1) routes EPUB
+  to the Readium Swift Toolkit engine (`ReadiumEPUBHost`) behind the
+  default-OFF `FeatureFlags.readiumEPUBEngine`: the flag read lives in the
+  dispatcher (`ReaderContainerView.engineReaderView` → `ReaderEngine.routeEPUB`),
+  not in `resolve`, so a flag-unaware caller still gets the legacy
+  `EPUBReaderHost`. The `.epubReadium` engine case exists for switch totality;
+  `resolve` never returns it.
 
 #### Chrome
 
@@ -99,6 +105,7 @@ Each host owns its ViewModel lifecycle via `@State`:
 
 - `TXTReaderHost` → `TXTReaderContainerView` → `TXTTextViewBridge` (small single-chapter / Paged) or `TXTChunkedReaderBridge` (>500K UTF-16, **and** chaptered TXT in Scroll layout — bug #180). Chaptered TXT in Scroll layout renders as one continuous `UITableView` surface fed the whole book: `TXTContinuousChunkBuilder` splits the decoded book into document-global-offset chunks, `TXTChapterOffsetIndex` layers chapter awareness so `currentChapterIdx` is *derived* from scroll offset (no per-chapter render unit, no chapter-swap).
 - `EPUBReaderHost` → `EPUBReaderContainerView` → `EPUBWebViewBridge` (WKWebView + JS injection). **Paged** EPUB loads one spine item per `loadFileURL`. **Continuous scroll** (feature #71, the DEFAULT for EPUB scroll layout since the terminal-WI flag flip on 2026-05-28 — `FeatureFlags.epubContinuousScroll` defaults ON; a persisted user/debug override can still disable it) instead loads a single bootstrap document and stitches a lazy ±1-chapter window into it: `EPUBContinuousScrollCoordinator` owns an `EPUBSpineWindow` `[lo…hi]` anchored on the reading chapter and, on the section-aware scroll observer's boundary signals, materializes the adjacent chapter (`EPUBContinuousChapterProvider` → `EPUBChapterBodyRewriter` → `EPUBContinuousScrollJS.append/prependChapterSectionJS`) and evicts the far side (`maxSpan`) to bound memory. Per-section highlight restore hangs off a `sectionMaterialized` lifecycle message (appended sections never fire `didFinish`); saved-position restore + TOC/bookmark/search navigation drive the coordinator (`navigate(toSpineIndex:fraction:)` — scroll within the window, or rebuild around an out-of-window target). The evaluator reaches the live `WKWebView` through a late-binding `EPUBWebViewEvaluatorHandle` the bridge binds in `makeUIView`.
+- `ReadiumEPUBHost` (feature #42 Phase 1, WI-5) → `ReadiumNavigatorRepresentable` → Readium Swift Toolkit `EPUBNavigatorViewController`. Selected by the dispatcher in place of `EPUBReaderHost` only when `FeatureFlags.readiumEPUBEngine` is ON (default OFF). Opens the publication off-main via `ReadiumEPUBReaderViewModel` (`AssetRetriever` → `PublicationOpener`), then mounts the navigator; `EPUBPreferences(scroll:)` is mapped from `ReaderSettingsStore.epubLayout`. The `ReadiumReaderCoordinator` is the `EPUBNavigatorDelegate` + (DEBUG) `ReadiumNavigatorEvaluating` seam — it registers the active navigator with `DebugReaderRegistry.setActiveReadiumNavigator` and `markReaderSettled` on `locationDidChange`, and tears that registration down on `dismantleUIViewController` via `detach()` → `clearActiveReadiumNavigator` (the host registers no `DebugReaderProbe`, so it owns its own registry teardown). Render-only at WI-5; position / theme / highlights / search / TTS land in WI-6…WI-10.
 - `PDFReaderHost` → `PDFReaderContainerView` → `PDFViewBridge` (PDFKit)
 - `MDReaderHost` → `MDReaderContainerView` → reuses `TXTTextViewBridge` with NSAttributedString
 - AZW3/MOBI is dispatched directly to `FoliateSpikeView` (the AZW3 spike landed before the host abstraction; convergence is deferred). `FoliateReaderHost` / `FoliateReaderContainerView` exist but are not currently wired into `ReaderContainerView`.

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 699
-        MARKETING_VERSION: 3.40.18
+        CURRENT_PROJECT_VERSION: 700
+        MARKETING_VERSION: 3.40.19
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/project.yml
+++ b/project.yml
@@ -313,11 +313,15 @@ targets:
       # Feature #42 WI-1: the Readium open-smoke test imports ReadiumShared +
       # ReadiumStreamer directly, so the test target must link them explicitly
       # (relying on host-app transitive exposure is fragile — Gate-4 audit).
-      # ReadiumNavigator stays app-only (the test doesn't render).
+      # WI-5: ReadiumNavigator is now also linked so ReadiumEPUBHostTests can
+      # assert the real `EPUBPreferences(scroll:)` mapping from the host's
+      # layout-preference translation (the render itself stays untested).
       - package: Readium
         product: ReadiumShared
       - package: Readium
         product: ReadiumStreamer
+      - package: Readium
+        product: ReadiumNavigator
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.tests

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -343,6 +343,7 @@
 		3B62997EF7304D0ACFBF141D /* HighlightableTextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E293CFD61A19BB48B38963 /* HighlightableTextViewTests.swift */; };
 		3C190BFB365BCA80358E99AA /* TTSHighlightCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D721FA5AC22C4EBD49791B48 /* TTSHighlightCoordinator.swift */; };
 		3C6784421BC6B3DD6F1D3C16 /* BookModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B811BD48F552B167D438BFCF /* BookModelTests.swift */; };
+		3C894F8ED6493D1DF6DB58D6 /* ReadiumEPUBHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0690CFD7EBDB5EFF481F2202 /* ReadiumEPUBHostTests.swift */; };
 		3CAC33209031F93DC4692879 /* MDFileLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6974D0F73862058FC97358 /* MDFileLoaderTests.swift */; };
 		3D31B039400E1A83C4A1DF6D /* EPUBMetadataExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F003D569BCC0F29113468A /* EPUBMetadataExtractorTests.swift */; };
 		3D32DA9E354C6BA5A74A09C6 /* Feature31AutoPageTurnVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6BE724AEC4E98F6180228E /* Feature31AutoPageTurnVerificationTests.swift */; };
@@ -418,6 +419,7 @@
 		49D992E6F2DAB74CCD4FDC68 /* TokenSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D944728B17A940A3716EA9 /* TokenSpanTests.swift */; };
 		49E7475E7118E6366C0530E5 /* PersistentSearchIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25EC6B4A507BE08D646A4AD /* PersistentSearchIndexTests.swift */; };
 		4A2E9C584A5BF628CDB9716A /* ReadingStatsAggregatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AB5B40BD735A699BB480DE /* ReadingStatsAggregatorTests.swift */; };
+		4A33EE0148BD76B18E7A3724 /* ReadiumEPUBHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6914428EA8FF673A76DDFF66 /* ReadiumEPUBHost.swift */; };
 		4A67A7ACD5E890A1AECA8854 /* TXTChapterIndexStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E94F1579C79832BB2EEDEB05 /* TXTChapterIndexStoreTests.swift */; };
 		4A87A6889CFFC099EE0AFBD6 /* SeriesTagPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58BA99C96063F3F0CA7A300 /* SeriesTagPersistenceTests.swift */; };
 		4A8B2E9CC8837F5523420479 /* TXTTextViewBridgeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96A115C3FA0B797030C1D1F /* TXTTextViewBridgeCoordinator.swift */; };
@@ -504,6 +506,7 @@
 		5A94BE236411F0F7268F803F /* ReaderNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB7C7EC41A96F5D4B53E983 /* ReaderNotifications.swift */; };
 		5B9209E7096FD5D30F56BA8F /* ResolveHighlightColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6616756D16593398F889C8 /* ResolveHighlightColorTests.swift */; };
 		5BA867B4591F0916810C91B8 /* EPUBPaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9500033AC714D470A3024F8 /* EPUBPaginationTests.swift */; };
+		5BB27DAA4914CE57DD0049C2 /* ReadiumEPUBReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE1995445027494280CEE07 /* ReadiumEPUBReaderViewModel.swift */; };
 		5BCD69B7FFD787F33D6E0C8D /* AutoPageTurnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2396FE1BB03C2F3CEFAB8E2 /* AutoPageTurnerTests.swift */; };
 		5BF0D6683395428E016CBDC8 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD245135256A06A28C88178 /* SearchBar.swift */; };
 		5BF55452ABA60AB492B54C6D /* AIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02B540992E1F3C96A00723F /* AIProvider.swift */; };
@@ -1311,6 +1314,7 @@
 		F5A4EBAB5C5CC459BEFE77B0 /* FoliateBilingualContainerView+BottomChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = D026E639A53478C9636C20CE /* FoliateBilingualContainerView+BottomChrome.swift */; };
 		F5C06CBFBB03CA953526172B /* FontSizeCalibrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655053889CBE2E90527473CD /* FontSizeCalibrationTests.swift */; };
 		F5C2144F0820EC9CE807F482 /* EPUBThemeOverrideCSSV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864232F1C9EEF1A310AA820A /* EPUBThemeOverrideCSSV2Tests.swift */; };
+		F6491F10294DBD6435A3F117 /* ReadiumNavigator in Frameworks */ = {isa = PBXBuildFile; productRef = 40371B0D544B5328AAF77E07 /* ReadiumNavigator */; };
 		F6F40F9E52D3ED8B95323D65 /* epub.js in Resources */ = {isa = PBXBuildFile; fileRef = 3EC2FBB83EE7D774B3B5D5D3 /* epub.js */; };
 		F725E00A6B2B5C15B63B5037 /* BilingualTextRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FA184F0D822A7EC8A0F445B /* BilingualTextRendererTests.swift */; };
 		F787B0120B50F971DF7930DD /* Feature34CollectionsVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AEB955B6E5713C9AB4D701E /* Feature34CollectionsVerificationTests.swift */; };
@@ -1418,6 +1422,7 @@
 		0646DB2E4CD5095035092623 /* FoliateHighlightTapResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightTapResolver.swift; sourceTree = "<group>"; };
 		064AE6DC1BC56B9DD7CCA796 /* AIProviderPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderPicker.swift; sourceTree = "<group>"; };
 		0676527574C593F03D71FEE7 /* epubcfi.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = epubcfi.js; sourceTree = "<group>"; };
+		0690CFD7EBDB5EFF481F2202 /* ReadiumEPUBHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumEPUBHostTests.swift; sourceTree = "<group>"; };
 		06B5DEE74F91C3767F8C70BF /* ReaderBottomChromeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderBottomChromeTests.swift; sourceTree = "<group>"; };
 		06EFFD5584526A6602FEE2E1 /* SyncTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncTestHelpers.swift; sourceTree = "<group>"; };
 		073161C86CE5691A8173C851 /* DebugBridgeHighlightObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugBridgeHighlightObserver.swift; sourceTree = "<group>"; };
@@ -1952,6 +1957,7 @@
 		686E0EE508E85349AED791BE /* TokenSpan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSpan.swift; sourceTree = "<group>"; };
 		68A7FC6A70A060CD5E43602E /* ReadingProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingProgressBar.swift; sourceTree = "<group>"; };
 		68BB90FF5CA185660AAE66BD /* MDReaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReaderViewModel.swift; sourceTree = "<group>"; };
+		6914428EA8FF673A76DDFF66 /* ReadiumEPUBHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumEPUBHost.swift; sourceTree = "<group>"; };
 		695A8EDF52A1BFDDB7BC5A10 /* TXTBridgeSharedBilingualTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTBridgeSharedBilingualTests.swift; sourceTree = "<group>"; };
 		6974F61108CB28EFA08F1D68 /* SettingsRowPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRowPalette.swift; sourceTree = "<group>"; };
 		69A5BB670EA065F36FCD605B /* TXTOffsetTranslator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTOffsetTranslator.swift; sourceTree = "<group>"; };
@@ -1971,6 +1977,7 @@
 		6CFECBFD38A16DE449662507 /* MigrationFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationFixtureTests.swift; sourceTree = "<group>"; };
 		6D1F7A887F53AD14596BFF30 /* Feature28ChineseConversionVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature28ChineseConversionVerificationTests.swift; sourceTree = "<group>"; };
 		6D72F88359945829695CD984 /* DebugPresentSheetEffectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugPresentSheetEffectTests.swift; sourceTree = "<group>"; };
+		6DE1995445027494280CEE07 /* ReadiumEPUBReaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumEPUBReaderViewModel.swift; sourceTree = "<group>"; };
 		6DF113D7E83A1CE51F417258 /* AIReaderPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReaderPanel.swift; sourceTree = "<group>"; };
 		6E358C3A06D7CC0958A40876 /* BookSourceSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSourceSearchView.swift; sourceTree = "<group>"; };
 		6E57059EA750B150D10FC828 /* PillSwitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillSwitchTests.swift; sourceTree = "<group>"; };
@@ -2757,6 +2764,7 @@
 			files = (
 				324C39E083F8BC2E929BB4F3 /* ReadiumShared in Frameworks */,
 				C010AB44C037B67E5A65B50A /* ReadiumStreamer in Frameworks */,
+				F6491F10294DBD6435A3F117 /* ReadiumNavigator in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3331,6 +3339,7 @@
 				1D51DC243D8B3F2A404ABA38 /* ReaderSettingsPanelThemePickerTests.swift */,
 				AE98B137F042D616716D4C72 /* ReaderTapZoneRouterTests.swift */,
 				63E4737FA3A880C3CC2BA07D /* ReadingProgressBarTests.swift */,
+				0690CFD7EBDB5EFF481F2202 /* ReadiumEPUBHostTests.swift */,
 				BE6616756D16593398F889C8 /* ResolveHighlightColorTests.swift */,
 				62569DC663E2BDD2DC0155C3 /* SearchHighlightDismissTests.swift */,
 				AB8FC6D57843EAC26DB980D3 /* SearchResultHighlightTests.swift */,
@@ -3913,6 +3922,7 @@
 				82199531AD7036AB0F37C56C /* ReaderTopChrome.swift */,
 				50AA77FDB19CB7EDA69418C8 /* ReaderUnifiedCoordinator.swift */,
 				68A7FC6A70A060CD5E43602E /* ReadingProgressBar.swift */,
+				6914428EA8FF673A76DDFF66 /* ReadiumEPUBHost.swift */,
 				7024E7AEAC9AEAA028952C46 /* ScrollProgressHelper.swift */,
 				50E944C737D2389E8481C5AD /* SelectionPopoverActionRouter.swift */,
 				A26827F9E5CF8521F1152661 /* SelectionPopoverActionRow.swift */,
@@ -4086,6 +4096,7 @@
 				43D54AC9AD2556A67C96BD52 /* PDFReaderViewModel.swift */,
 				D363190FCDF47ED48A1D7BC1 /* ReaderLifecycleHelper.swift */,
 				44B5BF67DD0616C80294ABC7 /* ReadingDashboardViewModel.swift */,
+				6DE1995445027494280CEE07 /* ReadiumEPUBReaderViewModel.swift */,
 				864A1B050775A46ADBE3304F /* SearchViewModel.swift */,
 				8500C7EDCB2A51F928910E7F /* SettingsHeaderViewModel.swift */,
 				E19A1FE14FDE4829AF0F5913 /* TXTReaderViewModel.swift */,
@@ -5098,6 +5109,7 @@
 			packageProductDependencies = (
 				8C7CAF7AA1A6A8C127B15373 /* ReadiumShared */,
 				EA3051FC39A4EA8313F32F9D /* ReadiumStreamer */,
+				40371B0D544B5328AAF77E07 /* ReadiumNavigator */,
 			);
 			productName = vreaderTests;
 			productReference = E46AADA707F0E3AF7E8AB297 /* vreaderTests.xctest */;
@@ -5682,6 +5694,7 @@
 				7D0B1A054D3897CAD9D768A6 /* ReadingStatsTests.swift in Sources */,
 				800F472661AB1030CC54DB46 /* ReadingTimeFormatterTests.swift in Sources */,
 				1B2EF4DD9E11CE736EDCAC1E /* ReadiumDebugProbeTests.swift in Sources */,
+				3C894F8ED6493D1DF6DB58D6 /* ReadiumEPUBHostTests.swift in Sources */,
 				792FA8647985692CC1ED5694 /* ReadiumOpenSmokeTests.swift in Sources */,
 				75F2C31298F0C62115778DED /* RealDebugBridgeContextTests.swift in Sources */,
 				6B7F71BDB5ECEA83F19496FC /* ReflowableTextSourceTests.swift in Sources */,
@@ -6330,6 +6343,8 @@
 				8A1909A1927C0A98F6F8D6D0 /* ReadingStatsModels.swift in Sources */,
 				38F1AB473618B5EB717D05DE /* ReadingTimeFormatter.swift in Sources */,
 				7A40E167BF58AD2D781145F4 /* ReadiumDebugProbe.swift in Sources */,
+				4A33EE0148BD76B18E7A3724 /* ReadiumEPUBHost.swift in Sources */,
+				5BB27DAA4914CE57DD0049C2 /* ReadiumEPUBReaderViewModel.swift in Sources */,
 				3825952E33170D1AB08DECAE /* RealDebugBridgeContext+AIAction.swift in Sources */,
 				2DCCDBB57F5086AF49FF8D99 /* RealDebugBridgeContext+Eval.swift in Sources */,
 				213C32619E2ABE94230B020A /* RealDebugBridgeContext+Navigate.swift in Sources */,
@@ -6897,6 +6912,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D7AA73DC59084585FC730EDE /* XCRemoteSwiftPackageReference "swift-toolkit" */;
 			productName = ReadiumStreamer;
+		};
+		40371B0D544B5328AAF77E07 /* ReadiumNavigator */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D7AA73DC59084585FC730EDE /* XCRemoteSwiftPackageReference "swift-toolkit" */;
+			productName = ReadiumNavigator;
 		};
 		486194008CF2C34F53F2B60B /* ReadiumNavigator */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6692,13 +6692,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 699;
+				CURRENT_PROJECT_VERSION = 700;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.40.18;
+				MARKETING_VERSION = 3.40.19;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6842,13 +6842,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 699;
+				CURRENT_PROJECT_VERSION = 700;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.40.18;
+				MARKETING_VERSION = 3.40.19;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Models/ReaderEngine.swift
+++ b/vreader/Models/ReaderEngine.swift
@@ -3,12 +3,15 @@
 // chosen entirely inside the app (feature #54).
 //
 // Key decisions:
-// - Five engines, one per current rendering host. `epubWKWebView` and
-//   `foliateWeb` both exist now; `resolve(format:)` maps EPUB to
-//   `epubWKWebView` unconditionally until feature #42 introduces a
-//   Foliate-EPUB flag that differentiates the two.
-// - `resolve(format:)` is a pure, total function over BookFormat — the
-//   typed replacement for the previous `book.format.lowercased()` switch.
+// - Six engines, one per current rendering host plus the Readium EPUB engine
+//   (feature #42 Phase 1, flag-gated). `epubWKWebView` is the live EPUB default;
+//   `epubReadium` is the Readium-Navigator host selected only when the
+//   `readiumEPUBEngine` flag is ON.
+// - `resolve(format:)` stays a pure, total function over BookFormat and maps
+//   EPUB to `epubWKWebView` UNCONDITIONALLY (the typed replacement for the old
+//   `book.format.lowercased()` switch). The Readium flag branch is a SEPARATE
+//   pure helper — `routeEPUB(readiumFlagEnabled:)` — so `resolve` never reads a
+//   feature flag (the flag check lives in the dispatcher; feature #42 plan).
 // - String-backed RawRepresentable so the value is stable and debuggable;
 //   it is NOT persisted (no UserDefaults key) — the engine is derived from
 //   the book's format on every open.
@@ -26,8 +29,11 @@ enum ReaderEngine: String, Sendable, Hashable, CaseIterable {
     case textNative
     /// Native Markdown reader (UITextView with attributed string).
     case markdownNative
-    /// Legacy EPUB reader (custom WKWebView + JS bridge).
+    /// Legacy EPUB reader (custom WKWebView + JS bridge). The live default.
     case epubWKWebView
+    /// Readium Swift Toolkit EPUB reader (`EPUBNavigatorViewController`).
+    /// Selected only when the `readiumEPUBEngine` flag is ON (feature #42).
+    case epubReadium
     /// Foliate-js based reader (WKWebView + Foliate bundle) — AZW3/MOBI today.
     case foliateWeb
     /// PDF reader (PDFKit `PDFView`).
@@ -36,8 +42,9 @@ enum ReaderEngine: String, Sendable, Hashable, CaseIterable {
     /// Selects the rendering engine for a book format.
     ///
     /// Total over `BookFormat` — every case maps to exactly one engine. EPUB
-    /// resolves to `epubWKWebView` unconditionally; feature #42 will later
-    /// route EPUB to `foliateWeb` behind a flag.
+    /// resolves to `epubWKWebView` unconditionally; the Readium-vs-legacy EPUB
+    /// choice is made by `routeEPUB(readiumFlagEnabled:)` in the dispatcher so
+    /// this function never reads a feature flag.
     static func resolve(format: BookFormat) -> ReaderEngine {
         switch format {
         case .txt:  return .textNative
@@ -46,5 +53,13 @@ enum ReaderEngine: String, Sendable, Hashable, CaseIterable {
         case .azw3: return .foliateWeb
         case .pdf:  return .pdfKit
         }
+    }
+
+    /// Picks the EPUB rendering engine given the `readiumEPUBEngine` flag state.
+    /// Pure (no flag read inside — the caller passes the resolved flag value) so
+    /// the dispatcher's routing decision is unit-testable. Feature #42 Phase 1:
+    /// flag ON → the Readium host; flag OFF → the legacy `EPUBWebViewBridge`.
+    static func routeEPUB(readiumFlagEnabled: Bool) -> ReaderEngine {
+        readiumFlagEnabled ? .epubReadium : .epubWKWebView
     }
 }

--- a/vreader/Services/DebugBridge/DebugReaderRegistry.swift
+++ b/vreader/Services/DebugBridge/DebugReaderRegistry.swift
@@ -278,6 +278,11 @@ final class DebugReaderRegistry {
         set { activeReadiumNavigatorToken = newValue }
     }
 
+    /// Internal read accessor for `expectedReaderToken` (which is `private`)
+    /// so the `ReadiumDebugProbe.swift` extension can mirror `unregister(_:)`'s
+    /// `preservingToken` posture when clearing settle state on Readium detach.
+    var expectedReaderTokenInternal: UUID? { expectedReaderToken }
+
     /// Test seam — raw stored key without match checks (mirrors the
     /// EPUB/Foliate `rawActive…KeyForTests`).
     var rawActiveReadiumNavigatorKeyForTests: String? { activeReadiumNavigatorKey }

--- a/vreader/Services/DebugBridge/ReadiumDebugProbe.swift
+++ b/vreader/Services/DebugBridge/ReadiumDebugProbe.swift
@@ -91,6 +91,37 @@ extension DebugReaderRegistry {
               readiumNavigatorTokenInternal == token else { return nil }
         return readiumNavigatorRefInternal
     }
+
+    /// Clear the Readium navigator slot iff it currently holds
+    /// `(fingerprintKey, token)`, and drop that key's render-settled state.
+    /// Called from the Readium host's `dismantleUIViewController` via the
+    /// coordinator's `detach()`. The slot holds the navigator `weak`, so the
+    /// ref auto-nils on dealloc — but the key/token + settle state otherwise
+    /// linger until that happens, and during a same-key reader switch a stale
+    /// settled flag could fast-path a freshly-mounted reader (bug #141 class).
+    /// The legacy EPUB/Foliate slots get this deterministic clear from
+    /// `unregister(_:)`, but the Readium host registers no `DebugReaderProbe`,
+    /// so it needs its own explicit teardown. Guarded on an exact key+token
+    /// match so a late detach from an outgoing reader cannot wipe an incoming
+    /// reader's binding.
+    func clearActiveReadiumNavigator(for fingerprintKey: String, token: UUID) {
+        guard readiumNavigatorKeyInternal == fingerprintKey,
+              readiumNavigatorTokenInternal == token else { return }
+        readiumNavigatorRefInternal = nil
+        readiumNavigatorKeyInternal = nil
+        readiumNavigatorTokenInternal = nil
+        // Mirror `unregister(_:)`'s posture: in a same-book quick reopen the
+        // outgoing reader A can still own the slot while `expectedReaderToken`
+        // already belongs to the incoming reader B. A's detach must clear its
+        // OWN settle state without clobbering B's pending/settled state.
+        // Preserve the expected token unless it IS the clearing token (A is
+        // genuinely the last reader for the key → clear everything).
+        let expected = expectedReaderTokenInternal
+        clearSettleState(
+            forFingerprintKey: fingerprintKey,
+            preservingToken: expected == token ? nil : expected
+        )
+    }
 }
 
 #endif

--- a/vreader/ViewModels/ReadiumEPUBReaderViewModel.swift
+++ b/vreader/ViewModels/ReadiumEPUBReaderViewModel.swift
@@ -1,0 +1,98 @@
+// Purpose: Feature #42 Phase 1 (WI-5) — @MainActor view model that opens an EPUB
+// through the Readium 3.x opening flow (AssetRetriever → PublicationOpener with
+// DefaultPublicationParser) off the main actor, then hands the resulting
+// `Publication` back to the main actor so `ReadiumEPUBHost` can mount an
+// `EPUBNavigatorViewController`. Holds the open lifecycle state (loading /
+// ready / failed) the host renders, and the pure `epubPreferences(for:)`
+// translation from vreader's `EPUBLayoutPreference` to Readium `EPUBPreferences`.
+//
+// Scope (WI-5): open + render + scroll/paginate behind the `readiumEPUBEngine`
+// flag. Position save/restore (VReaderLocator ↔ Readium Locator), highlights,
+// theme/font, search, and TTS land in later WIs (WI-6…WI-10). This VM stays
+// thin — it owns opening and layout-preference mapping only.
+//
+// Concurrency (feature #42 round-1 Med-4): the open is `async` and runs off the
+// main actor inside Readium's own executors; the `Publication` reference is
+// handed back to this @MainActor VM. No WebKit/UIKit object is stored in a
+// Sendable actor — the navigator itself is owned by the host's coordinator.
+//
+// @coordinates-with ReadiumEPUBHost.swift, EPUBLayoutPreference.swift
+
+import Foundation
+import OSLog
+import ReadiumShared
+import ReadiumStreamer
+import ReadiumNavigator
+
+@MainActor
+@Observable
+final class ReadiumEPUBReaderViewModel {
+
+    /// Open lifecycle the host renders.
+    enum OpenState {
+        case loading
+        case ready(Publication)
+        case failed(String)
+    }
+
+    private(set) var state: OpenState = .loading
+
+    private let fileURL: URL
+    private let log = Logger(subsystem: "com.vreader.app", category: "ReadiumEPUB")
+
+    init(fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
+    // MARK: - Opening
+
+    /// Opens the EPUB via Readium's `AssetRetriever` → `PublicationOpener`.
+    /// Idempotent: a second call after a successful open is a no-op so a
+    /// transient host re-mount does not reopen. The heavy parse runs inside
+    /// Readium's async executors (off the main actor); the `Publication` is
+    /// stored back on this @MainActor VM.
+    func open() async {
+        if case .ready = state { return }
+
+        guard let assetURL = FileURL(url: fileURL) else {
+            state = .failed("invalid file URL")
+            log.error("ReadiumEPUB open: invalid FileURL")
+            return
+        }
+
+        let httpClient = DefaultHTTPClient()
+        let assetRetriever = AssetRetriever(httpClient: httpClient)
+        let opener = PublicationOpener(
+            parser: DefaultPublicationParser(
+                httpClient: httpClient,
+                assetRetriever: assetRetriever,
+                pdfFactory: DefaultPDFDocumentFactory()
+            )
+        )
+
+        switch await assetRetriever.retrieve(url: assetURL) {
+        case let .failure(error):
+            state = .failed(String(describing: error))
+            log.error("ReadiumEPUB retrieve failed: \(String(describing: error), privacy: .public)")
+        case let .success(asset):
+            switch await opener.open(asset: asset, allowUserInteraction: false) {
+            case let .failure(error):
+                state = .failed(String(describing: error))
+                log.error("ReadiumEPUB open failed: \(String(describing: error), privacy: .public)")
+            case let .success(publication):
+                state = .ready(publication)
+                log.info("ReadiumEPUB opened: \(publication.metadata.title ?? "untitled", privacy: .public)")
+            }
+        }
+    }
+
+    // MARK: - Preferences mapping (pure)
+
+    /// Translates vreader's `EPUBLayoutPreference` into a Readium
+    /// `EPUBPreferences`. `.scroll` → continuous vertical scroll
+    /// (`scroll: true`); `.paged` → horizontal paginated (`scroll: false`).
+    /// Pure + static so the mapping is unit-testable without a render.
+    nonisolated static func epubPreferences(for layout: EPUBLayoutPreference) -> EPUBPreferences {
+        EPUBPreferences(scroll: layout == .scroll)
+    }
+}

--- a/vreader/ViewModels/ReadiumEPUBReaderViewModel.swift
+++ b/vreader/ViewModels/ReadiumEPUBReaderViewModel.swift
@@ -40,6 +40,15 @@ final class ReadiumEPUBReaderViewModel {
     private let fileURL: URL
     private let log = Logger(subsystem: "com.vreader.app", category: "ReadiumEPUB")
 
+    /// High (Gate-4 round 2): set by `close()` to invalidate an in-flight
+    /// `open()`. The host's `.onDisappear` calls `close()` while a suspended
+    /// `open()` (inside the SwiftUI `.task`) may still resume and assign
+    /// `.ready(publication)` after the close — re-leaking a fresh `Publication`
+    /// past teardown. `open()` re-checks this after every `await` before
+    /// mutating `state`, so a dismiss-during-open never installs a publication
+    /// into a closed VM. `@MainActor`-isolated so the read/write is serialized.
+    private var isClosed = false
+
     init(fileURL: URL) {
         self.fileURL = fileURL
     }
@@ -53,6 +62,7 @@ final class ReadiumEPUBReaderViewModel {
     /// stored back on this @MainActor VM.
     func open() async {
         if case .ready = state { return }
+        guard !isClosed else { return }
 
         guard let assetURL = FileURL(url: fileURL) else {
             state = .failed("invalid file URL")
@@ -72,18 +82,48 @@ final class ReadiumEPUBReaderViewModel {
 
         switch await assetRetriever.retrieve(url: assetURL) {
         case let .failure(error):
+            guard !isClosed else { return }
             state = .failed(String(describing: error))
             log.error("ReadiumEPUB retrieve failed: \(String(describing: error), privacy: .public)")
         case let .success(asset):
             switch await opener.open(asset: asset, allowUserInteraction: false) {
             case let .failure(error):
+                guard !isClosed else { return }
                 state = .failed(String(describing: error))
                 log.error("ReadiumEPUB open failed: \(String(describing: error), privacy: .public)")
             case let .success(publication):
+                // High (Gate-4 round 2): the host disappeared mid-open — do
+                // NOT install the freshly-opened publication into a closed VM.
+                guard !isClosed else { return }
                 state = .ready(publication)
                 log.info("ReadiumEPUB opened: \(publication.metadata.title ?? "untitled", privacy: .public)")
             }
         }
+    }
+
+    // MARK: - Teardown
+
+    /// Releases the open `Publication` (dropping Readium's container + the
+    /// EPUB's open file handles) and returns to the loading state. Called from
+    /// the host's `.onDisappear` when the reader genuinely leaves the hierarchy
+    /// (nav pop) so the publication is freed deterministically rather than
+    /// waiting on `@State` teardown timing — the bug-#252 lesson applied to the
+    /// Readium engine: tie the close to the resource owner (the host). The
+    /// navigator/registry side of teardown is handled by the representable's
+    /// `dismantleUIViewController`. Idempotent. Sets `isClosed` first so an
+    /// in-flight `open()` that resumes after this point cannot re-install a
+    /// publication (Gate-4 round-2 High).
+    func close() {
+        isClosed = true
+        state = .loading
+    }
+
+    /// Surface an `EPUBNavigatorViewController` init failure (thrown from the
+    /// representable's `makeUIViewController`) into the host's render state so
+    /// the host swaps in its `.failed` error view instead of leaving an empty
+    /// placeholder controller on screen.
+    func markNavigatorInitFailed(_ message: String) {
+        state = .failed(message)
     }
 
     // MARK: - Preferences mapping (pure)

--- a/vreader/Views/Reader/ReaderContainerView.swift
+++ b/vreader/Views/Reader/ReaderContainerView.swift
@@ -735,7 +735,21 @@ struct ReaderContainerView: View {
             if resolvedBookFormat == .epub {
                 let key = book.fingerprintKey
                 let token = readerToken
+                // Feature #42 WI-5: when the Readium engine is active, route
+                // eval to the Readium navigator's `evaluateJavaScriptValue`
+                // (which already JSON-serializes the `Result<Any, Error>` per
+                // the WI-4 `ReadiumNavigatorEvaluating` seam) instead of the
+                // legacy keyed `epubWebView`. Selected on the same flag the
+                // dispatcher routes on, so eval reaches whichever engine is
+                // actually rendering this book.
+                let readiumActive = FeatureFlags.shared.isEnabled(.readiumEPUBEngine)
                 probe.jsEvaluator = { @MainActor script in
+                    if readiumActive {
+                        guard let navigator = DebugReaderRegistry.shared.readiumNavigator(for: key, token: token) else {
+                            throw DebugReaderProbeError.evalUnsupported(format: "epub")
+                        }
+                        return try await navigator.evaluateJavaScriptValue(script)
+                    }
                     guard let webView = DebugReaderRegistry.shared.epubWebView(for: key, token: token) else {
                         throw DebugReaderProbeError.evalUnsupported(format: "epub")
                     }
@@ -926,12 +940,39 @@ struct ReaderContainerView: View {
     func engineReaderView(fingerprint: DocumentFingerprint) -> some View {
         switch ReaderEngine.resolve(format: fingerprint.format) {
         case .epubWKWebView:
-            EPUBReaderHost(
+            // Feature #42 Phase 1: route EPUB to the Readium engine when the
+            // `readiumEPUBEngine` flag is ON (default OFF → `EPUBReaderHost`
+            // stays the live default). The flag read lives here in the
+            // dispatcher, not in the pure `ReaderEngine.resolve`. `if`/`else`
+            // (not an inner `switch`) so the EPUB dispatch keeps a single
+            // `case` label — the source-level dispatch guard slices on case
+            // boundaries.
+            if ReaderEngine.routeEPUB(
+                readiumFlagEnabled: FeatureFlags.shared.isEnabled(.readiumEPUBEngine)
+            ) == .epubReadium {
+                ReadiumEPUBHost(
+                    fileURL: resolvedFileURL,
+                    fingerprint: fingerprint,
+                    settingsStore: settingsStore,
+                    readerToken: readerToken
+                )
+            } else {
+                EPUBReaderHost(
+                    fileURL: resolvedFileURL,
+                    fingerprint: fingerprint,
+                    modelContainer: modelContext.container,
+                    settingsStore: settingsStore,
+                    ttsService: ttsService,
+                    readerToken: readerToken
+                )
+            }
+        case .epubReadium:
+            // `resolve(format:)` never returns this (the Readium choice is made
+            // by `routeEPUB` above); handled for switch totality.
+            ReadiumEPUBHost(
                 fileURL: resolvedFileURL,
                 fingerprint: fingerprint,
-                modelContainer: modelContext.container,
                 settingsStore: settingsStore,
-                ttsService: ttsService,
                 readerToken: readerToken
             )
         case .pdfKit:

--- a/vreader/Views/Reader/ReaderContainerView.swift
+++ b/vreader/Views/Reader/ReaderContainerView.swift
@@ -732,7 +732,7 @@ struct ReaderContainerView: View {
             // from being matched against an incoming probe (Codex audit
             // 2026-05-06). Compare on the typed enum, not raw string, so
             // case/aliasing drift can't silently disable the wiring.
-            if resolvedBookFormat == .epub {
+            if resolvedFingerprintFormat == .epub {
                 let key = book.fingerprintKey
                 let token = readerToken
                 // Feature #42 WI-5: when the Readium engine is active, route
@@ -770,7 +770,7 @@ struct ReaderContainerView: View {
                         for: key, token: token, timeout: timeout
                     )
                 }
-            } else if resolvedBookFormat == .azw3 {
+            } else if resolvedFingerprintFormat == .azw3 {
                 // BookFormat.azw3 covers all Foliate-rendered formats
                 // (azw3/azw/mobi/prc per FormatCapabilities); the
                 // FoliateViewBridge is the single host for all of them.
@@ -845,6 +845,19 @@ struct ReaderContainerView: View {
     /// The resolved book format enum value.
     var resolvedBookFormat: BookFormat {
         BookFormat(rawValue: book.format.lowercased()) ?? .txt
+    }
+
+    /// Feature #42 WI-5 (Codex Med-3): the canonical book format parsed from
+    /// `book.fingerprintKey` (the structural primary key), falling back to the
+    /// `book.format` String column only when the key is unparseable. The DEBUG
+    /// eval-gate routes on THIS, not `resolvedBookFormat` — bug #246 / GH #1072
+    /// hardened `engineReaderView` to dispatch on `fingerprint.format`, and the
+    /// eval wiring must agree, or a stale `book.format` column (a SwiftData
+    /// migration / restore edit that updated one column but not the other)
+    /// could wire the wrong engine's eval bridge while the reader renders the
+    /// engine the fingerprint dictates.
+    var resolvedFingerprintFormat: BookFormat {
+        DocumentFingerprint(canonicalKey: book.fingerprintKey)?.format ?? resolvedBookFormat
     }
 
     /// Lazily creates the AI coordinator on first access.

--- a/vreader/Views/Reader/ReadiumEPUBHost.swift
+++ b/vreader/Views/Reader/ReadiumEPUBHost.swift
@@ -52,7 +52,16 @@ struct ReadiumEPUBHost: View {
                         for: settingsStore.epubLayout
                     ),
                     fingerprintKey: fingerprint.canonicalKey,
-                    readerToken: readerToken
+                    readerToken: readerToken,
+                    // Med-2: when `EPUBNavigatorViewController` init throws the
+                    // representable can only return a placeholder controller
+                    // synchronously — it routes the failure here so the host
+                    // flips to `.failed` and shows the error view instead of a
+                    // blank page. `[weak viewModel]` avoids capturing the View
+                    // struct + mutating @State during a render pass.
+                    onNavigatorInitFailure: { [weak viewModel] message in
+                        viewModel?.markNavigatorInitFailed(message)
+                    }
                 )
                 .ignoresSafeArea()
             case .failed:
@@ -78,6 +87,16 @@ struct ReadiumEPUBHost: View {
             viewModel = vm
             await vm.open()
         }
+        .onDisappear {
+            // High (bug #252 lesson): host-level close lifecycle. The host owns
+            // the VM (and through `.ready` its `Publication`) via @State, so the
+            // close fires only when the host genuinely leaves the hierarchy (nav
+            // pop) — releasing the publication's file handles deterministically
+            // instead of waiting on @State teardown timing. The registry slot +
+            // navigator teardown is handled in the representable's
+            // `dismantleUIViewController` (it knows the coordinator's token).
+            viewModel?.close()
+        }
     }
 }
 
@@ -90,6 +109,12 @@ private struct ReadiumNavigatorRepresentable: UIViewControllerRepresentable {
     let preferences: EPUBPreferences
     let fingerprintKey: String
     let readerToken: UUID?
+    /// Med-2: invoked (on the main actor, deferred past the current render
+    /// pass) when `EPUBNavigatorViewController` init throws, so the host can
+    /// flip to `.failed`. `@MainActor @Sendable` so capturing it into the
+    /// deferral `Task` is clean under `SWIFT_STRICT_CONCURRENCY = complete`
+    /// (Gate-4 round-2 Med).
+    var onNavigatorInitFailure: (@MainActor @Sendable (String) -> Void)?
 
     func makeCoordinator() -> ReadiumReaderCoordinator {
         ReadiumReaderCoordinator(
@@ -113,8 +138,14 @@ private struct ReadiumNavigatorRepresentable: UIViewControllerRepresentable {
             context.coordinator.log.error(
                 "ReadiumEPUB navigator init failed: \(String(describing: error), privacy: .public)"
             )
-            // Empty controller — the host's `.failed` branch normally pre-empts
-            // this; a precondition failure here would crash the reader.
+            // Med-2: a representable must return a controller synchronously, so
+            // hand back an empty placeholder and route the failure into host
+            // state on the next main-actor turn (mutating @State synchronously
+            // here would be a "modifying state during view update" violation).
+            // The host then swaps this placeholder for its `.failed` error view.
+            let handler = onNavigatorInitFailure
+            let message = String(describing: error)
+            Task { @MainActor in handler?(message) }
             return UIViewController()
         }
     }
@@ -126,6 +157,17 @@ private struct ReadiumNavigatorRepresentable: UIViewControllerRepresentable {
         if let navigator = controller as? EPUBNavigatorViewController {
             navigator.submitPreferences(preferences)
         }
+    }
+
+    /// High (bug #252 lesson): deterministic navigator + registry teardown when
+    /// the representable leaves the hierarchy. The coordinator knows its own
+    /// `(fingerprintKey, token)` — which the host cannot when `readerToken` was
+    /// nil and the coordinator generated its own — so it owns the clear.
+    static func dismantleUIViewController(
+        _ controller: UIViewController,
+        coordinator: ReadiumReaderCoordinator
+    ) {
+        coordinator.detach()
     }
 }
 
@@ -159,6 +201,24 @@ final class ReadiumReaderCoordinator: NSObject {
 
     func attach(navigator: EPUBNavigatorViewController) {
         self.navigator = navigator
+    }
+
+    /// High (bug #252 lesson): host-teardown hook called from the
+    /// representable's `dismantleUIViewController`. Clears this reader's
+    /// DebugBridge registry slot (the slot holds the navigator `weak`, but the
+    /// key/token + settle state otherwise linger until the weak ref nils — a
+    /// reader-switch race in the verify harness; the legacy EPUB/Foliate slots
+    /// get this from `unregister(_:)`, which the Readium host never triggers)
+    /// and drops the navigator delegate + ref so no stale delegate callback
+    /// fires after the host leaves the hierarchy.
+    func detach() {
+        #if DEBUG
+        DebugReaderRegistry.shared.clearActiveReadiumNavigator(
+            for: fingerprintKey, token: readerToken
+        )
+        #endif
+        navigator?.delegate = nil
+        navigator = nil
     }
 }
 

--- a/vreader/Views/Reader/ReadiumEPUBHost.swift
+++ b/vreader/Views/Reader/ReadiumEPUBHost.swift
@@ -1,0 +1,225 @@
+// Purpose: Feature #42 Phase 1 (WI-5) — SwiftUI host that renders an EPUB via
+// the Readium Swift Toolkit `EPUBNavigatorViewController`, selected only when
+// the `readiumEPUBEngine` flag is ON (the legacy `EPUBWebViewBridge`
+// `EPUBReaderHost` stays the live default). Sibling of `EPUBReaderHost`: owns
+// the `ReadiumEPUBReaderViewModel` + the navigator-hosting representable via
+// `@State`, opens the publication off-main in `.task`, and tears the reading
+// session down in `.onDisappear` (mirrors `EPUBReaderHost`'s bug-#252 lifecycle).
+//
+// Render scope (WI-5): open + render + scroll/paginate (`EPUBPreferences(scroll:)`
+// from `ReaderSettingsStore.epubLayout`). Position/highlight/theme/search/TTS
+// parity land in later WIs. Loading + error states reuse the existing reader's
+// plain `ProgressView` + the dispatcher's `fingerprintErrorView`-style message
+// (no new UI chrome — rule 51: this is an engine swap behind a dark flag for the
+// already-designed EPUB reading surface).
+//
+// DebugBridge (WI-4 probe): the coordinator registers the active navigator on
+// `navigator(_:locationDidChange:)` via `setActiveReadiumNavigator(_:for:token:)`
+// and marks the reader settled, so `eval?bridge=epub` + settle probes reach the
+// Readium spine WebView CU-free (the eval wiring is in ReaderContainerView's
+// DEBUG `.onAppear`).
+//
+// @coordinates-with ReadiumEPUBReaderViewModel.swift, ReaderContainerView.swift,
+//   ReadiumDebugProbe.swift (DEBUG)
+
+#if canImport(UIKit)
+import SwiftUI
+import UIKit
+import OSLog
+import ReadiumShared
+import ReadiumNavigator
+
+/// Owns `ReadiumEPUBReaderViewModel` lifecycle via @State and hosts the Readium
+/// navigator. Selected by the dispatcher when `readiumEPUBEngine` is ON.
+struct ReadiumEPUBHost: View {
+    let fileURL: URL
+    let fingerprint: DocumentFingerprint
+    let settingsStore: ReaderSettingsStore
+    /// Bug #142 / WI-4: per-reader instance token threaded into the coordinator's
+    /// registry registration so a stale callback from an outgoing reader cannot
+    /// clobber an incoming probe binding.
+    var readerToken: UUID?
+
+    @State private var viewModel: ReadiumEPUBReaderViewModel?
+
+    var body: some View {
+        Group {
+            switch viewModel?.state {
+            case .ready(let publication):
+                ReadiumNavigatorRepresentable(
+                    publication: publication,
+                    preferences: ReadiumEPUBReaderViewModel.epubPreferences(
+                        for: settingsStore.epubLayout
+                    ),
+                    fingerprintKey: fingerprint.canonicalKey,
+                    readerToken: readerToken
+                )
+                .ignoresSafeArea()
+            case .failed:
+                // Reuse the existing reader's failure messaging (rule 51 — no
+                // new chrome): the same copy the dispatcher shows when a book
+                // cannot be opened.
+                VStack(spacing: 16) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.system(size: 48))
+                        .foregroundStyle(.secondary)
+                    Text("Unable to open this book.")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityIdentifier("readiumOpenErrorView")
+            case .loading, .none:
+                ProgressView()
+            }
+        }
+        .task {
+            guard viewModel == nil else { return }
+            let vm = ReadiumEPUBReaderViewModel(fileURL: fileURL)
+            viewModel = vm
+            await vm.open()
+        }
+    }
+}
+
+/// Bridges the Readium `EPUBNavigatorViewController` into SwiftUI. The
+/// coordinator owns the navigator-delegate callbacks + the DebugBridge
+/// registration. Constructed only once the publication is open (the host gates
+/// on `.ready`).
+private struct ReadiumNavigatorRepresentable: UIViewControllerRepresentable {
+    let publication: Publication
+    let preferences: EPUBPreferences
+    let fingerprintKey: String
+    let readerToken: UUID?
+
+    func makeCoordinator() -> ReadiumReaderCoordinator {
+        ReadiumReaderCoordinator(
+            fingerprintKey: fingerprintKey,
+            readerToken: readerToken ?? UUID()
+        )
+    }
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        let config = EPUBNavigatorViewController.Configuration(preferences: preferences)
+        do {
+            let navigator = try EPUBNavigatorViewController(
+                publication: publication,
+                initialLocation: nil,
+                config: config
+            )
+            navigator.delegate = context.coordinator
+            context.coordinator.attach(navigator: navigator)
+            return navigator
+        } catch {
+            context.coordinator.log.error(
+                "ReadiumEPUB navigator init failed: \(String(describing: error), privacy: .public)"
+            )
+            // Empty controller — the host's `.failed` branch normally pre-empts
+            // this; a precondition failure here would crash the reader.
+            return UIViewController()
+        }
+    }
+
+    func updateUIViewController(_ controller: UIViewController, context: Context) {
+        // WI-5 renders a fixed layout preference; live preference updates
+        // (theme/font/scroll toggle) land in WI-7. Re-submit the current
+        // preference so a re-render after a settings change reflects it.
+        if let navigator = controller as? EPUBNavigatorViewController {
+            navigator.submitPreferences(preferences)
+        }
+    }
+}
+
+/// Navigator-delegate + DebugBridge coordinator for the Readium EPUB host.
+/// `final class` (not the SwiftUI view) so it survives view-body recomputation
+/// and can hold the navigator + per-reader token. `@MainActor` because the
+/// navigator and its WebViews are main-actor-isolated (feature #42 Med-4).
+@MainActor
+final class ReadiumReaderCoordinator: NSObject {
+    private let fingerprintKey: String
+    private let readerToken: UUID
+    fileprivate let log = Logger(subsystem: "com.vreader.app", category: "ReadiumEPUB")
+
+    /// Weak — the navigator is owned by the SwiftUI representable's controller
+    /// lifecycle; the coordinator must not keep it alive past the host.
+    private weak var navigator: EPUBNavigatorViewController?
+
+    #if DEBUG
+    /// Test seam: when set, `evaluateJavaScriptValue` uses this instead of the
+    /// real navigator's `evaluateJavaScript`, so the JSON-serialization contract
+    /// is unit-testable without a rendered spine WebView. Returns the raw value
+    /// Readium's `Result<Any, Error>.success` would carry (`nil` = JS undefined).
+    var evaluatorForTests: ((String) async -> Any?)?
+    #endif
+
+    init(fingerprintKey: String, readerToken: UUID) {
+        self.fingerprintKey = fingerprintKey
+        self.readerToken = readerToken
+        super.init()
+    }
+
+    func attach(navigator: EPUBNavigatorViewController) {
+        self.navigator = navigator
+    }
+}
+
+// MARK: - Navigator delegate
+
+extension ReadiumReaderCoordinator: EPUBNavigatorDelegate {
+    nonisolated func navigator(_ navigator: Navigator, presentError error: NavigatorError) {
+        // Surfaced by Readium for resource-load errors; logged, not fatal.
+        Task { @MainActor in
+            self.log.error("ReadiumEPUB navigator error: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    func navigator(_ navigator: Navigator, locationDidChange locator: ReadiumShared.Locator) {
+        // WI-4 probe wiring: register the active navigator + signal settle the
+        // first time a spine is rendered and a location is reported, so the
+        // DebugBridge eval/settle probes (eval?bridge=epub) reach this host.
+        #if DEBUG
+        // Register the coordinator (not the navigator) — the coordinator is the
+        // `ReadiumNavigatorEvaluating` conformer that holds the navigator + the
+        // JSON-serializing eval seam.
+        DebugReaderRegistry.shared.setActiveReadiumNavigator(
+            self, for: fingerprintKey, token: readerToken
+        )
+        DebugReaderRegistry.shared.markReaderSettled(
+            for: fingerprintKey, token: readerToken
+        )
+        #endif
+    }
+}
+
+#if DEBUG
+// MARK: - DebugBridge eval seam (WI-4)
+
+extension ReadiumReaderCoordinator: ReadiumNavigatorEvaluating {
+    /// Evaluate `script` on the navigator's currently-visible spine HTML and
+    /// JSON-serialize the success value into raw bytes (mirrors the EPUB/Foliate
+    /// `jsEvaluator` contract: `nil`/undefined → `null`, then `JSONSerialization`
+    /// with `.fragmentsAllowed` so scalars/arrays/objects all splat cleanly).
+    func evaluateJavaScriptValue(_ script: String) async throws -> Data {
+        let raw: Any?
+        if let stub = evaluatorForTests {
+            raw = await stub(script)
+        } else {
+            guard let navigator else {
+                throw DebugReaderProbeError.evalUnsupported(format: "epub")
+            }
+            switch await navigator.evaluateJavaScript(script) {
+            case let .success(value):
+                raw = value
+            case let .failure(error):
+                throw error
+            }
+        }
+        let normalized: Any = raw ?? NSNull()
+        return try JSONSerialization.data(
+            withJSONObject: normalized,
+            options: [.fragmentsAllowed]
+        )
+    }
+}
+#endif
+
+#endif

--- a/vreaderTests/Models/ReaderEngineTests.swift
+++ b/vreaderTests/Models/ReaderEngineTests.swift
@@ -43,8 +43,9 @@ struct ReaderEngineTests {
 
     // MARK: - CaseIterable
 
-    @Test func caseIterable_hasFiveCases() {
-        #expect(ReaderEngine.allCases.count == 5)
+    @Test func caseIterable_hasSixCases() {
+        // Six engines: feature #42 added `.epubReadium` (flag-gated EPUB).
+        #expect(ReaderEngine.allCases.count == 6)
     }
 
     @Test func caseIterable_containsAllExpectedCases() {
@@ -52,6 +53,7 @@ struct ReaderEngineTests {
         #expect(all.contains(.textNative))
         #expect(all.contains(.markdownNative))
         #expect(all.contains(.epubWKWebView))
+        #expect(all.contains(.epubReadium))
         #expect(all.contains(.foliateWeb))
         #expect(all.contains(.pdfKit))
     }
@@ -62,6 +64,7 @@ struct ReaderEngineTests {
         #expect(ReaderEngine.textNative.rawValue == "textNative")
         #expect(ReaderEngine.markdownNative.rawValue == "markdownNative")
         #expect(ReaderEngine.epubWKWebView.rawValue == "epubWKWebView")
+        #expect(ReaderEngine.epubReadium.rawValue == "epubReadium")
         #expect(ReaderEngine.foliateWeb.rawValue == "foliateWeb")
         #expect(ReaderEngine.pdfKit.rawValue == "pdfKit")
     }
@@ -82,7 +85,7 @@ struct ReaderEngineTests {
             set.insert(engine)
         }
         set.insert(.textNative) // duplicate
-        #expect(set.count == 5)
+        #expect(set.count == 6)
     }
 
     // MARK: - Sendable

--- a/vreaderTests/Views/Reader/ReaderContainerViewEngineDispatchTests.swift
+++ b/vreaderTests/Views/Reader/ReaderContainerViewEngineDispatchTests.swift
@@ -231,7 +231,16 @@ struct ReaderContainerViewEngineDispatchTests {
         let wiring: [(caseLabel: String, host: String)] = [
             ("case .textNative:",    "TXTReaderHost("),
             ("case .markdownNative:", "MDReaderHost("),
+            // Feature #42 Phase 1 WI-5: the `.epubWKWebView` case now branches
+            // on the `readiumEPUBEngine` flag — `EPUBReaderHost(` (flag OFF,
+            // the live default) OR `ReadiumEPUBHost(` (flag ON). The guard
+            // pins the legacy default host stays wired in that case.
             ("case .epubWKWebView:", "EPUBReaderHost("),
+            // Feature #42 Phase 1 WI-5: `resolve` never returns `.epubReadium`
+            // (the dispatcher's `routeEPUB` makes the Readium choice), but the
+            // case is handled for switch totality and must construct the
+            // Readium host.
+            ("case .epubReadium:",   "ReadiumEPUBHost("),
             ("case .pdfKit:",        "PDFReaderHost("),
             // Feature #56 WI-11: the `.foliateWeb` dispatch now wraps
             // `FoliateSpikeView` inside `FoliateBilingualContainerView`
@@ -245,11 +254,16 @@ struct ReaderContainerViewEngineDispatchTests {
                 continue
             }
             // The host construction must appear after this case label and
-            // before the next `case ` label (or the switch's close).
+            // before the NEXT top-level (8-space-indented) `case ` label or
+            // the switch's close. Feature #42 WI-5 widened this from the old
+            // `prefix(400)` fallback: the flag-gated `.epubWKWebView` branch is
+            // now longer than 400 chars (it constructs both hosts), so the
+            // slice must bound on the real case boundary, not a fixed length.
             let afterCase = source[caseIndex.upperBound...]
-            let nextCase = afterCase.range(of: "\n            case .")
+            let nextCase = afterCase.range(of: "\n        case .")
+                ?? afterCase.range(of: "\n        }")
             let caseBody = nextCase.map { String(afterCase[..<$0.lowerBound]) }
-                ?? String(afterCase.prefix(400))
+                ?? String(afterCase)
             #expect(
                 caseBody.contains(host),
                 "`engineReaderView` `\(caseLabel)` must construct `\(host)` — the engine-to-host wiring."

--- a/vreaderTests/Views/Reader/ReadiumEPUBHostTests.swift
+++ b/vreaderTests/Views/Reader/ReadiumEPUBHostTests.swift
@@ -110,4 +110,126 @@ struct ReadiumEPUBHostTests {
         let data = try await coordinator(returning: "被讨厌的勇气").evaluateJavaScriptValue("title")
         #expect(try decode(data) as? String == "被讨厌的勇气")
     }
+
+    // MARK: - VM teardown + init-failure state (Codex Gate-4 round 2)
+
+    /// Med-2: a thrown navigator init is surfaced into the VM's render state so
+    /// the host shows its error view instead of a blank placeholder controller.
+    @MainActor @Test func markNavigatorInitFailed_setsFailedWithMessage() {
+        let vm = ReadiumEPUBReaderViewModel(fileURL: URL(fileURLWithPath: "/dev/null"))
+        vm.markNavigatorInitFailed("navigator init threw")
+        guard case let .failed(message) = vm.state else {
+            Issue.record("expected .failed state, got \(vm.state)")
+            return
+        }
+        #expect(message == "navigator init threw")
+    }
+
+    /// High: `close()` drops whatever the VM was holding (releasing the
+    /// publication's file handles in the `.ready` case) and returns to loading.
+    /// Driven from `.failed` here because constructing a real `.ready`
+    /// `Publication` needs a fixture open; the state reassignment is the same
+    /// code path that drops a `.ready(Publication)`.
+    @MainActor @Test func close_resetsToLoading() {
+        let vm = ReadiumEPUBReaderViewModel(fileURL: URL(fileURLWithPath: "/dev/null"))
+        vm.markNavigatorInitFailed("boom")
+        vm.close()
+        guard case .loading = vm.state else {
+            Issue.record("close should reset to .loading, got \(vm.state)")
+            return
+        }
+    }
+
+    /// High (Gate-4 round 2): a dismiss-during-open must not install a result.
+    /// `close()` (host `.onDisappear`) runs before a still-suspended `open()`
+    /// resumes; the `isClosed` guard makes `open()` a no-op so no `.ready` /
+    /// `.failed` is written into the closed VM.
+    @MainActor @Test func open_afterClose_isNoOp() async {
+        let vm = ReadiumEPUBReaderViewModel(
+            fileURL: URL(fileURLWithPath: "/nonexistent/missing.epub")
+        )
+        vm.close()
+        await vm.open()
+        guard case .loading = vm.state else {
+            Issue.record("open() after close() must not mutate state, got \(vm.state)")
+            return
+        }
+    }
+
+    #if DEBUG
+    // MARK: - Registry deterministic teardown (Codex Gate-4 round 2 — High)
+
+    /// `clearActiveReadiumNavigator` drops the slot when the key+token match,
+    /// so a Readium host (which registers no `DebugReaderProbe`) can tear its
+    /// registry binding down deterministically on dismantle.
+    @MainActor @Test func clearActiveReadiumNavigator_clearsMatchingSlot() {
+        let registry = DebugReaderRegistry.makeIsolatedForTests()
+        let token = UUID()
+        let key = "epub:\(String(repeating: "a", count: 64)):10"
+        // Strong local ref — the registry holds the navigator weak.
+        let coord = ReadiumReaderCoordinator(fingerprintKey: key, readerToken: token)
+        registry.setActiveReadiumNavigator(coord, for: key, token: token)
+        #expect(registry.readiumNavigator(for: key, token: token) != nil)
+
+        registry.clearActiveReadiumNavigator(for: key, token: token)
+        #expect(registry.readiumNavigator(for: key, token: token) == nil)
+        #expect(registry.rawActiveReadiumNavigatorKeyForTests == nil)
+        _ = coord // keep alive across the clear
+    }
+
+    /// A late detach from an outgoing reader (mismatched key) must not wipe the
+    /// current reader's binding (bug #142 stale-write class).
+    @MainActor @Test func clearActiveReadiumNavigator_ignoresNonMatchingKey() {
+        let registry = DebugReaderRegistry.makeIsolatedForTests()
+        let token = UUID()
+        let key = "epub:\(String(repeating: "b", count: 64)):20"
+        let coord = ReadiumReaderCoordinator(fingerprintKey: key, readerToken: token)
+        registry.setActiveReadiumNavigator(coord, for: key, token: token)
+
+        registry.clearActiveReadiumNavigator(for: "epub:other:1", token: token)
+        #expect(registry.readiumNavigator(for: key, token: token) != nil)
+
+        registry.clearActiveReadiumNavigator(for: key, token: UUID())
+        #expect(registry.readiumNavigator(for: key, token: token) != nil)
+        _ = coord
+    }
+
+    /// Med (Gate-4 round 2): in a same-book quick reopen, the outgoing reader A
+    /// still owns the slot while `expectedReaderToken` belongs to incoming
+    /// reader B. A's detach must clear its OWN settle state without clobbering
+    /// B's (mirrors `unregister(_:)`'s `preservingToken` posture).
+    @MainActor @Test func clearActiveReadiumNavigator_preservesIncomingTokenSettleState() {
+        let registry = DebugReaderRegistry.makeIsolatedForTests()
+        let key = "epub:\(String(repeating: "c", count: 64)):30"
+        let tokenA = UUID()
+        let tokenB = UUID()
+        let coordA = ReadiumReaderCoordinator(fingerprintKey: key, readerToken: tokenA)
+        // A registers first (no expected token yet), then B claims the slot
+        // expectation + settles.
+        registry.setActiveReadiumNavigator(coordA, for: key, token: tokenA)
+        registry.setExpectedReaderToken(tokenB)
+        registry.markReaderSettled(for: key, token: tokenB)
+        #expect(registry.settledKeys.contains(.init(fingerprintKey: key, token: tokenB)))
+
+        registry.clearActiveReadiumNavigator(for: key, token: tokenA)
+        #expect(registry.settledKeys.contains(.init(fingerprintKey: key, token: tokenB)))
+        _ = coordA
+    }
+
+    /// When the leaving reader IS the last reader for the key (no incoming
+    /// `expectedReaderToken`), its detach clears ALL of the key's settle state.
+    @MainActor @Test func clearActiveReadiumNavigator_clearsOwnSettleWhenLastReader() {
+        let registry = DebugReaderRegistry.makeIsolatedForTests()
+        let key = "epub:\(String(repeating: "d", count: 64)):40"
+        let token = UUID()
+        let coord = ReadiumReaderCoordinator(fingerprintKey: key, readerToken: token)
+        registry.setActiveReadiumNavigator(coord, for: key, token: token)
+        registry.markReaderSettled(for: key, token: token)
+        #expect(registry.settledKeys.contains(.init(fingerprintKey: key, token: token)))
+
+        registry.clearActiveReadiumNavigator(for: key, token: token)
+        #expect(!registry.settledKeys.contains(.init(fingerprintKey: key, token: token)))
+        _ = coord
+    }
+    #endif
 }

--- a/vreaderTests/Views/Reader/ReadiumEPUBHostTests.swift
+++ b/vreaderTests/Views/Reader/ReadiumEPUBHostTests.swift
@@ -1,0 +1,113 @@
+// Purpose: Feature #42 Phase 1 WI-5 — unit tests for the testable seams of the
+// Readium EPUB host: (1) the pure dispatch routing decision (flag ON →
+// `.epubReadium`, flag OFF → `.epubWKWebView`); (2) the `EPUBLayoutPreference`
+// → Readium `EPUBPreferences(scroll:)` mapping; (3) the coordinator's
+// `ReadiumNavigatorEvaluating` JSON serialization of a navigator eval result
+// (fed through a stub navigator-evaluator closure so no real WebView renders).
+//
+// The render itself (UIViewControllerRepresentable hosting
+// EPUBNavigatorViewController) is exercised by device verification, not here.
+//
+// @coordinates-with vreader/Views/Reader/ReadiumEPUBHost.swift,
+//   vreader/ViewModels/ReadiumEPUBReaderViewModel.swift,
+//   vreader/Models/ReaderEngine.swift
+
+import Testing
+import Foundation
+import ReadiumNavigator
+@testable import vreader
+
+@Suite("ReadiumEPUBHost (WI-5)")
+struct ReadiumEPUBHostTests {
+
+    // MARK: - Dispatch routing (pure, flag-driven)
+
+    @Test func routeEPUB_flagOff_isLegacyWKWebView() {
+        #expect(ReaderEngine.routeEPUB(readiumFlagEnabled: false) == .epubWKWebView)
+    }
+
+    @Test func routeEPUB_flagOn_isReadium() {
+        #expect(ReaderEngine.routeEPUB(readiumFlagEnabled: true) == .epubReadium)
+    }
+
+    /// `resolve(format:)` stays the pure format→default-engine map (the flag
+    /// branch lives in the dispatcher, NOT here) — EPUB still resolves to the
+    /// legacy engine so a flag-unaware caller gets today's behavior.
+    @Test func resolve_epub_unchanged_isLegacy() {
+        #expect(ReaderEngine.resolve(format: .epub) == .epubWKWebView)
+    }
+
+    @Test func epubReadium_isACase_andRoundTrips() {
+        #expect(ReaderEngine.allCases.contains(.epubReadium))
+        #expect(ReaderEngine(rawValue: "epubReadium") == .epubReadium)
+        #expect(ReaderEngine.epubReadium.rawValue == "epubReadium")
+    }
+
+    // MARK: - EPUBLayoutPreference → EPUBPreferences(scroll:)
+
+    @Test func preferences_scrollLayout_enablesScroll() {
+        let prefs = ReadiumEPUBReaderViewModel.epubPreferences(for: .scroll)
+        #expect(prefs.scroll == true)
+    }
+
+    @Test func preferences_pagedLayout_disablesScroll() {
+        let prefs = ReadiumEPUBReaderViewModel.epubPreferences(for: .paged)
+        #expect(prefs.scroll == false)
+    }
+
+    // MARK: - Coordinator eval serialization (ReadiumNavigatorEvaluating)
+
+    /// Stub navigator-evaluator that returns a caller-supplied raw value (the
+    /// shape Readium's `evaluateJavaScript(_:) -> Result<Any, Error>` yields on
+    /// success), so the coordinator's JSON-serialization contract is testable
+    /// without a real spine WebView.
+    @MainActor
+    private func coordinator(returning value: Any?) -> ReadiumReaderCoordinator {
+        let coord = ReadiumReaderCoordinator(
+            fingerprintKey: "epub:\(String(repeating: "a", count: 64)):10",
+            readerToken: UUID()
+        )
+        coord.evaluatorForTests = { _ in value }
+        return coord
+    }
+
+    @MainActor
+    private func decode(_ data: Data) throws -> Any {
+        try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+    }
+
+    @MainActor @Test func eval_serializesNumber() async throws {
+        let data = try await coordinator(returning: 42).evaluateJavaScriptValue("1+41")
+        #expect(try decode(data) as? Int == 42)
+    }
+
+    @MainActor @Test func eval_serializesString() async throws {
+        let data = try await coordinator(returning: "hello").evaluateJavaScriptValue("'hello'")
+        #expect(try decode(data) as? String == "hello")
+    }
+
+    @MainActor @Test func eval_serializesArray() async throws {
+        let data = try await coordinator(returning: [1, 2, 3]).evaluateJavaScriptValue("[1,2,3]")
+        let arr = try decode(data) as? [Int]
+        #expect(arr == [1, 2, 3])
+    }
+
+    @MainActor @Test func eval_serializesObject() async throws {
+        let data = try await coordinator(returning: ["k": "v"]).evaluateJavaScriptValue("({k:'v'})")
+        let obj = try decode(data) as? [String: String]
+        #expect(obj?["k"] == "v")
+    }
+
+    /// JS `undefined` / Swift `nil` → JSON `null` (mirrors the EPUB/Foliate
+    /// jsEvaluator `raw ?? NSNull()` contract so the bridge can splat it).
+    @MainActor @Test func eval_undefinedBecomesNull() async throws {
+        let data = try await coordinator(returning: nil).evaluateJavaScriptValue("void 0")
+        #expect(try decode(data) is NSNull)
+    }
+
+    /// CJK string round-trips through UTF-8 JSON without mojibake (edge case).
+    @MainActor @Test func eval_serializesCJK() async throws {
+        let data = try await coordinator(returning: "被讨厌的勇气").evaluateJavaScriptValue("title")
+        #expect(try decode(data) as? String == "被讨厌的勇气")
+    }
+}


### PR DESCRIPTION
## Summary

First **behavioral** WI of feature #42 Phase 1: render a reflowable EPUB through the Readium Swift Toolkit `EPUBNavigatorViewController`, selected in place of the legacy `EPUBReaderHost` only when the default-OFF `FeatureFlags.readiumEPUBEngine` is ON. Render-only at this WI (open + render + scroll/paginate); position / theme / highlights / search / TTS land in WI-6…WI-10.

Part of feature #42 (Readium + libmobi unified reader engine; tracking GH #113). Plan: `dev-docs/plans/20260528-feature-42-readium-libmobi-reader-engine.md`.

## What Changed

- **`ReadiumEPUBHost`** + `ReadiumNavigatorRepresentable` + `ReadiumReaderCoordinator` (`Views/Reader/ReadiumEPUBHost.swift`) — SwiftUI host owning the VM via `@State`; the coordinator is the `EPUBNavigatorDelegate` + (DEBUG) `ReadiumNavigatorEvaluating` seam, registering the navigator on `locationDidChange` and tearing it down on `dismantleUIViewController`.
- **`ReadiumEPUBReaderViewModel`** (`ViewModels/`) — thin `@MainActor` opener (`AssetRetriever` → `PublicationOpener`) + pure `epubPreferences(for:)` mapping from `ReaderSettingsStore.epubLayout`.
- **Dispatch** — `ReaderEngine.routeEPUB(readiumFlagEnabled:)` + the dispatcher's `.epubWKWebView` branch select `ReadiumEPUBHost` when the flag is ON; `resolve(format:)` stays the pure default map.
- **DebugBridge** — `clearActiveReadiumNavigator(for:token:)` (deterministic registry teardown the Readium host needs because it registers no `DebugReaderProbe`); eval-gate routes on the canonical `resolvedFingerprintFormat`.

## Codex Audit (Gate 4)

3 rounds, final verdict **ship-as-is** (zero open Critical/High/Medium). Round 1 (impl) found 1 High / 2 Medium (teardown/leak, blank-controller-on-init-failure, eval gate on stale `book.format`); round 2 (on the fixes) found 1 High / 2 Medium (dismiss-during-open race, settle-state preservation on detach, `@Sendable` closure under `complete` strict concurrency); round 3 clean. Audit log: `.claude/codex-audits/feat-feature-42-wi5-readium-host-audit.md`.

## Validation

- [x] `xcodebuild test` green — 42 tests / 3 suites (`ReadiumEPUBHostTests` + `ReaderEngineTests` + `ReaderContainerViewEngineDispatchTests`), incl. 7 regression tests for the audit fixes.
- [x] Full build SUCCEEDED at v3.40.19 under `SWIFT_STRICT_CONCURRENCY: complete`.
- [x] Codex audit loop clean (3 rounds, ship-as-is).
- [x] Docs sync — `docs/architecture.md` (ReadiumEPUBHost Format Hosts entry + corrected the stale "feature #42 → .foliateWeb" claim).
- [x] Version bumped: 3.40.18 → 3.40.19 (build 699 → 700).

## Gate 5a Verification (behavioral slice — pre-merge)

Device slice verified CU-free on iPhone 17 Pro Simulator (iOS 26, UDID `61149F0E…`) against the freshly-built **3.40.19** with `readiumEPUBEngine` forced ON (`simctl launch -com.vreader.featureFlags.readiumEPUBEngine YES`):

- `reset` → `seed?fixture=mini-epub3` → `open?bookId=epub:f284…:2198` → render confirmed: **"Chapter One"** + the mini-epub3 paragraphs on screen (`dev-docs/verification/artifacts/feature-42-wi5-readium-render-20260529.png`).
- Fresh `eval?bridge=epub` (unique `wi5marker:1`) returned `{"len":498,"foliate":"undefined","vreaderBridge":"undefined","title":"Chapter One"}` — the eval reached the **Readium** spine via the `readiumNavigator` registry slot.
- **Joint Readium-not-legacy proof**: eval succeeded (Readium slot filled) WHILE `settle` reported `webview not registered` (the legacy `epubWebView` slot is empty → the legacy `EPUBWebViewBridge` is NOT rendering).

**Known harness follow-up (non-blocking)**: `settle`'s Stage-2 gate (`awaitWebViewRegistered`) is EPUB-*webview*-specific and doesn't recognize the Readium navigator slot, so `settle` errors `webview not registered` for the Readium engine even though Stage-1 probe settle (`markReaderSettled`) succeeds. CU-free verification uses the `eval` path (which works), so this doesn't block WI-5; will be filed as a DevTools/Verification harness bug to teach `awaitWebViewRegistered` about the Readium slot.

## Type of Change

- [x] Feature WI (Part of feature #42 — intermediate WI, plain prose to avoid the open-feature merge gate)