### PR TITLE
feat(#76 WI-3): remove #vertical windowing gates; axis-aware primitives

### DIFF
--- a/.claude/codex-audits/feat-feature-76-wi-3-remove-vertical-gates-audit.md
+++ b/.claude/codex-audits/feat-feature-76-wi-3-remove-vertical-gates-audit.md
@@ -1,0 +1,48 @@
+---
+branch: feat/feature-76-wi-3-remove-vertical-gates
+threadId: 019e8723-3a7c-7572-b6a4-ea516865b86d
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-02
+---
+
+# Codex audit — Feature #76 WI-3 (remove `#vertical` windowing gates, axis-aware primitives)
+
+Independent Codex audit (cc-suite via `scripts/run-codex.sh`, model `gpt-5.5`,
+effort `high`, read-only) of WI-3 — the load-bearing WI that removes the
+`!this.#vertical` gates from the windowed continuous-scroll path so K=3 windowing
+runs for vertical-writing AZW3/MOBI (Bug #283), and generalizes the remaining
+windowed primitives over the ScrollModel axis. **Critical invariant: the shipped
++ VERIFIED horizontal-tb (#73) path stays byte-identical.**
+
+- Round 1 session: `019e8723-3a7c-7572-b6a4-ea516865b86d`
+- Round 2 session: `019e872d-1304-72a2-b57b-d2cfbeae6c5d`
+
+## Scope
+
+- `vreader/Services/Foliate/JS/paginator.js` — 9 gate/hardcode sites (`#ensureWindow`, `#viewRelativeStart`, `#scrollToRect`, `#scrollTo` sign, `#scrollToAnchor`, `#afterScroll`, `#scrollPrev`, `#scrollNext`, `#maybeCrossSectionBoundary`) + new `#axisScrollSize`/`#axisClientSize` helpers + `scrollModelFor` vertical-rl `rectStartProp` + `#getRectMapper`.
+- `vreader/Services/Foliate/FoliateScrollModel.swift` (mirror: vertical-rl `rectStartProp`).
+- `vreader/Services/Foliate/JS/foliate-bundle.js` (rebuilt).
+- `vreaderTests/Services/Foliate/{FoliateScrollModelTests, FoliateVerticalWindowBundleTests}.swift`.
+
+## Round 1 — findings
+
+| Severity | Issue | Resolution |
+|---|---|---|
+| **High** | `scrollModelFor('vertical-rl')` used `rectStartProp: 'left'`, but under WebKit's negative `scrollLeft` the logical reading-order start of a vertical-rl section is its RIGHT edge — so `#elementAxisStart` (and everything keyed off it) drifted by ~`sectionWidth − clientWidth`. | FIXED — vertical-rl `rectStartProp` → `'right'` in the JS `scrollModelFor` AND the Swift `FoliateScrollModel` mirror; `FoliateScrollModelTests` updated. R2 confirmed first/rightmost section start ≈0, increasing leftward. |
+| **Medium** | `#getRectMapper` scrolled branch still keyed on blanket `this.#vertical`, so vertical-lr (directionSign +1) wrongly used the vertical-rl mirror. | FIXED — the scrolled mapper now branches on `#activeScrollModel`: vertical-rl (directionSign<0) mirrors (`size−right`), vertical-lr (directionSign>0) maps non-mirrored (`left+margin`, the horizontal-axis analogue of horizontal-tb), horizontal-tb unchanged. |
+| Low | `#scrollTo` compared the raw DOM offset to the logical offset before signing → a vertical-rl no-op seek never short-circuited. | FIXED — the `directionSign` sign is applied BEFORE the early-return compare. |
+| Low | Tests didn't pin `#viewRelativeStart`/`#scrollToRect`/`#scrollToAnchor`/`#afterScroll` or the vertical-rl right-edge. | FIXED — `FoliateVerticalWindowBundleTests` extended to 11 tests. |
+
+## Round 2 — verification
+
+**R1 High + Medium resolved in code.** Auditor confirmed:
+- vertical-rl uses `rectStartProp: 'right'` (source + bundle); the `#elementAxisStart` math is correct.
+- vertical-lr keeps `'left'`; the non-mirrored rect mapper is consistent with directionSign +1.
+- **horizontal-tb is byte-identical across all WI-3 sites** (model stays scrollTop/height/top/+1, so the helper substitutions collapse to the old expressions); `#scrollTo` horizontal compare unchanged.
+
+The only round-2 "High" was the working-tree observation that `FoliateVerticalWindowBundleTests.swift` was untracked while `project.pbxproj` referenced it — a staging artifact, resolved by committing the file together with the project change (done in this WI's commit).
+
+## Verdict
+
+**ship-as-is.** Build + all affected suites GREEN: `FoliateVerticalWindowBundleTests` 11, `FoliateScrollModelTests` 6, `FoliateScrolledWindowMathTests` 19, `FoliatePaginatorScrollBoundaryTests` 15, `FoliateVerticalContainerLayoutTests` 5. Horizontal regression device-verified on mini-azw3. **Vertical-writing behavior (the new capability) is audit-clean + unit-tested; its DEVICE verification on a real vertical-rl book is WI-5** (no vertical-rl AZW3 DebugBridge seed exists; the real `被讨厌的勇气.azw3` needs sim-transfer) — the planned WI-3/WI-5 split.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 800
-        MARKETING_VERSION: 3.42.37
+        CURRENT_PROJECT_VERSION: 801
+        MARKETING_VERSION: 3.42.38
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7189,7 +7189,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 800;
+				CURRENT_PROJECT_VERSION = 801;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7197,7 +7197,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.37;
+				MARKETING_VERSION = 3.42.38;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7343,7 +7343,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 800;
+				CURRENT_PROJECT_VERSION = 801;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7351,7 +7351,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.42.37;
+				MARKETING_VERSION = 3.42.38;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -1441,6 +1441,7 @@
 		FB0A5F6990BB44BA58C1F366 /* PersistenceActor+Backup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2832B213595B426B8FFC8B6B /* PersistenceActor+Backup.swift */; };
 		FB0BC111F33D81D4E93A031F /* HighlightListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 275DFDD33FCF69E75F251F27 /* HighlightListViewModelTests.swift */; };
 		FB165F7EA6481A67F3435EDD /* OPDSCatalogListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326632F80DB744679F67D712 /* OPDSCatalogListTests.swift */; };
+		FB1821C008D68AD3D3A3502A /* FoliateVerticalWindowBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41605378442282DEAB0DBFCA /* FoliateVerticalWindowBundleTests.swift */; };
 		FB379B5459AC6B9D5975E3D2 /* BookFileState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2838729583E68E78C072AD56 /* BookFileState.swift */; };
 		FB4B2B41D865A14865DF4DE1 /* HTTPTTSProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDE700F3AC42B0D8AD377E1 /* HTTPTTSProviderTests.swift */; };
 		FB59D6FDE7A4F0E7F44C78DA /* DebugAIActionEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291B9DC0FD8C89549850D5A6 /* DebugAIActionEffect.swift */; };
@@ -1830,6 +1831,7 @@
 		40E27899DB05507AB2F13CDE /* NotesRowStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesRowStateTests.swift; sourceTree = "<group>"; };
 		410014C25D3480276D1E5F00 /* WebDAVProfileMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProfileMigratorTests.swift; sourceTree = "<group>"; };
 		410BA6F21267316487DF58FC /* PersistenceBookmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceBookmarkTests.swift; sourceTree = "<group>"; };
+		41605378442282DEAB0DBFCA /* FoliateVerticalWindowBundleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateVerticalWindowBundleTests.swift; sourceTree = "<group>"; };
 		4184F6CBC1069C92654BCB19 /* DebugReaderProbeAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReaderProbeAdapterTests.swift; sourceTree = "<group>"; };
 		41C3ECA5E8F6419DB347F2E4 /* BookFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFormat.swift; sourceTree = "<group>"; };
 		41D94EE13466B0286DEA2EA7 /* ReadingSessionTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingSessionTracker.swift; sourceTree = "<group>"; };
@@ -5404,6 +5406,7 @@
 				0C511C16F7FA93E91D703EE7 /* FoliateTTSAdapterTests.swift */,
 				432F646AE5FB7BFD06470EB5 /* FoliateURLSchemeHandlerTests.swift */,
 				E8EE09BCDCB14CCFAA6A943D /* FoliateVerticalContainerLayoutTests.swift */,
+				41605378442282DEAB0DBFCA /* FoliateVerticalWindowBundleTests.swift */,
 			);
 			path = Foliate;
 			sourceTree = "<group>";
@@ -5904,6 +5907,7 @@
 				8AD533CDAFAC138CA7E20D75 /* FoliateTapToleranceBundleTests.swift in Sources */,
 				DCE7A66917407F83D657A63B /* FoliateURLSchemeHandlerTests.swift in Sources */,
 				5088375DABF1823ED1BA0CC8 /* FoliateVerticalContainerLayoutTests.swift in Sources */,
+				FB1821C008D68AD3D3A3502A /* FoliateVerticalWindowBundleTests.swift in Sources */,
 				6E94155F0ECDFD59EAAAD010 /* FoliateViewCoordinatorTests.swift in Sources */,
 				D2A9D9BF75759BDA0213247F /* FontSizeCalibrationMeasurementTests.swift in Sources */,
 				F5C06CBFBB03CA953526172B /* FontSizeCalibrationTests.swift in Sources */,

--- a/vreader/Services/Foliate/FoliateScrollModel.swift
+++ b/vreader/Services/Foliate/FoliateScrollModel.swift
@@ -52,9 +52,13 @@ struct FoliateScrollModel: Equatable {
     static func scrolled(writingMode: String) -> FoliateScrollModel {
         switch writingMode {
         case "vertical-rl":
+            // Feature #76 WI-3 (Gate-4 High): the logical reading-order start of a
+            // vertical-rl section is its RIGHT edge (WebKit scrollLeft is 0 at the
+            // right, negative leftward), so the windowed `#elementAxisStart`
+            // measures `el.right - container.right`. Mirrors the JS `scrollModelFor`.
             return FoliateScrollModel(
                 axis: .horizontal, scrollProp: "scrollLeft", sizeProp: "width",
-                rectStartProp: "left", directionSign: -1)
+                rectStartProp: "right", directionSign: -1)
         case "vertical-lr":
             return FoliateScrollModel(
                 axis: .horizontal, scrollProp: "scrollLeft", sizeProp: "width",

--- a/vreader/Services/Foliate/JS/foliate-bundle.js
+++ b/vreader/Services/Foliate/JS/foliate-bundle.js
@@ -4314,7 +4314,7 @@ ${doc.querySelector("parsererror").innerText}`);
               axis: "horizontal",
               scrollProp: "scrollLeft",
               sizeProp: "width",
-              rectStartProp: "left",
+              rectStartProp: "right",
               directionSign: -1
             };
           case "vertical-lr":
@@ -5008,6 +5008,16 @@ ${doc.querySelector("parsererror").innerText}`);
         #elementAxisSize(el) {
           return Math.max(0, el.getBoundingClientRect()[this.#activeScrollModel.sizeProp]);
         }
+        // Feature #76 WI-3: the container's total scroll extent + viewport size along
+        // the active axis (horizontal-tb: scrollHeight / clientHeight; vertical-
+        // writing: scrollWidth / clientWidth). Used by the windowed `#scrollNext`
+        // remaining-room check so it works on the horizontal scroll axis too.
+        #axisScrollSize() {
+          return this.#container[this.#activeScrollModel.sizeProp === "width" ? "scrollWidth" : "scrollHeight"];
+        }
+        #axisClientSize() {
+          return this.#container[this.#activeScrollModel.sizeProp === "width" ? "clientWidth" : "clientHeight"];
+        }
         // Element's logical start offset within the container's scroll content along
         // the active axis (axis-aware generalization of the old #elementScrollTop).
         // horizontal-tb: rect.top - container.top + scrollTop — byte-identical.
@@ -5032,7 +5042,7 @@ ${doc.querySelector("parsererror").innerText}`);
           }
         }
         async #ensureWindow() {
-          if (!this.#windowedScroll || !this.scrolled || this.#vertical) return;
+          if (!this.#windowedScroll || !this.scrolled) return;
           const range = this.#windowRange(this.#index, this.sections.length, this.#K);
           if (!range) return;
           const [lo, hi] = range;
@@ -5127,8 +5137,8 @@ ${doc.querySelector("parsererror").innerText}`);
         // offset RELATIVE to the current view's position in the container. Flag OFF
         // (or no neighbours) → one view at offset 0 → relative == absolute.
         #viewRelativeStart() {
-          if (!this.#windowedScroll || !this.#view || this.#vertical) return this.start;
-          return Math.max(0, this.#container.scrollTop - this.#elementScrollTop(this.#view.element));
+          if (!this.#windowedScroll || !this.#view) return this.start;
+          return Math.max(0, this.#axisScrollOffset() - this.#elementScrollTop(this.#view.element));
         }
         #beforeRender({ vertical, rtl, background }) {
           this.#vertical = vertical;
@@ -5289,7 +5299,11 @@ ${doc.querySelector("parsererror").innerText}`);
           if (this.scrolled) {
             const size = this.viewSize;
             const margin = this.#margin;
-            return this.#vertical ? ({ left, right }) => ({ left: size - right - margin, right: size - left - margin }) : ({ top, bottom }) => ({ left: top + margin, right: bottom + margin });
+            const m3 = this.#activeScrollModel;
+            if (m3.axis === "horizontal") {
+              return m3.directionSign < 0 ? ({ left, right }) => ({ left: size - right - margin, right: size - left - margin }) : ({ left, right }) => ({ left: left + margin, right: right + margin });
+            }
+            return ({ top, bottom }) => ({ left: top + margin, right: bottom + margin });
           }
           const pxSize = this.pages * this.size;
           return this.#rtl ? ({ left, right }) => ({ left: pxSize - right, right: pxSize - left }) : this.#vertical ? ({ top, bottom }) => ({ left: top, right: bottom }) : (f3) => f3;
@@ -5297,7 +5311,7 @@ ${doc.querySelector("parsererror").innerText}`);
         async #scrollToRect(rect, reason) {
           if (this.scrolled) {
             let offset2 = this.#getRectMapper()(rect).left - this.#margin;
-            if (this.#windowedScroll && this.#view && !this.#vertical) offset2 += this.#elementScrollTop(this.#view.element);
+            if (this.#windowedScroll && this.#view) offset2 += this.#elementScrollTop(this.#view.element);
             return this.#scrollTo(offset2, reason);
           }
           const offset = this.#getRectMapper()(rect).left;
@@ -5306,12 +5320,12 @@ ${doc.querySelector("parsererror").innerText}`);
         async #scrollTo(offset, reason, smooth) {
           const element = this.#container;
           const { scrollProp, size } = this;
+          if (this.scrolled && this.#activeScrollModel.directionSign < 0) offset = -offset;
           if (element[scrollProp] === offset) {
             this.#scrollBounds = [offset, this.atStart ? 0 : size, this.atEnd ? 0 : size];
             this.#afterScroll(reason);
             return;
           }
-          if (this.scrolled && this.#vertical) offset = -offset;
           if ((reason === "snap" || smooth) && this.hasAttribute("animated")) return animate(
             element[scrollProp],
             offset,
@@ -5346,7 +5360,7 @@ ${doc.querySelector("parsererror").innerText}`);
           }
           if (this.scrolled) {
             let offset = anchor * this.viewSize;
-            if (this.#windowedScroll && this.#view && !this.#vertical) offset += this.#elementScrollTop(this.#view.element);
+            if (this.#windowedScroll && this.#view) offset += this.#elementScrollTop(this.#view.element);
             await this.#scrollTo(offset, reason);
             return;
           }
@@ -5377,7 +5391,7 @@ ${doc.querySelector("parsererror").innerText}`);
         }
         #afterScroll(reason) {
           let scrolledFraction = null;
-          if (this.scrolled && this.#windowedScroll && !this.#vertical) {
+          if (this.scrolled && this.#windowedScroll) {
             const r3 = this.#windowedResolve();
             this.#promoteCurrentView(r3);
             scrolledFraction = r3.intra;
@@ -5458,9 +5472,9 @@ ${doc.querySelector("parsererror").innerText}`);
         #scrollPrev(distance) {
           if (!this.#view) return true;
           if (this.scrolled) {
-            if (this.#windowedScroll && !this.#vertical) {
-              const top = this.#container.scrollTop;
-              if (top > 0) return this.#scrollTo(Math.max(0, top - (distance ?? this.size)), null, true);
+            if (this.#windowedScroll) {
+              const offset = this.#axisScrollOffset();
+              if (offset > 0) return this.#scrollTo(Math.max(0, offset - (distance ?? this.size)), null, true);
               return this.#adjacentIndex(-1) != null;
             }
             if (this.start > 0) return this.#scrollTo(
@@ -5477,10 +5491,10 @@ ${doc.querySelector("parsererror").innerText}`);
         #scrollNext(distance) {
           if (!this.#view) return true;
           if (this.scrolled) {
-            if (this.#windowedScroll && !this.#vertical) {
-              const c2 = this.#container;
-              const remaining = c2.scrollHeight - (c2.scrollTop + c2.clientHeight);
-              if (remaining > 2) return this.#scrollTo(c2.scrollTop + (distance ?? this.size), null, true);
+            if (this.#windowedScroll) {
+              const offset = this.#axisScrollOffset();
+              const remaining = this.#axisScrollSize() - (offset + this.#axisClientSize());
+              if (remaining > 2) return this.#scrollTo(offset + (distance ?? this.size), null, true);
               return this.#adjacentIndex(1) != null;
             }
             if (this.viewSize - this.end > 2) return this.#scrollTo(
@@ -5560,7 +5574,7 @@ ${doc.querySelector("parsererror").innerText}`);
           if (!this.scrolled) return;
           if (this.#locked) return;
           if (!this.#view) return;
-          if (this.#windowedScroll && !this.#vertical) {
+          if (this.#windowedScroll) {
             const r3 = this.#windowedResolve();
             this.#promoteCurrentView(r3);
             this.#ensureWindow();

--- a/vreader/Services/Foliate/JS/paginator.js
+++ b/vreader/Services/Foliate/JS/paginator.js
@@ -199,8 +199,12 @@ const getDirection = doc => {
 const scrollModelFor = writingMode => {
     switch (writingMode) {
         case 'vertical-rl':
+            // Gate-4 WI-3 High: the logical reading-order start of a vertical-rl
+            // section is its RIGHT edge (WebKit scrollLeft is 0 at the right and
+            // goes negative leftward), so `#elementAxisStart` must measure
+            // `el.right - container.right` (then directionSign<0 maps it positive).
             return { axis: 'horizontal', scrollProp: 'scrollLeft', sizeProp: 'width',
-                rectStartProp: 'left', directionSign: -1 }
+                rectStartProp: 'right', directionSign: -1 }
         case 'vertical-lr':
             return { axis: 'horizontal', scrollProp: 'scrollLeft', sizeProp: 'width',
                 rectStartProp: 'left', directionSign: 1 }
@@ -985,6 +989,16 @@ export class Paginator extends HTMLElement {
     #elementAxisSize(el) {
         return Math.max(0, el.getBoundingClientRect()[this.#activeScrollModel.sizeProp])
     }
+    // Feature #76 WI-3: the container's total scroll extent + viewport size along
+    // the active axis (horizontal-tb: scrollHeight / clientHeight; vertical-
+    // writing: scrollWidth / clientWidth). Used by the windowed `#scrollNext`
+    // remaining-room check so it works on the horizontal scroll axis too.
+    #axisScrollSize() {
+        return this.#container[this.#activeScrollModel.sizeProp === 'width' ? 'scrollWidth' : 'scrollHeight']
+    }
+    #axisClientSize() {
+        return this.#container[this.#activeScrollModel.sizeProp === 'width' ? 'clientWidth' : 'clientHeight']
+    }
     // Element's logical start offset within the container's scroll content along
     // the active axis (axis-aware generalization of the old #elementScrollTop).
     // horizontal-tb: rect.top - container.top + scrollTop — byte-identical.
@@ -1012,13 +1026,12 @@ export class Paginator extends HTMLElement {
         }
     }
     async #ensureWindow() {
-        // Gate-4 H (audit): the windowed coordinate math (#elementScrollTop /
-        // #windowedResolve / eviction + expand compensation) is vertical-scroll
-        // (top/height/scrollTop) only. Vertical-WRITING scrolled mode scrolls on
-        // the horizontal axis, so scope windowing to horizontal writing for now —
-        // vertical writing falls back to the proven per-section swap (window stays
-        // empty → all resolvers return the single `#view`).
-        if (!this.#windowedScroll || !this.scrolled || this.#vertical) return
+        // Feature #76 WI-3: the windowed coordinate math (#elementAxisStart /
+        // #windowedResolve / eviction + expand compensation) is now AXIS-AWARE via
+        // the ScrollModel, so windowing runs for vertical-writing too (it scrolls
+        // the horizontal axis). The `this.#vertical` gate is gone — horizontal-tb
+        // resolves to the identical scrollTop/height expressions (directionSign +1).
+        if (!this.#windowedScroll || !this.scrolled) return
         const range = this.#windowRange(this.#index, this.sections.length, this.#K)
         if (!range) return
         const [lo, hi] = range
@@ -1113,11 +1126,11 @@ export class Paginator extends HTMLElement {
     // offset RELATIVE to the current view's position in the container. Flag OFF
     // (or no neighbours) → one view at offset 0 → relative == absolute.
     #viewRelativeStart() {
-        // Gate-4 H: vertical-writing scroll is horizontal-axis; the windowed
-        // helpers are vertical-only, so vertical writing keeps the container-
-        // absolute `start` (windowing is disabled for it in #ensureWindow).
-        if (!this.#windowedScroll || !this.#view || this.#vertical) return this.start
-        return Math.max(0, this.#container.scrollTop - this.#elementScrollTop(this.#view.element))
+        // Feature #76 WI-3: axis-aware. The container-absolute logical offset minus
+        // the current view's logical start in the container = the intra-view offset.
+        // horizontal-tb resolves to `scrollTop - elementTop` (byte-identical).
+        if (!this.#windowedScroll || !this.#view) return this.start
+        return Math.max(0, this.#axisScrollOffset() - this.#elementScrollTop(this.#view.element))
     }
     #beforeRender({ vertical, rtl, background }) {
         this.#vertical = vertical
@@ -1317,10 +1330,21 @@ export class Paginator extends HTMLElement {
         if (this.scrolled) {
             const size = this.viewSize
             const margin = this.#margin
-            return this.#vertical
-                ? ({ left, right }) =>
-                    ({ left: size - right - margin, right: size - left - margin })
-                : ({ top, bottom }) => ({ left: top + margin, right: bottom + margin })
+            const m = this.#activeScrollModel
+            if (m.axis === 'horizontal') {
+                // Feature #76 WI-3: vertical writing scrolls the horizontal axis.
+                // vertical-rl (directionSign < 0) reads right→left, so MIRROR the
+                // rect's horizontal extent into the logical offset (`size - right`).
+                // vertical-lr (directionSign +1) reads left→right — map the left
+                // edge directly (the horizontal-axis analogue of horizontal-tb's
+                // `top + margin`), NOT mirrored (the Gate-4 Medium: the old blanket
+                // `this.#vertical` wrongly mirrored vertical-lr too).
+                return m.directionSign < 0
+                    ? ({ left, right }) =>
+                        ({ left: size - right - margin, right: size - left - margin })
+                    : ({ left, right }) => ({ left: left + margin, right: right + margin })
+            }
+            return ({ top, bottom }) => ({ left: top + margin, right: bottom + margin })
         }
         const pxSize = this.pages * this.size
         return this.#rtl
@@ -1337,7 +1361,7 @@ export class Paginator extends HTMLElement {
             // coordinates; in windowed mode `#view` may sit at a nonzero
             // container offset, so add its position to land at the right
             // container scroll. Flag OFF → offset 0 → unchanged.
-            if (this.#windowedScroll && this.#view && !this.#vertical) offset += this.#elementScrollTop(this.#view.element)
+            if (this.#windowedScroll && this.#view) offset += this.#elementScrollTop(this.#view.element)
             return this.#scrollTo(offset, reason)
         }
         const offset = this.#getRectMapper()(rect).left
@@ -1346,13 +1370,19 @@ export class Paginator extends HTMLElement {
     async #scrollTo(offset, reason, smooth) {
         const element = this.#container
         const { scrollProp, size } = this
+        // Feature #76 WI-3: sign the logical offset for the actual scroll direction
+        // FIRST — vertical-rl (directionSign < 0) writes a NEGATIVE scrollLeft
+        // (WebKit RTL); vertical-lr and horizontal-tb (directionSign +1) stay
+        // positive. Done before the early-return compare so a vertical-rl no-op
+        // seek (raw scrollLeft === signed offset) short-circuits correctly (Gate-4
+        // Low), and fixes the old `this.#vertical` check that wrongly negated
+        // vertical-lr too (the live FIXME).
+        if (this.scrolled && this.#activeScrollModel.directionSign < 0) offset = -offset
         if (element[scrollProp] === offset) {
             this.#scrollBounds = [offset, this.atStart ? 0 : size, this.atEnd ? 0 : size]
             this.#afterScroll(reason)
             return
         }
-        // FIXME: vertical-rl only, not -lr
-        if (this.scrolled && this.#vertical) offset = -offset
         if ((reason === 'snap' || smooth) && this.hasAttribute('animated')) return animate(
             element[scrollProp], offset, 300, easeOutQuad,
             x => element[scrollProp] = x,
@@ -1395,7 +1425,7 @@ export class Paginator extends HTMLElement {
             // re-assert window) lands too high by the above-sections' height.
             // Same offset gap WI-6c fixed for `#scrollToRect`. Flag OFF → 0.
             let offset = anchor * this.viewSize
-            if (this.#windowedScroll && this.#view && !this.#vertical) offset += this.#elementScrollTop(this.#view.element)
+            if (this.#windowedScroll && this.#view) offset += this.#elementScrollTop(this.#view.element)
             await this.#scrollTo(offset, reason)
             return
         }
@@ -1429,7 +1459,7 @@ export class Paginator extends HTMLElement {
         // still owns whole-book conversion + Bug #265 restore). Non-windowed path
         // unchanged.
         let scrolledFraction = null
-        if (this.scrolled && this.#windowedScroll && !this.#vertical) {
+        if (this.scrolled && this.#windowedScroll) {
             const r = this.#windowedResolve()
             this.#promoteCurrentView(r)
             scrolledFraction = r.intra
@@ -1526,9 +1556,10 @@ export class Paginator extends HTMLElement {
             // container (all mounted sections), not just `#view`. Scroll within it
             // and let the scroll-driven promote/#ensureWindow slide the window; only
             // fall through to #goTo at the true top of the book.
-            if (this.#windowedScroll && !this.#vertical) {
-                const top = this.#container.scrollTop
-                if (top > 0) return this.#scrollTo(Math.max(0, top - (distance ?? this.size)), null, true)
+            if (this.#windowedScroll) {
+                // Feature #76 WI-3: axis-aware logical offset (horizontal-tb == scrollTop).
+                const offset = this.#axisScrollOffset()
+                if (offset > 0) return this.#scrollTo(Math.max(0, offset - (distance ?? this.size)), null, true)
                 return this.#adjacentIndex(-1) != null
             }
             if (this.start > 0) return this.#scrollTo(
@@ -1542,10 +1573,14 @@ export class Paginator extends HTMLElement {
     #scrollNext(distance) {
         if (!this.#view) return true
         if (this.scrolled) {
-            if (this.#windowedScroll && !this.#vertical) {
-                const c = this.#container
-                const remaining = c.scrollHeight - (c.scrollTop + c.clientHeight)
-                if (remaining > 2) return this.#scrollTo(c.scrollTop + (distance ?? this.size), null, true)
+            if (this.#windowedScroll) {
+                // Feature #76 WI-3: axis-aware remaining-room (horizontal-tb ==
+                // scrollHeight - (scrollTop + clientHeight)). `#axisScrollOffset`
+                // is the logical (positive) offset; `#axisScrollSize`/`#axisClientSize`
+                // pick scrollWidth/clientWidth for the vertical-writing horizontal axis.
+                const offset = this.#axisScrollOffset()
+                const remaining = this.#axisScrollSize() - (offset + this.#axisClientSize())
+                if (remaining > 2) return this.#scrollTo(offset + (distance ?? this.size), null, true)
                 return this.#adjacentIndex(1) != null
             }
             if (this.viewSize - this.end > 2) return this.#scrollTo(
@@ -1627,7 +1662,7 @@ export class Paginator extends HTMLElement {
         // do NOT swap. Track the current section live from the scroll position
         // and keep the K-window mounted ahead/behind. (D1 offset-reset gone:
         // there is no scrollToAnchor(0) reset, the scroll simply continues.)
-        if (this.#windowedScroll && !this.#vertical) {
+        if (this.#windowedScroll) {
             const r = this.#windowedResolve()
             this.#promoteCurrentView(r) // WI-6a: track `#view` to the viewport's section
             this.#ensureWindow()

--- a/vreaderTests/Services/Foliate/FoliateScrollModelTests.swift
+++ b/vreaderTests/Services/Foliate/FoliateScrollModelTests.swift
@@ -21,13 +21,15 @@ struct FoliateScrollModelTests {
         #expect(m.directionSign == 1)
     }
 
-    @Test("vertical-rl: scrolls horizontally (scrollLeft/width/left), sign −1 (WebKit negative scrollLeft)")
+    @Test("vertical-rl: scrolls horizontally (scrollLeft/width/RIGHT), sign −1 (WebKit negative scrollLeft)")
     func verticalRL() {
         let m = FoliateScrollModel.scrolled(writingMode: "vertical-rl")
         #expect(m.axis == .horizontal)
         #expect(m.scrollProp == "scrollLeft")
         #expect(m.sizeProp == "width")
-        #expect(m.rectStartProp == "left")
+        // Feature #76 WI-3: the logical reading-order start is the section's RIGHT
+        // edge (reading starts at the right; scrollLeft 0 there, negative leftward).
+        #expect(m.rectStartProp == "right")
         #expect(m.directionSign == -1)
     }
 

--- a/vreaderTests/Services/Foliate/FoliateVerticalWindowBundleTests.swift
+++ b/vreaderTests/Services/Foliate/FoliateVerticalWindowBundleTests.swift
@@ -1,0 +1,181 @@
+// Purpose: Feature #76 WI-3 — the windowed continuous-scroll primitives are now
+// ScrollModel-axis-aware and the `!this.#vertical` gates are REMOVED, so K=3
+// windowing runs for vertical-writing AZW3/MOBI (the Bug #283 chapter-boundary
+// jump). horizontal-tb stays byte-identical (directionSign +1 → identical
+// expressions). The runtime path is inside a WKWebView, so this file pins the
+// static contract in BOTH source `paginator.js` and built `foliate-bundle.js`,
+// following the FoliatePaginatorScrollBoundaryTests pattern.
+//
+// @coordinates-with: vreader/Services/Foliate/JS/paginator.js,
+//   vreader/Services/Foliate/JS/foliate-bundle.js, FoliateScrollModelTests.swift
+
+import Testing
+import Foundation
+
+@Suite("Foliate paginator — WI-3 vertical windowing gates removed + axis-aware (Feature #76 / Bug #283)")
+struct FoliateVerticalWindowBundleTests {
+
+    private func loadBundle() throws -> String {
+        for c in [Bundle(for: BundleToken.self), .main] {
+            if let url = c.url(forResource: "foliate-bundle", withExtension: "js") {
+                return try String(contentsOf: url, encoding: .utf8)
+            }
+        }
+        throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "foliate-bundle.js not found"])
+    }
+
+    private func loadSource() throws -> String {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent()
+            .deletingLastPathComponent().deletingLastPathComponent()
+        return try String(contentsOf: repoRoot.appendingPathComponent("vreader/Services/Foliate/JS/paginator.js"), encoding: .utf8)
+    }
+
+    // MARK: - The #ensureWindow vertical gate is REMOVED
+
+    @Test("#ensureWindow no longer early-returns on this.#vertical (windowing runs for vertical-writing)")
+    func ensureWindowGateRemoved() throws {
+        let body = extractHelperBody(try loadSource(), name: "#ensureWindow")
+        #expect(!body.isEmpty, "could not locate #ensureWindow body")
+        // The guard must be the windowing-flag + scrolled-mode check, with NO
+        // `this.#vertical` term (that gate falling back to per-section swap is gone).
+        #expect(body.contains("if (!this.#windowedScroll || !this.scrolled) return"),
+                "#ensureWindow guard must be `!#windowedScroll || !scrolled` with no `#vertical` term (WI-3 enables vertical windowing).")
+        // First statement of the method must not re-introduce a #vertical early return.
+        let firstLine = body.split(separator: "\n").first(where: { $0.contains("return") }) ?? ""
+        #expect(!firstLine.contains("#vertical"),
+                "#ensureWindow's guard must not gate on #vertical.")
+    }
+
+    // MARK: - Windowed scroll uses axis-aware container offset/size (not raw scrollTop/Height)
+
+    @Test("#scrollNext windowed branch uses axis-aware size + offset, not raw scrollHeight/scrollTop/clientHeight")
+    func scrollNextAxisAware() throws {
+        let body = extractHelperBody(try loadSource(), name: "#scrollNext")
+        #expect(body.contains("#axisScrollSize()") && body.contains("#axisClientSize()") && body.contains("#axisScrollOffset()"),
+                "#scrollNext windowed remaining-room must use #axisScrollSize/#axisClientSize/#axisScrollOffset.")
+        // The windowed branch must NOT be gated on #vertical anymore.
+        #expect(!body.contains("this.#windowedScroll && !this.#vertical"),
+                "#scrollNext windowed branch must not gate on `!this.#vertical`.")
+    }
+
+    @Test("#scrollPrev windowed branch uses #axisScrollOffset, not container.scrollTop")
+    func scrollPrevAxisAware() throws {
+        let body = extractHelperBody(try loadSource(), name: "#scrollPrev")
+        #expect(body.contains("#axisScrollOffset()"),
+                "#scrollPrev windowed branch must read #axisScrollOffset (axis-aware).")
+        #expect(!body.contains("this.#windowedScroll && !this.#vertical"),
+                "#scrollPrev windowed branch must not gate on `!this.#vertical`.")
+    }
+
+    // MARK: - The scroll sign is direction-aware (vertical-rl only), fixing the FIXME
+
+    @Test("#scrollTo negates the offset by ScrollModel directionSign, not a blanket this.#vertical")
+    func scrollSignUsesDirectionSign() throws {
+        let body = extractHelperBody(try loadSource(), name: "#scrollTo")
+        #expect(body.contains("this.#activeScrollModel.directionSign < 0"),
+                "#scrollTo must negate by directionSign < 0 (vertical-rl only), not the old `this.#vertical` (which wrongly negated vertical-lr).")
+        #expect(!body.contains("this.scrolled && this.#vertical) offset = -offset"),
+                "the old `this.scrolled && this.#vertical) offset = -offset` (vertical-rl-only FIXME) must be gone.")
+    }
+
+    // MARK: - #maybeCrossSectionBoundary windowed branch is no longer #vertical-gated
+
+    @Test("#maybeCrossSectionBoundary windowed swap-free branch runs for vertical too")
+    func boundaryWindowedUngated() throws {
+        let body = extractHelperBody(try loadSource(), name: "#maybeCrossSectionBoundary")
+        #expect(!body.contains("this.#windowedScroll && !this.#vertical"),
+                "#maybeCrossSectionBoundary windowed branch must not gate on `!this.#vertical`.")
+    }
+
+    // MARK: - The other windowed sites are ungated + axis-aware (Gate-4 r1 Low-2)
+
+    @Test("#viewRelativeStart uses #axisScrollOffset and is no longer #vertical-gated")
+    func viewRelativeStartAxisAware() throws {
+        let body = extractHelperBody(try loadSource(), name: "#viewRelativeStart")
+        #expect(body.contains("#axisScrollOffset()"),
+                "#viewRelativeStart must read #axisScrollOffset (not container.scrollTop).")
+        #expect(!body.contains("|| this.#vertical"),
+                "#viewRelativeStart must not gate on #vertical.")
+    }
+
+    @Test("#scrollToRect, #scrollToAnchor, #afterScroll windowed offset-adds are no longer #vertical-gated")
+    func windowedOffsetAddsUngated() throws {
+        let src = try loadSource()
+        for name in ["#scrollToRect", "#scrollToAnchor", "#afterScroll"] {
+            let body = extractHelperBody(src, name: name)
+            #expect(!body.isEmpty, "could not locate \(name) body")
+            #expect(!body.contains("&& !this.#vertical"),
+                    "\(name) windowed branch must not gate on `!this.#vertical` (WI-3 enables vertical).")
+        }
+    }
+
+    // MARK: - vertical-rl logical start uses the RIGHT edge (Gate-4 r1 High)
+
+    @Test("scrollModelFor vertical-rl uses rectStartProp 'right' in source + bundle")
+    func verticalRLRightEdge() throws {
+        for (label, text) in [("source", try loadSource()), ("bundle", try loadBundle())] {
+            // The vertical-rl model entry must carry rectStartProp 'right' (the
+            // reading-order start under WebKit's negative scrollLeft).
+            #expect(text.contains("rectStartProp: 'right'") || text.contains("rectStartProp: \"right\""),
+                    "\(label) scrollModelFor vertical-rl must use rectStartProp 'right' (WI-3 High).")
+        }
+    }
+
+    @Test("#getRectMapper scrolled vertical branch is direction-aware (directionSign, not blanket #vertical)")
+    func rectMapperDirectionAware() throws {
+        let body = extractHelperBody(try loadSource(), name: "#getRectMapper")
+        #expect(body.contains("directionSign < 0"),
+                "#getRectMapper scrolled-vertical must branch on directionSign (vertical-rl mirrors, vertical-lr does not) — Gate-4 Medium.")
+    }
+
+    // MARK: - source↔bundle parity for the new axis helpers
+
+    @Test("source + bundle both declare the axis container-size helpers")
+    func axisHelpersInBundle() throws {
+        for (label, text) in [("source", try loadSource()), ("bundle", try loadBundle())] {
+            #expect(text.contains("#axisScrollSize"), "\(label) must declare #axisScrollSize (rebuild bundle if missing).")
+            #expect(text.contains("#axisClientSize"), "\(label) must declare #axisClientSize.")
+        }
+    }
+
+    @Test("bundle has the directionSign-based scroll sign (rebuilt from source)")
+    func bundleHasDirectionSign() throws {
+        let bundle = try loadBundle()
+        #expect(bundle.contains("directionSign < 0"),
+                "foliate-bundle.js must carry the directionSign-based scroll sign — run build-bundle.sh.")
+    }
+
+    // MARK: - Helpers (balanced-brace extractor, mirrors ScrollBoundary tests)
+
+    private func extractHelperBody(_ source: String, name: String) -> String {
+        var searchStart = source.startIndex
+        while let nameRange = source.range(of: name, range: searchStart..<source.endIndex) {
+            let afterName = source[nameRange.upperBound...]
+            guard let openParen = afterName.firstIndex(where: { !$0.isWhitespace }),
+                  afterName[openParen] == "(" else { searchStart = nameRange.upperBound; continue }
+            var pDepth = 0
+            var afterParen: String.Index? = nil
+            for i in afterName[openParen...].indices {
+                let ch = afterName[i]
+                if ch == "(" { pDepth += 1 }
+                else if ch == ")" { pDepth -= 1; if pDepth == 0 { afterParen = afterName.index(after: i); break } }
+            }
+            guard let afterClose = afterParen else { searchStart = nameRange.upperBound; continue }
+            let tail = afterName[afterClose...]
+            guard let braceIdx = tail.firstIndex(where: { !$0.isWhitespace }),
+                  tail[braceIdx] == "{" else { searchStart = nameRange.upperBound; continue }
+            var depth = 0
+            var end: String.Index = braceIdx
+            for i in tail[braceIdx...].indices {
+                let ch = tail[i]
+                if ch == "{" { depth += 1 }
+                else if ch == "}" { depth -= 1; if depth == 0 { end = i; break } }
+            }
+            return String(tail[braceIdx...end])
+        }
+        return ""
+    }
+
+    private final class BundleToken {}
+}


### PR DESCRIPTION
## Summary

The load-bearing WI of Feature #76: removes the `!this.#vertical` gates from the windowed continuous-scroll path so K=3 windowing runs for vertical-writing AZW3/MOBI (`vertical-rl`, common CJK — the Bug #283 chapter-boundary jump), and generalizes the windowed primitives over the ScrollModel axis.

- 9 sites generalized (`#ensureWindow`, `#viewRelativeStart`, `#scrollToRect`, `#scrollToAnchor`, `#afterScroll`, `#scrollPrev`, `#scrollNext` + new `#axisScrollSize`/`#axisClientSize`, `#scrollTo` sign, `#maybeCrossSectionBoundary`).
- `#scrollTo` negates by ScrollModel `directionSign` (not blanket `#vertical`) — fixes the live vertical-rl-only FIXME.
- vertical-rl `rectStartProp` corrected `'left'`→`'right'` (logical start is the right edge under WebKit negative scrollLeft) in JS + the Swift `FoliateScrollModel` mirror; `#getRectMapper` made direction-aware (vertical-lr non-mirrored).
- **horizontal-tb is byte-identical** (directionSign +1 → identical expressions; the removed `!#vertical` guards were no-ops there).

Part of feature #76 (Bug #283 vertical residual). Rebuilt `foliate-bundle.js`.

## Codex Audit

cc-suite / `codex exec`, gpt-5.5/high, read-only. **2 rounds, ship-as-is.** R1: High (vertical-rl right-edge `rectStartProp`) + Medium (vertical-lr `#getRectMapper`) + 2 Low — all fixed; R2 confirmed resolved + **horizontal-tb byte-identical across all sites**.

Audit log: `.claude/codex-audits/feat-feature-76-wi-3-remove-vertical-gates-audit.md`

## Validation

- [x] `FoliateVerticalWindowBundleTests` (11) + `FoliateScrollModelTests` (6) + `FoliateScrolledWindowMathTests` (19) + `FoliatePaginatorScrollBoundaryTests` (15) + `FoliateVerticalContainerLayoutTests` (5) — all green
- [x] Codex audit (2 rounds, ship-as-is)
- [x] Docs sync — n/a (vendored-JS substrate)
- [x] Version bumped: 3.42.37 → 3.42.38
- [x] **Device-verified (idb) — horizontal regression**: mini-azw3 scroll mode scrolls continuously through title → full story body, no blank/jump/stuck (the #73 path is intact after the core scroll-math rewrite). Evidence: `dev-docs/verification/artifacts/feature-76-wi3-horizontal-azw3-continuous-scroll-20260602.png`. **Vertical-rl device verification is WI-5** (no vertical-rl AZW3 DebugBridge seed; the real `被讨厌的勇气.azw3` needs sim-transfer).

## Type of Change

- [x] Feature work item (Part of #76)

🤖 Generated with [Claude Code](https://claude.com/claude-code)