### PR TITLE
feat(#75 WI-2): axis-aware EPUBPaginationHelper generators

### DIFF
--- a/.claude/codex-audits/feat-feature-75-wi2-pagination-axis-audit.md
+++ b/.claude/codex-audits/feat-feature-75-wi2-pagination-axis-audit.md
@@ -1,0 +1,37 @@
+---
+branch: feat/feature-75-wi2-pagination-axis
+threadId: codex-exec-readonly
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-31
+---
+
+# Codex audit — Feature #75 WI-2 (EPUBPaginationHelper axis-aware generators)
+
+Read-only `codex exec` audit. Foundational WI (pure string/Int generators →
+unit-tested; WKWebView multicol layout validated on-device in WI-5).
+
+## Summary
+
+New pure `EPUBPagedAxis` — `scrollOffset(page:viewportWidth:axis:)` (LTR positive,
+RTL/verticalRL negative `scrollLeft`) + `directionCSS(axis:)` (LTR empty, RTL
+`direction:rtl`, verticalRL `writing-mode`+`direction`). Wired into
+`navigateToPageJS`, `paginationCSS`, `injectPaginationCSSJS` with `axis` defaulting
+to `.horizontalLTR` so existing callers are unchanged.
+
+## Round 1 findings
+
+| file:line | severity | issue | resolution |
+|---|---|---|---|
+| EPUBPaginationHelper.swift:76 | Low | LTR not byte-identical — empty directionCSS line added whitespace. | Fixed — conditional `directionLine` (empty for LTR); test `paginationCSS_ltr_defaultMatchesExplicitLTR` pins byte-identity. |
+| EPUBPaginationHelper.swift:233 | Medium | `injectPaginationCSSJS` wrapper had no axis param → runtime paged path couldn't inject RTL/vertical CSS. | Fixed — added `axis: PageAxis = .horizontalLTR`, threaded to `paginationCSS`. |
+
+Codex confirmed: RTL negative-`scrollLeft` + page-0=0 correct; verticalRL reusing
+RTL offset acceptable as a WI-2 hypothesis with WI-5 device validation BINDING
+before claiming vertical support; clamps correct; no Swift 6 issue.
+
+## Verdict
+
+ship-as-is. Tests: `EPUBPagedAxisTests` (offset + directionCSS + paginationCSS
+LTR-byte-identity + RTL/vertical injection + navigateToPageJS RTL) green; existing
+`EPUBPaginationTests` unchanged. verticalRL scroll axis is device-validated in WI-5.

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 750
-        MARKETING_VERSION: 3.41.24
+        CURRENT_PROJECT_VERSION: 751
+        MARKETING_VERSION: 3.41.25
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -1198,6 +1198,7 @@
 		D35863F85B17FE883F4EABBF /* ChapterTranslationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551DA6A3D645B1D9D72EE159 /* ChapterTranslationService.swift */; };
 		D36EEE178AE4BC41B7B4C650 /* FileAvailabilityBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4B7084FA4C129303F52CB8 /* FileAvailabilityBadge.swift */; };
 		D371F8D98EA9603C6BF3E6ED /* EPUBHighlightTapBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8BD899A79BEB3964941631 /* EPUBHighlightTapBridgeTests.swift */; };
+		D3A9394A17D78A98DDF4E618 /* EPUBPagedAxis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8401AD7C7023A69BE9B68215 /* EPUBPagedAxis.swift */; };
 		D3AA14442F5D8686DD9BAA18 /* HTTPSpeechSynthesizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060D40EBDC75C3812596FB84 /* HTTPSpeechSynthesizer.swift */; };
 		D41473E2CF7AB980E43C6C54 /* BookFormatAZW3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627E42F1B1E8A59081CC6628 /* BookFormatAZW3Tests.swift */; };
 		D4332566CDFE7329E3709381 /* EPUBWebViewBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E536B950D178C97842DF52 /* EPUBWebViewBridge.swift */; };
@@ -1247,6 +1248,7 @@
 		DD1020F3F0A2D5BA7FFCB279 /* UnifiedScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0753D8C40DFE06B0323EE5B /* UnifiedScrollView.swift */; };
 		DD273808CA81E259EAC3F7C5 /* LocatorRestorerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10A08E980C92248337462DF /* LocatorRestorerTests.swift */; };
 		DD32F48A384939AC2389DCAE /* PersistenceHighlightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDD43BA2EC5C331FDF3A703 /* PersistenceHighlightTests.swift */; };
+		DD69A5306F3DA8F15F1091E0 /* EPUBPagedAxisTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A56CF939EF4F69F9304BC332 /* EPUBPagedAxisTests.swift */; };
 		DD711E614DD2743B1CB0088E /* BookmarkFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85205257E8103AA80C08BAB /* BookmarkFeedbackTests.swift */; };
 		DD95745C7DEBB12D1A8067CF /* FoliateSpikeView+Restore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597F6A9C185AEBABD1E8F21B /* FoliateSpikeView+Restore.swift */; };
 		DDAF2F7D65A07079EFE2A421 /* PDFReaderContainerView+Overlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC88500940FCA638D86E8E4 /* PDFReaderContainerView+Overlays.swift */; };
@@ -2185,6 +2187,7 @@
 		83BEF8E9F5CAD4246490C06D /* AISummaryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISummaryCard.swift; sourceTree = "<group>"; };
 		83CA82E6D9E86220E10B3728 /* SchemaV8.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV8.swift; sourceTree = "<group>"; };
 		83F36EF81271874A13417D45 /* OPDSEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSEntryView.swift; sourceTree = "<group>"; };
+		8401AD7C7023A69BE9B68215 /* EPUBPagedAxis.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBPagedAxis.swift; sourceTree = "<group>"; };
 		8404837D8FC686DDDB62EEC3 /* AccentColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccentColorTests.swift; sourceTree = "<group>"; };
 		847DD24E5292D6B493E29C15 /* BilingualPairing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualPairing.swift; sourceTree = "<group>"; };
 		84BAC2CBFB7F533857E6A65B /* search_no_results.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = search_no_results.html; sourceTree = "<group>"; };
@@ -2364,6 +2367,7 @@
 		A4FC31294DE996929269182A /* ReadiumBilingualCommanderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumBilingualCommanderTests.swift; sourceTree = "<group>"; };
 		A504B80204BEC5B968087D02 /* PersistenceActorRemoteOnlyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceActorRemoteOnlyTests.swift; sourceTree = "<group>"; };
 		A53978A56FA1C7D888914503 /* MDChapterTextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDChapterTextProvider.swift; sourceTree = "<group>"; };
+		A56CF939EF4F69F9304BC332 /* EPUBPagedAxisTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBPagedAxisTests.swift; sourceTree = "<group>"; };
 		A5717B0EFF152D86D07C5C0D /* EPUBSelectionTokenCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBSelectionTokenCacheTests.swift; sourceTree = "<group>"; };
 		A579625590B25F81679F1EA0 /* ReaderNotificationModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderNotificationModifier.swift; sourceTree = "<group>"; };
 		A61992F892AF73F530F54DAC /* FoliateHighlightMutatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightMutatorTests.swift; sourceTree = "<group>"; };
@@ -3385,6 +3389,7 @@
 				5C5EC86BB06D46DC9A5A4F6B /* EPUBHighlightBridgeTests.swift */,
 				59540377ED7FDB678914B972 /* EPUBHighlightRendererBug77Tests.swift */,
 				9A8BD899A79BEB3964941631 /* EPUBHighlightTapBridgeTests.swift */,
+				A56CF939EF4F69F9304BC332 /* EPUBPagedAxisTests.swift */,
 				002A1A054B82164581081351 /* EPUBPagedProgressTests.swift */,
 				B9500033AC714D470A3024F8 /* EPUBPaginationTests.swift */,
 				8FA15EA6877E3CA9421E1B59 /* EPUBProgressTests.swift */,
@@ -3958,6 +3963,7 @@
 				435C00E099B7F5D7A7821FDC /* EPUBHighlightBridge.swift */,
 				44423E8976A2B27C4B14617F /* EPUBHighlightJS.swift */,
 				3650C684EB90A5D7E2F8059A /* EPUBHighlightRenderer.swift */,
+				8401AD7C7023A69BE9B68215 /* EPUBPagedAxis.swift */,
 				43677A0B2B4A42609A2800ED /* EPUBPagedProgress.swift */,
 				E5EC9B0FFB09D08F65F205F3 /* EPUBPaginationHelper.swift */,
 				DBBB555BA86F7648ACBC780F /* EPUBProgressCalculator.swift */,
@@ -5616,6 +5622,7 @@
 				56A100BED3272494DE799F55 /* EPUBHighlightRendererBug77Tests.swift in Sources */,
 				D371F8D98EA9603C6BF3E6ED /* EPUBHighlightTapBridgeTests.swift in Sources */,
 				3D31B039400E1A83C4A1DF6D /* EPUBMetadataExtractorTests.swift in Sources */,
+				DD69A5306F3DA8F15F1091E0 /* EPUBPagedAxisTests.swift in Sources */,
 				E431016A81D6B202241B4275 /* EPUBPagedProgressTests.swift in Sources */,
 				5BA867B4591F0916810C91B8 /* EPUBPaginationTests.swift in Sources */,
 				EB3D180641036C8A6FA00030 /* EPUBParserTests.swift in Sources */,
@@ -6246,6 +6253,7 @@
 				EE8189DAD855D15887FBBCFA /* EPUBHighlightJS.swift in Sources */,
 				863103455E8B23D20B97F192 /* EPUBHighlightRenderer.swift in Sources */,
 				1D0B7D11E74A0E06F27A9F8B /* EPUBLayoutPreference.swift in Sources */,
+				D3A9394A17D78A98DDF4E618 /* EPUBPagedAxis.swift in Sources */,
 				3E445837C0B98903CFCC5AD7 /* EPUBPagedProgress.swift in Sources */,
 				39699408A91BBF24E36FCE53 /* EPUBPaginationHelper.swift in Sources */,
 				F78B9D218FBB628F31479271 /* EPUBParser.swift in Sources */,
@@ -6920,13 +6928,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 750;
+				CURRENT_PROJECT_VERSION = 751;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.24;
+				MARKETING_VERSION = 3.41.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -7070,13 +7078,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 750;
+				CURRENT_PROJECT_VERSION = 751;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.24;
+				MARKETING_VERSION = 3.41.25;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Views/Reader/EPUBPagedAxis.swift
+++ b/vreader/Views/Reader/EPUBPagedAxis.swift
@@ -1,0 +1,46 @@
+// Purpose: Feature #75 WI-2 — pure axis-aware seams for EPUB paged navigation.
+// Given a resolved per-document `PageAxis`, produce (a) the body direction /
+// writing-mode CSS fragment and (b) the page→scroll-offset for `navigateToPageJS`.
+// Kept pure (Int / String generators) so the axis math is unit-testable; the
+// actual WKWebView multicol layout is validated on-device in WI-5.
+//
+// Horizontal LTR/RTL are fully resolved here (LTR is byte-unchanged; RTL uses
+// WebKit's negative `scrollLeft` convention — scrollLeft is 0 at the right/start
+// edge and goes negative toward later content). `verticalRL` emits its
+// writing-mode CSS and uses the SAME negative-`scrollLeft` page advance as RTL
+// (vertical-rl columns also overflow horizontally right-to-left); the exact
+// WebKit stride for vertical writing is confirmed on-device in WI-5.
+//
+// @coordinates-with: PageAxisResolver.swift (PageAxis), EPUBPaginationHelper.swift
+
+import Foundation
+
+enum EPUBPagedAxis {
+    /// The horizontal page→`scrollLeft` offset for `page` (zero-based) under
+    /// `axis`. LTR is `page * viewportWidth`; RTL / vertical-rl negate it
+    /// (WebKit's negative-`scrollLeft` RTL convention).
+    static func scrollOffset(page: Int, viewportWidth: Int, axis: PageAxis) -> Int {
+        let safePage = max(0, page)
+        let magnitude = safePage * max(0, viewportWidth)
+        switch axis {
+        case .horizontalLTR: return magnitude
+        case .horizontalRTL, .verticalRL: return -magnitude
+        }
+    }
+
+    /// The body CSS fragment that sets writing direction for `axis`. Empty for
+    /// LTR (no override needed); `direction: rtl` for horizontal RTL; both
+    /// `writing-mode: vertical-rl` + `direction: rtl` for vertical-rl. Each
+    /// declaration is `!important` to win over the book's stylesheet, matching
+    /// the pagination CSS's specificity discipline.
+    static func directionCSS(axis: PageAxis) -> String {
+        switch axis {
+        case .horizontalLTR:
+            return ""
+        case .horizontalRTL:
+            return "direction: rtl !important;"
+        case .verticalRL:
+            return "writing-mode: vertical-rl !important; direction: rtl !important;"
+        }
+    }
+}

--- a/vreader/Views/Reader/EPUBPaginationHelper.swift
+++ b/vreader/Views/Reader/EPUBPaginationHelper.swift
@@ -28,7 +28,9 @@ enum EPUBPaginationHelper {
     /// Column gap between pages (prevents text clipping at edges).
     static let columnGap: Int = 40
 
-    static func paginationCSS(viewportWidth: CGFloat, viewportHeight: CGFloat) -> String {
+    static func paginationCSS(
+        viewportWidth: CGFloat, viewportHeight: CGFloat, axis: PageAxis = .horizontalLTR
+    ) -> String {
         // Bug #171 fix: clamp the computed column-width to a positive
         // value. The pre-fix expression `Int(viewportWidth) - columnGap`
         // emits negative px values for very small viewports (e.g.
@@ -37,6 +39,10 @@ enum EPUBPaginationHelper {
         // gap; tightening it here while we're in the file.
         let colWidth = max(Int(viewportWidth) - columnGap, 1)
         let h = max(Int(viewportHeight), 0)
+        // Feature #75 WI-2: inject the axis direction/writing-mode only when
+        // non-LTR, so the LTR output is byte-identical to pre-#75.
+        let directionDecl = EPUBPagedAxis.directionCSS(axis: axis)
+        let directionLine = directionDecl.isEmpty ? "" : "\n            \(directionDecl)"
         // Bug #171: `column-width` alone is a HINT (minimum desired
         // width). The browser will fit as many columns as the available
         // body width permits — which produced a two-column "newspaper"
@@ -70,7 +76,7 @@ enum EPUBPaginationHelper {
             height: \(h)px !important;
             overflow: hidden !important;
             margin: 0;
-            -webkit-column-break-inside: avoid;
+            -webkit-column-break-inside: avoid;\(directionLine)
         }
         img, svg, video, figure {
             break-inside: avoid;
@@ -94,9 +100,14 @@ enum EPUBPaginationHelper {
     ///   - page: Zero-based page index. Negative values are treated as 0.
     ///   - viewportWidth: The viewport width used to compute scroll offset.
     /// - Returns: A JavaScript string that sets the horizontal scroll position.
-    static func navigateToPageJS(page: Int, viewportWidth: CGFloat) -> String {
-        let safePage = max(0, page)
-        let offset = safePage * Int(viewportWidth)
+    static func navigateToPageJS(
+        page: Int, viewportWidth: CGFloat, axis: PageAxis = .horizontalLTR
+    ) -> String {
+        // Feature #75 WI-2: axis-aware page→scrollLeft offset. LTR is unchanged
+        // (positive); RTL / vertical-rl negate (WebKit negative-scrollLeft).
+        let offset = EPUBPagedAxis.scrollOffset(
+            page: page, viewportWidth: Int(viewportWidth), axis: axis
+        )
         return """
         (function() {
             document.documentElement.scrollLeft = \(offset);
@@ -222,8 +233,12 @@ enum EPUBPaginationHelper {
     // MARK: - JS: CSS Injection/Removal
 
     /// Generates JavaScript to inject or replace the pagination CSS style element.
-    static func injectPaginationCSSJS(viewportWidth: CGFloat, viewportHeight: CGFloat) -> String {
-        let css = paginationCSS(viewportWidth: viewportWidth, viewportHeight: viewportHeight)
+    static func injectPaginationCSSJS(
+        viewportWidth: CGFloat, viewportHeight: CGFloat, axis: PageAxis = .horizontalLTR
+    ) -> String {
+        let css = paginationCSS(
+            viewportWidth: viewportWidth, viewportHeight: viewportHeight, axis: axis
+        )
         // Bug #136: delegate to the shared escape helper for parity with
         // FoliateJSEscaper-routed sites and the bug #135 fix.
         let escaped = FoliateJSEscaper.escapeForJSString(css)

--- a/vreaderTests/Views/Reader/EPUBPagedAxisTests.swift
+++ b/vreaderTests/Views/Reader/EPUBPagedAxisTests.swift
@@ -1,0 +1,87 @@
+// Feature #75 WI-2 — tests for the pure EPUBPagedAxis seams (page→scroll offset
+// + direction CSS per PageAxis). The WKWebView layout behavior is validated
+// on-device in WI-5; these pin the pure generators.
+
+import Testing
+@testable import vreader
+
+@Suite("EPUBPagedAxis")
+struct EPUBPagedAxisTests {
+
+    // MARK: - scrollOffset
+
+    @Test func ltr_offsetIsPositive() {
+        #expect(EPUBPagedAxis.scrollOffset(page: 0, viewportWidth: 400, axis: .horizontalLTR) == 0)
+        #expect(EPUBPagedAxis.scrollOffset(page: 1, viewportWidth: 400, axis: .horizontalLTR) == 400)
+        #expect(EPUBPagedAxis.scrollOffset(page: 3, viewportWidth: 400, axis: .horizontalLTR) == 1200)
+    }
+
+    @Test func rtl_offsetIsNegated() {
+        // WebKit RTL: scrollLeft 0 at the start (right) edge, negative toward later pages.
+        #expect(EPUBPagedAxis.scrollOffset(page: 0, viewportWidth: 400, axis: .horizontalRTL) == 0)
+        #expect(EPUBPagedAxis.scrollOffset(page: 1, viewportWidth: 400, axis: .horizontalRTL) == -400)
+        #expect(EPUBPagedAxis.scrollOffset(page: 3, viewportWidth: 400, axis: .horizontalRTL) == -1200)
+    }
+
+    @Test func verticalRL_usesNegativeScrollLikeRTL() {
+        #expect(EPUBPagedAxis.scrollOffset(page: 2, viewportWidth: 400, axis: .verticalRL) == -800)
+    }
+
+    @Test func scrollOffset_clampsNegativePageAndWidth() {
+        #expect(EPUBPagedAxis.scrollOffset(page: -5, viewportWidth: 400, axis: .horizontalLTR) == 0)
+        #expect(EPUBPagedAxis.scrollOffset(page: 2, viewportWidth: -400, axis: .horizontalLTR) == 0)
+        #expect(EPUBPagedAxis.scrollOffset(page: -5, viewportWidth: 400, axis: .horizontalRTL) == 0)
+    }
+
+    // MARK: - directionCSS
+
+    @Test func ltr_directionCSS_isEmpty() {
+        #expect(EPUBPagedAxis.directionCSS(axis: .horizontalLTR) == "")
+    }
+
+    @Test func rtl_directionCSS_setsDirectionRTL() {
+        let css = EPUBPagedAxis.directionCSS(axis: .horizontalRTL)
+        #expect(css.contains("direction: rtl !important;"))
+        #expect(!css.contains("writing-mode"))
+    }
+
+    @Test func verticalRL_directionCSS_setsWritingModeAndDirection() {
+        let css = EPUBPagedAxis.directionCSS(axis: .verticalRL)
+        #expect(css.contains("writing-mode: vertical-rl !important;"))
+        #expect(css.contains("direction: rtl !important;"))
+    }
+
+    // MARK: - paginationCSS integration (LTR byte-identity + non-LTR injection)
+
+    @Test func paginationCSS_ltr_hasNoDirectionDeclarations() {
+        let css = EPUBPaginationHelper.paginationCSS(viewportWidth: 400, viewportHeight: 800)
+        #expect(!css.contains("direction:"))
+        #expect(!css.contains("writing-mode:"))
+    }
+
+    @Test func paginationCSS_ltr_defaultMatchesExplicitLTR() {
+        // The default (no axis) must be byte-identical to explicit .horizontalLTR.
+        let implicit = EPUBPaginationHelper.paginationCSS(viewportWidth: 400, viewportHeight: 800)
+        let explicit = EPUBPaginationHelper.paginationCSS(
+            viewportWidth: 400, viewportHeight: 800, axis: .horizontalLTR)
+        #expect(implicit == explicit)
+    }
+
+    @Test func paginationCSS_rtl_injectsDirection() {
+        let css = EPUBPaginationHelper.paginationCSS(
+            viewportWidth: 400, viewportHeight: 800, axis: .horizontalRTL)
+        #expect(css.contains("direction: rtl !important;"))
+    }
+
+    @Test func paginationCSS_verticalRL_injectsWritingMode() {
+        let css = EPUBPaginationHelper.paginationCSS(
+            viewportWidth: 400, viewportHeight: 800, axis: .verticalRL)
+        #expect(css.contains("writing-mode: vertical-rl !important;"))
+    }
+
+    @Test func navigateToPageJS_rtl_usesNegativeOffset() {
+        let js = EPUBPaginationHelper.navigateToPageJS(
+            page: 2, viewportWidth: 400, axis: .horizontalRTL)
+        #expect(js.contains("scrollLeft = -800"))
+    }
+}


### PR DESCRIPTION
Part of **Feature #75**, foundational WI-2. New pure `EPUBPagedAxis` (page→scrollLeft offset + direction/writing-mode CSS per `PageAxis`), wired into `navigateToPageJS`/`paginationCSS`/`injectPaginationCSSJS` with `axis` defaulting to LTR (existing callers byte-unchanged, pinned by a test). RTL = negative scrollLeft; verticalRL scroll axis is a WI-5-device-validated hypothesis. Tests green; Codex audit 1 round ship-as-is (LTR byte-identity + wrapper axis param fixed). Version 3.41.24 → 3.41.25.