### PR TITLE
chore(canon): agent↔canon collaboration wiring (rule 56) + staleness demotion

### DIFF
--- a/.claude/cron-prompts/watchdog.md
+++ b/.claude/cron-prompts/watchdog.md
@@ -59,6 +59,23 @@ WATCHDOG: keep every session-only cron alive past the 7-day auto-expire AND swee
    Do NOT kill a healthy idle Gradle daemon or a booted emulator (resident by
    design — `sweep-ghosts.sh` already excludes them).
 
+8. **Canon staleness sweep (rule 56).** If a `canon/` bureau workspace exists,
+   re-hash the verified dossiers' evidence against the live code and demote any
+   page whose CODE evidence drifted (tracker churn is advisory only, never a
+   demotion):
+
+   ```bash
+   [ -f canon/_verify.json ] && scripts/canon-staleness.sh --apply
+   ```
+
+   `CANON-STALENESS RESULT: STALE <n>` means `<n>` verified pages were demoted
+   to `stale` because the code they document changed since the last compile —
+   that is expected drift, not an error; it queues those pages for the next
+   `bureau:compile`/verify pass. `CLEAN` (possibly with an advisory count) means
+   no code drift. Never demote `canonical` (human-owned) — the script already
+   refuses. This is detection + demotion only; do NOT re-verify or rewrite
+   dossiers from the watchdog (that is a deliberate compile pass, not a sweep).
+
 ## Part 3 — Outcome
 
 8. Outcome:

--- a/.claude/rules/56-canon-collaboration.md
+++ b/.claude/rules/56-canon-collaboration.md
@@ -1,0 +1,83 @@
+# 56 — Agent ↔ Canon Collaboration
+
+How every agent (interactive, cron, dispatch lane) reads from and keeps fresh
+the bureau knowledge base under `canon/` (compiled by the 2026-07-11 codebase
+audit; workspace + trust-tier rules in `BUREAU.md`). The thesis: **route reads,
+don't force them; funnel writes, never write direct.** Blanket "read the whole
+canon before acting" is unverifiable friction; unreviewed post-hoc dossier
+writes dilute the trust tiers that make the canon usable. Four enforcement
+points, each mechanical where it can be, plus two hard prohibitions.
+
+## Trust tiers (from `BUREAU.md`, restated because they gate everything here)
+
+`canonical` = human-approved, treat as fact. `verified` = auto-checked against
+the repo, not yet human-approved — usable but reconfirm anything load-bearing.
+`proposed`/`stale`/`contested` = NOT fact, verify before relying. Only a human
+(`bureau:review`) writes `canonical`; AI writes `proposed`/`verified`/
+`contested`/`stale`.
+
+## Read side — route, don't force
+
+1. **Sessions**: `CLAUDE.md` imports `BUREAU.md`, so every session already
+   carries the consult-before-deriving instruction. Before deciding something
+   the repo may have settled (an architecture choice, a convention, a prior
+   call), `bureau:query` first instead of re-deriving. No extra machinery.
+2. **Dispatch lanes**: the `/dispatch` brief generator runs
+   `scripts/canon-owner.sh <the lane's writes: prefixes>` (which resolves paths
+   to owning dossiers via `canon/_coverage-ledger.json`) and injects the
+   returned dossier path(s) into the lane brief as READ-ONLY orientation inputs
+   — "read for cross-module context and known edge cases before editing;
+   reconfirm load-bearing claims against the live code." This is the *relevant*
+   page arriving as a contract input, not a vague instruction. Enforced by
+   `scripts/__tests__/dispatch-shape.test.sh` (asserts the brief carries the
+   `canon-owner.sh` clause + the lane-never-edits-canon guard). See rule 55.
+
+## Write side — funnel through capture → compile → review
+
+3. **Capture is automatic, per session.** The bureau plugin self-registers a
+   `SessionEnd` hook (`capture-stub.mjs`) that writes a mechanical logbook stub
+   for every session — write-after-action already happens at session
+   granularity. Rich `bureau:note` capture is for sessions that produced
+   durable knowledge (a decision, a resolved question); most bugfix/verify cron
+   runs produce none and need no note.
+4. **Compile is periodic, not per-action.** `bureau:compile` distils the
+   accumulated minutes into dossier updates on a cadence (or piggybacked on a
+   maintenance pass) — never once per edit. Compile is where claims are placed,
+   conflicts become `contested`, and checkable facts are re-verified.
+5. **Staleness is detected, not hoped for.** `canon/_verify.json` holds a
+   sha256 of every artifact behind each `verified` page. The watchdog cron runs
+   `scripts/canon-staleness.sh --apply` (rule-56 step in `watchdog.md`): it
+   re-hashes those artifacts and demotes any page whose **code** evidence
+   drifted to `stale` (a legal AI tier). High-churn provenance files
+   (`docs/features.md`, `docs/bugs.md`, `docs/tasks.md`,
+   `archive/bugs-history.md`) are advisory only — a page cites them for
+   bug/feature numbers, and their churn does not invalidate its claims about the
+   code. `canonical` pages are never touched. A demoted page waits for the next
+   compile/verify pass; it is never silently rewritten by the sweep.
+
+## Lane contribution — propose, don't write
+
+A lane that discovers a documented claim is wrong or stale reports it in the
+rule-55 HANDOFF `notes` field. The orchestrator routes that into the session
+minute (capture), and the next `bureau:compile` reconciles it. Canon is an
+orchestrator-owned surface like the trackers, `project.yml`, and the tags —
+lanes never edit it directly (sed/heredoc or Edit alike).
+
+## Hard prohibitions
+
+- **No PreToolUse hook that blocks an action until "the canon was read."** It is
+  unverifiable (there is no signal that a read happened or that it was the right
+  page) and is pure friction. Read-routing (point 2) is the mechanism; a
+  blocking gate is not.
+- **No per-action dossier writes.** An agent finishing a task does not append to
+  or edit a dossier. That violates the one-writer rule (rule 48), churns the
+  `verified` corpus (any substantive edit demotes a page — see
+  `Decision — composite dossier schema`), and skips the review gate. Durable
+  knowledge goes to the logbook (capture) and reaches the cabinets only through
+  compile.
+
+## What this rule does NOT change
+
+Trust tiers and the write gate (`BUREAU.md`), the compile/review skills, TDD
+(rule 10), the six gates (rule 47), lane dispatch (rule 55). This rule is only
+the read-routing + freshness contract layered on top.

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -113,6 +113,16 @@ the interest of brevity.
    (probe: "Skill exists but is not enabled in this context") — artifact
    committed on the branch, ≤3 rounds then blocked. Long logs go to
    `<worktree>/.reports/` and travel as PATHS in the HANDOFF.
+6. **Canon orientation** (rule 56 — read-routing, not read-forcing): run
+   `scripts/canon-owner.sh <the lane's writes: prefixes>` and add each
+   returned dossier path to the brief's inputs as READ-ONLY orientation —
+   "read this dossier for cross-module context and known edge cases before
+   editing; it is `verified`/`proposed` (not human-approved `canonical`), so
+   reconfirm anything load-bearing against the live code."
+   A lane NEVER edits canon — it is an orchestrator-owned surface like the
+   trackers. A lane that finds a documented claim wrong or stale says so in the HANDOFF
+   `notes`, and the orchestrator routes that to the next capture → compile
+   pass — it does not edit the dossier from the lane.
 
 Spawn a full wave in ONE message (both Agent calls together at width 2).
 

--- a/canon/modules/android-port.md
+++ b/canon/modules/android-port.md
@@ -1,8 +1,10 @@
 ---
 title: Module — Android port
 updated: 2026-07-10
-status: verified
+status: stale
 ---
+
+**Stale.** verification evidence drifted; re-run the compile/verify pass.
 
 # Module — Android port
 

--- a/canon/modules/automation-tooling.md
+++ b/canon/modules/automation-tooling.md
@@ -1,8 +1,10 @@
 ---
 title: Module — automation and tooling
 updated: 2026-07-10
-status: verified
+status: stale
 ---
+
+**Stale.** verification evidence drifted; re-run the compile/verify pass.
 
 # Module — automation and tooling
 

--- a/scripts/__tests__/canon-staleness.test.sh
+++ b/scripts/__tests__/canon-staleness.test.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Contract tests for scripts/canon-staleness.sh — the bureau-canon drift
+# detector. All fixtures live in a temp tree (CANON_ROOT/CANON_DIR/VERIFY_JSON
+# overrides); never the real canon/ or repo.
+#
+# Run: bash scripts/__tests__/canon-staleness.test.sh
+
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../canon-staleness.sh"
+fails=0
+ok()   { echo "ok   — $1"; }
+fail() { echo "FAIL — $1"; fails=$((fails+1)); }
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "FAIL — $SCRIPT does not exist"; echo "1 FAILURE(S)"; exit 1
+fi
+
+sha() { python3 -c "import hashlib,sys;print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$1"; }
+
+# Build a fresh fixture tree; echoes the root.
+make_fixture() {
+    local root; root="$(mktemp -d)"
+    mkdir -p "$root/canon/modules" "$root/src" "$root/docs"
+    # a code artifact + a soft provenance artifact
+    printf 'let x = 1\n'      > "$root/src/foo.swift"
+    printf '| feature rows |\n' > "$root/docs/features.md"
+    local foohash feathash
+    foohash="$(sha "$root/src/foo.swift")"
+    feathash="$(sha "$root/docs/features.md")"
+    # a verified dossier citing both
+    cat > "$root/canon/modules/foo.md" <<EOF
+---
+title: Module — foo
+updated: 2026-07-11
+status: verified
+---
+
+# Module — foo
+
+Body.
+
+**Sources.** [[session x]]
+**Verified.** 2026-07-11 — checked against: src/foo.swift, docs/features.md
+EOF
+    # a canonical dossier that must never be demoted
+    cat > "$root/canon/modules/adr.md" <<EOF
+---
+title: ADR — untouchable
+updated: 2026-07-11
+status: canonical
+---
+# ADR
+EOF
+    cat > "$root/canon/_verify.json" <<EOF
+{
+ "Module — foo": {
+  "verifiedAt": "2026-07-11",
+  "checks": [
+   {"artifact": "src/foo.swift", "hash": "$foohash", "claim": "c"},
+   {"artifact": "docs/features.md", "hash": "$feathash", "claim": "c"}
+  ]
+ }
+}
+EOF
+    echo "$root"
+}
+
+run() {  # run <root> [--apply] ; sets $OUT $RC
+    local root="$1"; shift
+    OUT="$(CANON_ROOT="$root" CANON_DIR="$root/canon" VERIFY_JSON="$root/canon/_verify.json" bash "$SCRIPT" "$@" 2>&1)"
+    RC=$?
+}
+
+# 1. Nothing changed -> CLEAN, exit 0.
+R="$(make_fixture)"
+run "$R"
+{ [ $RC -eq 0 ] && echo "$OUT" | grep -q 'RESULT: CLEAN'; } \
+    && ok "unchanged canon is CLEAN (exit 0)" \
+    || fail "unchanged should be CLEAN exit 0 — got rc=$RC: $(echo "$OUT" | tail -1)"
+rm -rf "$R"
+
+# 2. Code artifact changed -> STALE 1, exit 3.
+R="$(make_fixture)"
+printf 'let x = 2  // changed\n' > "$R/src/foo.swift"
+run "$R"
+{ [ $RC -eq 3 ] && echo "$OUT" | grep -q 'RESULT: STALE 1'; } \
+    && ok "code drift -> STALE 1 (exit 3)" \
+    || fail "code drift should be STALE 1 exit 3 — got rc=$RC: $(echo "$OUT" | tail -1)"
+rm -rf "$R"
+
+# 3. Only the soft provenance file changed -> CLEAN (advisory), exit 0.
+R="$(make_fixture)"
+printf '| feature rows |\n| new row |\n' > "$R/docs/features.md"
+run "$R"
+{ [ $RC -eq 0 ] && echo "$OUT" | grep -q 'RESULT: CLEAN' && echo "$OUT" | grep -q 'ADVISORY'; } \
+    && ok "tracker-only drift is advisory, stays CLEAN (exit 0)" \
+    || fail "tracker-only drift should be CLEAN+advisory exit 0 — got rc=$RC: $(echo "$OUT" | tail -1)"
+rm -rf "$R"
+
+# 4. Missing code artifact -> STALE.
+R="$(make_fixture)"
+rm -f "$R/src/foo.swift"
+run "$R"
+{ [ $RC -eq 3 ] && echo "$OUT" | grep -q 'missing: src/foo.swift'; } \
+    && ok "missing code artifact -> STALE with 'missing:' reason" \
+    || fail "missing artifact should be STALE — got rc=$RC: $(echo "$OUT" | tail -1)"
+rm -rf "$R"
+
+# 5. --apply demotes a hard-stale verified page to stale + adds marker; leaves
+#    canonical untouched.
+R="$(make_fixture)"
+printf 'let x = 3\n' > "$R/src/foo.swift"
+run "$R" --apply
+foo_status="$(grep -m1 '^status:' "$R/canon/modules/foo.md" | sed 's/status: //')"
+adr_status="$(grep -m1 '^status:' "$R/canon/modules/adr.md" | sed 's/status: //')"
+{ [ "$foo_status" = "stale" ] && grep -q '\*\*Stale\.\*\*' "$R/canon/modules/foo.md" && [ "$adr_status" = "canonical" ]; } \
+    && ok "--apply demotes verified->stale (+marker); canonical untouched" \
+    || fail "--apply should demote foo to stale and leave adr canonical — foo=$foo_status adr=$adr_status"
+rm -rf "$R"
+
+# 6. Bad usage -> exit 2, ERROR result line.
+run "$(mktemp -d)" --bogus
+{ [ $RC -eq 2 ] && echo "$OUT" | grep -q 'RESULT: ERROR'; } \
+    && ok "unknown arg -> ERROR (exit 2)" \
+    || fail "unknown arg should ERROR exit 2 — got rc=$RC"
+
+# 7. Missing _verify.json -> exit 2, ERROR.
+EMPTY="$(mktemp -d)"; mkdir -p "$EMPTY/canon"
+OUT="$(CANON_ROOT="$EMPTY" CANON_DIR="$EMPTY/canon" VERIFY_JSON="$EMPTY/canon/_verify.json" bash "$SCRIPT" 2>&1)"; RC=$?
+{ [ $RC -eq 2 ] && echo "$OUT" | grep -q 'RESULT: ERROR'; } \
+    && ok "missing _verify.json -> ERROR (exit 2)" \
+    || fail "missing ledger should ERROR exit 2 — got rc=$RC"
+rm -rf "$EMPTY"
+
+echo
+if [ "$fails" -eq 0 ]; then echo "ALL PASS"; exit 0; else echo "$fails FAILURE(S)"; exit 1; fi

--- a/scripts/__tests__/dispatch-shape.test.sh
+++ b/scripts/__tests__/dispatch-shape.test.sh
@@ -47,6 +47,11 @@ has "$SKILL" "git log origin/main..main" "committed-contamination detection"
 has "$SKILL" "check-write-set.sh" "write-set gate in the tail"
 has "$SKILL" "sim-lease.sh" "sim leases wired"
 
+# canon orientation (rule 56) — the brief routes the owning dossier(s) in as
+# read-only inputs, and forbids lanes editing canon
+has "$SKILL" "canon-owner.sh" "canon orientation wired into the lane brief"
+has "$SKILL" "NEVER edits canon" "brief carries the lane-never-edits-canon guard"
+
 # Gate-4 R1 operational invariants (audit thread 019f4467)
 has "$SKILL" "git -C <worktree> commit" "tail tracker/docs edits committed ON the lane branch"
 has "$SKILL" "as the branch's LAST commit" "bump is the branch's last commit, in the worktree"

--- a/scripts/canon-owner.sh
+++ b/scripts/canon-owner.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# canon-owner.sh — resolve repo paths (or path prefixes) to the bureau-canon
+# dossier(s) that document them, via canon/_coverage-ledger.json.
+#
+# Purpose: the /dispatch brief generator calls this with a lane's write-set
+# prefixes so the generated lane brief can list the owning dossier(s) as
+# read-only orientation Inputs (rule 55 lane-brief step). An implementer lane
+# then reads the relevant canon page for cross-module context BEFORE editing,
+# without a human hand-picking it. Read-routing, not read-forcing.
+#
+# Usage:
+#   scripts/canon-owner.sh vreader/Services/Backup/            # a write-set prefix
+#   scripts/canon-owner.sh vreader/Services/Foo.swift docs/x   # exact files/prefixes
+#
+# Prints one repo-relative dossier path per line (deduped, sorted), then a
+# final `CANON-OWNER RESULT: <n> dossier(s)` line. Exit 0 if >=1 owner found,
+# 3 if none, 2 on error.
+
+set -uo pipefail
+
+if [ "$#" -eq 0 ]; then
+    echo "usage: canon-owner.sh <path-or-prefix>..." >&2
+    echo "CANON-OWNER RESULT: ERROR (no paths)"; exit 2
+fi
+
+REPO_ROOT="${CANON_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+CANON_DIR="${CANON_DIR:-$REPO_ROOT/canon}"
+LEDGER="${COVERAGE_LEDGER:-$CANON_DIR/_coverage-ledger.json}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "canon-owner: python3 not found" >&2
+    echo "CANON-OWNER RESULT: ERROR (no python3)"; exit 2
+fi
+if [ ! -f "$LEDGER" ]; then
+    echo "canon-owner: coverage ledger not found: $LEDGER" >&2
+    echo "CANON-OWNER RESULT: ERROR (no _coverage-ledger.json)"; exit 2
+fi
+
+CANON_DIR="$CANON_DIR" LEDGER="$LEDGER" python3 - "$@" <<'PY'
+import json, os, re, sys
+
+canon_dir = os.environ["CANON_DIR"]
+ledger_p  = os.environ["LEDGER"]
+inputs    = [a.rstrip("/") for a in sys.argv[1:]]
+
+try:
+    ledger = json.load(open(ledger_p, encoding="utf-8"))
+except Exception as e:
+    print(f"canon-owner: cannot parse {ledger_p}: {e}", file=sys.stderr)
+    print("CANON-OWNER RESULT: ERROR (bad ledger)"); sys.exit(2)
+
+# (path, dossier) pairs from per-file rows and group rows.
+entries = []
+for r in ledger.get("rows", []):
+    if r.get("dossier"):
+        entries.append((r["path"].rstrip("/"), r["dossier"]))
+for g in ledger.get("groups", []):
+    if g.get("dossier"):
+        entries.append((g["path"].rstrip("/"), g["dossier"]))
+
+def owners_for(query):
+    q = query.rstrip("/")
+    found = set()
+    for path, dossier in entries:
+        # exact file match, query is a prefix of an entry, or entry (a group
+        # dir) is a prefix of the query.
+        if path == q or path.startswith(q + "/") or q.startswith(path + "/"):
+            found.add(dossier)
+    return found
+
+dossiers = set()
+for q in inputs:
+    dossiers |= owners_for(q)
+
+# Map dossier title -> canon file path.
+title_re = re.compile(r'^title:\s*(.+?)\s*$', re.MULTILINE)
+by_title = {}
+for root, _d, files in os.walk(canon_dir):
+    for fn in files:
+        if not fn.endswith(".md"):
+            continue
+        fp = os.path.join(root, fn)
+        try:
+            head = open(fp, encoding="utf-8", errors="replace").read(2048)
+        except OSError:
+            continue
+        m = title_re.search(head)
+        if m:
+            by_title[m.group(1).strip()] = fp
+
+repo_root = os.path.dirname(canon_dir)
+paths = sorted({os.path.relpath(by_title[d], repo_root) for d in dossiers if d in by_title})
+for p in paths:
+    print(p)
+n = len(paths)
+print(f"CANON-OWNER RESULT: {n} dossier(s)")
+sys.exit(0 if n else 3)
+PY

--- a/scripts/canon-staleness.sh
+++ b/scripts/canon-staleness.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# canon-staleness.sh — detect drift between the bureau canon's verified
+# dossiers and the code they were verified against.
+#
+# The compile pipeline records, for every `status: verified` dossier, a
+# sha256 of each artifact it was checked against (canon/_verify.json, built
+# by the compile step). This script re-hashes those artifacts and flags any
+# page whose evidence no longer matches the live repo — i.e. the code changed
+# under a dossier and its `verified` claim may now be stale.
+#
+# This is the "keep the canon fresh" detector: `verified` is auto-checked but
+# not human-approved, and `stale` is a legal AI-writable trust tier, so a page
+# whose evidence drifted is demoted to `stale` (never touched again until a
+# fresh compile/verify pass re-confirms it). Never touches `canonical`
+# (human-owned) or `proposed`/`stale` pages.
+#
+# Usage:
+#   scripts/canon-staleness.sh            # report only (read-only)
+#   scripts/canon-staleness.sh --apply    # also flip drifted pages verified -> stale
+#
+# Env (for tests): CANON_DIR (default: canon), VERIFY_JSON (default:
+#   $CANON_DIR/_verify.json).
+#
+# Exit: 0 = clean (no drift), 3 = drift found, 2 = usage/environment error.
+# Emits one machine-parseable final line: `CANON-STALENESS RESULT: ...`.
+
+set -uo pipefail
+
+APPLY=0
+for arg in "$@"; do
+    case "$arg" in
+        --apply) APPLY=1 ;;
+        -h|--help)
+            sed -n '2,26p' "$0"; exit 0 ;;
+        *) echo "canon-staleness: unknown argument: $arg" >&2
+           echo "CANON-STALENESS RESULT: ERROR (bad usage)"; exit 2 ;;
+    esac
+done
+
+# CANON_ROOT overridable so tests can point artifact resolution at a fixture
+# tree; defaults to the repo root inferred from this script's location.
+REPO_ROOT="${CANON_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+CANON_DIR="${CANON_DIR:-$REPO_ROOT/canon}"
+VERIFY_JSON="${VERIFY_JSON:-$CANON_DIR/_verify.json}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "canon-staleness: python3 not found" >&2
+    echo "CANON-STALENESS RESULT: ERROR (no python3)"; exit 2
+fi
+if [ ! -f "$VERIFY_JSON" ]; then
+    echo "canon-staleness: verify ledger not found: $VERIFY_JSON" >&2
+    echo "CANON-STALENESS RESULT: ERROR (no _verify.json)"; exit 2
+fi
+
+CANON_DIR="$CANON_DIR" VERIFY_JSON="$VERIFY_JSON" REPO_ROOT="$REPO_ROOT" \
+APPLY="$APPLY" python3 - <<'PY'
+import json, os, re, sys, hashlib
+
+canon_dir  = os.environ["CANON_DIR"]
+verify_p   = os.environ["VERIFY_JSON"]
+repo_root  = os.environ["REPO_ROOT"]
+apply      = os.environ["APPLY"] == "1"
+
+try:
+    verify = json.load(open(verify_p, encoding="utf-8"))
+except Exception as e:
+    print(f"canon-staleness: cannot parse {verify_p}: {e}", file=sys.stderr)
+    print("CANON-STALENESS RESULT: ERROR (bad _verify.json)")
+    sys.exit(2)
+
+# Index every dossier by its frontmatter title -> (path, current status).
+title_re  = re.compile(r'^title:\s*(.+?)\s*$', re.MULTILINE)
+status_re = re.compile(r'^status:\s*(\S+)', re.MULTILINE)
+by_title = {}
+for root, _dirs, files in os.walk(canon_dir):
+    for fn in files:
+        if not fn.endswith(".md"):
+            continue
+        fp = os.path.join(root, fn)
+        try:
+            head = open(fp, encoding="utf-8", errors="replace").read(4096)
+        except OSError:
+            continue
+        mt = title_re.search(head)
+        ms = status_re.search(head)
+        if mt:
+            by_title[mt.group(1).strip()] = (fp, ms.group(1).strip() if ms else None)
+
+def sha256(path):
+    try:
+        with open(path, "rb") as f:
+            return hashlib.sha256(f.read()).hexdigest()
+    except OSError:
+        return None
+
+# High-churn provenance files: almost every dossier cites these for bug/feature
+# cross-references, and they change on essentially every merge. Drift here does
+# NOT invalidate a dossier's claims about the CODE, so it is advisory only —
+# never a demotion trigger. Everything else (source, rules, architecture doc,
+# contracts, README, dev-docs) is substantive: drift demotes.
+SOFT = {
+    "docs/features.md",
+    "docs/bugs.md",
+    "docs/tasks.md",
+    "archive/bugs-history.md",
+}
+
+stale = []       # (title, path, status, hard_reasons) — real code drift
+soft_only = []   # (title, [soft_reasons]) — drifted only on provenance files
+orphaned = []    # titles in _verify.json with no matching dossier
+for title, entry in sorted(verify.items()):
+    hit = by_title.get(title)
+    if hit is None:
+        orphaned.append(title)
+        continue
+    path, status = hit
+    hard, soft = [], []
+    for chk in entry.get("checks", []):
+        art = chk.get("artifact")
+        want = chk.get("hash")
+        if not art or not want:
+            continue
+        got = sha256(os.path.join(repo_root, art))
+        if got is None:
+            (soft if art in SOFT else hard).append(f"missing: {art}")
+        elif got != want:
+            (soft if art in SOFT else hard).append(f"changed: {art}")
+    if hard:
+        stale.append((title, path, status, hard))
+    elif soft:
+        soft_only.append((title, soft))
+
+# Report.
+for title in orphaned:
+    print(f"ORPHAN   {title}  (in _verify.json but no dossier with that title)")
+flipped = 0
+for title, path, status, reasons in stale:
+    rel = os.path.relpath(path, repo_root)
+    shown = reasons[:6]
+    extra = f" (+{len(reasons)-6} more)" if len(reasons) > 6 else ""
+    print(f"STALE    {title}")
+    print(f"         {rel}  [{len(reasons)} artifact(s) drifted]{extra}")
+    for r in shown:
+        print(f"           - {r}")
+    if apply and status == "verified":
+        # Re-read live to avoid racing a concurrent human edit; only flip a
+        # page that is STILL verified.
+        txt = open(path, encoding="utf-8").read()
+        m = re.search(r'^status:\s*verified\s*$', txt, re.MULTILINE)
+        if m:
+            txt2 = txt[:m.start()] + "status: stale" + txt[m.end():]
+            # Add a one-line marker after the frontmatter's closing --- if not
+            # already present, so a reader knows why it went stale.
+            marker = "**Stale.** verification evidence drifted; re-run the compile/verify pass."
+            if "**Stale.**" not in txt2:
+                fm_end = txt2.find("\n---", 3)
+                if fm_end != -1:
+                    insert = txt2.find("\n", fm_end + 1)
+                    # place the marker right after the first blank line past frontmatter
+                    body_nl = txt2.find("\n\n", insert if insert != -1 else fm_end)
+                    if body_nl != -1:
+                        txt2 = txt2[:body_nl+2] + marker + "\n\n" + txt2[body_nl+2:]
+            tmp = path + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as f:
+                f.write(txt2)
+            os.replace(tmp, path)
+            flipped += 1
+            print(f"         -> demoted to status: stale")
+
+for title, soft in soft_only:
+    print(f"ADVISORY {title}  (only provenance files drifted: {', '.join(soft[:3])}"
+          + (f", +{len(soft)-3} more" if len(soft) > 3 else "") + ")")
+
+n = len(stale)
+advisories = len(soft_only) + len(orphaned)
+if apply:
+    print(f"canon-staleness: {flipped} page(s) demoted verified -> stale")
+if n == 0:
+    tail = f" ({advisories} advisory)" if advisories else ""
+    print(f"CANON-STALENESS RESULT: CLEAN{tail}")
+    sys.exit(0)
+tail = f" ({advisories} advisory)" if advisories else ""
+print(f"CANON-STALENESS RESULT: STALE {n}{tail}")
+sys.exit(3)
+PY


### PR DESCRIPTION
## Summary

Makes the bureau canon (`canon/`) usable as agent memory without heavy-handed enforcement: **route reads, funnel writes, detect drift.**

## What's in it

**Tooling**
- **`scripts/canon-staleness.sh`** (+ 7-case test) — re-hashes every artifact behind a `verified` dossier (`canon/_verify.json`) and demotes pages whose **code** evidence drifted to `stale`. High-churn trackers (`docs/features.md`, `bugs.md`, `tasks.md`, `archive/bugs-history.md`) are advisory-only (a dossier cites them for issue numbers; their churn doesn't invalidate its code claims). `canonical` is never touched. Wired into the watchdog cron (`--apply`, step 8).
- **`scripts/canon-owner.sh`** — resolves a lane's write-set prefixes → owning dossier(s) via `canon/_coverage-ledger.json`. The `/dispatch` brief generator injects these as **read-only orientation inputs** (brief template item 6), so a lane gets the relevant dossier as a contract input. Read-routing, not read-forcing.

**Rule + wiring**
- **`.claude/rules/56-canon-collaboration.md`** — codifies the model: four enforcement points (session consult-first; lane read-routing; per-session capture via the bureau plugin's already-registered `SessionEnd` hook; watchdog staleness demotion) and two hard prohibitions (no PreToolUse "must-read" gate; no per-action dossier writes — lanes propose via HANDOFF `notes`, never edit canon).
- `dispatch/SKILL.md` brief template gains the canon-orientation clause + lane-never-edits-canon guard, both asserted by `dispatch-shape.test.sh` so they can't silently regress.
- `watchdog.md` runs the staleness sweep each fire.

**Staleness demotion (second commit)**
- `canon-staleness.sh --apply` demoted 2 pages whose code evidence genuinely drifted: `Module — Android port` (merged #128/#129 Android work) and `Module — automation and tooling` (this PR's own tooling changes). Both marked `stale` to await the next `bureau:compile`; neither rewritten here.

## Notes
- **No app code changed** — scripts, a rule, cron/skill wiring, and 2 dossier status flips.
- Tests: `canon-staleness.test.sh` (7/7), `dispatch-shape.test.sh` (all pass incl. new assertions), `deps-check.test.sh` sanity (pass).
- Gazette press/health green (46 documents, zero dangling/schema/contradiction).