### PR TITLE
fix(#329): skip disconnected sections in the resize compensation

### DIFF
--- a/.claude/codex-audits/fix-issue-1568-resize-evicted-double-comp-audit.md
+++ b/.claude/codex-audits/fix-issue-1568-resize-evicted-double-comp-audit.md
@@ -1,0 +1,30 @@
+---
+branch: fix/issue-1568-resize-evicted-double-comp
+threadId: 019eb1ae-eaa6-72c1-b085-9878db701a8f
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-10
+---
+
+# Gate-4 mini-audit — Bug #329 round-3 follow-up (evicted-section resize double-compensation)
+
+Follow-up to the round-3 audit (`019eb187`). The post-merge 1px re-close sweep
+through the LONG image-bearing chapters (spine 7→11) caught 5 residual backward
+jumps: scrollTop crashing toward 0 at multi-evict moments (11308→278, 6523→1),
+then a backward-extend flash. Root cause: an EVICTED section fires a terminal
+zero-size ResizeObserver entry; its detached `offsetTop` reads 0, passing the
+above-viewport check → its height subtracted a SECOND time on top of
+`removeChapterSectionJS`'s own compensation.
+
+Fix: `if (!el.isConnected) { continue; }` as the first line of the RO callback.
+
+## Verdict — ship-as-is, no findings
+
+Codex confirmed: (1) the guard closes the only eviction-time compensation path;
+(2) skipping WeakMap bookkeeping for disconnected elements is correct (identity-
+keyed, GC reclaims); (3) live shrink/growth compensation preserved; (4) the
+batched-entry ordering hazard (connected at observe, disconnected at delivery)
+is covered — connection is checked at delivery time, the only dangerous moment.
+
+Device re-sweep of the failing region (spine 7→11, 12166 ticks): 0 jumps,
+0 stalls, 0 thrash.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 950
-        MARKETING_VERSION: 3.62.5
+        CURRENT_PROJECT_VERSION: 951
+        MARKETING_VERSION: 3.62.6
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7917,7 +7917,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 950;
+				CURRENT_PROJECT_VERSION = 951;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7925,7 +7925,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.62.5;
+				MARKETING_VERSION = 3.62.6;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -8071,7 +8071,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 950;
+				CURRENT_PROJECT_VERSION = 951;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8079,7 +8079,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.62.5;
+				MARKETING_VERSION = 3.62.6;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Views/Reader/EPUBContinuousScrollJS.swift
+++ b/vreader/Views/Reader/EPUBContinuousScrollJS.swift
@@ -208,8 +208,13 @@ enum EPUBContinuousScrollJS {
     /// `scrollTop` by the height delta. The "entirely above" gate uses the
     /// PRE-resize bottom (`offsetTop + oldH`) — Codex Gate-4 High: gating on the
     /// post-resize bottom would skip the compensation exactly when a growth
-    /// crosses the viewport top (and over-compensate the symmetric shrink). The
-    /// first observation of a section only
+    /// crosses the viewport top (and over-compensate the symmetric shrink).
+    /// DISCONNECTED targets are skipped — an EVICTED section can fire a final
+    /// zero-size entry whose detached `offsetTop` reads 0, which would pass the
+    /// above-viewport check and subtract its height a SECOND time on top of
+    /// `removeChapterSectionJS`'s own compensation (the post-merge 1px sweep
+    /// caught exactly this: scrollTop crashing to ~0 at multi-evict moments,
+    /// then a backward-extend flash). The first observation of a section only
     /// records its baseline height (the insert-time compensation in
     /// `prependChapterSectionJS` already covered its initial height).
     static let continuousScrollObserverJS = """
@@ -259,6 +264,7 @@ enum EPUBContinuousScrollJS {
         var resizeObserver = new ResizeObserver(function(entries) {
             for (var i = 0; i < entries.length; i++) {
                 var el = entries[i].target;
+                if (!el.isConnected) { continue; }
                 var newH = el.offsetHeight || 0;
                 var oldH = lastHeights.get(el);
                 lastHeights.set(el, newH);

--- a/vreaderTests/Views/Reader/EPUBContinuousScrollEvictionGuardTests.swift
+++ b/vreaderTests/Views/Reader/EPUBContinuousScrollEvictionGuardTests.swift
@@ -276,6 +276,11 @@ struct EPUBContinuousScrollEvictionGuardTests {
         // Only sections ENTIRELY above the viewport (by their PRE-resize bottom —
         // Codex Gate-4 High) shift the reader's content.
         #expect(js.contains("(el.offsetTop + oldH) <= root.scrollTop"))
+        // An EVICTED (disconnected) section must never compensate — its final
+        // zero-size entry reads offsetTop 0 and would double-subtract on top of
+        // removeChapterSectionJS's own compensation (the post-merge 1px sweep
+        // caught scrollTop crashing to ~0 at multi-evict moments).
+        #expect(js.contains("if (!el.isConnected) { continue; }"))
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1624 (the round-3 px-aware eviction deferral). The post-merge **1px re-close sweep through the long image-bearing chapters** (spine 7→11) caught 5 residual backward jumps with a distinct signature: `scrollTop` crashing toward 0 at multi-evict moments (11308→278, 6523→1), then a backward-extend flash reload.

Root cause: an **evicted** section fires a terminal zero-size ResizeObserver entry; its detached `offsetTop` reads 0, passing the above-viewport check → its height is subtracted a **second** time on top of `removeChapterSectionJS`'s own compensation.

Refs #1568

## What Changed

One guard as the first line of the ResizeObserver callback: `if (!el.isConnected) { continue; }` (+ doc comment + JS-shape test pin).

## Codex Audit

1 round, **ship-as-is, no findings** (`.claude/codex-audits/fix-issue-1568-resize-evicted-double-comp-audit.md`) — confirmed the guard closes the only eviction-time compensation path, covers the batched-entry ordering hazard (connection checked at delivery time), and preserves live shrink/growth compensation.

## Validation

- [x] 32 tests green (guard + sim + JS suites)
- [x] **Device 1px re-sweep of the failing region** (spine 7→11, 12166 ticks): **0 jumps, 0 stalls, 0 thrash** (was 5 jumps)
- [x] Version bumped: 3.62.5 → 3.62.6

## Post-Merge Verification Plan

The complete formal re-close verification on the merged build: 1px sweeps across the front matter (0→7) AND the long chapters (7→11) — both clean → evidence file → close #1568.

## Type of Change

- [x] Bug fix (Refs #1568)

🤖 Generated with [Claude Code](https://claude.com/claude-code)