### PR TITLE
docs(#306): verification-exception evidence file

### DIFF
--- a/dev-docs/verification/bug-306-20260602.md
+++ b/dev-docs/verification/bug-306-20260602.md
@@ -1,0 +1,54 @@
+---
+kind: bug
+id: 306
+status_target: FIXED
+commit_sha: 12c4e328d5757c3cffdbc50eff55a0d821015174
+app_version: "3.42.28 (791)"
+date: 2026-06-02
+verifier: claude
+device_or_simulator: iPhone 17 Pro Simulator (test host)
+os_version: iOS 26.4
+build_configuration: Debug
+backend: n/a
+result: pass
+---
+
+# Bug #306 — translation cache unreachable behind the provider gate
+
+## Verification: verification-exception (high-fidelity integration test)
+
+The production failure — an already-translated chapter re-failing when AI is
+disabled/unconfigured/key-less — requires a populated translation cache AND a
+provider-config resolution that throws. The fix is verified through a
+high-fidelity integration test that drives the SAME real subsystem boundaries
+the production path hits: the `ChapterTranslationStore` actor (real SwiftData
+in-memory container) + the `ChapterTranslationService` actor + the real
+`ChapterTranslationRecord.lookupKey` + segment-count freshness gate.
+
+## Acceptance criteria
+
+| Criterion | Test | Result |
+|---|---|---|
+| A fresh cached row is served WITHOUT any provider config | `cacheHitNeedsNoConfig` | ✅ |
+| Cache miss → nil (caller falls through to the provider gate) | `cacheMiss` | ✅ |
+| Stale row (source paragraph count changed) → nil, not a wrong render | `staleCacheReturnsNil` | ✅ |
+| Different provider profile id misses (key includes the profile) | `differentProfileMisses` | ✅ |
+| Prefetcher consults the cache BEFORE `resolveProviderConfig` | code review (Codex CLEAN) + the reorder | ✅ |
+
+## Commands run
+
+```bash
+scripts/run-tests.sh vreaderTests/ChapterTranslationCacheLookupTests
+# RUN-TESTS RESULT: SUCCEEDED — 4 tests
+```
+
+## Observations
+
+The new `cachedTranslation` shares the exact lookupKey + freshness gate with
+`translate()` (Codex-verified), so a pre-gate hit is identical to the in-`translate`
+hit — no divergence. The prefetcher reorder fetches source once, checks cache,
+and resolves config only on a miss.
+
+## Artifacts
+
+- Test suite `vreaderTests/Services/AI/ChapterTranslationCacheLookupTests.swift`.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 791
-        MARKETING_VERSION: 3.42.28
+        CURRENT_PROJECT_VERSION: 792
+        MARKETING_VERSION: 3.42.29
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7145,7 +7145,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 791;
+				CURRENT_PROJECT_VERSION = 792;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7153,7 +7153,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.28;
+				MARKETING_VERSION = 3.42.29;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7299,7 +7299,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 791;
+				CURRENT_PROJECT_VERSION = 792;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7307,7 +7307,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.28;
+				MARKETING_VERSION = 3.42.29;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
Evidence file for Bug #306's verification-exception close (GH #1361 already closed citing it). High-fidelity integration test (`ChapterTranslationCacheLookupTests`) at the real ChapterTranslationStore + ChapterTranslationService boundaries.

Version bumped: 3.42.28 → 3.42.29

🤖 Generated with [Claude Code](https://claude.com/claude-code)