### PR TITLE
feat(#99 WI-2): edit-framed translation-settings sheet

### DIFF
--- a/.claude/codex-audits/feat-feature-99-wi-2-edit-sheet-audit.md
+++ b/.claude/codex-audits/feat-feature-99-wi-2-edit-sheet-audit.md
@@ -1,0 +1,36 @@
+---
+branch: feat/feature-99-wi-2-edit-sheet
+threadId: 019eb61f-a3e2-7e90-bf35-a0613f1b5513
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-11
+---
+
+# Feature #99 WI-2 — Gate 4 implementation audit
+
+Plan: `dev-docs/plans/20260611-feature-99-translation-settings-reentry.md`
+(WI-2: the edit-framed setup sheet). Runner: `scripts/run-codex.sh`.
+Round-2 session: `019eb629-f23b-71f2-a564-0dc7989f6340`.
+
+## Round 1 findings
+
+| Finding | Severity | Resolution |
+|---|---|---|
+| `BilingualSetupSheet+EditMode.swift:119` — the context strip italicised the whole line; the design italicises only the serif book-title run | Medium | **Fixed** — concatenated runs: plain 11.5pt prefix + italic Source Serif 4 title, single line tail-truncated. |
+| `BilingualLanguagePickerCell.swift:79` — the cached-badge ring used `theme.chromeColor`; the design pins it to the sheet surface | Low | **Fixed** — `theme.sheetSurfaceColor`. |
+| `BilingualSetupSheet.swift` at 314 lines (> ~300) | Low | **Fixed** — `TranslationGranularity` display-label extension moved to `BilingualSetupSheetState.swift`; the sheet is 293 lines. |
+
+Round 1 explicitly confirmed: first-enable keeps the default trailing
+close button and renders unchanged; the `normalised()`/dirty
+interaction is covered by the WI-1 canonicalisation; the state-file
+extraction kept behavior + doc comments; unknown cached keys are safe.
+
+## Round 2 (verify)
+
+Clean — all three fixes confirmed; no new issues.
+
+## Verdict
+
+ship-as-is. 31 tests green across the sheet suites (12 edit-mode pins
+incl. first-enable-unchanged + CTA/strip/badge/caption rules + cost
+strip copy; existing first-enable suite; language registry suite).

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 981
-        MARKETING_VERSION: 3.65.3
+        CURRENT_PROJECT_VERSION: 982
+        MARKETING_VERSION: 3.65.4
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -303,6 +303,7 @@
 		2CD1D6C0686DD8C096580AB3 /* SummaryScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA8C0234B383C8D2877E21CC /* SummaryScope.swift */; };
 		2D1E2FD1F2B6D51EC62EBB60 /* BookSourceHTTPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50CA80F28DFB8D0D4F4BEC25 /* BookSourceHTTPClientTests.swift */; };
 		2D22FEBD43A0354357992A28 /* RealDebugBridgeContext+Present.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8C0771E06618E5F68C410D /* RealDebugBridgeContext+Present.swift */; };
+		2D624B258CC0D4EF850C4234 /* BilingualCostStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635A22A57F3A7B544B9AEF36 /* BilingualCostStrip.swift */; };
 		2D73988936C9A657637B8154 /* FoliateHighlightMutator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC51E5F1213D2B1363C13D5 /* FoliateHighlightMutator.swift */; };
 		2D873AE2762173772AA967E5 /* PDFBilingualPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8CFB25779576176F1D678C7 /* PDFBilingualPanelState.swift */; };
 		2D8D59A6A41D0A2D5AB16741 /* ReaderAuditFix2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD76366E51B98FEE9E53DB3C /* ReaderAuditFix2Tests.swift */; };
@@ -584,6 +585,7 @@
 		547FFE39E9DC4280100F850F /* BookDetailsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6D4D3FF162BE1661731AAA /* BookDetailsSheet.swift */; };
 		54852944B2631BA79CF41926 /* sha1.c in Sources */ = {isa = PBXBuildFile; fileRef = 629CCC658A5843CA9CB3915C /* sha1.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		5496FD5A3A1618D7845C45B5 /* FoliateBottomChromeWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A487F84E183F99F1D9107F /* FoliateBottomChromeWiringTests.swift */; };
+		549FECC5FEA22B0FD4161B61 /* BilingualSetupSheetEditModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E866942B03CE186122845FE2 /* BilingualSetupSheetEditModeTests.swift */; };
 		54AE686286BC92388C9F8B7D /* TOCSheet+Support.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DDE77F4975D2E9EA4B33D3B /* TOCSheet+Support.swift */; };
 		5565D6CFF2A7610CDA45D441 /* StatsTimeWindowBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2265BDFB809DF67F55C9BFC /* StatsTimeWindowBar.swift */; };
 		5572AED7041B6CFD3C93AB79 /* LazyDownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159BB4EBD79ECE6657D50EC1 /* LazyDownloadDelegate.swift */; };
@@ -935,6 +937,7 @@
 		8A34787973BCC059B72DC032 /* BilingualSettingsEditModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118DB22E96D619680C295BE8 /* BilingualSettingsEditModel.swift */; };
 		8A3AE73DD5935F4E45882E38 /* AccessibilityFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC4CE4DBCD7E5A52BC4E511 /* AccessibilityFormatters.swift */; };
 		8A45E09F7832BE075BAF73D3 /* PersistenceActorStatsReadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D313521AE0A256629A2B0244 /* PersistenceActorStatsReadTests.swift */; };
+		8A59895CE7FB81694BC22032 /* BilingualSetupSheetState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4629D6E0833DD7B6472430FC /* BilingualSetupSheetState.swift */; };
 		8A5EFD4729B7E4BE9D2CA38E /* ReplacementTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF84D4FD4FAA3232D18AA96 /* ReplacementTransform.swift */; };
 		8AD533CDAFAC138CA7E20D75 /* FoliateTapToleranceBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839E44D56EADF8DC5E5B8BB8 /* FoliateTapToleranceBundleTests.swift */; };
 		8AE1A6146EC01A464580BBA9 /* DeviceIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B8B24C49B7E5DCAC2B9667 /* DeviceIdentityTests.swift */; };
@@ -1634,6 +1637,7 @@
 		FB4B2B41D865A14865DF4DE1 /* HTTPTTSProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDE700F3AC42B0D8AD377E1 /* HTTPTTSProviderTests.swift */; };
 		FB59D6FDE7A4F0E7F44C78DA /* DebugAIActionEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291B9DC0FD8C89549850D5A6 /* DebugAIActionEffect.swift */; };
 		FB7EAB10F53380ED4FFAF9D1 /* ChapterTranslationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A9F4F3A737FB80599893B5 /* ChapterTranslationStore.swift */; };
+		FB8CC2BCA4B7F5D2D7C731D5 /* BilingualSetupSheet+EditMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E451D278E6E62CBB3AC574 /* BilingualSetupSheet+EditMode.swift */; };
 		FBA0D5A48A4DC6B55237AD7C /* StandaloneNoteCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9EFCEB831649A6421626591 /* StandaloneNoteCard.swift */; };
 		FBE9680C2EE09F4F1936BC5C /* PDFReaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D54AC9AD2556A67C96BD52 /* PDFReaderViewModel.swift */; };
 		FBF9F886D16DA6D941A6C8CD /* LibraryShellTokensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D40146D7306CDCE0F1A2FC91 /* LibraryShellTokensTests.swift */; };
@@ -2130,6 +2134,7 @@
 		46221600B62F5482365B0484 /* AIAssistantViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAssistantViewModel.swift; sourceTree = "<group>"; };
 		4622E66CB12A25DFDE0EEBD1 /* BilingualTextRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualTextRenderer.swift; sourceTree = "<group>"; };
 		46230855AD50583047E521C5 /* TXTChapterOverlayViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTChapterOverlayViews.swift; sourceTree = "<group>"; };
+		4629D6E0833DD7B6472430FC /* BilingualSetupSheetState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualSetupSheetState.swift; sourceTree = "<group>"; };
 		4630258E354B2D34ADB23182 /* WebDAVProfileListViewModelEditorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVProfileListViewModelEditorTests.swift; sourceTree = "<group>"; };
 		469230212394815593F6047E /* xmlwriter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = xmlwriter.c; sourceTree = "<group>"; };
 		469B267E0D3DB05D1D8F530A /* FoliateHighlightJSBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateHighlightJSBridgeTests.swift; sourceTree = "<group>"; };
@@ -2355,6 +2360,7 @@
 		62D7DA128D4B2AC1F362D571 /* LaunchHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchHelper.swift; sourceTree = "<group>"; };
 		631D0375777D50E5B1EDF31C /* HighlightedSnippetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightedSnippetTests.swift; sourceTree = "<group>"; };
 		633822DF0A5822C12C6B1B3D /* AgenticToolRegistryBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgenticToolRegistryBuilderTests.swift; sourceTree = "<group>"; };
+		635A22A57F3A7B544B9AEF36 /* BilingualCostStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualCostStrip.swift; sourceTree = "<group>"; };
 		63604C0EFC18CDB16EF2C176 /* Feature11EPUBBottomChromeVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature11EPUBBottomChromeVerificationTests.swift; sourceTree = "<group>"; };
 		6362591D3F62B4BC84CE136A /* FileAvailabilityStateMachineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileAvailabilityStateMachineTests.swift; sourceTree = "<group>"; };
 		637BAF0EB6E458BE29A4C2CE /* ReaderLifecycleHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderLifecycleHelperTests.swift; sourceTree = "<group>"; };
@@ -2786,6 +2792,7 @@
 		A8B682E216B5A24055B696F0 /* SwiftDataSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataSessionStore.swift; sourceTree = "<group>"; };
 		A8C28D0E24662BFD87AEBC16 /* EPUBSwipeGestureClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EPUBSwipeGestureClassifierTests.swift; sourceTree = "<group>"; };
 		A8C56D76EC2A57744D168E86 /* AnnotationImportError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationImportError.swift; sourceTree = "<group>"; };
+		A8E451D278E6E62CBB3AC574 /* BilingualSetupSheet+EditMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BilingualSetupSheet+EditMode.swift"; sourceTree = "<group>"; };
 		A922B4886FE1CE378009FB1B /* EPUBReaderContainerView+Highlights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EPUBReaderContainerView+Highlights.swift"; sourceTree = "<group>"; };
 		A94CDCF4ECFB73E713C008EF /* ReaderAICoordinatorChatContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderAICoordinatorChatContextTests.swift; sourceTree = "<group>"; };
 		A96A115C3FA0B797030C1D1F /* TXTTextViewBridgeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TXTTextViewBridgeCoordinator.swift; sourceTree = "<group>"; };
@@ -3206,6 +3213,7 @@
 		E7D86F739CC4D19AF019F728 /* LocatorNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocatorNormalizer.swift; sourceTree = "<group>"; };
 		E84B53D4E30D6614436E4C68 /* SearchResultsGroupedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsGroupedList.swift; sourceTree = "<group>"; };
 		E861A379A620B769CEA36300 /* AIChatViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatViewModelTests.swift; sourceTree = "<group>"; };
+		E866942B03CE186122845FE2 /* BilingualSetupSheetEditModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BilingualSetupSheetEditModeTests.swift; sourceTree = "<group>"; };
 		E8CFB25779576176F1D678C7 /* PDFBilingualPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFBilingualPanelState.swift; sourceTree = "<group>"; };
 		E8EE09BCDCB14CCFAA6A943D /* FoliateVerticalContainerLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoliateVerticalContainerLayoutTests.swift; sourceTree = "<group>"; };
 		E8F7E4F4F972EB04756197F0 /* ReadinessProviderBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadinessProviderBlock.swift; sourceTree = "<group>"; };
@@ -4357,6 +4365,7 @@
 			isa = PBXGroup;
 			children = (
 				1923055CD55D02FA17D295ED /* BilingualAttributedStringComposer.swift */,
+				635A22A57F3A7B544B9AEF36 /* BilingualCostStrip.swift */,
 				DC88A66F5D64402A04C999C3 /* BilingualDisplayPipeline.swift */,
 				35ACE50FE5717CCC34553EA7 /* BilingualLanguage.swift */,
 				29FC6C8B57A45954AF4A20C0 /* BilingualLanguagePickerCell.swift */,
@@ -4365,8 +4374,10 @@
 				1987220FE3E8931D9F8185F2 /* BilingualPill.swift */,
 				118DB22E96D619680C295BE8 /* BilingualSettingsEditModel.swift */,
 				4493553E18BBEB66EA8D32BF /* BilingualSetupSheet.swift */,
+				A8E451D278E6E62CBB3AC574 /* BilingualSetupSheet+EditMode.swift */,
 				D35CDC4131829818B115292B /* BilingualSetupSheet+Sections.swift */,
 				CA9C0EC7A5761ACEAEFB3304 /* BilingualSetupSheetContainer.swift */,
+				4629D6E0833DD7B6472430FC /* BilingualSetupSheetState.swift */,
 				4622E66CB12A25DFDE0EEBD1 /* BilingualTextRenderer.swift */,
 				2058A0653A7728740207C3C7 /* BilingualTXTBridgeDelegateAdapter.swift */,
 				904A30F4AD7E5862C2D3C955 /* EPUBBilingualJS.swift */,
@@ -5296,6 +5307,7 @@
 				584B96C4075536A21E49E647 /* BilingualOffsetRouterTests.swift */,
 				B8AF952035ED7A7AF46DE73A /* BilingualPillTests.swift */,
 				EC1A9810CAC74CD2F1ADBC6D /* BilingualSettingsEditModelTests.swift */,
+				E866942B03CE186122845FE2 /* BilingualSetupSheetEditModeTests.swift */,
 				E49486599FAD7ED74521BC9C /* BilingualSetupSheetTests.swift */,
 				7FA184F0D822A7EC8A0F445B /* BilingualTextRendererTests.swift */,
 				5EFF95845B612E1D435DD2FD /* BilingualTXTBridgeDelegateAdapterTests.swift */,
@@ -6397,6 +6409,7 @@
 				5350AA549A9AC79C1013241B /* BilingualReadingViewModelPrefetchUnitTests.swift in Sources */,
 				58C21B04E91D34FD03CDECF8 /* BilingualReadingViewModelRetryUnitTests.swift in Sources */,
 				F8A964A5A7D89F4C2FE2734A /* BilingualSettingsEditModelTests.swift in Sources */,
+				549FECC5FEA22B0FD4161B61 /* BilingualSetupSheetEditModeTests.swift in Sources */,
 				D966A8500C90AB2D3834ECD4 /* BilingualSetupSheetTests.swift in Sources */,
 				5E9EF78E503032EED9BEA90A /* BilingualTXTBridgeDelegateAdapterTests.swift in Sources */,
 				F725E00A6B2B5C15B63B5037 /* BilingualTextRendererTests.swift in Sources */,
@@ -7086,6 +7099,7 @@
 				986EFB28F7203E56F853A0FD /* BasePageNavigator.swift in Sources */,
 				C6B8E8D2BCF336DDFBF24E36 /* BilingualAIReadiness.swift in Sources */,
 				C1F29CC2BCCD3BA426DEB952 /* BilingualAttributedStringComposer.swift in Sources */,
+				2D624B258CC0D4EF850C4234 /* BilingualCostStrip.swift in Sources */,
 				04059C90590FC9DE007E150D /* BilingualDisplayPipeline.swift in Sources */,
 				430AF3E819AA5E3B26746B00 /* BilingualDisplaySegmentMap.swift in Sources */,
 				BBD66D4BA45254B25A30640F /* BilingualLanguage.swift in Sources */,
@@ -7097,9 +7111,11 @@
 				2B0B44B591B5F61E1AC6DB83 /* BilingualReadingViewModel+Prefetch.swift in Sources */,
 				32A02A2EECC7FFE73EEFC242 /* BilingualReadingViewModel.swift in Sources */,
 				8A34787973BCC059B72DC032 /* BilingualSettingsEditModel.swift in Sources */,
+				FB8CC2BCA4B7F5D2D7C731D5 /* BilingualSetupSheet+EditMode.swift in Sources */,
 				0EF8D8D693C59F1ACA5140CF /* BilingualSetupSheet+Sections.swift in Sources */,
 				6F77E9702493FB758FBF3319 /* BilingualSetupSheet.swift in Sources */,
 				491192974582008A6771D718 /* BilingualSetupSheetContainer.swift in Sources */,
+				8A59895CE7FB81694BC22032 /* BilingualSetupSheetState.swift in Sources */,
 				722C1A60DE160DCF295D808F /* BilingualTXTBridgeDelegateAdapter.swift in Sources */,
 				87260794475A7CB03D8DCBE0 /* BilingualTextRenderer.swift in Sources */,
 				30C1DE820BD42DAC78AC80FC /* BlobPath.swift in Sources */,

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -8021,7 +8021,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 981;
+				CURRENT_PROJECT_VERSION = 982;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8029,7 +8029,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.65.3;
+				MARKETING_VERSION = 3.65.4;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -8175,7 +8175,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 981;
+				CURRENT_PROJECT_VERSION = 982;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8183,7 +8183,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.65.3;
+				MARKETING_VERSION = 3.65.4;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;

--- a/vreader/Views/Reader/Bilingual/BilingualCostStrip.swift
+++ b/vreader/Views/Reader/Bilingual/BilingualCostStrip.swift
@@ -1,0 +1,97 @@
+// Purpose: Feature #99 WI-2 — the edit-frame cost strip (design §#1640
+// `BSCostStrip`): new-language (accent-tinted, sparkle), cached-language
+// (neutral, check) and granularity (neutral, check) variants, rendered
+// in the sheet's two strip slots per `BilingualSettingsEditModel`.
+//
+// Adaptation (plan Known limitations): the mock's "≈ $0.31" clause is
+// sample data needing a per-model price table that doesn't exist — the
+// new-language sub keeps the behavioral copy only.
+//
+// @coordinates-with: BilingualSetupSheet+EditMode.swift,
+//   BilingualSettingsEditModel.swift, ReaderThemeV2.swift,
+//   `dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual-suite.jsx`
+
+import SwiftUI
+
+/// The edit-frame cost strip. Copy is pinned by tests.
+struct BilingualCostStrip: View {
+
+    let theme: ReaderThemeV2
+    let kind: BilingualSettingsEditModel.StripKind
+    /// The draft language's display name (used by the new-language head).
+    let languageDisplay: String
+
+    /// The strip's headline, per kind (design copy).
+    static func head(
+        for kind: BilingualSettingsEditModel.StripKind, languageDisplay: String
+    ) -> String {
+        switch kind {
+        case .newLanguage:     return "\(languageDisplay) is new for this book"
+        case .cachedLanguage:  return "Cached \u{2014} switches instantly"
+        case .granularityOnly: return "Granularity change re-translates"
+        }
+    }
+
+    /// The strip's sub line, per kind (design copy; the new-language
+    /// cost clause is dropped — see the file header).
+    static func sub(for kind: BilingualSettingsEditModel.StripKind) -> String {
+        switch kind {
+        case .newLanguage:
+            return "Pages re-translate as you read."
+        case .cachedLanguage:
+            return "This language was translated before. Nothing is re-paid."
+        case .granularityOnly:
+            return "Cached rows are per-granularity \u{B7} starts from this page."
+        }
+    }
+
+    private var isAccented: Bool { kind == .newLanguage }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 9) {
+            Group {
+                if isAccented {
+                    Image(systemName: "sparkles")
+                        .foregroundStyle(Color(theme.accentColor))
+                } else {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(Color(theme.subColor))
+                }
+            }
+            .font(.system(size: 12, weight: .semibold))
+            .padding(.top, 1)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(Self.head(for: kind, languageDisplay: languageDisplay))
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(isAccented
+                        ? Color(theme.accentColor) : Color(theme.inkColor))
+                Text(Self.sub(for: kind))
+                    .font(.system(size: 11))
+                    .foregroundStyle(Color(theme.subColor))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(isAccented
+                    ? Color(theme.accentColor).opacity(0.07)
+                    : (theme.isDark
+                        ? Color.white.opacity(0.04)
+                        : Color.black.opacity(0.03)))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .strokeBorder(
+                    isAccented
+                        ? Color(theme.accentColor).opacity(0.27)
+                        : Color(theme.ruleColor),
+                    lineWidth: 0.5)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("bilingualCostStrip")
+    }
+}

--- a/vreader/Views/Reader/Bilingual/BilingualLanguagePickerCell.swift
+++ b/vreader/Views/Reader/Bilingual/BilingualLanguagePickerCell.swift
@@ -33,6 +33,11 @@ struct BilingualLanguagePickerCell: View {
     /// Tap handler — host stores the new selection.
     let onTap: () -> Void
 
+    /// Feature #99 (edit frame): the green "translated before" tick
+    /// badge at the cell's top-right (design `BSLangTile` `cached`).
+    /// Default off — first-enable renders unchanged.
+    var showsCachedBadge: Bool = false
+
     var body: some View {
         Button(action: onTap) {
             HStack(spacing: 8) {
@@ -48,10 +53,33 @@ struct BilingualLanguagePickerCell: View {
             .padding(.vertical, 10)
             .background(cellBackground)
             .contentShape(Rectangle())
+            .overlay(alignment: .topTrailing) {
+                if showsCachedBadge { cachedBadge }
+            }
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier(Self.cellAccessibilityIdentifier(for: language.key))
         .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityValue(showsCachedBadge ? "translated before" : "")
+    }
+
+    /// The 15pt green tick disc with a 2pt surface ring (design
+    /// `BSLangTile` `cached` badge).
+    private var cachedBadge: some View {
+        Circle()
+            .fill(theme.isDark
+                ? Color(red: 0.247, green: 0.416, blue: 0.345)
+                : Color(red: 0.227, green: 0.416, blue: 0.353))
+            .frame(width: 15, height: 15)
+            .overlay(
+                Image(systemName: "checkmark")
+                    .font(.system(size: 7, weight: .heavy))
+                    .foregroundStyle(.white)
+            )
+            .overlay(
+                Circle().strokeBorder(Color(theme.chromeColor), lineWidth: 2)
+            )
+            .offset(x: 4, y: -4)
     }
 
     /// Per-cell glyph chip — accent-filled when selected, dimmed when

--- a/vreader/Views/Reader/Bilingual/BilingualLanguagePickerCell.swift
+++ b/vreader/Views/Reader/Bilingual/BilingualLanguagePickerCell.swift
@@ -77,7 +77,7 @@ struct BilingualLanguagePickerCell: View {
                     .foregroundStyle(.white)
             )
             .overlay(
-                Circle().strokeBorder(Color(theme.chromeColor), lineWidth: 2)
+                Circle().strokeBorder(Color(theme.sheetSurfaceColor), lineWidth: 2)
             )
             .offset(x: 4, y: -4)
     }

--- a/vreader/Views/Reader/Bilingual/BilingualSetupSheet+EditMode.swift
+++ b/vreader/Views/Reader/Bilingual/BilingualSetupSheet+EditMode.swift
@@ -31,9 +31,17 @@ extension BilingualSetupSheet {
     var showsCancelButton: Bool { isEditMode }
 
     /// "Bilingual mode is on · {book title}" — nil in first-enable mode.
+    /// The combined-string testing surface; the view renders the title
+    /// as a separate italic-serif run (design `BSSettingsSheet`).
     var contextStripText: String? {
+        guard let editBookTitle else { return nil }
+        return "Bilingual mode is on \u{B7} \(editBookTitle)"
+    }
+
+    /// The edit frame's book title — nil in first-enable mode.
+    var editBookTitle: String? {
         guard case .edit(let bookTitle) = mode else { return nil }
-        return "Bilingual mode is on \u{B7} \(bookTitle)"
+        return bookTitle
     }
 
     /// The dirty kind for the current draft (edit mode only — `.none`
@@ -109,16 +117,20 @@ extension BilingualSetupSheet {
     }
 
     /// The book-context strip — "Bilingual mode is on · *{title}*".
+    /// Only the TITLE run is italic serif (Gate-4 r1 Medium — the
+    /// design italicises the book title, not the whole line).
     @ViewBuilder
     var editContextStrip: some View {
-        if let text = contextStripText {
+        if let title = editBookTitle {
             HStack(spacing: 8) {
                 Image(systemName: "character.bubble")
                     .font(.system(size: 12))
                     .foregroundStyle(Color(theme.subColor))
-                Text(text)
+                (Text("Bilingual mode is on \u{B7} ")
                     .font(.system(size: 11.5))
-                    .italic()
+                    + Text(title)
+                    .font(Font(ReaderTypography.body(for: .sourceSerif4, size: 11.5)))
+                    .italic())
                     .foregroundStyle(Color(theme.subColor))
                     .lineLimit(1)
                     .truncationMode(.tail)

--- a/vreader/Views/Reader/Bilingual/BilingualSetupSheet+EditMode.swift
+++ b/vreader/Views/Reader/Bilingual/BilingualSetupSheet+EditMode.swift
@@ -1,0 +1,149 @@
+// Purpose: Feature #99 WI-2 — the setup sheet's EDIT-frame surfaces
+// (design §#1640 `BSSettingsSheet`): the mode-derived title / CTA /
+// dirty computations (exposed as testable computed properties), the
+// leading Cancel button, the book-context strip, and the cached-
+// languages caption. Split from BilingualSetupSheet.swift for the
+// ~300-line file budget (rule 50 §9).
+//
+// @coordinates-with: BilingualSetupSheet.swift,
+//   BilingualSettingsEditModel.swift, BilingualCostStrip.swift,
+//   dev-docs/plans/20260611-feature-99-translation-settings-reentry.md
+
+import SwiftUI
+
+extension BilingualSetupSheet {
+
+    // MARK: - Mode-derived surfaces (testing seam)
+
+    /// Whether the edit frame is active.
+    var isEditMode: Bool {
+        if case .edit = mode { return true }
+        return false
+    }
+
+    /// "Bilingual mode" (first enable) / "Translation settings" (edit).
+    var displayTitle: String {
+        isEditMode ? "Translation settings" : "Bilingual mode"
+    }
+
+    /// The edit frame shows a leading Cancel text button; first-enable
+    /// keeps only the default circular close.
+    var showsCancelButton: Bool { isEditMode }
+
+    /// "Bilingual mode is on · {book title}" — nil in first-enable mode.
+    var contextStripText: String? {
+        guard case .edit(let bookTitle) = mode else { return nil }
+        return "Bilingual mode is on \u{B7} \(bookTitle)"
+    }
+
+    /// The dirty kind for the current draft (edit mode only — `.none`
+    /// in first-enable, whose CTA is constant).
+    var editDirtyKind: BilingualSettingsEditModel.DirtyKind {
+        guard isEditMode,
+              let currentLanguageKey, let currentGranularity else { return .none }
+        return BilingualSettingsEditModel.dirtyKind(
+            currentLanguage: currentLanguageKey,
+            currentGranularity: currentGranularity,
+            draft: state,
+            cachedLanguages: cachedLanguages
+        )
+    }
+
+    /// The footer CTA label for the active frame.
+    var resolvedCTALabel: String {
+        guard isEditMode else { return Self.primaryCTALabel }
+        return BilingualSettingsEditModel.ctaLabel(
+            dirty: editDirtyKind, draftLanguageDisplay: draftLanguageDisplay)
+    }
+
+    /// Accent CTA: always in first-enable; dirty-only in edit.
+    var ctaUsesAccentFill: Bool {
+        guard isEditMode else { return true }
+        return BilingualSettingsEditModel.ctaIsAccent(dirty: editDirtyKind)
+    }
+
+    /// The language-slot cost strip kind (under the grid), edit only.
+    var languageStripKind: BilingualSettingsEditModel.StripKind? {
+        guard isEditMode else { return nil }
+        return BilingualSettingsEditModel.languageStripKind(dirty: editDirtyKind)
+    }
+
+    /// The granularity-slot cost strip kind, edit only.
+    var granularityStripKind: BilingualSettingsEditModel.StripKind? {
+        guard isEditMode else { return nil }
+        return BilingualSettingsEditModel.granularityStripKind(dirty: editDirtyKind)
+    }
+
+    /// Whether a language tile carries the green cached tick (edit only).
+    func showsCachedBadge(forLanguageKey key: String) -> Bool {
+        isEditMode && cachedLanguages.contains(key)
+    }
+
+    /// The "Already translated — switching back is instant" caption —
+    /// shown when at least one tile carries a badge.
+    var showsCachedCaption: Bool {
+        guard isEditMode else { return false }
+        return BilingualSetupSheetState.availableLanguages
+            .contains { cachedLanguages.contains($0.key) }
+    }
+
+    /// The draft language's display name (registry-resolved).
+    var draftLanguageDisplay: String {
+        BilingualLanguage.findOrDefault(key: state.languageKey).key
+    }
+
+    // MARK: - Edit-frame views
+
+    /// Leading Cancel text button (design `BSSettingsSheet` leading slot).
+    @ViewBuilder
+    var cancelButton: some View {
+        if showsCancelButton {
+            Button(action: onCancel) {
+                Text("Cancel")
+                    .font(.system(size: 13.5, weight: .medium))
+                    .foregroundStyle(Color(theme.accentColor))
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("bilingualSettingsCancel")
+        }
+    }
+
+    /// The book-context strip — "Bilingual mode is on · *{title}*".
+    @ViewBuilder
+    var editContextStrip: some View {
+        if let text = contextStripText {
+            HStack(spacing: 8) {
+                Image(systemName: "character.bubble")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color(theme.subColor))
+                Text(text)
+                    .font(.system(size: 11.5))
+                    .italic()
+                    .foregroundStyle(Color(theme.subColor))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            .accessibilityIdentifier("bilingualSettingsContextStrip")
+        }
+    }
+
+    /// The cached-languages caption under the grid (green dot + sub).
+    var editCachedCaption: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(theme.isDark
+                    ? Color(red: 0.247, green: 0.416, blue: 0.345)
+                    : Color(red: 0.227, green: 0.416, blue: 0.353))
+                .frame(width: 11, height: 11)
+                .overlay(
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 6, weight: .heavy))
+                        .foregroundStyle(.white)
+                )
+            Text("Already translated \u{2014} switching back is instant")
+                .font(.system(size: 10.5))
+                .foregroundStyle(Color(theme.subColor))
+        }
+        .accessibilityIdentifier("bilingualSettingsCachedCaption")
+    }
+}

--- a/vreader/Views/Reader/Bilingual/BilingualSetupSheet.swift
+++ b/vreader/Views/Reader/Bilingual/BilingualSetupSheet.swift
@@ -26,89 +26,21 @@
 
 import SwiftUI
 
-/// Shared state for the bilingual setup sheet — held by the host
-/// (the per-format reader container, WI-10..13) and bound to the
-/// view model on confirm. A pure value type so the sheet can stay
-/// stateless and testable.
-struct BilingualSetupSheetState: Equatable, Sendable {
-
-    /// One of `BilingualLanguage.all`'s `key` values.
-    var languageKey: String
-
-    /// Segmentation granularity — paragraph (default) or sentence.
-    var granularity: TranslationGranularity
-
-    /// Default state per design §2.2 — Chinese + paragraph.
-    static let defaultValue = BilingualSetupSheetState(
-        languageKey: "Chinese",
-        granularity: .paragraph
-    )
-
-    /// Languages the picker offers. Pinned to `BilingualLanguage.all`
-    /// so any registry edit flows through to the sheet automatically.
-    static var availableLanguages: [BilingualLanguage] { BilingualLanguage.all }
-
-    /// Granularity options in design order (paragraph then sentence).
-    static let availableGranularities: [TranslationGranularity] = [.paragraph, .sentence]
-
-    /// Returns a copy with the language key canonicalised through the
-    /// registry (`BilingualLanguage.findOrDefault`). A persisted key
-    /// that's no longer in `BilingualLanguage.all` is rewritten to
-    /// the registry's first entry — same fallback the pill uses, so
-    /// the picker always paints a selection.
-    func normalised() -> BilingualSetupSheetState {
-        let resolvedKey = BilingualLanguage.findOrDefault(key: languageKey).key
-        return BilingualSetupSheetState(
-            languageKey: resolvedKey,
-            granularity: granularity
-        )
-    }
-}
-
-/// AI provider descriptor the host passes into the setup sheet. The
-/// sheet renders the descriptor's display surface verbatim; the host
-/// resolves the provider name + subtitle from `ProviderProfileStore`.
-struct BilingualEngineDescriptor: Equatable, Sendable {
-
-    /// Whether an AI provider profile is configured. Drives the
-    /// engine strip's visual + the engine button label.
-    let configured: Bool
-
-    /// Provider display name (e.g. `"Claude"`). Optional — `nil`
-    /// degrades to a generic "AI provider configured" title.
-    let providerName: String?
-
-    /// Subtitle shown under the title. Optional — `nil` degrades to
-    /// the design's generic copy.
-    let subtitle: String?
-
-    /// Display title — provider name when configured + supplied,
-    /// otherwise a generic title.
-    var displayTitle: String {
-        if configured {
-            if let name = providerName, !name.isEmpty {
-                return name
-            }
-            return "AI provider configured"
-        }
-        return "No AI provider configured"
-    }
-
-    /// Display subtitle — host-supplied when configured + supplied,
-    /// otherwise the design's generic copy.
-    var displaySubtitle: String {
-        if let subtitle, !subtitle.isEmpty {
-            return subtitle
-        }
-        if configured {
-            return "Translations cached per paragraph, one page ahead."
-        }
-        return "Bilingual mode needs an AI provider to translate."
-    }
+/// Which frame the setup sheet renders (feature #99).
+enum BilingualSetupSheetMode: Equatable, Sendable {
+    /// The original first-enable frame — "Bilingual mode" title,
+    /// preview section, constant CTA. The default; pre-#99 callers
+    /// render byte-identical.
+    case firstEnable
+    /// The edit frame (design §#1640 `BSSettingsSheet`) — "Translation
+    /// settings" title, leading Cancel, book-context strip, cached
+    /// badges, cost strips, dirty-driven CTA.
+    case edit(bookTitle: String)
 }
 
 /// First-enable bilingual setup half-sheet — target language,
-/// granularity, AI provider chip.
+/// granularity, AI provider chip. Feature #99 adds the edit frame
+/// (`BilingualSetupSheetMode.edit`) for post-setup re-entry.
 struct BilingualSetupSheet: View {
 
     /// Visual-identity-v2 theme tokens for the active book.
@@ -144,6 +76,20 @@ struct BilingualSetupSheet: View {
     /// the control dims rather than silently forcing `.paragraph`.
     var sentenceGranularityAvailable: Bool = true
 
+    /// Feature #99: which frame to render. Defaults to the original
+    /// first-enable frame — existing callers are unchanged.
+    var mode: BilingualSetupSheetMode = .firstEnable
+
+    /// Feature #99 (edit frame): languages with ≥1 cached row for this
+    /// book (`ChapterTranslationStore.cachedLanguages`) — drives the
+    /// tick badges, the caption, and the cached-vs-new dirty kind.
+    var cachedLanguages: Set<String> = []
+
+    /// Feature #99 (edit frame): the book's CURRENT persisted language /
+    /// granularity — the dirty baseline. nil in first-enable mode.
+    var currentLanguageKey: String? = nil
+    var currentGranularity: TranslationGranularity? = nil
+
     /// Sheet accessibility identifier for XCUITest + verify-cron.
     static let accessibilityIdentifier = "bilingualSetupSheet"
 
@@ -161,12 +107,19 @@ struct BilingualSetupSheet: View {
     var body: some View {
         ReaderSheetChrome(
             theme: theme,
-            title: "Bilingual mode",
+            title: displayTitle,
             onClose: onCancel,
+            leading: { cancelButton },
             content: {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 22) {
-                        previewSection
+                        // Feature #99: the edit frame swaps the preview
+                        // for the book-context strip (design BSSettingsSheet).
+                        if isEditMode {
+                            editContextStrip
+                        } else {
+                            previewSection
+                        }
                         languageSection
                         granularitySection
                         engineSection
@@ -204,9 +157,20 @@ struct BilingualSetupSheet: View {
                         theme: theme,
                         language: lang,
                         isSelected: lang.key == state.languageKey,
-                        onTap: { state.languageKey = lang.key }
+                        onTap: { state.languageKey = lang.key },
+                        showsCachedBadge: showsCachedBadge(forLanguageKey: lang.key)
                     )
                 }
+            }
+            // Feature #99 (edit frame): the cached caption + the
+            // language-slot cost strip live tight under the grid.
+            if showsCachedCaption {
+                editCachedCaption
+            }
+            if let kind = languageStripKind {
+                BilingualCostStrip(
+                    theme: theme, kind: kind,
+                    languageDisplay: draftLanguageDisplay)
             }
         }
     }
@@ -264,6 +228,12 @@ struct BilingualSetupSheet: View {
                 }
                 .accessibilityIdentifier("bilingualGranularityUnavailableFootnote")
             }
+            // Feature #99 (edit frame): the granularity-slot cost strip.
+            if let kind = granularityStripKind {
+                BilingualCostStrip(
+                    theme: theme, kind: kind,
+                    languageDisplay: draftLanguageDisplay)
+            }
         }
     }
 
@@ -291,17 +261,28 @@ struct BilingualSetupSheet: View {
     // MARK: - CTA
 
     var cta: some View {
+        // Feature #99: the edit frame's CTA is dirty-driven — quiet
+        // "Done" when nothing changed, accent otherwise; first-enable
+        // keeps the constant accent CTA.
         Button(action: onConfirm) {
-            Text(Self.primaryCTALabel)
+            Text(resolvedCTALabel)
                 .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(Color.white)
+                .foregroundStyle(ctaUsesAccentFill ? Color.white : Color(theme.inkColor))
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 14)
                 .background(
-                    RoundedRectangle(cornerRadius: 14).fill(Color(theme.accentColor))
+                    RoundedRectangle(cornerRadius: 14).fill(
+                        ctaUsesAccentFill
+                            ? Color(theme.accentColor)
+                            : (theme.isDark
+                                ? Color.white.opacity(0.08)
+                                : Color.black.opacity(0.06))
+                    )
                 )
                 .shadow(
-                    color: Color(theme.accentColor).opacity(0.33),
+                    color: ctaUsesAccentFill
+                        ? Color(theme.accentColor).opacity(0.33)
+                        : Color.clear,
                     radius: 6, x: 0, y: 4
                 )
         }

--- a/vreader/Views/Reader/Bilingual/BilingualSetupSheet.swift
+++ b/vreader/Views/Reader/Bilingual/BilingualSetupSheet.swift
@@ -291,24 +291,3 @@ struct BilingualSetupSheet: View {
         .accessibilityIdentifier("bilingualSetupConfirm")
     }
 }
-
-// MARK: - Granularity labels
-
-extension TranslationGranularity {
-
-    /// Display label for the segmented control — design pins these.
-    var label: String {
-        switch self {
-        case .paragraph: return "Paragraph"
-        case .sentence:  return "Sentence"
-        }
-    }
-
-    /// Smaller-text descriptor under the label.
-    var detail: String {
-        switch self {
-        case .paragraph: return "Translate after each ¶"
-        case .sentence:  return "Translate after each sentence"
-        }
-    }
-}

--- a/vreader/Views/Reader/Bilingual/BilingualSetupSheetContainer.swift
+++ b/vreader/Views/Reader/Bilingual/BilingualSetupSheetContainer.swift
@@ -36,6 +36,12 @@ struct BilingualSetupSheetContainer: View {
     /// Bug #344 (design #1646): threads the per-format sentence-granularity
     /// capability into the sheet's dim-or-selectable control state.
     let sentenceGranularityAvailable: Bool
+    /// Feature #99: the sheet frame + edit-frame inputs (pass-through —
+    /// the `.firstEnable` defaults keep pre-#99 hosts unchanged).
+    let mode: BilingualSetupSheetMode
+    let cachedLanguages: Set<String>
+    let currentLanguageKey: String?
+    let currentGranularity: TranslationGranularity?
 
     /// Owns the AI-providers VM + the push/activation transitions. Built once
     /// from the `onConfigured` init param (which fires when a provider becomes
@@ -51,7 +57,11 @@ struct BilingualSetupSheetContainer: View {
         onConfirm: @escaping () -> Void,
         onCancel: @escaping () -> Void,
         onConfigured: @escaping () async -> Void,
-        sentenceGranularityAvailable: Bool = true
+        sentenceGranularityAvailable: Bool = true,
+        mode: BilingualSetupSheetMode = .firstEnable,
+        cachedLanguages: Set<String> = [],
+        currentLanguageKey: String? = nil,
+        currentGranularity: TranslationGranularity? = nil
     ) {
         self.theme = theme
         self._state = state
@@ -59,6 +69,10 @@ struct BilingualSetupSheetContainer: View {
         self.onConfirm = onConfirm
         self.onCancel = onCancel
         self.sentenceGranularityAvailable = sentenceGranularityAvailable
+        self.mode = mode
+        self.cachedLanguages = cachedLanguages
+        self.currentLanguageKey = currentLanguageKey
+        self.currentGranularity = currentGranularity
         _flow = State(initialValue: ReaderAIProvidersFlow(onConfigured: onConfigured))
     }
 
@@ -72,7 +86,11 @@ struct BilingualSetupSheetContainer: View {
                 onConfirm: onConfirm,
                 onCancel: onCancel,
                 onOpenSettings: { flow.openProviders() },
-                sentenceGranularityAvailable: sentenceGranularityAvailable
+                sentenceGranularityAvailable: sentenceGranularityAvailable,
+                mode: mode,
+                cachedLanguages: cachedLanguages,
+                currentLanguageKey: currentLanguageKey,
+                currentGranularity: currentGranularity
             )
             .toolbar(.hidden, for: .navigationBar)
             .navigationDestination(isPresented: $flow.showingProviders) {

--- a/vreader/Views/Reader/Bilingual/BilingualSetupSheetState.swift
+++ b/vreader/Views/Reader/Bilingual/BilingualSetupSheetState.swift
@@ -90,3 +90,24 @@ struct BilingualEngineDescriptor: Equatable, Sendable {
         return "Bilingual mode needs an AI provider to translate."
     }
 }
+
+// MARK: - Granularity labels
+
+extension TranslationGranularity {
+
+    /// Display label for the segmented control — design pins these.
+    var label: String {
+        switch self {
+        case .paragraph: return "Paragraph"
+        case .sentence:  return "Sentence"
+        }
+    }
+
+    /// Smaller-text descriptor under the label.
+    var detail: String {
+        switch self {
+        case .paragraph: return "Translate after each ¶"
+        case .sentence:  return "Translate after each sentence"
+        }
+    }
+}

--- a/vreader/Views/Reader/Bilingual/BilingualSetupSheetState.swift
+++ b/vreader/Views/Reader/Bilingual/BilingualSetupSheetState.swift
@@ -1,0 +1,92 @@
+// Purpose: Feature #56 WI-9 — the setup sheet's value types:
+// `BilingualSetupSheetState` (the host-held draft the sheet binds to)
+// and `BilingualEngineDescriptor` (the AI-provider display descriptor).
+// Split from BilingualSetupSheet.swift for the ~300-line file budget
+// (feature #99 WI-2 pushed the sheet over).
+//
+// @coordinates-with: BilingualSetupSheet.swift, BilingualLanguage.swift,
+//   ChapterTranslationService.swift (`TranslationGranularity`)
+
+import Foundation
+import SwiftUI
+
+/// Shared state for the bilingual setup sheet — held by the host
+/// (the per-format reader container, WI-10..13) and bound to the
+/// view model on confirm. A pure value type so the sheet can stay
+/// stateless and testable.
+struct BilingualSetupSheetState: Equatable, Sendable {
+
+    /// One of `BilingualLanguage.all`'s `key` values.
+    var languageKey: String
+
+    /// Segmentation granularity — paragraph (default) or sentence.
+    var granularity: TranslationGranularity
+
+    /// Default state per design §2.2 — Chinese + paragraph.
+    static let defaultValue = BilingualSetupSheetState(
+        languageKey: "Chinese",
+        granularity: .paragraph
+    )
+
+    /// Languages the picker offers. Pinned to `BilingualLanguage.all`
+    /// so any registry edit flows through to the sheet automatically.
+    static var availableLanguages: [BilingualLanguage] { BilingualLanguage.all }
+
+    /// Granularity options in design order (paragraph then sentence).
+    static let availableGranularities: [TranslationGranularity] = [.paragraph, .sentence]
+
+    /// Returns a copy with the language key canonicalised through the
+    /// registry (`BilingualLanguage.findOrDefault`). A persisted key
+    /// that's no longer in `BilingualLanguage.all` is rewritten to
+    /// the registry's first entry — same fallback the pill uses, so
+    /// the picker always paints a selection.
+    func normalised() -> BilingualSetupSheetState {
+        let resolvedKey = BilingualLanguage.findOrDefault(key: languageKey).key
+        return BilingualSetupSheetState(
+            languageKey: resolvedKey,
+            granularity: granularity
+        )
+    }
+}
+
+/// AI provider descriptor the host passes into the setup sheet. The
+/// sheet renders the descriptor's display surface verbatim; the host
+/// resolves the provider name + subtitle from `ProviderProfileStore`.
+struct BilingualEngineDescriptor: Equatable, Sendable {
+
+    /// Whether an AI provider profile is configured. Drives the
+    /// engine strip's visual + the engine button label.
+    let configured: Bool
+
+    /// Provider display name (e.g. `"Claude"`). Optional — `nil`
+    /// degrades to a generic "AI provider configured" title.
+    let providerName: String?
+
+    /// Subtitle shown under the title. Optional — `nil` degrades to
+    /// the design's generic copy.
+    let subtitle: String?
+
+    /// Display title — provider name when configured + supplied,
+    /// otherwise a generic title.
+    var displayTitle: String {
+        if configured {
+            if let name = providerName, !name.isEmpty {
+                return name
+            }
+            return "AI provider configured"
+        }
+        return "No AI provider configured"
+    }
+
+    /// Display subtitle — host-supplied when configured + supplied,
+    /// otherwise the design's generic copy.
+    var displaySubtitle: String {
+        if let subtitle, !subtitle.isEmpty {
+            return subtitle
+        }
+        if configured {
+            return "Translations cached per paragraph, one page ahead."
+        }
+        return "Bilingual mode needs an AI provider to translate."
+    }
+}

--- a/vreaderTests/Views/Reader/Bilingual/BilingualSetupSheetEditModeTests.swift
+++ b/vreaderTests/Views/Reader/Bilingual/BilingualSetupSheetEditModeTests.swift
@@ -1,0 +1,141 @@
+// Purpose: Feature #99 WI-2 — pins the setup sheet's edit framing
+// (design §#1640 `BSSettingsSheet`): title, Cancel leading slot, the
+// book-context strip, cached-language tick badges + caption, the cost
+// strips' render slots, and the CTA label/fill per dirty kind — while
+// first-enable mode stays byte-identical to the pre-#99 sheet.
+
+import Testing
+import SwiftUI
+@testable import vreader
+
+@Suite("BilingualSetupSheet edit mode (feature #99 WI-2)")
+@MainActor
+struct BilingualSetupSheetEditModeTests {
+
+    private func makeSheet(
+        mode: BilingualSetupSheetMode = .firstEnable,
+        state: BilingualSetupSheetState = .defaultValue,
+        cachedLanguages: Set<String> = [],
+        currentLanguageKey: String? = nil,
+        currentGranularity: TranslationGranularity? = nil
+    ) -> BilingualSetupSheet {
+        BilingualSetupSheet(
+            theme: .paper,
+            state: .constant(state),
+            engineDescriptor: BilingualEngineDescriptor(
+                configured: true, providerName: "Claude", subtitle: nil),
+            onConfirm: {}, onCancel: {}, onOpenSettings: {},
+            mode: mode,
+            cachedLanguages: cachedLanguages,
+            currentLanguageKey: currentLanguageKey,
+            currentGranularity: currentGranularity
+        )
+    }
+
+    // MARK: - First-enable unchanged
+
+    @Test func firstEnableKeepsTodaysFrame() {
+        let sheet = makeSheet()
+        #expect(sheet.displayTitle == "Bilingual mode")
+        #expect(sheet.resolvedCTALabel == BilingualSetupSheet.primaryCTALabel)
+        #expect(sheet.ctaUsesAccentFill)
+        #expect(sheet.contextStripText == nil)
+        #expect(!sheet.showsCancelButton)
+        #expect(!sheet.showsCachedBadge(forLanguageKey: "Chinese"))
+        #expect(!sheet.showsCachedCaption)
+        #expect(sheet.languageStripKind == nil)
+        #expect(sheet.granularityStripKind == nil)
+    }
+
+    // MARK: - Edit frame
+
+    @Test func editFrameTitleCancelAndContext() {
+        let sheet = makeSheet(
+            mode: .edit(bookTitle: "Pride and Prejudice"),
+            currentLanguageKey: "Chinese", currentGranularity: .paragraph)
+        #expect(sheet.displayTitle == "Translation settings")
+        #expect(sheet.showsCancelButton)
+        #expect(sheet.contextStripText
+            == "Bilingual mode is on \u{B7} Pride and Prejudice")
+    }
+
+    @Test func cleanEditShowsQuietDone() {
+        let sheet = makeSheet(
+            mode: .edit(bookTitle: "B"),
+            state: BilingualSetupSheetState(languageKey: "Chinese", granularity: .paragraph),
+            currentLanguageKey: "Chinese", currentGranularity: .paragraph)
+        #expect(sheet.resolvedCTALabel == "Done")
+        #expect(!sheet.ctaUsesAccentFill)
+        #expect(sheet.languageStripKind == nil)
+    }
+
+    @Test func newLanguagePickShowsAccentApplyAndLanguageStrip() {
+        let sheet = makeSheet(
+            mode: .edit(bookTitle: "B"),
+            state: BilingualSetupSheetState(languageKey: "Japanese", granularity: .paragraph),
+            cachedLanguages: ["Chinese"],
+            currentLanguageKey: "Chinese", currentGranularity: .paragraph)
+        #expect(sheet.resolvedCTALabel == "Apply \u{B7} re-translate as you read")
+        #expect(sheet.ctaUsesAccentFill)
+        #expect(sheet.languageStripKind == .newLanguage)
+        #expect(sheet.granularityStripKind == nil)
+    }
+
+    @Test func cachedLanguagePickShowsSwitchCTA() {
+        let sheet = makeSheet(
+            mode: .edit(bookTitle: "B"),
+            state: BilingualSetupSheetState(languageKey: "French", granularity: .paragraph),
+            cachedLanguages: ["Chinese", "French"],
+            currentLanguageKey: "Chinese", currentGranularity: .paragraph)
+        #expect(sheet.resolvedCTALabel == "Switch to French")
+        #expect(sheet.languageStripKind == .cachedLanguage)
+    }
+
+    @Test func granularityChangeShowsGranularityStrip() {
+        let sheet = makeSheet(
+            mode: .edit(bookTitle: "B"),
+            state: BilingualSetupSheetState(languageKey: "Chinese", granularity: .sentence),
+            cachedLanguages: ["Chinese"],
+            currentLanguageKey: "Chinese", currentGranularity: .paragraph)
+        #expect(sheet.resolvedCTALabel == "Apply \u{B7} re-translate as you read")
+        #expect(sheet.languageStripKind == nil)
+        #expect(sheet.granularityStripKind == .granularityOnly)
+    }
+
+    // MARK: - Badges + caption
+
+    @Test func badgesRenderForCachedLanguagesInEditOnly() {
+        let sheet = makeSheet(
+            mode: .edit(bookTitle: "B"),
+            cachedLanguages: ["Chinese", "French"],
+            currentLanguageKey: "Chinese", currentGranularity: .paragraph)
+        #expect(sheet.showsCachedBadge(forLanguageKey: "Chinese"))
+        #expect(sheet.showsCachedBadge(forLanguageKey: "French"))
+        #expect(!sheet.showsCachedBadge(forLanguageKey: "Japanese"))
+        #expect(sheet.showsCachedCaption)
+    }
+
+    @Test func captionHiddenWithNoCachedLanguages() {
+        let sheet = makeSheet(
+            mode: .edit(bookTitle: "B"),
+            currentLanguageKey: "Chinese", currentGranularity: .paragraph)
+        #expect(!sheet.showsCachedCaption)
+    }
+
+    // MARK: - Cost strip copy pins
+
+    @Test func costStripCopy() {
+        #expect(BilingualCostStrip.head(for: .newLanguage, languageDisplay: "Japanese")
+            == "Japanese is new for this book")
+        #expect(BilingualCostStrip.sub(for: .newLanguage)
+            == "Pages re-translate as you read.")
+        #expect(BilingualCostStrip.head(for: .cachedLanguage, languageDisplay: "French")
+            == "Cached \u{2014} switches instantly")
+        #expect(BilingualCostStrip.sub(for: .cachedLanguage)
+            == "This language was translated before. Nothing is re-paid.")
+        #expect(BilingualCostStrip.head(for: .granularityOnly, languageDisplay: "x")
+            == "Granularity change re-translates")
+        #expect(BilingualCostStrip.sub(for: .granularityOnly)
+            == "Cached rows are per-granularity \u{B7} starts from this page.")
+    }
+}


### PR DESCRIPTION
## Summary

- `BilingualSetupSheetMode` (`.firstEnable` default / `.edit(bookTitle:)`): the edit frame renders the design's `BSSettingsSheet` — "Translation settings" title, leading Cancel, the book-context strip (plain prefix + italic-serif title run), cached-language tick badges + "switching back is instant" caption, the two `BilingualCostStrip` slots, and the dirty-driven CTA (quiet "Done" / "Switch to {lang}" / accent "Apply · re-translate as you read"). First-enable renders byte-identical to pre-#99 (pinned).
- New `BilingualCostStrip` (3 designed variants; the mock's "$0.31" clause dropped per the plan's known limitation) + the picker-cell cached badge (sheet-surface ring).
- Container pass-through props with `.firstEnable` defaults — the six hosts stay unchanged until WI-4 wires presentation.

Part of feature #99 (GH #1671) — WI-2 of 4.

## Codex Audit

2 rounds via `scripts/run-codex.sh`. R1: 1 Medium (whole-line italic vs the design's title-only italic-serif run), 2 Low (badge ring color token; file budget) — all fixed. R2: clean, ship-as-is.

Audit log: `.claude/codex-audits/feat-feature-99-wi-2-edit-sheet-audit.md`

## Validation

- [x] 31 tests green (12 edit-mode composition pins incl. first-enable-unchanged, CTA/strip/badge/caption rules, cost-strip copy; existing sheet + language suites)
- [x] Codex audit loop completed (2 rounds, ship-as-is)
- [x] Docs sync — n/a (no new layer/notification this WI)
- [x] Version bumped: 3.65.3 → 3.65.4 (build 982)

## Gate 5 tier

Behavioral but UNREACHABLE in the running app until WI-4 wires the presentation (no host passes `.edit` yet) — slice verification is the composition-pin suite; the device pass lands with WI-4's full acceptance.

## Type of Change

- [x] New feature work item (intermediate WI)