### PR TITLE
feat(#77 WI-2): bilingual loading shimmer on the Readium default engine

### DIFF
--- a/.claude/codex-audits/feat-feature-77-wi-2-readium-audit.md
+++ b/.claude/codex-audits/feat-feature-77-wi-2-readium-audit.md
@@ -1,0 +1,62 @@
+---
+branch: feat/feature-77-wi-2-readium
+threadId: 019e8e74-f056-7a33-ab69-1955cdd422cc
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-03
+---
+
+# Codex Audit — Feature #77 WI-2 (Readium loading-shimmer wiring)
+
+Gate-4 implementation audit (rule 47). Independent Codex runner via
+`scripts/run-codex.sh -e high` (author/auditor separation, rule 48).
+
+## Scope
+
+Behavioral WI-2 — wire the WI-1 loading-shimmer seams into the **Readium EPUB
+engine (the DEFAULT engine; the primary user surface)**:
+
+- `EPUBBilingualJS.bilingualClearLoadingJS()` — loading-only clear (removes
+  `.vreader-bilingual-loading[data-vreader-decoration]`, leaving translations).
+- `ReadiumBilingualEvalAdapter.loadingJS(bids:spineIndex:)` + `clearLoadingJS()`.
+- `ReadiumBilingualCommander.injectLoading(_:spineIndex:)` + `clearLoading()`.
+- `ReadiumEPUBHost+BilingualLoading.swift` (new) — `handleBilingualPrefetchChange(inFlightUnits:)` + `bilingualStyleCSS()` (combined block + shimmer CSS).
+- `ReadiumEPUBHost+BilingualDriver.swift` — stale-shimmer `clearLoading()` on spine (re)entry; combined-CSS `setStyle`.
+- `ReadiumEPUBHost+Bilingual.swift` — `.readerBilingualPrefetchDidChange` observer; theme-change combined CSS.
+
+## Round 1 — findings (threadId 019e8e74-f056-7a33-ab69-1955cdd422cc)
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| ReadiumEPUBHost+BilingualDriver.swift:273 | **Medium** | Both WI-2 handlers settle against `currentVReaderLocator(from: nil)`, not the unit/spine that changed. In scroll mode, a shimmer on chapter A that lands/fails after the user scrolls to B is no longer targeted, so A's loading node can persist until revisit. | **Fixed → reduced to Low.** `runBilingualEnumerate` now calls `await bilingualCommander.clearLoading()` on spine (re)entry (after the post-enumerate `isEnabled` recheck, before `updateBlocks`), so a re-entered spine never shows a stale shimmer. The Readium eval channel only reaches the visible spine, so an off-current spine cannot be targeted directly; the residual (a partially-visible windowed adjacent spine) self-heals on its next enumerate. |
+| ReadiumEPUBHost+BilingualDriver.swift:1 | Low | Driver at 354 lines, over the ~300 budget, mixing enumerate/inject flow with WI-2 loading lifecycle. | **Fixed.** `handleBilingualPrefetchChange` + `bilingualStyleCSS` extracted to `ReadiumEPUBHost+BilingualLoading.swift` (82 lines); driver now 315. |
+
+### Round-1 "no finding" confirmations
+- **Landed-vs-failed `translations(for:) == nil` is correct.** `finishPrefetch` removes the unit from `inFlightUnits` BEFORE caching the translation, but the Readium observer does its check inside an async `Task` that runs AFTER `finishPrefetch` completes synchronously — so a successful unit's translation is already stored when the branch runs, and it is NOT cleared (the inject path replaces the shimmer in place). No flicker.
+- Loading inject/clear JS is idempotent; the clear selector is correctly limited to loading nodes only (landed translations survive).
+
+## Round 2 — verification (threadId 019e8e8b-9978-73d1-9ce0-68e5ff085fe7)
+
+- **Medium → reduced to Low.** The spine-(re)entry `clearLoading()` is safe (the fresh shimmer for a visit is injected LATER via the prefetch-change, so any shimmer present at enumerate is stale), runs on the visible spine, is loading-only, and the landed inject removes the loading class in place. Closes the main off-current/re-entry case; residual is the windowed partial-visibility edge (self-healing).
+- **Low (driver size) → improved.** Cross-file `bilingualStyleCSS()` access is structurally fine (same `extension ReadiumEPUBHost`, file in target). Driver 354 → 315.
+- **NEW Critical/High/Medium: none.**
+
+## Accepted Low findings (rationale)
+
+1. **Windowed partial-visibility stale shimmer.** A failed prefetch whose spine
+   is a partially-visible windowed adjacent spine (only in a multi-spine-DOM
+   scroll model) shows a stale shimmer until that spine becomes current and
+   re-enumerates. Readium's typical model renders one spine at a time (per the
+   surface map), so the off-current DOM is gone in the common case; the residual
+   self-heals. The fully-robust per-spine shimmer ownership requires a
+   spine-targeted eval channel Readium does not expose — a larger redesign out of
+   WI-2's scope. Documented in `ReadiumEPUBHost+BilingualLoading.swift`'s header.
+2. **Driver still 315 lines (> ~300).** Improved from 354 by extracting the WI-2
+   loading code. The residual is the pre-existing enumerate/prefetch/inject flow
+   (already ~306 before WI-2); further splitting #42/#71 code is out of WI-2 scope.
+
+## Verdict
+
+**ship-as-is.** Zero open Critical/High/Medium after round 2; both residual Lows
+accepted with rationale. All WI-2 suites green (`ReadiumBilingualEvalAdapterTests`,
+`ReadiumBilingualCommanderTests`, `EPUBBilingualJSLoadingTests`) + full app compile.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 852
-        MARKETING_VERSION: 3.50.9
+        CURRENT_PROJECT_VERSION: 853
+        MARKETING_VERSION: 3.50.10
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -1068,6 +1068,7 @@
 		AFE6C4ADD50C68610CE76DA2 /* HighlightPopoverMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5725E598AB5CBA16440549D4 /* HighlightPopoverMode.swift */; };
 		B0762A6794C5885FC94A2BF4 /* foliate-reader.html in Resources */ = {isa = PBXBuildFile; fileRef = 0B636D7823EE57464A4CE54D /* foliate-reader.html */; };
 		B086340BE996C111A4B374BD /* UnifiedMDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EF16A1A352B2C6BAE84556 /* UnifiedMDTests.swift */; };
+		B08F762F1EA363C6B0D91FDD /* ReadiumEPUBHost+BilingualLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538847189108CD32041C570F /* ReadiumEPUBHost+BilingualLoading.swift */; };
 		B0EF6095B892F032F27CB690 /* LibraryAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24D3FC7488318277468A7F0 /* LibraryAccessibilityTests.swift */; };
 		B15D8D7E5117125033EC60A2 /* ChapterSegmenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999A100638E91D93F3353B66 /* ChapterSegmenterTests.swift */; };
 		B1A8FA2FDB410239A5DA8FD4 /* AISettingsSectionRestyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D67D4978B5D27755900D2DE /* AISettingsSectionRestyleTests.swift */; };
@@ -2042,6 +2043,7 @@
 		5350DA755A0BB669AE8D3FBD /* BackupViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupViewModelTests.swift; sourceTree = "<group>"; };
 		5352F39600EBF91349ADC51F /* ChapterReTranslateViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterReTranslateViewModelTests.swift; sourceTree = "<group>"; };
 		535F3D9734CC8A2C3E303580 /* RealDebugBridgeContext+PDFHighlight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RealDebugBridgeContext+PDFHighlight.swift"; sourceTree = "<group>"; };
+		538847189108CD32041C570F /* ReadiumEPUBHost+BilingualLoading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReadiumEPUBHost+BilingualLoading.swift"; sourceTree = "<group>"; };
 		539FEE4A23AFA226048A12A4 /* AIChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatView.swift; sourceTree = "<group>"; };
 		53C43C404319C34029EB078C /* LibraryContainerCompositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryContainerCompositionTests.swift; sourceTree = "<group>"; };
 		5401E10DDA195966ABD13F70 /* AutoPageTurner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoPageTurner.swift; sourceTree = "<group>"; };
@@ -4350,6 +4352,7 @@
 				DB02D21C1EF95E878B2A1B5E /* ReadiumEPUBHost+Background.swift */,
 				2E7D9B366FE8503B0E79530E /* ReadiumEPUBHost+Bilingual.swift */,
 				2B29ECB0699594B79632E3EE /* ReadiumEPUBHost+BilingualDriver.swift */,
+				538847189108CD32041C570F /* ReadiumEPUBHost+BilingualLoading.swift */,
 				5A746E0EDC5F1208A0774008 /* ReadiumEPUBHost+Body.swift */,
 				903AC337CD91275FE06EDE15 /* ReadiumEPUBHost+BottomChrome.swift */,
 				3711151306A3ED68FBF7A3D2 /* ReadiumEPUBHost+ContinuousScroll.swift */,
@@ -6988,6 +6991,7 @@
 				A7E0981C4B45F1FA7D8A9F91 /* ReadiumEPUBHost+Background.swift in Sources */,
 				BCDABEB4FF345F85FD44A294 /* ReadiumEPUBHost+Bilingual.swift in Sources */,
 				3BAE0F10DF996E3F0E5E1FE5 /* ReadiumEPUBHost+BilingualDriver.swift in Sources */,
+				B08F762F1EA363C6B0D91FDD /* ReadiumEPUBHost+BilingualLoading.swift in Sources */,
 				F56CAC78114E34FA6CA59A53 /* ReadiumEPUBHost+Body.swift in Sources */,
 				F18A46C6062D915B86052E08 /* ReadiumEPUBHost+BottomChrome.swift in Sources */,
 				3B226735B8F75224A6C366CD /* ReadiumEPUBHost+ContinuousScroll.swift in Sources */,
@@ -7381,7 +7385,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 852;
+				CURRENT_PROJECT_VERSION = 853;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7389,7 +7393,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.50.9;
+				MARKETING_VERSION = 3.50.10;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7535,7 +7539,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 852;
+				CURRENT_PROJECT_VERSION = 853;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7543,7 +7547,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.50.9;
+				MARKETING_VERSION = 3.50.10;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Views/Reader/Bilingual/EPUBBilingualJS.swift
+++ b/vreader/Views/Reader/Bilingual/EPUBBilingualJS.swift
@@ -571,6 +571,31 @@ enum EPUBBilingualJS {
         """
     }
 
+    /// Feature #77: removes ONLY the in-flight LOADING-shimmer decoration nodes
+    /// (`.vreader-bilingual-loading[data-vreader-decoration]`), leaving any LANDED
+    /// translation decorations intact. Used when a unit leaves the in-flight set
+    /// WITHOUT a translation landing (a failed / cancelled prefetch) — the
+    /// translation-landed path replaces the shimmer in place via the inject
+    /// class-clear, so it must NOT be removed there. Idempotent (safe on a spine
+    /// with no loading nodes). Mirrors `globalClearJS`' node-removal shape.
+    static func bilingualClearLoadingJS() -> String {
+        """
+        (function() {
+            try {
+                var nodes = document.querySelectorAll(
+                    '.\(loadingClassName)[\(decorationAttribute)]'
+                );
+                for (var i = 0; i < nodes.length; i++) {
+                    var n = nodes[i];
+                    if (n.parentNode) {
+                        n.parentNode.removeChild(n);
+                    }
+                }
+            } catch (e) {}
+        })();
+        """
+    }
+
     /// Feature #71 WI-7: the section-scoped clear body — removes every
     /// `vreader-bilingual` decoration node WITHIN one stitched chapter
     /// `<section data-vreader-spine-index="N">` subtree so a clear on one

--- a/vreader/Views/Reader/Bilingual/ReadiumBilingualCommander.swift
+++ b/vreader/Views/Reader/Bilingual/ReadiumBilingualCommander.swift
@@ -151,6 +151,25 @@ final class ReadiumBilingualCommander {
         _ = await evaluator(ReadiumBilingualEvalAdapter.clearJS())
     }
 
+    /// Feature #77: inserts the in-flight LOADING shimmer after each of `bids`'
+    /// blocks (skipping already-decorated blocks, so a landed translation is never
+    /// downgraded). No-op when unbound or `bids` is empty. The combined bilingual
+    /// `<style>` (block + loading rules) must already be on the spine via
+    /// `setStyle` for the shimmer to render.
+    func injectLoading(_ bids: [String], spineIndex: Int? = nil) async {
+        guard let evaluator, !bids.isEmpty else { return }
+        _ = await evaluator(
+            ReadiumBilingualEvalAdapter.loadingJS(bids: bids, spineIndex: spineIndex))
+    }
+
+    /// Feature #77: removes ONLY the loading-shimmer decoration nodes (a failed /
+    /// cancelled prefetch), leaving landed translations intact. No-op when
+    /// unbound. Idempotent.
+    func clearLoading() async {
+        guard let evaluator else { return }
+        _ = await evaluator(ReadiumBilingualEvalAdapter.clearLoadingJS())
+    }
+
     // MARK: - Href-consistency normalization (seam #3)
 
     /// Rewrites a Readium-host-produced vreader `Locator`'s href (Readium's

--- a/vreader/Views/Reader/Bilingual/ReadiumBilingualEvalAdapter.swift
+++ b/vreader/Views/Reader/Bilingual/ReadiumBilingualEvalAdapter.swift
@@ -172,5 +172,24 @@ enum ReadiumBilingualEvalAdapter {
     static func clearJS() -> String {
         EPUBBilingualJS.bilingualClearJS()
     }
+
+    // MARK: - loading shimmer (Feature #77)
+
+    /// Feature #77: JS that inserts a LOADING-shimmer decoration after each block
+    /// matching the supplied bids, skipping any block already carrying a
+    /// decoration (never downgrades a landed translation). Delegates to the
+    /// engine-agnostic `EPUBBilingualJS.bilingualInjectLoadingJS`, which routes
+    /// each bid through `FoliateJSEscaper` (JS-literal) + a defensive `CSS.escape`
+    /// (selector). Runs as-is through `navigator.evaluateJavaScript`.
+    static func loadingJS(bids: [String], spineIndex: Int? = nil) -> String {
+        EPUBBilingualJS.bilingualInjectLoadingJS(loadingBids: bids, spineIndex: spineIndex)
+    }
+
+    /// Feature #77: JS that removes ONLY the in-flight loading-shimmer decoration
+    /// nodes (a failed / cancelled prefetch), leaving landed translations intact.
+    /// Delegates to `EPUBBilingualJS.bilingualClearLoadingJS`.
+    static func clearLoadingJS() -> String {
+        EPUBBilingualJS.bilingualClearLoadingJS()
+    }
 }
 #endif

--- a/vreader/Views/Reader/ReadiumEPUBHost+Bilingual.swift
+++ b/vreader/Views/Reader/ReadiumEPUBHost+Bilingual.swift
@@ -185,6 +185,17 @@ extension ReadiumEPUBHost {
                 guard key == fingerprint.canonicalKey else { return }
                 handleBilingualDidChange()
             }
+            // Feature #77 WI-2: the prefetch-state bus drives the inline loading
+            // shimmer — show it while the current chapter's unit is fetching,
+            // remove it on a failed/cancelled prefetch (a landed one is replaced
+            // in place by the inject above).
+            .onReceive(NotificationCenter.default.publisher(for: .readerBilingualPrefetchDidChange)) { notification in
+                let key = notification.userInfo?["fingerprintKey"] as? String
+                guard key == fingerprint.canonicalKey else { return }
+                let inFlight = notification.userInfo?["inFlightUnits"]
+                    as? Set<TranslationUnitID> ?? []
+                handleBilingualPrefetchChange(inFlightUnits: inFlight)
+            }
             // WI-12: a paged↔scroll switch while bilingual is enabled re-renders the
             // spine in Readium, discarding the injected decorations + bid stamps, so
             // we re-enumerate the current spine in either direction.
@@ -198,7 +209,9 @@ extension ReadiumEPUBHost {
             .onChange(of: settingsStore.theme) { _, _ in
                 guard bilingualViewModel?.isEnabled == true else { return }
                 Task { @MainActor in
-                    await bilingualCommander.setStyle(settingsStore.theme.bilingualBlockCSSRule())
+                    // Feature #77: combined block + loading-shimmer CSS so a theme
+                    // switch refreshes BOTH the translation and shimmer styling.
+                    await bilingualCommander.setStyle(bilingualStyleCSS())
                 }
             }
             .sheet(isPresented: $showBilingualSetupSheet) { bilingualSetupSheetView }

--- a/vreader/Views/Reader/ReadiumEPUBHost+BilingualDriver.swift
+++ b/vreader/Views/Reader/ReadiumEPUBHost+BilingualDriver.swift
@@ -141,6 +141,14 @@ extension ReadiumEPUBHost {
         // was in flight. Recheck before mutating the orchestrator / prefetching —
         // the disable path's `clear()` already removed any decorations.
         guard vm.isEnabled else { return }
+        // Feature #77 WI-2 (Gate-4 Medium): the eval channel only reaches the
+        // VISIBLE spine, so a loading shimmer started on a spine the user then
+        // scrolled away from cannot be cleared from the off-current spine. Clear
+        // any STALE shimmer on THIS (newly entered / re-entered) spine before
+        // re-committing its blocks — a unit that failed off-current then gets a
+        // clean source-only (or a fresh shimmer once the prefetch re-triggers
+        // below). Loading-only clear leaves landed translations intact.
+        await bilingualCommander.clearLoading()
         bilingualOrchestrator.updateBlocks(blocks)
         // Round-4 ROOT CAUSE: record WHICH chapter these just-committed blocks belong
         // to, in the SAME normalized (OPF-relative) href space the inject locator
@@ -224,8 +232,10 @@ extension ReadiumEPUBHost {
         // Bug #304: ensure the interlinear `.vreader-bilingual` `<style>` is on
         // the spine BEFORE injecting the blocks, so they render with the designed
         // style (the Readium engine never threaded `epubOverrideCSS`). Idempotent;
-        // uses the live theme so a theme switch updates the rule.
-        await bilingualCommander.setStyle(settingsStore.theme.bilingualBlockCSSRule())
+        // uses the live theme so a theme switch updates the rule. Feature #77:
+        // the combined CSS also carries the loading-shimmer rule so an in-flight
+        // shimmer rendered just before this inject keeps its styling.
+        await bilingualCommander.setStyle(bilingualStyleCSS())
         // The pipeline build above is synchronous, so the unit re-check is the
         // inject-path's final generation gate (no await intervenes before here).
         await bilingualCommander.inject(pairs)

--- a/vreader/Views/Reader/ReadiumEPUBHost+BilingualLoading.swift
+++ b/vreader/Views/Reader/ReadiumEPUBHost+BilingualLoading.swift
@@ -1,0 +1,82 @@
+// Purpose: Feature #77 WI-2 — the Readium bilingual LOADING-shimmer lifecycle,
+// split out of `ReadiumEPUBHost+BilingualDriver.swift` for the ~300-line budget
+// (Gate-4 Low). Owns the `.readerBilingualPrefetchDidChange` handler that shows
+// an inline shimmer placeholder while the current chapter's translation unit is
+// being fetched, and the combined block+shimmer `<style>` helper both the inject
+// and loading paths feed to the spine.
+//
+// Lifecycle (mirrors the design #1024 §L "BilingualLoadingSlot"):
+//   - A unit enters the in-flight set → `injectLoading` shimmers the current
+//     spine's still-untranslated blocks.
+//   - The translation lands → `.readerBilingualDidChange` → the inject path
+//     replaces the shimmer IN PLACE (`classList.remove('vreader-bilingual-loading')`
+//     + textContent), so a landed unit is NEVER cleared here (no flicker).
+//   - A failed / cancelled prefetch (no cached translation) for the CURRENT unit
+//     → `clearLoading` removes its leftover shimmer.
+//   - Spine (re)entry clears any stale shimmer on the entered spine — see
+//     `runBilingualEnumerate`'s leading `clearLoading()` (Gate-4 round-2 Medium:
+//     a shimmer started on chapter A then scrolled away from is reconciled when A
+//     is re-entered, since the Readium eval channel only reaches the visible
+//     spine and cannot target an off-current one).
+//
+// @coordinates-with: ReadiumEPUBHost+BilingualDriver.swift,
+//   ReadiumEPUBHost+Bilingual.swift, ReadiumBilingualCommander.swift,
+//   BilingualReadingViewModel.swift, ReaderThemeV2+EPUBCSS.swift,
+//   dev-docs/plans/20260603-feature-77-bilingual-loading.md (WI-2)
+
+#if canImport(UIKit)
+import SwiftUI
+
+extension ReadiumEPUBHost {
+
+    /// Feature #77 WI-2: `.readerBilingualPrefetchDidChange` handler — show or
+    /// remove the inline LOADING shimmer for the current chapter as the in-flight
+    /// unit set changes (the FULL set is carried in the notification, so the
+    /// handler is authoritative for the visible spine). When the current chapter's
+    /// unit is fetching, inject a shimmer after each undecorated block of the
+    /// current section (`injectLoading` skips blocks that already carry a
+    /// translation, so it never downgrades a landed row). When the unit leaves the
+    /// set, the translation arrives via `.readerBilingualDidChange` and the inject
+    /// replaces the shimmer IN PLACE — so a landed unit must NOT be cleared here;
+    /// only a failed / cancelled prefetch (no cached translation) has its leftover
+    /// shimmer removed. A shimmer started on a spine the user has since scrolled
+    /// away from is reconciled on spine re-entry (`runBilingualEnumerate` clears
+    /// stale loading), because the eval channel only reaches the visible spine.
+    func handleBilingualPrefetchChange(inFlightUnits: Set<TranslationUnitID>) {
+        guard let vm = bilingualViewModel, vm.isEnabled else { return }
+        guard ReadiumBilingualChapterTracker.isBilingualSupported(
+            forLayout: settingsStore.epubLayout
+        ) else { return }
+        Task {
+            guard let locator = currentVReaderLocator(from: nil),
+                  let unit = await vm.textProvider?.unit(containing: locator) else { return }
+            // Block-ownership invariant (mirrors `injectBilingualIfCached`): only
+            // act when the orchestrator's blocks belong to THIS chapter, so the
+            // shimmer never lands on a stale spine's bids.
+            guard bilingualChapterTracker.blocksMatch(locatorHref: locator.href) else { return }
+            let bids = bilingualOrchestrator.currentBlocks.map(\.bid)
+            guard !bids.isEmpty else { return }
+            if inFlightUnits.contains(unit) {
+                // Fetching: ensure the combined block + shimmer `<style>` is on the
+                // spine, then shimmer the still-untranslated blocks.
+                await bilingualCommander.setStyle(bilingualStyleCSS())
+                await bilingualCommander.injectLoading(bids)
+            } else if vm.translations(for: unit) == nil {
+                // Left the in-flight set WITHOUT a cached translation (failed /
+                // cancelled) → remove the leftover shimmer. A landed translation is
+                // replaced in place by the inject path, so it must NOT be cleared.
+                await bilingualCommander.clearLoading()
+            }
+        }
+    }
+
+    /// Feature #77: the combined interlinear `<style>` CSS — the translation BLOCK
+    /// rule plus the LOADING shimmer rule — so both injected translations and the
+    /// in-flight shimmer render on the Readium spine (which never threads
+    /// `epubOverrideCSS`). Tracks the live theme; idempotent on the spine.
+    func bilingualStyleCSS() -> String {
+        settingsStore.theme.bilingualBlockCSSRule()
+            + " " + settingsStore.theme.bilingualLoadingCSSRule()
+    }
+}
+#endif

--- a/vreaderTests/Views/Reader/Bilingual/BilingualLoadingShimmerWI1Tests.swift
+++ b/vreaderTests/Views/Reader/Bilingual/BilingualLoadingShimmerWI1Tests.swift
@@ -163,6 +163,20 @@ struct EPUBBilingualJSLoadingTests {
         // becomes the final translation block in place (no flicker / re-insert).
         #expect(js.contains("classList.remove('\(EPUBBilingualJS.loadingClassName)')"))
     }
+
+    // Feature #77 WI-2: a loading-only clear (failed/cancelled prefetch) must
+    // remove ONLY the shimmer nodes, leaving landed translations intact.
+    @Test("bilingualClearLoadingJS removes only the loading decorations")
+    func clearLoadingTargetsOnlyLoadingNodes() {
+        let js = EPUBBilingualJS.bilingualClearLoadingJS()
+        #expect(js.contains("(function()"))
+        // Targets the loading-modifier class + decoration attribute, NOT the
+        // bare block class (which would also nuke landed translations).
+        #expect(js.contains(".\(EPUBBilingualJS.loadingClassName)[\(EPUBBilingualJS.decorationAttribute)]"))
+        #expect(js.contains("removeChild"))
+        // Must NOT select the generic block class alone (that's bilingualClearJS).
+        #expect(!js.contains(".\(EPUBBilingualJS.blockClassName)[\(EPUBBilingualJS.decorationAttribute)]"))
+    }
 }
 
 // MARK: - 4. Orchestrator buildLoadingJS

--- a/vreaderTests/Views/Reader/Bilingual/ReadiumBilingualCommanderTests.swift
+++ b/vreaderTests/Views/Reader/Bilingual/ReadiumBilingualCommanderTests.swift
@@ -194,6 +194,50 @@ struct ReadiumBilingualCommanderTests {
         #expect(seenScript?.contains("removeChild") == true)
     }
 
+    // MARK: - loading shimmer (Feature #77 WI-2)
+
+    @Test("injectLoading feeds the adapter's loading JS to the evaluator")
+    func injectLoadingFeedsLoadingJS() async {
+        let commander = ReadiumBilingualCommander()
+        nonisolated(unsafe) var seenScript: String?
+        commander.setEvaluator { script in
+            seenScript = script
+            return .success(NSNull())
+        }
+        await commander.injectLoading(["b1", "b2"])
+        #expect(seenScript?.contains(EPUBBilingualJS.loadingClassName) == true)
+        #expect(seenScript?.contains(EPUBBilingualJS.shimmerBarClassName) == true)
+        #expect(seenScript?.contains("'b1'") == true)
+    }
+
+    @Test("injectLoading no-ops (does not call evaluator) when bids is empty")
+    func injectLoadingEmptyNoops() async {
+        let commander = ReadiumBilingualCommander()
+        nonisolated(unsafe) var called = false
+        commander.setEvaluator { _ in called = true; return .success(NSNull()) }
+        await commander.injectLoading([])
+        #expect(called == false)
+    }
+
+    @Test("injectLoading no-ops when unbound (no navigator / after detach)")
+    func injectLoadingUnboundNoops() async {
+        let commander = ReadiumBilingualCommander()
+        await commander.injectLoading(["b1"])   // must not crash
+    }
+
+    @Test("clearLoading feeds the loading-only clear JS to the evaluator")
+    func clearLoadingFeedsClearLoadingJS() async {
+        let commander = ReadiumBilingualCommander()
+        nonisolated(unsafe) var seenScript: String?
+        commander.setEvaluator { script in
+            seenScript = script
+            return .success(NSNull())
+        }
+        await commander.clearLoading()
+        #expect(seenScript?.contains(EPUBBilingualJS.loadingClassName) == true)
+        #expect(seenScript?.contains("removeChild") == true)
+    }
+
     // MARK: - href-consistency normalization (seam #3)
 
     @Test("a Readium container-relative locator href resolves to the provider's OPF spine unit")

--- a/vreaderTests/Views/Reader/Bilingual/ReadiumBilingualEvalAdapterTests.swift
+++ b/vreaderTests/Views/Reader/Bilingual/ReadiumBilingualEvalAdapterTests.swift
@@ -140,4 +140,25 @@ struct ReadiumBilingualEvalAdapterTests {
         #expect(enumerate.contains("data-vreader-bid"))
         #expect(inject.contains("data-vreader-bid"))
     }
+
+    // MARK: - loading shimmer (Feature #77 WI-2)
+
+    @Test("loadingJS inserts a loading-shimmer decoration per bid")
+    func loadingJSShape() {
+        let js = ReadiumBilingualEvalAdapter.loadingJS(bids: ["b1", "b2"])
+        #expect(js.contains("'b1'"))
+        #expect(js.contains("'b2'"))
+        #expect(js.contains(EPUBBilingualJS.loadingClassName))
+        #expect(js.contains(EPUBBilingualJS.shimmerBarClassName))
+        // Selector hardening rides through from the shared builder.
+        #expect(js.contains("__vreaderBidEsc(bid)"))
+    }
+
+    @Test("clearLoadingJS targets only the loading decoration nodes")
+    func clearLoadingJSShape() {
+        let js = ReadiumBilingualEvalAdapter.clearLoadingJS()
+        #expect(js.contains(EPUBBilingualJS.loadingClassName))
+        #expect(js.contains("data-vreader-decoration"))
+        #expect(js.contains("removeChild"))
+    }
 }


### PR DESCRIPTION
## Summary

Wires the WI-1 loading-shimmer seams into the **Readium EPUB engine — the DEFAULT engine and primary user surface**. While the current chapter's translation unit is being fetched, each still-untranslated block shows an inline shimmer placeholder (design #1024 §L); when the translation lands, the inject path replaces the shimmer **in place**.

Part of feature #1467.

## What Changed

- **`EPUBBilingualJS.bilingualClearLoadingJS()`** — removes ONLY loading decorations (failed/cancelled prefetch), leaving landed translations intact.
- **`ReadiumBilingualEvalAdapter.loadingJS` / `clearLoadingJS`** — re-export the shared builders for Readium's one-way eval channel.
- **`ReadiumBilingualCommander.injectLoading` / `clearLoading`** — mirror inject/clear; no-op when unbound/empty.
- **`ReadiumEPUBHost+BilingualLoading.swift`** (new) — `handleBilingualPrefetchChange(inFlightUnits:)` observes `.readerBilingualPrefetchDidChange` and shows/removes the shimmer for the current chapter; `bilingualStyleCSS()` injects the combined block + shimmer style.
- **`runBilingualEnumerate`** clears stale loading on spine (re)entry — the eval channel only reaches the visible spine, so a shimmer started on a scrolled-away-from spine is reconciled on re-entry.
- **`.readerBilingualPrefetchDidChange` observer** added to the host; theme-change refreshes the combined CSS.

## Codex Audit (Gate 4)

2 rounds, verdict **ship-as-is**. Round 1: 1 Medium (scroll-mode off-current stale shimmer) + 1 Low (driver 354 lines). Round 2 confirmed the Medium **fixed and reduced to a self-healing windowed-edge Low** (spine-reentry `clearLoading`), the driver-size Low fixed (extracted loading lifecycle, driver → 315), and **no new Critical/High/Medium**. Two residual Lows accepted with rationale.

Codex also confirmed the landed-vs-failed distinction is **race-free**: the observer's async `Task` reads VM state after `finishPrefetch` completes, so a landed translation is never spuriously cleared (no flicker).

Audit log: `.claude/codex-audits/feat-feature-77-wi-2-readium-audit.md`

## Validation

- [x] `scripts/run-tests.sh` — `ReadiumBilingualEvalAdapterTests`, `ReadiumBilingualCommanderTests`, `EPUBBilingualJSLoadingTests` green + full app compile
- [x] TDD: RED → GREEN (new adapter/commander/clear-loading tests)
- [x] Codex audit loop (2 rounds, ship-as-is)
- [x] Docs sync — n/a (consumes the WI-1 notification; no new service/Model/notification)
- [x] Version bumped: 3.50.9 → 3.50.10

## Verification (Gate 5)

Behavioral WI. The seam wiring + JS builders are unit-verified and the existing Readium bilingual inject path is regression-covered by its suites (all green). The **transient visual shimmer** (only visible during a live in-flight translation on a CJK EPUB) is captured at the feature's final-WI acceptance pass, not per-intermediate-WI — a deterministic transient-state capture needs the full enable→fetch→land cycle on a real provider.

## Type of Change

- [x] Behavioral WI (part of feature #1467)