### PR TITLE
docs(design): land standalone-note editor presentation (#1296 / #1121 WI-3)

### DIFF
--- a/dev-docs/designs/vreader-fidelity-v1/chats/chat12.md
+++ b/dev-docs/designs/vreader-fidelity-v1/chats/chat12.md
@@ -1,0 +1,136 @@
+# GitHub Issues Discussion
+
+_Started 2026-05-31 01:04 UTC_
+
+---
+
+## User
+
+https://github.com/lllyys/vreader/issues/1296 https://github.com/lllyys/vreader/issues/1292
+
+## Assistant
+
+_[tool: list_files]_
+
+_[tool: read_file]_
+
+Let me fetch those two issues to understand what's being requested.
+
+_[tool: web_fetch]_
+
+_[tool: web_fetch]_
+
+I now understand both issues. Let me explore the existing project's patterns before building. The user is viewing the Slider Track Canvas — and issue #1292 explicitly references that the slider-track facet already shipped via a sibling design pass. Let me study the established conventions.Let me study the slider-track artboards (the sibling design that shipped) and the themes file — these are the closest precedent for issue #1292.
+
+_[tool: read_file]_
+
+_[tool: read_file]_
+
+_[tool: read_file]_
+
+_[tool: read_file]_
+
+This is a well-established pattern: each `needs-design` issue gets a "decision canvas" — DesignCanvas artboards with live-measured WCAG ratios, before/after, candidates, across-themes, and a binding spec card. I'll match it exactly for both issues. Let me read the canvas/frame APIs and the components involved in #1296 (the standalone-note editor flow).
+
+_[tool: read_file]_
+
+_[tool: read_file]_
+
+Excellent — I have the full pattern now. Let me read the components I need to faithfully recreate for both issues: the unified notes card / highlights sheet / annotation editor (for #1296), and the Display panel list chrome (for #1292).
+
+_[tool: read_file]_
+
+Now let me read the panels file — it holds the `Sheet` component, the Display panel, and the List section headers/footers that issue #1292 is about.
+
+_[tool: read_file]_
+
+I have a thorough understanding of both issues and the codebase conventions. Let me quickly check the existing note-actions / delete menu pattern (the `⋯` menu referenced in #1296) so my standalone-note card menu matches.
+
+_[tool: read_file]_
+
+_[tool: grep]_
+
+The `vreader-notes-delete.jsx` (issue #1103) already built `HighlightsSheetV4`, `StandaloneNoteCardV4`, and `NotesActionMenu` with the `⋯ → Edit note` flow — and even notes the open question my issue #1296 resolves. Let me check the existing canvas HTML shells to copy the exact dependency-include pattern.
+
+_[tool: read_file]_
+
+Let me peek at how the delete canvas artboards mount `HighlightsSheetV4` inside a phone frame, so my #1296 storyboard matches.
+
+_[tool: update_todos]_
+
+I have a complete picture — the conventions, components, data, and dependency-include pattern are all clear. These are two specific, well-scoped design decisions in a mature, established "decision-canvas" system (this is the 12th+ such canvas). I won't ask questions; I'll match the precedent exactly. Let me lay out the plan.
+
+_[tool: write_file]_
+
+Starting with **#1292** (secondary-text AA contrast) — it's the direct sibling of the slider-track canvas the user is viewing. Writing the artboards file with live-measured WCAG ratios.Now the HTML shell for #1292:
+
+_[tool: write_file]_
+
+Let me verify #1292 loads cleanly before moving on.
+
+_[tool: show_html]_
+
+_[tool: show_html]_
+
+_[tool: get_webview_logs]_
+
+_[tool: save_screenshot]_
+
+Clean. Let me screenshot to confirm the layout.
+
+_[tool: view_image]_
+
+_[tool: update_todos]_
+
+#1292 renders beautifully — the measured ratios (3.82 Paper, 3.37 Sepia) match the issue exactly, and the AFTER panels are visibly more legible. Marking done and moving to #1296.
+
+_[tool: write_file]_
+
+Now **#1296** — the standalone-note editor presentation. This is the storyboard-based decision (Option A "edit over the sheet" vs Option B "dismiss + navigate"). I'll reuse `HighlightsSheetV4`, `NotesActionMenu`, `FakeIOSKeyboard`, `NoteSavedToast`, and `DiscardNoteAlert`, and build a faithful standalone-note editor surface. Writing the artboards file:Now the HTML shell for #1296, loading the full dependency chain (icons, panels, the V4 notes sheet, the note editor):
+
+_[tool: write_file]_
+
+_[tool: show_html]_
+
+_[tool: get_webview_logs]_
+
+Clean. Let me screenshot the decision and storyboard sections to confirm the stacked-sheet rendering and overall layout.
+
+_[tool: save_screenshot]_
+
+_[tool: view_image]_
+
+_[tool: str_replace_edit]_
+
+Looks great — the editor is clearly stacked over the dimmed list. One nit: the "Edit note" title wraps to two lines (the center header group is narrow). Let me fix that with `nowrap`.
+
+_[tool: show_html]_
+
+Let me confirm the title fix and spot-check a storyboard section by panning the canvas.
+
+_[tool: save_screenshot]_
+
+_[tool: view_image]_
+
+_[tool: delete_file]_
+
+Both canvases are complete and render faithfully — the "Edit note" title is now on one line, the CJK/pinyin keyboard, saving state, long-note scroll, and spec card all read correctly. Let me clean up the temp screenshots and finalize.
+
+_[tool: update_todos]_
+
+_[tool: done]_
+
+_[tool: fork_verifier_agent]_
+
+Both `needs-design` issues are resolved as decision canvases, matching the project's established pattern (live-measured contrast, before/after, candidates, across-themes, binding spec card).
+
+**#1292 — Paper/Sepia secondary-text AA contrast** → `VReader Secondary Text Canvas.html`
+Decision: bump the light-family `sub` token from **ink @ 55% → ink @ 68%**. One rule derived from each theme's ink (mirroring #1273's rail), it's the smallest unified alpha that clears WCAG AA in the binding case — Sepia at **4.88:1**, Paper at **5.81:1** — while staying clearly lighter than primary ink. All ratios are computed live in-canvas (current values reproduce the issue's 3.82 / 3.36). Dark/OLED are measured honestly (~3.7:1, also under AA) and flagged as an out-of-scope follow-up rather than silently claimed fine.
+
+**#1296 — Standalone-note editor presentation (WI-3)** → `VReader Standalone Note Editor Canvas.html`
+Decision: **Option A — present `AnnotationEditSheet` over the HighlightsSheet, non-dismissing**, returning to the list on Save. Both options are storyboarded 4-up; a decision matrix and a "two intents" card make the case: a standalone note is anchorless, so the "after the jump" rationale (which exists for highlights so the popover can anchor to the visible passage) does nothing here. A keeps the user in their triage context, reuses the existing sheet primitive, and needs no new reader-level mount. The spec card defines the exact plumbing (`edit().standalone → editAnnotation(id)` observed at sheet level → `updateAnnotation` → dismiss to list).
+
+A background verifier is sweeping both. Two notes:
+- The recommended values are computed/displayed, but a maintainer should confirm the 68% weight against any other `sub`-consuming surfaces before merging globally (the spec calls out the considered-and-rejected `subAA` alternative if a scoped token is preferred).
+- These present the design decision; both still carry the `needs-design` framing — they don't ship code.
+

--- a/dev-docs/designs/vreader-fidelity-v1/project/VReader Standalone Note Editor Canvas.html
+++ b/dev-docs/designs/vreader-fidelity-v1/project/VReader Standalone Note Editor Canvas.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>VReader — Standalone-note editor presentation (#1296)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,300..900;1,8..60,300..900&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0; padding: 0; background: #f0eee9;
+    font-family: 'Inter', -apple-system, system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  .hide-scroll::-webkit-scrollbar { display: none; }
+  .hide-scroll { scrollbar-width: none; -ms-overflow-style: none; }
+  button { font-family: inherit; }
+  button:focus { outline: none; }
+  code { font-family: "SF Mono", "JetBrains Mono", Menlo, monospace; }
+
+  @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  @keyframes popIn { from { transform: translate(-50%,-50%) scale(0.9); opacity: 0; } to { transform: translate(-50%,-50%) scale(1); opacity: 1; } }
+  @keyframes slideUp { from { transform: translateY(100%); } to { transform: translateY(0); } }
+  @keyframes ndMenuIn { from { transform: scale(0.94) translateY(-4px); opacity: 0; } to { transform: scale(1) translateY(0); opacity: 1; } }
+  @keyframes seCaret { 50% { opacity: 0; } }
+</style>
+<template id="__bundler_thumbnail">
+  <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <rect width="200" height="200" fill="#1a1815"/>
+    <!-- dimmed list behind -->
+    <rect x="30" y="30" width="140" height="150" rx="10" fill="#3a352e"/>
+    <!-- editor sheet over -->
+    <rect x="22" y="78" width="156" height="92" rx="12" fill="#fcf8f0"/>
+    <rect x="86" y="86" width="28" height="4" rx="2" fill="#1d1a14" opacity="0.18"/>
+    <rect x="34" y="100" width="8" height="8" rx="2" fill="#8c2f2f" opacity="0.5"/>
+    <rect x="48" y="102" width="40" height="4" rx="2" fill="#5a554a"/>
+    <rect x="34" y="120" width="120" height="4" rx="2" fill="#1d1a14" opacity="0.55"/>
+    <rect x="34" y="130" width="104" height="4" rx="2" fill="#1d1a14" opacity="0.55"/>
+    <rect x="138" y="86" width="32" height="14" rx="7" fill="#8c2f2f"/>
+    <text x="100" y="194" font-family="Inter, sans-serif" font-size="11" font-weight="700" fill="#d8d2c5" text-anchor="middle" letter-spacing="2">#1296 WI-3</text>
+  </svg>
+</template>
+</head>
+<body>
+
+<div id="root"></div>
+
+<!-- React + Babel -->
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<!-- Canvas + base -->
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="vreader-themes.jsx"></script>
+<script type="text/babel" src="vreader-icons.jsx"></script>
+<script type="text/babel" src="vreader-panels.jsx"></script>
+
+<!-- Surfaces this design depends on -->
+<script type="text/babel" src="vreader-annotations.jsx"></script>
+<script type="text/babel" src="vreader-notes-unified.jsx"></script>
+<script type="text/babel" src="vreader-highlight-popover.jsx"></script>
+<script type="text/babel" src="vreader-note-editor.jsx"></script>
+<script type="text/babel" src="vreader-notes-delete.jsx"></script>
+
+<!-- This issue's design -->
+<script type="text/babel" src="standalone-note-editor-artboards.jsx"></script>
+
+<script type="text/babel">
+  const root = ReactDOM.createRoot(document.getElementById('root'));
+  root.render(<StandaloneNoteEditorCanvas/>);
+</script>
+</body>
+</html>

--- a/dev-docs/designs/vreader-fidelity-v1/project/design-notes/standalone-note-editor.md
+++ b/dev-docs/designs/vreader-fidelity-v1/project/design-notes/standalone-note-editor.md
@@ -1,0 +1,67 @@
+# Standalone-note editor presentation — Edit handoff WI-3 (#1296 · Feature #1121)
+
+> Source of truth (design): `VReader Standalone Note Editor Canvas.html` → `standalone-note-editor-artboards.jsx`.
+> Chat transcript: `chats/chat12.md`.
+> Resolves the `needs-design` issue [#1296](https://github.com/lllyys/vreader/issues/1296) (design dependency of Feature [#1121](https://github.com/lllyys/vreader/issues/1121) WI-3).
+> Status: **design landed — implementation deferred** (recorded, not built; see "Scope reality" below).
+
+## The question
+
+Feature #1121 (Edit handoff). The HIGHLIGHT path (WI-1/WI-2, shipped) opens the editor "after the jump":
+tap Edit → dismiss the sheet → navigate to the highlight → the popover modifier auto-opens the editor over
+the page. A STANDALONE note has no anchored passage and no reader-level editor mount point, so #1121/#1296
+flagged an open presentation question: edit **(A) over the HighlightsSheet (non-dismissing)** or
+**(B) after dismissing + navigating to the locator**.
+
+## Decision (binding): Option A — edit over the sheet
+
+When the user taps `⋯ → Edit` on a standalone-note card, present `AnnotationEditSheet` as a sheet stacked
+**over** the HighlightsSheet, non-dismissing. After Save, the editor dismisses back to the list, in place.
+
+Rationale:
+- The entry context is **triage, not reading** — Edit is a "fix the wording" micro-task; tearing down the
+  sheet to fly to the reader is disproportionate. A returns the user exactly where they were (same filter,
+  same scroll).
+- A standalone note has **no passage to re-anchor to**. The highlight path navigates because a highlight's
+  note is *about* a visible passage; for a standalone note the jump reveals ordinary body text the note
+  doesn't quote — the jump does no work for the edit.
+- Clean gesture grammar: tap the card body = "go read there" (the existing `onJump`, unchanged);
+  `⋯ → Edit` = "change the text" (in place). B collapses both into navigate-then-edit.
+- The consistency that matters — the **editor surface and the gesture** — is identical in both paths; only
+  the container differs, because the data differs.
+
+## Presentation contract (from the spec card)
+
+- **Trigger**: `edit()`'s `.standalone` branch posts an `editAnnotation(id)` request, observed at the
+  **HighlightsSheet** level (not the reader). The sheet stays mounted.
+- **Present**: the observer presents `AnnotationEditSheet` over the list (`.sheet`, keyboard-anchored),
+  seeded with `initialContent: annotation.content`. No dismiss, no navigation.
+- **Save**: `onSave` → `updateAnnotation(annotationId:content:)` → dismiss back to the list; the row reflects
+  the new text in place; a "Note saved" toast confirms.
+- **Cancel**: clean draft → dismiss. Dirty draft → `DiscardNoteAlert` (#914). Empty content is not a valid
+  standalone note — Save reads "Clear" and routes through the Delete confirm.
+- **Locator strip**: replaces the highlight excerpt — chapter · page + a "Standalone note — no quoted
+  passage" hint.
+- **States covered**: editing existing · idle, dirty/Save, saving, discard-confirm, long note (scrolls),
+  CJK/IME, sepia, dark.
+
+## Scope reality (read before implementing — the design's premise is partly false)
+
+The design/issue call WI-3 "small plumbing" on the basis that the surfaces are **all committed**. A code
+audit (2026-05-31) found that is **only partly true**:
+
+| Design assumes committed | Reality |
+| --- | --- |
+| `AnnotationEditSheet` = the designed editor (locator strip, "Standalone note" hint, word-count footer, Delete-note, cream keyboard-anchored sheet) | A minimal **un-wired stub** — `NavigationStack` + `TextEditor` titled "Edit Annotation", Cancel/Save only. None of the designed chrome. (`vreader/Views/Annotations/AnnotationEditSheet.swift`) |
+| `DiscardNoteAlert` (#914) | **Does not exist** in the codebase |
+| "Note saved" toast | **Does not exist** |
+
+What *is* ready and small: the flow plumbing. `edit()`'s `.standalone` branch is a `break` stub
+(`HighlightsSheet+Delete.swift:122`); `HighlightEditHandoff.action(for:)` already returns
+`.openStandaloneNote(annotationID:)`; `updateAnnotation(annotationId:content:)` exists
+(`PersistenceActor+Annotations.swift:59`, VM wrapper `AnnotationListViewModel.swift:91`); a RED routing test
+exists (`HighlightEditHandoffTests.standaloneRoutesToNoteEditor`).
+
+So implementing the **designed** WI-3 is a real UI slice (build the editor surface to the design + a discard
+alert + a toast + the over-the-sheet plumbing), not the few-line plumbing the issue estimated. Treat it as a
+feature-workflow effort, not a stub fill-in, when it's picked up.

--- a/dev-docs/designs/vreader-fidelity-v1/project/standalone-note-editor-artboards.jsx
+++ b/dev-docs/designs/vreader-fidelity-v1/project/standalone-note-editor-artboards.jsx
@@ -1,0 +1,663 @@
+// Canvas artboards · issue #1296 — standalone-note editor PRESENTATION
+// for the Edit handoff (feature #1121 WI-3).
+//
+// What's already built (not in scope here):
+//   • AnnotationEditSheet { initialContent, onSave } — the editor surface.
+//   • updateAnnotation(annotationId:content:) — the persistence call.
+//   • StandaloneNoteCardV4 + NotesActionMenu (⋯ → Edit · Copy · Delete) — #1103.
+//   • The HIGHLIGHT Edit path (WI-1/WI-2, shipped v3.41.7/.8): tap Edit →
+//     dismiss the sheet → navigate to the highlight → the existing popover
+//     modifier auto-opens the editor over the page. "After the jump."
+//
+// The open question (#1121 / #1296): a STANDALONE note has no anchored
+// highlight and no reader-level editor mount point. When the user taps
+// ⋯ → Edit on a standalone-note card, where does AnnotationEditSheet present?
+//     A) OVER the HighlightsSheet, non-dismissing (sheet-over-sheet), or
+//     B) AFTER dismissing the sheet + navigating to the locator (reader-level).
+// The design's stated intent was (B) "after the jump"; the issue flags that
+// (A) "may be cleaner." Rule 51: this is the design call to make.
+//
+// ─────────────────────────────────────────────────────────────
+// DECISION: A — present AnnotationEditSheet as a sheet stacked OVER the
+// HighlightsSheet, non-dismissing. After Save, the editor dismisses back to
+// the list, in place. Rationale, in §5:
+//   1. The entry context is TRIAGE, not reading. Edit is a "fix the wording"
+//      micro-task; tearing down the sheet to fly to the reader is
+//      disproportionate. A returns the user exactly where they were.
+//   2. A standalone note has NO passage to re-anchor to. The reason the
+//      highlight path navigates is that a highlight's note is ABOUT a visible
+//      passage — the popover anchors there. Navigating for a standalone note
+//      reveals ordinary body text the note doesn't quote; the jump does no
+//      work for the edit.
+//   3. Clean gesture grammar: tap the card body = "go read there" (jump);
+//      ⋯ → Edit = "change the text" (in place). B collapses both into
+//      navigate-then-edit and makes Edit redundant with tap-to-jump.
+//   4. Lighter to build: reuses the dim + keyboard-anchored sheet primitive
+//      the editor already is. B needs a new reader-level observer + mount.
+//   5. The consistency that matters — the editor SURFACE — is identical in
+//      both paths. Only the container differs, because the data differs.
+
+// ─────────────────────────────────────────────────────
+// Geometry + sample data
+// ─────────────────────────────────────────────────────
+const SE_PHONE_W = 402;
+const SE_PHONE_H = 720;
+const SE_KB = 291;
+
+const SE_SERIF = '"Source Serif 4", Georgia, serif';
+const SE_FONT = '"Inter", system-ui, -apple-system, sans-serif';
+
+const SE_NOTE = {
+  id: 's1', chapter: 'Chapter 6', page: 47, date: 'Apr 18',
+  body: "Charlotte's pragmatism here is the inverse of Elizabeth's — \"happiness in marriage is entirely a matter of chance.\" Worth re-reading next to Lizzy's reaction.",
+};
+const SE_NOTE_EDITED = {
+  ...SE_NOTE,
+  body: SE_NOTE.body + ' Cross-ref the Collins proposal in Ch. 19 — same logic, played for comedy.',
+};
+const SE_NOTE_LONG = {
+  id: 's-long', chapter: 'Chapter 6', page: 47, date: 'Apr 18',
+  body: "Charlotte's thesis — and the novel's most chilling line, almost throwaway. Three things to track on a re-read:\n\n1. Austen plants it BEFORE Charlotte commits, so it can't be read as post-hoc rationalisation.\n2. It mirrors the opening line — a universal-truth-stated-as-fact the book half-endorses, half-undercuts.\n3. Compare with Elizabeth's rebuttal on the next page; the novel never resolves it, just lets both views stand.",
+};
+const SE_NOTE_CJK = {
+  id: 's-zh', chapter: '第六章', page: 47, date: '四月 18',
+  body: '夏洛特的实用主义恰是伊丽莎白的反面——"婚姻幸福全凭运气"。这句几乎是随口道出，却是全书最冷峻的一句。值得与丽兹在下一页的反驳对照重读。',
+};
+
+const SE_STANDALONES = [
+  SE_NOTE,
+  { id: 's2', kind: 'standalone', chapter: 'Chapter 11', page: 89, date: 'Yesterday',
+    body: "Note: the ball scene is the structural midpoint of the first volume. Track Darcy's reluctance vs. his actions." },
+];
+const SE_HIGHLIGHTS = [
+  { id: 'h1', kind: 'highlight',
+    text: 'It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife.',
+    color: 'yellow', chapter: 'Chapter 1', page: 1, date: 'Apr 12' },
+  { id: 'h3', kind: 'highlight', text: 'She is tolerable, but not handsome enough to tempt me.',
+    color: 'blue', chapter: 'Chapter 3', page: 18, date: 'Apr 15',
+    note: 'The line that sets up the whole arc.' },
+];
+
+function seDanger(t) { return t.isDark ? '#e89090' : '#a83a3a'; }
+
+// ─────────────────────────────────────────────────────
+// Phone frame
+// ─────────────────────────────────────────────────────
+function SEPhone({ themeKey = 'paper', children }) {
+  const t = THEMES[themeKey];
+  return (
+    <div style={{
+      width: SE_PHONE_W, height: SE_PHONE_H, position: 'relative', overflow: 'hidden',
+      background: t.bg, borderRadius: 18,
+      boxShadow: '0 0 0 1px rgba(255,255,255,0.04), 0 14px 40px rgba(0,0,0,0.35)',
+    }}>
+      {children}
+    </div>
+  );
+}
+
+// Reader page at the note's locator (Chapter 6). Standalone notes anchor to a
+// LOCATOR, not a passage — so there's no highlight to land on. A thin accent
+// tick in the margin marks where the note lives.
+function SEReaderCh6({ themeKey = 'paper', showLocator = true, dim = 0 }) {
+  const t = THEMES[themeKey];
+  return (
+    <div style={{ position: 'absolute', inset: 0, background: t.bg }}>
+      <div style={{
+        height: 44, display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between',
+        padding: '0 18px 4px', fontSize: 12, color: t.ink, fontWeight: 600, opacity: 0.75,
+      }}>
+        <span>9:41</span><span style={{ letterSpacing: 1 }}>•••</span>
+      </div>
+      <div style={{
+        fontFamily: SE_SERIF, fontSize: 10.5, color: t.sub, letterSpacing: 2,
+        textTransform: 'uppercase', textAlign: 'center', margin: '8px 0 16px',
+      }}>Chapter 6 · p. 47</div>
+      <div style={{ position: 'relative', padding: '0 28px' }}>
+        {showLocator && (
+          <div style={{ position: 'absolute', left: 10, top: 4, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3 }}>
+            <div style={{ width: 9, height: 9, borderRadius: 3, background: `${t.accent}22`, color: t.accent, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <svg width="5" height="6" viewBox="0 0 7 8"><path d="M0.5 0.5h5l1 1v6h-6z" fill="currentColor" opacity="0.9"/></svg>
+            </div>
+            <div style={{ width: 2, height: 64, borderRadius: 1, background: `${t.accent}55` }} />
+          </div>
+        )}
+        <p style={{
+          fontFamily: SE_SERIF, fontSize: 15, lineHeight: 1.62, color: t.ink, margin: 0, textAlign: 'justify',
+        }}>
+          Sir William Lucas had been formerly in trade in Meryton, where he had made a tolerable
+          fortune and risen to the honour of knighthood. "Happiness in marriage is entirely a
+          matter of chance," said Charlotte. The distinction had perhaps been felt too strongly,
+          and the family removed to a house about a mile from the town, denominated from that
+          period Lucas Lodge.
+        </p>
+      </div>
+      {dim > 0 && <div style={{ position: 'absolute', inset: 0, background: `rgba(0,0,0,${dim})` }} />}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// The HighlightsSheet review surface (reuses the committed V4 sheet/cards)
+// ─────────────────────────────────────────────────────
+function SEList({ themeKey = 'paper', filter = 'notes', forcedRowId = null, forcedState = null, standalones = SE_STANDALONES }) {
+  const t = THEMES[themeKey];
+  return (
+    <SEPhone themeKey={themeKey}>
+      <SEReaderCh6 themeKey={themeKey} showLocator={false} />
+      <HighlightsSheetV4 theme={t}
+        highlights={SE_HIGHLIGHTS} standalones={standalones}
+        filter={filter} forcedRowId={forcedRowId} forcedState={forcedState}
+        onClose={() => {}} onJump={() => {}} />
+    </SEPhone>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// StandaloneNoteEditSheet — the AnnotationEditSheet surface, drawn for a
+// standalone (anchorless) note: same sheet chrome as the highlight-note
+// editor, but a LOCATOR strip replaces the quoted-passage excerpt.
+// Body is rendered as a static div (artboards don't type) with an optional
+// faux caret. Reuses the committed FakeIOSKeyboard.
+// ─────────────────────────────────────────────────────
+function SEPin({ t, size = 8 }) {
+  return (
+    <div style={{
+      width: size + 4, height: size + 4, borderRadius: 3,
+      background: `${t.accent}22`, color: t.accent,
+      display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+    }}>
+      <svg width={size - 1} height={size} viewBox="0 0 7 8">
+        <path d="M0.5 0.5h5l1 1v6h-6z" fill="currentColor" opacity="0.9"/>
+        <path d="M1.8 3h3.2M1.8 4.6h2.2" stroke={t.isDark ? '#26231f' : '#fcf8f0'} strokeWidth="0.7"/>
+      </svg>
+    </div>
+  );
+}
+
+function SESaveBtn({ t, label, disabled, destructive, saving }) {
+  const bg = disabled ? (t.isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.04)')
+    : destructive ? seDanger(t) : t.accent;
+  const fg = disabled ? (t.isDark ? 'rgba(216,210,197,0.4)' : 'rgba(29,26,20,0.35)') : '#fff';
+  return (
+    <div style={{
+      padding: '7px 16px', borderRadius: 100, background: bg, color: fg,
+      fontFamily: SE_FONT, fontSize: 14, fontWeight: 600,
+      display: 'inline-flex', alignItems: 'center', gap: 6, minWidth: 60, justifyContent: 'center',
+    }}>
+      {saving && <span style={{ width: 12, height: 12, borderRadius: 6, border: `1.5px solid ${fg}55`, borderTopColor: fg, display: 'inline-block', animation: 'spin 0.7s linear infinite' }} />}
+      {label}
+    </div>
+  );
+}
+
+function SEStandaloneEditSheet({
+  themeKey = 'paper', note = SE_NOTE, draft = null,
+  title, state = 'idle', forceDirty = null, isNew = false,
+  showKeyboard = true, keyboardHeight = SE_KB, dimOpacity = 0.32,
+  showCaret = false, cjk = false, scroll = false, inputSource = 'English',
+}) {
+  const t = THEMES[themeKey];
+  const original = note?.body || '';
+  const text = draft != null ? draft : original;
+  const dirty = forceDirty != null ? forceDirty : (text !== original);
+  const willClear = original && (text || '').trim() === '';
+  const sheetBottom = showKeyboard ? keyboardHeight : 0;
+  const label = state === 'saving' ? 'Saving…' : willClear ? 'Clear' : 'Save';
+  const ttl = title || (isNew ? 'New note' : 'Edit note');
+  const bodyFont = cjk ? '"Source Han Serif SC", "Songti SC", "Noto Serif SC", ' + SE_SERIF : SE_SERIF;
+
+  return (
+    <>
+      <div style={{ position: 'absolute', inset: 0, zIndex: 200, background: `rgba(0,0,0,${dimOpacity})` }} />
+      <div style={{
+        position: 'absolute', left: 0, right: 0, bottom: sheetBottom, zIndex: 205,
+        borderTopLeftRadius: 18, borderTopRightRadius: 18,
+        background: t.isDark ? '#26231f' : '#fcf8f0',
+        boxShadow: '0 -10px 32px rgba(0,0,0,0.32)',
+        display: 'flex', flexDirection: 'column',
+        maxHeight: `calc(100% - ${sheetBottom + 40}px)`,
+        height: scroll ? `calc(100% - ${sheetBottom + 40}px)` : undefined,
+        overflow: 'hidden',
+      }}>
+        {/* grabber */}
+        <div style={{ display: 'flex', justifyContent: 'center', padding: '8px 0 4px' }}>
+          <div style={{ width: 36, height: 5, borderRadius: 3, background: t.isDark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.12)' }} />
+        </div>
+        {/* header */}
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          padding: '6px 12px 10px', borderBottom: `0.5px solid ${t.rule}`,
+        }}>
+          <div style={{ fontFamily: SE_FONT, fontSize: 15, color: t.accent, padding: '6px 8px' }}>Cancel</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <SEPin t={t} />
+            <div style={{ fontFamily: SE_SERIF, fontSize: 16, fontWeight: 600, color: t.ink, whiteSpace: 'nowrap' }}>{ttl}</div>
+          </div>
+          <SESaveBtn t={t} label={label} disabled={!dirty || state === 'saving'} destructive={willClear} saving={state === 'saving'} />
+        </div>
+
+        {/* locator strip — stands in for the highlight excerpt; a standalone
+            note has no quoted passage, only a chapter/page anchor. */}
+        <div style={{
+          padding: '11px 18px 10px', display: 'flex', gap: 10, alignItems: 'center',
+          borderBottom: `0.5px solid ${t.rule}`,
+          background: t.isDark ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.015)',
+        }}>
+          <SEPin t={t} size={10} />
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 10, letterSpacing: 0.8, textTransform: 'uppercase', color: t.sub, fontWeight: 600 }}>
+              {note?.chapter} · p. {note?.page}
+            </div>
+            <div style={{ fontSize: 12, color: t.sub, opacity: 0.9, marginTop: 1 }}>Standalone note — no quoted passage</div>
+          </div>
+        </div>
+
+        {/* body */}
+        <div style={{ flex: 1, minHeight: scroll ? 0 : 150, padding: '14px 18px 0', overflowY: scroll ? 'auto' : 'hidden' }} className="hide-scroll">
+          {text ? (
+            <div style={{
+              fontFamily: bodyFont, fontSize: 17, lineHeight: cjk ? 1.85 : 1.55,
+              color: t.ink, whiteSpace: 'pre-wrap', textAlign: cjk ? 'left' : 'left',
+            }}>
+              {text}
+              {showCaret && <span style={{ display: 'inline-block', width: 2, height: cjk ? 22 : 19, background: t.accent, marginLeft: 1, transform: 'translateY(3px)', animation: 'seCaret 1s steps(1) infinite' }} />}
+            </div>
+          ) : (
+            <div style={{ fontFamily: bodyFont, fontSize: 17, lineHeight: 1.55, color: t.sub, opacity: 0.7 }}>
+              Write a note for this spot in the chapter…
+              {showCaret && <span style={{ display: 'inline-block', width: 2, height: 19, background: t.accent, marginLeft: 1, transform: 'translateY(3px)', animation: 'seCaret 1s steps(1) infinite' }} />}
+            </div>
+          )}
+        </div>
+
+        {/* footer */}
+        <div style={{
+          padding: '8px 14px 10px', display: 'flex', alignItems: 'center', gap: 10,
+          borderTop: `0.5px solid ${t.rule}`, fontSize: 12, color: t.sub,
+        }}>
+          <span>{cjk ? `${[...text.replace(/\s+/g, '')].length} 字` : text ? `${text.trim().split(/\s+/).filter(Boolean).length} words` : 'Empty'}</span>
+          <div style={{ flex: 1 }} />
+          {!isNew && (
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, color: seDanger(t), fontWeight: 500, fontSize: 12.5 }}>
+              <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke={seDanger(t)} strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M2.5 4h9M6 2h2a1 1 0 011 1v1H5V3a1 1 0 011-1zM3.5 4l.6 8.2A1 1 0 005.1 13h3.8a1 1 0 001-.8L10.5 4M6 7v3.5M8 7v3.5"/>
+              </svg>
+              Delete note
+            </span>
+          )}
+        </div>
+      </div>
+
+      {showKeyboard && <FakeIOSKeyboard theme={t} height={keyboardHeight} inputSource={inputSource} script={cjk ? 'cjk' : 'latin'} />}
+    </>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// Annotation chips (shared vocabulary with the contrast canvases)
+// ─────────────────────────────────────────────────────
+function SEChip({ tone = 'info', children }) {
+  const map = {
+    reject: { bg: 'rgba(168,58,58,0.94)', fg: '#fff' },
+    pick:   { bg: 'rgba(42,122,68,0.96)', fg: '#fff' },
+    alt:    { bg: 'rgba(166,120,40,0.96)', fg: '#fff' },
+    info:   { bg: 'rgba(40,36,30,0.86)', fg: '#fff' },
+    step:   { bg: '#fff', fg: '#2a251f' },
+  }[tone];
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 5,
+      padding: '3px 9px', borderRadius: 100, background: map.bg, color: map.fg,
+      fontSize: 11, fontWeight: 700, letterSpacing: 0.3, fontFamily: SE_FONT,
+      boxShadow: '0 3px 9px rgba(0,0,0,0.16)',
+    }}>{children}</span>
+  );
+}
+function SENote({ top, left, right, bottom, tone, children }) {
+  return <div style={{ position: 'absolute', top, left, right, bottom, zIndex: 6 }}><SEChip tone={tone}>{children}</SEChip></div>;
+}
+function SEStepBadge({ n, children }) {
+  return (
+    <div style={{ position: 'absolute', top: 16, left: 16, zIndex: 6, display: 'flex', alignItems: 'center', gap: 8 }}>
+      <span style={{ width: 24, height: 24, borderRadius: 12, background: '#2a251f', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 700, fontFamily: SE_FONT, boxShadow: '0 3px 9px rgba(0,0,0,0.2)' }}>{n}</span>
+      {children && <span style={{ padding: '4px 10px', borderRadius: 100, background: 'rgba(255,255,255,0.94)', color: '#2a251f', fontSize: 11.5, fontWeight: 600, fontFamily: SE_FONT, boxShadow: '0 3px 9px rgba(0,0,0,0.16)' }}>{children}</span>}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// Comparison card — A vs B across the criteria that decide it
+// ─────────────────────────────────────────────────────
+function SECompareCard() {
+  const t = THEMES.paper;
+  const rows = [
+    ['After Edit, the user is…', 'back in the annotations list — same filter, same scroll', 'in the reader at the locator; the list is gone'],
+    ['The navigation does…', 'nothing — there is nowhere to go', 'scrolls the book to a locator showing ordinary text — no passage to land on'],
+    ['Taps to resume triaging notes', 'zero — already there', 're-open Annotations, re-pick the filter, re-scroll'],
+    ['New surface to build', 'none — reuses the dim + keyboard sheet primitive', 'a reader-level observer + AnnotationEditSheet mount point'],
+    ['Editor surface', 'AnnotationEditSheet { initialContent, onSave }', 'identical — AnnotationEditSheet { initialContent, onSave }'],
+    ['Fits the anchorless model', 'yes — edit the text where you found it', 'no — implies the note has a passage to read'],
+    ['Vs. the highlight Edit path', 'same gesture grammar + same editor; container differs by design', 'same container, but for a reason that doesn\u2019t apply here'],
+  ];
+  return (
+    <div style={{ width: '100%', height: '100%', boxSizing: 'border-box', background: '#fcf8f0', padding: '30px 34px', fontFamily: SE_FONT, color: t.ink, overflow: 'hidden' }}>
+      <div style={{ fontFamily: SE_SERIF, fontSize: 23, fontWeight: 700, marginBottom: 14 }}>Why edit over the sheet</div>
+      <div style={{ display: 'grid', gridTemplateColumns: '210px 1fr 1fr', gap: 0 }}>
+        <div style={{ padding: '0 0 10px' }} />
+        <div style={{ padding: '0 14px 10px', display: 'flex', alignItems: 'center', gap: 8 }}>
+          <SEChip tone="pick">A · RECOMMEND</SEChip>
+          <span style={{ fontSize: 12.5, fontWeight: 700 }}>Over the sheet</span>
+        </div>
+        <div style={{ padding: '0 14px 10px', display: 'flex', alignItems: 'center', gap: 8 }}>
+          <SEChip tone="reject">B</SEChip>
+          <span style={{ fontSize: 12.5, fontWeight: 700 }}>Dismiss + navigate</span>
+        </div>
+        {rows.map((r, i) => (
+          <React.Fragment key={i}>
+            <div style={{ padding: '11px 0', borderTop: `0.5px solid ${t.rule}`, fontSize: 12.5, fontWeight: 600, color: t.ink }}>{r[0]}</div>
+            <div style={{ padding: '11px 14px', borderTop: `0.5px solid ${t.rule}`, fontSize: 12.5, color: t.ink, lineHeight: 1.4, background: 'rgba(42,122,68,0.05)' }}>{r[1]}</div>
+            <div style={{ padding: '11px 14px', borderTop: `0.5px solid ${t.rule}`, fontSize: 12.5, color: t.sub, lineHeight: 1.4 }}>{r[2]}</div>
+          </React.Fragment>
+        ))}
+      </div>
+      <div style={{ marginTop: 16, fontSize: 12.5, color: t.sub, lineHeight: 1.5 }}>
+        Consistency with the highlight path is preserved where it counts — the <b>editor surface and the gesture</b> are the
+        same. The container differs because the data differs: a highlight note is anchored to a visible passage (navigate, then
+        the popover anchors there); a standalone note is anchored only to a locator (nothing to show), so it edits in place.
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// "Two intents" grammar card
+// ─────────────────────────────────────────────────────
+function SEGrammarCard() {
+  const t = THEMES.paper;
+  const Box = ({ tone, gesture, intent, outcome }) => (
+    <div style={{ flex: 1, borderRadius: 14, padding: '16px 16px 18px', background: '#fffdf7', boxShadow: 'inset 0 0 0 0.5px rgba(0,0,0,0.06)' }}>
+      <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: 0.6, textTransform: 'uppercase', color: tone, marginBottom: 8 }}>{gesture}</div>
+      <div style={{ fontFamily: SE_SERIF, fontSize: 17, fontWeight: 600, color: t.ink, marginBottom: 4 }}>{intent}</div>
+      <div style={{ fontSize: 13, color: t.sub, lineHeight: 1.45 }}>{outcome}</div>
+    </div>
+  );
+  return (
+    <div style={{ width: '100%', height: '100%', boxSizing: 'border-box', background: '#fcf8f0', padding: '30px 34px', fontFamily: SE_FONT, color: t.ink }}>
+      <div style={{ fontFamily: SE_SERIF, fontSize: 23, fontWeight: 700, marginBottom: 4 }}>Two intents, one card</div>
+      <div style={{ fontSize: 13, color: t.sub, marginBottom: 18, lineHeight: 1.45 }}>
+        The standalone-note card already carries two separable intents. Keeping Edit in-sheet makes them visibly different
+        outcomes — instead of collapsing both into "navigate, then edit."
+      </div>
+      <div style={{ display: 'flex', gap: 14 }}>
+        <Box tone={t.accent} gesture="Tap the card body" intent="“Go read there”" outcome="Dismiss the sheet, navigate to the locator. The existing onJump — unchanged." />
+        <Box tone="#2a7a44" gesture="⋯ → Edit note" intent="“Fix the wording”" outcome="Open AnnotationEditSheet over the list. Save returns you to the list, in place." />
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// Spec card — binding plumbing contract
+// ─────────────────────────────────────────────────────
+function SESpecCard() {
+  const t = THEMES.paper;
+  const rowStyle = { display: 'grid', gridTemplateColumns: '150px 1fr', gap: 16, padding: '11px 0', borderTop: `0.5px solid ${t.rule}`, alignItems: 'baseline' };
+  const labelStyle = { fontSize: 11, letterSpacing: 0.8, textTransform: 'uppercase', color: t.sub, fontWeight: 600 };
+  const valStyle = { fontSize: 13.5, color: t.ink, lineHeight: 1.5 };
+  const code = { fontFamily: '"SF Mono", "JetBrains Mono", Menlo, monospace', background: 'rgba(0,0,0,0.05)', padding: '1px 5px', borderRadius: 4, fontSize: 12, color: '#5a3a3a' };
+  return (
+    <div style={{ width: '100%', height: '100%', boxSizing: 'border-box', padding: '32px 40px', background: '#fcf8f0', color: t.ink, fontFamily: SE_FONT, overflow: 'auto' }}>
+      <div style={{ fontFamily: SE_SERIF, fontSize: 25, fontWeight: 700, marginBottom: 4 }}>WI-3 — standalone-note Edit, presentation contract</div>
+      <div style={{ fontSize: 13, color: t.sub, marginBottom: 16 }}>
+        Resolves the open question in #1121 / #1296. Decision: present over the HighlightsSheet, non-dismissing.
+      </div>
+      <div style={rowStyle}>
+        <div style={labelStyle}>Trigger</div>
+        <div style={valStyle}>
+          <span style={code}>edit()</span>'s <span style={code}>.standalone</span> branch posts an
+          <span style={code}>editAnnotation(id)</span> request — observed at the <b>HighlightsSheet</b> level, not the reader.
+          The sheet stays mounted.
+        </div>
+      </div>
+      <div style={rowStyle}>
+        <div style={labelStyle}>Present</div>
+        <div style={valStyle}>
+          The observer presents <span style={code}>AnnotationEditSheet</span> as a sheet over the list
+          (<span style={code}>.sheet</span> / keyboard-anchored), seeded with <span style={code}>initialContent: annotation.content</span>.
+          No dismiss, no navigation.
+        </div>
+      </div>
+      <div style={rowStyle}>
+        <div style={labelStyle}>Save</div>
+        <div style={valStyle}>
+          <span style={code}>onSave</span> → <span style={code}>updateAnnotation(annotationId:content:)</span> → dismiss the editor
+          back to the list. The row reflects the new text in place; a "Note saved" toast confirms.
+        </div>
+      </div>
+      <div style={rowStyle}>
+        <div style={labelStyle}>Cancel</div>
+        <div style={valStyle}>
+          Clean draft → dismiss to the list. Dirty draft → DiscardNoteAlert (the committed #914 alert), then dismiss to the list.
+          Empty content is not a valid standalone note — Save reads "Clear" and routes through Delete confirm.
+        </div>
+      </div>
+      <div style={rowStyle}>
+        <div style={labelStyle}>Locator strip</div>
+        <div style={valStyle}>
+          Replaces the highlight excerpt: chapter · page + a "Standalone note" hint. The user knows which note they're editing
+          without a quoted passage to show.
+        </div>
+      </div>
+      <div style={rowStyle}>
+        <div style={labelStyle}>Reuse, don't build</div>
+        <div style={valStyle}>
+          AnnotationEditSheet, FakeIOSKeyboard, DiscardNoteAlert, the saved toast — all committed. No reader-level mount point is
+          added. The "tap card → jump" path (<span style={code}>onJump</span>) is unchanged.
+        </div>
+      </div>
+      <div style={rowStyle}>
+        <div style={labelStyle}>Parity</div>
+        <div style={valStyle}>
+          Highlight Edit keeps its shipped behaviour (navigate + popover). Only the standalone branch is defined here. Same editor
+          surface, same gesture grammar across both.
+        </div>
+      </div>
+      <div style={rowStyle}>
+        <div style={labelStyle}>Source of truth</div>
+        <div style={valStyle}>
+          Feature #1121 WI-3 (parent). Editor surface from #914; card + ⋯ menu from #1103.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// CanvasRoot
+// ─────────────────────────────────────────────────────
+function StandaloneNoteEditorCanvas() {
+  const W = SE_PHONE_W, H = SE_PHONE_H;
+  return (
+    <DesignCanvas>
+
+      {/* ─── 1. Decision ─── */}
+      <DCSection id="decision"
+        title="#1296 — Standalone-note editor presentation (WI-3)"
+        subtitle="When the user taps ⋯ → Edit on a standalone note, the editor opens OVER the Annotations sheet — non-dismissing — and returns there on Save. Not 'after the jump': a standalone note has no passage to navigate to. End-state below.">
+        <DCArtboard id="rec-paper" label="Recommended · editor over the list" width={W} height={H}>
+          <SEPhone themeKey="paper">
+            <SEReaderCh6 themeKey="paper" showLocator={false} />
+            <HighlightsSheetV4 theme={THEMES.paper} highlights={SE_HIGHLIGHTS} standalones={SE_STANDALONES} filter="notes" onClose={() => {}} onJump={() => {}} />
+            <SEStandaloneEditSheet themeKey="paper" note={SE_NOTE} showCaret />
+          </SEPhone>
+        </DCArtboard>
+        <DCArtboard id="rec-dark" label="Recommended · dark" width={W} height={H}>
+          <SEPhone themeKey="dark">
+            <SEReaderCh6 themeKey="dark" showLocator={false} />
+            <HighlightsSheetV4 theme={THEMES.dark} highlights={SE_HIGHLIGHTS} standalones={SE_STANDALONES} filter="notes" onClose={() => {}} onJump={() => {}} />
+            <SEStandaloneEditSheet themeKey="dark" note={SE_NOTE} showCaret />
+          </SEPhone>
+        </DCArtboard>
+        <DCPostIt top={-34} right={36} rotate={2} width={262}>
+          The list stays mounted behind the dim. The editor is the same keyboard-anchored sheet the highlight-note editor already is — just stacked over the review sheet instead of the page.
+        </DCPostIt>
+      </DCSection>
+
+      {/* ─── 2. Entry point ─── */}
+      <DCSection id="entry"
+        title="Entry point · ⋯ → Edit"
+        subtitle="The committed StandaloneNoteCard (#1103) already carries a ⋯ menu with Edit · Copy · Delete. This issue is only about what 'Edit note' does next.">
+        <DCArtboard id="card-menu" label="Standalone card · ⋯ menu open" width={W} height={H}>
+          <SEList themeKey="paper" filter="notes" forcedRowId="s1" forcedState="menu-open" />
+        </DCArtboard>
+        <DCArtboard id="card-rest" label="The two notes, at rest" width={W} height={H}>
+          <SEList themeKey="paper" filter="notes" />
+        </DCArtboard>
+        <DCArtboard id="grammar" label="Two intents, one card" width={620} height={H}>
+          <SEGrammarCard />
+        </DCArtboard>
+        <DCPostIt top={-34} left={36} rotate={-2} width={232}>
+          Tapping the card body already means "go read there." So Edit should mean something else — fix the text — not a second route to the same jump.
+        </DCPostIt>
+      </DCSection>
+
+      {/* ─── 3. Option A storyboard ─── */}
+      <DCSection id="optionA"
+        title="Option A · edit over the sheet (recommended)"
+        subtitle="Edit opens the editor as a sheet stacked over the dimmed Annotations list. The user types, saves, and lands back in the list exactly where they were — filter and scroll intact.">
+        <DCArtboard id="a1" label="1 · Tap Edit note" width={W} height={H}>
+          <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+            <SEList themeKey="paper" filter="notes" forcedRowId="s1" forcedState="menu-open" />
+            <SEStepBadge n="1">⋯ → Edit note</SEStepBadge>
+          </div>
+        </DCArtboard>
+        <DCArtboard id="a2" label="2 · Editor rises over the list" width={W} height={H}>
+          <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+            <SEPhone themeKey="paper">
+              <SEReaderCh6 themeKey="paper" showLocator={false} />
+              <HighlightsSheetV4 theme={THEMES.paper} highlights={SE_HIGHLIGHTS} standalones={SE_STANDALONES} filter="notes" onClose={() => {}} onJump={() => {}} />
+              <SEStandaloneEditSheet themeKey="paper" note={SE_NOTE} showCaret />
+            </SEPhone>
+            <SEStepBadge n="2" />
+            <SENote bottom={SE_KB + 14} right={16} tone="info">list still mounted behind</SENote>
+          </div>
+        </DCArtboard>
+        <DCArtboard id="a3" label="3 · Editing · Save enabled" width={W} height={H}>
+          <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+            <SEPhone themeKey="paper">
+              <SEReaderCh6 themeKey="paper" showLocator={false} />
+              <HighlightsSheetV4 theme={THEMES.paper} highlights={SE_HIGHLIGHTS} standalones={SE_STANDALONES} filter="notes" onClose={() => {}} onJump={() => {}} />
+              <SEStandaloneEditSheet themeKey="paper" note={SE_NOTE} draft={SE_NOTE_EDITED.body} showCaret forceDirty />
+            </SEPhone>
+            <SEStepBadge n="3" />
+            <SENote bottom={SE_KB + 14} right={16} tone="pick">draft dirty · Save on</SENote>
+          </div>
+        </DCArtboard>
+        <DCArtboard id="a4" label="4 · Save → back in the list, updated" width={W} height={H}>
+          <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+            <SEPhone themeKey="paper">
+              <SEReaderCh6 themeKey="paper" showLocator={false} />
+              <HighlightsSheetV4 theme={THEMES.paper} highlights={SE_HIGHLIGHTS} standalones={[SE_NOTE_EDITED, SE_STANDALONES[1]]} filter="notes" onClose={() => {}} onJump={() => {}} />
+              <NoteSavedToast theme={THEMES.paper} message="Note saved" />
+            </SEPhone>
+            <SEStepBadge n="4" />
+            <SENote top={64} right={16} tone="pick">same filter · same scroll</SENote>
+          </div>
+        </DCArtboard>
+        <DCPostIt top={-34} right={36} rotate={2} width={236}>
+          Four taps, zero context lost. The user never leaves the triage surface they opened — the whole point of the Annotations sheet.
+        </DCPostIt>
+      </DCSection>
+
+      {/* ─── 4. Option B storyboard ─── */}
+      <DCSection id="optionB"
+        title="Option B · dismiss + navigate (the prior 'intent')"
+        subtitle="The originally-sketched path: Edit dismisses the sheet, flies the reader to the locator, then presents the editor there. It mirrors the highlight path's container — but the reason that path navigates doesn't apply to an anchorless note.">
+        <DCArtboard id="b1" label="1 · Tap Edit note" width={W} height={H}>
+          <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+            <SEList themeKey="paper" filter="notes" forcedRowId="s1" forcedState="menu-open" />
+            <SEStepBadge n="1">⋯ → Edit note</SEStepBadge>
+          </div>
+        </DCArtboard>
+        <DCArtboard id="b2" label="2 · Sheet dismissed · reader jumps" width={W} height={H}>
+          <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+            <SEPhone themeKey="paper"><SEReaderCh6 themeKey="paper" showLocator /></SEPhone>
+            <SEStepBadge n="2" />
+            <SENote top={150} right={16} tone="reject">list + filter gone</SENote>
+            <SENote top={300} left={64} tone="alt">no passage to land on</SENote>
+          </div>
+        </DCArtboard>
+        <DCArtboard id="b3" label="3 · Editor presents at reader level" width={W} height={H}>
+          <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+            <SEPhone themeKey="paper">
+              <SEReaderCh6 themeKey="paper" showLocator />
+              <SEStandaloneEditSheet themeKey="paper" note={SE_NOTE} draft={SE_NOTE_EDITED.body} showCaret forceDirty />
+            </SEPhone>
+            <SEStepBadge n="3" />
+            <SENote bottom={SE_KB + 14} right={16} tone="alt">needs a new reader-level mount</SENote>
+          </div>
+        </DCArtboard>
+        <DCArtboard id="b4" label="4 · Save → stranded in the reader" width={W} height={H}>
+          <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+            <SEPhone themeKey="paper"><SEReaderCh6 themeKey="paper" showLocator /><NoteSavedToast theme={THEMES.paper} message="Note saved" /></SEPhone>
+            <SEStepBadge n="4" />
+            <SENote top={150} right={16} tone="reject">re-open Annotations to keep triaging</SENote>
+          </div>
+        </DCArtboard>
+        <DCPostIt top={-34} left={36} rotate={-2} width={244}>
+          The jump is the cost, not the feature. For a highlight, navigating shows the passage the note is about. For a standalone note there's nothing to show — so B spends a full screen transition to reveal unrelated text.
+        </DCPostIt>
+      </DCSection>
+
+      {/* ─── 5. Why A ─── */}
+      <DCSection id="why"
+        title="Why A wins"
+        subtitle="Same editor, same gesture, lighter build — and it respects what a standalone note actually is.">
+        <DCArtboard id="compare" label="A vs B · decision matrix" width={860} height={476}>
+          <SECompareCard />
+        </DCArtboard>
+      </DCSection>
+
+      {/* ─── 6. Editor states ─── */}
+      <DCSection id="states"
+        title="Editor states"
+        subtitle="The standalone editor reuses the committed #914 surface vocabulary: editing, dirty/Save, saving, discard-confirm, plus long-form and CJK. Sepia + dark inherit ReaderThemeV2 tokens.">
+        <DCArtboard id="st-edit" label="Editing existing · idle" width={W} height={H}>
+          <SEPhone themeKey="paper"><SEReaderCh6 themeKey="paper" showLocator={false} /><SEStandaloneEditSheet themeKey="paper" note={SE_NOTE} showCaret /></SEPhone>
+        </DCArtboard>
+        <DCArtboard id="st-saving" label="Saving…" width={W} height={H}>
+          <SEPhone themeKey="paper"><SEReaderCh6 themeKey="paper" showLocator={false} /><SEStandaloneEditSheet themeKey="paper" note={SE_NOTE} draft={SE_NOTE_EDITED.body} state="saving" forceDirty /></SEPhone>
+        </DCArtboard>
+        <DCArtboard id="st-discard" label="Discard alert · dirty Cancel" width={W} height={H}>
+          <SEPhone themeKey="paper">
+            <SEReaderCh6 themeKey="paper" showLocator={false} />
+            <SEStandaloneEditSheet themeKey="paper" note={SE_NOTE} draft={SE_NOTE_EDITED.body} forceDirty />
+            <DiscardNoteAlert theme={THEMES.paper} addingNew={false} onKeep={() => {}} onDiscard={() => {}} />
+          </SEPhone>
+        </DCArtboard>
+        <DCArtboard id="st-long" label="Long note · scrolls" width={W} height={H}>
+          <SEPhone themeKey="paper"><SEReaderCh6 themeKey="paper" showLocator={false} /><SEStandaloneEditSheet themeKey="paper" note={SE_NOTE_LONG} scroll /></SEPhone>
+        </DCArtboard>
+        <DCArtboard id="st-cjk" label="Chinese · IME" width={W} height={H}>
+          <SEPhone themeKey="paper"><SEReaderCh6 themeKey="paper" showLocator={false} /><SEStandaloneEditSheet themeKey="paper" note={SE_NOTE_CJK} cjk inputSource="拼音" showCaret /></SEPhone>
+        </DCArtboard>
+        <DCArtboard id="st-sepia" label="Sepia" width={W} height={H}>
+          <SEPhone themeKey="sepia"><SEReaderCh6 themeKey="sepia" showLocator={false} /><SEStandaloneEditSheet themeKey="sepia" note={SE_NOTE} showCaret /></SEPhone>
+        </DCArtboard>
+      </DCSection>
+
+      {/* ─── 7. Spec ─── */}
+      <DCSection id="spec"
+        title="Implementation notes"
+        subtitle="The binding contract — what WI-3's plumbing builds against.">
+        <DCArtboard id="spec-card" label="" width={760} height={560}>
+          <SESpecCard />
+        </DCArtboard>
+      </DCSection>
+
+    </DesignCanvas>
+  );
+}
+
+Object.assign(window, { StandaloneNoteEditorCanvas });

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 736
-        MARKETING_VERSION: 3.41.10
+        CURRENT_PROJECT_VERSION: 737
+        MARKETING_VERSION: 3.41.11
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6900,13 +6900,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 736;
+				CURRENT_PROJECT_VERSION = 737;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.10;
+				MARKETING_VERSION = 3.41.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -7050,13 +7050,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 736;
+				CURRENT_PROJECT_VERSION = 737;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.10;
+				MARKETING_VERSION = 3.41.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
## Summary

Records the claude.ai/design handoff resolving needs-design **#1296** — the standalone-note Edit presentation for Feature #1121 WI-3. Design only; **implementation deferred** (no app code).

## What's added (`dev-docs/designs/vreader-fidelity-v1/`)
- `project/VReader Standalone Note Editor Canvas.html` + `project/standalone-note-editor-artboards.jsx`
- `chats/chat12.md`
- `project/design-notes/standalone-note-editor.md` — decision + a **scope finding**

## Decision (binding)
Present `AnnotationEditSheet` **over** the HighlightsSheet (non-dismissing), returning to the list on Save — not "after the jump", since a standalone note has no passage to navigate to.

## Scope finding (important)
The design assumes the editor surface + `DiscardNoteAlert` (#914) + a "Note saved" toast are "all committed." A code audit found they're **not**: only a minimal un-wired `AnnotationEditSheet` stub exists, and neither the alert nor the toast. So WI-3 implementation is **feature-sized**, not the small plumbing the issue assumed — captured in the design-notes for whoever picks it up.

## Type of Change
- [x] Design bundle (dev-docs) — no `vreader/` code.

## Validation
- [x] No Swift touched → codex-audit merge-gate escape hatch applies.
- [x] Version bumped 3.41.10 → 3.41.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)