### PR TITLE
feat(#125 WI-2): MarkdownOffsetMap + ChunkTextMapper offset conversions

### DIFF
--- a/.claude/codex-audits/feat-feature-125-wi-2-offset-map-audit.md
+++ b/.claude/codex-audits/feat-feature-125-wi-2-offset-map-audit.md
@@ -1,0 +1,41 @@
+---
+branch: feat/feature-125-wi-2-offset-map
+threadId: 019f1235-d82b-7332-bd7d-eec67db58649
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-29
+---
+
+# Gate-4 audit — feature #125 WI-2 (MarkdownOffsetMap + ChunkTextMapper)
+
+Independent Codex audit (gpt-5.5, high reasoning, read-only sandbox) of WI-2:
+`MarkdownOffsetMap` (chunk-local rendered↔source UTF-16 conversions over WI-1's
+per-char source spans) + `ChunkTextMapper` (interface + `IdentityChunkTextMapper`
+for TXT, `MarkdownChunkTextMapper` for MD with a lazy LRU of per-chunk maps).
+
+## Findings — 2 Low, both fixed
+
+| file | severity | issue | resolution |
+|---|---|---|---|
+| `MarkdownOffsetMap.kt` | Low | `renderedRangeToSource` clamped `start`/`end-1` AFTER deciding emptiness, so a wholly out-of-range positive range mapped to the last char's span and a negative range to the first char. | **Fixed.** Clamp to rendered-cursor space `0..n` first (`a`, `b`); if `b <= a` collapse empty at cursor `a`'s source edge; else `[srcStart[a], srcEnd[b-1])`. Added `renderedRangeToSource_outOfRange_collapsesAtEnd` test. |
+| `ChunkTextMapper.kt` | Low | `IdentityChunkTextMapper.sourceRangeToRendered` / `renderedCursorForSourceEnd` returned out-of-range inputs unchanged — safe from indexing but violated the "clamped" contract for corrupt inputs. | **Fixed.** Identity conversions + the cursor now clamp to the chunk's `0..length` (`clampRange` helper). Added `identity_clampsRangeConversions` test. |
+
+## Clean areas (auditor)
+
+> "Conversions are otherwise affinity-correct for marker boundaries and
+> marker-only collapse. Empty chunks are safe. The O(n) scans are acceptable
+> given `TxtDocument.DEFAULT_MAX_CHUNK_CHARS == 4000`. The
+> `LinkedHashMap(accessOrder=true)` LRU plus `getOrPut` is correct for
+> main-thread use. `visibleText` vs `sourceText` behavior is correct."
+
+## Test evidence
+
+- `MarkdownOffsetMapTest` — 17/17 (golden rendered↔source, marker-only collapse,
+  surrogate-pair offsets, round-trip, the new out-of-range clamp case).
+- `ChunkTextMapperTest` — 11/11 (Identity passthrough + clamp, Markdown
+  conversions, visible-vs-source, LRU bound + recompute-evicted).
+
+## Verdict
+
+ship-as-is. WI-2 is foundational (pure conversions, no behavior change);
+consumed by WI-3's engine integration.

--- a/android/app/src/main/kotlin/com/vreader/app/reader/ChunkTextMapper.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/ChunkTextMapper.kt
@@ -1,0 +1,86 @@
+// Purpose: feature #125 WI-2 — the format-aware chunk text + offset seam. One instance per open book;
+// the SINGLE per-chunk render+cache owner so the body composable, the selection controller, and the
+// highlight wash all read the same rendered text + the same offset map (no recompute, no downcast).
+// All ranges are CHUNK-LOCAL UTF-16 (the caller adds the chunk's document start offset).
+//
+// TXT == IdentityChunkTextMapper (rendered == source, every conversion is identity). MD ==
+// MarkdownChunkTextMapper (bridges rendered↔source via a lazily-computed, LRU-cached MarkdownOffsetMap
+// per visible/highlighted chunk — never precomputed for all chunks).
+//
+// @coordinates-with: MarkdownOffsetMap.kt (the per-chunk conversions), TxtDocument.kt (the chunk source),
+//   TxtReaderActivity.kt (#125 WI-3 builds the right impl from book.originalFormat), TxtSelectionController.kt
+//   / TxtHighlightWash.kt (#125 WI-3 consumers).
+package com.vreader.app.reader
+
+import androidx.compose.ui.text.AnnotatedString
+
+/** Format-aware chunk text + rendered↔source conversions. CHUNK-LOCAL coords. */
+interface ChunkTextMapper {
+    /** The text the body draws for [chunkIndex] (TXT: raw; MD: rendered AnnotatedString). */
+    fun renderedText(chunkIndex: Int): AnnotatedString
+
+    /** Rendered range → source range (chunk-local). */
+    fun renderedRangeToSource(chunkIndex: Int, rendered: Utf16Range): Utf16Range
+
+    /** Source range → rendered range (chunk-local, clamped; marker-only → empty). */
+    fun sourceRangeToRendered(chunkIndex: Int, source: Utf16Range): Utf16Range
+
+    /** Rendered cursor (end-affinity) for a source end — positions the popover anchor. */
+    fun renderedCursorForSourceEnd(chunkIndex: Int, sourceEnd: Int): Int
+
+    /** The VISIBLE (rendered) substring for copy/share/UI. */
+    fun visibleText(chunkIndex: Int, rendered: Utf16Range): String
+
+    /** The SOURCE (markdown) substring for the textQuote / anchor. */
+    fun sourceText(chunkIndex: Int, source: Utf16Range): String
+}
+
+/** TXT: rendered == source, every conversion is identity — clamped to the chunk's `0..length`. */
+class IdentityChunkTextMapper(private val doc: TxtDocument) : ChunkTextMapper {
+    private fun chunk(chunkIndex: Int): String = doc.textForChunk(chunkIndex).toString()
+    override fun renderedText(chunkIndex: Int): AnnotatedString = AnnotatedString(chunk(chunkIndex))
+    override fun renderedRangeToSource(chunkIndex: Int, rendered: Utf16Range): Utf16Range = clampRange(chunkIndex, rendered)
+    override fun sourceRangeToRendered(chunkIndex: Int, source: Utf16Range): Utf16Range = clampRange(chunkIndex, source)
+    override fun renderedCursorForSourceEnd(chunkIndex: Int, sourceEnd: Int): Int =
+        sourceEnd.coerceIn(0, doc.textForChunk(chunkIndex).length)
+    override fun visibleText(chunkIndex: Int, rendered: Utf16Range): String = slice(chunk(chunkIndex), rendered)
+    override fun sourceText(chunkIndex: Int, source: Utf16Range): String = slice(chunk(chunkIndex), source)
+    /** Identity is in-bounds by definition; clamp to the chunk's `0..length` so a corrupt input can't escape. */
+    private fun clampRange(chunkIndex: Int, r: Utf16Range): Utf16Range {
+        val len = doc.textForChunk(chunkIndex).length
+        val a = r.startInclusive.coerceIn(0, len)
+        return Utf16Range(a, r.endExclusive.coerceIn(a, len))
+    }
+    private fun slice(s: String, r: Utf16Range): String {
+        val a = r.startInclusive.coerceIn(0, s.length)
+        return s.substring(a, r.endExclusive.coerceIn(a, s.length))
+    }
+}
+
+/** MD: lazily computes + LRU-caches the per-chunk [MarkdownOffsetMap]; the single render+cache owner. */
+class MarkdownChunkTextMapper(private val doc: TxtDocument, private val maxCached: Int = 24) : ChunkTextMapper {
+    private val cache = object : LinkedHashMap<Int, MarkdownOffsetMap>(maxCached.coerceAtLeast(1), 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Int, MarkdownOffsetMap>): Boolean = size > maxCached
+    }
+
+    private fun mapFor(chunkIndex: Int): MarkdownOffsetMap =
+        cache.getOrPut(chunkIndex) { MarkdownOffsetMap(MarkdownRenderer.renderWithMap(doc.textForChunk(chunkIndex).toString())) }
+
+    /** Test visibility into the LRU bound. */
+    val cacheSize: Int get() = cache.size
+
+    override fun renderedText(chunkIndex: Int): AnnotatedString = mapFor(chunkIndex).renderedText
+    override fun renderedRangeToSource(chunkIndex: Int, rendered: Utf16Range): Utf16Range = mapFor(chunkIndex).renderedRangeToSource(rendered)
+    override fun sourceRangeToRendered(chunkIndex: Int, source: Utf16Range): Utf16Range = mapFor(chunkIndex).sourceRangeToRendered(source)
+    override fun renderedCursorForSourceEnd(chunkIndex: Int, sourceEnd: Int): Int = mapFor(chunkIndex).renderedCursorForSourceEnd(sourceEnd)
+    override fun visibleText(chunkIndex: Int, rendered: Utf16Range): String {
+        val t = mapFor(chunkIndex).renderedText.text
+        val a = rendered.startInclusive.coerceIn(0, t.length)
+        return t.substring(a, rendered.endExclusive.coerceIn(a, t.length))
+    }
+    override fun sourceText(chunkIndex: Int, source: Utf16Range): String {
+        val s = doc.textForChunk(chunkIndex).toString()
+        val a = source.startInclusive.coerceIn(0, s.length)
+        return s.substring(a, source.endExclusive.coerceIn(a, s.length))
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/MarkdownOffsetMap.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/MarkdownOffsetMap.kt
@@ -1,0 +1,67 @@
+// Purpose: feature #125 WI-2 — per-rendered-char source-span map for ONE MD line-chunk. Wraps the
+// MarkdownRenderer.renderWithMap output (srcStart/srcEnd) and converts CHUNK-LOCAL rendered ranges ↔
+// CHUNK-LOCAL markdown-source ranges. The caller adds the chunk's document start offset to reach the
+// global source coords highlights are stored in. Pure JVM (unit-testable).
+//
+// Dual-affinity: a stripped marker between two visible runs keeps their distinct source positions
+// (`**bold**x` → rendered "boldx", where 'x' maps to source 8 not 6). marker-only source ranges
+// (the `**`) collapse to an EMPTY rendered range (the wash draws nothing there).
+//
+// @coordinates-with: MarkdownRenderer.kt (produces MarkdownRendered), ChunkTextMapper.kt (owns the
+//   per-chunk maps + global/local translation), TxtHighlightWash.kt (#125 WI-3 projects source→rendered).
+package com.vreader.app.reader
+
+import androidx.compose.ui.text.AnnotatedString
+
+/** Rendered↔source conversions for one MD chunk's [MarkdownRendered]. All coords are CHUNK-LOCAL UTF-16. */
+class MarkdownOffsetMap(private val rendered: MarkdownRendered) {
+    val renderedText: AnnotatedString get() = rendered.text
+    private val n: Int get() = rendered.text.length
+    private val srcStart get() = rendered.srcStart
+    private val srcEnd get() = rendered.srcEnd
+
+    /** The source-end past the last rendered char (the chunk's mapped source extent), or 0 if empty. */
+    private fun sourceEndBound(): Int = if (n == 0) 0 else srcEnd[n - 1]
+
+    /**
+     * Rendered `[a, b)` → source `[srcStart[a], srcEnd[b-1])`. Clamped to rendered-cursor space `0..n`
+     * FIRST, so a wholly out-of-range range collapses correctly: a degenerate/empty range (after
+     * clamping `b <= a`) maps to an empty source range at cursor `a`'s source edge (`srcStart[a]`, or
+     * the source-end bound past the last char when `a == n`).
+     */
+    fun renderedRangeToSource(r: Utf16Range): Utf16Range {
+        if (n == 0) return Utf16Range(0, 0)
+        val a = r.startInclusive.coerceIn(0, n)
+        val b = r.endExclusive.coerceIn(0, n)
+        if (b <= a) {
+            val at = if (a < n) srcStart[a] else sourceEndBound()
+            return Utf16Range(at, at)
+        }
+        return Utf16Range(srcStart[a], srcEnd[b - 1])
+    }
+
+    /**
+     * Source `[s0, s1)` → rendered, clamped + affinity-correct: rendered start = the first rendered char
+     * whose source overlaps the range (`srcEnd[r] > s0`); rendered end = one past the last whose source
+     * begins before the range end (`srcStart[r] < s1`). A marker-only source range (no rendered char
+     * overlaps) collapses to EMPTY.
+     */
+    fun sourceRangeToRendered(s: Utf16Range): Utf16Range {
+        if (n == 0 || s.isEmpty) return Utf16Range(0, 0)
+        val start = renderedCursorForSourceStart(s.startInclusive)
+        val end = renderedCursorForSourceEnd(s.endExclusive)
+        return if (end > start) Utf16Range(start, end) else Utf16Range(start.coerceAtMost(n), start.coerceAtMost(n))
+    }
+
+    /** First rendered char whose source extends past [sourceStart] (start-affinity), or n. */
+    fun renderedCursorForSourceStart(sourceStart: Int): Int {
+        for (r in 0 until n) if (srcEnd[r] > sourceStart) return r
+        return n
+    }
+
+    /** One past the last rendered char whose source begins before [sourceEnd] (end-affinity), or 0. */
+    fun renderedCursorForSourceEnd(sourceEnd: Int): Int {
+        for (r in n - 1 downTo 0) if (srcStart[r] < sourceEnd) return r + 1
+        return 0
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/ChunkTextMapperTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/ChunkTextMapperTest.kt
@@ -1,0 +1,110 @@
+package com.vreader.app.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Feature #125 WI-2 — [ChunkTextMapper] (Identity for TXT, Markdown for MD). CHUNK-LOCAL coords;
+ * the caller adds the chunk's document start offset.
+ */
+class ChunkTextMapperTest {
+    private fun r(a: Int, b: Int) = Utf16Range(a, b)
+
+    // --- Identity (TXT): every conversion is identity ------------------------------------------
+
+    @Test fun identity_isPassthrough() {
+        val doc = TxtDocument.of("hello\nworld\n")
+        val m = IdentityChunkTextMapper(doc)
+        assertEquals("hello\n", m.renderedText(0).text)
+        assertEquals(r(0, 5), m.renderedRangeToSource(0, r(0, 5)))
+        assertEquals(r(0, 5), m.sourceRangeToRendered(0, r(0, 5)))
+        assertEquals(2, m.renderedCursorForSourceEnd(0, 2))
+        assertEquals("hello", m.visibleText(0, r(0, 5)))
+        assertEquals("hello", m.sourceText(0, r(0, 5)))
+    }
+
+    @Test fun identity_clampsOutOfBounds() {
+        val doc = TxtDocument.of("hi\n")
+        val m = IdentityChunkTextMapper(doc)
+        assertEquals("hi\n", m.visibleText(0, r(0, 999)))
+    }
+
+    @Test fun identity_clampsRangeConversions() {
+        // chunk 0 = "hi\n" (len 3). Identity conversions clamp out-of-range inputs to 0..len (WI-2 audit fix).
+        val m = IdentityChunkTextMapper(TxtDocument.of("hi\n"))
+        assertEquals(r(0, 3), m.sourceRangeToRendered(0, r(-2, 99)))
+        assertEquals(r(0, 3), m.renderedRangeToSource(0, r(-2, 99)))
+        assertEquals(3, m.renderedCursorForSourceEnd(0, 99))
+        assertEquals(0, m.renderedCursorForSourceEnd(0, -5))
+    }
+
+    // --- Markdown (MD): conversions bridge rendered↔source -------------------------------------
+
+    private fun mdDoc() = TxtDocument.of("# Title\n**bold**x\n- item\n")
+    // chunk 0 = "# Title\n", chunk 1 = "**bold**x\n", chunk 2 = "- item\n"
+
+    @Test fun markdown_rendersChunk() {
+        val m = MarkdownChunkTextMapper(mdDoc())
+        assertEquals("Title\n", m.renderedText(0).text)   // heading markers stripped
+        assertEquals("boldx\n", m.renderedText(1).text)
+        assertEquals("• item\n", m.renderedText(2).text)
+    }
+
+    @Test fun markdown_renderedToSource_chunkLocal() {
+        val m = MarkdownChunkTextMapper(mdDoc())
+        // chunk 1 "**bold**x\n" → rendered "boldx\n"; rendered [0,5) ("boldx") → source [2,9)
+        assertEquals(r(2, 9), m.renderedRangeToSource(1, r(0, 5)))
+        // just "x" (rendered [4,5)) → source [8,9)
+        assertEquals(r(8, 9), m.renderedRangeToSource(1, r(4, 5)))
+    }
+
+    @Test fun markdown_sourceToRendered_markerOnlyEmpty() {
+        val m = MarkdownChunkTextMapper(mdDoc())
+        // chunk 1: the opening "**" (source [0,2)) maps to NO visible char → empty
+        assertEquals(0, m.sourceRangeToRendered(1, r(0, 2)).length)
+        // "bold" source [2,6) → rendered [0,4)
+        assertEquals(r(0, 4), m.sourceRangeToRendered(1, r(2, 6)))
+    }
+
+    @Test fun markdown_visibleVsSource_differ() {
+        val m = MarkdownChunkTextMapper(mdDoc())
+        // selecting rendered "boldx" → VISIBLE "boldx", SOURCE span [2,9) = "bold**x" (the source the
+        // textQuote anchor stores — includes the interior markers it spans).
+        assertEquals("boldx", m.visibleText(1, r(0, 5)))
+        assertEquals("bold**x", m.sourceText(1, r(2, 9)))
+    }
+
+    @Test fun markdown_roundTrip_rendered_source_rendered() {
+        val m = MarkdownChunkTextMapper(mdDoc())
+        val rendered = r(0, 5)
+        val source = m.renderedRangeToSource(1, rendered)
+        assertEquals(rendered, m.sourceRangeToRendered(1, source))
+    }
+
+    @Test fun markdown_cursorForSourceEnd_anchor() {
+        val m = MarkdownChunkTextMapper(mdDoc())
+        // chunk 1: source end 6 (end of "bold") → rendered cursor 4
+        assertEquals(4, m.renderedCursorForSourceEnd(1, 6))
+    }
+
+    // --- LRU cache bound -----------------------------------------------------------------------
+
+    @Test fun markdown_lru_boundsCacheSize() {
+        val sb = StringBuilder()
+        repeat(50) { sb.append("line $it\n") }
+        val m = MarkdownChunkTextMapper(TxtDocument.of(sb.toString()), maxCached = 8)
+        for (i in 0 until 50) m.renderedText(i)   // touch all 50 chunks
+        assertTrue("LRU should bound the cache to maxCached, was ${m.cacheSize}", m.cacheSize <= 8)
+    }
+
+    @Test fun markdown_lru_recomputesEvicted() {
+        val sb = StringBuilder()
+        repeat(50) { sb.append("**b$it**\n") }
+        val m = MarkdownChunkTextMapper(TxtDocument.of(sb.toString()), maxCached = 4)
+        for (i in 0 until 50) m.renderedText(i)
+        // chunk 0 was evicted; re-accessing it still returns the correct rendered text.
+        assertEquals("b0\n", m.renderedText(0).text)
+        assertTrue(m.cacheSize <= 4)
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/MarkdownOffsetMapTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/MarkdownOffsetMapTest.kt
@@ -1,0 +1,134 @@
+package com.vreader.app.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Feature #125 WI-2 — [MarkdownOffsetMap] chunk-local rendered↔source conversions over the WI-1
+ * per-rendered-char source spans. All coords are CHUNK-LOCAL UTF-16 (the caller adds the chunk's
+ * document start offset). Goldens mirror the plan's worked examples.
+ */
+class MarkdownOffsetMapTest {
+    private fun map(chunk: String) = MarkdownOffsetMap(MarkdownRenderer.renderWithMap(chunk))
+    private fun r(a: Int, b: Int) = Utf16Range(a, b)
+
+    // --- renderedRangeToSource -----------------------------------------------------------------
+
+    @Test fun bold_renderedToSource_excludesMarkers() {
+        // "**bold**" → "bold"; rendered [0,4) → source [2,6)
+        assertEquals(r(2, 6), map("**bold**").renderedRangeToSource(r(0, 4)))
+    }
+
+    @Test fun boldThenChar_renderedToSource_distinct() {
+        // "**bold**x" → "boldx"; rendered [4,5) ("x") → source [8,9); rendered [0,4) → [2,6)
+        val m = map("**bold**x")
+        assertEquals(r(8, 9), m.renderedRangeToSource(r(4, 5)))
+        assertEquals(r(2, 6), m.renderedRangeToSource(r(0, 4)))
+        assertEquals(r(2, 9), m.renderedRangeToSource(r(0, 5))) // "boldx" → source [2,9)
+    }
+
+    @Test fun heading_renderedToSource_pastPrefix() {
+        // "# H" → "H"; rendered [0,1) → source [2,3)
+        assertEquals(r(2, 3), map("# H").renderedRangeToSource(r(0, 1)))
+    }
+
+    @Test fun code_renderedToSource_dropsBackticks() {
+        // "`c`x" → "cx"; rendered [0,1) ("c") → source [1,2); rendered [0,2) → [1,4)
+        val m = map("`c`x")
+        assertEquals(r(1, 2), m.renderedRangeToSource(r(0, 1)))
+        assertEquals(r(1, 4), m.renderedRangeToSource(r(0, 2)))
+    }
+
+    @Test fun escape_renderedToSource_spansTwoSource() {
+        // "\*x" → "*x"; rendered [0,1) ("*") → source [0,2)
+        assertEquals(r(0, 2), map("\\*x").renderedRangeToSource(r(0, 1)))
+    }
+
+    @Test fun emptyRendered_mapsToEmptySource() {
+        // empty rendered range → empty source at the start char's source-start
+        val m = map("**bold**")
+        val out = m.renderedRangeToSource(r(2, 2))
+        assertEquals(0, out.length)
+        assertEquals(4, out.startInclusive) // srcStart[2] == 4
+    }
+
+    // --- sourceRangeToRendered (clamped, affinity, marker-only → empty) -------------------------
+
+    @Test fun source_x_toRendered() {
+        // "**bold**x"; source [8,9) ("x") → rendered [4,5)
+        assertEquals(r(4, 5), map("**bold**x").sourceRangeToRendered(r(8, 9)))
+    }
+
+    @Test fun source_bold_toRendered() {
+        // "**bold**"; source [2,6) ("bold") → rendered [0,4)
+        assertEquals(r(0, 4), map("**bold**").sourceRangeToRendered(r(2, 6)))
+    }
+
+    @Test fun source_markerOnly_collapsesToEmpty() {
+        // "**bold**"; source [0,2) (the opening "**") overlaps NO visible char → empty rendered
+        val out = map("**bold**").sourceRangeToRendered(r(0, 2))
+        assertEquals("marker-only source draws nothing", 0, out.length)
+    }
+
+    @Test fun source_trailingMarker_collapsesToEmpty() {
+        // "**bold**"; source [6,8) (the closing "**") → empty rendered
+        assertEquals(0, map("**bold**").sourceRangeToRendered(r(6, 8)).length)
+    }
+
+    @Test fun source_spanningMarker_clampsToVisible() {
+        // "**bold**x"; source [6,9) (closing "**" + "x") → rendered [4,5) (just "x", markers clipped)
+        assertEquals(r(4, 5), map("**bold**x").sourceRangeToRendered(r(6, 9)))
+    }
+
+    @Test fun source_roundTrip_bold() {
+        // rendered → source → rendered is stable for a visible range
+        val m = map("**bold**x")
+        val rendered = r(0, 5)
+        val source = m.renderedRangeToSource(rendered)
+        assertEquals(rendered, m.sourceRangeToRendered(source))
+    }
+
+    // --- renderedCursorForSourceEnd (popover anchor, end-affinity) ------------------------------
+
+    @Test fun cursorForSourceEnd_atSelectionEnd() {
+        // "**bold**x"; source end 6 (end of "bold") → rendered cursor 4 (one past 'd')
+        assertEquals(4, map("**bold**x").renderedCursorForSourceEnd(6))
+        // source end 9 (end of "x") → rendered cursor 5
+        assertEquals(5, map("**bold**x").renderedCursorForSourceEnd(9))
+    }
+
+    // --- bullet + CJK + empty chunk ------------------------------------------------------------
+
+    @Test fun bullet_sourceToRendered() {
+        // "- item" → "• item"; source [2,6) ("item") → rendered [2,6)
+        assertEquals(r(2, 6), map("- item").sourceRangeToRendered(r(2, 6)))
+        // source [0,2) (the "- " marker) → the bullet glyphs "• " → rendered [0,2)
+        assertEquals(r(0, 2), map("- item").sourceRangeToRendered(r(0, 2)))
+    }
+
+    @Test fun cjk_surrogate_offsetsCorrect() {
+        // "**𝄞x**" — 𝄞 is a surrogate pair (2 UTF-16 units). rendered "𝄞x".
+        val m = map("**𝄞x**")
+        // rendered [0,2) is the surrogate pair → source [2,4)
+        assertEquals(r(2, 4), m.renderedRangeToSource(r(0, 2)))
+    }
+
+    @Test fun emptyChunk_safe() {
+        val m = map("")
+        assertEquals(r(0, 0), m.sourceRangeToRendered(r(0, 5)))
+        assertEquals(0, m.renderedCursorForSourceEnd(3))
+    }
+
+    @Test fun renderedRangeToSource_outOfRange_collapsesAtEnd() {
+        // "**bold**" → "bold" (n=4). A wholly-past-end rendered range collapses empty at the source end,
+        // NOT to the last char's span (WI-2 audit fix).
+        val m = map("**bold**")
+        val pastEnd = m.renderedRangeToSource(r(9, 10))
+        assertEquals(0, pastEnd.length)
+        assertEquals(6, pastEnd.startInclusive) // sourceEndBound() == srcEnd[3] == 6
+        // A negative range clamps to the start side, not the last char.
+        val negative = m.renderedRangeToSource(r(-5, -4))
+        assertEquals(0, negative.length)
+        assertEquals(2, negative.startInclusive) // srcStart[0] == 2
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.12.10
-versionCode=70
+versionName=0.12.11
+versionCode=71


### PR DESCRIPTION
## Summary

WI-2 (foundational) of feature #125 — the rendered↔source conversion layer that lets MD highlighting reuse #124's selection engine.

- `MarkdownOffsetMap` — chunk-local rendered↔source conversions over WI-1's per-char source spans: `renderedRangeToSource` (`[a,b)`→`[srcStart[a], srcEnd[b-1])`), `sourceRangeToRendered` (clamped, affinity-correct, marker-only→empty), `renderedCursorForSourceEnd` (popover anchor, end-affinity).
- `ChunkTextMapper` — the format-aware seam. `IdentityChunkTextMapper` (TXT, every conversion identity) + `MarkdownChunkTextMapper` (MD, lazy LRU-cached per-chunk map — the single render+cache owner shared by body/controller/wash).

All coords are CHUNK-LOCAL UTF-16 (the caller adds the chunk's document start offset).

## Validation

- `MarkdownOffsetMapTest` — 17/17 (goldens incl. `**bold**x` dual-affinity, surrogate pairs, marker-only collapse, round-trip, out-of-range clamp).
- `ChunkTextMapperTest` — 11/11 (Identity passthrough+clamp, MD conversions, visible-vs-source, LRU bound + recompute-evicted).

## Codex audit

Gate-4 thread `019f1235`, 1 round, **ship-as-is** — 2 Low fixed (out-of-range clamping in both files), no Critical/High/Medium.

Audit log: `.claude/codex-audits/feat-feature-125-wi-2-offset-map-audit.md`

## Tracker

Part of feature #1847. Foundational WI — no device verification (pure conversions). Version: `android/v0.12.11`.

Part of feature #1847