### PR TITLE
docs(#75): RTL device-verification evidence

### DIFF
--- a/dev-docs/verification/feature-75-20260531.md
+++ b/dev-docs/verification/feature-75-20260531.md
@@ -1,0 +1,69 @@
+---
+kind: feature
+id: 75
+status_target: DONE
+commit_sha: e0929934
+app_version: 3.41.28 (build 754)
+date: 2026-05-31
+verifier: claude
+device_or_simulator: iPhone 17 Pro Simulator
+os_version: iOS 26.4
+build_configuration: Debug
+backend: n/a
+result: partial
+---
+
+# Feature #75 — RTL/vertical EPUB paged rendering — device verification
+
+Slice verification of the **horizontal-RTL axis** end-to-end on device, driven
+CU-free via `scripts/sim-tap.sh` + `xcrun simctl io` screenshots. Vertical-rl is
+**deferred** (see Observations).
+
+## Acceptance criteria
+
+| Criterion | Observed | Result |
+|---|---|---|
+| RTL EPUB renders right-aligned | `mini-rtl` chapter 1 — Arabic "الفصل الأول" + body right-aligned, paragraph starts top-RIGHT (drop-cap on right) | ✅ pass |
+| RTL paged mode (columns, single page) | Display → Paged; single page shown, "Chapter 1 of 2" | ✅ pass |
+| RTL tap-direction inversion (WI-4) | LEFT-zone tap advanced Chapter 1 → Chapter 2 (leading edge advances in RTL) | ✅ pass |
+| LTR EPUB unchanged (regression) | `mini-epub3` renders normally, left-aligned, opens + reads | ✅ pass |
+| Vertical-rl (`mini-cjk` ch2) | NOT verified — see Observations | ⬜ deferred |
+
+## Commands run
+
+```bash
+# Build + install the WI-1..4 build
+xcodebuild build -project vreader.xcodeproj -scheme vreader -destination 'platform=iOS Simulator,id=<UDID>' -configuration Debug
+xcrun simctl install <UDID> "<BUILT_PRODUCTS_DIR>/vreader.app"
+xcrun simctl launch <UDID> com.vreader.app --reader-default-layout=paged
+
+# Seed + open mini-rtl, force Paged via the Display sheet, drive taps
+xcrun simctl openurl <UDID> "vreader-debug://reset"
+xcrun simctl openurl <UDID> "vreader-debug://seed?fixture=mini-rtl"
+scripts/sim-tap.sh label "VReader Mini RTL Fixture, by VReader DebugBridge, EPUB format"
+scripts/sim-tap.sh label "Display"; scripts/sim-tap.sh xy 290 769   # Paged
+scripts/sim-tap.sh xy 50 430                                         # left-zone tap → advances in RTL
+scripts/sim-tap.sh shot /tmp/wi5-rtl-after-lefttap.png
+```
+
+## Observations
+
+- The horizontal-RTL path (WI-1 axis resolution → WI-2 `direction: rtl` CSS +
+  negative-scrollLeft → WI-3 pre-pagination probe → WI-4 tap-zone mirror) works
+  end-to-end in production: RTL content renders right-aligned in paged columns,
+  and a left-zone tap advances (RTL reading order).
+- LTR regression check passed — the probe (now on every paged setup) did not
+  break normal EPUB reading.
+- **Vertical-rl deferred**: (a) it needs the remaining WI-5 vertical code (the
+  vertical-`dy` swipe JS + the `{x,y,w,h}` axis-aware tap path + on-device
+  confirmation that the negative-scrollLeft hypothesis is correct for
+  `writing-mode: vertical-rl` columns); (b) device verification is currently
+  blocked by DebugBridge harness friction — `vreader-debug://reset` does not
+  fully swap the seeded library, so `mini-cjk` could not be opened to reach its
+  vertical-rl chapter 2 cleanly.
+
+## Artifacts
+
+- `/tmp/wi5-rtl-paged2.png` — paged RTL chapter 1 (right-aligned)
+- `/tmp/wi5-rtl-after-lefttap.png` — advanced to chapter 2 after a left-zone tap
+- `/tmp/wi5-ltr-reader.png` — LTR regression (mini-epub3 renders normally)

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 754
-        MARKETING_VERSION: 3.41.28
+        CURRENT_PROJECT_VERSION: 755
+        MARKETING_VERSION: 3.41.29
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6936,13 +6936,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 754;
+				CURRENT_PROJECT_VERSION = 755;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.28;
+				MARKETING_VERSION = 3.41.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -7086,13 +7086,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 754;
+				CURRENT_PROJECT_VERSION = 755;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.28;
+				MARKETING_VERSION = 3.41.29;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
Slice verification evidence for Feature #75: the horizontal-RTL path (WI-1..4) is device-verified end-to-end (mini-rtl renders right-aligned paged, left-zone tap advances = RTL reading order, LTR regression passes). result: partial — vertical-rl deferred. Screenshots in the evidence file. Version 3.41.28 → 3.41.29.