### PR TITLE
feat(#127 WI-5): collections manage sheet + scoped header

### DIFF
--- a/.claude/codex-audits/feat-feature-127-wi-5-manage-sheet-audit.md
+++ b/.claude/codex-audits/feat-feature-127-wi-5-manage-sheet-audit.md
@@ -1,0 +1,61 @@
+---
+branch: feat/feature-127-wi-5-manage-sheet
+threadId: 019f12f4
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-29
+---
+
+# Gate-4 audit — feature #127 WI-5 (collections manage UI)
+
+WI-5 adds the collections **manage** surface for the Android library. Scope after the
+round-2 rule-51 rework: the manage sheet (`CollectionsManageSheet` / `ManageSheetContent`)
+lists collections + book counts, taps a name → inline rename, and an inline "New Collection"
+create row — opened from the **designed scoped-collection header** ("N books · edit collection",
+`vreader-library-android.jsx` `scope === 'collection'`). Files: `LibraryScreen.kt` (scoped
+header), `CollectionSheets.kt` (manage sheet), `MainActivity.kt` (route wiring),
+`LibraryViewModel.kt` (rename/create/delete seams), `ManageSheetUiTest.kt`.
+
+## Round 1 (Codex 019f12f4, gpt-5.5/high) — 2 Medium, both rule-51 (no self-designed UI)
+
+| file:line | severity | issue | resolution |
+|---|---|---|---|
+| `LibraryScreen.kt` (nav bar) | Medium | The manage entry point was an **invented** nav-bar Folder pill — not depicted in the committed design (the library top bar shows Search + More, not a Folder pill). Route through a designed affordance or block on design. | **FIXED** — removed the pill. The manage sheet is now opened ONLY from the DESIGNED scoped-collection header's "edit collection" affordance (`scope === 'collection'` in `vreader-library-android.jsx`), which this WI adds to `LibraryScreen` (back breadcrumb → "All", serif collection name, "N books · edit collection" subtitle). |
+| `CollectionSheets.kt:268` | Medium | The trailing `DeleteOutline` button is **not faithful** to `CollectionsManageSheet` — the design has no inline delete control; delete lives behind an Edit-mode per-collection detail disclosure that is **not depicted**. Remove it or get delete designed first. | **FIXED** — removed the trash `IconButton` + its `onDelete` wiring + the `DeleteOutline`/`IconButton` imports. Delete UI deferred to **needs-design #1875**. `LibraryViewModel.deleteCollection` retained (commented) as the seam the deferred UI will wire; the delete capability stays repo-backed + tested (`CollectionRepositoryTest`, `LibraryViewModelCollectionsTest` reset-on-delete). |
+
+Auditor explicitly accepted: the inline rename state is a reasonable read of the edit
+affordance; the manage sheet hidden-when-empty is acceptable; the tests are fine.
+
+## Round 2 (Codex `bb38tru1f`, gpt-5.5/high) — re-audit of the reworked diff: 1 Medium + 1 Low
+
+Confirmed both round-1 Mediums resolved (the invented nav pill + trash button are gone; the scoped
+header is the designed entry). Two NEW findings on the reworked diff:
+
+| file:line | severity | issue | resolution |
+|---|---|---|---|
+| `LibraryScreen.kt:81` | Medium | The scoped-collection surface still rendered the all-library action row (view-toggle + import pills) ABOVE the back breadcrumb. The committed `scope === 'collection'` design goes from the status strip directly to the back row → title → "N books · edit collection"; the pills are an extra visible surface not in the scoped design. | **FIXED** — moved the nav-pill `Row` INTO the All-only (`else`) branch. The scoped view now renders only the designed `ScopedCollectionHeader` (no pills). |
+| `CollectionSheets.kt:1` + `LibraryScreen.kt:1` | Low | The diff pushed both files over the ~300-line convention (`CollectionSheets.kt` 311, `LibraryScreen.kt` 319). | **FIXED** — extracted the manage sheet (`ManageCollectionsSheet`/`ManageSheetContent`/`ManageNewCollectionRow`) AND the scoped header into a new file `library/CollectionManageSheet.kt`. Now: `CollectionSheets.kt` 191, `LibraryScreen.kt` 292, new file ~210 — all under 300. |
+
+## Round 3 (Codex `bcpcx5y6e`, gpt-5.5/high) — confirm the round-2 fixes
+
+**Clean re-audit. No findings.** The auditor confirmed: the scoped view no longer shows nav pills
+(round-2 Medium resolved); the All view is unchanged/correct; `ScopedCollectionHeader(collectionName,
+bookCount, onBack, onEditCollection)` is a faithful, correct extraction; the file split is clean (no
+behavior change, no duplicate/dead code, no broken imports).
+
+## Verdict
+
+**ship-as-is.** Three rounds: round 1 (2 Medium rule-51 — invented nav pill + trash button) →
+round 2 (1 Medium scoped-view pills + 1 Low file-size) → round 3 clean. Zero open
+Critical/High/Medium/Low. The delete UI is the only deferred item (needs-design #1875), with the
+capability repo/VM-backed + tested. Build: main + unit + androidTest compile clean.
+
+## Gate-5 slice verification
+
+`ManageSheetUiTest` (connected, vreader-test AVD API-35): **3/3 tests passed (0 skipped, 0 failed)** —
+lists collections + counts, tap-name → inline rename submit, "New Collection" inline-create submit.
+Note: the run took 3 attempts to land — the first two TIMEOUT'd at the instrumentation stage because
+stale hung `adb shell getprop` processes (accumulated from repeated boot-state probes) congested adbd;
+killing those + `adb kill-server/start-server` cleared it and the test passed cleanly. A pure
+environment artifact, not a code/test defect (rule 52 contention class). The deferred delete UI
+(needs-design #1875) is out of this slice.

--- a/android/app/src/androidTest/kotlin/com/vreader/app/library/ManageSheetUiTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/library/ManageSheetUiTest.kt
@@ -1,0 +1,59 @@
+package com.vreader.app.library
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.vreader.app.data.Collection
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Feature #127 WI-5 — the manage-collections sheet content lists collections + their counts (the
+ * design's `CollectionsManageSheet` list mode), taps a name → inline rename (submit reports the new
+ * name), and the "New Collection" inline-create reports the name. Renders `ManageSheetContent` directly.
+ * Delete is intentionally absent — deferred to a needs-design follow-up (rule 51).
+ */
+@RunWith(AndroidJUnit4::class)
+class ManageSheetUiTest {
+    @get:Rule val compose = createComposeRule()
+
+    private val cols = listOf(
+        Collection(id = "c1", name = "Fiction", createdAt = 1L, bookCount = 3),
+        Collection(id = "c2", name = "Tech", createdAt = 2L, bookCount = 1),
+    )
+
+    @Test fun listsCollections_withCounts() {
+        compose.setContent { ManageSheetContent(cols, { _, _ -> }, {}) }
+        compose.onNodeWithText("Collections").assertIsDisplayed()
+        compose.onNodeWithText("Fiction").assertIsDisplayed()
+        compose.onNodeWithText("Tech").assertIsDisplayed()
+        compose.onNodeWithText("3", useUnmergedTree = true).assertExists()  // Fiction's book count
+    }
+
+    @Test fun tappingName_revealsRenameField_andSubmitReportsNewName() {
+        var renamed: Pair<String, String>? = null
+        compose.setContent { ManageSheetContent(cols, { id, name -> renamed = id to name }, {}) }
+        compose.onNodeWithTag("manage-name-Fiction", useUnmergedTree = true).performClick()
+        compose.onNodeWithTag("manage-rename-field", useUnmergedTree = true).performTextClearance()
+        compose.onNodeWithTag("manage-rename-field", useUnmergedTree = true).performTextInput("Novels")
+        compose.onNodeWithTag("manage-rename-field", useUnmergedTree = true).performImeAction()
+        assertEquals("c1" to "Novels", renamed)
+    }
+
+    @Test fun inlineNewCollection_revealsField_andSubmitReportsName() {
+        var created: String? = null
+        compose.setContent { ManageSheetContent(cols, { _, _ -> }, { created = it }) }
+        compose.onNodeWithTag("manage-new-collection").performClick()
+        compose.onNodeWithTag("manage-new-collection-field").performTextInput("History")
+        compose.onNodeWithTag("manage-new-collection-field").performImeAction()
+        assertEquals("History", created)
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/MainActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import com.vreader.app.library.AssignToCollectionsSheet
+import com.vreader.app.library.ManageCollectionsSheet
 import com.vreader.app.library.LibraryEvent
 import com.vreader.app.library.LibraryScreen
 import com.vreader.app.library.LibraryViewModel
@@ -74,6 +75,7 @@ class MainActivity : ComponentActivity() {
                     selectedCollectionId = selectedCollectionId,
                     onSelectCollection = viewModel::selectCollection,
                     onAssignBook = { book -> sheetRoute = SheetRoute.Assign(book.id) },
+                    onManageCollections = { sheetRoute = SheetRoute.Manage },
                     onOpenBook = { book ->
                         // Route by the typed format (exhaustive — never open a format into
                         // the wrong host). Formats without a reader yet are surfaced, not
@@ -127,6 +129,18 @@ class MainActivity : ComponentActivity() {
                             onDismiss = { sheetRoute = SheetRoute.None },
                         )
                     }
+                }
+
+                // feature #127 WI-5 — the manage-collections sheet (list + rename + create), opened from
+                // the designed scoped-collection "edit collection" header. Delete is deferred to a
+                // needs-design follow-up (the design routes it behind an undepicted detail disclosure).
+                if (route is SheetRoute.Manage) {
+                    ManageCollectionsSheet(
+                        collections = collections,
+                        onRename = { id, newName -> viewModel.renameCollection(id, newName) },
+                        onCreate = { name -> viewModel.createCollection(name) },
+                        onDismiss = { sheetRoute = SheetRoute.None },
+                    )
                 }
             }
         }

--- a/android/app/src/main/kotlin/com/vreader/app/library/CollectionManageSheet.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/library/CollectionManageSheet.kt
@@ -1,0 +1,217 @@
+// Purpose: feature #127 WI-5 — the collections "manage" surface for the Android library.
+// `ScopedCollectionHeader` is the DESIGNED scoped-collection header (vreader-library-android.jsx
+// `scope === 'collection'`: a back breadcrumb to "All", the collection name in serif, and a
+// "N books · edit collection" subtitle whose tap opens the manage sheet). `ManageCollectionsSheet`
+// is the list+rename+create bottom sheet (the design's `CollectionsManageSheet` list mode). Delete is
+// intentionally absent — the design routes it behind an undepicted Edit-mode detail disclosure, so its
+// UI is deferred to needs-design #1875 (rule 51); the capability stays repo/VM-backed + tested.
+//
+// @coordinates-with: library/LibraryScreen.kt (renders ScopedCollectionHeader), library/CollectionSheets.kt
+//   (the sibling AssignToCollectionsSheet + SheetRoute), MainActivity.kt (wires the sheet to the VM)
+package com.vreader.app.library
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.vreader.app.data.Collection
+import com.vreader.app.ui.theme.VReaderColors
+import com.vreader.app.ui.theme.VReaderFonts
+
+/**
+ * The DESIGNED scoped-collection header (vreader-library-android.jsx `scope === 'collection'`): a back
+ * breadcrumb to the all-library view, the collection name (serif), and a "N books · edit collection"
+ * subtitle whose tap is the entry into the manage sheet. Replaces the "Library" title + shelf-bar when a
+ * collection is selected; per the design the scoped view has NO action pills (Gate-4 WI-5 round-2 Medium).
+ */
+@Composable
+fun ScopedCollectionHeader(
+    collectionName: String,
+    bookCount: Int,
+    onBack: () -> Unit,
+    onEditCollection: () -> Unit,
+) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clickable { onBack() }
+            .padding(start = 18.dp, end = 18.dp, top = 4.dp, bottom = 4.dp)
+            .testTag("scoped-back"),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Icon(
+            Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+            contentDescription = "Back to all books",
+            tint = VReaderColors.Ink.copy(alpha = 0.8f),
+        )
+        Text("Library", color = VReaderColors.InkMuted, fontSize = 14.sp)
+    }
+    Text(
+        collectionName,
+        Modifier.padding(start = 22.dp, end = 22.dp, top = 2.dp),
+        color = VReaderColors.Ink,
+        fontFamily = VReaderFonts.Serif,
+        fontSize = 25.sp,
+        fontWeight = FontWeight.Bold,
+    )
+    Text(
+        "$bookCount books · edit collection",
+        Modifier
+            .clickable { onEditCollection() }
+            .padding(start = 22.dp, end = 22.dp, top = 2.dp, bottom = 14.dp)
+            .testTag("scoped-edit-collection"),
+        color = VReaderColors.InkMuted,
+        fontSize = 13.sp,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ManageCollectionsSheet(
+    collections: List<Collection>,
+    onRename: (id: String, newName: String) -> Unit,
+    onCreate: (name: String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = VReaderColors.Surface,
+        modifier = Modifier.testTag("manage-sheet"),
+    ) {
+        ManageSheetContent(collections, onRename, onCreate)
+    }
+}
+
+/** The manage-sheet content (extracted for direct UI testing). Lists collections with their book counts
+ *  (the design's `CollectionsManageSheet` list mode); tapping a name reveals an inline rename field; the
+ *  bottom "New Collection" row inline-creates. Per the design — NO reorder (the contract has no order
+ *  field). Delete is intentionally absent: the design routes it behind the Edit-mode per-collection
+ *  detail disclosure, which is not yet depicted — deferred to a needs-design follow-up (rule 51). */
+@Composable
+fun ManageSheetContent(
+    collections: List<Collection>,
+    onRename: (id: String, newName: String) -> Unit,
+    onCreate: (name: String) -> Unit,
+) {
+    var renamingId by rememberSaveable { mutableStateOf<String?>(null) }
+    var renameDraft by rememberSaveable { mutableStateOf("") }
+
+    Column(Modifier.testTag("manage-sheet-content")) {
+        Text(
+            "Collections",
+            Modifier.padding(start = 18.dp, end = 18.dp, bottom = 12.dp),
+            color = VReaderColors.Ink, fontFamily = VReaderFonts.Serif, fontSize = 18.sp, fontWeight = FontWeight.SemiBold,
+        )
+        Column(Modifier.padding(horizontal = 16.dp)) {
+            Surface(shape = RoundedCornerShape(14.dp), color = VReaderColors.Background) {
+                Column {
+                    collections.forEachIndexed { i, c ->
+                        Row(
+                            Modifier.fillMaxWidth().heightIn(min = 52.dp).testTag("manage-row-${c.name}").padding(horizontal = 14.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Icon(Icons.Filled.Folder, contentDescription = null, tint = VReaderColors.Accent, modifier = Modifier.size(19.dp))
+                            if (renamingId == c.id) {
+                                fun submit() {
+                                    val name = renameDraft.trim()
+                                    if (name.isNotEmpty()) onRename(c.id, name)
+                                    renamingId = null
+                                }
+                                OutlinedTextField(
+                                    value = renameDraft,
+                                    onValueChange = { renameDraft = it },
+                                    singleLine = true,
+                                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                                    keyboardActions = KeyboardActions(onDone = { submit() }),
+                                    modifier = Modifier.weight(1f).padding(start = 8.dp, top = 4.dp, bottom = 4.dp).testTag("manage-rename-field"),
+                                )
+                            } else {
+                                Text(
+                                    c.name,
+                                    Modifier.weight(1f).padding(start = 11.dp)
+                                        .clickable { renamingId = c.id; renameDraft = c.name }
+                                        .testTag("manage-name-${c.name}"),
+                                    color = VReaderColors.Ink, fontSize = 15.5.sp, fontFamily = VReaderFonts.Sans,
+                                )
+                                Text("${c.bookCount}", color = VReaderColors.InkMuted, fontSize = 13.5.sp, fontFamily = VReaderFonts.Sans)
+                            }
+                        }
+                        if (i < collections.lastIndex) {
+                            HorizontalDivider(Modifier.padding(start = 44.dp), thickness = 0.5.dp, color = VReaderColors.Ink.copy(alpha = 0.08f))
+                        }
+                    }
+                }
+            }
+
+            ManageNewCollectionRow(onCreate = onCreate)
+        }
+    }
+}
+
+/** The manage sheet's "New Collection" inline-create row. */
+@Composable
+private fun ManageNewCollectionRow(onCreate: (String) -> Unit) {
+    var editing by rememberSaveable { mutableStateOf(false) }
+    var draft by rememberSaveable { mutableStateOf("") }
+
+    if (!editing) {
+        Row(
+            Modifier.fillMaxWidth().clickable { editing = true }.testTag("manage-new-collection").padding(vertical = 15.dp, horizontal = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(9.dp),
+        ) {
+            Icon(Icons.Filled.Add, contentDescription = null, tint = VReaderColors.Accent, modifier = Modifier.size(20.dp))
+            Text("New Collection", color = VReaderColors.Accent, fontSize = 15.5.sp, fontWeight = FontWeight.Medium, fontFamily = VReaderFonts.Sans)
+        }
+    } else {
+        fun submit() {
+            val name = draft.trim()
+            if (name.isNotEmpty()) onCreate(name)
+            draft = ""; editing = false
+        }
+        OutlinedTextField(
+            value = draft,
+            onValueChange = { draft = it },
+            singleLine = true,
+            placeholder = { Text("Collection name", color = Color.Gray) },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { submit() }),
+            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp).testTag("manage-new-collection-field"),
+        )
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/library/LibraryScreen.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/library/LibraryScreen.kt
@@ -62,6 +62,8 @@ fun LibraryScreen(
     onSelectCollection: (String?) -> Unit = {},
     // feature #127 WI-4 — long-press a book to assign it to collections.
     onAssignBook: (LibraryBook) -> Unit = {},
+    // feature #127 WI-5 — open the manage-collections sheet (shown once a collection exists).
+    onManageCollections: () -> Unit = {},
 ) {
     // Boolean (not the enum) so rememberSaveable persists the mode across rotation /
     // process recreation without a custom Saver.
@@ -71,48 +73,63 @@ fun LibraryScreen(
     Column(
         Modifier.fillMaxSize().background(VReaderColors.Background).systemBarsPadding(),
     ) {
-        // Nav bar — the functional controls (view-toggle / import). The design's
-        // settings + search pills are added when those features land (separate WIs);
-        // shipping non-functional controls is a fidelity defect, so they're omitted now.
-        Row(
-            Modifier.fillMaxWidth().padding(start = 18.dp, end = 18.dp, top = 6.dp),
-            horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                PillIcon(
-                    if (view == LibraryView.Grid) Icons.AutoMirrored.Filled.ViewList else Icons.Filled.GridView,
-                    "Toggle view",
-                ) { isGrid = !isGrid }
-                PillIcon(Icons.Filled.Add, "Import book", onImport)
-            }
-        }
-
-        // Title + count.
-        Text(
-            "Library",
-            Modifier.padding(start = 22.dp, end = 22.dp, top = 12.dp, bottom = 4.dp),
-            color = VReaderColors.Ink,
-            fontFamily = VReaderFonts.Serif,
-            fontSize = 36.sp,
-            fontWeight = FontWeight.SemiBold,
-        )
-        Text(
-            "${state.books.size} books · ${state.readingCount} reading",
-            Modifier.padding(start = 22.dp, bottom = 16.dp),
-            color = VReaderColors.InkMuted,
-            fontSize = 13.sp,
-        )
-
-        // feature #127 — the collections shelf-bar (shown once the user has a collection; the
-        // create/assign entry points are the WI-4/WI-5 sheets). Tapping a chip filters the grid.
-        if (collections.isNotEmpty()) {
-            CollectionShelfBar(
-                collections = collections,
-                selectedId = selectedCollectionId,
-                onSelect = onSelectCollection,
-                modifier = Modifier.padding(bottom = 12.dp),
+        // feature #127 — header. When a collection is selected the design's `scope === 'collection'`
+        // surface replaces the WHOLE all-library header (nav pills + "Library" title + shelf-bar) with
+        // just the scoped-collection header: a back breadcrumb to "All", the collection name (serif), and
+        // a "N books · edit collection" subtitle (the DESIGNED manage-sheet entry). The scoped view has NO
+        // action pills (Gate-4 WI-5 round-2 Medium, rule 51) — the nav pills live only in the All branch.
+        val selectedCollection = collections.firstOrNull { it.id == selectedCollectionId }
+        if (selectedCollection != null) {
+            ScopedCollectionHeader(
+                collectionName = selectedCollection.name,
+                bookCount = state.books.size,
+                onBack = { onSelectCollection(null) },
+                onEditCollection = onManageCollections,
             )
+        } else {
+            // Nav bar — the functional controls (view-toggle / import). The design's
+            // settings + search pills are added when those features land (separate WIs);
+            // shipping non-functional controls is a fidelity defect, so they're omitted now.
+            Row(
+                Modifier.fillMaxWidth().padding(start = 18.dp, end = 18.dp, top = 6.dp),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    PillIcon(
+                        if (view == LibraryView.Grid) Icons.AutoMirrored.Filled.ViewList else Icons.Filled.GridView,
+                        "Toggle view",
+                    ) { isGrid = !isGrid }
+                    PillIcon(Icons.Filled.Add, "Import book", onImport)
+                }
+            }
+
+            // Title + count.
+            Text(
+                "Library",
+                Modifier.padding(start = 22.dp, end = 22.dp, top = 12.dp, bottom = 4.dp),
+                color = VReaderColors.Ink,
+                fontFamily = VReaderFonts.Serif,
+                fontSize = 36.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                "${state.books.size} books · ${state.readingCount} reading",
+                Modifier.padding(start = 22.dp, bottom = 16.dp),
+                color = VReaderColors.InkMuted,
+                fontSize = 13.sp,
+            )
+
+            // feature #127 — the collections shelf-bar (shown once the user has a collection; the
+            // create/assign entry points are the WI-4/WI-5 sheets). Tapping a chip filters the grid.
+            if (collections.isNotEmpty()) {
+                CollectionShelfBar(
+                    collections = collections,
+                    selectedId = selectedCollectionId,
+                    onSelect = onSelectCollection,
+                    modifier = Modifier.padding(bottom = 12.dp),
+                )
+            }
         }
 
         when {

--- a/android/app/src/main/kotlin/com/vreader/app/library/LibraryViewModel.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/library/LibraryViewModel.kt
@@ -110,6 +110,9 @@ class LibraryViewModel(
 
     fun createCollection(name: String) = runCollectionOp { collectionRepository.createCollection(name) }
     fun renameCollection(id: String, name: String) = runCollectionOp { collectionRepository.rename(id, name) }
+    // The delete CAPABILITY is repo-backed + tested (CollectionRepositoryTest, LibraryViewModelCollectionsTest
+    // reset-on-delete); its UI is deferred to a needs-design follow-up (the design routes delete behind an
+    // undepicted per-collection detail disclosure — rule 51). This seam is what that UI will wire.
     fun deleteCollection(id: String) = runCollectionOp { collectionRepository.delete(id); Result.success(Unit) }
     fun assign(bookKey: String, collectionId: String) = runCollectionOp { collectionRepository.assign(bookKey, collectionId); Result.success(Unit) }
     fun unassign(bookKey: String, collectionId: String) = runCollectionOp { collectionRepository.unassign(bookKey, collectionId); Result.success(Unit) }

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.13.5
-versionCode=78
+versionName=0.13.6
+versionCode=79

--- a/dev-docs/plans/20260629-feature-127-android-library-collections-search.md
+++ b/dev-docs/plans/20260629-feature-127-android-library-collections-search.md
@@ -135,9 +135,9 @@ iOS (`vreader/`); library/in-reader search (#128 / #F); reorder; the Android `Bo
 | WI-2 | foundational | `CollectionDao` full + `CollectionRepository` (transactional create with trim/≤100/case-insensitive dedup; rename; delete; membership). Tests: CRUD + dedup goldens (case variants, whitespace, CJK, >100, empty) + cascade-on-book-delete + `observeCollectionsWithCount` correctness | L |
 | WI-3 | behavioral | `LibraryViewModel` collections state + **`flatMapLatest`** membership filter (+ reset-to-All on delete) + `CollectionShelfBar` Compose. Tests: VM filter (JVM, incl. the stale-selection race) + a shelf-bar UI test | L |
 | WI-4 | behavioral | `AssignToCollectionsSheet` (checklist + inline create) + the sheet route state, wired VM→repo. Tests: assign/unassign persists + the chip count updates (connected) | M |
-| WI-5 | behavioral | `CollectionsManageSheet` (create / rename / delete — no reorder) wired VM→repo with `CollectionError` surfacing. Tests: manage create/rename(dup→error)/delete round-trip (connected) | M |
+| WI-5 | behavioral | `CollectionsManageSheet` (list + inline rename + inline create — no reorder; **delete UI deferred to needs-design #1875**, Gate-4 round-2 rule-51) opened from the DESIGNED scoped-collection "edit collection" header. Wired VM→repo with `CollectionError` surfacing. Tests: manage list/rename/create (connected) | M |
 | WI-6 | behavioral | Backup/restore: `BackupCollector` emits `collections.json` (`BackupCollectionsEnvelope`) + `RestoreImporter` restores it (case-insensitive merge, membership union). Tests: collect→restore round-trip + (if a shared golden vector exists) cross-platform conformance | M-L |
-| WI-7 | behavioral (final) | Acceptance on the emulator: import → create collection → assign → filter by chip → manage rename/delete → **backup → wipe → restore** preserves collections + membership. Evidence file → VERIFIED | M |
+| WI-7 | behavioral (final) | Acceptance on the emulator: import → create collection → assign → filter by chip → manage rename → **backup → wipe → restore** preserves collections + membership. (Delete UI is needs-design #1875 — out of this acceptance pass.) Evidence file → VERIFIED | M |
 
 ## Test catalogue
 
@@ -151,7 +151,8 @@ iOS (`vreader/`); library/in-reader search (#128 / #F); reorder; the Android `Bo
 - `LibraryViewModelCollectionsTest` (JVM, WI-3): chip select filters; "All" resets; deleting the
   selected collection resets to All; the `flatMapLatest` doesn't leak the previous selection's membership.
 - `CollectionShelfBarUiTest` / `AssignSheetUiTest` / `ManageSheetUiTest` (connected, WI-3/4/5):
-  chip select, checklist toggle persists, inline create, rename, delete + the duplicate-name error.
+  chip select, checklist toggle persists, inline create, inline rename. (Manage delete UI deferred —
+  needs-design #1875; the delete capability stays repo/VM-tested.)
 - `CollectionBackupRoundTripTest` (JVM/connected, WI-6): collect → `BackupCollectionsEnvelope` →
   restore → collections + membership preserved; **byte-stability** (same logical DB, different insert
   order → identical `collections.json`); restore merge goldens — same name / different case / different
@@ -176,6 +177,12 @@ iOS (`vreader/`); library/in-reader search (#128 / #F); reorder; the Android `Bo
   display order = createdAt; reorder deferred pending a cross-platform decision. **The manage sheet ships
   NO drag handles / no reorder affordance** — inert reorder UI is not acceptable (rule 51); reorder is
   tracked as a separate cross-platform feature/design decision, not a placeholder here.
+- **R7 — manage delete affordance is undesigned** (Gate-4 WI-5 round-2, rule 51): the committed
+  `CollectionsManageSheet` depicts list/create/rename + an Edit-mode chevron disclosure, but the
+  per-collection detail screen where **delete** lives is NOT depicted. The first WI-5 cut invented an
+  inline trash button (+ an invented nav-bar manage entry); both were removed. The manage sheet now
+  opens from the DESIGNED scoped-collection "edit collection" header and ships list + rename + create
+  only. Delete UI is deferred to **needs-design #1875**; the capability stays repo/VM-backed + tested.
 
 ## Backward compat
 


### PR DESCRIPTION
## Summary

Feature #127 WI-5 — the collections **manage** surface for the Android library.

- **`ScopedCollectionHeader`** (new `CollectionManageSheet.kt`): the designed `scope === 'collection'` header (back breadcrumb → All, serif collection name, "N books · edit collection" subtitle) — the designed entry into the manage sheet.
- **`ManageCollectionsSheet` / `ManageSheetContent`**: lists collections + book counts, tap-name inline rename, "New Collection" inline create (the design's `CollectionsManageSheet` list mode).
- **`LibraryScreen`**: renders the scoped header when a collection is selected; the nav pills live only in the All view (the scoped design has none).
- **Delete UI deferred** to needs-design **#1875** (the committed design routes delete behind an undepicted per-collection detail disclosure; rule 51). The delete *capability* stays repo/VM-backed + tested.

Part of feature #1869.

## Validation

- [x] Gate-4 Codex audit **ship-as-is** — 3 rounds: 2 rule-51 Mediums (invented nav pill + trash button) → 1 Medium (scoped-view pills) + 1 Low (file-size) → clean. Audit log: `.claude/codex-audits/feat-feature-127-wi-5-manage-sheet-audit.md`.
- [x] Build: main + unit + androidTest compile clean.
- [x] Gate-5 slice: **`ManageSheetUiTest` 3/3 connected** (vreader-test AVD API-35) — list+counts, inline rename, inline create. (The run needed adb-shell-congestion cleanup first — stale hung `getprop` shells wedged instrumentation twice; `adb kill-server` cleared it. Environment artifact, not a code defect.)
- [x] File sizes: CollectionSheets.kt 191, LibraryScreen.kt 292, CollectionManageSheet.kt ~210 (all <300).
- [x] Version bumped: android 0.13.5 → 0.13.6.

## Type of Change

- [x] New feature WI (Part of feature #1869)