### PR TITLE
feat(#129 WI-3): ReaderBottomChrome shell

### DIFF
--- a/.claude/codex-audits/feat-feature-129-wi-3-chrome-audit.md
+++ b/.claude/codex-audits/feat-feature-129-wi-3-chrome-audit.md
@@ -1,0 +1,52 @@
+---
+branch: feat/feature-129-wi-3-chrome
+threadId: b7rxlgpom
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-06-29
+---
+
+# Gate-4 audit — feature #129 WI-3 (the ReaderBottomChrome shell)
+
+WI-3 adds the designed reader bottom chrome (`ReaderBottomChrome`): an interactive progress scrubber +
+a Display-only toolbar (Contents/Notes/AI omitted until F/D — the LibraryScreen "omit non-functional
+controls, no dead placeholders" precedent + the Gate-2 ruling). Standalone composable; per-host wiring
+rides with each host's application (WI-4..7). Files: `reader/chrome/ReaderBottomChrome.kt`,
+`ReaderBottomChromeUiTest.kt`.
+
+## Round 1 (Codex `b7rxlgpom`, gpt-5.5/high) — 1 High, 2 Medium, 1 Low
+
+| file | severity | issue | resolution |
+|---|---|---|---|
+| `ReaderBottomChrome.kt` | High | The thumb's RIGHT edge (not center) was placed at `progress`; at progress≈0 the parent width collapsed so the 14dp thumb could shrink/disappear. | **FIXED** — `BoxWithConstraints` computes `trackWidth`; the thumb's CENTER sits at `trackWidth * safeProgress - 7.dp`; the fill uses the fraction. |
+| `ReaderBottomChrome.kt` | Medium | Rendered on `theme.background` with no distinct chrome surface + no top rule (the design's `t.chrome`/`t.rule`). | **FIXED** — added the 0.5dp top divider (`rule = ink@0.10`); chrome = `theme.background` (a documented local mapping; `ReaderTheme` has no separate chrome token). |
+| `ReaderBottomChrome.kt` | Medium | Named/implemented as a scrubber but had no `onScrub` callback / pointer handling — host WIs couldn't wire seeking. | **FIXED** — added `onScrub: (Float)->Unit` + `detectTapGestures` + `detectHorizontalDragGestures` on the track (tap/drag → the clamped 0..1 fraction). A host WI wires it to seek. |
+| `ReaderBottomChrome.kt` | Low | Same-package `ChromeLabel` + fully-qualified `androidx.compose.material3.Text` calls were noise. | **FIXED** — imported `Text`/`Color`, dropped the prefixes. |
+
+## Round 2 (Codex re-audit) — production resolved, 1 Medium (test)
+
+The auditor confirmed the round-1 production issues resolved (thumb centered, chrome/rule mapping
+present, tap/drag call `onScrub` with a clamped fraction, `fillMaxWidth(safeProgress)` fine at 0/1). One
+new finding:
+
+| file | severity | issue | resolution |
+|---|---|---|---|
+| `ReaderBottomChromeUiTest.kt` | Medium | `performClick()` targets the `pointerInput`-only scrubber track (no semantics click action) → the test would fail / not exercise the gesture. | **FIXED** — `performTouchInput { click() }` (raw pointer input, which drives `detectTapGestures`). |
+
+## Verdict
+
+**ship-as-is.** Two rounds; all production + test findings fixed. Compiles clean (main + androidTest).
+
+## Gate-5a verification note (instrumentation-platform flakiness — rule 47/52)
+
+The connected `ReaderBottomChromeUiTest` could not be landed green this session — the **same instrumentation
+platform flakiness** that blocked WI-2 (UTP crash with `tests="0"`, adb-shell congestion, instrumentation
+wedges) recurred across WI-2 and WI-3 (3+ failed/wedged runs; the host has been running heavy build+audit+
+emulator workloads for hours; a combined comma-class filter also fast-failed). Per rule 47/52 ("do not let
+tooling flakiness block a code-proven WI"), WI-3 is **accepted** on: the code **compiles** (main +
+androidTest), the Gate-4 audit is **ship-as-is**, and the **sibling connected sheet/list tests use the
+identical `createComposeRule` + content-composable + `testTag`/`useUnmergedTree` harness and merged green**
+(`ManageSheetUiTest` 3/3, `AssignSheetUiTest`, `CollectionShelfBarUiTest`). The chrome's live connected
+confirmation is **consolidated into WI-8's acceptance pass** on a freshly cold-booted emulator (where all
+the deferred connected tests run together). Lesson for the loop: run **one** test class per connected
+invocation (a comma-separated `class=A,B` filter fast-fails with `tests="0"`).

--- a/android/app/src/androidTest/kotlin/com/vreader/app/reader/chrome/ReaderBottomChromeUiTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/reader/chrome/ReaderBottomChromeUiTest.kt
@@ -1,0 +1,62 @@
+package com.vreader.app.reader.chrome
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.click
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.vreader.app.reader.settings.ReaderTheme
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Feature #129 WI-3 — the `ReaderBottomChrome` shell: the Display slot opens settings, the scrubber tap
+ * seeks (onScrub), the scrubber + page labels render, and the Contents/Notes/AI slots are OMITTED (no
+ * dead placeholders — the LibraryScreen precedent + the Gate-2 ruling).
+ */
+@RunWith(AndroidJUnit4::class)
+class ReaderBottomChromeUiTest {
+    @get:Rule val compose = createComposeRule()
+
+    @Test fun tappingDisplay_invokesOnOpenDisplay() {
+        var opened = false
+        compose.setContent {
+            ReaderBottomChrome(ReaderTheme.Paper, progress = 0.4f, displayPage = 5, totalPages = 100, onScrub = {}, onOpenDisplay = { opened = true })
+        }
+        compose.onNodeWithTag("chrome-display", useUnmergedTree = true).performClick()
+        assertTrue(opened)
+    }
+
+    @Test fun tappingScrubber_invokesOnScrub() {
+        var scrubbed: Float? = null
+        compose.setContent {
+            ReaderBottomChrome(ReaderTheme.Paper, progress = 0.4f, displayPage = 5, totalPages = 100, onScrub = { scrubbed = it }, onOpenDisplay = {})
+        }
+        // The track has pointerInput gesture handlers (no semantics click action) — drive raw touch.
+        compose.onNodeWithTag("scrubber-track", useUnmergedTree = true).performTouchInput { click() }
+        assertNotNull("a tap on the scrubber seeks", scrubbed)
+        assertTrue(scrubbed!! in 0f..1f)
+    }
+
+    @Test fun rendersScrubberAndDisplayOnly_omittedSlotsAbsent() {
+        compose.setContent {
+            ReaderBottomChrome(ReaderTheme.Dark, progress = 0.4f, displayPage = 5, totalPages = 100, onScrub = {}, onOpenDisplay = {})
+        }
+        compose.onNodeWithTag("reader-bottom-chrome").assertExists()
+        compose.onNodeWithTag("scrubber-thumb", useUnmergedTree = true).assertExists()
+        compose.onNodeWithText("Display", useUnmergedTree = true).assertExists()
+        compose.onNodeWithText("Page 5", useUnmergedTree = true).assertExists()
+        compose.onNodeWithText("95 pages left in book", useUnmergedTree = true).assertExists()
+        // The omitted slots must not ship as dead placeholders.
+        compose.onAllNodesWithText("Contents", useUnmergedTree = true).assertCountEquals(0)
+        compose.onAllNodesWithText("Notes", useUnmergedTree = true).assertCountEquals(0)
+        compose.onAllNodesWithText("AI", useUnmergedTree = true).assertCountEquals(0)
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderBottomChrome.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderBottomChrome.kt
@@ -1,0 +1,126 @@
+// Purpose: feature #129 WI-3 (#110 Phase 3) — the designed reader bottom chrome
+// (vreader-reader.jsx ReaderBottomChrome): an interactive progress scrubber (track + fill + centered
+// thumb + "Page N / M pages left" labels, tap/drag → onScrub) and a toolbar. Per #129 scope (Gate-2 —
+// omit non-functional slots, the LibraryScreen precedent, no dead placeholders) the toolbar ships ONLY
+// the "Display" (Aa) slot, which opens the WI-2 ReaderSettingsSheet; Contents / Notes / AI are added by
+// feature F / D later. Renders in the active [ReaderTheme]'s colors (chrome = the theme background +
+// a top rule — a local mapping of the design's chrome/rule tokens). Pure function of state + callbacks.
+package com.vreader.app.reader.chrome
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.vreader.app.reader.settings.ReaderTheme
+import com.vreader.app.ui.theme.VReaderFonts
+
+/**
+ * The reader bottom chrome. [progress] is 0..1; [displayPage]/[totalPages] drive the scrubber labels
+ * (pass totalPages <= 0 to hide them for hosts without paging). [onScrub] is invoked with the tapped/
+ * dragged fraction (0..1) — the host WI wires it to the reader's seek. [onOpenDisplay] opens the Display
+ * settings sheet. Renders in [theme]'s colors.
+ */
+@Composable
+fun ReaderBottomChrome(
+    theme: ReaderTheme,
+    progress: Float,
+    displayPage: Int,
+    totalPages: Int,
+    onScrub: (Float) -> Unit,
+    onOpenDisplay: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val ink = theme.ink
+    val sub = theme.ink.copy(alpha = 0.6f)
+    val rule = theme.ink.copy(alpha = 0.10f)
+    val accent = theme.accent
+    val safeProgress = progress.coerceIn(0f, 1f)
+
+    Column(
+        modifier
+            .fillMaxWidth()
+            .background(theme.background)
+            .testTag("reader-bottom-chrome"),
+    ) {
+        // Top rule (the design's chrome divider).
+        Box(Modifier.fillMaxWidth().height(0.5.dp).background(rule))
+
+        Column(Modifier.padding(top = 14.dp, bottom = 28.dp)) {
+            // Scrubber — tap or drag anywhere on the row seeks.
+            Column(Modifier.padding(horizontal = 22.dp)) {
+                BoxWithConstraints(
+                    Modifier
+                        .fillMaxWidth()
+                        .height(24.dp)
+                        .testTag("scrubber-track")
+                        .pointerInput(Unit) {
+                            detectTapGestures { o -> onScrub((o.x / size.width).coerceIn(0f, 1f)) }
+                        }
+                        .pointerInput(Unit) {
+                            detectHorizontalDragGestures { change, _ -> onScrub((change.position.x / size.width).coerceIn(0f, 1f)) }
+                        },
+                    contentAlignment = Alignment.CenterStart,
+                ) {
+                    val trackWidth = maxWidth
+                    Box(Modifier.fillMaxWidth().height(3.dp).clip(RoundedCornerShape(2.dp)).background(rule))
+                    Box(Modifier.fillMaxWidth(safeProgress).height(3.dp).clip(RoundedCornerShape(2.dp)).background(accent))
+                    // Thumb: its CENTER sits at trackWidth * progress (offset by -half the thumb).
+                    Box(
+                        Modifier
+                            .offset(x = trackWidth * safeProgress - 7.dp)
+                            .size(14.dp)
+                            .clip(CircleShape)
+                            .background(accent)
+                            .testTag("scrubber-thumb"),
+                    )
+                }
+                if (totalPages > 0) {
+                    Row(Modifier.fillMaxWidth().padding(top = 4.dp), horizontalArrangement = Arrangement.SpaceBetween) {
+                        ChromeLabel("Page $displayPage", sub)
+                        ChromeLabel("${(totalPages - displayPage).coerceAtLeast(0)} pages left in book", sub)
+                    }
+                }
+            }
+
+            // Toolbar — Display only (Contents/Notes/AI omitted until F/D, no dead placeholders).
+            Row(Modifier.fillMaxWidth().padding(top = 14.dp, start = 12.dp, end = 12.dp), horizontalArrangement = Arrangement.Center) {
+                Column(
+                    Modifier.clickable { onOpenDisplay() }.padding(horizontal = 12.dp, vertical = 4.dp).testTag("chrome-display"),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(3.dp),
+                ) {
+                    Text("Aa", color = ink, fontFamily = VReaderFonts.Serif, fontSize = 20.sp, fontWeight = FontWeight.SemiBold)
+                    Text("Display", color = sub, fontSize = 10.sp, fontWeight = FontWeight.Medium)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChromeLabel(text: String, color: Color) {
+    Text(text, color = color, fontSize = 11.sp, fontFamily = VReaderFonts.Sans)
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.13.10
-versionCode=83
+versionName=0.13.11
+versionCode=84


### PR DESCRIPTION
## Summary

Feature #129 WI-3 — the designed reader bottom chrome (`ReaderBottomChrome`, vreader-reader.jsx): an interactive progress scrubber (track + fill + centered thumb + "Page N / M pages left"; tap/drag → `onScrub`) and a toolbar that ships **only the "Display" (Aa) slot** opening the WI-2 sheet. Contents/Notes/AI are **omitted** until feature F/D land (the LibraryScreen "omit non-functional controls, no dead placeholders" precedent + the Gate-2 ruling). Renders in the active `ReaderTheme`'s colors.

Standalone chrome composable; **per-host wiring rides with each host's application (WI-4..7)** so every Display control actually changes its reader (no half-wired state — the Gate-2 concern).

Part of feature #1879.

## Validation

- [x] Gate-4 Codex audit **ship-as-is** — 2 rounds: High (thumb edge→center via BoxWithConstraints) + 2 Medium (top divider; `onScrub` tap/drag) + Low (imports) → fixed; round-2 Medium (test `performTouchInput`) → fixed. Audit log: `.claude/codex-audits/feat-feature-129-wi-3-chrome-audit.md`.
- [x] Compiles clean (main + androidTest).
- [⚠] **Connected `ReaderBottomChromeUiTest` deferred to WI-8 acceptance** under the session's instrumentation-platform flakiness (UTP `tests="0"` crashes + adb congestion across WI-2/WI-3 on a hours-loaded host). Accepted per rule 47/52 on compile + audit + **green-sibling-precedent** (`ManageSheetUiTest` 3/3, `AssignSheetUiTest`, `CollectionShelfBarUiTest` — identical harness). Lesson: one test class per connected run (comma `class=A,B` fast-fails).
- [x] Version bumped: android 0.13.10 → 0.13.11.

## Type of Change

- [x] Feature WI (Part of feature #1879)