### PR TITLE
build: run-codex.sh watchdog + rule 53 — prevent Codex stdin-wedge ghosts

### DIFF
--- a/.claude/rules/53-codex-runner-isolation.md
+++ b/.claude/rules/53-codex-runner-isolation.md
@@ -1,0 +1,80 @@
+# 53 — Codex Runner Isolation (no more stdin-wedge ghosts)
+
+## The failure
+
+`codex exec "<prompt>"` passes the prompt as an argument but **also reads
+stdin**. In a non-tty shell — every `run_in_background` Bash, every cron-driven
+agent session — stdin never reaches EOF, so Codex prints
+
+```
+Reading additional input from stdin...
+```
+
+and **blocks forever at 0% CPU**. The process is a ghost: alive in `ps`, no
+output, no completion, no failure. Observed 2026-06-01: one such ghost lingered
+**4h20m**, and a freshly-launched audit wedged the same way the moment it ran in
+a backgrounded shell.
+
+This is the same class as:
+- **Rule 52** — the wedged `xcodebuild test` (0% CPU, lingers for hours).
+- **Rule 49** — the `pgrep -f` waiter that watches a class of work, not an
+  instance.
+
+A long-runner with no liveness signal and no timeout.
+
+## Aggravator (what made it invisible)
+
+Redirecting the backgrounded Codex's stdout to a side `/tmp` file
+(`codex exec … > /tmp/audit.txt`) instead of letting it flow to the task-output
+file. The task-output file then looked empty/dead, so the harness's own
+liveness display and completion notification had nothing to show — the wedge was
+invisible until someone ran `ps`.
+
+## Hard rules
+
+1. **Never call raw `codex exec` inside a backgrounded Bash.** Use
+   **`scripts/run-codex.sh`** (closes stdin, enforces a wall-clock watchdog on
+   the exact pid, prints one unambiguous `RUN-CODEX RESULT:` line) **or**
+   cc-suite's own `--background` runner (it has job tracking + a completion
+   signal). Both isolate stdin; a hand-rolled `codex exec` does not.
+2. **If you must call `codex exec` directly, close stdin: `< /dev/null`.** With
+   immediate EOF, Codex runs normally — it does not need stdin when the prompt
+   is an argument. This is the single load-bearing fix.
+3. **Do not redirect a backgrounded long-runner's stdout to a side file.** Let
+   it land in the task-output file so the harness's liveness + completion
+   notification work and a wedge is visible.
+4. **Diagnose "is it hung?" by PROCESS, not the output file** (rule 52's lesson,
+   applied to Codex):
+
+   ```bash
+   ps -Ao pid=,%cpu=,etime=,comm= | grep -i '[c]odex'
+   ```
+
+   A `codex` binary at **0% CPU with growing elapsed and no output growth** =
+   wedged. Kill it and re-run through the wrapper:
+
+   ```bash
+   pkill -9 -f "openai/codex.*/codex"
+   ```
+
+5. **Before ending a turn, confirm no live Codex ghost:** `pgrep -x codex`
+   (NOT `pgrep -f codex` — `-f` matches your own grep line). Zero = clean.
+
+## Quick reference
+
+```bash
+# Bounded, stdin-isolated Codex audit (default gpt-5.4 / medium / 300s):
+scripts/run-codex.sh -o /tmp/audit.txt "Audit these files: …"
+
+# Longer budget for a big review:
+CODEX_TIMEOUT_SECS=600 scripts/run-codex.sh -m gpt-5.5 -e high "…"
+```
+
+## Relationship to other rules
+
+- **Rule 49 (background shells):** the wrapper's watchdog waits on the exact pid
+  and is cancelled when Codex finishes first — it never re-arms on a future run.
+- **Rule 52 (test/sim isolation):** same ghost-class; same process-not-output
+  diagnosis. `run-codex.sh` is to `codex exec` what `run-tests.sh` is to
+  `xcodebuild test` — the watchdog that turns an indefinite hang into a bounded,
+  self-terminating run with one unambiguous result line.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 781
-        MARKETING_VERSION: 3.42.18
+        CURRENT_PROJECT_VERSION: 782
+        MARKETING_VERSION: 3.42.19
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/scripts/run-codex.sh
+++ b/scripts/run-codex.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# run-codex.sh — wrap `codex exec` with stdin isolation + a wall-clock watchdog
+# so a wedged Codex self-terminates instead of lingering for hours at 0% CPU.
+#
+# THE GHOST THIS PREVENTS (2026-06-01): `codex exec "<prompt>"` passes the prompt
+# as an arg but ALSO reads stdin. In a non-tty / `run_in_background` shell, stdin
+# never reaches EOF, so Codex prints `Reading additional input from stdin...` and
+# blocks FOREVER at 0% CPU — a ghost indistinguishable from a hang (one lingered
+# 4h20m). Same class as the xcodebuild ghost (rule 52) and the `pgrep -f` waiter
+# (rule 49): a long-runner with no liveness signal + no timeout.
+#
+# This wrapper:
+#   1. Closes stdin (`< /dev/null`) so Codex never blocks on it.
+#   2. Bounds the run with a watchdog on the EXACT pid (rule 49) — kills a wedge.
+#   3. Prints ONE unambiguous final line: `RUN-CODEX RESULT: SUCCEEDED|FAILED|TIMEOUT`.
+#
+# Usage:
+#   scripts/run-codex.sh [-m MODEL] [-e EFFORT] [-o OUTFILE] "<prompt>"
+# Env:
+#   CODEX_TIMEOUT_SECS  (default 300)
+#
+# Always invoke Codex through this wrapper (or cc-suite's own runner). Never call
+# raw `codex exec` inside a backgrounded Bash — see rule 53.
+set -uo pipefail
+
+TIMEOUT_SECS="${CODEX_TIMEOUT_SECS:-300}"
+MODEL="gpt-5.4"
+EFFORT="medium"
+OUT=""
+
+while getopts "m:e:o:" opt; do
+  case "$opt" in
+    m) MODEL="$OPTARG" ;;
+    e) EFFORT="$OPTARG" ;;
+    o) OUT="$OPTARG" ;;
+    *) echo "RUN-CODEX RESULT: FAILED (bad flag)"; exit 2 ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+PROMPT="${1:-}"
+if [ -z "$PROMPT" ]; then
+  echo "usage: run-codex.sh [-m MODEL] [-e EFFORT] [-o OUTFILE] \"<prompt>\"" >&2
+  echo "RUN-CODEX RESULT: FAILED (no prompt)"
+  exit 2
+fi
+
+OUT="${OUT:-$(mktemp -t run-codex.XXXXXX)}"
+
+# Launch Codex with stdin CLOSED (the load-bearing fix) and output to $OUT.
+codex exec --sandbox read-only -m "$MODEL" -c "model_reasoning_effort=$EFFORT" "$PROMPT" \
+  < /dev/null > "$OUT" 2>&1 &
+pid=$!
+
+# Watchdog tied to THIS exact pid (rule 49 — identity, not likeness). If Codex
+# is still alive after the budget, kill it and mark the wedge.
+( sleep "$TIMEOUT_SECS"
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -9 "$pid" 2>/dev/null
+    echo "__RUN_CODEX_WATCHDOG_KILLED__" >> "$OUT"
+  fi
+) &
+wd=$!
+
+wait "$pid"
+rc=$?
+# Cancel the watchdog if Codex finished first (it never re-arms on a later run).
+kill "$wd" 2>/dev/null
+wait "$wd" 2>/dev/null
+
+echo "----- codex output ($OUT) -----"
+cat "$OUT"
+echo "-------------------------------"
+
+if grep -q "__RUN_CODEX_WATCHDOG_KILLED__" "$OUT"; then
+  echo "RUN-CODEX RESULT: TIMEOUT (${TIMEOUT_SECS}s) — killed pid $pid"
+  exit 124
+elif [ "$rc" -eq 0 ]; then
+  echo "RUN-CODEX RESULT: SUCCEEDED"
+else
+  echo "RUN-CODEX RESULT: FAILED (codex exit $rc)"
+fi
+exit "$rc"

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7117,7 +7117,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 781;
+				CURRENT_PROJECT_VERSION = 782;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7125,7 +7125,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.18;
+				MARKETING_VERSION = 3.42.19;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7271,7 +7271,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 781;
+				CURRENT_PROJECT_VERSION = 782;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7279,7 +7279,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.18;
+				MARKETING_VERSION = 3.42.19;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
## Summary

Codex audits were being run via raw `codex exec` inside backgrounded shells. `codex exec` **also reads stdin**; in a non-tty shell stdin never EOFs, so Codex blocks forever at 0% CPU on `Reading additional input from stdin...` — a ghost indistinguishable from a hang (one lingered **4h20m** this session).

This is the same ghost-class as the wedged `xcodebuild test` (rule 52) and the `pgrep -f` waiter (rule 49): a long-runner with no liveness signal + no timeout.

## What changed
- **`scripts/run-codex.sh`** — closes stdin (`< /dev/null`, the load-bearing fix), bounds the run with a watchdog on the **exact pid** (rule 49), prints one unambiguous `RUN-CODEX RESULT: SUCCEEDED|FAILED|TIMEOUT` line. Same contract `run-tests.sh` gives `xcodebuild`.
- **`.claude/rules/53-codex-runner-isolation.md`** — makes it binding for all agents/crons: never raw `codex exec` in a backgrounded Bash; if direct, `< /dev/null`; don't side-redirect a backgrounded runner's stdout; diagnose by process CPU/elapsed, not the output file.

Meta-process change (no bug/feature row → exempt from the fix-or-implement merge gate).

## Validation
- [x] `bash -n` syntax OK; no-prompt path prints `RUN-CODEX RESULT: FAILED (no prompt)`
- [x] The `< /dev/null` fix already confirmed working this session (the WI-2a audit ran clean through it)
- [x] Version bumped: 3.42.18 → 3.42.19

🤖 Generated with [Claude Code](https://claude.com/claude-code)