### PR TITLE
feat(#122 WI-3): reading-stats Compose surfaces

### DIFF
--- a/.claude/codex-audits/feat-feature-122-wi-3-stats-ui-audit.md
+++ b/.claude/codex-audits/feat-feature-122-wi-3-stats-ui-audit.md
@@ -1,0 +1,27 @@
+---
+branch: feat/feature-122-wi-3-stats-ui
+threadId: 019f0405-f122wi3
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-28
+---
+
+# Feature #122 WI-3 — Codex audit (reading-stats Compose surfaces)
+
+Files: `stats/InReaderTimePill.kt` (session pill + detail card), `stats/StatsDashboard.kt` (window bar +
+hero + 14-day chart + per-book table); instrumented `StatsUiTest` (4).
+
+## Round 1 — 2 Medium, 1 Low (all fixed)
+
+| file | severity | issue | resolution |
+|---|---|---|---|
+| StatsDashboard DailyChart | Medium | empty `daily14` (no-data/initial state) lost the designed 14-day frame/baseline | FIXED — normalize to 14 slots (pad zeros when empty), last slot = today |
+| StatsDashboard PerBookTable | Medium | the time hairline was broken (`height(3).padding(top=7)` left no usable height; no track behind the fill) | FIXED — `padding(top=7).height(3)` on a full-width clipped track + a clamped-fraction filled child |
+| StatsDashboard chart/table | Low | fractions didn't clamp negative inputs (stateless UI callable directly) | FIXED — `coerceAtLeast(0)` on minutes + `coerceIn(0f,1f)` on fractions |
+
+Codex confirmed `formatClock`/`formatMinutes` are correct for zero/negative/`<1h`/`h>0`/large, and that
+`today == lastIndex` holds (the repo returns 14 chronological days ending today).
+
+## Summary
+
+2 Medium + 1 Low, all fixed; 4 instrumented Compose tests green on emulator-5554. **Verdict: ship-as-is.**

--- a/android/app/src/androidTest/kotlin/com/vreader/app/stats/StatsUiTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/stats/StatsUiTest.kt
@@ -1,0 +1,61 @@
+package com.vreader.app.stats
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.vreader.app.backup.BackupSurface
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Feature #122 WI-3 — the in-reader pill/card + the dashboard (populated + no-data). */
+@RunWith(AndroidJUnit4::class)
+class StatsUiTest {
+    @get:Rule val compose = createComposeRule()
+
+    @Test fun sessionPill_formatsClock() {
+        compose.setContent { com.vreader.app.ui.theme.VReaderTheme { InReaderSessionPill(sessionSeconds = 1448) } }
+        compose.onNodeWithTag("stats-session-pill").assertIsDisplayed()
+        compose.onNodeWithText("24:08").assertIsDisplayed()   // 1448s = 24:08
+    }
+
+    @Test fun detailCard_showsStats() {
+        compose.setContent {
+            com.vreader.app.ui.theme.VReaderTheme {
+                InReaderTimeDetailCard(InReaderStats(sessionSeconds = 1440, bookTotalMinutes = 738, timeLeftMinutes = 580, pace = 230), bookTitle = "Pride and Prejudice", progressPercent = 42)
+            }
+        }
+        compose.onNodeWithText("Pride and Prejudice").assertIsDisplayed()
+        compose.onNodeWithText("12h 18m").assertIsDisplayed()   // 738 min total
+        compose.onNodeWithText("230 wpm").assertIsDisplayed()
+    }
+
+    @Test fun dashboard_populated_showsHeroChartTable_andWindowSwitch() {
+        val data = DashboardData(
+            windowMinutes = 2472, streakDays = 9, dailyAvgMinutes = 82,
+            daily14 = (0 until 14).map { DayMinutes("2026-06-${it + 14}", (it * 5) % 60) },
+            perBook = listOf(BookStat("b1", "Pride and Prejudice", 738), BookStat("b2", "Walden", 242)),
+        )
+        var picked: StatsWindow? = null
+        compose.setContent { BackupSurface(darkOverride = false) { StatsDashboard(DashboardUiState(StatsWindow.d30, data, false), onWindow = { picked = it }) } }
+        compose.onNodeWithTag("stats-hero-total").assertIsDisplayed()
+        compose.onNodeWithText("41h 12m").assertIsDisplayed()       // 2472 min
+        compose.onNodeWithText("9 days").assertIsDisplayed()        // streak
+        compose.onNodeWithTag("stats-daily-chart").assertIsDisplayed()
+        compose.onNodeWithText("Pride and Prejudice").performScrollTo().assertIsDisplayed()
+        compose.onNodeWithTag("window-7d").performClick()
+        assertEquals(StatsWindow.d7, picked)
+    }
+
+    @Test fun dashboard_noData_keepsFrames() {
+        compose.setContent { BackupSurface(darkOverride = false) { StatsDashboard(DashboardUiState(StatsWindow.d30, DashboardData(), false)) } }
+        compose.onNodeWithTag("stats-nodata").assertIsDisplayed()           // hero nudge
+        compose.onNodeWithTag("stats-daily-chart").assertIsDisplayed()      // chart frame kept
+        compose.onNodeWithTag("stats-perbook-empty").performScrollTo().assertIsDisplayed()
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/stats/InReaderTimePill.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/stats/InReaderTimePill.kt
@@ -1,0 +1,87 @@
+// Purpose: feature #122 WI-3 (#110 Phase 3) — the in-reader reading-time surfaces (design
+// vreader-stats-android.jsx `InReaderTime`): a glassy session pill (auto-fade is the host's concern)
+// + the time-detail card (session · book total · left · pace). Uses the reader's VReaderColors/
+// VReaderFonts. Stateless: pure functions of the inputs.
+package com.vreader.app.stats
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.vreader.app.ui.theme.VReaderColors
+import com.vreader.app.ui.theme.VReaderFonts
+import java.util.Locale
+
+/** The session pill: timer glyph + MM:SS + "this session". The host (#122 WI-4) handles auto-fade. */
+@Composable
+fun InReaderSessionPill(sessionSeconds: Long, modifier: Modifier = Modifier) {
+    val c = VReaderColors
+    Row(
+        modifier.clip(RoundedCornerShape(100.dp)).background(c.Surface).padding(horizontal = 13.dp, vertical = 7.dp).testTag("stats-session-pill"),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(Icons.Filled.Schedule, contentDescription = null, tint = c.Accent, modifier = Modifier.size(15.dp))
+        Text(formatClock(sessionSeconds), color = c.Ink, fontFamily = VReaderFonts.Sans, fontSize = 12.5.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.padding(start = 7.dp))
+        Text("this session", color = c.InkMuted, fontFamily = VReaderFonts.Sans, fontSize = 12.sp, modifier = Modifier.padding(start = 5.dp))
+    }
+}
+
+/** The time-detail card: book + progress + 4 stat cells + the pace line. */
+@Composable
+fun InReaderTimeDetailCard(stats: InReaderStats, bookTitle: String, progressPercent: Int, modifier: Modifier = Modifier) {
+    val c = VReaderColors
+    Column(
+        modifier.fillMaxWidth().clip(RoundedCornerShape(16.dp)).background(c.Surface).padding(16.dp).testTag("stats-detail-card"),
+    ) {
+        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            Text(bookTitle, color = c.Ink, fontFamily = VReaderFonts.Serif, fontSize = 16.sp, modifier = Modifier.weight(1f))
+            Text("$progressPercent%", color = c.InkMuted, fontFamily = VReaderFonts.Sans, fontSize = 12.sp)
+        }
+        Row(Modifier.fillMaxWidth().padding(top = 12.dp)) {
+            Cell("This session", formatClock(stats.sessionSeconds), Modifier.weight(1f))
+            Cell("Total in book", formatMinutes(stats.bookTotalMinutes), Modifier.weight(1f))
+        }
+        Row(Modifier.fillMaxWidth().padding(top = 12.dp)) {
+            Cell("Left in book", "~" + formatMinutes(stats.timeLeftMinutes), Modifier.weight(1f))
+            Cell("Pace", stats.pace?.let { "$it wpm" } ?: "—", Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+private fun Cell(label: String, value: String, modifier: Modifier) {
+    val c = VReaderColors
+    Column(modifier) {
+        Text(label, color = c.InkMuted, fontFamily = VReaderFonts.Sans, fontSize = 11.5.sp)
+        Text(value, color = c.Ink, fontFamily = VReaderFonts.Serif, fontSize = 20.sp, fontWeight = FontWeight.Bold, modifier = Modifier.padding(top = 1.dp))
+    }
+}
+
+internal fun formatClock(totalSeconds: Long): String {
+    val s = totalSeconds.coerceAtLeast(0)
+    val h = s / 3600; val m = (s % 3600) / 60; val sec = s % 60
+    return if (h > 0) String.format(Locale.ROOT, "%d:%02d:%02d", h, m, sec) else String.format(Locale.ROOT, "%d:%02d", m, sec)
+}
+
+internal fun formatMinutes(minutes: Int): String {
+    val m = minutes.coerceAtLeast(0)
+    val h = m / 60; val rem = m % 60
+    return if (h > 0) "${h}h ${rem}m" else "${rem}m"
+}

--- a/android/app/src/main/kotlin/com/vreader/app/stats/StatsDashboard.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/stats/StatsDashboard.kt
@@ -1,0 +1,170 @@
+// Purpose: feature #122 WI-3 (#110 Phase 3) — the reading-stats dashboard (design
+// vreader-stats-android.jsx `StatsDashboard`): a time-window chip bar + an hour hero (streak +
+// daily-avg, or a no-data nudge) + a 14-day daily-reading column chart (today tinted) + a per-book
+// table (Time + Hl/Nt + a per-row time hairline). Reuses the backup AppSheet/SettingsCard +
+// BackupTokens. Stateless: a pure function of DashboardUiState + callbacks.
+package com.vreader.app.stats
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.vreader.app.backup.AppSheet
+import com.vreader.app.backup.BackupFonts
+import com.vreader.app.backup.LocalBackupTokens
+import com.vreader.app.backup.SettingsCard
+import com.vreader.app.backup.VSpace
+
+private val WINDOWS = listOf(
+    StatsWindow.today to "Today", StatsWindow.d7 to "7d", StatsWindow.d30 to "30d",
+    StatsWindow.d90 to "90d", StatsWindow.year to "Year", StatsWindow.all to "All",
+)
+
+@Composable
+fun StatsDashboard(state: DashboardUiState, onWindow: (StatsWindow) -> Unit = {}, onClose: () -> Unit = {}) {
+    val t = LocalBackupTokens.current
+    AppSheet(
+        title = "Reading Stats",
+        leading = {
+            Box(Modifier.clickable(onClick = onClose).testTag("stats-close")) {
+                Text("Close", color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 15.sp)
+            }
+        },
+        trailing = {},
+    ) {
+        Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp).padding(bottom = 28.dp)) {
+            WindowBar(state.window, onWindow)
+            VSpace(12)
+            Hero(state.data)
+            VSpace(12)
+            DailyChart(state.data.daily14)
+            VSpace(12)
+            PerBookTable(state.data.perBook)
+        }
+    }
+}
+
+@Composable
+private fun WindowBar(active: StatsWindow, onWindow: (StatsWindow) -> Unit) {
+    val t = LocalBackupTokens.current
+    Row(Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(7.dp)) {
+        WINDOWS.forEach { (w, label) ->
+            val on = w == active
+            Box(
+                Modifier.clip(RoundedCornerShape(100.dp)).background(if (on) t.ink else t.chipBg)
+                    .clickable { onWindow(w) }.testTag("window-$label").padding(horizontal = 14.dp, vertical = 7.dp),
+            ) { Text(label, color = if (on) t.bg else t.ink, fontFamily = BackupFonts.Sans, fontSize = 13.sp, fontWeight = if (on) FontWeight.Bold else FontWeight.Medium) }
+        }
+    }
+}
+
+@Composable
+private fun Hero(data: DashboardData) {
+    val t = LocalBackupTokens.current
+    SettingsCard {
+        Column(Modifier.fillMaxWidth().padding(17.dp)) {
+            Text("THIS WINDOW", color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
+            Text(if (data.hasData) formatMinutes(data.windowMinutes) else "0m", color = t.ink, fontFamily = BackupFonts.Serif, fontSize = 44.sp, fontWeight = FontWeight.Bold, modifier = Modifier.padding(top = 4.dp).testTag("stats-hero-total"))
+            if (data.hasData) {
+                Row(Modifier.padding(top = 14.dp), horizontalArrangement = Arrangement.spacedBy(18.dp)) {
+                    HeroStat("${data.streakDays} days", "Streak")
+                    HeroStat(formatMinutes(data.dailyAvgMinutes), "Daily avg")
+                }
+            } else {
+                Text("Open a book to start tracking. Your reading time, streak, and per-book breakdown show up here.",
+                    color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 13.5.sp, lineHeight = 20.sp, modifier = Modifier.padding(top = 6.dp).testTag("stats-nodata"))
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeroStat(value: String, label: String) {
+    val t = LocalBackupTokens.current
+    Column {
+        Text(value, color = t.ink, fontFamily = BackupFonts.Serif, fontSize = 18.sp, fontWeight = FontWeight.Bold)
+        Text(label, color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 11.sp, modifier = Modifier.padding(top = 1.dp))
+    }
+}
+
+@Composable
+private fun DailyChart(days: List<DayMinutes>) {
+    val t = LocalBackupTokens.current
+    // always 14 slots so the no-data/initial state keeps the designed frame (the last slot = today).
+    val slots = when { days.size == 14 -> days; days.isEmpty() -> List(14) { DayMinutes("", 0) }; else -> days }
+    val max = (slots.maxOfOrNull { it.minutes.coerceAtLeast(0) } ?: 0).coerceAtLeast(1)
+    SettingsCard {
+        Column(Modifier.fillMaxWidth().padding(15.dp)) {
+            Text("Daily reading · last 14 days", color = t.ink, fontFamily = BackupFonts.Sans, fontSize = 13.sp, fontWeight = FontWeight.SemiBold)
+            Row(Modifier.fillMaxWidth().height(88.dp).padding(top = 12.dp).testTag("stats-daily-chart"), verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(5.dp)) {
+                slots.forEachIndexed { i, d ->
+                    val frac = (d.minutes.coerceAtLeast(0).toFloat() / max).coerceIn(0f, 1f)
+                    val isToday = i == slots.lastIndex
+                    Box(Modifier.weight(1f).fillMaxWidth()) {
+                        Box(
+                            Modifier.fillMaxWidth().height((84 * frac).dp.coerceAtLeast(2.dp))
+                                .clip(RoundedCornerShape(3.dp))
+                                .background(if (isToday) t.tint else t.tint.copy(alpha = 0.38f))
+                                .align(Alignment.BottomCenter),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PerBookTable(books: List<BookStat>) {
+    val t = LocalBackupTokens.current
+    SettingsCard {
+        Column(Modifier.fillMaxWidth().padding(horizontal = 15.dp, vertical = 13.dp)) {
+            Row(Modifier.fillMaxWidth().padding(bottom = 9.dp)) {
+                Text("BOOK", color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 11.5.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+                Text("TIME", color = t.tint, fontFamily = BackupFonts.Sans, fontSize = 11.5.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.width(70.dp))
+                Text("HL", color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 11.5.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.width(30.dp))
+                Text("NT", color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 11.5.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.width(30.dp))
+            }
+            if (books.isEmpty()) {
+                Text("No books opened yet", color = t.ter, fontFamily = BackupFonts.Sans, fontSize = 13.5.sp, modifier = Modifier.padding(vertical = 16.dp).testTag("stats-perbook-empty"))
+            } else {
+                val maxM = books.maxOf { it.minutes }.coerceAtLeast(1)
+                books.forEach { b ->
+                    Column(Modifier.fillMaxWidth().padding(vertical = 6.dp).testTag("book-${b.bookKey}")) {
+                        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                            Text(b.title, color = t.ink, fontFamily = BackupFonts.Serif, fontSize = 14.sp, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
+                            Text(formatMinutes(b.minutes), color = t.ink, fontFamily = BackupFonts.Sans, fontSize = 13.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.width(70.dp))
+                            Text("0", color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 13.sp, modifier = Modifier.width(30.dp))   // Hl — until #1801
+                            Text("0", color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 13.sp, modifier = Modifier.width(30.dp))   // Nt — until #1801
+                        }
+                        // full-width track (padding BEFORE height so the bar keeps its 3dp) + clamped fill
+                        Box(Modifier.fillMaxWidth().padding(top = 7.dp).height(3.dp).clip(RoundedCornerShape(2.dp)).background(t.sep)) {
+                            val frac = (b.minutes.coerceAtLeast(0).toFloat() / maxM).coerceIn(0f, 1f)
+                            Box(Modifier.fillMaxWidth(frac).height(3.dp).clip(RoundedCornerShape(2.dp)).background(t.tint.copy(alpha = 0.7f)))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.9.2
-versionCode=50
+versionName=0.9.3
+versionCode=51


### PR DESCRIPTION
## Summary

WI-3 (behavioral) of feature #122 (Android reading-stats) — the Compose UI, per design `vreader-stats-android.jsx`.

- **InReaderTimePill** — the glassy session pill (MM:SS + "this session") + the time-detail card (session · book total · left · pace). `VReaderColors`/`VReaderFonts`.
- **StatsDashboard** — `AppSheet`: time-window chip bar + hour hero (streak + daily-avg, or the no-data nudge) + 14-day daily chart (today tinted; keeps the 14-slot frame even when empty) + per-book table (Time + Hl/Nt[=0 until #1801] + a clamped per-row time hairline). `BackupTokens`.

Part of feature #122. (WI-4 = DI wiring + TxtReader hook + acceptance.)

## Tests

4 instrumented Compose: pill clock format (1448s → 24:08), detail card stats, dashboard populated (hero total/streak + chart + per-book + window switch), no-data keeps all module frames.

## Codex Audit

1 round, ship-as-is. 2 Medium (empty-chart lost its 14-day frame; per-book hairline broken — modifier order + missing track), 1 Low (negative-input clamp). All fixed. `formatClock`/`formatMinutes` confirmed correct.

Audit log: `.claude/codex-audits/feat-feature-122-wi-3-stats-ui-audit.md`

## Validation

- [x] 4 instrumented Compose tests green
- [x] Codex audit (1 round, ship-as-is)
- [x] Version bumped: android 0.9.2 → 0.9.3 (versionCode 51)