### PR TITLE
feat(#129 WI-2): Display settings sheet

### DIFF
--- a/.claude/codex-audits/feat-feature-129-wi-2-display-sheet-audit.md
+++ b/.claude/codex-audits/feat-feature-129-wi-2-display-sheet-audit.md
@@ -1,0 +1,49 @@
+---
+branch: feat/feature-129-wi-2-display-sheet
+threadId: brrm1e801
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-06-29
+---
+
+# Gate-4 audit — feature #129 WI-2 (the "Display" settings sheet)
+
+WI-2 adds the designed "Display" `ReaderSettingsSheet` (vreader-panels.jsx): a Theme 5-swatch row, a
+Font serif/sans toggle, and Size/Line-spacing/Margin sliders, bound to `ReaderSettings` + callbacks
+(brightness + the layout toggle omitted per #129 scope). Pure function of state; the content is extracted
+(`ReaderSettingsSheetContent`) for direct UI testing. Files: `ReaderSettingsSheet.kt`,
+`ReaderSettingsSheetUiTest.kt` (connected), + `ReaderTheme.kt` (`displayName`).
+
+## Round 1 (Codex `brrm1e801`, gpt-5.5/high) — 1 Medium, 2 Low
+
+| file | severity | issue | resolution |
+|---|---|---|---|
+| `ReaderSettingsSheet.kt` | Medium | Sheet chrome/content colors were hard-coded to `VReaderColors` (the Paper palette) instead of the active reader theme — so Dark/OLED/Photo settings rendered on a white sheet with paper ink/accent, missing the design's `theme={t}` surface. | **FIXED** — the sheet now derives all tokens from `settings.theme`: `containerColor`/background = `theme.background`, title/labels = `theme.ink`/sub, the selected swatch ring + slider tint = `theme.accent`, the font toggle's track/fill follow the theme's `isDark` (the design's `#3a3530`/`#fff`). The sheet renders in the active theme. |
+| `ReaderTheme` swatch label | Low | `ReaderTheme.Oled` rendered as `Oled`; the design label is `OLED`. | **FIXED** — added `ReaderTheme.displayName` (`OLED` for Oled, stable enum `name` kept for persistence/test tags); the swatch shows `displayName`. New tests `displayName_capitalizesOled` (JVM) + an `OLED` assertion in the connected test. |
+| `SegmentedToggle` | Low | The generic toggle carried `ReaderFontFamily`-specific font logic — a misleading abstraction. | **FIXED** — replaced with a dedicated `FontSegmentedToggle` (no misused generic). |
+
+The auditor found no Critical/High; design fidelity to `vreader-panels.jsx` was the main theme.
+
+## Verdict
+
+**ship-as-is.** One round, 1 Medium + 2 Low — all fixed.
+
+## Gate-5a verification note (connected-test environment flakiness — rule 47/52)
+
+`ReaderSettingsSheetUiTest` (connected: theme swatch → onTheme, font toggle → onFontFamily, size slider
+→ onFontSize, all 5 themes + OLED label + 3 sliders) could **not be landed green this session** — three
+consecutive runs failed at the **instrumentation platform** level, NOT on a test assertion: two wedged at
+the `connectedDebugAndroidTest` stage (the documented adb-shell-congestion class — the emulator had been
+up 2h24m) and the third, on a freshly cold-booted emulator + cleaned adb + a lighter mac, **crashed the
+AndroidX Unified Test Platform** (`com.google.testing.platform.core.telemetry.TelemetryKt.createEvent` →
+`NonInteractiveServerStrategy`) after 12 min with `tests="0"` (no test ever executed). This is a tooling/
+environment failure on a host that's been running heavy build+audit+emulator workloads for hours.
+
+Per rule 47/52 ("do not let tooling flakiness block a code-proven WI"), the WI is **accepted** on the
+evidence that the code is sound: (1) main + androidTest **compile clean**; (2) JVM `ReaderThemeTest` **4/0**
+incl. `displayName`; (3) this Gate-4 audit is **ship-as-is**; (4) the **sibling connected sheet tests use
+the identical harness + pattern and merged green** — `ManageSheetUiTest` 3/3 (#127 WI-5), `AssignSheetUiTest`
+(#127 WI-4), `CollectionShelfBarUiTest` (#127 WI-3) — same `createComposeRule` + extracted-content-composable
++ `testTag`/`useUnmergedTree`. The live connected confirmation of the sheet **rides to WI-8's acceptance
+pass** (a fresh cold-booted emulator). This is a behavioral WI whose UI is pure (no host wiring yet — WI-3
+wires it), so the JVM + audit + sibling-precedent are an adequate pre-merge slice.

--- a/android/app/src/androidTest/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheetUiTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheetUiTest.kt
@@ -1,0 +1,63 @@
+package com.vreader.app.reader.settings
+
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Feature #129 WI-2 — the designed "Display" `ReaderSettingsSheetContent`: a theme swatch reports its
+ * theme, the font toggle reports its family, the size slider reports a value, and all 5 themes + 3
+ * sliders render. Renders the content composable directly (the #127 sheet-test precedent).
+ */
+@RunWith(AndroidJUnit4::class)
+class ReaderSettingsSheetUiTest {
+    @get:Rule val compose = createComposeRule()
+    private val defaults = ReaderSettings()
+
+    private fun render(
+        onTheme: (ReaderTheme) -> Unit = {},
+        onFont: (ReaderFontFamily) -> Unit = {},
+        onSize: (Float) -> Unit = {},
+        onSpacing: (Float) -> Unit = {},
+        onMargin: (Float) -> Unit = {},
+    ) = compose.setContent { ReaderSettingsSheetContent(defaults, onTheme, onFont, onSize, onSpacing, onMargin) }
+
+    @Test fun tappingThemeSwatch_reportsTheTheme() {
+        var picked: ReaderTheme? = null
+        render(onTheme = { picked = it })
+        compose.onNodeWithTag("theme-Dark", useUnmergedTree = true).performClick()
+        assertEquals(ReaderTheme.Dark, picked)
+    }
+
+    @Test fun tappingFontToggle_reportsTheFamily() {
+        var family: ReaderFontFamily? = null
+        render(onFont = { family = it })
+        compose.onNodeWithTag("font-sans", useUnmergedTree = true).performClick()
+        assertEquals(ReaderFontFamily.Sans, family)
+    }
+
+    @Test fun draggingSizeSlider_reportsTheValue() {
+        var size: Float? = null
+        render(onSize = { size = it })
+        compose.onNodeWithTag("size-slider").performSemanticsAction(SemanticsActions.SetProgress) { it(22f) }
+        assertEquals(22f, size!!, 1e-3f)
+    }
+
+    @Test fun rendersAllFiveThemesAndThreeSliders() {
+        render()
+        compose.onNodeWithText("Display").assertExists()
+        ReaderTheme.entries.forEach { compose.onNodeWithTag("theme-${it.name}", useUnmergedTree = true).assertExists() }
+        compose.onNodeWithText("OLED", useUnmergedTree = true).assertExists()   // displayName (not "Oled")
+        compose.onNodeWithTag("size-slider").assertExists()
+        compose.onNodeWithTag("spacing-slider").assertExists()
+        compose.onNodeWithTag("margin-slider").assertExists()
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheet.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheet.kt
@@ -1,0 +1,195 @@
+// Purpose: feature #129 WI-2 (#110 Phase 3) — the designed "Display" settings sheet
+// (vreader-panels.jsx ReaderSettingsSheet): a Theme 5-swatch row, a Font serif/sans toggle, and
+// Size / Line-spacing / Margin sliders. The sheet renders in the ACTIVE theme's colors (the design's
+// `theme={t}` surface), so Dark/OLED/Photo look right. Pure function of [ReaderSettings] + callbacks;
+// the content is extracted ([ReaderSettingsSheetContent]) for direct UI testing (the #127 precedent).
+// Brightness (device-brightness) + the layout toggle are omitted per #129 scope (tracked follow-ups).
+package com.vreader.app.reader.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.vreader.app.ui.theme.VReaderFonts
+import kotlin.math.roundToInt
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReaderSettingsSheet(
+    settings: ReaderSettings,
+    onTheme: (ReaderTheme) -> Unit,
+    onFontFamily: (ReaderFontFamily) -> Unit,
+    onFontSize: (Float) -> Unit,
+    onLineSpacing: (Float) -> Unit,
+    onMargin: (Float) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = settings.theme.background,   // the sheet renders in the active theme
+        modifier = Modifier.testTag("display-sheet"),
+    ) {
+        ReaderSettingsSheetContent(settings, onTheme, onFontFamily, onFontSize, onLineSpacing, onMargin)
+    }
+}
+
+/** The sheet content (extracted for direct UI testing). Colors derive from the active [ReaderSettings.theme]. */
+@Composable
+fun ReaderSettingsSheetContent(
+    settings: ReaderSettings,
+    onTheme: (ReaderTheme) -> Unit,
+    onFontFamily: (ReaderFontFamily) -> Unit,
+    onFontSize: (Float) -> Unit,
+    onLineSpacing: (Float) -> Unit,
+    onMargin: (Float) -> Unit,
+) {
+    val theme = settings.theme
+    val ink = theme.ink
+    val sub = theme.ink.copy(alpha = 0.6f)
+    val accent = theme.accent
+    val sliderColors = SliderDefaults.colors(thumbColor = accent, activeTrackColor = accent, inactiveTrackColor = ink.copy(alpha = 0.18f))
+
+    Column(Modifier.background(theme.background).padding(horizontal = 18.dp).testTag("display-sheet-content")) {
+        Text(
+            "Display",
+            Modifier.padding(bottom = 14.dp),
+            color = ink, fontFamily = VReaderFonts.Serif, fontSize = 18.sp, fontWeight = FontWeight.SemiBold,
+        )
+
+        SectionLabel("Theme", sub)
+        Row(Modifier.fillMaxWidth().padding(top = 10.dp), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            ReaderTheme.entries.forEach { swatch ->
+                ThemeSwatch(swatch, selected = theme == swatch, ringColor = accent, labelColor = sub, onClick = { onTheme(swatch) }, modifier = Modifier.weight(1f))
+            }
+        }
+
+        SectionLabel("Font", sub, topPadding = 22.dp)
+        FontSegmentedToggle(selected = settings.fontFamily, isDark = theme.isDark, ink = ink, onSelect = onFontFamily)
+
+        SectionLabel("Size", sub, topPadding = 22.dp)
+        Slider(
+            value = settings.fontSizeSp,
+            onValueChange = { onFontSize(it.roundToInt().toFloat()) },
+            valueRange = ReaderSettings.MIN_FONT_SIZE..ReaderSettings.MAX_FONT_SIZE,
+            colors = sliderColors,
+            modifier = Modifier.testTag("size-slider"),
+        )
+
+        SectionLabel("Line spacing", sub, topPadding = 6.dp)
+        Slider(
+            value = settings.lineSpacing,
+            onValueChange = onLineSpacing,
+            valueRange = ReaderSettings.MIN_LINE_SPACING..ReaderSettings.MAX_LINE_SPACING,
+            colors = sliderColors,
+            modifier = Modifier.testTag("spacing-slider"),
+        )
+
+        SectionLabel("Margin", sub, topPadding = 6.dp)
+        Slider(
+            value = settings.marginDp,
+            onValueChange = onMargin,
+            valueRange = ReaderSettings.MIN_MARGIN..ReaderSettings.MAX_MARGIN,
+            colors = sliderColors,
+            modifier = Modifier.testTag("margin-slider").padding(bottom = 24.dp),
+        )
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String, color: Color, topPadding: Dp = 0.dp) {
+    Text(
+        text,
+        Modifier.padding(top = topPadding),
+        color = color, fontFamily = VReaderFonts.Sans, fontSize = 12.sp, fontWeight = FontWeight.SemiBold,
+    )
+}
+
+/** A theme swatch: the theme's background with a serif "Aa" in its ink; the selected one gets an accent ring. */
+@Composable
+private fun ThemeSwatch(
+    theme: ReaderTheme,
+    selected: Boolean,
+    ringColor: Color,
+    labelColor: Color,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier.testTag("theme-${theme.name}").clickable { onClick() }, horizontalAlignment = Alignment.CenterHorizontally) {
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f)
+                .clip(RoundedCornerShape(12.dp))
+                .background(theme.background)
+                .then(
+                    if (selected) Modifier.border(2.5.dp, ringColor, RoundedCornerShape(12.dp))
+                    else Modifier.border(0.5.dp, theme.ink.copy(alpha = 0.18f), RoundedCornerShape(12.dp))
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text("Aa", color = theme.ink, fontFamily = VReaderFonts.Serif, fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
+        }
+        Text(
+            theme.displayName,
+            Modifier.padding(top = 6.dp),
+            color = labelColor, fontSize = 11.sp,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+        )
+    }
+}
+
+/** The Font serif/sans segmented toggle — dedicated (the design's `t.isDark ? '#3a3530' : '#fff'` fill). */
+@Composable
+private fun FontSegmentedToggle(selected: ReaderFontFamily, isDark: Boolean, ink: Color, onSelect: (ReaderFontFamily) -> Unit) {
+    val trackBg = ink.copy(alpha = if (isDark) 0.06f else 0.05f)
+    val selectedFill = if (isDark) Color(0xFF3A3530) else Color.White
+    Row(
+        Modifier.fillMaxWidth().padding(top = 10.dp).clip(RoundedCornerShape(12.dp)).background(trackBg).padding(3.dp),
+        horizontalArrangement = Arrangement.spacedBy(3.dp),
+    ) {
+        listOf(
+            ReaderFontFamily.Serif to ("Source Serif" to VReaderFonts.Serif),
+            ReaderFontFamily.Sans to ("Inter" to VReaderFonts.Sans),
+        ).forEach { (family, labelFont) ->
+            val (label, font) = labelFont
+            val isOn = family == selected
+            Box(
+                Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(if (isOn) selectedFill else Color.Transparent)
+                    .clickable { onSelect(family) }
+                    .testTag("font-${family.name.lowercase()}")
+                    .padding(vertical = 10.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(label, color = ink, fontFamily = font, fontSize = 15.sp, fontWeight = if (isOn) FontWeight.SemiBold else FontWeight.Medium)
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderTheme.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderTheme.kt
@@ -16,10 +16,12 @@ enum class ReaderTheme(
     val ink: Color,
     val accent: Color,
     val isDark: Boolean,
+    /** The user-facing label (the design capitalizes OLED); enum [name] stays the stable persistence/test key. */
+    val displayName: String,
 ) {
-    Paper(background = Color(0xFFF4EEE0), ink = Color(0xFF1D1A14), accent = Color(0xFF8C2F2F), isDark = false),
-    Sepia(background = Color(0xFFE6D6B6), ink = Color(0xFF3A2913), accent = Color(0xFF7A3A1F), isDark = false),
-    Dark(background = Color(0xFF1A1815), ink = Color(0xFFD8D2C5), accent = Color(0xFFD6885A), isDark = true),
-    Oled(background = Color(0xFF000000), ink = Color(0xFFB9B6B0), accent = Color(0xFFD6885A), isDark = true),
-    Photo(background = Color(0xFF2A2520), ink = Color(0xFFE8E0D0), accent = Color(0xFFE8B465), isDark = true),
+    Paper(background = Color(0xFFF4EEE0), ink = Color(0xFF1D1A14), accent = Color(0xFF8C2F2F), isDark = false, displayName = "Paper"),
+    Sepia(background = Color(0xFFE6D6B6), ink = Color(0xFF3A2913), accent = Color(0xFF7A3A1F), isDark = false, displayName = "Sepia"),
+    Dark(background = Color(0xFF1A1815), ink = Color(0xFFD8D2C5), accent = Color(0xFFD6885A), isDark = true, displayName = "Dark"),
+    Oled(background = Color(0xFF000000), ink = Color(0xFFB9B6B0), accent = Color(0xFFD6885A), isDark = true, displayName = "OLED"),
+    Photo(background = Color(0xFF2A2520), ink = Color(0xFFE8E0D0), accent = Color(0xFFE8B465), isDark = true, displayName = "Photo"),
 }

--- a/android/app/src/test/kotlin/com/vreader/app/reader/settings/ReaderThemeTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/settings/ReaderThemeTest.kt
@@ -36,6 +36,14 @@ class ReaderThemeTest {
         assertEquals(Color(0xFFE8B465), ReaderTheme.Photo.accent)
     }
 
+    @Test fun displayName_capitalizesOled() {
+        assertEquals("OLED", ReaderTheme.Oled.displayName)   // design label is OLED, not "Oled"
+        assertEquals("Paper", ReaderTheme.Paper.displayName)
+        assertEquals("Sepia", ReaderTheme.Sepia.displayName)
+        assertEquals("Dark", ReaderTheme.Dark.displayName)
+        assertEquals("Photo", ReaderTheme.Photo.displayName)
+    }
+
     @Test fun isDark_classifiesLightVsDark() {
         assertFalse(ReaderTheme.Paper.isDark)
         assertFalse(ReaderTheme.Sepia.isDark)

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.13.9
-versionCode=82
+versionName=0.13.10
+versionCode=83


### PR DESCRIPTION
## Summary

Feature #129 WI-2 — the designed "Display" `ReaderSettingsSheet` (vreader-panels.jsx): a Theme 5-swatch row, a Font serif/sans toggle, and Size/Line-spacing/Margin sliders, bound to `ReaderSettings` + callbacks (brightness + the layout toggle omitted per #129 scope). The sheet **renders in the active theme's colors**. Pure function of state; content extracted (`ReaderSettingsSheetContent`) for direct UI testing — no host wiring yet (WI-3 wires it into the chrome).

Part of feature #1879.

## Validation

- [x] Gate-4 Codex audit **ship-as-is** — 1 round: Medium (theme-driven sheet colors) + 2 Lows (OLED `displayName`, dedicated `FontSegmentedToggle`), all fixed. Audit log: `.claude/codex-audits/feat-feature-129-wi-2-display-sheet-audit.md`.
- [x] **JVM `ReaderThemeTest` 4/0** (incl. `displayName_capitalizesOled`); main + androidTest compile clean.
- [⚠] **Connected `ReaderSettingsSheetUiTest` blocked by instrumentation-platform flakiness** this session — 3 runs failed at the UTP/`connectedDebugAndroidTest` level (2 wedges + 1 `TelemetryKt` UTP crash, `tests="0"`, NOT a code defect; the host's been running heavy workloads for hours). **Accepted per rule 47/52** on the compile + JVM + audit + **green-sibling-precedent** (`ManageSheetUiTest` 3/3, `AssignSheetUiTest`, `CollectionShelfBarUiTest` — identical `createComposeRule` + extracted-content + `testTag`/`useUnmergedTree`). The sheet's live confirmation rides to **WI-8 acceptance** (fresh emulator).
- [x] Version bumped: android 0.13.9 → 0.13.10.

## Type of Change

- [x] Feature WI (Part of feature #1879)