### PR TITLE
feat(#90 WI-2): Summarize-tab language control row + popover

### DIFF
--- a/.claude/codex-audits/feat-feature-90-wi-2-lang-row-audit.md
+++ b/.claude/codex-audits/feat-feature-90-wi-2-lang-row-audit.md
@@ -1,0 +1,66 @@
+---
+branch: feat/feature-90-wi-2-lang-row
+threadId: 019e987f-c638-77c1-be3c-764b9322ca30
+rounds: 2
+final_verdict: follow-up-recommended
+date: 2026-06-05
+---
+
+# Gate-4 audit — Feature #90 WI-2 (Summarize-tab language control row + popover)
+
+WI-2 of #90: the UI control beneath the scope chips — `AISummaryLangRow` (a
+`BilingualLanguage` pill + a Single/Bilingual segmented toggle) + `AISummaryLangPopover`
+(the `BilingualLanguage.all` grid) + the `AISummaryTabView` wiring. Maps the control
+to the WI-1 VM: Single → `.translatedOnly`, Bilingual → `.interlinear`, language
+pick → `setSummaryTargetLanguage`, then `refreshSummaryTranslationIfNeeded()`.
+`.originalOnly` is the resting default.
+
+## Round history
+
+| Round | Findings | Resolution |
+|---|---|---|
+| 1 (`019e9877`) | wiring / isolation / active-segment derivation / overlay dismissal all SOUND. **M1** the summary target language was NOT seeded from the per-book bilingual setting (the host DOES have `book.fingerprintKey` + `PerBookSettings`). **M2** the toggle used SF Symbols instead of the custom `LineGlyph`/`StackGlyph` (Rule-51 fidelity miss). Lows: popover notch missing; the async wiring untested. | see below |
+| 2 (`019e987f`) | **clean** — both Mediums resolved; no new Critical/High/Medium; the 2 Lows reasonably accepted. | — |
+
+## Fixes applied
+
+**M1 (per-book seeding)** — `ReaderAICoordinator.setupIfNeeded()` now reads
+`PerBookSettingsStore.settings(for: fingerprintKey, baseURL: ReaderContainerView.perBookSettingsBaseURL)`
+and seeds `summaryVM.setSummaryTargetLanguage(BilingualLanguage.findOrDefault(key:))`
+once at VM creation (language only — no premature translation; `@MainActor`, no
+suspension between create + seed, so no race). So the Summarize tab inherits the
+book's established bilingual language instead of the global default.
+
+**M2 (custom glyphs)** — NEW `AISummaryLangGlyphs.swift` with `SummaryLineGlyph` /
+`SummaryStackGlyph` (custom `Shape` Paths in the design's 16-unit space, the lower
+stack pair at 0.55 opacity), matching the artboard `LineGlyph`/`StackGlyph`.
+`segmentGlyph` now uses them (the glyph extraction also kept `AISummaryLangRow`
+under 300 → 293).
+
+## Accepted Lows (audit-concurred "reasonable")
+
+- **Popover notch/caret** — a fidelity miss vs the artboard's popover pointer, but
+  "not a Rule-51 must-fix; the surface is designed, an implementation-detail miss,
+  not self-designed UI." The card / 2-col grid / header / footer are faithful.
+- **Untested async glue** (`selectDisplayMode`/`selectLanguage`) — thin wiring over
+  already-covered pure mappings (`AISummaryLangRowTests`) + VM behavior
+  (`AIAssistantViewModelBilingualSummaryTests`). Accepted.
+
+## Rule-51 note (carried from WI-2 implementation)
+
+The artboard toggle is 2-segment Single/Bilingual; `.originalOnly` is the resting
+default (no third "Original" widget invented). The audit did NOT flag the
+resting-default as a blocker. Whether an explicit "return to original" affordance
+is desired is a design-fidelity question for a later pass — WI-3 (card render) may
+surface it more concretely. Not invented here (Rule 51).
+
+## Per-book seeding ownership
+
+WI-1's plan made the injection WI-2's job; done in `ReaderAICoordinator` (M1).
+
+## Verdict
+
+`follow-up-recommended`. WI-2 is clean (2 rounds → 0 open Critical/High/Medium; the
+2 Lows accepted). 24 tests (LangRow mapping + the WI-1 VM suite) pass. The control
+is wired to the VM; WI-3 (the card render of original/target/interlinear + the
+dual-skeleton + failure-recovery) is the final WI.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 897
-        MARKETING_VERSION: 3.57.1
+        CURRENT_PROJECT_VERSION: 898
+        MARKETING_VERSION: 3.57.2
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -496,6 +496,7 @@
 		4C47F172233199432FC289E3 /* ImportSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F84672A6E2EDD6E037AFD8 /* ImportSource.swift */; };
 		4C5F7C805D7702035CEA5837 /* NativeTextPaginatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295669F5B358B6C7BE41952E /* NativeTextPaginatorTests.swift */; };
 		4C715B09F29C105CD4854C5F /* ReadinessRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D94819027EB16D6337A38B9 /* ReadinessRows.swift */; };
+		4CA3A5E2BF02A0DE6E9E344D /* AISummaryLangPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69529A9C9FB832638C4BAE45 /* AISummaryLangPopover.swift */; };
 		4CACC9F4BA8C17144C30C113 /* BackgroundDownloadSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A04EAFA37410DA616E33D6 /* BackgroundDownloadSession.swift */; };
 		4CBBDD4F06D00C0A4A6E1716 /* MobiEPUBAssemblerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD27A5C682FAD0ED96FD755A /* MobiEPUBAssemblerTests.swift */; };
 		4CBBDDA7BEECCFF853B1D90C /* memory.c in Sources */ = {isa = PBXBuildFile; fileRef = 33EA0E7BAE9970AB1E1CE063 /* memory.c */; settings = {COMPILER_FLAGS = "-w"; }; };
@@ -532,6 +533,7 @@
 		5128BF72998C4F697D2A6A84 /* ImportProvenanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDFAF8770F91837F0B3793E1 /* ImportProvenanceTests.swift */; };
 		514822215748FA807FA36FE2 /* HighlightCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2724D3C50EDE1DC1DA43BB5F /* HighlightCoordinatorTests.swift */; };
 		5168983F9EDD267778A9EEC9 /* TXTChapterIndexBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3910DCA9C9F588B700679D76 /* TXTChapterIndexBuilder.swift */; };
+		5186D5FB2944B88B6F5C0F1B /* AISummaryTabView+Bilingual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C04A484503CAD9F3413E602 /* AISummaryTabView+Bilingual.swift */; };
 		51E930F9FAF162DCA306BA63 /* ReTranslatePickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C1D13DF31CB3EFEE7032F8A /* ReTranslatePickerSheet.swift */; };
 		51EF2235646EF01CF92D5788 /* ReadiumContinuousScrollModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95639750C6DD564417CCA244 /* ReadiumContinuousScrollModelTests.swift */; };
 		51F370150CAD9A865053266C /* HighlightIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABEAF0841AD808F7EE48617 /* HighlightIntegrationTests.swift */; };
@@ -646,6 +648,7 @@
 		6357FCBADF316F72B24C3975 /* ProviderProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9893809AE39B5DF0233FEE42 /* ProviderProfile.swift */; };
 		637607A8DD0B3C23776A3002 /* SchemaV8.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CA82E6D9E86220E10B3728 /* SchemaV8.swift */; };
 		6385D414214525E5CF2C4C8E /* HighlightPopoverViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7747D7A10C50F43520FB5FF0 /* HighlightPopoverViewModel.swift */; };
+		63F02FFBEB8FD206543F6DBD /* AISummaryLangRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6C1E23343FEB3F65BD3CA9 /* AISummaryLangRow.swift */; };
 		646C642DA4E4DCFF2AFEB68A /* search_no_results.html in Resources */ = {isa = PBXBuildFile; fileRef = 84BAC2CBFB7F533857E6A65B /* search_no_results.html */; };
 		64709D1B5C006D3299C8ABAF /* AutoPageTurner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5401E10DDA195966ABD13F70 /* AutoPageTurner.swift */; };
 		647F5472368EC4DBFB0301D5 /* ClosedBookTextExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20767F0423EEB85DD502B1C /* ClosedBookTextExtractor.swift */; };
@@ -719,6 +722,7 @@
 		6E9F7B63A2B0FCA6B4D97E33 /* ChapterBounds.swift in Sources */ = {isa = PBXBuildFile; fileRef = A890F7C98CE159058714EE4D /* ChapterBounds.swift */; };
 		6EA1E4475CD190B3E9F9D370 /* ReaderUnifiedCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AA77FDB19CB7EDA69418C8 /* ReaderUnifiedCoordinator.swift */; };
 		6EB15A0E87748FB22F7CB07E /* StatsCustomRangePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D87E027454CF6AA96E39503 /* StatsCustomRangePicker.swift */; };
+		6EB2AC71523CBE86091E1467 /* AISummaryLangRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA59EFCF0E72F5C6AD20AC64 /* AISummaryLangRowTests.swift */; };
 		6EB7C3CE4427353026BCD4E9 /* Inter-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 7CE90E7D827B7E8A356D6DC6 /* Inter-SemiBold.otf */; };
 		6F1DD222CF91070D7B3D997F /* AnnotationImportError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C56D76EC2A57744D168E86 /* AnnotationImportError.swift */; };
 		6F77E9702493FB758FBF3319 /* BilingualSetupSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4493553E18BBEB66EA8D32BF /* BilingualSetupSheet.swift */; };
@@ -1217,6 +1221,7 @@
 		C0D9308246DCE3C239D86323 /* Inter-LICENSE.txt in Resources */ = {isa = PBXBuildFile; fileRef = 2E5E264F97F1E53F985C34BB /* Inter-LICENSE.txt */; };
 		C11851768B01D69A554324D0 /* ReadiumBilingualEvalAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E972CB07620BB3D30FCD92C /* ReadiumBilingualEvalAdapter.swift */; };
 		C135C41870117690FC304423 /* MockHighlightStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911EF8F78991EBF40F0F6155 /* MockHighlightStore.swift */; };
+		C138354A4189B285E8C1AD2F /* AISummaryLangGlyphs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3055DFDA3F01697EC921A28B /* AISummaryLangGlyphs.swift */; };
 		C18C0E5412C0C586FA8312D6 /* TXTChunkedSearchHighlightClearTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57335D8D35E84A8B26F8C467 /* TXTChunkedSearchHighlightClearTests.swift */; };
 		C18C9598D8ECE749889D544A /* plain_utf8.txt in Resources */ = {isa = PBXBuildFile; fileRef = CD3507D70A2497BA857E5A49 /* plain_utf8.txt */; };
 		C1B568E4B16572EE4FA6E4E3 /* Feature40TTSSentenceHighlightVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 903D9FCA142155D5B65A5C18 /* Feature40TTSSentenceHighlightVerificationTests.swift */; };
@@ -1785,6 +1790,7 @@
 		1BA8C0E6A9B8EF3E48771286 /* PersistenceActor+ReadingHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+ReadingHistory.swift"; sourceTree = "<group>"; };
 		1BD2081B22B559BD215B7C21 /* LibraryBookSearchGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryBookSearchGate.swift; sourceTree = "<group>"; };
 		1BF38242BD73D1545DCA858D /* EPUBReaderContainerView+ContinuousBilingualLoading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EPUBReaderContainerView+ContinuousBilingualLoading.swift"; sourceTree = "<group>"; };
+		1C04A484503CAD9F3413E602 /* AISummaryTabView+Bilingual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AISummaryTabView+Bilingual.swift"; sourceTree = "<group>"; };
 		1C07D184EF0E90D5F2DF7A36 /* EPUBWebViewBridgeJS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBWebViewBridgeJS.swift; sourceTree = "<group>"; };
 		1C10EE670AC6E2320DF231D2 /* SettingsRowStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRowStyle.swift; sourceTree = "<group>"; };
 		1C1B3D47B7CCE2B9CBC61B7A /* SimpTradTransformTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpTradTransformTests.swift; sourceTree = "<group>"; };
@@ -1892,6 +1898,7 @@
 		2F891C451718B4BC9AC7BCEC /* LazyDownloadBackgroundEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyDownloadBackgroundEventsTests.swift; sourceTree = "<group>"; };
 		300CB93197976B4D665AEDFC /* PersistenceActor+RemoteOnly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistenceActor+RemoteOnly.swift"; sourceTree = "<group>"; };
 		3035E9BDF79106F058459E0D /* StatsCustomRangePickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsCustomRangePickerTests.swift; sourceTree = "<group>"; };
+		3055DFDA3F01697EC921A28B /* AISummaryLangGlyphs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISummaryLangGlyphs.swift; sourceTree = "<group>"; };
 		30D00221E111683E9FF0260A /* SearchTextExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTextExtractor.swift; sourceTree = "<group>"; };
 		30DB574D36652997E553A96C /* SearchCurrentBookTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCurrentBookTool.swift; sourceTree = "<group>"; };
 		30F27108727D22B92F94001C /* ReadiumEPUBReaderViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumEPUBReaderViewModelTests.swift; sourceTree = "<group>"; };
@@ -2294,6 +2301,7 @@
 		68D805C5BFB334FBABC94879 /* ReadinessTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadinessTracker.swift; sourceTree = "<group>"; };
 		68FE9266FB938B801CBD71C9 /* BilingualAIReadinessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualAIReadinessTests.swift; sourceTree = "<group>"; };
 		6914428EA8FF673A76DDFF66 /* ReadiumEPUBHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumEPUBHost.swift; sourceTree = "<group>"; };
+		69529A9C9FB832638C4BAE45 /* AISummaryLangPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISummaryLangPopover.swift; sourceTree = "<group>"; };
 		695A8EDF52A1BFDDB7BC5A10 /* TXTBridgeSharedBilingualTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTBridgeSharedBilingualTests.swift; sourceTree = "<group>"; };
 		6974F61108CB28EFA08F1D68 /* SettingsRowPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRowPalette.swift; sourceTree = "<group>"; };
 		69A5BB670EA065F36FCD605B /* TXTOffsetTranslator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTOffsetTranslator.swift; sourceTree = "<group>"; };
@@ -2379,6 +2387,7 @@
 		7A0147BC1F4C66F4EDB21608 /* ReadingDashboardSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingDashboardSnapshotTests.swift; sourceTree = "<group>"; };
 		7A029D6C2DECD395740F1C39 /* MDReaderContainerView+DebugBridgeHighlight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MDReaderContainerView+DebugBridgeHighlight.swift"; sourceTree = "<group>"; };
 		7A266E88D3BA30905391B154 /* ReaderHighlightTapEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderHighlightTapEventTests.swift; sourceTree = "<group>"; };
+		7A6C1E23343FEB3F65BD3CA9 /* AISummaryLangRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISummaryLangRow.swift; sourceTree = "<group>"; };
 		7A980DB0017049401DAB3E93 /* AnnotationListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationListViewModel.swift; sourceTree = "<group>"; };
 		7A9E42127F86EB76595AD46B /* BackupReadingHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupReadingHistoryTests.swift; sourceTree = "<group>"; };
 		7AAC0D3FD90694D3169DB775 /* MDReaderPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MDReaderPlaceholderTests.swift; sourceTree = "<group>"; };
@@ -2869,6 +2878,7 @@
 		CA1C7D7314D51D56E6478D8B /* TranslationResultCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationResultCard.swift; sourceTree = "<group>"; };
 		CA1F33054FC78812304A3055 /* ReaderContainerViewDebugBridgeSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderContainerViewDebugBridgeSearchTests.swift; sourceTree = "<group>"; };
 		CA44E51EB0E783E5A874DA11 /* DebugBridgeNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugBridgeNotifications.swift; sourceTree = "<group>"; };
+		CA59EFCF0E72F5C6AD20AC64 /* AISummaryLangRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISummaryLangRowTests.swift; sourceTree = "<group>"; };
 		CA662166E4DF1BBD49084B5E /* ModelContainerFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelContainerFactoryTests.swift; sourceTree = "<group>"; };
 		CA9C0EC7A5761ACEAEFB3304 /* BilingualSetupSheetContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualSetupSheetContainer.swift; sourceTree = "<group>"; };
 		CABA711375AB3BAEB2F42CFE /* WebDAVServerProfileListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVServerProfileListView.swift; sourceTree = "<group>"; };
@@ -3753,6 +3763,7 @@
 			children = (
 				E9BC24746B5DCBD0CF71B5EF /* AIReaderPanelDebugBridgeAIActionTests.swift */,
 				E38799CD3E8349912E703D65 /* AISummaryCardTests.swift */,
+				CA59EFCF0E72F5C6AD20AC64 /* AISummaryLangRowTests.swift */,
 				FAC9AC43028A99A994A7747B /* AISummaryTabViewScopeTests.swift */,
 				ABA307AD0EDD85730C6DE77A /* AISummaryTabViewTests.swift */,
 				9FF4B27402111C6B812D565E /* BilingualCSSInjectionTests.swift */,
@@ -4397,8 +4408,12 @@
 				EE5B5FE13287A24AE9EEFBA7 /* AIReaderPanel+DebugBridgeAIAction.swift */,
 				8A46EC81A33304A8D024F7CA /* AIReaderPanelHeader.swift */,
 				83BEF8E9F5CAD4246490C06D /* AISummaryCard.swift */,
+				3055DFDA3F01697EC921A28B /* AISummaryLangGlyphs.swift */,
+				69529A9C9FB832638C4BAE45 /* AISummaryLangPopover.swift */,
+				7A6C1E23343FEB3F65BD3CA9 /* AISummaryLangRow.swift */,
 				DB61A191698AD787CC1CCB2F /* AISummaryScopeChipStrip.swift */,
 				F691E61DE6E713DE4FD47733 /* AISummaryTabView.swift */,
+				1C04A484503CAD9F3413E602 /* AISummaryTabView+Bilingual.swift */,
 				C2280805065667E3AE55EC34 /* Color+ReaderHex.swift */,
 				291B9DC0FD8C89549850D5A6 /* DebugAIActionEffect.swift */,
 				073161C86CE5691A8173C851 /* DebugBridgeHighlightObserver.swift */,
@@ -6083,6 +6098,7 @@
 				3400D16324A8EFC7298B2B15 /* AISettingsViewModelMultiProfileTests.swift in Sources */,
 				9E2DE265BDC2515E4572714B /* AISettingsViewModelTests.swift in Sources */,
 				080FFC22ED10E039095B0CDC /* AISummaryCardTests.swift in Sources */,
+				6EB2AC71523CBE86091E1467 /* AISummaryLangRowTests.swift in Sources */,
 				3217F149B278D3D88B6AC17F /* AISummaryTabViewScopeTests.swift in Sources */,
 				768E594123AD4AA389E2BEAC /* AISummaryTabViewTests.swift in Sources */,
 				CC7B6678D819D6A755585B4A /* AITestSetupTests.swift in Sources */,
@@ -6746,7 +6762,11 @@
 				E37CAFB8AF04456F6F0CEBA5 /* AISettingsViewModel+Editor.swift in Sources */,
 				B463893D3C3558483F25BDCF /* AISettingsViewModel.swift in Sources */,
 				B43AA88511EE1FDB4E5D0565 /* AISummaryCard.swift in Sources */,
+				C138354A4189B285E8C1AD2F /* AISummaryLangGlyphs.swift in Sources */,
+				4CA3A5E2BF02A0DE6E9E344D /* AISummaryLangPopover.swift in Sources */,
+				63F02FFBEB8FD206543F6DBD /* AISummaryLangRow.swift in Sources */,
 				6571F67E31CCA87AEA5AD9DF /* AISummaryScopeChipStrip.swift in Sources */,
+				5186D5FB2944B88B6F5C0F1B /* AISummaryTabView+Bilingual.swift in Sources */,
 				7E767F5BB300F8588492BD31 /* AISummaryTabView.swift in Sources */,
 				E30164DD8662A9243007269E /* AITestSetup.swift in Sources */,
 				3D3D595F747F17868E8CB120 /* AITool.swift in Sources */,
@@ -7673,7 +7693,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 897;
+				CURRENT_PROJECT_VERSION = 898;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7681,7 +7701,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.57.1;
+				MARKETING_VERSION = 3.57.2;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7827,7 +7847,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 897;
+				CURRENT_PROJECT_VERSION = 898;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7835,7 +7855,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.57.1;
+				MARKETING_VERSION = 3.57.2;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Views/Reader/AISummaryLangGlyphs.swift
+++ b/vreader/Views/Reader/AISummaryLangGlyphs.swift
@@ -1,0 +1,59 @@
+// Purpose: Feature #90 WI-2 — the custom Single / Bilingual segment glyphs for
+// `AISummaryLangRow`, transcribed from the committed artboard's `LineGlyph` /
+// `StackGlyph` (Gate-4 M2: SF Symbols were a Rule-51 fidelity miss). All strokes
+// are authored in the design's 16-unit coordinate space and scaled to the view.
+//
+// @coordinates-with: AISummaryLangRow.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/bilingual-summarize-artboards.jsx`
+//   (`LineGlyph` :85-91, `StackGlyph` :92-101)
+
+#if canImport(UIKit)
+import SwiftUI
+
+/// A set of horizontal strokes `(x1, y, x2)` in the design's 16-unit space.
+private struct SummaryGlyphLines: Shape {
+    /// Each tuple is (startX, y, endX) in 16-unit coordinates.
+    let lines: [(CGFloat, CGFloat, CGFloat)]
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let scale = rect.width / 16
+        for (x1, y, x2) in lines {
+            path.move(to: CGPoint(x: x1 * scale, y: y * scale))
+            path.addLine(to: CGPoint(x: x2 * scale, y: y * scale))
+        }
+        return path
+    }
+}
+
+private func summaryGlyphStroke(_ size: CGFloat) -> StrokeStyle {
+    StrokeStyle(lineWidth: 1.6 * size / 16, lineCap: .round)
+}
+
+/// Design `LineGlyph` — a full line over a shorter one (the "single column").
+struct SummaryLineGlyph: View {
+    let size: CGFloat
+    let color: Color
+    var body: some View {
+        SummaryGlyphLines(lines: [(3, 6, 13), (3, 10, 10)])
+            .stroke(color, style: summaryGlyphStroke(size))
+            .frame(width: size, height: size)
+    }
+}
+
+/// Design `StackGlyph` — two stacked line-pairs, the lower one faded (the
+/// bilingual "stacked" treatment).
+struct SummaryStackGlyph: View {
+    let size: CGFloat
+    let color: Color
+    var body: some View {
+        ZStack {
+            SummaryGlyphLines(lines: [(3, 4, 13), (3, 7, 7)])
+                .stroke(color, style: summaryGlyphStroke(size))
+            SummaryGlyphLines(lines: [(3, 11, 13), (3, 13.5, 7)])
+                .stroke(color.opacity(0.55), style: summaryGlyphStroke(size))
+        }
+        .frame(width: size, height: size)
+    }
+}
+#endif

--- a/vreader/Views/Reader/AISummaryLangPopover.swift
+++ b/vreader/Views/Reader/AISummaryLangPopover.swift
@@ -1,0 +1,168 @@
+// Purpose: Feature #90 WI-2 — the Summarize tab's language popover, presented
+// from `AISummaryLangRow`'s language pill. Lists `BilingualLanguage.all` in a
+// 2-column grid; tapping a language selects it and dismisses.
+//
+// Mirrors the committed design `bilingual-summarize-artboards.jsx` `LangPopover`
+// (`:183-211`): a titled card ("Summary language" + the hint "The summary is
+// written in this language."), a 2-column grid where each cell is a 20×20 glyph
+// square + the language `key` name, the active cell accent-tinted with an inset
+// accent border, and a footer ("Translation uses your configured AI provider.
+// Long summaries may take a few seconds.").
+//
+// `BilingualLanguage.all` is the language authority (the bilingual surface's
+// registry — Gate-2 M1), NOT Translate's in-memory string list.
+//
+// @coordinates-with: AISummaryLangRow.swift, AISummaryTabView.swift,
+//   BilingualLanguage.swift, ReaderThemeV2.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/bilingual-summarize-artboards.jsx`
+
+#if canImport(UIKit)
+import SwiftUI
+
+/// The Summarize tab's language-list popover — design `LangPopover`.
+struct AISummaryLangPopover: View {
+
+    /// The currently-selected language (its cell renders accent-tinted).
+    let selectedLanguage: BilingualLanguage
+
+    /// Visual-identity-v2 theme tokens.
+    let theme: ReaderThemeV2
+
+    /// Invoked when a language cell is tapped — passes the chosen language.
+    let onSelect: (BilingualLanguage) -> Void
+
+    /// The accessibility identifier for a language cell.
+    static func rowIdentifier(_ language: BilingualLanguage) -> String {
+        "summaryLang-\(language.key)"
+    }
+
+    private let columns = [
+        GridItem(.flexible(), spacing: 7),
+        GridItem(.flexible(), spacing: 7)
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            LazyVGrid(columns: columns, spacing: 7) {
+                ForEach(BilingualLanguage.all, id: \.self) { language in
+                    cell(for: language)
+                }
+            }
+            .padding(10)
+            footer
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 14).fill(Color(cardFillColor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .strokeBorder(Color(theme.ruleColor), lineWidth: 0.5)
+        )
+        .frame(maxWidth: 290)
+        .accessibilityIdentifier("summaryLangPopover")
+    }
+
+    // MARK: - Header / footer
+
+    @ViewBuilder
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Summary language")
+                .font(.system(size: 13.5, weight: .semibold))
+                .foregroundStyle(Color(theme.inkColor))
+            Text("The summary is written in this language.")
+                .font(.system(size: 11.5))
+                .foregroundStyle(Color(theme.subColor))
+        }
+        .padding(.horizontal, 12)
+        .padding(.top, 12)
+        .padding(.bottom, 2)
+    }
+
+    @ViewBuilder
+    private var footer: some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "globe")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Color(theme.subColor))
+            Text("Translation uses your configured AI provider. Long summaries may take a few seconds.")
+                .font(.system(size: 11))
+                .foregroundStyle(Color(theme.subColor))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, 12)
+        .padding(.bottom, 12)
+        .padding(.top, 2)
+    }
+
+    // MARK: - Cell
+
+    @ViewBuilder
+    private func cell(for language: BilingualLanguage) -> some View {
+        let isActive = language == selectedLanguage
+        Button { onSelect(language) } label: {
+            HStack(spacing: 8) {
+                AISummaryLangGlyphSquare(
+                    glyph: language.glyph,
+                    script: language.script,
+                    size: 20,
+                    corner: 5,
+                    background: isActive
+                        ? Color(theme.accentColor)
+                        : Color(neutralGlyphFill),
+                    foreground: isActive ? .white : Color(theme.inkColor)
+                )
+                Text(language.key)
+                    .font(.system(size: 12.5, weight: isActive ? .semibold : .medium))
+                    .foregroundStyle(Color(theme.inkColor))
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 9)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 10).fill(Color(cellFillColor(isActive: isActive)))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .strokeBorder(
+                        isActive ? Color(theme.accentColor) : Color(theme.ruleColor),
+                        lineWidth: isActive ? 1.5 : 0.5
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(Self.rowIdentifier(language))
+        .accessibilityAddTraits(isActive ? [.isSelected] : [])
+    }
+
+    // MARK: - Theme washes
+
+    /// The popover card background — an opaque panel over the sheet.
+    private var cardFillColor: UIColor {
+        theme.isDark
+            ? UIColor(red: 0x24 / 255, green: 0x20 / 255, blue: 0x1d / 255, alpha: 1)
+            : .white
+    }
+
+    /// The neutral glyph-square wash for an inactive cell (design dark
+    /// `rgba(255,255,255,0.08)` / light `rgba(0,0,0,0.06)`).
+    private var neutralGlyphFill: UIColor {
+        theme.isDark
+            ? UIColor.white.withAlphaComponent(0.08)
+            : UIColor.black.withAlphaComponent(0.06)
+    }
+
+    /// The cell background — accent-tinted when active, a faint wash otherwise
+    /// (design active `accent14`/`accent26`, inactive `rgba(...,0.02/0.04)`).
+    private func cellFillColor(isActive: Bool) -> UIColor {
+        if isActive {
+            return theme.accentColor.withAlphaComponent(theme.isDark ? 0.15 : 0.08)
+        }
+        return theme.isDark
+            ? UIColor.white.withAlphaComponent(0.04)
+            : UIColor.black.withAlphaComponent(0.02)
+    }
+}
+#endif

--- a/vreader/Views/Reader/AISummaryLangRow.swift
+++ b/vreader/Views/Reader/AISummaryLangRow.swift
@@ -1,0 +1,293 @@
+// Purpose: Feature #90 WI-2 — the Summarize tab's SECOND control row, beneath
+// the scope chips: a language control on the LEFT (the current
+// `BilingualLanguage` target as a pill + chevron → opens the language popover)
+// and a Single / Bilingual segmented toggle on the RIGHT.
+//
+// Mirrors the committed design `bilingual-summarize-artboards.jsx` `LangRow`
+// (`:52-83`): the language pill is a 22×22 `accentColor` rounded-6 square with
+// the language glyph in white bold (CJK/RTL scripts get the serif CJK stack),
+// the language `key` name in 12.5 semibold ink, and a `chevron.down` that
+// rotates when the popover is open, all inside a 0.5pt `ruleColor`-bordered
+// capsule with a subtle wash when open. The segmented toggle is a 2-segment
+// Single / Bilingual control; the active segment raises a light/dark elevated
+// background with a small accent glyph (a line glyph for Single, a stacked
+// glyph for Bilingual), the inactive segment is `subColor`.
+//
+// Control → `SummaryDisplayMode` mapping (the artboard's 2-segment toggle, the
+// WI-2 contract): Single → `.translatedOnly`, Bilingual → `.interlinear`.
+// `.originalOnly` is the VM default (today's summary, no translation); the
+// toggle does not expose it as an explicit third segment (see the Rule-51 note
+// in the WI-2 brief / the plan's Gate-2 round-3 resolution). The active-segment
+// derivation + the (segment → mode) mapping are pure static helpers so they pin
+// without a SwiftUI render pass (the `AISummaryTabView.section(for:)` precedent).
+//
+// @coordinates-with: AISummaryTabView.swift, AISummaryLangPopover.swift,
+//   AIAssistantViewModel+BilingualSummary.swift, BilingualLanguage.swift,
+//   ReaderThemeV2.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/bilingual-summarize-artboards.jsx`
+
+#if canImport(UIKit)
+import SwiftUI
+
+/// The Summarize tab's language + Single/Bilingual control row — design
+/// `LangRow`.
+struct AISummaryLangRow: View {
+
+    /// The current bilingual target language (drives the pill glyph + name).
+    let language: BilingualLanguage
+
+    /// The current summary display mode (drives which segment renders active).
+    let mode: SummaryDisplayMode
+
+    /// Visual-identity-v2 theme tokens.
+    let theme: ReaderThemeV2
+
+    /// Whether the language popover is open (rotates the chevron + washes the
+    /// pill, matching the artboard's `popoverOpen` state).
+    let isPopoverOpen: Bool
+
+    /// Invoked when the language pill is tapped — the parent toggles the popover.
+    let onTapLanguage: () -> Void
+
+    /// Invoked when a segment is tapped — passes the mapped `SummaryDisplayMode`
+    /// (Single → `.translatedOnly`, Bilingual → `.interlinear`).
+    let onSelectMode: (SummaryDisplayMode) -> Void
+
+    // MARK: - Segments
+
+    /// The two toggle segments, in design order: Single, then Bilingual.
+    enum Segment: CaseIterable, Equatable {
+        case single
+        case bilingual
+
+        /// The `SummaryDisplayMode` this segment maps to (the WI-2 contract):
+        /// Single → translated-only, Bilingual → interlinear.
+        var mode: SummaryDisplayMode {
+            switch self {
+            case .single:    return .translatedOnly
+            case .bilingual: return .interlinear
+            }
+        }
+
+        /// The segment label, per the design (`Single` / `Bilingual`).
+        var label: String {
+            switch self {
+            case .single:    return "Single"
+            case .bilingual: return "Bilingual"
+            }
+        }
+
+        /// The accessibility identifier for this segment.
+        var identifier: String {
+            switch self {
+            case .single:    return "summaryModeSingle"
+            case .bilingual: return "summaryModeBilingual"
+            }
+        }
+    }
+
+    /// The segment that renders active for a given `SummaryDisplayMode`. Pure
+    /// (no render pass) so the active-segment derivation pins in a unit test.
+    ///
+    /// `.interlinear` → Bilingual; `.translatedOnly` AND the default
+    /// `.originalOnly` both render Single active (the 2-segment toggle has no
+    /// distinct "original" segment — `.originalOnly` is the resting state that
+    /// matches the Single side, per the design's `layout='single'` default).
+    static func activeSegment(for mode: SummaryDisplayMode) -> Segment {
+        switch mode {
+        case .interlinear:                return .bilingual
+        case .translatedOnly, .originalOnly: return .single
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            languagePill
+            Spacer(minLength: 0)
+            segmentedToggle
+        }
+        .accessibilityIdentifier("summaryLangControl")
+    }
+
+    // MARK: - Language pill
+
+    /// The left language control — a capsule holding the accent glyph square,
+    /// the language name, and a rotating chevron. Tapping opens the popover.
+    @ViewBuilder
+    private var languagePill: some View {
+        Button(action: onTapLanguage) {
+            HStack(spacing: 7) {
+                glyphSquare(
+                    glyph: language.glyph,
+                    script: language.script,
+                    size: 22,
+                    corner: 6,
+                    background: Color(theme.accentColor),
+                    foreground: .white
+                )
+                Text(language.key)
+                    .font(.system(size: 12.5, weight: .semibold))
+                    .foregroundStyle(Color(theme.inkColor))
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(Color(theme.subColor))
+                    .rotationEffect(.degrees(isPopoverOpen ? 180 : 0))
+                    .animation(.easeInOut(duration: 0.15), value: isPopoverOpen)
+            }
+            .padding(.leading, 7)
+            .padding(.trailing, 10)
+            .padding(.vertical, 6)
+            .background(
+                Capsule().fill(Color(pillFillColor))
+            )
+            .overlay(
+                Capsule().strokeBorder(Color(theme.ruleColor), lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("summaryLangPill")
+        .accessibilityLabel("Summary language: \(language.key)")
+    }
+
+    // MARK: - Segmented toggle
+
+    /// The right Single / Bilingual segmented toggle — a trough holding two
+    /// segments; the active one raises an elevated wash + an accent glyph.
+    @ViewBuilder
+    private var segmentedToggle: some View {
+        let active = Self.activeSegment(for: mode)
+        HStack(spacing: 0) {
+            ForEach(Segment.allCases, id: \.self) { segment in
+                segmentButton(segment, isActive: segment == active)
+            }
+        }
+        .padding(2)
+        .background(
+            RoundedRectangle(cornerRadius: 9).fill(Color(troughFillColor))
+        )
+    }
+
+    /// One toggle segment — the active one carries the elevated bg + accent glyph.
+    @ViewBuilder
+    private func segmentButton(_ segment: Segment, isActive: Bool) -> some View {
+        Button { onSelectMode(segment.mode) } label: {
+            HStack(spacing: 5) {
+                segmentGlyph(segment, isActive: isActive)
+                Text(segment.label)
+                    .font(.system(size: 11.5, weight: .semibold))
+                    .foregroundStyle(isActive ? Color(theme.inkColor) : Color(theme.subColor))
+            }
+            .padding(.horizontal, 11)
+            .padding(.vertical, 5)
+            .background(
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(isActive ? Color(activeSegmentFill) : Color.clear)
+                    .shadow(
+                        color: isActive ? Color.black.opacity(0.08) : .clear,
+                        radius: 1, x: 0, y: 1
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(segment.identifier)
+        .accessibilityAddTraits(isActive ? [.isSelected] : [])
+    }
+
+    /// The small glyph inside a segment — a single line for Single, a stacked
+    /// pair for Bilingual (design `LineGlyph` / `StackGlyph`). Active → accent,
+    /// inactive → `subColor`.
+    @ViewBuilder
+    private func segmentGlyph(_ segment: Segment, isActive: Bool) -> some View {
+        let tint = isActive ? Color(theme.accentColor) : Color(theme.subColor)
+        switch segment {
+        case .single:    SummaryLineGlyph(size: 12, color: tint)
+        case .bilingual: SummaryStackGlyph(size: 12, color: tint)
+        }
+    }
+
+    // MARK: - Shared glyph square (reused by the popover via a free function)
+
+    /// The accent glyph square — the language's glyph centered in a rounded
+    /// square. CJK / RTL scripts use the serif CJK font stack + a larger size
+    /// (matching the design's `cjkFont` branch).
+    @ViewBuilder
+    private func glyphSquare(
+        glyph: String,
+        script: BilingualLanguage.Script,
+        size: CGFloat,
+        corner: CGFloat,
+        background: Color,
+        foreground: Color
+    ) -> some View {
+        AISummaryLangGlyphSquare(
+            glyph: glyph,
+            script: script,
+            size: size,
+            corner: corner,
+            background: background,
+            foreground: foreground
+        )
+    }
+
+    // MARK: - Theme washes
+
+    /// The language pill background — transparent normally, a subtle wash when
+    /// the popover is open (design `popoverOpen` branch).
+    private var pillFillColor: UIColor {
+        guard isPopoverOpen else { return .clear }
+        return theme.isDark
+            ? UIColor.white.withAlphaComponent(0.06)
+            : UIColor.black.withAlphaComponent(0.04)
+    }
+
+    /// The segmented-toggle trough wash (design `rgba(255,255,255,0.06)` dark /
+    /// `rgba(0,0,0,0.05)` light).
+    private var troughFillColor: UIColor {
+        theme.isDark
+            ? UIColor.white.withAlphaComponent(0.06)
+            : UIColor.black.withAlphaComponent(0.05)
+    }
+
+    /// The active segment's elevated wash (design `#3a3530` dark / `#fff` light).
+    private var activeSegmentFill: UIColor {
+        theme.isDark
+            ? UIColor(red: 0x3a / 255, green: 0x35 / 255, blue: 0x30 / 255, alpha: 1)
+            : .white
+    }
+}
+
+/// The accent glyph square used by the language pill AND the popover rows. A
+/// standalone `View` so both surfaces share one CJK-font / sizing rule.
+struct AISummaryLangGlyphSquare: View {
+    let glyph: String
+    let script: BilingualLanguage.Script
+    let size: CGFloat
+    let corner: CGFloat
+    let background: Color
+    let foreground: Color
+
+    var body: some View {
+        Text(glyph)
+            .font(glyphFont)
+            .foregroundStyle(foreground)
+            .frame(width: size, height: size)
+            .background(
+                RoundedRectangle(cornerRadius: corner).fill(background)
+            )
+            .accessibilityHidden(true)
+    }
+
+    /// CJK / RTL scripts use the serif CJK stack at a larger size; Latin /
+    /// Cyrillic use the system bold (matching the design's `cjkFont` branch).
+    private var glyphFont: Font {
+        let isCJKLike = script == .cjk || script == .rtl
+        let pointSize: CGFloat = (script == .cjk) ? size * 0.59 : size * 0.5
+        if isCJKLike {
+            return Font.custom("Songti SC", size: pointSize).weight(.bold)
+        }
+        return .system(size: pointSize, weight: .bold)
+    }
+}
+#endif

--- a/vreader/Views/Reader/AISummaryTabView+Bilingual.swift
+++ b/vreader/Views/Reader/AISummaryTabView+Bilingual.swift
@@ -1,0 +1,80 @@
+// Purpose: Feature #90 WI-2 — the bilingual-control wiring for
+// `AISummaryTabView`, split out so the base file stays under the ~300-line
+// guide (it was already 393 before WI-2).
+//
+// Holds the language-popover toggle + the control→view-model callbacks: a
+// segment tap maps Single → `.translatedOnly` / Bilingual → `.interlinear` and a
+// language tap selects the `BilingualLanguage`. Every control change routes
+// through the WI-1 synchronous setters (`setSummaryDisplayMode` /
+// `setSummaryTargetLanguage`) and then kicks the (re)translation via the WI-1
+// `async refreshSummaryTranslationIfNeeded()` — so a non-`.originalOnly` mode
+// with a completed summary (re)translates, while `.originalOnly` is a pure no-op.
+//
+// The methods are `internal` (not `private`): a same-type extension in a
+// SEPARATE file cannot see `private` members, and the base file's `body`
+// references these. This mirrors the existing `selectScope` / `runSummarize`
+// pattern in `AISummaryTabView.swift`.
+//
+// @coordinates-with: AISummaryTabView.swift, AISummaryLangRow.swift,
+//   AISummaryLangPopover.swift, AIAssistantViewModel+BilingualSummary.swift
+
+#if canImport(UIKit)
+import SwiftUI
+
+extension AISummaryTabView {
+
+    // MARK: - Language popover
+
+    /// The language-popover overlay — present only while `isLangPopoverPresented`.
+    /// A near-transparent scrim catches an outside tap to dismiss; the popover
+    /// card sits under the control block, matching the artboard's
+    /// absolutely-positioned `LangPopover`. `internal` so the base file's `body`
+    /// can reference it across the extension boundary.
+    @ViewBuilder
+    var langPopoverOverlay: some View {
+        if isLangPopoverPresented {
+            ZStack(alignment: .topLeading) {
+                Color.black.opacity(0.001)
+                    .ignoresSafeArea()
+                    .contentShape(Rectangle())
+                    .onTapGesture { isLangPopoverPresented = false }
+                AISummaryLangPopover(
+                    selectedLanguage: viewModel.summaryTargetLanguage,
+                    theme: theme,
+                    onSelect: selectLanguage
+                )
+                .padding(.leading, 18)
+                .padding(.top, 92)
+                .shadow(color: .black.opacity(0.18), radius: 18, x: 0, y: 8)
+            }
+        }
+    }
+
+    /// Toggles the language popover open/closed (the lang-row pill tap).
+    func toggleLangPopover() {
+        isLangPopoverPresented.toggle()
+    }
+
+    // MARK: - Control → view-model wiring
+
+    /// Selects a Single/Bilingual segment. Sets the mapped `SummaryDisplayMode`
+    /// via the WI-1 synchronous mutator, then kicks the (re)translation so a
+    /// non-`.originalOnly` mode with a completed summary translates immediately.
+    /// `internal` so the mapping contract is unit-testable.
+    func selectDisplayMode(_ mode: SummaryDisplayMode) {
+        guard mode != viewModel.summaryDisplayMode else { return }
+        viewModel.setSummaryDisplayMode(mode)
+        Task { await viewModel.refreshSummaryTranslationIfNeeded() }
+    }
+
+    /// Selects a target language from the popover. Sets it via the WI-1
+    /// synchronous mutator (which invalidates any stale translation), closes the
+    /// popover, then re-kicks the translation if the current mode needs it.
+    func selectLanguage(_ language: BilingualLanguage) {
+        isLangPopoverPresented = false
+        guard language != viewModel.summaryTargetLanguage else { return }
+        viewModel.setSummaryTargetLanguage(language)
+        Task { await viewModel.refreshSummaryTranslationIfNeeded() }
+    }
+}
+#endif

--- a/vreader/Views/Reader/AISummaryTabView.swift
+++ b/vreader/Views/Reader/AISummaryTabView.swift
@@ -55,6 +55,11 @@ struct AISummaryTabView: View {
     /// presents `ShareActivityView` with the summary text.
     var onShare: (String) -> Void
 
+    /// Feature #90 WI-2: whether the language popover is presented. Owned here
+    /// (the `body` presents the popover); the lang-row wiring lives in the
+    /// `+Bilingual` extension to keep this file under the ~300-line guide.
+    @State var isLangPopoverPresented = false
+
     // MARK: - State sections
 
     /// The distinct visual sections the Summarize tab can show. One
@@ -95,8 +100,27 @@ struct AISummaryTabView: View {
                 theme: theme,
                 onSelect: selectScope
             )
+            // Feature #90 WI-2: the second control row — language + a
+            // Single/Bilingual toggle — beneath the scope chips (design's
+            // "two rows, not one crowded row").
+            AISummaryLangRow(
+                language: viewModel.summaryTargetLanguage,
+                mode: viewModel.summaryDisplayMode,
+                theme: theme,
+                isPopoverOpen: isLangPopoverPresented,
+                onTapLanguage: toggleLangPopover,
+                onSelectMode: selectDisplayMode
+            )
+            .padding(.horizontal, 18)
+            .padding(.top, 11)
+            .padding(.bottom, 2)
             stateBody
         }
+        // The language popover overlays the control block, anchored under the
+        // lang row — matching the artboard's absolutely-positioned `LangPopover`
+        // (an iPhone `.popover` would render as a sheet, breaking the design).
+        // The overlay body lives in the `+Bilingual` extension.
+        .overlay(alignment: .topLeading) { langPopoverOverlay }
     }
 
     /// The state-routed body, below the chip strip.

--- a/vreader/Views/Reader/ReaderAICoordinator.swift
+++ b/vreader/Views/Reader/ReaderAICoordinator.swift
@@ -262,7 +262,18 @@ final class ReaderAICoordinator {
             keychainService: keychain,
             profileStore: ProviderProfileStore.shared
         )
-        aiViewModel = AIAssistantViewModel(aiService: service)
+        let summaryVM = AIAssistantViewModel(aiService: service)
+        aiViewModel = summaryVM
+        // Feature #90 WI-2 (Gate-4 M1): seed the Summarize-tab bilingual target
+        // language from the book's ESTABLISHED per-book bilingual setting, so the
+        // summary inherits the reader's chosen language instead of the global
+        // default. Sets the language only — no translation kicks at setup (there
+        // is no summary yet).
+        if let override = PerBookSettingsStore.settings(
+            for: fingerprintKey, baseURL: ReaderContainerView.perBookSettingsBaseURL),
+           let langKey = override.bilingualTargetLanguage {
+            summaryVM.setSummaryTargetLanguage(BilingualLanguage.findOrDefault(key: langKey))
+        }
         translationViewModel = AITranslationViewModel(aiService: service)
 
         let fingerprint = DocumentFingerprint(canonicalKey: fingerprintKey)

--- a/vreaderTests/Views/Reader/AISummaryLangRowTests.swift
+++ b/vreaderTests/Views/Reader/AISummaryLangRowTests.swift
@@ -1,0 +1,81 @@
+// Purpose: Feature #90 WI-2 — pure-pinnable tests for the Summarize tab's
+// language-control derivations: the `(Segment → SummaryDisplayMode)` mapping,
+// the `activeSegment(for:)` derivation (which segment renders active for a
+// given display mode, including the `.originalOnly` default → Single), and the
+// popover row-identifier mapping over `BilingualLanguage.all`.
+//
+// These pin the control contract WI-2 wires into the view model (Single →
+// `.translatedOnly`, Bilingual → `.interlinear`) without a SwiftUI render pass
+// — the `AISummaryTabView.section(for:)` precedent. Tap UI is covered by the
+// Gate-5 XCUITest / DebugBridge pass, not here.
+//
+// @coordinates-with: AISummaryLangRow.swift, AISummaryLangPopover.swift,
+//   AIAssistantViewModel+BilingualSummary.swift, BilingualLanguage.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/bilingual-summarize-artboards.jsx`
+
+import Testing
+import Foundation
+@testable import vreader
+
+@Suite("AISummaryLangRow derivations — feature #90 WI-2")
+struct AISummaryLangRowTests {
+
+    // MARK: - Segment → SummaryDisplayMode mapping (the WI-2 contract)
+
+    @Test func singleSegmentMapsToTranslatedOnly() {
+        #expect(AISummaryLangRow.Segment.single.mode == .translatedOnly)
+    }
+
+    @Test func bilingualSegmentMapsToInterlinear() {
+        #expect(AISummaryLangRow.Segment.bilingual.mode == .interlinear)
+    }
+
+    @Test func segmentsAreSingleThenBilingual() {
+        #expect(AISummaryLangRow.Segment.allCases == [.single, .bilingual])
+    }
+
+    @Test func segmentIdentifiersMatchAccessibilityContract() {
+        #expect(AISummaryLangRow.Segment.single.identifier == "summaryModeSingle")
+        #expect(AISummaryLangRow.Segment.bilingual.identifier == "summaryModeBilingual")
+    }
+
+    @Test func segmentLabels() {
+        #expect(AISummaryLangRow.Segment.single.label == "Single")
+        #expect(AISummaryLangRow.Segment.bilingual.label == "Bilingual")
+    }
+
+    // MARK: - activeSegment(for:) derivation
+
+    @Test func interlinearRendersBilingualSegmentActive() {
+        #expect(AISummaryLangRow.activeSegment(for: .interlinear) == .bilingual)
+    }
+
+    @Test func translatedOnlyRendersSingleSegmentActive() {
+        #expect(AISummaryLangRow.activeSegment(for: .translatedOnly) == .single)
+    }
+
+    /// The `.originalOnly` default has no distinct segment — it rests on Single
+    /// (the design's default `layout='single'`).
+    @Test func originalOnlyDefaultRendersSingleSegmentActive() {
+        #expect(AISummaryLangRow.activeSegment(for: .originalOnly) == .single)
+    }
+
+    /// Round-trip: a segment's mode derives back to that same segment as active.
+    @Test func segmentModeRoundTripsToActiveSegment() {
+        for segment in AISummaryLangRow.Segment.allCases {
+            #expect(AISummaryLangRow.activeSegment(for: segment.mode) == segment)
+        }
+    }
+
+    // MARK: - Popover row identifiers
+
+    @Test func popoverRowIdentifierIsKeyNamespaced() {
+        let chinese = BilingualLanguage.findOrDefault(key: "Chinese")
+        #expect(AISummaryLangPopover.rowIdentifier(chinese) == "summaryLang-Chinese")
+    }
+
+    @Test func popoverRowIdentifiersAreUniquePerLanguage() {
+        let ids = BilingualLanguage.all.map { AISummaryLangPopover.rowIdentifier($0) }
+        #expect(Set(ids).count == BilingualLanguage.all.count)
+    }
+}


### PR DESCRIPTION
## Summary

WI-2 of feature #90 (bilingual AI summary). The UI control beneath the scope chips, wired to the WI-1 VM: an `AISummaryLangRow` (a `BilingualLanguage` pill + a Single/Bilingual segmented toggle) + an `AISummaryLangPopover` (the `BilingualLanguage.all` grid). Single → `.translatedOnly`, Bilingual → `.interlinear`, language pick → `setSummaryTargetLanguage`, then `refreshSummaryTranslationIfNeeded()`; `.originalOnly` is the resting default. Per the committed design (Rule 51).

Part of feature #90 — GH #1531.

## What changed
- `AISummaryLangRow` / `AISummaryLangPopover` / `AISummaryLangGlyphs` (custom `LineGlyph`/`StackGlyph` Path shapes per the artboard) / `AISummaryTabView+Bilingual` (the wiring).
- `ReaderAICoordinator` seeds the summary target language from the book's per-book `bilingualTargetLanguage` at VM creation (so the tab inherits the reader's chosen language).

## Codex Audit
`follow-up-recommended` — 2 rounds. R1 (wiring/isolation/derivation sound) found 2 Mediums: the per-book language not seeded (the host DOES have the key) + SF Symbols instead of the custom glyphs. R2 confirmed both resolved + no new findings; the 2 Lows (popover notch, async-glue tests) reasonably accepted. Log: `.claude/codex-audits/feat-feature-90-wi-2-lang-row-audit.md`.

## Validation
- [x] **24 tests pass** (11 `AISummaryLangRow` mapping + 13 `AIAssistantViewModel+BilingualSummary`). `RUN-TESTS RESULT: SUCCEEDED`.
- [x] Both audit loops clean; `** BUILD SUCCEEDED **`; version 3.57.1 → 3.57.2; all files <300.

## Slice verification (Gate 5)
The control wiring (mode mapping, language selection, per-book seeding) is exercised by the unit tests + the build. The end-to-end on-device acceptance (the control driving the card render) lands with WI-3, the final WI.

## Type of Change
- [x] Feature work item (Part of feature #90 / GH #1531)