### PR TITLE
feat(#91 WI-3): Anthropic tool-use (behavioral)

### DIFF
--- a/.claude/codex-audits/feat-feature-91-wi-3-anthropic-tooluse-audit.md
+++ b/.claude/codex-audits/feat-feature-91-wi-3-anthropic-tooluse-audit.md
@@ -1,0 +1,46 @@
+---
+branch: feat/feature-91-wi-3-anthropic-tooluse
+threadId: 019e90ba-cfd5-7b60-b6a9-1ef9330e025c
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-06-03
+---
+
+# Codex Audit — Feature #91 WI-3 (Anthropic tool-use)
+
+Gate-4 implementation audit (rule 47). Independent Codex runner via
+`scripts/run-codex.sh -e high` (author/auditor separation, rule 48).
+
+## Scope
+
+Behavioral WI-3 — the first provider tool-use impl:
+
+- `AnthropicProvider+ToolUse.swift` (new) — `supportsToolUse=true` + `sendToolRequest`; `buildToolURLRequest` (tools body + multi-turn messages); static encoders (tool/message/block → Anthropic JSON); `parseToolResponse`/`parseToolTurn`; `validateToolHistory`.
+- `AnthropicProvider.swift` — extracted `makeMessagesURLRequest(validatingMaxTokens:)` (shared scaffolding).
+- `AnthropicProviderToolUseTests.swift` (new).
+
+## Round 1 — findings (threadId 019e90ba-cfd5-7b60-b6a9-1ef9330e025c)
+
+The audit **confirmed the wire format is correct** per the Anthropic Messages API
+docs (`input_schema`, `tool_use {id,name,input}`, `tool_result {tool_use_id,content,is_error}`
+in a user-role message, `max_tokens` required). The findings were robustness gaps:
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| AnthropicProvider+ToolUse.swift `sendToolRequest` | **High** | `stop_reason` ignored — a `max_tokens` truncation could silently downgrade a partial trailing `tool_use`. | **Fixed.** Extracted `parseToolResponse(_ json:)`; rejects `stop_reason == "max_tokens"` with a clean retriable `AIError.providerError`; normal stop reasons parse through. (Round-2 RESOLVED.) |
+| AnthropicProvider+ToolUse.swift `buildToolURLRequest` | **Medium** | No history validation — Anthropic requires `tool_result` to immediately follow the `tool_use` turn, tool_result-blocks-first, AND every `tool_use` id answered. A malformed caller 400s on the wire. | **Fixed (2 iterations).** `validateToolHistory` enforces adjacency + tool_result-first (round 1), THEN every assistant `tool_use` id has a matching `tool_result` in the next user turn (round-3 — the round-2 gap). RESOLVED round 3. |
+| AnthropicProvider+ToolUse.swift / AnthropicProvider.swift | Low | `makeMessagesURLRequest` validated the PROFILE `maxTokens`, not the effective per-request budget — the documented override was ineffective if the profile value was bad. | **Fixed.** `makeMessagesURLRequest(validatingMaxTokens:)` validates the EFFECTIVE budget the caller emits. (Round-2 RESOLVED.) |
+
+## Rounds 2 (threadId 019e90ce) / 3 (threadId 019e90de)
+
+- R2: High + Low RESOLVED; Medium partially (adjacency/ordering done, but missing the tool_use-id-coverage check) → NOT.
+- R3: `validateToolHistory` now requires `toolUseIDs.isSubset(of: resultIDs)` (every tool_use answered) — **RESOLVED**, consistent with Anthropic's "one tool_result per tool_use" rule. No new findings.
+
+## Verdict
+
+**ship-as-is.** Zero open Critical/High/Medium after round 3. `AnthropicProviderToolUseTests`
+green (body shape, encoders, `parseToolResponse` stop_reason handling, history
+validation incl. missing-id, effective-budget) + `AnthropicProviderTests` regression
+green (the `makeMessagesURLRequest` extraction is behavior-preserving for plain chat).
+Slice device-verification against a real Anthropic provider is planned at the
+feature's final-WI acceptance.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 863
-        MARKETING_VERSION: 3.51.7
+        CURRENT_PROJECT_VERSION: 864
+        MARKETING_VERSION: 3.51.8
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -657,6 +657,7 @@
 		68BEE555698E2ECAE8536655 /* MDReaderReplacementRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7672B4D5423E0D3AAE16343 /* MDReaderReplacementRulesTests.swift */; };
 		68E502A3165D068458A7033D /* LandingBloomCurve.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9224D36A1C657115C1AF6E83 /* LandingBloomCurve.swift */; };
 		68F25FD5B04A5CE2EC41E895 /* AnnotationStreamBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C930176EDA59BA6AE769B8C /* AnnotationStreamBuilder.swift */; };
+		68FADA011BBB240793CC4E83 /* AnthropicProviderToolUseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6686907B7FE75075E1D9EDC /* AnthropicProviderToolUseTests.swift */; };
 		691280DF99A2E74DE49D6D94 /* SettingsIconRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C994418AB3E9CCF1914CA9 /* SettingsIconRowTests.swift */; };
 		6A1321CE165723A3531ECCE5 /* ReadiumShared in Frameworks */ = {isa = PBXBuildFile; productRef = BD4466456EBD017A56F147F0 /* ReadiumShared */; };
 		6A82598FAC95114A1E5CF06B /* footnotes.js in Resources */ = {isa = PBXBuildFile; fileRef = 7D068D6691FC6690BF3341B1 /* footnotes.js */; };
@@ -1474,6 +1475,7 @@
 		F6491F10294DBD6435A3F117 /* ReadiumNavigator in Frameworks */ = {isa = PBXBuildFile; productRef = 40371B0D544B5328AAF77E07 /* ReadiumNavigator */; };
 		F6F40F9E52D3ED8B95323D65 /* epub.js in Resources */ = {isa = PBXBuildFile; fileRef = 3EC2FBB83EE7D774B3B5D5D3 /* epub.js */; };
 		F725E00A6B2B5C15B63B5037 /* BilingualTextRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FA184F0D822A7EC8A0F445B /* BilingualTextRendererTests.swift */; };
+		F7356D07A6682B6A1EF19DFE /* AnthropicProvider+ToolUse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B977F46EF1A43D8BD15362 /* AnthropicProvider+ToolUse.swift */; };
 		F787B0120B50F971DF7930DD /* Feature34CollectionsVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AEB955B6E5713C9AB4D701E /* Feature34CollectionsVerificationTests.swift */; };
 		F78B9D218FBB628F31479271 /* EPUBParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E742DD046F5CE970132E0C /* EPUBParser.swift */; };
 		F7D1DD8DB8FE7E683B95BABA /* LazyDownloadTaskMeta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592405D887F7AE66A58FA8D9 /* LazyDownloadTaskMeta.swift */; };
@@ -2196,6 +2198,7 @@
 		685C8ADDC85C551C75E38594 /* WebDAVServerProfileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVServerProfileStore.swift; sourceTree = "<group>"; };
 		686E0EE508E85349AED791BE /* TokenSpan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSpan.swift; sourceTree = "<group>"; };
 		68A7FC6A70A060CD5E43602E /* ReadingProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingProgressBar.swift; sourceTree = "<group>"; };
+		68B977F46EF1A43D8BD15362 /* AnthropicProvider+ToolUse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnthropicProvider+ToolUse.swift"; sourceTree = "<group>"; };
 		68BB90FF5CA185660AAE66BD /* MDReaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReaderViewModel.swift; sourceTree = "<group>"; };
 		68D805C5BFB334FBABC94879 /* ReadinessTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadinessTracker.swift; sourceTree = "<group>"; };
 		68FE9266FB938B801CBD71C9 /* BilingualAIReadinessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualAIReadinessTests.swift; sourceTree = "<group>"; };
@@ -2835,6 +2838,7 @@
 		D5CE4AD339F8C68B973D9C88 /* NativeTextPagedIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTextPagedIntegrationTests.swift; sourceTree = "<group>"; };
 		D5DF3877E8FD8A626E3A1DD6 /* ReadingDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDashboardView.swift; sourceTree = "<group>"; };
 		D6623BDBAEAD521C6F4402DF /* FoliatePositionPersistenceIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliatePositionPersistenceIntegrationTests.swift; sourceTree = "<group>"; };
+		D6686907B7FE75075E1D9EDC /* AnthropicProviderToolUseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnthropicProviderToolUseTests.swift; sourceTree = "<group>"; };
 		D6A24122FDBAEA4D6DBE9465 /* HighlightActionCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightActionCardView.swift; sourceTree = "<group>"; };
 		D6A71F1EFD6CE46CD549A0AD /* HighlightHitTolerance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightHitTolerance.swift; sourceTree = "<group>"; };
 		D6A8B4C14F5DEEB43C139E7A /* TXTReaderContainerView+Bilingual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TXTReaderContainerView+Bilingual.swift"; sourceTree = "<group>"; };
@@ -5154,6 +5158,7 @@
 				3840F0544DB0B9050ECBB5F6 /* AIToolDTOTests.swift */,
 				1836AA0E3E80CADFB1B46834 /* AnthropicProviderStreamingTests.swift */,
 				E5892DBA34520F6BB7B8E5A3 /* AnthropicProviderTests.swift */,
+				D6686907B7FE75075E1D9EDC /* AnthropicProviderToolUseTests.swift */,
 				68FE9266FB938B801CBD71C9 /* BilingualAIReadinessTests.swift */,
 				DD7224616391A07142BD1979 /* BookTranslationCoordinatorTests.swift */,
 				EF42781312FD73B373FB2BB5 /* BookTranslationProgressTests.swift */,
@@ -5456,6 +5461,7 @@
 				46C22F30DF9F05C20CF8DDBC /* AITypes.swift */,
 				B8C6D6A8EC00DFFAC294DD87 /* AnthropicProvider.swift */,
 				C682F2AF644C10CEC95208AE /* AnthropicProvider+Streaming.swift */,
+				68B977F46EF1A43D8BD15362 /* AnthropicProvider+ToolUse.swift */,
 				816EBC35111B21F7E6B75746 /* BilingualAIReadiness.swift */,
 				0C3959530D53C3CE271377F5 /* BookTranslationCoordinator.swift */,
 				CC65B4AF0602473F3F11C161 /* BookTranslationProgress.swift */,
@@ -5887,6 +5893,7 @@
 				1C047439042E40ABD9D6DFA7 /* AnnotationsSheetRouteTests.swift in Sources */,
 				CAF37A53ACA1334F8A0AD2A4 /* AnthropicProviderStreamingTests.swift in Sources */,
 				B8C609FE1F6F51E950F4B96A /* AnthropicProviderTests.swift in Sources */,
+				68FADA011BBB240793CC4E83 /* AnthropicProviderToolUseTests.swift in Sources */,
 				A2B7E3D8BAEC3C9A9375D3E4 /* AppConfigurationTests.swift in Sources */,
 				5BCD69B7FFD787F33D6E0C8D /* AutoPageTurnerTests.swift in Sources */,
 				C9D2AE1A81222E67A05CA05C /* BackgroundIndexingCoordinatorTests.swift in Sources */,
@@ -6528,6 +6535,7 @@
 				34EBF21FA663958498E44A1C /* AnnotationsEmptyStateView.swift in Sources */,
 				C90F581D922CB5FC37C94EFA /* AnnotationsSheetRoute.swift in Sources */,
 				FFC1BF2B3E0963AAD120E93E /* AnthropicProvider+Streaming.swift in Sources */,
+				F7356D07A6682B6A1EF19DFE /* AnthropicProvider+ToolUse.swift in Sources */,
 				57E1462E66FEAA422A970FA5 /* AnthropicProvider.swift in Sources */,
 				8E7482D250AFDBEF1803780A /* AppConfiguration.swift in Sources */,
 				0CDCF9DAE4BA56A30FA71097 /* AppLogger.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7409,7 +7409,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 863;
+				CURRENT_PROJECT_VERSION = 864;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7417,7 +7417,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.7;
+				MARKETING_VERSION = 3.51.8;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7563,7 +7563,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 863;
+				CURRENT_PROJECT_VERSION = 864;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7571,7 +7571,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.7;
+				MARKETING_VERSION = 3.51.8;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Services/AI/AnthropicProvider+ToolUse.swift
+++ b/vreader/Services/AI/AnthropicProvider+ToolUse.swift
@@ -1,0 +1,210 @@
+// Purpose: Feature #91 WI-3 — Anthropic tool-use for the agentic chat loop. Adds
+// `supportsToolUse`/`sendToolRequest` (the WI-2 seam) for `AnthropicProvider`:
+// assembles the `/v1/messages` body with a `tools` array + the accumulated
+// multi-turn `messages` (text / tool_use / tool_result content blocks), and
+// parses the response `content` blocks into an `AIToolTurn` (a `tool_use` turn
+// preserves the full ordered blocks; otherwise the concatenated text).
+//
+// Anthropic tool-use wire format (Messages API):
+//   request.tools:    [{name, description, input_schema}]
+//   assistant turn:   content: [{type:text,text}, {type:tool_use,id,name,input}]
+//   tool_result turn: content: [{type:tool_result,tool_use_id,content,is_error}]
+//   response:         content blocks; stop_reason "tool_use" when a tool is called.
+//
+// All JSON values route through `JSONValue.toFoundation()` / `init(foundation:)`,
+// so a tool's input/output schema crosses the boundary without `[String: Any]`
+// Sendable holes and never hands a non-finite number to `JSONSerialization`.
+//
+// @coordinates-with: AnthropicProvider.swift, AIProvider.swift (WI-2 seam),
+//   AITool.swift (DTOs), AnthropicProvider+Streaming.swift,
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-3)
+
+import Foundation
+
+extension AnthropicProvider {
+
+    var supportsToolUse: Bool { true }
+
+    /// One turn of a tool-use conversation. Sends the accumulated `messages` +
+    /// the `tools`, then parses the assistant's content blocks: a `tool_use`
+    /// block makes it a `.toolUse` turn (full ordered blocks preserved), else a
+    /// final `.text` turn.
+    ///
+    /// Gate-4 High: `stop_reason` is honored — a `max_tokens` truncation is
+    /// rejected as a clean retriable error rather than silently downgrading a
+    /// partial trailing `tool_use` into a `.text`/dropped block.
+    func sendToolRequest(_ request: AIToolRequest) async throws -> AIToolTurn {
+        let urlRequest = try buildToolURLRequest(request)
+        let (data, response) = try await session.data(for: urlRequest)
+        try validateHTTPResponse(response, data: data)
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AIError.invalidResponse
+        }
+        return try Self.parseToolResponse(json)
+    }
+
+    /// Parse a full `/v1/messages` response body into an `AIToolTurn`, honoring
+    /// `stop_reason` (Gate-4 High). Extracted from `sendToolRequest` so the
+    /// stop-reason + content handling is unit-testable without a network stub.
+    static func parseToolResponse(_ json: [String: Any]) throws -> AIToolTurn {
+        guard let blocks = json["content"] as? [[String: Any]], !blocks.isEmpty else {
+            throw AIError.invalidResponse
+        }
+        // A truncated turn (stop_reason "max_tokens") may carry an incomplete
+        // trailing tool_use — fail loud (retriable) instead of acting on it.
+        if json["stop_reason"] as? String == "max_tokens" {
+            throw AIError.providerError(
+                "Anthropic response truncated (stop_reason=max_tokens) — increase the token budget and retry.")
+        }
+        return parseToolTurn(contentBlocks: blocks)
+    }
+
+    /// Assemble the `/v1/messages` body for a tool-use turn.
+    func buildToolURLRequest(_ request: AIToolRequest) throws -> URLRequest {
+        // Gate-4 Medium: fail fast on a malformed tool-use history (the wire would
+        // otherwise 400) — a tool_use assistant turn must be immediately followed
+        // by a user turn whose content LEADS with tool_result blocks.
+        try Self.validateToolHistory(request.messages)
+        // Anthropic requires max_tokens >= 1; the request carries its own budget
+        // but fall back to the profile's if the caller passed a non-positive value.
+        let maxTok = request.maxTokens >= 1 ? request.maxTokens : maxTokens
+        var urlRequest = try makeMessagesURLRequest(validatingMaxTokens: maxTok)
+        var body: [String: Any] = [
+            "model": model,
+            "max_tokens": maxTok,
+            "system": request.systemPrompt,
+            "messages": request.messages.map { Self.encodeMessage($0) },
+        ]
+        if !request.tools.isEmpty {
+            body["tools"] = request.tools.map { Self.encodeTool($0) }
+        }
+        urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return urlRequest
+    }
+
+    // MARK: - Encode (DTO → Anthropic JSON)
+
+    static func encodeTool(_ tool: ToolDefinition) -> [String: Any] {
+        [
+            "name": tool.name,
+            "description": tool.description,
+            "input_schema": tool.inputSchema.toFoundation(),
+        ]
+    }
+
+    static func encodeMessage(_ message: ToolTurnMessage) -> [String: Any] {
+        [
+            "role": message.role.rawValue,
+            "content": message.content.map { encodeBlock($0) },
+        ]
+    }
+
+    static func encodeBlock(_ block: ToolContentBlock) -> [String: Any] {
+        switch block {
+        case .text(let text):
+            return ["type": "text", "text": text]
+        case .toolUse(let call):
+            return [
+                "type": "tool_use",
+                "id": call.id,
+                "name": call.name,
+                "input": call.input.toFoundation(),
+            ]
+        case .toolResult(let result):
+            return [
+                "type": "tool_result",
+                "tool_use_id": result.toolUseID,
+                "content": result.content,
+                "is_error": result.isError,
+            ]
+        }
+    }
+
+    // MARK: - Parse (Anthropic JSON → AIToolTurn)
+
+    /// Parse the response `content` blocks. If ANY `tool_use` block is present
+    /// it's a `.toolUse` turn carrying the full ordered text + tool_use blocks
+    /// (lossless); otherwise the concatenated `text` is the final answer.
+    /// Unknown block types are ignored.
+    static func parseToolTurn(contentBlocks: [[String: Any]]) -> AIToolTurn {
+        var parsed: [ToolContentBlock] = []
+        var hasToolUse = false
+        for block in contentBlocks {
+            switch block["type"] as? String {
+            case "text":
+                if let text = block["text"] as? String {
+                    parsed.append(.text(text))
+                }
+            case "tool_use":
+                guard let id = block["id"] as? String,
+                      let name = block["name"] as? String else { continue }
+                let input = block["input"].map { JSONValue(foundation: $0) } ?? .object([:])
+                parsed.append(.toolUse(ToolCall(id: id, name: name, input: input)))
+                hasToolUse = true
+            default:
+                continue
+            }
+        }
+        if hasToolUse {
+            return .toolUse(blocks: parsed)
+        }
+        let text = parsed.compactMap {
+            if case .text(let t) = $0 { return t } else { return nil }
+        }.joined()
+        return .text(text)
+    }
+
+    // MARK: - History validation (Gate-4 Medium)
+
+    /// Validate a tool-use message history against Anthropic's adjacency rules so
+    /// a malformed caller fails fast HERE instead of burning a 400 round-trip:
+    ///   1. Every assistant turn that contains a `tool_use` block MUST be
+    ///      immediately followed by a `user` turn.
+    ///   2. That following user turn's content MUST LEAD with `tool_result`
+    ///      blocks (all tool_results before any other block) — and generally, in
+    ///      ANY user message, no non-`tool_result` block may precede a
+    ///      `tool_result` block.
+    /// Throws `AIError.providerError` on a violation.
+    static func validateToolHistory(_ messages: [ToolTurnMessage]) throws {
+        for (i, message) in messages.enumerated() {
+            let toolUseIDs: Set<String> = Set(message.content.compactMap {
+                if case .toolUse(let call) = $0 { return call.id } else { return nil }
+            })
+            if message.role == .assistant, !toolUseIDs.isEmpty {
+                guard i + 1 < messages.count, messages[i + 1].role == .user else {
+                    throw AIError.providerError(
+                        "malformed tool-use history: an assistant tool_use turn must be immediately followed by a user tool_result turn.")
+                }
+                let next = messages[i + 1]
+                guard case .toolResult = next.content.first else {
+                    throw AIError.providerError(
+                        "malformed tool-use history: the user turn after a tool_use must lead with tool_result blocks.")
+                }
+                // Every tool_use id MUST have a matching tool_result in the next
+                // user turn (Anthropic 400s on a missing tool_use id).
+                let resultIDs: Set<String> = Set(next.content.compactMap {
+                    if case .toolResult(let r) = $0 { return r.toolUseID } else { return nil }
+                })
+                guard toolUseIDs.isSubset(of: resultIDs) else {
+                    throw AIError.providerError(
+                        "malformed tool-use history: every tool_use must have a matching tool_result (missing: \(toolUseIDs.subtracting(resultIDs).sorted().joined(separator: ", "))).")
+                }
+            }
+            // tool_result-blocks-first within any user message.
+            if message.role == .user {
+                var seenNonResult = false
+                for block in message.content {
+                    if case .toolResult = block {
+                        if seenNonResult {
+                            throw AIError.providerError(
+                                "malformed tool-use history: tool_result blocks must come before any other block in a user message.")
+                        }
+                    } else {
+                        seenNonResult = true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vreader/Services/AI/AnthropicProvider.swift
+++ b/vreader/Services/AI/AnthropicProvider.swift
@@ -110,15 +110,43 @@ struct AnthropicProvider: AIProvider, Sendable {
     // MARK: - Request construction
 
     func buildURLRequest(for request: AIRequest, stream: Bool) throws -> URLRequest {
+        var urlRequest = try makeMessagesURLRequest(validatingMaxTokens: maxTokens)
+
+        let systemPrompt = buildSystemPrompt(for: request.actionType)
+        let userMessage = buildUserMessage(for: request)
+
+        var body: [String: Any] = [
+            "model": model,
+            "max_tokens": maxTokens,
+            "system": systemPrompt,
+            "messages": [
+                ["role": "user", "content": userMessage]
+            ]
+        ]
+        if stream {
+            body["stream"] = true
+        }
+
+        urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return urlRequest
+    }
+
+    /// Shared `/v1/messages` POST scaffolding (validation + endpoint + headers)
+    /// for both the plain-chat `buildURLRequest` and the Feature #91 tool-use
+    /// `buildToolURLRequest`. The caller sets `httpBody`. `validatingMaxTokens` is
+    /// the EFFECTIVE budget the caller will actually emit (Gate-4 Low: the tool
+    /// path's per-request override means the profile value alone is the wrong
+    /// thing to validate).
+    func makeMessagesURLRequest(validatingMaxTokens effectiveMaxTokens: Int) throws -> URLRequest {
         // Anthropic requires `max_tokens >= 1` (per Messages API docs). We
         // validate here rather than at init so misconfigured profiles
         // surface as a clean `AIError` to UI instead of a precondition
         // trap on profile load. Sending the value untouched would also
         // work (the API returns 400) but burns a network round trip and
         // produces a less specific error message.
-        guard maxTokens >= 1 else {
+        guard effectiveMaxTokens >= 1 else {
             throw AIError.providerError(
-                "\(providerName) profile is misconfigured: max_tokens must be >= 1 (got \(maxTokens))."
+                "\(providerName) profile is misconfigured: max_tokens must be >= 1 (got \(effectiveMaxTokens))."
             )
         }
 
@@ -140,23 +168,6 @@ struct AnthropicProvider: AIProvider, Sendable {
             Self.anthropicVersionHeader,
             forHTTPHeaderField: "anthropic-version"
         )
-
-        let systemPrompt = buildSystemPrompt(for: request.actionType)
-        let userMessage = buildUserMessage(for: request)
-
-        var body: [String: Any] = [
-            "model": model,
-            "max_tokens": maxTokens,
-            "system": systemPrompt,
-            "messages": [
-                ["role": "user", "content": userMessage]
-            ]
-        ]
-        if stream {
-            body["stream"] = true
-        }
-
-        urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
         return urlRequest
     }
 

--- a/vreaderTests/Services/AI/AnthropicProviderToolUseTests.swift
+++ b/vreaderTests/Services/AI/AnthropicProviderToolUseTests.swift
@@ -1,0 +1,272 @@
+// Purpose: Feature #91 WI-3 — pin the Anthropic tool-use request assembly +
+// response parsing. `buildToolURLRequest` is synchronous (no network) so the body
+// shape is asserted by decoding its `httpBody`; `parseToolTurn` is a pure function
+// over the response `content` blocks. Mirrors `AnthropicProviderTests`' body/parse
+// pins without needing the URLSession stub.
+//
+// @coordinates-with: AnthropicProvider+ToolUse.swift, AITool.swift,
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-3)
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("Feature #91 WI-3 — Anthropic tool-use")
+struct AnthropicProviderToolUseTests {
+
+    private func makeProvider() -> AnthropicProvider {
+        AnthropicProvider(
+            providerName: "Anthropic",
+            baseURL: URL(string: "https://api.anthropic.com")!,
+            apiKey: "k", model: "claude-x", maxTokens: 2048, session: .shared)
+    }
+
+    private static let toolDef = ToolDefinition(
+        name: "search_current_book",
+        description: "Full-text search the open book.",
+        inputSchema: .object([
+            "type": .string("object"),
+            "properties": .object(["query": .object(["type": .string("string")])]),
+            "required": .array([.string("query")]),
+        ]))
+
+    private func decodeBody(_ req: URLRequest) throws -> [String: Any] {
+        try #require(req.httpBody.flatMap {
+            try? JSONSerialization.jsonObject(with: $0) as? [String: Any]
+        })
+    }
+
+    // MARK: - Capability
+
+    @Test("AnthropicProvider supports tool use")
+    func supportsToolUse() {
+        #expect(makeProvider().supportsToolUse == true)
+    }
+
+    // MARK: - Request assembly
+
+    @Test("the tool-use body carries the tools array (name/description/input_schema)")
+    func bodyCarriesTools() throws {
+        let req = AIToolRequest(
+            systemPrompt: "sys",
+            messages: [ToolTurnMessage(role: .user, content: [.text("find darcy")])],
+            tools: [Self.toolDef], maxTokens: 1024)
+        let body = try decodeBody(try makeProvider().buildToolURLRequest(req))
+        #expect(body["model"] as? String == "claude-x")
+        #expect(body["max_tokens"] as? Int == 1024)
+        #expect(body["system"] as? String == "sys")
+        let tools = try #require(body["tools"] as? [[String: Any]])
+        #expect(tools.count == 1)
+        #expect(tools[0]["name"] as? String == "search_current_book")
+        #expect(tools[0]["description"] as? String == "Full-text search the open book.")
+        #expect(tools[0]["input_schema"] is [String: Any])  // JSON-Schema object survives
+    }
+
+    @Test("an empty tools list omits the tools key entirely")
+    func emptyToolsOmitsKey() throws {
+        let req = AIToolRequest(
+            systemPrompt: "s", messages: [ToolTurnMessage(role: .user, content: [.text("hi")])],
+            tools: [], maxTokens: 512)
+        let body = try decodeBody(try makeProvider().buildToolURLRequest(req))
+        #expect(body["tools"] == nil)
+    }
+
+    @Test("multi-turn messages serialize text / tool_use / tool_result content blocks")
+    func messagesSerializeContentBlocks() throws {
+        let call = ToolCall(id: "tu_1", name: "search", input: .object(["q": .string("x")]))
+        let req = AIToolRequest(
+            systemPrompt: "s",
+            messages: [
+                ToolTurnMessage(role: .user, content: [.text("find x")]),
+                ToolTurnMessage(role: .assistant, content: [.text("searching"), .toolUse(call)]),
+                ToolTurnMessage(role: .user, content: [
+                    .toolResult(ToolResult(toolUseID: "tu_1", content: "3 hits", isError: false)),
+                ]),
+            ], tools: [Self.toolDef], maxTokens: 1024)
+        let body = try decodeBody(try makeProvider().buildToolURLRequest(req))
+        let messages = try #require(body["messages"] as? [[String: Any]])
+        #expect(messages.count == 3)
+        // assistant turn: a text block + a tool_use block (id/name/input).
+        let asst = try #require(messages[1]["content"] as? [[String: Any]])
+        #expect(asst[0]["type"] as? String == "text")
+        #expect(asst[1]["type"] as? String == "tool_use")
+        #expect(asst[1]["id"] as? String == "tu_1")
+        #expect(asst[1]["name"] as? String == "search")
+        #expect(asst[1]["input"] is [String: Any])
+        // tool_result turn keys.
+        let toolMsg = try #require(messages[2]["content"] as? [[String: Any]])
+        #expect(toolMsg[0]["type"] as? String == "tool_result")
+        #expect(toolMsg[0]["tool_use_id"] as? String == "tu_1")
+        #expect(toolMsg[0]["content"] as? String == "3 hits")
+        #expect(toolMsg[0]["is_error"] as? Bool == false)
+    }
+
+    @Test("the request carries the Anthropic auth + version headers")
+    func headers() throws {
+        let req = AIToolRequest(systemPrompt: "s",
+            messages: [ToolTurnMessage(role: .user, content: [.text("hi")])],
+            tools: [], maxTokens: 256)
+        let urlReq = try makeProvider().buildToolURLRequest(req)
+        #expect(urlReq.value(forHTTPHeaderField: "x-api-key") == "k")
+        #expect(urlReq.value(forHTTPHeaderField: "anthropic-version") == AnthropicProvider.anthropicVersionHeader)
+        #expect(urlReq.url?.absoluteString.hasSuffix("/v1/messages") == true)
+    }
+
+    // MARK: - Response parsing
+
+    @Test("a tool_use response parses to a .toolUse turn preserving ordered blocks")
+    func parseToolUseResponse() {
+        let blocks: [[String: Any]] = [
+            ["type": "text", "text": "I'll search."],
+            ["type": "tool_use", "id": "toolu_9", "name": "search_current_book",
+             "input": ["query": "darcy"]],
+        ]
+        let turn = AnthropicProvider.parseToolTurn(contentBlocks: blocks)
+        #expect(turn.toolCalls == [ToolCall(id: "toolu_9", name: "search_current_book",
+                                            input: .object(["query": .string("darcy")]))])
+        #expect(turn.assistantText == "I'll search.")
+    }
+
+    @Test("a text-only response parses to a concatenated .text turn")
+    func parseTextResponse() {
+        let turn = AnthropicProvider.parseToolTurn(contentBlocks: [
+            ["type": "text", "text": "Final "],
+            ["type": "text", "text": "answer."],
+        ])
+        #expect(turn == .text("Final answer."))
+        #expect(turn.toolCalls.isEmpty)
+    }
+
+    @Test("a malformed tool_use (missing id) is skipped, not crashed")
+    func parseMalformedToolUseSkipped() {
+        let turn = AnthropicProvider.parseToolTurn(contentBlocks: [
+            ["type": "tool_use", "name": "x"],           // no id → skipped
+            ["type": "text", "text": "ok"],
+            ["type": "future_block_kind", "data": 1],    // unknown type → ignored
+        ])
+        // No valid tool_use survived → falls back to text.
+        #expect(turn == .text("ok"))
+    }
+
+    @Test("a tool_use with no input defaults to an empty object")
+    func parseToolUseNoInput() {
+        let turn = AnthropicProvider.parseToolTurn(contentBlocks: [
+            ["type": "tool_use", "id": "t", "name": "noargs"],
+        ])
+        #expect(turn.toolCalls == [ToolCall(id: "t", name: "noargs", input: .object([:]))])
+    }
+
+    // MARK: - Gate-4 High: stop_reason
+
+    @Test("a max_tokens-truncated response is rejected (not silently downgraded)")
+    func truncatedResponseThrows() {
+        let json: [String: Any] = [
+            "content": [["type": "text", "text": "partial"]],
+            "stop_reason": "max_tokens",
+        ]
+        #expect(throws: AIError.self) { _ = try AnthropicProvider.parseToolResponse(json) }
+    }
+
+    @Test("a normal stop_reason parses through to the turn")
+    func normalStopReasonParses() throws {
+        let toolJSON: [String: Any] = [
+            "content": [["type": "tool_use", "id": "t", "name": "search", "input": ["q": "x"]]],
+            "stop_reason": "tool_use",
+        ]
+        let turn = try AnthropicProvider.parseToolResponse(toolJSON)
+        #expect(turn.toolCalls.first?.name == "search")
+        let textJSON: [String: Any] = [
+            "content": [["type": "text", "text": "done"]], "stop_reason": "end_turn"]
+        #expect(try AnthropicProvider.parseToolResponse(textJSON) == .text("done"))
+    }
+
+    @Test("an empty / missing content response throws invalidResponse")
+    func emptyContentThrows() {
+        #expect(throws: AIError.self) { _ = try AnthropicProvider.parseToolResponse(["content": []]) }
+        #expect(throws: AIError.self) { _ = try AnthropicProvider.parseToolResponse([:]) }
+    }
+
+    // MARK: - Gate-4 Medium: history validation
+
+    @Test("a valid tool-use history passes validation")
+    func validHistoryPasses() throws {
+        let call = ToolCall(id: "t1", name: "s", input: .null)
+        try AnthropicProvider.validateToolHistory([
+            ToolTurnMessage(role: .user, content: [.text("q")]),
+            ToolTurnMessage(role: .assistant, content: [.text("ok"), .toolUse(call)]),
+            ToolTurnMessage(role: .user, content: [
+                .toolResult(ToolResult(toolUseID: "t1", content: "r")),
+            ]),
+        ])
+    }
+
+    @Test("an assistant tool_use turn NOT followed by a user tool_result throws")
+    func toolUseNotFollowedThrows() {
+        let call = ToolCall(id: "t1", name: "s", input: .null)
+        #expect(throws: AIError.self) {
+            try AnthropicProvider.validateToolHistory([
+                ToolTurnMessage(role: .assistant, content: [.toolUse(call)]),
+                // no following user tool_result turn
+            ])
+        }
+        #expect(throws: AIError.self) {
+            try AnthropicProvider.validateToolHistory([
+                ToolTurnMessage(role: .assistant, content: [.toolUse(call)]),
+                ToolTurnMessage(role: .user, content: [.text("not a tool_result first")]),
+            ])
+        }
+    }
+
+    @Test("an assistant tool_use whose id has no matching tool_result throws")
+    func missingToolResultIDThrows() {
+        let c1 = ToolCall(id: "t1", name: "s", input: .null)
+        let c2 = ToolCall(id: "t2", name: "f", input: .null)
+        #expect(throws: AIError.self) {
+            try AnthropicProvider.validateToolHistory([
+                ToolTurnMessage(role: .assistant, content: [.toolUse(c1), .toolUse(c2)]),
+                // only t1 answered — t2's tool_use id is missing a result → 400
+                ToolTurnMessage(role: .user, content: [
+                    .toolResult(ToolResult(toolUseID: "t1", content: "r")),
+                ]),
+            ])
+        }
+        // both answered → passes
+        #expect(throws: Never.self) {
+            try AnthropicProvider.validateToolHistory([
+                ToolTurnMessage(role: .assistant, content: [.toolUse(c1), .toolUse(c2)]),
+                ToolTurnMessage(role: .user, content: [
+                    .toolResult(ToolResult(toolUseID: "t1", content: "r1")),
+                    .toolResult(ToolResult(toolUseID: "t2", content: "r2")),
+                ]),
+            ])
+        }
+    }
+
+    @Test("a user message with a non-tool_result block before a tool_result throws")
+    func toolResultNotFirstThrows() {
+        #expect(throws: AIError.self) {
+            try AnthropicProvider.validateToolHistory([
+                ToolTurnMessage(role: .user, content: [
+                    .text("preamble"),
+                    .toolResult(ToolResult(toolUseID: "t1", content: "r")),
+                ]),
+            ])
+        }
+    }
+
+    // MARK: - Gate-4 Low: effective per-request max_tokens validation
+
+    @Test("a per-request max_tokens override is validated (not the bad profile value)")
+    func effectiveMaxTokensValidated() throws {
+        // Profile maxTokens=0 (bad) but the request carries a valid 1024 — must
+        // NOT throw, and the body emits 1024.
+        let provider = AnthropicProvider(
+            providerName: "Anthropic", baseURL: URL(string: "https://api.anthropic.com")!,
+            apiKey: "k", model: "m", maxTokens: 0, session: .shared)
+        let req = AIToolRequest(systemPrompt: "s",
+            messages: [ToolTurnMessage(role: .user, content: [.text("hi")])],
+            tools: [], maxTokens: 1024)
+        let body = try decodeBody(try provider.buildToolURLRequest(req))
+        #expect(body["max_tokens"] as? Int == 1024)
+    }
+}


### PR DESCRIPTION
## Summary

WI-3 of Feature #91 — the first provider tool-use impl. `AnthropicProvider` gains the WI-2 seam: assembles the `/v1/messages` body with a `tools` array + the accumulated multi-turn messages (text/tool_use/tool_result content blocks), and parses the response content blocks into an `AIToolTurn`.

Part of feature #1482.

## What Changed

- **`AnthropicProvider+ToolUse.swift`** (new) — `supportsToolUse` + `sendToolRequest` + `buildToolURLRequest` + static encoders (tool/message/block → Anthropic JSON, all via `JSONValue.toFoundation()`) + `parseToolResponse`/`parseToolTurn` + `validateToolHistory`.
- **`AnthropicProvider.swift`** — extracted `makeMessagesURLRequest(validatingMaxTokens:)` shared scaffolding (behavior-preserving for plain chat).

## WI Status

- WI-3: **behavioral** — this PR. Done: WI-1/2/3. Remaining: WI-4 (OpenAI), WI-5 (registry), WI-6a/b/c (tools), WI-7 (driver), WI-8 (VM wiring).

## Codex Audit (Gate 4)

3 rounds, **ship-as-is**. The wire format was **confirmed correct** per the Anthropic docs; the audit caught + I fixed three robustness gaps:
- **High** — honor `stop_reason` so a `max_tokens` truncation is a clean retriable error, not a silent partial-`tool_use` downgrade.
- **Medium** — `validateToolHistory` enforces `tool_use`→`tool_result` adjacency, tool_result-blocks-first, AND every `tool_use` id answered (Anthropic 400s otherwise).
- **Low** — validate the EFFECTIVE per-request `max_tokens`, not the profile value.

Audit log: `.claude/codex-audits/feat-feature-91-wi-3-anthropic-tooluse-audit.md`

## Validation

- [x] `AnthropicProviderToolUseTests` green (body shape, encoders, stop_reason, history validation incl. missing-id, effective-budget) + `AnthropicProviderTests` regression green
- [x] TDD: RED → GREEN
- [x] Codex audit (3 rounds, ship-as-is)
- [x] Version bumped: 3.51.7 → 3.51.8

## Gate 5a (behavioral)

Request-assembly + response-parsing are unit-verified (no network mock needed — both are sync/pure). Live Anthropic provider slice at the feature's final-WI acceptance.

## Type of Change

- [x] Behavioral WI (Part of feature #1482)