### PR TITLE
docs(#75): re-correct vertical-rl — it DOES render (content elements compute vertical-rl)

### DIFF
--- a/dev-docs/verification/feature-75-20260531.md
+++ b/dev-docs/verification/feature-75-20260531.md
@@ -28,8 +28,8 @@ remaining WI-5 work (see Observations).
 | RTL paged mode (columns, single page) | Display → Paged; single page shown, "Chapter 1 of 2" | ✅ pass |
 | RTL tap-direction inversion (WI-4) | LEFT-zone tap advanced Chapter 1 → Chapter 2 (leading edge advances in RTL) | ✅ pass |
 | LTR EPUB unchanged (regression) | `mini-epub3` renders normally, left-aligned, opens + reads | ✅ pass |
-| Vertical-rl renders (`mini-cjk` ch2 / `mini-cjk-vlong`) | **CORRECTED — NOT working.** On-device `eval` proves `getComputedStyle(body).writingMode == horizontal-tb` everywhere (de, body, content div) with `colCount: auto`; the book's `writing-mode: vertical-rl` (in `<head><style>`) is NOT applied — the EPUB reader extracts chapter content into a wrapper div and drops/overrides head styles. The earlier 'vertical columns' read was narrow multi-column HORIZONTAL CJK (1-char-wide columns are visually indistinguishable from vertical). So the probe correctly reads horizontal-tb → resolves LTR → the vertical path never triggers. | ❌ fail |
-| Vertical-rl page-turn | blocked by the above — the writing-mode isn't applied, so there is no true vertical layout to page. Separately, `eval` shows the top document has no horizontal overflow (`sw==cw==402`) while the content div does (`sw:2052`), so `navigateToPageJS`'s `documentElement.scrollLeft` targets the wrong element regardless. | ❌ blocked |
+| Vertical-rl renders (`mini-cjk-vlong`) | **RE-CONFIRMED working** (re-corrects the v3.41.32 over-correction). On-device `eval` of the ACTUAL content elements: `getComputedStyle(p).writingMode == "vertical-rl"` and `h1 == "vertical-rl"`. The scoped style `[data-vreader-spine-index="0"] > .vreader-chapter-content {writing-mode:vertical-rl}` applies correctly. The earlier `body == horizontal-tb` reading was a **measurement red herring** — in continuous-scroll mode the writing-mode lands on `.vreader-chapter-content`, NOT on `body`, so checking `body`/`html` alone gave a false negative. Text genuinely renders vertically (columns top-to-bottom, right-to-left). | ✅ pass |
+| Vertical-rl page-turn (paged mode) | **NOT verified this session** — the open book stayed in continuous-scroll mode (`hasScrollRoot:true, hasPaginationStyle:false, overflowY:auto, scrollH>clientH`); the `--reader-default-layout=paged` launch arg did not stick and the reading-mode toolbar could not be driven CU-free to switch to paged. The original WI-5 finding (paged vertical page-turn direction inverted under the shared negative-`scrollLeft` sign) stands as the remaining open item, now correctly isolated to PAGING DIRECTION — rendering is not the gap. | ⬜ open |
 
 ## Commands run
 
@@ -78,17 +78,36 @@ scripts/sim-tap.sh shot /tmp/wi5-rtl-after-lefttap.png
   not clear the imported-books library, so seeding a second fixture leaves the
   first; a clean `simctl uninstall`+`install` is the current workaround.
 
-## Correction (eval-grounded)
+## Correction history (eval-grounded)
 
-An earlier revision of this file claimed vertical-rl RENDERS correctly. On-device
-`eval` (`getComputedStyle`) disproves it: writing-mode is `horizontal-tb`
-throughout, so vertical-rl is NOT actually rendering — the visual was narrow
-multi-column horizontal CJK. The real #75 vertical gap is twofold and deeper than
-a pagination sign: (1) the EPUB reader must PRESERVE + apply the book's
-`writing-mode` (head `<style>` is currently dropped when content is extracted into
-the wrapper div), and (2) `navigateToPageJS` must target the actually-scrollable
-element (the content div has horizontal overflow `sw:2052`; the top document does
-not). Only the horizontal-RTL axis is genuinely verified.
+This file's vertical-rl verdict was corrected twice. The final, accurate state
+is the FIRST row of the table above. The chain:
+
+1. **v3.41.31 (original)**: claimed vertical-rl renders — based on a visual read.
+2. **v3.41.32 (over-correction, WRONG)**: claimed it does NOT render, because an
+   `eval` showed `getComputedStyle(body).writingMode == horizontal-tb`. This was
+   an **incomplete measurement** — it checked only `body`/`html`/the
+   `vreader-scroll-root` wrapper, none of which carry the writing-mode.
+3. **v3.41.33 (re-correction, ACCURATE)**: `eval` of the actual content elements
+   shows `p` and `h1` both compute `writing-mode: vertical-rl`. The scoped style
+   `[data-vreader-spine-index="0"] > .vreader-chapter-content {writing-mode:vertical-rl}`
+   applies. **Vertical-rl rendering works.**
+
+**Lesson (process):** `EPUBPageAxisProbe.computedStyleJS` reads
+`getComputedStyle(document.body).writingMode`. In **continuous-scroll** mode the
+book's CSS is scoped onto `.vreader-chapter-content`, so `body` stays
+`horizontal-tb` while the content is `vertical-rl` — the probe's body-only read is
+the wrong signal there. (Scroll mode does not use the paged-axis system, so this
+does not break scroll rendering; it only means the probe is not a reliable
+vertical detector in scroll mode.) In **paged** mode the chapter loads via
+`loadFileURL` with the head un-scoped, so `html,body{writing-mode:vertical-rl}`
+applies to `body` directly and the probe reads `vertical-rl` correctly.
+
+**Remaining #75 gap (single, isolated):** the paged-mode vertical page-turn
+DIRECTION (the negative-`scrollLeft` sign shared with horizontal-RTL), per the
+original WI-5 finding. Rendering is NOT the gap. This was not re-verified this
+session because the test book stayed in scroll mode and the mode toggle could not
+be driven CU-free.
 
 ## Artifacts
 

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 758
-        MARKETING_VERSION: 3.41.32
+        CURRENT_PROJECT_VERSION: 759
+        MARKETING_VERSION: 3.41.33
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6936,13 +6936,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 758;
+				CURRENT_PROJECT_VERSION = 759;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.32;
+				MARKETING_VERSION = 3.41.33;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -7086,13 +7086,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 758;
+				CURRENT_PROJECT_VERSION = 759;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.41.32;
+				MARKETING_VERSION = 3.41.33;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
The v3.41.32 correction was wrong (incomplete eval — checked only body/html, which never carry the writing-mode). Eval of the actual content: `getComputedStyle(p).writingMode == vertical-rl`, `h1 == vertical-rl`. Vertical-rl rendering works. Remaining #75 gap isolated to paged-mode page-turn DIRECTION. Version 3.41.32 → 3.41.33.