### PR TITLE
feat(#82 WI-2): Bug #308 AI-button entry + AIReaderAvailability per-profile alignment

### DIFF
--- a/.claude/codex-audits/feat-feature-82-wi-2-bug308-availability-audit.md
+++ b/.claude/codex-audits/feat-feature-82-wi-2-bug308-availability-audit.md
@@ -1,0 +1,36 @@
+---
+branch: feat/feature-82-wi-2-bug308-availability
+threadId: 019e886c-6c61-7913-a71a-403eb9ccdd20
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-02
+---
+
+# Gate-4 implementation audit — Feature #82 WI-2 (Bug #308 entry + AIReaderAvailability alignment)
+
+Codex gpt-5.5 / high, read-only (via `scripts/run-codex.sh`). Audited the
+`AIReaderAvailability` alignment (the Gate-2 Critical) + the standalone
+`ReaderAIReadinessSheet` (Bug #308 AI-button entry) + the `ReaderContainerView.onAI`
+routing.
+
+## Verdict
+
+Round 1: **follow-up-recommended** — 0 Critical/High, 2 Medium. Both FIXED → post-fix
+**ship-as-is**. Auditor confirmed the core no-legacy regression: active provider +
+per-profile key now makes `isAvailable` pass (fixing the #308 loop); the active-id
+UserDefaults read is synchronous + fresh per access.
+
+## Findings + resolutions
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| `AIReaderAvailability.swift` | Medium | Legacy-key fallback ran BEFORE the active-provider check — a stale legacy key could mask a key-less active profile, making `isAvailable` true while the live request throws `apiKeyMissing` (divergent from the live gate) | Reordered: **active provider first** (its per-profile key is authoritative when an active profile exists); legacy fallback only when NO active profile. New inverse test `unavailable_legacyKeyButActiveProviderHasNoKey`. |
+| `ReaderContainerView.swift` | Medium | `onReady` set `showAIReadiness=false` + `showAIPanel=true` in one update (sibling-sheet handoff drops the panel) | `onReady` sets a `pendingOpenAIPanelAfterReadiness` flag + dismisses readiness; the panel opens from the readiness sheet's `.sheet(onDismiss:)` (the #81 pattern). |
+
+## Tests
+
+- `AIReaderAvailabilityPerProfileTests` (7): per-profile key (no legacy) → available
+  (the #308 regression); flag-off / no-consent / keyless-active / no-provider-no-legacy
+  → unavailable; legacy fallback (no profiles) → available; **legacy key + keyless
+  active profile → unavailable** (the Gate-4 fix). Existing `AIReaderIntegrationTests`
+  + `ReaderAIProvidersFlowTests` regression green.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 812
-        MARKETING_VERSION: 3.43.3
+        CURRENT_PROJECT_VERSION: 813
+        MARKETING_VERSION: 3.44.0
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -410,6 +410,7 @@
 		432C40433346C054B7EC5D07 /* ReduceMotionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4425D7764DA53AD595FF93 /* ReduceMotionHelper.swift */; };
 		432FAED1CA14525CAB953BC3 /* UnifiedTextRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A1A428419630E618721E37 /* UnifiedTextRenderer.swift */; };
 		4331E31295D932065A8E3DCB /* HighlightListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD7F2C7E93907B97A730010 /* HighlightListViewModel.swift */; };
+		43668756F842A8C891FCC1BF /* AIReaderAvailabilityPerProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B92E2A0146CEC96DB224FE99 /* AIReaderAvailabilityPerProfileTests.swift */; };
 		43915A8DDE117AD0E0118A28 /* FileAvailabilityBadgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637D35BECC7768038F474E5E /* FileAvailabilityBadgeTests.swift */; };
 		43BD02365D537972791DF4D5 /* ReaderAuditFixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DA904E79F5CF69E46ECC26 /* ReaderAuditFixTests.swift */; };
 		43E5608C73F29F783F64BE8A /* ReaderNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DB169F568633A25E157B4DE /* ReaderNavigationTests.swift */; };
@@ -1056,6 +1057,7 @@
 		B43AA88511EE1FDB4E5D0565 /* AISummaryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BEF8E9F5CAD4246490C06D /* AISummaryCard.swift */; };
 		B463893D3C3558483F25BDCF /* AISettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0C783DCFD9CFDD8F488F80 /* AISettingsViewModel.swift */; };
 		B47FA1294B60A0652B9F0BCA /* FoliateReaderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E141EA554A8E0C1C3B36250 /* FoliateReaderViewModelTests.swift */; };
+		B4BE4D742D25DD7D487AF697 /* ReaderAIReadinessSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4AD7799181C8389AFF3F59 /* ReaderAIReadinessSheet.swift */; };
 		B4D2A7240900413D3A320FEA /* ReadingDashboardSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0147BC1F4C66F4EDB21608 /* ReadingDashboardSnapshotTests.swift */; };
 		B509E410B2ECC2B00275FD92 /* FoliateBilingualPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FBF157299A06F8948FB8689 /* FoliateBilingualPipeline.swift */; };
 		B5114E58420F95EFB408CA82 /* ReaderSettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A86CD6BD10792F5107FFB5A /* ReaderSettingsStoreTests.swift */; };
@@ -1922,6 +1924,7 @@
 		4989B9674C26B3825DF3C4D4 /* read.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = read.c; sourceTree = "<group>"; };
 		4A1B327713437D80D690ED9B /* ChapterTranslationChunkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterTranslationChunkerTests.swift; sourceTree = "<group>"; };
 		4A3BC126A794F2C82F782E7D /* TXTTextChunkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTTextChunkerTests.swift; sourceTree = "<group>"; };
+		4A4AD7799181C8389AFF3F59 /* ReaderAIReadinessSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderAIReadinessSheet.swift; sourceTree = "<group>"; };
 		4A57E82A7221B36240E501FD /* AIConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIConfigurationTests.swift; sourceTree = "<group>"; };
 		4A888610BD2499B817A278EB /* SearchResultRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultRow.swift; sourceTree = "<group>"; };
 		4AB6961454313724C5A3676A /* BookDetailsTagFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailsTagFlow.swift; sourceTree = "<group>"; };
@@ -2578,6 +2581,7 @@
 		B8D6186050D8E6FE32B2578B /* legado_source_js.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = legado_source_js.json; sourceTree = "<group>"; };
 		B90F4EB83CC68406DA14DD94 /* AIChatGeneralTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatGeneralTests.swift; sourceTree = "<group>"; };
 		B925BE5683D3296D77D3503B /* MockPersistenceActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPersistenceActor.swift; sourceTree = "<group>"; };
+		B92E2A0146CEC96DB224FE99 /* AIReaderAvailabilityPerProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReaderAvailabilityPerProfileTests.swift; sourceTree = "<group>"; };
 		B94F43CFA9AC0D681C75333D /* PDFReaderContainerView+Highlights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PDFReaderContainerView+Highlights.swift"; sourceTree = "<group>"; };
 		B9500033AC714D470A3024F8 /* EPUBPaginationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBPaginationTests.swift; sourceTree = "<group>"; };
 		B9B13E64FBD9D9A3063AC677 /* TXTChapterContentLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterContentLoaderTests.swift; sourceTree = "<group>"; };
@@ -3924,6 +3928,7 @@
 				BEF27FBFB95343D4BE50B1F4 /* PDFBilingualPanelBodies.swift */,
 				E8CFB25779576176F1D678C7 /* PDFBilingualPanelState.swift */,
 				B5476697062ADF98ABA39E9A /* ReaderAIProvidersFlow.swift */,
+				4A4AD7799181C8389AFF3F59 /* ReaderAIReadinessSheet.swift */,
 				AB40195193F2FC6B56384C75 /* ReaderAIReadinessView.swift */,
 				E8F7E4F4F972EB04756197F0 /* ReadinessProviderBlock.swift */,
 				9D94819027EB16D6337A38B9 /* ReadinessRows.swift */,
@@ -5034,6 +5039,7 @@
 				FFD1AE78FBFF38B3616352FF /* AIConsentManagerTests.swift */,
 				D1368D4DA7FCD1EC48778531 /* AIContextExtractorScopedTests.swift */,
 				20237121BB4ACF22C0818BA4 /* AIContextExtractorTests.swift */,
+				B92E2A0146CEC96DB224FE99 /* AIReaderAvailabilityPerProfileTests.swift */,
 				15C1B40888B5C8213559B111 /* AIRequestCacheKeyTests.swift */,
 				C5CB5C659CC573EF448F0992 /* AIResponseCacheTests.swift */,
 				28A6E86CE6A4730CD6F7D674 /* AIServiceProfileDispatchTests.swift */,
@@ -5723,6 +5729,7 @@
 				37B8708ABD85D7635B98995F /* AIEditorContextTests.swift in Sources */,
 				50CE60AB8A7F591C45CEB976 /* AIProviderEditSheetSaveSuccessTests.swift in Sources */,
 				BB03511CFAB402BC18C393B7 /* AIProviderPickerViewModelTests.swift in Sources */,
+				43668756F842A8C891FCC1BF /* AIReaderAvailabilityPerProfileTests.swift in Sources */,
 				4E2207CD7F48BCE945A0971C /* AIReaderIntegrationTests.swift in Sources */,
 				4597AB9A7B4EC164B6F67B67 /* AIReaderPanelDebugBridgeAIActionTests.swift in Sources */,
 				E92CBF70F353E737625B557F /* AIRequestCacheKeyTests.swift in Sources */,
@@ -6775,6 +6782,7 @@
 				1486C59650FEE786655A27F0 /* ReTranslateProgress.swift in Sources */,
 				F2BD86F42ADB5A9CAF16B57A /* ReaderAICoordinator.swift in Sources */,
 				04EE6E5BEC23E9824FB4B63F /* ReaderAIProvidersFlow.swift in Sources */,
+				B4BE4D742D25DD7D487AF697 /* ReaderAIReadinessSheet.swift in Sources */,
 				8E140846AE562243B7CEFA0F /* ReaderAIReadinessView.swift in Sources */,
 				50CB24522FC7CCD97EE58224 /* ReaderBottomChrome.swift in Sources */,
 				252CB71020888B6952C2F69E /* ReaderBottomOverlay.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7237,7 +7237,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 812;
+				CURRENT_PROJECT_VERSION = 813;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7245,7 +7245,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.43.3;
+				MARKETING_VERSION = 3.44.0;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7391,7 +7391,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 812;
+				CURRENT_PROJECT_VERSION = 813;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7399,7 +7399,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.43.3;
+				MARKETING_VERSION = 3.44.0;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Services/AI/AIReaderAvailability.swift
+++ b/vreader/Services/AI/AIReaderAvailability.swift
@@ -38,7 +38,8 @@ enum AIReaderAvailability {
     static func isAvailable(
         featureFlags: FeatureFlags,
         keychainService: KeychainService,
-        consentManager: AIConsentManager
+        consentManager: AIConsentManager,
+        providerPreferences: any PreferenceStoring = UserDefaultsPreferenceStore()
     ) -> Bool {
         #if DEBUG
         // Bug #237: the --enable-ai XCUITest launch flag forces availability
@@ -48,21 +49,50 @@ enum AIReaderAvailability {
         if AITestOverride.forceAvailable { return true }
         #endif
         guard featureFlags.aiAssistant else { return false }
-        guard hasAPIKey(keychainService: keychainService) else { return false }
+        guard hasAPIKey(keychainService: keychainService, providerPreferences: providerPreferences) else { return false }
         return consentManager.hasConsent
     }
 
-    /// Returns true when a non-empty API key exists in the keychain.
+    /// Returns true when a usable API key exists — either the legacy single-key
+    /// account OR the **active provider profile's per-profile key**.
     ///
-    /// - Parameter keychainService: The keychain service to check.
-    /// - Returns: Whether an API key is saved.
-    static func hasAPIKey(keychainService: KeychainService) -> Bool {
-        guard let key = try? keychainService.readString(
-            forAccount: AIService.apiKeyAccount
-        ) else {
+    /// Feature #82 / Bug #308: the AI panel/button previously gated only on the
+    /// legacy `AIService.apiKeyAccount` key, so a user who configured a provider
+    /// through the multi-profile path (in-reader readiness flow, Library AI
+    /// settings) had no legacy key and the AI button stayed a silent no-op —
+    /// looping back to readiness forever. This now mirrors the gate the live
+    /// request path (`AIService` / `BilingualAIReadiness`) actually uses. The
+    /// active-provider lookup is a synchronous static read of the same
+    /// UserDefaults the shared `ProviderProfileStore` writes, so `isAvailable`
+    /// stays sync (no async ripple) and re-reads fresh on each access.
+    ///
+    /// - Parameters:
+    ///   - keychainService: The keychain to read keys from.
+    ///   - providerPreferences: The preference store the provider list lives in
+    ///     (defaults to the shared `UserDefaultsPreferenceStore`).
+    static func hasAPIKey(
+        keychainService: KeychainService,
+        providerPreferences: any PreferenceStoring = UserDefaultsPreferenceStore()
+    ) -> Bool {
+        // Active provider FIRST — mirror the live request gate
+        // (`AIService.resolveProvider` uses the active profile). When an active
+        // profile exists, ITS per-profile key is authoritative: a stale legacy
+        // key must NOT mask a key-less active profile (which would make
+        // `isAvailable` true while the request throws `apiKeyMissing`).
+        if let activeID = DefaultProviderProfileMigrator.readActiveID(preferences: providerPreferences) {
+            if let key = try? keychainService.readAPIKey(forProfile: activeID),
+               !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return true
+            }
             return false
         }
-        return !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        // No active profile → legacy single-key fallback (pre-migration installs
+        // that never adopted the multi-profile store).
+        if let legacy = try? keychainService.readString(forAccount: AIService.apiKeyAccount),
+           !legacy.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return true
+        }
+        return false
     }
 }
 

--- a/vreader/Views/Reader/Bilingual/ReaderAIReadinessSheet.swift
+++ b/vreader/Views/Reader/Bilingual/ReaderAIReadinessSheet.swift
@@ -1,0 +1,40 @@
+// Purpose: Feature #82 WI-2 / Bug #308 — the STANDALONE entry to the AI
+// readiness flow, presented from the reader bottom-bar AI button when AI is
+// unconfigured (instead of the old silent no-op). Unlike the bilingual entry
+// (which pushes `ReaderAIReadinessView` inside the bilingual sheet's
+// NavigationStack via `BilingualSetupSheetContainer`), this owns its OWN
+// `@State` flow + `NavigationStack`, so it doesn't depend on the bilingual
+// stack's push state.
+//
+// On the ready transition the flow fires `onConfigured` → `onReady`, which the
+// host wires to "dismiss this sheet (+ open the AI panel)". Because the host's
+// AI-availability gate now mirrors the active-provider per-profile key
+// (`AIReaderAvailability` fix), the next AI-button tap opens the panel rather
+// than looping back here.
+//
+// @coordinates-with: ReaderAIReadinessView.swift, ReaderAIProvidersFlow.swift,
+//   ReaderContainerView.swift (onAI), AIReaderAvailability.swift
+
+import SwiftUI
+
+/// Standalone presentation of the readiness flow for the Bug #308 AI-button
+/// entry. `onReady` fires once all four gates clear (dismiss + open the panel).
+struct ReaderAIReadinessSheet: View {
+
+    let theme: ReaderThemeV2
+    @State private var flow: ReaderAIProvidersFlow
+
+    init(theme: ReaderThemeV2, onReady: @escaping () -> Void) {
+        self.theme = theme
+        // The flow's `onConfigured` fires on the in-session not-ready→ready
+        // transition (the user arrived here BECAUSE AI was unconfigured, so
+        // `startedReady` is false — the transition pop is exactly "now ready").
+        _flow = State(initialValue: ReaderAIProvidersFlow(onConfigured: { onReady() }))
+    }
+
+    var body: some View {
+        NavigationStack {
+            ReaderAIReadinessView(theme: theme, flow: flow)
+        }
+    }
+}

--- a/vreader/Views/Reader/ReaderContainerView.swift
+++ b/vreader/Views/Reader/ReaderContainerView.swift
@@ -82,6 +82,13 @@ struct ReaderContainerView: View {
     /// file is presented — driven by the More-menu's "Share book" row.
     @State var showShareSheet = false
     @State var showAIPanel = false
+    /// Bug #308 (Feature #82): the in-reader AI readiness sheet, presented from
+    /// the bottom-bar AI button when AI is unconfigured (instead of a no-op).
+    @State var showAIReadiness = false
+    /// Bug #308: when readiness completes, open the AI panel — but only AFTER
+    /// the readiness sheet fully dismisses (sibling-sheet handoff; opening both
+    /// in one update drops the panel). Set on ready, consumed in `onDismiss`.
+    @State var pendingOpenAIPanelAfterReadiness = false
     @State var aiInitialTab: AIReaderTab = .summarize
     #if DEBUG
     /// Bug #256 — the AI sheet's active detent, bound to its
@@ -310,11 +317,13 @@ struct ReaderContainerView: View {
             },
             onDisplay: { showSettings = true },
             onAI: {
-                // Mirrors the legacy chrome's AI gate — a no-op when
-                // AI isn't configured rather than presenting an empty
-                // sheet.
                 if resolvedAICoordinator.isAIAvailable {
                     showAIPanel = true
+                } else {
+                    // Bug #308 (Feature #82): instead of a silent no-op, route the
+                    // unconfigured tap to the in-reader AI readiness sheet so the
+                    // user can enable AI + grant consent + add a provider in place.
+                    showAIReadiness = true
                 }
             }
         )
@@ -354,6 +363,26 @@ struct ReaderContainerView: View {
             aiPanelDetent = .medium
             #endif
         }) { aiSheet }
+        // Bug #308 (Feature #82): the readiness sheet for the unconfigured
+        // AI-button tap. On the ready transition it dismisses + opens the AI
+        // panel — the availability gate now mirrors the active-provider
+        // per-profile key, so the panel actually opens (no loop back).
+        .sheet(isPresented: $showAIReadiness, onDismiss: {
+            // Sibling-sheet handoff: open the AI panel only after readiness has
+            // fully dismissed (matches the #81 .sheet(onDismiss:) pattern).
+            if pendingOpenAIPanelAfterReadiness {
+                pendingOpenAIPanelAfterReadiness = false
+                showAIPanel = true
+            }
+        }) {
+            ReaderAIReadinessSheet(
+                theme: settingsStore.theme,
+                onReady: {
+                    pendingOpenAIPanelAfterReadiness = true
+                    showAIReadiness = false
+                }
+            )
+        }
         .onReceive(NotificationCenter.default.publisher(for: .readerDefineRequested)) { notification in
             guard let info = notification.object as? TextSelectionInfo else { return }
             if let word = DictionaryLookup.extractWord(from: info.selectedText) {

--- a/vreaderTests/Services/AI/AIReaderAvailabilityPerProfileTests.swift
+++ b/vreaderTests/Services/AI/AIReaderAvailabilityPerProfileTests.swift
@@ -1,0 +1,124 @@
+// Purpose: Feature #82 / Bug #308 — pin that AI reader availability mirrors the
+// ACTIVE PROVIDER's per-profile key, not only the legacy single-key account.
+// Before the fix, a user who configured a provider through the multi-profile
+// path (the in-reader readiness flow / Library AI settings) had no legacy key,
+// so the AI button stayed a silent no-op and looped back to readiness forever.
+//
+// @coordinates-with: vreader/Services/AI/AIReaderAvailability.swift,
+//   ProviderProfileMigrator.swift, KeychainService+ProviderProfile.swift
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("AIReaderAvailability — active-provider per-profile key (Feature #82 / Bug #308)")
+@MainActor
+struct AIReaderAvailabilityPerProfileTests {
+
+    private func keychain() -> KeychainService {
+        KeychainService(serviceIdentifier: "com.vreader.test.\(UUID().uuidString)")
+    }
+    private func flags(ai: Bool) -> FeatureFlags {
+        let f = FeatureFlags(environment: .prod); f.setOverride(ai, for: .aiAssistant); return f
+    }
+    private func consent(_ granted: Bool) -> AIConsentManager {
+        let c = AIConsentManager(defaults: UserDefaults(suiteName: "com.vreader.test.consent.\(UUID().uuidString)")!)
+        if granted { c.grantConsent() }
+        return c
+    }
+    private func profile(_ id: UUID) -> ProviderProfile {
+        let kind = ProviderKind.openAICompatible
+        return ProviderProfile(id: id, name: "P", kind: kind, baseURL: kind.defaultBaseURL,
+                               model: kind.defaultModel, temperature: 0.7, maxTokens: 2048)
+    }
+
+    private func resetOverride() {
+        #if DEBUG
+        AITestOverride.forceAvailable = false
+        #endif
+    }
+
+    // MARK: - The Bug #308 regression: per-profile key, NO legacy key
+
+    @Test func available_withActiveProviderPerProfileKey_noLegacyKey() throws {
+        resetOverride()
+        let kc = keychain()
+        let prefs = MockPreferenceStore()
+        let id = UUID()
+        DefaultProviderProfileMigrator.writeProfiles([profile(id)], activeID: id, preferences: prefs)
+        try kc.saveAPIKey("sk-perprofile", forProfile: id)   // per-profile key, NO legacy key
+
+        let result = AIReaderAvailability.isAvailable(
+            featureFlags: flags(ai: true), keychainService: kc,
+            consentManager: consent(true), providerPreferences: prefs)
+        #expect(result == true, "an active provider with a per-profile key must make AI available even without a legacy key")
+    }
+
+    // MARK: - Gating still applies
+
+    @Test func unavailable_whenFlagOff() throws {
+        resetOverride()
+        let kc = keychain(); let prefs = MockPreferenceStore(); let id = UUID()
+        DefaultProviderProfileMigrator.writeProfiles([profile(id)], activeID: id, preferences: prefs)
+        try kc.saveAPIKey("sk", forProfile: id)
+        #expect(AIReaderAvailability.isAvailable(
+            featureFlags: flags(ai: false), keychainService: kc,
+            consentManager: consent(true), providerPreferences: prefs) == false)
+    }
+
+    @Test func unavailable_whenNoConsent() throws {
+        resetOverride()
+        let kc = keychain(); let prefs = MockPreferenceStore(); let id = UUID()
+        DefaultProviderProfileMigrator.writeProfiles([profile(id)], activeID: id, preferences: prefs)
+        try kc.saveAPIKey("sk", forProfile: id)
+        #expect(AIReaderAvailability.isAvailable(
+            featureFlags: flags(ai: true), keychainService: kc,
+            consentManager: consent(false), providerPreferences: prefs) == false)
+    }
+
+    @Test func unavailable_whenActiveProviderHasNoKey() {
+        resetOverride()
+        let kc = keychain(); let prefs = MockPreferenceStore(); let id = UUID()
+        DefaultProviderProfileMigrator.writeProfiles([profile(id)], activeID: id, preferences: prefs)
+        // no key saved for the active provider, no legacy key
+        #expect(AIReaderAvailability.isAvailable(
+            featureFlags: flags(ai: true), keychainService: kc,
+            consentManager: consent(true), providerPreferences: prefs) == false)
+    }
+
+    @Test func unavailable_whenNoProviderAndNoLegacyKey() {
+        resetOverride()
+        #expect(AIReaderAvailability.isAvailable(
+            featureFlags: flags(ai: true), keychainService: keychain(),
+            consentManager: consent(true), providerPreferences: MockPreferenceStore()) == false)
+    }
+
+    // MARK: - Legacy single-key install still works (fallback)
+
+    @Test func available_withLegacyKey_noProfiles() throws {
+        resetOverride()
+        let kc = keychain()
+        try kc.saveString("sk-legacy", forAccount: AIService.apiKeyAccount)
+        #expect(AIReaderAvailability.isAvailable(
+            featureFlags: flags(ai: true), keychainService: kc,
+            consentManager: consent(true), providerPreferences: MockPreferenceStore()) == true)
+    }
+
+    // MARK: - Active provider takes precedence over a stale legacy key (Gate-4 fix)
+
+    @Test func unavailable_legacyKeyButActiveProviderHasNoKey() throws {
+        resetOverride()
+        let kc = keychain()
+        let prefs = MockPreferenceStore()
+        let id = UUID()
+        DefaultProviderProfileMigrator.writeProfiles([profile(id)], activeID: id, preferences: prefs)
+        // A stale legacy key exists, but the ACTIVE profile has none. The live
+        // request path uses the active profile → would throw apiKeyMissing, so
+        // the gate must NOT be masked into "available" by the legacy key.
+        try kc.saveString("sk-legacy", forAccount: AIService.apiKeyAccount)
+        #expect(AIReaderAvailability.isAvailable(
+            featureFlags: flags(ai: true), keychainService: kc,
+            consentManager: consent(true), providerPreferences: prefs) == false,
+            "an active profile with no key is unavailable even if a stale legacy key exists")
+    }
+}


### PR DESCRIPTION
## Summary
Completes **Feature #82** (the AI-gating capstone) and fixes **Bug #308**. Final WI.

Refs #1402

## What changed
- **`AIReaderAvailability`** now mirrors the live request gate: `hasAPIKey` checks the **active provider's per-profile key first** (sync static UserDefaults read + keychain — `isAvailable` stays sync + fresh), legacy single-key only as fallback when no active profile. Fixes the #308 loop (a per-profile-configured user's AI button was a silent no-op because the legacy gate never saw the key).
- New **`ReaderAIReadinessSheet`** — standalone readiness entry (own NavigationStack + flow); on ready → `onReady` (dismiss + open panel).
- **`ReaderContainerView.onAI`**: unconfigured tap → readiness sheet (not no-op); on ready → open AI panel via `.sheet(onDismiss:)` sibling-handoff.

## Codex Audit (Gate 4)
ship-as-is — 2 Mediums fixed (active-provider-first ordering; onDismiss handoff). Log: `.claude/codex-audits/feat-feature-82-wi-2-bug308-availability-audit.md`.

## Validation
- [x] 7 availability tests (per-profile #308 regression + legacy-masking inverse + gating); `AIReaderIntegrationTests` + `ReaderAIProvidersFlowTests` regression green
- [x] Version bumped 3.43.3 → 3.44.0 (minor — final WI)

## Gate 5a/5b Verification (device)
iPhone 17 Pro Sim, v3.44.0. **Bug #308**: AI button (providers cleared → unconfigured) → opened the readiness sheet (vs the old no-op). **Critical fix**: with provider (per-profile key, no legacy key) seeded, toggling the gates to ready → readiness dismissed and the **AI panel opened** showing the active provider — `isAvailable` recognizes the per-profile key, no loop. 5b evidence file lands post-merge.

## Type of Change
- [x] Feature WI — final (Refs #1402); also fixes Bug #308 (#1396)