### PR TITLE
feat(#121 WI-2): AndroidTtsEngine — TextToSpeech wrapper

### DIFF
--- a/.claude/codex-audits/feat-feature-121-wi-2-android-tts-engine-audit.md
+++ b/.claude/codex-audits/feat-feature-121-wi-2-android-tts-engine-audit.md
@@ -1,0 +1,50 @@
+---
+branch: feat/feature-121-wi-2-android-tts-engine
+threadId: 019f0405-f121wi2
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-06-26
+---
+
+# Feature #121 WI-2 — Codex audit (AndroidTtsEngine TextToSpeech wrapper)
+
+Files: `tts/AndroidTtsEngine.kt` (+ `AndroidTtsEngineFactory`), `tts/TtsVoiceFilter.kt` (new pure
+helper), `AndroidManifest.xml` (`<queries>` TTS_SERVICE), `tts/AndroidTtsEngineTest.kt` (instrumented,
+3), `tts/TtsVoiceFilterTest.kt` (JVM, 6).
+
+## Round 1 — 3 High, 4 Medium, 2 Low (all fixed)
+
+| severity | issue | resolution |
+|---|---|---|
+| High | init could resurrect a cancelled/shut-down engine (callback published after cancel) | FIXED — `synchronized(lifecycle)` + `closed` flag; the init callback publishes only when `!closed` |
+| High | double init leaked (second `awaitInit` constructed a second TextToSpeech) | FIXED — single-flight (round 2 hardened to a CompletableDeferred) |
+| High | `voices()` could drop EVERY voice (`all.size<=1` heuristic) | FIXED — extracted pure `TtsVoiceFilter`: deprioritize very-low but never drop all; JVM-tested |
+| Medium | re-entrant init (`var engine` self-ref) could publish null | FIXED (round 2 — earlyStatus defer) |
+| Medium | `tryEmit` silently lossy | FIXED (round 2/3 — type-aware split) |
+| Medium | `emitFailed` fabricated generation 0 on a malformed id | FIXED — drops unparseable ids |
+| Medium | smoke tests too shallow | FIXED — added double-init + shutdown-then-speak instrumented + the JVM voice-filter suite |
+| Low×2 | `setVoice(null)` no-op contract unclear | FIXED — documented as "leave current/default" |
+
+## Round 2 — 3 High (all fixed)
+
+| severity | issue | resolution |
+|---|---|---|
+| High | concurrent `awaitInit()` could construct two engines | FIXED — single-flight `CompletableDeferred` under `lifecycle`; first caller constructs, others join |
+| High | re-entrant init (`OnInitListener` before `holder[0]` assigned) could orphan the engine | FIXED — `constructEngine` stashes `earlyStatus` and processes it after assignment via `finishInit` (idempotent complete) |
+| High | `DROP_OLDEST` could evict a terminal event | FIXED — split `_terminal` (1024) + `_range` (64, DROP_OLDEST), merged; a range burst can't evict a terminal |
+
+## Round 3 — 1 High (resolved by documented consumer contract)
+
+| severity | issue | resolution |
+|---|---|---|
+| High | `merge(_terminal,_range)` doesn't guarantee cross-flow ordering (a Range could land before Started / after Done) | RESOLVED-BY-CONTRACT — the engine documents, and the VM (WI-3) enforces, that Range is gated by the CURRENT sentence: applied only while `currentSentence.index == range.index` (the Started→Done window), so an out-of-order/stale Range is ignored. Range is highlight-refinement only; sentence advance is Started-keyed, so reordering/loss is harmless. WI-3 implements + tests the gate (`range-before-started ignored`, `range-after-done ignored`, `range-for-stale-index ignored`). This is the correct layer for the contract (mirrors the iOS TTSHighlightCoordinator). |
+
+Round 3 confirmed the three round-2 lifecycle fixes resolved (single-flight init, no re-entrant orphan,
+shutdown completes the deferred outside the lock), no deadlock, no cancelled-await leak beyond the
+VM-owned engine that `shutdown()` tears down.
+
+## Summary
+
+3 High + 4 Medium + 2 Low across 3 rounds; all fixed or resolved-by-contract. 6 JVM + 3 instrumented
+tests green on emulator-5554. The one round-3 finding is a consumer contract the VM owns (WI-3), not an
+engine bug. **Verdict: ship-as-is.**

--- a/android/app/src/androidTest/kotlin/com/vreader/app/tts/AndroidTtsEngineTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/tts/AndroidTtsEngineTest.kt
@@ -1,0 +1,71 @@
+package com.vreader.app.tts
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Locale
+
+/**
+ * Feature #121 WI-2 — AndroidTtsEngine instrumented smoke: drives the REAL TextToSpeech on the
+ * emulator. Audible output is NOT asserted (unobservable headless, like iOS TTS verification); this
+ * proves init bridges to a result, enumeration is callable, and language availability maps to a
+ * domain value — whether or not the emulator ships voice data.
+ */
+@RunWith(AndroidJUnit4::class)
+class AndroidTtsEngineTest {
+
+    private val ctx get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test fun init_returnsAResult_andEnumerationIsCallable() = runBlocking<Unit> {
+        val engine = AndroidTtsEngine(ctx.applicationContext)
+        try {
+            // init must RESOLVE (ok or failed) within a bounded time — never hang.
+            val result = withTimeout(15_000) { engine.awaitInit() }
+            assertNotNull(result)
+
+            if (result == TtsInitResult.ok) {
+                // enumeration + language check are callable without throwing
+                val engines = engine.engines()
+                val voices = engine.voices(Locale.US)
+                val avail = engine.isLanguageAvailable(Locale.US)
+                assertNotNull(avail)
+                assertTrue("engines list is non-null", engines.size >= 0)
+                assertTrue("voices list is non-null", voices.size >= 0)
+                // setRate is accepted (pre-clamped value)
+                engine.setRate(1.0f)
+            }
+        } finally {
+            engine.shutdown()
+        }
+    }
+
+    @Test fun factory_createsEngine() = runBlocking<Unit> {
+        val factory = AndroidTtsEngineFactory(ctx.applicationContext)
+        val engine = factory.create()
+        try {
+            assertNotNull(engine)
+            withTimeout(15_000) { engine.awaitInit() }
+        } finally {
+            engine.shutdown()
+        }
+    }
+
+    @Test fun doubleInitIsIdempotent_andShutdownThenSpeakIsSafe() = runBlocking<Unit> {
+        val engine = AndroidTtsEngine(ctx.applicationContext)
+        try {
+            val first = withTimeout(15_000) { engine.awaitInit() }
+            val second = withTimeout(15_000) { engine.awaitInit() }  // must NOT re-construct / hang
+            assertTrue("double init agrees", first == second)
+        } finally {
+            engine.shutdown()
+        }
+        // after shutdown the engine is single-use: speak is a safe no-op (false), awaitInit → failed
+        assertTrue("speak after shutdown is a safe no-op", !engine.speak(TtsUtterance(0, 0, "hi")))
+        assertTrue("re-init after shutdown fails (single-use)", engine.awaitInit() == TtsInitResult.failed)
+    }
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,13 @@
          here); the debug build adds a network-security-config allowing cleartext ONLY to the
          emulator's host alias 10.0.2.2 for the local-WebDAV round-trip verification. -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- feature #121 — TTS read-aloud. Android 11+ (API 30) package visibility: declare the TTS
+         service intent so TextToSpeech can see + enumerate installed on-device TTS engines. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.TTS_SERVICE" />
+        </intent>
+    </queries>
     <application
         android:name=".VReaderApp"
         android:label="VReader"

--- a/android/app/src/main/kotlin/com/vreader/app/tts/AndroidTtsEngine.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/tts/AndroidTtsEngine.kt
@@ -1,0 +1,165 @@
+// Purpose: feature #121 WI-2 (#110 Phase 3) — the production TtsEngine over android.speech.tts.
+// TextToSpeech. Built with the APPLICATION context (no Activity leak). Init bridges the OnInitListener
+// to a suspend; progress callbacks (not guaranteed on main) forward into a thread-safe SharedFlow that
+// the ViewModel collects on main. Engine SWITCHING is recreate-via-factory, not the deprecated setter.
+package com.vreader.app.tts
+
+import android.content.Context
+import android.speech.tts.TextToSpeech
+import android.speech.tts.UtteranceProgressListener
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.merge
+import java.util.Locale
+
+class AndroidTtsEngine(
+    context: Context,
+    private val enginePackage: String? = null,
+) : TtsEngine {
+
+    private val appContext = context.applicationContext
+    private val lifecycle = Any()                 // guards tts / closed / initDeferred transitions
+    @Volatile private var tts: TextToSpeech? = null
+    @Volatile private var closed = false
+    private var initDeferred: CompletableDeferred<TtsInitResult>? = null  // single-flight init
+
+    // TYPE-AWARE buffering so a Range burst can NEVER evict a terminal event: terminals (Started/Done/
+    // Failed — one per sentence, trivial rate) go to a large buffer; ranges (hundreds per utterance,
+    // highlight-only, lossy by design) to a small DROP_OLDEST one. The two are isolated, then merged.
+    private val _terminal = MutableSharedFlow<TtsProgress>(extraBufferCapacity = 1024, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    private val _range = MutableSharedFlow<TtsProgress>(extraBufferCapacity = 64, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    // CONTRACT: `merge` does NOT guarantee cross-flow ordering — a Range may arrive before its
+    // Started or after its Done. The CONSUMER (TtsViewModel, WI-3) gates Range by the CURRENT sentence:
+    // a Range is applied only while `currentSentence.index == range.index` (the Started→Done window), so
+    // an out-of-order Range (before Started / after a terminal, or for a stale index) is ignored. Range
+    // is highlight-refinement only — losing/ignoring one never affects sentence advance (Started-keyed).
+    override val progress: Flow<TtsProgress> = merge(_terminal, _range)
+
+    private val progressListener = object : UtteranceProgressListener() {
+        override fun onStart(utteranceId: String?) = emitTerminal(utteranceId) { g, i -> TtsProgress.Started(g, i) }
+        override fun onRangeStart(utteranceId: String?, start: Int, end: Int, frame: Int) {
+            val (g, i) = TtsUtterance.parse(utteranceId) ?: return
+            _range.tryEmit(TtsProgress.Range(g, i, start, end))
+        }
+        override fun onDone(utteranceId: String?) = emitTerminal(utteranceId) { g, i -> TtsProgress.Done(g, i) }
+        @Deprecated("deprecated base method", ReplaceWith(""))
+        override fun onError(utteranceId: String?) = emitTerminal(utteranceId) { g, i -> TtsProgress.Failed(g, i, TtsErrorKind.speakFailed) }
+        override fun onError(utteranceId: String?, errorCode: Int) = emitTerminal(utteranceId) { g, i -> TtsProgress.Failed(g, i, TtsErrorKind.speakFailed) }
+    }
+
+    override suspend fun awaitInit(): TtsInitResult {
+        val deferred: CompletableDeferred<TtsInitResult>
+        val isFirst: Boolean
+        synchronized(lifecycle) {
+            if (closed) return TtsInitResult.failed             // single-use: shut down, don't revive
+            tts?.let { return TtsInitResult.ok }                // idempotent: already initialized
+            val existing = initDeferred
+            if (existing != null) { deferred = existing; isFirst = false }  // join the in-flight init
+            else { deferred = CompletableDeferred(); initDeferred = deferred; isFirst = true }
+        }
+        // Only the FIRST caller constructs the (single) TextToSpeech; others await the same deferred,
+        // so two concurrent awaitInit()s can never construct two engines.
+        if (isFirst) constructEngine(deferred)
+        return deferred.await()
+    }
+
+    /** Construct the one engine; resolve [deferred] from the init callback — re-entrancy-safe (if the
+     *  OnInitListener fires synchronously during construction, before `holder[0]` is set, the status is
+     *  stashed and processed right after assignment, never dropping/orphaning the engine). */
+    private fun constructEngine(deferred: CompletableDeferred<TtsInitResult>) {
+        val holder = arrayOfNulls<TextToSpeech>(1)
+        var earlyStatus: Int? = null
+        val engine = TextToSpeech(appContext, { status ->
+            synchronized(lifecycle) {
+                val e = holder[0]
+                if (e == null) earlyStatus = status            // re-entrant: defer until assigned
+                else finishInit(status, e, deferred)
+            }
+        }, enginePackage)
+        synchronized(lifecycle) {
+            holder[0] = engine
+            earlyStatus?.let { finishInit(it, engine, deferred) }
+        }
+    }
+
+    /** Caller holds [lifecycle]. Publishes a clean success or tears the engine down + reports failed.
+     *  `CompletableDeferred.complete` is idempotent, so a double-fire is harmless. */
+    private fun finishInit(status: Int, engine: TextToSpeech, deferred: CompletableDeferred<TtsInitResult>) {
+        if (status == TextToSpeech.SUCCESS && !closed) {
+            engine.setOnUtteranceProgressListener(progressListener)
+            tts = engine
+            deferred.complete(TtsInitResult.ok)
+        } else {
+            runCatching { engine.stop(); engine.shutdown() }
+            deferred.complete(TtsInitResult.failed)
+        }
+    }
+
+    override fun speak(utterance: TtsUtterance): Boolean {
+        val t = tts ?: return false
+        return t.speak(utterance.text, TextToSpeech.QUEUE_ADD, null, utterance.utteranceId) == TextToSpeech.SUCCESS
+    }
+
+    override fun stop() { tts?.stop() }
+
+    override fun setRate(rate: Float): Boolean = tts?.setSpeechRate(rate) == TextToSpeech.SUCCESS
+
+    /** Select a voice by name. `null` = leave the engine's current/default voice unchanged (NOT a
+     *  reset — the VM picks an explicit embedded voice on start, so a null here is a documented no-op). */
+    override fun setVoice(name: String?): Boolean {
+        val t = tts ?: return false
+        if (name == null) return true
+        val v = t.voices?.firstOrNull { it.name == name } ?: return false
+        return t.setVoice(v) == TextToSpeech.SUCCESS
+    }
+
+    override fun engines(): List<TtsEngineOption> =
+        tts?.engines?.map { TtsEngineOption(it.name, it.label) } ?: emptyList()
+
+    override fun voices(locale: Locale?): List<TtsVoiceOption> {
+        val all = tts?.voices ?: return emptyList()
+        val candidates = all.map { v ->
+            TtsVoiceFilter.Candidate(
+                name = v.name, locale = v.locale, quality = v.quality,
+                networkRequired = v.isNetworkConnectionRequired,
+                notInstalled = v.features?.contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED) == true,
+            )
+        }
+        return TtsVoiceFilter.filter(candidates, locale)   // deprioritizes very-low, never drops all
+    }
+
+    override fun isLanguageAvailable(locale: Locale): TtsLanguageAvailability =
+        when (tts?.isLanguageAvailable(locale)) {
+            TextToSpeech.LANG_MISSING_DATA -> TtsLanguageAvailability.missingData
+            TextToSpeech.LANG_NOT_SUPPORTED, null -> TtsLanguageAvailability.notSupported
+            else -> TtsLanguageAvailability.available  // LANG_AVAILABLE / COUNTRY_(VAR_)AVAILABLE
+        }
+
+    override fun shutdown() {
+        val pending: CompletableDeferred<TtsInitResult>?
+        synchronized(lifecycle) {
+            closed = true
+            runCatching { tts?.stop(); tts?.shutdown() }
+            tts = null
+            pending = initDeferred
+            initDeferred = null
+        }
+        pending?.complete(TtsInitResult.failed)  // unblock an in-flight awaitInit (outside the lock)
+    }
+
+    /** Emit a terminal event (Started/Done/Failed), dropping an UNATTRIBUTABLE one (no parseable id) —
+     *  never fabricate generation 0, which the VM would mistake for the first generation's utterance. */
+    private inline fun emitTerminal(id: String?, make: (Long, Int) -> TtsProgress) {
+        val (g, i) = TtsUtterance.parse(id) ?: return
+        _terminal.tryEmit(make(g, i))
+    }
+}
+
+/** Builds an [AndroidTtsEngine] (optionally for a specific engine package). Engine switching is a
+ *  shutdown + recreate of the engine via this factory, NOT the deprecated `setEngineByPackageName`. */
+class AndroidTtsEngineFactory(context: Context) : TtsEngineFactory {
+    private val appContext = context.applicationContext
+    override suspend fun create(enginePackage: String?): TtsEngine = AndroidTtsEngine(appContext, enginePackage)
+}

--- a/android/app/src/main/kotlin/com/vreader/app/tts/TtsVoiceFilter.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/tts/TtsVoiceFilter.kt
@@ -1,0 +1,45 @@
+// Purpose: feature #121 WI-2 (#110 Phase 3) — pure voice selection logic, extracted from
+// AndroidTtsEngine so it's JVM-unit-testable without the Android Voice type. Filters voices to a
+// locale and DEPRIORITIZES (never hard-drops) very-low-quality voices — so a locale whose only voices
+// are low-quality / not-yet-installed still surfaces them rather than appearing voice-less.
+package com.vreader.app.tts
+
+import java.util.Locale
+
+object TtsVoiceFilter {
+    // == android.speech.tts.Voice.QUALITY_VERY_LOW (kept as a literal so this stays Android-free).
+    const val QUALITY_VERY_LOW = 100
+
+    /** A platform-free projection of an android.speech.tts.Voice. */
+    data class Candidate(
+        val name: String,
+        val locale: Locale,
+        val quality: Int,
+        val networkRequired: Boolean,
+        val notInstalled: Boolean,
+    )
+
+    /**
+     * Voices for [locale] (or all if null), best-quality first, never returning empty when the locale
+     * HAS candidates: above-very-low voices are preferred, but if a locale only has very-low ones they
+     * are still returned (a low-quality voice beats no read-aloud).
+     */
+    fun filter(candidates: List<Candidate>, locale: Locale?): List<TtsVoiceOption> {
+        val byLocale = candidates.filter { locale == null || it.locale.language.equals(locale.language, ignoreCase = true) }
+        if (byLocale.isEmpty()) return emptyList()
+        val aboveVeryLow = byLocale.filter { it.quality > QUALITY_VERY_LOW }
+        val chosen = (if (aboveVeryLow.isNotEmpty()) aboveVeryLow else byLocale).sortedByDescending { it.quality }
+        return chosen.map { c ->
+            TtsVoiceOption(
+                name = c.name, locale = c.locale, label = label(c),
+                networkRequired = c.networkRequired, notInstalled = c.notInstalled,
+            )
+        }
+    }
+
+    private fun label(c: Candidate): String {
+        val loc = c.locale.getDisplayName(Locale.getDefault()).ifBlank { c.locale.toLanguageTag() }
+        val net = if (c.networkRequired) " · network" else ""
+        return "$loc$net"
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/tts/TtsVoiceFilterTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/tts/TtsVoiceFilterTest.kt
@@ -1,0 +1,51 @@
+package com.vreader.app.tts
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Locale
+
+/** Feature #121 WI-2 — TtsVoiceFilter: locale filter + very-low deprioritize that never drops all. */
+class TtsVoiceFilterTest {
+    private fun c(name: String, lang: String, quality: Int, net: Boolean = false, notInstalled: Boolean = false) =
+        TtsVoiceFilter.Candidate(name, Locale.forLanguageTag(lang), quality, net, notInstalled)
+
+    @Test fun filtersToLocaleAndSortsByQuality() {
+        val out = TtsVoiceFilter.filter(
+            listOf(c("en-low", "en-US", 200), c("fr", "fr-FR", 400), c("en-high", "en-GB", 500)),
+            Locale.ENGLISH,
+        )
+        assertEquals(listOf("en-high", "en-low"), out.map { it.name })  // both English, high first
+    }
+
+    @Test fun deprioritizesVeryLowWhenBetterExists() {
+        val out = TtsVoiceFilter.filter(
+            listOf(c("verylow", "en-US", TtsVoiceFilter.QUALITY_VERY_LOW), c("normal", "en-US", 300)),
+            Locale.ENGLISH,
+        )
+        assertEquals(listOf("normal"), out.map { it.name })  // very-low dropped because a better one exists
+    }
+
+    @Test fun keepsVeryLowWhenItsAllThereIs() {
+        // the load-bearing fix: a locale whose ONLY voices are very-low must still surface them
+        val out = TtsVoiceFilter.filter(
+            listOf(c("only", "en-US", TtsVoiceFilter.QUALITY_VERY_LOW)),
+            Locale.ENGLISH,
+        )
+        assertEquals(listOf("only"), out.map { it.name })
+    }
+
+    @Test fun emptyWhenLocaleHasNoCandidates() {
+        assertTrue(TtsVoiceFilter.filter(listOf(c("fr", "fr-FR", 400)), Locale.GERMAN).isEmpty())
+    }
+
+    @Test fun nullLocaleReturnsAll() {
+        val out = TtsVoiceFilter.filter(listOf(c("en", "en-US", 300), c("fr", "fr-FR", 400)), null)
+        assertEquals(2, out.size)
+    }
+
+    @Test fun preservesNetworkAndNotInstalledFlags() {
+        val out = TtsVoiceFilter.filter(listOf(c("net", "en-US", 300, net = true, notInstalled = true)), Locale.ENGLISH)
+        assertTrue(out.single().networkRequired && out.single().notInstalled)
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.8.5
-versionCode=44
+versionName=0.8.6
+versionCode=45


### PR DESCRIPTION
## Summary

WI-2 (platform) of feature #121 (Android TTS read-aloud) — the production `TtsEngine` over `android.speech.tts.TextToSpeech`.

- **AndroidTtsEngine** — application-context wrapper. **Single-flight init** via a `CompletableDeferred` (concurrent `awaitInit` can't double-construct; re-entrant `OnInitListener` is safe via deferred `earlyStatus`; single-use after `shutdown`). **Type-aware progress flows** — terminal events (Started/Done/Failed) isolated from `onRangeStart` bursts so a range can never evict a terminal; ranges are gated by the VM's current sentence (WI-3 contract). One-utterance `speak`, `setRate`/`setVoice`, `engines()`/`voices()` (via `TtsVoiceFilter`), `isLanguageAvailable`→domain enum, `shutdown`. + `AndroidTtsEngineFactory`.
- **TtsVoiceFilter** (pure) — locale filter + deprioritize-very-low-but-never-drop-all.
- **Manifest `<queries>` TTS_SERVICE** — Android-11 package visibility for engine enumeration.

Part of feature #121.

## Tests

- `TtsVoiceFilterTest` (JVM, 6) — locale filter, sort-by-quality, **keep-very-low-when-it's-all-there-is**, flags preserved.
- `AndroidTtsEngineTest` (instrumented, 3) — init bridges to a result + enumeration callable on the emulator, factory, **double-init idempotent + shutdown-then-speak safe**. (Audible output not asserted — unobservable headless, as on iOS.)
- All green on emulator-5554.

## Codex Audit

3 rounds, ship-as-is. R1 (3H/4M/2L): init-resurrect, double-init, voices-drops-all, re-entrant init, lossy emit, fake-gen-0, setVoice contract. R2 (3H): concurrent-init double-construct, re-entrant orphan, DROP_OLDEST evicting terminals. R3 (1H): cross-flow ordering — resolved by the documented VM consumer contract (Range gated by current sentence; WI-3 implements + tests it). All fixed/resolved.

Audit log: `.claude/codex-audits/feat-feature-121-wi-2-android-tts-engine-audit.md`

## Validation

- [x] JVM + instrumented tests green
- [x] Codex audit (3 rounds, ship-as-is)
- [x] Version bumped: android 0.8.5 → 0.8.6 (versionCode 45)