### PR TITLE
feat(#125 WI-3): thread ChunkTextMapper through selection/wash — MD highlighting

### DIFF
--- a/.claude/codex-audits/feat-feature-125-wi-3-md-integration-audit.md
+++ b/.claude/codex-audits/feat-feature-125-wi-3-md-integration-audit.md
@@ -1,0 +1,44 @@
+---
+branch: feat/feature-125-wi-3-md-integration
+threadId: 019f125e-e6db-7b12-9414-ee49480d11f6
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-29
+---
+
+# Gate-4 audit — feature #125 WI-3 (engine integration: thread ChunkTextMapper)
+
+Independent Codex audit (gpt-5.5, high reasoning, read-only sandbox) of WI-3:
+thread the format-aware `ChunkTextMapper` (WI-2) through the #124 TXT-highlighting
+engine so MD books get highlighting. `TxtSelectionController` + `TxtWashMapper` +
+`TxtReaderActivity` (gate removed, `originalFormat.name` locator, visible-vs-source
+text). The chunk `TextLayoutResult` speaks RENDERED coords; the mapper bridges to
+the SOURCE coords highlights persist in.
+
+## Findings — none
+
+> "Clean: no Gate-4 findings in the supplied diff. The changed call sites use the
+> correct coordinate direction: hit/word selection rendered→source; wash and
+> in-progress selection fill source→rendered; popover anchor source-end→rendered
+> cursor. TXT behavior remains identity-mapped, `selectedText()` has no remaining
+> callers, MD stores visible text while persisting source quote/range, and
+> `TxtBody`, wash, and controller all share the same `chunkMapper` instance.
+> Marker-only and empty rendered ranges are skipped safely."
+
+## Test evidence
+
+- `MdHighlightWashTest` — 4/4 (JVM): an MD highlight's SOURCE range washes the
+  correct RENDERED range (markers excluded); heading prefix stripped; marker-only
+  draws nothing; identity unchanged for TXT.
+- `MdHighlightConnectedTest` — 1/1 (**emulator**, cold-restarted): an MD highlight
+  (md locator) persists to real Room and the wash recompute through a
+  `MarkdownChunkTextMapper` projects it onto chunk 1's rendered `[0,4)` ("bold");
+  the `md` locator format round-trips (the Gate-2 Critical).
+- `TxtWashMapperTest` (JVM) + `TxtHighlightConnectedTest` (emulator) — regression,
+  unchanged via the identity mapper.
+
+## Verdict
+
+ship-as-is. WI-3 is behavioral; the slice is verified end-to-end on the emulator.
+The full long-press-gesture → popover → create/edit acceptance on a real `.md`
+fixture is WI-4 (final).

--- a/android/app/src/androidTest/kotlin/com/vreader/app/reader/MdHighlightConnectedTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/reader/MdHighlightConnectedTest.kt
@@ -1,0 +1,62 @@
+package com.vreader.app.reader
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vreader.app.annotations.AnnotationAnchor
+import com.vreader.app.annotations.AnnotationColor
+import com.vreader.app.annotations.AnnotationsRepository
+import com.vreader.app.data.BookEntity
+import com.vreader.app.data.VReaderDatabase
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import vreader.contracts.Locator
+
+/**
+ * Feature #125 WI-3 — on-device: an MD highlight (anchored in SOURCE coords, `md` locator format)
+ * persists to real Room and the wash recompute through a `MarkdownChunkTextMapper` projects it onto the
+ * RENDERED range (markers stripped). Proves the MD persist → re-render path end-to-end (the live gesture
+ * + visual paint are WI-4). The `md` locator format (not hardcoded "txt") is the Gate-2 Critical.
+ */
+@RunWith(AndroidJUnit4::class)
+class MdHighlightConnectedTest {
+    private lateinit var db: VReaderDatabase
+    private lateinit var repo: AnnotationsRepository
+    // chunk 0 = "# Title\n" (src [0,8)); chunk 1 = "**bold**x\n" (src [8,18))
+    private val text = "# Title\n**bold**x\n"
+    private val doc = TxtDocument.of(text)
+    private val mapper = MarkdownChunkTextMapper(doc)
+    private val sha = "a".repeat(64)
+    private val key = "md:$sha:${text.length}"
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext, VReaderDatabase::class.java,
+        ).build()
+        repo = AnnotationsRepository(db.annotationDao())
+        runBlocking { db.bookDao().upsert(BookEntity(key, "T", "md", sha, text.length.toLong(), null, null, 1L, null)) }
+    }
+
+    @After fun tearDown() = db.close()
+
+    @Test fun mdHighlightPersists_andWashRecomputesToRenderedRange_onDevice() = runBlocking {
+        // "bold" in chunk 1: source [10,14). Persist a highlight anchored in SOURCE coords with the md locator.
+        val locator = Locator(sha, text.length.toLong(), "md", charRangeStartUTF16 = 10, charRangeEndUTF16 = 14, textQuote = "bold**x".substring(0, 4))
+        repo.addHighlight(key, AnnotationColor.green, "bold", locator, AnnotationAnchor.Text("text-document:$key", 10, 14))
+
+        val highlights = repo.highlights(key).first()
+        assertEquals(1, highlights.size)
+        assertEquals("the md locator format must round-trip (not 'txt')", "md", highlights.single().locator.format)
+
+        // The wash recompute projects the SOURCE highlight onto chunk 1's RENDERED range [0,4) ("bold").
+        val map = TxtWashMapper.washesByChunk(doc, highlights, mapper)
+        assertTrue("wash projected onto chunk 1", map.containsKey(1))
+        assertEquals(WashSpan(Utf16Range(0, 4), AnnotationColor.green), map[1]!!.single())
+    }
+}

--- a/android/app/src/androidTest/kotlin/com/vreader/app/reader/TxtHighlightConnectedTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/reader/TxtHighlightConnectedTest.kt
@@ -48,7 +48,7 @@ class TxtHighlightConnectedTest {
 
         val highlights = repo.highlights(key).first()
         assertEquals(1, highlights.size)
-        val map = TxtWashMapper.washesByChunk(doc, highlights)
+        val map = TxtWashMapper.washesByChunk(doc, highlights, IdentityChunkTextMapper(doc))
         assertTrue("wash projected onto chunk 1", map.containsKey(1))
         assertEquals(WashSpan(Utf16Range(1, 3), AnnotationColor.green), map[1]!!.single())
     }

--- a/android/app/src/main/kotlin/com/vreader/app/reader/TxtHighlightWash.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/TxtHighlightWash.kt
@@ -15,15 +15,22 @@ import com.vreader.app.annotations.HighlightRecord
 data class WashSpan(val local: Utf16Range, val color: AnnotationColor)
 
 object TxtWashMapper {
-    /** Project every highlight's `[charRangeStartUTF16, charRangeEndUTF16)` onto the chunks it spans. */
-    fun washesByChunk(doc: TxtDocument, highlights: List<HighlightRecord>): Map<Int, List<WashSpan>> {
+    /**
+     * Project every highlight's SOURCE range `[charRangeStartUTF16, charRangeEndUTF16)` onto the chunks
+     * it spans, as chunk-LOCAL RENDERED ranges (`getPathForRange` speaks rendered coords). [mapper]
+     * converts each chunk-local source range → rendered (TXT = identity; MD strips markers, so a
+     * marker-only slice collapses to empty and draws nothing).
+     */
+    fun washesByChunk(doc: TxtDocument, highlights: List<HighlightRecord>, mapper: ChunkTextMapper): Map<Int, List<WashSpan>> {
         val map = HashMap<Int, MutableList<WashSpan>>()
         for (h in highlights) {
             val s = h.locator.charRangeStartUTF16 ?: continue
             val e = h.locator.charRangeEndUTF16 ?: continue
             if (e <= s) continue
             for (cr in TxtSourceOffsets.chunkRanges(doc, Utf16Range(s, e))) {
-                map.getOrPut(cr.chunkIndex) { mutableListOf() }.add(WashSpan(cr.local, h.color))
+                val rendered = mapper.sourceRangeToRendered(cr.chunkIndex, cr.local)
+                if (rendered.isEmpty) continue
+                map.getOrPut(cr.chunkIndex) { mutableListOf() }.add(WashSpan(rendered, h.color))
             }
         }
         return map

--- a/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt
@@ -222,17 +222,22 @@ class TxtReaderActivity : ComponentActivity() {
                         val bookKey = s.book.fingerprintKey
                         val sessionSeconds by tracker.sessionSeconds.collectAsStateWithLifecycle()
 
-                        // feature #124 — stored TXT highlights → per-chunk washes (BINDING gate: TXT only;
-                        // MD render-only until #125 adds the source-offset map). Collect the list (for both
-                        // the wash recompute AND the WI-4 tap hit-test).
-                        val isTxt = s.book.originalFormat == BookFormat.txt
-                        val highlightsList by remember(bookKey, isTxt) {
-                            if (isTxt) container.annotationsRepository.highlights(bookKey) else flowOf(emptyList())
+                        // feature #124/#125 — stored highlights → per-chunk washes. Enabled for TXT AND MD
+                        // (#125 added the MarkdownChunkTextMapper source-offset map, so MD is no longer
+                        // render-only). The mapper is the single rendered↔source bridge + render owner,
+                        // shared by the wash, the selection controller, and the body.
+                        val annotatable = s.book.originalFormat == BookFormat.txt || s.book.originalFormat == BookFormat.md
+                        val chunkMapper = remember(s.document, s.book.originalFormat) {
+                            if (s.book.originalFormat == BookFormat.md) MarkdownChunkTextMapper(s.document)
+                            else IdentityChunkTextMapper(s.document)
+                        }
+                        val highlightsList by remember(bookKey, annotatable) {
+                            if (annotatable) container.annotationsRepository.highlights(bookKey) else flowOf(emptyList())
                         }.collectAsStateWithLifecycle(emptyList())
-                        val washMap = remember(highlightsList, s.document) { TxtWashMapper.washesByChunk(s.document, highlightsList) }
+                        val washMap = remember(highlightsList, s.document, chunkMapper) { TxtWashMapper.washesByChunk(s.document, highlightsList, chunkMapper) }
 
-                        // feature #124 — TXT custom selection + popover (TXT only).
-                        val selectionController = remember(s.document, isTxt) { if (isTxt) TxtSelectionController(s.document) else null }
+                        // feature #124/#125 — custom selection + popover (TXT + MD).
+                        val selectionController = remember(s.document, chunkMapper) { if (annotatable) TxtSelectionController(s.document, chunkMapper) else null }
                         val popoverVm = remember(bookKey) { com.vreader.app.annotations.SelectionPopoverViewModel() }
                         val popoverState by popoverVm.state.collectAsStateWithLifecycle()
                         DisposableEffect(lifecycleOwner, bookKey) {
@@ -285,7 +290,7 @@ class TxtReaderActivity : ComponentActivity() {
                             var boxSize by remember { mutableStateOf(androidx.compose.ui.unit.IntSize.Zero) }
                             Box(Modifier.fillMaxSize().onGloballyPositioned { boxOriginWindow = it.localToWindow(androidx.compose.ui.geometry.Offset.Zero); boxSize = it.size }) {
                                 TxtBody(
-                                    s.document, listState, s.book.originalFormat,
+                                    s.document, listState, s.book.originalFormat, chunkMapper,
                                     highlightSpan = { chunkIndex ->
                                         if (!active) null
                                         else {
@@ -403,9 +408,9 @@ class TxtReaderActivity : ComponentActivity() {
 
     private fun finalizeTxtSelection(controller: TxtSelectionController?, vm: com.vreader.app.annotations.SelectionPopoverViewModel) {
         val c = controller ?: return
-        if (c.selectedText().isNullOrBlank() || !c.isCurrentSelectionValid()) { c.clear(); return }
+        if (c.selectedVisibleText().isNullOrBlank() || !c.isCurrentSelectionValid()) { c.clear(); return }
         pendingTxtHighlightId = null   // a fresh selection is CREATE context
-        pendingTxtText = c.selectedText()
+        pendingTxtText = c.selectedVisibleText()
         val anchor = c.selectionEndAnchorWindow() ?: androidx.compose.ui.geometry.Offset.Zero
         vm.showForSelection(anchor.x, anchor.y)   // WINDOW px
     }
@@ -493,22 +498,23 @@ class TxtReaderActivity : ComponentActivity() {
     ) {
         val c = controller ?: return
         val range = c.currentRange()
-        val text = c.selectedText()
-        if (range == null || text.isNullOrBlank() || !c.isCurrentSelectionValid()) { clearTxtSelection(c, vm); return }
+        val visible = c.selectedVisibleText()   // #125: stored selectedText = what the user sees (rendered)
+        val source = c.selectedSourceText()      // #125: textQuote + anchor = the markdown/raw source span
+        if (range == null || visible.isNullOrBlank() || source.isNullOrBlank() || !c.isCurrentSelectionValid()) { clearTxtSelection(c, vm); return }
         val locator = vreader.contracts.Locator(
-            book.contentSHA256, book.fileByteCount, "txt",
-            charRangeStartUTF16 = range.startInclusive, charRangeEndUTF16 = range.endExclusive, textQuote = text,
+            book.contentSHA256, book.fileByteCount, book.originalFormat.name,   // #125: NOT hardcoded "txt" — MD key is "md:…"
+            charRangeStartUTF16 = range.startInclusive, charRangeEndUTF16 = range.endExclusive, textQuote = source,
         )
         val anchor = com.vreader.app.annotations.AnnotationAnchor.Text("text-document:${book.fingerprintKey}", range.startInclusive, range.endExclusive)
         container.appScope.launch {
-            container.annotationsRepository.addHighlight(book.fingerprintKey, color, text, locator, anchor, note)
+            container.annotationsRepository.addHighlight(book.fingerprintKey, color, visible, locator, anchor, note)
         }
         clearTxtSelection(c, vm)
     }
 
     /** The text for copy/share — the live selection's, or (EDIT) the tapped highlight's. */
     private fun txtTextForAction(controller: TxtSelectionController?): String? =
-        pendingTxtText ?: controller?.selectedText()
+        pendingTxtText ?: controller?.selectedVisibleText()
 
     private fun copyTxtTextForAction(controller: TxtSelectionController?) {
         val text = txtTextForAction(controller) ?: return
@@ -587,6 +593,9 @@ private fun TtsEntryBar(enabled: Boolean, onReadAloud: () -> Unit) {
 @Composable
 private fun TxtBody(
     document: TxtDocument, listState: LazyListState, format: BookFormat,
+    // feature #125 — the single render owner. MD chunks render via mapper.renderedText so the body's
+    // TextLayoutResult matches the controller/wash's offset map exactly (no double render, no drift).
+    mapper: ChunkTextMapper,
     highlightSpan: (chunkIndex: Int) -> IntRange? = { null },
     // feature #124 — annotation highlight washes per chunk (TXT only; the activity passes empty for MD).
     washesForChunk: (chunkIndex: Int) -> List<WashSpan> = { emptyList() },
@@ -643,7 +652,7 @@ private fun TxtBody(
             // .txt → raw verbatim, with the spoken-sentence span washed when read-aloud is active.
             val span = if (isMarkdown) null else highlightSpan(i)
             val text = when {
-                isMarkdown -> MarkdownRenderer.render(raw)
+                isMarkdown -> mapper.renderedText(i)   // #125: the mapper is the single render owner
                 span != null -> buildAnnotatedString {
                     append(raw)
                     val a = span.first.coerceIn(0, raw.length); val b = (span.last + 1).coerceIn(a, raw.length)

--- a/android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt
@@ -16,7 +16,13 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 @Stable
-class TxtSelectionController(private val doc: TxtDocument) {
+class TxtSelectionController(
+    private val doc: TxtDocument,
+    // feature #125 — format-aware rendered↔source bridge. The chunk TextLayoutResults are built from the
+    // RENDERED text, so getOffsetForPosition/getWordBoundary/getCursorRect speak rendered coords; the
+    // mapper converts them to/from the SOURCE coords selections + highlights are stored in. TXT = identity.
+    private val mapper: ChunkTextMapper,
+) {
     private data class ChunkInfo(val layout: TextLayoutResult, val coords: LayoutCoordinates)
     /** A resolved hit: the chunk index/info + the chunk-local rendered offset + the absolute source offset. */
     private data class Hit(val chunkIndex: Int, val info: ChunkInfo, val rendered: Int, val source: Int)
@@ -47,16 +53,20 @@ class TxtSelectionController(private val doc: TxtDocument) {
             ?: return null
         val chunkLocal = hit.value.coords.windowToLocal(windowPoint)
         val rendered = hit.value.layout.getOffsetForPosition(chunkLocal).coerceIn(0, hit.value.layout.layoutInput.text.length)
-        return Hit(hit.key, hit.value, rendered, TxtSourceOffsets.sourceOffset(doc, hit.key, rendered))
+        // rendered cursor → chunk-local source (empty rendered range maps to the source edge) → global source.
+        val localSource = mapper.renderedRangeToSource(hit.key, Utf16Range(rendered, rendered)).startInclusive
+        return Hit(hit.key, hit.value, rendered, doc.offsetForChunk(hit.key) + localSource)
     }
 
     /** Long-press: select the word under [localPoint] (word boundary in the HIT chunk, mapped to source). */
     fun beginAt(localPoint: Offset) {
         val hit = hitAt(localPoint) ?: return
-        val word = hit.info.layout.getWordBoundary(hit.rendered)   // rendered coords in the hit chunk
+        val word = hit.info.layout.getWordBoundary(hit.rendered)   // RENDERED coords in the hit chunk
         val base = doc.offsetForChunk(hit.chunkIndex)
-        val start = base + word.start
-        val end = base + word.end
+        // rendered word → chunk-local source span → global source (markers stripped for MD).
+        val src = mapper.renderedRangeToSource(hit.chunkIndex, Utf16Range(word.start, word.end))
+        val start = base + src.startInclusive
+        val end = base + src.endExclusive
         val range = if (end > start) Utf16Range(start, end) else Utf16Range(hit.source, (hit.source + 1).coerceAtMost(doc.text.length))
         anchorRange = range
         _selection.value = range
@@ -89,17 +99,31 @@ class TxtSelectionController(private val doc: TxtDocument) {
     /** Whether the current selection is a persist-worthy range (in-bounds, non-empty, surrogate-safe). */
     fun isCurrentSelectionValid(): Boolean = _selection.value?.let { TxtSelection.isValid(it, doc.text) } ?: false
 
-    /** The SOURCE substring of the current selection (for the popover's text / copy / share). */
-    fun selectedText(): String? {
+    /** The VISIBLE (rendered) substring of the current selection — for the popover / copy / share / UI.
+     *  For TXT this equals the source; for MD it's the marker-stripped rendered text the user sees. */
+    fun selectedVisibleText(): String? {
+        val r = _selection.value ?: return null
+        if (r.isEmpty || r.endExclusive > doc.text.length) return null
+        val sb = StringBuilder()
+        for (cr in TxtSourceOffsets.chunkRanges(doc, r)) {
+            sb.append(mapper.visibleText(cr.chunkIndex, mapper.sourceRangeToRendered(cr.chunkIndex, cr.local)))
+        }
+        return sb.toString().ifEmpty { null }
+    }
+
+    /** The SOURCE (markdown/raw) substring of the current selection — for the locator textQuote + anchor. */
+    fun selectedSourceText(): String? {
         val r = _selection.value ?: return null
         if (r.isEmpty || r.endExclusive > doc.text.length) return null
         return doc.text.substring(r.startInclusive, r.endExclusive)
     }
 
-    /** The in-progress selection projected onto [chunkIndex] (chunk-local), for the accent wash. */
+    /** The in-progress selection projected onto [chunkIndex] as a chunk-local RENDERED range, for the
+     *  accent wash (`getPathForRange` speaks rendered coords). Source→rendered via the mapper (MD). */
     fun selectionForChunk(chunkIndex: Int): Utf16Range? {
         val r = _selection.value ?: return null
-        return TxtSourceOffsets.chunkRanges(doc, r).firstOrNull { it.chunkIndex == chunkIndex }?.local
+        val localSource = TxtSourceOffsets.chunkRanges(doc, r).firstOrNull { it.chunkIndex == chunkIndex }?.local ?: return null
+        return mapper.sourceRangeToRendered(chunkIndex, localSource)
     }
 
     /** The window-space point just below the selection's end, to anchor the popover. */
@@ -108,7 +132,9 @@ class TxtSelectionController(private val doc: TxtDocument) {
         val endChunk = doc.chunkForOffset((r.endExclusive - 1).coerceAtLeast(0)).coerceIn(0, doc.chunkCount - 1)
         val info = chunks[endChunk] ?: return null
         val base = doc.offsetForChunk(endChunk)
-        val renderedEnd = (r.endExclusive - base).coerceIn(0, info.layout.layoutInput.text.length)
+        // source end → chunk-local source → rendered cursor (end-affinity) for getCursorRect.
+        val localSourceEnd = (r.endExclusive - base).coerceAtLeast(0)
+        val renderedEnd = mapper.renderedCursorForSourceEnd(endChunk, localSourceEnd).coerceIn(0, info.layout.layoutInput.text.length)
         val rect = info.layout.getCursorRect(renderedEnd)
         return info.coords.localToWindow(Offset(rect.left, rect.bottom))
     }

--- a/android/app/src/test/kotlin/com/vreader/app/reader/MdHighlightWashTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/MdHighlightWashTest.kt
@@ -1,0 +1,53 @@
+package com.vreader.app.reader
+
+import com.vreader.app.annotations.AnnotationColor
+import com.vreader.app.annotations.HighlightRecord
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import vreader.contracts.Locator
+
+/**
+ * Feature #125 WI-3 — a stored MD highlight is anchored in SOURCE coords, but the wash must draw the
+ * RENDERED range (`getPathForRange` speaks rendered offsets). `TxtWashMapper.washesByChunk` + a
+ * `MarkdownChunkTextMapper` projects source→rendered, so markers are excluded and a marker-only
+ * highlight washes nothing.
+ */
+class MdHighlightWashTest {
+    // chunk 0 = "# Title\n" (src [0,8)); chunk 1 = "**bold**x\n" (src [8,18))
+    private val doc = TxtDocument.of("# Title\n**bold**x\n")
+    private val mapper = MarkdownChunkTextMapper(doc)
+    private val key = "md:${"a".repeat(64)}:18"
+
+    private fun hl(start: Int, end: Int) = HighlightRecord(
+        id = "h$start", bookKey = key, color = AnnotationColor.yellow, selectedText = "bold", note = null,
+        locator = Locator("a".repeat(64), 18L, "md", charRangeStartUTF16 = start, charRangeEndUTF16 = end),
+        anchor = null, createdAt = 1L, updatedAt = 1L,
+    )
+
+    @Test fun boldHighlight_washesRenderedRangeNotSource() {
+        // "bold" source span: chunk 1 base 8, source [10,14). Rendered "boldx\n" → "bold" is rendered [0,4).
+        val map = TxtWashMapper.washesByChunk(doc, listOf(hl(10, 14)), mapper)
+        assertEquals(setOf(1), map.keys)
+        assertEquals(WashSpan(Utf16Range(0, 4), AnnotationColor.yellow), map[1]!!.single())
+    }
+
+    @Test fun headingHighlight_washesStrippedPrefix() {
+        // "Title" source: chunk 0 "# Title\n", "Title" is source [2,7). Rendered "Title\n" → rendered [0,5).
+        val map = TxtWashMapper.washesByChunk(doc, listOf(hl(2, 7)), mapper)
+        assertEquals(WashSpan(Utf16Range(0, 5), AnnotationColor.yellow), map[0]!!.single())
+    }
+
+    @Test fun markerOnlyHighlight_washesNothing() {
+        // The opening "**" of chunk 1 is source [8,10) — overlaps no visible char → no wash.
+        val map = TxtWashMapper.washesByChunk(doc, listOf(hl(8, 10)), mapper)
+        assertTrue("a marker-only highlight draws nothing", map[1].isNullOrEmpty())
+    }
+
+    @Test fun identityMapper_unchangedForTxt() {
+        // Same highlight through the identity mapper (TXT) washes the SOURCE range verbatim (regression).
+        val txt = TxtDocument.of("# Title\n**bold**x\n")
+        val map = TxtWashMapper.washesByChunk(txt, listOf(hl(10, 14)), IdentityChunkTextMapper(txt))
+        assertEquals(WashSpan(Utf16Range(2, 6), AnnotationColor.yellow), map[1]!!.single())
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/TxtWashMapperTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/TxtWashMapperTest.kt
@@ -10,6 +10,7 @@ import vreader.contracts.Locator
 /** Feature #124 WI-2 — [TxtWashMapper.washesByChunk] projects highlights onto per-chunk washes. */
 class TxtWashMapperTest {
     private val doc = TxtDocument.of("AAAA\nBBBB\nCCCC\nDDDD\n", maxChunkChars = 6)
+    private val mapper = IdentityChunkTextMapper(doc)   // #125: TXT = identity, so washes are unchanged
     private val key = "txt:${"a".repeat(64)}:20"
 
     private fun hl(start: Int, end: Int, color: AnnotationColor = AnnotationColor.yellow) = HighlightRecord(
@@ -20,7 +21,7 @@ class TxtWashMapperTest {
 
     @Test fun singleChunkHighlight_oneWash() {
         val base1 = doc.offsetForChunk(1)
-        val map = TxtWashMapper.washesByChunk(doc, listOf(hl(base1 + 1, base1 + 3, AnnotationColor.pink)))
+        val map = TxtWashMapper.washesByChunk(doc, listOf(hl(base1 + 1, base1 + 3, AnnotationColor.pink)), mapper)
         assertEquals(setOf(1), map.keys)
         assertEquals(WashSpan(Utf16Range(1, 3), AnnotationColor.pink), map[1]!!.single())
     }
@@ -28,7 +29,7 @@ class TxtWashMapperTest {
     @Test fun multiChunkHighlight_splitsAcrossChunks() {
         val start = doc.offsetForChunk(0) + 2
         val end = doc.offsetForChunk(2) + 2
-        val map = TxtWashMapper.washesByChunk(doc, listOf(hl(start, end)))
+        val map = TxtWashMapper.washesByChunk(doc, listOf(hl(start, end)), mapper)
         assertTrue("covers >= 2 chunks", map.keys.size >= 2)
         // reassembling the per-chunk locals back to source equals the original range
         var cursor = start
@@ -44,12 +45,12 @@ class TxtWashMapperTest {
 
     @Test fun multipleHighlights_distinctChunks() {
         val b0 = doc.offsetForChunk(0); val b3 = doc.offsetForChunk(3)
-        val map = TxtWashMapper.washesByChunk(doc, listOf(hl(b0, b0 + 2), hl(b3, b3 + 2)))
+        val map = TxtWashMapper.washesByChunk(doc, listOf(hl(b0, b0 + 2), hl(b3, b3 + 2)), mapper)
         assertTrue(map.containsKey(0) && map.containsKey(3))
     }
 
     @Test fun highlightWithoutCharRange_skipped() {
         val noRange = HighlightRecord("h", key, AnnotationColor.blue, "x", null, Locator("a".repeat(64), 20L, "txt", href = "c"), null, 1L, 1L)
-        assertTrue(TxtWashMapper.washesByChunk(doc, listOf(noRange)).isEmpty())
+        assertTrue(TxtWashMapper.washesByChunk(doc, listOf(noRange), mapper).isEmpty())
     }
 }

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.12.11
-versionCode=71
+versionName=0.12.12
+versionCode=72

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -660,9 +660,15 @@ visible chunk's `TextLayoutResult` + `LayoutCoordinates`; one `awaitEachGesture`
 (edit an existing highlight) from a long-press-drag (new word selection), converting the pointer
 → window → chunk-local → SOURCE UTF-16 offset (`TxtSourceOffsets`). Stored highlights render as washes
 via `drawBehind` + `getPathForRange` (`TxtWashMapper`/`drawWashes`); a tap hit-tests via
-`TxtHighlightHitTester`. Everything is gated to `BookFormat.txt` (MD highlighting is the #125 follow-on,
-which needs a `MarkdownRenderer` source-offset map). The selection gesture is verifiable via the Compose
-test harness (`TxtReaderActivityTest` long-press/tap E2E), unlike the EPUB WebView gesture.
+`TxtHighlightHitTester`. **Feature #125 extended this to MD** (the same `TxtReaderActivity` hosts both):
+a format-aware `ChunkTextMapper` — `IdentityChunkTextMapper` for TXT, `MarkdownChunkTextMapper` for MD
+over `MarkdownRenderer.renderWithMap`'s per-rendered-char source spans (`MarkdownOffsetMap`) — threads
+through the controller + wash + `TxtBody`, so a chunk's RENDERED offsets (the `TextLayoutResult` speaks
+rendered coords) map to/from the SOURCE UTF-16 coords highlights persist in, with markers stripped (a
+marker-only slice washes nothing). The old `BookFormat.txt` gate is gone — `TxtReaderActivity` builds the
+mapper from `book.originalFormat` and stores `selectedText` = visible text / `locator.textQuote` = source
+/ `locator.format` = `originalFormat.name`. The selection gesture is verifiable via the Compose test
+harness (`TxtReaderActivityTest` long-press/tap E2E), unlike the EPUB WebView gesture.
 
 ### Reading-stats (`com.vreader.app.stats`) — feature #122
 


### PR DESCRIPTION
## Summary

WI-3 (behavioral) of feature #125 — wire WI-2's `ChunkTextMapper` into the #124 TXT-highlighting engine so **MD books get highlighting** too. The chunk `TextLayoutResult` speaks RENDERED coords; the mapper bridges to/from the SOURCE coords highlights persist in.

## What changed

- **`TxtSelectionController`** takes a `ChunkTextMapper`. hit/word selection: rendered→source; in-progress wash: source→rendered; popover anchor: source-end→rendered cursor. `selectedText()` split into `selectedVisibleText()` (rendered) + `selectedSourceText()` (source).
- **`TxtWashMapper.washesByChunk`** takes the mapper: a stored highlight's chunk-local SOURCE range → RENDERED via `sourceRangeToRendered` (a marker-only slice collapses to empty → draws nothing).
- **`TxtReaderActivity`** removes the `BookFormat.txt` gate (`annotatable = txt||md`), builds `MarkdownChunkTextMapper`/`IdentityChunkTextMapper` from `book.originalFormat`, threads it into the wash + controller + `TxtBody` (MD renders via `mapper.renderedText` — single render owner). `createTxtHighlight`: stored `selectedText` = visible, `locator.textQuote` = source, `locator.format` = `originalFormat.name` (the Gate-2 Critical — MD key is `md:…`).

## Validation

- `MdHighlightWashTest` — 4/4 (JVM): MD source range → correct rendered wash; marker-only → nothing; identity unchanged for TXT.
- `MdHighlightConnectedTest` — 1/1 (**emulator**): an MD highlight persists to real Room with the `md` locator and the wash recomputes to chunk 1's rendered `[0,4)`.
- `TxtWashMapperTest` + `TxtHighlightConnectedTest` — TXT regression (identity), green.

## Codex audit

Gate-4 thread `019f125e`, 1 round, **ship-as-is** — no findings (coordinate directions correct, TXT identity-preserved, no remaining `selectedText()` callers, single mapper instance shared).

Audit log: `.claude/codex-audits/feat-feature-125-wi-3-md-integration-audit.md`

## Docs

`docs/architecture.md` Android annotations section updated (the `BookFormat.txt` gate is gone).

## Tracker

Part of feature #1847. Behavioral WI — slice verified on the emulator (the full long-press gesture acceptance is WI-4). Version: `android/v0.12.12`.

Part of feature #1847