### PR TITLE
feat(#91 WI-2): AIProvider tool-use capability seam (foundational)

### DIFF
--- a/.claude/codex-audits/feat-feature-91-wi-2-provider-seam-audit.md
+++ b/.claude/codex-audits/feat-feature-91-wi-2-provider-seam-audit.md
@@ -1,0 +1,54 @@
+---
+branch: feat/feature-91-wi-2-provider-seam
+threadId: 019e9097-7a7f-7980-9b32-f8e5748afe40
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-03
+---
+
+# Codex Audit — Feature #91 WI-2 (AIProvider tool-use capability seam)
+
+Gate-4 implementation audit (rule 47). Independent Codex runner via
+`scripts/run-codex.sh -e high` (author/auditor separation, rule 48).
+
+## Scope
+
+Foundational WI-2 — the `AIProvider` tool-use capability seam (no real provider
+impl yet):
+
+- `vreader/Services/AI/AIProvider.swift` — two protocol REQUIREMENTS
+  (`var supportsToolUse: Bool { get }`, `func sendToolRequest(_:) async throws -> AIToolTurn`)
+  with default impls in an `extension AIProvider` (`false` / throws
+  `AIError.toolUseUnsupported`). A provider opts IN by overriding both.
+- `vreader/Services/AI/AIError.swift` — `case toolUseUnsupported` + message.
+- `vreader/Utils/ErrorMessageAuditor.swift` — the new case in the exhaustive `sanitizeAI` switch.
+- `vreaderTests/Services/AI/AIProviderToolSeamTests.swift` (new).
+
+## Round 1 — findings (threadId 019e9097-7a7f-7980-9b32-f8e5748afe40)
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| AIProviderToolSeamTests.swift:66 | **Medium** | The suite exercised the override only on the CONCRETE `ToolProvider`, not through `any AIProvider` — so the classic protocol-extension dispatch trap (would a default in an extension statically dispatch?) wasn't pinned by tests. | **Fixed (test-only).** The dispatch-critical tests now bind `let provider: any AIProvider = …` and assert: a `NonToolProvider` existential → `false` + throws `.toolUseUnsupported`; a `ToolProvider` existential → `true` + returns its stubbed `AIToolTurn` (the override wins through the existential). |
+
+**No production-code findings.** Codex confirmed the seam is shaped correctly for
+dynamic dispatch (both members are protocol REQUIREMENTS, so the override is
+witness-table-dispatched even through `any AIProvider`), existing conformers/stubs
+inherit the defaults unchanged, fail-closed via `.toolUseUnsupported` is
+appropriate, and the `AIError` / `ErrorMessageAuditor` additions are complete.
+
+## Round 2 — verification
+
+The Medium was a test-coverage gap on an already-correct production seam. The fix
+adds the exact existential-dispatch tests Codex requested; they **pass**
+(`overridingDispatchesThroughExistential` asserts a `ToolProvider` held as
+`any AIProvider` returns `true` + its turn, NOT the default — i.e. the override is
+dynamically dispatched). The passing existential run IS the verification the
+finding asked for; no production logic changed, so no separate Codex re-audit was
+needed for a test-only addition that demonstrably exercises the dispatch path.
+
+## Verdict
+
+**ship-as-is.** Zero open Critical/High/Medium. `AIProviderToolSeamTests` green,
+including the existential-dispatch assertions. (Compile fix: the new `AIError`
+case was added to the exhaustive `ErrorMessageAuditor.sanitizeAI` switch — the
+only other exhaustive `AIError` switch in the codebase; the build confirms no others.)

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 862
-        MARKETING_VERSION: 3.51.6
+        CURRENT_PROJECT_VERSION: 863
+        MARKETING_VERSION: 3.51.7
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -1172,6 +1172,7 @@
 		C1B568E4B16572EE4FA6E4E3 /* Feature40TTSSentenceHighlightVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 903D9FCA142155D5B65A5C18 /* Feature40TTSSentenceHighlightVerificationTests.swift */; };
 		C1F29CC2BCCD3BA426DEB952 /* BilingualAttributedStringComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1923055CD55D02FA17D295ED /* BilingualAttributedStringComposer.swift */; };
 		C205A1413A59C630A10ECEB7 /* BookContentCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF50D372D73575F047EF0991 /* BookContentCacheTests.swift */; };
+		C219E48A62C464DDB48DF9C0 /* AIProviderToolSeamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B38EA8570FCCBF0F7E3B2E7 /* AIProviderToolSeamTests.swift */; };
 		C229986578226ECF2297D01A /* BookSourceSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E358C3A06D7CC0958A40876 /* BookSourceSearchView.swift */; };
 		C243AD36AE83E921EA70EEDD /* MDTextExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D9F31A3F96B73C8E3653E6 /* MDTextExtractor.swift */; };
 		C28C9220D25AECBA8CAF8EB7 /* XCUITestMockSpeechSynthesizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87772C29A5D590FB8679B7E7 /* XCUITestMockSpeechSynthesizerTests.swift */; };
@@ -1710,6 +1711,7 @@
 		1A7668891CD8BA0B6DED7A25 /* LibraryCardTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryCardTokens.swift; sourceTree = "<group>"; };
 		1ABFAC14455C6F7DE43C1ABC /* overlayer.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = overlayer.js; sourceTree = "<group>"; };
 		1B311C3A88BD6DC42005FE1B /* ExportedAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportedAnnotation.swift; sourceTree = "<group>"; };
+		1B38EA8570FCCBF0F7E3B2E7 /* AIProviderToolSeamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderToolSeamTests.swift; sourceTree = "<group>"; };
 		1BA8C0E6A9B8EF3E48771286 /* PersistenceActor+ReadingHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+ReadingHistory.swift"; sourceTree = "<group>"; };
 		1BF38242BD73D1545DCA858D /* EPUBReaderContainerView+ContinuousBilingualLoading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EPUBReaderContainerView+ContinuousBilingualLoading.swift"; sourceTree = "<group>"; };
 		1C07D184EF0E90D5F2DF7A36 /* EPUBWebViewBridgeJS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBWebViewBridgeJS.swift; sourceTree = "<group>"; };
@@ -5142,6 +5144,7 @@
 				FFD1AE78FBFF38B3616352FF /* AIConsentManagerTests.swift */,
 				D1368D4DA7FCD1EC48778531 /* AIContextExtractorScopedTests.swift */,
 				20237121BB4ACF22C0818BA4 /* AIContextExtractorTests.swift */,
+				1B38EA8570FCCBF0F7E3B2E7 /* AIProviderToolSeamTests.swift */,
 				B92E2A0146CEC96DB224FE99 /* AIReaderAvailabilityPerProfileTests.swift */,
 				15C1B40888B5C8213559B111 /* AIRequestCacheKeyTests.swift */,
 				C5CB5C659CC573EF448F0992 /* AIResponseCacheTests.swift */,
@@ -5851,6 +5854,7 @@
 				37B8708ABD85D7635B98995F /* AIEditorContextTests.swift in Sources */,
 				50CE60AB8A7F591C45CEB976 /* AIProviderEditSheetSaveSuccessTests.swift in Sources */,
 				BB03511CFAB402BC18C393B7 /* AIProviderPickerViewModelTests.swift in Sources */,
+				C219E48A62C464DDB48DF9C0 /* AIProviderToolSeamTests.swift in Sources */,
 				43668756F842A8C891FCC1BF /* AIReaderAvailabilityPerProfileTests.swift in Sources */,
 				4E2207CD7F48BCE945A0971C /* AIReaderIntegrationTests.swift in Sources */,
 				4597AB9A7B4EC164B6F67B67 /* AIReaderPanelDebugBridgeAIActionTests.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7401,7 +7401,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 862;
+				CURRENT_PROJECT_VERSION = 863;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7409,7 +7409,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.6;
+				MARKETING_VERSION = 3.51.7;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7555,7 +7555,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 862;
+				CURRENT_PROJECT_VERSION = 863;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7563,7 +7563,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.6;
+				MARKETING_VERSION = 3.51.7;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Services/AI/AIError.swift
+++ b/vreader/Services/AI/AIError.swift
@@ -41,6 +41,12 @@ enum AIError: Error, LocalizedError, Sendable, Equatable {
     /// No cached response found. Internal only — not user-facing.
     case cacheMiss
 
+    /// Feature #91: the active provider does not support tool/function calling,
+    /// so the agentic loop cannot run. The chat falls back to the non-tool path —
+    /// this is the default `AIProvider.sendToolRequest` behavior for any provider
+    /// that doesn't override it.
+    case toolUseUnsupported
+
     var errorDescription: String? {
         switch self {
         case .featureDisabled:
@@ -64,6 +70,8 @@ enum AIError: Error, LocalizedError, Sendable, Equatable {
             return "Received an invalid response from the AI provider."
         case .cacheMiss:
             return "No cached response available."
+        case .toolUseUnsupported:
+            return "This AI provider does not support tool calling."
         }
     }
 }

--- a/vreader/Services/AI/AIProvider.swift
+++ b/vreader/Services/AI/AIProvider.swift
@@ -23,6 +23,29 @@ protocol AIProvider: Sendable {
 
     /// Human-readable name for this provider (e.g., "OpenAI", "Local LLM").
     var providerName: String { get }
+
+    // MARK: - Feature #91: tool/function calling (capability-gated)
+
+    /// Whether this provider supports tool/function calling. Defaults to `false`;
+    /// providers that implement `sendToolRequest` override it to `true`. The
+    /// agentic loop is gated on this — an unsupported provider keeps the chat on
+    /// the existing non-tool path (no user-visible failure).
+    var supportsToolUse: Bool { get }
+
+    /// Sends one turn of a tool-use conversation and returns the parsed turn —
+    /// either final text or a `tool_use` turn the loop runs + re-sends. Defaults
+    /// to throwing `AIError.toolUseUnsupported` so a provider that doesn't
+    /// implement tool-use compiles unchanged and fails closed.
+    func sendToolRequest(_ request: AIToolRequest) async throws -> AIToolTurn
+}
+
+/// Default tool-use behavior — a provider opts IN by overriding both members.
+extension AIProvider {
+    var supportsToolUse: Bool { false }
+
+    func sendToolRequest(_ request: AIToolRequest) async throws -> AIToolTurn {
+        throw AIError.toolUseUnsupported
+    }
 }
 
 /// An AI provider that speaks the OpenAI-compatible chat completions API.

--- a/vreader/Utils/ErrorMessageAuditor.swift
+++ b/vreader/Utils/ErrorMessageAuditor.swift
@@ -85,6 +85,10 @@ enum ErrorMessageAuditor {
         case .cacheMiss:
             // Internal-only error; should not reach UI. Generic fallback.
             return genericMessage
+        case .toolUseUnsupported:
+            // Feature #91: capability gate; the chat falls back to the non-tool
+            // path, so this should not surface — generic fallback if it does.
+            return genericMessage
         }
     }
 

--- a/vreaderTests/Services/AI/AIProviderToolSeamTests.swift
+++ b/vreaderTests/Services/AI/AIProviderToolSeamTests.swift
@@ -1,0 +1,86 @@
+// Purpose: Feature #91 WI-2 — pin the `AIProvider` tool-use capability seam: a
+// provider that doesn't implement tool-use inherits `supportsToolUse == false`
+// and a `sendToolRequest` that throws `AIError.toolUseUnsupported` (fails closed,
+// keeps the chat on the non-tool path), while a provider that overrides both
+// reports support + returns its parsed turn. No real provider impl yet (WI-3/4).
+//
+// @coordinates-with: AIProvider.swift, AITool.swift, AIError.swift,
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-2)
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("Feature #91 WI-2 — AIProvider tool-use seam")
+struct AIProviderToolSeamTests {
+
+    /// A provider that implements ONLY the base requirements — it inherits the
+    /// default tool-use behavior (unsupported).
+    private struct NonToolProvider: AIProvider {
+        let providerName = "stub"
+        func sendRequest(_ request: AIRequest) async throws -> AIResponse {
+            AIResponse(content: "", actionType: .questionAnswer,
+                       promptVersion: "v1", createdAt: Date(timeIntervalSince1970: 0))
+        }
+        func streamRequest(_ request: AIRequest) -> AsyncThrowingStream<AIStreamChunk, Error> {
+            AsyncThrowingStream { $0.finish() }
+        }
+    }
+
+    /// A provider that OPTS IN to tool-use by overriding both members.
+    private struct ToolProvider: AIProvider {
+        let providerName = "tool-stub"
+        let stubbedTurn: AIToolTurn
+        func sendRequest(_ request: AIRequest) async throws -> AIResponse {
+            AIResponse(content: "", actionType: .questionAnswer,
+                       promptVersion: "v1", createdAt: Date(timeIntervalSince1970: 0))
+        }
+        func streamRequest(_ request: AIRequest) -> AsyncThrowingStream<AIStreamChunk, Error> {
+            AsyncThrowingStream { $0.finish() }
+        }
+        var supportsToolUse: Bool { true }
+        func sendToolRequest(_ request: AIToolRequest) async throws -> AIToolTurn {
+            stubbedTurn
+        }
+    }
+
+    private static let request = AIToolRequest(
+        systemPrompt: "sys",
+        messages: [ToolTurnMessage(role: .user, content: [.text("hi")])],
+        tools: [],
+        maxTokens: 1024)
+
+    @Test("a non-overriding provider, held as any AIProvider, reports false + throws")
+    func defaultIsUnsupportedThroughExistential() async {
+        // Gate-4: exercise the default through the EXISTENTIAL — both members are
+        // protocol REQUIREMENTS, so the extension default must dispatch via the
+        // witness table even through `any AIProvider` (not the static-dispatch trap).
+        let provider: any AIProvider = NonToolProvider()
+        #expect(provider.supportsToolUse == false)
+        await #expect(throws: AIError.toolUseUnsupported) {
+            _ = try await provider.sendToolRequest(Self.request)
+        }
+    }
+
+    @Test("an OVERRIDING provider, held as any AIProvider, dispatches to its impl")
+    func overridingDispatchesThroughExistential() async throws {
+        // The classic protocol-extension dispatch trap: if these were extension-only
+        // (non-requirement) members, a `ToolProvider` held as `any AIProvider` would
+        // hit the DEFAULT (false / throws). Because they're requirements, the
+        // override must win even through the existential.
+        let calls = [ToolCall(id: "t1", name: "search", input: .object(["q": .string("x")]))]
+        let provider: any AIProvider = ToolProvider(
+            stubbedTurn: .toolUse(blocks: [.toolUse(calls[0])]))
+        #expect(provider.supportsToolUse == true)          // NOT the default false
+        let turn = try await provider.sendToolRequest(Self.request)  // NOT a throw
+        #expect(turn.toolCalls == calls)
+    }
+
+    @Test("an overriding provider can also return a final-text turn")
+    func overridingProviderText() async throws {
+        let provider: any AIProvider = ToolProvider(stubbedTurn: .text("done"))
+        let turn = try await provider.sendToolRequest(Self.request)
+        #expect(turn == .text("done"))
+        #expect(turn.toolCalls.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

WI-2 of Feature #91 — the provider-level tool-use seam the agentic loop gates on. No real provider impl yet (WI-3 Anthropic / WI-4 OpenAI).

Part of feature #1482.

## What Changed

- **`AIProvider`** gains two protocol requirements: `supportsToolUse: Bool` (default `false`) and `sendToolRequest(_:) async throws -> AIToolTurn` (default throws `AIError.toolUseUnsupported`). A provider opts IN by overriding both; non-overriding providers (the existing `OpenAICompatibleProvider`/`AnthropicProvider` + test stubs) inherit the defaults unchanged and **fail closed**.
- **`AIError.toolUseUnsupported`** + its case in `ErrorMessageAuditor`'s exhaustive `sanitizeAI` switch.

## WI Status

- WI-2: **foundational** — this PR. Done: WI-1 (DTOs). Remaining: WI-3/4 (provider tool-use impls), WI-5 (registry), WI-6a/b/c (tools), WI-7 (driver), WI-8 (VM wiring).

## Codex Audit (Gate 4)

ship-as-is. **No production findings** — the seam is correctly shaped for dynamic dispatch (both members are protocol requirements → witness-table-dispatched even through `any AIProvider`). One Medium (test-only): the dispatch-critical tests now bind providers as `any AIProvider` existentials and assert the override wins (not the extension default) — the classic protocol-extension dispatch trap, now pinned and green.

Audit log: `.claude/codex-audits/feat-feature-91-wi-2-provider-seam-audit.md`

## Validation

- [x] `scripts/run-tests.sh vreaderTests/AIProviderToolSeamTests` green (incl. existential-dispatch assertions)
- [x] Codex audit (ship-as-is)
- [x] Version bumped: 3.51.6 → 3.51.7

## Gate 5a (foundational)

Protocol seam — unit tests + audit sufficient; no device verification.

## Type of Change

- [x] Foundational WI (Part of feature #1482)