### PR TITLE
feat(#91 WI-8b/4): AgenticToolRegistryBuilder (assemble the tool registry)

### DIFF
--- a/.claude/codex-audits/feat-feature-91-wi-8b-registry-builder-audit.md
+++ b/.claude/codex-audits/feat-feature-91-wi-8b-registry-builder-audit.md
@@ -1,0 +1,51 @@
+---
+branch: feat/feature-91-wi-8b-registry-builder
+threadId: 019e9331-628b-78e2-b872-cfd24bb31db1
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-04
+---
+
+# Codex Audit — Feature #91 WI-8b (slice 4: AgenticToolRegistryBuilder)
+
+Gate-4 implementation audit (rule 47). Independent Codex runner via
+`scripts/run-codex.sh -e high` (author/auditor separation, rule 48; rule-53
+stdin-isolated watchdog).
+
+## Scope
+
+WI-8b slice 4 — assemble the `AIToolRegistry` for an agentic chat turn:
+
+- `vreader/Services/AI/Tools/AgenticToolRegistryBuilder.swift` (new) — pure
+  assembly: `search_current_book` only when BOTH an open-book fingerprint AND a
+  live `SearchProviding` are present; `search_other_books` (wired with
+  `currentBook?.canonicalKey` to exclude the open book) + `get_book_content` always.
+- `vreaderTests/Services/AI/Tools/AgenticToolRegistryBuilderTests.swift` (new).
+
+## Round 1 — findings (threadId 019e9331-628b-78e2-b872-cfd24bb31db1)
+
+**No code findings.** The auditor confirmed the builder matches its contract
+(current-book tool gated by both inputs; library tools always included;
+general-chat non-empty; `SearchOtherBooksTool` excludes the open book at runtime),
+and the Swift 6 isolation is clean (stateless enum, all stored existentials
+`Sendable`-constrained). Relying on each tool's default caps is fine for v1.
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| AgenticToolRegistryBuilderTests.swift | **Medium** | The tests proved only the tool NAMES, not the runtime behavior that `search_other_books` is built with `currentBook?.canonicalKey` (excludes the open book). A regression to `nil` would still pass. | **Fixed.** `searchOtherBooksExcludesOpenBook` builds the registry with an open-book fingerprint, runs `search_other_books` via `registry.run(...)` against a `SpyLibraryBackend` (2 indexed epub books), and asserts the OTHER book is searched while the open book is NOT. |
+
+## Round 2 — verification (threadId 019e9343-f5d0-7ea2-89cc-4a438ea35ce8)
+
+**RESOLVED.** No new issues — the runtime test would fail if the builder stopped
+passing `currentBook?.canonicalKey` into `SearchOtherBooksTool`.
+
+## Verdict
+
+**ship-as-is.** Zero open Critical/High/Medium after round 2. `AgenticToolRegistryBuilderTests`
+green (4 tests: all-three with an open book, no-book omits search_current_book,
+book-without-search omits it, and the behavioral open-book exclusion).
+
+The only remaining WI-8b work — the `AIChatViewModel.sendMessage` branch
+(driver-via-`sendToolTurn` vs stream) + citation suppression + the dependency-
+acquisition wiring at the chat construction site, `docs/architecture.md`, and
+Gate-5 device verification — completes Feature #91 to `DONE`/`VERIFIED`.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 874
-        MARKETING_VERSION: 3.51.18
+        CURRENT_PROJECT_VERSION: 875
+        MARKETING_VERSION: 3.51.19
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -258,6 +258,7 @@
 		2999C19D201DFD14B176D2B3 /* TXTLazyTextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F7F0E16B5468446AE51D0C /* TXTLazyTextProvider.swift */; };
 		29B4FA8EBF5958A675E5A8DF /* FoliateBottomChromeLabels.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B78961833B958737E550A6 /* FoliateBottomChromeLabels.swift */; };
 		29B5552598092B0BE25D9FF5 /* Feature64FoliateMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A3C9C74AEB817E120ACDAF9 /* Feature64FoliateMigrationTests.swift */; };
+		2A7576C76889A35A4EFD3147 /* AgenticToolRegistryBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6B4291B435E4465DA4A10A /* AgenticToolRegistryBuilder.swift */; };
 		2A9AD149CEFDF663E4C7CB5D /* ReaderBridgeSideTapWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95424A5FBB4CD4804BFDB61D /* ReaderBridgeSideTapWiringTests.swift */; };
 		2AB9286D902B8B6A8BB1DD16 /* FoliateBilingualJS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7CBC6DECE0826C5C95D76D /* FoliateBilingualJS.swift */; };
 		2ACDD49C29110C6459556A71 /* SheetSectionContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529E7234A3FC73811D573A6C /* SheetSectionContract.swift */; };
@@ -349,6 +350,7 @@
 		36972763F4542783F654FB33 /* SchemaV8MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E644FA2FFCEBC9F45E1E6E /* SchemaV8MigrationTests.swift */; };
 		369D003DCE5F36A64E5C1C06 /* AIChatGeneralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90F4EB83CC68406DA14DD94 /* AIChatGeneralTests.swift */; };
 		36B37715BB3494F635566157 /* ImportJobQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117731FF4D8AE414141C5ECF /* ImportJobQueue.swift */; };
+		36CB4918118A5C33A77FE4F4 /* AgenticToolRegistryBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633822DF0A5822C12C6B1B3D /* AgenticToolRegistryBuilderTests.swift */; };
 		37128EB810887C2A4D36E99F /* VerificationSettingsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1C2AB4E9DBE8437C7C8CF8 /* VerificationSettingsHelper.swift */; };
 		371BDEC687E965D30E539A94 /* WebDAVProviderSelectiveRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777477DCF173A1397609EC1F /* WebDAVProviderSelectiveRestoreTests.swift */; };
 		371BF186C1E2B822963A744D /* SourceSerif4-BoldIt.otf in Resources */ = {isa = PBXBuildFile; fileRef = CF1F16CEFB8EE0AE91C72BA2 /* SourceSerif4-BoldIt.otf */; };
@@ -2207,6 +2209,7 @@
 		62B304D30B717A1AB66C2A5B /* Feature64PDFMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature64PDFMigrationTests.swift; sourceTree = "<group>"; };
 		62D7DA128D4B2AC1F362D571 /* LaunchHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchHelper.swift; sourceTree = "<group>"; };
 		631D0375777D50E5B1EDF31C /* HighlightedSnippetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightedSnippetTests.swift; sourceTree = "<group>"; };
+		633822DF0A5822C12C6B1B3D /* AgenticToolRegistryBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgenticToolRegistryBuilderTests.swift; sourceTree = "<group>"; };
 		63604C0EFC18CDB16EF2C176 /* Feature11EPUBBottomChromeVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature11EPUBBottomChromeVerificationTests.swift; sourceTree = "<group>"; };
 		6362591D3F62B4BC84CE136A /* FileAvailabilityStateMachineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileAvailabilityStateMachineTests.swift; sourceTree = "<group>"; };
 		637D35BECC7768038F474E5E /* FileAvailabilityBadgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileAvailabilityBadgeTests.swift; sourceTree = "<group>"; };
@@ -2933,6 +2936,7 @@
 		DCC4E330CF0A4F1EBF039346 /* FoliateCoordinatorBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateCoordinatorBox.swift; sourceTree = "<group>"; };
 		DCC9BD90E5F37387526CBFF1 /* FoliateSpikeViewCreateOverlayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateSpikeViewCreateOverlayTests.swift; sourceTree = "<group>"; };
 		DD2C3A426BB929B2462E439E /* DebugCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugCommand.swift; sourceTree = "<group>"; };
+		DD6B4291B435E4465DA4A10A /* AgenticToolRegistryBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgenticToolRegistryBuilder.swift; sourceTree = "<group>"; };
 		DD7224616391A07142BD1979 /* BookTranslationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookTranslationCoordinatorTests.swift; sourceTree = "<group>"; };
 		DD76366E51B98FEE9E53DB3C /* ReaderAuditFix2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderAuditFix2Tests.swift; sourceTree = "<group>"; };
 		DDB7C7EC41A96F5D4B53E983 /* ReaderNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderNotifications.swift; sourceTree = "<group>"; };
@@ -3275,6 +3279,7 @@
 		17F5D2D6157B0982ED966239 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				633822DF0A5822C12C6B1B3D /* AgenticToolRegistryBuilderTests.swift */,
 				A868AC7292423FB54ACA099D /* BookContentProviderAdapterTests.swift */,
 				628F93F39DE835610F930D5E /* ClosedBookTextExtractorTests.swift */,
 				0CE295C77B7BFB9AD3B6A85F /* GetBookContentGateTests.swift */,
@@ -4253,6 +4258,7 @@
 		8398255B9EC6E36B2D2EE0AF /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				DD6B4291B435E4465DA4A10A /* AgenticToolRegistryBuilder.swift */,
 				D31AE45779D6F79B237D8BFE /* BookContentProviderAdapter.swift */,
 				A20767F0423EEB85DD502B1C /* ClosedBookTextExtractor.swift */,
 				220C9C125ECE9753714E40D1 /* GetBookContentGate.swift */,
@@ -5978,6 +5984,7 @@
 				495502CCD0035DB7C8AE37DA /* AccentColorTests.swift in Sources */,
 				65C927CBE6855076656719CE /* AccessibilityFormattersTests.swift in Sources */,
 				58492304DE5E8129C46DE24C /* AgenticChatDriverTests.swift in Sources */,
+				36CB4918118A5C33A77FE4F4 /* AgenticToolRegistryBuilderTests.swift in Sources */,
 				13EC9440F35FF01443E4FABF /* AnnotationAnchorTests.swift in Sources */,
 				058C2F104DE6D10D81F907D9 /* AnnotationExporterTests.swift in Sources */,
 				C35B2A71395E812536EDFEBD /* AnnotationImporterTests.swift in Sources */,
@@ -6629,6 +6636,7 @@
 				8A3AE73DD5935F4E45882E38 /* AccessibilityFormatters.swift in Sources */,
 				19A48F5C5BC46818F3CC10BB /* AddNoteSheet.swift in Sources */,
 				A9C00155CFDFF275A6C51742 /* AgenticChatDriver.swift in Sources */,
+				2A7576C76889A35A4EFD3147 /* AgenticToolRegistryBuilder.swift in Sources */,
 				21145D281B373D2D3262E65F /* AnnotationAnchor.swift in Sources */,
 				7872FD996BEB1009EFF26413 /* AnnotationEditSheet.swift in Sources */,
 				C7963EB4DD0ACFD3A87D97CC /* AnnotationExporter.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7537,7 +7537,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 874;
+				CURRENT_PROJECT_VERSION = 875;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7545,7 +7545,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.18;
+				MARKETING_VERSION = 3.51.19;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7691,7 +7691,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 874;
+				CURRENT_PROJECT_VERSION = 875;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7699,7 +7699,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.18;
+				MARKETING_VERSION = 3.51.19;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Services/AI/Tools/AgenticToolRegistryBuilder.swift
+++ b/vreader/Services/AI/Tools/AgenticToolRegistryBuilder.swift
@@ -1,0 +1,42 @@
+// Purpose: Feature #91 WI-8b — assemble the AIToolRegistry for an agentic chat
+// turn from the open book's context + the production backends. Pure assembly: the
+// current-book search tool is included only when a book is open; the library tools
+// always are. The AIChatViewModel passes the resulting registry into the
+// AgenticChatDriver.
+//
+// @coordinates-with: AIToolRegistry.swift, SearchCurrentBookTool.swift,
+//   SearchOtherBooksTool.swift, GetBookContentTool.swift,
+//   LibrarySearchBackendAdapter.swift, BookContentProviderAdapter.swift,
+//   AIChatViewModel.swift (the WI-8 consumer),
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-8)
+
+import Foundation
+
+enum AgenticToolRegistryBuilder {
+
+    /// Build the read-only tool registry for a chat turn.
+    /// - `currentBook` / `currentBookSearch`: the open book's fingerprint + its live
+    ///   (already-indexed) search service — when both are present, `search_current_book`
+    ///   is offered. General (no-book) chat omits it.
+    /// - `libraryBackend`: powers `search_other_books` (the whole library, excluding
+    ///   the open book).
+    /// - `contentProvider`: powers `get_book_content` (fetch a book's text by title).
+    static func build(
+        currentBook: DocumentFingerprint?,
+        currentBookSearch: (any SearchProviding)?,
+        libraryBackend: any LibrarySearchBackend,
+        contentProvider: any BookContentProvider
+    ) -> AIToolRegistry {
+        var tools: [any AITool] = []
+
+        if let currentBook, let currentBookSearch {
+            tools.append(SearchCurrentBookTool(
+                search: currentBookSearch, bookFingerprint: currentBook))
+        }
+        tools.append(SearchOtherBooksTool(
+            backend: libraryBackend, currentBookFingerprintKey: currentBook?.canonicalKey))
+        tools.append(GetBookContentTool(provider: contentProvider))
+
+        return AIToolRegistry(tools)
+    }
+}

--- a/vreaderTests/Services/AI/Tools/AgenticToolRegistryBuilderTests.swift
+++ b/vreaderTests/Services/AI/Tools/AgenticToolRegistryBuilderTests.swift
@@ -1,0 +1,117 @@
+// Purpose: Feature #91 WI-8b — pin the agentic tool-registry assembly: with an
+// open book all three tools are offered; general (no-book) chat omits
+// search_current_book; a book fingerprint without a live search service also omits
+// it. Stubs for the three backends; the builder is pure assembly.
+//
+// @coordinates-with: AgenticToolRegistryBuilder.swift, AIToolRegistry.swift,
+//   dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-8)
+
+import Testing
+import Foundation
+@testable import vreader
+
+private struct StubSearch: SearchProviding {
+    func indexBook(
+        fingerprint: DocumentFingerprint, textUnits: [TextUnit],
+        segmentBaseOffsets: [Int: Int]?) async throws {}
+    func search(
+        query: String, bookFingerprint: DocumentFingerprint, page: Int, pageSize: Int
+    ) async throws -> SearchResultPage {
+        SearchResultPage(results: [], page: 0, hasMore: false, totalEstimate: 0)
+    }
+    func removeIndex(fingerprint: DocumentFingerprint) async throws {}
+    func isIndexed(fingerprint: DocumentFingerprint) async -> Bool { true }
+}
+
+private struct StubLibraryBackend: LibrarySearchBackend {
+    func libraryBooks() async throws -> [LibraryBookItem] { [] }
+    func indexState(fingerprintKey: String) async -> LibraryIndexState {
+        LibraryIndexState(isIndexed: false, requiresReindex: false, segmentOffsets: nil)
+    }
+    func restoreSegmentOffsets(fingerprint: DocumentFingerprint, offsets: [Int: Int]) async {}
+    func search(
+        query: String, fingerprint: DocumentFingerprint, limit: Int
+    ) async throws -> SearchResultPage {
+        SearchResultPage(results: [], page: 0, hasMore: false, totalEstimate: 0)
+    }
+}
+
+private struct StubContent: BookContentProvider {
+    func findBook(title: String) async -> BookTitleResolution { .notFound }
+    func extractText(fingerprintKey: String) async throws -> String { "" }
+}
+
+/// Records which book fingerprints search_other_books actually searches, so a test
+/// can prove the OPEN book is excluded (not merely that the tool exists).
+private final class SpyLibraryBackend: LibrarySearchBackend, @unchecked Sendable {
+    let books: [LibraryBookItem]
+    private(set) var searchedKeys: [String] = []
+    init(books: [LibraryBookItem]) { self.books = books }
+    func libraryBooks() async throws -> [LibraryBookItem] { books }
+    func indexState(fingerprintKey: String) async -> LibraryIndexState {
+        LibraryIndexState(isIndexed: true, requiresReindex: false, segmentOffsets: nil)  // epub → searchable
+    }
+    func restoreSegmentOffsets(fingerprint: DocumentFingerprint, offsets: [Int: Int]) async {}
+    func search(
+        query: String, fingerprint: DocumentFingerprint, limit: Int
+    ) async throws -> SearchResultPage {
+        searchedKeys.append(fingerprint.canonicalKey)
+        return SearchResultPage(results: [], page: 0, hasMore: false, totalEstimate: 0)
+    }
+}
+
+@Suite("Feature #91 WI-8b — AgenticToolRegistryBuilder")
+struct AgenticToolRegistryBuilderTests {
+
+    private static let fp = DocumentFingerprint(
+        contentSHA256: String(repeating: "a", count: 64), fileByteCount: 4096, format: .epub)
+
+    @Test("with an open book + a live search service, the registry offers all three tools")
+    func includesCurrentBookTool() {
+        let registry = AgenticToolRegistryBuilder.build(
+            currentBook: Self.fp, currentBookSearch: StubSearch(),
+            libraryBackend: StubLibraryBackend(), contentProvider: StubContent())
+        #expect(registry.definitions().map(\.name)
+            == ["get_book_content", "search_current_book", "search_other_books"])
+    }
+
+    @Test("general chat (no open book) omits search_current_book")
+    func noBookOmitsCurrentTool() {
+        let registry = AgenticToolRegistryBuilder.build(
+            currentBook: nil, currentBookSearch: nil,
+            libraryBackend: StubLibraryBackend(), contentProvider: StubContent())
+        #expect(registry.definitions().map(\.name) == ["get_book_content", "search_other_books"])
+        #expect(!registry.isEmpty)
+    }
+
+    @Test("a book fingerprint without a live search service still omits search_current_book")
+    func bookButNoSearchOmitsCurrentTool() {
+        let registry = AgenticToolRegistryBuilder.build(
+            currentBook: Self.fp, currentBookSearch: nil,
+            libraryBackend: StubLibraryBackend(), contentProvider: StubContent())
+        #expect(!registry.definitions().map(\.name).contains("search_current_book"))
+        #expect(registry.definitions().map(\.name) == ["get_book_content", "search_other_books"])
+    }
+
+    @Test("the assembled search_other_books EXCLUDES the open book at runtime (not just the names)")
+    func searchOtherBooksExcludesOpenBook() async {
+        let openKey = "epub:\(String(repeating: "a", count: 64)):4096"
+        let otherKey = "epub:\(String(repeating: "b", count: 64)):4096"
+        let spy = SpyLibraryBackend(books: [
+            LibraryBookItem.stub(fingerprintKey: openKey, title: "Open", format: "epub"),
+            LibraryBookItem.stub(fingerprintKey: otherKey, title: "Other", format: "epub"),
+        ])
+        let registry = AgenticToolRegistryBuilder.build(
+            currentBook: DocumentFingerprint(canonicalKey: openKey),
+            currentBookSearch: StubSearch(), libraryBackend: spy, contentProvider: StubContent())
+
+        _ = await registry.run(ToolCall(
+            id: "c", name: "search_other_books", input: .object(["query": .string("x")])))
+
+        // The builder wired currentBook?.canonicalKey into the tool → the open book
+        // is NOT searched; the other indexed book IS. (A regression to nil would
+        // search the open book too and fail.)
+        #expect(spy.searchedKeys.contains(otherKey))
+        #expect(!spy.searchedKeys.contains(openKey))
+    }
+}


### PR DESCRIPTION
## Summary

Pure assembly of the `AIToolRegistry` for an agentic chat turn (a WI-8b slice; the `AIChatViewModel.sendMessage` branch + device verification follow):

- `search_current_book` only when **both** an open-book fingerprint **and** a live `SearchProviding` are present.
- `search_other_books` (wired with `currentBook?.canonicalKey` to **exclude the open book**) + `get_book_content` always.
- General (no-book) chat omits the current-book tool; the registry stays non-empty.

Part of feature #1482.

## Codex Audit

2 rounds, `ship-as-is`, **zero code findings** (contract correct, Swift 6 isolation clean). The one finding was test-strengthening:
- **r1 Medium** — a behavioral test that runs `search_other_books` via `registry.run(...)` against a spy backend and asserts the open book is **excluded at runtime** (a regression to a `nil` exclusion key would fail), not just the tool names.
- **r2** — RESOLVED, no new issues.

Audit log: `.claude/codex-audits/feat-feature-91-wi-8b-registry-builder-audit.md`

## Validation

- [x] `scripts/run-tests.sh vreaderTests/AgenticToolRegistryBuilderTests` → `SUCCEEDED` (4 tests)
- [x] TDD: RED → GREEN → 2 audit rounds
- [x] Version bumped: 3.51.18 → 3.51.19 (foundational → patch)

## Verification tier

Foundational — not wired into the VM yet (the `sendMessage` branch slice). The assembly + the runtime open-book exclusion are unit-tested; the end-to-end agentic chat is device-verified at the feature's final acceptance pass.

## Type of Change

- [x] New feature work item (Part of feature #1482)