### PR TITLE
feat(#127 WI-3): collections shelf-bar + VM membership filter

### DIFF
--- a/.claude/codex-audits/feat-feature-127-wi-3-shelf-bar-audit.md
+++ b/.claude/codex-audits/feat-feature-127-wi-3-shelf-bar-audit.md
@@ -1,0 +1,43 @@
+---
+branch: feat/feature-127-wi-3-shelf-bar
+threadId: 019f12bf-cf6f-7b41-82d5-ad9ca4be9f55
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-29
+---
+
+# Gate-4 audit — feature #127 WI-3 (collections shelf-bar + VM membership filter)
+
+Independent Codex audit (gpt-5.5, high reasoning, read-only sandbox) of WI-3: the
+`CollectionShelfBar` Compose chip row + the `LibraryViewModel` `flatMapLatest`
+membership filter (over the WI-1/WI-2 data layer).
+
+## Findings — 2 Medium, both fixed; no Critical/High
+
+| file | severity | issue | resolution |
+|---|---|---|---|
+| `LibraryScreen.kt` | Medium | A selected collection with no members fell into the global `EmptyState` ("No books yet / Tap + to import") — misleading (the library HAS books) and import wouldn't add to the collection. No committed design for a collection-filter-empty state exists. | **Fixed (rule-51-safe).** The import `EmptyState` now shows ONLY for a truly-empty library (`selectedCollectionId == null`); a filtered-empty collection renders nothing rather than inventing an empty-collection surface. The user returns via the "All" chip. |
+| `LibraryViewModel.kt` | Medium | Collection error surfacing was incomplete — `delete`/`assign`/`unassign` launched raw repo calls, so a thrown FK-race exception (assign to a just-deleted collection) would crash instead of emitting `CollectionOpFailed`. | **Fixed.** All five collection mutations route through one `runCollectionOp` try/catch boundary that surfaces both a `Result` failure AND a thrown exception as `LibraryEvent.CollectionOpFailed` (CancellationException re-thrown). |
+
+## Auditor confirmations (clean)
+
+- **Rule 51 fidelity:** `CollectionShelfBar` matches the committed `CollectionBar` — 8dp gap, 18dp
+  horizontal padding, 13.5sp sans, active = ink bg + page-bg text + bold, inactive = ~5% ink tint,
+  radius 100. Omitting the manage/reorder affordance is correct for this slice (WI-4/WI-5 own those
+  surfaces; a half-built manage button would be worse under the design gate).
+- `flatMapLatest` cancels the previous membership flow (no stale leak); the reset-to-All guard's
+  lifetime `collections.collect` is safe and cancels with the VM; the initial-`emptyList` reset race
+  isn't reachable (a user only taps chips after real collections render). Selection survives rotation
+  via VM state. MainActivity wiring + exhaustive event handling correct.
+
+## Test evidence
+
+- `LibraryViewModelCollectionsTest` — 3/3 (chip filters to members; "All" resets; delete-selected resets
+  to All; `flatMapLatest` no-leak on selection switch).
+- `LibraryViewModelTest` — regression green (constructor change absorbed).
+- `CollectionShelfBarUiTest` — 3 connected (render "All" + chips; tap → reports id / null; active chip
+  carries `selected` semantics). Simple clicks on a directly-rendered composable (no Activity/gesture).
+
+## Verdict
+
+ship-as-is. WI-3 is behavioral; WI-4 (assign sheet) + WI-5 (manage sheet) add the create/assign surfaces.

--- a/android/app/src/androidTest/kotlin/com/vreader/app/library/CollectionShelfBarUiTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/library/CollectionShelfBarUiTest.kt
@@ -1,0 +1,53 @@
+package com.vreader.app.library
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.vreader.app.data.Collection
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Feature #127 WI-3 — the [CollectionShelfBar] renders "All" + each collection chip, tapping a chip
+ * reports its id (null for "All"), and the active chip carries the `selected` semantics (the designed
+ * ink-filled state). Renders the composable directly (clicks + semantics, no Activity/gesture flakiness).
+ */
+@RunWith(AndroidJUnit4::class)
+class CollectionShelfBarUiTest {
+    @get:Rule val compose = createComposeRule()
+
+    private val cols = listOf(
+        Collection(id = "c1", name = "Fiction", createdAt = 1L, bookCount = 3),
+        Collection(id = "c2", name = "Tech", createdAt = 2L, bookCount = 1),
+    )
+
+    @Test fun rendersAll_andEachChip() {
+        compose.setContent { CollectionShelfBar(cols, selectedId = null, onSelect = {}) }
+        compose.onNodeWithText("All").assertIsDisplayed()
+        compose.onNodeWithText("Fiction").assertIsDisplayed()
+        compose.onNodeWithText("Tech").assertIsDisplayed()
+    }
+
+    @Test fun tappingChip_reportsItsId_andAllReportsNull() {
+        var selected: String? = "unset"
+        compose.setContent { CollectionShelfBar(cols, selectedId = null, onSelect = { selected = it }) }
+        compose.onNodeWithText("Fiction").performClick()
+        assertEquals("c1", selected)
+        compose.onNodeWithText("All").performClick()
+        assertNull(selected)
+    }
+
+    @Test fun activeChip_hasSelectedSemantics() {
+        compose.setContent { CollectionShelfBar(cols, selectedId = "c2", onSelect = {}) }
+        compose.onNodeWithText("Tech").assertIsSelected()
+        compose.onNodeWithText("Fiction").assertIsNotSelected()
+        compose.onNodeWithText("All").assertIsNotSelected()
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/MainActivity.kt
@@ -35,13 +35,15 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         val container = (application as VReaderApp).container
         val factory = viewModelFactory {
-            initializer { LibraryViewModel(container.repository, container.importer, contentResolver) }
+            initializer { LibraryViewModel(container.repository, container.importer, container.collectionRepository, contentResolver) }
         }
 
         setContent {
             VReaderTheme {
                 val viewModel: LibraryViewModel = viewModel(factory = factory)
                 val state by viewModel.uiState.collectAsStateWithLifecycle()
+                val collections by viewModel.collections.collectAsStateWithLifecycle()
+                val selectedCollectionId by viewModel.selectedCollectionId.collectAsStateWithLifecycle()
 
                 val picker = rememberLauncherForActivityResult(
                     ActivityResultContracts.OpenDocument(),
@@ -49,14 +51,19 @@ class MainActivity : ComponentActivity() {
 
                 LaunchedEffect(Unit) {
                     viewModel.events.collect { event ->
-                        if (event is LibraryEvent.ImportFailed) {
-                            Toast.makeText(this@MainActivity, event.message, Toast.LENGTH_SHORT).show()
+                        val message = when (event) {
+                            is LibraryEvent.ImportFailed -> event.message
+                            is LibraryEvent.CollectionOpFailed -> event.message
                         }
+                        Toast.makeText(this@MainActivity, message, Toast.LENGTH_SHORT).show()
                     }
                 }
 
                 LibraryScreen(
                     state = state,
+                    collections = collections,
+                    selectedCollectionId = selectedCollectionId,
+                    onSelectCollection = viewModel::selectCollection,
                     onOpenBook = { book ->
                         // Route by the typed format (exhaustive — never open a format into
                         // the wrong host). Formats without a reader yet are surfaced, not

--- a/android/app/src/main/kotlin/com/vreader/app/library/CollectionShelfBar.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/library/CollectionShelfBar.kt
@@ -1,0 +1,68 @@
+// Purpose: the collections shelf-bar over the library grid — feature #127 WI-3 (#110 Phase 3).
+// A Compose recreation of the committed design `vreader-library-android.jsx` CollectionBar: a
+// horizontal scrolling chip row of "All" + each user collection; the active chip is ink-filled
+// with the page-bg text + bold, inactive chips are a faint ink tint. Tapping a chip selects it
+// (null = "All"); selection filters the grid (the LibraryViewModel membership filter). Pure function
+// of (collections, selectedId) + an onSelect callback (rule 50 §4). Shown only when ≥1 collection
+// exists; the manage/assign sheets (the create/rename entry points) are WI-4/WI-5.
+package com.vreader.app.library
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.vreader.app.data.Collection
+import com.vreader.app.ui.theme.VReaderColors
+import com.vreader.app.ui.theme.VReaderFonts
+
+/** A null id is the "All" chip (no collection filter). */
+@Composable
+fun CollectionShelfBar(
+    collections: List<Collection>,
+    selectedId: String?,
+    onSelect: (String?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier.testTag("collection-shelf-bar"),
+        contentPadding = PaddingValues(start = 18.dp, end = 18.dp),
+        horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp),
+    ) {
+        item(key = "all") { CollectionChip(label = "All", selected = selectedId == null) { onSelect(null) } }
+        items(collections, key = { it.id }) { c ->
+            CollectionChip(label = c.name, selected = selectedId == c.id) { onSelect(c.id) }
+        }
+    }
+}
+
+@Composable
+private fun CollectionChip(label: String, selected: Boolean, onClick: () -> Unit) {
+    Text(
+        text = label,
+        color = if (selected) VReaderColors.Background else VReaderColors.Ink,
+        fontFamily = VReaderFonts.Sans,
+        fontSize = 13.5.sp,
+        fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium,
+        maxLines = 1,
+        modifier = Modifier
+            .testTag("collection-chip-$label")
+            .clip(RoundedCornerShape(100))
+            .background(if (selected) VReaderColors.Ink else VReaderColors.Ink.copy(alpha = 0.05f))
+            .clickable(onClick = onClick)
+            .semantics { this.selected = selected }
+            .padding(horizontal = 15.dp, vertical = 8.dp),
+    )
+}

--- a/android/app/src/main/kotlin/com/vreader/app/library/LibraryScreen.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/library/LibraryScreen.kt
@@ -55,6 +55,10 @@ fun LibraryScreen(
     state: LibraryUiState,
     onOpenBook: (LibraryBook) -> Unit,
     onImport: () -> Unit,
+    // feature #127 — collections shelf-bar (empty list = no bar; "All" = null selection).
+    collections: List<com.vreader.app.data.Collection> = emptyList(),
+    selectedCollectionId: String? = null,
+    onSelectCollection: (String?) -> Unit = {},
 ) {
     // Boolean (not the enum) so rememberSaveable persists the mode across rotation /
     // process recreation without a custom Saver.
@@ -97,9 +101,25 @@ fun LibraryScreen(
             fontSize = 13.sp,
         )
 
+        // feature #127 — the collections shelf-bar (shown once the user has a collection; the
+        // create/assign entry points are the WI-4/WI-5 sheets). Tapping a chip filters the grid.
+        if (collections.isNotEmpty()) {
+            CollectionShelfBar(
+                collections = collections,
+                selectedId = selectedCollectionId,
+                onSelect = onSelectCollection,
+                modifier = Modifier.padding(bottom = 12.dp),
+            )
+        }
+
         when {
             state.loading -> Unit
-            state.books.isEmpty() -> EmptyState(onImport)
+            // The import EmptyState is ONLY for a truly-empty LIBRARY ("All" selected) — a selected
+            // collection that happens to be empty must NOT show "Tap + to import" (misleading + import
+            // wouldn't add to the collection). No designed collection-filter-empty state exists, so per
+            // rule 51 we render nothing rather than invent one (Gate-4 WI-3 Medium).
+            state.books.isEmpty() && selectedCollectionId == null -> EmptyState(onImport)
+            state.books.isEmpty() -> Unit
             view == LibraryView.Grid -> BookGrid(state.books, onOpenBook)
             else -> BookList(state.books, onOpenBook)
         }

--- a/android/app/src/main/kotlin/com/vreader/app/library/LibraryViewModel.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/library/LibraryViewModel.kt
@@ -13,15 +13,23 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vreader.app.data.Book
 import com.vreader.app.data.BookImporter
+import com.vreader.app.data.Collection
+import com.vreader.app.data.CollectionException
+import com.vreader.app.data.CollectionRepository
 import com.vreader.app.data.ImportException
 import com.vreader.app.data.LibraryRepository
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -52,18 +60,81 @@ data class LibraryUiState(
 /** One-shot events (e.g. an import error toast) the screen consumes. */
 sealed interface LibraryEvent {
     data class ImportFailed(val message: String) : LibraryEvent
+    /** A collection create/rename/delete/assign was rejected (feature #127). */
+    data class CollectionOpFailed(val message: String) : LibraryEvent
 }
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class LibraryViewModel(
     private val repository: LibraryRepository,
     private val importer: BookImporter,
+    private val collectionRepository: CollectionRepository,
     private val resolver: ContentResolver,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModel() {
 
-    val uiState: StateFlow<LibraryUiState> = repository.observeLibrary()
+    // feature #127 — the user collections (for the shelf-bar) + the selected chip ("All" = null).
+    val collections: StateFlow<List<Collection>> = collectionRepository.observeCollections()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    private val _selectedCollectionId = MutableStateFlow<String?>(null)
+    val selectedCollectionId: StateFlow<String?> = _selectedCollectionId.asStateFlow()
+
+    // flatMapLatest so changing the selection CANCELS the previous selection's membership flow —
+    // a stale previous-selection list can never filter the new selection (Gate-2 race fix).
+    val uiState: StateFlow<LibraryUiState> = _selectedCollectionId
+        .flatMapLatest { id ->
+            if (id == null) {
+                repository.observeLibrary()
+            } else {
+                combine(repository.observeLibrary(), collectionRepository.observeBookKeysInCollection(id)) { books, keys ->
+                    val members = keys.toHashSet()
+                    books.filter { it.fingerprintKey in members }
+                }
+            }
+        }
         .map { books -> LibraryUiState(loading = false, books = books.map(::toUi)) }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), LibraryUiState(loading = true))
+
+    init {
+        // reset the selection to "All" when the selected collection is deleted/gone underneath it.
+        viewModelScope.launch {
+            collections.collect { cols ->
+                val sel = _selectedCollectionId.value
+                if (sel != null && cols.none { it.id == sel }) _selectedCollectionId.value = null
+            }
+        }
+    }
+
+    fun selectCollection(id: String?) { _selectedCollectionId.value = id }
+
+    fun createCollection(name: String) = runCollectionOp { collectionRepository.createCollection(name) }
+    fun renameCollection(id: String, name: String) = runCollectionOp { collectionRepository.rename(id, name) }
+    fun deleteCollection(id: String) = runCollectionOp { collectionRepository.delete(id); Result.success(Unit) }
+    fun assign(bookKey: String, collectionId: String) = runCollectionOp { collectionRepository.assign(bookKey, collectionId); Result.success(Unit) }
+    fun unassign(bookKey: String, collectionId: String) = runCollectionOp { collectionRepository.unassign(bookKey, collectionId); Result.success(Unit) }
+
+    /** The single failure boundary for ALL collection mutations: surfaces a returned [Result] failure
+     *  AND a THROWN exception (e.g. an FK constraint race when assigning to a just-deleted collection) as
+     *  a [LibraryEvent.CollectionOpFailed] toast (Gate-4 WI-3 Medium) — never crashes the screen. */
+    private fun runCollectionOp(op: suspend () -> Result<*>) {
+        viewModelScope.launch {
+            try {
+                op().onFailure { e -> _events.trySend(LibraryEvent.CollectionOpFailed(collectionErrorMessage(e))) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _events.trySend(LibraryEvent.CollectionOpFailed(collectionErrorMessage(e)))
+            }
+        }
+    }
+
+    private fun collectionErrorMessage(e: Throwable): String = when ((e as? CollectionException)?.error) {
+        com.vreader.app.data.CollectionError.EmptyName -> "Enter a collection name"
+        com.vreader.app.data.CollectionError.DuplicateName -> "A collection with that name already exists"
+        com.vreader.app.data.CollectionError.NotFound -> "That collection no longer exists"
+        null -> "Couldn't update the collection"
+    }
 
     // A Channel (one consumer) rather than a non-replaying SharedFlow: an import that
     // finishes during the LaunchedEffect collector gap around a config change is

--- a/android/app/src/test/kotlin/com/vreader/app/library/LibraryViewModelCollectionsTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/library/LibraryViewModelCollectionsTest.kt
@@ -1,0 +1,101 @@
+package com.vreader.app.library
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.vreader.app.data.BookEntity
+import com.vreader.app.data.BookImporter
+import com.vreader.app.data.CollectionRepository
+import com.vreader.app.data.LibraryRepository
+import com.vreader.app.data.VReaderDatabase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+/**
+ * Feature #127 WI-3 — [LibraryViewModel] collections filtering. Selecting a collection chip filters the
+ * grid to that collection's members (flatMapLatest, race-free); "All" shows everything; deleting the
+ * selected collection resets the selection to "All". Robolectric + in-memory Room (the LibraryViewModelTest
+ * precedent: real-time runBlocking, Room Flow emits on its own executor).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class LibraryViewModelCollectionsTest {
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private lateinit var db: VReaderDatabase
+    private lateinit var collections: CollectionRepository
+    private lateinit var vm: LibraryViewModel
+    private val key1 = "epub:${"a".repeat(64)}:1"
+    private val key2 = "epub:${"b".repeat(64)}:2"
+
+    @Before fun setUp() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+        db = Room.inMemoryDatabaseBuilder(context, VReaderDatabase::class.java).build()
+        val repository = LibraryRepository(db.bookDao(), db.readingPositionDao())
+        collections = CollectionRepository(db.collectionDao())
+        val importer = BookImporter(File(context.cacheDir, "b-${System.nanoTime()}"), repository, Dispatchers.Unconfined)
+        runBlocking {
+            db.bookDao().upsert(BookEntity(key1, "Alpha", "epub", "a".repeat(64), 1L, null, null, 1L, null))
+            db.bookDao().upsert(BookEntity(key2, "Beta", "epub", "b".repeat(64), 2L, null, null, 2L, null))
+        }
+        vm = LibraryViewModel(repository, importer, collections, context.contentResolver, Dispatchers.Unconfined)
+    }
+
+    @After fun tearDown() { db.close(); Dispatchers.resetMain() }
+
+    /** Await a uiState whose book titles (sorted) match [expected]. */
+    private fun awaitTitles(vararg expected: String): List<String> = runBlocking {
+        val want = expected.sorted()
+        withTimeout(3_000) { vm.uiState.map { it.books.map { b -> b.title }.sorted() }.first { it == want } }
+    }
+
+    @Test fun selectingChip_filtersToMembers_andAllResets() = runBlocking {
+        val fic = collections.createCollection("Fiction").getOrThrow()
+        collections.assign(key1, fic.id)
+        // "All" shows both.
+        assertEquals(listOf("Alpha", "Beta"), awaitTitles("Alpha", "Beta"))
+        // selecting Fiction filters to its single member.
+        vm.selectCollection(fic.id)
+        assertEquals(listOf("Alpha"), awaitTitles("Alpha"))
+        // back to "All".
+        vm.selectCollection(null)
+        assertEquals(listOf("Alpha", "Beta"), awaitTitles("Alpha", "Beta"))
+    }
+
+    @Test fun deletingSelectedCollection_resetsToAll() = runBlocking {
+        val fic = collections.createCollection("Fiction").getOrThrow()
+        collections.assign(key1, fic.id)
+        vm.selectCollection(fic.id)
+        awaitTitles("Alpha")
+        // delete the selected collection → the VM resets the selection to "All" and shows everything.
+        collections.delete(fic.id)
+        withTimeout(3_000) { vm.selectedCollectionId.first { it == null } }
+        assertNull(vm.selectedCollectionId.value)
+        assertEquals(listOf("Alpha", "Beta"), awaitTitles("Alpha", "Beta"))
+    }
+
+    @Test fun switchingSelection_doesNotLeakPreviousMembership() = runBlocking {
+        val a = collections.createCollection("A").getOrThrow()
+        val b = collections.createCollection("B").getOrThrow()
+        collections.assign(key1, a.id) // A = {Alpha}
+        collections.assign(key2, b.id) // B = {Beta}
+        vm.selectCollection(a.id)
+        assertEquals("A → only Alpha", listOf("Alpha"), awaitTitles("Alpha"))
+        vm.selectCollection(b.id)
+        // flatMapLatest cancels A's flow → B shows only Beta, never the stale Alpha.
+        assertEquals("B → only Beta (no leak from A)", listOf("Beta"), awaitTitles("Beta"))
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/library/LibraryViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/library/LibraryViewModelTest.kt
@@ -6,6 +6,7 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import com.vreader.app.data.Book
 import com.vreader.app.data.BookImporter
+import com.vreader.app.data.CollectionRepository
 import com.vreader.app.data.LibraryRepository
 import com.vreader.app.data.VReaderDatabase
 import kotlinx.coroutines.Dispatchers
@@ -51,7 +52,9 @@ class LibraryViewModelTest {
         val importer = BookImporter(
             File(context.cacheDir, "books-${System.nanoTime()}"), repository, Dispatchers.Unconfined,
         )
-        viewModel = LibraryViewModel(repository, importer, context.contentResolver, Dispatchers.Unconfined)
+        viewModel = LibraryViewModel(
+            repository, importer, CollectionRepository(db.collectionDao()), context.contentResolver, Dispatchers.Unconfined,
+        )
     }
 
     @After

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.13.3
-versionCode=76
+versionName=0.13.4
+versionCode=77


### PR DESCRIPTION
## Summary

WI-3 (behavioral) — the collections shelf-bar + the library filter.

- `LibraryViewModel`: `collections` StateFlow, `selectedCollectionId` ("All" = null), and `uiState` = `selectedCollectionId.flatMapLatest { membership filter }` (switching selection cancels the previous membership flow → race-free, no stale leak); reset-to-All when the selected collection is deleted; all collection mutations through one failure boundary → `CollectionOpFailed` toast.
- `CollectionShelfBar` Compose — the committed design's `CollectionBar` chip row (active = ink-filled, inactive = faint tint), shown when ≥1 collection exists.

## Codex audit

Gate-4 thread `019f12bf`, ship-as-is — no Critical/High; **2 Medium fixed**: (1) the import `EmptyState` is gated to a truly-empty library (a filtered-empty collection renders nothing — rule-51-safe, no invented surface); (2) all collection mutations route through one try/catch boundary that surfaces thrown FK-race exceptions too. **Rule-51 chip fidelity confirmed** by the auditor.

Audit log: `.claude/codex-audits/feat-feature-127-wi-3-shelf-bar-audit.md`

## Slice verification

- `LibraryViewModelCollectionsTest` — 3/3 (chip filters to members, "All" resets, delete-selected resets, `flatMapLatest` no-leak).
- `CollectionShelfBarUiTest` — 3/3 on the emulator (render, tap→id, `selected` semantics).
- VM regression — 4/4.

Part of feature #1869. Version: `android/v0.13.4`.