### PR TITLE
feat(#91 WI-8b/2): BookContentProvider production path (extractor + adapter)

### DIFF
--- a/.claude/codex-audits/feat-feature-91-wi-8b-book-content-adapter-audit.md
+++ b/.claude/codex-audits/feat-feature-91-wi-8b-book-content-adapter-audit.md
@@ -1,0 +1,68 @@
+---
+branch: feat/feature-91-wi-8b-book-content-adapter
+threadId: 019e92c8-b107-7221-87ce-6bf43575c6dc
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-06-04
+---
+
+# Codex Audit — Feature #91 WI-8b (slice 2: BookContentProvider production path)
+
+Gate-4 implementation audit (rule 47). Independent Codex runner via
+`scripts/run-codex.sh -e high` (author/auditor separation, rule 48; rule-53
+stdin-isolated watchdog).
+
+## Scope
+
+WI-8b slice 2 — the production `BookContentProvider` the get_book_content tool
+(WI-6c) depends on:
+
+- `vreader/Services/AI/Tools/ClosedBookTextExtractor.swift` (new) — off-actor
+  file→text per format (EPUB via EPUBParser spine + stripHTML; TXT/MD via the
+  canonical decoder; PDF via PDFKit).
+- `vreader/Services/AI/Tools/BookContentProviderAdapter.swift` (new) — title
+  resolution via `LibraryPersisting` (notFound/found/ambiguous-with-author) +
+  extraction; `BookContentInfo.format` derived from the key.
+- `vreader/Models/ImportedBookFileURL.swift` (new) — the single source of truth
+  for the imported-book sandbox URL; `LibraryBookItem.resolvedFileURL` delegates.
+- Tests: `ClosedBookTextExtractorTests` + `BookContentProviderAdapterTests`.
+
+## Round 1 — findings (threadId 019e92c8-b107-7221-87ce-6bf43575c6dc)
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| ClosedBookTextExtractor.swift `extractPlainText` | **Medium** | A partial decoder (detect-once + UTF-8) — NOT the reader's `TXTService.decodeForDisplayAndSearch` path (UTF-16 BOM / GBK/Big5/Shift_JIS/…) — so it could misdecode non-UTF-8 TXT/MD books the reader opens fine. | **Fixed.** Now decodes via `TXTService.decodeForDisplayAndSearch(data)` (UTF-8 last-resort fallback) — one decoder shared with the reader/search. |
+| ClosedBookTextExtractorTests.swift | **Medium** | The TXT test was UTF-8-only. | **Fixed.** `decodesNonUTF8` writes a UTF-16(BOM) temp file and asserts the decode (exact-string in round 2). |
+| ClosedBookTextExtractor.swift `importedFileURL` | Low | A 4th copy of the ImportedBooks path convention (drift risk → false file-not-found). | **Fixed.** Extracted `ImportedBookFileURL`; `LibraryBookItem.resolvedFileURL` + the adapter both delegate; the duplicate removed. |
+| BookContentProviderAdapterTests.swift | Low | Matrix incomplete (no fetch-throws, no format-drift, no non-local). | **Fixed.** `fetchFailureNotFound`, `formatFromKeyAndLocalityPropagation` (drifted `format` column → format from the key; `.remoteOnly` → `isReadable == false`). |
+
+## Round 2 — verification (threadId 019e92de-c56b-7010-8eaf-ce5815d4372a)
+
+Items 1, 3, 4 **RESOLVED**. Item 2 partial (the UTF-16 test used `contains`). One
+**new Medium**: `extractText` resolved the PRIMARY extension only (`.txt`/`.md`),
+but restore/lazy-download can materialize TXT/MD under their ORIGINAL extension
+(`.text`/`.markdown`) → file-not-found for a readable book. **Both fixed.**
+`ImportedBookFileURL.resolveExisting` tries each `BookFormat.fileExtensions`
+candidate and returns the one that exists on disk (primary fallback); `extractText`
+uses it. The synchronous no-I/O `resolve()` (the `resolvedFileURL` contract) is
+unchanged. The UTF-16 test now asserts the exact trimmed string + no `\u{FFFD}`.
+Test `resolveExistingTriesCandidateExtensions` writes a real `.text` file and
+asserts the `.text` path is returned.
+
+## Round 3 — verification (threadId 019e92f2-db1c-7081-aaa4-ee48ffd2d2cb)
+
+**RESOLVED.** No new issues.
+
+## Verdict
+
+**ship-as-is.** Zero open Critical/High/Medium after round 3. Test gate green:
+`ClosedBookTextExtractorTests` (TXT/MD UTF-8 + non-UTF-8 exact decode, unsupported/
+missing-file throws, the shared sandbox-URL convention + the `.text` original-
+extension resolution) + `BookContentProviderAdapterTests` (found/notFound/blank/
+ambiguous-with-author, fetch-failure → notFound, key-derived format under a drifted
+column, `.remoteOnly` isReadable propagation, malformed-key throw). EPUB/PDF
+extraction is device-verified at the feature's final acceptance pass.
+
+The remaining WI-8b work (the `LibrarySearchBackend` adapter + the registry builder
++ the `AIChatViewModel.sendMessage` branch + citation suppression + Gate-5 device
+verification) completes Feature #91 to `DONE`/`VERIFIED`.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 872
-        MARKETING_VERSION: 3.51.16
+        CURRENT_PROJECT_VERSION: 873
+        MARKETING_VERSION: 3.51.17
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		0AF2C077EAD177EE3AF2985A /* TXTService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1DBBFF061B96088FFE84194 /* TXTService.swift */; };
 		0B26F0A7F6A79455D49FF472 /* PDFReaderContainerView+Highlights.swift in Sources */ = {isa = PBXBuildFile; fileRef = B94F43CFA9AC0D681C75333D /* PDFReaderContainerView+Highlights.swift */; };
 		0B2C125F4B243C2D1D0874B0 /* ReadiumBilingualEvalAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6216F1011252A14AA8AB31CF /* ReadiumBilingualEvalAdapterTests.swift */; };
+		0B4A16A0E063F80E0A445F5A /* BookContentProviderAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A868AC7292423FB54ACA099D /* BookContentProviderAdapterTests.swift */; };
 		0B598B705531647D3BC5BC60 /* DebugCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9279142901B3666BD14E0B20 /* DebugCommandTests.swift */; };
 		0B755264A7061A0DDB5C194B /* TextHighlightHitResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C8F91E6BD028B12064B14B5 /* TextHighlightHitResolver.swift */; };
 		0BA51C02457E94D60CF41180 /* TXTReaderContainerView+Bilingual.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A8B4C14F5DEEB43C139E7A /* TXTReaderContainerView+Bilingual.swift */; };
@@ -629,6 +630,7 @@
 		6385D414214525E5CF2C4C8E /* HighlightPopoverViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7747D7A10C50F43520FB5FF0 /* HighlightPopoverViewModel.swift */; };
 		646C642DA4E4DCFF2AFEB68A /* search_no_results.html in Resources */ = {isa = PBXBuildFile; fileRef = 84BAC2CBFB7F533857E6A65B /* search_no_results.html */; };
 		64709D1B5C006D3299C8ABAF /* AutoPageTurner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5401E10DDA195966ABD13F70 /* AutoPageTurner.swift */; };
+		647F5472368EC4DBFB0301D5 /* ClosedBookTextExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20767F0423EEB85DD502B1C /* ClosedBookTextExtractor.swift */; };
 		64BF0E0C54C919613EFEECD9 /* search_results.html in Resources */ = {isa = PBXBuildFile; fileRef = E3D9BD563DBFE23CE71083C5 /* search_results.html */; };
 		64F77F9B1EB4BFF2CD6CE172 /* FoliateSpikeThemeCSSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9258C4CB71408907084E12F /* FoliateSpikeThemeCSSTests.swift */; };
 		6544A2C30555EACAB1AF79D8 /* SettleStubProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39AAC3C08F3B56CA6863FEC3 /* SettleStubProbe.swift */; };
@@ -908,6 +910,7 @@
 		909ADB564394665014A94D74 /* RegexRuleEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66BBCB51EBC23CCC7632C74 /* RegexRuleEvaluator.swift */; };
 		90BEC64CA9EC46D50BFD938F /* miniz.c in Sources */ = {isa = PBXBuildFile; fileRef = DBCDEF7FE521C85F02FCB750 /* miniz.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		90D2C41C30E622E119877967 /* BackupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5350DA755A0BB669AE8D3FBD /* BackupViewModelTests.swift */; };
+		914EE56DB222B4725BDF8B81 /* ClosedBookTextExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 628F93F39DE835610F930D5E /* ClosedBookTextExtractorTests.swift */; };
 		915C38C106026EB4386107C5 /* FoliateChapterTextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF17767136D4087D5F38F901 /* FoliateChapterTextProvider.swift */; };
 		916CF15735E1F170E2CE4695 /* HTTPTTSConfigStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CD66C1E52331AC245386C9 /* HTTPTTSConfigStore.swift */; };
 		91B1FD3EEE9D392F1274E2C9 /* EPUBPageAxisProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11A6F4B5DD22F0A6EE84B48 /* EPUBPageAxisProbeTests.swift */; };
@@ -1022,6 +1025,7 @@
 		A4A49ED0A6DF2433D8292FF3 /* BilingualOffsetRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B6FF7CD976BEA8E7BBA282 /* BilingualOffsetRouter.swift */; };
 		A4B263A7DDAB48522AB48E0D /* ReadiumEPUBReaderViewModel+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D40C8AC1C6099E72E545AD8 /* ReadiumEPUBReaderViewModel+Navigation.swift */; };
 		A4BA4366BC946C80885678AE /* Feature54ReadingModeRemovalVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC502E886EBA816F1DA34471 /* Feature54ReadingModeRemovalVerificationTests.swift */; };
+		A4DFED6054A6819B3DAC2ED4 /* BookContentProviderAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31AE45779D6F79B237D8BFE /* BookContentProviderAdapter.swift */; };
 		A50497A14DDBBD85C999A424 /* AnnotationStreamItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC8C2B2EE71211499AA0EE4 /* AnnotationStreamItem.swift */; };
 		A51705EB5AB296DECFDADEB4 /* Bookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB82BDFCDB76725A5586D5E0 /* Bookmark.swift */; };
 		A518BAD356A09888EF4C3937 /* MDReaderViewModelChapterStartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D271B91E1F8A6374667C5E /* MDReaderViewModelChapterStartTests.swift */; };
@@ -1230,6 +1234,7 @@
 		C72258E7A1E6477E89E27D6E /* ImportError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982822FD76DDFB1EEE150FF0 /* ImportError.swift */; };
 		C731DA5F2D3885D918F1640A /* EncodingDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43A801A0876E2437CE63808 /* EncodingDetector.swift */; };
 		C7963EB4DD0ACFD3A87D97CC /* AnnotationExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB17C932D5188B36F01F024A /* AnnotationExporter.swift */; };
+		C7BE80C325389ABB41ED4A72 /* ImportedBookFileURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B38D157861E7801DB93AD9C5 /* ImportedBookFileURL.swift */; };
 		C7CAC48B79D83659A7D10FB2 /* GetBookContentTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18EF8C2454CBCC951F3CA25E /* GetBookContentTool.swift */; };
 		C819E99DEF2A16B032B767B1 /* WebDAVServerProfileEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800ED346D9C0E17741704040 /* WebDAVServerProfileEditSheet.swift */; };
 		C81A31B52218576A75210100 /* TXTFileLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F7059169A9ADC70EE01420E /* TXTFileLoaderTests.swift */; };
@@ -2194,6 +2199,7 @@
 		62569DC663E2BDD2DC0155C3 /* SearchHighlightDismissTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHighlightDismissTests.swift; sourceTree = "<group>"; };
 		6263E25CBF3A833B2BAC789D /* PersistenceActor+AnnotationBus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+AnnotationBus.swift"; sourceTree = "<group>"; };
 		627E42F1B1E8A59081CC6628 /* BookFormatAZW3Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookFormatAZW3Tests.swift; sourceTree = "<group>"; };
+		628F93F39DE835610F930D5E /* ClosedBookTextExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedBookTextExtractorTests.swift; sourceTree = "<group>"; };
 		629CCC658A5843CA9CB3915C /* sha1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sha1.c; sourceTree = "<group>"; };
 		62B304D30B717A1AB66C2A5B /* Feature64PDFMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature64PDFMigrationTests.swift; sourceTree = "<group>"; };
 		62D7DA128D4B2AC1F362D571 /* LaunchHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchHelper.swift; sourceTree = "<group>"; };
@@ -2566,6 +2572,7 @@
 		A1A046B497B731C451670CED /* BookmarkPersisting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkPersisting.swift; sourceTree = "<group>"; };
 		A1E3F274866072EA56D8C0B4 /* FoliateStyleMapperChapterStartTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateStyleMapperChapterStartTests.swift; sourceTree = "<group>"; };
 		A1E577DAF65D34544D713137 /* TombstoneStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TombstoneStoreTests.swift; sourceTree = "<group>"; };
+		A20767F0423EEB85DD502B1C /* ClosedBookTextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedBookTextExtractor.swift; sourceTree = "<group>"; };
 		A26827F9E5CF8521F1152661 /* SelectionPopoverActionRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionPopoverActionRow.swift; sourceTree = "<group>"; };
 		A2D06EE3505728373BD89B04 /* StatsCustomRangePicker+Subviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsCustomRangePicker+Subviews.swift"; sourceTree = "<group>"; };
 		A36D2CA026CE5A5A63DFFE7F /* ReadiumDebugProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumDebugProbe.swift; sourceTree = "<group>"; };
@@ -2593,6 +2600,7 @@
 		A7EBC969B5DD8804D6AFF3DD /* structure.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = structure.c; sourceTree = "<group>"; };
 		A84982F334E70A0D71A44893 /* ReaderContainerViewEngineDispatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderContainerViewEngineDispatchTests.swift; sourceTree = "<group>"; };
 		A84BF17CCCD4B376BDDF8CD1 /* utf8_bom.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = utf8_bom.txt; sourceTree = "<group>"; };
+		A868AC7292423FB54ACA099D /* BookContentProviderAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookContentProviderAdapterTests.swift; sourceTree = "<group>"; };
 		A890F7C98CE159058714EE4D /* ChapterBounds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterBounds.swift; sourceTree = "<group>"; };
 		A8B682E216B5A24055B696F0 /* SwiftDataSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataSessionStore.swift; sourceTree = "<group>"; };
 		A8C28D0E24662BFD87AEBC16 /* EPUBSwipeGestureClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBSwipeGestureClassifierTests.swift; sourceTree = "<group>"; };
@@ -2663,6 +2671,7 @@
 		B2DB7F421D9D2E7492E12F89 /* ZIPReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZIPReader.swift; sourceTree = "<group>"; };
 		B311EFBC5A90B5A6B167389E /* AgenticChatDriver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgenticChatDriver.swift; sourceTree = "<group>"; };
 		B34C87EDF46A4EFC99012268 /* AnnotationsPanelPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationsPanelPlaceholderTests.swift; sourceTree = "<group>"; };
+		B38D157861E7801DB93AD9C5 /* ImportedBookFileURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportedBookFileURL.swift; sourceTree = "<group>"; };
 		B39618F097181A76AAF862F0 /* LazyDownloadCoordinatorEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyDownloadCoordinatorEnvironment.swift; sourceTree = "<group>"; };
 		B3987200016FB6CA3D063E44 /* LocatorCanonicalHashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorCanonicalHashTests.swift; sourceTree = "<group>"; };
 		B3C5FD151F344952BEB2BE85 /* ReadingStatsCustomRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingStatsCustomRangeTests.swift; sourceTree = "<group>"; };
@@ -2855,6 +2864,7 @@
 		D2EA03BEFDBB65F5D7533EDE /* SchemaV1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV1Tests.swift; sourceTree = "<group>"; };
 		D31265D2F8B445FADB98DDFC /* WebDAVProfileListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProfileListViewModelTests.swift; sourceTree = "<group>"; };
 		D313521AE0A256629A2B0244 /* PersistenceActorStatsReadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceActorStatsReadTests.swift; sourceTree = "<group>"; };
+		D31AE45779D6F79B237D8BFE /* BookContentProviderAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookContentProviderAdapter.swift; sourceTree = "<group>"; };
 		D35CDC4131829818B115292B /* BilingualSetupSheet+Sections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BilingualSetupSheet+Sections.swift"; sourceTree = "<group>"; };
 		D363190FCDF47ED48A1D7BC1 /* ReaderLifecycleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderLifecycleHelper.swift; sourceTree = "<group>"; };
 		D36D5CFF47A223349C004E39 /* VReaderAnnotationParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VReaderAnnotationParserTests.swift; sourceTree = "<group>"; };
@@ -3261,6 +3271,8 @@
 		17F5D2D6157B0982ED966239 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				A868AC7292423FB54ACA099D /* BookContentProviderAdapterTests.swift */,
+				628F93F39DE835610F930D5E /* ClosedBookTextExtractorTests.swift */,
 				0CE295C77B7BFB9AD3B6A85F /* GetBookContentGateTests.swift */,
 				AB53B0494E5197769A64CCF1 /* GetBookContentToolTests.swift */,
 				33AE4518BC7EBC8968B54CFF /* LibraryBookSearchGateTests.swift */,
@@ -4236,6 +4248,8 @@
 		8398255B9EC6E36B2D2EE0AF /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				D31AE45779D6F79B237D8BFE /* BookContentProviderAdapter.swift */,
+				A20767F0423EEB85DD502B1C /* ClosedBookTextExtractor.swift */,
 				220C9C125ECE9753714E40D1 /* GetBookContentGate.swift */,
 				18EF8C2454CBCC951F3CA25E /* GetBookContentTool.swift */,
 				1BD2081B22B559BD215B7C21 /* LibraryBookSearchGate.swift */,
@@ -5150,6 +5164,7 @@
 				9B75BA41298C5306AC9AD036 /* GenerativeCoverStyle.swift */,
 				C775619D3C0E4641505CE2B8 /* Highlight.swift */,
 				471A2FD68C127CC3FC2C239A /* HighlightPopoverAction.swift */,
+				B38D157861E7801DB93AD9C5 /* ImportedBookFileURL.swift */,
 				37DF69361FD0FBED7294C43E /* ImportProvenance.swift */,
 				22F84672A6E2EDD6E037AFD8 /* ImportSource.swift */,
 				746091C5D6814B751FAA32B0 /* LegadoBookSourceDTO.swift */,
@@ -6001,6 +6016,7 @@
 				096B20388931B21DAA4DC091 /* BlobPathTests.swift in Sources */,
 				24537AC8998113A9C739DBD6 /* BookCardViewVisualTests.swift in Sources */,
 				C205A1413A59C630A10ECEB7 /* BookContentCacheTests.swift in Sources */,
+				0B4A16A0E063F80E0A445F5A /* BookContentProviderAdapterTests.swift in Sources */,
 				A09FA8DF38589B83DA06D15C /* BookDetailsActionsTests.swift in Sources */,
 				41823752F96DAD8D53DEEF0F /* BookDetailsRouteTests.swift in Sources */,
 				BCD2C70D406E07C400C83333 /* BookDetailsViewModelTests.swift in Sources */,
@@ -6044,6 +6060,7 @@
 				4D763B3132D474C73F9F66F8 /* ChatCitationFactoryTests.swift in Sources */,
 				D5BFB1EBD8FCFB12E438DCE9 /* ChatContextFoundationTests.swift in Sources */,
 				E4F03F269AFA7E2CF65B2E6A /* ChatScopeSelectionTests.swift in Sources */,
+				914EE56DB222B4725BDF8B81 /* ClosedBookTextExtractorTests.swift in Sources */,
 				2DA32CDB11AE06DBCF3E97DE /* CloudKitRecordMapperTests.swift in Sources */,
 				E400E164FA809CC3AB0AC796 /* CollectionPersistenceTests.swift in Sources */,
 				3937725DB44FBDE74644583E /* CollectionTestHelper.swift in Sources */,
@@ -6657,6 +6674,7 @@
 				12EE1BD6335013980EFA3EC0 /* BookCardView.swift in Sources */,
 				AF32B348898F4110FED715F5 /* BookCollection.swift in Sources */,
 				BB796644EE14228057D77738 /* BookContentCache.swift in Sources */,
+				A4DFED6054A6819B3DAC2ED4 /* BookContentProviderAdapter.swift in Sources */,
 				2243225993799BBBCC9BE25B /* BookCoverArtView.swift in Sources */,
 				16DBB441C73ADEB1B6EA98B4 /* BookDetailsActionRow.swift in Sources */,
 				C3BE566C5E906C665C95F68C /* BookDetailsMetadataRow.swift in Sources */,
@@ -6723,6 +6741,7 @@
 				8FD1FAC0AE8611D29DEDC87D /* ChatScopeMenu.swift in Sources */,
 				5BDAA75F4C3A30CBCC893190 /* ChatSourceSelection.swift in Sources */,
 				25C35999B6BAA3D90435C66A /* ChatSourcesMenu.swift in Sources */,
+				647F5472368EC4DBFB0301D5 /* ClosedBookTextExtractor.swift in Sources */,
 				CD3F1CD3B0FD3B013D82E26D /* CloudKitClient.swift in Sources */,
 				479BBE7406AFCACEE1CA5EE3 /* CloudKitRecordMapper.swift in Sources */,
 				70DA481383CC5F3047D96E83 /* CollectionSidebar.swift in Sources */,
@@ -6898,6 +6917,7 @@
 				36B37715BB3494F635566157 /* ImportJobQueue.swift in Sources */,
 				98E08494B40D86923451655E /* ImportProvenance.swift in Sources */,
 				4C47F172233199432FC289E3 /* ImportSource.swift in Sources */,
+				C7BE80C325389ABB41ED4A72 /* ImportedBookFileURL.swift in Sources */,
 				EC94A16FA04EA4F5BBE10344 /* JSONExportFormatter.swift in Sources */,
 				408FD10C4D83D162C1A9D69C /* KeychainService+ProviderProfile.swift in Sources */,
 				6D073A0311A72B82FEF65852 /* KeychainService.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7521,7 +7521,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 872;
+				CURRENT_PROJECT_VERSION = 873;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7529,7 +7529,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.16;
+				MARKETING_VERSION = 3.51.17;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7675,7 +7675,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 872;
+				CURRENT_PROJECT_VERSION = 873;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7683,7 +7683,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.16;
+				MARKETING_VERSION = 3.51.17;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Models/ImportedBookFileURL.swift
+++ b/vreader/Models/ImportedBookFileURL.swift
@@ -1,0 +1,45 @@
+// Purpose: The SINGLE source of truth for an imported book's on-device sandbox
+// file URL — Application Support/ImportedBooks/<fingerprintKey with ':' → '_'>.<ext>.
+// Both `LibraryBookItem.resolvedFileURL` and the agentic closed-book text
+// extractor (Feature #91) resolve through here, so the two can never drift to
+// different paths (a drift = a "file not found" for a book that is really present).
+//
+// @coordinates-with: LibraryBookItem.swift (resolvedFileURL), BookImporter (the
+//   import-time write convention), ClosedBookTextExtractor.swift / Feature #91.
+
+import Foundation
+
+enum ImportedBookFileURL {
+    /// The sandbox URL for an imported book (PRIMARY extension), from its
+    /// fingerprint key + format. Synchronous, no I/O — the historical
+    /// `resolvedFileURL` contract.
+    static func resolve(fingerprintKey: String, format: String) -> URL {
+        let safeName = fingerprintKey.replacingOccurrences(of: ":", with: "_")
+        let ext = BookFormat(rawValue: format.lowercased())?.fileExtensions.first ?? format.lowercased()
+        return importedBooksDirectory().appendingPathComponent(safeName).appendingPathExtension(ext)
+    }
+
+    /// Resolve to the file that ACTUALLY exists on disk, trying each of the
+    /// format's candidate extensions (e.g. `txt → ["txt","text"]`,
+    /// `md → ["md","markdown"]`). Restore / lazy-download can materialize a book
+    /// with its ORIGINAL extension (`.text` / `.markdown`), not the primary, so a
+    /// primary-only path would file-not-found a readable book (Feature #91 Gate-4).
+    /// Falls back to the primary path when none exists.
+    static func resolveExisting(fingerprintKey: String, format: String) -> URL {
+        let safeName = fingerprintKey.replacingOccurrences(of: ":", with: "_")
+        let dir = importedBooksDirectory()
+        let candidates = BookFormat(rawValue: format.lowercased())?.fileExtensions
+            ?? [format.lowercased()]
+        for ext in candidates {
+            let url = dir.appendingPathComponent(safeName).appendingPathExtension(ext)
+            if FileManager.default.fileExists(atPath: url.path) { return url }
+        }
+        return resolve(fingerprintKey: fingerprintKey, format: format)
+    }
+
+    private static func importedBooksDirectory() -> URL {
+        FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("ImportedBooks", isDirectory: true)
+    }
+}

--- a/vreader/Models/LibraryBookItem.swift
+++ b/vreader/Models/LibraryBookItem.swift
@@ -169,15 +169,7 @@ struct LibraryBookItem: Sendable, Identifiable, Equatable, Hashable {
     /// Uses the same convention as BookImporter: fingerprintKey with colons replaced
     /// by underscores, stored under Application Support/ImportedBooks/.
     var resolvedFileURL: URL {
-        let booksDir = FileManager.default
-            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("ImportedBooks", isDirectory: true)
-        let safeName = fingerprintKey.replacingOccurrences(of: ":", with: "_")
-        let bookFormat = BookFormat(rawValue: format.lowercased())
-        let ext = bookFormat?.fileExtensions.first ?? format.lowercased()
-        return booksDir
-            .appendingPathComponent(safeName)
-            .appendingPathExtension(ext)
+        ImportedBookFileURL.resolve(fingerprintKey: fingerprintKey, format: format)
     }
 
     /// SF Symbol name for the book's format.

--- a/vreader/Services/AI/Tools/BookContentProviderAdapter.swift
+++ b/vreader/Services/AI/Tools/BookContentProviderAdapter.swift
@@ -1,0 +1,68 @@
+// Purpose: Feature #91 WI-8b — the production BookContentProvider the
+// get_book_content tool (WI-6c) depends on. Resolves a model-supplied TITLE to a
+// library book via `LibraryPersisting.fetchAllLibraryBooks()` (ambiguity-aware:
+// notFound / found / ambiguous-with-author), and extracts a resolved book's text
+// off-actor via `ClosedBookTextExtractor`. The locality + format SAFETY decisions
+// stay in the pure `GetBookContentGate` (the tool calls it on this adapter's
+// `BookContentInfo`); this adapter is pure resolution + extraction glue.
+//
+// `BookContentInfo.format` is DERIVED from the fingerprint key (the WI-6c
+// drift-proof contract), so this adapter only supplies fingerprintKey/title/
+// isReadable — never a stale `book.format` column.
+//
+// @coordinates-with: GetBookContentGate.swift (BookContentProvider seam),
+//   GetBookContentTool.swift (consumer), ClosedBookTextExtractor.swift,
+//   LibraryPersisting.swift (fetchAllLibraryBooks), DocumentFingerprint.swift,
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-8)
+
+import Foundation
+
+struct BookContentProviderAdapter: BookContentProvider {
+
+    private let library: any LibraryPersisting
+    private let extractor: ClosedBookTextExtractor
+
+    init(library: any LibraryPersisting, extractor: ClosedBookTextExtractor = ClosedBookTextExtractor()) {
+        self.library = library
+        self.extractor = extractor
+    }
+
+    /// Resolve a book by case-insensitive exact title. 0 matches → notFound; 1 →
+    /// found; 2+ → ambiguous (with author so the model can disambiguate).
+    func findBook(title: String) async -> BookTitleResolution {
+        let query = title.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return .notFound }
+
+        let books = (try? await library.fetchAllLibraryBooks()) ?? []
+        let matches = books.filter {
+            $0.title.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == query
+        }
+        switch matches.count {
+        case 0:
+            return .notFound
+        case 1:
+            let book = matches[0]
+            return .found(BookContentInfo(
+                fingerprintKey: book.fingerprintKey,
+                title: book.title,
+                isReadable: book.isReadable))   // BookFileState == .local
+        default:
+            return .ambiguous(matches.map { BookContentMatch(title: $0.title, author: $0.author) })
+        }
+    }
+
+    /// Extract the book's text from its on-device file. The format is the CANONICAL
+    /// format parsed from the fingerprint key (never a stale column); a malformed
+    /// key throws (the tool turns that into an isError result).
+    func extractText(fingerprintKey: String) async throws -> String {
+        guard let fingerprint = DocumentFingerprint(canonicalKey: fingerprintKey) else {
+            throw AIError.providerError("Unreadable book metadata.")
+        }
+        let format = fingerprint.format.rawValue
+        // resolveExisting tries the format's candidate extensions (.txt/.text,
+        // .md/.markdown) so a restore/lazy-download book materialized under its
+        // ORIGINAL extension is still found (Gate-4 r2 Medium).
+        let url = ImportedBookFileURL.resolveExisting(fingerprintKey: fingerprintKey, format: format)
+        return try await extractor.extract(url: url, format: format)
+    }
+}

--- a/vreader/Services/AI/Tools/ClosedBookTextExtractor.swift
+++ b/vreader/Services/AI/Tools/ClosedBookTextExtractor.swift
@@ -1,0 +1,76 @@
+// Purpose: Feature #91 WI-8b — extract a CLOSED book's full plain text from its
+// on-device file, dispatching per format. This is the file-I/O half of the
+// get_book_content production path (the BookContentProvider adapter): EPUB via the
+// EPUBParser spine, TXT/MD via encoding-detected decode (matching the search/TTS
+// path), PDF via PDFKit. A `Sendable` value type with no stored state — safe to
+// call off the main actor.
+//
+// The supported set mirrors GetBookContentGate.supportedFormats; an unsupported
+// format (native azw3) throws rather than returning empty — the WI-6c gate already
+// rejects it before extractText is reached, so this throw is a defence-in-depth.
+//
+// @coordinates-with: BookContentProviderAdapter.swift (consumer), EPUBParser.swift
+//   + EPUBTextExtractor.stripHTML, TXTService (encoding detect), BookFormat.swift,
+//   LibraryBookItem.resolvedFileURL (the same sandbox-path convention),
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-8)
+
+import Foundation
+import PDFKit
+
+struct ClosedBookTextExtractor: Sendable {
+
+    /// Extract a book's full plain text from its on-device file URL. Throws for an
+    /// unreadable file or an unsupported format.
+    func extract(url: URL, format: String) async throws -> String {
+        switch format.lowercased() {
+        case "epub": return try await Self.extractEPUB(url: url)
+        case "txt", "md": return try Self.extractPlainText(url: url)
+        case "pdf": return try Self.extractPDF(url: url)
+        default:
+            throw AIError.providerError("Text extraction is not supported for \(format) books.")
+        }
+    }
+
+    // MARK: - Per-format
+
+    static func extractEPUB(url: URL) async throws -> String {
+        let parser = EPUBParser()
+        let metadata = try await parser.open(url: url)
+        var parts: [String] = []
+        for item in metadata.spineItems {
+            // Skip an inaccessible spine item — partial text beats none.
+            guard let xhtml = try? await parser.contentForSpineItem(href: item.href) else { continue }
+            let plain = EPUBTextExtractor.stripHTML(xhtml)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !plain.isEmpty { parts.append(plain) }
+        }
+        await parser.close()
+        return parts.joined(separator: "\n\n")
+    }
+
+    /// TXT/MD — decode through the SAME canonical decoder the reader + search use
+    /// (`TXTService.decodeForDisplayAndSearch`: UTF-16 BOM, NSString heuristics,
+    /// GBK/Big5/Shift_JIS/EUC-KR, …) so a closed-book read decodes exactly what the
+    /// reader opens (Gate-4 Medium — a partial copy mis-decoded non-UTF-8 books).
+    /// UTF-8 is the last-resort fallback if the canonical decoder returns nil.
+    static func extractPlainText(url: URL) throws -> String {
+        let data = try Data(contentsOf: url, options: .mappedIfSafe)
+        if let (decoded, _) = TXTService.decodeForDisplayAndSearch(data) {
+            return decoded
+        }
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    static func extractPDF(url: URL) throws -> String {
+        guard let doc = PDFDocument(url: url) else {
+            throw AIError.providerError("Couldn't open the PDF file.")
+        }
+        var pages: [String] = []
+        for index in 0..<doc.pageCount {
+            if let page = doc.page(at: index), let text = page.string {
+                pages.append(text)
+            }
+        }
+        return pages.joined(separator: "\n\n")
+    }
+}

--- a/vreaderTests/Services/AI/Tools/BookContentProviderAdapterTests.swift
+++ b/vreaderTests/Services/AI/Tools/BookContentProviderAdapterTests.swift
@@ -1,0 +1,117 @@
+// Purpose: Feature #91 WI-8b — pin the production BookContentProvider's title
+// resolution (the GetBookContentTool seam): case-insensitive exact match →
+// notFound / found / ambiguous-with-author, the canonical-format-derived
+// BookContentInfo, and the malformed-key throw in extractText. The library is a
+// stub; the file extraction is covered by ClosedBookTextExtractorTests / device.
+//
+// @coordinates-with: BookContentProviderAdapter.swift, GetBookContentGate.swift,
+//   LibraryPersisting.swift, dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-8)
+
+import Testing
+import Foundation
+@testable import vreader
+
+private enum StubLibraryError: Error { case boom }
+
+private struct StubLibrary: LibraryPersisting {
+    let books: [LibraryBookItem]
+    let fetchThrows: Bool
+    init(books: [LibraryBookItem], fetchThrows: Bool = false) {
+        self.books = books
+        self.fetchThrows = fetchThrows
+    }
+    func fetchAllLibraryBooks() async throws -> [LibraryBookItem] {
+        if fetchThrows { throw StubLibraryError.boom }
+        return books
+    }
+    func deleteBook(fingerprintKey: String) async throws {}
+}
+
+@Suite("Feature #91 WI-8b — BookContentProviderAdapter")
+struct BookContentProviderAdapterTests {
+
+    private static func key(_ c: Character) -> String {
+        "epub:\(String(repeating: c, count: 64)):4096"
+    }
+
+    private static func book(_ title: String, key: String, author: String? = nil) -> LibraryBookItem {
+        .stub(fingerprintKey: key, title: title, author: author, format: "epub")
+    }
+
+    @Test("an exact (case-insensitive) title resolves to that book, format derived from the key")
+    func findsByTitle() async {
+        let adapter = BookContentProviderAdapter(library: StubLibrary(books: [
+            Self.book("Moby Dick", key: Self.key("a")),
+            Self.book("Pride and Prejudice", key: Self.key("b")),
+        ]))
+        guard case .found(let info) = await adapter.findBook(title: "moby dick") else {
+            Issue.record("expected found"); return
+        }
+        #expect(info.fingerprintKey == Self.key("a"))
+        #expect(info.title == "Moby Dick")
+        #expect(info.isReadable == true)   // .stub defaults fileState .local
+        #expect(info.format == "epub")     // derived from the fingerprint key, not a column
+    }
+
+    @Test("no matching (or blank) title resolves to notFound")
+    func notFound() async {
+        let adapter = BookContentProviderAdapter(
+            library: StubLibrary(books: [Self.book("X", key: Self.key("a"))]))
+        #expect(await adapter.findBook(title: "ghost") == .notFound)
+        #expect(await adapter.findBook(title: "   ") == .notFound)
+    }
+
+    @Test("two books sharing a title resolve to ambiguous, carrying authors to disambiguate")
+    func ambiguous() async {
+        let adapter = BookContentProviderAdapter(library: StubLibrary(books: [
+            Self.book("Dune", key: Self.key("a"), author: "Frank Herbert"),
+            Self.book("Dune", key: Self.key("b"), author: "Someone Else"),
+        ]))
+        guard case .ambiguous(let candidates) = await adapter.findBook(title: "Dune") else {
+            Issue.record("expected ambiguous"); return
+        }
+        #expect(candidates.count == 2)
+        #expect(candidates.contains { $0.author == "Frank Herbert" })
+    }
+
+    @Test("a library-fetch failure collapses to notFound, never a crash")
+    func fetchFailureNotFound() async {
+        let adapter = BookContentProviderAdapter(
+            library: StubLibrary(books: [Self.book("Real", key: Self.key("a"))], fetchThrows: true))
+        #expect(await adapter.findBook(title: "Real") == .notFound)
+    }
+
+    @Test("format is derived from the KEY even when the book.format column drifts; isReadable propagates")
+    func formatFromKeyAndLocalityPropagation() async {
+        // A row whose canonical key says TXT but whose `format` column lies "epub",
+        // and which is remote-only (not readable).
+        let txtKey = "txt:\(String(repeating: "c", count: 64)):4096"
+        let drifted = LibraryBookItem.stub(
+            fingerprintKey: txtKey, title: "Drift", format: "epub")   // column LIES
+        let remote = LibraryBookItem(
+            fingerprintKey: "pdf:\(String(repeating: "d", count: 64)):4096", title: "Remote",
+            author: nil, coverImagePath: nil, format: "pdf", fileByteCount: 1, addedAt: Date(),
+            lastOpenedAt: nil, isFavorite: false, totalReadingSeconds: 0, averagePagesPerHour: nil,
+            averageWordsPerMinute: nil, fileState: .remoteOnly)
+        let adapter = BookContentProviderAdapter(library: StubLibrary(books: [drifted, remote]))
+
+        guard case .found(let txt) = await adapter.findBook(title: "Drift") else {
+            Issue.record("expected found"); return
+        }
+        #expect(txt.format == "txt")        // derived from the key, NOT the "epub" column
+        #expect(txt.isReadable == true)
+
+        guard case .found(let rem) = await adapter.findBook(title: "Remote") else {
+            Issue.record("expected found"); return
+        }
+        #expect(rem.isReadable == false)    // fileState .remoteOnly propagated
+    }
+
+    @Test("extractText rejects a malformed fingerprint key, never reaching the file")
+    func extractTextMalformedKey() async {
+        let adapter = BookContentProviderAdapter(library: StubLibrary(books: []))
+        await #expect(throws: (any Error).self) {
+            _ = try await adapter.extractText(fingerprintKey: "epub:not-a-sha:1")
+        }
+    }
+}

--- a/vreaderTests/Services/AI/Tools/ClosedBookTextExtractorTests.swift
+++ b/vreaderTests/Services/AI/Tools/ClosedBookTextExtractorTests.swift
@@ -1,0 +1,94 @@
+// Purpose: Feature #91 WI-8b — pin the off-actor closed-book text extractor's
+// testable surface: TXT/MD extraction from a real on-device file (encoding-
+// detected), the unsupported-format throw, and the imported-file sandbox-URL
+// convention. EPUB/PDF extraction is file-fixture/device-verified (no synthetic
+// fixture cheaply available in a CI unit test).
+//
+// @coordinates-with: ClosedBookTextExtractor.swift,
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-8)
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("Feature #91 WI-8b — ClosedBookTextExtractor")
+struct ClosedBookTextExtractorTests {
+
+    @Test("extracts TXT/MD text from an on-device file (encoding-detected, CJK-safe)")
+    func extractsPlainText() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let txtURL = dir.appendingPathComponent("book.txt")
+        try "Hello, reader. 你好世界。".write(to: txtURL, atomically: true, encoding: .utf8)
+        let extractor = ClosedBookTextExtractor()
+        let txt = try await extractor.extract(url: txtURL, format: "txt")
+        #expect(txt.contains("Hello, reader."))
+        #expect(txt.contains("你好世界"))
+
+        let mdURL = dir.appendingPathComponent("book.md")
+        try "# Title\n\nthe body text".write(to: mdURL, atomically: true, encoding: .utf8)
+        #expect(try await extractor.extract(url: mdURL, format: "md").contains("the body text"))
+    }
+
+    @Test("decodes a NON-UTF-8 file via the canonical TXTService decoder (UTF-16 BOM)")
+    func decodesNonUTF8() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // A UTF-16 (BOM) file — the old detect-once + UTF-8-fallback path would
+        // mis-decode this; the canonical decoder handles it.
+        let url = dir.appendingPathComponent("u16.txt")
+        try "经典文本 classic".write(to: url, atomically: true, encoding: .utf16)
+        let text = try await ClosedBookTextExtractor().extract(url: url, format: "txt")
+        // Exact content (no BOM / replacement-char garbage) — a `contains` check
+        // would pass on mis-decode; assert the precise string (Gate-4 r2 Low).
+        #expect(text.trimmingCharacters(in: .whitespacesAndNewlines) == "经典文本 classic")
+        #expect(!text.contains("\u{FFFD}"))   // no replacement characters
+    }
+
+    @Test("resolveExisting finds a TXT book materialized under its .text original extension")
+    func resolveExistingTriesCandidateExtensions() throws {
+        // Simulate a lazy-download/restore that wrote the file as `.text`, not `.txt`.
+        let sha = String(repeating: "a", count: 64)
+        let key = "txt:\(sha):4096"
+        let safeName = key.replacingOccurrences(of: ":", with: "_")
+        let dir = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("ImportedBooks", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let textURL = dir.appendingPathComponent(safeName).appendingPathExtension("text")
+        try "body".write(to: textURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: textURL) }
+
+        let resolved = ImportedBookFileURL.resolveExisting(fingerprintKey: key, format: "txt")
+        #expect(resolved.lastPathComponent == "\(safeName).text")   // found the existing .text, not .txt
+    }
+
+    @Test("an unsupported format (azw3) throws, never returns empty")
+    func unsupportedFormatThrows() async {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("x.azw3")
+        await #expect(throws: (any Error).self) {
+            _ = try await ClosedBookTextExtractor().extract(url: url, format: "azw3")
+        }
+    }
+
+    @Test("a missing file throws (read failure surfaced, not a silent empty)")
+    func missingFileThrows() async {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).txt")
+        await #expect(throws: (any Error).self) {
+            _ = try await ClosedBookTextExtractor().extract(url: url, format: "txt")
+        }
+    }
+
+    @Test("the shared ImportedBookFileURL resolves the sandbox convention")
+    func importedURLConvention() {
+        let sha = String(repeating: "a", count: 64)
+        let url = ImportedBookFileURL.resolve(fingerprintKey: "epub:\(sha):4096", format: "epub")
+        #expect(url.lastPathComponent == "epub_\(sha)_4096.epub")
+        #expect(url.deletingLastPathComponent().lastPathComponent == "ImportedBooks")
+    }
+}


### PR DESCRIPTION
## Summary

The production `BookContentProvider` the `get_book_content` tool depends on (a WI-8b slice; the `LibrarySearchBackend` adapter + registry builder + VM branch + device verification follow):

- **`ClosedBookTextExtractor`** (off-actor, `Sendable`): EPUB via the `EPUBParser` spine + `stripHTML` (parser always closed after a successful open; skip-inaccessible-spine-item); TXT/MD via the **canonical** `TXTService.decodeForDisplayAndSearch` (UTF-16 BOM / GBK/Big5/Shift_JIS/… — the same decoder the reader + search use); PDF via PDFKit.
- **`BookContentProviderAdapter`**: title resolution via `LibraryPersisting` (notFound / found / ambiguous-with-author), `BookContentInfo.format` **derived from the fingerprint key** (drift-proof), malformed-key throw.
- **`ImportedBookFileURL`**: single source of truth for the imported-book sandbox URL (`LibraryBookItem.resolvedFileURL` now delegates) + `resolveExisting()` which tries the format's candidate extensions so a restore/lazy-download book materialized under its **original** extension (`.text`/`.markdown`) is still found.

Part of feature #1482.

## Codex Audit

3 rounds, `ship-as-is`, zero open Critical/High/Medium:
- **r1 Medium** — share the reader's canonical TXT decoder (was a partial copy that mis-decoded non-UTF-8 books).
- **r1 Medium + Low** — non-UTF-8 regression test (exact decode) + the URL-convention dedupe.
- **r1 Low** — adapter matrix: fetch-failure → notFound, key-derived format under a drifted column, `.remoteOnly` → isReadable.
- **r2 Medium** — resolve the file by the extension that **exists** on disk (original extension preserved by restore/lazy-download), not the primary only.
- **r3** — RESOLVED, no new issues.

Audit log: `.claude/codex-audits/feat-feature-91-wi-8b-book-content-adapter-audit.md`

## Validation

- [x] `scripts/run-tests.sh` over the extractor + adapter + `GetBookContentTool` + `LibraryBookItemFileState` suites → `SUCCEEDED`
- [x] TDD: RED → GREEN → 3 audit rounds
- [x] Version bumped: 3.51.16 → 3.51.17 (foundational → patch)

## Verification tier

Foundational — the tool isn't constructed yet (registry-builder + VM branch slice). The title resolution + TXT/MD decode + URL convention are unit-tested; EPUB/PDF extraction is device-verified at the feature's final acceptance pass.

## Type of Change

- [x] New feature work item (Part of feature #1482)