### PR TITLE
feat(#42 P2-WI-2c): end-to-end MOBI→EPUB converter (real AZW3 → valid .epub)

### DIFF
--- a/.claude/codex-audits/feat-feature-42-wi-p2-2c-epub-package-audit.md
+++ b/.claude/codex-audits/feat-feature-42-wi-p2-2c-epub-package-audit.md
@@ -1,0 +1,31 @@
+---
+branch: feat/feature-42-wi-p2-2c-epub-package
+threadId: codex-exec-gpt-5.4
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-01
+---
+
+# Codex audit — Feature #42 P2-WI-2c (end-to-end MOBI→EPUB converter)
+
+Runner: cc-suite via `scripts/run-codex.sh` (stdin-isolated watchdog —
+`RUN-CODEX RESULT: SUCCEEDED`, no ghost), gpt-5.4, medium, read-only. Codex
+confirmed the wiring is correct: decode/assemble/package errors propagate,
+mimetype-first is guaranteed (assemble emits it first + ZIPWriter preserves
+order), Stored-only ZIP is valid EPUB OCF, and `convert()` is background-safe
+(no shared mutable state, Sendable values).
+
+## Round 1 findings + resolutions
+
+| file:line | sev | issue | resolution |
+|---|---|---|---|
+| MobiEPUBConverter.swift:38 | Medium | `package` relies on ZIPWriter storing every entry without proving it — a future ZIPWriter change could silently ship a non-compliant (deflated-mimetype) EPUB. | **FIXED (CI-gated).** Added `mimetypeRawHeaderIsStored`: parses the RAW first local-file-header (independent of ZIPWriter's own helpers) and asserts compression-method == 0 (Stored) + filename == "mimetype" + first. If ZIPWriter ever deflates, this fails before merge. `package()` doc now cites the guarding test. |
+| MobiEPUBConverterTests.swift:32 | Medium | Tests round-tripped only via ZIPWriter's own helpers, never inspecting raw ZIP headers → didn't prove the OCF Stored-mimetype invariant. | **FIXED.** Same raw-header test independently validates the local-file-header structure (signature, method, filename). |
+| MobiEPUBConverter.swift:39 | Low | ZIPWriter lives under `Services/Backup/` — a layering smell now that Libmobi depends on it. | **ACCEPTED w/ rationale.** ZIPWriter is pure/static/generic and vreader is a single module (no real import dependency — purely organizational). Relocating it is a separate Backup reorg; doing it as a drive-by in a Libmobi WI risks destabilizing Backup + its tests. Tracked as a future infra-tidy, not done here. |
+| MobiEPUBConverter.swift:29 | Low | Fully in-memory pipeline → ~2-3× peak RAM for image-heavy books. | **ACCEPTED + documented.** `convert()` doc now states the peak-memory behavior; acceptable for the current ≤~18 MB fixture range; flagged a file-backed archive path as a WI-4 option if larger Kindle books appear. |
+
+## Verdict
+
+ship-as-is — both Medium fixed (raw-header CI gate); both Low accepted with
+documented rationale. Suite 5/5 green (`RUN-TESTS SUCCEEDED`), incl. the real
+6 MB CJK AZW3 full-pipeline conversion to a structurally-valid .epub.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 783
-        MARKETING_VERSION: 3.42.20
+        CURRENT_PROJECT_VERSION: 784
+        MARKETING_VERSION: 3.42.21
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7133,7 +7133,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 783;
+				CURRENT_PROJECT_VERSION = 784;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7141,7 +7141,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.20;
+				MARKETING_VERSION = 3.42.21;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7287,7 +7287,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 783;
+				CURRENT_PROJECT_VERSION = 784;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7295,7 +7295,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.20;
+				MARKETING_VERSION = 3.42.21;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -449,6 +449,7 @@
 		4A87A6889CFFC099EE0AFBD6 /* SeriesTagPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58BA99C96063F3F0CA7A300 /* SeriesTagPersistenceTests.swift */; };
 		4A8B2E9CC8837F5523420479 /* TXTTextViewBridgeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96A115C3FA0B797030C1D1F /* TXTTextViewBridgeCoordinator.swift */; };
 		4BAFB4A830DDA62784FEBDA1 /* LibrarySectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012F237F2750DF33FC54AA26 /* LibrarySectionHeader.swift */; };
+		4BE98B3368624469680C5CD0 /* MobiEPUBConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1ABA7D279F0A44A754F582F /* MobiEPUBConverterTests.swift */; };
 		4C47F172233199432FC289E3 /* ImportSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F84672A6E2EDD6E037AFD8 /* ImportSource.swift */; };
 		4C5F7C805D7702035CEA5837 /* NativeTextPaginatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295669F5B358B6C7BE41952E /* NativeTextPaginatorTests.swift */; };
 		4CACC9F4BA8C17144C30C113 /* BackgroundDownloadSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A04EAFA37410DA616E33D6 /* BackgroundDownloadSession.swift */; };
@@ -468,6 +469,7 @@
 		4E41A2349D76D4F0814C3FF1 /* TXTViewConfigThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F3E6C42E1711EF70E585526 /* TXTViewConfigThemeTests.swift */; };
 		4EFC0ADF77B237B9D1D37A2F /* ChapterTranslationRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999E14A7BDE872FF420E5E37 /* ChapterTranslationRecord.swift */; };
 		4F2FEC62B6D23F67263EDF34 /* BackupProviderContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED150D276C082FEC194F2F31 /* BackupProviderContractTests.swift */; };
+		4F9B3604353932457F862A56 /* MobiEPUBConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6824BB10509996851B0E86C5 /* MobiEPUBConverter.swift */; };
 		4FDDEB10D3E2014D806618AD /* SyncConflictResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8188B21271D103070EE8CDE6 /* SyncConflictResolver.swift */; };
 		50214665FE48786605E6CF7E /* EPUBHighlightBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435C00E099B7F5D7A7821FDC /* EPUBHighlightBridge.swift */; };
 		505E3728FE1C69A31079DA9B /* ReaderBottomOverlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF9547D23D813327B536EAD5 /* ReaderBottomOverlayTests.swift */; };
@@ -2093,6 +2095,7 @@
 		67BCECCD4519E437A347DBA5 /* MDAttributedStringRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDAttributedStringRendererTests.swift; sourceTree = "<group>"; };
 		680CAEF6D5FC66EDF8844280 /* ReadiumBilingualCommander.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumBilingualCommander.swift; sourceTree = "<group>"; };
 		680EB356F2540A7274E57F1D /* BookDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailsViewModelTests.swift; sourceTree = "<group>"; };
+		6824BB10509996851B0E86C5 /* MobiEPUBConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobiEPUBConverter.swift; sourceTree = "<group>"; };
 		6831CFC733602179AD44E331 /* FoliateURLSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateURLSchemeHandler.swift; sourceTree = "<group>"; };
 		6832D0CE94B6D7181A2D82B0 /* V6toV7MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V6toV7MigrationTests.swift; sourceTree = "<group>"; };
 		685C8ADDC85C551C75E38594 /* WebDAVServerProfileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVServerProfileStore.swift; sourceTree = "<group>"; };
@@ -2678,6 +2681,7 @@
 		D1368D4DA7FCD1EC48778531 /* AIContextExtractorScopedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIContextExtractorScopedTests.swift; sourceTree = "<group>"; };
 		D14E222357346107CB34B750 /* SmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokeTests.swift; sourceTree = "<group>"; };
 		D17013114ADB4797AB48D794 /* FoliateViewBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateViewBridge.swift; sourceTree = "<group>"; };
+		D1ABA7D279F0A44A754F582F /* MobiEPUBConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobiEPUBConverterTests.swift; sourceTree = "<group>"; };
 		D1B00C0FE14AB02EDE7E9EDD /* SyncOutboundQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncOutboundQueueTests.swift; sourceTree = "<group>"; };
 		D1E644FA2FFCEBC9F45E1E6E /* SchemaV8MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV8MigrationTests.swift; sourceTree = "<group>"; };
 		D2AEB48E4BF208D97EEF397C /* QuoteRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuoteRecovery.swift; sourceTree = "<group>"; };
@@ -3678,6 +3682,7 @@
 				89E60C649B564A45FD862030 /* LibmobiSmokeTests.swift */,
 				00FA26E476FF553131CD1EA7 /* MobiDocumentTests.swift */,
 				FD27A5C682FAD0ED96FD755A /* MobiEPUBAssemblerTests.swift */,
+				D1ABA7D279F0A44A754F582F /* MobiEPUBConverterTests.swift */,
 			);
 			path = Libmobi;
 			sourceTree = "<group>";
@@ -3950,6 +3955,7 @@
 				02568BCB9C0024CD13E6B213 /* Libmobi.swift */,
 				E21A8FA98D52AD57B6C145B9 /* MobiDocument.swift */,
 				52EC2FD8AA88F51D2C739C54 /* MobiEPUBAssembler.swift */,
+				6824BB10509996851B0E86C5 /* MobiEPUBConverter.swift */,
 			);
 			path = Libmobi;
 			sourceTree = "<group>";
@@ -5948,6 +5954,7 @@
 				4930168887D85648F1EDA897 /* MigrationFixtures.swift in Sources */,
 				451D95C31492840BFA338F69 /* MobiDocumentTests.swift in Sources */,
 				4CBBDD4F06D00C0A4A6E1716 /* MobiEPUBAssemblerTests.swift in Sources */,
+				4BE98B3368624469680C5CD0 /* MobiEPUBConverterTests.swift in Sources */,
 				E057330B701161FF1AD06DB4 /* MockAnnotationStore.swift in Sources */,
 				7B9FDFE7688C6E45D59916CD /* MockBackupProvider.swift in Sources */,
 				A3B284AC778E4DC971B5E0A5 /* MockBookImporter.swift in Sources */,
@@ -6607,6 +6614,7 @@
 				AF7D99D9C0CEA266BFD976B8 /* MetadataExtractor.swift in Sources */,
 				38804060BFAD87B87936AF08 /* MobiDocument.swift in Sources */,
 				81335B193A21695719B19FC1 /* MobiEPUBAssembler.swift in Sources */,
+				4F9B3604353932457F862A56 /* MobiEPUBConverter.swift in Sources */,
 				8D6ECB8A09289C09C71F2047 /* ModelContainerFactory.swift in Sources */,
 				FE4AA790FC56F646C3E68DDE /* MonthBoundary.swift in Sources */,
 				1A7E58193D247BB8900BA5B3 /* NSUKVSBridge.swift in Sources */,

--- a/vreader/Services/Libmobi/MobiEPUBConverter.swift
+++ b/vreader/Services/Libmobi/MobiEPUBConverter.swift
@@ -23,6 +23,12 @@ enum MobiEPUBConverter {
     /// CPU- and memory-bound for a multi-megabyte book, so call off the main
     /// actor.
     ///
+    /// Peak memory note (Codex Gate-4 Low): the pipeline is fully in-memory —
+    /// the decoded parts, the assembled `EPUBFile` `Data` blobs, and the zip
+    /// archive coexist, so an image-heavy book sees ~2-3× its size in peak RAM.
+    /// Acceptable for the current fixture range (≤~18 MB); WI-4 may switch to a
+    /// file-backed archive path if larger Kindle books appear.
+    ///
     /// - Throws: `MobiDecodeError` (load/parse/corrupt/noMarkup) or
     ///   `MobiEPUBError` (assembly) or `ZIPWriterError` (packaging).
     static func convert(mobiPath: String, title: String) throws -> Data {
@@ -34,6 +40,13 @@ enum MobiEPUBConverter {
     /// Package already-assembled EPUB file entries into an OCF zip. Entry order
     /// is preserved, so the `mimetype` entry (first from `assemble`) lands first
     /// in the archive, as the OCF spec requires.
+    ///
+    /// OCF requires the `mimetype` entry be Stored (uncompressed). `ZIPWriter`
+    /// stores every entry, so this holds today; the invariant is CI-gated by
+    /// `MobiEPUBConverterTests.mimetypeRawHeaderIsStored`, which reads the raw
+    /// local-file-header compression-method field — if `ZIPWriter` ever starts
+    /// deflating, that test fails before this can ship a non-compliant EPUB
+    /// (Codex Gate-4 Medium).
     static func package(files: [EPUBFile]) throws -> Data {
         let entries = files.map { ZIPWriter.Entry(name: $0.path, data: $0.data) }
         return try ZIPWriter.createArchive(entries: entries)

--- a/vreader/Services/Libmobi/MobiEPUBConverter.swift
+++ b/vreader/Services/Libmobi/MobiEPUBConverter.swift
@@ -1,0 +1,41 @@
+// Purpose: Feature #42 Phase 2 WI-2c — the end-to-end MOBI→EPUB converter. Ties
+// the decode (WI-2a) and assembly (WI-2b) halves together and packages the
+// result into an actual `.epub` byte stream (a Stored-method OCF zip), ready to
+// write to disk and import through the Readium engine (WI-4).
+//
+//   decode (libmobi)  →  assemble (EPUB layout)  →  package (OCF zip)
+//
+// The packaging reuses `ZIPWriter` — generic, write-only, in-memory ZIP infra
+// (it writes every entry Stored/uncompressed, which is valid EPUB OCF and
+// satisfies the "mimetype must be stored" requirement; `assemble` emits the
+// mimetype first, and ZIPWriter preserves entry order, so it lands first).
+//
+// @coordinates-with: MobiDocument.swift, MobiEPUBAssembler.swift,
+//   vreader/Services/Backup/ZIPWriter.swift,
+//   vreader/Services/Libmobi/BUILD-RECIPE.md
+
+import Foundation
+
+enum MobiEPUBConverter {
+
+    /// Convert the Kindle file at `mobiPath` (AZW3/MOBI/KF8/PRC) into EPUB bytes:
+    /// decode via libmobi → lay out the EPUB → package as a Stored OCF zip.
+    /// CPU- and memory-bound for a multi-megabyte book, so call off the main
+    /// actor.
+    ///
+    /// - Throws: `MobiDecodeError` (load/parse/corrupt/noMarkup) or
+    ///   `MobiEPUBError` (assembly) or `ZIPWriterError` (packaging).
+    static func convert(mobiPath: String, title: String) throws -> Data {
+        let parts = try Libmobi.decodeParts(atPath: mobiPath)
+        let files = try MobiEPUBAssembler.assemble(parts: parts, title: title)
+        return try package(files: files)
+    }
+
+    /// Package already-assembled EPUB file entries into an OCF zip. Entry order
+    /// is preserved, so the `mimetype` entry (first from `assemble`) lands first
+    /// in the archive, as the OCF spec requires.
+    static func package(files: [EPUBFile]) throws -> Data {
+        let entries = files.map { ZIPWriter.Entry(name: $0.path, data: $0.data) }
+        return try ZIPWriter.createArchive(entries: entries)
+    }
+}

--- a/vreaderTests/Services/Libmobi/MobiEPUBConverterTests.swift
+++ b/vreaderTests/Services/Libmobi/MobiEPUBConverterTests.swift
@@ -58,6 +58,32 @@ struct MobiEPUBConverterTests {
         #expect(extracted == original)
     }
 
+    /// Independent of ZIPWriter's own read helpers: parse the RAW first local
+    /// file header and assert the EPUB-critical OCF invariant — `mimetype` is
+    /// the first entry AND is Stored (compression method 0). If ZIPWriter ever
+    /// starts deflating, this fails before a non-compliant EPUB can ship
+    /// (Codex Gate-4 Medium — enforces the storage contract package() relies on).
+    @Test("the first archive entry is mimetype, written Stored (method 0)")
+    func mimetypeRawHeaderIsStored() throws {
+        let bytes = [UInt8](try MobiEPUBConverter.package(files: try sampleFiles))
+        try #require(bytes.count > 30)
+        // Local file header signature 0x04034b50 (little-endian) at offset 0.
+        #expect(le32(bytes, 0) == 0x0403_4b50)
+        // Compression method (offset 8, u16 LE) must be 0 = Stored.
+        #expect(le16(bytes, 8) == 0, "mimetype must be Stored, not deflated, for OCF")
+        // Filename (length at offset 26, bytes at offset 30) must be "mimetype".
+        let nameLen = Int(le16(bytes, 26))
+        try #require(bytes.count >= 30 + nameLen)
+        #expect(String(decoding: bytes[30..<(30 + nameLen)], as: UTF8.self) == "mimetype")
+    }
+
+    private func le16(_ b: [UInt8], _ o: Int) -> UInt16 {
+        UInt16(b[o]) | (UInt16(b[o + 1]) << 8)
+    }
+    private func le32(_ b: [UInt8], _ o: Int) -> UInt32 {
+        UInt32(b[o]) | (UInt32(b[o + 1]) << 8) | (UInt32(b[o + 2]) << 16) | (UInt32(b[o + 3]) << 24)
+    }
+
     // MARK: Real-book end-to-end (SKIPPED in CI)
 
     @Test("a real AZW3 converts to a structurally-valid epub",

--- a/vreaderTests/Services/Libmobi/MobiEPUBConverterTests.swift
+++ b/vreaderTests/Services/Libmobi/MobiEPUBConverterTests.swift
@@ -1,0 +1,83 @@
+// Feature #42 Phase 2 WI-2c: the end-to-end MOBI→EPUB converter. CI-safe cases
+// package synthetic assembled files into an OCF zip and assert the archive shape
+// (mimetype first + exact, container/opf present, round-trippable). One real-AZW3
+// case runs the FULL decode→assemble→package pipeline against an actual Kindle
+// book, skipped when test-books/ is absent (CI) — the rendered-in-Readium proof
+// is WI-5's device verification.
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("MOBI→EPUB converter (Feature #42 Phase 2 WI-2c)")
+struct MobiEPUBConverterTests {
+
+    private func part(_ s: MobiPart.Section, _ uid: Int, _ ext: String, _ body: String) -> MobiPart {
+        MobiPart(section: s, uid: uid, fileExtension: ext, data: Data(body.utf8))
+    }
+
+    private var sampleFiles: [EPUBFile] {
+        get throws {
+            try MobiEPUBAssembler.assemble(parts: [
+                part(.markup, 0, "html", "<html><body><p>Ch1</p></body></html>"),
+                part(.markup, 1, "html", "<html><body><p>Ch2</p></body></html>"),
+                part(.flow, 0, "css", "p{}"),
+                part(.resource, 0, "jpg", "img-bytes"),
+            ], title: "T")
+        }
+    }
+
+    // MARK: CI-safe packaging (synthetic, no libmobi)
+
+    @Test("packaged epub is a valid zip with mimetype FIRST and exact content")
+    func packageMimetypeFirst() throws {
+        let epub = try MobiEPUBConverter.package(files: try sampleFiles)
+        let names = try ZIPWriter.listEntryNames(in: epub)
+        #expect(names.first == "mimetype", "OCF requires the mimetype entry first")
+        let mimetype = try ZIPWriter.extractEntry(named: "mimetype", from: epub)
+        #expect(String(decoding: mimetype, as: UTF8.self) == "application/epub+zip")
+    }
+
+    @Test("packaged epub contains container.xml + content.opf + part files")
+    func packageContainsStructure() throws {
+        let epub = try MobiEPUBConverter.package(files: try sampleFiles)
+        let names = Set(try ZIPWriter.listEntryNames(in: epub))
+        #expect(names.contains("META-INF/container.xml"))
+        #expect(names.contains("OEBPS/content.opf"))
+        #expect(names.contains("OEBPS/nav.xhtml"))
+        #expect(names.contains("OEBPS/text/part0000.xhtml"))
+        #expect(names.contains("OEBPS/resources/res0000.jpg"))
+    }
+
+    @Test("content.opf round-trips through the archive byte-identically")
+    func opfRoundTrips() throws {
+        let files = try sampleFiles
+        let original = try #require(files.first { $0.path == "OEBPS/content.opf" }).data
+        let epub = try MobiEPUBConverter.package(files: files)
+        let extracted = try ZIPWriter.extractEntry(named: "OEBPS/content.opf", from: epub)
+        #expect(extracted == original)
+    }
+
+    // MARK: Real-book end-to-end (SKIPPED in CI)
+
+    @Test("a real AZW3 converts to a structurally-valid epub",
+          .enabled(if: MobiDocumentTests.realAzw3Path != nil))
+    func realAzw3ConvertsToEPUB() throws {
+        let path = try #require(MobiDocumentTests.realAzw3Path)
+        let epub = try MobiEPUBConverter.convert(mobiPath: path, title: "Converted")
+
+        let names = try ZIPWriter.listEntryNames(in: epub)
+        #expect(names.first == "mimetype")
+        #expect(names.contains("OEBPS/content.opf"))
+        #expect(names.contains { $0.hasPrefix("OEBPS/text/part") }, "must carry markup")
+
+        // The OPF must declare a non-empty spine, and a markup part must be XHTML.
+        let opf = String(decoding: try ZIPWriter.extractEntry(named: "OEBPS/content.opf", from: epub),
+                         as: UTF8.self)
+        #expect(opf.contains("<itemref"))
+        let firstPart = try #require(names.first { $0.hasPrefix("OEBPS/text/part") })
+        let markup = String(decoding: try ZIPWriter.extractEntry(named: firstPart, from: epub),
+                            as: UTF8.self).lowercased()
+        #expect(markup.contains("<html") || markup.contains("<body") || markup.contains("<p"))
+    }
+}


### PR DESCRIPTION
## Summary

Ties WI-2a (decode) + WI-2b (assemble) together and packages the result into an actual `.epub`. `MobiEPUBConverter.convert(mobiPath:title:)` runs decode → assemble → `ZIPWriter` (Stored OCF zip, mimetype first). **Proven against the real 6 MB CJK AZW3**: the full pipeline produces a structurally-valid `.epub` (mimetype-first OCF, non-empty spine, XHTML markup) in 0.75 s. Part of feature #1234 (Phase 2).

## What changed
- **MobiEPUBConverter.swift** — `convert(mobiPath:title:)` (full pipeline) + `package(files:)` (the CI-testable zip step). Reuses `ZIPWriter` (generic Stored-method zip infra). Documents the peak-memory behavior + the OCF Stored-mimetype invariant.
- **MobiEPUBConverterTests** — 5 tests: CI-safe packaging (mimetype first+exact, container/opf/nav/parts present, opf byte-identical round-trip, **raw-header assertion that mimetype is Stored/method-0**) + one real-AZW3 full-pipeline conversion (`.enabled(if:)` skip in CI).

## Codex Audit (via `run-codex.sh` watchdog)
gpt-5.4, 1 round, **ship-as-is**. Wiring confirmed correct (error propagation, mimetype-first, Stored=valid OCF, background-safe). 2 Medium fixed (raw-header CI gate for the Stored invariant) + 2 Low accepted with documented rationale (ZIPWriter relocation = separate reorg; in-memory peak fine for current sizes).
Audit log: `.claude/codex-audits/feat-feature-42-wi-p2-2c-epub-package-audit.md`

## Validation
- [x] `** BUILD SUCCEEDED **`
- [x] Suite 5/5 (`RUN-TESTS RESULT: SUCCEEDED`) incl. real 6 MB CJK AZW3 → valid .epub
- [x] Codex audit clean (ship-as-is)
- [x] Version bumped: 3.42.20 → 3.42.21

🤖 Generated with [Claude Code](https://claude.com/claude-code)