### PR TITLE
feat(#42 P2-WI-1b): make libmobi callable from Swift (bridging header + smoke)

### DIFF
--- a/.claude/codex-audits/feat-feature-42-wi-p2-1b-libmobi-binding-audit.md
+++ b/.claude/codex-audits/feat-feature-42-wi-p2-1b-libmobi-binding-audit.md
@@ -1,0 +1,31 @@
+---
+branch: feat/feature-42-wi-p2-1b-libmobi-binding
+threadId: codex-exec-gpt-5.4-mini-audit
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-01
+---
+
+# Codex audit — Feature #42 P2-WI-1b (libmobi → Swift binding)
+
+Runner: cc-suite `codex exec`, model gpt-5.4, effort medium, sandbox read-only.
+Mini audit (5 dims) over the first-party WI-1b surface (the vendored libmobi
+`.c/.h` are upstream + already merged in WI-1a → out of scope).
+
+## Round 1 findings + resolutions
+
+| file:line | severity | issue | resolution |
+|---|---|---|---|
+| project.yml:215 | Medium | `GCC_WARN_INHIBIT_ALL_WARNINGS: YES` was target-wide → would suppress warnings on any future first-party ObjC/ObjC++ in the vreader target, not just the vendored C. | **FIXED.** Removed the target-wide flag. The libmobi C is now excluded from the app-wide source entry and re-added via a dedicated `vreader/Services/Libmobi/src` source entry with `compilerFlags: "-w"` — scoping warning suppression to the third-party C only. Verified: pbxproj shows `COMPILER_FLAGS = "-w"` on all 17 `.c`, `GCC_WARN_INHIBIT_ALL_WARNINGS` gone (0 refs), `** BUILD SUCCEEDED **`, smoke `RUN-TESTS RESULT: SUCCEEDED`. |
+| vreaderTests/.../LibmobiSmokeTests.swift:21 | Low | The smoke proves runtime linkage for `mobi_version` + `mobi_init`/`mobi_free` but does NOT exercise the `USE_LIBXML2`-gated xmlwriter/OPF path, so it can't prove that conversion path runs. | **ACCEPTED + narrowed (Codex's offered alt).** Exercising the xmlwriter path needs a real MOBI→EPUB conversion — that IS WI-2, verified there with a real fixture. The libxml2 *link* is already proven at build time: xmlwriter.c references libxml2 symbols, so the app would fail to link if `-lxml2` didn't resolve (it links → proven). The test header now scopes the runtime claim to the two exercised symbols + states the link-vs-runtime distinction explicitly. |
+
+## Clean (no change needed)
+
+- `Libmobi.swift` — `version` is a read-only `mobi_version()` wrapper; `contextAllocates()` ownership is correct: nil early-return, single `mobi_free` on success, no leak/double-free. No shared mutable state → isolation-safe.
+- `Libmobi-Bridging-Header.h` — exposing `mobi.h` is broad but acceptable: self-contained, consistently `mobi_`/`MOBI_`-prefixed → low collision risk.
+- `project.yml` `$(inherited)` chains on GCC_PREPROCESSOR_DEFINITIONS / HEADER_SEARCH_PATHS / OTHER_LDFLAGS are preserved; `-lxml2` is the correct iOS SDK link; `SWIFT_OBJC_BRIDGING_HEADER` points at the right file.
+
+## Verdict
+
+ship-as-is — the one Medium is fixed + build/smoke-verified; the one Low is an
+explicit, documented WI-2 deferral with the link already proven at build time.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 779
-        MARKETING_VERSION: 3.42.16
+        CURRENT_PROJECT_VERSION: 780
+        MARKETING_VERSION: 3.42.17
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/project.yml
+++ b/project.yml
@@ -50,14 +50,18 @@ targets:
           # build-bundle.sh is also a dev/build tool, not a runtime
           # asset; keep it out of the app bundle.
           - "Services/Foliate/JS/build-bundle.sh"
-          # Feature #42 Phase-2 WI-1a (libmobi convert-on-import, LGPL-3.0):
-          # the vendored libmobi C sources need their own compile flags
-          # (-DUSE_LIBXML2=1, the libxml2 include path, no -Werror) which differ
-          # from the app target's. Exclude them from the app's source glob so
-          # they don't auto-compile with the wrong flags; WI-1b wires them via a
-          # dedicated static-library target + module map. The build recipe that
-          # was verified for iOS lives in Services/Libmobi/BUILD-RECIPE.md.
-          - "Services/Libmobi/**"
+          # Feature #42 Phase-2 WI-1b (libmobi convert-on-import, LGPL-3.0):
+          # the vendored libmobi C sources DO compile into the app target (so
+          # their symbols link), exposed to Swift via Libmobi-Bridging-Header.h.
+          # Their compile flags (USE_LIBXML2, the libxml2 include path) + the
+          # libxml2 link live in this target's `settings` below. mobi.h is
+          # self-contained (stdlib includes only), so the bridge is trivial.
+          # Only the vendored docs/license are excluded here — globbing them
+          # would copy README/LICENSE into the app bundle as stray resources.
+          # Recipe + remaining WIs: Services/Libmobi/BUILD-RECIPE.md.
+          - "Services/Libmobi/LICENSE"
+          - "Services/Libmobi/README.md"
+          - "Services/Libmobi/BUILD-RECIPE.md"
           # Bug #111: DebugFixtures must NOT ship in Release. xcodegen `excludes`
           # is not per-build-config, so we strip the directory from the source
           # phase entirely and re-inject it via a Debug-only Run Script below.
@@ -195,6 +199,20 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
         CURRENT_PROJECT_VERSION: 779
         MARKETING_VERSION: 3.42.16
+        # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
+        # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
+        # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2
+        # and a link stub reachable via -lxml2. The Libmobi src dir is on the
+        # header path so the bridging header's #include "mobi.h" resolves.
+        # GCC_WARN_INHIBIT_ALL_WARNINGS scopes to C compilation only (the app
+        # is pure Swift), so it silences third-party libmobi warnings without
+        # hiding the app's own Swift warnings. miniz is bundled inside libmobi,
+        # so no zlib link is needed beyond what libxml2 itself pulls.
+        GCC_PREPROCESSOR_DEFINITIONS: "$(inherited) USE_LIBXML2=1"
+        HEADER_SEARCH_PATHS: "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src"
+        SWIFT_OBJC_BRIDGING_HEADER: "vreader/SupportingFiles/Libmobi-Bridging-Header.h"
+        OTHER_LDFLAGS: "$(inherited) -lxml2"
+        GCC_WARN_INHIBIT_ALL_WARNINGS: YES
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/project.yml
+++ b/project.yml
@@ -53,12 +53,19 @@ targets:
           # Feature #42 Phase-2 WI-1b (libmobi convert-on-import, LGPL-3.0):
           # the vendored libmobi C sources DO compile into the app target (so
           # their symbols link), exposed to Swift via Libmobi-Bridging-Header.h.
-          # Their compile flags (USE_LIBXML2, the libxml2 include path) + the
-          # libxml2 link live in this target's `settings` below. mobi.h is
-          # self-contained (stdlib includes only), so the bridge is trivial.
-          # Only the vendored docs/license are excluded here — globbing them
-          # would copy README/LICENSE into the app bundle as stray resources.
+          # The C is excluded from THIS (app-wide) source entry and re-added by
+          # the dedicated `Services/Libmobi/src` entry below with `-w` scoped to
+          # it — so third-party-C warning suppression never leaks onto the app's
+          # own (future) first-party ObjC/ObjC++ (Codex Gate-4 finding). mobi.h
+          # is self-contained (stdlib includes only), so the bridge is trivial.
+          # USE_LIBXML2 / the libxml2 include path + the -lxml2 link stay in this
+          # target's `settings` below (benign target-wide; needed so the Swift
+          # bridging-header view of mobi.h matches the .c). Libmobi.swift (first-
+          # party) stays in this glob and compiles with the app's normal flags.
+          # Docs/LICENSE excluded — globbing them would copy README/LICENSE into
+          # the app bundle as stray resources.
           # Recipe + remaining WIs: Services/Libmobi/BUILD-RECIPE.md.
+          - "Services/Libmobi/src/**"
           - "Services/Libmobi/LICENSE"
           - "Services/Libmobi/README.md"
           - "Services/Libmobi/BUILD-RECIPE.md"
@@ -73,6 +80,14 @@ targets:
           # into the BUILT Info.plist so the vreader-debug:// URL scheme actually
           # registers with iOS.
           - "SupportingFiles/DebugBridge.plist"
+      # Feature #42 Phase-2 WI-1b: the vendored libmobi C, compiled into the app
+      # target with `-w` scoped to ONLY these third-party sources. Keeping the
+      # suppression here (not target-wide via GCC_WARN_INHIBIT_ALL_WARNINGS)
+      # preserves the app target's own warning flags for first-party ObjC/ObjC++
+      # (Codex Gate-4 Medium). USE_LIBXML2 + the libxml2 header path come from
+      # the target settings below, which these files inherit.
+      - path: vreader/Services/Libmobi/src
+        compilerFlags: "-w"
     dependencies:
       # Feature #42 Phase 1: Readium Swift Toolkit products. ReadiumShared
       # supplies the Locator/Publication model; ReadiumStreamer supplies
@@ -204,15 +219,17 @@ targets:
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2
         # and a link stub reachable via -lxml2. The Libmobi src dir is on the
         # header path so the bridging header's #include "mobi.h" resolves.
-        # GCC_WARN_INHIBIT_ALL_WARNINGS scopes to C compilation only (the app
-        # is pure Swift), so it silences third-party libmobi warnings without
-        # hiding the app's own Swift warnings. miniz is bundled inside libmobi,
-        # so no zlib link is needed beyond what libxml2 itself pulls.
+        # USE_LIBXML2 / the libxml2 header path are benign target-wide (Swift
+        # ignores C preprocessor defs; first-party ObjC, if ever added, is
+        # unaffected by an unused macro + extra include dir). Warning
+        # suppression for the third-party C is NOT here — it's scoped to the
+        # `Services/Libmobi/src` source entry above via `-w` (Codex Gate-4
+        # Medium). miniz is bundled inside libmobi, so no zlib link is needed
+        # beyond what libxml2 itself pulls.
         GCC_PREPROCESSOR_DEFINITIONS: "$(inherited) USE_LIBXML2=1"
         HEADER_SEARCH_PATHS: "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src"
         SWIFT_OBJC_BRIDGING_HEADER: "vreader/SupportingFiles/Libmobi-Bridging-Header.h"
         OTHER_LDFLAGS: "$(inherited) -lxml2"
-        GCC_WARN_INHIBIT_ALL_WARNINGS: YES
     info:
       # XcodeGen writes vreader/SupportingFiles/Info.plist with this content.
       # We need a real Info.plist (not Xcode's auto-generated one) because

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		00AA9871B88FE39518AC1320 /* utf16be_bom.txt in Resources */ = {isa = PBXBuildFile; fileRef = F2EFEE7A0EC5352A0BB1A994 /* utf16be_bom.txt */; };
 		010552D4E12A8F6FC2A333F5 /* ReadiumNavCommanderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03321A13C86F9E69BE338864 /* ReadiumNavCommanderTests.swift */; };
 		010EC2576D94F9B1E1AC2983 /* search.js in Resources */ = {isa = PBXBuildFile; fileRef = 87DF28B0149478FEC7B8EC4E /* search.js */; };
+		01161AA2FED893368F345289 /* meta.c in Sources */ = {isa = PBXBuildFile; fileRef = F73114784F0062C27A90420D /* meta.c */; };
 		01440A60BDBE08FC56500DA7 /* SearchHitToLocatorResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A2CD5F8AD4DEC1A14A255A /* SearchHitToLocatorResolver.swift */; };
 		01450E848C5A2110A56DDD21 /* TXTTextChunkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3BC126A794F2C82F782E7D /* TXTTextChunkerTests.swift */; };
 		018E696CD9238CE5A290D9AF /* MDIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EE79C451D86828387A1BEF /* MDIntegrationTests.swift */; };
@@ -128,6 +129,7 @@
 		14471AC7E32BFFD1BBAFB829 /* EPUBContinuousScrollJSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3985B5AA10C2F75D5A24CF3 /* EPUBContinuousScrollJSTests.swift */; };
 		1486C59650FEE786655A27F0 /* ReTranslateProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB32B8E264864D8B94DE2EC /* ReTranslateProgress.swift */; };
 		149A6822E6971C612A1D9CAA /* EPUBContinuousScrollBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = F05F28A8422C4AB0951D9586 /* EPUBContinuousScrollBridge.swift */; };
+		14CAE71643EC2BB8213DD906 /* LibmobiSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E60C649B564A45FD862030 /* LibmobiSmokeTests.swift */; };
 		153D8AC5E69BB60CF272EE5A /* NotesSwipeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC942D0BB7FF478B060D874 /* NotesSwipeResolver.swift */; };
 		15560934D5C58CBA9C8A2AFD /* FoliatePositionRestoreController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86C32AA4EAE4EA8014E71A14 /* FoliatePositionRestoreController.swift */; };
 		1558B65D447DCD7705FE074C /* FoliateTTSAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C511C16F7FA93E91D703EE7 /* FoliateTTSAdapterTests.swift */; };
@@ -158,6 +160,7 @@
 		1B78DA4330A421FE2206B70C /* FoliateSearchAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8C36563D7885AD214F885A /* FoliateSearchAdapter.swift */; };
 		1BD4CC8621C43917629D4728 /* HighlightRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96BE19585BF1F4C8174F7219 /* HighlightRecord.swift */; };
 		1BE57FEAD56B11B8BB4F4B97 /* PillSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14FEA325D6BADCAF881358B5 /* PillSwitch.swift */; };
+		1BF392E0910D136950668E41 /* compression.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DF1208DFEA4E40A0D028BDD /* compression.c */; };
 		1C047439042E40ABD9D6DFA7 /* AnnotationsSheetRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4782896641E1278B54C247 /* AnnotationsSheetRouteTests.swift */; };
 		1C44F27B696718DDCDCD8942 /* WebDAVNetworkPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B73649BCBDBE8A99B210A9 /* WebDAVNetworkPolicyTests.swift */; };
 		1C6369DA44DE9BEF6A8F7E89 /* WebDAVProfileListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31265D2F8B445FADB98DDFC /* WebDAVProfileListViewModelTests.swift */; };
@@ -175,6 +178,7 @@
 		1E114184ED4E99E9EB1FE43C /* SearchIndexStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DB1CCA367AE0B610F4526FC /* SearchIndexStore.swift */; };
 		1E335C7D712FBA26BE8AB6C1 /* EPUBContinuousChapterProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C49D62E589CDF0C9F2D094 /* EPUBContinuousChapterProvider.swift */; };
 		1E5332F73297C4DB6DF747BD /* FontSizeCalibratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1946F92E99B7DCC600147C /* FontSizeCalibratorTests.swift */; };
+		1EA3DE3ED82E75202D5B0A5B /* parse_rawml.c in Sources */ = {isa = PBXBuildFile; fileRef = E09CB8C0A0B9450D82B3687E /* parse_rawml.c */; };
 		1EBF5B02922DA284822CDE3F /* SettingsNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE37B6A3CEA41E0CD7821292 /* SettingsNotifications.swift */; };
 		1EE68B75A44789E6789BA6EB /* EPUBTextExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADECFF5C347B6D68C1A8529 /* EPUBTextExtractorTests.swift */; };
 		1F3F0A67EB5D7AEC3B11D3C3 /* HighlightPersisting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D988A4CE41E94A8A9280CC /* HighlightPersisting.swift */; };
@@ -494,6 +498,7 @@
 		5572AED7041B6CFD3C93AB79 /* LazyDownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159BB4EBD79ECE6657D50EC1 /* LazyDownloadDelegate.swift */; };
 		5599E405840D204BE7FA8104 /* LibrarySortOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC606D4AF30DF956E04C13DF /* LibrarySortOrder.swift */; };
 		55E8CDBFFC9EC1C49EAC47EE /* DocumentFingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99D14A41185FFD87E278E66C /* DocumentFingerprint.swift */; };
+		55F288C34B0362788ECAE2C0 /* memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 86219F525D53A66480857B58 /* memory.c */; };
 		56075E2760DBF80032EE55CE /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13D1E2EE401D4C3053FB687A /* MockURLSession.swift */; };
 		5619DB9FC83E7182AE0EB63F /* PersistenceBookmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410BA6F21267316487DF58FC /* PersistenceBookmarkTests.swift */; };
 		563B878DD14F1699FFC52439 /* NavigationFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874E517A41CB3B9C7C5C8D3A /* NavigationFlowTests.swift */; };
@@ -556,6 +561,7 @@
 		60C9597A3AB3E5C1DF8D5BE8 /* EPUBChapterNavigationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4155E7139CA2623252814A6 /* EPUBChapterNavigationRouter.swift */; };
 		60F28F11E8F15E0FFAF4922C /* LibraryBookItemFileStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4E5558CB75432C026267C1 /* LibraryBookItemFileStateTests.swift */; };
 		61303A8643869C6334AFB873 /* ReaderMorePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BA71E474E9C05E3689CF88 /* ReaderMorePopover.swift */; };
+		614C767C1814F710ECAD56AC /* Libmobi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02568BCB9C0024CD13E6B213 /* Libmobi.swift */; };
 		6153EBE134D9A0A41A48C8A1 /* HighlightsSheet+Export.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50988D487A861C52A06E6159 /* HighlightsSheet+Export.swift */; };
 		6173290A06E9E4303D363AE8 /* ReaderThemeCSSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DE298149C25261E2ECADA1 /* ReaderThemeCSSTests.swift */; };
 		6179B1DCDC87E71E3A7218CC /* EPUBChapterWrapPendingTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864BA35C7F82D6437278E5C6 /* EPUBChapterWrapPendingTargetTests.swift */; };
@@ -574,6 +580,7 @@
 		6357FCBADF316F72B24C3975 /* ProviderProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9893809AE39B5DF0233FEE42 /* ProviderProfile.swift */; };
 		637607A8DD0B3C23776A3002 /* SchemaV8.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CA82E6D9E86220E10B3728 /* SchemaV8.swift */; };
 		6385D414214525E5CF2C4C8E /* HighlightPopoverViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7747D7A10C50F43520FB5FF0 /* HighlightPopoverViewModel.swift */; };
+		63CD1BD55C4410F70D1C8549 /* debug.c in Sources */ = {isa = PBXBuildFile; fileRef = 7E468F4DBD64650AF7E80CE6 /* debug.c */; };
 		646C642DA4E4DCFF2AFEB68A /* search_no_results.html in Resources */ = {isa = PBXBuildFile; fileRef = 84BAC2CBFB7F533857E6A65B /* search_no_results.html */; };
 		64709D1B5C006D3299C8ABAF /* AutoPageTurner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5401E10DDA195966ABD13F70 /* AutoPageTurner.swift */; };
 		64BF0E0C54C919613EFEECD9 /* search_results.html in Resources */ = {isa = PBXBuildFile; fileRef = E3D9BD563DBFE23CE71083C5 /* search_results.html */; };
@@ -629,6 +636,7 @@
 		6CC40A6DE2F14BB94A53006B /* FoliateMessageParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB35F648E8E697C82E4C41DE /* FoliateMessageParserTests.swift */; };
 		6CFD5F91EEF10C009963AEB0 /* TextReaderUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E25002586402AAE67B29CE6 /* TextReaderUIState.swift */; };
 		6D073A0311A72B82FEF65852 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC105D38A4A85CBCB79A772 /* KeychainService.swift */; };
+		6D54759E6F840D7506AE2C36 /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = 0A9AF8B9047FF5BA819DE46F /* sha1.c */; };
 		6D6ADF2C31C5386957B6EF65 /* LazyDownloadEnqueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DF85A7A806124F57A8FB6E /* LazyDownloadEnqueueTests.swift */; };
 		6D9880CCA623B7887967DB45 /* DebugPresentSheetEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BCADB7187645F41A660385 /* DebugPresentSheetEffect.swift */; };
 		6DC960D68C180A1078911388 /* EPUBWebViewBridgeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1920480AF349823757484C2D /* EPUBWebViewBridgeCoordinator.swift */; };
@@ -644,6 +652,7 @@
 		6EB7C3CE4427353026BCD4E9 /* Inter-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 7CE90E7D827B7E8A356D6DC6 /* Inter-SemiBold.otf */; };
 		6F1DD222CF91070D7B3D997F /* AnnotationImportError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C56D76EC2A57744D168E86 /* AnnotationImportError.swift */; };
 		6F77E9702493FB758FBF3319 /* BilingualSetupSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4493553E18BBEB66EA8D32BF /* BilingualSetupSheet.swift */; };
+		6FBF472BF60BE1164ED7EA80 /* index.c in Sources */ = {isa = PBXBuildFile; fileRef = 1AA31A6079F35AFE9A74C04A /* index.c */; };
 		6FCF7DD822CCDC8C47899DF7 /* RealDebugBridgeContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0378B284E969CD8625A89EA1 /* RealDebugBridgeContext.swift */; };
 		6FF433287ABA2EEBDE2D5636 /* TXTViewConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48EFB2798AC0354FCC8D4A9B /* TXTViewConfig.swift */; };
 		700CFFEC7C74E0532A0271F4 /* ExportTestFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5CAE41C429B6868957C540 /* ExportTestFixtures.swift */; };
@@ -685,6 +694,7 @@
 		762B3F65978080FE7D26BF4C /* AnnotationModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11E9DBFB16DA26DD0659851 /* AnnotationModelTests.swift */; };
 		768E594123AD4AA389E2BEAC /* AISummaryTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA307AD0EDD85730C6DE77A /* AISummaryTabViewTests.swift */; };
 		76B75FF4AC85FDA4239E43DE /* ProviderProfileMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7C16F12BA653A217A5439C /* ProviderProfileMigratorTests.swift */; };
+		76B92705C3DDA309A262E19E /* read.c in Sources */ = {isa = PBXBuildFile; fileRef = 7C1BE488B566578C5C914796 /* read.c */; };
 		770CE6C30927E26DC0DB017F /* FoliateScrolledWindowMathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AECD22002DD170A5BF984A /* FoliateScrolledWindowMathTests.swift */; };
 		7778CE2B4527836E7E8B3FD7 /* PDFHighlightTapResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E21285A9149B2F11210A9430 /* PDFHighlightTapResolverTests.swift */; };
 		7783FE9E844F919F1D722742 /* EPUBBilingualJS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904A30F4AD7E5862C2D3C955 /* EPUBBilingualJS.swift */; };
@@ -702,6 +712,7 @@
 		792FA8647985692CC1ED5694 /* ReadiumOpenSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3101BC67249AD8280F55AFA /* ReadiumOpenSmokeTests.swift */; };
 		793A39541D8253B1CA8984A5 /* ScrollProgressHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7024E7AEAC9AEAA028952C46 /* ScrollProgressHelper.swift */; };
 		794FD606545B9368CD9CF18F /* legado_source_minimal.json in Resources */ = {isa = PBXBuildFile; fileRef = DE360E19106AAA7A1FCEEEB9 /* legado_source_minimal.json */; };
+		797368D84A628FD0CC75BB75 /* encryption.c in Sources */ = {isa = PBXBuildFile; fileRef = 6644E66A9BEDE9071D8D876F /* encryption.c */; };
 		79ACFB3DD40281B2A3B9AE8B /* DebugSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94C32FCAEDE0062125F6A51E /* DebugSnapshot.swift */; };
 		7A2CAFE661BD03C0255C9DD7 /* Feature37PerBookSettingsVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB03A3F8DCE5FCBEC5458547 /* Feature37PerBookSettingsVerificationTests.swift */; };
 		7A3B9A992F12E5E187F0794E /* ReaderThemeMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A480E951C2CA72DB6A22C24 /* ReaderThemeMigrationTests.swift */; };
@@ -786,6 +797,7 @@
 		88472C0C4B06190CA46E917F /* BookImporterEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163C2BBCB1C2FEFB9713C4CF /* BookImporterEnvironment.swift */; };
 		884CC3C2EDE6FC428A666910 /* SyncTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E72DDEAD6225A21E973A51 /* SyncTypes.swift */; };
 		88521B18CEC15B95AC59E36D /* TXTBridgeHighlightTapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5792668BED81E507B2C693DA /* TXTBridgeHighlightTapTests.swift */; };
+		88742A7F3156E292969BE063 /* structure.c in Sources */ = {isa = PBXBuildFile; fileRef = A4D62CB2C235BD942DAD8E06 /* structure.c */; };
 		88B73AB500D0DFD555AC9363 /* WebPageEncodingDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB19A1C01A25FDB23FA3E7DB /* WebPageEncodingDetectorTests.swift */; };
 		891E1E70B176150B071E464F /* AIContextExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20237121BB4ACF22C0818BA4 /* AIContextExtractorTests.swift */; };
 		892A9F3136477F52D3AECE11 /* text-walker.js in Resources */ = {isa = PBXBuildFile; fileRef = 43CD38D8708AAE752995001B /* text-walker.js */; };
@@ -819,6 +831,7 @@
 		8E153D7C3B713EDDBF484A24 /* AIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334D6D06A294323E149970E4 /* AIService.swift */; };
 		8E272AD8C74C7EB03B9D3E7D /* ReaderDisplayControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8807117D114833F057AD99CE /* ReaderDisplayControls.swift */; };
 		8E2E64928835A3533FDE10FA /* PDFAnnotationBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A064D62C86857484454D0BE3 /* PDFAnnotationBridge.swift */; };
+		8E55B405568C0A20C0869CEF /* util.c in Sources */ = {isa = PBXBuildFile; fileRef = 3D68C1EB7A52364906CB54B8 /* util.c */; };
 		8E7482D250AFDBEF1803780A /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB31146A831DACE67C50F08 /* AppConfiguration.swift */; };
 		8E936BF32CF0850398C9D742 /* AIChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539FEE4A23AFA226048A12A4 /* AIChatView.swift */; };
 		8E93B4DCB415EC16CEE9F01E /* WebPageEncodingDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA008CC17CE7798B70F4E2D /* WebPageEncodingDetector.swift */; };
@@ -977,6 +990,7 @@
 		AAEA9983AA0492366955FB9B /* PositionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BCC142F6FF2ABE9B5BA64B /* PositionPersistenceTests.swift */; };
 		ABB95D6805BADA4CC6DBE564 /* RealDebugBridgeContext+SeedSessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65CF531180D798D01E12893 /* RealDebugBridgeContext+SeedSessions.swift */; };
 		ABE20173610A76DC711FBA55 /* ReaderThemeV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB26FE0A7766F5E461A6BC7 /* ReaderThemeV2.swift */; };
+		AC68C2599DEA6A14C6E7BA57 /* xmlwriter.c in Sources */ = {isa = PBXBuildFile; fileRef = 0B192843406A9DDE4B3E7776 /* xmlwriter.c */; };
 		ACE4A8A746F082AEC08BB273 /* CustomCoverStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5955766DF21883C0C57B71E4 /* CustomCoverStoreTests.swift */; };
 		AD1910F64D226400933FDBA2 /* PDFHighlightRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8719A34DB441AF9DC6379DC9 /* PDFHighlightRenderer.swift */; };
 		AD27484127EA24D230616F48 /* TestConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B2824739E67F567813198E /* TestConstants.swift */; };
@@ -1006,6 +1020,7 @@
 		B1B9E936492D58B0768C0785 /* TXTTextExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8707DA3A6FC024EAC4F63E76 /* TXTTextExtractorTests.swift */; };
 		B1BF1136437114637B9F8800 /* BookDetailsSheet+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F79D3BEB86E859FEF2D09E2A /* BookDetailsSheet+Actions.swift */; };
 		B1DFA851C827F5BB877DD2B8 /* ReadingSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41196788F697BB4ACD4B06 /* ReadingSessionTests.swift */; };
+		B1E83DEDFD2024431E1123A1 /* miniz.c in Sources */ = {isa = PBXBuildFile; fileRef = 449D9045380C2ACAB1ECDA05 /* miniz.c */; };
 		B1EF7FB8170BAD9BFA1B5636 /* EPUBTextExtractorBilingualTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3595767B5C24F2D437C634BF /* EPUBTextExtractorBilingualTests.swift */; };
 		B227E3B75BE0BFAE923628BD /* HighlightsSheet+Delete.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A21498B4BB8CCB388677F3 /* HighlightsSheet+Delete.swift */; };
 		B272D2C56AF8559115BBD8E3 /* AIContextExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42CFB0E94DE1D37E0FD2741B /* AIContextExtractor.swift */; };
@@ -1088,6 +1103,7 @@
 		C02BE297CD13689403CC7FE3 /* FoliateSpikeView+HighlightTap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086557F549C56946CFD6194E /* FoliateSpikeView+HighlightTap.swift */; };
 		C03DA14D8DBA94B0CE4135D5 /* SearchViewActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08856C035686A119B4371C25 /* SearchViewActions.swift */; };
 		C08E9C36FF3ED5C05E74F52B /* WI11TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2D542588B3156C4A282264 /* WI11TestHelpers.swift */; };
+		C09DC2D3EE103276AF5DEDF0 /* randombytes.c in Sources */ = {isa = PBXBuildFile; fileRef = F5222DA16840ED81F2DBE676 /* randombytes.c */; };
 		C0CFC8A31D8F8F2AE475DEFB /* TXTChapterTextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E601CAC151908F402E8F30 /* TXTChapterTextProvider.swift */; };
 		C0D9308246DCE3C239D86323 /* Inter-LICENSE.txt in Resources */ = {isa = PBXBuildFile; fileRef = 2E5E264F97F1E53F985C34BB /* Inter-LICENSE.txt */; };
 		C11851768B01D69A554324D0 /* ReadiumBilingualEvalAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E972CB07620BB3D30FCD92C /* ReadiumBilingualEvalAdapter.swift */; };
@@ -1120,6 +1136,7 @@
 		C535579CBC09F0C9E79EBB6F /* TXTChapterOffsetIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FBA8CFEF94EDBE0398AC4A /* TXTChapterOffsetIndexTests.swift */; };
 		C545A7D59A2D63CC5B1DF45B /* OPDSParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF47D926F78F13327F6770C /* OPDSParser.swift */; };
 		C57845DF5A192CA91CE07FED /* HighlightActionCardViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB42619D63C6DB1728CE74D0 /* HighlightActionCardViewTests.swift */; };
+		C58BFD854BB68CD7F974AE20 /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = 435A9AA017E6DED1ABD5EDD4 /* buffer.c */; };
 		C59B87F85C20B1B2D9DDC387 /* SyncStatusMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F693921BA233745D77EC0037 /* SyncStatusMonitor.swift */; };
 		C5E2EFAA979EF5CBE624F14C /* SettingsRowPalette+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E998CB9F64AEAFC0D2A42C46 /* SettingsRowPalette+SwiftUI.swift */; };
 		C5EEEAABF1F852CDABDA43F1 /* WebDAVClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4946129FECC6C9BA7A7F16A1 /* WebDAVClient.swift */; };
@@ -1272,6 +1289,7 @@
 		DF36D73AC9B53845BF561CBC /* BookImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5160D7D68BF1AF6654AD08B6 /* BookImporter.swift */; };
 		DF4946C8219D6823B1BC3E64 /* WebDAVProfileListViewModelEditorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4630258E354B2D34ADB23182 /* WebDAVProfileListViewModelEditorTests.swift */; };
 		DF587005A7C4257AD28C42A0 /* TTSServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A2FE9743AF484093A21969 /* TTSServiceTests.swift */; };
+		DFED97AA770947C9808D2C8A /* write.c in Sources */ = {isa = PBXBuildFile; fileRef = 7AEF9EDC3C81B6E2AFCD6590 /* write.c */; };
 		E03FE4F3997CC67281E84F1E /* ReadingSessionTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D94EE13466B0286DEA2EA7 /* ReadingSessionTracker.swift */; };
 		E057330B701161FF1AD06DB4 /* MockAnnotationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E10DBA312E3C1934B36E63 /* MockAnnotationStore.swift */; };
 		E05A4A7DA74E241520EB2F0E /* TXTBridgeShared.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43C03327815457BD7B01409 /* TXTBridgeShared.swift */; };
@@ -1434,6 +1452,7 @@
 		FFA194178E9956EF14C4B8DD /* overlayer.js in Resources */ = {isa = PBXBuildFile; fileRef = 1ABFAC14455C6F7DE43C1ABC /* overlayer.js */; };
 		FFA99A696DC411A0D8A0C969 /* ChapterReTranslateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFE15DA4C0FC8B57E3B4728B /* ChapterReTranslateViewModel.swift */; };
 		FFC1BF2B3E0963AAD120E93E /* AnthropicProvider+Streaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = C682F2AF644C10CEC95208AE /* AnthropicProvider+Streaming.swift */; };
+		FFC62D5EFD014C76A0E5369E /* opf.c in Sources */ = {isa = PBXBuildFile; fileRef = 79A043D83CF700D279FF0358 /* opf.c */; };
 		FFCACE71EA64842074302A98 /* DebugBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1348B555C6A2C90B03ED65 /* DebugBridge.swift */; };
 		FFF583F410E0987A762830D5 /* InfoPlistDocumentTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6E69931BB43A61C776F63A /* InfoPlistDocumentTypesTests.swift */; };
 /* End PBXBuildFile section */
@@ -1475,6 +1494,7 @@
 		01CD66C1E52331AC245386C9 /* HTTPTTSConfigStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTTSConfigStore.swift; sourceTree = "<group>"; };
 		01E72DDEAD6225A21E973A51 /* SyncTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncTypes.swift; sourceTree = "<group>"; };
 		02275826847D45CA3746D53D /* CollectionSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSidebar.swift; sourceTree = "<group>"; };
+		02568BCB9C0024CD13E6B213 /* Libmobi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Libmobi.swift; sourceTree = "<group>"; };
 		02DE298149C25261E2ECADA1 /* ReaderThemeCSSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeCSSTests.swift; sourceTree = "<group>"; };
 		03019F035CBDE3EF65771114 /* Feature29WebDAVVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature29WebDAVVerificationTests.swift; sourceTree = "<group>"; };
 		03321A13C86F9E69BE338864 /* ReadiumNavCommanderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumNavCommanderTests.swift; sourceTree = "<group>"; };
@@ -1484,6 +1504,7 @@
 		03E01318DE23F63217033B89 /* ProviderProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderProfileTests.swift; sourceTree = "<group>"; };
 		03FA3AC72012ED6686293475 /* ReadingStatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsTests.swift; sourceTree = "<group>"; };
 		0459CAA7394555E5A8E17146 /* ReaderUnsupportedFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderUnsupportedFormatTests.swift; sourceTree = "<group>"; };
+		048A73AE0C45DB140C6E4F2D /* index.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = index.h; sourceTree = "<group>"; };
 		04CBEAF6FEDB714FCE897550 /* BookCoverArtView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCoverArtView.swift; sourceTree = "<group>"; };
 		04ED79BFAD4BEF6B8A30F982 /* BookFileMaterializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFileMaterializerTests.swift; sourceTree = "<group>"; };
 		050AAFD290B8995258D78AC2 /* FormatCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatCapabilities.swift; sourceTree = "<group>"; };
@@ -1517,7 +1538,9 @@
 		0A1F641F61AC5B5DDEB0FD24 /* FoliateBilingualContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateBilingualContainerView.swift; sourceTree = "<group>"; };
 		0A2A16647F198641F11AC9C1 /* WCAGContrastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCAGContrastTests.swift; sourceTree = "<group>"; };
 		0A53B5CE5A37514E7E7D4BEC /* TestSeederMDMultiPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSeederMDMultiPageTests.swift; sourceTree = "<group>"; };
+		0A9AF8B9047FF5BA819DE46F /* sha1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sha1.c; sourceTree = "<group>"; };
 		0ACE55DA655F52A0757536E1 /* SyncPipelineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncPipelineTests.swift; sourceTree = "<group>"; };
+		0B192843406A9DDE4B3E7776 /* xmlwriter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = xmlwriter.c; sourceTree = "<group>"; };
 		0B244CEE76D4FFD2FE2CFE99 /* MDChapterStartTypographyIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDChapterStartTypographyIntegrationTests.swift; sourceTree = "<group>"; };
 		0B636D7823EE57464A4CE54D /* foliate-reader.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "foliate-reader.html"; sourceTree = "<group>"; };
 		0B9584B44764B8D11C7CC9F6 /* ReplacementRulesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplacementRulesView.swift; sourceTree = "<group>"; };
@@ -1563,6 +1586,7 @@
 		12841E371391B5AD20122A37 /* ReaderMorePopoverParts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderMorePopoverParts.swift; sourceTree = "<group>"; };
 		12A19B27CA094A4BAA679504 /* TXTBridgeHighlightNonceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTBridgeHighlightNonceTests.swift; sourceTree = "<group>"; };
 		12FBBBC16EB3E7F31AD7A126 /* ReaderSettingsStoreCalibrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsStoreCalibrationTests.swift; sourceTree = "<group>"; };
+		13260106C045DDB460F1126C /* parse_rawml.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = parse_rawml.h; sourceTree = "<group>"; };
 		1332F42A0C57EA1D1F37D9C0 /* Feature63SearchPanelVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature63SearchPanelVerificationTests.swift; sourceTree = "<group>"; };
 		13404BD286B135797ECF391A /* AccentColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccentColor.swift; sourceTree = "<group>"; };
 		1351525282D8D0C13B726F85 /* DebugReaderRegistry+WebViewWait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DebugReaderRegistry+WebViewWait.swift"; sourceTree = "<group>"; };
@@ -1610,6 +1634,7 @@
 		19EA79EB5577BF31A4096B39 /* NoOpSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoOpSessionStore.swift; sourceTree = "<group>"; };
 		1A49E33ACBED018932A38F0C /* AddNoteSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddNoteSheet.swift; sourceTree = "<group>"; };
 		1A7668891CD8BA0B6DED7A25 /* LibraryCardTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryCardTokens.swift; sourceTree = "<group>"; };
+		1AA31A6079F35AFE9A74C04A /* index.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = index.c; sourceTree = "<group>"; };
 		1ABFAC14455C6F7DE43C1ABC /* overlayer.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = overlayer.js; sourceTree = "<group>"; };
 		1B311C3A88BD6DC42005FE1B /* ExportedAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportedAnnotation.swift; sourceTree = "<group>"; };
 		1BA8C0E6A9B8EF3E48771286 /* PersistenceActor+ReadingHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+ReadingHistory.swift"; sourceTree = "<group>"; };
@@ -1646,6 +1671,7 @@
 		21BC5F159064D57CFAE2A676 /* MetadataExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataExtractorTests.swift; sourceTree = "<group>"; };
 		21CF1C76C54971B97341E5E9 /* FoliateHighlightRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightRenderer.swift; sourceTree = "<group>"; };
 		22012CDD369E616CC9FD8075 /* AnnotationsEmptyStateArtTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationsEmptyStateArtTests.swift; sourceTree = "<group>"; };
+		2222400AEEA81DA9402E672A /* config.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
 		222624560E31B939E32955D8 /* FoliateHostTapCoordinateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHostTapCoordinateTests.swift; sourceTree = "<group>"; };
 		22789AF01A93F31CDFDFB3F2 /* TranslationUnitIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationUnitIDTests.swift; sourceTree = "<group>"; };
 		228F27716382F3B61E0E15C8 /* CollectionSidebarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSidebarTests.swift; sourceTree = "<group>"; };
@@ -1760,6 +1786,7 @@
 		3AEB955B6E5713C9AB4D701E /* Feature34CollectionsVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature34CollectionsVerificationTests.swift; sourceTree = "<group>"; };
 		3B1563E77E28434568F45736 /* LibraryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModelTests.swift; sourceTree = "<group>"; };
 		3B6E69931BB43A61C776F63A /* InfoPlistDocumentTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoPlistDocumentTypesTests.swift; sourceTree = "<group>"; };
+		3B829FF68F544237FC7C1078 /* mobi.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mobi.h; sourceTree = "<group>"; };
 		3BAA1482C17A94A21E44EFEB /* BackgroundIndexingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundIndexingCoordinator.swift; sourceTree = "<group>"; };
 		3BB186FF39C9836750BE4499 /* ReaderContainerView+SearchPollAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderContainerView+SearchPollAction.swift"; sourceTree = "<group>"; };
 		3C20894DFE22D83069C6D505 /* SheetReSkinSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetReSkinSnapshotTests.swift; sourceTree = "<group>"; };
@@ -1768,6 +1795,7 @@
 		3C567EE93DC61BBB63CEAC20 /* Locator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locator.swift; sourceTree = "<group>"; };
 		3CA99312EF465709359C1EBF /* ReaderMoreMenuBilingualTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderMoreMenuBilingualTests.swift; sourceTree = "<group>"; };
 		3D16B9536A1919EBEBAA22B3 /* SettingsProfileCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsProfileCardTests.swift; sourceTree = "<group>"; };
+		3D68C1EB7A52364906CB54B8 /* util.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = util.c; sourceTree = "<group>"; };
 		3D6C41170131F22118778D83 /* FontSizeCalibration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCalibration.swift; sourceTree = "<group>"; };
 		3D70FBE6B4F5F9DDBA035D25 /* SPIKE_RESULTS.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = SPIKE_RESULTS.md; sourceTree = "<group>"; };
 		3DF47D926F78F13327F6770C /* OPDSParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSParser.swift; sourceTree = "<group>"; };
@@ -1779,11 +1807,13 @@
 		3FB3C13EB1794A1F78C93D37 /* ReadingStatsModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsModelsTests.swift; sourceTree = "<group>"; };
 		3FF06F0E93BCCA150869AE18 /* Feature35AnnotationsExportVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature35AnnotationsExportVerificationTests.swift; sourceTree = "<group>"; };
 		400D03ADE39639337E9993C5 /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
+		4041D83714C7F56092E8741F /* debug.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = debug.h; sourceTree = "<group>"; };
 		4078AAB96560B1BC1794472E /* DeleteConfirmationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteConfirmationTests.swift; sourceTree = "<group>"; };
 		40A2CD5F8AD4DEC1A14A255A /* SearchHitToLocatorResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHitToLocatorResolver.swift; sourceTree = "<group>"; };
 		40E27899DB05507AB2F13CDE /* NotesRowStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesRowStateTests.swift; sourceTree = "<group>"; };
 		410014C25D3480276D1E5F00 /* WebDAVProfileMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProfileMigratorTests.swift; sourceTree = "<group>"; };
 		410BA6F21267316487DF58FC /* PersistenceBookmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceBookmarkTests.swift; sourceTree = "<group>"; };
+		411C61E3504673FFE214FA5A /* structure.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = structure.h; sourceTree = "<group>"; };
 		4184F6CBC1069C92654BCB19 /* DebugReaderProbeAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReaderProbeAdapterTests.swift; sourceTree = "<group>"; };
 		41C3ECA5E8F6419DB347F2E4 /* BookFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFormat.swift; sourceTree = "<group>"; };
 		41D94EE13466B0286DEA2EA7 /* ReadingSessionTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingSessionTracker.swift; sourceTree = "<group>"; };
@@ -1803,6 +1833,7 @@
 		432F646AE5FB7BFD06470EB5 /* FoliateURLSchemeHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateURLSchemeHandlerTests.swift; sourceTree = "<group>"; };
 		43347208CA56C84F65B2DCF7 /* TXTTextViewBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTTextViewBridge.swift; sourceTree = "<group>"; };
 		4349ACADC38E53A4D87D5D5A /* HTMLHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLHelper.swift; sourceTree = "<group>"; };
+		435A9AA017E6DED1ABD5EDD4 /* buffer.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = buffer.c; sourceTree = "<group>"; };
 		435C00E099B7F5D7A7821FDC /* EPUBHighlightBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBHighlightBridge.swift; sourceTree = "<group>"; };
 		43677A0B2B4A42609A2800ED /* EPUBPagedProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBPagedProgress.swift; sourceTree = "<group>"; };
 		436ED12C1DAEAF6D9DB32B4A /* BookDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailsViewModel.swift; sourceTree = "<group>"; };
@@ -1818,6 +1849,7 @@
 		4459ED2850B657C535C05F16 /* DebugPositionResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugPositionResolverTests.swift; sourceTree = "<group>"; };
 		445A7C6C3D4466A57B29BDA8 /* ReaderSettingsSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsSheetTests.swift; sourceTree = "<group>"; };
 		4493553E18BBEB66EA8D32BF /* BilingualSetupSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualSetupSheet.swift; sourceTree = "<group>"; };
+		449D9045380C2ACAB1ECDA05 /* miniz.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = miniz.c; sourceTree = "<group>"; };
 		44AEA97F06DB06AEAFB526F1 /* HighlightPopoverModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPopoverModifier.swift; sourceTree = "<group>"; };
 		44B5BF67DD0616C80294ABC7 /* ReadingDashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDashboardViewModel.swift; sourceTree = "<group>"; };
 		44CDE923DD9CB934E3E42969 /* ReaderTOCTXTAlignmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTOCTXTAlignmentTests.swift; sourceTree = "<group>"; };
@@ -1902,6 +1934,7 @@
 		4F8AEC7D40405AE90840ABE4 /* HighlightRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightRenderer.swift; sourceTree = "<group>"; };
 		4FA36CFAC187DC7B25B7A920 /* ChapterStartTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterStartTypography.swift; sourceTree = "<group>"; };
 		4FBF157299A06F8948FB8689 /* FoliateBilingualPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateBilingualPipeline.swift; sourceTree = "<group>"; };
+		4FE4DC2DFC2C87C8E958A247 /* encryption.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = encryption.h; sourceTree = "<group>"; };
 		4FE8B867BCF9BCDCF23941DB /* EPUBPreExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBPreExtractorTests.swift; sourceTree = "<group>"; };
 		5009D3D555DF12B60ACC2D88 /* HighlightPopoverModifierBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPopoverModifierBody.swift; sourceTree = "<group>"; };
 		506F86FDA1498276D10E5E7B /* FoliateViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateViewCoordinator.swift; sourceTree = "<group>"; };
@@ -1981,6 +2014,7 @@
 		5ADFBB978A77BD6B9E977F36 /* SettingsSliderRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSliderRowTests.swift; sourceTree = "<group>"; };
 		5AF84D4FD4FAA3232D18AA96 /* ReplacementTransform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplacementTransform.swift; sourceTree = "<group>"; };
 		5B0357FF4CC21B381B9CA016 /* ReaderMoreMenuRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderMoreMenuRowTests.swift; sourceTree = "<group>"; };
+		5B3648D95507E187C2CC5DF6 /* compression.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = compression.h; sourceTree = "<group>"; };
 		5B58A3A5DB35DA47F032FCEB /* LegadoImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegadoImporter.swift; sourceTree = "<group>"; };
 		5B5C3B574FE1EBD73201C8C2 /* EPUBWebViewEvaluatorHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBWebViewEvaluatorHandle.swift; sourceTree = "<group>"; };
 		5B67894BA57026638D94B118 /* ReaderThemeV2+EPUBCSS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderThemeV2+EPUBCSS.swift"; sourceTree = "<group>"; };
@@ -2018,6 +2052,7 @@
 		60D19CA6B370181C8BF08270 /* VReaderAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderAppDelegate.swift; sourceTree = "<group>"; };
 		60F442A575A04CD706CC53FE /* EPUBDebugBridgeHighlightJS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBDebugBridgeHighlightJS.swift; sourceTree = "<group>"; };
 		6147C39C4171F0BFA004780E /* VReaderLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderLocator.swift; sourceTree = "<group>"; };
+		614C6D408C5EE1EC5D276754 /* opf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = opf.h; sourceTree = "<group>"; };
 		6195F10A5C760B111459790C /* PollUntil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollUntil.swift; sourceTree = "<group>"; };
 		61C7310D3FF8C5778BFCB6E1 /* TXTAttributedStringBuilderChapterStartTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTAttributedStringBuilderChapterStartTests.swift; sourceTree = "<group>"; };
 		61D2ACCFF53EDBE89326A37F /* LocatorFactoryTXTChapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorFactoryTXTChapterTests.swift; sourceTree = "<group>"; };
@@ -2048,6 +2083,7 @@
 		662756B2F0105F6DDB1E0241 /* BilingualReadingViewModel+Prefetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BilingualReadingViewModel+Prefetch.swift"; sourceTree = "<group>"; };
 		6635582524CF50059E66F973 /* ReadingDashboardViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDashboardViewTests.swift; sourceTree = "<group>"; };
 		66440341C1BA8050AFD3A65C /* EPUBChapterNavigationRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBChapterNavigationRouterTests.swift; sourceTree = "<group>"; };
+		6644E66A9BEDE9071D8D876F /* encryption.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = encryption.c; sourceTree = "<group>"; };
 		6671E9F8673155BDC726A6ED /* RealDebugBridgeContext+Settle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RealDebugBridgeContext+Settle.swift"; sourceTree = "<group>"; };
 		667AC3E733DFC3883BC89D39 /* AlertDialogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertDialogTests.swift; sourceTree = "<group>"; };
 		67368B0914CFE12052417225 /* LazyDownloadCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyDownloadCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -2084,6 +2120,7 @@
 		6DE1995445027494280CEE07 /* ReadiumEPUBReaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumEPUBReaderViewModel.swift; sourceTree = "<group>"; };
 		6DF113D7E83A1CE51F417258 /* AIReaderPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReaderPanel.swift; sourceTree = "<group>"; };
 		6E358C3A06D7CC0958A40876 /* BookSourceSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSourceSearchView.swift; sourceTree = "<group>"; };
+		6E4CC1253B1BAD112E36AB2C /* sha1.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sha1.h; sourceTree = "<group>"; };
 		6E57059EA750B150D10FC828 /* PillSwitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillSwitchTests.swift; sourceTree = "<group>"; };
 		6E5D3F39FDBF4693D33D1BCB /* MDMetadataExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDMetadataExtractor.swift; sourceTree = "<group>"; };
 		6ED83105BFA1AA160A12D158 /* BookFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFormatTests.swift; sourceTree = "<group>"; };
@@ -2133,6 +2170,7 @@
 		78BD4CC018110BC0C96E2788 /* DebugReaderRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReaderRegistryTests.swift; sourceTree = "<group>"; };
 		78F701D2D5416A758988C808 /* HTTPTTSChunkPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTTSChunkPlayer.swift; sourceTree = "<group>"; };
 		791CB502C8B59E737F15E63C /* VerificationSettingsHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationSettingsHelperTests.swift; sourceTree = "<group>"; };
+		79A043D83CF700D279FF0358 /* opf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = opf.c; sourceTree = "<group>"; };
 		79E3E09003BD79ED972F15D6 /* ChapterTranslationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterTranslationStoreTests.swift; sourceTree = "<group>"; };
 		79F003D569BCC0F29113468A /* EPUBMetadataExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBMetadataExtractorTests.swift; sourceTree = "<group>"; };
 		7A0147BC1F4C66F4EDB21608 /* ReadingDashboardSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDashboardSnapshotTests.swift; sourceTree = "<group>"; };
@@ -2141,10 +2179,12 @@
 		7A980DB0017049401DAB3E93 /* AnnotationListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationListViewModel.swift; sourceTree = "<group>"; };
 		7A9E42127F86EB76595AD46B /* BackupReadingHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupReadingHistoryTests.swift; sourceTree = "<group>"; };
 		7AAC0D3FD90694D3169DB775 /* MDReaderPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReaderPlaceholderTests.swift; sourceTree = "<group>"; };
+		7AEF9EDC3C81B6E2AFCD6590 /* write.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = write.c; sourceTree = "<group>"; };
 		7B3463E0D88B62CFEF84E4F9 /* chapter_content.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = chapter_content.html; sourceTree = "<group>"; };
 		7BA6B74EE0E50E049C9BAC5C /* WebDAVSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVSettingsView.swift; sourceTree = "<group>"; };
 		7BD36F5CC483659F962BFB3A /* TTSService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSService.swift; sourceTree = "<group>"; };
 		7C0A7E77EFE308BC9CF8A3FE /* ErrorMessageAuditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMessageAuditor.swift; sourceTree = "<group>"; };
+		7C1BE488B566578C5C914796 /* read.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = read.c; sourceTree = "<group>"; };
 		7C842F00C6B506FC831E0347 /* EPUBTextStripperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBTextStripperTests.swift; sourceTree = "<group>"; };
 		7CB1FD8F0785F095177A4AE6 /* BookSourceEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSourceEditorView.swift; sourceTree = "<group>"; };
 		7CE90E7D827B7E8A356D6DC6 /* Inter-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Inter-SemiBold.otf"; sourceTree = "<group>"; };
@@ -2157,8 +2197,10 @@
 		7D9CC8400AF6E7894D65B332 /* EPUBChapterWrapPendingTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBChapterWrapPendingTarget.swift; sourceTree = "<group>"; };
 		7DAC8E20A001D7803A16AAD1 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		7DBF9C3C1FBBCE4354F7DAAD /* DictionaryLookupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryLookupTests.swift; sourceTree = "<group>"; };
+		7DD5FCBE242265B2EB6F7E6D /* Libmobi-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Libmobi-Bridging-Header.h"; sourceTree = "<group>"; };
 		7DE6A4A50E59B50DE7574A87 /* paginator.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = paginator.js; sourceTree = "<group>"; };
 		7DEA283D3F2224EDC297B6E1 /* MDFileLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDFileLoader.swift; sourceTree = "<group>"; };
+		7E468F4DBD64650AF7E80CE6 /* debug.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = debug.c; sourceTree = "<group>"; };
 		7E86175071842E275652A4F2 /* ReaderContainerView+DebugBridgeRenderedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderContainerView+DebugBridgeRenderedText.swift"; sourceTree = "<group>"; };
 		7F1BC0259A472381A819DF2A /* mobi.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = mobi.js; sourceTree = "<group>"; };
 		7F2360F05D5C411D05806514 /* ReaderThemeV2EPUBCSSChapterStartTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeV2EPUBCSSChapterStartTests.swift; sourceTree = "<group>"; };
@@ -2182,6 +2224,7 @@
 		81816D53162945723E79FB9B /* SyncOutboundQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncOutboundQueue.swift; sourceTree = "<group>"; };
 		8188B21271D103070EE8CDE6 /* SyncConflictResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncConflictResolver.swift; sourceTree = "<group>"; };
 		818F6161D2855C49A12AF5A6 /* TOCBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOCBuilder.swift; sourceTree = "<group>"; };
+		81CF5EFF981B3902B76768D9 /* miniz.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = miniz.h; sourceTree = "<group>"; };
 		820C166494A63E2245B18252 /* ReadiumEPUBHost+Highlights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReadiumEPUBHost+Highlights.swift"; sourceTree = "<group>"; };
 		82199531AD7036AB0F37C56C /* ReaderTopChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTopChrome.swift; sourceTree = "<group>"; };
 		823A94AB15D85579FB0C8D5C /* BookSourcePipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSourcePipeline.swift; sourceTree = "<group>"; };
@@ -2212,6 +2255,7 @@
 		85C4EC2BEDD3FD73FFBF56B8 /* DebugReaderRegistryAwaitReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReaderRegistryAwaitReaderTests.swift; sourceTree = "<group>"; };
 		85EEEA47C4E7D01D716EF2A4 /* TXTContinuousChunkBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTContinuousChunkBuilderTests.swift; sourceTree = "<group>"; };
 		85F0F2460E80C3EC09624384 /* Feature27ReplacementRulesVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature27ReplacementRulesVerificationTests.swift; sourceTree = "<group>"; };
+		86219F525D53A66480857B58 /* memory.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = memory.c; sourceTree = "<group>"; };
 		864232F1C9EEF1A310AA820A /* EPUBThemeOverrideCSSV2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBThemeOverrideCSSV2Tests.swift; sourceTree = "<group>"; };
 		864A1B050775A46ADBE3304F /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
 		864BA35C7F82D6437278E5C6 /* EPUBChapterWrapPendingTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBChapterWrapPendingTargetTests.swift; sourceTree = "<group>"; };
@@ -2231,6 +2275,7 @@
 		8807117D114833F057AD99CE /* ReaderDisplayControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDisplayControls.swift; sourceTree = "<group>"; };
 		88D54435E0293B133D7C4ECE /* PersistenceActor+HighlightLookupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+HighlightLookupTests.swift"; sourceTree = "<group>"; };
 		89DE76057526BA48CAE2A83A /* UpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateChecker.swift; sourceTree = "<group>"; };
+		89E60C649B564A45FD862030 /* LibmobiSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibmobiSmokeTests.swift; sourceTree = "<group>"; };
 		8A12A0D94CF17D48152929F0 /* ReadingStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStats.swift; sourceTree = "<group>"; };
 		8A1A348FFCBCC9C7A5360C28 /* RuleEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleEngineTests.swift; sourceTree = "<group>"; };
 		8A3F655F5FD823BABBA93412 /* FoliateDebugSeekFractionObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateDebugSeekFractionObserver.swift; sourceTree = "<group>"; };
@@ -2288,6 +2333,7 @@
 		93955827511F55BEEFCA2307 /* BookSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSource.swift; sourceTree = "<group>"; };
 		939BC09F1D771D2E22301ED3 /* V1toV2MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V1toV2MigrationTests.swift; sourceTree = "<group>"; };
 		93E6312BDB7B7B5A5672E68B /* BilingualAttributedStringComposerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualAttributedStringComposerTests.swift; sourceTree = "<group>"; };
+		9438793466362160FD85E5E1 /* randombytes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = randombytes.h; sourceTree = "<group>"; };
 		9452FAFFDEBDF03FF6CCEBB1 /* MDParserProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDParserProtocol.swift; sourceTree = "<group>"; };
 		94AF8D98E6FAD355A8B3416B /* TranslateLanguageRailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateLanguageRailTests.swift; sourceTree = "<group>"; };
 		94C32FCAEDE0062125F6A51E /* DebugSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSnapshot.swift; sourceTree = "<group>"; };
@@ -2340,6 +2386,7 @@
 		9B75BA41298C5306AC9AD036 /* GenerativeCoverStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerativeCoverStyle.swift; sourceTree = "<group>"; };
 		9B8C36563D7885AD214F885A /* FoliateSearchAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateSearchAdapter.swift; sourceTree = "<group>"; };
 		9C192DC2E4B6D7B71D711849 /* BookCardViewVisualTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCardViewVisualTests.swift; sourceTree = "<group>"; };
+		9C20501C933155E5C53D85B9 /* memory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = memory.h; sourceTree = "<group>"; };
 		9C3C090346A269737F00D577 /* TXTPagedChapterAdvance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTPagedChapterAdvance.swift; sourceTree = "<group>"; };
 		9C5A2D5CFE8B719D4C8F3580 /* SchemaV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV1.swift; sourceTree = "<group>"; };
 		9C78911337C79BBAE9B2AB7C /* BookDetailsSheet+Cards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BookDetailsSheet+Cards.swift"; sourceTree = "<group>"; };
@@ -2352,6 +2399,7 @@
 		9DB1CCA367AE0B610F4526FC /* SearchIndexStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchIndexStore.swift; sourceTree = "<group>"; };
 		9DB260B5C0A147C9AE9A46DC /* BookInfoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookInfoSheet.swift; sourceTree = "<group>"; };
 		9DBD86DDBB52369C831FF078 /* ReadingStatsAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsAggregator.swift; sourceTree = "<group>"; };
+		9DF1208DFEA4E40A0D028BDD /* compression.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = compression.c; sourceTree = "<group>"; };
 		9E09E65978F174E10780F7D3 /* LibraryContinueCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryContinueCard.swift; sourceTree = "<group>"; };
 		9E4A364E7AFF2DD96244D639 /* WebDAVServerProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVServerProfile.swift; sourceTree = "<group>"; };
 		9E9734639739473622AE22A1 /* HighlightHitToleranceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightHitToleranceTests.swift; sourceTree = "<group>"; };
@@ -2363,6 +2411,7 @@
 		A069D350D0DC6B4C000E1D43 /* TXTChunkedLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChunkedLoaderTests.swift; sourceTree = "<group>"; };
 		A0753D8C40DFE06B0323EE5B /* UnifiedScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedScrollView.swift; sourceTree = "<group>"; };
 		A0797CB73F5D8FDAF0B7298E /* TestSeeder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSeeder.swift; sourceTree = "<group>"; };
+		A08C4AFA17A3D37D00D9A18B /* util.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = util.h; sourceTree = "<group>"; };
 		A0FDBE03DFF8791C7027EEAD /* BookDetailsActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailsActionsTests.swift; sourceTree = "<group>"; };
 		A15103F3E39BB0F94806914C /* fflate.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = fflate.js; sourceTree = "<group>"; };
 		A17676C4AE9DD328C39176D8 /* BackupDataCollectorRestorerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupDataCollectorRestorerTests.swift; sourceTree = "<group>"; };
@@ -2379,6 +2428,7 @@
 		A43C03327815457BD7B01409 /* TXTBridgeShared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTBridgeShared.swift; sourceTree = "<group>"; };
 		A457F48D22CD5B4952817701 /* EPUBTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBTypes.swift; sourceTree = "<group>"; };
 		A496DB7B37A1E68FA33AD5A3 /* JSONExportFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONExportFormatter.swift; sourceTree = "<group>"; };
+		A4D62CB2C235BD942DAD8E06 /* structure.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = structure.c; sourceTree = "<group>"; };
 		A4D9A3C4C1072DA23511265D /* PDFReaderPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReaderPlaceholderTests.swift; sourceTree = "<group>"; };
 		A4FC31294DE996929269182A /* ReadiumBilingualCommanderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumBilingualCommanderTests.swift; sourceTree = "<group>"; };
 		A504B80204BEC5B968087D02 /* PersistenceActorRemoteOnlyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceActorRemoteOnlyTests.swift; sourceTree = "<group>"; };
@@ -2421,6 +2471,7 @@
 		AC12F17B1F2EDD25E25B114C /* SyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncService.swift; sourceTree = "<group>"; };
 		AC38E517D1EE7098DCB96426 /* MarkdownExportFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownExportFormatter.swift; sourceTree = "<group>"; };
 		AC517B8E3581F795DEDEC934 /* PersistenceActor+Highlights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+Highlights.swift"; sourceTree = "<group>"; };
+		AC94A68265F7E85C1D82D143 /* buffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = buffer.h; sourceTree = "<group>"; };
 		AC968C1CC671160D930BF4F9 /* ReadiumReaderCoordinator+Transparency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReadiumReaderCoordinator+Transparency.swift"; sourceTree = "<group>"; };
 		ACD95B7F2CED44C4E8E33E05 /* PDFBilingualPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFBilingualPanel.swift; sourceTree = "<group>"; };
 		AD065491E8CFE99188D62E09 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
@@ -2472,6 +2523,7 @@
 		B6CC92F8C2796AB46E2B5E21 /* CloudKitClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudKitClient.swift; sourceTree = "<group>"; };
 		B6DAD680DB86CF1A65D34F3F /* LibraryRefreshServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryRefreshServiceTests.swift; sourceTree = "<group>"; };
 		B6E7989DDF416C464057AB6D /* TXTChunkedReaderConversionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChunkedReaderConversionTests.swift; sourceTree = "<group>"; };
+		B7449C22542E7A6A51777ADD /* read.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = read.h; sourceTree = "<group>"; };
 		B75EC9C3C222236A27183F13 /* FoliateHighlightJSBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightJSBridge.swift; sourceTree = "<group>"; };
 		B811BD48F552B167D438BFCF /* BookModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookModelTests.swift; sourceTree = "<group>"; };
 		B849723B3079FB8F3F4A7961 /* PDFHighlightIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFHighlightIntegrationTests.swift; sourceTree = "<group>"; };
@@ -2709,6 +2761,7 @@
 		E02C0C97FFE66E8DEC728D64 /* SyncRecordDTOs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncRecordDTOs.swift; sourceTree = "<group>"; };
 		E05A8F8B018491C86ABB86AD /* ChapterTranslationChunker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterTranslationChunker.swift; sourceTree = "<group>"; };
 		E07FB35EC9805F51CAD10444 /* ThemeBackgroundStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeBackgroundStore.swift; sourceTree = "<group>"; };
+		E09CB8C0A0B9450D82B3687E /* parse_rawml.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = parse_rawml.c; sourceTree = "<group>"; };
 		E11E9DBFB16DA26DD0659851 /* AnnotationModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationModelTests.swift; sourceTree = "<group>"; };
 		E124CB39746DB0B59D0390C3 /* LazyDownloadReattachTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyDownloadReattachTests.swift; sourceTree = "<group>"; };
 		E12EBCB8CD58F740D9042C32 /* TXTTocRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTTocRule.swift; sourceTree = "<group>"; };
@@ -2766,6 +2819,7 @@
 		E9BD495685BB360AF81EDAE3 /* TranslationChunkContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationChunkContract.swift; sourceTree = "<group>"; };
 		E9C49D62E589CDF0C9F2D094 /* EPUBContinuousChapterProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBContinuousChapterProvider.swift; sourceTree = "<group>"; };
 		E9D4D088D34AA8A5692A991B /* PageTurnAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTurnAnimator.swift; sourceTree = "<group>"; };
+		E9F3CA16BAAFA10F49A196D0 /* write.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = write.h; sourceTree = "<group>"; };
 		EA0C50C474AA2F96C39AAC94 /* PaginationCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationCache.swift; sourceTree = "<group>"; };
 		EA0CD7509429C4B75ACB98F2 /* KeychainProviderProfileExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainProviderProfileExtensionTests.swift; sourceTree = "<group>"; };
 		EA401D8FC3B4F17213528B27 /* AIAssistantViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAssistantViewModelTests.swift; sourceTree = "<group>"; };
@@ -2829,6 +2883,7 @@
 		F4104BB5FAFACC19E9FBB4D7 /* LibraryProgressRing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryProgressRing.swift; sourceTree = "<group>"; };
 		F4C18F1E19149F8DBAE36A31 /* AIResponseCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIResponseCache.swift; sourceTree = "<group>"; };
 		F518E98F02B1A2000C41AAB2 /* TXTChapterIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterIntegrationTests.swift; sourceTree = "<group>"; };
+		F5222DA16840ED81F2DBE676 /* randombytes.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = randombytes.c; sourceTree = "<group>"; };
 		F560EA65913036C78284C138 /* ErrorScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorScreenTests.swift; sourceTree = "<group>"; };
 		F59A9AD0DFA1903B19F49D85 /* PDFChapterTextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFChapterTextProvider.swift; sourceTree = "<group>"; };
 		F64BCF588EF860DD6C214737 /* BackupLibraryManifestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupLibraryManifestTests.swift; sourceTree = "<group>"; };
@@ -2837,6 +2892,8 @@
 		F6CD884E38B64F954A2AFADD /* PDFReaderContainerView+Bilingual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PDFReaderContainerView+Bilingual.swift"; sourceTree = "<group>"; };
 		F6E02E23F3C9B74668C4264F /* HighlightActionCardSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightActionCardSubviews.swift; sourceTree = "<group>"; };
 		F70B62CBA5AED4AECA05825E /* SchemaV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV4.swift; sourceTree = "<group>"; };
+		F714532B8715316EE50BDBE8 /* meta.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = meta.h; sourceTree = "<group>"; };
+		F73114784F0062C27A90420D /* meta.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = meta.c; sourceTree = "<group>"; };
 		F75548C00D82133FCD8F0DB3 /* ReadingStatsModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsModels.swift; sourceTree = "<group>"; };
 		F7672B4D5423E0D3AAE16343 /* MDReaderReplacementRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReaderReplacementRulesTests.swift; sourceTree = "<group>"; };
 		F771364B47585A44CCA66EA4 /* ReaderThemeV2EPUBCSSCalibrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeV2EPUBCSSCalibrationTests.swift; sourceTree = "<group>"; };
@@ -2848,6 +2905,7 @@
 		F85E36013A798EB205697B9A /* AISettingsViewModelMultiProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISettingsViewModelMultiProfileTests.swift; sourceTree = "<group>"; };
 		F8DB79901C559905D3015DD3 /* ChapterPrefetching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterPrefetching.swift; sourceTree = "<group>"; };
 		F8DEE3B767FC8F7457067C11 /* MutationDriftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationDriftTests.swift; sourceTree = "<group>"; };
+		F8E8AD6FB530D2091CAC2111 /* xmlwriter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = xmlwriter.h; sourceTree = "<group>"; };
 		F9102277C4126793229AEEB9 /* SearchHitToLocatorResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHitToLocatorResolverTests.swift; sourceTree = "<group>"; };
 		F971403A2807A2788FD2D99F /* BookSourceListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSourceListView.swift; sourceTree = "<group>"; };
 		F9C022878EC860D3EFF8800C /* EPUBChapterTextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBChapterTextProvider.swift; sourceTree = "<group>"; };
@@ -3010,6 +3068,49 @@
 				47C95AAF8C186ABB17B12943 /* JS */,
 			);
 			path = Foliate;
+			sourceTree = "<group>";
+		};
+		1546FD679023FFD5624DDAF3 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				435A9AA017E6DED1ABD5EDD4 /* buffer.c */,
+				AC94A68265F7E85C1D82D143 /* buffer.h */,
+				9DF1208DFEA4E40A0D028BDD /* compression.c */,
+				5B3648D95507E187C2CC5DF6 /* compression.h */,
+				2222400AEEA81DA9402E672A /* config.h */,
+				7E468F4DBD64650AF7E80CE6 /* debug.c */,
+				4041D83714C7F56092E8741F /* debug.h */,
+				6644E66A9BEDE9071D8D876F /* encryption.c */,
+				4FE4DC2DFC2C87C8E958A247 /* encryption.h */,
+				1AA31A6079F35AFE9A74C04A /* index.c */,
+				048A73AE0C45DB140C6E4F2D /* index.h */,
+				86219F525D53A66480857B58 /* memory.c */,
+				9C20501C933155E5C53D85B9 /* memory.h */,
+				F73114784F0062C27A90420D /* meta.c */,
+				F714532B8715316EE50BDBE8 /* meta.h */,
+				449D9045380C2ACAB1ECDA05 /* miniz.c */,
+				81CF5EFF981B3902B76768D9 /* miniz.h */,
+				3B829FF68F544237FC7C1078 /* mobi.h */,
+				79A043D83CF700D279FF0358 /* opf.c */,
+				614C6D408C5EE1EC5D276754 /* opf.h */,
+				E09CB8C0A0B9450D82B3687E /* parse_rawml.c */,
+				13260106C045DDB460F1126C /* parse_rawml.h */,
+				F5222DA16840ED81F2DBE676 /* randombytes.c */,
+				9438793466362160FD85E5E1 /* randombytes.h */,
+				7C1BE488B566578C5C914796 /* read.c */,
+				B7449C22542E7A6A51777ADD /* read.h */,
+				0A9AF8B9047FF5BA819DE46F /* sha1.c */,
+				6E4CC1253B1BAD112E36AB2C /* sha1.h */,
+				A4D62CB2C235BD942DAD8E06 /* structure.c */,
+				411C61E3504673FFE214FA5A /* structure.h */,
+				3D68C1EB7A52364906CB54B8 /* util.c */,
+				A08C4AFA17A3D37D00D9A18B /* util.h */,
+				7AEF9EDC3C81B6E2AFCD6590 /* write.c */,
+				E9F3CA16BAAFA10F49A196D0 /* write.h */,
+				0B192843406A9DDE4B3E7776 /* xmlwriter.c */,
+				F8E8AD6FB530D2091CAC2111 /* xmlwriter.h */,
+			);
+			path = src;
 			sourceTree = "<group>";
 		};
 		193A7CF46EE48B365E0A6079 /* Sync */ = {
@@ -3606,6 +3707,14 @@
 			path = JS;
 			sourceTree = "<group>";
 		};
+		49EAC85094EE17849D57D438 /* Libmobi */ = {
+			isa = PBXGroup;
+			children = (
+				89E60C649B564A45FD862030 /* LibmobiSmokeTests.swift */,
+			);
+			path = Libmobi;
+			sourceTree = "<group>";
+		};
 		4A2763D1CAC2BDF0F9A60D00 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
@@ -3868,6 +3977,15 @@
 			path = Fonts;
 			sourceTree = "<group>";
 		};
+		7213AFE0F52B8E99C80B921E /* Libmobi */ = {
+			isa = PBXGroup;
+			children = (
+				02568BCB9C0024CD13E6B213 /* Libmobi.swift */,
+				1546FD679023FFD5624DDAF3 /* src */,
+			);
+			path = Libmobi;
+			sourceTree = "<group>";
+		};
 		795F81FD0188297E4F3D6735 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -3910,6 +4028,7 @@
 			isa = PBXGroup;
 			children = (
 				CB182FC977C25E932E0BE1D3 /* Info.plist */,
+				7DD5FCBE242265B2EB6F7E6D /* Libmobi-Bridging-Header.h */,
 			);
 			path = SupportingFiles;
 			sourceTree = "<group>";
@@ -4657,6 +4776,7 @@
 				ED7D6CFBFC3C6AF82E21EA90 /* Export */,
 				F6B825FA31B4BE686CDE11CE /* Foliate */,
 				47187216896DA91206B58757 /* Import */,
+				49EAC85094EE17849D57D438 /* Libmobi */,
 				5F8FFECE27C7EBAE6B16B555 /* Locator */,
 				5D4C46833F42CC54A2204930 /* MD */,
 				8D9655BC6E5498F95CB02833 /* Mocks */,
@@ -4995,6 +5115,7 @@
 				D6AC8160470E6C79DAEE5D74 /* Export */,
 				125CC0F5D1D55B25A8D180D5 /* Foliate */,
 				DF51ED51F6E2411895F3300D /* Import */,
+				7213AFE0F52B8E99C80B921E /* Libmobi */,
 				5CF05FDFCFCF1A5110783282 /* Locator */,
 				E90FBCF83CA21869224CA665 /* MD */,
 				A4FCC2B159B04F516D5E542E /* OPDS */,
@@ -5772,6 +5893,7 @@
 				7B1619D0A3AF6B77D0D4C7B0 /* LazyDownloadTaskMetaTests.swift in Sources */,
 				A8A3BDDF157E89577638C20F /* LegadoImporterTests.swift in Sources */,
 				1FDAAAE256E0BFC292778111 /* LegadoRuleParserTests.swift in Sources */,
+				14CAE71643EC2BB8213DD906 /* LibmobiSmokeTests.swift in Sources */,
 				60F28F11E8F15E0FFAF4922C /* LibraryBookItemFileStateTests.swift in Sources */,
 				EB3FFD36A03AA194F33246D4 /* LibraryBookItemTests.swift in Sources */,
 				966F8A5B17A489AC0E8E1F06 /* LibraryContainerCompositionTests.swift in Sources */,
@@ -6423,6 +6545,7 @@
 				8012757D10E8CB83AD54B641 /* LegadoCompatibility.swift in Sources */,
 				D2A05D3F78803BFD1248FFC2 /* LegadoImporter.swift in Sources */,
 				5475FDB13471D68A8ACB1ADD /* LegadoRuleParser.swift in Sources */,
+				614C767C1814F710ECAD56AC /* Libmobi.swift in Sources */,
 				CFF2F7127E363B96F2B6429B /* LibraryBookItem.swift in Sources */,
 				F83C8F0B1D75175DC7B481CC /* LibraryCardTokens.swift in Sources */,
 				56F3DE1EB4A7638FDC6D2FED /* LibraryCardTranslateBadge.swift in Sources */,
@@ -6810,6 +6933,23 @@
 				066A3021DFE04C15ECFEBF55 /* XCUITestMockSpeechSynthesizer.swift in Sources */,
 				AEFC819574E845429DFC9D78 /* ZIPReader.swift in Sources */,
 				48515116AAAA6DD5DFAA4ADE /* ZIPWriter.swift in Sources */,
+				C58BFD854BB68CD7F974AE20 /* buffer.c in Sources */,
+				1BF392E0910D136950668E41 /* compression.c in Sources */,
+				63CD1BD55C4410F70D1C8549 /* debug.c in Sources */,
+				797368D84A628FD0CC75BB75 /* encryption.c in Sources */,
+				6FBF472BF60BE1164ED7EA80 /* index.c in Sources */,
+				55F288C34B0362788ECAE2C0 /* memory.c in Sources */,
+				01161AA2FED893368F345289 /* meta.c in Sources */,
+				B1E83DEDFD2024431E1123A1 /* miniz.c in Sources */,
+				FFC62D5EFD014C76A0E5369E /* opf.c in Sources */,
+				1EA3DE3ED82E75202D5B0A5B /* parse_rawml.c in Sources */,
+				C09DC2D3EE103276AF5DEDF0 /* randombytes.c in Sources */,
+				76B92705C3DDA309A262E19E /* read.c in Sources */,
+				6D54759E6F840D7506AE2C36 /* sha1.c in Sources */,
+				88742A7F3156E292969BE063 /* structure.c in Sources */,
+				8E55B405568C0A20C0869CEF /* util.c in Sources */,
+				DFED97AA770947C9808D2C8A /* write.c in Sources */,
+				AC68C2599DEA6A14C6E7BA57 /* xmlwriter.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6969,14 +7109,19 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 779;
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
+				GCC_WARN_INHIBIT_ALL_WARNINGS = YES;
+				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 3.42.16;
+				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "vreader/SupportingFiles/Libmobi-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -7119,14 +7264,19 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 779;
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
+				GCC_WARN_INHIBIT_ALL_WARNINGS = YES;
+				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 3.42.16;
+				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "vreader/SupportingFiles/Libmobi-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		00AA9871B88FE39518AC1320 /* utf16be_bom.txt in Resources */ = {isa = PBXBuildFile; fileRef = F2EFEE7A0EC5352A0BB1A994 /* utf16be_bom.txt */; };
 		010552D4E12A8F6FC2A333F5 /* ReadiumNavCommanderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03321A13C86F9E69BE338864 /* ReadiumNavCommanderTests.swift */; };
 		010EC2576D94F9B1E1AC2983 /* search.js in Resources */ = {isa = PBXBuildFile; fileRef = 87DF28B0149478FEC7B8EC4E /* search.js */; };
-		01161AA2FED893368F345289 /* meta.c in Sources */ = {isa = PBXBuildFile; fileRef = F73114784F0062C27A90420D /* meta.c */; };
 		01440A60BDBE08FC56500DA7 /* SearchHitToLocatorResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A2CD5F8AD4DEC1A14A255A /* SearchHitToLocatorResolver.swift */; };
 		01450E848C5A2110A56DDD21 /* TXTTextChunkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3BC126A794F2C82F782E7D /* TXTTextChunkerTests.swift */; };
 		018E696CD9238CE5A290D9AF /* MDIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EE79C451D86828387A1BEF /* MDIntegrationTests.swift */; };
@@ -27,6 +26,7 @@
 		0246F6958C782714D1E5FAB4 /* ReplacementTransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8045B5C97D76DA514B27B577 /* ReplacementTransformTests.swift */; };
 		0258514C78DE454EDE81F87C /* NotesDeleteConfirm.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9DE056A8CDF8A9AB97C000 /* NotesDeleteConfirm.swift */; };
 		025BD086B35FC1C9C1892F21 /* EPUBChapterBodyRewriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4613C1666E0FA587EAA979C0 /* EPUBChapterBodyRewriterTests.swift */; };
+		0273E44CF9345BDA028B6D1E /* write.c in Sources */ = {isa = PBXBuildFile; fileRef = B0B74C47070E85D25A033A74 /* write.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		02CBE47CFF27030CBBCF0B13 /* EPUBSelectionTokenCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78743D11EADF7D49C2AD970 /* EPUBSelectionTokenCache.swift */; };
 		0355A26EEC17FC8847311896 /* HighlightPopoverActionRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726B2271F9C320E40AA66D67 /* HighlightPopoverActionRouter.swift */; };
 		036A7AA1F02D9219384C777A /* NativeTextPagedIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE4AD339F8C68B973D9C88 /* NativeTextPagedIntegrationTests.swift */; };
@@ -38,6 +38,7 @@
 		046B70CD437629F0157D0263 /* HighlightPopoverViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACA11D7AB61D725EB2A1BA1 /* HighlightPopoverViewModelTests.swift */; };
 		04759BE2CD3CA39424689484 /* AIResponseCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C18F1E19149F8DBAE36A31 /* AIResponseCache.swift */; };
 		05007F5C2D7687A1173C48CB /* ReaderSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B432A1C9D875A14C4E9E633 /* ReaderSettingsStore.swift */; };
+		05387F5DA897FD61E601407F /* compression.c in Sources */ = {isa = PBXBuildFile; fileRef = C705960FA892E81AB33952F9 /* compression.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		054050637EFD8ACE415BCF2E /* ReplacementRulesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9584B44764B8D11C7CC9F6 /* ReplacementRulesView.swift */; };
 		0551D7B498604A2F477349A1 /* TXTChunkedReaderBridgeEditMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10B7F1A4BCC11533447A4829 /* TXTChunkedReaderBridgeEditMenuTests.swift */; };
 		05746231141B8C7001BEBDAD /* FoliateSelectionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF493E1A2F50B0916C76306D /* FoliateSelectionDispatcher.swift */; };
@@ -160,7 +161,6 @@
 		1B78DA4330A421FE2206B70C /* FoliateSearchAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8C36563D7885AD214F885A /* FoliateSearchAdapter.swift */; };
 		1BD4CC8621C43917629D4728 /* HighlightRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96BE19585BF1F4C8174F7219 /* HighlightRecord.swift */; };
 		1BE57FEAD56B11B8BB4F4B97 /* PillSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14FEA325D6BADCAF881358B5 /* PillSwitch.swift */; };
-		1BF392E0910D136950668E41 /* compression.c in Sources */ = {isa = PBXBuildFile; fileRef = 9DF1208DFEA4E40A0D028BDD /* compression.c */; };
 		1C047439042E40ABD9D6DFA7 /* AnnotationsSheetRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4782896641E1278B54C247 /* AnnotationsSheetRouteTests.swift */; };
 		1C44F27B696718DDCDCD8942 /* WebDAVNetworkPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B73649BCBDBE8A99B210A9 /* WebDAVNetworkPolicyTests.swift */; };
 		1C6369DA44DE9BEF6A8F7E89 /* WebDAVProfileListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31265D2F8B445FADB98DDFC /* WebDAVProfileListViewModelTests.swift */; };
@@ -178,7 +178,6 @@
 		1E114184ED4E99E9EB1FE43C /* SearchIndexStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DB1CCA367AE0B610F4526FC /* SearchIndexStore.swift */; };
 		1E335C7D712FBA26BE8AB6C1 /* EPUBContinuousChapterProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C49D62E589CDF0C9F2D094 /* EPUBContinuousChapterProvider.swift */; };
 		1E5332F73297C4DB6DF747BD /* FontSizeCalibratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1946F92E99B7DCC600147C /* FontSizeCalibratorTests.swift */; };
-		1EA3DE3ED82E75202D5B0A5B /* parse_rawml.c in Sources */ = {isa = PBXBuildFile; fileRef = E09CB8C0A0B9450D82B3687E /* parse_rawml.c */; };
 		1EBF5B02922DA284822CDE3F /* SettingsNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE37B6A3CEA41E0CD7821292 /* SettingsNotifications.swift */; };
 		1EE68B75A44789E6789BA6EB /* EPUBTextExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DADECFF5C347B6D68C1A8529 /* EPUBTextExtractorTests.swift */; };
 		1F3F0A67EB5D7AEC3B11D3C3 /* HighlightPersisting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D988A4CE41E94A8A9280CC /* HighlightPersisting.swift */; };
@@ -396,6 +395,7 @@
 		4222752F69DF72644596BAD9 /* MDTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCA33DBE911B5B1B6425277 /* MDTypesTests.swift */; };
 		426386DE8ABF03F1A1292508 /* CoverPickCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C31D7BC3688FEB94A94EC8 /* CoverPickCoordinator.swift */; };
 		429316840ADE46912C2A89E9 /* BookImporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 593A77413CD93AEE33F15156 /* BookImporting.swift */; };
+		42AD2B72A490CAB256B61882 /* util.c in Sources */ = {isa = PBXBuildFile; fileRef = DA3FE0BD5CD0A18890C97E59 /* util.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		42C12085597D305DE974B0B1 /* SearchIndexCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14418F18DF9D9A3B912AC090 /* SearchIndexCore.swift */; };
 		430AF3E819AA5E3B26746B00 /* BilingualDisplaySegmentMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = C856C9D999D604A725A3B95C /* BilingualDisplaySegmentMap.swift */; };
 		43228D2AF27BDD7DDD6BB5AB /* HTTPTTSConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E47FF2613D8D1B235852F68 /* HTTPTTSConfigTests.swift */; };
@@ -450,6 +450,7 @@
 		4C47F172233199432FC289E3 /* ImportSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F84672A6E2EDD6E037AFD8 /* ImportSource.swift */; };
 		4C5F7C805D7702035CEA5837 /* NativeTextPaginatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295669F5B358B6C7BE41952E /* NativeTextPaginatorTests.swift */; };
 		4CACC9F4BA8C17144C30C113 /* BackgroundDownloadSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A04EAFA37410DA616E33D6 /* BackgroundDownloadSession.swift */; };
+		4CBBDDA7BEECCFF853B1D90C /* memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 33EA0E7BAE9970AB1E1CE063 /* memory.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		4CC9567091E0CABFDD800F6C /* AIConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52103AEAF5528A9DD58625E /* AIConfiguration.swift */; };
 		4CCBF4F6E186A7363A995303 /* ReaderContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB42EEEFFCAD8D654D57AE7 /* ReaderContainerView.swift */; };
 		4CCE624D88A6301BB7A2E18C /* V6toV7MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6832D0CE94B6D7181A2D82B0 /* V6toV7MigrationTests.swift */; };
@@ -492,13 +493,13 @@
 		5470F5126740B26C2751E22D /* TXTReaderContainerView+Paged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95574A908E5A45E773CF0D0B /* TXTReaderContainerView+Paged.swift */; };
 		5475FDB13471D68A8ACB1ADD /* LegadoRuleParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515AB3C2D2185F41DAFD8D16 /* LegadoRuleParser.swift */; };
 		547FFE39E9DC4280100F850F /* BookDetailsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6D4D3FF162BE1661731AAA /* BookDetailsSheet.swift */; };
+		54852944B2631BA79CF41926 /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = 629CCC658A5843CA9CB3915C /* sha1.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		5496FD5A3A1618D7845C45B5 /* FoliateBottomChromeWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A487F84E183F99F1D9107F /* FoliateBottomChromeWiringTests.swift */; };
 		54AE686286BC92388C9F8B7D /* TOCSheet+Support.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DDE77F4975D2E9EA4B33D3B /* TOCSheet+Support.swift */; };
 		5565D6CFF2A7610CDA45D441 /* StatsTimeWindowBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2265BDFB809DF67F55C9BFC /* StatsTimeWindowBar.swift */; };
 		5572AED7041B6CFD3C93AB79 /* LazyDownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159BB4EBD79ECE6657D50EC1 /* LazyDownloadDelegate.swift */; };
 		5599E405840D204BE7FA8104 /* LibrarySortOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC606D4AF30DF956E04C13DF /* LibrarySortOrder.swift */; };
 		55E8CDBFFC9EC1C49EAC47EE /* DocumentFingerprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99D14A41185FFD87E278E66C /* DocumentFingerprint.swift */; };
-		55F288C34B0362788ECAE2C0 /* memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 86219F525D53A66480857B58 /* memory.c */; };
 		56075E2760DBF80032EE55CE /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13D1E2EE401D4C3053FB687A /* MockURLSession.swift */; };
 		5619DB9FC83E7182AE0EB63F /* PersistenceBookmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410BA6F21267316487DF58FC /* PersistenceBookmarkTests.swift */; };
 		563B878DD14F1699FFC52439 /* NavigationFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874E517A41CB3B9C7C5C8D3A /* NavigationFlowTests.swift */; };
@@ -543,6 +544,7 @@
 		5C4609A0AEAD65A12670FB78 /* DebugBridgeHighlightObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310813C564EF1BF86A13694E /* DebugBridgeHighlightObserverTests.swift */; };
 		5CFB9D494F377849E9341376 /* Feature36OPDSVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E868FB040D93F83C745083C /* Feature36OPDSVerificationTests.swift */; };
 		5D0737B628F92C5588E95081 /* SyncRecordDTOs.swift in Sources */ = {isa = PBXBuildFile; fileRef = E02C0C97FFE66E8DEC728D64 /* SyncRecordDTOs.swift */; };
+		5D3BF98A6D912091E9E09F9F /* randombytes.c in Sources */ = {isa = PBXBuildFile; fileRef = 929DB9C524CFA70B2ED5F899 /* randombytes.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		5D3C554CE5388769AA455D1E /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41F3E1A368720EFCB55A9582 /* SearchService.swift */; };
 		5D53F7068BB4C5DD2621CE3D /* StatsPerBookTableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE49FB1A651B998A7460A924 /* StatsPerBookTableTests.swift */; };
 		5DFCBE952D79C3AB14FE7BB6 /* Feature62AnnotationsSplitVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0802B8C85A3A602D945756B2 /* Feature62AnnotationsSplitVerificationTests.swift */; };
@@ -580,7 +582,6 @@
 		6357FCBADF316F72B24C3975 /* ProviderProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9893809AE39B5DF0233FEE42 /* ProviderProfile.swift */; };
 		637607A8DD0B3C23776A3002 /* SchemaV8.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CA82E6D9E86220E10B3728 /* SchemaV8.swift */; };
 		6385D414214525E5CF2C4C8E /* HighlightPopoverViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7747D7A10C50F43520FB5FF0 /* HighlightPopoverViewModel.swift */; };
-		63CD1BD55C4410F70D1C8549 /* debug.c in Sources */ = {isa = PBXBuildFile; fileRef = 7E468F4DBD64650AF7E80CE6 /* debug.c */; };
 		646C642DA4E4DCFF2AFEB68A /* search_no_results.html in Resources */ = {isa = PBXBuildFile; fileRef = 84BAC2CBFB7F533857E6A65B /* search_no_results.html */; };
 		64709D1B5C006D3299C8ABAF /* AutoPageTurner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5401E10DDA195966ABD13F70 /* AutoPageTurner.swift */; };
 		64BF0E0C54C919613EFEECD9 /* search_results.html in Resources */ = {isa = PBXBuildFile; fileRef = E3D9BD563DBFE23CE71083C5 /* search_results.html */; };
@@ -636,7 +637,6 @@
 		6CC40A6DE2F14BB94A53006B /* FoliateMessageParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB35F648E8E697C82E4C41DE /* FoliateMessageParserTests.swift */; };
 		6CFD5F91EEF10C009963AEB0 /* TextReaderUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E25002586402AAE67B29CE6 /* TextReaderUIState.swift */; };
 		6D073A0311A72B82FEF65852 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC105D38A4A85CBCB79A772 /* KeychainService.swift */; };
-		6D54759E6F840D7506AE2C36 /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = 0A9AF8B9047FF5BA819DE46F /* sha1.c */; };
 		6D6ADF2C31C5386957B6EF65 /* LazyDownloadEnqueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DF85A7A806124F57A8FB6E /* LazyDownloadEnqueueTests.swift */; };
 		6D9880CCA623B7887967DB45 /* DebugPresentSheetEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BCADB7187645F41A660385 /* DebugPresentSheetEffect.swift */; };
 		6DC960D68C180A1078911388 /* EPUBWebViewBridgeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1920480AF349823757484C2D /* EPUBWebViewBridgeCoordinator.swift */; };
@@ -652,7 +652,6 @@
 		6EB7C3CE4427353026BCD4E9 /* Inter-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 7CE90E7D827B7E8A356D6DC6 /* Inter-SemiBold.otf */; };
 		6F1DD222CF91070D7B3D997F /* AnnotationImportError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C56D76EC2A57744D168E86 /* AnnotationImportError.swift */; };
 		6F77E9702493FB758FBF3319 /* BilingualSetupSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4493553E18BBEB66EA8D32BF /* BilingualSetupSheet.swift */; };
-		6FBF472BF60BE1164ED7EA80 /* index.c in Sources */ = {isa = PBXBuildFile; fileRef = 1AA31A6079F35AFE9A74C04A /* index.c */; };
 		6FCF7DD822CCDC8C47899DF7 /* RealDebugBridgeContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0378B284E969CD8625A89EA1 /* RealDebugBridgeContext.swift */; };
 		6FF433287ABA2EEBDE2D5636 /* TXTViewConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48EFB2798AC0354FCC8D4A9B /* TXTViewConfig.swift */; };
 		700CFFEC7C74E0532A0271F4 /* ExportTestFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5CAE41C429B6868957C540 /* ExportTestFixtures.swift */; };
@@ -672,6 +671,7 @@
 		72F65D57D593D7D6D18D1C6C /* ReaderMoreMenuBilingualTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA99312EF465709359C1EBF /* ReaderMoreMenuBilingualTests.swift */; };
 		7301F1373CCC7E6FE8E0873B /* paginator.js in Resources */ = {isa = PBXBuildFile; fileRef = 7DE6A4A50E59B50DE7574A87 /* paginator.js */; };
 		73319DBA75C0F4352DDCD858 /* LibraryContextMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42FD55371CD8FA98699541E /* LibraryContextMenuTests.swift */; };
+		734D18CAC0BFEBC21C2C79EC /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = CF93EB81220A9280AE60189A /* buffer.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		7381A2EB6ABF08C91A1C4F8F /* PDFBilingualPanelStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171A6346645BCAF3A827BF70 /* PDFBilingualPanelStateTests.swift */; };
 		7388501251356E2DE780DC22 /* BookRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A84FE014139E7B5524445D /* BookRowView.swift */; };
 		738B74E158FE8F96E40E718D /* FoliateReaderContainerView+Highlights.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61F8C90DF1A0856DF33999E /* FoliateReaderContainerView+Highlights.swift */; };
@@ -694,7 +694,6 @@
 		762B3F65978080FE7D26BF4C /* AnnotationModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11E9DBFB16DA26DD0659851 /* AnnotationModelTests.swift */; };
 		768E594123AD4AA389E2BEAC /* AISummaryTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA307AD0EDD85730C6DE77A /* AISummaryTabViewTests.swift */; };
 		76B75FF4AC85FDA4239E43DE /* ProviderProfileMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7C16F12BA653A217A5439C /* ProviderProfileMigratorTests.swift */; };
-		76B92705C3DDA309A262E19E /* read.c in Sources */ = {isa = PBXBuildFile; fileRef = 7C1BE488B566578C5C914796 /* read.c */; };
 		770CE6C30927E26DC0DB017F /* FoliateScrolledWindowMathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AECD22002DD170A5BF984A /* FoliateScrolledWindowMathTests.swift */; };
 		7778CE2B4527836E7E8B3FD7 /* PDFHighlightTapResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E21285A9149B2F11210A9430 /* PDFHighlightTapResolverTests.swift */; };
 		7783FE9E844F919F1D722742 /* EPUBBilingualJS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904A30F4AD7E5862C2D3C955 /* EPUBBilingualJS.swift */; };
@@ -712,7 +711,6 @@
 		792FA8647985692CC1ED5694 /* ReadiumOpenSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3101BC67249AD8280F55AFA /* ReadiumOpenSmokeTests.swift */; };
 		793A39541D8253B1CA8984A5 /* ScrollProgressHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7024E7AEAC9AEAA028952C46 /* ScrollProgressHelper.swift */; };
 		794FD606545B9368CD9CF18F /* legado_source_minimal.json in Resources */ = {isa = PBXBuildFile; fileRef = DE360E19106AAA7A1FCEEEB9 /* legado_source_minimal.json */; };
-		797368D84A628FD0CC75BB75 /* encryption.c in Sources */ = {isa = PBXBuildFile; fileRef = 6644E66A9BEDE9071D8D876F /* encryption.c */; };
 		79ACFB3DD40281B2A3B9AE8B /* DebugSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94C32FCAEDE0062125F6A51E /* DebugSnapshot.swift */; };
 		7A2CAFE661BD03C0255C9DD7 /* Feature37PerBookSettingsVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB03A3F8DCE5FCBEC5458547 /* Feature37PerBookSettingsVerificationTests.swift */; };
 		7A3B9A992F12E5E187F0794E /* ReaderThemeMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A480E951C2CA72DB6A22C24 /* ReaderThemeMigrationTests.swift */; };
@@ -735,6 +733,7 @@
 		7E14E9F4DB1451B47A4DDC9E /* AIServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB9DBE73613A6499D43B18C /* AIServiceTests.swift */; };
 		7E1AD7E1C555FE37FB7EC7FA /* DebugPositionResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D9F7749E205C92E5346FAE /* DebugPositionResolver.swift */; };
 		7E4274201E53904CDE46FC16 /* ReadingSessionTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398F1BAF549E7AC80E9CE320 /* ReadingSessionTrackerTests.swift */; };
+		7E4A84CD67B43365EC2B421D /* index.c in Sources */ = {isa = PBXBuildFile; fileRef = 54DB141E4F9A1F2AE3806B10 /* index.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		7E4E6AF24C7B32B3C62953F9 /* AIProviderEditSheet+Sections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C23761CBD69F0641A15F71 /* AIProviderEditSheet+Sections.swift */; };
 		7E5B7EA85345570160FFB2BD /* ReaderThemeV2EPUBCSSCalibrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F771364B47585A44CCA66EA4 /* ReaderThemeV2EPUBCSSCalibrationTests.swift */; };
 		7E767F5BB300F8588492BD31 /* AISummaryTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F691E61DE6E713DE4FD47733 /* AISummaryTabView.swift */; };
@@ -760,6 +759,7 @@
 		81498F908FAF97F421A3C35F /* AIReaderPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF113D7E83A1CE51F417258 /* AIReaderPanel.swift */; };
 		8178696A12B2FC6B462D9C3A /* LibraryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1563E77E28434568F45736 /* LibraryViewModelTests.swift */; };
 		818D42F1D3D6548605297F83 /* ReaderFormatHosts.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF23B1A0CC0BE35DF685C5FA /* ReaderFormatHosts.swift */; };
+		81A3402C6C5D0E39680A0066 /* read.c in Sources */ = {isa = PBXBuildFile; fileRef = 4989B9674C26B3825DF3C4D4 /* read.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		81A664E468D49A74D54DA6F6 /* ReadingDashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44B5BF67DD0616C80294ABC7 /* ReadingDashboardViewModel.swift */; };
 		81A875C50C5A9B68C2E415D1 /* TXTChapterIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = F02AE770B22BFE6D2F175A1A /* TXTChapterIndex.swift */; };
 		8211FDEF87BCA2DA4EBD357A /* BookSourceHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDE356D5C7D77EC05E82520 /* BookSourceHTTPClient.swift */; };
@@ -797,8 +797,8 @@
 		88472C0C4B06190CA46E917F /* BookImporterEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163C2BBCB1C2FEFB9713C4CF /* BookImporterEnvironment.swift */; };
 		884CC3C2EDE6FC428A666910 /* SyncTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E72DDEAD6225A21E973A51 /* SyncTypes.swift */; };
 		88521B18CEC15B95AC59E36D /* TXTBridgeHighlightTapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5792668BED81E507B2C693DA /* TXTBridgeHighlightTapTests.swift */; };
-		88742A7F3156E292969BE063 /* structure.c in Sources */ = {isa = PBXBuildFile; fileRef = A4D62CB2C235BD942DAD8E06 /* structure.c */; };
 		88B73AB500D0DFD555AC9363 /* WebPageEncodingDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB19A1C01A25FDB23FA3E7DB /* WebPageEncodingDetectorTests.swift */; };
+		88FC2400338EE530ECAE8E9A /* structure.c in Sources */ = {isa = PBXBuildFile; fileRef = A7EBC969B5DD8804D6AFF3DD /* structure.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		891E1E70B176150B071E464F /* AIContextExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20237121BB4ACF22C0818BA4 /* AIContextExtractorTests.swift */; };
 		892A9F3136477F52D3AECE11 /* text-walker.js in Resources */ = {isa = PBXBuildFile; fileRef = 43CD38D8708AAE752995001B /* text-walker.js */; };
 		89B733D394A024A550FDC0F1 /* TXTReaderContainerView+DebugBridgeHighlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CAE98744C71CECB79F67EB /* TXTReaderContainerView+DebugBridgeHighlight.swift */; };
@@ -831,7 +831,6 @@
 		8E153D7C3B713EDDBF484A24 /* AIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334D6D06A294323E149970E4 /* AIService.swift */; };
 		8E272AD8C74C7EB03B9D3E7D /* ReaderDisplayControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8807117D114833F057AD99CE /* ReaderDisplayControls.swift */; };
 		8E2E64928835A3533FDE10FA /* PDFAnnotationBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A064D62C86857484454D0BE3 /* PDFAnnotationBridge.swift */; };
-		8E55B405568C0A20C0869CEF /* util.c in Sources */ = {isa = PBXBuildFile; fileRef = 3D68C1EB7A52364906CB54B8 /* util.c */; };
 		8E7482D250AFDBEF1803780A /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB31146A831DACE67C50F08 /* AppConfiguration.swift */; };
 		8E936BF32CF0850398C9D742 /* AIChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539FEE4A23AFA226048A12A4 /* AIChatView.swift */; };
 		8E93B4DCB415EC16CEE9F01E /* WebPageEncodingDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA008CC17CE7798B70F4E2D /* WebPageEncodingDetector.swift */; };
@@ -847,6 +846,7 @@
 		9092232FBB529C5C6D9A53DB /* AIResponseCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5CB5C659CC573EF448F0992 /* AIResponseCacheTests.swift */; };
 		9094D1AB67E383434EF3F3EC /* PDFViewBridgeThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58705D22AE9F6101164D5FA3 /* PDFViewBridgeThemeTests.swift */; };
 		909ADB564394665014A94D74 /* RegexRuleEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66BBCB51EBC23CCC7632C74 /* RegexRuleEvaluator.swift */; };
+		90BEC64CA9EC46D50BFD938F /* miniz.c in Sources */ = {isa = PBXBuildFile; fileRef = DBCDEF7FE521C85F02FCB750 /* miniz.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		90D2C41C30E622E119877967 /* BackupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5350DA755A0BB669AE8D3FBD /* BackupViewModelTests.swift */; };
 		915C38C106026EB4386107C5 /* FoliateChapterTextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF17767136D4087D5F38F901 /* FoliateChapterTextProvider.swift */; };
 		916CF15735E1F170E2CE4695 /* HTTPTTSConfigStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CD66C1E52331AC245386C9 /* HTTPTTSConfigStore.swift */; };
@@ -990,7 +990,6 @@
 		AAEA9983AA0492366955FB9B /* PositionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BCC142F6FF2ABE9B5BA64B /* PositionPersistenceTests.swift */; };
 		ABB95D6805BADA4CC6DBE564 /* RealDebugBridgeContext+SeedSessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65CF531180D798D01E12893 /* RealDebugBridgeContext+SeedSessions.swift */; };
 		ABE20173610A76DC711FBA55 /* ReaderThemeV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB26FE0A7766F5E461A6BC7 /* ReaderThemeV2.swift */; };
-		AC68C2599DEA6A14C6E7BA57 /* xmlwriter.c in Sources */ = {isa = PBXBuildFile; fileRef = 0B192843406A9DDE4B3E7776 /* xmlwriter.c */; };
 		ACE4A8A746F082AEC08BB273 /* CustomCoverStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5955766DF21883C0C57B71E4 /* CustomCoverStoreTests.swift */; };
 		AD1910F64D226400933FDBA2 /* PDFHighlightRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8719A34DB441AF9DC6379DC9 /* PDFHighlightRenderer.swift */; };
 		AD27484127EA24D230616F48 /* TestConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B2824739E67F567813198E /* TestConstants.swift */; };
@@ -1020,7 +1019,6 @@
 		B1B9E936492D58B0768C0785 /* TXTTextExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8707DA3A6FC024EAC4F63E76 /* TXTTextExtractorTests.swift */; };
 		B1BF1136437114637B9F8800 /* BookDetailsSheet+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F79D3BEB86E859FEF2D09E2A /* BookDetailsSheet+Actions.swift */; };
 		B1DFA851C827F5BB877DD2B8 /* ReadingSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41196788F697BB4ACD4B06 /* ReadingSessionTests.swift */; };
-		B1E83DEDFD2024431E1123A1 /* miniz.c in Sources */ = {isa = PBXBuildFile; fileRef = 449D9045380C2ACAB1ECDA05 /* miniz.c */; };
 		B1EF7FB8170BAD9BFA1B5636 /* EPUBTextExtractorBilingualTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3595767B5C24F2D437C634BF /* EPUBTextExtractorBilingualTests.swift */; };
 		B227E3B75BE0BFAE923628BD /* HighlightsSheet+Delete.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A21498B4BB8CCB388677F3 /* HighlightsSheet+Delete.swift */; };
 		B272D2C56AF8559115BBD8E3 /* AIContextExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42CFB0E94DE1D37E0FD2741B /* AIContextExtractor.swift */; };
@@ -1103,7 +1101,6 @@
 		C02BE297CD13689403CC7FE3 /* FoliateSpikeView+HighlightTap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086557F549C56946CFD6194E /* FoliateSpikeView+HighlightTap.swift */; };
 		C03DA14D8DBA94B0CE4135D5 /* SearchViewActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08856C035686A119B4371C25 /* SearchViewActions.swift */; };
 		C08E9C36FF3ED5C05E74F52B /* WI11TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F2D542588B3156C4A282264 /* WI11TestHelpers.swift */; };
-		C09DC2D3EE103276AF5DEDF0 /* randombytes.c in Sources */ = {isa = PBXBuildFile; fileRef = F5222DA16840ED81F2DBE676 /* randombytes.c */; };
 		C0CFC8A31D8F8F2AE475DEFB /* TXTChapterTextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E601CAC151908F402E8F30 /* TXTChapterTextProvider.swift */; };
 		C0D9308246DCE3C239D86323 /* Inter-LICENSE.txt in Resources */ = {isa = PBXBuildFile; fileRef = 2E5E264F97F1E53F985C34BB /* Inter-LICENSE.txt */; };
 		C11851768B01D69A554324D0 /* ReadiumBilingualEvalAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E972CB07620BB3D30FCD92C /* ReadiumBilingualEvalAdapter.swift */; };
@@ -1120,6 +1117,7 @@
 		C3129F763BDCF3AB47BC7098 /* BackupDataCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAAF285B1D1B4F09E3AAD56 /* BackupDataCollector.swift */; };
 		C320E44AF92161F0A556FDA7 /* EPUBReaderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAD9A773D4AA9098981720D /* EPUBReaderViewModelTests.swift */; };
 		C32AAC75E3E671C0FB74F84F /* ReaderSettingsStoreCalibrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12FBBBC16EB3E7F31AD7A126 /* ReaderSettingsStoreCalibrationTests.swift */; };
+		C33D6398694BEB59B3827AE9 /* meta.c in Sources */ = {isa = PBXBuildFile; fileRef = 201AFC5B16E679291704CAAF /* meta.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		C35B2A71395E812536EDFEBD /* AnnotationImporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BCFD179C107F7E997AEB88 /* AnnotationImporterTests.swift */; };
 		C36236EF98C50E9D4C074A01 /* BookDetailsSheet+Cards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C78911337C79BBAE9B2AB7C /* BookDetailsSheet+Cards.swift */; };
 		C36B9E88E11A37371BDDF225 /* FoliateNavSeek.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD7B08B41BC2F95D59ACC3B /* FoliateNavSeek.swift */; };
@@ -1136,7 +1134,6 @@
 		C535579CBC09F0C9E79EBB6F /* TXTChapterOffsetIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FBA8CFEF94EDBE0398AC4A /* TXTChapterOffsetIndexTests.swift */; };
 		C545A7D59A2D63CC5B1DF45B /* OPDSParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF47D926F78F13327F6770C /* OPDSParser.swift */; };
 		C57845DF5A192CA91CE07FED /* HighlightActionCardViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB42619D63C6DB1728CE74D0 /* HighlightActionCardViewTests.swift */; };
-		C58BFD854BB68CD7F974AE20 /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = 435A9AA017E6DED1ABD5EDD4 /* buffer.c */; };
 		C59B87F85C20B1B2D9DDC387 /* SyncStatusMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F693921BA233745D77EC0037 /* SyncStatusMonitor.swift */; };
 		C5E2EFAA979EF5CBE624F14C /* SettingsRowPalette+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E998CB9F64AEAFC0D2A42C46 /* SettingsRowPalette+SwiftUI.swift */; };
 		C5EEEAABF1F852CDABDA43F1 /* WebDAVClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4946129FECC6C9BA7A7F16A1 /* WebDAVClient.swift */; };
@@ -1190,6 +1187,7 @@
 		CD8C26CB53B0BE57CE214F00 /* TXTBridgeOffsetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50B0954852C3621D008EE07 /* TXTBridgeOffsetTests.swift */; };
 		CD974EC7A40101D141EEA38F /* ReadiumEPUBReaderViewModel+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB81B68085FED4408A96E51 /* ReadiumEPUBReaderViewModel+Mapping.swift */; };
 		CD9751D76A3A9DBF872CA5D7 /* PersistenceActor+Library.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46A786B20AA87E763D00F45 /* PersistenceActor+Library.swift */; };
+		CDA22F80AC0636ED20C0EEEF /* xmlwriter.c in Sources */ = {isa = PBXBuildFile; fileRef = 469230212394815593F6047E /* xmlwriter.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		CDE29CE8275DB7E13C585E74 /* SchemaV6.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9899D5096108025F3AA19C /* SchemaV6.swift */; };
 		CE3CD75789B4E025F0F87CF5 /* BackupBlobStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 837009678FE3EE7B38B7CD8B /* BackupBlobStore.swift */; };
 		CE3D74414B1983EB35589EFD /* TypographySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19522F65C0947EFDCF9E4D2B /* TypographySettings.swift */; };
@@ -1222,8 +1220,10 @@
 		D32E57C07E8D41055084129C /* AnnotationNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF63E3EE60CC06C5650C3AD /* AnnotationNote.swift */; };
 		D352E53FDD1D6FEF94B393ED /* LazyDownloadFinalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F117A908F9B8098182FF9DB /* LazyDownloadFinalizerTests.swift */; };
 		D35863F85B17FE883F4EABBF /* ChapterTranslationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551DA6A3D645B1D9D72EE159 /* ChapterTranslationService.swift */; };
+		D36596FE4AD6EB66E818A92D /* opf.c in Sources */ = {isa = PBXBuildFile; fileRef = 445C53BC365999C7D62A3FD0 /* opf.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		D36EEE178AE4BC41B7B4C650 /* FileAvailabilityBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4B7084FA4C129303F52CB8 /* FileAvailabilityBadge.swift */; };
 		D371F8D98EA9603C6BF3E6ED /* EPUBHighlightTapBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8BD899A79BEB3964941631 /* EPUBHighlightTapBridgeTests.swift */; };
+		D3A4F0401FDBDB1AC17DBD51 /* debug.c in Sources */ = {isa = PBXBuildFile; fileRef = E282EBE7B2C78235790C892B /* debug.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		D3A9394A17D78A98DDF4E618 /* EPUBPagedAxis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8401AD7C7023A69BE9B68215 /* EPUBPagedAxis.swift */; };
 		D3AA14442F5D8686DD9BAA18 /* HTTPSpeechSynthesizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060D40EBDC75C3812596FB84 /* HTTPSpeechSynthesizer.swift */; };
 		D41473E2CF7AB980E43C6C54 /* BookFormatAZW3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627E42F1B1E8A59081CC6628 /* BookFormatAZW3Tests.swift */; };
@@ -1289,7 +1289,6 @@
 		DF36D73AC9B53845BF561CBC /* BookImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5160D7D68BF1AF6654AD08B6 /* BookImporter.swift */; };
 		DF4946C8219D6823B1BC3E64 /* WebDAVProfileListViewModelEditorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4630258E354B2D34ADB23182 /* WebDAVProfileListViewModelEditorTests.swift */; };
 		DF587005A7C4257AD28C42A0 /* TTSServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A2FE9743AF484093A21969 /* TTSServiceTests.swift */; };
-		DFED97AA770947C9808D2C8A /* write.c in Sources */ = {isa = PBXBuildFile; fileRef = 7AEF9EDC3C81B6E2AFCD6590 /* write.c */; };
 		E03FE4F3997CC67281E84F1E /* ReadingSessionTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D94EE13466B0286DEA2EA7 /* ReadingSessionTracker.swift */; };
 		E057330B701161FF1AD06DB4 /* MockAnnotationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E10DBA312E3C1934B36E63 /* MockAnnotationStore.swift */; };
 		E05A4A7DA74E241520EB2F0E /* TXTBridgeShared.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43C03327815457BD7B01409 /* TXTBridgeShared.swift */; };
@@ -1377,6 +1376,7 @@
 		F10FCB9E3EC6862A640BD406 /* VReaderApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605C9BAEA41B7C63D7E343B1 /* VReaderApp.swift */; };
 		F14370F35DEFDB725452B5CA /* SearchWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C47B0077BE4937C424FFBD9 /* SearchWiringTests.swift */; };
 		F14A4E744781186C72D46349 /* CustomCoverStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5CB381B25E50D44505CAAB3 /* CustomCoverStore.swift */; };
+		F1F063D59EA5927565EA07A9 /* encryption.c in Sources */ = {isa = PBXBuildFile; fileRef = 70147197363D24AF5E1FF6DB /* encryption.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		F227494184D4B41D6E183C4C /* DurableTombstoneStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E4EDBC478C22E7EB6BCE618 /* DurableTombstoneStoreTests.swift */; };
 		F27AD3A7527418A2667BE8B1 /* ChangeTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8D5CB4F3E93E8A15D3EDEA /* ChangeTokenStore.swift */; };
 		F2BD86F42ADB5A9CAF16B57A /* ReaderAICoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14088AEC6B083B2C049AB25C /* ReaderAICoordinator.swift */; };
@@ -1386,6 +1386,7 @@
 		F333DF8A66B96E51CC5CF97B /* AlertDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 667AC3E733DFC3883BC89D39 /* AlertDialogTests.swift */; };
 		F3958B26AAD50F2152E03AEB /* TTSControlBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F63868C11B04D324F09751 /* TTSControlBar.swift */; };
 		F3AA4FF7E6B3938E23EAF863 /* FoliateTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9776A011745AF967BBAB2A4C /* FoliateTypes.swift */; };
+		F3B4F71A5DF36249F3A9127E /* parse_rawml.c in Sources */ = {isa = PBXBuildFile; fileRef = 1780C35DB73F4E46831B1BE1 /* parse_rawml.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		F3C36A4536E9CDB717877BFE /* TranslationUnitID.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBCE9334037F29F612553D7 /* TranslationUnitID.swift */; };
 		F3D61B52408E7E4CF29C7C3F /* ReadiumSelectionHighlightBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBF5C1D817A97C3E5AACBFFC /* ReadiumSelectionHighlightBuilder.swift */; };
 		F3E08AC82699CE045DD5B98A /* HighlightPopoverContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D93AA422199A410F2161589 /* HighlightPopoverContentTests.swift */; };
@@ -1452,7 +1453,6 @@
 		FFA194178E9956EF14C4B8DD /* overlayer.js in Resources */ = {isa = PBXBuildFile; fileRef = 1ABFAC14455C6F7DE43C1ABC /* overlayer.js */; };
 		FFA99A696DC411A0D8A0C969 /* ChapterReTranslateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFE15DA4C0FC8B57E3B4728B /* ChapterReTranslateViewModel.swift */; };
 		FFC1BF2B3E0963AAD120E93E /* AnthropicProvider+Streaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = C682F2AF644C10CEC95208AE /* AnthropicProvider+Streaming.swift */; };
-		FFC62D5EFD014C76A0E5369E /* opf.c in Sources */ = {isa = PBXBuildFile; fileRef = 79A043D83CF700D279FF0358 /* opf.c */; };
 		FFCACE71EA64842074302A98 /* DebugBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1348B555C6A2C90B03ED65 /* DebugBridge.swift */; };
 		FFF583F410E0987A762830D5 /* InfoPlistDocumentTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6E69931BB43A61C776F63A /* InfoPlistDocumentTypesTests.swift */; };
 /* End PBXBuildFile section */
@@ -1504,7 +1504,6 @@
 		03E01318DE23F63217033B89 /* ProviderProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderProfileTests.swift; sourceTree = "<group>"; };
 		03FA3AC72012ED6686293475 /* ReadingStatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsTests.swift; sourceTree = "<group>"; };
 		0459CAA7394555E5A8E17146 /* ReaderUnsupportedFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderUnsupportedFormatTests.swift; sourceTree = "<group>"; };
-		048A73AE0C45DB140C6E4F2D /* index.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = index.h; sourceTree = "<group>"; };
 		04CBEAF6FEDB714FCE897550 /* BookCoverArtView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCoverArtView.swift; sourceTree = "<group>"; };
 		04ED79BFAD4BEF6B8A30F982 /* BookFileMaterializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFileMaterializerTests.swift; sourceTree = "<group>"; };
 		050AAFD290B8995258D78AC2 /* FormatCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatCapabilities.swift; sourceTree = "<group>"; };
@@ -1538,9 +1537,7 @@
 		0A1F641F61AC5B5DDEB0FD24 /* FoliateBilingualContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateBilingualContainerView.swift; sourceTree = "<group>"; };
 		0A2A16647F198641F11AC9C1 /* WCAGContrastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCAGContrastTests.swift; sourceTree = "<group>"; };
 		0A53B5CE5A37514E7E7D4BEC /* TestSeederMDMultiPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSeederMDMultiPageTests.swift; sourceTree = "<group>"; };
-		0A9AF8B9047FF5BA819DE46F /* sha1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sha1.c; sourceTree = "<group>"; };
 		0ACE55DA655F52A0757536E1 /* SyncPipelineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncPipelineTests.swift; sourceTree = "<group>"; };
-		0B192843406A9DDE4B3E7776 /* xmlwriter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = xmlwriter.c; sourceTree = "<group>"; };
 		0B244CEE76D4FFD2FE2CFE99 /* MDChapterStartTypographyIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDChapterStartTypographyIntegrationTests.swift; sourceTree = "<group>"; };
 		0B636D7823EE57464A4CE54D /* foliate-reader.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "foliate-reader.html"; sourceTree = "<group>"; };
 		0B9584B44764B8D11C7CC9F6 /* ReplacementRulesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplacementRulesView.swift; sourceTree = "<group>"; };
@@ -1586,7 +1583,6 @@
 		12841E371391B5AD20122A37 /* ReaderMorePopoverParts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderMorePopoverParts.swift; sourceTree = "<group>"; };
 		12A19B27CA094A4BAA679504 /* TXTBridgeHighlightNonceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTBridgeHighlightNonceTests.swift; sourceTree = "<group>"; };
 		12FBBBC16EB3E7F31AD7A126 /* ReaderSettingsStoreCalibrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsStoreCalibrationTests.swift; sourceTree = "<group>"; };
-		13260106C045DDB460F1126C /* parse_rawml.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = parse_rawml.h; sourceTree = "<group>"; };
 		1332F42A0C57EA1D1F37D9C0 /* Feature63SearchPanelVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature63SearchPanelVerificationTests.swift; sourceTree = "<group>"; };
 		13404BD286B135797ECF391A /* AccentColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccentColor.swift; sourceTree = "<group>"; };
 		1351525282D8D0C13B726F85 /* DebugReaderRegistry+WebViewWait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DebugReaderRegistry+WebViewWait.swift"; sourceTree = "<group>"; };
@@ -1612,6 +1608,7 @@
 		16E293CFD61A19BB48B38963 /* HighlightableTextViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightableTextViewTests.swift; sourceTree = "<group>"; };
 		1700C3F11D9ECDDBC750B939 /* HighlightCoordinatorMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightCoordinatorMutationTests.swift; sourceTree = "<group>"; };
 		171A6346645BCAF3A827BF70 /* PDFBilingualPanelStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFBilingualPanelStateTests.swift; sourceTree = "<group>"; };
+		1780C35DB73F4E46831B1BE1 /* parse_rawml.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = parse_rawml.c; sourceTree = "<group>"; };
 		1790A0CEB902B16952776EE4 /* HighlightPaintColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPaintColorTests.swift; sourceTree = "<group>"; };
 		17E7FD8CD67F19A2213DB6F5 /* PDFViewBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFViewBridge.swift; sourceTree = "<group>"; };
 		181E14C009F03D7B2EE1F117 /* StatusBarTintingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarTintingTests.swift; sourceTree = "<group>"; };
@@ -1634,7 +1631,6 @@
 		19EA79EB5577BF31A4096B39 /* NoOpSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoOpSessionStore.swift; sourceTree = "<group>"; };
 		1A49E33ACBED018932A38F0C /* AddNoteSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddNoteSheet.swift; sourceTree = "<group>"; };
 		1A7668891CD8BA0B6DED7A25 /* LibraryCardTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryCardTokens.swift; sourceTree = "<group>"; };
-		1AA31A6079F35AFE9A74C04A /* index.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = index.c; sourceTree = "<group>"; };
 		1ABFAC14455C6F7DE43C1ABC /* overlayer.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = overlayer.js; sourceTree = "<group>"; };
 		1B311C3A88BD6DC42005FE1B /* ExportedAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportedAnnotation.swift; sourceTree = "<group>"; };
 		1BA8C0E6A9B8EF3E48771286 /* PersistenceActor+ReadingHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+ReadingHistory.swift"; sourceTree = "<group>"; };
@@ -1656,6 +1652,7 @@
 		1F445E3A9D4CEEC79F674239 /* EPUBReaderHostLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBReaderHostLifecycleTests.swift; sourceTree = "<group>"; };
 		1F9542255A6791C9BCB034DB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1FD65C0547DF264510657CA2 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		201AFC5B16E679291704CAAF /* meta.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = meta.c; sourceTree = "<group>"; };
 		20237121BB4ACF22C0818BA4 /* AIContextExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIContextExtractorTests.swift; sourceTree = "<group>"; };
 		2058A0653A7728740207C3C7 /* BilingualTXTBridgeDelegateAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualTXTBridgeDelegateAdapter.swift; sourceTree = "<group>"; };
 		206F4BCC7294731E8A3A82DB /* AIChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatViewModel.swift; sourceTree = "<group>"; };
@@ -1671,7 +1668,6 @@
 		21BC5F159064D57CFAE2A676 /* MetadataExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataExtractorTests.swift; sourceTree = "<group>"; };
 		21CF1C76C54971B97341E5E9 /* FoliateHighlightRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightRenderer.swift; sourceTree = "<group>"; };
 		22012CDD369E616CC9FD8075 /* AnnotationsEmptyStateArtTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationsEmptyStateArtTests.swift; sourceTree = "<group>"; };
-		2222400AEEA81DA9402E672A /* config.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
 		222624560E31B939E32955D8 /* FoliateHostTapCoordinateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHostTapCoordinateTests.swift; sourceTree = "<group>"; };
 		22789AF01A93F31CDFDFB3F2 /* TranslationUnitIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationUnitIDTests.swift; sourceTree = "<group>"; };
 		228F27716382F3B61E0E15C8 /* CollectionSidebarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSidebarTests.swift; sourceTree = "<group>"; };
@@ -1754,6 +1750,7 @@
 		3354A74B809D0D3DB13A41F7 /* ReaderSettingsTypographyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsTypographyTests.swift; sourceTree = "<group>"; };
 		336495F8165F79A364CE9B09 /* AccessibilityFormattersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityFormattersTests.swift; sourceTree = "<group>"; };
 		33CA445AA96E5EEBA05B7C36 /* OPDSModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSModels.swift; sourceTree = "<group>"; };
+		33EA0E7BAE9970AB1E1CE063 /* memory.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = memory.c; sourceTree = "<group>"; };
 		35597ECF4679E74A0019B17E /* Feature26TextToSpeechVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature26TextToSpeechVerificationTests.swift; sourceTree = "<group>"; };
 		3595767B5C24F2D437C634BF /* EPUBTextExtractorBilingualTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBTextExtractorBilingualTests.swift; sourceTree = "<group>"; };
 		35A84A99AB99BEE06A942983 /* CoverLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoverLifecycleTests.swift; sourceTree = "<group>"; };
@@ -1786,7 +1783,6 @@
 		3AEB955B6E5713C9AB4D701E /* Feature34CollectionsVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature34CollectionsVerificationTests.swift; sourceTree = "<group>"; };
 		3B1563E77E28434568F45736 /* LibraryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModelTests.swift; sourceTree = "<group>"; };
 		3B6E69931BB43A61C776F63A /* InfoPlistDocumentTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoPlistDocumentTypesTests.swift; sourceTree = "<group>"; };
-		3B829FF68F544237FC7C1078 /* mobi.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mobi.h; sourceTree = "<group>"; };
 		3BAA1482C17A94A21E44EFEB /* BackgroundIndexingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundIndexingCoordinator.swift; sourceTree = "<group>"; };
 		3BB186FF39C9836750BE4499 /* ReaderContainerView+SearchPollAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderContainerView+SearchPollAction.swift"; sourceTree = "<group>"; };
 		3C20894DFE22D83069C6D505 /* SheetReSkinSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetReSkinSnapshotTests.swift; sourceTree = "<group>"; };
@@ -1795,7 +1791,6 @@
 		3C567EE93DC61BBB63CEAC20 /* Locator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locator.swift; sourceTree = "<group>"; };
 		3CA99312EF465709359C1EBF /* ReaderMoreMenuBilingualTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderMoreMenuBilingualTests.swift; sourceTree = "<group>"; };
 		3D16B9536A1919EBEBAA22B3 /* SettingsProfileCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsProfileCardTests.swift; sourceTree = "<group>"; };
-		3D68C1EB7A52364906CB54B8 /* util.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = util.c; sourceTree = "<group>"; };
 		3D6C41170131F22118778D83 /* FontSizeCalibration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCalibration.swift; sourceTree = "<group>"; };
 		3D70FBE6B4F5F9DDBA035D25 /* SPIKE_RESULTS.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = SPIKE_RESULTS.md; sourceTree = "<group>"; };
 		3DF47D926F78F13327F6770C /* OPDSParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSParser.swift; sourceTree = "<group>"; };
@@ -1807,13 +1802,11 @@
 		3FB3C13EB1794A1F78C93D37 /* ReadingStatsModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsModelsTests.swift; sourceTree = "<group>"; };
 		3FF06F0E93BCCA150869AE18 /* Feature35AnnotationsExportVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature35AnnotationsExportVerificationTests.swift; sourceTree = "<group>"; };
 		400D03ADE39639337E9993C5 /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
-		4041D83714C7F56092E8741F /* debug.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = debug.h; sourceTree = "<group>"; };
 		4078AAB96560B1BC1794472E /* DeleteConfirmationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteConfirmationTests.swift; sourceTree = "<group>"; };
 		40A2CD5F8AD4DEC1A14A255A /* SearchHitToLocatorResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHitToLocatorResolver.swift; sourceTree = "<group>"; };
 		40E27899DB05507AB2F13CDE /* NotesRowStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesRowStateTests.swift; sourceTree = "<group>"; };
 		410014C25D3480276D1E5F00 /* WebDAVProfileMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProfileMigratorTests.swift; sourceTree = "<group>"; };
 		410BA6F21267316487DF58FC /* PersistenceBookmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceBookmarkTests.swift; sourceTree = "<group>"; };
-		411C61E3504673FFE214FA5A /* structure.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = structure.h; sourceTree = "<group>"; };
 		4184F6CBC1069C92654BCB19 /* DebugReaderProbeAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReaderProbeAdapterTests.swift; sourceTree = "<group>"; };
 		41C3ECA5E8F6419DB347F2E4 /* BookFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFormat.swift; sourceTree = "<group>"; };
 		41D94EE13466B0286DEA2EA7 /* ReadingSessionTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingSessionTracker.swift; sourceTree = "<group>"; };
@@ -1833,7 +1826,6 @@
 		432F646AE5FB7BFD06470EB5 /* FoliateURLSchemeHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateURLSchemeHandlerTests.swift; sourceTree = "<group>"; };
 		43347208CA56C84F65B2DCF7 /* TXTTextViewBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTTextViewBridge.swift; sourceTree = "<group>"; };
 		4349ACADC38E53A4D87D5D5A /* HTMLHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLHelper.swift; sourceTree = "<group>"; };
-		435A9AA017E6DED1ABD5EDD4 /* buffer.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = buffer.c; sourceTree = "<group>"; };
 		435C00E099B7F5D7A7821FDC /* EPUBHighlightBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBHighlightBridge.swift; sourceTree = "<group>"; };
 		43677A0B2B4A42609A2800ED /* EPUBPagedProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBPagedProgress.swift; sourceTree = "<group>"; };
 		436ED12C1DAEAF6D9DB32B4A /* BookDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailsViewModel.swift; sourceTree = "<group>"; };
@@ -1848,8 +1840,9 @@
 		4456336AA865CC6E79488325 /* ModelContainerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelContainerFactory.swift; sourceTree = "<group>"; };
 		4459ED2850B657C535C05F16 /* DebugPositionResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugPositionResolverTests.swift; sourceTree = "<group>"; };
 		445A7C6C3D4466A57B29BDA8 /* ReaderSettingsSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsSheetTests.swift; sourceTree = "<group>"; };
+		445C53BC365999C7D62A3FD0 /* opf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = opf.c; sourceTree = "<group>"; };
+		4468102E4502A0FF889C3BEF /* mobi.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = mobi.h; sourceTree = "<group>"; };
 		4493553E18BBEB66EA8D32BF /* BilingualSetupSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualSetupSheet.swift; sourceTree = "<group>"; };
-		449D9045380C2ACAB1ECDA05 /* miniz.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = miniz.c; sourceTree = "<group>"; };
 		44AEA97F06DB06AEAFB526F1 /* HighlightPopoverModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPopoverModifier.swift; sourceTree = "<group>"; };
 		44B5BF67DD0616C80294ABC7 /* ReadingDashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDashboardViewModel.swift; sourceTree = "<group>"; };
 		44CDE923DD9CB934E3E42969 /* ReaderTOCTXTAlignmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTOCTXTAlignmentTests.swift; sourceTree = "<group>"; };
@@ -1870,6 +1863,7 @@
 		4622E66CB12A25DFDE0EEBD1 /* BilingualTextRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualTextRenderer.swift; sourceTree = "<group>"; };
 		46230855AD50583047E521C5 /* TXTChapterOverlayViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterOverlayViews.swift; sourceTree = "<group>"; };
 		4630258E354B2D34ADB23182 /* WebDAVProfileListViewModelEditorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProfileListViewModelEditorTests.swift; sourceTree = "<group>"; };
+		469230212394815593F6047E /* xmlwriter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = xmlwriter.c; sourceTree = "<group>"; };
 		469B267E0D3DB05D1D8F530A /* FoliateHighlightJSBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightJSBridgeTests.swift; sourceTree = "<group>"; };
 		46BCC142F6FF2ABE9B5BA64B /* PositionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionPersistenceTests.swift; sourceTree = "<group>"; };
 		46C22F30DF9F05C20CF8DDBC /* AITypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AITypes.swift; sourceTree = "<group>"; };
@@ -1889,6 +1883,7 @@
 		495092976A763ACB8B0DF741 /* ReadiumNavigatorRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumNavigatorRepresentable.swift; sourceTree = "<group>"; };
 		49624FC3C8E1AC31E011351C /* TOCBuilderTXTTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOCBuilderTXTTests.swift; sourceTree = "<group>"; };
 		4962BEF634F94652553FC6BD /* BookImporterAZW3Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookImporterAZW3Tests.swift; sourceTree = "<group>"; };
+		4989B9674C26B3825DF3C4D4 /* read.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = read.c; sourceTree = "<group>"; };
 		4A1B327713437D80D690ED9B /* ChapterTranslationChunkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterTranslationChunkerTests.swift; sourceTree = "<group>"; };
 		4A3BC126A794F2C82F782E7D /* TXTTextChunkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTTextChunkerTests.swift; sourceTree = "<group>"; };
 		4A57E82A7221B36240E501FD /* AIConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIConfigurationTests.swift; sourceTree = "<group>"; };
@@ -1934,7 +1929,6 @@
 		4F8AEC7D40405AE90840ABE4 /* HighlightRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightRenderer.swift; sourceTree = "<group>"; };
 		4FA36CFAC187DC7B25B7A920 /* ChapterStartTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterStartTypography.swift; sourceTree = "<group>"; };
 		4FBF157299A06F8948FB8689 /* FoliateBilingualPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateBilingualPipeline.swift; sourceTree = "<group>"; };
-		4FE4DC2DFC2C87C8E958A247 /* encryption.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = encryption.h; sourceTree = "<group>"; };
 		4FE8B867BCF9BCDCF23941DB /* EPUBPreExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBPreExtractorTests.swift; sourceTree = "<group>"; };
 		5009D3D555DF12B60ACC2D88 /* HighlightPopoverModifierBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPopoverModifierBody.swift; sourceTree = "<group>"; };
 		506F86FDA1498276D10E5E7B /* FoliateViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateViewCoordinator.swift; sourceTree = "<group>"; };
@@ -1968,8 +1962,10 @@
 		544A2F3FF8BBB1C08DDCE02D /* PageNavigatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageNavigatorTests.swift; sourceTree = "<group>"; };
 		5487566F93AB8376D1BD1F1B /* EPUBFileLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBFileLoaderTests.swift; sourceTree = "<group>"; };
 		54AC37DCD75A3993463AC297 /* WebDAVServerProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVServerProfileTests.swift; sourceTree = "<group>"; };
+		54DB141E4F9A1F2AE3806B10 /* index.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = index.c; sourceTree = "<group>"; };
 		54F63868C11B04D324F09751 /* TTSControlBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSControlBar.swift; sourceTree = "<group>"; };
 		54F6890E87192A26A4D07A87 /* LibraryViewObservers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewObservers.swift; sourceTree = "<group>"; };
+		550C7AB6FFFB64F0A6E97C38 /* structure.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = structure.h; sourceTree = "<group>"; };
 		551DA6A3D645B1D9D72EE159 /* ChapterTranslationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterTranslationService.swift; sourceTree = "<group>"; };
 		552781BB888D9F5ACA8B6B80 /* TXTReaderContainerViewPagedLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReaderContainerViewPagedLayoutTests.swift; sourceTree = "<group>"; };
 		55633F1E05B29D20C4A4D0D5 /* TXTReaderPositionBackCompatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReaderPositionBackCompatTests.swift; sourceTree = "<group>"; };
@@ -2004,6 +2000,7 @@
 		59AD0B57E130DE8620C8AEC4 /* TextHighlightHitTesterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextHighlightHitTesterTests.swift; sourceTree = "<group>"; };
 		59B2824739E67F567813198E /* TestConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConstants.swift; sourceTree = "<group>"; };
 		59C9E78D6768871560C6C7CB /* ChapterTextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterTextProviderTests.swift; sourceTree = "<group>"; };
+		59D4242F8E27621A0CF36842 /* xmlwriter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = xmlwriter.h; sourceTree = "<group>"; };
 		59ECD5BE8EE959A2EF3E208E /* PersistenceActor+ReadingPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+ReadingPosition.swift"; sourceTree = "<group>"; };
 		5A3C9E1EE2F6EA56F40872E6 /* EPUBReaderContainerView+Bilingual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EPUBReaderContainerView+Bilingual.swift"; sourceTree = "<group>"; };
 		5A54A2C5DE8C1631C04BB2A1 /* PDFProgressHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFProgressHelper.swift; sourceTree = "<group>"; };
@@ -2014,7 +2011,6 @@
 		5ADFBB978A77BD6B9E977F36 /* SettingsSliderRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSliderRowTests.swift; sourceTree = "<group>"; };
 		5AF84D4FD4FAA3232D18AA96 /* ReplacementTransform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplacementTransform.swift; sourceTree = "<group>"; };
 		5B0357FF4CC21B381B9CA016 /* ReaderMoreMenuRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderMoreMenuRowTests.swift; sourceTree = "<group>"; };
-		5B3648D95507E187C2CC5DF6 /* compression.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = compression.h; sourceTree = "<group>"; };
 		5B58A3A5DB35DA47F032FCEB /* LegadoImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegadoImporter.swift; sourceTree = "<group>"; };
 		5B5C3B574FE1EBD73201C8C2 /* EPUBWebViewEvaluatorHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBWebViewEvaluatorHandle.swift; sourceTree = "<group>"; };
 		5B67894BA57026638D94B118 /* ReaderThemeV2+EPUBCSS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderThemeV2+EPUBCSS.swift"; sourceTree = "<group>"; };
@@ -2026,6 +2022,7 @@
 		5C502F959BB80E4EE5F022C8 /* view.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = view.js; sourceTree = "<group>"; };
 		5C5EC86BB06D46DC9A5A4F6B /* EPUBHighlightBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBHighlightBridgeTests.swift; sourceTree = "<group>"; };
 		5C65E5FD23C2800C87ADD82A /* TOCProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOCProvider.swift; sourceTree = "<group>"; };
+		5C8C813D4D2AE69EC6BA16FD /* parse_rawml.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = parse_rawml.h; sourceTree = "<group>"; };
 		5D2BA1A05E4E36D5D7B2DCFD /* PDFReaderContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReaderContainerView.swift; sourceTree = "<group>"; };
 		5D3EF2FFB105C9E0DF1EDF51 /* SpeechSynthesizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechSynthesizing.swift; sourceTree = "<group>"; };
 		5D7F4F4B985D58E03A78680D /* PDFReaderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReaderViewModelTests.swift; sourceTree = "<group>"; };
@@ -2052,7 +2049,6 @@
 		60D19CA6B370181C8BF08270 /* VReaderAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderAppDelegate.swift; sourceTree = "<group>"; };
 		60F442A575A04CD706CC53FE /* EPUBDebugBridgeHighlightJS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBDebugBridgeHighlightJS.swift; sourceTree = "<group>"; };
 		6147C39C4171F0BFA004780E /* VReaderLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderLocator.swift; sourceTree = "<group>"; };
-		614C6D408C5EE1EC5D276754 /* opf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = opf.h; sourceTree = "<group>"; };
 		6195F10A5C760B111459790C /* PollUntil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollUntil.swift; sourceTree = "<group>"; };
 		61C7310D3FF8C5778BFCB6E1 /* TXTAttributedStringBuilderChapterStartTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTAttributedStringBuilderChapterStartTests.swift; sourceTree = "<group>"; };
 		61D2ACCFF53EDBE89326A37F /* LocatorFactoryTXTChapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorFactoryTXTChapterTests.swift; sourceTree = "<group>"; };
@@ -2064,6 +2060,7 @@
 		6216F1011252A14AA8AB31CF /* ReadiumBilingualEvalAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumBilingualEvalAdapterTests.swift; sourceTree = "<group>"; };
 		62569DC663E2BDD2DC0155C3 /* SearchHighlightDismissTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHighlightDismissTests.swift; sourceTree = "<group>"; };
 		627E42F1B1E8A59081CC6628 /* BookFormatAZW3Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFormatAZW3Tests.swift; sourceTree = "<group>"; };
+		629CCC658A5843CA9CB3915C /* sha1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sha1.c; sourceTree = "<group>"; };
 		62B304D30B717A1AB66C2A5B /* Feature64PDFMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature64PDFMigrationTests.swift; sourceTree = "<group>"; };
 		62D7DA128D4B2AC1F362D571 /* LaunchHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchHelper.swift; sourceTree = "<group>"; };
 		631D0375777D50E5B1EDF31C /* HighlightedSnippetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightedSnippetTests.swift; sourceTree = "<group>"; };
@@ -2083,7 +2080,6 @@
 		662756B2F0105F6DDB1E0241 /* BilingualReadingViewModel+Prefetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BilingualReadingViewModel+Prefetch.swift"; sourceTree = "<group>"; };
 		6635582524CF50059E66F973 /* ReadingDashboardViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDashboardViewTests.swift; sourceTree = "<group>"; };
 		66440341C1BA8050AFD3A65C /* EPUBChapterNavigationRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBChapterNavigationRouterTests.swift; sourceTree = "<group>"; };
-		6644E66A9BEDE9071D8D876F /* encryption.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = encryption.c; sourceTree = "<group>"; };
 		6671E9F8673155BDC726A6ED /* RealDebugBridgeContext+Settle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RealDebugBridgeContext+Settle.swift"; sourceTree = "<group>"; };
 		667AC3E733DFC3883BC89D39 /* AlertDialogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertDialogTests.swift; sourceTree = "<group>"; };
 		67368B0914CFE12052417225 /* LazyDownloadCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyDownloadCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -2104,6 +2100,7 @@
 		69C7229E97D0F8B543683A02 /* SearchQueryExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchQueryExecutor.swift; sourceTree = "<group>"; };
 		69ECDAED09428E0C1CD6A724 /* HighlightRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightRendererTests.swift; sourceTree = "<group>"; };
 		6A3131E83F93590395D14009 /* UnifiedEPUBLoadResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedEPUBLoadResult.swift; sourceTree = "<group>"; };
+		6A34312E819B990FD90CAD78 /* randombytes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = randombytes.h; sourceTree = "<group>"; };
 		6A3C9C74AEB817E120ACDAF9 /* Feature64FoliateMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature64FoliateMigrationTests.swift; sourceTree = "<group>"; };
 		6A5928551FF9FBB8D2E87E6F /* AIAssistantView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAssistantView.swift; sourceTree = "<group>"; };
 		6AA1E6FB5ADF99CF8CEB51FF /* HighlightPopoverPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPopoverPresenterTests.swift; sourceTree = "<group>"; };
@@ -2120,7 +2117,6 @@
 		6DE1995445027494280CEE07 /* ReadiumEPUBReaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumEPUBReaderViewModel.swift; sourceTree = "<group>"; };
 		6DF113D7E83A1CE51F417258 /* AIReaderPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReaderPanel.swift; sourceTree = "<group>"; };
 		6E358C3A06D7CC0958A40876 /* BookSourceSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSourceSearchView.swift; sourceTree = "<group>"; };
-		6E4CC1253B1BAD112E36AB2C /* sha1.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sha1.h; sourceTree = "<group>"; };
 		6E57059EA750B150D10FC828 /* PillSwitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillSwitchTests.swift; sourceTree = "<group>"; };
 		6E5D3F39FDBF4693D33D1BCB /* MDMetadataExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDMetadataExtractor.swift; sourceTree = "<group>"; };
 		6ED83105BFA1AA160A12D158 /* BookFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFormatTests.swift; sourceTree = "<group>"; };
@@ -2132,6 +2128,7 @@
 		6FC5D3DF85816AC1F7B42E3D /* WebDAVProfileMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProfileMigrator.swift; sourceTree = "<group>"; };
 		6FD939A141F12D7003A40C3D /* UIKitHighlightPopoverPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitHighlightPopoverPresenterTests.swift; sourceTree = "<group>"; };
 		7008A22A4FBE1574E8B9C8A4 /* TXTStreamingOpenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTStreamingOpenTests.swift; sourceTree = "<group>"; };
+		70147197363D24AF5E1FF6DB /* encryption.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = encryption.c; sourceTree = "<group>"; };
 		7024E7AEAC9AEAA028952C46 /* ScrollProgressHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollProgressHelper.swift; sourceTree = "<group>"; };
 		7056486BA460E0BE06235F54 /* UnifiedTextRendererViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedTextRendererViewModel.swift; sourceTree = "<group>"; };
 		70987122A8AE280D70E9D906 /* PageAxisResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageAxisResolverTests.swift; sourceTree = "<group>"; };
@@ -2170,7 +2167,6 @@
 		78BD4CC018110BC0C96E2788 /* DebugReaderRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReaderRegistryTests.swift; sourceTree = "<group>"; };
 		78F701D2D5416A758988C808 /* HTTPTTSChunkPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTTSChunkPlayer.swift; sourceTree = "<group>"; };
 		791CB502C8B59E737F15E63C /* VerificationSettingsHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationSettingsHelperTests.swift; sourceTree = "<group>"; };
-		79A043D83CF700D279FF0358 /* opf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = opf.c; sourceTree = "<group>"; };
 		79E3E09003BD79ED972F15D6 /* ChapterTranslationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterTranslationStoreTests.swift; sourceTree = "<group>"; };
 		79F003D569BCC0F29113468A /* EPUBMetadataExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBMetadataExtractorTests.swift; sourceTree = "<group>"; };
 		7A0147BC1F4C66F4EDB21608 /* ReadingDashboardSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDashboardSnapshotTests.swift; sourceTree = "<group>"; };
@@ -2179,12 +2175,10 @@
 		7A980DB0017049401DAB3E93 /* AnnotationListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationListViewModel.swift; sourceTree = "<group>"; };
 		7A9E42127F86EB76595AD46B /* BackupReadingHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupReadingHistoryTests.swift; sourceTree = "<group>"; };
 		7AAC0D3FD90694D3169DB775 /* MDReaderPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReaderPlaceholderTests.swift; sourceTree = "<group>"; };
-		7AEF9EDC3C81B6E2AFCD6590 /* write.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = write.c; sourceTree = "<group>"; };
 		7B3463E0D88B62CFEF84E4F9 /* chapter_content.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = chapter_content.html; sourceTree = "<group>"; };
 		7BA6B74EE0E50E049C9BAC5C /* WebDAVSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVSettingsView.swift; sourceTree = "<group>"; };
 		7BD36F5CC483659F962BFB3A /* TTSService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSService.swift; sourceTree = "<group>"; };
 		7C0A7E77EFE308BC9CF8A3FE /* ErrorMessageAuditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMessageAuditor.swift; sourceTree = "<group>"; };
-		7C1BE488B566578C5C914796 /* read.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = read.c; sourceTree = "<group>"; };
 		7C842F00C6B506FC831E0347 /* EPUBTextStripperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBTextStripperTests.swift; sourceTree = "<group>"; };
 		7CB1FD8F0785F095177A4AE6 /* BookSourceEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSourceEditorView.swift; sourceTree = "<group>"; };
 		7CE90E7D827B7E8A356D6DC6 /* Inter-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Inter-SemiBold.otf"; sourceTree = "<group>"; };
@@ -2200,7 +2194,6 @@
 		7DD5FCBE242265B2EB6F7E6D /* Libmobi-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Libmobi-Bridging-Header.h"; sourceTree = "<group>"; };
 		7DE6A4A50E59B50DE7574A87 /* paginator.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = paginator.js; sourceTree = "<group>"; };
 		7DEA283D3F2224EDC297B6E1 /* MDFileLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDFileLoader.swift; sourceTree = "<group>"; };
-		7E468F4DBD64650AF7E80CE6 /* debug.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = debug.c; sourceTree = "<group>"; };
 		7E86175071842E275652A4F2 /* ReaderContainerView+DebugBridgeRenderedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderContainerView+DebugBridgeRenderedText.swift"; sourceTree = "<group>"; };
 		7F1BC0259A472381A819DF2A /* mobi.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = mobi.js; sourceTree = "<group>"; };
 		7F2360F05D5C411D05806514 /* ReaderThemeV2EPUBCSSChapterStartTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeV2EPUBCSSChapterStartTests.swift; sourceTree = "<group>"; };
@@ -2220,11 +2213,11 @@
 		80CB6321B674BB16BF0DEC55 /* legacy-backup-no-manifest.vreader.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = "legacy-backup-no-manifest.vreader.zip"; sourceTree = "<group>"; };
 		80ED96E0CBD0FFF1335B41D0 /* LibraryViewModelImportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModelImportTests.swift; sourceTree = "<group>"; };
 		815A2F870C4D8EC102254ACC /* PersistenceActor+Bookmarks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+Bookmarks.swift"; sourceTree = "<group>"; };
+		81680767353B999AFCC3A8DE /* write.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = write.h; sourceTree = "<group>"; };
 		8180BC93B7839BF9878114F1 /* ReadingDashboardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDashboardViewModelTests.swift; sourceTree = "<group>"; };
 		81816D53162945723E79FB9B /* SyncOutboundQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncOutboundQueue.swift; sourceTree = "<group>"; };
 		8188B21271D103070EE8CDE6 /* SyncConflictResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncConflictResolver.swift; sourceTree = "<group>"; };
 		818F6161D2855C49A12AF5A6 /* TOCBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOCBuilder.swift; sourceTree = "<group>"; };
-		81CF5EFF981B3902B76768D9 /* miniz.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = miniz.h; sourceTree = "<group>"; };
 		820C166494A63E2245B18252 /* ReadiumEPUBHost+Highlights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReadiumEPUBHost+Highlights.swift"; sourceTree = "<group>"; };
 		82199531AD7036AB0F37C56C /* ReaderTopChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTopChrome.swift; sourceTree = "<group>"; };
 		823A94AB15D85579FB0C8D5C /* BookSourcePipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSourcePipeline.swift; sourceTree = "<group>"; };
@@ -2255,7 +2248,6 @@
 		85C4EC2BEDD3FD73FFBF56B8 /* DebugReaderRegistryAwaitReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReaderRegistryAwaitReaderTests.swift; sourceTree = "<group>"; };
 		85EEEA47C4E7D01D716EF2A4 /* TXTContinuousChunkBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTContinuousChunkBuilderTests.swift; sourceTree = "<group>"; };
 		85F0F2460E80C3EC09624384 /* Feature27ReplacementRulesVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature27ReplacementRulesVerificationTests.swift; sourceTree = "<group>"; };
-		86219F525D53A66480857B58 /* memory.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = memory.c; sourceTree = "<group>"; };
 		864232F1C9EEF1A310AA820A /* EPUBThemeOverrideCSSV2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBThemeOverrideCSSV2Tests.swift; sourceTree = "<group>"; };
 		864A1B050775A46ADBE3304F /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
 		864BA35C7F82D6437278E5C6 /* EPUBChapterWrapPendingTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBChapterWrapPendingTargetTests.swift; sourceTree = "<group>"; };
@@ -2324,6 +2316,7 @@
 		9236535723F8728665D0BA74 /* MOBIMetadataParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MOBIMetadataParser.swift; sourceTree = "<group>"; };
 		92676552DDABC9E3D5E7DC76 /* HapticFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticFeedback.swift; sourceTree = "<group>"; };
 		9279142901B3666BD14E0B20 /* DebugCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugCommandTests.swift; sourceTree = "<group>"; };
+		929DB9C524CFA70B2ED5F899 /* randombytes.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = randombytes.c; sourceTree = "<group>"; };
 		92A21498B4BB8CCB388677F3 /* HighlightsSheet+Delete.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HighlightsSheet+Delete.swift"; sourceTree = "<group>"; };
 		92AB43BED5AC7096E7278A16 /* QuoteRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuoteRecoveryTests.swift; sourceTree = "<group>"; };
 		9348BA9420642018DA5C3767 /* ReadiumDecorationHighlightAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumDecorationHighlightAdapterTests.swift; sourceTree = "<group>"; };
@@ -2333,7 +2326,6 @@
 		93955827511F55BEEFCA2307 /* BookSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSource.swift; sourceTree = "<group>"; };
 		939BC09F1D771D2E22301ED3 /* V1toV2MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V1toV2MigrationTests.swift; sourceTree = "<group>"; };
 		93E6312BDB7B7B5A5672E68B /* BilingualAttributedStringComposerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualAttributedStringComposerTests.swift; sourceTree = "<group>"; };
-		9438793466362160FD85E5E1 /* randombytes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = randombytes.h; sourceTree = "<group>"; };
 		9452FAFFDEBDF03FF6CCEBB1 /* MDParserProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDParserProtocol.swift; sourceTree = "<group>"; };
 		94AF8D98E6FAD355A8B3416B /* TranslateLanguageRailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateLanguageRailTests.swift; sourceTree = "<group>"; };
 		94C32FCAEDE0062125F6A51E /* DebugSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSnapshot.swift; sourceTree = "<group>"; };
@@ -2362,6 +2354,7 @@
 		97EE89998FF9D71667B4B83C /* FoliateSelectionDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateSelectionDispatcherTests.swift; sourceTree = "<group>"; };
 		982822FD76DDFB1EEE150FF0 /* ImportError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportError.swift; sourceTree = "<group>"; };
 		9844BEF447FBDBA15ADCEFAB /* TXTAttributedStringBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTAttributedStringBuilder.swift; sourceTree = "<group>"; };
+		987073031286E75BEF89E941 /* buffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = buffer.h; sourceTree = "<group>"; };
 		98814DDDA2DB119CB5AA53A0 /* LegadoCompatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegadoCompatibility.swift; sourceTree = "<group>"; };
 		98913241E6FA9EDD33571CB9 /* ChapterStartTypographyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterStartTypographyTests.swift; sourceTree = "<group>"; };
 		9893809AE39B5DF0233FEE42 /* ProviderProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderProfile.swift; sourceTree = "<group>"; };
@@ -2386,7 +2379,6 @@
 		9B75BA41298C5306AC9AD036 /* GenerativeCoverStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerativeCoverStyle.swift; sourceTree = "<group>"; };
 		9B8C36563D7885AD214F885A /* FoliateSearchAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateSearchAdapter.swift; sourceTree = "<group>"; };
 		9C192DC2E4B6D7B71D711849 /* BookCardViewVisualTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCardViewVisualTests.swift; sourceTree = "<group>"; };
-		9C20501C933155E5C53D85B9 /* memory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = memory.h; sourceTree = "<group>"; };
 		9C3C090346A269737F00D577 /* TXTPagedChapterAdvance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTPagedChapterAdvance.swift; sourceTree = "<group>"; };
 		9C5A2D5CFE8B719D4C8F3580 /* SchemaV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV1.swift; sourceTree = "<group>"; };
 		9C78911337C79BBAE9B2AB7C /* BookDetailsSheet+Cards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BookDetailsSheet+Cards.swift"; sourceTree = "<group>"; };
@@ -2399,7 +2391,6 @@
 		9DB1CCA367AE0B610F4526FC /* SearchIndexStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchIndexStore.swift; sourceTree = "<group>"; };
 		9DB260B5C0A147C9AE9A46DC /* BookInfoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookInfoSheet.swift; sourceTree = "<group>"; };
 		9DBD86DDBB52369C831FF078 /* ReadingStatsAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsAggregator.swift; sourceTree = "<group>"; };
-		9DF1208DFEA4E40A0D028BDD /* compression.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = compression.c; sourceTree = "<group>"; };
 		9E09E65978F174E10780F7D3 /* LibraryContinueCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryContinueCard.swift; sourceTree = "<group>"; };
 		9E4A364E7AFF2DD96244D639 /* WebDAVServerProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVServerProfile.swift; sourceTree = "<group>"; };
 		9E9734639739473622AE22A1 /* HighlightHitToleranceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightHitToleranceTests.swift; sourceTree = "<group>"; };
@@ -2411,7 +2402,6 @@
 		A069D350D0DC6B4C000E1D43 /* TXTChunkedLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChunkedLoaderTests.swift; sourceTree = "<group>"; };
 		A0753D8C40DFE06B0323EE5B /* UnifiedScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedScrollView.swift; sourceTree = "<group>"; };
 		A0797CB73F5D8FDAF0B7298E /* TestSeeder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSeeder.swift; sourceTree = "<group>"; };
-		A08C4AFA17A3D37D00D9A18B /* util.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = util.h; sourceTree = "<group>"; };
 		A0FDBE03DFF8791C7027EEAD /* BookDetailsActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailsActionsTests.swift; sourceTree = "<group>"; };
 		A15103F3E39BB0F94806914C /* fflate.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = fflate.js; sourceTree = "<group>"; };
 		A17676C4AE9DD328C39176D8 /* BackupDataCollectorRestorerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupDataCollectorRestorerTests.swift; sourceTree = "<group>"; };
@@ -2428,7 +2418,6 @@
 		A43C03327815457BD7B01409 /* TXTBridgeShared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTBridgeShared.swift; sourceTree = "<group>"; };
 		A457F48D22CD5B4952817701 /* EPUBTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBTypes.swift; sourceTree = "<group>"; };
 		A496DB7B37A1E68FA33AD5A3 /* JSONExportFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONExportFormatter.swift; sourceTree = "<group>"; };
-		A4D62CB2C235BD942DAD8E06 /* structure.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = structure.c; sourceTree = "<group>"; };
 		A4D9A3C4C1072DA23511265D /* PDFReaderPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFReaderPlaceholderTests.swift; sourceTree = "<group>"; };
 		A4FC31294DE996929269182A /* ReadiumBilingualCommanderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumBilingualCommanderTests.swift; sourceTree = "<group>"; };
 		A504B80204BEC5B968087D02 /* PersistenceActorRemoteOnlyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceActorRemoteOnlyTests.swift; sourceTree = "<group>"; };
@@ -2440,9 +2429,11 @@
 		A694EB7A8BB6138115DAB32E /* tts.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = tts.js; sourceTree = "<group>"; };
 		A6DB55181F2F55D99D879507 /* FoliateSearchAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateSearchAdapterTests.swift; sourceTree = "<group>"; };
 		A6F1C998AAACA679A10A86D2 /* BookCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCollection.swift; sourceTree = "<group>"; };
+		A74E93AEDA2E0A0AF57253D9 /* meta.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = meta.h; sourceTree = "<group>"; };
 		A77D3287AEC40129E6AA379F /* LibraryDynamicTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryDynamicTypeTests.swift; sourceTree = "<group>"; };
 		A78743D11EADF7D49C2AD970 /* EPUBSelectionTokenCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBSelectionTokenCache.swift; sourceTree = "<group>"; };
 		A7E742DD046F5CE970132E0C /* EPUBParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBParser.swift; sourceTree = "<group>"; };
+		A7EBC969B5DD8804D6AFF3DD /* structure.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = structure.c; sourceTree = "<group>"; };
 		A84982F334E70A0D71A44893 /* ReaderContainerViewEngineDispatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderContainerViewEngineDispatchTests.swift; sourceTree = "<group>"; };
 		A84BF17CCCD4B376BDDF8CD1 /* utf8_bom.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = utf8_bom.txt; sourceTree = "<group>"; };
 		A890F7C98CE159058714EE4D /* ChapterBounds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterBounds.swift; sourceTree = "<group>"; };
@@ -2471,7 +2462,6 @@
 		AC12F17B1F2EDD25E25B114C /* SyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncService.swift; sourceTree = "<group>"; };
 		AC38E517D1EE7098DCB96426 /* MarkdownExportFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownExportFormatter.swift; sourceTree = "<group>"; };
 		AC517B8E3581F795DEDEC934 /* PersistenceActor+Highlights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+Highlights.swift"; sourceTree = "<group>"; };
-		AC94A68265F7E85C1D82D143 /* buffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = buffer.h; sourceTree = "<group>"; };
 		AC968C1CC671160D930BF4F9 /* ReadiumReaderCoordinator+Transparency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReadiumReaderCoordinator+Transparency.swift"; sourceTree = "<group>"; };
 		ACD95B7F2CED44C4E8E33E05 /* PDFBilingualPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFBilingualPanel.swift; sourceTree = "<group>"; };
 		AD065491E8CFE99188D62E09 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
@@ -2492,7 +2482,9 @@
 		AF4E488AD7274100802E64AD /* HighlightedSnippet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightedSnippet.swift; sourceTree = "<group>"; };
 		AFFFEDEA99460D1154D19EE5 /* NSUKVSBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSUKVSBridge.swift; sourceTree = "<group>"; };
 		B011230154D950EDFE2EA274 /* SettingsView+StatsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsView+StatsSheet.swift"; sourceTree = "<group>"; };
+		B054BED63B658956320D03A4 /* read.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = read.h; sourceTree = "<group>"; };
 		B08E95607978EED0EB89FA0B /* AppLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLogger.swift; sourceTree = "<group>"; };
+		B0B74C47070E85D25A033A74 /* write.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = write.c; sourceTree = "<group>"; };
 		B10A08E980C92248337462DF /* LocatorRestorerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorRestorerTests.swift; sourceTree = "<group>"; };
 		B12F4D45796EA04FB6D5C3F9 /* TXTPagedChapterAdvanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTPagedChapterAdvanceTests.swift; sourceTree = "<group>"; };
 		B13E51BF43992E1B2786A8FD /* ChapterTranslationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterTranslationServiceTests.swift; sourceTree = "<group>"; };
@@ -2511,6 +2503,7 @@
 		B3CB57338FD24289DAC8ABE4 /* WI9TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WI9TestHelpers.swift; sourceTree = "<group>"; };
 		B442FC7A6A6ED344AB5C1FC9 /* CollectionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionPersistenceTests.swift; sourceTree = "<group>"; };
 		B4CE8C718C8DE75E35CF5EC0 /* BilingualReadingViewModelPrefetchUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualReadingViewModelPrefetchUnitTests.swift; sourceTree = "<group>"; };
+		B4D1EEB6771BA0294E069885 /* miniz.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = miniz.h; sourceTree = "<group>"; };
 		B4FC46B472B8A5D69BD80220 /* EPUBReaderContainerView+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EPUBReaderContainerView+Navigation.swift"; sourceTree = "<group>"; };
 		B501E24B36BF00B609B04BF3 /* ReaderSearchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSearchCoordinator.swift; sourceTree = "<group>"; };
 		B56E5394E251AA0C42AE3557 /* TOCChapterProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOCChapterProgressTests.swift; sourceTree = "<group>"; };
@@ -2523,7 +2516,6 @@
 		B6CC92F8C2796AB46E2B5E21 /* CloudKitClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudKitClient.swift; sourceTree = "<group>"; };
 		B6DAD680DB86CF1A65D34F3F /* LibraryRefreshServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryRefreshServiceTests.swift; sourceTree = "<group>"; };
 		B6E7989DDF416C464057AB6D /* TXTChunkedReaderConversionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChunkedReaderConversionTests.swift; sourceTree = "<group>"; };
-		B7449C22542E7A6A51777ADD /* read.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = read.h; sourceTree = "<group>"; };
 		B75EC9C3C222236A27183F13 /* FoliateHighlightJSBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightJSBridge.swift; sourceTree = "<group>"; };
 		B811BD48F552B167D438BFCF /* BookModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookModelTests.swift; sourceTree = "<group>"; };
 		B849723B3079FB8F3F4A7961 /* PDFHighlightIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFHighlightIntegrationTests.swift; sourceTree = "<group>"; };
@@ -2550,6 +2542,8 @@
 		BB8C0771E06618E5F68C410D /* RealDebugBridgeContext+Present.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RealDebugBridgeContext+Present.swift"; sourceTree = "<group>"; };
 		BC42F137A3776DEED18D9044 /* EPUBComplexityClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBComplexityClassifierTests.swift; sourceTree = "<group>"; };
 		BC7CBC6DECE0826C5C95D76D /* FoliateBilingualJS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateBilingualJS.swift; sourceTree = "<group>"; };
+		BCAD037C92A0ECF7A9FD75C2 /* memory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = memory.h; sourceTree = "<group>"; };
+		BCDE9829093BAF958CB879B6 /* debug.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = debug.h; sourceTree = "<group>"; };
 		BD6D19741098BC82E294F1E1 /* PageNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageNavigator.swift; sourceTree = "<group>"; };
 		BD9F0676ACCEE6F37D547E72 /* EPUBHighlightActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBHighlightActionsTests.swift; sourceTree = "<group>"; };
 		BDC254C94AE749FFA8AACCE4 /* LibraryRefreshService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryRefreshService.swift; sourceTree = "<group>"; };
@@ -2560,6 +2554,7 @@
 		BE8121B86DA337766FD55AEF /* WebDAVClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVClientTests.swift; sourceTree = "<group>"; };
 		BEAA04C3430C5B247FB86585 /* TXTChapterIndexBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterIndexBuilderTests.swift; sourceTree = "<group>"; };
 		BEF27FBFB95343D4BE50B1F4 /* PDFBilingualPanelBodies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFBilingualPanelBodies.swift; sourceTree = "<group>"; };
+		BF0281FA950548AB6B0A7041 /* util.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = util.h; sourceTree = "<group>"; };
 		BFA61DA459242CFDBBD809B7 /* DebugSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSnapshotTests.swift; sourceTree = "<group>"; };
 		BFB65788879E3D91E69E8BA5 /* BlobPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlobPathTests.swift; sourceTree = "<group>"; };
 		BFC96A0B7273BB922335B1B0 /* TXTLoaderBackedChapterTextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTLoaderBackedChapterTextProviderTests.swift; sourceTree = "<group>"; };
@@ -2600,6 +2595,8 @@
 		C68E9908FEE2CDE00C6EB279 /* AISettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISettingsViewModelTests.swift; sourceTree = "<group>"; };
 		C69DD8E878FC41BDF6203450 /* RealDebugBridgeContext+TXTContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RealDebugBridgeContext+TXTContent.swift"; sourceTree = "<group>"; };
 		C6E58A8977DC02FDA7235A9E /* ProviderProfileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderProfileStore.swift; sourceTree = "<group>"; };
+		C6EB75042AA68C9558E6F62D /* encryption.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = encryption.h; sourceTree = "<group>"; };
+		C705960FA892E81AB33952F9 /* compression.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = compression.c; sourceTree = "<group>"; };
 		C74A4D9FF0F23D7D38DC185F /* WebDAVBlobStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVBlobStoreTests.swift; sourceTree = "<group>"; };
 		C758F02F43A58CA4A2A8382D /* NotesDeleteRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesDeleteRow.swift; sourceTree = "<group>"; };
 		C76B2024F008B3A41C030585 /* ReaderBottomChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderBottomChrome.swift; sourceTree = "<group>"; };
@@ -2660,6 +2657,7 @@
 		CF5C12635DFA6BEE42EBB1CE /* KeychainServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainServiceTests.swift; sourceTree = "<group>"; };
 		CF65A328F9A79571A5164390 /* FoliateReaderContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateReaderContainerView.swift; sourceTree = "<group>"; };
 		CF66A8065E5B60907FB0A3C8 /* GenerativeCoverMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerativeCoverMetrics.swift; sourceTree = "<group>"; };
+		CF93EB81220A9280AE60189A /* buffer.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = buffer.c; sourceTree = "<group>"; };
 		CFB26FE0A7766F5E461A6BC7 /* ReaderThemeV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeV2.swift; sourceTree = "<group>"; };
 		D00CF4678DEA6B609A56CE89 /* Feature42ReadiumAcceptanceFeaturesVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature42ReadiumAcceptanceFeaturesVerificationTests.swift; sourceTree = "<group>"; };
 		D026E639A53478C9636C20CE /* FoliateBilingualContainerView+BottomChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FoliateBilingualContainerView+BottomChrome.swift"; sourceTree = "<group>"; };
@@ -2669,6 +2667,7 @@
 		D04953A6060F401FEB272F2E /* AnnotationsRouteWiringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationsRouteWiringTests.swift; sourceTree = "<group>"; };
 		D054A0A5EF2A48B83A3DFE53 /* SyncPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncPipeline.swift; sourceTree = "<group>"; };
 		D093115A7D0F348656FA314B /* HighlightPopoverActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPopoverActionTests.swift; sourceTree = "<group>"; };
+		D0F43302E29E2FBA0759BA9A /* compression.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = compression.h; sourceTree = "<group>"; };
 		D1228610110E4D62C2B2B88F /* EPUBReaderContainerView+ChapterWrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EPUBReaderContainerView+ChapterWrap.swift"; sourceTree = "<group>"; };
 		D1368D4DA7FCD1EC48778531 /* AIContextExtractorScopedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIContextExtractorScopedTests.swift; sourceTree = "<group>"; };
 		D14E222357346107CB34B750 /* SmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokeTests.swift; sourceTree = "<group>"; };
@@ -2718,6 +2717,7 @@
 		D9EF707655DE949BB9C51A96 /* MDReplacementRuleFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReplacementRuleFetcherTests.swift; sourceTree = "<group>"; };
 		DA0E95AA02EBAE369ABF9AE5 /* TXTChapterIndexStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterIndexStore.swift; sourceTree = "<group>"; };
 		DA1946F92E99B7DCC600147C /* FontSizeCalibratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCalibratorTests.swift; sourceTree = "<group>"; };
+		DA3FE0BD5CD0A18890C97E59 /* util.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = util.c; sourceTree = "<group>"; };
 		DA823268583E27AF564272EC /* BackupDataRestorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupDataRestorer.swift; sourceTree = "<group>"; };
 		DAAAF285B1D1B4F09E3AAD56 /* BackupDataCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupDataCollector.swift; sourceTree = "<group>"; };
 		DADECFF5C347B6D68C1A8529 /* EPUBTextExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBTextExtractorTests.swift; sourceTree = "<group>"; };
@@ -2731,6 +2731,7 @@
 		DBA51F184E6AA5F2FD1F5456 /* zip.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = zip.js; sourceTree = "<group>"; };
 		DBAA3F90BD69DDACBE195884 /* NamedHighlightColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamedHighlightColor.swift; sourceTree = "<group>"; };
 		DBBB555BA86F7648ACBC780F /* EPUBProgressCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBProgressCalculator.swift; sourceTree = "<group>"; };
+		DBCDEF7FE521C85F02FCB750 /* miniz.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = miniz.c; sourceTree = "<group>"; };
 		DBD58B3560B70B8E874D669C /* EPUBBilingualPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBBilingualPipeline.swift; sourceTree = "<group>"; };
 		DC089C251F85AABA6BF4C347 /* EPUBChapterResourceURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBChapterResourceURL.swift; sourceTree = "<group>"; };
 		DC606D4AF30DF956E04C13DF /* LibrarySortOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySortOrder.swift; sourceTree = "<group>"; };
@@ -2761,7 +2762,6 @@
 		E02C0C97FFE66E8DEC728D64 /* SyncRecordDTOs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncRecordDTOs.swift; sourceTree = "<group>"; };
 		E05A8F8B018491C86ABB86AD /* ChapterTranslationChunker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterTranslationChunker.swift; sourceTree = "<group>"; };
 		E07FB35EC9805F51CAD10444 /* ThemeBackgroundStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeBackgroundStore.swift; sourceTree = "<group>"; };
-		E09CB8C0A0B9450D82B3687E /* parse_rawml.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = parse_rawml.c; sourceTree = "<group>"; };
 		E11E9DBFB16DA26DD0659851 /* AnnotationModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationModelTests.swift; sourceTree = "<group>"; };
 		E124CB39746DB0B59D0390C3 /* LazyDownloadReattachTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyDownloadReattachTests.swift; sourceTree = "<group>"; };
 		E12EBCB8CD58F740D9042C32 /* TXTTocRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTTocRule.swift; sourceTree = "<group>"; };
@@ -2769,10 +2769,12 @@
 		E1C9AB72079AF7B2ACCAB516 /* AIConsentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIConsentManager.swift; sourceTree = "<group>"; };
 		E1EF16A1A352B2C6BAE84556 /* UnifiedMDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedMDTests.swift; sourceTree = "<group>"; };
 		E21285A9149B2F11210A9430 /* PDFHighlightTapResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFHighlightTapResolverTests.swift; sourceTree = "<group>"; };
+		E21FA39387AC5CD4A056036B /* sha1.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sha1.h; sourceTree = "<group>"; };
 		E2396FE1BB03C2F3CEFAB8E2 /* AutoPageTurnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoPageTurnerTests.swift; sourceTree = "<group>"; };
 		E24A33BE5829870D3FBE2446 /* FoliateSpikeView+SectionExtracting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FoliateSpikeView+SectionExtracting.swift"; sourceTree = "<group>"; };
 		E24D3FC7488318277468A7F0 /* LibraryAccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryAccessibilityTests.swift; sourceTree = "<group>"; };
 		E25EC6B4A507BE08D646A4AD /* PersistentSearchIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentSearchIndexTests.swift; sourceTree = "<group>"; };
+		E282EBE7B2C78235790C892B /* debug.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = debug.c; sourceTree = "<group>"; };
 		E28AEE54347E9EC752286A2A /* EPUBHighlightActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBHighlightActions.swift; sourceTree = "<group>"; };
 		E29F1CDF0FEEA0BE9476555B /* ReaderTopChromeBilingualPillTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTopChromeBilingualPillTests.swift; sourceTree = "<group>"; };
 		E368FCB9544C39958CDC31CE /* TextKit2PaginatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextKit2PaginatorTests.swift; sourceTree = "<group>"; };
@@ -2819,7 +2821,6 @@
 		E9BD495685BB360AF81EDAE3 /* TranslationChunkContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationChunkContract.swift; sourceTree = "<group>"; };
 		E9C49D62E589CDF0C9F2D094 /* EPUBContinuousChapterProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBContinuousChapterProvider.swift; sourceTree = "<group>"; };
 		E9D4D088D34AA8A5692A991B /* PageTurnAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTurnAnimator.swift; sourceTree = "<group>"; };
-		E9F3CA16BAAFA10F49A196D0 /* write.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = write.h; sourceTree = "<group>"; };
 		EA0C50C474AA2F96C39AAC94 /* PaginationCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationCache.swift; sourceTree = "<group>"; };
 		EA0CD7509429C4B75ACB98F2 /* KeychainProviderProfileExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainProviderProfileExtensionTests.swift; sourceTree = "<group>"; };
 		EA401D8FC3B4F17213528B27 /* AIAssistantViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAssistantViewModelTests.swift; sourceTree = "<group>"; };
@@ -2865,6 +2866,7 @@
 		F02AE770B22BFE6D2F175A1A /* TXTChapterIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterIndex.swift; sourceTree = "<group>"; };
 		F038832B6A3B0C184154B6AD /* PipelineTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipelineTypes.swift; sourceTree = "<group>"; };
 		F05F28A8422C4AB0951D9586 /* EPUBContinuousScrollBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBContinuousScrollBridge.swift; sourceTree = "<group>"; };
+		F0660961FD57607DE851928C /* index.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = index.h; sourceTree = "<group>"; };
 		F069A328AA628585D86B52B2 /* SyncStatusViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusViewTests.swift; sourceTree = "<group>"; };
 		F114D9F3F59EEF655D5327EA /* EPUBCoverParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBCoverParsingTests.swift; sourceTree = "<group>"; };
 		F11A6F4B5DD22F0A6EE84B48 /* EPUBPageAxisProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBPageAxisProbeTests.swift; sourceTree = "<group>"; };
@@ -2883,7 +2885,6 @@
 		F4104BB5FAFACC19E9FBB4D7 /* LibraryProgressRing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryProgressRing.swift; sourceTree = "<group>"; };
 		F4C18F1E19149F8DBAE36A31 /* AIResponseCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIResponseCache.swift; sourceTree = "<group>"; };
 		F518E98F02B1A2000C41AAB2 /* TXTChapterIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterIntegrationTests.swift; sourceTree = "<group>"; };
-		F5222DA16840ED81F2DBE676 /* randombytes.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = randombytes.c; sourceTree = "<group>"; };
 		F560EA65913036C78284C138 /* ErrorScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorScreenTests.swift; sourceTree = "<group>"; };
 		F59A9AD0DFA1903B19F49D85 /* PDFChapterTextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFChapterTextProvider.swift; sourceTree = "<group>"; };
 		F64BCF588EF860DD6C214737 /* BackupLibraryManifestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupLibraryManifestTests.swift; sourceTree = "<group>"; };
@@ -2892,8 +2893,6 @@
 		F6CD884E38B64F954A2AFADD /* PDFReaderContainerView+Bilingual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PDFReaderContainerView+Bilingual.swift"; sourceTree = "<group>"; };
 		F6E02E23F3C9B74668C4264F /* HighlightActionCardSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightActionCardSubviews.swift; sourceTree = "<group>"; };
 		F70B62CBA5AED4AECA05825E /* SchemaV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV4.swift; sourceTree = "<group>"; };
-		F714532B8715316EE50BDBE8 /* meta.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = meta.h; sourceTree = "<group>"; };
-		F73114784F0062C27A90420D /* meta.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = meta.c; sourceTree = "<group>"; };
 		F75548C00D82133FCD8F0DB3 /* ReadingStatsModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsModels.swift; sourceTree = "<group>"; };
 		F7672B4D5423E0D3AAE16343 /* MDReaderReplacementRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReaderReplacementRulesTests.swift; sourceTree = "<group>"; };
 		F771364B47585A44CCA66EA4 /* ReaderThemeV2EPUBCSSCalibrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeV2EPUBCSSCalibrationTests.swift; sourceTree = "<group>"; };
@@ -2903,9 +2902,9 @@
 		F8038AAB18412F30C09CBDD9 /* AIConfigurationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIConfigurationStore.swift; sourceTree = "<group>"; };
 		F82AD6F50703DBCA984EBAAC /* UnifiedPagedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedPagedView.swift; sourceTree = "<group>"; };
 		F85E36013A798EB205697B9A /* AISettingsViewModelMultiProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISettingsViewModelMultiProfileTests.swift; sourceTree = "<group>"; };
+		F89BB1B1D01EB18947B00C09 /* config.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
 		F8DB79901C559905D3015DD3 /* ChapterPrefetching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterPrefetching.swift; sourceTree = "<group>"; };
 		F8DEE3B767FC8F7457067C11 /* MutationDriftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationDriftTests.swift; sourceTree = "<group>"; };
-		F8E8AD6FB530D2091CAC2111 /* xmlwriter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = xmlwriter.h; sourceTree = "<group>"; };
 		F9102277C4126793229AEEB9 /* SearchHitToLocatorResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHitToLocatorResolverTests.swift; sourceTree = "<group>"; };
 		F971403A2807A2788FD2D99F /* BookSourceListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSourceListView.swift; sourceTree = "<group>"; };
 		F9C022878EC860D3EFF8800C /* EPUBChapterTextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBChapterTextProvider.swift; sourceTree = "<group>"; };
@@ -2913,6 +2912,7 @@
 		FA7880EAC5DA9681AC6EF498 /* Bug233AZW3SeedVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bug233AZW3SeedVerificationTests.swift; sourceTree = "<group>"; };
 		FABEAF0841AD808F7EE48617 /* HighlightIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightIntegrationTests.swift; sourceTree = "<group>"; };
 		FAC9AC43028A99A994A7747B /* AISummaryTabViewScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISummaryTabViewScopeTests.swift; sourceTree = "<group>"; };
+		FB0E28C588B9C43889725C9C /* opf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = opf.h; sourceTree = "<group>"; };
 		FB17C932D5188B36F01F024A /* AnnotationExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationExporter.swift; sourceTree = "<group>"; };
 		FB5AB21F49D361F1160920C0 /* ContentReplacementRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentReplacementRule.swift; sourceTree = "<group>"; };
 		FB82BDFCDB76725A5586D5E0 /* Bookmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bookmark.swift; sourceTree = "<group>"; };
@@ -3068,49 +3068,6 @@
 				47C95AAF8C186ABB17B12943 /* JS */,
 			);
 			path = Foliate;
-			sourceTree = "<group>";
-		};
-		1546FD679023FFD5624DDAF3 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				435A9AA017E6DED1ABD5EDD4 /* buffer.c */,
-				AC94A68265F7E85C1D82D143 /* buffer.h */,
-				9DF1208DFEA4E40A0D028BDD /* compression.c */,
-				5B3648D95507E187C2CC5DF6 /* compression.h */,
-				2222400AEEA81DA9402E672A /* config.h */,
-				7E468F4DBD64650AF7E80CE6 /* debug.c */,
-				4041D83714C7F56092E8741F /* debug.h */,
-				6644E66A9BEDE9071D8D876F /* encryption.c */,
-				4FE4DC2DFC2C87C8E958A247 /* encryption.h */,
-				1AA31A6079F35AFE9A74C04A /* index.c */,
-				048A73AE0C45DB140C6E4F2D /* index.h */,
-				86219F525D53A66480857B58 /* memory.c */,
-				9C20501C933155E5C53D85B9 /* memory.h */,
-				F73114784F0062C27A90420D /* meta.c */,
-				F714532B8715316EE50BDBE8 /* meta.h */,
-				449D9045380C2ACAB1ECDA05 /* miniz.c */,
-				81CF5EFF981B3902B76768D9 /* miniz.h */,
-				3B829FF68F544237FC7C1078 /* mobi.h */,
-				79A043D83CF700D279FF0358 /* opf.c */,
-				614C6D408C5EE1EC5D276754 /* opf.h */,
-				E09CB8C0A0B9450D82B3687E /* parse_rawml.c */,
-				13260106C045DDB460F1126C /* parse_rawml.h */,
-				F5222DA16840ED81F2DBE676 /* randombytes.c */,
-				9438793466362160FD85E5E1 /* randombytes.h */,
-				7C1BE488B566578C5C914796 /* read.c */,
-				B7449C22542E7A6A51777ADD /* read.h */,
-				0A9AF8B9047FF5BA819DE46F /* sha1.c */,
-				6E4CC1253B1BAD112E36AB2C /* sha1.h */,
-				A4D62CB2C235BD942DAD8E06 /* structure.c */,
-				411C61E3504673FFE214FA5A /* structure.h */,
-				3D68C1EB7A52364906CB54B8 /* util.c */,
-				A08C4AFA17A3D37D00D9A18B /* util.h */,
-				7AEF9EDC3C81B6E2AFCD6590 /* write.c */,
-				E9F3CA16BAAFA10F49A196D0 /* write.h */,
-				0B192843406A9DDE4B3E7776 /* xmlwriter.c */,
-				F8E8AD6FB530D2091CAC2111 /* xmlwriter.h */,
-			);
-			path = src;
 			sourceTree = "<group>";
 		};
 		193A7CF46EE48B365E0A6079 /* Sync */ = {
@@ -3981,7 +3938,6 @@
 			isa = PBXGroup;
 			children = (
 				02568BCB9C0024CD13E6B213 /* Libmobi.swift */,
-				1546FD679023FFD5624DDAF3 /* src */,
 			);
 			path = Libmobi;
 			sourceTree = "<group>";
@@ -4425,6 +4381,50 @@
 				E5D7174921347E183EEB34A6 /* TextMapperTests.swift */,
 			);
 			path = TextMapping;
+			sourceTree = "<group>";
+		};
+		980A3DCBBA4B1368BB0D4D2B /* src */ = {
+			isa = PBXGroup;
+			children = (
+				CF93EB81220A9280AE60189A /* buffer.c */,
+				987073031286E75BEF89E941 /* buffer.h */,
+				C705960FA892E81AB33952F9 /* compression.c */,
+				D0F43302E29E2FBA0759BA9A /* compression.h */,
+				F89BB1B1D01EB18947B00C09 /* config.h */,
+				E282EBE7B2C78235790C892B /* debug.c */,
+				BCDE9829093BAF958CB879B6 /* debug.h */,
+				70147197363D24AF5E1FF6DB /* encryption.c */,
+				C6EB75042AA68C9558E6F62D /* encryption.h */,
+				54DB141E4F9A1F2AE3806B10 /* index.c */,
+				F0660961FD57607DE851928C /* index.h */,
+				33EA0E7BAE9970AB1E1CE063 /* memory.c */,
+				BCAD037C92A0ECF7A9FD75C2 /* memory.h */,
+				201AFC5B16E679291704CAAF /* meta.c */,
+				A74E93AEDA2E0A0AF57253D9 /* meta.h */,
+				DBCDEF7FE521C85F02FCB750 /* miniz.c */,
+				B4D1EEB6771BA0294E069885 /* miniz.h */,
+				4468102E4502A0FF889C3BEF /* mobi.h */,
+				445C53BC365999C7D62A3FD0 /* opf.c */,
+				FB0E28C588B9C43889725C9C /* opf.h */,
+				1780C35DB73F4E46831B1BE1 /* parse_rawml.c */,
+				5C8C813D4D2AE69EC6BA16FD /* parse_rawml.h */,
+				929DB9C524CFA70B2ED5F899 /* randombytes.c */,
+				6A34312E819B990FD90CAD78 /* randombytes.h */,
+				4989B9674C26B3825DF3C4D4 /* read.c */,
+				B054BED63B658956320D03A4 /* read.h */,
+				629CCC658A5843CA9CB3915C /* sha1.c */,
+				E21FA39387AC5CD4A056036B /* sha1.h */,
+				A7EBC969B5DD8804D6AFF3DD /* structure.c */,
+				550C7AB6FFFB64F0A6E97C38 /* structure.h */,
+				DA3FE0BD5CD0A18890C97E59 /* util.c */,
+				BF0281FA950548AB6B0A7041 /* util.h */,
+				B0B74C47070E85D25A033A74 /* write.c */,
+				81680767353B999AFCC3A8DE /* write.h */,
+				469230212394815593F6047E /* xmlwriter.c */,
+				59D4242F8E27621A0CF36842 /* xmlwriter.h */,
+			);
+			name = src;
+			path = vreader/Services/Libmobi/src;
 			sourceTree = "<group>";
 		};
 		9A27269DBB24004990DDA77D /* OPDS */ = {
@@ -5144,6 +5144,7 @@
 		E630D3048A0AF78632A66A2B = {
 			isa = PBXGroup;
 			children = (
+				980A3DCBBA4B1368BB0D4D2B /* src */,
 				E274CCA41781C721DABB75BA /* vreader */,
 				1CE455ACA7E90BC9E65C3D81 /* vreaderTests */,
 				384C67139B47F3B81E8E039F /* vreaderUITests */,
@@ -6933,23 +6934,23 @@
 				066A3021DFE04C15ECFEBF55 /* XCUITestMockSpeechSynthesizer.swift in Sources */,
 				AEFC819574E845429DFC9D78 /* ZIPReader.swift in Sources */,
 				48515116AAAA6DD5DFAA4ADE /* ZIPWriter.swift in Sources */,
-				C58BFD854BB68CD7F974AE20 /* buffer.c in Sources */,
-				1BF392E0910D136950668E41 /* compression.c in Sources */,
-				63CD1BD55C4410F70D1C8549 /* debug.c in Sources */,
-				797368D84A628FD0CC75BB75 /* encryption.c in Sources */,
-				6FBF472BF60BE1164ED7EA80 /* index.c in Sources */,
-				55F288C34B0362788ECAE2C0 /* memory.c in Sources */,
-				01161AA2FED893368F345289 /* meta.c in Sources */,
-				B1E83DEDFD2024431E1123A1 /* miniz.c in Sources */,
-				FFC62D5EFD014C76A0E5369E /* opf.c in Sources */,
-				1EA3DE3ED82E75202D5B0A5B /* parse_rawml.c in Sources */,
-				C09DC2D3EE103276AF5DEDF0 /* randombytes.c in Sources */,
-				76B92705C3DDA309A262E19E /* read.c in Sources */,
-				6D54759E6F840D7506AE2C36 /* sha1.c in Sources */,
-				88742A7F3156E292969BE063 /* structure.c in Sources */,
-				8E55B405568C0A20C0869CEF /* util.c in Sources */,
-				DFED97AA770947C9808D2C8A /* write.c in Sources */,
-				AC68C2599DEA6A14C6E7BA57 /* xmlwriter.c in Sources */,
+				734D18CAC0BFEBC21C2C79EC /* buffer.c in Sources */,
+				05387F5DA897FD61E601407F /* compression.c in Sources */,
+				D3A4F0401FDBDB1AC17DBD51 /* debug.c in Sources */,
+				F1F063D59EA5927565EA07A9 /* encryption.c in Sources */,
+				7E4A84CD67B43365EC2B421D /* index.c in Sources */,
+				4CBBDDA7BEECCFF853B1D90C /* memory.c in Sources */,
+				C33D6398694BEB59B3827AE9 /* meta.c in Sources */,
+				90BEC64CA9EC46D50BFD938F /* miniz.c in Sources */,
+				D36596FE4AD6EB66E818A92D /* opf.c in Sources */,
+				F3B4F71A5DF36249F3A9127E /* parse_rawml.c in Sources */,
+				5D3BF98A6D912091E9E09F9F /* randombytes.c in Sources */,
+				81A3402C6C5D0E39680A0066 /* read.c in Sources */,
+				54852944B2631BA79CF41926 /* sha1.c in Sources */,
+				88FC2400338EE530ECAE8E9A /* structure.c in Sources */,
+				42AD2B72A490CAB256B61882 /* util.c in Sources */,
+				0273E44CF9345BDA028B6D1E /* write.c in Sources */,
+				CDA22F80AC0636ED20C0EEEF /* xmlwriter.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7110,7 +7111,6 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 779;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
-				GCC_WARN_INHIBIT_ALL_WARNINGS = YES;
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -7265,7 +7265,6 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 779;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
-				GCC_WARN_INHIBIT_ALL_WARNINGS = YES;
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7109,7 +7109,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 779;
+				CURRENT_PROJECT_VERSION = 780;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7117,7 +7117,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.16;
+				MARKETING_VERSION = 3.42.17;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7263,7 +7263,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 779;
+				CURRENT_PROJECT_VERSION = 780;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7271,7 +7271,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.16;
+				MARKETING_VERSION = 3.42.17;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Services/Libmobi/Libmobi.swift
+++ b/vreader/Services/Libmobi/Libmobi.swift
@@ -1,0 +1,34 @@
+// Purpose: Feature #42 Phase 2 WI-1b — minimal Swift surface proving the
+// vendored libmobi (LGPL-3.0) C library links and is callable from Swift.
+// The real AZW3/MOBI/KF8 → EPUB converter (WI-2: MobiToEPUBConverter) builds
+// on this seam; WI-1b only establishes that the C interop works end-to-end —
+// at both compile time (the bridging header resolves mobi.h) and runtime (the
+// symbols are present in the linked binary, not merely declared).
+//
+// @coordinates-with: vreader/SupportingFiles/Libmobi-Bridging-Header.h,
+//   vreader/Services/Libmobi/BUILD-RECIPE.md,
+//   dev-docs/plans/20260528-feature-42-readium-libmobi-reader-engine.md
+
+import Foundation
+
+/// Thin namespace over the libmobi C API. WI-1b exposes only enough to prove
+/// linkage; the conversion surface (`mobi_load_filename` → `mobi_parse_kf8` →
+/// rawml → OPF/XML) lands in WI-2.
+enum Libmobi {
+
+    /// The vendored libmobi version string (e.g. `"0.12"`), read straight from
+    /// the C `mobi_version()`. Non-nil iff the C symbol links and returns.
+    static var version: String? {
+        guard let c = mobi_version() else { return nil }
+        return String(cString: c)
+    }
+
+    /// Allocate a libmobi context and immediately free it. Returns `true` if
+    /// `mobi_init()` returned a non-NULL `MOBIData *` — proving both
+    /// `mobi_init` and `mobi_free` link and run, not just resolve at link time.
+    static func contextAllocates() -> Bool {
+        guard let data = mobi_init() else { return false }
+        mobi_free(data)
+        return true
+    }
+}

--- a/vreader/SupportingFiles/Libmobi-Bridging-Header.h
+++ b/vreader/SupportingFiles/Libmobi-Bridging-Header.h
@@ -1,0 +1,13 @@
+//
+//  Libmobi-Bridging-Header.h
+//  Feature #42 Phase 2 (WI-1b): expose the vendored libmobi (LGPL-3.0) public
+//  C API to Swift, for Kindle (AZW3/MOBI/KF8) → EPUB convert-on-import.
+//
+//  Only the public umbrella header `mobi.h` is exposed. It is self-contained
+//  (includes only <stdio.h>/<stdint.h>/<stdbool.h>/<time.h>), so no internal
+//  libmobi headers leak into the Swift module. The .c sources compile into the
+//  app target (see project.yml); this header makes their declared symbols
+//  callable from Swift. Compile flags (USE_LIBXML2, the libxml2 include path)
+//  and the libxml2 link are configured on the vreader target in project.yml.
+//
+#include "mobi.h"

--- a/vreaderTests/Services/Libmobi/LibmobiSmokeTests.swift
+++ b/vreaderTests/Services/Libmobi/LibmobiSmokeTests.swift
@@ -1,9 +1,17 @@
 // Feature #42 Phase 2 WI-1b: smoke test proving the vendored libmobi (LGPL-3.0)
 // C library links and is callable from Swift through the bridging header. If
-// these fail, the C interop (compile flags / bridging header / libxml2 link)
-// is broken — which would block the WI-2 MobiToEPUBConverter entirely. This is
-// the RED→GREEN seam for WI-1b: the test cannot even compile until the bridging
+// these fail, the C interop (compile flags / bridging header) is broken —
+// which would block the WI-2 MobiToEPUBConverter entirely. This is the
+// RED→GREEN seam for WI-1b: the test cannot even compile until the bridging
 // header + project.yml wiring expose the libmobi symbols.
+//
+// Scope of the RUNTIME guarantee (Codex Gate-4 Low): these two cases prove
+// `mobi_version` and `mobi_init`/`mobi_free` resolve and run. They do NOT
+// exercise the USE_LIBXML2-gated xmlwriter/OPF path — that runs only inside a
+// real MOBI→EPUB conversion, which lands in WI-2 (and is verified there with a
+// real fixture). The libxml2 *link* is nonetheless already proven at build
+// time: xmlwriter.c references libxml2 symbols, so the app would fail to link
+// if `-lxml2` weren't resolving. Runtime coverage of that path is WI-2's job.
 
 import Testing
 @testable import vreader

--- a/vreaderTests/Services/Libmobi/LibmobiSmokeTests.swift
+++ b/vreaderTests/Services/Libmobi/LibmobiSmokeTests.swift
@@ -1,0 +1,25 @@
+// Feature #42 Phase 2 WI-1b: smoke test proving the vendored libmobi (LGPL-3.0)
+// C library links and is callable from Swift through the bridging header. If
+// these fail, the C interop (compile flags / bridging header / libxml2 link)
+// is broken — which would block the WI-2 MobiToEPUBConverter entirely. This is
+// the RED→GREEN seam for WI-1b: the test cannot even compile until the bridging
+// header + project.yml wiring expose the libmobi symbols.
+
+import Testing
+@testable import vreader
+
+@Suite("Libmobi C interop smoke (Feature #42 Phase 2 WI-1b)")
+struct LibmobiSmokeTests {
+
+    @Test("mobi_version() links and returns a non-empty version string")
+    func versionLinks() {
+        let v = Libmobi.version
+        #expect(v != nil, "mobi_version() must link + return — nil means the C symbol didn't resolve")
+        #expect(!(v ?? "").isEmpty, "version string must be non-empty")
+    }
+
+    @Test("mobi_init()/mobi_free() allocate + free a context at runtime")
+    func contextAllocatesAndFrees() {
+        #expect(Libmobi.contextAllocates(), "mobi_init() returned NULL — allocation/link failure")
+    }
+}


### PR DESCRIPTION
## Summary

WI-1a vendored libmobi but excluded it from the build. **WI-1b wires it in**: the 17 `src/*.c` now compile into the app target and their symbols link, exposed to Swift via a bridging header over the self-contained public umbrella `mobi.h`. libmobi is now **callable from Swift** at compile + runtime.

Part of feature #1234 (Phase 2).

## What changed
- **project.yml** — the libmobi C compiles in-target (`USE_LIBXML2=1`, the iOS SDK libxml2 include path, `-lxml2` link, the Libmobi src on the header path). Warning suppression (`-w`) is scoped **per-file** to the third-party C via its own source entry (not target-wide) so the app's own warning flags stay intact. Only the vendored docs/LICENSE are excluded.
- **Libmobi-Bridging-Header.h** — `#include "mobi.h"` (stdlib-only includes → no internal libmobi headers leak into the Swift module).
- **Libmobi.swift** — thin namespace: `version` (`mobi_version`) + `contextAllocates()` (`mobi_init`/`mobi_free`), proving linkage at compile + runtime.
- **LibmobiSmokeTests** — 2 Swift Testing cases, both PASS (`RUN-TESTS SUCCEEDED`): `mobi_version()` returns non-empty; `mobi_init()` returns non-NULL.

## Codex Audit
gpt-5.4 mini, 1 round, verdict **ship-as-is**. Medium (target-wide warning suppression) **fixed** → per-file `-w` scoping. Low (smoke doesn't exercise libxml2 path) **narrowed** → libxml2 link proven at build time, runtime path deferred to WI-2.
Audit log: `.claude/codex-audits/feat-feature-42-wi-p2-1b-libmobi-binding-audit.md`

## Validation
- [x] `** BUILD SUCCEEDED **` (17/17 libmobi `.c` compile in-target, libxml2 links)
- [x] Smoke tests pass (`RUN-TESTS RESULT: SUCCEEDED`) — runtime symbol resolution confirmed
- [x] Per-file `-w` scoping verified in pbxproj (target-wide flag removed)
- [x] Codex audit clean (ship-as-is)
- [x] Version bumped: 3.42.16 → 3.42.17

🤖 Generated with [Claude Code](https://claude.com/claude-code)