### PR TITLE
design(#1798): import Android AI provider + bilingual + chat bundle

### DIFF
--- a/dev-docs/designs/vreader-fidelity-v1/project/design-notes/android-phase3-batch2-issues.md
+++ b/dev-docs/designs/vreader-fidelity-v1/project/design-notes/android-phase3-batch2-issues.md
@@ -1,0 +1,91 @@
+# Six Android Phase-3 needs-design issues — design notes (batch 2)
+
+> Resolves the design gaps blocking [#1797](https://github.com/lllyys/vreader/issues/1797), [#1798](https://github.com/lllyys/vreader/issues/1798), [#1799](https://github.com/lllyys/vreader/issues/1799), [#1800](https://github.com/lllyys/vreader/issues/1800), [#1801](https://github.com/lllyys/vreader/issues/1801), [#1802](https://github.com/lllyys/vreader/issues/1802) — all children of the [#110](https://github.com/lllyys/vreader/issues/110) Android Phase-3 capability-parity driver. Follows the batch-1 note (`android-phase3-issues.md`, #1766/#1767).
+
+All six are blocked by Rule 51 (UI from the committed design bundle only). iOS gets these surfaces from system components or already-shipped subsystems; Android has the data/runtime layer (Room, `android.speech.tts.TextToSpeech`, the OPDS client, the AI provider client) but no UI, so each user-facing surface had to be designed. Every design is rendered in VReader's existing vocabulary — the reader `THEMES`, Source-Serif titles, `#8c2f2f` / `#d6885a` accent, rounded-14 cards, and the AI-provider/backup form primitives (`UI`, `Card`, `Row`, `GroupHeader/Footer`, `Tag`, `PhoneFrame`, `AppSheet`) — so Android reads as the same product, **not a Material re-skin**. Each canvas shows every state across the paper and dark themes.
+
+| Issue | Canvas | Component file | Artboards |
+|---|---|---|---|
+| #1797 TTS read-aloud | `VReader TTS Read-Aloud Canvas.html` | `vreader-tts.jsx` | `tts-artboards.jsx` |
+| #1801 Highlights + annotations | `VReader Highlights & Annotations Canvas.html` | `vreader-android-annotations.jsx` | `android-annotations-artboards.jsx` |
+| #1802 Library management | `VReader Library Management Canvas.html` | `vreader-library-android.jsx` | `library-android-artboards.jsx` |
+| #1800 Reading-stats | `VReader Reading Stats Canvas.html` | `vreader-stats-android.jsx` | `stats-android-artboards.jsx` |
+| #1799 OPDS catalog | `VReader OPDS Catalog Canvas.html` | `vreader-opds.jsx` | `opds-artboards.jsx` |
+| #1798 AI provider + bilingual + chat | `VReader AI Provider & Chat Canvas.html` | `vreader-ai-android.jsx` | `ai-android-artboards.jsx` |
+
+`vreader-tts.jsx` also exports the reader frame chrome (`TtsFrame`, `StatusStrip`, `ReaderChrome`, `ReaderProse`) reused by the annotations, library, stats, bilingual and chat canvases, so every in-reader surface shares one device frame and top bar.
+
+---
+
+## #1797 · TTS read-aloud control bar
+
+**Decision: a glassy transport docked at the foot of the reader — not a system media-notification surrogate.** Component: `vreader-tts.jsx` (`TtsBar`, `TtsScreen`, `VoiceSheet`, `SpeedSheet`, `TtsEntry`).
+
+iOS reads aloud through `AVSpeechSynthesizer`; Android has on-device `android.speech.tts.TextToSpeech` (no credentials, multiple engines). The control bar owns play/pause, sentence prev/next, speed, and a voice/engine chip; a chunk-progress line rides the bar's top edge. The page behind highlights the **spoken sentence** with an accent wash + a left keyline — sentences already read dim to the secondary ink, upcoming text stays full-strength — and an auto-scroll keepline holds the spoken line in view.
+
+- **Entry** is the reader's own bottom toolbar (the Volume item, beside Contents / Aa / AI) — no new navigation.
+- **States:** idle (ready, not started), speaking, paused (highlight retained), and **error/unavailable** — no installed voice for the book's language → one primary CTA ("Install voice data") + a secondary jump to System TTS.
+- **Voice & engine** is the genuinely-Android surface: pick the on-device engine (Google / Samsung), then a per-language voice; uninstalled voices show a sized **Download**, one is mid-install. iOS's AVSpeech surface has none of this.
+- **Speed** is a slider + preset pills (0.5×–2.0×) with the current rate set large for at-a-glance legibility while listening.
+
+---
+
+## #1801 · Highlights + annotations
+
+**Decision: one popover does double duty (fresh selection + tap-on-existing-highlight); the review list renders all three record kinds with a filter whose *Notes* merges by intent, not anchor.** Component: `vreader-android-annotations.jsx`.
+
+- **In-reader (A):** press-and-hold selects a passage (blue handles); a popover with a downward notch floats above it carrying 5 highlight colors + Highlight / Note / Copy / Translate / Share. Picking a color highlights in place; **Note** swaps the action row for an inline compose (no jump to a separate editor for a one-liner). Tapping a saved highlight re-opens the same popover scoped to edit/recolor/remove.
+- **Review (B):** a filter chip row (All · Highlights · Notes · Bookmarks). `HighlightCard` carries a color rule + optional note; `StandaloneNoteCard` (a note with no passage behind it) uses a **dashed** accent rule + a `STANDALONE` pill; bookmarks are a compact locator row. The **Notes filter merges highlight-notes and standalone notes** — notes are notes regardless of anchor (mirrors the iOS #860 decision). Per-book and library-wide (grouped under book headers); empty and edit states.
+
+---
+
+## #1802 · Library management (collections + search)
+
+**Decision: collections are a horizontal shelf-bar over the grid (not a separate tab); two collections are derived from progress and locked; search splits metadata hits from in-text hits.** Component: `vreader-library-android.jsx`. Covers are typographic (a tonal card + serif title), never illustrated art.
+
+- **Library (A):** the 2-up cover grid with the collection chip-bar pinned under the title; covers carry a reading-progress hairline. Tapping a chip scopes the grid and swaps the header to the collection name + count + edit affordance.
+- **Manage & assign (B):** the collections manager (rename / reorder / delete, create-new inline) and the per-book **Assign** sheet (a checklist, so one book can sit on several shelves). *Currently Reading* and *Finished* update from progress automatically and can't be deleted.
+- **Search (C):** empty (recent searches + browse-by-collection), results, no-results. Results split **metadata hits** (title/author, matched span washed) from **in-text hits** (a serif snippet with the matched word) so a half-remembered phrase still surfaces its book. Every state names what search actually covers.
+
+---
+
+## #1800 · Reading-stats surfaces
+
+**Decision: the in-reader surface stays out of the way (auto-fading pill → expandable detail card); the dashboard is window-bar-driven.** Component: `vreader-stats-android.jsx`.
+
+- **In-reader (A):** a glassy **session pill** rides the top-right and fades after a few seconds; the progress area expands the full **time detail card** — session · book total · time-left estimates · current pace.
+- **Dashboard (B):** a time-window chip bar (Today · 7d · 30d · 90d · Year · All) drives everything below — an hour hero (with streak / daily-avg / finished), a 14-day daily-reading column chart (today tinted), and a per-book table sortable by Time / Highlights / Notes. The **Time column drives a per-row hairline bar** so relative magnitude reads even after re-sorting. **No-data** isn't a blank screen: the hero becomes a one-line nudge and every module keeps its frame.
+
+---
+
+## #1799 · OPDS catalog browse/add/download
+
+**Decision: honor both OPDS feed kinds explicitly; reuse the backup/AI form vocabulary so catalogs feel like one system with Settings; every error names its HTTP cause + one CTA.** Component: `vreader-opds.jsx`. The backend (feed parser, HTTP client, acquisition→import) ships separately and isn't design-gated.
+
+- **Source list (A):** saved catalogs with a live status dot + exact host (or failure reason); empty onboards by naming compatible catalogs (Standard Ebooks, Project Gutenberg, a self-hosted Calibre server).
+- **Add/edit (B):** Name · URL · optional sign-in (the toggle reveals username/password). Test Connection runs against the live form and reports inline; edit adds Remove Catalog.
+- **Browse (C):** **navigation** feeds render as folder rows (with entry counts, drill in); **acquisition** feeds as book entries (cover · title · author · EPUB · download). Every per-entry state lives on the row — get / downloading (radial) / in-library. Loading shimmers the rows; empty names the cause.
+- **Errors (D):** offline (retry), 401 auth (edit sign-in), 404 not-found (edit URL) — three visually distinct outcomes, never a generic failure.
+
+---
+
+## #1798 · AI provider + bilingual + chat
+
+**Decision: one credential drives all three features, so the spine is the four states the issue names — unconfigured → configured → in-flight → error. The provider editor is the already-committed `EditorSheet`; this batch adds the list, the interlinear reader, and the chat/summary panel.** Component: `vreader-ai-android.jsx`.
+
+- **Provider (A):** the provider **list** is the gate. Unconfigured onboards to a single Add action; configured shows the active provider + per-provider status (model, or the rejection reason). Add / edit / test reuse the committed `EditorSheet` (`vreader-ai-provider-fields.jsx`) verbatim — in-flight and error are its existing `test="testing"` / `test="fail"` states.
+- **Bilingual (B):** interlinear — the original line keeps full weight, the translation sits beneath behind an accent keyline so the eye can drop to it or skip it. A docked toggle carries the mode + language/provider/style summary. In-flight translates progressively (later paragraphs dimmed); **error keeps the original** and names the HTTP cause (429). A setup sheet sets languages · provider · model · style (Literal / Natural / Literary) + a cost estimate.
+- **Chat & summary (C):** a panel docked over a dimmed reader. **Unconfigured** routes to AI settings (the same gate); idle offers suggested prompts; in-flight shows a typing indicator; the **answer streams in the reading serif** (the AI's prose shares the book's voice, not a chat-app sans); the chapter **summary** renders cached key-points with an explicit regenerate. Summaries are cached per chapter so re-opening is instant and free.
+
+---
+
+## Cross-references
+
+| File | Role |
+|---|---|
+| `vreader-tts.jsx` | TTS bar, voice/speed sheets, reader entry **+ shared reader frame chrome** (`TtsFrame` / `StatusStrip` / `ReaderChrome` / `ReaderProse`) — #1797 |
+| `vreader-android-annotations.jsx` | `SelectionReader`, `SelectionPopover`, `AnnotationsSheet`, the three card kinds — #1801 |
+| `vreader-library-android.jsx` | `LibraryScreen`, `SearchScreen`, `CollectionsManageSheet`, `AssignSheet`, `Cover` — #1802 |
+| `vreader-stats-android.jsx` | `InReaderTime`, `StatsDashboard`, `TimeWindowBar`, `DailyChart`, `PerBookTable` — #1800 |
+| `vreader-opds.jsx` | `OpdsSourceList`, `OpdsAddSheet`, `OpdsBrowse`, `OpdsError`, `AcquisitionEntry` — #1799 |
+| `vreader-ai-android.jsx` | `AiProviderList`, `BilingualReader`, `BilingualSetupSheet`, `AiChatPanel` — #1798 |

--- a/dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-android.jsx
+++ b/dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-android.jsx
@@ -1,0 +1,306 @@
+// Issue #1798 / Feature #110 (Android Phase-3) — AI provider + bilingual + chat.
+//
+// iOS has bilingual interlinear translation (#56) + AI chat (#89); Android
+// needs both UIs AND a user-configured provider credential. None of these were
+// in a committed bundle (rule 51). Built in VReader's vocabulary; the provider
+// editor itself is the already-designed EditorSheet (vreader-ai-provider-
+// fields.jsx) — this file adds the provider LIST, the bilingual interlinear
+// reader + setup, and the reader AI-chat / summary panel.
+//
+// One credential powers all three features, so the through-line is the four
+// states the issue calls out: unconfigured → configured → in-flight → error.
+
+const AI_SERIF = '"Source Serif 4", Georgia, serif';
+const AI_SANS = "'Inter', -apple-system, system-ui, sans-serif";
+
+// ── A · provider list (the gate for everything) ──────────────
+function AiProviderList({ ui, state = 'configured', height = 880 }) {
+  const unconf = state === 'unconfigured';
+  const providers = [
+    { name: 'Claude (Anthropic)', model: 'claude-sonnet-4-6', active: true, status: 'ok' },
+    { name: 'OpenAI', model: 'gpt-4o-mini', active: false, status: 'ok' },
+    { name: 'DeepSeek', model: 'deepseek-chat', active: false, status: 'fail' },
+  ];
+  return (
+    <PhoneFrame ui={ui} height={height}>
+      <div style={{ position: 'absolute', inset: 0, background: ui.bg, display: 'flex', flexDirection: 'column' }}>
+        <div style={{ height: 30 }} />
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '6px 14px 12px', borderBottom: `0.5px solid ${ui.sep}` }}>
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke={ui.tint} strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round"><path d="M15 6l-6 6 6 6"/></svg>
+          <div style={{ flex: 1, fontFamily: AI_SERIF, fontSize: 18, fontWeight: 600, color: ui.ink }}>AI Providers</div>
+          <window.Icons.Plus size={24} color={ui.tint} />
+        </div>
+        <div className="hide-scroll" style={{ flex: 1, overflow: 'auto', padding: '14px 16px 32px' }}>
+          {unconf ? (
+            <>
+              <div style={{ textAlign: 'center', padding: '36px 24px 10px' }}>
+                <div style={{ width: 64, height: 64, borderRadius: 32, background: ui.isDark ? 'rgba(214,136,90,0.14)' : 'rgba(140,47,47,0.09)', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 18px' }}>
+                  <window.Icons.Sparkle size={30} color={ui.tint} />
+                </div>
+                <div style={{ fontFamily: AI_SERIF, fontSize: 21, color: ui.ink, marginBottom: 8 }}>Connect an AI provider</div>
+                <div style={{ fontFamily: AI_SANS, fontSize: 14, color: ui.sec, lineHeight: 1.55 }}>
+                  One key unlocks bilingual translation, chat about a book, and chapter summaries. Your key is stored on-device only.
+                </div>
+              </div>
+              <button style={{ width: '100%', border: 'none', cursor: 'pointer', background: ui.tint, color: '#fff', borderRadius: 13, padding: '14px 0', fontFamily: AI_SANS, fontSize: 15, fontWeight: 600, marginTop: 18 }}>Add a provider</button>
+              <GroupFooter ui={ui}>Works with Anthropic, OpenAI-compatible endpoints, and local models.</GroupFooter>
+            </>
+          ) : (
+            <>
+              <GroupHeader ui={ui}>Providers</GroupHeader>
+              <Card ui={ui}>
+                {providers.map((p, i) => (
+                  <div key={p.name} style={{ display: 'flex', alignItems: 'center', minHeight: 60, padding: '0 14px', position: 'relative' }}>
+                    {p.active
+                      ? <svg width="20" height="20" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="9" fill={ui.tint}/><path d="M8 12.3l3 3 5.5-6" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none"/></svg>
+                      : <div style={{ width: 20, height: 20, borderRadius: 10, boxShadow: `inset 0 0 0 1.7px ${ui.sep}` }} />}
+                    <div style={{ flex: 1, minWidth: 0, marginLeft: 12 }}>
+                      <div style={{ fontFamily: AI_SANS, fontSize: 15.5, fontWeight: 500, color: ui.ink }}>{p.name}</div>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 2 }}>
+                        <span style={{ width: 7, height: 7, borderRadius: 4, background: p.status === 'ok' ? ui.green : ui.red }} />
+                        <span style={{ fontFamily: window.MONO, fontSize: 11.5, color: p.status === 'ok' ? ui.sec : ui.red }}>{p.status === 'ok' ? p.model : '401 — key rejected'}</span>
+                      </div>
+                    </div>
+                    <window.Icons.ChevronD size={18} color={ui.ter} style={{ transform: 'rotate(-90deg)' }} />
+                    {i < providers.length - 1 && <div style={{ position: 'absolute', left: 46, right: 0, bottom: 0, height: 0.5, background: ui.sep }} />}
+                  </div>
+                ))}
+              </Card>
+              <GroupFooter ui={ui}>The selected provider is used for translation, chat, and summaries. Tap one to edit or test it.</GroupFooter>
+            </>
+          )}
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+// ── B · bilingual interlinear reader ─────────────────────────
+const BL_PAIRS = [
+  ['It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife.', '凡是有钱的单身汉，总想娶位太太，这已成了一条举世公认的真理。'],
+  ['However little known the feelings of such a man may be, this truth is so well fixed in the minds of the surrounding families…', '这样的单身汉，每逢新搬到一个地方，四邻八舍虽然完全不了解他的性情……'],
+  ['…that he is considered as the rightful property of some one or other of their daughters.', '……却把他视作自己某一个女儿理所应得的一笔财产。'],
+];
+
+function BilingualReader({ themeKey = 'paper', state = 'on', height = 880 }) {
+  const t = window.THEMES[themeKey];
+  const trans = t.isDark ? '#d6885a' : '#8c2f2f';
+  return (
+    <window.TtsFrame t={t} height={height}>
+      <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column' }}>
+        <window.StatusStrip t={t} />
+        <window.ReaderChrome t={t} />
+        {state === 'inflight' && (
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 9, padding: '6px 0 10px' }}>
+            <svg className="apf-spin" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke={trans} strokeWidth="2.6" strokeLinecap="round"><path d="M12 3a9 9 0 1 0 9 9"/></svg>
+            <span style={{ fontFamily: AI_SANS, fontSize: 12.5, fontWeight: 600, color: trans }}>Translating chapter… 38%</span>
+          </div>
+        )}
+        <div style={{ flex: 1, overflow: 'hidden', padding: '6px 26px 0' }}>
+          {state === 'error' ? (
+            <div style={{ textAlign: 'center', padding: '90px 20px' }}>
+              <div style={{ width: 58, height: 58, borderRadius: 29, background: t.isDark ? 'rgba(224,119,90,0.14)' : 'rgba(168,64,47,0.1)', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 16px' }}>
+                <window.Icons.Translate size={28} color={trans} />
+              </div>
+              <div style={{ fontFamily: AI_SERIF, fontSize: 18, color: t.ink, marginBottom: 8 }}>Couldn't translate</div>
+              <div style={{ fontFamily: AI_SANS, fontSize: 13.5, color: t.sub, lineHeight: 1.5, marginBottom: 18 }}>Claude returned a 429 (rate limit). The original text is unchanged — try again or switch provider.</div>
+              <button style={{ border: 'none', cursor: 'pointer', background: t.accent, color: '#fff', borderRadius: 11, padding: '10px 20px', fontFamily: AI_SANS, fontSize: 14, fontWeight: 600 }}>Retry</button>
+            </div>
+          ) : (
+            <div style={{ fontFamily: AI_SERIF, fontSize: 18, lineHeight: 1.5, color: t.ink, textWrap: 'pretty' }}>
+              {BL_PAIRS.map(([en, zh], i) => (
+                <div key={i} style={{ marginBottom: 19 }}>
+                  <div style={{ color: state === 'inflight' && i > 0 ? t.sub : t.ink, opacity: state === 'inflight' && i > 0 ? 0.5 : 1 }}>{en}</div>
+                  {(state === 'on' || (state === 'inflight' && i === 0)) && (
+                    <div style={{ color: trans, fontSize: 16, marginTop: 5, lineHeight: 1.5, paddingLeft: 11, borderLeft: `2px solid ${trans}`, opacity: 0.92 }}>{zh}</div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+        {/* bilingual toggle in a mini More-popover footer */}
+        {state !== 'error' && (
+          <div style={{ margin: '0 14px 14px', background: t.chrome, borderRadius: 14, border: `0.5px solid ${t.rule}`, padding: '12px 15px', display: 'flex', alignItems: 'center', gap: 11 }}>
+            <window.Icons.Translate size={20} color={t.accent} />
+            <div style={{ flex: 1 }}>
+              <div style={{ fontFamily: AI_SANS, fontSize: 14.5, fontWeight: 600, color: t.ink }}>Bilingual mode</div>
+              <div style={{ fontFamily: AI_SANS, fontSize: 11.5, color: t.sub, marginTop: 1 }}>English → 中文 · Claude · Literary</div>
+            </div>
+            <div style={{ width: 46, height: 28, borderRadius: 14, background: t.accent, position: 'relative' }}>
+              <div style={{ position: 'absolute', top: 2, left: 20, width: 24, height: 24, borderRadius: 12, background: '#fff', boxShadow: '0 1px 3px rgba(0,0,0,0.25)' }} />
+            </div>
+          </div>
+        )}
+      </div>
+    </window.TtsFrame>
+  );
+}
+
+function BilingualSetupSheet({ ui, height = 880 }) {
+  const Seg = ({ opts, sel }) => (
+    <div style={{ display: 'flex', padding: 3, borderRadius: 12, background: ui.segBg, marginTop: 8 }}>
+      {opts.map((o) => {
+        const on = o === sel;
+        return <div key={o} style={{ flex: 1, textAlign: 'center', padding: '9px 4px', borderRadius: 10, fontFamily: AI_SANS, fontSize: 13.5, fontWeight: on ? 600 : 500, color: ui.ink, background: on ? ui.segSel : 'transparent', boxShadow: on ? '0 1px 2px rgba(0,0,0,0.08)' : 'none' }}>{o}</div>;
+      })}
+    </div>
+  );
+  return (
+    <PhoneFrame ui={ui} height={height}>
+      <div style={{ position: 'absolute', inset: 0, background: ui.bg }} />
+      <AppSheet ui={ui} title="Bilingual Mode"
+        leading={<button style={{ background: 'none', border: 'none', padding: 0, fontFamily: AI_SANS, fontSize: 15, color: ui.sec }}>Cancel</button>}
+        trailing={<button style={{ background: 'none', border: 'none', padding: 0, fontFamily: AI_SANS, fontSize: 15, fontWeight: 600, color: ui.tint }}>Translate</button>}
+        height={height - 36}>
+        <div style={{ padding: '16px 18px 32px' }}>
+          <GroupHeader ui={ui}>Languages</GroupHeader>
+          <Card ui={ui}>
+            <Row ui={ui} label="From"><ValueText ui={ui} text="English (detected)" /></Row>
+            <Row ui={ui} label="To" last><ValueText ui={ui} text="中文 (Simplified)" /></Row>
+          </Card>
+
+          <div style={{ height: 18 }} />
+          <GroupHeader ui={ui}>Provider</GroupHeader>
+          <Card ui={ui}>
+            <Row ui={ui} label="Provider"><ValueText ui={ui} text="Claude (Anthropic)" /></Row>
+            <Row ui={ui} label="Model" last><ValueText ui={ui} text="claude-sonnet-4-6" /></Row>
+          </Card>
+
+          <div style={{ height: 18 }} />
+          <GroupHeader ui={ui}>Style</GroupHeader>
+          <Seg opts={['Literal', 'Natural', 'Literary']} sel="Literary" />
+          <GroupFooter ui={ui}>Literary keeps tone and rhythm at the cost of word-for-word fidelity. The original is always kept — bilingual mode shows both.</GroupFooter>
+
+          <div style={{ height: 18 }} />
+          <Card ui={ui}>
+            <Row ui={ui} label="Keep term overrides" last>
+              <div style={{ width: 46, height: 28, borderRadius: 14, background: ui.tint, position: 'relative' }}>
+                <div style={{ position: 'absolute', top: 2, left: 20, width: 24, height: 24, borderRadius: 12, background: '#fff', boxShadow: '0 1px 3px rgba(0,0,0,0.25)' }} />
+              </div>
+            </Row>
+          </Card>
+          <GroupFooter ui={ui}>~$0.04 · 7,900 tokens for this chapter. Translations are cached per chapter.</GroupFooter>
+        </div>
+      </AppSheet>
+    </PhoneFrame>
+  );
+}
+
+// ── C · AI chat + summary panel ──────────────────────────────
+function AiChatPanel({ themeKey = 'paper', state = 'idle', height = 880 }) {
+  const t = window.THEMES[themeKey];
+  const glass = t.isDark ? 'rgba(28,26,23,0.95)' : 'rgba(252,248,240,0.98)';
+  const userBubble = t.isDark ? 'rgba(214,136,90,0.18)' : 'rgba(140,47,47,0.1)';
+  const unconf = state === 'unconfigured';
+
+  return (
+    <window.TtsFrame t={t} height={height}>
+      <div style={{ position: 'absolute', inset: 0 }}>
+        {/* dimmed reader behind */}
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', filter: 'blur(1.5px)', opacity: 0.5 }}>
+          <window.StatusStrip t={t} />
+          <window.ReaderChrome t={t} />
+          <div style={{ padding: '6px 26px', fontFamily: AI_SERIF, fontSize: 18, lineHeight: 1.6, color: t.ink }}>
+            It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife.
+          </div>
+        </div>
+        <div style={{ position: 'absolute', inset: 0, background: 'rgba(0,0,0,0.28)' }} />
+
+        {/* chat sheet */}
+        <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, top: 96, background: glass, backdropFilter: 'blur(20px)', WebkitBackdropFilter: 'blur(20px)', borderTopLeftRadius: 22, borderTopRightRadius: 22, display: 'flex', flexDirection: 'column', boxShadow: '0 -8px 28px rgba(0,0,0,0.25)' }}>
+          <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 8 }}>
+            <div style={{ width: 36, height: 5, borderRadius: 3, background: t.isDark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.12)' }} />
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 9, padding: '12px 18px 12px', borderBottom: `0.5px solid ${t.rule}` }}>
+            <window.Icons.Sparkle size={20} color={t.accent} />
+            <div style={{ flex: 1, fontFamily: AI_SERIF, fontSize: 16.5, fontWeight: 600, color: t.ink }}>{state === 'summary' ? 'Chapter summary' : 'Ask about this book'}</div>
+            {!unconf && <span style={{ fontFamily: AI_SANS, fontSize: 11.5, fontWeight: 600, color: t.sub, background: t.isDark ? 'rgba(255,255,255,0.07)' : 'rgba(29,26,20,0.05)', borderRadius: 100, padding: '4px 9px' }}>Claude</span>}
+          </div>
+
+          <div className="hide-scroll" style={{ flex: 1, overflow: 'auto', padding: '16px 18px' }}>
+            {unconf && (
+              <div style={{ textAlign: 'center', padding: '50px 26px' }}>
+                <div style={{ width: 60, height: 60, borderRadius: 30, background: t.isDark ? 'rgba(214,136,90,0.14)' : 'rgba(140,47,47,0.09)', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 18px' }}>
+                  <window.Icons.Sparkle size={28} color={t.accent} />
+                </div>
+                <div style={{ fontFamily: AI_SERIF, fontSize: 19, color: t.ink, marginBottom: 8 }}>Connect a provider first</div>
+                <div style={{ fontFamily: AI_SANS, fontSize: 13.5, color: t.sub, lineHeight: 1.5, marginBottom: 18 }}>Chat and summaries need an AI provider. Add one in Settings — it takes a key and a minute.</div>
+                <button style={{ border: 'none', cursor: 'pointer', background: t.accent, color: '#fff', borderRadius: 11, padding: '11px 20px', fontFamily: AI_SANS, fontSize: 14, fontWeight: 600 }}>Open AI settings</button>
+              </div>
+            )}
+
+            {state === 'idle' && (
+              <>
+                <div style={{ fontFamily: AI_SANS, fontSize: 13, color: t.sub, marginBottom: 12 }}>Ask anything about what you're reading, or try:</div>
+                {['Who is Mr. Bingley?', 'Explain this sentence', 'What themes appear in Chapter 1?', 'Summarize this chapter'].map((s) => (
+                  <div key={s} style={{ display: 'inline-flex', alignItems: 'center', margin: '0 8px 8px 0', fontFamily: AI_SANS, fontSize: 13.5, fontWeight: 500, color: t.ink, background: t.isDark ? 'rgba(255,255,255,0.06)' : 'rgba(29,26,20,0.05)', borderRadius: 100, padding: '9px 14px' }}>{s}</div>
+                ))}
+              </>
+            )}
+
+            {(state === 'inflight' || state === 'answer') && (
+              <>
+                <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 16 }}>
+                  <div style={{ maxWidth: '78%', background: userBubble, borderRadius: '16px 16px 4px 16px', padding: '10px 14px', fontFamily: AI_SANS, fontSize: 14.5, color: t.ink, lineHeight: 1.45 }}>Who is Mr. Bingley and why does he matter?</div>
+                </div>
+                <div style={{ display: 'flex', gap: 9 }}>
+                  <window.Icons.Sparkle size={18} color={t.accent} style={{ marginTop: 2, flexShrink: 0 }} />
+                  <div style={{ flex: 1 }}>
+                    {state === 'inflight' ? (
+                      <div style={{ display: 'flex', gap: 5, padding: '6px 0' }}>
+                        {[0, 1, 2].map((i) => <span key={i} style={{ width: 7, height: 7, borderRadius: 4, background: t.sub, opacity: 0.4 }} />)}
+                      </div>
+                    ) : (
+                      <div style={{ fontFamily: AI_SERIF, fontSize: 15.5, color: t.ink, lineHeight: 1.58 }}>
+                        Mr. Bingley is the wealthy, good-natured bachelor who has just leased Netherfield Park. He matters because his arrival sets the novel's marriage plot in motion — and his easy charm is the foil against which Darcy's reserve first reads as pride.
+                        <span style={{ display: 'inline-block', width: 2, height: 16, background: t.accent, verticalAlign: -3, marginLeft: 2 }} />
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </>
+            )}
+
+            {state === 'summary' && (
+              <>
+                <div style={{ background: t.isDark ? 'rgba(255,255,255,0.04)' : '#fff', borderRadius: 14, padding: '15px 16px', boxShadow: t.isDark ? 'none' : '0 1px 3px rgba(0,0,0,0.05)' }}>
+                  <div style={{ fontFamily: AI_SANS, fontSize: 11.5, fontWeight: 600, letterSpacing: 0.4, textTransform: 'uppercase', color: t.sub, marginBottom: 9 }}>Chapter 1 · 4 key points</div>
+                  {[
+                    'The Bennet family learns the wealthy Mr. Bingley has leased nearby Netherfield Park.',
+                    'Mrs. Bennet is determined to marry one of her five daughters to him.',
+                    'Mr. Bennet teases his wife but agrees to call on Bingley.',
+                    'Austen establishes her ironic narrator with the famous opening line.',
+                  ].map((p, i) => (
+                    <div key={i} style={{ display: 'flex', gap: 9, marginBottom: 9 }}>
+                      <span style={{ width: 6, height: 6, borderRadius: 3, background: t.accent, marginTop: 7, flexShrink: 0 }} />
+                      <span style={{ fontFamily: AI_SERIF, fontSize: 14.5, color: t.ink, lineHeight: 1.5 }}>{p}</span>
+                    </div>
+                  ))}
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 12, fontFamily: AI_SANS, fontSize: 12.5, color: t.sub }}>
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={t.sub} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><path d="M3 3v5h5"/></svg>
+                  Regenerate · Claude · cached
+                </div>
+              </>
+            )}
+          </div>
+
+          {/* input bar */}
+          {!unconf && state !== 'summary' && (
+            <div style={{ padding: '10px 14px 16px', borderTop: `0.5px solid ${t.rule}`, display: 'flex', alignItems: 'center', gap: 10 }}>
+              <div style={{ flex: 1, display: 'flex', alignItems: 'center', height: 44, borderRadius: 22, padding: '0 16px', background: t.isDark ? 'rgba(255,255,255,0.06)' : 'rgba(29,26,20,0.05)' }}>
+                <span style={{ fontFamily: AI_SANS, fontSize: 15, color: t.sub }}>Ask a question…</span>
+              </div>
+              <div style={{ width: 44, height: 44, borderRadius: 22, background: t.accent, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <window.Icons.Send size={20} color="#fff" />
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </window.TtsFrame>
+  );
+}
+
+Object.assign(window, { AiProviderList, BilingualReader, BilingualSetupSheet, AiChatPanel });

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 1032
-        MARKETING_VERSION: 3.66.48
+        CURRENT_PROJECT_VERSION: 1033
+        MARKETING_VERSION: 3.66.49
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -8113,7 +8113,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8121,7 +8121,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.48;
+				MARKETING_VERSION = 3.66.49;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -8267,7 +8267,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1032;
+				CURRENT_PROJECT_VERSION = 1033;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8275,7 +8275,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.48;
+				MARKETING_VERSION = 3.66.49;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
## Summary

Imports the committed claude.ai/design handoff for the Android AI provider + bilingual + chat surfaces (the user's design that resolves needs-design #1798), so rule 51 is satisfied before the AI feature implementation begins.

## What Changed

- `dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-android.jsx` — `AiProviderList` (the provider gate: unconfigured→configured), `BilingualReader` (interlinear on/in-flight/error), `BilingualSetupSheet`, `AiChatPanel` (chat + summary: unconfigured/idle/in-flight/answer/summary).
- `…/design-notes/android-phase3-batch2-issues.md` — the batch-2 rationale covering all six Phase-3 needs-design issues (#1797–#1802).

The provider `EditorSheet` (`vreader-ai-provider-fields.jsx`) was already committed from the #79 import.

## Validation

- [x] Design-only import (no code) — unblocks rule 51 for the Android AI feature
- [x] Version bumped: 3.66.48 → **3.66.49** (shared change bumps the iOS version per rule 40)

## Type of Change

- [x] Design bundle import (resolves needs-design #1798)