### PR TITLE
feat(#91 WI-6a): search_current_book agentic tool executor

### DIFF
--- a/.claude/codex-audits/feat-feature-91-wi-6a-search-current-audit.md
+++ b/.claude/codex-audits/feat-feature-91-wi-6a-search-current-audit.md
@@ -1,0 +1,62 @@
+---
+branch: feat/feature-91-wi-6a-search-current
+threadId: 019e9158-f373-7312-ae32-b08c72f8965a
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-04
+---
+
+# Codex Audit — Feature #91 WI-6a (SearchCurrentBookTool)
+
+Gate-4 implementation audit (rule 47). Independent Codex runner via
+`scripts/run-codex.sh -e high` (author/auditor separation, rule 48; rule-53
+stdin-isolated watchdog).
+
+## Scope
+
+Behavioral WI-6a — the first agentic tool executor:
+
+- `vreader/Services/AI/Tools/SearchCurrentBookTool.swift` (new) — `struct
+  SearchCurrentBookTool: AITool`; wraps `SearchProviding.search` scoped to the
+  open book's fingerprint (always page 0, pageSize = maxResults), strips FTS5
+  `<b>…</b>` markers, formats one line per result, byte-clamps the content, and
+  turns a missing query / search failure into an `isError` ToolResult — never a
+  throw (the AITool contract).
+- `vreaderTests/Services/AI/Tools/SearchCurrentBookToolTests.swift` (new) — a
+  local capturing `SearchProviding` stub (records query / fingerprint / page /
+  pageSize / callCount).
+
+## Round 1 — findings (threadId 019e9144-b0cb-7af0-b3de-56dfe08b29ac)
+
+Page-0 forwarding, `<b>`-strip, the Character-boundary UTF-8 clamp loop
+(`max(0,…)` underflow-safe), and `Sendable` over `any SearchProviding` all
+confirmed sound. Findings:
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| SearchCurrentBookTool.swift `run`/`format` | **Medium** | Only the populated-results path was byte-clamped; the `catch` + zero-match branches echoed `query` verbatim, so an oversized model-supplied query could blow the tool_result budget. | **Fixed.** Every return path now routes through `clamp(...)` (a private `errorResult(_:)` clamps error/missing-query text; `format` clamps both the zero-match and populated branches), and the echoed query is normalized to one short line via `oneLine(_:maxChars:120)` before reuse. |
+| SearchCurrentBookTool.swift `format` line | **Medium** | `sourceContext` (book-controlled chapter/section text) was inserted verbatim while only the snippet was normalized — embedded newlines / `]` broke the documented one-line-per-result contract and let hostile book metadata shape the output. | **Fixed.** Both snippet AND sourceContext go through `oneLine()` (strip `<b>`, collapse whitespace/newlines, char-cap), and the row format changed to `N. snippet — source` (em-dash separator, no closing bracket a title could spoof). New test `sourceContextNormalizedToOneLine` pins one-line-per-result with an embedded-newline title. |
+| SearchCurrentBookToolTests.swift | **Medium** | The forwarding test proved `query` + `page == 0` but not current-book scoping or the request-side cap (the reused shared stub captured neither `bookFingerprint` nor `pageSize`). | **Fixed.** Replaced with a local `CapturingSearch` actor that records `lastFingerprint` + `lastPageSize`; `searchesScopedAndFormats` asserts `lastFingerprint == bookFP` and `lastPageSize == maxResults`. |
+| SearchCurrentBookToolTests.swift | Low | The "byte-bounded" test asserted only result count, never byte length / truncation marker / UTF-8 boundary. | **Fixed.** `contentIsByteBounded` feeds 8 multibyte (CJK) results with `maxContentBytes = 256` and asserts `result.content.utf8.count <= 256` AND the `…(truncated)` marker is present. |
+
+## Round 2 — verification (threadId 019e9158-f373-7312-ae32-b08c72f8965a)
+
+All four **RESOLVED**, **no new issues** in static review:
+
+1. RESOLVED — every user-visible return path is byte-clamped; the echoed query is one-lined first.
+2. RESOLVED — both snippet and sourceContext go through `oneLine()`; the `N. snippet — source` format removes the newline / `]` spoofing hole.
+3. RESOLVED — the test asserts `lastFingerprint == bookFP` and `lastPageSize == maxResults` on the capturing stub.
+4. RESOLVED — multibyte CJK byte-bound coverage with `utf8.count <= limit` + truncation-marker assertions.
+
+(The auditor's sandbox couldn't run `xcodebuild`; verification was source-level.
+The test gate was run by the author via `scripts/run-tests.sh
+vreaderTests/SearchCurrentBookToolTests` → `RUN-TESTS RESULT: SUCCEEDED`,
+10 tests.)
+
+## Verdict
+
+**ship-as-is.** Zero open Critical/High/Medium after round 2. `SearchCurrentBookToolTests`
+green (10 tests: definition shape, scoped-page-0 forwarding + pageSize cap,
+one-line normalization of hostile titles, zero-match non-error, missing/blank
+query never calls search, thrown-search → isError, result cap, multibyte
+byte-bound + truncation marker).

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 866
-        MARKETING_VERSION: 3.51.10
+        CURRENT_PROJECT_VERSION: 867
+        MARKETING_VERSION: 3.51.11
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -1047,6 +1047,7 @@
 		AA578B681E89F766F1902FAA /* ReaderSettingsTypographyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3354A74B809D0D3DB13A41F7 /* ReaderSettingsTypographyTests.swift */; };
 		AAE6B9BC238DD37272640F0E /* ReaderThemeV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80381187837EB2DA41E98207 /* ReaderThemeV2Tests.swift */; };
 		AAEA9983AA0492366955FB9B /* PositionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BCC142F6FF2ABE9B5BA64B /* PositionPersistenceTests.swift */; };
+		AB3EB1A5DA6DFE883B2C5322 /* SearchCurrentBookTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30DB574D36652997E553A96C /* SearchCurrentBookTool.swift */; };
 		ABB95D6805BADA4CC6DBE564 /* RealDebugBridgeContext+SeedSessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65CF531180D798D01E12893 /* RealDebugBridgeContext+SeedSessions.swift */; };
 		ABE20173610A76DC711FBA55 /* ReaderThemeV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB26FE0A7766F5E461A6BC7 /* ReaderThemeV2.swift */; };
 		ACE4A8A746F082AEC08BB273 /* CustomCoverStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5955766DF21883C0C57B71E4 /* CustomCoverStoreTests.swift */; };
@@ -1367,6 +1368,7 @@
 		E0699A5EBCDBBBD2D56304DE /* ReadiumBilingualCommander.swift in Sources */ = {isa = PBXBuildFile; fileRef = 680CAEF6D5FC66EDF8844280 /* ReadiumBilingualCommander.swift */; };
 		E0722D3E90824BE3E72AFE5E /* MDReaderContainerView+Bilingual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACEA5D5CF4C1C95B41B1496 /* MDReaderContainerView+Bilingual.swift */; };
 		E08A7E4EAF4C3831B03E8B72 /* ChapterTextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C9E78D6768871560C6C7CB /* ChapterTextProviderTests.swift */; };
+		E0C10040191ABF803B889B49 /* SearchCurrentBookToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4612140BE197E8A0EA480CC /* SearchCurrentBookToolTests.swift */; };
 		E11C399EFF99AF41282FF9C2 /* TranslateLanguageRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8D91D1FCEAE96F78872388 /* TranslateLanguageRail.swift */; };
 		E13CF08250AAA017BEAB29DD /* ReadingDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5DF3877E8FD8A626E3A1DD6 /* ReadingDashboardView.swift */; };
 		E153024C836519993C468665 /* ZIPReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB65B98019C814421DDB0668 /* ZIPReaderTests.swift */; };
@@ -1823,6 +1825,7 @@
 		300CB93197976B4D665AEDFC /* PersistenceActor+RemoteOnly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+RemoteOnly.swift"; sourceTree = "<group>"; };
 		3035E9BDF79106F058459E0D /* StatsCustomRangePickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsCustomRangePickerTests.swift; sourceTree = "<group>"; };
 		30D00221E111683E9FF0260A /* SearchTextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTextExtractor.swift; sourceTree = "<group>"; };
+		30DB574D36652997E553A96C /* SearchCurrentBookTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCurrentBookTool.swift; sourceTree = "<group>"; };
 		30F27108727D22B92F94001C /* ReadiumEPUBReaderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumEPUBReaderViewModelTests.swift; sourceTree = "<group>"; };
 		310813C564EF1BF86A13694E /* DebugBridgeHighlightObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugBridgeHighlightObserverTests.swift; sourceTree = "<group>"; };
 		31257B79B3B1BE785EFD5C26 /* HTTPTTSChunkPlayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTTSChunkPlayerTests.swift; sourceTree = "<group>"; };
@@ -2934,6 +2937,7 @@
 		E3D8B3D17D6551C053F12355 /* MockTXTService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTXTService.swift; sourceTree = "<group>"; };
 		E3D9BD563DBFE23CE71083C5 /* search_results.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = search_results.html; sourceTree = "<group>"; };
 		E3E2D1C060B3EF0B66847F23 /* WebDAVNetworkPolicyEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVNetworkPolicyEnvironment.swift; sourceTree = "<group>"; };
+		E4612140BE197E8A0EA480CC /* SearchCurrentBookToolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCurrentBookToolTests.swift; sourceTree = "<group>"; };
 		E46A786B20AA87E763D00F45 /* PersistenceActor+Library.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+Library.swift"; sourceTree = "<group>"; };
 		E46AADA707F0E3AF7E8AB297 /* vreaderTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = vreaderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E49486599FAD7ED74521BC9C /* BilingualSetupSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualSetupSheetTests.swift; sourceTree = "<group>"; };
@@ -3226,6 +3230,14 @@
 				47C95AAF8C186ABB17B12943 /* JS */,
 			);
 			path = Foliate;
+			sourceTree = "<group>";
+		};
+		17F5D2D6157B0982ED966239 /* Tools */ = {
+			isa = PBXGroup;
+			children = (
+				E4612140BE197E8A0EA480CC /* SearchCurrentBookToolTests.swift */,
+			);
+			path = Tools;
 			sourceTree = "<group>";
 		};
 		193A7CF46EE48B365E0A6079 /* Sync */ = {
@@ -4189,6 +4201,14 @@
 				FD477B685E3E8163D52949DC /* ChatSourcesMenu.swift */,
 			);
 			path = AI;
+			sourceTree = "<group>";
+		};
+		8398255B9EC6E36B2D2EE0AF /* Tools */ = {
+			isa = PBXGroup;
+			children = (
+				30DB574D36652997E553A96C /* SearchCurrentBookTool.swift */,
+			);
+			path = Tools;
 			sourceTree = "<group>";
 		};
 		846B50E898E5A4755C819642 /* AI */ = {
@@ -5190,6 +5210,7 @@
 				37B0FE6ABBF2FE99E9903D79 /* TranslationChunkContractTests.swift */,
 				B26F3EB2A31C52E81656141C /* WholeBookReducerTests.swift */,
 				9F2D542588B3156C4A282264 /* WI11TestHelpers.swift */,
+				17F5D2D6157B0982ED966239 /* Tools */,
 			);
 			path = AI;
 			sourceTree = "<group>";
@@ -5504,6 +5525,7 @@
 				5EA7131588028150DB331B01 /* UTF16Clamp.swift */,
 				A9ABEE3CBF62A1CC57F2952F /* UTF16TextSlicer.swift */,
 				933679BD65980582ECBB1A12 /* WholeBookReducer.swift */,
+				8398255B9EC6E36B2D2EE0AF /* Tools */,
 			);
 			path = AI;
 			sourceTree = "<group>";
@@ -6331,6 +6353,7 @@
 				48C743A0324468FF7507F157 /* RuleEngineTests.swift in Sources */,
 				FD253FA0CEB159E2B1299BD4 /* SchemaV1Tests.swift in Sources */,
 				36972763F4542783F654FB33 /* SchemaV8MigrationTests.swift in Sources */,
+				E0C10040191ABF803B889B49 /* SearchCurrentBookToolTests.swift in Sources */,
 				0681EC94635E9BBB798AAB77 /* SearchHighlightDismissTests.swift in Sources */,
 				3821F3BE76B9BE588B9FA995 /* SearchHitToLocatorResolverTests.swift in Sources */,
 				9760CE8C8811986D6EEECF61 /* SearchIndexStoreTests.swift in Sources */,
@@ -7084,6 +7107,7 @@
 				97731990DD3F91A22A6C9038 /* ScreenSpaceDemo.swift in Sources */,
 				793A39541D8253B1CA8984A5 /* ScrollProgressHelper.swift in Sources */,
 				5BF0D6683395428E016CBDC8 /* SearchBar.swift in Sources */,
+				AB3EB1A5DA6DFE883B2C5322 /* SearchCurrentBookTool.swift in Sources */,
 				01440A60BDBE08FC56500DA7 /* SearchHitToLocatorResolver.swift in Sources */,
 				42C12085597D305DE974B0B1 /* SearchIndexCore.swift in Sources */,
 				1E114184ED4E99E9EB1FE43C /* SearchIndexStore.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7449,7 +7449,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 866;
+				CURRENT_PROJECT_VERSION = 867;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7457,7 +7457,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.10;
+				MARKETING_VERSION = 3.51.11;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7603,7 +7603,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 866;
+				CURRENT_PROJECT_VERSION = 867;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7611,7 +7611,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.10;
+				MARKETING_VERSION = 3.51.11;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Services/AI/Tools/SearchCurrentBookTool.swift
+++ b/vreader/Services/AI/Tools/SearchCurrentBookTool.swift
@@ -1,0 +1,154 @@
+// Purpose: Feature #91 WI-6a — the first agentic tool executor. A thin, read-only
+// wrapper over `SearchProviding.search` scoped to the book the user is currently
+// reading (its fingerprint is already indexed in the live SearchService), so the
+// model can full-text search the open book mid-conversation. `run` NEVER throws —
+// a missing query or a search failure is an `isError` ToolResult the loop routes
+// around (the AITool contract).
+//
+// Key decisions:
+// - Always page 0, pageSize = maxResults: the model asks one focused question; it
+//   doesn't paginate. The cap bounds both the search work and the tool_result size.
+// - FTS5 `<b>…</b>` highlight markers are stripped (same as the search UI's
+//   HighlightedSnippet) so the model sees clean prose, and the snippet is
+//   whitespace-collapsed to one line.
+// - The content is byte-clamped (UTF-8) so a pathological snippet set can't blow
+//   the tool_result past a sane budget.
+//
+// @coordinates-with: AITool.swift (DTOs + protocol), AIToolRegistry.swift (dispatch),
+//   SearchService.swift (SearchProviding), HighlightedSnippet.swift (marker strip),
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-6a)
+
+import Foundation
+import OSLog
+
+/// `search_current_book` — full-text search the open book and return matching
+/// snippets with their source context.
+struct SearchCurrentBookTool: AITool {
+
+    static let toolName = "search_current_book"
+    private static let log = Logger(subsystem: "com.vreader.app", category: "SearchCurrentBookTool")
+
+    private let search: any SearchProviding
+    private let bookFingerprint: DocumentFingerprint
+    private let maxResults: Int
+    private let maxContentBytes: Int
+
+    init(
+        search: any SearchProviding,
+        bookFingerprint: DocumentFingerprint,
+        maxResults: Int = 8,
+        maxContentBytes: Int = 6_000
+    ) {
+        self.search = search
+        self.bookFingerprint = bookFingerprint
+        self.maxResults = max(1, maxResults)
+        self.maxContentBytes = max(256, maxContentBytes)
+    }
+
+    var definition: ToolDefinition {
+        ToolDefinition(
+            name: Self.toolName,
+            description: """
+                Full-text search the book the user is currently reading. Returns the \
+                matching snippets with their location (chapter / page / section) so \
+                you can quote or cite where something appears. Use this to find a \
+                passage, character, term, or quote inside the current book.
+                """,
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "query": .object([
+                        "type": .string("string"),
+                        "description": .string(
+                            "Words or a short phrase to find in the current book."),
+                    ]),
+                ]),
+                "required": .array([.string("query")]),
+            ]))
+    }
+
+    func run(_ input: JSONValue) async -> ToolResult {
+        guard let query = input["query"]?.stringValue?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !query.isEmpty else {
+            return errorResult(
+                "Missing required 'query' — provide a non-empty string of words to search for.")
+        }
+        // The query is echoed back in the header / error text, so bound it to one
+        // short line first — an oversized model-supplied query can't blow the
+        // tool_result budget (every return path is clamped below).
+        let displayQuery = Self.oneLine(query, maxChars: 120)
+        do {
+            let page = try await search.search(
+                query: query, bookFingerprint: bookFingerprint, page: 0, pageSize: maxResults)
+            return ToolResult(
+                toolUseID: "",
+                content: Self.format(
+                    displayQuery: displayQuery, page: page,
+                    maxResults: maxResults, maxBytes: maxContentBytes),
+                isError: false)
+        } catch {
+            Self.log.error(
+                "search_current_book failed: \(String(describing: error), privacy: .public)")
+            return errorResult("Search failed for \"\(displayQuery)\". The book may not be indexed yet.")
+        }
+    }
+
+    /// An `isError` result whose content is byte-clamped like the success path.
+    private func errorResult(_ message: String) -> ToolResult {
+        ToolResult(toolUseID: "", content: Self.clamp(message, toBytes: maxContentBytes), isError: true)
+    }
+
+    // MARK: - Formatting
+
+    /// Render a result page as plain text for the model: a count header + one line
+    /// per result `N. snippet — source`, byte-clamped on EVERY branch.
+    static func format(displayQuery: String, page: SearchResultPage, maxResults: Int, maxBytes: Int) -> String {
+        let shown = Array(page.results.prefix(maxResults))
+        guard !shown.isEmpty else {
+            return clamp("No matches for \"\(displayQuery)\" in the current book.", toBytes: maxBytes)
+        }
+        let count = page.totalEstimate ?? shown.count
+        let countLabel = "\(count)\(page.hasMore ? "+" : "")"
+        var lines = ["Found \(countLabel) match(es) for \"\(displayQuery)\" in the current book:"]
+        for (i, result) in shown.enumerated() {
+            // Both snippet AND sourceContext are book-controlled text — normalize
+            // BOTH to one line, and put the source at line-end (em-dash separator,
+            // no closing bracket a chapter title could spoof) so the one-line-per-
+            // result contract holds regardless of book metadata.
+            let snippet = oneLine(result.snippet, maxChars: 400)
+            let source = oneLine(result.sourceContext, maxChars: 80)
+            lines.append("\(i + 1). \(snippet) — \(source)")
+        }
+        return clamp(lines.joined(separator: "\n"), toBytes: maxBytes)
+    }
+
+    /// Strip FTS5 `<b>…</b>` highlight markers, collapse all whitespace/newlines to
+    /// single spaces, and cap the character length — so any book-controlled text
+    /// (snippet or chapter title) renders as one bounded line.
+    static func oneLine(_ text: String, maxChars: Int) -> String {
+        let collapsed = text
+            .replacingOccurrences(of: "<b>", with: "")
+            .replacingOccurrences(of: "</b>", with: "")
+            .split(whereSeparator: { $0.isWhitespace || $0.isNewline })
+            .joined(separator: " ")
+        guard collapsed.count > maxChars else { return collapsed }
+        return String(collapsed.prefix(maxChars)) + "…"
+    }
+
+    /// Truncate to a UTF-8 byte budget on a Character boundary, appending a marker
+    /// when truncated (so the model knows the result was cut).
+    static func clamp(_ string: String, toBytes maxBytes: Int) -> String {
+        guard string.utf8.count > maxBytes else { return string }
+        let suffix = "\n…(truncated)"
+        let budget = max(0, maxBytes - suffix.utf8.count)
+        var out = ""
+        var used = 0
+        for ch in string {
+            let n = String(ch).utf8.count
+            if used + n > budget { break }
+            out.append(ch)
+            used += n
+        }
+        return out + suffix
+    }
+}

--- a/vreaderTests/Services/AI/Tools/SearchCurrentBookToolTests.swift
+++ b/vreaderTests/Services/AI/Tools/SearchCurrentBookToolTests.swift
@@ -1,0 +1,204 @@
+// Purpose: Feature #91 WI-6a — pin the `search_current_book` tool: forwards the
+// `query` to `SearchProviding.search` scoped to the open book's fingerprint at
+// page 0 with pageSize == maxResults, formats snippets (FTS5 <b> markers stripped,
+// one line, source at line-end), byte-clamps EVERY branch, and turns a missing
+// query / search failure into an `isError` ToolResult — never a throw.
+//
+// Uses a local capturing stub (records query / fingerprint / page / pageSize /
+// callCount) so the request-side contract — current-book scoping + the cap — is
+// actually asserted, not just the response shape.
+//
+// @coordinates-with: SearchCurrentBookTool.swift, AITool.swift, SearchService.swift,
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-6a)
+
+import Testing
+import Foundation
+@testable import vreader
+
+// MARK: - Capturing stub
+
+private enum CapturingSearchError: Error { case boom }
+
+/// Records the exact arguments the tool forwards, so scoping (fingerprint) and the
+/// request-side cap (pageSize) are testable — the shared StubSearchService doesn't
+/// capture those.
+private actor CapturingSearch: SearchProviding {
+    private(set) var lastQuery: String?
+    private(set) var lastFingerprint: DocumentFingerprint?
+    private(set) var lastPage: Int?
+    private(set) var lastPageSize: Int?
+    private(set) var callCount = 0
+    private var page = SearchResultPage(results: [], page: 0, hasMore: false, totalEstimate: 0)
+    private var shouldThrow = false
+
+    func setPage(_ p: SearchResultPage) { page = p }
+    func setThrow(_ v: Bool) { shouldThrow = v }
+
+    func indexBook(
+        fingerprint: DocumentFingerprint, textUnits: [TextUnit],
+        segmentBaseOffsets: [Int: Int]?) async throws {}
+
+    func search(
+        query: String, bookFingerprint: DocumentFingerprint, page: Int, pageSize: Int
+    ) async throws -> SearchResultPage {
+        callCount += 1
+        lastQuery = query
+        lastFingerprint = bookFingerprint
+        lastPage = page
+        lastPageSize = pageSize
+        if shouldThrow { throw CapturingSearchError.boom }
+        return self.page
+    }
+
+    func removeIndex(fingerprint: DocumentFingerprint) async throws {}
+    func isIndexed(fingerprint: DocumentFingerprint) async -> Bool { true }
+}
+
+@Suite("Feature #91 WI-6a — SearchCurrentBookTool")
+struct SearchCurrentBookToolTests {
+
+    private static let bookFP = DocumentFingerprint(
+        contentSHA256: String(repeating: "a", count: 64), fileByteCount: 4096, format: .epub)
+
+    private static func locator() -> Locator {
+        Locator(
+            bookFingerprint: bookFP,
+            href: nil, progression: nil, totalProgression: nil, cfi: nil,
+            page: nil, charOffsetUTF16: 0,
+            charRangeStartUTF16: nil, charRangeEndUTF16: nil,
+            textQuote: nil, textContextBefore: nil, textContextAfter: nil)
+    }
+
+    private static func result(_ snippet: String, _ context: String, _ i: Int) -> SearchResult {
+        SearchResult(id: "x:\(i)", snippet: snippet, locator: locator(), sourceContext: context)
+    }
+
+    private func tool(
+        _ stub: CapturingSearch, maxResults: Int = 8, maxContentBytes: Int = 6_000
+    ) -> SearchCurrentBookTool {
+        SearchCurrentBookTool(
+            search: stub, bookFingerprint: Self.bookFP,
+            maxResults: maxResults, maxContentBytes: maxContentBytes)
+    }
+
+    // MARK: - Definition
+
+    @Test("definition advertises the tool name + required query string")
+    func definitionShape() {
+        let def = tool(CapturingSearch()).definition
+        #expect(def.name == "search_current_book")
+        #expect(def.inputSchema["properties"]?["query"]?["type"]?.stringValue == "string")
+        #expect(def.inputSchema["required"] == .array([.string("query")]))
+    }
+
+    // MARK: - Happy path + request-side scoping/cap
+
+    @Test("forwards the query to the open book's fingerprint at page 0, pageSize == maxResults")
+    func searchesScopedAndFormats() async {
+        let stub = CapturingSearch()
+        await stub.setPage(SearchResultPage(
+            results: [
+                Self.result("the proud <b>Darcy</b> bowed", "Chapter 2", 0),
+                Self.result("<b>Darcy</b> wrote a letter", "Chapter 5", 1),
+            ],
+            page: 0, hasMore: false, totalEstimate: 2))
+
+        let result = await tool(stub, maxResults: 5).run(.object(["query": .string("Darcy")]))
+
+        #expect(result.isError == false)
+        // Request-side contract: scoped to THIS book, page 0, the cap forwarded.
+        #expect(await stub.lastQuery == "Darcy")
+        #expect(await stub.lastFingerprint == Self.bookFP)
+        #expect(await stub.lastPage == 0)
+        #expect(await stub.lastPageSize == 5)
+        // Response: <b>…</b> markers stripped, source surfaced for citation.
+        #expect(result.content.contains("the proud Darcy bowed"))
+        #expect(result.content.contains("Darcy wrote a letter"))
+        #expect(!result.content.contains("<b>"))
+        #expect(result.content.contains("Chapter 2"))
+    }
+
+    @Test("a book-controlled chapter title with newlines stays one line per result")
+    func sourceContextNormalizedToOneLine() async {
+        let stub = CapturingSearch()
+        await stub.setPage(SearchResultPage(
+            results: [Self.result("a match", "Chapter\n  3:  Hostile\nTitle", 0)],
+            page: 0, hasMore: false, totalEstimate: 1))
+
+        let result = await tool(stub).run(.object(["query": .string("a")]))
+        // One result → exactly two lines (header + one result line); the embedded
+        // newlines in the chapter title must NOT add extra lines.
+        #expect(result.content.split(separator: "\n").count == 2)
+        #expect(result.content.contains("Chapter 3: Hostile Title"))
+    }
+
+    @Test("zero matches is a non-error result, not a failure")
+    func zeroMatches() async {
+        let stub = CapturingSearch()
+        let result = await tool(stub).run(.object(["query": .string("nonexistent")]))
+        #expect(result.isError == false)
+        #expect(result.content.localizedCaseInsensitiveContains("no match"))
+    }
+
+    // MARK: - Bad input (never calls search)
+
+    @Test("a missing query yields an isError result and does NOT call search")
+    func missingQuery() async {
+        let stub = CapturingSearch()
+        let result = await tool(stub).run(.object(["unrelated": .number(1)]))
+        #expect(result.isError == true)
+        #expect(await stub.callCount == 0)
+    }
+
+    @Test("an empty / whitespace query yields an isError result and does NOT call search")
+    func blankQuery() async {
+        let stub = CapturingSearch()
+        let result = await tool(stub).run(.object(["query": .string("   ")]))
+        #expect(result.isError == true)
+        #expect(await stub.callCount == 0)
+    }
+
+    // MARK: - Failure is data, never a throw
+
+    @Test("a thrown search error becomes an isError result, not a crash")
+    func searchThrows() async {
+        let stub = CapturingSearch()
+        await stub.setThrow(true)
+        let result = await tool(stub).run(.object(["query": .string("Darcy")]))
+        #expect(result.isError == true)
+    }
+
+    // MARK: - Caps
+
+    @Test("results are capped to maxResults")
+    func capsResults() async {
+        let stub = CapturingSearch()
+        let many = (0..<20).map { Self.result("match number \($0)", "Section \($0)", $0) }
+        await stub.setPage(SearchResultPage(
+            results: many, page: 0, hasMore: true, totalEstimate: 20))
+
+        let result = await tool(stub, maxResults: 3).run(.object(["query": .string("match")]))
+
+        #expect(result.isError == false)
+        #expect(result.content.contains("match number 0"))
+        #expect(result.content.contains("match number 2"))
+        #expect(!result.content.contains("match number 3"))
+    }
+
+    @Test("content is byte-clamped (UTF-8) with a truncation marker, even for CJK snippets")
+    func contentIsByteBounded() async {
+        let stub = CapturingSearch()
+        // Eight multibyte (CJK) results — joined they far exceed a 256-byte budget.
+        let cjk = (0..<8).map { Self.result("这是第\($0)个匹配的段落内容，很长很长。", "第\($0)章", $0) }
+        await stub.setPage(SearchResultPage(
+            results: cjk, page: 0, hasMore: false, totalEstimate: 8))
+
+        let limit = 256  // the init floor; large enough to pass, small enough to truncate 8 CJK lines
+        let result = await tool(stub, maxResults: 8, maxContentBytes: limit)
+            .run(.object(["query": .string("匹配")]))
+
+        #expect(result.isError == false)
+        #expect(result.content.utf8.count <= limit)            // hard byte bound
+        #expect(result.content.contains("…(truncated)"))       // the cut is signalled
+    }
+}


### PR DESCRIPTION
## Summary

- First agentic tool executor for Feature #91 — `SearchCurrentBookTool`, a thin read-only `AITool` wrapping `SearchProviding.search` scoped to the **open book's** fingerprint (always page 0, pageSize = maxResults), so the model can full-text search the current book mid-conversation.
- Strips FTS5 `<b>…</b>` markers, normalizes both snippet **and** source to one line (`N. snippet — source`), byte-clamps **every** return path, and turns a missing/blank query or a thrown search into an `isError` `ToolResult` — never a throw (the AITool loop-robustness contract).

Part of feature #1482.

## What Changed

- **New** `vreader/Services/AI/Tools/SearchCurrentBookTool.swift` — `struct SearchCurrentBookTool: AITool`. Reads `query` via the WI-5 `JSONValue` accessors; `run` is fail-soft (errors are data the loop routes around). `oneLine()` (strip `<b>`, collapse whitespace/newlines, char-cap) + `clamp()` (UTF-8 byte budget on a Character boundary, truncation marker).
- **New** `vreaderTests/Services/AI/Tools/SearchCurrentBookToolTests.swift` — local `CapturingSearch` actor; 10 tests.

## Codex Audit

2 rounds, `ship-as-is`, zero open Critical/High/Medium. Round 1 found 3 Medium + 1 Low — all fixed: clamp now covers the error/zero-match branches; `sourceContext` is one-lined (closes the newline/`]` spoof); the test asserts current-book scoping (`lastFingerprint`) + the request-side cap (`lastPageSize`); multibyte CJK byte-bound coverage added. Round 2: all RESOLVED, no new issues.

Audit log: `.claude/codex-audits/feat-feature-91-wi-6a-search-current-audit.md`

## Validation

- [x] `scripts/run-tests.sh vreaderTests/SearchCurrentBookToolTests` → `RUN-TESTS RESULT: SUCCEEDED` (10 tests)
- [x] TDD: RED (7 tests) → GREEN → audit-driven REFACTOR (10 tests)
- [x] Codex audit loop complete (2 rounds, ship-as-is)
- [x] Docs sync — n/a (no user-visible wiring yet; the agentic-cluster architecture entry lands with WI-8, as for WI-1..5)
- [x] Version bumped: 3.51.10 → 3.51.11 (behavioral, not final → patch)

## Verification tier

Behavioral WI, but the tool is **not yet constructed/wired anywhere** (the registry is built in WI-8) — no user-observable surface to device-verify in isolation. Slice verification of the agentic path happens at WI-7 (driver) and WI-8 (VM wiring). Unit + audit are sufficient here.

## Type of Change

- [x] New feature work item (Part of feature #1482)