### PR TITLE
design(#110): import 4 Android Phase-3 batch-2 design specs

### DIFF
--- a/dev-docs/designs/vreader-fidelity-v1/project/vreader-android-annotations.jsx
+++ b/dev-docs/designs/vreader-fidelity-v1/project/vreader-android-annotations.jsx
@@ -1,0 +1,302 @@
+// Issue #1801 / Feature #110 (Android Phase-3) — highlights + annotations.
+//
+// iOS has highlights, bookmarks and notes with a review surface; Android's
+// persistence (Room) can carry them, but the reader selection→highlight UI and
+// the annotations review/list UI were design-gated (rule 51). Built in
+// VReader's own vocabulary (reader THEMES for the in-page surfaces, the shared
+// form UI tokens for the review sheets) so it reads as the same product.
+//
+// Two surfaces:
+//   A. In-reader text selection → a floating action popover: 5 highlight
+//      colors, add-note, copy, share. Tapping an existing highlight re-opens
+//      the same popover with Edit/Delete. Note compose is inline.
+//   B. The annotations review list — per-book and library-wide. Three record
+//      kinds (highlight / standalone note / bookmark), a filter chip row, and
+//      empty + edit states. Mirrors the iOS HighlightsSheet decisions (#860).
+
+const ANN_SERIF = '"Source Serif 4", Georgia, serif';
+const ANN_SANS = "'Inter', -apple-system, system-ui, sans-serif";
+
+// Highlight palette — book-friendly muted tones, shared by popover + cards.
+const HL_COLORS = [
+  { key: 'yellow', dot: '#e6b800', wash: 'rgba(230,184,0,0.28)', rule: '#d9a800' },
+  { key: 'green',  dot: '#5a9a6e', wash: 'rgba(90,154,110,0.26)', rule: '#5a9a6e' },
+  { key: 'blue',   dot: '#5c8fc4', wash: 'rgba(92,143,196,0.26)', rule: '#5c8fc4' },
+  { key: 'pink',   dot: '#cf7a9a', wash: 'rgba(207,122,154,0.26)', rule: '#cf7a9a' },
+  { key: 'red',    dot: '#b5503f', wash: 'rgba(181,80,63,0.24)', rule: '#b5503f' },
+];
+
+// ── in-reader selection / popover ────────────────────────────
+// modes: 'select' (just-selected, color + actions) · 'colors' · 'note'
+//        'editHL' (tapped an existing highlight)
+function SelectionReader({ themeKey = 'paper', mode = 'select', height = 880 }) {
+  const t = window.THEMES[themeKey];
+  const selBg = t.isDark ? 'rgba(92,143,196,0.4)' : 'rgba(92,143,196,0.34)';
+  const selColor = HL_COLORS[0];
+  const existing = mode === 'editHL';
+
+  return (
+    <window.TtsFrame t={t} height={height}>
+      <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column' }}>
+        <window.StatusStrip t={t} />
+        <window.ReaderChrome t={t} />
+        <div style={{ flex: 1, position: 'relative', padding: '6px 26px 0', overflow: 'hidden' }}>
+          <div style={{ fontFamily: ANN_SERIF, fontSize: 18.5, lineHeight: 1.62, color: t.ink, textWrap: 'pretty' }}>
+            <p style={{ margin: '0 0 17px' }}>
+              Mr. Bennet was so odd a mixture of quick parts, sarcastic humour, reserve, and caprice, that the experience of three-and-twenty years had been insufficient to make his wife understand his character.
+            </p>
+            <p style={{ margin: '0 0 17px', position: 'relative' }}>
+              Her mind was less difficult to develop.{' '}
+              <span style={{
+                background: existing ? selColor.wash : selBg,
+                boxShadow: existing ? `inset 2px 0 0 ${selColor.rule}` : 'none',
+                borderRadius: 2, padding: '1px 2px', position: 'relative',
+              }}>
+                {!existing && <span style={{ position: 'absolute', left: -3, top: -3, width: 9, height: 9, borderRadius: 5, background: '#5c8fc4' }} />}
+                She was a woman of mean understanding, little information, and uncertain temper.
+                {!existing && <span style={{ position: 'absolute', right: -3, bottom: -3, width: 9, height: 9, borderRadius: 5, background: '#5c8fc4' }} />}
+              </span>{' '}
+              When she was discontented, she fancied herself nervous.
+            </p>
+            <p style={{ margin: 0, color: t.sub }}>
+              The business of her life was to get her daughters married; its solace was visiting and news.
+            </p>
+          </div>
+
+          {/* the floating popover, anchored under the selection */}
+          <div style={{ position: 'absolute', left: 24, right: 24, top: 232, display: 'flex', justifyContent: 'center' }}>
+            <SelectionPopover t={t} mode={mode} />
+          </div>
+        </div>
+      </div>
+    </window.TtsFrame>
+  );
+}
+
+function SelectionPopover({ t, mode }) {
+  const card = t.isDark ? '#2c2926' : '#ffffff';
+  const divider = t.isDark ? 'rgba(255,255,255,0.1)' : 'rgba(29,26,20,0.1)';
+  const ActionBtn = ({ icon, label, danger }) => (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4, padding: '4px 12px', minWidth: 52 }}>
+      <span style={{ color: danger ? '#b5503f' : t.ink, opacity: 0.9 }}>{icon}</span>
+      <span style={{ fontFamily: ANN_SANS, fontSize: 11, fontWeight: 500, color: danger ? '#b5503f' : t.sub }}>{label}</span>
+    </div>
+  );
+  const ic = (name, c) => { const I = window.Icons[name]; return <I size={20} color={c || t.ink} stroke={1.7} />; };
+
+  return (
+    <div style={{
+      background: card, borderRadius: 16, boxShadow: '0 8px 30px rgba(0,0,0,0.28), 0 0 0 0.5px rgba(0,0,0,0.06)',
+      position: 'relative', maxWidth: 340,
+    }}>
+      {/* color row */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '13px 16px', justifyContent: 'center' }}>
+        {HL_COLORS.map((c, i) => (
+          <div key={c.key} style={{
+            width: 28, height: 28, borderRadius: 14, background: c.dot,
+            boxShadow: (mode === 'editHL' ? i === 4 : i === 0) ? `0 0 0 2.5px ${card}, 0 0 0 4.5px ${c.dot}` : 'none',
+          }} />
+        ))}
+        <div style={{ width: 0.5, height: 26, background: divider, margin: '0 2px' }} />
+        <div style={{
+          width: 28, height: 28, borderRadius: 14, border: `1.5px dashed ${t.sub}`,
+          display: 'flex', alignItems: 'center', justifyContent: 'center', color: t.sub, fontSize: 16,
+        }}>+</div>
+      </div>
+      <div style={{ height: 0.5, background: divider }} />
+      {/* action row */}
+      {mode === 'note' ? (
+        <div style={{ padding: '12px 14px 14px', width: 312 }}>
+          <div style={{ fontFamily: ANN_SANS, fontSize: 11, fontWeight: 600, letterSpacing: 0.4, textTransform: 'uppercase', color: t.sub, marginBottom: 8 }}>Add note</div>
+          <div style={{
+            background: t.isDark ? 'rgba(255,255,255,0.05)' : 'rgba(29,26,20,0.04)', borderRadius: 10, padding: '10px 12px',
+            fontFamily: ANN_SERIF, fontSize: 15, color: t.ink, minHeight: 64, lineHeight: 1.5,
+          }}>
+            Austen's irony lands in the dependent clause<span style={{ display: 'inline-block', width: 1.5, height: 17, background: t.accent, verticalAlign: -3, marginLeft: 1 }} />
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 11 }}>
+            <button style={{ border: 'none', background: 'transparent', color: t.sub, fontFamily: ANN_SANS, fontSize: 14, fontWeight: 500, padding: '7px 12px' }}>Cancel</button>
+            <button style={{ border: 'none', background: t.accent, color: '#fff', fontFamily: ANN_SANS, fontSize: 14, fontWeight: 600, borderRadius: 9, padding: '7px 16px' }}>Save</button>
+          </div>
+        </div>
+      ) : (
+        <div style={{ display: 'flex', alignItems: 'center', padding: '8px 6px', gap: 0 }}>
+          {mode === 'editHL' ? (
+            <>
+              <ActionBtn icon={ic('Note')} label="Note" />
+              <ActionBtn icon={ic('Copy')} label="Copy" />
+              <ActionBtn icon={ic('Share')} label="Share" />
+              <ActionBtn icon={ic('Close', '#b5503f')} label="Remove" danger />
+            </>
+          ) : (
+            <>
+              <ActionBtn icon={ic('Highlighter')} label="Highlight" />
+              <ActionBtn icon={ic('Note')} label="Note" />
+              <ActionBtn icon={ic('Copy')} label="Copy" />
+              <ActionBtn icon={ic('Translate')} label="Translate" />
+              <ActionBtn icon={ic('Share')} label="Share" />
+            </>
+          )}
+        </div>
+      )}
+      {/* downward notch */}
+      <div style={{ position: 'absolute', bottom: -7, left: '50%', transform: 'translateX(-50%) rotate(45deg)', width: 14, height: 14, background: card, borderRadius: 3 }} />
+    </div>
+  );
+}
+
+// ── annotation cards ─────────────────────────────────────────
+function FilterChips({ ui, active = 'All' }) {
+  const chips = ['All', 'Highlights', 'Notes', 'Bookmarks'];
+  return (
+    <div style={{ display: 'flex', gap: 8, padding: '2px 0 4px', flexWrap: 'wrap' }}>
+      {chips.map((c) => {
+        const on = c === active;
+        return (
+          <span key={c} style={{
+            fontFamily: ANN_SANS, fontSize: 13, fontWeight: on ? 600 : 500,
+            color: on ? ui.bg : ui.ink, background: on ? ui.ink : (ui.isDark ? 'rgba(255,255,255,0.06)' : 'rgba(29,26,20,0.05)'),
+            borderRadius: 100, padding: '7px 14px',
+          }}>{c}</span>
+        );
+      })}
+    </div>
+  );
+}
+
+function HighlightCard({ ui, color, quote, note, meta, editing }) {
+  const c = HL_COLORS.find((x) => x.key === color) || HL_COLORS[0];
+  return (
+    <div style={{ background: ui.card, borderRadius: 14, padding: '14px 15px', boxShadow: ui.cardShadow, position: 'relative', marginBottom: 10 }}>
+      <div style={{ display: 'flex', gap: 12 }}>
+        <div style={{ width: 4, borderRadius: 2, background: c.rule, flexShrink: 0 }} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontFamily: ANN_SERIF, fontSize: 15.5, lineHeight: 1.5, color: ui.ink }}>{quote}</div>
+          {note != null && !editing && (
+            <div style={{ marginTop: 9, paddingTop: 9, borderTop: `0.5px solid ${ui.sep}`, fontFamily: ANN_SANS, fontSize: 13.5, lineHeight: 1.5, color: ui.sec }}>{note}</div>
+          )}
+          {editing && (
+            <div style={{ marginTop: 9 }}>
+              <div style={{ background: ui.isDark ? 'rgba(255,255,255,0.05)' : 'rgba(29,26,20,0.04)', borderRadius: 9, padding: '9px 11px', fontFamily: ANN_SANS, fontSize: 13.5, color: ui.ink, lineHeight: 1.5, boxShadow: `inset 0 0 0 1.5px ${ui.tint}` }}>
+                {note}<span style={{ display: 'inline-block', width: 1.5, height: 15, background: ui.tint, verticalAlign: -2, marginLeft: 1 }} />
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 11 }}>
+                {HL_COLORS.map((cc, i) => (
+                  <div key={cc.key} style={{ width: 22, height: 22, borderRadius: 11, background: cc.dot, boxShadow: cc.key === color ? `0 0 0 2px ${ui.card}, 0 0 0 3.5px ${cc.dot}` : 'none' }} />
+                ))}
+                <span style={{ flex: 1 }} />
+                <span style={{ fontFamily: ANN_SANS, fontSize: 13.5, color: ui.sec, fontWeight: 500 }}>Cancel</span>
+                <span style={{ fontFamily: ANN_SANS, fontSize: 13.5, color: ui.tint, fontWeight: 600 }}>Save</span>
+              </div>
+            </div>
+          )}
+          {!editing && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginTop: 9, fontFamily: ANN_SANS, fontSize: 12, color: ui.ter }}>
+              <span>{meta}</span>
+              {note != null && <span style={{ color: ui.tint, fontWeight: 600 }}>· Note</span>}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StandaloneNoteCard({ ui, body, meta }) {
+  return (
+    <div style={{ background: ui.card, borderRadius: 14, padding: '14px 15px', boxShadow: ui.cardShadow, position: 'relative', marginBottom: 10 }}>
+      <div style={{ display: 'flex', gap: 12 }}>
+        <div style={{ width: 4, borderRadius: 2, flexShrink: 0, background: `repeating-linear-gradient(${ui.tint} 0 4px, transparent 4px 8px)` }} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontFamily: ANN_SERIF, fontSize: 15.5, lineHeight: 1.52, color: ui.ink }}>{body}</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 9 }}>
+            <span style={{ fontFamily: ANN_SANS, fontSize: 9.5, fontWeight: 700, letterSpacing: 0.5, color: ui.tint, background: ui.tagBg, borderRadius: 5, padding: '2px 6px' }}>STANDALONE</span>
+            <span style={{ fontFamily: ANN_SANS, fontSize: 12, color: ui.ter }}>{meta}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BookmarkCard({ ui, label, meta }) {
+  return (
+    <div style={{ background: ui.card, borderRadius: 14, padding: '13px 15px', boxShadow: ui.cardShadow, marginBottom: 10, display: 'flex', alignItems: 'center', gap: 12 }}>
+      <window.Icons.BookmarkFilled size={20} color={ui.tint} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontFamily: ANN_SERIF, fontSize: 15, color: ui.ink, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{label}</div>
+        <div style={{ fontFamily: ANN_SANS, fontSize: 12, color: ui.ter, marginTop: 2 }}>{meta}</div>
+      </div>
+    </div>
+  );
+}
+
+// ── the review sheet (per-book or library-wide) ──────────────
+function AnnotationsSheet({ ui, scope = 'book', state = 'populated', height = 880 }) {
+  const empty = state === 'empty';
+  return (
+    <PhoneFrame ui={ui} height={height}>
+      <div style={{ position: 'absolute', inset: 0, background: ui.bg }} />
+      <AppSheet ui={ui} title={scope === 'book' ? 'Annotations' : 'All Annotations'}
+        leading={<button style={{ background: 'none', border: 'none', padding: 0, fontFamily: ANN_SANS, fontSize: 15, color: ui.sec }}>Close</button>}
+        trailing={<window.Icons.Share size={20} color={ui.tint} />}
+        height={height - 36}>
+        <div style={{ padding: '12px 16px 32px' }}>
+          {scope === 'book' && (
+            <div style={{ marginBottom: 10 }}>
+              <div style={{ fontFamily: ANN_SERIF, fontStyle: 'italic', fontSize: 19, color: ui.ink }}>Pride and Prejudice</div>
+              <div style={{ fontFamily: ANN_SANS, fontSize: 12.5, color: ui.sec, marginTop: 2 }}>{empty ? 'No annotations yet' : '12 highlights · 4 notes · 3 bookmarks'}</div>
+            </div>
+          )}
+          <FilterChips ui={ui} active="All" />
+          <div style={{ height: 12 }} />
+
+          {empty ? (
+            <div style={{ textAlign: 'center', padding: '64px 30px' }}>
+              <div style={{ width: 60, height: 60, borderRadius: 30, background: ui.isDark ? 'rgba(255,255,255,0.05)' : 'rgba(29,26,20,0.04)', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 18px' }}>
+                <window.Icons.Highlighter size={28} color={ui.ter} />
+              </div>
+              <div style={{ fontFamily: ANN_SERIF, fontSize: 19, color: ui.ink, marginBottom: 8 }}>Nothing saved yet</div>
+              <div style={{ fontFamily: ANN_SANS, fontSize: 14, color: ui.sec, lineHeight: 1.5 }}>
+                Press and hold a passage to highlight it, or tap the note icon on a chapter to jot a standalone note.
+              </div>
+            </div>
+          ) : scope === 'library' ? (
+            <>
+              <BookGroupHeader ui={ui} title="Pride and Prejudice" count="19" />
+              <HighlightCard ui={ui} color="yellow" quote={'"She was a woman of mean understanding, little information, and uncertain temper."'} note="Austen's irony lands in the dependent clause." meta="Ch. 1 · Apr 18" />
+              <StandaloneNoteCard ui={ui} body="Track how often weather forces the plot — Jane's cold at Netherfield is the first." meta="Ch. 7 · Apr 19" />
+              <BookGroupHeader ui={ui} title="The Beginning of Infinity" count="11" />
+              <HighlightCard ui={ui} color="blue" quote={'"Problems are inevitable… Problems are soluble."'} meta="Ch. 3 · Apr 12" />
+            </>
+          ) : (
+            <>
+              <HighlightCard ui={ui} color="yellow" quote={'"She was a woman of mean understanding, little information, and uncertain temper."'} note="Austen's irony lands in the dependent clause." meta="Ch. 1 · Apr 18" editing={state === 'edit'} />
+              {state !== 'edit' && <>
+                <StandaloneNoteCard ui={ui} body="Track how often weather forces the plot — Jane's cold at Netherfield is the first major instance." meta="Ch. 7 · Apr 19" />
+                <HighlightCard ui={ui} color="green" quote={'"It is a truth universally acknowledged…"'} meta="Ch. 1 · Apr 18" />
+                <BookmarkCard ui={ui} label={'"…the rightful property of some one or other of their daughters."'} meta="Ch. 1 · 14%" />
+                <HighlightCard ui={ui} color="pink" quote={'"A lady\'s imagination is very rapid; it jumps from admiration to love…"'} note="Foreshadows Elizabeth's own leaps to judgment." meta="Ch. 6 · Apr 20" />
+              </>}
+            </>
+          )}
+        </div>
+      </AppSheet>
+    </PhoneFrame>
+  );
+}
+
+function BookGroupHeader({ ui, title, count }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, margin: '6px 2px 10px' }}>
+      <span style={{ fontFamily: ANN_SERIF, fontStyle: 'italic', fontSize: 16, color: ui.ink }}>{title}</span>
+      <span style={{ flex: 1, height: 0.5, background: ui.sep }} />
+      <span style={{ fontFamily: ANN_SANS, fontSize: 12, color: ui.ter, fontVariantNumeric: 'tabular-nums' }}>{count}</span>
+    </div>
+  );
+}
+
+Object.assign(window, {
+  HL_COLORS, SelectionReader, SelectionPopover, AnnotationsSheet,
+  HighlightCard, StandaloneNoteCard, BookmarkCard, FilterChips,
+});

--- a/dev-docs/designs/vreader-fidelity-v1/project/vreader-library-android.jsx
+++ b/dev-docs/designs/vreader-fidelity-v1/project/vreader-library-android.jsx
@@ -1,0 +1,335 @@
+// Issue #1802 / Feature #110 (Android Phase-3) — library management.
+//
+// iOS has collections and library search; Android's Room layer can back them,
+// but the collections-management + search UI were design-gated (rule 51).
+// Built in VReader's vocabulary (reader THEMES for the surface, the shared
+// form tokens for the management sheets). Covers are typographic — a tonal
+// card + serif title — not illustrated art.
+//
+// Surfaces:
+//   A. Library with a collections shelf-bar (All / a horizontal chip row) +
+//      the 2-up cover grid; the collection-filtered view (scoped header).
+//   B. Collections management sheet (reorder / rename / delete / new) and the
+//      per-book Assign sheet (checklist + create-new inline).
+//   C. Search: empty (recents + suggestions), results, no-results.
+
+const LIB_SERIF = '"Source Serif 4", Georgia, serif';
+const LIB_SANS = "'Inter', -apple-system, system-ui, sans-serif";
+
+const BOOKS = [
+  { t: 'Pride and Prejudice', a: 'Jane Austen', bg: '#6e2b2b', fg: '#f3e7d8', pct: 42 },
+  { t: 'Designing Data-Intensive Applications', a: 'Martin Kleppmann', bg: '#244f4a', fg: '#e8ddc8', pct: 18 },
+  { t: 'The Pragmatic Programmer', a: 'Hunt & Thomas', bg: '#2f3a46', fg: '#dfe4e8', pct: 76 },
+  { t: 'The Beginning of Infinity', a: 'David Deutsch', bg: '#8a6a1f', fg: '#f6ecd2', pct: 9 },
+  { t: 'Sapiens', a: 'Yuval Noah Harari', bg: '#4a2f46', fg: '#e8d8e4', pct: 100 },
+  { t: 'Dune', a: 'Frank Herbert', bg: '#2f4630', fg: '#dfe8d8', pct: 0 },
+];
+
+const COLLECTIONS = ['All', 'Currently Reading', 'To Read', 'Fiction', 'Tech', 'Finished'];
+
+// typographic cover
+function Cover({ b, w = 116, showProgress }) {
+  const h = Math.round(w * 1.5);
+  return (
+    <div style={{ width: w, flexShrink: 0 }}>
+      <div style={{
+        width: w, height: h, borderRadius: 8, background: b.bg, position: 'relative', overflow: 'hidden',
+        boxShadow: '0 2px 6px rgba(0,0,0,0.2), inset 0 0 0 0.5px rgba(255,255,255,0.06)',
+        padding: '13px 12px', display: 'flex', flexDirection: 'column',
+      }}>
+        <div style={{ position: 'absolute', left: 0, top: 12, bottom: 12, width: 3, background: 'rgba(255,255,255,0.18)' }} />
+        <div style={{ fontFamily: LIB_SERIF, fontWeight: 600, fontSize: w < 100 ? 13 : 15, lineHeight: 1.2, color: b.fg, textWrap: 'pretty' }}>{b.t}</div>
+        <div style={{ flex: 1 }} />
+        <div style={{ fontFamily: LIB_SANS, fontSize: 9.5, fontWeight: 500, letterSpacing: 0.3, color: b.fg, opacity: 0.72, textTransform: 'uppercase' }}>{b.a}</div>
+        {showProgress && b.pct > 0 && b.pct < 100 && (
+          <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, height: 3, background: 'rgba(0,0,0,0.25)' }}>
+            <div style={{ height: '100%', width: `${b.pct}%`, background: 'rgba(255,255,255,0.85)' }} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function LibTopBar({ t, title, trailing }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '6px 18px 12px', flexShrink: 0 }}>
+      <div style={{ flex: 1, fontFamily: LIB_SERIF, fontSize: 26, fontWeight: 700, color: t.ink }}>{title}</div>
+      {trailing}
+    </div>
+  );
+}
+
+function CollectionBar({ t, active = 'All' }) {
+  return (
+    <div className="hide-scroll" style={{ display: 'flex', gap: 8, padding: '0 18px 12px', overflowX: 'auto', flexShrink: 0 }}>
+      {COLLECTIONS.map((c) => {
+        const on = c === active;
+        return (
+          <span key={c} style={{
+            flexShrink: 0, fontFamily: LIB_SANS, fontSize: 13.5, fontWeight: on ? 700 : 500,
+            color: on ? t.bg : t.ink, background: on ? t.ink : (t.isDark ? 'rgba(255,255,255,0.06)' : 'rgba(29,26,20,0.05)'),
+            borderRadius: 100, padding: '8px 15px', whiteSpace: 'nowrap',
+          }}>{c}</span>
+        );
+      })}
+    </div>
+  );
+}
+
+function CoverGrid({ t, books = BOOKS }) {
+  return (
+    <div style={{ flex: 1, overflow: 'hidden', padding: '4px 18px 0' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '22px 18px' }}>
+        {books.map((b, i) => (
+          <div key={i} style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 8 }}>
+            <Cover b={b} w={152} showProgress />
+            <div style={{ width: 152 }}>
+              <div style={{ fontFamily: LIB_SERIF, fontSize: 14, fontWeight: 600, color: t.ink, lineHeight: 1.25, textWrap: 'pretty' }}>{b.t}</div>
+              <div style={{ fontFamily: LIB_SANS, fontSize: 11.5, color: t.sub, marginTop: 2 }}>{b.a}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── A · library + collection-filtered ────────────────────────
+function LibraryScreen({ themeKey = 'paper', scope = 'all', height = 880 }) {
+  const t = window.THEMES[themeKey];
+  const filtered = scope === 'collection' ? [BOOKS[0], BOOKS[2]] : BOOKS;
+  return (
+    <window.TtsFrame t={t} height={height}>
+      <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column' }}>
+        <window.StatusStrip t={t} />
+        {scope === 'collection' ? (
+          <>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '4px 16px 4px', flexShrink: 0 }}>
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={t.ink} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: 0.8 }}><path d="M15 6l-6 6 6 6"/></svg>
+              <span style={{ fontFamily: LIB_SANS, fontSize: 14, color: t.sub }}>Library</span>
+            </div>
+            <div style={{ padding: '2px 18px 12px', flexShrink: 0 }}>
+              <div style={{ fontFamily: LIB_SERIF, fontSize: 25, fontWeight: 700, color: t.ink }}>Currently Reading</div>
+              <div style={{ fontFamily: LIB_SANS, fontSize: 12.5, color: t.sub, marginTop: 2 }}>2 books · edit collection</div>
+            </div>
+          </>
+        ) : (
+          <>
+            <LibTopBar t={t} title="Library" trailing={
+              <div style={{ display: 'flex', gap: 4 }}>
+                <div style={{ width: 40, height: 40, borderRadius: 20, display: 'flex', alignItems: 'center', justifyContent: 'center' }}><window.Icons.Search size={22} color={t.ink} /></div>
+                <div style={{ width: 40, height: 40, borderRadius: 20, display: 'flex', alignItems: 'center', justifyContent: 'center' }}><window.Icons.More size={22} color={t.ink} /></div>
+              </div>
+            } />
+            <CollectionBar t={t} active="All" />
+          </>
+        )}
+        <CoverGrid t={t} books={filtered} />
+      </div>
+    </window.TtsFrame>
+  );
+}
+
+// ── search states ────────────────────────────────────────────
+function SearchScreen({ themeKey = 'paper', state = 'results', height = 880 }) {
+  const t = window.THEMES[themeKey];
+  const q = state === 'empty' ? '' : state === 'noresults' ? 'thermodynamics' : 'pra';
+  const results = [BOOKS[2], BOOKS[0]];
+  return (
+    <window.TtsFrame t={t} height={height}>
+      <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column' }}>
+        <window.StatusStrip t={t} />
+        {/* search field */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '4px 16px 12px', flexShrink: 0 }}>
+          <div style={{
+            flex: 1, display: 'flex', alignItems: 'center', gap: 9, height: 42, borderRadius: 12, padding: '0 13px',
+            background: t.isDark ? 'rgba(255,255,255,0.06)' : 'rgba(29,26,20,0.05)',
+            boxShadow: state !== 'empty' ? `inset 0 0 0 1.5px ${t.accent}` : 'none',
+          }}>
+            <window.Icons.Search size={19} color={t.sub} />
+            {q
+              ? <span style={{ fontFamily: LIB_SANS, fontSize: 15.5, color: t.ink }}>{q}<span style={{ display: 'inline-block', width: 1.5, height: 18, background: t.accent, verticalAlign: -3, marginLeft: 1 }} /></span>
+              : <span style={{ fontFamily: LIB_SANS, fontSize: 15.5, color: t.sub }}>Search title, author, or text…</span>}
+            <span style={{ flex: 1 }} />
+            {q && <window.Icons.Close size={18} color={t.sub} />}
+          </div>
+          <span style={{ fontFamily: LIB_SANS, fontSize: 15, color: t.accent, fontWeight: 500 }}>Cancel</span>
+        </div>
+
+        <div style={{ flex: 1, overflow: 'hidden', padding: '0 18px' }}>
+          {state === 'empty' && (
+            <>
+              <div style={{ fontFamily: LIB_SANS, fontSize: 12, fontWeight: 600, letterSpacing: 0.5, textTransform: 'uppercase', color: t.sub, margin: '6px 2px 10px' }}>Recent</div>
+              {['pragmatic', 'austen', 'data-intensive'].map((r) => (
+                <div key={r} style={{ display: 'flex', alignItems: 'center', gap: 11, padding: '11px 2px', borderBottom: `0.5px solid ${t.rule}` }}>
+                  <window.Icons.Timer size={18} color={t.sub} />
+                  <span style={{ flex: 1, fontFamily: LIB_SANS, fontSize: 15, color: t.ink }}>{r}</span>
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke={t.sub} strokeWidth="2" strokeLinecap="round"><path d="M7 17L17 7M9 7h8v8"/></svg>
+                </div>
+              ))}
+              <div style={{ fontFamily: LIB_SANS, fontSize: 12, fontWeight: 600, letterSpacing: 0.5, textTransform: 'uppercase', color: t.sub, margin: '20px 2px 10px' }}>Browse collections</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                {COLLECTIONS.slice(1).map((c) => (
+                  <span key={c} style={{ fontFamily: LIB_SANS, fontSize: 13.5, fontWeight: 500, color: t.ink, background: t.isDark ? 'rgba(255,255,255,0.06)' : 'rgba(29,26,20,0.05)', borderRadius: 100, padding: '8px 14px' }}>{c}</span>
+                ))}
+              </div>
+            </>
+          )}
+
+          {state === 'results' && (
+            <>
+              <div style={{ fontFamily: LIB_SANS, fontSize: 12.5, color: t.sub, margin: '4px 2px 12px' }}>2 books · 1 in-text match</div>
+              {results.map((b, i) => (
+                <div key={i} style={{ display: 'flex', gap: 13, padding: '8px 0 16px', borderBottom: `0.5px solid ${t.rule}`, marginBottom: 12 }}>
+                  <Cover b={b} w={62} />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontFamily: LIB_SERIF, fontSize: 16, fontWeight: 600, color: t.ink, lineHeight: 1.25 }}>
+                      {hl(b.t, 'Pra', t)}
+                    </div>
+                    <div style={{ fontFamily: LIB_SANS, fontSize: 12.5, color: t.sub, marginTop: 3 }}>{b.a}</div>
+                    {i === 0 && (
+                      <div style={{ marginTop: 8, fontFamily: LIB_SERIF, fontSize: 13, color: t.sub, lineHeight: 1.45, fontStyle: 'italic' }}>
+                        "…the {hlPlain('pragmatic', t)} programmer is quick to adapt…" — Ch. 1
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </>
+          )}
+
+          {state === 'noresults' && (
+            <div style={{ textAlign: 'center', padding: '70px 30px' }}>
+              <div style={{ width: 60, height: 60, borderRadius: 30, background: t.isDark ? 'rgba(255,255,255,0.05)' : 'rgba(29,26,20,0.04)', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 18px' }}>
+                <window.Icons.Search size={28} color={t.sub} />
+              </div>
+              <div style={{ fontFamily: LIB_SERIF, fontSize: 19, color: t.ink, marginBottom: 8 }}>No matches for "{q}"</div>
+              <div style={{ fontFamily: LIB_SANS, fontSize: 14, color: t.sub, lineHeight: 1.5 }}>
+                Search looks across titles, authors, and the text of downloaded books. Try a different term.
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </window.TtsFrame>
+  );
+}
+
+// inline-highlight a query match in a title
+function hl(text, q, t) {
+  const i = text.toLowerCase().indexOf(q.toLowerCase());
+  if (i < 0) return text;
+  const wash = t.isDark ? 'rgba(214,136,90,0.3)' : 'rgba(140,47,47,0.16)';
+  return <>{text.slice(0, i)}<span style={{ background: wash, borderRadius: 2 }}>{text.slice(i, i + q.length)}</span>{text.slice(i + q.length)}</>;
+}
+function hlPlain(text, t) {
+  const wash = t.isDark ? 'rgba(214,136,90,0.3)' : 'rgba(140,47,47,0.16)';
+  return <span style={{ background: wash, borderRadius: 2, fontStyle: 'normal' }}>{text}</span>;
+}
+
+// ── B · collections management + assign ──────────────────────
+function CollectionsManageSheet({ ui, mode = 'list', height = 880 }) {
+  const cols = [
+    { name: 'Currently Reading', n: 2, sys: true },
+    { name: 'To Read', n: 8 },
+    { name: 'Fiction', n: 5 },
+    { name: 'Tech', n: 4 },
+    { name: 'Finished', n: 11, sys: true },
+  ];
+  return (
+    <PhoneFrame ui={ui} height={height}>
+      <div style={{ position: 'absolute', inset: 0, background: ui.bg }} />
+      <AppSheet ui={ui} title="Collections"
+        leading={<button style={{ background: 'none', border: 'none', padding: 0, fontFamily: LIB_SANS, fontSize: 15, color: ui.sec }}>Done</button>}
+        trailing={<span style={{ fontFamily: LIB_SANS, fontSize: 15, fontWeight: 600, color: ui.tint }}>Edit</span>}
+        height={height - 36}>
+        <div style={{ padding: '14px 16px 32px' }}>
+          <Card ui={ui}>
+            {cols.map((c, i) => (
+              <div key={c.name} style={{ display: 'flex', alignItems: 'center', minHeight: 52, padding: '0 14px', position: 'relative' }}>
+                {mode === 'edit' && <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={ui.ter} strokeWidth="2" strokeLinecap="round" style={{ marginRight: 12 }}><path d="M4 8h16M4 16h16"/></svg>}
+                <window.Icons.Folder size={19} color={ui.tint} />
+                <span style={{ flex: 1, fontFamily: LIB_SANS, fontSize: 15.5, color: ui.ink, marginLeft: 11 }}>{c.name}</span>
+                {mode === 'edit' && !c.sys
+                  ? <window.Icons.ChevronD size={18} color={ui.ter} style={{ transform: 'rotate(-90deg)' }} />
+                  : <span style={{ fontFamily: LIB_SANS, fontSize: 13.5, color: ui.ter, fontVariantNumeric: 'tabular-nums' }}>{c.n}</span>}
+                {i < cols.length - 1 && <div style={{ position: 'absolute', left: 44, right: 0, bottom: 0, height: 0.5, background: ui.sep }} />}
+              </div>
+            ))}
+          </Card>
+
+          <div style={{ height: 16 }} />
+          {mode === 'create' ? (
+            <Card ui={ui}>
+              <div style={{ display: 'flex', alignItems: 'center', minHeight: 52, padding: '0 14px', boxShadow: `inset 0 0 0 1.5px ${ui.tint}`, borderRadius: 14 }}>
+                <window.Icons.Folder size={19} color={ui.tint} />
+                <span style={{ flex: 1, fontFamily: LIB_SANS, fontSize: 15.5, color: ui.ink, marginLeft: 11 }}>Philosophy<span style={{ display: 'inline-block', width: 1.5, height: 17, background: ui.tint, verticalAlign: -3, marginLeft: 1 }} /></span>
+                <span style={{ fontFamily: LIB_SANS, fontSize: 14, fontWeight: 600, color: ui.tint }}>Add</span>
+              </div>
+            </Card>
+          ) : (
+            <button style={{
+              display: 'flex', alignItems: 'center', gap: 9, width: '100%', border: 'none', cursor: 'pointer',
+              background: ui.card, borderRadius: 14, padding: '15px 14px', boxShadow: ui.cardShadow,
+              fontFamily: LIB_SANS, fontSize: 15.5, fontWeight: 500, color: ui.tint,
+            }}>
+              <window.Icons.Plus size={20} color={ui.tint} /> New Collection
+            </button>
+          )}
+          <GroupFooter ui={ui}>"Currently Reading" and "Finished" update automatically from your reading progress and can't be deleted.</GroupFooter>
+        </div>
+      </AppSheet>
+    </PhoneFrame>
+  );
+}
+
+function AssignSheet({ ui, height = 880 }) {
+  const cols = [
+    { name: 'Currently Reading', on: true },
+    { name: 'To Read', on: false },
+    { name: 'Fiction', on: true },
+    { name: 'Tech', on: false },
+  ];
+  return (
+    <PhoneFrame ui={ui} height={height}>
+      <div style={{ position: 'absolute', inset: 0, background: ui.bg }} />
+      <div style={{ position: 'absolute', inset: 0, zIndex: 200, display: 'flex', flexDirection: 'column', justifyContent: 'flex-end', background: 'rgba(0,0,0,0.35)' }}>
+        <div style={{ background: ui.sheetBg, borderTopLeftRadius: 22, borderTopRightRadius: 22, padding: '8px 0 24px', boxShadow: '0 -8px 28px rgba(0,0,0,0.25)' }}>
+          <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 4, paddingBottom: 10 }}>
+            <div style={{ width: 36, height: 5, borderRadius: 3, background: ui.isDark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.12)' }} />
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '0 18px 14px' }}>
+            <Cover b={BOOKS[0]} w={44} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontFamily: LIB_SERIF, fontSize: 16, fontWeight: 600, color: ui.ink }}>Add to Collection</div>
+              <div style={{ fontFamily: LIB_SANS, fontSize: 12.5, color: ui.sec, marginTop: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>Pride and Prejudice</div>
+            </div>
+          </div>
+          <div style={{ padding: '0 16px' }}>
+            <Card ui={ui}>
+              {cols.map((c, i) => (
+                <div key={c.name} style={{ display: 'flex', alignItems: 'center', minHeight: 52, padding: '0 14px', position: 'relative' }}>
+                  <window.Icons.Folder size={19} color={ui.sec} />
+                  <span style={{ flex: 1, fontFamily: LIB_SANS, fontSize: 15.5, color: ui.ink, marginLeft: 11 }}>{c.name}</span>
+                  {c.on
+                    ? <svg width="22" height="22" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" fill={ui.tint}/><path d="M7.5 12.3l3 3 6-6.5" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none"/></svg>
+                    : <div style={{ width: 22, height: 22, borderRadius: 11, boxShadow: `inset 0 0 0 1.7px ${ui.sep}` }} />}
+                  {i < cols.length - 1 && <div style={{ position: 'absolute', left: 44, right: 0, bottom: 0, height: 0.5, background: ui.sep }} />}
+                </div>
+              ))}
+            </Card>
+            <button style={{ display: 'flex', alignItems: 'center', gap: 9, width: '100%', border: 'none', cursor: 'pointer', background: 'transparent', padding: '15px 4px 4px', fontFamily: LIB_SANS, fontSize: 15, fontWeight: 500, color: ui.tint }}>
+              <window.Icons.Plus size={19} color={ui.tint} /> New Collection…
+            </button>
+          </div>
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+Object.assign(window, {
+  BOOKS, COLLECTIONS, Cover, LibraryScreen, SearchScreen,
+  CollectionsManageSheet, AssignSheet,
+});

--- a/dev-docs/designs/vreader-fidelity-v1/project/vreader-stats-android.jsx
+++ b/dev-docs/designs/vreader-fidelity-v1/project/vreader-stats-android.jsx
@@ -1,0 +1,204 @@
+// Issue #1800 / Feature #110 (Android Phase-3) — reading-stats surfaces.
+//
+// iOS shows cumulative + per-session reading time (#101) and per-book stats;
+// the Android tracking layer is backend, but the display UI was design-gated
+// (rule 51). Built in VReader's vocabulary — reader THEMES for the in-reader
+// HUD, the shared form tokens for the dashboard. States: no-data, populated.
+//
+// Two surfaces:
+//   A. In-reader reading-time — a glassy session pill that auto-fades, and the
+//      reading-time detail card (session · total · time-left · pace) reached
+//      from the progress area.
+//   B. The stats dashboard — a time-window chip bar, an hour hero, a 14-day
+//      daily-reading column chart, and a sortable per-book table.
+
+const ST_SERIF = '"Source Serif 4", Georgia, serif';
+const ST_SANS = "'Inter', -apple-system, system-ui, sans-serif";
+
+const DAILY = [22, 34, 0, 41, 58, 30, 12, 47, 63, 38, 0, 25, 54, 72]; // minutes/day
+const PERBOOK = [
+  { t: 'Pride and Prejudice', time: '12h 18m', mins: 738, hl: 47, nt: 18 },
+  { t: 'The Beginning of Infinity', time: '9h 47m', mins: 587, hl: 22, nt: 11 },
+  { t: 'Designing Data-Intensive Apps', time: '7h 11m', mins: 431, hl: 31, nt: 4 },
+  { t: 'The Pragmatic Programmer', time: '4h 02m', mins: 242, hl: 9, nt: 2 },
+];
+
+// ── A · in-reader reading time ───────────────────────────────
+function InReaderTime({ themeKey = 'paper', variant = 'pill', height = 880 }) {
+  const t = window.THEMES[themeKey];
+  const glass = t.isDark ? 'rgba(28,26,23,0.82)' : 'rgba(252,248,240,0.88)';
+  return (
+    <window.TtsFrame t={t} height={height}>
+      <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column' }}>
+        <window.StatusStrip t={t} />
+        <window.ReaderChrome t={t} />
+        <div style={{ flex: 1, position: 'relative', padding: '6px 26px 0', overflow: 'hidden' }}>
+          <div style={{ fontFamily: ST_SERIF, fontSize: 18.5, lineHeight: 1.62, color: t.ink, textWrap: 'pretty' }}>
+            <p style={{ margin: '0 0 17px' }}>Elizabeth's astonishment was beyond expression. She stared, coloured, doubted, and was silent. This he considered sufficient encouragement.</p>
+            <p style={{ margin: '0 0 17px' }}>The avowal of all that he felt, and had long felt for her, immediately followed. He spoke well; but there were feelings besides those of the heart to be detailed.</p>
+            <p style={{ margin: 0, color: t.sub }}>He was not more eloquent on the subject of tenderness than of pride.</p>
+          </div>
+
+          {variant === 'pill' && (
+            <div style={{
+              position: 'absolute', top: 14, right: 18, display: 'inline-flex', alignItems: 'center', gap: 7,
+              background: glass, backdropFilter: 'blur(16px)', WebkitBackdropFilter: 'blur(16px)',
+              borderRadius: 100, padding: '7px 13px', boxShadow: '0 4px 16px rgba(0,0,0,0.14)',
+              border: `0.5px solid ${t.rule}`,
+            }}>
+              <window.Icons.Timer size={15} color={t.accent} />
+              <span style={{ fontFamily: ST_SANS, fontSize: 12.5, fontWeight: 600, color: t.ink, fontVariantNumeric: 'tabular-nums' }}>24:08</span>
+              <span style={{ fontFamily: ST_SANS, fontSize: 12, color: t.sub }}>this session</span>
+            </div>
+          )}
+        </div>
+
+        {/* progress footer — the time detail card sits above it */}
+        {variant === 'detail' && (
+          <div style={{
+            margin: '0 14px 14px', background: glass, backdropFilter: 'blur(20px)', WebkitBackdropFilter: 'blur(20px)',
+            borderRadius: 16, border: `0.5px solid ${t.rule}`, padding: '15px 17px', boxShadow: '0 8px 28px rgba(0,0,0,0.18)',
+          }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 13 }}>
+              <span style={{ fontFamily: ST_SERIF, fontStyle: 'italic', fontSize: 16, color: t.ink }}>Pride and Prejudice</span>
+              <span style={{ fontFamily: ST_SANS, fontSize: 12, color: t.sub }}>42% · Ch. 34</span>
+            </div>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '13px 10px' }}>
+              {[['This session', '24m'], ['Total in book', '12h 18m'], ['Left in chapter', '~6m'], ['Left in book', '~9h 40m']].map(([k, v]) => (
+                <div key={k}>
+                  <div style={{ fontFamily: ST_SANS, fontSize: 11.5, color: t.sub }}>{k}</div>
+                  <div style={{ fontFamily: ST_SERIF, fontSize: 20, fontWeight: 700, color: t.ink, marginTop: 1, fontVariantNumeric: 'tabular-nums' }}>{v}</div>
+                </div>
+              ))}
+            </div>
+            <div style={{ marginTop: 14, display: 'flex', alignItems: 'center', gap: 8, fontFamily: ST_SANS, fontSize: 11.5, color: t.sub }}>
+              <span style={{ width: 8, height: 8, borderRadius: 4, background: t.accent }} />
+              Reading pace 248 wpm · faster than your average
+            </div>
+          </div>
+        )}
+      </div>
+    </window.TtsFrame>
+  );
+}
+
+// ── B · stats dashboard ──────────────────────────────────────
+function TimeWindowBar({ ui, active = '30d' }) {
+  const w = ['Today', '7d', '30d', '90d', 'Year', 'All'];
+  return (
+    <div className="hide-scroll" style={{ display: 'flex', gap: 7, overflowX: 'auto', padding: '2px 0 2px' }}>
+      {w.map((k) => {
+        const on = k === active;
+        return (
+          <span key={k} style={{
+            flexShrink: 0, fontFamily: ST_SANS, fontSize: 13, fontWeight: on ? 700 : 500,
+            color: on ? ui.bg : ui.ink, background: on ? ui.ink : (ui.isDark ? 'rgba(255,255,255,0.06)' : 'rgba(29,26,20,0.05)'),
+            borderRadius: 100, padding: '7px 14px',
+          }}>{k}</span>
+        );
+      })}
+    </div>
+  );
+}
+
+function DailyChart({ ui, empty }) {
+  const max = Math.max(...DAILY);
+  return (
+    <Card ui={ui} style={{ padding: '14px 15px 12px', marginTop: 12 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 12 }}>
+        <span style={{ fontFamily: ST_SANS, fontSize: 13, fontWeight: 600, color: ui.ink }}>Daily reading</span>
+        <span style={{ fontFamily: ST_SANS, fontSize: 11.5, color: ui.sec }}>last 14 days</span>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'flex-end', gap: 5, height: 88 }}>
+        {DAILY.map((m, i) => (
+          <div key={i} style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'flex-end', height: '100%' }}>
+            <div style={{
+              height: empty ? 2 : `${Math.max(4, (m / max) * 100)}%`,
+              background: empty ? ui.sep : (i === DAILY.length - 1 ? ui.tint : (ui.isDark ? 'rgba(214,136,90,0.45)' : 'rgba(140,47,47,0.32)')),
+              borderRadius: 3,
+            }} />
+          </div>
+        ))}
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 8, fontFamily: ST_SANS, fontSize: 10.5, color: ui.ter }}>
+        <span>2 wks ago</span><span>Today</span>
+      </div>
+    </Card>
+  );
+}
+
+function PerBookTable({ ui, empty }) {
+  const Th = ({ children, active, right }) => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 3, justifyContent: right ? 'flex-end' : 'flex-start', color: active ? ui.tint : ui.sec, fontFamily: ST_SANS, fontSize: 11.5, fontWeight: 600 }}>
+      {children}{active && <svg width="9" height="9" viewBox="0 0 12 12" fill="none" stroke={ui.tint} strokeWidth="2" strokeLinecap="round"><path d="M3 5l3 3 3-3"/></svg>}
+    </div>
+  );
+  return (
+    <Card ui={ui} style={{ padding: '13px 15px 6px', marginTop: 12 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 70px 34px 34px', gap: 8, paddingBottom: 9, borderBottom: `0.5px solid ${ui.sep}` }}>
+        <Th>Book</Th><Th right active>Time</Th><Th right>Hl</Th><Th right>Nt</Th>
+      </div>
+      {(empty ? [] : PERBOOK).map((b, i) => {
+        const maxM = PERBOOK[0].mins;
+        return (
+          <div key={i} style={{ padding: '11px 0 10px', borderBottom: i < PERBOOK.length - 1 ? `0.5px solid ${ui.sep}` : 'none' }}>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 70px 34px 34px', gap: 8, alignItems: 'center' }}>
+              <div style={{ fontFamily: ST_SERIF, fontSize: 14, color: ui.ink, lineHeight: 1.2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{b.t}</div>
+              <div style={{ textAlign: 'right', fontFamily: ST_SANS, fontSize: 13, fontWeight: 600, color: ui.ink, fontVariantNumeric: 'tabular-nums' }}>{b.time}</div>
+              <div style={{ textAlign: 'right', fontFamily: ST_SANS, fontSize: 13, color: ui.sec, fontVariantNumeric: 'tabular-nums' }}>{b.hl}</div>
+              <div style={{ textAlign: 'right', fontFamily: ST_SANS, fontSize: 13, color: ui.sec, fontVariantNumeric: 'tabular-nums' }}>{b.nt}</div>
+            </div>
+            <div style={{ height: 3, borderRadius: 2, background: ui.isDark ? 'rgba(255,255,255,0.07)' : 'rgba(29,26,20,0.06)', marginTop: 8 }}>
+              <div style={{ height: '100%', width: `${(b.mins / maxM) * 100}%`, background: ui.tint, borderRadius: 2, opacity: 0.7 }} />
+            </div>
+          </div>
+        );
+      })}
+      {empty && <div style={{ padding: '24px 0', textAlign: 'center', fontFamily: ST_SANS, fontSize: 13.5, color: ui.ter }}>No books opened yet</div>}
+    </Card>
+  );
+}
+
+function StatsDashboard({ ui, state = 'populated', height = 880 }) {
+  const empty = state === 'nodata';
+  return (
+    <PhoneFrame ui={ui} height={height}>
+      <div style={{ position: 'absolute', inset: 0, background: ui.bg }} />
+      <AppSheet ui={ui} title="Reading Stats"
+        leading={<button style={{ background: 'none', border: 'none', padding: 0, fontFamily: ST_SANS, fontSize: 15, color: ui.sec }}>Close</button>}
+        trailing={<window.Icons.Share size={20} color={ui.tint} />}
+        height={height - 36}>
+        <div style={{ padding: '14px 16px 32px' }}>
+          <TimeWindowBar ui={ui} active="30d" />
+
+          {/* hero */}
+          <Card ui={ui} style={{ padding: '18px 17px', marginTop: 12 }}>
+            <div style={{ fontFamily: ST_SANS, fontSize: 12, fontWeight: 600, letterSpacing: 0.4, textTransform: 'uppercase', color: ui.sec }}>This month</div>
+            <div style={{ fontFamily: ST_SERIF, fontSize: 44, fontWeight: 700, color: ui.ink, lineHeight: 1, margin: '6px 0 2px', fontVariantNumeric: 'tabular-nums' }}>
+              {empty ? '0m' : '41h 12m'}
+            </div>
+            {empty ? (
+              <div style={{ fontFamily: ST_SANS, fontSize: 13.5, color: ui.sec, marginTop: 6, lineHeight: 1.5 }}>Open a book to start tracking. Your reading time, streak, and per-book breakdown will show up here.</div>
+            ) : (
+              <div style={{ display: 'flex', gap: 18, marginTop: 14 }}>
+                {[['Streak', '9 days'], ['Daily avg', '1h 22m'], ['Finished', '3 books']].map(([k, v]) => (
+                  <div key={k}>
+                    <div style={{ fontFamily: ST_SERIF, fontSize: 18, fontWeight: 700, color: ui.ink, fontVariantNumeric: 'tabular-nums' }}>{v}</div>
+                    <div style={{ fontFamily: ST_SANS, fontSize: 11, color: ui.sec, marginTop: 1 }}>{k}</div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </Card>
+
+          <DailyChart ui={ui} empty={empty} />
+
+          <div style={{ fontFamily: ST_SANS, fontSize: 12, fontWeight: 600, letterSpacing: 0.5, textTransform: 'uppercase', color: ui.sec, margin: '20px 2px 0' }}>By book</div>
+          <PerBookTable ui={ui} empty={empty} />
+        </div>
+      </AppSheet>
+    </PhoneFrame>
+  );
+}
+
+Object.assign(window, { InReaderTime, StatsDashboard, TimeWindowBar, DailyChart, PerBookTable });

--- a/dev-docs/designs/vreader-fidelity-v1/project/vreader-tts.jsx
+++ b/dev-docs/designs/vreader-fidelity-v1/project/vreader-tts.jsx
@@ -1,0 +1,399 @@
+// Issue #1797 / Feature #110 (Android Phase-3) — TTS read-aloud control bar.
+//
+// iOS read-aloud (#26/#72) is backed by AVSpeechSynthesizer; Android has
+// android.speech.tts.TextToSpeech (no credentials, on-device engines) but no
+// committed control-bar UI, so per rule 51 it had to be designed. Rendered in
+// VReader's own reader vocabulary (the paper/dark THEMES, Source-Serif body,
+// #8c2f2f / #d6885a accent) so read-aloud reads as the same product.
+//
+// Decision: a glassy transport bar docked at the foot of the reader (not a
+// system media-notification surrogate). The bar owns play/pause, sentence
+// prev/next, speed, and the voice/engine chip; the reader behind it shows the
+// spoken sentence highlighted with an accent wash + an auto-scroll keepline.
+// Engine/voice selection is the genuinely-Android part: on-device engines
+// (Google, Samsung), per-language voices, and "voice data not installed →
+// Download" — none of which iOS's AVSpeech surface has.
+
+const TTS_SERIF = '"Source Serif 4", Georgia, serif';
+const TTS_SANS = "'Inter', -apple-system, system-ui, sans-serif";
+
+// Chapter prose, split into sentences so one can be the spoken chunk.
+const TTS_PARAS = [
+  [
+    'It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife.',
+    'However little known the feelings or views of such a man may be on his first entering a neighbourhood, this truth is so well fixed in the minds of the surrounding families, that he is considered the rightful property of some one or other of their daughters.',
+  ],
+  [
+    '"My dear Mr. Bennet," said his lady to him one day, "have you heard that Netherfield Park is let at last?"',
+    'Mr. Bennet replied that he had not.',
+    '"But it is," returned she; "for Mrs. Long has just been here, and she told me all about it."',
+  ],
+  [
+    'Mr. Bennet made no answer.',
+    '"Do you not want to know who has taken it?" cried his wife impatiently.',
+    '"You want to tell me, and I have no objection to hearing it."',
+  ],
+];
+
+function ttsTheme(key) { return window.THEMES[key]; }
+
+// ── device frame in the reader's theme ───────────────────────
+function TtsFrame({ t, height = 880, children }) {
+  return (
+    <div style={{
+      width: 402, height, position: 'relative', overflow: 'hidden',
+      background: t.bg, borderRadius: 18,
+      boxShadow: '0 0 0 1px rgba(255,255,255,0.04), 0 14px 40px rgba(0,0,0,0.35)',
+      fontFamily: TTS_SANS, WebkitFontSmoothing: 'antialiased',
+    }}>{children}</div>
+  );
+}
+
+// Android status strip — minimal, themed.
+function StatusStrip({ t }) {
+  return (
+    <div style={{
+      height: 32, display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+      padding: '0 20px', color: t.ink, fontSize: 12.5, fontWeight: 600, opacity: 0.7, flexShrink: 0,
+    }}>
+      <span style={{ fontVariantNumeric: 'tabular-nums' }}>9:41</span>
+      <span style={{ display: 'flex', gap: 5, alignItems: 'center' }}>
+        <svg width="16" height="11" viewBox="0 0 16 11" fill="none"><path d="M1 9a14 14 0 0114 0M3.3 6.5a10 10 0 019.4 0M5.6 4a6 6 0 014.8 0" stroke={t.ink} strokeWidth="1.3" strokeLinecap="round"/><circle cx="8" cy="9.5" r="1" fill={t.ink}/></svg>
+        <svg width="22" height="11" viewBox="0 0 22 11" fill="none"><rect x="0.6" y="0.6" width="18" height="9.8" rx="2.2" stroke={t.ink} strokeWidth="1.1" opacity="0.5"/><rect x="2" y="2" width="13" height="7" rx="1" fill={t.ink}/><rect x="20" y="3.5" width="1.6" height="4" rx="0.8" fill={t.ink} opacity="0.5"/></svg>
+      </span>
+    </div>
+  );
+}
+
+// Reader chrome — back chevron + chapter title (the reader's own top bar).
+function ReaderChrome({ t }) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 10, padding: '4px 16px 10px', flexShrink: 0,
+    }}>
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={t.ink} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: 0.8 }}><path d="M15 6l-6 6 6 6"/></svg>
+      <div style={{ flex: 1, fontFamily: TTS_SERIF, fontStyle: 'italic', fontSize: 15, color: t.ink, opacity: 0.78, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+        Pride and Prejudice
+      </div>
+      <div style={{ fontSize: 12.5, color: t.sub, fontVariantNumeric: 'tabular-nums' }}>Ch. 1</div>
+    </div>
+  );
+}
+
+// The reading surface. `spoken` = {p, s} index of the currently-spoken
+// sentence; sentences before it are dimmed (already read), the spoken one
+// carries the accent wash + a left keyline, the rest are upcoming.
+function ReaderProse({ t, spoken, active = true, dimAll = false }) {
+  const accentWash = t.isDark ? 'rgba(214,136,90,0.20)' : 'rgba(140,47,47,0.13)';
+  let idx = 0;
+  return (
+    <div style={{ flex: 1, overflow: 'hidden', position: 'relative', padding: '4px 26px 0' }}>
+      <div style={{
+        fontFamily: TTS_SERIF, fontSize: 18.5, lineHeight: 1.62, color: t.ink,
+        textWrap: 'pretty',
+      }}>
+        {TTS_PARAS.map((para, pi) => (
+          <p key={pi} style={{ margin: '0 0 17px' }}>
+            {para.map((sent, si) => {
+              const isSpoken = spoken && spoken.p === pi && spoken.s === si;
+              const before = spoken && (pi < spoken.p || (pi === spoken.p && si < spoken.s));
+              idx += 1;
+              return (
+                <span key={si} style={{
+                  background: isSpoken ? accentWash : 'transparent',
+                  boxShadow: isSpoken ? `inset 2px 0 0 ${t.accent}` : 'none',
+                  color: dimAll ? t.sub : (before ? t.sub : t.ink),
+                  opacity: dimAll ? 0.6 : 1,
+                  borderRadius: 2, padding: isSpoken ? '1px 3px' : 0,
+                  margin: isSpoken ? '0 -3px' : 0,
+                  transition: 'background .2s',
+                }}>{sent}{' '}</span>
+              );
+            })}
+          </p>
+        ))}
+      </div>
+      {/* auto-scroll keepline indicator — only while actively speaking */}
+      {active && spoken && (
+        <div style={{ position: 'absolute', right: 8, top: '34%', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3, color: t.accent, opacity: 0.55 }}>
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={t.accent} strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round"><path d="M6 9l6 6 6-6"/></svg>
+        </div>
+      )}
+      {/* fade the prose into the control bar */}
+      <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, height: 70, background: `linear-gradient(to bottom, transparent, ${t.bg})`, pointerEvents: 'none' }} />
+    </div>
+  );
+}
+
+function RoundBtn({ t, children, size = 40, faded }) {
+  return (
+    <div style={{
+      width: size, height: size, borderRadius: size / 2, display: 'flex', alignItems: 'center', justifyContent: 'center',
+      color: t.ink, opacity: faded ? 0.4 : 0.92,
+    }}>{children}</div>
+  );
+}
+
+// Transport glyphs not in the shared Icons set.
+function PrevGlyph({ c }) { return <svg width="26" height="26" viewBox="0 0 24 24" fill={c}><path d="M7 5v14h2.2V5zM20 5l-9 7 9 7z"/></svg>; }
+function NextGlyph({ c }) { return <svg width="26" height="26" viewBox="0 0 24 24" fill={c}><path d="M17 5v14h-2.2V5zM4 5l9 7-9 7z"/></svg>; }
+
+// ════════════════════════════════════════════════════════════
+// TtsBar — the docked read-aloud transport.
+//   state: 'idle' | 'speaking' | 'paused' | 'error'
+// ════════════════════════════════════════════════════════════
+function TtsBar({ t, state = 'speaking', speed = '1.0×', voice = 'Google · English (US)', progress = 0.32 }) {
+  const glass = t.isDark ? 'rgba(28,26,23,0.86)' : 'rgba(252,248,240,0.9)';
+  const playing = state === 'speaking';
+  const err = state === 'error';
+
+  const Chip = ({ icon, label, strong }) => (
+    <div style={{
+      display: 'inline-flex', alignItems: 'center', gap: 6, padding: '7px 11px', borderRadius: 100,
+      background: t.isDark ? 'rgba(255,255,255,0.07)' : 'rgba(29,26,20,0.05)',
+      fontFamily: TTS_SANS, fontSize: 13, fontWeight: strong ? 700 : 500, color: t.ink,
+      whiteSpace: 'nowrap',
+    }}>{icon}{label}
+      <svg width="11" height="11" viewBox="0 0 12 12" fill="none" stroke={t.sub} strokeWidth="1.8" strokeLinecap="round"><path d="M2 4l4 4 4-4"/></svg>
+    </div>
+  );
+
+  return (
+    <div style={{
+      position: 'absolute', left: 0, right: 0, bottom: 0,
+      background: glass, backdropFilter: 'blur(20px)', WebkitBackdropFilter: 'blur(20px)',
+      borderTop: `0.5px solid ${t.rule}`, padding: '0 0 12px', flexShrink: 0,
+    }}>
+      {/* chunk progress line */}
+      <div style={{ height: 3, background: t.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(29,26,20,0.08)', position: 'relative' }}>
+        {!err && <div style={{ position: 'absolute', left: 0, top: 0, bottom: 0, width: `${progress * 100}%`, background: t.accent }} />}
+      </div>
+
+      {err ? (
+        <div style={{ padding: '16px 18px 6px' }}>
+          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 11 }}>
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={t.accent} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, marginTop: 1 }}><path d="M12 3l9 16H3z"/><path d="M12 10v4M12 17v.01"/></svg>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontFamily: TTS_SANS, fontSize: 14.5, fontWeight: 600, color: t.ink }}>No voice for English (US)</div>
+              <div style={{ fontFamily: TTS_SANS, fontSize: 13, color: t.sub, lineHeight: 1.45, marginTop: 2 }}>
+                Google Speech Services has no voice data installed for this language.
+              </div>
+            </div>
+          </div>
+          <div style={{ display: 'flex', gap: 9, marginTop: 13 }}>
+            <button style={{
+              flex: 1, border: 'none', borderRadius: 11, padding: '11px 0', cursor: 'pointer',
+              background: t.accent, color: '#fff', fontFamily: TTS_SANS, fontSize: 14, fontWeight: 600,
+            }}>Install voice data</button>
+            <button style={{
+              border: `1px solid ${t.rule}`, borderRadius: 11, padding: '11px 16px', cursor: 'pointer',
+              background: 'transparent', color: t.ink, fontFamily: TTS_SANS, fontSize: 14, fontWeight: 500,
+            }}>System TTS</button>
+          </div>
+        </div>
+      ) : (
+        <>
+          {/* status row */}
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '11px 18px 3px' }}>
+            <span style={{ fontFamily: TTS_SANS, fontSize: 12.5, fontWeight: 600, letterSpacing: 0.3, color: playing ? t.accent : t.sub, textTransform: 'uppercase' }}>
+              {state === 'idle' ? 'Ready to read aloud' : playing ? 'Reading aloud' : 'Paused'}
+            </span>
+            <span style={{ fontFamily: TTS_SANS, fontSize: 12.5, color: t.sub, fontVariantNumeric: 'tabular-nums' }}>
+              {state === 'idle' ? 'Chapter 1 · ~14 min' : '2:14 · ~9 min left'}
+            </span>
+          </div>
+
+          {/* transport row */}
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '4px 18px 0' }}>
+            <div onClick={() => {}} style={{ cursor: 'pointer' }}><Chip label={speed} strong /></div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <RoundBtn t={t}><PrevGlyph c={t.ink}/></RoundBtn>
+              <div style={{
+                width: 60, height: 60, borderRadius: 30, background: t.accent, display: 'flex', alignItems: 'center', justifyContent: 'center',
+                boxShadow: `0 4px 16px ${t.isDark ? 'rgba(0,0,0,0.4)' : 'rgba(140,47,47,0.3)'}`,
+              }}>
+                {playing
+                  ? <svg width="26" height="26" viewBox="0 0 24 24" fill="#fff"><rect x="6" y="5" width="4.4" height="14" rx="1.2"/><rect x="13.6" y="5" width="4.4" height="14" rx="1.2"/></svg>
+                  : <svg width="28" height="28" viewBox="0 0 24 24" fill="#fff"><path d="M7 4.5l13 7.5-13 7.5z"/></svg>}
+              </div>
+              <RoundBtn t={t}><NextGlyph c={t.ink}/></RoundBtn>
+            </div>
+            <div style={{ width: 56, display: 'flex', justifyContent: 'flex-end' }}>
+              <div style={{
+                width: 40, height: 40, borderRadius: 20, display: 'flex', alignItems: 'center', justifyContent: 'center',
+                color: t.ink, opacity: 0.85,
+              }}>
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={t.ink} strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><path d="M6 6l12 12M18 6L6 18"/></svg>
+              </div>
+            </div>
+          </div>
+
+          {/* voice/engine row */}
+          <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 10 }}>
+            <div style={{ cursor: 'pointer' }}>
+              <Chip icon={<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={t.ink} strokeWidth="1.7"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3c2.5 2.5 2.5 15 0 18M12 3c-2.5 2.5-2.5 15 0 18"/></svg>} label={voice} />
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// Full reader screen + bar in one of the bar states.
+function TtsScreen({ themeKey = 'paper', state = 'speaking', height = 880 }) {
+  const t = ttsTheme(themeKey);
+  const spoken = state === 'idle' ? { p: 0, s: 0 } : { p: 1, s: 0 };
+  return (
+    <TtsFrame t={t} height={height}>
+      <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column' }}>
+        <StatusStrip t={t} />
+        <ReaderChrome t={t} />
+        <ReaderProse t={t} spoken={state === 'error' ? null : spoken} active={state === 'speaking'} dimAll={state === 'error'} />
+        <TtsBar t={t} state={state} />
+      </div>
+    </TtsFrame>
+  );
+}
+
+// ── voice / engine selection sheet ───────────────────────────
+function VoiceRow({ ui, name, sub, selected, action }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', minHeight: 56, padding: '0 16px', position: 'relative' }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontFamily: TTS_SANS, fontSize: 15.5, fontWeight: 500, color: ui.ink }}>{name}</div>
+        {sub && <div style={{ fontFamily: TTS_SANS, fontSize: 12.5, color: ui.sec, marginTop: 1 }}>{sub}</div>}
+      </div>
+      {action === 'download' && (
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontFamily: TTS_SANS, fontSize: 13.5, fontWeight: 600, color: ui.tint }}>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke={ui.tint} strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round"><path d="M12 3v13M7 11l5 5 5-5M5 20h14"/></svg>
+          1.4 MB
+        </span>
+      )}
+      {action === 'downloading' && (
+        <span style={{ fontFamily: TTS_SANS, fontSize: 13, color: ui.sec, fontVariantNumeric: 'tabular-nums' }}>62%</span>
+      )}
+      {selected && (
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke={ui.tint} strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12l5 5L20 7"/></svg>
+      )}
+      <div style={{ position: 'absolute', left: 16, right: 0, bottom: 0, height: 0.5, background: ui.sep }} />
+    </div>
+  );
+}
+
+function VoiceSheet({ ui, height = 880 }) {
+  return (
+    <PhoneFrame ui={ui} height={height}>
+      <div style={{ position: 'absolute', inset: 0, background: ui.bg }} />
+      <AppSheet ui={ui} title="Voice"
+        leading={<button style={{ background: 'none', border: 'none', padding: 0, fontFamily: TTS_SANS, fontSize: 15, color: ui.sec }}>Cancel</button>}
+        trailing={<button style={{ background: 'none', border: 'none', padding: 0, fontFamily: TTS_SANS, fontSize: 15, fontWeight: 600, color: ui.tint }}>Done</button>}
+        height={height - 36}>
+        <div style={{ padding: '14px 16px 32px' }}>
+          <GroupHeader ui={ui}>Engine</GroupHeader>
+          <Card ui={ui}>
+            <VoiceRow ui={ui} name="Google Speech Services" sub="On-device · default" selected />
+            <VoiceRow ui={ui} name="Samsung text-to-speech" sub="On-device" />
+          </Card>
+          <GroupFooter ui={ui}>Engines are provided by Android. Add more from <span style={{ color: ui.ink }}>System settings → Text-to-speech</span>.</GroupFooter>
+
+          <div style={{ height: 18 }} />
+          <GroupHeader ui={ui}>English (US) voices</GroupHeader>
+          <Card ui={ui}>
+            <VoiceRow ui={ui} name="English (US) · Voice 1" sub="Female · network-free" selected />
+            <VoiceRow ui={ui} name="English (US) · Voice 4" sub="Male · network-free" />
+            <VoiceRow ui={ui} name="English (UK) · Voice 2" sub="Not installed" action="download" />
+            <VoiceRow ui={ui} name="Français · Voix 3" sub="Installing…" action="downloading" />
+          </Card>
+          <GroupFooter ui={ui}>VReader follows the book's language when a matching voice is installed. Otherwise it uses the engine default.</GroupFooter>
+        </div>
+      </AppSheet>
+    </PhoneFrame>
+  );
+}
+
+// ── speed control sheet ──────────────────────────────────────
+function SpeedSheet({ ui, height = 880 }) {
+  const speeds = ['0.5×', '0.75×', '1.0×', '1.25×', '1.5×', '1.75×', '2.0×'];
+  const sel = '1.0×';
+  return (
+    <PhoneFrame ui={ui} height={height}>
+      <div style={{ position: 'absolute', inset: 0, background: ui.bg }} />
+      <div style={{ position: 'absolute', inset: 0, zIndex: 200, display: 'flex', flexDirection: 'column', justifyContent: 'flex-end', background: 'rgba(0,0,0,0.35)' }}>
+        <div style={{ background: ui.sheetBg, borderTopLeftRadius: 22, borderTopRightRadius: 22, padding: '8px 0 26px', boxShadow: '0 -8px 28px rgba(0,0,0,0.25)' }}>
+          <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 4, paddingBottom: 8 }}>
+            <div style={{ width: 36, height: 5, borderRadius: 3, background: ui.isDark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.12)' }} />
+          </div>
+          <div style={{ fontFamily: TTS_SERIF, fontSize: 17, fontWeight: 600, color: ui.ink, textAlign: 'center', paddingBottom: 6 }}>Speaking rate</div>
+          <div style={{ textAlign: 'center', fontFamily: TTS_SERIF, fontSize: 40, fontWeight: 700, color: ui.tint, padding: '6px 0 14px' }}>1.0×</div>
+          {/* slider */}
+          <div style={{ padding: '0 26px' }}>
+            <div style={{ height: 5, borderRadius: 3, background: ui.isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.1)', position: 'relative' }}>
+              <div style={{ position: 'absolute', left: 0, top: 0, bottom: 0, width: '40%', background: ui.tint, borderRadius: 3 }} />
+              <div style={{ position: 'absolute', left: '40%', top: '50%', width: 24, height: 24, borderRadius: 12, background: '#fff', transform: 'translate(-50%,-50%)', boxShadow: '0 1px 5px rgba(0,0,0,0.22)' }} />
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 10, fontFamily: TTS_SANS, fontSize: 11.5, color: ui.sec }}>
+              <span>Slower</span><span>Faster</span>
+            </div>
+          </div>
+          {/* preset pills */}
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, padding: '20px 22px 0', justifyContent: 'center' }}>
+            {speeds.map((s) => {
+              const on = s === sel;
+              return (
+                <span key={s} style={{
+                  fontFamily: TTS_SANS, fontSize: 13.5, fontWeight: on ? 700 : 500,
+                  color: on ? '#fff' : ui.ink,
+                  background: on ? ui.tint : (ui.isDark ? 'rgba(255,255,255,0.06)' : 'rgba(29,26,20,0.05)'),
+                  borderRadius: 100, padding: '8px 14px',
+                }}>{s}</span>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+// ── entry affordance: the reader toolbar with read-aloud ─────
+function TtsEntry({ themeKey = 'paper', height = 880 }) {
+  const t = ttsTheme(themeKey);
+  const toolbar = ['TOC', 'Volume', 'Aa', 'Sparkle'];
+  return (
+    <TtsFrame t={t} height={height}>
+      <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column' }}>
+        <StatusStrip t={t} />
+        <ReaderChrome t={t} />
+        <ReaderProse t={t} spoken={null} active={false} />
+        {/* reader bottom toolbar with read-aloud (Volume) highlighted */}
+        <div style={{
+          display: 'flex', justifyContent: 'space-around', alignItems: 'center',
+          padding: '12px 18px 16px', borderTop: `0.5px solid ${t.rule}`,
+          background: t.chrome, flexShrink: 0,
+        }}>
+          {toolbar.map((k) => {
+            const I = window.Icons[k];
+            const on = k === 'Volume';
+            return (
+              <div key={k} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3 }}>
+                <div style={{
+                  width: 44, height: 44, borderRadius: 14, display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  background: on ? (t.isDark ? 'rgba(214,136,90,0.18)' : 'rgba(140,47,47,0.1)') : 'transparent',
+                }}>
+                  <I size={23} color={on ? t.accent : t.ink} stroke={1.7} />
+                </div>
+                {on && <span style={{ fontFamily: TTS_SANS, fontSize: 10.5, fontWeight: 600, color: t.accent }}>Read aloud</span>}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </TtsFrame>
+  );
+}
+
+Object.assign(window, {
+  TtsFrame, StatusStrip, ReaderChrome, ReaderProse, TtsBar, TtsScreen,
+  VoiceSheet, SpeedSheet, TtsEntry,
+});


### PR DESCRIPTION
## Summary

Imports the committed claude.ai/design component specs (via DesignSync) for the four remaining design-gated #110 Android Phase-3 capabilities, landing them under `dev-docs/designs/vreader-fidelity-v1/project/` so each surface is "designed" per rule 51:

- `vreader-tts.jsx` — TTS read-aloud control bar (#1797)
- `vreader-stats-android.jsx` — reading-stats in-reader pill/card + dashboard (#1800)
- `vreader-android-annotations.jsx` — selection popover + annotations review list (#1801)
- `vreader-library-android.jsx` — collections shelf-bar + management + search (#1802)

The batch-2 design note (`design-notes/android-phase3-batch2-issues.md`) documenting all four decisions was already committed. This lands the depictions, closing the four needs-design gates so the capabilities can be implemented.

Pure design-bundle import — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)