### PR TITLE
feat(#91 WI-8b/6): AIChatViewModel agentic-branch logic (foundational)

### DIFF
--- a/.claude/codex-audits/feat-feature-91-wi-8b-vm-branch-audit.md
+++ b/.claude/codex-audits/feat-feature-91-wi-8b-vm-branch-audit.md
@@ -1,0 +1,59 @@
+---
+branch: feat/feature-91-wi-8b-vm-branch
+threadId: 019e9386-9cc9-74d2-91f3-8f3a9401f352
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-05
+---
+
+# Codex Audit — Feature #91 WI-8b (slice 6: AIChatViewModel agentic-branch logic)
+
+Gate-4 implementation audit (rule 47). Independent Codex runner via
+`scripts/run-codex.sh -e high` (author/auditor separation, rule 48; rule-53
+stdin-isolated watchdog).
+
+## Scope
+
+WI-8b slice 6 — the **VM-branch logic** (FOUNDATIONAL — dormant until the
+construction-site registry wiring activates it):
+
+- `vreader/Services/AI/AIService.swift` — `streamRequest(_:using:)` (gate-rechecking,
+  pinned config; mirrors `sendRequest(_:using:)`).
+- `vreader/ViewModels/AIChatViewModel.swift` — injected `featureFlags` +
+  `agenticRegistry`; `sendMessage` resolves the provider ONCE when `agenticTools` is
+  live-ON + a non-empty registry is injected → agentic loop if `supportsToolUse`,
+  else stream via the SAME pinned config; otherwise the unchanged streaming path.
+  `runAgenticTurn` + `consumeStream` helpers.
+- `vreaderTests/ViewModels/AIChatViewModelAgenticTests.swift` (new) — 7 tests.
+
+## Round 1 — findings (threadId 019e9386-9cc9-74d2-91f3-8f3a9401f352)
+
+The success/error/`assistantIndex` paths were confirmed sound (assistant content is
+written only after driver success, so the existing `catch` cleanup matches the
+streaming path). Findings:
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| ReaderAICoordinator.swift / LibraryView.swift | High×2 | The branch is unreachable — both construction sites build `AIChatViewModel` without an injected `agenticRegistry`. | **Reclassified as deferred scope (round 2), not a code defect.** This slice is the VM-branch logic (foundational, dormant); the construction-site registry wiring needs a shared **Services-layer** persistent-`SearchIndexStore` factory (the persistent store is currently a Views-layer private static; `SearchIndexStore()` is in-memory) — that + Gate-5 device verification is the explicitly-deferred completing slice. |
+| AIChatViewModel.swift fallback | **Medium** | The `supportsToolUse == false` fallback did an EXTRA `resolveToolProvider()` then `streamRequest()` → profile/consent/key could drift between the probe and the stream. | **Fixed.** Added `AIService.streamRequest(_:using:)`; `sendMessage` resolves ONCE — if non-tool, streams through the SAME pinned config (no re-resolve). |
+| AIChatViewModel.swift gate | **Medium** | Agentic enablement was latched by the injected registry, not the live flag — a mid-session `agenticTools` OFF flip would keep using tools. | **Fixed.** Injected `featureFlags`; `sendMessage` re-checks `featureFlags.agenticTools` live. Test `flagOff_fallsBackToStreaming`. |
+| AIChatViewModelAgenticTests.swift | Low | Missing branch-cleanup tests. | **Fixed.** `agenticThrow_removesPlaceholder_setsError`, `agenticEmptyFinalText_removesMessage`, `nonToolProvider_fallsBackToStreaming`. |
+
+## Round 2 — verification (threadId 019e93a1-b782-74f2-af9d-3b3809e7d6af)
+
+**PASS for this foundational slice.** All three round-1 CODE findings RESOLVED
+(single resolution via the pinned-config overload; live-flag re-check; cleanup-path
+coverage). The two prior Highs are correctly classified as deferred scope/wiring
+items, NOT defects in the shipped VM-branch logic. No new code defects.
+
+## Verdict
+
+**ship-as-is** (foundational). Zero open code Critical/High/Medium. Test gate green:
+`AIChatViewModelAgenticTests` (7 — agentic path without streaming, flag-OFF / no-
+registry / non-tool fallbacks, citation suppression, throw-cleanup, empty-finalText
+removal) + the `AIChatViewModelTests` streaming regression.
+
+Remaining for #91 `DONE`: the construction-site registry wiring (a shared
+Services-layer persistent-`SearchIndexStore` factory + injecting the registry at
+`ReaderAICoordinator`/`LibraryView` under the flag) + `docs/architecture.md`, then
+Gate-5 device verification → `VERIFIED`.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 876
-        MARKETING_VERSION: 3.51.20
+        CURRENT_PROJECT_VERSION: 877
+        MARKETING_VERSION: 3.51.21
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7541,7 +7541,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 876;
+				CURRENT_PROJECT_VERSION = 877;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7549,7 +7549,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.20;
+				MARKETING_VERSION = 3.51.21;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7695,7 +7695,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 876;
+				CURRENT_PROJECT_VERSION = 877;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7703,7 +7703,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.51.20;
+				MARKETING_VERSION = 3.51.21;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -861,6 +861,7 @@
 		88FC2400338EE530ECAE8E9A /* structure.c in Sources */ = {isa = PBXBuildFile; fileRef = A7EBC969B5DD8804D6AFF3DD /* structure.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		891E1E70B176150B071E464F /* AIContextExtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20237121BB4ACF22C0818BA4 /* AIContextExtractorTests.swift */; };
 		892A9F3136477F52D3AECE11 /* text-walker.js in Resources */ = {isa = PBXBuildFile; fileRef = 43CD38D8708AAE752995001B /* text-walker.js */; };
+		899A8EDE1AC66460CA1992EB /* AIChatViewModelAgenticTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795229C80DBDAAE4FE8E66F2 /* AIChatViewModelAgenticTests.swift */; };
 		89B733D394A024A550FDC0F1 /* TXTReaderContainerView+DebugBridgeHighlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CAE98744C71CECB79F67EB /* TXTReaderContainerView+DebugBridgeHighlight.swift */; };
 		89F6E6A39DB88435F76F7D72 /* SettingsToggleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8220CC5FF3C114CFA6B6E3 /* SettingsToggleRow.swift */; };
 		8A1909A1927C0A98F6F8D6D0 /* ReadingStatsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = F75548C00D82133FCD8F0DB3 /* ReadingStatsModels.swift */; };
@@ -2322,6 +2323,7 @@
 		78BD4CC018110BC0C96E2788 /* DebugReaderRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReaderRegistryTests.swift; sourceTree = "<group>"; };
 		78F701D2D5416A758988C808 /* HTTPTTSChunkPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTTSChunkPlayer.swift; sourceTree = "<group>"; };
 		791CB502C8B59E737F15E63C /* VerificationSettingsHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationSettingsHelperTests.swift; sourceTree = "<group>"; };
+		795229C80DBDAAE4FE8E66F2 /* AIChatViewModelAgenticTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatViewModelAgenticTests.swift; sourceTree = "<group>"; };
 		79E3E09003BD79ED972F15D6 /* ChapterTranslationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterTranslationStoreTests.swift; sourceTree = "<group>"; };
 		79F003D569BCC0F29113468A /* EPUBMetadataExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBMetadataExtractorTests.swift; sourceTree = "<group>"; };
 		7A0147BC1F4C66F4EDB21608 /* ReadingDashboardSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDashboardSnapshotTests.swift; sourceTree = "<group>"; };
@@ -3486,6 +3488,7 @@
 				1EE0734EE0796711AE09253D /* AIAssistantViewModelScopeTests.swift */,
 				EA401D8FC3B4F17213528B27 /* AIAssistantViewModelTests.swift */,
 				B90F4EB83CC68406DA14DD94 /* AIChatGeneralTests.swift */,
+				795229C80DBDAAE4FE8E66F2 /* AIChatViewModelAgenticTests.swift */,
 				E861A379A620B769CEA36300 /* AIChatViewModelTests.swift */,
 				88425F3137F5EDCF6D04AB6A /* AIChatViewModelWholeBookTests.swift */,
 				4E7196BED97C3B45955EC89D /* AIProviderPickerViewModelTests.swift */,
@@ -5952,6 +5955,7 @@
 				369D003DCE5F36A64E5C1C06 /* AIChatGeneralTests.swift in Sources */,
 				62BE094A6E99C25AD7880CE4 /* AIChatMessageRowTests.swift in Sources */,
 				4553F7F292278C1995E28192 /* AIChatViewContrastTests.swift in Sources */,
+				899A8EDE1AC66460CA1992EB /* AIChatViewModelAgenticTests.swift in Sources */,
 				05BE70789318FA085B9A735E /* AIChatViewModelTests.swift in Sources */,
 				668309455FFECACFE6B0368D /* AIChatViewModelWholeBookTests.swift in Sources */,
 				C81C50DAC16681379E93FC9D /* AIConfigurationTests.swift in Sources */,

--- a/vreader/Services/AI/AIService.swift
+++ b/vreader/Services/AI/AIService.swift
@@ -133,6 +133,18 @@ actor AIService {
         return resolvedProvider.streamRequest(request)
     }
 
+    /// Stream through a PINNED resolved config (re-checking the live flag + consent),
+    /// so a caller that already resolved once — e.g. the agentic chat probing
+    /// `supportsToolUse` — can fall back to streaming WITHOUT re-resolving (no
+    /// profile/model/key drift between the probe and the stream — Feature #91 Gate-4).
+    func streamRequest(
+        _ request: AIRequest, using config: ResolvedAIProviderConfig
+    ) async throws -> AsyncThrowingStream<AIStreamChunk, Error> {
+        guard featureFlags.aiAssistant else { throw AIError.featureDisabled }
+        guard consentManager.hasConsent else { throw AIError.consentRequired }
+        return providerInstance(for: config).streamRequest(request)
+    }
+
     /// Clears the response cache. Called when consent is revoked.
     func clearCache() async {
         await cache.clearAll()

--- a/vreader/ViewModels/AIChatViewModel.swift
+++ b/vreader/ViewModels/AIChatViewModel.swift
@@ -125,6 +125,16 @@ final class AIChatViewModel {
 
     private let aiService: AIService
 
+    /// Feature #91: live feature-flag source, so the agentic path re-checks the
+    /// CURRENT `agenticTools` value each send (a mid-session OFF flip falls back to
+    /// streaming — Gate-4 Medium), not a value latched at construction.
+    private let featureFlags: FeatureFlags
+
+    /// Feature #91: the agentic tool registry. nil/empty (or a non-tool provider, or
+    /// the flag OFF) → the chat uses the existing streaming path unchanged. The
+    /// construction site builds + injects this; activation is gated on the live flag.
+    private let agenticRegistry: AIToolRegistry?
+
     // MARK: - Init
 
     /// Creates a new chat view model.
@@ -133,14 +143,22 @@ final class AIChatViewModel {
     ///   - aiService: The AI service for sending requests.
     ///   - bookFingerprint: If non-nil, book context is included in requests.
     ///   - contextWindowSize: Max messages in the sliding context window (default 10).
+    ///   - featureFlags: live flag source for the agentic gate (default `.shared`).
+    ///   - agenticRegistry: Feature #91 — when non-nil + non-empty AND `agenticTools`
+    ///     is on AND the resolved provider supports tool-use, the chat routes through
+    ///     the agentic loop.
     init(
         aiService: AIService,
         bookFingerprint: DocumentFingerprint? = nil,
-        contextWindowSize: Int = 10
+        contextWindowSize: Int = 10,
+        featureFlags: FeatureFlags = .shared,
+        agenticRegistry: AIToolRegistry? = nil
     ) {
         self.aiService = aiService
         self.bookFingerprint = bookFingerprint
         self.contextWindowSize = contextWindowSize
+        self.featureFlags = featureFlags
+        self.agenticRegistry = agenticRegistry
     }
 
     // MARK: - Actions
@@ -193,14 +211,20 @@ final class AIChatViewModel {
             messages.append(assistantMessage)
             let assistantIndex = messages.count - 1
 
-            let stream = try await aiService.streamRequest(request)
-            for try await chunk in stream {
-                messages[assistantIndex].content += chunk.text
-            }
-
-            // If streaming produced no content, remove the empty message
-            if messages[assistantIndex].content.isEmpty {
-                messages.remove(at: assistantIndex)
+            // Feature #91: when `agenticTools` is on (live) AND a non-empty registry is
+            // injected, resolve the provider ONCE. If it supports tool-use, run the
+            // agentic loop; otherwise stream through the SAME pinned config (no second
+            // resolution — Gate-4 Medium). Otherwise the default streaming path.
+            if featureFlags.agenticTools, let registry = agenticRegistry, !registry.isEmpty {
+                let (config, supportsToolUse) = try await aiService.resolveToolProvider()
+                if supportsToolUse {
+                    try await runAgenticTurn(assistantIndex: assistantIndex, config: config, registry: registry)
+                } else {
+                    try await consumeStream(
+                        aiService.streamRequest(request, using: config), into: assistantIndex)
+                }
+            } else {
+                try await consumeStream(aiService.streamRequest(request), into: assistantIndex)
             }
         } catch let aiError as AIError {
             // Remove empty assistant message if it was added
@@ -214,6 +238,51 @@ final class AIChatViewModel {
                 messages.removeLast()
             }
             errorMessage = error.localizedDescription
+        }
+    }
+
+    /// Consume a stream into the assistant message, removing it if no content
+    /// arrived (the historical streaming behavior, factored out so the agentic
+    /// fallback shares it).
+    private func consumeStream(
+        _ stream: AsyncThrowingStream<AIStreamChunk, Error>, into assistantIndex: Int
+    ) async throws {
+        for try await chunk in stream {
+            messages[assistantIndex].content += chunk.text
+        }
+        if messages[assistantIndex].content.isEmpty {
+            messages.remove(at: assistantIndex)
+        }
+    }
+
+    /// Feature #91: run the bounded agentic loop through the PINNED `config` and
+    /// write the single final answer into the assistant message. Suppresses the
+    /// "Drew on" citation stamp on a tool-driven reply (the pre-send snapshot
+    /// doesn't reflect what tools read — Gate-2 Medium 3). Throws propagate to
+    /// `sendMessage`'s catch, which clears the empty assistant message.
+    private func runAgenticTurn(
+        assistantIndex: Int, config: ResolvedAIProviderConfig, registry: AIToolRegistry
+    ) async throws {
+        // The empty assistant placeholder appended above is dropped by the mapper,
+        // so the history ends on the user's prompt; the current book's UNTRUSTED
+        // context rides as a leading user turn.
+        var history = AIChatHistoryMapper.toolTurns(from: messages, window: contextWindowSize)
+        if let prelude = AIChatHistoryMapper.contextPrelude(bookContext: bookContext) {
+            history.insert(prelude, at: 0)
+        }
+        let result = try await AgenticChatDriver().run(
+            systemPrompt: AIChatHistoryMapper.systemPrompt(),
+            history: history,
+            registry: registry,
+            provider: AIServiceToolUseAdapter(service: aiService, config: config),
+            maxTokens: config.maxTokens)
+
+        messages[assistantIndex].content = result.finalText
+        if result.usedTools {
+            messages[assistantIndex].citations = []
+        }
+        if messages[assistantIndex].content.isEmpty {
+            messages.remove(at: assistantIndex)
         }
     }
 

--- a/vreaderTests/ViewModels/AIChatViewModelAgenticTests.swift
+++ b/vreaderTests/ViewModels/AIChatViewModelAgenticTests.swift
@@ -1,0 +1,145 @@
+// Purpose: Feature #91 WI-8b — pin the AIChatViewModel agentic branch: when the
+// live `agenticTools` flag is ON, a non-empty registry is injected, AND the
+// resolved provider supports tool-use, the chat routes through AgenticChatDriver
+// (single final answer, no streaming) and suppresses citations on a tool reply;
+// otherwise it falls back to streaming (flag OFF, no registry, or non-tool
+// provider — via the SAME resolved config). Plus the branch cleanup paths.
+//
+// @coordinates-with: AIChatViewModel.swift, AgenticChatDriver.swift,
+//   AIChatAgenticSupport.swift, dev-docs/plans/20260603-feature-91-agentic-tool-calling.md (WI-8)
+
+import Testing
+import Foundation
+@testable import vreader
+
+private final class ScriptedToolProvider: AIProvider, @unchecked Sendable {
+    let providerName = "Scripted"
+    let supports: Bool
+    private var turns: [AIToolTurn]
+    let throwsOnTool: Bool
+    private(set) var streamCalled = false
+
+    init(supports: Bool = true, turns: [AIToolTurn] = [.text("agentic answer")], throwsOnTool: Bool = false) {
+        self.supports = supports
+        self.turns = turns
+        self.throwsOnTool = throwsOnTool
+    }
+    var supportsToolUse: Bool { supports }
+    func sendRequest(_ request: AIRequest) async throws -> AIResponse { throw AIError.invalidResponse }
+    func streamRequest(_ request: AIRequest) -> AsyncThrowingStream<AIStreamChunk, Error> {
+        streamCalled = true
+        return AsyncThrowingStream { c in
+            c.yield(AIStreamChunk(text: "STREAMED", isComplete: true)); c.finish()
+        }
+    }
+    func sendToolRequest(_ request: AIToolRequest) async throws -> AIToolTurn {
+        if throwsOnTool { throw AIError.invalidResponse }
+        return turns.isEmpty ? .text("(end)") : turns.removeFirst()
+    }
+}
+
+private struct NoopTool: AITool {
+    var definition: ToolDefinition {
+        ToolDefinition(name: "noop", description: "noop", inputSchema: .object([:]))
+    }
+    func run(_ input: JSONValue) async -> ToolResult {
+        ToolResult(toolUseID: "", content: "noop ran", isError: false)
+    }
+}
+
+@Suite("Feature #91 WI-8b — AIChatViewModel agentic branch")
+struct AIChatViewModelAgenticTests {
+
+    @MainActor
+    private func makeSUT(
+        provider: ScriptedToolProvider, registry: AIToolRegistry?, flagOn: Bool = true
+    ) async -> AIChatViewModel {
+        let prefs = MockPreferenceStore()
+        prefs.set("true", forKey: DefaultProviderProfileMigrator.migrationFlagKey)
+        let keychain = KeychainService(serviceIdentifier: "com.vreader.test.\(UUID().uuidString)")
+        let store = ProviderProfileStore(
+            preferences: prefs, migrator: DefaultProviderProfileMigrator(), keychain: keychain)
+        let profile = ProviderProfile(
+            id: UUID(), name: "T", kind: .openAICompatible,
+            baseURL: URL(string: "https://x.example.com/v1")!, model: "m",
+            temperature: 0.5, maxTokens: 1000)
+        try? keychain.saveAPIKey("sk-test", forProfile: profile.id)
+        await store.upsert(profile)
+        await store.setActiveProfileID(profile.id)
+
+        let flags = FeatureFlags(environment: .prod)
+        flags.setOverride(true, for: .aiAssistant)
+        if flagOn { flags.setOverride(true, for: .agenticTools) }
+        let service = AIService(
+            featureFlags: flags,
+            consentManager: WI11TestHelpers.makeConsentManager(hasConsent: true),
+            keychainService: keychain, provider: provider, profileStore: store)
+        return AIChatViewModel(
+            aiService: service, featureFlags: flags, agenticRegistry: registry)
+    }
+
+    @Test @MainActor func agenticPath_producesFinalAnswer_withoutStreaming() async {
+        let provider = ScriptedToolProvider(turns: [.text("agentic answer")])
+        let vm = await makeSUT(provider: provider, registry: AIToolRegistry([NoopTool()]))
+        await vm.sendMessage("what is X?")
+        #expect(vm.messages.last?.content == "agentic answer")
+        #expect(provider.streamCalled == false)
+        #expect(vm.errorMessage == nil)
+    }
+
+    @Test @MainActor func flagOff_fallsBackToStreaming() async {
+        // Live flag re-check: registry injected but the flag is OFF → streaming.
+        let provider = ScriptedToolProvider()
+        let vm = await makeSUT(provider: provider, registry: AIToolRegistry([NoopTool()]), flagOn: false)
+        await vm.sendMessage("hi")
+        #expect(provider.streamCalled == true)
+        #expect(vm.messages.last?.content == "STREAMED")
+    }
+
+    @Test @MainActor func noRegistry_fallsBackToStreaming() async {
+        let provider = ScriptedToolProvider()
+        let vm = await makeSUT(provider: provider, registry: nil)
+        await vm.sendMessage("hi")
+        #expect(provider.streamCalled == true)
+        #expect(vm.messages.last?.content == "STREAMED")
+    }
+
+    @Test @MainActor func nonToolProvider_fallsBackToStreaming() async {
+        let provider = ScriptedToolProvider(supports: false)
+        let vm = await makeSUT(provider: provider, registry: AIToolRegistry([NoopTool()]))
+        await vm.sendMessage("hi")
+        #expect(provider.streamCalled == true)
+        #expect(vm.messages.last?.content == "STREAMED")
+    }
+
+    @Test @MainActor func toolDrivenReply_suppressesCitations() async {
+        let provider = ScriptedToolProvider(turns: [
+            .toolUse(blocks: [.toolUse(ToolCall(id: "c", name: "noop", input: .object([:])))]),
+            .text("done"),
+        ])
+        let vm = await makeSUT(provider: provider, registry: AIToolRegistry([NoopTool()]))
+        vm.pendingCitations = [ChatCitation(sourceKind: .scope, label: "Chapter 1")]
+        await vm.sendMessage("q")
+        #expect(vm.messages.last?.content == "done")
+        #expect(vm.messages.last?.citations.isEmpty == true)
+    }
+
+    @Test @MainActor func agenticThrow_removesPlaceholder_setsError() async {
+        let provider = ScriptedToolProvider(throwsOnTool: true)
+        let vm = await makeSUT(provider: provider, registry: AIToolRegistry([NoopTool()]))
+        await vm.sendMessage("q")
+        #expect(vm.errorMessage != nil)
+        // The empty assistant placeholder was removed; only the user message remains.
+        #expect(vm.messages.last?.role == .user)
+        #expect(vm.messages.count == 1)
+    }
+
+    @Test @MainActor func agenticEmptyFinalText_removesMessage() async {
+        let provider = ScriptedToolProvider(turns: [.text("")])
+        let vm = await makeSUT(provider: provider, registry: AIToolRegistry([NoopTool()]))
+        await vm.sendMessage("q")
+        #expect(vm.errorMessage == nil)
+        #expect(vm.messages.last?.role == .user)   // empty agentic answer → message removed
+        #expect(vm.messages.count == 1)
+    }
+}


### PR DESCRIPTION
## Summary

The `AIChatViewModel.sendMessage` agentic-branch **logic** (a WI-8b slice; the construction-site registry wiring + device verification are the completing slice). When `agenticTools` is **live-on** AND a non-empty registry is injected, `sendMessage` resolves the provider **once**: if it supports tool-use → run `AgenticChatDriver` (one final answer, no streaming) + suppress citations on a tool reply; else stream through the **same pinned config**. Flag OFF / no registry → the existing streaming path, unchanged.

- **`AIService.streamRequest(_:using:)`** (gate-rechecking, pinned config; mirrors `sendRequest(_:using:)`) — the non-tool fallback streams **without a second resolve** (no profile/model/key drift).
- **Injected `featureFlags`** — the agentic gate re-checks the **live** `agenticTools` each send (a mid-session OFF flip falls back to streaming), not a value latched at construction.

Part of feature #1482.

## Codex Audit

2 rounds, `ship-as-is` (PASS for this foundational slice):
- **r1 Medium** — double-resolution drift → single resolution via the new `streamRequest(_:using:)`.
- **r1 Medium** — latched flag → injected `featureFlags` + live re-check.
- **r1 Low** — cleanup-path tests (throw-cleanup, empty-finalText, fallback parity).
- **The 2 r1 Highs** ("branch unreachable without wiring") are reclassified in r2 as **deferred scope** — the construction-site registry wiring needs a shared **Services-layer** persistent-`SearchIndexStore` factory (`SearchIndexStore()` is in-memory; the persistent FTS DB is a Views-layer private static), which + Gate-5 device verification is the completing slice. **Not code defects** in this slice.
- **r2** — all code findings RESOLVED, no new defects.

Audit log: `.claude/codex-audits/feat-feature-91-wi-8b-vm-branch-audit.md`

## Validation

- [x] `scripts/run-tests.sh vreaderTests/AIChatViewModelAgenticTests vreaderTests/AIChatViewModelTests` → `SUCCEEDED` (7 agentic tests + streaming regression)
- [x] TDD: RED → GREEN → 2 audit rounds
- [x] Version bumped: 3.51.20 → 3.51.21 (foundational → patch)

## Verification tier

Foundational — the branch is **dormant** until the construction site injects the registry under the flag (no user-visible change). The VM logic is unit-tested; end-to-end is device-verified at the completing slice's acceptance pass.

## Type of Change

- [x] New feature work item (Part of feature #1482)