### PR TITLE
feat(#91 WI-5): AIToolRegistry (foundational)

### DIFF
--- a/.claude/codex-audits/feat-feature-91-wi-5-tool-registry-audit.md
+++ b/.claude/codex-audits/feat-feature-91-wi-5-tool-registry-audit.md
@@ -1,0 +1,42 @@
+---
+branch: feat/feature-91-wi-5-tool-registry
+threadId: 019e911a-6746-7502-bca3-9aebe3081261
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-03
+---
+
+# Codex Audit — Feature #91 WI-5 (AIToolRegistry)
+
+Gate-4 implementation audit (rule 47). Independent Codex runner via
+`scripts/run-codex.sh -e high` (author/auditor separation, rule 48).
+
+## Scope
+
+Foundational WI-5 — the tool registry + `JSONValue` input accessors:
+
+- `vreader/Services/AI/AIToolRegistry.swift` (new) — `struct AIToolRegistry: Sendable`; `run(_ call:)` dispatches + rebinds the call id; unknown tool → `isError` result (never throws); `definitions()`; `isEmpty`. Plus `JSONValue` accessors (`subscript[key]`, `stringValue`/`intValue`/`doubleValue`/`boolValue`).
+- `vreaderTests/Services/AI/AIToolRegistryTests.swift` (new).
+
+## Round 1 — findings (threadId 019e911a-6746-7502-bca3-9aebe3081261)
+
+Call-id rebinding, fail-closed, and `Sendable` on `[String: any AITool]` all
+confirmed sound. Findings:
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| AIToolRegistry.swift `definitions()` | **Medium** | Re-read each tool's LIVE `definition` instead of an init-time snapshot — a conformer with a mutable-state definition could advertise name/schema B while dispatch keyed on init-time name A. | **Fixed.** Init snapshots each `definition` once into `definitionsByName` alongside `toolsByName`; `definitions()` returns the frozen snapshot, dispatch keys on the same init-time name. No drift possible. |
+| AIToolRegistry.swift init | Low | Duplicate names silently shadowed. | **Fixed.** A `Logger.warning` flags a collision (non-trapping — the "never traps" contract is load-bearing for the loop, so NOT an `assert`; last-wins retained). |
+| AIToolRegistryTests.swift | Low | `intValue` large-integral boundary untested/undocumented. | **Fixed.** `intValue` documents the precision-safe `\|n\| < 2^53` range (named constant); `intValuePrecisionBoundary` pins 2^53-1 → Int, 2^53 / -2^53 / ∞ → nil. |
+
+## Round 2 — verification (threadId 019e912c-defc-7f21-aef3-93a73d41a752)
+
+All three **RESOLVED**, no new findings. The snapshot guarantees advertised ==
+dispatched; the dup signal is a non-trapping `Logger.warning`; the boundary test
++ doc pin the precision-safe semantics.
+
+## Verdict
+
+**ship-as-is.** Zero open Critical/High/Medium after round 2. `AIToolRegistryTests`
+green (dispatch + id-rebinding, fail-closed unknown tool, last-wins dup, definitions
+order, JSONValue accessors incl. the 2^53 boundary).

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 865
-        MARKETING_VERSION: 3.51.9
+        CURRENT_PROJECT_VERSION: 866
+        MARKETING_VERSION: 3.51.10
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7425,7 +7425,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 865;
+				CURRENT_PROJECT_VERSION = 866;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7433,7 +7433,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.9;
+				MARKETING_VERSION = 3.51.10;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7579,7 +7579,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 865;
+				CURRENT_PROJECT_VERSION = 866;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7587,7 +7587,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.9;
+				MARKETING_VERSION = 3.51.10;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -484,6 +484,7 @@
 		4CCE624D88A6301BB7A2E18C /* V6toV7MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6832D0CE94B6D7181A2D82B0 /* V6toV7MigrationTests.swift */; };
 		4CDDE0625D290A614C772CF1 /* HighlightEditHandoffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F32CF0D8EA1782A58090C09 /* HighlightEditHandoffTests.swift */; };
 		4D262FBAEBAC69E057B371DA /* SourceSerif4-It.otf in Resources */ = {isa = PBXBuildFile; fileRef = BDD31D89F9B0E622F58B6F5C /* SourceSerif4-It.otf */; };
+		4D31B2077F604638F279165F /* AIToolRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F05D46F6815F5175572AEFF /* AIToolRegistryTests.swift */; };
 		4D323FB1DB077A50154AFC72 /* SummaryScopeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4201BB3B1C117672C45389AE /* SummaryScopeResolverTests.swift */; };
 		4D4A49E8738329EC2B336683 /* TXTReaderViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D998048CE6DE8DC3BC77C284 /* TXTReaderViewModelTests.swift */; };
 		4D4D7B16BBA5732D1E6AB875 /* GenerativeCoverMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF66A8065E5B60907FB0A3C8 /* GenerativeCoverMetrics.swift */; };
@@ -1067,6 +1068,7 @@
 		AF530BEC6BEA9625240F57C3 /* ChapterPrefetching.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DB79901C559905D3015DD3 /* ChapterPrefetching.swift */; };
 		AF710860E4C45D5A6750EC74 /* SourceSerif4-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 14FC5A8465BA6BCCB0751270 /* SourceSerif4-Regular.otf */; };
 		AF7D99D9C0CEA266BFD976B8 /* MetadataExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAE6C27BECED96A8DA016439 /* MetadataExtractor.swift */; };
+		AF8AC0AC3C16698D0E8B5524 /* AIToolRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C5EB066E167F441DAA4A19A /* AIToolRegistry.swift */; };
 		AFA2A219EE9A27F09BF552D0 /* ReadingStatsAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DBD86DDBB52369C831FF078 /* ReadingStatsAggregator.swift */; };
 		AFBEC85BAAD8651B52E46DC5 /* TextHighlightRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7E3B8864B52047738D5006 /* TextHighlightRenderer.swift */; };
 		AFE6C4ADD50C68610CE76DA2 /* HighlightPopoverMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5725E598AB5CBA16440549D4 /* HighlightPopoverMode.swift */; };
@@ -1881,6 +1883,7 @@
 		3C3606C4B6B47F89102CCF3A /* BookDetailsRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailsRouteTests.swift; sourceTree = "<group>"; };
 		3C39119533D269F76F970FD1 /* PDFPageNavigatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFPageNavigatorTests.swift; sourceTree = "<group>"; };
 		3C567EE93DC61BBB63CEAC20 /* Locator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locator.swift; sourceTree = "<group>"; };
+		3C5EB066E167F441DAA4A19A /* AIToolRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIToolRegistry.swift; sourceTree = "<group>"; };
 		3CA99312EF465709359C1EBF /* ReaderMoreMenuBilingualTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderMoreMenuBilingualTests.swift; sourceTree = "<group>"; };
 		3D16B9536A1919EBEBAA22B3 /* SettingsProfileCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsProfileCardTests.swift; sourceTree = "<group>"; };
 		3D6C41170131F22118778D83 /* FontSizeCalibration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCalibration.swift; sourceTree = "<group>"; };
@@ -2310,6 +2313,7 @@
 		7DE6A4A50E59B50DE7574A87 /* paginator.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = paginator.js; sourceTree = "<group>"; };
 		7DEA283D3F2224EDC297B6E1 /* MDFileLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDFileLoader.swift; sourceTree = "<group>"; };
 		7E86175071842E275652A4F2 /* ReaderContainerView+DebugBridgeRenderedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderContainerView+DebugBridgeRenderedText.swift"; sourceTree = "<group>"; };
+		7F05D46F6815F5175572AEFF /* AIToolRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIToolRegistryTests.swift; sourceTree = "<group>"; };
 		7F1BC0259A472381A819DF2A /* mobi.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = mobi.js; sourceTree = "<group>"; };
 		7F2360F05D5C411D05806514 /* ReaderThemeV2EPUBCSSChapterStartTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderThemeV2EPUBCSSChapterStartTests.swift; sourceTree = "<group>"; };
 		7F49F51FD45D703CEF790F7C /* ChapterTranslation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterTranslation.swift; sourceTree = "<group>"; };
@@ -5160,6 +5164,7 @@
 				6F95BA4F7C74E524DFCCF548 /* AIServiceResolvedConfigTests.swift */,
 				EFB9DBE73613A6499D43B18C /* AIServiceTests.swift */,
 				3840F0544DB0B9050ECBB5F6 /* AIToolDTOTests.swift */,
+				7F05D46F6815F5175572AEFF /* AIToolRegistryTests.swift */,
 				1836AA0E3E80CADFB1B46834 /* AnthropicProviderStreamingTests.swift */,
 				E5892DBA34520F6BB7B8E5A3 /* AnthropicProviderTests.swift */,
 				D6686907B7FE75075E1D9EDC /* AnthropicProviderToolUseTests.swift */,
@@ -5463,6 +5468,7 @@
 				F4C18F1E19149F8DBAE36A31 /* AIResponseCache.swift */,
 				334D6D06A294323E149970E4 /* AIService.swift */,
 				62389E1899D77BB9A41C659B /* AITool.swift */,
+				3C5EB066E167F441DAA4A19A /* AIToolRegistry.swift */,
 				46C22F30DF9F05C20CF8DDBC /* AITypes.swift */,
 				B8C6D6A8EC00DFFAC294DD87 /* AnthropicProvider.swift */,
 				C682F2AF644C10CEC95208AE /* AnthropicProvider+Streaming.swift */,
@@ -5884,6 +5890,7 @@
 				768E594123AD4AA389E2BEAC /* AISummaryTabViewTests.swift in Sources */,
 				CC7B6678D819D6A755585B4A /* AITestSetupTests.swift in Sources */,
 				26E7875B7202377642B83BB9 /* AIToolDTOTests.swift in Sources */,
+				4D31B2077F604638F279165F /* AIToolRegistryTests.swift in Sources */,
 				5C20BECE1338802F60F3E7B7 /* AITranslationTests.swift in Sources */,
 				495502CCD0035DB7C8AE37DA /* AccentColorTests.swift in Sources */,
 				65C927CBE6855076656719CE /* AccessibilityFormattersTests.swift in Sources */,
@@ -6522,6 +6529,7 @@
 				7E767F5BB300F8588492BD31 /* AISummaryTabView.swift in Sources */,
 				E30164DD8662A9243007269E /* AITestSetup.swift in Sources */,
 				3D3D595F747F17868E8CB120 /* AITool.swift in Sources */,
+				AF8AC0AC3C16698D0E8B5524 /* AIToolRegistry.swift in Sources */,
 				7EE8C91043F4F20D39AF326B /* AITranslationViewModel.swift in Sources */,
 				FD9B24BBE1D852DA18A23E6F /* AITypes.swift in Sources */,
 				9AEE4782EDC4308FAA289B3B /* AccentColor.swift in Sources */,

--- a/vreader/Services/AI/AIToolRegistry.swift
+++ b/vreader/Services/AI/AIToolRegistry.swift
@@ -1,0 +1,120 @@
+// Purpose: Feature #91 WI-5 (foundational) — the tool registry that the agentic
+// loop (WI-7) dispatches `ToolCall`s through, plus small `JSONValue` input
+// accessors the tool executors (WI-6) read their arguments with. Pure value type;
+// no concrete tools yet.
+//
+// Key decisions:
+// - The registry OWNS the call→result binding: a tool's `run(_ input:)` produces
+//   content + isError, and the registry stamps `call.id` onto the returned
+//   `ToolResult` (the tool doesn't know the provider-assigned call id). So an
+//   executor can build a `ToolResult` with any `toolUseID` — the registry
+//   overwrites it.
+// - `run` NEVER throws: an unknown tool name yields an `isError` result the model
+//   can route around, so a hallucinated tool name can't crash the loop.
+// - Duplicate tool names are last-wins (not a trap) so registration order is safe.
+//
+// @coordinates-with: AITool.swift (DTOs + AITool protocol),
+//   AgenticChatDriver.swift (WI-7 consumer), AnthropicProvider+ToolUse.swift /
+//   OpenAICompatibleProvider+ToolUse.swift (the providers that emit ToolCalls),
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-5)
+
+import Foundation
+import OSLog
+
+/// Maps tool name → `AITool`, exposes the tool definitions for the provider
+/// `tools` array, and dispatches a `ToolCall` to its tool (binding the call id).
+struct AIToolRegistry: Sendable {
+
+    private static let log = Logger(subsystem: "com.vreader.app", category: "AIToolRegistry")
+
+    private let toolsByName: [String: any AITool]
+    /// Gate-4 Medium: the tool definitions are SNAPSHOT once at registration so
+    /// `definitions()` (what the provider is told) can never drift from the
+    /// dispatch key in `toolsByName` — even if a conformer's `definition` is
+    /// computed from mutable state.
+    private let definitionsByName: [String: ToolDefinition]
+
+    init(_ tools: [any AITool]) {
+        var byName: [String: any AITool] = [:]
+        var defs: [String: ToolDefinition] = [:]
+        for tool in tools {
+            let definition = tool.definition  // snapshot ONCE — frozen metadata.
+            // Last-wins on a duplicate name (registration safe; never traps), but
+            // LOG it so an accidental collision is visible during development
+            // (a non-trapping warning — the "never traps" contract is load-bearing
+            // for the agentic loop's robustness).
+            if byName[definition.name] != nil {
+                Self.log.warning(
+                    "duplicate tool name '\(definition.name, privacy: .public)' — the later one wins.")
+            }
+            byName[definition.name] = tool
+            defs[definition.name] = definition
+        }
+        toolsByName = byName
+        definitionsByName = defs
+    }
+
+    /// Whether the registry has any tools (the loop only enables tool-use when so).
+    var isEmpty: Bool { toolsByName.isEmpty }
+
+    /// The tool definitions to send in the provider `tools` array (the frozen
+    /// init-time snapshot, name-sorted for a deterministic request).
+    func definitions() -> [ToolDefinition] {
+        definitionsByName.keys.sorted().compactMap { definitionsByName[$0] }
+    }
+
+    /// Dispatch a `ToolCall` to its tool, binding the result to THIS call's id.
+    /// An unknown tool name yields an `isError` result (never a throw).
+    func run(_ call: ToolCall) async -> ToolResult {
+        guard let tool = toolsByName[call.name] else {
+            return ToolResult(
+                toolUseID: call.id,
+                content: "Unknown tool '\(call.name)'. Available: \(toolsByName.keys.sorted().joined(separator: ", ")).",
+                isError: true)
+        }
+        let result = await tool.run(call.input)
+        // The tool doesn't know the provider-assigned call id — bind it here so
+        // the provider can match this result to its tool_use/tool_call.
+        return ToolResult(toolUseID: call.id, content: result.content, isError: result.isError)
+    }
+}
+
+// MARK: - JSONValue input accessors (WI-6 ergonomics)
+
+extension JSONValue {
+    /// Member of an `.object` by key (nil for non-objects / absent keys).
+    subscript(key: String) -> JSONValue? {
+        if case .object(let dict) = self { return dict[key] }
+        return nil
+    }
+
+    /// The `.string` payload, or nil.
+    var stringValue: String? {
+        if case .string(let s) = self { return s }
+        return nil
+    }
+
+    /// The `.number` as an `Int` when it is finite, integral, AND within the
+    /// precision-safe range (`|n| < 2^53`) — beyond that a `Double` can't
+    /// represent consecutive integers, so the conversion would be lossy and is
+    /// rejected (nil) rather than silently truncated. Tool inputs (page indices,
+    /// counts) live far below this bound.
+    var intValue: Int? {
+        let maxSafe = 9_007_199_254_740_992.0  // 2^53
+        if case .number(let n) = self, n.isFinite, n.rounded() == n,
+           abs(n) < maxSafe { return Int(n) }
+        return nil
+    }
+
+    /// The `.number` as a `Double`, or nil.
+    var doubleValue: Double? {
+        if case .number(let n) = self { return n }
+        return nil
+    }
+
+    /// The `.bool` payload, or nil.
+    var boolValue: Bool? {
+        if case .bool(let b) = self { return b }
+        return nil
+    }
+}

--- a/vreaderTests/Services/AI/AIToolRegistryTests.swift
+++ b/vreaderTests/Services/AI/AIToolRegistryTests.swift
@@ -1,0 +1,107 @@
+// Purpose: Feature #91 WI-5 — pin the AIToolRegistry dispatch contract (call→tool,
+// id-binding, unknown-tool error, definitions order) + the JSONValue input
+// accessors the WI-6 executors read arguments with. Pure-value tests.
+//
+// @coordinates-with: AIToolRegistry.swift, AITool.swift,
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-5)
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("Feature #91 WI-5 — AIToolRegistry")
+struct AIToolRegistryTests {
+
+    /// A stub tool that echoes its input (or errors) — and ignores the toolUseID
+    /// it sets (the registry must rebind it to the call id).
+    private struct EchoTool: AITool {
+        let name: String
+        let fail: Bool
+        var definition: ToolDefinition {
+            ToolDefinition(name: name, description: "echo \(name)", inputSchema: .object([:]))
+        }
+        func run(_ input: JSONValue) async -> ToolResult {
+            // Deliberately set a WRONG toolUseID — the registry must overwrite it.
+            ToolResult(toolUseID: "WRONG", content: input.stringValue ?? "ran:\(name)", isError: fail)
+        }
+    }
+
+    @Test("run dispatches to the named tool and binds the call id (not the tool's)")
+    func dispatchBindsCallID() async {
+        let registry = AIToolRegistry([EchoTool(name: "a", fail: false)])
+        let result = await registry.run(
+            ToolCall(id: "call_42", name: "a", input: .string("hi")))
+        #expect(result.toolUseID == "call_42")   // rebound from the call, NOT "WRONG"
+        #expect(result.content == "hi")
+        #expect(result.isError == false)
+    }
+
+    @Test("a tool that reports failure surfaces isError, still bound to the call id")
+    func failingToolIsError() async {
+        let registry = AIToolRegistry([EchoTool(name: "a", fail: true)])
+        let result = await registry.run(ToolCall(id: "c", name: "a", input: .null))
+        #expect(result.isError == true)
+        #expect(result.toolUseID == "c")
+    }
+
+    @Test("an unknown tool name yields an isError result, never a crash")
+    func unknownToolIsError() async {
+        let registry = AIToolRegistry([EchoTool(name: "a", fail: false)])
+        let result = await registry.run(ToolCall(id: "c", name: "nope", input: .null))
+        #expect(result.isError == true)
+        #expect(result.toolUseID == "c")
+        #expect(result.content.contains("Unknown tool 'nope'"))
+    }
+
+    @Test("definitions() returns every tool's definition, name-sorted + isEmpty")
+    func definitionsAndEmpty() {
+        #expect(AIToolRegistry([]).isEmpty)
+        let registry = AIToolRegistry([
+            EchoTool(name: "zebra", fail: false), EchoTool(name: "alpha", fail: false)])
+        #expect(registry.isEmpty == false)
+        #expect(registry.definitions().map(\.name) == ["alpha", "zebra"])
+    }
+
+    @Test("duplicate tool names are last-wins (registration is never a trap)")
+    func duplicateNamesLastWins() async {
+        // Two tools named "dup" — the SECOND wins; no crash.
+        let registry = AIToolRegistry([
+            EchoTool(name: "dup", fail: false), EchoTool(name: "dup", fail: true)])
+        #expect(registry.definitions().count == 1)
+        let result = await registry.run(ToolCall(id: "c", name: "dup", input: .null))
+        #expect(result.isError == true)   // the last (failing) tool won
+    }
+
+    // MARK: - JSONValue accessors
+
+    @Test("JSONValue object subscript + typed accessors")
+    func jsonAccessors() {
+        let v = JSONValue.object([
+            "q": .string("darcy"), "page": .number(2), "ratio": .number(0.5),
+            "flag": .bool(true), "nested": .object(["k": .string("x")]),
+        ])
+        #expect(v["q"]?.stringValue == "darcy")
+        #expect(v["page"]?.intValue == 2)
+        #expect(v["page"]?.doubleValue == 2)
+        #expect(v["ratio"]?.intValue == nil)         // non-integral → not an Int
+        #expect(v["ratio"]?.doubleValue == 0.5)
+        #expect(v["flag"]?.boolValue == true)
+        #expect(v["nested"]?["k"]?.stringValue == "x")
+        #expect(v["absent"] == nil)
+        // subscript on a non-object is nil.
+        #expect(JSONValue.string("s")["q"] == nil)
+        // a non-finite number is not an Int/Double-as-int.
+        #expect(JSONValue.number(.nan).intValue == nil)
+    }
+
+    @Test("intValue is precision-safe: rejects integers beyond 2^53 (lossy)")
+    func intValuePrecisionBoundary() {
+        // 2^53 - 1 is the largest exactly-representable consecutive integer.
+        #expect(JSONValue.number(9_007_199_254_740_991).intValue == 9_007_199_254_740_991)
+        // 2^53 and beyond are NOT exactly representable as Double → rejected (nil)
+        // rather than silently truncated.
+        #expect(JSONValue.number(9_007_199_254_740_992).intValue == nil)
+        #expect(JSONValue.number(-9_007_199_254_740_992).intValue == nil)
+        #expect(JSONValue.number(.infinity).intValue == nil)
+    }
+}


### PR DESCRIPTION
## Summary

WI-5 of Feature #91 — the tool registry the agentic loop (WI-7) dispatches `ToolCall`s through, plus `JSONValue` input accessors the tool executors (WI-6) read arguments with.

Part of feature #1482.

## What Changed

- **`AIToolRegistry`** (`Sendable`): name→`AITool` map (last-wins on a dup, logged); `definitions()` returns the **init-time-snapshot** defs (name-sorted, can't drift from the dispatch key); `run(_ call:)` dispatches + **rebinds** the result to `call.id` (the tool doesn't know the provider call id); an unknown tool name → `isError` result, never a throw (a hallucinated name can't wedge the loop).
- **`JSONValue` accessors**: `subscript[key]`, `stringValue`, `intValue` (precision-safe `|n| < 2^53`), `doubleValue`, `boolValue`.

## WI Status

- WI-5: **foundational** — this PR. Done: WI-1/2/3/4/5. Remaining: WI-6a/b/c (tool executors), WI-7 (driver), WI-8 (VM wiring).

## Codex Audit (Gate 4)

2 rounds, **ship-as-is**. Call-id rebinding / fail-closed / `Sendable` confirmed sound. Fixed a Medium (snapshot definitions at init so advertised == dispatched) + 2 Lows (non-trapping dup warning; documented + tested the `intValue` 2^53 boundary).

Audit log: `.claude/codex-audits/feat-feature-91-wi-5-tool-registry-audit.md`

## Validation

- [x] `AIToolRegistryTests` green (dispatch + id-rebinding, fail-closed unknown tool, last-wins dup, definitions order, JSONValue accessors incl. the 2^53 boundary)
- [x] Codex audit (2 rounds, ship-as-is)
- [x] Version bumped: 3.51.9 → 3.51.10

## Type of Change

- [x] Foundational WI (Part of feature #1482)