### PR TITLE
feat(#121 WI-4): TTS control bar + voice/speed sheets

### DIFF
--- a/.claude/codex-audits/feat-feature-121-wi-4-tts-control-bar-audit.md
+++ b/.claude/codex-audits/feat-feature-121-wi-4-tts-control-bar-audit.md
@@ -1,0 +1,28 @@
+---
+branch: feat/feature-121-wi-4-tts-control-bar
+threadId: 019f0405-f121wi4
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-27
+---
+
+# Feature #121 WI-4 — Codex audit (TTS control bar + voice/speed sheets)
+
+Files: `tts/TtsControlBar.kt`, `tts/TtsSpeedSheet.kt`, `tts/TtsVoiceSheet.kt`, instrumented
+`TtsControlBarTest.kt` (4) + `TtsSheetsTest.kt` (3).
+
+## Round 1 — 1 Medium, 2 Low (all fixed)
+
+| file | severity | issue | resolution |
+|---|---|---|---|
+| TtsControlBar Chip | Medium | unbounded chip text — a long voice label / invalid rate label could overflow / push transport controls | FIXED — `Chip` Text is `maxLines=1` + `TextOverflow.Ellipsis`; the voice chip is `widthIn(max=240.dp)` |
+| TtsSpeedSheet FlowRow | Low | preset pills wrapped start-biased, design centers them | FIXED — `Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally)` |
+| TtsControlBar play/pause + icon btns | Low | the action label was only on the child Icon, not the clickable node | FIXED — `clickable(onClickLabel = …)` on the play/pause + IconBtn nodes; the child icons are now decorative (`contentDescription = null`) |
+
+Codex confirmed: no statelessness/recomposition issue (the composables hold no local mutable state,
+render as pure functions of inputs + callbacks), and the not-installed voice row correctly routes to
+`onInstall` (not `onVoice`).
+
+## Summary
+
+1 Medium + 2 Low, all fixed; 7 instrumented Compose tests green on emulator-5554. **Verdict: ship-as-is.**

--- a/android/app/src/androidTest/kotlin/com/vreader/app/tts/TtsControlBarTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/tts/TtsControlBarTest.kt
@@ -1,0 +1,68 @@
+package com.vreader.app.tts
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Feature #121 WI-4 — the TTS control bar: transport states + callbacks + the error layout. */
+@RunWith(AndroidJUnit4::class)
+class TtsControlBarTest {
+    @get:Rule val compose = createComposeRule()
+
+    @Test fun speaking_showsStatusAndTransportCallbacks() {
+        var pp = false; var nx = false; var pv = false; var st = false
+        compose.setContent {
+            TtsControlBar(
+                TtsUiState(phase = TtsPhase.speaking, sentenceIndex = 1, sentenceCount = 5, voiceLabel = "English"),
+                onPlayPause = { pp = true }, onNext = { nx = true }, onPrevious = { pv = true }, onStop = { st = true },
+            )
+        }
+        compose.onNodeWithText("READING ALOUD").assertIsDisplayed()
+        compose.onNodeWithText("2 / 5").assertIsDisplayed()
+        compose.onNodeWithTag("tts-playpause").performClick()
+        compose.onNodeWithTag("tts-next").performClick()
+        compose.onNodeWithTag("tts-prev").performClick()
+        compose.onNodeWithTag("tts-stop").performClick()
+        assertTrue(pp && nx && pv && st)
+    }
+
+    @Test fun paused_showsPausedStatus() {
+        compose.setContent { TtsControlBar(TtsUiState(phase = TtsPhase.paused, sentenceCount = 3)) }
+        compose.onNodeWithText("PAUSED").assertIsDisplayed()
+    }
+
+    @Test fun error_showsInstallAndSystemCtas() {
+        var install = false; var system = false
+        compose.setContent {
+            TtsControlBar(
+                TtsUiState(phase = TtsPhase.error, error = TtsErrorKind.noVoiceData),
+                onInstallVoice = { install = true }, onSystemTts = { system = true },
+            )
+        }
+        compose.onNodeWithTag("tts-error").assertIsDisplayed()
+        compose.onNodeWithTag("tts-install-voice").performClick()
+        compose.onNodeWithTag("tts-system").performClick()
+        assertTrue(install && system)
+    }
+
+    @Test fun speedAndVoiceChips_fireCallbacks() {
+        var speed = false; var voice = false
+        compose.setContent {
+            TtsControlBar(
+                TtsUiState(phase = TtsPhase.speaking, sentenceCount = 2, rate = 1.5f, voiceLabel = "English"),
+                onSpeed = { speed = true }, onVoice = { voice = true },
+            )
+        }
+        compose.onNodeWithText("1.5×").assertIsDisplayed()   // the speed chip
+        compose.onNodeWithTag("tts-speed").performClick()
+        compose.onNodeWithTag("tts-voice").performClick()
+        assertTrue(speed && voice)
+    }
+}

--- a/android/app/src/androidTest/kotlin/com/vreader/app/tts/TtsSheetsTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/tts/TtsSheetsTest.kt
@@ -1,0 +1,58 @@
+package com.vreader.app.tts
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.vreader.app.backup.BackupSurface
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Locale
+
+/** Feature #121 WI-4 — the speed + voice sheets. */
+@RunWith(AndroidJUnit4::class)
+class TtsSheetsTest {
+    @get:Rule val compose = createComposeRule()
+
+    @Test fun speedSheet_showsCurrentAndPicksPreset() {
+        var picked: Float? = null
+        compose.setContent { BackupSurface(darkOverride = false) { TtsSpeedSheet(rate = 1.0f, onRate = { picked = it }) } }
+        compose.onNodeWithTag("speed-current").assertIsDisplayed()   // current rate, large
+        compose.onNodeWithTag("speed-1.5×").performScrollTo().performClick()
+        assertEquals(1.5f, picked)
+    }
+
+    @Test fun voiceSheet_rendersEnginesAndVoices_andSelects() {
+        var selected: TtsVoiceOption? = null
+        val state = TtsVoiceListState(
+            engines = listOf(TtsEngineOption("g", "Google Speech")),
+            selectedEngineId = "g",
+            voices = listOf(
+                TtsVoiceOption("v1", Locale.US, "English (US)", networkRequired = false, notInstalled = false),
+                TtsVoiceOption("v2", Locale.UK, "English (UK)", networkRequired = false, notInstalled = true),
+            ),
+            selectedVoiceName = "v1",
+        )
+        compose.setContent { BackupSurface(darkOverride = false) { TtsVoiceSheet(state, onVoice = { selected = it }) } }
+        compose.onNodeWithText("Google Speech").assertIsDisplayed()
+        compose.onNodeWithTag("voice-v1").performScrollTo().assertIsDisplayed()
+        compose.onNodeWithTag("voice-v1").performClick()
+        assertEquals("v1", selected?.name)
+    }
+
+    @Test fun voiceSheet_notInstalledTriggersInstall() {
+        var install: TtsVoiceOption? = null
+        val state = TtsVoiceListState(
+            voices = listOf(TtsVoiceOption("v2", Locale.UK, "English (UK)", notInstalled = true)),
+        )
+        compose.setContent { BackupSurface(darkOverride = false) { TtsVoiceSheet(state, onInstall = { install = it }) } }
+        compose.onNodeWithTag("voice-v2").performScrollTo().performClick()
+        assertTrue(install?.name == "v2")
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/tts/TtsControlBar.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/tts/TtsControlBar.kt
@@ -1,0 +1,152 @@
+// Purpose: feature #121 WI-4 (#110 Phase 3) — the docked read-aloud transport (design vreader-tts.jsx
+// `TtsBar`): a chunk-progress line, a status row, the speed chip + prev/play-pause/next transport + a
+// close, and a voice/engine chip; plus the error layout (no-voice-data → Install voice data + System
+// TTS). Uses the reader's VReaderColors/VReaderFonts (the in-reader surface). Stateless: a pure
+// function of TtsUiState + callbacks.
+package com.vreader.app.tts
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.vreader.app.ui.theme.VReaderColors
+import com.vreader.app.ui.theme.VReaderFonts
+
+@Composable
+fun TtsControlBar(
+    state: TtsUiState,
+    onPlayPause: () -> Unit = {},
+    onPrevious: () -> Unit = {},
+    onNext: () -> Unit = {},
+    onStop: () -> Unit = {},
+    onSpeed: () -> Unit = {},
+    onVoice: () -> Unit = {},
+    onInstallVoice: () -> Unit = {},
+    onSystemTts: () -> Unit = {},
+) {
+    val c = VReaderColors
+    val rule = Color(0x14000000)
+    Column(
+        Modifier.fillMaxWidth().background(c.Background).testTag("tts-bar"),
+    ) {
+        // progress line
+        Box(Modifier.fillMaxWidth().height(3.dp).background(rule)) {
+            if (state.phase != TtsPhase.error) {
+                Box(Modifier.fillMaxWidth(state.progressFraction.coerceIn(0f, 1f)).height(3.dp).background(c.Accent))
+            }
+        }
+        if (state.phase == TtsPhase.error) ErrorLayout(state, onInstallVoice, onSystemTts)
+        else TransportLayout(state, onPlayPause, onPrevious, onNext, onStop, onSpeed, onVoice)
+    }
+}
+
+@Composable
+private fun TransportLayout(
+    state: TtsUiState, onPlayPause: () -> Unit, onPrevious: () -> Unit, onNext: () -> Unit,
+    onStop: () -> Unit, onSpeed: () -> Unit, onVoice: () -> Unit,
+) {
+    val c = VReaderColors
+    val playing = state.phase == TtsPhase.speaking
+    Column(Modifier.fillMaxWidth().padding(start = 18.dp, end = 18.dp, top = 11.dp, bottom = 12.dp)) {
+        // status row
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text(
+                when (state.phase) { TtsPhase.idle -> "READY TO READ ALOUD"; TtsPhase.speaking -> "READING ALOUD"; else -> "PAUSED" },
+                color = if (playing) c.Accent else c.InkMuted, fontFamily = VReaderFonts.Sans,
+                fontSize = 12.5.sp, fontWeight = FontWeight.SemiBold,
+            )
+            if (state.sentenceCount > 0) {
+                Text("${state.sentenceIndex + 1} / ${state.sentenceCount}", color = c.InkMuted, fontFamily = VReaderFonts.Sans, fontSize = 12.5.sp)
+            }
+        }
+        // transport row
+        Row(Modifier.fillMaxWidth().padding(top = 6.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
+            Chip(state.rateLabel, c.ChipFill, c.Ink, onSpeed, "tts-speed")
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                IconBtn(Icons.Filled.SkipPrevious, "Previous sentence", c.Ink, onPrevious, "tts-prev")
+                Box(
+                    Modifier.size(60.dp).clip(CircleShape).background(c.Accent)
+                        .clickable(onClickLabel = if (playing) "Pause" else "Play", onClick = onPlayPause).testTag("tts-playpause"),
+                    contentAlignment = Alignment.Center,
+                ) { Icon(if (playing) Icons.Filled.Pause else Icons.Filled.PlayArrow, contentDescription = null, tint = Color.White, modifier = Modifier.size(30.dp)) }
+                IconBtn(Icons.Filled.SkipNext, "Next sentence", c.Ink, onNext, "tts-next")
+            }
+            IconBtn(Icons.Filled.Close, "Stop read-aloud", c.Ink, onStop, "tts-stop")
+        }
+        // voice/engine chip (constrained so a long label ellipsizes instead of overflowing)
+        Row(Modifier.fillMaxWidth().padding(top = 10.dp), horizontalArrangement = Arrangement.Center) {
+            Chip(state.voiceLabel.ifBlank { state.engineLabel.ifBlank { "Voice" } }, c.ChipFill, c.Ink, onVoice, "tts-voice", Modifier.widthIn(max = 240.dp))
+        }
+    }
+}
+
+@Composable
+private fun ErrorLayout(state: TtsUiState, onInstallVoice: () -> Unit, onSystemTts: () -> Unit) {
+    val c = VReaderColors
+    Column(Modifier.fillMaxWidth().padding(18.dp).testTag("tts-error")) {
+        Text(
+            when (state.error) {
+                TtsErrorKind.noVoiceData, TtsErrorKind.languageNotSupported -> "No voice for this language"
+                TtsErrorKind.initFailed -> "Text-to-speech is unavailable"
+                else -> "Read-aloud failed"
+            },
+            color = c.Ink, fontFamily = VReaderFonts.Sans, fontSize = 14.5.sp, fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            "The on-device speech engine has no voice data installed for this language.",
+            color = c.InkMuted, fontFamily = VReaderFonts.Sans, fontSize = 13.sp, modifier = Modifier.padding(top = 2.dp),
+        )
+        Row(Modifier.fillMaxWidth().padding(top = 13.dp), horizontalArrangement = Arrangement.spacedBy(9.dp)) {
+            Box(
+                Modifier.weight(1f).clip(RoundedCornerShape(11.dp)).background(c.Accent).clickable(onClick = onInstallVoice).testTag("tts-install-voice").padding(vertical = 11.dp),
+                contentAlignment = Alignment.Center,
+            ) { Text("Install voice data", color = Color.White, fontFamily = VReaderFonts.Sans, fontSize = 14.sp, fontWeight = FontWeight.SemiBold) }
+            Box(
+                Modifier.clip(RoundedCornerShape(11.dp)).background(c.ChipFill).clickable(onClick = onSystemTts).testTag("tts-system").padding(horizontal = 16.dp, vertical = 11.dp),
+                contentAlignment = Alignment.Center,
+            ) { Text("System TTS", color = c.Ink, fontFamily = VReaderFonts.Sans, fontSize = 14.sp) }
+        }
+    }
+}
+
+@Composable
+private fun Chip(label: String, bg: Color, fg: Color, onClick: () -> Unit, tag: String, modifier: Modifier = Modifier) {
+    Box(
+        modifier.clip(RoundedCornerShape(100.dp)).background(bg).clickable(onClick = onClick).testTag(tag).padding(horizontal = 12.dp, vertical = 7.dp),
+    ) { Text(label, color = fg, fontFamily = VReaderFonts.Sans, fontSize = 13.sp, fontWeight = FontWeight.Medium, maxLines = 1, overflow = TextOverflow.Ellipsis) }
+}
+
+@Composable
+private fun IconBtn(icon: androidx.compose.ui.graphics.vector.ImageVector, desc: String, tint: Color, onClick: () -> Unit, tag: String) {
+    // the action label lives on the clickable node; the icon is decorative.
+    Box(Modifier.size(40.dp).clip(CircleShape).clickable(onClickLabel = desc, onClick = onClick).testTag(tag), contentAlignment = Alignment.Center) {
+        Icon(icon, contentDescription = null, tint = tint, modifier = Modifier.size(26.dp))
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/tts/TtsSpeedSheet.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/tts/TtsSpeedSheet.kt
@@ -1,0 +1,64 @@
+// Purpose: feature #121 WI-4 (#110 Phase 3) — the speaking-rate sheet (design vreader-tts.jsx
+// `SpeedSheet`): the current rate large + preset pills (0.5×–2.0×). Reuses the backup AppSheet +
+// BackupTokens. Stateless: a pure function of the rate + callbacks.
+package com.vreader.app.tts
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.vreader.app.backup.AppSheet
+import com.vreader.app.backup.BackupFonts
+import com.vreader.app.backup.LocalBackupTokens
+import com.vreader.app.backup.VSpace
+import java.util.Locale
+
+private val PRESETS = listOf(0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f)
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun TtsSpeedSheet(rate: Float, onRate: (Float) -> Unit = {}, onDone: () -> Unit = {}) {
+    val t = LocalBackupTokens.current
+    AppSheet(
+        title = "Speaking rate",
+        leading = {},
+        trailing = {
+            Box(Modifier.clickable(onClick = onDone).testTag("speed-done"), contentAlignment = Alignment.CenterEnd) {
+                Text("Done", color = t.tint, fontFamily = BackupFonts.Sans, fontSize = 15.sp, fontWeight = FontWeight.SemiBold)
+            }
+        },
+    ) {
+        Column(Modifier.fillMaxWidth().padding(horizontal = 18.dp, vertical = 8.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(rateLabel(rate), color = t.tint, fontFamily = BackupFonts.Serif, fontSize = 40.sp, fontWeight = FontWeight.Bold, textAlign = TextAlign.Center, modifier = Modifier.testTag("speed-current"))
+            VSpace(18)
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally), verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+                PRESETS.forEach { p ->
+                    val on = kotlin.math.abs(p - rate) < 0.001f
+                    Box(
+                        Modifier.clip(RoundedCornerShape(100.dp)).background(if (on) t.tint else t.chipBg).clickable { onRate(p) }.testTag("speed-${rateLabel(p)}").padding(horizontal = 14.dp, vertical = 8.dp),
+                    ) { Text(rateLabel(p), color = if (on) Color.White else t.ink, fontFamily = BackupFonts.Sans, fontSize = 13.5.sp, fontWeight = if (on) FontWeight.Bold else FontWeight.Medium) }
+                }
+            }
+            VSpace(16)
+        }
+    }
+}
+
+private fun rateLabel(r: Float) = "${String.format(Locale.ROOT, "%.2f", r).trimEnd('0').trimEnd('.')}×"

--- a/android/app/src/main/kotlin/com/vreader/app/tts/TtsVoiceSheet.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/tts/TtsVoiceSheet.kt
@@ -1,0 +1,108 @@
+// Purpose: feature #121 WI-4 (#110 Phase 3) — the voice/engine sheet (design vreader-tts.jsx
+// `VoiceSheet`): the on-device engine list + the per-locale voice list (selected check / network /
+// not-installed → Download). Reuses the backup AppSheet/SettingsCard + BackupTokens. Stateless.
+package com.vreader.app.tts
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.vreader.app.backup.AppSheet
+import com.vreader.app.backup.BackupFonts
+import com.vreader.app.backup.GroupFooter
+import com.vreader.app.backup.GroupHeader
+import com.vreader.app.backup.LocalBackupTokens
+import com.vreader.app.backup.SettingsCard
+import com.vreader.app.backup.VSpace
+
+@Composable
+fun TtsVoiceSheet(
+    state: TtsVoiceListState,
+    onEngine: (TtsEngineOption) -> Unit = {},
+    onVoice: (TtsVoiceOption) -> Unit = {},
+    onInstall: (TtsVoiceOption) -> Unit = {},
+    onDone: () -> Unit = {},
+) {
+    val t = LocalBackupTokens.current
+    AppSheet(
+        title = "Voice",
+        leading = {},
+        trailing = {
+            Box(Modifier.clickable(onClick = onDone).testTag("voice-done")) {
+                Text("Done", color = t.tint, fontFamily = BackupFonts.Sans, fontSize = 15.sp, fontWeight = FontWeight.SemiBold)
+            }
+        },
+    ) {
+        Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp).padding(bottom = 28.dp)) {
+            if (state.engines.isNotEmpty()) {
+                GroupHeader("Engine")
+                SettingsCard {
+                    state.engines.forEachIndexed { i, e ->
+                        Row(
+                            Modifier.fillMaxWidth().heightIn(min = 52.dp).clickable { onEngine(e) }.testTag("engine-${e.id}").padding(horizontal = 14.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(e.label, color = t.ink, fontFamily = BackupFonts.Sans, fontSize = 15.5.sp, modifier = Modifier.weight(1f))
+                            if (e.id == state.selectedEngineId) Icon(Icons.Filled.Check, contentDescription = "Selected", tint = t.tint, modifier = Modifier.size(20.dp))
+                        }
+                        if (i < state.engines.lastIndex) Box(Modifier.fillMaxWidth().padding(start = 14.dp).height(0.5.dp).background(t.sep))
+                    }
+                }
+                GroupFooter("Engines are provided by Android. Add more in System settings → Text-to-speech.")
+                VSpace(18)
+            }
+            GroupHeader("Voices")
+            SettingsCard {
+                if (state.voices.isEmpty()) {
+                    Box(Modifier.fillMaxWidth().heightIn(min = 52.dp).padding(14.dp), contentAlignment = Alignment.CenterStart) {
+                        Text("No voices for this language", color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 14.sp)
+                    }
+                } else state.voices.forEachIndexed { i, v ->
+                    VoiceRow(v, selected = v.name == state.selectedVoiceName, onVoice = onVoice, onInstall = onInstall)
+                    if (i < state.voices.lastIndex) Box(Modifier.fillMaxWidth().padding(start = 14.dp).height(0.5.dp).background(t.sep))
+                }
+            }
+            GroupFooter("VReader follows the book's language when a matching voice is installed.")
+        }
+    }
+}
+
+@Composable
+private fun VoiceRow(v: TtsVoiceOption, selected: Boolean, onVoice: (TtsVoiceOption) -> Unit, onInstall: (TtsVoiceOption) -> Unit) {
+    val t = LocalBackupTokens.current
+    Row(
+        Modifier.fillMaxWidth().heightIn(min = 56.dp).clickable { if (v.notInstalled) onInstall(v) else onVoice(v) }.testTag("voice-${v.name}").padding(horizontal = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(v.label, color = t.ink, fontFamily = BackupFonts.Sans, fontSize = 15.5.sp, fontWeight = FontWeight.Medium, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            val sub = when { v.notInstalled -> "Not installed"; v.networkRequired -> "Network required"; else -> "On-device" }
+            Text(sub, color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 12.5.sp, modifier = Modifier.padding(top = 1.dp))
+        }
+        when {
+            v.notInstalled -> Icon(Icons.Filled.Download, contentDescription = "Download voice", tint = t.tint, modifier = Modifier.size(20.dp))
+            selected -> Icon(Icons.Filled.Check, contentDescription = "Selected", tint = t.tint, modifier = Modifier.size(20.dp))
+        }
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.8.7
-versionCode=46
+versionName=0.8.8
+versionCode=47


### PR DESCRIPTION
## Summary

WI-4 (behavioral) of feature #121 (Android TTS read-aloud) — the Compose UI, per design `vreader-tts.jsx`.

- **TtsControlBar** — the docked transport (`TtsBar`): progress line, status row, speed chip + prev/play-pause/next + close, voice/engine chip, and the **error layout** (no-voice-data → Install voice data + System TTS). Uses the reader's `VReaderColors`/`VReaderFonts`; chips ellipsize; a11y click labels on transport nodes.
- **TtsSpeedSheet** (rate display + centered preset pills) + **TtsVoiceSheet** (engine list + voice list with selected/network/not-installed→Download) — reuse the backup `AppSheet`/`SettingsCard` + `BackupTokens`. All stateless (pure function of state + callbacks).

Part of feature #121. (WI-5 = the TxtReader integration + acceptance.)

## Tests

7 instrumented Compose: control bar (speaking/paused/error states + transport callbacks + install/system CTAs + speed/voice chips), speed sheet (current + preset pick), voice sheet (engine/voice render + select + not-installed→install routing).

## Codex Audit

1 round, ship-as-is. 1 Medium (chip overflow → maxLines/ellipsis + max width), 2 Low (FlowRow centering, a11y click labels). Statelessness + routing confirmed correct.

Audit log: `.claude/codex-audits/feat-feature-121-wi-4-tts-control-bar-audit.md`

## Validation

- [x] 7 instrumented Compose tests green
- [x] Codex audit (1 round, ship-as-is)
- [x] Version bumped: android 0.8.7 → 0.8.8 (versionCode 47)