### PR TITLE
docs(#347): verification evidence

### DIFF
--- a/dev-docs/verification/bug-347-20260611.md
+++ b/dev-docs/verification/bug-347-20260611.md
@@ -1,0 +1,46 @@
+---
+kind: bug
+id: 347
+status_target: FIXED
+commit_sha: 5ef2207d7ef94432450b65410e5df3c41fb9f3e9
+app_version: 3.64.2 (build 974)
+date: 2026-06-11
+verifier: claude
+device_or_simulator: iPhone 17 Pro Simulator
+os_version: iOS 26.4
+build_configuration: Debug
+backend: n/a
+result: pass
+---
+
+# Bug #347 — forward-append starvation: verification
+
+## Acceptance criteria
+
+| Criterion | Observed | Result |
+|---|---|---|
+| Chained edge-driven appends continue past the old soft ceiling under one unbroken gesture | `chainedGesture_appendsContinuePastSoftCeiling` drives the PRODUCTION coordinator with 8 consecutive near-bottom signals (touchActive true throughout): the window grows past maxSpan+3 with zero evictions | pass |
+| A pathological signal storm stays bounded | `pathologicalGesture_hardCapStopsAppends`: growth stops at maxSpan+12 | pass |
+| The first settle drains the WHOLE backlog | `settleAfterHardCapGrowth_drainsTheWholeBacklog`: span returns to exactly maxSpan, every eviction runs | pass |
+| No regression on real scrolling | 14-fling rapid idb sweep through 道诡异仙 (19MB, 1042 spines): content always present, no stitch-edge stall | pass |
+
+## Commands run
+
+```bash
+scripts/run-tests.sh vreaderTests/EPUBContinuousScrollEvictionGuardTests
+scripts/run-tests.sh vreaderTests/EPUBContinuousScrollObserverJSTests
+# device smoke: 14× idb ui swipe --duration 1.0 200 650 200 150 (0.4s gaps)
+```
+
+## Observations
+
+The user's exact timing (inter-fling gaps under the 160ms settle window)
+is physically unreproducible via idb — process-spawn latency between
+commands exceeds the window, so every scripted sequence settles between
+flings. The deterministic suite supplies the never-settling signal shape
+directly to the production coordinator (the same boundary-signal entry
+point the JS observer drives) — verification-exception class.
+
+## Artifacts
+
+- `artifacts/bug-347-fix-sweep-no-edge-20260611.png`


### PR DESCRIPTION
Evidence file for the GH #1658 close (exception class). No version bump (docs-only).