### PR TITLE
feat(#130 WI-4): /dispatch — the lane orchestrator (canary-proven)

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -47,9 +47,15 @@ PR #1029). If `pwd` mismatches, STOP and report — do not guess.
 2. **RED** — failing tests first (the Spec block's named tests, or the bug's
    regression test), covering the edge cases.
 3. **GREEN** — minimal implementation. **REFACTOR** — behavior-preserving.
-4. **Gate 4 in-lane**: run the Codex audit via cc-suite's runner or
-   `scripts/run-codex.sh` (rule 53 — never raw `codex exec`), fix findings
-   (max 3 rounds), commit `.claude/codex-audits/<branch>-audit.md`.
+4. **Gate 4 in-lane** — the audit ladder (PROBED 2026-07-09, feature #130:
+   custom agents get NO Skill tool in this harness — "Skill exists but is
+   not enabled in this context" — so cc-suite slash-skills are unreachable
+   from a lane; do not waste a round trying):
+   PRIMARY: `scripts/run-codex.sh -o <worktree>/.reports/audit-rN.txt "<prompt>"`
+   (rule 53 — never raw `codex exec`). Fix findings, max 3 rounds, then
+   HANDOFF `outcome: blocked`. Commit
+   `.claude/codex-audits/<branch>-audit.md` on the branch (frontmatter:
+   branch/threadId/rounds/final_verdict — the merge hook's exact contract).
 5. **Test gate**: `TEST_UDID=<leased> scripts/run-tests.sh <targeted-suite>`
    per suite in scope (Android: `scripts/run-android-tests.sh`) — never bare
    `xcodebuild`/`gradlew` (rule 52), never the >20-min full suite.

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -39,7 +39,9 @@ PR #1029). If `pwd` mismatches, STOP and report — do not guess.
   or `blocked` (with blockers[]) after the audit loop's 3rd round or a
   non-reproducible/needs-design situation. Never push past a block — report.
 
-## The inner loop (rule 10, unchanged)
+## The inner loop (rule 10, unchanged — canonical lane order:
+## RED → GREEN → REFACTOR → targeted test gate → in-lane audit loop →
+## targeted RE-test if audit fixes changed code → HANDOFF)
 
 1. **Preflight**: reproduce/describe current vs expected; trace the smallest
    safe change boundary; brainstorm edge cases (empty, nil, boundaries,

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -1,6 +1,6 @@
 ---
 name: implementer
-description: Worktree-isolated lane implementer — runs one bug fix or one feature WI end-to-end (repro → RED → GREEN → REFACTOR → in-lane Codex audit → targeted test gate) and stops at ready-for-integration with a structured HANDOFF. Never touches shared surfaces (trackers, project.yml, docs sync targets, tags, PRs).
+description: Worktree-isolated lane implementer — runs one bug fix or one feature WI end-to-end (repro → RED → GREEN → REFACTOR → targeted test gate → in-lane Codex audit) and stops at ready-for-integration with a structured HANDOFF. Never touches shared surfaces (trackers, project.yml, docs sync targets, tags, PRs).
 tools: Read, Write, Edit, Bash, Grep, Glob
 ---
 
@@ -49,7 +49,11 @@ PR #1029). If `pwd` mismatches, STOP and report — do not guess.
 2. **RED** — failing tests first (the Spec block's named tests, or the bug's
    regression test), covering the edge cases.
 3. **GREEN** — minimal implementation. **REFACTOR** — behavior-preserving.
-4. **Gate 4 in-lane** — the audit ladder (PROBED 2026-07-09, feature #130:
+4. **Test gate**: `TEST_UDID=<leased> scripts/run-tests.sh <targeted-suite>`
+   per suite in scope (Android: `scripts/run-android-tests.sh`) — never bare
+   `xcodebuild`/`gradlew` (rule 52), never the >20-min full suite. Re-run
+   after any audit-driven code change (step 5).
+5. **Gate 4 in-lane** — the audit ladder (PROBED 2026-07-09, feature #130:
    custom agents get NO Skill tool in this harness — "Skill exists but is
    not enabled in this context" — so cc-suite slash-skills are unreachable
    from a lane; do not waste a round trying):
@@ -58,9 +62,6 @@ PR #1029). If `pwd` mismatches, STOP and report — do not guess.
    HANDOFF `outcome: blocked`. Commit
    `.claude/codex-audits/<branch>-audit.md` on the branch (frontmatter:
    branch/threadId/rounds/final_verdict — the merge hook's exact contract).
-5. **Test gate**: `TEST_UDID=<leased> scripts/run-tests.sh <targeted-suite>`
-   per suite in scope (Android: `scripts/run-android-tests.sh`) — never bare
-   `xcodebuild`/`gradlew` (rule 52), never the >20-min full suite.
 
 Hard rules: keep side effects out of core helpers; no cross-feature imports;
 files <300 lines; comment maintenance per rule 22.

--- a/.claude/codex-audits/feat-feature-130-wi-4-dispatch-audit.md
+++ b/.claude/codex-audits/feat-feature-130-wi-4-dispatch-audit.md
@@ -1,0 +1,57 @@
+---
+branch: feat/feature-130-wi-4-dispatch
+threadId: 019f4467-0184-7942-9712-c3548e25368d
+rounds: 2
+final_verdict: ship-as-is
+---
+
+# Gate-4 audit — feature #130 WI-4 (/dispatch orchestrator)
+
+Auditor: cc-suite runner, gpt-5.5, read-only. Round 1 on thread
+`019f4467-0184-7942-9712-c3548e25368d` (high effort, full-branch walk against
+plan v6 + the shipped primitives); round 2 fresh focused verification on
+thread `019f446d-ed70-7e70-b06f-7cbb184f3f01`.
+
+## Round 1 — block-recommended
+
+- **Critical**: the integration tail didn't pin WHERE tracker/docs/version
+  edits happen (an executor could commit shared files on main), and one line
+  contradicted the plan by describing orchestrator tracker-write commits on
+  local main. → Fixed (`39166a28`): 5d/5e mandate Edit on files under
+  `<worktree>/` committed via `git -C <worktree>`; bump = the branch's LAST
+  commit; pre-PR assertion (`origin/main..HEAD` shows
+  fix+artifact+tracker+bump AND contamination probes clean); the
+  pull-rebase rationale now cites cron finalizer chore(tracker) commits.
+- **High**: contamination check placed AFTER the merge block → dual
+  pre-merge call sites (post-HANDOFF + pre-PR) + shared definition; shape
+  test asserts line-number ordering vs `gh pr merge`.
+- **High**: invalid/missing HANDOFFs leaked lease/worktree → ONE cleanup
+  routine for EVERY non-ready outcome (release + teardown-or-preserve +
+  ledger + requeue-once/escalate).
+- **High**: kill-switch/N=1 inline fallbacks ran unlocked → Step 0
+  reordered (lock FIRST); both fallbacks run under the `dispatch` lock.
+- **High**: single batch-end tag pass → per-PR tag immediately after each
+  merge (rule 40; a batch-end pass corrupts the next slot's latest-tag
+  input).
+- **Medium**: teardown didn't own branch deletion as claimed →
+  `--delete-branch` flag (post-merge only; requeued branches survive; gh's
+  `--delete-branch` stays banned) + tests. **Medium**: shape test
+  presence-only → +7 invariant anchors incl. an ordering assertion.
+- **Low**: lane-order wording inconsistency → canonical order stated once.
+
+## Round 2 — ship-as-is
+
+Findings 1–7 verified resolved with citations; no new Critical/High in the
+renumbering/teardown-parsing sweep. Three Lows, all FIXED post-verdict
+rather than accepted: implementer.md's frontmatter + numbered steps now
+match the canonical order (test gate 4 before audit 5, re-test on
+audit-driven changes); the Gate-6-comments wording disambiguated from the
+skill's step numbering; teardown flag-permutation tests added
+(`--force --delete-branch` both orders).
+
+## Test evidence
+
+`dispatch-shape.test.sh` — 34 static gates ALL PASS (incl. the
+contamination-before-merge ordering assertion); `worktree.test.sh` —
+13 cases ALL PASS (incl. branch-preserve/delete paths + permutations +
+8-way cap race).

--- a/.claude/commands/dispatch.md
+++ b/.claude/commands/dispatch.md
@@ -1,0 +1,14 @@
+---
+description: Parallel lane dispatch — worktree lanes on leased sims, serial integration tail (feature #130, rule 55)
+argument-hint: "#123 #456 | feature <id> WI-a WI-b"
+---
+
+# Dispatch (stub — single-sourced)
+
+Invoke the `dispatch` skill via the Skill tool with these arguments:
+
+```
+$ARGUMENTS
+```
+
+Do not add orchestration content here — edit `.claude/skills/dispatch/SKILL.md`.

--- a/.claude/rules/40-version-bump.md
+++ b/.claude/rules/40-version-bump.md
@@ -89,6 +89,20 @@ git diff vreader.xcodeproj/project.pbxproj | grep -E "MARKETING_VERSION|CURRENT_
 
 After a bump, the App's About / TestFlight build number both should reflect the new `MARKETING_VERSION`. The build number from `CURRENT_PROJECT_VERSION` is shown in TestFlight's release lists.
 
+## Batch mode (feature #130 lane dispatch — version-at-slot)
+
+In a `/dispatch` batch, **the orchestrator allocates versions at the merge
+slot** (the fix-issue M3 integrator pattern as the universal rule): lanes
+never touch `project.yml`/pbxproj; the HANDOFF carries only a `bump_tier`
+(patch|minor|major); at each item's integration slot the orchestrator
+computes X.Y.Z from the THEN-current `project.yml` + latest `v*` tag,
+applies the bump + `xcodegen generate`, and commits both files as the
+branch's last commit before `gh pr create`. Never pre-assign numbers — a
+requeued lane would shift every subsequent one. The letter of this rule is
+preserved: every PR still ends with its own bump commit before opening;
+monotonic `CURRENT_PROJECT_VERSION` holds because exactly one allocator
+exists per batch (serialized by the `dispatch` lock).
+
 ## Multi-platform (Android port — feature #103 Phase 0)
 
 vreader is becoming two independently-shippable native apps (iOS at the

--- a/.claude/rules/48-parallel-execution.md
+++ b/.claude/rules/48-parallel-execution.md
@@ -158,6 +158,21 @@ the interest of brevity.
 - [ ] If the brief includes multi-step bash sequences, every step starts with `cd "<worktree-path>"` (compound commands `cd X && Y && Z` are fine — what's not fine is a later Bash call that omits the prefix and assumes the previous call's cwd persists).
 - [ ] If the agent reports something that smells like contamination (PR has unexpected `project.pbxproj` references, `git status` in main checkout shows files the agent shouldn't have written), treat the agent's output as suspect and verify by inspecting the main checkout's working tree before merging.
 
+## Lane dispatch (feature #130 — THE sanctioned fan-out mechanism)
+
+Multi-item parallel work runs through **`/dispatch`**
+(`.claude/skills/dispatch/SKILL.md`) under the **rule 55** lane contract —
+worktree-isolated `implementer` lanes on leased simulators
+(`scripts/sim-lease.sh`), write-sets gated by `scripts/check-write-set.sh`,
+dependencies gated by `scripts/deps-check.sh`, one global `dispatch` lock
+(`scripts/agent-lock.sh`), a serial integration tail with version-at-slot,
+and ≤2 lanes (width 1 default). Lane briefs are GENERATED from the dispatch
+skill's template — never hand-written — and always embed this rule's
+"Critical Operational" preamble verbatim. The subagent contract above now
+includes the rule-55 HANDOFF JSON as the required return format for lanes.
+Hand-rolled multi-worktree orchestration (the old fix-issue M1–M5 prose) is
+dead — see the dispatch skill's "Dropped by design" section.
+
 ## Worked examples
 
 **Good — mixed gates, this session's `#46 WI-0a + #48 planning`**:

--- a/.claude/rules/55-lane-dispatch.md
+++ b/.claude/rules/55-lane-dispatch.md
@@ -243,8 +243,12 @@ the interest of brevity.
 3. The test-gate command shape: `TEST_UDID=<udid> scripts/run-tests.sh
    <targeted-suite>` (Android: `scripts/run-android-tests.sh`) — wrappers
    only (rule 52), targeted suites only (never the >20-min full suite).
-4. The in-lane Gate-4 instruction: cc-suite runner or `scripts/run-codex.sh`
-   (rule 53), artifact committed on the branch, ≤3 rounds then blocked.
+4. The in-lane Gate-4 instruction: `scripts/run-codex.sh` (rule 53) is the
+   PRIMARY rung — **probed 2026-07-09 (twice, incl. with `Skill` in the
+   agent frontmatter): custom agents get NO Skill tool in this harness, so
+   cc-suite slash-skills are unreachable from a lane** — artifact committed
+   on the branch, ≤3 rounds then blocked. Long output goes to
+   `<worktree>/.reports/` and travels as paths.
 
 ## Degrades
 

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: dispatch
+description: "Parallel lane dispatch — the ONLY sanctioned multi-item fan-out (feature #130, rule 55). Use when the user asks to fix several bugs at once ('fix #a #b #c'), implement independent feature WIs in parallel, or run a dispatch batch. Orchestrates worktree-isolated implementer lanes on leased simulators, validates HANDOFFs, and runs the serial integration tail (rebase → re-test → tracker/docs → version-at-slot → PR → merge-from-worktree → tag). A single item degrades to the inline /fix-issue or /feature-workflow flow."
+---
+
+# Dispatch (rule 55 — the lane orchestrator)
+
+You are the ORCHESTRATOR. Lanes do the heavy work; you own every contended
+surface (trackers, `project.yml`/pbxproj versions, `git tag`, `gh pr`,
+docs sync) and all policy decisions. Lanes never decide anything.
+
+## Step 0 — preconditions (any failure ⇒ report, do not dispatch)
+
+1. **Kill switch**: if `.claude/state/dispatch-kill` exists → dispatch is
+   disabled; fall back to the inline single-item flow and say so.
+2. **Global lock**: `scripts/agent-lock.sh acquire dispatch` — exit 2 means
+   another orchestrator (interactive or cron) is mid-batch: report
+   "blocked (dispatch busy)" and STOP. Cron prompts take only their
+   `cron-<kind>` lock; /dispatch itself owns `dispatch` (pre-acquiring it
+   outside would self-deadlock — the lock is non-reentrant).
+3. **N=1 degrade**: a single work item runs today's inline flow
+   (/fix-issue or /feature-workflow) — fan-out overhead isn't worth it
+   (rule 48 decision test). Release the lock first.
+4. **Width**: default 1 lane; open a second ONLY with memory headroom —
+   check `vm_stat` free+inactive pages ≳ 4GB equivalent. Hard cap 2.
+   `android-app`/`android-spike` items always width 1 (no ANDROID_SERIAL
+   routing yet).
+
+## Step 1 — intake + the ephemeral ledger
+
+Build the batch ledger IN CONTEXT (never persisted — durable state lives in
+tracker rows, GH gate-timeline comments, `git worktree list`,
+`scripts/sim-lease.sh status`, `scripts/agent-lock.sh status`):
+
+```
+| item | branch | write-set | UDID | status | verdict/version |
+```
+
+Statuses: dispatched → returned → integrating → merged | requeued | escalated.
+Update the row on every spawn and every HANDOFF.
+
+For each candidate item:
+- **Bug**: `scripts/deps-check.sh bug <id>` must say READY; micro-spec =
+  repro + expected-vs-actual + regression-test name (+ bug-mode Phase 0.5:
+  reproduce FIRST; one explicit root-cause line "the bug is X because Y";
+  the RED test must fail for the bug's REASON; re-run the original repro
+  after GREEN and record it in the HANDOFF's `notes_append`).
+- **Feature WI**: read ONLY the plan's Spec blocks (never the plan body);
+  `scripts/deps-check.sh feature <id>` READY; an intra-batch `depends:`
+  edge counts as satisfied only when the dependency WI's branch has
+  **MERGED** — not merely HANDOFF-returned or PR-opened (a returned branch
+  can still bounce at integration).
+- Write-sets must be pairwise-disjoint across the batch (compare `writes:`
+  prefixes against every in-flight ledger row); overlap ⇒ serialize those
+  items into later waves.
+
+## Step 2 — pre-spawn checklist (a failed item blocks the SPAWN)
+
+Per item, in order: main tree clean (pbxproj signing carve-out excepted) →
+`scripts/worktree-setup.sh <id> <branch>` (records the ABSOLUTE path) →
+GH issue exists with `GH: #N` stamped → `scripts/sim-lease.sh acquire test`
+(record UDID in the ledger) → brief generated from the template below.
+
+## Step 3 — the lane brief (generated, NEVER hand-written)
+
+Every brief contains, in this order:
+
+1. The rule-48 preamble VERBATIM with the worktree path substituted:
+
+```
+## CRITICAL OPERATIONAL — binding
+
+Your worktree path is: <ABSOLUTE-WORKTREE-PATH>
+
+Every `Bash` tool call you issue MUST begin with `cd "<ABSOLUTE-WORKTREE-PATH>"`.
+Before your first edit or write, run `pwd` and confirm it prints the worktree
+path. If `pwd` does NOT match, stop and report — do NOT attempt to recover by
+guessing.
+
+The Agent harness creates the worktree but does NOT set your initial cwd to
+it. Your Bash tool starts with cwd = the orchestrator's main checkout. A
+single Bash call that forgets the `cd` prefix can write to the main checkout
+instead of your worktree; a later `xcodegen generate` then folds stray files
+into `project.pbxproj` and breaks the build on every clean clone. Standing
+precedent: PR #1029 (v3.37.19) was a hotfix for exactly this pattern.
+
+This is binding for every Bash call, not just the first. Do not skip this in
+the interest of brevity.
+```
+
+2. The six-field contract instantiated (objective = the one item; inputs =
+   Spec block or micro-spec + exact file list + leased `TEST_UDID`; allowed
+   writes = the `writes:` prefixes; forbidden = rule 55's shared surfaces +
+   "no Bash file edits" + nothing outside the write-set; output = the
+   rule-55 HANDOFF JSON; stop = ready-for-integration or blocked).
+3. **Skill-override clause**: the lane contract OVERRIDES any standing
+   skill phases — no PR creation, no tracker edits, no close-gate, no
+   version bump, no `git tag`; STOP at ready-for-integration + HANDOFF.
+4. Test gate shape: `TEST_UDID=<udid> scripts/run-tests.sh <targeted-suite>`
+   (Android: `scripts/run-android-tests.sh`) — wrappers only, targeted only.
+5. Gate-4 ladder (probed 2026-07-09): `scripts/run-codex.sh` (rule 53) is
+   the lanes' PRIMARY audit rung — custom agents have no Skill tool
+   (probe: "Skill exists but is not enabled in this context") — artifact
+   committed on the branch, ≤3 rounds then blocked. Long logs go to
+   `<worktree>/.reports/` and travel as PATHS in the HANDOFF.
+
+Spawn a full wave in ONE message (both Agent calls together at width 2).
+
+## Step 4 — HANDOFF validation (per returned lane)
+
+Validate against rule 55's JSON schema. Invalid or missing HANDOFF = lane
+failure → requeue the item ONCE with a fresh lane, then escalate.
+`outcome: blocked` → read `blockers`, release the lane's lease, tear down,
+escalate or requeue per cause. Never argue with a lane — re-brief once
+(rule 48) or collapse to inline.
+
+## Step 5 — integration tail (serial, per lane, in ledger order)
+
+Ordered so any failure before PR-open leaves ZERO shared-surface changes:
+
+a. `scripts/check-write-set.sh <worktree> <declared-prefixes>` (+
+   `CHECK_LANE_PLATFORM=<lane platform>`) — violations ⇒ requeue/escalate.
+b. Rebase the branch on `origin/main` IN the worktree. Conflict ⇒
+   `git rebase --abort`, requeue for serialized redo (fresh lane brief:
+   "rebase onto current main and resolve"), no version burned, no PR.
+c. Independent re-run of the lane's declared targeted suite
+   (`TEST_UDID=<its udid> scripts/run-tests.sh <suite>`) — never trust the
+   HANDOFF's RESULT line.
+d. Apply `tracker_edit` + `docs_sync` yourself via Edit under
+   `scripts/agent-lock.sh acquire tracker-write` (release immediately
+   after). New row IDs were minted via `scripts/reserve-id.sh` BEFORE
+   taking tracker-write.
+e. **Version-at-slot**: compute X.Y.Z NOW from then-current `project.yml`
+   + latest `v*` tag, applying the HANDOFF's `bump_tier`; never pre-assign
+   (a requeued lane would shift every subsequent number). Edit
+   `project.yml`, `xcodegen generate`, commit both as the branch's LAST
+   commit.
+f. `gh pr create` (HANDOFF as body, `Part of feature #N` / `Refs #N` per
+   the merge-gate convention), then run `gh pr merge --squash`
+   **FROM the lane worktree** — the audit-artifact hook checks the
+   artifact as a filesystem path under the resolved root; merging from
+   main false-blocks. And never pass `--delete-branch` (gh then checks
+   out the default branch, which fails in a linked worktree — teardown
+   owns branch deletion). On a NON-hook nonzero exit: `gh pr view --json
+   state,mergeCommit` FIRST — never close-and-requeue an already-MERGED
+   PR (network blips happen).
+g. Lane cleanup on EVERY exit path: `scripts/sim-lease.sh release <udid>` +
+   `scripts/worktree-teardown.sh <id>`. Batch ends with
+   `sim-lease.sh status` clean.
+
+After the last item: on the MAIN checkout run `git pull --rebase` (local
+main may carry your own unpushed tracker-write commits), cut the annotated
+tag on the true merge commit, push. Post the per-WI Gate-6 comment.
+
+## Step 6 — post-return contamination check (per lane, before its merge)
+
+BOTH checks, always:
+- `git status --porcelain` on the main checkout (uncommitted contamination —
+  the pbxproj class arrives via a later `xcodegen generate`).
+- `git log origin/main..main --oneline` — only YOUR OWN chore/tracker/plan/
+  evidence commits may appear. A drifted lane that COMMITTED from
+  main-checkout cwd leaves `git status` clean; the log check is the only
+  detector.
+
+## Step 7 — Gate 5 + release the lock
+
+Release the `dispatch` lock BEFORE Gate-5 verification (rule 55: the lock
+covers dispatch+integration only — the next batch's lanes may start while
+verification runs). Verification uses `sim-lease.sh acquire verify` + the
+verifier agent (observations only); you write evidence files and flip rows
+under `tracker-write`.
+
+## Context protection (binding in dispatch mode)
+
+You never read: full diffs, run-tests logs, Codex rawOutput, sim
+transcripts, or plan bodies (Spec blocks + HANDOFFs only). You never run
+`git diff` beyond `--name-only`. MAY read: HANDOFF JSON, single tracker
+rows (grep, never a full Read of the 499KB tracker), one-line gh results,
+`RUN-* RESULT:` lines, `--name-only` lists, `<worktree>/.reports/` paths
+(pass them on, don't open them).
+
+## Escalation
+
+Audit round-3 failure, needs-design (rule 51 — file the `needs-design`
+issue yourself), non-reproducible bugs, double-requeue → escalate to the
+user with the ledger row + the lane's blockers. Lanes never make policy
+decisions.
+
+## Dropped by design — do not reintroduce
+
+The pre-#130 fix-issue "Multi-Issue Pipeline" (M1–M5) is dead. Its
+load-bearing defects, so a future rewrite can't regress into them:
+- **Resumable two-way agents** ("integrator resumes each worktree-agent
+  through Phases 7→8") — subagents are fire-and-forget with a single
+  return; there is no resume. Lanes STOP at ready-for-integration.
+- **Per-WI inline bump/PR by the worktree agent** — versions are
+  orchestrator-allocated at the merge slot; lanes never touch project.yml.
+- **Un-briefed spawns** — every lane gets the generated brief; there is no
+  "the agent has context" shortcut (context absorption was the multi-issue
+  design's silent failure).

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -11,16 +11,20 @@ docs sync) and all policy decisions. Lanes never decide anything.
 
 ## Step 0 — preconditions (any failure ⇒ report, do not dispatch)
 
-1. **Kill switch**: if `.claude/state/dispatch-kill` exists → dispatch is
-   disabled; fall back to the inline single-item flow and say so.
-2. **Global lock**: `scripts/agent-lock.sh acquire dispatch` — exit 2 means
-   another orchestrator (interactive or cron) is mid-batch: report
+1. **Global lock FIRST**: `scripts/agent-lock.sh acquire dispatch` — exit 2
+   means another orchestrator (interactive or cron) is mid-batch: report
    "blocked (dispatch busy)" and STOP. Cron prompts take only their
    `cron-<kind>` lock; /dispatch itself owns `dispatch` (pre-acquiring it
    outside would self-deadlock — the lock is non-reentrant).
+2. **Kill switch**: if `.claude/state/dispatch-kill` exists → dispatch is
+   disabled; run the item(s) through the inline single-item flow
+   **while still holding the `dispatch` lock** (the inline flow edits the
+   same shared surfaces — running it unlocked could race a concurrent
+   batch), release the lock at the end, and say so.
 3. **N=1 degrade**: a single work item runs today's inline flow
    (/fix-issue or /feature-workflow) — fan-out overhead isn't worth it
-   (rule 48 decision test). Release the lock first.
+   (rule 48 decision test). Same rule: **the inline degrade runs under the
+   `dispatch` lock**, released when the inline flow finishes.
 4. **Width**: default 1 lane; open a second ONLY with memory headroom —
    check `vm_stat` free+inactive pages ≳ 4GB equivalent. Hard cap 2.
    `android-app`/`android-spike` items always width 1 (no ANDROID_SERIAL
@@ -106,13 +110,19 @@ the interest of brevity.
 
 Spawn a full wave in ONE message (both Agent calls together at width 2).
 
-## Step 4 — HANDOFF validation (per returned lane)
+## Step 4 — HANDOFF validation + contamination check (per returned lane)
 
-Validate against rule 55's JSON schema. Invalid or missing HANDOFF = lane
-failure → requeue the item ONCE with a fresh lane, then escalate.
-`outcome: blocked` → read `blockers`, release the lane's lease, tear down,
-escalate or requeue per cause. Never argue with a lane — re-brief once
-(rule 48) or collapse to inline.
+Validate against rule 55's JSON schema, then IMMEDIATELY run the first
+contamination check (both probes — see "Contamination checks" below).
+
+**One cleanup routine for EVERY non-ready outcome** (invalid HANDOFF,
+missing HANDOFF, `outcome: failed`, `outcome: blocked`): release the lane's
+lease (`scripts/sim-lease.sh release <udid>`), tear down the worktree
+(`scripts/worktree-teardown.sh <id>` — or preserve it with an explicit
+"preserved for investigation" ledger note when the failure needs forensics),
+update the ledger row, THEN requeue-once (fresh lane) or escalate per cause.
+No exit path leaves a lease or an unaccounted worktree behind. Never argue
+with a lane — re-brief once (rule 48) or collapse to inline.
 
 ## Step 5 — integration tail (serial, per lane, in ledger order)
 
@@ -126,43 +136,56 @@ b. Rebase the branch on `origin/main` IN the worktree. Conflict ⇒
 c. Independent re-run of the lane's declared targeted suite
    (`TEST_UDID=<its udid> scripts/run-tests.sh <suite>`) — never trust the
    HANDOFF's RESULT line.
-d. Apply `tracker_edit` + `docs_sync` yourself via Edit under
-   `scripts/agent-lock.sh acquire tracker-write` (release immediately
-   after). New row IDs were minted via `scripts/reserve-id.sh` BEFORE
-   taking tracker-write.
-e. **Version-at-slot**: compute X.Y.Z NOW from then-current `project.yml`
-   + latest `v*` tag, applying the HANDOFF's `bump_tier`; never pre-assign
-   (a requeued lane would shift every subsequent number). Edit
-   `project.yml`, `xcodegen generate`, commit both as the branch's LAST
-   commit.
+d. Apply `tracker_edit` + `docs_sync` yourself via Edit **on files under
+   `<worktree>/`** (e.g. `<worktree>/docs/bugs.md`), committed on the lane
+   branch with `git -C <worktree> commit` — the tracker/docs deltas ride
+   the PR, never main. Take `scripts/agent-lock.sh acquire tracker-write`
+   around the edit, release immediately after. New row IDs were minted via
+   `scripts/reserve-id.sh` BEFORE taking tracker-write.
+e. **Version-at-slot**: compute X.Y.Z NOW from the then-current
+   `<worktree>/project.yml` + latest `v*` tag, applying the HANDOFF's
+   `bump_tier`; never pre-assign (a requeued lane would shift every
+   subsequent number). Edit `<worktree>/project.yml`, run
+   `xcodegen generate` IN the worktree, commit both files with
+   `git -C <worktree>` as the branch's LAST commit.
+   **Pre-PR assertion**: `git -C <worktree> log origin/main..HEAD
+   --oneline` shows fix + audit-artifact + tracker/docs + bump commits,
+   AND the second contamination check (below) is clean.
 f. `gh pr create` (HANDOFF as body, `Part of feature #N` / `Refs #N` per
    the merge-gate convention), then run `gh pr merge --squash`
    **FROM the lane worktree** — the audit-artifact hook checks the
    artifact as a filesystem path under the resolved root; merging from
    main false-blocks. And never pass `--delete-branch` (gh then checks
-   out the default branch, which fails in a linked worktree — teardown
-   owns branch deletion). On a NON-hook nonzero exit: `gh pr view --json
-   state,mergeCommit` FIRST — never close-and-requeue an already-MERGED
-   PR (network blips happen).
-g. Lane cleanup on EVERY exit path: `scripts/sim-lease.sh release <udid>` +
-   `scripts/worktree-teardown.sh <id>`. Batch ends with
-   `sim-lease.sh status` clean.
+   out the default branch, which fails in a linked worktree — branch
+   deletion is teardown's `--delete-branch` flag, post-merge only). On a
+   NON-hook nonzero exit: `gh pr view --json state,mergeCommit` FIRST —
+   never close-and-requeue an already-MERGED PR (network blips happen).
+g. **Tag per PR, immediately**: on the MAIN checkout `git pull --rebase`
+   (local main may carry cron finalizer chore(tracker) commits), resolve
+   THIS PR's merge commit (`gh pr view --json mergeCommit`), tag its
+   `vX.Y.Z` there, push the tag — after EACH successful merge, never a
+   single batch-end tag pass (rule 40: every PR's bump gets its tag on
+   its own merge commit; a batch-end pass can miss earlier PRs and
+   corrupts version-at-slot's latest-tag input for the NEXT slot).
+h. Lane cleanup: `scripts/sim-lease.sh release <udid>` +
+   `scripts/worktree-teardown.sh <id> --delete-branch` (post-merge).
+   Batch ends with `sim-lease.sh status` clean.
 
-After the last item: on the MAIN checkout run `git pull --rebase` (local
-main may carry your own unpushed tracker-write commits), cut the annotated
-tag on the true merge commit, push. Post the per-WI Gate-6 comment.
+After the last item: post the per-WI Gate-6 comments and report the ledger.
 
-## Step 6 — post-return contamination check (per lane, before its merge)
+## Contamination checks (run at BOTH points: after each HANDOFF validation,
+## and again in step 5e's pre-PR assertion)
 
-BOTH checks, always:
+BOTH probes, always:
 - `git status --porcelain` on the main checkout (uncommitted contamination —
   the pbxproj class arrives via a later `xcodegen generate`).
-- `git log origin/main..main --oneline` — only YOUR OWN chore/tracker/plan/
-  evidence commits may appear. A drifted lane that COMMITTED from
-  main-checkout cwd leaves `git status` clean; the log check is the only
-  detector.
+- `git log origin/main..main --oneline` on the main checkout — only YOUR OWN
+  chore/tracker/plan/evidence commits may appear. A drifted lane that
+  COMMITTED from main-checkout cwd leaves `git status` clean; the log check
+  is the only detector. Anything unexpected ⇒ quarantine the lane's output
+  (do NOT merge), restore main, escalate.
 
-## Step 7 — Gate 5 + release the lock
+## Step 6 — Gate 5 + release the lock
 
 Release the `dispatch` lock BEFORE Gate-5 verification (rule 55: the lock
 covers dispatch+integration only — the next batch's lanes may start while

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -171,7 +171,9 @@ h. Lane cleanup: `scripts/sim-lease.sh release <udid>` +
    `scripts/worktree-teardown.sh <id> --delete-branch` (post-merge).
    Batch ends with `sim-lease.sh status` clean.
 
-After the last item: post the per-WI Gate-6 comments and report the ledger.
+After the last item: post the per-item GATE-TIMELINE comments on the GH
+issues (rule 47's per-WI-merge rows — unrelated to this skill's step
+numbering) and report the final ledger.
 
 ## Contamination checks (run at BOTH points: after each HANDOFF validation,
 ## and again in step 5e's pre-PR assertion)

--- a/.claude/skills/feature-workflow/SKILL.md
+++ b/.claude/skills/feature-workflow/SKILL.md
@@ -306,6 +306,17 @@ Per `.claude/rules/10-tdd.md`:
 Codebase conventions: see `.claude/rules/50-codebase-conventions.md`.
 File-size guideline: ~300 lines max.
 
+## Lane mode (feature #130 / rule 55 — Gate-3 WIs inside dispatch lanes)
+
+Independent WIs (disjoint `writes:`, satisfied `depends:` — **an intra-batch
+dependency counts only when the dependency WI's branch has MERGED**) may run
+as dispatch lanes via the `dispatch` skill. Inside a lane, this skill's
+standing steps are OVERRIDDEN: the lane runs ONE WI's 3a–3d (RED → GREEN →
+REFACTOR → in-lane Gate-4 via `scripts/run-codex.sh`) in its worktree on its
+leased `TEST_UDID`, then STOPS with the rule-55 HANDOFF. No PR, no merge, no
+tracker edits, no docs sync, no version bump, no tags — the orchestrator
+owns the integration tail and Gate 5 (verify-sim lease).
+
 ## 3c. Test gate
 
 ALWAYS through the watchdog wrapper — never a raw Xcode test invocation

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -504,14 +504,31 @@ If Phase 1 classified the issue as `question`:
 
 ---
 
+# Lane mode (feature #130 / rule 55 — when this skill runs INSIDE a dispatch lane)
+
+When the brief says you are a dispatch LANE, this skill's standing phases are
+**OVERRIDDEN** as follows (the lane contract wins — a skill loaded "for
+method" must not carry you past your dispatch):
+
+- You run **Phases 0.5 → 6a only** (reproduce → classify → fix with TDD →
+  in-lane Gate-4 audit via `scripts/run-codex.sh` → targeted test gate on
+  your leased `TEST_UDID`), inside YOUR worktree, on the branch the
+  orchestrator created.
+- **Dead to you**: branch ceremony (done), Phase 6b/6c tracker + docs-sync
+  edits, Phase 7 version bump, Phase 8 PR, Phase 9 finalizer/close-gate,
+  `git tag`, anything `gh` beyond reading the issue. The orchestrator owns
+  all of it (rule 55). Your `tracker_edit`/`docs_sync` are TEXT in the
+  HANDOFF, not edits.
+- **Stop condition**: emit the rule-55 HANDOFF JSON (outcome
+  `ready-for-integration` or `blocked`) and stop.
+
 # Multi-Issue Pipeline
 
-> **⚠️ Scheduled for replacement by `/dispatch` (feature #130 WI-4).** The
-> M-step prose below has a known structural defect: M3's "resume each
-> worktree-agent through Phases 7→8" is NOT executable — subagents are
-> fire-and-forget with a single return (rule 48); there is no resume. Do NOT
-> hand-execute the agent-resume steps. Until /dispatch lands, run multi-issue
-> batches SEQUENTIALLY through the single-issue pipeline above.
+> **⚠️ REPLACED by `/dispatch` (feature #130 WI-4 — live).** Do NOT
+> hand-execute the M-step prose below; it is retained only as historical
+> context and its defects are catalogued in the dispatch skill's "Dropped by
+> design" section (M3's agent-resume is not executable — subagents are
+> fire-and-forget, rule 48). Multiple issues → invoke the `dispatch` skill.
 
 When multiple issue numbers are provided (e.g. `#123 #456 #789`).
 

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 1041
-        MARKETING_VERSION: 3.66.57
+        CURRENT_PROJECT_VERSION: 1042
+        MARKETING_VERSION: 3.67.0
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/scripts/__tests__/dispatch-shape.test.sh
+++ b/scripts/__tests__/dispatch-shape.test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Feature #130 WI-4 — static shape gates for the dispatch layer: the skill
+# text must carry every load-bearing clause (verbatim preamble, kill switch,
+# merge-from-worktree, disambiguation, contamination check, never-read lists,
+# ledger, merged-dependency rule) so a future edit can't silently drop one.
+#
+# Run: bash scripts/__tests__/dispatch-shape.test.sh
+
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+SKILL="$ROOT/.claude/skills/dispatch/SKILL.md"
+CMD="$ROOT/.claude/commands/dispatch.md"
+IMPL="$ROOT/.claude/agents/implementer.md"
+fails=0
+
+ok()   { echo "ok   — $1"; }
+fail() { echo "FAIL — $1"; fails=$((fails+1)); }
+
+has() { # file pattern description
+    if grep -q -- "$2" "$1" 2>/dev/null; then ok "$3"; else fail "$3 (missing: $2)"; fi
+}
+
+echo "== dispatch layer shape =="
+
+if [ ! -f "$SKILL" ]; then
+    echo "FAIL — $SKILL does not exist"; echo "1 FAILURE(S)"; exit 1
+fi
+
+# rule-48 preamble embedded VERBATIM (the two load-bearing sentences)
+has "$SKILL" "CRITICAL OPERATIONAL — binding" "brief template carries the preamble header"
+has "$SKILL" "does NOT set your initial cwd" "preamble carries the harness-cwd warning verbatim"
+has "$SKILL" "PR #1029" "preamble names the contamination precedent"
+
+# kill switch + global lock + lock order
+has "$SKILL" "dispatch-kill" "kill-switch check present"
+has "$SKILL" "agent-lock.sh acquire dispatch" "global dispatch lock acquired by the skill"
+has "$SKILL" "tracker-write" "tracker-write lock named"
+has "$SKILL" "deps-check.sh" "dependency gate wired"
+
+# lucid-informed integration tail
+has "$SKILL" "FROM the lane worktree" "merge runs from the lane worktree"
+has "$SKILL" "never pass \`--delete-branch\`" "no --delete-branch clause"
+has "$SKILL" "state,mergeCommit" "gh pr view merge disambiguation"
+has "$SKILL" "pull --rebase" "pull --rebase before tag"
+has "$SKILL" "git log origin/main..main" "committed-contamination detection"
+has "$SKILL" "check-write-set.sh" "write-set gate in the tail"
+has "$SKILL" "sim-lease.sh" "sim leases wired"
+
+# ledger + scheduling discipline
+has "$SKILL" "dispatched → returned → integrating" "ephemeral ledger statuses"
+has "$SKILL" "never persisted" "ledger declared ephemeral"
+has "$SKILL" "MERGED" "intra-batch dependency = merged, not returned"
+has "$SKILL" "vm_stat" "memory-pressure width degrade"
+has "$SKILL" "N=1" "single-item inline degrade kept"
+
+# context protection
+has "$SKILL" "never read" "never-READ list present"
+has "$SKILL" "--name-only" "diff reading capped at --name-only"
+has "$SKILL" ".reports/" "overflow channel named"
+
+# version-at-slot
+has "$SKILL" "bump_tier" "HANDOFF carries only bump_tier"
+has "$SKILL" "never pre-assign" "version-at-slot: no pre-assigned numbers"
+
+# dropped-by-design (replaces M1–M5)
+has "$SKILL" "Dropped by design" "dropped-by-design section present"
+
+# command stub
+if [ -f "$CMD" ] && grep -q "dispatch" "$CMD" && [ "$(wc -l < "$CMD" | tr -d ' ')" -le 20 ]; then
+    ok "commands/dispatch.md is a stub invoking the skill"
+else
+    fail "commands/dispatch.md stub missing or oversized"
+fi
+
+# implementer ladder (probe-shaped: custom agents get NO Skill tool — probed
+# 2026-07-09 twice, incl. with Skill in frontmatter; run-codex.sh is PRIMARY)
+has "$IMPL" "PROBED 2026-07-09" "implementer records the probe verdict"
+has "$IMPL" "run-codex.sh" "implementer names the watchdogged primary rung"
+if grep -q "Skill" <<<"$(head -4 "$IMPL")"; then fail "implementer frontmatter lists an ungrantable Skill tool"; else ok "implementer frontmatter honest (no phantom Skill grant)"; fi
+
+echo
+if [ "$fails" -eq 0 ]; then echo "ALL PASS"; exit 0; else echo "$fails FAILURE(S)"; exit 1; fi

--- a/scripts/__tests__/dispatch-shape.test.sh
+++ b/scripts/__tests__/dispatch-shape.test.sh
@@ -47,6 +47,25 @@ has "$SKILL" "git log origin/main..main" "committed-contamination detection"
 has "$SKILL" "check-write-set.sh" "write-set gate in the tail"
 has "$SKILL" "sim-lease.sh" "sim leases wired"
 
+# Gate-4 R1 operational invariants (audit thread 019f4467)
+has "$SKILL" "git -C <worktree> commit" "tail tracker/docs edits committed ON the lane branch"
+has "$SKILL" "as the branch's LAST commit" "bump is the branch's last commit, in the worktree"
+has "$SKILL" "after EACH successful merge" "tags are per-PR, never batch-end"
+has "$SKILL" "EVERY non-ready outcome" "one cleanup routine for all failure exits"
+has "$SKILL" "while still holding the \`dispatch\` lock" "inline fallbacks run under the dispatch lock"
+has "$SKILL" "worktree-teardown.sh <id> --delete-branch" "post-merge branch deletion via teardown flag"
+# ordering: the contamination check must be defined for use BEFORE the merge
+# (validation-time + pre-PR assertion) — assert both call sites exist
+CONTAM_VALIDATION=$(grep -n "HANDOFF validation + contamination check" "$SKILL" | head -1 | cut -d: -f1)
+CONTAM_PREPR=$(grep -n "second contamination check" "$SKILL" | head -1 | cut -d: -f1)
+MERGE_LINE=$(grep -n "gh pr merge --squash" "$SKILL" | head -1 | cut -d: -f1)
+if [ -n "$CONTAM_VALIDATION" ] && [ -n "$CONTAM_PREPR" ] && [ -n "$MERGE_LINE" ] \
+   && [ "$CONTAM_VALIDATION" -lt "$MERGE_LINE" ] && [ "$CONTAM_PREPR" -lt "$MERGE_LINE" ]; then
+    ok "contamination checks precede the merge (lines $CONTAM_VALIDATION,$CONTAM_PREPR < $MERGE_LINE)"
+else
+    fail "contamination-check ordering (validation=$CONTAM_VALIDATION prePR=$CONTAM_PREPR merge=$MERGE_LINE)"
+fi
+
 # ledger + scheduling discipline
 has "$SKILL" "dispatched → returned → integrating" "ephemeral ledger statuses"
 has "$SKILL" "never persisted" "ledger declared ephemeral"

--- a/scripts/__tests__/worktree.test.sh
+++ b/scripts/__tests__/worktree.test.sh
@@ -69,6 +69,16 @@ if [ "$RC" -ne 0 ] && [ -d "$WT" ]; then ok "teardown refuses dirty worktree"; e
 OUT="$(run_teardown issue-1 --force)"; RC=$?
 if [ "$RC" -eq 0 ] && [ ! -d "$WT" ]; then ok "teardown --force removes"; else fail "teardown --force (rc=$RC): $OUT"; fi
 
+# 6b. teardown --delete-branch removes the lane branch (post-merge path);
+#     plain teardown leaves it (requeue path needs it)
+OUT="$(run_setup issue-6 fix/issue-6-slug)"
+run_teardown issue-6 >/dev/null 2>&1
+if git -C "$REPO" rev-parse --verify -q fix/issue-6-slug >/dev/null; then ok "plain teardown preserves the branch"; else fail "plain teardown deleted the branch"; fi
+git -C "$REPO" worktree prune
+OUT="$(run_setup issue-7 fix/issue-7-slug)"
+run_teardown issue-7 --delete-branch >/dev/null 2>&1
+if ! git -C "$REPO" rev-parse --verify -q fix/issue-7-slug >/dev/null; then ok "--delete-branch removes the branch"; else fail "--delete-branch left the branch"; fi
+
 # 7. SETUP CAP RACE (Gate-4 Medium): 8 concurrent setups on an empty base →
 #    exactly 2 CREATED (the setup mutex serializes count+add)
 rm -rf "$REPO/.claude/worktrees"

--- a/scripts/__tests__/worktree.test.sh
+++ b/scripts/__tests__/worktree.test.sh
@@ -79,6 +79,18 @@ OUT="$(run_setup issue-7 fix/issue-7-slug)"
 run_teardown issue-7 --delete-branch >/dev/null 2>&1
 if ! git -C "$REPO" rev-parse --verify -q fix/issue-7-slug >/dev/null; then ok "--delete-branch removes the branch"; else fail "--delete-branch left the branch"; fi
 
+# 6c. flag permutations: --force --delete-branch in both orders
+git -C "$REPO" worktree prune
+run_setup issue-8 fix/issue-8-slug >/dev/null
+echo dirty > "$REPO/.claude/worktrees/issue-8/file.txt"
+run_teardown issue-8 --force --delete-branch >/dev/null 2>&1
+if [ ! -d "$REPO/.claude/worktrees/issue-8" ] && ! git -C "$REPO" rev-parse --verify -q fix/issue-8-slug >/dev/null; then ok "--force --delete-branch"; else fail "--force --delete-branch permutation"; fi
+git -C "$REPO" worktree prune
+run_setup issue-9 fix/issue-9-slug >/dev/null
+echo dirty > "$REPO/.claude/worktrees/issue-9/file.txt"
+run_teardown issue-9 --delete-branch --force >/dev/null 2>&1
+if [ ! -d "$REPO/.claude/worktrees/issue-9" ] && ! git -C "$REPO" rev-parse --verify -q fix/issue-9-slug >/dev/null; then ok "--delete-branch --force"; else fail "--delete-branch --force permutation"; fi
+
 # 7. SETUP CAP RACE (Gate-4 Medium): 8 concurrent setups on an empty base →
 #    exactly 2 CREATED (the setup mutex serializes count+add)
 rm -rf "$REPO/.claude/worktrees"

--- a/scripts/worktree-teardown.sh
+++ b/scripts/worktree-teardown.sh
@@ -1,16 +1,29 @@
 #!/usr/bin/env bash
-# worktree-teardown.sh <id> [--force] — remove a lane worktree + its
-# DerivedData (feature #130 WI-3; lifts the fix-issue M5 cleanup out of
-# skill prose). Refuses a worktree with uncommitted changes unless --force.
+# worktree-teardown.sh <id> [--force] [--delete-branch] — remove a lane
+# worktree + its DerivedData (feature #130 WI-3; lifts the fix-issue M5
+# cleanup out of skill prose). Refuses a worktree with uncommitted changes
+# unless --force. --delete-branch also deletes the lane's local branch —
+# POST-MERGE only (a requeued lane's branch must survive for the redo);
+# gh pr merge --delete-branch is banned (it checks out the default branch,
+# which fails in a linked worktree).
 #
-# Usage: worktree-teardown.sh <id> [--force]
+# Usage: worktree-teardown.sh <id> [--force] [--delete-branch]
 #   exit 0 REMOVED | 1 dirty without --force / git failure | 3 no such worktree
 
 set -euo pipefail
 
 id="${1:-}"
-force="${2:-}"
-[ -n "$id" ] || { echo "usage: worktree-teardown.sh <id> [--force]" >&2; exit 64; }
+[ -n "$id" ] || { echo "usage: worktree-teardown.sh <id> [--force] [--delete-branch]" >&2; exit 64; }
+force=""
+delete_branch=""
+shift || true
+for a in "$@"; do
+    case "$a" in
+        --force) force="--force" ;;
+        --delete-branch) delete_branch=1 ;;
+        *) echo "usage: worktree-teardown.sh <id> [--force] [--delete-branch]" >&2; exit 64 ;;
+    esac
+done
 
 ROOT="$(git rev-parse --show-toplevel)"
 WT="$ROOT/.claude/worktrees/$id"
@@ -25,10 +38,18 @@ if [ "$force" != "--force" ] && [ -n "$(git -C "$WT" status --porcelain 2>/dev/n
     exit 1
 fi
 
+BRANCH="$(git -C "$WT" branch --show-current 2>/dev/null || true)"
+
 if [ "$force" = "--force" ]; then
     git -C "$ROOT" worktree remove --force "$WT" >/dev/null
 else
     git -C "$ROOT" worktree remove "$WT" >/dev/null
+fi
+
+if [ -n "$delete_branch" ] && [ -n "$BRANCH" ]; then
+    git -C "$ROOT" branch -D "$BRANCH" >/dev/null 2>&1 \
+        && echo "[worktree-teardown] deleted branch $BRANCH" \
+        || echo "[worktree-teardown] branch $BRANCH not deleted (already gone?)" >&2
 fi
 
 # M5 DerivedData sweep: each worktree accrues ~5GB keyed on WorkspacePath.

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -8105,7 +8105,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1041;
+				CURRENT_PROJECT_VERSION = 1042;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8113,7 +8113,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.57;
+				MARKETING_VERSION = 3.67.0;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -8259,7 +8259,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1041;
+				CURRENT_PROJECT_VERSION = 1042;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8267,7 +8267,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.66.57;
+				MARKETING_VERSION = 3.67.0;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
## What (feature #130 WI-4 — behavioral tier; the capability WI, minor bump → 3.67.0)

- **`.claude/skills/dispatch/SKILL.md`** (+ command stub) — the full orchestrator playbook: lock-first preconditions (inline fallbacks run UNDER the dispatch lock), kill switch, vm_stat width gate, ephemeral in-context ledger, pre-spawn checklist (intra-batch dependency = MERGED), generated briefs (verbatim rule-48 preamble + skill-override + bug Phase-0.5), one cleanup routine for every non-ready HANDOFF, the serial integration tail (write-set gate → rebase-with-recovery → independent re-test → tracker edits committed ON the lane branch under tracker-write → version-at-slot → PR → merge FROM the lane worktree, never `--delete-branch` → `state,mergeCommit` disambiguation → per-PR tags), dual pre-merge contamination probes (porcelain + `origin/main..main` log), never-READ context protection, and the "Dropped by design" catalogue replacing M1–M5.
- **Skill-probe verdict recorded** (probed twice, incl. with Skill in frontmatter): custom agents get NO Skill tool in this harness → `scripts/run-codex.sh` is the lanes' PRIMARY Gate-4 rung (diverges from lucid's broad-toolset PASS, by measurement).
- Rules 48 ("Lane dispatch" section) + 40 ("Batch mode" version-at-slot); lane-mode override sections in fix-issue/feature-workflow (M1–M5 → REPLACED); implementer.md canonical lane order; `worktree-teardown.sh --delete-branch` (post-merge only); `dispatch-shape.test.sh` — 34 static gates incl. a contamination-before-merge ordering assertion.

## Gate 4

cc-suite, gpt-5.5: R1 (thread `019f4467…`) **block-recommended** — 1 Critical (tail-edit location ambiguity) + 4 High (contamination ordering, cleanup gaps, unlocked fallbacks, batch-end tags), all fixed in `39166a28`; R2 fresh-thread (thread `019f446d…`) **ship-as-is** (3 Lows fixed post-verdict). Artifact: `.claude/codex-audits/feat-feature-130-wi-4-dispatch-audit.md`.

## Gate 5a — SINGLE-LANE LIVE CANARY (passed)

Bug #360 (GH #1890) driven end-to-end through this skill's exact procedure, real everything:
`dispatch` lock → deps-check READY → `worktree-setup issue-1890` → real sim leased (`998D583D…`, booted on demand) → generated brief → **implementer lane: 6m47s, ~141k lane-tokens, ~1KB HANDOFF back** (RED-first 8-case hook test, deletion fix, in-lane run-codex Gate-4 ship-as-is r1) → HANDOFF valid → contamination probes clean ×2 → `check-write-set` CLEAN → rebase clean → independent re-test ALL PASS → tracker rows committed on the lane branch under `tracker-write` → version-at-slot **3.66.57** → PR #1892 **merged from the worktree** (audit-artifact hook validated the branch-committed artifact) → per-PR tag `v3.66.57` on the merge commit → `teardown --delete-branch` → lease released → `sim-lease status` **clean, zero held** → bug #1890 verified + closed.

Canary findings folded back: rule 55's `test_result_line` schema pattern is too narrow for bash-suite lanes (`ALL PASS` vs `RUN-* RESULT:`) — noted for the M-SHAKEDOWN round; sim leases could be need-based for hook-only lanes (observation, not a defect).

Part of feature #130