### PR TITLE
feat(#76 WI-2): axis-aware scrolled container layout

### DIFF
--- a/.claude/codex-audits/feat-feature-76-wi-2-container-axis-layout-audit.md
+++ b/.claude/codex-audits/feat-feature-76-wi-2-container-axis-layout-audit.md
@@ -1,0 +1,49 @@
+---
+branch: feat/feature-76-wi-2-container-axis-layout
+threadId: 019e8705-06d8-7153-a223-74002f91292e
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-02
+---
+
+# Codex audit — Feature #76 WI-2 (axis-aware scrolled container layout)
+
+Independent Codex audit (cc-suite via `scripts/run-codex.sh`, model `gpt-5.5`,
+effort `high`, read-only) of WI-2: the scrolled-mode `#container` now lays out
+sections along the active scroll axis (`#applyScrolledContainerAxis`) so the
+windowed surface (WI-3) accumulates in the right direction for vertical-writing
+AZW3/MOBI. Horizontal-writing (#73) stays byte-identical.
+
+- Round 1 session: `019e8705-06d8-7153-a223-74002f91292e`
+- Round 2 session: `019e870c-9ac5-7b93-a4c0-c5279f83491e`
+
+## Scope
+
+- `vreader/Services/Foliate/JS/paginator.js` (`#applyScrolledContainerAxis` + call in `#display` and the `flow` `attributeChangedCallback`)
+- `vreader/Services/Foliate/JS/foliate-bundle.js` (rebuilt via `build-bundle.sh`)
+- `vreaderTests/Services/Foliate/FoliateVerticalContainerLayoutTests.swift` (new, 5 source↔bundle contract tests)
+
+## Round 1 — findings
+
+| Severity | Issue | Resolution |
+|---|---|---|
+| **High** | `flexDirection: row-reverse` for `directionSign < 0` DOUBLE-reverses vertical-rl, because the host already forces `dir=rtl` for every vertical book (`paginator.js:~1146`, incl. vertical-lr) and `direction` inherits into the shadow tree; vertical-lr was also mismatched (forced rtl despite `directionSign:+1`). | FIXED — the helper now sets `flexDirection: 'row'` (plain) + an EXPLICIT `direction = directionSign < 0 ? 'rtl' : 'ltr'`, and resets `direction` too in the horizontal-writing branch. Round 2 confirmed this matches `#axisScrollOffset`'s sign handling for both vertical-rl (negative scrollLeft) and vertical-lr; the container direction governs flex-child order without affecting iframe document contents. |
+| **Medium** | A paged→scrolled `flow` switch re-rendered but never applied the layout, so a vertical book could enter scrolled mode block-stacked until the next navigation. | FIXED — `attributeChangedCallback('flow')` now calls `if (this.scrolled && this.#view) this.#applyScrolledContainerAxis()` after `render()` and before `#ensureWindow()`. Round 2 confirmed placement/gating. |
+| **Low** | The reset test only checked for any `removeProperty`, and didn't inspect the bundle body. | FIXED — asserts `removeProperty('display'/'flex-direction'/'direction')` in BOTH source and bundle, quote-agnostic (esbuild rewrites to double quotes). |
+
+## Round 2 — verification
+
+HIGH + MEDIUM confirmed **resolved**. Two minor new findings:
+
+| Severity | Issue | Resolution |
+|---|---|---|
+| Medium | The new test file was untracked while `project.pbxproj` referenced it (working-tree-only observation). | Non-issue — the file is committed together with the pbxproj change in this WI's commit. |
+| Low | The ordering test matched the flow-callback call first (both call sites are correct, but `#display`'s ordering was under-pinned). | FIXED — the test now scopes the before-`#ensureWindow` ordering assertion to the extracted `#display` body specifically. |
+
+## Verdict
+
+**ship-as-is.** Build + 5 WI-2 tests + existing Foliate parity suites
+(`FoliatePaginatorScrollBoundaryTests` 15/15, `FoliateTapToleranceBundleTests` 4/4)
+GREEN; the horizontal-writing #73 path is byte-identical (the vertical-axis branch
+leaves no inline style). WI-2 is the layout substrate; WI-3 removes the
+`#ensureWindow` `#vertical` gate, WI-4/5/6 verify (incl. the large-CJK memory gate).

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 799
-        MARKETING_VERSION: 3.42.36
+        CURRENT_PROJECT_VERSION: 800
+        MARKETING_VERSION: 3.42.37
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7185,7 +7185,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 799;
+				CURRENT_PROJECT_VERSION = 800;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7193,7 +7193,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.36;
+				MARKETING_VERSION = 3.42.37;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7339,7 +7339,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 799;
+				CURRENT_PROJECT_VERSION = 800;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7347,7 +7347,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.36;
+				MARKETING_VERSION = 3.42.37;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -480,6 +480,7 @@
 		50526F6EDA9CF826BAB1552B /* ReadiumDecorationTapEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5FC69D853F6222ADED7DB9 /* ReadiumDecorationTapEventTests.swift */; };
 		505E3728FE1C69A31079DA9B /* ReaderBottomOverlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF9547D23D813327B536EAD5 /* ReaderBottomOverlayTests.swift */; };
 		50837395A5CDCDFC14CF2B64 /* PDFPasswordPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425829C48779CD64EB0C5A05 /* PDFPasswordPromptView.swift */; };
+		5088375DABF1823ED1BA0CC8 /* FoliateVerticalContainerLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8EE09BCDCB14CCFAA6A943D /* FoliateVerticalContainerLayoutTests.swift */; };
 		50CB24522FC7CCD97EE58224 /* ReaderBottomChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76B2024F008B3A41C030585 /* ReaderBottomChrome.swift */; };
 		50D3F5B291DB7188E2BB0442 /* BackupBookProjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFABA0F5E3E749CC8108947C /* BackupBookProjectionTests.swift */; };
 		51099F95B7DD54CD3D90C23B /* LazyDownloadFinalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E2A8F2AD957F6A16BC7C4F /* LazyDownloadFinalizer.swift */; };
@@ -2849,6 +2850,7 @@
 		E84B53D4E30D6614436E4C68 /* SearchResultsGroupedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsGroupedList.swift; sourceTree = "<group>"; };
 		E861A379A620B769CEA36300 /* AIChatViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatViewModelTests.swift; sourceTree = "<group>"; };
 		E8CFB25779576176F1D678C7 /* PDFBilingualPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFBilingualPanelState.swift; sourceTree = "<group>"; };
+		E8EE09BCDCB14CCFAA6A943D /* FoliateVerticalContainerLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateVerticalContainerLayoutTests.swift; sourceTree = "<group>"; };
 		E94F1579C79832BB2EEDEB05 /* TXTChapterIndexStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterIndexStoreTests.swift; sourceTree = "<group>"; };
 		E97DAB513E717D83CD9ED3F7 /* TTSProviderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSProviderProtocol.swift; sourceTree = "<group>"; };
 		E998CB9F64AEAFC0D2A42C46 /* SettingsRowPalette+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsRowPalette+SwiftUI.swift"; sourceTree = "<group>"; };
@@ -5401,6 +5403,7 @@
 				C91F653CA8E9B107CA2CA4CA /* FoliateTOCConverterTests.swift */,
 				0C511C16F7FA93E91D703EE7 /* FoliateTTSAdapterTests.swift */,
 				432F646AE5FB7BFD06470EB5 /* FoliateURLSchemeHandlerTests.swift */,
+				E8EE09BCDCB14CCFAA6A943D /* FoliateVerticalContainerLayoutTests.swift */,
 			);
 			path = Foliate;
 			sourceTree = "<group>";
@@ -5900,6 +5903,7 @@
 				1558B65D447DCD7705FE074C /* FoliateTTSAdapterTests.swift in Sources */,
 				8AD533CDAFAC138CA7E20D75 /* FoliateTapToleranceBundleTests.swift in Sources */,
 				DCE7A66917407F83D657A63B /* FoliateURLSchemeHandlerTests.swift in Sources */,
+				5088375DABF1823ED1BA0CC8 /* FoliateVerticalContainerLayoutTests.swift in Sources */,
 				6E94155F0ECDFD59EAAAD010 /* FoliateViewCoordinatorTests.swift in Sources */,
 				D2A9D9BF75759BDA0213247F /* FontSizeCalibrationMeasurementTests.swift in Sources */,
 				F5C06CBFBB03CA953526172B /* FontSizeCalibrationTests.swift in Sources */,

--- a/vreader/Services/Foliate/JS/foliate-bundle.js
+++ b/vreader/Services/Foliate/JS/foliate-bundle.js
@@ -4792,6 +4792,7 @@ ${doc.querySelector("parsererror").innerText}`);
           switch (name) {
             case "flow":
               this.render();
+              if (this.scrolled && this.#view) this.#applyScrolledContainerAxis();
               if (this.#windowedScroll && this.scrolled && this.#view) this.#ensureWindow();
               break;
             case "gap":
@@ -4967,6 +4968,29 @@ ${doc.querySelector("parsererror").innerText}`);
         // the horizontal-tb model when no view is mounted.
         get #activeScrollModel() {
           return this.#view?.scrollModel ?? scrollModelFor("horizontal-tb");
+        }
+        // Feature #76 WI-2: lay out scrolled-mode sections along the ACTIVE SCROLL
+        // AXIS, so the windowed surface (WI-3) accumulates in the right direction.
+        // Horizontal-writing (vertical scroll, axis='vertical') keeps the default
+        // BLOCK stacking — no inline style is set, so the #73 path is byte-identical.
+        // Vertical-writing (horizontal scroll, axis='horizontal') stacks sections in
+        // a flex row so they accumulate along the horizontal axis; vertical-rl
+        // (directionSign < 0, later content extends leftward) uses `row-reverse`.
+        // Idempotent + reversible (a re-display with a different writing-mode resets
+        // the inline style), and called from #display BEFORE the windowing gate so it
+        // applies even while #ensureWindow still returns early for vertical (WI-3
+        // removes that gate).
+        #applyScrolledContainerAxis() {
+          const m3 = this.#activeScrollModel;
+          if (m3.axis === "horizontal") {
+            this.#container.style.display = "flex";
+            this.#container.style.flexDirection = "row";
+            this.#container.style.direction = m3.directionSign < 0 ? "rtl" : "ltr";
+          } else {
+            this.#container.style.removeProperty("display");
+            this.#container.style.removeProperty("flex-direction");
+            this.#container.style.removeProperty("direction");
+          }
         }
         // Logical (non-negative, reading-order) scroll offset of the container along
         // the active axis. For vertical-rl, WebKit's `scrollLeft` is negative toward
@@ -5404,6 +5428,7 @@ ${doc.querySelector("parsererror").innerText}`);
           }
           await this.scrollToAnchor((typeof anchor === "function" ? anchor(this.#view.document) : anchor) ?? 0, select);
           if (hasFocus) this.focusView();
+          if (this.scrolled) this.#applyScrolledContainerAxis();
           if (this.scrolled && this.#windowedScroll) this.#ensureWindow();
         }
         #canGoToIndex(index) {

--- a/vreader/Services/Foliate/JS/paginator.js
+++ b/vreader/Services/Foliate/JS/paginator.js
@@ -698,6 +698,12 @@ export class Paginator extends HTMLElement {
         switch (name) {
             case 'flow':
                 this.render()
+                // Feature #76 WI-2 (Gate-4 Medium): a paged→scrolled flow switch
+                // re-renders but the initial #display's container-axis pass may
+                // have run while still paginated — re-orient the container BEFORE
+                // (re)building the window, so a vertical book entering scrolled
+                // mode doesn't stay block-stacked until the next navigation.
+                if (this.scrolled && this.#view) this.#applyScrolledContainerAxis()
                 // Feature #73 WI-3: the initial #display may have run while flow
                 // was still paginated (so its #ensureWindow was gated out). When
                 // flow becomes 'scrolled', (re)build the windowed neighbour set.
@@ -930,6 +936,38 @@ export class Paginator extends HTMLElement {
     // the horizontal-tb model when no view is mounted.
     get #activeScrollModel() {
         return this.#view?.scrollModel ?? scrollModelFor('horizontal-tb')
+    }
+    // Feature #76 WI-2: lay out scrolled-mode sections along the ACTIVE SCROLL
+    // AXIS, so the windowed surface (WI-3) accumulates in the right direction.
+    // Horizontal-writing (vertical scroll, axis='vertical') keeps the default
+    // BLOCK stacking — no inline style is set, so the #73 path is byte-identical.
+    // Vertical-writing (horizontal scroll, axis='horizontal') stacks sections in
+    // a flex row so they accumulate along the horizontal axis; vertical-rl
+    // (directionSign < 0, later content extends leftward) uses `row-reverse`.
+    // Idempotent + reversible (a re-display with a different writing-mode resets
+    // the inline style), and called from #display BEFORE the windowing gate so it
+    // applies even while #ensureWindow still returns early for vertical (WI-3
+    // removes that gate).
+    #applyScrolledContainerAxis() {
+        const m = this.#activeScrollModel
+        if (m.axis === 'horizontal') {
+            this.#container.style.display = 'flex'
+            this.#container.style.flexDirection = 'row'
+            // Gate-4 High: the host forces `dir=rtl` for EVERY vertical book
+            // (`:1146`, incl. vertical-lr), and `direction` inherits into the
+            // shadow tree — so a `row-reverse` here would DOUBLE-reverse
+            // vertical-rl and vertical-lr would still mismatch. Instead set the
+            // container's logical direction EXPLICITLY from the scroll model and
+            // keep a plain `row`: vertical-rl (directionSign < 0) → `rtl` (later
+            // sections extend leftward, scroll origin on the right, matching
+            // WebKit's negative scrollLeft that `#axisScrollOffset` un-signs);
+            // vertical-lr → `ltr`.
+            this.#container.style.direction = m.directionSign < 0 ? 'rtl' : 'ltr'
+        } else {
+            this.#container.style.removeProperty('display')
+            this.#container.style.removeProperty('flex-direction')
+            this.#container.style.removeProperty('direction')
+        }
     }
     // Logical (non-negative, reading-order) scroll offset of the container along
     // the active axis. For vertical-rl, WebKit's `scrollLeft` is negative toward
@@ -1444,6 +1482,11 @@ export class Paginator extends HTMLElement {
         await this.scrollToAnchor((typeof anchor === 'function'
             ? anchor(this.#view.document) : anchor) ?? 0, select)
         if (hasFocus) this.focusView()
+        // Feature #76 WI-2: orient the scrolled container along the active scroll
+        // axis BEFORE the windowing math — runs for vertical-writing even though
+        // #ensureWindow still gates it out (WI-3). Horizontal-writing is a no-op
+        // (block stacking, byte-identical to #73).
+        if (this.scrolled) this.#applyScrolledContainerAxis()
         // Feature #73 WI-2: after the anchor section renders, mount the
         // neighbour window so the scrolled surface spans multiple sections.
         // Gated on #windowedScroll (OFF by default → paged + non-windowed

--- a/vreaderTests/Services/Foliate/FoliateVerticalContainerLayoutTests.swift
+++ b/vreaderTests/Services/Foliate/FoliateVerticalContainerLayoutTests.swift
@@ -1,0 +1,165 @@
+// Purpose: Feature #76 WI-2 — the scrolled-mode `#container` must lay out
+// sections along the ACTIVE SCROLL AXIS so the windowed surface (WI-3)
+// accumulates in the right direction for vertical-writing AZW3/MOBI (the Bug
+// #283 chapter-boundary jump). Horizontal-writing (vertical scroll) keeps the
+// default block stacking — byte-identical to Feature #73.
+//
+// The layout runs inside a WKWebView, so the runtime path is not unit-testable
+// directly. Following the FoliatePaginatorScrollBoundaryTests pattern, this file
+// pins the static contract: both the source `paginator.js` and the built
+// `foliate-bundle.js` declare `#applyScrolledContainerAxis`, invoke it from
+// `#display` BEFORE the windowing gate (so it runs for vertical even while
+// `#ensureWindow` still returns early — WI-3 removes that gate), and the helper
+// orients the container by the ScrollModel axis (flex row / row-reverse for
+// vertical-writing; reset to block for horizontal-writing).
+//
+// @coordinates-with: vreader/Services/Foliate/JS/paginator.js,
+//   vreader/Services/Foliate/JS/foliate-bundle.js, FoliateScrollModelTests.swift
+
+import Testing
+import Foundation
+
+@Suite("Foliate paginator — WI-2 axis-aware scrolled container layout (Feature #76 / Bug #283)")
+struct FoliateVerticalContainerLayoutTests {
+
+    private func loadBundle() throws -> String {
+        let candidates: [Bundle] = [Bundle(for: BundleToken.self), .main]
+        for c in candidates {
+            if let url = c.url(forResource: "foliate-bundle", withExtension: "js") {
+                return try String(contentsOf: url, encoding: .utf8)
+            }
+        }
+        throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "foliate-bundle.js not found"])
+    }
+
+    private func loadSource() throws -> String {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent()
+            .deletingLastPathComponent().deletingLastPathComponent()
+        let url = repoRoot.appendingPathComponent("vreader/Services/Foliate/JS/paginator.js")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    // MARK: - Declaration + call wired (source + bundle parity)
+
+    @Test("source + bundle both declare #applyScrolledContainerAxis")
+    func declaresHelper() throws {
+        let src = try loadSource(), bundle = try loadBundle()
+        #expect(src.contains("#applyScrolledContainerAxis"),
+                "paginator.js must declare #applyScrolledContainerAxis (WI-2).")
+        #expect(bundle.contains("#applyScrolledContainerAxis"),
+                "foliate-bundle.js must declare #applyScrolledContainerAxis — run build-bundle.sh after editing paginator.js.")
+    }
+
+    @Test("source + bundle both invoke this.#applyScrolledContainerAxis()")
+    func invokesHelper() throws {
+        let src = try loadSource(), bundle = try loadBundle()
+        #expect(src.contains("this.#applyScrolledContainerAxis()"),
+                "paginator.js must call #applyScrolledContainerAxis — declaring without calling is dead code.")
+        #expect(bundle.contains("this.#applyScrolledContainerAxis()"),
+                "foliate-bundle.js must call #applyScrolledContainerAxis — rebuild the bundle.")
+    }
+
+    // MARK: - Helper body: axis-aware orientation
+
+    @Test("helper orients the container by explicit DIRECTION (not row-reverse) for vertical-writing")
+    func helperOrientsVerticalWriting() throws {
+        let body = extractHelperBody(try loadSource(), name: "#applyScrolledContainerAxis")
+        #expect(!body.isEmpty, "could not locate #applyScrolledContainerAxis body")
+        #expect(body.contains("'horizontal'") || body.contains("\"horizontal\""),
+                "helper must branch on the ScrollModel axis === 'horizontal' (vertical-writing).")
+        #expect(body.contains("flexDirection") && body.contains("'row'"),
+                "helper must use a plain flex `row` (direction handles the reversal).")
+        // Gate-4 High: the host already forces dir=rtl for every vertical book, so
+        // `row-reverse` would double-reverse vertical-rl. The helper must instead
+        // set an EXPLICIT direction (rtl for vertical-rl, ltr for vertical-lr).
+        // Check the string LITERAL (quoted), not prose — the explanatory comment
+        // legitimately mentions row-reverse to say why it's avoided.
+        #expect(!body.contains("'row-reverse'") && !body.contains("\"row-reverse\""),
+                "helper must NOT set flexDirection to row-reverse — the host's blanket dir=rtl would double-reverse vertical-rl.")
+        #expect(body.contains("direction") && body.contains("'rtl'") && body.contains("'ltr'"),
+                "helper must set container direction explicitly: rtl for directionSign<0 (vertical-rl), ltr otherwise (vertical-lr).")
+        #expect(body.contains("directionSign"),
+                "helper must pick rtl vs ltr from the ScrollModel directionSign.")
+    }
+
+    @Test("helper RESETS display + flex-direction + direction for horizontal-writing (byte-identical to #73)")
+    func helperResetsHorizontalWriting() throws {
+        // Horizontal-writing must NOT leave any inline style — it removes ALL three
+        // so the CSS default (block flow, inherited direction) stays exactly as #73
+        // shipped. Assert the exact strings in BOTH source and bundle (Gate-4 Low).
+        // esbuild rewrites the source's single quotes to double quotes in the
+        // bundle, so assert quote-agnostically.
+        func removesProperty(_ body: String, _ prop: String) -> Bool {
+            body.contains("removeProperty('\(prop)')") || body.contains("removeProperty(\"\(prop)\")")
+        }
+        for (label, text) in [("source", try loadSource()), ("bundle", try loadBundle())] {
+            let body = extractHelperBody(text, name: "#applyScrolledContainerAxis")
+            #expect(!body.isEmpty, "\(label): could not locate #applyScrolledContainerAxis body")
+            #expect(removesProperty(body, "display"),
+                    "\(label) helper must removeProperty('display') for horizontal-writing.")
+            #expect(removesProperty(body, "flex-direction"),
+                    "\(label) helper must removeProperty('flex-direction') for horizontal-writing.")
+            #expect(removesProperty(body, "direction"),
+                    "\(label) helper must removeProperty('direction') for horizontal-writing.")
+        }
+    }
+
+    // MARK: - Call site runs BEFORE the windowing gate, gated on scrolled only
+
+    @Test("in #display, the layout call runs before #ensureWindow, gated on scrolled only")
+    func layoutRunsBeforeWindowingGate() throws {
+        let src = try loadSource()
+        // Scope the ordering assertion to the #display body specifically (the flow
+        // attributeChangedCallback ALSO calls the helper, so a global search would
+        // match that first and leave #display's ordering unpinned — Gate-4 r2 Low).
+        let display = extractHelperBody(src, name: "#display")
+        #expect(!display.isEmpty, "could not locate #display body")
+        guard let callRange = display.range(of: "this.#applyScrolledContainerAxis()"),
+              let ensureRange = display.range(of: "this.#ensureWindow()", range: callRange.upperBound..<display.endIndex)
+        else {
+            Issue.record("expected #applyScrolledContainerAxis() before #ensureWindow() inside #display")
+            return
+        }
+        #expect(callRange.lowerBound < ensureRange.lowerBound,
+                "WI-2 layout must apply BEFORE the windowing math in #display (it must run for vertical even while #ensureWindow gates it out).")
+        // The guard immediately preceding the call is `this.scrolled` (not
+        // `#windowedScroll`) — so the container is oriented even in the
+        // non-windowed vertical fallback.
+        #expect(display.contains("if (this.scrolled) this.#applyScrolledContainerAxis()"),
+                "the #display layout call must be gated on `this.scrolled` only (not #windowedScroll), so vertical-writing books orient the container even while windowing is gated out.")
+    }
+
+    // MARK: - Helpers (balanced-brace body extractor, mirrors ScrollBoundary tests)
+
+    private func extractHelperBody(_ source: String, name: String) -> String {
+        var searchStart = source.startIndex
+        while let nameRange = source.range(of: name, range: searchStart..<source.endIndex) {
+            let afterName = source[nameRange.upperBound...]
+            guard let openParen = afterName.firstIndex(where: { !$0.isWhitespace }),
+                  afterName[openParen] == "(" else { searchStart = nameRange.upperBound; continue }
+            var pDepth = 0
+            var afterParen: String.Index? = nil
+            for i in afterName[openParen...].indices {
+                let ch = afterName[i]
+                if ch == "(" { pDepth += 1 }
+                else if ch == ")" { pDepth -= 1; if pDepth == 0 { afterParen = afterName.index(after: i); break } }
+            }
+            guard let afterClose = afterParen else { searchStart = nameRange.upperBound; continue }
+            let tail = afterName[afterClose...]
+            guard let braceIdx = tail.firstIndex(where: { !$0.isWhitespace }),
+                  tail[braceIdx] == "{" else { searchStart = nameRange.upperBound; continue }
+            var depth = 0
+            var end: String.Index = braceIdx
+            for i in tail[braceIdx...].indices {
+                let ch = tail[i]
+                if ch == "{" { depth += 1 }
+                else if ch == "}" { depth -= 1; if depth == 0 { end = i; break } }
+            }
+            return String(tail[braceIdx...end])
+        }
+        return ""
+    }
+
+    private final class BundleToken {}
+}


### PR DESCRIPTION
## Summary

Feature #73's K=3 windowed continuous-scroll is vertical-scroll-axis only; vertical-writing AZW3/MOBI (`vertical-rl`/`-lr`) scroll on the horizontal axis and were gated out of windowing → still per-section-swap = the Bug #283 chapter-boundary jump. WI-1 landed the ScrollModel + axis-aware windowed primitives; this WI-2 adds the **layout substrate**.

- New `#applyScrolledContainerAxis()` orients the scrolled `#container` along the active scroll axis.
- **Horizontal-writing (#73 path) stays byte-identical** — the helper removes any inline display/flex-direction/direction (block stacking).
- **Vertical-writing** stacks sections in a flex `row` with an EXPLICIT container `direction` from the ScrollModel (`rtl` for vertical-rl, `ltr` for vertical-lr) — not `row-reverse` (the host already forces `dir=rtl`, which would double-reverse). Runs in `#display` + the `flow` callback BEFORE the windowing gate.

Part of feature #76 (Bug #283 vertical residual). Rebuilt `foliate-bundle.js`.

## Codex Audit

cc-suite / `codex exec`, gpt-5.5/high, read-only. **2 rounds, ship-as-is.** R1: High (`row-reverse` double-reverse → explicit `direction`) + Medium (flow-switch didn't apply layout) + Low (test); R2 confirmed both resolved + fixed a Low test-scope finding.

Audit log: `.claude/codex-audits/feat-feature-76-wi-2-container-axis-layout-audit.md`

## Validation

- [x] `FoliateVerticalContainerLayoutTests` (5, source↔bundle contract) pass
- [x] Existing parity suites green — `FoliatePaginatorScrollBoundaryTests` 15, `FoliateTapToleranceBundleTests` 4
- [x] Codex audit (2 rounds, ship-as-is)
- [x] Docs sync — n/a (vendored-JS rendering substrate)
- [x] Version bumped: 3.42.36 → 3.42.37
- [x] **Device-verified (idb) — horizontal regression**: mini-azw3 in scroll mode scrolls continuously through front-matter → title → story body, no blank/jump/stuck (the #73 path is intact). Evidence: `dev-docs/verification/artifacts/feature-76-wi2-horizontal-azw3-continuous-scroll-20260602.png`. Vertical-writing behavior is reachable in WI-3 (which removes the `#ensureWindow` `#vertical` gate).

## Type of Change

- [x] Feature work item (Part of #76)

🤖 Generated with [Claude Code](https://claude.com/claude-code)