### PR TITLE
docs(#107 PR-C): Kotlin TDD + Compose conventions + Gate-5 Android tier

### DIFF
--- a/.claude/rules/10-tdd.md
+++ b/.claude/rules/10-tdd.md
@@ -205,6 +205,34 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
 
 The TDD Guardian config at `.claude/tdd-guardian/config.json` invokes the same `xcodebuild test` flow.
 
+## Android / Kotlin TDD (feature #107 — the workflow can drive Android)
+
+The RED→GREEN→REFACTOR discipline is platform-neutral; only the framework + run
+command differ. **Android tests run through `scripts/run-android-tests.sh`** (the
+Android `run-tests.sh` — watchdog-wrapped, rule 49/52/53), NEVER a bare
+`./gradlew test` (a wedged Gradle daemon ghosts like `xcodebuild` does — rule 52
+Cause D).
+
+| Layer | Framework | Pattern |
+| --- | --- | --- |
+| Pure Kotlin / domain / mappers | **JUnit5** (`@Test`, `assertEquals`) or **Kotest** | the Swift-Testing analog — value types, parameterized (`@ParameterizedTest`), no Android deps |
+| Repos / Room / coroutines | JUnit5 + `runTest` + an **in-memory Room** db (`Room.inMemoryDatabaseBuilder`) | the `PersistenceActor` analog: in-memory store per test, `kotlinx-coroutines-test` `StandardTestDispatcher`, no real I/O |
+| ViewModels / state | JUnit5 + `runTest` + a fake repo (interface boundary) | assert observable `StateFlow`/`State`, not internals; `Turbine` for flow assertions |
+| Compose UI | **`createComposeRule()`** (Robolectric for JVM, or instrumented) | test behavior (clicks, semantics, state) — not pixels; the SwiftUI-view analog |
+| Reader / WebView bridges | unit-test the message parser / JS-escaping / locator math | not the WKWebView/Android-WebView interaction itself |
+
+```bash
+# Until #106's app shell exists, the only real Android target is the spike
+# harness; once it lands, point the runner at the app's Gradle task:
+scripts/run-android-tests.sh                                  # spike-harness smoke
+ANDROID_CMD="./gradlew :app:testDebugUnitTest" scripts/run-android-tests.sh
+ANDROID_CMD="./gradlew :app:test --tests '*MapperTest'" scripts/run-android-tests.sh
+```
+
+Edge cases are not optional on Android either — empty/null, max values, CJK/RTL,
+config changes (rotation / process death → `SavedStateHandle`), coroutine
+cancellation, and Room migration round-trips (the SwiftData-migration analog).
+
 ## File Placement
 
 - Tests go next to the production code, mirroring the source tree:

--- a/.claude/rules/47-feature-workflow.md
+++ b/.claude/rules/47-feature-workflow.md
@@ -88,6 +88,11 @@ For each PR before it merges:
 
 Record slice verification in the PR description (what was run, what was observed). Record final acceptance verification in a structured evidence file at `dev-docs/verification/feature-<id>-<YYYYMMDD>.md` per the schema in `dev-docs/verification/SCHEMA.md`. The PreToolUse hook `.claude/hooks/check_terminal_status_evidence.sh` blocks any tracker edit that flips a row to `VERIFIED` (features) or `FIXED` (bugs) without a matching evidence file.
 
+**Android tier (feature #107)** — the platform-router (`code_paths_platform`) picks the lane:
+- **iOS WIs**: iPhone 17 Pro Simulator + `vreader-debug://` harness, as above.
+- **Android WIs** (`android-app` / `android-spike`): verify on a booted **Android emulator** (AVD, android-35+) via `scripts/run-android-verify.sh` (the emulator analog of driving the simulator — rule 49/52/53). The CU-free instrumentation lane is the Spike-B `am instrument` pattern (#104/#105 precedent); the evidence file's `device_or_simulator` records the AVD (e.g. "Pixel 7 API 35 emulator"). Until #106's app shell exists, the only Android target is the `spikes/` harness, so Android-app Gate-5 is itself blocked on #106; pre-#106 Android work is spike/tooling (no device-verify, like a foundational WI).
+- **Shared WIs** route to the iOS lane (rule 40 — shared is iOS while Android is pre-foundation).
+
 **Acceptance bar per PR**: every behavioral slice in the PR has been verified end-to-end at the level appropriate to its WI tier. Final WI requires full acceptance pass + evidence file.
 
 **"Tooling unavailable" is NOT an acceptable deferral reason** unless a specific tool is named and confirmed missing (e.g., `xcrun simctl` returns "command not found", a real device is required and none is connected, the rclone WebDAV server is down). "I'll do it next session" is not a tool-unavailability claim — it's a discipline lapse. The Stop hook (`.claude/hooks/check_unfinished_verification.sh`) surfaces unverified `DONE` rows at session end so the gap doesn't quietly carry over.

--- a/.claude/rules/50-codebase-conventions.md
+++ b/.claude/rules/50-codebase-conventions.md
@@ -180,3 +180,41 @@ final class DebugFoo { ... }
 ```
 
 Don't `#if DEBUG` individual lines inside otherwise-production code unless a single line genuinely needs it.
+
+## 12. Android / Kotlin + Compose conventions (feature #107)
+
+Sections 1–11 above are the **iOS/Swift** conventions. The Android app (`android/`,
+landing in #106) is a second native app — these are its analogs, so a Kotlin PR
+reads like the Swift one. Source of truth for the port strategy:
+`docs/decisions/0001-android-port-strategy.md`.
+
+1. **Concurrency** — Kotlin coroutines + structured concurrency are the
+   actor/`@MainActor` analog. Repos/use-cases run on an injected
+   `CoroutineDispatcher` (never hardcode `Dispatchers.IO`); UI state is updated on
+   `Dispatchers.Main`. Expose `StateFlow`/`SharedFlow`, collect with
+   `repeatOnLifecycle`. No `GlobalScope`; scope to `viewModelScope` /
+   lifecycle.
+2. **Persistence** — **Room** is the SwiftData analog. DAOs are the CRUD seam
+   (the `PersistenceActor+Foo` analog); return value-type DTOs / domain models
+   from the repository, not `@Entity` rows, across boundaries. Schema-versioned
+   `Migration`s mirror `VReaderMigrationPlan`; an additive column is a lightweight
+   `Migration`, a data transform is a custom one (cf. feature #108/#109 lessons).
+3. **Reader** — EPUB via **Readium-Kotlin** (decided viable by Spike B #105),
+   Kindle/native via the legacy-compat path; one Compose host per format, the
+   `ReaderContainerView` dispatcher analog.
+4. **UI** — **Jetpack Compose**, unidirectional data flow: a ViewModel owns
+   `StateFlow<UiState>`, the composable is a pure function of state + emits events.
+   Hoist state; `@Composable` previews for designed surfaces only (rule 51 still
+   binds — UI from claude.ai/design, no self-invented Compose screens).
+5. **DI** — constructor injection at boundaries (interfaces, so tests mock the
+   boundary — the `LibraryPersisting` analog). Hilt/Koin module wiring at the app
+   edge, not in domain code.
+6. **Errors** — sealed `Result`/domain error types with a `userMessage`, the Swift
+   `enum … : Error { var userMessage }` analog; never swallow silently.
+7. **Logging** — the platform `Logger`/Timber, namespaced like the OSLog
+   categories; no bare `println` in production.
+8. **Files** — package-by-feature under `android/app/src/main/java/...`, mirror the
+   `vreader/Services/<Name>/` layout; keep files focused (~300 lines).
+
+Cross-platform identity/locator/backup/schema stay **contract-bound**
+(`contracts/`); only those surfaces require strict iOS↔Android parity (ADR-0001).

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -45,10 +45,32 @@ a merged feature into an accepted one.
 Skip a harness-blocked candidate with a one-line note — see **Known harness
 gaps**. If every candidate in both modes is blocked, that is `no_work_in_scope`.
 
+## Android Mode (feature #107)
+
+The modes + pick-order above are **iOS** (XCUITest + DebugBridge + simulator).
+When the target row/issue is **Android** (`platform:android` label, or the
+changed paths classify `android-app`/`android-spike` via
+`code_paths_platform`), verify on a booted **Android emulator** instead:
+
+- Run the CU-free instrumentation lane through **`scripts/run-android-verify.sh`**
+  (rule 49/52/53 — watchdog, never a bare `./gradlew`). The Spike-B `am
+  instrument` pattern (#104/#105) is the accessibility-XCUITest analog: it drives
+  a deterministic in-process sweep and pulls metrics, no UI automation.
+- Evidence file `device_or_simulator` records the AVD (e.g. "Pixel 7 API 35
+  emulator"), `os_version` the Android API level.
+- **Until #106's app shell exists, the only Android target is the `spikes/`
+  harness** — so an Android-*app* feature's Gate-5 is itself blocked on #106.
+  Mark such a candidate harness-blocked (see Known harness gaps) rather than
+  forcing it. Pre-#106 Android work is tooling/spike (no device-verify).
+
+The rest of this skill (real-books-first, evidence schema, terminal actions) is
+platform-neutral; only the harness + commands differ.
+
 ## The CU-free method
 
 Computer-use is unavailable in cron contexts. Verify through the XCUITest
-harness, which synthesizes its own gestures via the accessibility API.
+harness (iOS) or the `am instrument` emulator lane (Android — see Android Mode),
+which synthesize their own gestures via the accessibility API.
 
 **Real books first (binding).** When the verification needs a book, import a
 real book from `test-books/books/` via the `sim-transfer` skill and verify

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 1025
-        MARKETING_VERSION: 3.66.41
+        CURRENT_PROJECT_VERSION: 1026
+        MARKETING_VERSION: 3.66.42
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -8109,7 +8109,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1025;
+				CURRENT_PROJECT_VERSION = 1026;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8117,7 +8117,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.41;
+				MARKETING_VERSION = 3.66.42;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -8263,7 +8263,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1025;
+				CURRENT_PROJECT_VERSION = 1026;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8271,7 +8271,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.41;
+				MARKETING_VERSION = 3.66.42;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
## Summary

PR-C (docs) of feature #107 — makes the workflow's rules/skills Android-aware:
- **rule 10** — Android/Kotlin TDD section (JUnit5 / in-memory Room / `runTest` / `createComposeRule` patterns; tests via `scripts/run-android-tests.sh`, never bare `./gradlew`).
- **rule 50** — §12 Kotlin/Compose conventions (coroutines = actor analog, Room = SwiftData analog, Readium-Kotlin reader, unidirectional Compose, DI at boundaries, contract-bound identity).
- **rule 47** — Gate-5 Android tier (emulator verify via `run-android-verify.sh`; shared → iOS lane; Android-app Gate-5 blocked on #106).
- **verify SKILL** — Android Mode (`am instrument` emulator lane, the XCUITest analog).

Docs-only; no code change. Part of feature #1732.

## Validation
- [x] Docs render; consistent with PR-A/PR-B (`code_paths_platform`, the runners)
- [x] Version bumped: 3.66.41 → 3.66.42 (`.claude/` is `shared` → iOS bump, rule 40)

## Type of Change
- [x] Docs WI; part of feature #1732