### PR TITLE
chore: set cc-suite defaults to gpt-5.6-sol / low effort

### DIFF
--- a/.cc-suite.md
+++ b/.cc-suite.md
@@ -15,8 +15,8 @@ Ported from the retired `.codex-toolkit.md` (codex-toolkit plugin replaced by cc
 These override the built-in defaults for all commands in this project.
 Remove a line to fall back to the built-in default.
 
-- **Default model**: gpt-5.5
-- **Default effort**: high
+- **Default model**: gpt-5.6-sol
+- **Default effort**: low
 - **Default audit type**: mini
 - **Default sandbox**: workspace-write
 


### PR DESCRIPTION
Persists the cc-suite default model + effort (gpt-5.5/high -> gpt-5.6-sol/low) configured this session. Config-only, no code.