### PR TITLE
chore: sweep-ghosts.sh detects orphaned waiter loops

### DIFF
--- a/.claude/rules/49-background-shells.md
+++ b/.claude/rules/49-background-shells.md
@@ -125,7 +125,7 @@ because nothing periodically sweeps. For that:
 
 ```bash
 scripts/sweep-ghosts.sh           # report ghosts: stale tail -f / log stream /
-                                  # codex / xcodebuild at ~0% CPU past 2h
+                                  # codex / xcodebuild / waiter-loops at ~0% CPU past 2h
 scripts/sweep-ghosts.sh --kill    # reap them
 THRESHOLD_MIN=30 scripts/sweep-ghosts.sh   # tighter age threshold
 ```
@@ -134,3 +134,34 @@ It never flags `SWBBuildService` (Xcode's resident build daemon — alive
 and idle between builds by design) or `idb_companion` (persistent sim
 bridge). Run it whenever "is the shell hung?" comes up, and at the start
 of cron sweep iterations.
+
+### Waiter-loop class (the recurring "hung shell" — 2026-06-15)
+
+The most common ghost in practice is NOT a wedged tool — it's a
+`run_in_background` **waiter loop** polling a task-output file:
+
+```bash
+# ANTI-PATTERN — do NOT do this:
+until grep -qE "BUILD SUCCEEDED|error:" .../tasks/<id>.output; do sleep 5; done
+```
+
+These come from launching a build/test with `run_in_background: true` and
+THEN launching a SECOND background shell to poll its output. They are the
+exact anti-pattern this whole rule bans (one async job = one owner = one
+completion channel), and they're insidious because:
+
+- They survive long past the task they watch (a `do sleep 25` waiter was
+  found looping **3d18h** on 2026-06-15, from a session 3 days earlier
+  whose `RUN-TESTS RESULT` count-≥3 condition never fired).
+- They're invisible to `pgrep -x xcodebuild`/`-x codex` (they're `zsh`/
+  `sleep`), to the harness task list (they detach), AND they slipped past
+  the FIRST version of `sweep-ghosts.sh` (which only watched tool names).
+- Multiple of them are what makes the operator's UI show a persistent
+  "running" indicator and ask "is the shell hung again?".
+
+**The fix is behavioral, not tooling: never launch a waiter loop.** When a
+`run_in_background` task finishes it emits a `<task-notification>`; act on
+that in the next turn. Do not add an `until grep…; do sleep` shell on top.
+`sweep-ghosts.sh` now ALSO detects + reaps the waiter-loop class
+(`(until|while) … do sleep N`) as a backstop, but the loop should never be
+created in the first place.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 998
-        MARKETING_VERSION: 3.66.13
+        CURRENT_PROJECT_VERSION: 999
+        MARKETING_VERSION: 3.66.14
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/scripts/sweep-ghosts.sh
+++ b/scripts/sweep-ghosts.sh
@@ -37,14 +37,28 @@ KILL=0
 
 # pid | etime | %cpu | command  for the ghost classes, older than the
 # threshold and idle (<1% CPU). etime formats: MM:SS, HH:MM:SS, DD-HH:MM:SS.
+#
+# Classes flagged (all excluding the sweeper's own ps/ugrep pipeline and the
+# resident SWBBuildService/idb_companion daemons):
+#   - tail -f / log stream / codex / xcodebuild (test|build) — excludes bare
+#     grep/awk so the sweeper's diagnostic greps don't self-match.
+#   - waiter loop `until/while … do sleep N; done` — the rule-49 anti-pattern
+#     (a run_in_background shell polling a task-output file). These DO contain
+#     grep -q/-c markers, so the grep exclusion must not apply to them.
+#     Origin: a `do sleep 25` waiter looped 3d18h before the 2026-06-15 sweep.
 ghosts=$(ps -Ao pid=,etime=,pcpu=,command= | awk -v thr="$THRESHOLD_MIN" '
     {
         cmd = ""
         for (i = 4; i <= NF; i++) cmd = cmd (i > 4 ? " " : "") $i
     }
-    cmd !~ /(awk|grep|sweep-ghosts|idb_companion|SWBBuildService)/ &&
-    (cmd ~ /tail -f/ || cmd ~ /log stream/ ||
-     cmd ~ /(^|\/)codex( |$)/ || cmd ~ /xcodebuild (test|build)/) {
+    cmd ~ /(ps -Ao|ugrep|sweep-ghosts|idb_companion|SWBBuildService)/ { next }
+    {
+        otherClass = (cmd !~ /( grep | awk )/) && \
+            (cmd ~ /tail -f/ || cmd ~ /log stream/ || \
+             cmd ~ /(^|\/)codex( |$)/ || cmd ~ /xcodebuild (test|build)/)
+        waiterClass = (cmd ~ /(until|while) .*do sleep [0-9]/)
+    }
+    otherClass || waiterClass {
         days = 0; hms = $2
         if (split($2, d, "-") == 2) { days = d[1]; hms = d[2] }
         n = split(hms, t, ":")

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -8077,7 +8077,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 998;
+				CURRENT_PROJECT_VERSION = 999;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8085,7 +8085,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.13;
+				MARKETING_VERSION = 3.66.14;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -8231,7 +8231,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 998;
+				CURRENT_PROJECT_VERSION = 999;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8239,7 +8239,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.13;
+				MARKETING_VERSION = 3.66.14;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
## Summary

The recurring "is the shell hung?" was traced to orphaned `run_in_background` **waiter loops** — `until grep -q <marker>; do sleep N; done` shells polling a task-output file (the rule-49 anti-pattern). One had been looping `sleep 25` for **3 days 18 hours** from a session 3 days earlier whose `RUN-TESTS RESULT` count-≥3 condition never fired. They're invisible to `pgrep -x xcodebuild`/`-x codex`, to the harness task list, and slipped past the first `sweep-ghosts.sh` (which only matched tool names).

- `sweep-ghosts.sh` now flags + reaps the waiter-loop class (`(until|while) … do sleep N`). The grep exclusion no longer applies to that class (waiters legitimately contain `grep -q`/`-c` markers), and the sweeper's own `ps`/`grep` pipeline is excluded so a normal run stays `CLEAN`.
- Rule 49 documents the waiter-loop class as the common "hung shell" and restates the behavioral fix: never launch a waiter loop — act on the native `<task-notification>` instead.

## Validation

- [x] Plants a `until grep…; do sleep 5` waiter → sweeper detects it (`THRESHOLD_MIN=0`) and `--kill` reaps it
- [x] Normal run reports `CLEAN` (no self-match on the sweeper's own pipeline; `SWBBuildService`/`idb_companion` not flagged)
- [x] The four real orphans found this session (incl. the 3d18h one) were killed
- [x] Version bumped: 3.66.13 → 3.66.14 (build 999)

Meta-process tooling change — no bug/feature row referenced.

## Type of Change

- [x] Chore / developer tooling