### PR TITLE
fix(devtools): --enable-ai grants consent + aiAssistant gates

### DIFF
--- a/.claude/codex-audits/fix-enable-ai-grants-consent-and-flag-audit.md
+++ b/.claude/codex-audits/fix-enable-ai-grants-consent-and-flag-audit.md
@@ -1,0 +1,43 @@
+---
+branch: fix/enable-ai-grants-consent-and-flag
+threadId: codex-exec-gpt-5.5-20260601
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-01
+---
+
+# Codex Audit — --enable-ai grants consent + aiAssistant (harness gap)
+
+## Scope
+
+Bug #237 forwarded `--enable-ai` to `AITestOverride.forceAvailable` (the
+`AIReaderAvailability` UI gate). But `AIService.sendRequest`/`streamRequest` gate
+DIRECTLY on `featureFlags.aiAssistant` + `consentManager.hasConsent` (not via
+AIReaderAvailability), so live AI requests (bilingual translate, summarize, chat)
+still threw featureDisabled/consentRequired in CU-free verification — the UI lit
+up but no content rendered. Fix: DEBUG-only `AITestSetup.apply(enableAI:...)` sets
+all three; `VReaderApp` calls it.
+
+Files: `vreader/App/AITestSetup.swift` (NEW), `vreaderTests/App/AITestSetupTests.swift`
+(NEW), `vreader/App/VReaderApp.swift` (call site).
+
+## Round 1 — findings
+
+Codex (gpt-5.5, read-only). Implementation **Checked Clean** (no Release leak —
+both `AITestSetup` + the call site are `#if DEBUG`; correct stores —
+`AIConsentManager()` + `FeatureFlags.shared` match what `AIService` reads;
+`@MainActor` correct). 1 Medium + 1 Low (both test-quality) — FIXED:
+
+| # | sev | issue | resolution |
+|---|---|---|---|
+| 1 | Medium | `enableTrueSetsAllThreeGates` leaked `AITestOverride.forceAvailable == true` (global static) → could contaminate later AIReaderAvailability tests. | FIXED — `defer { AITestOverride.forceAvailable = false }` + reset at start in both gate-setting tests. |
+| 2 | Low | No test pinned cold `enableAI=false` not granting the real gates. | FIXED — added `enableFalseGrantsNothing` (asserts aiAssistant + consent stay off, no auto-grant). |
+
+## Test evidence
+
+`AITestSetupTests` — 3 tests green. No Release leak (DEBUG-gated). No production
+risk: consent/flag granted ONLY under `--enable-ai` in a `#if DEBUG` path.
+
+## Verdict
+
+ship-as-is (implementation clean; 2 test-quality findings fixed).

--- a/project.yml
+++ b/project.yml
@@ -185,8 +185,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 775
-        MARKETING_VERSION: 3.42.12
+        CURRENT_PROJECT_VERSION: 776
+        MARKETING_VERSION: 3.42.13
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -1161,6 +1161,7 @@
 		CC46DEE722313420D6F150ED /* TXTAttributedStringBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77119C3681DB428BD5F1207C /* TXTAttributedStringBuilderTests.swift */; };
 		CC5A3B33193938B59254FD8A /* PersistenceActor+Collections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00814B9C69A0E1190146095E /* PersistenceActor+Collections.swift */; };
 		CC774F69EFD8E1BD204DD515 /* AnnotationListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5CDE195E585067DE4D6124 /* AnnotationListViewModelTests.swift */; };
+		CC7B6678D819D6A755585B4A /* AITestSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C98D1301031FAFF68ABDD9 /* AITestSetupTests.swift */; };
 		CCADB57440392A88FAEAFBAF /* HighlightActionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A24122FDBAEA4D6DBE9465 /* HighlightActionCardView.swift */; };
 		CCC8728E1750053B1F454A32 /* PageTurnAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D4D088D34AA8A5692A991B /* PageTurnAnimator.swift */; };
 		CCCA05F0A380F2D77780D17C /* VerificationDebugBridgeHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C215281F33EFC48463EA8E24 /* VerificationDebugBridgeHelperTests.swift */; };
@@ -1288,6 +1289,7 @@
 		E25C2E1B2AD3CB697D37166D /* MDParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC614F4D61859721C71EC447 /* MDParser.swift */; };
 		E276113ABA6A03C93EE62848 /* TXTTextViewBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6E8611E23F1BE57E84E732 /* TXTTextViewBridgeTests.swift */; };
 		E2D367FAF3E72F3B5B4D3BDD /* ReaderSettingsPanelChineseConversionGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07B1C372BC384811003D5608 /* ReaderSettingsPanelChineseConversionGateTests.swift */; };
+		E30164DD8662A9243007269E /* AITestSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71F38445339841523CE79B06 /* AITestSetup.swift */; };
 		E32045817D5C8E858B7C4A30 /* AnnotationsPanelPlaceholderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34C87EDF46A4EFC99012268 /* AnnotationsPanelPlaceholderTests.swift */; };
 		E343C0F33B9E8DED665FAB5B /* ReaderSettingsThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0072BB2EF5A87447A6101A /* ReaderSettingsThemeTests.swift */; };
 		E378688E028925097D69864F /* LibraryView+Body.swift in Sources */ = {isa = PBXBuildFile; fileRef = 582AD3C3AF9773965AC0340F /* LibraryView+Body.swift */; };
@@ -2100,6 +2102,7 @@
 		71A6667FB5A4B6534854FD37 /* SchemaV5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV5.swift; sourceTree = "<group>"; };
 		71ABC6D719C77BC75E945F06 /* EPUBWebViewEvaluatorHandleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBWebViewEvaluatorHandleTests.swift; sourceTree = "<group>"; };
 		71DF9DC9E8F3CCA4BE321C47 /* VReaderUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderUITests.swift; sourceTree = "<group>"; };
+		71F38445339841523CE79B06 /* AITestSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AITestSetup.swift; sourceTree = "<group>"; };
 		71FBA8CFEF94EDBE0398AC4A /* TXTChapterOffsetIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterOffsetIndexTests.swift; sourceTree = "<group>"; };
 		7205862B286DDE2DD2233F6D /* TXTChunkedReaderBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChunkedReaderBridge.swift; sourceTree = "<group>"; };
 		725F9036150B858160ACFF7B /* TXTReaderContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReaderContainerView.swift; sourceTree = "<group>"; };
@@ -2114,6 +2117,7 @@
 		746091C5D6814B751FAA32B0 /* LegadoBookSourceDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegadoBookSourceDTO.swift; sourceTree = "<group>"; };
 		74BC81AA927F17D2572106F6 /* BookFormatIsSupportedExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFormatIsSupportedExtensionTests.swift; sourceTree = "<group>"; };
 		759C78EC56C473977FA14017 /* SearchResultGrouping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultGrouping.swift; sourceTree = "<group>"; };
+		75C98D1301031FAFF68ABDD9 /* AITestSetupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AITestSetupTests.swift; sourceTree = "<group>"; };
 		765DA2396E1D41FEDF5652AD /* ReaderSheetChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSheetChrome.swift; sourceTree = "<group>"; };
 		7703EBA1FB78FEA2CADBFB7F /* RealDebugBridgeContext+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RealDebugBridgeContext+Snapshot.swift"; sourceTree = "<group>"; };
 		770B26672B9E379E795E28E7 /* LibraryBookItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryBookItemTests.swift; sourceTree = "<group>"; };
@@ -2977,6 +2981,7 @@
 		0EC164E538AD6C9061777F8D /* App */ = {
 			isa = PBXGroup;
 			children = (
+				71F38445339841523CE79B06 /* AITestSetup.swift */,
 				2CB31146A831DACE67C50F08 /* AppConfiguration.swift */,
 				4456336AA865CC6E79488325 /* ModelContainerFactory.swift */,
 				A0797CB73F5D8FDAF0B7298E /* TestSeeder.swift */,
@@ -5260,6 +5265,7 @@
 		FDF7354ED65C36908A8EDE2E /* App */ = {
 			isa = PBXGroup;
 			children = (
+				75C98D1301031FAFF68ABDD9 /* AITestSetupTests.swift */,
 				51935A413CAABF4DE2D3C488 /* AppConfigurationTests.swift */,
 				3B6E69931BB43A61C776F63A /* InfoPlistDocumentTypesTests.swift */,
 				4EE30F08BFCC54CF8598180F /* LaunchArgParsingTests.swift */,
@@ -5518,6 +5524,7 @@
 				080FFC22ED10E039095B0CDC /* AISummaryCardTests.swift in Sources */,
 				3217F149B278D3D88B6AC17F /* AISummaryTabViewScopeTests.swift in Sources */,
 				768E594123AD4AA389E2BEAC /* AISummaryTabViewTests.swift in Sources */,
+				CC7B6678D819D6A755585B4A /* AITestSetupTests.swift in Sources */,
 				5C20BECE1338802F60F3E7B7 /* AITranslationTests.swift in Sources */,
 				495502CCD0035DB7C8AE37DA /* AccentColorTests.swift in Sources */,
 				65C927CBE6855076656719CE /* AccessibilityFormattersTests.swift in Sources */,
@@ -6123,6 +6130,7 @@
 				B43AA88511EE1FDB4E5D0565 /* AISummaryCard.swift in Sources */,
 				6571F67E31CCA87AEA5AD9DF /* AISummaryScopeChipStrip.swift in Sources */,
 				7E767F5BB300F8588492BD31 /* AISummaryTabView.swift in Sources */,
+				E30164DD8662A9243007269E /* AITestSetup.swift in Sources */,
 				7EE8C91043F4F20D39AF326B /* AITranslationViewModel.swift in Sources */,
 				FD9B24BBE1D852DA18A23E6F /* AITypes.swift in Sources */,
 				9AEE4782EDC4308FAA289B3B /* AccentColor.swift in Sources */,
@@ -6960,13 +6968,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 775;
+				CURRENT_PROJECT_VERSION = 776;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.12;
+				MARKETING_VERSION = 3.42.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -7110,13 +7118,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 775;
+				CURRENT_PROJECT_VERSION = 776;
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.12;
+				MARKETING_VERSION = 3.42.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/vreader/App/AITestSetup.swift
+++ b/vreader/App/AITestSetup.swift
@@ -1,0 +1,47 @@
+// Purpose: DEBUG-only setup that makes the `--enable-ai` XCUITest / DebugBridge
+// launch flag enable the FULL AI request path — not just UI availability.
+//
+// Bug #237 forwarded `--enable-ai` to `AITestOverride.forceAvailable`, which
+// short-circuits `AIReaderAvailability.isAvailable` (the UI gate). But the live
+// request path `AIService.sendRequest` / `streamRequest` gates SEPARATELY and
+// DIRECTLY on `featureFlags.aiAssistant` AND `consentManager.hasConsent` — those
+// are NOT routed through `AIReaderAvailability`. So forcing availability alone
+// left every live AI request (bilingual translate, summarize, chat) throwing
+// `featureDisabled` / `consentRequired`, which the bilingual prefetcher swallows
+// silently — so CU-free AI verification saw the UI light up but no content ever
+// rendered. This setup also sets the two real gates so `--enable-ai` exercises
+// the whole request path end-to-end.
+//
+// @coordinates-with: VReaderApp.swift (TestLaunchConfig handling),
+//   AIService.swift (the gates), AIReaderAvailability.swift (AITestOverride),
+//   FeatureFlags.swift, AIConsentManager.swift
+
+#if DEBUG
+
+import Foundation
+
+@MainActor
+enum AITestSetup {
+    /// Apply the `--enable-ai` launch flag to ALL three AI gates so a CU-free /
+    /// XCUITest run exercises the live AI request path:
+    /// 1. `AITestOverride.forceAvailable` — the `AIReaderAvailability` UI gate.
+    /// 2. `featureFlags.aiAssistant` — checked directly by `AIService.sendRequest`.
+    /// 3. `consentManager.hasConsent` — checked directly by `AIService.sendRequest`.
+    ///
+    /// Availability is written unconditionally (both branches) so a prior launch's
+    /// value in the same process doesn't leak. The flag + consent are only GRANTED
+    /// when enabling — never revoked here, so a verification run that intentionally
+    /// configured them stays configured.
+    static func apply(
+        enableAI: Bool,
+        featureFlags: FeatureFlags,
+        consentManager: AIConsentManager
+    ) {
+        AITestOverride.forceAvailable = enableAI
+        guard enableAI else { return }
+        featureFlags.setOverride(true, for: .aiAssistant)
+        consentManager.grantConsent()
+    }
+}
+
+#endif

--- a/vreader/App/VReaderApp.swift
+++ b/vreader/App/VReaderApp.swift
@@ -216,14 +216,19 @@ struct VReaderApp: App {
                 // value in the same process doesn't leak.
                 TTSTestOverride.useMockSynthesizer = config.ttsTestMode
 
-                // Bug #237: the --enable-ai launch flag was parsed into
-                // config.enableAI but never consumed, so AI verification
-                // surfaces stayed unreachable in XCUITest. Forward it to
-                // AITestOverride so AIReaderAvailability.isAvailable can
-                // short-circuit the API-key + consent gates a headless
-                // test can't satisfy. Written unconditionally so a prior
-                // launch's value in the same process doesn't leak.
-                AITestOverride.forceAvailable = config.enableAI
+                // Bug #237 (+ follow-up): the --enable-ai launch flag enables AI
+                // verification surfaces. Forwarding it to AITestOverride alone
+                // only short-circuits AIReaderAvailability (the UI gate) — but
+                // AIService.sendRequest gates DIRECTLY on featureFlags.aiAssistant
+                // + consentManager.hasConsent, so live AI requests (bilingual
+                // translate, summarize, chat) still threw featureDisabled/
+                // consentRequired. AITestSetup sets all three so CU-free AI
+                // verification exercises the full request path.
+                AITestSetup.apply(
+                    enableAI: config.enableAI,
+                    featureFlags: .shared,
+                    consentManager: AIConsentManager()
+                )
 
                 let persistence = PersistenceActor(modelContainer: container)
                 let seedConfig = config

--- a/vreaderTests/App/AITestSetupTests.swift
+++ b/vreaderTests/App/AITestSetupTests.swift
@@ -1,0 +1,71 @@
+// Tests for AITestSetup (Bug #237 follow-up): `--enable-ai` must enable the FULL
+// AI request path, not just UI availability. `AIService.sendRequest` gates on
+// `featureFlags.aiAssistant` AND `consentManager.hasConsent` DIRECTLY (not via
+// `AIReaderAvailability`), so forcing availability alone left live AI requests
+// (bilingual translate, summarize, chat) throwing featureDisabled/consentRequired
+// in CU-free verification. This pins that `--enable-ai` sets all three gates.
+
+#if DEBUG
+import Testing
+import Foundation
+@testable import vreader
+
+@MainActor
+@Suite("AITestSetup — --enable-ai enables the full AI request path")
+struct AITestSetupTests {
+
+    private func freshDefaults() -> UserDefaults {
+        let suite = "AITestSetupTests-\(UUID().uuidString)"
+        let d = UserDefaults(suiteName: suite)!
+        d.removePersistentDomain(forName: suite)
+        return d
+    }
+
+    @Test("enableAI=true sets availability + aiAssistant flag + consent")
+    func enableTrueSetsAllThreeGates() {
+        // The override is a global @MainActor static — reset it so this test
+        // can't contaminate later AIReaderAvailability tests.
+        defer { AITestOverride.forceAvailable = false }
+        AITestOverride.forceAvailable = false
+        let defaults = freshDefaults()
+        let flags = FeatureFlags(environment: .prod, persistenceDefaults: defaults)
+        let consent = AIConsentManager(defaults: defaults)
+        #expect(consent.hasConsent == false)   // precondition
+        #expect(flags.aiAssistant == false)
+
+        AITestSetup.apply(enableAI: true, featureFlags: flags, consentManager: consent)
+
+        #expect(AITestOverride.forceAvailable == true)
+        #expect(flags.aiAssistant == true, "aiAssistant flag must be set so AIService doesn't throw featureDisabled")
+        #expect(consent.hasConsent == true, "consent must be granted so AIService doesn't throw consentRequired")
+    }
+
+    @Test("enableAI=false clears the availability override (no leak)")
+    func enableFalseClearsAvailability() {
+        defer { AITestOverride.forceAvailable = false }
+        let defaults = freshDefaults()
+        let flags = FeatureFlags(environment: .prod, persistenceDefaults: defaults)
+        let consent = AIConsentManager(defaults: defaults)
+        AITestSetup.apply(enableAI: true, featureFlags: flags, consentManager: consent)
+        #expect(AITestOverride.forceAvailable == true)
+
+        AITestSetup.apply(enableAI: false, featureFlags: flags, consentManager: consent)
+        #expect(AITestOverride.forceAvailable == false, "a later launch without --enable-ai must not inherit availability")
+    }
+
+    @Test("enableAI=false does NOT grant the aiAssistant flag or consent (cold start)")
+    func enableFalseGrantsNothing() {
+        defer { AITestOverride.forceAvailable = false }
+        AITestOverride.forceAvailable = false
+        let defaults = freshDefaults()
+        let flags = FeatureFlags(environment: .prod, persistenceDefaults: defaults)
+        let consent = AIConsentManager(defaults: defaults)
+
+        AITestSetup.apply(enableAI: false, featureFlags: flags, consentManager: consent)
+
+        #expect(AITestOverride.forceAvailable == false)
+        #expect(flags.aiAssistant == false, "no --enable-ai → the real aiAssistant flag stays off")
+        #expect(consent.hasConsent == false, "no --enable-ai → consent is not auto-granted")
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Bug #237 made `--enable-ai` set `AITestOverride.forceAvailable` (the `AIReaderAvailability` UI gate). But `AIService.sendRequest`/`streamRequest` gate **directly** on `featureFlags.aiAssistant` + `consentManager.hasConsent` (not via `AIReaderAvailability`) — so live AI requests (bilingual translate, summarize, chat) still threw `featureDisabled`/`consentRequired` under CU-free verification: the UI lit up but no content rendered. New DEBUG-only `AITestSetup.apply()` sets all three gates.

Discovered while verifying Feature #42's bilingual criterion (#1234) — this is the harness gap behind the "bilingual UI activates but nothing translates" symptom.

## What Changed

- **New** `vreader/App/AITestSetup.swift` — DEBUG-only; sets availability + grants the `aiAssistant` flag + consent under `--enable-ai`.
- `VReaderApp.swift` — calls `AITestSetup.apply()` instead of the single `AITestOverride` line.
- **New** `AITestSetupTests.swift` — 3 tests (all-three-set, no-leak, cold-false-grants-nothing).

## Codex Audit

1 round, **ship-as-is**. Implementation clean (no Release leak — DEBUG-gated; correct stores; @MainActor correct). 2 test-quality findings (global-static leak, missing cold-false test) fixed. Log committed.

## Validation

- [x] `AITestSetupTests` — 3 green
- [x] Codex: ship-as-is; **DEBUG-only, no production/Release path** (consent granted ONLY under `--enable-ai`)
- [x] Version bumped: 3.42.12 → 3.42.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)