### PR TITLE
feat(#126 WI-7): AZW3 backup round-trip (plain-Locator) test

### DIFF
--- a/.claude/codex-audits/feat-feature-126-wi-7-backup-roundtrip-audit.md
+++ b/.claude/codex-audits/feat-feature-126-wi-7-backup-roundtrip-audit.md
@@ -1,0 +1,26 @@
+---
+branch: feat/feature-126-wi-7-backup-roundtrip
+threadId: 019f119a-f7d8-77e0-9119-9e601c57c690
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-29
+---
+
+# Gate-4 audit — feature #126 WI-7 (plain-Locator backup round-trip test)
+
+Codex (gpt-5.5/high). **No findings.** Confirmed:
+- The test exercises the REAL production seam (`BackupJson.encode(plainLocator)` →
+  `BackupJson.decode<Locator>`, the same as `BackupCollector.kt:92` / `RestoreImporter.kt:108`)
+  AND the `BackupPositionsEnvelope` section shape — not contrived (generic collector/importer
+  coverage already exists elsewhere).
+- `plain == restored` + explicit `format`/`cfi`/`progression` assertions are adequate for the
+  AZW3/foliate fields `Azw3LocatorBridge` actually produces.
+- The progression-only (no-CFI) case is meaningful (foliate can emit no CFI; progression is the
+  cross-platform anchor).
+- `totalProgression`/`textQuote`/NFC correctly out of scope (the bridge doesn't populate them; NFC
+  is a canonical-locator concern, not a `BackupJson` round-trip concern).
+- `schemaVersion = 3` = `BackupSchema.CURRENT_SCHEMA_VERSION`.
+
+Verification: `Azw3BackupRoundTripTest` 3/3 (`:app:testDebugUnitTest`).
+
+**Verdict: ship-as-is.**

--- a/android/app/src/test/kotlin/com/vreader/app/reader/foliate/Azw3BackupRoundTripTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/foliate/Azw3BackupRoundTripTest.kt
@@ -1,0 +1,73 @@
+package com.vreader.app.reader.foliate
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import vreader.contracts.Locator
+import vreader.contracts.backup.BackupJson
+import vreader.contracts.backup.BackupPosition
+import vreader.contracts.backup.BackupPositionsEnvelope
+import java.time.Instant
+
+/**
+ * Feature #126 WI-7 — an AZW3/foliate reading position survives the BACKUP round-trip. Backup
+ * serializes a PLAIN `Locator` (not the `VReaderLocator` envelope) into `BackupPosition.locatorJSON`
+ * (Gate-2 H2): `BackupCollector` does `BackupJson.encode(legacyLocator)`, `RestoreImporter` does
+ * `BackupJson.decode<Locator>(...)`. This proves the foliate `cfi` + `progression` round-trip through
+ * that plain-Locator path — including inside a full positions section.
+ */
+class Azw3BackupRoundTripTest {
+
+    private val sha = "a".repeat(64)
+    private val bytes = 6_291_456L
+
+    @Test
+    fun foliatePosition_survivesPlainLocatorBackupRoundTrip() {
+        val relocate = FoliateMessage.Relocate(cfi = "/6/4!/2[ch5]", fraction = 0.63, sectionIndex = 5, sectionTotal = 85)
+        val plain: Locator = Azw3LocatorBridge.toEnvelope(relocate, sha, bytes).legacyLocator!!
+
+        // Exactly the production path (BackupCollector encode → RestoreImporter decode).
+        val locatorJSON = BackupJson.encode(plain)
+        val restored = BackupJson.decode<Locator>(locatorJSON)
+
+        assertEquals("azw3", restored.format)
+        assertEquals("/6/4!/2[ch5]", restored.cfi)
+        assertEquals(0.63, restored.progression!!, 0.0)
+        assertEquals(plain.fingerprintKey, restored.fingerprintKey)
+        assertEquals(plain, restored)
+    }
+
+    @Test
+    fun foliatePosition_survivesFullPositionsSectionRoundTrip() {
+        val plain = Azw3LocatorBridge.toEnvelope(
+            FoliateMessage.Relocate(cfi = "/6/4!/2[caféch]", fraction = 0.5, sectionIndex = 3, sectionTotal = 9),
+            sha, bytes,
+        ).legacyLocator!!
+
+        val env = BackupPositionsEnvelope(
+            schemaVersion = 3,
+            positions = listOf(
+                BackupPosition(plain.fingerprintKey, BackupJson.encode(plain), Instant.parse("2026-06-29T00:00:00Z"), null),
+            ),
+        )
+        val sectionJson = BackupJson.encode(env)
+        val back = BackupJson.decode<BackupPositionsEnvelope>(sectionJson)
+        val backLocator = BackupJson.decode<Locator>(back.positions.single().locatorJSON)
+
+        assertEquals(plain, backLocator)
+        assertEquals("azw3", backLocator.format)
+        assertEquals(0.5, backLocator.progression!!, 0.0)
+    }
+
+    @Test
+    fun progressionOnlyPosition_roundTrips() {
+        // A position with no CFI (cross-platform progression anchor) must also survive.
+        val plain = Azw3LocatorBridge.toEnvelope(
+            FoliateMessage.Relocate(cfi = null, fraction = 0.12, sectionIndex = 1, sectionTotal = 9),
+            sha, bytes,
+        ).legacyLocator!!
+        val restored = BackupJson.decode<Locator>(BackupJson.encode(plain))
+        assertEquals(plain, restored)
+        assertEquals(null, restored.cfi)
+        assertEquals(0.12, restored.progression!!, 0.0)
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.12.6
-versionCode=66
+versionName=0.12.7
+versionCode=67


### PR DESCRIPTION
## Summary
Closes the Gate-2 **H2** verification: backup serializes a **plain `Locator`** (not the `VReaderLocator` envelope) into `BackupPosition.locatorJSON`. `Azw3BackupRoundTripTest` (3/3) proves an AZW3/foliate position (cfi + progression) round-trips through the **real production seam** (`BackupJson.encode → decode<Locator>`, as `BackupCollector`/`RestoreImporter` do) + the full `BackupPositionsEnvelope` section, incl. the progression-only (no-cfi) cross-platform case.

Persist/restore/onStop already shipped in WI-4+6 (the AZW3 reader). Part of feature #1851.

## Gate-4 audit
Codex — **ship-as-is**, no findings. Log: `.claude/codex-audits/feat-feature-126-wi-7-backup-roundtrip-audit.md`.

## Validation
- [x] `Azw3BackupRoundTripTest` 3/3 (`:app:testDebugUnitTest`)
- [x] android/v0.12.6 → v0.12.7