### PR TITLE
feat(#127 WI-1): collections schema + Room v4→v5 migration

### DIFF
--- a/.claude/codex-audits/feat-feature-127-wi-1-collections-schema-audit.md
+++ b/.claude/codex-audits/feat-feature-127-wi-1-collections-schema-audit.md
@@ -1,0 +1,46 @@
+---
+branch: feat/feature-127-wi-1-collections-schema
+threadId: 019f12a7-08bb-7c73-acd2-b382f7f7d5d4
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-29
+---
+
+# Gate-4 audit — feature #127 WI-1 (collections schema + Room v4→v5 migration)
+
+Independent Codex audit (gpt-5.5, high reasoning, read-only sandbox) of WI-1:
+`CollectionEntity` + `BookCollectionCrossRef` + `MIGRATION_4_5` + `@Database(version=5)`
++ a `CollectionDao` skeleton + the exported `5.json`, with a Robolectric v1→v5 migration
+test + an in-memory `CollectionDaoTest`.
+
+## Findings — no Critical/High/Medium; 1 Low (fixed)
+
+> "No Critical/High/Medium findings. The schema/migration work is clean for Gate-4:
+> `MIGRATION_4_5` matches the exported v5 schema for the new tables/indices, v4 existing
+> table DDL is unchanged, `ALL_MIGRATIONS` includes 4→5, and the FK/index design is sound."
+
+| file | severity | issue | resolution |
+|---|---|---|---|
+| `CollectionDao.kt` / `CollectionDaoTest.kt` | Low | Comment/test name still said "upsert" though the behavior is a strict `@Insert` (ABORT-on-conflict). Doc drift, not a runtime bug. | **Fixed.** DAO header reworded (strict `@Insert`, not `@Upsert`); test renamed `insert_andFindByNameKey`. |
+
+## Auditor confirmations
+
+- Composite PK `(bookKey, collectionId)` + an explicit `collectionId` index is correct (PK covers the
+  book-side lookup/FK; the explicit index covers the reverse "books in collection" lookup + the
+  collection FK).
+- `INSERT OR IGNORE` is appropriate for idempotent membership; FK violations are still not silently
+  accepted.
+- Storing `nameKey` without a DB CHECK tying it to `name` is a reasonable WI-1/WI-2 split — the
+  locale-stable normalization belongs in the repository (WI-2).
+- The full 1→5 migration test exercises the 4→5 step + Room's final structural validation, plus
+  behavioral coverage for the unique `nameKey` and book-delete cascade.
+
+## Test evidence
+
+- `VReaderDatabaseMigrationTest` — 4/4 (the new `migrate1To5_…addsCollections_cascades_andEnforcesUniqueName`).
+- `CollectionDaoTest` — 3/3 (insert/find, observe-ordered, membership idempotent + reverse lookup).
+
+## Verdict
+
+ship-as-is. WI-1 is foundational; `CollectionDao` full + `CollectionRepository` (transactional dedup,
+counts) is WI-2.

--- a/android/app/schemas/com.vreader.app.data.VReaderDatabase/5.json
+++ b/android/app/schemas/com.vreader.app.data.VReaderDatabase/5.json
@@ -1,0 +1,544 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "a2b3a4c589bcf3c141b6468f83e4cc03",
+    "entities": [
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fingerprintKey` TEXT NOT NULL, `title` TEXT NOT NULL, `originalFormat` TEXT NOT NULL, `contentSHA256` TEXT NOT NULL, `fileByteCount` INTEGER NOT NULL, `localFilePath` TEXT, `sourceUri` TEXT, `addedAt` INTEGER NOT NULL, `lastOpenedAt` INTEGER, PRIMARY KEY(`fingerprintKey`))",
+        "fields": [
+          {
+            "fieldPath": "fingerprintKey",
+            "columnName": "fingerprintKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalFormat",
+            "columnName": "originalFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentSHA256",
+            "columnName": "contentSHA256",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileByteCount",
+            "columnName": "fileByteCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "localFilePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceUri",
+            "columnName": "sourceUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fingerprintKey"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fingerprintKey` TEXT NOT NULL, `vreaderLocatorJSON` TEXT NOT NULL, `canonicalHash` TEXT NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`fingerprintKey`), FOREIGN KEY(`fingerprintKey`) REFERENCES `books`(`fingerprintKey`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fingerprintKey",
+            "columnName": "fingerprintKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vreaderLocatorJSON",
+            "columnName": "vreaderLocatorJSON",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canonicalHash",
+            "columnName": "canonicalHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fingerprintKey"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fingerprintKey"
+            ],
+            "referencedColumns": [
+              "fingerprintKey"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "daily_reading",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, `bookKey` TEXT NOT NULL, `minutes` INTEGER NOT NULL, PRIMARY KEY(`date`, `bookKey`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookKey",
+            "columnName": "bookKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minutes",
+            "columnName": "minutes",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "date",
+            "bookKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_daily_reading_bookKey",
+            "unique": false,
+            "columnNames": [
+              "bookKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_daily_reading_bookKey` ON `${TABLE_NAME}` (`bookKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "highlights",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`highlightId` TEXT NOT NULL, `bookKey` TEXT NOT NULL, `profileKey` TEXT NOT NULL, `anchorKey` TEXT NOT NULL, `color` TEXT NOT NULL, `selectedText` TEXT NOT NULL, `note` TEXT, `locatorJSON` TEXT NOT NULL, `anchorJSON` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`highlightId`), FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "highlightId",
+            "columnName": "highlightId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookKey",
+            "columnName": "bookKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileKey",
+            "columnName": "profileKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "anchorKey",
+            "columnName": "anchorKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectedText",
+            "columnName": "selectedText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "locatorJSON",
+            "columnName": "locatorJSON",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "anchorJSON",
+            "columnName": "anchorJSON",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "highlightId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_highlights_bookKey",
+            "unique": false,
+            "columnNames": [
+              "bookKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_highlights_bookKey` ON `${TABLE_NAME}` (`bookKey`)"
+          },
+          {
+            "name": "index_highlights_profileKey_anchorKey",
+            "unique": true,
+            "columnNames": [
+              "profileKey",
+              "anchorKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_highlights_profileKey_anchorKey` ON `${TABLE_NAME}` (`profileKey`, `anchorKey`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookKey"
+            ],
+            "referencedColumns": [
+              "fingerprintKey"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "annotation_notes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`noteId` TEXT NOT NULL, `bookKey` TEXT NOT NULL, `profileKey` TEXT NOT NULL, `content` TEXT NOT NULL, `locatorJSON` TEXT NOT NULL, `anchorJSON` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`noteId`), FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "noteId",
+            "columnName": "noteId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookKey",
+            "columnName": "bookKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileKey",
+            "columnName": "profileKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locatorJSON",
+            "columnName": "locatorJSON",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "anchorJSON",
+            "columnName": "anchorJSON",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "noteId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotation_notes_bookKey",
+            "unique": false,
+            "columnNames": [
+              "bookKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotation_notes_bookKey` ON `${TABLE_NAME}` (`bookKey`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookKey"
+            ],
+            "referencedColumns": [
+              "fingerprintKey"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookmarkId` TEXT NOT NULL, `bookKey` TEXT NOT NULL, `profileKey` TEXT NOT NULL, `title` TEXT, `locatorJSON` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`bookmarkId`), FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookmarkId",
+            "columnName": "bookmarkId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookKey",
+            "columnName": "bookKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileKey",
+            "columnName": "profileKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "locatorJSON",
+            "columnName": "locatorJSON",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookmarkId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bookmarks_bookKey",
+            "unique": false,
+            "columnNames": [
+              "bookKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bookmarks_bookKey` ON `${TABLE_NAME}` (`bookKey`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookKey"
+            ],
+            "referencedColumns": [
+              "fingerprintKey"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `nameKey` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameKey",
+            "columnName": "nameKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_collections_nameKey",
+            "unique": true,
+            "columnNames": [
+              "nameKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_collections_nameKey` ON `${TABLE_NAME}` (`nameKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "book_collection",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookKey` TEXT NOT NULL, `collectionId` TEXT NOT NULL, PRIMARY KEY(`bookKey`, `collectionId`), FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`collectionId`) REFERENCES `collections`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bookKey",
+            "columnName": "bookKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookKey",
+            "collectionId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_collection_collectionId",
+            "unique": false,
+            "columnNames": [
+              "collectionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_collection_collectionId` ON `${TABLE_NAME}` (`collectionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "books",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bookKey"
+            ],
+            "referencedColumns": [
+              "fingerprintKey"
+            ]
+          },
+          {
+            "table": "collections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "collectionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a2b3a4c589bcf3c141b6468f83e4cc03')"
+    ]
+  }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/data/CollectionDao.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/data/CollectionDao.kt
@@ -1,0 +1,43 @@
+// Purpose: Room DAO for library collections — feature #127 WI-1 (#110 Phase 3). WI-1 is the SKELETON
+// (insert + basic queries, enough for the migration + entity tests); the full transactional CRUD +
+// membership + count surface (CollectionRepository's seam) lands in WI-2. Mirrors the BookDao
+// convention of explicit @Query SQL; the collection create uses a strict @Insert (ABORT on conflict)
+// so the unique nameKey index rejects case-folded duplicates — NOT @Upsert, which would silently
+// UPDATE the conflicting row.
+package com.vreader.app.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface CollectionDao {
+    /** Strict insert (default ABORT on conflict) — a duplicate `nameKey` throws, so the unique index is
+     *  the SQL backstop behind the repository's transactional dedup check (WI-2). NOT `@Upsert`, which
+     *  would silently UPDATE the conflicting row instead of rejecting the duplicate. */
+    @Insert
+    suspend fun insertCollection(collection: CollectionEntity)
+
+    /** Idempotent membership add — a duplicate (bookKey, collectionId) is ignored (composite PK). */
+    @Query(
+        "INSERT OR IGNORE INTO book_collection (bookKey, collectionId) VALUES (:bookKey, :collectionId)",
+    )
+    suspend fun addMembership(bookKey: String, collectionId: String)
+
+    @Query("DELETE FROM book_collection WHERE bookKey = :bookKey AND collectionId = :collectionId")
+    suspend fun removeMembership(bookKey: String, collectionId: String)
+
+    @Query("SELECT * FROM collections ORDER BY createdAt ASC")
+    suspend fun getAllCollections(): List<CollectionEntity>
+
+    @Query("SELECT * FROM collections WHERE nameKey = :nameKey LIMIT 1")
+    suspend fun findByNameKey(nameKey: String): CollectionEntity?
+
+    @Query("SELECT * FROM collections ORDER BY createdAt ASC")
+    fun observeCollections(): Flow<List<CollectionEntity>>
+
+    /** The book fingerprintKeys in a collection (reverse lookup served by the collectionId index). */
+    @Query("SELECT bookKey FROM book_collection WHERE collectionId = :collectionId")
+    suspend fun bookKeysInCollection(collectionId: String): List<String>
+}

--- a/android/app/src/main/kotlin/com/vreader/app/data/CollectionEntities.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/data/CollectionEntities.kt
@@ -1,0 +1,55 @@
+// Purpose: Room entities for user library collections — feature #127 WI-1 (#110 Phase 3).
+// A collection is the Android mirror of the iOS `BookCollection` @Model + the shared backup contract
+// `BackupCollection { name, createdAt, bookFingerprintKeys }`. The cross-platform IDENTITY is
+// name + createdAt + membership; `id` here is an internal UUID PK (FK efficiency), NOT part of the
+// backup identity (restore merges by `nameKey`, never by id, since ids differ across devices).
+// `nameKey` = name.trim().lowercase(Locale.ROOT) — the locale-invariant case-insensitive unique key
+// (iOS rejects duplicates case-insensitively). Membership is a many-to-many to `books` by fingerprintKey.
+package com.vreader.app.data
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/** A user collection. `nameKey` is the normalized case-insensitive unique key; `id` is internal-only. */
+@Entity(
+    tableName = "collections",
+    indices = [Index(value = ["nameKey"], unique = true)],
+)
+data class CollectionEntity(
+    @PrimaryKey val id: String,   // UUID string — internal PK, NOT the backup identity (name+createdAt is)
+    val name: String,             // the display name (trimmed, ≤100 chars — enforced in the repository)
+    val nameKey: String,          // name.trim().lowercase(Locale.ROOT) — locale-invariant unique key
+    val createdAt: Long,          // epoch millis — part of the cross-platform identity
+)
+
+/**
+ * The book↔collection membership join. Composite PK `(bookKey, collectionId)` (so a book can't be in the
+ * same collection twice). Both FKs CASCADE: deleting a book OR a collection removes the membership row,
+ * never the other parent. The composite PK indexes `bookKey` first; the explicit `collectionId` index
+ * serves the reverse lookup ("books in collection X").
+ */
+@Entity(
+    tableName = "book_collection",
+    primaryKeys = ["bookKey", "collectionId"],
+    foreignKeys = [
+        ForeignKey(
+            entity = BookEntity::class,
+            parentColumns = ["fingerprintKey"],
+            childColumns = ["bookKey"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+        ForeignKey(
+            entity = CollectionEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["collectionId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("collectionId")],
+)
+data class BookCollectionCrossRef(
+    val bookKey: String,        // fingerprintKey (FK → books)
+    val collectionId: String,   // CollectionEntity.id (FK → collections)
+)

--- a/android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt
@@ -17,8 +17,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
     entities = [
         BookEntity::class, ReadingPositionEntity::class, DailyReadingEntity::class,
         HighlightEntity::class, AnnotationNoteEntity::class, BookmarkEntity::class,
+        CollectionEntity::class, BookCollectionCrossRef::class,
     ],
-    version = 4,
+    version = 5,
     exportSchema = true,
 )
 abstract class VReaderDatabase : RoomDatabase() {
@@ -26,6 +27,7 @@ abstract class VReaderDatabase : RoomDatabase() {
     abstract fun readingPositionDao(): ReadingPositionDao
     abstract fun readingStatsDao(): ReadingStatsDao
     abstract fun annotationDao(): AnnotationDao
+    abstract fun collectionDao(): CollectionDao
 
     companion object {
         private const val DB_NAME = "vreader.db"
@@ -94,8 +96,37 @@ abstract class VReaderDatabase : RoomDatabase() {
             }
         }
 
+        /** v4 → v5: feature #127 — add the additive `collections` table (unique `nameKey` index) +
+         *  the `book_collection` many-to-many join (composite PK, both FKs ON DELETE CASCADE, a
+         *  `collectionId` index for the reverse lookup). No data transform. DDL matches Room's generated
+         *  v5 schema exactly (the migration test opens the real Room DB, whose structural PRAGMA
+         *  validation catches any drift). */
+        val MIGRATION_4_5: Migration = object : Migration(4, 5) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `collections` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, " +
+                        "`nameKey` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+                )
+                db.execSQL(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS `index_collections_nameKey` ON `collections` (`nameKey`)",
+                )
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `book_collection` (`bookKey` TEXT NOT NULL, " +
+                        "`collectionId` TEXT NOT NULL, PRIMARY KEY(`bookKey`, `collectionId`), " +
+                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+                        "ON UPDATE NO ACTION ON DELETE CASCADE , " +
+                        "FOREIGN KEY(`collectionId`) REFERENCES `collections`(`id`) " +
+                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_book_collection_collectionId` " +
+                        "ON `book_collection` (`collectionId`)",
+                )
+            }
+        }
+
         /** All registered migrations, oldest first. Append future Migration(n,n+1) here. */
-        val ALL_MIGRATIONS: Array<Migration> = arrayOf(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
+        val ALL_MIGRATIONS: Array<Migration> = arrayOf(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
 
         /** The production on-disk database (app-private storage). */
         fun build(context: Context): VReaderDatabase =

--- a/android/app/src/test/kotlin/com/vreader/app/data/CollectionDaoTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/data/CollectionDaoTest.kt
@@ -1,0 +1,63 @@
+package com.vreader.app.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Feature #127 WI-1 — [CollectionDao] skeleton against an in-memory v5 Room DB (no migration). Covers
+ * the WI-1 surface: upsert, findByNameKey, observe, membership add/remove (idempotent), and the reverse
+ * lookup. The full transactional CRUD + counts + repository validation is WI-2.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CollectionDaoTest {
+    private lateinit var db: VReaderDatabase
+    private lateinit var dao: CollectionDao
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private val bookKey = "epub:${"a".repeat(64)}:2048"
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(context, VReaderDatabase::class.java)
+            .allowMainThreadQueries().build()
+        dao = db.collectionDao()
+        // a book row is required for the cross-ref FK.
+        runBlocking {
+            db.bookDao().upsert(
+                BookEntity(bookKey, "T", "epub", "a".repeat(64), 2048L, null, null, 1L, null),
+            )
+        }
+    }
+
+    @After fun tearDown() = db.close()
+
+    @Test fun insert_andFindByNameKey() = runBlocking {
+        dao.insertCollection(CollectionEntity("c1", "Fiction", "fiction", 1L))
+        assertEquals("Fiction", dao.findByNameKey("fiction")?.name)
+        assertNull("no match for a different key", dao.findByNameKey("scifi"))
+    }
+
+    @Test fun observeCollections_emitsInsertedRows() = runBlocking {
+        dao.insertCollection(CollectionEntity("c1", "Alpha", "alpha", 1L))
+        dao.insertCollection(CollectionEntity("c2", "Beta", "beta", 2L))
+        val rows = dao.observeCollections().first()
+        assertEquals(listOf("Alpha", "Beta"), rows.map { it.name }) // ordered by createdAt ASC
+    }
+
+    @Test fun membership_addIdempotent_remove_reverseLookup() = runBlocking {
+        dao.insertCollection(CollectionEntity("c1", "Fiction", "fiction", 1L))
+        dao.addMembership(bookKey, "c1")
+        dao.addMembership(bookKey, "c1") // INSERT OR IGNORE — no duplicate, no throw
+        assertEquals(listOf(bookKey), dao.bookKeysInCollection("c1"))
+        dao.removeMembership(bookKey, "c1")
+        assertEquals(emptyList<String>(), dao.bookKeysInCollection("c1"))
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/data/VReaderDatabaseMigrationTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/data/VReaderDatabaseMigrationTest.kt
@@ -196,4 +196,46 @@ class VReaderDatabaseMigrationTest {
             db.close()
         }
     }
+
+    /**
+     * Feature #127 WI-1 — the FULL migration chain 1→2→3→4→5 through [VReaderDatabase.ALL_MIGRATIONS]:
+     * a v1 file opens as v5 (Room's structural PRAGMA validation passes, so MIGRATION_4_5's DDL matches
+     * the generated v5 schema exactly), the new `collections` + `book_collection` tables work, the
+     * `book_collection` FK CASCADES when its book is deleted, and the unique `nameKey` index holds.
+     */
+    @Test
+    fun migrate1To5_throughAllMigrations_addsCollections_cascades_andEnforcesUniqueName() {
+        seedVersion1Database()
+
+        val db = Room.databaseBuilder(context, VReaderDatabase::class.java, dbName)
+            .addMigrations(*VReaderDatabase.ALL_MIGRATIONS)
+            .build()
+        try {
+            assertNotNull("book survived 1→5", runBlocking { db.bookDao().find(key) })
+            val dao = db.collectionDao()
+            runBlocking {
+                // create a collection + add the seeded book → membership works.
+                val c = CollectionEntity(id = "c1", name = "Fiction", nameKey = "fiction", createdAt = 1L)
+                dao.insertCollection(c)
+                dao.addMembership(key, "c1")
+                assertEquals("the book is in the collection", listOf(key), dao.bookKeysInCollection("c1"))
+
+                // the unique nameKey index rejects a second collection with the SAME nameKey (diff id).
+                var threw = false
+                try {
+                    dao.insertCollection(CollectionEntity(id = "c2", name = "FICTION", nameKey = "fiction", createdAt = 2L))
+                } catch (e: android.database.sqlite.SQLiteConstraintException) {
+                    threw = true
+                }
+                assertTrue("the unique nameKey index rejects a case-folded duplicate", threw)
+
+                // deleting the book CASCADES the cross-ref (FK ON DELETE CASCADE), not the collection.
+                db.bookDao().delete(key)
+                assertTrue("the membership cascaded away with the book", dao.bookKeysInCollection("c1").isEmpty())
+                assertEquals("the collection itself survives the book delete", 1, dao.getAllCollections().size)
+            }
+        } finally {
+            db.close()
+        }
+    }
 }

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.13.1
-versionCode=74
+versionName=0.13.2
+versionCode=75


### PR DESCRIPTION
## Summary

WI-1 (foundational) of feature #127 (Android library collections) — the Room schema + migration.

- `CollectionEntity` (UUID `id` PK, `name`, `nameKey` = `name.trim().lowercase(Locale.ROOT)` unique-indexed, `createdAt`) + `BookCollectionCrossRef` (composite PK `(bookKey, collectionId)`, both FK `ON DELETE CASCADE`, `collectionId` index).
- `MIGRATION_4_5` (additive, no data transform) — DDL verified **byte-for-byte** against the generated `5.json`; `@Database(version=5)`; `ALL_MIGRATIONS` += `MIGRATION_4_5`; `collectionDao()`.
- `CollectionDao` skeleton — strict `@Insert` (so the unique `nameKey` index rejects case-folded duplicates, the SQL backstop behind WI-2's transactional dedup), `INSERT OR IGNORE` membership, observe/find/reverse-lookup.

## Validation

- `VReaderDatabaseMigrationTest` — 4/4 (the new v1→v5 chain: Room structural validation + unique-`nameKey` rejection + FK cascade on book delete).
- `CollectionDaoTest` — 3/3 (insert/find, ordered observe, idempotent membership).

## Codex audit

Gate-4 thread `019f12a7`, ship-as-is — **no Critical/High/Medium**; 1 Low (doc/test-name drift) fixed. Auditor confirmed the FK/index design + the migration DDL match.

Audit log: `.claude/codex-audits/feat-feature-127-wi-1-collections-schema-audit.md`

Part of feature #1869. Foundational WI (JVM/Robolectric — no device verification). Version: `android/v0.13.2`.