### PR TITLE
feat(#86 WI-6): provenance "Drew on" citations

### DIFF
--- a/.claude/codex-audits/feat-feature-86-wi-6-citations-audit.md
+++ b/.claude/codex-audits/feat-feature-86-wi-6-citations-audit.md
@@ -1,0 +1,79 @@
+---
+branch: feat/feature-86-wi-6-citations
+threadId: codex-exec (run-codex.sh, 3 rounds)
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-06-03
+---
+
+# Codex audit — Feature #86 WI-6: provenance "Drew on" citations (Gate 4)
+
+## Implementation summary
+
+The per-reply provenance row:
+
+- `ChatMessage.citations` (default `[]`).
+- `ChatCitationFactory` — scope citation always; per-source citation only when ON &&
+  count>0; whole-book span citation (spoiler-aware `aheadOfReader`, label by
+  `coverage.isComplete`). Provenance-first: scope-level labels, no fabricated ordinals.
+- `AIChatViewModel.pendingCitations`; `sendMessage` SNAPSHOTS them after the whole-book
+  read trigger but before the stream, stamping the assistant reply (no mid-send mis-stamp).
+- `ReaderAICoordinator.refreshChatContext` computes the citations + feeds them through
+  `ChatContextAssembler` (which retains only those surviving the clamp).
+- `ChatCitationRow` — the "Drew on" chips (a tiny `FlowRow` Layout), amber `· ahead` for
+  whole-book spoilers.
+
+Plan: `dev-docs/plans/20260603-feature-86-wi2-chat-scope-sources-retrieval.md` (WI-6).
+
+## Round 1 — 1 High + 2 Medium
+
+| severity | issue | resolution |
+|---|---|---|
+| High | The whole-book coverage citation read `digest?.coverage` regardless of phase — a stale digest surviving `disarm()` (+ a pre-read provider failure) could stamp `wholeBookSpan` on a send that actually used the `.bookSoFar` fallback. | **Fixed.** Gate the coverage on the SAME condition as the scope text — `usesWholeBookDigest = scope==.wholeBook && availableContext non-empty` (i.e. `.ready`/`.partial`). |
+| Medium | Citation retention was all-or-nothing for the whole annotation block; a partial clamp keeping Notes but cutting Bookmarks dropped ALL annotation citations → under-report. | **Fixed.** PER-SECTION retention: an annotation citation survives iff its section header (`ChatAnnotationContext.{notes,highlights,bookmarks}Header`, now shared constants the serializer uses) is present in the clamped text. Test: `partialClamp_retainsSurvivingSectionsOnly`. Removed the dead `annotationKinds` set. |
+| Medium | `ChatCitationRow`'s accessibility label read only the chip label, so VoiceOver couldn't distinguish a spoiler chip. | **Fixed.** The label appends ", ahead" for `aheadOfReader` chips. |
+
+Round 1 explicitly cleared: the send-time snapshot is placed correctly (after the awaited
+whole-book update, before request construction — no mid-stream re-stamp); the empty
+assistant row is removed on failure (no citation leak from a failed send); `@MainActor`/
+`Sendable` fine; `ChatCitation` UUID churn is harmless once copied into a stamped reply.
+
+## Round 2 — 1 Medium
+
+The High + a11y Medium confirmed fixed. New: the `bounded.contains(header)` retention had
+false positives — the header could appear in scope/note content, or survive with no items.
+
+**Fixed (round 3).** Retention now checks the section's FIRST BULLET survived:
+`firstBulletUTF16Offset(forHeader:in:)` locates the section via the LINE-ANCHORED marker
+`"\n<header>\n- "` (a header substring inside content can't false-match) and a citation is
+retained iff `bounded.utf16.count > firstBullet` (the first item, not merely the header,
+survived). Tests: `headerSurvivesButItemCut_dropsCitation`, `headerInScopeContent_doesNot
+FalseRetain`.
+
+## Round 3 — 1 Medium fixed + 1 Medium accepted (round cap)
+
+The round-2 first-bullet check surfaced two finer edges:
+
+| issue | resolution |
+|---|---|
+| `firstBulletUTF16Offset` searched the whole `combined` string, so scope prose matching `"\n<header>\n- "` could false-retain. | **Fixed.** Search ONLY the annotation `block` (offset rebased by `blockStartUTF16`); scope text is never scanned. Test strengthened: `headerLineShapeInScopeContent_doesNotFalseRetain` (scope text with the exact `\nNotes:\n- …` shape + empty block → not retained). |
+| The offset is after `- `, but items are `- [label] text`, so a clamp keeping only `- [p.12] ` retains. | **Accepted with rationale (round cap).** This requires the combined context to exceed the 12K budget AND the clamp to land precisely inside a bullet's `[label]` prefix — a rare double-edge. The chips are **advisory provenance**, not a correctness/security boundary, so a narrow over-report (the model saw the section's header + first label but not its text) is low-harm. A fully precise item-text-offset check would require the serializer to emit per-item text offsets threaded through the cache → coordinator → assembler — disproportionate for this edge. Rule 47 permits accept-with-rationale at the 3-round cap. |
+
+The file-size note (`ReaderAICoordinator` ~344) is also **accepted** (grew across WI-2..6).
+
+## Verdict
+
+`ship-as-is`. The retention went through 4 rounds of genuine accuracy improvement
+(all-or-nothing → header-present → first-bullet → block-scoped first-bullet); the one
+residual is an accepted narrow over-report at the round cap. Zero open Critical/High; one
+accepted Medium with documented rationale.
+
+## Verification
+
+- Unit (green via `scripts/run-tests.sh`): `ChatCitationFactoryTests` (scope always;
+  source-only-when-on-and-nonempty; whole-book spoiler span; partial-vs-complete label;
+  no fabricated ordinals; ChatMessage carries citations), `ChatContextAssemblerSection
+  RetentionTests` (per-section retention). No regression in `ChatContextAssemblerTests`.
+- Tier: behavioral. Gate-5 — the "Drew on" row renders under a reply; the actual
+  citation *content* depends on a real AI answer (provider-key-blocked) → keyed-verification
+  (the factory + retention + a11y are unit-proven).

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 848
-        MARKETING_VERSION: 3.50.5
+        CURRENT_PROJECT_VERSION: 849
+        MARKETING_VERSION: 3.50.6
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -486,6 +486,7 @@
 		4D4A49E8738329EC2B336683 /* TXTReaderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D998048CE6DE8DC3BC77C284 /* TXTReaderViewModelTests.swift */; };
 		4D4D7B16BBA5732D1E6AB875 /* GenerativeCoverMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF66A8065E5B60907FB0A3C8 /* GenerativeCoverMetrics.swift */; };
 		4D66B6E16F96E24A0B01F7A9 /* WebDAVBackupIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F1695C0E7481CB3EA2B8A3 /* WebDAVBackupIntegrationTests.swift */; };
+		4D763B3132D474C73F9F66F8 /* ChatCitationFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B36C649C2C6066B9BAAEC7 /* ChatCitationFactoryTests.swift */; };
 		4D82E64F299F0EEBA0FD2851 /* WebDAVServerProfileListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABA711375AB3BAEB2F42CFE /* WebDAVServerProfileListView.swift */; };
 		4E2207CD7F48BCE945A0971C /* AIReaderIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E706779E64026004319957F /* AIReaderIntegrationTests.swift */; };
 		4E41A2349D76D4F0814C3FF1 /* TXTViewConfigThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F3E6C42E1711EF70E585526 /* TXTViewConfigThemeTests.swift */; };
@@ -675,6 +676,7 @@
 		6CC40A6DE2F14BB94A53006B /* FoliateMessageParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB35F648E8E697C82E4C41DE /* FoliateMessageParserTests.swift */; };
 		6CFD5F91EEF10C009963AEB0 /* TextReaderUIState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E25002586402AAE67B29CE6 /* TextReaderUIState.swift */; };
 		6D073A0311A72B82FEF65852 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC105D38A4A85CBCB79A772 /* KeychainService.swift */; };
+		6D25BFBFB7750E0FC61BE61E /* ChatCitationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F8BA3B09B19FB28EEC1996 /* ChatCitationFactory.swift */; };
 		6D6ADF2C31C5386957B6EF65 /* LazyDownloadEnqueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DF85A7A806124F57A8FB6E /* LazyDownloadEnqueueTests.swift */; };
 		6D9880CCA623B7887967DB45 /* DebugPresentSheetEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BCADB7187645F41A660385 /* DebugPresentSheetEffect.swift */; };
 		6DC960D68C180A1078911388 /* EPUBWebViewBridgeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1920480AF349823757484C2D /* EPUBWebViewBridgeCoordinator.swift */; };
@@ -832,6 +834,7 @@
 		879E269189DBE24A5AF6095B /* LibraryRefreshServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DAD680DB86CF1A65D34F3F /* LibraryRefreshServiceTests.swift */; };
 		87A2CA804F42A82380742109 /* TXTChunkedReaderBridgeRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A99A934AA5136EF8FF48D41 /* TXTChunkedReaderBridgeRestoreTests.swift */; };
 		87A61AC432B6116973B7D291 /* LocatorIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0069CA3A00998B13DE06E424 /* LocatorIntegrationTests.swift */; };
+		87C3D7093F686FD9DF2E1EEA /* ChatCitationRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320EA026FDDCD3BED91BCBE7 /* ChatCitationRow.swift */; };
 		87ECBC5C79A780F1A681A02C /* ReaderMorePopoverTTSGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB11ECCB50D770FE1E8F0B29 /* ReaderMorePopoverTTSGateTests.swift */; };
 		881677EB4D38D3439473606D /* ContentReplacementRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5AB21F49D361F1160920C0 /* ContentReplacementRule.swift */; };
 		88472C0C4B06190CA46E917F /* BookImporterEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163C2BBCB1C2FEFB9713C4CF /* BookImporterEnvironment.swift */; };
@@ -1814,6 +1817,7 @@
 		31AB5B40BD735A699BB480DE /* ReadingStatsAggregatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsAggregatorTests.swift; sourceTree = "<group>"; };
 		31D94746694BD66410FDB471 /* BookDetailsMetadataRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailsMetadataRow.swift; sourceTree = "<group>"; };
 		31EE8C98490794A73383C3A1 /* ChatAnnotationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAnnotationContext.swift; sourceTree = "<group>"; };
+		320EA026FDDCD3BED91BCBE7 /* ChatCitationRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatCitationRow.swift; sourceTree = "<group>"; };
 		326632F80DB744679F67D712 /* OPDSCatalogListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSCatalogListTests.swift; sourceTree = "<group>"; };
 		32BC7A4A1B047A76FD209AB3 /* ChapterBoundsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterBoundsTests.swift; sourceTree = "<group>"; };
 		32C7988191A61F11CF1F38F6 /* EPUBContinuousChapterProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBContinuousChapterProviderTests.swift; sourceTree = "<group>"; };
@@ -2552,6 +2556,7 @@
 		A97DEE6FFCAE4CC96DFEDC24 /* BackupReadingHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupReadingHistory.swift; sourceTree = "<group>"; };
 		A983D06F916C51795A2223E7 /* ReaderBottomOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderBottomOverlay.swift; sourceTree = "<group>"; };
 		A9ABEE3CBF62A1CC57F2952F /* UTF16TextSlicer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTF16TextSlicer.swift; sourceTree = "<group>"; };
+		A9B36C649C2C6066B9BAAEC7 /* ChatCitationFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatCitationFactoryTests.swift; sourceTree = "<group>"; };
 		A9C2070D3EFFBFC041A1474B /* TTSTextSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSTextSource.swift; sourceTree = "<group>"; };
 		A9EE79C451D86828387A1BEF /* MDIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDIntegrationTests.swift; sourceTree = "<group>"; };
 		AA409234BCE569EFCD508360 /* FoliateBilingualJSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateBilingualJSTests.swift; sourceTree = "<group>"; };
@@ -2636,6 +2641,7 @@
 		B8AF952035ED7A7AF46DE73A /* BilingualPillTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualPillTests.swift; sourceTree = "<group>"; };
 		B8C6D6A8EC00DFFAC294DD87 /* AnthropicProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnthropicProvider.swift; sourceTree = "<group>"; };
 		B8D6186050D8E6FE32B2578B /* legado_source_js.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = legado_source_js.json; sourceTree = "<group>"; };
+		B8F8BA3B09B19FB28EEC1996 /* ChatCitationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatCitationFactory.swift; sourceTree = "<group>"; };
 		B90F4EB83CC68406DA14DD94 /* AIChatGeneralTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatGeneralTests.swift; sourceTree = "<group>"; };
 		B925BE5683D3296D77D3503B /* MockPersistenceActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPersistenceActor.swift; sourceTree = "<group>"; };
 		B92E2A0146CEC96DB224FE99 /* AIReaderAvailabilityPerProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIReaderAvailabilityPerProfileTests.swift; sourceTree = "<group>"; };
@@ -4152,6 +4158,7 @@
 				539FEE4A23AFA226048A12A4 /* AIChatView.swift */,
 				4B55B710BEC6ADA4EE00C594 /* AIChatView+Composer.swift */,
 				83B60F61628D0969B18B3A9B /* AIConsentView.swift */,
+				320EA026FDDCD3BED91BCBE7 /* ChatCitationRow.swift */,
 				02C8F2C0DD4DC5CDA2601383 /* ChatContextBar.swift */,
 				FDB526ADB0E1190463E08AE9 /* ChatRetrievalCluster.swift */,
 				4007FACF71264B6118B3F5FA /* ChatScopeMenu.swift */,
@@ -5139,6 +5146,7 @@
 				4A1B327713437D80D690ED9B /* ChapterTranslationChunkerTests.swift */,
 				B13E51BF43992E1B2786A8FD /* ChapterTranslationServiceTests.swift */,
 				2B8F846506ADCDC633162553 /* ChatAnnotationCacheTests.swift */,
+				A9B36C649C2C6066B9BAAEC7 /* ChatCitationFactoryTests.swift */,
 				5CBB56AF58AC56AB5CD3E692 /* ChatContextFoundationTests.swift */,
 				EA0CD7509429C4B75ACB98F2 /* KeychainProviderProfileExtensionTests.swift */,
 				C5C46A3D7400CC956FA8D46D /* ProviderKindTests.swift */,
@@ -5442,6 +5450,7 @@
 				77A37012A543D5737FFC9039 /* ChatAnnotationCache.swift */,
 				31EE8C98490794A73383C3A1 /* ChatAnnotationContext.swift */,
 				01DD3EDBBD948811D620B337 /* ChatCitation.swift */,
+				B8F8BA3B09B19FB28EEC1996 /* ChatCitationFactory.swift */,
 				3E46C9FBB99778BBC01EC556 /* ChatContextAssembler.swift */,
 				457E4B76590E361D08897EC3 /* ChatContextScope.swift */,
 				D04FD082244C1C8F6A4B8C3A /* ChatContextScope+Menu.swift */,
@@ -5928,6 +5937,7 @@
 				56CDEC7C3ADB3B1142561E60 /* ChapterTranslationServiceTests.swift in Sources */,
 				E19364EB475B945F4B96F3DB /* ChapterTranslationStoreTests.swift in Sources */,
 				F8ECE2A47A7713B5A7ECCB96 /* ChatAnnotationCacheTests.swift in Sources */,
+				4D763B3132D474C73F9F66F8 /* ChatCitationFactoryTests.swift in Sources */,
 				D5BFB1EBD8FCFB12E438DCE9 /* ChatContextFoundationTests.swift in Sources */,
 				E4F03F269AFA7E2CF65B2E6A /* ChatScopeSelectionTests.swift in Sources */,
 				2DA32CDB11AE06DBCF3E97DE /* CloudKitRecordMapperTests.swift in Sources */,
@@ -6587,6 +6597,8 @@
 				6868CB22925098DC45ED5161 /* ChatAnnotationCache.swift in Sources */,
 				D1E30622FC94E669C740FFD7 /* ChatAnnotationContext.swift in Sources */,
 				A5269794813DB85D5D1053F4 /* ChatCitation.swift in Sources */,
+				6D25BFBFB7750E0FC61BE61E /* ChatCitationFactory.swift in Sources */,
+				87C3D7093F686FD9DF2E1EEA /* ChatCitationRow.swift in Sources */,
 				AF263750044D4A8AD25C3675 /* ChatContextAssembler.swift in Sources */,
 				FC5945D7EE05A9B54F1815E8 /* ChatContextBar.swift in Sources */,
 				73044473A655F7D1FAD82A18 /* ChatContextScope+Menu.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7377,7 +7377,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 848;
+				CURRENT_PROJECT_VERSION = 849;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7385,7 +7385,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.50.5;
+				MARKETING_VERSION = 3.50.6;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7531,7 +7531,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 848;
+				CURRENT_PROJECT_VERSION = 849;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7539,7 +7539,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.50.5;
+				MARKETING_VERSION = 3.50.6;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Models/ChatMessage.swift
+++ b/vreader/Models/ChatMessage.swift
@@ -25,16 +25,21 @@ struct ChatMessage: Identifiable, Sendable, Equatable {
     /// Message content. Mutable to support incremental streaming updates.
     var content: String
     let timestamp: Date
+    /// Feature #86 WI-6: the provenance an assistant reply drew on — the "Drew on"
+    /// chips. Stamped from the send-time snapshot of the context the request used.
+    var citations: [ChatCitation]
 
     init(
         id: UUID = UUID(),
         role: ChatRole,
         content: String,
-        timestamp: Date = Date()
+        timestamp: Date = Date(),
+        citations: [ChatCitation] = []
     ) {
         self.id = id
         self.role = role
         self.content = content
         self.timestamp = timestamp
+        self.citations = citations
     }
 }

--- a/vreader/Services/AI/ChatAnnotationContext.swift
+++ b/vreader/Services/AI/ChatAnnotationContext.swift
@@ -19,6 +19,13 @@ import Foundation
 
 enum ChatAnnotationContext {
 
+    /// The section header each annotation kind serializes under — the assembler
+    /// uses these to retain a kind's citation only if its section survived the
+    /// budget clamp (Feature #86 WI-6 per-section retention).
+    static let notesHeader = "Notes:"
+    static let highlightsHeader = "Highlights:"
+    static let bookmarksHeader = "Bookmarks:"
+
     /// A non-empty note: present and not whitespace-only.
     static func hasNote(_ note: String?) -> Bool {
         guard let note else { return false }
@@ -69,7 +76,7 @@ enum ChatAnnotationContext {
                 .map { line(label: locatorLabel($0.1), text: sanitize($0.2)) }
                 .filter { !$0.isEmpty }
             if !lines.isEmpty {
-                sections.append("Notes:\n" + lines.joined(separator: "\n"))
+                sections.append(notesHeader + "\n" + lines.joined(separator: "\n"))
             }
         }
 
@@ -79,7 +86,7 @@ enum ChatAnnotationContext {
                 .map { line(label: locatorLabel($0.locator), text: sanitize($0.selectedText), quote: true) }
                 .filter { !$0.isEmpty }
             if !lines.isEmpty {
-                sections.append("Highlights:\n" + lines.joined(separator: "\n"))
+                sections.append(highlightsHeader + "\n" + lines.joined(separator: "\n"))
             }
         }
 
@@ -89,7 +96,7 @@ enum ChatAnnotationContext {
                 .map { line(label: locatorLabel($0.locator), text: sanitize($0.title ?? "Bookmark")) }
                 .filter { !$0.isEmpty }
             if !lines.isEmpty {
-                sections.append("Bookmarks:\n" + lines.joined(separator: "\n"))
+                sections.append(bookmarksHeader + "\n" + lines.joined(separator: "\n"))
             }
         }
 

--- a/vreader/Services/AI/ChatCitationFactory.swift
+++ b/vreader/Services/AI/ChatCitationFactory.swift
@@ -1,0 +1,58 @@
+// Purpose: Computes the provenance-first "Drew on" citations for an AI Chat reply
+// from the context that was assembled (Feature #86 WI-6). Pure + testable; the
+// coordinator feeds the result through `ChatContextAssembler.assemble`, which then
+// RETAINS only the citations whose content survived the budget clamp.
+//
+// Citations are scope-level (not fabricated chapter ordinals — the WI-2
+// provenance-first decision): the scope's display name, one per active+non-empty
+// source kind, and — for Whole book — a spoiler-aware whole-book span citation.
+//
+// @coordinates-with: ChatCitation.swift, ChatContextAssembler.swift,
+//   ChatContextScope.swift, ChatSourceSelection.swift, WholeBookReducer.swift,
+//   ChatCitationRow.swift (the UI)
+
+import Foundation
+
+enum ChatCitationFactory {
+
+    /// Builds the citation set for a context assembled from `scope` + `sources`.
+    ///
+    /// - Parameters:
+    ///   - counts: per-book annotation counts (a source kind only cites when it's
+    ///     toggled ON *and* has items).
+    ///   - wholeBookCoverage: present when `scope == .wholeBook` and a read produced
+    ///     coverage — adds a spoiler-aware whole-book span citation.
+    static func citations(
+        scope: ChatContextScope,
+        sources: ChatSourceSelection,
+        counts: (notes: Int, highlights: Int, bookmarks: Int),
+        wholeBookCoverage: WholeBookCoverage? = nil
+    ) -> [ChatCitation] {
+        var result: [ChatCitation] = []
+
+        // The reading scope itself.
+        result.append(ChatCitation(sourceKind: .scope, label: scope.displayName))
+
+        // The reader's own marks — only kinds that are ON and actually have items.
+        if sources.notes, counts.notes > 0 {
+            result.append(ChatCitation(sourceKind: .note, label: "your notes"))
+        }
+        if sources.highlights, counts.highlights > 0 {
+            result.append(ChatCitation(sourceKind: .highlight, label: "your highlights"))
+        }
+        if sources.bookmarks, counts.bookmarks > 0 {
+            result.append(ChatCitation(sourceKind: .bookmark, label: "your bookmarks"))
+        }
+
+        // Whole book reads pages ahead of the reader → spoiler-aware (amber chip).
+        if scope == .wholeBook, let coverage = wholeBookCoverage, !coverage.coveredSpans.isEmpty {
+            result.append(ChatCitation(
+                sourceKind: .wholeBookSpan,
+                label: coverage.isComplete ? "the whole book" : "the book so far",
+                spanUTF16: coverage.coveredSpans.first,
+                aheadOfReader: true
+            ))
+        }
+        return result
+    }
+}

--- a/vreader/Services/AI/ChatContextAssembler.swift
+++ b/vreader/Services/AI/ChatContextAssembler.swift
@@ -27,10 +27,6 @@ struct ChatContextAssembly: Sendable, Equatable {
 
 enum ChatContextAssembler {
 
-    /// The annotation source kinds — citations the annotation block contributes.
-    /// (Scope / whole-book citations come from the scope text, not the block.)
-    private static let annotationKinds: Set<ChatCitation.SourceKind> = [.note, .highlight, .bookmark]
-
     /// Combines the scope text and the annotation block into the injected
     /// `bookContext`, clamped to `maxUTF16`, and bundles the citations — keeping
     /// only the citations whose content actually SURVIVED the clamp (Gate-4: the
@@ -66,24 +62,57 @@ enum ChatContextAssembler {
 
         let bounded = UTF16Clamp.clamp(combined, maxUTF16: max(0, maxUTF16))
 
-        // Citation retention:
-        // - bookContext empty → nothing was injected → no citations.
-        // - the annotation block didn't fully survive the clamp → drop the
-        //   annotation-derived citations (the scope citation still holds, since
-        //   the scope text is preserved first).
+        // Citation retention: keep only citations whose content actually survived
+        // the clamp — PER source SECTION (Gate-4 WI-6), not all-or-nothing, so a
+        // partial clamp that keeps Notes but drops Bookmarks under-reports neither.
         let citations = retainedCitations(
-            citations, bounded: bounded, trimmedBlock: trimmedBlock, blockStartUTF16: blockStartUTF16
+            citations, block: trimmedBlock, blockStartUTF16: blockStartUTF16, bounded: bounded
         )
         return ChatContextAssembly(bookContext: bounded, citations: citations)
     }
 
+    /// The section header each annotation-kind citation maps to.
+    private static func sectionHeader(for kind: ChatCitation.SourceKind) -> String? {
+        switch kind {
+        case .note:      return ChatAnnotationContext.notesHeader
+        case .highlight: return ChatAnnotationContext.highlightsHeader
+        case .bookmark:  return ChatAnnotationContext.bookmarksHeader
+        case .scope, .wholeBookSpan: return nil   // not annotation-block-derived
+        }
+    }
+
+    /// The UTF-16 offset (in the COMBINED string) where a section's first bullet
+    /// content begins. Searches ONLY the annotation `block` (never the scope text),
+    /// via the line-anchored marker `"\n<header>\n- "`, so scope/annotation prose
+    /// that happens to match the line shape can't false-retain a citation. Returns
+    /// nil if the section isn't in the block.
+    private static func firstBulletUTF16Offset(
+        forHeader header: String, block: String, blockStartUTF16: Int
+    ) -> Int? {
+        let marker = "\n" + header + "\n- "
+        guard let range = block.range(of: marker) else { return nil }
+        return blockStartUTF16 + block[block.startIndex..<range.upperBound].utf16.count
+    }
+
     private static func retainedCitations(
-        _ citations: [ChatCitation], bounded: String, trimmedBlock: String, blockStartUTF16: Int
+        _ citations: [ChatCitation], block: String, blockStartUTF16: Int, bounded: String
     ) -> [ChatCitation] {
-        guard !bounded.isEmpty else { return [] }
-        let blockFullySurvived = trimmedBlock.isEmpty
-            || bounded.utf16.count >= blockStartUTF16 + trimmedBlock.utf16.count
-        guard !blockFullySurvived else { return citations }
-        return citations.filter { !annotationKinds.contains($0.sourceKind) }
+        guard !bounded.isEmpty else { return [] }   // nothing injected → no provenance
+        let boundedLen = bounded.utf16.count
+        return citations.filter { citation in
+            guard let header = sectionHeader(for: citation.sourceKind) else {
+                return true   // scope / whole-book citations ride with the scope text (kept)
+            }
+            guard let firstBullet = firstBulletUTF16Offset(
+                forHeader: header, block: block, blockStartUTF16: blockStartUTF16
+            ) else {
+                return false   // the section isn't in the annotation block at all
+            }
+            // The section's first ITEM survived iff the clamp kept past its bullet
+            // marker. (A clamp that preserves only the bullet's `[label]` prefix but
+            // cuts the item text can still retain — an accepted narrow over-report
+            // in the rare >budget-clamp case; provenance is advisory.)
+            return boundedLen > firstBullet
+        }
     }
 }

--- a/vreader/ViewModels/AIChatViewModel.swift
+++ b/vreader/ViewModels/AIChatViewModel.swift
@@ -94,6 +94,11 @@ final class AIChatViewModel {
     /// bookmarks). Set by the coordinator from the `ChatAnnotationCache`.
     var sourceCounts: (notes: Int, highlights: Int, bookmarks: Int) = (0, 0, 0)
 
+    /// Feature #86 WI-6: the citations the CURRENT assembled context drew on (set
+    /// by the coordinator's funnel). `sendMessage` snapshots these at send time and
+    /// stamps the assistant reply's "Drew on" row from the snapshot.
+    var pendingCitations: [ChatCitation] = []
+
     /// Toggles a single source kind and re-assembles the book context.
     func setSources(_ newSources: ChatSourceSelection) {
         guard newSources != sources else { return }
@@ -163,6 +168,11 @@ final class AIChatViewModel {
             await onWholeBookReadRequested?()
         }
 
+        // Feature #86 WI-6: SNAPSHOT the citations the context drew on, AFTER any
+        // whole-book read (so the snapshot reflects the digest) but BEFORE the
+        // async stream — so a scope/source change mid-send can't mis-stamp the reply.
+        let citationSnapshot = pendingCitations
+
         // Build context from conversation history (sliding window)
         let contextText = buildContextText()
 
@@ -177,8 +187,9 @@ final class AIChatViewModel {
         )
 
         do {
-            // Create an empty assistant message for incremental streaming
-            let assistantMessage = ChatMessage(role: .assistant, content: "")
+            // Create an empty assistant message (stamped with the citation snapshot)
+            // for incremental streaming.
+            let assistantMessage = ChatMessage(role: .assistant, content: "", citations: citationSnapshot)
             messages.append(assistantMessage)
             let assistantIndex = messages.count - 1
 

--- a/vreader/Views/AI/AIChatMessageRow.swift
+++ b/vreader/Views/AI/AIChatMessageRow.swift
@@ -97,13 +97,20 @@ struct AIChatMessageRow: View {
     private var assistantRow: some View {
         HStack(alignment: .top, spacing: 8) {
             sparkleAvatar
-            Text(message.content)
-                .font(Font(ReaderTypography.body(for: .sourceSerif4, size: 14.5)))
-                .lineSpacing(4)
-                .foregroundStyle(Color(theme.inkColor))
-                .textSelection(.enabled)
-                .padding(.vertical, 4)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            VStack(alignment: .leading, spacing: 0) {
+                Text(message.content)
+                    .font(Font(ReaderTypography.body(for: .sourceSerif4, size: 14.5)))
+                    .lineSpacing(4)
+                    .foregroundStyle(Color(theme.inkColor))
+                    .textSelection(.enabled)
+                    .padding(.vertical, 4)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                // Feature #86 WI-6: the "Drew on" provenance row under the reply.
+                if !message.citations.isEmpty {
+                    ChatCitationRow(citations: message.citations, theme: theme)
+                        .padding(.bottom, 4)
+                }
+            }
             Spacer(minLength: 32)
         }
         .padding(.horizontal, 18)

--- a/vreader/Views/AI/ChatCitationRow.swift
+++ b/vreader/Views/AI/ChatCitationRow.swift
@@ -1,0 +1,104 @@
+// Purpose: The "Drew on" provenance row under an AI Chat reply (Feature #86 WI-6,
+// design #1455). A small uppercase "Drew on" label followed by chips naming what
+// the answer read. A whole-book span that reached PAST the reader is an amber
+// `· ahead` spoiler chip; everything else is a neutral chip (a note chip carries a
+// note glyph).
+//
+// @coordinates-with: ChatCitation.swift, AIChatMessageRow.swift, ReaderThemeV2.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/chat-context-artboards.jsx`
+
+#if canImport(UIKit)
+import SwiftUI
+
+struct ChatCitationRow: View {
+    let citations: [ChatCitation]
+    let theme: ReaderThemeV2
+
+    static let identifier = "chatCitationRow"
+
+    var body: some View {
+        FlowRow(spacing: 6) {
+            Text("Drew on")
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.4)
+                .textCase(.uppercase)
+                .foregroundStyle(Color(theme.subColor))
+            ForEach(citations) { citation in
+                chip(citation)
+            }
+        }
+        .accessibilityIdentifier(Self.identifier)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Drew on: " + citations.map(\.label).joined(separator: ", "))
+    }
+
+    @ViewBuilder
+    private func chip(_ citation: ChatCitation) -> some View {
+        let ahead = citation.aheadOfReader
+        HStack(spacing: 4) {
+            if citation.sourceKind == .note {
+                Image(systemName: "note.text").font(.system(size: 10))
+            }
+            if ahead {
+                Image(systemName: "info.circle").font(.system(size: 10, weight: .semibold))
+            }
+            Text(ahead ? "\(citation.label) · ahead" : citation.label)
+                .font(.system(size: 11, weight: .medium))
+        }
+        .foregroundStyle(Color(ahead ? amberInk : theme.subColor))
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(Capsule().fill(Color(ahead ? amberWash : neutralWash)))
+        .overlay(
+            Capsule().stroke(Color(ahead ? amberBorder : .clear), lineWidth: 0.5)
+        )
+    }
+
+    // Amber spoiler treatment.
+    private var amberInk: UIColor {
+        theme.isDark ? UIColor(red: 0xe8/255, green: 0xb4/255, blue: 0x65/255, alpha: 1)
+                     : UIColor(red: 0x9a/255, green: 0x6a/255, blue: 0x1f/255, alpha: 1)
+    }
+    private var amberWash: UIColor { UIColor(red: 180/255, green: 120/255, blue: 40/255, alpha: 0.13) }
+    private var amberBorder: UIColor {
+        theme.isDark ? UIColor(red: 232/255, green: 180/255, blue: 101/255, alpha: 0.4)
+                     : UIColor(red: 154/255, green: 106/255, blue: 31/255, alpha: 0.3)
+    }
+    private var neutralWash: UIColor {
+        theme.isDark ? UIColor(white: 1, alpha: 0.06) : UIColor(white: 0, alpha: 0.05)
+    }
+}
+
+/// A minimal wrapping HStack (chips flow to the next line). Sufficient for the
+/// short "Drew on" rows; avoids a heavier layout dependency.
+private struct FlowRow: Layout {
+    var spacing: CGFloat = 6
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var x: CGFloat = 0, y: CGFloat = 0, rowHeight: CGFloat = 0
+        for view in subviews {
+            let size = view.sizeThatFits(.unspecified)
+            if x + size.width > maxWidth, x > 0 {
+                x = 0; y += rowHeight + spacing; rowHeight = 0
+            }
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+        return CGSize(width: maxWidth == .infinity ? x : maxWidth, height: y + rowHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var x = bounds.minX, y = bounds.minY, rowHeight: CGFloat = 0
+        for view in subviews {
+            let size = view.sizeThatFits(.unspecified)
+            if x + size.width > bounds.maxX, x > bounds.minX {
+                x = bounds.minX; y += rowHeight + spacing; rowHeight = 0
+            }
+            view.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}
+#endif

--- a/vreader/Views/AI/ChatCitationRow.swift
+++ b/vreader/Views/AI/ChatCitationRow.swift
@@ -29,7 +29,11 @@ struct ChatCitationRow: View {
         }
         .accessibilityIdentifier(Self.identifier)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Drew on: " + citations.map(\.label).joined(separator: ", "))
+        // Gate-4 WI-6: announce the spoiler ("ahead") state to VoiceOver, not just
+        // the label — otherwise a spoiler chip sounds the same as a safe one.
+        .accessibilityLabel("Drew on: " + citations.map {
+            $0.aheadOfReader ? "\($0.label), ahead" : $0.label
+        }.joined(separator: ", "))
     }
 
     @ViewBuilder

--- a/vreader/Views/Reader/ReaderAICoordinator.swift
+++ b/vreader/Views/Reader/ReaderAICoordinator.swift
@@ -126,7 +126,13 @@ final class ReaderAICoordinator {
         // Feature #86 WI-6: compute the provenance citations the context drew on;
         // the assembler retains only those that survive the budget clamp.
         let counts = chatAnnotationCache?.counts ?? (0, 0, 0)
-        let wholeBookCoverage = chatVM.scope == .wholeBook
+        // Gate the whole-book coverage citation on the SAME condition the scope text
+        // uses (a non-empty `availableContext` — i.e. .ready/.partial), so a stale
+        // digest that survived disarm can't stamp a whole-book span on a send that
+        // actually used the book-so-far fallback (Gate-4 High).
+        let usesWholeBookDigest = chatVM.scope == .wholeBook
+            && (chatVM.wholeBookRetrieval?.availableContext?.isEmpty == false)
+        let wholeBookCoverage = usesWholeBookDigest
             ? chatVM.wholeBookRetrieval?.digest?.coverage : nil
         let citations = ChatCitationFactory.citations(
             scope: chatVM.scope, sources: chatVM.sources, counts: counts,

--- a/vreader/Views/Reader/ReaderAICoordinator.swift
+++ b/vreader/Views/Reader/ReaderAICoordinator.swift
@@ -123,11 +123,21 @@ final class ReaderAICoordinator {
         let block = chatAnnotationCache?.annotationBlock(
             for: chatVM.sources, maxUTF16: AIContextBudget.defaultMaxUTF16
         ) ?? ""
+        // Feature #86 WI-6: compute the provenance citations the context drew on;
+        // the assembler retains only those that survive the budget clamp.
+        let counts = chatAnnotationCache?.counts ?? (0, 0, 0)
+        let wholeBookCoverage = chatVM.scope == .wholeBook
+            ? chatVM.wholeBookRetrieval?.digest?.coverage : nil
+        let citations = ChatCitationFactory.citations(
+            scope: chatVM.scope, sources: chatVM.sources, counts: counts,
+            wholeBookCoverage: wholeBookCoverage
+        )
         let assembly = ChatContextAssembler.assemble(
-            scopeText: scopeText, annotationBlock: block, citations: [],
+            scopeText: scopeText, annotationBlock: block, citations: citations,
             maxUTF16: AIContextBudget.defaultMaxUTF16
         )
         chatVM.bookContext = assembly.bookContext
+        chatVM.pendingCitations = assembly.citations
     }
 
     /// Feature #86 WI-4: the per-book annotation cache backing the sources chip.

--- a/vreaderTests/Services/AI/ChatCitationFactoryTests.swift
+++ b/vreaderTests/Services/AI/ChatCitationFactoryTests.swift
@@ -1,0 +1,80 @@
+// Feature #86 WI-6: ChatCitationFactory — the provenance "Drew on" citations from
+// (scope, sources, counts, whole-book coverage), and ChatMessage carrying them.
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("ChatCitationFactory (Feature #86 WI-6)")
+struct ChatCitationFactoryTests {
+
+    private let allCounts = (notes: 3, highlights: 5, bookmarks: 2)
+
+    @Test func always_includesTheScopeCitation() {
+        let c = ChatCitationFactory.citations(
+            scope: .chapter, sources: ChatSourceSelection(notes: false, highlights: false, bookmarks: false),
+            counts: (0, 0, 0)
+        )
+        #expect(c.count == 1)
+        #expect(c.first?.sourceKind == .scope)
+        #expect(c.first?.label == "Chapter")
+    }
+
+    @Test func sourceCitations_onlyWhenOnAndNonEmpty() {
+        // Notes on + has items → cited; highlights on but 0 → not; bookmarks off → not.
+        let c = ChatCitationFactory.citations(
+            scope: .chapter,
+            sources: ChatSourceSelection(notes: true, highlights: true, bookmarks: false),
+            counts: (notes: 4, highlights: 0, bookmarks: 9)
+        )
+        let kinds = c.map(\.sourceKind)
+        #expect(kinds.contains(.note))         // on + 4 items
+        #expect(!kinds.contains(.highlight))   // on but 0 items
+        #expect(!kinds.contains(.bookmark))    // off
+    }
+
+    @Test func allSourcesOn_withItems_citesEach() {
+        let c = ChatCitationFactory.citations(
+            scope: .section, sources: .init(notes: true, highlights: true, bookmarks: true),
+            counts: allCounts
+        )
+        let kinds = Set(c.map(\.sourceKind))
+        #expect(kinds == [.scope, .note, .highlight, .bookmark])
+    }
+
+    @Test func wholeBook_addsSpoilerAwareSpanCitation() {
+        let coverage = WholeBookCoverage(coveredSpans: [0...999], totalUTF16: 1000, droppedSpans: [])
+        let c = ChatCitationFactory.citations(
+            scope: .wholeBook, sources: .init(notes: false, highlights: false, bookmarks: false),
+            counts: (0, 0, 0), wholeBookCoverage: coverage
+        )
+        let span = c.first { $0.sourceKind == .wholeBookSpan }
+        #expect(span != nil)
+        #expect(span?.aheadOfReader == true)       // whole-book reads pages ahead → spoiler
+        #expect(span?.label == "the whole book")   // complete coverage
+    }
+
+    @Test func wholeBook_partialCoverage_labelsBookSoFar() {
+        let coverage = WholeBookCoverage(coveredSpans: [0...499], totalUTF16: 1000, droppedSpans: [500...999])
+        let c = ChatCitationFactory.citations(
+            scope: .wholeBook, sources: .default, counts: allCounts, wholeBookCoverage: coverage
+        )
+        #expect(c.first { $0.sourceKind == .wholeBookSpan }?.label == "the book so far")
+    }
+
+    @Test func nonWholeBook_noSpanCitation_evenWithCoverage() {
+        let coverage = WholeBookCoverage(coveredSpans: [0...999], totalUTF16: 1000, droppedSpans: [])
+        let c = ChatCitationFactory.citations(
+            scope: .chapter, sources: .default, counts: allCounts, wholeBookCoverage: coverage
+        )
+        #expect(!c.contains { $0.sourceKind == .wholeBookSpan })
+    }
+
+    @Test func chatMessage_carriesCitations() {
+        let cites = [ChatCitation(sourceKind: .scope, label: "Chapter")]
+        let msg = ChatMessage(role: .assistant, content: "hi", citations: cites)
+        #expect(msg.citations == cites)
+        // Default is empty (backward-compatible).
+        #expect(ChatMessage(role: .user, content: "q").citations.isEmpty)
+    }
+}

--- a/vreaderTests/Services/AI/ChatCitationFactoryTests.swift
+++ b/vreaderTests/Services/AI/ChatCitationFactoryTests.swift
@@ -78,3 +78,63 @@ struct ChatCitationFactoryTests {
         #expect(ChatMessage(role: .user, content: "q").citations.isEmpty)
     }
 }
+
+@Suite("ChatContextAssembler per-section retention (Feature #86 WI-6)")
+struct ChatContextAssemblerSectionRetentionTests {
+
+    /// Gate-4 WI-6: a partial clamp that keeps the Notes section but cuts the
+    /// Bookmarks section retains the note citation and drops only the bookmark
+    /// citation — not all-or-nothing.
+    @Test func partialClamp_retainsSurvivingSectionsOnly() {
+        let block = "[Your notes & marks]\nNotes:\n- mynote\n\n"
+            + String(repeating: "x", count: 200)
+            + "\n\nBookmarks:\n- mybm"
+        let cites = [
+            ChatCitation(sourceKind: .scope, label: "Chapter"),
+            ChatCitation(sourceKind: .note, label: "your notes"),
+            ChatCitation(sourceKind: .bookmark, label: "your bookmarks"),
+        ]
+        let a = ChatContextAssembler.assemble(
+            scopeText: "s", annotationBlock: block, citations: cites, maxUTF16: 60
+        )
+        #expect(a.bookContext.contains("Notes:"))          // notes section survived
+        #expect(!a.bookContext.contains("Bookmarks:"))     // bookmarks clamped off
+        let kinds = a.citations.map(\.sourceKind)
+        #expect(kinds.contains(.scope))                    // scope always kept
+        #expect(kinds.contains(.note))                     // its section survived → kept
+        #expect(!kinds.contains(.bookmark))                // its section cut → dropped
+    }
+
+    /// Gate-4 WI-6 round-3: a clamp that leaves only the section HEADER + bullet
+    /// marker but NO item content drops the citation (the first item must survive,
+    /// not merely the header — closes the `contains(header)` false positive).
+    @Test func headerSurvivesButItemCut_dropsCitation() {
+        let block = "[Your notes & marks]\nNotes:\n- mynote"
+        // The combined prefix exactly through the first bullet marker "- " — no
+        // item content fits.
+        let prefixThroughMarker = "s\n\n[Your notes & marks]\nNotes:\n- "
+        let cites = [
+            ChatCitation(sourceKind: .scope, label: "Chapter"),
+            ChatCitation(sourceKind: .note, label: "your notes"),
+        ]
+        let a = ChatContextAssembler.assemble(
+            scopeText: "s", annotationBlock: block, citations: cites,
+            maxUTF16: prefixThroughMarker.utf16.count
+        )
+        #expect(!a.citations.map(\.sourceKind).contains(.note))   // no item content → dropped
+        #expect(a.citations.map(\.sourceKind).contains(.scope))   // scope still kept
+    }
+
+    /// Scope text that EXACTLY matches the section line shape (`\nNotes:\n- …`)
+    /// must NOT false-retain a citation — retention searches only the annotation
+    /// block, never the scope text.
+    @Test func headerLineShapeInScopeContent_doesNotFalseRetain() {
+        let a = ChatContextAssembler.assemble(
+            scopeText: "A passage.\nNotes:\n- a fake bullet in the prose.\nThe end.",
+            annotationBlock: "",   // NO real annotation block
+            citations: [ChatCitation(sourceKind: .note, label: "your notes")],
+            maxUTF16: 10_000
+        )
+        #expect(!a.citations.contains { $0.sourceKind == .note })   // prose match doesn't count
+    }
+}


### PR DESCRIPTION
## Summary

- The per-reply provenance row: each AI Chat answer shows a "Drew on" row naming the scope + the reader's marks it used, with a spoiler-aware amber chip when whole-book retrieval reached pages ahead.

Part of feature #1453 (WI-6 of 6). Design: #1455.

## What Changed

- **`ChatMessage.citations`** (default `[]`).
- **`ChatCitationFactory`** — scope citation always; per-source citation only when ON && count>0; whole-book span citation (spoiler-aware, label by coverage). Provenance-first (scope-level labels, no fabricated chapter ordinals).
- **`AIChatViewModel`** — `pendingCitations`; `sendMessage` SNAPSHOTS them after the whole-book read but before the stream, stamping the reply (no mid-send mis-stamp).
- **`ReaderAICoordinator.refreshChatContext`** computes citations + feeds them through `ChatContextAssembler`, which retains only those whose section's first bullet survived the budget clamp (block-scoped, per-section).
- **`ChatCitationRow`** — the "Drew on" chips (a tiny `FlowRow` Layout), amber `· ahead` for whole-book spoilers, VoiceOver announces the spoiler state.

## Codex Audit

Gate-4, 3 rounds, ship-as-is. R1 1 High (stale-digest could stamp wholeBookSpan → gated on availableContext) + 2 Med (all-or-nothing retention → per-section; a11y spoiler) → R2/R3 refined the retention precision (header-present → first-bullet → block-scoped first-bullet). One residual edge (clamp inside a bullet's `[label]`) accepted with rationale at the round cap (narrow over-report; advisory provenance). Log: `.claude/codex-audits/feat-feature-86-wi-6-citations-audit.md`.

## Validation

- [x] Unit suites green: `ChatCitationFactoryTests` (scope/source/whole-book citations; partial-vs-complete; no fabricated ordinals), `ChatContextAssemblerSectionRetentionTests` (per-section + header-without-items + prose-false-match). No regression in `ChatContextAssemblerTests`/`ChatAnnotationContextTests`.
- [x] Version bumped: 3.50.5 → 3.50.6.

## Tier

Behavioral. The "Drew on" row's *content* depends on a real AI answer → provider-key-blocked for CU-free device verification (same as WI-1/WI-5b read effect); the factory + retention + a11y are unit-proven → keyed-verification.

## Type of Change

- [x] New feature (WI-6 of Feature #86)