### PR TITLE
feat(#76 WI-1a): FoliateScrollModel scrolled-mode axis derivation

### DIFF
--- a/.claude/codex-audits/feat-feature-76-wi1-scrollmodel-audit.md
+++ b/.claude/codex-audits/feat-feature-76-wi1-scrollmodel-audit.md
@@ -1,0 +1,55 @@
+---
+branch: feat/feature-76-wi1-scrollmodel
+threadId: codex-exec-gpt-5.5-20260601
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-01
+---
+
+# Codex Audit — Feature #76 WI-1a (FoliateScrollModel derivation)
+
+## Scope
+
+Foundational Swift type `FoliateScrollModel` deriving the scrolled-mode scroll
+model (`axis`, `scrollProp`, `sizeProp`, `rectStartProp`, `directionSign`) from a
+section's computed `writing-mode`. Replaces the lossy `{vertical, rtl}`
+(vertical-rl vs -lr collapse; axis sign unrecoverable) as the source-of-truth the
+vendored `paginator.js` getDirection/ScrollModel will mirror. The `directionSign`
+feeds the existing `FoliateScrolledWindowMath.logicalOffset(sign:)` seam (#1322).
+Scrolled mode only; no consumer yet (lands ahead of WI-2/WI-3 windowing).
+
+Files:
+- `vreader/Services/Foliate/FoliateScrollModel.swift` (NEW — pure value type)
+- `vreaderTests/Services/Foliate/FoliateScrollModelTests.swift` (NEW — 6 tests)
+
+## Round 1 — findings
+
+Codex (gpt-5.5, read-only). **No findings.**
+
+Verified:
+- Derivation table correct: horizontal-tb → vertical/scrollTop/height/top/+1;
+  vertical-rl → horizontal/scrollLeft/width/left/−1; vertical-lr →
+  horizontal/scrollLeft/width/left/+1.
+- Unknown/empty fallback to the horizontal-tb model is safe — preserves the
+  Feature #73 vertical-scroll path.
+- `directionSign == -1` for vertical-rl matches WebKit negative `scrollLeft`
+  (`logicalOffset(-300, -1) == 300`).
+- Test coverage spans the table, unknown/unsupported modes, the sign-integration
+  seam, and `isVerticalWriting`.
+- Swift value-type / synthesized `Equatable` correct; no dead code.
+
+## Test evidence
+
+`vreaderTests/FoliateScrollModelTests` — 6 tests green (`RUN-TESTS RESULT: SUCCEEDED`).
+
+## WI tier
+
+**Foundational** (pure type, no user-observable behavior, #73 untouched) — per
+rule 47 Gate 5, merges on unit tests + audit; no device verification required.
+The behavioral consumers are WI-1b (JS getDirection mirror), WI-2 (#container
+flex), WI-3 (ScrollModel-aware windowed primitives), device-verified in WI-5 on
+the real vertical-writing AZW3 fixture.
+
+## Verdict
+
+ship-as-is (zero findings).

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 772
-        MARKETING_VERSION: 3.42.9
+        CURRENT_PROJECT_VERSION: 773
+        MARKETING_VERSION: 3.42.10
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 		301498E0C7A6CBC1E7E8DF49 /* FoliateCoordinatorBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC4E330CF0A4F1EBF039346 /* FoliateCoordinatorBox.swift */; };
 		301BA4423DE1212ADB315388 /* BookImporterAZW3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4962BEF634F94652553FC6BD /* BookImporterAZW3Tests.swift */; };
 		307C4D2604D68F512FC259C7 /* BookDetailsSheet+Translate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804F605FB952D69D68D4F332 /* BookDetailsSheet+Translate.swift */; };
+		3087734A5D1A71537DDA5CDD /* FoliateScrollModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E566AD1B0392524AA5BB8B0 /* FoliateScrollModel.swift */; };
 		30C1DE820BD42DAC78AC80FC /* BlobPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560129625F0E48471C0F4B62 /* BlobPath.swift */; };
 		30F0FC1144518F1FD72AAB6D /* EPUBBilingualJSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D19C79EE604BFAB916EC630 /* EPUBBilingualJSTests.swift */; };
 		30F629136C9EED9FCD557222 /* SmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D14E222357346107CB34B750 /* SmokeTests.swift */; };
@@ -1109,6 +1110,7 @@
 		C36DD49DF8C98812AD95EE37 /* RealDebugBridgeContext+SetLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA70AC0CF70660D3FBBC6169 /* RealDebugBridgeContext+SetLayout.swift */; };
 		C3BE566C5E906C665C95F68C /* BookDetailsMetadataRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D94746694BD66410FDB471 /* BookDetailsMetadataRow.swift */; };
 		C3E08FC456AC81388D905F7F /* ErrorMessageAuditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7E77EFE308BC9CF8A3FE /* ErrorMessageAuditor.swift */; };
+		C40FEEE617C93C57FCAC49C5 /* FoliateScrollModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1989CF2F582B5C821059BA /* FoliateScrollModelTests.swift */; };
 		C42A9F7FEC0AEF99637EFE63 /* ErrorScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F560EA65913036C78284C138 /* ErrorScreenTests.swift */; };
 		C439F4679323C4D7486BB047 /* KeyboardInteractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41DD0013DEFFC287885D1A48 /* KeyboardInteractionTests.swift */; };
 		C470300A552B997B253D9856 /* LibraryFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D046EDAB83AA8534D942EAE /* LibraryFilterTests.swift */; };
@@ -1997,6 +1999,7 @@
 		5E270DE50F23F6125F3151CA /* PhaseBMediumAuditTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhaseBMediumAuditTests.swift; sourceTree = "<group>"; };
 		5E3AA514298AACD2F963913C /* TOCChapterProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOCChapterProgress.swift; sourceTree = "<group>"; };
 		5E3D2050D82A39083191EDDA /* LibraryBookItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryBookItem.swift; sourceTree = "<group>"; };
+		5E566AD1B0392524AA5BB8B0 /* FoliateScrollModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateScrollModel.swift; sourceTree = "<group>"; };
 		5E6114D9038B37A9B437BDC9 /* SelectionPopoverActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionPopoverActionTests.swift; sourceTree = "<group>"; };
 		5E72779818424BCA8025B0A0 /* BackupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupViewModel.swift; sourceTree = "<group>"; };
 		5E868FB040D93F83C745083C /* Feature36OPDSVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature36OPDSVerificationTests.swift; sourceTree = "<group>"; };
@@ -2860,6 +2863,7 @@
 		FC729E5B1BA7DC69B40D4929 /* NativeTextPageNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTextPageNavigator.swift; sourceTree = "<group>"; };
 		FCC8C2B2EE71211499AA0EE4 /* AnnotationStreamItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationStreamItem.swift; sourceTree = "<group>"; };
 		FCDA968F8186B11859D8CCFE /* MDTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDTypes.swift; sourceTree = "<group>"; };
+		FD1989CF2F582B5C821059BA /* FoliateScrollModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateScrollModelTests.swift; sourceTree = "<group>"; };
 		FDEB28B2CAB1481C73FBE351 /* TestSeederMDMultiPagePaginationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSeederMDMultiPagePaginationTests.swift; sourceTree = "<group>"; };
 		FDF40785A923791B0241CF75 /* GlobalAccessibilityAuditTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalAccessibilityAuditTests.swift; sourceTree = "<group>"; };
 		FDFAF8770F91837F0B3793E1 /* ImportProvenanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportProvenanceTests.swift; sourceTree = "<group>"; };
@@ -2990,6 +2994,7 @@
 				36EE33B24FB16F8AC319BDB2 /* FoliateMessageParser.swift */,
 				EDD7B08B41BC2F95D59ACC3B /* FoliateNavSeek.swift */,
 				AD8DA73FC4DB2CFB0B841E4D /* FoliateScrolledWindowMath.swift */,
+				5E566AD1B0392524AA5BB8B0 /* FoliateScrollModel.swift */,
 				9B8C36563D7885AD214F885A /* FoliateSearchAdapter.swift */,
 				AF493E1A2F50B0916C76306D /* FoliateSelectionDispatcher.swift */,
 				0928B53225E1D74131620204 /* FoliateStyleMapper.swift */,
@@ -5205,6 +5210,7 @@
 				EB35F648E8E697C82E4C41DE /* FoliateMessageParserTests.swift */,
 				8293E5CECE7616545BEEE15F /* FoliatePaginatorScrollBoundaryTests.swift */,
 				03AECD22002DD170A5BF984A /* FoliateScrolledWindowMathTests.swift */,
+				FD1989CF2F582B5C821059BA /* FoliateScrollModelTests.swift */,
 				A6DB55181F2F55D99D879507 /* FoliateSearchAdapterTests.swift */,
 				97EE89998FF9D71667B4B83C /* FoliateSelectionDispatcherTests.swift */,
 				2F4BA9D085BDF7728D698FDA /* FoliateStyleMapperCascadeFlattenTests.swift */,
@@ -5691,6 +5697,7 @@
 				46BE197094C37683ABE4FC6B /* FoliatePositionRestoreControllerTests.swift in Sources */,
 				B8B06D067BBB837C6138967D /* FoliateReaderContainerViewTests.swift in Sources */,
 				B47FA1294B60A0652B9F0BCA /* FoliateReaderViewModelTests.swift in Sources */,
+				C40FEEE617C93C57FCAC49C5 /* FoliateScrollModelTests.swift in Sources */,
 				770CE6C30927E26DC0DB017F /* FoliateScrolledWindowMathTests.swift in Sources */,
 				7A90F0D9EB7A4F82D33EE237 /* FoliateSearchAdapterTests.swift in Sources */,
 				C999EC3BE3EA4ECBC2EF7F5B /* FoliateSelectionDispatcherTests.swift in Sources */,
@@ -6331,6 +6338,7 @@
 				0DDED2E512493B4CB2DCD33F /* FoliateReaderContainerView+Navigation.swift in Sources */,
 				7D4818D21C7BE30304755F35 /* FoliateReaderContainerView.swift in Sources */,
 				AE34D7222B4EAB4191316FD2 /* FoliateReaderViewModel.swift in Sources */,
+				3087734A5D1A71537DDA5CDD /* FoliateScrollModel.swift in Sources */,
 				8A3108EFB992214662E20858 /* FoliateScrolledWindowMath.swift in Sources */,
 				1B78DA4330A421FE2206B70C /* FoliateSearchAdapter.swift in Sources */,
 				BB76E4E9F07F901B637B765D /* FoliateSectionExtracting.swift in Sources */,
@@ -6952,13 +6960,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 772;
+				CURRENT_PROJECT_VERSION = 773;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.9;
+				MARKETING_VERSION = 3.42.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -7102,13 +7110,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 772;
+				CURRENT_PROJECT_VERSION = 773;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.9;
+				MARKETING_VERSION = 3.42.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Foliate/FoliateScrollModel.swift
+++ b/vreader/Services/Foliate/FoliateScrollModel.swift
@@ -1,0 +1,68 @@
+// Purpose: The scrolled-mode scroll model for the Foliate continuous surface
+// (Feature #76 WI-1). Foliate's `getDirection` returned only `{ vertical, rtl }`,
+// which is LOSSY — `vertical-rl` vs `vertical-lr` collapse to the same value, and
+// the windowing axis sign (WebKit's negative `scrollLeft` for vertical-rl) cannot
+// be recovered from it (there is even a live `FIXME: vertical-rl only, not -lr` in
+// paginator.js `#scrollTo`). This Swift type is the source-of-truth derivation the
+// vendored `paginator.js` `getDirection`/ScrollModel mirrors, so the axis props +
+// sign are pinned by `FoliateScrollModelTests` rather than re-derived ad hoc in JS.
+//
+// SCROLLED MODE ONLY: horizontal-writing books scroll on the vertical axis
+// (`scrollTop`), vertical-writing books scroll on the horizontal axis
+// (`scrollLeft`). Paged mode keeps paginator's own axis handling and is out of
+// scope here. The `directionSign` feeds the canonical logical-offset seam
+// (`FoliateScrolledWindowMath.logicalOffset(sign:)`, Feature #76 #1322), so the
+// Feature #73 horizontal-tb path stays sign `+1` / byte-unchanged.
+//
+// @coordinates-with: FoliateScrolledWindowMath.swift (logicalOffset/rawOffset),
+//   vreader/Services/Foliate/JS/paginator.js (getDirection → ScrollModel)
+
+import Foundation
+
+struct FoliateScrollModel: Equatable {
+
+    enum Axis: String, Equatable {
+        case vertical    // scrolls top↔bottom (horizontal-writing books)
+        case horizontal  // scrolls left↔right (vertical-writing books)
+    }
+
+    /// The scroll axis for the section's writing mode in scrolled mode.
+    let axis: Axis
+    /// The DOM scroll property to read/write: `scrollTop` (vertical axis) or
+    /// `scrollLeft` (horizontal axis).
+    let scrollProp: String
+    /// The size dimension that accumulates along the scroll axis: `height`
+    /// (vertical) or `width` (horizontal).
+    let sizeProp: String
+    /// The `DOMRect` start edge along the scroll axis: `top` or `left`.
+    let rectStartProp: String
+    /// `+1` when the raw DOM offset already increases in reading order; `−1` for
+    /// vertical-rl, where WebKit's `scrollLeft` is `0` at the start and goes
+    /// NEGATIVE toward later content. Consumed by
+    /// `FoliateScrolledWindowMath.logicalOffset(sign:)`.
+    let directionSign: Int
+
+    /// `true` for vertical-writing (`vertical-rl` / `vertical-lr`) sections — the
+    /// ones Feature #73 gated out of windowing and Feature #76 re-enables.
+    var isVerticalWriting: Bool { axis == .horizontal }
+
+    /// Derive the scrolled-mode model from a section's computed `writing-mode`.
+    /// Unknown / unsupported values fall back to the horizontal-tb model (the
+    /// safe Feature #73 path), matching `getDirection`'s prior implicit default.
+    static func scrolled(writingMode: String) -> FoliateScrollModel {
+        switch writingMode {
+        case "vertical-rl":
+            return FoliateScrollModel(
+                axis: .horizontal, scrollProp: "scrollLeft", sizeProp: "width",
+                rectStartProp: "left", directionSign: -1)
+        case "vertical-lr":
+            return FoliateScrollModel(
+                axis: .horizontal, scrollProp: "scrollLeft", sizeProp: "width",
+                rectStartProp: "left", directionSign: 1)
+        default: // horizontal-tb and any non-vertical writing mode
+            return FoliateScrollModel(
+                axis: .vertical, scrollProp: "scrollTop", sizeProp: "height",
+                rectStartProp: "top", directionSign: 1)
+        }
+    }
+}

--- a/vreaderTests/Services/Foliate/FoliateScrollModelTests.swift
+++ b/vreaderTests/Services/Foliate/FoliateScrollModelTests.swift
@@ -1,0 +1,70 @@
+// Tests for FoliateScrollModel (Feature #76 WI-1): the scrolled-mode scroll
+// model derived from a section's computed `writing-mode`. This is the Swift
+// source-of-truth the JS `getDirection`/ScrollModel mirrors — `{vertical, rtl}`
+// was lossy (vertical-rl vs -lr indistinguishable; the axis sign can't be
+// inferred), so the derivation is pinned here and the vendored paginator.js
+// builds the same object.
+
+import Testing
+@testable import vreader
+
+@Suite("FoliateScrollModel — scrolled-mode axis derivation (Feature #76 WI-1)")
+struct FoliateScrollModelTests {
+
+    @Test("horizontal-tb: scrolls vertically (scrollTop/height/top), sign +1")
+    func horizontalWriting() {
+        let m = FoliateScrollModel.scrolled(writingMode: "horizontal-tb")
+        #expect(m.axis == .vertical)
+        #expect(m.scrollProp == "scrollTop")
+        #expect(m.sizeProp == "height")
+        #expect(m.rectStartProp == "top")
+        #expect(m.directionSign == 1)
+    }
+
+    @Test("vertical-rl: scrolls horizontally (scrollLeft/width/left), sign −1 (WebKit negative scrollLeft)")
+    func verticalRL() {
+        let m = FoliateScrollModel.scrolled(writingMode: "vertical-rl")
+        #expect(m.axis == .horizontal)
+        #expect(m.scrollProp == "scrollLeft")
+        #expect(m.sizeProp == "width")
+        #expect(m.rectStartProp == "left")
+        #expect(m.directionSign == -1)
+    }
+
+    @Test("vertical-lr: scrolls horizontally, sign +1 (left-to-right column flow)")
+    func verticalLR() {
+        let m = FoliateScrollModel.scrolled(writingMode: "vertical-lr")
+        #expect(m.axis == .horizontal)
+        #expect(m.scrollProp == "scrollLeft")
+        #expect(m.sizeProp == "width")
+        #expect(m.rectStartProp == "left")
+        #expect(m.directionSign == 1)
+    }
+
+    @Test("unknown / empty writing-mode falls back to the horizontal-tb model (safe default)")
+    func unknownFallsBackToHorizontalTB() {
+        for raw in ["", "sideways-rl", "garbage", "horizontal-bt"] {
+            let m = FoliateScrollModel.scrolled(writingMode: raw)
+            #expect(m.axis == .vertical, "\(raw) should default to vertical-scroll")
+            #expect(m.scrollProp == "scrollTop")
+            #expect(m.directionSign == 1)
+        }
+    }
+
+    @Test("directionSign feeds the existing logical-offset seam (#1322) consistently")
+    func signFeedsLogicalOffset() {
+        // vertical-rl: a raw negative scrollLeft becomes a positive logical offset.
+        let rl = FoliateScrollModel.scrolled(writingMode: "vertical-rl")
+        #expect(FoliateScrolledWindowMath.logicalOffset(rawOffset: -300, sign: rl.directionSign) == 300)
+        // horizontal-tb: raw == logical (Feature #73 path byte-unchanged).
+        let tb = FoliateScrollModel.scrolled(writingMode: "horizontal-tb")
+        #expect(FoliateScrolledWindowMath.logicalOffset(rawOffset: 300, sign: tb.directionSign) == 300)
+    }
+
+    @Test("isVertical convenience matches the axis")
+    func isVerticalConvenience() {
+        #expect(FoliateScrollModel.scrolled(writingMode: "vertical-rl").isVerticalWriting)
+        #expect(FoliateScrollModel.scrolled(writingMode: "vertical-lr").isVerticalWriting)
+        #expect(!FoliateScrollModel.scrolled(writingMode: "horizontal-tb").isVerticalWriting)
+    }
+}


### PR DESCRIPTION
## Summary

Foundational Swift type `FoliateScrollModel` — the source-of-truth derivation of the scrolled-mode scroll model (`axis`, `scrollProp`, `sizeProp`, `rectStartProp`, `directionSign`) from a section's computed `writing-mode`. The vendored `paginator.js` `getDirection` returned only `{vertical, rtl}`, which is lossy (vertical-rl vs -lr collapse; the windowing axis sign — WebKit's negative `scrollLeft` for vertical-rl — can't be recovered). This pins the derivation in Swift so the JS mirror (WI-1b) and the windowing rewrite (WI-2/WI-3) build on a tested spec.

Part of feature #1260 (Feature #76 — vertical-writing windowed continuous scroll).

## What Changed

- **New** `FoliateScrollModel.swift` — pure value type + `scrolled(writingMode:)` derivation (horizontal-tb → vertical/scrollTop/+1; vertical-rl → horizontal/scrollLeft/−1; vertical-lr → horizontal/scrollLeft/+1; unknown → safe horizontal-tb fallback).
- **New** `FoliateScrollModelTests.swift` — 6 tests (table, unknown/empty fallback, `directionSign` integration with the #1322 `logicalOffset(sign:)` seam, `isVerticalWriting`).

## WI tier — foundational

Pure type, **Feature #73 untouched**, no consumer yet (lands ahead of the WI-2/WI-3 windowing consumers). Per rule 47 Gate 5, foundational WIs merge on unit tests + audit — no device verification. Behavioral consumers (JS getDirection mirror, axis-aware `#container` flex, ScrollModel-aware windowed primitives) are device-verified in WI-5 on the real vertical-writing AZW3 fixture (`Bei Tao Yan De Yong Qi`).

## Codex Audit

1 round, **ship-as-is**, 0 findings (derivation table correct; vertical-rl sign matches WebKit; fallback safe; coverage complete). Log: `.claude/codex-audits/feat-feature-76-wi1-scrollmodel-audit.md`

## Validation

- [x] `FoliateScrollModelTests` — 6 green
- [x] TDD: RED → GREEN
- [x] Codex: ship-as-is
- [x] Version bumped: 3.42.9 → 3.42.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)