### PR TITLE
feat(#1121 WI-1): edit-handoff foundation (open-in-edit intent pipeline)

### DIFF
--- a/.claude/codex-audits/feat-feature-1121-wi1-edit-handoff-audit.md
+++ b/.claude/codex-audits/feat-feature-1121-wi1-edit-handoff-audit.md
@@ -1,0 +1,30 @@
+---
+branch: feat/feature-1121-wi1-edit-handoff
+threadId: codex-exec-2026-05-31-feat1121-wi1
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-31
+---
+
+# Gate-4 audit — Feature #1121 WI-1 (edit-handoff foundation)
+
+`codex exec --sandbox read-only`. **No findings.** Foundational, non-presenting
+slice: adds the types + threads the open-in-edit intent through the popover
+pipeline + the pure `HighlightEditHandoff` router. `edit()` stays navigate-only and
+no bridge observes `.readerHighlightEditRequested` yet → strict runtime no-op.
+
+Auditor confirmations:
+- Existing tap behavior unchanged (all `ReaderHighlightTapEvent` producers omit the
+  trailing-defaulted `openInEditMode`; `present(_:initialMode: .reading)` preserves
+  the old `present(_)` semantics — mode .reading, draft "").
+- Intent thread has no stale-mode race: `handleTap` (@MainActor) sets
+  `presentedInitialMode` before the async lookup; only the latest `latestTapToken`
+  publishes `presented`; a superseding normal tap resets to `.reading` first.
+- `.editing` draft seed matches `beginEdit`; Equatable/Sendable intact + source-compatible.
+- `HighlightEditHandoff.action` projects highlightId / annotationId correctly.
+
+## Gate-2 plan audit (round 1): 2 High + 5 Medium + 2 Low — all addressed in the
+plan/WI-1 scope (see plan "Gate-2 audit fixes applied"). H1 (lost flag) fixed in WI-1;
+the per-format ack/resolver/cancellation findings scope WI-2.
+
+## Verdict: ship-as-is.

--- a/dev-docs/plans/20260531-feature-1121-edit-handoff-autoopen.md
+++ b/dev-docs/plans/20260531-feature-1121-edit-handoff-autoopen.md
@@ -1,0 +1,119 @@
+# Feature #1121 — Edit handoff: auto-open editor after jump (Bug #249 follow-up)
+
+> GH #1121. Source of truth: this plan + the issue. Design status: **plumbing, not
+> new UI** — the Edit destination (`HighlightActionCard` editing mode for highlights,
+> the note editor for standalones) is already designed/built; this wires the
+> programmatic "navigate → open the editor" entry point that #1080 deferred.
+
+## Problem
+
+The HighlightsSheet (Notes) `⋯ → Edit` currently does a navigate-only handoff
+(`HighlightsSheet+Delete.edit()` → `onNavigate(locator)` + `onDismiss()`), landing
+the user on the passage where the in-reader edit affordance is one tap away. The
+committed design says Edit should **auto-open** the editor after the jump. It can't
+today: the in-reader popover (`HighlightPopoverModifier`) only presents in response
+to a real `.readerHighlightTapped` (a tap on a *rendered* highlight, resolved async
+by the per-format reader bridge); there is no programmatic post-navigation
+edit-open entry point. Standalone notes have no presentation path from the sheet at all.
+
+## Surface area (file-by-file)
+
+- **`vreader/Views/Reader/ReaderNotifications.swift`** — `ReaderHighlightTapEvent`
+  gains `openInEditMode: Bool = false` (Sendable/Equatable preserved; default keeps
+  every existing call site unchanged). Add a new `Notification.Name`
+  `.readerHighlightEditRequested` (payload: highlight `UUID`).
+- **`vreader/Views/Reader/HighlightPopoverModifier.swift`** — when presenting a card
+  for an event with `openInEditMode == true`, present in `mode = .editing` (and seed
+  the `noteDraft` from the highlight's note). Extract the mode/draft seed into a pure
+  helper `HighlightPopoverEditSeed.mode(for:)` for unit testing.
+- **`vreader/Views/Reader/Annotations/HighlightsSheet+Delete.swift`** — `edit()` for
+  a `.highlight` posts `.readerHighlightEditRequested(highlightID)` AFTER
+  `onNavigate` (a pure router `HighlightEditHandoff.request(for:)` decides
+  highlight-vs-standalone routing — testable). For `.standalone`, route to the note
+  editor presentation (WI-3).
+- **Per-format reader bridges** (TXT/MD chunked + non-chunked, EPUB, Foliate, PDF) —
+  observe `.readerHighlightEditRequested`: once the highlight re-renders in the new
+  scroll/page position (reuse each format's existing highlight-render/restore
+  signal — e.g. Foliate `.foliateOverlayReadyForSection`, EPUB `sectionMaterialized`,
+  TXT cell render), resolve the highlight's anchor rect (the SAME resolver the tap
+  path uses) and post `.readerHighlightTapped` with `openInEditMode: true`.
+- **Standalone notes** — wire `HighlightNoteEditSheet` (feature #914) / `AnnotationEditSheet`
+  presentation from the review-sheet edit on a `.standalone` card.
+
+### Files OUT of scope
+- The popover card UI itself (`HighlightActionCard`) — already designed/built; only
+  the *trigger* + initial `mode` change.
+- The delete/copy actions (#1080, shipped).
+- Any new visible chrome — none. If the in-sheet-vs-after-jump presentation question
+  resurfaces, file `needs-design` then (per the issue).
+
+## Prior art / precedent
+- The `.readerHighlightTapped` → `HighlightPopoverRequest.event(from:)` →
+  `presentCard(mode:)` pipeline (feature #53/#64) — the edit-open reuses it, only
+  adding a programmatic producer + the `openInEditMode` flag.
+- Per-format highlight-render signals already exist for restore (Foliate
+  `.foliateOverlayReadyForSection`, EPUB `sectionMaterialized`) — the edit-open keys
+  on the same signals rather than inventing a new "rendered" channel.
+
+## Work-item sequencing
+- **WI-1 (foundational, unit-testable, no user-observable behavior alone)**:
+  `openInEditMode` flag on `ReaderHighlightTapEvent`; `.readerHighlightEditRequested`
+  name; `HighlightPopoverEditSeed.mode(for:)` (pure); modifier presents `.editing`
+  when the flag is set; `HighlightEditHandoff.request(for:)` router; `edit()` posts
+  the request for highlights. **Ships now.** No format wiring yet → no behavior change
+  until a bridge produces the flagged tap (WI-2), so this is safe to ship flag-free.
+- **WI-2 (behavioral, CU-verified)**: per-format bridge resolution — observe
+  `.readerHighlightEditRequested`, resolve-after-render, post the flagged
+  `.readerHighlightTapped`. One format per PR (start with the chunked TXT path —
+  the default). Device-verified each.
+- **WI-3 (behavioral, CU-verified)**: standalone-note editor presentation path.
+
+## Test catalogue
+- `ReaderHighlightTapEventTests` — `openInEditMode` default false; Equatable includes it.
+- `HighlightPopoverEditSeedTests` — `mode(for:)` returns `.editing` when the flag is
+  set (seeds draft from the note), `.reading` otherwise.
+- `HighlightEditHandoffTests` — router maps `.highlight` → an edit-request for that
+  id; `.standalone` → the note-editor route.
+- WI-2/WI-3: per-bridge integration (CU/device) — the resolve-after-render + present.
+
+## Risks + mitigations
+- **Async race (the hard part)**: the highlight may not be rendered when the request
+  arrives. Mitigation: key on each format's existing render/restore signal + a bounded
+  retry/timeout; if it never renders (e.g. evicted), no-op (the user still landed on
+  the passage — the #1080 behavior, no regression).
+- **5-format surface**: WI-2 ships one format per PR so each is device-verified
+  independently; partial coverage degrades gracefully to the navigate-only handoff.
+
+## Backward compat
+- `openInEditMode` defaults false → every existing `ReaderHighlightTapEvent` call site
+  + tap behavior is unchanged. WI-1 ships no behavior change until a producer sets the
+  flag. No persistence/schema impact.
+
+## CU note
+WI-1 is unit-test-verified (pure seams). WI-2/WI-3 are inherently device/CU-verified
+(the navigate→render→present flow) — with CU currently down they ship
+`awaiting-device-verification` like the in-flight bug fixes, OR pause for CU per the
+verification gate.
+
+---
+
+## Gate-2 audit fixes applied (2026-05-31, Codex round 1 → addressed)
+
+| Finding | Resolution |
+|---|---|
+| H1: the flag is lost in the popover pipeline (`router.present` hard-resets mode=.reading; VM publishes only content) | WI-1 threads intent end-to-end: `VM.presentedInitialMode` set in `handleTap` from `event.openInEditMode`; the modifier passes it to `router.present(_:initialMode:)` (new param) which seeds `mode` + `noteDraft` from `content.note`. Unit-tested. |
+| H2: EPUB `sectionMaterialized` too early to mean "highlight measurable" | Deferred to WI-2; the plan's per-format wiring will hook the AFTER-restore ack (post-`restoreHighlightsInSectionJS`), not `sectionMaterialized`. Paged EPUB hooks `didFinish` + pending restore. |
+| M3: all 6 `ReaderHighlightTapEvent` constructors (PDF/EPUB/TXT×2/Foliate×2) | The default `openInEditMode = false` keeps all 6 unchanged; WI-2 touches them one format/PR. |
+| M4: payload under-specified | `ReaderHighlightEditRequest { highlightID, bookFingerprintKey, token }` — book-scoped + single-flight token. |
+| M5: Foliate resolver differs (UUID→CFI, no rect) | WI-2 plans Foliate separately (fetch by UUID → CFI → await overlay → post `.zero` rect → sheet fallback). |
+| M6: TXT/MD render signal vague | WI-2: non-chunked resolves after `scrollToMatchedOffset`+`ensureLayout`; chunked waits for the target chunk cell to be visible/rendered. |
+| M7: cancellation/staleness | The `token` is the single-flight handle; observers ignore mismatched book / superseded token. WI-2 cancels on new request / manual tap / reader close / book change. |
+| L8: equality semantics | tested: default false; `false != true`. |
+| L9: "WI-1 behavior-free" imprecise | WI-1 is **non-presenting**: it adds the types + router intent-threading + the pure `HighlightEditHandoff` router, but does NOT change `edit()` (stays navigate-only) and NO bridge observes `.readerHighlightEditRequested` yet → strictly no runtime behavior change. The producer (`edit()` posting) + first observer land together in WI-2. |
+
+**WI-1 shipped** (this PR): `openInEditMode` flag, `ReaderHighlightEditRequest` +
+`.readerHighlightEditRequested`, `router.present(_:initialMode:)` + VM threading,
+`HighlightEditHandoff` router. Unit-tested (`HighlightEditHandoffTests`,
+`HighlightPopoverActionRouterTests`). Non-presenting → no device verification needed.
+WI-2 (per-format resolve-after-render) + WI-3 (standalone editor) are the behavioral,
+CU-verified slices.

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 732
-        MARKETING_VERSION: 3.41.6
+        CURRENT_PROJECT_VERSION: 733
+        MARKETING_VERSION: 3.41.7
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -444,6 +444,7 @@
 		4CC9567091E0CABFDD800F6C /* AIConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52103AEAF5528A9DD58625E /* AIConfiguration.swift */; };
 		4CCBF4F6E186A7363A995303 /* ReaderContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB42EEEFFCAD8D654D57AE7 /* ReaderContainerView.swift */; };
 		4CCE624D88A6301BB7A2E18C /* V6toV7MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6832D0CE94B6D7181A2D82B0 /* V6toV7MigrationTests.swift */; };
+		4CDDE0625D290A614C772CF1 /* HighlightEditHandoffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F32CF0D8EA1782A58090C09 /* HighlightEditHandoffTests.swift */; };
 		4D262FBAEBAC69E057B371DA /* SourceSerif4-It.otf in Resources */ = {isa = PBXBuildFile; fileRef = BDD31D89F9B0E622F58B6F5C /* SourceSerif4-It.otf */; };
 		4D323FB1DB077A50154AFC72 /* SummaryScopeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4201BB3B1C117672C45389AE /* SummaryScopeResolverTests.swift */; };
 		4D4A49E8738329EC2B336683 /* TXTReaderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D998048CE6DE8DC3BC77C284 /* TXTReaderViewModelTests.swift */; };
@@ -724,6 +725,7 @@
 		7E84EE1334499F661728483E /* UpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89DE76057526BA48CAE2A83A /* UpdateChecker.swift */; };
 		7EE8C91043F4F20D39AF326B /* AITranslationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B992B24F86DF8CA23E1215 /* AITranslationViewModel.swift */; };
 		7F17555C4DA7C6845661BBB5 /* WebDAVBlobStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74A4D9FF0F23D7D38DC185F /* WebDAVBlobStoreTests.swift */; };
+		7F7CBE37EB640B7FFA5CD0C9 /* HighlightEditHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C92C565A8031982C687338 /* HighlightEditHandoff.swift */; };
 		7F8BACA8231195C0465A126E /* StatsCustomRangePickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C9BC667542D27D5073EC0C4 /* StatsCustomRangePickerState.swift */; };
 		7F9B63BF3B9DCB2C4ED34710 /* ReadingStatsCustomRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D8C2F300254BE19CB77776 /* ReadingStatsCustomRange.swift */; };
 		7FB5A34EF09FD38AB35BC2F4 /* ResolvedAIProviderConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF4A6CC054CFA7E4E893F893 /* ResolvedAIProviderConfig.swift */; };
@@ -1444,6 +1446,7 @@
 		0069CA3A00998B13DE06E424 /* LocatorIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorIntegrationTests.swift; sourceTree = "<group>"; };
 		00814B9C69A0E1190146095E /* PersistenceActor+Collections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+Collections.swift"; sourceTree = "<group>"; };
 		00B189F7F32FF82BCF254923 /* TXTTextChunker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTTextChunker.swift; sourceTree = "<group>"; };
+		00C92C565A8031982C687338 /* HighlightEditHandoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightEditHandoff.swift; sourceTree = "<group>"; };
 		00DE93DBD2142D882858486F /* Bug93GeneralChatPersistenceVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bug93GeneralChatPersistenceVerificationTests.swift; sourceTree = "<group>"; };
 		00E65D537B445A7271390081 /* ChapterTranslationPrefetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterTranslationPrefetcher.swift; sourceTree = "<group>"; };
 		00FE0912FBC85E22DF8C637F /* ReadingTimeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingTimeFormatter.swift; sourceTree = "<group>"; };
@@ -1873,6 +1876,7 @@
 		4EE30F08BFCC54CF8598180F /* LaunchArgParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchArgParsingTests.swift; sourceTree = "<group>"; };
 		4EF994B8B9C677990960D7F2 /* TXTChapterStartDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterStartDecorator.swift; sourceTree = "<group>"; };
 		4F1348B555C6A2C90B03ED65 /* DebugBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugBridge.swift; sourceTree = "<group>"; };
+		4F32CF0D8EA1782A58090C09 /* HighlightEditHandoffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightEditHandoffTests.swift; sourceTree = "<group>"; };
 		4F472E419C207DEF572E322B /* NotesRowState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesRowState.swift; sourceTree = "<group>"; };
 		4F8AEC7D40405AE90840ABE4 /* HighlightRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightRenderer.swift; sourceTree = "<group>"; };
 		4FA36CFAC187DC7B25B7A920 /* ChapterStartTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterStartTypography.swift; sourceTree = "<group>"; };
@@ -4477,6 +4481,7 @@
 				BB4782896641E1278B54C247 /* AnnotationsSheetRouteTests.swift */,
 				3E3B2EC2A68566A49EFF1271 /* AnnotationStreamBuilderTests.swift */,
 				E4A1E377D377C7BFEE10AE14 /* HighlightAnnotationCardTests.swift */,
+				4F32CF0D8EA1782A58090C09 /* HighlightEditHandoffTests.swift */,
 				5F46FAD0B946CB839FF15BB6 /* HighlightsSheetDeleteTests.swift */,
 				494171D4E38F6498FC04AC2C /* HighlightsSheetTests.swift */,
 				40E27899DB05507AB2F13CDE /* NotesRowStateTests.swift */,
@@ -5127,6 +5132,7 @@
 				6C930176EDA59BA6AE769B8C /* AnnotationStreamBuilder.swift */,
 				FCC8C2B2EE71211499AA0EE4 /* AnnotationStreamItem.swift */,
 				D4793BFB8AB85773B1931C28 /* HighlightAnnotationCard.swift */,
+				00C92C565A8031982C687338 /* HighlightEditHandoff.swift */,
 				5E0196F7E5E8458281F5C896 /* HighlightsSheet.swift */,
 				92A21498B4BB8CCB388677F3 /* HighlightsSheet+Delete.swift */,
 				50988D487A861C52A06E6159 /* HighlightsSheet+Export.swift */,
@@ -5675,6 +5681,7 @@
 				CFF91208E4CD56126CC9FB8D /* HighlightCoordinatorMutationTests.swift in Sources */,
 				514822215748FA807FA36FE2 /* HighlightCoordinatorTests.swift in Sources */,
 				2509B7983AE76F5C85B71634 /* HighlightDedupeTests.swift in Sources */,
+				4CDDE0625D290A614C772CF1 /* HighlightEditHandoffTests.swift in Sources */,
 				FCDCB2D6F445BE64BFE95D03 /* HighlightHitToleranceTests.swift in Sources */,
 				51F370150CAD9A865053266C /* HighlightIntegrationTests.swift in Sources */,
 				7ACFB80A7A453D8665EA3E86 /* HighlightListViewModelFoliateOverlayStripTests.swift in Sources */,
@@ -6314,6 +6321,7 @@
 				CCADB57440392A88FAEAFBAF /* HighlightActionCardView.swift in Sources */,
 				3F171AACB1188132A688A94E /* HighlightAnnotationCard.swift in Sources */,
 				68334589D47C834C926DEF1C /* HighlightCoordinator.swift in Sources */,
+				7F7CBE37EB640B7FFA5CD0C9 /* HighlightEditHandoff.swift in Sources */,
 				61A73A3870F542FDEEDA92B7 /* HighlightHitTolerance.swift in Sources */,
 				4331E31295D932065A8E3DCB /* HighlightListViewModel.swift in Sources */,
 				D8653FB28D757A7EE29D0D37 /* HighlightLookup.swift in Sources */,
@@ -6892,13 +6900,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 732;
+				CURRENT_PROJECT_VERSION = 733;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.6;
+				MARKETING_VERSION = 3.41.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -7042,13 +7050,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 732;
+				CURRENT_PROJECT_VERSION = 733;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.6;
+				MARKETING_VERSION = 3.41.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/ViewModels/HighlightPopoverViewModel.swift
+++ b/vreader/ViewModels/HighlightPopoverViewModel.swift
@@ -42,6 +42,12 @@ final class HighlightPopoverViewModel {
     /// shown. A popover surface observes this to mount/dismiss itself.
     private(set) var presented: HighlightPopoverContent?
 
+    /// Feature #1121: the sub-mode the popover should OPEN in for the pending
+    /// `presented` — `.editing` when the resolving tap carried `openInEditMode`
+    /// (the Edit-handoff auto-open), else `.reading`. The modifier passes this to
+    /// `router.present(_:initialMode:)`, fixing the lost-flag pipeline gap.
+    private(set) var presentedInitialMode: HighlightPopoverMode = .reading
+
     private let persistence: any HighlightLookup
     private let bookFingerprintKey: String
     private let log = Logger(subsystem: "com.vreader.app", category: "HighlightPopover")
@@ -64,6 +70,9 @@ final class HighlightPopoverViewModel {
     func handleTap(_ event: ReaderHighlightTapEvent, chapter: String?) async {
         latestTapToken &+= 1
         let myToken = latestTapToken
+        // Feature #1121: carry the open-in-edit intent so the modifier presents
+        // the resolved content in `.editing` (a normal tap leaves it `.reading`).
+        presentedInitialMode = event.openInEditMode ? .editing : .reading
 
         let record: HighlightRecord?
         do {

--- a/vreader/Views/Reader/Annotations/HighlightEditHandoff.swift
+++ b/vreader/Views/Reader/Annotations/HighlightEditHandoff.swift
@@ -1,0 +1,46 @@
+// Purpose: Pure routing for Feature #1121 — the HighlightsSheet "Edit" handoff.
+// Decides, for an `AnnotationStreamItem`, what the post-navigation auto-open
+// should do: a highlight requests the per-format reader bridge to re-open its
+// in-reader editor (`ReaderHighlightEditRequest`, observed + resolved after the
+// highlight re-renders), a standalone note opens its standalone editor.
+//
+// Lifted out of the SwiftUI sheet so the routing + payload construction are
+// unit-testable without a view. The actual notification post / editor
+// presentation (WI-2/WI-3) is bridge/UI wiring keyed on this decision.
+//
+// @coordinates-with: HighlightsSheet+Delete.swift (edit handoff), ReaderNotifications.swift
+//   (ReaderHighlightEditRequest / .readerHighlightEditRequested)
+
+import Foundation
+
+enum HighlightEditHandoff {
+
+    /// What the Edit handoff should do AFTER the navigate-to-passage jump.
+    enum Action: Equatable {
+        /// A highlight — ask the per-format bridge to auto-open the in-reader
+        /// highlight editor once the highlight re-renders at the new position.
+        case requestHighlightEdit(ReaderHighlightEditRequest)
+        /// A standalone note — open its standalone editor (no anchored passage).
+        case openStandaloneNote(annotationID: UUID)
+    }
+
+    /// The routing decision for `item`. `bookFingerprintKey` scopes the request
+    /// to the open book; `token` is the single-flight handle (a newer Edit
+    /// supersedes an older one).
+    static func action(
+        for item: AnnotationStreamItem,
+        bookFingerprintKey: String,
+        token: UUID
+    ) -> Action {
+        switch item {
+        case .highlight(let record):
+            return .requestHighlightEdit(ReaderHighlightEditRequest(
+                highlightID: record.highlightId,
+                bookFingerprintKey: bookFingerprintKey,
+                token: token
+            ))
+        case .standalone(let record):
+            return .openStandaloneNote(annotationID: record.annotationId)
+        }
+    }
+}

--- a/vreader/Views/Reader/HighlightPopoverActionRouter.swift
+++ b/vreader/Views/Reader/HighlightPopoverActionRouter.swift
@@ -64,14 +64,16 @@ final class HighlightPopoverActionRouter {
 
     // MARK: - Presentation
 
-    /// Presents (or replaces) the popover for `content`. Always resets the
-    /// interaction state: `mode` → `.reading`, `noteDraft` → `""` — so a rapid
-    /// second tap on a different highlight never carries the prior highlight's
-    /// stale draft or editing mode (R1-6).
-    func present(_ content: HighlightPopoverContent) {
+    /// Presents (or replaces) the popover for `content`. Resets the interaction
+    /// state — so a rapid second tap on a different highlight never carries the
+    /// prior highlight's stale draft (R1-6). `initialMode` selects the opening
+    /// sub-state: `.reading` for a normal tap (default); Feature #1121 passes
+    /// `.editing` for the "Edit handoff" auto-open, seeding `noteDraft` from the
+    /// content's note so the editor opens ready to type.
+    func present(_ content: HighlightPopoverContent, initialMode: HighlightPopoverMode = .reading) {
         self.content = content
-        mode = .reading
-        noteDraft = ""
+        mode = initialMode
+        noteDraft = initialMode == .editing ? (content.note ?? "") : ""
         pressedColor = nil
     }
 

--- a/vreader/Views/Reader/HighlightPopoverModifierBody.swift
+++ b/vreader/Views/Reader/HighlightPopoverModifierBody.swift
@@ -83,7 +83,9 @@ struct HighlightPopoverModifier: ViewModifier {
             }
             .onChange(of: viewModel.presented) { _, newValue in
                 if let newValue {
-                    router.present(newValue)
+                    // Feature #1121: open in `.editing` for an Edit-handoff
+                    // auto-open; `.reading` for a normal tap.
+                    router.present(newValue, initialMode: viewModel.presentedInitialMode)
                 } else {
                     router.dismiss()
                 }

--- a/vreader/Views/Reader/ReaderNotifications.swift
+++ b/vreader/Views/Reader/ReaderNotifications.swift
@@ -65,6 +65,11 @@ extension Notification.Name {
     /// torn down in feature #64 WI-10 — this notification is the surviving,
     /// now tap-triggered, entry point.)
     static let readerHighlightTapped = Notification.Name("vreader.readerHighlightTapped")
+    /// Feature #1121: a programmatic "navigate then auto-open the editor" request
+    /// from the HighlightsSheet Edit handoff. Object is a `ReaderHighlightEditRequest`.
+    /// The per-format bridge resolves the highlight after re-render and re-posts a
+    /// `readerHighlightTapped` with `openInEditMode: true`.
+    static let readerHighlightEditRequested = Notification.Name("vreader.readerHighlightEditRequested")
     /// Posted after annotation import completes (bug #88).
     /// Reader containers observe this to re-render persisted highlights.
     static let readerHighlightsDidImport = Notification.Name("vreader.readerHighlightsDidImport")
@@ -423,4 +428,24 @@ struct PDFHighlightNotificationPayload {
 struct ReaderHighlightTapEvent: Sendable, Equatable {
     let highlightID: UUID
     let sourceRect: CGRect
+    /// Feature #1121: when true the unified popover opens directly in `.editing`
+    /// mode (the "Edit handoff" auto-open from the HighlightsSheet Notes menu).
+    /// Defaults false so every existing tap-driven producer + behavior is
+    /// unchanged. A real user tap always leaves this false.
+    var openInEditMode: Bool = false
+}
+
+/// Feature #1121: a programmatic request to navigate to a highlight and then
+/// auto-open its editor. Posted by the HighlightsSheet "Edit" handoff; observed
+/// by the per-format reader bridge, which — once the highlight has re-rendered
+/// in the new scroll/page position — resolves its anchor and re-posts a
+/// `ReaderHighlightTapEvent(openInEditMode: true)`. Carries the book key + a
+/// single-flight token so a stale/superseded request (the user navigated away,
+/// tapped another highlight, or changed book) is ignored (plan-audit M7).
+struct ReaderHighlightEditRequest: Sendable, Equatable {
+    let highlightID: UUID
+    /// The book the request targets — observers ignore a mismatch.
+    let bookFingerprintKey: String
+    /// Monotonic per-session token; a newer request supersedes an older one.
+    let token: UUID
 }

--- a/vreaderTests/Views/Reader/Annotations/HighlightEditHandoffTests.swift
+++ b/vreaderTests/Views/Reader/Annotations/HighlightEditHandoffTests.swift
@@ -1,0 +1,61 @@
+// Purpose: Feature #1121 WI-1 — tests for the pure Edit-handoff routing
+// (`HighlightEditHandoff`) + the `ReaderHighlightTapEvent.openInEditMode` flag
+// that carries the auto-open-in-editing intent through the popover pipeline.
+
+#if canImport(UIKit)
+import Testing
+import Foundation
+import CoreGraphics
+@testable import vreader
+
+@Suite("HighlightEditHandoff (Feature #1121)")
+struct HighlightEditHandoffTests {
+
+    // MARK: - Routing
+
+    @Test("a highlight item → a ReaderHighlightEditRequest for that id/book/token")
+    func highlightRoutesToEditRequest() {
+        let record = makeHighlightRecord(note: "note")
+        let token = UUID()
+        let action = HighlightEditHandoff.action(
+            for: .highlight(record), bookFingerprintKey: "book-key", token: token)
+        #expect(action == .requestHighlightEdit(ReaderHighlightEditRequest(
+            highlightID: record.highlightId, bookFingerprintKey: "book-key", token: token)))
+    }
+
+    @Test("a standalone item → the standalone-note editor route")
+    func standaloneRoutesToNoteEditor() {
+        let record = makeAnnotationRecord()
+        let action = HighlightEditHandoff.action(
+            for: .standalone(record), bookFingerprintKey: "book-key", token: UUID())
+        #expect(action == .openStandaloneNote(annotationID: record.annotationId))
+    }
+
+    // MARK: - ReaderHighlightTapEvent.openInEditMode
+
+    @Test("openInEditMode defaults false — a normal tap is unchanged")
+    func openInEditModeDefaultsFalse() {
+        let event = ReaderHighlightTapEvent(highlightID: UUID(), sourceRect: .zero)
+        #expect(event.openInEditMode == false)
+    }
+
+    @Test("Equatable distinguishes the edit-mode flag")
+    func equalityIncludesFlag() {
+        let id = UUID()
+        let reading = ReaderHighlightTapEvent(highlightID: id, sourceRect: .zero)
+        let editing = ReaderHighlightTapEvent(highlightID: id, sourceRect: .zero, openInEditMode: true)
+        #expect(reading != editing)
+        #expect(reading == ReaderHighlightTapEvent(highlightID: id, sourceRect: .zero, openInEditMode: false))
+    }
+
+    // MARK: - ReaderHighlightEditRequest single-flight identity
+
+    @Test("requests with different tokens are distinct (single-flight supersession)")
+    func requestTokenDistinguishes() {
+        let id = UUID()
+        let r1 = ReaderHighlightEditRequest(highlightID: id, bookFingerprintKey: "k", token: UUID())
+        let r2 = ReaderHighlightEditRequest(highlightID: id, bookFingerprintKey: "k", token: UUID())
+        #expect(r1 != r2)
+    }
+}
+#endif

--- a/vreaderTests/Views/Reader/HighlightPopoverActionRouterTests.swift
+++ b/vreaderTests/Views/Reader/HighlightPopoverActionRouterTests.swift
@@ -127,6 +127,29 @@ struct HighlightPopoverActionRouterTests {
         #expect(router.noteDraft == "")
     }
 
+    // MARK: Feature #1121 — present(initialMode:)
+
+    @Test func present_defaultInitialModeIsReading() {
+        let router = makeRouter()
+        router.present(routerContent(note: "a note"))
+        #expect(router.mode == .reading)
+        #expect(router.noteDraft == "") // reading never seeds a draft
+    }
+
+    @Test func present_editingInitialMode_opensEditingAndSeedsDraftFromNote() {
+        let router = makeRouter()
+        router.present(routerContent(note: "existing note"), initialMode: .editing)
+        #expect(router.mode == .editing)
+        #expect(router.noteDraft == "existing note") // seeded so the editor is ready
+    }
+
+    @Test func present_editingInitialMode_emptyNote_seedsEmptyDraft() {
+        let router = makeRouter()
+        router.present(routerContent(note: nil), initialMode: .editing)
+        #expect(router.mode == .editing)
+        #expect(router.noteDraft == "")
+    }
+
     // MARK: changeColor
 
     @Test func changeColor_success_callsMutatingAndRefreshesContent() async {


### PR DESCRIPTION
Foundational WI-1 of Feature #1121 (auto-open editor after the HighlightsSheet Edit jump). **Non-presenting, strict runtime no-op.** Part of #1121

- `ReaderHighlightTapEvent.openInEditMode` (default false → all producers unchanged)
- `ReaderHighlightEditRequest` { highlightID, bookFingerprintKey, token } + `.readerHighlightEditRequested`
- `router.present(_:initialMode:)` + `VM.presentedInitialMode` thread the intent end-to-end (fixes the plan-audit H1 'flag lost in pipeline')
- `HighlightEditHandoff` pure router

Gate-2 plan audit (2 High + 5 Medium, addressed in scope) + Gate-4 impl audit: **no findings**. Unit-tested. WI-2 (per-format resolve-after-render) + WI-3 (standalone editor) are the behavioral, CU-verified slices. v3.41.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)