### PR TITLE
fix(hooks): gh-issue-mirror hook dies with E2BIG on large trackers (Argument list too long)

### DIFF
--- a/.claude/hooks/check_gh_issue_mirror.sh
+++ b/.claude/hooks/check_gh_issue_mirror.sh
@@ -51,9 +51,11 @@ new_content() {
             echo "$INPUT" | jq -r '.tool_input.content // ""'
             ;;
         Edit)
-            HOOK_INPUT="$INPUT" HOOK_FILE="$FILE_PATH" python3 -c '
+            # INPUT goes via stdin, not env/argv — env vars count against
+            # ARG_MAX (E2BIG: "Argument list too long" once bugs.md grew >1MB).
+            printf '%s' "$INPUT" | HOOK_FILE="$FILE_PATH" python3 -c '
 import json, os, sys
-data = json.loads(os.environ["HOOK_INPUT"])
+data = json.load(sys.stdin)
 old = data["tool_input"].get("old_string", "")
 new = data["tool_input"].get("new_string", "")
 try:
@@ -69,9 +71,10 @@ else:
 '
             ;;
         MultiEdit)
-            HOOK_INPUT="$INPUT" HOOK_FILE="$FILE_PATH" python3 -c '
+            # stdin, not env — see the Edit branch (ARG_MAX / E2BIG).
+            printf '%s' "$INPUT" | HOOK_FILE="$FILE_PATH" python3 -c '
 import json, os, sys
-data = json.loads(os.environ["HOOK_INPUT"])
+data = json.load(sys.stdin)
 edits = data["tool_input"].get("edits", [])
 try:
     with open(os.environ["HOOK_FILE"]) as f:
@@ -98,8 +101,16 @@ NEW="$(new_content)"
 # status/notes than OLD. For each such row, require `GH: #N` (or the
 # kind-appropriate Mirror escape) in the Notes column.
 MISSING_FILE="$(mktemp)"
-trap 'rm -f "$MISSING_FILE"' EXIT
-KIND="$KIND" NEW_CONTENT="$NEW" OLD_CONTENT="$OLD" python3 - >"$MISSING_FILE" <<'PYEOF'
+OLD_FILE="$(mktemp)"
+NEW_FILE="$(mktemp)"
+trap 'rm -f "$MISSING_FILE" "$OLD_FILE" "$NEW_FILE"' EXIT
+# Contents go via temp FILES, paths via env — passing the full tracker
+# text as env vars exceeded ARG_MAX once docs/bugs.md grew past ~1MB
+# ("python3: Argument list too long", E2BIG; env + argv share the limit).
+# printf is a bash builtin: no exec, no ARG_MAX exposure.
+printf '%s' "$OLD" > "$OLD_FILE"
+printf '%s' "$NEW" > "$NEW_FILE"
+KIND="$KIND" NEW_PATH="$NEW_FILE" OLD_PATH="$OLD_FILE" python3 - >"$MISSING_FILE" <<'PYEOF'
 import os, re, sys
 
 KIND = os.environ["KIND"]
@@ -147,8 +158,10 @@ def has_gh_or_exempt(notes):
         return True
     return False
 
-new_rows = parse_rows(os.environ["NEW_CONTENT"])
-old_rows = parse_rows(os.environ["OLD_CONTENT"])
+with open(os.environ["NEW_PATH"]) as f:
+    new_rows = parse_rows(f.read())
+with open(os.environ["OLD_PATH"]) as f:
+    old_rows = parse_rows(f.read())
 
 missing = []
 for rid, (status, notes) in new_rows.items():

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 967
-        MARKETING_VERSION: 3.63.3
+        CURRENT_PROJECT_VERSION: 968
+        MARKETING_VERSION: 3.63.4
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -7941,7 +7941,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 967;
+				CURRENT_PROJECT_VERSION = 968;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -7949,7 +7949,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.63.3;
+				MARKETING_VERSION = 3.63.4;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -8095,7 +8095,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 967;
+				CURRENT_PROJECT_VERSION = 968;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8103,7 +8103,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.63.3;
+				MARKETING_VERSION = 3.63.4;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
Meta-process/tooling fix (merge-gate exempt — no bug/feature row referenced).

## Problem
Every `docs/bugs.md` / `docs/features.md` edit logs:
```
check_gh_issue_mirror.sh: line 102: /opt/homebrew/bin/python3: Argument list too long
```
The hook passed the **entire old+new tracker contents** to python3 as environment variables (`NEW_CONTENT`/`OLD_CONTENT`) and the tool JSON as `HOOK_INPUT`. Env vars + argv share macOS's ~1MB ARG_MAX; `docs/bugs.md` is now ~990KB, so OLD+NEW ≈ 2MB exceeded it. The failure was non-blocking, so the GH-mirror check has been **silently not running** on tracker edits.

## Fix
- Contents → **mktemp files**, paths via env (`printf` is a builtin: no exec, no ARG_MAX exposure); python reads the files.
- Tool JSON → **stdin** in the Edit/MultiEdit `new_content` branches (`json.load(sys.stdin)`).

## Verified (against the live 990KB bugs.md)
- Benign edit → exit 0 (previously E2BIG at exec)
- Synthetic mirror-required row without `GH:` → exit 2 with the full block message
- Non-tracker file → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)