### PR TITLE
feat(#91 WI-4): OpenAI function-calling (behavioral)

### DIFF
--- a/.claude/codex-audits/feat-feature-91-wi-4-openai-funccall-audit.md
+++ b/.claude/codex-audits/feat-feature-91-wi-4-openai-funccall-audit.md
@@ -1,0 +1,49 @@
+---
+branch: feat/feature-91-wi-4-openai-funccall
+threadId: 019e90f3-57df-7543-b694-e41171092ef5
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-03
+---
+
+# Codex Audit — Feature #91 WI-4 (OpenAI function-calling)
+
+Gate-4 implementation audit (rule 47). Independent Codex runner via
+`scripts/run-codex.sh -e high` (author/auditor separation, rule 48).
+
+## Scope
+
+Behavioral WI-4 — OpenAI-style function-calling for `OpenAICompatibleProvider`
+(sibling to the merged Anthropic WI-3):
+
+- `AIProvider.swift` — extracted `makeChatCompletionsURLRequest()` shared scaffolding; widened `session`/`validateHTTPResponse` to internal.
+- `OpenAICompatibleProvider+ToolUse.swift` (new) — `supportsToolUse`/`sendToolRequest`; `buildToolURLRequest` maps the shared `ToolTurnMessage` model to OpenAI shape (tools as function objects, a user tool_result turn → separate `role:"tool"` messages, `arguments` as a JSON STRING, assistant `content:null` when only tool_calls); `parseToolResponse` (tool_calls → `.toolUse`, else `.text`; `finish_reason:"length"` truncation → throw).
+- `AITool.swift` — `ToolHistoryValidator` (extracted shared validator).
+- `AnthropicProvider+ToolUse.swift` — `validateToolHistory` → thin forwarder to the shared validator.
+- `OpenAICompatibleProviderToolUseTests.swift` (new).
+
+## Round 1 — findings (threadId 019e90f3-57df-7543-b694-e41171092ef5)
+
+The audit **confirmed the OpenAI wire format is correct** per the OpenAI docs
+(`tools[].function.parameters`, `arguments` as a JSON string, `role:"tool"` +
+`tool_call_id`, `content:null` for tool-call turns; the `makeChatCompletionsURLRequest`
+extraction is behavior-preserving). Both findings were robustness:
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| OpenAICompatibleProvider+ToolUse.swift `buildToolURLRequest` | **Medium** | No history validation (unlike the Anthropic sibling) — a malformed shared history serializes to an invalid OpenAI sequence (unanswered tool_call → 400). | **Fixed.** Extracted the Anthropic validator to a shared `ToolHistoryValidator.validate(_:)` in `AITool.swift`; both providers call it (Anthropic via a forwarder; OpenAI in `buildToolURLRequest`). |
+| OpenAICompatibleProvider+ToolUse.swift `parseToolResponse` | **Medium** | Returned `.toolUse` on raw `tool_calls` presence, not successfully-parsed calls — an all-malformed `tool_calls` array yields a `.toolUse` with zero executable calls (would wedge WI-7's loop). (Anthropic's parse doesn't have this — it keys off successfully-parsed blocks.) | **Fixed.** Counts valid parsed calls; returns `.toolUse` only if ≥1 survives; else falls back to assistant text, else throws `AIError.invalidResponse`. |
+
+## Round 2 — verification (threadId 019e9107-5d18-77d0-a17f-a9fb957d585d)
+
+- **FIX 1: RESOLVED** — shared `ToolHistoryValidator` enforces the provider-agnostic invariants; Anthropic forwards (behavior-preserving); OpenAI validates on build; coverage on both sides.
+- **FIX 2: RESOLVED** — `.toolUse` only when ≥1 valid call survives; the three cases (mixed→valid, all-malformed+text→text, all-malformed+no-text→throws) are covered.
+- **NEW Critical/High/Medium: none.**
+
+## Verdict
+
+**ship-as-is.** Zero open Critical/High/Medium after round 2.
+`OpenAICompatibleProviderToolUseTests` + `AnthropicProviderToolUseTests` green (the
+shared-validator extraction is behavior-preserving for the Anthropic path). Slice
+device-verification against a live OpenAI-compatible provider at the feature's
+final-WI acceptance.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 864
-        MARKETING_VERSION: 3.51.8
+        CURRENT_PROJECT_VERSION: 865
+        MARKETING_VERSION: 3.51.9
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7417,7 +7417,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 864;
+				CURRENT_PROJECT_VERSION = 865;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7425,7 +7425,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.8;
+				MARKETING_VERSION = 3.51.9;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7571,7 +7571,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 864;
+				CURRENT_PROJECT_VERSION = 865;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7579,7 +7579,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.8;
+				MARKETING_VERSION = 3.51.9;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -1089,6 +1089,7 @@
 		B409ED069E31C39F7DCE6726 /* ImportJobQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DA305663C991FC6F15F80E /* ImportJobQueueTests.swift */; };
 		B4230822C3A709F2E72DEF80 /* TXTAttributedStringBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9844BEF447FBDBA15ADCEFAB /* TXTAttributedStringBuilder.swift */; };
 		B43AA88511EE1FDB4E5D0565 /* AISummaryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BEF8E9F5CAD4246490C06D /* AISummaryCard.swift */; };
+		B461333FC37C36CEB27D46B1 /* OpenAICompatibleProviderToolUseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB271F22E6794C56E4BF987 /* OpenAICompatibleProviderToolUseTests.swift */; };
 		B463893D3C3558483F25BDCF /* AISettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0C783DCFD9CFDD8F488F80 /* AISettingsViewModel.swift */; };
 		B47FA1294B60A0652B9F0BCA /* FoliateReaderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E141EA554A8E0C1C3B36250 /* FoliateReaderViewModelTests.swift */; };
 		B4BE4D742D25DD7D487AF697 /* ReaderAIReadinessSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4AD7799181C8389AFF3F59 /* ReaderAIReadinessSheet.swift */; };
@@ -1199,6 +1200,7 @@
 		C545A7D59A2D63CC5B1DF45B /* OPDSParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF47D926F78F13327F6770C /* OPDSParser.swift */; };
 		C57845DF5A192CA91CE07FED /* HighlightActionCardViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB42619D63C6DB1728CE74D0 /* HighlightActionCardViewTests.swift */; };
 		C59B87F85C20B1B2D9DDC387 /* SyncStatusMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F693921BA233745D77EC0037 /* SyncStatusMonitor.swift */; };
+		C5E268A84485A0E8312E5E4F /* OpenAICompatibleProvider+ToolUse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6507DF977FFB9B74D8C20221 /* OpenAICompatibleProvider+ToolUse.swift */; };
 		C5E2EFAA979EF5CBE624F14C /* SettingsRowPalette+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E998CB9F64AEAFC0D2A42C46 /* SettingsRowPalette+SwiftUI.swift */; };
 		C5EEEAABF1F852CDABDA43F1 /* WebDAVClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4946129FECC6C9BA7A7F16A1 /* WebDAVClient.swift */; };
 		C5F12BF03440CB49AB7D882A /* ReadiumDecorationHighlightAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 234B0CDF583E348E490933FE /* ReadiumDecorationHighlightAdapter.swift */; };
@@ -2177,6 +2179,7 @@
 		647BF55A1C20635AD7062973 /* RuleEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleEngine.swift; sourceTree = "<group>"; };
 		64CD9AF98ED5763A7E105FCC /* TXTReaderContainerBilingualPositionTriggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReaderContainerBilingualPositionTriggerTests.swift; sourceTree = "<group>"; };
 		64D6B83FC65D64C1271E28F4 /* BackupSectionDTOs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSectionDTOs.swift; sourceTree = "<group>"; };
+		6507DF977FFB9B74D8C20221 /* OpenAICompatibleProvider+ToolUse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OpenAICompatibleProvider+ToolUse.swift"; sourceTree = "<group>"; };
 		655053889CBE2E90527473CD /* FontSizeCalibrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCalibrationTests.swift; sourceTree = "<group>"; };
 		656F8ADBF0BFC1AD8F999D47 /* SelectionPopoverPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionPopoverPresenter.swift; sourceTree = "<group>"; };
 		65ADEC012EA6D486E647B7B8 /* ReadiumEPUBPreferencesMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumEPUBPreferencesMappingTests.swift; sourceTree = "<group>"; };
@@ -2498,6 +2501,7 @@
 		9B6458ABB611B5C32252C6DE /* DebugFixtureCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugFixtureCatalogTests.swift; sourceTree = "<group>"; };
 		9B75BA41298C5306AC9AD036 /* GenerativeCoverStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerativeCoverStyle.swift; sourceTree = "<group>"; };
 		9B8C36563D7885AD214F885A /* FoliateSearchAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateSearchAdapter.swift; sourceTree = "<group>"; };
+		9BB271F22E6794C56E4BF987 /* OpenAICompatibleProviderToolUseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAICompatibleProviderToolUseTests.swift; sourceTree = "<group>"; };
 		9C192DC2E4B6D7B71D711849 /* BookCardViewVisualTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCardViewVisualTests.swift; sourceTree = "<group>"; };
 		9C3C090346A269737F00D577 /* TXTPagedChapterAdvance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTPagedChapterAdvance.swift; sourceTree = "<group>"; };
 		9C5A2D5CFE8B719D4C8F3580 /* SchemaV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV1.swift; sourceTree = "<group>"; };
@@ -5171,6 +5175,7 @@
 				A9B36C649C2C6066B9BAAEC7 /* ChatCitationFactoryTests.swift */,
 				5CBB56AF58AC56AB5CD3E692 /* ChatContextFoundationTests.swift */,
 				EA0CD7509429C4B75ACB98F2 /* KeychainProviderProfileExtensionTests.swift */,
+				9BB271F22E6794C56E4BF987 /* OpenAICompatibleProviderToolUseTests.swift */,
 				C5C46A3D7400CC956FA8D46D /* ProviderKindTests.swift */,
 				CE7C16F12BA653A217A5439C /* ProviderProfileMigratorTests.swift */,
 				0125F1FAD971AFEE5D536AFD /* ProviderProfileStoreTests.swift */,
@@ -5480,6 +5485,7 @@
 				D04FD082244C1C8F6A4B8C3A /* ChatContextScope+Menu.swift */,
 				A18C8A706E429955843E3EC5 /* ChatSourceSelection.swift */,
 				AE50C2E67CBF0EB4747276C1 /* KeychainService+ProviderProfile.swift */,
+				6507DF977FFB9B74D8C20221 /* OpenAICompatibleProvider+ToolUse.swift */,
 				2652A8EB81DF49609A3EDAC8 /* ProviderKind.swift */,
 				9893809AE39B5DF0233FEE42 /* ProviderProfile.swift */,
 				2E550B37E4C8E30F6A9238E2 /* ProviderProfileMigrator.swift */,
@@ -6205,6 +6211,7 @@
 				319AE1251458BD5F7BFBF5A1 /* NotesRowStateTests.swift in Sources */,
 				BB25264CA5F169472F9C06CD /* NotesSwipeResolverTests.swift in Sources */,
 				32C58BAAF2DB529049921D4D /* OPDSParserTests.swift in Sources */,
+				B461333FC37C36CEB27D46B1 /* OpenAICompatibleProviderToolUseTests.swift in Sources */,
 				CBF9C34C3E23A55FD82B726D /* PDFAnnotationBridgeTests.swift in Sources */,
 				7381A2EB6ABF08C91A1C4F8F /* PDFBilingualPanelStateTests.swift in Sources */,
 				680F8342C5B16E574943FC20 /* PDFBilingualPanelTests.swift in Sources */,
@@ -6895,6 +6902,7 @@
 				44A1BF88B48D717D89913706 /* OPDSModels.swift in Sources */,
 				C545A7D59A2D63CC5B1DF45B /* OPDSParser.swift in Sources */,
 				DB1CB3500F488BBB187E9726 /* OffsetMap.swift in Sources */,
+				C5E268A84485A0E8312E5E4F /* OpenAICompatibleProvider+ToolUse.swift in Sources */,
 				8E2E64928835A3533FDE10FA /* PDFAnnotationBridge.swift in Sources */,
 				A7E29F29524E613439B24168 /* PDFBilingualPanel.swift in Sources */,
 				D09937B3D94A8AA30431956D /* PDFBilingualPanelBodies.swift in Sources */,

--- a/vreader/Services/AI/AIProvider.swift
+++ b/vreader/Services/AI/AIProvider.swift
@@ -56,7 +56,7 @@ struct OpenAICompatibleProvider: AIProvider, Sendable {
     let baseURL: URL
     let apiKey: String
     let model: String
-    private let session: URLSession
+    let session: URLSession
 
     init(
         providerName: String = "OpenAI",
@@ -133,17 +133,7 @@ struct OpenAICompatibleProvider: AIProvider, Sendable {
     // MARK: - Private
 
     private func buildURLRequest(for request: AIRequest, stream: Bool) throws -> URLRequest {
-        // Only send API key over HTTPS (or localhost for local LLM testing)
-        let isLocalhost = baseURL.host == "localhost" || baseURL.host == "127.0.0.1"
-        guard baseURL.scheme == "https" || isLocalhost else {
-            throw AIError.networkError("API key requires HTTPS connection (got \(baseURL.scheme ?? "none"))")
-        }
-
-        let endpoint = baseURL.appendingPathComponent("chat/completions")
-        var urlRequest = URLRequest(url: endpoint)
-        urlRequest.httpMethod = "POST"
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        urlRequest.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        var urlRequest = try makeChatCompletionsURLRequest()
 
         let systemPrompt = buildSystemPrompt(for: request.actionType)
         let userMessage = buildUserMessage(for: request)
@@ -160,6 +150,24 @@ struct OpenAICompatibleProvider: AIProvider, Sendable {
         }
 
         urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return urlRequest
+    }
+
+    /// Shared `/chat/completions` POST scaffolding (HTTPS check + endpoint +
+    /// headers) for both the plain-chat `buildURLRequest` and the Feature #91
+    /// tool-use `buildToolURLRequest`. The caller sets `httpBody`.
+    func makeChatCompletionsURLRequest() throws -> URLRequest {
+        // Only send API key over HTTPS (or localhost for local LLM testing)
+        let isLocalhost = baseURL.host == "localhost" || baseURL.host == "127.0.0.1"
+        guard baseURL.scheme == "https" || isLocalhost else {
+            throw AIError.networkError("API key requires HTTPS connection (got \(baseURL.scheme ?? "none"))")
+        }
+
+        let endpoint = baseURL.appendingPathComponent("chat/completions")
+        var urlRequest = URLRequest(url: endpoint)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         return urlRequest
     }
 
@@ -189,7 +197,7 @@ struct OpenAICompatibleProvider: AIProvider, Sendable {
         return message
     }
 
-    private func validateHTTPResponse(_ response: URLResponse, data: Data?) throws {
+    func validateHTTPResponse(_ response: URLResponse, data: Data?) throws {
         guard let httpResponse = response as? HTTPURLResponse else {
             throw AIError.networkError("Invalid response type")
         }

--- a/vreader/Services/AI/AITool.swift
+++ b/vreader/Services/AI/AITool.swift
@@ -208,6 +208,54 @@ struct AIToolRequest: Sendable, Equatable {
     let maxTokens: Int
 }
 
+/// Feature #91: shared validation of a tool-use message history — the
+/// provider-agnostic `ToolTurnMessage` invariants BOTH Anthropic (WI-3) and
+/// OpenAI (WI-4) require, so a malformed caller fails fast HERE instead of
+/// burning a provider 400 round-trip. Throws `AIError.providerError`.
+enum ToolHistoryValidator {
+    static func validate(_ messages: [ToolTurnMessage]) throws {
+        for (i, message) in messages.enumerated() {
+            let toolUseIDs: Set<String> = Set(message.content.compactMap {
+                if case .toolUse(let call) = $0 { return call.id } else { return nil }
+            })
+            if message.role == .assistant, !toolUseIDs.isEmpty {
+                guard i + 1 < messages.count, messages[i + 1].role == .user else {
+                    throw AIError.providerError(
+                        "malformed tool-use history: an assistant tool_use turn must be immediately followed by a user tool_result turn.")
+                }
+                let next = messages[i + 1]
+                guard case .toolResult = next.content.first else {
+                    throw AIError.providerError(
+                        "malformed tool-use history: the user turn after a tool_use must lead with tool_result blocks.")
+                }
+                // Every tool_use id MUST have a matching tool_result (providers
+                // 400 on a missing id).
+                let resultIDs: Set<String> = Set(next.content.compactMap {
+                    if case .toolResult(let r) = $0 { return r.toolUseID } else { return nil }
+                })
+                guard toolUseIDs.isSubset(of: resultIDs) else {
+                    throw AIError.providerError(
+                        "malformed tool-use history: every tool_use must have a matching tool_result (missing: \(toolUseIDs.subtracting(resultIDs).sorted().joined(separator: ", "))).")
+                }
+            }
+            // tool_result-blocks-first within any user message.
+            if message.role == .user {
+                var seenNonResult = false
+                for block in message.content {
+                    if case .toolResult = block {
+                        if seenNonResult {
+                            throw AIError.providerError(
+                                "malformed tool-use history: tool_result blocks must come before any other block in a user message.")
+                        }
+                    } else {
+                        seenNonResult = true
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// The parsed result of one provider turn: either the model produced a final
 /// answer with NO tool calls, or its turn contains at least one `tool_use`.
 ///

--- a/vreader/Services/AI/AnthropicProvider+ToolUse.swift
+++ b/vreader/Services/AI/AnthropicProvider+ToolUse.swift
@@ -157,54 +157,11 @@ extension AnthropicProvider {
 
     // MARK: - History validation (Gate-4 Medium)
 
-    /// Validate a tool-use message history against Anthropic's adjacency rules so
-    /// a malformed caller fails fast HERE instead of burning a 400 round-trip:
-    ///   1. Every assistant turn that contains a `tool_use` block MUST be
-    ///      immediately followed by a `user` turn.
-    ///   2. That following user turn's content MUST LEAD with `tool_result`
-    ///      blocks (all tool_results before any other block) — and generally, in
-    ///      ANY user message, no non-`tool_result` block may precede a
-    ///      `tool_result` block.
-    /// Throws `AIError.providerError` on a violation.
+    /// Validate a tool-use message history — forwards to the shared
+    /// `ToolHistoryValidator` (Gate-4 WI-4: the rules are provider-agnostic, so
+    /// OpenAI reuses the same validator). Kept as a forwarder so existing tests
+    /// and `buildToolURLRequest` keep their call site.
     static func validateToolHistory(_ messages: [ToolTurnMessage]) throws {
-        for (i, message) in messages.enumerated() {
-            let toolUseIDs: Set<String> = Set(message.content.compactMap {
-                if case .toolUse(let call) = $0 { return call.id } else { return nil }
-            })
-            if message.role == .assistant, !toolUseIDs.isEmpty {
-                guard i + 1 < messages.count, messages[i + 1].role == .user else {
-                    throw AIError.providerError(
-                        "malformed tool-use history: an assistant tool_use turn must be immediately followed by a user tool_result turn.")
-                }
-                let next = messages[i + 1]
-                guard case .toolResult = next.content.first else {
-                    throw AIError.providerError(
-                        "malformed tool-use history: the user turn after a tool_use must lead with tool_result blocks.")
-                }
-                // Every tool_use id MUST have a matching tool_result in the next
-                // user turn (Anthropic 400s on a missing tool_use id).
-                let resultIDs: Set<String> = Set(next.content.compactMap {
-                    if case .toolResult(let r) = $0 { return r.toolUseID } else { return nil }
-                })
-                guard toolUseIDs.isSubset(of: resultIDs) else {
-                    throw AIError.providerError(
-                        "malformed tool-use history: every tool_use must have a matching tool_result (missing: \(toolUseIDs.subtracting(resultIDs).sorted().joined(separator: ", "))).")
-                }
-            }
-            // tool_result-blocks-first within any user message.
-            if message.role == .user {
-                var seenNonResult = false
-                for block in message.content {
-                    if case .toolResult = block {
-                        if seenNonResult {
-                            throw AIError.providerError(
-                                "malformed tool-use history: tool_result blocks must come before any other block in a user message.")
-                        }
-                    } else {
-                        seenNonResult = true
-                    }
-                }
-            }
-        }
+        try ToolHistoryValidator.validate(messages)
     }
 }

--- a/vreader/Services/AI/OpenAICompatibleProvider+ToolUse.swift
+++ b/vreader/Services/AI/OpenAICompatibleProvider+ToolUse.swift
@@ -1,0 +1,192 @@
+// Purpose: Feature #91 WI-4 — OpenAI-style function-calling for the agentic chat
+// loop. Adds `supportsToolUse`/`sendToolRequest` (the WI-2 seam) for
+// `OpenAICompatibleProvider`. OpenAI's wire shape differs from Anthropic's
+// (WI-3), so this maps the shared `ToolTurnMessage` model onto it:
+//
+//   tools:        [{type:"function", function:{name, description, parameters}}]
+//   assistant:    {role:"assistant", content:<text|null>, tool_calls:[{id, type:"function", function:{name, arguments:<JSON STRING>}}]}
+//   tool result:  a SEPARATE {role:"tool", tool_call_id, content} message (NOT a content block)
+//   response:     choices[0].message.tool_calls (else .content); finish_reason "tool_calls" | "stop" | "length"
+//
+// Key translation quirks vs Anthropic: `arguments` is a JSON STRING (encode the
+// input object, parse the string back); a user turn carrying `tool_result` blocks
+// expands to N `role:"tool"` messages; `finish_reason == "length"` is the
+// truncation analog of Anthropic's `max_tokens` stop_reason.
+//
+// @coordinates-with: AIProvider.swift (OpenAICompatibleProvider + WI-2 seam),
+//   AITool.swift (DTOs), AnthropicProvider+ToolUse.swift (the Anthropic sibling),
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-4)
+
+import Foundation
+
+extension OpenAICompatibleProvider {
+
+    var supportsToolUse: Bool { true }
+
+    func sendToolRequest(_ request: AIToolRequest) async throws -> AIToolTurn {
+        let urlRequest = try buildToolURLRequest(request)
+        let (data, response) = try await session.data(for: urlRequest)
+        try validateHTTPResponse(response, data: data)
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AIError.invalidResponse
+        }
+        return try Self.parseToolResponse(json)
+    }
+
+    /// Assemble the `/chat/completions` body for a tool-use turn.
+    func buildToolURLRequest(_ request: AIToolRequest) throws -> URLRequest {
+        // Gate-4 Medium: fail fast on a malformed tool-use history (shared with
+        // the Anthropic path) — every assistant tool_call must be answered.
+        try ToolHistoryValidator.validate(request.messages)
+        var urlRequest = try makeChatCompletionsURLRequest()
+        var messages: [[String: Any]] = [
+            ["role": "system", "content": request.systemPrompt],
+        ]
+        for message in request.messages {
+            messages.append(contentsOf: Self.encodeMessage(message))
+        }
+        var body: [String: Any] = ["model": model, "messages": messages]
+        if request.maxTokens >= 1 {
+            body["max_tokens"] = request.maxTokens
+        }
+        if !request.tools.isEmpty {
+            body["tools"] = request.tools.map { Self.encodeTool($0) }
+        }
+        urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return urlRequest
+    }
+
+    // MARK: - Encode (shared DTO → OpenAI JSON)
+
+    static func encodeTool(_ tool: ToolDefinition) -> [String: Any] {
+        [
+            "type": "function",
+            "function": [
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.inputSchema.toFoundation(),
+            ],
+        ]
+    }
+
+    /// Map ONE shared `ToolTurnMessage` to one-or-more OpenAI messages — a user
+    /// turn carrying `tool_result` blocks expands into separate `role:"tool"`
+    /// messages (OpenAI has no tool_result-block concept).
+    static func encodeMessage(_ message: ToolTurnMessage) -> [[String: Any]] {
+        switch message.role {
+        case .user:
+            var out: [[String: Any]] = []
+            // tool_result blocks → individual tool messages.
+            for block in message.content {
+                if case .toolResult(let result) = block {
+                    out.append([
+                        "role": "tool",
+                        "tool_call_id": result.toolUseID,
+                        "content": result.content,
+                    ])
+                }
+            }
+            // Any text blocks → one user message (rare in a tool-result turn).
+            let text = message.content.compactMap {
+                if case .text(let t) = $0 { return t } else { return nil }
+            }.joined(separator: "\n")
+            if !text.isEmpty {
+                out.append(["role": "user", "content": text])
+            }
+            return out
+        case .assistant:
+            let text = message.content.compactMap {
+                if case .text(let t) = $0 { return t } else { return nil }
+            }.joined(separator: "\n")
+            let toolCalls: [[String: Any]] = message.content.compactMap {
+                guard case .toolUse(let call) = $0 else { return nil }
+                return [
+                    "id": call.id,
+                    "type": "function",
+                    "function": [
+                        "name": call.name,
+                        "arguments": encodeArguments(call.input),
+                    ],
+                ]
+            }
+            var msg: [String: Any] = ["role": "assistant"]
+            // OpenAI wants content null when only tool_calls are present.
+            msg["content"] = text.isEmpty ? NSNull() : text
+            if !toolCalls.isEmpty {
+                msg["tool_calls"] = toolCalls
+            }
+            return [msg]
+        }
+    }
+
+    /// OpenAI `function.arguments` is a JSON STRING (not an object). Encode the
+    /// input object; an empty / non-object input degrades to "{}".
+    static func encodeArguments(_ input: JSONValue) -> String {
+        guard input.isWellFormed,
+              let data = try? JSONSerialization.data(
+                withJSONObject: input.toFoundation(), options: [.fragmentsAllowed]),
+              let str = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return str
+    }
+
+    // MARK: - Parse (OpenAI JSON → AIToolTurn)
+
+    /// Parse a `/chat/completions` response into an `AIToolTurn`, honoring
+    /// `finish_reason` (a `length` truncation is rejected as retriable, the
+    /// analog of Anthropic's `max_tokens`).
+    static func parseToolResponse(_ json: [String: Any]) throws -> AIToolTurn {
+        guard let choices = json["choices"] as? [[String: Any]],
+              let first = choices.first,
+              let message = first["message"] as? [String: Any] else {
+            throw AIError.invalidResponse
+        }
+        if first["finish_reason"] as? String == "length" {
+            throw AIError.providerError(
+                "Response truncated (finish_reason=length) — increase the token budget and retry.")
+        }
+        // tool_calls present → parse the VALID calls first (Gate-4 Medium: don't
+        // return a .toolUse turn with zero executable calls — that would wedge the
+        // loop). Only commit to .toolUse if at least one valid call survives.
+        if let toolCalls = message["tool_calls"] as? [[String: Any]], !toolCalls.isEmpty {
+            var blocks: [ToolContentBlock] = []
+            if let text = message["content"] as? String, !text.isEmpty {
+                blocks.append(.text(text))
+            }
+            var validCalls = 0
+            for call in toolCalls {
+                guard let id = call["id"] as? String,
+                      let fn = call["function"] as? [String: Any],
+                      let name = fn["name"] as? String else { continue }
+                let input = Self.decodeArguments(fn["arguments"] as? String)
+                blocks.append(.toolUse(ToolCall(id: id, name: name, input: input)))
+                validCalls += 1
+            }
+            if validCalls > 0 {
+                return .toolUse(blocks: blocks)
+            }
+            // All tool_calls were malformed — fall back to any text, else fail.
+            if let text = message["content"] as? String, !text.isEmpty {
+                return .text(text)
+            }
+            throw AIError.invalidResponse
+        }
+        // Otherwise final text.
+        let content = message["content"] as? String ?? ""
+        return .text(content)
+    }
+
+    /// Parse an OpenAI `function.arguments` JSON string back into a `JSONValue`.
+    /// A nil / malformed string degrades to an empty object (the loop's tool
+    /// executor then reports an `isError` result for missing required fields).
+    static func decodeArguments(_ arguments: String?) -> JSONValue {
+        guard let arguments, let data = arguments.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(
+                with: data, options: [.fragmentsAllowed]) else {
+            return .object([:])
+        }
+        return JSONValue(foundation: obj)
+    }
+}

--- a/vreaderTests/Services/AI/OpenAICompatibleProviderToolUseTests.swift
+++ b/vreaderTests/Services/AI/OpenAICompatibleProviderToolUseTests.swift
@@ -1,0 +1,233 @@
+// Purpose: Feature #91 WI-4 — pin the OpenAI-style function-calling request
+// assembly + response parsing for OpenAICompatibleProvider. `buildToolURLRequest`
+// is synchronous so the body is asserted by decoding its `httpBody`;
+// `parseToolResponse` / `encodeArguments` / `decodeArguments` / `encodeMessage`
+// are pure. Mirrors the Anthropic WI-3 tests for the (different) OpenAI wire shape.
+//
+// @coordinates-with: OpenAICompatibleProvider+ToolUse.swift, AITool.swift,
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-4)
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("Feature #91 WI-4 — OpenAI function-calling")
+struct OpenAICompatibleProviderToolUseTests {
+
+    private func makeProvider() -> OpenAICompatibleProvider {
+        OpenAICompatibleProvider(
+            providerName: "OpenAI",
+            baseURL: URL(string: "https://api.openai.com/v1")!,
+            apiKey: "k", model: "gpt-x", session: .shared)
+    }
+
+    private static let toolDef = ToolDefinition(
+        name: "search_current_book",
+        description: "Full-text search the open book.",
+        inputSchema: .object([
+            "type": .string("object"),
+            "properties": .object(["query": .object(["type": .string("string")])]),
+        ]))
+
+    private func decodeBody(_ req: URLRequest) throws -> [String: Any] {
+        try #require(req.httpBody.flatMap {
+            try? JSONSerialization.jsonObject(with: $0) as? [String: Any]
+        })
+    }
+
+    // MARK: - Capability
+
+    @Test("OpenAICompatibleProvider supports tool use")
+    func supportsToolUse() {
+        #expect(makeProvider().supportsToolUse == true)
+    }
+
+    // MARK: - Request assembly
+
+    @Test("tools serialize as OpenAI function objects (type/function.name/description/parameters)")
+    func toolsAsFunctionObjects() throws {
+        let req = AIToolRequest(systemPrompt: "sys",
+            messages: [ToolTurnMessage(role: .user, content: [.text("find darcy")])],
+            tools: [Self.toolDef], maxTokens: 1024)
+        let body = try decodeBody(try makeProvider().buildToolURLRequest(req))
+        #expect(body["model"] as? String == "gpt-x")
+        #expect(body["max_tokens"] as? Int == 1024)
+        let tools = try #require(body["tools"] as? [[String: Any]])
+        #expect(tools[0]["type"] as? String == "function")
+        let fn = try #require(tools[0]["function"] as? [String: Any])
+        #expect(fn["name"] as? String == "search_current_book")
+        #expect(fn["description"] as? String == "Full-text search the open book.")
+        #expect(fn["parameters"] is [String: Any])
+        // system message is first.
+        let messages = try #require(body["messages"] as? [[String: Any]])
+        #expect(messages[0]["role"] as? String == "system")
+        #expect(messages[0]["content"] as? String == "sys")
+    }
+
+    @Test("an assistant tool_use maps to tool_calls with arguments as a JSON STRING")
+    func assistantToolCallsArgumentsAreString() throws {
+        let call = ToolCall(id: "call_1", name: "search",
+                            input: .object(["q": .string("darcy")]))
+        let req = AIToolRequest(systemPrompt: "s",
+            messages: [
+                ToolTurnMessage(role: .user, content: [.text("find")]),
+                ToolTurnMessage(role: .assistant, content: [.text("searching"), .toolUse(call)]),
+                ToolTurnMessage(role: .user, content: [
+                    .toolResult(ToolResult(toolUseID: "call_1", content: "3 hits")),
+                ]),
+            ], tools: [Self.toolDef], maxTokens: 512)
+        let body = try decodeBody(try makeProvider().buildToolURLRequest(req))
+        let messages = try #require(body["messages"] as? [[String: Any]])
+        // [system, user, assistant, tool]
+        #expect(messages.count == 4)
+        let asst = messages[2]
+        #expect(asst["role"] as? String == "assistant")
+        #expect(asst["content"] as? String == "searching")
+        let toolCalls = try #require(asst["tool_calls"] as? [[String: Any]])
+        #expect(toolCalls[0]["id"] as? String == "call_1")
+        #expect(toolCalls[0]["type"] as? String == "function")
+        let fn = try #require(toolCalls[0]["function"] as? [String: Any])
+        #expect(fn["name"] as? String == "search")
+        // arguments MUST be a JSON string, not an object.
+        let argsStr = try #require(fn["arguments"] as? String)
+        #expect(argsStr.contains("\"q\""))
+        #expect(argsStr.contains("darcy"))
+        // the tool_result user turn became a role:tool message.
+        #expect(messages[3]["role"] as? String == "tool")
+        #expect(messages[3]["tool_call_id"] as? String == "call_1")
+        #expect(messages[3]["content"] as? String == "3 hits")
+    }
+
+    @Test("an assistant turn with only tool_calls sets content to null")
+    func assistantNoTextContentNull() throws {
+        let call = ToolCall(id: "c", name: "n", input: .null)
+        let req = AIToolRequest(systemPrompt: "s",
+            messages: [ToolTurnMessage(role: .assistant, content: [.toolUse(call)]),
+                       ToolTurnMessage(role: .user, content: [.toolResult(ToolResult(toolUseID: "c", content: "r"))])],
+            tools: [], maxTokens: 256)
+        let body = try decodeBody(try makeProvider().buildToolURLRequest(req))
+        let messages = try #require(body["messages"] as? [[String: Any]])
+        #expect(messages[1]["content"] is NSNull)
+    }
+
+    @Test("Bearer auth + chat/completions endpoint")
+    func headers() throws {
+        let req = AIToolRequest(systemPrompt: "s",
+            messages: [ToolTurnMessage(role: .user, content: [.text("hi")])],
+            tools: [], maxTokens: 128)
+        let urlReq = try makeProvider().buildToolURLRequest(req)
+        #expect(urlReq.value(forHTTPHeaderField: "Authorization") == "Bearer k")
+        #expect(urlReq.url?.absoluteString.hasSuffix("/chat/completions") == true)
+    }
+
+    // MARK: - arguments JSON-string round-trip
+
+    @Test("encodeArguments emits a JSON object string; decodeArguments round-trips it")
+    func argumentsRoundTrip() {
+        let input = JSONValue.object(["q": .string("x"), "n": .number(2)])
+        let str = OpenAICompatibleProvider.encodeArguments(input)
+        #expect(OpenAICompatibleProvider.decodeArguments(str) == input)
+        // degenerate inputs degrade safely.
+        #expect(OpenAICompatibleProvider.encodeArguments(.null) == "{}" ||
+                OpenAICompatibleProvider.encodeArguments(.null) == "null")
+        #expect(OpenAICompatibleProvider.decodeArguments(nil) == .object([:]))
+        #expect(OpenAICompatibleProvider.decodeArguments("not json") == .object([:]))
+    }
+
+    // MARK: - Response parsing
+
+    @Test("a tool_calls response parses to a .toolUse turn (arguments string → JSONValue)")
+    func parseToolCallsResponse() throws {
+        let json: [String: Any] = [
+            "choices": [[
+                "message": [
+                    "role": "assistant", "content": NSNull(),
+                    "tool_calls": [[
+                        "id": "call_9", "type": "function",
+                        "function": ["name": "search_current_book", "arguments": "{\"query\":\"darcy\"}"],
+                    ]],
+                ],
+                "finish_reason": "tool_calls",
+            ]],
+        ]
+        let turn = try OpenAICompatibleProvider.parseToolResponse(json)
+        #expect(turn.toolCalls == [ToolCall(id: "call_9", name: "search_current_book",
+                                            input: .object(["query": .string("darcy")]))])
+    }
+
+    @Test("a text response parses to a .text turn")
+    func parseTextResponse() throws {
+        let json: [String: Any] = [
+            "choices": [["message": ["content": "Final answer."], "finish_reason": "stop"]],
+        ]
+        #expect(try OpenAICompatibleProvider.parseToolResponse(json) == .text("Final answer."))
+    }
+
+    @Test("a length-truncated response is rejected")
+    func parseTruncatedThrows() {
+        let json: [String: Any] = [
+            "choices": [["message": ["content": "partial"], "finish_reason": "length"]],
+        ]
+        #expect(throws: AIError.self) { _ = try OpenAICompatibleProvider.parseToolResponse(json) }
+    }
+
+    @Test("a missing/empty choices response throws invalidResponse")
+    func parseMissingChoicesThrows() {
+        #expect(throws: AIError.self) { _ = try OpenAICompatibleProvider.parseToolResponse([:]) }
+        #expect(throws: AIError.self) {
+            _ = try OpenAICompatibleProvider.parseToolResponse(["choices": []])
+        }
+    }
+
+    @Test("a malformed tool_call (missing id) is skipped")
+    func parseMalformedToolCallSkipped() throws {
+        let json: [String: Any] = [
+            "choices": [[
+                "message": [
+                    "content": NSNull(),
+                    "tool_calls": [
+                        ["type": "function", "function": ["name": "x", "arguments": "{}"]],  // no id
+                        ["id": "ok", "type": "function", "function": ["name": "y", "arguments": "{}"]],
+                    ],
+                ],
+                "finish_reason": "tool_calls",
+            ]],
+        ]
+        let turn = try OpenAICompatibleProvider.parseToolResponse(json)
+        #expect(turn.toolCalls.map(\.id) == ["ok"])
+    }
+
+    @Test("tool_calls present but ALL malformed → fall back to text (not an empty .toolUse)")
+    func allMalformedToolCallsFallBack() throws {
+        // Gate-4 Medium: a .toolUse turn with zero executable calls would wedge
+        // the loop — fall back to assistant text when present.
+        let withText: [String: Any] = [
+            "choices": [[
+                "message": [
+                    "content": "here is my answer",
+                    "tool_calls": [["type": "function", "function": ["name": "x"]]],  // no id
+                ],
+                "finish_reason": "tool_calls",
+            ]],
+        ]
+        #expect(try OpenAICompatibleProvider.parseToolResponse(withText) == .text("here is my answer"))
+        // …and throw when neither a valid call nor text remains.
+        let noText: [String: Any] = [
+            "choices": [["message": [
+                "content": NSNull(),
+                "tool_calls": [["type": "function", "function": ["name": "x"]]],
+            ]]],
+        ]
+        #expect(throws: AIError.self) { _ = try OpenAICompatibleProvider.parseToolResponse(noText) }
+    }
+
+    @Test("buildToolURLRequest validates the tool-use history (shared validator)")
+    func buildValidatesHistory() {
+        let call = ToolCall(id: "c", name: "n", input: .null)
+        // assistant tool_use with NO answering tool_result → invalid → throws.
+        let bad = AIToolRequest(systemPrompt: "s",
+            messages: [ToolTurnMessage(role: .assistant, content: [.toolUse(call)])],
+            tools: [], maxTokens: 256)
+        #expect(throws: AIError.self) { _ = try makeProvider().buildToolURLRequest(bad) }
+    }
+}


### PR DESCRIPTION
## Summary

WI-4 of Feature #91 — the second provider tool-use impl (sibling to Anthropic WI-3). `OpenAICompatibleProvider` gains the WI-2 seam, mapping the shared `ToolTurnMessage` model onto OpenAI's distinct wire shape.

Part of feature #1482.

## What Changed

- **`OpenAICompatibleProvider+ToolUse.swift`** (new) — tools → `[{type:function, function:{name,description,parameters}}]`; a user tool_result turn → separate `{role:tool, tool_call_id, content}` messages; `tool_calls[].function.arguments` as a JSON **string** (encode/decode); assistant `content:null` when only tool_calls; `finish_reason:"length"` → retriable truncation error.
- **`AITool.swift`** — extracted a **shared `ToolHistoryValidator`** (provider-agnostic).
- **`AnthropicProvider+ToolUse.swift`** — `validateToolHistory` now forwards to the shared validator.
- **`AIProvider.swift`** — extracted `makeChatCompletionsURLRequest()` + widened `session`/`validateHTTPResponse` to internal.

## WI Status

- WI-4: **behavioral** — this PR. Done: WI-1/2/3/4. Remaining: WI-5 (registry), WI-6a/b/c (tools), WI-7 (driver), WI-8 (VM wiring).

## Codex Audit (Gate 4)

2 rounds, **ship-as-is**. Wire format **confirmed correct** per the OpenAI docs. Two Mediums fixed: (1) extracted the history validator to a **shared** `ToolHistoryValidator` both providers use (OpenAI 400s the same as Anthropic on an unanswered tool_call); (2) `parseToolResponse` returns `.toolUse` only when **≥1 valid** call survives (else falls back to text/throws) so an all-malformed `tool_calls` array can't wedge the loop.

Audit log: `.claude/codex-audits/feat-feature-91-wi-4-openai-funccall-audit.md`

## Validation

- [x] `OpenAICompatibleProviderToolUseTests` + `AnthropicProviderToolUseTests` green (the shared-validator extraction is behavior-preserving)
- [x] Codex audit (2 rounds, ship-as-is)
- [x] Version bumped: 3.51.8 → 3.51.9

## Type of Change

- [x] Behavioral WI (Part of feature #1482)