### PR TITLE
feat(#126 WI-4+6): Azw3ReaderActivity — the AZW3 reader renders

### DIFF
--- a/.claude/codex-audits/feat-feature-126-wi-6-reader-activity-audit.md
+++ b/.claude/codex-audits/feat-feature-126-wi-6-reader-activity-audit.md
@@ -1,0 +1,31 @@
+---
+branch: feat/feature-126-wi-6-reader-activity
+threadId: 019f1194-a7de-7a92-b428-86591ba0982d
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-29
+---
+
+# Gate-4 audit — feature #126 WI-4+WI-6 (Azw3Document + Azw3ReaderActivity)
+
+The user-facing AZW3/foliate reader. Codex (gpt-5.5/high), 2 rounds.
+
+## Round 1 (threadId 019f118a-e058-7903-85bd-1ac89a05ad89) — **block-recommended** (2H/2M)
+| # | sev | finding | fix |
+|---|---|---|---|
+| 1 | **High** | render-death recovery broken: `reloadKey++` made a new `Holder`/WebView but the `AndroidView` was unkeyed → Compose kept the dead WebView node. | `key(reloadKey) { AndroidView(factory = { holder.webView }) }` swaps the node. |
+| 2 | Medium | the message collector launched into `rememberCoroutineScope()` (host lifetime) → a reload retained the old document/bridge/WebView. | `Azw3Document.start(scope)` → `suspend fun run()`; the host collects it in `LaunchedEffect(holder)` (holder-scoped, cancelled on reload/dispose). |
+| 3 | **High** | rule-51: the visible reader chrome had no cited committed design. | Cites the committed `dev-docs/designs/vreader-fidelity-v1/project/vreader-reader.jsx` — the SAME shared reader-chrome subset TxtReaderActivity/PdfReaderActivity implement (per feature #106 the iOS fidelity bundle is a valid Android design source; the checklist defines "Design" as exactly that). Not new UI. |
+| 4 | Medium | the test proved first-render + save only, not restore. | Added `reopen_restoresSavedPosition` — seeds 0.5, waits until the reader's OWN relocate save replaces the exact seed (a non-restoring reader would overwrite with ~0 → fail), asserts resume > 0.25. Forced render-process-death test deferred to WI-8 (reliably crashing the renderer in CI is flaky; the recreate mechanism = keyed `reloadKey`, and the restore test exercises the recreate→resume path). |
+
+## Round 2 (threadId 019f1194-a7de-7a92-b428-86591ba0982d) — **ship-as-is**
+**No findings.** All 4 closed; the auditor accepts deferring the forced render-death test to
+WI-8 acceptance ("keep render-death survival in final WI-8 acceptance").
+
+## Verification (on emulator API 35)
+`Azw3ReaderActivityTest` **2/2**: a real 6 MB CJK AZW3 imports → renders through the real
+FoliateBridge + production bundle (book-ready → init → `blob:` subframe render → relocate →
+`azw3` position saved) [discharges the WI-3 deferred render smoke]; and `reopen_restoresSavedPosition`
+proves resume. No JS console errors. JVM Foliate suites unaffected.
+
+**Verdict: ship-as-is** (after the round-1 block was cleared).

--- a/android/app/src/androidTest/kotlin/com/vreader/app/reader/Azw3ReaderActivityTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/reader/Azw3ReaderActivityTest.kt
@@ -1,0 +1,100 @@
+package com.vreader.app.reader
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vreader.app.VReaderApp
+import com.vreader.app.data.Book
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import vreader.contracts.Locator
+import vreader.contracts.VReaderLocator
+import java.io.File
+
+/**
+ * Feature #126 WI-6 — the AZW3 reader renders a REAL Kindle book end-to-end through the real
+ * FoliateBridge + the production `assets/foliate/` bundle, and persists a position. Reaching a saved
+ * `azw3` position proves the full path: import → Activity → secure bridge → patched bundle → book-ready
+ * → init renders the first page in a `blob:` SUBFRAME (the WI-3 subframe-nav fix) → relocate → save.
+ * This discharges the on-device render verification deferred from WI-3.
+ *
+ * The real 6 MB CJK AZW3 fixture is local-only (gitignored, not in CI); the test self-skips if absent.
+ */
+@RunWith(AndroidJUnit4::class)
+class Azw3ReaderActivityTest {
+
+    @get:Rule val compose = createEmptyComposeRule()
+
+    private fun importAzw3OrSkip(): Book {
+        val inst = InstrumentationRegistry.getInstrumentation()
+        val present = inst.context.assets.list("foliate-spike")?.contains("book.azw3") == true
+        assumeTrue("local-only foliate-spike/book.azw3 absent — skipping AZW3 render test", present)
+        val app = inst.targetContext.applicationContext as VReaderApp
+        val staged = File(inst.targetContext.cacheDir, "azw3-${System.nanoTime()}")
+        inst.context.assets.open("foliate-spike/book.azw3").use { input -> staged.outputStream().use { input.copyTo(it) } }
+        // The importer detects format from the display name's extension — keep `.azw3`.
+        return runBlocking { app.container.importer.importStream("content://test/book.azw3", "Bei Tao Yan.azw3", staged.inputStream()) }
+    }
+
+    @Test
+    fun opensAzw3_rendersThroughRealBridge_andSavesPosition() {
+        val book = importAzw3OrSkip()
+        val app = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as VReaderApp
+        val key = book.fingerprintKey
+
+        ActivityScenario.launch<Azw3ReaderActivity>(
+            Azw3ReaderActivity.intent(InstrumentationRegistry.getInstrumentation().targetContext, key),
+        ).use {
+            // The designed reader chrome is up.
+            compose.waitUntil(10_000) { compose.onAllNodesWithText("Library").fetchSemanticsNodes().isNotEmpty() }
+            compose.onNodeWithText("Library").assertIsDisplayed()
+
+            // The book rendered through the real bridge → a relocate fired → a position was saved.
+            compose.waitUntil(40_000) { runBlocking { app.container.repository.loadPosition(key) != null } }
+            val saved = runBlocking { app.container.repository.loadPosition(key) }
+            assertNotNull("no position saved — the AZW3 did not render through the real FoliateBridge", saved)
+            assertEquals("azw3", saved!!.legacyLocator?.format)
+        }
+    }
+
+    @Test
+    fun reopen_restoresSavedPosition() {
+        val book = importAzw3OrSkip()
+        val app = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as VReaderApp
+        val key = book.fingerprintKey
+
+        // Seed a mid-book position (fraction only → forces the initAtFraction restore path).
+        runBlocking {
+            val seeded = VReaderLocator.wrapLegacy(
+                Locator(book.contentSHA256, book.fileByteCount, "azw3", progression = 0.5),
+            )
+            app.container.repository.savePosition(seeded, System.currentTimeMillis())
+        }
+
+        ActivityScenario.launch<Azw3ReaderActivity>(
+            Azw3ReaderActivity.intent(InstrumentationRegistry.getInstrumentation().targetContext, key),
+        ).use {
+            // Wait until the reader's OWN relocate save REPLACES the exact 0.5 seed (its rendered
+            // fraction snaps to a page boundary, so it won't equal 0.5 exactly). A restoring reader
+            // re-saves near 0.5; a NON-restoring reader would overwrite with ~0 — so the assertion
+            // below catches a regression, not just the seed.
+            compose.waitUntil(40_000) {
+                val p = runBlocking { app.container.repository.loadPosition(key)?.legacyLocator?.progression }
+                p != null && p != 0.5
+            }
+            val restored = runBlocking { app.container.repository.loadPosition(key)?.legacyLocator?.progression }
+            assertNotNull("no position after reopen", restored)
+            assertTrue("restored position should resume near the seeded 0.5, got $restored", restored!! > 0.25)
+        }
+    }
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,5 +38,8 @@
         <activity
             android:name=".reader.PdfReaderActivity"
             android:exported="false" />
+        <activity
+            android:name=".reader.Azw3ReaderActivity"
+            android:exported="false" />
     </application>
 </manifest>

--- a/android/app/src/main/kotlin/com/vreader/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import com.vreader.app.library.LibraryEvent
 import com.vreader.app.library.LibraryScreen
 import com.vreader.app.library.LibraryViewModel
+import com.vreader.app.reader.Azw3ReaderActivity
 import com.vreader.app.reader.ReaderActivity
 import com.vreader.app.reader.PdfReaderActivity
 import com.vreader.app.reader.TxtReaderActivity
@@ -71,11 +72,8 @@ class MainActivity : ComponentActivity() {
                                 // #115 — continuous-scroll PdfRenderer reader.
                                 startActivity(PdfReaderActivity.intent(this@MainActivity, book.id))
                             BookFormat.azw3 ->
-                                Toast.makeText(
-                                    this@MainActivity,
-                                    "${book.format} reading isn't available yet",
-                                    Toast.LENGTH_SHORT,
-                                ).show()
+                                // #126 — foliate-js WebView reader (AZW3/MOBI/KF8).
+                                startActivity(Azw3ReaderActivity.intent(this@MainActivity, book.id))
                         }
                     },
                     // EPUBs are exposed by SAF providers under varied MIME types

--- a/android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt
@@ -1,0 +1,227 @@
+// Purpose: the AZW3/MOBI/KF8 (Kindle) reader screen. Hosts an Android WebView running the
+// security-patched foliate-js bundle (via Azw3Document + FoliateBridge) in the committed shared
+// reader chrome — design `vreader-fidelity-v1/project/vreader-reader.jsx` (the SAME chrome subset
+// TxtReaderActivity / PdfReaderActivity implement; per feature #106 the iOS-authored fidelity bundle
+// is a valid Android design source — rule 51). Persists the reading position (conflated, latest-wins)
+// + flushes on onStop, and recreates the WebView on render-process death.
+// Feature #126 WI-4 + WI-6. Routing from MainActivity; AZW3 import already exists.
+package com.vreader.app.reader
+
+import android.os.Bundle
+import android.webkit.WebView
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBackIos
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.vreader.app.VReaderApp
+import com.vreader.app.data.Book
+import com.vreader.app.reader.foliate.Azw3DocState
+import com.vreader.app.reader.foliate.Azw3Document
+import com.vreader.app.reader.foliate.Azw3LocatorBridge
+import com.vreader.app.reader.foliate.FoliateMessage
+import com.vreader.app.ui.theme.VReaderFonts
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import vreader.contracts.VReaderLocator
+import java.io.File
+
+class Azw3ReaderActivity : ComponentActivity() {
+
+    private val container get() = (application as VReaderApp).container
+
+    // Hoisted so onStop can flush the latest position synchronously (mirrors PdfReaderActivity).
+    private var currentBook: Book? = null
+    private var latestRelocate: FoliateMessage.Relocate? = null
+    private val saveRequests = Channel<VReaderLocator>(Channel.CONFLATED) // latest-wins, lone writer
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val key = intent.getStringExtra(EXTRA_FINGERPRINT_KEY)
+        if (key == null) { finish(); return }
+
+        // The lone position writer — drains in order on the process scope so an onStop save survives
+        // this Activity's teardown.
+        container.appScope.launch {
+            for (locator in saveRequests) container.repository.savePosition(locator, System.currentTimeMillis())
+        }
+
+        setContent {
+            val outer by produceState<OuterState>(OuterState.Loading, key) { value = loadOuter(key) }
+            when (val o = outer) {
+                OuterState.Loading -> ReaderScaffold("", ::finish) { Centered { CircularProgressIndicator() } }
+                OuterState.NoBook -> ReaderScaffold("", ::finish) { Centered { Text("This book can’t be opened.", color = Ink) } }
+                is OuterState.Ready -> {
+                    currentBook = o.book
+                    Azw3ReaderHost(
+                        book = o.book,
+                        bookFile = File(o.path),
+                        restore = o.restore,
+                        onBack = ::finish,
+                        onRelocate = { rel -> enqueueSave(o.book, rel) },
+                    )
+                }
+            }
+        }
+    }
+
+    private suspend fun loadOuter(key: String): OuterState {
+        val book = container.repository.findBook(key) ?: return OuterState.NoBook
+        val path = book.localFilePath ?: return OuterState.NoBook
+        if (!File(path).isFile) return OuterState.NoBook
+        container.repository.markOpened(key, System.currentTimeMillis())
+        return OuterState.Ready(book, path, container.repository.loadPosition(key))
+    }
+
+    private fun enqueueSave(book: Book, relocate: FoliateMessage.Relocate) {
+        currentBook = book
+        latestRelocate = relocate
+        saveRequests.trySend(Azw3LocatorBridge.toEnvelope(relocate, book.contentSHA256, book.fileByteCount))
+    }
+
+    override fun onStop() {
+        super.onStop()
+        val book = currentBook
+        val relocate = latestRelocate
+        if (book != null && relocate != null) {
+            saveRequests.trySend(Azw3LocatorBridge.toEnvelope(relocate, book.contentSHA256, book.fileByteCount))
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        saveRequests.close()
+    }
+
+    private sealed interface OuterState {
+        data object Loading : OuterState
+        data object NoBook : OuterState
+        data class Ready(val book: Book, val path: String, val restore: VReaderLocator?) : OuterState
+    }
+
+    companion object {
+        const val EXTRA_FINGERPRINT_KEY = "fingerprintKey"
+        fun intent(context: android.content.Context, fingerprintKey: String): android.content.Intent =
+            android.content.Intent(context, Azw3ReaderActivity::class.java).putExtra(EXTRA_FINGERPRINT_KEY, fingerprintKey)
+    }
+}
+
+private val Ink = Color(0xFF1D1A14)
+private val ChromeFill = Color(0xFFF7F4EE)
+private val Accent = Color(0xFF8C2F2F)
+
+/** The reader screen: the WebView fills the body; a state overlay covers it until Loaded. */
+@Composable
+private fun Azw3ReaderHost(
+    book: Book,
+    bookFile: File,
+    restore: VReaderLocator?,
+    onBack: () -> Unit,
+    onRelocate: (FoliateMessage.Relocate) -> Unit,
+) {
+    val context = LocalContext.current
+    var reloadKey by remember { mutableIntStateOf(0) }
+    // Latest known position, for render-death resume (starts at the persisted restore point).
+    var resume by remember { mutableStateOf(restore) }
+
+    // A fresh WebView + document each reloadKey (render-process-death recovery).
+    val holder = remember(reloadKey) { Holder(WebView(context), bookFile, context) }
+    val state by holder.document.state.collectAsState()
+
+    DisposableEffect(holder) {
+        val doc = holder.document
+        doc.onRelocate = { rel ->
+            onRelocate(rel)
+            resume = Azw3LocatorBridge.toEnvelope(rel, book.contentSHA256, book.fileByteCount)
+        }
+        doc.onRenderProcessGone = { reloadKey++ }
+        onDispose { doc.destroy() }
+    }
+
+    // Holder-scoped: the collector lives exactly as long as this holder (cancelled on reload/dispose).
+    LaunchedEffect(holder) { holder.document.run(resume) }
+
+    ReaderScaffold(book.title, onBack) {
+        Box(Modifier.fillMaxSize()) {
+            // Keyed on reloadKey so render-death recovery swaps in the NEW WebView node (not the dead one).
+            key(reloadKey) { AndroidView(factory = { holder.webView }, modifier = Modifier.fillMaxSize()) }
+            when (state) {
+                Azw3DocState.Loading -> Centered { CircularProgressIndicator() }
+                Azw3DocState.WebViewUnsupported -> Centered { Text("Update Android System WebView to read this format.", color = Ink) }
+                Azw3DocState.Corrupt -> Centered { Text("This book can’t be opened.", color = Ink) }
+                Azw3DocState.Empty -> Centered { Text("This book has no readable content.", color = Ink) }
+                is Azw3DocState.Loaded -> Unit // the WebView shows the book
+            }
+        }
+    }
+}
+
+/** Bundles the per-session WebView + document so `remember(reloadKey)` recreates both together. */
+private class Holder(val webView: WebView, bookFile: File, context: android.content.Context) {
+    val document = Azw3Document(webView, bookFile, context)
+}
+
+@Composable
+private fun ReaderScaffold(title: String, onBack: () -> Unit, body: @Composable () -> Unit) {
+    Column(Modifier.fillMaxSize().background(Color.White).systemBarsPadding()) {
+        Row(
+            Modifier.fillMaxWidth().background(ChromeFill).padding(horizontal = 4.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Row(
+                Modifier.heightIn(min = 48.dp).clip(RoundedCornerShape(8.dp)).clickable(onClickLabel = "Library", onClick = onBack).padding(horizontal = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBackIos, contentDescription = null, tint = Accent, modifier = Modifier.size(18.dp))
+                Text("Library", color = Accent, fontSize = 14.sp, fontWeight = FontWeight.Medium)
+            }
+            Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(title, color = Ink, fontFamily = VReaderFonts.Serif, fontSize = 13.5.sp, fontWeight = FontWeight.SemiBold, maxLines = 1)
+                    Text(" AZW3", color = Color(0xFF7A6A4A), fontSize = 9.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.padding(start = 6.dp))
+                }
+            }
+            Box(Modifier.size(60.dp))
+        }
+        Box(Modifier.weight(1f)) { body() }
+    }
+}
+
+@Composable
+private fun Centered(content: @Composable () -> Unit) =
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { content() }

--- a/android/app/src/main/kotlin/com/vreader/app/reader/foliate/Azw3Document.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/foliate/Azw3Document.kt
@@ -1,0 +1,101 @@
+// Purpose: the MAIN-THREAD controller for an AZW3/MOBI/KF8 reading session. Owns a WebView + the
+// secure FoliateBridge, drives the open → restore → render → navigate flow, and exposes the reading
+// state + the latest position (main-thread-owned, so the Activity's onStop can flush synchronously).
+// All methods are main-thread only (WebView is). Feature #126 WI-4.
+package com.vreader.app.reader.foliate
+
+import android.content.Context
+import android.webkit.WebView
+import androidx.annotation.MainThread
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.onSubscription
+import vreader.contracts.VReaderLocator
+import java.io.File
+
+/** What the reader UI shows for a Foliate session. */
+sealed interface Azw3DocState {
+    data object Loading : Azw3DocState
+    /** This device's System WebView is too old for the secure bridge (`addWebMessageListener`). */
+    data object WebViewUnsupported : Azw3DocState
+    /** The book opened + rendered; `sectionTotal` spine items. */
+    data class Loaded(val sectionTotal: Int) : Azw3DocState
+    /** The book parsed but had no readable sections. */
+    data object Empty : Azw3DocState
+    /** The book could not be opened/parsed (corrupt / unsupported / JS error before book-ready). */
+    data object Corrupt : Azw3DocState
+}
+
+@MainThread
+class Azw3Document(
+    private val webView: WebView,
+    bookFile: File,
+    context: Context,
+) {
+    private val bridge = FoliateBridge(webView, FoliateAssetServer.loader(context, bookFile))
+
+    private val _state = MutableStateFlow<Azw3DocState>(Azw3DocState.Loading)
+    val state: StateFlow<Azw3DocState> = _state.asStateFlow()
+
+    /** The latest position foliate reported, main-thread-owned so onStop can flush it synchronously. */
+    var latestRelocate: FoliateMessage.Relocate? = null
+        private set
+
+    /** Fired on every relocate (main thread) — the host persists the position. */
+    var onRelocate: ((FoliateMessage.Relocate) -> Unit)? = null
+
+    /** Fired when the render process dies — the host recreates the WebView + document (resume). */
+    var onRenderProcessGone: (() -> Unit)? = null
+
+    private var bookReady = false
+    private var restore: VReaderLocator? = null
+
+    /**
+     * Wire the bridge and load, then SUSPEND collecting messages until cancelled. Call from a
+     * HOLDER-SCOPED `LaunchedEffect` on the Main dispatcher (WebView is main-thread-only) so a reload
+     * / dispose cancels the collector and never retains the old document/bridge/WebView. The
+     * `onSubscription { load() }` guarantees the collector is subscribed BEFORE the bundle emits (no
+     * hot-flow race), so `bridge-ready`/`book-ready` are never missed.
+     */
+    suspend fun run(restore: VReaderLocator?) {
+        this.restore = restore
+        bridge.onWebViewUnsupported = { _state.value = Azw3DocState.WebViewUnsupported }
+        bridge.onRenderProcessGone = { onRenderProcessGone?.invoke(); true } // survive; host recreates
+        bridge.attach()
+        bridge.messages.onSubscription { bridge.load() }.collect(::handle)
+    }
+
+    private fun handle(message: FoliateMessage) {
+        when (message) {
+            FoliateMessage.BridgeReady -> bridge.openBook()
+            is FoliateMessage.BookReady -> {
+                bookReady = true
+                restoreOrInit()
+                _state.value = if (message.sectionTotal > 0) Azw3DocState.Loaded(message.sectionTotal) else Azw3DocState.Empty
+            }
+            is FoliateMessage.Relocate -> {
+                latestRelocate = message
+                onRelocate?.invoke(message)
+            }
+            is FoliateMessage.Error -> if (!bookReady) _state.value = Azw3DocState.Corrupt
+            is FoliateMessage.Other -> Unit
+        }
+    }
+
+    /** Render the first page at the restored CFI (precise, same-platform) → fraction → start. */
+    private fun restoreOrInit() {
+        val loc = restore?.legacyLocator
+        val cfi = loc?.cfi
+        val fraction = loc?.progression
+        when {
+            cfi != null -> bridge.initAtCfi(cfi)
+            fraction != null -> bridge.initAtFraction(fraction)
+            else -> bridge.init()
+        }
+    }
+
+    fun next() = bridge.next()
+    fun prev() = bridge.prev()
+    fun destroy() = bridge.destroy()
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.12.5
-versionCode=65
+versionName=0.12.6
+versionCode=66


### PR DESCRIPTION
## Summary
The **user-facing AZW3/MOBI/KF8 (Kindle) reader** — the foliate-js WebView reader, wired end-to-end. Part of feature #1851.

- **Azw3Document** — `@MainThread` WebView controller driving open→render→navigate; exposes state + `latestRelocate`; collector is holder-scoped (`suspend run()` in `LaunchedEffect`).
- **Azw3ReaderActivity** — Compose host in the committed shared reader chrome (design `vreader-reader.jsx`); conflated-Channel position save + onStop flush; render-death recovery via a **keyed** `AndroidView` + `reloadKey`.
- **MainActivity** routes `BookFormat.azw3` here; **manifest** registers it.

## On-device verification (emulator API 35, `Azw3ReaderActivityTest` 2/2)
- A real **6 MB CJK AZW3 renders end-to-end** through the real `FoliateBridge` + production bundle (book-ready → init → `blob:` subframe render → relocate → `azw3` position saved) — **discharges the WI-3 deferred render smoke**. No JS console errors.
- **Reopen restores** the saved position (seed 0.5 → reader re-saves near 0.5, not a fresh 0).

## Gate-4 audit (2 rounds)
**block-recommended → ship-as-is.** R1 (2H/2M): unkeyed `AndroidView` broke render-death recovery; collector-scope leak; rule-51 design cite; weak restore test — all fixed. R2: ship-as-is. rule-51 resolved by citing the committed `vreader-reader.jsx` (the established Android-reader precedent). Log: `.claude/codex-audits/feat-feature-126-wi-6-reader-activity-audit.md`.

## Validation
- [x] `Azw3ReaderActivityTest` 2/2 on emulator; JVM Foliate suites unaffected
- [x] Gate-4 ship-as-is (2 rounds)
- [x] android/v0.12.5 → v0.12.6

## Gate 5a (behavioral)
On-device render + restore verified. Forced render-process-death survival deferred to WI-8 final acceptance (auditor-accepted).