### PR TITLE
fix: run-opds-roundtrip.sh orphaned its http.server (process leak)

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 1033
-        MARKETING_VERSION: 3.66.49
+        CURRENT_PROJECT_VERSION: 1034
+        MARKETING_VERSION: 3.66.50
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/scripts/run-opds-roundtrip.sh
+++ b/scripts/run-opds-roundtrip.sh
@@ -49,7 +49,10 @@ cat > "$SERVEDIR/feed.xml" <<EOF
 </feed>
 EOF
 
-( cd "$SERVEDIR" && python3 -m http.server "$PORT" --bind 127.0.0.1 >/dev/null 2>&1 ) &
+# NOT `( cd … && python3 … ) &` — that captures the SUBSHELL pid in $!, so the trap's
+# `kill $SERVER_PID` reaps the subshell but ORPHANS the python child (it survives as a ghost
+# http.server). `--directory` runs python directly so $! is the real server pid (rule 49).
+python3 -m http.server "$PORT" --bind 127.0.0.1 --directory "$SERVEDIR" >/dev/null 2>&1 &
 SERVER_PID=$!
 
 # Wait (bounded) for the server to accept connections.

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -8113,7 +8113,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1033;
+				CURRENT_PROJECT_VERSION = 1034;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8121,7 +8121,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.49;
+				MARKETING_VERSION = 3.66.50;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -8267,7 +8267,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1033;
+				CURRENT_PROJECT_VERSION = 1034;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8275,7 +8275,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.49;
+				MARKETING_VERSION = 3.66.50;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
## Summary

The OPDS round-trip verification harness (`scripts/run-opds-roundtrip.sh`) leaked its HTTP server. It started the server as `( cd … && python3 -m http.server ) &` and captured the **subshell** pid in `$!`, so the EXIT trap's `kill $SERVER_PID` reaped the subshell but **orphaned** the python child — two ghost `http.server` processes survived from the two #117 verification runs (found 2026-06-23, killed by exact PID).

## Fix

Run python directly with `--directory "$SERVEDIR"` (no subshell), so `$!` captures the real server pid the trap kills (rule 49 — one async job, one owner, one completion channel).

## Validation

- [x] One-line harness fix; the two leaked servers were reaped
- [x] Version bumped: 3.66.49 → **3.66.50**

## Type of Change

- [x] Bug fix (verification tooling / process hygiene)