### PR TITLE
feat(#1121 WI-2): auto-open the editor after the Edit handoff (format-agnostic)

### DIFF
--- a/.claude/codex-audits/feat-feature-1121-wi2-edit-autoopen-audit.md
+++ b/.claude/codex-audits/feat-feature-1121-wi2-edit-autoopen-audit.md
@@ -1,0 +1,35 @@
+---
+branch: feat/feature-1121-wi2-edit-autoopen
+threadId: codex-exec-2026-05-31-feat1121-wi2
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-31
+---
+
+# Gate-4 audit — Feature #1121 WI-2 (edit-handoff auto-open, behavioral)
+
+`codex exec --sandbox read-only`. The audit confirmed the FORMAT-AGNOSTIC design
+works (`HighlightPopoverPresenter.form` returns `.sheet` for `sourceRect == .zero`;
+`openInEditMode` flows through `presentedInitialMode` → `router.present`). Findings
+(all fixed):
+
+| # | sev | issue | fix |
+|---|---|---|---|
+| 1 | High | the 250ms delayed edit task wasn't superseded — a real tap (or newer edit) during the window then lost to the late-waking edit (token never checked). | `@State pendingEditTask` + `latestEditToken`: each edit cancels the prior task + records its token; the task fires only if `!isCancelled && latestEditToken == request.token`; a real `.readerHighlightTapped` cancels the pending edit + clears the token; `.onDisappear` cancels. |
+| 2 | Medium | `request.bookFingerprintKey` ignored → two same-book readers would both present. | Exposed `viewModel.bookFingerprintKey`; the observer guards `request.bookFingerprintKey == viewModel.bookFingerprintKey` before scheduling. |
+| 3 | Medium | 250ms is a heuristic, not a navigation-settled signal — editor could open mid-jump on slow paths. | **ACCEPTED with rationale**: the `.zero`-rect SHEET form is NOT position-anchored, so opening before the jump fully lands is cosmetically tolerable (the editor isn't pinned to the on-page highlight). A deterministic navigation-settled handoff is a documented follow-up (no generic production signal exists today). |
+| 4 | Low | doc said per-format bridges observe; actually the modifier does. | Comment corrected to describe the modifier + sheet-form path. |
+
+## Design note
+
+WI-2 deliberately replaces the plan's 5-format async rect-resolution (the audit's
+"hard part") with the format-agnostic `.zero`-rect sheet form — one robust slice for
+all formats, no per-format wiring. Trade-off: the editor opens as a bottom sheet, not
+anchored to the on-page highlight. The anchored-card refinement (per-format rect) is a
+cosmetic follow-up, not required for "auto-open the editor in edit mode after the jump."
+
+Tests: `HighlightEditHandoffTests` (routing + `editRequest(from:)` parse),
+`HighlightPopoverActionRouterTests` (`present(initialMode:)`). The runtime open-flow is
+device/CU-verified (post → settle → resolve → present) — ships awaiting CU.
+
+## Verdict: ship-as-is.

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 733
-        MARKETING_VERSION: 3.41.7
+        CURRENT_PROJECT_VERSION: 734
+        MARKETING_VERSION: 3.41.8
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6900,13 +6900,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 733;
+				CURRENT_PROJECT_VERSION = 734;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.7;
+				MARKETING_VERSION = 3.41.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -7050,13 +7050,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 733;
+				CURRENT_PROJECT_VERSION = 734;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.7;
+				MARKETING_VERSION = 3.41.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/ViewModels/HighlightPopoverViewModel.swift
+++ b/vreader/ViewModels/HighlightPopoverViewModel.swift
@@ -49,7 +49,10 @@ final class HighlightPopoverViewModel {
     private(set) var presentedInitialMode: HighlightPopoverMode = .reading
 
     private let persistence: any HighlightLookup
-    private let bookFingerprintKey: String
+    /// The book this reader resolves highlights against. Feature #1121: the
+    /// modifier reads it to ignore an edit-request targeting a different book
+    /// (a same-book multi-window guard; cross-book is already a lookup no-op).
+    let bookFingerprintKey: String
     private let log = Logger(subsystem: "com.vreader.app", category: "HighlightPopover")
 
     /// Monotonic tap token. Incremented on every `handleTap` and every

--- a/vreader/Views/Reader/Annotations/HighlightsSheet+Delete.swift
+++ b/vreader/Views/Reader/Annotations/HighlightsSheet+Delete.swift
@@ -99,11 +99,28 @@ extension HighlightsSheet {
     /// entry point yet).
     func edit(_ item: AnnotationStreamItem) {
         rowState = rowState.dismissed()
+        // Navigate to the passage (the #1080 handoff) …
         switch item {
         case .highlight(let record):  onNavigate(record.locator)
         case .standalone(let record): onNavigate(record.locator)
         }
         onDismiss()
+        // … then Feature #1121 WI-2: request the in-reader editor to auto-open.
+        // For a highlight we post `.readerHighlightEditRequested`; the mounted
+        // `HighlightPopoverModifier` resolves the record (book-scoped) and opens
+        // the unified card in editing mode. A standalone-note editor path is WI-3
+        // (still navigate-only). The book key + a single-flight token scope/order
+        // the request (HighlightEditHandoff + the VM's latest-token supersession).
+        switch HighlightEditHandoff.action(
+            for: item, bookFingerprintKey: bookFingerprintKey, token: UUID()
+        ) {
+        case .requestHighlightEdit(let request):
+            NotificationCenter.default.post(
+                name: .readerHighlightEditRequested, object: request
+            )
+        case .openStandaloneNote:
+            break // WI-3
+        }
     }
 
     // MARK: - Delete plumbing

--- a/vreader/Views/Reader/HighlightPopoverModifier.swift
+++ b/vreader/Views/Reader/HighlightPopoverModifier.swift
@@ -96,6 +96,13 @@ enum HighlightPopoverRequest {
     nonisolated static func event(from notification: Notification) -> ReaderHighlightTapEvent? {
         notification.object as? ReaderHighlightTapEvent
     }
+
+    /// Feature #1121: extracts the `ReaderHighlightEditRequest` from a
+    /// `.readerHighlightEditRequested` notification (the Edit-handoff auto-open).
+    /// `nil` for a mis-posted / nil object.
+    nonisolated static func editRequest(from notification: Notification) -> ReaderHighlightEditRequest? {
+        notification.object as? ReaderHighlightEditRequest
+    }
 }
 
 // MARK: - Share channel

--- a/vreader/Views/Reader/HighlightPopoverModifierBody.swift
+++ b/vreader/Views/Reader/HighlightPopoverModifierBody.swift
@@ -49,6 +49,14 @@ struct HighlightPopoverModifier: ViewModifier {
     /// present the share sheet only once the popover sheet has fully
     /// dismissed. `nil` ⇒ a plain dismissal.
     @State private var pendingPostSheetDismiss: (@MainActor () -> Void)?
+    /// Feature #1121 WI-2: the in-flight Edit-handoff auto-open task (a settle
+    /// delay before opening the editor). Cancelled + replaced by a newer edit
+    /// request, and cancelled by a real highlight tap, so a stale edit can never
+    /// win over what the user is doing now.
+    @State private var pendingEditTask: Task<Void, Never>?
+    /// The token of the latest accepted edit request — a delayed task only fires
+    /// if it still matches (single-flight supersession, audit High).
+    @State private var latestEditToken: UUID?
 
     let theme: ReaderThemeV2
     /// Optional chapter/location string for the meta row.
@@ -79,8 +87,40 @@ struct HighlightPopoverModifier: ViewModifier {
                 NotificationCenter.default.publisher(for: .readerHighlightTapped)
             ) { note in
                 guard let event = HighlightPopoverRequest.event(from: note) else { return }
+                // A real tap supersedes any pending Edit-handoff auto-open (audit High).
+                pendingEditTask?.cancel(); pendingEditTask = nil; latestEditToken = nil
                 Task { await viewModel.handleTap(event, chapter: chapter) }
             }
+            .onReceive(
+                NotificationCenter.default.publisher(for: .readerHighlightEditRequested)
+            ) { note in
+                // Feature #1121 WI-2: the HighlightsSheet "Edit" handoff. Open the
+                // unified card in editing mode for the requested highlight. Book
+                // guard: ignore a request for a different book (a same-book
+                // multi-window guard; cross-book is already a lookup no-op).
+                // `sourceRect: .zero` → the card's sheet form (no per-format anchor
+                // needed) → format-agnostic. A short settle lets the navigation
+                // land; the task is cancellable + token-guarded so a stale edit
+                // never wins over a newer edit or a real tap (audit High).
+                guard let request = HighlightPopoverRequest.editRequest(from: note),
+                      request.bookFingerprintKey == viewModel.bookFingerprintKey
+                else { return }
+                pendingEditTask?.cancel()
+                latestEditToken = request.token
+                pendingEditTask = Task {
+                    try? await Task.sleep(nanoseconds: 250_000_000)
+                    guard !Task.isCancelled, latestEditToken == request.token else { return }
+                    await viewModel.handleTap(
+                        ReaderHighlightTapEvent(
+                            highlightID: request.highlightID,
+                            sourceRect: .zero,
+                            openInEditMode: true
+                        ),
+                        chapter: chapter
+                    )
+                }
+            }
+            .onDisappear { pendingEditTask?.cancel(); pendingEditTask = nil }
             .onChange(of: viewModel.presented) { _, newValue in
                 if let newValue {
                     // Feature #1121: open in `.editing` for an Edit-handoff

--- a/vreader/Views/Reader/ReaderNotifications.swift
+++ b/vreader/Views/Reader/ReaderNotifications.swift
@@ -437,11 +437,12 @@ struct ReaderHighlightTapEvent: Sendable, Equatable {
 
 /// Feature #1121: a programmatic request to navigate to a highlight and then
 /// auto-open its editor. Posted by the HighlightsSheet "Edit" handoff; observed
-/// by the per-format reader bridge, which — once the highlight has re-rendered
-/// in the new scroll/page position — resolves its anchor and re-posts a
-/// `ReaderHighlightTapEvent(openInEditMode: true)`. Carries the book key + a
-/// single-flight token so a stale/superseded request (the user navigated away,
-/// tapped another highlight, or changed book) is ignored (plan-audit M7).
+/// by the mounted `HighlightPopoverModifier`, which — after a short navigation
+/// settle — resolves the highlight (book-scoped) and opens the unified card in
+/// editing mode via the `.zero`-rect sheet form (format-agnostic; no per-format
+/// anchor rect needed). Carries the book key + a single-flight token so a
+/// stale/superseded request (the user tapped another highlight, triggered a
+/// newer edit, or the request targets a different book) is ignored.
 struct ReaderHighlightEditRequest: Sendable, Equatable {
     let highlightID: UUID
     /// The book the request targets — observers ignore a mismatch.

--- a/vreaderTests/Views/Reader/Annotations/HighlightEditHandoffTests.swift
+++ b/vreaderTests/Views/Reader/Annotations/HighlightEditHandoffTests.swift
@@ -57,5 +57,23 @@ struct HighlightEditHandoffTests {
         let r2 = ReaderHighlightEditRequest(highlightID: id, bookFingerprintKey: "k", token: UUID())
         #expect(r1 != r2)
     }
+
+    // MARK: - WI-2: editRequest(from:) notification parse
+
+    @Test("editRequest(from:) round-trips the posted ReaderHighlightEditRequest")
+    func editRequestParseRoundTrips() {
+        let req = ReaderHighlightEditRequest(
+            highlightID: UUID(), bookFingerprintKey: "book-key", token: UUID())
+        let note = Notification(name: .readerHighlightEditRequested, object: req)
+        #expect(HighlightPopoverRequest.editRequest(from: note) == req)
+    }
+
+    @Test("editRequest(from:) returns nil for a mis-posted object")
+    func editRequestParseRejectsWrongType() {
+        let note = Notification(name: .readerHighlightEditRequested, object: "not a request")
+        #expect(HighlightPopoverRequest.editRequest(from: note) == nil)
+        let nilNote = Notification(name: .readerHighlightEditRequested, object: nil)
+        #expect(HighlightPopoverRequest.editRequest(from: nilNote) == nil)
+    }
 }
 #endif


### PR DESCRIPTION
Makes Feature #1121 behavioral. `edit()` posts `.readerHighlightEditRequested`; the mounted popover modifier resolves the book-scoped record and opens the unified card in editing mode via the `.zero`-rect **sheet form** — format-agnostic, covering all 5 formats without per-format anchor-rect resolution (the plan-audit's 'hard part'). Part of #1121

Gate-4 audit-hardened: cancellable + token-guarded pending task (real tap / newer edit supersedes; .onDisappear cancels), book guard, doc fix. The 250ms settle is accepted (sheet form isn't position-anchored). Unit-tested. Runtime open-flow is device/CU-verified → ships awaiting-device-verification. WI-3 = standalone-note editor path. v3.41.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)