### PR TITLE
feat(#107 PR-B): Android test/verify runners + ghost-sweep

### DIFF
--- a/.claude/codex-audits/feat-feature-107-prb-android-runners-audit.md
+++ b/.claude/codex-audits/feat-feature-107-prb-android-runners-audit.md
@@ -1,0 +1,54 @@
+---
+branch: feat/feature-107-prb-android-runners
+threadId: 019ed6e2-4175-75b3-a66d-e262bd0fd3e0
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-06-18
+---
+
+# Gate-4 audit — feature #107 PR-B (Android test/verify runners + ghost sweep)
+
+PR-B adds `scripts/run-android-tests.sh` (watchdog runner) + `run-android-verify.sh`
+(delegate) + a real-process contract test, extends `scripts/sweep-ghosts.sh` for
+Android ghost classes, and adds rule-52 "Cause D" + watchdog.md Android notes.
+
+`scripts/`+`.claude/` is `shared` (not `code_paths_touched`), so the merge hook
+doesn't require this log — recorded for Gate-4 discipline. Codex (gpt-5.4, high),
+3 rounds. Sessions: r1 `019ed6e2-…`, r2 `019ed6e6-…`, r3 `019ed6e9-…`.
+
+## Round 1 — 1 High + 2 Medium (+ a pre-launch latent watchdog fd bug found by the contract test)
+
+| file | sev | issue | resolution |
+|---|---|---|---|
+| run-android-tests.sh | High | `pkill -9 -f org.gradle.launcher.daemon` is machine-global — could kill another repo's resident daemon. | Snapshot `PRE_DAEMONS` before launch; on timeout kill ONLY new daemons via `comm -13` diff (a run that connects to a pre-existing daemon leaves it alone). |
+| run-android-tests.sh | Medium | "kill the process tree" was direct-children-only (`pkill -P`); a `bash -c` wrapper can orphan deeper descendants. | Recursive `kill_tree()` (pgrep -P recursion; no setsid — absent on macOS). |
+| run-android-tests.sh | Medium | `adb get-state` ≠ booted-emulator detection (passes for a physical device; errors on multiple devices). | `emulator_online()` parses `adb devices` for an `emulator-NNNN … device` line. |
+| (pre-audit, found by the contract test) | — | The watchdog subshell's backgrounded `sleep` held the captured stdout fd → a `$(...)` caller blocked until TIMEOUT. | Watchdog redirected to the LOG + `pkill -P "$wd"` kills its sleep child on cancel. |
+
+## Round 2 — 1 new Medium (race I introduced)
+
+| file | sev | issue | resolution |
+|---|---|---|---|
+| run-android-tests.sh | Medium | The parent cancelled the watchdog after `wait $pid`, which on timeout returns the instant `kill_tree` lands — interrupting the watchdog's Gradle-daemon cleanup. | A `FIRED` sentinel (`mktemp -u`) the watchdog touches BEFORE `kill_tree`; the parent `wait "$wd"` (lets cleanup finish) when FIRED exists, else cancels the still-sleeping watchdog. FIRED is the authoritative TIMEOUT signal; removed on every exit. |
+
+Round 2 confirmed the 3 round-1 findings resolved.
+
+## Round 3 — CLEAN
+
+"No new Critical/High/Medium findings. The round-2 race is resolved." Confirmed:
+the sentinel is set before the kill that unblocks `wait $pid` (race-free); FIRED
+is removed on every exit + the temp name is fresh per run (no stale read); the
+timeout-path `wait $wd` cannot hang (bounded local cleanup). Only a Low
+`mktemp -u` TOCTOU note (acceptable for a local watchdog).
+
+## Validation
+
+`scripts/__tests__/run-android-tests.test.sh` — ALL PASS (SUCCEEDED / FAILED /
+TIMEOUT-killed-in-2s / NO_EMULATOR, via real-process ANDROID_CMD stubs).
+`sweep-ghosts.sh` syntax OK + CLEAN. verify.sh delegates correctly.
+
+## Verdict
+
+**ship-as-is.** 3-round real Codex audit; the rule-49/52/53-compliant Android
+runner + ghost-sweep are sound (scoped daemon kill, recursive tree kill, real
+emulator detection, race-free timeout).

--- a/.claude/cron-prompts/watchdog.md
+++ b/.claude/cron-prompts/watchdog.md
@@ -34,13 +34,26 @@ WATCHDOG: keep every session-only cron alive past the 7-day auto-expire AND swee
    - **ETIME 10 minutes – 1 hour**: log as `suspicious` in `.claude/cron-logs/watchdog.log` (PID, command, age). Do NOT kill — the operator may be running a long test on purpose.
    - **ETIME > 1 hour**: log as `ghost` AND kill with `kill <pid>` (TERM, not KILL-9). If still alive after 5 s, escalate to `kill -9 <pid>`. Print every kill action to stdout so it surfaces in cron telemetry.
 
-7. Also scan for stale `xcodebuild test` or `xcrun simctl` processes that have been running > 30 min — these can also become orphaned across sessions:
+7. Also scan for stale iOS **and Android** tool ghosts (> 30 min). Prefer the
+   maintained sweeper, which already classifies every ghost class (iOS + Android)
+   and excludes the resident daemons (SWBBuildService / Gradle daemon / booted
+   emulator / idb_companion):
 
    ```bash
-   ps -eo pid,etime,command | grep -E "xcodebuild test|xcrun simctl" | grep -v grep
+   scripts/sweep-ghosts.sh           # report; --kill to reap; THRESHOLD_MIN to tune
+   ```
+
+   If running the raw `ps` instead, cover both platforms (rule 52 Cause D adds the
+   Android classes — wedged `am instrument`, orphaned `gradle` build, detached
+   `adb … logcat`):
+
+   ```bash
+   ps -eo pid,etime,command | grep -E "xcodebuild test|xcrun simctl|am instrument|adb .*logcat|org.gradle.launcher.daemon" | grep -v grep
    ```
 
    Same decision matrix as step 6 (skip < 10 min, suspicious 10–60 min, ghost > 1h).
+   Do NOT kill a healthy idle Gradle daemon or a booted emulator (resident by
+   design — `sweep-ghosts.sh` already excludes them).
 
 ## Part 3 — Outcome
 

--- a/.claude/rules/52-test-sim-isolation.md
+++ b/.claude/rules/52-test-sim-isolation.md
@@ -61,6 +61,31 @@ scripts/run-tests.sh vreaderTests/DebugCommandTests
 TIMEOUT_SECS=2400 scripts/run-tests.sh vreaderTests
 ```
 
+### Cause D — Android: wedged Gradle daemon / emulator contention (feature #107)
+
+The Android lane has the same ghost-class shapes as iOS, with Android tools:
+
+- **Gradle daemon = the SWBBuildService analog.** A `kill -9` of a hung `gradle`
+  orphans the resident Gradle daemon in a wedged state, hanging the NEXT build.
+  `scripts/run-android-tests.sh`'s watchdog kills the daemon
+  (`org.gradle.launcher.daemon` / `GradleDaemon`) on timeout, same as the iOS
+  runner clears `SWBBuildService`. A *healthy idle* Gradle daemon (and a booted
+  emulator) is resident-by-design — `scripts/sweep-ghosts.sh` excludes both, and
+  flags only a wedged `am instrument` or a detached `adb … logcat` capture.
+- **Emulator contention = simulator contention.** Driving the SAME emulator
+  (`adb` / `am instrument` / screenshots) while an instrumentation run is in
+  flight wedges it. Serialize, or use a second emulator (AVD).
+- **Always run the Android gate through `scripts/run-android-tests.sh`** (the
+  Android `run-tests.sh`): hard wall-clock timeout, exact-pid wait (rule 49),
+  kills the process tree + Gradle daemon on timeout, prints one
+  `RUN-ANDROID-TESTS RESULT:` line. The verify lane is `scripts/run-android-verify.sh`.
+  Until #106's app shell exists, these drive the `spikes/` harness.
+
+```bash
+scripts/run-android-tests.sh                 # spike-harness smoke (needs a booted emulator)
+ANDROID_CMD="./gradlew :app:testDebugUnitTest" scripts/run-android-tests.sh   # post-#106
+```
+
 ## Hard rules
 
 1. **Never drive a simulator while `xcodebuild test` runs against it.** Tests and

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 1024
-        MARKETING_VERSION: 3.66.40
+        CURRENT_PROJECT_VERSION: 1025
+        MARKETING_VERSION: 3.66.41
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/scripts/__tests__/run-android-tests.test.sh
+++ b/scripts/__tests__/run-android-tests.test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Feature #107 PR-B — exercises the watchdog/RESULT-line CONTRACT of
+# scripts/run-android-tests.sh with REAL processes (via ANDROID_CMD stubs), not
+# a dry-run of the Android lane. Asserts the four RESULT outcomes + that a wedged
+# command is actually killed by the watchdog (rule 49/52/53).
+#
+# Run: bash scripts/__tests__/run-android-tests.test.sh
+
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN="$HERE/../run-android-tests.sh"
+fails=0
+
+# assert_result <expected RESULT substring> <expected exit> <description> -- <env assignments...>
+assert_result() {
+    local want_result="$1" want_exit="$2" desc="$3"; shift 3
+    [ "$1" = "--" ] && shift
+    local out rc
+    out="$(env "$@" bash "$RUN" 2>&1)"; rc=$?
+    if grep -q "$want_result" <<<"$out" && [ "$rc" -eq "$want_exit" ]; then
+        echo "ok   — $desc (exit $rc)"
+    else
+        echo "FAIL — $desc: want '$want_result'/exit $want_exit, got exit $rc:"; echo "$out" | tail -3; fails=$((fails+1))
+    fi
+}
+
+echo "== run-android-tests.sh watchdog contract =="
+assert_result "RUN-ANDROID-TESTS RESULT: SUCCEEDED" 0 "ANDROID_CMD=true → SUCCEEDED" -- ANDROID_CMD="true"
+assert_result "RUN-ANDROID-TESTS RESULT: FAILED"    1 "ANDROID_CMD=false → FAILED"   -- ANDROID_CMD="false"
+
+# TIMEOUT: a 30s sleep with a 2s deadline must be killed and report TIMEOUT in ~2s.
+echo "   (timing the watchdog kill...)"
+start=$(date +%s 2>/dev/null || echo 0)
+assert_result "RUN-ANDROID-TESTS RESULT: TIMEOUT"   3 "wedged cmd → TIMEOUT (killed)" -- ANDROID_CMD="sleep 30" TIMEOUT_SECS="2"
+end=$(date +%s 2>/dev/null || echo 0)
+if [ "$start" != 0 ] && [ $((end - start)) -le 10 ]; then
+    echo "ok   — watchdog killed the wedged run promptly ($((end - start))s)"
+else
+    echo "FAIL — watchdog did not kill promptly ($((end - start))s)"; fails=$((fails+1))
+fi
+
+# NO_EMULATOR: the default (spike) command requires an online emulator. When
+# none is online (the common CI / dev case here), the runner short-circuits.
+if ! command -v adb >/dev/null 2>&1 || [ "$(adb get-state 2>/dev/null)" != "device" ]; then
+    assert_result "RUN-ANDROID-TESTS RESULT: NO_EMULATOR" 2 "no emulator + default cmd → NO_EMULATOR" --
+else
+    echo "skip — NO_EMULATOR case (an emulator is online)"
+fi
+
+echo
+if [ "$fails" -eq 0 ]; then echo "ALL PASS"; exit 0; else echo "$fails FAILURE(S)"; exit 1; fi

--- a/scripts/run-android-tests.sh
+++ b/scripts/run-android-tests.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Purpose: Watchdog wrapper for Android test / instrumentation runs — the
+# Android analog of scripts/run-tests.sh. Feature #107 PR-B.
+#
+# Guarantees (rule 49 / 52 / 53):
+#  - HARD wall-clock timeout: a wedged run is killed (process tree + the Gradle
+#    daemon — rule 52 "Cause D", the Android analog of SWBBuildService) after
+#    TIMEOUT_SECS instead of ghosting indefinitely.
+#  - Waits on the EXACT pid (rule 49 — identity, not likeness). One job, one
+#    owner, one completion channel; the watchdog is cancelled the instant the
+#    run finishes, so it never outlives this invocation.
+#  - Emits ONE unambiguous final line:
+#    "RUN-ANDROID-TESTS RESULT: SUCCEEDED|FAILED|TIMEOUT|NO_EMULATOR".
+#
+# Target: until feature #106's `android/` app shell exists there is NO root
+# `./gradlew` — the only real Android target is the Spike-B harness, so this
+# runner drives THAT by default (a small CHAPTERS smoke). Once #106 lands, point
+# it at the app's Gradle task via ANDROID_CMD.
+#
+# Usage:
+#   scripts/run-android-tests.sh                          # spike harness smoke
+#   ANDROID_CMD="./gradlew :app:testDebugUnitTest" scripts/run-android-tests.sh   # post-#106
+#   ANDROID_CMD="true" scripts/run-android-tests.sh       # contract self-test
+#   TIMEOUT_SECS=600 scripts/run-android-tests.sh
+#
+# IMPORTANT (rule 52): do NOT drive the SAME emulator (adb/am instrument/
+# screenshots) while this runs — contention is what wedges Gradle/instrumentation.
+set -uo pipefail
+
+TIMEOUT_SECS="${TIMEOUT_SECS:-1200}"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Default target = the Spike-B harness (a real emulator instrumentation run); a
+# small smoke by default so the runner self-verifies cheaply. When the caller
+# overrides ANDROID_CMD they own device readiness, so we only require an online
+# emulator for the DEFAULT (spike) command.
+if [ -n "${ANDROID_CMD:-}" ]; then
+  CMD="$ANDROID_CMD"
+  REQUIRE_EMULATOR=0
+else
+  CMD="CHAPTERS=${CHAPTERS:-6} SCROLLS=${SCROLLS:-1} bash \"$REPO/spikes/android-reader-bench/run-bench.sh\""
+  REQUIRE_EMULATOR=1
+fi
+
+# Real "booted emulator" detection (Codex Gate-4): `adb get-state` is not it —
+# it passes for a physical device and errors with multiple devices. Require an
+# `emulator-NNNN` serial in `device` state.
+emulator_online() {
+  command -v adb >/dev/null 2>&1 || return 1
+  adb devices 2>/dev/null | awk '/^emulator-[0-9]+[[:space:]]+device$/ {f=1} END {exit !f}'
+}
+if [ "$REQUIRE_EMULATOR" -eq 1 ] && ! emulator_online; then
+  echo "RUN-ANDROID-TESTS RESULT: NO_EMULATOR (no emulator-NNNN device online — boot an AVD or pass ANDROID_CMD)"
+  exit 2
+fi
+
+# Recursively kill a process + ALL descendants (Codex Gate-4: pkill -P is
+# direct-children-only; a `bash -c` wrapper can leave deeper orphans). Portable
+# (pgrep -P), no setsid (absent on macOS).
+kill_tree() {
+  local p="$1" c
+  for c in $(pgrep -P "$p" 2>/dev/null); do kill_tree "$c"; done
+  kill -9 "$p" 2>/dev/null
+}
+# Snapshot pre-existing Gradle daemons so a timeout kill targets ONLY daemons
+# THIS run spawned (Codex Gate-4: a global `pkill -f org.gradle…` could kill an
+# unrelated repo's resident daemon). A run that connects to a pre-existing
+# daemon leaves it alone — correct, it's resident-by-design.
+gradle_daemons() { pgrep -f 'org.gradle.launcher.daemon|GradleDaemon' 2>/dev/null | sort -u; }
+PRE_DAEMONS="$(gradle_daemons || true)"
+
+LOG="$(mktemp -t run-android-tests.XXXXXX)"
+# Sentinel the watchdog touches BEFORE it starts killing — distinguishes a
+# real timeout from normal completion so the parent does not cancel the
+# watchdog mid-cleanup (Codex Gate-4 r2: the daemon diff/kill must finish).
+FIRED="$(mktemp -u -t run-android-fired.XXXXXX)"
+echo "[run-android-tests] cmd=$CMD timeout=${TIMEOUT_SECS}s log=$LOG"
+
+bash -c "$CMD" >"$LOG" 2>&1 &
+pid=$!
+
+# Watchdog tied to THIS pid only (rule 49). On timeout: recursive tree kill +
+# kill ONLY Gradle daemons spawned during this run (a wedged new daemon would
+# hang the NEXT build — rule 52 Cause D — but a pre-existing one is left alone).
+# The subshell is redirected to the LOG (not this script's stdout); otherwise
+# its backgrounded `sleep` keeps the stdout fd open and a `$(...)` caller blocks
+# until TIMEOUT_SECS even after the run finished. On cancel we kill the subshell
+# AND its sleep child so nothing lingers (rule 49).
+(
+  sleep "$TIMEOUT_SECS"
+  if kill -0 "$pid" 2>/dev/null; then
+    : > "$FIRED"   # mark timeout BEFORE the kill that unblocks the parent's wait
+    echo "[run-android-tests][watchdog] exceeded ${TIMEOUT_SECS}s — killing tree of $pid + this run's Gradle daemon(s)"
+    kill_tree "$pid"
+    post="$(gradle_daemons || true)"
+    new="$(comm -13 <(printf '%s\n' "$PRE_DAEMONS") <(printf '%s\n' "$post") 2>/dev/null)"
+    [ -n "$new" ] && printf '%s\n' "$new" | xargs kill -9 2>/dev/null
+  fi
+) >>"$LOG" 2>&1 &
+wd=$!
+
+wait "$pid"; rc=$?
+if [ -e "$FIRED" ]; then
+  # Timeout fired — the sentinel was set BEFORE kill_tree, so it exists by the
+  # time `wait $pid` returns. Let the watchdog FINISH its daemon cleanup; do not
+  # cancel it mid-flight (Codex Gate-4 r2).
+  wait "$wd" 2>/dev/null
+else
+  # Normal completion — cancel the still-sleeping watchdog + its sleep child.
+  pkill -P "$wd" 2>/dev/null
+  kill "$wd" 2>/dev/null
+  wait "$wd" 2>/dev/null
+fi
+
+echo "----- last log lines -----"
+tail -12 "$LOG"
+echo "--------------------------"
+
+if [ -e "$FIRED" ]; then
+  rm -f "$FIRED"
+  echo "RUN-ANDROID-TESTS RESULT: TIMEOUT (killed after ${TIMEOUT_SECS}s — emulator likely contended; do not drive it during a run)"
+  exit 3
+elif [ "$rc" -eq 0 ]; then
+  rm -f "$FIRED"
+  echo "RUN-ANDROID-TESTS RESULT: SUCCEEDED"
+  exit 0
+else
+  rm -f "$FIRED"
+  echo "RUN-ANDROID-TESTS RESULT: FAILED (exit $rc)"
+  exit 1
+fi

--- a/scripts/run-android-verify.sh
+++ b/scripts/run-android-verify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Purpose: Watchdog wrapper for the Android emulator VERIFY lane (Gate-5 Android
+# tier) — the Android analog of driving the iOS simulator for verification.
+# Feature #107 PR-B.
+#
+# Thin delegate over scripts/run-android-tests.sh (one watchdog implementation,
+# rule 49/52/53). Until feature #106's app exists, the real emulator-verify
+# target is the Spike-B instrumentation harness, so this drives a verification
+# sweep through it by default; once #106 lands, point it at
+# `connectedAndroidTest` / `am instrument` via ANDROID_CMD.
+#
+# Usage:
+#   scripts/run-android-verify.sh                                  # spike emulator sweep
+#   ANDROID_CMD="./gradlew :app:connectedDebugAndroidTest" scripts/run-android-verify.sh   # post-#106
+#   TIMEOUT_SECS=1800 scripts/run-android-verify.sh
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# A fuller sweep than the test smoke (more chapters) — verification, not a unit
+# smoke. Caller can override ANDROID_CMD for the post-#106 connected-test lane.
+if [ -z "${ANDROID_CMD:-}" ]; then
+  export CHAPTERS="${CHAPTERS:-24}" SCROLLS="${SCROLLS:-2}"
+fi
+# Verify runs are longer than unit smokes.
+export TIMEOUT_SECS="${TIMEOUT_SECS:-1800}"
+
+# Delegate to the single watchdog implementation (preserves live streaming + the
+# exact exit code). The RESULT line is RUN-ANDROID-TESTS RESULT: …; the verify
+# lane reuses it (the caller knows which script it invoked). exec keeps one
+# process / one completion channel (rule 49).
+exec bash "$REPO/scripts/run-android-tests.sh"

--- a/scripts/sweep-ghosts.sh
+++ b/scripts/sweep-ghosts.sh
@@ -12,10 +12,14 @@
 #   - `codex` / `codex exec`      rule 53 — stdin-wedge (origin: 4h20m ghost,
 #                                  2026-06-01)
 #   - `xcodebuild test|build`     rule 52 — sim contention / wedged daemon
+#   - `am instrument`             rule 52 Cause D — wedged Android instrumentation
+#   - `adb … logcat`              rule 49 — detached logcat side-channel capture
 #                                  (recurring; watchdogged by run-tests.sh)
 #
 # NOT flagged: SWBBuildService (Xcode's resident build daemon — alive and
-# idle between builds by design), idb_companion (persistent sim bridge),
+# idle between builds by design), the Gradle daemon + a booted Android
+# emulator (resident-by-design, rule 52 Cause D), idb_companion (persistent
+# sim bridge),
 # and anything younger than the threshold or actually using CPU.
 #
 # Usage:
@@ -51,11 +55,16 @@ ghosts=$(ps -Ao pid=,etime=,pcpu=,command= | awk -v thr="$THRESHOLD_MIN" '
         cmd = ""
         for (i = 4; i <= NF; i++) cmd = cmd (i > 4 ? " " : "") $i
     }
-    cmd ~ /(ps -Ao|ugrep|sweep-ghosts|idb_companion|SWBBuildService)/ { next }
+    # Resident-by-design daemons are NEVER ghosts: Xcode SWBBuildService, the sim
+    # bridge idb_companion, the Gradle daemon (alive + idle between builds — rule
+    # 52 Cause D), and a booted Android emulator (qemu/emulator — like a booted
+    # simulator). The sweep ps/ugrep pipeline is excluded too.
+    cmd ~ /(ps -Ao|ugrep|sweep-ghosts|idb_companion|SWBBuildService|GradleDaemon|org\.gradle\.launcher\.daemon|qemu-system|emulator64|\/emulator )/ { next }
     {
         otherClass = (cmd !~ /( grep | awk )/) && \
             (cmd ~ /tail -f/ || cmd ~ /log stream/ || \
-             cmd ~ /(^|\/)codex( |$)/ || cmd ~ /xcodebuild (test|build)/)
+             cmd ~ /(^|\/)codex( |$)/ || cmd ~ /xcodebuild (test|build)/ || \
+             cmd ~ /am instrument/ || cmd ~ /adb .*logcat/)
         waiterClass = (cmd ~ /(until|while) .*do sleep [0-9]/)
     }
     otherClass || waiterClass {

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -8109,7 +8109,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1024;
+				CURRENT_PROJECT_VERSION = 1025;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8117,7 +8117,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.40;
+				MARKETING_VERSION = 3.66.41;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -8263,7 +8263,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1024;
+				CURRENT_PROJECT_VERSION = 1025;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8271,7 +8271,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.40;
+				MARKETING_VERSION = 3.66.41;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
## Summary

PR-B of feature #107. The rule-49/52/53-compliant Android runner the workflow needs:
- `scripts/run-android-tests.sh` — watchdog-wrapped (hard timeout, **recursive** tree kill, **scoped** Gradle-daemon kill via snapshot/diff — never global, real `emulator-NNNN` detection, **race-free** timeout via a sentinel; one `RUN-ANDROID-TESTS RESULT:` line). Drives the `spikes/` harness until #106's app exists; `ANDROID_CMD` overrides.
- `scripts/run-android-verify.sh` — exec delegate (verify lane).
- `scripts/__tests__/run-android-tests.test.sh` — exercises SUCCEEDED/FAILED/TIMEOUT/NO_EMULATOR with **real processes**.
- `scripts/sweep-ghosts.sh` — adds `am instrument` / `adb logcat` ghost classes; excludes the resident Gradle daemon + booted emulator.
- rule 52 "Cause D" + `watchdog.md` Android ghosts.

Part of feature #1732.

## Codex Audit

Real Codex, **3 rounds, ship-as-is**. R1: 1 High (global daemon kill) + 2 Medium (tree-kill depth, emulator detection) — fixed via snapshot-diff / recursive kill_tree / `adb devices` parse. R2: 1 Medium (watchdog-cancel race) — fixed with a `FIRED` sentinel. R3 clean. Log: `.claude/codex-audits/feat-feature-107-prb-android-runners-audit.md`.

## Validation

- [x] `run-android-tests.test.sh` — ALL PASS (TIMEOUT killed in 2s)
- [x] `sweep-ghosts.sh` syntax + CLEAN; verify.sh delegates correctly
- [x] Version bumped: 3.66.40 → 3.66.41 (`scripts/`/`.claude/` is `shared` → iOS bump, rule 40)

## Type of Change

- [x] Tooling WI; part of feature #1732