### PR TITLE
docs(#323): close-gate verification-exception evidence

### DIFF
--- a/dev-docs/verification/bug-323-20260606.md
+++ b/dev-docs/verification/bug-323-20260606.md
@@ -1,0 +1,87 @@
+---
+kind: bug
+id: 323
+status_target: FIXED
+commit_sha: 07bf4b926adb760f98e6a74d55efd9fb9fa78c09
+app_version: 3.59.13 (build 913)
+date: 2026-06-06
+verifier: claude
+device_or_simulator: iPhone 17 Pro Simulator
+os_version: iOS 26.4
+build_configuration: Debug
+backend: n/a
+result: pass
+---
+
+# Bug #323 — AI chat hangs on the second message (composer never re-enables)
+
+## Close path: verification-exception
+
+The symptom (composer frozen after turn 1, second message un-sendable) only
+manifests when a session-op on the serialized `sessionOpChain` lane STALLS — a
+slow/never-settling cold-store `loadSessions()` (or a stuck store op) parked
+ahead of the turn's `saveSettledTurn`. That stall is a fault-injection condition:
+it cannot be reproduced on a device without a harness that holds a session-store
+op open. Per AGENTS.md "Close gate — verification exception", the close is
+anchored on a **deterministic high-fidelity integration test that drives the same
+failure path through the real subsystem boundaries** (only the persistence store
+— the genuine dependency boundary — is stubbed; `AIChatViewModel.runSend`,
+`runSerializedSessionOp`, and `saveSettledTurn` are the real production code).
+
+## Acceptance criteria
+
+| # | Criterion (GH #1545) | Verification | Result |
+|---|---|---|---|
+| 1 | Second (and subsequent) messages send and stream a reply | `AIChatViewModelTurn2HangTests.secondMessage_completes_doesNotHang` + the stall test below drive two sequential turns through real `runSend`; turn 2's `[MOCK]` reply lands. | PASS |
+| 2 | The composer re-enables after each turn | `secondMessage_composerReEnables_whenSessionSaveStalls`: with turn 2's session save **parked** on the lane, `isLoading == false` (composer usable) the moment the reply settles. **Fails on the pre-fix commit** (`** TEST FAILED **`, no hang), passes after the fix. | PASS |
+| 3 | A slow/failed session save cannot freeze the chat | Same stall test — the save is `gateUpdate()`-parked for the whole assertion window; the composer is still re-enabled. | PASS |
+| 4 | A slow/failed tool call cannot freeze the chat | `AgenticChatDriverTests.cancellationBreaksLoop` (outer-loop) + `cancellationBreaksInRound` (gated tool parks mid-round → cancel → the 2nd in-round tool never runs; `CancellationError` thrown). The driver is also iteration-capped (6). | PASS |
+| 5 | Regression test for the two-message sequence | `secondMessage_completes_doesNotHang` (happy path) + `secondMessage_composerReEnables_whenSessionSaveStalls` (stall path). | PASS |
+
+## Commands run
+
+Close-gate verification on the merged `main` (`07bf4b92`, v3.59.13 build 913):
+
+```bash
+# Primary regression suite (RED→GREEN test) on merged main:
+TIMEOUT_SECS=900 scripts/run-tests.sh vreaderTests/AIChatViewModelTurn2HangTests
+#   → ✔ Test run with 2 tests in 1 suite passed
+#   → RUN-TESTS RESULT: SUCCEEDED
+
+# Driver cancellation suite:
+scripts/run-tests.sh vreaderTests/AgenticChatDriverTests
+#   → ✔ Test run with 11 tests in 1 suite passed
+
+# Pre-fix RED confirmation (Fix A reverted via `git stash`):
+#   secondMessage_composerReEnables_whenSessionSaveStalls → ** TEST FAILED ** (exit 65), no hang
+
+# Regression (no break from Fix A's teardown reorder — save still awaited):
+scripts/run-tests.sh vreaderTests/AIChatViewModelSessionsTests   # 28 passed
+scripts/run-tests.sh vreaderTests/AIChatViewModelAgenticTests    #  8 passed
+scripts/run-tests.sh vreaderTests/AIChatViewModelTests           #  passed
+scripts/run-tests.sh vreaderTests/AIChatViewModelWholeBookTests  #  passed
+```
+
+## Observations
+
+- **Root cause was deterministic, not provider-specific.** A prior session
+  mis-framed #1545 as "needs the user's configured AI provider" after chasing a
+  connection-reuse hypothesis. The tracker's code-read root cause is the real
+  one: `runSend` `await`ed `saveSettledTurn` (`:179`) before its `defer` (`:96`)
+  reset `isLoading`; the serialized session lane (`runSerializedSessionOp` →
+  `await prior?.value`) blocks the save behind a parked prior op → `isLoading`
+  stuck true → `canSend` (`!isLoading`) false → Send button disabled. No provider
+  required to reproduce — `MockAIProvider` + a `gateUpdate()`-stalled store does it.
+- **Fix A keeps the save awaited** (only the user-visible `isLoading`/`streamTask`
+  reset moves ahead of it), so the ~28 session-save observability tests, which
+  assert `createCallCount`/`updateCallCount`/`lastSavedMessages` synchronously
+  after `await sendMessage`, are unchanged.
+- Codex audit `019e9b7b` cleared Fix A with no findings and raised one Medium on
+  Fix B (in-round cancellation), fixed in-diff + covered by `cancellationBreaksInRound`.
+
+## Artifacts
+
+- Audit log: `.claude/codex-audits/fix-issue-1545-chat-turn2-hang-audit.md`
+- PR: #1557 (squash-merged as `07bf4b92`).
+- Tests: `vreaderTests/ViewModels/AIChatViewModelTurn2HangTests.swift`,
+  `vreaderTests/Services/AI/AgenticChatDriverTests.swift`.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 913
-        MARKETING_VERSION: 3.59.13
+        CURRENT_PROJECT_VERSION: 914
+        MARKETING_VERSION: 3.59.14
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7757,7 +7757,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 913;
+				CURRENT_PROJECT_VERSION = 914;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7765,7 +7765,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.59.13;
+				MARKETING_VERSION = 3.59.14;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -7911,7 +7911,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 913;
+				CURRENT_PROJECT_VERSION = 914;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7919,7 +7919,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.59.13;
+				MARKETING_VERSION = 3.59.14;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
## Summary

Adds the verification-exception evidence file for the Bug #323 (GH #1545) close
gate. The composer-freeze symptom only manifests under a stalled session-op lane
(a fault-injection condition), so the close is anchored on a deterministic
high-fidelity test at the real `runSend` / `runSerializedSessionOp` /
`saveSettledTurn` boundaries (only the persistence store stubbed). RED on the
pre-fix commit, GREEN on merged `main` (`07bf4b92`, v3.59.13).

Follows the established precedent (`dev-docs/verification/bug-302/304/306/311/316`).

- [x] Docs sync — n/a (evidence doc only)
- [x] Version bumped: 3.59.13 → 3.59.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)