### PR TITLE
feat(#76 WI-3 scaffold): axis-aware windowed primitives (#73 byte-identical)

### DIFF
--- a/.claude/codex-audits/feat-feature-76-wi2-3-windowing-audit.md
+++ b/.claude/codex-audits/feat-feature-76-wi2-3-windowing-audit.md
@@ -1,0 +1,58 @@
+---
+branch: feat/feature-76-wi2-3-windowing
+threadId: codex-exec-gpt-5.5-20260601
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-01
+---
+
+# Codex Audit — Feature #76 WI-3 scaffolding (axis-aware windowed primitives)
+
+## Scope
+
+Parameterize the windowed-scroll primitives in vendored `paginator.js` through an
+axis-aware ScrollModel (`#activeScrollModel`, `#axisScrollOffset`,
+`#setAxisScrollOffset`, `#elementAxisSize`, `#elementAxisStart`) instead of
+hardcoding `scrollTop`/`height`/`top`. Rewrites `#onNeighbourExpand`,
+`#evictOutsideWindow`, `#elementScrollTop` (now a pass-through), `#windowedResolve`.
+
+**Intent: ZERO behavior change.** horizontal-tb (#73) model is
+`{scrollTop, height, top, +1}`, so every helper reduces to the exact prior
+expression. Vertical writing stays GATED (`#ensureWindow`'s `|| this.#vertical`
+early-return + the `!this.#vertical` resolve/promote guards are unchanged), so the
+vertical branch of the helpers is dead scaffolding — completed later after the
+WI-0 on-device measurement of WebKit vertical multicol layout.
+
+Files: `vreader/Services/Foliate/JS/paginator.js`, `…/foliate-bundle.js` (rebuilt).
+
+## Round 1 — findings
+
+Codex (gpt-5.5, read-only). **No findings.** Independently verified:
+- `#axisScrollOffset()` ≡ `container.scrollTop`; `#elementAxisStart` ≡ old
+  `#elementScrollTop`; `#elementAxisSize` ≡ `rect.height` (the `Math.max(0,…)`
+  clamp is a no-op on a non-negative height).
+- `#onNeighbourExpand` / `#evictOutsideWindow` / `#windowedResolve` preserve the
+  same deltas, comparisons, scroll adjustment, and `(view,index,intra)` selection
+  for horizontal-tb.
+- `#elementScrollTop` pass-through is correct; callers unaffected.
+- Vertical genuinely still gated; no path runs the vertical branch.
+- No JS syntax / typo / sign / NaN issues; no path changes #73 runtime behavior.
+
+## Test evidence
+
+- `FoliatePaginatorScrollBoundaryTests` (15) — source↔bundle parity + boundary
+  assertions GREEN.
+- `FoliateScrolledWindowMathTests` (19) + `FoliateScrollModelTests` (6) GREEN.
+- esbuild built cleanly (valid bundle).
+
+## WI tier
+
+Behavior-preserving refactor (no observable change; #73 byte-identical; vertical
+gated) → effectively foundational; merges on the parity/unit guards + this audit.
+The behavioral vertical slice (ungate + vertical-rl coordinate math) is the
+follow-up gated on WI-0 device measurement, device-verified in WI-5 on the real
+`Bei Tao Yan De Yong Qi` vertical-writing AZW3.
+
+## Verdict
+
+ship-as-is (zero findings; horizontal-tb byte-identity independently confirmed).

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 774
-        MARKETING_VERSION: 3.42.11
+        CURRENT_PROJECT_VERSION: 775
+        MARKETING_VERSION: 3.42.12
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -6960,13 +6960,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 774;
+				CURRENT_PROJECT_VERSION = 775;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.11;
+				MARKETING_VERSION = 3.42.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -7110,13 +7110,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 774;
+				CURRENT_PROJECT_VERSION = 775;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.11;
+				MARKETING_VERSION = 3.42.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/Services/Foliate/JS/foliate-bundle.js
+++ b/vreader/Services/Foliate/JS/foliate-bundle.js
@@ -4958,18 +4958,53 @@ ${doc.querySelector("parsererror").innerText}`);
             this.#mountingIndices.delete(index);
           }
         }
-        // WI-6c: when a mounted neighbour's height changes after layout (fonts.ready,
-        // image load, reflow), shift `scrollTop` by the delta IF the neighbour sits
-        // above the current scroll position — so the visible content does not jump.
+        // Feature #76 WI-3: the active section's scroll model (axis/props/sign),
+        // mirroring Swift FoliateScrollModel. The windowed primitives below read the
+        // axis through these helpers instead of hardcoding scrollTop/height/top, so
+        // the horizontal-writing (#73) path resolves to the IDENTICAL expressions
+        // (scrollProp=scrollTop, sizeProp=height, rectStartProp=top, sign=+1) while a
+        // vertical-writing section can later drive the horizontal axis. Defaults to
+        // the horizontal-tb model when no view is mounted.
+        get #activeScrollModel() {
+          return this.#view?.scrollModel ?? scrollModelFor("horizontal-tb");
+        }
+        // Logical (non-negative, reading-order) scroll offset of the container along
+        // the active axis. For vertical-rl, WebKit's `scrollLeft` is negative toward
+        // later content, so the sign maps it positive. horizontal-tb: == scrollTop.
+        #axisScrollOffset() {
+          const m3 = this.#activeScrollModel;
+          const raw = this.#container[m3.scrollProp];
+          return m3.directionSign < 0 ? -raw : raw;
+        }
+        #setAxisScrollOffset(logical) {
+          const m3 = this.#activeScrollModel;
+          this.#container[m3.scrollProp] = m3.directionSign < 0 ? -logical : logical;
+        }
+        // Element extent along the active axis. horizontal-tb: == rect.height.
+        #elementAxisSize(el) {
+          return Math.max(0, el.getBoundingClientRect()[this.#activeScrollModel.sizeProp]);
+        }
+        // Element's logical start offset within the container's scroll content along
+        // the active axis (axis-aware generalization of the old #elementScrollTop).
+        // horizontal-tb: rect.top - container.top + scrollTop — byte-identical.
+        #elementAxisStart(el) {
+          const m3 = this.#activeScrollModel;
+          const rawDelta = el.getBoundingClientRect()[m3.rectStartProp] - this.#container.getBoundingClientRect()[m3.rectStartProp];
+          return (m3.directionSign < 0 ? -rawDelta : rawDelta) + this.#axisScrollOffset();
+        }
+        // WI-6c: when a mounted neighbour's size changes after layout (fonts.ready,
+        // image load, reflow), shift the axis scroll offset by the delta IF the
+        // neighbour sits before the current scroll position — so visible content
+        // does not jump. (#76 WI-3: axis-aware; horizontal-tb == the old scrollTop+height path.)
         #onNeighbourExpand(view2) {
           if (!this.#windowedScroll || !view2?.element) return;
           const prev = view2.wi73Height ?? 0;
-          const now = Math.max(0, view2.element.getBoundingClientRect().height);
+          const now = this.#elementAxisSize(view2.element);
           view2.wi73Height = now;
           const delta = now - prev;
           if (delta === 0) return;
-          if (this.#elementScrollTop(view2.element) < this.#container.scrollTop) {
-            this.#container.scrollTop = Math.max(0, this.#container.scrollTop + delta);
+          if (this.#elementAxisStart(view2.element) < this.#axisScrollOffset()) {
+            this.#setAxisScrollOffset(Math.max(0, this.#axisScrollOffset() + delta));
           }
         }
         async #ensureWindow() {
@@ -5005,20 +5040,22 @@ ${doc.querySelector("parsererror").innerText}`);
               continue;
             }
             if (idx < this.#index) {
-              scrollAdjust += Math.max(0, v3.element.getBoundingClientRect().height);
+              scrollAdjust += this.#elementAxisSize(v3.element);
             }
             v3.destroy();
             if (v3.element.parentNode === this.#container) this.#container.removeChild(v3.element);
             this.sections[idx]?.unload?.();
           }
           this.#scrolledViews = keep;
-          if (scrollAdjust > 0) this.#container.scrollTop = Math.max(0, this.#container.scrollTop - scrollAdjust);
+          if (scrollAdjust > 0) {
+            this.#setAxisScrollOffset(Math.max(0, this.#axisScrollOffset() - scrollAdjust));
+          }
         }
         // Feature #73 WI-3/WI-5: resolve the CURRENT section + intra-section fraction
         // from the live scroll position over the mounted views (the anchor `#view`
         // plus its neighbours), so windowed crossing is native scroll — no swap.
         #elementScrollTop(el) {
-          return el.getBoundingClientRect().top - this.#container.getBoundingClientRect().top + this.#container.scrollTop;
+          return this.#elementAxisStart(el);
         }
         #windowedViews() {
           return [this.#view, ...this.#scrolledViews].filter(Boolean).sort((a3, b3) => (a3.wi73Index ?? this.#index) - (b3.wi73Index ?? this.#index));
@@ -5027,13 +5064,13 @@ ${doc.querySelector("parsererror").innerText}`);
           const views = this.#windowedViews();
           if (!views.length) return { view: this.#view, index: this.#index, intra: 0 };
           if (this.#view && this.#view.wi73Index == null) this.#view.wi73Index = this.#index;
-          const scrollTop = this.#container.scrollTop;
+          const offset = this.#axisScrollOffset();
           for (const v3 of views) {
-            const top = this.#elementScrollTop(v3.element);
-            const h3 = v3.element.getBoundingClientRect().height;
-            if (scrollTop < top + h3 - 1) {
+            const start = this.#elementAxisStart(v3.element);
+            const size = this.#elementAxisSize(v3.element);
+            if (offset < start + size - 1) {
               const idx = v3.wi73Index ?? this.#index;
-              const intra = h3 > 0 ? Math.min(Math.max((scrollTop - top) / h3, 0), 1) : 0;
+              const intra = size > 0 ? Math.min(Math.max((offset - start) / size, 0), 1) : 0;
               return { view: v3, index: idx, intra };
             }
           }

--- a/vreader/Services/Foliate/JS/paginator.js
+++ b/vreader/Services/Foliate/JS/paginator.js
@@ -921,20 +921,56 @@ export class Paginator extends HTMLElement {
             this.#mountingIndices.delete(index)
         }
     }
-    // WI-6c: when a mounted neighbour's height changes after layout (fonts.ready,
-    // image load, reflow), shift `scrollTop` by the delta IF the neighbour sits
-    // above the current scroll position — so the visible content does not jump.
+    // Feature #76 WI-3: the active section's scroll model (axis/props/sign),
+    // mirroring Swift FoliateScrollModel. The windowed primitives below read the
+    // axis through these helpers instead of hardcoding scrollTop/height/top, so
+    // the horizontal-writing (#73) path resolves to the IDENTICAL expressions
+    // (scrollProp=scrollTop, sizeProp=height, rectStartProp=top, sign=+1) while a
+    // vertical-writing section can later drive the horizontal axis. Defaults to
+    // the horizontal-tb model when no view is mounted.
+    get #activeScrollModel() {
+        return this.#view?.scrollModel ?? scrollModelFor('horizontal-tb')
+    }
+    // Logical (non-negative, reading-order) scroll offset of the container along
+    // the active axis. For vertical-rl, WebKit's `scrollLeft` is negative toward
+    // later content, so the sign maps it positive. horizontal-tb: == scrollTop.
+    #axisScrollOffset() {
+        const m = this.#activeScrollModel
+        const raw = this.#container[m.scrollProp]
+        return m.directionSign < 0 ? -raw : raw
+    }
+    #setAxisScrollOffset(logical) {
+        const m = this.#activeScrollModel
+        this.#container[m.scrollProp] = m.directionSign < 0 ? -logical : logical
+    }
+    // Element extent along the active axis. horizontal-tb: == rect.height.
+    #elementAxisSize(el) {
+        return Math.max(0, el.getBoundingClientRect()[this.#activeScrollModel.sizeProp])
+    }
+    // Element's logical start offset within the container's scroll content along
+    // the active axis (axis-aware generalization of the old #elementScrollTop).
+    // horizontal-tb: rect.top - container.top + scrollTop — byte-identical.
+    #elementAxisStart(el) {
+        const m = this.#activeScrollModel
+        const rawDelta = el.getBoundingClientRect()[m.rectStartProp]
+            - this.#container.getBoundingClientRect()[m.rectStartProp]
+        return (m.directionSign < 0 ? -rawDelta : rawDelta) + this.#axisScrollOffset()
+    }
+    // WI-6c: when a mounted neighbour's size changes after layout (fonts.ready,
+    // image load, reflow), shift the axis scroll offset by the delta IF the
+    // neighbour sits before the current scroll position — so visible content
+    // does not jump. (#76 WI-3: axis-aware; horizontal-tb == the old scrollTop+height path.)
     #onNeighbourExpand(view) {
         if (!this.#windowedScroll || !view?.element) return
         const prev = view.wi73Height ?? 0
-        const now = Math.max(0, view.element.getBoundingClientRect().height)
+        const now = this.#elementAxisSize(view.element)
         view.wi73Height = now
         const delta = now - prev
         if (delta === 0) return
-        // a view whose top is above the viewport top contributes its full height
-        // to everything below it; growing it pushes the viewport content down.
-        if (this.#elementScrollTop(view.element) < this.#container.scrollTop) {
-            this.#container.scrollTop = Math.max(0, this.#container.scrollTop + delta)
+        // a view whose start is before the viewport start contributes its full
+        // size to everything after it; growing it pushes later content along.
+        if (this.#elementAxisStart(view.element) < this.#axisScrollOffset()) {
+            this.#setAxisScrollOffset(Math.max(0, this.#axisScrollOffset() + delta))
         }
     }
     async #ensureWindow() {
@@ -969,22 +1005,25 @@ export class Paginator extends HTMLElement {
             const idx = v.wi73Index
             if (idx >= lo && idx <= hi) { keep.push(v); continue }
             if (idx < this.#index) {
-                scrollAdjust += Math.max(0, v.element.getBoundingClientRect().height)
+                // #76 WI-3: axis-aware extent (horizontal-tb == rect.height).
+                scrollAdjust += this.#elementAxisSize(v.element)
             }
             v.destroy()
             if (v.element.parentNode === this.#container) this.#container.removeChild(v.element)
             this.sections[idx]?.unload?.()
         }
         this.#scrolledViews = keep
-        if (scrollAdjust > 0) this.#container.scrollTop = Math.max(0, this.#container.scrollTop - scrollAdjust)
+        if (scrollAdjust > 0) {
+            this.#setAxisScrollOffset(Math.max(0, this.#axisScrollOffset() - scrollAdjust))
+        }
     }
     // Feature #73 WI-3/WI-5: resolve the CURRENT section + intra-section fraction
     // from the live scroll position over the mounted views (the anchor `#view`
     // plus its neighbours), so windowed crossing is native scroll — no swap.
     #elementScrollTop(el) {
-        return el.getBoundingClientRect().top
-            - this.#container.getBoundingClientRect().top
-            + this.#container.scrollTop
+        // #76 WI-3: delegate to the axis-aware helper. horizontal-tb resolves to
+        // the identical `rect.top - container.top + scrollTop`.
+        return this.#elementAxisStart(el)
     }
     #windowedViews() {
         return [this.#view, ...this.#scrolledViews]
@@ -995,13 +1034,14 @@ export class Paginator extends HTMLElement {
         const views = this.#windowedViews()
         if (!views.length) return { view: this.#view, index: this.#index, intra: 0 }
         if (this.#view && this.#view.wi73Index == null) this.#view.wi73Index = this.#index
-        const scrollTop = this.#container.scrollTop
+        // #76 WI-3: resolve along the active axis (horizontal-tb == scrollTop/height).
+        const offset = this.#axisScrollOffset()
         for (const v of views) {
-            const top = this.#elementScrollTop(v.element)
-            const h = v.element.getBoundingClientRect().height
-            if (scrollTop < top + h - 1) {
+            const start = this.#elementAxisStart(v.element)
+            const size = this.#elementAxisSize(v.element)
+            if (offset < start + size - 1) {
                 const idx = v.wi73Index ?? this.#index
-                const intra = h > 0 ? Math.min(Math.max((scrollTop - top) / h, 0), 1) : 0
+                const intra = size > 0 ? Math.min(Math.max((offset - start) / size, 0), 1) : 0
                 return { view: v, index: idx, intra }
             }
         }


### PR DESCRIPTION
## Summary

Parameterize the windowed-scroll primitives in vendored `paginator.js` through an axis-aware `ScrollModel` (`#activeScrollModel`, `#axisScrollOffset`, `#setAxisScrollOffset`, `#elementAxisSize`, `#elementAxisStart`) instead of hardcoding `scrollTop`/`height`/`top`. This is the WI-3 structural groundwork so a vertical-writing section can later drive the horizontal scroll axis.

**ZERO behavior change.** horizontal-tb (#73) resolves to the *identical* expressions (Codex independently confirmed byte-identity, each helper reduces exactly). Vertical writing stays **gated** — `#ensureWindow`'s `|| this.#vertical` early-return is unchanged, so the vertical branch of the helpers is dead scaffolding, completed later after the **WI-0 on-device measurement** of WebKit vertical multicol layout (the plan gates the vertical-rl coordinate math on that measurement; implementing it blind would be unsafe).

Part of feature #1260 (Feature #76).

## What Changed

`#onNeighbourExpand`, `#evictOutsideWindow`, `#elementScrollTop` (now a pass-through to `#elementAxisStart`), `#windowedResolve` — all rewritten to read the axis through the helpers. `foliate-bundle.js` regenerated.

## Codex Audit

1 round, **ship-as-is**, 0 findings — independently verified each helper reduces to the prior expression for horizontal-tb, vertical stays gated, no JS/sign/NaN issues, no #73 runtime change. Log: `.claude/codex-audits/feat-feature-76-wi2-3-windowing-audit.md`

## Validation

- [x] Codex byte-identity confirmation (horizontal-tb)
- [x] `FoliatePaginatorScrollBoundaryTests` (15) — source↔bundle parity + boundary green
- [x] `FoliateScrolledWindowMathTests` (19) + `FoliateScrollModelTests` (6) green
- [x] esbuild built cleanly
- [x] Version bumped: 3.42.11 → 3.42.12

## Next (not in this PR)

WI-0 device measurement (vertical multicol layout on `Bei Tao Yan De Yong Qi`) → ungate vertical in `#ensureWindow` + complete the vertical-rl coordinate math in the helper vertical branches → WI-5 device-verify. The #73 horizontal regression is the guardrail throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)