### PR TITLE
feat(#88 WI-3): AIChatViewModel session lifecycle on a serialized async lane

### DIFF
--- a/.claude/codex-audits/feat-feature-88-wi-3-vm-session-lifecycle-audit.md
+++ b/.claude/codex-audits/feat-feature-88-wi-3-vm-session-lifecycle-audit.md
@@ -1,0 +1,128 @@
+---
+branch: feat/feature-88-wi-3-vm-session-lifecycle
+threadId: 019e978b-d907-7cc3-90e6-c64171850987
+rounds: 7
+final_verdict: follow-up-recommended
+date: 2026-06-05
+---
+
+# Gate-4 audit — Feature #88 WI-3 (AIChatViewModel session lifecycle + streaming handoff)
+
+WI-3 adds the chat-session lifecycle to `AIChatViewModel`: one-shot load of the
+most-recent non-empty session, lazy create-on-first-turn, debounced settled-turn
+save, and the switch / new / rename / delete transitions — wired into the
+streaming send path (`+Streaming`). Because every one of these mutates the same
+small state set (`messages` / `settledMessages` / `activeSessionId` / the store)
+across `await`s on the @MainActor, the audit centered on **async interleaving**.
+
+## Round history
+
+The point-patch rounds (1–5) each found a real new interleaving and fixed it
+with a targeted guard. Round 5 concluded the *class* was not closeable by more
+await-boundary patches and recommended a **structural** fix; round 6 audited the
+structural fix and found one separate (non-interleaving) High, now fixed.
+
+| Round | Finding (sev) | Resolution |
+|---|---|---|
+| 1 | Load-hook reruns on Chat-tab re-entry → clobbers a fresh thread (High) | `loadedFingerprintKey` idempotency + non-clobber guard |
+| 2 | Orphan session left when a transition races the first-turn create (High); orphan-cleanup delete silently swallowed (Medium) | delete the orphan when the token changed mid-create; log (not swallow) a cleanup-delete failure |
+| 3 | Test-gate arming was fire-and-forget → nondeterministic gate miss (Medium) | `gateFetch`/`gateUpdate`/… arm `async` + awaited before the raced task |
+| 4 | A transition racing an existing-session settled-turn UPDATE seals the STALE snapshot → just-settled turn lost (High) | promote `settledMessages = snapshot` BEFORE the `updateChatSession` await |
+| 5 | Whole interleaving class not closeable by point patches (structural) | **moved ALL session-mutating ops onto one serialized async lane** (`runSerializedSessionOp`) — see below |
+| 6 | `deleteSession` cancels the active stream + bumps `opCounter` even for a NON-active delete → active turn's save skipped, lost (High) | gate the transition-style cancel/token-bump on `id == activeSessionId` |
+| 7 | (confirming audit of the round-6 fix, threadId `019e978b`) | **clean** — round-6 High resolved, no new Critical/High/Medium |
+
+## Round 5 → the structural fix (closes the interleaving class)
+
+All session-mutating public ops (`loadSessions`, `saveSettledTurn`,
+`switchToSession`, `newConversation`, `renameActiveSession`, `deleteSession`)
+now run their bodies through `runSerializedSessionOp` (`AIChatViewModel.swift:96`):
+it captures the prior chain task, builds a new `@MainActor` Task that `await`s the
+prior then runs the body, assigns the chain, and `await`s its own completion. The
+read-of-prior + write-of-chain happen with no `await` between them, so the
+capture+assign is atomic on the MainActor serial executor → two ops launched
+without awaiting each other **cannot interleave their bodies**. The synchronous
+pre-lane steps (stream cancel + `sessionTransitionToken` bump + `requestedSessionId`)
+stay OUTSIDE the lane so a superseded body still bails early on its token check.
+
+Deadlock constraint honored: no laned public op body calls another laned public
+op; the only helpers invoked inside laned bodies (`sealCurrentSessionIfNeeded`,
+`loadMostRecentRemaining`) are explicitly NON-laned.
+
+## Round 6 — confirming audit of the structural fix (threadId `019e977d`)
+
+Codex confirmed, with line references:
+
+- **Q1 serialization** — `AIChatViewModel.swift:96` does serialize; the capture+assign is atomic; two un-awaited callers cannot interleave. *No fix.*
+- **Q2 deadlock** — no laned public op awaits another laned public op; helpers are non-laned. *No fix.*
+- **Q3 R5 unrelated-delete-during-save** — **closed** by the lane (delete queues behind the parked save; no interleave). *No fix.*
+- **Q4 pre-lane ordering** — correct for supersession; no lost-update on `activeSessionId`. *No fix.*
+- **Q5 Swift 6 / @MainActor / Sendable** — clean; spawned task + closure are `@MainActor`, the persistence boundary is `Sendable`. File sizes within cap (287 / 183 / 186 / 292). *No fix.*
+- **One High (separate, non-interleaving)** — `AIChatViewModel+SessionTransitions.swift:100` + `+Streaming.swift:178`: `deleteSession` unconditionally treated EVERY delete as a transition (`cancelStreamingForTransition()` + token bump). Deleting an unrelated non-active session B while session A streams cancelled A's stream → `runSend` saw `opId != opCounter` → skipped `saveSettledTurn` → A's latest turn never persisted; a later seal could then write the older snapshot.
+
+### Resolution of the round-6 High (fixed this round)
+
+`deleteSession(_:)` now only performs the transition-style cancel + token bump
+when `id == activeSessionId`; a non-active delete still runs through the
+serialized lane but leaves the active send untouched (no `opCounter` bump → the
+active turn still reaches its settled-turn save). Pinned by a RED→GREEN
+regression test `nonActiveDeleteDuringActiveStream_doesNotCancelStream_norLoseTurn`
+(gates the active stream mid-flight, deletes a non-active session, asserts the
+active turn is still persisted — 4 messages, contains "active q2").
+
+## Round 7 — confirming audit of the round-6 fix (threadId `019e978b`)
+
+Codex verified the one-method `deleteSession` fix with line references:
+(1) the round-6 High is resolved — a non-active delete no longer cancels the
+active stream nor bumps `opCounter`, so `runSend` still reaches `saveSettledTurn`;
+(2) the active-delete-while-streaming path still works (cancel + token bump +
+`wasActive` re-eval + `loadMostRecentRemaining`);
+(3) `wasActive` stays consistent — a non-active delete returns at `guard wasActive`
+before the token check, so the un-bumped token is unused;
+(4) no new interleaving from the un-bumped token — the delete still runs through
+the serialized lane;
+(5) both lane orderings are correct — delete-first → the later switch fetch finds
+no record and returns; switch-first → `_deleteSession` re-evaluates `wasActive` and
+treats it as an active delete at execution time.
+**Verdict: "Round-6 High is resolved. I do not see any new Critical/High/Medium
+issue in this one-method fix."**
+
+## Verdict
+
+`follow-up-recommended`. The structural serial lane closes the whole interleaving
+race class the point-patch rounds were chasing (Q1–Q5 clean), and the one
+separate High found in the confirming audit is fixed + regression-tested. The
+auditor's round-5 recommendation — "move session-mutating work onto one
+serialized async lane before WI-4 adds more surface area" — is now **implemented**,
+so WI-4/WI-5 build on serialized session state rather than a web of await-boundary
+guards. 27 prior session tests + 2 structural tests + this regression test green.
+
+### Test rework forced by the structural change (orchestrator-caught)
+
+The serial lane changed the concurrency model: a session op issued while another
+is parked now QUEUES behind it (it cannot interleave). Five pre-existing
+interleaving tests `await`-ed a transition while a lane op was parked on a test
+gate and only released the gate AFTER that await returned — which now **deadlocks**
+(the awaited op waits for the parked op; the parked op waits for the release that
+never comes). The implementing subagent reported "67/0 passed" but the run had
+actually hung on these 5 (the watchdog `TIMEOUT` was misread as a finalization
+stall); the orchestrator caught it by reading the test `$LOG` directly — only 23
+of 28 session tests flushed, 0 failed, no suite-summary line. The five
+(`rapidSwitch_BthenC`, `coldOpen_sendBeforeLoadResolves`,
+`transitionDuringFirstTurnCreate`, `orphanCleanupFailure`,
+`transitionDuringExistingSessionUpdate`) were reworked to the fire-as-Task
+pattern (fire the second op without awaiting so its synchronous pre-lane bump
+runs, release the gate, drain the lane, then assert the serialized end-state) —
+the same pattern the subagent's own `unrelatedDeleteDuringActiveSave` test uses.
+This is a TEST-design fix, not a production change: production gates resolve, so
+the lane drains normally with no deadlock. **Lesson: trust the test `$LOG`, not a
+subagent's pass claim.**
+
+### Note on round count
+
+This WI exceeded the nominal 3-round Gate-4 cap (6 rounds). The justification is
+recorded here per rule 47's escalation clause: rounds 1–4 were convergent
+point-fixes (each closed a distinct, real race), round 5 was the auditor's own
+structural recommendation (not a new defect), and round 6 confirmed the
+structural fix + found one separate, mechanical High with an obvious fix. The
+work was converging, not thrashing; the structural fix is the durable close-out.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ VReader is an iOS e-book reader built with SwiftUI + SwiftData. It supports TXT,
 ```
 ┌──────────────────────────────────────────────────────┐
 │                    VReaderApp                         │
-│  SwiftData SchemaV8 · PersistenceActor · BookImporter│
+│  SwiftData SchemaV9 · PersistenceActor · BookImporter│
 └─────────────────────┬────────────────────────────────┘
                       │
           ┌───────────┴───────────┐
@@ -34,7 +34,7 @@ VReader is an iOS e-book reader built with SwiftUI + SwiftData. It supports TXT,
 
 ### 1. App Layer (`vreader/App/`)
 
-- `VReaderApp.swift` — SwiftData `ModelContainer` init (SchemaV8), migration plan (V1→V2→V3→V4→V5→V6→V7→V8), test seeding, error handling. Injects the live `PersistenceActor` into the SwiftUI environment via `\.persistenceActor` so settings sub-screens can construct backup providers without rewriting every parent's signature. Adopts `@UIApplicationDelegateAdaptor(VReaderAppDelegate.self)` for background-URLSession completion-handler delivery (feature #47).
+- `VReaderApp.swift` — SwiftData `ModelContainer` init (SchemaV9), migration plan (V1→V2→V3→V4→V5→V6→V7→V8→V9), test seeding, error handling. Injects the live `PersistenceActor` into the SwiftUI environment via `\.persistenceActor` so settings sub-screens can construct backup providers without rewriting every parent's signature. Adopts `@UIApplicationDelegateAdaptor(VReaderAppDelegate.self)` for background-URLSession completion-handler delivery (feature #47).
 - `VReaderAppDelegate.swift` — `UIApplicationDelegate` adapter that captures `application(_:handleEventsForBackgroundURLSession:completionHandler:)` into a MainActor-isolated static dictionary keyed by URLSession identifier. The lazy-download coordinator retrieves and invokes the handler from `LazyDownloadDelegate.urlSessionDidFinishEvents` so iOS releases the app's background-launch grace period.
 
 ### 2. Library Layer (`vreader/Views/LibraryView.swift`, `vreader/ViewModels/LibraryViewModel.swift`)
@@ -233,12 +233,13 @@ Bridge-internal coordinators (`EPUBWebViewBridgeCoordinator`, `FoliateViewCoordi
 
 ### 6. Data Layer (`vreader/Models/`)
 
-SwiftData SchemaV8 entities:
+SwiftData SchemaV9 entities:
 
-- `Book` (fingerprintKey unique; gains `originalExtension: String?` in SchemaV5 for backup blob extension preservation; gains `fileState: String` and `blobPath: String?` in SchemaV6 for feature #47's lazy-load row state) → `ReadingPosition` (gains `vreaderLocatorData: Data?` in SchemaV8 — feature #42's engine-agnostic `VReaderLocator` envelope, stored as raw JSON `Data?` mirroring `Highlight.anchorData`; additive/optional → lightweight migration, no stage), `Highlight`, `Bookmark`, `AnnotationNote`, `BookCollection`
+- `Book` (fingerprintKey unique; gains `originalExtension: String?` in SchemaV5 for backup blob extension preservation; gains `fileState: String` and `blobPath: String?` in SchemaV6 for feature #47's lazy-load row state) → `ReadingPosition` (gains `vreaderLocatorData: Data?` in SchemaV8 — feature #42's engine-agnostic `VReaderLocator` envelope, stored as raw JSON `Data?` mirroring `Highlight.anchorData`; additive/optional → lightweight migration, no stage), `Highlight`, `Bookmark`, `AnnotationNote`, `BookCollection`, `ChatSession` (SchemaV9 cascade child)
 - `ReadingSession`, `ReadingStats`
 - `BookSource`, `ContentReplacementRule` (added in SchemaV4)
 - `ChapterTranslation` (added in SchemaV7 — feature #56 bilingual-reading persistent translation cache; independent entity, no `@Relationship` to `Book`; `lookupKey: String` is the `@Attribute(.unique)` dedupe key joined from `bookFingerprintKey` + `unitStorageKey` + `targetLanguage` + `providerProfileID` + `promptVersion`)
+- `ChatSession` (added in SchemaV9 — feature #88 AI conversation sessions; a `Book.chatSessions` cascade child, one row per persisted chat thread keyed by `bookFingerprintKey`. The conversation is stored as a `ChatSessionPayload` Codable envelope encoded to a `payloadData: Data?` blob — decoupled from the non-Codable runtime `ChatMessage`/`ChatCitation` types; encode-never-wipes + version-gated decode. Carries `title` + `lastMessageSnippet` + `messageCount` + `createdAt`/`updatedAt` for the session list. `PersistenceActor+ChatSessions` is the CRUD seam; `AIChatViewModel`'s session lifecycle (load / lazy-create-on-first-turn / settled-turn save / switch·new·rename·delete transitions) runs every session-mutating op through one serialized async lane so they cannot interleave across `await`s — feature #88 WI-3)
 
 `PersistenceActor.fetchAllBooksForBackup() -> [BackupBookProjection]` (in `PersistenceActor+Backup.swift`) returns a Sendable value-type view of every book — used by feature #46's WebDAV backup to emit `library-manifest.json` without leaking `@Model` instances across the actor boundary. Legacy V4 rows (no `originalExtension`) coalesce to the canonical extension for their format.
 

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 892
-        MARKETING_VERSION: 3.55.2
+        CURRENT_PROJECT_VERSION: 893
+        MARKETING_VERSION: 3.55.3
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -393,6 +393,7 @@
 		3BAE0F10DF996E3F0E5E1FE5 /* ReadiumEPUBHost+BilingualDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B29ECB0699594B79632E3EE /* ReadiumEPUBHost+BilingualDriver.swift */; };
 		3BAE7CA09E5241A14F30A7F4 /* WholeBookReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26F3EB2A31C52E81656141C /* WholeBookReducerTests.swift */; };
 		3C190BFB365BCA80358E99AA /* TTSHighlightCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D721FA5AC22C4EBD49791B48 /* TTSHighlightCoordinator.swift */; };
+		3C2FBA8AA05B5626DC2FC3AF /* AIChatViewModel+Sessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3451F33709B6E268B7CF0485 /* AIChatViewModel+Sessions.swift */; };
 		3C6784421BC6B3DD6F1D3C16 /* BookModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B811BD48F552B167D438BFCF /* BookModelTests.swift */; };
 		3C894F8ED6493D1DF6DB58D6 /* ReadiumEPUBHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0690CFD7EBDB5EFF481F2202 /* ReadiumEPUBHostTests.swift */; };
 		3CAC33209031F93DC4692879 /* MDFileLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6974D0F73862058FC97358 /* MDFileLoaderTests.swift */; };
@@ -512,6 +513,7 @@
 		4EFC0ADF77B237B9D1D37A2F /* ChapterTranslationRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999E14A7BDE872FF420E5E37 /* ChapterTranslationRecord.swift */; };
 		4F2FEC62B6D23F67263EDF34 /* BackupProviderContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED150D276C082FEC194F2F31 /* BackupProviderContractTests.swift */; };
 		4F9B3604353932457F862A56 /* MobiEPUBConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6824BB10509996851B0E86C5 /* MobiEPUBConverter.swift */; };
+		4FB39089E0B193F90021D7BE /* AIChatViewModelSessionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6683E529266E0E54B1A85BA0 /* AIChatViewModelSessionsTests.swift */; };
 		4FDDEB10D3E2014D806618AD /* SyncConflictResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8188B21271D103070EE8CDE6 /* SyncConflictResolver.swift */; };
 		50214665FE48786605E6CF7E /* EPUBHighlightBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435C00E099B7F5D7A7821FDC /* EPUBHighlightBridge.swift */; };
 		50526F6EDA9CF826BAB1552B /* ReadiumDecorationTapEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5FC69D853F6222ADED7DB9 /* ReadiumDecorationTapEventTests.swift */; };
@@ -990,6 +992,7 @@
 		9C8762E2789F97355348E7AA /* MockMDParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E9F1953C017E6B1F990FB44 /* MockMDParser.swift */; };
 		9C87FCF01164A269B85DA51A /* FoliateJSEscaper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58CB10F386B36EF83C36873F /* FoliateJSEscaper.swift */; };
 		9CAC9B0C921E5EBF0C11B1CA /* ReaderAIProvidersFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74429166F68BE798F2EC14C3 /* ReaderAIProvidersFlowTests.swift */; };
+		9CB284CFAFA7A0984032BDA8 /* AIChatViewModelSessionsTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DC0576C2BB5F79C6744494 /* AIChatViewModelSessionsTestHelpers.swift */; };
 		9CD197C006508A9EDE0E28C8 /* TXTContinuousChunkBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D6E992E453F455F4226202 /* TXTContinuousChunkBuilder.swift */; };
 		9D19E2B1B840D00BA2D58376 /* SearchOtherBooksToolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F2B1E6C1AB1225D416D9939 /* SearchOtherBooksToolTests.swift */; };
 		9D28C839CBBFF9BC8727BAF0 /* ChapterTranslation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F49F51FD45D703CEF790F7C /* ChapterTranslation.swift */; };
@@ -1223,6 +1226,7 @@
 		C36236EF98C50E9D4C074A01 /* BookDetailsSheet+Cards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C78911337C79BBAE9B2AB7C /* BookDetailsSheet+Cards.swift */; };
 		C36B9E88E11A37371BDDF225 /* FoliateNavSeek.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD7B08B41BC2F95D59ACC3B /* FoliateNavSeek.swift */; };
 		C36DD49DF8C98812AD95EE37 /* RealDebugBridgeContext+SetLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA70AC0CF70660D3FBBC6169 /* RealDebugBridgeContext+SetLayout.swift */; };
+		C36F297819A5CEC970CCF633 /* AIChatViewModel+SessionTransitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F866E3BC39A82C966DE4AA52 /* AIChatViewModel+SessionTransitions.swift */; };
 		C3BE566C5E906C665C95F68C /* BookDetailsMetadataRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D94746694BD66410FDB471 /* BookDetailsMetadataRow.swift */; };
 		C3E08FC456AC81388D905F7F /* ErrorMessageAuditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C0A7E77EFE308BC9CF8A3FE /* ErrorMessageAuditor.swift */; };
 		C40FEEE617C93C57FCAC49C5 /* FoliateScrollModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1989CF2F582B5C821059BA /* FoliateScrollModelTests.swift */; };
@@ -1900,6 +1904,7 @@
 		33AE4518BC7EBC8968B54CFF /* LibraryBookSearchGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryBookSearchGateTests.swift; sourceTree = "<group>"; };
 		33CA445AA96E5EEBA05B7C36 /* OPDSModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSModels.swift; sourceTree = "<group>"; };
 		33EA0E7BAE9970AB1E1CE063 /* memory.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = memory.c; sourceTree = "<group>"; };
+		3451F33709B6E268B7CF0485 /* AIChatViewModel+Sessions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AIChatViewModel+Sessions.swift"; sourceTree = "<group>"; };
 		35597ECF4679E74A0019B17E /* Feature26TextToSpeechVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature26TextToSpeechVerificationTests.swift; sourceTree = "<group>"; };
 		3595767B5C24F2D437C634BF /* EPUBTextExtractorBilingualTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBTextExtractorBilingualTests.swift; sourceTree = "<group>"; };
 		35A84A99AB99BEE06A942983 /* CoverLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoverLifecycleTests.swift; sourceTree = "<group>"; };
@@ -2258,6 +2263,7 @@
 		66440341C1BA8050AFD3A65C /* EPUBChapterNavigationRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBChapterNavigationRouterTests.swift; sourceTree = "<group>"; };
 		6671E9F8673155BDC726A6ED /* RealDebugBridgeContext+Settle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RealDebugBridgeContext+Settle.swift"; sourceTree = "<group>"; };
 		667AC3E733DFC3883BC89D39 /* AlertDialogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertDialogTests.swift; sourceTree = "<group>"; };
+		6683E529266E0E54B1A85BA0 /* AIChatViewModelSessionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatViewModelSessionsTests.swift; sourceTree = "<group>"; };
 		67368B0914CFE12052417225 /* LazyDownloadCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyDownloadCoordinatorTests.swift; sourceTree = "<group>"; };
 		6782FA6981AE8309748D8E5D /* binary_masquerade.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = binary_masquerade.txt; sourceTree = "<group>"; };
 		67BCECCD4519E437A347DBA5 /* MDAttributedStringRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDAttributedStringRendererTests.swift; sourceTree = "<group>"; };
@@ -2806,6 +2812,7 @@
 		C3F1695C0E7481CB3EA2B8A3 /* WebDAVBackupIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVBackupIntegrationTests.swift; sourceTree = "<group>"; };
 		C42FD55371CD8FA98699541E /* LibraryContextMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryContextMenuTests.swift; sourceTree = "<group>"; };
 		C47343EAD4CE63CDA1604255 /* fixed-layout.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "fixed-layout.js"; sourceTree = "<group>"; };
+		C4DC0576C2BB5F79C6744494 /* AIChatViewModelSessionsTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatViewModelSessionsTestHelpers.swift; sourceTree = "<group>"; };
 		C52103AEAF5528A9DD58625E /* AIConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIConfiguration.swift; sourceTree = "<group>"; };
 		C5959972E9775E5B52E5C840 /* SwiftDataSessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataSessionStoreTests.swift; sourceTree = "<group>"; };
 		C5C46A3D7400CC956FA8D46D /* ProviderKindTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderKindTests.swift; sourceTree = "<group>"; };
@@ -3140,6 +3147,7 @@
 		F8038AAB18412F30C09CBDD9 /* AIConfigurationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIConfigurationStore.swift; sourceTree = "<group>"; };
 		F82AD6F50703DBCA984EBAAC /* UnifiedPagedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedPagedView.swift; sourceTree = "<group>"; };
 		F85E36013A798EB205697B9A /* AISettingsViewModelMultiProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISettingsViewModelMultiProfileTests.swift; sourceTree = "<group>"; };
+		F866E3BC39A82C966DE4AA52 /* AIChatViewModel+SessionTransitions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AIChatViewModel+SessionTransitions.swift"; sourceTree = "<group>"; };
 		F89BB1B1D01EB18947B00C09 /* config.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
 		F8DB79901C559905D3015DD3 /* ChapterPrefetching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterPrefetching.swift; sourceTree = "<group>"; };
 		F8DEE3B767FC8F7457067C11 /* MutationDriftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationDriftTests.swift; sourceTree = "<group>"; };
@@ -3526,6 +3534,8 @@
 				EA401D8FC3B4F17213528B27 /* AIAssistantViewModelTests.swift */,
 				B90F4EB83CC68406DA14DD94 /* AIChatGeneralTests.swift */,
 				795229C80DBDAAE4FE8E66F2 /* AIChatViewModelAgenticTests.swift */,
+				C4DC0576C2BB5F79C6744494 /* AIChatViewModelSessionsTestHelpers.swift */,
+				6683E529266E0E54B1A85BA0 /* AIChatViewModelSessionsTests.swift */,
 				E861A379A620B769CEA36300 /* AIChatViewModelTests.swift */,
 				88425F3137F5EDCF6D04AB6A /* AIChatViewModelWholeBookTests.swift */,
 				4E7196BED97C3B45955EC89D /* AIProviderPickerViewModelTests.swift */,
@@ -4674,6 +4684,8 @@
 				46221600B62F5482365B0484 /* AIAssistantViewModel.swift */,
 				FF7F290BCEE8F6D864F0AC95 /* AIAssistantViewModel+Streaming.swift */,
 				206F4BCC7294731E8A3A82DB /* AIChatViewModel.swift */,
+				3451F33709B6E268B7CF0485 /* AIChatViewModel+Sessions.swift */,
+				F866E3BC39A82C966DE4AA52 /* AIChatViewModel+SessionTransitions.swift */,
 				46AF7DE90554FB3C0C434EEF /* AIChatViewModel+Streaming.swift */,
 				43809A2F181DF2BBEAAD50C5 /* AIProviderPickerViewModel.swift */,
 				82B992B24F86DF8CA23E1215 /* AITranslationViewModel.swift */,
@@ -6010,6 +6022,8 @@
 				62BE094A6E99C25AD7880CE4 /* AIChatMessageRowTests.swift in Sources */,
 				4553F7F292278C1995E28192 /* AIChatViewContrastTests.swift in Sources */,
 				899A8EDE1AC66460CA1992EB /* AIChatViewModelAgenticTests.swift in Sources */,
+				9CB284CFAFA7A0984032BDA8 /* AIChatViewModelSessionsTestHelpers.swift in Sources */,
+				4FB39089E0B193F90021D7BE /* AIChatViewModelSessionsTests.swift in Sources */,
 				05BE70789318FA085B9A735E /* AIChatViewModelTests.swift in Sources */,
 				668309455FFECACFE6B0368D /* AIChatViewModelWholeBookTests.swift in Sources */,
 				C81C50DAC16681379E93FC9D /* AIConfigurationTests.swift in Sources */,
@@ -6666,6 +6680,8 @@
 				56A9335B5F44D301240C81B7 /* AIChatMessageRow.swift in Sources */,
 				5C7330D1B5481B25BA637DA7 /* AIChatView+Composer.swift in Sources */,
 				8E936BF32CF0850398C9D742 /* AIChatView.swift in Sources */,
+				C36F297819A5CEC970CCF633 /* AIChatViewModel+SessionTransitions.swift in Sources */,
+				3C2FBA8AA05B5626DC2FC3AF /* AIChatViewModel+Sessions.swift in Sources */,
 				0FDA2E710B308C43DA57EEBA /* AIChatViewModel+Streaming.swift in Sources */,
 				C8AC5FD914F26F89DA69AA8C /* AIChatViewModel.swift in Sources */,
 				4CC9567091E0CABFDD800F6C /* AIConfiguration.swift in Sources */,
@@ -7613,7 +7629,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 892;
+				CURRENT_PROJECT_VERSION = 893;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7621,7 +7637,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.55.2;
+				MARKETING_VERSION = 3.55.3;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7767,7 +7783,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 892;
+				CURRENT_PROJECT_VERSION = 893;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7775,7 +7791,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.55.2;
+				MARKETING_VERSION = 3.55.3;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/ViewModels/AIChatViewModel+SessionTransitions.swift
+++ b/vreader/ViewModels/AIChatViewModel+SessionTransitions.swift
@@ -1,0 +1,196 @@
+// Purpose: Feature #88 WI-3 — the chat-session TRANSITIONS for AIChatViewModel
+// (switch / new / rename / delete) + their private helpers, split out of
+// `AIChatViewModel+Sessions.swift` to keep both files under the ~300-line guide.
+//
+// Key decisions (Gate-4 structural fix):
+// - EVERY public transition runs its mutating body through the single serialized
+//   lane (`runSerializedSessionOp`, on the base class) so two session-mutating
+//   ops can never interleave across an await on the @MainActor.
+// - The SYNCHRONOUS pre-lane steps stay OUTSIDE the lane: cancel the in-flight
+//   stream + bump `sessionTransitionToken` (+ stash `requestedSessionId` for
+//   switch). This lets a rapid superseding op bump the token before the older
+//   op's laned body runs, so the superseded body bails early on its token check.
+// - DEADLOCK CONSTRAINT: a laned op body must NEVER call another laned PUBLIC op.
+//   The internal helpers `sealCurrentSessionIfNeeded()` / `loadMostRecentRemaining`
+//   are invoked WITHIN laned bodies, so they stay NON-laned.
+//
+// @coordinates-with: AIChatViewModel.swift, AIChatViewModel+Sessions.swift,
+//   AIChatViewModel+Streaming.swift, ChatSessionPersisting.swift
+
+import Foundation
+import OSLog
+
+private let transitionLog = Logger(subsystem: "com.vreader.app", category: "ChatSessions")
+
+extension AIChatViewModel {
+
+    // MARK: - Transitions
+
+    /// Seals the current conversation and resets to the empty state. The former
+    /// `clearHistory` toolbar entry point becomes this. Cancels any in-flight
+    /// stream + bumps the transition token FIRST (so a late reply / in-flight load
+    /// is discarded), seals the current session if it has content, then resets.
+    func newConversation() async {
+        cancelStreamingForTransition()        // synchronous — immediate stream abort, BEFORE the lane
+        sessionTransitionToken &+= 1           // synchronous — a rapid superseding op bumps the token first
+        let token = sessionTransitionToken
+        await runSerializedSessionOp { await self._newConversation(token: token) }
+    }
+
+    private func _newConversation(token: UInt64) async {
+        await sealCurrentSessionIfNeeded()
+        guard token == sessionTransitionToken else { return }
+        messages = []
+        settledMessages = []
+        activeSessionId = nil
+        errorMessage = nil
+    }
+
+    /// Switches to a persisted session: saves the current thread (if it has
+    /// content), loads the target, and replaces `messages` / `activeSessionId`.
+    /// Cancels any in-flight stream + bumps the token + stashes `requestedSessionId`
+    /// synchronously BEFORE the first await; re-checks both after every await so a
+    /// rapid B→C switch lets the newer C win and abandons the older B load.
+    func switchToSession(_ id: UUID) async {
+        guard chatSessionStore != nil else { return }
+        cancelStreamingForTransition()        // synchronous — immediate stream abort, BEFORE the lane
+        sessionTransitionToken &+= 1           // synchronous — a rapid B→C switch bumps the token first
+        requestedSessionId = id                // synchronous — so a superseded body bails on the id check
+        let token = sessionTransitionToken
+        await runSerializedSessionOp { await self._switchToSession(id, token: token) }
+    }
+
+    private func _switchToSession(_ id: UUID, token: UInt64) async {
+        guard let store = chatSessionStore else { return }
+        await sealCurrentSessionIfNeeded()
+        guard transitionIsCurrent(token: token, id: id) else { return }
+        do {
+            guard let record = try await store.fetchChatSession(sessionId: id) else { return }
+            guard transitionIsCurrent(token: token, id: id) else { return }
+            messages = record.messages
+            settledMessages = record.messages   // a loaded session is fully settled
+            activeSessionId = record.sessionId
+            errorMessage = nil
+        } catch {
+            transitionLog.error("switchToSession failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Renames the active session (title only). A no-op when there is no active
+    /// session or no store. Does not touch `messages` / `activeSessionId`.
+    func renameActiveSession(_ title: String) async {
+        guard chatSessionStore != nil else { return }
+        await runSerializedSessionOp { await self._renameActiveSession(title) }
+    }
+
+    private func _renameActiveSession(_ title: String) async {
+        guard let store = chatSessionStore, let id = activeSessionId else { return }
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        do {
+            try await store.renameChatSession(sessionId: id, title: trimmed)
+        } catch {
+            transitionLog.error("renameActiveSession failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Deletes a session. When the active one is deleted, falls back to the
+    /// most-recent remaining NON-EMPTY session (or the empty state when none
+    /// remain). Cancels any in-flight stream + bumps the token FIRST.
+    func deleteSession(_ id: UUID) async {
+        guard chatSessionStore != nil else { return }
+        // Only a delete of the CURRENTLY-active session is a transition that must
+        // abort the in-flight stream + supersede the active send (Gate-4 WI-3 r6
+        // High): deleting an UNRELATED non-active session must NOT cancel the
+        // active session's stream — that would bump `opCounter`, make `runSend`
+        // skip its settled-turn save (`opId != opCounter`), and lose the active
+        // session's latest turn (a later seal would then persist the older
+        // snapshot). Non-active deletes still run through the serialized lane;
+        // they just leave the active send untouched.
+        if id == activeSessionId {
+            cancelStreamingForTransition()    // synchronous — immediate stream abort, BEFORE the lane
+            sessionTransitionToken &+= 1       // synchronous — a rapid superseding op bumps the token first
+        }
+        let token = sessionTransitionToken
+        await runSerializedSessionOp { await self._deleteSession(id, token: token) }
+    }
+
+    private func _deleteSession(_ id: UUID, token: UInt64) async {
+        guard let store = chatSessionStore else { return }
+        // Captured inside the laned body: a prior op that drained ahead of this one
+        // may have changed which session is active, so reflect the state at the
+        // moment the delete actually runs.
+        let wasActive = activeSessionId == id
+        do {
+            try await store.deleteChatSession(sessionId: id)
+        } catch {
+            transitionLog.error("deleteSession failed: \(String(describing: error), privacy: .public)")
+            return
+        }
+        guard wasActive else { return }
+        guard token == sessionTransitionToken else { return }
+        // Reset locally first so a fallback failure still leaves a clean empty state.
+        messages = []
+        settledMessages = []
+        activeSessionId = nil
+        errorMessage = nil
+        await loadMostRecentRemaining(token: token)
+    }
+
+    // MARK: - Private helpers
+
+    /// True iff the captured token + requested id still match the latest transition.
+    private func transitionIsCurrent(token: UInt64, id: UUID) -> Bool {
+        token == sessionTransitionToken && requestedSessionId == id
+    }
+
+    /// Saves the current thread to its session if it has content, so switching /
+    /// starting a new conversation never loses the conversation being left. A no-op
+    /// when the thread is empty (an empty thread is never persisted) or has no
+    /// active session yet AND no content to lazily create from.
+    ///
+    /// NON-laned: it is called only from WITHIN a laned transition body — laning it
+    /// would re-enter the chain head and deadlock.
+    private func sealCurrentSessionIfNeeded() async {
+        guard let store = chatSessionStore, let key = bookFingerprintKey else { return }
+        // Seal the SETTLED snapshot, never the live `messages` — a cancelled
+        // in-flight turn (the transition just `cancelStreamingForTransition`'d it)
+        // is abandoned, not persisted (Gate-4 WI-3 High). No settled content (e.g.
+        // a transition during the very first, still-in-flight turn) → no-op, so the
+        // abandoned turn never even creates a session.
+        let snapshot = settledMessages
+        guard !snapshot.isEmpty else { return }
+        let title = derivedTitle(from: snapshot)
+        do {
+            if let id = activeSessionId {
+                _ = try await store.updateChatSession(sessionId: id, messages: snapshot, title: title)
+            } else {
+                let record = try await store.createChatSession(
+                    bookFingerprintKey: key, title: title ?? Self.defaultSessionTitle,
+                    messages: snapshot)
+                activeSessionId = record.sessionId
+            }
+        } catch {
+            transitionLog.error("sealCurrentSession failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// After deleting the active session, loads the most-recent remaining NON-EMPTY
+    /// session, else leaves the empty state. Re-checks the token before applying.
+    /// NON-laned (called only from within the laned `_deleteSession`).
+    private func loadMostRecentRemaining(token: UInt64) async {
+        guard let store = chatSessionStore, let key = bookFingerprintKey else { return }
+        do {
+            let summaries = try await store.fetchChatSessionSummaries(forBookWithKey: key)
+            guard token == sessionTransitionToken, activeSessionId == nil else { return }
+            guard let target = summaries.first(where: { $0.messageCount > 0 }) else { return }
+            guard let record = try await store.fetchChatSession(sessionId: target.id) else { return }
+            guard token == sessionTransitionToken, activeSessionId == nil else { return }
+            messages = record.messages
+            settledMessages = record.messages   // a loaded session is fully settled
+            activeSessionId = record.sessionId
+        } catch {
+            transitionLog.error("loadMostRecentRemaining failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+}

--- a/vreader/ViewModels/AIChatViewModel+Sessions.swift
+++ b/vreader/ViewModels/AIChatViewModel+Sessions.swift
@@ -1,0 +1,183 @@
+// Purpose: Feature #88 WI-3 — the chat-session lifecycle for AIChatViewModel,
+// split out of the base file to keep it under the ~300-line guide. Owns the
+// one-shot load, lazy create-on-first-turn, the settled-turn save, and the
+// switch / new / rename / delete transitions — all guarded by the
+// `sessionTransitionToken` so a late async load/fetch can't clobber a newer
+// thread (Gate-2 rounds 3+4 async-race hardening).
+//
+// Key decisions:
+// - nil `chatSessionStore` ⇒ every method is a no-op (general chat / tests keep
+//   the pre-#88 ephemeral single thread).
+// - `loadSessions()` is idempotent + non-clobbering: it runs at most once per
+//   fingerprint key and never overwrites a non-empty / active local thread.
+// - EVERY transition (switch/new/delete) AND the lazy-create-on-first-turn path
+//   bumps `sessionTransitionToken` BEFORE its first await; each re-checks the
+//   token after every await before applying, so a superseding transition (or a
+//   just-started send) wins.
+// - The settled-turn save is debounced (one write per settled turn, never per
+//   streamed chunk) and runs from the streaming extension's placeholder cleanup.
+//
+// @coordinates-with: AIChatViewModel.swift, AIChatViewModel+Streaming.swift,
+//   ChatSessionPersisting.swift, ChatSessionRecord.swift, ChatMessage.swift
+
+import Foundation
+import OSLog
+
+private let sessionLog = Logger(subsystem: "com.vreader.app", category: "ChatSessions")
+
+extension AIChatViewModel {
+
+    /// The default title a fresh session carries until the first user message
+    /// derives one. Mirrors `ChatSession.init`'s default.
+    static let defaultSessionTitle = "New conversation"
+
+    // MARK: - One-shot load
+
+    /// Loads the most-recent NON-EMPTY persisted session for the current book into
+    /// `messages` / `activeSessionId`, else leaves the designed empty state
+    /// (`activeSessionId == nil`, `messages == []`) — an empty session is NEVER
+    /// persisted on open. Idempotent + non-clobbering: a no-op when the store is
+    /// nil, there is no book key, it has already run for this key, or local session
+    /// state already exists. Owned by `ReaderAICoordinator` (one-shot after VM
+    /// construction), NOT a view `.task` (which reruns on Chat-tab re-entry).
+    ///
+    /// Cold-open race (Gate-2 round-4): a user can send a first message before this
+    /// fetch returns. The post-await + pre-apply re-checks (`activeSessionId == nil
+    /// && messages.isEmpty && token == sessionTransitionToken`) abandon the load if
+    /// a turn started meanwhile, so the just-started thread is never overwritten.
+    func loadSessions() async {
+        guard chatSessionStore != nil else { return }
+        await runSerializedSessionOp { await self._loadSessions() }
+    }
+
+    private func _loadSessions() async {
+        guard let store = chatSessionStore, let key = bookFingerprintKey else { return }
+        guard loadedFingerprintKey != key else { return }
+        guard activeSessionId == nil, messages.isEmpty else {
+            // Local state already exists — record the key so a later call no-ops too.
+            loadedFingerprintKey = key
+            return
+        }
+        // Mark as run for this key up front so a concurrent load double-fetch can't
+        // race; the token discipline below handles the load-vs-turn race.
+        loadedFingerprintKey = key
+        let token = sessionTransitionToken
+
+        do {
+            let summaries = try await store.fetchChatSessionSummaries(forBookWithKey: key)
+            guard loadIsStillValid(token: token) else { return }
+            guard let target = summaries.first(where: { $0.messageCount > 0 }) else {
+                return  // no non-empty session → keep the empty state
+            }
+            guard let record = try await store.fetchChatSession(sessionId: target.id) else { return }
+            guard loadIsStillValid(token: token) else { return }
+            messages = record.messages
+            settledMessages = record.messages   // a loaded session is fully settled
+            activeSessionId = record.sessionId
+        } catch {
+            sessionLog.error("loadSessions failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// The cold-open guard: the load may apply ONLY if no turn started and no
+    /// transition superseded it since the token was captured.
+    private func loadIsStillValid(token: UInt64) -> Bool {
+        activeSessionId == nil && messages.isEmpty && token == sessionTransitionToken
+    }
+
+    // MARK: - Lazy create + settled-turn save (called from +Streaming)
+
+    /// Called synchronously at the START of a send when this is the first real user
+    /// turn of an unsaved thread (`activeSessionId == nil`) on a book chat with a
+    /// store. Bumps `sessionTransitionToken` so an in-flight `loadSessions` fails
+    /// its re-check and cannot overwrite the just-started thread (Gate-2 round-4).
+    /// The session row itself is created lazily on the settled-turn save.
+    func noteFirstTurnStartedIfNeeded() {
+        guard chatSessionStore != nil, bookFingerprintKey != nil, activeSessionId == nil else { return }
+        sessionTransitionToken &+= 1
+    }
+
+    /// Persists the active conversation after a SETTLED turn. Debounced by the
+    /// caller (runs once after the placeholder cleanup, never per chunk). Creates
+    /// the session lazily on the first turn, updates it thereafter. Guarded by the
+    /// streaming op identity + session identity captured at send time so a
+    /// superseded / switched-away turn never writes to the wrong session.
+    ///
+    /// - Parameters:
+    ///   - capturedSessionId: `activeSessionId` snapshot at send time. The save is
+    ///     skipped if the active session changed (switch/new/delete) since then —
+    ///     UNLESS it was nil at send time and is still nil now (the lazy-create case).
+    func saveSettledTurn(capturedSessionId: UUID?) async {
+        guard chatSessionStore != nil else { return }
+        await runSerializedSessionOp { await self._saveSettledTurn(capturedSessionId: capturedSessionId) }
+    }
+
+    private func _saveSettledTurn(capturedSessionId: UUID?) async {
+        guard let store = chatSessionStore, let key = bookFingerprintKey else { return }
+        // The reply must still belong to the session it was sent for.
+        guard activeSessionId == capturedSessionId else { return }
+        guard !messages.isEmpty else { return }
+
+        // Snapshot the transition token: a switch / new / delete that fires DURING
+        // the create await must not have its empty-state reset clobbered by this
+        // turn adopting a freshly-created session id (the create-vs-transition race).
+        let token = sessionTransitionToken
+        let snapshot = messages
+        let title = derivedTitle(from: snapshot)
+        do {
+            if let id = activeSessionId {
+                // Promote the settled snapshot to transition-visible state BEFORE the
+                // persistence await (Gate-4 WI-3 r4 High): a `switch`/`new`/`delete`
+                // racing this update must seal the FRESH snapshot, not the older one
+                // — otherwise its seal would overwrite the just-settled turn with
+                // stale data. (`messages` here is the same session's settled history,
+                // so it's safe to promote eagerly.)
+                settledMessages = snapshot
+                _ = try await store.updateChatSession(sessionId: id, messages: snapshot, title: title)
+            } else {
+                let record = try await store.createChatSession(
+                    bookFingerprintKey: key, title: title ?? Self.defaultSessionTitle,
+                    messages: snapshot)
+                // Adopt the new id ONLY if no transition superseded this turn during
+                // the create await. Otherwise a `newConversation` / switch that fired
+                // mid-create ABANDONED this turn — DELETE the just-created orphan row
+                // (Gate-4 WI-3 High: a cancelled send must not leave a duplicate
+                // session) and do not adopt it.
+                guard token == sessionTransitionToken, activeSessionId == nil else {
+                    // A transition abandoned this turn during the create await — roll
+                    // back the orphan row. Best-effort + LOGGED (not swallowed): if the
+                    // delete fails the orphan is a harmless abandoned (non-active)
+                    // session, surfaced in the log rather than silently retained
+                    // (Gate-4 WI-3 r2 Medium). Compensating, not atomic: a brief window
+                    // exists between create-return and delete; acceptable for a
+                    // low-stakes empty/abandoned chat row.
+                    do {
+                        try await store.deleteChatSession(sessionId: record.sessionId)
+                    } catch {
+                        sessionLog.error(
+                            "saveSettledTurn orphan cleanup failed: \(String(describing: error), privacy: .public)")
+                    }
+                    return
+                }
+                activeSessionId = record.sessionId
+                settledMessages = snapshot
+            }
+        } catch {
+            sessionLog.error("saveSettledTurn failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// The session title: derived from the first user message when the session is
+    /// still on the default title (or unsaved); else nil (leave the stored title).
+    /// `internal` (not `private`) so the `+SessionTransitions` seal path reuses it.
+    func derivedTitle(from source: [ChatMessage]) -> String? {
+        guard let firstUser = source.first(where: { $0.role == .user }) else { return nil }
+        let trimmed = firstUser.content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return String(trimmed.prefix(Self.titleMaxLength))
+    }
+
+    static let titleMaxLength = 80
+
+    // MARK: - Transitions moved to AIChatViewModel+SessionTransitions.swift
+}

--- a/vreader/ViewModels/AIChatViewModel+Streaming.swift
+++ b/vreader/ViewModels/AIChatViewModel+Streaming.swift
@@ -51,6 +51,18 @@ extension AIChatViewModel {
         isLoading = false
     }
 
+    /// Feature #88 (Gate-2 High 3): the FIRST step of every session transition —
+    /// cancel the in-flight stream AND bump `opCounter` so a late provider reply
+    /// from the superseded op cannot land in (or seal) the new / deleted session.
+    /// The in-flight `runSend`'s post-await `opId == opCounter` guards then discard
+    /// its placeholder cleanup write + its settled-turn save. Distinct from
+    /// `cancelStreaming()` (the Stop button), which keeps the op id stable so the
+    /// stopped turn's partial is still saved as a real turn.
+    func cancelStreamingForTransition() {
+        cancelStreaming()
+        opCounter &+= 1
+    }
+
     // MARK: - Send pipeline
 
     /// One send operation. `opId` tags this op so a superseded predecessor's late
@@ -64,6 +76,15 @@ extension AIChatViewModel {
 
         // Clear previous error
         errorMessage = nil
+
+        // Feature #88: if this is the first real turn of an unsaved thread, bump the
+        // session transition token NOW (synchronously, before any await) so an
+        // in-flight loadSessions fails its post-await re-check and cannot overwrite
+        // the thread this turn is starting (cold-open race, Gate-2 round-4). Snapshot
+        // the active session id so the settled-turn save only writes if the reply
+        // still belongs to the session it was sent for (streaming handoff guard).
+        noteFirstTurnStartedIfNeeded()
+        let sessionAtSend = activeSessionId
 
         // Add user message to history
         let userMessage = ChatMessage(role: .user, content: trimmed)
@@ -144,6 +165,18 @@ extension AIChatViewModel {
         // cancel-mid-stream → non-empty → kept; provider returned nothing → removed).
         if let assistant = message(withId: assistantId), assistant.content.isEmpty {
             removeMessage(withId: assistantId)
+        }
+
+        // Feature #88: persist the SETTLED turn (debounced — one write here, never
+        // per chunk). Only the CURRENT, live op writes: a superseded (resent) op
+        // must not save (opId != opCounter), and the save itself re-checks that the
+        // active session still matches the one captured at send time (a switch /
+        // new / delete mid-send cancelled this op + changed the active session, so
+        // its reply must not land in — or seal — the wrong session). A cancelled op
+        // that kept a partial reply is still a real turn worth saving, so we do NOT
+        // gate on `Task.isCancelled` here — only on op + session identity.
+        if opId == opCounter {
+            await saveSettledTurn(capturedSessionId: sessionAtSend)
         }
     }
 

--- a/vreader/ViewModels/AIChatViewModel.swift
+++ b/vreader/ViewModels/AIChatViewModel.swift
@@ -27,6 +27,43 @@ final class AIChatViewModel {
     /// `internal(set)` so the streaming extension (`+Streaming`) can mutate it.
     internal(set) var messages: [ChatMessage] = []
 
+    // MARK: - Feature #88 session state
+
+    /// The persisted session currently shown, or nil for the empty (not-yet-saved)
+    /// state. The setter is `internal` so the session lifecycle (`+Sessions`) and
+    /// the streaming save hook (`+Streaming`) — extensions that cannot add stored
+    /// properties — can update it. Drives the WI-4 session bar.
+    internal(set) var activeSessionId: UUID?
+
+    // Feature #88 session plumbing. Stored on the base class (extensions cannot add
+    // stored properties); `internal` so `+Sessions` / `+Streaming` reach them;
+    // `@ObservationIgnored` keeps them out of SwiftUI observation (internal
+    // plumbing, not rendered state — mirrors `streamTask`/`opCounter`).
+
+    /// Idempotency guard for the one-shot `loadSessions()` — once it has run for a
+    /// fingerprint key it never re-loads (a Chat-tab re-entry must not clobber a
+    /// fresh / unsaved thread).
+    @ObservationIgnored var loadedFingerprintKey: String?
+
+    /// Monotonic token bumped synchronously at the START of every session
+    /// transition (switch / new / delete) AND the lazy-create-on-first-turn path.
+    /// Each transition re-checks `token == sessionTransitionToken` after every
+    /// await before applying — so a newer transition (or a just-started turn)
+    /// supersedes an in-flight older load/switch (Gate-2 rounds 3+4).
+    @ObservationIgnored var sessionTransitionToken: UInt64 = 0
+
+    /// The session id the most-recent `switchToSession(_:)` requested, stashed
+    /// synchronously before its first await so a rapid B→C switch can detect that
+    /// an older B load was superseded (paired with the token).
+    @ObservationIgnored var requestedSessionId: UUID?
+
+    /// The messages as of the LAST successfully-settled-and-persisted turn (or a
+    /// freshly loaded session). A transition (`switch`/`new`/`delete`) seals THIS
+    /// snapshot — never the live `messages` — so a cancelled in-flight turn
+    /// (partial / empty assistant) is abandoned, not saved into the old session
+    /// (Gate-4 WI-3 High). Empty until the first turn settles.
+    @ObservationIgnored var settledMessages: [ChatMessage] = []
+
     /// Whether a request is currently in flight.
     /// `internal(set)` so the streaming extension can clear it on cancel.
     internal(set) var isLoading: Bool = false
@@ -38,6 +75,33 @@ final class AIChatViewModel {
     // + cancel API in `AIChatViewModel+Streaming.swift`.
     @ObservationIgnored var streamTask: Task<Void, Never>?
     @ObservationIgnored var opCounter: UInt64 = 0
+
+    // Feature #88 WI-3 (Gate-4 structural fix): the single serialized lane every
+    // session-mutating op runs through, so two ops can never interleave across an
+    // `await` on the @MainActor (the whole lost-message / wrong-active-session /
+    // duplicate-orphan / stuck-load interleaving-race class). Stored on the base
+    // class (extensions cannot add stored properties); `@ObservationIgnored`
+    // keeps it out of SwiftUI observation (internal plumbing).
+    @ObservationIgnored private var sessionOpChain: Task<Void, Never>?
+
+    /// Runs `body` on a single serialized lane: it waits for the prior session op
+    /// to FULLY complete (across its awaits) before running, so two
+    /// session-mutating ops can never interleave. Runs on the @MainActor; the
+    /// prior task is captured synchronously, so the ordering is the call order.
+    ///
+    /// DEADLOCK CONSTRAINT: a laned op's body must NEVER call another laned PUBLIC
+    /// op — that would `await` the current chain head (this op) and deadlock. The
+    /// internal helpers `sealCurrentSessionIfNeeded()` / `loadMostRecentRemaining`
+    /// are invoked WITHIN laned bodies, so they stay NON-laned.
+    func runSerializedSessionOp(_ body: @escaping @MainActor () async -> Void) async {
+        let prior = sessionOpChain
+        let task = Task { @MainActor in
+            await prior?.value
+            await body()
+        }
+        sessionOpChain = task
+        await task.value
+    }
 
     /// Error message from the last failed request, nil if no error.
     var errorMessage: String?
@@ -154,6 +218,17 @@ final class AIChatViewModel {
         agenticRegistry = registry
     }
 
+    /// Feature #88: chat-session persistence. `nil` ⇒ ephemeral behavior (general
+    /// chat / tests that don't exercise sessions) — `loadSessions()` no-ops and no
+    /// session is ever created/saved, so the pre-#88 single-thread flow is
+    /// unchanged. Non-nil (book chat) ⇒ multiple switchable persisted sessions.
+    /// `internal` so the `+Sessions` / `+Streaming` extensions can reach it.
+    let chatSessionStore: (any ChatSessionPersisting)?
+
+    /// The book's primitive lookup key (matches `Book.fingerprintKey`), derived
+    /// from `bookFingerprint`. Nil for general chat. The session store keys on it.
+    var bookFingerprintKey: String? { bookFingerprint?.canonicalKey }
+
     // MARK: - Init
 
     /// Creates a new chat view model.
@@ -166,18 +241,23 @@ final class AIChatViewModel {
     ///   - agenticRegistry: Feature #91 — when non-nil + non-empty AND `agenticTools`
     ///     is on AND the resolved provider supports tool-use, the chat routes through
     ///     the agentic loop.
+    ///   - chatSessionStore: Feature #88 — when non-nil (book chat), enables multiple
+    ///     switchable persisted conversations. nil (general chat / tests) keeps the
+    ///     pre-#88 ephemeral single-thread behavior.
     init(
         aiService: AIService,
         bookFingerprint: DocumentFingerprint? = nil,
         contextWindowSize: Int = 10,
         featureFlags: FeatureFlags = .shared,
-        agenticRegistry: AIToolRegistry? = nil
+        agenticRegistry: AIToolRegistry? = nil,
+        chatSessionStore: (any ChatSessionPersisting)? = nil
     ) {
         self.aiService = aiService
         self.bookFingerprint = bookFingerprint
         self.contextWindowSize = contextWindowSize
         self.featureFlags = featureFlags
         self.agenticRegistry = agenticRegistry
+        self.chatSessionStore = chatSessionStore
     }
 
     // MARK: - Actions
@@ -185,6 +265,11 @@ final class AIChatViewModel {
     /// Clears the entire conversation history and resets state. Feature #87 WI-1:
     /// cancels any in-flight stream FIRST (combined with id-based writes in the
     /// streaming extension, a mid-flight clear cannot index-corrupt the thread).
+    ///
+    /// Feature #88: this is the LOW-LEVEL clear (the cancel path). It does NOT seal
+    /// the active session — `newConversation()` (in `+Sessions`) is the session-aware
+    /// entry point that seals + resets `activeSessionId`. `clearHistory` leaves
+    /// `activeSessionId` untouched so a cancel doesn't orphan the session identity.
     func clearHistory() {
         cancelStreaming()
         messages = []
@@ -194,6 +279,9 @@ final class AIChatViewModel {
 
     // The streaming + cancellation concern (sendMessage launcher, runSend,
     // cancelStreaming, consumeStream, runAgenticTurn, context builders, and the
-    // id-based write helper) lives in `AIChatViewModel+Streaming.swift` to keep
-    // this base file under the ~300-line guide.
+    // id-based write helper) lives in `AIChatViewModel+Streaming.swift`; the
+    // Feature #88 session lifecycle (loadSessions / newConversation / switch /
+    // rename / delete + the settled-turn save hook) lives in
+    // `AIChatViewModel+Sessions.swift`, both to keep this base file under the
+    // ~300-line guide.
 }

--- a/vreader/Views/AI/AIChatView.swift
+++ b/vreader/Views/AI/AIChatView.swift
@@ -120,7 +120,11 @@ struct AIChatView: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
-                    viewModel.clearHistory()
+                    // Feature #88 WI-3: the former clear-history button now starts a
+                    // NEW conversation — it seals the current session (if it has
+                    // content) and resets to the empty state, instead of a destructive
+                    // wipe. The session-bar "New" button (WI-4) lands separately.
+                    Task { await viewModel.newConversation() }
                 } label: {
                     Image(systemName: "trash")
                 }

--- a/vreader/Views/Reader/ReaderAICoordinator.swift
+++ b/vreader/Views/Reader/ReaderAICoordinator.swift
@@ -228,16 +228,24 @@ final class ReaderAICoordinator {
     /// conforms to all three). Nil when persistence isn't injected.
     private let annotationStores: (any AnnotationPersisting & HighlightPersisting & BookmarkPersisting)?
 
+    /// Feature #88: the chat-session store (the `PersistenceActor`, which conforms
+    /// to `ChatSessionPersisting`). Injected into the book-chat VM so a reader chat
+    /// persists multiple switchable conversations. Nil when no persistence is
+    /// injected (the chat stays ephemeral).
+    private let chatSessionStore: (any ChatSessionPersisting)?
+
     init(
         fallbackTitle: String,
         bookFormat: BookFormat,
         fingerprintKey: String,
-        annotationStores: (any AnnotationPersisting & HighlightPersisting & BookmarkPersisting)? = nil
+        annotationStores: (any AnnotationPersisting & HighlightPersisting & BookmarkPersisting)? = nil,
+        chatSessionStore: (any ChatSessionPersisting)? = nil
     ) {
         self.fallbackTitle = fallbackTitle
         self.bookFormat = bookFormat
         self.fingerprintKey = fingerprintKey
         self.annotationStores = annotationStores
+        self.chatSessionStore = chatSessionStore
     }
 
     /// Creates the AI ViewModels if AI features are available.
@@ -258,8 +266,19 @@ final class ReaderAICoordinator {
         translationViewModel = AITranslationViewModel(aiService: service)
 
         let fingerprint = DocumentFingerprint(canonicalKey: fingerprintKey)
-        let chatVM = AIChatViewModel(aiService: service, bookFingerprint: fingerprint)
+        let chatVM = AIChatViewModel(
+            aiService: service,
+            bookFingerprint: fingerprint,
+            chatSessionStore: chatSessionStore   // Feature #88: persisted sessions (nil ⇒ ephemeral)
+        )
         chatViewModel = chatVM
+        // Feature #88 WI-3: trigger the ONE-SHOT session load from the long-lived
+        // coordinator (idempotent + non-clobbering), NOT from `AIChatView.task`
+        // (which reruns on every Chat-tab re-entry and would clobber a fresh /
+        // unsaved thread — Gate-2 round-3). A nil store / general chat no-ops.
+        if chatSessionStore != nil {
+            Task { @MainActor [weak chatVM] in await chatVM?.loadSessions() }
+        }
         // Feature #91: when agenticTools is ON, build the agentic tool registry over
         // the persistent FTS store + the persistence actor (also a LibraryPersisting)
         // OFF-MAIN (the cold SQLite open is heavy), then inject it. A build failure

--- a/vreader/Views/Reader/ReaderContainerView.swift
+++ b/vreader/Views/Reader/ReaderContainerView.swift
@@ -1009,7 +1009,8 @@ struct ReaderContainerView: View {
             fallbackTitle: book.title,
             bookFormat: resolvedBookFormat,
             fingerprintKey: book.fingerprintKey,
-            annotationStores: aiAnnotationStores   // Feature #86 WI-4 (nil when no persistence)
+            annotationStores: aiAnnotationStores,   // Feature #86 WI-4 (nil when no persistence)
+            chatSessionStore: persistenceActor       // Feature #88 (nil when no persistence)
         )
         // SwiftUI will apply the mutation at the end of the render pass
         DispatchQueue.main.async {

--- a/vreaderTests/ViewModels/AIChatViewModelSessionsTestHelpers.swift
+++ b/vreaderTests/ViewModels/AIChatViewModelSessionsTestHelpers.swift
@@ -1,0 +1,253 @@
+// Purpose: Test doubles for Feature #88 WI-3 session-lifecycle tests — an
+// in-memory `ChatSessionPersisting` mock (with gateable fetches so the race
+// guards are deterministically pinnable) and a session-scoped gated streaming
+// provider (a copy of the #87 gated pattern, used only by the session tests so
+// it doesn't depend on the `private` doubles in AIChatViewModelTests.swift).
+//
+// @coordinates-with: AIChatViewModelSessionsTests.swift, ChatSessionPersisting.swift
+
+import Foundation
+@testable import vreader
+
+// MARK: - MockChatSessionStore
+
+/// In-memory `ChatSessionPersisting` mock. Records call counts + last writes and
+/// supports GATING the `fetchChatSession` (per id) and `fetchChatSessionSummaries`
+/// calls so a test can park a load/switch fetch and fire a superseding transition
+/// before it resolves (the transition-token + cold-open race tests).
+///
+/// `@unchecked Sendable`: all mutable state is touched only on the @MainActor VM's
+/// hop or the test's @MainActor context; the actor-style `async` methods serialize
+/// through the awaits. The gate is a `Sendable` actor.
+final class MockChatSessionStore: ChatSessionPersisting, @unchecked Sendable {
+
+    struct Stored {
+        var record: ChatSessionRecord
+        var renamedTitle: String?
+    }
+
+    private var sessions: [UUID: Stored] = [:]
+    private(set) var createCallCount = 0
+    private(set) var updateCallCount = 0
+    private(set) var fetchSummariesCallCount = 0
+    private(set) var deletedIds: [UUID] = []
+
+    // Gating: a parked continuation per gated fetch.
+    private let gate = FetchGate()
+
+    // MARK: Seeding (test setup, synchronous)
+
+    @discardableResult
+    func seed(key: String, title: String, messages: [ChatMessage], updatedAt: Date) -> UUID {
+        let id = UUID()
+        let record = ChatSessionRecord(
+            sessionId: id, bookFingerprintKey: key, title: title,
+            messages: messages, createdAt: updatedAt, updatedAt: updatedAt)
+        sessions[id] = Stored(record: record)
+        return id
+    }
+
+    func seededMessages(for id: UUID) -> [ChatMessage]? { sessions[id]?.record.messages }
+    func lastSavedMessages(for id: UUID) -> [ChatMessage]? { sessions[id]?.record.messages }
+    func lastSavedTitle(for id: UUID) -> String? { sessions[id]?.record.title }
+    func lastRenamedTitle(for id: UUID) -> String? { sessions[id]?.renamedTitle }
+
+    // MARK: Gating controls
+
+    // Arming is `async` + awaited at the call site BEFORE launching the raced task
+    // (Gate-4 WI-3 r3 Medium): a fire-and-forget `Task { arm }` could land AFTER the
+    // raced op reached `waitIfArmed`, missing the gate → a nondeterministic hang.
+    func gateFetch(for id: UUID) async { await gate.arm(.session(id)) }
+    func gateSummariesFetch() async { await gate.arm(.summaries) }
+    var parkedFetchCount: Int { get async { await gate.parkedCount(.sessionAny) } }
+    var parkedSummariesCount: Int { get async { await gate.parkedCount(.summaries) } }
+    func releaseFetch(for id: UUID) async { await gate.release(.session(id)) }
+    func releaseSummariesFetch() async { await gate.release(.summaries) }
+    func gateCreate() async { await gate.arm(.create) }
+    func releaseCreate() async { await gate.release(.create) }
+    var parkedCreateCount: Int { get async { await gate.parkedCount(.create) } }
+    func gateUpdate() async { await gate.arm(.update) }
+    func releaseUpdate() async { await gate.release(.update) }
+    var parkedUpdateCount: Int { get async { await gate.parkedCount(.update) } }
+    var sessionRowCount: Int { sessions.count }
+
+    // MARK: ChatSessionPersisting
+
+    func createChatSession(
+        bookFingerprintKey: String, title: String, messages: [ChatMessage]
+    ) async throws -> ChatSessionRecord {
+        createCallCount += 1
+        await gate.waitIfArmed(.create)
+        let id = UUID()
+        let now = Date()
+        let record = ChatSessionRecord(
+            sessionId: id, bookFingerprintKey: bookFingerprintKey, title: title,
+            messages: messages, createdAt: now, updatedAt: now)
+        sessions[id] = Stored(record: record)
+        return record
+    }
+
+    func fetchChatSessionSummaries(forBookWithKey key: String) async throws -> [ChatSessionSummary] {
+        fetchSummariesCallCount += 1
+        await gate.waitIfArmed(.summaries)
+        return sessions.values
+            .map { $0.record }
+            .filter { $0.bookFingerprintKey == key }
+            .sorted { $0.updatedAt > $1.updatedAt }
+            .map { rec in
+                ChatSessionSummary(
+                    id: rec.sessionId, title: rec.title,
+                    snippet: rec.messages.last?.content ?? "",
+                    updatedAt: rec.updatedAt, messageCount: rec.messages.count)
+            }
+    }
+
+    func fetchChatSession(sessionId: UUID) async throws -> ChatSessionRecord? {
+        await gate.waitIfArmed(.session(sessionId))
+        return sessions[sessionId]?.record
+    }
+
+    func updateChatSession(
+        sessionId: UUID, messages: [ChatMessage], title: String?
+    ) async throws -> ChatSessionRecord {
+        updateCallCount += 1
+        await gate.waitIfArmed(.update)
+        guard var stored = sessions[sessionId] else {
+            throw PersistenceError.recordNotFound("ChatSession \(sessionId)")
+        }
+        let r = stored.record
+        let newRecord = ChatSessionRecord(
+            sessionId: r.sessionId, bookFingerprintKey: r.bookFingerprintKey,
+            title: title ?? r.title, messages: messages,
+            createdAt: r.createdAt, updatedAt: Date())
+        stored.record = newRecord
+        sessions[sessionId] = stored
+        return newRecord
+    }
+
+    func renameChatSession(sessionId: UUID, title: String) async throws {
+        guard var stored = sessions[sessionId] else {
+            throw PersistenceError.recordNotFound("ChatSession \(sessionId)")
+        }
+        stored.renamedTitle = title
+        let r = stored.record
+        stored.record = ChatSessionRecord(
+            sessionId: r.sessionId, bookFingerprintKey: r.bookFingerprintKey,
+            title: title, messages: r.messages, createdAt: r.createdAt, updatedAt: Date())
+        sessions[sessionId] = stored
+    }
+
+    /// When true, `deleteChatSession` throws — used to pin the orphan-cleanup
+    /// failure path (Gate-4 WI-3 r2 Medium): a delete failure must not crash / must
+    /// leave the VM in a clean state, with the abandoned row retained (logged).
+    var failDelete = false
+
+    func deleteChatSession(sessionId: UUID) async throws {
+        if failDelete { throw PersistenceError.recordNotFound("forced delete failure") }
+        deletedIds.append(sessionId)
+        sessions[sessionId] = nil
+    }
+}
+
+/// Actor backing the mock's gateable fetches. A gate "key" is either the
+/// summaries fetch or a specific session id. `waitIfArmed` parks until released.
+private actor FetchGate {
+    enum Key: Hashable { case summaries; case session(UUID); case sessionAny; case create; case update }
+
+    private var armed: Set<Key> = []
+    private var parked: [Key: [CheckedContinuation<Void, Never>]] = [:]
+    private var parkedCounts: [Key: Int] = [:]
+
+    func arm(_ key: Key) { armed.insert(key) }
+
+    func parkedCount(_ key: Key) -> Int {
+        if key == .sessionAny {
+            return parkedCounts.reduce(0) { acc, kv in
+                if case .session = kv.key { return acc + kv.value }
+                return acc
+            }
+        }
+        return parkedCounts[key] ?? 0
+    }
+
+    func waitIfArmed(_ key: Key) async {
+        guard armed.contains(key) else { return }
+        armed.remove(key)
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            parked[key, default: []].append(cont)
+            parkedCounts[key, default: 0] += 1
+        }
+    }
+
+    func release(_ key: Key) {
+        guard var conts = parked[key], !conts.isEmpty else { return }
+        let cont = conts.removeFirst()
+        parked[key] = conts
+        parkedCounts[key, default: 0] -= 1
+        cont.resume()
+    }
+}
+
+// MARK: - SessionGatedProvider
+
+/// A streaming provider whose stream yields ONE chunk immediately, then parks on a
+/// per-call gate until `releaseGate(callIndex:)` — a session-test-local copy of the
+/// #87 GatedChatAIProvider (that one is `private` to AIChatViewModelTests.swift).
+final class SessionGatedProvider: AIProvider, @unchecked Sendable {
+    let providerName = "SessionGated"
+    var firstChunk = "partial "
+    var secondChunk = "rest"
+
+    private let registry = SessionGateRegistry()
+    var streamRequestCallCount: Int { get async { await registry.callCount } }
+    func releaseGate(callIndex index: Int) async { await registry.release(callIndex: index) }
+
+    func sendRequest(_ request: AIRequest) async throws -> AIResponse { throw AIError.invalidResponse }
+
+    func streamRequest(_ request: AIRequest) -> AsyncThrowingStream<AIStreamChunk, Error> {
+        let registry = self.registry
+        let first = firstChunk
+        let second = secondChunk
+        return AsyncThrowingStream { continuation in
+            Task {
+                let (_, gate) = await registry.registerCall()
+                continuation.yield(AIStreamChunk(text: first, isComplete: false))
+                await gate.waitForRelease()
+                continuation.yield(AIStreamChunk(text: second, isComplete: true))
+                continuation.finish()
+            }
+        }
+    }
+}
+
+private actor SessionStreamGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var released: Bool
+    init(preReleased: Bool = false) { released = preReleased }
+    func release() {
+        if let continuation { self.continuation = nil; continuation.resume() }
+        else { released = true }
+    }
+    func waitForRelease() async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            if released { released = false; cont.resume() } else { continuation = cont }
+        }
+    }
+}
+
+private actor SessionGateRegistry {
+    private var gates: [Int: SessionStreamGate] = [:]
+    private var pendingReleases: Set<Int> = []
+    private(set) var callCount = 0
+    func registerCall() -> (index: Int, gate: SessionStreamGate) {
+        let index = callCount
+        callCount += 1
+        let gate = SessionStreamGate(preReleased: pendingReleases.remove(index) != nil)
+        gates[index] = gate
+        return (index, gate)
+    }
+    func release(callIndex index: Int) async {
+        if let gate = gates[index] { await gate.release() }
+        else { pendingReleases.insert(index) }
+    }
+}

--- a/vreaderTests/ViewModels/AIChatViewModelSessionsTests.swift
+++ b/vreaderTests/ViewModels/AIChatViewModelSessionsTests.swift
@@ -1,0 +1,709 @@
+// Purpose: Feature #88 WI-3 — pin AIChatViewModel session lifecycle + streaming
+// handoff. Covers: load most-recent-non-empty / no-persist-empty-on-open /
+// lazy-create-on-first-turn / save-on-settled-turn / newConversation
+// seals+resets / switch replaces messages / delete-active falls back /
+// title-from-first-user-message, PLUS the three async-race guards (cold-open,
+// transition token, streaming handoff) hardened by the Gate-2 audit.
+//
+// @coordinates-with: AIChatViewModel.swift, AIChatViewModel+Sessions.swift,
+//   AIChatViewModel+Streaming.swift, ChatSessionPersisting.swift,
+//   dev-docs/plans/20260605-feature-88-conversation-sessions.md (WI-3)
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("AIChatViewModelSessions")
+struct AIChatViewModelSessionsTests {
+
+    // MARK: - SUT helpers
+
+    private static let bookKey = "epub:aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233:1024"
+
+    @MainActor
+    private func makeFingerprint() -> DocumentFingerprint {
+        DocumentFingerprint(
+            contentSHA256: "aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233",
+            fileByteCount: 1024,
+            format: .epub
+        )
+    }
+
+    @MainActor
+    private func makeSUT(
+        store: MockChatSessionStore?,
+        provider: AIProvider? = nil,
+        bookChat: Bool = true
+    ) -> (AIChatViewModel, MockChatSessionStore?) {
+        let flags = FeatureFlags(environment: .prod)
+        flags.setOverride(true, for: .aiAssistant)
+        let stub = provider ?? {
+            let s = StubChatAIProvider()
+            s.stubbedResponse = AIResponse(
+                content: "AI reply", actionType: .questionAnswer,
+                promptVersion: "v1", createdAt: Date())
+            return s
+        }()
+        let service = AIService(
+            featureFlags: flags,
+            consentManager: WI11TestHelpers.makeConsentManager(hasConsent: true),
+            keychainService: WI11TestHelpers.makeKeychainService(),
+            provider: stub
+        )
+        let vm = AIChatViewModel(
+            aiService: service,
+            bookFingerprint: bookChat ? makeFingerprint() : nil,
+            contextWindowSize: 10,
+            chatSessionStore: store
+        )
+        return (vm, store)
+    }
+
+    // MARK: - loadSessions — load most-recent NON-EMPTY
+
+    @Test @MainActor func loadSessions_loadsMostRecentNonEmpty() async {
+        let store = MockChatSessionStore()
+        let older = store.seed(key: Self.bookKey, title: "Older",
+            messages: [ChatMessage(role: .user, content: "old q")], updatedAt: Date(timeIntervalSince1970: 100))
+        let newer = store.seed(key: Self.bookKey, title: "Newer",
+            messages: [ChatMessage(role: .user, content: "new q"),
+                       ChatMessage(role: .assistant, content: "new a")],
+            updatedAt: Date(timeIntervalSince1970: 200))
+        _ = older
+        let (vm, _) = makeSUT(store: store)
+
+        await vm.loadSessions()
+
+        #expect(vm.activeSessionId == newer)
+        #expect(vm.messages.count == 2)
+        #expect(vm.messages.first?.content == "new q")
+    }
+
+    @Test @MainActor func loadSessions_skipsEmptySessions_loadsFirstNonEmpty() async {
+        let store = MockChatSessionStore()
+        // The most-recent has 0 messages (a stale empty row); the load must skip it
+        // and pick the most-recent NON-EMPTY one.
+        _ = store.seed(key: Self.bookKey, title: "Empty", messages: [],
+                       updatedAt: Date(timeIntervalSince1970: 300))
+        let withContent = store.seed(key: Self.bookKey, title: "Has content",
+            messages: [ChatMessage(role: .user, content: "hi")],
+            updatedAt: Date(timeIntervalSince1970: 200))
+        let (vm, _) = makeSUT(store: store)
+
+        await vm.loadSessions()
+
+        #expect(vm.activeSessionId == withContent)
+        #expect(vm.messages.count == 1)
+    }
+
+    // MARK: - No persist empty on open
+
+    @Test @MainActor func loadSessions_noSessions_leavesEmptyState_noPersist() async {
+        let store = MockChatSessionStore()
+        let (vm, _) = makeSUT(store: store)
+
+        await vm.loadSessions()
+
+        #expect(vm.activeSessionId == nil)
+        #expect(vm.messages.isEmpty)
+        #expect(store.createCallCount == 0, "no empty session is persisted on open")
+    }
+
+    @Test @MainActor func loadSessions_nilStore_isNoOp() async {
+        let (vm, _) = makeSUT(store: nil)
+        await vm.loadSessions()
+        #expect(vm.activeSessionId == nil)
+        #expect(vm.messages.isEmpty)
+    }
+
+    @Test @MainActor func loadSessions_generalChat_nilFingerprint_isNoOp() async {
+        let store = MockChatSessionStore()
+        _ = store.seed(key: Self.bookKey, title: "x",
+            messages: [ChatMessage(role: .user, content: "q")], updatedAt: Date())
+        let (vm, _) = makeSUT(store: store, bookChat: false)
+
+        await vm.loadSessions()
+
+        #expect(vm.activeSessionId == nil)
+        #expect(vm.messages.isEmpty)
+        #expect(store.fetchSummariesCallCount == 0)
+    }
+
+    @Test @MainActor func loadSessions_idempotent_secondCallNoOps() async {
+        let store = MockChatSessionStore()
+        _ = store.seed(key: Self.bookKey, title: "x",
+            messages: [ChatMessage(role: .user, content: "q")], updatedAt: Date())
+        let (vm, _) = makeSUT(store: store)
+
+        await vm.loadSessions()
+        let firstFetchCount = store.fetchSummariesCallCount
+        await vm.loadSessions()
+
+        #expect(store.fetchSummariesCallCount == firstFetchCount, "second load is a no-op once loaded for the key")
+    }
+
+    @Test @MainActor func loadSessions_nonClobbering_skipsWhenMessagesPresent() async {
+        let store = MockChatSessionStore()
+        let seeded = store.seed(key: Self.bookKey, title: "x",
+            messages: [ChatMessage(role: .user, content: "q")], updatedAt: Date())
+        _ = seeded
+        let (vm, _) = makeSUT(store: store)
+        // Local state already has content (e.g. a fresh thread) → load must not run.
+        vm.messages = [ChatMessage(role: .user, content: "fresh local")]
+
+        await vm.loadSessions()
+
+        #expect(vm.messages.count == 1)
+        #expect(vm.messages.first?.content == "fresh local")
+        #expect(store.fetchSummariesCallCount == 0)
+    }
+
+    // MARK: - Lazy create on first turn + save on settled turn
+
+    @Test @MainActor func firstTurn_lazyCreatesSession_persistsOnSettled() async {
+        let store = MockChatSessionStore()
+        let (vm, _) = makeSUT(store: store)
+        await vm.loadSessions()      // empty book → no active session
+
+        await vm.sendMessage("What is this book about?")
+
+        #expect(vm.activeSessionId != nil, "the first real turn lazily creates a session")
+        #expect(store.createCallCount == 1)
+        // The created/updated session holds the user + assistant turn.
+        let saved = store.lastSavedMessages(for: vm.activeSessionId!)
+        #expect(saved?.count == 2)
+        #expect(saved?.first?.content == "What is this book about?")
+    }
+
+    @Test @MainActor func settledTurn_savesDebounced_notPerChunk() async {
+        let store = MockChatSessionStore()
+        let (vm, _) = makeSUT(store: store)
+        await vm.loadSessions()
+
+        await vm.sendMessage("hello")
+        // One persisted write for the settled turn (create), not per streamed chunk.
+        #expect(store.createCallCount + store.updateCallCount == 1)
+    }
+
+    @Test @MainActor func secondTurn_updatesExistingSession() async {
+        let store = MockChatSessionStore()
+        let (vm, _) = makeSUT(store: store)
+        await vm.loadSessions()
+
+        await vm.sendMessage("first")
+        let id = vm.activeSessionId
+        await vm.sendMessage("second")
+
+        #expect(vm.activeSessionId == id, "same session across turns")
+        #expect(store.createCallCount == 1)
+        #expect(store.updateCallCount >= 1)
+        #expect(store.lastSavedMessages(for: id!)?.count == 4)
+    }
+
+    // MARK: - Title from first user message
+
+    @Test @MainActor func title_derivedFromFirstUserMessage() async {
+        let store = MockChatSessionStore()
+        let (vm, _) = makeSUT(store: store)
+        await vm.loadSessions()
+
+        await vm.sendMessage("Explain the theme of loneliness")
+
+        let title = store.lastSavedTitle(for: vm.activeSessionId!)
+        #expect(title == "Explain the theme of loneliness")
+    }
+
+    @Test @MainActor func title_cjkFirstMessage_preserved() async {
+        let store = MockChatSessionStore()
+        let (vm, _) = makeSUT(store: store)
+        await vm.loadSessions()
+
+        await vm.sendMessage("解释这本书的主题")
+
+        #expect(store.lastSavedTitle(for: vm.activeSessionId!) == "解释这本书的主题")
+    }
+
+    // MARK: - newConversation seals + resets
+
+    @Test @MainActor func newConversation_sealsCurrent_resetsToEmpty() async {
+        let store = MockChatSessionStore()
+        let (vm, _) = makeSUT(store: store)
+        await vm.loadSessions()
+        await vm.sendMessage("first thread")
+        let firstId = vm.activeSessionId
+
+        await vm.newConversation()
+
+        #expect(vm.activeSessionId == nil, "reset to the empty state")
+        #expect(vm.messages.isEmpty)
+        // The sealed session still exists in the store with its content.
+        #expect(store.lastSavedMessages(for: firstId!)?.isEmpty == false)
+        // No empty session is created for the new (not-yet-used) thread.
+        #expect(store.createCallCount == 1)
+    }
+
+    @Test @MainActor func newConversation_thenSend_createsSecondSession() async {
+        let store = MockChatSessionStore()
+        let (vm, _) = makeSUT(store: store)
+        await vm.loadSessions()
+        await vm.sendMessage("thread A")
+        let a = vm.activeSessionId
+        await vm.newConversation()
+        await vm.sendMessage("thread B")
+        let b = vm.activeSessionId
+
+        #expect(a != b)
+        #expect(store.createCallCount == 2)
+    }
+
+    // MARK: - switch replaces messages
+
+    @Test @MainActor func switchToSession_replacesMessages_savesCurrent() async {
+        let store = MockChatSessionStore()
+        let target = store.seed(key: Self.bookKey, title: "Target",
+            messages: [ChatMessage(role: .user, content: "target q"),
+                       ChatMessage(role: .assistant, content: "target a")],
+            updatedAt: Date(timeIntervalSince1970: 50))
+        let (vm, _) = makeSUT(store: store)
+        await vm.loadSessions()           // loads "Target" (only non-empty)
+        // Move off Target onto a fresh thread with content.
+        await vm.newConversation()
+        await vm.sendMessage("current thread")
+        let current = vm.activeSessionId
+
+        await vm.switchToSession(target)
+
+        #expect(vm.activeSessionId == target)
+        #expect(vm.messages.count == 2)
+        #expect(vm.messages.first?.content == "target q")
+        // The previously-active thread was saved before switching away.
+        #expect(store.lastSavedMessages(for: current!)?.isEmpty == false)
+    }
+
+    // MARK: - delete active falls back
+
+    @Test @MainActor func deleteActiveSession_fallsBackToMostRecentRemaining() async {
+        let store = MockChatSessionStore()
+        let other = store.seed(key: Self.bookKey, title: "Other",
+            messages: [ChatMessage(role: .user, content: "other")],
+            updatedAt: Date(timeIntervalSince1970: 10))
+        let (vm, _) = makeSUT(store: store)
+        await vm.loadSessions()
+        await vm.newConversation()
+        await vm.sendMessage("to be deleted")
+        let active = vm.activeSessionId!
+
+        await vm.deleteSession(active)
+
+        #expect(store.deletedIds.contains(active))
+        #expect(vm.activeSessionId == other, "falls back to the most-recent remaining")
+        #expect(vm.messages.first?.content == "other")
+    }
+
+    @Test @MainActor func deleteActiveSession_noneRemaining_resetsToEmpty() async {
+        let store = MockChatSessionStore()
+        let (vm, _) = makeSUT(store: store)
+        await vm.loadSessions()
+        await vm.sendMessage("only thread")
+        let active = vm.activeSessionId!
+
+        await vm.deleteSession(active)
+
+        #expect(vm.activeSessionId == nil)
+        #expect(vm.messages.isEmpty)
+    }
+
+    // MARK: - rename active
+
+    @Test @MainActor func renameActiveSession_renamesInStore() async {
+        let store = MockChatSessionStore()
+        let (vm, _) = makeSUT(store: store)
+        await vm.loadSessions()
+        await vm.sendMessage("hi")
+        let id = vm.activeSessionId!
+
+        await vm.renameActiveSession("My renamed thread")
+
+        #expect(store.lastRenamedTitle(for: id) == "My renamed thread")
+    }
+
+    // MARK: - RACE: switch mid-send cancels stream + reply does NOT land in new session
+
+    @Test @MainActor func switchMidSend_cancelsStream_replyDoesNotLandInNewSession() async {
+        let store = MockChatSessionStore()
+        let target = store.seed(key: Self.bookKey, title: "Target",
+            messages: [ChatMessage(role: .user, content: "target only")],
+            updatedAt: Date(timeIntervalSince1970: 5))
+        let gated = SessionGatedProvider()
+        gated.firstChunk = "leaking "
+        gated.secondChunk = "into wrong session"
+        let (vm, _) = makeSUT(store: store, provider: gated)
+        await vm.loadSessions()
+        // Start a fresh thread and send (parks mid-stream after the first chunk).
+        await vm.newConversation()
+        let send = Task { @MainActor in await vm.sendMessage("question on thread A") }
+        while vm.messages.last?.content.isEmpty ?? true { await Task.yield() }
+
+        // Switch to Target while the stream is parked. This must cancel the stream.
+        await vm.switchToSession(target)
+        #expect(vm.activeSessionId == target)
+        #expect(vm.messages.count == 1)
+        #expect(vm.messages.first?.content == "target only")
+
+        // Release the now-stale producer; its second chunk must NOT land in Target.
+        await gated.releaseGate(callIndex: 0)
+        await send.value
+
+        #expect(vm.activeSessionId == target)
+        #expect(vm.messages.count == 1, "the cancelled reply does not append to the switched-to session")
+        #expect(vm.messages.first?.content == "target only")
+        // Target's stored messages were not mutated by the stale reply.
+        let targetStored = store.lastSavedMessages(for: target) ?? store.seededMessages(for: target)
+        #expect(targetStored?.count == 1)
+    }
+
+    // MARK: - RACE: rapid B→C switch — the older B load is abandoned (transition token)
+
+    @Test @MainActor func rapidSwitch_BthenC_olderLoadAbandoned() async {
+        let store = MockChatSessionStore()
+        let b = store.seed(key: Self.bookKey, title: "B",
+            messages: [ChatMessage(role: .user, content: "B content")],
+            updatedAt: Date(timeIntervalSince1970: 20))
+        let c = store.seed(key: Self.bookKey, title: "C",
+            messages: [ChatMessage(role: .user, content: "C content")],
+            updatedAt: Date(timeIntervalSince1970: 30))
+        // Gate B's fetch so we can fire the C switch before B resolves.
+        await store.gateFetch(for: b)
+        let (vm, _) = makeSUT(store: store)
+
+        let switchB = Task { @MainActor in await vm.switchToSession(b) }
+        // Wait until B's fetch is parked (inside the serialized lane).
+        while await store.parkedFetchCount < 1 { await Task.yield() }
+
+        // Fire C while B is parked. C's synchronous pre-lane bumps the transition
+        // token (superseding B); C's body queues behind B in the lane. Don't await
+        // it here — that would deadlock behind B's parked fetch. Release B, then drain
+        // both: B's body resumes, fails its token/id re-check, and is abandoned; C wins.
+        let switchC = Task { @MainActor in await vm.switchToSession(c) }
+        await store.releaseFetch(for: b)
+        _ = await switchB.value
+        _ = await switchC.value
+
+        #expect(vm.activeSessionId == c, "the newer C switch wins (serialized; C drains last)")
+        #expect(vm.messages.first?.content == "C content")
+    }
+
+    // MARK: - RACE: cold open — send before loadSessions resolves → sent turn wins
+
+    @Test @MainActor func coldOpen_sendBeforeLoadResolves_sentTurnWins_loadAbandoned() async {
+        let store = MockChatSessionStore()
+        let prior = store.seed(key: Self.bookKey, title: "Prior",
+            messages: [ChatMessage(role: .user, content: "prior q"),
+                       ChatMessage(role: .assistant, content: "prior a")],
+            updatedAt: Date(timeIntervalSince1970: 40))
+        _ = prior
+        // Gate the summaries fetch so loadSessions parks before applying.
+        await store.gateSummariesFetch()
+        let (vm, _) = makeSUT(store: store)
+
+        let load = Task { @MainActor in await vm.loadSessions() }
+        while await store.parkedSummariesCount < 1 { await Task.yield() }
+
+        // The user sends a first message BEFORE the load resolves. Fire it without
+        // awaiting (its settled-turn save queues behind the parked load in the lane;
+        // awaiting here would deadlock). The user message is appended synchronously
+        // and `noteFirstTurnStartedIfNeeded` bumps the token — both abandon the load.
+        let send = Task { @MainActor in await vm.sendMessage("brand new question") }
+        while !vm.messages.contains(where: { $0.content == "brand new question" }) { await Task.yield() }
+
+        // Release the parked load; it must ABANDON (messages non-empty + token bumped).
+        await store.releaseSummariesFetch()
+        _ = await send.value
+        _ = await load.value
+
+        #expect(vm.activeSessionId != prior, "the sent turn wins; the load is abandoned")
+        #expect(vm.activeSessionId != nil, "the first turn lazily created its own session")
+        #expect(vm.messages.contains { $0.content == "brand new question" })
+        #expect(!vm.messages.contains { $0.content == "prior q" })
+    }
+
+    // MARK: - RACE (Gate-4 WI-3 High): transition seals the SETTLED snapshot, not the abandoned in-flight turn
+
+    @Test @MainActor func transitionMidSend_sealsSettledSnapshot_noPartialPersisted() async {
+        let store = MockChatSessionStore()
+        let gated = SessionGatedProvider()
+        gated.firstChunk = "answer 1"
+        let (vm, _) = makeSUT(store: store, provider: gated)
+        await vm.loadSessions()
+
+        // Turn 1: send + let it settle (lazily creates the session).
+        let t1 = Task { @MainActor in await vm.sendMessage("first question") }
+        while vm.messages.last?.content.isEmpty ?? true { await Task.yield() }
+        await gated.releaseGate(callIndex: 0)
+        await t1.value
+        let sourceId = try! #require(vm.activeSessionId)
+        #expect(store.lastSavedMessages(for: sourceId)?.count == 2)   // user1 + assistant1 settled
+
+        // Turn 2: send, parks mid-stream (the assistant placeholder gets a partial chunk).
+        gated.firstChunk = "partial 2"
+        let t2 = Task { @MainActor in await vm.sendMessage("second question") }
+        while vm.messages.count < 4 { await Task.yield() }
+        while vm.messages.last?.content.isEmpty ?? true { await Task.yield() }
+
+        // Transition while turn 2 is in flight — must persist ONLY the settled snapshot.
+        await vm.newConversation()
+
+        let stored = store.lastSavedMessages(for: sourceId)
+        #expect(stored?.count == 2,
+                "the abandoned in-flight turn is NOT persisted into the source session (settled snapshot only)")
+        #expect(stored?.first?.content == "first question")
+        #expect(stored?.contains { $0.content == "second question" } == false)
+
+        await gated.releaseGate(callIndex: 1)   // cleanup
+        await t2.value
+    }
+
+    @Test @MainActor func transitionDuringFirstTurnCreate_doesNotLeaveOrphanSession() async {
+        let store = MockChatSessionStore()
+        let gated = SessionGatedProvider()
+        gated.firstChunk = "answer"
+        let (vm, _) = makeSUT(store: store, provider: gated)
+        await vm.loadSessions()
+
+        // First turn: complete the stream so saveSettledTurn reaches createChatSession,
+        // which we park so a transition can race the create.
+        await store.gateCreate()
+        let t1 = Task { @MainActor in await vm.sendMessage("first") }
+        while vm.messages.last?.content.isEmpty ?? true { await Task.yield() }
+        await gated.releaseGate(callIndex: 0)                 // stream completes → create parks
+        while await store.parkedCreateCount < 1 { await Task.yield() }
+
+        // Transition while the first-turn create is parked. newConversation's
+        // SYNCHRONOUS pre-lane bumps the token immediately (superseding the turn);
+        // its body queues behind the parked create in the lane. Fire without awaiting
+        // (awaiting would deadlock behind the parked create), let the sync bump run,
+        // then release the create so saveSettledTurn resumes, sees the bumped token,
+        // and rolls back the orphan.
+        let newConv = Task { @MainActor in await vm.newConversation() }
+        for _ in 0..<5 { await Task.yield() }                 // let the synchronous token bump run
+        await store.releaseCreate()                           // the parked create returns
+        _ = await newConv.value
+        _ = await t1.value
+
+        #expect(store.sessionRowCount == 0,
+                "the abandoned first-turn create is rolled back — no orphan/duplicate session")
+        #expect(vm.activeSessionId == nil)
+        #expect(vm.messages.isEmpty)
+    }
+
+    @Test @MainActor func orphanCleanupFailure_leavesVMClean_retainsRow() async {
+        // Gate-4 WI-3 r2 Medium: if the orphan-cleanup delete FAILS, the failure is
+        // logged (not swallowed) and must not crash / corrupt the VM — the VM is in
+        // the post-transition empty state; only a harmless abandoned row is retained.
+        let store = MockChatSessionStore()
+        store.failDelete = true
+        let gated = SessionGatedProvider()
+        gated.firstChunk = "answer"
+        let (vm, _) = makeSUT(store: store, provider: gated)
+        await vm.loadSessions()
+
+        await store.gateCreate()
+        let t1 = Task { @MainActor in await vm.sendMessage("first") }
+        while vm.messages.last?.content.isEmpty ?? true { await Task.yield() }
+        await gated.releaseGate(callIndex: 0)
+        while await store.parkedCreateCount < 1 { await Task.yield() }
+
+        // Fire the transition without awaiting (its body queues behind the parked
+        // create in the lane); let the synchronous token bump run, then release.
+        let newConv = Task { @MainActor in await vm.newConversation() }
+        for _ in 0..<5 { await Task.yield() }
+        await store.releaseCreate()           // create returns; cleanup delete THROWS (logged)
+        _ = await newConv.value
+        _ = await t1.value
+
+        #expect(store.sessionRowCount == 1, "a failed cleanup leaves the abandoned row (logged, not silently lost)")
+        #expect(vm.activeSessionId == nil, "the VM is still in the clean post-transition empty state")
+        #expect(vm.messages.isEmpty)
+    }
+
+    @Test @MainActor func transitionDuringExistingSessionUpdate_sealsFreshSnapshot_noStaleOverwrite() async {
+        // Gate-4 WI-3 r4 High: a transition racing an existing-session settled-turn
+        // UPDATE must seal the FRESH snapshot (promoted before the persistence await),
+        // not the older one that would overwrite the just-settled turn (data loss).
+        let store = MockChatSessionStore()
+        let gated = SessionGatedProvider()
+        gated.firstChunk = "a1"
+        let (vm, _) = makeSUT(store: store, provider: gated)
+        await vm.loadSessions()
+
+        // Turn 1: settle (creates the session; settledMessages = [u1, a1]).
+        let t1 = Task { @MainActor in await vm.sendMessage("q1") }
+        while vm.messages.last?.content.isEmpty ?? true { await Task.yield() }
+        await gated.releaseGate(callIndex: 0)
+        await t1.value
+        let sid = try! #require(vm.activeSessionId)
+
+        // Turn 2: gate the settled-turn UPDATE so it parks; the snapshot is promoted
+        // before that parked await.
+        gated.firstChunk = "a2"
+        await store.gateUpdate()
+        let t2 = Task { @MainActor in await vm.sendMessage("q2") }
+        while vm.messages.count < 4 { await Task.yield() }
+        await gated.releaseGate(callIndex: 1)                 // stream done → saveSettledTurn → update parks
+        while await store.parkedUpdateCount < 1 { await Task.yield() }
+
+        // Transition while the settled update is parked. Fire without awaiting (its
+        // body queues behind the parked update in the lane; awaiting deadlocks). The
+        // settled snapshot was promoted BEFORE the update await (r4 fix), so neither
+        // the parked update nor the subsequent seal can lose turn 2. Release the
+        // update, drain the lane, then assert the persisted snapshot is fresh.
+        let newConv = Task { @MainActor in await vm.newConversation() }
+        for _ in 0..<5 { await Task.yield() }
+        await store.releaseUpdate()                           // parked update completes, then the seal
+        _ = await newConv.value
+        _ = await t2.value
+
+        let sealed = store.lastSavedMessages(for: sid)
+        #expect(sealed?.count == 4,
+                "turn 2 is persisted (settled snapshot promoted before the await) — not dropped by a stale overwrite")
+        #expect(sealed?.contains { $0.content == "q2" } == true)
+    }
+
+    // MARK: - RACE (Gate-4 structural): the serial lane — an unrelated delete during a
+    // settled-turn save for the ACTIVE session does not corrupt the active session.
+
+    @Test @MainActor func unrelatedDeleteDuringActiveSave_doesNotLoseActiveMessages() async {
+        // While a settled-turn UPDATE for the ACTIVE session is in flight (gated),
+        // delete an unrelated NON-active session. With the serial lane the delete
+        // waits for the save to fully complete, so the two cannot interleave across
+        // the await — the active session's just-settled messages are not lost.
+        let store = MockChatSessionStore()
+        let gated = SessionGatedProvider()
+        gated.firstChunk = "a1"
+        let (vm, _) = makeSUT(store: store, provider: gated)
+        await vm.loadSessions()      // empty store → no active session
+
+        // Turn 1: settle so the active session exists (create) + settledMessages set.
+        let t1 = Task { @MainActor in await vm.sendMessage("active q1") }
+        while vm.messages.last?.content.isEmpty ?? true { await Task.yield() }
+        await gated.releaseGate(callIndex: 0)
+        await t1.value
+        let active = try! #require(vm.activeSessionId)
+
+        // Seed a SEPARATE non-active session AFTER the active one is established, so
+        // it is never the active session and a fallback never targets it.
+        let other = store.seed(key: Self.bookKey, title: "Other (non-active)",
+            messages: [ChatMessage(role: .user, content: "other content")],
+            updatedAt: Date(timeIntervalSince1970: 5))
+        #expect(other != active)
+
+        // Turn 2: gate the settled-turn UPDATE so the save parks mid-lane.
+        gated.firstChunk = "a2"
+        await store.gateUpdate()
+        let t2 = Task { @MainActor in await vm.sendMessage("active q2") }
+        while vm.messages.count < 4 { await Task.yield() }
+        await gated.releaseGate(callIndex: 1)                 // stream done → saveSettledTurn → update parks
+        while await store.parkedUpdateCount < 1 { await Task.yield() }
+
+        // Delete the UNRELATED non-active session while the active save is parked.
+        let del = Task { @MainActor in await vm.deleteSession(other) }
+        // The delete must NOT have run yet — it is queued behind the parked save on
+        // the lane (no interleave). Release the save so the lane drains in order.
+        await store.releaseUpdate()
+        await t2.value
+        await del.value
+
+        #expect(store.deletedIds.contains(other), "the unrelated session was deleted")
+        #expect(vm.activeSessionId == active, "the active session is unchanged")
+        // The active session keeps its 4-message settled turn — not clobbered by the
+        // interleaved delete.
+        let saved = store.lastSavedMessages(for: active)
+        #expect(saved?.count == 4)
+        #expect(saved?.contains { $0.content == "active q2" } == true)
+        #expect(vm.messages.count == 4)
+    }
+
+    // MARK: - RACE (Gate-4 WI-3 r6 High): deleting a NON-active session must NOT
+    // cancel the ACTIVE session's in-flight stream nor drop its settled-turn save.
+
+    @Test @MainActor func nonActiveDeleteDuringActiveStream_doesNotCancelStream_norLoseTurn() async {
+        // A non-active delete must not be treated as a transition against the active
+        // send: if it cancelled the active stream (bumping `opCounter`), `runSend`
+        // would skip `saveSettledTurn` (opId != opCounter) and the active session's
+        // latest turn would never be persisted — a later seal would then write the
+        // older snapshot. `deleteSession` only cancels/supersedes when the deleted
+        // session IS the active one.
+        let store = MockChatSessionStore()
+        let gated = SessionGatedProvider()
+        gated.firstChunk = "a1"
+        let (vm, _) = makeSUT(store: store, provider: gated)
+        await vm.loadSessions()      // empty store → no active session
+
+        // Turn 1: settle so the active session exists + settledMessages set.
+        let t1 = Task { @MainActor in await vm.sendMessage("active q1") }
+        while vm.messages.last?.content.isEmpty ?? true { await Task.yield() }
+        await gated.releaseGate(callIndex: 0)
+        await t1.value
+        let active = try! #require(vm.activeSessionId)
+        #expect(store.lastSavedMessages(for: active)?.count == 2)
+
+        // Seed a SEPARATE non-active session.
+        let other = store.seed(key: Self.bookKey, title: "Other (non-active)",
+            messages: [ChatMessage(role: .user, content: "other content")],
+            updatedAt: Date(timeIntervalSince1970: 5))
+        #expect(other != active)
+
+        // Turn 2 on the ACTIVE session: parks mid-stream (gate 1 not yet released).
+        gated.firstChunk = "a2"
+        let t2 = Task { @MainActor in await vm.sendMessage("active q2") }
+        while vm.messages.count < 4 { await Task.yield() }
+        while vm.messages.last?.content.isEmpty ?? true { await Task.yield() }
+
+        // Delete the UNRELATED non-active session while turn 2's stream is parked.
+        // This must NOT cancel the active stream (no opCounter bump for a non-active
+        // delete), so turn 2 still reaches its settled-turn save.
+        await vm.deleteSession(other)
+        #expect(store.deletedIds.contains(other), "the unrelated session was deleted")
+        #expect(vm.activeSessionId == active, "a non-active delete leaves the active session unchanged")
+
+        // Release turn 2's stream; it must COMPLETE and persist the settled turn.
+        await gated.releaseGate(callIndex: 1)
+        await t2.value
+
+        let saved = store.lastSavedMessages(for: active)
+        #expect(saved?.count == 4,
+                "the active turn is saved — the non-active delete did not cancel its stream")
+        #expect(saved?.contains { $0.content == "active q2" } == true)
+    }
+
+    // MARK: - RACE (Gate-4 structural): two concurrent transitions serialize to a
+    // CLEAN single-session end state (no corruption). The deterministic
+    // "later-wins" case is covered by `rapidSwitch_BthenC_olderLoadAbandoned`,
+    // which orders the two transitions via a gated fetch.
+
+    @Test @MainActor func concurrentTransitions_serialize_toCleanSingleSession() async {
+        let store = MockChatSessionStore()
+        let b = store.seed(key: Self.bookKey, title: "B",
+            messages: [ChatMessage(role: .user, content: "B content")],
+            updatedAt: Date(timeIntervalSince1970: 20))
+        let c = store.seed(key: Self.bookKey, title: "C",
+            messages: [ChatMessage(role: .user, content: "C content")],
+            updatedAt: Date(timeIntervalSince1970: 30))
+        let (vm, _) = makeSUT(store: store)
+        await vm.loadSessions()       // loads C (most-recent non-empty)
+
+        // `async let` gives NO ordering guarantee on which switch runs its
+        // synchronous pre-lane (token bump) first, so which one "wins" is not
+        // deterministic. The serial lane's guarantee is that the two bodies cannot
+        // interleave — the end state is ONE cleanly-loaded session, never a mix.
+        async let first: Void = vm.switchToSession(b)
+        async let second: Void = vm.switchToSession(c)
+        _ = await (first, second)
+
+        #expect(vm.messages.count == 1, "no interleave corruption — exactly one session loaded")
+        let landed = vm.activeSessionId
+        #expect(landed == b || landed == c, "the end state is cleanly one of the two sessions")
+        if landed == b { #expect(vm.messages.first?.content == "B content") }
+        if landed == c { #expect(vm.messages.first?.content == "C content") }
+    }
+}


### PR DESCRIPTION
## Summary

WI-3 of feature #88 (AI conversation sessions). Adds the chat-session lifecycle to `AIChatViewModel`: one-shot load of the most-recent non-empty session, lazy create-on-first-turn, debounced settled-turn save, and the switch / new / rename / delete transitions — wired into the streaming send path (`+Streaming`).

Every session-mutating op runs through ONE serialized async lane (`runSerializedSessionOp`) so two ops can never interleave across an `await` on the @MainActor. This is the **Gate-4 structural fix** that closes the whole interleaving-race class (lost messages / wrong active session / duplicate orphan / stuck load) after five prior point-patch rounds.

Part of feature #88 — GH #1523.

## What changed

- `AIChatViewModel.swift` — `runSerializedSessionOp` serial lane + session plumbing (`activeSessionId`, `settledMessages`, `sessionTransitionToken`, `loadedFingerprintKey`).
- `AIChatViewModel+Sessions.swift` (new) — `loadSessions` (cold-open-safe, idempotent, non-clobbering) + the lazy-create / settled-turn save.
- `AIChatViewModel+SessionTransitions.swift` (new) — switch / new / rename / delete + non-laned seal/fallback helpers. `deleteSession` only cancels the active stream + supersedes the active send when the deleted session **is** the active one (a non-active delete must not drop the active turn's save — Gate-4 r6 High).
- `AIChatViewModel+Streaming.swift` — `saveSettledTurn` hook + `noteFirstTurnStartedIfNeeded` + `cancelStreamingForTransition`.
- View wiring (`AIChatView`, `ReaderAICoordinator`, `ReaderContainerView`) — one-shot `loadSessions` ownership.

## Codex Audit

`follow-up-recommended` — 7 rounds. Rounds 1–4 point-fixed real races; round 5 was the auditor's structural recommendation (the serial lane); round 6 confirmed the lane (Q1 serialization / Q2 deadlock-free / Q3 the R5 delete-race closed / Q4 pre-lane ordering / Q5 Swift 6 — all clean) and found one separate High (non-active delete cancelling the active stream), fixed + regression-tested; round 7 confirmed the fix clean. Audit log: `.claude/codex-audits/feat-feature-88-wi-3-vm-session-lifecycle-audit.md`.

## Validation

- [x] **73 tests across 4 AIChatViewModel suites pass** — 28 session (incl. the new `nonActiveDeleteDuringActiveStream` regression + the de-flaked `concurrentTransitions_serialize_toCleanSingleSession`) + 45 base/agentic/whole-book. `RUN-TESTS RESULT: SUCCEEDED`, `** TEST SUCCEEDED **`, 0 failures.
- [x] Tests cover changed behavior (TDD): load / lazy-create / save / switch / new / rename / delete + the cold-open, rapid-switch, orphan-cleanup, fresh-snapshot-seal, unrelated-delete-during-save/stream race guards.
- [x] Codex audit loop complete (7 rounds, verdict follow-up-recommended).
- [x] Docs sync — `architecture.md` updated (SchemaV9 + ChatSession entity + the session lane).
- [x] Version bumped: 3.55.2 → 3.55.3.

## Slice verification (Gate 5)

WI-3 is a VM-lifecycle WI with **no user-visible surface yet** — the session bar (WI-4) and Conversations sheet (WI-5) are where the lifecycle becomes UI-driveable. Its behavior is exercised end-to-end through the VM's real public API by the 73 unit tests (load → send → settle → save → switch / new / delete, plus the async race guards). On-device UI verification lands with WI-4/WI-5.

## Type of Change

- [x] Feature work item (Part of feature #88 / GH #1523)