### PR TITLE
feat(#86 WI-4): Chat sources chip + sources popover

### DIFF
--- a/.claude/codex-audits/feat-feature-86-wi-4-sources-popover-audit.md
+++ b/.claude/codex-audits/feat-feature-86-wi-4-sources-popover-audit.md
@@ -1,0 +1,60 @@
+---
+branch: feat/feature-86-wi-4-sources-popover
+threadId: codex-exec (run-codex.sh, 2 rounds)
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-03
+---
+
+# Codex audit — Feature #86 WI-4: Chat sources chip + sources popover (Gate 4)
+
+## Implementation summary
+
+The right-side **sources chip** + the **sources popover** (Notes / Highlights /
+Bookmarks toggles), backed by a per-book annotation cache:
+
+- `ChatAnnotationCache` (`@MainActor @Observable`) — loads the reader's annotations
+  once on open + refreshes ONLY on `.readerAnnotationsDidChange` (never on relocate);
+  fires `onChange` after each load so the coordinator re-assembles the context +
+  the chip counts. `annotationBlock(for:maxUTF16:)` delegates to `ChatAnnotationContext`.
+- `ChatSourcesMenu` — the popover (icon tile + label + "N in this book" + switch + footer).
+- `ChatContextBar` — the right-side sources chip (green wash + count badge / "Off").
+- `AIChatViewModel.setSources` → the shared `onScopeChanged` re-assembly funnel + `sourceCounts`.
+- `ReaderAICoordinator` — owns the cache (persistence threaded from `ReaderContainerView`
+  via `@Environment(\.persistenceActor)`); `refreshChatContext` folds the serialized
+  annotation block into `ChatContextAssembler.assemble`.
+- `AIChatView` — the two menus as mutually-exclusive overlays (scope leading, sources
+  trailing) with a shared dismiss scrim.
+
+Plan: `dev-docs/plans/20260603-feature-86-wi2-chat-scope-sources-retrieval.md` (WI-4).
+
+## Round 1 — 1 High + 1 Low + 1 maintainability note
+
+| severity | issue | resolution |
+|---|---|---|
+| High | `ChatAnnotationCache.load()` mutated the three arrays incrementally across awaits; two rapid `.readerAnnotationsDidChange` posts spawn overlapping fire-and-forget Tasks that could interleave → a stale/mixed snapshot. | **Fixed.** `load()` is now latest-wins + atomic: increment `loadGeneration`, capture `generation`, fetch all three into locals, `guard generation == loadGeneration` before committing all three + firing `onChange`. Only the newest reload publishes (`@MainActor` serializes the generation token). |
+| Low | The bus carries no book identity → in a multi-reader scenario every cache would refetch on any annotation mutation. | **Accepted with rationale.** vreader opens exactly one reader at a time (one `ChatAnnotationCache` exists), so there's no cross-book redundancy in practice; threading `fingerprintKey` through the id-based mutation chokepoints (`removeBookmark(bookmarkId:)` etc.) would require extra fetches to resolve the key. |
+| Note | `AIChatView.swift` was 418 lines (>300). | **Fixed.** Extracted the composer (`inputBar` + helpers + `secondaryContentColor`) into `AIChatView+Composer.swift`; `AIChatView.swift` dropped to ~290 lines. `inputText`/`isInputFocused` relaxed `private`→internal so the extension reads them; no behavior change. |
+
+Round 1 explicitly cleared: no infinite loop in the `onChange → syncSourceCounts /
+refreshChatContext` path (refresh never re-triggers `load()`); no retain cycle (the
+coordinator/cache/observer captures are all `[weak self]`); the optional persistence
+boundary is nil-safe and concurrency-sound (the three protocols are `Sendable`,
+`PersistenceActor` is an actor); and no Rule-51 fidelity problem on the chip/popover.
+
+## Round 2 — CLEAN
+
+The latest-wins fix confirmed; the Low acceptance reasonable; the extraction behavior-
+preserving. Zero open Critical/High/Medium.
+
+## Verdict
+
+`ship-as-is` after 2 rounds.
+
+## Verification
+
+- Unit (2 suites green via `scripts/run-tests.sh`): `ChatAnnotationCacheTests` (load /
+  counts / refresh-on-bus-not-relocate / annotationBlock-respects-selection),
+  `AIChatViewModelSourcesTests` (`setSources` funnel + default + no-op).
+- Tier: behavioral. Gate-5 slice (device) follows in the PR — open the reader, tap the
+  sources chip, toggle a kind, confirm the chip badge updates.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 845
-        MARKETING_VERSION: 3.50.2
+        CURRENT_PROJECT_VERSION: 846
+        MARKETING_VERSION: 3.50.3
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7341,7 +7341,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 845;
+				CURRENT_PROJECT_VERSION = 846;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7349,7 +7349,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.50.2;
+				MARKETING_VERSION = 3.50.3;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7495,7 +7495,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 845;
+				CURRENT_PROJECT_VERSION = 846;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7503,7 +7503,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.50.2;
+				MARKETING_VERSION = 3.50.3;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -228,6 +228,7 @@
 		252CB71020888B6952C2F69E /* ReaderBottomOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A983D06F916C51795A2223E7 /* ReaderBottomOverlay.swift */; };
 		25327C608F6719156A58C8B3 /* LaunchHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62D7DA128D4B2AC1F362D571 /* LaunchHelper.swift */; };
 		2568348E9159667C4193A0B6 /* ProviderKindTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C46A3D7400CC956FA8D46D /* ProviderKindTests.swift */; };
+		25C35999B6BAA3D90435C66A /* ChatSourcesMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD477B685E3E8163D52949DC /* ChatSourcesMenu.swift */; };
 		25C94D1D2DFC0087C1FC328F /* Feature42ReadiumAcceptanceRenderVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380DDC4A9D64A9ADD3AB979D /* Feature42ReadiumAcceptanceRenderVerificationTests.swift */; };
 		26285A9C2309CC149C5372DC /* AIConsentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C9AB72079AF7B2ACCAB516 /* AIConsentManager.swift */; };
 		2639375285887DD55F80815B /* SearchResultGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759C78EC56C473977FA14017 /* SearchResultGrouping.swift */; };
@@ -642,6 +643,7 @@
 		680F8342C5B16E574943FC20 /* PDFBilingualPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05214DBBEAC115D3CA73477D /* PDFBilingualPanelTests.swift */; };
 		68334589D47C834C926DEF1C /* HighlightCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8271FD51C6DF16B39F398C99 /* HighlightCoordinator.swift */; };
 		683D526BEEDC434933BB7A22 /* TXTSearchTapHighlightNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D2913CF3E7A07D5115997B /* TXTSearchTapHighlightNavigationTests.swift */; };
+		6868CB22925098DC45ED5161 /* ChatAnnotationCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A37012A543D5737FFC9039 /* ChatAnnotationCache.swift */; };
 		689521FED3BECF363AF06049 /* SchemaV1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5A2D5CFE8B719D4C8F3580 /* SchemaV1.swift */; };
 		689A68666A4FDCD57304AC8E /* MDMetadataExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FDB1CD71ED267C2FD85F325 /* MDMetadataExtractorTests.swift */; };
 		68B750CB7D82E8E4DE0DA393 /* SearchServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32DF5DC258E6460D4FE84706 /* SearchServiceTests.swift */; };
@@ -1466,6 +1468,7 @@
 		F8A29678ED4FE3B33CC97C71 /* SelectionPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B17BC96A003E5777FBFACC /* SelectionPopoverView.swift */; };
 		F8D243D5F4F95EDA50118FE5 /* foliate-bridge.js in Resources */ = {isa = PBXBuildFile; fileRef = CCBA2A70DA3EE6E28FAB3FFE /* foliate-bridge.js */; };
 		F8E7BB01AAFADCB93BF6DBFA /* Feature29WebDAVVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03019F035CBDE3EF65771114 /* Feature29WebDAVVerificationTests.swift */; };
+		F8ECE2A47A7713B5A7ECCB96 /* ChatAnnotationCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8F846506ADCDC633162553 /* ChatAnnotationCacheTests.swift */; };
 		F9944CF0FBC506CE9BA58EF3 /* SettingsHeaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8500C7EDCB2A51F928910E7F /* SettingsHeaderViewModel.swift */; };
 		F9DEEC528536DD293DF2397E /* Feature67SettingsProfileCardVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364D31D2138FFD463A149322 /* Feature67SettingsProfileCardVerificationTests.swift */; };
 		FA4B10B797D6B9D403FC756C /* BilingualReadingViewModelBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABFE45DFA72032791BC08F3 /* BilingualReadingViewModelBehaviorTests.swift */; };
@@ -1769,6 +1772,7 @@
 		2B29ECB0699594B79632E3EE /* ReadiumEPUBHost+BilingualDriver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReadiumEPUBHost+BilingualDriver.swift"; sourceTree = "<group>"; };
 		2B41E933EF843E0AC73B3E37 /* progress.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = progress.js; sourceTree = "<group>"; };
 		2B7C59839A119870BE9B6FF9 /* ReaderSelectionEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSelectionEventTests.swift; sourceTree = "<group>"; };
+		2B8F846506ADCDC633162553 /* ChatAnnotationCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAnnotationCacheTests.swift; sourceTree = "<group>"; };
 		2B94D8DF6728DEE93B09DE96 /* HighlightPopoverDeleteConfirm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPopoverDeleteConfirm.swift; sourceTree = "<group>"; };
 		2B98DA0DED4325E7AE1BEF59 /* DebugReaderProbeAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReaderProbeAdapter.swift; sourceTree = "<group>"; };
 		2B9AD84A4BE2CF0F8D59D9CC /* TXTChapterScrollOffsetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterScrollOffsetTests.swift; sourceTree = "<group>"; };
@@ -2240,6 +2244,7 @@
 		775CED0704F1D6D39F873FF9 /* PDFProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFProgressTests.swift; sourceTree = "<group>"; };
 		777477DCF173A1397609EC1F /* WebDAVProviderSelectiveRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProviderSelectiveRestoreTests.swift; sourceTree = "<group>"; };
 		77811B16F2CF741310C23CF5 /* EncodingDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingDetectorTests.swift; sourceTree = "<group>"; };
+		77A37012A543D5737FFC9039 /* ChatAnnotationCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAnnotationCache.swift; sourceTree = "<group>"; };
 		77A6970A21B903B77B011DE8 /* TXTTextViewBridgeEditMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTTextViewBridgeEditMenuTests.swift; sourceTree = "<group>"; };
 		77AEAE00997ED48B68EE20E6 /* Feature25TapZonesVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature25TapZonesVerificationTests.swift; sourceTree = "<group>"; };
 		78459E9C87CFFEA5BD741A5F /* SearchViewReskinTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewReskinTests.swift; sourceTree = "<group>"; };
@@ -3033,6 +3038,7 @@
 		FCDA968F8186B11859D8CCFE /* MDTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDTypes.swift; sourceTree = "<group>"; };
 		FD1989CF2F582B5C821059BA /* FoliateScrollModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateScrollModelTests.swift; sourceTree = "<group>"; };
 		FD27A5C682FAD0ED96FD755A /* MobiEPUBAssemblerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobiEPUBAssemblerTests.swift; sourceTree = "<group>"; };
+		FD477B685E3E8163D52949DC /* ChatSourcesMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSourcesMenu.swift; sourceTree = "<group>"; };
 		FDEB28B2CAB1481C73FBE351 /* TestSeederMDMultiPagePaginationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSeederMDMultiPagePaginationTests.swift; sourceTree = "<group>"; };
 		FDF40785A923791B0241CF75 /* GlobalAccessibilityAuditTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalAccessibilityAuditTests.swift; sourceTree = "<group>"; };
 		FDFAF8770F91837F0B3793E1 /* ImportProvenanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportProvenanceTests.swift; sourceTree = "<group>"; };
@@ -4131,6 +4137,7 @@
 				83B60F61628D0969B18B3A9B /* AIConsentView.swift */,
 				02C8F2C0DD4DC5CDA2601383 /* ChatContextBar.swift */,
 				4007FACF71264B6118B3F5FA /* ChatScopeMenu.swift */,
+				FD477B685E3E8163D52949DC /* ChatSourcesMenu.swift */,
 			);
 			path = AI;
 			sourceTree = "<group>";
@@ -5112,6 +5119,7 @@
 				B21BF3A477B679DC3646FE38 /* ChapterTranslationCacheLookupTests.swift */,
 				4A1B327713437D80D690ED9B /* ChapterTranslationChunkerTests.swift */,
 				B13E51BF43992E1B2786A8FD /* ChapterTranslationServiceTests.swift */,
+				2B8F846506ADCDC633162553 /* ChatAnnotationCacheTests.swift */,
 				5CBB56AF58AC56AB5CD3E692 /* ChatContextFoundationTests.swift */,
 				EA0CD7509429C4B75ACB98F2 /* KeychainProviderProfileExtensionTests.swift */,
 				C5C46A3D7400CC956FA8D46D /* ProviderKindTests.swift */,
@@ -5411,6 +5419,7 @@
 				E05A8F8B018491C86ABB86AD /* ChapterTranslationChunker.swift */,
 				00E65D537B445A7271390081 /* ChapterTranslationPrefetcher.swift */,
 				551DA6A3D645B1D9D72EE159 /* ChapterTranslationService.swift */,
+				77A37012A543D5737FFC9039 /* ChatAnnotationCache.swift */,
 				31EE8C98490794A73383C3A1 /* ChatAnnotationContext.swift */,
 				01DD3EDBBD948811D620B337 /* ChatCitation.swift */,
 				3E46C9FBB99778BBC01EC556 /* ChatContextAssembler.swift */,
@@ -5896,6 +5905,7 @@
 				3987A922844B144661A868B8 /* ChapterTranslationRecordTests.swift in Sources */,
 				56CDEC7C3ADB3B1142561E60 /* ChapterTranslationServiceTests.swift in Sources */,
 				E19364EB475B945F4B96F3DB /* ChapterTranslationStoreTests.swift in Sources */,
+				F8ECE2A47A7713B5A7ECCB96 /* ChatAnnotationCacheTests.swift in Sources */,
 				D5BFB1EBD8FCFB12E438DCE9 /* ChatContextFoundationTests.swift in Sources */,
 				E4F03F269AFA7E2CF65B2E6A /* ChatScopeSelectionTests.swift in Sources */,
 				2DA32CDB11AE06DBCF3E97DE /* CloudKitRecordMapperTests.swift in Sources */,
@@ -6549,6 +6559,7 @@
 				4EFC0ADF77B237B9D1D37A2F /* ChapterTranslationRecord.swift in Sources */,
 				D35863F85B17FE883F4EABBF /* ChapterTranslationService.swift in Sources */,
 				FB7EAB10F53380ED4FFAF9D1 /* ChapterTranslationStore.swift in Sources */,
+				6868CB22925098DC45ED5161 /* ChatAnnotationCache.swift in Sources */,
 				D1E30622FC94E669C740FFD7 /* ChatAnnotationContext.swift in Sources */,
 				A5269794813DB85D5D1053F4 /* ChatCitation.swift in Sources */,
 				AF263750044D4A8AD25C3675 /* ChatContextAssembler.swift in Sources */,
@@ -6558,6 +6569,7 @@
 				F51F7B9360A990E857FE1373 /* ChatMessage.swift in Sources */,
 				8FD1FAC0AE8611D29DEDC87D /* ChatScopeMenu.swift in Sources */,
 				5BDAA75F4C3A30CBCC893190 /* ChatSourceSelection.swift in Sources */,
+				25C35999B6BAA3D90435C66A /* ChatSourcesMenu.swift in Sources */,
 				CD3F1CD3B0FD3B013D82E26D /* CloudKitClient.swift in Sources */,
 				479BBE7406AFCACEE1CA5EE3 /* CloudKitRecordMapper.swift in Sources */,
 				70DA481383CC5F3047D96E83 /* CollectionSidebar.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -573,6 +573,7 @@
 		5C20BECE1338802F60F3E7B7 /* AITranslationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE29B97304B59C88E3F3F9CF /* AITranslationTests.swift */; };
 		5C43358A8E8C8AB46D744514 /* ReadinessTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D805C5BFB334FBABC94879 /* ReadinessTracker.swift */; };
 		5C4609A0AEAD65A12670FB78 /* DebugBridgeHighlightObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310813C564EF1BF86A13694E /* DebugBridgeHighlightObserverTests.swift */; };
+		5C7330D1B5481B25BA637DA7 /* AIChatView+Composer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B55B710BEC6ADA4EE00C594 /* AIChatView+Composer.swift */; };
 		5C73631E3B5708B83FB0FCDE /* SettingsSectionHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C27BEEC63F7D76A423821D /* SettingsSectionHeaderTests.swift */; };
 		5CFB9D494F377849E9341376 /* Feature36OPDSVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E868FB040D93F83C745083C /* Feature36OPDSVerificationTests.swift */; };
 		5D0737B628F92C5588E95081 /* SyncRecordDTOs.swift in Sources */ = {isa = PBXBuildFile; fileRef = E02C0C97FFE66E8DEC728D64 /* SyncRecordDTOs.swift */; };
@@ -1967,6 +1968,7 @@
 		4AF425B4F1C4D35531E0D261 /* TranslateBookActionRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateBookActionRow.swift; sourceTree = "<group>"; };
 		4B0EDE73D4EB702686B1326E /* MDReaderContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReaderContainerView.swift; sourceTree = "<group>"; };
 		4B3A240BB6031B14144741FE /* PDFAnnotationBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFAnnotationBridgeTests.swift; sourceTree = "<group>"; };
+		4B55B710BEC6ADA4EE00C594 /* AIChatView+Composer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AIChatView+Composer.swift"; sourceTree = "<group>"; };
 		4B81B909B41CB8C14B613D73 /* LocatorRestorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorRestorer.swift; sourceTree = "<group>"; };
 		4BC51E5F1213D2B1363C13D5 /* FoliateHighlightMutator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightMutator.swift; sourceTree = "<group>"; };
 		4BD245135256A06A28C88178 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
@@ -4134,6 +4136,7 @@
 				6A5928551FF9FBB8D2E87E6F /* AIAssistantView.swift */,
 				BA0216684C6AC6F1F2DA5EF4 /* AIChatMessageRow.swift */,
 				539FEE4A23AFA226048A12A4 /* AIChatView.swift */,
+				4B55B710BEC6ADA4EE00C594 /* AIChatView+Composer.swift */,
 				83B60F61628D0969B18B3A9B /* AIConsentView.swift */,
 				02C8F2C0DD4DC5CDA2601383 /* ChatContextBar.swift */,
 				4007FACF71264B6118B3F5FA /* ChatScopeMenu.swift */,
@@ -6422,6 +6425,7 @@
 				384E9916435C82876752D9D9 /* AIAssistantView.swift in Sources */,
 				99456D2FCC39AA83E0B43C65 /* AIAssistantViewModel.swift in Sources */,
 				56A9335B5F44D301240C81B7 /* AIChatMessageRow.swift in Sources */,
+				5C7330D1B5481B25BA637DA7 /* AIChatView+Composer.swift in Sources */,
 				8E936BF32CF0850398C9D742 /* AIChatView.swift in Sources */,
 				C8AC5FD914F26F89DA69AA8C /* AIChatViewModel.swift in Sources */,
 				4CC9567091E0CABFDD800F6C /* AIConfiguration.swift in Sources */,

--- a/vreader/Services/AI/ChatAnnotationCache.swift
+++ b/vreader/Services/AI/ChatAnnotationCache.swift
@@ -45,6 +45,10 @@ final class ChatAnnotationCache {
     /// after all references are gone — no concurrent access. `NotificationCenter`
     /// removal is itself thread-safe.
     nonisolated(unsafe) private var changeObserver: NSObjectProtocol?
+    /// Monotonic load generation — guards against interleaved reloads (Gate-4
+    /// High): rapid `.readerAnnotationsDidChange` posts spawn overlapping
+    /// `load()` Tasks, and only the newest may publish state + fire `onChange`.
+    private var loadGeneration = 0
 
     init(
         fingerprintKey: String,
@@ -75,9 +79,17 @@ final class ChatAnnotationCache {
     /// on each `.readerAnnotationsDidChange`. A fetch failure leaves that kind
     /// empty (the AI context simply omits it — never blocks the chat).
     func load() async {
-        annotations = (try? await annotationStore.fetchAnnotations(forBookWithKey: fingerprintKey)) ?? []
-        highlights = (try? await highlightStore.fetchHighlights(forBookWithKey: fingerprintKey)) ?? []
-        bookmarks = (try? await bookmarkStore.fetchBookmarks(forBookWithKey: fingerprintKey)) ?? []
+        loadGeneration += 1
+        let generation = loadGeneration
+        // Fetch into locals across the awaits, THEN commit atomically — so an
+        // older reload that finishes last can't leave a mixed/stale snapshot.
+        let fetchedAnnotations = (try? await annotationStore.fetchAnnotations(forBookWithKey: fingerprintKey)) ?? []
+        let fetchedHighlights = (try? await highlightStore.fetchHighlights(forBookWithKey: fingerprintKey)) ?? []
+        let fetchedBookmarks = (try? await bookmarkStore.fetchBookmarks(forBookWithKey: fingerprintKey)) ?? []
+        guard generation == loadGeneration else { return }   // a newer load superseded us
+        annotations = fetchedAnnotations
+        highlights = fetchedHighlights
+        bookmarks = fetchedBookmarks
         onChange?()
     }
 

--- a/vreader/Services/AI/ChatAnnotationCache.swift
+++ b/vreader/Services/AI/ChatAnnotationCache.swift
@@ -1,0 +1,92 @@
+// Purpose: Per-book cache of the reader's own annotations for the AI Chat tab's
+// sources feature (Feature #86 WI-4). Holds the fetched standalone notes /
+// highlights / bookmarks + their counts, so the chat-context funnel can assemble
+// the "[Your notes & marks]" block WITHOUT hitting SwiftData on every relocate.
+//
+// It loads once when the reader opens and refreshes ONLY on the single
+// mutation-complete bus `.readerAnnotationsDidChange` (posted by PersistenceActor
+// after a successful annotation save, WI-2) — never on a position change. This is
+// the Gate-2 fix that keeps annotation I/O out of the relocate path.
+//
+// @coordinates-with: ChatAnnotationContext.swift, ReaderAICoordinator.swift,
+//   AnnotationPersisting.swift, HighlightPersisting.swift, BookmarkPersisting.swift,
+//   ReaderNotifications.swift (.readerAnnotationsDidChange)
+
+import Foundation
+import SwiftUI
+
+/// A per-book cache of the reader's annotations for the Chat sources feature.
+@MainActor
+@Observable
+final class ChatAnnotationCache {
+
+    private(set) var annotations: [AnnotationRecord] = []
+    private(set) var highlights: [HighlightRecord] = []
+    private(set) var bookmarks: [BookmarkRecord] = []
+
+    /// Per-kind counts for the sources popover (notes = standalone + annotated highlights).
+    var counts: (notes: Int, highlights: Int, bookmarks: Int) {
+        ChatAnnotationContext.counts(
+            annotations: annotations, highlights: highlights, bookmarks: bookmarks
+        )
+    }
+
+    /// Set by the coordinator: invoked after each (re)load so the chat context +
+    /// the sources-chip counts re-assemble when an annotation mutation lands.
+    var onChange: (() -> Void)?
+
+    private let fingerprintKey: String
+    private let annotationStore: any AnnotationPersisting
+    private let highlightStore: any HighlightPersisting
+    private let bookmarkStore: any BookmarkPersisting
+    /// `nonisolated(unsafe)` so the nonisolated `deinit` can remove the observer
+    /// (Swift 6 forbids a nonisolated deinit from touching a MainActor-isolated
+    /// stored property). Set once in `init` (MainActor), read once in `deinit`
+    /// after all references are gone — no concurrent access. `NotificationCenter`
+    /// removal is itself thread-safe.
+    nonisolated(unsafe) private var changeObserver: NSObjectProtocol?
+
+    init(
+        fingerprintKey: String,
+        annotationStore: any AnnotationPersisting,
+        highlightStore: any HighlightPersisting,
+        bookmarkStore: any BookmarkPersisting
+    ) {
+        self.fingerprintKey = fingerprintKey
+        self.annotationStore = annotationStore
+        self.highlightStore = highlightStore
+        self.bookmarkStore = bookmarkStore
+        // Refresh on the mutation-complete bus ONLY (not on relocate).
+        changeObserver = NotificationCenter.default.addObserver(
+            forName: .readerAnnotationsDidChange, object: nil, queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { await self.load() }
+        }
+    }
+
+    deinit {
+        if let changeObserver {
+            NotificationCenter.default.removeObserver(changeObserver)
+        }
+    }
+
+    /// Fetches the three annotation kinds for this book. Called once on open and
+    /// on each `.readerAnnotationsDidChange`. A fetch failure leaves that kind
+    /// empty (the AI context simply omits it — never blocks the chat).
+    func load() async {
+        annotations = (try? await annotationStore.fetchAnnotations(forBookWithKey: fingerprintKey)) ?? []
+        highlights = (try? await highlightStore.fetchHighlights(forBookWithKey: fingerprintKey)) ?? []
+        bookmarks = (try? await bookmarkStore.fetchBookmarks(forBookWithKey: fingerprintKey)) ?? []
+        onChange?()
+    }
+
+    /// The serialized `[Your notes & marks]` block for the given source selection,
+    /// budget-capped. Empty when the selection is all-off or nothing matches.
+    func annotationBlock(for selection: ChatSourceSelection, maxUTF16: Int) -> String {
+        ChatAnnotationContext.serialize(
+            annotations: annotations, highlights: highlights, bookmarks: bookmarks,
+            selection: selection, maxUTF16: maxUTF16
+        )
+    }
+}

--- a/vreader/ViewModels/AIChatViewModel.swift
+++ b/vreader/ViewModels/AIChatViewModel.swift
@@ -84,6 +84,23 @@ final class AIChatViewModel {
         onScopeChanged?()
     }
 
+    /// Feature #86 WI-4: which of the reader's own annotation kinds (Notes /
+    /// Highlights / Bookmarks) are folded into the AI context. Drives the
+    /// context-bar sources chip. Changing it re-assembles `bookContext` via the
+    /// same coordinator funnel as scope.
+    private(set) var sources: ChatSourceSelection = .default
+
+    /// Per-book annotation counts for the sources popover (notes / highlights /
+    /// bookmarks). Set by the coordinator from the `ChatAnnotationCache`.
+    var sourceCounts: (notes: Int, highlights: Int, bookmarks: Int) = (0, 0, 0)
+
+    /// Toggles a single source kind and re-assembles the book context.
+    func setSources(_ newSources: ChatSourceSelection) {
+        guard newSources != sources else { return }
+        sources = newSources
+        onScopeChanged?()   // same single re-assembly funnel as scope
+    }
+
     // MARK: - Dependencies
 
     private let aiService: AIService

--- a/vreader/Views/AI/AIChatView+Composer.swift
+++ b/vreader/Views/AI/AIChatView+Composer.swift
@@ -1,0 +1,125 @@
+// Purpose: The AI Chat composer (input pill + send button) + its styling
+// helpers, extracted from AIChatView.swift to keep that file under the ~300-line
+// guide as the context bar / scope / sources / retrieval surfaces accrete
+// (Feature #86 WI-4). Behaviour is unchanged — the design pill input row, the
+// bug-#94 focus/submit wiring, and the bug-#310 themed placeholder all move
+// verbatim.
+//
+// @coordinates-with: AIChatView.swift, AIChatViewModel.swift, ReaderThemeV2.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-panels.jsx`
+
+#if canImport(UIKit)
+import SwiftUI
+
+extension AIChatView {
+
+    // MARK: - Input Bar
+
+    /// The design's rounded pill input field with a circular send button —
+    /// `vreader-panels.jsx` `ChatView`'s input row. Multiline (`axis: .vertical`,
+    /// `lineLimit(1...5)`) with the bug-#94 focus/submit wiring.
+    @ViewBuilder
+    var inputBar: some View {
+        // Feature #86 WI-3: the cluster's single top rule lives on the docked
+        // ChatContextBar above this composer (design #1455), so the composer
+        // draws no rule of its own.
+        HStack(spacing: 8) {
+            ZStack(alignment: .topLeading) {
+                // Bug #310: themed placeholder. SwiftUI ignores `.foregroundStyle`
+                // on a `TextField`'s own placeholder (it stays the system
+                // appearance-aware colour — ~1.07:1, near-invisible over the cream
+                // sheet in Dark Mode), so overlay a `Text` in the designed `sub`
+                // token. Identical font + the shared padding keep it aligned.
+                if inputText.isEmpty {
+                    Text(inputPlaceholder)
+                        .font(.system(size: 14))
+                        .foregroundStyle(Color(Self.secondaryContentColor(for: theme)))
+                        .allowsHitTesting(false)
+                        .accessibilityHidden(true)
+                }
+                TextField("", text: $inputText, axis: .vertical)
+                    .lineLimit(1...5)
+                    .font(.system(size: 14))
+                    .foregroundStyle(Color(theme.inkColor))
+                    .textFieldStyle(.plain)
+                    .focused($isInputFocused)
+                    .onSubmit { sendCurrentMessage() }
+                    .accessibilityIdentifier("chatInputField")
+                    // Bug #310: the empty prompt `""` would leave VoiceOver an
+                    // unlabeled field (the overlay placeholder is hidden), so
+                    // carry the label explicitly.
+                    .accessibilityLabel(inputPlaceholder)
+            }
+            .padding(.leading, 14)
+            .padding(.vertical, 6)
+
+            Button {
+                sendCurrentMessage()
+            } label: {
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 32, height: 32)
+                    .background(Circle().fill(Color(sendButtonFillColor)))
+            }
+            .buttonStyle(.plain)
+            .disabled(!canSend)
+            .accessibilityIdentifier("chatSendButton")
+            .accessibilityLabel("Send message")
+        }
+        .padding(6)
+        .background(Capsule().fill(Color(pillFillColor)))
+        .padding(.horizontal, 14)
+        .padding(.top, 8)
+        .padding(.bottom, 16)
+    }
+
+    // MARK: - Composer helpers
+
+    /// The input placeholder mirrors the empty state's book/no-book split: the
+    /// reader AI-sheet chat (`bookFingerprint != nil`) uses the design's
+    /// book-specific copy; the Library general-chat sheet keeps the neutral
+    /// pre-v2 wording so the WI-2 re-skin doesn't regress that reused surface.
+    var inputPlaceholder: String {
+        viewModel.bookFingerprint != nil
+            ? "Ask about this book\u{2026}"
+            : "Type a message\u{2026}"
+    }
+
+    var canSend: Bool {
+        !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !viewModel.isLoading
+    }
+
+    /// Bug #310: the empty-state + the placeholder must read the designed
+    /// cream-aware `sub` token — NOT the system appearance-aware `.secondary`,
+    /// which resolves to ~1.07:1 over the cream AI sheet in Dark Mode. `static`
+    /// so a contrast test can pin it without rendering the view.
+    static func secondaryContentColor(for theme: ReaderThemeV2) -> UIColor {
+        theme.subColor
+    }
+
+    /// The pill's neutral wash — design `ChatView` input container.
+    var pillFillColor: UIColor {
+        theme.isDark
+            ? UIColor.white.withAlphaComponent(0.06)
+            : UIColor.black.withAlphaComponent(0.04)
+    }
+
+    /// The send button's fill — accent when sendable, a neutral wash otherwise.
+    var sendButtonFillColor: UIColor {
+        guard canSend else {
+            return theme.isDark
+                ? UIColor.white.withAlphaComponent(0.12)
+                : UIColor.black.withAlphaComponent(0.10)
+        }
+        return theme.accentColor
+    }
+
+    func sendCurrentMessage() {
+        let text = inputText
+        inputText = ""
+        Task { await viewModel.sendMessage(text) }
+    }
+}
+#endif

--- a/vreader/Views/AI/AIChatView.swift
+++ b/vreader/Views/AI/AIChatView.swift
@@ -30,8 +30,10 @@ import SwiftUI
 struct AIChatView: View {
 
     @Bindable var viewModel: AIChatViewModel
-    @State private var inputText: String = ""
-    @FocusState private var isInputFocused: Bool
+    // Internal (not private) so the composer extracted into AIChatView+Composer.swift
+    // can read them (Feature #86 WI-4: keep AIChatView.swift under the size guide).
+    @State var inputText: String = ""
+    @FocusState var isInputFocused: Bool
 
     /// Visual-identity-v2 theme tokens (feature #65 WI-2). Defaults to
     /// `.paper` so existing callers / previews that omit it keep working.
@@ -288,131 +290,5 @@ struct AIChatView: View {
         .accessibilityIdentifier("chatErrorBanner")
     }
 
-    // MARK: - Input Bar
-
-    /// The design's rounded pill input field with a circular send
-    /// button — `vreader-panels.jsx` `ChatView`'s input row. The
-    /// previous plain `TextField` + `arrow.up.circle.fill` button is
-    /// replaced; the multiline (`axis: .vertical`, `lineLimit(1...5)`)
-    /// behaviour and the bug-#94 focus / submit wiring are preserved.
-    @ViewBuilder
-    private var inputBar: some View {
-        // Feature #86 WI-3: the cluster's single top rule now lives on the docked
-        // ChatContextBar above this composer (design #1455 — one shared rule around
-        // bar + composer), so the composer no longer draws its own.
-        HStack(spacing: 8) {
-            ZStack(alignment: .topLeading) {
-                // Bug #310: themed placeholder. SwiftUI ignores `.foregroundStyle`
-                // on a `TextField`'s own placeholder (it stays the system
-                // appearance-aware colour — ~1.07:1, near-invisible over the cream
-                // sheet in Dark Mode), so overlay a `Text` in the designed `sub`
-                // token. Identical font + the shared padding below keep it aligned
-                // with the entered text.
-                if inputText.isEmpty {
-                    Text(inputPlaceholder)
-                        .font(.system(size: 14))
-                        .foregroundStyle(Color(Self.secondaryContentColor(for: theme)))
-                        .allowsHitTesting(false)
-                        .accessibilityHidden(true)
-                }
-                TextField("", text: $inputText, axis: .vertical)
-                    .lineLimit(1...5)
-                    .font(.system(size: 14))
-                    .foregroundStyle(Color(theme.inkColor))
-                    .textFieldStyle(.plain)
-                    .focused($isInputFocused)
-                    .onSubmit {
-                        sendCurrentMessage()
-                    }
-                    .accessibilityIdentifier("chatInputField")
-                    // Bug #310 (Codex Gate-4 Medium): the empty prompt `""`
-                    // would leave VoiceOver an unlabeled field (the overlay
-                    // placeholder is accessibilityHidden), so carry the label
-                    // explicitly.
-                    .accessibilityLabel(inputPlaceholder)
-            }
-            .padding(.leading, 14)
-            .padding(.vertical, 6)
-
-            Button {
-                sendCurrentMessage()
-            } label: {
-                Image(systemName: "arrow.up")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(.white)
-                    .frame(width: 32, height: 32)
-                    .background(
-                        Circle().fill(Color(sendButtonFillColor))
-                    )
-            }
-            .buttonStyle(.plain)
-            .disabled(!canSend)
-            .accessibilityIdentifier("chatSendButton")
-            .accessibilityLabel("Send message")
-        }
-        .padding(6)
-        .background(
-            Capsule().fill(Color(pillFillColor))
-        )
-        .padding(.horizontal, 14)
-        .padding(.top, 8)
-        .padding(.bottom, 16)
-    }
-
-    // MARK: - Private
-
-    /// The input placeholder mirrors the empty state's book/no-book
-    /// split: the reader AI-sheet chat (`bookFingerprint != nil`) uses
-    /// the design's book-specific copy; the Library general-chat sheet
-    /// (`bookFingerprint == nil`) keeps the neutral pre-v2 wording so
-    /// the WI-2 re-skin does not regress that reused surface.
-    private var inputPlaceholder: String {
-        viewModel.bookFingerprint != nil
-            ? "Ask about this book\u{2026}"
-            : "Type a message\u{2026}"
-    }
-
-    private var canSend: Bool {
-        !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && !viewModel.isLoading
-    }
-
-    /// Bug #310: the empty-state (icon + headline) and the input placeholder
-    /// must read the designed cream-aware `sub` token — NOT the system
-    /// appearance-aware `.secondary`, which resolves to ~1.07:1 (near-white)
-    /// over the cream AI sheet (`#fcf8f0`) in Dark Mode. Same restore-to-
-    /// designed-token fix as the sibling `AIReaderPanelHeader` subtitle
-    /// (#285 / #297 / #300 class). `static` so a contrast test can pin it
-    /// without rendering the view.
-    static func secondaryContentColor(for theme: ReaderThemeV2) -> UIColor {
-        theme.subColor
-    }
-
-    /// The pill's neutral wash — design `ChatView` input container.
-    private var pillFillColor: UIColor {
-        theme.isDark
-            ? UIColor.white.withAlphaComponent(0.06)
-            : UIColor.black.withAlphaComponent(0.04)
-    }
-
-    /// The send button's fill — accent when a message can be sent,
-    /// a neutral wash otherwise (design `ChatView`'s `draft.trim()`
-    /// conditional).
-    private var sendButtonFillColor: UIColor {
-        guard canSend else {
-            return theme.isDark
-                ? UIColor.white.withAlphaComponent(0.12)
-                : UIColor.black.withAlphaComponent(0.10)
-        }
-        return theme.accentColor
-    }
-
-    private func sendCurrentMessage() {
-        let text = inputText
-        inputText = ""
-        Task {
-            await viewModel.sendMessage(text)
-        }
-    }
 }
 #endif

--- a/vreader/Views/AI/AIChatView.swift
+++ b/vreader/Views/AI/AIChatView.swift
@@ -37,11 +37,12 @@ struct AIChatView: View {
     /// `.paper` so existing callers / previews that omit it keep working.
     var theme: ReaderThemeV2 = .paper
 
-    /// Feature #86 WI-3: whether the scope menu is presented above the bar.
-    @State private var isScopeMenuOpen = false
+    /// Feature #86 WI-3/4: which context-bar menu is presented (or none).
+    @State private var openMenu: ContextMenuKind?
+    private enum ContextMenuKind { case scope, sources }
 
     var body: some View {
-        ZStack(alignment: .bottomLeading) {
+        ZStack(alignment: .bottom) {
             VStack(spacing: 0) {
                 messageList
 
@@ -49,38 +50,57 @@ struct AIChatView: View {
                     errorBanner(message: error)
                 }
 
-                // Feature #86 WI-3: the docked context bar, above the composer.
+                // Feature #86 WI-3/4: the docked context bar, above the composer.
                 ChatContextBar(
                     scope: viewModel.scope,
                     theme: theme,
-                    isScopeMenuOpen: isScopeMenuOpen,
-                    onScopeTap: { isScopeMenuOpen.toggle() }
+                    isScopeMenuOpen: openMenu == .scope,
+                    onScopeTap: { toggleMenu(.scope) },
+                    sourcesCount: viewModel.sources.activeCount,
+                    isSourcesMenuOpen: openMenu == .sources,
+                    onSourcesTap: { toggleMenu(.sources) }
                 )
 
                 inputBar
             }
 
-            // Feature #86 WI-3: the scope menu floats above the composer with a
-            // tap-scrim that dismisses it.
-            if isScopeMenuOpen {
+            // Feature #86 WI-3/4: the scope / sources menus float above the
+            // composer (scope at leading, sources at trailing) with a shared
+            // tap-scrim that dismisses whichever is open.
+            if openMenu != nil {
                 Color.black.opacity(0.001)
                     .ignoresSafeArea()
                     .contentShape(Rectangle())
-                    .onTapGesture { isScopeMenuOpen = false }
+                    .onTapGesture { openMenu = nil }
+            }
+            if openMenu == .scope {
                 ChatScopeMenu(
                     selected: viewModel.scope,
                     theme: theme,
                     onSelect: { scope in
                         viewModel.setScope(scope)
-                        isScopeMenuOpen = false
+                        openMenu = nil
                     }
                 )
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.leading, 14)
                 .padding(.bottom, 80)
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
             }
+            if openMenu == .sources {
+                ChatSourcesMenu(
+                    selection: viewModel.sources,
+                    counts: viewModel.sourceCounts,
+                    theme: theme,
+                    onToggle: { viewModel.setSources($0) }   // stays open for multi-toggle
+                )
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .padding(.trailing, 14)
+                .padding(.bottom, 80)
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
         }
-        .animation(.spring(response: 0.28, dampingFraction: 0.85), value: isScopeMenuOpen)
+        .animation(.spring(response: 0.28, dampingFraction: 0.85), value: openMenu)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
@@ -122,6 +142,12 @@ struct AIChatView: View {
     static func seedDecision(seededInput: String?, currentInput: String) -> SeedDecision {
         guard let seed = seededInput else { return .none }
         return currentInput.isEmpty ? .apply(seed) : .dropAndClear
+    }
+
+    /// Feature #86 WI-3/4: toggle a context-bar menu (tapping the open one closes it,
+    /// tapping the other switches to it).
+    private func toggleMenu(_ kind: ContextMenuKind) {
+        openMenu = (openMenu == kind) ? nil : kind
     }
 
     /// One-shot consumption of `viewModel.seededInput` (applies the pure

--- a/vreader/Views/AI/ChatContextBar.swift
+++ b/vreader/Views/AI/ChatContextBar.swift
@@ -16,7 +16,8 @@
 #if canImport(UIKit)
 import SwiftUI
 
-/// The Chat context bar (WI-3: scope chip only).
+/// The Chat context bar: a left scope chip + a right sources chip (Feature #86
+/// WI-3 + WI-4).
 struct ChatContextBar: View {
     let scope: ChatContextScope
     let theme: ReaderThemeV2
@@ -24,14 +25,24 @@ struct ChatContextBar: View {
     let isScopeMenuOpen: Bool
     /// Tapped the scope chip.
     let onScopeTap: () -> Void
+    /// Number of toggled-on source kinds (the green badge; 0 ⇒ "Off").
+    let sourcesCount: Int
+    /// Whether the sources menu is currently open.
+    let isSourcesMenuOpen: Bool
+    /// Tapped the sources chip.
+    let onSourcesTap: () -> Void
 
     static let scopeChipIdentifier = "chatContextScopeChip"
+    static let sourcesChipIdentifier = "chatContextSourcesChip"
+
+    /// The "on" green — matches `PillSwitch` ON across the app (design `#3a6a5a`).
+    static let accentGreen = UIColor(red: 0x3a / 255, green: 0x6a / 255, blue: 0x5a / 255, alpha: 1)
 
     var body: some View {
         HStack(spacing: 0) {
             scopeChip
-            Spacer(minLength: 0)
-            // WI-4: sources chip docks here.
+            Spacer(minLength: 8)
+            sourcesChip
         }
         .padding(.horizontal, 14)
         .padding(.top, 9)
@@ -42,6 +53,56 @@ struct ChatContextBar: View {
                 .frame(height: 0.5)
         }
         .accessibilityIdentifier("chatContextBar")
+    }
+
+    @ViewBuilder
+    private var sourcesChip: some View {
+        let on = sourcesCount > 0
+        Button(action: onSourcesTap) {
+            HStack(spacing: 6) {
+                Image(systemName: "note.text")
+                    .font(.system(size: 12, weight: .regular))
+                    .foregroundStyle(Color(on ? Self.accentGreen : theme.subColor))
+                Text("Sources")
+                    .font(.system(size: 12.5, weight: .medium))
+                    .foregroundStyle(Color(on ? theme.inkColor : theme.subColor))
+                if on {
+                    Text("\(sourcesCount)")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundStyle(.white)
+                        .frame(minWidth: 16)
+                        .padding(.horizontal, 3)
+                        .frame(height: 16)
+                        .background(Capsule().fill(Color(Self.accentGreen)))
+                } else {
+                    Text("Off")
+                        .font(.system(size: 12))
+                        .foregroundStyle(Color(theme.subColor))
+                }
+            }
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+            .padding(.horizontal, 11)
+            .padding(.vertical, 6)
+            .background(Capsule().fill(Color(sourcesChipFill(on: on))))
+            .overlay(
+                Capsule().stroke(
+                    Color(isSourcesMenuOpen ? theme.accentColor : (on ? .clear : theme.ruleColor)),
+                    lineWidth: 0.5
+                )
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(Self.sourcesChipIdentifier)
+        .accessibilityLabel(on ? "Chat sources: \(sourcesCount) on" : "Chat sources: off")
+    }
+
+    /// Soft green wash when any source is on; transparent when all off.
+    private func sourcesChipFill(on: Bool) -> UIColor {
+        guard on else { return .clear }
+        return theme.isDark
+            ? Self.accentGreen.withAlphaComponent(0.22)
+            : Self.accentGreen.withAlphaComponent(0.12)
     }
 
     @ViewBuilder

--- a/vreader/Views/AI/ChatSourcesMenu.swift
+++ b/vreader/Views/AI/ChatSourcesMenu.swift
@@ -1,0 +1,140 @@
+// Purpose: The Chat sources menu — the popover that opens upward from the context
+// bar's sources chip (Feature #86 WI-4, design #1455). Three toggle rows over the
+// reader's own annotations (Notes / Highlights / Bookmarks), each with a per-book
+// count. When all three are off, none of the reader's marks leave the device.
+//
+// @coordinates-with: ChatContextBar.swift, ChatSourceSelection.swift,
+//   ChatAnnotationCache.swift, ReaderThemeV2.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/chat-context-artboards.jsx`
+
+#if canImport(UIKit)
+import SwiftUI
+
+/// The Chat annotation-sources toggle menu (popover).
+struct ChatSourcesMenu: View {
+    let selection: ChatSourceSelection
+    /// Per-book counts (notes / highlights / bookmarks).
+    let counts: (notes: Int, highlights: Int, bookmarks: Int)
+    let theme: ReaderThemeV2
+    /// Toggled a kind — returns the new selection.
+    let onToggle: (ChatSourceSelection) -> Void
+
+    private enum Kind { case notes, highlights, bookmarks }
+
+    static func rowIdentifier(_ kind: String) -> String { "chatSourcesRow.\(kind)" }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider().overlay(Color(theme.ruleColor))
+            VStack(spacing: 0) {
+                row(.notes, label: "Notes", icon: "note.text", count: counts.notes, isOn: selection.notes)
+                row(.highlights, label: "Highlights", icon: "highlighter", count: counts.highlights, isOn: selection.highlights)
+                row(.bookmarks, label: "Bookmarks", icon: "bookmark", count: counts.bookmarks, isOn: selection.bookmarks)
+            }
+            .padding(.vertical, 4)
+            Divider().overlay(Color(theme.ruleColor))
+            footer
+        }
+        .frame(width: 280)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous).fill(Color(theme.paperColor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous).stroke(Color(theme.ruleColor), lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(theme.isDark ? 0.5 : 0.18), radius: 18, y: 8)
+        .accessibilityIdentifier("chatSourcesMenu")
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text("Your annotations")
+                .font(.system(size: 15, weight: .semibold, design: .serif))
+                .foregroundStyle(Color(theme.inkColor))
+            Text("Add what you’ve marked to the context")
+                .font(.system(size: 11.5))
+                .foregroundStyle(Color(theme.subColor))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 14)
+        .padding(.top, 13)
+        .padding(.bottom, 9)
+    }
+
+    @ViewBuilder
+    private func row(_ kind: Kind, label: String, icon: String, count: Int, isOn: Bool) -> some View {
+        Button { onToggle(toggled(kind)) } label: {
+            HStack(spacing: 11) {
+                iconTile(icon, on: isOn)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(label)
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(Color(theme.inkColor))
+                    Text("\(count) in this book")
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(Color(theme.subColor))
+                }
+                Spacer(minLength: 8)
+                switchView(isOn)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 11)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(Self.rowIdentifier(label.lowercased()))
+        .accessibilityAddTraits(isOn ? [.isSelected] : [])
+    }
+
+    @ViewBuilder
+    private func iconTile(_ icon: String, on: Bool) -> some View {
+        Image(systemName: icon)
+            .font(.system(size: 14))
+            .foregroundStyle(Color(on ? ChatContextBar.accentGreen : theme.subColor))
+            .frame(width: 28, height: 28)
+            .background(RoundedRectangle(cornerRadius: 8, style: .continuous).fill(Color(tileFill(on: on))))
+    }
+
+    @ViewBuilder
+    private func switchView(_ on: Bool) -> some View {
+        Capsule()
+            .fill(Color(on ? ChatContextBar.accentGreen : (theme.isDark ? .init(white: 1, alpha: 0.12) : .init(white: 0, alpha: 0.12))))
+            .frame(width: 38, height: 22)
+            .overlay(alignment: on ? .trailing : .leading) {
+                Circle().fill(.white).frame(width: 18, height: 18).padding(2)
+                    .shadow(color: .black.opacity(0.2), radius: 1, y: 1)
+            }
+    }
+
+    private var footer: some View {
+        HStack(alignment: .top, spacing: 7) {
+            Image(systemName: "info.circle")
+                .font(.system(size: 12))
+                .foregroundStyle(Color(theme.subColor))
+            Text("Included alongside the book text so answers can cite what you marked.")
+                .font(.system(size: 11.5))
+                .foregroundStyle(Color(theme.subColor))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+
+    private func toggled(_ kind: Kind) -> ChatSourceSelection {
+        var s = selection
+        switch kind {
+        case .notes:      s.notes.toggle()
+        case .highlights: s.highlights.toggle()
+        case .bookmarks:  s.bookmarks.toggle()
+        }
+        return s
+    }
+
+    private func tileFill(on: Bool) -> UIColor {
+        if on { return ChatContextBar.accentGreen.withAlphaComponent(theme.isDark ? 0.25 : 0.12) }
+        return theme.isDark ? .init(white: 1, alpha: 0.05) : .init(white: 0, alpha: 0.04)
+    }
+}
+#endif

--- a/vreader/Views/Reader/ReaderAICoordinator.swift
+++ b/vreader/Views/Reader/ReaderAICoordinator.swift
@@ -110,8 +110,28 @@ final class ReaderAICoordinator {
     /// and the chat VM calls it on a scope change, so a late TOC upgrades the
     /// context and a scroll never reverts it.
     func refreshChatContext() {
-        let scope = chatViewModel?.scope ?? .chapter
-        chatViewModel?.bookContext = scopedChatContext(scope)
+        guard let chatVM = chatViewModel else { return }
+        let scopeText = scopedChatContext(chatVM.scope)
+        // Feature #86 WI-4: fold in the reader's selected annotation kinds, read
+        // from the in-memory cache (NO SwiftData fetch on relocate). When no cache
+        // exists (AI without persistence), the block is empty → WI-1/3 behavior.
+        let block = chatAnnotationCache?.annotationBlock(
+            for: chatVM.sources, maxUTF16: AIContextBudget.defaultMaxUTF16
+        ) ?? ""
+        let assembly = ChatContextAssembler.assemble(
+            scopeText: scopeText, annotationBlock: block, citations: [],
+            maxUTF16: AIContextBudget.defaultMaxUTF16
+        )
+        chatVM.bookContext = assembly.bookContext
+    }
+
+    /// Feature #86 WI-4: the per-book annotation cache backing the sources chip.
+    /// Created in `setupIfNeeded` when persistence is available.
+    private(set) var chatAnnotationCache: ChatAnnotationCache?
+
+    /// Pushes the cache's current per-kind counts to the chat VM's sources chip.
+    private func syncSourceCounts() {
+        chatViewModel?.sourceCounts = chatAnnotationCache?.counts ?? (0, 0, 0)
     }
 
     /// Book title used as fallback when no text content is available.
@@ -120,11 +140,20 @@ final class ReaderAICoordinator {
     private let bookFormat: BookFormat
     /// Fingerprint key for creating chat VM.
     private let fingerprintKey: String
+    /// Annotation stores for the sources cache (the `PersistenceActor`, which
+    /// conforms to all three). Nil when persistence isn't injected.
+    private let annotationStores: (any AnnotationPersisting & HighlightPersisting & BookmarkPersisting)?
 
-    init(fallbackTitle: String, bookFormat: BookFormat, fingerprintKey: String) {
+    init(
+        fallbackTitle: String,
+        bookFormat: BookFormat,
+        fingerprintKey: String,
+        annotationStores: (any AnnotationPersisting & HighlightPersisting & BookmarkPersisting)? = nil
+    ) {
         self.fallbackTitle = fallbackTitle
         self.bookFormat = bookFormat
         self.fingerprintKey = fingerprintKey
+        self.annotationStores = annotationStores
     }
 
     /// Creates the AI ViewModels if AI features are available.
@@ -147,9 +176,26 @@ final class ReaderAICoordinator {
         let fingerprint = DocumentFingerprint(canonicalKey: fingerprintKey)
         let chatVM = AIChatViewModel(aiService: service, bookFingerprint: fingerprint)
         chatViewModel = chatVM
-        // Feature #86 WI-3: re-assemble the context when the user changes scope,
-        // through the same single funnel.
+        // Feature #86 WI-3/4: re-assemble the context when the user changes scope
+        // OR toggles sources, through the same single funnel.
         chatVM.onScopeChanged = { [weak self] in self?.refreshChatContext() }
+
+        // Feature #86 WI-4: the sources cache. Loads once now and refreshes on
+        // `.readerAnnotationsDidChange`; each (re)load re-assembles the context +
+        // updates the chip counts.
+        if let stores = annotationStores {
+            let cache = ChatAnnotationCache(
+                fingerprintKey: fingerprintKey,
+                annotationStore: stores, highlightStore: stores, bookmarkStore: stores
+            )
+            cache.onChange = { [weak self] in
+                self?.syncSourceCounts()
+                self?.refreshChatContext()
+            }
+            chatAnnotationCache = cache
+            Task { await cache.load() }   // populates, then fires onChange
+        }
+
         // Feature #86 WI-1: assign chatViewModel FIRST, then refresh — else the
         // refresh no-ops against a nil VM (Gate-2 round-2 note).
         refreshChatContext()

--- a/vreader/Views/Reader/ReaderContainerView.swift
+++ b/vreader/Views/Reader/ReaderContainerView.swift
@@ -43,6 +43,10 @@ struct ReaderContainerView: View {
 
     @Environment(\.dismiss) var dismiss
     @Environment(\.modelContext) var modelContext
+    /// Feature #86 WI-4: persistence for the AI Chat sources cache (the
+    /// `PersistenceActor`, which conforms to the three annotation-persisting
+    /// protocols). Nil in previews / no-store contexts → sources simply stay empty.
+    @Environment(\.persistenceActor) private var persistenceActor
     @State var settingsStore = ReaderSettingsStore()
     @State var showSettings = false
     /// Feature #61 WI-3: whether the reader Book Details sheet is
@@ -981,13 +985,21 @@ struct ReaderContainerView: View {
         DocumentFingerprint(canonicalKey: book.fingerprintKey)?.format ?? resolvedBookFormat
     }
 
+    /// Feature #86 WI-4: the annotation stores for the AI sources cache — the
+    /// `PersistenceActor` (which conforms to all three persisting protocols), or
+    /// nil when no store is injected.
+    private var aiAnnotationStores: (any AnnotationPersisting & HighlightPersisting & BookmarkPersisting)? {
+        persistenceActor
+    }
+
     /// Lazily creates the AI coordinator on first access.
     var resolvedAICoordinator: ReaderAICoordinator {
         if let existing = aiCoordinator { return existing }
         let coordinator = ReaderAICoordinator(
             fallbackTitle: book.title,
             bookFormat: resolvedBookFormat,
-            fingerprintKey: book.fingerprintKey
+            fingerprintKey: book.fingerprintKey,
+            annotationStores: aiAnnotationStores   // Feature #86 WI-4 (nil when no persistence)
         )
         // SwiftUI will apply the mutation at the end of the render pass
         DispatchQueue.main.async {

--- a/vreaderTests/Services/AI/ChatAnnotationCacheTests.swift
+++ b/vreaderTests/Services/AI/ChatAnnotationCacheTests.swift
@@ -1,0 +1,167 @@
+// Feature #86 WI-4: the ChatAnnotationCache — loads the reader's annotations
+// once and refreshes ONLY on `.readerAnnotationsDidChange` (never on relocate),
+// and AIChatViewModel.setSources (the sources re-assembly funnel). XCTest for the
+// cache (NotificationCenter + async load timing); Swift Testing for the VM.
+
+import XCTest
+import Foundation
+@testable import vreader
+
+// A mock conforming to all three annotation-persisting protocols. Returns canned
+// records and counts fetch calls (to prove "no refetch on relocate").
+private actor MockAnnotationStores: AnnotationPersisting, HighlightPersisting, BookmarkPersisting {
+    private let annotations: [AnnotationRecord]
+    private let highlights: [HighlightRecord]
+    private let bookmarks: [BookmarkRecord]
+    private(set) var fetchCount = 0
+
+    init(annotations: [AnnotationRecord] = [], highlights: [HighlightRecord] = [], bookmarks: [BookmarkRecord] = []) {
+        self.annotations = annotations
+        self.highlights = highlights
+        self.bookmarks = bookmarks
+    }
+    func fetchAnnotations(forBookWithKey key: String) async throws -> [AnnotationRecord] { fetchCount += 1; return annotations }
+    func fetchHighlights(forBookWithKey key: String) async throws -> [HighlightRecord] { fetchCount += 1; return highlights }
+    func fetchBookmarks(forBookWithKey key: String) async throws -> [BookmarkRecord] { fetchCount += 1; return bookmarks }
+    // Unused mutation methods (the cache only reads).
+    func addAnnotation(locator: Locator, content: String, toBookWithKey key: String) async throws -> AnnotationRecord { fatalError() }
+    func removeAnnotation(annotationId: UUID) async throws {}
+    func updateAnnotation(annotationId: UUID, content: String) async throws {}
+    func addHighlight(locator: Locator, selectedText: String, color: String, note: String?, toBookWithKey key: String) async throws -> HighlightRecord { fatalError() }
+    func addHighlight(locator: Locator, anchor: AnnotationAnchor?, selectedText: String, color: String, note: String?, toBookWithKey key: String) async throws -> HighlightRecord { fatalError() }
+    func removeHighlight(highlightId: UUID) async throws {}
+    func updateHighlightNote(highlightId: UUID, note: String?) async throws {}
+    func updateHighlightColor(highlightId: UUID, color: String) async throws {}
+    func fetchHighlight(highlightId: UUID) async throws -> HighlightRecord? { nil }
+    func addBookmark(locator: Locator, title: String?, toBookWithKey key: String) async throws -> BookmarkRecord { fatalError() }
+    func removeBookmark(bookmarkId: UUID) async throws {}
+    func updateBookmarkTitle(bookmarkId: UUID, title: String?) async throws {}
+    func isBookmarked(locator: Locator, forBookWithKey key: String) async throws -> Bool { false }
+}
+
+@MainActor
+final class ChatAnnotationCacheTests: XCTestCase {
+
+    private let fp = DocumentFingerprint(
+        contentSHA256: String(repeating: "d", count: 64), fileByteCount: 100, format: .txt
+    )
+    private func loc(_ o: Int) -> Locator {
+        LocatorFactory.txtPosition(fingerprint: fp, charOffsetUTF16: o)!
+    }
+    private func note(_ s: String) -> AnnotationRecord {
+        AnnotationRecord(annotationId: UUID(), locator: loc(0), profileKey: "k", content: s, createdAt: Date(timeIntervalSince1970: 0), updatedAt: Date(timeIntervalSince1970: 0))
+    }
+    private func highlight(_ s: String, note: String? = nil) -> HighlightRecord {
+        HighlightRecord(highlightId: UUID(), locator: loc(0), anchor: nil, profileKey: "k", selectedText: s, color: "yellow", note: note, createdAt: Date(timeIntervalSince1970: 0), updatedAt: Date(timeIntervalSince1970: 0))
+    }
+    private func bookmark(_ t: String) -> BookmarkRecord {
+        BookmarkRecord(bookmarkId: UUID(), locator: loc(0), profileKey: "k", title: t, createdAt: Date(timeIntervalSince1970: 0), updatedAt: Date(timeIntervalSince1970: 0))
+    }
+
+    func test_load_populatesRecordsAndCounts() async {
+        let stores = MockAnnotationStores(
+            annotations: [note("a standalone note")],
+            highlights: [highlight("h1", note: "annotated"), highlight("h2")],
+            bookmarks: [bookmark("bm")]
+        )
+        let cache = ChatAnnotationCache(
+            fingerprintKey: fp.canonicalKey,
+            annotationStore: stores, highlightStore: stores, bookmarkStore: stores
+        )
+        await cache.load()
+        XCTAssertEqual(cache.counts.notes, 2)        // 1 standalone + 1 annotated highlight
+        XCTAssertEqual(cache.counts.highlights, 2)
+        XCTAssertEqual(cache.counts.bookmarks, 1)
+    }
+
+    func test_refreshesOnMutationBus_notOnRelocate() async throws {
+        let stores = MockAnnotationStores(annotations: [note("n")])
+        let cache = ChatAnnotationCache(
+            fingerprintKey: fp.canonicalKey,
+            annotationStore: stores, highlightStore: stores, bookmarkStore: stores
+        )
+        await cache.load()
+        let afterLoad = await stores.fetchCount   // 3 (one per kind)
+
+        // A relocate posts NO annotation bus → no refetch.
+        NotificationCenter.default.post(name: .readerPositionDidChange, object: nil)
+        try await Task.sleep(nanoseconds: 200_000_000)
+        let afterRelocate = await stores.fetchCount
+        XCTAssertEqual(afterRelocate, afterLoad, "relocate must not refetch annotations")
+
+        // The mutation-complete bus DOES refetch (and fires onChange).
+        let exp = expectation(description: "onChange after bus")
+        cache.onChange = { exp.fulfill() }
+        NotificationCenter.default.post(name: .readerAnnotationsDidChange, object: nil)
+        await fulfillment(of: [exp], timeout: 2.0)
+        let afterMutation = await stores.fetchCount
+        XCTAssertGreaterThan(afterMutation, afterRelocate, "mutation bus must refetch")
+    }
+
+    func test_annotationBlock_respectsSelection() async {
+        let stores = MockAnnotationStores(
+            annotations: [note("my standalone note")],
+            highlights: [highlight("a highlighted phrase")],
+            bookmarks: [bookmark("a bookmark")]
+        )
+        let cache = ChatAnnotationCache(
+            fingerprintKey: fp.canonicalKey,
+            annotationStore: stores, highlightStore: stores, bookmarkStore: stores
+        )
+        await cache.load()
+        let notesOnly = cache.annotationBlock(
+            for: ChatSourceSelection(notes: true, highlights: false, bookmarks: false), maxUTF16: 10_000
+        )
+        XCTAssertTrue(notesOnly.contains("my standalone note"))
+        XCTAssertFalse(notesOnly.contains("a highlighted phrase"))
+
+        let allOff = cache.annotationBlock(
+            for: ChatSourceSelection(notes: false, highlights: false, bookmarks: false), maxUTF16: 10_000
+        )
+        XCTAssertTrue(allOff.isEmpty)
+    }
+}
+
+// MARK: - AIChatViewModel.setSources (the sources re-assembly funnel)
+
+@MainActor
+final class AIChatViewModelSourcesTests: XCTestCase {
+
+    private func makeVM() -> AIChatViewModel {
+        AIChatViewModel(
+            aiService: AIService(
+                featureFlags: FeatureFlags.shared,
+                consentManager: AIConsentManager(),
+                keychainService: KeychainService(),
+                profileStore: ProviderProfileStore.shared
+            ),
+            bookFingerprint: nil
+        )
+    }
+
+    func test_defaultSources_notesAndHighlightsOn() {
+        let vm = makeVM()
+        XCTAssertTrue(vm.sources.notes)
+        XCTAssertTrue(vm.sources.highlights)
+        XCTAssertFalse(vm.sources.bookmarks)
+        XCTAssertEqual(vm.sources.activeCount, 2)
+    }
+
+    func test_setSources_changesAndInvokesFunnel() {
+        let vm = makeVM()
+        var calls = 0
+        vm.onScopeChanged = { calls += 1 }   // shared re-assembly funnel
+        vm.setSources(ChatSourceSelection(notes: false, highlights: true, bookmarks: true))
+        XCTAssertFalse(vm.sources.notes)
+        XCTAssertTrue(vm.sources.bookmarks)
+        XCTAssertEqual(calls, 1)
+    }
+
+    func test_setSources_sameSelection_isNoOp() {
+        let vm = makeVM()
+        var calls = 0
+        vm.onScopeChanged = { calls += 1 }
+        vm.setSources(.default)   // already default
+        XCTAssertEqual(calls, 0)
+    }
+}


### PR DESCRIPTION
## Summary

- The right-side **sources chip** + the **sources popover** (Notes / Highlights / Bookmarks toggles), backed by a per-book `ChatAnnotationCache` that folds the reader's selected annotations into the AI context.

Part of feature #1453 (WI-4 of 6). Design: #1455.

## What Changed

- **`ChatAnnotationCache`** — loads the reader's annotations once on open + refreshes ONLY on `.readerAnnotationsDidChange` (never on relocate); latest-wins atomic reload; `annotationBlock(for:)` via `ChatAnnotationContext`.
- **`ChatSourcesMenu`** — the popover (icon tile + label + "N in this book" + switch + footer).
- **`ChatContextBar`** — the right-side sources chip (green wash + count badge / "Off").
- **`AIChatViewModel.setSources`** → the shared re-assembly funnel + `sourceCounts`.
- **`ReaderAICoordinator`** — owns the cache (persistence threaded from `ReaderContainerView`); `refreshChatContext` folds the serialized annotation block into `ChatContextAssembler`.
- **`AIChatView`** — the scope + sources menus as mutually-exclusive overlays; the composer extracted into `AIChatView+Composer.swift`.

## Codex Audit

Gate-4, 2 rounds, ship-as-is. R1 1 High (cache `load()` not latest-wins → atomic generation-guarded commit) + 1 Low (no book identity, accepted — single-reader app) + file-size note (composer extracted, AIChatView 418→290) → R2 clean. Log: `.claude/codex-audits/feat-feature-86-wi-4-sources-popover-audit.md`.

## Validation

- [x] 2 unit suites green: `ChatAnnotationCacheTests` (load / counts / refresh-on-bus-not-relocate / annotationBlock), `AIChatViewModelSourcesTests` (`setSources` funnel).
- [x] **Gate-5 slice — device-verified** (iPhone 17 Pro, v3.50.2, war-and-peace, `--enable-ai`): the sources chip renders ("Sources [2]", green wash + badge); tapping it opens the popover with 3 rows (Notes/Highlights/Bookmarks, "0 in this book", default Notes+Highlights ON / Bookmarks OFF) + header + footer matching #1455; toggling Highlights OFF flips the switch and drops the chip badge 2→1. Evidence: `dev-docs/verification/artifacts/feature-86-wi4-{sources-chip,sources-menu,sources-toggled,badge-updated}-20260603.png`.
- [x] Version bumped: 3.50.2 → 3.50.3.

## Type of Change

- [x] New feature (WI-4 of Feature #86)