### PR TITLE
feat(#124): WI-3 TXT custom selection gesture + popover create

### DIFF
--- a/.claude/codex-audits/feat-feature-124-wi-3-txt-selection-gesture-audit.md
+++ b/.claude/codex-audits/feat-feature-124-wi-3-txt-selection-gesture-audit.md
@@ -1,0 +1,37 @@
+---
+branch: feat/feature-124-wi-3-txt-selection-gesture
+threadId: codex-exec-f124-wi3
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-28
+---
+
+# Feature #124 WI-3 (behavioral) — TXT custom selection gesture + popover create
+
+`TxtSelectionController` (chunk layout/coords registry; pointer→window→chunk-local→source offset;
+long-press `getWordBoundary`; drag extend anchored on the initial word; selection accent;
+`selectionEndAnchorWindow`). `TxtBody` installs `detectDragGesturesAfterLongPress` + the selection
+accent (TXT only). `TxtReaderActivity` hosts the `SelectionPopover` overlay + create/copy/share.
+
+## Round 1 — findings
+
+| # | file | severity | issue | resolution |
+|---|---|---|---|---|
+| 1 | TxtSelectionController.extendTo | Medium | Backward/cross-anchor drag used the moving endpoint as the anchor → dropped the initial word / collapsed. | FIXED — store `anchorRange` (the initial word) in `beginAt`; `extendTo` grows relative to the FIXED anchor (before→grow start, after→grow end, inside→keep word). The anchor word is never dropped. |
+| 2 | TxtSelectionController.beginAt | Medium | Reconstructed the chunk-local offset via `chunkBaseFor(sourceOff)` → at a chunk boundary it resolved to the next chunk while `layout` was the hit chunk (selection shifted). | FIXED — `hitAt` now returns the hit chunk index + rendered offset + source; `beginAt` uses that SAME chunk for `getWordBoundary` + base. `chunkBaseFor` removed. |
+| 3 | TxtReaderActivity.createTxtHighlight | Medium | `note` param was ignored — a TXT note save persisted a plain highlight. | FIXED — pass `note = note` to `addHighlight`. |
+| 4 | TxtReaderActivity popover positioning | Low | Only left/top clamped → a near-edge selection could push the popover off-screen. | FIXED — capture `boxSize`; clamp X into `[margin, boxW-popW-margin]`; flip above when below overflows. |
+
+Codex checked clean: the window-space coordinate round-trip is the right model; chunk unregister is
+tied to lazy disposal with a stable `key`; TXT `requireSameBook` holds from the locator identity
+triple; MD can't reach the gesture (its controller is null).
+
+## Slice verification (emulator API 35)
+
+- `TxtReaderActivityTest.longPressOnText_selectsWord_showsSelectionPopover` — a **real long-press** gesture (via the Compose test harness — automatable, unlike #123's WebView) selects a word + shows the popover.
+- `TxtReaderActivityTest.longPress_thenTapColor_createsAndPersistsHighlight` — **full create E2E**: long-press → tap a color → highlight persists to Room.
+- `rendersWithSeededHighlight_drawsWash_noCrash` + `TxtHighlightConnectedTest` (WI-2) still green.
+
+## Verdict
+**ship-as-is.** The custom TXT selection gesture + popover create is implemented and verified
+end-to-end on-device (the gesture itself is automatable); all audit findings fixed.

--- a/android/app/src/androidTest/kotlin/com/vreader/app/reader/TxtReaderActivityTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/reader/TxtReaderActivityTest.kt
@@ -2,8 +2,13 @@ package com.vreader.app.reader
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -49,6 +54,73 @@ class TxtReaderActivityTest {
                     .fetchSemanticsNodes().isNotEmpty()
             }
             compose.onNodeWithText("quick brown fox", substring = true).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun longPressOnText_selectsWord_showsSelectionPopover() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val appContext = instrumentation.targetContext
+        val app = appContext.applicationContext as VReaderApp
+
+        val staged = File(appContext.cacheDir, "sample-sel-${System.nanoTime()}.txt")
+        instrumentation.context.assets.open("sample.txt").use { input ->
+            staged.outputStream().use { output -> input.copyTo(output) }
+        }
+        val book = runBlocking {
+            app.container.importer.importStream("content://test/sample.txt", "sample.txt", staged.inputStream())
+        }
+
+        ActivityScenario.launch<TxtReaderActivity>(
+            TxtReaderActivity.intent(appContext, book.fingerprintKey),
+        ).use {
+            compose.waitUntil(5_000) {
+                compose.onAllNodesWithText("quick brown fox", substring = true).fetchSemanticsNodes().isNotEmpty()
+            }
+            // a long-press on the text drives detectDragGesturesAfterLongPress → word selection → popover.
+            compose.onNodeWithText("quick brown fox", substring = true).performTouchInput { longClick() }
+            compose.waitUntil(5_000) {
+                compose.onAllNodesWithTag("selection-popover").fetchSemanticsNodes().isNotEmpty()
+            }
+            compose.onNodeWithTag("selection-popover").assertIsDisplayed()
+            compose.onNodeWithText("Highlight").assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun longPress_thenTapColor_createsAndPersistsHighlight() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val appContext = instrumentation.targetContext
+        val app = appContext.applicationContext as VReaderApp
+
+        val staged = File(appContext.cacheDir, "sample-create-${System.nanoTime()}.txt")
+        instrumentation.context.assets.open("sample.txt").use { input ->
+            staged.outputStream().use { output -> input.copyTo(output) }
+        }
+        val book = runBlocking {
+            app.container.importer.importStream("content://test/sample.txt", "sample.txt", staged.inputStream())
+        }
+
+        ActivityScenario.launch<TxtReaderActivity>(
+            TxtReaderActivity.intent(appContext, book.fingerprintKey),
+        ).use {
+            compose.waitUntil(5_000) {
+                compose.onAllNodesWithText("quick brown fox", substring = true).fetchSemanticsNodes().isNotEmpty()
+            }
+            compose.onNodeWithText("quick brown fox", substring = true).performTouchInput { longClick() }
+            compose.waitUntil(5_000) {
+                compose.onAllNodesWithTag("popover-color-yellow").fetchSemanticsNodes().isNotEmpty()
+            }
+            compose.onNodeWithTag("popover-color-yellow").performClick()
+
+            // createTxtHighlight runs on appScope (async) → poll Room for the persisted highlight.
+            var count = 0
+            repeat(50) {
+                count = runBlocking { app.container.annotationsRepository.highlightsForBook(book.fingerprintKey).size }
+                if (count >= 1) return@repeat
+                Thread.sleep(150)
+            }
+            org.junit.Assert.assertTrue("a highlight was created + persisted from the selection", count >= 1)
         }
     }
 

--- a/android/app/src/main/kotlin/com/vreader/app/reader/TxtHighlightWash.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/TxtHighlightWash.kt
@@ -32,11 +32,14 @@ object TxtWashMapper {
 
 /** Paint [washes] behind a chunk's text using its [layout]. Call from `Modifier.drawBehind`. */
 fun DrawScope.drawWashes(layout: TextLayoutResult, washes: List<WashSpan>) {
-    for (w in washes) {
-        if (w.local.endExclusive <= w.local.startInclusive) continue
-        val end = w.local.endExclusive.coerceAtMost(layout.layoutInput.text.length)
-        val start = w.local.startInclusive.coerceIn(0, end)
-        if (end <= start) continue
-        drawPath(layout.getPathForRange(start, end), color = Color(android.graphics.Color.parseColor(w.color.washHex)))
-    }
+    for (w in washes) drawRangeFill(layout, w.local, Color(android.graphics.Color.parseColor(w.color.washHex)))
+}
+
+/** Paint a single chunk-local half-open range with [color] behind the text (used for the in-progress
+ *  selection accent). */
+fun DrawScope.drawRangeFill(layout: TextLayoutResult, local: Utf16Range, color: Color) {
+    val end = local.endExclusive.coerceAtMost(layout.layoutInput.text.length)
+    val start = local.startInclusive.coerceIn(0, end)
+    if (end <= start) return
+    drawPath(layout.getPathForRange(start, end), color = color)
 }

--- a/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt
@@ -59,7 +59,15 @@ import java.io.File
 import android.speech.tts.TextToSpeech
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.runtime.DisposableEffect
@@ -217,6 +225,11 @@ class TxtReaderActivity : ComponentActivity() {
                                 flowOf(emptyMap())
                             }
                         }.collectAsStateWithLifecycle(emptyMap())
+
+                        // feature #124 — TXT custom selection + popover (TXT only).
+                        val selectionController = remember(s.document, isTxt) { if (isTxt) TxtSelectionController(s.document) else null }
+                        val popoverVm = remember(bookKey) { com.vreader.app.annotations.SelectionPopoverViewModel() }
+                        val popoverState by popoverVm.state.collectAsStateWithLifecycle()
                         DisposableEffect(lifecycleOwner, bookKey) {
                             val obs = LifecycleEventObserver { _, e ->
                                 when (e) {
@@ -263,7 +276,9 @@ class TxtReaderActivity : ComponentActivity() {
                                 }
                             },
                         ) {
-                            Box(Modifier.fillMaxSize()) {
+                            var boxOriginWindow by remember { mutableStateOf(androidx.compose.ui.geometry.Offset.Zero) }
+                            var boxSize by remember { mutableStateOf(androidx.compose.ui.unit.IntSize.Zero) }
+                            Box(Modifier.fillMaxSize().onGloballyPositioned { boxOriginWindow = it.localToWindow(androidx.compose.ui.geometry.Offset.Zero); boxSize = it.size }) {
                                 TxtBody(
                                     s.document, listState, s.book.originalFormat,
                                     highlightSpan = { chunkIndex ->
@@ -275,9 +290,31 @@ class TxtReaderActivity : ComponentActivity() {
                                         }
                                     },
                                     washesForChunk = { washMap[it] ?: emptyList() },
+                                    selectionController = selectionController,
+                                    onSelectionFinalized = { finalizeTxtSelection(selectionController, popoverVm) },
                                 )
                                 AnimatedVisibility(pillVisible, modifier = Modifier.align(Alignment.TopEnd).padding(12.dp)) {
                                     InReaderSessionPill(sessionSeconds)
+                                }
+                                // the selection popover, anchored under the selection end. anchorX/anchorY
+                                // carry WINDOW px (set by finalizeTxtSelection); convert to box-local + clamp.
+                                if (popoverState.visible) {
+                                    val density = LocalDensity.current.density
+                                    val half = 150f * density
+                                    val popW = 320f * density
+                                    val popH = 130f * density
+                                    val margin = 8f * density
+                                    val maxX = (boxSize.width - popW - margin).coerceAtLeast(margin)
+                                    val xPx = (popoverState.anchorX - boxOriginWindow.x - half).coerceIn(margin, maxX)
+                                    // below the selection by default; flip above when it would overflow the bottom.
+                                    val belowY = popoverState.anchorY - boxOriginWindow.y + margin
+                                    val yPx = if (belowY + popH <= boxSize.height) belowY
+                                        else (popoverState.anchorY - boxOriginWindow.y - popH - margin).coerceAtLeast(margin)
+                                    com.vreader.app.annotations.SelectionPopover(
+                                        state = popoverState,
+                                        actions = txtPopoverActions(s.book, selectionController, popoverVm),
+                                        modifier = Modifier.offset { IntOffset(xPx.toInt(), yPx.toInt()) },
+                                    )
                                 }
                             }
                         }
@@ -356,6 +393,77 @@ class TxtReaderActivity : ComponentActivity() {
         }
     }
 
+    // ---- feature #124 TXT selection-popover side effects ----
+
+    private fun finalizeTxtSelection(controller: TxtSelectionController?, vm: com.vreader.app.annotations.SelectionPopoverViewModel) {
+        val c = controller ?: return
+        if (c.selectedText().isNullOrBlank() || !c.isCurrentSelectionValid()) { c.clear(); return }
+        val anchor = c.selectionEndAnchorWindow() ?: androidx.compose.ui.geometry.Offset.Zero
+        vm.showForSelection(anchor.x, anchor.y)   // WINDOW px
+    }
+
+    private fun txtPopoverActions(
+        book: com.vreader.app.data.Book,
+        controller: TxtSelectionController?,
+        vm: com.vreader.app.annotations.SelectionPopoverViewModel,
+    ) = com.vreader.app.annotations.SelectionPopoverActions(
+        onColor = { color ->
+            when (vm.state.value.mode) {
+                com.vreader.app.annotations.PopoverMode.SELECT -> createTxtHighlight(book, controller, vm, color, null)
+                else -> vm.selectColor(color)
+            }
+        },
+        onHighlight = { createTxtHighlight(book, controller, vm, vm.state.value.activeColor, null) },
+        onNote = { vm.beginNote() },
+        onCopy = { copyTxtSelection(controller); clearTxtSelection(controller, vm) },
+        onShare = { shareTxtSelection(controller); clearTxtSelection(controller, vm) },
+        onRemove = { /* edit/remove an existing TXT highlight — WI-4 */ },
+        onNoteDraftChange = { vm.updateNoteDraft(it) },
+        onSaveNote = { createTxtHighlight(book, controller, vm, vm.state.value.activeColor, vm.state.value.noteDraft.ifBlank { null }) },
+        onCancelNote = { clearTxtSelection(controller, vm) },
+    )
+
+    private fun createTxtHighlight(
+        book: com.vreader.app.data.Book,
+        controller: TxtSelectionController?,
+        vm: com.vreader.app.annotations.SelectionPopoverViewModel,
+        color: com.vreader.app.annotations.AnnotationColor,
+        note: String?,
+    ) {
+        val c = controller ?: return
+        val range = c.currentRange()
+        val text = c.selectedText()
+        if (range == null || text.isNullOrBlank() || !c.isCurrentSelectionValid()) { clearTxtSelection(c, vm); return }
+        val locator = vreader.contracts.Locator(
+            book.contentSHA256, book.fileByteCount, "txt",
+            charRangeStartUTF16 = range.startInclusive, charRangeEndUTF16 = range.endExclusive, textQuote = text,
+        )
+        val anchor = com.vreader.app.annotations.AnnotationAnchor.Text("text-document:${book.fingerprintKey}", range.startInclusive, range.endExclusive)
+        container.appScope.launch {
+            container.annotationsRepository.addHighlight(book.fingerprintKey, color, text, locator, anchor, note)
+        }
+        clearTxtSelection(c, vm)
+    }
+
+    private fun copyTxtSelection(controller: TxtSelectionController?) {
+        val text = controller?.selectedText() ?: return
+        val clip = getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+        clip.setPrimaryClip(android.content.ClipData.newPlainText("vreader", text))
+    }
+
+    private fun shareTxtSelection(controller: TxtSelectionController?) {
+        val text = controller?.selectedText() ?: return
+        val send = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
+            type = "text/plain"; putExtra(android.content.Intent.EXTRA_TEXT, text)
+        }
+        startActivity(android.content.Intent.createChooser(send, null))
+    }
+
+    private fun clearTxtSelection(controller: TxtSelectionController?, vm: com.vreader.app.annotations.SelectionPopoverViewModel) {
+        controller?.clear()
+        vm.dismiss()
+    }
+
     companion object {
         const val EXTRA_FINGERPRINT_KEY = "fingerprintKey"
 
@@ -415,11 +523,33 @@ private fun TxtBody(
     highlightSpan: (chunkIndex: Int) -> IntRange? = { null },
     // feature #124 — annotation highlight washes per chunk (TXT only; the activity passes empty for MD).
     washesForChunk: (chunkIndex: Int) -> List<WashSpan> = { emptyList() },
+    // feature #124 — TXT custom selection (null = no selection, e.g. MD). onSelectionFinalized fires on
+    // long-press-drag release so the host can show the popover.
+    selectionController: TxtSelectionController? = null,
+    onSelectionFinalized: () -> Unit = {},
 ) {
     val isMarkdown = format == BookFormat.md
     val wash = VReaderColors.Accent.copy(alpha = 0.18f)
+    val selectionAccent = Color(0x575C8FC4)   // design selection bg rgba(92,143,196,0.34)
+    val selection by (selectionController?.selection ?: flowOf(null)).collectAsState(null)
     LazyColumn(
-        Modifier.fillMaxSize(),
+        Modifier
+            .fillMaxSize()
+            .onGloballyPositioned { selectionController?.setLazyCoords(it) }
+            .then(
+                if (selectionController != null) {
+                    Modifier.pointerInput(selectionController) {
+                        detectDragGesturesAfterLongPress(
+                            onDragStart = { selectionController.beginAt(it) },
+                            onDrag = { change, _ -> selectionController.extendTo(change.position) },
+                            onDragEnd = { onSelectionFinalized() },
+                            onDragCancel = { onSelectionFinalized() },
+                        )
+                    }
+                } else {
+                    Modifier
+                },
+            ),
         state = listState,
         contentPadding = PaddingValues(horizontal = 24.dp, vertical = 16.dp),
     ) {
@@ -441,6 +571,16 @@ private fun TxtBody(
             // annotation washes drawn BEHIND the text (getPathForRange) — separate from the read-aloud span.
             val washes = washesForChunk(i)
             var layout by remember(i) { mutableStateOf<TextLayoutResult?>(null) }
+            var coords by remember(i) { mutableStateOf<androidx.compose.ui.layout.LayoutCoordinates?>(null) }
+            if (selectionController != null) {
+                LaunchedEffect(i, layout, coords) {
+                    val l = layout; val c = coords
+                    if (l != null && c != null) selectionController.registerChunk(i, l, c)
+                }
+                DisposableEffect(selectionController, i) { onDispose { selectionController.unregisterChunk(i) } }
+            }
+            // read `selection` (a State) so a selection change recomposes + redraws the accent.
+            val selRange = if (selection != null) selectionController?.selectionForChunk(i) else null
             Text(
                 text = text,
                 color = VReaderColors.Ink,
@@ -449,7 +589,14 @@ private fun TxtBody(
                 fontSize = 18.sp,
                 lineHeight = 29.sp,
                 onTextLayout = { layout = it },
-                modifier = Modifier.drawBehind { layout?.let { drawWashes(it, washes) } },
+                modifier = Modifier
+                    .onGloballyPositioned { coords = it }
+                    .drawBehind {
+                        layout?.let { l ->
+                            drawWashes(l, washes)
+                            selRange?.let { drawRangeFill(l, it, selectionAccent) }
+                        }
+                    },
             )
         }
     }

--- a/android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt
@@ -1,0 +1,112 @@
+// Purpose: feature #124 WI-3 — drives the TXT custom selection. Each visible chunk registers its
+// TextLayoutResult + LayoutCoordinates; the controller converts a pointer (LazyColumn-local) → window
+// space → the hit chunk's local space → rendered offset → SOURCE offset (TxtSourceOffsets), and resolves
+// a word boundary at long-press. Selection is a SOURCE Utf16Range; the in-progress range renders as an
+// accent wash. Kept off the Activity so the geometry is isolated; the Activity wires the gesture +
+// popover + persistence.
+package com.vreader.app.reader
+
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.text.TextLayoutResult
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+@Stable
+class TxtSelectionController(private val doc: TxtDocument) {
+    private data class ChunkInfo(val layout: TextLayoutResult, val coords: LayoutCoordinates)
+    /** A resolved hit: the chunk index/info + the chunk-local rendered offset + the absolute source offset. */
+    private data class Hit(val chunkIndex: Int, val info: ChunkInfo, val rendered: Int, val source: Int)
+    private val chunks = HashMap<Int, ChunkInfo>()
+    private var lazyCoords: LayoutCoordinates? = null
+    // the initial word selected at long-press — the FIXED anchor; drags extend relative to it (never drop it).
+    private var anchorRange: Utf16Range? = null
+
+    private val _selection = MutableStateFlow<Utf16Range?>(null)
+    val selection: StateFlow<Utf16Range?> = _selection.asStateFlow()
+
+    fun setLazyCoords(coords: LayoutCoordinates) { lazyCoords = coords }
+    fun registerChunk(index: Int, layout: TextLayoutResult, coords: LayoutCoordinates) {
+        chunks[index] = ChunkInfo(layout, coords)
+    }
+    fun unregisterChunk(index: Int) { chunks.remove(index) }
+
+    /** Pointer (LazyColumn-local) → the hit chunk + chunk-local rendered offset + source offset. The hit
+     *  chunk is used for BOTH the source mapping AND word-boundary lookup (avoids a chunk-boundary shift). */
+    private fun hitAt(localPoint: Offset): Hit? {
+        val lz = lazyCoords ?: return null
+        if (chunks.isEmpty()) return null
+        val windowPoint = lz.localToWindow(localPoint)
+        val hit = chunks.entries.firstOrNull { it.value.coords.boundsInWindow().contains(windowPoint) }
+            ?: chunks.entries.minByOrNull { verticalDistance(it.value.coords.boundsInWindow(), windowPoint) }
+            ?: return null
+        val chunkLocal = hit.value.coords.windowToLocal(windowPoint)
+        val rendered = hit.value.layout.getOffsetForPosition(chunkLocal).coerceIn(0, hit.value.layout.layoutInput.text.length)
+        return Hit(hit.key, hit.value, rendered, TxtSourceOffsets.sourceOffset(doc, hit.key, rendered))
+    }
+
+    /** Long-press: select the word under [localPoint] (word boundary in the HIT chunk, mapped to source). */
+    fun beginAt(localPoint: Offset) {
+        val hit = hitAt(localPoint) ?: return
+        val word = hit.info.layout.getWordBoundary(hit.rendered)   // rendered coords in the hit chunk
+        val base = doc.offsetForChunk(hit.chunkIndex)
+        val start = base + word.start
+        val end = base + word.end
+        val range = if (end > start) Utf16Range(start, end) else Utf16Range(hit.source, (hit.source + 1).coerceAtMost(doc.text.length))
+        anchorRange = range
+        _selection.value = range
+    }
+
+    /** Drag: extend relative to the FIXED [anchorRange] (the initial word) — extending before it grows the
+     *  start, after it grows the end, inside it keeps the word. The anchor word is never dropped. */
+    fun extendTo(localPoint: Offset) {
+        val anchor = anchorRange ?: return
+        val off = (hitAt(localPoint) ?: return).source.coerceIn(0, doc.text.length)
+        _selection.value = when {
+            off <= anchor.startInclusive -> Utf16Range(off, anchor.endExclusive)
+            off >= anchor.endExclusive -> Utf16Range(anchor.startInclusive, off)
+            else -> anchor
+        }
+    }
+
+    fun clear() { _selection.value = null; anchorRange = null }
+
+    /** The current selection range, or null. */
+    fun currentRange(): Utf16Range? = _selection.value
+
+    /** Whether the current selection is a persist-worthy range (in-bounds, non-empty, surrogate-safe). */
+    fun isCurrentSelectionValid(): Boolean = _selection.value?.let { TxtSelection.isValid(it, doc.text) } ?: false
+
+    /** The SOURCE substring of the current selection (for the popover's text / copy / share). */
+    fun selectedText(): String? {
+        val r = _selection.value ?: return null
+        if (r.isEmpty || r.endExclusive > doc.text.length) return null
+        return doc.text.substring(r.startInclusive, r.endExclusive)
+    }
+
+    /** The in-progress selection projected onto [chunkIndex] (chunk-local), for the accent wash. */
+    fun selectionForChunk(chunkIndex: Int): Utf16Range? {
+        val r = _selection.value ?: return null
+        return TxtSourceOffsets.chunkRanges(doc, r).firstOrNull { it.chunkIndex == chunkIndex }?.local
+    }
+
+    /** The window-space point just below the selection's end, to anchor the popover. */
+    fun selectionEndAnchorWindow(): Offset? {
+        val r = _selection.value ?: return null
+        val endChunk = doc.chunkForOffset((r.endExclusive - 1).coerceAtLeast(0)).coerceIn(0, doc.chunkCount - 1)
+        val info = chunks[endChunk] ?: return null
+        val base = doc.offsetForChunk(endChunk)
+        val renderedEnd = (r.endExclusive - base).coerceIn(0, info.layout.layoutInput.text.length)
+        val rect = info.layout.getCursorRect(renderedEnd)
+        return info.coords.localToWindow(Offset(rect.left, rect.bottom))
+    }
+
+    private fun verticalDistance(bounds: androidx.compose.ui.geometry.Rect, p: Offset): Float = when {
+        p.y < bounds.top -> bounds.top - p.y
+        p.y > bounds.bottom -> p.y - bounds.bottom
+        else -> 0f
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.11.2
-versionCode=58
+versionName=0.11.3
+versionCode=59


### PR DESCRIPTION
WI-3 of feature #124. Custom long-press-drag selection in the TXT reader → the designed popover → create highlight/note. The gesture is automatable via the Compose harness (verified on emulator). Part of #1841.

## Codex Audit
Gate-4, 1 round, ship-as-is (3 Medium + 1 Low fixed).

## Validation (emulator API 35)
- [x] longPressOnText_selectsWord_showsSelectionPopover — real long-press → popover
- [x] longPress_thenTapColor_createsAndPersistsHighlight — full create E2E
- [x] rendersWithSeededHighlight + TxtHighlightConnectedTest
- [x] Version: android/v0.11.2 → v0.11.3 (behavioral, patch)