### PR TITLE
feat(#106 WI-6): resume bridge plumbing (Readium Locator ↔ VReaderLocator)

### DIFF
--- a/.claude/codex-audits/feat-feature-106-wi6-resume-bridge-audit.md
+++ b/.claude/codex-audits/feat-feature-106-wi6-resume-bridge-audit.md
@@ -1,0 +1,47 @@
+---
+branch: feat/feature-106-wi6-resume-bridge
+threadId: 019eda-wi6-resume-2rounds
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-18
+---
+
+# Gate-4 audit — feature #106 WI-6 (resume bridge PLUMBING)
+
+WI-6 ships the UI-free resume plumbing (the reader-host `locationDidChange`/
+process-death wiring is design-blocked #1745): `ReadiumLocatorBridge` (Readium
+Locator JSON ↔ `VReaderLocator` envelope) + `ResumeResolver` (precise-first /
+canonical-fallback, the `contracts/identity/locator.md` resume rule). Pure JVM —
+consumes the documented Readium Locator JSON shape, no Readium dependency. Room
+save/restore of the envelope already shipped in WI-3.
+
+Codex (gpt-5.4, high), 2 rounds.
+
+## Round 1 — 1 High, 1 Medium, 1 Low (block-recommended)
+
+| file | sev | issue | resolution |
+|---|---|---|---|
+| ResumeResolver.kt | **High** | `Precise(json)` discarded `legacyLocator`, so if the Readium anchor can't reapply on the device the contract's precise-then-canonical fallback is impossible through this API. | `ResumeTarget.Precise(readiumLocatorJSON, canonicalFallback: Locator?)` now carries the fallback; the resolver passes `envelope.legacyLocator`. Test `precise_carriesCanonicalFallback_forDegradedRestore`. |
+| ReadiumLocatorBridge.kt | Medium | `toEnvelope` decoded unguarded — blank/malformed JSON threw a raw `SerializationException` out of the bridge with no defined degraded behavior. | Added typed `ReaderLocatorParseException`; decode wrapped in try/catch. Tests `toEnvelope_blankJSON_throwsTyped`, `toEnvelope_malformedJSON_throwsTyped`. |
+| ReadiumLocatorBridge.kt | Low | `readiumLocatorJSON()` treated whitespace JSON as a present anchor, disagreeing with `ResumeResolver` (blank ⇒ absent). | Helper now `?.takeIf { it.isNotBlank() && engine == readium }`. Test `readiumLocatorJSON_nullForBlankAnchor`. |
+
+## Round 2 — all resolved, no new findings (ship-as-is)
+
+Auditor confirmed each fix on inspection; no still-open or new finding.
+
+## Validation
+
+- `scripts/run-android-tests.sh :app:testDebugUnitTest` → **SUCCEEDED**; reader
+  tests `ReadiumLocatorBridgeTest` 8 + `ResumeResolverTest` 6 = 14, full `:app`
+  suite 40, 0 failures.
+- `contracts/conformance/run.sh kotlin` → **PASS** (unchanged — `:identity`
+  untouched this WI).
+- `android/app/build.gradle.kts` gained `kotlin.plugin.serialization` for the
+  local `@Serializable` `ReadiumLocatorDto` (the cross-module `:identity`
+  `@Serializable` types compiled there already; the in-`:app` DTO needs the plugin
+  in `:app`). Auditor confirmed the addition correct and minimal.
+
+## Verdict
+
+**ship-as-is.** All round-1 findings (High + Medium + Low) resolved with tests;
+zero open Critical/High/Medium after 2 rounds.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -9,7 +9,8 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
-    id("com.google.devtools.ksp")   // feature #106 WI-3 — Room codegen
+    id("com.google.devtools.ksp")                        // feature #106 WI-3 — Room codegen
+    id("org.jetbrains.kotlin.plugin.serialization")      // feature #106 WI-6 — @Serializable in :app (ReadiumLocatorDto)
 }
 
 // Read via Gradle's provider API so `version.properties` is a TRACKED input

--- a/android/app/src/main/kotlin/com/vreader/app/reader/ReadiumLocatorBridge.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/ReadiumLocatorBridge.kt
@@ -1,0 +1,104 @@
+// Purpose: Bridge between Readium's own Locator JSON and vreader's engine-neutral
+// VReaderLocator envelope — feature #106 WI-6 (Gate-2 Critical resume). Consumes the
+// DOCUMENTED Readium Locator JSON shape (href + locations.progression/
+// totalProgression + text.before/highlight/after), so it carries NO Readium
+// dependency and is pure-JVM testable. The (design-blocked, #1745) reader host will
+// convert Readium's `Locator` <-> JSON via Readium's own toJSON()/fromJSON() and hand
+// the string to this bridge; the bridge keeps the verbatim JSON for precise restore
+// AND derives a canonical fallback Locator for cross-platform/degraded resume.
+package com.vreader.app.reader
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import vreader.contracts.BookFormat
+import vreader.contracts.Locator
+import vreader.contracts.ReaderLocatorEngine
+import vreader.contracts.VReaderLocator
+
+/** A Readium Locator JSON string could not be decoded (blank / malformed / corrupt). */
+class ReaderLocatorParseException(message: String, cause: Throwable? = null) : Exception(message, cause)
+
+/** The minimal slice of Readium's Locator JSON the resume contract needs. */
+@Serializable
+private data class ReadiumLocatorDto(
+    val href: String? = null,
+    val locations: Locations? = null,
+    val text: Text? = null,
+) {
+    @Serializable
+    data class Locations(
+        val progression: Double? = null,
+        val totalProgression: Double? = null,
+        val position: Int? = null,
+    )
+
+    @Serializable
+    data class Text(
+        val before: String? = null,
+        val highlight: String? = null,
+        val after: String? = null,
+    )
+}
+
+/**
+ * Converts between a Readium Locator JSON string and the [VReaderLocator] envelope.
+ * The [bookContentSHA256]/[bookFileByteCount]/[bookFormat] triple supplies the book
+ * identity Readium's locator omits (it only describes a position WITHIN a known book).
+ */
+class ReadiumLocatorBridge(
+    private val json: Json = DEFAULT_JSON,
+) {
+    /**
+     * Wraps a Readium Locator JSON string as a `readium`-engine [VReaderLocator]:
+     * keeps the verbatim JSON for precise on-device restore AND derives a canonical
+     * fallback [Locator] (href + progression + text-quote) for degraded/cross-platform
+     * resume. A non-finite progression in the Readium JSON is dropped from the fallback
+     * (it would make the canonical locator invalid).
+     */
+    fun toEnvelope(
+        readiumLocatorJSON: String,
+        bookContentSHA256: String,
+        bookFileByteCount: Long,
+        bookFormat: BookFormat,
+    ): VReaderLocator {
+        // Defined degraded behavior for corrupt upstream input: a typed failure the
+        // caller can catch (never a raw SerializationException out of the bridge).
+        val dto = try {
+            json.decodeFromString<ReadiumLocatorDto>(readiumLocatorJSON)
+        } catch (e: Exception) {
+            throw ReaderLocatorParseException("malformed Readium Locator JSON", e)
+        }
+        val fallback = Locator(
+            contentSHA256 = bookContentSHA256,
+            fileByteCount = bookFileByteCount,
+            format = bookFormat.name,
+            href = dto.href,
+            progression = dto.locations?.progression?.takeIf { it.isFinite() },
+            totalProgression = dto.locations?.totalProgression?.takeIf { it.isFinite() },
+            textQuote = dto.text?.highlight,
+            textContextBefore = dto.text?.before,
+            textContextAfter = dto.text?.after,
+        )
+        return VReaderLocator(
+            fingerprintKey = fallback.fingerprintKey,
+            originalFormat = bookFormat,
+            engine = ReaderLocatorEngine.readium,
+            readiumLocatorJSON = readiumLocatorJSON,
+            legacyLocator = fallback,
+        )
+    }
+
+    /**
+     * The verbatim Readium Locator JSON to feed back to the navigator for a PRECISE
+     * restore, or null when the envelope has no Readium locator (a legacy-engine
+     * position → the caller uses the canonical fallback instead).
+     */
+    fun readiumLocatorJSON(envelope: VReaderLocator): String? =
+        envelope.readiumLocatorJSON
+            ?.takeIf { it.isNotBlank() && envelope.engine == ReaderLocatorEngine.readium }
+
+    companion object {
+        private val DEFAULT_JSON = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/ResumeResolver.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/ResumeResolver.kt
@@ -1,0 +1,48 @@
+// Purpose: Resolve a saved VReaderLocator envelope to a concrete restore target —
+// feature #106 WI-6 (Gate-2 Critical resume). Encodes the cross-platform resume rule
+// (contracts/identity/locator.md): try the PRECISE anchor first (Readium's own
+// locator JSON), fall back to the CANONICAL legacy locator (progression + text-quote)
+// so a position is restorable to at least progression precision even when the precise
+// anchor doesn't round-trip. Pure function — the (#1745 design-blocked) reader host
+// applies the target to the Readium navigator.
+package com.vreader.app.reader
+
+import vreader.contracts.Locator
+import vreader.contracts.ReaderLocatorEngine
+import vreader.contracts.VReaderLocator
+
+/** Where to restore a reader to, resolved from a saved [VReaderLocator]. */
+sealed interface ResumeTarget {
+    /**
+     * Feed [readiumLocatorJSON] to the navigator for an exact restore — and if that
+     * anchor can't be reapplied on this device/Readium version, degrade to
+     * [canonicalFallback] (progression/quote). The precise-FIRST-then-canonical rule
+     * lives in this one target so the host never loses the fallback (Gate-4 High).
+     */
+    data class Precise(val readiumLocatorJSON: String, val canonicalFallback: Locator?) : ResumeTarget
+
+    /** No precise anchor — approximate via the canonical [Locator] (progression/quote). */
+    data class Canonical(val locator: Locator) : ResumeTarget
+
+    /** No saved position — open at the beginning. */
+    data object None : ResumeTarget
+}
+
+object ResumeResolver {
+    /**
+     * Precise-first / canonical-fallback. A `readium`-engine envelope with a non-blank
+     * `readiumLocatorJSON` restores precisely, carrying its `legacyLocator` as the
+     * degrade target; otherwise the canonical `legacyLocator` (progression + text-quote)
+     * drives a degraded restore; a null envelope or one carrying neither anchor opens
+     * at the start.
+     */
+    fun resolve(envelope: VReaderLocator?): ResumeTarget {
+        if (envelope == null) return ResumeTarget.None
+        val readium = envelope.readiumLocatorJSON
+        if (envelope.engine == ReaderLocatorEngine.readium && !readium.isNullOrBlank()) {
+            return ResumeTarget.Precise(readium, envelope.legacyLocator)
+        }
+        envelope.legacyLocator?.let { return ResumeTarget.Canonical(it) }
+        return ResumeTarget.None
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/ReadiumLocatorBridgeTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/ReadiumLocatorBridgeTest.kt
@@ -1,0 +1,113 @@
+package com.vreader.app.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import vreader.contracts.BookFormat
+import vreader.contracts.Identity
+import vreader.contracts.ReaderLocatorEngine
+
+/**
+ * ReadiumLocatorBridge maps Readium's Locator JSON ↔ the VReaderLocator envelope
+ * (feature #106 WI-6). Pure JVM — no Android/Readium dependency, just the documented
+ * Readium Locator JSON shape.
+ */
+class ReadiumLocatorBridgeTest {
+    private val bridge = ReadiumLocatorBridge()
+    private val sha = "a".repeat(64)
+    private val bytes = 4096L
+
+    @Test
+    fun toEnvelope_keepsVerbatimJSON_andDerivesCanonicalFallback() {
+        val readiumJson = """
+            {"href":"/OEBPS/ch3.xhtml","type":"application/xhtml+xml","title":"Ch 3",
+             "locations":{"progression":0.4213,"totalProgression":0.18,"position":12},
+             "text":{"before":"… and then ","highlight":"Call me Ishmael","after":" . Some"}}
+        """.trimIndent()
+
+        val env = bridge.toEnvelope(readiumJson, sha, bytes, BookFormat.epub)
+
+        assertEquals(ReaderLocatorEngine.readium, env.engine)
+        assertEquals("verbatim Readium JSON kept for precise restore", readiumJson, env.readiumLocatorJSON)
+        assertEquals(BookFormat.epub, env.originalFormat)
+        assertEquals(Identity.canonicalKey("epub", sha, bytes), env.fingerprintKey)
+
+        val fb = env.legacyLocator!!
+        assertEquals("/OEBPS/ch3.xhtml", fb.href)
+        assertEquals(0.4213, fb.progression!!, 1e-9)
+        assertEquals(0.18, fb.totalProgression!!, 1e-9)
+        assertEquals("Call me Ishmael", fb.textQuote)
+        assertEquals("… and then ", fb.textContextBefore)
+        assertEquals(" . Some", fb.textContextAfter)
+        assertEquals(sha, fb.contentSHA256)
+        assertEquals(bytes, fb.fileByteCount)
+    }
+
+    @Test
+    fun toEnvelope_minimalJSON_derivesNullableFields() {
+        val env = bridge.toEnvelope("""{"href":"/c.xhtml"}""", sha, bytes, BookFormat.epub)
+        val fb = env.legacyLocator!!
+        assertEquals("/c.xhtml", fb.href)
+        assertNull(fb.progression)
+        assertNull(fb.textQuote)
+    }
+
+    @Test
+    fun toEnvelope_ignoresUnknownReadiumFields() {
+        // Real Readium locators carry cssSelector/domRange/fragments/etc. — must not break.
+        val json = """
+            {"href":"/c.xhtml","locations":{"progression":0.5,"cssSelector":"#x","fragments":["t=1"],
+             "domRange":{"start":{"cssSelector":"#x"}}},"text":{"highlight":"q"}}
+        """.trimIndent()
+        val env = bridge.toEnvelope(json, sha, bytes, BookFormat.epub)
+        assertEquals(0.5, env.legacyLocator!!.progression!!, 1e-9)
+        assertEquals("q", env.legacyLocator!!.textQuote)
+    }
+
+    @Test
+    fun readiumLocatorJSON_returnsVerbatimForReadiumEngine() {
+        val json = """{"href":"/c.xhtml","locations":{"progression":0.2}}"""
+        val env = bridge.toEnvelope(json, sha, bytes, BookFormat.epub)
+        assertEquals(json, bridge.readiumLocatorJSON(env))
+    }
+
+    @Test
+    fun toEnvelope_blankJSON_throwsTyped() {
+        var threw = false
+        try {
+            bridge.toEnvelope("   ", sha, bytes, BookFormat.epub)
+        } catch (e: ReaderLocatorParseException) {
+            threw = true
+        }
+        assertEquals(true, threw)
+    }
+
+    @Test
+    fun toEnvelope_malformedJSON_throwsTyped() {
+        var threw = false
+        try {
+            bridge.toEnvelope("""{"href": }""", sha, bytes, BookFormat.epub)
+        } catch (e: ReaderLocatorParseException) {
+            threw = true
+        }
+        assertEquals(true, threw)
+    }
+
+    @Test
+    fun readiumLocatorJSON_nullForBlankAnchor() {
+        val env = vreader.contracts.VReaderLocator(
+            fingerprintKey = "epub:$sha:$bytes", originalFormat = BookFormat.epub,
+            engine = ReaderLocatorEngine.readium, readiumLocatorJSON = "  ", legacyLocator = null,
+        )
+        assertNull("blank anchor is treated as absent (consistent with ResumeResolver)", bridge.readiumLocatorJSON(env))
+    }
+
+    @Test
+    fun readiumLocatorJSON_nullForLegacyEngine() {
+        val legacy = vreader.contracts.VReaderLocator.wrapLegacy(
+            vreader.contracts.Locator(contentSHA256 = sha, fileByteCount = bytes, format = "epub",
+                href = "/c.xhtml", progression = 0.3),
+        )
+        assertNull("legacy engine has no Readium locator", bridge.readiumLocatorJSON(legacy))
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/ResumeResolverTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/ResumeResolverTest.kt
@@ -1,0 +1,80 @@
+package com.vreader.app.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import vreader.contracts.BookFormat
+import vreader.contracts.Locator
+import vreader.contracts.ReaderLocatorEngine
+import vreader.contracts.VReaderLocator
+
+/**
+ * ResumeResolver: precise-first / canonical-fallback (feature #106 WI-6, the
+ * cross-platform resume rule in contracts/identity/locator.md).
+ */
+class ResumeResolverTest {
+    private val sha = "b".repeat(64)
+    private fun legacy(progression: Double) = Locator(
+        contentSHA256 = sha, fileByteCount = 100, format = "epub", href = "/c.xhtml", progression = progression,
+    )
+
+    @Test
+    fun nullEnvelope_isNone() {
+        assertSame(ResumeTarget.None, ResumeResolver.resolve(null))
+    }
+
+    @Test
+    fun readiumEngineWithJSON_isPrecise() {
+        val json = """{"href":"/c.xhtml","locations":{"progression":0.7}}"""
+        val env = VReaderLocator(
+            fingerprintKey = "epub:$sha:100", originalFormat = BookFormat.epub,
+            engine = ReaderLocatorEngine.readium, readiumLocatorJSON = json, legacyLocator = legacy(0.7),
+        )
+        val target = ResumeResolver.resolve(env)
+        assertTrue(target is ResumeTarget.Precise)
+        assertEquals(json, (target as ResumeTarget.Precise).readiumLocatorJSON)
+    }
+
+    @Test
+    fun precise_carriesCanonicalFallback_forDegradedRestore() {
+        // The precise target must keep the canonical fallback so the host can degrade
+        // if the Readium anchor won't reapply (Gate-4 High).
+        val json = """{"href":"/c.xhtml","locations":{"progression":0.7}}"""
+        val fallback = legacy(0.7)
+        val env = VReaderLocator(
+            fingerprintKey = "epub:$sha:100", originalFormat = BookFormat.epub,
+            engine = ReaderLocatorEngine.readium, readiumLocatorJSON = json, legacyLocator = fallback,
+        )
+        val target = ResumeResolver.resolve(env) as ResumeTarget.Precise
+        assertEquals(fallback, target.canonicalFallback)
+    }
+
+    @Test
+    fun readiumEngineWithBlankJSON_fallsBackToCanonical() {
+        val env = VReaderLocator(
+            fingerprintKey = "epub:$sha:100", originalFormat = BookFormat.epub,
+            engine = ReaderLocatorEngine.readium, readiumLocatorJSON = "  ", legacyLocator = legacy(0.4),
+        )
+        val target = ResumeResolver.resolve(env)
+        assertTrue(target is ResumeTarget.Canonical)
+        assertEquals(0.4, (target as ResumeTarget.Canonical).locator.progression!!, 1e-9)
+    }
+
+    @Test
+    fun legacyEngine_isCanonical() {
+        val env = VReaderLocator.wrapLegacy(legacy(0.25))
+        val target = ResumeResolver.resolve(env)
+        assertTrue(target is ResumeTarget.Canonical)
+        assertEquals(0.25, (target as ResumeTarget.Canonical).locator.progression!!, 1e-9)
+    }
+
+    @Test
+    fun readiumEngineWithNoAnchors_isNone() {
+        val env = VReaderLocator(
+            fingerprintKey = "epub:$sha:100", originalFormat = BookFormat.epub,
+            engine = ReaderLocatorEngine.readium, readiumLocatorJSON = null, legacyLocator = null,
+        )
+        assertSame(ResumeTarget.None, ResumeResolver.resolve(env))
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.1.3
-versionCode=4
+versionName=0.1.4
+versionCode=5


### PR DESCRIPTION
## Summary

UI-free resume **plumbing** (the reader-host `locationDidChange` / process-death wiring is design-blocked #1745; Room save/restore of the envelope shipped in WI-3):

- **`ReadiumLocatorBridge`** — maps Readium's documented Locator JSON ↔ the `VReaderLocator` envelope: keeps the verbatim JSON for precise restore AND derives a canonical fallback `Locator` (href + progression + text quote). No Readium dependency (consumes the JSON shape only) → pure-JVM testable. Decode failures surface a typed `ReaderLocatorParseException`.
- **`ResumeResolver`** — precise-first / canonical-fallback (`contracts/identity/locator.md`). `ResumeTarget.Precise` carries the canonical fallback so the host can degrade if the Readium anchor won't reapply.

Part of feature #1739 (Android foundation bar, WI-6 of 7).

## Tests

`scripts/run-android-tests.sh :app:testDebugUnitTest` → **SUCCEEDED**, 14 reader tests (ReadiumLocatorBridgeTest 8 + ResumeResolverTest 6), full `:app` suite 40, 0 failures. `contracts/conformance/run.sh kotlin` → PASS.

## Codex Audit (Gate-4)

2 rounds, verdict **ship-as-is**. R1: High (precise dropped the canonical fallback), Medium (unguarded decode → raw `SerializationException`), Low (blank-anchor inconsistency) — all fixed + tested. Log: `.claude/codex-audits/feat-feature-106-wi6-resume-bridge-audit.md`.

## Rule 51

The `locationDidChange`/process-death reader wiring is **design-blocked (#1745)**; this PR ships only the non-UI resume plumbing.

## Version

`android/version.properties` → 0.1.4 (versionCode 5).