### PR TITLE
feat(#42 P2-WI-2b): deterministic EPUB-assembly core (OPF + nav + container)

### DIFF
--- a/.claude/codex-audits/feat-feature-42-wi-p2-2b-epub-assembler-audit.md
+++ b/.claude/codex-audits/feat-feature-42-wi-p2-2b-epub-assembler-audit.md
@@ -1,0 +1,29 @@
+---
+branch: feat/feature-42-wi-p2-2b-epub-assembler
+threadId: codex-exec-gpt-5.4
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-01
+---
+
+# Codex audit — Feature #42 P2-WI-2b (EPUB assembly core)
+
+Runner: cc-suite via `scripts/run-codex.sh` (the new stdin-isolated watchdog
+wrapper — `RUN-CODEX RESULT: SUCCEEDED`, no ghost), gpt-5.4, medium, read-only.
+The escaper was confirmed correct (5 entities, `&` first); hrefs/ids are
+safe-by-construction (assembler-generated).
+
+## Round 1 findings + resolutions (all fixed)
+
+| file:line | sev | issue | resolution |
+|---|---|---|---|
+| MobiEPUBAssembler.swift:162 | High | `packageUUID` hashed only `part.data` → two part lists with identical bytes but different section/uid/extension collide on one `urn:uuid:` id. | **FIXED.** Now hashes a domain-separated, length-prefixed header (`section|uid|ext|byteCount\n`) before each payload. New test `idDependsOnStructureNotJustBytes` proves different uid / different section-bytes → different id. |
+| MobiEPUBAssembler.swift:128 | Medium | Zero markup → `<ol>` with no `<li>` = invalid EPUB3 nav, yet the package was emitted. | **FIXED.** `assemble` is now throwing and rejects zero markup with `MobiEPUBError.noMarkup` (mirrors the decode layer's `.noMarkup`; the real pipeline already guards it upstream). |
+| MobiEPUBAssemblerTests.swift:99 | Medium | The old `noMarkup` test only checked the opf, masking the invalid nav. | **FIXED.** Replaced with `zeroMarkupThrows` (asserts `.noMarkup`) + a new `navStructure` test that parses nav.xhtml and asserts one `<li>` per markup part. |
+| MobiEPUBAssembler.swift:172 | Low | `mediaType` lacked `mpg` though the decoder can emit it → wrong manifest type. | **FIXED.** Added `mpg`/`mpeg` → `video/mpeg`. |
+| MobiEPUBAssemblerTests.swift:74 | Low | Escaping test covered only the opf title, not nav, not all 5 entities. | **FIXED.** `titleEscapedEverywhere` asserts all 5 entities escaped + well-formed + raw title absent, in BOTH content.opf and nav.xhtml. |
+
+## Verdict
+
+ship-as-is after fixes — High + 2 Medium + 2 Low all resolved; suite green at
+9/9 (`RUN-TESTS RESULT: SUCCEEDED`).

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 782
-        MARKETING_VERSION: 3.42.19
+        CURRENT_PROJECT_VERSION: 783
+        MARKETING_VERSION: 3.42.20
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -452,6 +452,7 @@
 		4C47F172233199432FC289E3 /* ImportSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F84672A6E2EDD6E037AFD8 /* ImportSource.swift */; };
 		4C5F7C805D7702035CEA5837 /* NativeTextPaginatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295669F5B358B6C7BE41952E /* NativeTextPaginatorTests.swift */; };
 		4CACC9F4BA8C17144C30C113 /* BackgroundDownloadSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A04EAFA37410DA616E33D6 /* BackgroundDownloadSession.swift */; };
+		4CBBDD4F06D00C0A4A6E1716 /* MobiEPUBAssemblerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD27A5C682FAD0ED96FD755A /* MobiEPUBAssemblerTests.swift */; };
 		4CBBDDA7BEECCFF853B1D90C /* memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 33EA0E7BAE9970AB1E1CE063 /* memory.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		4CC9567091E0CABFDD800F6C /* AIConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52103AEAF5528A9DD58625E /* AIConfiguration.swift */; };
 		4CCBF4F6E186A7363A995303 /* ReaderContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB42EEEFFCAD8D654D57AE7 /* ReaderContainerView.swift */; };
@@ -757,6 +758,7 @@
 		80C8BBADB032CF847DC6CE17 /* DebugCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD2C3A426BB929B2462E439E /* DebugCommand.swift */; };
 		80CA0E4FF773CBEC357DF93D /* TOCBuilderMDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456FDDA03D7DEF3A4AEB01DB /* TOCBuilderMDTests.swift */; };
 		80CABDCB3569E07FE3AD3FD0 /* MockPositionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2355F0CDCE9B874D6BD148FB /* MockPositionStore.swift */; };
+		81335B193A21695719B19FC1 /* MobiEPUBAssembler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EC2FD8AA88F51D2C739C54 /* MobiEPUBAssembler.swift */; };
 		8146FBBF9AF55DA7C8B68FDB /* SourceSerif4-LICENSE.md in Resources */ = {isa = PBXBuildFile; fileRef = 0E32E90EB8316752FB90F6B5 /* SourceSerif4-LICENSE.md */; };
 		81498F908FAF97F421A3C35F /* AIReaderPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF113D7E83A1CE51F417258 /* AIReaderPanel.swift */; };
 		8178696A12B2FC6B462D9C3A /* LibraryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1563E77E28434568F45736 /* LibraryViewModelTests.swift */; };
@@ -1951,6 +1953,7 @@
 		529D0FB4C5C73B62F1C8D6D6 /* TXTChapterContentLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterContentLoader.swift; sourceTree = "<group>"; };
 		529E7234A3FC73811D573A6C /* SheetSectionContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetSectionContract.swift; sourceTree = "<group>"; };
 		52B46A5F229515020166A545 /* ReaderContainerView+DebugBridgeSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderContainerView+DebugBridgeSearch.swift"; sourceTree = "<group>"; };
+		52EC2FD8AA88F51D2C739C54 /* MobiEPUBAssembler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobiEPUBAssembler.swift; sourceTree = "<group>"; };
 		533D2D4F8B5502E8D51A714E /* EPUBTextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBTextExtractor.swift; sourceTree = "<group>"; };
 		53476F2A0426877FA297A911 /* TranslationStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationStyle.swift; sourceTree = "<group>"; };
 		5350DA755A0BB669AE8D3FBD /* BackupViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupViewModelTests.swift; sourceTree = "<group>"; };
@@ -2930,6 +2933,7 @@
 		FCC8C2B2EE71211499AA0EE4 /* AnnotationStreamItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationStreamItem.swift; sourceTree = "<group>"; };
 		FCDA968F8186B11859D8CCFE /* MDTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDTypes.swift; sourceTree = "<group>"; };
 		FD1989CF2F582B5C821059BA /* FoliateScrollModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateScrollModelTests.swift; sourceTree = "<group>"; };
+		FD27A5C682FAD0ED96FD755A /* MobiEPUBAssemblerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobiEPUBAssemblerTests.swift; sourceTree = "<group>"; };
 		FDEB28B2CAB1481C73FBE351 /* TestSeederMDMultiPagePaginationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSeederMDMultiPagePaginationTests.swift; sourceTree = "<group>"; };
 		FDF40785A923791B0241CF75 /* GlobalAccessibilityAuditTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalAccessibilityAuditTests.swift; sourceTree = "<group>"; };
 		FDFAF8770F91837F0B3793E1 /* ImportProvenanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportProvenanceTests.swift; sourceTree = "<group>"; };
@@ -3673,6 +3677,7 @@
 			children = (
 				89E60C649B564A45FD862030 /* LibmobiSmokeTests.swift */,
 				00FA26E476FF553131CD1EA7 /* MobiDocumentTests.swift */,
+				FD27A5C682FAD0ED96FD755A /* MobiEPUBAssemblerTests.swift */,
 			);
 			path = Libmobi;
 			sourceTree = "<group>";
@@ -3944,6 +3949,7 @@
 			children = (
 				02568BCB9C0024CD13E6B213 /* Libmobi.swift */,
 				E21A8FA98D52AD57B6C145B9 /* MobiDocument.swift */,
+				52EC2FD8AA88F51D2C739C54 /* MobiEPUBAssembler.swift */,
 			);
 			path = Libmobi;
 			sourceTree = "<group>";
@@ -5941,6 +5947,7 @@
 				1FC25DD5163814F8A1DF4EBF /* MigrationFixtureTests.swift in Sources */,
 				4930168887D85648F1EDA897 /* MigrationFixtures.swift in Sources */,
 				451D95C31492840BFA338F69 /* MobiDocumentTests.swift in Sources */,
+				4CBBDD4F06D00C0A4A6E1716 /* MobiEPUBAssemblerTests.swift in Sources */,
 				E057330B701161FF1AD06DB4 /* MockAnnotationStore.swift in Sources */,
 				7B9FDFE7688C6E45D59916CD /* MockBackupProvider.swift in Sources */,
 				A3B284AC778E4DC971B5E0A5 /* MockBookImporter.swift in Sources */,
@@ -6599,6 +6606,7 @@
 				15C15DFE4818EDE663481250 /* MarkdownExportFormatter.swift in Sources */,
 				AF7D99D9C0CEA266BFD976B8 /* MetadataExtractor.swift in Sources */,
 				38804060BFAD87B87936AF08 /* MobiDocument.swift in Sources */,
+				81335B193A21695719B19FC1 /* MobiEPUBAssembler.swift in Sources */,
 				8D6ECB8A09289C09C71F2047 /* ModelContainerFactory.swift in Sources */,
 				FE4AA790FC56F646C3E68DDE /* MonthBoundary.swift in Sources */,
 				1A7E58193D247BB8900BA5B3 /* NSUKVSBridge.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7125,7 +7125,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 782;
+				CURRENT_PROJECT_VERSION = 783;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7133,7 +7133,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.19;
+				MARKETING_VERSION = 3.42.20;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7279,7 +7279,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 782;
+				CURRENT_PROJECT_VERSION = 783;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7287,7 +7287,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.19;
+				MARKETING_VERSION = 3.42.20;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Services/Libmobi/MobiEPUBAssembler.swift
+++ b/vreader/Services/Libmobi/MobiEPUBAssembler.swift
@@ -25,6 +25,15 @@ struct EPUBFile: Equatable {
     let isStored: Bool
 }
 
+/// Errors from EPUB assembly.
+enum MobiEPUBError: Error, Equatable {
+    /// No markup parts → there is nothing to put in the spine or the TOC nav,
+    /// and an empty `<ol>` is invalid EPUB3. Mirrors the decode layer's
+    /// `MobiDecodeError.noMarkup`; in the real pipeline `decodeParts` already
+    /// rejects this, so reaching the assembler with zero markup is a bug.
+    case noMarkup
+}
+
 enum MobiEPUBAssembler {
 
     /// Lay out decoded MOBI `parts` into ordered EPUB file entries. Markup parts
@@ -36,7 +45,16 @@ enum MobiEPUBAssembler {
     /// The returned array is ordered `[mimetype, container.xml, content.opf,
     /// nav, …parts]` — WI-2c writes them in this order so `mimetype` lands
     /// first.
-    static func assemble(parts: [MobiPart], title: String) -> [EPUBFile] {
+    ///
+    /// - Throws: `MobiEPUBError.noMarkup` if there are no markup parts — an
+    ///   empty spine + empty TOC `<ol>` is invalid EPUB3, so reject rather than
+    ///   emit a malformed package (Codex Gate-4).
+    static func assemble(parts: [MobiPart], title: String) throws -> [EPUBFile] {
+        let markup = parts.filter { $0.section == .markup }
+        let flow = parts.filter { $0.section == .flow }
+        let resources = parts.filter { $0.section == .resource }
+        guard !markup.isEmpty else { throw MobiEPUBError.noMarkup }
+
         // Stable, content-addressed identifier — same MOBI → same EPUB id.
         let identifier = "urn:uuid:" + packageUUID(for: parts)
 
@@ -44,10 +62,6 @@ enum MobiEPUBAssembler {
         var manifest: [ManifestEntry] = []
         var spineIDs: [String] = []
         var files: [EPUBFile] = []
-
-        let markup = parts.filter { $0.section == .markup }
-        let flow = parts.filter { $0.section == .flow }
-        let resources = parts.filter { $0.section == .resource }
 
         for (i, part) in markup.enumerated() {
             let id = "html\(pad(i))"
@@ -161,7 +175,15 @@ enum MobiEPUBAssembler {
     /// same EPUB identity.
     private static func packageUUID(for parts: [MobiPart]) -> String {
         var hasher = SHA256()
-        for part in parts { hasher.update(data: part.data) }
+        for part in parts {
+            // Domain-separate each field so two part lists with identical bytes
+            // but different section / uid / extension cannot collide on one id
+            // (Codex Gate-4 High). The length-prefixed header + delimiter make
+            // the boundary between fields and payload unambiguous.
+            let header = "\(part.section)|\(part.uid)|\(part.fileExtension)|\(part.data.count)\n"
+            hasher.update(data: Data(header.utf8))
+            hasher.update(data: part.data)
+        }
         let hex = hasher.finalize().map { String(format: "%02x", $0) }.joined()
         // Shape the first 32 hex chars as 8-4-4-4-12.
         let h = Array(hex.prefix(32))
@@ -181,6 +203,7 @@ enum MobiEPUBAssembler {
         case "otf":           return "font/otf"
         case "ttf":           return "font/ttf"
         case "mp3":           return "audio/mpeg"
+        case "mpg", "mpeg":   return "video/mpeg"
         case "pdf":           return "application/pdf"
         default:              return "application/octet-stream"
         }

--- a/vreader/Services/Libmobi/MobiEPUBAssembler.swift
+++ b/vreader/Services/Libmobi/MobiEPUBAssembler.swift
@@ -1,0 +1,198 @@
+// Purpose: Feature #42 Phase 2 WI-2b — the deterministic EPUB-assembly core.
+// Given decoded MOBI parts (WI-2a's `MobiPart`s), lay out the EPUB's file
+// entries: a stable path for each part, a generated content.opf (manifest +
+// markup-ordered spine), an EPUB3 nav document, META-INF/container.xml, and the
+// mimetype. Pure + deterministic (no clock, no RNG — the package identifier is
+// the SHA-256 of the part bytes) → 100% CI-testable.
+//
+// WI-2c zips these `EPUBFile` entries into a `.epub` on disk (honoring the
+// stored-mimetype flag); WI-3 verifies href fidelity against a real Kindle book;
+// WI-4 wires the whole pipeline into BookImporter.
+//
+// @coordinates-with: MobiDocument.swift, Libmobi.swift,
+//   vreader/Services/Libmobi/BUILD-RECIPE.md
+
+import Foundation
+import CryptoKit
+
+/// One file destined for the EPUB OCF container.
+struct EPUBFile: Equatable {
+    /// Path relative to the EPUB root (e.g. `OEBPS/text/part0001.xhtml`).
+    let path: String
+    let data: Data
+    /// EPUB OCF requires the `mimetype` entry be STORED (uncompressed) and
+    /// first in the zip. WI-2c honors this flag when packaging.
+    let isStored: Bool
+}
+
+enum MobiEPUBAssembler {
+
+    /// Lay out decoded MOBI `parts` into ordered EPUB file entries. Markup parts
+    /// become the reading order (spine), in decode order; flow (CSS/SVG) and
+    /// resources (images/fonts) go in the manifest only. Filenames are
+    /// deterministic and stable so the OPF hrefs and the on-disk paths always
+    /// agree.
+    ///
+    /// The returned array is ordered `[mimetype, container.xml, content.opf,
+    /// nav, …parts]` — WI-2c writes them in this order so `mimetype` lands
+    /// first.
+    static func assemble(parts: [MobiPart], title: String) -> [EPUBFile] {
+        // Stable, content-addressed identifier — same MOBI → same EPUB id.
+        let identifier = "urn:uuid:" + packageUUID(for: parts)
+
+        // 1. Assign each part a stable path + manifest id, partitioned by section.
+        var manifest: [ManifestEntry] = []
+        var spineIDs: [String] = []
+        var files: [EPUBFile] = []
+
+        let markup = parts.filter { $0.section == .markup }
+        let flow = parts.filter { $0.section == .flow }
+        let resources = parts.filter { $0.section == .resource }
+
+        for (i, part) in markup.enumerated() {
+            let id = "html\(pad(i))"
+            let href = "text/part\(pad(i)).xhtml"
+            manifest.append(ManifestEntry(id: id, href: href, mediaType: "application/xhtml+xml"))
+            spineIDs.append(id)
+            files.append(EPUBFile(path: "OEBPS/\(href)", data: part.data, isStored: false))
+        }
+        for (i, part) in flow.enumerated() {
+            let ext = part.fileExtension.isEmpty ? "css" : part.fileExtension
+            let id = "flow\(pad(i))"
+            let href = "styles/flow\(pad(i)).\(ext)"
+            manifest.append(ManifestEntry(id: id, href: href, mediaType: mediaType(forExtension: ext)))
+            files.append(EPUBFile(path: "OEBPS/\(href)", data: part.data, isStored: false))
+        }
+        for (i, part) in resources.enumerated() {
+            let ext = part.fileExtension.isEmpty ? "bin" : part.fileExtension
+            let id = "res\(pad(i))"
+            let href = "resources/res\(pad(i)).\(ext)"
+            manifest.append(ManifestEntry(id: id, href: href, mediaType: mediaType(forExtension: ext)))
+            files.append(EPUBFile(path: "OEBPS/\(href)", data: part.data, isStored: false))
+        }
+
+        // 2. Generated documents.
+        let navEntry = ManifestEntry(id: "nav", href: "nav.xhtml",
+                                     mediaType: "application/xhtml+xml", properties: "nav")
+        let opf = contentOPF(identifier: identifier, title: title,
+                             manifest: manifest + [navEntry], spineIDs: spineIDs)
+        let nav = navDocument(title: title, markupHrefs: markup.indices.map { "text/part\(pad($0)).xhtml" })
+
+        // 3. Assemble in container order (mimetype FIRST + stored).
+        var result: [EPUBFile] = [
+            EPUBFile(path: "mimetype", data: Data("application/epub+zip".utf8), isStored: true),
+            EPUBFile(path: "META-INF/container.xml", data: Data(containerXML.utf8), isStored: false),
+            EPUBFile(path: "OEBPS/content.opf", data: Data(opf.utf8), isStored: false),
+            EPUBFile(path: "OEBPS/nav.xhtml", data: Data(nav.utf8), isStored: false),
+        ]
+        result.append(contentsOf: files)
+        return result
+    }
+
+    // MARK: - Generated XML
+
+    private static let containerXML = """
+    <?xml version="1.0" encoding="utf-8"?>
+    <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+      <rootfiles>
+        <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+      </rootfiles>
+    </container>
+    """
+
+    private static func contentOPF(identifier: String, title: String,
+                                   manifest: [ManifestEntry], spineIDs: [String]) -> String {
+        let items = manifest.map { entry -> String in
+            let props = entry.properties.map { " properties=\"\($0)\"" } ?? ""
+            return "    <item id=\"\(entry.id)\" href=\"\(entry.href)\" media-type=\"\(entry.mediaType)\"\(props)/>"
+        }.joined(separator: "\n")
+        let itemrefs = spineIDs.map { "    <itemref idref=\"\($0)\"/>" }.joined(separator: "\n")
+        return """
+        <?xml version="1.0" encoding="utf-8"?>
+        <package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="bookid">
+          <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <dc:identifier id="bookid">\(xmlEscape(identifier))</dc:identifier>
+            <dc:title>\(xmlEscape(title))</dc:title>
+            <dc:language>und</dc:language>
+          </metadata>
+          <manifest>
+        \(items)
+          </manifest>
+          <spine>
+        \(itemrefs)
+          </spine>
+        </package>
+        """
+    }
+
+    private static func navDocument(title: String, markupHrefs: [String]) -> String {
+        let items = markupHrefs.enumerated().map { i, href in
+            "        <li><a href=\"\(href)\">\(xmlEscape(title)) — \(i + 1)</a></li>"
+        }.joined(separator: "\n")
+        return """
+        <?xml version="1.0" encoding="utf-8"?>
+        <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+          <head><title>\(xmlEscape(title))</title></head>
+          <body>
+            <nav epub:type="toc" id="toc">
+              <ol>
+        \(items)
+              </ol>
+            </nav>
+          </body>
+        </html>
+        """
+    }
+
+    // MARK: - Helpers
+
+    private struct ManifestEntry {
+        let id: String
+        let href: String
+        let mediaType: String
+        var properties: String? = nil
+    }
+
+    /// 4-digit zero-padded index for stable, sortable filenames.
+    private static func pad(_ i: Int) -> String { String(format: "%04d", i) }
+
+    /// Deterministic identifier: SHA-256 over each part's bytes (order-sensitive),
+    /// formatted UUID-like. No clock / RNG, so the same MOBI always yields the
+    /// same EPUB identity.
+    private static func packageUUID(for parts: [MobiPart]) -> String {
+        var hasher = SHA256()
+        for part in parts { hasher.update(data: part.data) }
+        let hex = hasher.finalize().map { String(format: "%02x", $0) }.joined()
+        // Shape the first 32 hex chars as 8-4-4-4-12.
+        let h = Array(hex.prefix(32))
+        func seg(_ a: Int, _ b: Int) -> String { String(h[a..<b]) }
+        return "\(seg(0, 8))-\(seg(8, 12))-\(seg(12, 16))-\(seg(16, 20))-\(seg(20, 32))"
+    }
+
+    private static func mediaType(forExtension ext: String) -> String {
+        switch ext.lowercased() {
+        case "html", "xhtml": return "application/xhtml+xml"
+        case "css":           return "text/css"
+        case "svg":           return "image/svg+xml"
+        case "jpg", "jpeg":   return "image/jpeg"
+        case "png":           return "image/png"
+        case "gif":           return "image/gif"
+        case "bmp":           return "image/bmp"
+        case "otf":           return "font/otf"
+        case "ttf":           return "font/ttf"
+        case "mp3":           return "audio/mpeg"
+        case "pdf":           return "application/pdf"
+        default:              return "application/octet-stream"
+        }
+    }
+
+    /// Minimal XML text/attribute escaper (local to keep the feature self-
+    /// contained). Order matters: `&` first.
+    private static func xmlEscape(_ s: String) -> String {
+        s.replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&apos;")
+    }
+}

--- a/vreaderTests/Services/Libmobi/MobiEPUBAssemblerTests.swift
+++ b/vreaderTests/Services/Libmobi/MobiEPUBAssemblerTests.swift
@@ -1,0 +1,120 @@
+// Feature #42 Phase 2 WI-2b: the deterministic EPUB-assembly core. All cases are
+// CI-safe — they build synthetic MobiParts (no libmobi parse) and assert the
+// resulting EPUB file layout: mimetype-first/stored, a well-formed container.xml
+// + content.opf (manifest covers every part + nav, spine is markup in decode
+// order), part bytes at the manifest hrefs, XML-escaped title, deterministic +
+// content-addressed identity.
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("MOBI→EPUB assembler (Feature #42 Phase 2 WI-2b)")
+struct MobiEPUBAssemblerTests {
+
+    private func part(_ section: MobiPart.Section, _ uid: Int, _ ext: String, _ body: String) -> MobiPart {
+        MobiPart(section: section, uid: uid, fileExtension: ext, data: Data(body.utf8))
+    }
+
+    private var sampleParts: [MobiPart] {
+        [
+            part(.markup, 0, "html", "<html><body><p>Chapter 1</p></body></html>"),
+            part(.markup, 1, "html", "<html><body><p>Chapter 2</p></body></html>"),
+            part(.flow, 0, "css", "p { margin: 1em; }"),
+            part(.resource, 0, "jpg", "pretend-jpeg-bytes"),
+        ]
+    }
+
+    @Test("mimetype is first, stored, exactly application/epub+zip; nothing else stored")
+    func mimetypeFirstStored() {
+        let files = MobiEPUBAssembler.assemble(parts: sampleParts, title: "T")
+        #expect(files.first?.path == "mimetype")
+        #expect(files.first?.isStored == true)
+        #expect(String(decoding: files[0].data, as: UTF8.self) == "application/epub+zip")
+        #expect(files.dropFirst().allSatisfy { !$0.isStored })
+    }
+
+    @Test("container.xml points at OEBPS/content.opf and is well-formed XML")
+    func containerXMLValid() throws {
+        let files = MobiEPUBAssembler.assemble(parts: sampleParts, title: "T")
+        let container = try #require(files.first { $0.path == "META-INF/container.xml" })
+        let s = String(decoding: container.data, as: UTF8.self)
+        #expect(s.contains("full-path=\"OEBPS/content.opf\""))
+        #expect(isWellFormedXML(container.data))
+    }
+
+    @Test("content.opf manifests every part + nav, spine is markup in decode order")
+    func opfManifestAndSpine() throws {
+        let files = MobiEPUBAssembler.assemble(parts: sampleParts, title: "T")
+        let opf = try #require(files.first { $0.path == "OEBPS/content.opf" })
+        let s = String(decoding: opf.data, as: UTF8.self)
+        #expect(isWellFormedXML(opf.data))
+        #expect(s.contains("href=\"text/part0000.xhtml\" media-type=\"application/xhtml+xml\""))
+        #expect(s.contains("href=\"text/part0001.xhtml\""))
+        #expect(s.contains("href=\"styles/flow0000.css\" media-type=\"text/css\""))
+        #expect(s.contains("href=\"resources/res0000.jpg\" media-type=\"image/jpeg\""))
+        #expect(s.contains("properties=\"nav\""))
+        let spine = s.range(of: "<spine>").map { String(s[$0.upperBound...]) } ?? ""
+        let r0 = try #require(spine.range(of: "idref=\"html0000\""))
+        let r1 = try #require(spine.range(of: "idref=\"html0001\""))
+        #expect(r0.lowerBound < r1.lowerBound, "spine order must follow decode order")
+    }
+
+    @Test("part bytes land at the manifest hrefs; nav present")
+    func partFilesPresent() throws {
+        let files = MobiEPUBAssembler.assemble(parts: sampleParts, title: "T")
+        let p0 = try #require(files.first { $0.path == "OEBPS/text/part0000.xhtml" })
+        #expect(String(decoding: p0.data, as: UTF8.self).contains("Chapter 1"))
+        let css = try #require(files.first { $0.path == "OEBPS/styles/flow0000.css" })
+        #expect(String(decoding: css.data, as: UTF8.self).contains("margin"))
+        #expect(files.contains { $0.path == "OEBPS/resources/res0000.jpg" })
+        #expect(files.contains { $0.path == "OEBPS/nav.xhtml" })
+    }
+
+    @Test("title is XML-escaped in the opf")
+    func titleEscaped() {
+        let files = MobiEPUBAssembler.assemble(parts: sampleParts, title: "A & B <c>")
+        let opf = String(decoding: files.first { $0.path == "OEBPS/content.opf" }!.data, as: UTF8.self)
+        #expect(opf.contains("A &amp; B &lt;c&gt;"))
+        #expect(!opf.contains("<dc:title>A & B <c></dc:title>"))
+        #expect(isWellFormedXML(files.first { $0.path == "OEBPS/content.opf" }!.data))
+    }
+
+    @Test("assembly is deterministic — same parts yield byte-identical output")
+    func deterministic() {
+        #expect(MobiEPUBAssembler.assemble(parts: sampleParts, title: "T")
+                == MobiEPUBAssembler.assemble(parts: sampleParts, title: "T"))
+    }
+
+    @Test("package identifier is content-addressed — different content → different id")
+    func contentAddressedID() {
+        let a = idFromOPF(MobiEPUBAssembler.assemble(parts: sampleParts, title: "T"))
+        var other = sampleParts
+        other[0] = part(.markup, 0, "html", "<html><body>different content entirely</body></html>")
+        let b = idFromOPF(MobiEPUBAssembler.assemble(parts: other, title: "T"))
+        #expect(!a.isEmpty && !b.isEmpty)
+        #expect(a != b)
+    }
+
+    @Test("no markup → empty spine, but still a valid package")
+    func noMarkup() throws {
+        let resourceOnly = [part(.resource, 0, "png", "img")]
+        let files = MobiEPUBAssembler.assemble(parts: resourceOnly, title: "T")
+        let opf = try #require(files.first { $0.path == "OEBPS/content.opf" })
+        #expect(isWellFormedXML(opf.data))
+        #expect(String(decoding: opf.data, as: UTF8.self).contains("<spine>"))
+    }
+
+    // MARK: helpers
+
+    private func isWellFormedXML(_ data: Data) -> Bool {
+        XMLParser(data: data).parse()
+    }
+
+    private func idFromOPF(_ files: [EPUBFile]) -> String {
+        let opf = String(decoding: files.first { $0.path == "OEBPS/content.opf" }!.data, as: UTF8.self)
+        guard let r = opf.range(of: "<dc:identifier id=\"bookid\">"),
+              let end = opf.range(of: "</dc:identifier>") else { return "" }
+        return String(opf[r.upperBound..<end.lowerBound])
+    }
+}

--- a/vreaderTests/Services/Libmobi/MobiEPUBAssemblerTests.swift
+++ b/vreaderTests/Services/Libmobi/MobiEPUBAssemblerTests.swift
@@ -26,8 +26,8 @@ struct MobiEPUBAssemblerTests {
     }
 
     @Test("mimetype is first, stored, exactly application/epub+zip; nothing else stored")
-    func mimetypeFirstStored() {
-        let files = MobiEPUBAssembler.assemble(parts: sampleParts, title: "T")
+    func mimetypeFirstStored() throws {
+        let files = (try MobiEPUBAssembler.assemble(parts: sampleParts, title: "T"))
         #expect(files.first?.path == "mimetype")
         #expect(files.first?.isStored == true)
         #expect(String(decoding: files[0].data, as: UTF8.self) == "application/epub+zip")
@@ -36,7 +36,7 @@ struct MobiEPUBAssemblerTests {
 
     @Test("container.xml points at OEBPS/content.opf and is well-formed XML")
     func containerXMLValid() throws {
-        let files = MobiEPUBAssembler.assemble(parts: sampleParts, title: "T")
+        let files = (try MobiEPUBAssembler.assemble(parts: sampleParts, title: "T"))
         let container = try #require(files.first { $0.path == "META-INF/container.xml" })
         let s = String(decoding: container.data, as: UTF8.self)
         #expect(s.contains("full-path=\"OEBPS/content.opf\""))
@@ -45,7 +45,7 @@ struct MobiEPUBAssemblerTests {
 
     @Test("content.opf manifests every part + nav, spine is markup in decode order")
     func opfManifestAndSpine() throws {
-        let files = MobiEPUBAssembler.assemble(parts: sampleParts, title: "T")
+        let files = (try MobiEPUBAssembler.assemble(parts: sampleParts, title: "T"))
         let opf = try #require(files.first { $0.path == "OEBPS/content.opf" })
         let s = String(decoding: opf.data, as: UTF8.self)
         #expect(isWellFormedXML(opf.data))
@@ -62,7 +62,7 @@ struct MobiEPUBAssemblerTests {
 
     @Test("part bytes land at the manifest hrefs; nav present")
     func partFilesPresent() throws {
-        let files = MobiEPUBAssembler.assemble(parts: sampleParts, title: "T")
+        let files = (try MobiEPUBAssembler.assemble(parts: sampleParts, title: "T"))
         let p0 = try #require(files.first { $0.path == "OEBPS/text/part0000.xhtml" })
         #expect(String(decoding: p0.data, as: UTF8.self).contains("Chapter 1"))
         let css = try #require(files.first { $0.path == "OEBPS/styles/flow0000.css" })
@@ -71,38 +71,60 @@ struct MobiEPUBAssemblerTests {
         #expect(files.contains { $0.path == "OEBPS/nav.xhtml" })
     }
 
-    @Test("title is XML-escaped in the opf")
-    func titleEscaped() {
-        let files = MobiEPUBAssembler.assemble(parts: sampleParts, title: "A & B <c>")
-        let opf = String(decoding: files.first { $0.path == "OEBPS/content.opf" }!.data, as: UTF8.self)
-        #expect(opf.contains("A &amp; B &lt;c&gt;"))
-        #expect(!opf.contains("<dc:title>A & B <c></dc:title>"))
-        #expect(isWellFormedXML(files.first { $0.path == "OEBPS/content.opf" }!.data))
+    @Test("all five XML entities are escaped in BOTH content.opf and nav.xhtml")
+    func titleEscapedEverywhere() throws {
+        let nasty = "A & B < C > D \" E ' F"
+        let files = try MobiEPUBAssembler.assemble(parts: sampleParts, title: nasty)
+        for path in ["OEBPS/content.opf", "OEBPS/nav.xhtml"] {
+            let file = try #require(files.first { $0.path == path })
+            let s = String(decoding: file.data, as: UTF8.self)
+            #expect(s.contains("&amp;"))
+            #expect(s.contains("&lt;"))
+            #expect(s.contains("&gt;"))
+            #expect(s.contains("&quot;"))
+            #expect(s.contains("&apos;"))
+            // The raw, un-escaped title must not appear verbatim.
+            #expect(!s.contains(nasty))
+            // And the document stays well-formed after escaping.
+            #expect(isWellFormedXML(file.data))
+        }
     }
 
     @Test("assembly is deterministic — same parts yield byte-identical output")
-    func deterministic() {
-        #expect(MobiEPUBAssembler.assemble(parts: sampleParts, title: "T")
-                == MobiEPUBAssembler.assemble(parts: sampleParts, title: "T"))
+    func deterministic() throws {
+        #expect((try MobiEPUBAssembler.assemble(parts: sampleParts, title: "T"))
+                == (try MobiEPUBAssembler.assemble(parts: sampleParts, title: "T")))
     }
 
-    @Test("package identifier is content-addressed — different content → different id")
-    func contentAddressedID() {
-        let a = idFromOPF(MobiEPUBAssembler.assemble(parts: sampleParts, title: "T"))
-        var other = sampleParts
-        other[0] = part(.markup, 0, "html", "<html><body>different content entirely</body></html>")
-        let b = idFromOPF(MobiEPUBAssembler.assemble(parts: other, title: "T"))
-        #expect(!a.isEmpty && !b.isEmpty)
-        #expect(a != b)
+    @Test("package id depends on structure, not just bytes (section/uid/ext)")
+    func idDependsOnStructureNotJustBytes() throws {
+        // Same payload bytes, different section → must NOT collide on one id.
+        let a = idFromOPF(try MobiEPUBAssembler.assemble(
+            parts: [part(.markup, 0, "html", "<html/>"), part(.flow, 0, "css", "X")], title: "T"))
+        let b = idFromOPF(try MobiEPUBAssembler.assemble(
+            parts: [part(.markup, 0, "html", "<html/>"), part(.flow, 0, "css", "Y")], title: "T"))
+        let c = idFromOPF(try MobiEPUBAssembler.assemble(
+            parts: [part(.markup, 0, "html", "<html/>"), part(.flow, 1, "css", "X")], title: "T"))
+        #expect(a != b, "different flow bytes → different id")
+        #expect(a != c, "different uid (same bytes) → different id")
     }
 
-    @Test("no markup → empty spine, but still a valid package")
-    func noMarkup() throws {
+    @Test("zero markup is rejected with .noMarkup (invalid empty spine/TOC)")
+    func zeroMarkupThrows() {
         let resourceOnly = [part(.resource, 0, "png", "img")]
-        let files = MobiEPUBAssembler.assemble(parts: resourceOnly, title: "T")
-        let opf = try #require(files.first { $0.path == "OEBPS/content.opf" })
-        #expect(isWellFormedXML(opf.data))
-        #expect(String(decoding: opf.data, as: UTF8.self).contains("<spine>"))
+        #expect(throws: MobiEPUBError.noMarkup) {
+            _ = try MobiEPUBAssembler.assemble(parts: resourceOnly, title: "T")
+        }
+    }
+
+    @Test("nav.xhtml is well-formed and has one <li> per markup part")
+    func navStructure() throws {
+        let files = try MobiEPUBAssembler.assemble(parts: sampleParts, title: "T")
+        let nav = try #require(files.first { $0.path == "OEBPS/nav.xhtml" })
+        #expect(isWellFormedXML(nav.data))
+        let s = String(decoding: nav.data, as: UTF8.self)
+        // sampleParts has 2 markup parts → 2 <li>.
+        #expect(s.components(separatedBy: "<li>").count - 1 == 2)
     }
 
     // MARK: helpers


### PR DESCRIPTION
## Summary

Given decoded `MobiPart`s (WI-2a), `MobiEPUBAssembler.assemble` lays out the EPUB's file entries: stable per-part paths, a `content.opf` (manifest covers every part + nav; spine = markup in decode order), an EPUB3 nav doc, `META-INF/container.xml`, and the `mimetype` (stored, first). Pure + deterministic — the package id is the SHA-256 of the parts' structured fields — so the same MOBI yields the same EPUB identity. Part of feature #1234 (Phase 2).

## What changed
- **MobiEPUBAssembler.swift** — `assemble(parts:title:) throws -> [EPUBFile]`. Media-type mapping, XML-escaped metadata, content-addressed id, `mimetype`-stored-first ordering. Throws `MobiEPUBError.noMarkup` on zero markup (invalid empty spine/TOC).
- **MobiEPUBAssemblerTests** — 9 CI-safe tests (synthetic parts): mimetype first+stored, well-formed container/opf/nav via `XMLParser`, manifest+spine decode-order, part bytes at hrefs, all-5-entity escaping in opf+nav, deterministic output, structure-aware id, zero-markup rejection, nav `<li>`-per-markup.

## Codex Audit (via the new `run-codex.sh` watchdog)
gpt-5.4, 1 round, verdict **ship-as-is** after fixes. 1 High (id hashed only bytes → structure collisions) + 2 Medium (zero-markup invalid nav; test masked it) + 2 Low (mpg media-type; escaping coverage) — all fixed. Ran clean through the stdin-isolated wrapper (no ghost).
Audit log: `.claude/codex-audits/feat-feature-42-wi-p2-2b-epub-assembler-audit.md`

## Validation
- [x] `** BUILD SUCCEEDED **`
- [x] Suite 9/9 (`RUN-TESTS RESULT: SUCCEEDED`)
- [x] Codex audit clean (ship-as-is)
- [x] Version bumped: 3.42.19 → 3.42.20

🤖 Generated with [Claude Code](https://claude.com/claude-code)