### PR TITLE
feat(#129 WI-1): reader settings store + 5 themes

### DIFF
--- a/.claude/codex-audits/feat-feature-129-wi-1-settings-store-audit.md
+++ b/.claude/codex-audits/feat-feature-129-wi-1-settings-store-audit.md
@@ -1,0 +1,31 @@
+---
+branch: feat/feature-129-wi-1-settings-store
+threadId: bfp4j84th
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-29
+---
+
+# Gate-4 audit — feature #129 WI-1 (reader settings store + 5 themes, foundational)
+
+WI-1 adds the device-local reader display-settings foundation: `ReaderTheme` (5 themes, exact design
+RGB + `isDark`), `ReaderSettings` (value type + ranges/clamp helpers — no layout), `ReaderSettingsStore`
+(DataStore JSON-in-Preferences, the OpdsSourceStore/AiProviderStore precedent), and the VReaderApp DI
+singleton. Tests: `ReaderSettingsStoreTest`, `ReaderThemeTest` (JVM/Robolectric).
+
+## Round 1 (Codex `bfp4j84th`, gpt-5.5/high) — 1 Medium, 2 Low
+
+| file:line | severity | issue | resolution |
+|---|---|---|---|
+| `VReaderApp.kt` (DI) | Medium | The DataStore file under `filesDir` is eligible for **Android Auto Backup**, violating the WI-1 "device-local, NOT backed up" contract. | **FIXED** — moved the file to `appContext.noBackupFilesDir` (excluded from Auto Backup), matching the device-local contract (iOS keeps reader settings in UserDefaults, also out of the backup). |
+| `ReaderSettingsStore.kt:45` | Low | Writes clamped only the field being set, so a previously hand-edited/older out-of-range numeric field would survive an unrelated setter — not truly "clamped on write." | **FIXED** — `update` now `.normalized()`s ALL numeric fields before encoding, so any stale out-of-range value is healed on the next write. |
+| `ReaderSettings.kt:36` | Low | `Float.coerceIn` does not sanitize `NaN`/±Inf — a non-finite setter input could reach JSON encoding and fail. | **FIXED** — the clamp helpers are now total: a non-finite input falls back to the field default before coercing. New test `clamp_sanitizesNonFinite`. |
+
+The auditor confirmed: no DataStore single-instance-per-file hazard (the store is a lazy process
+singleton; no second factory for the same file), no Flow-concurrency issue, no dead code.
+
+## Verdict
+
+**ship-as-is.** One round, 1 Medium + 2 Low — all fixed. Tests green (ReaderSettingsStoreTest 5/0 incl.
+the new NaN case, ReaderThemeTest 3/0). Foundational WI — no device verification required (Gate-5a: unit
+tests + audit sufficient for a DTO/store with no user-observable behavior yet).

--- a/android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt
@@ -53,6 +53,19 @@ class AppContainer(context: Context) {
         com.vreader.app.data.CollectionRepository(database.collectionDao())
     }
 
+    // feature #129 — reader display settings. A device-local DataStore (the OpdsSourceStore /
+    // AiProviderStore precedent), global (not per-book), process-singleton so a settings change
+    // propagates to whatever reader is open. Stored under noBackupFilesDir — display prefs are
+    // per-device (NOT in the backup contract), so they must be excluded from Android Auto Backup.
+    private val readerSettingsDataStore: androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences> by lazy {
+        androidx.datastore.preferences.core.PreferenceDataStoreFactory.create {
+            File(appContext.noBackupFilesDir, "reader_settings.preferences_pb")
+        }
+    }
+    val readerSettingsStore: com.vreader.app.reader.settings.ReaderSettingsStore by lazy {
+        com.vreader.app.reader.settings.ReaderSettingsStore(readerSettingsDataStore)
+    }
+
     /** Process-lifetime scope for fire-and-forget writes that must outlive a screen
      *  (e.g. the reader's onStop position flush — it must finish even as the activity
      *  is being torn down). */

--- a/android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettings.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettings.kt
@@ -1,0 +1,42 @@
+// Purpose: feature #129 WI-1 (#110 Phase 3) — the reader "Display" settings value type. iOS parity:
+// `TypographySettings` + `ReaderThemeV2`. Global (not per-book), device-local (not backed up). The
+// layout (scroll/paged) toggle is a tracked follow-up — NOT in #129 (TXT/MD are scroll-only). Ranges
+// are the committed design's slider bounds (vreader-panels.jsx ReaderSettingsSheet).
+package com.vreader.app.reader.settings
+
+/** The two designed font families (Source Serif 4 / Inter → platform serif / sans). */
+enum class ReaderFontFamily { Serif, Sans }
+
+/**
+ * The display settings applied across the reflowable readers (EPUB/TXT/MD/AZW3); PDF reads only [theme]
+ * (its background). A pure value type — the [ReaderSettingsStore] persists it, the hosts apply it.
+ */
+data class ReaderSettings(
+    val theme: ReaderTheme = ReaderTheme.Paper,
+    val fontFamily: ReaderFontFamily = ReaderFontFamily.Serif,
+    val fontSizeSp: Float = DEFAULT_FONT_SIZE,
+    val lineSpacing: Float = DEFAULT_LINE_SPACING,
+    val marginDp: Float = DEFAULT_MARGIN,
+) {
+    companion object {
+        // Defaults = the current hardcoded look (so an install with no stored settings is unchanged).
+        const val DEFAULT_FONT_SIZE = 18f
+        const val DEFAULT_LINE_SPACING = 1.5f
+        const val DEFAULT_MARGIN = 20f
+
+        // Slider bounds from the design (vreader-panels.jsx): font-size 13–26pt, line-spacing 1.3–2.0,
+        // margin 16–48px.
+        const val MIN_FONT_SIZE = 13f
+        const val MAX_FONT_SIZE = 26f
+        const val MIN_LINE_SPACING = 1.3f
+        const val MAX_LINE_SPACING = 2.0f
+        const val MIN_MARGIN = 16f
+        const val MAX_MARGIN = 48f
+
+        // Total clamps: a non-finite (NaN/±Inf) input — which `coerceIn` does NOT sanitize and which
+        // would fail JSON encoding — falls back to the default before coercing into range.
+        fun clampFontSize(v: Float) = (if (v.isFinite()) v else DEFAULT_FONT_SIZE).coerceIn(MIN_FONT_SIZE, MAX_FONT_SIZE)
+        fun clampLineSpacing(v: Float) = (if (v.isFinite()) v else DEFAULT_LINE_SPACING).coerceIn(MIN_LINE_SPACING, MAX_LINE_SPACING)
+        fun clampMargin(v: Float) = (if (v.isFinite()) v else DEFAULT_MARGIN).coerceIn(MIN_MARGIN, MAX_MARGIN)
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt
@@ -1,0 +1,75 @@
+// Purpose: feature #129 WI-1 (#110 Phase 3) — persists the reader "Display" [ReaderSettings] in
+// DataStore (the OpdsSourceStore / AiProviderStore JSON-in-Preferences precedent). Global, device-
+// local (NOT backed up — display prefs are per-device, like iOS UserDefaults). Exposes a reactive
+// [settings] Flow the reader hosts collect, and clamped suspend setters. Enum fields are stored by
+// NAME so an unknown/old value decodes to the default (forward-compatible).
+package com.vreader.app.reader.settings
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/** The persisted shape — enums as String names for forward-compat; clamped on read AND write. */
+@Serializable
+private data class ReaderSettingsState(
+    val theme: String = ReaderTheme.Paper.name,
+    val fontFamily: String = ReaderFontFamily.Serif.name,
+    val fontSizeSp: Float = ReaderSettings.DEFAULT_FONT_SIZE,
+    val lineSpacing: Float = ReaderSettings.DEFAULT_LINE_SPACING,
+    val marginDp: Float = ReaderSettings.DEFAULT_MARGIN,
+)
+
+class ReaderSettingsStore(
+    private val dataStore: DataStore<Preferences>,
+    private val json: Json = Json { ignoreUnknownKeys = true; encodeDefaults = true },
+) {
+    /** The reactive settings stream — a host collects this (`collectAsStateWithLifecycle`) and applies
+     *  live; emits the defaults until the user changes something. */
+    val settings: Flow<ReaderSettings> = dataStore.data.map { read(it).toSettings() }
+
+    /** A one-shot read (the current settings) — for a host's initial config at open. */
+    suspend fun current(): ReaderSettings = read(dataStore.data.first()).toSettings()
+
+    suspend fun setTheme(theme: ReaderTheme) = update { it.copy(theme = theme.name) }
+    suspend fun setFontFamily(family: ReaderFontFamily) = update { it.copy(fontFamily = family.name) }
+    suspend fun setFontSize(sp: Float) = update { it.copy(fontSizeSp = ReaderSettings.clampFontSize(sp)) }
+    suspend fun setLineSpacing(v: Float) = update { it.copy(lineSpacing = ReaderSettings.clampLineSpacing(v)) }
+    suspend fun setMargin(dp: Float) = update { it.copy(marginDp = ReaderSettings.clampMargin(dp)) }
+
+    private suspend fun update(transform: (ReaderSettingsState) -> ReaderSettingsState) {
+        // Normalize EVERY numeric field on write (not just the one being set) so a previously
+        // hand-edited / older out-of-range value is healed on the next write — truly "clamped on write".
+        dataStore.edit { prefs -> prefs[KEY] = json.encodeToString(transform(read(prefs)).normalized()) }
+    }
+
+    private fun ReaderSettingsState.normalized() = copy(
+        fontSizeSp = ReaderSettings.clampFontSize(fontSizeSp),
+        lineSpacing = ReaderSettings.clampLineSpacing(lineSpacing),
+        marginDp = ReaderSettings.clampMargin(marginDp),
+    )
+
+    private fun read(prefs: Preferences): ReaderSettingsState {
+        val raw = prefs[KEY] ?: return ReaderSettingsState()
+        return runCatching { json.decodeFromString<ReaderSettingsState>(raw) }.getOrDefault(ReaderSettingsState())
+    }
+
+    /** Map the persisted state → the value type, defaulting unknown enum names and clamping ranges
+     *  (so a hand-edited / older file can never yield an out-of-range or unreadable setting). */
+    private fun ReaderSettingsState.toSettings() = ReaderSettings(
+        theme = runCatching { ReaderTheme.valueOf(theme) }.getOrDefault(ReaderTheme.Paper),
+        fontFamily = runCatching { ReaderFontFamily.valueOf(fontFamily) }.getOrDefault(ReaderFontFamily.Serif),
+        fontSizeSp = ReaderSettings.clampFontSize(fontSizeSp),
+        lineSpacing = ReaderSettings.clampLineSpacing(lineSpacing),
+        marginDp = ReaderSettings.clampMargin(marginDp),
+    )
+
+    companion object {
+        private val KEY = stringPreferencesKey("reader_settings_json")
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderTheme.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderTheme.kt
@@ -1,0 +1,25 @@
+// Purpose: feature #129 WI-1 (#110 Phase 3) — the 5 reader themes for the "Display" settings, iOS
+// `ReaderThemeV2` parity. Exact RGB lifted from the committed design bundle
+// `dev-docs/designs/vreader-fidelity-v1/project/vreader-themes.jsx` (the SAME identity iOS uses;
+// ADR-0001). Pure value type (Compose `Color`, no Android runtime) so it's JVM-unit-testable.
+package com.vreader.app.reader.settings
+
+import androidx.compose.ui.graphics.Color
+
+/**
+ * A reader theme: the page [background], the primary text [ink], the [accent] (per-theme oxblood/amber),
+ * and [isDark] (the color-scheme hint). The 5 themes mirror iOS `ReaderThemeV2` (paper/sepia/dark/oled/
+ * photo); colors are the design bundle's exact values.
+ */
+enum class ReaderTheme(
+    val background: Color,
+    val ink: Color,
+    val accent: Color,
+    val isDark: Boolean,
+) {
+    Paper(background = Color(0xFFF4EEE0), ink = Color(0xFF1D1A14), accent = Color(0xFF8C2F2F), isDark = false),
+    Sepia(background = Color(0xFFE6D6B6), ink = Color(0xFF3A2913), accent = Color(0xFF7A3A1F), isDark = false),
+    Dark(background = Color(0xFF1A1815), ink = Color(0xFFD8D2C5), accent = Color(0xFFD6885A), isDark = true),
+    Oled(background = Color(0xFF000000), ink = Color(0xFFB9B6B0), accent = Color(0xFFD6885A), isDark = true),
+    Photo(background = Color(0xFF2A2520), ink = Color(0xFFE8E0D0), accent = Color(0xFFE8B465), isDark = true),
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/settings/ReaderSettingsStoreTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/settings/ReaderSettingsStoreTest.kt
@@ -1,0 +1,74 @@
+package com.vreader.app.reader.settings
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+/**
+ * Feature #129 WI-1 — [ReaderSettingsStore] persists the reader Display settings in DataStore: defaults
+ * when unset, round-trips each field, clamps out-of-range writes, and the reactive [settings] flow emits
+ * the latest. Robolectric (DataStore needs a real file + context); a fresh file per test.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ReaderSettingsStoreTest {
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var store: ReaderSettingsStore
+
+    @Before fun setUp() {
+        val file = File(context.cacheDir, "reader-settings-${System.nanoTime()}.preferences_pb")
+        dataStore = PreferenceDataStoreFactory.create { file }
+        store = ReaderSettingsStore(dataStore)
+    }
+
+    @Test fun default_whenUnset() = runBlocking {
+        assertEquals(ReaderSettings(), store.current())
+    }
+
+    @Test fun roundTrips_eachField() = runBlocking {
+        store.setTheme(ReaderTheme.Dark)
+        store.setFontFamily(ReaderFontFamily.Sans)
+        store.setFontSize(22f)
+        store.setLineSpacing(1.8f)
+        store.setMargin(30f)
+
+        val s = store.current()
+        assertEquals(ReaderTheme.Dark, s.theme)
+        assertEquals(ReaderFontFamily.Sans, s.fontFamily)
+        assertEquals(22f, s.fontSizeSp, 1e-4f)
+        assertEquals(1.8f, s.lineSpacing, 1e-4f)
+        assertEquals(30f, s.marginDp, 1e-4f)
+    }
+
+    @Test fun clamps_outOfRange() = runBlocking {
+        store.setFontSize(99f); assertEquals(26f, store.current().fontSizeSp, 1e-4f)   // max
+        store.setFontSize(5f);  assertEquals(13f, store.current().fontSizeSp, 1e-4f)   // min
+        store.setLineSpacing(3f);   assertEquals(2.0f, store.current().lineSpacing, 1e-4f)
+        store.setLineSpacing(1.0f); assertEquals(1.3f, store.current().lineSpacing, 1e-4f)
+        store.setMargin(100f); assertEquals(48f, store.current().marginDp, 1e-4f)
+        store.setMargin(1f);   assertEquals(16f, store.current().marginDp, 1e-4f)
+    }
+
+    @Test fun clamp_sanitizesNonFinite() = runBlocking {
+        // NaN/±Inf must not corrupt the store — they fall back to the defaults (the clamp is total).
+        store.setFontSize(Float.NaN);                  assertEquals(ReaderSettings.DEFAULT_FONT_SIZE, store.current().fontSizeSp, 1e-4f)
+        store.setLineSpacing(Float.POSITIVE_INFINITY); assertEquals(ReaderSettings.DEFAULT_LINE_SPACING, store.current().lineSpacing, 1e-4f)
+        store.setMargin(Float.NaN);                    assertEquals(ReaderSettings.DEFAULT_MARGIN, store.current().marginDp, 1e-4f)
+    }
+
+    @Test fun settingsFlow_emitsTheLatest() = runBlocking {
+        assertEquals(ReaderTheme.Paper, store.settings.first().theme)   // default
+        store.setTheme(ReaderTheme.Sepia)
+        assertEquals(ReaderTheme.Sepia, store.settings.first().theme)
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/settings/ReaderThemeTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/settings/ReaderThemeTest.kt
@@ -1,0 +1,46 @@
+package com.vreader.app.reader.settings
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Feature #129 WI-1 — the 5 reader themes' colors must match the committed design bundle
+ * (vreader-themes.jsx) exactly, and `isDark` must classify them correctly. Pure JVM (Compose `Color`
+ * is a value type).
+ */
+class ReaderThemeTest {
+    @Test fun fiveThemes_exist() {
+        assertEquals(5, ReaderTheme.entries.size)
+    }
+
+    @Test fun themeColors_matchTheDesignBundleRgb() {
+        assertEquals(Color(0xFFF4EEE0), ReaderTheme.Paper.background)
+        assertEquals(Color(0xFF1D1A14), ReaderTheme.Paper.ink)
+        assertEquals(Color(0xFF8C2F2F), ReaderTheme.Paper.accent)
+
+        assertEquals(Color(0xFFE6D6B6), ReaderTheme.Sepia.background)
+        assertEquals(Color(0xFF3A2913), ReaderTheme.Sepia.ink)
+        assertEquals(Color(0xFF7A3A1F), ReaderTheme.Sepia.accent)
+
+        assertEquals(Color(0xFF1A1815), ReaderTheme.Dark.background)
+        assertEquals(Color(0xFFD8D2C5), ReaderTheme.Dark.ink)
+
+        assertEquals(Color(0xFF000000), ReaderTheme.Oled.background)
+        assertEquals(Color(0xFFB9B6B0), ReaderTheme.Oled.ink)
+
+        assertEquals(Color(0xFF2A2520), ReaderTheme.Photo.background)
+        assertEquals(Color(0xFFE8E0D0), ReaderTheme.Photo.ink)
+        assertEquals(Color(0xFFE8B465), ReaderTheme.Photo.accent)
+    }
+
+    @Test fun isDark_classifiesLightVsDark() {
+        assertFalse(ReaderTheme.Paper.isDark)
+        assertFalse(ReaderTheme.Sepia.isDark)
+        assertTrue(ReaderTheme.Dark.isDark)
+        assertTrue(ReaderTheme.Oled.isDark)
+        assertTrue(ReaderTheme.Photo.isDark)
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.13.8
-versionCode=81
+versionName=0.13.9
+versionCode=82


### PR DESCRIPTION
## Summary

Feature #129 WI-1 (foundational) — the device-local reader display-settings foundation.

- **`ReaderTheme`** — the 5 reader themes (Paper/Sepia/Dark/Oled/Photo) with exact design-bundle RGB + `isDark` (iOS `ReaderThemeV2` parity).
- **`ReaderSettings`** — value type (theme/fontFamily/fontSizeSp/lineSpacing/marginDp; **no layout** — that's a tracked follow-up) + total clamp helpers (ranges 13–26 / 1.3–2.0 / 16–48; non-finite → default).
- **`ReaderSettingsStore`** — DataStore JSON-in-Preferences (the OpdsSourceStore/AiProviderStore precedent) under **`noBackupFilesDir`** (device-local, excluded from Auto Backup); enums stored by name (forward-compat); normalizes all numeric fields on write; reactive `settings` Flow.
- VReaderApp DI singleton.

Part of feature #1879.

## Validation

- [x] Gate-4 Codex audit **ship-as-is** — 1 round: Medium (`filesDir` → `noBackupFilesDir`, Auto-Backup exclusion) + 2 Lows (clamp-all-on-write, NaN sanitization), all fixed. Audit log: `.claude/codex-audits/feat-feature-129-wi-1-settings-store-audit.md`.
- [x] **ReaderSettingsStoreTest 5/0** (round-trip/clamp/default/NaN/Flow) + **ReaderThemeTest 3/0** (the 5 themes' RGB + isDark).
- [x] Gate-5a: foundational WI (DTO/store, no user-observable behavior) — unit + audit sufficient.
- [x] Version bumped: android 0.13.8 → 0.13.9.

## Type of Change

- [x] Foundational feature WI (Part of feature #1879)