### PR TITLE
feat(#91 WI-8b/1): AIService.resolveToolProvider + sendToolTurn agentic seam

### DIFF
--- a/.claude/codex-audits/feat-feature-91-wi-8b-resolve-tool-provider-audit.md
+++ b/.claude/codex-audits/feat-feature-91-wi-8b-resolve-tool-provider-audit.md
@@ -1,0 +1,52 @@
+---
+branch: feat/feature-91-wi-8b-resolve-tool-provider
+threadId: 019e929c-d85f-7d53-aa70-23e94ff133fc
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-04
+---
+
+# Codex Audit — Feature #91 WI-8b (slice 1: AIService agentic seam)
+
+Gate-4 implementation audit (rule 47). Independent Codex runner via
+`scripts/run-codex.sh -e high` (author/auditor separation, rule 48; rule-53
+stdin-isolated watchdog).
+
+## Scope
+
+WI-8b slice 1 — the `AIService` seam the agentic chat loop resolves through:
+
+- `vreader/Services/AI/AIService.swift` — `resolveToolProvider()` (resolve the
+  active config ONCE: flag + consent + active-profile + key gates, report tool-use
+  capability) + `sendToolTurn(_:using:)` (one tool turn through a PINNED config,
+  re-checking the live gates each turn).
+- `vreaderTests/Services/AI/AIServiceResolvedConfigTests.swift` — 6 tests via the
+  `provider:` injection seam.
+
+## Round 1 — findings (threadId 019e929c-d85f-7d53-aa70-23e94ff133fc)
+
+`maxTokens` carry + actor isolation confirmed sound.
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| AIService.swift `resolveToolProvider` | **Medium** | Returning a raw `AIProvider` meant the multi-turn agentic loop would bypass the LIVE `aiAssistant`/consent gates after the initial resolve — a flag flip or consent revoke mid-loop could still reach the provider. | **Fixed.** `resolveToolProvider()` now returns `(config: ResolvedAIProviderConfig, supportsToolUse)` — NOT a raw provider; each round-trip goes through `sendToolTurn(_:using:)`, which re-checks the flag + consent EACH turn (fails closed) while reusing the pinned config (no provider/model/key drift — Gate-2 Medium). Test `sendToolTurn_reChecksTheLiveFlagEachTurn` flips the flag OFF mid-loop → the next turn throws `featureDisabled`. |
+| AIServiceResolvedConfigTests.swift | Low | The "same gates" test only covered `featureDisabled`. | **Fixed.** `resolveToolProvider_failsClosedOnEveryGate` covers `featureDisabled` + `consentRequired` + `apiKeyMissing`. |
+| AIServiceResolvedConfigTests.swift | Low | The resolve-once pinning was documented, not proven. | **Fixed.** The config is structurally pinned (`sendToolTurn(_:using:)`); the returned snapshot's `kind`/`maxTokens` are asserted, and `sendToolTurn` reuses exactly that config. |
+
+## Round 2 — verification (threadId 019e92b0-e5f1-7341-a548-3307874a15cc)
+
+**No findings.** All three **RESOLVED**: the pinned config + per-turn gate re-check
+(fails closed mid-loop), all three resolve gates covered, and the structural
+pinning proven.
+
+## Verdict
+
+**ship-as-is.** Zero open Critical/High/Medium after round 2. `AIServiceResolvedConfigTests`
+green (6 WI-8 tests: config+capability+maxTokens, non-tool → unsupported, all three
+resolve gates fail closed, `sendToolTurn` forwards through the pinned config when
+gates pass, and re-checks the live flag each turn).
+
+The remaining WI-8b work (the `LibrarySearchBackend` + `BookContentProvider`
+production adapters + the closed-book text extractor, the registry builder, the
+`AIChatViewModel.sendMessage` branch + citation suppression, and the Gate-5 device
+verification) completes the feature to `DONE`/`VERIFIED`.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 871
-        MARKETING_VERSION: 3.51.15
+        CURRENT_PROJECT_VERSION: 872
+        MARKETING_VERSION: 3.51.16
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7501,7 +7501,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 871;
+				CURRENT_PROJECT_VERSION = 872;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7509,7 +7509,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.15;
+				MARKETING_VERSION = 3.51.16;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7655,7 +7655,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 871;
+				CURRENT_PROJECT_VERSION = 872;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7663,7 +7663,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.15;
+				MARKETING_VERSION = 3.51.16;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Services/AI/AIService.swift
+++ b/vreader/Services/AI/AIService.swift
@@ -211,6 +211,31 @@ actor AIService {
         return try config(from: snapshot, modelOverride: nil)
     }
 
+    /// Feature #91: resolve the active provider config ONCE for an agentic tool-use
+    /// turn — the same flag + consent + active-profile + key gates as
+    /// `resolveActiveProviderConfig` — and report whether the built provider
+    /// supports tool-use. The driver pins THIS config for the whole loop (no
+    /// provider/model/key drift mid-operation — Gate-2 Medium); each round-trip
+    /// goes back through `sendToolTurn(_:using:)`, which re-checks the LIVE gates
+    /// (Gate-4 Medium). `maxTokens` comes from `config.maxTokens`.
+    func resolveToolProvider() async throws -> (config: ResolvedAIProviderConfig, supportsToolUse: Bool) {
+        let config = try await resolveActiveProviderConfig()
+        return (config, providerInstance(for: config).supportsToolUse)
+    }
+
+    /// Send ONE tool-use turn through a PINNED resolved config. Re-checks the live
+    /// `aiAssistant` flag + consent EACH turn (Gate-4 Medium: a multi-turn agentic
+    /// loop must stop the instant AI is disabled or consent is revoked mid-loop),
+    /// while reusing the same `config` so the provider/model/key never drift
+    /// (Gate-2 Medium).
+    func sendToolTurn(
+        _ request: AIToolRequest, using config: ResolvedAIProviderConfig
+    ) async throws -> AIToolTurn {
+        guard featureFlags.aiAssistant else { throw AIError.featureDisabled }
+        guard consentManager.hasConsent else { throw AIError.consentRequired }
+        return try await providerInstance(for: config).sendToolRequest(request)
+    }
+
     /// Resolves a *named* provider profile (not necessarily the active one)
     /// into a config snapshot, applying an optional `modelOverride`. Used by
     /// the re-translate flow's provider-override picker. Throws `providerError`

--- a/vreaderTests/Services/AI/AIServiceResolvedConfigTests.swift
+++ b/vreaderTests/Services/AI/AIServiceResolvedConfigTests.swift
@@ -129,6 +129,124 @@ struct AIServiceResolvedConfigTests {
         }
     }
 
+    // MARK: - resolveToolProvider / sendToolTurn (Feature #91 WI-8)
+
+    /// A tool-capable provider stub (supportsToolUse = true, returns a canned tool
+    /// turn) — the injected `provider:` short-circuits `providerInstance(for:)`.
+    private final class ToolCapableStub: AIProvider, @unchecked Sendable {
+        let providerName = "ToolStub"
+        var supportsToolUse: Bool { true }
+        func sendRequest(_ request: AIRequest) async throws -> AIResponse {
+            throw AIError.invalidResponse
+        }
+        func streamRequest(_ request: AIRequest) -> AsyncThrowingStream<AIStreamChunk, Error> {
+            AsyncThrowingStream { $0.finish() }
+        }
+        func sendToolRequest(_ request: AIToolRequest) async throws -> AIToolTurn {
+            .text("tool answer")
+        }
+    }
+
+    private static func toolRequest() -> AIToolRequest {
+        AIToolRequest(
+            systemPrompt: "s", messages: [ToolTurnMessage(role: .user, content: [.text("q")])],
+            tools: [], maxTokens: 128)
+    }
+
+    /// Build a service with a held FeatureFlags handle so a test can flip a gate
+    /// mid-loop.
+    private static func makeServiceHoldingFlags(
+        store: ProviderProfileStore, keychain: KeychainService,
+        provider: any AIProvider
+    ) -> (AIService, FeatureFlags) {
+        let flags = FeatureFlags(environment: .prod)
+        flags.setOverride(true, for: .aiAssistant)
+        let service = AIService(
+            featureFlags: flags,
+            consentManager: WI11TestHelpers.makeConsentManager(hasConsent: true),
+            keychainService: keychain, provider: provider, profileStore: store)
+        return (service, flags)
+    }
+
+    @Test func resolveToolProvider_returnsConfigCapabilityAndMaxTokens() async throws {
+        let (store, keychain) = Self.makeTestStore()
+        let profile = Self.makeAnthropicProfile()   // maxTokens 4321
+        try keychain.saveAPIKey("sk-ant-active", forProfile: profile.id)
+        await store.upsert(profile)
+        await store.setActiveProfileID(profile.id)
+
+        let service = Self.makeService(store: store, keychain: keychain, provider: ToolCapableStub())
+        let (config, supports) = try await service.resolveToolProvider()
+        #expect(supports == true)
+        #expect(config.maxTokens == 4321)            // pinned from the resolved config
+        #expect(config.kind == .anthropicNative)
+    }
+
+    @Test func resolveToolProvider_reportsUnsupportedForNonToolProvider() async throws {
+        let (store, keychain) = Self.makeTestStore()
+        let profile = Self.makeOpenAIProfile()
+        try keychain.saveAPIKey("sk-openai-active", forProfile: profile.id)
+        await store.upsert(profile)
+        await store.setActiveProfileID(profile.id)
+
+        let service = Self.makeService(store: store, keychain: keychain, provider: StubAIProvider())
+        let (_, supports) = try await service.resolveToolProvider()
+        #expect(supports == false)   // StubAIProvider defaults supportsToolUse=false
+    }
+
+    @Test func resolveToolProvider_failsClosedOnEveryGate() async throws {
+        // Same gate set as resolveActiveProviderConfig — the agentic path never
+        // reaches a provider when AI is off / no consent / no key.
+        let (store, keychain) = Self.makeTestStore()
+        await #expect(throws: AIError.featureDisabled) {
+            _ = try await Self.makeService(store: store, keychain: keychain, aiEnabled: false)
+                .resolveToolProvider()
+        }
+        await #expect(throws: AIError.consentRequired) {
+            _ = try await Self.makeService(store: store, keychain: keychain, hasConsent: false)
+                .resolveToolProvider()
+        }
+        // Active profile but no stored key → apiKeyMissing.
+        let profile = Self.makeOpenAIProfile()
+        await store.upsert(profile)
+        await store.setActiveProfileID(profile.id)
+        await #expect(throws: AIError.apiKeyMissing) {
+            _ = try await Self.makeService(store: store, keychain: keychain).resolveToolProvider()
+        }
+    }
+
+    @Test func sendToolTurn_forwardsThroughThePinnedConfigWhenGatesPass() async throws {
+        let (store, keychain) = Self.makeTestStore()
+        let profile = Self.makeOpenAIProfile()
+        try keychain.saveAPIKey("sk-openai-active", forProfile: profile.id)
+        await store.upsert(profile)
+        await store.setActiveProfileID(profile.id)
+
+        let service = Self.makeService(store: store, keychain: keychain, provider: ToolCapableStub())
+        let (config, _) = try await service.resolveToolProvider()
+        let turn = try await service.sendToolTurn(Self.toolRequest(), using: config)
+        #expect(turn == .text("tool answer"))
+    }
+
+    @Test func sendToolTurn_reChecksTheLiveFlagEachTurn() async throws {
+        // Gate-4 Medium: a flag flip / consent revoke MID-loop must fail the next
+        // tool turn closed, even though the config was already resolved.
+        let (store, keychain) = Self.makeTestStore()
+        let profile = Self.makeOpenAIProfile()
+        try keychain.saveAPIKey("sk-openai-active", forProfile: profile.id)
+        await store.upsert(profile)
+        await store.setActiveProfileID(profile.id)
+
+        let (service, flags) = Self.makeServiceHoldingFlags(
+            store: store, keychain: keychain, provider: ToolCapableStub())
+        let (config, _) = try await service.resolveToolProvider()
+
+        flags.setOverride(false, for: .aiAssistant)   // AI disabled mid-loop
+        await #expect(throws: AIError.featureDisabled) {
+            _ = try await service.sendToolTurn(Self.toolRequest(), using: config)
+        }
+    }
+
     // MARK: - resolveProviderConfig(profileID:modelOverride:)
 
     @Test func resolveProviderConfig_resolvesANamedNonActiveProfile() async throws {


### PR DESCRIPTION
## Summary

The `AIService` seam the agentic chat loop resolves through (first slice of WI-8b — the final WI's adapters + VM branch + device verification follow):

- **`resolveToolProvider()`** resolves the active provider config **once** (same flag + consent + active-profile + key gates as `resolveActiveProviderConfig`) and reports whether the built provider `supportsToolUse`. The driver pins this config for the whole loop — no provider/model/key drift mid-operation (Gate-2 Medium).
- **`sendToolTurn(_:using:)`** sends one tool turn through the **pinned config** while **re-checking the live `aiAssistant` flag + consent each turn** — a mid-loop flag flip / consent revoke fails the next turn closed (Gate-4 Medium).

Part of feature #1482.

## Codex Audit

2 rounds, `ship-as-is`, zero open Critical/High/Medium:
- **r1 Medium** — a raw-provider return would have let a long loop bypass the **live** gates after the initial resolve; reshaped to a pinned `ResolvedAIProviderConfig` + the gate-rechecking `sendToolTurn` seam.
- **r1 Low ×2** — all three resolve gates now covered (`featureDisabled`/`consentRequired`/`apiKeyMissing`) + the config pinning proven.
- **r2** — no findings, all RESOLVED.

Audit log: `.claude/codex-audits/feat-feature-91-wi-8b-resolve-tool-provider-audit.md`

## Validation

- [x] `scripts/run-tests.sh vreaderTests/AIServiceResolvedConfigTests` → `SUCCEEDED` (6 WI-8 tests)
- [x] TDD: RED → GREEN → 2 audit rounds
- [x] Version bumped: 3.51.15 → 3.51.16 (foundational → patch)

## Verification tier

Foundational — no VM branch, flag default OFF. The seam is unit-tested via the provider-factory injection. End-to-end is at the completing slice (Gate-5, device).

## Type of Change

- [x] New feature work item (Part of feature #1482)