### PR TITLE
feat(#91 WI-8b/3): LibrarySearchBackend production path (search_other_books)

### DIFF
--- a/.claude/codex-audits/feat-feature-91-wi-8b-library-search-adapter-audit.md
+++ b/.claude/codex-audits/feat-feature-91-wi-8b-library-search-adapter-audit.md
@@ -1,0 +1,59 @@
+---
+branch: feat/feature-91-wi-8b-library-search-adapter
+threadId: 019e9309-babb-7743-9c95-8fb04e5f367f
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-04
+---
+
+# Codex Audit — Feature #91 WI-8b (slice 3: LibrarySearchBackend production path)
+
+Gate-4 implementation audit (rule 47). Independent Codex runner via
+`scripts/run-codex.sh -e high` (author/auditor separation, rule 48; rule-53
+stdin-isolated watchdog).
+
+## Scope
+
+WI-8b slice 3 — the production `LibrarySearchBackend` the search_other_books tool
+(WI-6b) depends on:
+
+- `vreader/Services/AI/Tools/LibrarySearchBackendAdapter.swift` (new) — forwarding
+  glue over `LibraryPersisting` + `SearchIndexStore` + `SearchService`, reached
+  through two narrow seams (`SearchIndexReading` / `IndexedBookSearching`) the
+  concrete types conform to via empty extensions (compile-time drift detection).
+  libraryBooks → fetchAllLibraryBooks; indexState → the 3 store reads mapped into
+  `LibraryIndexState`; restoreSegmentOffsets → the service; search → page 0,
+  pageSize = limit. The index-coverage RISK lives in the already-tested pure
+  `LibraryBookSearchGate`.
+- `vreaderTests/Services/AI/Tools/LibrarySearchBackendAdapterTests.swift` (new).
+
+## Round 1 — findings (threadId 019e9309-babb-7743-9c95-8fb04e5f367f)
+
+**No production-code findings.** The auditor confirmed by exact-signature
+inspection that both empty-extension conformances compile (`SearchIndexStore` /
+`SearchService` match the seam protocols), the mapping forwards into the right
+`LibraryIndexState` slots, search forwards page 0 / pageSize = limit, and the
+Sendable story holds. Both findings were test-strengthening:
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| LibrarySearchBackendAdapterTests.swift | **Medium** | `indexStateMaps` used symmetric `true/true`, so an `isIndexed↔requiresReindex` swap would still pass; the stub ignored the forwarded key. | **Fixed.** `RecordingIndex` records the key of all 3 reads; the test now uses ASYMMETRIC `indexed:false`/`reindex:true` and asserts `keys == ["the-key", ×3]`. |
+| LibrarySearchBackendAdapterTests.swift | Low | `restoreForwards` dropped the offsets payload. | **Fixed.** `RecordingSearch` captures `restoredOffsets`; the test asserts `== [0:0, 1:4096]`. |
+
+## Round 2 — verification (threadId 019e931d-599a-7592-ad47-b6dc25b32e82)
+
+**RESOLVED.** No new issues — both test gaps closed (asymmetric mapping + key
+forwarding on all three reads; the offsets payload asserted).
+
+## Verdict
+
+**ship-as-is.** Zero open Critical/High/Medium after round 2. `LibrarySearchBackendAdapterTests`
+green (4 tests: libraryBooks forwarding, indexState mapping into the right slots +
+key-forwarding, restore forwarding the fingerprint + offsets, search at page 0 /
+pageSize = limit). The empty-extension conformances give compile-time drift
+detection if the concrete `SearchIndexStore`/`SearchService` signatures change.
+
+Both production adapters (BookContentProvider + LibrarySearchBackend) are now
+complete. The remaining WI-8b work (the registry builder + the
+`AIChatViewModel.sendMessage` branch + citation suppression + Gate-5 device
+verification) completes Feature #91 to `DONE`/`VERIFIED`.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 873
-        MARKETING_VERSION: 3.51.17
+        CURRENT_PROJECT_VERSION: 874
+        MARKETING_VERSION: 3.51.18
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		09DBE45859D311C4D9B47B88 /* TypefacePillToggleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65A7D8CB655BD0E344BB52F /* TypefacePillToggleTests.swift */; };
 		0A0E59E50351ED190E24D03D /* RealDebugBridgeContext+PDFHighlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535F3D9734CC8A2C3E303580 /* RealDebugBridgeContext+PDFHighlight.swift */; };
 		0A359570B32735E17EC5893F /* TXTChunkedBridgeHighlightTapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB9A749915A46E6DD506275A /* TXTChunkedBridgeHighlightTapTests.swift */; };
+		0A37F29338B9453F40693188 /* LibrarySearchBackendAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5B25C34369CB3C3582F2E8 /* LibrarySearchBackendAdapter.swift */; };
 		0A520A30E35389B96854B922 /* FontSizeCalibration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6C41170131F22118778D83 /* FontSizeCalibration.swift */; };
 		0A6A74D96B7763878D13CFDD /* LibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF473C04CE58CE0887DAA5A1 /* LibraryViewModel.swift */; };
 		0A866D2088849BF693C99A10 /* V5toV6MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD170A9C4FEB206D5F5F2157 /* V5toV6MigrationTests.swift */; };
@@ -1487,6 +1488,7 @@
 		F3F7CDAB38376CE0AE8AE67A /* FoliateSpikeViewTTSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44FC663099F4228086D7EA54 /* FoliateSpikeViewTTSTests.swift */; };
 		F42AB6BD6B470B69A0F5A551 /* BookTranslationProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF42781312FD73B373FB2BB5 /* BookTranslationProgressTests.swift */; };
 		F437CE5879D0238AC5523F52 /* BookFileImportFinalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21FF5B2854F2C50C5A43F17 /* BookFileImportFinalizerTests.swift */; };
+		F4A77349F471CCDC2941A36A /* LibrarySearchBackendAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 057320738B3F583C98B72D1D /* LibrarySearchBackendAdapterTests.swift */; };
 		F4FA879DAB45756BADC7D26E /* AIReaderPanel+DebugBridgeAIAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5B5FE13287A24AE9EEFBA7 /* AIReaderPanel+DebugBridgeAIAction.swift */; };
 		F4FE45E62955A90DF146DE4B /* GenerativeCoverStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B75BA41298C5306AC9AD036 /* GenerativeCoverStyle.swift */; };
 		F51F7B9360A990E857FE1373 /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6686ECBBE526053A51CBA2 /* ChatMessage.swift */; };
@@ -1613,6 +1615,7 @@
 		05214DBBEAC115D3CA73477D /* PDFBilingualPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFBilingualPanelTests.swift; sourceTree = "<group>"; };
 		0539DF828CDF0E2D670CDEFB /* SearchStateViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchStateViews.swift; sourceTree = "<group>"; };
 		055FBEA382F82BE342A50C8E /* LocatorFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorFactoryTests.swift; sourceTree = "<group>"; };
+		057320738B3F583C98B72D1D /* LibrarySearchBackendAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySearchBackendAdapterTests.swift; sourceTree = "<group>"; };
 		05F9CE63DD8632C8B63BACCD /* TXTChapterStartTypographyIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterStartTypographyIntegrationTests.swift; sourceTree = "<group>"; };
 		060D40EBDC75C3812596FB84 /* HTTPSpeechSynthesizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPSpeechSynthesizer.swift; sourceTree = "<group>"; };
 		0616892213196BCF802266F8 /* ContentHasherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentHasherTests.swift; sourceTree = "<group>"; };
@@ -2837,6 +2840,7 @@
 		CF1F16CEFB8EE0AE91C72BA2 /* SourceSerif4-BoldIt.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSerif4-BoldIt.otf"; sourceTree = "<group>"; };
 		CF473C04CE58CE0887DAA5A1 /* LibraryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryViewModel.swift; sourceTree = "<group>"; };
 		CF50D372D73575F047EF0991 /* BookContentCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookContentCacheTests.swift; sourceTree = "<group>"; };
+		CF5B25C34369CB3C3582F2E8 /* LibrarySearchBackendAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySearchBackendAdapter.swift; sourceTree = "<group>"; };
 		CF5C12635DFA6BEE42EBB1CE /* KeychainServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainServiceTests.swift; sourceTree = "<group>"; };
 		CF65A328F9A79571A5164390 /* FoliateReaderContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateReaderContainerView.swift; sourceTree = "<group>"; };
 		CF66A8065E5B60907FB0A3C8 /* GenerativeCoverMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerativeCoverMetrics.swift; sourceTree = "<group>"; };
@@ -3276,6 +3280,7 @@
 				0CE295C77B7BFB9AD3B6A85F /* GetBookContentGateTests.swift */,
 				AB53B0494E5197769A64CCF1 /* GetBookContentToolTests.swift */,
 				33AE4518BC7EBC8968B54CFF /* LibraryBookSearchGateTests.swift */,
+				057320738B3F583C98B72D1D /* LibrarySearchBackendAdapterTests.swift */,
 				E4612140BE197E8A0EA480CC /* SearchCurrentBookToolTests.swift */,
 				6F2B1E6C1AB1225D416D9939 /* SearchOtherBooksToolTests.swift */,
 			);
@@ -4253,6 +4258,7 @@
 				220C9C125ECE9753714E40D1 /* GetBookContentGate.swift */,
 				18EF8C2454CBCC951F3CA25E /* GetBookContentTool.swift */,
 				1BD2081B22B559BD215B7C21 /* LibraryBookSearchGate.swift */,
+				CF5B25C34369CB3C3582F2E8 /* LibrarySearchBackendAdapter.swift */,
 				30DB574D36652997E553A96C /* SearchCurrentBookTool.swift */,
 				EE709CC0DFA0C4AB3910C5F1 /* SearchOtherBooksTool.swift */,
 				50E5306AB115FB64D6F9C1E9 /* ToolResultText.swift */,
@@ -6243,6 +6249,7 @@
 				73319DBA75C0F4352DDCD858 /* LibraryContextMenuTests.swift in Sources */,
 				C470300A552B997B253D9856 /* LibraryFilterTests.swift in Sources */,
 				879E269189DBE24A5AF6095B /* LibraryRefreshServiceTests.swift in Sources */,
+				F4A77349F471CCDC2941A36A /* LibrarySearchBackendAdapterTests.swift in Sources */,
 				FBF9F886D16DA6D941A6C8CD /* LibraryShellTokensTests.swift in Sources */,
 				C6D9CCA699EBFFBE7A5479F1 /* LibraryTestHelpers.swift in Sources */,
 				EBA5AEC161A4C9D055955BB4 /* LibraryViewModelImportTests.swift in Sources */,
@@ -6946,6 +6953,7 @@
 				41E9EFE59EB5DE541CB17BF0 /* LibraryPillButton.swift in Sources */,
 				276E47B44DB8004A3D700E05 /* LibraryProgressRing.swift in Sources */,
 				2DDEE520E3606572AED3598F /* LibraryRefreshService.swift in Sources */,
+				0A37F29338B9453F40693188 /* LibrarySearchBackendAdapter.swift in Sources */,
 				90568C5AF6C318AC12CEC471 /* LibrarySearchBar.swift in Sources */,
 				4BAFB4A830DDA62784FEBDA1 /* LibrarySectionHeader.swift in Sources */,
 				5599E405840D204BE7FA8104 /* LibrarySortOrder.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7529,7 +7529,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 873;
+				CURRENT_PROJECT_VERSION = 874;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7537,7 +7537,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.17;
+				MARKETING_VERSION = 3.51.18;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7683,7 +7683,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 873;
+				CURRENT_PROJECT_VERSION = 874;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7691,7 +7691,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.17;
+				MARKETING_VERSION = 3.51.18;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Services/AI/Tools/LibrarySearchBackendAdapter.swift
+++ b/vreader/Services/AI/Tools/LibrarySearchBackendAdapter.swift
@@ -1,0 +1,76 @@
+// Purpose: Feature #91 WI-8b — the production LibrarySearchBackend the
+// search_other_books tool (WI-6b) depends on. Pure forwarding glue over the live
+// search subsystem: list books via LibraryPersisting, read each book's persisted-
+// index state off the SearchIndexStore (the WI-6b gate inputs), restore TXT/MD
+// offsets + run per-book FTS via the SearchService. The index-coverage RISK
+// (which books are safely searchable) lives in the already-tested pure
+// LibraryBookSearchGate; this adapter only maps + forwards.
+//
+// The concrete `SearchService` / `SearchIndexStore` are reached through two narrow
+// seams (SearchIndexReading / IndexedBookSearching) so the adapter's mapping +
+// forwarding is unit-testable with stubs (no live FTS DB).
+//
+// @coordinates-with: LibraryBookSearchGate.swift (LibrarySearchBackend + the gate),
+//   SearchOtherBooksTool.swift (consumer), SearchService.swift, SearchIndexStore.swift,
+//   LibraryPersisting.swift, dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-8)
+
+import Foundation
+
+/// The persistent-index reads the adapter needs (the WI-6b guard inputs).
+/// `SearchIndexStore` conforms — it already vends exactly these.
+protocol SearchIndexReading: Sendable {
+    func isBookIndexed(fingerprintKey: String) -> Bool
+    func requiresReindex(fingerprintKey: String) -> Bool
+    func getSegmentBaseOffsets(fingerprintKey: String) -> [Int: Int]?
+}
+
+/// Per-book FTS search + TXT/MD offset restore. `SearchService` conforms.
+protocol IndexedBookSearching: Sendable {
+    func search(
+        query: String, bookFingerprint: DocumentFingerprint, page: Int, pageSize: Int
+    ) async throws -> SearchResultPage
+    func restoreSegmentOffsets(fingerprint: DocumentFingerprint, offsets: [Int: Int])
+}
+
+extension SearchIndexStore: SearchIndexReading {}
+extension SearchService: IndexedBookSearching {}
+
+struct LibrarySearchBackendAdapter: LibrarySearchBackend {
+
+    private let library: any LibraryPersisting
+    private let index: any SearchIndexReading
+    private let search: any IndexedBookSearching
+
+    init(
+        library: any LibraryPersisting,
+        index: any SearchIndexReading,
+        search: any IndexedBookSearching
+    ) {
+        self.library = library
+        self.index = index
+        self.search = search
+    }
+
+    func libraryBooks() async throws -> [LibraryBookItem] {
+        try await library.fetchAllLibraryBooks()
+    }
+
+    func indexState(fingerprintKey: String) async -> LibraryIndexState {
+        LibraryIndexState(
+            isIndexed: index.isBookIndexed(fingerprintKey: fingerprintKey),
+            requiresReindex: index.requiresReindex(fingerprintKey: fingerprintKey),
+            segmentOffsets: index.getSegmentBaseOffsets(fingerprintKey: fingerprintKey))
+    }
+
+    func restoreSegmentOffsets(fingerprint: DocumentFingerprint, offsets: [Int: Int]) async {
+        search.restoreSegmentOffsets(fingerprint: fingerprint, offsets: offsets)
+    }
+
+    func search(
+        query: String, fingerprint: DocumentFingerprint, limit: Int
+    ) async throws -> SearchResultPage {
+        // search_other_books is single-page per book: always page 0, pageSize = the
+        // per-book cap.
+        try await search.search(query: query, bookFingerprint: fingerprint, page: 0, pageSize: limit)
+    }
+}

--- a/vreaderTests/Services/AI/Tools/LibrarySearchBackendAdapterTests.swift
+++ b/vreaderTests/Services/AI/Tools/LibrarySearchBackendAdapterTests.swift
@@ -1,0 +1,107 @@
+// Purpose: Feature #91 WI-8b — pin the LibrarySearchBackendAdapter's mapping +
+// forwarding: libraryBooks → LibraryPersisting, indexState → the three store reads
+// mapped into LibraryIndexState, restoreSegmentOffsets → the search service, and
+// search → page 0 with pageSize == the per-book limit. The index-coverage gate
+// itself is tested in LibraryBookSearchGateTests.
+//
+// @coordinates-with: LibrarySearchBackendAdapter.swift, LibraryBookSearchGate.swift,
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-8)
+
+import Testing
+import Foundation
+@testable import vreader
+
+private struct StubLibrary: LibraryPersisting {
+    let books: [LibraryBookItem]
+    func fetchAllLibraryBooks() async throws -> [LibraryBookItem] { books }
+    func deleteBook(fingerprintKey: String) async throws {}
+}
+
+/// Records the fingerprintKey passed to EACH of the three reads, so a test can
+/// prove the key is forwarded (not dropped) — and returns asymmetric values so a
+/// field swap is caught.
+private final class RecordingIndex: SearchIndexReading, @unchecked Sendable {
+    let indexed: Bool
+    let reindex: Bool
+    let offsets: [Int: Int]?
+    private(set) var keys: [String] = []
+    init(indexed: Bool, reindex: Bool, offsets: [Int: Int]?) {
+        self.indexed = indexed; self.reindex = reindex; self.offsets = offsets
+    }
+    func isBookIndexed(fingerprintKey: String) -> Bool { keys.append(fingerprintKey); return indexed }
+    func requiresReindex(fingerprintKey: String) -> Bool { keys.append(fingerprintKey); return reindex }
+    func getSegmentBaseOffsets(fingerprintKey: String) -> [Int: Int]? {
+        keys.append(fingerprintKey); return offsets
+    }
+}
+
+private final class RecordingSearch: IndexedBookSearching, @unchecked Sendable {
+    var stubbedPage = SearchResultPage(results: [], page: 0, hasMore: false, totalEstimate: 0)
+    private(set) var lastSearch: (query: String, key: String, page: Int, pageSize: Int)?
+    private(set) var restoredKey: String?
+    private(set) var restoredOffsets: [Int: Int]?
+
+    func search(
+        query: String, bookFingerprint: DocumentFingerprint, page: Int, pageSize: Int
+    ) async throws -> SearchResultPage {
+        lastSearch = (query, bookFingerprint.canonicalKey, page, pageSize)
+        return stubbedPage
+    }
+    func restoreSegmentOffsets(fingerprint: DocumentFingerprint, offsets: [Int: Int]) {
+        restoredKey = fingerprint.canonicalKey
+        restoredOffsets = offsets
+    }
+}
+
+@Suite("Feature #91 WI-8b — LibrarySearchBackendAdapter")
+struct LibrarySearchBackendAdapterTests {
+
+    private static let fp = DocumentFingerprint(
+        contentSHA256: String(repeating: "a", count: 64), fileByteCount: 4096, format: .txt)
+
+    private func adapter(
+        library: StubLibrary = StubLibrary(books: []),
+        index: RecordingIndex = RecordingIndex(indexed: true, reindex: false, offsets: nil),
+        search: RecordingSearch = RecordingSearch()
+    ) -> LibrarySearchBackendAdapter {
+        LibrarySearchBackendAdapter(library: library, index: index, search: search)
+    }
+
+    @Test("libraryBooks forwards to LibraryPersisting.fetchAllLibraryBooks")
+    func libraryBooksForwards() async throws {
+        let book = LibraryBookItem.stub(
+            fingerprintKey: "txt:\(String(repeating: "a", count: 64)):4096", title: "B", format: "txt")
+        let books = try await adapter(library: StubLibrary(books: [book])).libraryBooks()
+        #expect(books.map(\.title) == ["B"])
+    }
+
+    @Test("indexState maps the three store reads into the right LibraryIndexState slots")
+    func indexStateMaps() async {
+        // Asymmetric values (isIndexed=false, requiresReindex=true) so an
+        // isIndexed↔requiresReindex swap would fail.
+        let index = RecordingIndex(indexed: false, reindex: true, offsets: [0: 0, 1: 4096])
+        let state = await adapter(index: index).indexState(fingerprintKey: "the-key")
+        #expect(state == LibraryIndexState(
+            isIndexed: false, requiresReindex: true, segmentOffsets: [0: 0, 1: 4096]))
+        #expect(index.keys == ["the-key", "the-key", "the-key"])   // the key reached all 3 reads
+    }
+
+    @Test("restoreSegmentOffsets forwards the fingerprint AND the offsets payload")
+    func restoreForwards() async {
+        let search = RecordingSearch()
+        await adapter(search: search).restoreSegmentOffsets(
+            fingerprint: Self.fp, offsets: [0: 0, 1: 4096])
+        #expect(search.restoredKey == Self.fp.canonicalKey)
+        #expect(search.restoredOffsets == [0: 0, 1: 4096])
+    }
+
+    @Test("search forwards at page 0 with pageSize == the per-book limit")
+    func searchForwards() async throws {
+        let search = RecordingSearch()
+        _ = try await adapter(search: search).search(query: "darcy", fingerprint: Self.fp, limit: 5)
+        #expect(search.lastSearch?.page == 0)
+        #expect(search.lastSearch?.pageSize == 5)
+        #expect(search.lastSearch?.key == Self.fp.canonicalKey)
+        #expect(search.lastSearch?.query == "darcy")
+    }
+}


### PR DESCRIPTION
## Summary

The production `LibrarySearchBackend` the `search_other_books` tool depends on (a WI-8b slice; the registry builder + VM branch + device verification follow):

- **`LibrarySearchBackendAdapter`** — forwarding glue over `LibraryPersisting` + `SearchIndexStore` + `SearchService`, reached through two narrow seams (`SearchIndexReading` / `IndexedBookSearching`) the concrete types conform to via **empty extensions** (compile-time drift detection). `libraryBooks` → `fetchAllLibraryBooks`; `indexState` → the 3 store reads mapped into `LibraryIndexState`; `restoreSegmentOffsets` → the service; `search` → page 0, pageSize = limit.
- The index-coverage **risk** (which books are safely searchable) stays in the already-tested pure `LibraryBookSearchGate`.

Part of feature #1482.

## Codex Audit

2 rounds, `ship-as-is`, **zero production-code findings** (the empty-extension conformances compile, the mapping + forwarding are correct, Sendable holds). The 2 findings were test-strengthening:
- **r1 Medium** — asymmetric mapping values (catch an `isIndexed↔requiresReindex` swap) + assert the key is forwarded to all three reads.
- **r1 Low** — assert the offsets payload is forwarded.
- **r2** — RESOLVED, no new issues.

Audit log: `.claude/codex-audits/feat-feature-91-wi-8b-library-search-adapter-audit.md`

## Validation

- [x] `scripts/run-tests.sh vreaderTests/LibrarySearchBackendAdapterTests vreaderTests/LibraryBookSearchGateTests` → `SUCCEEDED`
- [x] TDD: RED → GREEN → 2 audit rounds
- [x] Version bumped: 3.51.17 → 3.51.18 (foundational → patch)

## Verification tier

Foundational — the tool isn't constructed yet (registry-builder + VM branch slice). The mapping + forwarding are unit-tested; the live FTS path is device-verified at the feature's final acceptance pass.

## Type of Change

- [x] New feature work item (Part of feature #1482)