### PR TITLE
chore: sweep-ghosts.sh — detect/reap stale background ghosts

### DIFF
--- a/.claude/rules/49-background-shells.md
+++ b/.claude/rules/49-background-shells.md
@@ -116,3 +116,21 @@ vreader's cron prompts (`.claude/cron-prompts/{verify,bugfix,watchdog}.md`) fire
 ## Quick check before ending an iteration
 
 Run mentally: "Did I launch any `run_in_background` shells in this iteration that aren't either (a) finished with a `<task-notification>` already received, or (b) explicitly intended to outlive the iteration?" If neither, the iteration's clean. If it's (b), document why in the cron log line so future operators don't assume it's a leak.
+
+## Sweeping pre-existing ghosts (`scripts/sweep-ghosts.sh`)
+
+The rules above prevent NEW ghosts but don't reap old ones — a `tail -f`
+from a mid-May session survived 31 days unnoticed (found 2026-06-13)
+because nothing periodically sweeps. For that:
+
+```bash
+scripts/sweep-ghosts.sh           # report ghosts: stale tail -f / log stream /
+                                  # codex / xcodebuild at ~0% CPU past 2h
+scripts/sweep-ghosts.sh --kill    # reap them
+THRESHOLD_MIN=30 scripts/sweep-ghosts.sh   # tighter age threshold
+```
+
+It never flags `SWBBuildService` (Xcode's resident build daemon — alive
+and idle between builds by design) or `idb_companion` (persistent sim
+bridge). Run it whenever "is the shell hung?" comes up, and at the start
+of cron sweep iterations.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 994
-        MARKETING_VERSION: 3.66.9
+        CURRENT_PROJECT_VERSION: 995
+        MARKETING_VERSION: 3.66.10
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/scripts/sweep-ghosts.sh
+++ b/scripts/sweep-ghosts.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Purpose: detect — and with --kill, reap — "ghost" background processes
+# left behind by agent sessions. A ghost is a process from a known leak
+# class sitting at ~0% CPU past an age threshold: it produces nothing,
+# never exits, and survives the session that spawned it.
+#
+# Known ghost classes (each has a rule + origin incident):
+#   - `tail -f <file>`            rule 49/52 — detached output-file waiters
+#                                  (origin: a 31-day tail found 2026-06-13)
+#   - `log stream`                rule 49 — detached side-channel captures
+#                                  (origin: ~3h simctl log stream, 2026-06-11)
+#   - `codex` / `codex exec`      rule 53 — stdin-wedge (origin: 4h20m ghost,
+#                                  2026-06-01)
+#   - `xcodebuild test|build`     rule 52 — sim contention / wedged daemon
+#                                  (recurring; watchdogged by run-tests.sh)
+#
+# NOT flagged: SWBBuildService (Xcode's resident build daemon — alive and
+# idle between builds by design), idb_companion (persistent sim bridge),
+# and anything younger than the threshold or actually using CPU.
+#
+# Usage:
+#   scripts/sweep-ghosts.sh           # report only
+#   scripts/sweep-ghosts.sh --kill    # report + TERM the ghosts
+#   THRESHOLD_MIN=30 scripts/sweep-ghosts.sh
+#
+# Exit codes: 0 = clean (or killed), 1 = ghosts found (report-only mode).
+# Final line is always one of:
+#   SWEEP-GHOSTS RESULT: CLEAN
+#   SWEEP-GHOSTS RESULT: FOUND <n>
+#   SWEEP-GHOSTS RESULT: KILLED <n>
+
+set -euo pipefail
+
+THRESHOLD_MIN="${THRESHOLD_MIN:-120}"
+KILL=0
+[[ "${1:-}" == "--kill" ]] && KILL=1
+
+# pid | etime | %cpu | command  for the ghost classes, older than the
+# threshold and idle (<1% CPU). etime formats: MM:SS, HH:MM:SS, DD-HH:MM:SS.
+ghosts=$(ps -Ao pid=,etime=,pcpu=,command= | awk -v thr="$THRESHOLD_MIN" '
+    {
+        cmd = ""
+        for (i = 4; i <= NF; i++) cmd = cmd (i > 4 ? " " : "") $i
+    }
+    cmd !~ /(awk|grep|sweep-ghosts|idb_companion|SWBBuildService)/ &&
+    (cmd ~ /tail -f/ || cmd ~ /log stream/ ||
+     cmd ~ /(^|\/)codex( |$)/ || cmd ~ /xcodebuild (test|build)/) {
+        days = 0; hms = $2
+        if (split($2, d, "-") == 2) { days = d[1]; hms = d[2] }
+        n = split(hms, t, ":")
+        mins = days * 1440
+        if (n == 3)      mins += t[1] * 60 + t[2]
+        else if (n == 2) mins += t[1]
+        if (mins >= thr && $3 + 0 < 1.0)
+            printf "%s\t%s\t%s%%\t%s\n", $1, $2, $3, cmd
+    }')
+
+if [[ -z "$ghosts" ]]; then
+    echo "SWEEP-GHOSTS RESULT: CLEAN"
+    exit 0
+fi
+
+echo "PID	ELAPSED	CPU	COMMAND"
+echo "$ghosts"
+count=$(printf '%s\n' "$ghosts" | wc -l | tr -d ' ')
+
+if [[ "$KILL" -eq 1 ]]; then
+    printf '%s\n' "$ghosts" | cut -f1 | xargs kill 2>/dev/null || true
+    echo "SWEEP-GHOSTS RESULT: KILLED $count"
+    exit 0
+fi
+
+echo "SWEEP-GHOSTS RESULT: FOUND $count (re-run with --kill to reap)"
+exit 1

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -8069,7 +8069,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 994;
+				CURRENT_PROJECT_VERSION = 995;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8077,7 +8077,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.9;
+				MARKETING_VERSION = 3.66.10;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -8223,7 +8223,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 994;
+				CURRENT_PROJECT_VERSION = 995;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8231,7 +8231,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.9;
+				MARKETING_VERSION = 3.66.10;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
## Summary

- New `scripts/sweep-ghosts.sh`: detects (and with `--kill`, reaps) ghost background processes from the known leak classes — stale `tail -f`, detached `log stream`, wedged `codex` / `xcodebuild` at ~0% CPU past a threshold (default 2h, `THRESHOLD_MIN` to override). Excludes the legitimately-resident `SWBBuildService` and `idb_companion`. One unambiguous `SWEEP-GHOSTS RESULT:` final line (CLEAN / FOUND n / KILLED n).
- Rule 49 gains a "Sweeping pre-existing ghosts" section pointing at it.

## Why

Rules 49/52/53 prevent NEW ghosts but nothing reaps pre-existing leaks from older sessions: a `tail -f` from a mid-May session survived **31 days** unnoticed until a manual `ps` sweep on 2026-06-13. Recurring operator question ("is the shell hung?") now has a one-command answer.

## Validation

- [x] Report path: planted `tail -f` flagged at `THRESHOLD_MIN=0` (FOUND 1, exit 1)
- [x] Kill path: `--kill` reaped the plant (KILLED 1, process confirmed gone)
- [x] Clean path: real-world run reports CLEAN, exit 0; resident `SWBBuildService` correctly not flagged
- [x] Smoke build green after bump
- [x] Version bumped: 3.66.9 → 3.66.10 (build 995)
- [x] Docs sync — rule 49 updated in-PR; tests n/a (tooling script, exempt per rule 10 config/tooling exception)

Meta-process tooling change — no bug/feature row referenced (exempt from the fix-or-implement merge gate per AGENTS.md).

## Type of Change

- [x] Chore / developer tooling