### PR TITLE
feat(#91 WI-8b/5): AIServiceToolUseAdapter (gate-rechecking production bridge)

### DIFF
--- a/.claude/codex-audits/feat-feature-91-wi-8b-service-tooluse-adapter-audit.md
+++ b/.claude/codex-audits/feat-feature-91-wi-8b-service-tooluse-adapter-audit.md
@@ -1,0 +1,51 @@
+---
+branch: feat/feature-91-wi-8b-service-tooluse-adapter
+threadId: 019e935d-6dfd-7f00-be4d-ba23a6047b47
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-05
+---
+
+# Codex Audit — Feature #91 WI-8b (slice 5: AIServiceToolUseAdapter)
+
+Gate-4 implementation audit (rule 47). Independent Codex runner via
+`scripts/run-codex.sh -e high` (author/auditor separation, rule 48; rule-53
+stdin-isolated watchdog).
+
+## Scope
+
+WI-8b slice 5 — the PRODUCTION `ToolUseSending` the agentic chat loop uses:
+
+- `vreader/Services/AI/AIChatAgenticSupport.swift` — `AIServiceToolUseAdapter`
+  wraps `(AIService, ResolvedAIProviderConfig)` and forwards each driver turn
+  through `AIService.sendToolTurn(_:using:)` (live flag/consent re-check each turn,
+  pinned config). The callerless `ProviderToolUseAdapter` (WI-8a) was removed.
+- `vreaderTests/Services/AI/AIServiceResolvedConfigTests.swift` — 2 adapter tests.
+
+## Audit (threadId 019e935d-6dfd-7f00-be4d-ba23a6047b47)
+
+> The first run (threadId 019e9359) was watchdog-killed at 210s while exploring the
+> full test suite, before producing a verdict; re-run concise.
+
+**No finding on the adapter's correctness or Swift 6 story:** the forward to
+`sendToolTurn` is correct, and the `Sendable` story is sound (`AIService` is an
+actor, `ResolvedAIProviderConfig` is `Sendable`). **No finding on the test seam:**
+the `provider:` injection is acceptable for these two tests — the adapter's job is
+only "delegate to `sendToolTurn`"; config→provider construction is `AIService`'s
+responsibility and is covered by the existing `sendRequestUsing` factory-seam tests.
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| AIChatAgenticSupport.swift `ProviderToolUseAdapter` | Low | Now callerless dead code, and being non-gate-rechecking it's a production footgun (a future caller could pick the wrong bridge). | **Fixed.** Removed (it had no callers and no tests; build green confirms no dangling references). A non-gating bridge can be reintroduced at a concrete caller with local docs/tests if ever needed. |
+
+## Verdict
+
+**ship-as-is.** Zero open Critical/High/Medium. The Low (dead-code removal) is a
+build-verified deletion of unused code. `AIServiceResolvedConfigTests` green
+(the adapter forwards through `sendToolTurn` and fails closed on a mid-loop flag
+revoke; `AIChatAgenticSupportTests` green after the removal).
+
+The only remaining WI-8b work — the `AIChatViewModel.sendMessage` branch
+(driver via `AIServiceToolUseAdapter` over `sendToolTurn` vs stream) + citation
+suppression + the construction-site registry wiring, `docs/architecture.md`, and
+Gate-5 device verification — completes Feature #91 to `DONE`/`VERIFIED`.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 875
-        MARKETING_VERSION: 3.51.19
+        CURRENT_PROJECT_VERSION: 876
+        MARKETING_VERSION: 3.51.20
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7537,7 +7537,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 875;
+				CURRENT_PROJECT_VERSION = 876;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7545,7 +7545,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.19;
+				MARKETING_VERSION = 3.51.20;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7691,7 +7691,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 875;
+				CURRENT_PROJECT_VERSION = 876;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7699,7 +7699,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.19;
+				MARKETING_VERSION = 3.51.20;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Services/AI/AIChatAgenticSupport.swift
+++ b/vreader/Services/AI/AIChatAgenticSupport.swift
@@ -62,12 +62,15 @@ enum AIChatHistoryMapper {
     }
 }
 
-/// Bridges a resolved `any AIProvider` to the driver's narrow `ToolUseSending`
-/// seam (`AIProvider` already vends `sendToolRequest`). Keeps `AgenticChatDriver`
-/// decoupled from the full provider protocol + trivially testable.
-struct ProviderToolUseAdapter: ToolUseSending {
-    let provider: any AIProvider
+/// The PRODUCTION `ToolUseSending` for the agentic chat loop: each driver turn
+/// goes back through `AIService.sendToolTurn(_:using:)`, which RE-CHECKS the live
+/// `aiAssistant` flag + consent each turn (a mid-loop disable / consent revoke
+/// fails closed — Gate-4 Medium) while reusing the PINNED `config` so the
+/// provider/model/key never drift (Gate-2 Medium).
+struct AIServiceToolUseAdapter: ToolUseSending {
+    let service: AIService
+    let config: ResolvedAIProviderConfig
     func sendToolRequest(_ request: AIToolRequest) async throws -> AIToolTurn {
-        try await provider.sendToolRequest(request)
+        try await service.sendToolTurn(request, using: config)
     }
 }

--- a/vreaderTests/Services/AI/AIServiceResolvedConfigTests.swift
+++ b/vreaderTests/Services/AI/AIServiceResolvedConfigTests.swift
@@ -247,6 +247,38 @@ struct AIServiceResolvedConfigTests {
         }
     }
 
+    @Test func aiServiceToolUseAdapter_forwardsThroughSendToolTurn() async throws {
+        let (store, keychain) = Self.makeTestStore()
+        let profile = Self.makeOpenAIProfile()
+        try keychain.saveAPIKey("sk-openai-active", forProfile: profile.id)
+        await store.upsert(profile)
+        await store.setActiveProfileID(profile.id)
+
+        let service = Self.makeService(store: store, keychain: keychain, provider: ToolCapableStub())
+        let (config, _) = try await service.resolveToolProvider()
+        let adapter = AIServiceToolUseAdapter(service: service, config: config)
+        let turn = try await adapter.sendToolRequest(Self.toolRequest())
+        #expect(turn == .text("tool answer"))   // forwarded to the stub via sendToolTurn
+    }
+
+    @Test func aiServiceToolUseAdapter_failsClosedOnMidLoopGateRevoke() async throws {
+        let (store, keychain) = Self.makeTestStore()
+        let profile = Self.makeOpenAIProfile()
+        try keychain.saveAPIKey("sk-openai-active", forProfile: profile.id)
+        await store.upsert(profile)
+        await store.setActiveProfileID(profile.id)
+
+        let (service, flags) = Self.makeServiceHoldingFlags(
+            store: store, keychain: keychain, provider: ToolCapableStub())
+        let (config, _) = try await service.resolveToolProvider()
+        let adapter = AIServiceToolUseAdapter(service: service, config: config)
+
+        flags.setOverride(false, for: .aiAssistant)   // AI disabled mid-loop
+        await #expect(throws: AIError.featureDisabled) {
+            _ = try await adapter.sendToolRequest(Self.toolRequest())
+        }
+    }
+
     // MARK: - resolveProviderConfig(profileID:modelOverride:)
 
     @Test func resolveProviderConfig_resolvesANamedNonActiveProfile() async throws {


### PR DESCRIPTION
## Summary

The **production** `ToolUseSending` the agentic chat loop drives through (a WI-8b slice; the `AIChatViewModel.sendMessage` branch + device verification follow):

- **`AIServiceToolUseAdapter`** wraps `(AIService, ResolvedAIProviderConfig)` and forwards each driver turn through `AIService.sendToolTurn(_:using:)`, which re-checks the live `aiAssistant` flag + consent **each turn** (a mid-loop disable / consent revoke fails closed) while reusing the **pinned config** (no provider/model/key drift).
- **Removed `ProviderToolUseAdapter`** (WI-8a): now callerless + non-gate-rechecking — dead code and a footgun.

Part of feature #1482.

## Codex Audit

1 round, `ship-as-is`. The adapter forward + Swift 6 `Sendable` are **sound** (no finding); the provider-injection test seam is **acceptable** (config→provider construction is `AIService`'s job, covered by the factory-seam tests — no finding). The one **Low** — the dead `ProviderToolUseAdapter` — was removed (build green confirms no dangling references).

Audit log: `.claude/codex-audits/feat-feature-91-wi-8b-service-tooluse-adapter-audit.md`

## Validation

- [x] `scripts/run-tests.sh vreaderTests/AIChatAgenticSupportTests vreaderTests/AIServiceResolvedConfigTests` → `SUCCEEDED`
- [x] TDD: RED → GREEN → audit (forward + fail-closed-on-mid-loop-revoke)
- [x] Version bumped: 3.51.19 → 3.51.20 (foundational → patch)

## Verification tier

Foundational — not wired into the VM yet (the `sendMessage` branch slice). The forward + the per-turn gate re-check are unit-tested; end-to-end is device-verified at the feature's final acceptance pass.

## Type of Change

- [x] New feature work item (Part of feature #1482)