### PR TITLE
docs(design): commit #1292 secondary-text re-export transcript (chat18)

### DIFF
--- a/dev-docs/designs/vreader-fidelity-v1/chats/chat18.md
+++ b/dev-docs/designs/vreader-fidelity-v1/chats/chat18.md
@@ -1,0 +1,65 @@
+# I don't have the ability to access external URLs or browse the internet, including GitHub links. 
+
+Could you please share the content of that GitHub issue or
+
+_Started 2026-06-02 11:15 UTC_
+
+---
+
+## User
+
+https://github.com/lllyys/vreader/issues/1292
+
+## Assistant
+
+_[tool: list_files]_
+
+_[tool: github_list_repos]_
+
+_[tool: web_fetch]_
+
+This is a design decision for the `vreader` reader app — picking an AA-compliant secondary-text token for the Paper and Sepia themes. Let me explore both the repo and what's already in this project.
+
+_[tool: read_file]_
+
+_[tool: read_file]_
+
+This is a SwiftUI iOS reader app, and there's already a "VReader Secondary Text Canvas" in the project — this issue is a direct follow-up. Let me read the theme tokens and the existing secondary-text work.
+
+_[tool: read_file]_
+
+Interesting — this project already contains a design canvas built specifically for issue #1292 (`VReader Secondary Text Canvas.html` / `secondary-text-canvas-artboards.jsx`). The header comment, the measured contrast numbers (3.82 Paper / 3.36 Sepia), and the proposed fix all map directly to the issue. Let me check the HTML wrapper and confirm it renders, then look at the sibling slider-track canvas (#1273) it references for consistency.
+
+_[tool: show_html]_
+
+The design pass for issue #1292 is **already fully built** in this project — `VReader Secondary Text Canvas.html` is wired up and addresses exactly this issue (the section-header/footer/caption `sub` token failing AA on the cream Display panel). The recommendation is `ink @ 68%`. I verified the contrast math independently — Sepia ink @ 68% over `#fcf8f0` computes to ~4.89:1, clearing AA, matching the canvas's claim.
+
+Let me confirm it renders cleanly before I bring it to your view.
+
+_[tool: show_html]_
+
+_[tool: get_webview_logs]_
+
+_[tool: save_screenshot]_
+
+Renders cleanly (only the standard Babel dev warning). Let me take a quick look to confirm it's visually intact.
+
+_[tool: view_image]_
+
+_[tool: done]_
+
+This renders perfectly. The design pass for issue #1292 already exists in the project and is complete and correct — so rather than rebuild it, I'll surface it for you.
+
+Issue #1292 already has a complete design pass in this project — I've opened it in your view (`VReader Secondary Text Canvas.html`).
+
+**The decision it lands on:** darken the light-family `sub` token from `ink @ 55%` → **`ink @ 68%`** for Paper and Sepia.
+
+- **Why 68%** — it's the *smallest* unified alpha that clears WCAG AA (4.5:1) in the harder Sepia case (4.89:1), with Paper comfortably above at 5.83:1. I re-derived the Sepia number by hand and it checks out.
+- **Why a single derived rule** — keeping it as each theme's own ink at one alpha preserves the warmth (Paper near-black, Sepia brown) and mirrors how the slider-track facet (#1273) used `ink @ 22%`, rather than introducing two hand-picked greys or a parallel `subAA` token.
+- **Hierarchy intact** — primary ink stays ~16:1 (Paper), so secondary text is still clearly lighter; it's a legibility lift, not a promotion.
+- **Honest scoping** — Dark/OLED are out of Bug #285's light-family scope, but §5 measures them at ~3.7:1 (also under AA) and flags a matched follow-up rather than silently claiming they pass.
+
+The canvas walks through it in six sections: the decision, the measured bug, candidate alphas, in-context before/after, across-themes, and a binding spec card for the implementer.
+
+Do you want me to change anything — adjust the recommended alpha, fold in a Dark/OLED follow-up decision, or extract the final token values for the Swift `ReaderThemeV2` change?
+

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 817
-        MARKETING_VERSION: 3.45.1
+        CURRENT_PROJECT_VERSION: 818
+        MARKETING_VERSION: 3.45.2
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7249,7 +7249,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 817;
+				CURRENT_PROJECT_VERSION = 818;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7257,7 +7257,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.45.1;
+				MARKETING_VERSION = 3.45.2;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7403,7 +7403,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 817;
+				CURRENT_PROJECT_VERSION = 818;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7411,7 +7411,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.45.1;
+				MARKETING_VERSION = 3.45.2;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
The 2026-06-02 re-run of the #1292 secondary-text design produced a **byte-identical** canvas + artboards to the already-committed design (PR #1317) — the design assistant recognized #1292 was already designed and re-surfaced it unchanged. The only new artifact is the session transcript (`chat18.md`), committed here for provenance.

**No design change.** #1292's implementation (`ReaderThemeV2.subColor` ink@55%→68%) remains **held** per the user's direction — not implemented this session.

Refs #1292

🤖 Generated with [Claude Code](https://claude.com/claude-code)