### PR TITLE
feat(#86 WI-5b): whole-book retrieval cluster + send-flow

### DIFF
--- a/.claude/codex-audits/feat-feature-86-wi-5b-retrieval-cluster-audit.md
+++ b/.claude/codex-audits/feat-feature-86-wi-5b-retrieval-cluster-audit.md
@@ -1,0 +1,87 @@
+---
+branch: feat/feature-86-wi-5b-retrieval-cluster
+threadId: codex-exec (run-codex.sh, 3 rounds)
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-06-03
+---
+
+# Codex audit — Feature #86 WI-5b: retrieval cluster + whole-book send-flow (Gate 4)
+
+## Implementation summary
+
+The whole-book on-demand retrieval surface + its integration into the chat flow:
+
+- `WholeBookRetrievalViewModel` — the `@MainActor` mirror over the WI-5a reducer
+  (phase machine: idle/armed/reading%/ready/partial; ordered async progress;
+  `cancel()` → reducer-flag → `.partial`).
+- `ChatRetrievalCluster` — the bar morphs to Armed / Reading% (spinner + progress +
+  Cancel) / Ready / Partial when the scope is `.wholeBook`.
+- `ChatScopeMenu` re-adds the Whole-book row (retrieval now exists).
+- `AIChatViewModel` — `wholeBookRetrieval` + `onWholeBookReadRequested`;
+  `sendMessage` triggers the on-demand read on the first whole-book question (before
+  building context); `isComposerDisabled` while reading.
+- `ReaderAICoordinator` — owns the retrieval VM; `runWholeBookRead` resolves ONE
+  provider config (pinned) + drives `read` with a per-chunk summarize `condense`
+  closure + awaits + re-assembles; `scopedChatContext(.wholeBook)` returns the
+  digest once ready (else book-so-far).
+
+Plan: `dev-docs/plans/20260603-feature-86-wi2-chat-scope-sources-retrieval.md` (WI-5).
+
+## Round 1 — 1 High + 1 Medium
+
+| severity | issue | resolution |
+|---|---|---|
+| High | `handleChatContextChanged` (shared by `setScope` + `setSources`) armed whole-book on EVERY change → a sources toggle downgraded a `.ready` digest back to armed → the next send re-ran the expensive read. | **Fixed.** Track `lastChatScope`; arm ONLY on the transition INTO `.wholeBook`; a sources-only toggle leaves scope unchanged and preserves `.ready`/`.partial`; leaving whole-book disarms. |
+| Medium | The composer only disabled *sending* (`canSend`); the `TextField` stayed editable while reading. | **Fixed.** `.disabled(viewModel.isComposerDisabled)` on the field + `.onChange` drops focus when reading begins. |
+
+Round 1 explicitly cleared: no deadlock/re-entrancy in `sendMessage → onWholeBookRead
+Requested → runWholeBookRead → read → await readTask`; the digest ordering before
+`buildContextText()` is correct; cancel-to-partial sound; `.wholeBook` degrades to
+`.bookSoFar` when no digest exists (backward-compatible); Rule-51 cluster/state reuse
+acceptable; `@MainActor` consistent; no dead code.
+
+## Round 2 — 1 Medium
+
+Both round-1 findings confirmed fixed. New: `disarm()` cancelled the consuming
+`readTask` but not the reducer, so a stale in-flight read could write `.ready`/
+`.partial` back over `.idle` after the user left whole-book.
+
+**Fixed.** A monotonic `generation` epoch: `disarm()` bumps it + calls
+`reducer.cancel()` (stops the off-actor work) + `.idle`; `read()` bumps + captures the
+epoch and guards BOTH the onProgress hop and the terminal write with
+`guard generation == self.generation`, so a superseded read never writes. The user's
+`cancel()` (the × button) does NOT bump the epoch, so a user-cancel still lands
+`.partial` (keeps what was indexed). Test: `disarm_duringRead_staysIdle_noStaleWrite`.
+
+The file-size note (AIChatView 308 / ReaderAICoordinator 325, marginally over ~300) is
+**accepted** — both recently refactored; further extraction is churn.
+
+## Round 3 — 1 Medium fixed + 1 Medium accepted (round cap)
+
+The round-2 generation guard surfaced a deeper nuance:
+
+| severity | issue | resolution |
+|---|---|---|
+| Medium | `disarm()`'s fire-and-forget `Task { await reducer.cancel() }` could land AFTER a quick re-enter's `reset()` on the SHARED reducer, poisoning the fresh read. | **Fixed robustly** — a **fresh reducer per read** (`reducerFactory()` in `read()`), so the cancel flag is per-read state; an old read's cancel can never touch a new read's reducer (different instance). `reset()` is gone (a fresh reducer starts un-cancelled). This eliminates the shared-flag race *class*, not just one path. |
+| Medium | The "cancel→partial" test invokes `reducer.cancel()` directly, not the UI's `vm.cancel()`. | **Accepted with rationale.** `vm.cancel()`/`vm.disarm()` are the same 1-line `if let reducer { Task { await reducer.cancel() } }` forward; the new `disarm_duringRead_staysIdle_noStaleWrite` test exercises `vm.disarm()` → `reducer.cancel()` through the real method, and the reducer-level cancel→partial + the read→`.partial` phase mapping are both deterministically tested. A fully deterministic `vm.cancel()`→partial test needs an async-suspension hook the `read()` API doesn't expose without contrivance; the path is covered by composition. |
+
+**Round cap (rule 47, ≤3).** Round 3 is reached; the substantive correctness issue
+(the shared-flag race) is robustly fixed, and the one remaining item is a test-coverage
+nicety accepted with rationale. Concluding rather than a 4th round.
+
+## Verdict
+
+`ship-as-is` after 3 rounds (Medium 1 fixed via fresh-reducer-per-read; Medium 2
+accepted with composition-coverage rationale).
+
+## Verification
+
+- Unit (green via `scripts/run-tests.sh`): `WholeBookRetrievalViewModelTests` (phase
+  machine, cancel→partial, overflow→partial, re-arm), `AIChatViewModelWholeBookTests`
+  (send-flow trigger on the first whole-book question; non-whole-book doesn't trigger;
+  `isComposerDisabled` cases).
+- Tier: behavioral. Gate-5 slice — the menu re-adds the Whole-book row and selecting
+  it shows the Armed cluster are device-verifiable; the actual whole-book *read effect*
+  is **provider-key-blocked** for CU-free verification (same as WI-1), so it's keyed/
+  manual-verification — recorded in the PR.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 847
-        MARKETING_VERSION: 3.50.4
+        CURRENT_PROJECT_VERSION: 848
+        MARKETING_VERSION: 3.50.5
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -632,6 +632,7 @@
 		65FC6B2A5172850AB0B7CA42 /* EPUBBilingualPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD58B3560B70B8E874D669C /* EPUBBilingualPipeline.swift */; };
 		65FDF3DF582C0F5E67305EED /* ReaderSettingsPanelReadingModeGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83246694DE80F5760F85506E /* ReaderSettingsPanelReadingModeGateTests.swift */; };
 		66588E6EE7A6E8D551B71492 /* VReaderLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19656D9EB4A4D95E03DD9354 /* VReaderLocatorTests.swift */; };
+		668309455FFECACFE6B0368D /* AIChatViewModelWholeBookTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88425F3137F5EDCF6D04AB6A /* AIChatViewModelWholeBookTests.swift */; };
 		66BF815FA62FF51C7C0053ED /* ReaderContainerView+DebugBridgeSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B46A5F229515020166A545 /* ReaderContainerView+DebugBridgeSearch.swift */; };
 		66D2DC1C52A9CFA24FBB7E1F /* NativeTextPagedViewSideTapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7456EC54564FFE74772E88E8 /* NativeTextPagedViewSideTapTests.swift */; };
 		66EBE9BC48EBEA51AEC3B77C /* ReaderContainerView+SearchPollAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB186FF39C9836750BE4499 /* ReaderContainerView+SearchPollAction.swift */; };
@@ -857,6 +858,7 @@
 		8B893E3D3C61482BEA500F32 /* Feature25TapZonesVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77AEAE00997ED48B68EE20E6 /* Feature25TapZonesVerificationTests.swift */; };
 		8BBE50E626A6524E8C6DB59D /* SearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576F111E93E863C656BDEC70 /* SearchViewModelTests.swift */; };
 		8C0CD88AF5CB9D0509452BA0 /* AIContextExtracting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542F38CF85937EB04F013ABA /* AIContextExtracting.swift */; };
+		8C213604F3E66CDD58B35960 /* ChatRetrievalCluster.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB526ADB0E1190463E08AE9 /* ChatRetrievalCluster.swift */; };
 		8C4E8905FFFF8DB6C6CC5B13 /* SelectionPopoverPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15BBF7DF0943B2AF47BA6E53 /* SelectionPopoverPresenterTests.swift */; };
 		8C5EFF0A113773C9FA1153E1 /* VoiceOverAuditTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED80D7FC768F4B87E7DB036A /* VoiceOverAuditTests.swift */; };
 		8CAAA8CE24E5701C76A9A55F /* EncodingFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C483C40C61CC5C3F7B66030 /* EncodingFixtureTests.swift */; };
@@ -2359,6 +2361,7 @@
 		87DF28B0149478FEC7B8EC4E /* search.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = search.js; sourceTree = "<group>"; };
 		87ECE13E023EB87748CF6B7B /* MOBIMetadataParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MOBIMetadataParserTests.swift; sourceTree = "<group>"; };
 		8807117D114833F057AD99CE /* ReaderDisplayControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDisplayControls.swift; sourceTree = "<group>"; };
+		88425F3137F5EDCF6D04AB6A /* AIChatViewModelWholeBookTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatViewModelWholeBookTests.swift; sourceTree = "<group>"; };
 		88D54435E0293B133D7C4ECE /* PersistenceActor+HighlightLookupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+HighlightLookupTests.swift"; sourceTree = "<group>"; };
 		89DE76057526BA48CAE2A83A /* UpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateChecker.swift; sourceTree = "<group>"; };
 		89E60C649B564A45FD862030 /* LibmobiSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibmobiSmokeTests.swift; sourceTree = "<group>"; };
@@ -3049,6 +3052,7 @@
 		FD1989CF2F582B5C821059BA /* FoliateScrollModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateScrollModelTests.swift; sourceTree = "<group>"; };
 		FD27A5C682FAD0ED96FD755A /* MobiEPUBAssemblerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobiEPUBAssemblerTests.swift; sourceTree = "<group>"; };
 		FD477B685E3E8163D52949DC /* ChatSourcesMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSourcesMenu.swift; sourceTree = "<group>"; };
+		FDB526ADB0E1190463E08AE9 /* ChatRetrievalCluster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRetrievalCluster.swift; sourceTree = "<group>"; };
 		FDEB28B2CAB1481C73FBE351 /* TestSeederMDMultiPagePaginationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSeederMDMultiPagePaginationTests.swift; sourceTree = "<group>"; };
 		FDF40785A923791B0241CF75 /* GlobalAccessibilityAuditTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalAccessibilityAuditTests.swift; sourceTree = "<group>"; };
 		FDFAF8770F91837F0B3793E1 /* ImportProvenanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportProvenanceTests.swift; sourceTree = "<group>"; };
@@ -3389,6 +3393,7 @@
 				EA401D8FC3B4F17213528B27 /* AIAssistantViewModelTests.swift */,
 				B90F4EB83CC68406DA14DD94 /* AIChatGeneralTests.swift */,
 				E861A379A620B769CEA36300 /* AIChatViewModelTests.swift */,
+				88425F3137F5EDCF6D04AB6A /* AIChatViewModelWholeBookTests.swift */,
 				4E7196BED97C3B45955EC89D /* AIProviderPickerViewModelTests.swift */,
 				4E706779E64026004319957F /* AIReaderIntegrationTests.swift */,
 				AE29B97304B59C88E3F3F9CF /* AITranslationTests.swift */,
@@ -4148,6 +4153,7 @@
 				4B55B710BEC6ADA4EE00C594 /* AIChatView+Composer.swift */,
 				83B60F61628D0969B18B3A9B /* AIConsentView.swift */,
 				02C8F2C0DD4DC5CDA2601383 /* ChatContextBar.swift */,
+				FDB526ADB0E1190463E08AE9 /* ChatRetrievalCluster.swift */,
 				4007FACF71264B6118B3F5FA /* ChatScopeMenu.swift */,
 				FD477B685E3E8163D52949DC /* ChatSourcesMenu.swift */,
 			);
@@ -5813,6 +5819,7 @@
 				62BE094A6E99C25AD7880CE4 /* AIChatMessageRowTests.swift in Sources */,
 				4553F7F292278C1995E28192 /* AIChatViewContrastTests.swift in Sources */,
 				05BE70789318FA085B9A735E /* AIChatViewModelTests.swift in Sources */,
+				668309455FFECACFE6B0368D /* AIChatViewModelWholeBookTests.swift in Sources */,
 				C81C50DAC16681379E93FC9D /* AIConfigurationTests.swift in Sources */,
 				CD104D016ED7015A7F8B42C7 /* AIConsentManagerTests.swift in Sources */,
 				98080594ED513CD2F999EF8C /* AIContextExtractorScopedTests.swift in Sources */,
@@ -6585,6 +6592,7 @@
 				73044473A655F7D1FAD82A18 /* ChatContextScope+Menu.swift in Sources */,
 				397FF3ADF6619130950525FE /* ChatContextScope.swift in Sources */,
 				F51F7B9360A990E857FE1373 /* ChatMessage.swift in Sources */,
+				8C213604F3E66CDD58B35960 /* ChatRetrievalCluster.swift in Sources */,
 				8FD1FAC0AE8611D29DEDC87D /* ChatScopeMenu.swift in Sources */,
 				5BDAA75F4C3A30CBCC893190 /* ChatSourceSelection.swift in Sources */,
 				25C35999B6BAA3D90435C66A /* ChatSourcesMenu.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7365,7 +7365,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 847;
+				CURRENT_PROJECT_VERSION = 848;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7373,7 +7373,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.50.4;
+				MARKETING_VERSION = 3.50.5;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7519,7 +7519,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 847;
+				CURRENT_PROJECT_VERSION = 848;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7527,7 +7527,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.50.4;
+				MARKETING_VERSION = 3.50.5;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -235,6 +235,7 @@
 		265B4C9C4B99A0500F0EC6B7 /* MDMetadataExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5D3F39FDBF4693D33D1BCB /* MDMetadataExtractor.swift */; };
 		268DE55B3D1C25F7AAC58E0D /* FoliateHighlightRestoreDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F1F3EF7737CB98C28172050 /* FoliateHighlightRestoreDispatcher.swift */; };
 		269A2D02557877E9147BE848 /* BilingualParagraphRanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455F8B9D85F0DD60D657D6FE /* BilingualParagraphRanges.swift */; };
+		26A978EAED2538218AE960EF /* WholeBookRetrievalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231C9DC05EBE4F64D94633EA /* WholeBookRetrievalViewModel.swift */; };
 		26D79FC598918201D178F348 /* PersistenceActorEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2F1636BA674F5AF7A50902 /* PersistenceActorEnvironment.swift */; };
 		26E2B41897B117FD5976B75E /* MDTOCVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AECA1E4C104DEBC5FE30E61 /* MDTOCVerificationTests.swift */; };
 		270748270CF3E119F24D985F /* EPUBWebViewBridgeJS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C07D184EF0E90D5F2DF7A36 /* EPUBWebViewBridgeJS.swift */; };
@@ -1085,6 +1086,7 @@
 		B5114E58420F95EFB408CA82 /* ReaderSettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A86CD6BD10792F5107FFB5A /* ReaderSettingsStoreTests.swift */; };
 		B544230499216CCFFAECD2CC /* SettingsStatsPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EEA30416FD1F1335DADB0DC /* SettingsStatsPresenterTests.swift */; };
 		B55F8BD1634B4C01228A7453 /* FoliateBilingualOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6DDBB884E9EA341FDA82E3E /* FoliateBilingualOrchestrator.swift */; };
+		B5E5E5B3033713EBCD61A0AA /* WholeBookRetrievalViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A97D366AF1103614118689 /* WholeBookRetrievalViewModelTests.swift */; };
 		B5EA7DDDFE9F836F99A87EF1 /* TXTReaderContainerBilingualPositionTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CD9AF98ED5763A7E105FCC /* TXTReaderContainerBilingualPositionTriggerTests.swift */; };
 		B5EED69421D1469D01B8C392 /* ReaderSettingsPanelTapZonesGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0024CBCAE4AC02A47B58AE48 /* ReaderSettingsPanelTapZonesGateTests.swift */; };
 		B5FEE27BBCF7231BC8F25242 /* MDReplacementRuleFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9EF707655DE949BB9C51A96 /* MDReplacementRuleFetcherTests.swift */; };
@@ -1741,6 +1743,7 @@
 		22C20D015AD61E29BEB57DC3 /* LocatorNormalizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorNormalizerTests.swift; sourceTree = "<group>"; };
 		22C31D7BC3688FEB94A94EC8 /* CoverPickCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoverPickCoordinator.swift; sourceTree = "<group>"; };
 		22F84672A6E2EDD6E037AFD8 /* ImportSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportSource.swift; sourceTree = "<group>"; };
+		231C9DC05EBE4F64D94633EA /* WholeBookRetrievalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WholeBookRetrievalViewModel.swift; sourceTree = "<group>"; };
 		234B0CDF583E348E490933FE /* ReadiumDecorationHighlightAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumDecorationHighlightAdapter.swift; sourceTree = "<group>"; };
 		2355F0CDCE9B874D6BD148FB /* MockPositionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPositionStore.swift; sourceTree = "<group>"; };
 		23A84FE014139E7B5524445D /* BookRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookRowView.swift; sourceTree = "<group>"; };
@@ -2055,6 +2058,7 @@
 		566173BF61B58B66B8225A79 /* ReadiumSelectionTokenCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumSelectionTokenCache.swift; sourceTree = "<group>"; };
 		5664BAD79CD42CE256A6CA0C /* FontSizeCalibrationMeasurementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCalibrationMeasurementTests.swift; sourceTree = "<group>"; };
 		56912BE618BA41A3B17325C5 /* SettingsHeaderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHeaderViewModelTests.swift; sourceTree = "<group>"; };
+		56A97D366AF1103614118689 /* WholeBookRetrievalViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WholeBookRetrievalViewModelTests.swift; sourceTree = "<group>"; };
 		56E344B835F385EF870989C9 /* WebDAVProviderFactoryProfileDispatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProviderFactoryProfileDispatchTests.swift; sourceTree = "<group>"; };
 		57133EF1841CC86C1DFF1C11 /* AIProviderListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderListView.swift; sourceTree = "<group>"; };
 		57171272166BB46F00A14A91 /* ReadiumEPUBHost+TTSFollow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReadiumEPUBHost+TTSFollow.swift"; sourceTree = "<group>"; };
@@ -3417,6 +3421,7 @@
 				55633F1E05B29D20C4A4D0D5 /* TXTReaderPositionBackCompatTests.swift */,
 				96A2462C6A873DEC45025230 /* TXTReaderViewModelChapterHeadingTests.swift */,
 				510A755F74250CC74B14021D /* TXTReaderViewModelContinuousTests.swift */,
+				56A97D366AF1103614118689 /* WholeBookRetrievalViewModelTests.swift */,
 				B3CB57338FD24289DAC8ABE4 /* WI9TestHelpers.swift */,
 			);
 			path = ViewModels;
@@ -4528,6 +4533,7 @@
 				8500C7EDCB2A51F928910E7F /* SettingsHeaderViewModel.swift */,
 				E19A1FE14FDE4829AF0F5913 /* TXTReaderViewModel.swift */,
 				7056486BA460E0BE06235F54 /* UnifiedTextRendererViewModel.swift */,
+				231C9DC05EBE4F64D94633EA /* WholeBookRetrievalViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -6420,6 +6426,7 @@
 				58C066AA53EC9D61B9960E9B /* WebDAVServerProfileTests.swift in Sources */,
 				88B73AB500D0DFD555AC9363 /* WebPageEncodingDetectorTests.swift in Sources */,
 				3BAE7CA09E5241A14F30A7F4 /* WholeBookReducerTests.swift in Sources */,
+				B5E5E5B3033713EBCD61A0AA /* WholeBookRetrievalViewModelTests.swift in Sources */,
 				C28C9220D25AECBA8CAF8EB7 /* XCUITestMockSpeechSynthesizerTests.swift in Sources */,
 				E153024C836519993C468665 /* ZIPReaderTests.swift in Sources */,
 			);
@@ -7171,6 +7178,7 @@
 				671D7F1B0A003041831E308E /* WebDAVSettingsView.swift in Sources */,
 				8E93B4DCB415EC16CEE9F01E /* WebPageEncodingDetector.swift in Sources */,
 				9535B8042DC8DD5AAB980A7A /* WholeBookReducer.swift in Sources */,
+				26A978EAED2538218AE960EF /* WholeBookRetrievalViewModel.swift in Sources */,
 				066A3021DFE04C15ECFEBF55 /* XCUITestMockSpeechSynthesizer.swift in Sources */,
 				AEFC819574E845429DFC9D78 /* ZIPReader.swift in Sources */,
 				48515116AAAA6DD5DFAA4ADE /* ZIPWriter.swift in Sources */,

--- a/vreader/ViewModels/AIChatViewModel.swift
+++ b/vreader/ViewModels/AIChatViewModel.swift
@@ -101,6 +101,21 @@ final class AIChatViewModel {
         onScopeChanged?()   // same single re-assembly funnel as scope
     }
 
+    /// Feature #86 WI-5b: the whole-book retrieval state machine (set by the
+    /// coordinator). Drives the context bar's Armed/Reading/Ready cluster when the
+    /// scope is `.wholeBook`.
+    var wholeBookRetrieval: WholeBookRetrievalViewModel?
+
+    /// Set by the coordinator: triggers the on-demand whole-book read and awaits
+    /// it (so the digest is in `bookContext` before the question is answered).
+    var onWholeBookReadRequested: (() async -> Void)?
+
+    /// The composer is disabled while the whole book is being read.
+    var isComposerDisabled: Bool {
+        if case .reading = wholeBookRetrieval?.phase { return true }
+        return false
+    }
+
     // MARK: - Dependencies
 
     private let aiService: AIService
@@ -140,6 +155,13 @@ final class AIChatViewModel {
 
         isLoading = true
         defer { isLoading = false }
+
+        // Feature #86 WI-5b: the Whole-book scope reads on the FIRST question
+        // ("reads on your next question"). Trigger the on-demand read and await it
+        // so the digest is folded into `bookContext` before the answer is built.
+        if scope == .wholeBook, let retrieval = wholeBookRetrieval, !retrieval.isReady {
+            await onWholeBookReadRequested?()
+        }
 
         // Build context from conversation history (sliding window)
         let contextText = buildContextText()

--- a/vreader/ViewModels/WholeBookRetrievalViewModel.swift
+++ b/vreader/ViewModels/WholeBookRetrievalViewModel.swift
@@ -1,0 +1,131 @@
+// Purpose: The thin @MainActor state-machine mirror over the off-actor
+// WholeBookReducer (Feature #86 WI-5b). It owns ONLY the UI phase + progress; the
+// chunking / prompting / reduction all run inside the reducer actor. Drives the
+// context bar's Armed / Reading% / Ready / Partial states.
+//
+// Cancellation (Gate-2-approved): `cancel()` calls `reducer.cancel()` (NOT the
+// consuming task), and the read keeps running until the reducer returns its
+// terminal PARTIAL digest — so `.partial(coverage)` is always set from real
+// structured coverage, never a phantom revert.
+//
+// @coordinates-with: WholeBookReducer.swift, ReaderAICoordinator.swift,
+//   ChatRetrievalCluster.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/design-notes/chat-ai-scope-sources.md`
+
+import Foundation
+
+@MainActor
+@Observable
+final class WholeBookRetrievalViewModel {
+
+    enum Phase: Sendable, Equatable {
+        case idle
+        case armed                              // "Reads on your next question"
+        case reading(done: Int, total: Int)     // "Reading the whole book… 38%"
+        case ready(WholeBookCoverage)           // "Indexed · ready"
+        case partial(WholeBookCoverage)         // cancelled / incomplete — NOT auto-ready
+    }
+
+    private(set) var phase: Phase = .idle
+    private(set) var digest: WholeBookDigest?
+    /// The consuming read task (exposed for tests to await; NOT the cancel lever).
+    private(set) var readTask: Task<Void, Never>?
+
+    private let reducer: WholeBookReducer
+
+    init(reducer: WholeBookReducer = WholeBookReducer()) {
+        self.reducer = reducer
+    }
+
+    /// Arms whole-book retrieval — the next question triggers the read.
+    func arm() {
+        switch phase {
+        case .idle, .partial, .ready: phase = .armed
+        case .armed, .reading: break
+        }
+    }
+
+    /// Resets to idle (e.g. when the user switches away from whole-book scope).
+    func disarm() {
+        readTask?.cancel()
+        phase = .idle
+    }
+
+    /// Requests cancellation of an in-flight read. Cancels the REDUCER (not the
+    /// consuming task), so the read finishes with the partial digest and lands in
+    /// `.partial`. Keeps everything already indexed.
+    func cancel() {
+        let reducer = self.reducer
+        Task { await reducer.cancel() }
+    }
+
+    /// Starts a whole-book read. `condense` is the injected per-chunk AI call (the
+    /// coordinator pins one provider snapshot). On completion the phase becomes
+    /// `.ready` (full coverage) or `.partial` (cancelled / overflow).
+    func read(
+        fullText: String,
+        chunkBudgetUTF16: Int,
+        digestBudgetUTF16: Int,
+        maxChunks: Int,
+        condense: @escaping @Sendable (String) async throws -> String
+    ) {
+        readTask?.cancel()
+        phase = .reading(done: 0, total: 0)
+        let reducer = self.reducer
+        readTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await reducer.reset()
+            do {
+                let digest = try await reducer.reduce(
+                    fullText: fullText,
+                    chunkBudgetUTF16: chunkBudgetUTF16,
+                    digestBudgetUTF16: digestBudgetUTF16,
+                    maxChunks: maxChunks,
+                    condense: condense,
+                    onProgress: { done, total in
+                        await MainActor.run { [weak self] in
+                            self?.phase = .reading(done: done, total: total)
+                        }
+                    }
+                )
+                self.digest = digest
+                self.phase = digest.coverage.isComplete
+                    ? .ready(digest.coverage)
+                    : .partial(digest.coverage)
+            } catch {
+                // A read failure → partial with whatever coverage the reducer last
+                // reported (or empty), so the UI never claims a phantom "ready".
+                let coverage = self.digest?.coverage
+                    ?? WholeBookCoverage(coveredSpans: [], totalUTF16: fullText.utf16.count, droppedSpans: [])
+                self.phase = .partial(coverage)
+            }
+        }
+    }
+
+    /// 0…1 progress for the reading bar.
+    var progressFraction: Double {
+        switch phase {
+        case let .reading(done, total): return total > 0 ? min(1, Double(done) / Double(total)) : 0
+        case let .ready(c): return c.fraction
+        case let .partial(c): return c.fraction
+        case .idle, .armed: return 0
+        }
+    }
+
+    /// The "23 / 61" unit label shown while reading (chunks read / total).
+    var unitProgressLabel: String {
+        if case let .reading(done, total) = phase, total > 0 { return "\(done) / \(total)" }
+        return ""
+    }
+
+    /// Whether a whole-book digest is ready to use as the chat scope text.
+    var isReady: Bool { if case .ready = phase { return true } else { return false } }
+
+    /// The digest's context when `.ready` or `.partial` — usable as scope text.
+    var availableContext: String? {
+        switch phase {
+        case .ready, .partial: return digest?.context
+        case .idle, .armed, .reading: return nil
+        }
+    }
+}

--- a/vreader/ViewModels/WholeBookRetrievalViewModel.swift
+++ b/vreader/ViewModels/WholeBookRetrievalViewModel.swift
@@ -31,10 +31,19 @@ final class WholeBookRetrievalViewModel {
     /// The consuming read task (exposed for tests to await; NOT the cancel lever).
     private(set) var readTask: Task<Void, Never>?
 
-    private let reducer: WholeBookReducer
+    /// A FRESH reducer per read (Gate-4 r3): the reducer's `isCancelled` flag is
+    /// per-read state, so sharing one reducer across reads let a `disarm()` cancel
+    /// race a re-enter's reset and poison the new read. Each read owns its reducer;
+    /// `cancel()`/`disarm()` target the current one; an old read's cancel can never
+    /// touch a new read's (different instance). Injectable for tests.
+    private let reducerFactory: () -> WholeBookReducer
+    private var reducer: WholeBookReducer?
+    /// Monotonic read epoch — a `disarm()` (or a new `read()`) bumps it so a stale
+    /// in-flight read can never write its terminal phase back over the new state.
+    private var generation = 0
 
-    init(reducer: WholeBookReducer = WholeBookReducer()) {
-        self.reducer = reducer
+    init(reducerFactory: @escaping () -> WholeBookReducer = { WholeBookReducer() }) {
+        self.reducerFactory = reducerFactory
     }
 
     /// Arms whole-book retrieval — the next question triggers the read.
@@ -46,17 +55,21 @@ final class WholeBookRetrievalViewModel {
     }
 
     /// Resets to idle (e.g. when the user switches away from whole-book scope).
+    /// Bumps the epoch (so any in-flight read's terminal write is discarded), stops
+    /// the reducer work, and cancels the consuming task.
     func disarm() {
+        generation += 1
+        if let reducer { Task { await reducer.cancel() } }   // stop the off-actor work
         readTask?.cancel()
         phase = .idle
     }
 
-    /// Requests cancellation of an in-flight read. Cancels the REDUCER (not the
-    /// consuming task), so the read finishes with the partial digest and lands in
-    /// `.partial`. Keeps everything already indexed.
+    /// Requests cancellation of an in-flight read by the USER (the Cancel ×).
+    /// Cancels the REDUCER (not the consuming task) and does NOT bump the epoch, so
+    /// the read finishes with the partial digest and lands in `.partial` — keeping
+    /// everything already indexed.
     func cancel() {
-        let reducer = self.reducer
-        Task { await reducer.cancel() }
+        if let reducer { Task { await reducer.cancel() } }
     }
 
     /// Starts a whole-book read. `condense` is the injected per-chunk AI call (the
@@ -70,11 +83,13 @@ final class WholeBookRetrievalViewModel {
         condense: @escaping @Sendable (String) async throws -> String
     ) {
         readTask?.cancel()
+        generation += 1
+        let generation = self.generation
         phase = .reading(done: 0, total: 0)
-        let reducer = self.reducer
+        let reducer = reducerFactory()   // fresh, un-cancelled — no shared-flag poisoning
+        self.reducer = reducer
         readTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            await reducer.reset()
             do {
                 let digest = try await reducer.reduce(
                     fullText: fullText,
@@ -84,15 +99,18 @@ final class WholeBookRetrievalViewModel {
                     condense: condense,
                     onProgress: { done, total in
                         await MainActor.run { [weak self] in
-                            self?.phase = .reading(done: done, total: total)
+                            guard let self, generation == self.generation else { return }
+                            self.phase = .reading(done: done, total: total)
                         }
                     }
                 )
+                guard generation == self.generation else { return }   // superseded by disarm / a new read
                 self.digest = digest
                 self.phase = digest.coverage.isComplete
                     ? .ready(digest.coverage)
                     : .partial(digest.coverage)
             } catch {
+                guard generation == self.generation else { return }
                 // A read failure → partial with whatever coverage the reducer last
                 // reported (or empty), so the UI never claims a phantom "ready".
                 let coverage = self.digest?.coverage

--- a/vreader/Views/AI/AIChatView+Composer.swift
+++ b/vreader/Views/AI/AIChatView+Composer.swift
@@ -81,7 +81,10 @@ extension AIChatView {
     /// book-specific copy; the Library general-chat sheet keeps the neutral
     /// pre-v2 wording so the WI-2 re-skin doesn't regress that reused surface.
     var inputPlaceholder: String {
-        viewModel.bookFingerprint != nil
+        // Feature #86 WI-5b: while the whole book is being read, the composer is
+        // disabled and the placeholder says so.
+        if viewModel.isComposerDisabled { return "Reading\u{2026} ask once the book is ready" }
+        return viewModel.bookFingerprint != nil
             ? "Ask about this book\u{2026}"
             : "Type a message\u{2026}"
     }
@@ -89,6 +92,7 @@ extension AIChatView {
     var canSend: Bool {
         !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && !viewModel.isLoading
+            && !viewModel.isComposerDisabled   // Feature #86 WI-5b: disabled while reading
     }
 
     /// Bug #310: the empty-state + the placeholder must read the designed

--- a/vreader/Views/AI/AIChatView+Composer.swift
+++ b/vreader/Views/AI/AIChatView+Composer.swift
@@ -44,6 +44,12 @@ extension AIChatView {
                     .textFieldStyle(.plain)
                     .focused($isInputFocused)
                     .onSubmit { sendCurrentMessage() }
+                    // Feature #86 WI-5b (Gate-4): the field itself is non-editable
+                    // while the whole book is being read — not just the send button.
+                    .disabled(viewModel.isComposerDisabled)
+                    .onChange(of: viewModel.isComposerDisabled) { _, disabled in
+                        if disabled { isInputFocused = false }
+                    }
                     .accessibilityIdentifier("chatInputField")
                     // Bug #310: the empty prompt `""` would leave VoiceOver an
                     // unlabeled field (the overlay placeholder is hidden), so

--- a/vreader/Views/AI/AIChatView.swift
+++ b/vreader/Views/AI/AIChatView.swift
@@ -52,16 +52,30 @@ struct AIChatView: View {
                     errorBanner(message: error)
                 }
 
-                // Feature #86 WI-3/4: the docked context bar, above the composer.
-                ChatContextBar(
-                    scope: viewModel.scope,
-                    theme: theme,
-                    isScopeMenuOpen: openMenu == .scope,
-                    onScopeTap: { toggleMenu(.scope) },
-                    sourcesCount: viewModel.sources.activeCount,
-                    isSourcesMenuOpen: openMenu == .sources,
-                    onSourcesTap: { toggleMenu(.sources) }
-                )
+                // Feature #86 WI-3/4/5b: the docked context bar above the composer.
+                // For the on-demand Whole-book scope, the bar morphs into the
+                // retrieval cluster (Armed/Reading/Ready); otherwise the normal
+                // scope + sources chips.
+                if viewModel.scope == .wholeBook, let retrieval = viewModel.wholeBookRetrieval {
+                    ChatRetrievalCluster(
+                        phase: retrieval.phase,
+                        theme: theme,
+                        progressFraction: retrieval.progressFraction,
+                        unitProgressLabel: retrieval.unitProgressLabel,
+                        onScopeTap: { toggleMenu(.scope) },
+                        onCancel: { retrieval.cancel() }
+                    )
+                } else {
+                    ChatContextBar(
+                        scope: viewModel.scope,
+                        theme: theme,
+                        isScopeMenuOpen: openMenu == .scope,
+                        onScopeTap: { toggleMenu(.scope) },
+                        sourcesCount: viewModel.sources.activeCount,
+                        isSourcesMenuOpen: openMenu == .sources,
+                        onSourcesTap: { toggleMenu(.sources) }
+                    )
+                }
 
                 inputBar
             }

--- a/vreader/Views/AI/ChatRetrievalCluster.swift
+++ b/vreader/Views/AI/ChatRetrievalCluster.swift
@@ -1,0 +1,169 @@
+// Purpose: The whole-book retrieval cluster — the context bar morphs in place
+// while the AI reads the whole book on demand (Feature #86 WI-5b, design #1455).
+// Replaces the normal scope/sources bar when the scope is `.wholeBook`:
+//   - Armed:   accent "Whole book" chip + "Reads on your next question"
+//   - Reading: spinner + "Reading the whole book… 38%" + "23 / 61" + Cancel ×
+//              + a thin accent progress bar; the composer disables.
+//   - Ready:   green "Whole book" chip + "Indexed · ready"
+//   - Partial: a cancel/overflow left a partial index — rendered with the Ready
+//              treatment (a partial digest IS usable scope text), captioned
+//              "Partial · ready" so it never claims full coverage.
+//
+// @coordinates-with: WholeBookRetrievalViewModel.swift, AIChatView.swift,
+//   ChatContextBar.swift, ReaderThemeV2.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/chat-context-artboards.jsx`
+
+#if canImport(UIKit)
+import SwiftUI
+
+struct ChatRetrievalCluster: View {
+    let phase: WholeBookRetrievalViewModel.Phase
+    let theme: ReaderThemeV2
+    let progressFraction: Double
+    let unitProgressLabel: String
+    /// Tap the "Whole book" chip (armed / ready / partial) → reopen the scope menu.
+    let onScopeTap: () -> Void
+    /// Cancel the in-flight read.
+    let onCancel: () -> Void
+
+    static let identifier = "chatRetrievalCluster"
+
+    var body: some View {
+        Group {
+            switch phase {
+            case .idle, .armed: armedBar
+            case .reading:      readingBar
+            case .ready:        readyBar(caption: "Indexed · ready")
+            case .partial:      readyBar(caption: "Partial · ready")
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 9)
+        .padding(.bottom, 2)
+        .overlay(alignment: .top) {
+            Rectangle().fill(Color(theme.ruleColor)).frame(height: 0.5)
+        }
+        .accessibilityIdentifier(Self.identifier)
+    }
+
+    // MARK: - Armed
+
+    private var armedBar: some View {
+        HStack {
+            wholeBookChip(accentBorder: true, fill: scopeOpenWash, leading: sparkle)
+            Spacer(minLength: 8)
+            Text("Reads on your next question")
+                .font(.system(size: 11.5))
+                .foregroundStyle(Color(theme.subColor))
+        }
+    }
+
+    // MARK: - Reading
+
+    private var readingBar: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 9) {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(Color(theme.accentColor))
+                Text("Reading the whole book…")
+                    .font(.system(size: 12.5, weight: .semibold))
+                    .foregroundStyle(Color(theme.inkColor))
+                Text("\(Int((progressFraction * 100).rounded()))%")
+                    .font(.system(size: 12).monospacedDigit())
+                    .foregroundStyle(Color(theme.subColor))
+                Spacer(minLength: 4)
+                if !unitProgressLabel.isEmpty {
+                    Text(unitProgressLabel)
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(Color(theme.subColor))
+                }
+                Button(action: onCancel) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(Color(theme.subColor))
+                        .frame(width: 22, height: 22)
+                        .background(Circle().fill(Color(neutralWash)))
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("chatRetrievalCancel")
+                .accessibilityLabel("Cancel reading the whole book")
+            }
+            // Thin accent progress bar.
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Color(neutralWash))
+                    Capsule().fill(Color(theme.accentColor))
+                        .frame(width: max(0, min(1, progressFraction)) * geo.size.width)
+                }
+            }
+            .frame(height: 3)
+        }
+    }
+
+    // MARK: - Ready / Partial
+
+    private func readyBar(caption: String) -> some View {
+        HStack {
+            wholeBookChip(accentBorder: false, fill: greenWash, leading: greenCheck)
+            Spacer(minLength: 8)
+            HStack(spacing: 5) {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 10, weight: .bold))
+                Text(caption)
+                    .font(.system(size: 11.5, weight: .semibold))
+            }
+            .foregroundStyle(Color(ChatContextBar.accentGreen))
+        }
+    }
+
+    // MARK: - Shared chip
+
+    @ViewBuilder
+    private func wholeBookChip<L: View>(accentBorder: Bool, fill: UIColor, leading: L) -> some View {
+        Button(action: onScopeTap) {
+            HStack(spacing: 6) {
+                leading
+                Text("Context")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(Color(theme.subColor))
+                Text("Whole book")
+                    .font(.system(size: 12.5, weight: .semibold))
+                    .foregroundStyle(Color(theme.inkColor))
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(Color(theme.subColor))
+            }
+            .padding(.leading, 11)
+            .padding(.trailing, 10)
+            .padding(.vertical, 6)
+            .background(Capsule().fill(Color(fill)))
+            .overlay(Capsule().stroke(Color(accentBorder ? theme.accentColor : .clear), lineWidth: 0.5))
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(ChatContextBar.scopeChipIdentifier)
+        .accessibilityLabel("Chat context scope: Whole book")
+    }
+
+    private var sparkle: some View {
+        Image(systemName: "sparkle").font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(Color(theme.accentColor))
+    }
+    private var greenCheck: some View {
+        Image(systemName: "checkmark").font(.system(size: 11, weight: .bold))
+            .foregroundStyle(Color(ChatContextBar.accentGreen))
+    }
+
+    private var scopeOpenWash: UIColor {
+        theme.isDark
+            ? UIColor(red: 214/255, green: 136/255, blue: 90/255, alpha: 0.14)
+            : UIColor(red: 140/255, green: 47/255, blue: 47/255, alpha: 0.07)
+    }
+    private var greenWash: UIColor {
+        ChatContextBar.accentGreen.withAlphaComponent(theme.isDark ? 0.22 : 0.12)
+    }
+    private var neutralWash: UIColor {
+        theme.isDark ? UIColor(white: 1, alpha: 0.08) : UIColor(white: 0, alpha: 0.06)
+    }
+}
+#endif

--- a/vreader/Views/AI/ChatScopeMenu.swift
+++ b/vreader/Views/AI/ChatScopeMenu.swift
@@ -22,9 +22,10 @@ struct ChatScopeMenu: View {
         "chatScopeRow.\(scope.rawValue)"
     }
 
-    /// The scopes the WI-3 menu offers: the synchronous (non-on-demand) ones.
-    /// WI-5 adds the on-demand Whole-book row alongside its retrieval states.
-    static let menuScopes: [ChatContextScope] = ChatContextScope.allCases.filter { !$0.isOnDemand }
+    /// All four scopes. WI-5 added the on-demand Whole-book row now that its
+    /// retrieval + armed/reading/ready states exist (it was filtered out in WI-3
+    /// to avoid offering whole-book before retrieval was built).
+    static let menuScopes: [ChatContextScope] = ChatContextScope.allCases
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {

--- a/vreader/Views/Reader/ReaderAICoordinator.swift
+++ b/vreader/Views/Reader/ReaderAICoordinator.swift
@@ -80,7 +80,12 @@ final class ReaderAICoordinator {
     func scopedChatContext(_ scope: ChatContextScope) -> String {
         let section = currentTextContent
         guard let summaryScope = scope.summaryScope else {
-            return scopedChatContext(.bookSoFar)   // .wholeBook → best synchronous scope (WI-5 replaces)
+            // .wholeBook (WI-5b): use the retrieved digest once available; until the
+            // read completes, fall back to the broadest synchronous scope.
+            if let digest = chatViewModel?.wholeBookRetrieval?.availableContext, !digest.isEmpty {
+                return digest
+            }
+            return scopedChatContext(.bookSoFar)
         }
         if summaryScope == .section { return section }
         guard let loaded = loadedTextContent, !loaded.isEmpty,
@@ -134,6 +139,60 @@ final class ReaderAICoordinator {
         chatViewModel?.sourceCounts = chatAnnotationCache?.counts ?? (0, 0, 0)
     }
 
+    /// The pinned AI service for whole-book retrieval (WI-5b). Set in setupIfNeeded.
+    private var pinnedAIService: AIService?
+
+    /// Feature #86 WI-5b: a scope/sources change. Arms whole-book retrieval when
+    /// `.wholeBook` is selected (disarms otherwise), then re-assembles via the
+    /// single funnel.
+    private func handleChatContextChanged() {
+        if let retrieval = chatViewModel?.wholeBookRetrieval {
+            if chatViewModel?.scope == .wholeBook {
+                retrieval.arm()
+            } else if retrieval.phase != .idle {
+                retrieval.disarm()
+            }
+        }
+        refreshChatContext()
+    }
+
+    /// Feature #86 WI-5b: the on-demand whole-book read. Resolves ONE provider
+    /// config (pinned for the whole job), drives `WholeBookRetrievalViewModel.read`
+    /// with a `condense` closure that summarizes each chunk, awaits completion, and
+    /// re-assembles the context so the digest becomes the scope text.
+    func runWholeBookRead() async {
+        guard let retrieval = chatViewModel?.wholeBookRetrieval,
+              let service = pinnedAIService,
+              let text = loadedTextContent, !text.isEmpty
+        else { return }
+        if retrieval.isReady { return }
+        if case .reading = retrieval.phase { await retrieval.readTask?.value; return }
+
+        do {
+            let config = try await service.resolveActiveProviderConfig()
+            retrieval.read(
+                fullText: text,
+                chunkBudgetUTF16: AIContextBudget.defaultMaxUTF16,
+                digestBudgetUTF16: AIContextBudget.defaultMaxUTF16,
+                maxChunks: 30,   // overflow bound on provider calls — large books read a bounded digest
+                condense: { chunk in
+                    let request = AIRequest(
+                        actionType: .summarize, bookFingerprint: nil, locator: nil,
+                        contextText: chunk,
+                        userPrompt: "Summarize the key events, characters, and ideas in this passage concisely.",
+                        targetLanguage: nil, promptVersion: "v1"
+                    )
+                    return try await service.sendRequest(request, using: config).content
+                }
+            )
+            await retrieval.readTask?.value
+        } catch {
+            // Provider/config failure → the VM lands in .partial; the scope text
+            // falls back to book-so-far. Never blocks the send.
+        }
+        refreshChatContext()
+    }
+
     /// Book title used as fallback when no text content is available.
     private let fallbackTitle: String
     /// Resolved book format for context extraction.
@@ -176,9 +235,13 @@ final class ReaderAICoordinator {
         let fingerprint = DocumentFingerprint(canonicalKey: fingerprintKey)
         let chatVM = AIChatViewModel(aiService: service, bookFingerprint: fingerprint)
         chatViewModel = chatVM
-        // Feature #86 WI-3/4: re-assemble the context when the user changes scope
-        // OR toggles sources, through the same single funnel.
-        chatVM.onScopeChanged = { [weak self] in self?.refreshChatContext() }
+        pinnedAIService = service
+        // Feature #86 WI-5b: the whole-book retrieval state machine.
+        chatVM.wholeBookRetrieval = WholeBookRetrievalViewModel()
+        chatVM.onWholeBookReadRequested = { [weak self] in await self?.runWholeBookRead() }
+        // Feature #86 WI-3/4/5b: re-assemble the context when the user changes scope
+        // OR toggles sources, through the same single funnel; whole-book select arms.
+        chatVM.onScopeChanged = { [weak self] in self?.handleChatContextChanged() }
 
         // Feature #86 WI-4: the sources cache. Loads once now and refreshes on
         // `.readerAnnotationsDidChange`; each (re)load re-assembles the context +

--- a/vreader/Views/Reader/ReaderAICoordinator.swift
+++ b/vreader/Views/Reader/ReaderAICoordinator.swift
@@ -142,17 +142,26 @@ final class ReaderAICoordinator {
     /// The pinned AI service for whole-book retrieval (WI-5b). Set in setupIfNeeded.
     private var pinnedAIService: AIService?
 
-    /// Feature #86 WI-5b: a scope/sources change. Arms whole-book retrieval when
-    /// `.wholeBook` is selected (disarms otherwise), then re-assembles via the
-    /// single funnel.
+    /// The chat scope last seen by the funnel — so a whole-book read is armed only
+    /// on the TRANSITION into `.wholeBook`, not on every sources toggle (Gate-4
+    /// High: a sources change must NOT downgrade a `.ready` digest back to armed).
+    private var lastChatScope: ChatContextScope = .chapter
+
+    /// Feature #86 WI-5b: a scope/sources change. Arms whole-book retrieval ONLY
+    /// when the scope transitions into `.wholeBook` (disarms when it leaves); a
+    /// source-only toggle preserves `.ready`/`.partial`. Always re-assembles via
+    /// the single funnel.
     private func handleChatContextChanged() {
+        let scope = chatViewModel?.scope ?? .chapter
         if let retrieval = chatViewModel?.wholeBookRetrieval {
-            if chatViewModel?.scope == .wholeBook {
-                retrieval.arm()
-            } else if retrieval.phase != .idle {
-                retrieval.disarm()
+            if scope == .wholeBook, lastChatScope != .wholeBook {
+                retrieval.arm()                       // transition INTO whole-book
+            } else if scope != .wholeBook, retrieval.phase != .idle {
+                retrieval.disarm()                    // left whole-book
             }
+            // scope unchanged (e.g. a sources toggle) → preserve the read state.
         }
+        lastChatScope = scope
         refreshChatContext()
     }
 

--- a/vreaderTests/ViewModels/AIChatViewModelWholeBookTests.swift
+++ b/vreaderTests/ViewModels/AIChatViewModelWholeBookTests.swift
@@ -1,0 +1,60 @@
+// Feature #86 WI-5b: AIChatViewModel's whole-book send-flow integration — the
+// first question under the .wholeBook scope triggers the on-demand read, and the
+// composer is disabled while reading.
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("AIChatViewModel whole-book send flow (Feature #86 WI-5b)")
+@MainActor
+struct AIChatViewModelWholeBookTests {
+
+    private func makeVM() -> AIChatViewModel {
+        AIChatViewModel(
+            aiService: AIService(
+                featureFlags: FeatureFlags.shared,
+                consentManager: AIConsentManager(),
+                keychainService: KeychainService(),
+                profileStore: ProviderProfileStore.shared
+            ),
+            bookFingerprint: nil
+        )
+    }
+
+    @Test func isComposerDisabled_falseWhenNoRetrievalOrIdle() {
+        let vm = makeVM()
+        #expect(!vm.isComposerDisabled)               // no retrieval
+        vm.wholeBookRetrieval = WholeBookRetrievalViewModel()
+        #expect(!vm.isComposerDisabled)               // idle
+        vm.wholeBookRetrieval?.arm()
+        #expect(!vm.isComposerDisabled)               // armed (not reading)
+    }
+
+    @Test func sendMessage_wholeBookArmed_triggersTheRead() async {
+        let vm = makeVM()
+        vm.setScope(.wholeBook)
+        let retrieval = WholeBookRetrievalViewModel()
+        retrieval.arm()
+        vm.wholeBookRetrieval = retrieval
+        nonisolated(unsafe) var readRequested = false
+        vm.onWholeBookReadRequested = { readRequested = true }
+
+        // The send will fail at the provider (no key) AFTER the read trigger; we
+        // only assert the trigger fired.
+        await vm.sendMessage("What happens at the end?")
+        #expect(readRequested)
+    }
+
+    @Test func sendMessage_nonWholeBookScope_doesNotTriggerRead() async {
+        let vm = makeVM()
+        vm.setScope(.chapter)
+        let retrieval = WholeBookRetrievalViewModel()
+        vm.wholeBookRetrieval = retrieval
+        nonisolated(unsafe) var readRequested = false
+        vm.onWholeBookReadRequested = { readRequested = true }
+
+        await vm.sendMessage("A chapter question")
+        #expect(!readRequested)
+    }
+}

--- a/vreaderTests/ViewModels/WholeBookRetrievalViewModelTests.swift
+++ b/vreaderTests/ViewModels/WholeBookRetrievalViewModelTests.swift
@@ -57,7 +57,7 @@ struct WholeBookRetrievalViewModelTests {
 
     @Test func cancel_midRead_movesToPartial() async {
         let reducer = WholeBookReducer()
-        let vm = WholeBookRetrievalViewModel(reducer: reducer)
+        let vm = WholeBookRetrievalViewModel(reducerFactory: { reducer })
         nonisolated(unsafe) var calls = 0
         vm.read(
             fullText: String(repeating: "w", count: 1000), chunkBudgetUTF16: 100,
@@ -73,6 +73,25 @@ struct WholeBookRetrievalViewModelTests {
         }
         #expect(!coverage.isComplete)
         #expect(coverage.coveredSpans.count <= 3)
+    }
+
+    /// Gate-4: disarm during an in-flight read bumps the epoch + cancels the
+    /// reducer, so the stale read's terminal write is discarded — the phase stays
+    /// `.idle`, never resurrecting `.ready`/`.partial` after the user left whole-book.
+    @Test func disarm_duringRead_staysIdle_noStaleWrite() async {
+        let reducer = WholeBookReducer()
+        let vm = WholeBookRetrievalViewModel(reducerFactory: { reducer })
+        nonisolated(unsafe) var calls = 0
+        vm.read(
+            fullText: String(repeating: "y", count: 1000), chunkBudgetUTF16: 100,
+            digestBudgetUTF16: 10_000, maxChunks: 50
+        ) { _ in
+            calls += 1
+            if calls == 1 { await MainActor.run { vm.disarm() } }   // leave whole-book mid-read
+            return "s"
+        }
+        await vm.readTask?.value
+        #expect(vm.phase == .idle)   // the late read never wrote ready/partial
     }
 
     @Test func arm_fromPartial_reArms() async {

--- a/vreaderTests/ViewModels/WholeBookRetrievalViewModelTests.swift
+++ b/vreaderTests/ViewModels/WholeBookRetrievalViewModelTests.swift
@@ -1,0 +1,89 @@
+// Feature #86 WI-5b: the WholeBookRetrievalViewModel phase machine — arm /
+// read→ready / cancel→partial, progress, and the available-context gate. Uses the
+// real WholeBookReducer with a fake condense closure (no AIService).
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("WholeBookRetrievalViewModel (Feature #86 WI-5b)")
+@MainActor
+struct WholeBookRetrievalViewModelTests {
+
+    @Test func arm_fromIdle_movesToArmed() {
+        let vm = WholeBookRetrievalViewModel()
+        #expect(vm.phase == .idle)
+        vm.arm()
+        #expect(vm.phase == .armed)
+    }
+
+    @Test func disarm_returnsToIdle() {
+        let vm = WholeBookRetrievalViewModel()
+        vm.arm()
+        vm.disarm()
+        #expect(vm.phase == .idle)
+    }
+
+    @Test func read_completes_movesToReady_withContext() async {
+        let vm = WholeBookRetrievalViewModel()
+        vm.read(
+            fullText: String(repeating: "x", count: 300), chunkBudgetUTF16: 100,
+            digestBudgetUTF16: 10_000, maxChunks: 50
+        ) { chunk in "[sum:\(chunk.utf16.count)]" }
+        await vm.readTask?.value
+        guard case let .ready(coverage) = vm.phase else {
+            Issue.record("expected .ready, got \(vm.phase)"); return
+        }
+        #expect(coverage.isComplete)
+        #expect(vm.isReady)
+        #expect(vm.availableContext?.isEmpty == false)
+        #expect(vm.progressFraction == 1.0)
+    }
+
+    @Test func read_overflow_movesToPartial_notReady() async {
+        let vm = WholeBookRetrievalViewModel()
+        vm.read(
+            fullText: String(repeating: "z", count: 1000), chunkBudgetUTF16: 100,
+            digestBudgetUTF16: 10_000, maxChunks: 3   // only 3 of 10 chunks → partial
+        ) { _ in "s" }
+        await vm.readTask?.value
+        guard case let .partial(coverage) = vm.phase else {
+            Issue.record("expected .partial, got \(vm.phase)"); return
+        }
+        #expect(!coverage.isComplete)
+        #expect(!vm.isReady)
+        #expect(vm.availableContext != nil)   // a partial digest is still usable text
+    }
+
+    @Test func cancel_midRead_movesToPartial() async {
+        let reducer = WholeBookReducer()
+        let vm = WholeBookRetrievalViewModel(reducer: reducer)
+        nonisolated(unsafe) var calls = 0
+        vm.read(
+            fullText: String(repeating: "w", count: 1000), chunkBudgetUTF16: 100,
+            digestBudgetUTF16: 10_000, maxChunks: 50
+        ) { _ in
+            calls += 1
+            if calls == 2 { await reducer.cancel() }   // cancel after the 2nd chunk
+            return "s"
+        }
+        await vm.readTask?.value
+        guard case let .partial(coverage) = vm.phase else {
+            Issue.record("expected .partial after cancel, got \(vm.phase)"); return
+        }
+        #expect(!coverage.isComplete)
+        #expect(coverage.coveredSpans.count <= 3)
+    }
+
+    @Test func arm_fromPartial_reArms() async {
+        let vm = WholeBookRetrievalViewModel()
+        vm.read(
+            fullText: String(repeating: "z", count: 1000), chunkBudgetUTF16: 100,
+            digestBudgetUTF16: 10_000, maxChunks: 3
+        ) { _ in "s" }
+        await vm.readTask?.value
+        #expect({ if case .partial = vm.phase { return true } else { return false } }())
+        vm.arm()
+        #expect(vm.phase == .armed)
+    }
+}


### PR DESCRIPTION
## Summary

- The on-demand whole-book retrieval surface: the `@MainActor WholeBookRetrievalViewModel` (Armed/Reading%/Ready/Partial state machine over the WI-5a reducer), the `ChatRetrievalCluster` UI, the re-added Whole-book scope row, and the send-flow wiring ("reads on your next question").

Part of feature #1453 (WI-5b of 6). Design: #1455.

## What Changed

- **`WholeBookRetrievalViewModel`** — phase machine; a **fresh reducer per read** (no shared cancel-flag race) + a generation epoch (no stale write after disarm); `cancel()` → reducer-flag → `.partial`.
- **`ChatRetrievalCluster`** — the bar morphs to Armed / Reading% (spinner + progress + Cancel) / Ready / Partial under `.wholeBook`.
- **`ChatScopeMenu`** re-adds the Whole-book row (retrieval now exists).
- **`AIChatViewModel`** — `wholeBookRetrieval`; `sendMessage` triggers the on-demand read on the first whole-book question (before building context); `isComposerDisabled` while reading.
- **`ReaderAICoordinator`** — owns the retrieval VM; arms ONLY on the transition into `.wholeBook`; `runWholeBookRead` pins one provider config + a per-chunk summarize `condense`; `scopedChatContext(.wholeBook)` returns the digest once ready (else book-so-far).
- **`AIChatView`** swaps the bar for the cluster under `.wholeBook`; composer disables + re-placeholders while reading.

## Codex Audit

Gate-4, 3 rounds, ship-as-is. R1 1 High (re-arm on every sources toggle → arm-on-transition) + 1 Med (composer field not actually disabled) → R2 1 Med (stale-write after disarm → generation epoch) → R3 1 Med (shared cancel-flag race → **fresh reducer per read**) + 1 Med accepted (vm.cancel() test, composition-covered). Log: `.claude/codex-audits/feat-feature-86-wi-5b-retrieval-cluster-audit.md`.

## Validation

- [x] Unit suites green: `WholeBookRetrievalViewModelTests` (phase machine, cancel→partial, overflow→partial, disarm-stays-idle, re-arm), `AIChatViewModelWholeBookTests` (send-flow trigger; composer-disable). No regression (`ReaderAICoordinatorScopedContextTests`).
- [x] **Gate-5 slice — device-verified** (iPhone 17 Pro, v3.50.4, war-and-peace, `--enable-ai`): the scope menu re-adds the **Whole-book row** (4 rows + ON-DEMAND tag); selecting it morphs the bar to the **Armed cluster** ("Whole book" + "Reads on your next question"). Evidence: `dev-docs/verification/artifacts/feature-86-wi5b-{scope-menu-4rows,armed-cluster}-20260603.png`. The Reading/Ready states + the actual whole-book read **effect** are provider-key-blocked (the condense calls AIService) → keyed-verification.
- [x] Version bumped: 3.50.4 → 3.50.5.

## Type of Change

- [x] New feature (WI-5b of Feature #86)