### PR TITLE
feat(#88 WI-4): Chat-tab session bar

### DIFF
--- a/.claude/codex-audits/feat-feature-88-wi-4-session-bar-audit.md
+++ b/.claude/codex-audits/feat-feature-88-wi-4-session-bar-audit.md
@@ -1,0 +1,66 @@
+---
+branch: feat/feature-88-wi-4-session-bar
+threadId: 019e97c3-1503-7a21-9fff-f0c2b55cc3cb
+rounds: 3
+final_verdict: follow-up-recommended
+date: 2026-06-05
+---
+
+# Gate-4 audit — Feature #88 WI-4 (Chat-tab session bar)
+
+WI-4 adds the slim session bar at the top of the Chat tab (book chat only): the
+active conversation's title + chevron (left) and a "New" compose pill (right),
+per the committed `SessionBar` artboard (Rule 51). New SwiftUI view
+`ChatSessionBar.swift`, a VM `activeSessionTitle`/`storedActiveTitle`, and the
+`AIChatView` wiring (bar at top, toolbar trash gated to general chat).
+
+## Round history
+
+| Round | Findings | Resolution |
+|---|---|---|
+| 1 (`019e97b4`) | **M1** `activeSessionTitle` always re-derived from `messages` (wrong for renamed / stored-title-differs sessions); **M2** `showConversations` set-true-never-reset → sticky chevron/wash; Lows: test coverage, SF-Symbol fidelity, file size. Plus an orchestrator-caught `UIScreen.main` 74% width. | see below |
+| 2 (`019e97bd`) | M2 **resolved**. M1 only partially resolved (display side) — the deeper bug is on the PERSISTENCE side: `_saveSettledTurn` + `sealCurrentSessionIfNeeded` re-derive + overwrite the stored title on every update/seal, so a later turn / transition reverts a renamed title. Two Mediums. | see below |
+| 3 (`019e97c3`) | **clean** — both round-2 Mediums resolved; carry-forward contract verified in the real store + mock; create path correct; regression tests pin it; no new Critical/High/Medium. | — |
+
+## Fixes applied
+
+**Orchestrator-caught (pre-round-1 in review)** — `ChatSessionBar` capped the title
+at `UIScreen.main.bounds.width * 0.74` (deprecated API + wrong for a non-fullscreen
+sheet). Replaced with responsive layout: `Spacer(minLength: 8)` + `.layoutPriority(1)`
+on the New pill so a long title truncates (lineLimit 1, tail) instead of pushing
+New off — correct at any bar width.
+
+**M2 (sticky open)** — removed the `showConversations` `@State`; the bar is passed
+`isOpen: false` + `onTitleTap: {}` (inert) until WI-5 wires the actual
+Conversations sheet (then `isOpen` binds to the sheet presentation). No sticky
+local state; the New button still works.
+
+**M1 — display side** — added an observed `internal(set) var storedActiveTitle: String?`;
+`activeSessionTitle = storedActiveTitle ?? derivedTitle(from: messages) ?? defaultSessionTitle`.
+`storedActiveTitle` is set = `record.title` on load / switch / delete-fallback /
+first-turn create-adopt, and reset to nil on newConversation + the active-delete
+reset. So a loaded/switched session shows its STORED title; a fresh thread derives.
+
+**M1 — persistence side (round 2)** — `_saveSettledTurn` and `sealCurrentSessionIfNeeded`
+now pass `title: nil` on the UPDATE branch (existing session), so a later settled
+turn / transition seal preserves the stored title via the store's carry-forward
+contract (`PersistenceActor+ChatSessions.swift:119` assigns title only when non-nil;
+the mock mirrors it). The title is set only at CREATE (derived) + on rename (WI-5).
+Pinned by `storedTitle_survivesLaterSettledTurn` + `storedTitle_survivesNewConversationSeal`
+(both fail pre-fix).
+
+## Accepted Lows
+
+- **SF-Symbol fidelity** — the bar uses `bubble.left` / `chevron.down` / `plus` SF
+  Symbols rather than the artboard's custom outlined glyphs. SF Symbols are the
+  app-wide convention (ChatContextBar etc.); the match is faithful. Accepted.
+- **File size** — `AIChatView.swift` is ~331 lines (35 over the ~300 soft guideline).
+  WI-4's additions are minimal cohesive wiring; a dedicated extraction is deferred
+  (not worth a churny split mid-feature). Accepted.
+
+## Verdict
+
+`follow-up-recommended`. The WI-4 surface is clean (3 audit rounds → 0 open
+Critical/High/Medium). The follow-up is WI-5: wire the title-tap → Conversations
+sheet, bind `isOpen` to the sheet presentation, and add rename (which will set
+`storedActiveTitle`). 38 tests across the title + sessions suites pass.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 893
-        MARKETING_VERSION: 3.55.3
+        CURRENT_PROJECT_VERSION: 894
+        MARKETING_VERSION: 3.55.4
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -306,6 +306,7 @@
 		2F83E3F7A71F46B472372C2B /* ReaderTOCTXTAlignmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44CDE923DD9CB934E3E42969 /* ReaderTOCTXTAlignmentTests.swift */; };
 		2FA04FC59FECB40C45FAD4D8 /* LocatorFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055FBEA382F82BE342A50C8E /* LocatorFactoryTests.swift */; };
 		2FAEAAB8498E00263D366E37 /* AIAssistantViewModelScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EE0734EE0796711AE09253D /* AIAssistantViewModelScopeTests.swift */; };
+		2FD8E6F49FE9DEBAF76E19FC /* AIChatViewModelTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EF7D18AAA34BD2158A1DB5 /* AIChatViewModelTitleTests.swift */; };
 		2FDBB9D830B8DC7FF418BD3D /* DebugSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA61DA459242CFDBBD809B7 /* DebugSnapshotTests.swift */; };
 		30043FDF6F3A8F38D2891AF1 /* ReaderContainerView+Sheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C77872C4F869769F4C83F7 /* ReaderContainerView+Sheets.swift */; };
 		301498E0C7A6CBC1E7E8DF49 /* FoliateCoordinatorBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC4E330CF0A4F1EBF039346 /* FoliateCoordinatorBox.swift */; };
@@ -321,6 +322,7 @@
 		3175AC389AA08324899106EC /* TOCSheetRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80042D2F170FF72D3792F03E /* TOCSheetRows.swift */; };
 		319AE1251458BD5F7BFBF5A1 /* NotesRowStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E27899DB05507AB2F13CDE /* NotesRowStateTests.swift */; };
 		31AA6ED885B4A7D78A1FAD29 /* TXTPagedChapterAdvanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12F4D45796EA04FB6D5C3F9 /* TXTPagedChapterAdvanceTests.swift */; };
+		31C4C7448AE362451EE62CAA /* ChatSessionBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455E716DF296F69178DF2F35 /* ChatSessionBar.swift */; };
 		31F5B5AEC09F731ACEB8A46E /* Feature63SearchPanelVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1332F42A0C57EA1D1F37D9C0 /* Feature63SearchPanelVerificationTests.swift */; };
 		320025CDBC69B31CC1B4DEAA /* PDFReaderContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2BA1A05E4E36D5D7B2DCFD /* PDFReaderContainerView.swift */; };
 		3217F149B278D3D88B6AC17F /* AISummaryTabViewScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC9AC43028A99A994A7747B /* AISummaryTabViewScopeTests.swift */; };
@@ -2012,6 +2014,7 @@
 		450FC9EBF7835D39CA42C0EC /* SettingsRowPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRowPaletteTests.swift; sourceTree = "<group>"; };
 		453A5F80C353442B3C88C611 /* HighlightPaintColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightPaintColor.swift; sourceTree = "<group>"; };
 		4559FD0011E0F990013EAE48 /* TXTChapterHighlightCreationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterHighlightCreationTests.swift; sourceTree = "<group>"; };
+		455E716DF296F69178DF2F35 /* ChatSessionBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatSessionBar.swift; sourceTree = "<group>"; };
 		455F8B9D85F0DD60D657D6FE /* BilingualParagraphRanges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualParagraphRanges.swift; sourceTree = "<group>"; };
 		456FDDA03D7DEF3A4AEB01DB /* TOCBuilderMDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOCBuilderMDTests.swift; sourceTree = "<group>"; };
 		457E4B76590E361D08897EC3 /* ChatContextScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatContextScope.swift; sourceTree = "<group>"; };
@@ -2176,6 +2179,7 @@
 		59C9E78D6768871560C6C7CB /* ChapterTextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterTextProviderTests.swift; sourceTree = "<group>"; };
 		59D4242F8E27621A0CF36842 /* xmlwriter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = xmlwriter.h; sourceTree = "<group>"; };
 		59ECD5BE8EE959A2EF3E208E /* PersistenceActor+ReadingPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+ReadingPosition.swift"; sourceTree = "<group>"; };
+		59EF7D18AAA34BD2158A1DB5 /* AIChatViewModelTitleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatViewModelTitleTests.swift; sourceTree = "<group>"; };
 		5A3C9E1EE2F6EA56F40872E6 /* EPUBReaderContainerView+Bilingual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EPUBReaderContainerView+Bilingual.swift"; sourceTree = "<group>"; };
 		5A54A2C5DE8C1631C04BB2A1 /* PDFProgressHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFProgressHelper.swift; sourceTree = "<group>"; };
 		5A746E0EDC5F1208A0774008 /* ReadiumEPUBHost+Body.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReadiumEPUBHost+Body.swift"; sourceTree = "<group>"; };
@@ -3537,6 +3541,7 @@
 				C4DC0576C2BB5F79C6744494 /* AIChatViewModelSessionsTestHelpers.swift */,
 				6683E529266E0E54B1A85BA0 /* AIChatViewModelSessionsTests.swift */,
 				E861A379A620B769CEA36300 /* AIChatViewModelTests.swift */,
+				59EF7D18AAA34BD2158A1DB5 /* AIChatViewModelTitleTests.swift */,
 				88425F3137F5EDCF6D04AB6A /* AIChatViewModelWholeBookTests.swift */,
 				4E7196BED97C3B45955EC89D /* AIProviderPickerViewModelTests.swift */,
 				4E706779E64026004319957F /* AIReaderIntegrationTests.swift */,
@@ -4304,6 +4309,7 @@
 				02C8F2C0DD4DC5CDA2601383 /* ChatContextBar.swift */,
 				FDB526ADB0E1190463E08AE9 /* ChatRetrievalCluster.swift */,
 				4007FACF71264B6118B3F5FA /* ChatScopeMenu.swift */,
+				455E716DF296F69178DF2F35 /* ChatSessionBar.swift */,
 				FD477B685E3E8163D52949DC /* ChatSourcesMenu.swift */,
 			);
 			path = AI;
@@ -6025,6 +6031,7 @@
 				9CB284CFAFA7A0984032BDA8 /* AIChatViewModelSessionsTestHelpers.swift in Sources */,
 				4FB39089E0B193F90021D7BE /* AIChatViewModelSessionsTests.swift in Sources */,
 				05BE70789318FA085B9A735E /* AIChatViewModelTests.swift in Sources */,
+				2FD8E6F49FE9DEBAF76E19FC /* AIChatViewModelTitleTests.swift in Sources */,
 				668309455FFECACFE6B0368D /* AIChatViewModelWholeBookTests.swift in Sources */,
 				C81C50DAC16681379E93FC9D /* AIConfigurationTests.swift in Sources */,
 				CD104D016ED7015A7F8B42C7 /* AIConsentManagerTests.swift in Sources */,
@@ -6838,6 +6845,7 @@
 				8C213604F3E66CDD58B35960 /* ChatRetrievalCluster.swift in Sources */,
 				8FD1FAC0AE8611D29DEDC87D /* ChatScopeMenu.swift in Sources */,
 				0CE78E5F2D829D2E769058FC /* ChatSession.swift in Sources */,
+				31C4C7448AE362451EE62CAA /* ChatSessionBar.swift in Sources */,
 				9103C7A976C0AAD5AC684EA9 /* ChatSessionPayload.swift in Sources */,
 				02272B33835EDA4272817645 /* ChatSessionPersisting.swift in Sources */,
 				BDD2DBEC1FB509FB4B73272F /* ChatSessionRecord.swift in Sources */,
@@ -7629,7 +7637,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 893;
+				CURRENT_PROJECT_VERSION = 894;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7637,7 +7645,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.55.3;
+				MARKETING_VERSION = 3.55.4;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7783,7 +7791,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 893;
+				CURRENT_PROJECT_VERSION = 894;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7791,7 +7799,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.55.3;
+				MARKETING_VERSION = 3.55.4;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/ViewModels/AIChatViewModel+SessionTransitions.swift
+++ b/vreader/ViewModels/AIChatViewModel+SessionTransitions.swift
@@ -43,6 +43,7 @@ extension AIChatViewModel {
         messages = []
         settledMessages = []
         activeSessionId = nil
+        storedActiveTitle = nil   // #88 WI-4: a fresh thread derives its title from messages
         errorMessage = nil
     }
 
@@ -70,6 +71,7 @@ extension AIChatViewModel {
             messages = record.messages
             settledMessages = record.messages   // a loaded session is fully settled
             activeSessionId = record.sessionId
+            storedActiveTitle = record.title    // #88 WI-4: the bar shows the stored title
             errorMessage = nil
         } catch {
             transitionLog.error("switchToSession failed: \(String(describing: error), privacy: .public)")
@@ -133,6 +135,7 @@ extension AIChatViewModel {
         messages = []
         settledMessages = []
         activeSessionId = nil
+        storedActiveTitle = nil   // #88 WI-4 (reset; loadMostRecentRemaining re-sets it if a session remains)
         errorMessage = nil
         await loadMostRecentRemaining(token: token)
     }
@@ -163,7 +166,11 @@ extension AIChatViewModel {
         let title = derivedTitle(from: snapshot)
         do {
             if let id = activeSessionId {
-                _ = try await store.updateChatSession(sessionId: id, messages: snapshot, title: title)
+                // PRESERVE the stored title on seal-update (#88 WI-4 audit r2 Medium):
+                // leaving a renamed session via new/switch must not revert its
+                // persisted title to the first user message. Title is set only at
+                // CREATE (below) + on rename (WI-5).
+                _ = try await store.updateChatSession(sessionId: id, messages: snapshot, title: nil)
             } else {
                 let record = try await store.createChatSession(
                     bookFingerprintKey: key, title: title ?? Self.defaultSessionTitle,
@@ -189,6 +196,7 @@ extension AIChatViewModel {
             messages = record.messages
             settledMessages = record.messages   // a loaded session is fully settled
             activeSessionId = record.sessionId
+            storedActiveTitle = record.title    // #88 WI-4: the bar shows the stored title
         } catch {
             transitionLog.error("loadMostRecentRemaining failed: \(String(describing: error), privacy: .public)")
         }

--- a/vreader/ViewModels/AIChatViewModel+Sessions.swift
+++ b/vreader/ViewModels/AIChatViewModel+Sessions.swift
@@ -74,6 +74,7 @@ extension AIChatViewModel {
             messages = record.messages
             settledMessages = record.messages   // a loaded session is fully settled
             activeSessionId = record.sessionId
+            storedActiveTitle = record.title    // #88 WI-4: the bar shows the stored title
         } catch {
             sessionLog.error("loadSessions failed: \(String(describing: error), privacy: .public)")
         }
@@ -133,7 +134,13 @@ extension AIChatViewModel {
                 // stale data. (`messages` here is the same session's settled history,
                 // so it's safe to promote eagerly.)
                 settledMessages = snapshot
-                _ = try await store.updateChatSession(sessionId: id, messages: snapshot, title: title)
+                // PRESERVE the stored title on update (#88 WI-4 audit r2 Medium):
+                // pass `title: nil` so a later settled turn never reverts a renamed
+                // (or otherwise stored-title-differs) session back to the first
+                // user message. The title is set only at CREATE (below) + on rename
+                // (WI-5). The store's carry-forward contract keeps the existing title
+                // when `title == nil`.
+                _ = try await store.updateChatSession(sessionId: id, messages: snapshot, title: nil)
             } else {
                 let record = try await store.createChatSession(
                     bookFingerprintKey: key, title: title ?? Self.defaultSessionTitle,
@@ -161,6 +168,7 @@ extension AIChatViewModel {
                 }
                 activeSessionId = record.sessionId
                 settledMessages = snapshot
+                storedActiveTitle = title ?? Self.defaultSessionTitle   // #88 WI-4
             }
         } catch {
             sessionLog.error("saveSettledTurn failed: \(String(describing: error), privacy: .public)")

--- a/vreader/ViewModels/AIChatViewModel.swift
+++ b/vreader/ViewModels/AIChatViewModel.swift
@@ -35,6 +35,22 @@ final class AIChatViewModel {
     /// properties — can update it. Drives the WI-4 session bar.
     internal(set) var activeSessionId: UUID?
 
+    /// The STORED title of the active session (set when a session is loaded /
+    /// switched-to / its first turn creates it; WI-5's rename updates it). Nil for
+    /// an unsaved / fresh thread — then `activeSessionTitle` derives from the
+    /// thread instead. Observed so the session bar repaints on a switch/rename.
+    /// `internal(set)` so the `+Sessions` / `+SessionTransitions` lifecycle sets it.
+    internal(set) var storedActiveTitle: String?
+
+    /// The active conversation's display title for the session bar (#88 WI-4): the
+    /// loaded/switched/renamed session's STORED title wins; otherwise the derived
+    /// title of the in-progress thread (the title it will be saved under), else the
+    /// default for a fresh/empty thread. Reading `messages` keeps it observed so the
+    /// bar updates live as the first turn is typed.
+    var activeSessionTitle: String {
+        storedActiveTitle ?? derivedTitle(from: messages) ?? Self.defaultSessionTitle
+    }
+
     // Feature #88 session plumbing. Stored on the base class (extensions cannot add
     // stored properties); `internal` so `+Sessions` / `+Streaming` reach them;
     // `@ObservationIgnored` keeps them out of SwiftUI observation (internal

--- a/vreader/Views/AI/AIChatView.swift
+++ b/vreader/Views/AI/AIChatView.swift
@@ -46,6 +46,20 @@ struct AIChatView: View {
     var body: some View {
         ZStack(alignment: .bottom) {
             VStack(spacing: 0) {
+                // Feature #88 WI-4: the Chat-tab session bar (book chat only) —
+                // the active conversation's title + a "New" compose button. It
+                // sits ABOVE the message list, scoped to book chat because
+                // conversations don't exist for general chat.
+                if viewModel.bookFingerprint != nil {
+                    ChatSessionBar(
+                        title: viewModel.activeSessionTitle,
+                        isOpen: false,   // WI-5 binds this to the Conversations sheet presentation
+                        theme: theme,
+                        onTitleTap: {},   // WI-5 presents the Conversations sheet here
+                        onNew: { Task { await viewModel.newConversation() } }
+                    )
+                }
+
                 messageList
 
                 if let error = viewModel.errorMessage {
@@ -118,19 +132,24 @@ struct AIChatView: View {
         }
         .animation(.spring(response: 0.28, dampingFraction: 0.85), value: openMenu)
         .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    // Feature #88 WI-3: the former clear-history button now starts a
-                    // NEW conversation — it seals the current session (if it has
-                    // content) and resets to the empty state, instead of a destructive
-                    // wipe. The session-bar "New" button (WI-4) lands separately.
-                    Task { await viewModel.newConversation() }
-                } label: {
-                    Image(systemName: "trash")
+            // Feature #88 WI-4: the toolbar "new conversation" button is now
+            // GENERAL-chat-only — for book chat the session bar's "New" pill
+            // replaces it (the bar isn't shown for general chat).
+            if viewModel.bookFingerprint == nil {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        // Feature #88 WI-3: the former clear-history button now starts a
+                        // NEW conversation — it seals the current session (if it has
+                        // content) and resets to the empty state, instead of a destructive
+                        // wipe.
+                        Task { await viewModel.newConversation() }
+                    } label: {
+                        Image(systemName: "trash")
+                    }
+                    .disabled(viewModel.messages.isEmpty)
+                    .accessibilityIdentifier("chatClearButton")
+                    .accessibilityLabel("Clear chat history")
                 }
-                .disabled(viewModel.messages.isEmpty)
-                .accessibilityIdentifier("chatClearButton")
-                .accessibilityLabel("Clear chat history")
             }
             // Bug #94: keyboard-toolbar Done button as secondary dismissal —
             // covers the case where the message list is short or empty and

--- a/vreader/Views/AI/ChatSessionBar.swift
+++ b/vreader/Views/AI/ChatSessionBar.swift
@@ -1,0 +1,139 @@
+// Purpose: Feature #88 WI-4 — the slim Chat-tab SESSION BAR docked at the top of
+// the Chat tab (book chat only), above the message list. Left = a tappable pill
+// (chat-bubble glyph + active conversation title + chevron) that opens the
+// Conversations switcher (WI-5); right = a "New" pill that starts a fresh thread.
+//
+// From the `SessionBar` artboard: a 0.5pt bottom rule, a serif semibold title
+// pill (truncates tail-first under width pressure — the "New" pill holds a higher
+// layout priority so it never gets pushed off), an accent-green compose plus.
+// Mirrors ChatContextBar's theming idiom (Color(theme.ruleColor) etc.).
+//
+// @coordinates-with: AIChatView.swift, AIChatViewModel.swift, ReaderThemeV2.swift,
+//   ChatContextBar.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/session-switcher-artboards.jsx`
+
+#if canImport(UIKit)
+import SwiftUI
+
+/// The Chat-tab session bar: a left title pill (tap → Conversations) + a right
+/// "New" compose pill (Feature #88 WI-4).
+struct ChatSessionBar: View {
+    /// The active conversation's display title.
+    let title: String
+    /// Whether the Conversations switcher is currently open (drives the title
+    /// pill's wash + chevron rotation).
+    let isOpen: Bool
+    let theme: ReaderThemeV2
+    /// Tapped the title pill (opens the Conversations switcher — WI-5).
+    let onTitleTap: () -> Void
+    /// Tapped "New" (starts a fresh conversation).
+    let onNew: () -> Void
+
+    static let titleIdentifier = "chatSessionBarTitle"
+    static let newIdentifier = "chatSessionBarNew"
+
+    /// The accent "on" green — matches `ChatContextBar.accentGreen` (design `#3a6a5a`).
+    static let accentGreen = UIColor(red: 0x3a / 255, green: 0x6a / 255, blue: 0x5a / 255, alpha: 1)
+
+    var body: some View {
+        HStack(spacing: 0) {
+            titlePill
+            Spacer(minLength: 8)
+            newButton
+                .layoutPriority(1)   // New stays full-size; a long title truncates instead
+        }
+        .padding(.top, 10)
+        .padding(.bottom, 10)
+        .padding(.leading, 16)
+        .padding(.trailing, 14)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(Color(theme.ruleColor))
+                .frame(height: 0.5)
+        }
+        .accessibilityIdentifier("chatSessionBar")
+    }
+
+    // MARK: - Left: title pill
+
+    @ViewBuilder
+    private var titlePill: some View {
+        Button(action: onTitleTap) {
+            HStack(spacing: 7) {
+                glyphCircle
+                Text(title)
+                    .font(.system(size: 14.5, weight: .semibold, design: .serif))
+                    .foregroundStyle(Color(theme.inkColor))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Color(theme.subColor))
+                    .rotationEffect(.degrees(isOpen ? 180 : 0))
+                    .animation(.easeInOut(duration: 0.15), value: isOpen)
+            }
+            .padding(.leading, 4)
+            .padding(.trailing, 8)
+            .padding(.vertical, 4)
+            .background(Capsule().fill(Color(titlePillFill)))
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(Self.titleIdentifier)
+        .accessibilityLabel("Conversation: \(title)")
+    }
+
+    /// The 22×22 subtly-filled circle holding the chat-bubble glyph.
+    @ViewBuilder
+    private var glyphCircle: some View {
+        Image(systemName: "bubble.left")
+            .font(.system(size: 12, weight: .regular))
+            .foregroundStyle(Color(theme.subColor))
+            .frame(width: 22, height: 22)
+            .background(
+                RoundedRectangle(cornerRadius: 11)
+                    .fill(Color(glyphCircleFill))
+            )
+    }
+
+    /// Transparent at rest; a subtle wash while the switcher is open.
+    private var titlePillFill: UIColor {
+        guard isOpen else { return .clear }
+        return theme.isDark
+            ? UIColor(white: 1, alpha: 0.06)
+            : UIColor(white: 0, alpha: 0.05)
+    }
+
+    private var glyphCircleFill: UIColor {
+        theme.isDark
+            ? UIColor(white: 1, alpha: 0.07)
+            : UIColor(white: 0, alpha: 0.05)
+    }
+
+    // MARK: - Right: New pill
+
+    @ViewBuilder
+    private var newButton: some View {
+        Button(action: onNew) {
+            HStack(spacing: 5) {
+                Image(systemName: "plus")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(Color(Self.accentGreen))
+                Text("New")
+                    .font(.system(size: 12.5, weight: .semibold))
+                    .foregroundStyle(Color(theme.inkColor))
+            }
+            .fixedSize(horizontal: true, vertical: false)
+            .padding(.leading, 9)
+            .padding(.trailing, 11)
+            .padding(.vertical, 6)
+            .background(Capsule().fill(Color.clear))
+            .overlay(
+                Capsule().stroke(Color(theme.ruleColor), lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(Self.newIdentifier)
+        .accessibilityLabel("New conversation")
+    }
+}
+#endif

--- a/vreaderTests/ViewModels/AIChatViewModelTitleTests.swift
+++ b/vreaderTests/ViewModels/AIChatViewModelTitleTests.swift
@@ -1,0 +1,210 @@
+// Purpose: Feature #88 WI-4 — pin `AIChatViewModel.activeSessionTitle`, the
+// display title the Chat-tab session bar renders. Covers: empty thread →
+// default title, derived-from-first-user-message (incl. CJK), and the
+// post-`switchToSession` derived title. Reuses the shared MockChatSessionStore
+// helper (AIChatViewModelSessionsTestHelpers.swift).
+//
+// SwiftUI button-tap tests are out of scope (rule 10 — test the VM resolver,
+// not pixels).
+//
+// @coordinates-with: AIChatViewModel.swift, AIChatViewModel+Sessions.swift,
+//   ChatSessionPersisting.swift,
+//   dev-docs/designs/vreader-fidelity-v1/project/session-switcher-artboards.jsx
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("AIChatViewModelTitle")
+struct AIChatViewModelTitleTests {
+
+    // MARK: - SUT helpers
+
+    private static let bookKey =
+        "epub:aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233:1024"
+
+    @MainActor
+    private func makeFingerprint() -> DocumentFingerprint {
+        DocumentFingerprint(
+            contentSHA256: "aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233",
+            fileByteCount: 1024,
+            format: .epub
+        )
+    }
+
+    @MainActor
+    private func makeSUT(store: MockChatSessionStore?) -> AIChatViewModel {
+        let flags = FeatureFlags(environment: .prod)
+        flags.setOverride(true, for: .aiAssistant)
+        let stub = StubChatAIProvider()
+        stub.stubbedResponse = AIResponse(
+            content: "AI reply", actionType: .questionAnswer,
+            promptVersion: "v1", createdAt: Date())
+        let service = AIService(
+            featureFlags: flags,
+            consentManager: WI11TestHelpers.makeConsentManager(hasConsent: true),
+            keychainService: WI11TestHelpers.makeKeychainService(),
+            provider: stub
+        )
+        return AIChatViewModel(
+            aiService: service,
+            bookFingerprint: makeFingerprint(),
+            contextWindowSize: 10,
+            chatSessionStore: store
+        )
+    }
+
+    // MARK: - empty thread → default title
+
+    @Test @MainActor func activeSessionTitle_emptyThread_isDefault() {
+        let vm = makeSUT(store: MockChatSessionStore())
+        #expect(vm.messages.isEmpty)
+        #expect(vm.activeSessionTitle == AIChatViewModel.defaultSessionTitle)
+        #expect(vm.activeSessionTitle == "New conversation")
+    }
+
+    // MARK: - derived from first user message
+
+    @Test @MainActor func activeSessionTitle_derivesFromFirstUserMessage() {
+        let vm = makeSUT(store: MockChatSessionStore())
+        vm.messages = [
+            ChatMessage(role: .user, content: "What is this book about?"),
+            ChatMessage(role: .assistant, content: "It's about a lot of things."),
+        ]
+        #expect(vm.activeSessionTitle == "What is this book about?")
+    }
+
+    // MARK: - CJK first user message preserved
+
+    @Test @MainActor func activeSessionTitle_preservesCJKFirstUserMessage() {
+        let vm = makeSUT(store: MockChatSessionStore())
+        vm.messages = [
+            ChatMessage(role: .user, content: "这本书讲什么？"),
+            ChatMessage(role: .assistant, content: "这本书讲述了……"),
+        ]
+        #expect(vm.activeSessionTitle == "这本书讲什么？")
+    }
+
+    // MARK: - whitespace-only first user → falls back to default
+
+    @Test @MainActor func activeSessionTitle_whitespaceOnlyFirstUser_isDefault() {
+        let vm = makeSUT(store: MockChatSessionStore())
+        vm.messages = [
+            ChatMessage(role: .user, content: "   \n  "),
+        ]
+        #expect(vm.activeSessionTitle == AIChatViewModel.defaultSessionTitle)
+    }
+
+    // MARK: - after switchToSession → that session's STORED title (not the derived one)
+
+    @Test @MainActor func activeSessionTitle_afterSwitch_showsStoredTitle() async {
+        let store = MockChatSessionStore()
+        // A session whose STORED title differs from its first-message-derived title
+        // (e.g. a renamed thread). The bar must show the stored title, not the prompt.
+        let seededId = store.seed(
+            key: Self.bookKey, title: "Stored heading",
+            messages: [
+                ChatMessage(role: .user, content: "Who is Mr. Darcy?"),
+                ChatMessage(role: .assistant, content: "Fitzwilliam Darcy is…"),
+            ],
+            updatedAt: Date(timeIntervalSince1970: 50))
+        let vm = makeSUT(store: store)
+
+        await vm.switchToSession(seededId)
+
+        #expect(vm.activeSessionId == seededId)
+        #expect(vm.activeSessionTitle == "Stored heading",
+                "the bar shows the STORED session title, not the first-message-derived one")
+    }
+
+    // MARK: - after loadSessions → the loaded session's STORED title
+
+    @Test @MainActor func activeSessionTitle_afterLoad_showsStoredTitle() async {
+        let store = MockChatSessionStore()
+        _ = store.seed(
+            key: Self.bookKey, title: "Renamed Topic",
+            messages: [ChatMessage(role: .user, content: "what is the entail")],
+            updatedAt: Date(timeIntervalSince1970: 60))
+        let vm = makeSUT(store: store)
+
+        await vm.loadSessions()
+
+        #expect(vm.activeSessionTitle == "Renamed Topic",
+                "a loaded session shows its stored title, not the derived one")
+    }
+
+    // MARK: - after newConversation → resets to the default title
+
+    @Test @MainActor func activeSessionTitle_afterNewConversation_isDefault() async {
+        let store = MockChatSessionStore()
+        let seededId = store.seed(
+            key: Self.bookKey, title: "Stored heading",
+            messages: [ChatMessage(role: .user, content: "Who is Mr. Darcy?")],
+            updatedAt: Date(timeIntervalSince1970: 50))
+        let vm = makeSUT(store: store)
+        await vm.switchToSession(seededId)
+        #expect(vm.activeSessionTitle == "Stored heading")
+
+        await vm.newConversation()
+
+        #expect(vm.activeSessionTitle == AIChatViewModel.defaultSessionTitle,
+                "starting a new conversation clears the stored title back to the default")
+    }
+
+    // MARK: - assistant-first thread (no user message) → default title
+
+    @Test @MainActor func activeSessionTitle_assistantFirstThread_isDefault() {
+        // A thread with no user message can't derive a title — fall back to the
+        // default. (In practice the user always sends first, so this is a guard.)
+        let vm = makeSUT(store: MockChatSessionStore())
+        vm.messages = [ChatMessage(role: .assistant, content: "Hello, ask me anything.")]
+        #expect(vm.activeSessionTitle == AIChatViewModel.defaultSessionTitle)
+    }
+
+    // MARK: - stored title survives a later settled turn (no derived-title overwrite)
+
+    @Test @MainActor func storedTitle_survivesLaterSettledTurn() async {
+        let store = MockChatSessionStore()
+        // A renamed session: stored title "Renamed Topic" ≠ its derived title.
+        let id = store.seed(
+            key: Self.bookKey, title: "Renamed Topic",
+            messages: [
+                ChatMessage(role: .user, content: "what is the entail"),
+                ChatMessage(role: .assistant, content: "An entail restricts inheritance…"),
+            ],
+            updatedAt: Date(timeIntervalSince1970: 60))
+        let vm = makeSUT(store: store)
+        await vm.loadSessions()
+        #expect(vm.activeSessionTitle == "Renamed Topic")
+
+        // Send another turn — the settled-turn save must PRESERVE the stored title,
+        // not rewrite the persisted title back to the first user message.
+        await vm.sendMessage("and who inherits Longbourn")
+
+        #expect(store.lastSavedTitle(for: id) == "Renamed Topic",
+                "a later settled turn preserves the stored/renamed title")
+        #expect(vm.activeSessionTitle == "Renamed Topic")
+    }
+
+    // MARK: - stored title survives the transition seal (new / switch away)
+
+    @Test @MainActor func storedTitle_survivesNewConversationSeal() async {
+        let store = MockChatSessionStore()
+        let id = store.seed(
+            key: Self.bookKey, title: "Renamed Topic",
+            messages: [
+                ChatMessage(role: .user, content: "what is the entail"),
+                ChatMessage(role: .assistant, content: "An entail restricts inheritance…"),
+            ],
+            updatedAt: Date(timeIntervalSince1970: 60))
+        let vm = makeSUT(store: store)
+        await vm.loadSessions()
+
+        // Leaving the session (new conversation) seals it — the seal must NOT revert
+        // the persisted title to the derived one.
+        await vm.newConversation()
+
+        #expect(store.lastSavedTitle(for: id) == "Renamed Topic",
+                "the transition seal preserves the stored/renamed title")
+    }
+}


### PR DESCRIPTION
## Summary

WI-4 of feature #88 (AI conversation sessions). Adds the slim **session bar** at the top of the Chat tab (book chat only), per the committed `SessionBar` design: the active conversation's title + chevron (left) and a **"New"** compose pill (right), with a 0.5pt bottom rule. The toolbar trash button is now general-chat-only — for book chat the bar's "New" replaces it.

Part of feature #88 — GH #1523.

## What changed

- **`ChatSessionBar.swift`** (new) — the bar view (bubble-glyph circle + serif title + chevron pill; accent-green plus + "New" pill). A long title truncates (`.layoutPriority` on New, no fixed width) so "New" never gets pushed off.
- **`AIChatViewModel.activeSessionTitle`** — the bar's title source: an observed `storedActiveTitle` (set on load / switch / first-turn create-adopt / delete-fallback; reset on new) wins, else the derived title of the in-progress thread, else `"New conversation"`.
- **Stored-title preservation** — `_saveSettledTurn` + `sealCurrentSessionIfNeeded` now pass `title: nil` on the UPDATE branch (carry-forward), so a later settled turn / transition seal won't revert a renamed session's title to the first user message (sets up WI-5's rename).
- **`AIChatView`** — renders the bar at the top (book chat only) + gates the toolbar trash to general chat.

The title-tap → Conversations sheet (and `isOpen` binding) wires in **WI-5**; for now `onTitleTap` is inert / `isOpen` is `false`.

## Codex Audit

`follow-up-recommended` — 3 rounds. R1 found two Mediums (title re-derived from messages; sticky `showConversations` open state) + Lows; R2 cleared M2 and found the deeper M1 persistence overwrite (`_saveSettledTurn` / `sealCurrentSessionIfNeeded` re-derived + clobbered the stored title); R3 confirmed both resolved (`title: nil` preserve via the carry-forward contract, verified in the real store + mock) with no new findings. Also caught + fixed (orchestrator review) a deprecated `UIScreen.main` width cap. Audit log: `.claude/codex-audits/feat-feature-88-wi-4-session-bar-audit.md`.

## Validation

- [x] **38 tests pass** across the title + sessions suites (10 `AIChatViewModelTitle` incl. stored-title / new-reset / assistant-first / preserve-on-save + preserve-on-seal regressions; 28 `AIChatViewModelSessions`). `RUN-TESTS RESULT: SUCCEEDED`, 0 failures.
- [x] Codex audit loop complete (3 rounds, both Mediums resolved).
- [x] `** BUILD SUCCEEDED **`; version bumped 3.55.3 → 3.55.4.

## Slice verification (Gate 5)

The bar is a designed surface (Rule 51 ✓). Its data/logic (`activeSessionTitle` resolution, stored-title preservation, the toolbar gating) is exercised by the 38 unit tests. The on-device session-switcher acceptance (the bar + the Conversations sheet driven end-to-end) lands with **WI-5**, the final WI, which wires the chevron→sheet.

## Type of Change

- [x] Feature work item (Part of feature #88 / GH #1523)