### PR TITLE
feat(#122 WI-2): reading-stats repository + time tracker + VM

### DIFF
--- a/.claude/codex-audits/feat-feature-122-wi-2-stats-tracker-audit.md
+++ b/.claude/codex-audits/feat-feature-122-wi-2-stats-tracker-audit.md
@@ -1,0 +1,38 @@
+---
+branch: feat/feature-122-wi-2-stats-tracker
+threadId: 019f0405-f122wi2
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-28
+---
+
+# Feature #122 WI-2 — Codex audit (reading-stats repository + tracker + VM)
+
+Files: `stats/ReadingStatsRepository.kt`, `stats/ReadingTimeTracker.kt`, `reader/TxtProgress.kt`,
+`stats/StatsViewModel.kt`, `stats/StatsUiState.kt`; tests `ReadingTimeTrackerTest` (7),
+`ReadingStatsRepositoryTest` (7), `StatsViewModelTest` (3), `TxtProgressTest` (5).
+
+## Round 1 — 1 High, 4 Medium, 1 Low (all fixed)
+
+| severity | issue | resolution |
+|---|---|---|
+| High | scalar `carryMillis` lost its wall-date → a pre-midnight fragment could bank to the wrong day across flushes | FIXED — redesigned to a per-LOCAL-DATE carry map; `flushLocked` splits the window into date segments and banks whole minutes per date, keeping each date's remainder. Removed the largest-remainder allocation (no longer needed). Regression `carryCrossingMidnightAcrossTwoFlushes_banksToCorrectDay` |
+| Medium | negative delta moved the accounted marks backward → replay on clock recovery | FIXED — `delta <= 0` returns BEFORE advancing (high-water preserved) |
+| Medium | idle dropped carry vs the "no time dropped" claim | FIXED — documented: idle gap + new session/book clear the sub-minute carry (negligible, explicit) |
+| Medium | window aggregates had no upper bound (future-dated rows counted) | FIXED — repo filters `date <= today` on all rows before aggregating |
+| Medium | daily-avg divided by active days, not window days | FIXED — bounded windows divide by `window.days`; all-time by active days |
+| Low | zero-duration segment could leave a remainder unrecorded | MOOT after the per-date-carry redesign (each segment banks its own floor; `splitByLocalDate` yields only positive segments) |
+
+## Round 2 — 1 Medium (fixed)
+
+| severity | issue | resolution |
+|---|---|---|
+| Medium | `bookTotalMinutes` (in-reader path) lacked the `date <= today` future bound the dashboard now has | FIXED — same `date <= today` filter |
+
+Round 2 confirmed: per-date carry preserves midnight provenance across flushes; `delta <= 0` preserves
+the high-water mark without replay; idle/new-session carry drops are explicit; bounded daily averages
+use the intended denominators; the future-row filter keeps legitimate today rows.
+
+## Summary
+
+1 High + 4 Medium + 1 Low (R1) + 1 Medium (R2), all fixed. 22 JVM/Robolectric tests green. **Verdict: ship-as-is.**

--- a/android/app/src/main/kotlin/com/vreader/app/reader/TxtProgress.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/TxtProgress.kt
@@ -1,0 +1,13 @@
+// Purpose: feature #122 WI-2 (#110 Phase 3) — a minimal TXT progress provider. The TXT reader has
+// chunks (not chapters) and no progress model; reading-stats' "time left in book" needs a 0..1
+// fraction. Pure: the top-visible char offset over the document's total length. No "left in chapter"
+// for TXT (no chapter index).
+package com.vreader.app.reader
+
+object TxtProgress {
+    /** Reading progress 0..1 = [firstVisibleCharOffset] / [textLength] (clamped). 0 for empty text. */
+    fun fraction(firstVisibleCharOffset: Int, textLength: Int): Float {
+        if (textLength <= 0) return 0f
+        return (firstVisibleCharOffset.toFloat() / textLength).coerceIn(0f, 1f)
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/stats/ReadingStatsRepository.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/stats/ReadingStatsRepository.kt
@@ -1,0 +1,97 @@
+// Purpose: feature #122 WI-2 (#110 Phase 3) — reading-stats aggregate policy over ReadingStatsDao +
+// LibraryRepository. Derives the dashboard (window totals, 14-day chart, per-book table with live
+// titles, a WINDOW-INDEPENDENT consecutive-day streak, daily average) from all daily_reading rows.
+// Date-string math uses java.time.LocalDate anchored on the injected DateClock.today() (deterministic).
+package com.vreader.app.stats
+
+import com.vreader.app.data.ReadingStatsDao
+import com.vreader.app.data.LibraryRepository
+import com.vreader.app.stats.clock.DateClock
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import java.time.LocalDate
+
+/** Dashboard time window. `days == null` = all-time. */
+enum class StatsWindow(val days: Int?) { today(1), d7(7), d30(30), d90(90), year(365), all(null) }
+
+data class DayMinutes(val date: String, val minutes: Int)
+data class BookStat(val bookKey: String, val title: String, val minutes: Int)
+data class DashboardData(
+    val windowMinutes: Int = 0,
+    val streakDays: Int = 0,
+    val dailyAvgMinutes: Int = 0,
+    val daily14: List<DayMinutes> = emptyList(),
+    val perBook: List<BookStat> = emptyList(),
+) {
+    val hasData: Boolean get() = windowMinutes > 0 || daily14.any { it.minutes > 0 } || perBook.isNotEmpty()
+}
+
+class ReadingStatsRepository(
+    private val dao: ReadingStatsDao,
+    private val library: LibraryRepository,
+    private val dateClock: DateClock,
+) {
+    suspend fun recordMinutes(bookKey: String, date: String, deltaMinutes: Int) {
+        if (deltaMinutes > 0) dao.addMinutes(date, bookKey, deltaMinutes)
+    }
+
+    suspend fun bookTotalMinutes(bookKey: String): Int {
+        val today = dateClock.today()   // exclude future-dated rows (clock skew), consistent with dashboard()
+        return dao.allRows().filter { it.bookKey == bookKey && it.date <= today }.sumOf { it.minutes }
+    }
+
+    /** Observe the dashboard for [window]. All rows are observed (daily_reading is small — one row per
+     *  day per book); the window scopes totals/chart/perBook in-memory, while the streak is all-time. */
+    fun dashboard(window: StatsWindow): Flow<DashboardData> =
+        combine(dao.observeRowsSince(ALL_FLOOR), library.observeLibrary()) { allRows, books ->
+            val today = LocalDate.parse(dateClock.today())
+            val todayStr = today.toString()
+            // exclude FUTURE-dated rows (clock skew / bad seed) from every aggregate.
+            val rows = allRows.filter { it.date <= todayStr }
+            val since = window.days?.let { today.minusDays((it - 1).toLong()).toString() }
+            val windowRows = if (since == null) rows else rows.filter { it.date >= since }
+
+            val windowMinutes = windowRows.sumOf { it.minutes }
+            // "Daily avg" = average per day OVER the window: bounded windows divide by the window's day
+            // span; all-time divides by the active-day count (no fixed span).
+            val denomDays = window.days ?: windowRows.map { it.date }.distinct().size
+            val dailyAvg = if (denomDays > 0) windowMinutes / denomDays else 0
+
+            val titles = books.associate { it.fingerprintKey to it.title }
+            val perBook = windowRows.groupBy { it.bookKey }
+                .mapNotNull { (key, rs) -> titles[key]?.let { BookStat(key, it, rs.sumOf { r -> r.minutes }) } }  // orphans omitted
+                .sortedByDescending { it.minutes }
+
+            DashboardData(
+                windowMinutes = windowMinutes,
+                streakDays = currentStreak(rows.map { it.date }.toSet(), today),  // WINDOW-INDEPENDENT
+                dailyAvgMinutes = dailyAvg,
+                daily14 = last14Days(rows, today),
+                perBook = perBook,
+            )
+        }
+
+    /** Consecutive active local days ending today (or yesterday if today is 0) — NOT window-scoped. */
+    internal fun currentStreak(activeDates: Set<String>, today: LocalDate): Int {
+        // anchor: today if active, else yesterday if active, else streak 0.
+        var day = when {
+            today.toString() in activeDates -> today
+            today.minusDays(1).toString() in activeDates -> today.minusDays(1)
+            else -> return 0
+        }
+        var streak = 0
+        while (day.toString() in activeDates) { streak++; day = day.minusDays(1) }
+        return streak
+    }
+
+    /** The last 14 local days (chronological), 0-filled for inactive days — the daily chart. */
+    internal fun last14Days(rows: List<com.vreader.app.data.DailyReadingEntity>, today: LocalDate): List<DayMinutes> {
+        val byDate = rows.groupBy { it.date }.mapValues { (_, rs) -> rs.sumOf { it.minutes } }
+        return (13 downTo 0).map { back ->
+            val d = today.minusDays(back.toLong()).toString()
+            DayMinutes(d, byDate[d] ?: 0)
+        }
+    }
+
+    private companion object { const val ALL_FLOOR = "0000-01-01" }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/stats/ReadingTimeTracker.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/stats/ReadingTimeTracker.kt
@@ -1,0 +1,86 @@
+// Purpose: feature #122 WI-2 (#110 Phase 3) — accumulates in-reader reading time into per-day/per-book
+// minutes. Idempotent state machine over a MONOTONIC ElapsedClock (durations) + a calendar DateClock
+// (local-date buckets): start switches/flushes the old book; flush banks whole minutes (carrying a
+// sub-minute remainder so none is lost), clamps an idle gap to 0, splits a midnight-crossing window
+// across local dates (largest-remainder so the per-day sum is exact), and advances the accounted marks
+// so a restart/repeat can never replay. Process-singleton (the reader VM is shorter-lived).
+package com.vreader.app.stats
+
+import com.vreader.app.stats.clock.DateClock
+import com.vreader.app.stats.clock.ElapsedClock
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class ReadingTimeTracker(
+    private val repo: ReadingStatsRepository,
+    private val elapsed: ElapsedClock,
+    private val dateClock: DateClock,
+    private val maxIdleMillis: Long = 5 * 60_000L,   // a gap longer than this banks 0 (backgrounded/idle)
+) {
+    private val mutex = Mutex()
+    private var activeBook: String? = null
+    private var lastAccountedElapsed = 0L
+    private var lastAccountedWall = 0L
+    private var sessionStartElapsed = 0L
+    // sub-minute reading time not yet banked, kept PER LOCAL DATE (provenance) — so a fragment from
+    // before midnight banks to the right day even across flushes. Cleared on a book switch / idle gap.
+    private val carryByDate = HashMap<String, Long>()
+
+    private val _sessionSeconds = MutableStateFlow(0L)
+    val sessionSeconds: StateFlow<Long> = _sessionSeconds.asStateFlow()
+
+    /** Begin (or switch to) a book. A different active book is flushed first. Idempotent for the same book. */
+    suspend fun start(bookKey: String) = mutex.withLock {
+        if (activeBook == bookKey) return@withLock
+        if (activeBook != null) flushLocked()
+        activeBook = bookKey
+        lastAccountedElapsed = elapsed.nowMillis()
+        lastAccountedWall = dateClock.nowEpochMillis()
+        sessionStartElapsed = lastAccountedElapsed
+        carryByDate.clear()                          // a new session/book starts fresh (sub-minute carry dropped)
+        _sessionSeconds.value = 0
+    }
+
+    /** Bank the time since the last accounting, then keep going (periodic flush). */
+    suspend fun flush() = mutex.withLock { flushLocked() }
+
+    /** Bank the time, then clear the active book. Idempotent (a second stop banks 0 and no-ops). */
+    suspend fun stop() = mutex.withLock {
+        flushLocked()
+        activeBook = null
+        _sessionSeconds.value = 0
+    }
+
+    /** Refresh the live session-time pill (call from a ticker). No banking. */
+    fun tickSessionSeconds() {
+        if (activeBook == null) return
+        _sessionSeconds.value = (elapsed.nowMillis() - sessionStartElapsed).coerceAtLeast(0) / 1000
+    }
+
+    // caller holds the mutex
+    private suspend fun flushLocked() {
+        val book = activeBook ?: return
+        val now = elapsed.nowMillis()
+        val delta = now - lastAccountedElapsed
+        // delta <= 0 = no time / a monotonic anomaly: do NOT move the marks backward (that would let a
+        // recovered clock replay the interval). Leave the high-water marks; bank nothing.
+        if (delta <= 0) return
+        val windowStart = lastAccountedWall
+        lastAccountedElapsed = now
+        lastAccountedWall += delta
+        if (delta > maxIdleMillis) { carryByDate.clear(); return }  // idle gap → bank nothing, drop sub-minute carry
+
+        // Add each local-date segment's millis to that DATE's carry, then bank whole minutes per date,
+        // keeping the per-date remainder. Each segment lies within one local date, so attribution is
+        // exact + a fragment before midnight banks to the right day even across flushes.
+        for (seg in dateClock.splitByLocalDate(windowStart, windowStart + delta)) {
+            val total = (carryByDate[seg.date] ?: 0L) + (seg.endMs - seg.startMs)
+            val minutes = (total / 60_000L).toInt()
+            carryByDate[seg.date] = total % 60_000L
+            if (minutes > 0) repo.recordMinutes(book, seg.date, minutes)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/stats/StatsUiState.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/stats/StatsUiState.kt
@@ -1,0 +1,18 @@
+// Purpose: feature #122 WI-2 (#110 Phase 3) — UI state for the stats dashboard + the in-reader
+// time-detail card. Stateless composables (WI-3) render a pure function of these.
+package com.vreader.app.stats
+
+/** The dashboard's state for the selected window. */
+data class DashboardUiState(
+    val window: StatsWindow = StatsWindow.d30,
+    val data: DashboardData = DashboardData(),
+    val loading: Boolean = true,
+)
+
+/** The in-reader time-detail card numbers (session pill uses [sessionSeconds] alone). */
+data class InReaderStats(
+    val sessionSeconds: Long = 0,
+    val bookTotalMinutes: Int = 0,
+    val timeLeftMinutes: Int = 0,
+    val pace: Int? = null,        // words per minute estimate, or null when unknown
+)

--- a/android/app/src/main/kotlin/com/vreader/app/stats/StatsViewModel.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/stats/StatsViewModel.kt
@@ -1,0 +1,52 @@
+// Purpose: feature #122 WI-2 (#110 Phase 3) — drives the stats dashboard (window-switchable) + exposes
+// the in-reader session-time + a suspend helper for the time-detail card. Over the repository + tracker.
+package com.vreader.app.stats
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StatsViewModel(
+    private val repo: ReadingStatsRepository,
+    private val tracker: ReadingTimeTracker,
+) : ViewModel() {
+
+    private val _window = MutableStateFlow(StatsWindow.d30)
+
+    val dashboard: StateFlow<DashboardUiState> =
+        _window.flatMapLatest { w -> repo.dashboard(w).map { DashboardUiState(w, it, loading = false) } }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), DashboardUiState())
+
+    /** The live in-reader session-time (seconds), from the tracker. */
+    val sessionSeconds: StateFlow<Long> = tracker.sessionSeconds
+
+    fun selectWindow(window: StatsWindow) { _window.value = window }
+
+    /**
+     * The time-detail card numbers for [bookKey] at reading [fraction] (0..1). The total reading-time
+     * estimate is the book's word count ÷ a fixed pace; "time left" scales by the remaining fraction.
+     */
+    suspend fun inReaderStats(bookKey: String, fraction: Float, wordCount: Int): InReaderStats {
+        val total = bookTotalMinutesSafe(bookKey)
+        val estTotalMin = if (wordCount > 0) (wordCount.toFloat() / WORDS_PER_MINUTE).toInt() else 0
+        val left = (estTotalMin * (1f - fraction).coerceIn(0f, 1f)).toInt()
+        return InReaderStats(
+            sessionSeconds = sessionSeconds.value,
+            bookTotalMinutes = total,
+            timeLeftMinutes = left,
+            pace = if (wordCount > 0) WORDS_PER_MINUTE else null,
+        )
+    }
+
+    private suspend fun bookTotalMinutesSafe(bookKey: String): Int =
+        runCatching { repo.bookTotalMinutes(bookKey) }.getOrDefault(0)
+
+    private companion object { const val WORDS_PER_MINUTE = 230 }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/TxtProgressTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/TxtProgressTest.kt
@@ -1,0 +1,13 @@
+package com.vreader.app.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Feature #122 WI-2 — TxtProgress.fraction edge cases. */
+class TxtProgressTest {
+    @Test fun emptyTextIsZero() = assertEquals(0f, TxtProgress.fraction(0, 0))
+    @Test fun start() = assertEquals(0f, TxtProgress.fraction(0, 1000))
+    @Test fun midway() = assertEquals(0.5f, TxtProgress.fraction(500, 1000))
+    @Test fun eofClampsToOne() = assertEquals(1f, TxtProgress.fraction(1200, 1000))
+    @Test fun negativeClampsToZero() = assertEquals(0f, TxtProgress.fraction(-5, 1000))
+}

--- a/android/app/src/test/kotlin/com/vreader/app/stats/ReadingStatsRepositoryTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/stats/ReadingStatsRepositoryTest.kt
@@ -1,0 +1,103 @@
+package com.vreader.app.stats
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.vreader.app.data.BookEntity
+import com.vreader.app.data.LibraryRepository
+import com.vreader.app.data.VReaderDatabase
+import com.vreader.app.stats.clock.DateClock
+import com.vreader.app.stats.clock.DateSegment
+import com.vreader.app.stats.clock.SystemDateClock
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.time.Clock
+import java.time.LocalDate
+import java.time.ZoneId
+
+/** Feature #122 WI-2 — ReadingStatsRepository: streak (window-independent), windows, per-book join, chart. */
+@RunWith(RobolectricTestRunner::class)
+class ReadingStatsRepositoryTest {
+    private class FixedDate(private val today: String) : DateClock {
+        private val d = SystemDateClock(Clock.systemUTC(), ZoneId.of("UTC"))
+        override fun today() = today
+        override fun nowEpochMillis() = 0L
+        override fun localDate(epochMillis: Long) = d.localDate(epochMillis)
+        override fun splitByLocalDate(s: Long, e: Long): List<DateSegment> = d.splitByLocalDate(s, e)
+    }
+
+    private lateinit var db: VReaderDatabase
+    private fun repo(today: String) =
+        ReadingStatsRepository(db.readingStatsDao(), LibraryRepository(db.bookDao(), db.readingPositionDao()), FixedDate(today))
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext(), VReaderDatabase::class.java)
+            .allowMainThreadQueries().build()
+    }
+    @After fun tearDown() = db.close()
+
+    private fun day(today: String, back: Int) = LocalDate.parse(today).minusDays(back.toLong()).toString()
+
+    // ── streak (pure helper) ────────────────────────────────────────
+    @Test fun streak_consecutiveEndingToday() {
+        val r = repo("2026-06-27")
+        val dates = setOf("2026-06-27", "2026-06-26", "2026-06-25")
+        assertEquals(3, r.currentStreak(dates, LocalDate.parse("2026-06-27")))
+    }
+
+    @Test fun streak_todayZeroButYesterdayActive() {
+        val r = repo("2026-06-27")
+        val dates = setOf("2026-06-26", "2026-06-25")   // today not active
+        assertEquals(2, r.currentStreak(dates, LocalDate.parse("2026-06-27")))
+    }
+
+    @Test fun streak_brokenByGap() {
+        val r = repo("2026-06-27")
+        val dates = setOf("2026-06-27", "2026-06-25")   // 06-26 missing
+        assertEquals(1, r.currentStreak(dates, LocalDate.parse("2026-06-27")))
+    }
+
+    @Test fun streak_emptyIsZero() {
+        assertEquals(0, repo("2026-06-27").currentStreak(emptySet(), LocalDate.parse("2026-06-27")))
+    }
+
+    // ── dashboard (real Room) ──────────────────────────────────────
+    @Test fun dashboard_windowIndependentStreak_andWindowScopedTotals() = runBlocking {
+        val today = "2026-06-27"
+        val r = repo(today)
+        db.bookDao().upsert(book("b1", "Austen"))
+        // 30 consecutive active days, 5 min each
+        repeat(30) { back -> r.recordMinutes("b1", day(today, back), 5) }
+
+        val d7 = r.dashboard(StatsWindow.d7).first()
+        assertEquals(30, d7.streakDays)            // streak is ALL-TIME, not capped by the 7-day window
+        assertEquals(7 * 5, d7.windowMinutes)      // totals ARE window-scoped
+        assertEquals(14, d7.daily14.size)          // chart is always 14 days
+        assertEquals(listOf("Austen"), d7.perBook.map { it.title })
+    }
+
+    @Test fun dashboard_orphanStatsExcludedFromPerBook_butCountInTotals() = runBlocking {
+        val today = "2026-06-27"
+        val r = repo(today)
+        db.bookDao().upsert(book("b1", "Austen"))
+        r.recordMinutes("b1", today, 10)
+        r.recordMinutes("ghost", today, 4)         // no book row → orphan
+        val data = r.dashboard(StatsWindow.all).first()
+        assertEquals(14, data.windowMinutes)       // orphan minutes still count
+        assertEquals(listOf("Austen"), data.perBook.map { it.title })  // but orphan omitted from the table
+    }
+
+    @Test fun dashboard_noData() = runBlocking {
+        val data = repo("2026-06-27").dashboard(StatsWindow.d30).first()
+        assertEquals(0, data.windowMinutes)
+        assertEquals(false, data.hasData)
+    }
+
+    private fun book(key: String, title: String) =
+        BookEntity(key, title, "txt", "h", 1L, null, null, 0L, null)
+}

--- a/android/app/src/test/kotlin/com/vreader/app/stats/ReadingTimeTrackerTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/stats/ReadingTimeTrackerTest.kt
@@ -1,0 +1,120 @@
+package com.vreader.app.stats
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.vreader.app.data.LibraryRepository
+import com.vreader.app.data.VReaderDatabase
+import com.vreader.app.stats.clock.DateClock
+import com.vreader.app.stats.clock.DateSegment
+import com.vreader.app.stats.clock.ElapsedClock
+import com.vreader.app.stats.clock.SystemDateClock
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+
+/** Feature #122 WI-2 — ReadingTimeTracker accounting (carry, idle-cap, midnight split, no-replay,
+ *  book-switch, idempotent stop). Real repo + in-memory Room; fake monotonic + wall clocks. */
+@RunWith(RobolectricTestRunner::class)
+class ReadingTimeTrackerTest {
+    private class FakeElapsed(var ms: Long = 0) : ElapsedClock { override fun nowMillis() = ms }
+    private class FakeDate(var wallMs: Long, zone: ZoneId = ZoneId.of("UTC")) : DateClock {
+        private val d = SystemDateClock(Clock.systemUTC(), zone)  // splitByLocalDate/localDate take explicit ms
+        override fun today() = d.localDate(wallMs)
+        override fun nowEpochMillis() = wallMs
+        override fun localDate(epochMillis: Long) = d.localDate(epochMillis)
+        override fun splitByLocalDate(startInclusiveMs: Long, endExclusiveMs: Long): List<DateSegment> =
+            d.splitByLocalDate(startInclusiveMs, endExclusiveMs)
+    }
+
+    private lateinit var db: VReaderDatabase
+    private lateinit var repo: ReadingStatsRepository
+    private val elapsed = FakeElapsed()
+    private fun ms(iso: String) = Instant.parse(iso).toEpochMilli()
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext(), VReaderDatabase::class.java)
+            .allowMainThreadQueries().build()
+        repo = ReadingStatsRepository(db.readingStatsDao(), LibraryRepository(db.bookDao(), db.readingPositionDao()),
+            FakeDate(ms("2026-06-27T10:00:00Z")))
+    }
+    @After fun tearDown() = db.close()
+
+    private fun tracker(wall: String) = ReadingTimeTracker(repo, elapsed, FakeDate(ms(wall)))
+    private suspend fun minutesOn(date: String) = db.readingStatsDao().rowsSince(date).filter { it.date == date }.sumOf { it.minutes }
+
+    @Test fun accumulatesWholeMinutes_carryingRemainder() = runBlocking {
+        val t = tracker("2026-06-27T10:00:00Z")
+        elapsed.ms = 1_000
+        t.start("b1")
+        elapsed.ms = 1_000 + 70_000          // 70s → 1 min banked, 10s carried
+        t.flush()
+        assertEquals(1, minutesOn("2026-06-27"))
+        elapsed.ms += 55_000                  // carry 10s + 55s = 65s → +1 min, 5s carried
+        t.flush()
+        assertEquals(2, minutesOn("2026-06-27"))
+    }
+
+    @Test fun idleGapBanksZero() = runBlocking {
+        val t = tracker("2026-06-27T10:00:00Z")
+        t.start("b1")
+        elapsed.ms += 10 * 60_000             // 10 min > 5 min idle cap
+        t.flush()
+        assertEquals(0, minutesOn("2026-06-27"))
+    }
+
+    @Test fun midnightCrossing_splitsAcrossDays_sumExact() = runBlocking {
+        val t = tracker("2026-06-27T23:58:00Z")  // start near midnight
+        t.start("b1")
+        elapsed.ms += 4 * 60_000              // 4 minutes, crossing into 06-28
+        t.flush()
+        val total = minutesOn("2026-06-27") + minutesOn("2026-06-28")
+        assertEquals(4, total)               // no minute lost or duplicated across the boundary
+        assertEquals(true, minutesOn("2026-06-28") > 0)  // some banked to the new day
+    }
+
+    @Test fun carryCrossingMidnightAcrossTwoFlushes_banksToCorrectDay() = runBlocking {
+        // pre-midnight active time must bank to the PRE-midnight day even when the minute completes in
+        // a later flush past midnight (the per-date-carry provenance fix).
+        val t = tracker("2026-06-27T23:59:00Z")
+        t.start("b1")
+        elapsed.ms += 50_000                  // → 23:59:50, 50s carried on 2026-06-27
+        t.flush()
+        assertEquals(0, minutesOn("2026-06-27"))
+        elapsed.ms += 20_000                  // → 00:00:10: 10s on 06-27 (completes the minute) + 10s on 06-28
+        t.flush()
+        assertEquals(1, minutesOn("2026-06-27"))   // the carried pre-midnight time banks to 06-27
+        assertEquals(0, minutesOn("2026-06-28"))   // only 10s on 06-28 — sub-minute, still carried
+    }
+
+    @Test fun reFlushDoesNotReplay() = runBlocking {
+        val t = tracker("2026-06-27T10:00:00Z")
+        t.start("b1")
+        elapsed.ms += 120_000                 // 2 min
+        t.flush(); t.flush(); t.flush()       // extra flushes with delta 0
+        assertEquals(2, minutesOn("2026-06-27"))
+    }
+
+    @Test fun bookSwitch_flushesPreviousBook() = runBlocking {
+        val t = tracker("2026-06-27T10:00:00Z")
+        t.start("b1")
+        elapsed.ms += 180_000                 // 3 min on b1
+        t.start("b2")                         // switch flushes b1
+        assertEquals(3, db.readingStatsDao().allRows().single { it.bookKey == "b1" }.minutes)
+    }
+
+    @Test fun stopIsIdempotent() = runBlocking {
+        val t = tracker("2026-06-27T10:00:00Z")
+        t.start("b1")
+        elapsed.ms += 120_000
+        t.stop()
+        t.stop()                              // second stop: no active book → no-op
+        assertEquals(2, minutesOn("2026-06-27"))
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/stats/StatsViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/stats/StatsViewModelTest.kt
@@ -1,0 +1,72 @@
+package com.vreader.app.stats
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.vreader.app.data.LibraryRepository
+import com.vreader.app.data.VReaderDatabase
+import com.vreader.app.stats.clock.DateClock
+import com.vreader.app.stats.clock.DateSegment
+import com.vreader.app.stats.clock.ElapsedClock
+import com.vreader.app.stats.clock.SystemDateClock
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.time.Clock
+import java.time.ZoneId
+
+/** Feature #122 WI-2 — StatsViewModel.inReaderStats math (the VM's unique logic; the dashboard flow is
+ *  covered by ReadingStatsRepositoryTest). */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class StatsViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private class FixedDate(private val today: String) : DateClock {
+        private val d = SystemDateClock(Clock.systemUTC(), ZoneId.of("UTC"))
+        override fun today() = today
+        override fun nowEpochMillis() = 0L
+        override fun localDate(epochMillis: Long) = d.localDate(epochMillis)
+        override fun splitByLocalDate(s: Long, e: Long): List<DateSegment> = d.splitByLocalDate(s, e)
+    }
+    private lateinit var db: VReaderDatabase
+    private lateinit var repo: ReadingStatsRepository
+    private lateinit var vm: StatsViewModel
+
+    @Before fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        db = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext(), VReaderDatabase::class.java)
+            .allowMainThreadQueries().build()
+        repo = ReadingStatsRepository(db.readingStatsDao(), LibraryRepository(db.bookDao(), db.readingPositionDao()), FixedDate("2026-06-27"))
+        val tracker = ReadingTimeTracker(repo, ElapsedClock { 0 }, FixedDate("2026-06-27"))
+        vm = StatsViewModel(repo, tracker)
+    }
+    @After fun tearDown() { Dispatchers.resetMain(); db.close() }
+
+    @Test fun inReaderStats_computesLeftTotalAndPace() = runTest(dispatcher) {
+        repo.recordMinutes("b1", "2026-06-27", 30)
+        // 46000 words / 230 wpm = 200 min total; at 50% read → 100 min left
+        val s = vm.inReaderStats("b1", fraction = 0.5f, wordCount = 46_000)
+        assertEquals(30, s.bookTotalMinutes)
+        assertEquals(100, s.timeLeftMinutes)
+        assertEquals(230, s.pace)
+    }
+
+    @Test fun inReaderStats_zeroWordCount_noPaceNoLeft() = runTest(dispatcher) {
+        val s = vm.inReaderStats("b1", fraction = 0.0f, wordCount = 0)
+        assertEquals(0, s.timeLeftMinutes)
+        assertNull(s.pace)
+    }
+
+    @Test fun selectWindow_doesNotCrash() = runTest(dispatcher) {
+        vm.selectWindow(StatsWindow.year)   // window-scoped totals are covered by ReadingStatsRepositoryTest
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.9.1
-versionCode=49
+versionName=0.9.2
+versionCode=50


### PR DESCRIPTION
## Summary

WI-2 (behavioral) of feature #122 (Android reading-stats) — the aggregate policy + the time tracker + the ViewModel.

- **ReadingStatsRepository** — `dashboard(window)` over all `daily_reading` rows + the library: window-scoped totals / 14-day chart / per-book table (live-title join, orphans omitted), a **window-independent** consecutive-day streak, daily-avg (window-days for bounded, active-days for all). Future-dated rows excluded everywhere.
- **ReadingTimeTracker** — an idempotent monotonic state machine: **per-local-date carry** (no lost time + correct midnight provenance across flushes), idle-gap → bank 0, `delta<=0` preserves the high-water mark (no replay on clock recovery), book-switch flushes the old book, idempotent stop.
- **TxtProgress** (reading fraction) + **StatsViewModel** (window switch + `inReaderStats` math).

Part of feature #122. (WI-3 = the Compose pill/card + dashboard; WI-4 = reader hook + acceptance.)

## Tests

22 JVM/Robolectric: tracker (carry+remainder, idle-cap, midnight split, **carry-across-midnight-two-flushes**, no-replay, book-switch, idempotent stop), repo (streak consecutive/today-zero/gap/empty, window-independent-streak-with-window-totals, orphan-excluded, no-data), VM (`inReaderStats` math), TxtProgress.

## Codex Audit

2 rounds, ship-as-is. R1 (1H/4M/1L): carry lost wall-date across midnight (→ per-date carry redesign), negative-delta replay, idle-carry policy, future-row bound, daily-avg denominator, zero-duration segment. R2 (1M): `bookTotalMinutes` future bound. All fixed.

Audit log: `.claude/codex-audits/feat-feature-122-wi-2-stats-tracker-audit.md`

## Validation

- [x] 22 JVM/Robolectric tests green
- [x] Codex audit (2 rounds, ship-as-is)
- [x] Version bumped: android 0.9.1 → 0.9.2 (versionCode 50)