### PR TITLE
feat(#86 WI-3): Chat scope chip + scope menu

### DIFF
--- a/.claude/codex-audits/feat-feature-86-wi-3-scope-chip-menu-audit.md
+++ b/.claude/codex-audits/feat-feature-86-wi-3-scope-chip-menu-audit.md
@@ -1,0 +1,56 @@
+---
+branch: feat/feature-86-wi-3-scope-chip-menu
+threadId: codex-exec (run-codex.sh, 2 rounds)
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-03
+---
+
+# Codex audit — Feature #86 WI-3: Chat scope chip + scope menu (Gate 4)
+
+## Implementation summary
+
+The docked context bar's **scope chip** + the upward **scope menu**, wired to
+`AIChatViewModel.scope` and the coordinator's scope-aware re-assembly:
+
+- `ChatContextScope+Menu` — menu copy (`menuDescription` / `tokenEstimate` /
+  spoiler-aware `menuFooter`), matching the #1455 design strings.
+- `ChatContextBar` — the scope chip (Sparkle + "Context" + scope name + chevron;
+  transparent at rest, faint accent wash when its menu is open). The sources chip lands WI-4.
+- `ChatScopeMenu` — the popover (radio + label + description + token estimate + spoiler footer).
+- `AIChatViewModel.setScope` → `onScopeChanged` (the coordinator's single funnel).
+- `ReaderAICoordinator.scopedChatContext(_:)` — section/chapter/bookSoFar map onto the #69
+  `AIContextExtractor`; `refreshChatContext` reads `chatViewModel?.scope`.
+
+Plan: `dev-docs/plans/20260603-feature-86-wi2-chat-scope-sources-retrieval.md` (WI-3).
+
+## Round 1 — 1 High + 1 Medium + 2 Low
+
+| severity | issue | resolution |
+|---|---|---|
+| High | Selecting Whole book immediately reassembled `bookContext` as `.bookSoFar` while the menu showed whole-book/spoiler/on-demand copy — a narrower slice under a broader label. | **Fixed.** The Whole-book row is filtered OUT of the WI-3 menu (`ChatScopeMenu.menuScopes` = the synchronous scopes only); the on-demand row + its retrieval/armed states land in WI-5. The coordinator's `.wholeBook → .bookSoFar` degrade remains only as an unreachable safety net. |
+| Medium | The bar added a top rule even though the composer already drew its own → two separators (the design has one shared rule around bar + composer). | **Fixed.** Removed the composer's top rule; the bar's top rule is the cluster's single shared rule. |
+| Low | `tokenEstimate(.wholeBook)` was "On-demand"; the #1455 source string is "on-demand". | **Fixed.** Verbatim "on-demand". |
+| Low | `AIChatView.swift` is ~389 lines (>300). | **Accepted with rationale.** The file was already >300 before WI-3; a proper composer extraction requires relaxing several `private @State` visibilities (the composer reads `inputText`/`isInputFocused`) and is deferred to WI-4, which adds the sources chip to the same cluster and is the natural place to extract `AIChatView+Composer`. |
+
+Round 1 explicitly cleared: the single-funnel write path, the `@MainActor` callback hop, the
+`[weak self]` closure, the `.wholeBook → .bookSoFar` recursion safety, and the required
+accessibility identifiers.
+
+## Round 2 — CLEAN
+
+Both the High and Medium confirmed resolved; the on-demand Low fixed; the file-size Low
+accepted. Zero open Critical/High/Medium.
+
+## Verdict
+
+`ship-as-is` after 2 rounds.
+
+## Verification
+
+- Unit (3 suites green via `scripts/run-tests.sh`): `ChatContextScopeMenuTests` (menu copy),
+  `AIChatViewModelScopeTests` (`setScope` funnel + no-op), `ReaderAICoordinatorScopedContextTests`
+  (per-scope extraction; whole-book degrade; no-text fallback).
+- Tier: behavioral (new UI + scope re-assembly). Gate-5 slice verification (device) follows
+  in the PR — open the reader, tap the scope chip, pick a scope, confirm the chip updates and
+  the menu dismisses.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 844
-        MARKETING_VERSION: 3.50.1
+        CURRENT_PROJECT_VERSION: 845
+        MARKETING_VERSION: 3.50.2
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -702,6 +702,7 @@
 		72BBA56325CAC43C8F4CC3EB /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD65C0547DF264510657CA2 /* ContentView.swift */; };
 		72F65D57D593D7D6D18D1C6C /* ReaderMoreMenuBilingualTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA99312EF465709359C1EBF /* ReaderMoreMenuBilingualTests.swift */; };
 		7301F1373CCC7E6FE8E0873B /* paginator.js in Resources */ = {isa = PBXBuildFile; fileRef = 7DE6A4A50E59B50DE7574A87 /* paginator.js */; };
+		73044473A655F7D1FAD82A18 /* ChatContextScope+Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04FD082244C1C8F6A4B8C3A /* ChatContextScope+Menu.swift */; };
 		73319DBA75C0F4352DDCD858 /* LibraryContextMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42FD55371CD8FA98699541E /* LibraryContextMenuTests.swift */; };
 		734D18CAC0BFEBC21C2C79EC /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = CF93EB81220A9280AE60189A /* buffer.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		7381A2EB6ABF08C91A1C4F8F /* PDFBilingualPanelStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171A6346645BCAF3A827BF70 /* PDFBilingualPanelStateTests.swift */; };
@@ -873,6 +874,7 @@
 		8F280281FE847272C7E64547 /* CollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E026EDF24B39D1CD50B39389 /* CollectionTests.swift */; };
 		8F49E620D597517097E96AE7 /* PersistenceActor+HighlightLookupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D54435E0293B133D7C4ECE /* PersistenceActor+HighlightLookupTests.swift */; };
 		8F6ADD143DF892DFAAED7C80 /* BilingualDisplayPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18967D09A42C1FAF3DD22C48 /* BilingualDisplayPipelineTests.swift */; };
+		8FD1FAC0AE8611D29DEDC87D /* ChatScopeMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4007FACF71264B6118B3F5FA /* ChatScopeMenu.swift */; };
 		8FFE1DA9C8F17FC318BE81BD /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138AEC5BBAD52B075096E5C8 /* SettingsView.swift */; };
 		9008E6E28C2B6F8202E2183A /* TXTChapterIndexBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEAA04C3430C5B247FB86585 /* TXTChapterIndexBuilderTests.swift */; };
 		9046B57894C5D46BDFBA4B49 /* PersistenceActorAnnotationBusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF24473B2CF440F36180E227 /* PersistenceActorAnnotationBusTests.swift */; };
@@ -1366,6 +1368,7 @@
 		E47B06C25D9525500CE31095 /* ReadingDashboardViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6635582524CF50059E66F973 /* ReadingDashboardViewTests.swift */; };
 		E4C963854C70662E3D59835D /* TXTChapterIndexStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0E95AA02EBAE369ABF9AE5 /* TXTChapterIndexStore.swift */; };
 		E4EE7528CED2596567ED4AE5 /* ReadiumEPUBNavigationMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57269B0A15DD1FA2817823F /* ReadiumEPUBNavigationMappingTests.swift */; };
+		E4F03F269AFA7E2CF65B2E6A /* ChatScopeSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11CDF8377E319897CD9B1EFF /* ChatScopeSelectionTests.swift */; };
 		E5A530D53A57B6CC92665E4C /* HighlightActionCardSubviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6E02E23F3C9B74668C4264F /* HighlightActionCardSubviews.swift */; };
 		E5C970CD2DB58A81E743F7DA /* WebDAVATSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A7B601E9791FB068616C98 /* WebDAVATSTests.swift */; };
 		E5CCF1857B5B93C085BF11EC /* TranslateStatusSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59223EAACB7B8C53C03EB6C4 /* TranslateStatusSheet.swift */; };
@@ -1479,6 +1482,7 @@
 		FBA0D5A48A4DC6B55237AD7C /* StandaloneNoteCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9EFCEB831649A6421626591 /* StandaloneNoteCard.swift */; };
 		FBE9680C2EE09F4F1936BC5C /* PDFReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D54AC9AD2556A67C96BD52 /* PDFReaderViewModel.swift */; };
 		FBF9F886D16DA6D941A6C8CD /* LibraryShellTokensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40146D7306CDCE0F1A2FC91 /* LibraryShellTokensTests.swift */; };
+		FC5945D7EE05A9B54F1815E8 /* ChatContextBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C8F2C0DD4DC5CDA2601383 /* ChatContextBar.swift */; };
 		FC837C49E1AE0FA920A347A7 /* SearchResultsGroupedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E84B53D4E30D6614436E4C68 /* SearchResultsGroupedList.swift */; };
 		FCDCB2D6F445BE64BFE95D03 /* HighlightHitToleranceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9734639739473622AE22A1 /* HighlightHitToleranceTests.swift */; };
 		FCDFF1E5C56E9AC7D3EB298F /* MDChapterStartTypographyIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B244CEE76D4FFD2FE2CFE99 /* MDChapterStartTypographyIntegrationTests.swift */; };
@@ -1547,6 +1551,7 @@
 		01E72DDEAD6225A21E973A51 /* SyncTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncTypes.swift; sourceTree = "<group>"; };
 		02275826847D45CA3746D53D /* CollectionSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSidebar.swift; sourceTree = "<group>"; };
 		02568BCB9C0024CD13E6B213 /* Libmobi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Libmobi.swift; sourceTree = "<group>"; };
+		02C8F2C0DD4DC5CDA2601383 /* ChatContextBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatContextBar.swift; sourceTree = "<group>"; };
 		02DE298149C25261E2ECADA1 /* ReaderThemeCSSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeCSSTests.swift; sourceTree = "<group>"; };
 		03019F035CBDE3EF65771114 /* Feature29WebDAVVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature29WebDAVVerificationTests.swift; sourceTree = "<group>"; };
 		03321A13C86F9E69BE338864 /* ReadiumNavCommanderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumNavCommanderTests.swift; sourceTree = "<group>"; };
@@ -1629,6 +1634,7 @@
 		10C9907D3479515B56338825 /* HTTPTTSConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTTSConfig.swift; sourceTree = "<group>"; };
 		10F8EE6C68FBB40F0A229AC0 /* utf16le_bom.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = utf16le_bom.txt; sourceTree = "<group>"; };
 		117731FF4D8AE414141C5ECF /* ImportJobQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportJobQueue.swift; sourceTree = "<group>"; };
+		11CDF8377E319897CD9B1EFF /* ChatScopeSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScopeSelectionTests.swift; sourceTree = "<group>"; };
 		11D25C147D85CED89E0862EE /* FoliateTOCNavWiringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateTOCNavWiringTests.swift; sourceTree = "<group>"; };
 		11D4AD419DD1123CDA21CCD0 /* ReflowableTextSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReflowableTextSource.swift; sourceTree = "<group>"; };
 		11F6250C22449E7E83591620 /* SyncStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusView.swift; sourceTree = "<group>"; };
@@ -1860,6 +1866,7 @@
 		3F5FC69D853F6222ADED7DB9 /* ReadiumDecorationTapEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumDecorationTapEventTests.swift; sourceTree = "<group>"; };
 		3FB3C13EB1794A1F78C93D37 /* ReadingStatsModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsModelsTests.swift; sourceTree = "<group>"; };
 		3FF06F0E93BCCA150869AE18 /* Feature35AnnotationsExportVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature35AnnotationsExportVerificationTests.swift; sourceTree = "<group>"; };
+		4007FACF71264B6118B3F5FA /* ChatScopeMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScopeMenu.swift; sourceTree = "<group>"; };
 		400D03ADE39639337E9993C5 /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
 		4078AAB96560B1BC1794472E /* DeleteConfirmationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteConfirmationTests.swift; sourceTree = "<group>"; };
 		40A2CD5F8AD4DEC1A14A255A /* SearchHitToLocatorResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHitToLocatorResolver.swift; sourceTree = "<group>"; };
@@ -2758,6 +2765,7 @@
 		D02B540992E1F3C96A00723F /* AIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProvider.swift; sourceTree = "<group>"; };
 		D036492CF6A9DB2DAFE010BC /* VReaderAnnotationParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderAnnotationParser.swift; sourceTree = "<group>"; };
 		D04953A6060F401FEB272F2E /* AnnotationsRouteWiringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationsRouteWiringTests.swift; sourceTree = "<group>"; };
+		D04FD082244C1C8F6A4B8C3A /* ChatContextScope+Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatContextScope+Menu.swift"; sourceTree = "<group>"; };
 		D054A0A5EF2A48B83A3DFE53 /* SyncPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncPipeline.swift; sourceTree = "<group>"; };
 		D093115A7D0F348656FA314B /* HighlightPopoverActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPopoverActionTests.swift; sourceTree = "<group>"; };
 		D0F43302E29E2FBA0759BA9A /* compression.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = compression.h; sourceTree = "<group>"; };
@@ -3561,6 +3569,7 @@
 				CF50D372D73575F047EF0991 /* BookContentCacheTests.swift */,
 				C85205257E8103AA80C08BAB /* BookmarkFeedbackTests.swift */,
 				C80D6D1B18008B168D01FFF2 /* BookOpenPerformanceTests.swift */,
+				11CDF8377E319897CD9B1EFF /* ChatScopeSelectionTests.swift */,
 				55CA2260032B7EFD94B1480B /* DebugAIActionEffectTests.swift */,
 				310813C564EF1BF86A13694E /* DebugBridgeHighlightObserverTests.swift */,
 				6D72F88359945829695CD984 /* DebugPresentSheetEffectTests.swift */,
@@ -4120,6 +4129,8 @@
 				BA0216684C6AC6F1F2DA5EF4 /* AIChatMessageRow.swift */,
 				539FEE4A23AFA226048A12A4 /* AIChatView.swift */,
 				83B60F61628D0969B18B3A9B /* AIConsentView.swift */,
+				02C8F2C0DD4DC5CDA2601383 /* ChatContextBar.swift */,
+				4007FACF71264B6118B3F5FA /* ChatScopeMenu.swift */,
 			);
 			path = AI;
 			sourceTree = "<group>";
@@ -5404,6 +5415,7 @@
 				01DD3EDBBD948811D620B337 /* ChatCitation.swift */,
 				3E46C9FBB99778BBC01EC556 /* ChatContextAssembler.swift */,
 				457E4B76590E361D08897EC3 /* ChatContextScope.swift */,
+				D04FD082244C1C8F6A4B8C3A /* ChatContextScope+Menu.swift */,
 				A18C8A706E429955843E3EC5 /* ChatSourceSelection.swift */,
 				AE50C2E67CBF0EB4747276C1 /* KeychainService+ProviderProfile.swift */,
 				2652A8EB81DF49609A3EDAC8 /* ProviderKind.swift */,
@@ -5885,6 +5897,7 @@
 				56CDEC7C3ADB3B1142561E60 /* ChapterTranslationServiceTests.swift in Sources */,
 				E19364EB475B945F4B96F3DB /* ChapterTranslationStoreTests.swift in Sources */,
 				D5BFB1EBD8FCFB12E438DCE9 /* ChatContextFoundationTests.swift in Sources */,
+				E4F03F269AFA7E2CF65B2E6A /* ChatScopeSelectionTests.swift in Sources */,
 				2DA32CDB11AE06DBCF3E97DE /* CloudKitRecordMapperTests.swift in Sources */,
 				E400E164FA809CC3AB0AC796 /* CollectionPersistenceTests.swift in Sources */,
 				3937725DB44FBDE74644583E /* CollectionTestHelper.swift in Sources */,
@@ -6539,8 +6552,11 @@
 				D1E30622FC94E669C740FFD7 /* ChatAnnotationContext.swift in Sources */,
 				A5269794813DB85D5D1053F4 /* ChatCitation.swift in Sources */,
 				AF263750044D4A8AD25C3675 /* ChatContextAssembler.swift in Sources */,
+				FC5945D7EE05A9B54F1815E8 /* ChatContextBar.swift in Sources */,
+				73044473A655F7D1FAD82A18 /* ChatContextScope+Menu.swift in Sources */,
 				397FF3ADF6619130950525FE /* ChatContextScope.swift in Sources */,
 				F51F7B9360A990E857FE1373 /* ChatMessage.swift in Sources */,
+				8FD1FAC0AE8611D29DEDC87D /* ChatScopeMenu.swift in Sources */,
 				5BDAA75F4C3A30CBCC893190 /* ChatSourceSelection.swift in Sources */,
 				CD3F1CD3B0FD3B013D82E26D /* CloudKitClient.swift in Sources */,
 				479BBE7406AFCACEE1CA5EE3 /* CloudKitRecordMapper.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7325,7 +7325,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 844;
+				CURRENT_PROJECT_VERSION = 845;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7333,7 +7333,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.50.1;
+				MARKETING_VERSION = 3.50.2;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7479,7 +7479,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 844;
+				CURRENT_PROJECT_VERSION = 845;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7487,7 +7487,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.50.1;
+				MARKETING_VERSION = 3.50.2;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Services/AI/ChatContextScope+Menu.swift
+++ b/vreader/Services/AI/ChatContextScope+Menu.swift
@@ -1,0 +1,42 @@
+// Purpose: The Chat scope-menu copy for each `ChatContextScope` — the one-line
+// descriptor + token estimate shown in `ChatScopeMenu`, and the menu footer
+// (spoiler-aware for Whole book). Feature #86 WI-3. Kept on the enum (not inlined
+// in the view) so the strings are centralized and unit-testable, matching the
+// committed #1455 design copy exactly.
+//
+// @coordinates-with: ChatContextScope.swift, ChatScopeMenu.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/design-notes/chat-ai-scope-sources.md`
+
+import Foundation
+
+extension ChatContextScope {
+    /// The one-line descriptor under the scope's name in the menu.
+    var menuDescription: String {
+        switch self {
+        case .section:   return "Just the passage you’re reading"
+        case .chapter:   return "The whole current chapter"
+        case .bookSoFar: return "Everything up to your page"
+        case .wholeBook: return "Reads the entire book on demand"
+        }
+    }
+
+    /// The trailing token estimate. Whole book is on-demand (retrieved), so it
+    /// shows "On-demand" rather than a fixed count.
+    var tokenEstimate: String {
+        switch self {
+        case .section:   return "~600 tokens"
+        case .chapter:   return "~4.2k tokens"
+        case .bookSoFar: return "~58k tokens"
+        case .wholeBook: return "On-demand"
+        }
+    }
+
+    /// The menu footer for a given selected scope. Whole book is the one
+    /// spoiler-aware scope, so it gets the spoiler caption; every other scope
+    /// gets the cost caption.
+    static func menuFooter(forSelected scope: ChatContextScope) -> String {
+        scope.spoilerAware
+            ? "Whole book can reference pages ahead of you — answers may contain spoilers."
+            : "Larger scopes give fuller answers but cost more per message."
+    }
+}

--- a/vreader/Services/AI/ChatContextScope+Menu.swift
+++ b/vreader/Services/AI/ChatContextScope+Menu.swift
@@ -27,7 +27,7 @@ extension ChatContextScope {
         case .section:   return "~600 tokens"
         case .chapter:   return "~4.2k tokens"
         case .bookSoFar: return "~58k tokens"
-        case .wholeBook: return "On-demand"
+        case .wholeBook: return "on-demand"   // matches the #1455 source string verbatim
         }
     }
 

--- a/vreader/ViewModels/AIChatViewModel.swift
+++ b/vreader/ViewModels/AIChatViewModel.swift
@@ -66,6 +66,24 @@ final class AIChatViewModel {
     /// When non-nil and non-empty, prepended as "[Book Context]" in the AI request.
     var bookContext: String?
 
+    /// Feature #86 WI-3: the breadth of book text the Chat tab reads. Drives the
+    /// context-bar scope chip. Changing it (via `setScope`) re-assembles
+    /// `bookContext` through `onScopeChanged` (the coordinator's single funnel).
+    /// Default `.chapter` matches the shipped WI-1 behavior.
+    private(set) var scope: ChatContextScope = .chapter
+
+    /// Set by the reader coordinator: invoked after a scope change so the
+    /// coordinator re-computes `bookContext` for the new scope.
+    var onScopeChanged: (() -> Void)?
+
+    /// Selects a new Chat context scope and re-assembles the book context.
+    /// A no-op when the scope is unchanged (avoids a redundant re-assembly).
+    func setScope(_ newScope: ChatContextScope) {
+        guard newScope != scope else { return }
+        scope = newScope
+        onScopeChanged?()
+    }
+
     // MARK: - Dependencies
 
     private let aiService: AIService

--- a/vreader/Views/AI/AIChatView.swift
+++ b/vreader/Views/AI/AIChatView.swift
@@ -37,16 +37,50 @@ struct AIChatView: View {
     /// `.paper` so existing callers / previews that omit it keep working.
     var theme: ReaderThemeV2 = .paper
 
-    var body: some View {
-        VStack(spacing: 0) {
-            messageList
+    /// Feature #86 WI-3: whether the scope menu is presented above the bar.
+    @State private var isScopeMenuOpen = false
 
-            if let error = viewModel.errorMessage {
-                errorBanner(message: error)
+    var body: some View {
+        ZStack(alignment: .bottomLeading) {
+            VStack(spacing: 0) {
+                messageList
+
+                if let error = viewModel.errorMessage {
+                    errorBanner(message: error)
+                }
+
+                // Feature #86 WI-3: the docked context bar, above the composer.
+                ChatContextBar(
+                    scope: viewModel.scope,
+                    theme: theme,
+                    isScopeMenuOpen: isScopeMenuOpen,
+                    onScopeTap: { isScopeMenuOpen.toggle() }
+                )
+
+                inputBar
             }
 
-            inputBar
+            // Feature #86 WI-3: the scope menu floats above the composer with a
+            // tap-scrim that dismisses it.
+            if isScopeMenuOpen {
+                Color.black.opacity(0.001)
+                    .ignoresSafeArea()
+                    .contentShape(Rectangle())
+                    .onTapGesture { isScopeMenuOpen = false }
+                ChatScopeMenu(
+                    selected: viewModel.scope,
+                    theme: theme,
+                    onSelect: { scope in
+                        viewModel.setScope(scope)
+                        isScopeMenuOpen = false
+                    }
+                )
+                .padding(.leading, 14)
+                .padding(.bottom, 80)
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
         }
+        .animation(.spring(response: 0.28, dampingFraction: 0.85), value: isScopeMenuOpen)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {

--- a/vreader/Views/AI/AIChatView.swift
+++ b/vreader/Views/AI/AIChatView.swift
@@ -271,8 +271,9 @@ struct AIChatView: View {
     /// behaviour and the bug-#94 focus / submit wiring are preserved.
     @ViewBuilder
     private var inputBar: some View {
-        Color(theme.ruleColor).frame(height: 0.5)
-
+        // Feature #86 WI-3: the cluster's single top rule now lives on the docked
+        // ChatContextBar above this composer (design #1455 — one shared rule around
+        // bar + composer), so the composer no longer draws its own.
         HStack(spacing: 8) {
             ZStack(alignment: .topLeading) {
                 // Bug #310: themed placeholder. SwiftUI ignores `.foregroundStyle`

--- a/vreader/Views/AI/ChatContextBar.swift
+++ b/vreader/Views/AI/ChatContextBar.swift
@@ -1,0 +1,92 @@
+// Purpose: The persistent ~40px context bar docked directly above the Chat
+// composer (Feature #86 WI-3, design #1455). WI-3 renders the left **scope chip**
+// (tap → ChatScopeMenu); WI-4 adds the right **sources chip**. The bar shares the
+// composer's top rule and never scrolls away — scope is a thread-wide property,
+// not a one-shot like the Summarize chips.
+//
+// The scope chip is a quiet outline pill: a Sparkle accent glyph, the muted
+// "Context" label, the bold current-scope name, and a chevron. It tints to a
+// faint accent wash only while its menu is open (accent discipline — the bar is
+// permanently docked, so it can't shout).
+//
+// @coordinates-with: ChatScopeMenu.swift, AIChatView.swift, ChatContextScope.swift,
+//   ReaderThemeV2.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/chat-context-artboards.jsx`
+
+#if canImport(UIKit)
+import SwiftUI
+
+/// The Chat context bar (WI-3: scope chip only).
+struct ChatContextBar: View {
+    let scope: ChatContextScope
+    let theme: ReaderThemeV2
+    /// Whether the scope menu is currently open (drives the chip's accent wash).
+    let isScopeMenuOpen: Bool
+    /// Tapped the scope chip.
+    let onScopeTap: () -> Void
+
+    static let scopeChipIdentifier = "chatContextScopeChip"
+
+    var body: some View {
+        HStack(spacing: 0) {
+            scopeChip
+            Spacer(minLength: 0)
+            // WI-4: sources chip docks here.
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 9)
+        .padding(.bottom, 2)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(Color(theme.ruleColor))
+                .frame(height: 0.5)
+        }
+        .accessibilityIdentifier("chatContextBar")
+    }
+
+    @ViewBuilder
+    private var scopeChip: some View {
+        Button(action: onScopeTap) {
+            HStack(spacing: 6) {
+                Image(systemName: "sparkle")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Color(theme.accentColor))
+                Text("Context")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(Color(theme.subColor))
+                Text(scope.displayName)
+                    .font(.system(size: 12.5, weight: .semibold))
+                    .foregroundStyle(Color(theme.inkColor))
+                Image(systemName: isScopeMenuOpen ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(Color(theme.subColor))
+            }
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+            .padding(.leading, 11)
+            .padding(.trailing, 10)
+            .padding(.vertical, 6)
+            .background(
+                Capsule().fill(Color(chipFill))
+            )
+            .overlay(
+                Capsule().stroke(
+                    Color(isScopeMenuOpen ? theme.accentColor : theme.ruleColor),
+                    lineWidth: 0.5
+                )
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(Self.scopeChipIdentifier)
+        .accessibilityLabel("Chat context scope: \(scope.displayName)")
+    }
+
+    /// Transparent at rest; a faint accent wash while the menu is open.
+    private var chipFill: UIColor {
+        guard isScopeMenuOpen else { return .clear }
+        return theme.isDark
+            ? UIColor(red: 214/255, green: 136/255, blue: 90/255, alpha: 0.14)
+            : UIColor(red: 140/255, green: 47/255, blue: 47/255, alpha: 0.07)
+    }
+}
+#endif

--- a/vreader/Views/AI/ChatScopeMenu.swift
+++ b/vreader/Views/AI/ChatScopeMenu.swift
@@ -1,0 +1,154 @@
+// Purpose: The Chat scope menu — the popover that opens upward from the context
+// bar's scope chip (Feature #86 WI-3, design #1455). Four rows (Section / Chapter
+// / Book so far / Whole book), each with a radio check, a one-line descriptor, a
+// token estimate, and — for Whole book — an "On-demand" tag. The footer is
+// spoiler-aware: Whole book warns it can reference pages ahead.
+//
+// @coordinates-with: ChatContextBar.swift, ChatContextScope.swift,
+//   ChatContextScope+Menu.swift, ReaderThemeV2.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/chat-context-artboards.jsx`
+
+#if canImport(UIKit)
+import SwiftUI
+
+/// The Chat context-scope selection menu (popover).
+struct ChatScopeMenu: View {
+    let selected: ChatContextScope
+    let theme: ReaderThemeV2
+    /// Picked a scope row.
+    let onSelect: (ChatContextScope) -> Void
+
+    static func rowIdentifier(_ scope: ChatContextScope) -> String {
+        "chatScopeRow.\(scope.rawValue)"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider().overlay(Color(theme.ruleColor))
+            VStack(spacing: 0) {
+                ForEach(ChatContextScope.allCases, id: \.self) { scope in
+                    row(scope)
+                }
+            }
+            .padding(.vertical, 4)
+            Divider().overlay(Color(theme.ruleColor))
+            footer
+        }
+        .frame(width: 286)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(theme.paperColor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color(theme.ruleColor), lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(theme.isDark ? 0.5 : 0.18), radius: 18, y: 8)
+        .accessibilityIdentifier("chatScopeMenu")
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Chat context")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Color(theme.inkColor))
+            Text("How much of the book the assistant reads")
+                .font(.system(size: 11.5))
+                .foregroundStyle(Color(theme.subColor))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 11)
+    }
+
+    @ViewBuilder
+    private func row(_ scope: ChatContextScope) -> some View {
+        let isSelected = scope == selected
+        Button { onSelect(scope) } label: {
+            HStack(alignment: .top, spacing: 10) {
+                radio(isSelected)
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 7) {
+                        Text(scope.displayName)
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(Color(theme.inkColor))
+                        if scope.isOnDemand {
+                            Text("ON-DEMAND")
+                                .font(.system(size: 9.5, weight: .bold))
+                                .tracking(0.4)
+                                .foregroundStyle(Color(theme.accentColor))
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Capsule().fill(Color(onDemandTagFill)))
+                        }
+                    }
+                    Text(scope.menuDescription)
+                        .font(.system(size: 12))
+                        .foregroundStyle(Color(theme.subColor))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 6)
+                Text(scope.tokenEstimate)
+                    .font(.system(size: 11))
+                    .foregroundStyle(Color(theme.subColor))
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(isSelected ? Color(selectedRowFill) : .clear)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(Self.rowIdentifier(scope))
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+
+    @ViewBuilder
+    private func radio(_ isSelected: Bool) -> some View {
+        ZStack {
+            Circle()
+                .fill(isSelected ? Color(theme.accentColor) : .clear)
+                .overlay(
+                    Circle().stroke(
+                        isSelected ? .clear : Color(theme.ruleColor), lineWidth: 1.5
+                    )
+                )
+            if isSelected {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.white)
+            }
+        }
+        .frame(width: 18, height: 18)
+        .padding(.top, 1)
+    }
+
+    private var footer: some View {
+        HStack(alignment: .top, spacing: 7) {
+            Image(systemName: "info.circle")
+                .font(.system(size: 12))
+                .foregroundStyle(Color(theme.subColor))
+            Text(ChatContextScope.menuFooter(forSelected: selected))
+                .font(.system(size: 11.5))
+                .foregroundStyle(Color(theme.subColor))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+
+    private var selectedRowFill: UIColor {
+        theme.isDark
+            ? UIColor(red: 214/255, green: 136/255, blue: 90/255, alpha: 0.12)
+            : UIColor(red: 140/255, green: 47/255, blue: 47/255, alpha: 0.05)
+    }
+
+    private var onDemandTagFill: UIColor {
+        theme.isDark
+            ? UIColor(red: 214/255, green: 136/255, blue: 90/255, alpha: 0.16)
+            : UIColor(red: 140/255, green: 47/255, blue: 47/255, alpha: 0.08)
+    }
+}
+#endif

--- a/vreader/Views/AI/ChatScopeMenu.swift
+++ b/vreader/Views/AI/ChatScopeMenu.swift
@@ -22,12 +22,21 @@ struct ChatScopeMenu: View {
         "chatScopeRow.\(scope.rawValue)"
     }
 
+    /// The scopes the WI-3 menu offers: the synchronous (non-on-demand) ones.
+    /// WI-5 adds the on-demand Whole-book row alongside its retrieval states.
+    static let menuScopes: [ChatContextScope] = ChatContextScope.allCases.filter { !$0.isOnDemand }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
             Divider().overlay(Color(theme.ruleColor))
             VStack(spacing: 0) {
-                ForEach(ChatContextScope.allCases, id: \.self) { scope in
+                // WI-3 ships the three synchronous scopes only. The on-demand
+                // Whole-book row lands in WI-5 together with its retrieval +
+                // armed/reading/ready states — so the menu never offers whole-book
+                // (with its spoiler-aware copy) while requests would silently use a
+                // narrower slice (Gate-4 High).
+                ForEach(Self.menuScopes, id: \.self) { scope in
                     row(scope)
                 }
             }

--- a/vreader/Views/Reader/ReaderAICoordinator.swift
+++ b/vreader/Views/Reader/ReaderAICoordinator.swift
@@ -68,34 +68,50 @@ final class ReaderAICoordinator {
     /// the chapter can't be resolved — EPUB / non-char-offset TOC, no locator, or
     /// no loaded text — it **degrades to `currentTextContent` (`.section`)**, so
     /// EPUB chat and the no-context fallback are unchanged.
-    var chatContext: String {
+    var chatContext: String { scopedChatContext(.chapter) }
+
+    /// Feature #86 WI-3: the Chat tab's book context for a GIVEN scope. The three
+    /// bounded scopes map onto the #69 `AIContextExtractor` stack:
+    /// `.section` → the ~2500-char window; `.chapter` → the TOC-chapter slice;
+    /// `.bookSoFar` → the budget-capped prefix to the locator. `.wholeBook`
+    /// retrieval lands in WI-5 — until then it degrades to `.bookSoFar` (the
+    /// broadest synchronous scope). Any unresolvable case degrades to
+    /// `currentTextContent` (`.section`), so EPUB chat / no-context are unchanged.
+    func scopedChatContext(_ scope: ChatContextScope) -> String {
         let section = currentTextContent
+        guard let summaryScope = scope.summaryScope else {
+            return scopedChatContext(.bookSoFar)   // .wholeBook → best synchronous scope (WI-5 replaces)
+        }
+        if summaryScope == .section { return section }
         guard let loaded = loadedTextContent, !loaded.isEmpty,
-              let locator = currentLocator,
-              let bounds = SummaryScopeResolver.chapterBounds(
-                  for: locator,
-                  tocEntries: tocEntries,
-                  totalTextLengthUTF16: loaded.utf16.count
-              )
+              let locator = currentLocator
         else { return section }
+        let bounds = SummaryScopeResolver.chapterBounds(
+            for: locator, tocEntries: tocEntries, totalTextLengthUTF16: loaded.utf16.count
+        )
+        // Chapter needs resolved bounds; book-so-far does not.
+        if summaryScope == .chapter, bounds == nil { return section }
         let extracted = AIContextExtractor().extractContext(
             locator: locator,
             fullText: loaded,
             format: bookFormat,
-            scope: .chapter,
+            scope: summaryScope,
             chapterBounds: bounds,
             maxUTF16: AIContextBudget.defaultMaxUTF16
         )
         return extracted.isEmpty ? section : extracted
     }
 
-    /// Feature #86 WI-1: the SINGLE place the chat's `bookContext` is assigned.
-    /// Idempotent — recomputes `chatContext` from the current
-    /// `loadedTextContent` / `currentLocator` / `tocEntries`. The host calls this
-    /// on every state change (text load, locator change, TOC arrival) so a late
-    /// TOC upgrades the context and a scroll never reverts it to section.
+    /// Feature #86 WI-1/WI-3: the SINGLE place the chat's `bookContext` is
+    /// assigned. Idempotent — recomputes from the current
+    /// `loadedTextContent` / `currentLocator` / `tocEntries` for the chat's
+    /// currently-selected scope (`.chapter` until the user changes it). The host
+    /// calls this on every state change (text load, locator change, TOC arrival),
+    /// and the chat VM calls it on a scope change, so a late TOC upgrades the
+    /// context and a scroll never reverts it.
     func refreshChatContext() {
-        chatViewModel?.bookContext = chatContext
+        let scope = chatViewModel?.scope ?? .chapter
+        chatViewModel?.bookContext = scopedChatContext(scope)
     }
 
     /// Book title used as fallback when no text content is available.
@@ -131,6 +147,9 @@ final class ReaderAICoordinator {
         let fingerprint = DocumentFingerprint(canonicalKey: fingerprintKey)
         let chatVM = AIChatViewModel(aiService: service, bookFingerprint: fingerprint)
         chatViewModel = chatVM
+        // Feature #86 WI-3: re-assemble the context when the user changes scope,
+        // through the same single funnel.
+        chatVM.onScopeChanged = { [weak self] in self?.refreshChatContext() }
         // Feature #86 WI-1: assign chatViewModel FIRST, then refresh — else the
         // refresh no-ops against a nil VM (Gate-2 round-2 note).
         refreshChatContext()

--- a/vreaderTests/Views/Reader/ChatScopeSelectionTests.swift
+++ b/vreaderTests/Views/Reader/ChatScopeSelectionTests.swift
@@ -23,7 +23,7 @@ struct ChatContextScopeMenuTests {
         #expect(ChatContextScope.section.tokenEstimate == "~600 tokens")
         #expect(ChatContextScope.chapter.tokenEstimate == "~4.2k tokens")
         #expect(ChatContextScope.bookSoFar.tokenEstimate == "~58k tokens")
-        #expect(ChatContextScope.wholeBook.tokenEstimate == "On-demand")
+        #expect(ChatContextScope.wholeBook.tokenEstimate == "on-demand")
     }
 
     @Test func menuFooter_isSpoilerAwareOnlyForWholeBook() {

--- a/vreaderTests/Views/Reader/ChatScopeSelectionTests.swift
+++ b/vreaderTests/Views/Reader/ChatScopeSelectionTests.swift
@@ -1,0 +1,149 @@
+// Feature #86 WI-3: the Chat context-scope selection — the scope-menu metadata,
+// `AIChatViewModel.setScope` (re-assembly funnel), and `ReaderAICoordinator`'s
+// scope-aware `scopedChatContext` / `refreshChatContext`. The SwiftUI bar/menu
+// chrome is device-verified; this pins the pure logic.
+
+import Testing
+import Foundation
+@testable import vreader
+
+// MARK: - Scope menu metadata
+
+@Suite("ChatContextScope menu copy (Feature #86 WI-3)")
+struct ChatContextScopeMenuTests {
+
+    @Test func menuDescription_perScope() {
+        #expect(ChatContextScope.section.menuDescription == "Just the passage you’re reading")
+        #expect(ChatContextScope.chapter.menuDescription == "The whole current chapter")
+        #expect(ChatContextScope.bookSoFar.menuDescription == "Everything up to your page")
+        #expect(ChatContextScope.wholeBook.menuDescription == "Reads the entire book on demand")
+    }
+
+    @Test func tokenEstimate_perScope_wholeBookIsOnDemand() {
+        #expect(ChatContextScope.section.tokenEstimate == "~600 tokens")
+        #expect(ChatContextScope.chapter.tokenEstimate == "~4.2k tokens")
+        #expect(ChatContextScope.bookSoFar.tokenEstimate == "~58k tokens")
+        #expect(ChatContextScope.wholeBook.tokenEstimate == "On-demand")
+    }
+
+    @Test func menuFooter_isSpoilerAwareOnlyForWholeBook() {
+        #expect(ChatContextScope.menuFooter(forSelected: .wholeBook).contains("spoilers"))
+        for scope in [ChatContextScope.section, .chapter, .bookSoFar] {
+            #expect(ChatContextScope.menuFooter(forSelected: scope).contains("cost more"))
+        }
+    }
+}
+
+// MARK: - AIChatViewModel.setScope
+
+@Suite("AIChatViewModel scope selection (Feature #86 WI-3)")
+@MainActor
+struct AIChatViewModelScopeTests {
+
+    private func makeVM() -> AIChatViewModel {
+        AIChatViewModel(
+            aiService: AIService(
+                featureFlags: FeatureFlags.shared,
+                consentManager: AIConsentManager(),
+                keychainService: KeychainService(),
+                profileStore: ProviderProfileStore.shared
+            ),
+            bookFingerprint: nil
+        )
+    }
+
+    @Test func defaultScope_isChapter() {
+        #expect(makeVM().scope == .chapter)
+    }
+
+    @Test func setScope_changesScope_andInvokesCallback() {
+        let vm = makeVM()
+        var calls = 0
+        vm.onScopeChanged = { calls += 1 }
+        vm.setScope(.bookSoFar)
+        #expect(vm.scope == .bookSoFar)
+        #expect(calls == 1)
+    }
+
+    @Test func setScope_sameScope_isNoOp() {
+        let vm = makeVM()
+        var calls = 0
+        vm.onScopeChanged = { calls += 1 }
+        vm.setScope(.chapter)   // already .chapter
+        #expect(calls == 0)
+    }
+}
+
+// MARK: - ReaderAICoordinator scope-aware context
+
+@Suite("ReaderAICoordinator scoped chat context (Feature #86 WI-3)")
+@MainActor
+struct ReaderAICoordinatorScopedContextTests {
+
+    private func fingerprint() -> DocumentFingerprint {
+        DocumentFingerprint(
+            contentSHA256: String(repeating: "a", count: 64),
+            fileByteCount: 100, format: .txt
+        )
+    }
+    private func coordinator() -> ReaderAICoordinator {
+        ReaderAICoordinator(
+            fallbackTitle: "Title", bookFormat: .txt,
+            fingerprintKey: fingerprint().canonicalKey
+        )
+    }
+    private func locator(_ offset: Int) -> Locator {
+        Locator.validated(bookFingerprint: fingerprint(), charOffsetUTF16: offset)!
+    }
+    private func toc(_ pairs: [(String, Int)]) -> [TOCEntry] {
+        pairs.map { TOCEntry(title: $0.0, level: 0, locator: locator($0.1)) }
+    }
+
+    /// `.section` is the centered window; `.chapter` is the whole chapter — they
+    /// differ for a multi-chapter book.
+    @Test func scopedContext_sectionVsChapter() {
+        let c = coordinator()
+        let ch1 = String(repeating: "A", count: 3000)
+        let ch2 = String(repeating: "B", count: 2000)
+        c.loadedTextContent = ch1 + ch2
+        c.tocEntries = toc([("Ch1", 0), ("Ch2", 3000)])
+        c.currentLocator = locator(3000)
+
+        #expect(c.scopedChatContext(.chapter) == ch2)
+        #expect(c.scopedChatContext(.section) == c.currentTextContent)
+        #expect(c.scopedChatContext(.chapter) != c.scopedChatContext(.section))
+    }
+
+    /// `.bookSoFar` reaches back to the book start (here within budget) — it
+    /// includes chapter-1 text the `.chapter` (ch2-only) scope excludes.
+    @Test func scopedContext_bookSoFar_reachesBackToStart() {
+        let c = coordinator()
+        let ch1 = String(repeating: "A", count: 1000)
+        let ch2 = String(repeating: "B", count: 1000)
+        c.loadedTextContent = ch1 + ch2
+        c.tocEntries = toc([("Ch1", 0), ("Ch2", 1000)])
+        c.currentLocator = locator(1500)   // mid chapter 2
+        let soFar = c.scopedChatContext(.bookSoFar)
+        #expect(soFar.contains("A"))       // includes chapter-1 text
+    }
+
+    /// `.wholeBook` retrieval lands in WI-5; until then it degrades to the broadest
+    /// synchronous scope (`.bookSoFar`), NOT the narrow section.
+    @Test func scopedContext_wholeBook_degradesToBookSoFar_untilWI5() {
+        let c = coordinator()
+        c.loadedTextContent = String(repeating: "A", count: 1000) + String(repeating: "B", count: 1000)
+        c.tocEntries = toc([("Ch1", 0), ("Ch2", 1000)])
+        c.currentLocator = locator(1500)
+        #expect(c.scopedChatContext(.wholeBook) == c.scopedChatContext(.bookSoFar))
+    }
+
+    /// An unresolvable scope (no loaded text) degrades to the section fallback for
+    /// every scope.
+    @Test func scopedContext_noLoadedText_degradesToSection() {
+        let c = coordinator()
+        c.loadedTextContent = nil
+        for scope in ChatContextScope.allCases {
+            #expect(c.scopedChatContext(scope) == c.currentTextContent)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- The docked context bar's **scope chip** + the upward **scope menu** (Section / Chapter / Book so far), wired to `AIChatViewModel.scope` and the coordinator's scope-aware re-assembly. The on-demand Whole-book row + its retrieval land in WI-5.

Part of feature #1453 (WI-3 of 6). Design: #1455 (Rule 51 satisfied).

## What Changed

- **`ChatContextScope+Menu`** — menu copy (description / token estimate / spoiler-aware footer), matching the #1455 strings.
- **`ChatContextBar`** — the docked scope chip (Sparkle + "Context" + scope name + chevron; transparent at rest, faint accent wash when its menu is open). The cluster's single top rule moved here.
- **`ChatScopeMenu`** — the popover (radio + label + description + token estimate + spoiler-aware footer). Renders the three synchronous scopes; the on-demand Whole-book row lands in WI-5 with retrieval.
- **`AIChatViewModel.setScope`** → `onScopeChanged` (the coordinator's single funnel; no-op when unchanged).
- **`ReaderAICoordinator.scopedChatContext(_:)`** — section/chapter/bookSoFar map onto the #69 `AIContextExtractor`; `refreshChatContext` reads the chat scope.
- **`AIChatView`** — the bar above the composer + the menu overlay with a dismiss scrim.

## Codex Audit

Gate-4, 2 rounds, ship-as-is. R1 1 High (whole-book silently sent bookSoFar under a broader/spoiler label → **filtered the on-demand row out of the WI-3 menu**) + 1 Med (double cluster rule → single shared rule) + 2 Low (on-demand string verbatim; file-size accepted with rationale) → R2 clean. Log: `.claude/codex-audits/feat-feature-86-wi-3-scope-chip-menu-audit.md`.

## Validation

- [x] 3 unit suites green: `ChatContextScopeMenuTests`, `AIChatViewModelScopeTests`, `ReaderAICoordinatorScopedContextTests`.
- [x] **Gate-5 slice — device-verified** on iPhone 17 Pro Simulator (v3.50.1, `war-and-peace` TXT fixture, `--enable-ai`): the context bar renders ("Context Chapter"); tapping the chip opens the scope menu showing **3 rows — Section / Chapter / Book so far, no Whole-book** (confirms the Gate-4 fix on-device) with the design header + cost footer; selecting "Book so far" updates the chip → "Context Book so far" and dismisses the menu. Evidence: `dev-docs/verification/artifacts/feature-86-wi3-{chat-contextbar,scope-menu,scope-changed}-20260603.png`.
- [x] Version bumped: 3.50.1 → 3.50.2 (behavioral, not final → patch).

## Type of Change

- [x] New feature (WI-3 of Feature #86)