### PR TITLE
feat(#75 WI-4): RTL/vertical tap + swipe input inversion

### DIFF
--- a/.claude/codex-audits/feat-feature-75-wi4-rtl-input-audit.md
+++ b/.claude/codex-audits/feat-feature-75-wi4-rtl-input-audit.md
@@ -1,0 +1,32 @@
+---
+branch: feat/feature-75-wi4-rtl-input
+threadId: codex-exec-readonly
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-05-31
+---
+
+# Codex audit — Feature #75 WI-4 (RTL tap + swipe input inversion)
+
+Read-only `codex exec` audit. Behavioral WI. No findings.
+
+## Summary
+
+Two pure helpers on `EPUBPagedAxis`: `tapZoneConfig(base:axis:)` (LTR returns
+base; RTL/vertical-rl mirror left↔right zone actions) and `swipeOutcome(_:axis:)`
+(LTR unchanged; RTL/vertical-rl swap next↔previous). Wired into the EPUB-paged
+content-tap dispatch (`config:` arg, NOT the shared router default) and the
+paged-swipe handler.
+
+## Findings
+
+None. Codex confirmed: RTL tap mirror correct (left zone → next, right → prev);
+swipe inversion correct (leftward swipe → previous in RTL); LTR identical;
+`currentPageAxis` is the per-document probed axis (generation-guarded, no stale
+risk); center action + custom base preserved; no concurrency issue.
+
+## Verdict
+
+ship-as-is. Tests: `EPUBPagedAxisTests` WI-4 cases (tap mirror LTR/RTL/vertical +
+custom base; swipe inversion). Visual RTL tap/swipe behavior is device-verified
+at the WI-6 acceptance gate.

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 752
-        MARKETING_VERSION: 3.41.26
+        CURRENT_PROJECT_VERSION: 753
+        MARKETING_VERSION: 3.41.27
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6936,13 +6936,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 752;
+				CURRENT_PROJECT_VERSION = 753;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.26;
+				MARKETING_VERSION = 3.41.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -7086,13 +7086,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 752;
+				CURRENT_PROJECT_VERSION = 753;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.26;
+				MARKETING_VERSION = 3.41.27;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Views/Reader/EPUBPagedAxis.swift
+++ b/vreader/Views/Reader/EPUBPagedAxis.swift
@@ -43,4 +43,40 @@ enum EPUBPagedAxis {
             return "writing-mode: vertical-rl !important; direction: rtl !important;"
         }
     }
+
+    /// The EPUB-paged tap-zone config for `axis` (Feature #75 WI-4). LTR returns
+    /// `base` unchanged; RTL / vertical-rl mirror the left↔right zone actions so
+    /// a tap on the leading edge advances and the trailing edge goes back — i.e.
+    /// tap zones follow reading order WITHOUT mutating the shared
+    /// `ReaderTapZoneRouter` default used by every other format.
+    static func tapZoneConfig(base: TapZoneConfig, axis: PageAxis) -> TapZoneConfig {
+        switch axis {
+        case .horizontalLTR:
+            return base
+        case .horizontalRTL, .verticalRL:
+            return TapZoneConfig(
+                leftAction: base.rightAction,
+                centerAction: base.centerAction,
+                rightAction: base.leftAction
+            )
+        }
+    }
+
+    /// Invert a swipe outcome for an RTL / vertical-rl axis (Feature #75 WI-4):
+    /// a leftward swipe advances in LTR but goes to the PREVIOUS page in RTL.
+    /// LTR returns the outcome unchanged.
+    static func swipeOutcome(
+        _ outcome: EPUBSwipeGestureClassifier.SwipeOutcome, axis: PageAxis
+    ) -> EPUBSwipeGestureClassifier.SwipeOutcome {
+        switch axis {
+        case .horizontalLTR:
+            return outcome
+        case .horizontalRTL, .verticalRL:
+            switch outcome {
+            case .nextPage: return .previousPage
+            case .previousPage: return .nextPage
+            case .none: return .none
+            }
+        }
+    }
 }

--- a/vreader/Views/Reader/EPUBWebViewBridgeCoordinator.swift
+++ b/vreader/Views/Reader/EPUBWebViewBridgeCoordinator.swift
@@ -172,10 +172,16 @@ extension EPUBWebViewBridge {
                        let x = (dict["x"] as? NSNumber)?.doubleValue,
                        let w = (dict["w"] as? NSNumber)?.doubleValue,
                        w > 0 {
+                        // Feature #75 WI-4: mirror the tap zones for an RTL /
+                        // vertical-rl document so they follow reading order,
+                        // without changing the shared router default.
                         ReaderTapZoneRouter.dispatch(
                             x: CGFloat(x),
                             totalWidth: CGFloat(w),
-                            layout: self.isPaged ? .paged : .scroll
+                            layout: self.isPaged ? .paged : .scroll,
+                            config: EPUBPagedAxis.tapZoneConfig(
+                                base: .default, axis: self.currentPageAxis
+                            )
                         )
                     } else {
                         NotificationCenter.default.post(
@@ -257,9 +263,14 @@ extension EPUBWebViewBridge {
                   let dict = body as? [String: Any],
                   let dx = (dict["dx"] as? NSNumber)?.doubleValue,
                   let dy = (dict["dy"] as? NSNumber)?.doubleValue else { return }
-            let outcome = EPUBSwipeGestureClassifier.classify(
-                deltaX: dx, deltaY: dy,
-                threshold: EPUBSwipeGestureClassifier.defaultThreshold
+            // Feature #75 WI-4: invert the swipe outcome for an RTL / vertical-rl
+            // document (a leftward swipe goes to the PREVIOUS page in RTL).
+            let outcome = EPUBPagedAxis.swipeOutcome(
+                EPUBSwipeGestureClassifier.classify(
+                    deltaX: dx, deltaY: dy,
+                    threshold: EPUBSwipeGestureClassifier.defaultThreshold
+                ),
+                axis: currentPageAxis
             )
             switch outcome {
             case .nextPage:

--- a/vreaderTests/Views/Reader/EPUBPagedAxisTests.swift
+++ b/vreaderTests/Views/Reader/EPUBPagedAxisTests.swift
@@ -84,4 +84,53 @@ struct EPUBPagedAxisTests {
             page: 2, viewportWidth: 400, axis: .horizontalRTL)
         #expect(js.contains("scrollLeft = -800"))
     }
+
+    // MARK: - WI-4: tap-zone mirror
+
+    @Test func tapZoneConfig_ltr_unchanged() {
+        let cfg = EPUBPagedAxis.tapZoneConfig(base: .default, axis: .horizontalLTR)
+        #expect(cfg == TapZoneConfig.default)
+        #expect(cfg.leftAction == .previousPage)
+        #expect(cfg.rightAction == .nextPage)
+    }
+
+    @Test func tapZoneConfig_rtl_mirrorsLeftRight() {
+        let cfg = EPUBPagedAxis.tapZoneConfig(base: .default, axis: .horizontalRTL)
+        #expect(cfg.leftAction == .nextPage)      // leading edge advances in RTL
+        #expect(cfg.rightAction == .previousPage)
+        #expect(cfg.centerAction == .toggleChrome) // center unchanged
+    }
+
+    @Test func tapZoneConfig_verticalRL_mirrors() {
+        let cfg = EPUBPagedAxis.tapZoneConfig(base: .default, axis: .verticalRL)
+        #expect(cfg.leftAction == .nextPage)
+        #expect(cfg.rightAction == .previousPage)
+    }
+
+    @Test func tapZoneConfig_preservesCustomBase() {
+        let base = TapZoneConfig(leftAction: .none, centerAction: .nextPage, rightAction: .previousPage)
+        let cfg = EPUBPagedAxis.tapZoneConfig(base: base, axis: .horizontalRTL)
+        #expect(cfg.leftAction == .previousPage)  // was rightAction
+        #expect(cfg.centerAction == .nextPage)    // unchanged
+        #expect(cfg.rightAction == .none)         // was leftAction
+    }
+
+    // MARK: - WI-4: swipe inversion
+
+    @Test func swipeOutcome_ltr_unchanged() {
+        #expect(EPUBPagedAxis.swipeOutcome(.nextPage, axis: .horizontalLTR) == .nextPage)
+        #expect(EPUBPagedAxis.swipeOutcome(.previousPage, axis: .horizontalLTR) == .previousPage)
+        #expect(EPUBPagedAxis.swipeOutcome(.none, axis: .horizontalLTR) == .none)
+    }
+
+    @Test func swipeOutcome_rtl_inverts() {
+        #expect(EPUBPagedAxis.swipeOutcome(.nextPage, axis: .horizontalRTL) == .previousPage)
+        #expect(EPUBPagedAxis.swipeOutcome(.previousPage, axis: .horizontalRTL) == .nextPage)
+        #expect(EPUBPagedAxis.swipeOutcome(.none, axis: .horizontalRTL) == .none)
+    }
+
+    @Test func swipeOutcome_verticalRL_inverts() {
+        #expect(EPUBPagedAxis.swipeOutcome(.nextPage, axis: .verticalRL) == .previousPage)
+        #expect(EPUBPagedAxis.swipeOutcome(.previousPage, axis: .verticalRL) == .nextPage)
+    }
 }


### PR DESCRIPTION
Part of **Feature #75**, behavioral WI-4. Pure `EPUBPagedAxis.tapZoneConfig` (mirror left↔right tap zones for RTL/vertical-rl, leading edge advances) + `swipeOutcome` (swap next↔previous), wired into the EPUB-paged tap dispatch (`config:` — NOT the shared router default) + swipe handler, reading WI-3's per-document `currentPageAxis`. LTR identical. Codex audit 1 round, **no findings** (RTL tap/swipe direction verified correct). Version 3.41.26 → 3.41.27.