### PR TITLE
feat(#75 WI-3): pre-pagination page-axis probe + plumbing

### DIFF
--- a/.claude/codex-audits/feat-feature-75-wi3-pageaxis-probe-audit.md
+++ b/.claude/codex-audits/feat-feature-75-wi3-pageaxis-probe-audit.md
@@ -1,0 +1,55 @@
+---
+branch: feat/feature-75-wi3-pageaxis-probe
+threadId: codex-exec-readonly
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-05-31
+---
+
+# Codex audit — Feature #75 WI-3 (pre-pagination page-axis probe)
+
+Read-only `codex exec` audit, 3 rounds. Behavioral WI.
+
+## Summary
+
+`setupPagination` now evaluates `EPUBPageAxisProbe.computedStyleJS` FIRST (before
+injecting pagination CSS), resolves the per-document `PageAxis` (hint `.auto`),
+stores `coordinator.currentPageAxis`, then a new `paginate()` injects CSS +
+counts pages + navigates using that axis. `updateUIView`'s page-nav also reads
+`currentPageAxis`. New `EPUBPageAxisProbe` (JS + JSON parse + resolve) is pure +
+unit-tested.
+
+## Round 1 (High)
+
+- The async probe→paginate chain wasn't scoped to the load generation — a chapter
+  change mid-chain could write the wrong axis / publish a wrong page count. Fixed:
+  monotonic `paginationGeneration` incremented per `setupPagination`; the probe
+  callback + the totalPages hops guard `== generation`.
+
+## Round 2 (High + Medium)
+
+- `onPaginationReady` Task and the pending-nav eval still ran unguarded. Fixed:
+  the `Task { @MainActor }` re-checks the generation before `onPaginationReady`;
+  the pending nav is gated by `if paginationGeneration == generation` immediately
+  before the eval.
+
+## Round 3 (Medium — ACCEPTED with rationale)
+
+- Once `evaluateJavaScript(injectJS)` is dispatched, a newer `setupPagination`
+  could start before that JS runs, so the stale CSS could momentarily inject.
+  **Accepted**: `injectPaginationCSSJS` removes-and-replaces the
+  `#vreader-pagination` style element by id, so the newer generation's injection
+  overwrites any stale one — the END-STATE CSS is always the latest generation's.
+  The only effect is a sub-frame transient if two chapter loads race within the
+  eval latency; the guarded completion (totalPages/onPaginationReady/nav) of the
+  stale chain still bails, so no wrong page count / nav. No page-side token added
+  — the cost (a JS contract token round-trip) exceeds the benefit for a
+  self-correcting transient.
+
+## Verdict
+
+ship-as-is. LTR is behaviorally unchanged (axis defaults LTR → byte-identical CSS
++ positive offsets; probe failure falls back through `.auto` to LTR). Tests:
+`EPUBPageAxisProbeTests` (resolve + robustness) green; EPUB bridge suite green.
+The visual RTL/vertical rendering is device-verified at the WI-5/WI-6 acceptance
+gate (binding per the plan) — this WI delivers the probe + axis plumbing.

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 751
-        MARKETING_VERSION: 3.41.25
+        CURRENT_PROJECT_VERSION: 752
+        MARKETING_VERSION: 3.41.26
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -834,6 +834,7 @@
 		90D2C41C30E622E119877967 /* BackupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5350DA755A0BB669AE8D3FBD /* BackupViewModelTests.swift */; };
 		915C38C106026EB4386107C5 /* FoliateChapterTextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF17767136D4087D5F38F901 /* FoliateChapterTextProvider.swift */; };
 		916CF15735E1F170E2CE4695 /* HTTPTTSConfigStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CD66C1E52331AC245386C9 /* HTTPTTSConfigStore.swift */; };
+		91B1FD3EEE9D392F1274E2C9 /* EPUBPageAxisProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11A6F4B5DD22F0A6EE84B48 /* EPUBPageAxisProbeTests.swift */; };
 		91B218D155D6760DBC8D733A /* EPUBReaderContainerView+Highlights.swift in Sources */ = {isa = PBXBuildFile; fileRef = A922B4886FE1CE378009FB1B /* EPUBReaderContainerView+Highlights.swift */; };
 		91B3A04F3B23BE09FCA9967C /* LazyDownloadDelegateStagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D4DDB55DA30E015172A16D /* LazyDownloadDelegateStagingTests.swift */; };
 		91B6BC18F3DE3D9A54B7C30B /* FontSizeCalibrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE9DA4CCA7E942838A838495 /* FontSizeCalibrator.swift */; };
@@ -949,6 +950,7 @@
 		A6AD2E80D9CF312EF3AB962C /* TapZoneConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20EBB13D56BE43A552188D9F /* TapZoneConfig.swift */; };
 		A6E44E99068166200DADB131 /* TXTTocRuleEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D8A001ABD732F1E2FF24463 /* TXTTocRuleEngine.swift */; };
 		A72A8023369D98CC9A93D00F /* ReaderContainerView+DebugBridgePosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B6C9DDFFC8DC87C03983B5 /* ReaderContainerView+DebugBridgePosition.swift */; };
+		A738D1DE426FA9E098381F98 /* EPUBPageAxisProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0847128AEF3C85341A6A24BF /* EPUBPageAxisProbe.swift */; };
 		A74E0B8A07E4DD90EB24B234 /* AIProviderPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43809A2F181DF2BBEAAD50C5 /* AIProviderPickerViewModel.swift */; };
 		A7C1006FE4BB21D62EA2C0AF /* TXTContinuousChunkBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EEEA47C4E7D01D716EF2A4 /* TXTContinuousChunkBuilderTests.swift */; };
 		A7E0981C4B45F1FA7D8A9F91 /* ReadiumEPUBHost+Background.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB02D21C1EF95E878B2A1B5E /* ReadiumEPUBHost+Background.swift */; };
@@ -1494,6 +1496,7 @@
 		07B1C372BC384811003D5608 /* ReaderSettingsPanelChineseConversionGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsPanelChineseConversionGateTests.swift; sourceTree = "<group>"; };
 		07DE6A6AACF59EC026271CC3 /* PersistenceActor+ReadingWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+ReadingWindow.swift"; sourceTree = "<group>"; };
 		0802B8C85A3A602D945756B2 /* Feature62AnnotationsSplitVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature62AnnotationsSplitVerificationTests.swift; sourceTree = "<group>"; };
+		0847128AEF3C85341A6A24BF /* EPUBPageAxisProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBPageAxisProbe.swift; sourceTree = "<group>"; };
 		084985F81373662E33980955 /* ReadiumTTSFollowMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumTTSFollowMapperTests.swift; sourceTree = "<group>"; };
 		086557F549C56946CFD6194E /* FoliateSpikeView+HighlightTap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FoliateSpikeView+HighlightTap.swift"; sourceTree = "<group>"; };
 		08710FD2531ABF39338B56E9 /* SearchSheetPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSheetPlaceholderTests.swift; sourceTree = "<group>"; };
@@ -2795,6 +2798,7 @@
 		F05F28A8422C4AB0951D9586 /* EPUBContinuousScrollBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBContinuousScrollBridge.swift; sourceTree = "<group>"; };
 		F069A328AA628585D86B52B2 /* SyncStatusViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusViewTests.swift; sourceTree = "<group>"; };
 		F114D9F3F59EEF655D5327EA /* EPUBCoverParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBCoverParsingTests.swift; sourceTree = "<group>"; };
+		F11A6F4B5DD22F0A6EE84B48 /* EPUBPageAxisProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBPageAxisProbeTests.swift; sourceTree = "<group>"; };
 		F16AF7EAA6EC1F1D0D126E75 /* BasePageNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePageNavigator.swift; sourceTree = "<group>"; };
 		F17C33D19BD1735676CA01BC /* TXTReaderContainerHighlightCoordinatorWiringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReaderContainerHighlightCoordinatorWiringTests.swift; sourceTree = "<group>"; };
 		F1B78961833B958737E550A6 /* FoliateBottomChromeLabels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateBottomChromeLabels.swift; sourceTree = "<group>"; };
@@ -3389,6 +3393,7 @@
 				5C5EC86BB06D46DC9A5A4F6B /* EPUBHighlightBridgeTests.swift */,
 				59540377ED7FDB678914B972 /* EPUBHighlightRendererBug77Tests.swift */,
 				9A8BD899A79BEB3964941631 /* EPUBHighlightTapBridgeTests.swift */,
+				F11A6F4B5DD22F0A6EE84B48 /* EPUBPageAxisProbeTests.swift */,
 				A56CF939EF4F69F9304BC332 /* EPUBPagedAxisTests.swift */,
 				002A1A054B82164581081351 /* EPUBPagedProgressTests.swift */,
 				B9500033AC714D470A3024F8 /* EPUBPaginationTests.swift */,
@@ -3963,6 +3968,7 @@
 				435C00E099B7F5D7A7821FDC /* EPUBHighlightBridge.swift */,
 				44423E8976A2B27C4B14617F /* EPUBHighlightJS.swift */,
 				3650C684EB90A5D7E2F8059A /* EPUBHighlightRenderer.swift */,
+				0847128AEF3C85341A6A24BF /* EPUBPageAxisProbe.swift */,
 				8401AD7C7023A69BE9B68215 /* EPUBPagedAxis.swift */,
 				43677A0B2B4A42609A2800ED /* EPUBPagedProgress.swift */,
 				E5EC9B0FFB09D08F65F205F3 /* EPUBPaginationHelper.swift */,
@@ -5622,6 +5628,7 @@
 				56A100BED3272494DE799F55 /* EPUBHighlightRendererBug77Tests.swift in Sources */,
 				D371F8D98EA9603C6BF3E6ED /* EPUBHighlightTapBridgeTests.swift in Sources */,
 				3D31B039400E1A83C4A1DF6D /* EPUBMetadataExtractorTests.swift in Sources */,
+				91B1FD3EEE9D392F1274E2C9 /* EPUBPageAxisProbeTests.swift in Sources */,
 				DD69A5306F3DA8F15F1091E0 /* EPUBPagedAxisTests.swift in Sources */,
 				E431016A81D6B202241B4275 /* EPUBPagedProgressTests.swift in Sources */,
 				5BA867B4591F0916810C91B8 /* EPUBPaginationTests.swift in Sources */,
@@ -6253,6 +6260,7 @@
 				EE8189DAD855D15887FBBCFA /* EPUBHighlightJS.swift in Sources */,
 				863103455E8B23D20B97F192 /* EPUBHighlightRenderer.swift in Sources */,
 				1D0B7D11E74A0E06F27A9F8B /* EPUBLayoutPreference.swift in Sources */,
+				A738D1DE426FA9E098381F98 /* EPUBPageAxisProbe.swift in Sources */,
 				D3A9394A17D78A98DDF4E618 /* EPUBPagedAxis.swift in Sources */,
 				3E445837C0B98903CFCC5AD7 /* EPUBPagedProgress.swift in Sources */,
 				39699408A91BBF24E36FCE53 /* EPUBPaginationHelper.swift in Sources */,
@@ -6928,13 +6936,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 751;
+				CURRENT_PROJECT_VERSION = 752;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.25;
+				MARKETING_VERSION = 3.41.26;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -7078,13 +7086,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 751;
+				CURRENT_PROJECT_VERSION = 752;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.25;
+				MARKETING_VERSION = 3.41.26;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Views/Reader/EPUBPageAxisProbe.swift
+++ b/vreader/Views/Reader/EPUBPageAxisProbe.swift
@@ -1,0 +1,53 @@
+// Purpose: Feature #75 WI-3 — the pre-pagination page-axis probe. Evaluates the
+// loaded EPUB spine document's COMPUTED writing-mode / direction (+ the document
+// `dir` / `lang`) and resolves it through `PageAxisResolver`. Must run BEFORE the
+// app injects its pagination CSS, so it reads the BOOK's writing direction rather
+// than the app-authored column CSS (Gate-2 High). The JS + JSON parsing are split
+// out as a pure seam so the resolution is unit-testable without a WKWebView.
+//
+// @coordinates-with: PageAxisResolver.swift, EPUBWebViewBridgeCoordinator.swift
+//   (setupPagination evaluates `computedStyleJS`, then calls `resolve`).
+
+import Foundation
+
+enum EPUBPageAxisProbe {
+    /// JS that returns a JSON string of the body's computed writing direction.
+    /// Run this on the loaded document BEFORE pagination CSS injection.
+    static let computedStyleJS = """
+    (function() {
+        var s = getComputedStyle(document.body);
+        var de = document.documentElement;
+        return JSON.stringify({
+            wm: s.writingMode || '',
+            dir: s.direction || '',
+            docDir: (de.getAttribute('dir') || document.body.getAttribute('dir') || ''),
+            lang: (de.getAttribute('lang') || document.body.getAttribute('lang') || de.lang || '')
+        });
+    })();
+    """
+
+    /// Resolve the `PageAxis` from the probe's `evaluateJavaScript` result.
+    /// A nil / malformed result falls back to resolving with empty computed
+    /// values (so the hint / default decides) — never crashes.
+    static func resolve(from evalResult: Any?, hint: ReadingDirection) -> PageAxis {
+        let dict = parse(evalResult)
+        return PageAxisResolver.resolve(
+            writingMode: dict["wm"] ?? "",
+            direction: dict["dir"] ?? "",
+            dir: dict["docDir"],
+            lang: dict["lang"],
+            readingDirectionHint: hint
+        )
+    }
+
+    /// Parse the probe JSON into a `[String: String]`; `[:]` on any failure.
+    static func parse(_ evalResult: Any?) -> [String: String] {
+        guard let json = evalResult as? String,
+              let data = json.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data),
+              let dict = obj as? [String: String] else {
+            return [:]
+        }
+        return dict
+    }
+}

--- a/vreader/Views/Reader/EPUBWebViewBridge.swift
+++ b/vreader/Views/Reader/EPUBWebViewBridge.swift
@@ -431,8 +431,11 @@ struct EPUBWebViewBridge: UIViewRepresentable {
             // Paged mode: navigate to specific page
             context.coordinator.pendingPaginationPage = page
             let viewportWidth = webView.bounds.width
+            // Feature #75 WI-3: honor the resolved per-document page axis (RTL /
+            // vertical) for the offset direction.
             let js = EPUBPaginationHelper.navigateToPageJS(
-                page: page, viewportWidth: viewportWidth
+                page: page, viewportWidth: viewportWidth,
+                axis: context.coordinator.currentPageAxis
             )
             webView.evaluateJavaScript(js) { _, error in
                 if let error { AppLogger.epub.error("page nav error: \(error)") }

--- a/vreader/Views/Reader/EPUBWebViewBridgeCoordinator.swift
+++ b/vreader/Views/Reader/EPUBWebViewBridgeCoordinator.swift
@@ -32,6 +32,18 @@ extension EPUBWebViewBridge {
         var pendingScrollFraction: Double?
         /// Page index to navigate to after pagination setup (paged mode).
         var pendingPaginationPage: Int?
+        /// Feature #75 WI-3: the loaded spine document's resolved page axis
+        /// (RTL / vertical), set by the pre-pagination probe in
+        /// `setupPagination` and consumed by the pagination CSS + page nav.
+        /// Per-document — re-resolved on every chapter load. Defaults to LTR.
+        var currentPageAxis: PageAxis = .horizontalLTR
+        /// Feature #75 WI-3: monotonic token incremented on each
+        /// `setupPagination`. The async probe→paginate chain captures it and
+        /// bails if a newer pagination (chapter change, resize, theme re-paginate)
+        /// has started — so a stale chapter's probe can't write `currentPageAxis`
+        /// / inject CSS / publish a page count against the wrong load. A counter
+        /// (not `expectedURL`) because same-URL re-pagination also exists.
+        var paginationGeneration = 0
         /// Bug #182: highlight JS deferred from a URL-change update so it
         /// runs against the NEW chapter DOM, not the old/loading one. Set
         /// in `EPUBWebViewBridge.updateUIView` when `pendingJS` arrives in
@@ -586,8 +598,35 @@ extension EPUBWebViewBridge {
             // through the safe-area branch.
             lastPagedBounds = webView.bounds
 
+            // Feature #75 WI-3: probe the loaded document's COMPUTED writing
+            // direction BEFORE injecting pagination CSS, so we read the BOOK's
+            // direction (not our column CSS — Gate-2 High). Resolve + store the
+            // per-document `PageAxis`; this re-runs on every chapter load
+            // (setupPagination is called per load), so a mixed-direction book
+            // gets per-section axes. The coordinator has no book metadata, so
+            // the hint is `.auto` — the computed values are authoritative.
+            paginationGeneration &+= 1
+            let generation = paginationGeneration
+            webView.evaluateJavaScript(EPUBPageAxisProbe.computedStyleJS) { [weak self] probeResult, _ in
+                guard let self, self.paginationGeneration == generation else { return }
+                self.currentPageAxis = EPUBPageAxisProbe.resolve(from: probeResult, hint: .auto)
+                self.paginate(
+                    webView: webView, viewportWidth: viewportWidth,
+                    viewportHeight: viewportHeight, generation: generation
+                )
+            }
+        }
+
+        /// Inject the pagination CSS for the resolved `currentPageAxis`, query
+        /// the page count, and apply the restore / pending-page navigation.
+        /// Called by `setupPagination` after the page-axis probe resolves.
+        private func paginate(
+            webView: WKWebView, viewportWidth: CGFloat, viewportHeight: CGFloat,
+            generation: Int
+        ) {
             let injectJS = EPUBPaginationHelper.injectPaginationCSSJS(
-                viewportWidth: viewportWidth, viewportHeight: viewportHeight
+                viewportWidth: viewportWidth, viewportHeight: viewportHeight,
+                axis: currentPageAxis
             )
             webView.evaluateJavaScript(injectJS) { [weak self] _, error in
                 if let error {
@@ -596,12 +635,12 @@ extension EPUBWebViewBridge {
                 }
                 // Delay to allow column layout to settle before querying page count
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                    guard let self else { return }
+                    guard let self, self.paginationGeneration == generation else { return }
                     let totalPagesJS = EPUBPaginationHelper.totalPagesJS(
                         viewportWidth: viewportWidth
                     )
                     webView.evaluateJavaScript(totalPagesJS) { [weak self] result, error in
-                        guard let self else { return }
+                        guard let self, self.paginationGeneration == generation else { return }
                         if let error {
                             AppLogger.epub.error("totalPages query error: \(error)")
                             return
@@ -628,17 +667,23 @@ extension EPUBWebViewBridge {
                         // The restore fraction is a one-shot intent consumed here.
                         self.pendingScrollFraction = nil
 
-                        Task { @MainActor in
+                        Task { @MainActor [weak self] in
+                            // WI-3: re-check the generation inside the hop — a
+                            // newer pagination may have started before this task runs.
+                            guard let self, self.paginationGeneration == generation else { return }
                             self.onPaginationReady?(totalPages, resumeFromFraction)
                         }
 
                         // Navigate to an explicit pending page if set (the
                         // container already owns that page state — only the
                         // fraction path needs the container-side sync above).
-                        if let page = self.pendingPaginationPage, page > 0 {
+                        // Re-guard the generation immediately before the nav eval.
+                        if self.paginationGeneration == generation,
+                           let page = self.pendingPaginationPage, page > 0 {
                             self.pendingPaginationPage = nil
                             let navJS = EPUBPaginationHelper.navigateToPageJS(
-                                page: page, viewportWidth: viewportWidth
+                                page: page, viewportWidth: viewportWidth,
+                                axis: self.currentPageAxis
                             )
                             webView.evaluateJavaScript(navJS) { _, error in
                                 if let error {

--- a/vreaderTests/Views/Reader/EPUBPageAxisProbeTests.swift
+++ b/vreaderTests/Views/Reader/EPUBPageAxisProbeTests.swift
@@ -1,0 +1,69 @@
+// Feature #75 WI-3 — tests for the pure parse + resolve half of the
+// pre-pagination page-axis probe (the WKWebView eval is integration-tested
+// on-device in WI-5).
+
+import Testing
+@testable import vreader
+
+@Suite("EPUBPageAxisProbe")
+struct EPUBPageAxisProbeTests {
+
+    private func json(wm: String = "", dir: String = "", docDir: String = "", lang: String = "") -> String {
+        #"{"wm":"\#(wm)","dir":"\#(dir)","docDir":"\#(docDir)","lang":"\#(lang)"}"#
+    }
+
+    @Test func resolvesVerticalRLFromWritingMode() {
+        let axis = EPUBPageAxisProbe.resolve(
+            from: json(wm: "vertical-rl", dir: "ltr"), hint: .auto)
+        #expect(axis == .verticalRL)
+    }
+
+    @Test func resolvesHorizontalRTLFromComputedDirection() {
+        let axis = EPUBPageAxisProbe.resolve(
+            from: json(wm: "horizontal-tb", dir: "rtl"), hint: .ltr)
+        #expect(axis == .horizontalRTL)
+    }
+
+    @Test func resolvesHorizontalLTRDefault() {
+        let axis = EPUBPageAxisProbe.resolve(
+            from: json(wm: "horizontal-tb", dir: "ltr"), hint: .auto)
+        #expect(axis == .horizontalLTR)
+    }
+
+    @Test func ambiguousComputed_fallsBackToDocDir() {
+        let axis = EPUBPageAxisProbe.resolve(
+            from: json(wm: "horizontal-tb", dir: "", docDir: "rtl"), hint: .ltr)
+        #expect(axis == .horizontalRTL)
+    }
+
+    @Test func ambiguousComputed_autoHint_rtlLang() {
+        let axis = EPUBPageAxisProbe.resolve(
+            from: json(wm: "horizontal-tb", dir: "", lang: "ar"), hint: .auto)
+        #expect(axis == .horizontalRTL)
+    }
+
+    // MARK: - Robustness
+
+    @Test func nilResult_fallsBackToHint() {
+        #expect(EPUBPageAxisProbe.resolve(from: nil, hint: .rtl) == .horizontalRTL)
+        #expect(EPUBPageAxisProbe.resolve(from: nil, hint: .ltr) == .horizontalLTR)
+    }
+
+    @Test func malformedJSON_fallsBackToHint() {
+        #expect(EPUBPageAxisProbe.resolve(from: "not json", hint: .rtl) == .horizontalRTL)
+        #expect(EPUBPageAxisProbe.resolve(from: 42, hint: .ltr) == .horizontalLTR)
+    }
+
+    @Test func parse_emptyOnGarbage() {
+        #expect(EPUBPageAxisProbe.parse(nil).isEmpty)
+        #expect(EPUBPageAxisProbe.parse("[]").isEmpty)
+        #expect(EPUBPageAxisProbe.parse("{\"wm\":\"vertical-rl\"}")["wm"] == "vertical-rl")
+    }
+
+    @Test func computedStyleJS_readsBodyAndDocElement() {
+        // Contract: the probe reads computed body style + the doc dir/lang.
+        #expect(EPUBPageAxisProbe.computedStyleJS.contains("getComputedStyle(document.body)"))
+        #expect(EPUBPageAxisProbe.computedStyleJS.contains("writingMode"))
+        #expect(EPUBPageAxisProbe.computedStyleJS.contains("direction"))
+    }
+}


### PR DESCRIPTION
Part of **Feature #75**, behavioral WI-3. `setupPagination` evaluates a computed-writing-direction probe BEFORE injecting pagination CSS, resolves the per-document `PageAxis`, stores `currentPageAxis`, and threads it into pagination CSS + page nav (per-document, re-resolved per chapter load). A monotonic `paginationGeneration` guards every async hop so a chapter change mid-chain can't write a stale axis. LTR behaviorally unchanged. Codex audit **3 rounds** ship-as-is (caught + fixed real concurrency hazards: generation scoping across probe→paginate→onPaginationReady→nav). Visual RTL/vertical rendering is device-verified at the WI-5/WI-6 acceptance gate. Version 3.41.25 → 3.41.26.