### PR TITLE
feat(#111 WI-1): TXT decode + range-based document model

### DIFF
--- a/.claude/codex-audits/feat-feature-111-wi1-txt-decode-audit.md
+++ b/.claude/codex-audits/feat-feature-111-wi1-txt-decode-audit.md
@@ -1,0 +1,45 @@
+---
+branch: feat/feature-111-wi1-txt-decode
+threadId: 019ede-wi1-txt-1round
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-19
+---
+
+# Gate-4 audit — feature #111 WI-1 (Android TXT decode + document model)
+
+WI-1 is the foundational offset/decode contract for the Android TXT reader:
+`TxtDecoder` (BOM-first charset detection + decode; BOM-less fallback strict-UTF-8 →
+GBK heuristic → UTF-8 replacement) and `TxtDocument` (range-based chunking over one
+backing decoded `String`; UTF-16 `offsetForChunk`/`chunkForOffset` against the RAW
+text; hard-split at `maxChunkChars` never mid-surrogate-pair; EOF clamp). Pure JVM.
+
+Codex (gpt-5.4, high), 1 round, follow-up-recommended → fixed to ship-as-is.
+
+## Findings (1 Medium, 1 Low — both fixed)
+
+| file | sev | issue | resolution |
+|---|---|---|---|
+| TxtDocument.kt | Medium | chunk-start collection used `ArrayList<Int>` + `toIntArray()` → boxed every offset + a duplicating copy; a newline-dense 14MB file spikes tens of MB of transient objects (breaks the "one String + one IntArray" profile). | Rewrote with a primitive growable `IntArray` (double-on-full + a single `copyOf(count)` trim) — no Int boxing. |
+| TxtDecoder.kt | Low | empty input → `confident = true` (strict UTF-8 accepts empty), inconsistent with "real charset evidence" elsewhere. | Special-cased empty → `confident = false`; test `emptyFile_decodesToEmpty_notConfident` asserts it. |
+
+## Confirmed correct (auditor, no correctness bugs)
+
+- BOM stripping + detection order correct (UTF-8 / UTF-16 LE/BE).
+- GBK cannot shadow valid UTF-8 — strict UTF-8 runs first.
+- Offsets are raw UTF-16 code-unit indexes; CRLF/CR/LF preserved (no normalization)
+  — the resume contract holds.
+- The surrogate-pair hard-split always advances and never splits a valid pair.
+- `chunkForOffset` clamp + binary search sound; empty/single-line/no-newline edges correct.
+
+## Validation
+
+`scripts/run-android-tests.sh :app:testDebugUnitTest` → **SUCCEEDED**; `TxtDecoderTest`
+7 + `TxtDocumentTest` 7 = 14 tests (UTF-16LE/BE BOM+CJK, GBK fallback, empty-not-confident,
+mixed CRLF/CR/LF preservation, surrogate-pair safety, EOF clamp, huge-line split,
+offset↔chunk round-trip), 0 failures. Full `:app` suite green.
+
+## Verdict
+
+**ship-as-is.** No correctness bugs; the Medium (memory) + Low (confident semantics)
+fixed with tests.

--- a/android/app/src/main/kotlin/com/vreader/app/reader/TxtDecoder.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/TxtDecoder.kt
@@ -1,0 +1,56 @@
+// Purpose: Decode a .txt file's bytes to a String with charset detection — feature
+// #111 WI-1 (the Android analog of iOS EncodingDetector). BOM-first (deterministic
+// for UTF-8 / UTF-16 LE/BE — the real fixture is UTF-16LE+BOM); BOM-less falls back
+// explicitly: strict UTF-8 → a single GBK heuristic (CJK) → UTF-8 with replacement.
+// Pure JVM (no Android deps) so it's unit-testable without Robolectric.
+package com.vreader.app.reader
+
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.charset.Charset
+import java.nio.charset.CodingErrorAction
+
+/** A decoded text + the charset used + whether detection was confident (BOM / valid strict decode). */
+data class TxtDecodeResult(val charsetName: String, val text: String, val confident: Boolean)
+
+object TxtDecoder {
+    private val UTF8_BOM = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
+
+    fun decode(file: File): TxtDecodeResult = decode(file.readBytes())
+
+    fun decode(bytes: ByteArray): TxtDecodeResult {
+        // Empty input has no charset evidence — confident reflects "real charset
+        // signal", not merely "decoded without error".
+        if (bytes.isEmpty()) return TxtDecodeResult("UTF-8", "", confident = false)
+        // 1. BOM — deterministic. Strip the BOM bytes so they don't appear as U+FEFF.
+        if (bytes.size >= 3 && bytes[0] == UTF8_BOM[0] && bytes[1] == UTF8_BOM[1] && bytes[2] == UTF8_BOM[2]) {
+            return TxtDecodeResult("UTF-8", String(bytes, 3, bytes.size - 3, Charsets.UTF_8), confident = true)
+        }
+        if (bytes.size >= 2 && bytes[0] == 0xFF.toByte() && bytes[1] == 0xFE.toByte()) {
+            return TxtDecodeResult("UTF-16LE", String(bytes, 2, bytes.size - 2, Charsets.UTF_16LE), confident = true)
+        }
+        if (bytes.size >= 2 && bytes[0] == 0xFE.toByte() && bytes[1] == 0xFF.toByte()) {
+            return TxtDecodeResult("UTF-16BE", String(bytes, 2, bytes.size - 2, Charsets.UTF_16BE), confident = true)
+        }
+        // 2. BOM-less: strict UTF-8 (valid UTF-8 is rarely accidental).
+        decodeStrict(bytes, Charsets.UTF_8)?.let { return TxtDecodeResult("UTF-8", it, confident = true) }
+        // 3. Single heuristic guess for CJK: GBK (low confidence — decodes most byte
+        //    sequences, so it's a guess, not a detection).
+        runCatching { Charset.forName("GBK") }.getOrNull()?.let { gbk ->
+            decodeStrict(bytes, gbk)?.let { return TxtDecodeResult("GBK", it, confident = false) }
+        }
+        // 4. Last resort: UTF-8 with replacement (never throws; lossy).
+        return TxtDecodeResult("UTF-8", String(bytes, Charsets.UTF_8), confident = false)
+    }
+
+    /** Decode strictly (report malformed/unmappable) — returns null if the bytes aren't valid in [charset]. */
+    private fun decodeStrict(bytes: ByteArray, charset: Charset): String? = try {
+        charset.newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT)
+            .decode(ByteBuffer.wrap(bytes))
+            .toString()
+    } catch (e: Exception) {
+        null
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt
@@ -1,0 +1,90 @@
+// Purpose: Addressable, range-based model of a decoded .txt — feature #111 WI-1.
+// Holds ONE backing decoded String and an array of chunk START offsets (UTF-16 code
+// units against the RAW text — NO line-ending normalization, so charOffsetUTF16 stays
+// exact for resume). Splits at line boundaries (CRLF/CR/LF kept inside the chunk);
+// hard-splits a runaway line at maxChunkChars (never mid-surrogate-pair). Visible
+// chunk text is materialized on demand (no per-chunk substrings retained). Pure JVM.
+package com.vreader.app.reader
+
+class TxtDocument private constructor(
+    val text: String,
+    private val starts: IntArray,
+) {
+    /** Number of chunks (0 for empty text). */
+    val chunkCount: Int get() = starts.size
+
+    /** The UTF-16 start offset of chunk [index] (clamped to a valid chunk). */
+    fun offsetForChunk(index: Int): Int {
+        if (starts.isEmpty()) return 0
+        return starts[index.coerceIn(0, starts.size - 1)]
+    }
+
+    /** The chunk index containing [offsetUtf16] (EOF-clamped); 0 for empty text. */
+    fun chunkForOffset(offsetUtf16: Int): Int {
+        if (starts.isEmpty()) return 0
+        val offset = offsetUtf16.coerceIn(0, text.length)
+        // Largest start <= offset (binary search).
+        var lo = 0; var hi = starts.size - 1; var ans = 0
+        while (lo <= hi) {
+            val mid = (lo + hi) ushr 1
+            if (starts[mid] <= offset) { ans = mid; lo = mid + 1 } else { hi = mid - 1 }
+        }
+        return ans
+    }
+
+    /** The text of chunk [index], materialized on demand from the backing string. */
+    fun textForChunk(index: Int): CharSequence {
+        if (starts.isEmpty()) return ""
+        val i = index.coerceIn(0, starts.size - 1)
+        val end = if (i + 1 < starts.size) starts[i + 1] else text.length
+        return text.subSequence(starts[i], end)
+    }
+
+    companion object {
+        const val DEFAULT_MAX_CHUNK_CHARS = 4000
+
+        /**
+         * Build a document from already-decoded [text]. Chunk boundaries fall after a
+         * line terminator (`\n`, `\r`, or `\r\n` — preserved in the chunk); a line longer
+         * than [maxChunkChars] is hard-split, but never between a surrogate pair.
+         */
+        fun of(text: String, maxChunkChars: Int = DEFAULT_MAX_CHUNK_CHARS): TxtDocument {
+            if (text.isEmpty()) return TxtDocument(text, IntArray(0))
+            // Primitive growable IntArray (no Int boxing) — a newline-dense 14MB file
+            // would otherwise spike tens of MB of boxed Integers + a duplicating copy.
+            var starts = IntArray(64)
+            var count = 0
+            fun push(v: Int) {
+                if (count == starts.size) starts = starts.copyOf(starts.size * 2)
+                starts[count++] = v
+            }
+            push(0)
+            var i = 0
+            var chunkStart = 0
+            val n = text.length
+            while (i < n) {
+                val c = text[i]
+                when {
+                    c == '\n' -> {
+                        i++
+                        if (i < n) { push(i); chunkStart = i }
+                    }
+                    c == '\r' -> {
+                        i++
+                        if (i < n && text[i] == '\n') i++   // CRLF stays one terminator
+                        if (i < n) { push(i); chunkStart = i }
+                    }
+                    else -> {
+                        i++
+                        // Hard-split a runaway line, but not mid-surrogate-pair (don't
+                        // split right after a high surrogate — its low half follows at i).
+                        if (i - chunkStart >= maxChunkChars && i < n && !text[i - 1].isHighSurrogate()) {
+                            push(i); chunkStart = i
+                        }
+                    }
+                }
+            }
+            return TxtDocument(text, starts.copyOf(count))
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/TxtDecoderTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/TxtDecoderTest.kt
@@ -1,0 +1,70 @@
+package com.vreader.app.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.charset.Charset
+
+/**
+ * TxtDecoder charset detection (feature #111 WI-1). BOM-first is deterministic; the
+ * real fixture is UTF-16LE+BOM CJK, exercised here synthetically (CI can't read the
+ * gitignored test-books/, so a constructed UTF-16LE CJK byte array stands in).
+ */
+class TxtDecoderTest {
+    private val cjk = "测试文本\n第二行"
+
+    @Test fun utf8_noBom_isConfident() {
+        val r = TxtDecoder.decode("Hello, world\nsecond".toByteArray(Charsets.UTF_8))
+        assertEquals("UTF-8", r.charsetName)
+        assertTrue(r.confident)
+        assertEquals("Hello, world\nsecond", r.text)
+    }
+
+    @Test fun utf8_withBom_stripsBom() {
+        val bom = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
+        val r = TxtDecoder.decode(bom + cjk.toByteArray(Charsets.UTF_8))
+        assertEquals("UTF-8", r.charsetName)
+        assertTrue(r.confident)
+        assertEquals(cjk, r.text)                      // BOM removed
+        assertFalse("no U+FEFF leftover", r.text.startsWith("﻿"))
+    }
+
+    @Test fun utf16le_withBom_decodesCjk() {
+        val bom = byteArrayOf(0xFF.toByte(), 0xFE.toByte())
+        val r = TxtDecoder.decode(bom + cjk.toByteArray(Charsets.UTF_16LE))
+        assertEquals("UTF-16LE", r.charsetName)
+        assertTrue(r.confident)
+        assertEquals(cjk, r.text)
+    }
+
+    @Test fun utf16be_withBom_decodesCjk() {
+        val bom = byteArrayOf(0xFE.toByte(), 0xFF.toByte())
+        val r = TxtDecoder.decode(bom + cjk.toByteArray(Charsets.UTF_16BE))
+        assertEquals("UTF-16BE", r.charsetName)
+        assertTrue(r.confident)
+        assertEquals(cjk, r.text)
+    }
+
+    @Test fun gbk_bomlessCjk_fallsBackLowConfidence() {
+        val gbk = Charset.forName("GBK")
+        val bytes = cjk.toByteArray(gbk)               // valid GBK, NOT valid UTF-8
+        val r = TxtDecoder.decode(bytes)
+        assertEquals("GBK", r.charsetName)
+        assertFalse("heuristic guess is not confident", r.confident)
+        assertEquals(cjk, r.text)
+    }
+
+    @Test fun emptyFile_decodesToEmpty_notConfident() {
+        val r = TxtDecoder.decode(ByteArray(0))
+        assertEquals("", r.text)
+        assertFalse("empty input has no charset evidence", r.confident)
+    }
+
+    @Test fun decode_neverThrows_onArbitraryBytes() {
+        // 0xFF 0xFF isn't a UTF-16 BOM, fails strict UTF-8; the replacement fallback
+        // must still produce a (lossy) string rather than throw.
+        val r = TxtDecoder.decode(byteArrayOf(0xFF.toByte(), 0xFF.toByte(), 0x41))
+        assertTrue(r.text.isNotEmpty())
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/TxtDocumentTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/TxtDocumentTest.kt
@@ -1,0 +1,79 @@
+package com.vreader.app.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * TxtDocument range-based chunking + UTF-16-offset addressing (feature #111 WI-1).
+ * Offsets index the RAW decoded string (no line-ending normalization) so
+ * charOffsetUTF16 stays exact for resume.
+ */
+class TxtDocumentTest {
+    private fun TxtDocument.roundTrip(): String =
+        (0 until chunkCount).joinToString("") { textForChunk(it).toString() }
+
+    @Test fun mixedLineEndings_preservedAndChunked() {
+        val text = "a\r\nb\nc\rd"   // CRLF, LF, CR, then no terminator
+        val doc = TxtDocument.of(text)
+        assertEquals(4, doc.chunkCount)
+        assertEquals("a\r\n", doc.textForChunk(0).toString())
+        assertEquals("b\n", doc.textForChunk(1).toString())
+        assertEquals("c\r", doc.textForChunk(2).toString())
+        assertEquals("d", doc.textForChunk(3).toString())
+        assertEquals("round-trips byte-for-byte", text, doc.roundTrip())
+        assertEquals(3, doc.offsetForChunk(1))
+        assertEquals(5, doc.offsetForChunk(2))
+    }
+
+    @Test fun offsetForChunk_chunkForOffset_roundTrip() {
+        val doc = TxtDocument.of("line1\nline2\nline3\nlast")
+        for (i in 0 until doc.chunkCount) {
+            assertEquals(i, doc.chunkForOffset(doc.offsetForChunk(i)))
+        }
+        // An offset inside a chunk resolves to that chunk.
+        assertEquals(1, doc.chunkForOffset(doc.offsetForChunk(1) + 2))
+    }
+
+    @Test fun eofClamp_andNegative() {
+        val doc = TxtDocument.of("a\nb\nc")
+        assertEquals(doc.chunkCount - 1, doc.chunkForOffset(10_000))   // past EOF
+        assertEquals(0, doc.chunkForOffset(-50))                       // before start
+    }
+
+    @Test fun surrogatePairs_neverSplitMidPair() {
+        // A long line of emojis (each a surrogate pair) far exceeding the chunk bound.
+        val emoji = "😀"   // U+1F600, one surrogate pair (2 UTF-16 units)
+        val text = emoji.repeat(5_000)   // 10,000 UTF-16 units, no line breaks
+        val doc = TxtDocument.of(text, maxChunkChars = 1000)
+        assertTrue("a huge line is hard-split", doc.chunkCount > 1)
+        assertEquals("round-trips exactly", text, doc.roundTrip())
+        // No chunk boundary lands on a low surrogate (which would split a pair).
+        for (i in 0 until doc.chunkCount) {
+            val start = doc.offsetForChunk(i)
+            assertFalse("chunk start $start is mid-surrogate-pair", text[start].isLowSurrogate())
+        }
+    }
+
+    @Test fun noNewline_hardSplitByMaxChunk() {
+        val text = "x".repeat(10_000)
+        val doc = TxtDocument.of(text, maxChunkChars = 4000)
+        assertTrue(doc.chunkCount >= 3)
+        assertEquals(text, doc.roundTrip())
+    }
+
+    @Test fun emptyDocument_isInert() {
+        val doc = TxtDocument.of("")
+        assertEquals(0, doc.chunkCount)
+        assertEquals(0, doc.offsetForChunk(0))
+        assertEquals(0, doc.chunkForOffset(5))
+        assertEquals("", doc.textForChunk(0).toString())
+    }
+
+    @Test fun singleLine_noTerminator_isOneChunk() {
+        val doc = TxtDocument.of("just one line")
+        assertEquals(1, doc.chunkCount)
+        assertEquals("just one line", doc.textForChunk(0).toString())
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.3.0
-versionCode=9
+versionName=0.3.1
+versionCode=10


### PR DESCRIPTION
## Summary

Foundational offset/decode contract for the Android TXT reader (Phase 3, #110 driver):
- **`TxtDecoder`** — BOM-first charset detection (UTF-8 / UTF-16 LE/BE) + explicit BOM-less fallback (strict UTF-8 → GBK heuristic → UTF-8 replacement). Pure JVM.
- **`TxtDocument`** — range-based over ONE backing decoded `String`: line-boundary chunks with separators (CRLF/CR/LF) **preserved**, UTF-16 `offsetForChunk`/`chunkForOffset` addressing against the raw text, EOF clamp, runaway-line hard-split that never breaks a surrogate pair, primitive `IntArray` (no boxing).

Part of feature #1757 (TXT reader, WI-1 of 3 — foundational).

## Tests

`scripts/run-android-tests.sh :app:testDebugUnitTest` → SUCCEEDED — 14 JVM tests (`TxtDecoderTest` 7 + `TxtDocumentTest` 7): UTF-16LE/BE BOM+CJK, GBK fallback, empty-not-confident, mixed CRLF/CR/LF preservation, surrogate-pair safety, EOF clamp, huge-line split, offset↔chunk round-trip.

## Codex Audit (Gate-4)

1 round, **ship-as-is** — no correctness bugs (BOM/offset/surrogate/binary-search confirmed); Medium (boxed `ArrayList<Int>` → primitive `IntArray`) + Low (empty → `confident=false`) fixed. Log: `.claude/codex-audits/feat-feature-111-wi1-txt-decode-audit.md`.

## Version

`android/version.properties` → 0.3.1 (versionCode 10).