### PR TITLE
feat(#91 WI-7): AgenticChatDriver — the bounded agentic loop

### DIFF
--- a/.claude/codex-audits/feat-feature-91-wi-7-agentic-driver-audit.md
+++ b/.claude/codex-audits/feat-feature-91-wi-7-agentic-driver-audit.md
@@ -1,0 +1,54 @@
+---
+branch: feat/feature-91-wi-7-agentic-driver
+threadId: 019e922d-ada6-7022-a695-415ca9ccbc39
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-04
+---
+
+# Codex Audit — Feature #91 WI-7 (AgenticChatDriver)
+
+Gate-4 implementation audit (rule 47). Independent Codex runner via
+`scripts/run-codex.sh -e high` (author/auditor separation, rule 48; rule-53
+stdin-isolated watchdog).
+
+## Scope
+
+Behavioral WI-7 — the bounded agentic loop:
+
+- `vreader/Services/AI/AgenticChatDriver.swift` (new) — `protocol ToolUseSending`
+  (the narrow provider seam) + `struct AgenticResult { finalText, usedTools }` +
+  `struct AgenticChatDriver`. `run(...)` drives send → on `.toolUse` run each call
+  via the registry, append the assistant turn losslessly + a tool_result-leading
+  user turn, re-send → until `.text` or the `maxIterations` cap.
+- `vreaderTests/Services/AI/AgenticChatDriverTests.swift` (new).
+
+## Round 1 — findings (threadId 019e922d-ada6-7022-a695-415ca9ccbc39)
+
+**No production-code defects.** The auditor confirmed the loop is hard-capped by
+sends, appends assistant `.toolUse` blocks losslessly, emits a tool_result-leading
+user turn in call order, snapshots `registry.definitions()` once (never re-resolves
+— Gate-2 Medium), propagates a provider throw while feeding tool failures back as
+`isError`, and that the `ToolUseSending` narrowing is sound for WI-8 (bridged via a
+small Sendable adapter / concrete conformance). All three findings were
+test-coverage gaps:
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| AgenticChatDriverTests.swift | **Medium** | No test exercised TWO completed tool rounds, so multi-resend ordering + validator-safety across >1 resend was unproven. | **Fixed.** `twoToolRoundsThenText` scripts `.toolUse(a) → .toolUse(b) → .text(done)`, asserts the 3rd request's role sequence `[user, assistant, user, assistant, user]`, and runs the real `ToolHistoryValidator.validate(...)` on the recorded multi-round history. |
+| AgenticChatDriverTests.swift | Low | The cap test only asserted `finalText` non-empty — wouldn't catch a regression in the last-text-vs-fallback path. | **Fixed.** Split into `capStopsAtMaxFallback` (no-text loop → exact fallback string + send count == cap) and `capReturnsLastText` (loop with text → that last assistant text). |
+| AgenticChatDriverTests.swift | Low | No test for `maxIterations` floor-to-1. | **Fixed.** `maxIterationsFloor` — `AgenticChatDriver(maxIterations: 0)` → exactly one send. |
+
+## Round 2 — verification (threadId 019e9243-20db-7f33-8a4d-41c625d1d8d1)
+
+All three **RESOLVED**, no new issues. The two-round test runs the real
+`ToolHistoryValidator` on the multi-round history; the cap path is split into
+fallback-text + last-text; the floor-to-1 guard is pinned.
+
+## Verdict
+
+**ship-as-is.** Zero open Critical/High/Medium after round 2. `AgenticChatDriverTests`
+green (10 tests: text-immediately/no-tools, one tool round with lossless assistant
+re-append + rebound tool_result, two completed rounds + validator-safety, tool
+error fed back continues the loop, multiple calls in one turn, cap fallback +
+cap-last-text, `maxIterations` floor, provider-throw propagation).

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 869
-        MARKETING_VERSION: 3.51.13
+        CURRENT_PROJECT_VERSION: 870
+        MARKETING_VERSION: 3.51.14
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7493,7 +7493,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 869;
+				CURRENT_PROJECT_VERSION = 870;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7501,7 +7501,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.13;
+				MARKETING_VERSION = 3.51.14;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7647,7 +7647,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 869;
+				CURRENT_PROJECT_VERSION = 870;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7655,7 +7655,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.13;
+				MARKETING_VERSION = 3.51.14;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -555,6 +555,7 @@
 		58132D890E317C57F2940579 /* SelectionPopoverAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5825B20D8E48C77A28E061A /* SelectionPopoverAction.swift */; };
 		581D8C5F46D4CAAD4DA31EF8 /* FoliateViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506F86FDA1498276D10E5E7B /* FoliateViewCoordinator.swift */; };
 		5846D1DF8548F8F8214DF178 /* PDFReaderContainerView+DebugBridgePDFHighlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = A184EB55FF1E4B6B2E8FD112 /* PDFReaderContainerView+DebugBridgePDFHighlight.swift */; };
+		58492304DE5E8129C46DE24C /* AgenticChatDriverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF9453C981DC4FE44C43679 /* AgenticChatDriverTests.swift */; };
 		5895F86BFE58FBFBAA7D8424 /* SyncStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F6250C22449E7E83591620 /* SyncStatusView.swift */; };
 		58C066AA53EC9D61B9960E9B /* WebDAVServerProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54AC37DCD75A3993463AC297 /* WebDAVServerProfileTests.swift */; };
 		58C21B04E91D34FD03CDECF8 /* BilingualReadingViewModelRetryUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7CCF325A8D2CDC827B49C7 /* BilingualReadingViewModelRetryUnitTests.swift */; };
@@ -1044,6 +1045,7 @@
 		A94C7BEA198AF83B90936259 /* TranslateLanguageRailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94AF8D98E6FAD355A8B3416B /* TranslateLanguageRailTests.swift */; };
 		A957D0C3F823092026646570 /* Highlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = C775619D3C0E4641505CE2B8 /* Highlight.swift */; };
 		A95CA2A8C9841860265A7FF3 /* PDFReaderPlaceholderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D9A3C4C1072DA23511265D /* PDFReaderPlaceholderTests.swift */; };
+		A9C00155CFDFF275A6C51742 /* AgenticChatDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B311EFBC5A90B5A6B167389E /* AgenticChatDriver.swift */; };
 		A9CAA729B2E8B4DCDF7D17AB /* legado_source_js.json in Resources */ = {isa = PBXBuildFile; fileRef = B8D6186050D8E6FE32B2578B /* legado_source_js.json */; };
 		A9FBA093179D68123CDA14E5 /* FoliateSpikeViewTapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472BFDA2BCCC6A713B4C2AEF /* FoliateSpikeViewTapTests.swift */; };
 		AA131C9C9A1EA322761D936A /* ChapterTranslationCacheLookupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21BF3A477B679DC3646FE38 /* ChapterTranslationCacheLookupTests.swift */; };
@@ -1745,6 +1747,7 @@
 		1D51DC243D8B3F2A404ABA38 /* ReaderSettingsPanelThemePickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSettingsPanelThemePickerTests.swift; sourceTree = "<group>"; };
 		1D579834E6924BB521873C38 /* FormatCapabilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatCapabilitiesTests.swift; sourceTree = "<group>"; };
 		1DF155633B0D81B0E477E63C /* SchemaV7.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV7.swift; sourceTree = "<group>"; };
+		1DF9453C981DC4FE44C43679 /* AgenticChatDriverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgenticChatDriverTests.swift; sourceTree = "<group>"; };
 		1E4E3B1DC47242FC7A17BD69 /* Feature64TXTMDMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature64TXTMDMigrationTests.swift; sourceTree = "<group>"; };
 		1EC15AFBBED7042657A406C9 /* OffsetMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffsetMap.swift; sourceTree = "<group>"; };
 		1EE0734EE0796711AE09253D /* AIAssistantViewModelScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAssistantViewModelScopeTests.swift; sourceTree = "<group>"; };
@@ -2655,6 +2658,7 @@
 		B2A04EAFA37410DA616E33D6 /* BackgroundDownloadSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundDownloadSession.swift; sourceTree = "<group>"; };
 		B2B73649BCBDBE8A99B210A9 /* WebDAVNetworkPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVNetworkPolicyTests.swift; sourceTree = "<group>"; };
 		B2DB7F421D9D2E7492E12F89 /* ZIPReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZIPReader.swift; sourceTree = "<group>"; };
+		B311EFBC5A90B5A6B167389E /* AgenticChatDriver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgenticChatDriver.swift; sourceTree = "<group>"; };
 		B34C87EDF46A4EFC99012268 /* AnnotationsPanelPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationsPanelPlaceholderTests.swift; sourceTree = "<group>"; };
 		B39618F097181A76AAF862F0 /* LazyDownloadCoordinatorEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyDownloadCoordinatorEnvironment.swift; sourceTree = "<group>"; };
 		B3987200016FB6CA3D063E44 /* LocatorCanonicalHashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorCanonicalHashTests.swift; sourceTree = "<group>"; };
@@ -5199,6 +5203,7 @@
 		D90CA6776A077CBDC255F35C /* AI */ = {
 			isa = PBXGroup;
 			children = (
+				1DF9453C981DC4FE44C43679 /* AgenticChatDriverTests.swift */,
 				4A57E82A7221B36240E501FD /* AIConfigurationTests.swift */,
 				FFD1AE78FBFF38B3616352FF /* AIConsentManagerTests.swift */,
 				D1368D4DA7FCD1EC48778531 /* AIContextExtractorScopedTests.swift */,
@@ -5505,6 +5510,7 @@
 		F1A2DC49F84E40DE8F921733 /* AI */ = {
 			isa = PBXGroup;
 			children = (
+				B311EFBC5A90B5A6B167389E /* AgenticChatDriver.swift */,
 				C52103AEAF5528A9DD58625E /* AIConfiguration.swift */,
 				F8038AAB18412F30C09CBDD9 /* AIConfigurationStore.swift */,
 				E1C9AB72079AF7B2ACCAB516 /* AIConsentManager.swift */,
@@ -5943,6 +5949,7 @@
 				5C20BECE1338802F60F3E7B7 /* AITranslationTests.swift in Sources */,
 				495502CCD0035DB7C8AE37DA /* AccentColorTests.swift in Sources */,
 				65C927CBE6855076656719CE /* AccessibilityFormattersTests.swift in Sources */,
+				58492304DE5E8129C46DE24C /* AgenticChatDriverTests.swift in Sources */,
 				13EC9440F35FF01443E4FABF /* AnnotationAnchorTests.swift in Sources */,
 				058C2F104DE6D10D81F907D9 /* AnnotationExporterTests.swift in Sources */,
 				C35B2A71395E812536EDFEBD /* AnnotationImporterTests.swift in Sources */,
@@ -6589,6 +6596,7 @@
 				9AEE4782EDC4308FAA289B3B /* AccentColor.swift in Sources */,
 				8A3AE73DD5935F4E45882E38 /* AccessibilityFormatters.swift in Sources */,
 				19A48F5C5BC46818F3CC10BB /* AddNoteSheet.swift in Sources */,
+				A9C00155CFDFF275A6C51742 /* AgenticChatDriver.swift in Sources */,
 				21145D281B373D2D3262E65F /* AnnotationAnchor.swift in Sources */,
 				7872FD996BEB1009EFF26413 /* AnnotationEditSheet.swift in Sources */,
 				C7963EB4DD0ACFD3A87D97CC /* AnnotationExporter.swift in Sources */,

--- a/vreader/Services/AI/AgenticChatDriver.swift
+++ b/vreader/Services/AI/AgenticChatDriver.swift
@@ -1,0 +1,115 @@
+// Purpose: Feature #91 WI-7 — the bounded agentic loop. Given a pre-resolved
+// tool-use provider + a tool registry, it drives: send → if the model requests
+// tools, run each via the registry, append the tool_results, re-send → repeat
+// until the model returns a final text answer or a hard iteration cap is hit.
+//
+// Key decisions:
+// - ONE pre-resolved provider (Gate-2 Medium): the driver is handed a provider
+//   resolved once at loop start, so a provider/model/key change mid-loop cannot
+//   straddle the operation. The driver NEVER re-resolves.
+// - Off-`@MainActor` (a plain Sendable struct, mirroring #86's off-actor reducer):
+//   the `@MainActor` VM (WI-8) awaits it, but the loop itself crosses no UI actor.
+// - Lossless assistant turn: a `.toolUse` turn's FULL ordered content blocks
+//   (interleaved text + tool_use) are re-appended verbatim — the provider API
+//   requires the re-sent assistant turn to carry exactly those blocks.
+// - Bounded: `maxIterations` send calls. On the cap, return the model's last
+//   assistant text if any, else a graceful message — never an unbounded loop.
+// - `usedTools` lets the VM decide citation handling (Gate-2 Medium 3: suppress
+//   the "Drew on" stamp on tool-driven replies).
+//
+// @coordinates-with: AITool.swift (DTOs + AIToolTurn), AIToolRegistry.swift
+//   (tool dispatch), AIProvider.swift (the provider's sendToolRequest seam),
+//   AIChatViewModel.swift (the WI-8 consumer),
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-7)
+
+import Foundation
+import OSLog
+
+/// The narrow capability the driver needs from a provider — one tool-use turn.
+/// `AIProvider` already vends `sendToolRequest`; WI-8 bridges the resolved
+/// provider to this seam. Keeping it narrow makes the driver trivially testable.
+protocol ToolUseSending: Sendable {
+    func sendToolRequest(_ request: AIToolRequest) async throws -> AIToolTurn
+}
+
+/// The outcome of one agentic run.
+struct AgenticResult: Sendable, Equatable {
+    /// The model's final text answer (or a graceful message if the cap was hit).
+    let finalText: String
+    /// Whether the loop executed at least one tool (drives citation suppression).
+    let usedTools: Bool
+}
+
+/// The bounded send → tool → result → re-send loop.
+struct AgenticChatDriver: Sendable {
+
+    private static let log = Logger(subsystem: "com.vreader.app", category: "AgenticChatDriver")
+
+    /// Hard cap on provider round-trips (a runaway-loop / cost backstop).
+    let maxIterations: Int
+
+    init(maxIterations: Int = 6) {
+        self.maxIterations = max(1, maxIterations)
+    }
+
+    /// Run the loop. `history` is the conversation so far (the user's prompt is the
+    /// last message). Throws only if the PROVIDER throws — every tool failure is an
+    /// `isError` tool_result fed back to the model, not a thrown error.
+    func run(
+        systemPrompt: String,
+        history: [ToolTurnMessage],
+        registry: AIToolRegistry,
+        provider: any ToolUseSending,
+        maxTokens: Int
+    ) async throws -> AgenticResult {
+        var messages = history
+        var usedTools = false
+        let tools = registry.definitions()
+
+        for iteration in 0..<maxIterations {
+            let request = AIToolRequest(
+                systemPrompt: systemPrompt, messages: messages, tools: tools, maxTokens: maxTokens)
+            let turn = try await provider.sendToolRequest(request)
+
+            switch turn {
+            case .text(let text):
+                return AgenticResult(finalText: text, usedTools: usedTools)
+
+            case .toolUse(let blocks):
+                usedTools = true
+                // Re-append the assistant turn LOSSLESSLY (the API requires exactly
+                // these blocks on the re-sent turn).
+                messages.append(ToolTurnMessage(role: .assistant, content: blocks))
+                // Run every requested tool; collect the results as a single
+                // tool_result-leading user turn (provider history invariant).
+                var resultBlocks: [ToolContentBlock] = []
+                for call in turn.toolCalls {
+                    let result = await registry.run(call)
+                    resultBlocks.append(.toolResult(result))
+                }
+                Self.log.info(
+                    "agentic iteration \(iteration + 1, privacy: .public): ran \(resultBlocks.count, privacy: .public) tool(s)")
+                messages.append(ToolTurnMessage(role: .user, content: resultBlocks))
+            }
+        }
+
+        // Cap reached while the model still wanted tools — return its last words if
+        // any, else a graceful message. Never loop unbounded.
+        Self.log.warning("agentic loop hit the \(self.maxIterations, privacy: .public)-iteration cap")
+        let lastText = Self.lastAssistantText(in: messages)
+        return AgenticResult(
+            finalText: lastText ?? "I wasn't able to finish answering within the tool-call limit.",
+            usedTools: usedTools)
+    }
+
+    /// The most recent non-empty assistant text in the history (for the cap path).
+    private static func lastAssistantText(in messages: [ToolTurnMessage]) -> String? {
+        for message in messages.reversed() where message.role == .assistant {
+            let text = message.content.compactMap {
+                if case .text(let t) = $0 { return t } else { return nil }
+            }.joined(separator: "\n")
+            if !text.isEmpty { return text }
+        }
+        return nil
+    }
+}

--- a/vreaderTests/Services/AI/AgenticChatDriverTests.swift
+++ b/vreaderTests/Services/AI/AgenticChatDriverTests.swift
@@ -1,0 +1,225 @@
+// Purpose: Feature #91 WI-7 — pin the bounded agentic loop: a scripted
+// ToolUseSending provider drives the driver through tool rounds + a final text;
+// a real AIToolRegistry runs the tools. Proves: text-immediately (no tools),
+// tool→result→re-send→text, the assistant turn re-appended losslessly + the
+// tool_result fed back, a tool error continues the loop, multiple calls in one
+// turn, the iteration cap, and provider-throw propagation.
+//
+// @coordinates-with: AgenticChatDriver.swift, AIToolRegistry.swift, AITool.swift,
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-7)
+
+import Testing
+import Foundation
+@testable import vreader
+
+private enum ScriptedProviderError: Error { case boom }
+
+/// A test tool that echoes a fixed reply (and records nothing — the registry
+/// rebinds the call id, which the driver tests assert on the fed-back result).
+private struct ProbeTool: AITool {
+    let toolName: String
+    let reply: String
+    let fail: Bool
+    init(name: String, reply: String = "tool output", fail: Bool = false) {
+        self.toolName = name; self.reply = reply; self.fail = fail
+    }
+    var definition: ToolDefinition {
+        ToolDefinition(name: toolName, description: "probe \(toolName)", inputSchema: .object([:]))
+    }
+    func run(_ input: JSONValue) async -> ToolResult {
+        ToolResult(toolUseID: "IGNORED", content: reply, isError: fail)
+    }
+}
+
+/// Returns a scripted sequence of turns (looping the last one when `loopLast`),
+/// records every request, and can throw on the Nth call.
+private actor ScriptedProvider: ToolUseSending {
+    private var queue: [AIToolTurn]
+    private let loopLast: Bool
+    private let throwOnCall: Int?
+    private var last: AIToolTurn?
+    private var callCount = 0
+    private(set) var requests: [AIToolRequest] = []
+
+    init(_ queue: [AIToolTurn], loopLast: Bool = false, throwOnCall: Int? = nil) {
+        self.queue = queue
+        self.loopLast = loopLast
+        self.throwOnCall = throwOnCall
+    }
+
+    func sendToolRequest(_ request: AIToolRequest) async throws -> AIToolTurn {
+        callCount += 1
+        requests.append(request)
+        if let t = throwOnCall, callCount == t { throw ScriptedProviderError.boom }
+        if !queue.isEmpty {
+            last = queue.removeFirst()
+            return last!
+        }
+        if loopLast, let last { return last }
+        return .text("(exhausted)")
+    }
+}
+
+@Suite("Feature #91 WI-7 — AgenticChatDriver")
+struct AgenticChatDriverTests {
+
+    private static func history(_ prompt: String) -> [ToolTurnMessage] {
+        [ToolTurnMessage(role: .user, content: [.text(prompt)])]
+    }
+
+    private static func toolUseTurn(callID: String, name: String, text: String? = nil) -> AIToolTurn {
+        var blocks: [ToolContentBlock] = []
+        if let text { blocks.append(.text(text)) }
+        blocks.append(.toolUse(ToolCall(id: callID, name: name, input: .object([:]))))
+        return .toolUse(blocks: blocks)
+    }
+
+    private func run(
+        _ provider: ScriptedProvider, _ registry: AIToolRegistry, maxIterations: Int = 6
+    ) async throws -> AgenticResult {
+        try await AgenticChatDriver(maxIterations: maxIterations).run(
+            systemPrompt: "sys", history: Self.history("question"),
+            registry: registry, provider: provider, maxTokens: 1024)
+    }
+
+    // MARK: - No tools
+
+    @Test("a text-only first turn returns immediately, usedTools == false, one send")
+    func textImmediately() async throws {
+        let provider = ScriptedProvider([.text("Hello.")])
+        let result = try await run(provider, AIToolRegistry([]))
+        #expect(result.finalText == "Hello.")
+        #expect(result.usedTools == false)
+        #expect(await provider.requests.count == 1)
+    }
+
+    // MARK: - One tool round
+
+    @Test("tool turn → run → tool_result re-sent → final text; assistant turn is lossless")
+    func runsToolThenText() async throws {
+        let provider = ScriptedProvider([
+            Self.toolUseTurn(callID: "c1", name: "search", text: "Let me search."),
+            .text("The answer is 42."),
+        ])
+        let registry = AIToolRegistry([ProbeTool(name: "search", reply: "search result text")])
+
+        let result = try await run(provider, registry)
+
+        #expect(result.finalText == "The answer is 42.")
+        #expect(result.usedTools == true)
+        let requests = await provider.requests
+        #expect(requests.count == 2)
+        // The re-sent (2nd) request carries: user(q), assistant(the EXACT toolUse
+        // blocks), user(tool_result).
+        let msgs = requests[1].messages
+        #expect(msgs.count == 3)
+        #expect(msgs[1].role == .assistant)
+        #expect(msgs[1].content == [.text("Let me search."), .toolUse(ToolCall(id: "c1", name: "search", input: .object([:])))])
+        // The fed-back tool_result is bound to the call id (registry rebind) + carries the tool's output.
+        guard case .toolResult(let fed) = msgs[2].content.first else {
+            Issue.record("expected a tool_result block"); return
+        }
+        #expect(fed.toolUseID == "c1")
+        #expect(fed.content == "search result text")
+        #expect(fed.isError == false)
+    }
+
+    // MARK: - Tool error continues the loop
+
+    @Test("a tool error is fed back as data; the loop continues to a final answer")
+    func toolErrorContinues() async throws {
+        // Empty registry → the call resolves to an unknown-tool isError result.
+        let provider = ScriptedProvider([
+            Self.toolUseTurn(callID: "c1", name: "missing"),
+            .text("Recovered without that tool."),
+        ])
+        let result = try await run(provider, AIToolRegistry([]))
+        #expect(result.finalText == "Recovered without that tool.")
+        #expect(result.usedTools == true)
+        let msgs = await provider.requests[1].messages
+        guard case .toolResult(let fed) = msgs[2].content.first else {
+            Issue.record("expected a tool_result block"); return
+        }
+        #expect(fed.isError == true)                 // the unknown-tool error was fed back
+        #expect(fed.content.contains("Unknown tool 'missing'"))
+    }
+
+    // MARK: - Multiple calls in one turn
+
+    @Test("multiple tool calls in one turn all run, in one tool_result user turn")
+    func multipleCallsOneTurn() async throws {
+        let blocks: [ToolContentBlock] = [
+            .toolUse(ToolCall(id: "a", name: "search", input: .object([:]))),
+            .toolUse(ToolCall(id: "b", name: "search", input: .object([:]))),
+        ]
+        let provider = ScriptedProvider([.toolUse(blocks: blocks), .text("done")])
+        let result = try await run(provider, AIToolRegistry([ProbeTool(name: "search")]))
+        #expect(result.finalText == "done")
+        let userTurn = await provider.requests[1].messages[2]
+        #expect(userTurn.role == .user)
+        let resultIDs = userTurn.content.compactMap {
+            if case .toolResult(let r) = $0 { return r.toolUseID } else { return nil }
+        }
+        #expect(resultIDs == ["a", "b"])             // both results, in order, one turn
+    }
+
+    // MARK: - Two completed tool rounds (multi-resend ordering + validator-safety)
+
+    @Test("two tool rounds stay ordered + provider-invariant-valid before the final text")
+    func twoToolRoundsThenText() async throws {
+        let provider = ScriptedProvider([
+            Self.toolUseTurn(callID: "a", name: "search"),
+            Self.toolUseTurn(callID: "b", name: "search"),
+            .text("done"),
+        ])
+        let result = try await run(provider, AIToolRegistry([ProbeTool(name: "search")]))
+        #expect(result.finalText == "done")
+        let requests = await provider.requests
+        #expect(requests.count == 3)
+        // The 3rd request carries BOTH completed rounds in order:
+        // user(q), assistant(a), user(result a), assistant(b), user(result b).
+        let msgs = requests[2].messages
+        #expect(msgs.map(\.role) == [.user, .assistant, .user, .assistant, .user])
+        // Each assistant tool_use turn is immediately followed by a tool_result-
+        // leading user turn with every id answered — pin it with the real validator.
+        try ToolHistoryValidator.validate(msgs)
+    }
+
+    // MARK: - Iteration cap
+
+    @Test("the loop stops at maxIterations; with no model text the result is the fallback")
+    func capStopsAtMaxFallback() async throws {
+        let provider = ScriptedProvider(
+            [Self.toolUseTurn(callID: "c", name: "search")], loopLast: true)   // no text
+        let result = try await run(provider, AIToolRegistry([ProbeTool(name: "search")]), maxIterations: 3)
+        #expect(await provider.requests.count == 3)   // capped — not unbounded
+        #expect(result.usedTools == true)
+        #expect(result.finalText == "I wasn't able to finish answering within the tool-call limit.")
+    }
+
+    @Test("on the cap, the model's last assistant text is returned when present")
+    func capReturnsLastText() async throws {
+        let provider = ScriptedProvider(
+            [Self.toolUseTurn(callID: "c", name: "search", text: "Still digging…")], loopLast: true)
+        let result = try await run(provider, AIToolRegistry([ProbeTool(name: "search")]), maxIterations: 2)
+        #expect(result.finalText == "Still digging…")
+    }
+
+    @Test("maxIterations is floored to 1 — a 0 cap still makes exactly one send")
+    func maxIterationsFloor() async throws {
+        let provider = ScriptedProvider(
+            [Self.toolUseTurn(callID: "c", name: "search")], loopLast: true)
+        _ = try await run(provider, AIToolRegistry([ProbeTool(name: "search")]), maxIterations: 0)
+        #expect(await provider.requests.count == 1)
+    }
+
+    // MARK: - Provider error propagates
+
+    @Test("a provider error propagates (the driver throws), unlike a tool error")
+    func providerThrows() async {
+        let provider = ScriptedProvider([.text("never reached")], throwOnCall: 1)
+        await #expect(throws: ScriptedProviderError.self) {
+            try await run(provider, AIToolRegistry([]))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `AgenticChatDriver` — the send → tool → result → re-send loop. Given a **pre-resolved** tool-use provider + the `AIToolRegistry`, it sends; on a `.toolUse` turn it runs each call via the registry, re-appends the assistant turn **losslessly** (the API requires exactly those blocks) + a tool_result-leading user turn, and re-sends — until the model returns a final `.text` answer or the `maxIterations` cap is hit.

Part of feature #1482.

## What Changed

- **New** `AgenticChatDriver.swift` — `protocol ToolUseSending` (narrow provider seam) + `struct AgenticResult { finalText, usedTools }` + `struct AgenticChatDriver`.
  - ONE pre-resolved provider, never re-resolved per turn (Gate-2 Medium); tools snapshotted once from `registry.definitions()`.
  - Bounded: `maxIterations` sends (floored to 1); on the cap → the model's last assistant text, else a graceful message — never unbounded.
  - A **tool** failure is an `isError` tool_result fed back (loop continues); only a **provider** throw propagates.
  - `usedTools` lets the VM suppress the "Drew on" citation stamp on tool-driven replies (Gate-2 Medium 3).
- **New tests** — `AgenticChatDriverTests` (10).

WI-8 bridges the resolved `AIProvider` (which already has `sendToolRequest`) to the `ToolUseSending` seam and wires the driver into `AIChatViewModel`.

## Codex Audit

2 rounds, `ship-as-is`, zero open Critical/High/Medium. Round 1 found **zero production-code defects** (loop hard-capped, lossless re-append, tool_result ordering, snapshot-once, provider-throw-vs-tool-error all confirmed); the 3 findings were test-coverage gaps — added a two-completed-rounds test that runs the real `ToolHistoryValidator` on the recorded multi-round history, split the cap path into fallback-text + last-text, and pinned the `maxIterations` floor. Round 2: all RESOLVED.

Audit log: `.claude/codex-audits/feat-feature-91-wi-7-agentic-driver-audit.md`

## Validation

- [x] `scripts/run-tests.sh vreaderTests/AgenticChatDriverTests` → `SUCCEEDED` (10 tests)
- [x] TDD: RED → GREEN → audit-driven test-hardening
- [x] Docs sync — n/a (no user-visible wiring yet; agentic-cluster architecture entry lands with WI-8)
- [x] Version bumped: 3.51.13 → 3.51.14 (behavioral, not final → patch)

## Verification tier

Behavioral, but not yet wired (WI-8 connects it to `AIChatViewModel`). The loop is exhaustively unit-tested against a scripted provider + a real registry. End-to-end slice verification happens at WI-8 (Gate-5, device).

## Type of Change

- [x] New feature work item (Part of feature #1482)