### PR TITLE
feat(#76 WI-1b): getDirection writingMode + JS ScrollModel mirror

### DIFF
--- a/.claude/codex-audits/feat-feature-76-wi1b-js-scrollmodel-audit.md
+++ b/.claude/codex-audits/feat-feature-76-wi1b-js-scrollmodel-audit.md
@@ -1,0 +1,51 @@
+---
+branch: feat/feature-76-wi1b-js-scrollmodel
+threadId: codex-exec-gpt-5.5-20260601
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-01
+---
+
+# Codex Audit — Feature #76 WI-1b (JS getDirection → ScrollModel mirror)
+
+## Scope
+
+Additive JS half of WI-1 in vendored `paginator.js`: `getDirection` also returns
+`writingMode`; a `scrollModelFor(writingMode)` helper mirrors the merged Swift
+`FoliateScrollModel.scrolled(writingMode:)`; the `View` class stores `#scrollModel`
++ exposes a getter. No consumer yet (WI-3 consumes it). Intent: ZERO runtime
+behavior change; Feature #73's horizontal-AZW3 windowed scroll byte-unchanged.
+`foliate-bundle.js` regenerated via `build-bundle.sh` (esbuild 0.28.0).
+
+Files: `vreader/Services/Foliate/JS/paginator.js`, `…/foliate-bundle.js` (built).
+
+## Round 1 — findings
+
+Codex (gpt-5.5, read-only). **No findings.**
+
+- `getDirection` behavior-neutral: all call sites destructure named props; the
+  extra `writingMode` doesn't affect `{vertical, rtl}` or `beforeRender`.
+- `scrollModelFor` matches the Swift table exactly (horizontal-tb/default,
+  vertical-rl −1, vertical-lr +1).
+- `#scrollModel` default (`horizontal-tb`) safe; overwritten on every `View.load`.
+- No runtime path consumes `View.scrollModel` → #73 unaffected in effect.
+- Getter on the correct (View) class; no shadowing/typos; bundle reflects source.
+
+## Test evidence
+
+- `FoliatePaginatorScrollBoundaryTests` (15) — source↔bundle parity guard +
+  boundary assertions GREEN (proves the rebuilt bundle matches source + #73
+  boundary behavior holds).
+- `FoliateScrolledWindowMathTests` (19) + `FoliateScrollModelTests` (6) GREEN.
+- esbuild built cleanly (syntactically valid bundle).
+
+## WI tier
+
+**Foundational** — additive seam, no runtime behavior change, #73 untouched in
+effect (Codex-confirmed). Per rule 47 Gate 5, merges on unit/parity tests +
+audit; the behavioral device verification is WI-5 (when WI-3 makes the windowing
+consume the model). Consistent with WI-1a + the #1322 seam.
+
+## Verdict
+
+ship-as-is (zero findings).

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 773
-        MARKETING_VERSION: 3.42.10
+        CURRENT_PROJECT_VERSION: 774
+        MARKETING_VERSION: 3.42.11
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6960,13 +6960,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 773;
+				CURRENT_PROJECT_VERSION = 774;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.10;
+				MARKETING_VERSION = 3.42.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -7110,13 +7110,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 773;
+				CURRENT_PROJECT_VERSION = 774;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.10;
+				MARKETING_VERSION = 3.42.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Foliate/JS/foliate-bundle.js
+++ b/vreader/Services/Foliate/JS/foliate-bundle.js
@@ -4152,7 +4152,7 @@ ${doc.querySelector("parsererror").innerText}`);
   __export(paginator_exports, {
     Paginator: () => Paginator
   });
-  var wait, debounce, lerp, easeOutQuad, animate, uncollapse, makeRange, bisectNode, SHOW_ELEMENT, SHOW_TEXT, SHOW_CDATA_SECTION, FILTER_ACCEPT, FILTER_REJECT, FILTER_SKIP, filter2, getBoundingClientRect, getVisibleRange, selectionIsBackward, setSelectionTo, getDirection, getBackground, makeMarginals, setStylesImportant, View, Paginator;
+  var wait, debounce, lerp, easeOutQuad, animate, uncollapse, makeRange, bisectNode, SHOW_ELEMENT, SHOW_TEXT, SHOW_CDATA_SECTION, FILTER_ACCEPT, FILTER_REJECT, FILTER_SKIP, filter2, getBoundingClientRect, getVisibleRange, selectionIsBackward, setSelectionTo, getDirection, scrollModelFor, getBackground, makeMarginals, setStylesImportant, View, Paginator;
   var init_paginator = __esm({
     "paginator.js"() {
       wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -4305,7 +4305,35 @@ ${doc.querySelector("parsererror").innerText}`);
         const { writingMode, direction } = defaultView.getComputedStyle(doc.body);
         const vertical = writingMode === "vertical-rl" || writingMode === "vertical-lr";
         const rtl = doc.body.dir === "rtl" || direction === "rtl" || doc.documentElement.dir === "rtl";
-        return { vertical, rtl };
+        return { vertical, rtl, writingMode };
+      };
+      scrollModelFor = (writingMode) => {
+        switch (writingMode) {
+          case "vertical-rl":
+            return {
+              axis: "horizontal",
+              scrollProp: "scrollLeft",
+              sizeProp: "width",
+              rectStartProp: "left",
+              directionSign: -1
+            };
+          case "vertical-lr":
+            return {
+              axis: "horizontal",
+              scrollProp: "scrollLeft",
+              sizeProp: "width",
+              rectStartProp: "left",
+              directionSign: 1
+            };
+          default:
+            return {
+              axis: "vertical",
+              scrollProp: "scrollTop",
+              sizeProp: "height",
+              rectStartProp: "top",
+              directionSign: 1
+            };
+        }
       };
       getBackground = (doc) => {
         const bodyStyle = doc.defaultView.getComputedStyle(doc.body);
@@ -4330,6 +4358,11 @@ ${doc.querySelector("parsererror").innerText}`);
         #overlayer;
         #vertical = false;
         #rtl = false;
+        // Feature #76 WI-1b: the loaded section's scroll model (axis/props/sign),
+        // mirroring Swift `FoliateScrollModel`. Defaults to the horizontal-tb model
+        // (Feature #73 vertical-scroll path). Stored additively here; the windowed
+        // primitives consume it in WI-3.
+        #scrollModel = scrollModelFor("horizontal-tb");
         #column = true;
         #size;
         #layout = {};
@@ -4365,6 +4398,11 @@ ${doc.querySelector("parsererror").innerText}`);
         get document() {
           return this.#iframe.contentDocument;
         }
+        // Feature #76 WI-1b: the loaded section's scroll model (axis/props/sign).
+        // Consumed by the windowed primitives in WI-3.
+        get scrollModel() {
+          return this.#scrollModel;
+        }
         async load(src, afterLoad, beforeRender) {
           if (typeof src !== "string") throw new Error(`${src} is not string`);
           return new Promise((resolve) => {
@@ -4372,11 +4410,12 @@ ${doc.querySelector("parsererror").innerText}`);
               const doc = this.document;
               afterLoad?.(doc);
               this.#iframe.style.display = "block";
-              const { vertical, rtl } = getDirection(doc);
+              const { vertical, rtl, writingMode } = getDirection(doc);
               const background = getBackground(doc);
               this.#iframe.style.display = "none";
               this.#vertical = vertical;
               this.#rtl = rtl;
+              this.#scrollModel = scrollModelFor(writingMode);
               this.#contentRange.selectNodeContents(doc.body);
               const layout = beforeRender?.({ vertical, rtl, background });
               this.#iframe.style.display = "block";

--- a/vreader/Services/Foliate/JS/paginator.js
+++ b/vreader/Services/Foliate/JS/paginator.js
@@ -183,7 +183,31 @@ const getDirection = doc => {
     const rtl = doc.body.dir === 'rtl'
         || direction === 'rtl'
         || doc.documentElement.dir === 'rtl'
-    return { vertical, rtl }
+    // Feature #76 WI-1b: also surface the raw `writingMode` — `{vertical, rtl}`
+    // is lossy (vertical-rl vs -lr collapse; the windowing axis sign can't be
+    // recovered). Additive: existing `{vertical, rtl}` consumers are unchanged.
+    return { vertical, rtl, writingMode }
+}
+
+// Feature #76 WI-1b: the scrolled-mode scroll model derived from a section's
+// computed `writing-mode`. MIRRORS the Swift source-of-truth
+// `FoliateScrollModel.scrolled(writingMode:)` (pinned by FoliateScrollModelTests)
+// so the axis props + RTL/vertical-rl `directionSign` stay in lockstep across the
+// Swift seam (FoliateScrolledWindowMath.logicalOffset) and the JS windowing.
+// Scrolled mode only; the windowed primitives consume this in WI-3. Horizontal-tb
+// keeps sign +1 (Feature #73 path byte-unchanged); unknown modes fall back to it.
+const scrollModelFor = writingMode => {
+    switch (writingMode) {
+        case 'vertical-rl':
+            return { axis: 'horizontal', scrollProp: 'scrollLeft', sizeProp: 'width',
+                rectStartProp: 'left', directionSign: -1 }
+        case 'vertical-lr':
+            return { axis: 'horizontal', scrollProp: 'scrollLeft', sizeProp: 'width',
+                rectStartProp: 'left', directionSign: 1 }
+        default: // horizontal-tb and any non-vertical writing mode
+            return { axis: 'vertical', scrollProp: 'scrollTop', sizeProp: 'height',
+                rectStartProp: 'top', directionSign: 1 }
+    }
 }
 
 const getBackground = doc => {
@@ -215,6 +239,11 @@ class View {
     #overlayer
     #vertical = false
     #rtl = false
+    // Feature #76 WI-1b: the loaded section's scroll model (axis/props/sign),
+    // mirroring Swift `FoliateScrollModel`. Defaults to the horizontal-tb model
+    // (Feature #73 vertical-scroll path). Stored additively here; the windowed
+    // primitives consume it in WI-3.
+    #scrollModel = scrollModelFor('horizontal-tb')
     #column = true
     #size
     #layout = {}
@@ -250,6 +279,11 @@ class View {
     get document() {
         return this.#iframe.contentDocument
     }
+    // Feature #76 WI-1b: the loaded section's scroll model (axis/props/sign).
+    // Consumed by the windowed primitives in WI-3.
+    get scrollModel() {
+        return this.#scrollModel
+    }
     async load(src, afterLoad, beforeRender) {
         if (typeof src !== 'string') throw new Error(`${src} is not string`)
         return new Promise(resolve => {
@@ -259,12 +293,15 @@ class View {
 
                 // it needs to be visible for Firefox to get computed style
                 this.#iframe.style.display = 'block'
-                const { vertical, rtl } = getDirection(doc)
+                const { vertical, rtl, writingMode } = getDirection(doc)
                 const background = getBackground(doc)
                 this.#iframe.style.display = 'none'
 
                 this.#vertical = vertical
                 this.#rtl = rtl
+                // Feature #76 WI-1b (additive): derive + store the scroll model
+                // from the real writing-mode for the windowed primitives (WI-3).
+                this.#scrollModel = scrollModelFor(writingMode)
 
                 this.#contentRange.selectNodeContents(doc.body)
                 const layout = beforeRender?.({ vertical, rtl, background })


### PR DESCRIPTION
## Summary

Additive JS half of WI-1 in vendored `paginator.js`: `getDirection` also returns `writingMode`, and a `scrollModelFor(writingMode)` helper mirrors the merged Swift `FoliateScrollModel` exactly. The `View` class stores `#scrollModel` + a getter for the windowed primitives (consumed in WI-3).

**Zero runtime behavior change** — nothing reads `#scrollModel` yet; Feature #73's horizontal-AZW3 windowed scroll is byte-unchanged in effect (Codex-confirmed). Bundle regenerated via `build-bundle.sh`.

Part of feature #1260 (Feature #76).

## WI tier — foundational

Additive seam, no behavior change. Per rule 47 Gate 5, merges on unit/parity tests + audit; behavioral device-verification is WI-5 (when WI-3 consumes the model). Consistent with WI-1a + the #1322 seam.

## Codex Audit

1 round, **ship-as-is**, 0 findings (behavior-neutral; exact Swift mirror; #73 unaffected; bundle reflects source). Log: `.claude/codex-audits/feat-feature-76-wi1b-js-scrollmodel-audit.md`

## Validation

- [x] `FoliatePaginatorScrollBoundaryTests` (15) — source↔bundle parity guard + boundary assertions green
- [x] `FoliateScrolledWindowMathTests` (19) + `FoliateScrollModelTests` (6) green
- [x] esbuild built cleanly (valid bundle)
- [x] Version bumped: 3.42.10 → 3.42.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)