### PR TITLE
feat(debugbridge): page?dir=next|prev — CU-free page-turn driver

### DIFF
--- a/.claude/codex-audits/feat-debugbridge-page-nav-driver-audit.md
+++ b/.claude/codex-audits/feat-debugbridge-page-nav-driver-audit.md
@@ -1,0 +1,55 @@
+---
+branch: feat/debugbridge-page-nav-driver
+threadId: codex-exec-gpt-5.5-20260601
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-01
+---
+
+# Codex Audit — DebugBridge `page` command (feature #42/#75 nav driver)
+
+## Scope
+
+DEBUG-only `vreader-debug://page?dir=<next|prev>` command that posts the shared
+`.readerNextPage` / `.readerPreviousPage` notification (existing release
+notifications in `ReaderNotifications.swift`) — the bus every native reader host
+observes (Readium → `goForward`/`goBackward`; legacy EPUB/Foliate paged → their
+page nav). Built because XCUITest / synthetic idb swipes cannot reliably drive
+Readium's own gesture recognizers, so a bus-level page-turn driver is the
+reliable CU-free path to verify reading-order navigation.
+
+Files:
+- `vreader/Services/DebugBridge/DebugCommand.swift` (case + local `PageDirection` enum + parse)
+- `vreader/Services/DebugBridge/DebugBridge.swift` (protocol method + dispatch)
+- `vreader/Services/DebugBridge/RealDebugBridgeContext+Page.swift` (handler posts the notification)
+- `vreaderTests/.../DebugCommandTests.swift` (5 parse tests)
+- `vreaderTests/.../RealDebugBridgeContextTests.swift` (2 handler tests)
+- `vreaderTests/.../DebugBridgeTests.swift` (both mock conformers)
+
+## Round 1 — findings
+
+Codex (gpt-5.5, read-only): **Clean — no findings.** Parser validation,
+notification mapping (next→`.readerNextPage`, prev→`.readerPreviousPage`), DEBUG
+gating, MainActor usage, and reuse of the existing reader nav bus all correct.
+
+## Test evidence
+
+- `vreaderTests/DebugCommandTests` + `RealDebugBridgeContextTests` +
+  `DebugBridgeTests` — 349 tests, 0 failures.
+- New: 5 parse cases (next/prev/missing/invalid/deep-path) + 2 handler cases
+  (next→`.readerNextPage`, prev→`.readerPreviousPage`).
+
+## Field note (the command worked — it diagnosed a #75 finding)
+
+Driving `page?dir=next` on the vertical-rl fixture (via the command) confirmed the
+command reaches Readium's `goToNextPage`/`goForward` end-to-end. In the default
+**scroll** layout, `goForward` returns false for a single-spine-item book — that
+is expected Readium scroll-mode behavior (scroll-mode advances by scrolling within
+a resource; `goForward` moves between spine items, of which the single-chapter
+fixture has none after the first). Verifying paged-mode vertical-rl page nav needs
+Readium in paged mode, which `set-layout` does not currently reach (it wires only
+the legacy host) — a follow-up harness gap. Documented in `docs/features.md` #75.
+
+## Summary verdict
+
+ship-as-is.

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 764
-        MARKETING_VERSION: 3.42.1
+        CURRENT_PROJECT_VERSION: 765
+        MARKETING_VERSION: 3.42.2
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -212,6 +212,7 @@
 		2464151C976B35F68DD2169A /* LazyDownloadReattachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E124CB39746DB0B59D0390C3 /* LazyDownloadReattachTests.swift */; };
 		250865E2A2A7BC3DE436183F /* PDFReaderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7F4F4B985D58E03A78680D /* PDFReaderViewModelTests.swift */; };
 		2509B7983AE76F5C85B71634 /* HighlightDedupeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD56854A37D8EA2B318B926 /* HighlightDedupeTests.swift */; };
+		251259935FB92098FECCAC65 /* RealDebugBridgeContext+Page.swift in Sources */ = {isa = PBXBuildFile; fileRef = C780DC4B823286F5AD97E044 /* RealDebugBridgeContext+Page.swift */; };
 		252CB71020888B6952C2F69E /* ReaderBottomOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A983D06F916C51795A2223E7 /* ReaderBottomOverlay.swift */; };
 		25327C608F6719156A58C8B3 /* LaunchHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62D7DA128D4B2AC1F362D571 /* LaunchHelper.swift */; };
 		2568348E9159667C4193A0B6 /* ProviderKindTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C46A3D7400CC956FA8D46D /* ProviderKindTests.swift */; };
@@ -2542,6 +2543,7 @@
 		C758F02F43A58CA4A2A8382D /* NotesDeleteRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesDeleteRow.swift; sourceTree = "<group>"; };
 		C76B2024F008B3A41C030585 /* ReaderBottomChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderBottomChrome.swift; sourceTree = "<group>"; };
 		C775619D3C0E4641505CE2B8 /* Highlight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlight.swift; sourceTree = "<group>"; };
+		C780DC4B823286F5AD97E044 /* RealDebugBridgeContext+Page.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RealDebugBridgeContext+Page.swift"; sourceTree = "<group>"; };
 		C78DF73C0577F734E90ACB70 /* FoliateBottomChromeSeek.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateBottomChromeSeek.swift; sourceTree = "<group>"; };
 		C7CA57AE61E378A1980BFF60 /* UIKitHighlightPopoverPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitHighlightPopoverPresenter.swift; sourceTree = "<group>"; };
 		C80D6D1B18008B168D01FFF2 /* BookOpenPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookOpenPerformanceTests.swift; sourceTree = "<group>"; };
@@ -3261,6 +3263,7 @@
 				B29B89D96641AE245EA38B05 /* RealDebugBridgeContext+AIAction.swift */,
 				A3D74F5FB31BAB5089EB5022 /* RealDebugBridgeContext+Eval.swift */,
 				FDFF04928B66CAA00503B70A /* RealDebugBridgeContext+Navigate.swift */,
+				C780DC4B823286F5AD97E044 /* RealDebugBridgeContext+Page.swift */,
 				535F3D9734CC8A2C3E303580 /* RealDebugBridgeContext+PDFHighlight.swift */,
 				BB8C0771E06618E5F68C410D /* RealDebugBridgeContext+Present.swift */,
 				2E5C9F4DD3DE16D29E00E5F6 /* RealDebugBridgeContext+Provider.swift */,
@@ -6594,6 +6597,7 @@
 				2DCCDBB57F5086AF49FF8D99 /* RealDebugBridgeContext+Eval.swift in Sources */,
 				213C32619E2ABE94230B020A /* RealDebugBridgeContext+Navigate.swift in Sources */,
 				0A0E59E50351ED190E24D03D /* RealDebugBridgeContext+PDFHighlight.swift in Sources */,
+				251259935FB92098FECCAC65 /* RealDebugBridgeContext+Page.swift in Sources */,
 				2D22FEBD43A0354357992A28 /* RealDebugBridgeContext+Present.swift in Sources */,
 				009D566180EA91AB79A4F32C /* RealDebugBridgeContext+Provider.swift in Sources */,
 				195F279BFC30A19186455052 /* RealDebugBridgeContext+ScrollBoundary.swift in Sources */,
@@ -6944,13 +6948,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 764;
+				CURRENT_PROJECT_VERSION = 765;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.1;
+				MARKETING_VERSION = 3.42.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -7094,13 +7098,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 764;
+				CURRENT_PROJECT_VERSION = 765;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.1;
+				MARKETING_VERSION = 3.42.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/DebugBridge/DebugBridge.swift
+++ b/vreader/Services/DebugBridge/DebugBridge.swift
@@ -151,6 +151,14 @@ protocol DebugBridgeContext {
     /// observer fires — the URL is silently a no-op (matches `navigate` /
     /// `seek` / `present`).
     func setLayout(layout: DebugCommand.LayoutMode) async throws
+    /// Feature #42/#75 — drive a page turn CU-free by posting the shared
+    /// `.readerNextPage` / `.readerPreviousPage` notification every native reader
+    /// host observes (Readium → `goForward`/`goBackward`; legacy EPUB/Foliate
+    /// paged → their page nav). Synthetic swipes can't drive Readium's gesture
+    /// recognizers, so this bus-level driver is the reliable CU-free page-nav
+    /// path (incl. RTL / vertical-rl reading order). No-op when no reader is
+    /// presented.
+    func page(direction: DebugCommand.PageDirection) async throws
 }
 
 /// Routes parsed `DebugCommand` values to a `DebugBridgeContext`.
@@ -297,6 +305,8 @@ final class DebugBridge {
             try await context.pdfHighlight(page: page, rect: rect, color: color)
         case .setLayout(let layout):
             try await context.setLayout(layout: layout)
+        case .page(let direction):
+            try await context.page(direction: direction)
         }
     }
 }

--- a/vreader/Services/DebugBridge/DebugCommand.swift
+++ b/vreader/Services/DebugBridge/DebugCommand.swift
@@ -218,6 +218,16 @@ enum DebugCommand: Equatable {
     /// `seek` / `present`).
     case setLayout(layout: LayoutMode)
 
+    /// Feature #42/#75 verification — `page?dir=<next|prev>` drives a page turn
+    /// CU-free by posting the shared `.readerNextPage` / `.readerPreviousPage`
+    /// notification every native reader host observes (Readium →
+    /// `goForward`/`goBackward`; legacy EPUB/Foliate paged → their page nav).
+    /// XCUITest / synthetic swipes can't reliably drive Readium's own gesture
+    /// recognizers, so this bus-level driver is the reliable CU-free path to
+    /// verify page navigation (incl. RTL / vertical-rl reading order, feature
+    /// #75) regardless of engine. No-op when no reader is presented.
+    case page(direction: PageDirection)
+
     /// Which AI action the `ai` command fires (Bug #255 — verification
     /// harness AI-action driver). The handler posts `.debugBridgeAIAction`;
     /// the AI panel's observer invokes the SAME view-model path the chrome
@@ -244,6 +254,15 @@ enum DebugCommand: Equatable {
     enum LayoutMode: String, Equatable, CaseIterable {
         case paged
         case scroll
+    }
+
+    /// Page-turn direction for the `page` command (feature #42/#75 verification).
+    /// `next` / `prev` are reading-order (the host + engine resolve the physical
+    /// direction per the publication's reading direction — RTL / vertical-rl
+    /// "next" advances in reading order, not a fixed screen edge).
+    enum PageDirection: String, Equatable, CaseIterable {
+        case next
+        case prev
     }
 
     /// Reader theme selector for the `theme` command.
@@ -944,6 +963,17 @@ extension DebugCommand {
                 throw DebugCommandError.invalidParam("mode", reason: "expected \(valid), got \(modeRaw)")
             }
             return .setLayout(layout: layout)
+
+        case "page":
+            // Feature #42/#75: drive a page turn CU-free by posting the shared
+            // `.readerNextPage` / `.readerPreviousPage` notification. `dir` is
+            // required; one of next|prev (mirrors the allowlist posture).
+            let dirRaw = try requireParam("dir", in: params)
+            guard let direction = PageDirection(rawValue: dirRaw) else {
+                let valid = PageDirection.allCases.map(\.rawValue).joined(separator: "|")
+                throw DebugCommandError.invalidParam("dir", reason: "expected \(valid), got \(dirRaw)")
+            }
+            return .page(direction: direction)
 
         default:
             throw DebugCommandError.unknownCommand(host)

--- a/vreader/Services/DebugBridge/RealDebugBridgeContext+Page.swift
+++ b/vreader/Services/DebugBridge/RealDebugBridgeContext+Page.swift
@@ -1,0 +1,42 @@
+// Purpose: `page` command handler for the vreader-debug:// scheme (feature
+// #42/#75 verification harness — drive a page turn CU-free). Posts the shared
+// `.readerNextPage` / `.readerPreviousPage` notification that every native
+// reader host already observes:
+//   • Readium (`ReadiumEPUBHost+Body`) → coordinator `goForward` / `goBackward`;
+//   • legacy EPUB (`EPUBReaderContainerView`) → `handleSideTapNext/Previous`;
+//   • Foliate (AZW3/MOBI) + TXT/MD/PDF paged → their own observers.
+// XCUITest / synthetic idb swipes can't reliably drive Readium's own gesture
+// recognizers (the navigator owns its content controller), so this bus-level
+// driver is the reliable CU-free path to verify reading-order page navigation —
+// including RTL / vertical-rl, where "next" advances in reading order regardless
+// of screen edge. DEBUG-only — entire file compiled out of Release.
+//
+// Split from RealDebugBridgeContext.swift for the 300-line LOC guideline
+// (mirrors RealDebugBridgeContext+Navigate.swift / +SetLayout.swift).
+//
+// @coordinates-with: DebugBridge.swift, DebugCommand.swift,
+//   ReaderNotifications.swift (.readerNextPage / .readerPreviousPage),
+//   ReadiumEPUBHost+Body.swift, EPUBReaderContainerView.swift,
+//   RealDebugBridgeContextTests.swift
+
+#if DEBUG
+
+import Foundation
+
+extension RealDebugBridgeContext {
+
+    /// Feature #42/#75 — drive a reading-order page turn for the active reader.
+    ///
+    /// Posts `.readerNextPage` (for `.next`) or `.readerPreviousPage` (for
+    /// `.prev`) — the SAME notifications a side-tap / swipe produces, so the
+    /// active host advances through its real navigation path (no parallel page
+    /// logic). If no reader is presented, no host observes it — the URL is
+    /// silently a no-op (the same posture as `navigate` / `seek` / `set-layout`).
+    func page(direction: DebugCommand.PageDirection) async throws {
+        let name: Notification.Name = direction == .next ? .readerNextPage : .readerPreviousPage
+        NotificationCenter.default.post(name: name, object: nil)
+        log.info("page: posted \(name.rawValue, privacy: .public) (dir=\(direction.rawValue, privacy: .public))")
+    }
+}
+
+#endif

--- a/vreaderTests/Services/DebugBridge/DebugBridgeTests.swift
+++ b/vreaderTests/Services/DebugBridge/DebugBridgeTests.swift
@@ -474,6 +474,9 @@ final class SlowDebugBridgeContext: DebugBridgeContext {
     func setLayout(layout: DebugCommand.LayoutMode) async throws {
         await record("set-layout:\(layout.rawValue)")
     }
+    func page(direction: DebugCommand.PageDirection) async throws {
+        await record("page:\(direction.rawValue)")
+    }
 
     private func actionTag(_ action: DebugCommand.ProviderAction) -> String {
         switch action {
@@ -513,6 +516,7 @@ final class RecordingDebugBridgeContext: DebugBridgeContext {
         case scrollBoundary(spineIndex: Int, near: DebugCommand.ScrollBoundaryEdge)
         case pdfHighlight(page: Int, rect: NormalizedRect, color: String?)
         case setLayout(layout: DebugCommand.LayoutMode)
+        case page(direction: DebugCommand.PageDirection)
     }
 
     private(set) var calls: [Call] = []
@@ -571,6 +575,9 @@ final class RecordingDebugBridgeContext: DebugBridgeContext {
     }
     func setLayout(layout: DebugCommand.LayoutMode) async throws {
         calls.append(.setLayout(layout: layout))
+    }
+    func page(direction: DebugCommand.PageDirection) async throws {
+        calls.append(.page(direction: direction))
     }
 }
 

--- a/vreaderTests/Services/DebugBridge/DebugCommandTests.swift
+++ b/vreaderTests/Services/DebugBridge/DebugCommandTests.swift
@@ -2446,6 +2446,48 @@ final class DebugCommandTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - page (feature #42/#75 — CU-free page-turn driver via the shared
+    //   .readerNextPage / .readerPreviousPage bus; reliable where synthetic
+    //   swipes can't drive Readium's gesture recognizers)
+    //   `vreader-debug://page?dir=<next|prev>`
+
+    func test_parse_pageNext_returnsCommand() throws {
+        XCTAssertEqual(try DebugCommand.parse(URL(string: "vreader-debug://page?dir=next")!), .page(direction: .next))
+    }
+
+    func test_parse_pagePrev_returnsCommand() throws {
+        XCTAssertEqual(try DebugCommand.parse(URL(string: "vreader-debug://page?dir=prev")!), .page(direction: .prev))
+    }
+
+    func test_parse_pageMissingDir_throwsMissingParam() {
+        XCTAssertThrowsError(try DebugCommand.parse(URL(string: "vreader-debug://page")!)) { error in
+            guard case DebugCommandError.missingParam(let name) = error else {
+                XCTFail("expected missingParam, got \(error)")
+                return
+            }
+            XCTAssertEqual(name, "dir")
+        }
+    }
+
+    func test_parse_pageInvalidDir_throwsInvalidParam() {
+        XCTAssertThrowsError(try DebugCommand.parse(URL(string: "vreader-debug://page?dir=forward")!)) { error in
+            guard case DebugCommandError.invalidParam(let name, _) = error else {
+                XCTFail("expected invalidParam, got \(error)")
+                return
+            }
+            XCTAssertEqual(name, "dir")
+        }
+    }
+
+    func test_parse_pageDeepPath_throwsUnknownCommand() {
+        XCTAssertThrowsError(try DebugCommand.parse(URL(string: "vreader-debug://page/extra?dir=next")!)) { error in
+            guard case DebugCommandError.unknownCommand = error else {
+                XCTFail("expected unknownCommand, got \(error)")
+                return
+            }
+        }
+    }
 }
 
 #endif

--- a/vreaderTests/Services/DebugBridge/RealDebugBridgeContextTests.swift
+++ b/vreaderTests/Services/DebugBridge/RealDebugBridgeContextTests.swift
@@ -967,6 +967,40 @@ final class RealDebugBridgeContextTests: XCTestCase {
     }
 
     @MainActor
+    func test_page_next_postsReaderNextPage() async throws {
+        // Feature #42/#75: page?dir=next posts .readerNextPage — the SAME
+        // notification every reader host observes (Readium goForward; legacy
+        // EPUB/Foliate paged nav). Reliable CU-free page-turn where synthetic
+        // swipes can't drive Readium's gesture recognizers.
+        let exp = expectation(description: "readerNextPage posted")
+        let token = NotificationCenter.default.addObserver(
+            forName: .readerNextPage, object: nil, queue: .main
+        ) { _ in exp.fulfill() }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        let context = RealDebugBridgeContext(
+            persistence: persistence, importer: importer, userDefaults: defaults
+        )
+        try await context.page(direction: .next)
+        await fulfillment(of: [exp], timeout: 2.0)
+    }
+
+    @MainActor
+    func test_page_prev_postsReaderPreviousPage() async throws {
+        let exp = expectation(description: "readerPreviousPage posted")
+        let token = NotificationCenter.default.addObserver(
+            forName: .readerPreviousPage, object: nil, queue: .main
+        ) { _ in exp.fulfill() }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        let context = RealDebugBridgeContext(
+            persistence: persistence, importer: importer, userDefaults: defaults
+        )
+        try await context.page(direction: .prev)
+        await fulfillment(of: [exp], timeout: 2.0)
+    }
+
+    @MainActor
     func test_scrollBoundary_postsScrollBoundaryCommandWithSpineAndNear() async throws {
         // Feature #71 WI-6b: scrollBoundary posts .debugBridgeScrollBoundaryCommand
         // carrying the spine index + edge; the live EPUBReaderContainerView


### PR DESCRIPTION
Adds `vreader-debug://page?dir=<next|prev>` — posts the shared `.readerNextPage`/`.readerPreviousPage` notification every native reader host observes (Readium goForward/goBackward; legacy/Foliate paged nav). Reliable CU-free page-turn driver where synthetic swipes can't drive Readium's gesture recognizers — for the #42/#75 verify harness. 5 parse + 2 handler tests; 349 DebugBridge tests green. Codex audit clean. Version 3.42.1→3.42.2. DEBUG-only.