### PR TITLE
feat(#127 WI-4): assign-to-collections sheet

### DIFF
--- a/.claude/codex-audits/feat-feature-127-wi-4-assign-sheet-audit.md
+++ b/.claude/codex-audits/feat-feature-127-wi-4-assign-sheet-audit.md
@@ -1,0 +1,41 @@
+---
+branch: feat/feature-127-wi-4-assign-sheet
+threadId: 019f12d9-5ce4-7f51-a319-2d1f11df2f16
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-29
+---
+
+# Gate-4 audit — feature #127 WI-4 (assign-to-collections sheet)
+
+Independent Codex audit (gpt-5.5, high reasoning, read-only sandbox) of WI-4: the
+`AssignToCollectionsSheet` + `SheetRoute` + the book long-press, over the WI-1/2/3
+data layer + shelf-bar.
+
+## Findings — 1 High + 3 Medium + 1 Low, all fixed
+
+| file | severity | issue | resolution |
+|---|---|---|---|
+| `MainActivity.kt` | High | The "book deleted → close sheet" check read the collection-FILTERED `state.books`. Opening the sheet from a filtered collection and unassigning the book from it would drop the book from `state.books` → the sheet auto-closed, violating the no-auto-close batch contract. | **Fixed.** Added `LibraryViewModel.allBooks` (the UNFILTERED library StateFlow); the sheet resolves its book from it, and only closes when `book == null && allBooks.isNotEmpty()` (library loaded + book genuinely gone). |
+| `LibraryViewModel.kt` / repo / dao | Medium | `createCollectionAndAssign` wasn't atomic — `createCollection` could commit, then `assign` fail on an FK race, leaving an orphan empty collection. | **Fixed.** Added `CollectionDao.createAndAssign` `@Transaction` (insert + addMembership atomically; an FK failure rolls BOTH back) + `CollectionRepository.createAndAssign`; the VM delegates to it. New `createAndAssign_fkFailure_rollsBack_noOrphanCollection` test proves no orphan. |
+| `CollectionSheets.kt` | Medium | Design fidelity — the AssignSheet design wraps the checklist in a rounded card with row dividers; the rows were rendered bare. | **Fixed.** Wrapped the rows in a `Surface` card (rounded 14dp) with `HorizontalDivider`s between rows (per the design). |
+| `LibraryScreen.kt` | Medium | The long-press assign had no `onLongClickLabel` → TalkBack announced a generic action. | **Fixed.** Added `onLongClickLabel = "Add to collection"` to the grid + list `combinedClickable`. |
+| `MainActivity.kt` | Low | `viewModel.collectionIdsForBook(route.bookKey)` created a new Flow each recomposition. | **Fixed.** `remember(route.bookKey) { … }`. |
+
+## Auditor confirmations
+
+- `SheetRouteSaver` handles colon-containing fingerprintKeys correctly:
+  `"assign:epub:abc:123".removePrefix("assign:")` → `epub:abc:123`.
+- The duplicate-name path does not assign and surfaces the failure event; the `@Transaction` shape is
+  the correct atomic create-then-assign.
+
+## Test evidence
+
+- `CollectionRepositoryTest` — 13/13 (incl. `createAndAssign` happy-path + the FK-rollback / no-orphan).
+- `LibraryViewModelCollectionsTest` — 5/5 (filter/reset/no-leak + createCollectionAndAssign create+assign + dup).
+- `LibraryViewModelTest` — 4/4.
+- `AssignSheetUiTest` — 3 connected (render checked/unchecked via `useUnmergedTree`, tap toggles, inline create).
+
+## Verdict
+
+ship-as-is (after the 5 fixes). WI-4 is behavioral; WI-5 adds the manage sheet, WI-6 the backup/restore.

--- a/android/app/src/androidTest/kotlin/com/vreader/app/library/AssignSheetUiTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/library/AssignSheetUiTest.kt
@@ -1,0 +1,61 @@
+package com.vreader.app.library
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.vreader.app.data.Collection
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Feature #127 WI-4 — the assign-to-collections sheet content renders the book + a checklist of
+ * collections (member = check, non-member = ring), tapping a row reports the toggle (no auto-close),
+ * and the inline "New Collection…" reveals a field whose submit reports the name. Renders
+ * `AssignSheetContent` directly (the ModalBottomSheet wrapper is the same content).
+ */
+@RunWith(AndroidJUnit4::class)
+class AssignSheetUiTest {
+    @get:Rule val compose = createComposeRule()
+
+    private val cols = listOf(
+        Collection(id = "c1", name = "Fiction", createdAt = 1L, bookCount = 0),
+        Collection(id = "c2", name = "Tech", createdAt = 2L, bookCount = 0),
+    )
+
+    @Test fun rendersRows_withCheckedAndUncheckedState() {
+        compose.setContent { AssignSheetContent("My Book", cols, setOf("c1"), { _, _ -> }, {}) }
+        compose.onNodeWithText("Add to Collection").assertIsDisplayed()
+        compose.onNodeWithText("My Book").assertIsDisplayed()
+        compose.onNodeWithText("Fiction").assertIsDisplayed()
+        // the check/ring icons live inside the clickable row, whose semantics MERGE the children →
+        // find them in the unmerged tree.
+        compose.onNodeWithTag("assign-check-Fiction", useUnmergedTree = true).assertExists()   // member → check
+        compose.onNodeWithTag("assign-uncheck-Tech", useUnmergedTree = true).assertExists()    // non-member → ring
+    }
+
+    @Test fun tappingUncheckedRow_reportsToggleOn() {
+        var toggled: Pair<String, Boolean>? = null
+        compose.setContent { AssignSheetContent("My Book", cols, setOf("c1"), { id, now -> toggled = id to now }, {}) }
+        compose.onNodeWithTag("assign-row-Tech").performClick()
+        assertEquals("c2" to true, toggled)
+        // tapping a member row reports toggle OFF.
+        compose.onNodeWithTag("assign-row-Fiction").performClick()
+        assertEquals("c1" to false, toggled)
+    }
+
+    @Test fun inlineNewCollection_revealsField_andSubmitReportsName() {
+        var created: String? = null
+        compose.setContent { AssignSheetContent("My Book", cols, emptySet(), { _, _ -> }, { created = it }) }
+        compose.onNodeWithTag("assign-new-collection").performClick()
+        compose.onNodeWithTag("assign-new-collection-field").performTextInput("Sci-Fi")
+        compose.onNodeWithTag("assign-new-collection-field").performImeAction()
+        assertEquals("Sci-Fi", created)
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/MainActivity.kt
@@ -19,9 +19,16 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import com.vreader.app.library.AssignToCollectionsSheet
 import com.vreader.app.library.LibraryEvent
 import com.vreader.app.library.LibraryScreen
 import com.vreader.app.library.LibraryViewModel
+import com.vreader.app.library.SheetRoute
+import com.vreader.app.library.SheetRouteSaver
 import com.vreader.app.reader.Azw3ReaderActivity
 import com.vreader.app.reader.ReaderActivity
 import com.vreader.app.reader.PdfReaderActivity
@@ -44,6 +51,8 @@ class MainActivity : ComponentActivity() {
                 val state by viewModel.uiState.collectAsStateWithLifecycle()
                 val collections by viewModel.collections.collectAsStateWithLifecycle()
                 val selectedCollectionId by viewModel.selectedCollectionId.collectAsStateWithLifecycle()
+                // feature #127 WI-4 — which collections sheet is open (survives rotation/process death).
+                var sheetRoute by rememberSaveable(stateSaver = SheetRouteSaver) { mutableStateOf<SheetRoute>(SheetRoute.None) }
 
                 val picker = rememberLauncherForActivityResult(
                     ActivityResultContracts.OpenDocument(),
@@ -64,6 +73,7 @@ class MainActivity : ComponentActivity() {
                     collections = collections,
                     selectedCollectionId = selectedCollectionId,
                     onSelectCollection = viewModel::selectCollection,
+                    onAssignBook = { book -> sheetRoute = SheetRoute.Assign(book.id) },
                     onOpenBook = { book ->
                         // Route by the typed format (exhaustive — never open a format into
                         // the wrong host). Formats without a reader yet are surfaced, not
@@ -92,6 +102,32 @@ class MainActivity : ComponentActivity() {
                         )
                     },
                 )
+
+                // feature #127 WI-4 — the assign-to-collections sheet (long-press a book).
+                val route = sheetRoute
+                if (route is SheetRoute.Assign) {
+                    // resolve from the UNFILTERED library so unassigning from a filtered collection
+                    // doesn't drop the book + close the sheet (Gate-4 WI-4 High).
+                    val allBooks by viewModel.allBooks.collectAsStateWithLifecycle()
+                    val book = allBooks.firstOrNull { it.id == route.bookKey }
+                    if (book == null && allBooks.isNotEmpty()) {
+                        // the library has loaded and the book is genuinely gone (deleted) → close.
+                        LaunchedEffect(route) { sheetRoute = SheetRoute.None }
+                    } else if (book != null) {
+                        val memberIdsFlow = remember(route.bookKey) { viewModel.collectionIdsForBook(route.bookKey) }
+                        val memberIds by memberIdsFlow.collectAsStateWithLifecycle(emptyList())
+                        AssignToCollectionsSheet(
+                            bookTitle = book.title,
+                            collections = collections,
+                            memberIds = memberIds.toHashSet(),
+                            onToggle = { id, nowMember ->
+                                if (nowMember) viewModel.assign(route.bookKey, id) else viewModel.unassign(route.bookKey, id)
+                            },
+                            onCreateAndAssign = { name -> viewModel.createCollectionAndAssign(name, route.bookKey) },
+                            onDismiss = { sheetRoute = SheetRoute.None },
+                        )
+                    }
+                }
             }
         }
     }

--- a/android/app/src/main/kotlin/com/vreader/app/data/CollectionDao.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/data/CollectionDao.kt
@@ -78,6 +78,18 @@ abstract class CollectionDao {
         return true
     }
 
+    /** Atomic create-AND-assign: create the collection (if the name is free) and add [bookKey] to it in
+     *  ONE transaction — so an FK failure on the membership insert rolls back the collection too (no
+     *  orphan empty collection). Returns false on a duplicate name; throws (→ rollback) if the book FK
+     *  is invalid. Gate-4 WI-4 Medium. */
+    @Transaction
+    open suspend fun createAndAssign(collection: CollectionEntity, bookKey: String): Boolean {
+        if (findByNameKey(collection.nameKey) != null) return false
+        insertCollection(collection)
+        addMembership(bookKey, collection.id)
+        return true
+    }
+
     /** Atomic rename: NotFound if [id] is gone (checked FIRST), else Duplicate if the name is taken by
      *  ANOTHER collection, else update. The order matters — a gone id must report NotFound even when the
      *  target name exists elsewhere (Gate-4 WI-2 Medium). */

--- a/android/app/src/main/kotlin/com/vreader/app/data/CollectionRepository.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/data/CollectionRepository.kt
@@ -48,6 +48,18 @@ class CollectionRepository(
         }
     }
 
+    /** Create a collection AND add [bookKey] to it ATOMICALLY (one DB transaction — an FK failure on the
+     *  membership rolls back the collection, no orphan). Rejects empty / duplicate (case-insensitive). */
+    suspend fun createAndAssign(rawName: String, bookKey: String): Result<Collection> {
+        val name = normalize(rawName) ?: return fail(CollectionError.EmptyName)
+        val entity = CollectionEntity(id = newId(), name = name, nameKey = nameKey(name), createdAt = now())
+        return if (dao.createAndAssign(entity, bookKey)) {
+            Result.success(Collection(entity.id, entity.name, entity.createdAt, bookCount = 1))
+        } else {
+            fail(CollectionError.DuplicateName)
+        }
+    }
+
     /** Rename a collection; rejects empty / a name taken by ANOTHER collection; NotFound if gone. */
     suspend fun rename(id: String, rawName: String): Result<Unit> {
         val name = normalize(rawName) ?: return fail(CollectionError.EmptyName)

--- a/android/app/src/main/kotlin/com/vreader/app/library/CollectionSheets.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/library/CollectionSheets.kt
@@ -1,0 +1,191 @@
+// Purpose: the collections bottom sheets — feature #127 WI-4 (assign) / WI-5 (manage). A Compose
+// recreation of the committed design `vreader-library-android.jsx` AssignSheet: an "Add to Collection"
+// modal bottom sheet (book header + a checklist of collections + an inline "New Collection…"). Tapping
+// a collection row toggles membership and does NOT close the sheet (batch assign). Pure function of
+// (book, collections, memberIds) + callbacks (rule 50 §4). SheetRoute is the hoisted open-sheet state.
+package com.vreader.app.library
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.vreader.app.data.Collection
+import com.vreader.app.ui.theme.VReaderColors
+import com.vreader.app.ui.theme.VReaderFonts
+
+/** Which collections sheet is open. Saveable across rotation/process death via [SheetRouteSaver]. */
+sealed interface SheetRoute {
+    data object None : SheetRoute
+    data object Manage : SheetRoute
+    data class Assign(val bookKey: String) : SheetRoute
+}
+
+/** Serializes [SheetRoute] to a string so `rememberSaveable` survives process death. */
+val SheetRouteSaver: Saver<SheetRoute, String> = Saver(
+    save = {
+        when (it) {
+            SheetRoute.None -> "none"
+            SheetRoute.Manage -> "manage"
+            is SheetRoute.Assign -> "assign:${it.bookKey}"
+        }
+    },
+    restore = {
+        when {
+            it == "manage" -> SheetRoute.Manage
+            it.startsWith("assign:") -> SheetRoute.Assign(it.removePrefix("assign:"))
+            else -> SheetRoute.None
+        }
+    },
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AssignToCollectionsSheet(
+    bookTitle: String,
+    collections: List<Collection>,
+    memberIds: Set<String>,
+    onToggle: (collectionId: String, nowMember: Boolean) -> Unit,
+    onCreateAndAssign: (name: String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = VReaderColors.Surface,
+        modifier = Modifier.testTag("assign-sheet"),
+    ) {
+        AssignSheetContent(bookTitle, collections, memberIds, onToggle, onCreateAndAssign)
+    }
+}
+
+/** The sheet's content, extracted from the [ModalBottomSheet] wrapper so it's directly UI-testable. */
+@Composable
+fun AssignSheetContent(
+    bookTitle: String,
+    collections: List<Collection>,
+    memberIds: Set<String>,
+    onToggle: (collectionId: String, nowMember: Boolean) -> Unit,
+    onCreateAndAssign: (name: String) -> Unit,
+) {
+    Column(Modifier.testTag("assign-sheet-content")) {
+        // Header — a placeholder cover + "Add to Collection" + the book title.
+        Row(
+            Modifier.fillMaxWidth().padding(start = 18.dp, end = 18.dp, bottom = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Box(
+                Modifier.size(44.dp, 60.dp).clip(RoundedCornerShape(4.dp)).background(VReaderColors.Ink.copy(alpha = 0.08f)),
+            )
+            Column(Modifier.weight(1f)) {
+                Text("Add to Collection", color = VReaderColors.Ink, fontFamily = VReaderFonts.Serif, fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+                Text(bookTitle, color = VReaderColors.InkMuted, fontSize = 12.5.sp, maxLines = 1, fontFamily = VReaderFonts.Sans)
+            }
+        }
+
+        // Collection rows in the designed rounded card with row dividers — tap toggles membership
+        // (no auto-close, batch assign).
+        Column(Modifier.padding(horizontal = 16.dp)) {
+            Surface(shape = RoundedCornerShape(14.dp), color = VReaderColors.Background) {
+                Column {
+                    collections.forEachIndexed { i, c ->
+                        val member = c.id in memberIds
+                        Row(
+                            Modifier.fillMaxWidth().heightIn(min = 52.dp)
+                                .clickable { onToggle(c.id, !member) }
+                                .testTag("assign-row-${c.name}")
+                                .padding(horizontal = 14.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Icon(Icons.Filled.Folder, contentDescription = null, tint = VReaderColors.InkMuted, modifier = Modifier.size(19.dp))
+                            Text(c.name, Modifier.weight(1f).padding(start = 11.dp), color = VReaderColors.Ink, fontSize = 15.5.sp, fontFamily = VReaderFonts.Sans)
+                            if (member) {
+                                Icon(Icons.Filled.CheckCircle, contentDescription = "In collection", tint = VReaderColors.Accent, modifier = Modifier.size(22.dp).testTag("assign-check-${c.name}"))
+                            } else {
+                                Box(Modifier.size(22.dp).clip(CircleShape).border(1.7.dp, VReaderColors.Ink.copy(alpha = 0.18f), CircleShape).testTag("assign-uncheck-${c.name}"))
+                            }
+                        }
+                        if (i < collections.lastIndex) {
+                            HorizontalDivider(Modifier.padding(start = 44.dp), thickness = 0.5.dp, color = VReaderColors.Ink.copy(alpha = 0.08f))
+                        }
+                    }
+                }
+            }
+
+            NewCollectionRow(onCreate = onCreateAndAssign)
+        }
+    }
+}
+
+/** The inline "New Collection…" row — reveals a text field + Add on tap; submits a non-blank name. */
+@Composable
+private fun NewCollectionRow(onCreate: (String) -> Unit) {
+    var editing by rememberSaveable { mutableStateOf(false) }
+    var draft by rememberSaveable { mutableStateOf("") }
+
+    if (!editing) {
+        Row(
+            Modifier.fillMaxWidth().clickable { editing = true }.testTag("assign-new-collection").padding(vertical = 15.dp, horizontal = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(9.dp),
+        ) {
+            Icon(Icons.Filled.Add, contentDescription = null, tint = VReaderColors.Accent, modifier = Modifier.size(19.dp))
+            Text("New Collection…", color = VReaderColors.Accent, fontSize = 15.sp, fontWeight = FontWeight.Medium, fontFamily = VReaderFonts.Sans)
+        }
+    } else {
+        fun submit() {
+            val name = draft.trim()
+            if (name.isNotEmpty()) onCreate(name)
+            draft = ""; editing = false
+        }
+        OutlinedTextField(
+            value = draft,
+            onValueChange = { draft = it },
+            singleLine = true,
+            placeholder = { Text("Collection name", color = Color.Gray) },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { submit() }),
+            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp).testTag("assign-new-collection-field"),
+        )
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/library/LibraryScreen.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/library/LibraryScreen.kt
@@ -9,6 +9,7 @@ package com.vreader.app.library
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -59,6 +60,8 @@ fun LibraryScreen(
     collections: List<com.vreader.app.data.Collection> = emptyList(),
     selectedCollectionId: String? = null,
     onSelectCollection: (String?) -> Unit = {},
+    // feature #127 WI-4 — long-press a book to assign it to collections.
+    onAssignBook: (LibraryBook) -> Unit = {},
 ) {
     // Boolean (not the enum) so rememberSaveable persists the mode across rotation /
     // process recreation without a custom Saver.
@@ -120,8 +123,8 @@ fun LibraryScreen(
             // rule 51 we render nothing rather than invent one (Gate-4 WI-3 Medium).
             state.books.isEmpty() && selectedCollectionId == null -> EmptyState(onImport)
             state.books.isEmpty() -> Unit
-            view == LibraryView.Grid -> BookGrid(state.books, onOpenBook)
-            else -> BookList(state.books, onOpenBook)
+            view == LibraryView.Grid -> BookGrid(state.books, onOpenBook, onAssignBook)
+            else -> BookList(state.books, onOpenBook, onAssignBook)
         }
     }
 }
@@ -141,8 +144,9 @@ private fun PillIcon(
     }
 }
 
+@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
-private fun BookGrid(books: List<LibraryBook>, onOpen: (LibraryBook) -> Unit) {
+private fun BookGrid(books: List<LibraryBook>, onOpen: (LibraryBook) -> Unit, onAssign: (LibraryBook) -> Unit) {
     LazyVerticalGrid(
         columns = GridCells.Fixed(3),
         contentPadding = PaddingValues(start = 22.dp, end = 22.dp, bottom = 60.dp),
@@ -151,7 +155,14 @@ private fun BookGrid(books: List<LibraryBook>, onOpen: (LibraryBook) -> Unit) {
         modifier = Modifier.fillMaxSize(),
     ) {
         items(books, key = { it.id }) { book ->
-            Column(Modifier.clickable { onOpen(book) }, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(
+                Modifier.combinedClickable(
+                    onClick = { onOpen(book) },
+                    onLongClickLabel = "Add to collection",
+                    onLongClick = { onAssign(book) },
+                ),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 FallbackCover(book, Modifier.fillMaxWidth().aspectRatio(104f / 156f), 4.dp)
                 Text(
                     book.title,
@@ -167,8 +178,9 @@ private fun BookGrid(books: List<LibraryBook>, onOpen: (LibraryBook) -> Unit) {
     }
 }
 
+@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
-private fun BookList(books: List<LibraryBook>, onOpen: (LibraryBook) -> Unit) {
+private fun BookList(books: List<LibraryBook>, onOpen: (LibraryBook) -> Unit, onAssign: (LibraryBook) -> Unit) {
     LazyVerticalGrid(
         columns = GridCells.Fixed(1),
         contentPadding = PaddingValues(start = 18.dp, end = 18.dp, bottom = 60.dp),
@@ -177,7 +189,8 @@ private fun BookList(books: List<LibraryBook>, onOpen: (LibraryBook) -> Unit) {
     ) {
         items(books, key = { it.id }) { book ->
             Row(
-                Modifier.fillMaxWidth().clickable { onOpen(book) }
+                Modifier.fillMaxWidth()
+                    .combinedClickable(onClick = { onOpen(book) }, onLongClickLabel = "Add to collection", onLongClick = { onAssign(book) })
                     .background(VReaderColors.Surface).padding(14.dp),
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 verticalAlignment = Alignment.CenterVertically,

--- a/android/app/src/main/kotlin/com/vreader/app/library/LibraryViewModel.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/library/LibraryViewModel.kt
@@ -114,6 +114,24 @@ class LibraryViewModel(
     fun assign(bookKey: String, collectionId: String) = runCollectionOp { collectionRepository.assign(bookKey, collectionId); Result.success(Unit) }
     fun unassign(bookKey: String, collectionId: String) = runCollectionOp { collectionRepository.unassign(bookKey, collectionId); Result.success(Unit) }
 
+    /** Create a collection AND add [bookKey] to it — the assign sheet's "New Collection…" inline create.
+     *  Atomic in the repository (one DB transaction, no orphan on an FK failure); a duplicate name
+     *  surfaces the error. */
+    fun createCollectionAndAssign(name: String, bookKey: String) = runCollectionOp {
+        collectionRepository.createAndAssign(name, bookKey)
+    }
+
+    /** The collection ids a book currently belongs to (for the assign sheet's checked state). */
+    fun collectionIdsForBook(bookKey: String): Flow<List<String>> =
+        collectionRepository.observeCollectionIdsForBook(bookKey)
+
+    /** The UNFILTERED library — the assign sheet resolves its book here, NOT from the collection-filtered
+     *  uiState, so unassigning a book from the currently-filtered collection doesn't close the sheet
+     *  (Gate-4 WI-4 High). Empty initially → the sheet's close-if-gone guard waits for it to load. */
+    val allBooks: StateFlow<List<LibraryBook>> = repository.observeLibrary()
+        .map { books -> books.map(::toUi) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
     /** The single failure boundary for ALL collection mutations: surfaces a returned [Result] failure
      *  AND a THROWN exception (e.g. an FK constraint race when assigning to a just-deleted collection) as
      *  a [LibraryEvent.CollectionOpFailed] toast (Gate-4 WI-3 Medium) — never crashes the screen. */

--- a/android/app/src/test/kotlin/com/vreader/app/data/CollectionRepositoryTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/data/CollectionRepositoryTest.kt
@@ -118,4 +118,19 @@ class CollectionRepositoryTest {
         repo.delete(c.id) // no throw on a gone collection
         assertFalse(repo.observeCollections().first().any { it.id == c.id })
     }
+
+    @Test fun createAndAssign_succeeds_forAnExistingBook() = runBlocking {
+        val c = repo.createAndAssign("Fiction", bookKey).getOrThrow()
+        assertEquals(1, c.bookCount)
+        assertEquals(listOf(bookKey), db.collectionDao().bookKeysInCollection(c.id))
+    }
+
+    @Test fun createAndAssign_fkFailure_rollsBack_noOrphanCollection() = runBlocking {
+        val before = db.collectionDao().getAllCollections().size
+        // a non-existent book → the membership FK insert fails → the @Transaction rolls BOTH back.
+        try {
+            repo.createAndAssign("Orphan", "epub:${"z".repeat(64)}:9")
+        } catch (e: Exception) { /* expected: FK constraint → rollback */ }
+        assertEquals("no orphan collection survives the membership FK rollback", before, db.collectionDao().getAllCollections().size)
+    }
 }

--- a/android/app/src/test/kotlin/com/vreader/app/library/LibraryViewModelCollectionsTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/library/LibraryViewModelCollectionsTest.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -97,5 +98,19 @@ class LibraryViewModelCollectionsTest {
         vm.selectCollection(b.id)
         // flatMapLatest cancels A's flow → B shows only Beta, never the stale Alpha.
         assertEquals("B → only Beta (no leak from A)", listOf("Beta"), awaitTitles("Beta"))
+    }
+
+    @Test fun createCollectionAndAssign_createsTheCollection_andAddsTheBook() = runBlocking {
+        vm.createCollectionAndAssign("Fiction", key1)
+        val col = withTimeout(3_000) { vm.collections.first { list -> list.any { it.name == "Fiction" } } }.first { it.name == "Fiction" }
+        val members = withTimeout(3_000) { collections.observeBookKeysInCollection(col.id).first { it.contains(key1) } }
+        assertTrue("the new collection contains the assigned book", members.contains(key1))
+    }
+
+    @Test fun createCollectionAndAssign_duplicateName_doesNotCreateASecond() = runBlocking {
+        collections.createCollection("Fiction").getOrThrow()
+        vm.createCollectionAndAssign("FICTION", key1) // case-folded duplicate → rejected (event)
+        val count = withTimeout(3_000) { vm.collections.first { it.isNotEmpty() } }.count { it.name.equals("fiction", ignoreCase = true) }
+        assertEquals("the duplicate did not create a second collection", 1, count)
     }
 }

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.13.4
-versionCode=77
+versionName=0.13.5
+versionCode=78


### PR DESCRIPTION
## Summary

WI-4 (behavioral) — long-press a book → the "Add to Collection" sheet (the designed checklist: each collection toggles membership, batch (no auto-close), + inline "New Collection…"). `SheetRoute` hoisted via `rememberSaveable`. `createCollectionAndAssign` is atomic (a `CollectionDao.createAndAssign` `@Transaction`).

## Codex audit

Gate-4 thread `019f12d9`, ship-as-is — **1 High + 3 Medium + 1 Low all fixed**: (High) the close-if-deleted check now uses the unfiltered `allBooks` (unassigning from a filtered collection no longer closes the sheet); (Medium) atomic create+assign with FK rollback; (Medium) the designed `Surface` Card + dividers; (Medium) `onLongClickLabel`; (Low) remembered per-book Flow. Auditor confirmed `SheetRouteSaver` handles colon-containing keys.

Audit log: `.claude/codex-audits/feat-feature-127-wi-4-assign-sheet-audit.md`

## Slice verification

- `CollectionRepositoryTest` 13/13 (incl. `createAndAssign` happy-path + FK-rollback no-orphan).
- `LibraryViewModelCollectionsTest` 5/5; `LibraryViewModelTest` 4/4.
- `AssignSheetUiTest` 3/3 on the emulator (render checked/unchecked, tap toggles, inline create).

Part of feature #1869. Version: `android/v0.13.5`.