### PR TITLE
feat(#123): WI-3 EPUB selection → highlight + decoration render

### DIFF
--- a/.claude/codex-audits/feat-feature-123-wi-3-epub-selection-audit.md
+++ b/.claude/codex-audits/feat-feature-123-wi-3-epub-selection-audit.md
@@ -1,0 +1,46 @@
+---
+branch: feat/feature-123-wi-3-epub-selection
+threadId: codex-exec-f123-wi3
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-28
+---
+
+# Feature #123 WI-3 (behavioral) — EPUB selection → highlight + decoration render
+
+Wires Readium's selection (`selectionActionModeCallback` + `currentSelection()`) →
+the designed floating `SelectionPopover` → create highlight/note + `applyDecorations`
+re-render on open. Readium 3.3.0 API confirmed via `javap` against the cached AAR.
+
+Files: `annotations/{EpubAnnotationMapper,SelectionPopover,SelectionPopoverViewModel}.kt`,
+`annotations/AnnotationAnchor.kt` (+ `Epub.readiumLocatorJSON`), `reader/ReaderHighlightController.kt`,
+`reader/ReaderActivity.kt`; tests `EpubAnnotationMapperTest`/`SelectionPopoverViewModelTest` (JVM),
+`SelectionPopoverUiTest`/`AnnotationsConnectedTest`/`ReaderActivityTest.seededHighlight…` (emulator).
+
+## Round 1 — findings
+
+| # | file | severity | issue | resolution |
+|---|---|---|---|---|
+| 1 | ReaderActivity selectionCallback | **High** | `onCreateActionMode` returned `false` → relied on the WebView selection surviving action-mode cancellation; untested live → flaky/dead risk. | FIXED — keep the mode alive (`return true`, cleared menu), read `currentSelection()` WHILE alive, set `pendingSelection` + show popover, then `mode.finish()`. No longer depends on cancellation order. + added `ReaderActivityTest.seededHighlight_appliesAsDecoration_onLiveNavigator` exercising the live navigator/WebView decoration-render path. |
+| 2 | SelectionPopover / ReaderActivity | Medium | `Translate` was a dead no-op user-visible action (plan says OUT). | FIXED — removed the Translate action/icon/handler (+ test); commented it lands with #119. |
+| 3 | ReaderActivity PopoverOverlay | Medium | positioning ignored `anchorX`, no viewport clamp / above-below flip. | FIXED — `BoxWithConstraints`: center on `anchorX`, clamp horizontally, flip above when overflowing the bottom. |
+| 4 | ReaderActivity overlay | Low | no outside-tap dismissal. | FIXED — full-screen no-indication scrim → `clearSelectionAndDismiss()`. |
+
+## Round 2 — verify
+
+Findings 1–4 confirmed resolved. One new Medium: `appliedHighlightCount` was set to
+`highlights.size` (rows observed) rather than decorations actually built. **FIXED** —
+`ReaderHighlightController.applyHighlights` now returns the built-decoration count;
+the activity assigns that, so the live test proves ≥1 decoration was genuinely
+built from the seeded highlight's reconstructed Readium locator. Zero open
+Critical/High/Medium.
+
+## Slice verification (Gate-5a)
+
+- **On-device (emulator API 35):** popover renders + every action fires + note compose (`SelectionPopoverUiTest` ×4); persist→reload→Readium-locator-reconstruct + dedupe through real Room (`AnnotationsConnectedTest` ×2); **a stored highlight builds + applies as a decoration on the LIVE EpubNavigatorFragment/WebView** (`ReaderActivityTest.seededHighlight…`). JVM: mapper + popover VM.
+- **Deferred to WI-4 final acceptance:** the raw finger long-press-drag that triggers `onCreateActionMode` (not headlessly automatable). Everything downstream of the gesture (currentSelection→popover→create→persist→render) is verified; the trigger uses the documented Readium `selectionActionModeCallback` keep-alive pattern.
+
+## Verdict
+**ship-as-is.** The Readium selection/decoration integration is implemented against
+the confirmed 3.3.0 API, the create + reopen-render substance is verified on the live
+navigator, and all audit findings are fixed.

--- a/android/app/src/androidTest/kotlin/com/vreader/app/annotations/AnnotationsConnectedTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/annotations/AnnotationsConnectedTest.kt
@@ -1,0 +1,84 @@
+package com.vreader.app.annotations
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vreader.app.data.Book
+import com.vreader.app.data.BookEntity
+import com.vreader.app.data.VReaderDatabase
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.readium.r2.shared.publication.Locator as ReadiumLocator
+import org.readium.r2.shared.util.Url
+import org.readium.r2.shared.util.mediatype.MediaType
+import vreader.contracts.BookFormat
+
+/**
+ * Feature #123 WI-3 — on-device slice: a Readium selection → real `AnnotationsRepository` → real Room
+ * (SQLite) → reload → `EpubAnnotationMapper.readiumLocatorFor` reconstructs the Readium locator via
+ * `Locator.fromJSON` (the exact path `ReaderHighlightController.applyHighlights` uses to re-render the
+ * decoration on reopen). Proves the persist + re-render substance end-to-end on the emulator.
+ */
+@RunWith(AndroidJUnit4::class)
+class AnnotationsConnectedTest {
+    private lateinit var db: VReaderDatabase
+    private lateinit var repo: AnnotationsRepository
+    private val key = "epub:${"a".repeat(64)}:2048"
+    private val book = Book(
+        fingerprintKey = key, title = "Moby Dick", originalFormat = BookFormat.epub,
+        contentSHA256 = "a".repeat(64), fileByteCount = 2048L, addedAt = 1L,
+    )
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext, VReaderDatabase::class.java,
+        ).build()
+        repo = AnnotationsRepository(db.annotationDao())
+        runBlocking { db.bookDao().upsert(BookEntity(key, "Moby Dick", "epub", "a".repeat(64), 2048L, null, null, 1L, null)) }
+    }
+
+    @After fun tearDown() = db.close()
+
+    private fun selection(highlight: String) = ReadiumLocator(
+        href = Url("chapter1.xhtml")!!, mediaType = MediaType.XHTML,
+        locations = ReadiumLocator.Locations(progression = 0.42, totalProgression = 0.1),
+        text = ReadiumLocator.Text(before = "Call me ", highlight = highlight, after = "."),
+    )
+
+    @Test fun selection_persists_andReconstructsForDecoration_onDevice() = runBlocking {
+        val inputs = EpubAnnotationMapper.selectionToInputs(selection("Ishmael"), book)!!
+        val created = repo.addHighlight(key, AnnotationColor.green, inputs.selectedText, inputs.locator, inputs.anchor)
+
+        // reload from real SQLite + map back to a record (the reopen path)
+        val reloaded = repo.findHighlight(created.id)
+        assertNotNull("highlight persisted to real Room", reloaded)
+        assertEquals(AnnotationColor.green, reloaded!!.color)
+        assertEquals("Ishmael", reloaded.selectedText)
+
+        // the stored record reconstructs a valid Readium locator → a decoration would re-render
+        val readium = EpubAnnotationMapper.readiumLocatorFor(reloaded)
+        assertNotNull("decoration locator reconstructs via Locator.fromJSON on-device", readium)
+        assertEquals("chapter1.xhtml", readium!!.href.toString())
+        assertEquals("Ishmael", readium.text.highlight)
+
+        // edit color + remove (the create/edit lifecycle through real Room)
+        repo.updateHighlight(created.id, AnnotationColor.red, "a thought")
+        assertEquals(AnnotationColor.red, repo.findHighlight(created.id)!!.color)
+        repo.removeHighlight(created.id)
+        assertEquals(0, repo.highlightCount(key))
+    }
+
+    @Test fun reHighlightSameRange_dedupes_onDevice() = runBlocking {
+        val inputs = EpubAnnotationMapper.selectionToInputs(selection("Ishmael"), book)!!
+        val a = repo.addHighlight(key, AnnotationColor.yellow, inputs.selectedText, inputs.locator, inputs.anchor)
+        val b = repo.addHighlight(key, AnnotationColor.blue, inputs.selectedText, inputs.locator, inputs.anchor)
+        assertEquals("same selection → one persisted row", 1, repo.highlightsForBook(key).size)
+        assertEquals("returns the live persisted id", a.id, b.id)
+        assertEquals(AnnotationColor.blue, repo.findHighlight(b.id)!!.color)
+    }
+}

--- a/android/app/src/androidTest/kotlin/com/vreader/app/annotations/SelectionPopoverUiTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/annotations/SelectionPopoverUiTest.kt
@@ -1,0 +1,87 @@
+package com.vreader.app.annotations
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.vreader.app.ui.theme.VReaderTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Feature #123 WI-3 — the [SelectionPopover] composable (design vreader-android-annotations.jsx). */
+@RunWith(AndroidJUnit4::class)
+class SelectionPopoverUiTest {
+    @get:Rule val compose = createComposeRule()
+
+    @Test fun selectMode_showsColorsAndActions_colorTapFires() {
+        var tapped: AnnotationColor? = null
+        compose.setContent {
+            VReaderTheme {
+                SelectionPopover(
+                    state = SelectionPopoverState(visible = true, mode = PopoverMode.SELECT),
+                    actions = SelectionPopoverActions(onColor = { tapped = it }),
+                )
+            }
+        }
+        compose.onNodeWithTag("selection-popover").assertIsDisplayed()
+        // all 5 design colors present
+        for (c in AnnotationColor.palette) compose.onNodeWithTag("popover-color-${c.key}").assertIsDisplayed()
+        // SELECT-mode actions (Translate omitted in #123 — lands with #119)
+        compose.onNodeWithText("Highlight").assertIsDisplayed()
+        compose.onNodeWithText("Copy").assertIsDisplayed()
+        compose.onNodeWithTag("popover-color-pink").performClick()
+        assertEquals(AnnotationColor.pink, tapped)
+    }
+
+    @Test fun editMode_showsRemove_notHighlight() {
+        compose.setContent {
+            VReaderTheme {
+                SelectionPopover(
+                    state = SelectionPopoverState(visible = true, mode = PopoverMode.EDIT, activeColor = AnnotationColor.red),
+                    actions = SelectionPopoverActions(),
+                )
+            }
+        }
+        compose.onNodeWithText("Remove").assertIsDisplayed()
+        compose.onNodeWithText("Note").assertIsDisplayed()
+    }
+
+    @Test fun noteMode_typeAndSave() {
+        var saved = false
+        var typed = ""
+        compose.setContent {
+            VReaderTheme {
+                // host the draft so the controlled BasicTextField actually updates (a fixed value
+                // breaks the IME connection and drops the input).
+                var draft by remember { mutableStateOf("") }
+                SelectionPopover(
+                    state = SelectionPopoverState(visible = true, mode = PopoverMode.NOTE, noteDraft = draft),
+                    actions = SelectionPopoverActions(
+                        onNoteDraftChange = { draft = it; typed = it },
+                        onSaveNote = { saved = true },
+                    ),
+                )
+            }
+        }
+        compose.onNodeWithTag("popover-note-field").performTextInput("a thought")
+        compose.onNodeWithTag("popover-note-save").performClick()
+        assertEquals("a thought", typed)
+        assert(saved)
+    }
+
+    @Test fun notVisible_rendersNothing() {
+        compose.setContent { VReaderTheme { SelectionPopover(SelectionPopoverState(visible = false), SelectionPopoverActions()) } }
+        compose.onAllNodesWithTag("selection-popover").assertCountEquals(0)
+    }
+}

--- a/android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderActivityTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderActivityTest.kt
@@ -73,6 +73,42 @@ class ReaderActivityTest {
         }
     }
 
+    /** Feature #123 WI-3 — a stored highlight re-renders as a Readium decoration on the LIVE
+     *  navigator/WebView (the reopen path `observeHighlights` → `applyHighlights`). Seeds the highlight
+     *  at the actually-rendered href so the decoration targets loaded content. */
+    @Test
+    fun seededHighlight_appliesAsDecoration_onLiveNavigator() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val appContext = instrumentation.targetContext
+        val app = appContext.applicationContext as VReaderApp
+        val book = stageBook(appContext, instrumentation.context, app)
+
+        ActivityScenario.launch<ReaderActivity>(ReaderActivity.intent(appContext, book.fingerprintKey)).use { scenario ->
+            var href: String? = null
+            repeat(50) { scenario.onActivity { href = it.currentHref() }; if (href != null) return@repeat; Thread.sleep(200) }
+            assertNotNull("navigator rendered", href)
+
+            // seed a highlight at the rendered href through the real repository → the Flow re-applies it.
+            runBlocking {
+                val sel = org.readium.r2.shared.publication.Locator(
+                    href = org.readium.r2.shared.util.Url(href!!)!!,
+                    mediaType = org.readium.r2.shared.util.mediatype.MediaType.XHTML,
+                    locations = org.readium.r2.shared.publication.Locator.Locations(progression = 0.01),
+                    text = org.readium.r2.shared.publication.Locator.Text(highlight = "the"),
+                )
+                val inputs = com.vreader.app.annotations.EpubAnnotationMapper.selectionToInputs(sel, book)!!
+                app.container.annotationsRepository.addHighlight(
+                    book.fingerprintKey, com.vreader.app.annotations.AnnotationColor.yellow,
+                    inputs.selectedText, inputs.locator, inputs.anchor,
+                )
+            }
+
+            var applied = -1
+            repeat(50) { scenario.onActivity { applied = it.appliedHighlightCount() }; if (applied >= 1) return@repeat; Thread.sleep(200) }
+            assertTrue("the stored highlight applied as a decoration on the live navigator", applied >= 1)
+        }
+    }
+
     private fun stageBook(appContext: android.content.Context, testContext: android.content.Context, app: VReaderApp): Book {
         val staged = File(appContext.cacheDir, "reader-test-${System.nanoTime()}.epub")
         testContext.assets.open("minimal.epub").use { input ->

--- a/android/app/src/main/kotlin/com/vreader/app/annotations/AnnotationAnchor.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/annotations/AnnotationAnchor.kt
@@ -30,7 +30,16 @@ sealed interface AnnotationAnchor {
 
     @Serializable
     @SerialName("epub")
-    data class Epub(val href: String, val cfi: String, val serializedRange: EpubSerializedRange? = null) : AnnotationAnchor
+    data class Epub(
+        val href: String,
+        val cfi: String,
+        val serializedRange: EpubSerializedRange? = null,
+        // The verbatim Readium `Locator` JSON of the selection — the exact, lossless re-application
+        // anchor for `DecorableNavigator.applyDecorations` on reopen (reconstructed via
+        // `Locator.fromJSON`, the proven position-restore path). Android-originated (Readium-specific),
+        // additive + nullable so iOS-shaped anchors (href/cfi/serializedRange) still decode.
+        val readiumLocatorJSON: String? = null,
+    ) : AnnotationAnchor
 
     /** SHA-256 (hex) of the canonical JSON — the dedupe discriminant. Locally deterministic
      *  (kotlinx fixed field order), the same basis as `VReaderLocator.canonicalHash`. */

--- a/android/app/src/main/kotlin/com/vreader/app/annotations/EpubAnnotationMapper.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/annotations/EpubAnnotationMapper.kt
@@ -1,0 +1,61 @@
+// Purpose: feature #123 WI-3 — maps between Readium's selection/locator world and the annotation
+// domain. Selection -> (vreader Locator + AnnotationAnchor.Epub + selectedText) for persistence; a
+// stored highlight -> a Readium Locator for `DecorableNavigator.applyDecorations` re-render on reopen.
+// Kept free of Compose/Activity so the mapping is unit-testable; the navigator wiring lives in
+// ReaderHighlightController.
+package com.vreader.app.annotations
+
+import com.vreader.app.data.Book
+import org.json.JSONObject
+import vreader.contracts.Locator
+import org.readium.r2.shared.publication.Locator as ReadiumLocator
+
+/** The persistable inputs derived from a Readium text selection. */
+data class EpubSelectionInputs(
+    val selectedText: String,
+    val locator: Locator,
+    val anchor: AnnotationAnchor.Epub,
+)
+
+object EpubAnnotationMapper {
+    /**
+     * Derive the persistable inputs from a Readium selection [locator]. Returns null when there is no
+     * usable highlighted text (a selection must carry `text.highlight`). The canonical vreader
+     * [Locator] carries href/progression/text so the record is self-describing + cross-platform; the
+     * [AnnotationAnchor.Epub] additionally keeps the verbatim Readium JSON for lossless re-application.
+     */
+    fun selectionToInputs(locator: ReadiumLocator, book: Book): EpubSelectionInputs? {
+        val highlighted = locator.text.highlight?.takeUnless { it.isBlank() } ?: return null
+        val href = locator.href.toString()
+        val cfi = locator.locations.fragments.firstOrNull { it.startsWith("epubcfi(") } ?: ""
+        val vloc = Locator(
+            contentSHA256 = book.contentSHA256,
+            fileByteCount = book.fileByteCount,
+            format = book.originalFormat.name,
+            href = href,
+            progression = locator.locations.progression,
+            totalProgression = locator.locations.totalProgression,
+            cfi = cfi.ifBlank { null },
+            textQuote = highlighted,
+            textContextBefore = locator.text.before,
+            textContextAfter = locator.text.after,
+        )
+        val anchor = AnnotationAnchor.Epub(
+            href = href,
+            cfi = cfi,
+            serializedRange = null,
+            readiumLocatorJSON = locator.toJSON().toString(),
+        )
+        return EpubSelectionInputs(selectedText = highlighted, locator = vloc, anchor = anchor)
+    }
+
+    /**
+     * Reconstruct the Readium [ReadiumLocator] to re-apply a stored highlight as a decoration. Prefers
+     * the verbatim Readium JSON on the anchor (lossless, via `Locator.fromJSON` — the proven
+     * position-restore path); returns null if it can't be parsed (caller skips that decoration).
+     */
+    fun readiumLocatorFor(record: HighlightRecord): ReadiumLocator? {
+        val json = (record.anchor as? AnnotationAnchor.Epub)?.readiumLocatorJSON ?: return null
+        return runCatching { ReadiumLocator.fromJSON(JSONObject(json)) }.getOrNull()
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/annotations/SelectionPopover.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/annotations/SelectionPopover.kt
@@ -1,0 +1,174 @@
+// Purpose: feature #123 WI-3 — the in-reader selection popover (design vreader-android-annotations.jsx
+// `SelectionPopover`): a white rounded card with a 5-color dot row (+ "+"), a two-mode action row
+// (SELECT: Highlight/Note/Copy/Translate/Share · EDIT: Note/Copy/Share/Remove), an inline NOTE compose
+// row, and a downward notch. Pure function of [SelectionPopoverState] + callbacks; the host anchors it.
+package com.vreader.app.annotations
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.outlined.BorderColor
+import androidx.compose.material.icons.outlined.EditNote
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.vreader.app.ui.theme.VReaderColors
+import com.vreader.app.ui.theme.VReaderFonts
+
+private val CARD = Color.White
+private val DIVIDER = Color(0x1A1D1A14)
+private val DANGER = Color(0xFFB5503F)
+
+private fun colorOf(hex: String): Color = Color(android.graphics.Color.parseColor(hex))
+
+/** Callbacks the host wires to side effects (persist / decorate / copy / share). */
+data class SelectionPopoverActions(
+    val onColor: (AnnotationColor) -> Unit = {},
+    val onHighlight: () -> Unit = {},
+    val onNote: () -> Unit = {},
+    val onCopy: () -> Unit = {},
+    val onShare: () -> Unit = {},
+    val onRemove: () -> Unit = {},
+    val onNoteDraftChange: (String) -> Unit = {},
+    val onSaveNote: () -> Unit = {},
+    val onCancelNote: () -> Unit = {},
+)
+
+@Composable
+fun SelectionPopover(state: SelectionPopoverState, actions: SelectionPopoverActions, modifier: Modifier = Modifier) {
+    if (!state.visible) return
+    Column(
+        modifier
+            .widthIn(max = 340.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(CARD)
+            .testTag("selection-popover"),
+    ) {
+        ColorRow(state.activeColor, actions.onColor)
+        Box(Modifier.fillMaxWidth().height(0.5.dp).background(DIVIDER))
+        when (state.mode) {
+            PopoverMode.NOTE -> NoteCompose(state.noteDraft, actions)
+            PopoverMode.EDIT -> ActionRow(editMode = true, actions = actions)
+            PopoverMode.SELECT -> ActionRow(editMode = false, actions = actions)
+        }
+    }
+}
+
+@Composable
+private fun ColorRow(active: AnnotationColor, onColor: (AnnotationColor) -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 13.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AnnotationColor.palette.forEach { c ->
+            val selected = c == active
+            Box(
+                Modifier
+                    .size(28.dp)
+                    .clip(CircleShape)
+                    .background(colorOf(c.dotHex))
+                    .then(if (selected) Modifier.border(2.5.dp, colorOf(c.dotHex), CircleShape) else Modifier)
+                    .clickable { onColor(c) }
+                    .testTag("popover-color-${c.key}"),
+            )
+        }
+        Box(Modifier.size(width = 0.5.dp, height = 26.dp).background(DIVIDER))
+        Box(
+            Modifier.size(28.dp).clip(CircleShape).border(1.5.dp, VReaderColors.InkMuted, CircleShape),
+            contentAlignment = Alignment.Center,
+        ) { Text("+", color = VReaderColors.InkMuted, fontSize = 16.sp) }
+    }
+}
+
+@Composable
+private fun ActionRow(editMode: Boolean, actions: SelectionPopoverActions) {
+    Row(
+        Modifier.fillMaxWidth().padding(horizontal = 6.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (editMode) {
+            ActionBtn(Icons.Outlined.EditNote, "Note", actions.onNote)
+            ActionBtn(Icons.Filled.ContentCopy, "Copy", actions.onCopy)
+            ActionBtn(Icons.Filled.Share, "Share", actions.onShare)
+            ActionBtn(Icons.Filled.Close, "Remove", actions.onRemove, danger = true)
+        } else {
+            ActionBtn(Icons.Outlined.BorderColor, "Highlight", actions.onHighlight)
+            ActionBtn(Icons.Outlined.EditNote, "Note", actions.onNote)
+            ActionBtn(Icons.Filled.ContentCopy, "Copy", actions.onCopy)
+            // Translate is in the design but routes to #119 (bilingual/AI) — omitted here (plan §OOS)
+            // rather than shipped as a dead no-op; it lands when #119 wires the translation path.
+            ActionBtn(Icons.Filled.Share, "Share", actions.onShare)
+        }
+    }
+}
+
+@Composable
+private fun ActionBtn(icon: ImageVector, label: String, onClick: () -> Unit, danger: Boolean = false) {
+    val tint = if (danger) DANGER else VReaderColors.Ink
+    Column(
+        Modifier.clip(RoundedCornerShape(8.dp)).clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 4.dp).widthIn(min = 52.dp).testTag("popover-action-$label"),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Icon(icon, contentDescription = label, tint = tint, modifier = Modifier.size(20.dp))
+        Text(label, color = if (danger) DANGER else VReaderColors.InkMuted, fontFamily = VReaderFonts.Sans, fontSize = 11.sp, fontWeight = FontWeight.Medium)
+    }
+}
+
+@Composable
+private fun NoteCompose(draft: String, actions: SelectionPopoverActions) {
+    Column(Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp)) {
+        Text("ADD NOTE", color = VReaderColors.InkMuted, fontFamily = VReaderFonts.Sans, fontSize = 11.sp, fontWeight = FontWeight.SemiBold)
+        Box(
+            Modifier.fillMaxWidth().padding(top = 8.dp).clip(RoundedCornerShape(10.dp))
+                .background(Color(0x0A1D1A14)).padding(horizontal = 12.dp, vertical = 10.dp).height(72.dp),
+        ) {
+            BasicTextField(
+                value = draft,
+                onValueChange = actions.onNoteDraftChange,
+                textStyle = TextStyle(color = VReaderColors.Ink, fontFamily = VReaderFonts.Serif, fontSize = 15.sp),
+                modifier = Modifier.fillMaxWidth().testTag("popover-note-field"),
+            )
+        }
+        Row(Modifier.fillMaxWidth().padding(top = 11.dp), horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End)) {
+            Text(
+                "Cancel", color = VReaderColors.InkMuted, fontFamily = VReaderFonts.Sans, fontSize = 14.sp, fontWeight = FontWeight.Medium,
+                modifier = Modifier.clip(RoundedCornerShape(9.dp)).clickable(onClick = actions.onCancelNote).padding(horizontal = 12.dp, vertical = 7.dp).testTag("popover-note-cancel"),
+            )
+            Text(
+                "Save", color = Color.White, fontFamily = VReaderFonts.Sans, fontSize = 14.sp, fontWeight = FontWeight.SemiBold, textAlign = TextAlign.Center,
+                modifier = Modifier.clip(RoundedCornerShape(9.dp)).background(VReaderColors.Accent).clickable(onClick = actions.onSaveNote).padding(horizontal = 16.dp, vertical = 7.dp).testTag("popover-note-save"),
+            )
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/annotations/SelectionPopoverViewModel.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/annotations/SelectionPopoverViewModel.kt
@@ -1,0 +1,60 @@
+// Purpose: feature #123 WI-3 — state holder for the in-reader selection popover (design
+// vreader-android-annotations.jsx `SelectionPopover`). Three modes: SELECT (just-selected:
+// Highlight/Note/Copy/Translate/Share + color row), NOTE (inline compose), EDIT (an existing
+// highlight: Note/Copy/Share/Remove — wired in WI-4). Plain StateFlow holder (JVM-testable); the
+// Activity owns it and performs the side effects (persist, decorate, copy, share).
+package com.vreader.app.annotations
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+enum class PopoverMode { SELECT, NOTE, EDIT }
+
+data class SelectionPopoverState(
+    val visible: Boolean = false,
+    val mode: PopoverMode = PopoverMode.SELECT,
+    val activeColor: AnnotationColor = AnnotationColor.DEFAULT,
+    val noteDraft: String = "",
+    // anchor in the reader's content coordinates (px); the host positions the popover near it.
+    val anchorX: Float = 0f,
+    val anchorY: Float = 0f,
+)
+
+class SelectionPopoverViewModel {
+    private val _state = MutableStateFlow(SelectionPopoverState())
+    val state: StateFlow<SelectionPopoverState> = _state.asStateFlow()
+
+    /** Show for a fresh selection (SELECT mode), anchored near the selection rect. */
+    fun showForSelection(anchorX: Float, anchorY: Float) {
+        _state.value = SelectionPopoverState(
+            visible = true, mode = PopoverMode.SELECT, activeColor = AnnotationColor.DEFAULT,
+            noteDraft = "", anchorX = anchorX, anchorY = anchorY,
+        )
+    }
+
+    /** Show for an existing highlight (EDIT mode), seeding its current color/note. */
+    fun showForExisting(color: AnnotationColor, note: String?, anchorX: Float, anchorY: Float) {
+        _state.value = SelectionPopoverState(
+            visible = true, mode = PopoverMode.EDIT, activeColor = color,
+            noteDraft = note.orEmpty(), anchorX = anchorX, anchorY = anchorY,
+        )
+    }
+
+    fun selectColor(color: AnnotationColor) {
+        _state.value = _state.value.copy(activeColor = color)
+    }
+
+    /** Switch to the inline note-compose row (from SELECT or EDIT). */
+    fun beginNote() {
+        _state.value = _state.value.copy(mode = PopoverMode.NOTE)
+    }
+
+    fun updateNoteDraft(text: String) {
+        _state.value = _state.value.copy(noteDraft = text)
+    }
+
+    fun dismiss() {
+        _state.value = _state.value.copy(visible = false)
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt
@@ -6,18 +6,41 @@
 // reader controls (TOC/AI/highlights/settings) are Phase-3 features.
 package com.vreader.app.reader
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.ActionMode
 import android.view.Gravity
+import android.view.Menu
+import android.view.MenuItem
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.fragment.app.commitNow
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.withStarted
 import com.vreader.app.VReaderApp
+import com.vreader.app.annotations.AnnotationColor
+import com.vreader.app.annotations.AnnotationsRepository
+import com.vreader.app.annotations.EpubAnnotationMapper
+import com.vreader.app.annotations.PopoverMode
+import com.vreader.app.annotations.SelectionPopover
+import com.vreader.app.annotations.SelectionPopoverActions
+import com.vreader.app.annotations.SelectionPopoverViewModel
 import com.vreader.app.data.Book
 import com.vreader.app.data.LibraryRepository
 import kotlinx.coroutines.flow.debounce
@@ -40,11 +63,19 @@ class ReaderActivity : AppCompatActivity() {
     private val repository: LibraryRepository get() = container.repository
     private val bridge = ReadiumLocatorBridge()
 
+    private val annotations: AnnotationsRepository get() = container.annotationsRepository
+
     private var containerId: Int = 0
     private var navigator: EpubNavigatorFragment? = null
     private var publication: Publication? = null   // host-owned; closed in onDestroy
     private var book: Book? = null
     private lateinit var titleView: TextView
+
+    // feature #123 — in-reader highlighting
+    private var highlightController: ReaderHighlightController? = null
+    private val popoverVm = SelectionPopoverViewModel()
+    // the Readium locator of the live selection (set when the popover opens for a fresh selection)
+    private var pendingSelection: Locator? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // The navigator fragment can't be restored before its FragmentFactory is set,
@@ -83,6 +114,10 @@ class ReaderActivity : AppCompatActivity() {
                     listener = object : EpubNavigatorFragment.Listener {
                         override fun onExternalLinkActivated(url: AbsoluteUrl) {}
                     },
+                    configuration = EpubNavigatorFragment.Configuration().apply {
+                        // intercept the system selection menu → show the designed floating popover instead.
+                        selectionActionModeCallback = selectionCallback()
+                    },
                 )
                 supportFragmentManager.commitNow {
                     add(containerId, EpubNavigatorFragment::class.java, Bundle(), READER_TAG)
@@ -91,9 +126,90 @@ class ReaderActivity : AppCompatActivity() {
             }
             if (nav == null) { finish(); return@launch }
             navigator = nav
+            val controller = ReaderHighlightController(nav)
+            highlightController = controller
             repository.markOpened(key, System.currentTimeMillis())
             observePosition(nav, loaded)
+            observeHighlights(loaded, controller)
         }
+    }
+
+    /** Re-apply the book's stored highlights as Readium decorations whenever the set changes. */
+    private fun observeHighlights(current: Book, controller: ReaderHighlightController) {
+        lifecycleScope.launch {
+            annotations.highlights(current.fingerprintKey).collect { highlights ->
+                runCatching { controller.applyHighlights(highlights) }
+                    .onSuccess { built -> appliedHighlightCount = built }   // decorations actually built/applied
+            }
+        }
+    }
+
+    @Volatile private var appliedHighlightCount: Int = -1
+
+    /** Test hook: the count of highlights applied as decorations on the live navigator (-1 until the
+     *  first apply). Proves the reopen-render path ran against the real EpubNavigatorFragment. */
+    @androidx.annotation.VisibleForTesting
+    fun appliedHighlightCount(): Int = appliedHighlightCount
+
+    /** The selection action-mode callback. We KEEP the action mode alive (return true) with an emptied
+     *  menu so the WebView selection survives the suspend `currentSelection()` read, capture the
+     *  selection (text + rect) → show the floating popover, then `finish()` to drop the (empty) system
+     *  bar. Reading the selection while the mode is still alive avoids the "cancellation clears the
+     *  selection" race of a bare `return false`. The empty bar is transient (gone the same tick the
+     *  suspend read resolves), not persistent undesigned chrome. */
+    private fun selectionCallback(): ActionMode.Callback = object : ActionMode.Callback {
+        override fun onCreateActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+            menu?.clear()
+            lifecycleScope.launch {
+                val nav = navigator ?: run { mode?.finish(); return@launch }
+                val selection = nav.currentSelection()
+                if (selection == null || selection.locator.text.highlight.isNullOrBlank()) {
+                    mode?.finish(); return@launch
+                }
+                pendingSelection = selection.locator
+                val rect = selection.rect
+                val density = resources.displayMetrics.density
+                popoverVm.showForSelection((rect?.centerX() ?: 0f) / density, (rect?.bottom ?: 0f) / density)
+                mode?.finish()   // captured — drop the empty system bar; the floating popover is the menu
+            }
+            return true
+        }
+
+        override fun onPrepareActionMode(mode: ActionMode?, menu: Menu?): Boolean { menu?.clear(); return true }
+        override fun onActionItemClicked(mode: ActionMode?, item: MenuItem?): Boolean = false
+        override fun onDestroyActionMode(mode: ActionMode?) {}
+    }
+
+    // ---- popover side effects ----
+
+    private fun createHighlight(color: AnnotationColor, note: String?) {
+        val current = book ?: return
+        val locator = pendingSelection ?: return
+        val inputs = EpubAnnotationMapper.selectionToInputs(locator, current) ?: return
+        container.appScope.launch {
+            annotations.addHighlight(current.fingerprintKey, color, inputs.selectedText, inputs.locator, inputs.anchor, note)
+        }
+        clearSelectionAndDismiss()
+    }
+
+    private fun copySelection() {
+        val text = pendingSelection?.text?.highlight ?: return
+        val clip = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        clip.setPrimaryClip(ClipData.newPlainText("vreader", text))
+        clearSelectionAndDismiss()
+    }
+
+    private fun shareSelection() {
+        val text = pendingSelection?.text?.highlight ?: return
+        val send = Intent(Intent.ACTION_SEND).apply { type = "text/plain"; putExtra(Intent.EXTRA_TEXT, text) }
+        startActivity(Intent.createChooser(send, null))
+        clearSelectionAndDismiss()
+    }
+
+    private fun clearSelectionAndDismiss() {
+        highlightController?.clearSelection()
+        pendingSelection = null
+        popoverVm.dismiss()
     }
 
     override fun onStop() {
@@ -177,9 +293,67 @@ class ReaderActivity : AppCompatActivity() {
         val frame = FrameLayout(this).apply { id = View.generateViewId() }
         containerId = frame.id
 
+        // the navigator fragment + the floating selection-popover overlay share a stack.
+        val popoverOverlay = ComposeView(this).apply { setContent { PopoverOverlay() } }
+        val readerStack = FrameLayout(this).apply {
+            addView(frame, FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT))
+            addView(popoverOverlay, FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT))
+        }
+
         root.addView(bar, LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT))
-        root.addView(frame, LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, 0, 1f))
+        root.addView(readerStack, LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, 0, 1f))
         return root
+    }
+
+    /** The floating selection popover, positioned near the selection's anchor with a viewport clamp
+     *  and an above/below flip. The full-screen scrim dismisses the popover on an outside tap. */
+    @androidx.compose.runtime.Composable
+    private fun PopoverOverlay() {
+        val state by popoverVm.state.collectAsStateWithLifecycle()
+        if (!state.visible) return
+        androidx.compose.foundation.layout.BoxWithConstraints(
+            Modifier.fillMaxSize().clickable(
+                interactionSource = androidx.compose.runtime.remember { androidx.compose.foundation.interaction.MutableInteractionSource() },
+                indication = null,
+            ) { clearSelectionAndDismiss() },
+        ) {
+            val maxWPx = with(androidx.compose.ui.platform.LocalDensity.current) { maxWidth.toPx() }
+            val maxHPx = with(androidx.compose.ui.platform.LocalDensity.current) { maxHeight.toPx() }
+            val density = androidx.compose.ui.platform.LocalDensity.current.density
+            val popW = 320f * density // approx popover width px for centering/clamp
+            val popH = 120f * density // approx popover height px for the above/below flip
+            // center on the selection's x, clamp into the viewport
+            val xPx = (state.anchorX * density - popW / 2f).coerceIn(8f * density, (maxWPx - popW - 8f * density).coerceAtLeast(8f * density))
+            // below the selection by default; flip above if it would overflow the bottom
+            val belowY = state.anchorY * density + 8f * density
+            val yPx = if (belowY + popH <= maxHPx) belowY else (state.anchorY * density - popH - 8f * density).coerceAtLeast(8f * density)
+            SelectionPopover(
+                state = state,
+                actions = SelectionPopoverActions(
+                    onColor = { c ->
+                        when (popoverVm.state.value.mode) {
+                            PopoverMode.SELECT -> createHighlight(c, null)   // one-tap highlight (iOS-like)
+                            else -> popoverVm.selectColor(c)
+                        }
+                    },
+                    onHighlight = { createHighlight(popoverVm.state.value.activeColor, null) },
+                    onNote = { popoverVm.beginNote() },
+                    onCopy = { copySelection() },
+                    onShare = { shareSelection() },
+                    onRemove = { /* WI-4: edit/remove an existing highlight */ },
+                    onNoteDraftChange = { popoverVm.updateNoteDraft(it) },
+                    onSaveNote = {
+                        val s = popoverVm.state.value
+                        createHighlight(s.activeColor, s.noteDraft.ifBlank { null })
+                    },
+                    onCancelNote = { clearSelectionAndDismiss() },
+                ),
+                modifier = Modifier.offset(
+                    x = with(androidx.compose.ui.platform.LocalDensity.current) { xPx.toDp() },
+                    y = with(androidx.compose.ui.platform.LocalDensity.current) { yPx.toDp() },
+                ),
+            )
+        }
     }
 
     private fun dp(v: Int): Int = (v * resources.displayMetrics.density).toInt()

--- a/android/app/src/main/kotlin/com/vreader/app/reader/ReaderHighlightController.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/ReaderHighlightController.kt
@@ -1,0 +1,59 @@
+// Purpose: feature #123 WI-3 — wraps Readium's selection + decoration APIs (EpubNavigatorFragment
+// implements SelectableNavigator + DecorableNavigator) so ReaderActivity stays thin. Builds
+// Decorations from stored highlights and applies them; reads the current selection; relays
+// decoration-activation taps (an existing highlight) back to the host (used in WI-4's edit/remove).
+package com.vreader.app.reader
+
+import com.vreader.app.annotations.AnnotationColor
+import com.vreader.app.annotations.EpubAnnotationMapper
+import com.vreader.app.annotations.HighlightRecord
+import org.readium.r2.navigator.Decoration
+import org.readium.r2.navigator.DecorableNavigator
+import org.readium.r2.navigator.epub.EpubNavigatorFragment
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Locator as ReadiumLocator
+
+@OptIn(ExperimentalReadiumApi::class)
+class ReaderHighlightController(private val navigator: EpubNavigatorFragment) {
+
+    /** Render the given highlights as Readium decorations (skipping any whose anchor can't be
+     *  reconstructed). Idempotent — re-applying the full set replaces the group. Returns the number of
+     *  decorations actually BUILT + applied (≤ highlights.size; reconstruction failures are skipped). */
+    suspend fun applyHighlights(highlights: List<HighlightRecord>): Int {
+        val decorations = highlights.mapNotNull { rec ->
+            val loc: ReadiumLocator = EpubAnnotationMapper.readiumLocatorFor(rec) ?: return@mapNotNull null
+            Decoration(
+                id = rec.id,
+                locator = loc,
+                style = Decoration.Style.Highlight(tint = tintOf(rec.color), isActive = true),
+            )
+        }
+        navigator.applyDecorations(decorations, GROUP)
+        return decorations.size
+    }
+
+    /** The Readium locator of the current text selection, or null if nothing is selected. */
+    suspend fun currentSelectionLocator(): ReadiumLocator? = navigator.currentSelection()?.locator
+
+    fun clearSelection() = navigator.clearSelection()
+
+    /** Relay taps on an existing highlight decoration → its id (WI-4 opens the edit/remove popover). */
+    fun observeActivations(onActivated: (highlightId: String) -> Unit) {
+        navigator.addDecorationListener(
+            GROUP,
+            object : DecorableNavigator.Listener {
+                override fun onDecorationActivated(event: DecorableNavigator.OnActivatedEvent): Boolean {
+                    onActivated(event.decoration.id)
+                    return true
+                }
+            },
+        )
+    }
+
+    companion object {
+        const val GROUP = "highlights"
+
+        /** Readium applies its own wash alpha; pass the solid color. */
+        fun tintOf(color: AnnotationColor): Int = android.graphics.Color.parseColor(color.dotHex)
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/annotations/EpubAnnotationMapperTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/annotations/EpubAnnotationMapperTest.kt
@@ -1,0 +1,72 @@
+package com.vreader.app.annotations
+
+import com.vreader.app.data.Book
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.readium.r2.shared.publication.Locator as ReadiumLocator
+import org.readium.r2.shared.util.Url
+import org.readium.r2.shared.util.mediatype.MediaType
+import vreader.contracts.BookFormat
+
+/** Feature #123 WI-3 — [EpubAnnotationMapper]: Readium selection <-> annotation domain. */
+@RunWith(RobolectricTestRunner::class)
+class EpubAnnotationMapperTest {
+    private val book = Book(
+        fingerprintKey = "epub:${"a".repeat(64)}:2048", title = "Moby Dick",
+        originalFormat = BookFormat.epub, contentSHA256 = "a".repeat(64), fileByteCount = 2048L,
+        addedAt = 1L,
+    )
+
+    private fun readiumLocator(highlight: String?, progression: Double? = 0.42) = ReadiumLocator(
+        href = Url("chapter1.xhtml")!!,
+        mediaType = MediaType.XHTML,
+        locations = ReadiumLocator.Locations(progression = progression, totalProgression = 0.10),
+        text = ReadiumLocator.Text(before = "Call me ", highlight = highlight, after = ". Some years ago"),
+    )
+
+    @Test fun selection_withHighlight_mapsToCanonicalLocatorAndAnchor() {
+        val inputs = EpubAnnotationMapper.selectionToInputs(readiumLocator("Ishmael"), book)
+        assertNotNull(inputs)
+        assertEquals("Ishmael", inputs!!.selectedText)
+        assertEquals("chapter1.xhtml", inputs.locator.href)
+        assertEquals(0.42, inputs.locator.progression!!, 1e-9)
+        assertEquals("Ishmael", inputs.locator.textQuote)
+        assertEquals("Call me ", inputs.locator.textContextBefore)
+        assertEquals(book.fingerprintKey, inputs.locator.fingerprintKey)
+        assertEquals("chapter1.xhtml", inputs.anchor.href)
+        assertNotNull("keeps the verbatim Readium JSON for lossless re-apply", inputs.anchor.readiumLocatorJSON)
+    }
+
+    @Test fun selection_withoutHighlight_isRejected() {
+        assertNull(EpubAnnotationMapper.selectionToInputs(readiumLocator(null), book))
+        assertNull(EpubAnnotationMapper.selectionToInputs(readiumLocator("   "), book))
+    }
+
+    @Test fun storedHighlight_reconstructsReadiumLocator_forDecoration() {
+        val inputs = EpubAnnotationMapper.selectionToInputs(readiumLocator("Ishmael"), book)!!
+        val record = HighlightRecord(
+            id = "h1", bookKey = book.fingerprintKey, color = AnnotationColor.yellow,
+            selectedText = inputs.selectedText, note = null, locator = inputs.locator,
+            anchor = inputs.anchor, createdAt = 1L, updatedAt = 1L,
+        )
+        val readium = EpubAnnotationMapper.readiumLocatorFor(record)
+        assertNotNull("round-trips the Readium locator via fromJSON", readium)
+        assertEquals("chapter1.xhtml", readium!!.href.toString())
+        assertEquals("Ishmael", readium.text.highlight)
+    }
+
+    @Test fun storedHighlight_withoutReadiumJson_returnsNull() {
+        val record = HighlightRecord(
+            id = "h1", bookKey = book.fingerprintKey, color = AnnotationColor.yellow,
+            selectedText = "x", note = null,
+            locator = vreader.contracts.Locator("a".repeat(64), 2048L, "epub", href = "c", cfi = "/4:1"),
+            anchor = AnnotationAnchor.Epub(href = "c", cfi = "/4:1", readiumLocatorJSON = null),
+            createdAt = 1L, updatedAt = 1L,
+        )
+        assertNull(EpubAnnotationMapper.readiumLocatorFor(record))
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/annotations/SelectionPopoverViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/annotations/SelectionPopoverViewModelTest.kt
@@ -1,0 +1,64 @@
+package com.vreader.app.annotations
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Feature #123 WI-3 — [SelectionPopoverViewModel] mode/state transitions. */
+class SelectionPopoverViewModelTest {
+    private val vm = SelectionPopoverViewModel()
+
+    @Test fun showForSelection_entersSelectMode_visibleWithDefaults() {
+        vm.showForSelection(120f, 340f)
+        val s = vm.state.value
+        assertTrue(s.visible)
+        assertEquals(PopoverMode.SELECT, s.mode)
+        assertEquals(AnnotationColor.DEFAULT, s.activeColor)
+        assertEquals(120f, s.anchorX)
+        assertEquals(340f, s.anchorY)
+        assertEquals("", s.noteDraft)
+    }
+
+    @Test fun showForExisting_entersEditMode_seedsColorAndNote() {
+        vm.showForExisting(AnnotationColor.blue, "a thought", 10f, 20f)
+        val s = vm.state.value
+        assertTrue(s.visible)
+        assertEquals(PopoverMode.EDIT, s.mode)
+        assertEquals(AnnotationColor.blue, s.activeColor)
+        assertEquals("a thought", s.noteDraft)
+    }
+
+    @Test fun showForExisting_nullNote_seedsEmptyDraft() {
+        vm.showForExisting(AnnotationColor.green, null, 0f, 0f)
+        assertEquals("", vm.state.value.noteDraft)
+    }
+
+    @Test fun selectColor_updatesActiveColor() {
+        vm.showForSelection(0f, 0f)
+        vm.selectColor(AnnotationColor.pink)
+        assertEquals(AnnotationColor.pink, vm.state.value.activeColor)
+    }
+
+    @Test fun beginNote_switchesToNoteMode_keepingColor() {
+        vm.showForSelection(0f, 0f)
+        vm.selectColor(AnnotationColor.red)
+        vm.beginNote()
+        assertEquals(PopoverMode.NOTE, vm.state.value.mode)
+        assertEquals(AnnotationColor.red, vm.state.value.activeColor)
+    }
+
+    @Test fun updateNoteDraft_accumulates_andLongNoteRetained() {
+        vm.showForSelection(0f, 0f)
+        vm.beginNote()
+        val long = "x".repeat(5000)
+        vm.updateNoteDraft(long)
+        assertEquals(long, vm.state.value.noteDraft)
+    }
+
+    @Test fun dismiss_hides() {
+        vm.showForSelection(0f, 0f)
+        vm.dismiss()
+        assertFalse(vm.state.value.visible)
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.10.2
-versionCode=54
+versionName=0.10.3
+versionCode=55

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -633,6 +633,27 @@ the follow-on #119). Mirrors iOS `ProviderKind`/`AIProvider`/`AIChatViewModel`.
 Verified by `scripts/run-ai-roundtrip.sh` — a live OpenAI-compatible SSE stub,
 test-connection + streamed chat on the emulator (`AiRoundTripConnectedTest`).
 
+### Annotations (`com.vreader.app.annotations`) — feature #123 (EPUB highlights & notes)
+
+Select text in an EPUB → a 5-color highlight / note / copy / share, persisted to the WI-1 Room tables
+and re-rendered as Readium decorations on reopen. The selection gesture is the entry point (no reader
+chrome). TXT/MD highlighting (#124) and the annotations review sheet + bookmark creation (item F) are
+follow-ons; the bookmark table/repo ship here unused-by-UI.
+
+| Type | Purpose |
+| --- | --- |
+| `AnnotationColor` | The 5 design colors (yellow/green/blue/pink/red — design parity; iOS has 4, `red` is Android-only). |
+| `AnnotationAnchor` | Sealed `Text`(sourceUnitId/UTF-16 range) / `Epub`(href/cfi/serializedRange + the verbatim Readium locator JSON for lossless re-apply); SHA-256 `anchorHash` = the dedupe discriminant. |
+| `AnnotationsRepository` | DTO boundary over `AnnotationDao`: CRUD + Flow reads; `addHighlight` dedupes via the transactional upsert and returns the PERSISTED row; rejects a locator whose `fingerprintKey` ≠ the book. Process-singleton in `AppContainer`. |
+| `EpubAnnotationMapper` | Readium `Selection` → (canonical `Locator` + `AnnotationAnchor.Epub` + text); a stored highlight → a Readium `Locator` (via `Locator.fromJSON`) for `applyDecorations`. |
+| `SelectionPopover` + `SelectionPopoverViewModel` | The designed floating popover (color row + select/edit/note modes); a plain `StateFlow` holder, the Activity performs the side effects. |
+| `reader.ReaderHighlightController` | Wraps Readium's `SelectableNavigator`/`DecorableNavigator`: `applyHighlights` (builds `Decoration.Style.Highlight`), `currentSelectionLocator`, `clearSelection`, `observeActivations` (decoration taps → WI-4 edit/remove). |
+
+`ReaderActivity` configures the `EpubNavigatorFragment` with a `selectionActionModeCallback` that
+captures the live selection and shows the popover over a `ComposeView` overlay; stored highlights are
+re-applied as decorations via an `observeHighlights` Flow on open. Verified on the emulator
+(`ReaderActivityTest.seededHighlight_appliesAsDecoration_onLiveNavigator` drives the real WebView).
+
 ### Reading-stats (`com.vreader.app.stats`) — feature #122
 
 Reading-time tracking + the dashboard (design #1800). Mirrors the iOS feature


### PR DESCRIPTION
## Summary

WI-3 (behavioral) of feature #123. The in-reader EPUB highlighting flow: select text → the designed floating popover → 5-color highlight / note / copy / share → persists → re-renders as a Readium decoration on reopen.

Part of feature #1835.

## What Changed

- `EpubAnnotationMapper` — Readium `Selection` ↔ (canonical `Locator` + `AnnotationAnchor.Epub` + text); reconstructs a Readium `Locator` for decoration re-apply.
- `ReaderHighlightController` — wraps Readium `SelectableNavigator`/`DecorableNavigator` (`applyHighlights`, `currentSelection`, `addDecorationListener`).
- `SelectionPopover` + VM — the designed floating popover (5 colors, select/edit/note modes).
- `ReaderActivity` — `selectionActionModeCallback` (keep-alive) → popover over a `ComposeView` overlay; `observeHighlights` re-applies decorations on open; create/copy/share.
- `AnnotationAnchor.Epub.readiumLocatorJSON` (additive) for lossless re-apply.

## Codex Audit

Gate-4, 2 rounds, **ship-as-is** (`.claude/codex-audits/feat-feature-123-wi-3-epub-selection-audit.md`). Fixed 1 High (action-mode keep-alive vs cancellation race) + 3 Medium + 1 Low. Readium 3.3.0 API confirmed via `javap`.

## Validation (emulator API 35)

- [x] `SelectionPopoverUiTest` (4) — popover renders + actions + note compose
- [x] `AnnotationsConnectedTest` (2) — persist → reload → Readium-locator reconstruct + dedupe (real Room)
- [x] `ReaderActivityTest.seededHighlight_appliesAsDecoration_onLiveNavigator` — a stored highlight builds + applies as a decoration on the **live EpubNavigatorFragment/WebView**
- [x] JVM: `EpubAnnotationMapperTest`, `SelectionPopoverViewModelTest`
- [x] Docs sync — architecture.md annotations subsystem
- [x] Version bumped: android/v0.10.2 → v0.10.3 (behavioral WI, patch)

Raw finger long-press-drag trigger (not headlessly automatable) → WI-4 final acceptance; everything downstream is verified.

## Type of Change

- [x] New feature WI (behavioral, part of #1835)