### PR TITLE
feat(#105 WI-2): instrumented CJK scroll/memory/stability benchmark (Readium-Kotlin 3.3.0)

### DIFF
--- a/.claude/codex-audits/feat-feature-105-wi2-scroll-bench-audit.md
+++ b/.claude/codex-audits/feat-feature-105-wi2-scroll-bench-audit.md
@@ -1,0 +1,75 @@
+---
+branch: feat/feature-105-wi2-scroll-bench
+threadId: 019ed305-multi
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-06-17
+---
+
+# Codex Gate-4 audit — feature #105 Spike B WI-2 (instrumented CJK scroll benchmark)
+
+Runner: `scripts/run-codex.sh -m gpt-5.4 -e high`. Three rounds (sessions
+`019ed35…` R1, `019ed3…` R2, `019ed3…` R3). The change: an Android
+instrumentation benchmark (throwaway spike under `spikes/android-reader-bench/`)
+that opens the real 1042-chapter 道诡异仙 CJK EPUB via Readium-Kotlin 3.3.0, hosts
+the EPUB navigator in scroll mode in-process (no UI automation — ADR-0001 R2),
+drives a 250-chapter sweep, and records frame-timing + renderer-aware memory +
+renderer-stability metrics. The audit drove the measurement from *plausible* to
+*sound* — each round caught a way the benchmark could PASS while hiding the real
+risk.
+
+## Round 1 — 1 Critical + 2 High + 2 Medium + 1 Low
+
+| Finding | Sev | Resolution |
+|---|---|---|
+| `goForward` never checked + scroll mode unverified → run can PASS even if intra-chapter scroll is a no-op or paginated fallback (the `traversed>=200` jumps satisfy it) | Critical | Verify `navigator.settings.value.scroll` (Readium's authoritative resolved EpubSettings) + assert strictly-increasing whole-publication `currentLocator.totalProgression` + `scrollAdvances>0`. |
+| FrameSampler ran continuously incl. idle settle → jank% diluted by on-budget idle vsync | High | (see R2) initially gated to active scroll windows. |
+| Memory only sampled host PSS — Chromium renders in a separate sandboxed process, so host-only doesn't de-risk renderer eviction (the actual Risk-2 surface) | High | `MemoryProbe` now also `dumpsys meminfo`'s the WebView renderer via UiAutomation; reports host/renderer/total separately. |
+| Memory sampled only every 25 chapters after settle → biased to troughs | Medium | Sample every 10 chapters. |
+| `readerCrashes`/`blankFrames` hardcoded 0 in JSON → false-clean for JSON-only consumers | Medium | Removed from the JSON; crashes come from the wrapper's logcat scan only. |
+| `Publication`/`FragmentScenario` never closed | Low | `try/finally` close both. |
+
+The renderer-aware re-run immediately justified the audit: host-only had reported
+"~190MB, bounded" and hid a ~780MB renderer footprint.
+
+## Round 2 — Critical+Mediums+Low confirmed fixed; 2 new High
+
+| Finding | Sev | Resolution |
+|---|---|---|
+| Active-window frame sampling was still a FIXED `settle(220)` timer → fast scrolls fold in post-animation idle, slow scrolls lose late frames | High | Bound the window by **Readium locator stabilization** (`scrollOnce`: advance, then sample until progression moved AND held steady for 2 reads, cap 1200ms) — the auditor's suggested completion signal. Per-frame motion gating recorded 0 frames (currentLocator updates at completion, not per-frame), confirming stabilization is the right bound. |
+| `contains("sandboxed_process")` summed EVERY Chromium sandbox on the device, not just ours; "sole client" caveat was comment-only | High | `MemoryProbe.snapshotBaseline()` records pre-launch sandboxed PIDs; `sample()` attributes only newly-spawned renderers to our session; test asserts `rendererPssMaxKb>0` (fails rather than reporting host-only). |
+
+R2 confirmed: "The original Critical issue looks genuinely fixed… The Round-1
+mediums and low look resolved."
+
+## Round 3 — both R2 Highs resolved; 1 Medium (fixed)
+
+Verdict: "No Critical or High remains from the two round-2 items." R2 High #1
+(frame window) "genuinely resolved" — the loop can't exit before animation start
+(`stable` only increments after `moved`), and `setActive` resetting `lastNanos`
+correctly excludes the inter-window gap. R2 High #2 (attribution) "improved" but
+left one Medium:
+
+| Finding | Sev | Resolution |
+|---|---|---|
+| A foreign WebView sandbox spawned mid-sweep would still be misattributed into `rendererPssKb`; `processCount` recorded but not enforced | Medium | Applied the auditor's prescribed one-liner: assert `maxProcs<=2` (host + exactly 1 of our renderers) — a contaminated run now FAILS. Verified: all 26 baseline samples have `procs=2`; a smoke confirms the invariant holds. |
+
+This Medium was resolved with the auditor's verbatim suggested fix and is
+mechanically verifiable (compiles + passes + baseline data satisfies it), so
+Gate-4 is satisfied within the 3-round budget without a 4th Codex round.
+
+**Accepted residual** (auditor explicitly: "does not read as a remaining
+High/Medium"): the 1200ms scroll-stabilization cap could truncate a
+pathologically slow scroll. Accepted for a spike — Readium's scroll animation is
+~300-500ms, well under the cap.
+
+## Verdict
+
+ship-as-is. The audit turned a host-only benchmark that hid an ~1.1GB renderer
+footprint into a sound, renderer-aware, motion-bounded measurement. Authoritative
+250-chapter emulator baseline (`baselines/scroll-sweep-250-emulator-20260617.json`):
+28.5k motion-bounded frames at 0.23% jank, p50/p90/p99 16.67ms (60fps); renderer
+RAM ramps to a ~1.1GB high-water by ch~90-130 then EVICTS down to a 580-870MB
+oscillation for the second half (bounded, not monotonic — eviction works), peak
+total ~1.29GB, zero renderer crashes. Viable; the ~1.1GB renderer high-water is a
+low-RAM-device hardening obligation recorded for WI-4's engine decision.

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 1009
-        MARKETING_VERSION: 3.66.24
+        CURRENT_PROJECT_VERSION: 1010
+        MARKETING_VERSION: 3.66.25
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/spikes/android-reader-bench/app/build.gradle.kts
+++ b/spikes/android-reader-bench/app/build.gradle.kts
@@ -4,11 +4,13 @@ plugins {
 }
 android {
     namespace = "vreader.spike"
-    compileSdk = 35
+    // compileSdk 36: Readium 3.3.0's AARs reference API-36 symbols (the toolkit
+    // builds against compileSdk 36). 35 fails to resolve them.
+    compileSdk = 36
     defaultConfig {
         applicationId = "vreader.spike"
-        minSdk = 26
-        targetSdk = 35
+        minSdk = 26          // >= Readium 3.3.0's floor of 23
+        targetSdk = 36
         versionCode = 1
         versionName = "0.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -16,11 +18,42 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        // MANDATORY for Readium 3.3.0 — it enables core library desugaring in its
+        // own convention plugin; a consumer that doesn't will fail at link time.
+        isCoreLibraryDesugaringEnabled = true
     }
-    kotlinOptions { jvmTarget = "17" }
+}
+kotlin {
+    // Kotlin 2.3.20 removed the legacy `kotlinOptions` DSL (hard error) — use
+    // the compilerOptions DSL.
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        // Readium's preferences/navigator API (EpubPreferences, etc.) is gated
+        // behind @ExperimentalReadiumApi; opt in module-wide for the spike.
+        freeCompilerArgs.add("-opt-in=org.readium.r2.shared.ExperimentalReadiumApi")
+    }
 }
 dependencies {
+    val readium = "3.3.0"
+    implementation("org.readium.kotlin-toolkit:readium-shared:$readium")
+    implementation("org.readium.kotlin-toolkit:readium-streamer:$readium")
+    implementation("org.readium.kotlin-toolkit:readium-navigator:$readium")
+
+    // Readium's own pinned transitive versions (pin them in the consumer too).
+    implementation("androidx.appcompat:appcompat:1.7.1")
+    implementation("androidx.fragment:fragment-ktx:1.8.9")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
+
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
+
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test:runner:1.6.2")
     androidTestImplementation("androidx.test:core:1.6.1")
+    // FragmentScenario for hosting the navigator fragment in-process (no UI automation).
+    androidTestImplementation("androidx.fragment:fragment-testing:1.8.9")
+    // Contributes EmptyFragmentActivity to the app-under-test's DEBUG manifest —
+    // launchFragmentInContainer launches it, so it must be declared in the app
+    // (not just the test) manifest, or ActivityScenario can't resolve it.
+    debugImplementation("androidx.fragment:fragment-testing-manifest:1.8.9")
+    androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
 }

--- a/spikes/android-reader-bench/app/src/androidTest/kotlin/vreader/spike/ReaderScrollBenchmark.kt
+++ b/spikes/android-reader-bench/app/src/androidTest/kotlin/vreader/spike/ReaderScrollBenchmark.kt
@@ -1,0 +1,124 @@
+package vreader.spike
+
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.Lifecycle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.readium.r2.navigator.epub.EpubNavigatorFactory
+import org.readium.r2.navigator.epub.EpubNavigatorFragment
+import org.readium.r2.navigator.epub.EpubPreferences
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Publication
+
+/**
+ * Spike B (#105) WI-2 — instrumented scroll-sweep over the real 1042-chapter CJK
+ * corpus (道诡异仙). Opens via Readium-Kotlin 3.3.0, hosts the EPUB navigator in
+ * SCROLL mode in-process (no UI automation — ADR-0001 R2), and drives a
+ * deterministic chapter-by-chapter sweep with animated intra-chapter scrolls so
+ * the Choreographer frame sampler sees real scroll frames. Records frame timing
+ * (jank %, p90/p99), memory trajectory (PSS / native heap — the eviction signal),
+ * and chapter coverage; writes metrics.json for the host wrapper to pull.
+ *
+ * Hard asserts here are only the engine-BLOCKING invariants (opened, traversed,
+ * frames rendered, didn't OOM). The scroll-smoothness / eviction-shape verdict
+ * vs the iOS baseline is judged in WI-4 from the JSON — emulator frame timing is
+ * variable, so gating the test on a 5%-jank threshold would flake for reasons
+ * unrelated to Readium. The plan: memory/renderer FAIL is blocking; a scroll
+ * miss is a hardening obligation.
+ */
+@OptIn(ExperimentalReadiumApi::class)
+@RunWith(AndroidJUnit4::class)
+class ReaderScrollBenchmark {
+
+    private val instr = InstrumentationRegistry.getInstrumentation()
+    private val ctx = instr.targetContext
+
+    private fun arg(name: String, default: Int): Int =
+        InstrumentationRegistry.getArguments().getString(name)?.toIntOrNull() ?: default
+
+    private fun mainSync(block: () -> Unit) = instr.runOnMainSync(block)
+    private fun settle(ms: Long) {
+        instr.waitForIdleSync()
+        Thread.sleep(ms)
+    }
+
+    @Test
+    fun scrollSweep() {
+        val corpus = ReaderOpener.corpusFile(ctx)
+        assertTrue("corpus missing at ${corpus.absolutePath} (push it first)", corpus.exists())
+
+        val publication: Publication = runBlocking { ReaderOpener.open(ctx, corpus) }
+        val spine = publication.readingOrder
+        assertTrue("expected the 1000+-spine CJK corpus, got ${spine.size}", spine.size > 1000)
+
+        val targetChapters = arg("chapters", 250).coerceAtMost(spine.size)
+        val scrollsPerChapter = arg("scrollsPerChapter", 4)
+
+        val factory = EpubNavigatorFactory(publication)
+        val scenario = launchFragmentInContainer<EpubNavigatorFragment>(
+            factory = factory.createFragmentFactory(
+                initialLocator = null,
+                initialPreferences = EpubPreferences(scroll = true),
+                listener = object : EpubNavigatorFragment.Listener {
+                    override fun onExternalLinkActivated(
+                        url: org.readium.r2.shared.util.AbsoluteUrl,
+                    ) {}
+                },
+            ),
+            initialState = Lifecycle.State.RESUMED,
+        )
+
+        lateinit var navigator: EpubNavigatorFragment
+        scenario.onFragment { navigator = it }
+        settle(1500) // first-resource render
+
+        val sampler = FrameSampler()
+        val mem = ArrayList<MemSample>()
+        val started = System.currentTimeMillis()
+        mainSync { sampler.start() }
+
+        var traversed = 0
+        for (i in 0 until targetChapters) {
+            val locator = publication.locatorFromLink(spine[i]) ?: continue
+            var moved = false
+            mainSync { moved = navigator.go(locator, animated = false) }
+            if (moved) traversed++
+            settle(150) // chapter layout + resource load
+            repeat(scrollsPerChapter) {
+                mainSync { navigator.goForward(animated = true) } // smooth scroll → real frames
+                settle(220)
+            }
+            if (i % 25 == 0) {
+                mem.add(MemSample(i, samplePssKb(ctx), sampleNativeHeapBytes() / 1024))
+            }
+        }
+        mem.add(MemSample(targetChapters, samplePssKb(ctx), sampleNativeHeapBytes() / 1024))
+        mainSync { sampler.stop() }
+
+        val result = BenchResult(
+            corpusBytes = corpus.length(),
+            spineCount = spine.size,
+            chaptersTraversed = traversed,
+            frameIntervalsMs = sampler.intervalsMs(),
+            mem = mem,
+            readerCrashes = 0,   // host wrapper computes from logcat
+            blankFrames = 0,
+            wallClockMs = System.currentTimeMillis() - started,
+        )
+        val json = result.toJson()
+        java.io.File(ctx.getExternalFilesDir(null), "metrics.json")
+            .writeText(json.toString(2))
+        android.util.Log.i("ReaderBench", "METRICS ${json}")
+
+        // Engine-blocking invariants only (see class doc).
+        assertTrue("traversed only $traversed chapters (<200)", traversed >= 200)
+        assertTrue("no frames rendered during sweep", result.frameIntervalsMs.isNotEmpty())
+        assertTrue("memory not sampled", mem.size >= 5)
+        val pssLast = mem.last().pssKb
+        assertTrue("PSS ballooned to ${pssLast}KB (OOM risk)", pssLast in 1..1_500_000)
+    }
+}

--- a/spikes/android-reader-bench/app/src/androidTest/kotlin/vreader/spike/ReaderScrollBenchmark.kt
+++ b/spikes/android-reader-bench/app/src/androidTest/kotlin/vreader/spike/ReaderScrollBenchmark.kt
@@ -65,6 +65,11 @@ class ReaderScrollBenchmark {
         val targetChapters = arg("chapters", 250).coerceAtMost(spine.size)
         val scrollsPerChapter = arg("scrollsPerChapter", 4)
 
+        // Snapshot pre-existing WebView renderers BEFORE launch so sample() can
+        // attribute only our session's newly-spawned renderer (Gate-4 round-2).
+        val probe = MemoryProbe(instr, ctx)
+        probe.snapshotBaseline()
+
         val factory = EpubNavigatorFactory(publication)
         val scenario = launchFragmentInContainer<EpubNavigatorFragment>(
             factory = factory.createFragmentFactory(
@@ -92,7 +97,6 @@ class ReaderScrollBenchmark {
             val scrollModeVerified = navigator.settings.value.scroll
 
             val sampler = FrameSampler()
-            val probe = MemoryProbe(instr, ctx)
             val mem = ArrayList<MemSample>()
             val started = System.currentTimeMillis()
             mainSync { sampler.start() }
@@ -110,12 +114,7 @@ class ReaderScrollBenchmark {
                     firstProgression = navigatorProgression(navigator)
                 }
                 repeat(scrollsPerChapter) {
-                    mainSync { sampler.setActive(true) }
-                    var adv = false
-                    mainSync { adv = navigator.goForward(animated = true) } // smooth scroll
-                    if (adv) scrollAdvances++
-                    settle(220) // real scroll frames captured here
-                    mainSync { sampler.setActive(false) }
+                    if (scrollOnce(navigator, sampler)) scrollAdvances++
                 }
                 if (i % 10 == 0) mem.add(probe.sample(i))
             }
@@ -145,7 +144,7 @@ class ReaderScrollBenchmark {
             assertTrue("no scroll advances accepted by navigator", scrollAdvances > 0)
             assertTrue("no real forward progress: $firstProgression -> $lastProgression",
                 lastProgression > firstProgression)
-            assertTrue("no frames rendered during active scroll", result.frameIntervalsMs.isNotEmpty())
+            assertTrue("no scroll-motion frames recorded", result.frameIntervalsMs.isNotEmpty())
             assertTrue("memory not sampled", mem.size >= 5)
             val totalLast = mem.last().totalPssKb
             val rendererMax = mem.maxOfOrNull { it.rendererPssKb } ?: 0
@@ -160,4 +159,31 @@ class ReaderScrollBenchmark {
     /** Whole-publication progression (0..1), or 0 if unavailable. */
     private fun navigatorProgression(nav: EpubNavigatorFragment): Double =
         nav.currentLocator.value.locations.totalProgression ?: 0.0
+
+    /**
+     * One animated scroll with the frame sample-window bounded by Readium locator
+     * stabilization (Gate-4 round-2 fix): open the window, advance, then keep
+     * sampling until progression has moved AND held steady for two reads (the
+     * animation finished) — or a hard cap. No fixed settle timer, so fast scrolls
+     * don't fold in idle vsync and slow scrolls aren't clipped. Returns whether the
+     * navigator accepted the advance.
+     */
+    private fun scrollOnce(nav: EpubNavigatorFragment, sampler: FrameSampler): Boolean {
+        mainSync { sampler.setActive(true) }
+        var adv = false
+        val before = navigatorProgression(nav)
+        mainSync { adv = nav.goForward(animated = true) }
+        var last = before
+        var moved = false
+        var stable = 0
+        var waited = 0
+        while (waited < 1200 && stable < 2) {
+            Thread.sleep(32)
+            waited += 32
+            val p = navigatorProgression(nav)
+            if (p != last) { moved = true; stable = 0; last = p } else if (moved) stable++
+        }
+        mainSync { sampler.setActive(false) }
+        return adv
+    }
 }

--- a/spikes/android-reader-bench/app/src/androidTest/kotlin/vreader/spike/ReaderScrollBenchmark.kt
+++ b/spikes/android-reader-bench/app/src/androidTest/kotlin/vreader/spike/ReaderScrollBenchmark.kt
@@ -17,18 +17,17 @@ import org.readium.r2.shared.publication.Publication
 /**
  * Spike B (#105) WI-2 — instrumented scroll-sweep over the real 1042-chapter CJK
  * corpus (道诡异仙). Opens via Readium-Kotlin 3.3.0, hosts the EPUB navigator in
- * SCROLL mode in-process (no UI automation — ADR-0001 R2), and drives a
- * deterministic chapter-by-chapter sweep with animated intra-chapter scrolls so
- * the Choreographer frame sampler sees real scroll frames. Records frame timing
- * (jank %, p90/p99), memory trajectory (PSS / native heap — the eviction signal),
- * and chapter coverage; writes metrics.json for the host wrapper to pull.
+ * SCROLL mode in-process (no UI automation — ADR-0001 R2), drives a deterministic
+ * 250-chapter sweep with animated intra-chapter scrolls, and records frame timing
+ * (active-window only), renderer-aware memory trajectory (the eviction signal),
+ * and real forward-progress. Writes metrics.json for the host wrapper to pull.
  *
- * Hard asserts here are only the engine-BLOCKING invariants (opened, traversed,
- * frames rendered, didn't OOM). The scroll-smoothness / eviction-shape verdict
- * vs the iOS baseline is judged in WI-4 from the JSON — emulator frame timing is
- * variable, so gating the test on a 5%-jank threshold would flake for reasons
- * unrelated to Readium. The plan: memory/renderer FAIL is blocking; a scroll
- * miss is a hardening obligation.
+ * Hard asserts are the engine-BLOCKING invariants AND the validity guards the
+ * Gate-4 audit demanded: scroll mode actually took effect (not paginated
+ * fallback), real forward progress through the book (not just chapter jumps), and
+ * bounded TOTAL (host+renderer) PSS. The scroll-smoothness verdict vs the iOS
+ * baseline is judged in WI-4 from the JSON — emulator frame timing is variable,
+ * so gating on a 5%-jank threshold would flake for reasons unrelated to Readium.
  */
 @OptIn(ExperimentalReadiumApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -52,6 +51,14 @@ class ReaderScrollBenchmark {
         assertTrue("corpus missing at ${corpus.absolutePath} (push it first)", corpus.exists())
 
         val publication: Publication = runBlocking { ReaderOpener.open(ctx, corpus) }
+        try {
+            runSweep(publication, corpus)
+        } finally {
+            publication.close()
+        }
+    }
+
+    private fun runSweep(publication: Publication, corpus: java.io.File) {
         val spine = publication.readingOrder
         assertTrue("expected the 1000+-spine CJK corpus, got ${spine.size}", spine.size > 1000)
 
@@ -72,53 +79,85 @@ class ReaderScrollBenchmark {
             initialState = Lifecycle.State.RESUMED,
         )
 
-        lateinit var navigator: EpubNavigatorFragment
-        scenario.onFragment { navigator = it }
-        settle(1500) // first-resource render
+        try {
+            lateinit var navigator: EpubNavigatorFragment
+            scenario.onFragment { navigator = it }
+            settle(1500) // first-resource render
 
-        val sampler = FrameSampler()
-        val mem = ArrayList<MemSample>()
-        val started = System.currentTimeMillis()
-        mainSync { sampler.start() }
+            // Critical validity guard (Codex Gate-4): prove SCROLL mode actually
+            // took effect, not a paginated fallback. Readium's resolved
+            // `settings.scroll` is the authoritative signal (the applied
+            // EpubSettings after EpubPreferences(scroll=true)); combined with the
+            // progression-delta assert below it proves scroll mode + real movement.
+            val scrollModeVerified = navigator.settings.value.scroll
 
-        var traversed = 0
-        for (i in 0 until targetChapters) {
-            val locator = publication.locatorFromLink(spine[i]) ?: continue
-            var moved = false
-            mainSync { moved = navigator.go(locator, animated = false) }
-            if (moved) traversed++
-            settle(150) // chapter layout + resource load
-            repeat(scrollsPerChapter) {
-                mainSync { navigator.goForward(animated = true) } // smooth scroll → real frames
-                settle(220)
+            val sampler = FrameSampler()
+            val probe = MemoryProbe(instr, ctx)
+            val mem = ArrayList<MemSample>()
+            val started = System.currentTimeMillis()
+            mainSync { sampler.start() }
+
+            var traversed = 0
+            var scrollAdvances = 0
+            var firstProgression = -1.0
+            for (i in 0 until targetChapters) {
+                val locator = publication.locatorFromLink(spine[i]) ?: continue
+                var moved = false
+                mainSync { moved = navigator.go(locator, animated = false) } // jump (not sampled)
+                if (moved) traversed++
+                settle(150)
+                if (firstProgression < 0) {
+                    firstProgression = navigatorProgression(navigator)
+                }
+                repeat(scrollsPerChapter) {
+                    mainSync { sampler.setActive(true) }
+                    var adv = false
+                    mainSync { adv = navigator.goForward(animated = true) } // smooth scroll
+                    if (adv) scrollAdvances++
+                    settle(220) // real scroll frames captured here
+                    mainSync { sampler.setActive(false) }
+                }
+                if (i % 10 == 0) mem.add(probe.sample(i))
             }
-            if (i % 25 == 0) {
-                mem.add(MemSample(i, samplePssKb(ctx), sampleNativeHeapBytes() / 1024))
-            }
+            mem.add(probe.sample(targetChapters))
+            mainSync { sampler.stop() }
+            val lastProgression = navigatorProgression(navigator)
+
+            val result = BenchResult(
+                corpusBytes = corpus.length(),
+                spineCount = spine.size,
+                chaptersTraversed = traversed,
+                scrollAdvances = scrollAdvances,
+                scrollModeVerified = scrollModeVerified,
+                firstProgression = firstProgression.coerceAtLeast(0.0),
+                lastProgression = lastProgression,
+                frameIntervalsMs = sampler.intervalsMs(),
+                mem = mem,
+                wallClockMs = System.currentTimeMillis() - started,
+            )
+            val json = result.toJson()
+            java.io.File(ctx.getExternalFilesDir(null), "metrics.json").writeText(json.toString(2))
+            android.util.Log.i("ReaderBench", "METRICS $json")
+
+            // Engine-blocking invariants + Gate-4 validity guards.
+            assertTrue("scroll mode did not take effect (paginated fallback?)", scrollModeVerified)
+            assertTrue("traversed only $traversed chapters (<200)", traversed >= 200)
+            assertTrue("no scroll advances accepted by navigator", scrollAdvances > 0)
+            assertTrue("no real forward progress: $firstProgression -> $lastProgression",
+                lastProgression > firstProgression)
+            assertTrue("no frames rendered during active scroll", result.frameIntervalsMs.isNotEmpty())
+            assertTrue("memory not sampled", mem.size >= 5)
+            val totalLast = mem.last().totalPssKb
+            val rendererMax = mem.maxOfOrNull { it.rendererPssKb } ?: 0
+            assertTrue("WebView renderer memory never captured (host-only = unsound de-risk)",
+                rendererMax > 0)
+            assertTrue("total PSS ballooned to ${totalLast}KB (OOM risk)", totalLast in 1..2_500_000)
+        } finally {
+            scenario.close()
         }
-        mem.add(MemSample(targetChapters, samplePssKb(ctx), sampleNativeHeapBytes() / 1024))
-        mainSync { sampler.stop() }
-
-        val result = BenchResult(
-            corpusBytes = corpus.length(),
-            spineCount = spine.size,
-            chaptersTraversed = traversed,
-            frameIntervalsMs = sampler.intervalsMs(),
-            mem = mem,
-            readerCrashes = 0,   // host wrapper computes from logcat
-            blankFrames = 0,
-            wallClockMs = System.currentTimeMillis() - started,
-        )
-        val json = result.toJson()
-        java.io.File(ctx.getExternalFilesDir(null), "metrics.json")
-            .writeText(json.toString(2))
-        android.util.Log.i("ReaderBench", "METRICS ${json}")
-
-        // Engine-blocking invariants only (see class doc).
-        assertTrue("traversed only $traversed chapters (<200)", traversed >= 200)
-        assertTrue("no frames rendered during sweep", result.frameIntervalsMs.isNotEmpty())
-        assertTrue("memory not sampled", mem.size >= 5)
-        val pssLast = mem.last().pssKb
-        assertTrue("PSS ballooned to ${pssLast}KB (OOM risk)", pssLast in 1..1_500_000)
     }
+
+    /** Whole-publication progression (0..1), or 0 if unavailable. */
+    private fun navigatorProgression(nav: EpubNavigatorFragment): Double =
+        nav.currentLocator.value.locations.totalProgression ?: 0.0
 }

--- a/spikes/android-reader-bench/app/src/androidTest/kotlin/vreader/spike/ReaderScrollBenchmark.kt
+++ b/spikes/android-reader-bench/app/src/androidTest/kotlin/vreader/spike/ReaderScrollBenchmark.kt
@@ -148,8 +148,14 @@ class ReaderScrollBenchmark {
             assertTrue("memory not sampled", mem.size >= 5)
             val totalLast = mem.last().totalPssKb
             val rendererMax = mem.maxOfOrNull { it.rendererPssKb } ?: 0
+            val maxProcs = mem.maxOfOrNull { it.processCount } ?: 0
             assertTrue("WebView renderer memory never captured (host-only = unsound de-risk)",
                 rendererMax > 0)
+            // Attribution invariant (Codex Gate-4 round-3): exactly host + 1 of OUR
+            // renderers. >2 means a foreign WebView sandbox spawned mid-sweep and
+            // contaminated rendererPssKb — fail the run rather than report it as valid.
+            assertTrue("attributed $maxProcs procs (>2): a foreign WebView sandbox contaminated the run",
+                maxProcs <= 2)
             assertTrue("total PSS ballooned to ${totalLast}KB (OOM risk)", totalLast in 1..2_500_000)
         } finally {
             scenario.close()

--- a/spikes/android-reader-bench/app/src/main/kotlin/vreader/spike/ReaderOpener.kt
+++ b/spikes/android-reader-bench/app/src/main/kotlin/vreader/spike/ReaderOpener.kt
@@ -1,0 +1,47 @@
+package vreader.spike
+
+import android.content.Context
+import java.io.File
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.util.asset.AssetRetriever
+import org.readium.r2.shared.util.getOrElse
+import org.readium.r2.shared.util.http.DefaultHttpClient
+import org.readium.r2.shared.util.toUrl
+import org.readium.r2.streamer.PublicationOpener
+import org.readium.r2.streamer.parser.DefaultPublicationParser
+
+/**
+ * Spike B (#105) — the shared Readium-Kotlin 3.3.0 EPUB open path, reused by the
+ * scroll benchmark (WI-2) and the anchor-restore probes (WI-3). Mirrors the iOS
+ * AssetRetriever -> PublicationOpener flow; no product code, throwaway harness.
+ *
+ * Both `retrieve` and `open` are suspend + return Readium's own `Try<_, _Error>`
+ * (NOT kotlin.Result). `pdfFactory = null` because this spike opens EPUB only —
+ * no PDF adapter module is needed.
+ */
+@OptIn(ExperimentalReadiumApi::class)
+object ReaderOpener {
+
+    suspend fun open(context: Context, file: File): Publication {
+        require(file.exists()) { "corpus not found at ${file.absolutePath}" }
+        val httpClient = DefaultHttpClient()
+        val assetRetriever = AssetRetriever(context.contentResolver, httpClient)
+        val parser = DefaultPublicationParser(
+            context = context,
+            httpClient = httpClient,
+            assetRetriever = assetRetriever,
+            pdfFactory = null,
+        )
+        val opener = PublicationOpener(parser)
+
+        val asset = assetRetriever.retrieve(file.toUrl(isDirectory = false))
+            .getOrElse { error("retrieve failed: $it") }
+        return opener.open(asset, allowUserInteraction = false)
+            .getOrElse { error("open failed: $it") }
+    }
+
+    /** The corpus path the harness shell pushes to (app external files dir). */
+    fun corpusFile(context: Context): File =
+        File(context.getExternalFilesDir(null), "corpus.epub")
+}

--- a/spikes/android-reader-bench/app/src/main/kotlin/vreader/spike/ScrollMetrics.kt
+++ b/spikes/android-reader-bench/app/src/main/kotlin/vreader/spike/ScrollMetrics.kt
@@ -1,25 +1,33 @@
 package vreader.spike
 
-import android.app.ActivityManager
+import android.app.Instrumentation
 import android.content.Context
 import android.os.Debug
+import android.os.ParcelFileDescriptor
 import android.view.Choreographer
 import org.json.JSONArray
 import org.json.JSONObject
 
 /**
- * Spike B (#105) WI-2 — in-process frame-timing + memory samplers. This is the
- * "macrobenchmark FrameTimingMetric or equivalent" the plan allows: the spike is
- * instrumentation-first / NOT UI-automation-driven (ADR-0001 R2), so we sample
- * Choreographer frame intervals on the main thread and process memory via
- * ActivityManager rather than driving a real device swipe under macrobenchmark.
+ * Spike B (#105) WI-2 — in-process frame-timing + (renderer-aware) memory
+ * samplers. This is the "macrobenchmark FrameTimingMetric or equivalent" the
+ * plan allows: the spike is instrumentation-first / NOT UI-automation-driven
+ * (ADR-0001 R2), so we sample Choreographer frame intervals and process memory
+ * directly rather than driving a real device swipe under macrobenchmark.
  */
 
-/** Records inter-frame intervals on the main thread between start() and stop(). */
+/**
+ * Records inter-frame intervals on the main thread, but ONLY while `active`
+ * (set around the animated-scroll windows). A Choreographer callback ticks every
+ * vsync whenever posted, so counting every interval — including the idle settle
+ * periods — would dilute the jank ratio with perfectly-on-budget idle frames
+ * (Codex Gate-4 High). Gating on `active` measures jank during actual scroll work.
+ */
 class FrameSampler : Choreographer.FrameCallback {
-    private val frameNanos = ArrayList<Long>(4096)
+    private val frameNanos = ArrayList<Long>(8192)
     private var lastNanos = 0L
     private var running = false
+    @Volatile private var active = false
 
     /** Call on the main thread. */
     fun start() {
@@ -31,41 +39,109 @@ class FrameSampler : Choreographer.FrameCallback {
     /** Call on the main thread. */
     fun stop() {
         running = false
+        active = false
         Choreographer.getInstance().removeFrameCallback(this)
     }
 
+    /** Begin/end counting frames; resets the delta baseline so the gap isn't counted. */
+    fun setActive(value: Boolean) {
+        active = value
+        lastNanos = 0L
+    }
+
     override fun doFrame(frameTimeNanos: Long) {
-        if (lastNanos != 0L) frameNanos.add(frameTimeNanos - lastNanos)
+        if (active && lastNanos != 0L) frameNanos.add(frameTimeNanos - lastNanos)
         lastNanos = frameTimeNanos
         if (running) Choreographer.getInstance().postFrameCallback(this)
     }
 
-    /** Inter-frame deltas in milliseconds (one per rendered frame after the first). */
+    /** Inter-frame deltas (ms) recorded during active scroll windows only. */
     fun intervalsMs(): List<Double> = frameNanos.map { it / 1_000_000.0 }
 }
 
-/** Total PSS (KB) for this process — the memory-trajectory signal. */
-fun samplePssKb(context: Context): Int {
-    val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-    val info = am.getProcessMemoryInfo(intArrayOf(android.os.Process.myPid()))
-    return info.firstOrNull()?.totalPss ?: 0
+/**
+ * Renderer-aware memory probe. WebView Chromium renders in a separate sandboxed
+ * child process (named `<pkg>:sandboxed_process…`) — host-process PSS alone would
+ * NOT measure the renderer eviction that IS ADR-0001 Risk-2 (Codex Gate-4 High).
+ * Uses the instrumentation's UiAutomation shell (shell uid) to `dumpsys meminfo`
+ * every process whose name starts with our package: the main process plus its
+ * WebView renderer child. Reports host / renderer / total PSS separately.
+ */
+class MemoryProbe(private val instr: Instrumentation, ctx: Context) {
+    private val pkg = ctx.packageName
+
+    private fun shell(cmd: String): String =
+        ParcelFileDescriptor.AutoCloseInputStream(instr.uiAutomation.executeShellCommand(cmd))
+            .use { it.readBytes().decodeToString() }
+
+    private val totalPssRe = Regex("TOTAL PSS:\\s+(\\d+)")
+    private val totalRowRe = Regex("(?m)^\\s*TOTAL\\s+(\\d+)")
+
+    private fun pssKb(pid: Int): Int {
+        val out = shell("dumpsys meminfo --local $pid")
+        return totalPssRe.find(out)?.groupValues?.get(1)?.toIntOrNull()
+            ?: totalRowRe.find(out)?.groupValues?.get(1)?.toIntOrNull()
+            ?: 0
+    }
+
+    /**
+     * (processName, pid) for our host process plus the Chromium WebView renderer.
+     * The WebView renderer is a SHARED sandboxed process under the webview
+     * package's uid (`com.google.android.webview:sandboxed_process…`), NOT our
+     * package's uid — so a `startsWith(pkg)` filter misses it (Codex Gate-4 High).
+     * On this harness the benchmark app is the sole active WebView client, so that
+     * renderer's memory reflects our 250-chapter content; WI-4 records the caveat.
+     */
+    private fun appPids(): List<Pair<String, Int>> =
+        shell("ps -A -o PID -o NAME").lineSequence().mapNotNull { line ->
+            val parts = line.trim().split(Regex("\\s+"))
+            val name = parts.getOrNull(1) ?: return@mapNotNull null
+            if (parts.size >= 2 && (name == pkg || name.contains("sandboxed_process"))) {
+                parts[0].toIntOrNull()?.let { name to it }
+            } else null
+        }.toList()
+
+    fun sample(chapterIndex: Int): MemSample {
+        var host = 0
+        var renderer = 0
+        var procs = 0
+        for ((name, pid) in appPids()) {
+            val pss = pssKb(pid)
+            if (name == pkg) host += pss else renderer += pss
+            procs++
+        }
+        return MemSample(
+            chapterIndex = chapterIndex,
+            hostPssKb = host,
+            rendererPssKb = renderer,
+            totalPssKb = host + renderer,
+            nativeHeapKb = (Debug.getNativeHeapAllocatedSize() / 1024),
+            processCount = procs,
+        )
+    }
 }
 
-/** Native heap allocated bytes — cheap, sampled alongside PSS. */
-fun sampleNativeHeapBytes(): Long = Debug.getNativeHeapAllocatedSize()
-
 /** One sample of the memory trajectory at a sweep checkpoint. */
-data class MemSample(val chapterIndex: Int, val pssKb: Int, val nativeHeapKb: Long)
+data class MemSample(
+    val chapterIndex: Int,
+    val hostPssKb: Int,
+    val rendererPssKb: Int,
+    val totalPssKb: Int,
+    val nativeHeapKb: Long,
+    val processCount: Int,
+)
 
 /** Final benchmark result, serialized to JSON and pulled off-device. */
 data class BenchResult(
     val corpusBytes: Long,
     val spineCount: Int,
     val chaptersTraversed: Int,
+    val scrollAdvances: Int,
+    val scrollModeVerified: Boolean,
+    val firstProgression: Double,
+    val lastProgression: Double,
     val frameIntervalsMs: List<Double>,
     val mem: List<MemSample>,
-    val readerCrashes: Int,
-    val blankFrames: Int,
     val wallClockMs: Long,
 ) {
     private fun percentile(sorted: List<Double>, p: Double): Double {
@@ -82,16 +158,24 @@ data class BenchResult(
             mem.forEach {
                 put(JSONObject().apply {
                     put("chapter", it.chapterIndex)
-                    put("pssKb", it.pssKb)
+                    put("hostPssKb", it.hostPssKb)
+                    put("rendererPssKb", it.rendererPssKb)
+                    put("totalPssKb", it.totalPssKb)
                     put("nativeHeapKb", it.nativeHeapKb)
+                    put("processCount", it.processCount)
                 })
             }
         }
-        val pssVals = mem.map { it.pssKb }
+        val totals = mem.map { it.totalPssKb }
         return JSONObject().apply {
             put("corpusBytes", corpusBytes)
             put("spineCount", spineCount)
             put("chaptersTraversed", chaptersTraversed)
+            put("scrollAdvances", scrollAdvances)
+            put("scrollModeVerified", scrollModeVerified)
+            put("firstProgression", firstProgression)
+            put("lastProgression", lastProgression)
+            put("progressionDelta", lastProgression - firstProgression)
             put("frameCount", frameIntervalsMs.size)
             put("jankFrames", jank)
             put("jankPercent", if (frameIntervalsMs.isEmpty()) 0.0 else jank * 100.0 / frameIntervalsMs.size)
@@ -99,12 +183,11 @@ data class BenchResult(
             put("frameMsP90", percentile(sorted, 0.90))
             put("frameMsP99", percentile(sorted, 0.99))
             put("frameMsMax", sorted.lastOrNull() ?: 0.0)
-            put("pssFirstKb", pssVals.firstOrNull() ?: 0)
-            put("pssLastKb", pssVals.lastOrNull() ?: 0)
-            put("pssMaxKb", pssVals.maxOrNull() ?: 0)
-            put("pssGrowthKb", (pssVals.lastOrNull() ?: 0) - (pssVals.firstOrNull() ?: 0))
-            put("readerCrashes", readerCrashes)
-            put("blankFrames", blankFrames)
+            put("totalPssFirstKb", totals.firstOrNull() ?: 0)
+            put("totalPssLastKb", totals.lastOrNull() ?: 0)
+            put("totalPssMaxKb", totals.maxOrNull() ?: 0)
+            put("totalPssGrowthKb", (totals.lastOrNull() ?: 0) - (totals.firstOrNull() ?: 0))
+            put("rendererPssMaxKb", mem.maxOfOrNull { it.rendererPssKb } ?: 0)
             put("wallClockMs", wallClockMs)
             put("mem", memArr)
         }

--- a/spikes/android-reader-bench/app/src/main/kotlin/vreader/spike/ScrollMetrics.kt
+++ b/spikes/android-reader-bench/app/src/main/kotlin/vreader/spike/ScrollMetrics.kt
@@ -17,11 +17,14 @@ import org.json.JSONObject
  */
 
 /**
- * Records inter-frame intervals on the main thread, but ONLY while `active`
- * (set around the animated-scroll windows). A Choreographer callback ticks every
- * vsync whenever posted, so counting every interval — including the idle settle
- * periods — would dilute the jank ratio with perfectly-on-budget idle frames
- * (Codex Gate-4 High). Gating on `active` measures jank during actual scroll work.
+ * Records inter-frame intervals on the main thread while `active`. The active
+ * window is NOT a fixed timer (Codex Gate-4 round-2 High): the caller opens it at
+ * scroll start and closes it on a real completion signal — Readium locator
+ * stabilization (see ReaderScrollBenchmark.scrollOnce). Readium's currentLocator
+ * progression updates at scroll completion, not per-frame, so per-frame motion
+ * gating records nothing; bounding the window by "progression moved then held
+ * steady" is the auditor's suggested locator-stabilization signal and keeps the
+ * sample to the real scroll animation rather than an arbitrary settle pad.
  */
 class FrameSampler : Choreographer.FrameCallback {
     private val frameNanos = ArrayList<Long>(8192)
@@ -43,7 +46,8 @@ class FrameSampler : Choreographer.FrameCallback {
         Choreographer.getInstance().removeFrameCallback(this)
     }
 
-    /** Begin/end counting frames; resets the delta baseline so the gap isn't counted. */
+    /** Open/close the sample window; resets the delta baseline so the gap between
+     *  windows is never charged as a frame interval. */
     fun setActive(value: Boolean) {
         active = value
         lastNanos = 0L
@@ -55,7 +59,7 @@ class FrameSampler : Choreographer.FrameCallback {
         if (running) Choreographer.getInstance().postFrameCallback(this)
     }
 
-    /** Inter-frame deltas (ms) recorded during active scroll windows only. */
+    /** Inter-frame deltas (ms) recorded during the bounded scroll windows. */
     fun intervalsMs(): List<Double> = frameNanos.map { it / 1_000_000.0 }
 }
 
@@ -69,6 +73,17 @@ class FrameSampler : Choreographer.FrameCallback {
  */
 class MemoryProbe(private val instr: Instrumentation, ctx: Context) {
     private val pkg = ctx.packageName
+
+    /**
+     * Sandboxed-renderer PIDs already alive BEFORE our navigator launched. WebView
+     * renders in a shared sandboxed process under the webview package's uid
+     * (`…:sandboxed_process…`), so a name match alone would sum every Chromium
+     * sandbox on the device — not only ours (Codex Gate-4 round-2 High). We snapshot
+     * the pre-launch set and attribute ONLY newly-spawned renderers to our session;
+     * `sample()` reports `processCount` so the test can FAIL the run if no renderer
+     * was uniquely attributable rather than silently reporting host-only memory.
+     */
+    private var baselineSandbox: Set<Int> = emptySet()
 
     private fun shell(cmd: String): String =
         ParcelFileDescriptor.AutoCloseInputStream(instr.uiAutomation.executeShellCommand(cmd))
@@ -84,30 +99,33 @@ class MemoryProbe(private val instr: Instrumentation, ctx: Context) {
             ?: 0
     }
 
-    /**
-     * (processName, pid) for our host process plus the Chromium WebView renderer.
-     * The WebView renderer is a SHARED sandboxed process under the webview
-     * package's uid (`com.google.android.webview:sandboxed_process…`), NOT our
-     * package's uid — so a `startsWith(pkg)` filter misses it (Codex Gate-4 High).
-     * On this harness the benchmark app is the sole active WebView client, so that
-     * renderer's memory reflects our 250-chapter content; WI-4 records the caveat.
-     */
-    private fun appPids(): List<Pair<String, Int>> =
+    /** (processName, pid) for every running process. */
+    private fun allPids(): List<Pair<String, Int>> =
         shell("ps -A -o PID -o NAME").lineSequence().mapNotNull { line ->
             val parts = line.trim().split(Regex("\\s+"))
             val name = parts.getOrNull(1) ?: return@mapNotNull null
-            if (parts.size >= 2 && (name == pkg || name.contains("sandboxed_process"))) {
-                parts[0].toIntOrNull()?.let { name to it }
-            } else null
+            if (parts.size >= 2) parts[0].toIntOrNull()?.let { name to it } else null
         }.toList()
+
+    private fun sandboxPids(): Set<Int> =
+        allPids().filter { it.first.contains("sandboxed_process") }.map { it.second }.toSet()
+
+    /** Call BEFORE launching the navigator, to record pre-existing renderers. */
+    fun snapshotBaseline() {
+        baselineSandbox = sandboxPids()
+    }
 
     fun sample(chapterIndex: Int): MemSample {
         var host = 0
         var renderer = 0
         var procs = 0
-        for ((name, pid) in appPids()) {
+        for ((name, pid) in allPids()) {
+            val isHost = name == pkg
+            // renderer = sandboxed process spawned AFTER our launch (our session's).
+            val isOurRenderer = name.contains("sandboxed_process") && pid !in baselineSandbox
+            if (!isHost && !isOurRenderer) continue
             val pss = pssKb(pid)
-            if (name == pkg) host += pss else renderer += pss
+            if (isHost) host += pss else renderer += pss
             procs++
         }
         return MemSample(

--- a/spikes/android-reader-bench/app/src/main/kotlin/vreader/spike/ScrollMetrics.kt
+++ b/spikes/android-reader-bench/app/src/main/kotlin/vreader/spike/ScrollMetrics.kt
@@ -1,0 +1,112 @@
+package vreader.spike
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Debug
+import android.view.Choreographer
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Spike B (#105) WI-2 — in-process frame-timing + memory samplers. This is the
+ * "macrobenchmark FrameTimingMetric or equivalent" the plan allows: the spike is
+ * instrumentation-first / NOT UI-automation-driven (ADR-0001 R2), so we sample
+ * Choreographer frame intervals on the main thread and process memory via
+ * ActivityManager rather than driving a real device swipe under macrobenchmark.
+ */
+
+/** Records inter-frame intervals on the main thread between start() and stop(). */
+class FrameSampler : Choreographer.FrameCallback {
+    private val frameNanos = ArrayList<Long>(4096)
+    private var lastNanos = 0L
+    private var running = false
+
+    /** Call on the main thread. */
+    fun start() {
+        running = true
+        lastNanos = 0L
+        Choreographer.getInstance().postFrameCallback(this)
+    }
+
+    /** Call on the main thread. */
+    fun stop() {
+        running = false
+        Choreographer.getInstance().removeFrameCallback(this)
+    }
+
+    override fun doFrame(frameTimeNanos: Long) {
+        if (lastNanos != 0L) frameNanos.add(frameTimeNanos - lastNanos)
+        lastNanos = frameTimeNanos
+        if (running) Choreographer.getInstance().postFrameCallback(this)
+    }
+
+    /** Inter-frame deltas in milliseconds (one per rendered frame after the first). */
+    fun intervalsMs(): List<Double> = frameNanos.map { it / 1_000_000.0 }
+}
+
+/** Total PSS (KB) for this process — the memory-trajectory signal. */
+fun samplePssKb(context: Context): Int {
+    val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+    val info = am.getProcessMemoryInfo(intArrayOf(android.os.Process.myPid()))
+    return info.firstOrNull()?.totalPss ?: 0
+}
+
+/** Native heap allocated bytes — cheap, sampled alongside PSS. */
+fun sampleNativeHeapBytes(): Long = Debug.getNativeHeapAllocatedSize()
+
+/** One sample of the memory trajectory at a sweep checkpoint. */
+data class MemSample(val chapterIndex: Int, val pssKb: Int, val nativeHeapKb: Long)
+
+/** Final benchmark result, serialized to JSON and pulled off-device. */
+data class BenchResult(
+    val corpusBytes: Long,
+    val spineCount: Int,
+    val chaptersTraversed: Int,
+    val frameIntervalsMs: List<Double>,
+    val mem: List<MemSample>,
+    val readerCrashes: Int,
+    val blankFrames: Int,
+    val wallClockMs: Long,
+) {
+    private fun percentile(sorted: List<Double>, p: Double): Double {
+        if (sorted.isEmpty()) return 0.0
+        val idx = ((sorted.size - 1) * p).toInt().coerceIn(0, sorted.size - 1)
+        return sorted[idx]
+    }
+
+    fun toJson(): JSONObject {
+        val sorted = frameIntervalsMs.sorted()
+        val budget = 1000.0 / 60.0 // 16.6ms
+        val jank = frameIntervalsMs.count { it > budget }
+        val memArr = JSONArray().apply {
+            mem.forEach {
+                put(JSONObject().apply {
+                    put("chapter", it.chapterIndex)
+                    put("pssKb", it.pssKb)
+                    put("nativeHeapKb", it.nativeHeapKb)
+                })
+            }
+        }
+        val pssVals = mem.map { it.pssKb }
+        return JSONObject().apply {
+            put("corpusBytes", corpusBytes)
+            put("spineCount", spineCount)
+            put("chaptersTraversed", chaptersTraversed)
+            put("frameCount", frameIntervalsMs.size)
+            put("jankFrames", jank)
+            put("jankPercent", if (frameIntervalsMs.isEmpty()) 0.0 else jank * 100.0 / frameIntervalsMs.size)
+            put("frameMsP50", percentile(sorted, 0.50))
+            put("frameMsP90", percentile(sorted, 0.90))
+            put("frameMsP99", percentile(sorted, 0.99))
+            put("frameMsMax", sorted.lastOrNull() ?: 0.0)
+            put("pssFirstKb", pssVals.firstOrNull() ?: 0)
+            put("pssLastKb", pssVals.lastOrNull() ?: 0)
+            put("pssMaxKb", pssVals.maxOrNull() ?: 0)
+            put("pssGrowthKb", (pssVals.lastOrNull() ?: 0) - (pssVals.firstOrNull() ?: 0))
+            put("readerCrashes", readerCrashes)
+            put("blankFrames", blankFrames)
+            put("wallClockMs", wallClockMs)
+            put("mem", memArr)
+        }
+    }
+}

--- a/spikes/android-reader-bench/baselines/scroll-sweep-250-emulator-20260617.json
+++ b/spikes/android-reader-bench/baselines/scroll-sweep-250-emulator-20260617.json
@@ -1,0 +1,76 @@
+{
+  "corpusBytes": 19381838,
+  "spineCount": 1042,
+  "chaptersTraversed": 250,
+  "frameCount": 17951,
+  "jankFrames": 310,
+  "jankPercent": 1.7269232911815497,
+  "frameMsP50": 16.666666,
+  "frameMsP90": 16.666666,
+  "frameMsP99": 33.333332,
+  "frameMsMax": 66.666664,
+  "pssFirstKb": 167226,
+  "pssLastKb": 193373,
+  "pssMaxKb": 193373,
+  "pssGrowthKb": 26147,
+  "readerCrashes": 0,
+  "blankFrames": 0,
+  "wallClockMs": 305292,
+  "mem": [
+    {
+      "chapter": 0,
+      "pssKb": 167226,
+      "nativeHeapKb": 24693
+    },
+    {
+      "chapter": 25,
+      "pssKb": 180970,
+      "nativeHeapKb": 24763
+    },
+    {
+      "chapter": 50,
+      "pssKb": 176442,
+      "nativeHeapKb": 24810
+    },
+    {
+      "chapter": 75,
+      "pssKb": 192037,
+      "nativeHeapKb": 24866
+    },
+    {
+      "chapter": 100,
+      "pssKb": 191131,
+      "nativeHeapKb": 24878
+    },
+    {
+      "chapter": 125,
+      "pssKb": 177010,
+      "nativeHeapKb": 24953
+    },
+    {
+      "chapter": 150,
+      "pssKb": 179662,
+      "nativeHeapKb": 24884
+    },
+    {
+      "chapter": 175,
+      "pssKb": 185700,
+      "nativeHeapKb": 24982
+    },
+    {
+      "chapter": 200,
+      "pssKb": 184538,
+      "nativeHeapKb": 24901
+    },
+    {
+      "chapter": 225,
+      "pssKb": 179497,
+      "nativeHeapKb": 24970
+    },
+    {
+      "chapter": 250,
+      "pssKb": 193373,
+      "nativeHeapKb": 24928
+    }
+  ]
+}

--- a/spikes/android-reader-bench/baselines/scroll-sweep-250-emulator-20260617.json
+++ b/spikes/android-reader-bench/baselines/scroll-sweep-250-emulator-20260617.json
@@ -2,75 +2,232 @@
   "corpusBytes": 19381838,
   "spineCount": 1042,
   "chaptersTraversed": 250,
-  "frameCount": 17951,
-  "jankFrames": 310,
-  "jankPercent": 1.7269232911815497,
+  "scrollAdvances": 1000,
+  "scrollModeVerified": true,
+  "firstProgression": 0,
+  "lastProgression": 0.2288926094235829,
+  "progressionDelta": 0.2288926094235829,
+  "frameCount": 14166,
+  "jankFrames": 25,
+  "jankPercent": 0.17647889312438234,
   "frameMsP50": 16.666666,
   "frameMsP90": 16.666666,
-  "frameMsP99": 33.333332,
-  "frameMsMax": 66.666664,
-  "pssFirstKb": 167226,
-  "pssLastKb": 193373,
-  "pssMaxKb": 193373,
-  "pssGrowthKb": 26147,
-  "readerCrashes": 0,
-  "blankFrames": 0,
-  "wallClockMs": 305292,
+  "frameMsP99": 16.666666,
+  "frameMsMax": 83.33333,
+  "totalPssFirstKb": 298933,
+  "totalPssLastKb": 952536,
+  "totalPssMaxKb": 1045804,
+  "totalPssGrowthKb": 653603,
+  "rendererPssMaxKb": 853091,
+  "wallClockMs": 307550,
   "mem": [
     {
       "chapter": 0,
-      "pssKb": 167226,
-      "nativeHeapKb": 24693
+      "hostPssKb": 170205,
+      "rendererPssKb": 128728,
+      "totalPssKb": 298933,
+      "nativeHeapKb": 25417,
+      "processCount": 3
     },
     {
-      "chapter": 25,
-      "pssKb": 180970,
-      "nativeHeapKb": 24763
+      "chapter": 10,
+      "hostPssKb": 177395,
+      "rendererPssKb": 303464,
+      "totalPssKb": 480859,
+      "nativeHeapKb": 24767,
+      "processCount": 3
+    },
+    {
+      "chapter": 20,
+      "hostPssKb": 175764,
+      "rendererPssKb": 506459,
+      "totalPssKb": 682223,
+      "nativeHeapKb": 25570,
+      "processCount": 3
+    },
+    {
+      "chapter": 30,
+      "hostPssKb": 178978,
+      "rendererPssKb": 567902,
+      "totalPssKb": 746880,
+      "nativeHeapKb": 24829,
+      "processCount": 3
+    },
+    {
+      "chapter": 40,
+      "hostPssKb": 214404,
+      "rendererPssKb": 620731,
+      "totalPssKb": 835135,
+      "nativeHeapKb": 24879,
+      "processCount": 3
     },
     {
       "chapter": 50,
-      "pssKb": 176442,
-      "nativeHeapKb": 24810
+      "hostPssKb": 192298,
+      "rendererPssKb": 643449,
+      "totalPssKb": 835747,
+      "nativeHeapKb": 24884,
+      "processCount": 3
     },
     {
-      "chapter": 75,
-      "pssKb": 192037,
-      "nativeHeapKb": 24866
+      "chapter": 60,
+      "hostPssKb": 173494,
+      "rendererPssKb": 701805,
+      "totalPssKb": 875299,
+      "nativeHeapKb": 25625,
+      "processCount": 3
+    },
+    {
+      "chapter": 70,
+      "hostPssKb": 165454,
+      "rendererPssKb": 726953,
+      "totalPssKb": 892407,
+      "nativeHeapKb": 24959,
+      "processCount": 3
+    },
+    {
+      "chapter": 80,
+      "hostPssKb": 168190,
+      "rendererPssKb": 756969,
+      "totalPssKb": 925159,
+      "nativeHeapKb": 24964,
+      "processCount": 3
+    },
+    {
+      "chapter": 90,
+      "hostPssKb": 169154,
+      "rendererPssKb": 790185,
+      "totalPssKb": 959339,
+      "nativeHeapKb": 24986,
+      "processCount": 3
     },
     {
       "chapter": 100,
-      "pssKb": 191131,
-      "nativeHeapKb": 24878
+      "hostPssKb": 192780,
+      "rendererPssKb": 820339,
+      "totalPssKb": 1013119,
+      "nativeHeapKb": 24898,
+      "processCount": 3
     },
     {
-      "chapter": 125,
-      "pssKb": 177010,
-      "nativeHeapKb": 24953
+      "chapter": 110,
+      "hostPssKb": 184750,
+      "rendererPssKb": 774521,
+      "totalPssKb": 959271,
+      "nativeHeapKb": 24908,
+      "processCount": 3
+    },
+    {
+      "chapter": 120,
+      "hostPssKb": 165894,
+      "rendererPssKb": 805385,
+      "totalPssKb": 971279,
+      "nativeHeapKb": 24979,
+      "processCount": 3
+    },
+    {
+      "chapter": 130,
+      "hostPssKb": 174074,
+      "rendererPssKb": 821513,
+      "totalPssKb": 995587,
+      "nativeHeapKb": 25010,
+      "processCount": 3
+    },
+    {
+      "chapter": 140,
+      "hostPssKb": 173014,
+      "rendererPssKb": 849217,
+      "totalPssKb": 1022231,
+      "nativeHeapKb": 25019,
+      "processCount": 3
     },
     {
       "chapter": 150,
-      "pssKb": 179662,
-      "nativeHeapKb": 24884
+      "hostPssKb": 182834,
+      "rendererPssKb": 770631,
+      "totalPssKb": 953465,
+      "nativeHeapKb": 25643,
+      "processCount": 3
     },
     {
-      "chapter": 175,
-      "pssKb": 185700,
-      "nativeHeapKb": 24982
+      "chapter": 160,
+      "hostPssKb": 196176,
+      "rendererPssKb": 800793,
+      "totalPssKb": 996969,
+      "nativeHeapKb": 24968,
+      "processCount": 3
+    },
+    {
+      "chapter": 170,
+      "hostPssKb": 190820,
+      "rendererPssKb": 829557,
+      "totalPssKb": 1020377,
+      "nativeHeapKb": 24962,
+      "processCount": 3
+    },
+    {
+      "chapter": 180,
+      "hostPssKb": 180572,
+      "rendererPssKb": 763113,
+      "totalPssKb": 943685,
+      "nativeHeapKb": 25726,
+      "processCount": 3
+    },
+    {
+      "chapter": 190,
+      "hostPssKb": 189030,
+      "rendererPssKb": 809547,
+      "totalPssKb": 998577,
+      "nativeHeapKb": 25733,
+      "processCount": 3
     },
     {
       "chapter": 200,
-      "pssKb": 184538,
-      "nativeHeapKb": 24901
+      "hostPssKb": 196342,
+      "rendererPssKb": 828471,
+      "totalPssKb": 1024813,
+      "nativeHeapKb": 24955,
+      "processCount": 3
     },
     {
-      "chapter": 225,
-      "pssKb": 179497,
-      "nativeHeapKb": 24970
+      "chapter": 210,
+      "hostPssKb": 192713,
+      "rendererPssKb": 853091,
+      "totalPssKb": 1045804,
+      "nativeHeapKb": 25709,
+      "processCount": 3
+    },
+    {
+      "chapter": 220,
+      "hostPssKb": 191401,
+      "rendererPssKb": 764075,
+      "totalPssKb": 955476,
+      "nativeHeapKb": 24958,
+      "processCount": 3
+    },
+    {
+      "chapter": 230,
+      "hostPssKb": 181373,
+      "rendererPssKb": 789999,
+      "totalPssKb": 971372,
+      "nativeHeapKb": 24942,
+      "processCount": 3
+    },
+    {
+      "chapter": 240,
+      "hostPssKb": 185851,
+      "rendererPssKb": 840985,
+      "totalPssKb": 1026836,
+      "nativeHeapKb": 24955,
+      "processCount": 3
     },
     {
       "chapter": 250,
-      "pssKb": 193373,
-      "nativeHeapKb": 24928
+      "hostPssKb": 196471,
+      "rendererPssKb": 756065,
+      "totalPssKb": 952536,
+      "nativeHeapKb": 24960,
+      "processCount": 3
     }
   ]
 }

--- a/spikes/android-reader-bench/baselines/scroll-sweep-250-emulator-20260617.json
+++ b/spikes/android-reader-bench/baselines/scroll-sweep-250-emulator-20260617.json
@@ -5,229 +5,229 @@
   "scrollAdvances": 1000,
   "scrollModeVerified": true,
   "firstProgression": 0,
-  "lastProgression": 0.2288926094235829,
-  "progressionDelta": 0.2288926094235829,
-  "frameCount": 14166,
-  "jankFrames": 25,
-  "jankPercent": 0.17647889312438234,
+  "lastProgression": 0.23941640755800048,
+  "progressionDelta": 0.23941640755800048,
+  "frameCount": 28498,
+  "jankFrames": 65,
+  "jankPercent": 0.2280861814864201,
   "frameMsP50": 16.666666,
   "frameMsP90": 16.666666,
   "frameMsP99": 16.666666,
-  "frameMsMax": 83.33333,
-  "totalPssFirstKb": 298933,
-  "totalPssLastKb": 952536,
-  "totalPssMaxKb": 1045804,
-  "totalPssGrowthKb": 653603,
-  "rendererPssMaxKb": 853091,
-  "wallClockMs": 307550,
+  "frameMsMax": 49.999998,
+  "totalPssFirstKb": 293642,
+  "totalPssLastKb": 884749,
+  "totalPssMaxKb": 1287196,
+  "totalPssGrowthKb": 591107,
+  "rendererPssMaxKb": 1103928,
+  "wallClockMs": 545777,
   "mem": [
     {
       "chapter": 0,
-      "hostPssKb": 170205,
-      "rendererPssKb": 128728,
-      "totalPssKb": 298933,
-      "nativeHeapKb": 25417,
-      "processCount": 3
+      "hostPssKb": 166049,
+      "rendererPssKb": 127593,
+      "totalPssKb": 293642,
+      "nativeHeapKb": 24999,
+      "processCount": 2
     },
     {
       "chapter": 10,
-      "hostPssKb": 177395,
-      "rendererPssKb": 303464,
-      "totalPssKb": 480859,
-      "nativeHeapKb": 24767,
-      "processCount": 3
+      "hostPssKb": 179451,
+      "rendererPssKb": 338076,
+      "totalPssKb": 517527,
+      "nativeHeapKb": 25759,
+      "processCount": 2
     },
     {
       "chapter": 20,
-      "hostPssKb": 175764,
-      "rendererPssKb": 506459,
-      "totalPssKb": 682223,
-      "nativeHeapKb": 25570,
-      "processCount": 3
+      "hostPssKb": 170889,
+      "rendererPssKb": 753779,
+      "totalPssKb": 924668,
+      "nativeHeapKb": 25778,
+      "processCount": 2
     },
     {
       "chapter": 30,
-      "hostPssKb": 178978,
-      "rendererPssKb": 567902,
-      "totalPssKb": 746880,
-      "nativeHeapKb": 24829,
-      "processCount": 3
+      "hostPssKb": 171777,
+      "rendererPssKb": 809755,
+      "totalPssKb": 981532,
+      "nativeHeapKb": 25797,
+      "processCount": 2
     },
     {
       "chapter": 40,
-      "hostPssKb": 214404,
-      "rendererPssKb": 620731,
-      "totalPssKb": 835135,
-      "nativeHeapKb": 24879,
-      "processCount": 3
+      "hostPssKb": 180621,
+      "rendererPssKb": 915236,
+      "totalPssKb": 1095857,
+      "nativeHeapKb": 25096,
+      "processCount": 2
     },
     {
       "chapter": 50,
-      "hostPssKb": 192298,
-      "rendererPssKb": 643449,
-      "totalPssKb": 835747,
-      "nativeHeapKb": 24884,
-      "processCount": 3
+      "hostPssKb": 173939,
+      "rendererPssKb": 963618,
+      "totalPssKb": 1137557,
+      "nativeHeapKb": 25846,
+      "processCount": 2
     },
     {
       "chapter": 60,
-      "hostPssKb": 173494,
-      "rendererPssKb": 701805,
-      "totalPssKb": 875299,
-      "nativeHeapKb": 25625,
-      "processCount": 3
+      "hostPssKb": 178216,
+      "rendererPssKb": 968294,
+      "totalPssKb": 1146510,
+      "nativeHeapKb": 25876,
+      "processCount": 2
     },
     {
       "chapter": 70,
-      "hostPssKb": 165454,
-      "rendererPssKb": 726953,
-      "totalPssKb": 892407,
-      "nativeHeapKb": 24959,
-      "processCount": 3
+      "hostPssKb": 180206,
+      "rendererPssKb": 1014058,
+      "totalPssKb": 1194264,
+      "nativeHeapKb": 25893,
+      "processCount": 2
     },
     {
       "chapter": 80,
-      "hostPssKb": 168190,
-      "rendererPssKb": 756969,
-      "totalPssKb": 925159,
-      "nativeHeapKb": 24964,
-      "processCount": 3
+      "hostPssKb": 178522,
+      "rendererPssKb": 1023882,
+      "totalPssKb": 1202404,
+      "nativeHeapKb": 25192,
+      "processCount": 2
     },
     {
       "chapter": 90,
-      "hostPssKb": 169154,
-      "rendererPssKb": 790185,
-      "totalPssKb": 959339,
-      "nativeHeapKb": 24986,
-      "processCount": 3
+      "hostPssKb": 177839,
+      "rendererPssKb": 1078256,
+      "totalPssKb": 1256095,
+      "nativeHeapKb": 25902,
+      "processCount": 2
     },
     {
       "chapter": 100,
-      "hostPssKb": 192780,
-      "rendererPssKb": 820339,
-      "totalPssKb": 1013119,
-      "nativeHeapKb": 24898,
-      "processCount": 3
+      "hostPssKb": 175626,
+      "rendererPssKb": 1103339,
+      "totalPssKb": 1278965,
+      "nativeHeapKb": 25983,
+      "processCount": 2
     },
     {
       "chapter": 110,
-      "hostPssKb": 184750,
-      "rendererPssKb": 774521,
-      "totalPssKb": 959271,
-      "nativeHeapKb": 24908,
-      "processCount": 3
+      "hostPssKb": 178094,
+      "rendererPssKb": 1056269,
+      "totalPssKb": 1234363,
+      "nativeHeapKb": 25955,
+      "processCount": 2
     },
     {
       "chapter": 120,
-      "hostPssKb": 165894,
-      "rendererPssKb": 805385,
-      "totalPssKb": 971279,
-      "nativeHeapKb": 24979,
-      "processCount": 3
+      "hostPssKb": 175678,
+      "rendererPssKb": 1086650,
+      "totalPssKb": 1262328,
+      "nativeHeapKb": 25959,
+      "processCount": 2
     },
     {
       "chapter": 130,
-      "hostPssKb": 174074,
-      "rendererPssKb": 821513,
-      "totalPssKb": 995587,
-      "nativeHeapKb": 25010,
-      "processCount": 3
+      "hostPssKb": 183268,
+      "rendererPssKb": 1103928,
+      "totalPssKb": 1287196,
+      "nativeHeapKb": 25911,
+      "processCount": 2
     },
     {
       "chapter": 140,
-      "hostPssKb": 173014,
-      "rendererPssKb": 849217,
-      "totalPssKb": 1022231,
-      "nativeHeapKb": 25019,
-      "processCount": 3
+      "hostPssKb": 182737,
+      "rendererPssKb": 876974,
+      "totalPssKb": 1059711,
+      "nativeHeapKb": 25174,
+      "processCount": 2
     },
     {
       "chapter": 150,
-      "hostPssKb": 182834,
-      "rendererPssKb": 770631,
-      "totalPssKb": 953465,
-      "nativeHeapKb": 25643,
-      "processCount": 3
+      "hostPssKb": 178511,
+      "rendererPssKb": 875784,
+      "totalPssKb": 1054295,
+      "nativeHeapKb": 25532,
+      "processCount": 2
     },
     {
       "chapter": 160,
-      "hostPssKb": 196176,
-      "rendererPssKb": 800793,
-      "totalPssKb": 996969,
-      "nativeHeapKb": 24968,
-      "processCount": 3
+      "hostPssKb": 178615,
+      "rendererPssKb": 681904,
+      "totalPssKb": 860519,
+      "nativeHeapKb": 26050,
+      "processCount": 2
     },
     {
       "chapter": 170,
-      "hostPssKb": 190820,
-      "rendererPssKb": 829557,
-      "totalPssKb": 1020377,
-      "nativeHeapKb": 24962,
-      "processCount": 3
+      "hostPssKb": 189007,
+      "rendererPssKb": 874280,
+      "totalPssKb": 1063287,
+      "nativeHeapKb": 26038,
+      "processCount": 2
     },
     {
       "chapter": 180,
-      "hostPssKb": 180572,
-      "rendererPssKb": 763113,
-      "totalPssKb": 943685,
-      "nativeHeapKb": 25726,
-      "processCount": 3
+      "hostPssKb": 189277,
+      "rendererPssKb": 844222,
+      "totalPssKb": 1033499,
+      "nativeHeapKb": 25993,
+      "processCount": 2
     },
     {
       "chapter": 190,
-      "hostPssKb": 189030,
-      "rendererPssKb": 809547,
-      "totalPssKb": 998577,
-      "nativeHeapKb": 25733,
-      "processCount": 3
+      "hostPssKb": 191379,
+      "rendererPssKb": 891548,
+      "totalPssKb": 1082927,
+      "nativeHeapKb": 25287,
+      "processCount": 2
     },
     {
       "chapter": 200,
-      "hostPssKb": 196342,
-      "rendererPssKb": 828471,
-      "totalPssKb": 1024813,
-      "nativeHeapKb": 24955,
-      "processCount": 3
+      "hostPssKb": 188803,
+      "rendererPssKb": 785656,
+      "totalPssKb": 974459,
+      "nativeHeapKb": 26021,
+      "processCount": 2
     },
     {
       "chapter": 210,
-      "hostPssKb": 192713,
-      "rendererPssKb": 853091,
-      "totalPssKb": 1045804,
-      "nativeHeapKb": 25709,
-      "processCount": 3
+      "hostPssKb": 186580,
+      "rendererPssKb": 686510,
+      "totalPssKb": 873090,
+      "nativeHeapKb": 26044,
+      "processCount": 2
     },
     {
       "chapter": 220,
-      "hostPssKb": 191401,
-      "rendererPssKb": 764075,
-      "totalPssKb": 955476,
-      "nativeHeapKb": 24958,
-      "processCount": 3
+      "hostPssKb": 179778,
+      "rendererPssKb": 766196,
+      "totalPssKb": 945974,
+      "nativeHeapKb": 25966,
+      "processCount": 2
     },
     {
       "chapter": 230,
-      "hostPssKb": 181373,
-      "rendererPssKb": 789999,
-      "totalPssKb": 971372,
-      "nativeHeapKb": 24942,
-      "processCount": 3
+      "hostPssKb": 180533,
+      "rendererPssKb": 795852,
+      "totalPssKb": 976385,
+      "nativeHeapKb": 25985,
+      "processCount": 2
     },
     {
       "chapter": 240,
-      "hostPssKb": 185851,
-      "rendererPssKb": 840985,
-      "totalPssKb": 1026836,
-      "nativeHeapKb": 24955,
-      "processCount": 3
+      "hostPssKb": 189139,
+      "rendererPssKb": 592866,
+      "totalPssKb": 782005,
+      "nativeHeapKb": 25271,
+      "processCount": 2
     },
     {
       "chapter": 250,
-      "hostPssKb": 196471,
-      "rendererPssKb": 756065,
-      "totalPssKb": 952536,
-      "nativeHeapKb": 24960,
-      "processCount": 3
+      "hostPssKb": 186196,
+      "rendererPssKb": 698553,
+      "totalPssKb": 884749,
+      "nativeHeapKb": 26035,
+      "processCount": 2
     }
   ]
 }

--- a/spikes/android-reader-bench/build.gradle.kts
+++ b/spikes/android-reader-bench/build.gradle.kts
@@ -1,4 +1,11 @@
+// WI-2 bumps the toolchain to consume Readium-Kotlin 3.3.0: that AAR is built
+// with Kotlin 2.3.20 (binary metadata a 2.0.x compiler can't read) and targets
+// compileSdk 36, so the harness needs Kotlin >= 2.3.20 and an AGP that supports
+// API 36. We stay on the stable AGP 8.x line (8.13.2 — AGP >= 8.10 supports
+// compileSdk 36) rather than Readium's pinned AGP 9.0.0: AAR *consumption* only
+// requires the Kotlin-metadata + compileSdk + core-library-desugaring match, not
+// the producer's exact AGP. Gradle 8.14.4 (the pinned wrapper) supports AGP 8.13.
 plugins {
-    id("com.android.application") version "8.7.3" apply false
-    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+    id("com.android.application") version "8.13.2" apply false
+    id("org.jetbrains.kotlin.android") version "2.3.20" apply false
 }

--- a/spikes/android-reader-bench/gradle.properties
+++ b/spikes/android-reader-bench/gradle.properties
@@ -1,3 +1,3 @@
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 kotlin.code.style=official

--- a/spikes/android-reader-bench/run-bench.sh
+++ b/spikes/android-reader-bench/run-bench.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Spike B (#105) WI-2 — reproducible scroll-benchmark recipe (the
+# "minimally-automatable Android verification lane" the ADR calls for).
+# Instrumentation-first / NO UI automation: builds, installs, pushes the real
+# 1042-chapter CJK corpus, drives a deterministic chapter sweep in-process,
+# pulls metrics.json, and scans logcat for renderer crashes.
+#
+#   spikes/android-reader-bench/run-bench.sh                 # full 250-chapter sweep
+#   CHAPTERS=12 SCROLLS=2 spikes/android-reader-bench/run-bench.sh   # quick smoke
+#
+# Prereqs: an android-35+ emulator booted (adb device online), Android SDK +
+# JDK 17 on PATH (see /tmp/android-env.sh), and the corpus on the host at
+# $CORPUS (a real 1000+-spine CJK EPUB from the gitignored test-books/).
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+
+PKG="vreader.spike"
+RUNNER="$PKG.test/androidx.test.runner.AndroidJUnitRunner"
+DEVDIR="/sdcard/Android/data/$PKG/files"
+CHAPTERS="${CHAPTERS:-250}"
+SCROLLS="${SCROLLS:-4}"
+CORPUS="${CORPUS:-$REPO/test-books/books/epub/道诡异仙 - 狐尾的笔.epub}"
+OUT="${OUT:-/tmp/spikeB-metrics.json}"
+
+command -v adb >/dev/null || { echo "FAIL: adb not on PATH (source /tmp/android-env.sh)"; exit 1; }
+adb get-state >/dev/null 2>&1 || { echo "FAIL: no adb device (boot the emulator)"; exit 1; }
+[[ -f "$CORPUS" ]] || { echo "FAIL: corpus not found at $CORPUS"; exit 1; }
+
+echo "== build + install (app + androidTest) =="
+( cd "$HERE" && ./gradlew :app:assembleDebug :app:assembleDebugAndroidTest --console=plain --no-daemon ) || { echo "FAIL: build"; exit 1; }
+adb install -r "$HERE/app/build/outputs/apk/debug/app-debug.apk" >/dev/null || exit 1
+adb install -r "$HERE/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk" >/dev/null || exit 1
+
+echo "== push corpus =="
+adb shell mkdir -p "$DEVDIR" >/dev/null 2>&1
+adb push "$CORPUS" "$DEVDIR/corpus.epub" >/dev/null || { echo "FAIL: push corpus"; exit 1; }
+adb shell rm -f "$DEVDIR/metrics.json"
+adb logcat -c
+
+echo "== run sweep: $CHAPTERS chapters x $SCROLLS scrolls =="
+adb shell am instrument -w -e chapters "$CHAPTERS" -e scrollsPerChapter "$SCROLLS" \
+    -e class "$PKG.ReaderScrollBenchmark" "$RUNNER" 2>&1 | tee /tmp/spikeB-instrument.log
+
+echo "== pull metrics =="
+adb pull "$DEVDIR/metrics.json" "$OUT" >/dev/null 2>&1 || echo "warn: no metrics.json (test may have failed early)"
+
+echo "== renderer stability (logcat) =="
+CRASHES="$(adb logcat -d 2>/dev/null | grep -ciE 'FATAL EXCEPTION|render process (gone|crash)|chromium.*fatal')"
+echo "renderer-crash lines: $CRASHES"
+
+if grep -q "OK (1 test)" /tmp/spikeB-instrument.log && [[ "$CRASHES" -eq 0 ]]; then
+    echo "BENCH RESULT: PASS  (metrics: $OUT)"; exit 0
+else
+    echo "BENCH RESULT: FAIL"; exit 1
+fi

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -8089,7 +8089,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1009;
+				CURRENT_PROJECT_VERSION = 1010;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8097,7 +8097,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.24;
+				MARKETING_VERSION = 3.66.25;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -8243,7 +8243,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1009;
+				CURRENT_PROJECT_VERSION = 1010;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8251,7 +8251,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.24;
+				MARKETING_VERSION = 3.66.25;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
## Summary

- Instrumented scroll-sweep benchmark over the **real 1042-chapter 道诡异仙 CJK EPUB** via Readium-Kotlin 3.3.0, hosting the EPUB navigator in **scroll mode in-process** (no UI automation — ADR-0001 R2). Records frame timing, renderer-aware memory trajectory, and renderer stability over a 250-chapter sweep.
- **De-risks ADR-0001 Risk-2** (large-CJK WebView scroll/memory/eviction) with a measured, audit-hardened verdict — not an assumption.
- Toolchain bumped to consume Readium 3.3.0: **AGP 8.13.2 / Kotlin 2.3.20 / compileSdk 36 + core-library-desugaring** (Readium AARs carry Kotlin-2.3.20 metadata + API-36 refs). Stays on the stable AGP 8.x line, not Readium's pinned AGP 9.0.0 — AAR consumption only needs metadata+SDK+desugaring.

Part of feature #1703 (Android port Spike B).

## Authoritative baseline (250 chapters, android-35 arm64 emulator)

| Leg | Result | Verdict |
|---|---|---|
| Scroll smoothness | 28.5k motion-bounded frames, **0.23% jank**, p50/p90/p99 16.67ms (60fps), max 50ms | ✅ |
| Renderer memory / eviction | ramps to **~1.1GB high-water** by ch~90–130 then **evicts down to 580–870MB oscillation** (bounded, not monotonic), peak total ~1.29GB, zero OOM | ✅ bounded; ~1.1GB high-water is a low-RAM-device hardening obligation for WI-4 |
| Renderer stability | 0 crashes, 0 render-process-gone | ✅ |
| Scroll mode | `navigator.settings.scroll == true` (authoritative), progression delta 0.239 | ✅ |

Baseline: `spikes/android-reader-bench/baselines/scroll-sweep-250-emulator-20260617.json`. Reproduce: `spikes/android-reader-bench/run-bench.sh`.

## Codex Audit (Gate-4)

**3 rounds, verdict ship-as-is.** The audit drove the measurement from plausible to *sound*:
- R1 (Critical+2High+2Med+Low): scroll-mode verification, **renderer-process memory** (host-only hid a ~780MB renderer), resource close.
- R2 (2 High): frame window bounded by **locator stabilization** (not a fixed timer); renderer attribution via **baseline-PID diff**.
- R3 (1 Medium): `processCount<=2` attribution invariant — a contaminated run fails.

Audit log: `.claude/codex-audits/feat-feature-105-wi2-scroll-bench-audit.md`

## Validation

- [x] Full 250-chapter sweep PASSED on `vreader-test` AVD (`OK (1 test)`, 549s) with all validity guards (scroll mode, real progression, renderer captured, bounded memory)
- [x] Codex Gate-4: 3 rounds, ship-as-is
- [x] No machine-local leakage (no `local.properties`, `build/`, device `metrics.json`, or absolute paths)
- [x] Version bumped: 3.66.24 → 3.66.25 (spikes/ pre-Phase-2 bumps iOS per rule 40)

## Type of Change

- [x] Android port spike (Spike B WI-2; instrumentation-first benchmark)
