### PR TITLE
feat(#42 P2-WI-4b): gated Kindle convert-on-import wiring in BookImporter

### DIFF
--- a/.claude/codex-audits/feat-feature-42-wi-p2-4b-importer-wiring-audit.md
+++ b/.claude/codex-audits/feat-feature-42-wi-p2-4b-importer-wiring-audit.md
@@ -1,0 +1,38 @@
+---
+branch: feat/feature-42-wi-p2-4b-importer-wiring
+threadId: codex-exec-gpt-5.4
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-02
+---
+
+# Codex audit — Feature #42 P2-WI-4b (Kindle convert-on-import wiring)
+
+Runner: cc-suite via `scripts/run-codex.sh` (watchdog — `RUN-CODEX RESULT:
+SUCCEEDED`, no ghost), gpt-5.4, high, read-only.
+
+## Verdict: CLEAN — no findings.
+
+The high-blast-radius BookImporter integration followed the 4-round Gate-2
+v4 design, so it audited clean on the first round. Codex confirmed each risk
+(all notes resolved `fix: none`):
+
+- **Threading complete** — every Step 4-13 consumer (text-validation, hash,
+  fingerprint, dedupe key, sandbox copy, metadata extractor, originalExtension,
+  EPUB pre-extract gate) uses `workingURL`/`workingFormat`; no downstream read
+  still uses the original `fileURL`/`format`. The dedupe early-return drops the
+  Kindle observability fields intentionally (best-effort, non-load-bearing).
+- **Security scope safe** — `startAccessingSecurityScopedResource` precedes the
+  detached conversion; `stopAccessing` runs only after `.value`. Access is
+  process-wide, so the detached `libmobi` read (a path string) stays in scope.
+- **Fallback boundary correct** — `MobiDecodeError`/`MobiEPUBError` → native
+  fallback; `ZIPWriterError`/file-write errors correctly propagate as real
+  import failures.
+- **Temp cleanup balanced** — the converted temp is copied to sandbox (Step 8)
+  then removed once by the outer `defer`; `convertToFile` only cleans its own
+  partial-write artifact. No leak / double-remove.
+- **Backward-compat decode** — new `ImportProvenance` fields are optional →
+  missing keys in pre-v3 payloads decode to nil. `isKindleConvertible` scoped to
+  canonical `.azw3`.
+
+ship-as-is.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 786
-        MARKETING_VERSION: 3.42.23
+        CURRENT_PROJECT_VERSION: 787
+        MARKETING_VERSION: 3.42.24
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7133,7 +7133,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 786;
+				CURRENT_PROJECT_VERSION = 787;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7141,7 +7141,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.23;
+				MARKETING_VERSION = 3.42.24;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7287,7 +7287,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 786;
+				CURRENT_PROJECT_VERSION = 787;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7295,7 +7295,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.23;
+				MARKETING_VERSION = 3.42.24;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Models/BookFormat.swift
+++ b/vreader/Models/BookFormat.swift
@@ -23,6 +23,13 @@ enum BookFormat: String, Codable, Hashable, Sendable, CaseIterable {
         true
     }
 
+    /// Feature #42 Phase 2: whether this format is a Kindle format eligible for
+    /// convert-on-import to EPUB. `.azw3` is the canonical Kindle format (it
+    /// subsumes azw/mobi/prc — see `fileExtensions`).
+    var isKindleConvertible: Bool {
+        self == .azw3
+    }
+
     /// Common file extensions for this format.
     var fileExtensions: [String] {
         switch self {

--- a/vreader/Models/ImportProvenance.swift
+++ b/vreader/Models/ImportProvenance.swift
@@ -15,4 +15,34 @@ struct ImportProvenance: Codable, Hashable, Sendable {
     /// NOTE: Contains file access metadata. V2 should encrypt at rest via keychain-backed key
     /// if store is synced or accessible outside sandbox.
     let originalURLBookmarkData: Data?
+
+    /// Feature #42 Phase 2 (WI-4b): the original Kindle extension (`azw3`/`mobi`/
+    /// `prc`/`azw`) when this book was produced by convert-on-import; nil
+    /// otherwise. **Best-effort, non-load-bearing** (WI-4 design decision #5):
+    /// the converted EPUB is a self-describing first-class EPUB, so nothing in
+    /// correctness/rendering/backup/restore depends on this — it is observability
+    /// only, and its loss on restore/dedupe-replace is acceptable.
+    let convertedFromKindleExtension: String?
+
+    /// The `MobiEPUBConverter.version` that produced the converted EPUB; nil for
+    /// non-converted books. Best-effort (see `convertedFromKindleExtension`).
+    let converterVersion: Int?
+
+    /// Optional fields default to nil so existing call sites are unchanged and
+    /// pre-v3 persisted/backup payloads (which lack the new keys) decode cleanly
+    /// — Swift's synthesized `Codable` uses `decodeIfPresent` for Optionals, so
+    /// a missing key → nil (round-3 audit Medium: backward-compatible decode).
+    init(
+        source: ImportSource,
+        importedAt: Date,
+        originalURLBookmarkData: Data?,
+        convertedFromKindleExtension: String? = nil,
+        converterVersion: Int? = nil
+    ) {
+        self.source = source
+        self.importedAt = importedAt
+        self.originalURLBookmarkData = originalURLBookmarkData
+        self.convertedFromKindleExtension = convertedFromKindleExtension
+        self.converterVersion = converterVersion
+    }
 }

--- a/vreader/Services/BookImporter.swift
+++ b/vreader/Services/BookImporter.swift
@@ -14,6 +14,7 @@
 //   CustomCoverStore.swift
 
 import Foundation
+import OSLog
 
 extension Notification.Name {
     /// Posted by `BookImporter` after a successful import — both new-row and
@@ -56,13 +57,20 @@ final class BookImporter: BookImporting, Sendable {
     /// Metadata extractors by format.
     private let extractors: [BookFormat: any MetadataExtractor]
 
+    /// Feature flags — gates Kindle convert-on-import (#42 Phase 2 WI-4b).
+    private let featureFlags: FeatureFlags
+
+    private static let log = Logger(subsystem: "com.vreader.app", category: "BookImporter")
+
     init(
         persistence: any BookPersisting,
         sandboxBooksDirectory: URL,
-        extractors: [BookFormat: any MetadataExtractor]? = nil
+        extractors: [BookFormat: any MetadataExtractor]? = nil,
+        featureFlags: FeatureFlags = .shared
     ) {
         self.persistence = persistence
         self.sandboxBooksDirectory = sandboxBooksDirectory
+        self.featureFlags = featureFlags
         self.extractors = extractors ?? [
             .txt: TXTMetadataExtractor(),
             .epub: EPUBMetadataExtractor(),
@@ -136,11 +144,54 @@ final class BookImporter: BookImporting, Sendable {
             throw ImportError.fileNotReadable("File does not exist or is not readable")
         }
 
+        // Step 3.5 (Feature #42 Phase 2 WI-4b): Kindle convert-on-import (gated,
+        // default OFF). When ON and the file is a Kindle format, convert it to a
+        // self-describing EPUB and run the ENTIRE rest of the pipeline over the
+        // converted file — so identity/fingerprint/blob/metadata are all the
+        // EPUB's (a first-class EPUB; design decisions #1/#2). The source's own
+        // title/author/cover are baked into the EPUB (WI-4a), so the downstream
+        // EPUBMetadataExtractor recovers correct display metadata from the blob.
+        var workingURL = fileURL
+        var workingFormat = format
+        var convertedTempURL: URL? = nil
+        var kindleOriginExtension: String? = nil
+        defer {
+            // The converted EPUB is a temp file; it's copied into the sandbox by
+            // Step 8, so clean up the temp on every exit path.
+            if let temp = convertedTempURL { try? FileManager.default.removeItem(at: temp) }
+        }
+        if featureFlags.isEnabled(.kindleConvertOnImport), format.isKindleConvertible {
+            do {
+                let tempDir = FileManager.default.temporaryDirectory
+                let sourcePath = fileURL.path
+                // Off-main: libmobi decode + EPUB packaging is CPU-bound (design
+                // decision #6 — never block the @MainActor importer entry).
+                let converted = try await Task.detached(priority: .userInitiated) {
+                    try MobiEPUBConverter.convertToFile(mobiPath: sourcePath, destinationDir: tempDir)
+                }.value
+                convertedTempURL = converted
+                kindleOriginExtension = fileURL.pathExtension.lowercased()
+                workingURL = converted
+                workingFormat = .epub
+                Self.log.info("Kindle convert-on-import: converted source to EPUB")
+            } catch let error as MobiDecodeError {
+                // SEMANTIC failure (DRM/corrupt/no-markup) → import the original
+                // Kindle file natively; the user never loses the ability to
+                // import a book the converter can't yet handle (decision #8).
+                Self.log.warning("Kindle conversion failed semantically (\(String(describing: error), privacy: .public)) — importing native")
+            } catch let error as MobiEPUBError {
+                Self.log.warning("Kindle conversion failed (assembly: \(String(describing: error), privacy: .public)) — importing native")
+            }
+            // A filesystem/ZIPWriter write failure is NOT caught here → it
+            // propagates as a real import error (decision #8 — IO faults are not
+            // silently masked as a fallback).
+        }
+
         // Step 4: Text-specific validation (binary masquerade + encoding detection)
         // Only reads first 64KB for detection to avoid full-file memory spike.
         var detectedEncoding: String? = nil
-        if format == .txt || format == .md {
-            let sampleData = try readFileDataSample(at: fileURL, maxBytes: 64 * 1024)
+        if workingFormat == .txt || workingFormat == .md {
+            let sampleData = try readFileDataSample(at: workingURL, maxBytes: 64 * 1024)
             do {
                 let encodingResult = try EncodingDetector.detect(data: sampleData)
                 detectedEncoding = EncodingDetector.encodingName(encodingResult.encoding)
@@ -151,14 +202,15 @@ final class BookImporter: BookImporting, Sendable {
             }
         }
 
-        // Step 5: Compute content hash
-        let hashResult = try await ContentHasher.hash(fileAt: fileURL)
+        // Step 5: Compute content hash (of the working file — the converted EPUB
+        // when convert-on-import ran, else the original).
+        let hashResult = try await ContentHasher.hash(fileAt: workingURL)
 
         // Step 6: Build fingerprint
         guard let fingerprint = DocumentFingerprint.validated(
             contentSHA256: hashResult.sha256Hex,
             fileByteCount: hashResult.byteCount,
-            format: format
+            format: workingFormat
         ) else {
             throw ImportError.hashComputationFailed("Invalid hash result")
         }
@@ -220,11 +272,12 @@ final class BookImporter: BookImporting, Sendable {
             )
         }
 
-        // Step 8: Copy to sandbox (atomic: temp + rename)
+        // Step 8: Copy to sandbox (atomic: temp + rename). Copies the WORKING
+        // file — the converted EPUB when convert-on-import ran.
         let sandboxCopy = try atomicCopyToSandbox(
-            sourceURL: fileURL,
+            sourceURL: workingURL,
             fingerprintKey: fingerprintKey,
-            format: format
+            format: workingFormat
         )
         let sandboxURL = sandboxCopy.url
 
@@ -235,11 +288,14 @@ final class BookImporter: BookImporting, Sendable {
             try? FileManager.default.removeItem(at: sandboxURL)
         }
 
-        // Step 9: Extract metadata from original URL (sandbox filename is hash-based)
-        let extractor = extractors[format] ?? TXTMetadataExtractor()
+        // Step 9: Extract metadata from the working URL (sandbox filename is
+        // hash-based). For a converted Kindle book the working file is the
+        // self-describing EPUB, so EPUBMetadataExtractor recovers the source's
+        // title/author/cover (baked in by WI-4a) — correct display metadata.
+        let extractor = extractors[workingFormat] ?? TXTMetadataExtractor()
         let metadata: BookMetadata
         do {
-            metadata = try await extractor.extractMetadata(from: fileURL)
+            metadata = try await extractor.extractMetadata(from: workingURL)
         } catch let importErr as ImportError {
             rollbackSandboxIfOwned()
             throw importErr
@@ -255,11 +311,14 @@ final class BookImporter: BookImporting, Sendable {
             }
         }
 
-        // Step 10: Build provenance
+        // Step 10: Build provenance. When convert-on-import ran, record the
+        // Kindle origin (best-effort, non-load-bearing — design decision #5).
         let provenance = ImportProvenance(
             source: source,
             importedAt: Date(),
-            originalURLBookmarkData: nil
+            originalURLBookmarkData: nil,
+            convertedFromKindleExtension: kindleOriginExtension,
+            converterVersion: kindleOriginExtension == nil ? nil : MobiEPUBConverter.version
         )
 
         // Step 11: Persist book record
@@ -267,7 +326,11 @@ final class BookImporter: BookImporting, Sendable {
         // it on a fresh device. Particularly matters for MOBI/PRC/AZW which all
         // collapse to canonical BookFormat.azw3 — without this, restore loses
         // the user's original extension.
-        let pathExt = fileURL.pathExtension.lowercased()
+        // The canonical blob extension is the WORKING file's — "epub" for a
+        // converted Kindle book (the blob IS an EPUB; the original Kindle
+        // extension lives in provenance, Step 10). Restore reconstructs the
+        // blob from this, so it must match the stored bytes.
+        let pathExt = workingURL.pathExtension.lowercased()
         let originalExt: String? = pathExt.isEmpty ? nil : pathExt
         // Bug #247: when the caller (typically the WebDAV restore path)
         // supplies a non-empty title override, it wins over the extractor's

--- a/vreaderTests/Models/ImportProvenanceTests.swift
+++ b/vreaderTests/Models/ImportProvenanceTests.swift
@@ -62,6 +62,42 @@ struct ImportProvenanceTests {
         #expect(decoded.source == .shareSheet)
     }
 
+    // MARK: - Feature #42 Phase 2 WI-4b: Kindle-origin fields (backward-compat)
+
+    /// A payload encoded BEFORE the Kindle-origin fields existed must still
+    /// decode (the new Optional fields → nil via `decodeIfPresent`). Encoding the
+    /// old shape with the same encoder guarantees an identical Date format etc.
+    @Test func decodesPreV3PayloadWithoutKindleFields() throws {
+        struct OldProvenance: Encodable {
+            let source: ImportSource
+            let importedAt: Date
+            let originalURLBookmarkData: Data?
+        }
+        let oldData = try JSONEncoder().encode(OldProvenance(
+            source: .filesApp,
+            importedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            originalURLBookmarkData: nil))
+
+        let decoded = try JSONDecoder().decode(ImportProvenance.self, from: oldData)
+        #expect(decoded.source == .filesApp)
+        #expect(decoded.convertedFromKindleExtension == nil)
+        #expect(decoded.converterVersion == nil)
+    }
+
+    @Test func codableRoundTripWithKindleOrigin() throws {
+        let original = ImportProvenance(
+            source: .filesApp,
+            importedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            originalURLBookmarkData: nil,
+            convertedFromKindleExtension: "azw3",
+            converterVersion: 1)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ImportProvenance.self, from: data)
+        #expect(decoded == original)
+        #expect(decoded.convertedFromKindleExtension == "azw3")
+        #expect(decoded.converterVersion == 1)
+    }
+
     // MARK: - Hashable
 
     @Test func equalProvenancesHaveSameHash() {

--- a/vreaderTests/Services/BookImporterTests.swift
+++ b/vreaderTests/Services/BookImporterTests.swift
@@ -40,15 +40,115 @@ struct BookImporterTests {
 
     private func makeImporter(
         persistence: MockPersistenceActor? = nil,
-        sandboxDir: URL? = nil
+        sandboxDir: URL? = nil,
+        featureFlags: FeatureFlags? = nil
     ) async throws -> (BookImporter, MockPersistenceActor, URL) {
         let mock = persistence ?? MockPersistenceActor()
         let sandbox = try sandboxDir ?? makeSandboxDir()
         let importer = BookImporter(
             persistence: mock,
-            sandboxBooksDirectory: sandbox
+            sandboxBooksDirectory: sandbox,
+            featureFlags: featureFlags ?? FeatureFlags(environment: .prod)
         )
         return (importer, mock, sandbox)
+    }
+
+    /// First real AZW3 under `<repo>/test-books/books/azw3`, or nil in CI.
+    /// Repo root derived from this source file's path (no hard-coded username).
+    private static var realAzw3Path: String? {
+        let dir = URL(fileURLWithPath: #filePath)   // …/vreaderTests/Services/<this>
+            .deletingLastPathComponent()            // Services/
+            .deletingLastPathComponent()            // vreaderTests/
+            .deletingLastPathComponent()            // <repo root>
+            .appendingPathComponent("test-books/books/azw3")
+        guard let items = try? FileManager.default.contentsOfDirectory(atPath: dir.path),
+              let azw3 = items.first(where: { $0.lowercased().hasSuffix(".azw3") })
+        else { return nil }
+        return dir.appendingPathComponent(azw3).path
+    }
+
+    /// Copy the real AZW3 fixture to a temp `.azw3` the importer can consume.
+    private func copyRealAzw3ToTemp() throws -> URL? {
+        guard let path = Self.realAzw3Path else { return nil }
+        let dest = FileManager.default.temporaryDirectory
+            .appendingPathComponent("import-azw3-\(UUID().uuidString).azw3")
+        try FileManager.default.copyItem(at: URL(fileURLWithPath: path), to: dest)
+        return dest
+    }
+
+    // MARK: - Feature #42 Phase 2 WI-4b: Kindle convert-on-import (gated)
+
+    @Test("flag OFF + AZW3 → imported as native .azw3 (today's behavior)")
+    func convertOnImportFlagOffKeepsAzw3() async throws {
+        guard let azw3 = try copyRealAzw3ToTemp() else { return }  // CI / no fixture
+        defer { try? FileManager.default.removeItem(at: azw3) }
+        let flags = FeatureFlags(environment: .prod)  // kindleConvertOnImport default OFF
+        let (importer, _, sandbox) = try await makeImporter(featureFlags: flags)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let result = try await importer.importFile(at: azw3, source: .filesApp)
+        #expect(result.fingerprint.format == .azw3, "flag OFF must import natively")
+    }
+
+    @Test("flag ON + AZW3 → imported as a first-class .epub with Kindle origin recorded")
+    func convertOnImportFlagOnProducesEpub() async throws {
+        guard let azw3 = try copyRealAzw3ToTemp() else { return }
+        defer { try? FileManager.default.removeItem(at: azw3) }
+        let flags = FeatureFlags(environment: .prod)
+        flags.setOverride(true, for: .kindleConvertOnImport)
+        let (importer, _, sandbox) = try await makeImporter(featureFlags: flags)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let result = try await importer.importFile(at: azw3, source: .filesApp)
+        // Identity is the converted EPUB's — format .epub, self-consistent.
+        #expect(result.fingerprint.format == .epub, "flag ON must convert to EPUB")
+        #expect(result.provenance.convertedFromKindleExtension == "azw3")
+        #expect(result.provenance.converterVersion == MobiEPUBConverter.version)
+        // Display metadata recovered from the self-describing EPUB.
+        #expect(!result.title.isEmpty)
+        // Re-import the same AZW3 dedupes (deterministic conversion → same key).
+        let again = try await importer.importFile(at: azw3, source: .filesApp)
+        #expect(again.fingerprintKey == result.fingerprintKey)
+        #expect(again.isDuplicate)
+    }
+
+    @Test("flag ON + non-Kindle (txt) → untouched, no conversion")
+    func convertOnImportIgnoresNonKindle() async throws {
+        let txt = try makeTempTxtFile(content: "plain text body for import")
+        defer { try? FileManager.default.removeItem(at: txt) }
+        let flags = FeatureFlags(environment: .prod)
+        flags.setOverride(true, for: .kindleConvertOnImport)
+        let (importer, _, sandbox) = try await makeImporter(featureFlags: flags)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let result = try await importer.importFile(at: txt, source: .filesApp)
+        #expect(result.fingerprint.format == .txt)
+    }
+
+    @Test("flag ON + unconvertible .azw3 → semantic failure is caught, falls back to native")
+    func convertOnImportFallsBackOnSemanticFailure() async throws {
+        // A non-Kindle file masquerading as .azw3 → libmobi load fails →
+        // MobiDecodeError. The importer must CATCH it and fall back to native
+        // import, never propagate the conversion error. CI-safe (synthetic).
+        let fake = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fake-\(UUID().uuidString).azw3")
+        try Data("not a real kindle file, just text".utf8).write(to: fake)
+        defer { try? FileManager.default.removeItem(at: fake) }
+        let flags = FeatureFlags(environment: .prod)
+        flags.setOverride(true, for: .kindleConvertOnImport)
+        let (importer, _, sandbox) = try await makeImporter(featureFlags: flags)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        do {
+            let result = try await importer.importFile(at: fake, source: .filesApp)
+            // Fallback succeeded → imported natively (still .azw3, NOT .epub).
+            #expect(result.fingerprint.format == .azw3)
+        } catch is MobiDecodeError {
+            Issue.record("conversion MobiDecodeError must NOT propagate — fallback should swallow it")
+        } catch {
+            // The native importer may itself reject the fake file; acceptable —
+            // the guarantee under test is that the conversion error was caught.
+        }
     }
 
     // MARK: - Happy Path: TXT Import


### PR DESCRIPTION
## Summary

The behavioral slice that makes Kindle convert-on-import functional (Gate-2-approved v4 design, 4 audit rounds). **Flag default OFF → no behavior change.** When `kindleConvertOnImport` is ON and the file is a Kindle format, `BookImporter` converts it to a self-describing EPUB **off-main**, then runs the entire existing pipeline over the converted file — so identity/fingerprint/blob/metadata are all the EPUB's (a first-class EPUB). The real CJK AZW3 imports as a converted EPUB with recovered title/author/cover. Part of feature #1234 (Phase 2).

## What changed
- **BookImporter** — Step 3.5 converts (`Task.detached`, off-main) → reassigns `workingURL`/`workingFormat` for Steps 4-13. Semantic failure (`MobiDecodeError`/`MobiEPUBError`) → native fallback; IO/write failure → real error. Converted temp cleaned via `defer`. `featureFlags` injected.
- **ImportProvenance** — optional `convertedFromKindleExtension` + `converterVersion` (best-effort, non-load-bearing); backward-compat decode (missing keys → nil).
- **BookFormat** — `isKindleConvertible`.

## Codex Audit (via `run-codex.sh` watchdog)
gpt-5.4 high, 1 round, verdict **CLEAN — no findings**. Verified: threading completeness (every Step 4-13 uses the working URL/format), security-scope lifetime safe across the detached read, fallback boundary correct, temp cleanup balanced (no leak/double-remove), backward-compat decode sound.
Audit log: `.claude/codex-audits/feat-feature-42-wi-p2-4b-importer-wiring-audit.md`

## Validation
- [x] `** BUILD SUCCEEDED **`
- [x] BookImporter 24 tests (incl. flag-OFF→azw3, flag-ON→epub+provenance+dedupe on the real CJK AZW3, non-Kindle untouched, semantic-failure fallback) + ImportProvenance 13 (pre-v3 decode + round-trip)
- [x] Codex audit CLEAN
- [x] Version bumped: 3.42.23 → 3.42.24

🤖 Generated with [Claude Code](https://claude.com/claude-code)