### PR TITLE
feat(#106 WI-3): Android Room persistence + shared VReaderLocator envelope

### DIFF
--- a/.claude/codex-audits/feat-feature-106-wi3-room-audit.md
+++ b/.claude/codex-audits/feat-feature-106-wi3-room-audit.md
@@ -1,0 +1,65 @@
+---
+branch: feat/feature-106-wi3-room
+threadId: 019ed8-wi3-room-3rounds
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-06-18
+---
+
+# Gate-4 audit — feature #106 WI-3 (Android Room persistence + VReaderLocator envelope)
+
+WI-3 adds the Android persistence layer: a shared `:identity` `VReaderLocator`/
+`Locator` envelope (engine-neutral value types), Room `BookEntity` +
+`ReadingPositionEntity`, DAOs, `VReaderDatabase` (v2 + schema-versioned
+`MIGRATION_1_2` scaffold + `exportSchema`), and `LibraryRepository` returning DTOs.
+In-memory-Room CRUD + envelope round-trip tests + a migration round-trip test.
+
+Codex (gpt-5.4, high), 3 rounds. The reading position stores the FULL
+`VReaderLocator` envelope, not a bare `Locator` (Gate-2 Critical).
+
+## Round 1 — 3 findings (block-recommended)
+
+| file | sev | issue | resolution |
+|---|---|---|---|
+| Daos.kt | **Critical** | `BookDao.upsert` used `@Insert(REPLACE)`; in SQLite REPLACE = delete+insert, firing `reading_positions` `ON DELETE CASCADE` → a book re-import silently wipes its saved position. | Switched both DAOs to **`@Upsert`** (insert-or-UPDATE, no delete). Added regression `LibraryRepositoryTest.reUpsertBook_preservesSavedPosition`. |
+| Locator.kt | **High** | Kotlin `Locator` didn't mirror Swift's validation contract — negative `page`/offset, one-sided/inverted ranges all serialized + could persist (violates `contracts/identity/locator.md`). | Added `validate()` (mirrors Swift `LocatorValidationError`), `validatedOrNull()`, `repairedForCanonicalization()` (nulls non-finite, iOS #109 parity). `savePosition` repairs non-finite + **throws** on structural invalidity. Tests: `savePosition_rejectsNegativePage`, `savePosition_rejectsInvertedRange`, `savePosition_repairsNonFiniteProgression`. |
+| LibraryRepository.kt | **Medium** | Room flattened envelope fields into ad-hoc columns → a future `schemaVersion`-gated field would drop unless Room schema + mapper changed in lockstep (defeats "envelope evolves independently of Room"). | `ReadingPositionEntity` now stores the WHOLE envelope in a single `vreaderLocatorJSON` column (+ derived `canonicalHash`, `updatedAt`). `LibraryRepository` encodes/decodes the entire `VReaderLocator`; `DEFAULT_JSON` sets `ignoreUnknownKeys=true` (forward compat). Test: `loadPosition_toleratesForwardEnvelopeField`. |
+
+## Round 2 — findings 1/2/3 confirmed resolved; 1 NEW High raised
+
+| file | sev | issue | resolution |
+|---|---|---|---|
+| VReaderDatabase.kt | High | The Medium-fix rewrote `reading_positions` from the prior exported-v2 (flattened) layout to the new single-JSON layout while DB version stayed at 2 → "a database created by the earlier WI-3 build with the old v2 shape" would have no upgrade path. | **Withdrawn in round 3 — false-positive premise.** No such database exists in any committed/shipped lineage. |
+
+## Round 3 — premise re-evaluated against verified git history (ship-as-is)
+
+Presented the auditor with verified facts: `git log main -- android/app/schemas/`
+is empty (no Room schema ever committed to main); main's `android/app/build.gradle.kts`
+has no room/ksp deps (Room is introduced for the FIRST time in this unmerged WI-3);
+the only shipped Android tags `android/v0.1.0` (WI-1 shell) and `android/v0.1.1`
+(WI-2 identity module) carry no persistence; the old flattened-v2
+`reading_positions` lived ONLY in this WI's uncommitted working tree.
+
+Auditor verdict: **"The round-2 HIGH is withdrawn."** Shipping schema `version = 2`
+with the new exported `2.json` is not a real upgrade-path defect — it is the
+first-and-only on-device schema in vreader Android history. Bumping to v3 to model
+the abandoned local shape would encode fictional release history. The only caveat
+is procedural (a side-loaded uncommitted-dev APK's private DB is outside shipped
+support scope) — not a merge blocker.
+
+## Validation
+
+- `scripts/run-android-tests.sh` (`:app:testDebugUnitTest`) → **RUN-ANDROID-TESTS
+  RESULT: SUCCEEDED**; 17 data-layer tests (LibraryRepositoryTest 16 incl. the 5
+  audit-driven additions, VReaderDatabaseMigrationTest 1), 0 failures.
+- `contracts/conformance/run.sh kotlin` → **CONFORMANCE RESULT: PASS** (the
+  `:identity` Locator additions are non-breaking; canonical JSON unchanged).
+- Room `exportSchema` regenerated `2.json` to the single-`vreaderLocatorJSON`
+  column set; the migration test's hand-built v1 matches it (migration round-trip
+  green).
+
+## Verdict
+
+**ship-as-is.** All round-1 findings (Critical/High/Medium) resolved with tests;
+the round-2 High withdrawn on verified never-shipped state. Zero open
+Critical/High/Medium after 3 rounds.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
+    id("com.google.devtools.ksp")   // feature #106 WI-3 — Room codegen
 }
 
 // Read via Gradle's provider API so `version.properties` is a TRACKED input
@@ -50,6 +51,12 @@ android {
     }
 }
 
+// feature #106 WI-3 — Room exports the current schema JSON here so schema-versioned
+// migrations have a checked-in baseline (the migration round-trip test guards it).
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
+}
+
 kotlin {
     compilerOptions {
         jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
@@ -68,10 +75,23 @@ dependencies {
     // conformance lane tests the SAME code the app uses). WI-3 keys Room on it.
     implementation(project(":identity"))
 
+    // feature #106 WI-3 — Room persistence (the PersistenceActor analog). room-ktx
+    // brings the suspend/Flow DAO support; the compiler runs through KSP.
+    val room = "2.8.4"
+    implementation("androidx.room:room-runtime:$room")
+    implementation("androidx.room:room-ktx:$room")
+    ksp("androidx.room:room-compiler:$room")
+    // The repository JSON-encodes the VReaderLocator envelope into one column. The
+    // @Serializable types are compiled in :identity (which has the serialization
+    // plugin); :app only needs the runtime library to call Json.encode/decode.
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
+
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.robolectric:robolectric:4.13")
     testImplementation("androidx.test:core:1.6.1")
     testImplementation("androidx.test.ext:junit:1.2.1")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
 }

--- a/android/app/schemas/com.vreader.app.data.VReaderDatabase/2.json
+++ b/android/app/schemas/com.vreader.app.data.VReaderDatabase/2.json
@@ -1,0 +1,125 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "c1d246033fc2e7a6ad091916c85c2ff0",
+    "entities": [
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fingerprintKey` TEXT NOT NULL, `title` TEXT NOT NULL, `originalFormat` TEXT NOT NULL, `contentSHA256` TEXT NOT NULL, `fileByteCount` INTEGER NOT NULL, `localFilePath` TEXT, `sourceUri` TEXT, `addedAt` INTEGER NOT NULL, `lastOpenedAt` INTEGER, PRIMARY KEY(`fingerprintKey`))",
+        "fields": [
+          {
+            "fieldPath": "fingerprintKey",
+            "columnName": "fingerprintKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalFormat",
+            "columnName": "originalFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentSHA256",
+            "columnName": "contentSHA256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileByteCount",
+            "columnName": "fileByteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "localFilePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceUri",
+            "columnName": "sourceUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fingerprintKey"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fingerprintKey` TEXT NOT NULL, `vreaderLocatorJSON` TEXT NOT NULL, `canonicalHash` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`fingerprintKey`), FOREIGN KEY(`fingerprintKey`) REFERENCES `books`(`fingerprintKey`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fingerprintKey",
+            "columnName": "fingerprintKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vreaderLocatorJSON",
+            "columnName": "vreaderLocatorJSON",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canonicalHash",
+            "columnName": "canonicalHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fingerprintKey"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fingerprintKey"
+            ],
+            "referencedColumns": [
+              "fingerprintKey"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c1d246033fc2e7a6ad091916c85c2ff0')"
+    ]
+  }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/data/Daos.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/data/Daos.kt
@@ -1,0 +1,45 @@
+// Purpose: Room DAOs — the Android analog of the iOS PersistenceActor CRUD
+// extensions (feature #106 WI-3). DAOs expose suspend writes + Flow reads; Room
+// serializes access off the main thread. Views never touch a DAO directly — the
+// repository (DTOs) is the boundary (rule 50 §2: never return @Model/entity types
+// across the layer).
+package com.vreader.app.data
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface BookDao {
+    // @Upsert (insert-or-UPDATE), NOT @Insert(REPLACE). REPLACE is delete-then-insert
+    // in SQLite, which would fire reading_positions' ON DELETE CASCADE and silently
+    // wipe a book's saved position on every re-import (Gate-4 Critical). @Upsert
+    // updates in place, preserving the child row.
+    @Upsert
+    suspend fun upsert(book: BookEntity)
+
+    @Query("SELECT * FROM books ORDER BY addedAt DESC")
+    fun observeAll(): Flow<List<BookEntity>>
+
+    @Query("SELECT * FROM books WHERE fingerprintKey = :key")
+    suspend fun find(key: String): BookEntity?
+
+    @Query("DELETE FROM books WHERE fingerprintKey = :key")
+    suspend fun delete(key: String)
+
+    @Query("UPDATE books SET lastOpenedAt = :openedAt WHERE fingerprintKey = :key")
+    suspend fun markOpened(key: String, openedAt: Long)
+}
+
+@Dao
+interface ReadingPositionDao {
+    @Upsert
+    suspend fun upsert(position: ReadingPositionEntity)
+
+    @Query("SELECT * FROM reading_positions WHERE fingerprintKey = :key")
+    suspend fun find(key: String): ReadingPositionEntity?
+
+    @Query("DELETE FROM reading_positions WHERE fingerprintKey = :key")
+    suspend fun delete(key: String)
+}

--- a/android/app/src/main/kotlin/com/vreader/app/data/Entities.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/data/Entities.kt
@@ -1,0 +1,57 @@
+// Purpose: Room entities for the Android library — feature #106 WI-3.
+// BookEntity is the Android mirror of the iOS Book @Model; ReadingPositionEntity
+// stores the VReaderLocator ENVELOPE (engine + readiumLocatorJSON + serialized
+// canonical Locator), NOT a bare Locator (Gate-2 Critical) — so a saved position
+// survives an engine swap / cross-device restore.
+package com.vreader.app.data
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
+
+/**
+ * A book in the Android library, keyed by its canonical fingerprint
+ * (`DocumentFingerprint.canonicalKey`). `localFilePath`/`sourceUri` are nullable
+ * until WI-4 wires SAF import → app-private-storage copy. `lastOpenedAt` is the
+ * v2 schema addition (recents) — null until first open.
+ */
+@Entity(tableName = "books")
+data class BookEntity(
+    @PrimaryKey val fingerprintKey: String,
+    val title: String,
+    val originalFormat: String,   // BookFormat raw value (epub/pdf/txt/md/azw3)
+    val contentSHA256: String,
+    val fileByteCount: Long,
+    val localFilePath: String?,   // app-private storage path (set at import, WI-4)
+    val sourceUri: String?,       // SAF source URI metadata (WI-4)
+    val addedAt: Long,            // epoch millis
+    val lastOpenedAt: Long?,      // v2 addition — epoch millis of last open, or null
+)
+
+/**
+ * The persisted reading position for a book — the WHOLE [VReaderLocator] envelope
+ * serialized into a single `vreaderLocatorJSON` column (one position per book; PK =
+ * fingerprintKey). Storing the entire envelope (not flattened columns) is the
+ * iOS-parity contract: a new envelope field gated by its own `schemaVersion` evolves
+ * WITHOUT a Room schema change (Gate-4 Medium — the iOS analog persists the envelope
+ * as one `Data?` blob on `ReadingPosition`). `canonicalHash` is the only derived
+ * column, kept for dedup/sync lookups. `fingerprintKey` is both PK and the FK child
+ * column, so it is already indexed — no separate index needed.
+ */
+@Entity(
+    tableName = "reading_positions",
+    foreignKeys = [
+        ForeignKey(
+            entity = BookEntity::class,
+            parentColumns = ["fingerprintKey"],
+            childColumns = ["fingerprintKey"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+)
+data class ReadingPositionEntity(
+    @PrimaryKey val fingerprintKey: String,
+    val vreaderLocatorJSON: String,   // the FULL serialized VReaderLocator envelope
+    val canonicalHash: String,        // derived dedup/sync key (locally deterministic)
+    val updatedAt: Long,              // epoch millis of last save
+)

--- a/android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt
@@ -1,0 +1,121 @@
+// Purpose: Library persistence boundary — feature #106 WI-3. The Android analog of
+// the iOS PersistenceActor + its record DTOs: callers get value-type DTOs (Book /
+// VReaderLocator), never Room entities (rule 50 §2). Maps the persisted columns to
+// the shared :identity envelope types so saved positions round-trip through the
+// engine-neutral contract.
+package com.vreader.app.data
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import vreader.contracts.BookFormat
+import vreader.contracts.VReaderLocator
+
+/**
+ * Value-type DTO for a library book (decoupled from [BookEntity], mirroring iOS
+ * `BookRecord`). `fingerprintKey` is the canonical identity.
+ */
+data class Book(
+    val fingerprintKey: String,
+    val title: String,
+    val originalFormat: BookFormat,
+    val contentSHA256: String,
+    val fileByteCount: Long,
+    val localFilePath: String? = null,
+    val sourceUri: String? = null,
+    val addedAt: Long,
+    val lastOpenedAt: Long? = null,
+)
+
+/**
+ * The library/position persistence boundary. Suspends for writes, exposes a Flow
+ * for the observable library list. `json` is injectable for tests.
+ */
+class LibraryRepository(
+    private val bookDao: BookDao,
+    private val positionDao: ReadingPositionDao,
+    private val json: Json = DEFAULT_JSON,
+) {
+    fun observeLibrary(): Flow<List<Book>> = bookDao.observeAll().map { rows -> rows.map(::toBook) }
+
+    suspend fun upsertBook(book: Book) = bookDao.upsert(book.toEntity())
+
+    suspend fun findBook(fingerprintKey: String): Book? = bookDao.find(fingerprintKey)?.let(::toBook)
+
+    suspend fun deleteBook(fingerprintKey: String) = bookDao.delete(fingerprintKey)
+
+    suspend fun markOpened(fingerprintKey: String, openedAt: Long) =
+        bookDao.markOpened(fingerprintKey, openedAt)
+
+    /**
+     * Persists the full [VReaderLocator] envelope as the book's current position.
+     * Repairs a non-finite progression (iOS persistence-boundary parity) and REJECTS
+     * a structurally-invalid legacy locator (negative page/offset, inverted range) —
+     * an invalid position must never reach storage (Gate-4 High).
+     */
+    suspend fun savePosition(locator: VReaderLocator, updatedAt: Long) {
+        val repaired = locator.repaired()
+        repaired.legacyLocator?.validate()?.let { error ->
+            throw IllegalArgumentException("cannot persist invalid locator: $error")
+        }
+        positionDao.upsert(repaired.toEntity(updatedAt, json))
+    }
+
+    /** Loads the saved position envelope, or null if none. */
+    suspend fun loadPosition(fingerprintKey: String): VReaderLocator? =
+        positionDao.find(fingerprintKey)?.toEnvelope(json)
+
+    suspend fun clearPosition(fingerprintKey: String) = positionDao.delete(fingerprintKey)
+
+    // MARK: - Mapping (entity <-> DTO)
+
+    private fun toBook(e: BookEntity): Book = Book(
+        fingerprintKey = e.fingerprintKey,
+        title = e.title,
+        originalFormat = BookFormat.valueOf(e.originalFormat),
+        contentSHA256 = e.contentSHA256,
+        fileByteCount = e.fileByteCount,
+        localFilePath = e.localFilePath,
+        sourceUri = e.sourceUri,
+        addedAt = e.addedAt,
+        lastOpenedAt = e.lastOpenedAt,
+    )
+
+    private fun Book.toEntity(): BookEntity = BookEntity(
+        fingerprintKey = fingerprintKey,
+        title = title,
+        originalFormat = originalFormat.name,
+        contentSHA256 = contentSHA256,
+        fileByteCount = fileByteCount,
+        localFilePath = localFilePath,
+        sourceUri = sourceUri,
+        addedAt = addedAt,
+        lastOpenedAt = lastOpenedAt,
+    )
+
+    /** Nulls a non-finite progression in the legacy locator before storage. */
+    private fun VReaderLocator.repaired(): VReaderLocator =
+        legacyLocator?.let { copy(legacyLocator = it.repairedForCanonicalization()) } ?: this
+
+    private fun VReaderLocator.toEntity(updatedAt: Long, json: Json): ReadingPositionEntity =
+        ReadingPositionEntity(
+            fingerprintKey = fingerprintKey,
+            vreaderLocatorJSON = json.encodeToString(this),   // the WHOLE envelope
+            canonicalHash = canonicalHash,
+            updatedAt = updatedAt,
+        )
+
+    private fun ReadingPositionEntity.toEnvelope(json: Json): VReaderLocator =
+        json.decodeFromString<VReaderLocator>(vreaderLocatorJSON)
+
+    companion object {
+        // encodeDefaults so schemaVersion is always serialized; ignoreUnknownKeys so a
+        // newer app's extra envelope field decodes cleanly on an older build (forward
+        // compat — the whole point of storing the envelope JSON, not flat columns).
+        private val DEFAULT_JSON = Json {
+            encodeDefaults = true
+            ignoreUnknownKeys = true
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt
@@ -1,0 +1,44 @@
+// Purpose: Room database + schema-versioned migration scaffold — feature #106 WI-3.
+// Version 2 is the current schema; v1 was the initial books+positions baseline and
+// MIGRATION_1_2 is the worked example of the additive-migration pattern (adds
+// books.lastOpenedAt). The migration round-trip test (VReaderDatabaseMigrationTest)
+// guards it. Future schema changes append a Migration(n, n+1) to ALL_MIGRATIONS and
+// bump `version`.
+package com.vreader.app.data
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+@Database(
+    entities = [BookEntity::class, ReadingPositionEntity::class],
+    version = 2,
+    exportSchema = true,
+)
+abstract class VReaderDatabase : RoomDatabase() {
+    abstract fun bookDao(): BookDao
+    abstract fun readingPositionDao(): ReadingPositionDao
+
+    companion object {
+        private const val DB_NAME = "vreader.db"
+
+        /** v1 → v2: add the nullable `lastOpenedAt` recents column to `books`. */
+        val MIGRATION_1_2: Migration = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE books ADD COLUMN lastOpenedAt INTEGER")
+            }
+        }
+
+        /** All registered migrations, oldest first. Append future Migration(n,n+1) here. */
+        val ALL_MIGRATIONS: Array<Migration> = arrayOf(MIGRATION_1_2)
+
+        /** The production on-disk database (app-private storage). */
+        fun build(context: Context): VReaderDatabase =
+            Room.databaseBuilder(context.applicationContext, VReaderDatabase::class.java, DB_NAME)
+                .addMigrations(*ALL_MIGRATIONS)
+                .build()
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/data/LibraryRepositoryTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/data/LibraryRepositoryTest.kt
@@ -1,0 +1,263 @@
+package com.vreader.app.data
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import vreader.contracts.BookFormat
+import vreader.contracts.Identity
+import vreader.contracts.Locator
+import vreader.contracts.ReaderLocatorEngine
+import vreader.contracts.VReaderLocator
+
+/**
+ * In-memory Room CRUD + envelope round-trip for [LibraryRepository] (feature #106
+ * WI-3). Proves the persistence boundary stores/returns DTOs and the VReaderLocator
+ * envelope survives a save→load cycle byte-for-byte through the canonical contract.
+ */
+@RunWith(RobolectricTestRunner::class)
+class LibraryRepositoryTest {
+    private lateinit var db: VReaderDatabase
+    private lateinit var repo: LibraryRepository
+
+    private val sha = "a".repeat(64)
+    private val key = Identity.canonicalKey("epub", sha, 2048)
+
+    private fun book(
+        k: String = key,
+        title: String = "Moby-Dick",
+        format: BookFormat = BookFormat.epub,
+        addedAt: Long = 1000L,
+    ) = Book(
+        fingerprintKey = k,
+        title = title,
+        originalFormat = format,
+        contentSHA256 = sha,
+        fileByteCount = 2048,
+        addedAt = addedAt,
+    )
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            VReaderDatabase::class.java,
+        ).build()
+        repo = LibraryRepository(db.bookDao(), db.readingPositionDao())
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    @Test
+    fun upsertBook_thenFindAndObserve() = runTest {
+        repo.upsertBook(book())
+        val found = repo.findBook(key)
+        assertEquals("Moby-Dick", found?.title)
+        assertEquals(BookFormat.epub, found?.originalFormat)
+        assertNull("not opened yet", found?.lastOpenedAt)
+
+        val library = repo.observeLibrary().first()
+        assertEquals(1, library.size)
+        assertEquals(key, library.first().fingerprintKey)
+    }
+
+    @Test
+    fun observeLibrary_ordersByAddedAtDescending() = runTest {
+        val k1 = Identity.canonicalKey("epub", "b".repeat(64), 1)
+        val k2 = Identity.canonicalKey("epub", "c".repeat(64), 2)
+        repo.upsertBook(book(k = k1, title = "Older", addedAt = 100L))
+        repo.upsertBook(book(k = k2, title = "Newer", addedAt = 200L))
+        val titles = repo.observeLibrary().first().map { it.title }
+        assertEquals(listOf("Newer", "Older"), titles)
+    }
+
+    @Test
+    fun upsert_isReplaceOnConflict() = runTest {
+        repo.upsertBook(book(title = "v1"))
+        repo.upsertBook(book(title = "v2"))
+        assertEquals("v2", repo.findBook(key)?.title)
+        assertEquals(1, repo.observeLibrary().first().size)
+    }
+
+    @Test
+    fun deleteBook_removesIt() = runTest {
+        repo.upsertBook(book())
+        repo.deleteBook(key)
+        assertNull(repo.findBook(key))
+        assertTrue(repo.observeLibrary().first().isEmpty())
+    }
+
+    @Test
+    fun markOpened_setsLastOpenedAt() = runTest {
+        repo.upsertBook(book())
+        repo.markOpened(key, 5555L)
+        assertEquals(5555L, repo.findBook(key)?.lastOpenedAt)
+    }
+
+    @Test
+    fun cjkTitle_roundTrips() = runTest {
+        repo.upsertBook(book(title = "红楼梦"))
+        assertEquals("红楼梦", repo.findBook(key)?.title)
+    }
+
+    @Test
+    fun savePosition_legacyEnvelope_roundTrips() = runTest {
+        repo.upsertBook(book())
+        val locator = Locator(
+            contentSHA256 = sha,
+            fileByteCount = 2048,
+            format = "epub",
+            href = "chapter3.xhtml",
+            progression = 0.4213,
+            totalProgression = 0.18,
+            textQuote = "Call me Ishmael",
+        )
+        val envelope = VReaderLocator.wrapLegacy(locator)
+        repo.savePosition(envelope, updatedAt = 42L)
+
+        val loaded = repo.loadPosition(key)!!
+        assertEquals(ReaderLocatorEngine.epubWKWebView, loaded.engine)
+        assertNull(loaded.readiumLocatorJSON)
+        assertEquals(locator, loaded.legacyLocator)
+        assertEquals(BookFormat.epub, loaded.originalFormat)
+        assertEquals(VReaderLocator.CURRENT_SCHEMA_VERSION, loaded.schemaVersion)
+        // canonicalHash is stable across the save/load round-trip.
+        assertEquals(envelope.canonicalHash, loaded.canonicalHash)
+    }
+
+    @Test
+    fun savePosition_readiumEnvelope_roundTrips() = runTest {
+        repo.upsertBook(book())
+        val readiumJSON = """{"href":"/ch3.xhtml","locations":{"progression":0.4}}"""
+        val envelope = VReaderLocator(
+            fingerprintKey = key,
+            originalFormat = BookFormat.epub,
+            engine = ReaderLocatorEngine.readium,
+            readiumLocatorJSON = readiumJSON,
+            legacyLocator = null,
+        )
+        repo.savePosition(envelope, updatedAt = 7L)
+
+        val loaded = repo.loadPosition(key)!!
+        assertEquals(ReaderLocatorEngine.readium, loaded.engine)
+        assertEquals(readiumJSON, loaded.readiumLocatorJSON)
+        assertNull(loaded.legacyLocator)
+    }
+
+    @Test
+    fun savePosition_isReplaceOnConflict() = runTest {
+        repo.upsertBook(book())
+        repo.savePosition(VReaderLocator.wrapLegacy(legacyLocatorAt(0.1)), updatedAt = 1L)
+        repo.savePosition(VReaderLocator.wrapLegacy(legacyLocatorAt(0.9)), updatedAt = 2L)
+        assertEquals(0.9, repo.loadPosition(key)?.legacyLocator?.progression!!, 1e-9)
+    }
+
+    @Test
+    fun loadPosition_missing_isNull() = runTest {
+        assertNull(repo.loadPosition(key))
+    }
+
+    @Test
+    fun deleteBook_cascadesPosition() = runTest {
+        repo.upsertBook(book())
+        repo.savePosition(VReaderLocator.wrapLegacy(legacyLocatorAt(0.5)), updatedAt = 1L)
+        repo.deleteBook(key)
+        assertNull("position cascade-deleted with its book", repo.loadPosition(key))
+    }
+
+    /**
+     * Gate-4 Critical regression: re-importing a book must NOT wipe its saved
+     * position. @Upsert updates the book in place; a REPLACE (delete+insert) would
+     * fire the ON DELETE CASCADE and silently drop the reading_positions row.
+     */
+    @Test
+    fun reUpsertBook_preservesSavedPosition() = runTest {
+        repo.upsertBook(book(title = "v1"))
+        repo.savePosition(VReaderLocator.wrapLegacy(legacyLocatorAt(0.7)), updatedAt = 1L)
+        repo.upsertBook(book(title = "v2 re-import"))   // same fingerprintKey
+        assertEquals("v2 re-import", repo.findBook(key)?.title)
+        assertEquals(0.7, repo.loadPosition(key)?.legacyLocator?.progression!!, 1e-9)
+    }
+
+    @Test
+    fun savePosition_rejectsNegativePage() = runTest {
+        repo.upsertBook(book())
+        val bad = Locator(contentSHA256 = sha, fileByteCount = 2048, format = "pdf", page = -1)
+        assertThrowsIllegalArgument { repo.savePosition(VReaderLocator.wrapLegacy(bad), updatedAt = 1L) }
+        assertNull("nothing persisted for an invalid locator", repo.loadPosition(key))
+    }
+
+    @Test
+    fun savePosition_rejectsInvertedRange() = runTest {
+        repo.upsertBook(book())
+        val bad = Locator(
+            contentSHA256 = sha, fileByteCount = 2048, format = "txt",
+            charRangeStartUTF16 = 50, charRangeEndUTF16 = 10,
+        )
+        assertThrowsIllegalArgument { repo.savePosition(VReaderLocator.wrapLegacy(bad), updatedAt = 1L) }
+    }
+
+    /** Asserts a suspend block throws IllegalArgumentException (no nested runTest). */
+    private suspend fun assertThrowsIllegalArgument(block: suspend () -> Unit) {
+        var threw = false
+        try {
+            block()
+        } catch (e: IllegalArgumentException) {
+            threw = true
+        }
+        assertTrue("expected IllegalArgumentException", threw)
+    }
+
+    @Test
+    fun savePosition_repairsNonFiniteProgression() = runTest {
+        repo.upsertBook(book())
+        val infinite = Locator(
+            contentSHA256 = sha, fileByteCount = 2048, format = "epub",
+            href = "ch.xhtml", progression = Double.POSITIVE_INFINITY,
+        )
+        // Non-finite is repaired (nulled), not rejected — mirrors the iOS persistence
+        // boundary. It must store without throwing and load back with null progression.
+        repo.savePosition(VReaderLocator.wrapLegacy(infinite), updatedAt = 1L)
+        assertNull(repo.loadPosition(key)?.legacyLocator?.progression)
+    }
+
+    /**
+     * Gate-4 Medium: the position is stored as the WHOLE envelope JSON, so a future
+     * envelope field (written by a newer app) survives a round-trip on an older
+     * decoder WITHOUT a Room schema change. Insert a raw envelope JSON carrying an
+     * unknown field directly, then load it back through the repository.
+     */
+    @Test
+    fun loadPosition_toleratesForwardEnvelopeField() = runTest {
+        repo.upsertBook(book())
+        val futureJson =
+            """{"fingerprintKey":"$key","originalFormat":"epub","engine":"readium",""" +
+                """"readiumLocatorJSON":"{}","legacyLocator":null,"schemaVersion":2,""" +
+                """"futureOnlyField":"ignored-by-older-build"}"""
+        db.readingPositionDao().upsert(
+            ReadingPositionEntity(
+                fingerprintKey = key,
+                vreaderLocatorJSON = futureJson,
+                canonicalHash = "deadbeef",
+                updatedAt = 1L,
+            ),
+        )
+        val loaded = repo.loadPosition(key)!!
+        assertEquals(ReaderLocatorEngine.readium, loaded.engine)
+        assertEquals(2, loaded.schemaVersion)
+    }
+
+    private fun legacyLocatorAt(progression: Double) = Locator(
+        contentSHA256 = sha, fileByteCount = 2048, format = "epub",
+        href = "ch.xhtml", progression = progression,
+    )
+}

--- a/android/app/src/test/kotlin/com/vreader/app/data/VReaderDatabaseMigrationTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/data/VReaderDatabaseMigrationTest.kt
@@ -1,0 +1,133 @@
+package com.vreader.app.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Migration round-trip for [VReaderDatabase] (feature #106 WI-3). Hand-builds a v1
+ * database (the books+positions baseline, WITHOUT the v2 `lastOpenedAt` column),
+ * seeds a book + its position, then opens the real Room DB (version 2) with
+ * [VReaderDatabase.MIGRATION_1_2] registered — proving the additive migration runs,
+ * Room's structural validation passes, and the seeded data survives.
+ */
+@RunWith(RobolectricTestRunner::class)
+class VReaderDatabaseMigrationTest {
+    private val dbName = "migration-roundtrip.db"
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private val key = "epub:${"a".repeat(64)}:2048"
+
+    @Before
+    fun setUp() {
+        context.deleteDatabase(dbName)
+    }
+
+    @After
+    fun tearDown() {
+        context.deleteDatabase(dbName)
+    }
+
+    @Test
+    fun migrate1To2_preservesData_andAddsNullableColumn() {
+        seedVersion1Database()
+
+        // Open the current (v2) Room DB on the v1 file — triggers MIGRATION_1_2.
+        val db = Room.databaseBuilder(context, VReaderDatabase::class.java, dbName)
+            .addMigrations(VReaderDatabase.MIGRATION_1_2)
+            .build()
+        try {
+            val book = runBlocking { db.bookDao().find(key) }
+            assertNotNull("book survived the migration", book)
+            assertEquals("Pre-migration Book", book!!.title)
+            assertNull("new v2 column defaults to null for migrated rows", book.lastOpenedAt)
+
+            val position = runBlocking { db.readingPositionDao().find(key) }
+            assertNotNull("position survived the migration", position)
+            assertTrue(
+                "envelope JSON survived intact",
+                position!!.vreaderLocatorJSON.contains("readium"),
+            )
+        } finally {
+            db.close()
+        }
+    }
+
+    /**
+     * Creates the v1 schema directly (no Room) — exactly the v2 structure minus
+     * `books.lastOpenedAt`. Room's post-migration validation is structural (PRAGMA
+     * table/index/fk info), so the column names/affinities/PK/FK/index must match
+     * what Room expects for v2 after MIGRATION_1_2 adds the column.
+     */
+    private fun seedVersion1Database() {
+        val callback = object : SupportSQLiteOpenHelper.Callback(1) {
+            override fun onCreate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `books` (
+                        `fingerprintKey` TEXT NOT NULL,
+                        `title` TEXT NOT NULL,
+                        `originalFormat` TEXT NOT NULL,
+                        `contentSHA256` TEXT NOT NULL,
+                        `fileByteCount` INTEGER NOT NULL,
+                        `localFilePath` TEXT,
+                        `sourceUri` TEXT,
+                        `addedAt` INTEGER NOT NULL,
+                        PRIMARY KEY(`fingerprintKey`)
+                    )
+                    """.trimIndent(),
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `reading_positions` (
+                        `fingerprintKey` TEXT NOT NULL,
+                        `vreaderLocatorJSON` TEXT NOT NULL,
+                        `canonicalHash` TEXT NOT NULL,
+                        `updatedAt` INTEGER NOT NULL,
+                        PRIMARY KEY(`fingerprintKey`),
+                        FOREIGN KEY(`fingerprintKey`) REFERENCES `books`(`fingerprintKey`)
+                            ON UPDATE NO ACTION ON DELETE CASCADE
+                    )
+                    """.trimIndent(),
+                )
+            }
+
+            override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
+        }
+
+        val helper = FrameworkSQLiteOpenHelperFactory().create(
+            SupportSQLiteOpenHelper.Configuration.builder(context)
+                .name(dbName)
+                .callback(callback)
+                .build(),
+        )
+        helper.writableDatabase.use { db ->
+            db.execSQL(
+                "INSERT INTO books " +
+                    "(fingerprintKey, title, originalFormat, contentSHA256, fileByteCount, " +
+                    "localFilePath, sourceUri, addedAt) VALUES (?,?,?,?,?,?,?,?)",
+                arrayOf<Any?>(key, "Pre-migration Book", "epub", "a".repeat(64), 2048L, null, null, 1L),
+            )
+            val envelopeJson =
+                """{"fingerprintKey":"$key","originalFormat":"epub","engine":"readium",""" +
+                    """"readiumLocatorJSON":"{}","legacyLocator":null,"schemaVersion":1}"""
+            db.execSQL(
+                "INSERT INTO reading_positions " +
+                    "(fingerprintKey, vreaderLocatorJSON, canonicalHash, updatedAt) VALUES (?,?,?,?)",
+                arrayOf<Any?>(key, envelopeJson, "deadbeef", 1L),
+            )
+        }
+    }
+}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -12,4 +12,7 @@ plugins {
     // version as the app, per the Gate-2 toolchain pin).
     id("org.jetbrains.kotlin.jvm") version "2.3.20" apply false
     id("org.jetbrains.kotlin.plugin.serialization") version "2.3.20" apply false
+    // feature #106 WI-3 — Room codegen via KSP. KSP 2.3.9 is the build matched to
+    // Kotlin 2.3.20 (its stdlib dep is 2.3.20); the new standalone KSP versioning.
+    id("com.google.devtools.ksp") version "2.3.9" apply false
 }

--- a/android/identity/build.gradle.kts
+++ b/android/identity/build.gradle.kts
@@ -12,7 +12,10 @@ plugins {
 }
 
 dependencies {
-    testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+    // feature #106 WI-3 — the VReaderLocator/Locator envelope value types
+    // (`@Serializable`) live in main now, so serialization-json is an
+    // `implementation` dep, not test-only.
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
     testImplementation(kotlin("test"))
 }
 

--- a/android/identity/src/main/kotlin/vreader/contracts/Locator.kt
+++ b/android/identity/src/main/kotlin/vreader/contracts/Locator.kt
@@ -1,0 +1,110 @@
+package vreader.contracts
+
+import kotlinx.serialization.Serializable
+
+/** Validation failures for [Locator] field values — mirrors Swift `LocatorValidationError`. */
+enum class LocatorValidationError {
+    negativePageIndex,
+    negativeUTF16Offset,
+    invertedUTF16Range,
+    nonFiniteProgression,
+}
+
+/**
+ * Engine-neutral reading position within a book — the Kotlin value type that
+ * mirrors Swift `Locator` (vreader/Models/Locator.swift). Carries the book
+ * identity triple (`contentSHA256`/`fileByteCount`/`format`) plus the per-format
+ * position fields; format determines which fields apply (EPUB = href+progression
+ * +cfi, PDF = page, TXT = UTF-16 offsets). All position fields are optional.
+ *
+ * This is the **canonical** half of the persisted `VReaderLocator` envelope — it
+ * is what survives an engine swap / cross-device restore. `canonicalJson()` /
+ * `fingerprintKey` delegate to the existing [CanonicalLocator] / [Identity]
+ * references so there is ONE serialization contract, asserted by the conformance
+ * lane.
+ */
+@Serializable
+data class Locator(
+    val contentSHA256: String,
+    val fileByteCount: Long,
+    val format: String,
+    val href: String? = null,
+    val progression: Double? = null,
+    val totalProgression: Double? = null,
+    val page: Int? = null,
+    val charOffsetUTF16: Int? = null,
+    val charRangeStartUTF16: Int? = null,
+    val charRangeEndUTF16: Int? = null,
+    val cfi: String? = null,
+    val textQuote: String? = null,
+    val textContextBefore: String? = null,
+    val textContextAfter: String? = null,
+) {
+    /** The book identity key this locator points into (= DocumentFingerprint.canonicalKey). */
+    val fingerprintKey: String
+        get() = Identity.canonicalKey(format, contentSHA256, fileByteCount)
+
+    /**
+     * Validates field values — byte-for-byte the same contract as Swift
+     * `Locator.validate()`: non-negative page/offsets, both range endpoints present
+     * together with start <= end, finite progressions. Returns null when valid.
+     */
+    fun validate(): LocatorValidationError? {
+        page?.let { if (it < 0) return LocatorValidationError.negativePageIndex }
+        charOffsetUTF16?.let { if (it < 0) return LocatorValidationError.negativeUTF16Offset }
+        charRangeStartUTF16?.let { if (it < 0) return LocatorValidationError.negativeUTF16Offset }
+        charRangeEndUTF16?.let { if (it < 0) return LocatorValidationError.negativeUTF16Offset }
+        // Both range endpoints together or neither.
+        if ((charRangeStartUTF16 != null) != (charRangeEndUTF16 != null)) {
+            return LocatorValidationError.invertedUTF16Range
+        }
+        val start = charRangeStartUTF16
+        val end = charRangeEndUTF16
+        if (start != null && end != null && start > end) return LocatorValidationError.invertedUTF16Range
+        progression?.let { if (!it.isFinite()) return LocatorValidationError.nonFiniteProgression }
+        totalProgression?.let { if (!it.isFinite()) return LocatorValidationError.nonFiniteProgression }
+        return null
+    }
+
+    /** This locator if valid, else null — the Kotlin form of Swift `Locator.validated(...)`. */
+    fun validatedOrNull(): Locator? = if (validate() == null) this else null
+
+    /**
+     * Nulls a non-finite progression/totalProgression so an invalid input is stored
+     * as a valid locator rather than re-introducing the canonicalize collision —
+     * mirrors iOS `Locator.repairedForCanonicalization()` (feature #109 WI-2), the
+     * persistence-boundary repair. Structural invalidity (negative/inverted) is NOT
+     * repaired (it can't be silently fixed); the caller rejects those.
+     */
+    fun repairedForCanonicalization(): Locator {
+        val progNonFinite = progression?.isFinite() == false
+        val totalNonFinite = totalProgression?.isFinite() == false
+        if (!progNonFinite && !totalNonFinite) return this
+        return copy(
+            progression = progression?.takeIf { it.isFinite() },
+            totalProgression = totalProgression?.takeIf { it.isFinite() },
+        )
+    }
+
+    /**
+     * Engine-neutral canonical JSON — delegates to [CanonicalLocator] (the single
+     * cross-platform serialization contract). Rejects a non-finite progression
+     * (mirrors Swift `Locator.validate()`; bug #356).
+     */
+    fun canonicalJson(): String = CanonicalLocator.canonicalJson(
+        contentSHA256 = contentSHA256,
+        fileByteCount = fileByteCount,
+        format = format,
+        cfi = cfi,
+        charOffsetUTF16 = charOffsetUTF16,
+        charRangeEndUTF16 = charRangeEndUTF16,
+        charRangeStartUTF16 = charRangeStartUTF16,
+        href = href,
+        page = page,
+        progression = progression,
+        textContextAfter = textContextAfter,
+        textContextBefore = textContextBefore,
+        textQuote = textQuote,
+        totalProgression = totalProgression,
+    )
+}

--- a/android/identity/src/main/kotlin/vreader/contracts/VReaderLocator.kt
+++ b/android/identity/src/main/kotlin/vreader/contracts/VReaderLocator.kt
@@ -1,0 +1,90 @@
+package vreader.contracts
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.security.MessageDigest
+
+/**
+ * Which reader engine produced the authoritative locator in a [VReaderLocator]
+ * (mirrors Swift `ReaderLocatorEngine`). Exactly two persisted cases.
+ */
+enum class ReaderLocatorEngine {
+    /** The legacy bespoke EPUB WKWebView engine — locator lives in `legacyLocator`. */
+    epubWKWebView,
+
+    /** The Readium toolkit engine — locator lives in `readiumLocatorJSON`. */
+    readium,
+}
+
+/**
+ * Durable, engine-agnostic reading-position envelope — the Kotlin mirror of Swift
+ * `VReaderLocator` (vreader/Models/VReaderLocator.swift). The persistence layer
+ * stores THIS, never a bare [Locator] (feature #106 Gate-2 Critical): saved
+ * positions survive an engine swap / re-conversion because the envelope records
+ * which engine is authoritative plus the canonical fallback.
+ *
+ * - `readiumLocatorJSON` — Readium's own CFI-bearing JSON (platform-local; the
+ *   cross-platform fallback is `legacyLocator`'s progression + textQuote).
+ * - `legacyLocator` — the engine-neutral [Locator] (canonical resume anchor).
+ * - `schemaVersion` — the envelope's own migration hook, independent of the Room
+ *   database schema version.
+ *
+ * `@Serializable` so the Room layer can JSON-encode the whole envelope into one
+ * column (the iOS analog persists it as `Data?` on `ReadingPosition`).
+ */
+@Serializable
+data class VReaderLocator(
+    val fingerprintKey: String,
+    val originalFormat: BookFormat,
+    val engine: ReaderLocatorEngine,
+    val readiumLocatorJSON: String? = null,
+    val legacyLocator: Locator? = null,
+    val schemaVersion: Int = CURRENT_SCHEMA_VERSION,
+) {
+    /**
+     * SHA-256 (hex) of this envelope's deterministic JSON encoding — stable across
+     * encode/decode round-trips, for local dedup/sync keys (mirrors Swift
+     * `VReaderLocator.canonicalHash`).
+     *
+     * NOTE: this is **locally** deterministic (kotlinx fixed field order). It is
+     * NOT yet asserted byte-equal to Swift's `JSONEncoder(.sortedKeys)` output —
+     * cross-platform *envelope*-vector parity is the deferred WI-2 conformance
+     * extension. Use it for on-device dedup, not (yet) for cross-device sync keys.
+     */
+    val canonicalHash: String
+        get() {
+            val bytes = CANONICAL_JSON.encodeToString(this).toByteArray(Charsets.UTF_8)
+            return MessageDigest.getInstance("SHA-256").digest(bytes)
+                .joinToString("") { "%02x".format(it) }
+        }
+
+    companion object {
+        /** Current envelope schema version (independent of the Room DB version). */
+        const val CURRENT_SCHEMA_VERSION = 1
+
+        private val CANONICAL_JSON = Json { encodeDefaults = true }
+
+        /**
+         * Wraps an engine-neutral [Locator] as a legacy-engine envelope, deriving
+         * `fingerprintKey`/`originalFormat` from the locator's identity triple —
+         * mirrors Swift `init(legacyLocator:)`. The format string must be a valid
+         * [BookFormat] raw value (it came from a `DocumentFingerprint`).
+         */
+        fun wrapLegacy(
+            legacyLocator: Locator,
+            schemaVersion: Int = CURRENT_SCHEMA_VERSION,
+        ): VReaderLocator {
+            val format = BookFormat.entries.firstOrNull { it.name == legacyLocator.format }
+                ?: error("invalid BookFormat raw value: ${legacyLocator.format}")
+            return VReaderLocator(
+                fingerprintKey = legacyLocator.fingerprintKey,
+                originalFormat = format,
+                engine = ReaderLocatorEngine.epubWKWebView,
+                readiumLocatorJSON = null,
+                legacyLocator = legacyLocator,
+                schemaVersion = schemaVersion,
+            )
+        }
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.1.1
-versionCode=2
+versionName=0.1.2
+versionCode=3


### PR DESCRIPTION
## Summary

The Android persistence layer (the iOS `PersistenceActor` analog), keyed on the shared `:identity` contracts:

- `:identity` gains engine-neutral envelope value types `Locator`, `ReaderLocatorEngine`, `VReaderLocator` (`@Serializable`, `canonicalHash`, `wrapLegacy`) mirroring the Swift refs; `Locator` carries Swift-parity `validate()`/`validatedOrNull()`/`repairedForCanonicalization()`.
- `:app` Room layer: `BookEntity` + `ReadingPositionEntity` (stores the **full serialized `VReaderLocator` envelope** in one column, NOT a bare Locator — Gate-2 Critical; the envelope evolves independently of the Room schema), `@Upsert` DAOs, `VReaderDatabase` (v2 + schema-versioned `MIGRATION_1_2` scaffold + `exportSchema`), `LibraryRepository` returning DTOs. `savePosition` repairs non-finite + rejects structurally-invalid locators.
- Room 2.8.4 + KSP 2.3.9 (matched to Kotlin 2.3.20) wired into the Gradle build.

Part of feature #1739 (Android foundation bar, WI-3 of 7).

## Tests

Robolectric/JVM via `scripts/run-android-tests.sh :app:testDebugUnitTest` — **17 data-layer tests, 0 failures**:
- `LibraryRepositoryTest` (16): in-memory Room CRUD, envelope round-trip (legacy + readium), CJK title, ordering, FK cascade, **re-upsert-preserves-position regression**, negative-page/inverted-range rejection, non-finite repair, forward-envelope-field tolerance.
- `VReaderDatabaseMigrationTest` (1): hand-built v1 DB → Room migrates to v2 via `MIGRATION_1_2`, data survives.
- `contracts/conformance/run.sh kotlin` → CONFORMANCE RESULT: PASS (the `:identity` additions are non-breaking).

## Codex Audit (Gate-4)

3 rounds, verdict **ship-as-is**. Round 1 found a Critical (REPLACE cascade-wipe), High (missing Locator validation), Medium (envelope flattening) — all fixed with tests. The round-2 schema-version concern was withdrawn in round 3 on verified never-shipped state (no Room schema has ever reached `main`/a tag/a device). Log: `.claude/codex-audits/feat-feature-106-wi3-room-audit.md`.

## Version

`android/version.properties` → 0.1.2 (versionCode 3).

## Type of Change

- [x] New behavioral (persistence) WI (Android, WI-3)