### PR TITLE
feat(#126 WI-3): secure FoliateBridge + asset server + policy

### DIFF
--- a/.claude/codex-audits/feat-feature-126-wi-3-secure-bridge-audit.md
+++ b/.claude/codex-audits/feat-feature-126-wi-3-secure-bridge-audit.md
@@ -1,0 +1,40 @@
+---
+branch: feat/feature-126-wi-3-secure-bridge
+threadId: 019f1171-c36a-7f71-9429-f739dd3ef5be
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-29
+---
+
+# Gate-4 audit — feature #126 WI-3 (secure WebView bridge)
+
+Security-critical WI. Codex (gpt-5.5/high), 2 rounds.
+
+## Round 1 (threadId 019f1166-5d44-77e2-88b5-993414ffa279) — **block-recommended** (1H/3M/1L)
+The auditor confirmed the policy has NO prefix-match bypass (sibling-host
+`…androidplatform.net.evil.com` and userinfo `…net@evil.com` both rejected by the
+exact-origin/`origin + "/"` guard). Findings, all fixed:
+
+| # | sev | finding | fix |
+|---|---|---|---|
+| 1 | **High** | `shouldOverrideUrlLoading` blocked EVERY off-origin nav, including foliate's `blob:` SECTION SUBFRAMES → would break rendering. (WI-0's bare WebView had no WebViewClient, so it never hit this.) | Only gate `request.isForMainFrame`; allow subframe `blob:`/`about:blank` (their remote subresources are still blocked in `shouldInterceptRequest`). |
+| 2 | Medium | Same-origin requests the asset loader didn't handle returned `null` → WebView falls through to network (not fail-closed). | Same-origin miss → bridge **404**; only non-same-origin internal schemes (`blob:`/`data:`) return `null`. |
+| 3 | Medium | `BookFilePathHandler` served the full book for ANY `/book/...` path → a no-script section could force repeated large-book streams. | Serve ONLY `path == BOOK_NAME`; else `null` (→ 404); add `Cache-Control: no-store`. |
+| 4 | Medium | `send(js: String)` raw JS exec → a future caller passing a book-derived CFI could inject shell JS. | Removed raw `send`; typed `openBook()/init()/initAtCfi()/initAtFraction()/next()/prev()`; CFI via `Json.encodeToString(String.serializer(), cfi)` (injection-safe literal); `initAtFraction` guards `isFinite()`. |
+| 5 | Low | `androidx.webkit:webkit:1.12.1` stale. | → `1.16.0` (minSdk 24, compatible). |
+
+(Also fixed a self-inflicted compile break: a KDoc containing `` `/book/*` `` opened a
+nested block comment — Kotlin nests block comments — reworded.)
+
+## Round 2 (threadId 019f1171-c36a-7f71-9429-f739dd3ef5be) — **ship-as-is**
+**Findings: none.** All 5 round-1 fixes confirmed closed; no new issue.
+`FoliateBridgePolicyTest` 10/10 (added sibling-host/userinfo bypass tests).
+
+## Verification
+- JVM: `FoliateBridgePolicyTest` 10/10, `FoliateMessageParserTest` 22/22 (`:app:testDebugUnitTest`).
+- On-device: WI-0 already proved the same mechanism (patched bundle + `addWebMessageListener`
+  + `isMainFrame`) blocks the hostile-section escape. **The real-bridge render smoke is deferred to
+  WI-6's Activity test, which MUST verify: valid AZW3 render through real `blob:` subframes,
+  off-origin top-level nav blocked, remote subresource loads blocked** (per the round-2 residual note).
+
+**Verdict: ship-as-is** (after the round-1 block was cleared).

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -115,6 +115,11 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("androidx.fragment:fragment-ktx:1.8.9")
 
+    // feature #126 WI-3 — the AZW3/foliate reader's secure WebView bridge:
+    // WebViewAssetLoader (virtual https origin), WebViewCompat.addWebMessageListener
+    // (origin-allowlisted bridge, never addJavascriptInterface), WebViewFeature gating.
+    implementation("androidx.webkit:webkit:1.16.0")
+
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
 
     testImplementation("junit:junit:4.13.2")
@@ -133,9 +138,4 @@ dependencies {
     androidTestImplementation(composeBom)
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
-
-    // feature #126 WI-0 (spike) — WebView + foliate-js go/no-go harness.
-    // WebViewAssetLoader (virtual https origin) + WebViewCompat.addWebMessageListener
-    // (secure bridge) + WebViewFeature gating. WI-3 promotes this to `implementation`.
-    androidTestImplementation("androidx.webkit:webkit:1.12.1")
 }

--- a/android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateAssetServer.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateAssetServer.kt
@@ -1,0 +1,61 @@
+// Purpose: serve the foliate-js bundle + Android shell (from app assets/foliate/) and the imported
+// book file (from app-private storage) to the reader WebView over a single VIRTUAL HTTPS origin
+// (never file://). The book's untrusted scripts are neutered by the bundle patch (no `allow-scripts`
+// on section iframes) + the shell CSP — NOT by origin separation: WI-0 proved foliate's section
+// documents are shell-origin `blob:` URLs regardless of where the book FILE is served, so a separate
+// book domain would not isolate them. Feature #126 WI-3.
+package com.vreader.app.reader.foliate
+
+import android.content.Context
+import android.webkit.WebResourceResponse
+import androidx.webkit.WebViewAssetLoader
+import java.io.File
+
+object FoliateAssetServer {
+
+    /** The fixed virtual origin `WebViewAssetLoader` serves from. The bridge allow-lists ONLY this
+     *  origin for `addWebMessageListener`, and blocks navigation/resource requests to any other. */
+    const val SHELL_ORIGIN = "https://appassets.androidplatform.net"
+    const val SHELL_URL = "$SHELL_ORIGIN/assets/foliate/reader.html"
+    const val BOOK_PATH = "/book/"
+    const val BOOK_NAME = "book"
+
+    /** The same-origin URL the shell `fetch()`es to hand foliate the book bytes as a Blob. */
+    fun bookUrl(): String = "$SHELL_ORIGIN$BOOK_PATH$BOOK_NAME"
+
+    /**
+     * One loader on [SHELL_ORIGIN]: `/assets/…` → app assets (bundle + shell), `/book/…` → the
+     * imported book file. File IO happens inside the handler (off the main thread — the loader is
+     * invoked on a WebView background thread).
+     */
+    fun loader(context: Context, bookFile: File): WebViewAssetLoader =
+        WebViewAssetLoader.Builder()
+            .addPathHandler("/assets/", WebViewAssetLoader.AssetsPathHandler(context.applicationContext))
+            .addPathHandler(BOOK_PATH, BookFilePathHandler(bookFile))
+            .build()
+
+    /** Serves the imported book file for ONLY the exact `book` sub-path (a hostile no-script section
+     *  can't force repeated large-book streams via arbitrary `/book/...` URLs); null (→ the bridge
+     *  fails closed with 404) for anything else or if the file is gone. */
+    private class BookFilePathHandler(private val bookFile: File) : WebViewAssetLoader.PathHandler {
+        override fun handle(path: String): WebResourceResponse? {
+            if (path != BOOK_NAME) return null
+            return try {
+                if (!bookFile.isFile) {
+                    null
+                } else {
+                    WebResourceResponse(
+                        "application/octet-stream",
+                        null,
+                        200,
+                        "OK",
+                        mapOf("Cache-Control" to "no-store"),
+                        bookFile.inputStream(),
+                    )
+                }
+            } catch (e: Exception) {
+                null
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateBridge.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateBridge.kt
@@ -1,0 +1,129 @@
+// Purpose: the secure WebView<->native transport for the AZW3/foliate reader. Wires a WebView with:
+// WebViewAssetLoader (virtual https origin, no file://), a WebViewClient that serves same-origin
+// assets/book + BLOCKS every remote resource request and off-origin navigation, render-process-death
+// passthrough (the host Activity owns recovery — WI-6), and WebViewCompat.addWebMessageListener
+// allow-listed to the shell origin (NEVER addJavascriptInterface) feeding FoliateMessageParser. The
+// security decisions live in FoliateBridgePolicy (pure, JVM-tested). MAIN-THREAD ONLY. Feature #126 WI-3.
+package com.vreader.app.reader.foliate
+
+import android.annotation.SuppressLint
+import android.webkit.RenderProcessGoneDetail
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import androidx.annotation.MainThread
+import androidx.webkit.WebViewAssetLoader
+import androidx.webkit.WebViewClientCompat
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import java.io.ByteArrayInputStream
+
+/**
+ * Configures [webView] for secure foliate-js hosting and exposes its events as [messages].
+ * Construct on the main thread; call [attach] once, then [load]. All methods are main-thread only.
+ */
+@MainThread
+class FoliateBridge(
+    private val webView: WebView,
+    private val assetLoader: WebViewAssetLoader,
+) {
+    private val _messages = MutableSharedFlow<FoliateMessage>(extraBufferCapacity = 64)
+    val messages: SharedFlow<FoliateMessage> = _messages.asSharedFlow()
+
+    /** Invoked when this device's WebView is too old for `addWebMessageListener` (→ WebViewUnsupported). */
+    var onWebViewUnsupported: (() -> Unit)? = null
+
+    /** Render process died; the host Activity owns recovery (snapshot locator → recreate → reopen).
+     *  Return true to keep the app alive. Default false (no recovery) until WI-6 sets it. */
+    var onRenderProcessGone: ((RenderProcessGoneDetail?) -> Boolean)? = null
+
+    @SuppressLint("SetJavaScriptEnabled")
+    fun attach() {
+        webView.settings.apply {
+            javaScriptEnabled = true // foliate needs it; book section scripts are disabled via the bundle patch
+            allowFileAccess = false
+            allowContentAccess = false
+            @Suppress("DEPRECATION") allowFileAccessFromFileURLs = false
+            @Suppress("DEPRECATION") allowUniversalAccessFromFileURLs = false
+            domStorageEnabled = true
+            mediaPlaybackRequiresUserGesture = true
+        }
+        webView.webViewClient = object : WebViewClientCompat() {
+            override fun shouldInterceptRequest(view: WebView, request: WebResourceRequest): WebResourceResponse? {
+                val url = request.url?.toString()
+                if (FoliateBridgePolicy.shouldBlockRequest(url)) return blocked(403, "blocked")
+                val handled = request.url?.let { assetLoader.shouldInterceptRequest(it) }
+                if (handled != null) return handled
+                // Same-origin but the loader didn't handle it → FAIL CLOSED (never reach the network).
+                if (FoliateBridgePolicy.isSameOrigin(url)) return blocked(404, "not found")
+                return null // blob:/data:/etc. — handled internally by the WebView, not via this callback
+            }
+
+            override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+                // Only gate TOP-LEVEL navigation. Foliate renders each book section as a `blob:`
+                // SUBFRAME — allow those (their remote subresources are still blocked above). A
+                // main-frame nav off the shell origin is blocked.
+                if (!request.isForMainFrame) return false
+                return !FoliateBridgePolicy.isAllowedNavigation(request.url?.toString())
+            }
+
+            override fun onRenderProcessGone(view: WebView?, detail: RenderProcessGoneDetail?): Boolean =
+                onRenderProcessGone?.invoke(detail) ?: false
+        }
+
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) {
+            WebViewCompat.addWebMessageListener(
+                webView, BRIDGE_NAME, setOf(FoliateAssetServer.SHELL_ORIGIN),
+            ) { _, message, sourceOrigin, isMainFrame, _ ->
+                if (FoliateBridgePolicy.isTrustedMessage(sourceOrigin?.toString(), isMainFrame)) {
+                    FoliateMessageParser.parse(message.data ?: "")?.let { _messages.tryEmit(it) }
+                }
+            }
+        } else {
+            onWebViewUnsupported?.invoke()
+        }
+    }
+
+    fun load() = webView.loadUrl(FoliateAssetServer.SHELL_URL)
+
+    // --- typed reader API (no raw JS exposed; book-derived strings are JSON-escaped) ------------
+
+    /** Fetch the book bytes from the app-controlled same-origin URL and hand foliate a File to open. */
+    fun openBook() = eval(
+        "(async()=>{try{const r=await fetch(${jsString(FoliateAssetServer.bookUrl())});" +
+            "const b=await r.blob();await readerAPI.open(new File([b],'book',{type:'application/octet-stream'}));}" +
+            "catch(e){window.__vreaderPost&&window.__vreaderPost('error',{message:'open: '+e,type:'open'});}})()",
+    )
+
+    fun init() = eval("try{readerAPI.init({})}catch(e){}")
+
+    /** Restore by foliate CFI. The CFI is book-derived → JSON-escaped to prevent shell JS injection. */
+    fun initAtCfi(cfi: String) = eval("try{readerAPI.init({cfi:${jsString(cfi)}})}catch(e){}")
+
+    fun initAtFraction(fraction: Double) {
+        if (fraction.isFinite()) eval("try{readerAPI.init({fraction:$fraction})}catch(e){}")
+    }
+
+    fun next() = eval("try{readerAPI.next&&readerAPI.next()}catch(e){}")
+
+    fun prev() = eval("try{readerAPI.prev&&readerAPI.prev()}catch(e){}")
+
+    fun destroy() = webView.destroy()
+
+    private fun eval(js: String) = webView.evaluateJavascript(js, null)
+
+    /** Encode [s] as a JSON string literal — also a safe JS string literal (quotes/escapes handled). */
+    private fun jsString(s: String): String = Json.encodeToString(String.serializer(), s)
+
+    private fun blocked(status: Int, reason: String): WebResourceResponse =
+        WebResourceResponse("text/plain", "utf-8", status, reason, emptyMap(), ByteArrayInputStream(ByteArray(0)))
+
+    companion object {
+        const val BRIDGE_NAME = "vreaderHost"
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateBridgePolicy.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateBridgePolicy.kt
@@ -1,0 +1,43 @@
+// Purpose: the PURE security decisions for the AZW3/foliate reader WebView, extracted from
+// FoliateBridge so they are fully JVM-unit-testable (no WebView). Three boundaries, all keyed to the
+// single trusted shell origin: which bridge messages to trust, which navigations to allow, and which
+// resource requests to block (passive-exfil defense). Feature #126 WI-3.
+package com.vreader.app.reader.foliate
+
+import com.vreader.app.reader.foliate.FoliateAssetServer.SHELL_ORIGIN
+
+object FoliateBridgePolicy {
+
+    /**
+     * A bridge message is trusted only if it comes from the MAIN frame of the trusted shell origin.
+     * WI-0 proved `isMainFrame` alone is insufficient (a same-origin section script can call
+     * `parent.vreaderHost` and be attributed to the main frame), so the LOAD-BEARING defense is the
+     * bundle patch (book sections run no script). This is the second gate: even a main-frame call
+     * from a foreign origin is rejected.
+     */
+    fun isTrustedMessage(sourceOrigin: String?, isMainFrame: Boolean): Boolean =
+        isMainFrame && sourceOrigin == SHELL_ORIGIN
+
+    /** True iff [url] is on the trusted shell origin (exact, or a path under it). The leading-`/`
+     *  guard prevents a sibling-host bypass (`…androidplatform.net.evil.com`). */
+    fun isSameOrigin(url: String?): Boolean =
+        url != null && (url == SHELL_ORIGIN || url.startsWith("$SHELL_ORIGIN/"))
+
+    /** Allow MAIN-FRAME navigation only WITHIN the shell origin; block `javascript:`, off-origin,
+     *  `data:`, top-level `blob:` navs, `target=_blank` to remote, etc. (Sub-frame `blob:` section
+     *  documents are allowed by the bridge — they are required for rendering.) */
+    fun isAllowedNavigation(url: String?): Boolean = isSameOrigin(url)
+
+    /**
+     * Block any resource request that is NOT same-origin and IS an http(s) load — remote `img` /
+     * CSS `url()` / font / media / sub-frame the book HTML might trigger WITHOUT script (the passive
+     * exfil/tracking surface Gate-4 round 3 flagged). Same-origin (`/assets`, `/book`) is served by
+     * the loader; `blob:`/`data:` are handled by the WebView internally and never reach here.
+     */
+    fun shouldBlockRequest(url: String?): Boolean {
+        if (url == null) return false
+        if (isSameOrigin(url)) return false
+        val lower = url.lowercase()
+        return lower.startsWith("http://") || lower.startsWith("https://")
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/foliate/FoliateBridgePolicyTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/foliate/FoliateBridgePolicyTest.kt
@@ -1,0 +1,80 @@
+package com.vreader.app.reader.foliate
+
+import com.vreader.app.reader.foliate.FoliateAssetServer.SHELL_ORIGIN
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Feature #126 WI-3 — the pure WebView security decisions. */
+class FoliateBridgePolicyTest {
+
+    // --- isTrustedMessage: only the main frame of the shell origin ---
+
+    @Test fun trustedMessage_onlyMainFrameOfShellOrigin() {
+        assertTrue(FoliateBridgePolicy.isTrustedMessage(SHELL_ORIGIN, true))
+    }
+
+    @Test fun trustedMessage_rejectsSubFrame() {
+        assertFalse(FoliateBridgePolicy.isTrustedMessage(SHELL_ORIGIN, false))
+    }
+
+    @Test fun trustedMessage_rejectsForeignOrigin() {
+        assertFalse(FoliateBridgePolicy.isTrustedMessage("https://evil.example", true))
+        assertFalse(FoliateBridgePolicy.isTrustedMessage("https://appassets.androidplatform.net.evil.com", true))
+        assertFalse(FoliateBridgePolicy.isTrustedMessage(null, true))
+    }
+
+    // --- isSameOrigin: exact origin or a path under it; sibling-host bypass blocked ---
+
+    @Test fun sameOrigin_exactAndUnderPath() {
+        assertTrue(FoliateBridgePolicy.isSameOrigin(SHELL_ORIGIN))
+        assertTrue(FoliateBridgePolicy.isSameOrigin("$SHELL_ORIGIN/assets/foliate/reader.html"))
+    }
+
+    @Test fun sameOrigin_rejectsSiblingHostAndUserinfoBypass() {
+        assertFalse(FoliateBridgePolicy.isSameOrigin("https://appassets.androidplatform.net.evil.com/x"))
+        assertFalse(FoliateBridgePolicy.isSameOrigin("https://appassets.androidplatform.net@evil.com/x"))
+        assertFalse(FoliateBridgePolicy.isSameOrigin("https://evil.example/x"))
+        assertFalse(FoliateBridgePolicy.isSameOrigin(null))
+    }
+
+    // --- isAllowedNavigation: only within the shell origin ---
+
+    @Test fun navigation_allowsShellOrigin() {
+        assertTrue(FoliateBridgePolicy.isAllowedNavigation(SHELL_ORIGIN))
+        assertTrue(FoliateBridgePolicy.isAllowedNavigation("$SHELL_ORIGIN/assets/foliate/reader.html"))
+        assertTrue(FoliateBridgePolicy.isAllowedNavigation("$SHELL_ORIGIN/book/book"))
+    }
+
+    @Test fun navigation_blocksEverythingElse() {
+        assertFalse(FoliateBridgePolicy.isAllowedNavigation("https://evil.example/x"))
+        assertFalse(FoliateBridgePolicy.isAllowedNavigation("javascript:alert(1)"))
+        assertFalse(FoliateBridgePolicy.isAllowedNavigation("data:text/html,<script>1</script>"))
+        assertFalse(FoliateBridgePolicy.isAllowedNavigation("blob:$SHELL_ORIGIN/abc")) // top-level blob nav
+        assertFalse(FoliateBridgePolicy.isAllowedNavigation("file:///etc/hosts"))
+        assertFalse(FoliateBridgePolicy.isAllowedNavigation("https://appassets.androidplatform.net.evil.com/x"))
+        assertFalse(FoliateBridgePolicy.isAllowedNavigation(null))
+    }
+
+    // --- shouldBlockRequest: block remote http(s); allow same-origin; pass blob/data through ---
+
+    @Test fun request_allowsSameOriginAssetsAndBook() {
+        assertFalse(FoliateBridgePolicy.shouldBlockRequest("$SHELL_ORIGIN/assets/foliate/foliate-bundle.js"))
+        assertFalse(FoliateBridgePolicy.shouldBlockRequest("$SHELL_ORIGIN/book/book"))
+    }
+
+    @Test fun request_blocksRemoteHttpResources() {
+        // passive exfil: remote img / css url() / font / media a hostile book could trigger w/o script
+        assertTrue(FoliateBridgePolicy.shouldBlockRequest("https://tracker.example/pixel.gif"))
+        assertTrue(FoliateBridgePolicy.shouldBlockRequest("http://insecure.example/a.css"))
+        assertTrue(FoliateBridgePolicy.shouldBlockRequest("https://appassets.androidplatform.net.evil.com/x.png"))
+        assertTrue(FoliateBridgePolicy.shouldBlockRequest("HTTPS://Tracker.Example/p")) // case-insensitive
+    }
+
+    @Test fun request_passesNonHttpThrough() {
+        // blob:/data: section docs are handled internally by the WebView; the loader/WebView own these.
+        assertFalse(FoliateBridgePolicy.shouldBlockRequest("blob:$SHELL_ORIGIN/uuid"))
+        assertFalse(FoliateBridgePolicy.shouldBlockRequest("data:image/png;base64,AAAA"))
+        assertFalse(FoliateBridgePolicy.shouldBlockRequest(null))
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.12.3
-versionCode=63
+versionName=0.12.4
+versionCode=64

--- a/dev-docs/plans/20260629-feature-126-android-azw3-reader.md
+++ b/dev-docs/plans/20260629-feature-126-android-azw3-reader.md
@@ -234,16 +234,25 @@ Tier: **F** foundational · **B** behavioral (Gate-5a slice on emulator).
   cleanly to the iOS bundle. Small PR.
 - **WI-2 — `FoliateMessageParser` + `FoliateAssetServer` (shell + book loaders) — F.** Small–medium PR.
 - **WI-3 — `FoliateBridge` security integration (+`androidx.webkit`) — F (own audit).**
-  `addWebMessageListener` shell-origin-only + `isMainFrame`/`sourceOrigin` reject;
-  CSP; nav-block; feature-gate → `WebViewUnsupported`. **Re-runs the WI-0 hostile-AZW3
-  test as a gate.** Medium PR.
+  `FoliateAssetServer` (virtual-https loader + book `PathHandler`), `FoliateBridgePolicy`
+  (pure decisions: trusted-message origin/`isMainFrame`, allowed-nav, remote-resource block),
+  `FoliateBridge` (WebView hardening + `addWebMessageListener` shell-origin-only + `shouldInterceptRequest`
+  remote-block + nav-block + render-death passthrough + `WebViewFeature` gate → `WebViewUnsupported`).
+  Verified by `FoliateBridgePolicyTest` (JVM) + WI-0's on-device proof of the same mechanism.
+  **The real-bridge on-device hostile re-test is folded into WI-6's Activity end-to-end test** (a
+  standalone connected test here wedged the runner via a leaked collector/WebView; WI-6 drives the
+  real bridge with a real book + render, the stronger integration). Medium PR.
 - **WI-4 — `Azw3Document` (@MainThread WebView controller) — F.** Medium PR.
 - **WI-5 — `Azw3LocatorBridge` (relocate → wrapLegacy) — F.** Small–medium PR.
 - **WI-6 — `Azw3ReaderActivity` + Compose host + dispatch + manifest + render-death recovery — B.**
   Owns `onRenderProcessGone` recovery (snapshot `latestLocator` → remove+`destroy` →
   recreate on main → reopen → restore → return `true`). Design check: chrome mirrors
   the committed Android reader surfaces; `WebViewUnsupported` reuses the Pdf
-  Corrupt/Empty pattern (else `needs-design`). Medium PR.
+  Corrupt/Empty pattern (else `needs-design`). **MUST verify on-device (WI-3 audit
+  residual): a valid AZW3 renders through the real `FoliateBridge`'s `blob:` subframes,
+  off-origin top-level nav is blocked, and remote subresource loads are blocked** — the
+  real-bridge smoke deferred from WI-3 (its standalone connected test wedged the runner).
+  Medium PR.
 - **WI-7 — resume persist/restore + onStop flush — B.** Save per relocate via the
   conflated channel; onStop synchronously enqueues main-owned `latestLocator`, drains
   before close; restore `loadPosition→resolve→Canonical→readerAPI.init({cfi}|{fraction})`;


### PR DESCRIPTION
## Summary
The AZW3/foliate reader's **secure WebView transport** (the security-critical WI). Part of feature #1851.

- **FoliateAssetServer** — `WebViewAssetLoader` on a virtual https origin (no `file://`); serves the bundle/shell + the imported book (exact `/book/book` path only, `Cache-Control: no-store`).
- **FoliateBridgePolicy** — pure security decisions (trusted-message `origin`+`isMainFrame`, allowed main-frame nav, remote-resource block, `isSameOrigin`). **JVM-tested 10/10**, incl. sibling-host (`…net.evil.com`) + userinfo (`…net@evil.com`) bypass rejection.
- **FoliateBridge** (`@MainThread`) — WebView hardening (no file/universal access); `addWebMessageListener` allow-listed to the shell origin + `isMainFrame`/origin filter → `FoliateMessageParser` → `SharedFlow`; `shouldInterceptRequest` serves same-origin via the loader and **fails closed (404)** on same-origin misses + **403s remote resources**; `shouldOverrideUrlLoading` blocks only off-origin **main-frame** navs (allows foliate's `blob:` section subframes); typed reader API (no raw JS — CFI JSON-escaped); `WebViewFeature` gate → `WebViewUnsupported`.

## Gate-4 audit (security-critical, 2 rounds)
**block-recommended → ship-as-is.** Round 1 (1H/3M/1L): the **High** caught that blocking *all* off-origin navs would block foliate's `blob:` section **subframes** → break rendering (the WI-0 bare-WebView spike couldn't catch this). Fixed (main-frame-only nav block) + fail-closed intercept + exact book path + typed/escaped send + webkit→1.16.0. Round 2: **ship-as-is**, no findings. Log: `.claude/codex-audits/feat-feature-126-wi-3-secure-bridge-audit.md`.

## Validation
- [x] `FoliateBridgePolicyTest` 10/10 + `FoliateMessageParserTest` 22/22 (`:app:testDebugUnitTest`)
- [x] Gate-4 audit ship-as-is (2 rounds)
- [x] android/v0.12.3 → v0.12.4

## Gate 5a (foundational)
JVM policy tests + WI-0's on-device proof of the same mechanism. **WI-6 MUST verify on-device**: valid AZW3 renders through real `blob:` subframes, off-origin top-level nav blocked, remote subresources blocked (the real-bridge smoke deferred from WI-3 — its standalone connected test wedged the runner).