### PR TITLE
feat(#123): WI-2 annotations domain (color/anchor/records/repo)

### DIFF
--- a/.claude/codex-audits/feat-feature-123-wi-2-annotations-domain-audit.md
+++ b/.claude/codex-audits/feat-feature-123-wi-2-annotations-domain-audit.md
@@ -1,0 +1,38 @@
+---
+branch: feat/feature-123-wi-2-annotations-domain
+threadId: codex-exec-f123-wi2
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-28
+---
+
+# Feature #123 WI-2 (foundational) — annotations domain
+
+Adds `AnnotationColor` (5 colors), `AnnotationAnchor` (sealed Text/Epub + hash),
+the `HighlightRecord`/`NoteRecord`/`BookmarkRecord` DTOs + entity mappers +
+`profileKey`/`anchorKey` derivation, and `AnnotationsRepository` (DTO boundary)
++ the `AppContainer` DI singleton.
+
+## Round 1 — findings
+
+| # | file:line | severity | issue | resolution |
+|---|---|---|---|---|
+| 1 | AnnotationsRepository.addHighlight | **High** | On a dedupe the upsert keeps the EXISTING row's id, but `addHighlight` returned the freshly-generated (discarded) id — WI-3 callers would apply decorations/listeners against a dead highlightId. | FIXED — `AnnotationDao.upsertHighlight` now returns the PERSISTED entity (`findHighlightByKey(profileKey, anchorKey)` after insert-or-update); the repo returns `persisted.toRecordOrNull()`. New test asserts `second.id == first.id` and `findHighlight(second.id)` is live. |
+| 2 | AnnotationsRepository (all add*) | Medium | No `locator.fingerprintKey == bookKey` guard — a caller could file an annotation under one book with a locator pointing at another (poisons backup/restore; iOS rejects this). | FIXED — `requireSameBook(bookKey, locator)` = `require(locator.fingerprintKey == bookKey)` in addHighlight/addNote/addBookmark + a rejecting test. |
+| 3 | Annotation.kt / Entities.kt | Medium | Storage-contract inconsistency: mapper writes full `Locator` JSON but the entity doc/plan said `canonicalJson()`. | FIXED — Room stores the FULL round-trippable plain `Locator` (the position precedent); `profileKey` derives from `canonicalJson()` for cross-platform-stable dedup; the entity doc now states the #113 backup collector MUST convert to `record.locator.canonicalJson()` (don't copy verbatim). |
+
+## Round 2 — verify
+
+High + the two Medium confirmed resolved. One remaining Medium: stale inline
+comments still said "canonical" on the field + the note doc — **FIXED** (the
+`locatorJSON` field comment + the `AnnotationNoteEntity` doc now match the
+round-trippable-form contract). Zero open Critical/High/Medium.
+
+## Tests
+- `AnnotationColorTest` (5), `AnnotationAnchorTest` (6), `AnnotationsRepositoryTest` (12 incl. dedupe-returns-persisted-id + cross-book-rejected) — **SUCCEEDED** (Robolectric/JVM).
+- `AnnotationDaoTest` re-run green with the returning upsert.
+
+## Verdict
+**ship-as-is.** The dead-id dedupe bug (the one that would have bitten WI-3) is
+fixed and regression-tested; the book/locator guard mirrors iOS; the storage
+contract is documented consistently.

--- a/android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import com.vreader.app.data.BookImporter
 import com.vreader.app.data.LibraryRepository
 import com.vreader.app.data.VReaderDatabase
+import com.vreader.app.annotations.AnnotationsRepository
 import com.vreader.app.stats.ReadingStatsRepository
 import com.vreader.app.stats.ReadingTimeTracker
 import com.vreader.app.stats.clock.SystemDateClock
@@ -39,6 +40,12 @@ class AppContainer(context: Context) {
     }
     val readingTimeTracker: ReadingTimeTracker by lazy {
         ReadingTimeTracker(statsRepository, SystemElapsedClock(), dateClock)
+    }
+
+    // feature #123 — annotations (EPUB highlights & notes). Process-singleton so the reader VM /
+    // rotation share one instance (the statsRepository precedent).
+    val annotationsRepository: AnnotationsRepository by lazy {
+        AnnotationsRepository(database.annotationDao())
     }
 
     /** Process-lifetime scope for fire-and-forget writes that must outlive a screen

--- a/android/app/src/main/kotlin/com/vreader/app/annotations/Annotation.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/annotations/Annotation.kt
@@ -1,0 +1,132 @@
+// Purpose: feature #123 — the annotation DTOs crossing the repository boundary (the iOS
+// HighlightRecord/…Record analog; rule 50 §2: never return Room entities across a layer) + the
+// entity<->record mappers + the profileKey/anchorKey derivation.
+//
+// Storage contract:
+//  - `locatorJSON` stores the FULL serialized `Locator` (round-trippable, a PLAIN Locator — never a
+//    VReaderLocator envelope or Readium JSON; the position-precedent of storing the round-trippable
+//    form in Room). The #113 backup collector (deferred) converts it to `Locator.canonicalJson()`
+//    for the on-wire BackupHighlight.locatorJSON.
+//  - `profileKey = "$bookKey:${sha256(locator.canonicalJson())}"` — derived from the CANONICAL form
+//    so dedup is cross-platform-stable regardless of the stored round-trip form.
+//  - `anchorKey = anchor?.anchorHash ?: NIL_ANCHOR` — the non-null dedupe sentinel.
+package com.vreader.app.annotations
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import vreader.contracts.Locator
+import java.util.UUID
+
+const val NIL_ANCHOR = "__nil_anchor__"
+
+private val ANNOTATION_JSON = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+fun profileKeyFor(bookKey: String, locator: Locator): String =
+    "$bookKey:${AnnotationHashing.sha256Hex(locator.canonicalJson())}"
+
+fun anchorKeyFor(anchor: AnnotationAnchor?): String = anchor?.anchorHash ?: NIL_ANCHOR
+
+private fun Locator.toJson(): String = ANNOTATION_JSON.encodeToString(this)
+private fun locatorFromJson(json: String): Locator = ANNOTATION_JSON.decodeFromString(json)
+
+/** A highlight as the UI/repo sees it (the iOS `HighlightRecord` analog). */
+data class HighlightRecord(
+    val id: String,
+    val bookKey: String,
+    val color: AnnotationColor,
+    val selectedText: String,
+    val note: String?,
+    val locator: Locator,
+    val anchor: AnnotationAnchor?,
+    val createdAt: Long,
+    val updatedAt: Long,
+)
+
+data class NoteRecord(
+    val id: String,
+    val bookKey: String,
+    val content: String,
+    val locator: Locator,
+    val anchor: AnnotationAnchor?,
+    val createdAt: Long,
+    val updatedAt: Long,
+)
+
+data class BookmarkRecord(
+    val id: String,
+    val bookKey: String,
+    val title: String?,
+    val locator: Locator,
+    val createdAt: Long,
+    val updatedAt: Long,
+)
+
+// ---- record -> entity ----
+
+fun HighlightRecord.toEntity() = com.vreader.app.data.HighlightEntity(
+    highlightId = id,
+    bookKey = bookKey,
+    profileKey = profileKeyFor(bookKey, locator),
+    anchorKey = anchorKeyFor(anchor),
+    color = color.key,
+    selectedText = selectedText,
+    note = note,
+    locatorJSON = locator.toJson(),
+    anchorJSON = anchor?.let { AnnotationAnchor.encode(it) },
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+)
+
+fun NoteRecord.toEntity() = com.vreader.app.data.AnnotationNoteEntity(
+    noteId = id,
+    bookKey = bookKey,
+    profileKey = profileKeyFor(bookKey, locator),
+    content = content,
+    locatorJSON = locator.toJson(),
+    anchorJSON = anchor?.let { AnnotationAnchor.encode(it) },
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+)
+
+fun BookmarkRecord.toEntity() = com.vreader.app.data.BookmarkEntity(
+    bookmarkId = id,
+    bookKey = bookKey,
+    profileKey = profileKeyFor(bookKey, locator),
+    title = title,
+    locatorJSON = locator.toJson(),
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+)
+
+// ---- entity -> record (null when locatorJSON is corrupt — skip, don't crash) ----
+
+fun com.vreader.app.data.HighlightEntity.toRecordOrNull(): HighlightRecord? = runCatching {
+    HighlightRecord(
+        id = highlightId, bookKey = bookKey,
+        color = AnnotationColor.from(color) ?: AnnotationColor.DEFAULT,
+        selectedText = selectedText, note = note,
+        locator = locatorFromJson(locatorJSON),
+        anchor = AnnotationAnchor.decodeOrNull(anchorJSON),
+        createdAt = createdAt, updatedAt = updatedAt,
+    )
+}.getOrNull()
+
+fun com.vreader.app.data.AnnotationNoteEntity.toRecordOrNull(): NoteRecord? = runCatching {
+    NoteRecord(
+        id = noteId, bookKey = bookKey, content = content,
+        locator = locatorFromJson(locatorJSON),
+        anchor = AnnotationAnchor.decodeOrNull(anchorJSON),
+        createdAt = createdAt, updatedAt = updatedAt,
+    )
+}.getOrNull()
+
+fun com.vreader.app.data.BookmarkEntity.toRecordOrNull(): BookmarkRecord? = runCatching {
+    BookmarkRecord(
+        id = bookmarkId, bookKey = bookKey, title = title,
+        locator = locatorFromJson(locatorJSON),
+        createdAt = createdAt, updatedAt = updatedAt,
+    )
+}.getOrNull()
+
+/** A fresh UUID string id for a new annotation (iOS `UUID()` parity). */
+fun newAnnotationId(): String = UUID.randomUUID().toString()

--- a/android/app/src/main/kotlin/com/vreader/app/annotations/AnnotationAnchor.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/annotations/AnnotationAnchor.kt
@@ -1,0 +1,54 @@
+// Purpose: feature #123 — the engine-precise anchor for a highlight/note, serialized into the
+// entity's `anchorJSON` (the canonical `Locator` lives in `locatorJSON`). Mirrors the iOS
+// `AnnotationAnchor` field shape for cross-platform durability: a Text anchor (TXT/MD, #124) carries
+// `sourceUnitId` + UTF-16 range; an Epub anchor carries `href` + Readium `cfi` + an optional
+// serialized DOM range. `anchorHash` (SHA-256 of the canonical JSON) is the dedupe discriminant
+// (`anchorKey = anchorHash ?: "__nil_anchor__"`).
+package com.vreader.app.annotations
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.security.MessageDigest
+
+/** A serialized DOM range for an EPUB anchor (mirrors iOS `EPUBSerializedRange`). Null when Readium
+ *  exposes only a CFI (the CFI is then the durable anchor). */
+@Serializable
+data class EpubSerializedRange(
+    val startContainerPath: String,
+    val startOffset: Int,
+    val endContainerPath: String,
+    val endOffset: Int,
+)
+
+@Serializable
+sealed interface AnnotationAnchor {
+    @Serializable
+    @SerialName("text")
+    data class Text(val sourceUnitId: String, val startUTF16: Int, val endUTF16: Int) : AnnotationAnchor
+
+    @Serializable
+    @SerialName("epub")
+    data class Epub(val href: String, val cfi: String, val serializedRange: EpubSerializedRange? = null) : AnnotationAnchor
+
+    /** SHA-256 (hex) of the canonical JSON — the dedupe discriminant. Locally deterministic
+     *  (kotlinx fixed field order), the same basis as `VReaderLocator.canonicalHash`. */
+    val anchorHash: String
+        get() = AnnotationHashing.sha256Hex(CANONICAL_JSON.encodeToString(this))
+
+    companion object {
+        private val CANONICAL_JSON = Json { encodeDefaults = true; classDiscriminator = "kind" }
+
+        fun encode(anchor: AnnotationAnchor): String = CANONICAL_JSON.encodeToString(anchor)
+        fun decodeOrNull(json: String?): AnnotationAnchor? =
+            json?.let { runCatching { CANONICAL_JSON.decodeFromString<AnnotationAnchor>(it) }.getOrNull() }
+    }
+}
+
+/** Small SHA-256 hex helper shared by the annotation domain (profileKey + anchorKey derivation). */
+object AnnotationHashing {
+    fun sha256Hex(input: String): String =
+        MessageDigest.getInstance("SHA-256").digest(input.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/annotations/AnnotationColor.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/annotations/AnnotationColor.kt
@@ -1,0 +1,28 @@
+// Purpose: feature #123 (Android EPUB highlights & notes) — the highlight color palette.
+// The 5 colors are DESIGN parity (vreader-android-annotations.jsx HL_COLORS), NOT iOS-model parity:
+// iOS NamedHighlightColor has 4 (yellow/pink/green/blue, no red). Storage is the `key` string, so an
+// Android-only `red` highlight round-trips through the #113 backup as an unknown color on iOS rather
+// than corrupting data — `from()` is nil-tolerant for the same forward-compat reason.
+package com.vreader.app.annotations
+
+/** A highlight color. `key` is the stored, forward-compatible identifier; the hex triplet drives the
+ *  dot / text-wash / left-rule rendering (design `HL_COLORS`). */
+enum class AnnotationColor(val key: String, val dotHex: String, val washHex: String, val ruleHex: String) {
+    yellow("yellow", "#e6b800", "#47e6b800", "#d9a800"),
+    green("green", "#5a9a6e", "#425a9a6e", "#5a9a6e"),
+    blue("blue", "#5c8fc4", "#425c8fc4", "#5c8fc4"),
+    pink("pink", "#cf7a9a", "#42cf7a9a", "#cf7a9a"),
+    red("red", "#b5503f", "#3db5503f", "#b5503f"),
+    ;
+
+    companion object {
+        /** Parse a stored color string → the matching color, or null for an unknown value (graceful,
+         *  the iOS `NamedHighlightColor.from` analog). Callers default to [yellow] on null. */
+        fun from(storage: String?): AnnotationColor? = entries.firstOrNull { it.key == storage }
+
+        /** The palette order shown in the selection popover's color row. */
+        val palette: List<AnnotationColor> = entries.toList()
+
+        val DEFAULT: AnnotationColor = yellow
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/annotations/AnnotationsRepository.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/annotations/AnnotationsRepository.kt
@@ -1,0 +1,101 @@
+// Purpose: feature #123 — the annotation repository (the DTO boundary over AnnotationDao; rule 50 §2).
+// Process-singleton in AppContainer (the #122 statsRepository precedent). Exposes Flow reads mapping
+// entities -> records (corrupt rows skipped, not crashed) + suspend CRUD that creates records and
+// dedupes through the DAO's transactional upsert.
+package com.vreader.app.annotations
+
+import com.vreader.app.data.AnnotationDao
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import vreader.contracts.Locator
+
+class AnnotationsRepository(
+    private val dao: AnnotationDao,
+    private val now: () -> Long = { System.currentTimeMillis() },
+) {
+    // ---- highlights ----
+
+    fun highlights(bookKey: String): Flow<List<HighlightRecord>> =
+        dao.observeHighlights(bookKey).map { rows -> rows.mapNotNull { it.toRecordOrNull() } }
+
+    suspend fun highlightsForBook(bookKey: String): List<HighlightRecord> =
+        dao.highlightsForBook(bookKey).mapNotNull { it.toRecordOrNull() }
+
+    suspend fun allHighlights(): List<HighlightRecord> =
+        dao.allHighlights().mapNotNull { it.toRecordOrNull() }
+
+    /** Create (or, for a re-highlight of the same range, update) a highlight. Returns the record.
+     *  Dedupe is the DAO's transactional upsert on the unique (profileKey, anchorKey). */
+    suspend fun addHighlight(
+        bookKey: String,
+        color: AnnotationColor,
+        selectedText: String,
+        locator: Locator,
+        anchor: AnnotationAnchor?,
+        note: String? = null,
+    ): HighlightRecord {
+        requireSameBook(bookKey, locator)
+        val t = now()
+        val record = HighlightRecord(
+            id = newAnnotationId(), bookKey = bookKey, color = color, selectedText = selectedText,
+            note = note, locator = locator, anchor = anchor, createdAt = t, updatedAt = t,
+        )
+        // return the PERSISTED row: on a dedupe the upsert keeps the existing id, so the freshly
+        // generated id was never stored — returning it would hand callers a dead highlightId.
+        val persisted = dao.upsertHighlight(record.toEntity())
+        return persisted.toRecordOrNull() ?: record
+    }
+
+    suspend fun updateHighlight(id: String, color: AnnotationColor, note: String?) {
+        dao.updateHighlightColorNote(id, color.key, note, now())
+    }
+
+    suspend fun removeHighlight(id: String) = dao.deleteHighlight(id)
+
+    suspend fun findHighlight(id: String): HighlightRecord? = dao.findHighlight(id)?.toRecordOrNull()
+
+    // ---- standalone notes ----
+
+    fun notes(bookKey: String): Flow<List<NoteRecord>> =
+        dao.observeNotes(bookKey).map { rows -> rows.mapNotNull { it.toRecordOrNull() } }
+
+    suspend fun addNote(bookKey: String, content: String, locator: Locator, anchor: AnnotationAnchor? = null): NoteRecord {
+        requireSameBook(bookKey, locator)
+        val t = now()
+        val record = NoteRecord(
+            id = newAnnotationId(), bookKey = bookKey, content = content,
+            locator = locator, anchor = anchor, createdAt = t, updatedAt = t,
+        )
+        dao.upsertNote(record.toEntity())
+        return record
+    }
+
+    suspend fun removeNote(id: String) = dao.deleteNote(id)
+
+    // ---- bookmarks (schema wired; create/list UI is item F) ----
+
+    fun bookmarks(bookKey: String): Flow<List<BookmarkRecord>> =
+        dao.observeBookmarks(bookKey).map { rows -> rows.mapNotNull { it.toRecordOrNull() } }
+
+    suspend fun addBookmark(bookKey: String, title: String?, locator: Locator): BookmarkRecord {
+        requireSameBook(bookKey, locator)
+        val t = now()
+        val record = BookmarkRecord(
+            id = newAnnotationId(), bookKey = bookKey, title = title,
+            locator = locator, createdAt = t, updatedAt = t,
+        )
+        dao.upsertBookmark(record.toEntity())
+        return record
+    }
+
+    suspend fun removeBookmark(id: String) = dao.deleteBookmark(id)
+
+    suspend fun highlightCount(bookKey: String): Int = dao.highlightCount(bookKey)
+
+    /** An annotation's locator must belong to the same book it's filed under — else backup/export and
+     *  reader-restore assumptions are poisoned (the iOS persistence-boundary guard). */
+    private fun requireSameBook(bookKey: String, locator: Locator) =
+        require(locator.fingerprintKey == bookKey) {
+            "annotation locator (${locator.fingerprintKey}) does not match bookKey ($bookKey)"
+        }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/data/Daos.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/data/Daos.kt
@@ -116,8 +116,14 @@ abstract class AnnotationDao {
         updatedAt: Long,
     ): Int
 
+    @Query("SELECT * FROM highlights WHERE profileKey = :profileKey AND anchorKey = :anchorKey")
+    abstract suspend fun findHighlightByKey(profileKey: String, anchorKey: String): HighlightEntity?
+
+    /** Insert-or-update on the unique (profileKey, anchorKey), then return the PERSISTED row. On a
+     *  dedupe the persisted row keeps the EXISTING highlightId (the insert was ignored), so callers
+     *  must use the returned row's id — not the id of the entity they passed in (which was discarded). */
     @Transaction
-    open suspend fun upsertHighlight(highlight: HighlightEntity) {
+    open suspend fun upsertHighlight(highlight: HighlightEntity): HighlightEntity {
         val rowId = insertHighlightIfAbsent(highlight)
         if (rowId == -1L) {
             updateHighlightByKey(
@@ -125,6 +131,7 @@ abstract class AnnotationDao {
                 highlight.selectedText, highlight.locatorJSON, highlight.anchorJSON, highlight.updatedAt,
             )
         }
+        return findHighlightByKey(highlight.profileKey, highlight.anchorKey)!!
     }
 
     @Query("UPDATE highlights SET color = :color, note = :note, updatedAt = :updatedAt WHERE highlightId = :id")

--- a/android/app/src/main/kotlin/com/vreader/app/data/Entities.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/data/Entities.kt
@@ -73,13 +73,17 @@ data class DailyReadingEntity(
 
 /**
  * A text highlight — feature #123 (EPUB highlights & notes). Mirrors the iOS `Highlight` @Model.
- * `locatorJSON` is the canonical `vreader.contracts.Locator.canonicalJson()` (NOT a `VReaderLocator`
- * envelope or Readium JSON — the #113 backup contract requires plain `Locator`); the engine-precise
- * anchor (Readium CFI / TXT range) lives ONLY in `anchorJSON`. Dedupe is on the unique
- * `(profileKey, anchorKey)` — `profileKey = "$bookKey:${locator.canonicalHash}"`, `anchorKey` is the
- * NON-NULL `anchorHash ?: "__nil_anchor__"` sentinel (SQLite treats NULLs as distinct in a unique
- * index, so a nullable column would let repeated null-anchor highlights bypass dedupe — the sentinel
- * collapses them per `profileKey`, matching iOS's nil-anchor-by-profileKey dedupe).
+ * `locatorJSON` stores the FULL round-trippable `vreader.contracts.Locator` (the data-class JSON — a
+ * PLAIN `Locator`, NEVER a `VReaderLocator` envelope or Readium JSON), the position-precedent of
+ * keeping the round-trippable form in Room. **The #113 backup collector (deferred) MUST convert it to
+ * `record.locator.canonicalJson()` for the on-wire `BackupHighlight.locatorJSON` — do NOT copy this
+ * column verbatim into a backup.** The engine-precise anchor (Readium CFI / TXT range) lives ONLY in
+ * `anchorJSON`. Dedupe is on the unique `(profileKey, anchorKey)` — `profileKey =
+ * "$bookKey:${sha256(locator.canonicalJson())}"` (derived from the CANONICAL form so dedup is
+ * cross-platform-stable regardless of the stored round-trip form), `anchorKey` is the NON-NULL
+ * `anchorHash ?: "__nil_anchor__"` sentinel (SQLite treats NULLs as distinct in a unique index, so a
+ * nullable column would let repeated null-anchor highlights bypass dedupe — the sentinel collapses
+ * them per `profileKey`, matching iOS's nil-anchor-by-profileKey dedupe).
  */
 @Entity(
     tableName = "highlights",
@@ -101,7 +105,7 @@ data class HighlightEntity(
     val color: String,                     // AnnotationColor.key (yellow/green/blue/pink/red) or hex
     val selectedText: String,
     val note: String?,                     // optional inline note on the highlight
-    val locatorJSON: String,               // canonical Locator.canonicalJson()
+    val locatorJSON: String,               // full round-trippable plain Locator JSON (backup converts to canonicalJson)
     val anchorJSON: String?,               // serialized AnnotationAnchor (engine-precise)
     val createdAt: Long,
     val updatedAt: Long,
@@ -109,8 +113,9 @@ data class HighlightEntity(
 
 /**
  * A standalone note — feature #123. Mirrors the iOS `AnnotationNote` @Model (the design's
- * "STANDALONE" card). Same `locatorJSON` (canonical) + `anchorJSON` (precise) contract as
- * [HighlightEntity]. No range-dedupe (a reader may keep several notes at one spot).
+ * "STANDALONE" card). Same `locatorJSON` (full round-trippable plain Locator; backup converts to
+ * canonical) + `anchorJSON` (precise) contract as [HighlightEntity]. No range-dedupe (a reader may
+ * keep several notes at one spot).
  */
 @Entity(
     tableName = "annotation_notes",

--- a/android/app/src/test/kotlin/com/vreader/app/annotations/AnnotationAnchorTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/annotations/AnnotationAnchorTest.kt
@@ -1,0 +1,52 @@
+package com.vreader.app.annotations
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Feature #123 WI-2 — [AnnotationAnchor] serialization round-trip + hash stability. */
+class AnnotationAnchorTest {
+    @Test fun textAnchor_roundTrips() {
+        val a = AnnotationAnchor.Text(sourceUnitId = "chunk-12", startUTF16 = 40, endUTF16 = 55)
+        val decoded = AnnotationAnchor.decodeOrNull(AnnotationAnchor.encode(a))
+        assertEquals(a, decoded)
+    }
+
+    @Test fun epubAnchor_withRange_roundTrips() {
+        val a = AnnotationAnchor.Epub(
+            href = "chapter1.xhtml", cfi = "/4/2[p1]:3",
+            serializedRange = EpubSerializedRange("/4/2", 3, "/4/2", 18),
+        )
+        assertEquals(a, AnnotationAnchor.decodeOrNull(AnnotationAnchor.encode(a)))
+    }
+
+    @Test fun epubAnchor_nullRange_roundTrips() {
+        val a = AnnotationAnchor.Epub(href = "c.xhtml", cfi = "/4/2:1", serializedRange = null)
+        val decoded = AnnotationAnchor.decodeOrNull(AnnotationAnchor.encode(a)) as AnnotationAnchor.Epub
+        assertEquals(a, decoded)
+        assertNull(decoded.serializedRange)
+    }
+
+    @Test fun anchorHash_isStable_acrossInstances() {
+        val a1 = AnnotationAnchor.Text("u", 1, 9)
+        val a2 = AnnotationAnchor.Text("u", 1, 9)
+        assertEquals(a1.anchorHash, a2.anchorHash)
+        assertTrue("hex sha-256", a1.anchorHash.matches(Regex("[0-9a-f]{64}")))
+    }
+
+    @Test fun anchorHash_differs_byRangeAndKind() {
+        assertNotEquals(AnnotationAnchor.Text("u", 1, 9).anchorHash, AnnotationAnchor.Text("u", 1, 10).anchorHash)
+        assertNotEquals(
+            AnnotationAnchor.Text("u", 1, 9).anchorHash,
+            AnnotationAnchor.Epub("u", "/4:1").anchorHash,
+        )
+    }
+
+    @Test fun decode_corruptOrNull_returnsNull() {
+        assertNull(AnnotationAnchor.decodeOrNull(null))
+        assertNull(AnnotationAnchor.decodeOrNull("not json"))
+        assertNull(AnnotationAnchor.decodeOrNull("""{"kind":"bogus"}"""))
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/annotations/AnnotationColorTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/annotations/AnnotationColorTest.kt
@@ -1,0 +1,44 @@
+package com.vreader.app.annotations
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Feature #123 WI-2 — [AnnotationColor] round-trip + the design/iOS parity guard. */
+class AnnotationColorTest {
+    @Test fun allFiveColors_roundTripByKey() {
+        for (c in AnnotationColor.entries) {
+            assertEquals(c, AnnotationColor.from(c.key))
+        }
+        assertEquals(5, AnnotationColor.entries.size)
+    }
+
+    @Test fun unknownOrNull_returnsNull() {
+        assertNull(AnnotationColor.from("orange"))
+        assertNull(AnnotationColor.from(null))
+        assertNull(AnnotationColor.from(""))
+    }
+
+    @Test fun palette_isInDesignOrder() {
+        assertEquals(
+            listOf("yellow", "green", "blue", "pink", "red"),
+            AnnotationColor.palette.map { it.key },
+        )
+    }
+
+    @Test fun default_isYellow() {
+        assertEquals(AnnotationColor.yellow, AnnotationColor.DEFAULT)
+    }
+
+    @Test fun red_isAndroidOnly_iOSWouldTreatAsUnknown() {
+        // iOS NamedHighlightColor has only {yellow, pink, green, blue}. Android's 5th color `red`
+        // is design parity, not iOS-model parity: its key "red" is NOT one of the iOS four, so iOS's
+        // nil-tolerant from() returns null (graceful unknown) — it never corrupts data on restore.
+        val iosColors = setOf("yellow", "pink", "green", "blue")
+        assertTrue("red is the Android-only extra", AnnotationColor.red.key !in iosColors)
+        for (shared in iosColors) {
+            assertTrue("the 4 iOS colors all exist on Android", AnnotationColor.from(shared) != null)
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/annotations/AnnotationsRepositoryTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/annotations/AnnotationsRepositoryTest.kt
@@ -1,0 +1,127 @@
+package com.vreader.app.annotations
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.vreader.app.data.BookEntity
+import com.vreader.app.data.VReaderDatabase
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import vreader.contracts.Locator
+
+/** Feature #123 WI-2 — [AnnotationsRepository] over a real in-memory Room db. */
+@RunWith(RobolectricTestRunner::class)
+class AnnotationsRepositoryTest {
+    private lateinit var db: VReaderDatabase
+    private lateinit var repo: AnnotationsRepository
+    private val key = "epub:${"a".repeat(64)}:2048"
+    private var clock = 100L
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(), VReaderDatabase::class.java,
+        ).build()
+        repo = AnnotationsRepository(db.annotationDao(), now = { clock })
+        runBlocking {
+            db.bookDao().upsert(BookEntity(key, "Pride and Prejudice", "epub", "a".repeat(64), 2048L, null, null, 1L, null))
+        }
+    }
+
+    @After fun tearDown() = db.close()
+
+    private fun loc(cfi: String) = Locator(contentSHA256 = "a".repeat(64), fileByteCount = 2048L, format = "epub", href = "c.xhtml", cfi = cfi)
+    private fun anchor(cfi: String) = AnnotationAnchor.Epub(href = "c.xhtml", cfi = cfi)
+
+    @Test fun addHighlight_persists_andObserves() = runBlocking {
+        val rec = repo.addHighlight(key, AnnotationColor.yellow, "Call me Ishmael", loc("/4:1"), anchor("/4:1"))
+        assertNotNull(rec.id)
+        val observed = repo.highlights(key).first()
+        assertEquals(1, observed.size)
+        assertEquals("Call me Ishmael", observed.single().selectedText)
+        assertEquals(AnnotationColor.yellow, observed.single().color)
+        assertEquals(anchor("/4:1"), observed.single().anchor)
+    }
+
+    @Test fun addHighlight_sameRange_dedupes_updatesInPlace() = runBlocking {
+        repo.addHighlight(key, AnnotationColor.yellow, "x", loc("/4:1"), anchor("/4:1"))
+        repo.addHighlight(key, AnnotationColor.pink, "x", loc("/4:1"), anchor("/4:1"))
+        val all = repo.highlightsForBook(key)
+        assertEquals("same (profileKey, anchorKey) → one row", 1, all.size)
+        assertEquals("color updated in place", AnnotationColor.pink, all.single().color)
+    }
+
+    @Test fun addHighlight_onDedupe_returnsPersistedExistingId_notDeadNewId() = runBlocking {
+        val first = repo.addHighlight(key, AnnotationColor.yellow, "x", loc("/4:1"), anchor("/4:1"))
+        val second = repo.addHighlight(key, AnnotationColor.pink, "x", loc("/4:1"), anchor("/4:1"))
+        // the dedupe kept the existing row, so the returned id must be the PERSISTED one (findable),
+        // not the discarded freshly-generated id.
+        assertEquals("returns the existing persisted id", first.id, second.id)
+        assertNotNull("returned id is a live row", repo.findHighlight(second.id))
+        assertEquals("the persisted record reflects the update", AnnotationColor.pink, repo.findHighlight(second.id)!!.color)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun addHighlight_locatorForAnotherBook_rejected() = runBlocking {
+        val otherLoc = Locator(contentSHA256 = "b".repeat(64), fileByteCount = 4096L, format = "epub", href = "c", cfi = "/4:1")
+        repo.addHighlight(key, AnnotationColor.yellow, "x", otherLoc, anchor("/4:1"))
+        Unit
+    }
+
+    @Test fun addHighlight_differentRange_keepsBoth() = runBlocking {
+        repo.addHighlight(key, AnnotationColor.yellow, "a", loc("/4:1"), anchor("/4:1"))
+        repo.addHighlight(key, AnnotationColor.blue, "b", loc("/6:1"), anchor("/6:1"))
+        assertEquals(2, repo.highlightsForBook(key).size)
+    }
+
+    @Test fun updateHighlight_changesColorAndNote() = runBlocking {
+        val rec = repo.addHighlight(key, AnnotationColor.yellow, "x", loc("/4:1"), anchor("/4:1"))
+        repo.updateHighlight(rec.id, AnnotationColor.green, "a thought")
+        val h = repo.findHighlight(rec.id)!!
+        assertEquals(AnnotationColor.green, h.color)
+        assertEquals("a thought", h.note)
+    }
+
+    @Test fun removeHighlight_deletes() = runBlocking {
+        val rec = repo.addHighlight(key, AnnotationColor.yellow, "x", loc("/4:1"), anchor("/4:1"))
+        repo.removeHighlight(rec.id)
+        assertNull(repo.findHighlight(rec.id))
+        assertEquals(0, repo.highlightCount(key))
+    }
+
+    @Test fun notes_addAndRemove() = runBlocking {
+        val n = repo.addNote(key, "standalone thought", loc("/8:1"))
+        assertEquals(1, repo.notes(key).first().size)
+        repo.removeNote(n.id)
+        assertTrue(repo.notes(key).first().isEmpty())
+    }
+
+    @Test fun bookmarks_addAndRemove() = runBlocking {
+        val b = repo.addBookmark(key, "Chapter 1", loc("/2:0"))
+        assertEquals(1, repo.bookmarks(key).first().size)
+        repo.removeBookmark(b.id)
+        assertTrue(repo.bookmarks(key).first().isEmpty())
+    }
+
+    @Test fun highlight_locatorRoundTrips_throughStorage() = runBlocking {
+        val rec = repo.addHighlight(key, AnnotationColor.yellow, "x", loc("/4:7"), anchor("/4:7"))
+        val read = repo.findHighlight(rec.id)!!
+        assertEquals("locator survives the JSON round-trip", "/4:7", read.locator.cfi)
+        assertEquals("epub", read.locator.format)
+    }
+
+    @Test fun allHighlights_spansBooks() = runBlocking {
+        val key2 = "epub:${"b".repeat(64)}:4096"
+        db.bookDao().upsert(BookEntity(key2, "Walden", "epub", "b".repeat(64), 4096L, null, null, 2L, null))
+        repo.addHighlight(key, AnnotationColor.yellow, "a", loc("/4:1"), anchor("/4:1"))
+        repo.addHighlight(key2, AnnotationColor.blue, "b", Locator("b".repeat(64), 4096L, "epub", href = "c", cfi = "/4:1"), anchor("/4:1"))
+        assertEquals(2, repo.allHighlights().size)
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.10.1
-versionCode=53
+versionName=0.10.2
+versionCode=54


### PR DESCRIPTION
## Summary

WI-2 (foundational) of feature #123. The annotation domain layer over the WI-1 schema.

Part of feature #1835.

## What Changed

- `AnnotationColor` — 5 design colors (yellow/green/blue/pink/red), nil-tolerant `from()`.
- `AnnotationAnchor` — sealed Text/Epub + `EpubSerializedRange`, SHA-256 `anchorHash`.
- `HighlightRecord`/`NoteRecord`/`BookmarkRecord` DTOs + entity mappers + `profileKey`/`anchorKey` derivation.
- `AnnotationsRepository` (DTO boundary, Flow reads, CRUD) + `AppContainer` DI singleton.
- Storage: Room keeps the full round-trippable `Locator`; `profileKey` derives from `canonicalJson()`; backup conversion to canonical is the deferred #113 step.

## Codex Audit

Gate-4, 2 rounds, **ship-as-is** (`.claude/codex-audits/feat-feature-123-wi-2-annotations-domain-audit.md`). Fixed 1 High (addHighlight returned a dead id on dedupe → upsert returns the persisted row) + 3 Medium (book/locator guard mirroring iOS; storage-contract docs; stale comments).

## Validation

- [x] `AnnotationColorTest` (5) + `AnnotationAnchorTest` (6) + `AnnotationsRepositoryTest` (12) — SUCCEEDED (Robolectric/JVM)
- [x] `AnnotationDaoTest` re-run green with the returning upsert
- [x] Version bumped: android/v0.10.1 → v0.10.2 (foundational WI, patch)

## Type of Change

- [x] New feature WI (foundational, part of #1835)