### PR TITLE
feat(#91 WI-6c): get_book_content agentic tool (locality/format-gated)

### DIFF
--- a/.claude/codex-audits/feat-feature-91-wi-6c-get-content-audit.md
+++ b/.claude/codex-audits/feat-feature-91-wi-6c-get-content-audit.md
@@ -1,0 +1,86 @@
+---
+branch: feat/feature-91-wi-6c-get-content
+threadId: 019e91db-2072-7ae0-af2b-d89ddd7beba1
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-06-04
+---
+
+# Codex Audit — Feature #91 WI-6c (get_book_content)
+
+Gate-4 implementation audit (rule 47). Independent Codex runner via
+`scripts/run-codex.sh -e high` (author/auditor separation, rule 48; rule-53
+stdin-isolated watchdog).
+
+## Scope
+
+Behavioral WI-6c — fetch a library book's text by title (the second Gate-2-flagged
+coverage-risk executor):
+
+- `vreader/Services/AI/Tools/GetBookContentGate.swift` (new) — the PURE locality +
+  format gate (`GetBookContentGate.evaluate`) + the `BookContentProvider` seam +
+  `BookContentInfo` / `BookTitleResolution` / `BookContentMatch` /
+  `BookContentEligibility`.
+- `vreader/Services/AI/Tools/GetBookContentTool.swift` (new) — `struct
+  GetBookContentTool: AITool`; resolve title → gate → extract → range/byte-capped
+  result; explicit isError results for not-found / ambiguous / not-local /
+  unsupported-format / extract-failure / out-of-range. Never throws.
+- `vreader/Services/AI/Tools/ToolResultText.swift` (modified) — added a marker-free
+  `truncateToBytes`; `clamp` refactored to reuse it (behavior-preserving).
+- Tests: `GetBookContentGateTests` (5) + `GetBookContentToolTests` (17).
+
+**Design decision (endorsed by the auditor):** the tool takes a **title** (what
+the model sees from search results / the user), not a fingerprint key (an internal
+id the model never sees). The plan's "findBook(byFingerprintKey:)" was the internal
+mechanism; the model-facing contract is the title.
+
+## Round 1 — findings (threadId 019e91db-2072-7ae0-af2b-d89ddd7beba1)
+
+Locality-first gating, the exact `{epub,txt,md,pdf}` supported set, extract-only-on-
+eligible, never-throws, and the Swift 6 actor/Sendable story all confirmed sound.
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| GetBookContentGate.swift (seam) | **High** | `findBook(title:) -> BookContentInfo?` was binary — two books sharing a title would silently return the WRONG book's text. | **Fixed.** The seam returns `enum BookTitleResolution { notFound / found(BookContentInfo) / ambiguous([BookContentMatch]) }`; the tool surfaces the ambiguous candidates **with author** and returns an isError ("Several books match…"), never extracting. Test `ambiguousTitle` pins it. |
+| GetBookContentGate.swift (BookContentInfo) | **High** | The "canonical format" rule was comment-only — WI-8 could still fill `format` from the stale `book.format` column (the Bug #246 class) and the gate would trust it. | **Fixed.** `BookContentInfo` no longer stores a format; `var format: String?` is DERIVED from `fingerprintKey` via `DocumentFingerprint(canonicalKey:)?.format.rawValue` — a caller cannot supply a drifted format. A malformed key → nil → the tool reports "unreadable metadata". Tests `formatDerivedFromKey` + `malformedKeyUnreadable` pin both paths. |
+| GetBookContentToolTests.swift | Low | The two highest-risk cases (ambiguity, format-drift) were untestable with the old seam. | **Fixed.** `ambiguousTitle`, `formatDerivedFromKey`, `malformedKeyUnreadable` added. |
+
+## Round 2 — verification (threadId 019e91f1-75f4-7840-b9a4-6978422f4f6f)
+
+Findings 1–3 **RESOLVED**. One **new Medium**: the plan's "range-limited" contract
+was unimplemented (only `title` + `max_chars` prefix cap; no way to read later
+sections, and an "out-of-range" test was planned). **Fixed.** Added an optional
+0-based `start_char`: an empty extract → a non-error "no extractable text" result;
+`start_char >= total` → an isError "past the end" result; otherwise a grapheme-safe
+window with a "characters START–END of TOTAL" header. Tests `startCharWindowsLater`,
+`startCharOutOfRange`, `emptyExtract`.
+
+## Round 3 — verification (threadId 019e9206-5f03-7942-a054-7d76a10cf098)
+
+The round-2 Medium **RESOLVED**. One **new Medium**: the range header's END was
+computed BEFORE the UTF-8 byte clamp, so a CJK body clamped shorter than the
+window advertised a too-large END — a model paging with `start_char=END` would
+skip the clamped-off text. **Fixed.** `formatContent` now clamps the SLICE first
+(reserving the header's bytes via the new `truncateToBytes`), then derives END from
+the characters actually included, then builds the header — so the advertised range
+always matches the returned text. Test `headerEndMatchesClampedBody` pins it (CJK,
+300-byte budget → header END == the '字' chars actually returned).
+
+## Round-cap decision (rule 47: max 3 rounds)
+
+This is round 3, the documented cap. The round-3 finding was fixed rather than
+escalated for the same reasons as WI-6b: monotonic convergence (each round one
+distinct, accepted, cleanly-fixable issue — High×2 → Medium → Medium, never a
+re-litigation of a prior fix) and a mechanical, directly-test-pinned fix. The
+round-3 fix was applied WITHOUT a 4th audit round; its correctness rests on
+`headerEndMatchesClampedBody` + the byte-bound assertion.
+
+## Verdict
+
+**ship-as-is.** Zero open Critical/High/Medium. Test gate green:
+`GetBookContentGateTests` (5 — local supported, native-azw3 unsupported, non-local,
+locality-first, supported-set) + `GetBookContentToolTests` (17 — derived-format +
+malformed-key, ambiguity, not-found / not-local / unsupported / extract-throw,
+title-required, char/byte caps, start_char windowing + out-of-range + empty +
+header-END-matches-clamp). The `ToolResultText.clamp` refactor is behavior-
+preserving (WI-6a/6b suites green).

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 868
-        MARKETING_VERSION: 3.51.12
+        CURRENT_PROJECT_VERSION: 869
+        MARKETING_VERSION: 3.51.13
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		0B755264A7061A0DDB5C194B /* TextHighlightHitResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C8F91E6BD028B12064B14B5 /* TextHighlightHitResolver.swift */; };
 		0BA51C02457E94D60CF41180 /* TXTReaderContainerView+Bilingual.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A8B4C14F5DEEB43C139E7A /* TXTReaderContainerView+Bilingual.swift */; };
 		0C5A7F2FA0B3A33625E34506 /* TXTChapterHighlightHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C19E96D5AE40D3577255C38 /* TXTChapterHighlightHelperTests.swift */; };
+		0C886D43490878841FA3A513 /* GetBookContentGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220C9C125ECE9753714E40D1 /* GetBookContentGate.swift */; };
 		0CAEEF69ACEA07AE0DEC346E /* MutationDriftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8DEE3B767FC8F7457067C11 /* MutationDriftTests.swift */; };
 		0CB42A3BD17334007FFBB637 /* EPUBWebViewBridgeCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003A86C3EF12A6B1DD4F5201 /* EPUBWebViewBridgeCoordinatorTests.swift */; };
 		0CDCF9DAE4BA56A30FA71097 /* AppLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B08E95607978EED0EB89FA0B /* AppLogger.swift */; };
@@ -1225,6 +1226,7 @@
 		C72258E7A1E6477E89E27D6E /* ImportError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982822FD76DDFB1EEE150FF0 /* ImportError.swift */; };
 		C731DA5F2D3885D918F1640A /* EncodingDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43A801A0876E2437CE63808 /* EncodingDetector.swift */; };
 		C7963EB4DD0ACFD3A87D97CC /* AnnotationExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB17C932D5188B36F01F024A /* AnnotationExporter.swift */; };
+		C7CAC48B79D83659A7D10FB2 /* GetBookContentTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18EF8C2454CBCC951F3CA25E /* GetBookContentTool.swift */; };
 		C819E99DEF2A16B032B767B1 /* WebDAVServerProfileEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800ED346D9C0E17741704040 /* WebDAVServerProfileEditSheet.swift */; };
 		C81A31B52218576A75210100 /* TXTFileLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F7059169A9ADC70EE01420E /* TXTFileLoaderTests.swift */; };
 		C81C50DAC16681379E93FC9D /* AIConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A57E82A7221B36240E501FD /* AIConfigurationTests.swift */; };
@@ -1301,6 +1303,7 @@
 		D3A4F0401FDBDB1AC17DBD51 /* debug.c in Sources */ = {isa = PBXBuildFile; fileRef = E282EBE7B2C78235790C892B /* debug.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		D3A9394A17D78A98DDF4E618 /* EPUBPagedAxis.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8401AD7C7023A69BE9B68215 /* EPUBPagedAxis.swift */; };
 		D3AA14442F5D8686DD9BAA18 /* HTTPSpeechSynthesizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060D40EBDC75C3812596FB84 /* HTTPSpeechSynthesizer.swift */; };
+		D3CCA92F84C62F4C66D2775A /* GetBookContentGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE295C77B7BFB9AD3B6A85F /* GetBookContentGateTests.swift */; };
 		D41473E2CF7AB980E43C6C54 /* BookFormatAZW3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627E42F1B1E8A59081CC6628 /* BookFormatAZW3Tests.swift */; };
 		D4332566CDFE7329E3709381 /* EPUBWebViewBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E536B950D178C97842DF52 /* EPUBWebViewBridge.swift */; };
 		D451E5FB27521C48F0A54FEA /* PersistenceActor+Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96FDA9A40CE891B901F1A28F /* PersistenceActor+Stats.swift */; };
@@ -1319,6 +1322,7 @@
 		D87DD538291695D66BDA19E7 /* UpdateCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90EFFE1F64991A9192F31011 /* UpdateCheckerTests.swift */; };
 		D87F43FCAF1C67A3B864E62F /* ReaderTranslateBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F2CBC94D52B152BEE89C629 /* ReaderTranslateBanner.swift */; };
 		D88E87666D4269A9F113C4FC /* FoliateDebugSeekFractionObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CD4ACE9DDCC5C10A3C42C0 /* FoliateDebugSeekFractionObserverTests.swift */; };
+		D8918FCCCD89D0937260B8A6 /* GetBookContentToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB53B0494E5197769A64CCF1 /* GetBookContentToolTests.swift */; };
 		D8E3A478AAFAD10DD1BE96ED /* ReaderContainerView+DebugBridgeRenderedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E86175071842E275652A4F2 /* ReaderContainerView+DebugBridgeRenderedText.swift */; };
 		D8F99FEB2F50E4A1FF04CF91 /* DebugFixtureCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461EFE2364F2C7356BB47C88 /* DebugFixtureCatalog.swift */; };
 		D90375DAC9E5E9F7CFDE29B9 /* SearchResultsGroupedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99BCA5536656572478231B9E /* SearchResultsGroupedListTests.swift */; };
@@ -1639,6 +1643,7 @@
 		0C511C16F7FA93E91D703EE7 /* FoliateTTSAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateTTSAdapterTests.swift; sourceTree = "<group>"; };
 		0CB08960CA0FADA20027FD4B /* HTTPSpeechSynthesizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPSpeechSynthesizerTests.swift; sourceTree = "<group>"; };
 		0CDE700F3AC42B0D8AD377E1 /* HTTPTTSProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTTSProviderTests.swift; sourceTree = "<group>"; };
+		0CE295C77B7BFB9AD3B6A85F /* GetBookContentGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBookContentGateTests.swift; sourceTree = "<group>"; };
 		0D07360D9301C4F00D9BCA67 /* ChapterTextProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterTextProviding.swift; sourceTree = "<group>"; };
 		0D19C79EE604BFAB916EC630 /* EPUBBilingualJSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBBilingualJSTests.swift; sourceTree = "<group>"; };
 		0D40C8AC1C6099E72E545AD8 /* ReadiumEPUBReaderViewModel+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReadiumEPUBReaderViewModel+Navigation.swift"; sourceTree = "<group>"; };
@@ -1707,6 +1712,7 @@
 		1889243163114A51950527F6 /* BookFileMaterializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFileMaterializer.swift; sourceTree = "<group>"; };
 		18967D09A42C1FAF3DD22C48 /* BilingualDisplayPipelineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualDisplayPipelineTests.swift; sourceTree = "<group>"; };
 		18C0D116641E412150E6C620 /* TOCSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOCSheet.swift; sourceTree = "<group>"; };
+		18EF8C2454CBCC951F3CA25E /* GetBookContentTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBookContentTool.swift; sourceTree = "<group>"; };
 		1920480AF349823757484C2D /* EPUBWebViewBridgeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBWebViewBridgeCoordinator.swift; sourceTree = "<group>"; };
 		1923055CD55D02FA17D295ED /* BilingualAttributedStringComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualAttributedStringComposer.swift; sourceTree = "<group>"; };
 		19522F65C0947EFDCF9E4D2B /* TypographySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypographySettings.swift; sourceTree = "<group>"; };
@@ -1764,6 +1770,7 @@
 		21CF1C76C54971B97341E5E9 /* FoliateHighlightRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightRenderer.swift; sourceTree = "<group>"; };
 		21EEC4C32DD9D914F5F5B623 /* SettingsSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSectionHeader.swift; sourceTree = "<group>"; };
 		22012CDD369E616CC9FD8075 /* AnnotationsEmptyStateArtTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationsEmptyStateArtTests.swift; sourceTree = "<group>"; };
+		220C9C125ECE9753714E40D1 /* GetBookContentGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBookContentGate.swift; sourceTree = "<group>"; };
 		222624560E31B939E32955D8 /* FoliateHostTapCoordinateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHostTapCoordinateTests.swift; sourceTree = "<group>"; };
 		22789AF01A93F31CDFDFB3F2 /* TranslationUnitIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationUnitIDTests.swift; sourceTree = "<group>"; };
 		228F27716382F3B61E0E15C8 /* CollectionSidebarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSidebarTests.swift; sourceTree = "<group>"; };
@@ -2599,6 +2606,7 @@
 		AB0C783DCFD9CFDD8F488F80 /* AISettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISettingsViewModel.swift; sourceTree = "<group>"; };
 		AB12A029D167735B92A38BA7 /* AccessibilityAuditHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityAuditHelper.swift; sourceTree = "<group>"; };
 		AB40195193F2FC6B56384C75 /* ReaderAIReadinessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderAIReadinessView.swift; sourceTree = "<group>"; };
+		AB53B0494E5197769A64CCF1 /* GetBookContentToolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBookContentToolTests.swift; sourceTree = "<group>"; };
 		AB6D4D3FF162BE1661731AAA /* BookDetailsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailsSheet.swift; sourceTree = "<group>"; };
 		AB8FC6D57843EAC26DB980D3 /* SearchResultHighlightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultHighlightTests.swift; sourceTree = "<group>"; };
 		ABA307AD0EDD85730C6DE77A /* AISummaryTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISummaryTabViewTests.swift; sourceTree = "<group>"; };
@@ -3245,6 +3253,8 @@
 		17F5D2D6157B0982ED966239 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				0CE295C77B7BFB9AD3B6A85F /* GetBookContentGateTests.swift */,
+				AB53B0494E5197769A64CCF1 /* GetBookContentToolTests.swift */,
 				33AE4518BC7EBC8968B54CFF /* LibraryBookSearchGateTests.swift */,
 				E4612140BE197E8A0EA480CC /* SearchCurrentBookToolTests.swift */,
 				6F2B1E6C1AB1225D416D9939 /* SearchOtherBooksToolTests.swift */,
@@ -4218,6 +4228,8 @@
 		8398255B9EC6E36B2D2EE0AF /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				220C9C125ECE9753714E40D1 /* GetBookContentGate.swift */,
+				18EF8C2454CBCC951F3CA25E /* GetBookContentTool.swift */,
 				1BD2081B22B559BD215B7C21 /* LibraryBookSearchGate.swift */,
 				30DB574D36652997E553A96C /* SearchCurrentBookTool.swift */,
 				EE709CC0DFA0C4AB3910C5F1 /* SearchOtherBooksTool.swift */,
@@ -6142,6 +6154,8 @@
 				1E5332F73297C4DB6DF747BD /* FontSizeCalibratorTests.swift in Sources */,
 				67307D96FA4FE6F86F92B988 /* FormatCapabilitiesTests.swift in Sources */,
 				2CBF53D883E09532ABC29FE4 /* GenerativeCoverViewStyleTests.swift in Sources */,
+				D3CCA92F84C62F4C66D2775A /* GetBookContentGateTests.swift in Sources */,
+				D8918FCCCD89D0937260B8A6 /* GetBookContentToolTests.swift in Sources */,
 				A8AD263731FD57DF817D6151 /* HTTPSpeechSynthesizerTests.swift in Sources */,
 				A03DBE125D6347EB3A73527F /* HTTPTTSChunkPlayerTests.swift in Sources */,
 				599306799B2551F63E7C5BAE /* HTTPTTSConfigStoreTests.swift in Sources */,
@@ -6826,6 +6840,8 @@
 				4D4D7B16BBA5732D1E6AB875 /* GenerativeCoverMetrics.swift in Sources */,
 				F4FE45E62955A90DF146DE4B /* GenerativeCoverStyle.swift in Sources */,
 				15BC7FE6B105319B5709C4A9 /* GenerativeCoverView.swift in Sources */,
+				0C886D43490878841FA3A513 /* GetBookContentGate.swift in Sources */,
+				C7CAC48B79D83659A7D10FB2 /* GetBookContentTool.swift in Sources */,
 				2E988A3214761CEAEF22D451 /* HTMLHelper.swift in Sources */,
 				D3AA14442F5D8686DD9BAA18 /* HTTPSpeechSynthesizer.swift in Sources */,
 				A48202EACCA0A4A642674E26 /* HTTPTTSChunkPlayer.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7485,7 +7485,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 868;
+				CURRENT_PROJECT_VERSION = 869;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7493,7 +7493,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.12;
+				MARKETING_VERSION = 3.51.13;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7639,7 +7639,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 868;
+				CURRENT_PROJECT_VERSION = 869;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7647,7 +7647,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.12;
+				MARKETING_VERSION = 3.51.13;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Services/AI/Tools/GetBookContentGate.swift
+++ b/vreader/Services/AI/Tools/GetBookContentGate.swift
@@ -1,0 +1,102 @@
+// Purpose: Feature #91 WI-6c — the locality + format SAFETY GATE for
+// get_book_content, plus the provider seam the tool depends on. A closed book's
+// text can be extracted ONLY when the file is on-device (BookFileState.local) AND
+// the format has a closed-book text path. This is the Gate-2-flagged coverage
+// risk: native AZW3/MOBI has NO closed-book text extractor, and a remote-only /
+// failed row has no local file — both must yield an explicit error result the
+// model can route around, never a throw and never a silent empty read.
+//
+// Supported closed-book formats: EPUB, TXT, Markdown, PDF. NOT azw3 (the canonical
+// Kindle format, which subsumes azw/mobi/prc) — feature #42 converts NEW Kindle
+// imports to EPUB by default, so only legacy-native `.azw3` rows hit this.
+//
+// The gate is a PURE function of (isReadable, format) → exhaustively testable.
+// Title resolution is AMBIGUITY-AWARE (Gate-4 High): the model only ever sees
+// titles, and two books can share one, so the provider returns notFound / found /
+// ambiguous rather than silently picking one. The canonical format is DERIVED from
+// the fingerprint key (Gate-4 High), so it is structurally immune to the stale
+// `book.format` column drift (the Bug #246 class — the WI-6b lesson) — a caller
+// cannot supply a drifted format.
+//
+// @coordinates-with: GetBookContentTool.swift (consumer), BookFileState.swift
+//   (.local locality), BookFormat.swift / DocumentFingerprint.swift (the canonical
+//   format), PersistenceActor / EPUBTextExtractor (the WI-8 adapter),
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-6c)
+
+import Foundation
+
+/// Whether a resolved book's text can be extracted, or why not.
+enum BookContentEligibility: Sendable, Equatable {
+    case extractable
+    /// The file is not on-device (BookFileState != .local) — remote-only,
+    /// downloading, failed, or missing.
+    case notLocal
+    /// No closed-book text path for this format (native azw3/mobi/prc).
+    case unsupportedFormat
+}
+
+/// A resolved book. `format` is DERIVED from `fingerprintKey` — a caller cannot
+/// supply a drifted `book.format` (Gate-4 High; the Bug #246 class). `format` is
+/// nil only when the fingerprint key is malformed (should never happen for a real
+/// library row).
+struct BookContentInfo: Sendable, Equatable {
+    let fingerprintKey: String
+    let title: String
+    let isReadable: Bool   // BookFileState == .local
+
+    init(fingerprintKey: String, title: String, isReadable: Bool) {
+        self.fingerprintKey = fingerprintKey
+        self.title = title
+        self.isReadable = isReadable
+    }
+
+    /// Canonical format (rawValue), parsed from the fingerprint key — never the
+    /// stale `book.format` column.
+    var format: String? { DocumentFingerprint(canonicalKey: fingerprintKey)?.format.rawValue }
+}
+
+/// One candidate when a title matches more than one book — enough metadata
+/// (author) for the model to disambiguate with the user.
+struct BookContentMatch: Sendable, Equatable {
+    let title: String
+    let author: String?
+}
+
+/// The outcome of resolving a model-supplied title.
+enum BookTitleResolution: Sendable, Equatable {
+    case notFound
+    case found(BookContentInfo)
+    /// More than one library book matches the title.
+    case ambiguous([BookContentMatch])
+}
+
+/// The book-content backend get_book_content depends on: resolve a book by title
+/// (ambiguity-aware) and extract its closed-book text. The production adapter
+/// (WI-8) wraps `PersistenceActor` (title lookup + locality) + the per-format text
+/// extractors via the closed-book reopen path; tests use a stub.
+protocol BookContentProvider: Sendable {
+    func findBook(title: String) async -> BookTitleResolution
+    /// Extract the book's text from its on-device file. Throws on a read failure
+    /// (the tool turns that into an `isError` result).
+    func extractText(fingerprintKey: String) async throws -> String
+}
+
+/// The pure locality + format safety gate (the WI-6c risk core).
+enum GetBookContentGate {
+
+    /// Formats with a closed-book text path. azw3 (native Kindle) is excluded.
+    static let supportedFormats: Set<String> = ["epub", "txt", "md", "pdf"]
+
+    static func isSupportedFormat(_ format: String) -> Bool {
+        supportedFormats.contains(format)
+    }
+
+    /// Decide whether a resolved book's text is extractable. Locality is checked
+    /// FIRST: a remote azw3 reports `notLocal` (you can't read the file at all)
+    /// rather than `unsupportedFormat`.
+    static func evaluate(isReadable: Bool, format: String) -> BookContentEligibility {
+        guard isReadable else { return .notLocal }
+        guard isSupportedFormat(format) else { return .unsupportedFormat }
+        return .extractable
+    }
+}

--- a/vreader/Services/AI/Tools/GetBookContentTool.swift
+++ b/vreader/Services/AI/Tools/GetBookContentTool.swift
@@ -1,0 +1,185 @@
+// Purpose: Feature #91 WI-6c — the `get_book_content` agentic tool: fetch the text
+// of a library book by title so the AI chat can read on-demand across the library.
+// The locality + format risk is isolated in the pure `GetBookContentGate`; this
+// file is orchestration + capping only.
+//
+// Contract (read-only, never throws — AITool):
+// - Resolve the book by title; a no-match → an isError "not found" result.
+// - Gate on locality + format: a remote-only book → "not downloaded"; a native
+//   AZW3/MOBI → "unsupported format" — explicit isError results the model routes
+//   around (never a throw, never a silent empty read).
+// - Extract the text; a read failure → an isError result. Cap the returned text
+//   to `max_chars` (optional, ceiling-bounded) and a hard UTF-8 byte budget.
+//
+// The model identifies the book by TITLE (what it sees from search_other_books /
+// the user) — not the internal fingerprint key.
+//
+// @coordinates-with: GetBookContentGate.swift (the gate + provider seam),
+//   ToolResultText.swift (byte-clamp), AITool.swift (DTOs),
+//   AIToolRegistry.swift (dispatch),
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-6c)
+
+import Foundation
+import OSLog
+
+/// `get_book_content` — fetch a library book's text by title (local, supported
+/// formats only).
+struct GetBookContentTool: AITool {
+
+    static let toolName = "get_book_content"
+    private static let log = Logger(subsystem: "com.vreader.app", category: "GetBookContentTool")
+
+    private let provider: any BookContentProvider
+    private let maxChars: Int          // hard ceiling on returned characters
+    private let maxContentBytes: Int   // hard UTF-8 byte budget
+
+    init(
+        provider: any BookContentProvider,
+        maxChars: Int = 8_000,
+        maxContentBytes: Int = 16_000
+    ) {
+        self.provider = provider
+        self.maxChars = max(1, maxChars)
+        self.maxContentBytes = max(256, maxContentBytes)
+    }
+
+    var definition: ToolDefinition {
+        ToolDefinition(
+            name: Self.toolName,
+            description: """
+                Fetch the text of one of the user's books by its title, so you can \
+                read or quote its content. Only books stored on this device in a \
+                supported format (EPUB, TXT, Markdown, PDF) can be read. Use the \
+                exact title as it appears in the library or in a search result.
+                """,
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "title": .object([
+                        "type": .string("string"),
+                        "description": .string("The title of the book to fetch."),
+                    ]),
+                    "start_char": .object([
+                        "type": .string("integer"),
+                        "description": .string(
+                            "Optional 0-based character offset to start from (to read a later section). Defaults to 0."),
+                    ]),
+                    "max_chars": .object([
+                        "type": .string("integer"),
+                        "description": .string(
+                            "Optional cap on how many characters of text to return from start_char."),
+                    ]),
+                ]),
+                "required": .array([.string("title")]),
+            ]))
+    }
+
+    func run(_ input: JSONValue) async -> ToolResult {
+        guard let title = input["title"]?.stringValue?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !title.isEmpty else {
+            return errorResult("Missing required 'title' — name the book to fetch.")
+        }
+        let displayTitle = ToolResultText.oneLine(title, maxChars: 120)
+
+        let info: BookContentInfo
+        switch await provider.findBook(title: title) {
+        case .notFound:
+            return errorResult("No book titled \"\(displayTitle)\" is in the library.")
+        case .ambiguous(let candidates):
+            // Two+ books share the title — don't silently pick one (Gate-4 High).
+            // Surface them (with author) so the model can disambiguate with the user.
+            let list = candidates.prefix(5).map { candidate -> String in
+                let t = ToolResultText.oneLine(candidate.title, maxChars: 80)
+                return candidate.author.map { "\(t) by \(ToolResultText.oneLine($0, maxChars: 60))" } ?? t
+            }.joined(separator: "; ")
+            return errorResult(
+                "Several books match \"\(displayTitle)\": \(list). Ask the user which one, or give a more specific title.")
+        case .found(let resolved):
+            info = resolved
+        }
+
+        // `format` is DERIVED from the fingerprint key (canonical, drift-proof). A
+        // nil here means a malformed key — shouldn't happen for a real library row.
+        guard let format = info.format else {
+            return errorResult(
+                "\"\(ToolResultText.oneLine(info.title, maxChars: 120))\" has unreadable metadata.")
+        }
+
+        switch GetBookContentGate.evaluate(isReadable: info.isReadable, format: format) {
+        case .notLocal:
+            return errorResult(
+                "\"\(ToolResultText.oneLine(info.title, maxChars: 120))\" isn't downloaded to this device yet — its text can't be read until it's downloaded.")
+        case .unsupportedFormat:
+            return errorResult(
+                "\"\(ToolResultText.oneLine(info.title, maxChars: 120))\" is a \(format.uppercased()) book; its text can't be extracted here (only EPUB, TXT, Markdown, and PDF are supported).")
+        case .extractable:
+            break
+        }
+
+        let text: String
+        do {
+            text = try await provider.extractText(fingerprintKey: info.fingerprintKey)
+        } catch {
+            Self.log.error(
+                "get_book_content: extract failed: \(String(describing: error), privacy: .public)")
+            return errorResult(
+                "Couldn't read the text of \"\(ToolResultText.oneLine(info.title, maxChars: 120))\".")
+        }
+
+        let total = text.count
+        if total == 0 {
+            return ToolResult(
+                toolUseID: "",
+                content: ToolResultText.clamp(
+                    "\"\(ToolResultText.oneLine(info.title, maxChars: 120))\" has no extractable text.",
+                    toBytes: maxContentBytes),
+                isError: false)
+        }
+        // Range: an optional 0-based start offset (to read later sections) — past
+        // the end is an explicit out-of-range error result, not an empty read.
+        let start = max(0, input["start_char"]?.intValue ?? 0)
+        if start >= total {
+            return errorResult(
+                "\"\(ToolResultText.oneLine(info.title, maxChars: 120))\" has \(total) characters; start_char \(start) is past the end.")
+        }
+        // Cap: the smaller of the model's request and the hard ceiling, then a
+        // hard UTF-8 byte budget on top (so a CJK book can't blow the budget).
+        let requested = input["max_chars"]?.intValue
+        let charBudget = min(maxChars, max(1, requested ?? maxChars))
+        return ToolResult(
+            toolUseID: "",
+            content: formatContent(
+                title: info.title, text: text, start: start, charBudget: charBudget, total: total),
+            isError: false)
+    }
+
+    /// An `isError` result whose content is byte-clamped like the success path.
+    private func errorResult(_ message: String) -> ToolResult {
+        ToolResult(
+            toolUseID: "", content: ToolResultText.clamp(message, toBytes: maxContentBytes), isError: true)
+    }
+
+    // MARK: - Formatting
+
+    private func formatContent(
+        title: String, text: String, start: Int, charBudget: Int, total: Int
+    ) -> String {
+        let window = String(text.dropFirst(start).prefix(charBudget))
+        // Gate-4 r3 Medium: the header's reported END must reflect what is ACTUALLY
+        // returned after the UTF-8 byte clamp — otherwise a CJK body clamped shorter
+        // than `window` would advertise a too-large END and the model, paging with
+        // start_char=END, would skip the clamped-off text. So clamp the SLICE first
+        // (reserving the header's bytes + 1 for a possible "…"), THEN derive END.
+        func header(end: Int) -> String {
+            "Content of \"\(ToolResultText.oneLine(title, maxChars: 120))\" (characters \(start)–\(end) of \(total)):\n"
+        }
+        let headerBytes = header(end: start + window.count).utf8.count
+        let sliceBudget = max(0, maxContentBytes - headerBytes - "…".utf8.count)
+        let slice = ToolResultText.truncateToBytes(window, sliceBudget)
+        let end = start + slice.count               // characters actually included
+        let more = end < total                      // …text remains after this window
+        // The recomputed header is ≤ the reserved header bytes (end ≤ window end),
+        // so header + slice (+ "…") stays within maxContentBytes.
+        return header(end: end) + slice + (more ? "…" : "")
+    }
+}

--- a/vreader/Services/AI/Tools/ToolResultText.swift
+++ b/vreader/Services/AI/Tools/ToolResultText.swift
@@ -24,20 +24,27 @@ enum ToolResultText {
         return String(collapsed.prefix(maxChars)) + "…"
     }
 
+    /// Truncate to a UTF-8 byte budget on a Character boundary — NO marker. Use
+    /// when the caller appends its own marker / needs the exact included length
+    /// (e.g. get_book_content's range header must report what was actually kept).
+    static func truncateToBytes(_ string: String, _ maxBytes: Int) -> String {
+        guard string.utf8.count > maxBytes else { return string }
+        var out = ""
+        var used = 0
+        for ch in string {
+            let n = String(ch).utf8.count
+            if used + n > maxBytes { break }
+            out.append(ch)
+            used += n
+        }
+        return out
+    }
+
     /// Truncate to a UTF-8 byte budget on a Character boundary, appending a marker
     /// when truncated (so the model knows the result was cut).
     static func clamp(_ string: String, toBytes maxBytes: Int) -> String {
         guard string.utf8.count > maxBytes else { return string }
         let suffix = "\n…(truncated)"
-        let budget = max(0, maxBytes - suffix.utf8.count)
-        var out = ""
-        var used = 0
-        for ch in string {
-            let n = String(ch).utf8.count
-            if used + n > budget { break }
-            out.append(ch)
-            used += n
-        }
-        return out + suffix
+        return truncateToBytes(string, max(0, maxBytes - suffix.utf8.count)) + suffix
     }
 }

--- a/vreaderTests/Services/AI/Tools/GetBookContentGateTests.swift
+++ b/vreaderTests/Services/AI/Tools/GetBookContentGateTests.swift
@@ -1,0 +1,42 @@
+// Purpose: Feature #91 WI-6c — exhaustively pin the locality + format SAFETY GATE,
+// the risk core of get_book_content. Pure decision over (isReadable, format):
+// not-local → notLocal; local unsupported (azw3) → unsupportedFormat; local
+// EPUB/TXT/MD/PDF → extractable. Locality is checked first (a remote azw3 reports
+// notLocal, not unsupportedFormat).
+//
+// @coordinates-with: GetBookContentGate.swift,
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-6c)
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("Feature #91 WI-6c — GetBookContentGate")
+struct GetBookContentGateTests {
+
+    @Test("a local book in a supported format is extractable", arguments: ["epub", "txt", "md", "pdf"])
+    func localSupportedExtractable(format: String) {
+        #expect(GetBookContentGate.evaluate(isReadable: true, format: format) == .extractable)
+    }
+
+    @Test("a local native azw3 book is unsupported (no closed-book text path)")
+    func localAzw3Unsupported() {
+        #expect(GetBookContentGate.evaluate(isReadable: true, format: "azw3") == .unsupportedFormat)
+    }
+
+    @Test("a non-local book is notLocal regardless of format", arguments: ["epub", "txt", "md", "pdf", "azw3"])
+    func nonLocalIsNotLocal(format: String) {
+        #expect(GetBookContentGate.evaluate(isReadable: false, format: format) == .notLocal)
+    }
+
+    @Test("locality is checked FIRST: a remote azw3 reports notLocal, not unsupportedFormat")
+    func localityBeforeFormat() {
+        #expect(GetBookContentGate.evaluate(isReadable: false, format: "azw3") == .notLocal)
+    }
+
+    @Test("supported-format predicate covers exactly epub/txt/md/pdf")
+    func supportedFormats() {
+        for f in ["epub", "txt", "md", "pdf"] { #expect(GetBookContentGate.isSupportedFormat(f)) }
+        for f in ["azw3", "mobi", "prc", "cbz", ""] { #expect(!GetBookContentGate.isSupportedFormat(f)) }
+    }
+}

--- a/vreaderTests/Services/AI/Tools/GetBookContentToolTests.swift
+++ b/vreaderTests/Services/AI/Tools/GetBookContentToolTests.swift
@@ -1,0 +1,247 @@
+// Purpose: Feature #91 WI-6c — pin the get_book_content orchestration over a stub
+// BookContentProvider: resolve by title (ambiguity-aware); gate on locality +
+// format (the pure GetBookContentGate, tested separately) producing explicit
+// isError results for not-found / ambiguous / not-local / unsupported-format;
+// extract + char/byte-cap the text; a read failure → isError — never a throw.
+// Also pins the structural canonical-format derivation (drift-proof, Gate-4 High).
+//
+// @coordinates-with: GetBookContentTool.swift, GetBookContentGate.swift,
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-6c)
+
+import Testing
+import Foundation
+@testable import vreader
+
+private enum StubProviderError: Error { case boom }
+
+private actor StubContentProvider: BookContentProvider {
+    private let resolution: BookTitleResolution
+    private let text: String
+    private let extractThrows: Bool
+    private(set) var findCalls = 0
+    private(set) var extractCalls = 0
+
+    init(resolution: BookTitleResolution, text: String = "", extractThrows: Bool = false) {
+        self.resolution = resolution
+        self.text = text
+        self.extractThrows = extractThrows
+    }
+
+    func findBook(title: String) async -> BookTitleResolution {
+        findCalls += 1
+        return resolution
+    }
+
+    func extractText(fingerprintKey: String) async throws -> String {
+        extractCalls += 1
+        if extractThrows { throw StubProviderError.boom }
+        return text
+    }
+}
+
+@Suite("Feature #91 WI-6c — GetBookContentTool")
+struct GetBookContentToolTests {
+
+    private static func info(
+        format: String, local: Bool = true, title: String = "The Book"
+    ) -> BookContentInfo {
+        BookContentInfo(
+            fingerprintKey: "\(format):\(String(repeating: "a", count: 64)):4096",
+            title: title, isReadable: local)
+    }
+
+    private func tool(
+        _ provider: StubContentProvider, maxChars: Int = 8_000, maxContentBytes: Int = 16_000
+    ) -> GetBookContentTool {
+        GetBookContentTool(provider: provider, maxChars: maxChars, maxContentBytes: maxContentBytes)
+    }
+
+    // MARK: - Structural canonical-format derivation (Gate-4 High)
+
+    @Test("BookContentInfo.format is DERIVED from the fingerprint key, never a column")
+    func formatDerivedFromKey() {
+        #expect(Self.info(format: "txt").format == "txt")
+        #expect(Self.info(format: "epub").format == "epub")
+        #expect(Self.info(format: "azw3").format == "azw3")
+        // A malformed key derives nil (no format to trust).
+        #expect(BookContentInfo(fingerprintKey: "txt:bad:1", title: "X", isReadable: true).format == nil)
+    }
+
+    @Test("a book with a malformed fingerprint key reports unreadable metadata, never extracts")
+    func malformedKeyUnreadable() async {
+        let provider = StubContentProvider(
+            resolution: .found(BookContentInfo(fingerprintKey: "txt:bad:1", title: "Broken", isReadable: true)),
+            text: "secret")
+        let result = await tool(provider).run(.object(["title": .string("Broken")]))
+        #expect(result.isError == true)
+        #expect(result.content.localizedCaseInsensitiveContains("unreadable metadata"))
+        #expect(await provider.extractCalls == 0)
+    }
+
+    // MARK: - Definition
+
+    @Test("definition advertises the tool name + required title")
+    func definitionShape() {
+        let def = tool(StubContentProvider(resolution: .notFound)).definition
+        #expect(def.name == "get_book_content")
+        #expect(def.inputSchema["required"] == .array([.string("title")]))
+        #expect(def.inputSchema["properties"]?["title"]?["type"]?.stringValue == "string")
+    }
+
+    // MARK: - Bad input
+
+    @Test("a missing title yields an isError result and does NOT resolve a book")
+    func missingTitle() async {
+        let provider = StubContentProvider(resolution: .found(Self.info(format: "epub")))
+        let result = await tool(provider).run(.object(["nope": .number(1)]))
+        #expect(result.isError == true)
+        #expect(await provider.findCalls == 0)
+    }
+
+    // MARK: - Resolution + gating (each an explicit isError result)
+
+    @Test("a title with no matching book reports not-found")
+    func bookNotFound() async {
+        let provider = StubContentProvider(resolution: .notFound)
+        let result = await tool(provider).run(.object(["title": .string("Ghost")]))
+        #expect(result.isError == true)
+        #expect(result.content.localizedCaseInsensitiveContains("no book titled"))
+        #expect(await provider.extractCalls == 0)
+    }
+
+    @Test("two books sharing a title yield an ambiguity result with authors, never extracts")
+    func ambiguousTitle() async {
+        let provider = StubContentProvider(resolution: .ambiguous([
+            BookContentMatch(title: "Dune", author: "Frank Herbert"),
+            BookContentMatch(title: "Dune", author: "Someone Else"),
+        ]))
+        let result = await tool(provider).run(.object(["title": .string("Dune")]))
+        #expect(result.isError == true)
+        #expect(result.content.localizedCaseInsensitiveContains("several books match"))
+        #expect(result.content.contains("Frank Herbert"))   // author disambiguator surfaced
+        #expect(await provider.extractCalls == 0)            // never picks one silently
+    }
+
+    @Test("a remote-only book reports 'not downloaded', never extracts")
+    func notLocal() async {
+        let provider = StubContentProvider(resolution: .found(Self.info(format: "epub", local: false)))
+        let result = await tool(provider).run(.object(["title": .string("The Book")]))
+        #expect(result.isError == true)
+        #expect(result.content.localizedCaseInsensitiveContains("isn't downloaded"))
+        #expect(await provider.extractCalls == 0)
+    }
+
+    @Test("a native AZW3 book reports unsupported-format, never extracts")
+    func unsupportedFormat() async {
+        let provider = StubContentProvider(resolution: .found(Self.info(format: "azw3")))
+        let result = await tool(provider).run(.object(["title": .string("The Book")]))
+        #expect(result.isError == true)
+        #expect(result.content.contains("AZW3"))
+        #expect(result.content.localizedCaseInsensitiveContains("can't be extracted"))
+        #expect(await provider.extractCalls == 0)
+    }
+
+    @Test("locality is reported before format: a remote AZW3 says 'not downloaded'")
+    func localityBeatsFormat() async {
+        let provider = StubContentProvider(resolution: .found(Self.info(format: "azw3", local: false)))
+        let result = await tool(provider).run(.object(["title": .string("The Book")]))
+        #expect(result.isError == true)
+        #expect(result.content.localizedCaseInsensitiveContains("isn't downloaded"))
+    }
+
+    // MARK: - Happy path
+
+    @Test("a local supported book returns its text under a header")
+    func extractsLocalBook() async {
+        let provider = StubContentProvider(
+            resolution: .found(Self.info(format: "epub", title: "Moby Dick")), text: "Call me Ishmael.")
+        let result = await tool(provider).run(.object(["title": .string("Moby Dick")]))
+        #expect(result.isError == false)
+        #expect(result.content.contains("Call me Ishmael."))
+        #expect(result.content.contains("Moby Dick"))
+        #expect(await provider.extractCalls == 1)
+    }
+
+    @Test("an extraction failure becomes an isError result, not a crash")
+    func extractThrows() async {
+        let provider = StubContentProvider(
+            resolution: .found(Self.info(format: "txt")), text: "", extractThrows: true)
+        let result = await tool(provider).run(.object(["title": .string("The Book")]))
+        #expect(result.isError == true)
+        #expect(result.content.localizedCaseInsensitiveContains("couldn't read"))
+    }
+
+    // MARK: - Caps
+
+    @Test("max_chars caps the returned text")
+    func maxCharsCap() async {
+        let long = (0..<300).map { "L\($0)" }.joined(separator: " ")
+        let provider = StubContentProvider(resolution: .found(Self.info(format: "txt")), text: long)
+        let result = await tool(provider).run(
+            .object(["title": .string("The Book"), "max_chars": .number(30)]))
+        #expect(result.isError == false)
+        #expect(result.content.contains("L0"))        // early text present
+        #expect(!result.content.contains("L299"))     // late text capped off
+        #expect(result.content.contains("…"))         // truncation marker
+    }
+
+    @Test("start_char windows into a LATER section of the text")
+    func startCharWindowsLater() async {
+        let text = String(repeating: "A", count: 50) + String(repeating: "B", count: 50)
+        let provider = StubContentProvider(resolution: .found(Self.info(format: "txt")), text: text)
+        let result = await tool(provider).run(
+            .object(["title": .string("The Book"), "start_char": .number(50), "max_chars": .number(10)]))
+        #expect(result.isError == false)
+        #expect(result.content.contains("BBBBBBBBBB"))     // the window at offset 50
+        #expect(!result.content.contains("AAAA"))          // the earlier section is skipped
+        #expect(result.content.contains("characters 50–60 of 100"))
+    }
+
+    @Test("a start_char past the end is an explicit out-of-range error")
+    func startCharOutOfRange() async {
+        let provider = StubContentProvider(
+            resolution: .found(Self.info(format: "txt")), text: "short")   // 5 chars
+        let result = await tool(provider).run(
+            .object(["title": .string("The Book"), "start_char": .number(100)]))
+        #expect(result.isError == true)
+        #expect(result.content.localizedCaseInsensitiveContains("past the end"))
+    }
+
+    @Test("a book with no extractable text reports it, not an empty success")
+    func emptyExtract() async {
+        let provider = StubContentProvider(resolution: .found(Self.info(format: "txt")), text: "")
+        let result = await tool(provider).run(.object(["title": .string("The Book")]))
+        #expect(result.isError == false)
+        #expect(result.content.localizedCaseInsensitiveContains("no extractable text"))
+        #expect(await provider.extractCalls == 1)
+    }
+
+    @Test("the returned content is byte-bounded even for a large CJK book")
+    func byteBounded() async {
+        let cjk = String(repeating: "这是一本很长的中文书。", count: 200)   // multibyte, large
+        let provider = StubContentProvider(resolution: .found(Self.info(format: "txt")), text: cjk)
+        let result = await tool(provider, maxChars: 5_000, maxContentBytes: 512)
+            .run(.object(["title": .string("The Book")]))
+        #expect(result.isError == false)
+        #expect(result.content.utf8.count <= 512)
+        #expect(result.content.contains("…"))   // body byte-clamped → more text remains
+    }
+
+    @Test("the range header's END reflects the byte-clamped body, not the pre-clamp window")
+    func headerEndMatchesClampedBody() async {
+        // A CJK book whose window (5000-char request) is byte-clamped well short of
+        // 5000 chars → the header's END must equal the chars actually returned, so a
+        // model paging with start_char=END does not skip the clamped-off text.
+        let total = 400
+        let cjk = String(repeating: "字", count: total)   // 400 chars, 1200 bytes
+        let provider = StubContentProvider(resolution: .found(Self.info(format: "txt")), text: cjk)
+        let result = await tool(provider, maxChars: 5_000, maxContentBytes: 300)
+            .run(.object(["title": .string("The Book")]))
+        #expect(result.isError == false)
+        #expect(result.content.utf8.count <= 300)
+        // Parse the END the header advertises and count the '字' chars actually present.
+        let returned = result.content.filter { $0 == "字" }.count
+        #expect(result.content.contains("characters 0–\(returned) of \(total)"))
+        #expect(returned < total)                 // it WAS clamped short of the full book
+    }
+}


### PR DESCRIPTION
## Summary

- `get_book_content` — fetch a library book's text **by title** for the agentic AI chat. The model only ever sees titles (from `search_other_books` results / the user), never internal fingerprint keys, so **title is the model-facing contract** (the plan's `findBook(byFingerprintKey:)` was the internal mechanism).
- The locality + format risk is isolated in a **pure gate** (`GetBookContentGate`): not-local → "not downloaded"; native AZW3 → "unsupported format"; local EPUB/TXT/MD/PDF → extract. Range-limited (`start_char` + `max_chars`, out-of-range error) and byte-capped. Never throws.

Part of feature #1482.

## What Changed

- **New** `GetBookContentGate.swift` — pure locality+format gate + `BookContentProvider` seam. Resolution is **ambiguity-aware** (`notFound`/`found`/`ambiguous([candidate])`) so two books sharing a title never silently return the wrong text. `BookContentInfo.format` is **derived from the fingerprint key** (drift-proof — the Bug #246 class), never a caller-supplied column.
- **New** `GetBookContentTool.swift` — resolve title → gate → extract → range/byte-cap. Explicit isError results for not-found / ambiguous / not-local / unsupported / extract-failure / out-of-range.
- **`ToolResultText.swift`** — added marker-free `truncateToBytes`; `clamp` refactored to reuse it (behavior-preserving).
- **New tests** — `GetBookContentGateTests` (5) + `GetBookContentToolTests` (17).

The production `BookContentProvider` adapter (title lookup + closed-book reopen-path text extraction per format) is wired in WI-8.

## Codex Audit

3 rounds, `ship-as-is`, zero open Critical/High/Medium:
- **r1 High** — duplicate-title ambiguity → structural `BookTitleResolution` (surfaces candidates with author; never extracts the wrong book).
- **r1 High** — canonical-format invariant enforced structurally (derived from the key), not by comment.
- **r2 Medium** — implement the planned range contract (`start_char` + out-of-range).
- **r3 Medium** — the range header's `END` reflects the byte-clamped body (CJK), so paging with `start_char=END` can't skip clamped-off text.

Round-3 fix applied within the 3-round cap (mechanical + test-pinned; rationale in the log). Audit log: `.claude/codex-audits/feat-feature-91-wi-6c-get-content-audit.md`

## Validation

- [x] `scripts/run-tests.sh` over all 5 AI/Tools suites → `SUCCEEDED` (WI-6c + WI-6a/6b regression from the `ToolResultText` refactor)
- [x] TDD: RED → GREEN → 3 audit-driven refactor rounds
- [x] Docs sync — n/a (no user-visible wiring yet; agentic-cluster architecture entry lands with WI-8)
- [x] Version bumped: 3.51.12 → 3.51.13 (behavioral, not final → patch)

## Verification tier

Behavioral, but the tool is **not yet wired** (the production `BookContentProvider` adapter + registry are WI-8) — no user-observable surface to device-verify in isolation. The pure gate (the risk core) is exhaustively unit-tested. Slice verification of the agentic path is at WI-7/WI-8.

## Type of Change

- [x] New feature work item (Part of feature #1482)