### PR TITLE
fix(#75): restore main — land dispatcher set-layout observer (PR #1336 was incomplete)

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 766
-        MARKETING_VERSION: 3.42.3
+        CURRENT_PROJECT_VERSION: 767
+        MARKETING_VERSION: 3.42.4
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6948,13 +6948,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 766;
+				CURRENT_PROJECT_VERSION = 767;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.3;
+				MARKETING_VERSION = 3.42.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -7098,13 +7098,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 766;
+				CURRENT_PROJECT_VERSION = 767;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.3;
+				MARKETING_VERSION = 3.42.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Views/Reader/EPUBReaderContainerView.swift
+++ b/vreader/Views/Reader/EPUBReaderContainerView.swift
@@ -355,16 +355,11 @@ struct EPUBReaderContainerView: View {
             ) else { return }
             NotificationCenter.default.post(name: .readerNavigateToLocator, object: locator)
         }
-        // Feature #75 WI-5a: CU-free EPUB layout switch. XCUITest can't tap the
-        // segmented layout Picker on iOS 26 (gh #576), so the `set-layout`
-        // DebugBridge command posts the target mode; the observer sets
-        // `settingsStore.epubLayout` — the SAME binding the picker drives, whose
-        // `.onChange` relayouts the reader (no parallel layout path). Extracted
-        // to a ViewModifier so the trailing-closure type-inference stays out of
-        // this already-large body (mirrors ReaderDebugBridgePresentObserver).
-        .modifier(EPUBReaderDebugBridgeSetLayoutObserver { [weak settingsStore] layout in
-            settingsStore?.epubLayout = layout
-        })
+        // Feature #75: the CU-free EPUB layout-switch observer moved UP to the
+        // dispatcher (`ReaderContainerView+DebugBridgeSetLayout`) so it reaches
+        // every engine (legacy + Readium) via the shared `settingsStore`. The
+        // legacy host still relayouts via its own `.onChange(of: epubLayout)`
+        // below — it just no longer needs its own notification observer.
         #endif
         // Bug #88: re-render highlights after annotation import
         .onReceive(NotificationCenter.default.publisher(for: .readerHighlightsDidImport)) { _ in

--- a/vreader/Views/Reader/ReaderContainerView+DebugBridgeSetLayout.swift
+++ b/vreader/Views/Reader/ReaderContainerView+DebugBridgeSetLayout.swift
@@ -1,0 +1,48 @@
+// Purpose: DEBUG-only wiring that switches the EPUB layout preference from the
+// `.debugBridgeSetLayoutCommand` notification (feature #75 verification harness),
+// attached at the DISPATCHER (`ReaderContainerView`) so it reaches EVERY EPUB
+// engine. It sets the shared `settingsStore.epubLayout`, which both hosts read
+// reactively:
+//   • legacy `EPUBReaderContainerView` — its `.onChange(of: epubLayout)` injects
+//     / removes the pagination CSS live;
+//   • Readium `ReadiumEPUBHost` — its `.onChange(of: epubLayout)` re-renders the
+//     navigator with a recomputed `EPUBPreferences(scroll:)`.
+//
+// Replaces the earlier host-scoped `EPUBReaderDebugBridgeSetLayoutObserver`
+// (feature #75 WI-5a), which only reached the legacy host (the Readium host is a
+// different view, so a host-scoped observer never fired under the Readium
+// engine). XCUITest can't tap the segmented layout Picker on iOS 26 (gh #576),
+// and the `--reader-default-layout=` launch arg only pre-seeds the default
+// before a book opens; this switches an already-open reader on any engine.
+//
+// Extracted to a `ViewModifier` so the trailing-closure type-inference stays out
+// of `ReaderContainerView`'s already-large body (mirrors the sibling
+// `ReaderDebugBridge{Search,Present,RenderedText}Observer`). Compiled out of
+// Release.
+//
+// @coordinates-with: ReaderContainerView.swift, DebugBridgeNotifications.swift,
+//   RealDebugBridgeContext+SetLayout.swift, EPUBLayoutPreference.swift
+
+#if DEBUG
+
+import SwiftUI
+
+/// Dispatcher-level set-layout observer (feature #75). Maps the posted `"mode"`
+/// rawValue to `EPUBLayoutPreference` and hands it to `onLayout`, which the
+/// dispatcher wires to `settingsStore.epubLayout`. An unknown mode string
+/// (shouldn't happen — the parser validates it) is ignored.
+struct ReaderDebugBridgeSetLayoutObserver: ViewModifier {
+    let onLayout: (EPUBLayoutPreference) -> Void
+
+    func body(content: Content) -> some View {
+        content.onReceive(
+            NotificationCenter.default.publisher(for: .debugBridgeSetLayoutCommand)
+        ) { notification in
+            guard let mode = notification.userInfo?["mode"] as? String,
+                  let layout = EPUBLayoutPreference(rawValue: mode) else { return }
+            onLayout(layout)
+        }
+    }
+}
+
+#endif

--- a/vreader/Views/Reader/ReaderContainerView.swift
+++ b/vreader/Views/Reader/ReaderContainerView.swift
@@ -589,6 +589,24 @@ struct ReaderContainerView: View {
                 debugProbe?.renderedText = text
             }
         ))
+        // Feature #75 — CU-free EPUB layout switch (paged/scroll). Lives HERE at
+        // the dispatcher (not inside the EPUB host) so it sets the shared
+        // `settingsStore.epubLayout` that BOTH engines read reactively — the
+        // legacy `EPUBReaderContainerView` (.onChange) AND the Readium
+        // `ReadiumEPUBHost` (.onChange → re-renders the navigator with the new
+        // `EPUBPreferences(scroll:)`). The earlier host-scoped observer only
+        // reached the legacy engine; moving it up unblocks verifying paged
+        // vertical-rl / RTL page nav on the now-default Readium engine.
+        .modifier(ReaderDebugBridgeSetLayoutObserver { layout in
+            // Codex audit: this observer now mounts for EVERY format, so guard on
+            // EPUB — `epubLayout` is EPUB-specific and TXT/MD/Foliate/PDF also
+            // read it, so a `set-layout` fired while a non-EPUB reader is open
+            // must NOT mutate it (preserves the prior EPUB-only behavior). Both
+            // EPUB engines (legacy + Readium) are `.epub`, so the goal — reaching
+            // the Readium host — is unaffected.
+            guard DocumentFingerprint(canonicalKey: book.fingerprintKey)?.format == .epub else { return }
+            settingsStore.epubLayout = layout
+        })
         // Bug #237 — DebugBridge highlight-driver observer lives in the
         // TXT and MD format hosts, NOT here. Format hosts have the source
         // text + chapter index they need to build canonical Locators via


### PR DESCRIPTION
PR #1336's git add aborted on an already-rm'd pathspec, so the merge deleted the old observer file but didn't land the dispatcher replacement — main didn't compile. This lands the rest (ReaderContainerView modifier + new ViewModifier + EPUBReaderContainerView cleanup). BUILD SUCCEEDED. Version 3.42.3→3.42.4. Refs #1300.