### PR TITLE
feat(#121 WI-3): TtsViewModel transport state machine

### DIFF
--- a/.claude/codex-audits/feat-feature-121-wi-3-tts-viewmodel-audit.md
+++ b/.claude/codex-audits/feat-feature-121-wi-3-tts-viewmodel-audit.md
@@ -1,0 +1,38 @@
+---
+branch: feat/feature-121-wi-3-tts-viewmodel
+threadId: 019f0405-f121wi3
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-27
+---
+
+# Feature #121 WI-3 — Codex audit (TtsViewModel transport state machine)
+
+Files: `tts/TtsViewModel.kt`, `tts/TtsUiState.kt`, `tts/TtsViewModelTest.kt` (13, Robolectric + fake engine).
+
+## Round 1 — 3 High, 3 Medium, 2 Low (all fixed)
+
+| severity | issue | resolution |
+|---|---|---|
+| High | `start()` re-entrant / not token-guarded across `awaitInit()`; empty start didn't stop/bump | FIXED — a `startToken` + post-suspend bail checks; entry bumps generation + `engine.stop()`; empty start bumps + stops |
+| High | `engine.speak()` false ignored → could hang in `speaking` forever | FIXED — `speakOne()` checks the Boolean; on false → `failTerminal(speakFailed)` |
+| High | `Failed` only set error (later same-gen callbacks could revive) | FIXED — `failTerminal`: `generation++` + `engine.stop()` + error |
+| Medium | next/prev/selectVoice stopped BEFORE the generation bump (stale-callback window) | FIXED — centralized `restartFromCurrent()` bumps generation BEFORE `engine.stop()`; seek/selectVoice/play route through it |
+| Medium | `Done` refill tied to `p.index==current` → a dropped `Started` could stall the queue | FIXED — refill on ANY same-generation `Done` (from `enqueuedThrough`); idle when the last index's Done arrives |
+| Medium | `setVoice` failures ignored | FIXED — `selectVoice` keeps prior state on reject; start auto-pick sets the label only if accepted |
+| Low | `queueWindow` unvalidated | FIXED — coerced `>= 1` |
+| Low | `rateLabel` default-locale formatting | FIXED — `Locale.ROOT` |
+
+## Round 2 — 1 High (fixed)
+
+| severity | issue | resolution |
+|---|---|---|
+| High | `startToken` was bumped INSIDE the launched coroutine → a `stop()` racing before the coroutine ran wasn't visible, so a stale start could enqueue after stop | FIXED — `start()` captures `val token = ++startToken` SYNCHRONOUSLY before `viewModelScope.launch` (and stops/bumps generation synchronously); the coroutine bails immediately if `token != startToken` and re-checks after each suspend. `start()` returns the `Job`. |
+
+Round 2 confirmed no problem with the double generation bump, the `speakOne`/`failTerminal` mid-loop
+path, or the Done-refill ordering (bounded + ordered under the engine's one-terminal-callback-per-
+utterance contract). Regression tests added: `speakFailure_entersError`, `failedEvent_isTerminal_noRevive`.
+
+## Summary
+
+3 High + 3 Medium + 2 Low (R1) + 1 High (R2), all fixed. 13 Robolectric tests green. **Verdict: ship-as-is.**

--- a/android/app/src/main/kotlin/com/vreader/app/tts/TtsUiState.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/tts/TtsUiState.kt
@@ -1,0 +1,38 @@
+// Purpose: feature #121 WI-3 (#110 Phase 3) — UI state + one-shot intents for the TTS transport
+// (design vreader-tts.jsx: status row, transport, speed/voice chips, error layout). Stateless
+// composables (WI-4) render a pure function of TtsUiState.
+package com.vreader.app.tts
+
+import java.util.Locale
+
+/** The control-bar state. */
+data class TtsUiState(
+    val phase: TtsPhase = TtsPhase.idle,
+    val sentenceIndex: Int = 0,
+    val sentenceCount: Int = 0,
+    val charStart: Int = 0,           // spoken span in the RAW book text (for the reader highlight)
+    val charEnd: Int = 0,
+    val rate: Float = 1.0f,
+    val voiceLabel: String = "",
+    val engineLabel: String = "",
+    val error: TtsErrorKind? = null,
+) {
+    // Locale.ROOT so a comma-decimal locale never renders "1,25×".
+    val rateLabel: String get() = "${String.format(Locale.ROOT, "%.2f", rate).trimEnd('0').trimEnd('.')}×"
+    /** 0..1 progress through the book's sentences (for the bar's progress line). */
+    val progressFraction: Float get() = if (sentenceCount <= 1) 0f else (sentenceIndex.toFloat() / (sentenceCount - 1)).coerceIn(0f, 1f)
+}
+
+/** One-shot side effects the Activity performs (the VM stays platform-free). */
+sealed interface TtsIntent {
+    data object InstallVoiceData : TtsIntent
+    data object OpenSystemTts : TtsIntent
+}
+
+/** Voice-picker sheet state. */
+data class TtsVoiceListState(
+    val engines: List<TtsEngineOption> = emptyList(),
+    val selectedEngineId: String? = null,
+    val voices: List<TtsVoiceOption> = emptyList(),
+    val selectedVoiceName: String? = null,
+)

--- a/android/app/src/main/kotlin/com/vreader/app/tts/TtsViewModel.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/tts/TtsViewModel.kt
@@ -1,0 +1,189 @@
+// Purpose: feature #121 WI-3 (#110 Phase 3) — the read-aloud transport state machine over an injected
+// TtsEngine. Sentence advance is driven by Started (fires on every engine); Range only refines the
+// CURRENT sentence's highlight span (the WI-2 cross-flow-ordering contract — an out-of-order/stale
+// Range is ignored). Pause = engine.stop() + retain the anchor; resume re-speaks from it. A generation
+// token bumps BEFORE any stop that flushes the queue, so a flushed-queue callback is discarded; a
+// startToken guards the suspending start() against re-entrancy / stop-during-init.
+package com.vreader.app.tts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.util.Locale
+
+class TtsViewModel(
+    private val engine: TtsEngine,
+    private val readLocale: Locale = Locale.getDefault(),
+    queueWindow: Int = 3,
+) : ViewModel() {
+
+    private val window = queueWindow.coerceAtLeast(1)
+
+    private val _state = MutableStateFlow(TtsUiState())
+    val state: StateFlow<TtsUiState> = _state.asStateFlow()
+
+    private val _intents = MutableSharedFlow<TtsIntent>(extraBufferCapacity = 4)
+    val intents: SharedFlow<TtsIntent> = _intents.asSharedFlow()
+
+    private var sentences: List<TtsSentence> = emptyList()
+    private var generation = 0L          // bumped before any queue-flushing stop
+    private var startToken = 0L          // guards the suspending start() against re-entrancy / stop
+    private var current = 0              // the resume anchor / current sentence
+    private var enqueuedThrough = -1     // highest index handed to the engine this generation
+
+    init {
+        viewModelScope.launch { engine.progress.collect { onProgress(it) } }
+    }
+
+    /** Begin read-aloud over [sentences]. Awaits init, checks the read language, picks an embedded
+     *  voice, applies the rate, and enqueues the first window. A missing/unsupported language surfaces
+     *  the typed error instead of speaking. Re-entrancy + stop-during-init safe via [startToken]. */
+    fun start(sentences: List<TtsSentence>): kotlinx.coroutines.Job {
+        val token = ++startToken      // bumped SYNCHRONOUSLY so a stop() racing before the coroutine
+        generation++; engine.stop()   // runs is visible to the token checks below; stop playback now
+        return viewModelScope.launch {
+        if (token != startToken) return@launch       // a stop()/newer start() raced in before we ran
+        this@TtsViewModel.sentences = sentences
+        if (sentences.isEmpty()) { _state.value = _state.value.copy(phase = TtsPhase.idle, sentenceCount = 0, sentenceIndex = 0); return@launch }
+        if (engine.awaitInit() != TtsInitResult.ok) { if (token == startToken) fail(TtsErrorKind.initFailed); return@launch }
+        if (token != startToken) return@launch       // superseded by a newer start()/stop()
+        when (engine.isLanguageAvailable(readLocale)) {
+            TtsLanguageAvailability.missingData -> { fail(TtsErrorKind.noVoiceData); return@launch }
+            TtsLanguageAvailability.notSupported -> { fail(TtsErrorKind.languageNotSupported); return@launch }
+            TtsLanguageAvailability.available -> Unit
+        }
+        if (token != startToken) return@launch
+        val voices = engine.voices(readLocale)
+        val chosen = voices.firstOrNull { !it.networkRequired && !it.notInstalled } ?: voices.firstOrNull { !it.networkRequired }
+        val accepted = chosen != null && engine.setVoice(chosen.name)   // never auto-select a network voice
+        engine.setRate(_state.value.rate)
+        current = 0
+        _state.value = _state.value.copy(
+            phase = TtsPhase.speaking, sentenceIndex = 0, sentenceCount = sentences.size, error = null,
+            voiceLabel = if (accepted) chosen!!.label else "",
+            engineLabel = engine.engines().firstOrNull()?.label ?: "",
+            charStart = sentences[0].charStart, charEnd = sentences[0].charEnd,
+        )
+        restartFromCurrent()
+        }
+    }
+
+    fun play() {
+        if (_state.value.phase != TtsPhase.paused || sentences.isEmpty()) return
+        _state.value = _state.value.copy(phase = TtsPhase.speaking, error = null)
+        restartFromCurrent()
+    }
+
+    fun pause() {
+        if (_state.value.phase != TtsPhase.speaking) return
+        generation++; engine.stop()   // bump BEFORE stop so flushed-queue callbacks are stale
+        _state.value = _state.value.copy(phase = TtsPhase.paused)  // keep `current` as the resume anchor
+    }
+
+    fun stop() {
+        startToken++                   // cancel any in-flight start()
+        generation++; engine.stop()
+        current = 0
+        _state.value = _state.value.copy(phase = TtsPhase.idle, sentenceIndex = 0, charStart = 0, charEnd = 0)
+    }
+
+    fun next() = seek(current + 1)
+    fun previous() = seek(current - 1)
+
+    private fun seek(to: Int) {
+        if (sentences.isEmpty()) return
+        current = to.coerceIn(0, sentences.lastIndex)
+        val s = sentences[current]
+        _state.value = _state.value.copy(sentenceIndex = current, charStart = s.charStart, charEnd = s.charEnd)
+        if (_state.value.phase == TtsPhase.speaking) restartFromCurrent() else generation++
+    }
+
+    fun setRate(rate: Float) {
+        if (!rate.isFinite()) return
+        val clamped = rate.coerceIn(MIN_RATE, MAX_RATE)
+        engine.setRate(clamped)
+        _state.value = _state.value.copy(rate = clamped)
+    }
+
+    fun selectVoice(option: TtsVoiceOption) {
+        if (!engine.setVoice(option.name)) return   // engine rejected it — keep prior state
+        _state.value = _state.value.copy(voiceLabel = option.label)
+        if (_state.value.phase == TtsPhase.speaking) restartFromCurrent()
+    }
+
+    fun installVoiceData() { _intents.tryEmit(TtsIntent.InstallVoiceData) }
+    fun openSystemTts() { _intents.tryEmit(TtsIntent.OpenSystemTts) }
+
+    // ── engine progress ─────────────────────────────────────────────
+
+    private fun onProgress(p: TtsProgress) {
+        if (p.generation != generation) return  // stale (flushed queue / superseded start)
+        when (p) {
+            is TtsProgress.Started -> {
+                current = p.index
+                val s = sentences.getOrNull(p.index) ?: return
+                _state.value = _state.value.copy(phase = TtsPhase.speaking, sentenceIndex = p.index, charStart = s.charStart, charEnd = s.charEnd)
+            }
+            is TtsProgress.Range -> {
+                // gate by the CURRENT sentence — an out-of-order/stale Range is ignored (WI-2 contract).
+                if (p.index != current) return
+                val base = sentences.getOrNull(p.index) ?: return
+                val cs = (base.charStart + p.charStart).coerceIn(base.charStart, base.charEnd)
+                val ce = (base.charStart + p.charEnd).coerceIn(cs, base.charEnd)
+                _state.value = _state.value.copy(charStart = cs, charEnd = ce)
+            }
+            is TtsProgress.Done -> {
+                // Refill on ANY same-generation Done (not tied to `current`) so a dropped Started can't
+                // stall the queue; finish when the last sentence completes.
+                val nextToQueue = enqueuedThrough + 1
+                if (nextToQueue <= sentences.lastIndex) speakOne(nextToQueue)
+                else if (p.index >= sentences.lastIndex) _state.value = _state.value.copy(phase = TtsPhase.idle)
+            }
+            is TtsProgress.Failed -> failTerminal(p.kind)
+        }
+    }
+
+    // ── queueing ────────────────────────────────────────────────────
+
+    /** Bump the generation FIRST (invalidate stale callbacks), stop, then enqueue [current..+window). */
+    private fun restartFromCurrent() {
+        generation++
+        engine.stop()
+        enqueuedThrough = current - 1
+        val last = minOf(current + window - 1, sentences.lastIndex)
+        for (i in current..last) if (!speakOne(i)) return
+    }
+
+    /** Enqueue one utterance; on an engine ERROR, fail terminally (don't advance the bookkeeping). */
+    private fun speakOne(index: Int): Boolean {
+        val s = sentences.getOrNull(index) ?: return true
+        if (!engine.speak(TtsUtterance(generation, index, s.text))) { failTerminal(TtsErrorKind.speakFailed); return false }
+        if (index > enqueuedThrough) enqueuedThrough = index
+        return true
+    }
+
+    private fun fail(kind: TtsErrorKind) { _state.value = _state.value.copy(phase = TtsPhase.error, error = kind) }
+
+    /** A terminal failure: invalidate the queue (gen++), stop the engine, surface the error — so later
+     *  same-(old)generation callbacks can't revive `speaking` or refill. */
+    private fun failTerminal(kind: TtsErrorKind) {
+        generation++; engine.stop()
+        _state.value = _state.value.copy(phase = TtsPhase.error, error = kind)
+    }
+
+    override fun onCleared() {
+        engine.shutdown()
+        super.onCleared()
+    }
+
+    private companion object {
+        const val MIN_RATE = 0.5f
+        const val MAX_RATE = 2.0f
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/tts/TtsViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/tts/TtsViewModelTest.kt
@@ -1,0 +1,187 @@
+package com.vreader.app.tts
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.Locale
+
+/** Feature #121 WI-3 — TtsViewModel transport state machine (Started-keyed advance, gated Range,
+ *  pause/resume + generation tokens, rate clamp, locale/voice policy). */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class TtsViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    @Before fun setUp() = Dispatchers.setMain(dispatcher)
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    private class FakeEngine(
+        var init: TtsInitResult = TtsInitResult.ok,
+        var lang: TtsLanguageAvailability = TtsLanguageAvailability.available,
+        var voiceList: List<TtsVoiceOption> = listOf(TtsVoiceOption("v1", Locale.US, "English", false, false)),
+    ) : TtsEngine {
+        val spoken = mutableListOf<TtsUtterance>()
+        var stops = 0
+        var lastRate = 1.0f
+        var lastVoice: String? = "<unset>"
+        var speakResult = true
+        val flow = MutableSharedFlow<TtsProgress>(extraBufferCapacity = 64)
+        override val progress = flow
+        override suspend fun awaitInit() = init
+        override fun speak(utterance: TtsUtterance): Boolean { spoken += utterance; return speakResult }
+        override fun stop() { stops++ }
+        override fun setRate(rate: Float): Boolean { lastRate = rate; return true }
+        override fun setVoice(name: String?): Boolean { lastVoice = name; return true }
+        override fun engines() = listOf(TtsEngineOption("e", "Engine"))
+        override fun voices(locale: Locale?) = voiceList
+        override fun isLanguageAvailable(locale: Locale) = lang
+        override fun shutdown() {}
+    }
+
+    private fun sentences(n: Int) = (0 until n).map { TtsSentence(it, it * 10, it * 10 + 5, "S$it..") }
+
+    private fun vm(engine: FakeEngine, window: Int = 3) = TtsViewModel(engine, Locale.US, window)
+
+    @Test fun start_speaksWindow_andIsSpeaking() = runTest(dispatcher) {
+        val e = FakeEngine(); val v = vm(e)
+        v.start(sentences(5)); advanceUntilIdle()
+        assertEquals(TtsPhase.speaking, v.state.value.phase)
+        assertEquals(listOf(0, 1, 2), e.spoken.map { it.index })   // window of 3
+        assertEquals(5, v.state.value.sentenceCount)
+    }
+
+    @Test fun started_advancesSentenceAndSpan() = runTest(dispatcher) {
+        val e = FakeEngine(); val v = vm(e)
+        v.start(sentences(5)); advanceUntilIdle()
+        val g = e.spoken.first().generation
+        e.flow.emit(TtsProgress.Started(g, 1)); advanceUntilIdle()
+        assertEquals(1, v.state.value.sentenceIndex)
+        assertEquals(10, v.state.value.charStart)    // sentence 1 starts at 1*10
+    }
+
+    @Test fun range_refinesCurrentSentence_ignoresWrongIndexAndStaleGen() = runTest(dispatcher) {
+        val e = FakeEngine(); val v = vm(e)
+        v.start(sentences(5)); advanceUntilIdle()
+        val g = e.spoken.first().generation
+        e.flow.emit(TtsProgress.Started(g, 0)); advanceUntilIdle()
+        e.flow.emit(TtsProgress.Range(g, 0, 2, 4)); advanceUntilIdle()
+        assertEquals(2, v.state.value.charStart)     // base 0 + 2
+        assertEquals(4, v.state.value.charEnd)
+        // a Range for a non-current index is ignored
+        e.flow.emit(TtsProgress.Range(g, 3, 0, 1)); advanceUntilIdle()
+        assertEquals(2, v.state.value.charStart)
+        // a stale-generation Range is ignored
+        e.flow.emit(TtsProgress.Range(g - 1, 0, 9, 9)); advanceUntilIdle()
+        assertEquals(2, v.state.value.charStart)
+    }
+
+    @Test fun done_enqueuesNext_lastDoneGoesIdle() = runTest(dispatcher) {
+        val e = FakeEngine(); val v = vm(e, window = 2)
+        v.start(sentences(3)); advanceUntilIdle()      // queued 0,1
+        val g = e.spoken.first().generation
+        e.flow.emit(TtsProgress.Started(g, 0)); e.flow.emit(TtsProgress.Done(g, 0)); advanceUntilIdle()
+        assertEquals(listOf(0, 1, 2), e.spoken.map { it.index })  // Done(0) enqueued 2
+        e.flow.emit(TtsProgress.Started(g, 2)); e.flow.emit(TtsProgress.Done(g, 2)); advanceUntilIdle()
+        assertEquals(TtsPhase.idle, v.state.value.phase)          // last sentence done → idle
+    }
+
+    @Test fun pause_stopsBumpsGeneration_staleStartedIgnored() = runTest(dispatcher) {
+        val e = FakeEngine(); val v = vm(e)
+        v.start(sentences(5)); advanceUntilIdle()
+        val g = e.spoken.first().generation
+        v.pause(); advanceUntilIdle()
+        assertEquals(TtsPhase.paused, v.state.value.phase)
+        assertTrue(e.stops >= 1)
+        // a stale Started from the flushed queue (old generation) must NOT change state
+        e.flow.emit(TtsProgress.Started(g, 4)); advanceUntilIdle()
+        assertEquals(TtsPhase.paused, v.state.value.phase)
+        assertEquals(0, v.state.value.sentenceIndex)
+    }
+
+    @Test fun play_resumesFromAnchor() = runTest(dispatcher) {
+        val e = FakeEngine(); val v = vm(e)
+        v.start(sentences(5)); advanceUntilIdle()
+        val g0 = e.spoken.first().generation
+        e.flow.emit(TtsProgress.Started(g0, 2)); advanceUntilIdle()   // advanced to sentence 2
+        v.pause(); advanceUntilIdle()
+        e.spoken.clear()
+        v.play(); advanceUntilIdle()
+        assertEquals(TtsPhase.speaking, v.state.value.phase)
+        assertEquals(2, e.spoken.first().index)                       // resumes at the anchor (2)
+    }
+
+    @Test fun nextPrev_clampAndReQueue() = runTest(dispatcher) {
+        val e = FakeEngine(); val v = vm(e)
+        v.start(sentences(3)); advanceUntilIdle()
+        v.next(); advanceUntilIdle()
+        assertEquals(1, v.state.value.sentenceIndex)
+        v.previous(); v.previous(); advanceUntilIdle()
+        assertEquals(0, v.state.value.sentenceIndex)                  // clamped at 0
+    }
+
+    @Test fun setRate_clampsAndRejectsNonFinite() = runTest(dispatcher) {
+        val e = FakeEngine(); val v = vm(e)
+        v.setRate(3.0f); assertEquals(2.0f, v.state.value.rate)       // clamped to max
+        v.setRate(0.1f); assertEquals(0.5f, v.state.value.rate)       // clamped to min
+        v.setRate(Float.NaN); assertEquals(0.5f, v.state.value.rate)  // non-finite rejected (unchanged)
+    }
+
+    @Test fun languageMissing_failsNoVoiceData_withoutSpeaking() = runTest(dispatcher) {
+        val e = FakeEngine(lang = TtsLanguageAvailability.missingData); val v = vm(e)
+        v.start(sentences(3)); advanceUntilIdle()
+        assertEquals(TtsPhase.error, v.state.value.phase)
+        assertEquals(TtsErrorKind.noVoiceData, v.state.value.error)
+        assertTrue(e.spoken.isEmpty())
+    }
+
+    @Test fun networkVoice_notAutoSelected() = runTest(dispatcher) {
+        val e = FakeEngine(voiceList = listOf(
+            TtsVoiceOption("net", Locale.US, "Net", networkRequired = true),
+            TtsVoiceOption("embedded", Locale.US, "Embedded", networkRequired = false),
+        ))
+        val v = vm(e)
+        v.start(sentences(2)); advanceUntilIdle()
+        assertEquals("embedded", e.lastVoice)
+    }
+
+    @Test fun speakFailure_entersError() = runTest(dispatcher) {
+        val e = FakeEngine().apply { speakResult = false }; val v = vm(e)
+        v.start(sentences(3)); advanceUntilIdle()
+        assertEquals(TtsPhase.error, v.state.value.phase)
+        assertEquals(TtsErrorKind.speakFailed, v.state.value.error)
+    }
+
+    @Test fun failedEvent_isTerminal_noRevive() = runTest(dispatcher) {
+        val e = FakeEngine(); val v = vm(e)
+        v.start(sentences(5)); advanceUntilIdle()
+        val g = e.spoken.first().generation
+        e.flow.emit(TtsProgress.Failed(g, 1, TtsErrorKind.speakFailed)); advanceUntilIdle()
+        assertEquals(TtsPhase.error, v.state.value.phase)
+        // a stale same-(old)generation Started must NOT revive speaking (failTerminal bumped generation)
+        e.flow.emit(TtsProgress.Started(g, 2)); advanceUntilIdle()
+        assertEquals(TtsPhase.error, v.state.value.phase)
+    }
+
+    @Test fun installVoiceData_emitsIntent() = runTest(dispatcher) {
+        val e = FakeEngine(); val v = vm(e)
+        val seen = mutableListOf<TtsIntent>()
+        val job = launch { v.intents.collect { seen += it } }
+        advanceUntilIdle()                      // ensure the collector is subscribed (replay=0)
+        v.installVoiceData(); advanceUntilIdle()
+        assertTrue(seen.contains(TtsIntent.InstallVoiceData))
+        job.cancel()
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.8.6
-versionCode=45
+versionName=0.8.7
+versionCode=46


### PR DESCRIPTION
## Summary

WI-3 (behavioral) of feature #121 (Android TTS read-aloud) — the transport state machine over the injected `TtsEngine`.

- **TtsViewModel** — `start`/`play`/`pause`/`stop`/`next`/`previous`/`setRate`/`selectVoice`/`installVoiceData`. Sentence advance keyed on `Started`; `Range` gated by the current sentence (the WI-2 cross-flow-ordering contract). Pause = `engine.stop()` + retain anchor; resume re-speaks from it. A **generation token** bumps BEFORE every queue-flushing stop (centralized `restartFromCurrent`); a **synchronously-captured `startToken`** guards `start()` against re-entrancy / stop-during-init. Terminal failure handling (a `speak` ERROR or a `Failed` event → gen++/stop/error, no revive). Bounded queue window + gen-keyed refill. Rate clamp 0.5–2.0 + non-finite reject. Embedded-voice policy (never auto-select a network voice). `Locale.ROOT` rate label.
- **TtsUiState** + **TtsIntent** + **TtsVoiceListState**.

Part of feature #121. (WI-4 = the Compose control bar + sheets; WI-5 = TxtReader integration.)

## Tests

13 Robolectric (fake engine): window speak, Started advance, Range refine/gate (wrong-index + stale-gen ignored), Done refill + last-done→idle, pause stops+bumps (stale Started ignored), play resumes from anchor, next/prev clamp, rate clamp + non-finite reject, language-missing → noVoiceData (no speak), network-voice not auto-selected, **speak-failure → error**, **Failed terminal/no-revive**, intent emission.

## Codex Audit

2 rounds, ship-as-is. R1 (3H/3M/2L): start re-entrancy/empty, ignored speak() failure, non-terminal Failed, stop-before-bump windows, Done-refill-tied-to-current, ignored setVoice failure, queueWindow/rateLabel. R2 (1H): `startToken` bumped inside the coroutine → captured synchronously. All fixed.

Audit log: `.claude/codex-audits/feat-feature-121-wi-3-tts-viewmodel-audit.md`

## Validation

- [x] 13 Robolectric tests green
- [x] Codex audit (2 rounds, ship-as-is)
- [x] Version bumped: android 0.8.6 → 0.8.7 (versionCode 46)