### PR TITLE
chore: prevent leaked verification servers (sweeper backstop + harness + rule 49)

### DIFF
--- a/.claude/rules/49-background-shells.md
+++ b/.claude/rules/49-background-shells.md
@@ -104,6 +104,34 @@ Hard rules:
    session end. A capture nobody has killed by the time its consumer
    finished reading is already a leak.
 
+### Verification servers + the subshell-pid trap (2026-06-23)
+
+Round-trip harnesses (`run-webdav-roundtrip.sh`, `run-opds-roundtrip.sh`) stand
+up a throwaway local server (rclone / `python -m http.server`), run a connected
+test, and kill the server on an `EXIT` trap. Two `http.server` processes still
+leaked ~10h. Cause: the OPDS script started the server as
+
+```bash
+( cd "$DIR" && python3 -m http.server "$PORT" ) &   # WRONG
+SERVER_PID=$!                                         # ← the SUBSHELL's pid
+```
+
+`$!` captures the **subshell**, not the python grandchild. `kill $SERVER_PID`
+reaps the subshell and **orphans** python, which serves forever at 0% CPU.
+
+Hard rules for a script-owned server:
+
+1. **Start the server DIRECTLY, never in a `( … ) &` subshell**, so `$!` is the
+   real server pid. Use the tool's own cwd flag instead of `cd` in a subshell
+   (`python3 -m http.server --directory "$DIR"`, `rclone serve … "$DIR"`).
+2. **Belt-and-suspenders in `cleanup()`**: after `kill "$SERVER_PID"`, also
+   `pkill -f "<server> $PORT "` keyed to **this run's exact port** — never a
+   bare class match (that would catch another run's or the user's server).
+3. The backstop is **`scripts/sweep-ghosts.sh`**, which now flags a stale
+   `http.server` as a ghost class. It does NOT touch `rclone serve` — the user
+   runs persistent rclone WebDAV servers (`~/vreader-webdav-data` etc.); never
+   broad-`pkill` an `rclone`/`vreader-webdav` pattern.
+
 ## Cron-specific implications
 
 vreader's cron prompts (`.claude/cron-prompts/{verify,bugfix,watchdog}.md`) fire as fresh agent sessions. A background shell from a prior session can outlive that session's logical end (until the OS reaps it) and still appear in the operator's UI. To avoid this:

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 1034
-        MARKETING_VERSION: 3.66.50
+        CURRENT_PROJECT_VERSION: 1035
+        MARKETING_VERSION: 3.66.51
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/scripts/run-opds-roundtrip.sh
+++ b/scripts/run-opds-roundtrip.sh
@@ -15,7 +15,13 @@ PORT="${PORT:-$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1
 SERVEDIR="$(mktemp -d -t vreader-opds)"
 SERVER_PID=""
 
-cleanup() { [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null; rm -rf "$SERVEDIR" 2>/dev/null; }
+cleanup() {
+  [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null
+  # Belt-and-suspenders: reap any http.server bound to THIS run's exact port (never another run's
+  # or the user's anything), in case the pid above ever misses a forked child.
+  pkill -f "http.server $PORT " 2>/dev/null
+  rm -rf "$SERVEDIR" 2>/dev/null
+}
 trap cleanup EXIT INT TERM
 
 # Stage the EPUB.

--- a/scripts/sweep-ghosts.sh
+++ b/scripts/sweep-ghosts.sh
@@ -15,6 +15,12 @@
 #   - `am instrument`             rule 52 Cause D — wedged Android instrumentation
 #   - `adb … logcat`              rule 49 — detached logcat side-channel capture
 #                                  (recurring; watchdogged by run-tests.sh)
+#   - `python … http.server`      rule 49 — detached verification HTTP server left
+#                                  by a round-trip harness (origin: two
+#                                  run-opds-roundtrip.sh servers orphaned ~10h via
+#                                  a subshell-pid trap, found 2026-06-23). No one
+#                                  runs a persistent http.server here, so any past
+#                                  the threshold is a leak.
 #
 # NOT flagged: SWBBuildService (Xcode's resident build daemon — alive and
 # idle between builds by design), the Gradle daemon + a booted Android
@@ -64,7 +70,8 @@ ghosts=$(ps -Ao pid=,etime=,pcpu=,command= | awk -v thr="$THRESHOLD_MIN" '
         otherClass = (cmd !~ /( grep | awk )/) && \
             (cmd ~ /tail -f/ || cmd ~ /log stream/ || \
              cmd ~ /(^|\/)codex( |$)/ || cmd ~ /xcodebuild (test|build)/ || \
-             cmd ~ /am instrument/ || cmd ~ /adb .*logcat/)
+             cmd ~ /am instrument/ || cmd ~ /adb .*logcat/ || \
+             cmd ~ /http\.server/)
         waiterClass = (cmd ~ /(until|while) .*do sleep [0-9]/)
     }
     otherClass || waiterClass {

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -8113,7 +8113,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1034;
+				CURRENT_PROJECT_VERSION = 1035;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8121,7 +8121,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.50;
+				MARKETING_VERSION = 3.66.51;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -8267,7 +8267,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1034;
+				CURRENT_PROJECT_VERSION = 1035;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8275,7 +8275,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.50;
+				MARKETING_VERSION = 3.66.51;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
## Summary

Closes the gap that let two `python -m http.server` processes leak ~10h from my OPDS round-trip verification runs (#117). The one-script start-fix already shipped (#1809); this makes the leak **class** impossible to miss.

## What Changed

- **`scripts/sweep-ghosts.sh`** — now flags a stale `python … http.server` as a ghost class (the backstop that would have auto-caught these). Verified: it detects + `--kill` reaps a decoy server. It still **never** touches `rclone serve` — you run persistent rclone WebDAV servers (`~/vreader-webdav-data`, `/tmp/vreader-test-webdav-a`), so those stay excluded.
- **`scripts/run-opds-roundtrip.sh`** — `cleanup()` adds a port-specific `pkill -f "http.server $PORT "` belt (on top of the already-fixed direct-pid start), keyed to **this run's exact port** so it can't catch another run's or your server.
- **`.claude/rules/49-background-shells.md`** — documents the cause (`( … ) &` captures the subshell pid in `$!`, so the trap orphans the python grandchild) + the prevention (start directly, port-keyed belt, sweeper backstop).

## Validation

- [x] Both scripts pass `bash -n`
- [x] Sweeper proven: started a decoy `http.server`, `sweep-ghosts.sh` → `FOUND 1`, `--kill` → `KILLED 1`, decoy reaped
- [x] The two original leaked servers were already killed by exact PID
- [x] Version bumped: 3.66.50 → **3.66.51**

## Type of Change

- [x] Tooling / process hygiene (prevents the leak class recurring)