### PR TITLE
design: import needs-design artboards (cover/annotation-actions/bookmark-delete/collections-delete)

### DIFF
--- a/dev-docs/designs/vreader-fidelity-v1/project/vreader-annotations-actions.jsx
+++ b/dev-docs/designs/vreader-fidelity-v1/project/vreader-annotations-actions.jsx
@@ -1,0 +1,359 @@
+// Android annotations review-card per-card affordances · issue #1902
+// (blocks feature #132 — Android reader nav chrome, annotations review sheet;
+//  parity box B/F).
+//
+// The committed Android review sheet (AnnotationsSheet in
+// vreader-android-annotations.jsx) renders HighlightCard / StandaloneNoteCard /
+// BookmarkCard as tap-to-jump-only rows. Copy/Share exist ONLY on the in-reader
+// SelectionPopover (a different surface), and only a sheet-level Share is drawn.
+// There is NO per-card ⋯ overflow → Edit / Copy / Delete on Android — that menu
+// is the iOS HighlightsSheetV4 surface (vreader-notes-delete.jsx #1103). So
+// per-card Copy/Share and Edit / Delete-from-sheet have no Android depiction.
+// Feature #132 ships without them (sheet-level Share + tap-to-jump only). This
+// file designs the Android depiction so a follow-up can add them.
+//
+// ────────────────────────────────────────────────────
+// DECISION SUMMARY
+// ────────────────────────────────────────────────────
+//
+// Canonical · a per-card ACTION ROW under the card body — the two verbs the
+//   issue names as missing (Copy · Share) as labelled targets, plus a trailing
+//   ⋯ overflow that carries the destructive + edit verbs (Edit · Delete). This
+//   is the Android-idiomatic split: frequent, safe actions are one tap on a
+//   visible control; Edit/Delete live behind the overflow so a mis-tap can't
+//   mutate. It also re-uses the SelectionPopover's own Copy/Share vocabulary,
+//   so the reader and the review sheet speak the same language.
+//
+// Alternate · a trailing ⋯ overflow ONLY (Material "more" affordance in the
+//   meta row) carrying Edit · Copy · Share · Delete — denser, and 1:1 with the
+//   committed iOS ⋯ menu. Shown for comparison; not canonical because it hides
+//   the two most-used verbs behind a second tap on a touch device.
+//
+// Overflow menu · Material dropdown anchored to the ⋯. Edit · Copy · Share,
+//   then a divider, then Delete in destructive ink. Bookmark cards get a
+//   reduced menu (Copy · Share · Delete — no Edit; there's nothing to edit on a
+//   bookmark; bookmark deletion is scoped to its own issue #1903).
+//
+// Delete · inline row-replacement confirm — the SAME vocabulary as the iOS
+//   NotesDeleteConfirm (#1103) and the collections-delete confirm (#1875):
+//   a target-named title, one line naming what's lost, a Cancel / Delete pill
+//   pair in destructive ink. No system dialog — the confirm replaces the card
+//   body so the user keeps their place in the list.
+//
+// Failure · the body collapses to a tinted error chip with Retry (re-invokes
+//   the delete) + Undo (restores the row; nothing committed on failure).
+//
+// Note-edit entry · Edit swaps the card body for an inline compose field
+//   (Android annotations already compose notes inline in the SelectionPopover),
+//   with Cancel / Save. Standalone-note Edit needs an updateNote /
+//   updateNoteContent API (flagged in the issue) — the design is API-ready.
+
+const AA_SANS = "'Inter', -apple-system, system-ui, sans-serif";
+const AA_SERIF = '"Source Serif 4", Georgia, serif';
+
+function aaDanger(ui) { return ui.isDark ? '#e0775a' : '#a8402f'; }
+
+// Local glyphs (stroke 1.6, 24-box) — Copy / Share / Edit / Trash / More / dot.
+function AAGlyph({ name, size = 18, color = 'currentColor' }) {
+  const common = { width: size, height: size, viewBox: '0 0 24 24', fill: 'none',
+    stroke: color, strokeWidth: 1.7, strokeLinecap: 'round', strokeLinejoin: 'round' };
+  if (name === 'copy') return <svg {...common}><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 012-2h8"/></svg>;
+  if (name === 'share') return <svg {...common}><path d="M12 3v13M8 7l4-4 4 4M5 14v5a2 2 0 002 2h10a2 2 0 002-2v-5"/></svg>;
+  if (name === 'edit') return <svg {...common}><path d="M13 4l7 7-9 9H4v-7z"/><path d="M11 6l7 7"/></svg>;
+  if (name === 'trash') return <svg {...common}><path d="M4 7h16M9 7V5a1 1 0 011-1h4a1 1 0 011 1v2M6 7l1 13a1.6 1.6 0 001.6 1.5h6.8A1.6 1.6 0 0017 20l1-13M10 11v6M14 11v6"/></svg>;
+  if (name === 'more') return <svg width={size} height={size} viewBox="0 0 24 24"><circle cx="12" cy="5" r="1.6" fill={color}/><circle cx="12" cy="12" r="1.6" fill={color}/><circle cx="12" cy="19" r="1.6" fill={color}/></svg>;
+  return null;
+}
+function AASpinner({ size = 13, color = 'currentColor' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" style={{ animation: 'apfSpin .8s linear infinite' }}>
+      <circle cx="12" cy="12" r="9" stroke={color} strokeOpacity="0.25" strokeWidth="2.6" />
+      <path d="M12 3a9 9 0 019 9" stroke={color} strokeWidth="2.6" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+// ── the per-card action row: Copy · Share ······ ⋯ ───────────
+function AAActionRow({ ui, onMenu }) {
+  const btn = (name, label) => (
+    <button style={{
+      display: 'inline-flex', alignItems: 'center', gap: 7, border: 'none', cursor: 'pointer',
+      background: 'transparent', padding: '7px 10px', borderRadius: 9,
+      fontFamily: AA_SANS, fontSize: 13, fontWeight: 500, color: ui.sec,
+    }}>
+      <AAGlyph name={name} size={16} color={ui.sec} />{label}
+    </button>
+  );
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 2, marginTop: 10, paddingTop: 9,
+      borderTop: `0.5px solid ${ui.sep}`, marginLeft: -6,
+    }}>
+      {btn('copy', 'Copy')}
+      {btn('share', 'Share')}
+      <span style={{ flex: 1 }} />
+      <button aria-label="More actions" onClick={onMenu} style={{
+        width: 32, height: 32, borderRadius: 16, border: 'none', cursor: 'pointer',
+        background: 'transparent', display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}>
+        <AAGlyph name="more" size={18} color={ui.sec} />
+      </button>
+    </div>
+  );
+}
+
+// ── Material overflow menu (Edit · Copy · Share · Delete) ─────
+function AAOverflowMenu({ ui, kind = 'highlight' }) {
+  const danger = aaDanger(ui);
+  const items = [];
+  if (kind !== 'bookmark') items.push({ name: 'edit', label: kind === 'standalone' ? 'Edit note' : 'Edit note' });
+  items.push({ name: 'copy', label: kind === 'bookmark' ? 'Copy link' : 'Copy quote' });
+  items.push({ name: 'share', label: 'Share' });
+  items.push({ name: 'trash', label: kind === 'standalone' ? 'Delete note' : kind === 'bookmark' ? 'Delete bookmark' : 'Delete highlight', danger: true, divider: true });
+  return (
+    <div style={{
+      position: 'absolute', top: 4, right: 4, zIndex: 50, minWidth: 188, padding: '6px 0',
+      borderRadius: 14, background: ui.isDark ? '#2f2c28' : '#fdf9ec',
+      boxShadow: '0 14px 34px rgba(0,0,0,0.30), 0 0 0 0.5px ' + (ui.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'),
+      transformOrigin: 'top right',
+    }}>
+      {items.map((it) => (
+        <div key={it.name} style={{
+          display: 'flex', alignItems: 'center', gap: 13, padding: '11px 16px',
+          borderTop: it.divider ? `0.5px solid ${ui.sep}` : 'none',
+          fontFamily: AA_SANS, fontSize: 14.5, fontWeight: it.danger ? 600 : 500,
+          color: it.danger ? danger : ui.ink,
+        }}>
+          <AAGlyph name={it.name} size={17} color={it.danger ? danger : ui.ink} />
+          <span>{it.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── inline delete confirm — NotesDeleteConfirm vocabulary, ui-toned ──
+function AADeleteConfirm({ ui, kind = 'highlight', busy }) {
+  const danger = aaDanger(ui);
+  const title = kind === 'standalone' ? 'Delete this note?' : kind === 'bookmark' ? 'Delete this bookmark?' : 'Delete this highlight?';
+  const body = kind === 'standalone'
+    ? "The note comes off the chapter. Can’t be undone."
+    : kind === 'bookmark'
+    ? "The saved place is removed. Can’t be undone."
+    : "The colour, the note, and the underline come off the page. Can’t be undone.";
+  return (
+    <div style={{
+      marginTop: 10, borderRadius: 11, padding: '12px 13px 13px',
+      background: ui.isDark ? 'rgba(224,119,90,0.08)' : 'rgba(168,64,47,0.05)',
+      border: `0.5px solid ${ui.isDark ? 'rgba(224,119,90,0.24)' : 'rgba(168,64,47,0.18)'}`,
+    }}>
+      <div style={{ fontFamily: AA_SANS, fontSize: 13.5, fontWeight: 600, color: ui.ink, marginBottom: 3 }}>{title}</div>
+      <div style={{ fontFamily: AA_SANS, fontSize: 12, lineHeight: 1.45, color: ui.sec, marginBottom: 12, textWrap: 'pretty' }}>{body}</div>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button disabled={busy} style={{
+          flex: 1, padding: '9px 0', borderRadius: 9, border: `0.5px solid ${ui.sep}`,
+          background: 'transparent', fontFamily: AA_SANS, fontSize: 13, fontWeight: 500,
+          color: ui.ink, cursor: busy ? 'default' : 'pointer', opacity: busy ? 0.4 : 1,
+        }}>Cancel</button>
+        <button disabled={busy} style={{
+          flex: 1, padding: '9px 0', borderRadius: 9, border: 'none', background: danger, color: '#fff',
+          fontFamily: AA_SANS, fontSize: 13, fontWeight: 600, cursor: busy ? 'default' : 'pointer',
+          display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 7, opacity: busy ? 0.9 : 1,
+        }}>
+          {busy && <AASpinner size={12} color="#fff" />}
+          {busy ? 'Deleting…' : 'Delete'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── failed-delete chip — Retry + Undo (NotesRowError vocabulary) ──
+function AARowError({ ui, kind = 'highlight' }) {
+  const danger = aaDanger(ui);
+  return (
+    <div style={{
+      marginTop: 10, borderRadius: 11, padding: '11px 12px',
+      display: 'flex', alignItems: 'center', gap: 10,
+      background: ui.isDark ? 'rgba(224,119,90,0.10)' : 'rgba(168,64,47,0.07)',
+      border: `0.5px solid ${ui.isDark ? 'rgba(224,119,90,0.28)' : 'rgba(168,64,47,0.22)'}`,
+    }}>
+      <div style={{ width: 20, height: 20, borderRadius: 10, flexShrink: 0, background: danger, color: '#fff',
+        display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <svg width="11" height="11" viewBox="0 0 14 14" fill="none"><path d="M7 3v5M7 10.5v.5" stroke="#fff" strokeWidth="1.7" strokeLinecap="round" /></svg>
+      </div>
+      <div style={{ flex: 1, fontFamily: AA_SANS, fontSize: 12, color: ui.ink, lineHeight: 1.35 }}>
+        Couldn’t delete — {kind === 'standalone' ? 'the note' : kind === 'bookmark' ? 'the bookmark' : 'the highlight'} is still here.
+      </div>
+      <button style={{ padding: '5px 12px', borderRadius: 100, border: `0.5px solid ${ui.sep}`, background: 'transparent',
+        cursor: 'pointer', fontFamily: AA_SANS, fontSize: 12, fontWeight: 600, color: ui.ink }}>Retry</button>
+      <button style={{ padding: '5px 10px', borderRadius: 100, border: 'none', background: 'transparent',
+        cursor: 'pointer', fontFamily: AA_SANS, fontSize: 12, fontWeight: 500, color: ui.sec }}>Undo</button>
+    </div>
+  );
+}
+
+// ── inline note editor (Edit entry) ──────────────────────────
+function AANoteEditor({ ui, color, text }) {
+  const c = window.HL_COLORS.find((x) => x.key === color) || window.HL_COLORS[0];
+  return (
+    <div style={{ marginTop: 10 }}>
+      <div style={{
+        background: ui.isDark ? 'rgba(255,255,255,0.05)' : 'rgba(29,26,20,0.04)', borderRadius: 10,
+        padding: '10px 12px', fontFamily: AA_SANS, fontSize: 13.5, color: ui.ink, lineHeight: 1.5,
+        boxShadow: `inset 0 0 0 1.5px ${ui.tint}`, minHeight: 58,
+      }}>
+        {text}<span style={{ display: 'inline-block', width: 1.5, height: 15, background: ui.tint, verticalAlign: -2, marginLeft: 1 }} />
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 11 }}>
+        {color != null && window.HL_COLORS.map((cc) => (
+          <div key={cc.key} style={{ width: 22, height: 22, borderRadius: 11, background: cc.dot,
+            boxShadow: cc.key === color ? `0 0 0 2px ${ui.card}, 0 0 0 3.5px ${cc.dot}` : 'none' }} />
+        ))}
+        <span style={{ flex: 1 }} />
+        <button style={{ border: 'none', background: 'transparent', fontFamily: AA_SANS, fontSize: 13.5, fontWeight: 500, color: ui.sec, padding: '6px 8px', cursor: 'pointer' }}>Cancel</button>
+        <button style={{ border: 'none', background: ui.tint, color: '#fff', fontFamily: AA_SANS, fontSize: 13.5, fontWeight: 600, borderRadius: 9, padding: '7px 16px', cursor: 'pointer' }}>Save</button>
+      </div>
+    </div>
+  );
+}
+
+// ═════════════════════════════════════════════════════
+// AACard — a review card + affordance + per-card state machine.
+//   kind       : 'highlight' | 'standalone' | 'bookmark'
+//   affordance : 'row' (canonical) | 'overflow' (alternate)
+//   state      : 'default' | 'menu' | 'confirm' | 'deleting' | 'error' | 'editing'
+// ═════════════════════════════════════════════════════
+function AACard({ ui, rec, affordance = 'row', state = 'default' }) {
+  const kind = rec.kind;
+  const danger = aaDanger(ui);
+  const menu = state === 'menu';
+  const confirm = state === 'confirm';
+  const deleting = state === 'deleting';
+  const errored = state === 'error';
+  const editing = state === 'editing';
+  const c = kind === 'highlight' ? (window.HL_COLORS.find((x) => x.key === rec.color) || window.HL_COLORS[0]) : null;
+
+  // left rule
+  const rule = kind === 'highlight'
+    ? { width: 4, borderRadius: 2, background: c.rule }
+    : kind === 'standalone'
+    ? { width: 4, borderRadius: 2, background: `repeating-linear-gradient(${ui.tint} 0 4px, transparent 4px 8px)` }
+    : null;
+
+  const bodyDim = deleting ? 0.5 : 1;
+
+  return (
+    <div style={{ background: ui.card, borderRadius: 14, padding: '14px 15px', boxShadow: ui.cardShadow, position: 'relative', marginBottom: 10 }}>
+      {menu && <AAOverflowMenu ui={ui} kind={kind} />}
+      <div style={{ display: 'flex', gap: kind === 'bookmark' ? 12 : 12 }}>
+        {rule && <div style={{ flexShrink: 0, ...rule }} />}
+        {kind === 'bookmark' && <window.Icons.BookmarkFilled size={20} color={ui.tint} style={{ flexShrink: 0, marginTop: 1 }} />}
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          {/* meta row (overflow affordance lives here) */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginBottom: kind === 'bookmark' ? 3 : 8, fontFamily: AA_SANS, fontSize: 12, color: ui.ter }}>
+            {kind === 'standalone' && (
+              <span style={{ fontFamily: AA_SANS, fontSize: 9.5, fontWeight: 700, letterSpacing: 0.5, color: ui.tint, background: ui.tagBg, borderRadius: 5, padding: '2px 6px' }}>STANDALONE</span>
+            )}
+            <span>{rec.meta}</span>
+            {kind === 'highlight' && rec.note != null && <span style={{ color: ui.tint, fontWeight: 600 }}>· Note</span>}
+            <span style={{ flex: 1 }} />
+            {deleting ? (
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: ui.sec }}>
+                <AASpinner size={12} color={ui.sec} />Deleting…
+              </span>
+            ) : affordance === 'overflow' && !confirm && !errored && !editing ? (
+              <button aria-label="More actions" style={{
+                width: 30, height: 30, marginRight: -6, borderRadius: 15, border: 'none', cursor: 'pointer',
+                background: menu ? (ui.isDark ? 'rgba(255,255,255,0.10)' : 'rgba(0,0,0,0.06)') : 'transparent',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+              }}>
+                <AAGlyph name="more" size={17} color={ui.sec} />
+              </button>
+            ) : null}
+          </div>
+
+          {/* body */}
+          {confirm ? (
+            <AADeleteConfirm ui={ui} kind={kind} />
+          ) : deleting ? (
+            <AADeleteConfirm ui={ui} kind={kind} busy />
+          ) : errored ? (
+            <AARowError ui={ui} kind={kind} />
+          ) : editing ? (
+            <>
+              <div style={{ fontFamily: AA_SERIF, fontSize: 15, lineHeight: 1.5, color: ui.ink, opacity: kind === 'highlight' ? 1 : 0.5 }}>
+                {kind === 'highlight' ? rec.quote : null}
+              </div>
+              <AANoteEditor ui={ui} color={kind === 'highlight' ? rec.color : null} text={rec.note || rec.body} />
+            </>
+          ) : (
+            <>
+              {kind === 'bookmark' ? (
+                <div style={{ fontFamily: AA_SERIF, fontSize: 15, color: ui.ink, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', opacity: bodyDim }}>{rec.label}</div>
+              ) : kind === 'standalone' ? (
+                <div style={{ fontFamily: AA_SERIF, fontSize: 15.5, lineHeight: 1.52, color: ui.ink, opacity: bodyDim }}>{rec.body}</div>
+              ) : (
+                <>
+                  <div style={{ fontFamily: AA_SERIF, fontSize: 15.5, lineHeight: 1.5, color: ui.ink, opacity: bodyDim }}>{rec.quote}</div>
+                  {rec.note != null && (
+                    <div style={{ marginTop: 9, paddingTop: 9, borderTop: `0.5px solid ${ui.sep}`, fontFamily: AA_SANS, fontSize: 13.5, lineHeight: 1.5, color: ui.sec, opacity: bodyDim }}>{rec.note}</div>
+                  )}
+                </>
+              )}
+              {/* action row affordance */}
+              {affordance === 'row' && <AAActionRow ui={ui} />}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ═════════════════════════════════════════════════════
+// AnnotationsSheetV2 — the committed review sheet, now with per-card
+// affordances. One row can be forced into a non-default state.
+// ═════════════════════════════════════════════════════
+const AA_RECORDS = [
+  { id: 'h1', kind: 'highlight', color: 'yellow',
+    quote: '“She was a woman of mean understanding, little information, and uncertain temper.”',
+    note: "Austen's irony lands in the dependent clause.", meta: 'Ch. 1 · Apr 18' },
+  { id: 'n1', kind: 'standalone',
+    body: 'Track how often weather forces the plot — Jane’s cold at Netherfield is the first.', meta: 'Ch. 7 · Apr 19' },
+  { id: 'h2', kind: 'highlight', color: 'green',
+    quote: '“It is a truth universally acknowledged…”', note: null, meta: 'Ch. 1 · Apr 18' },
+  { id: 'b1', kind: 'bookmark',
+    label: '“…the rightful property of some one or other of their daughters.”', meta: 'Ch. 1 · 14%' },
+];
+
+function AnnotationsSheetV2({ ui, affordance = 'row', forcedId = 'h1', forcedState = 'default', height = 880 }) {
+  return (
+    <window.PhoneFrame ui={ui} height={height}>
+      <div style={{ position: 'absolute', inset: 0, background: ui.bg }} />
+      <window.AppSheet ui={ui} title="Annotations"
+        leading={<button style={{ background: 'none', border: 'none', padding: 0, fontFamily: AA_SANS, fontSize: 15, color: ui.sec }}>Close</button>}
+        trailing={<window.Icons.Share size={20} color={ui.tint} />}
+        height={height - 36}>
+        <div style={{ padding: '12px 16px 32px' }}>
+          <div style={{ marginBottom: 10 }}>
+            <div style={{ fontFamily: AA_SERIF, fontStyle: 'italic', fontSize: 19, color: ui.ink }}>Pride and Prejudice</div>
+            <div style={{ fontFamily: AA_SANS, fontSize: 12.5, color: ui.sec, marginTop: 2 }}>12 highlights · 4 notes · 3 bookmarks</div>
+          </div>
+          <window.FilterChips ui={ui} active="All" />
+          <div style={{ height: 12 }} />
+          {AA_RECORDS.map((rec) => (
+            <AACard key={rec.id} ui={ui} rec={rec} affordance={affordance}
+              state={rec.id === forcedId ? forcedState : 'default'} />
+          ))}
+        </div>
+      </window.AppSheet>
+    </window.PhoneFrame>
+  );
+}
+
+Object.assign(window, {
+  AACard, AnnotationsSheetV2, AAOverflowMenu, AADeleteConfirm, AARowError,
+  AAActionRow, AANoteEditor, AA_RECORDS,
+});

--- a/dev-docs/designs/vreader-fidelity-v1/project/vreader-bookmark-delete.jsx
+++ b/dev-docs/designs/vreader-fidelity-v1/project/vreader-bookmark-delete.jsx
@@ -1,0 +1,253 @@
+// Android bookmark row deletion (swipe / long-press / confirm) · issue #1903
+// (blocks feature #135 — Android bookmarks, split from #132; parity box F).
+//
+// The committed bookmark rows are tap-to-jump-only: the TOC/Bookmarks sheet
+// rows (vreader-panels.jsx TOCSheet → Bookmarks tab) and the annotations
+// review BookmarkCard (vreader-android-annotations.jsx) draw NO delete
+// affordance. The committed iOS delete design (vreader-notes-delete.jsx)
+// explicitly scopes its ⋯ Edit/Copy/Delete menu to highlight + standalone-note
+// cards, NOT bookmarks. So bookmark delete has no design-grounded control and
+// feature #135 ships create + jump + list without it. This file designs the
+// Android bookmark-delete interaction so a follow-up can add it.
+//
+// Rendered in the reader THEMES vocabulary (window.THEMES + the committed Sheet
+// from vreader-panels.jsx), because the TOC/Bookmarks sheet is a reader-chrome
+// surface. The same confirm applies to the annotations BookmarkCard (see #1902,
+// which already routes that card's ⋯ → the ui-toned confirm).
+//
+// ────────────────────────────────────────────────────
+// DECISION SUMMARY
+// ────────────────────────────────────────────────────
+//
+// Affordance · BOTH, as Android users expect on a list:
+//   1. Swipe the row left → a destructive Delete panel slides in from the
+//      trailing edge (trash glyph + "Delete"). Releasing past threshold does
+//      NOT auto-destroy — it parks the row open; the Delete panel is the tap
+//      target. (No blind full-swipe-dismiss: a bookmark is cheap to lose track
+//      of, and the surface is a list you scan, not an inbox you triage.)
+//   2. Long-press the row → a small Material menu (Copy link · Share · Delete).
+//      This is the discoverable + accessible path (TalkBack / Switch Access
+//      land on labelled items), and it's where Copy/Share live too.
+//
+// Confirm · a Material centre dialog — "Delete bookmark?" + the passage it
+//   marks + Cancel / Delete (destructive ink). Bookmarks earn a real dialog
+//   (not the inline row-confirm the annotation cards use) because a swipe or a
+//   long-press-Delete is easy to trigger by accident, and the row is about to
+//   leave the list entirely. Copy in the dialog names the passage so you know
+//   which place you're forgetting.
+//
+// Failure · the delete is optimistic — the row animates out immediately and a
+//   Snackbar appears ("Bookmark deleted · Undo"). If the persistence call
+//   fails, the Snackbar swaps to an error ("Couldn't delete · Retry") and the
+//   row animates back in. Undo restores the row before the call, so a
+//   fat-fingered delete is always recoverable.
+
+const BM_SANS = "'Inter', -apple-system, system-ui, sans-serif";
+const BM_SERIF = '"Source Serif 4", Georgia, serif';
+
+function bmDanger(t) { return t.isDark ? '#e0775a' : '#a8402f'; }
+
+const BOOKMARKS = [
+  { id: 'bm1', page: 1, chapter: 'Chapter 1', date: 'Apr 12', pct: '0%',
+    preview: 'It is a truth universally acknowledged…' },
+  { id: 'bm2', page: 47, chapter: 'Chapter 6', date: 'Apr 18', pct: '31%',
+    preview: 'Charlotte’s view on marriage' },
+  { id: 'bm3', page: 89, chapter: 'Chapter 11', date: 'Yesterday', pct: '58%',
+    preview: 'The Netherfield ball' },
+];
+
+// ── the swipe-behind destructive panel ──────────────────────
+function BMDeletePanel({ t, revealed }) {
+  const danger = bmDanger(t);
+  return (
+    <div style={{
+      position: 'absolute', top: 6, bottom: 6, right: 0, width: 88,
+      background: danger, borderRadius: 12,
+      display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 3,
+      opacity: revealed ? 1 : 0, transition: 'opacity .15s',
+    }}>
+      <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M4 7h16M9 7V5a1 1 0 011-1h4a1 1 0 011 1v2M6 7l1 13a1.6 1.6 0 001.6 1.5h6.8A1.6 1.6 0 0017 20l1-13M10 11v6M14 11v6"/>
+      </svg>
+      <span style={{ fontFamily: BM_SANS, fontSize: 11, fontWeight: 600, color: '#fff' }}>Delete</span>
+    </div>
+  );
+}
+
+// ── long-press Material menu ─────────────────────────────────
+function BMLongPressMenu({ t }) {
+  const danger = bmDanger(t);
+  const rowBg = t.isDark ? '#2f2c28' : '#fdf9ec';
+  const items = [
+    { name: 'copy', label: 'Copy link' },
+    { name: 'share', label: 'Share' },
+    { name: 'trash', label: 'Delete', danger: true, divider: true },
+  ];
+  const glyph = (name, color) => {
+    const common = { width: 17, height: 17, viewBox: '0 0 24 24', fill: 'none', stroke: color, strokeWidth: 1.7, strokeLinecap: 'round', strokeLinejoin: 'round' };
+    if (name === 'copy') return <svg {...common}><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 012-2h8"/></svg>;
+    if (name === 'share') return <svg {...common}><path d="M12 3v13M8 7l4-4 4 4M5 14v5a2 2 0 002 2h10a2 2 0 002-2v-5"/></svg>;
+    return <svg {...common}><path d="M4 7h16M9 7V5a1 1 0 011-1h4a1 1 0 011 1v2M6 7l1 13a1.6 1.6 0 001.6 1.5h6.8A1.6 1.6 0 0017 20l1-13M10 11v6M14 11v6"/></svg>;
+  };
+  return (
+    <div style={{
+      position: 'absolute', top: 44, right: 16, zIndex: 60, minWidth: 184, padding: '6px 0',
+      borderRadius: 14, background: rowBg,
+      boxShadow: '0 16px 36px rgba(0,0,0,0.34), 0 0 0 0.5px ' + (t.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'),
+    }}>
+      {items.map((it) => (
+        <div key={it.name} style={{
+          display: 'flex', alignItems: 'center', gap: 13, padding: '11px 16px',
+          borderTop: it.divider ? `0.5px solid ${t.rule}` : 'none',
+          fontFamily: BM_SANS, fontSize: 14.5, fontWeight: it.danger ? 600 : 500,
+          color: it.danger ? danger : t.ink,
+        }}>
+          {glyph(it.name, it.danger ? danger : t.ink)}
+          <span>{it.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── a bookmark row ───────────────────────────────────────────
+// state: 'default' | 'swipe' | 'menu' | 'pressed'
+function BookmarkRow({ t, bm, state = 'default', last }) {
+  const swipe = state === 'swipe';
+  const pressed = state === 'pressed' || state === 'menu';
+  return (
+    <div style={{ position: 'relative' }}>
+      <BMDeletePanel t={t} revealed={swipe} />
+      <div style={{
+        position: 'relative', display: 'flex', alignItems: 'flex-start', gap: 12,
+        padding: '14px 4px', borderRadius: 12,
+        borderBottom: last ? 'none' : `0.5px solid ${t.rule}`,
+        background: pressed ? (t.isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.035)') : (t.isDark ? '#21201c' : '#fcf8f0'),
+        transform: swipe ? 'translateX(-96px)' : 'none',
+        transition: 'transform .2s cubic-bezier(.32,.72,0,1)',
+      }}>
+        <window.Icons.BookmarkFilled size={18} color={t.accent} style={{ marginTop: 1, flexShrink: 0 }} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontFamily: BM_SERIF, fontSize: 14.5, fontStyle: 'italic', color: t.ink, lineHeight: 1.3, marginBottom: 4 }}>{bm.preview}</div>
+          <div style={{ fontFamily: BM_SANS, fontSize: 11, color: t.sub }}>{bm.chapter} · p. {bm.page} · {bm.date}</div>
+        </div>
+        <window.Icons.Chevron size={14} color={t.sub} stroke={2} style={{ marginTop: 3, flexShrink: 0 }} />
+      </div>
+    </div>
+  );
+}
+
+// ── Material centre confirm dialog ───────────────────────────
+function BMConfirmDialog({ t, bm, busy }) {
+  const danger = bmDanger(t);
+  return (
+    <div style={{ position: 'absolute', inset: 0, zIndex: 300, background: 'rgba(0,0,0,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 28 }}>
+      <div style={{
+        width: '100%', maxWidth: 320, background: t.isDark ? '#2b2823' : '#fcf8f0', borderRadius: 20,
+        padding: '22px 22px 16px', boxShadow: '0 24px 60px rgba(0,0,0,0.4)',
+      }}>
+        <div style={{ fontFamily: BM_SERIF, fontSize: 19, fontWeight: 600, color: t.ink, marginBottom: 8 }}>Delete bookmark?</div>
+        <div style={{ fontFamily: BM_SANS, fontSize: 13.5, lineHeight: 1.5, color: t.sub, textWrap: 'pretty' }}>
+          The saved place at{' '}
+          <span style={{ fontStyle: 'italic', color: t.ink, fontFamily: BM_SERIF }}>“{bm.preview}”</span>{' '}
+          ({bm.chapter} · p. {bm.page}) is removed. Your reading position isn’t affected.
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 6, marginTop: 20 }}>
+          <button style={{ border: 'none', background: 'transparent', cursor: 'pointer', fontFamily: BM_SANS, fontSize: 14, fontWeight: 600, color: t.accent, padding: '10px 14px', borderRadius: 10 }}>Cancel</button>
+          <button style={{ border: 'none', background: 'transparent', cursor: 'pointer', fontFamily: BM_SANS, fontSize: 14, fontWeight: 600, color: danger, padding: '10px 14px', borderRadius: 10, display: 'inline-flex', alignItems: 'center', gap: 7 }}>
+            {busy && <svg width="13" height="13" viewBox="0 0 24 24" fill="none" style={{ animation: 'apfSpin .8s linear infinite' }}><circle cx="12" cy="12" r="9" stroke={danger} strokeOpacity="0.25" strokeWidth="2.6"/><path d="M12 3a9 9 0 019 9" stroke={danger} strokeWidth="2.6" strokeLinecap="round"/></svg>}
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Snackbar (deleted-with-undo / failure-with-retry) ────────
+function BMSnackbar({ t, variant = 'deleted' }) {
+  const danger = bmDanger(t);
+  const err = variant === 'error';
+  return (
+    <div style={{
+      position: 'absolute', left: 16, right: 16, bottom: 24, zIndex: 320,
+      background: t.isDark ? '#3a3530' : '#2c2822', borderRadius: 12,
+      padding: '13px 12px 13px 16px', display: 'flex', alignItems: 'center', gap: 10,
+      boxShadow: '0 8px 24px rgba(0,0,0,0.3)', fontFamily: BM_SANS,
+    }}>
+      {err && (
+        <svg width="17" height="17" viewBox="0 0 24 24" fill="none" style={{ flexShrink: 0 }}><circle cx="12" cy="12" r="10" fill={danger}/><path d="M12 7v6M12 16v.01" stroke="#fff" strokeWidth="2" strokeLinecap="round"/></svg>
+      )}
+      <span style={{ flex: 1, fontSize: 13.5, color: '#f4eee0' }}>{err ? 'Couldn’t delete bookmark' : 'Bookmark deleted'}</span>
+      <button style={{ border: 'none', background: 'transparent', cursor: 'pointer', fontFamily: BM_SANS, fontSize: 13.5, fontWeight: 700, color: err ? '#f0b090' : '#e8b465', padding: '4px 10px' }}>
+        {err ? 'Retry' : 'Undo'}
+      </button>
+    </div>
+  );
+}
+
+// ═════════════════════════════════════════════════════
+// BookmarksSheet — the committed TOC/Bookmarks sheet, Bookmarks tab, with
+// the delete interaction layered on. Rendered inside a reader frame.
+//   forcedId / rowState — put one row into swipe / menu / pressed
+//   dialog  — 'confirm' | 'deleting'      (Material centre dialog)
+//   snackbar — 'deleted' | 'error'
+// ═════════════════════════════════════════════════════
+function BookmarksSheet({ themeKey = 'paper', rowId = null, rowState = 'default', dialog = null, snackbar = null, height = 880 }) {
+  const t = window.THEMES[themeKey];
+  const dialogBm = BOOKMARKS.find((b) => b.id === (rowId || 'bm2')) || BOOKMARKS[1];
+  return (
+    <window.TtsFrame t={t} height={height}>
+      <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column' }}>
+        <window.StatusStrip t={t} />
+        <window.ReaderChrome t={t} />
+        <div style={{ flex: 1 }} />
+      </div>
+
+      {/* dim + bottom sheet */}
+      <div style={{ position: 'absolute', inset: 0, zIndex: 200, display: 'flex', flexDirection: 'column', justifyContent: 'flex-end', background: 'rgba(0,0,0,0.35)' }}>
+        <div style={{
+          background: t.isDark ? '#222020' : '#fcf8f0', height: height - 200,
+          borderTopLeftRadius: 22, borderTopRightRadius: 22, boxShadow: '0 -8px 28px rgba(0,0,0,0.25)',
+          display: 'flex', flexDirection: 'column', overflow: 'hidden', position: 'relative',
+        }}>
+          <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 8 }}>
+            <div style={{ width: 36, height: 5, borderRadius: 3, background: t.isDark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.12)' }} />
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '14px 18px 12px', borderBottom: `0.5px solid ${t.rule}` }}>
+            <div style={{ fontFamily: BM_SERIF, fontSize: 17, fontWeight: 600, color: t.ink }}>Pride and Prejudice</div>
+          </div>
+          {/* tab strip */}
+          <div style={{ padding: '10px 18px 4px' }}>
+            <div style={{ display: 'flex', borderRadius: 10, padding: 3, background: t.isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.05)' }}>
+              {[['Contents', false], ['Bookmarks', true]].map(([label, on]) => (
+                <div key={label} style={{
+                  flex: 1, textAlign: 'center', padding: '7px 0', borderRadius: 8,
+                  background: on ? (t.isDark ? '#3a3530' : '#fff') : 'transparent',
+                  color: on ? t.ink : t.sub, fontFamily: BM_SANS, fontSize: 13, fontWeight: on ? 600 : 500,
+                  boxShadow: on ? '0 1px 2px rgba(0,0,0,0.08)' : 'none',
+                }}>{label}</div>
+              ))}
+            </div>
+          </div>
+          <div style={{ flex: 1, overflow: 'auto', padding: '8px 18px 18px' }} className="hide-scroll">
+            {BOOKMARKS.map((bm, i) => (
+              <BookmarkRow key={bm.id} t={t} bm={bm}
+                state={bm.id === rowId ? rowState : 'default'} last={i === BOOKMARKS.length - 1} />
+            ))}
+          </div>
+
+          {/* long-press menu overlays the sheet */}
+          {rowState === 'menu' && rowId && <BMLongPressMenu t={t} />}
+        </div>
+      </div>
+
+      {dialog && <BMConfirmDialog t={t} bm={dialogBm} busy={dialog === 'deleting'} />}
+      {snackbar && <BMSnackbar t={t} variant={snackbar} />}
+    </window.TtsFrame>
+  );
+}
+
+Object.assign(window, {
+  BookmarksSheet, BookmarkRow, BMConfirmDialog, BMSnackbar, BMLongPressMenu, BOOKMARKS,
+});

--- a/dev-docs/designs/vreader-fidelity-v1/project/vreader-collections-delete.jsx
+++ b/dev-docs/designs/vreader-fidelity-v1/project/vreader-collections-delete.jsx
@@ -1,0 +1,342 @@
+// Collections delete affordance · issue #1875 (parent #1869 / feature #127 WI-5).
+//
+// The committed Android manage sheet (CollectionsManageSheet in
+// vreader-library-android.jsx) ships list + inline-rename + create, and its
+// EDIT mode shows a reorder drag-handle + a right-chevron disclosure on each
+// user collection. That chevron was always meant to open a per-collection
+// detail/edit screen — but that screen was never depicted, so DELETE had no
+// design-grounded home. Feature #127 shipped WITHOUT delete and deferred it
+// here (rule 51: no self-designed UI).
+//
+// This file designs the missing screen and the delete control on it.
+//
+// ────────────────────────────────────────────────────
+// DECISION SUMMARY
+// ────────────────────────────────────────────────────
+//
+// Surface · the edit-mode chevron opens a pushed "Edit Collection" screen
+//   inside the same Collections sheet (back → Collections). It carries the
+//   rename field (promoted out of the list's inline rename) and, as a
+//   separate grouped card at the bottom, the destructive Delete control.
+//   Grounded: the committed edit mode already routes user collections to this
+//   chevron; system collections ("Currently Reading" / "Finished") show a
+//   count instead and never reach it, so they stay non-deletable by
+//   construction.
+//
+// Delete control · a left-aligned destructive row ("Delete Collection", trash
+//   glyph) in its own card — the same shape as the editor's existing
+//   "Delete Key" row (vreader-ai-provider-fields.jsx). NOT swipe-to-delete:
+//   the committed edit mode owns the horizontal gesture for reorder
+//   (drag-handle), so a swipe here would collide; and the row is a real
+//   labelled control (VoiceOver / Switch Control land on it).
+//
+// Confirmation · YES, an inline two-step confirm — the exact vocabulary of
+//   HPDeleteConfirm (vreader-highlight-popover.jsx #949) and NotesDeleteConfirm
+//   (vreader-notes-delete.jsx #1103): title that names the target, one line of
+//   body copy, paired Cancel / Delete pills in destructive ink, "Can't be
+//   undone." Collections warrant the confirm (unlike a single highlight) because
+//   the action drops every membership on the shelf at once. The confirm
+//   replaces the delete card's content in place — no system alert — so the
+//   user keeps their place.
+//
+// What delete does (stated in human terms in the footer + confirm body):
+//   removes the collection + its membership rows only. The BOOKS stay in the
+//   library — BookCollectionCrossRef FK is ON DELETE CASCADE, so only the
+//   join rows drop. LibraryViewModel.deleteCollection resets the active
+//   filter to "All".
+//
+// Failed delete · the row collapses to a tinted error chip with Retry
+//   (re-invokes the repo call) — mirrors NotesRowError. No data was lost
+//   because the delete transaction rolled back.
+//
+// Empty-after-last-delete · deleting the final collection returns to the list,
+//   which shows a brief "Collection deleted" toast, then the sheet's empty
+//   state. Because the shelf-bar and the Manage entry both hide when zero
+//   collections exist (already handled in #127), this empty sheet is only
+//   reachable transiently right after the last delete.
+
+const CD_SANS = "'Inter', -apple-system, system-ui, sans-serif";
+const CD_SERIF = '"Source Serif 4", Georgia, serif';
+
+function cdDanger(ui) { return ui.isDark ? '#e0775a' : '#a8402f'; }
+
+function CDTrash({ size = 19, color = 'currentColor' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none"
+      stroke={color} strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M4 7h16M9 7V5a1 1 0 011-1h4a1 1 0 011 1v2M6 7l1 13a1.6 1.6 0 001.6 1.5h6.8A1.6 1.6 0 0017 20l1-13M10 11v6M14 11v6"/>
+    </svg>
+  );
+}
+function CDSpinner({ size = 13, color = 'currentColor' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none"
+      style={{ animation: 'apfSpin .8s linear infinite' }}>
+      <circle cx="12" cy="12" r="9" stroke={color} strokeOpacity="0.25" strokeWidth="2.6" />
+      <path d="M12 3a9 9 0 019 9" stroke={color} strokeWidth="2.6" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// Inline two-step confirm — HPDeleteConfirm / NotesDeleteConfirm vocabulary,
+// re-toned to the sheet's form palette (ui.*). Replaces the delete card body.
+// ─────────────────────────────────────────────────────
+function CDDeleteConfirm({ ui, name, count, busy }) {
+  const danger = cdDanger(ui);
+  return (
+    <div style={{ padding: '13px 15px 15px' }}>
+      <div style={{ fontFamily: CD_SANS, fontSize: 14, fontWeight: 600, color: ui.ink, marginBottom: 3 }}>
+        Delete “{name}”?
+      </div>
+      <div style={{ fontFamily: CD_SANS, fontSize: 12.5, lineHeight: 1.45, color: ui.sec, marginBottom: 13, textWrap: 'pretty' }}>
+        The {count} {count === 1 ? 'book stays' : 'books stay'} in your library — only this shelf and its assignments are removed. Can’t be undone.
+      </div>
+      <div style={{ display: 'flex', gap: 9 }}>
+        <button disabled={busy} style={{
+          flex: 1, padding: '10px 0', borderRadius: 10,
+          border: `0.5px solid ${ui.sep}`, background: 'transparent',
+          fontFamily: CD_SANS, fontSize: 14, fontWeight: 500, color: ui.ink,
+          cursor: busy ? 'default' : 'pointer', opacity: busy ? 0.4 : 1,
+        }}>Cancel</button>
+        <button disabled={busy} style={{
+          flex: 1, padding: '10px 0', borderRadius: 10, border: 'none',
+          background: danger, color: '#fff',
+          fontFamily: CD_SANS, fontSize: 14, fontWeight: 600,
+          cursor: busy ? 'default' : 'pointer',
+          display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 7,
+          opacity: busy ? 0.9 : 1,
+        }}>
+          {busy && <CDSpinner size={13} color="#fff" />}
+          {busy ? 'Deleting…' : 'Delete'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// Failed-delete chip — NotesRowError vocabulary.
+function CDDeleteError({ ui }) {
+  const danger = cdDanger(ui);
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 11, padding: '13px 15px' }}>
+      <div style={{
+        width: 20, height: 20, borderRadius: 10, flexShrink: 0, background: danger, color: '#fff',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}>
+        <svg width="11" height="11" viewBox="0 0 14 14" fill="none">
+          <path d="M7 3v5M7 10.5v.5" stroke="#fff" strokeWidth="1.7" strokeLinecap="round" />
+        </svg>
+      </div>
+      <div style={{ flex: 1, fontFamily: CD_SANS, fontSize: 12.5, color: ui.ink, lineHeight: 1.35 }}>
+        Couldn’t delete — nothing was removed.
+      </div>
+      <button style={{
+        padding: '6px 14px', borderRadius: 100, border: `0.5px solid ${ui.sep}`,
+        background: 'transparent', cursor: 'pointer',
+        fontFamily: CD_SANS, fontSize: 12.5, fontWeight: 600, color: ui.ink,
+      }}>Retry</button>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// Shared sheet chrome with a back-nav header (wider leading than AppSheet,
+// so "‹ Collections" fits). Matches AppSheet's grabber + serif title + rule.
+// ─────────────────────────────────────────────────────
+function NavSheet({ ui, title, onBackLabel = 'Collections', trailing, height, children }) {
+  return (
+    <div style={{ position: 'absolute', inset: 0, zIndex: 200, display: 'flex', flexDirection: 'column', justifyContent: 'flex-end', background: 'rgba(0,0,0,0.35)' }}>
+      <div style={{
+        background: ui.sheetBg, height, borderTopLeftRadius: 22, borderTopRightRadius: 22,
+        boxShadow: '0 -8px 28px rgba(0,0,0,0.25)', display: 'flex', flexDirection: 'column', overflow: 'hidden',
+      }}>
+        <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 8 }}>
+          <div style={{ width: 36, height: 5, borderRadius: 3, background: ui.isDark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.12)' }} />
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', padding: '14px 16px 12px', borderBottom: `0.5px solid ${ui.sep}`, position: 'relative' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 3, minWidth: 108 }}>
+            <window.Icons.ChevronL size={22} color={ui.tint} />
+            <span style={{ fontFamily: CD_SANS, fontSize: 15, color: ui.tint }}>{onBackLabel}</span>
+          </div>
+          <div style={{ position: 'absolute', left: 0, right: 0, textAlign: 'center', pointerEvents: 'none' }}>
+            <span style={{ fontFamily: CD_SERIF, fontSize: 17, fontWeight: 600, color: ui.ink }}>{title}</span>
+          </div>
+          <div style={{ flex: 1 }} />
+          <div style={{ minWidth: 60, display: 'flex', justifyContent: 'flex-end' }}>{trailing}</div>
+        </div>
+        <div style={{ flex: 1, overflow: 'auto' }} className="hide-scroll">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+// ═════════════════════════════════════════════════════
+// CollectionDetailSheet — the pushed "Edit Collection" screen.
+//   state: 'rest' | 'renaming' | 'confirm' | 'deleting' | 'error'
+// ═════════════════════════════════════════════════════
+function CollectionDetailSheet({ ui, state = 'rest', name = 'Fiction', count = 5, height = 880 }) {
+  const { Card, GroupHeader, GroupFooter, Sep } = window;
+  const danger = cdDanger(ui);
+  const renaming = state === 'renaming';
+  const confirming = state === 'confirm';
+  const deleting = state === 'deleting';
+  const errored = state === 'error';
+  const displayName = renaming ? 'Sci-Fi & Fantasy' : name;
+
+  const Done = renaming
+    ? <button style={{ background: 'none', border: 'none', padding: 0, fontFamily: CD_SANS, fontSize: 15, fontWeight: 600, color: ui.tint, cursor: 'pointer' }}>Done</button>
+    : null;
+
+  return (
+    <window.PhoneFrame ui={ui} height={height}>
+      <div style={{ position: 'absolute', inset: 0, background: ui.bg }} />
+      <NavSheet ui={ui} title="Edit Collection" trailing={Done} height={height - 36}>
+        <div style={{ padding: '16px 18px 32px' }}>
+
+          {/* NAME */}
+          <GroupHeader ui={ui}>Name</GroupHeader>
+          <Card ui={ui}>
+            <div style={{
+              display: 'flex', alignItems: 'center', minHeight: 52, padding: '0 14px',
+              borderRadius: 14,
+              background: renaming ? ui.fieldHi : 'transparent',
+              boxShadow: renaming ? `inset 0 0 0 1.5px ${ui.tint}` : 'none',
+            }}>
+              <window.Icons.Folder size={19} color={ui.tint} />
+              <span style={{ flex: 1, fontFamily: CD_SANS, fontSize: 15.5, color: ui.ink, marginLeft: 11 }}>
+                {displayName}
+                {renaming && <span style={{ display: 'inline-block', width: 1.5, height: 17, background: ui.tint, verticalAlign: -3, marginLeft: 1 }} />}
+              </span>
+              {renaming
+                ? <window.Icons.Close size={17} color={ui.ter} />
+                : <window.Icons.ChevronD size={18} color={ui.ter} style={{ transform: 'rotate(-90deg)' }} />}
+            </div>
+          </Card>
+          <GroupFooter ui={ui}>
+            {renaming
+              ? 'The new name shows on the shelf-bar and everywhere this collection appears.'
+              : `${count} books · tap to rename. Reorder shelves back in the list.`}
+          </GroupFooter>
+
+          {/* DELETE */}
+          <div style={{ height: 26 }} />
+          <Card ui={ui}>
+            {confirming || deleting ? (
+              <CDDeleteConfirm ui={ui} name={name} count={count} busy={deleting} />
+            ) : errored ? (
+              <CDDeleteError ui={ui} />
+            ) : (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 11, minHeight: 52, padding: '0 15px' }}>
+                <CDTrash size={19} color={danger} />
+                <span style={{ fontFamily: CD_SANS, fontSize: 15.5, fontWeight: 500, color: danger }}>Delete Collection</span>
+              </div>
+            )}
+          </Card>
+          <GroupFooter ui={ui}>
+            Deleting removes the collection and its shelf assignments. The {count} books stay in your library.
+          </GroupFooter>
+        </div>
+      </NavSheet>
+    </window.PhoneFrame>
+  );
+}
+
+// ═════════════════════════════════════════════════════
+// Manage list — outcome states. Reuses the committed sheet's row shape;
+// `toast` shows the transient post-delete confirmation.
+// ═════════════════════════════════════════════════════
+function ManageListAfter({ ui, height = 880, toast }) {
+  const { Card } = window;
+  const cols = [
+    { name: 'Currently Reading', n: 2, sys: true },
+    { name: 'To Read', n: 8 },
+    { name: 'Tech', n: 4 },
+    { name: 'Finished', n: 11, sys: true },
+  ];
+  return (
+    <window.PhoneFrame ui={ui} height={height}>
+      <div style={{ position: 'absolute', inset: 0, background: ui.bg }} />
+      <window.AppSheet ui={ui} title="Collections"
+        leading={<button style={{ background: 'none', border: 'none', padding: 0, fontFamily: CD_SANS, fontSize: 15, color: ui.sec }}>Done</button>}
+        trailing={<span style={{ fontFamily: CD_SANS, fontSize: 15, fontWeight: 600, color: ui.tint }}>Edit</span>}
+        height={height - 36}>
+        <div style={{ padding: '14px 16px 32px' }}>
+          <Card ui={ui}>
+            {cols.map((c, i) => (
+              <div key={c.name} style={{ display: 'flex', alignItems: 'center', minHeight: 52, padding: '0 14px', position: 'relative' }}>
+                <window.Icons.Folder size={19} color={ui.tint} />
+                <span style={{ flex: 1, fontFamily: CD_SANS, fontSize: 15.5, color: ui.ink, marginLeft: 11 }}>{c.name}</span>
+                <span style={{ fontFamily: CD_SANS, fontSize: 13.5, color: ui.ter, fontVariantNumeric: 'tabular-nums' }}>{c.n}</span>
+                {i < cols.length - 1 && <div style={{ position: 'absolute', left: 44, right: 0, bottom: 0, height: 0.5, background: ui.sep }} />}
+              </div>
+            ))}
+          </Card>
+          <div style={{ height: 16 }} />
+          <button style={{
+            display: 'flex', alignItems: 'center', gap: 9, width: '100%', border: 'none', cursor: 'pointer',
+            background: ui.card, borderRadius: 14, padding: '15px 14px', boxShadow: ui.cardShadow,
+            fontFamily: CD_SANS, fontSize: 15.5, fontWeight: 500, color: ui.tint,
+          }}>
+            <window.Icons.Plus size={20} color={ui.tint} /> New Collection
+          </button>
+        </div>
+      </window.AppSheet>
+
+      {toast && (
+        <div style={{
+          position: 'absolute', left: 16, right: 16, bottom: 30, zIndex: 300,
+          background: ui.isDark ? '#3a3530' : '#2c2822', borderRadius: 12,
+          padding: '13px 16px', display: 'flex', alignItems: 'center', gap: 10,
+          boxShadow: '0 8px 24px rgba(0,0,0,0.28)',
+          fontFamily: CD_SANS,
+        }}>
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+            <circle cx="12" cy="12" r="10" fill={ui.isDark ? '#5a9a7a' : '#3a6a5a'} />
+            <path d="M7.5 12.3l3 3 6-6.5" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+          </svg>
+          <span style={{ flex: 1, fontSize: 14, color: '#f4eee0' }}>“{toast}” deleted</span>
+        </div>
+      )}
+    </window.PhoneFrame>
+  );
+}
+
+// Empty state — only reachable transiently right after the last delete.
+function ManageEmpty({ ui, height = 880 }) {
+  return (
+    <window.PhoneFrame ui={ui} height={height}>
+      <div style={{ position: 'absolute', inset: 0, background: ui.bg }} />
+      <window.AppSheet ui={ui} title="Collections"
+        leading={<button style={{ background: 'none', border: 'none', padding: 0, fontFamily: CD_SANS, fontSize: 15, color: ui.sec }}>Done</button>}
+        trailing={<span />}
+        height={height - 36}>
+        <div style={{ padding: '70px 40px 0', textAlign: 'center', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+          <div style={{
+            width: 66, height: 66, borderRadius: 33, marginBottom: 20,
+            background: ui.isDark ? 'rgba(255,255,255,0.05)' : 'rgba(29,26,20,0.045)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }}>
+            <window.Icons.Folder size={30} color={ui.ter} />
+          </div>
+          <div style={{ fontFamily: CD_SERIF, fontSize: 20, fontWeight: 600, color: ui.ink, marginBottom: 8 }}>No collections yet</div>
+          <div style={{ fontFamily: CD_SANS, fontSize: 13.5, lineHeight: 1.5, color: ui.sec, textWrap: 'pretty', maxWidth: 260 }}>
+            Group books into shelves like Fiction or To&nbsp;Read. They appear across the top of your library.
+          </div>
+          <button style={{
+            marginTop: 24, display: 'inline-flex', alignItems: 'center', gap: 8, border: 'none', cursor: 'pointer',
+            background: ui.tint, borderRadius: 100, padding: '11px 20px',
+            fontFamily: CD_SANS, fontSize: 15, fontWeight: 600, color: '#fff',
+          }}>
+            <window.Icons.Plus size={19} color="#fff" /> New Collection
+          </button>
+        </div>
+      </window.AppSheet>
+    </window.PhoneFrame>
+  );
+}
+
+Object.assign(window, {
+  CollectionDetailSheet, ManageListAfter, ManageEmpty,
+  CDDeleteConfirm, CDDeleteError, NavSheet,
+});

--- a/dev-docs/designs/vreader-fidelity-v1/project/vreader-generated-cover.jsx
+++ b/dev-docs/designs/vreader-fidelity-v1/project/vreader-generated-cover.jsx
@@ -1,0 +1,235 @@
+// Non-interactive generated-cover fallback for the Book Details sheet · #1905
+// (blocks feature #134 — Android reader More menu + book details + share).
+//
+// The committed missing-cover state (vreader-book-details.jsx CoverWithSwap) is
+// INTERACTIVE — a "Tap to add cover" placeholder + a pencil "Replace cover"
+// overlay + an Actions "Add cover…" row. But Android has NO cover store (the
+// Book model has no coverPath — verified), so EVERY Android book hits the
+// missing-cover branch and none of those controls can be honored. Shipping them
+// would be dead "Tap to add cover" controls (rule 51 + #129's no-dead-control
+// rule). So feature #134 ships NO cover art at all in the details sheet.
+//
+// This file designs the missing piece: a NON-INTERACTIVE generated-cover tile
+// — a deterministic title-initial monogram — that stands in for the absent
+// cover, plus the details-sheet composition that drops the pencil overlay and
+// the "Add cover…" Actions row entirely.
+//
+// ────────────────────────────────────────────────────
+// DECISION SUMMARY
+// ────────────────────────────────────────────────────
+//
+// The tile · a generated monogram in the app's existing generative-cover
+//   vocabulary (vreader-cover.jsx BookCover: cloth-tone ground, spine shadow,
+//   page edge, serif type). Ground colour is DETERMINISTIC from the title, so
+//   the same book always gets the same cover and a shelf of them reads as
+//   varied, not a wall of identical placeholders. A large serif initial is the
+//   hero; the title (2-line clamp) + author sit at the base like a real
+//   spine-less paperback. No dashed "empty" border, no glyph that says
+//   "missing" — it's a cover, not a hole.
+//
+// Non-interactive · the tile has no pencil overlay, no tap target, no focus
+//   ring. The details sheet drops the "Add cover…" Actions row. Nothing on
+//   this surface promises an action Android can't perform. If a cover store
+//   ever lands, the tile becomes the fallback and the swap controls return —
+//   the composition doesn't have to change.
+//
+// Composition · the tile leads the stacked layout exactly where the real
+//   cover would; the title / author / year block reads the same below it. In
+//   the compact (split) layout it sits left. Because the ground is tonal and
+//   the type on it is small, it never competes with the sheet's own title.
+//
+// Light + dark · the tile is theme-independent (a cover looks the same in
+//   both) — only the surrounding sheet chrome changes. This is deliberate:
+//   inverting a "cover" per theme would read as a UI surface, not artwork.
+
+const GC_SERIF = '"Source Serif 4", Georgia, serif';
+const GC_SANS = '"Inter", -apple-system, system-ui, sans-serif';
+
+// Deterministic cloth tones — muted, harmonious (matched lightness/chroma,
+// varied hue). A book cover, not a saturated placeholder.
+const GC_TONES = [
+  { bg: '#7c3b34', ink: '#f3e7d4', accent: '#e6c69a' }, // red-brown
+  { bg: '#3f5a4a', ink: '#eef0e2', accent: '#ccd8a8' }, // forest
+  { bg: '#3f4d63', ink: '#e8ecf3', accent: '#b9c8e0' }, // slate blue
+  { bg: '#8a6a30', ink: '#f6ecd6', accent: '#e8cf92' }, // ochre
+  { bg: '#5f3f57', ink: '#f1e6ee', accent: '#d9b8ce' }, // plum
+  { bg: '#35595c', ink: '#e6f0ef', accent: '#a9d2cf' }, // teal
+];
+
+function gcToneFor(title) {
+  let h = 0;
+  for (let i = 0; i < title.length; i++) h = (h * 31 + title.charCodeAt(i)) >>> 0;
+  return GC_TONES[h % GC_TONES.length];
+}
+function gcInitial(title) {
+  const m = (title || '').match(/[A-Za-z0-9]/);
+  return (m ? m[0] : '?').toUpperCase();
+}
+
+// ── the generated-cover tile — non-interactive ──────────────
+function CoverMonogram({ book, width = 120, height = 180 }) {
+  const tone = gcToneFor(book.title);
+  const initial = gcInitial(book.title);
+  const pad = Math.round(width * 0.11);
+  return (
+    <div aria-hidden="false" role="img"
+      aria-label={`Generated cover for ${book.title} by ${book.author}`}
+      style={{
+        width, height, borderRadius: 4, position: 'relative', overflow: 'hidden',
+        background: tone.bg, color: tone.ink, flexShrink: 0,
+        boxShadow: '0 1px 2px rgba(0,0,0,0.18), 0 8px 24px rgba(0,0,0,0.18), inset 0 0 0 1px rgba(0,0,0,0.08)',
+      }}>
+      {/* spine shadow + page edge — same as BookCover */}
+      <div style={{ position: 'absolute', left: 0, top: 0, bottom: 0, width: 6, background: 'linear-gradient(to right, rgba(0,0,0,0.28), rgba(0,0,0,0) 60%)' }} />
+      <div style={{ position: 'absolute', right: 0, top: 0, bottom: 0, width: 2, background: 'linear-gradient(to left, rgba(255,255,255,0.16), rgba(0,0,0,0.14))' }} />
+      {/* hairline frame */}
+      <div style={{ position: 'absolute', inset: pad * 0.7, border: `1px solid ${tone.accent}`, opacity: 0.4, borderRadius: 1 }} />
+
+      {/* big serif initial */}
+      <div style={{
+        position: 'absolute', top: pad * 1.1, left: 0, right: 0, textAlign: 'center',
+        fontFamily: GC_SERIF, fontWeight: 600, fontStyle: 'italic',
+        fontSize: width * 0.5, lineHeight: 1, color: tone.ink,
+      }}>{initial}</div>
+
+      {/* title + author at the base, like a spine-less paperback */}
+      <div style={{ position: 'absolute', left: pad, right: pad, bottom: pad }}>
+        <div style={{ width: width * 0.34, height: 1, background: tone.accent, opacity: 0.7, marginBottom: width * 0.05 }} />
+        <div style={{
+          fontFamily: GC_SERIF, fontWeight: 600, fontSize: Math.max(9.5, width * 0.105), lineHeight: 1.12,
+          color: tone.ink, display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden',
+        }}>{book.title}</div>
+        <div style={{
+          fontFamily: GC_SANS, fontSize: Math.max(7.5, width * 0.062), letterSpacing: 0.3,
+          textTransform: 'uppercase', color: tone.ink, opacity: 0.72, marginTop: width * 0.03,
+          whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+        }}>{book.author}</div>
+      </div>
+    </div>
+  );
+}
+
+// ── the details sheet with the generated cover, no swap controls ──
+function gcMiniBtn(t) {
+  return {
+    width: 26, height: 26, borderRadius: 8, padding: 0,
+    background: t.isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.05)',
+    border: 'none', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+  };
+}
+
+function GCSectionLabel({ t, children }) {
+  return <div style={{ fontFamily: GC_SANS, fontSize: 12, fontWeight: 600, color: t.sub, letterSpacing: 0.8, textTransform: 'uppercase' }}>{children}</div>;
+}
+
+function GCMetaList({ t, book }) {
+  const fingerprint = `${(book.format || 'epub').toLowerCase()}:8a4f2e91b7c3…2c1b`;
+  const rows = [
+    { label: 'Format', value: book.format, mono: true },
+    { label: 'Size', value: book.size, mono: true },
+    { label: 'Pages', value: `${book.pages}`, mono: true },
+    { label: 'Fingerprint', value: fingerprint, mono: true, copy: true },
+  ];
+  return (
+    <div style={{ marginTop: 22 }}>
+      <GCSectionLabel t={t}>Metadata</GCSectionLabel>
+      <div style={{ marginTop: 8, borderRadius: 14, overflow: 'hidden', background: t.isDark ? 'rgba(255,255,255,0.04)' : '#fff', boxShadow: t.isDark ? 'none' : '0 1px 0 rgba(0,0,0,0.04)' }}>
+        {rows.map((r, i) => (
+          <div key={r.label} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '11px 14px', borderBottom: i === rows.length - 1 ? 'none' : `0.5px solid ${t.rule}` }}>
+            <div style={{ width: 96, fontFamily: GC_SANS, fontSize: 12, fontWeight: 500, color: t.sub, flexShrink: 0 }}>{r.label}</div>
+            <div style={{ flex: 1, minWidth: 0, fontSize: 13.5, color: t.ink, fontFamily: r.mono ? '"SF Mono", Menlo, monospace' : 'inherit', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.value}</div>
+            {r.copy && (
+              <button style={gcMiniBtn(t)} aria-label="Copy fingerprint">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none"><rect x="8" y="4" width="12" height="14" rx="2" stroke={t.sub} strokeWidth="1.6"/><path d="M4 8v10a2 2 0 002 2h10" stroke={t.sub} strokeWidth="1.6"/></svg>
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Actions WITHOUT the cover-swap row — the whole point of the issue.
+function GCActionList({ t }) {
+  const actions = [
+    { label: 'Share book…', glyph: (p) => <window.Icons.Share {...p}/> },
+    { label: 'Export annotations…', sub: 'Markdown · JSON · VReader JSON', glyph: (p) => <window.Icons.Download {...p}/> },
+  ];
+  return (
+    <div style={{ marginTop: 22 }}>
+      <GCSectionLabel t={t}>Actions</GCSectionLabel>
+      <div style={{ marginTop: 8, borderRadius: 14, overflow: 'hidden', background: t.isDark ? 'rgba(255,255,255,0.04)' : '#fff', boxShadow: t.isDark ? 'none' : '0 1px 0 rgba(0,0,0,0.04)' }}>
+        {actions.map((a, i) => {
+          const G = a.glyph;
+          return (
+            <div key={a.label} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px', borderBottom: i === actions.length - 1 ? 'none' : `0.5px solid ${t.rule}` }}>
+              <div style={{ width: 28, height: 28, borderRadius: 8, background: t.isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.04)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                <G size={14} color={t.ink} stroke={1.7}/>
+              </div>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontFamily: GC_SANS, fontSize: 14.5, color: t.ink, fontWeight: 500, lineHeight: 1.2 }}>{a.label}</div>
+                {a.sub && <div style={{ fontFamily: GC_SANS, fontSize: 11, color: t.sub, marginTop: 2 }}>{a.sub}</div>}
+              </div>
+              <window.Icons.Chevron size={13} color={t.sub} stroke={2}/>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function GCTag({ t, children }) {
+  return <span style={{ padding: '3px 10px', borderRadius: 100, background: t.isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.05)', color: t.ink, fontSize: 11, fontWeight: 500, fontFamily: GC_SANS }}>{children}</span>;
+}
+
+function BookDetailsGeneratedSheet({ themeKey = 'paper', book, layout = 'stacked', height = 720 }) {
+  const t = window.THEMES[themeKey];
+  const b = book || GC_BOOK;
+  const stacked = layout === 'stacked';
+  return (
+    <window.TtsFrame t={t} height={height}>
+      <div style={{ position: 'absolute', inset: 0 }} />
+      <window.Sheet theme={t} onClose={() => {}} height={height - (stacked ? 90 : 170)} title="Book details"
+        trailing={
+          <button style={{ background: 'rgba(0,0,0,0.06)', border: 'none', width: 28, height: 28, borderRadius: 14, padding: 0, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }} aria-label="Share">
+            <window.Icons.Share size={16} color={t.ink} stroke={1.7}/>
+          </button>
+        }>
+        <div style={{ padding: stacked ? '20px 22px 32px' : '18px 20px 30px' }}>
+          {stacked ? (
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 16 }}>
+              <CoverMonogram book={b} width={120} height={180}/>
+              <div style={{ textAlign: 'center', width: '100%' }}>
+                <div style={{ fontFamily: GC_SERIF, fontSize: 22, fontStyle: 'italic', fontWeight: 600, color: t.ink, lineHeight: 1.12, textWrap: 'pretty', margin: '2px 0 6px' }}>{b.title}</div>
+                <div style={{ fontFamily: GC_SANS, fontSize: 13, color: t.sub, lineHeight: 1.35 }}>{b.author} · {b.year}</div>
+              </div>
+              {b.tags && <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', justifyContent: 'center' }}>{b.tags.map((tg) => <GCTag key={tg} t={t}>{tg}</GCTag>)}</div>}
+            </div>
+          ) : (
+            <div style={{ display: 'flex', gap: 16, alignItems: 'flex-start' }}>
+              <CoverMonogram book={b} width={92} height={138}/>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontFamily: GC_SERIF, fontSize: 18, fontStyle: 'italic', fontWeight: 600, color: t.ink, lineHeight: 1.15, textWrap: 'pretty', marginBottom: 4 }}>{b.title}</div>
+                <div style={{ fontFamily: GC_SANS, fontSize: 12.5, color: t.sub, lineHeight: 1.35, marginBottom: 10, display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}>{b.author} · {b.year}</div>
+                {b.tags && <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap' }}>{b.tags.slice(0, 3).map((tg) => <GCTag key={tg} t={t}>{tg}</GCTag>)}</div>}
+              </div>
+            </div>
+          )}
+          <GCMetaList t={t} book={b}/>
+          <GCActionList t={t}/>
+        </div>
+      </window.Sheet>
+    </window.TtsFrame>
+  );
+}
+
+const GC_BOOK = {
+  title: 'Pride and Prejudice', author: 'Jane Austen', year: 1813,
+  format: 'EPUB', size: '1.2 MB', pages: 384, tags: ['Classic', 'Romance'],
+};
+
+Object.assign(window, {
+  CoverMonogram, BookDetailsGeneratedSheet, gcToneFor, gcInitial, GC_TONES, GC_BOOK,
+});

--- a/project.yml
+++ b/project.yml
@@ -212,8 +212,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.vreader.app
-        CURRENT_PROJECT_VERSION: 1048
-        MARKETING_VERSION: 3.67.6
+        CURRENT_PROJECT_VERSION: 1049
+        MARKETING_VERSION: 3.67.7
         # Feature #42 Phase-2 WI-1b: compile + link the vendored libmobi C.
         # USE_LIBXML2 turns on libmobi's OPF/XML writer (KF8→EPUB needs it);
         # the iOS SDK ships libxml2 headers at $(SDKROOT)/usr/include/libxml2

--- a/vreader.xcodeproj/project.pbxproj
+++ b/vreader.xcodeproj/project.pbxproj
@@ -3613,6 +3613,7 @@
 				DB61B11E07DDB3EC558692C1 /* Helpers */,
 				B507E0BD7D08A4E11203ACB1 /* Integration */,
 				0B012D36F10FD0A92C516160 /* Models */,
+				5AD82895D4C8E34E5B1C9FF7 /* Reader */,
 				C89089F8D64EB38CF661EAB4 /* Services */,
 				3EC42569191D945E8426907A /* Utils */,
 				9B93CFA1683A5C606C3627E1 /* Verification */,
@@ -4276,6 +4277,13 @@
 				D978E90148FFF976EA612EB4 /* TypefacePillToggle.swift */,
 			);
 			path = Settings;
+			sourceTree = "<group>";
+		};
+		5AD82895D4C8E34E5B1C9FF7 /* Reader */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Reader;
 			sourceTree = "<group>";
 		};
 		5CF05FDFCFCF1A5110783282 /* Locator */ = {
@@ -8105,7 +8113,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1048;
+				CURRENT_PROJECT_VERSION = 1049;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8113,7 +8121,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.67.6;
+				MARKETING_VERSION = 3.67.7;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;
@@ -8259,7 +8267,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1048;
+				CURRENT_PROJECT_VERSION = 1049;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) USE_LIBXML2=1";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SDKROOT)/usr/include/libxml2 $(SRCROOT)/vreader/Services/Libmobi/src";
 				INFOPLIST_FILE = vreader/SupportingFiles/Info.plist;
@@ -8267,7 +8275,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.67.6;
+				MARKETING_VERSION = 3.67.7;
 				OTHER_LDFLAGS = "$(inherited) -lxml2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vreader.app;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
Imports the four open `needs-design` surfaces from the claude.ai/design vreader project into the committed bundle `dev-docs/designs/vreader-fidelity-v1/project/`, so each feature is unblocked for implementation (rule 51 one-way design loop):

- **`vreader-generated-cover.jsx`** — non-interactive generated-cover fallback for the Book Details sheet · closes **#1905** (feature #134)
- **`vreader-annotations-actions.jsx`** — annotations review-card per-card Copy/Share + ⋯ Edit/Delete · closes **#1902** (feature #132)
- **`vreader-bookmark-delete.jsx`** — bookmark row deletion (swipe / long-press / confirm) · closes **#1903** (feature #135)
- **`vreader-collections-delete.jsx`** — collections delete affordance (Edit Collection screen) · closes **#1875** (feature #127 follow-up)

Docs-only (design artboards). No app code. Bumps iOS `3.67.7` per rule 40 (shared/design → iOS version).

Refs #1905, #1902, #1903, #1875