### PR TITLE
feat(#126 WI-5): Azw3LocatorBridge (relocate → VReaderLocator)

### DIFF
--- a/.claude/codex-audits/feat-feature-126-wi-5-locator-bridge-audit.md
+++ b/.claude/codex-audits/feat-feature-126-wi-5-locator-bridge-audit.md
@@ -1,0 +1,26 @@
+---
+branch: feat/feature-126-wi-5-locator-bridge
+threadId: 019f117a-5809-7be0-aecf-511d20d07ab8
+rounds: 1
+final_verdict: follow-up-recommended
+date: 2026-06-29
+---
+
+# Gate-4 audit — feature #126 WI-5 (Azw3LocatorBridge)
+
+Codex (gpt-5.5/high). **No production correctness issues.** The auditor confirmed the
+mapping is right (`azw3`, finite-only `progression`, non-blank `cfi`, `wrapLegacy` →
+`epubWKWebView` with the identity-derived fingerprint), that omitting `textQuote` is
+acceptable for the MVP (relocate carries no visible text), and that **NFC must stay
+downstream** — normalizing the foliate CFI in the bridge would make platform-local exact
+restore less faithful (so storing it verbatim is correct).
+
+2 Low (test-only), both fixed in-branch:
+- Added `outOfRangeFiniteFraction_isPreserved_notClamped` (-0.1 / 1.2 preserved — the
+  shared Locator contract does not clamp).
+- Added `canonicalJson_isDeterministic_andNfcNormalizesStrings` (an NFD CFI →
+  `canonicalJson()` is stable + NFC-normalized; no combining mark retained).
+
+Re-verification: `Azw3LocatorBridgeTest` **10/10** (`:app:testDebugUnitTest`).
+
+**Verdict: follow-up-recommended** — Lows fixed; no production change needed.

--- a/android/app/src/main/kotlin/com/vreader/app/reader/foliate/Azw3LocatorBridge.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/foliate/Azw3LocatorBridge.kt
@@ -1,0 +1,35 @@
+// Purpose: map a foliate `relocate` event into the engine-neutral [VReaderLocator] the app persists,
+// mirroring ReadiumLocatorBridge. Foliate's CFI is platform-local (lossy cross-platform), so the
+// canonical resume anchor is `progression`; the CFI rides along in `legacyLocator.cfi` for precise
+// SAME-platform restore. Uses VReaderLocator.wrapLegacy (the `epubWKWebView` legacy engine) — NO new
+// contract enum (Gate-2 decision). String fields are NFC-normalized downstream by the canonical layer
+// (Identity.canonicalJson), so they're stored verbatim here (the ReadiumLocatorBridge pattern).
+// Feature #126 WI-5.
+package com.vreader.app.reader.foliate
+
+import vreader.contracts.BookFormat
+import vreader.contracts.Locator
+import vreader.contracts.VReaderLocator
+
+object Azw3LocatorBridge {
+
+    /**
+     * Build the persistable envelope for a foliate position. [contentSHA256]/[fileByteCount] supply
+     * the book identity foliate's event omits. A non-finite fraction is dropped (it would make the
+     * canonical locator invalid); a null/blank CFI is omitted.
+     */
+    fun toEnvelope(
+        relocate: FoliateMessage.Relocate,
+        contentSHA256: String,
+        fileByteCount: Long,
+    ): VReaderLocator {
+        val locator = Locator(
+            contentSHA256 = contentSHA256,
+            fileByteCount = fileByteCount,
+            format = BookFormat.azw3.name,
+            progression = relocate.fraction?.takeIf { it.isFinite() },
+            cfi = relocate.cfi?.takeIf { it.isNotBlank() },
+        )
+        return VReaderLocator.wrapLegacy(locator)
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/foliate/Azw3LocatorBridgeTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/foliate/Azw3LocatorBridgeTest.kt
@@ -1,0 +1,92 @@
+package com.vreader.app.reader.foliate
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlinx.serialization.json.Json
+import vreader.contracts.BookFormat
+import vreader.contracts.ReaderLocatorEngine
+import vreader.contracts.VReaderLocator
+
+/** Feature #126 WI-5 — relocate → persistable VReaderLocator. */
+class Azw3LocatorBridgeTest {
+
+    private val sha = "a".repeat(64)
+    private val bytes = 6_291_456L
+
+    private fun relocate(cfi: String? = "/6/4!/2", fraction: Double? = 0.42, idx: Int = 3, total: Int = 85) =
+        FoliateMessage.Relocate(cfi = cfi, fraction = fraction, sectionIndex = idx, sectionTotal = total)
+
+    @Test fun mapsToLegacyEnvelope_azw3() {
+        val env = Azw3LocatorBridge.toEnvelope(relocate(), sha, bytes)
+        assertEquals(ReaderLocatorEngine.epubWKWebView, env.engine)
+        assertEquals(BookFormat.azw3, env.originalFormat)
+        assertNull("foliate uses the legacy lane, not Readium JSON", env.readiumLocatorJSON)
+        val loc = env.legacyLocator!!
+        assertEquals("azw3", loc.format)
+        assertEquals(sha, loc.contentSHA256)
+        assertEquals(bytes, loc.fileByteCount)
+        assertEquals("/6/4!/2", loc.cfi)
+        assertEquals(0.42, loc.progression!!, 0.0)
+    }
+
+    @Test fun fingerprintKey_isBookIdentity() {
+        val env = Azw3LocatorBridge.toEnvelope(relocate(), sha, bytes)
+        assertEquals("azw3:$sha:$bytes", env.fingerprintKey)
+        assertEquals(env.fingerprintKey, env.legacyLocator!!.fingerprintKey)
+    }
+
+    @Test fun nullCfi_isOmitted() {
+        val loc = Azw3LocatorBridge.toEnvelope(relocate(cfi = null), sha, bytes).legacyLocator!!
+        assertNull(loc.cfi)
+    }
+
+    @Test fun blankCfi_isOmitted() {
+        val loc = Azw3LocatorBridge.toEnvelope(relocate(cfi = "   "), sha, bytes).legacyLocator!!
+        assertNull(loc.cfi)
+    }
+
+    @Test fun nullFraction_isOmittedProgression() {
+        val loc = Azw3LocatorBridge.toEnvelope(relocate(fraction = null), sha, bytes).legacyLocator!!
+        assertNull(loc.progression)
+    }
+
+    @Test fun nonFiniteFraction_isDropped() {
+        val loc = Azw3LocatorBridge.toEnvelope(relocate(fraction = Double.NaN), sha, bytes).legacyLocator!!
+        assertNull(loc.progression)
+        val loc2 = Azw3LocatorBridge.toEnvelope(relocate(fraction = Double.POSITIVE_INFINITY), sha, bytes).legacyLocator!!
+        assertNull(loc2.progression)
+    }
+
+    @Test fun fractionZero_isPreserved() {
+        val loc = Azw3LocatorBridge.toEnvelope(relocate(fraction = 0.0), sha, bytes).legacyLocator!!
+        assertEquals(0.0, loc.progression!!, 0.0)
+    }
+
+    @Test fun outOfRangeFiniteFraction_isPreserved_notClamped() {
+        // The shared Locator contract does NOT clamp; the bridge preserves any finite value.
+        assertEquals(-0.1, Azw3LocatorBridge.toEnvelope(relocate(fraction = -0.1), sha, bytes).legacyLocator!!.progression!!, 0.0)
+        assertEquals(1.2, Azw3LocatorBridge.toEnvelope(relocate(fraction = 1.2), sha, bytes).legacyLocator!!.progression!!, 0.0)
+    }
+
+    @Test fun canonicalJson_isDeterministic_andNfcNormalizesStrings() {
+        // Foliate CFI stored verbatim (NFD here); the canonical layer NFC-normalizes downstream.
+        val nfdCfi = "/6/4!/2[caf\u0065\u0301]" // 'e' + U+0301 combining acute = NFD "caf\u00e9"
+        val loc = Azw3LocatorBridge.toEnvelope(relocate(cfi = nfdCfi), sha, bytes).legacyLocator!!
+        val canon = loc.canonicalJson()
+        assertEquals("canonicalJson must be deterministic", canon, loc.canonicalJson())
+        assertTrue("canonical JSON must NFC-normalize (caf\u00e9): $canon", canon.contains("caf\u00e9"))
+        assertTrue("canonical JSON must not retain the NFD combining mark", !canon.contains("\u0301"))
+    }
+
+    @Test fun envelope_canonicalRoundTrips() {
+        // The persisted envelope must decode→re-encode stably (the shared backup contract).
+        val env = Azw3LocatorBridge.toEnvelope(relocate(cfi = "/6/4!/2[ch3]"), sha, bytes)
+        val codec = Json { encodeDefaults = true }
+        val json = codec.encodeToString(VReaderLocator.serializer(), env)
+        val back = codec.decodeFromString(VReaderLocator.serializer(), json)
+        assertEquals(env, back)
+        assertTrue(json.contains("\"azw3\""))
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.12.4
-versionCode=64
+versionName=0.12.5
+versionCode=65


### PR DESCRIPTION
## Summary
Maps a foliate `relocate` (cfi + fraction) → the engine-neutral `VReaderLocator` via `wrapLegacy` (the `epubWKWebView` legacy lane — **no new contract enum**, per Gate-2). Part of feature #1851.

- CFI is platform-local → stored verbatim in `legacyLocator.cfi` (same-platform precise restore); the canonical cross-platform anchor is `progression` (finite-only).
- NFC normalization stays **downstream** in the canonical layer (`Identity.canonicalJson`) — normalizing the CFI here would weaken platform-local restore (auditor-confirmed).

## Gate-4 audit
Codex — **follow-up-recommended** (no production issues; 2 Low test-adds fixed: out-of-range-not-clamped + canonical NFC round-trip with an NFD CFI). `Azw3LocatorBridgeTest` 10/10. Log: `.claude/codex-audits/feat-feature-126-wi-5-locator-bridge-audit.md`.

## Validation
- [x] `Azw3LocatorBridgeTest` 10/10 (`:app:testDebugUnitTest`)
- [x] Gate-4 follow-up-recommended (fixed)
- [x] android/v0.12.4 → v0.12.5

## Gate 5a (foundational)
Pure mapping; JVM tests + audit sufficient.