### PR TITLE
feat(#127 WI-2): CollectionDao + CollectionRepository

### DIFF
--- a/.claude/codex-audits/feat-feature-127-wi-2-collection-repository-audit.md
+++ b/.claude/codex-audits/feat-feature-127-wi-2-collection-repository-audit.md
@@ -1,0 +1,40 @@
+---
+branch: feat/feature-127-wi-2-collection-repository
+threadId: 019f12ae-bb16-7253-aefd-3312d6c6167d
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-29
+---
+
+# Gate-4 audit — feature #127 WI-2 (CollectionDao full + CollectionRepository)
+
+Independent Codex audit (gpt-5.5, high reasoning, read-only sandbox) of WI-2: the full
+`CollectionDao` (interface → abstract class so `@Transaction` create/rename dedup can call
+the abstract queries) + `CollectionRepository` (the DTO boundary) wired into `AppContainer`.
+
+## Findings — 2 Medium, both fixed; no Critical/High
+
+| file | severity | issue | resolution |
+|---|---|---|---|
+| `CollectionDao.renameIfAbsent` | Medium | Reported `Duplicate` before proving the target `id` exists — `rename("ghost", "Beta")` returned `DuplicateName` when "Beta" existed, though a gone id should be `NotFound`. | **Fixed.** Added `existsById(id)` and check it FIRST inside the `@Transaction`, then the duplicate-ownership check, then update. Added a `rename("ghost", existingName) → NotFound` test. |
+| `CollectionRepository.normalize` | Medium | Truncated by Kotlin UTF-16 code units, not iOS `String.prefix(100)` (extended grapheme cluster) semantics — a 101-emoji name would store 50 surrogate halves on Android vs 100 emoji on iOS, breaking parity + the backup name identity. | **Fixed.** Truncate to 100 **grapheme clusters** via `BreakIterator.getCharacterInstance()` (matches Swift `Character`). Added a 150-emoji test asserting 100 code points kept. `nameKey` is derived from the truncated stored name. |
+
+## Auditor confirmations (clean)
+
+- The `@Transaction` shape is correct: non-abstract `open suspend fun` on an abstract `@Dao` runs in a
+  DB transaction (Room docs), and Room serializes transactions — so `createIfAbsent`/`renameIfAbsent`
+  are atomic check-then-write (the unique `nameKey` index is the additional SQL backstop).
+- The `LEFT JOIN COUNT(bc.bookKey) GROUP BY c.id` maps cleanly to `CollectionWithCount`, 0 for empty
+  collections. DTO boundary respected (no entity leak). `AppContainer` lazy-singleton wiring matches the
+  `annotationsRepository` precedent. Flow types + FK cascade sound.
+
+## Test evidence
+
+- `CollectionRepositoryTest` — 11/11 (create, empty/whitespace→EmptyName, dedup case/whitespace/locale-
+  invariant/CJK→DuplicateName, truncate-100 ASCII + **grapheme/emoji**, rename success/duplicate/**gone-id
+  NotFound**, membership+count incl. empty=0, FK cascade, idempotent delete).
+- `CollectionDaoTest` — 3/3.
+
+## Verdict
+
+ship-as-is. WI-2 is foundational; WI-3 wires `LibraryViewModel` collections state + the shelf-bar.

--- a/android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt
@@ -48,6 +48,11 @@ class AppContainer(context: Context) {
         AnnotationsRepository(database.annotationDao())
     }
 
+    // feature #127 — library collections. Process-singleton (the annotationsRepository precedent).
+    val collectionRepository: com.vreader.app.data.CollectionRepository by lazy {
+        com.vreader.app.data.CollectionRepository(database.collectionDao())
+    }
+
     /** Process-lifetime scope for fire-and-forget writes that must outlive a screen
      *  (e.g. the reader's onStop position flush — it must finish even as the activity
      *  is being torn down). */

--- a/android/app/src/main/kotlin/com/vreader/app/data/CollectionDao.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/data/CollectionDao.kt
@@ -1,43 +1,92 @@
-// Purpose: Room DAO for library collections — feature #127 WI-1 (#110 Phase 3). WI-1 is the SKELETON
-// (insert + basic queries, enough for the migration + entity tests); the full transactional CRUD +
-// membership + count surface (CollectionRepository's seam) lands in WI-2. Mirrors the BookDao
-// convention of explicit @Query SQL; the collection create uses a strict @Insert (ABORT on conflict)
-// so the unique nameKey index rejects case-folded duplicates — NOT @Upsert, which would silently
-// UPDATE the conflicting row.
+// Purpose: Room DAO for library collections — feature #127 WI-2 (#110 Phase 3). The full transactional
+// CRUD + membership + count surface behind CollectionRepository (rule 50 §2). An `abstract class` (not
+// an interface) so the create/rename dedup can run as a @Transaction method calling the abstract
+// queries (the AnnotationDao precedent). The create uses a strict @Insert so the unique nameKey index
+// is the SQL backstop; the @Transaction check-then-insert is the primary dedup.
 package com.vreader.app.data
 
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
 
+/** A collection + its membership count (the LEFT-JOIN projection for the shelf-bar). */
+data class CollectionWithCount(val id: String, val name: String, val createdAt: Long, val bookCount: Int)
+
+/** Outcome of the transactional rename (so the repository maps it to a typed result). */
+enum class RenameOutcome { Ok, Duplicate, NotFound }
+
 @Dao
-interface CollectionDao {
-    /** Strict insert (default ABORT on conflict) — a duplicate `nameKey` throws, so the unique index is
-     *  the SQL backstop behind the repository's transactional dedup check (WI-2). NOT `@Upsert`, which
-     *  would silently UPDATE the conflicting row instead of rejecting the duplicate. */
+abstract class CollectionDao {
+
     @Insert
-    suspend fun insertCollection(collection: CollectionEntity)
+    abstract suspend fun insertCollection(collection: CollectionEntity)
 
-    /** Idempotent membership add — a duplicate (bookKey, collectionId) is ignored (composite PK). */
-    @Query(
-        "INSERT OR IGNORE INTO book_collection (bookKey, collectionId) VALUES (:bookKey, :collectionId)",
-    )
-    suspend fun addMembership(bookKey: String, collectionId: String)
+    @Query("UPDATE collections SET name = :name, nameKey = :nameKey WHERE id = :id")
+    abstract suspend fun updateName(id: String, name: String, nameKey: String): Int
 
-    @Query("DELETE FROM book_collection WHERE bookKey = :bookKey AND collectionId = :collectionId")
-    suspend fun removeMembership(bookKey: String, collectionId: String)
-
-    @Query("SELECT * FROM collections ORDER BY createdAt ASC")
-    suspend fun getAllCollections(): List<CollectionEntity>
+    @Query("DELETE FROM collections WHERE id = :id")
+    abstract suspend fun deleteCollection(id: String): Int
 
     @Query("SELECT * FROM collections WHERE nameKey = :nameKey LIMIT 1")
-    suspend fun findByNameKey(nameKey: String): CollectionEntity?
+    abstract suspend fun findByNameKey(nameKey: String): CollectionEntity?
+
+    @Query("SELECT EXISTS(SELECT 1 FROM collections WHERE id = :id)")
+    abstract suspend fun existsById(id: String): Boolean
 
     @Query("SELECT * FROM collections ORDER BY createdAt ASC")
-    fun observeCollections(): Flow<List<CollectionEntity>>
+    abstract suspend fun getAllCollections(): List<CollectionEntity>
 
-    /** The book fingerprintKeys in a collection (reverse lookup served by the collectionId index). */
+    @Query("SELECT * FROM collections ORDER BY createdAt ASC")
+    abstract fun observeCollections(): Flow<List<CollectionEntity>>
+
+    /** Each collection + its book count (empty collections show 0 via the LEFT JOIN), oldest first. */
+    @Query(
+        "SELECT c.id AS id, c.name AS name, c.createdAt AS createdAt, COUNT(bc.bookKey) AS bookCount " +
+            "FROM collections c LEFT JOIN book_collection bc ON bc.collectionId = c.id " +
+            "GROUP BY c.id ORDER BY c.createdAt ASC",
+    )
+    abstract fun observeCollectionsWithCount(): Flow<List<CollectionWithCount>>
+
+    // --- membership ---
+
+    /** Idempotent membership add — a duplicate (bookKey, collectionId) is ignored (composite PK). */
+    @Query("INSERT OR IGNORE INTO book_collection (bookKey, collectionId) VALUES (:bookKey, :collectionId)")
+    abstract suspend fun addMembership(bookKey: String, collectionId: String)
+
+    @Query("DELETE FROM book_collection WHERE bookKey = :bookKey AND collectionId = :collectionId")
+    abstract suspend fun removeMembership(bookKey: String, collectionId: String)
+
     @Query("SELECT bookKey FROM book_collection WHERE collectionId = :collectionId")
-    suspend fun bookKeysInCollection(collectionId: String): List<String>
+    abstract suspend fun bookKeysInCollection(collectionId: String): List<String>
+
+    /** The book fingerprintKeys in a collection (reverse lookup, served by the collectionId index). */
+    @Query("SELECT bookKey FROM book_collection WHERE collectionId = :collectionId")
+    abstract fun observeBooksInCollection(collectionId: String): Flow<List<String>>
+
+    @Query("SELECT collectionId FROM book_collection WHERE bookKey = :bookKey")
+    abstract fun observeCollectionIdsForBook(bookKey: String): Flow<List<String>>
+
+    // --- transactional dedup (check-then-write atomically) ---
+
+    /** Atomic create-if-absent: inserts only when [nameKey] is free. Returns false on a duplicate. */
+    @Transaction
+    open suspend fun createIfAbsent(collection: CollectionEntity): Boolean {
+        if (findByNameKey(collection.nameKey) != null) return false
+        insertCollection(collection)
+        return true
+    }
+
+    /** Atomic rename: NotFound if [id] is gone (checked FIRST), else Duplicate if the name is taken by
+     *  ANOTHER collection, else update. The order matters — a gone id must report NotFound even when the
+     *  target name exists elsewhere (Gate-4 WI-2 Medium). */
+    @Transaction
+    open suspend fun renameIfAbsent(id: String, name: String, nameKey: String): RenameOutcome {
+        if (!existsById(id)) return RenameOutcome.NotFound
+        val existing = findByNameKey(nameKey)
+        if (existing != null && existing.id != id) return RenameOutcome.Duplicate
+        updateName(id, name, nameKey)
+        return RenameOutcome.Ok
+    }
 }

--- a/android/app/src/main/kotlin/com/vreader/app/data/CollectionRepository.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/data/CollectionRepository.kt
@@ -1,0 +1,99 @@
+// Purpose: feature #127 WI-2 — the collection repository (the DTO boundary over CollectionDao;
+// rule 50 §2). Process-singleton in AppContainer (the #122/#123 repository precedent). Owns the name
+// normalization (trim → reject empty → truncate to 100 chars, iOS parity: iOS truncates, no length
+// error) + the locale-invariant case-insensitive uniqueness (`nameKey` = name.lowercase(Locale.ROOT)),
+// delegating the atomic check-then-write to the DAO's @Transaction methods. The cross-platform IDENTITY
+// is name + createdAt (the `BackupCollection` contract); `id` is an internal UUID.
+package com.vreader.app.data
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.text.BreakIterator
+import java.util.Locale
+import java.util.UUID
+
+/** A collection as the library renders it (the design's shelf chip + its book count). */
+data class Collection(val id: String, val name: String, val createdAt: Long, val bookCount: Int)
+
+/** Why a collection create/rename was rejected (mirrors iOS `CollectionError`). */
+enum class CollectionError { EmptyName, DuplicateName, NotFound }
+
+/** The failure carried by a rejected [CollectionRepository] op's [Result]. */
+class CollectionException(val error: CollectionError) : Exception(error.name)
+
+class CollectionRepository(
+    private val dao: CollectionDao,
+    private val now: () -> Long = { System.currentTimeMillis() },
+    private val newId: () -> String = { UUID.randomUUID().toString() },
+) {
+    fun observeCollections(): Flow<List<Collection>> =
+        dao.observeCollectionsWithCount().map { rows ->
+            rows.map { Collection(it.id, it.name, it.createdAt, it.bookCount) }
+        }
+
+    fun observeBookKeysInCollection(collectionId: String): Flow<List<String>> =
+        dao.observeBooksInCollection(collectionId)
+
+    fun observeCollectionIdsForBook(bookKey: String): Flow<List<String>> =
+        dao.observeCollectionIdsForBook(bookKey)
+
+    /** Create a collection; rejects empty / duplicate (case-insensitive) names; truncates to 100 chars. */
+    suspend fun createCollection(rawName: String): Result<Collection> {
+        val name = normalize(rawName) ?: return fail(CollectionError.EmptyName)
+        val entity = CollectionEntity(id = newId(), name = name, nameKey = nameKey(name), createdAt = now())
+        return if (dao.createIfAbsent(entity)) {
+            Result.success(Collection(entity.id, entity.name, entity.createdAt, bookCount = 0))
+        } else {
+            fail(CollectionError.DuplicateName)
+        }
+    }
+
+    /** Rename a collection; rejects empty / a name taken by ANOTHER collection; NotFound if gone. */
+    suspend fun rename(id: String, rawName: String): Result<Unit> {
+        val name = normalize(rawName) ?: return fail(CollectionError.EmptyName)
+        return when (dao.renameIfAbsent(id, name, nameKey(name))) {
+            RenameOutcome.Ok -> Result.success(Unit)
+            RenameOutcome.Duplicate -> fail(CollectionError.DuplicateName)
+            RenameOutcome.NotFound -> fail(CollectionError.NotFound)
+        }
+    }
+
+    /** Delete a collection (idempotent — deleting a gone collection is a no-op; FK CASCADEs the join). */
+    suspend fun delete(id: String) { dao.deleteCollection(id) }
+
+    suspend fun assign(bookKey: String, collectionId: String) = dao.addMembership(bookKey, collectionId)
+    suspend fun unassign(bookKey: String, collectionId: String) = dao.removeMembership(bookKey, collectionId)
+
+    /** Trim → null if empty (→ EmptyName) → truncate to [MAX_NAME] GRAPHEME CLUSTERS (iOS `prefix(100)`
+     *  counts Swift `Character`s = extended grapheme clusters, so a 101-emoji name keeps 100 emoji, not
+     *  50 UTF-16-code-unit halves — Gate-4 WI-2 Medium). */
+    private fun normalize(raw: String): String? {
+        val trimmed = raw.trim()
+        if (trimmed.isEmpty()) return null
+        return truncateToGraphemes(trimmed, MAX_NAME)
+    }
+
+    /** The first [max] grapheme clusters of [s] (the whole string if it has fewer). */
+    private fun truncateToGraphemes(s: String, max: Int): String {
+        val bi = BreakIterator.getCharacterInstance()
+        bi.setText(s)
+        var boundary = bi.first()
+        var count = 0
+        while (count < max) {
+            val next = bi.next()
+            if (next == BreakIterator.DONE) return s   // fewer than [max] graphemes — nothing to cut
+            boundary = next
+            count++
+        }
+        return s.substring(0, boundary)
+    }
+
+    /** Locale-invariant lowercasing — Turkish-I / CJK normalize consistently across devices. */
+    private fun nameKey(name: String): String = name.lowercase(Locale.ROOT)
+
+    private fun <T> fail(error: CollectionError): Result<T> = Result.failure(CollectionException(error))
+
+    companion object {
+        const val MAX_NAME = 100
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/data/CollectionRepositoryTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/data/CollectionRepositoryTest.kt
@@ -1,0 +1,121 @@
+package com.vreader.app.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Feature #127 WI-2 — [CollectionRepository] over an in-memory v5 Room DB. Covers the transactional
+ * create/rename dedup (case-insensitive via `nameKey`, locale-invariant), trim/empty/truncate-100
+ * (iOS parity), membership, cascade, and the LEFT-JOIN count (empty collection = 0).
+ */
+@RunWith(RobolectricTestRunner::class)
+class CollectionRepositoryTest {
+    private lateinit var db: VReaderDatabase
+    private lateinit var repo: CollectionRepository
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private val bookKey = "epub:${"a".repeat(64)}:2048"
+    private var seq = 0
+
+    @Before fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(context, VReaderDatabase::class.java).allowMainThreadQueries().build()
+        // deterministic ids + clock so assertions are stable.
+        repo = CollectionRepository(db.collectionDao(), now = { 100L }, newId = { "id-${seq++}" })
+        runBlocking { db.bookDao().upsert(BookEntity(bookKey, "T", "epub", "a".repeat(64), 2048L, null, null, 1L, null)) }
+    }
+
+    @After fun tearDown() = db.close()
+
+    private fun err(r: Result<*>) = (r.exceptionOrNull() as CollectionException).error
+
+    @Test fun create_succeeds_andCountsZero() = runBlocking {
+        val c = repo.createCollection("Fiction").getOrThrow()
+        assertEquals("Fiction", c.name)
+        assertEquals(0, c.bookCount)
+        assertEquals(listOf("Fiction"), repo.observeCollections().first().map { it.name })
+    }
+
+    @Test fun create_rejectsEmptyAndWhitespace() = runBlocking {
+        assertEquals(CollectionError.EmptyName, err(repo.createCollection("")))
+        assertEquals(CollectionError.EmptyName, err(repo.createCollection("   ")))
+    }
+
+    @Test fun create_dedupesCaseInsensitively_acrossWhitespaceAndCase() = runBlocking {
+        repo.createCollection("Fiction").getOrThrow()
+        assertEquals(CollectionError.DuplicateName, err(repo.createCollection("  fiction  ")))
+        assertEquals(CollectionError.DuplicateName, err(repo.createCollection("FICTION")))
+        assertEquals("only one row exists", 1, repo.observeCollections().first().size)
+    }
+
+    @Test fun create_caseInsensitive_isLocaleInvariant() = runBlocking {
+        // "INDEX".lowercase(Locale.ROOT) == "index" (NOT the Turkish dotless-ı) → these collide.
+        repo.createCollection("INDEX").getOrThrow()
+        assertEquals(CollectionError.DuplicateName, err(repo.createCollection("index")))
+    }
+
+    @Test fun create_dedupesCJK_afterTrim() = runBlocking {
+        repo.createCollection("小说").getOrThrow()
+        assertEquals(CollectionError.DuplicateName, err(repo.createCollection("  小说 ")))
+    }
+
+    @Test fun create_truncatesTo100Chars_notAnError() = runBlocking {
+        val c = repo.createCollection("x".repeat(150)).getOrThrow()
+        assertEquals(100, c.name.length)
+    }
+
+    @Test fun create_truncatesByGrapheme_notUtf16CodeUnits() = runBlocking {
+        // "😀" = 1 grapheme / 1 code point / 2 UTF-16 units. iOS prefix(100) keeps 100 emoji; a naive
+        // UTF-16 substring(0,100) would keep only 50. Assert we kept 100 code points (Gate-4 WI-2 fix).
+        val c = repo.createCollection("😀".repeat(150)).getOrThrow()
+        assertEquals(100, c.name.codePointCount(0, c.name.length))
+    }
+
+    @Test fun rename_succeeds_rejectsDuplicate_andNotFound() = runBlocking {
+        val a = repo.createCollection("Alpha").getOrThrow()
+        repo.createCollection("Beta").getOrThrow()
+        assertTrue(repo.rename(a.id, "Apex").isSuccess)                       // free name
+        assertEquals(CollectionError.DuplicateName, err(repo.rename(a.id, "beta"))) // taken by another
+        assertTrue("renaming to its own (case-folded) name is allowed", repo.rename(a.id, "APEX").isSuccess)
+        assertEquals(CollectionError.NotFound, err(repo.rename("ghost", "Zeta")))
+        // a GONE id reports NotFound even when the target name EXISTS elsewhere (Gate-4 WI-2 fix — the
+        // id-existence check runs BEFORE the duplicate check).
+        assertEquals(CollectionError.NotFound, err(repo.rename("ghost", "Beta")))
+    }
+
+    @Test fun membership_assign_unassign_and_countReflectsIt() = runBlocking {
+        val fic = repo.createCollection("Fiction").getOrThrow()
+        repo.createCollection("Empty").getOrThrow()
+        repo.assign(bookKey, fic.id)
+        repo.assign(bookKey, fic.id) // idempotent
+        val counts = repo.observeCollections().first().associate { it.name to it.bookCount }
+        assertEquals(1, counts["Fiction"])
+        assertEquals("empty collection counts 0 via the LEFT JOIN", 0, counts["Empty"])
+        repo.unassign(bookKey, fic.id)
+        assertEquals(0, repo.observeCollections().first().first { it.name == "Fiction" }.bookCount)
+    }
+
+    @Test fun deletingBook_cascadesMembership_keepsCollection() = runBlocking {
+        val fic = repo.createCollection("Fiction").getOrThrow()
+        repo.assign(bookKey, fic.id)
+        db.bookDao().delete(bookKey)
+        assertTrue(repo.observeBookKeysInCollection(fic.id).first().isEmpty())
+        assertEquals("the collection survives", 1, repo.observeCollections().first().size)
+    }
+
+    @Test fun delete_isIdempotent() = runBlocking {
+        val c = repo.createCollection("Temp").getOrThrow()
+        repo.delete(c.id)
+        repo.delete(c.id) // no throw on a gone collection
+        assertFalse(repo.observeCollections().first().any { it.id == c.id })
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.13.2
-versionCode=75
+versionName=0.13.3
+versionCode=76


### PR DESCRIPTION
## Summary

WI-2 (foundational) — the full collection DAO + repository over WI-1's schema.

- `CollectionDao` → **abstract class** so `@Transaction createIfAbsent`/`renameIfAbsent` can run the check-then-write dedup atomically (the `AnnotationDao` precedent); full membership + `observeCollectionsWithCount` (LEFT JOIN, empty collection = 0).
- `CollectionRepository` (DTO boundary): `createCollection`/`rename`/`delete` with trim → `EmptyName` → **grapheme-truncate to 100** (iOS `prefix(100)` parity) → case-insensitive `nameKey` (`Locale.ROOT`) dedup → `DuplicateName`; `assign`/`unassign`; `observe*`; `CollectionError`. Wired into `AppContainer` (lazy singleton).

## Codex audit

Gate-4 thread `019f12ae`, ship-as-is — no Critical/High; **2 Medium fixed**: (1) `rename` checks id-existence BEFORE the duplicate check (a gone id + an existing target name → `NotFound`, not `DuplicateName`); (2) truncation is by **grapheme cluster** not UTF-16 code units (a 101-emoji name keeps 100 emoji, matching iOS + the backup name identity). Auditor confirmed the `@Transaction` atomicity + the LEFT-JOIN count.

Audit log: `.claude/codex-audits/feat-feature-127-wi-2-collection-repository-audit.md`

## Validation

`CollectionRepositoryTest` 11/11 (dedup case/whitespace/locale/CJK, truncate ASCII+emoji, rename incl. gone-id NotFound, count, cascade, idempotent delete) + `CollectionDaoTest` 3/3.

Part of feature #1869. Foundational (JVM/Robolectric). Version: `android/v0.13.3`.