### PR TITLE
feat(#107 PR-D): platform-route skills/commands/crons + tdd-guardian Kotlin fix

### DIFF
--- a/.claude/codex-audits/feat-feature-107-prd-routing-audit.md
+++ b/.claude/codex-audits/feat-feature-107-prd-routing-audit.md
@@ -1,0 +1,57 @@
+---
+branch: feat/feature-107-prd-routing
+threadId: 019ed6f4-493b-7bc1-bc0a-0b876ffc14aa
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-06-18
+---
+
+# Gate-4 audit — feature #107 PR-D (platform routing + tdd-guardian false-green fix)
+
+PR-D makes the workflow Android-aware: a platform-routing section on the
+`/fix-issue` + `/feature-workflow` commands, SKIP-Android-until-ready on the 3
+work crons, and — the executable piece — `scripts/tdd-guardian-test.sh`, a
+platform-aware wrapper for the TDD Guardian (whose frozen iOS `xcodebuild`
+testCommand previously false-greened Kotlin). The audit focused on the wrapper
+(the markdown edits are docs).
+
+Codex (gpt-5.4, high), 3 rounds. Sessions: r1 `019ed6f4-…`, r2 `019ed6f7-…`,
+r3 `019ed6fa-…`.
+
+## Round 1 — 1 High + 1 Medium
+
+| file | sev | issue | resolution |
+|---|---|---|---|
+| tdd-guardian-test.sh | High | Detection used only `git diff HEAD` + `--cached` → a NEW untracked `android/Foo.kt` gave an empty diff → stayed `ios` → Kotlin false-green. | Added `git ls-files --others --exclude-standard` to the input; regression test creates an untracked `android/_probe.kt` and asserts refuse-to-green (exit 2). |
+| tdd-guardian-test.sh | Medium | `android-app` checked `android/gradlew` OR `./gradlew` but always ran `./gradlew`. | Resolve `gradle_dir` (prefer `android/`, else root) and `cd "$gradle_dir" && ./gradlew`. |
+
+Round 1 confirmed: iOS lane preserved for ios/shared/unknown/empty/classifier-
+unavailable; no silent android-app→iOS fallthrough; `eval "$IOS_CMD"` is a static
+literal (no injection); exit codes propagate.
+
+## Round 2 — 1 Medium
+
+| file | sev | issue | resolution |
+|---|---|---|---|
+| tdd-guardian-test.sh | Medium | A rename `android/Foo.kt -> docs/x.md` surfaced only the post-image (`docs/x.md`) → `shared` → iOS false-green. | Added `--no-renames` to both diffs: a rename becomes delete(OLD android path)+add(new path), so the Android pre-image stays in the input → `android-app`. |
+
+Round 2 confirmed both round-1 findings resolved (ls-files doesn't pull ignored
+build output; gradle_dir + ANDROID_CMD propagate failures non-green).
+
+## Round 3 — CLEAN
+
+"No findings. The round-2 rename false-green is resolved." No remaining
+Critical/High/Medium false-green path in the platform detection.
+
+## Validation
+
+`scripts/__tests__/tdd-guardian-test.test.sh` — ALL PASS (android-app refuse-to-
+green, android-spike routes Android, untracked-android-file routes Android, config
+wired to the wrapper). PR-A classifier test + PR-B runner test still green.
+
+## Verdict
+
+**ship-as-is.** 3-round real Codex audit; the TDD-Guardian Kotlin false-green is
+closed (untracked + rename + staged + working-tree detection), the iOS lane is
+byte-for-byte preserved, and the command/cron routing makes every downstream
+phase platform-aware without regressing iOS.

--- a/.claude/commands/feature-workflow.md
+++ b/.claude/commands/feature-workflow.md
@@ -45,6 +45,24 @@ running a fix through this skill skips the bug-tracker workflow.
 
 Plan around them; do not bypass.
 
+## Platform routing (feature #107 — binding for every gate below)
+
+vreader is two native apps (iOS at root, Android under `android/`). Classify the
+feature's changed files with `code_paths_platform`
+(`.claude/hooks/lib/code-paths.sh`) → `ios`/`android-app`/`android-spike`/`shared`,
+and **substitute the lane in every gate** (the gates are written iOS-first):
+
+- **Gate 3 test gate**: iOS → `scripts/run-tests.sh`; Android →
+  `scripts/run-android-tests.sh` (never bare `./gradlew` — rule 52 Cause D).
+- **Gate 5 verify**: iOS → iPhone 17 Pro Sim + `vreader-debug://`; Android →
+  `scripts/run-android-verify.sh` (emulator; rule 47 Android tier). Evidence
+  `device_or_simulator` = the AVD.
+- **Version bump**: stays iOS (`project.yml`) for `shared`/spike PRs until #106;
+  Android `android/version.properties` + `android/vX.Y.Z` tags begin with #106
+  (rule 40).
+- **`shared`-only and pre-#106 spike work → iOS lane.** An `android-app` feature
+  whose Gate-5 needs the app shell is **blocked on #106**.
+
 ## Pre-flight Checks
 
 1. **Resolve target**: parse `$ARGUMENTS` to a feature row in

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -53,6 +53,24 @@ Three PreToolUse hooks gate this pipeline:
 
 Plan around them; do not bypass.
 
+## Platform routing (feature #107 — binding for every phase below)
+
+vreader is two native apps (iOS at root, Android under `android/`). Determine the
+issue's platform from its changed files and **substitute the lane in every
+phase** — the phases below are written iOS-first; the Android substitutions are:
+
+| Phase | iOS (default) | Android (`android-app` / `android-spike`) |
+|---|---|---|
+| Classify | `printf '%s\n' <changed> \| code_paths_platform` (`.claude/hooks/lib/code-paths.sh`) → `ios`/`android-app`/`android-spike`/`shared` |
+| Test gate (Phase 5) | `scripts/run-tests.sh` (xcodebuild) | `scripts/run-android-tests.sh` |
+| Pre-FIXED / Gate-5 verify | iPhone 17 Pro Sim + `vreader-debug://` | `scripts/run-android-verify.sh` (emulator) |
+| Version bump (Phase 7) | `project.yml` (`vX.Y.Z`) | **stays iOS** until #106 — rule 40: spike/shared PRs bump `project.yml`; an Android `android/version.properties` + `android/vX.Y.Z` tag lane begins only with #106 |
+| Evidence `device_or_simulator` | "iPhone 17 Pro Simulator" | the AVD (e.g. "Pixel 7 API 35 emulator") |
+
+**`shared`-only and pre-#106 spike work route to the iOS lane** (rule 40). An
+`android-app` issue whose Gate-5 needs the app shell is **blocked on #106** — mark
+it `verification-blocked` rather than forcing it.
+
 ## Pre-flight Checks
 
 1. **Parse arguments** — extract issue numbers (e.g. `#123`, `123`, `#123 #456`).

--- a/.claude/cron-prompts/bugfix.md
+++ b/.claude/cron-prompts/bugfix.md
@@ -2,6 +2,8 @@ First, log the fire: run `mkdir -p .claude/cron-logs && echo "$(date -Iseconds) 
 
 Pick one open GitHub issue labeled `bug` from this repo (use `gh issue list --label bug --state open --json number,labels,title`). Prefer severity:high, then severity:medium, then others. Skip issues whose body or comments indicate they are blocked (waiting on fixture, multi-iteration scope, harness gap) — leave a one-line skip note in the issue and pick the next. Then run /fix-issue #N on the chosen issue.
 
+SKIP-ANDROID-UNTIL-READY (feature #107): until the Android app shell (#106) lands, an `android-app`-platform bug (label `platform:android`, or whose fix touches `android/`/`*.kt`/Gradle) cannot be tested/verified end-to-end. Skip such an issue with a one-line note (`blocked on #106 app shell`) and pick the next. iOS, `shared`, `contracts/`, and `spikes/`/tooling bugs ARE in scope and route to their normal lanes (`/fix-issue` handles the routing).
+
 SCOPE GUARDRAIL — only fix bugs from the authoritative trackers:
 - Acceptable scope sources:
   - `docs/bugs.md` rows (the authoritative tracker — entries triaged in)

--- a/.claude/cron-prompts/feature.md
+++ b/.claude/cron-prompts/feature.md
@@ -2,6 +2,8 @@ First, log the fire: run `mkdir -p .claude/cron-logs && echo "$(date -Iseconds) 
 
 Select a feature to implement from GitHub issues or local tasks, and use /feature-workflow to implement the feature.
 
+SKIP-ANDROID-UNTIL-READY (feature #107): until the Android app shell (#106) lands, an `android-app`-platform feature cannot reach Gate-5 (no app to verify). Do NOT auto-start `#106` or other `android-app` features from this cron — they are the deferred Android-port epic, user-steered. `#107` (the dev-loop tooling, `.claude/*`+`scripts/`) and any iOS / `shared` / `contracts/` / `spikes/` feature ARE in scope. `/feature-workflow` handles the per-gate lane routing.
+
 SCOPE: feature implementation only. Per `.claude/rules/47-feature-workflow.md`, `/feature-workflow` is the binding 6-gate sequence (Plan → Independent plan audit → TDD → Implementation audit → Device/integration verification → Merge); never skip a gate.
 
 PICK ORDER (highest priority first):

--- a/.claude/cron-prompts/verify.md
+++ b/.claude/cron-prompts/verify.md
@@ -2,6 +2,8 @@ First, log the fire: run `mkdir -p .claude/cron-logs && echo "$(date -Iseconds) 
 
 Run the `/verify` skill with no explicit target. It auto-picks per its Pick order — the `awaiting-device-verification` GH-issue backlog first (Mode A, bug close-gate verification), then `DONE` features needing Gate-5 (Mode B, feature verification). The skill owns the whole verification workflow: both modes, the CU-free method (XCUITest + DebugBridge, with `scripts/sim-tap.sh` (idb) as the gesture fallback for taps/swipes the first two can't express — see `docs/subsystems/sim-gesture-driver.md`), the UDID-pinned simulator, the close gate, the scope guardrail, and the known harness gaps.
 
+SKIP-ANDROID-UNTIL-READY (feature #107): the skill's Android Mode verifies on an emulator, but an `android-app` target's Gate-5 is blocked until the app shell (#106) exists — the skill marks such a candidate harness-blocked. iOS verification (the dominant backlog) is unaffected.
+
 Map the skill's result to the ENDED outcome: `work_done` if it verified and closed or flipped at least one target; `no_work_in_scope` if nothing needed (or could be) verified this iteration; `blocked` if a required tool/harness was genuinely unavailable; `error` on failure.
 
 Verification scope only — if the skill discovers a bug it FILES it (GH issue + `docs/bugs.md` row) but never fixes it; fixes are the bugfix cron's job.

--- a/.claude/tdd-guardian/config.json
+++ b/.claude/tdd-guardian/config.json
@@ -1,6 +1,7 @@
 {
   "enabled": true,
-  "testCommand": "DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build-for-testing -project vreader.xcodeproj -scheme vreader -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -quiet && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test-without-building -project vreader.xcodeproj -scheme vreader -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:vreaderTests -disable-concurrent-testing",
+  "testCommand": "bash scripts/tdd-guardian-test.sh",
+  "_testCommand_note": "Feature #107 PR-D: routed through a platform-aware wrapper so a Kotlin change no longer false-greens against the frozen iOS xcodebuild command. scripts/tdd-guardian-test.sh classifies changed files via code_paths_platform and runs the iOS xcodebuild lane (ios/shared — unchanged), the Android spike/Gradle lane (android-spike/android-app once #106 wires the app), or fails loudly (exit 2) for an android-app change with no app yet.",
   "coverageCommand": "",
   "coverageSummaryPath": "",
   "mutationCommand": "",

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 1026
-        MARKETING_VERSION: 3.66.42
+        CURRENT_PROJECT_VERSION: 1027
+        MARKETING_VERSION: 3.66.43
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/scripts/__tests__/tdd-guardian-test.test.sh
+++ b/scripts/__tests__/tdd-guardian-test.test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Feature #107 PR-D — verifies the tdd-guardian test wrapper ROUTES by platform
+# (the false-green fix: a Kotlin change must not pass the iOS test command).
+# Uses TDD_FORCE_PLATFORM to exercise each branch without running the slow iOS
+# xcodebuild lane. Run: bash scripts/__tests__/tdd-guardian-test.test.sh
+
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRAP="$HERE/../tdd-guardian-test.sh"
+fails=0
+
+# android-app with no app shell → must refuse to green (exit 2, explicit msg).
+out="$(TDD_FORCE_PLATFORM=android-app bash "$WRAP" 2>&1)"; rc=$?
+if [ "$rc" -eq 2 ] && grep -q "refusing to green" <<<"$out"; then
+    echo "ok   — android-app (no #106 app) refuses to green (exit 2)"
+else
+    echo "FAIL — android-app: expected exit 2 + 'refusing to green', got exit $rc"; fails=$((fails+1))
+fi
+
+# android-spike → routes to run-android-tests.sh (NO_EMULATOR here, exit 2 from
+# the runner — the point is it took the ANDROID lane, not the iOS one).
+out="$(TDD_FORCE_PLATFORM=android-spike bash "$WRAP" 2>&1)"
+if grep -q "android-spike change" <<<"$out" && grep -q "RUN-ANDROID-TESTS RESULT:" <<<"$out"; then
+    echo "ok   — android-spike routes to the Android runner (not iOS xcodebuild)"
+else
+    echo "FAIL — android-spike did not route to the Android runner:"; echo "$out" | tail -3; fails=$((fails+1))
+fi
+
+# Untracked Android file (Codex Gate-4 High): a brand-new, not-yet-`git add`ed
+# `android/*.kt` must classify android-app (→ refuse-to-green exit 2), NOT fall to
+# the iOS lane via an empty diff. Exercises the real git-detection path (no
+# TDD_FORCE_PLATFORM). The probe also proves `ls-files --others` is consulted.
+REPO="$(cd "$HERE/../.." && pwd)"
+PROBE="$REPO/android/_tdd_guardian_untracked_probe.kt"
+mkdir -p "$REPO/android"
+printf 'class Probe\n' > "$PROBE"
+out="$(bash "$WRAP" 2>&1)"; rc=$?
+rm -f "$PROBE"; rmdir "$REPO/android" 2>/dev/null || true
+if [ "$rc" -eq 2 ] && grep -q "refusing to green" <<<"$out"; then
+    echo "ok   — untracked android/*.kt classifies android-app (no iOS false-green)"
+else
+    echo "FAIL — untracked android/*.kt did not route Android: exit $rc"; echo "$out" | tail -2; fails=$((fails+1))
+fi
+
+# Config wiring: the guardian config invokes the wrapper, not the raw xcodebuild.
+CFG="$HERE/../../.claude/tdd-guardian/config.json"
+if grep -q "tdd-guardian-test.sh" "$CFG"; then
+    echo "ok   — tdd-guardian config routes through the wrapper"
+else
+    echo "FAIL — tdd-guardian config still hard-codes a raw test command"; fails=$((fails+1))
+fi
+
+echo
+if [ "$fails" -eq 0 ]; then echo "ALL PASS"; exit 0; else echo "$fails FAILURE(S)"; exit 1; fi

--- a/scripts/tdd-guardian-test.sh
+++ b/scripts/tdd-guardian-test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Purpose: platform-aware test command for the TDD Guardian (feature #107 PR-D).
+# The guardian's config previously hard-coded the iOS `xcodebuild` command, so a
+# Kotlin change "passed" tests that never ran (a false-green). This wrapper
+# classifies the changed files by platform (`code_paths_platform`) and routes:
+#   ios | shared      → the iOS xcodebuild lane (unchanged behavior)
+#   android-spike     → scripts/run-android-tests.sh (the spike emulator harness)
+#   android-app       → scripts/run-android-tests.sh ./gradlew IF #106's app
+#                       exists; ELSE FAIL LOUDLY (exit 2) — an android-app change
+#                       must NOT green until the app + its tests are wired.
+#
+# Safety: anything that doesn't classify cleanly as Android runs the iOS lane, so
+# the iOS guardian flow is identical to before.
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=.claude/hooks/lib/code-paths.sh
+source "$REPO/.claude/hooks/lib/code-paths.sh" 2>/dev/null || true
+
+IOS_CMD="DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build-for-testing -project vreader.xcodeproj -scheme vreader -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -quiet && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test-without-building -project vreader.xcodeproj -scheme vreader -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:vreaderTests -disable-concurrent-testing"
+
+# Classify the working-tree + staged changes. If the classifier is unavailable
+# or there are no changes, fall through to the iOS lane (preserve old behavior).
+# TDD_FORCE_PLATFORM is a test seam (unset in production → git-based detection).
+platform="${TDD_FORCE_PLATFORM:-ios}"
+if [ -z "${TDD_FORCE_PLATFORM:-}" ] && declare -f code_paths_platform >/dev/null 2>&1; then
+    # Tracked-unstaged + staged + UNTRACKED (Codex Gate-4 High: a brand-new
+    # `android/Foo.kt` that isn't `git add`ed yet must still classify Android, or
+    # a Kotlin change false-greens on the iOS lane via an empty diff).
+    # --no-renames (Codex Gate-4 Medium): a rename surfaces as delete(OLD path) +
+    # add(NEW path), so a `android/Foo.kt -> docs/x.md` rename keeps the Android
+    # source path in the input and still classifies android-app (rather than only
+    # the post-image `docs/x.md` → shared → iOS false-green).
+    changed="$( {
+        git -C "$REPO" diff --no-renames --name-only HEAD
+        git -C "$REPO" diff --no-renames --cached --name-only
+        git -C "$REPO" ls-files --others --exclude-standard
+    } 2>/dev/null )"
+    if [ -n "$changed" ]; then
+        platform="$(printf '%s\n' "$changed" | code_paths_platform)"
+    fi
+fi
+
+case "$platform" in
+    android-spike)
+        echo "[tdd-guardian] android-spike change → scripts/run-android-tests.sh"
+        exec bash "$REPO/scripts/run-android-tests.sh"
+        ;;
+    android-app)
+        # Run gradlew from the dir that actually contains it (Codex Gate-4 Medium:
+        # if #106 lands the wrapper under android/, invoke it there, not at root).
+        gradle_dir=""
+        [ -f "$REPO/android/gradlew" ] && gradle_dir="$REPO/android"
+        [ -z "$gradle_dir" ] && [ -f "$REPO/gradlew" ] && gradle_dir="$REPO"
+        if [ -n "$gradle_dir" ]; then
+            echo "[tdd-guardian] android-app change → ./gradlew unit tests (in $gradle_dir)"
+            ANDROID_CMD="cd \"$gradle_dir\" && ./gradlew :app:testDebugUnitTest" exec bash "$REPO/scripts/run-android-tests.sh"
+        fi
+        echo "TDD-GUARDIAN: android-app change but no Android app shell yet (feature #106) — Kotlin tests cannot be asserted; refusing to green." >&2
+        exit 2
+        ;;
+    *)
+        eval "$IOS_CMD"
+        ;;
+esac

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -8109,7 +8109,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1026;
+				CURRENT_PROJECT_VERSION = 1027;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8117,7 +8117,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.42;
+				MARKETING_VERSION = 3.66.43;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -8263,7 +8263,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1026;
+				CURRENT_PROJECT_VERSION = 1027;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8271,7 +8271,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.42;
+				MARKETING_VERSION = 3.66.43;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
## Summary

PR-D of feature #107 — makes the workflow drive Android (not just classify it):
- **`scripts/tdd-guardian-test.sh`** — platform-aware TDD-Guardian test command. Classifies changed files (tracked + staged + **untracked**, `--no-renames`) via `code_paths_platform` and routes: `ios`/`shared` → iOS xcodebuild (**unchanged**), `android-spike` → the runner, `android-app` → `./gradlew` if #106's app exists ELSE **refuses to green** (exit 2). Closes the false-green where a Kotlin change passed the frozen iOS command.
- **`/fix-issue` + `/feature-workflow`** — a platform-routing section: substitute the Android lane (`run-android-tests.sh`/`run-android-verify.sh`) in every test/verify phase; `/bump` stays iOS (rule 40).
- **3 work crons** (bugfix/feature/verify) — SKIP-Android-until-ready default (don't auto-start `android-app` work before #106).

Part of feature #1732.

## Codex Audit

Real Codex, **3 rounds, ship-as-is**. R1: 1 High (untracked files ignored → false-green) + 1 Medium (gradlew path). R2: 1 Medium (rename false-green). R3 clean. Log: `.claude/codex-audits/feat-feature-107-prd-routing-audit.md`.

## Validation
- [x] `tdd-guardian-test.test.sh` — ALL PASS (refuse-to-green / android-spike route / untracked-android route / config wired)
- [x] PR-A classifier + PR-B runner tests still green (iOS lane preserved)
- [x] Version bumped: 3.66.42 → 3.66.43

## Type of Change
- [x] Tooling WI; part of feature #1732