### PR TITLE
docs(#75): vertical-rl rendering device-verified

### DIFF
--- a/dev-docs/verification/feature-75-20260531.md
+++ b/dev-docs/verification/feature-75-20260531.md
@@ -15,9 +15,10 @@ result: partial
 
 # Feature #75 — RTL/vertical EPUB paged rendering — device verification
 
-Slice verification of the **horizontal-RTL axis** end-to-end on device, driven
-CU-free via `scripts/sim-tap.sh` + `xcrun simctl io` screenshots. Vertical-rl is
-**deferred** (see Observations).
+Slice verification of the paged-rendering of **both** the horizontal-RTL and
+vertical-rl axes on device, driven CU-free via `scripts/sim-tap.sh` +
+`xcrun simctl io` screenshots. Page-turn input for the vertical axis is the
+remaining WI-5 work (see Observations).
 
 ## Acceptance criteria
 
@@ -27,7 +28,8 @@ CU-free via `scripts/sim-tap.sh` + `xcrun simctl io` screenshots. Vertical-rl is
 | RTL paged mode (columns, single page) | Display → Paged; single page shown, "Chapter 1 of 2" | ✅ pass |
 | RTL tap-direction inversion (WI-4) | LEFT-zone tap advanced Chapter 1 → Chapter 2 (leading edge advances in RTL) | ✅ pass |
 | LTR EPUB unchanged (regression) | `mini-epub3` renders normally, left-aligned, opens + reads | ✅ pass |
-| Vertical-rl (`mini-cjk` ch2) | NOT verified — see Observations | ⬜ deferred |
+| Vertical-rl renders (`mini-cjk` ch2) | clean-installed + seeded `mini-cjk`, Contents → 第二章: Chinese text in vertical columns top-to-bottom, RIGHT-to-LEFT, in paged mode (`writing-mode: vertical-rl` from WI-2 + WI-3 probe → `verticalRL`). Per-document confirmed: ch1 horizontal, ch2 vertical, same book. | ✅ pass |
+| Vertical-rl page-turn input | partial — a left-zone tap toggled chrome rather than paging (single-page last chapter ambiguous); the vertical-`dy` swipe JS + `{x,y,w,h}` tap path are remaining WI-5 work | ⬜ remaining |
 
 ## Commands run
 
@@ -54,16 +56,24 @@ scripts/sim-tap.sh shot /tmp/wi5-rtl-after-lefttap.png
   and a left-zone tap advances (RTL reading order).
 - LTR regression check passed — the probe (now on every paged setup) did not
   break normal EPUB reading.
-- **Vertical-rl deferred**: (a) it needs the remaining WI-5 vertical code (the
-  vertical-`dy` swipe JS + the `{x,y,w,h}` axis-aware tap path + on-device
-  confirmation that the negative-scrollLeft hypothesis is correct for
-  `writing-mode: vertical-rl` columns); (b) device verification is currently
-  blocked by DebugBridge harness friction — `vreader-debug://reset` does not
-  fully swap the seeded library, so `mini-cjk` could not be opened to reach its
-  vertical-rl chapter 2 cleanly.
+- **Vertical-rl RENDERS correctly** (verified after bypassing the harness
+  friction with a clean `simctl uninstall`+`install`+seed): `mini-cjk` chapter 2
+  shows Chinese text in vertical columns, top-to-bottom, right-to-left, in paged
+  mode. The per-document probe correctly resolves ch1 horizontal vs ch2 vertical
+  in the same book. So WI-2's `writing-mode: vertical-rl` CSS + WI-3's probe are
+  confirmed on device.
+- **Vertical page-turn INPUT is the remaining WI-5 work**: the current content-tap
+  path is x/width-only; the plan's vertical `{x,y,w,h}` tap path + vertical-`dy`
+  swipe JS are not yet implemented, so vertical page-turn input is unverified
+  (a left-zone tap toggled chrome on the single-page last chapter).
+- **Harness gap (file as DevTools/Verification)**: `vreader-debug://reset` does
+  not clear the imported-books library, so seeding a second fixture leaves the
+  first; a clean `simctl uninstall`+`install` is the current workaround.
 
 ## Artifacts
 
 - `/tmp/wi5-rtl-paged2.png` — paged RTL chapter 1 (right-aligned)
 - `/tmp/wi5-rtl-after-lefttap.png` — advanced to chapter 2 after a left-zone tap
 - `/tmp/wi5-ltr-reader.png` — LTR regression (mini-epub3 renders normally)
+- `/tmp/wi5-cjk-ch2-vertical.png` — vertical-rl chapter 2 (vertical columns, RTL)
+- `/tmp/wi5-cjk-ch2-after-tap.png` — vertical-rl full-screen (chrome hidden)

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 755
-        MARKETING_VERSION: 3.41.29
+        CURRENT_PROJECT_VERSION: 756
+        MARKETING_VERSION: 3.41.30
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6936,13 +6936,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 755;
+				CURRENT_PROJECT_VERSION = 756;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.29;
+				MARKETING_VERSION = 3.41.30;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -7086,13 +7086,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 755;
+				CURRENT_PROJECT_VERSION = 756;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.29;
+				MARKETING_VERSION = 3.41.30;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
Both #75 axes now device-verified for paged rendering: horizontal-RTL (earlier) + vertical-rl (mini-cjk ch2, vertical columns right-to-left). Vertical page-turn input remains WI-5 work; result stays partial. Documents the reset-doesn't-clear-library harness gap. Version 3.41.29 → 3.41.30.