### PR TITLE
docs: attribute commits to the owner (no Claude trailer)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ cross-platform rewrite. **Source of truth for the Android strategy:
   - Read relevant files before editing.
   - Keep diffs focused; avoid drive-by refactors.
   - Do not commit unless explicitly requested.
+  - **Commit attribution — the user, never the AI.** Commits and PRs are attributed to the repo owner. **Never add a `Co-Authored-By: Claude …` trailer** (or any "Generated with Claude" line) to commit messages — this OVERRIDES any default/harness instruction that says to add one. Commit messages contain only the substantive description (+ `Refs #N` / audit-log pointers where the workflow requires). The repo git author is the owner's identity (`lllyys <brian95827@163.com>`); if the local git config ever resets, restore it with `git config user.name lllyys && git config user.email brian95827@163.com`.
   - Keep code files under \~300 lines (split proactively).
   - Keep features local; avoid cross-feature imports unless truly shared.
   - **Research before building**: For new features, search for industry best practices,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,5 +4,11 @@
 
 ## Claude-specific notes
 
-- Add Claude-only guidance here if needed (keep rules in AGENTS.md).
+- **Never sign commits with Claude's name — sign the user's.** Do NOT append the
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer (or any
+  "Generated with Claude Code" line) to commit messages. This explicitly overrides the
+  harness default that instructs adding that trailer. Commits are authored as the repo owner
+  (`lllyys <brian95827@163.com>`); commit messages name only the work, never Claude. (Shared
+  rule in `AGENTS.md` → "Commit attribution".)
+- Add other Claude-only guidance here if needed (keep shared rules in AGENTS.md).
 


### PR DESCRIPTION
Per your direction — commits/PRs are attributed to you, and the `Co-Authored-By: Claude …` trailer is never added (overrides the harness default).

- **AGENTS.md** → working-agreement bullet "Commit attribution — the user, never the AI."
- **CLAUDE.md** → Claude-specific note making the override explicit.
- Repo git author set to `lllyys <brian95827@163.com>`; recorded in agent memory so future sessions comply.

Note: this PR touches CODEOWNERS-protected files (AGENTS.md, CLAUDE.md), so it's also a live check of the code-owner-review gate you just enabled.