### PR TITLE
feat(#124): WI-2 TXT highlight wash rendering

### DIFF
--- a/.claude/codex-audits/feat-feature-124-wi-2-txt-wash-audit.md
+++ b/.claude/codex-audits/feat-feature-124-wi-2-txt-wash-audit.md
@@ -1,0 +1,32 @@
+---
+branch: feat/feature-124-wi-2-txt-wash
+threadId: codex-exec-f124-wi2
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-28
+---
+
+# Feature #124 WI-2 (behavioral) — TXT highlight wash rendering
+
+`TxtHighlightWash` (`WashSpan` + pure `TxtWashMapper.washesByChunk` + `DrawScope.drawWashes`
+via `getPathForRange`). `TxtBody` gains a `washesForChunk` param + per-chunk `onTextLayout`
+capture + `Modifier.drawBehind`; the Loaded branch derives `washMap` from
+`annotationsRepository.highlights(bookKey)` **only when `BookFormat.txt`** (else `flowOf(emptyMap())`).
+
+## Round 1 — findings
+
+**No reportable issues.** Codex verdict clean: the binding TXT gate is correct (MD gets
+`flowOf(emptyMap())` → no annotation washes); `drawBehind` is sound (per-chunk state keyed by
+the stable chunk index, `washes` read in the item body so a `washMap` change recomposes visible
+items); `drawWashes` clamps ranges + uses exclusive-end `getPathForRange`; `washHex` `#AARRGGBB`
+parses to a translucent Compose Color; render-time lookup is O(1) and only visible items draw.
+Residual note (not a finding): `TxtReaderActivity` is ~456 lines; moving selection/popover state to
+`TxtAnnotationController` in WI-3 is the planned next step.
+
+## Tests
+- `TxtWashMapperTest` (4, JVM) — single/multi-chunk split, multiple highlights, no-range skip.
+- `TxtHighlightConnectedTest` (emulator) — highlight persists to real Room → wash recomputes to the right chunk.
+- `TxtReaderActivityTest.rendersWithSeededHighlight_drawsWash_noCrash` (emulator) — the live `drawBehind`/`getPathForRange` path runs on the real TXT reader with a highlight present.
+
+## Verdict
+**ship-as-is.** Stored-highlight wash rendering works on the live reader; recompute is pure + tested; MD is gated out.

--- a/android/app/src/androidTest/kotlin/com/vreader/app/reader/TxtHighlightConnectedTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/reader/TxtHighlightConnectedTest.kt
@@ -1,0 +1,55 @@
+package com.vreader.app.reader
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vreader.app.annotations.AnnotationAnchor
+import com.vreader.app.annotations.AnnotationColor
+import com.vreader.app.annotations.AnnotationsRepository
+import com.vreader.app.data.BookEntity
+import com.vreader.app.data.VReaderDatabase
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import vreader.contracts.Locator
+
+/**
+ * Feature #124 WI-2 — on-device: a TXT highlight persists to real Room and the wash recompute
+ * (`TxtWashMapper.washesByChunk`) projects it onto the right chunk. Proves the persist → re-render
+ * substance end-to-end on the emulator (the visual `drawBehind` wash + the live gesture are WI-3/WI-4).
+ */
+@RunWith(AndroidJUnit4::class)
+class TxtHighlightConnectedTest {
+    private lateinit var db: VReaderDatabase
+    private lateinit var repo: AnnotationsRepository
+    private val text = "AAAA\nBBBB\nCCCC\nDDDD\n"
+    private val doc = TxtDocument.of(text, maxChunkChars = 6)
+    private val key = "txt:${"a".repeat(64)}:${text.length}"
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext, VReaderDatabase::class.java,
+        ).build()
+        repo = AnnotationsRepository(db.annotationDao())
+        runBlocking { db.bookDao().upsert(BookEntity(key, "T", "txt", "a".repeat(64), text.length.toLong(), null, null, 1L, null)) }
+    }
+
+    @After fun tearDown() = db.close()
+
+    @Test fun highlightPersists_andWashRecomputesToChunk_onDevice() = runBlocking {
+        val base1 = doc.offsetForChunk(1)
+        val locator = Locator("a".repeat(64), text.length.toLong(), "txt", charRangeStartUTF16 = base1 + 1, charRangeEndUTF16 = base1 + 3, textQuote = "BB")
+        repo.addHighlight(key, AnnotationColor.green, "BB", locator, AnnotationAnchor.Text("text-document:$key", base1 + 1, base1 + 3))
+
+        val highlights = repo.highlights(key).first()
+        assertEquals(1, highlights.size)
+        val map = TxtWashMapper.washesByChunk(doc, highlights)
+        assertTrue("wash projected onto chunk 1", map.containsKey(1))
+        assertEquals(WashSpan(Utf16Range(1, 3), AnnotationColor.green), map[1]!!.single())
+    }
+}

--- a/android/app/src/androidTest/kotlin/com/vreader/app/reader/TxtReaderActivityTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/reader/TxtReaderActivityTest.kt
@@ -53,6 +53,39 @@ class TxtReaderActivityTest {
     }
 
     @Test
+    fun rendersWithSeededHighlight_drawsWash_noCrash() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val appContext = instrumentation.targetContext
+        val app = appContext.applicationContext as VReaderApp
+
+        val staged = File(appContext.cacheDir, "sample-hl-${System.nanoTime()}.txt")
+        instrumentation.context.assets.open("sample.txt").use { input ->
+            staged.outputStream().use { output -> input.copyTo(output) }
+        }
+        val book = runBlocking {
+            app.container.importer.importStream("content://test/sample.txt", "sample.txt", staged.inputStream())
+        }
+        // seed a highlight over the first few source chars → the wash drawBehind path runs for chunk 0.
+        runBlocking {
+            val loc = Locator(book.contentSHA256, book.fileByteCount, "txt", charRangeStartUTF16 = 0, charRangeEndUTF16 = 8, textQuote = "seed")
+            app.container.annotationsRepository.addHighlight(
+                book.fingerprintKey, com.vreader.app.annotations.AnnotationColor.yellow, "seed", loc,
+                com.vreader.app.annotations.AnnotationAnchor.Text("text-document:${book.fingerprintKey}", 0, 8),
+            )
+        }
+
+        ActivityScenario.launch<TxtReaderActivity>(
+            TxtReaderActivity.intent(appContext, book.fingerprintKey),
+        ).use {
+            // render completes with the highlight present → the getPathForRange/drawWashes path executed.
+            compose.waitUntil(5_000) {
+                compose.onAllNodesWithText("quick brown fox", substring = true).fetchSemanticsNodes().isNotEmpty()
+            }
+            compose.onNodeWithText("quick brown fox", substring = true).assertIsDisplayed()
+        }
+    }
+
+    @Test
     fun resumesToSavedCharOffset() {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val appContext = instrumentation.targetContext

--- a/android/app/src/main/kotlin/com/vreader/app/reader/TxtHighlightWash.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/TxtHighlightWash.kt
@@ -1,0 +1,42 @@
+// Purpose: feature #124 WI-2 — render stored TXT highlights as colored washes. `TxtWashMapper` (pure)
+// projects each highlight's SOURCE range onto the per-chunk LOCAL ranges it spans; `drawWashes` paints
+// them BEHIND the text via `TextLayoutResult.getPathForRange` (NOT `SpanStyle(background=)`, which
+// doesn't compose for overlapping ranges — Gate-2). The wash color is the AnnotationColor's translucent
+// ARGB (`washHex`); read-aloud stays on top (it's a separate span on the AnnotatedString).
+package com.vreader.app.reader
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.text.TextLayoutResult
+import com.vreader.app.annotations.AnnotationColor
+import com.vreader.app.annotations.HighlightRecord
+
+/** A highlight slice within one chunk: the chunk-LOCAL half-open range + its color. */
+data class WashSpan(val local: Utf16Range, val color: AnnotationColor)
+
+object TxtWashMapper {
+    /** Project every highlight's `[charRangeStartUTF16, charRangeEndUTF16)` onto the chunks it spans. */
+    fun washesByChunk(doc: TxtDocument, highlights: List<HighlightRecord>): Map<Int, List<WashSpan>> {
+        val map = HashMap<Int, MutableList<WashSpan>>()
+        for (h in highlights) {
+            val s = h.locator.charRangeStartUTF16 ?: continue
+            val e = h.locator.charRangeEndUTF16 ?: continue
+            if (e <= s) continue
+            for (cr in TxtSourceOffsets.chunkRanges(doc, Utf16Range(s, e))) {
+                map.getOrPut(cr.chunkIndex) { mutableListOf() }.add(WashSpan(cr.local, h.color))
+            }
+        }
+        return map
+    }
+}
+
+/** Paint [washes] behind a chunk's text using its [layout]. Call from `Modifier.drawBehind`. */
+fun DrawScope.drawWashes(layout: TextLayoutResult, washes: List<WashSpan>) {
+    for (w in washes) {
+        if (w.local.endExclusive <= w.local.startInclusive) continue
+        val end = w.local.endExclusive.coerceAtMost(layout.layoutInput.text.length)
+        val start = w.local.startInclusive.coerceIn(0, end)
+        if (end <= start) continue
+        drawPath(layout.getPathForRange(start, end), color = Color(android.graphics.Color.parseColor(w.color.washHex)))
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt
@@ -49,6 +49,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import vreader.contracts.BookFormat
@@ -67,6 +69,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -201,6 +205,18 @@ class TxtReaderActivity : ComponentActivity() {
                         val tracker = container.readingTimeTracker
                         val bookKey = s.book.fingerprintKey
                         val sessionSeconds by tracker.sessionSeconds.collectAsStateWithLifecycle()
+
+                        // feature #124 — stored TXT highlights → per-chunk washes (BINDING gate: TXT only;
+                        // MD render-only until #125 adds the source-offset map).
+                        val isTxt = s.book.originalFormat == BookFormat.txt
+                        val washMap by remember(bookKey, s.document, isTxt) {
+                            if (isTxt) {
+                                container.annotationsRepository.highlights(bookKey)
+                                    .map { TxtWashMapper.washesByChunk(s.document, it) }
+                            } else {
+                                flowOf(emptyMap())
+                            }
+                        }.collectAsStateWithLifecycle(emptyMap())
                         DisposableEffect(lifecycleOwner, bookKey) {
                             val obs = LifecycleEventObserver { _, e ->
                                 when (e) {
@@ -248,14 +264,18 @@ class TxtReaderActivity : ComponentActivity() {
                             },
                         ) {
                             Box(Modifier.fillMaxSize()) {
-                                TxtBody(s.document, listState, s.book.originalFormat) { chunkIndex ->
-                                    if (!active) null
-                                    else {
-                                        val cs = s.document.offsetForChunk(chunkIndex)
-                                        val ce = if (chunkIndex + 1 < s.document.chunkCount) s.document.offsetForChunk(chunkIndex + 1) else s.document.text.length
-                                        TtsHighlight.localSpan(cs, ce, tts.charStart, tts.charEnd)
-                                    }
-                                }
+                                TxtBody(
+                                    s.document, listState, s.book.originalFormat,
+                                    highlightSpan = { chunkIndex ->
+                                        if (!active) null
+                                        else {
+                                            val cs = s.document.offsetForChunk(chunkIndex)
+                                            val ce = if (chunkIndex + 1 < s.document.chunkCount) s.document.offsetForChunk(chunkIndex + 1) else s.document.text.length
+                                            TtsHighlight.localSpan(cs, ce, tts.charStart, tts.charEnd)
+                                        }
+                                    },
+                                    washesForChunk = { washMap[it] ?: emptyList() },
+                                )
                                 AnimatedVisibility(pillVisible, modifier = Modifier.align(Alignment.TopEnd).padding(12.dp)) {
                                     InReaderSessionPill(sessionSeconds)
                                 }
@@ -393,6 +413,8 @@ private fun TtsEntryBar(enabled: Boolean, onReadAloud: () -> Unit) {
 private fun TxtBody(
     document: TxtDocument, listState: LazyListState, format: BookFormat,
     highlightSpan: (chunkIndex: Int) -> IntRange? = { null },
+    // feature #124 — annotation highlight washes per chunk (TXT only; the activity passes empty for MD).
+    washesForChunk: (chunkIndex: Int) -> List<WashSpan> = { emptyList() },
 ) {
     val isMarkdown = format == BookFormat.md
     val wash = VReaderColors.Accent.copy(alpha = 0.18f)
@@ -416,6 +438,9 @@ private fun TxtBody(
                 }
                 else -> AnnotatedString(raw)
             }
+            // annotation washes drawn BEHIND the text (getPathForRange) — separate from the read-aloud span.
+            val washes = washesForChunk(i)
+            var layout by remember(i) { mutableStateOf<TextLayoutResult?>(null) }
             Text(
                 text = text,
                 color = VReaderColors.Ink,
@@ -423,6 +448,8 @@ private fun TxtBody(
                 fontWeight = FontWeight.Normal,
                 fontSize = 18.sp,
                 lineHeight = 29.sp,
+                onTextLayout = { layout = it },
+                modifier = Modifier.drawBehind { layout?.let { drawWashes(it, washes) } },
             )
         }
     }

--- a/android/app/src/test/kotlin/com/vreader/app/reader/TxtWashMapperTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/TxtWashMapperTest.kt
@@ -1,0 +1,55 @@
+package com.vreader.app.reader
+
+import com.vreader.app.annotations.AnnotationColor
+import com.vreader.app.annotations.HighlightRecord
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import vreader.contracts.Locator
+
+/** Feature #124 WI-2 — [TxtWashMapper.washesByChunk] projects highlights onto per-chunk washes. */
+class TxtWashMapperTest {
+    private val doc = TxtDocument.of("AAAA\nBBBB\nCCCC\nDDDD\n", maxChunkChars = 6)
+    private val key = "txt:${"a".repeat(64)}:20"
+
+    private fun hl(start: Int, end: Int, color: AnnotationColor = AnnotationColor.yellow) = HighlightRecord(
+        id = "h$start", bookKey = key, color = color, selectedText = "x", note = null,
+        locator = Locator("a".repeat(64), 20L, "txt", charRangeStartUTF16 = start, charRangeEndUTF16 = end),
+        anchor = null, createdAt = 1L, updatedAt = 1L,
+    )
+
+    @Test fun singleChunkHighlight_oneWash() {
+        val base1 = doc.offsetForChunk(1)
+        val map = TxtWashMapper.washesByChunk(doc, listOf(hl(base1 + 1, base1 + 3, AnnotationColor.pink)))
+        assertEquals(setOf(1), map.keys)
+        assertEquals(WashSpan(Utf16Range(1, 3), AnnotationColor.pink), map[1]!!.single())
+    }
+
+    @Test fun multiChunkHighlight_splitsAcrossChunks() {
+        val start = doc.offsetForChunk(0) + 2
+        val end = doc.offsetForChunk(2) + 2
+        val map = TxtWashMapper.washesByChunk(doc, listOf(hl(start, end)))
+        assertTrue("covers >= 2 chunks", map.keys.size >= 2)
+        // reassembling the per-chunk locals back to source equals the original range
+        var cursor = start
+        for (ci in map.keys.sorted()) {
+            val base = doc.offsetForChunk(ci)
+            for (w in map[ci]!!) {
+                assertEquals(cursor, base + w.local.startInclusive)
+                cursor = base + w.local.endExclusive
+            }
+        }
+        assertEquals(end, cursor)
+    }
+
+    @Test fun multipleHighlights_distinctChunks() {
+        val b0 = doc.offsetForChunk(0); val b3 = doc.offsetForChunk(3)
+        val map = TxtWashMapper.washesByChunk(doc, listOf(hl(b0, b0 + 2), hl(b3, b3 + 2)))
+        assertTrue(map.containsKey(0) && map.containsKey(3))
+    }
+
+    @Test fun highlightWithoutCharRange_skipped() {
+        val noRange = HighlightRecord("h", key, AnnotationColor.blue, "x", null, Locator("a".repeat(64), 20L, "txt", href = "c"), null, 1L, 1L)
+        assertTrue(TxtWashMapper.washesByChunk(doc, listOf(noRange)).isEmpty())
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.11.1
-versionCode=57
+versionName=0.11.2
+versionCode=58


### PR DESCRIPTION
WI-2 of feature #124. Renders stored TXT highlights as colored washes via drawBehind+getPathForRange (gated to BookFormat.txt; MD render-only). Part of #1841.

## Codex Audit
Gate-4, 1 round, ship-as-is (no findings).

## Validation (emulator API 35)
- [x] TxtWashMapperTest (4, JVM)
- [x] TxtHighlightConnectedTest — persist→recompute on real Room
- [x] TxtReaderActivityTest.rendersWithSeededHighlight — live drawBehind render
- [x] Version: android/v0.11.1 → v0.11.2 (behavioral, patch)