### PR TITLE
docs(#75): correct vertical-rl verification (eval shows NOT rendering)

### DIFF
--- a/dev-docs/verification/feature-75-20260531.md
+++ b/dev-docs/verification/feature-75-20260531.md
@@ -28,8 +28,8 @@ remaining WI-5 work (see Observations).
 | RTL paged mode (columns, single page) | Display → Paged; single page shown, "Chapter 1 of 2" | ✅ pass |
 | RTL tap-direction inversion (WI-4) | LEFT-zone tap advanced Chapter 1 → Chapter 2 (leading edge advances in RTL) | ✅ pass |
 | LTR EPUB unchanged (regression) | `mini-epub3` renders normally, left-aligned, opens + reads | ✅ pass |
-| Vertical-rl renders (`mini-cjk` ch2) | clean-installed + seeded `mini-cjk`, Contents → 第二章: Chinese text in vertical columns top-to-bottom, RIGHT-to-LEFT, in paged mode (`writing-mode: vertical-rl` from WI-2 + WI-3 probe → `verticalRL`). Per-document confirmed: ch1 horizontal, ch2 vertical, same book. | ✅ pass |
-| Vertical-rl page-turn input | partial — a left-zone tap toggled chrome rather than paging (single-page last chapter ambiguous); the vertical-`dy` swipe JS + `{x,y,w,h}` tap path are remaining WI-5 work | ⬜ remaining |
+| Vertical-rl renders (`mini-cjk` ch2 / `mini-cjk-vlong`) | **CORRECTED — NOT working.** On-device `eval` proves `getComputedStyle(body).writingMode == horizontal-tb` everywhere (de, body, content div) with `colCount: auto`; the book's `writing-mode: vertical-rl` (in `<head><style>`) is NOT applied — the EPUB reader extracts chapter content into a wrapper div and drops/overrides head styles. The earlier 'vertical columns' read was narrow multi-column HORIZONTAL CJK (1-char-wide columns are visually indistinguishable from vertical). So the probe correctly reads horizontal-tb → resolves LTR → the vertical path never triggers. | ❌ fail |
+| Vertical-rl page-turn | blocked by the above — the writing-mode isn't applied, so there is no true vertical layout to page. Separately, `eval` shows the top document has no horizontal overflow (`sw==cw==402`) while the content div does (`sw:2052`), so `navigateToPageJS`'s `documentElement.scrollLeft` targets the wrong element regardless. | ❌ blocked |
 
 ## Commands run
 
@@ -77,6 +77,18 @@ scripts/sim-tap.sh shot /tmp/wi5-rtl-after-lefttap.png
 - **Harness gap (file as DevTools/Verification)**: `vreader-debug://reset` does
   not clear the imported-books library, so seeding a second fixture leaves the
   first; a clean `simctl uninstall`+`install` is the current workaround.
+
+## Correction (eval-grounded)
+
+An earlier revision of this file claimed vertical-rl RENDERS correctly. On-device
+`eval` (`getComputedStyle`) disproves it: writing-mode is `horizontal-tb`
+throughout, so vertical-rl is NOT actually rendering — the visual was narrow
+multi-column horizontal CJK. The real #75 vertical gap is twofold and deeper than
+a pagination sign: (1) the EPUB reader must PRESERVE + apply the book's
+`writing-mode` (head `<style>` is currently dropped when content is extracted into
+the wrapper div), and (2) `navigateToPageJS` must target the actually-scrollable
+element (the content div has horizontal overflow `sw:2052`; the top document does
+not). Only the horizontal-RTL axis is genuinely verified.
 
 ## Artifacts
 

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 757
-        MARKETING_VERSION: 3.41.31
+        CURRENT_PROJECT_VERSION: 758
+        MARKETING_VERSION: 3.41.32
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6936,13 +6936,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 757;
+				CURRENT_PROJECT_VERSION = 758;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.31;
+				MARKETING_VERSION = 3.41.32;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -7086,13 +7086,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 757;
+				CURRENT_PROJECT_VERSION = 758;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.31;
+				MARKETING_VERSION = 3.41.32;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
Honesty correction: on-device eval proves vertical-rl is NOT actually rendering (writingMode horizontal-tb throughout; the book's head-style writing-mode is dropped by the reader's content extraction). The earlier 'vertical renders' was narrow-column horizontal CJK misread as vertical. The real vertical gap is deeper (apply writing-mode + target the right scroll element). Only horizontal-RTL is genuinely verified. Version 3.41.31 → 3.41.32.