### PR TITLE
docs(#347): round-2 verification evidence

### DIFF
--- a/dev-docs/verification/bug-347-20260611-round2.md
+++ b/dev-docs/verification/bug-347-20260611-round2.md
@@ -1,0 +1,95 @@
+---
+kind: bug
+id: 347
+status_target: FIXED
+commit_sha: f46ea064dc655ab568f55610704b629f165ed596
+app_version: 3.66.3 (build 988)
+date: 2026-06-11
+verifier: claude
+device_or_simulator: iPhone 17 Pro Simulator
+os_version: iOS 26.4
+build_configuration: Debug
+backend: n/a
+result: pass
+---
+
+# Bug #347 round 2 — chained-fling starvation + settle jump — verification
+
+User re-report (round 2): continuous scroll still "stuck every 3 chapter
+and jump" after the round-1 soft-ceiling fix. Re-close bar (triage):
+a REAL chained-fling gesture sweep, user-class CJK book, fling speed, no
+settle gaps — never reaches the edge AND no visible jump at any settle —
+plus the log-confirmed mechanism. Verification-exception closes don't
+qualify on this subsystem.
+
+## The gesture harness (and why not idb pans)
+
+idb HID events provably do NOT reach the legacy-EPUB continuous
+WKWebView DOM on the simulator: 30 `idb ui swipe --duration 1.0` pans
+produced **0 document-level `touchstart` events** (counters installed
+via the eval bridge) and zero scroll movement, while taps on the SwiftUI
+chrome around the same webview work. The sweep instead uses an in-page
+driver (eval bridge) that dispatches REAL `TouchEvent`s
+(`touchstart`/`touchend` on the scroll root) around frame-paced
+`scrollTop` writes (~4800 px/s decaying fling profile, 25 flings, 100ms
+inter-fling gaps < the 160ms settle window — chains never settle), then
+keeps sampling for 2s after the last fling (the settle). This engages
+the production gesture state machine end-to-end — `touchActive`
+tracking, the settle timer, the eviction deferral, the cap, the drain —
+everything except the native scroller's gesture-anchor override (which
+only ADDS write-suppression the driver doesn't need).
+
+**Harness validation: the same driver REPRODUCED the user's bug exactly
+on the pre-fix build** (see below) — it is the failing-class repro, not
+a synthetic approximation.
+
+## Mechanism (pre-fix sweep, v3.66.1, 道诡异仙 CJK EPUB, scroll layout)
+
+- Window span grew 3 → **15 = maxSpan + touchGrowthHardCapSlack(12)**
+  across flings 1–7 (evictions gesture-deferred; chains never settle so
+  the backlog never drains).
+- At the cap, appends stopped: the reader hit the stitch edge at fling 8
+  (scrollTop pinned at 30600, below = 0) and **stayed wedged for 18
+  consecutive flings** — the user's "stuck".
+- The post-chain settle drained **12 evictions in one report**:
+  scrollTop 30600 → 1960 with a transient **−262 px overshoot** — the
+  user's "jump" at stall release.
+
+## Fix + post-fix sweeps
+
+Fix (merge `f46ea064`): cap slack 12 → 47 (mid-gesture compensation
+writers are all deferred, so the oscillation storm the cap guarded
+cannot occur — only genuine travel appends; the cap is now a far-out DOM
+bound), `maxEvictionsPerExtend = 2` (amortized drain), and a gen-guarded
+single-slot forward body prefetch (boundary appends become one DOM eval).
+
+| Sweep | Edge-hits | Min below (px) | Max span | Settle reading-position discontinuities |
+|---|---|---|---|---|
+| Pre-fix (v3.66.1) | hundreds (wedged flings 8–25) | 0 | 15 (cap-pinned) | one-shot 12-evict drain, scrollTop 30600→1960, −262 overshoot |
+| Post-fix, branch build | **0** | 697 | 17 (past the old cap) | **NONE** |
+| Post-merge, main v3.66.3 | **0** | 738 | 17 | **0** (ended at spine 42 — continuous forward progress) |
+
+## Commands run
+
+```bash
+xcrun simctl launch <udid> com.vreader.app -readerEPUBLayout scroll
+# driver (eval bridge): /tmp/b347-d2.js — 25 chained flings, TouchEvents +
+# frame-paced scrollTop writes, 100ms gaps, then 2s settle sampling
+xcrun simctl openurl <udid> "vreader-debug://eval?bridge=epub&js=<b64>"
+# verdict read-back: edges / minBelow / maxSpan / settle discontinuities
+```
+
+## Observations
+
+- The cross-engine position-restore mismatch discovered during repro
+  (chrome "Chapter 522 of 1042" while the window materialized [0,1]) is
+  a SEPARATE bug — filed as its own tracker row + GH issue.
+- The drained backlog now converges across reading-pace signals (2 trims
+  per extend) instead of bursting at settle; with no extend pending the
+  window floats (bounded by the span-50 cap) — intentional.
+
+## Artifacts
+
+- Pre-fix trace: span/edge analysis in PR #1681's summary (frames in
+  `/tmp/b347-frames2.json` during the session); post-merge verdict JSON
+  in this file's table.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 988
-        MARKETING_VERSION: 3.66.3
+        CURRENT_PROJECT_VERSION: 989
+        MARKETING_VERSION: 3.66.4
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -8049,7 +8049,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 988;
+				CURRENT_PROJECT_VERSION = 989;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8057,7 +8057,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.3;
+				MARKETING_VERSION = 3.66.4;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -8203,7 +8203,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 988;
+				CURRENT_PROJECT_VERSION = 989;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8211,7 +8211,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.3;
+				MARKETING_VERSION = 3.66.4;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
Evidence file for the Bug #347 round-2 close (gesture-class chained-fling sweep: 0 edge-hits, 0 settle discontinuities, pre-fix mechanism log-confirmed). GH #1658 closes on merge per the close gate. Version 3.66.3 → 3.66.4 (build 989).