### PR TITLE
feat(#87 WI-2): Translate stop — active language pill morphs to Stop

### DIFF
--- a/.claude/codex-audits/feat-feature-87-wi-2-translate-stop-audit.md
+++ b/.claude/codex-audits/feat-feature-87-wi-2-translate-stop-audit.md
@@ -1,0 +1,25 @@
+---
+branch: feat/feature-87-wi-2-translate-stop
+threadId: 019e969d-5c6c-7093-bb20-94b92d64a239
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-05
+---
+
+# Gate-4 Implementation Audit — Feature #87 WI-2 (Translate stop)
+
+Independent Codex audit (author = orchestrator; auditor = Codex via `scripts/run-codex.sh`). 2 rounds → `ship-as-is`.
+
+## Scope
+`vreader/ViewModels/AITranslationViewModel.swift` (public `cancelStreaming()`), `vreader/Views/Reader/TranslateLanguageRail.swift` + `TranslationPanel.swift` (in-place Stop morph), `vreaderTests/ViewModels/AITranslationTests.swift`.
+
+## Round 1 — Codex `019e9697-3759-70a1-bd0f-ee1406b48bfc`
+| file:line | sev | issue | resolution |
+|---|---|---|---|
+| TranslationPanel.swift:53 | Medium | Stop was a SEPARATE standalone button in `loadingView`, not the language control "doubling as the stop affordance" — a Rule-51 / design mismatch that changed the interaction model | **Fixed**: the `TranslateLanguageRail` active (`selected`) pill morphs IN PLACE into the Stop control (white square + sweeping ring + "Stop") while `isLoading`; its tap runs `onStop` (`cancelStreaming`) instead of `onSelect`. `loadingView` reverted to a plain status indicator. |
+
+## Round 2 — Codex `019e969d-5c6c-7093-bb20-94b92d64a239`
+"No remaining or new Critical/High/Medium issues found." Verdict: `ship-as-is`.
+
+## Verdict
+`ship-as-is`. `cancelStreaming()` leverages the existing post-`await` guards (`translate`'s `guard !Task.isCancelled` + `applyFailure`) so a stopped translate lands no result/error; the rail morph is design-faithful (Rule 51 — the language control doubles as the stop affordance) with defaulted params keeping existing call sites compiling. `AITranslationViewModelTests` green (incl. `cancelStreaming_stopsTranslate_clearsLoading_noError`).

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 888
-        MARKETING_VERSION: 3.54.2
+        CURRENT_PROJECT_VERSION: 889
+        MARKETING_VERSION: 3.54.3
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7573,7 +7573,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 888;
+				CURRENT_PROJECT_VERSION = 889;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7581,7 +7581,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.54.2;
+				MARKETING_VERSION = 3.54.3;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7727,7 +7727,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 888;
+				CURRENT_PROJECT_VERSION = 889;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7735,7 +7735,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.54.2;
+				MARKETING_VERSION = 3.54.3;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/ViewModels/AITranslationViewModel.swift
+++ b/vreader/ViewModels/AITranslationViewModel.swift
@@ -205,4 +205,15 @@ final class AITranslationViewModel {
         errorMessage = nil
         isLoading = false
     }
+
+    /// Feature #87 WI-2: user-triggered Stop of an in-flight translate. Cancels the
+    /// task and clears `isLoading`; surfaces NO error (a user stop is not a failure
+    /// — the post-`await` guard in `translate` + `applyFailure` already drop a
+    /// cancelled task's result/error). Does NOT wipe `originalText`/`translatedText`
+    /// (a Stop keeps any prior result; that's `reset()`'s job).
+    func cancelStreaming() {
+        translateTask?.cancel()
+        translateTask = nil
+        isLoading = false
+    }
 }

--- a/vreader/Views/Reader/TranslateLanguageRail.swift
+++ b/vreader/Views/Reader/TranslateLanguageRail.swift
@@ -45,6 +45,15 @@ struct TranslateLanguageRail: View {
     /// EVERY tap — including a re-tap of `selected`.
     var onSelect: (String) -> Void
 
+    /// Feature #87 WI-2: true while a translate is in flight. The active
+    /// (`selected`) pill then morphs IN PLACE into the Stop affordance (the
+    /// design's "the language control doubles as the stop affordance"), and
+    /// tapping it runs `onStop` instead of re-requesting that language.
+    var isLoading: Bool = false
+
+    /// Runs when the morphed Stop pill is tapped (aborts the in-flight translate).
+    var onStop: () -> Void = {}
+
     // MARK: - Tap behaviour
 
     /// Builds the tap action for a single pill. Exposed `static` so the
@@ -82,11 +91,10 @@ struct TranslateLanguageRail: View {
     /// still fires `onSelect`.
     private func pill(for language: String) -> some View {
         let isSelected = language == selected
-        return Button(action: Self.tapAction(for: language, onSelect: onSelect)) {
-            Text(language)
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(isSelected ? Color.white : Color(theme.inkColor))
-                .lineLimit(1)
+        // Feature #87 WI-2: the active pill becomes the Stop control while loading.
+        let isStop = isLoading && isSelected
+        return Button(action: isStop ? onStop : Self.tapAction(for: language, onSelect: onSelect)) {
+            pillLabel(language: language, isSelected: isSelected, isStop: isStop)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
                 .background(
@@ -94,8 +102,37 @@ struct TranslateLanguageRail: View {
                 )
         }
         .buttonStyle(.plain)
-        .accessibilityIdentifier("translateLanguagePill-\(language)")
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityIdentifier(isStop ? "translateStopPill" : "translateLanguagePill-\(language)")
+        .accessibilityLabel(isStop ? "Stop" : language)
+        .accessibilityAddTraits(isSelected && !isStop ? .isSelected : [])
+    }
+
+    /// The pill's content: the language label, or — when this pill is the active
+    /// Stop control — a white square + sweeping ring + "Stop" (the Chat stop visual).
+    @ViewBuilder
+    private func pillLabel(language: String, isSelected: Bool, isStop: Bool) -> some View {
+        if isStop {
+            HStack(spacing: 5) {
+                ZStack {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .tint(.white)
+                        .scaleEffect(0.7)
+                    Image(systemName: "square.fill")
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundStyle(.white)
+                }
+                .frame(width: 14, height: 14)
+                Text("Stop")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(Color.white)
+            }
+        } else {
+            Text(language)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(isSelected ? Color.white : Color(theme.inkColor))
+                .lineLimit(1)
+        }
     }
 
     // MARK: - Palette

--- a/vreader/Views/Reader/TranslationPanel.swift
+++ b/vreader/Views/Reader/TranslationPanel.swift
@@ -54,7 +54,9 @@ struct TranslationPanel: View {
                 languages: viewModel.supportedLanguages,
                 selected: viewModel.targetLanguage,
                 theme: theme,
-                onSelect: requestTranslation
+                onSelect: requestTranslation,
+                isLoading: viewModel.isLoading,           // #87 WI-2: active pill → Stop
+                onStop: { viewModel.cancelStreaming() }
             )
 
             Color(theme.ruleColor).frame(height: 0.5)
@@ -142,6 +144,9 @@ struct TranslationPanel: View {
 
     @ViewBuilder
     private var loadingView: some View {
+        // Feature #87 WI-2: the Stop affordance lives on the active language pill
+        // (the rail's selected pill morphs to Stop while loading — see
+        // TranslateLanguageRail). This view is just the in-flight status.
         VStack(spacing: 14) {
             Spacer()
 
@@ -149,8 +154,9 @@ struct TranslationPanel: View {
                 .controlSize(.large)
                 .tint(Color(theme.accentColor))
 
-            Text("Translating\u{2026}")
+            Text("Translating\u{2026} Tap the active language to stop")
                 .font(.system(size: 13))
+                .multilineTextAlignment(.center)
                 .foregroundStyle(Color(theme.subColor))
 
             Spacer()

--- a/vreaderTests/ViewModels/AITranslationTests.swift
+++ b/vreaderTests/ViewModels/AITranslationTests.swift
@@ -699,4 +699,33 @@ struct AITranslationViewModelTests {
         let finalCallCount = await gated.sendRequestCallCount
         #expect(finalCallCount == 1)
     }
+
+    // MARK: - Stop control (feature #87 WI-2)
+
+    @Test @MainActor func cancelStreaming_stopsTranslate_clearsLoading_noError() async {
+        // Feature #87 WI-2: a user Stop aborts an in-flight translate — `isLoading`
+        // clears immediately, no error surfaces, and the cancelled task lands no
+        // result (the post-`await` guard in `translate` + `applyFailure` hold).
+        let (vm, gated) = makeGatedViewModel()
+        await gated.stubResponse(
+            AIResponse(content: "译文", actionType: .translate, promptVersion: "v1", createdAt: Date()),
+            forCall: 0)
+
+        let t = Task { @MainActor in
+            await vm.translate(originalText: "hello", locator: WI11TestHelpers.makeLocator(),
+                               format: .txt, targetLanguage: "Chinese")
+        }
+        while await gated.sendRequestCallCount < 1 { await Task.yield() }   // parked on the gate
+        #expect(vm.isLoading == true)
+
+        vm.cancelStreaming()
+        #expect(vm.isLoading == false)
+        #expect(vm.errorMessage == nil)
+
+        // Release the gate; the cancelled task must not write a result or an error.
+        await gated.release(callIndex: 0)
+        await t.value
+        #expect(vm.translatedText == nil, "a stopped translate lands no result")
+        #expect(vm.errorMessage == nil, "a user stop is not an error")
+    }
 }


### PR DESCRIPTION
## Summary

- While a translate is in flight, the `TranslateLanguageRail` active (selected) pill morphs **in place** into a Stop control (white square + sweeping ring + "Stop"); tapping it aborts via the new `AITranslationViewModel.cancelStreaming()`.
- Design-faithful: the language control doubles as the stop affordance (Rule 51), rather than a separate button.

Part of feature #1518.

## WI Status
- WI-2: behavioral — this PR. Remaining: WI-3 Summary stop (VM-lifecycle refactor).

## Codex Audit (Gate 4)
2 rounds (`019e9697` → `019e969d`), final **ship-as-is**. Round 1 caught a Rule-51 mismatch (separate stop button vs the control doubling as stop) — fixed by the in-place pill morph. Audit log: `.claude/codex-audits/feat-feature-87-wi-2-translate-stop-audit.md`.

## Validation
- [x] `scripts/run-tests.sh vreaderTests/AITranslationViewModelTests` → `RUN-TESTS RESULT: SUCCEEDED` (incl. `cancelStreaming_stopsTranslate_clearsLoading_noError`)
- [x] Codex audit ship-as-is (2 rounds)
- [x] Version bumped: 3.54.2 → 3.54.3 (patch — behavioral, non-final WI)

## Gate 5a Verification
Tier: behavioral. The cancel logic is unit-verified; the rail-pill Stop morph is design-faithful in-place. Live abort observation is provider-gated → deferred to the feature's final Gate-5b acceptance.

## Type of Change
- [x] Feature WI (Part of feature #1518)