### PR TITLE
feat(#126 WI-2): FoliateMessageParser (typed bridge messages)

### DIFF
--- a/.claude/codex-audits/feat-feature-126-wi-2-message-parser-audit.md
+++ b/.claude/codex-audits/feat-feature-126-wi-2-message-parser-audit.md
@@ -1,0 +1,27 @@
+---
+branch: feat/feature-126-wi-2-message-parser
+threadId: 019f114f-416f-79c3-a0df-6c7574a32398
+rounds: 1
+final_verdict: follow-up-recommended
+date: 2026-06-29
+---
+
+# Gate-4 audit — feature #126 WI-2 (FoliateMessageParser)
+
+Codex (gpt-5.5/high) audited the pure bridge-message parser. Verdict:
+**follow-up-recommended** (1 Medium, 2 Low). The auditor confirmed the kotlinx
+usage is idiomatic and that `prim(key)?.takeIf { it.isString }` is the correct API to
+distinguish a JSON string from number/bool/null. All findings fixed in-branch:
+
+| # | sev | finding | resolution |
+|---|---|---|---|
+| 1 | **Medium** | `int()/dbl()` parsed from `JsonPrimitive.content`, so a quoted numeric string (`"3"`) was accepted as a number AND `"fraction":"NaN"`/`"Infinity"` could yield a non-finite Double — corrupting the `fraction` resume anchor (hostile-payload gap). | **Fixed** — `int()`/`dbl()` now reject JSON strings (`takeUnless { it.isString }`) and `dbl()` requires `isFinite()`. Tests `nonFiniteOrStringFraction_isRejected` + `quotedNumericSectionIndex_isRejected_defaults` lock it. |
+| 2 | Low | `str()` documented "non-blank" but only rejected `""` → `"name":"   "` became `Other("   ")`. | **Fixed** — `str()` uses `isNotBlank()`; a blank `name` now → `null` (non-usable). Test `blankName_returnsNull`. |
+| 3 | Low | Tests didn't lock hostile scalar types (numeric/null/bool name & title, NaN/Infinity fraction, non-object detail). | **Fixed** — added `nonStringName_returnsNull`, `numericOrNullTitle_isAbsent`, `nonFiniteOrStringFraction_isRejected`, `nonObjectDetail_degradesToEmpty`, etc. |
+
+The parser never throws (parse wraps decode in `runCatching`, returns `null` for
+non-usable input, `Other` for unknown names) — safe inside the WebMessageListener callback.
+
+Re-verification: `FoliateMessageParserTest` **22/22** green via `:app:testDebugUnitTest`.
+
+**Verdict: follow-up-recommended** — all findings fixed + test-proven in-branch.

--- a/android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateMessage.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateMessage.kt
@@ -1,0 +1,32 @@
+// Purpose: typed events the Android Foliate (AZW3/MOBI/KF8) reader receives from the foliate-js
+// bundle running in a WebView. The bundle posts `{name, detail}` JSON over the bridge (the iOS
+// `window.webkit.messageHandlers[name].postMessage` calls, forwarded by the Android shell shim to
+// `addWebMessageListener`'s `vreaderHost`). FoliateMessageParser turns that wire JSON into these.
+// Mirrors the iOS FoliateMessageParser contract. Feature #126 WI-2.
+package com.vreader.app.reader.foliate
+
+/** A parsed event from the foliate-js bundle. Only the messages the MVP reader consumes are typed;
+ *  everything else (selection/tap/tts/search/…) maps to [Other] and is ignored by the reader. */
+sealed interface FoliateMessage {
+
+    /** The bundle loaded and `window.readerAPI` is available — safe to call `open`/`init`. */
+    data object BridgeReady : FoliateMessage
+
+    /** The book parsed; metadata is available. `sectionTotal` is the spine length (> 0 when real). */
+    data class BookReady(val title: String?, val sectionTotal: Int) : FoliateMessage
+
+    /** Reading position changed. `cfi` is foliate's platform-local CFI (lossy cross-platform);
+     *  `fraction` is the 0..1 progress (the canonical resume anchor). */
+    data class Relocate(
+        val cfi: String?,
+        val fraction: Double?,
+        val sectionIndex: Int,
+        val sectionTotal: Int,
+    ) : FoliateMessage
+
+    /** A JS-side error (bundle init failure, open failure, unhandled rejection). */
+    data class Error(val message: String, val type: String?) : FoliateMessage
+
+    /** A recognized-but-unconsumed event name (selection, tap, tts-*, search-*, …). */
+    data class Other(val name: String) : FoliateMessage
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateMessageParser.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateMessageParser.kt
@@ -1,0 +1,61 @@
+// Purpose: parse the `{name, detail}` wire JSON the foliate-js bundle posts over the WebView bridge
+// into a typed [FoliateMessage]. Pure + side-effect-free so it is fully JVM-unit-testable (no WebView).
+// Uses kotlinx.serialization (the module convention, cf. ReadiumLocatorBridge) — NOT org.json, which
+// is a throwing stub under JVM unit tests. Feature #126 WI-2.
+package com.vreader.app.reader.foliate
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+
+object FoliateMessageParser {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    /**
+     * Parse one bridge message. Returns `null` for input that isn't a usable message — non-JSON,
+     * not an object, or missing/empty `name` — so a malformed/hostile payload degrades to "ignored"
+     * rather than throwing into the WebView callback. Unknown-but-valid names map to [FoliateMessage.Other].
+     */
+    fun parse(raw: String): FoliateMessage? {
+        val root = runCatching { json.parseToJsonElement(raw).jsonObject }.getOrNull() ?: return null
+        val name = root.str("name") ?: return null
+        val detail = (root["detail"] as? JsonObject) ?: JsonObject(emptyMap())
+        return when (name) {
+            "bridge-ready" -> FoliateMessage.BridgeReady
+            "book-ready" -> FoliateMessage.BookReady(
+                title = detail.str("title"),
+                sectionTotal = detail.int("sections") ?: detail.int("sectionTotal") ?: 0,
+            )
+            "relocate" -> FoliateMessage.Relocate(
+                cfi = detail.str("cfi"),
+                fraction = detail.dbl("fraction"),
+                sectionIndex = detail.int("sectionIndex") ?: 0,
+                sectionTotal = detail.int("sectionTotal") ?: 1,
+            )
+            "error" -> FoliateMessage.Error(
+                message = detail.str("message") ?: "unknown",
+                type = detail.str("type"),
+            )
+            else -> FoliateMessage.Other(name)
+        }
+    }
+
+    private fun JsonObject.prim(key: String): JsonPrimitive? = this[key] as? JsonPrimitive
+
+    /** Non-blank string content, or null (treats JSON null / blank / non-string as absent). */
+    private fun JsonObject.str(key: String): String? =
+        prim(key)?.takeIf { it.isString }?.content?.takeIf { it.isNotBlank() }
+
+    /** Integer from a JSON number, or null. A quoted numeric STRING ("3") is NOT accepted. */
+    private fun JsonObject.int(key: String): Int? =
+        prim(key)?.takeUnless { it.isString }?.intOrNull
+
+    /** FINITE double from a JSON number, or null. Quoted strings ("0.5", "NaN", "Infinity") and
+     *  non-finite values are rejected — a hostile book must not corrupt the fraction resume anchor. */
+    private fun JsonObject.dbl(key: String): Double? =
+        prim(key)?.takeUnless { it.isString }?.doubleOrNull?.takeIf { it.isFinite() }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/foliate/FoliateMessageParserTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/foliate/FoliateMessageParserTest.kt
@@ -1,0 +1,131 @@
+package com.vreader.app.reader.foliate
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Feature #126 WI-2 — the pure bridge-message parser. */
+class FoliateMessageParserTest {
+
+    @Test fun bridgeReady() {
+        assertEquals(FoliateMessage.BridgeReady, FoliateMessageParser.parse("""{"name":"bridge-ready","detail":{}}"""))
+    }
+
+    @Test fun bridgeReady_withoutDetail() {
+        assertEquals(FoliateMessage.BridgeReady, FoliateMessageParser.parse("""{"name":"bridge-ready"}"""))
+    }
+
+    @Test fun bookReady_sections() {
+        val m = FoliateMessageParser.parse("""{"name":"book-ready","detail":{"title":"被偷走的勇气","sections":85}}""")
+        assertEquals(FoliateMessage.BookReady("被偷走的勇气", 85), m)
+    }
+
+    @Test fun bookReady_acceptsSectionTotalAlias() {
+        val m = FoliateMessageParser.parse("""{"name":"book-ready","detail":{"sectionTotal":12}}""")
+        assertEquals(FoliateMessage.BookReady(null, 12), m)
+    }
+
+    @Test fun bookReady_missingSections_defaultsZero() {
+        assertEquals(FoliateMessage.BookReady(null, 0), FoliateMessageParser.parse("""{"name":"book-ready","detail":{}}"""))
+    }
+
+    @Test fun relocate_full() {
+        val m = FoliateMessageParser.parse(
+            """{"name":"relocate","detail":{"cfi":"/6/4!/4/2","fraction":0.42,"sectionIndex":3,"sectionTotal":85}}""",
+        )
+        assertEquals(FoliateMessage.Relocate("/6/4!/4/2", 0.42, 3, 85), m)
+    }
+
+    @Test fun relocate_nullCfiAndFraction() {
+        val m = FoliateMessageParser.parse("""{"name":"relocate","detail":{"cfi":null,"fraction":null}}""")
+        assertEquals(FoliateMessage.Relocate(null, null, 0, 1), m)
+    }
+
+    @Test fun relocate_missingFraction_isNull() {
+        val m = FoliateMessageParser.parse("""{"name":"relocate","detail":{"sectionIndex":2,"sectionTotal":9}}""") as FoliateMessage.Relocate
+        assertNull(m.fraction)
+        assertEquals(2, m.sectionIndex)
+    }
+
+    @Test fun relocate_fractionZero_isPreserved() {
+        val m = FoliateMessageParser.parse("""{"name":"relocate","detail":{"fraction":0.0}}""") as FoliateMessage.Relocate
+        assertEquals(0.0, m.fraction!!, 0.0)
+    }
+
+    @Test fun error_messageAndType() {
+        assertEquals(
+            FoliateMessage.Error("open failed: x", "open"),
+            FoliateMessageParser.parse("""{"name":"error","detail":{"message":"open failed: x","type":"open"}}"""),
+        )
+    }
+
+    @Test fun error_missingMessage_defaultsUnknown() {
+        assertEquals(FoliateMessage.Error("unknown", null), FoliateMessageParser.parse("""{"name":"error","detail":{}}"""))
+    }
+
+    @Test fun unknownName_mapsToOther() {
+        assertEquals(FoliateMessage.Other("selection"), FoliateMessageParser.parse("""{"name":"selection","detail":{"text":"hi"}}"""))
+        assertEquals(FoliateMessage.Other("tts-ssml"), FoliateMessageParser.parse("""{"name":"tts-ssml"}"""))
+    }
+
+    @Test fun malformedJson_returnsNull() {
+        assertNull(FoliateMessageParser.parse("not json"))
+        assertNull(FoliateMessageParser.parse("""{"name":"relocate","detail":{"""))
+        assertNull(FoliateMessageParser.parse(""))
+    }
+
+    @Test fun nonObjectJson_returnsNull() {
+        assertNull(FoliateMessageParser.parse("""["relocate"]"""))
+        assertNull(FoliateMessageParser.parse("""42"""))
+        assertNull(FoliateMessageParser.parse(""""relocate""""))
+    }
+
+    @Test fun missingOrEmptyName_returnsNull() {
+        assertNull(FoliateMessageParser.parse("""{"detail":{"x":1}}"""))
+        assertNull(FoliateMessageParser.parse("""{"name":"","detail":{}}"""))
+    }
+
+    // --- hostile / wrong-type scalar payloads must degrade safely (Gate-4) ---
+
+    @Test fun nonStringName_returnsNull() {
+        assertNull(FoliateMessageParser.parse("""{"name":42,"detail":{}}"""))
+        assertNull(FoliateMessageParser.parse("""{"name":true,"detail":{}}"""))
+        assertNull(FoliateMessageParser.parse("""{"name":null,"detail":{}}"""))
+    }
+
+    @Test fun blankName_returnsNull() {
+        assertNull(FoliateMessageParser.parse("""{"name":"   ","detail":{}}"""))
+    }
+
+    @Test fun numericOrNullTitle_isAbsent() {
+        assertEquals(FoliateMessage.BookReady(null, 5), FoliateMessageParser.parse("""{"name":"book-ready","detail":{"title":42,"sections":5}}"""))
+        assertEquals(FoliateMessage.BookReady(null, 5), FoliateMessageParser.parse("""{"name":"book-ready","detail":{"title":null,"sections":5}}"""))
+    }
+
+    @Test fun nonFiniteOrStringFraction_isRejected() {
+        // "NaN"/"Infinity" as JSON strings, and a quoted number, must not become a fraction.
+        assertNull((FoliateMessageParser.parse("""{"name":"relocate","detail":{"fraction":"NaN"}}""") as FoliateMessage.Relocate).fraction)
+        assertNull((FoliateMessageParser.parse("""{"name":"relocate","detail":{"fraction":"Infinity"}}""") as FoliateMessage.Relocate).fraction)
+        assertNull((FoliateMessageParser.parse("""{"name":"relocate","detail":{"fraction":"0.5"}}""") as FoliateMessage.Relocate).fraction)
+    }
+
+    @Test fun quotedNumericSectionIndex_isRejected_defaults() {
+        val m = FoliateMessageParser.parse("""{"name":"relocate","detail":{"sectionIndex":"7"}}""") as FoliateMessage.Relocate
+        assertEquals(0, m.sectionIndex) // quoted string not accepted → default
+    }
+
+    @Test fun nonObjectDetail_degradesToEmpty() {
+        assertEquals(FoliateMessage.BookReady(null, 0), FoliateMessageParser.parse("""{"name":"book-ready","detail":null}"""))
+        assertEquals(FoliateMessage.BookReady(null, 0), FoliateMessageParser.parse("""{"name":"book-ready","detail":[1,2]}"""))
+        assertEquals(FoliateMessage.BookReady(null, 0), FoliateMessageParser.parse("""{"name":"book-ready","detail":7}"""))
+    }
+
+    @Test fun extraUnknownKeys_areIgnored() {
+        val m = FoliateMessageParser.parse(
+            """{"name":"relocate","detail":{"cfi":"/2","fraction":0.1,"tocLabel":"Ch 1","locationCurrent":7},"ts":123}""",
+        )
+        assertTrue(m is FoliateMessage.Relocate)
+        assertEquals("/2", (m as FoliateMessage.Relocate).cfi)
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.12.2
-versionCode=62
+versionName=0.12.3
+versionCode=63


### PR DESCRIPTION
## Summary
Pure bridge-message parser for the Android AZW3/foliate reader: `{name, detail}` wire JSON → typed `FoliateMessage` (BridgeReady / BookReady / Relocate / Error / Other). Part of feature #1851.

- kotlinx.serialization (module convention); never throws (safe in the `WebMessageListener` callback).
- Numeric helpers reject quoted strings + **non-finite** doubles — a hostile book can't corrupt the `fraction` resume anchor via `"NaN"`/`"Infinity"`.

## Gate-4 audit
Codex — **follow-up-recommended**, 1M/2L all fixed in-branch (non-finite-fraction reject, blank-name handling, hostile-scalar tests). Log: `.claude/codex-audits/feat-feature-126-wi-2-message-parser-audit.md`.

## Validation
- [x] `FoliateMessageParserTest` 22/22 (`:app:testDebugUnitTest`)
- [x] Gate-4 follow-up-recommended (fixed)
- [x] android/v0.12.2 → v0.12.3

## Gate 5a (foundational)
Pure parser; unit tests + audit sufficient. Note: `FoliateAssetServer` moved to WI-3 (coupled with the `androidx.webkit` main dep + bridge).