### PR TITLE
feat(#83): Readium cross-chapter continuous scroll (fixes Bug #309)

### DIFF
--- a/.claude/codex-audits/feat-feature-83-wi-continuous-scroll-audit.md
+++ b/.claude/codex-audits/feat-feature-83-wi-continuous-scroll-audit.md
@@ -1,0 +1,38 @@
+---
+branch: feat/feature-83-wi-continuous-scroll
+threadId: 019e88b3-1e26-7793-9b37-8650b207b686
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-02
+---
+
+# Gate-4 implementation audit — Feature #83 (Readium cross-chapter continuous scroll)
+
+Codex gpt-5.5 / high, read-only (via `scripts/run-codex.sh`). Audited the boundary
+auto-advance impl (model + observer + weak proxy + coordinator wiring) against the
+plan. WI-1 feasibility spike already PROVED the JS boundary signal on device
+(round-1 thread `019e889e-3c8e-79c2-9c7b-99231e37d0a2`).
+
+## Verdict
+
+Round 1: **block-recommended** — 1 High + 1 Medium. Round 2: **ship-as-is** — both
+RESOLVED, no new issues. Auditor confirmed clean: edge math/direction, scroll-layout
+gating, fixed JS string injection (no app interpolation), weak-proxy retention shape,
+paged-mode gate, and the locationDidChange-driven bilingual/TTS/position paths.
+
+## Findings + resolutions
+
+| Round | File | Severity | Issue | Resolution |
+|---|---|---|---|---|
+| 1 | `ReadiumEPUBHost+ContinuousScroll.swift` | High | 0.7s per-proxy debounce only — a slow transition / long-held drag could let the stale outgoing spread post again → double-advance / chapter-skip | Added coordinator-owned `continuousScrollAdvancing` in-flight guard: set before `goForward`/`goBackward`, cleared in the same Task after the navigation await settles + on `locationDidChange` / `detach()` / layout change. Gates out stale-spread messages across spreads. |
+| 1 | `ReadiumEPUBHost+ContinuousScroll.swift` | Medium | `handleContinuousScrollBoundary` captured `boundNavigator` before the async Task → could drive a torn-down navigator after detach | Task now re-reads the weak navigator inside (`[weak self] guard let navigator = self.boundNavigator`), mirroring `+Navigation`; `detach()` nils it. |
+
+## Tests + device verification
+
+- `ReadiumContinuousScrollModelTests` (9): edge math, direction, scroll-layout gate,
+  debounce tolerance, zero-geometry.
+- WI-1 device spike: the `setupUserScripts` boundary observer fires reliably
+  (`window.scrollY`/`scrollHeight`/`innerHeight` valid + monotonic in Readium scroll).
+- Device acceptance: scrolling past ALPHA's bottom auto-advanced to BRAVO (Chapter Two)
+  and continued scrolling — the #309 cross-chapter continuity, restored (auto-advance,
+  honest seam per Gate-2).

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 815
-        MARKETING_VERSION: 3.44.2
+        CURRENT_PROJECT_VERSION: 816
+        MARKETING_VERSION: 3.45.0
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -365,6 +365,7 @@
 		3A49641C17BE1F189457C72C /* SettingsSliderRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADFBB978A77BD6B9E977F36 /* SettingsSliderRowTests.swift */; };
 		3A57CF035C836650B0FC668B /* SyncPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = D054A0A5EF2A48B83A3DFE53 /* SyncPipeline.swift */; };
 		3AB78E0F4510E5C661622EDD /* LibraryPopulatedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68D7B5F0EC86B4E39725EC9 /* LibraryPopulatedTests.swift */; };
+		3B226735B8F75224A6C366CD /* ReadiumEPUBHost+ContinuousScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3711151306A3ED68FBF7A3D2 /* ReadiumEPUBHost+ContinuousScroll.swift */; };
 		3B381CF830FBCE7C8A553E36 /* SheetReSkinSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C20894DFE22D83069C6D505 /* SheetReSkinSnapshotTests.swift */; };
 		3B4C20571A5F6A0F46295D75 /* ProviderKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2652A8EB81DF49609A3EDAC8 /* ProviderKind.swift */; };
 		3B62997EF7304D0ACFBF141D /* HighlightableTextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E293CFD61A19BB48B38963 /* HighlightableTextViewTests.swift */; };
@@ -496,6 +497,7 @@
 		514822215748FA807FA36FE2 /* HighlightCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2724D3C50EDE1DC1DA43BB5F /* HighlightCoordinatorTests.swift */; };
 		5168983F9EDD267778A9EEC9 /* TXTChapterIndexBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3910DCA9C9F588B700679D76 /* TXTChapterIndexBuilder.swift */; };
 		51E930F9FAF162DCA306BA63 /* ReTranslatePickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C1D13DF31CB3EFEE7032F8A /* ReTranslatePickerSheet.swift */; };
+		51EF2235646EF01CF92D5788 /* ReadiumContinuousScrollModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95639750C6DD564417CCA244 /* ReadiumContinuousScrollModelTests.swift */; };
 		51F370150CAD9A865053266C /* HighlightIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABEAF0841AD808F7EE48617 /* HighlightIntegrationTests.swift */; };
 		51F3C0591CD80685D3BD0117 /* BookTranslationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C344E898312308F197E6EF5E /* BookTranslationViewModel.swift */; };
 		51F6D90704CD88D8F5160E19 /* FoliateStyleMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42E9BBD87941E0D6C66010EC /* FoliateStyleMapperTests.swift */; };
@@ -923,6 +925,7 @@
 		9AEE4782EDC4308FAA289B3B /* AccentColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13404BD286B135797ECF391A /* AccentColor.swift */; };
 		9AF587978D1D58F58C7E8A23 /* UnifiedTextRendererViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7056486BA460E0BE06235F54 /* UnifiedTextRendererViewModel.swift */; };
 		9B04DEA549D9C760DD6D3C3E /* BookSourceListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F971403A2807A2788FD2D99F /* BookSourceListView.swift */; };
+		9BA3283DCEC5081F0A314DB7 /* ReadiumContinuousScrollModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A54B694558A193B889A747 /* ReadiumContinuousScrollModel.swift */; };
 		9BF39FDF19F34D65452D4C79 /* WebDAVNetworkPolicyEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E2D1C060B3EF0B66847F23 /* WebDAVNetworkPolicyEnvironment.swift */; };
 		9BF4E606FB4C251BD4492FA9 /* BackupReadingHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9E42127F86EB76595AD46B /* BackupReadingHistoryTests.swift */; };
 		9C0C69EAD4FE812FB41F6525 /* TextMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6266DCAB5ADCBB1B3257D9 /* TextMapper.swift */; };
@@ -1798,6 +1801,7 @@
 		36B6C9DDFFC8DC87C03983B5 /* ReaderContainerView+DebugBridgePosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderContainerView+DebugBridgePosition.swift"; sourceTree = "<group>"; };
 		36EE33B24FB16F8AC319BDB2 /* FoliateMessageParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateMessageParser.swift; sourceTree = "<group>"; };
 		36FC80576CA3D3C7EB629247 /* DurableTombstoneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DurableTombstoneStore.swift; sourceTree = "<group>"; };
+		3711151306A3ED68FBF7A3D2 /* ReadiumEPUBHost+ContinuousScroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReadiumEPUBHost+ContinuousScroll.swift"; sourceTree = "<group>"; };
 		3726EE2E777A431B2993FE12 /* PageAxisResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageAxisResolver.swift; sourceTree = "<group>"; };
 		3743321B8FFE925BFB43D262 /* BackupViewModelSelectiveRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupViewModelSelectiveRestoreTests.swift; sourceTree = "<group>"; };
 		3753D7CD01EA589932DF780C /* ThemeBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeBackgroundView.swift; sourceTree = "<group>"; };
@@ -2381,6 +2385,7 @@
 		95424A5FBB4CD4804BFDB61D /* ReaderBridgeSideTapWiringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderBridgeSideTapWiringTests.swift; sourceTree = "<group>"; };
 		954E578C5D58FF04DD5D582F /* LibraryNavBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryNavBar.swift; sourceTree = "<group>"; };
 		95574A908E5A45E773CF0D0B /* TXTReaderContainerView+Paged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TXTReaderContainerView+Paged.swift"; sourceTree = "<group>"; };
+		95639750C6DD564417CCA244 /* ReadiumContinuousScrollModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumContinuousScrollModelTests.swift; sourceTree = "<group>"; };
 		958438144E0D4CC1945E550E /* NotesActionMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesActionMenu.swift; sourceTree = "<group>"; };
 		95B006129C2FCEC99B9FBB91 /* RemoteBookCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBookCatalogTests.swift; sourceTree = "<group>"; };
 		95B9ADB001D66D4A6EC07C9A /* VerificationDebugBridgeHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationDebugBridgeHelper.swift; sourceTree = "<group>"; };
@@ -2633,6 +2638,7 @@
 		C24D5425530ABBE0DDA4758F /* TXTChunkedHighlightDeferredTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChunkedHighlightDeferredTimerTests.swift; sourceTree = "<group>"; };
 		C2780A3796872F31F1666DA7 /* ReaderTOCBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTOCBuilder.swift; sourceTree = "<group>"; };
 		C2997AAAB34DF84E64DC0DB4 /* MOBICoverExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MOBICoverExtractor.swift; sourceTree = "<group>"; };
+		C2A54B694558A193B889A747 /* ReadiumContinuousScrollModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumContinuousScrollModel.swift; sourceTree = "<group>"; };
 		C2D49361893EE9956D6EC5DB /* TXTOffsetMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTOffsetMapper.swift; sourceTree = "<group>"; };
 		C2E89BEB1454E17061367313 /* Feature64EPUBMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature64EPUBMigrationTests.swift; sourceTree = "<group>"; };
 		C3101BC67249AD8280F55AFA /* ReadiumOpenSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumOpenSmokeTests.swift; sourceTree = "<group>"; };
@@ -3627,6 +3633,7 @@
 				44CDE923DD9CB934E3E42969 /* ReaderTOCTXTAlignmentTests.swift */,
 				63E4737FA3A880C3CC2BA07D /* ReadingProgressBarTests.swift */,
 				9E832BE02889C93E96998938 /* ReadiumBottomChromeSeekTests.swift */,
+				95639750C6DD564417CCA244 /* ReadiumContinuousScrollModelTests.swift */,
 				0690CFD7EBDB5EFF481F2202 /* ReadiumEPUBHostTests.swift */,
 				03321A13C86F9E69BE338864 /* ReadiumNavCommanderTests.swift */,
 				CD909811249AF108809A8E38 /* ReadiumSelectionTokenCacheTests.swift */,
@@ -4257,6 +4264,7 @@
 				82199531AD7036AB0F37C56C /* ReaderTopChrome.swift */,
 				50AA77FDB19CB7EDA69418C8 /* ReaderUnifiedCoordinator.swift */,
 				68A7FC6A70A060CD5E43602E /* ReadingProgressBar.swift */,
+				C2A54B694558A193B889A747 /* ReadiumContinuousScrollModel.swift */,
 				6914428EA8FF673A76DDFF66 /* ReadiumEPUBHost.swift */,
 				1CCF81569818568122ED66F5 /* ReadiumEPUBHost+Annotations.swift */,
 				DB02D21C1EF95E878B2A1B5E /* ReadiumEPUBHost+Background.swift */,
@@ -4264,6 +4272,7 @@
 				2B29ECB0699594B79632E3EE /* ReadiumEPUBHost+BilingualDriver.swift */,
 				5A746E0EDC5F1208A0774008 /* ReadiumEPUBHost+Body.swift */,
 				903AC337CD91275FE06EDE15 /* ReadiumEPUBHost+BottomChrome.swift */,
+				3711151306A3ED68FBF7A3D2 /* ReadiumEPUBHost+ContinuousScroll.swift */,
 				820C166494A63E2245B18252 /* ReadiumEPUBHost+Highlights.swift */,
 				63ADF5E2B0D325F0B4F552D2 /* ReadiumEPUBHost+Navigation.swift */,
 				57171272166BB46F00A14A91 /* ReadiumEPUBHost+TTSFollow.swift */,
@@ -6151,6 +6160,7 @@
 				BA6B419E180F3EC54680DDCE /* ReadiumBilingualCommanderTests.swift in Sources */,
 				0B2C125F4B243C2D1D0874B0 /* ReadiumBilingualEvalAdapterTests.swift in Sources */,
 				020F29712F38DB3630EBACDD /* ReadiumBottomChromeSeekTests.swift in Sources */,
+				51EF2235646EF01CF92D5788 /* ReadiumContinuousScrollModelTests.swift in Sources */,
 				1B2EF4DD9E11CE736EDCAC1E /* ReadiumDebugProbeTests.swift in Sources */,
 				6B8ED541073183163907D347 /* ReadiumDecorationHighlightAdapterTests.swift in Sources */,
 				50526F6EDA9CF826BAB1552B /* ReadiumDecorationTapEventTests.swift in Sources */,
@@ -6843,6 +6853,7 @@
 				C66E6BCF1D3CE1583DFACE2C /* ReadiumBilingualChapterTracker.swift in Sources */,
 				E0699A5EBCDBBBD2D56304DE /* ReadiumBilingualCommander.swift in Sources */,
 				C11851768B01D69A554324D0 /* ReadiumBilingualEvalAdapter.swift in Sources */,
+				9BA3283DCEC5081F0A314DB7 /* ReadiumContinuousScrollModel.swift in Sources */,
 				7A40E167BF58AD2D781145F4 /* ReadiumDebugProbe.swift in Sources */,
 				C5F12BF03440CB49AB7D882A /* ReadiumDecorationHighlightAdapter.swift in Sources */,
 				EB50B60631B71D60ADC3CE62 /* ReadiumEPUBHost+Annotations.swift in Sources */,
@@ -6851,6 +6862,7 @@
 				3BAE0F10DF996E3F0E5E1FE5 /* ReadiumEPUBHost+BilingualDriver.swift in Sources */,
 				F56CAC78114E34FA6CA59A53 /* ReadiumEPUBHost+Body.swift in Sources */,
 				F18A46C6062D915B86052E08 /* ReadiumEPUBHost+BottomChrome.swift in Sources */,
+				3B226735B8F75224A6C366CD /* ReadiumEPUBHost+ContinuousScroll.swift in Sources */,
 				0AEFE05A668B529B34DC0133 /* ReadiumEPUBHost+Highlights.swift in Sources */,
 				3EAB442DE25D46C0F1E8AB32 /* ReadiumEPUBHost+Navigation.swift in Sources */,
 				A87B42C58CE5E5DBE06D4FB9 /* ReadiumEPUBHost+TTSFollow.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7249,7 +7249,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 815;
+				CURRENT_PROJECT_VERSION = 816;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7257,7 +7257,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.44.2;
+				MARKETING_VERSION = 3.45.0;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7403,7 +7403,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 815;
+				CURRENT_PROJECT_VERSION = 816;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7411,7 +7411,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.44.2;
+				MARKETING_VERSION = 3.45.0;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Views/Reader/ReadiumContinuousScrollModel.swift
+++ b/vreader/Views/Reader/ReadiumContinuousScrollModel.swift
@@ -1,0 +1,60 @@
+// Purpose: Feature #83 WI-2 — the pure boundary-decision logic for Readium
+// cross-chapter continuous scroll. Given the scroll geometry the WI-1 spike
+// proved observable (`window.scrollY` == `scrollingElement.scrollTop`,
+// `scrollHeight`, `innerHeight`) + the drag direction + the layout, decide
+// whether to auto-advance to the next resource, retreat to the previous, or do
+// nothing. Pure + value-typed → unit-tested without a render path.
+//
+// The signal shape mirrors what the boundary observer posts (Gate-2 audit):
+// `(scrollY, scrollHeight, innerHeight, dragDelta, layout)`. `dragDelta > 0`
+// means the finger moved UP (a scroll-DOWN intent); `< 0` means DOWN (scroll-up
+// intent).
+//
+// @coordinates-with: ReadiumEPUBHost+ContinuousScroll.swift (the observer/wiring),
+//   ReadiumEPUBHost+Navigation.swift (goForward/goBackward),
+//   dev-docs/plans/20260602-feature-83-readium-continuous-scroll.md (WI-2)
+
+import Foundation
+
+/// The scroll geometry reported by the boundary observer.
+struct ReadiumScrollGeometry: Equatable, Sendable {
+    let scrollY: Double
+    let scrollHeight: Double
+    let innerHeight: Double
+}
+
+/// The decision the boundary signal resolves to.
+enum ReadiumScrollBoundaryDecision: Equatable, Sendable {
+    case advance   // at the bottom + dragging further down → goForward
+    case retreat   // at the top + dragging further up → goBackward
+    case none
+}
+
+enum ReadiumContinuousScrollModel {
+
+    /// Px tolerance for "at the edge" (rounding + sub-pixel layout).
+    static let edgeEpsilon: Double = 4
+    /// Minimum finger travel to count as a deliberate boundary drag (vs a tap
+    /// jitter).
+    static let minDragDelta: Double = 10
+
+    /// Resolve a boundary-drag signal. Only acts in `.scroll` layout.
+    /// - `dragDelta` > 0: finger up → scroll-down intent (advance at bottom).
+    /// - `dragDelta` < 0: finger down → scroll-up intent (retreat at top).
+    static func decide(
+        geometry g: ReadiumScrollGeometry,
+        dragDelta: Double,
+        layout: EPUBLayoutPreference
+    ) -> ReadiumScrollBoundaryDecision {
+        guard layout == .scroll else { return .none }
+        guard abs(dragDelta) >= minDragDelta else { return .none }
+        guard g.innerHeight > 0, g.scrollHeight > 0 else { return .none }
+
+        let atBottom = (g.scrollY + g.innerHeight) >= (g.scrollHeight - edgeEpsilon)
+        let atTop = g.scrollY <= edgeEpsilon
+
+        if dragDelta > 0 && atBottom { return .advance }
+        if dragDelta < 0 && atTop { return .retreat }
+        return .none
+    }
+}

--- a/vreader/Views/Reader/ReadiumEPUBHost+ContinuousScroll.swift
+++ b/vreader/Views/Reader/ReadiumEPUBHost+ContinuousScroll.swift
@@ -1,0 +1,155 @@
+// Purpose: Feature #83 WI-3 — Readium cross-chapter continuous scroll (resolves
+// Bug #309). Makes scroll mode flow across chapter boundaries: when the user
+// drags PAST the end (or start) of the current resource, auto-`goForward`
+// (`goBackward`) to the next (previous) spine item. WI-1 proved on device that a
+// `setupUserScripts`-injected observer can read `window.scrollY`/`scrollHeight`/
+// `innerHeight` (Readium scrolls the window/scrollingElement in scroll mode);
+// this wires that boundary-intent signal → `ReadiumContinuousScrollModel` →
+// `navigator.goForward(animated:false)`.
+//
+// Honest scope (Gate-2): AUTO-ADVANCE at the boundary (no manual swipe), NOT
+// pixel-continuous #71 stitching — Readium swaps resources via its own
+// transition, so a seam remains. Tracked + accepted on #1403.
+//
+// Lifecycle (Gate-2 audit): the message handler is a WEAK proxy (so the
+// Readium-owned, per-spread `WKUserContentController` that strongly retains it
+// cannot create a retain cycle to the coordinator); a per-spread debounce
+// prevents a double-advance during the resource transition; the observer is
+// self-gating to scroll layout (the proxy + the model both re-check
+// `currentLayout == .scroll`).
+//
+// @coordinates-with: ReadiumReaderCoordinator.swift,
+//   ReadiumReaderCoordinator+Transparency.swift (setupUserScripts),
+//   ReadiumContinuousScrollModel.swift, ReadiumEPUBHost+Navigation.swift
+
+#if canImport(UIKit)
+import UIKit
+import WebKit
+import ReadiumNavigator
+
+extension ReadiumReaderCoordinator {
+
+    /// Message-handler name for the boundary-intent observer.
+    static var continuousScrollHandlerName: String { "vreaderBoundary" }
+
+    /// Boundary-intent observer (atDocumentEnd). Posts ONLY when the user drags
+    /// past the resource edge while already scrolled there — `{scrollY,
+    /// scrollHeight, innerHeight, dragDelta}` (dragDelta>0 = finger up =
+    /// scroll-down intent). Fixed compile-time string (no app interpolation).
+    static var continuousScrollObserverJS: String {
+        """
+        (function(){
+          var H=window.webkit&&window.webkit.messageHandlers&&window.webkit.messageHandlers.\(continuousScrollHandlerName);
+          if(!H)return; if(window.__vreaderBoundary)return; window.__vreaderBoundary=true;
+          var sy=null;
+          function se(){return document.scrollingElement||document.documentElement;}
+          document.addEventListener('touchstart',function(e){if(e.touches.length)sy=e.touches[0].clientY;},{passive:true,capture:true});
+          document.addEventListener('touchmove',function(e){
+            if(sy===null||!e.touches.length)return;
+            var dy=sy-e.touches[0].clientY; var el=se();
+            var y=(window.scrollY||el.scrollTop||0); var h=(el.scrollHeight||0); var ih=window.innerHeight||0;
+            var atBot=(y+ih)>=(h-4); var atTop=y<=4;
+            if((dy>10&&atBot)||(dy<-10&&atTop)){
+              try{H.postMessage({scrollY:Math.round(y),scrollHeight:Math.round(h),innerHeight:Math.round(ih),dragDelta:Math.round(dy)});}catch(err){}
+            }
+          },{passive:true,capture:true});
+        })();
+        """
+    }
+
+    /// Install the observer + a WEAK message-handler proxy on a freshly set-up
+    /// spread content controller. Called from `setupUserScripts`.
+    func installContinuousScroll(on userContentController: WKUserContentController) {
+        userContentController.removeScriptMessageHandler(forName: Self.continuousScrollHandlerName)
+        userContentController.add(
+            ReadiumBoundaryScrollProxy(coordinator: self),
+            name: Self.continuousScrollHandlerName
+        )
+        userContentController.addUserScript(WKUserScript(
+            source: Self.continuousScrollObserverJS,
+            injectionTime: .atDocumentEnd, forMainFrameOnly: false
+        ))
+    }
+
+    /// Act on a decoded boundary-intent signal: in scroll layout, decide via the
+    /// pure model and auto-advance/retreat with NO animation (minimise the
+    /// transition feel). Debounced by the proxy.
+    @MainActor
+    func handleContinuousScrollBoundary(geometry: ReadiumScrollGeometry, dragDelta: Double) {
+        // In-flight guard (Gate-4 High): once an advance/retreat starts, ignore
+        // every further boundary message — including a stale message from the
+        // outgoing spread during a slow transition or a long-held drag — until
+        // the navigation settles. Without this a second post could skip a
+        // chapter. Cleared in the Task below + on locationDidChange/detach/layout.
+        guard !continuousScrollAdvancing else { return }
+        let decision = ReadiumContinuousScrollModel.decide(
+            geometry: geometry, dragDelta: dragDelta, layout: currentLayout)
+        guard decision != .none else { return }
+        continuousScrollAdvancing = true
+        // Re-read the WEAK navigator INSIDE the task (Gate-4 Medium): a detach
+        // between now and execution must not drive a torn-down navigator —
+        // mirrors `ReadiumEPUBHost+Navigation`.
+        Task { @MainActor [weak self] in
+            guard let self, let navigator = self.boundNavigator else {
+                self?.continuousScrollAdvancing = false
+                return
+            }
+            switch decision {
+            case .advance: _ = await navigator.goForward(options: NavigatorGoOptions(animated: false))
+            case .retreat: _ = await navigator.goBackward(options: NavigatorGoOptions(animated: false))
+            case .none: break
+            }
+            // The navigation has settled (or no-op'd at the book edge). Clear so
+            // the next resource's boundary can advance. `locationDidChange` also
+            // clears as belt-and-suspenders.
+            self.continuousScrollAdvancing = false
+        }
+    }
+}
+
+/// Weak proxy between Readium's per-spread `WKUserContentController` (which
+/// strongly retains its message handlers) and the coordinator — avoids a retain
+/// cycle. Holds the per-spread debounce so a single boundary drag advances once.
+final class ReadiumBoundaryScrollProxy: NSObject, WKScriptMessageHandler {
+
+    private weak var coordinator: ReadiumReaderCoordinator?
+    private var lastAdvance: TimeInterval = 0
+    /// Min seconds between auto-advances (covers the resource transition).
+    private static let debounce: TimeInterval = 0.7
+
+    init(coordinator: ReadiumReaderCoordinator) {
+        self.coordinator = coordinator
+    }
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        guard message.name == ReadiumReaderCoordinator.continuousScrollHandlerName,
+              let coordinator else { return }
+        let b = (message.body as? [String: Any]) ?? [:]
+        func num(_ k: String) -> Double {
+            if let d = b[k] as? Double { return d }
+            if let i = b[k] as? Int { return Double(i) }
+            return 0
+        }
+        let now = Date().timeIntervalSinceReferenceDate
+        guard now - lastAdvance >= Self.debounce else { return }
+
+        let geometry = ReadiumScrollGeometry(
+            scrollY: num("scrollY"), scrollHeight: num("scrollHeight"), innerHeight: num("innerHeight"))
+        let dragDelta = num("dragDelta")
+        let decision = ReadiumContinuousScrollModel.decide(
+            geometry: geometry, dragDelta: dragDelta, layout: coordinator.currentLayout)
+        guard decision != .none else { return }
+        lastAdvance = now
+
+        // WKScriptMessageHandler callbacks arrive on the main thread; hop to the
+        // MainActor explicitly for Swift 6 isolation.
+        Task { @MainActor in
+            coordinator.handleContinuousScrollBoundary(geometry: geometry, dragDelta: dragDelta)
+        }
+    }
+}
+
+#endif

--- a/vreader/Views/Reader/ReadiumNavigatorRepresentable.swift
+++ b/vreader/Views/Reader/ReadiumNavigatorRepresentable.swift
@@ -140,6 +140,11 @@ struct ReadiumNavigatorRepresentable: UIViewControllerRepresentable {
         // to the live navigator without a reopen.
         // WI-9a: keep the coordinator's layout in sync so a live scroll↔paged
         // switch re-routes the tap behavior immediately.
+        // Feature #83: a layout change clears the continuous-scroll in-flight
+        // guard (a scroll→paged→scroll switch must not carry a stale flag).
+        if context.coordinator.currentLayout != resolvedLayout {
+            context.coordinator.continuousScrollAdvancing = false
+        }
         context.coordinator.currentLayout = resolvedLayout
         if let navigator = controller as? EPUBNavigatorViewController {
             // Gate-4 audit High: drive the transparency state through the

--- a/vreader/Views/Reader/ReadiumReaderCoordinator+Transparency.swift
+++ b/vreader/Views/Reader/ReadiumReaderCoordinator+Transparency.swift
@@ -75,6 +75,11 @@ extension ReadiumReaderCoordinator {
             source: Self.transparentStyleApplyJS,
             injectionTime: .atDocumentEnd, forMainFrameOnly: false
         ))
+        // Feature #83: cross-chapter continuous scroll — install the boundary-
+        // intent observer + weak message-handler proxy so scroll mode auto-
+        // advances across spine boundaries (resolves Bug #309). Self-gating to
+        // scroll layout (the proxy + model re-check `currentLayout`).
+        installContinuousScroll(on: userContentController)
     }
 
     /// Authoritatively asserts the current `transparentBackground` flag into the

--- a/vreader/Views/Reader/ReadiumReaderCoordinator.swift
+++ b/vreader/Views/Reader/ReadiumReaderCoordinator.swift
@@ -37,6 +37,13 @@ final class ReadiumReaderCoordinator: NSObject {
     /// chrome, matching the legacy reader's tap contract).
     var currentLayout: EPUBLayoutPreference = .paged
 
+    /// Feature #83: a cross-chapter continuous-scroll auto-advance is in flight.
+    /// Set before `goForward`/`goBackward`, cleared when the navigation settles
+    /// (in the same Task) and on `locationDidChange` / detach / layout change.
+    /// Gates out stale-spread boundary messages so a single boundary drag
+    /// advances exactly once (no chapter skip) — Gate-4 fix.
+    var continuousScrollAdvancing: Bool = false
+
     /// WI-7 photo/custom-background compositing: when true, `setupUserScripts`
     /// injects a transparent-`:root` style into each spine WebView so the
     /// composited `ThemeBackgroundView` behind the navigator shows through (set by
@@ -137,6 +144,9 @@ final class ReadiumReaderCoordinator: NSObject {
     /// and drops the navigator delegate + ref so no stale delegate callback
     /// fires after the host leaves the hierarchy.
     func detach() {
+        // Feature #83: clear the continuous-scroll in-flight guard on teardown
+        // so a stale flag can't wedge a future navigator.
+        continuousScrollAdvancing = false
         #if DEBUG
         DebugReaderRegistry.shared.clearActiveReadiumNavigator(
             for: fingerprintKey, token: readerToken
@@ -224,6 +234,10 @@ extension ReadiumReaderCoordinator: EPUBNavigatorDelegate {
     }
 
     func navigator(_ navigator: Navigator, locationDidChange locator: ReadiumShared.Locator) {
+        // Feature #83: a new spread settled — clear the continuous-scroll
+        // in-flight guard (belt-and-suspenders; the advance Task also clears it)
+        // so the newly-landed resource's boundary can advance.
+        continuousScrollAdvancing = false
         // WI-6: forward the reported locator to the host VM's debounced save so
         // the reading position persists as the user navigates/scrolls.
         onLocationChange?(locator)

--- a/vreaderTests/Views/Reader/ReadiumContinuousScrollModelTests.swift
+++ b/vreaderTests/Views/Reader/ReadiumContinuousScrollModelTests.swift
@@ -1,0 +1,66 @@
+// Purpose: Feature #83 WI-2 — pin the boundary-decision logic for Readium
+// cross-chapter continuous scroll. The geometry shape is what the WI-1 spike
+// proved observable on device (window.scrollY / scrollHeight / innerHeight).
+//
+// @coordinates-with: vreader/Views/Reader/ReadiumContinuousScrollModel.swift
+
+import Testing
+@testable import vreader
+
+@Suite("Feature #83 — ReadiumContinuousScrollModel")
+struct ReadiumContinuousScrollModelTests {
+
+    private func geo(_ y: Double, _ h: Double = 4680, _ inner: Double = 874) -> ReadiumScrollGeometry {
+        ReadiumScrollGeometry(scrollY: y, scrollHeight: h, innerHeight: inner)
+    }
+
+    @Test func atBottom_dragDown_advances() {
+        // bottom = scrollHeight - innerHeight = 4680 - 874 = 3806
+        let d = ReadiumContinuousScrollModel.decide(geometry: geo(3806), dragDelta: 30, layout: .scroll)
+        #expect(d == .advance)
+    }
+
+    @Test func atTop_dragUp_retreats() {
+        let d = ReadiumContinuousScrollModel.decide(geometry: geo(0), dragDelta: -30, layout: .scroll)
+        #expect(d == .retreat)
+    }
+
+    @Test func midResource_none() {
+        let d = ReadiumContinuousScrollModel.decide(geometry: geo(1908), dragDelta: 30, layout: .scroll)
+        #expect(d == .none)
+    }
+
+    @Test func atBottom_dragUp_wrongDirection_none() {
+        // At the bottom but dragging DOWN (scroll-up intent) → not an advance.
+        let d = ReadiumContinuousScrollModel.decide(geometry: geo(3806), dragDelta: -30, layout: .scroll)
+        #expect(d == .none)
+    }
+
+    @Test func atTop_dragDown_wrongDirection_none() {
+        let d = ReadiumContinuousScrollModel.decide(geometry: geo(0), dragDelta: 30, layout: .scroll)
+        #expect(d == .none)
+    }
+
+    @Test func smallDrag_none() {
+        let d = ReadiumContinuousScrollModel.decide(geometry: geo(3806), dragDelta: 4, layout: .scroll)
+        #expect(d == .none)
+    }
+
+    @Test func pagedLayout_none() {
+        let d = ReadiumContinuousScrollModel.decide(geometry: geo(3806), dragDelta: 30, layout: .paged)
+        #expect(d == .none)
+    }
+
+    @Test func edgeTolerance_nearBottom_advances() {
+        // 3 px short of the exact bottom is within edgeEpsilon (4).
+        let d = ReadiumContinuousScrollModel.decide(geometry: geo(3803), dragDelta: 30, layout: .scroll)
+        #expect(d == .advance)
+    }
+
+    @Test func zeroGeometry_none() {
+        let d = ReadiumContinuousScrollModel.decide(
+            geometry: ReadiumScrollGeometry(scrollY: 0, scrollHeight: 0, innerHeight: 0),
+            dragDelta: 30, layout: .scroll)
+        #expect(d == .none)
+    }
+}


### PR DESCRIPTION
## Summary
Restores cross-chapter continuous scroll on the Readium EPUB engine (default-ON since 2026-06-01) — the Feature #71 behavior that regressed to per-chapter scroll. **Fixes Bug #309 (#1403).**

Refs #1403

## What changed
- Boundary-intent observer via Readium's **public `setupUserScripts`** hook (WI-1 device spike proved `window.scrollY`/`scrollHeight`/`innerHeight` observable in Readium scroll mode — no private WebView access) → a **weak** message-handler proxy.
- `ReadiumContinuousScrollModel` (pure) decides advance/retreat/none; scroll-layout-gated.
- `handleContinuousScrollBoundary` → `goForward/goBackward(animated:false)`, guarded by a coordinator-owned **in-flight flag** (cleared on nav-settle / `locationDidChange` / `detach` / layout change → single clean advance, no stale-spread skip); navigator re-read weakly in the Task.

## Honest scope (Gate-2)
Auto-advance at the boundary (no manual swipe), **not** pixel-stitched #71 — a Readium resource-transition seam remains (accepted on #1403). Paged mode / legacy #71 engine / AZW3 / bilingual / TTS / position paths unaffected.

## Codex Audit (Gate 4)
ship-as-is — 2 rounds (in-flight guard for the stale-spread chapter-skip High; weak-navigator re-read Medium). Log: `.claude/codex-audits/feat-feature-83-wi-continuous-scroll-audit.md`.

## Validation
- [x] WI-1 device feasibility spike (the make-or-break) PASSED
- [x] 9 `ReadiumContinuousScrollModelTests`
- [x] Version bumped 3.44.2 → 3.45.0 (minor)

## Gate 5 Verification (device)
iPhone 17 Pro Sim, v3.45.0, Readium scroll mode, multi-chapter EPUB: scrolling past a chapter's bottom auto-advanced **ALPHA→BRAVO→CHARLIE** and continued scrolling — single clean advances (no skip), the in-flight guard re-arms each chapter. 5b evidence file post-merge.

## Type of Change
- [x] Feature (Refs #1403); fixes Bug #309