### PR TITLE
test(#125): restore WI-4 audit log + test-robustness fixes

### DIFF
--- a/.claude/codex-audits/chore-feature-125-wi4-test-robustness-audit.md
+++ b/.claude/codex-audits/chore-feature-125-wi4-test-robustness-audit.md
@@ -1,0 +1,30 @@
+---
+branch: chore/feature-125-wi4-test-robustness
+threadId: 019f1282-1276-7bf3-8966-43364fee0d98
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-29
+---
+
+# Gate-4 audit — feature #125 WI-4 test robustness (follow-up)
+
+The WI-4 acceptance PR (#1867) merged the `MdReaderHighlightUiTest` but the Gate-4
+audit log + the two test-robustness fixes were committed locally and not pushed
+before the squash-merge, so they did not land on `main`. This follow-up restores
+them.
+
+Independent Codex audit (gpt-5.5, high reasoning, read-only sandbox, thread
+`019f1282`) of `MdReaderHighlightUiTest` found no Critical/High; 1 Medium + 1 Low,
+both applied here:
+
+| file | severity | issue | resolution |
+|---|---|---|---|
+| `MdReaderHighlightUiTest.kt` (`mdSeededHighlight…`) | Medium | The wash test only asserted the line text is displayed — it would pass even if washes were disabled / the wash map were empty. | **Fixed.** Now computes `TxtWashMapper.washesByChunk(doc, highlights, MarkdownChunkTextMapper(doc))` for the seeded highlight and asserts a non-empty rendered wash span before the live render. (The exact span `[0,4)` is additionally pinned by `MdHighlightConnectedTest`.) |
+| `MdReaderHighlightUiTest.kt` (`styledLineSourceRange`) | Low | Offsets were computed from the hardcoded `mdContent` while the test imports `sample-note.md`; fixture drift could seed the wrong source range. | **Fixed.** Reads the imported asset content + a `check(content == mdContent)` drift guard. |
+
+No production code changes; test-only. `:app:compileDebugAndroidTestKotlin` is clean.
+
+## Verdict
+
+ship-as-is. Restores the WI-4 audit artifact + the two test-robustness fixes onto
+`main` (feature #125 is already VERIFIED at `android/v0.13.0`).

--- a/android/app/src/androidTest/kotlin/com/vreader/app/reader/MdReaderHighlightUiTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/reader/MdReaderHighlightUiTest.kt
@@ -50,9 +50,14 @@ class MdReaderHighlightUiTest {
     private fun app() = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext as VReaderApp
     private fun ctx() = InstrumentationRegistry.getInstrumentation().targetContext
 
-    /** The whole styled line's SOURCE range (chunk start..end-newline), for seeding a tappable highlight. */
+    /** The whole styled line's SOURCE range (chunk start..end-newline), for seeding a tappable highlight.
+     *  Computed from the IMPORTED asset content (not the hardcoded string) so a fixture edit can't seed
+     *  the wrong range; the drift check fails loudly if `sample-note.md` and `mdContent` diverge. */
     private fun styledLineSourceRange(): Pair<Int, Int> {
-        val doc = TxtDocument.of(mdContent)
+        val content = InstrumentationRegistry.getInstrumentation().context.assets
+            .open("sample-note.md").use { it.readBytes().decodeToString() }
+        check(content == mdContent) { "sample-note.md drifted from the test's mdContent — update mdContent" }
+        val doc = TxtDocument.of(content)
         val ci = (0 until doc.chunkCount).first { doc.textForChunk(it).contains("bold") }
         val base = doc.offsetForChunk(ci)
         val len = doc.textForChunk(ci).length
@@ -103,9 +108,15 @@ class MdReaderHighlightUiTest {
             val loc = Locator(book.contentSHA256, book.fileByteCount, "md", charRangeStartUTF16 = s, charRangeEndUTF16 = e, textQuote = "styled")
             app().container.annotationsRepository.addHighlight(key, AnnotationColor.yellow, "styled", loc, AnnotationAnchor.Text("text-document:$key", s, e))
         }
+        // PROVE the seeded MD highlight produces a NON-EMPTY rendered wash span (else this test would
+        // pass even if washes were disabled — Gate-4 Medium). The activity's drawBehind then paints it.
+        val hls = runBlocking { app().container.annotationsRepository.highlightsForBook(key) }
+        val washes = TxtWashMapper.washesByChunk(TxtDocument.of(mdContent), hls, MarkdownChunkTextMapper(TxtDocument.of(mdContent)))
+        assertTrue("the seeded MD highlight projects to a non-empty rendered wash span", washes.values.any { it.isNotEmpty() })
+
         ActivityScenario.launch<TxtReaderActivity>(TxtReaderActivity.intent(ctx(), key)).use {
             // render completes WITH the md highlight present → the source→rendered wash projection +
-            // getPathForRange path executed for the MD chunk without crashing.
+            // getPathForRange drawBehind path executed for the MD chunk without crashing.
             compose.waitUntil(12_000) { compose.onAllNodesWithText("This is bold and italic", substring = true).fetchSemanticsNodes().isNotEmpty() }
             compose.onNodeWithText("This is bold and italic", substring = true).assertIsDisplayed()
         }

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.13.0
-versionCode=73
+versionName=0.13.1
+versionCode=74


### PR DESCRIPTION
## Summary

The WI-4 acceptance PR (#1867) merged before its audit-fix commit was pushed, so the Gate-4 audit log + 2 test-robustness fixes for `MdReaderHighlightUiTest` didn't land on `main`. This restores them.

- **mdSeededHighlight** now asserts a non-empty rendered wash span via `TxtWashMapper.washesByChunk(...)` (Gate-4 **Medium** — was render-only; would pass even if washes were disabled).
- **styledLineSourceRange** reads the imported asset content + a `check(content == mdContent)` drift guard (Gate-4 **Low**).
- Restores `.claude/codex-audits/...` Gate-4 audit log (thread `019f1282`, ship-as-is).

Test-only; `:app:compileDebugAndroidTestKotlin` clean. Feature #125 is already VERIFIED at `android/v0.13.0`.