### PR TITLE
import(design): Android Phase-3 designs (#1766 PDF + #1767 backup/restore)

### DIFF
--- a/dev-docs/designs/vreader-fidelity-v1/project/design-notes/android-phase3-issues.md
+++ b/dev-docs/designs/vreader-fidelity-v1/project/design-notes/android-phase3-issues.md
@@ -1,0 +1,89 @@
+# Two Android Phase-3 needs-design issues — design notes
+
+> Resolves the design gaps blocking [#1766](https://github.com/lllyys/vreader/issues/1766) and [#1767](https://github.com/lllyys/vreader/issues/1767), both children of the [#110](https://github.com/lllyys/vreader/issues/110) Android Phase-3 capability-parity driver.
+> Source of truth: `VReader PDF Reader Canvas.html` and `VReader Backup Restore Canvas.html` (every state across themes).
+
+Both issues are blocked by Rule 51 (UI from the committed design bundle only). iOS gets these surfaces from system components (PDFKit's `PDFView`; the `Views/Backup` + `WebDAV*` subsystem); Android's `PdfRenderer` and the lack of a UI subsystem mean the surfaces have to be built — and therefore designed. These designs are rendered in VReader's existing vocabulary (the reader `THEMES`, Source-Serif titles, `#8c2f2f` / `#d6885a` accent, rounded-14 cards, the AI-provider form primitives) so Android reads as the same product, not a Material re-skin.
+
+---
+
+## #1766 · Android PDF reader — base page-view
+
+**Decision: continuous vertical scroll (canonical), with paged single-page as a Display-panel toggle.** Component file: `vreader-pdf-reader.jsx`. Canvas: `VReader PDF Reader Canvas.html`.
+
+### Why continuous scroll wins (the question the issue asks)
+
+`PdfRenderer` hands back one **bitmap per page**. The two layout options:
+
+- **A. Continuous scroll (CANONICAL).** Bitmaps stack vertically with gaps on a neutral viewer backdrop. This is the native grammar of every mainstream Android PDF surface (Drive, Files, Adobe), so it needs zero teaching. Crucially, a technical library (DDIA, Pragmatic Programmer — the actual PDFs in `BOOKS`) is figure-heavy, and a visible page edge above/below keeps figures and their captions legible. Tap-centre toggles chrome; the scroll itself is the navigation.
+- **B. Paged (alternative).** One page at a time, reusing the EPUB reader's left-30% / right-30% / centre tap-zones so PDF and EPUB share one navigation grammar. It loses page-edge context and re-rasterizes a fresh bitmap per turn. Good for prose-only PDFs; wrong as the default. Shipped as a **Display-panel toggle**, not a fork.
+
+### Surfaces & states
+
+| Area | Treatment |
+|---|---|
+| Page render area | Page bitmap floats on a neutral backdrop (`#cdc7ba` light / `#101010` dark), distinct from the reader paper tone so it reads as an object. |
+| Page progress | Floating glassy **"Page N of M"** pill, bottom-centre. Visible while scrolling / chrome-hidden. |
+| Chrome | Reuses `vreader-reader.jsx`'s vocabulary — back-chevron "Library" + italic serif title + icon row; bottom toolbar (Contents / Pages / Display / AI). |
+| Dark mode | The bitmap is drawn onto a **dimmed sheet**, not pure white — a full-white PDF page on OLED at night is the #1 PDF-reader complaint. Invert is a separate Display option. |
+| Loading | "Rendering page N…" — skeleton page frame + shimmer (the bitmap is rasterizing). |
+| Encrypted | Lock glyph + password field + Unlock; wrong-password sub-state. **Recoverable.** |
+| Corrupt | Undecodable file — re-import / back to Library. **Not recoverable in place.** |
+| Image-only (scan) | Not an error — the bitmap renders fine; only selection / translation degrade. |
+| Page jump | The "Pages" toolbar item: thumbnail strip + scrubber for non-linear navigation of a 600-page book. |
+
+Encrypted ≠ corrupt ≠ image-only — three visually distinct outcomes so the user knows whether to type a password, re-import, or just keep reading.
+
+---
+
+## #1767 · Android backup & WebDAV restore UI
+
+**Decision: three pushed surfaces in the app's own form vocabulary, every error naming its HTTP cause + the one action that fixes it.** Component file: `vreader-backup-webdav.jsx`. Canvas: `VReader Backup Restore Canvas.html`. Reuses the AI-provider editor's primitives (`UI`, `Card`, `Row`, `GroupHeader/Footer`, `Tag`, `PhoneFrame`, `AppSheet`) so Settings feels like one system.
+
+The **backend** (cross-platform backup-format per `contracts/identity/backup-format.md`, the WebDAV client, the restore import pipeline) is **not design-gated** and is verified separately via instrumented tests against a local WebDAV. Only the user-facing surfaces below were blocked.
+
+### A — WebDAV server settings
+
+Saved-servers list. Empty-state onboards (names the compatible hosts: Nextcloud, Fastmail, Synology). Populated rows carry a live **status dot** + the exact failure reason (`401 — authentication failed`), not a generic "error". Tap a row to edit/test; `+` adds.
+
+### B — Add / edit a server
+
+Name · Base URL · Username · Password · **Back up on Wi-Fi only** toggle. **Test Connection runs against the live form — no save first** (same contract as the AI-provider sheet) and reports the HTTP result inline (`Connected — found an existing /vreader folder with 3 backups` / `Failed: 401 Unauthorized`). Edit mode adds a destructive **Remove Server** with a confirm alert that promises the on-server backups are left untouched.
+
+### C — Backup & restore
+
+Active-server header + **Back Up Now** (which swaps to an inline `Backing up… 8 / 12` progress state), then the list of backups on the server (date · book count · size · device, newest tagged **Latest**). Covers `loading` (reading from server), `empty` (no backups → first-backup nudge), and **every WebDAV error the client can surface**: `401` (re-auth), `404` (no `/vreader` folder yet → back up to create it), `offline`, `timeout`. Each error states the cause and gives exactly one CTA.
+
+### D — Restore: confirm → progress → result
+
+- **Confirm alert** — states the merge rules explicitly: *"Merges 12 books… Nothing is deleted — existing books and progress are kept, newer versions win."*
+- **Progress** — radial percent + book-by-book label (`Downloading book 7 of 12 · The Pragmatic Programmer`) + Cancel.
+- **Result** — three distinct outcomes: **success** (Done), **partial** (`9 of 12… retry 3 books` in place), **failed** (`library unchanged` → try again). The partial/failed split is the part most apps get wrong; the copy always says what survived.
+
+**Restore never deletes** — this promise appears in the confirm alert, the screen footer, and the success copy. A backup is a merge, not a replace; that's what makes the big primary button safe.
+
+### E — Selective restore picker
+
+Choose which books to restore from a backup manifest. Per-book state is the whole point — a manifest can reference books not yet on this device:
+
+| State | Affordance |
+|---|---|
+| `local` | "On this device" + green dot — already here. |
+| `remote` | "Download · 1.8 MB" — pulled from the server lazily **on tap** (mirrors the iOS two-tap affordance, [#47](https://github.com/lllyys/vreader/issues/47)). |
+| `downloading` | Inline progress bar + percent. |
+| `failed` | "Download failed — tap to retry" — retries in place without restarting the whole restore. |
+
+Pinned footer totals the selection (`5 books selected · 3 already local · 2 will download`).
+
+---
+
+## Cross-references
+
+| File | Role |
+|---|---|
+| `VReader PDF Reader Canvas.html` | Canvas of every PDF-reader state across themes — #1766. |
+| `vreader-pdf-reader.jsx` | `PdfContinuousReader`, `PdfPagedReader`, `PdfPaper`, `PdfRendering`, `PdfEncrypted`, `PdfCorrupt`, `PdfPageJump`, reader chrome — #1766. |
+| `pdf-reader-artboards.jsx` | Canvas artboards — #1766. |
+| `VReader Backup Restore Canvas.html` | Canvas of every backup/WebDAV state across themes — #1767. |
+| `vreader-backup-webdav.jsx` | `WebDAVServerList`, `ServerEditSheet`, `BackupRestoreScreen`, `RestoreProgress`, `SelectiveRestoreSheet`, `AppAlert` — #1767. |
+| `backup-webdav-artboards.jsx` | Canvas artboards — #1767. |

--- a/dev-docs/designs/vreader-fidelity-v1/project/vreader-backup-webdav.jsx
+++ b/dev-docs/designs/vreader-fidelity-v1/project/vreader-backup-webdav.jsx
@@ -1,0 +1,682 @@
+// Android backup & WebDAV restore UI — issue #1767 (feature #110).
+//
+// iOS has a full subsystem (Views/Settings/WebDAV*, Views/Backup,
+// BackupViewModel). Android needs the equivalent USER-FACING surfaces.
+// The backend (backup-format model, WebDAV client, restore pipeline) is
+// implemented + emulator-verified separately and is NOT design-gated.
+//
+// Three surfaces, every state (idle / loading / empty / error / in-progress
+// / success / partial), rendered in VReader's own vocabulary — the paper /
+// dark tokens, Source-Serif titles, #8c2f2f accent, rounded-14 cards and
+// SectionLabel rows shared with the AI-provider editor. Primitives (UI, Card,
+// Row, GroupHeader, GroupFooter, Tag, Sep, PhoneFrame, AppSheet, APP_FONT,
+// SERIF, MONO) are reused from vreader-ai-provider-fields.jsx.
+//
+//   1. NavScreen / TopBar     — pushed settings screen scaffold
+//   2. Toggle, StatusDot, ConnBadge, AppAlert — shared bits
+//   3. WebDAVServerList       — saved servers (empty / populated / error)
+//   4. ServerEditSheet        — add / edit a server (+ test-connection states)
+//   5. BackupRestoreScreen    — back-up-now + available-backups list (states)
+//   6. RestoreProgress        — in-progress + success / partial / failed
+//   7. SelectiveRestoreSheet  — per-book restore picker w/ lazy download
+
+// ── shared bits ─────────────────────────────────────────────
+function Toggle({ ui, on }) {
+  return (
+    <div style={{
+      width: 44, height: 27, borderRadius: 14, flexShrink: 0,
+      background: on ? ui.tint : (ui.isDark ? 'rgba(255,255,255,0.16)' : 'rgba(0,0,0,0.16)'),
+      position: 'relative', transition: 'background .18s',
+    }}>
+      <div style={{
+        position: 'absolute', top: 2.5, left: on ? 20 : 2.5,
+        width: 22, height: 22, borderRadius: 11, background: '#fff',
+        boxShadow: '0 1px 3px rgba(0,0,0,0.3)', transition: 'left .18s',
+      }}/>
+    </div>
+  );
+}
+
+function StatusDot({ color, pulse }) {
+  return <span style={{
+    width: 8, height: 8, borderRadius: 4, background: color, flexShrink: 0,
+    boxShadow: pulse ? `0 0 0 3px ${color}33` : 'none',
+  }}/>;
+}
+
+// Top app bar — back chevron + serif title, optional trailing action.
+function TopBar({ ui, title, trailing, large = false }) {
+  return (
+    <div style={{
+      position: 'relative', zIndex: 10, background: ui.bg,
+      paddingTop: 38, borderBottom: large ? 'none' : `0.5px solid ${ui.sep}`,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', padding: '6px 8px 10px', minHeight: 44 }}>
+        <button style={{
+          display: 'flex', alignItems: 'center', gap: 1, padding: '6px 6px',
+          background: 'none', border: 'none', cursor: 'pointer', color: ui.tint,
+          fontFamily: APP_FONT, fontSize: 15, fontWeight: 500,
+        }}>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 6l-6 6 6 6"/></svg>
+          <span>Settings</span>
+        </button>
+        <div style={{ flex: 1 }}/>
+        {trailing}
+      </div>
+      {large && (
+        <div style={{ padding: '0 20px 14px' }}>
+          <div style={{ fontFamily: SERIF, fontSize: 28, fontWeight: 700, color: ui.ink, letterSpacing: -0.4 }}>{title}</div>
+        </div>
+      )}
+      {!large && (
+        <div style={{
+          position: 'absolute', top: 38, left: 0, right: 0, height: 50,
+          display: 'flex', alignItems: 'center', justifyContent: 'center', pointerEvents: 'none',
+        }}>
+          <span style={{ fontFamily: SERIF, fontSize: 17, fontWeight: 600, color: ui.ink }}>{title}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NavScreen({ ui, title, trailing, large, height = 880, children }) {
+  return (
+    <PhoneFrame ui={ui} height={height}>
+      <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', background: ui.bg }}>
+        <TopBar ui={ui} title={title} trailing={trailing} large={large}/>
+        <div className="hide-scroll" style={{ flex: 1, overflow: 'auto' }}>{children}</div>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+// centered iOS-style alert
+function AppAlert({ ui, title, children, buttons }) {
+  return (
+    <div style={{ position: 'absolute', inset: 0, zIndex: 300, background: 'rgba(0,0,0,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 28 }}>
+      <div style={{
+        width: '100%', maxWidth: 300, background: ui.isDark ? '#2a2724' : '#fbf7ef',
+        borderRadius: 18, overflow: 'hidden', boxShadow: '0 18px 50px rgba(0,0,0,0.4)',
+      }}>
+        <div style={{ padding: '20px 20px 16px', textAlign: 'center' }}>
+          <div style={{ fontFamily: SERIF, fontSize: 17, fontWeight: 700, color: ui.ink, marginBottom: 8 }}>{title}</div>
+          <div style={{ fontFamily: APP_FONT, fontSize: 13, color: ui.sec, lineHeight: 1.5 }}>{children}</div>
+        </div>
+        <div style={{ display: 'flex', borderTop: `0.5px solid ${ui.sep}` }}>
+          {buttons.map((b, i) => (
+            <React.Fragment key={i}>
+              {i > 0 && <div style={{ width: 0.5, background: ui.sep }}/>}
+              <div style={{
+                flex: 1, textAlign: 'center', padding: '13px 8px',
+                fontFamily: APP_FONT, fontSize: 15.5,
+                fontWeight: b.bold ? 700 : 500,
+                color: b.danger ? ui.red : ui.tint,
+              }}>{b.label}</div>
+            </React.Fragment>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ════════════════════════════════════════════════════
+// 3. WebDAVServerList
+// ════════════════════════════════════════════════════
+const SERVERS = [
+  { id: 'nas', name: 'Home NAS', url: 'nas.local/dav/vreader', user: 'leon', status: 'ok', detail: 'Connected · last sync 9:14 AM', wifiOnly: true },
+  { id: 'fm', name: 'Fastmail Files', url: 'myfiles.fastmail.com/dav', user: 'leon@fastmail.com', status: 'error', detail: '401 — authentication failed', wifiOnly: false },
+];
+
+function ServerRow({ ui, server, last }) {
+  const color = server.status === 'ok' ? ui.green : server.status === 'error' ? ui.red : ui.sec;
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', minHeight: 64, padding: '10px 14px', position: 'relative' }}>
+      <div style={{
+        width: 38, height: 38, borderRadius: 10, flexShrink: 0, marginRight: 12,
+        background: ui.isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.04)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}>
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={ui.sec} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="3" y="4" width="18" height="7" rx="1.5"/><rect x="3" y="13" width="18" height="7" rx="1.5"/><path d="M7 7.5h.01M7 16.5h.01"/>
+        </svg>
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontFamily: APP_FONT, fontSize: 15.5, fontWeight: 600, color: ui.ink, marginBottom: 3 }}>{server.name}</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <StatusDot color={color}/>
+          <span style={{ fontFamily: APP_FONT, fontSize: 12, color: server.status === 'error' ? ui.red : ui.sec, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{server.detail}</span>
+        </div>
+      </div>
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={ui.ter} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}><path d="M9 6l6 6-6 6"/></svg>
+      {!last && <div style={{ position: 'absolute', left: 64, right: 0, bottom: 0, height: 0.5, background: ui.sep }}/>}
+    </div>
+  );
+}
+
+function WebDAVServerList({ ui, empty = false, height = 880 }) {
+  const addBtn = (
+    <button style={{ background: 'none', border: 'none', padding: '6px 6px', cursor: 'pointer', color: ui.tint, display: 'flex', alignItems: 'center' }}>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M12 5v14M5 12h14"/></svg>
+    </button>
+  );
+  return (
+    <NavScreen ui={ui} title="WebDAV Servers" trailing={addBtn} large height={height}>
+      <div style={{ padding: '4px 18px 32px' }}>
+        {empty ? (
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center', padding: '64px 24px 0' }}>
+            <div style={{
+              width: 72, height: 72, borderRadius: 36, marginBottom: 20,
+              background: ui.isDark ? 'rgba(214,136,90,0.14)' : 'rgba(140,47,47,0.08)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+            }}>
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke={ui.tint} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                <rect x="3" y="4" width="18" height="7" rx="1.5"/><rect x="3" y="13" width="18" height="7" rx="1.5"/><path d="M7 7.5h.01M7 16.5h.01"/>
+              </svg>
+            </div>
+            <div style={{ fontFamily: SERIF, fontSize: 19, fontWeight: 600, color: ui.ink, marginBottom: 8, lineHeight: 1.25 }}>No servers yet</div>
+            <div style={{ fontFamily: APP_FONT, fontSize: 13.5, color: ui.sec, lineHeight: 1.55, maxWidth: 280, marginBottom: 22 }}>
+              Add a WebDAV server to back up your library and sync reading progress across devices. Works with Nextcloud, Fastmail, Synology, and any standard WebDAV host.
+            </div>
+            <button style={{
+              height: 46, padding: '0 22px', borderRadius: 100, border: 'none',
+              background: ui.tint, color: '#fff', fontFamily: APP_FONT, fontSize: 15, fontWeight: 600, cursor: 'pointer',
+              display: 'inline-flex', alignItems: 'center', gap: 7,
+            }}>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round"><path d="M12 5v14M5 12h14"/></svg>
+              Add Server
+            </button>
+          </div>
+        ) : (
+          <>
+            <GroupHeader ui={ui}>Saved Servers</GroupHeader>
+            <Card ui={ui}>
+              {SERVERS.map((s, i) => <ServerRow key={s.id} ui={ui} server={s} last={i === SERVERS.length - 1}/>)}
+            </Card>
+            <GroupFooter ui={ui}>Tap a server to edit its details or test the connection. The active server is used for automatic backups.</GroupFooter>
+
+            <div style={{ height: 22 }}/>
+            <Card ui={ui}>
+              <div style={{ display: 'flex', alignItems: 'center', minHeight: 50, padding: '0 14px', color: ui.tint, fontFamily: APP_FONT, fontSize: 15, fontWeight: 500, gap: 8 }}>
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round"><path d="M12 5v14M5 12h14"/></svg>
+                Add Server
+              </div>
+            </Card>
+          </>
+        )}
+      </div>
+    </NavScreen>
+  );
+}
+
+// ════════════════════════════════════════════════════
+// 4. ServerEditSheet — add / edit. test: idle|testing|ok|fail
+// ════════════════════════════════════════════════════
+function FieldRow({ ui, label, value, placeholder, mono, last, focused, secure }) {
+  const empty = !value;
+  return (
+    <Row ui={ui} label={label} last={last} focused={focused}>
+      <span style={{
+        fontFamily: mono ? MONO : APP_FONT, fontSize: mono ? 13.5 : 15,
+        color: empty ? ui.placeholder : ui.ink,
+        whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+        letterSpacing: secure ? 2 : 0,
+      }}>{empty ? placeholder : value}</span>
+    </Row>
+  );
+}
+
+function ServerEditSheet({ ui, mode = 'add', test = 'idle', height = 880 }) {
+  const editMode = mode === 'edit';
+  const name = editMode ? 'Home NAS' : '';
+  const url = editMode ? 'https://nas.local/dav/vreader' : '';
+  const user = editMode ? 'leon' : '';
+  const pass = editMode ? '••••••••••' : '';
+  const testResult = test === 'ok' || test === 'fail';
+  const canTest = editMode || true;
+
+  const Cancel = <button style={{ background: 'none', border: 'none', padding: 0, fontFamily: APP_FONT, fontSize: 15, color: ui.sec, cursor: 'pointer' }}>Cancel</button>;
+  const Save = <button style={{ background: 'none', border: 'none', padding: 0, fontFamily: APP_FONT, fontSize: 15, fontWeight: 600, color: editMode ? ui.tint : ui.ter, cursor: 'pointer' }}>Save</button>;
+
+  return (
+    <PhoneFrame ui={ui} height={height}>
+      <div style={{ position: 'absolute', inset: 0, background: ui.bg }}/>
+      <AppSheet ui={ui} title={editMode ? 'Edit Server' : 'Add Server'} leading={Cancel} trailing={Save} height={height - 36}>
+        <div style={{ padding: '16px 18px 32px' }}>
+          <GroupHeader ui={ui}>Server</GroupHeader>
+          <Card ui={ui}>
+            <FieldRow ui={ui} label="Name" value={name} placeholder="Home NAS"/>
+            <FieldRow ui={ui} label="Base URL" value={url} placeholder="https://host/dav" mono focused={!editMode}/>
+            <FieldRow ui={ui} label="Username" value={user} placeholder="Required" last/>
+          </Card>
+          <GroupFooter ui={ui}>The full WebDAV collection URL — the app stores backups in a <Code ui={ui}>/vreader</Code> folder there.</GroupFooter>
+
+          <div style={{ height: 20 }}/>
+          <GroupHeader ui={ui}>Authentication</GroupHeader>
+          <Card ui={ui}>
+            <FieldRow ui={ui} label="Password" value={pass} placeholder="Required" secure last/>
+          </Card>
+          <GroupFooter ui={ui}>Stored in the Android Keystore. Use an app password if your host offers one.</GroupFooter>
+
+          <div style={{ height: 20 }}/>
+          <GroupHeader ui={ui}>Sync</GroupHeader>
+          <Card ui={ui}>
+            <div style={{ display: 'flex', alignItems: 'center', minHeight: 50, padding: '0 14px' }}>
+              <span style={{ fontFamily: APP_FONT, fontSize: 15, color: ui.ink }}>Back up on Wi-Fi only</span>
+              <span style={{ flex: 1 }}/>
+              <Toggle ui={ui} on/>
+            </div>
+          </Card>
+          <GroupFooter ui={ui}>When off, backups may run over cellular data.</GroupFooter>
+
+          <div style={{ height: 20 }}/>
+          <GroupHeader ui={ui}>Connection</GroupHeader>
+          <Card ui={ui}>
+            <Row ui={ui} last={!testResult}>
+              <div style={{ display: 'flex', width: '100%', justifyContent: 'flex-start' }}>
+                <span style={{
+                  display: 'inline-flex', alignItems: 'center', gap: 7,
+                  fontFamily: APP_FONT, fontSize: 14, fontWeight: 600,
+                  color: canTest ? ui.tint : ui.ter,
+                  background: canTest ? ui.chipBg : 'transparent',
+                  boxShadow: canTest ? 'none' : `inset 0 0 0 1px ${ui.sep}`,
+                  borderRadius: 100, padding: '8px 15px',
+                }}>
+                  {test === 'testing' ? (
+                    <svg className="apf-spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={ui.tint} strokeWidth="2.4" strokeLinecap="round"><path d="M12 3a9 9 0 1 0 9 9"/></svg>
+                  ) : (
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={ui.tint} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12a7 7 0 0112-5l2 2M19 12a7 7 0 01-12 5l-2-2M17 4v3h-3M7 20v-3h3"/></svg>
+                  )}
+                  {test === 'testing' ? 'Testing…' : 'Test Connection'}
+                </span>
+              </div>
+            </Row>
+            {testResult && (
+              <Row ui={ui} last>
+                <div style={{ display: 'flex', alignItems: 'flex-start', gap: 7, width: '100%', justifyContent: 'flex-start', padding: '4px 0' }}>
+                  {test === 'ok' ? (
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0, marginTop: 1 }}><circle cx="12" cy="12" r="10" fill={ui.green}/><path d="M7.5 12.3l3 3 6-6.5" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none"/></svg>
+                  ) : (
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0, marginTop: 1 }}><circle cx="12" cy="12" r="10" fill={ui.red}/><path d="M8 8l8 8M16 8l-8 8" stroke="#fff" strokeWidth="2" strokeLinecap="round"/></svg>
+                  )}
+                  <span style={{ fontFamily: APP_FONT, fontSize: 13, color: test === 'ok' ? ui.green : ui.red, lineHeight: 1.45 }}>
+                    {test === 'ok' ? 'Connected — found an existing /vreader folder with 3 backups.' : 'Failed: 401 Unauthorized — check the username and password.'}
+                  </span>
+                </div>
+              </Row>
+            )}
+          </Card>
+
+          {editMode && (
+            <>
+              <div style={{ height: 28 }}/>
+              <Card ui={ui}>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: 50, color: ui.red, fontFamily: APP_FONT, fontSize: 15, fontWeight: 500 }}>
+                  Remove Server
+                </div>
+              </Card>
+            </>
+          )}
+        </div>
+      </AppSheet>
+    </PhoneFrame>
+  );
+}
+
+// ════════════════════════════════════════════════════
+// 5. BackupRestoreScreen — back-up-now + available backups
+//    state: 'idle' | 'loading' | 'empty' | 'error'
+//    err:   '401' | '404' | 'offline' | 'timeout'
+// ════════════════════════════════════════════════════
+const BACKUPS = [
+  { id: 'b1', when: 'Today, 9:14 AM', size: '4.2 MB', device: 'Pixel 8 · this device', books: 12, latest: true },
+  { id: 'b2', when: 'Yesterday, 10:01 PM', size: '4.1 MB', device: 'Pixel 8', books: 12 },
+  { id: 'b3', when: 'Jun 16, 8:30 AM', size: '3.9 MB', device: 'iPad Air', books: 11 },
+  { id: 'b4', when: 'Jun 9, 7:42 PM', size: '3.6 MB', device: 'iPhone 15', books: 10 },
+];
+
+function BackupHeaderCard({ ui, syncing }) {
+  return (
+    <Card ui={ui}>
+      <div style={{ padding: '14px 14px 16px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+          <StatusDot color={ui.green}/>
+          <span style={{ fontFamily: APP_FONT, fontSize: 12, fontWeight: 600, color: ui.sec, letterSpacing: 0.4, textTransform: 'uppercase', lineHeight: 1 }}>Active server</span>
+        </div>
+        <div style={{ fontFamily: APP_FONT, fontSize: 16, fontWeight: 600, color: ui.ink, lineHeight: 1.2 }}>Home NAS</div>
+        <div style={{ fontFamily: MONO, fontSize: 12, color: ui.sec, marginTop: 2 }}>nas.local/dav/vreader</div>
+        <button style={{
+          marginTop: 14, width: '100%', height: 46, borderRadius: 12, border: 'none', cursor: 'pointer',
+          background: syncing ? (ui.isDark ? 'rgba(214,136,90,0.16)' : 'rgba(140,47,47,0.1)') : ui.tint,
+          color: syncing ? ui.tint : '#fff',
+          fontFamily: APP_FONT, fontSize: 15, fontWeight: 600,
+          display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+        }}>
+          {syncing ? (
+            <><svg className="apf-spin" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke={ui.tint} strokeWidth="2.4" strokeLinecap="round"><path d="M12 3a9 9 0 1 0 9 9"/></svg>Backing up… 8 / 12</>
+          ) : (
+            <><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 16V4M7 9l5-5 5 5M5 20h14"/></svg>Back Up Now</>
+          )}
+        </button>
+      </div>
+    </Card>
+  );
+}
+
+function BackupItemRow({ ui, b, last }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', minHeight: 60, padding: '10px 14px', position: 'relative' }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 3 }}>
+          <span style={{ fontFamily: APP_FONT, fontSize: 15, fontWeight: 600, color: ui.ink }}>{b.when}</span>
+          {b.latest && <Tag ui={ui}>Latest</Tag>}
+        </div>
+        <div style={{ fontFamily: APP_FONT, fontSize: 12, color: ui.sec }}>
+          {b.books} books · {b.size} · {b.device}
+        </div>
+      </div>
+      <button style={{
+        flexShrink: 0, height: 32, padding: '0 14px', borderRadius: 100, cursor: 'pointer',
+        background: 'transparent', border: `1px solid ${ui.isDark ? 'rgba(214,136,90,0.4)' : 'rgba(140,47,47,0.3)'}`,
+        color: ui.tint, fontFamily: APP_FONT, fontSize: 13, fontWeight: 600,
+      }}>Restore</button>
+      {!last && <div style={{ position: 'absolute', left: 14, right: 0, bottom: 0, height: 0.5, background: ui.sep }}/>}
+    </div>
+  );
+}
+
+function BackupErrorBlock({ ui, err }) {
+  const map = {
+    '401': { t: 'Authentication failed', d: 'The server rejected your credentials (401). Re-enter the password in the server settings.', cta: 'Open Server Settings' },
+    '404': { t: 'No backup folder found', d: 'The /vreader folder doesn’t exist on this server yet (404). Run your first backup to create it.', cta: 'Back Up Now' },
+    'offline': { t: 'You’re offline', d: 'Connect to the internet to reach Home NAS, then pull to refresh.', cta: 'Retry' },
+    'timeout': { t: 'Server didn’t respond', d: 'The request to nas.local timed out. Check the server is reachable on your network.', cta: 'Retry' },
+  };
+  const e = map[err] || map.offline;
+  const glyph = err === 'offline'
+    ? <><path d="M7 18a4 4 0 010-8 6 6 0 0111.7 1.5A4 4 0 0118 18"/><path d="M3 3l18 18"/></>
+    : err === '401'
+      ? <><rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 018 0v3"/></>
+      : <><path d="M12 8v5M12 16v.01"/><circle cx="12" cy="12" r="9"/></>;
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center', padding: '40px 24px 0' }}>
+      <div style={{
+        width: 64, height: 64, borderRadius: 32, marginBottom: 18,
+        background: ui.isDark ? 'rgba(224,119,90,0.14)' : 'rgba(168,64,47,0.08)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}>
+        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke={ui.red} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">{glyph}</svg>
+      </div>
+      <div style={{ fontFamily: SERIF, fontSize: 18, fontWeight: 600, color: ui.ink, marginBottom: 8, lineHeight: 1.25 }}>{e.t}</div>
+      <div style={{ fontFamily: APP_FONT, fontSize: 13.5, color: ui.sec, lineHeight: 1.55, maxWidth: 280, marginBottom: 20 }}>{e.d}</div>
+      <button style={{
+        height: 44, padding: '0 20px', borderRadius: 100, border: 'none', cursor: 'pointer',
+        background: ui.tint, color: '#fff', fontFamily: APP_FONT, fontSize: 14.5, fontWeight: 600,
+      }}>{e.cta}</button>
+    </div>
+  );
+}
+
+function BackupRestoreScreen({ ui, state = 'idle', err = 'offline', syncing = false, height = 880 }) {
+  return (
+    <NavScreen ui={ui} title="Backup & Restore" large height={height}>
+      <div style={{ padding: '4px 18px 32px' }}>
+        <BackupHeaderCard ui={ui} syncing={syncing}/>
+
+        <div style={{ height: 22 }}/>
+        <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', padding: '0 2px' }}>
+          <GroupHeader ui={ui}>Available Backups</GroupHeader>
+          {state === 'idle' && <span style={{ fontFamily: APP_FONT, fontSize: 12, color: ui.sec }}>Home NAS</span>}
+        </div>
+
+        {state === 'loading' && (
+          <Card ui={ui}>
+            {[0, 1, 2].map(i => (
+              <div key={i} style={{ display: 'flex', alignItems: 'center', minHeight: 60, padding: '10px 14px', position: 'relative', gap: 12 }}>
+                <div style={{ flex: 1 }}>
+                  <div style={{ height: 11, width: '46%', borderRadius: 3, background: ui.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)', marginBottom: 7 }}/>
+                  <div style={{ height: 9, width: '66%', borderRadius: 3, background: ui.isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.04)' }}/>
+                </div>
+                {i < 2 && <div style={{ position: 'absolute', left: 14, right: 0, bottom: 0, height: 0.5, background: ui.sep }}/>}
+              </div>
+            ))}
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, padding: '12px', color: ui.sec, fontFamily: APP_FONT, fontSize: 12.5 }}>
+              <svg className="apf-spin" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={ui.sec} strokeWidth="2.4" strokeLinecap="round"><path d="M12 3a9 9 0 1 0 9 9"/></svg>
+              Reading backups from server…
+            </div>
+          </Card>
+        )}
+
+        {state === 'idle' && (
+          <>
+            <Card ui={ui}>
+              {BACKUPS.map((b, i) => <BackupItemRow key={b.id} ui={ui} b={b} last={i === BACKUPS.length - 1}/>)}
+            </Card>
+            <GroupFooter ui={ui}>Restoring merges a backup into your current library — nothing is deleted. Use selective restore to pick individual books.</GroupFooter>
+          </>
+        )}
+
+        {state === 'empty' && (
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', textAlign: 'center', padding: '36px 24px 0' }}>
+            <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke={ui.ter} strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" style={{ marginBottom: 14 }}>
+              <path d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"/>
+            </svg>
+            <div style={{ fontFamily: SERIF, fontSize: 17, fontWeight: 600, color: ui.ink, marginBottom: 6, lineHeight: 1.25 }}>No backups yet</div>
+            <div style={{ fontFamily: APP_FONT, fontSize: 13, color: ui.sec, lineHeight: 1.5, maxWidth: 260 }}>
+              This server has no VReader backups. Tap <b style={{ color: ui.ink }}>Back Up Now</b> to create your first one.
+            </div>
+          </div>
+        )}
+
+        {state === 'error' && <BackupErrorBlock ui={ui} err={err}/>}
+      </div>
+    </NavScreen>
+  );
+}
+
+// ════════════════════════════════════════════════════
+// 6. RestoreProgress — in-progress + result (success / partial / failed)
+// ════════════════════════════════════════════════════
+function RestoreProgress({ ui, mode = 'progress', height = 880 }) {
+  // mode: 'progress' | 'success' | 'partial' | 'failed'
+  const done = 7, total = 12;
+  const pct = mode === 'progress' ? done / total : 1;
+  const result = mode !== 'progress';
+
+  const resMeta = {
+    success: { color: ui.green, title: 'Restore complete', sub: `${total} of ${total} books restored from Today, 9:14 AM.` },
+    partial: { color: '#c79a2e', title: 'Restored with issues', sub: `9 of ${total} books restored. 3 couldn’t be downloaded — retry them below.` },
+    failed: { color: ui.red, title: 'Restore failed', sub: 'The connection dropped before any books were restored. Your library is unchanged.' },
+  }[mode];
+
+  return (
+    <PhoneFrame ui={ui} height={height}>
+      <div style={{ position: 'absolute', inset: 0, background: ui.bg, display: 'flex', flexDirection: 'column' }}>
+        <TopBar ui={ui} title="Restore" large={false}/>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '0 32px', textAlign: 'center' }}>
+
+          {/* progress ring / result mark */}
+          <div style={{ position: 'relative', width: 96, height: 96, marginBottom: 24 }}>
+            <svg width="96" height="96" viewBox="0 0 96 96" style={{ transform: 'rotate(-90deg)' }}>
+              <circle cx="48" cy="48" r="42" fill="none" stroke={ui.sep} strokeWidth="6"/>
+              <circle cx="48" cy="48" r="42" fill="none"
+                stroke={result ? resMeta.color : ui.tint} strokeWidth="6" strokeLinecap="round"
+                strokeDasharray={2 * Math.PI * 42}
+                strokeDashoffset={2 * Math.PI * 42 * (1 - pct)}
+                style={{ transition: 'stroke-dashoffset .4s' }}/>
+            </svg>
+            <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              {mode === 'progress' && <span style={{ fontFamily: APP_FONT, fontSize: 22, fontWeight: 700, color: ui.ink, fontVariantNumeric: 'tabular-nums' }}>{Math.round(pct * 100)}%</span>}
+              {mode === 'success' && <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke={ui.green} strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12.5l5 5 9-10"/></svg>}
+              {mode === 'partial' && <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="#c79a2e" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round"><path d="M12 8v5M12 16.5v.01"/></svg>}
+              {mode === 'failed' && <svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke={ui.red} strokeWidth="2.4" strokeLinecap="round"><path d="M7 7l10 10M17 7L7 17"/></svg>}
+            </div>
+          </div>
+
+          <div style={{ fontFamily: SERIF, fontSize: 20, fontWeight: 700, color: ui.ink, marginBottom: 8, lineHeight: 1.2 }}>
+            {result ? resMeta.title : 'Restoring your library'}
+          </div>
+          <div style={{ fontFamily: APP_FONT, fontSize: 13.5, color: ui.sec, lineHeight: 1.55, maxWidth: 270 }}>
+            {result ? resMeta.sub : `Downloading book ${done} of ${total} · The Pragmatic Programmer`}
+          </div>
+
+          {mode === 'progress' && (
+            <div style={{ width: '100%', maxWidth: 280, marginTop: 22 }}>
+              <div style={{ height: 5, borderRadius: 3, background: ui.sep, overflow: 'hidden' }}>
+                <div style={{ width: `${pct * 100}%`, height: '100%', background: ui.tint, borderRadius: 3, transition: 'width .4s' }}/>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 8, fontFamily: APP_FONT, fontSize: 11.5, color: ui.sec }}>
+                <span>{done} / {total} books</span>
+                <span>~40s left</span>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* footer action */}
+        <div style={{ padding: '0 24px 30px' }}>
+          {mode === 'progress' && (
+            <button style={{ width: '100%', height: 46, borderRadius: 12, background: 'transparent', border: `1px solid ${ui.sep}`, color: ui.ink, fontFamily: APP_FONT, fontSize: 15, fontWeight: 500, cursor: 'pointer' }}>Cancel</button>
+          )}
+          {(mode === 'success') && (
+            <button style={{ width: '100%', height: 46, borderRadius: 12, background: ui.tint, border: 'none', color: '#fff', fontFamily: APP_FONT, fontSize: 15, fontWeight: 600, cursor: 'pointer' }}>Done</button>
+          )}
+          {mode === 'partial' && (
+            <div style={{ display: 'flex', gap: 10 }}>
+              <button style={{ flex: 1, height: 46, borderRadius: 12, background: 'transparent', border: `1px solid ${ui.sep}`, color: ui.ink, fontFamily: APP_FONT, fontSize: 15, fontWeight: 500, cursor: 'pointer' }}>Done</button>
+              <button style={{ flex: 1, height: 46, borderRadius: 12, background: ui.tint, border: 'none', color: '#fff', fontFamily: APP_FONT, fontSize: 15, fontWeight: 600, cursor: 'pointer' }}>Retry 3 Books</button>
+            </div>
+          )}
+          {mode === 'failed' && (
+            <div style={{ display: 'flex', gap: 10 }}>
+              <button style={{ flex: 1, height: 46, borderRadius: 12, background: 'transparent', border: `1px solid ${ui.sep}`, color: ui.ink, fontFamily: APP_FONT, fontSize: 15, fontWeight: 500, cursor: 'pointer' }}>Back</button>
+              <button style={{ flex: 1, height: 46, borderRadius: 12, background: ui.tint, border: 'none', color: '#fff', fontFamily: APP_FONT, fontSize: 15, fontWeight: 600, cursor: 'pointer' }}>Try Again</button>
+            </div>
+          )}
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+// ════════════════════════════════════════════════════
+// 7. SelectiveRestoreSheet — per-book picker w/ lazy download
+//    book.state: 'local' | 'remote' | 'downloading' | 'failed'
+// ════════════════════════════════════════════════════
+const MANIFEST = [
+  { id: 'm1', title: 'Pride and Prejudice', author: 'Jane Austen', size: '432 KB', state: 'local', sel: true },
+  { id: 'm2', title: 'The Beginning of Infinity', author: 'David Deutsch', size: '1.8 MB', state: 'remote', sel: true },
+  { id: 'm3', title: 'Designing Data-Intensive Applications', author: 'Martin Kleppmann', size: '8.4 MB', state: 'downloading', sel: true, progress: 0.46 },
+  { id: 'm4', title: 'Sapiens', author: 'Yuval Noah Harari', size: '2.1 MB', state: 'remote', sel: false },
+  { id: 'm5', title: 'Meditations', author: 'Marcus Aurelius', size: '298 KB', state: 'failed', sel: true },
+  { id: 'm6', title: 'The Three-Body Problem', author: '刘慈欣', size: '1.2 MB', state: 'remote', sel: true },
+];
+
+function BookCover({ size = 38 }) {
+  return (
+    <div style={{
+      width: size, height: size * 1.32, borderRadius: 3, flexShrink: 0,
+      background: 'linear-gradient(135deg, #5a3a3a, #3a2424)',
+      boxShadow: '0 1px 3px rgba(0,0,0,0.25)', position: 'relative', overflow: 'hidden',
+    }}>
+      <div style={{ position: 'absolute', left: 4, top: 6, right: 4, height: 2, background: 'rgba(199,164,90,0.7)', borderRadius: 1 }}/>
+      <div style={{ position: 'absolute', left: 4, top: 11, right: 8, height: 1.5, background: 'rgba(244,233,212,0.4)', borderRadius: 1 }}/>
+    </div>
+  );
+}
+
+function ManifestRow({ ui, b, last }) {
+  const stateMeta = {
+    local: { label: 'On this device', color: ui.green, icon: <path d="M5 12.5l4 4 8-9" stroke={ui.green} strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round"/> },
+    remote: { label: `Download · ${b.size}`, color: ui.sec, icon: <><path d="M12 4v10M8 11l4 4 4-4" stroke={ui.tint} strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round"/></> },
+    downloading: { label: `Downloading… ${Math.round((b.progress || 0) * 100)}%`, color: ui.tint, icon: null },
+    failed: { label: 'Download failed — tap to retry', color: ui.red, icon: <><path d="M5 8a7 7 0 0112-3M19 12a7 7 0 01-12 5" stroke={ui.red} strokeWidth="2" fill="none" strokeLinecap="round"/><path d="M5 4v4h4M19 20v-4h-4" stroke={ui.red} strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round"/></> },
+  }[b.state];
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', minHeight: 64, padding: '10px 14px', position: 'relative', gap: 12, opacity: b.sel ? 1 : 0.55 }}>
+      {/* checkbox */}
+      <div style={{
+        width: 22, height: 22, borderRadius: 11, flexShrink: 0,
+        background: b.sel ? ui.tint : 'transparent',
+        boxShadow: b.sel ? 'none' : `inset 0 0 0 1.5px ${ui.isDark ? 'rgba(255,255,255,0.25)' : 'rgba(0,0,0,0.22)'}`,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}>
+        {b.sel && <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12.5l4 4 9-10"/></svg>}
+      </div>
+      <BookCover/>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontFamily: SERIF, fontSize: 14.5, fontWeight: 600, color: ui.ink, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{b.title}</div>
+        <div style={{ fontFamily: APP_FONT, fontSize: 11.5, color: ui.sec, marginBottom: b.state === 'downloading' ? 5 : 0, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{b.author}</div>
+        {b.state === 'downloading' ? (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginTop: 1 }}>
+            <div style={{ flex: 1, maxWidth: 120, height: 3, borderRadius: 2, background: ui.sep, overflow: 'hidden' }}>
+              <div style={{ width: `${(b.progress || 0) * 100}%`, height: '100%', background: ui.tint }}/>
+            </div>
+            <span style={{ fontFamily: APP_FONT, fontSize: 11, color: ui.tint, fontWeight: 600 }}>{Math.round((b.progress || 0) * 100)}%</span>
+          </div>
+        ) : (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 5, marginTop: 2 }}>
+            {b.state === 'local' && <StatusDot color={ui.green}/>}
+            <span style={{ fontFamily: APP_FONT, fontSize: 11.5, color: stateMeta.color, fontWeight: b.state === 'remote' ? 500 : 600, whiteSpace: 'nowrap' }}>{stateMeta.label}</span>
+          </div>
+        )}
+      </div>
+      {/* trailing affordance */}
+      {b.state === 'downloading' ? (
+        <svg className="apf-spin" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={ui.tint} strokeWidth="2.4" strokeLinecap="round" style={{ flexShrink: 0 }}><path d="M12 3a9 9 0 1 0 9 9"/></svg>
+      ) : (
+        <div style={{ width: 30, height: 30, borderRadius: 15, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', background: b.state === 'remote' ? ui.chipBg : 'transparent' }}>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none">{stateMeta.icon}</svg>
+        </div>
+      )}
+      {!last && <div style={{ position: 'absolute', left: 48, right: 0, bottom: 0, height: 0.5, background: ui.sep }}/>}
+    </div>
+  );
+}
+
+function SelectiveRestoreSheet({ ui, height = 880 }) {
+  const selCount = MANIFEST.filter(b => b.sel).length;
+  const Cancel = <button style={{ background: 'none', border: 'none', padding: 0, fontFamily: APP_FONT, fontSize: 15, color: ui.sec, cursor: 'pointer' }}>Cancel</button>;
+  const SelectAll = <button style={{ background: 'none', border: 'none', padding: 0, fontFamily: APP_FONT, fontSize: 14, fontWeight: 500, color: ui.tint, cursor: 'pointer' }}>Deselect all</button>;
+  return (
+    <PhoneFrame ui={ui} height={height}>
+      <div style={{ position: 'absolute', inset: 0, background: ui.bg }}/>
+      <AppSheet ui={ui} title="Choose Books" leading={Cancel} trailing={SelectAll} height={height - 36}>
+        <div style={{ padding: '12px 18px 8px' }}>
+          <div style={{ fontFamily: APP_FONT, fontSize: 12.5, color: ui.sec, lineHeight: 1.5, padding: '0 2px 12px' }}>
+            From <span style={{ color: ui.ink, fontWeight: 600 }}>Today, 9:14 AM</span> · 12 books in this backup. Remote-only books download from the server as you restore.
+          </div>
+          <Card ui={ui}>
+            {MANIFEST.map((b, i) => <ManifestRow key={b.id} ui={ui} b={b} last={i === MANIFEST.length - 1}/>)}
+          </Card>
+        </div>
+      </AppSheet>
+      {/* pinned restore CTA */}
+      <div style={{
+        position: 'absolute', left: 0, right: 0, bottom: 0, zIndex: 250,
+        padding: '12px 18px 26px', background: ui.sheetBg,
+        borderTop: `0.5px solid ${ui.sep}`,
+        display: 'flex', alignItems: 'center', gap: 14,
+      }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontFamily: APP_FONT, fontSize: 14, fontWeight: 600, color: ui.ink }}>{selCount} books selected</div>
+          <div style={{ fontFamily: APP_FONT, fontSize: 11.5, color: ui.sec }}>3 already local · 2 will download</div>
+        </div>
+        <button style={{
+          height: 46, padding: '0 24px', borderRadius: 12, border: 'none', cursor: 'pointer',
+          background: ui.tint, color: '#fff', fontFamily: APP_FONT, fontSize: 15, fontWeight: 600,
+        }}>Restore</button>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+Object.assign(window, {
+  Toggle, StatusDot, TopBar, NavScreen, AppAlert,
+  SERVERS, ServerRow, WebDAVServerList,
+  ServerEditSheet,
+  BACKUPS, BackupRestoreScreen, RestoreProgress,
+  MANIFEST, SelectiveRestoreSheet,
+});

--- a/dev-docs/designs/vreader-fidelity-v1/project/vreader-pdf-reader.jsx
+++ b/dev-docs/designs/vreader-fidelity-v1/project/vreader-pdf-reader.jsx
@@ -1,0 +1,573 @@
+// Android PDF reader — base page-view surface (issue #1766, feature #110).
+//
+// iOS gets the PDF reading surface free from PDFKit's PDFView. Android's
+// PdfRenderer only hands back per-page *bitmaps*, so the page-display +
+// navigation UI must be built — and therefore designed.
+//
+// This file is the base reader, NOT the bilingual translation panel
+// (that's vreader-pdf-translation.jsx). It composes:
+//   1. PdfPaper            — one rendered page bitmap mock (text / figure /
+//                            scanned-image / blank kinds).
+//   2. PdfContinuousReader — vertical scroll of pages (CANONICAL). Mirrors
+//                            how PdfRenderer bitmaps naturally stack; matches
+//                            every mainstream Android PDF surface.
+//   3. PdfPagedReader      — one page at a time, reusing the EPUB reader's
+//                            left/right/centre tap-zones for cross-format
+//                            muscle-memory (alternative B).
+//   4. PdfReaderTopChrome / PdfReaderBottomChrome — the reader chrome from
+//                            vreader-reader.jsx's vocabulary (back + italic
+//                            title + icon row / bottom toolbar), self-contained.
+//   5. State surfaces      — PdfRendering, PdfEncrypted, PdfCorrupt, PdfEmpty.
+//   6. PdfPageJump         — thumbnail-strip + scrubber overlay for jumping.
+//
+// Source-of-truth book: "Designing Data-Intensive Applications.pdf" (the
+// PDF in BOOKS — 614 pages, currentPage 111). Page content is a typeset
+// mock; the point is that the eye reads it as a real PDF page bitmap.
+
+const PDF_BOOK = { title: 'Designing Data-Intensive Applications', file: 'ddia.pdf', total: 614 };
+
+// Neutral "viewer backdrop" the page bitmaps sit on. Distinct from the
+// reader paper tone so a white page reads as an object floating on the
+// viewer, exactly like every native PDF surface.
+function pdfBackdrop(t) {
+  // Photo theme gets a warm photographic backdrop so the page bitmap reads
+  // as floating on the cover image, like the reader's photo mode.
+  if (t.image) return 'linear-gradient(150deg, #3a2818 0%, #1a1410 55%, #2a1818 100%)';
+  return t.isDark ? '#101010' : '#cdc7ba';
+}
+function pdfPaperTone(t) {
+  // The page bitmap itself. Real PDFs are white/cream regardless of the
+  // app theme; in dark mode we offer the dimmed-paper rendering (the
+  // bitmap is drawn onto a muted sheet, not pure white, to avoid glare).
+  return t.isDark ? '#standin' : '#ffffff';
+}
+
+// ════════════════════════════════════════════════════
+// 1. PdfPaper — a single page bitmap mock.
+//    kind: 'text' | 'figure' | 'scan' | 'blank'
+//    dim:  in dark theme, render the page muted instead of glaring white.
+// ════════════════════════════════════════════════════
+function PdfPaper({ theme, w, h, pageNumber, kind = 'text', dim = false, heading }) {
+  const t = theme;
+  const paperBg = t.isDark
+    ? (dim ? '#2a2724' : '#e8e3d8')
+    : '#ffffff';
+  const inkFull = t.isDark ? (dim ? '#cfc9bd' : '#23201b') : '#23201b';
+  const inkSub = t.isDark ? (dim ? 'rgba(207,201,189,0.55)' : 'rgba(35,32,27,0.55)') : 'rgba(35,32,27,0.5)';
+  const rule = t.isDark ? (dim ? 'rgba(207,201,189,0.16)' : 'rgba(35,32,27,0.14)') : 'rgba(35,32,27,0.12)';
+  const pad = Math.round(w * 0.11);
+  const fs = Math.max(7, Math.round(w * 0.032));
+
+  return (
+    <div style={{
+      width: w, height: h, flexShrink: 0, position: 'relative',
+      background: paperBg, overflow: 'hidden',
+      boxShadow: t.isDark
+        ? '0 2px 10px rgba(0,0,0,0.5)'
+        : '0 2px 10px rgba(40,30,15,0.22)',
+    }}>
+      {/* running header */}
+      <div style={{
+        position: 'absolute', top: pad * 0.55, left: pad, right: pad,
+        display: 'flex', justifyContent: 'space-between', alignItems: 'baseline',
+        fontFamily: '"Source Serif 4", Georgia, serif',
+        fontSize: fs * 0.78, color: inkSub,
+        letterSpacing: 1, textTransform: 'uppercase',
+        paddingBottom: pad * 0.28, borderBottom: `0.5px solid ${rule}`,
+      }}>
+        <span style={{ textTransform: 'none', letterSpacing: 0 }}>Chapter 5 · Replication</span>
+        <span style={{ fontVariantNumeric: 'tabular-nums' }}>{pageNumber}</span>
+      </div>
+
+      {kind === 'blank' && null}
+
+      {kind === 'text' && (
+        <div style={{
+          position: 'absolute', top: pad * 1.5, left: pad, right: pad, bottom: pad,
+          fontFamily: '"Source Serif 4", Georgia, "Times New Roman", serif',
+          fontSize: fs, lineHeight: 1.5, color: inkFull, textAlign: 'justify',
+        }}>
+          {heading && (
+            <div style={{
+              fontFamily: '"Source Serif 4", Georgia, serif',
+              fontSize: fs * 1.5, fontWeight: 700, color: inkFull,
+              marginBottom: fs * 0.9, lineHeight: 1.15, textAlign: 'left',
+            }}>{heading}</div>
+          )}
+          {PDF_TEXT.map((p, i) => (
+            <p key={i} style={{ margin: 0, marginBottom: fs * 0.7, textIndent: i === 0 || heading && i === 0 ? 0 : fs * 1.5 }}>{p}</p>
+          ))}
+        </div>
+      )}
+
+      {kind === 'figure' && (
+        <div style={{
+          position: 'absolute', top: pad * 1.5, left: pad, right: pad, bottom: pad,
+          fontFamily: '"Source Serif 4", Georgia, serif',
+          fontSize: fs, lineHeight: 1.5, color: inkFull,
+        }}>
+          <p style={{ margin: 0, marginBottom: fs * 0.8, textAlign: 'justify' }}>{PDF_TEXT[0]}</p>
+          {/* a diagram block */}
+          <div style={{
+            border: `1px solid ${rule}`, borderRadius: 2, padding: fs,
+            display: 'flex', flexDirection: 'column', gap: fs * 0.7, marginBottom: fs * 0.5,
+          }}>
+            <div style={{ display: 'flex', gap: fs * 0.7, justifyContent: 'space-between' }}>
+              {['Leader', 'Follower', 'Follower'].map((n, i) => (
+                <div key={i} style={{
+                  flex: 1, border: `1px solid ${inkSub}`, borderRadius: 2,
+                  padding: `${fs * 0.5}px 0`, textAlign: 'center',
+                  fontFamily: '"Inter", sans-serif', fontSize: fs * 0.74,
+                  color: inkFull, background: i === 0 ? (t.isDark ? 'rgba(214,136,90,0.18)' : 'rgba(140,47,47,0.08)') : 'transparent',
+                }}>{n}</div>
+              ))}
+            </div>
+            <svg viewBox="0 0 200 24" style={{ width: '100%', height: fs * 1.4 }} fill="none" stroke={inkSub} strokeWidth="1">
+              <path d="M40 4 L100 20 M160 4 L100 20" />
+              <path d="M96 16 l4 4 l4 -4" fill={inkSub} stroke="none"/>
+            </svg>
+          </div>
+          <div style={{
+            textAlign: 'center', fontSize: fs * 0.82, color: inkSub, fontStyle: 'italic',
+            marginBottom: fs * 0.8,
+          }}>Figure 5-1. Leader-based replication.</div>
+          <p style={{ margin: 0, textAlign: 'justify', textIndent: fs * 1.5 }}>{PDF_TEXT[1]}</p>
+        </div>
+      )}
+
+      {kind === 'scan' && (
+        <div style={{
+          position: 'absolute', top: pad * 1.5, left: pad, right: pad, bottom: pad,
+          display: 'flex', flexDirection: 'column', gap: fs * 0.7,
+        }}>
+          {/* a slightly skewed, lower-contrast "photographed page" look */}
+          <div style={{
+            flex: 1, borderRadius: 1,
+            background: t.isDark ? '#dad3c4' : '#f0ead9',
+            transform: 'rotate(-0.4deg)',
+            boxShadow: 'inset 0 0 40px rgba(120,100,70,0.18)',
+            padding: fs, display: 'flex', flexDirection: 'column', gap: fs * 0.6,
+            overflow: 'hidden', filter: 'contrast(0.92) sepia(0.12)',
+          }}>
+            {Array.from({ length: 14 }).map((_, i) => (
+              <div key={i} style={{
+                height: fs * 0.5,
+                width: `${[96, 92, 94, 60, 95, 90, 88, 70, 93, 91, 50, 94, 89, 64][i]}%`,
+                background: 'rgba(60,45,25,0.34)', borderRadius: 1,
+              }}/>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* page number footer */}
+      <div style={{
+        position: 'absolute', left: 0, right: 0, bottom: pad * 0.5,
+        textAlign: 'center', fontFamily: '"Source Serif 4", Georgia, serif',
+        fontSize: fs * 0.86, color: inkSub, fontVariantNumeric: 'oldstyle-nums tabular-nums',
+      }}>{pageNumber}</div>
+    </div>
+  );
+}
+
+const PDF_TEXT = [
+  'Replication means keeping a copy of the same data on multiple machines that are connected via a network. There are several reasons why you might want to replicate data: to keep it geographically close to your users, to allow the system to continue working even if some of its parts have failed, and to scale out the number of machines that can serve read queries.',
+  'The leader-based approach requires all writes to go through a single node, but reads can be served by any replica. This is a popular choice because it is relatively easy to reason about and is implemented by many relational and nonrelational databases. The main downside appears when the leader fails and a follower must be promoted in its place.',
+  'In this chapter we will assume that your dataset is small enough that each machine can hold a copy of the entire dataset. In Chapter 6 we will relax that assumption and discuss partitioning of datasets that are too big for a single machine.',
+];
+
+// ════════════════════════════════════════════════════
+// Reader chrome (back + italic title + icons / bottom toolbar)
+// Slim, self-contained, matches vreader-reader.jsx vocabulary.
+// ════════════════════════════════════════════════════
+function PdfReaderTopChrome({ theme, title = PDF_BOOK.title, onlyBack = false }) {
+  const t = theme;
+  const ico = (path, key) => (
+    <button key={key} style={{
+      width: 34, height: 34, borderRadius: 17, background: 'none', border: 'none',
+      cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
+    }}>
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={t.ink} strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">{path}</svg>
+    </button>
+  );
+  return (
+    <div style={{
+      position: 'absolute', top: 0, left: 0, right: 0,
+      paddingTop: 38, paddingBottom: 9, zIndex: 30,
+      background: t.chrome, borderBottom: `0.5px solid ${t.rule}`,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 12px' }}>
+        <button style={{
+          display: 'flex', alignItems: 'center', gap: 2, padding: '6px 6px',
+          background: 'none', border: 'none', cursor: 'pointer',
+          color: t.accent, fontFamily: '"Inter", system-ui', fontSize: 14, fontWeight: 500,
+        }}>
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 6l-6 6 6 6"/></svg>
+          <span>Library</span>
+        </button>
+        <div style={{
+          flex: 1, textAlign: 'center', padding: '0 8px', overflow: 'hidden',
+          whiteSpace: 'nowrap', textOverflow: 'ellipsis',
+          fontFamily: '"Source Serif 4", Georgia, serif',
+          fontSize: 13.5, fontWeight: 600, color: t.ink, fontStyle: 'italic',
+        }}>{title}<span style={{ fontStyle: 'normal', fontFamily: '"Inter", system-ui', fontWeight: 600, fontSize: 9, color: t.sub, letterSpacing: 0.5, marginLeft: 6, verticalAlign: 'middle' }}>PDF</span></div>
+        {onlyBack ? <div style={{ width: 68 }}/> : (
+          <div style={{ display: 'flex', gap: 0 }}>
+            {ico(<><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.5-3.5"/></>, 's')}
+            {ico(<><rect x="4" y="4" width="6" height="6" rx="1"/><rect x="14" y="4" width="6" height="6" rx="1"/><rect x="4" y="14" width="6" height="6" rx="1"/><rect x="14" y="14" width="6" height="6" rx="1"/></>, 'g')}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PdfReaderBottomChrome({ theme }) {
+  const t = theme;
+  const items = [
+    { glyph: <><path d="M4 6h2M4 12h2M4 18h2M9 6h11M9 12h11M9 18h11"/></>, label: 'Contents' },
+    { glyph: <><rect x="4" y="3" width="7" height="8" rx="1"/><rect x="13" y="3" width="7" height="8" rx="1"/><rect x="4" y="13" width="7" height="8" rx="1"/><rect x="13" y="13" width="7" height="8" rx="1"/></>, label: 'Pages' },
+    { glyph: <><text x="2" y="18" fontSize="17" fontFamily="serif" fontWeight="700" fill={t.ink} stroke="none">Aa</text></>, label: 'Display' },
+    { glyph: <><path d="M12 3l1.7 5.3L19 10l-5.3 1.7L12 17l-1.7-5.3L5 10l5.3-1.7z"/></>, label: 'AI', accent: true },
+  ];
+  return (
+    <div style={{
+      position: 'absolute', bottom: 0, left: 0, right: 0,
+      paddingBottom: 22, paddingTop: 9, zIndex: 30,
+      background: t.chrome, borderTop: `0.5px solid ${t.rule}`,
+      display: 'flex', justifyContent: 'space-around', alignItems: 'center',
+    }}>
+      {items.map((b, i) => (
+        <div key={i} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3, color: b.accent ? t.accent : t.sub }}>
+          <svg width="21" height="21" viewBox="0 0 24 24" fill="none" stroke={b.accent ? t.accent : t.ink} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">{b.glyph}</svg>
+          <span style={{ fontFamily: '"Inter", system-ui', fontSize: 9.5, fontWeight: 500 }}>{b.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Floating "Page N of M" pill — the page-progress indicator. Appears while
+// scrolling / on chrome-hidden; bottom-centre, glassy.
+function PdfProgressPill({ theme, page, total, floating = true }) {
+  const t = theme;
+  return (
+    <div style={{
+      position: floating ? 'absolute' : 'static',
+      bottom: 16, left: '50%', transform: floating ? 'translateX(-50%)' : 'none',
+      zIndex: 25,
+      display: 'inline-flex', alignItems: 'center', gap: 6,
+      padding: '6px 13px', borderRadius: 100,
+      background: t.isDark ? 'rgba(20,20,20,0.82)' : 'rgba(40,32,20,0.78)',
+      color: '#f3ede0', fontFamily: '"Inter", system-ui',
+      fontSize: 12, fontWeight: 600, letterSpacing: 0.2,
+      backdropFilter: 'blur(8px)', boxShadow: '0 4px 16px rgba(0,0,0,0.3)',
+      fontVariantNumeric: 'tabular-nums',
+    }}>
+      <span>Page {page}</span>
+      <span style={{ opacity: 0.5 }}>of {total}</span>
+    </div>
+  );
+}
+
+// ════════════════════════════════════════════════════
+// 2. PdfContinuousReader — vertical scroll of pages (CANONICAL)
+// ════════════════════════════════════════════════════
+function PdfContinuousReader({ theme, scroll = 0, chromeVisible = true, dim = false,
+                               firstKind = 'text', secondKind = 'figure' }) {
+  const t = theme;
+  const W = 402, topH = 80, botH = 53;
+  const pageW = W - 36;
+  const pageH = Math.round(pageW * 1.34);
+  const gap = 14;
+  // scroll offset (0..1) shifts the stack; 0 shows top of page 111.
+  const offset = -scroll * (pageH + gap);
+
+  return (
+    <div style={{ position: 'absolute', inset: 0, background: pdfBackdrop(t), overflow: 'hidden' }}>
+      {/* stacked pages */}
+      <div style={{
+        position: 'absolute', top: topH, left: 18, right: 18, bottom: 0,
+        overflow: 'hidden',
+      }}>
+        <div style={{
+          display: 'flex', flexDirection: 'column', gap, alignItems: 'center',
+          transform: `translateY(${offset}px)`,
+          paddingTop: 10,
+          transition: 'transform 0.3s cubic-bezier(0.32,0.72,0,1)',
+        }}>
+          <PdfPaper theme={t} w={pageW} h={pageH} pageNumber={110} kind={firstKind} dim={dim} heading={firstKind === 'text' ? 'Leaders and Followers' : null}/>
+          <PdfPaper theme={t} w={pageW} h={pageH} pageNumber={111} kind={secondKind} dim={dim}/>
+          <PdfPaper theme={t} w={pageW} h={pageH} pageNumber={112} kind="text" dim={dim}/>
+        </div>
+      </div>
+
+      {chromeVisible && <PdfReaderTopChrome theme={t}/>}
+      {chromeVisible && <PdfReaderBottomChrome theme={t}/>}
+      <PdfProgressPill theme={t} page={111} total={PDF_BOOK.total}
+        floating />
+    </div>
+  );
+}
+
+// ════════════════════════════════════════════════════
+// 3. PdfPagedReader — one page at a time, reusing tap-zones
+// ════════════════════════════════════════════════════
+function PdfPagedReader({ theme, chromeVisible = true, showZones = false, turning = false, dim = false, kind = 'text' }) {
+  const t = theme;
+  const W = 402;
+  const pageW = Math.round(W * 0.9);
+  const pageH = Math.round(pageW * 1.4);
+
+  return (
+    <div style={{ position: 'absolute', inset: 0, background: pdfBackdrop(t), overflow: 'hidden' }}>
+      {/* centred single page */}
+      <div style={{
+        position: 'absolute', inset: 0, display: 'flex',
+        alignItems: 'center', justifyContent: 'center',
+        transform: turning ? 'translateX(-9%)' : 'none',
+        opacity: turning ? 0 : 1,
+        transition: 'transform 0.3s cubic-bezier(0.32,0.72,0,1), opacity 0.24s ease-out',
+      }}>
+        <PdfPaper theme={t} w={pageW} h={pageH} pageNumber={111} kind={kind} dim={dim} heading={kind === 'text' ? 'Leaders and Followers' : null}/>
+      </div>
+
+      {/* tap-zone debug overlay */}
+      {showZones && (
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', zIndex: 20, pointerEvents: 'none' }}>
+          {[['Prev', 'rgba(140,47,47,0.10)'], ['Menu', 'rgba(40,40,40,0.06)'], ['Next', 'rgba(58,106,90,0.12)']].map(([lab, bg], i) => (
+            <div key={i} style={{
+              flex: i === 1 ? 1.33 : 1, background: bg,
+              borderLeft: i ? `1px dashed ${t.rule}` : 'none',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              flexDirection: 'column', gap: 6,
+            }}>
+              <span style={{
+                fontFamily: '"Inter", system-ui', fontSize: 11, fontWeight: 700,
+                letterSpacing: 1, textTransform: 'uppercase',
+                color: t.isDark ? 'rgba(255,255,255,0.6)' : 'rgba(40,30,15,0.55)',
+              }}>{lab}</span>
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none"
+                stroke={t.isDark ? 'rgba(255,255,255,0.5)' : 'rgba(40,30,15,0.45)'} strokeWidth="1.8" strokeLinecap="round">
+                {i === 0 && <path d="M15 6l-6 6 6 6"/>}
+                {i === 1 && <><circle cx="12" cy="12" r="2.4"/><path d="M12 4v3M12 17v3M4 12h3M17 12h3"/></>}
+                {i === 2 && <path d="M9 6l6 6-6 6"/>}
+              </svg>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {chromeVisible && <PdfReaderTopChrome theme={t}/>}
+      {chromeVisible && <PdfReaderBottomChrome theme={t}/>}
+      {!chromeVisible && <PdfProgressPill theme={t} page={111} total={PDF_BOOK.total} floating/>}
+    </div>
+  );
+}
+
+// ════════════════════════════════════════════════════
+// 5. State surfaces
+// ════════════════════════════════════════════════════
+function PdfStateScaffold({ theme, children }) {
+  const t = theme;
+  return (
+    <div style={{ position: 'absolute', inset: 0, background: pdfBackdrop(t), overflow: 'hidden' }}>
+      <PdfReaderTopChrome theme={t} onlyBack/>
+      <div style={{
+        position: 'absolute', top: 80, left: 0, right: 0, bottom: 0,
+        display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '0 40px',
+      }}>{children}</div>
+    </div>
+  );
+}
+
+// Rendering — the page bitmap is being rasterized by PdfRenderer. Skeleton
+// page frame + a thin determinate-ish bar. This is the loading state.
+function PdfRendering({ theme }) {
+  const t = theme;
+  const pageW = 280, pageH = Math.round(280 * 1.4);
+  const shimmer = t.isDark
+    ? 'linear-gradient(90deg, rgba(255,255,255,0.04), rgba(255,255,255,0.11), rgba(255,255,255,0.04))'
+    : 'linear-gradient(90deg, rgba(255,255,255,0.5), rgba(255,255,255,0.95), rgba(255,255,255,0.5))';
+  return (
+    <PdfStateScaffold theme={t}>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 18 }}>
+        <div style={{
+          width: pageW, height: pageH, background: t.isDark ? '#2a2724' : '#e7e1d4',
+          boxShadow: t.isDark ? '0 2px 10px rgba(0,0,0,0.5)' : '0 2px 10px rgba(40,30,15,0.22)',
+          padding: 28, display: 'flex', flexDirection: 'column', gap: 11,
+          position: 'relative', overflow: 'hidden',
+        }}>
+          {[92, 88, 94, 60, 90, 86, 70, 93, 50].map((w, i) => (
+            <div key={i} style={{
+              height: 9, width: `${w}%`, borderRadius: 3,
+              background: shimmer, backgroundSize: '200% 100%',
+              animation: `pdfShimmer 1.4s ease-in-out ${i * 0.05}s infinite`,
+            }}/>
+          ))}
+        </div>
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 8,
+          fontFamily: '"Inter", system-ui', fontSize: 12.5, color: t.isDark ? 'rgba(230,225,215,0.7)' : 'rgba(40,32,20,0.6)', fontWeight: 500,
+        }}>
+          <svg className="apf-spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={t.accent} strokeWidth="2.4" strokeLinecap="round"><path d="M12 3a9 9 0 1 0 9 9"/></svg>
+          Rendering page 111…
+        </div>
+      </div>
+    </PdfStateScaffold>
+  );
+}
+
+// Encrypted — password-protected PDF. Lock + password field + Unlock.
+function PdfEncrypted({ theme, wrong = false }) {
+  const t = theme;
+  const onDark = t.isDark;
+  const fg = onDark ? '#e6e1d5' : '#2a241b';
+  const sub = onDark ? 'rgba(230,225,213,0.55)' : 'rgba(42,36,27,0.55)';
+  const fieldBg = onDark ? 'rgba(255,255,255,0.06)' : 'rgba(255,255,255,0.7)';
+  return (
+    <PdfStateScaffold theme={t}>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0, maxWidth: 300, textAlign: 'center' }}>
+        <div style={{
+          width: 56, height: 56, borderRadius: 28,
+          background: onDark ? 'rgba(214,136,90,0.16)' : 'rgba(140,47,47,0.1)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 18,
+        }}>
+          <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke={t.accent} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 018 0v3"/><circle cx="12" cy="15.5" r="1.3" fill={t.accent} stroke="none"/>
+          </svg>
+        </div>
+        <div style={{ fontFamily: '"Source Serif 4", Georgia, serif', fontSize: 19, fontWeight: 600, color: fg, marginBottom: 7, lineHeight: 1.25 }}>
+          This PDF is protected
+        </div>
+        <div style={{ fontFamily: '"Inter", system-ui', fontSize: 13, color: sub, lineHeight: 1.5, marginBottom: 20 }}>
+          Enter the document password to open <span style={{ fontStyle: 'italic', fontFamily: '"Source Serif 4", serif' }}>{PDF_BOOK.title}</span>.
+        </div>
+        <div style={{
+          display: 'flex', alignItems: 'center', width: '100%',
+          background: fieldBg, borderRadius: 12, padding: '0 14px', height: 46,
+          boxShadow: wrong ? 'inset 0 0 0 1.5px #c0492f' : `inset 0 0 0 1px ${t.rule}`,
+        }}>
+          <span style={{ fontFamily: '"Inter"', fontSize: 17, letterSpacing: 3, color: fg }}>••••••••</span>
+          <span style={{ flex: 1 }}/>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={sub} strokeWidth="1.7"><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7z"/><circle cx="12" cy="12" r="3"/></svg>
+        </div>
+        {wrong && (
+          <div style={{ fontFamily: '"Inter", system-ui', fontSize: 12, color: '#c0492f', marginTop: 8, alignSelf: 'flex-start' }}>
+            Incorrect password — try again.
+          </div>
+        )}
+        <button style={{
+          marginTop: 16, width: '100%', height: 46, borderRadius: 12, border: 'none',
+          background: t.accent, color: '#fff', fontFamily: '"Inter", system-ui',
+          fontSize: 15, fontWeight: 600, cursor: 'pointer',
+        }}>Unlock</button>
+      </div>
+    </PdfStateScaffold>
+  );
+}
+
+// Corrupt — the file can't be decoded by PdfRenderer at all.
+function PdfCorrupt({ theme }) {
+  const t = theme;
+  const onDark = t.isDark;
+  const fg = onDark ? '#e6e1d5' : '#2a241b';
+  const sub = onDark ? 'rgba(230,225,213,0.55)' : 'rgba(42,36,27,0.55)';
+  return (
+    <PdfStateScaffold theme={t}>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0, maxWidth: 300, textAlign: 'center' }}>
+        <svg width="46" height="46" viewBox="0 0 24 24" fill="none" stroke={onDark ? 'rgba(230,225,213,0.5)' : 'rgba(42,36,27,0.4)'} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" style={{ marginBottom: 16 }}>
+          <path d="M6 2h8l4 4v14a2 2 0 01-2 2H6a2 2 0 01-2-2V4a2 2 0 012-2z"/><path d="M14 2v4h4"/><path d="M9.5 11l5 5M14.5 11l-5 5"/>
+        </svg>
+        <div style={{ fontFamily: '"Source Serif 4", Georgia, serif', fontSize: 19, fontWeight: 600, color: fg, marginBottom: 7, lineHeight: 1.25 }}>
+          Couldn’t open this PDF
+        </div>
+        <div style={{ fontFamily: '"Inter", system-ui', fontSize: 13, color: sub, lineHeight: 1.5, marginBottom: 20 }}>
+          The file appears to be damaged or uses a format the reader can’t decode. Try re-importing it from the original source.
+        </div>
+        <div style={{ display: 'flex', gap: 10 }}>
+          <button style={{
+            height: 42, padding: '0 18px', borderRadius: 100, border: 'none',
+            background: t.accent, color: '#fff', fontFamily: '"Inter", system-ui', fontSize: 14, fontWeight: 600, cursor: 'pointer',
+          }}>Re-import</button>
+          <button style={{
+            height: 42, padding: '0 18px', borderRadius: 100,
+            background: 'transparent', border: `1px solid ${t.rule}`,
+            color: fg, fontFamily: '"Inter", system-ui', fontSize: 14, fontWeight: 500, cursor: 'pointer',
+          }}>Back to Library</button>
+        </div>
+      </div>
+    </PdfStateScaffold>
+  );
+}
+
+// ════════════════════════════════════════════════════
+// 6. PdfPageJump — thumbnail strip + scrubber overlay (the "Pages" affordance)
+// ════════════════════════════════════════════════════
+function PdfPageJump({ theme, current = 111 }) {
+  const t = theme;
+  const onDark = t.isDark;
+  const panelBg = onDark ? 'rgba(24,24,24,0.96)' : 'rgba(250,247,240,0.97)';
+  const fg = onDark ? '#e6e1d5' : '#2a241b';
+  const sub = onDark ? 'rgba(230,225,213,0.55)' : 'rgba(42,36,27,0.55)';
+  const thumbs = [108, 109, 110, 111, 112, 113, 114];
+  return (
+    <div style={{ position: 'absolute', inset: 0, background: pdfBackdrop(t), overflow: 'hidden' }}>
+      <PdfReaderTopChrome theme={t}/>
+      {/* dimmed current page behind */}
+      <div style={{ position: 'absolute', top: 80, left: 0, right: 0, bottom: 200, display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: 0.5 }}>
+        <PdfPaper theme={t} w={230} h={Math.round(230 * 1.4)} pageNumber={111} kind="text" heading="Leaders and Followers"/>
+      </div>
+      {/* bottom jump panel */}
+      <div style={{
+        position: 'absolute', left: 0, right: 0, bottom: 0,
+        background: panelBg, backdropFilter: 'blur(12px)',
+        borderTop: `0.5px solid ${t.rule}`,
+        borderTopLeftRadius: 18, borderTopRightRadius: 18,
+        paddingTop: 14, paddingBottom: 24,
+        boxShadow: '0 -10px 30px rgba(0,0,0,0.2)',
+      }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', padding: '0 18px', marginBottom: 12 }}>
+          <span style={{ fontFamily: '"Inter", system-ui', fontSize: 14, fontWeight: 600, color: fg }}>Jump to page</span>
+          <span style={{ fontFamily: '"Inter", system-ui', fontSize: 12, color: sub, fontVariantNumeric: 'tabular-nums' }}>{current} / {PDF_BOOK.total}</span>
+        </div>
+        {/* thumbnail strip */}
+        <div className="hide-scroll" style={{ display: 'flex', gap: 10, padding: '0 18px 14px', overflowX: 'auto' }}>
+          {thumbs.map(n => {
+            const active = n === current;
+            return (
+              <div key={n} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 5, flexShrink: 0 }}>
+                <div style={{
+                  width: 58, height: 80, background: onDark ? '#2a2724' : '#fff',
+                  boxShadow: active ? `0 0 0 2px ${t.accent}` : `0 0 0 0.5px ${t.rule}, 0 1px 4px rgba(0,0,0,0.12)`,
+                  padding: 7, display: 'flex', flexDirection: 'column', gap: 3.5,
+                }}>
+                  {[90, 80, 86, 50, 84, 78, 60].map((w, i) => (
+                    <div key={i} style={{ height: 2.5, width: `${w}%`, background: onDark ? 'rgba(207,201,189,0.3)' : 'rgba(35,32,27,0.22)', borderRadius: 1 }}/>
+                  ))}
+                </div>
+                <span style={{ fontFamily: '"Inter", system-ui', fontSize: 10, color: active ? t.accent : sub, fontWeight: active ? 700 : 500, fontVariantNumeric: 'tabular-nums' }}>{n}</span>
+              </div>
+            );
+          })}
+        </div>
+        {/* scrubber */}
+        <div style={{ padding: '0 22px' }}>
+          <div style={{ height: 4, borderRadius: 2, background: t.rule, position: 'relative' }}>
+            <div style={{ position: 'absolute', left: 0, top: 0, bottom: 0, width: '18%', background: t.accent, borderRadius: 2 }}/>
+            <div style={{ position: 'absolute', left: '18%', top: '50%', width: 16, height: 16, borderRadius: 8, background: t.accent, transform: 'translate(-50%,-50%)', boxShadow: '0 1px 4px rgba(0,0,0,0.3)' }}/>
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontFamily: '"Inter", system-ui', fontSize: 10.5, color: sub, marginTop: 7 }}>
+            <span>1</span><span>{PDF_BOOK.total}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, {
+  PDF_BOOK, PdfPaper, PdfReaderTopChrome, PdfReaderBottomChrome, PdfProgressPill,
+  PdfContinuousReader, PdfPagedReader,
+  PdfStateScaffold, PdfRendering, PdfEncrypted, PdfCorrupt, PdfPageJump,
+});

--- a/docs/parity/README.md
+++ b/docs/parity/README.md
@@ -39,7 +39,7 @@ complete.
 | TXT reader | ✓ | ✓ | feature #111 (`android/v0.4.0`) — encoding-detected decode (UTF-16LE/CJK) + LazyColumn render + charOffsetUTF16 resume, emulator-verified incl. a real 14MB book. |
 | Markdown (.md) reader | ✓ | ✓ | feature #112 (`android/v0.5.0`) — thin delta over the TXT reader: `MarkdownRenderer` (line-chunk → AnnotatedString, single-line CommonMark subset: headers/bold/italic/code/bullets) reusing the TXT decode/document/resume/chrome; `md` routes to the shared text reader. Emulator-verified (library-path render + TXT-renders-literally regression + md resume). |
 | AZW3 reader | ✓ | ✗ | Phase 3 — DEFERRED on feasibility: Readium-Kotlin has no native AZW3/MOBI; iOS uses a libmobi C lib (large/HIGH-risk port). |
-| PDF reader | ✓ | ⛔ | Phase 3 — base page-view reader UI design-needed #1766 (Android `PdfRenderer` gives bitmaps only; the bundle has only the PDF translation panel, not a base reader surface). |
+| PDF reader | ✓ | ✗ | Phase 3 — **design LANDED** (#1766; `dev-docs/designs/vreader-fidelity-v1/project/vreader-pdf-reader.jsx` + `design-notes/android-phase3-issues.md`: continuous-scroll canonical + paged toggle, rendering/encrypted/corrupt/scan/page-jump states). Implementation not yet started (Android `PdfRenderer` bitmaps). |
 
 ## Sync & backup (Phase 3)
 
@@ -47,7 +47,7 @@ complete.
 | --- | --- | --- | --- |
 | Backup format model (sections + manifest, schema 3 / manifest 1) | ✓ | ◑ | feature #113 — Kotlin `@Serializable` DTOs matching `contracts/identity/backup-format.md` (ISO8601 UTC dates, plain `Locator` locatorJSON), golden-vector conformance. Backend only. |
 | WebDAV client + restore import pipeline | ✓ | ◑ | feature #113 — non-UI; emulator-verified via instrumented round-trip against a local WebDAV (no paid service). |
-| Backup/restore + WebDAV-settings UI | ✓ | ⛔ | design-needed #1767 (no backup/restore/WebDAV surface in the committed bundle). |
+| Backup/restore + WebDAV-settings UI | ✓ | ✗ | Phase 3 — **design LANDED** (#1767; `dev-docs/designs/vreader-fidelity-v1/project/vreader-backup-webdav.jsx` + `design-notes/android-phase3-issues.md`: 5 surfaces — WebDAV server list, server edit + test-connection, backup&restore + every WebDAV error, restore confirm→progress→result, selective restore picker). Implementation: feature #114. |
 
 ## Out of scope for the foundation bar (Phase 3)
 


### PR DESCRIPTION
Imports the committed claude.ai/design surfaces (project `vreader-fidelity`) that resolve both Android Phase-3 needs-design gates under #110, into the `vreader-fidelity-v1` bundle:

- `design-notes/android-phase3-issues.md` — authoritative spec for both surfaces, every state/theme.
- `vreader-backup-webdav.jsx` (**#1767**) — 5 surfaces: WebDAV server list, server edit + test-connection, backup & restore + every WebDAV error, restore confirm→progress→result, selective restore picker.
- `vreader-pdf-reader.jsx` (**#1766**) — continuous-scroll (canonical) + paged reader, rendering/encrypted/corrupt/scan/page-jump states.

Unblocks the rule-51 design gate for both. Backup/restore UI → feature #114 (this session). PDF reader → later #110 slice. Parity ledger updated (both ⛔→✗).

Imported via the `claude_design` MCP (DesignSync) from project `019e2bb7-e56b-7576-b95a-b99c715a3b1d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)