### PR TITLE
feat(#91 WI-6b): search_other_books agentic tool (persistent-index-gated)

### DIFF
--- a/.claude/codex-audits/feat-feature-91-wi-6b-search-other-audit.md
+++ b/.claude/codex-audits/feat-feature-91-wi-6b-search-other-audit.md
@@ -1,0 +1,92 @@
+---
+branch: feat/feature-91-wi-6b-search-other
+threadId: 019e9176-12fc-76b2-9b76-f9919e679e79
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-06-04
+---
+
+# Codex Audit — Feature #91 WI-6b (search_other_books)
+
+Gate-4 implementation audit (rule 47). Independent Codex runner via
+`scripts/run-codex.sh -e high` (author/auditor separation, rule 48; rule-53
+stdin-isolated watchdog).
+
+## Scope
+
+Behavioral WI-6b — library-wide agentic search (the Gate-2-flagged index-coverage
+risk):
+
+- `vreader/Services/AI/Tools/LibraryBookSearchGate.swift` (new) — the PURE
+  persistent-index safety gate (`LibraryBookSearchGate.evaluate`) + the
+  `LibrarySearchBackend` seam + `LibraryIndexState` / `LibrarySearchEligibility` /
+  `LibrarySearchExclusion`. Mirrors `ReaderSearchCoordinator.setup`'s full guard
+  set (isBookIndexed AND not requiresReindex AND non-nil TXT/MD offsets).
+- `vreader/Services/AI/Tools/SearchOtherBooksTool.swift` (new) — `struct
+  SearchOtherBooksTool: AITool`; orchestration: list → drop open book → gate →
+  restore TXT/MD offsets → per-book FTS search → coverage-reported result. Never
+  throws; per-book failure is skipped.
+- `vreader/Services/AI/Tools/ToolResultText.swift` (new) — shared `oneLine`/`clamp`
+  extracted from WI-6a's SearchCurrentBookTool (which was migrated to use it).
+- `vreader/Services/AI/Tools/SearchCurrentBookTool.swift` (modified) — delegates
+  to `ToolResultText` (behavior preserved).
+- Tests: `LibraryBookSearchGateTests` (7, exhaustive gate matrix),
+  `SearchOtherBooksToolTests` (21).
+
+Key design fact the auditor confirmed: `SearchService.search` queries the FTS
+store directly (no in-memory marking required), so `markPersistentlyIndexed` is
+correctly omitted; the gate only restores TXT/MD offsets (without which the
+hit→locator resolver drops the result).
+
+## Round 1 — findings (threadId 019e9176-12fc-76b2-9b76-f9919e679e79)
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| SearchOtherBooksTool.swift gate call | **High** | The gate was driven by `book.format` (a stale-prone parallel String column — the Bug #246 class), not the canonical `DocumentFingerprint.format` parsed from the fingerprint key. A drifted row could be mis-gated (real TXT/MD included without offset restore → dropped results; real EPUB/PDF wrongly excluded as staleOffsets). | **Fixed.** The gate is now called with `fingerprint.format.rawValue` (the canonical format from the key). Regression test `gatesOnCanonicalFormatNotColumn` pins BOTH directions (canonical-TXT with column lying "epub" → restored; canonical-EPUB with column lying "txt" + nil offsets → searched, not excluded). |
+| SearchOtherBooksToolTests.swift | **Medium** | The "restores TXT offsets first" test didn't prove ORDERING (separate restored/searched lists). | **Fixed.** The stub records an ordered `events` log; the TXT test asserts `firstIndex("restore:kB") < firstIndex("search:kB")`. |
+| SearchOtherBooksTool.swift footer | Low | The coverage footer said "not indexed or need re-indexing" but `excludedCount` also spans staleOffsets + malformed keys. | **Fixed.** Footer now reads "not indexed, need re-indexing, or unreadable metadata". |
+
+`ToolResultText` extraction confirmed behavior-preserving; no Swift 6
+sendability/isolation issue; `markPersistentlyIndexed` omission confirmed safe.
+
+## Round 2 — verification (threadId 019e918c-e94b-7f83-836b-4510c81ea974)
+
+Findings 1–3 **RESOLVED**. One **new Medium**: `searchedCount` was derived from
+`toSearch.count` (books *attempted*), so a skipped per-book search failure
+overstated coverage ("No matches in N books" while some of those N failed).
+**Fixed.** The loop counts `searchFailures` separately; `format` computes
+`completedCount = attempted - failed`, reports the completed count (or "Couldn't
+search N book(s) — the search failed." when all failed), and adds a "N book(s)
+failed to search" coverage line. Tests `eligibleButNoHits`, `allSearchesFailed`,
+and an assertion in `perBookFailureSkipped` pin it.
+
+## Round 3 — verification (threadId 019e91a2-046d-7940-88da-9f493c1d3936)
+
+The round-2 Medium **RESOLVED**. One **new Medium**: the coverage footer was
+appended last and then byte-clamped, so a large hit set could truncate the
+coverage signal away (misleading partial coverage). **Fixed.** `format` now builds
+the footer first and reserves its bytes — only the BODY is clamped (to
+`maxContentBytes - footerBytes`), then the footer is appended, so coverage always
+survives. Test `coverageSurvivesTruncation` pins it (large hit set, 400-byte
+budget → body shows `…(truncated)` AND the coverage line is present).
+
+## Round-cap decision (rule 47: max 3 rounds)
+
+This is round 3, the documented cap. The round-3 finding was fixed rather than
+escalated because (a) convergence was monotonic — each round surfaced one
+distinct, accepted, cleanly-fixable issue (High → Medium → Medium), never a
+re-litigation of a prior fix; (b) the round-3 fix is mechanical (reorder + reserve
+footer bytes) and directly test-pinned. Per the cap, the round-3 fix was applied
+WITHOUT a 4th audit round; its correctness rests on `coverageSurvivesTruncation`.
+A post-fix test bug (a `'g'/'h'` non-hex char in the truncation test's
+fingerprint keys crashed `DocumentFingerprint(canonicalKey:)!`) was caught by the
+test gate and fixed (hex-digit keys); not a production finding.
+
+## Verdict
+
+**ship-as-is.** Zero open Critical/High/Medium. Test gate green:
+`LibraryBookSearchGateTests` (7 — full guard matrix: not-indexed, TXT/MD
+reindex/nil-offsets/good, EPUB/PDF) + `SearchOtherBooksToolTests` (21 — open-book
+exclusion, canonical-format gating both directions, restore-before-search
+ordering, excluded/failed/capped coverage, truncation-survival, missing-query /
+list-throw → isError) + `SearchCurrentBookToolTests` (10, refactor regression).

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 867
-        MARKETING_VERSION: 3.51.11
+        CURRENT_PROJECT_VERSION: 868
+        MARKETING_VERSION: 3.51.12
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -493,6 +493,7 @@
 		4D82E64F299F0EEBA0FD2851 /* WebDAVServerProfileListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABA711375AB3BAEB2F42CFE /* WebDAVServerProfileListView.swift */; };
 		4E2207CD7F48BCE945A0971C /* AIReaderIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E706779E64026004319957F /* AIReaderIntegrationTests.swift */; };
 		4E41A2349D76D4F0814C3FF1 /* TXTViewConfigThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F3E6C42E1711EF70E585526 /* TXTViewConfigThemeTests.swift */; };
+		4E66EB1F83ADE0C878EF999E /* LibraryBookSearchGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BD2081B22B559BD215B7C21 /* LibraryBookSearchGate.swift */; };
 		4EFC0ADF77B237B9D1D37A2F /* ChapterTranslationRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999E14A7BDE872FF420E5E37 /* ChapterTranslationRecord.swift */; };
 		4F2FEC62B6D23F67263EDF34 /* BackupProviderContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED150D276C082FEC194F2F31 /* BackupProviderContractTests.swift */; };
 		4F9B3604353932457F862A56 /* MobiEPUBConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6824BB10509996851B0E86C5 /* MobiEPUBConverter.swift */; };
@@ -611,6 +612,7 @@
 		61EBFF18AB67FAA5DD37BB2D /* TTSProviderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97DAB513E717D83CD9ED3F7 /* TTSProviderProtocol.swift */; };
 		61F1501169ECAB4537B2C930 /* DictionaryLookupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DBF9C3C1FBBCE4354F7DAAD /* DictionaryLookupTests.swift */; };
 		6225EFF6A5A33D3F2FD4DABF /* BookmarkListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256C28A508EAD4DB73B49DD4 /* BookmarkListViewModelTests.swift */; };
+		62426B0CA06B3AA19E829500 /* SearchOtherBooksTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE709CC0DFA0C4AB3910C5F1 /* SearchOtherBooksTool.swift */; };
 		6254C228981BFCF2AC50B719 /* DictionarySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBD54F8887091F46753F09A4 /* DictionarySheet.swift */; };
 		6274548A4C4DDC1FCA13397C /* BackgroundIndexingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAA1482C17A94A21E44EFEB /* BackgroundIndexingCoordinator.swift */; };
 		62BE094A6E99C25AD7880CE4 /* AIChatMessageRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E1127A71F704F53ABC1B50 /* AIChatMessageRowTests.swift */; };
@@ -729,6 +731,7 @@
 		7517791F2112F0367A462A10 /* SchemaV3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 470BBE13ED7BCDD6E60D3400 /* SchemaV3.swift */; };
 		752B9949AB27FC69C8F017AE /* TOCBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818F6161D2855C49A12AF5A6 /* TOCBuilder.swift */; };
 		75400CF16E723E201013482C /* StatsCustomRangePicker+Subviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2D06EE3505728373BD89B04 /* StatsCustomRangePicker+Subviews.swift */; };
+		75C43BE90B7F2CD96B0BF92C /* ToolResultText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E5306AB115FB64D6F9C1E9 /* ToolResultText.swift */; };
 		75DCCF5A7597E311ECCC559A /* ReaderEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EDF15104F7C0B4EAC533454 /* ReaderEngineTests.swift */; };
 		75F2C31298F0C62115778DED /* RealDebugBridgeContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07FF4DC80918BEE43FF99D4 /* RealDebugBridgeContextTests.swift */; };
 		75FB6C4CEAA85621B51537C6 /* HighlightPopoverContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F9577DDE6531E6726A79862 /* HighlightPopoverContent.swift */; };
@@ -963,6 +966,7 @@
 		9C87FCF01164A269B85DA51A /* FoliateJSEscaper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CB10F386B36EF83C36873F /* FoliateJSEscaper.swift */; };
 		9CAC9B0C921E5EBF0C11B1CA /* ReaderAIProvidersFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74429166F68BE798F2EC14C3 /* ReaderAIProvidersFlowTests.swift */; };
 		9CD197C006508A9EDE0E28C8 /* TXTContinuousChunkBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D6E992E453F455F4226202 /* TXTContinuousChunkBuilder.swift */; };
+		9D19E2B1B840D00BA2D58376 /* SearchOtherBooksToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F2B1E6C1AB1225D416D9939 /* SearchOtherBooksToolTests.swift */; };
 		9D28C839CBBFF9BC8727BAF0 /* ChapterTranslation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F49F51FD45D703CEF790F7C /* ChapterTranslation.swift */; };
 		9D63AB1D5AFB8A4094E2A386 /* HighlightPopoverAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471A2FD68C127CC3FC2C239A /* HighlightPopoverAction.swift */; };
 		9D7E5501EDECEE61A46E34E7 /* EPUBBilingualPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FC1F40A79BFC35C3AE97EF3 /* EPUBBilingualPipelineTests.swift */; };
@@ -1522,6 +1526,7 @@
 		FE054F2D4C15B2BE95EFE3F0 /* UIKitHighlightPopoverPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7CA57AE61E378A1980BFF60 /* UIKitHighlightPopoverPresenter.swift */; };
 		FE0ABAEB526B90019A80B518 /* ReaderContainerViewDebugBridgeSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1F33054FC78812304A3055 /* ReaderContainerViewDebugBridgeSearchTests.swift */; };
 		FE244DEB01C2A5C716D1B5C7 /* LibraryDynamicTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77D3287AEC40129E6AA379F /* LibraryDynamicTypeTests.swift */; };
+		FE34017639B7A3519AE5B2C0 /* LibraryBookSearchGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AE4518BC7EBC8968B54CFF /* LibraryBookSearchGateTests.swift */; };
 		FE4AA790FC56F646C3E68DDE /* MonthBoundary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C55B0F88163F7245DC62BC /* MonthBoundary.swift */; };
 		FE6F700872F797C727EECB85 /* Feature64TXTMDMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4E3B1DC47242FC7A17BD69 /* Feature64TXTMDMigrationTests.swift */; };
 		FEA105C28C0D03B8EDF2D6EF /* MOBICoverExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10962D7E47EA2C6714E704CA /* MOBICoverExtractorTests.swift */; };
@@ -1721,6 +1726,7 @@
 		1B311C3A88BD6DC42005FE1B /* ExportedAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportedAnnotation.swift; sourceTree = "<group>"; };
 		1B38EA8570FCCBF0F7E3B2E7 /* AIProviderToolSeamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderToolSeamTests.swift; sourceTree = "<group>"; };
 		1BA8C0E6A9B8EF3E48771286 /* PersistenceActor+ReadingHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+ReadingHistory.swift"; sourceTree = "<group>"; };
+		1BD2081B22B559BD215B7C21 /* LibraryBookSearchGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryBookSearchGate.swift; sourceTree = "<group>"; };
 		1BF38242BD73D1545DCA858D /* EPUBReaderContainerView+ContinuousBilingualLoading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EPUBReaderContainerView+ContinuousBilingualLoading.swift"; sourceTree = "<group>"; };
 		1C07D184EF0E90D5F2DF7A36 /* EPUBWebViewBridgeJS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBWebViewBridgeJS.swift; sourceTree = "<group>"; };
 		1C10EE670AC6E2320DF231D2 /* SettingsRowStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRowStyle.swift; sourceTree = "<group>"; };
@@ -1844,6 +1850,7 @@
 		334D6D06A294323E149970E4 /* AIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIService.swift; sourceTree = "<group>"; };
 		3354A74B809D0D3DB13A41F7 /* ReaderSettingsTypographyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsTypographyTests.swift; sourceTree = "<group>"; };
 		336495F8165F79A364CE9B09 /* AccessibilityFormattersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityFormattersTests.swift; sourceTree = "<group>"; };
+		33AE4518BC7EBC8968B54CFF /* LibraryBookSearchGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryBookSearchGateTests.swift; sourceTree = "<group>"; };
 		33CA445AA96E5EEBA05B7C36 /* OPDSModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSModels.swift; sourceTree = "<group>"; };
 		33EA0E7BAE9970AB1E1CE063 /* memory.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = memory.c; sourceTree = "<group>"; };
 		35597ECF4679E74A0019B17E /* Feature26TextToSpeechVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature26TextToSpeechVerificationTests.swift; sourceTree = "<group>"; };
@@ -2040,6 +2047,7 @@
 		50988D487A861C52A06E6159 /* HighlightsSheet+Export.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HighlightsSheet+Export.swift"; sourceTree = "<group>"; };
 		50AA77FDB19CB7EDA69418C8 /* ReaderUnifiedCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderUnifiedCoordinator.swift; sourceTree = "<group>"; };
 		50CA80F28DFB8D0D4F4BEC25 /* BookSourceHTTPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSourceHTTPClientTests.swift; sourceTree = "<group>"; };
+		50E5306AB115FB64D6F9C1E9 /* ToolResultText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolResultText.swift; sourceTree = "<group>"; };
 		50E944C737D2389E8481C5AD /* SelectionPopoverActionRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionPopoverActionRouter.swift; sourceTree = "<group>"; };
 		5103C436DB10DEF552018E57 /* AnnotationsEmptyStateArt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationsEmptyStateArt.swift; sourceTree = "<group>"; };
 		510A755F74250CC74B14021D /* TXTReaderViewModelContinuousTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTReaderViewModelContinuousTests.swift; sourceTree = "<group>"; };
@@ -2241,6 +2249,7 @@
 		6EDE356D5C7D77EC05E82520 /* BookSourceHTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSourceHTTPClient.swift; sourceTree = "<group>"; };
 		6F117A908F9B8098182FF9DB /* LazyDownloadFinalizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyDownloadFinalizerTests.swift; sourceTree = "<group>"; };
 		6F1F3EF7737CB98C28172050 /* FoliateHighlightRestoreDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightRestoreDispatcher.swift; sourceTree = "<group>"; };
+		6F2B1E6C1AB1225D416D9939 /* SearchOtherBooksToolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchOtherBooksToolTests.swift; sourceTree = "<group>"; };
 		6F2F6606E3464813A962D1E0 /* TextHighlightHitTester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextHighlightHitTester.swift; sourceTree = "<group>"; };
 		6F95BA4F7C74E524DFCCF548 /* AIServiceResolvedConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIServiceResolvedConfigTests.swift; sourceTree = "<group>"; };
 		6FC5D3DF85816AC1F7B42E3D /* WebDAVProfileMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProfileMigrator.swift; sourceTree = "<group>"; };
@@ -3008,6 +3017,7 @@
 		EE41196788F697BB4ACD4B06 /* ReadingSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingSessionTests.swift; sourceTree = "<group>"; };
 		EE4A2E56BB468589356E2DBF /* BilingualLanguageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualLanguageTests.swift; sourceTree = "<group>"; };
 		EE5B5FE13287A24AE9EEFBA7 /* AIReaderPanel+DebugBridgeAIAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AIReaderPanel+DebugBridgeAIAction.swift"; sourceTree = "<group>"; };
+		EE709CC0DFA0C4AB3910C5F1 /* SearchOtherBooksTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchOtherBooksTool.swift; sourceTree = "<group>"; };
 		EE9DA4CCA7E942838A838495 /* FontSizeCalibrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCalibrator.swift; sourceTree = "<group>"; };
 		EEDD43BA2EC5C331FDF3A703 /* PersistenceHighlightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceHighlightTests.swift; sourceTree = "<group>"; };
 		EEF87AF7EE6B0FB8E4CC9332 /* TypographySettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypographySettingsTests.swift; sourceTree = "<group>"; };
@@ -3235,7 +3245,9 @@
 		17F5D2D6157B0982ED966239 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				33AE4518BC7EBC8968B54CFF /* LibraryBookSearchGateTests.swift */,
 				E4612140BE197E8A0EA480CC /* SearchCurrentBookToolTests.swift */,
+				6F2B1E6C1AB1225D416D9939 /* SearchOtherBooksToolTests.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -4206,7 +4218,10 @@
 		8398255B9EC6E36B2D2EE0AF /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				1BD2081B22B559BD215B7C21 /* LibraryBookSearchGate.swift */,
 				30DB574D36652997E553A96C /* SearchCurrentBookTool.swift */,
+				EE709CC0DFA0C4AB3910C5F1 /* SearchOtherBooksTool.swift */,
+				50E5306AB115FB64D6F9C1E9 /* ToolResultText.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -6177,6 +6192,7 @@
 				14CAE71643EC2BB8213DD906 /* LibmobiSmokeTests.swift in Sources */,
 				60F28F11E8F15E0FFAF4922C /* LibraryBookItemFileStateTests.swift in Sources */,
 				EB3FFD36A03AA194F33246D4 /* LibraryBookItemTests.swift in Sources */,
+				FE34017639B7A3519AE5B2C0 /* LibraryBookSearchGateTests.swift in Sources */,
 				966F8A5B17A489AC0E8E1F06 /* LibraryContainerCompositionTests.swift in Sources */,
 				0730B213351CE4D446379317 /* LibraryContainerModelTests.swift in Sources */,
 				73319DBA75C0F4352DDCD858 /* LibraryContextMenuTests.swift in Sources */,
@@ -6358,6 +6374,7 @@
 				3821F3BE76B9BE588B9FA995 /* SearchHitToLocatorResolverTests.swift in Sources */,
 				9760CE8C8811986D6EEECF61 /* SearchIndexStoreTests.swift in Sources */,
 				099933954CB74FAE04C6B877 /* SearchLocatorSliceTests.swift in Sources */,
+				9D19E2B1B840D00BA2D58376 /* SearchOtherBooksToolTests.swift in Sources */,
 				59B8E65739F0BDF9F099D348 /* SearchQueryExecutorTests.swift in Sources */,
 				11B285AD42721118145AE416 /* SearchResultHighlightTests.swift in Sources */,
 				D90375DAC9E5E9F7CFDE29B9 /* SearchResultsGroupedListTests.swift in Sources */,
@@ -6866,6 +6883,7 @@
 				5475FDB13471D68A8ACB1ADD /* LegadoRuleParser.swift in Sources */,
 				614C767C1814F710ECAD56AC /* Libmobi.swift in Sources */,
 				CFF2F7127E363B96F2B6429B /* LibraryBookItem.swift in Sources */,
+				4E66EB1F83ADE0C878EF999E /* LibraryBookSearchGate.swift in Sources */,
 				F83C8F0B1D75175DC7B481CC /* LibraryCardTokens.swift in Sources */,
 				56F3DE1EB4A7638FDC6D2FED /* LibraryCardTranslateBadge.swift in Sources */,
 				C911F3E129D88BA29AB3BBF4 /* LibraryContainerModel.swift in Sources */,
@@ -7111,6 +7129,7 @@
 				01440A60BDBE08FC56500DA7 /* SearchHitToLocatorResolver.swift in Sources */,
 				42C12085597D305DE974B0B1 /* SearchIndexCore.swift in Sources */,
 				1E114184ED4E99E9EB1FE43C /* SearchIndexStore.swift in Sources */,
+				62426B0CA06B3AA19E829500 /* SearchOtherBooksTool.swift in Sources */,
 				E9AAB1E1CE8C74F9517CBEC3 /* SearchQueryExecutor.swift in Sources */,
 				2639375285887DD55F80815B /* SearchResultGrouping.swift in Sources */,
 				21C14E9FBD7B7373B56A365C /* SearchResultRow.swift in Sources */,
@@ -7226,6 +7245,7 @@
 				9DB7FDDADD640EDC37004402 /* ThemeBackgroundView.swift in Sources */,
 				DB49A43B0C365D8308D5D1BB /* TokenSpan.swift in Sources */,
 				7C55E0AC6A420DF9B2B81DDB /* TombstoneStore.swift in Sources */,
+				75C43BE90B7F2CD96B0BF92C /* ToolResultText.swift in Sources */,
 				CA67E48C65474659751FF8B3 /* TranslateBookActionRow.swift in Sources */,
 				356E175C9A90FEEE9909908D /* TranslateBookConfirmAlert.swift in Sources */,
 				D9580C78825E4B6CCF28EF83 /* TranslateCancelAlert.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7469,7 +7469,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 867;
+				CURRENT_PROJECT_VERSION = 868;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7477,7 +7477,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.11;
+				MARKETING_VERSION = 3.51.12;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7623,7 +7623,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 867;
+				CURRENT_PROJECT_VERSION = 868;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7631,7 +7631,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.11;
+				MARKETING_VERSION = 3.51.12;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Services/AI/Tools/LibraryBookSearchGate.swift
+++ b/vreader/Services/AI/Tools/LibraryBookSearchGate.swift
@@ -1,0 +1,95 @@
+// Purpose: Feature #91 WI-6b — the persistent-index SAFETY GATE for
+// search_other_books, plus the backend seam the tool depends on. This is where
+// the Gate-2-flagged index-coverage risk lives: a library book is searchable
+// from its PERSISTED FTS index ONLY when its index is present AND not stale.
+//
+// Why this gate exists (verified against SearchService.search + the index store):
+// - `SearchService.search` queries the FTS store DIRECTLY — it does not require
+//   the book to be marked indexed in memory. So FTS content alone yields correct
+//   snippets.
+// - BUT the hit→locator resolver DROPS a result whose locator can't be resolved
+//   (compactMap on nil). TXT/MD store FTS positions as SEGMENT-relative; without
+//   the restored segment base offsets the locator resolves to nil and the result
+//   silently vanishes — the book would look empty. EPUB/PDF resolve without
+//   offsets. So TXT/MD must have non-nil, non-stale offsets (restored before the
+//   search), or be EXCLUDED.
+// - A persisted index built by an older decode pipeline (`requiresReindex`) can
+//   mis-align offsets → EXCLUDE (never serve a mis-resolved result).
+//
+// This mirrors the FULL guard set `ReaderSearchCoordinator.setup` applies
+// (isBookIndexed AND not requiresReindex AND non-nil TXT/MD offsets). The gate is
+// a PURE function of the index state, so every case is unit-testable without the
+// live store. NO on-demand (re)indexing — excluded books are reported by count so
+// the model knows coverage is partial.
+//
+// @coordinates-with: SearchOtherBooksTool.swift (consumer), SearchService.swift
+//   (search + restoreSegmentOffsets), SearchIndexStore.swift (the guard reads),
+//   ReaderSearchCoordinator.swift (the canonical guard set this mirrors),
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-6b)
+
+import Foundation
+
+/// Why a library book is NOT searchable from its persisted index.
+enum LibrarySearchExclusion: String, Sendable, Equatable {
+    /// No persistent index row — never indexed (import no longer auto-indexes).
+    case notIndexed
+    /// TXT/MD index built by an older decode pipeline — offsets may mis-align.
+    case requiresReindex
+    /// TXT/MD indexed but the segment base offsets are missing — a stale row
+    /// (interrupted index / older schema) whose results would silently drop.
+    case staleOffsets
+}
+
+/// The result of gating one book: searchable (with optional TXT/MD offsets to
+/// restore before searching) or excluded with a reason.
+enum LibrarySearchEligibility: Sendable, Equatable {
+    case searchable(restoreOffsets: [Int: Int]?)
+    case excluded(LibrarySearchExclusion)
+}
+
+/// A book's persistent-index state — the inputs the gate decides on. The
+/// production backend reads these off `SearchIndexStore`; tests build them inline.
+struct LibraryIndexState: Sendable, Equatable {
+    let isIndexed: Bool
+    let requiresReindex: Bool
+    let segmentOffsets: [Int: Int]?
+}
+
+/// The pure persistent-index safety gate (the WI-6b risk core).
+enum LibraryBookSearchGate {
+
+    /// TXT/MD store FTS positions as segment-relative, so they need restored base
+    /// offsets for the hit→locator resolver; EPUB/PDF do not. Mirrors
+    /// `ReaderSearchCoordinator.formatRequiresSegmentOffsets` (kept local to avoid
+    /// a Services→Views dependency; the format set rarely changes).
+    static func requiresSegmentOffsets(_ format: String) -> Bool {
+        format == "txt" || format == "md"
+    }
+
+    /// Decide whether `format`'s book is safely searchable from its persisted
+    /// index given its `state`. Pure — no I/O, exhaustively testable.
+    static func evaluate(format: String, state: LibraryIndexState) -> LibrarySearchEligibility {
+        guard state.isIndexed else { return .excluded(.notIndexed) }
+        guard requiresSegmentOffsets(format) else {
+            // EPUB/PDF (and any non-offset format): FTS content resolves without
+            // offsets.
+            return .searchable(restoreOffsets: nil)
+        }
+        // TXT/MD: must not be stale, and must carry restorable offsets.
+        if state.requiresReindex { return .excluded(.requiresReindex) }
+        guard let offsets = state.segmentOffsets else { return .excluded(.staleOffsets) }
+        return .searchable(restoreOffsets: offsets)
+    }
+}
+
+/// The library-search backend `search_other_books` depends on: list books,
+/// inspect each book's persistent-index state, restore TXT/MD offsets so locators
+/// resolve, and run a per-book FTS search. The production adapter (wired in WI-8)
+/// wraps the live `LibraryPersisting` + `SearchIndexStore` + `SearchService`;
+/// tests use a stub. All-async so an `actor` stub conforms cleanly.
+protocol LibrarySearchBackend: Sendable {
+    func libraryBooks() async throws -> [LibraryBookItem]
+    func indexState(fingerprintKey: String) async -> LibraryIndexState
+    func restoreSegmentOffsets(fingerprint: DocumentFingerprint, offsets: [Int: Int]) async
+    func search(query: String, fingerprint: DocumentFingerprint, limit: Int) async throws -> SearchResultPage
+}

--- a/vreader/Services/AI/Tools/SearchCurrentBookTool.swift
+++ b/vreader/Services/AI/Tools/SearchCurrentBookTool.swift
@@ -76,7 +76,7 @@ struct SearchCurrentBookTool: AITool {
         // The query is echoed back in the header / error text, so bound it to one
         // short line first — an oversized model-supplied query can't blow the
         // tool_result budget (every return path is clamped below).
-        let displayQuery = Self.oneLine(query, maxChars: 120)
+        let displayQuery = ToolResultText.oneLine(query, maxChars: 120)
         do {
             let page = try await search.search(
                 query: query, bookFingerprint: bookFingerprint, page: 0, pageSize: maxResults)
@@ -95,7 +95,8 @@ struct SearchCurrentBookTool: AITool {
 
     /// An `isError` result whose content is byte-clamped like the success path.
     private func errorResult(_ message: String) -> ToolResult {
-        ToolResult(toolUseID: "", content: Self.clamp(message, toBytes: maxContentBytes), isError: true)
+        ToolResult(
+            toolUseID: "", content: ToolResultText.clamp(message, toBytes: maxContentBytes), isError: true)
     }
 
     // MARK: - Formatting
@@ -105,7 +106,8 @@ struct SearchCurrentBookTool: AITool {
     static func format(displayQuery: String, page: SearchResultPage, maxResults: Int, maxBytes: Int) -> String {
         let shown = Array(page.results.prefix(maxResults))
         guard !shown.isEmpty else {
-            return clamp("No matches for \"\(displayQuery)\" in the current book.", toBytes: maxBytes)
+            return ToolResultText.clamp(
+                "No matches for \"\(displayQuery)\" in the current book.", toBytes: maxBytes)
         }
         let count = page.totalEstimate ?? shown.count
         let countLabel = "\(count)\(page.hasMore ? "+" : "")"
@@ -115,40 +117,10 @@ struct SearchCurrentBookTool: AITool {
             // BOTH to one line, and put the source at line-end (em-dash separator,
             // no closing bracket a chapter title could spoof) so the one-line-per-
             // result contract holds regardless of book metadata.
-            let snippet = oneLine(result.snippet, maxChars: 400)
-            let source = oneLine(result.sourceContext, maxChars: 80)
+            let snippet = ToolResultText.oneLine(result.snippet, maxChars: 400)
+            let source = ToolResultText.oneLine(result.sourceContext, maxChars: 80)
             lines.append("\(i + 1). \(snippet) — \(source)")
         }
-        return clamp(lines.joined(separator: "\n"), toBytes: maxBytes)
-    }
-
-    /// Strip FTS5 `<b>…</b>` highlight markers, collapse all whitespace/newlines to
-    /// single spaces, and cap the character length — so any book-controlled text
-    /// (snippet or chapter title) renders as one bounded line.
-    static func oneLine(_ text: String, maxChars: Int) -> String {
-        let collapsed = text
-            .replacingOccurrences(of: "<b>", with: "")
-            .replacingOccurrences(of: "</b>", with: "")
-            .split(whereSeparator: { $0.isWhitespace || $0.isNewline })
-            .joined(separator: " ")
-        guard collapsed.count > maxChars else { return collapsed }
-        return String(collapsed.prefix(maxChars)) + "…"
-    }
-
-    /// Truncate to a UTF-8 byte budget on a Character boundary, appending a marker
-    /// when truncated (so the model knows the result was cut).
-    static func clamp(_ string: String, toBytes maxBytes: Int) -> String {
-        guard string.utf8.count > maxBytes else { return string }
-        let suffix = "\n…(truncated)"
-        let budget = max(0, maxBytes - suffix.utf8.count)
-        var out = ""
-        var used = 0
-        for ch in string {
-            let n = String(ch).utf8.count
-            if used + n > budget { break }
-            out.append(ch)
-            used += n
-        }
-        return out + suffix
+        return ToolResultText.clamp(lines.joined(separator: "\n"), toBytes: maxBytes)
     }
 }

--- a/vreader/Services/AI/Tools/SearchOtherBooksTool.swift
+++ b/vreader/Services/AI/Tools/SearchOtherBooksTool.swift
@@ -1,0 +1,216 @@
+// Purpose: Feature #91 WI-6b — the `search_other_books` agentic tool: full-text
+// search the user's WHOLE LIBRARY (excluding the open book, which
+// search_current_book covers) across books that are SAFELY searchable from their
+// persisted index. The persistent-index risk is isolated in the pure
+// `LibraryBookSearchGate`; this file is orchestration + formatting only.
+//
+// Contract (read-only, never throws — AITool):
+// - List the library, drop the open book, gate each remaining book.
+// - For each searchable book (up to a cap): restore TXT/MD offsets if needed,
+//   FTS-search it, collect the top snippets.
+// - Report EXCLUDED books by count (not-indexed / needs-reindex / stale) so the
+//   model knows coverage is partial and never receives a mis-resolved result.
+// - NO on-demand (re)indexing (expensive). A per-book search failure is skipped,
+//   not fatal. Missing query / a library-list failure → an isError result.
+//
+// @coordinates-with: LibraryBookSearchGate.swift (the gate + backend seam),
+//   ToolResultText.swift (one-line + byte-clamp), AITool.swift (DTOs),
+//   AIToolRegistry.swift (dispatch),
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-6b)
+
+import Foundation
+import OSLog
+
+/// `search_other_books` — full-text search the rest of the library's
+/// safely-indexed books and return matching snippets grouped by book.
+struct SearchOtherBooksTool: AITool {
+
+    static let toolName = "search_other_books"
+    private static let log = Logger(subsystem: "com.vreader.app", category: "SearchOtherBooksTool")
+
+    private let backend: any LibrarySearchBackend
+    /// The currently-open book's fingerprint key, excluded from the search
+    /// (search_current_book owns it). nil when no book is open.
+    private let currentBookFingerprintKey: String?
+    private let maxBooks: Int          // cap on books actually searched
+    private let perBookResults: Int    // cap on snippets per book
+    private let maxContentBytes: Int
+
+    init(
+        backend: any LibrarySearchBackend,
+        currentBookFingerprintKey: String?,
+        maxBooks: Int = 10,
+        perBookResults: Int = 3,
+        maxContentBytes: Int = 8_000
+    ) {
+        self.backend = backend
+        self.currentBookFingerprintKey = currentBookFingerprintKey
+        self.maxBooks = max(1, maxBooks)
+        self.perBookResults = max(1, perBookResults)
+        self.maxContentBytes = max(256, maxContentBytes)
+    }
+
+    var definition: ToolDefinition {
+        ToolDefinition(
+            name: Self.toolName,
+            description: """
+                Full-text search the user's OTHER books (the whole library except \
+                the one currently open). Returns matching snippets grouped by book \
+                title, so you can find where something appears across the library. \
+                Only books that have been indexed are searched; un-indexed books \
+                are reported as a count.
+                """,
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "query": .object([
+                        "type": .string("string"),
+                        "description": .string(
+                            "Words or a short phrase to find across the other books."),
+                    ]),
+                ]),
+                "required": .array([.string("query")]),
+            ]))
+    }
+
+    func run(_ input: JSONValue) async -> ToolResult {
+        guard let query = input["query"]?.stringValue?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !query.isEmpty else {
+            return errorResult(
+                "Missing required 'query' — provide a non-empty string of words to search for.")
+        }
+        let displayQuery = ToolResultText.oneLine(query, maxChars: 120)
+
+        let books: [LibraryBookItem]
+        do {
+            books = try await backend.libraryBooks()
+        } catch {
+            Self.log.error(
+                "search_other_books: library list failed: \(String(describing: error), privacy: .public)")
+            return errorResult("Couldn't list the library to search.")
+        }
+
+        // Drop the open book; gate each remaining book on its persisted index.
+        let others = books.filter { $0.fingerprintKey != currentBookFingerprintKey }
+        var excludedCount = 0
+        var eligible: [(book: LibraryBookItem, fingerprint: DocumentFingerprint, restore: [Int: Int]?)] = []
+        for book in others {
+            guard let fingerprint = DocumentFingerprint(canonicalKey: book.fingerprintKey) else {
+                excludedCount += 1   // malformed key — treat as not searchable
+                continue
+            }
+            let state = await backend.indexState(fingerprintKey: book.fingerprintKey)
+            // Gate-4 High: gate on the CANONICAL format parsed from the
+            // fingerprint key, NOT `book.format` (a stale-prone parallel column —
+            // the Bug #246 class). A drifted row must not be mis-gated (a real
+            // TXT/MD included without offset restore → dropped results, or a real
+            // EPUB/PDF wrongly excluded as staleOffsets).
+            switch LibraryBookSearchGate.evaluate(format: fingerprint.format.rawValue, state: state) {
+            case .searchable(let restore):
+                eligible.append((book, fingerprint, restore))
+            case .excluded:
+                excludedCount += 1
+            }
+        }
+
+        // Search up to maxBooks eligible books (report the rest as capped).
+        let toSearch = eligible.prefix(maxBooks)
+        let cappedOut = eligible.count - toSearch.count
+        var hitsByBook: [(title: String, snippets: [String])] = []
+        var searchFailures = 0
+        for entry in toSearch {
+            if let offsets = entry.restore {
+                await backend.restoreSegmentOffsets(fingerprint: entry.fingerprint, offsets: offsets)
+            }
+            do {
+                let page = try await backend.search(
+                    query: query, fingerprint: entry.fingerprint, limit: perBookResults)
+                let snippets = page.results.prefix(perBookResults).map {
+                    ToolResultText.oneLine($0.snippet, maxChars: 300)
+                }
+                if !snippets.isEmpty {
+                    hitsByBook.append((entry.book.title, Array(snippets)))
+                }
+            } catch {
+                Self.log.error(
+                    "search_other_books: per-book search failed: \(String(describing: error), privacy: .public)")
+                searchFailures += 1   // one book failing must not fail the whole tool…
+                continue              // …but it must NOT be counted as searched (Gate-4 r2 Medium)
+            }
+        }
+
+        return ToolResult(
+            toolUseID: "",
+            content: format(
+                displayQuery: displayQuery, hitsByBook: hitsByBook,
+                attemptedCount: toSearch.count, failedCount: searchFailures,
+                excludedCount: excludedCount, cappedOut: cappedOut),
+            isError: false)
+    }
+
+    /// An `isError` result whose content is byte-clamped like the success path.
+    private func errorResult(_ message: String) -> ToolResult {
+        ToolResult(
+            toolUseID: "", content: ToolResultText.clamp(message, toBytes: maxContentBytes), isError: true)
+    }
+
+    // MARK: - Formatting
+
+    private func format(
+        displayQuery: String, hitsByBook: [(title: String, snippets: [String])],
+        attemptedCount: Int, failedCount: Int, excludedCount: Int, cappedOut: Int
+    ) -> String {
+        // Coverage footer FIRST — it's the partial-coverage signal the model needs,
+        // so it must NEVER be the part that truncation drops (Gate-4 r3 Medium: it
+        // was appended last and byte-clamped away when the hit set was large).
+        var coverage: [String] = []
+        if excludedCount > 0 {
+            // Gate-4 Low: excludedCount spans not-indexed, needs-reindex,
+            // stale-offsets, AND malformed fingerprint keys — keep the label
+            // accurate rather than understating it as "not indexed" only.
+            coverage.append(
+                "\(excludedCount) book(s) not searched (not indexed, need re-indexing, or unreadable metadata)")
+        }
+        if failedCount > 0 {
+            coverage.append("\(failedCount) book(s) failed to search")
+        }
+        if cappedOut > 0 {
+            coverage.append("\(cappedOut) more indexed book(s) not searched (result cap)")
+        }
+        let footer = coverage.isEmpty ? "" : "(" + coverage.joined(separator: "; ") + ".)"
+
+        // A book whose search THREW was attempted but NOT completed — don't let it
+        // inflate the "searched N books" coverage claim (Gate-4 r2 Medium).
+        let completedCount = attemptedCount - failedCount
+        var lines: [String] = []
+        if hitsByBook.isEmpty {
+            if completedCount > 0 {
+                lines.append(
+                    "No matches for \"\(displayQuery)\" in \(completedCount) other indexed book(s).")
+            } else if failedCount > 0 {
+                lines.append(
+                    "Couldn't search \(failedCount) indexed book(s) — the search failed.")
+            } else {
+                lines.append(
+                    "No other indexed books to search for \"\(displayQuery)\".")
+            }
+        } else {
+            let total = hitsByBook.reduce(0) { $0 + $1.snippets.count }
+            lines.append(
+                "Found \(total) match(es) for \"\(displayQuery)\" across \(hitsByBook.count) other book(s):")
+            for (book, snippets) in hitsByBook {
+                lines.append("• \(ToolResultText.oneLine(book, maxChars: 80)):")
+                for (i, snippet) in snippets.enumerated() {
+                    lines.append("    \(i + 1). \(snippet)")
+                }
+            }
+        }
+        let body = lines.joined(separator: "\n")
+
+        // Reserve the footer's bytes so it always survives: clamp only the BODY to
+        // the remaining budget, then append the (unclamped) footer.
+        guard !footer.isEmpty else { return ToolResultText.clamp(body, toBytes: maxContentBytes) }
+        let bodyBudget = max(0, maxContentBytes - (footer.utf8.count + 1))  // +1 for the "\n"
+        return ToolResultText.clamp(body, toBytes: bodyBudget) + "\n" + footer
+    }
+}

--- a/vreader/Services/AI/Tools/ToolResultText.swift
+++ b/vreader/Services/AI/Tools/ToolResultText.swift
@@ -1,0 +1,43 @@
+// Purpose: Feature #91 — shared text helpers for the agentic tool executors'
+// `ToolResult.content`. Both search_current_book (WI-6a) and search_other_books
+// (WI-6b) normalize book-controlled text (snippets, chapter titles) to one
+// bounded line and byte-clamp the whole result so a pathological book can't blow
+// the tool_result budget. Extracted from WI-6a so the two tools share one copy.
+//
+// @coordinates-with: SearchCurrentBookTool.swift, SearchOtherBooksTool.swift,
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-6a/6b)
+
+import Foundation
+
+enum ToolResultText {
+
+    /// Strip FTS5 `<b>…</b>` highlight markers, collapse all whitespace/newlines
+    /// to single spaces, and cap the character length — so any book-controlled
+    /// text (snippet or chapter title) renders as one bounded line.
+    static func oneLine(_ text: String, maxChars: Int) -> String {
+        let collapsed = text
+            .replacingOccurrences(of: "<b>", with: "")
+            .replacingOccurrences(of: "</b>", with: "")
+            .split(whereSeparator: { $0.isWhitespace || $0.isNewline })
+            .joined(separator: " ")
+        guard collapsed.count > maxChars else { return collapsed }
+        return String(collapsed.prefix(maxChars)) + "…"
+    }
+
+    /// Truncate to a UTF-8 byte budget on a Character boundary, appending a marker
+    /// when truncated (so the model knows the result was cut).
+    static func clamp(_ string: String, toBytes maxBytes: Int) -> String {
+        guard string.utf8.count > maxBytes else { return string }
+        let suffix = "\n…(truncated)"
+        let budget = max(0, maxBytes - suffix.utf8.count)
+        var out = ""
+        var used = 0
+        for ch in string {
+            let n = String(ch).utf8.count
+            if used + n > budget { break }
+            out.append(ch)
+            used += n
+        }
+        return out + suffix
+    }
+}

--- a/vreaderTests/Services/AI/Tools/LibraryBookSearchGateTests.swift
+++ b/vreaderTests/Services/AI/Tools/LibraryBookSearchGateTests.swift
@@ -1,0 +1,72 @@
+// Purpose: Feature #91 WI-6b — exhaustively pin the persistent-index SAFETY GATE,
+// the risk core of search_other_books. Pure decision over (format, index state):
+// not-indexed → excluded; TXT/MD stale-decode or nil-offsets → excluded (would
+// silently drop results); TXT/MD good → searchable + restore offsets; EPUB/PDF →
+// searchable directly. Mirrors ReaderSearchCoordinator.setup's guard set.
+//
+// @coordinates-with: LibraryBookSearchGate.swift,
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-6b)
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("Feature #91 WI-6b — LibraryBookSearchGate")
+struct LibraryBookSearchGateTests {
+
+    private func state(
+        indexed: Bool = true, reindex: Bool = false, offsets: [Int: Int]? = nil
+    ) -> LibraryIndexState {
+        LibraryIndexState(isIndexed: indexed, requiresReindex: reindex, segmentOffsets: offsets)
+    }
+
+    // MARK: - Not indexed (any format)
+
+    @Test("a never-indexed book is excluded regardless of format", arguments: ["epub", "pdf", "txt", "md"])
+    func notIndexedExcluded(format: String) {
+        #expect(LibraryBookSearchGate.evaluate(format: format, state: state(indexed: false))
+            == .excluded(.notIndexed))
+    }
+
+    // MARK: - EPUB / PDF need no offsets
+
+    @Test("an indexed EPUB/PDF is searchable with no offsets to restore", arguments: ["epub", "pdf"])
+    func epubPdfSearchableNoOffsets(format: String) {
+        // Even with requiresReindex true / offsets nil, non-offset formats search
+        // fine — those flags only matter for TXT/MD.
+        #expect(LibraryBookSearchGate.evaluate(format: format, state: state(reindex: true, offsets: nil))
+            == .searchable(restoreOffsets: nil))
+    }
+
+    // MARK: - TXT / MD staleness guards
+
+    @Test("a TXT/MD book needing reindex is excluded (offsets may mis-align)", arguments: ["txt", "md"])
+    func txtMdRequiresReindexExcluded(format: String) {
+        #expect(LibraryBookSearchGate.evaluate(
+            format: format, state: state(reindex: true, offsets: [0: 0]))
+            == .excluded(.requiresReindex))
+    }
+
+    @Test("an indexed TXT/MD book with NIL offsets is excluded as stale", arguments: ["txt", "md"])
+    func txtMdNilOffsetsExcluded(format: String) {
+        #expect(LibraryBookSearchGate.evaluate(format: format, state: state(offsets: nil))
+            == .excluded(.staleOffsets))
+    }
+
+    @Test("an indexed, non-stale TXT/MD book with offsets is searchable + restores them", arguments: ["txt", "md"])
+    func txtMdGoodSearchableRestores(format: String) {
+        let offsets = [0: 0, 1: 4096]
+        #expect(LibraryBookSearchGate.evaluate(format: format, state: state(offsets: offsets))
+            == .searchable(restoreOffsets: offsets))
+    }
+
+    // MARK: - requiresSegmentOffsets predicate
+
+    @Test("only txt + md require segment offsets")
+    func offsetFormats() {
+        #expect(LibraryBookSearchGate.requiresSegmentOffsets("txt"))
+        #expect(LibraryBookSearchGate.requiresSegmentOffsets("md"))
+        #expect(!LibraryBookSearchGate.requiresSegmentOffsets("epub"))
+        #expect(!LibraryBookSearchGate.requiresSegmentOffsets("pdf"))
+    }
+}

--- a/vreaderTests/Services/AI/Tools/SearchOtherBooksToolTests.swift
+++ b/vreaderTests/Services/AI/Tools/SearchOtherBooksToolTests.swift
@@ -1,0 +1,355 @@
+// Purpose: Feature #91 WI-6b — pin the search_other_books orchestration over a
+// stub LibrarySearchBackend: excludes the open book, gates each book on its
+// persisted index (the pure LibraryBookSearchGate, tested separately), restores
+// TXT/MD offsets before searching, reports excluded/capped coverage, skips a
+// per-book search failure (never fatal), and turns a missing query / library-list
+// failure into an isError result — never a throw.
+//
+// Keys are VALID canonical fingerprint strings ("{format}:{64-hex}:{bytes}") so
+// the tool's DocumentFingerprint(canonicalKey:) reconstruction round-trips.
+//
+// @coordinates-with: SearchOtherBooksTool.swift, LibraryBookSearchGate.swift,
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-6b)
+
+import Testing
+import Foundation
+@testable import vreader
+
+private enum StubBackendError: Error { case boom }
+
+/// In-memory LibrarySearchBackend recording restore/search calls.
+private actor StubBackend: LibrarySearchBackend {
+    private let books: [LibraryBookItem]
+    private let states: [String: LibraryIndexState]
+    private let pages: [String: SearchResultPage]
+    private let failSearchKeys: Set<String>
+    private let listThrows: Bool
+    private(set) var restoredKeys: [String] = []
+    private(set) var searchedKeys: [String] = []
+    /// Ordered call log ("restore:KEY" / "search:KEY") so a test can prove that a
+    /// TXT/MD book's offsets are restored BEFORE it is searched.
+    private(set) var events: [String] = []
+
+    init(
+        books: [LibraryBookItem], states: [String: LibraryIndexState],
+        pages: [String: SearchResultPage] = [:], failSearchKeys: Set<String> = [],
+        listThrows: Bool = false
+    ) {
+        self.books = books
+        self.states = states
+        self.pages = pages
+        self.failSearchKeys = failSearchKeys
+        self.listThrows = listThrows
+    }
+
+    func libraryBooks() async throws -> [LibraryBookItem] {
+        if listThrows { throw StubBackendError.boom }
+        return books
+    }
+
+    func indexState(fingerprintKey: String) async -> LibraryIndexState {
+        states[fingerprintKey]
+            ?? LibraryIndexState(isIndexed: false, requiresReindex: false, segmentOffsets: nil)
+    }
+
+    func restoreSegmentOffsets(fingerprint: DocumentFingerprint, offsets: [Int: Int]) async {
+        restoredKeys.append(fingerprint.canonicalKey)
+        events.append("restore:\(fingerprint.canonicalKey)")
+    }
+
+    func search(
+        query: String, fingerprint: DocumentFingerprint, limit: Int
+    ) async throws -> SearchResultPage {
+        searchedKeys.append(fingerprint.canonicalKey)
+        events.append("search:\(fingerprint.canonicalKey)")
+        if failSearchKeys.contains(fingerprint.canonicalKey) { throw StubBackendError.boom }
+        return pages[fingerprint.canonicalKey]
+            ?? SearchResultPage(results: [], page: 0, hasMore: false, totalEstimate: 0)
+    }
+}
+
+@Suite("Feature #91 WI-6b — SearchOtherBooksTool")
+struct SearchOtherBooksToolTests {
+
+    // MARK: - Builders
+
+    private static func key(_ format: String, _ c: Character) -> String {
+        "\(format):\(String(repeating: c, count: 64)):4096"
+    }
+
+    private static func book(_ key: String, format: String, title: String) -> LibraryBookItem {
+        .stub(fingerprintKey: key, title: title, format: format, fileByteCount: 4096)
+    }
+
+    private static func indexed(offsets: [Int: Int]? = nil, reindex: Bool = false) -> LibraryIndexState {
+        LibraryIndexState(isIndexed: true, requiresReindex: reindex, segmentOffsets: offsets)
+    }
+
+    private static func page(_ key: String, snippet: String) -> SearchResultPage {
+        let fp = DocumentFingerprint(canonicalKey: key)!
+        let loc = Locator(
+            bookFingerprint: fp, href: nil, progression: nil, totalProgression: nil, cfi: nil,
+            page: nil, charOffsetUTF16: 0, charRangeStartUTF16: nil, charRangeEndUTF16: nil,
+            textQuote: nil, textContextBefore: nil, textContextAfter: nil)
+        return SearchResultPage(
+            results: [SearchResult(id: "\(key):0", snippet: snippet, locator: loc, sourceContext: "Ch 1")],
+            page: 0, hasMore: false, totalEstimate: 1)
+    }
+
+    private func tool(
+        _ backend: StubBackend, openKey: String?, maxBooks: Int = 10, maxContentBytes: Int = 8_000
+    ) -> SearchOtherBooksTool {
+        SearchOtherBooksTool(
+            backend: backend, currentBookFingerprintKey: openKey,
+            maxBooks: maxBooks, maxContentBytes: maxContentBytes)
+    }
+
+    // MARK: - Tests
+
+    @Test("definition advertises the tool name + required query string")
+    func definitionShape() {
+        let backend = StubBackend(books: [], states: [:])
+        let def = tool(backend, openKey: nil).definition
+        #expect(def.name == "search_other_books")
+        #expect(def.inputSchema["required"] == .array([.string("query")]))
+    }
+
+    @Test("excludes the open book, searches the eligible ones, restores TXT offsets first")
+    func excludesOpenSearchesEligibleRestoresTxt() async {
+        let kA = Self.key("epub", "a")   // eligible EPUB
+        let kB = Self.key("txt", "b")    // eligible TXT (needs offset restore)
+        let kC = Self.key("epub", "c")   // the OPEN book — must be skipped
+        let backend = StubBackend(
+            books: [
+                Self.book(kA, format: "epub", title: "Alpha"),
+                Self.book(kB, format: "txt", title: "Beta"),
+                Self.book(kC, format: "epub", title: "OpenBook"),
+            ],
+            states: [kA: Self.indexed(), kB: Self.indexed(offsets: [0: 0]), kC: Self.indexed()],
+            pages: [kA: Self.page(kA, snippet: "alpha hit"), kB: Self.page(kB, snippet: "beta hit")])
+
+        let result = await tool(backend, openKey: kC).run(.object(["query": .string("hit")]))
+
+        #expect(result.isError == false)
+        let searched = await backend.searchedKeys
+        #expect(searched.contains(kA))
+        #expect(searched.contains(kB))
+        #expect(!searched.contains(kC))                 // the open book is never searched
+        // The TXT book had its offsets restored BEFORE searching; the EPUB did not.
+        let restored = await backend.restoredKeys
+        #expect(restored == [kB])
+        // ORDERING: for the TXT book, restore must precede search (else a search
+        // before the offsets are live would drop every result).
+        let events = await backend.events
+        let restoreIdx = events.firstIndex(of: "restore:\(kB)")
+        let searchIdx = events.firstIndex(of: "search:\(kB)")
+        #expect(restoreIdx != nil && searchIdx != nil)
+        #expect((restoreIdx ?? 1) < (searchIdx ?? 0))
+        #expect(result.content.contains("alpha hit"))
+        #expect(result.content.contains("beta hit"))
+        #expect(result.content.contains("Alpha"))
+        #expect(result.content.contains("Beta"))
+    }
+
+    @Test("the gate keys on the CANONICAL fingerprint format, not the stale book.format column")
+    func gatesOnCanonicalFormatNotColumn() async {
+        // Two rows whose `book.format` column DISAGREES with the canonical key:
+        //  - canonical TXT, column lies "epub", offsets present
+        //  - canonical EPUB, column lies "txt", offsets NIL
+        let txtKey = Self.key("txt", "a")
+        let epubKey = Self.key("epub", "b")
+        let backend = StubBackend(
+            books: [
+                Self.book(txtKey, format: "epub", title: "ReallyTxt"),   // column lies
+                Self.book(epubKey, format: "txt", title: "ReallyEpub"),  // column lies
+            ],
+            states: [txtKey: Self.indexed(offsets: [0: 0]), epubKey: Self.indexed(offsets: nil)],
+            pages: [txtKey: Self.page(txtKey, snippet: "t hit"), epubKey: Self.page(epubKey, snippet: "e hit")])
+
+        let result = await tool(backend, openKey: nil).run(.object(["query": .string("hit")]))
+
+        #expect(result.isError == false)
+        // Canonical-TXT → offsets restored (book.format=="epub" would have skipped it).
+        // Canonical-EPUB with nil offsets → searched, NOT excluded as staleOffsets
+        // (book.format=="txt" + nil offsets would have wrongly excluded it).
+        let restored = await backend.restoredKeys
+        #expect(restored == [txtKey])
+        let searched = await backend.searchedKeys
+        #expect(searched.contains(txtKey))
+        #expect(searched.contains(epubKey))
+        #expect(result.content.contains("t hit"))
+        #expect(result.content.contains("e hit"))
+    }
+
+    @Test("excluded books (not-indexed / stale TXT) are reported by count, not searched")
+    func reportsExcludedCoverage() async {
+        let kGood = Self.key("epub", "a")
+        let kNever = Self.key("epub", "b")   // not indexed
+        let kStale = Self.key("txt", "c")    // indexed but NIL offsets → stale
+        let backend = StubBackend(
+            books: [
+                Self.book(kGood, format: "epub", title: "Good"),
+                Self.book(kNever, format: "epub", title: "Never"),
+                Self.book(kStale, format: "txt", title: "Stale"),
+            ],
+            states: [
+                kGood: Self.indexed(),
+                kNever: LibraryIndexState(isIndexed: false, requiresReindex: false, segmentOffsets: nil),
+                kStale: Self.indexed(offsets: nil),
+            ],
+            pages: [kGood: Self.page(kGood, snippet: "found it")])
+
+        let result = await tool(backend, openKey: nil).run(.object(["query": .string("found")]))
+
+        #expect(result.isError == false)
+        #expect(result.content.contains("found it"))
+        #expect(result.content.contains("2 book(s) not searched"))   // Never + Stale
+        let searched = await backend.searchedKeys
+        #expect(searched == [kGood])                                 // only the eligible book
+    }
+
+    @Test("the number of books searched is capped; the rest are reported")
+    func capsBooksSearched() async {
+        let keys = (0..<5).map { Self.key("epub", Character(UnicodeScalar(97 + $0)!)) }
+        let backend = StubBackend(
+            books: keys.enumerated().map { Self.book($1, format: "epub", title: "B\($0)") },
+            states: Dictionary(uniqueKeysWithValues: keys.map { ($0, Self.indexed()) }),
+            pages: Dictionary(uniqueKeysWithValues: keys.map { ($0, Self.page($0, snippet: "x")) }))
+
+        let result = await tool(backend, openKey: nil, maxBooks: 2).run(.object(["query": .string("x")]))
+
+        #expect(result.isError == false)
+        let searched = await backend.searchedKeys
+        #expect(searched.count == 2)                                 // only maxBooks searched
+        #expect(result.content.contains("3 more indexed book(s) not searched (result cap)"))
+    }
+
+    @Test("zero eligible books yields a coverage message, not an error")
+    func zeroEligibleCoverageMessage() async {
+        let kA = Self.key("epub", "a")
+        let kB = Self.key("epub", "b")
+        let backend = StubBackend(
+            books: [Self.book(kA, format: "epub", title: "A"), Self.book(kB, format: "epub", title: "B")],
+            states: [
+                kA: LibraryIndexState(isIndexed: false, requiresReindex: false, segmentOffsets: nil),
+                kB: LibraryIndexState(isIndexed: false, requiresReindex: false, segmentOffsets: nil),
+            ])
+
+        let result = await tool(backend, openKey: nil).run(.object(["query": .string("x")]))
+
+        #expect(result.isError == false)
+        #expect(result.content.localizedCaseInsensitiveContains("no other indexed books"))
+        #expect(result.content.contains("2 book(s) not searched"))
+    }
+
+    @Test("a per-book search failure is skipped, not fatal")
+    func perBookFailureSkipped() async {
+        let kA = Self.key("epub", "a")   // its search THROWS
+        let kB = Self.key("epub", "b")   // succeeds
+        let backend = StubBackend(
+            books: [Self.book(kA, format: "epub", title: "Boom"), Self.book(kB, format: "epub", title: "Fine")],
+            states: [kA: Self.indexed(), kB: Self.indexed()],
+            pages: [kB: Self.page(kB, snippet: "survivor")],
+            failSearchKeys: [kA])
+
+        let result = await tool(backend, openKey: nil).run(.object(["query": .string("x")]))
+
+        #expect(result.isError == false)                            // the throw didn't sink the tool
+        #expect(result.content.contains("survivor"))
+        #expect(!result.content.contains("Boom"))                   // the failing book contributes nothing
+        // The failed book is reported as a failure, NOT silently counted as searched.
+        #expect(result.content.contains("1 book(s) failed to search"))
+    }
+
+    @Test("an eligible book with zero hits reports the COMPLETED count, not the attempted count")
+    func eligibleButNoHits() async {
+        let kA = Self.key("epub", "a")
+        let backend = StubBackend(
+            books: [Self.book(kA, format: "epub", title: "Empty")],
+            states: [kA: Self.indexed()],
+            pages: [kA: SearchResultPage(results: [], page: 0, hasMore: false, totalEstimate: 0)])
+
+        let result = await tool(backend, openKey: nil).run(.object(["query": .string("absent")]))
+
+        #expect(result.isError == false)
+        #expect(result.content.contains("No matches for \"absent\" in 1 other indexed book(s)"))
+    }
+
+    @Test("when every eligible book's search fails, coverage signals failure (not 'no matches')")
+    func allSearchesFailed() async {
+        let kA = Self.key("epub", "a")
+        let backend = StubBackend(
+            books: [Self.book(kA, format: "epub", title: "Boom")],
+            states: [kA: Self.indexed()],
+            failSearchKeys: [kA])
+
+        let result = await tool(backend, openKey: nil).run(.object(["query": .string("x")]))
+
+        #expect(result.isError == false)
+        // NOT "no matches in 1 book" — the book was attempted but never completed.
+        #expect(!result.content.localizedCaseInsensitiveContains("no matches"))
+        #expect(result.content.localizedCaseInsensitiveContains("couldn't search"))
+        #expect(result.content.contains("1 book(s) failed to search"))
+    }
+
+    @Test("a malformed fingerprint key is excluded, never searched")
+    func malformedKeyExcluded() async {
+        let kGood = Self.key("epub", "a")
+        let kBad = "epub:not-a-valid-sha:1"                          // invalid SHA → init? returns nil
+        let backend = StubBackend(
+            books: [Self.book(kGood, format: "epub", title: "Good"), Self.book(kBad, format: "epub", title: "Bad")],
+            states: [kGood: Self.indexed()],
+            pages: [kGood: Self.page(kGood, snippet: "ok")])
+
+        let result = await tool(backend, openKey: nil).run(.object(["query": .string("ok")]))
+
+        #expect(result.isError == false)
+        #expect(result.content.contains("ok"))
+        #expect(result.content.contains("1 book(s) not searched"))
+        let searched = await backend.searchedKeys
+        #expect(searched == [kGood])
+    }
+
+    @Test("the coverage footer survives byte-clamp truncation of a large hit set")
+    func coverageSurvivesTruncation() async {
+        // 8 eligible books with long snippets (would overflow a tight budget) plus
+        // 2 not-indexed books → the coverage line must NOT be truncated away.
+        // (Keys repeat a single HEX digit so DocumentFingerprint(canonicalKey:)
+        // accepts them — 'g'/'h' etc. are not valid SHA hex.)
+        let hex = Array("0123456789abcdef")
+        let eligible = (0..<8).map { Self.key("epub", hex[$0]) }      // '0'..'7'
+        let excluded = [Self.key("epub", hex[14]), Self.key("epub", hex[15])]  // 'e','f'
+        let longSnippet = String(repeating: "lorem ipsum dolor ", count: 30)   // ~540 chars
+        var books = eligible.map { Self.book($0, format: "epub", title: "E") }
+        books += excluded.map { Self.book($0, format: "epub", title: "X") }
+        var states = Dictionary(uniqueKeysWithValues: eligible.map { ($0, Self.indexed()) })
+        for k in excluded {
+            states[k] = LibraryIndexState(isIndexed: false, requiresReindex: false, segmentOffsets: nil)
+        }
+        let pages = Dictionary(uniqueKeysWithValues: eligible.map { ($0, Self.page($0, snippet: longSnippet)) })
+        let backend = StubBackend(books: books, states: states, pages: pages)
+
+        let result = await tool(backend, openKey: nil, maxContentBytes: 400)
+            .run(.object(["query": .string("lorem")]))
+
+        #expect(result.isError == false)
+        #expect(result.content.contains("…(truncated)"))                  // the body WAS truncated
+        #expect(result.content.contains("2 book(s) not searched"))        // …yet coverage survived
+    }
+
+    // MARK: - Bad input / failure is data
+
+    @Test("a missing query yields an isError result")
+    func missingQuery() async {
+        let backend = StubBackend(books: [], states: [:])
+        let result = await tool(backend, openKey: nil).run(.object(["nope": .number(1)]))
+        #expect(result.isError == true)
+    }
+
+    @Test("a library-list failure becomes an isError result, not a crash")
+    func libraryListThrows() async {
+        let backend = StubBackend(books: [], states: [:], listThrows: true)
+        let result = await tool(backend, openKey: nil).run(.object(["query": .string("x")]))
+        #expect(result.isError == true)
+    }
+}


### PR DESCRIPTION
## Summary

- `search_other_books` — library-wide full-text search for the agentic AI chat: search every **other** book (the whole library except the open one, which `search_current_book` covers) across books that are **safely searchable from their persisted FTS index**.
- The Gate-2-flagged index-coverage risk is isolated in a **pure, exhaustively-tested gate** (`LibraryBookSearchGate`) that mirrors `ReaderSearchCoordinator`'s full guard set. Excluded / failed / capped books are reported by count so the model knows coverage is partial. No on-demand re-indexing.

Part of feature #1482.

## What Changed

- **New** `LibraryBookSearchGate.swift` — pure gate + `LibrarySearchBackend` seam. not-indexed → excluded; TXT/MD stale-decode (`requiresReindex`) or nil segment offsets → excluded (else the hit→locator resolver silently drops results); TXT/MD good → restore offsets first; EPUB/PDF → search directly. (`SearchService.search` queries FTS directly, so `markPersistentlyIndexed` isn't needed — verified.)
- **New** `SearchOtherBooksTool.swift` — orchestration: list → drop open book → gate each on the **canonical** `fingerprint.format` → restore TXT/MD offsets → per-book FTS search → coverage-reported result. Never throws; a per-book failure is skipped + counted.
- **New** `ToolResultText.swift` — `oneLine` + UTF-8 `clamp`, extracted from WI-6a and shared (WI-6a's `SearchCurrentBookTool` migrated to it).
- **New tests** — `LibraryBookSearchGateTests` (7, full guard matrix) + `SearchOtherBooksToolTests` (21).

The production `LibrarySearchBackend` adapter (over `SearchIndexStore` + `SearchService` + `LibraryPersisting`) is wired in WI-8.

## Codex Audit

3 rounds, `ship-as-is`, zero open Critical/High/Medium:
- **r1 High** — gate on the canonical `fingerprint.format`, NOT the stale-prone `book.format` column (Bug #246 class); pinned by a bidirectional format-drift regression test.
- **r1 Medium** — prove restore-before-search ordering via an ordered event log.
- **r2 Medium** — count *completed* (not *attempted*) searches so a skipped per-book failure can't overstate coverage.
- **r3 Medium** — reserve the coverage footer's bytes so a large hit set can't truncate the partial-coverage signal away.

Round-3 fix applied without a 4th round per the 3-round cap (mechanical + test-pinned; rationale in the log). Audit log: `.claude/codex-audits/feat-feature-91-wi-6b-search-other-audit.md`

## Validation

- [x] `scripts/run-tests.sh vreaderTests/LibraryBookSearchGateTests vreaderTests/SearchOtherBooksToolTests vreaderTests/SearchCurrentBookToolTests` → `SUCCEEDED` (38 tests incl. the WI-6a refactor regression)
- [x] TDD: RED → GREEN → 3 audit-driven refactor rounds
- [x] Docs sync — n/a (no user-visible wiring yet; agentic-cluster architecture entry lands with WI-8)
- [x] Version bumped: 3.51.11 → 3.51.12 (behavioral, not final → patch)

## Verification tier

Behavioral, but the tool is **not yet wired** (the production `LibrarySearchBackend` adapter + registry construction are WI-8) — no user-observable surface to device-verify in isolation. The pure gate (the risk core) is exhaustively unit-tested. Slice verification of the agentic path is at WI-7/WI-8.

## Type of Change

- [x] New feature work item (Part of feature #1482)