### PR TITLE
test(#128 WI-2): fix addedAt round-trip assertion to second precision

### DIFF
--- a/.claude/codex-audits/feat-128-wi2-addedat-test-precision-audit.md
+++ b/.claude/codex-audits/feat-128-wi2-addedat-test-precision-audit.md
@@ -1,0 +1,32 @@
+---
+branch: feat/128-wi2-addedat-test-precision
+threadId: run-codex-inline-wi2fix
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-07-11
+---
+
+# Gate-4 audit — #128 WI-2 addedAt connected-test precision fix
+
+**Context:** the WI-2 live WebDAV round-trip (Gate-5) failed on
+`WebDavRoundTripConnectedTest.authorSurvivesRoundTrip_overLiveWebDav:188` —
+`addedAt survived the round-trip expected:<…261314> but was:<…261000>`. Root
+cause: the backup manifest's `IsoInstantSerializer` (`android/identity/.../backup/BackupJson.kt:41`)
+encodes timestamps with `.truncatedTo(ChronoUnit.SECONDS)` (iOS `.iso8601`
+parity), so `addedAt` round-trips at **whole-second** precision by contract.
+WI-2 did not change `addedAt` handling (identical `toEpochMilli()` before and
+after), so this is a too-strict test assertion, not a product defect.
+
+**Fix:** one line — the connected test now asserts `addedAt / 1000 ==
+restored.addedAt / 1000` (second precision) instead of exact-millis equality,
+with an explanatory comment citing the serializer.
+
+**Codex verdict: ship-as-is.**
+- (1) The fix correctly matches the serializer's seconds truncation.
+- (2) Test-only; no production behavior change.
+- (3) Coverage not weakened — `author` and `title` are still asserted exactly;
+  only `addedAt` is relaxed to its contractual second precision.
+
+**Re-verification:** the round-trip re-ran green from the worktree harness —
+`RUN-WEBDAV-ROUNDTRIP RESULT: SUCCEEDED`, `tests="2" failures="0"` (both
+`authorSurvivesRoundTrip_overLiveWebDav` and `backup_then_restore_overLiveWebDav`).

--- a/android/app/src/androidTest/kotlin/com/vreader/app/backup/WebDavRoundTripConnectedTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/backup/WebDavRoundTripConnectedTest.kt
@@ -185,7 +185,10 @@ class WebDavRoundTripConnectedTest {
             assertNotNull("book restored", restored)
             assertEquals("author survived the round-trip", "Herman Melville", restored!!.author)
             assertEquals("title survived the round-trip", book.title, restored.title)
-            assertEquals("addedAt survived the round-trip", addedAt, restored.addedAt)
+            // The backup manifest serializes timestamps at SECOND precision (IsoInstantSerializer
+            // truncatedTo SECONDS, iOS `.iso8601` parity), so addedAt round-trips to the whole second —
+            // the sub-second millis are dropped by contract. Assert equality at second precision.
+            assertEquals("addedAt survived the round-trip (second precision)", addedAt / 1000, restored.addedAt / 1000)
         } finally {
             db.close()
             booksDir.deleteRecursively()

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.13.18
-versionCode=91
+versionName=0.13.19
+versionCode=92


### PR DESCRIPTION
Follow-up to WI-2 (#1911). The live WebDAV round-trip (WI-2 Gate-5) surfaced that the new `authorSurvivesRoundTrip_overLiveWebDav` asserted `addedAt` at exact millis, but the backup manifest's `IsoInstantSerializer` truncates timestamps to whole seconds (iOS `.iso8601` parity). Test-only fix (second-precision comparison); production code unchanged. Round-trip now green (`tests=2 failures=0`). Gate-4 Codex ship-as-is.

Refs #1901