### PR TITLE
fix(#134): rendersAcrossThemes — one setContent per test (Compose test bug)

### DIFF
--- a/.claude/codex-audits/fix-134-theme-test-setcontent-audit.md
+++ b/.claude/codex-audits/fix-134-theme-test-setcontent-audit.md
@@ -1,0 +1,51 @@
+---
+branch: fix/134-theme-test-setcontent
+threadId: 019f515b-3dde-7ae1-a2b9-69ed8c3e87dd
+rounds: 1
+final_verdict: ship-as-is
+date: 2026-07-11
+tool: codex (scripts/run-codex.sh)
+scope: test-only (androidTest Kotlin) — feature #134 Gate-5 follow-up
+---
+
+# Gate-4 audit — #134 `rendersAcrossThemes` Compose test fix
+
+## Context
+
+Feature #134's Gate-5 acceptance verifier found two connected suites RED due to a
+test-authoring bug shipped in the merged WI-3 (`MorePopupTest`) and WI-4
+(`BookDetailsSheetTest`): both `rendersAcrossThemes` tests looped
+`compose.setContent { … }` inside `for (theme in ReaderTheme.values())`.
+`AndroidComposeTestRule.setContent` may be called only ONCE per test, so the
+second iteration threw `IllegalStateException: … has already set content`. No
+product defect — every acceptance-relevant test in both suites passed; the
+product itself verified end-to-end on real EPUB + TXT books.
+
+## Fix
+
+- `BookDetailsSheetTest.rendersAcrossThemes`: render every theme in ONE
+  `setContent` via a `Column` of `BookDetailsSheetContent(theme = …)`, then assert
+  `onAllNodesWithTag("book-details-sheet-content").assertCountEquals(ReaderTheme.values().size)`.
+- `MorePopupTest.rendersAcrossThemes`: single `setContent` with the theme driven
+  by `mutableStateOf`; the loop mutates the state and asserts `more-popup` exists
+  per theme (popup-safe — avoids stacking multiple popup windows).
+
+Production code untouched; two `androidTest` files only.
+
+## Verdict — ship-as-is (Codex, 1 round)
+
+Codex (thread `019f515b-3dde-7ae1-a2b9-69ed8c3e87dd`) confirmed:
+- Both tests now call `setContent` exactly once — the `IllegalStateException` is eliminated.
+- Coverage is NOT weakened: `BookDetailsSheetTest` composes one sheet per theme and
+  asserts the exact node count == enum size (exercises every theme); `MorePopupTest`
+  recomposes per theme with a synchronizing semantics assertion each iteration.
+- Only the two `androidTest` files changed; no production/config touched.
+- No new flakiness (no timers/animations/async/repeated content installation).
+
+## Green evidence
+
+Both suites re-run connected on `emulator-5554` after the fix:
+- `com.vreader.app.reader.details.BookDetailsSheetTest` — 14 tests / 0 failures / 0 errors / 0 skipped.
+- `com.vreader.app.reader.more.MorePopupTest` — 11 tests / 0 failures / 0 errors / 0 skipped.
+
+Raw Codex transcript: `.reports/testfix-audit.txt` (lane-local, not committed).

--- a/android/app/src/androidTest/kotlin/com/vreader/app/reader/details/BookDetailsSheetTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/reader/details/BookDetailsSheetTest.kt
@@ -246,12 +246,18 @@ class BookDetailsSheetTest {
 
     @Test fun rendersAcrossThemes() {
         // Pure function of the theme tokens — renders in every theme (light + dark) without crash.
-        for (theme in ReaderTheme.values()) {
-            compose.setContent {
-                BookDetailsSheetContent(theme = theme, model = model(), onCopyFingerprint = {}, onShare = {})
+        // AndroidComposeTestRule.setContent may be called only ONCE per test, so render every theme
+        // in a single content tree (a Column) rather than looping setContent (which throws
+        // "has already set content").
+        compose.setContent {
+            androidx.compose.foundation.layout.Column {
+                for (theme in ReaderTheme.values()) {
+                    BookDetailsSheetContent(theme = theme, model = model(), onCopyFingerprint = {}, onShare = {})
+                }
             }
-            compose.onNodeWithTag("book-details-sheet-content", useUnmergedTree = true).assertExists()
         }
+        compose.onAllNodesWithTag("book-details-sheet-content", useUnmergedTree = true)
+            .assertCountEquals(ReaderTheme.values().size)
     }
 
     @Test fun modelExposesFullFingerprintDistinctFromDisplay() {

--- a/android/app/src/androidTest/kotlin/com/vreader/app/reader/more/MorePopupTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/reader/more/MorePopupTest.kt
@@ -174,10 +174,15 @@ class MorePopupTest {
 
     @Test fun rendersAcrossThemes() {
         // The popup is a pure function of the theme tokens — it renders in every theme (light + dark).
-        for (theme in ReaderTheme.values()) {
-            compose.setContent {
-                MorePopup(theme = theme, rows = listOf(detailsRow(), shareRow()), onDismiss = {})
-            }
+        // AndroidComposeTestRule.setContent may be called only ONCE per test; drive the theme via
+        // state across a single content tree instead of looping setContent (which throws
+        // "has already set content").
+        val theme = androidx.compose.runtime.mutableStateOf(ReaderTheme.values().first())
+        compose.setContent {
+            MorePopup(theme = theme.value, rows = listOf(detailsRow(), shareRow()), onDismiss = {})
+        }
+        for (t in ReaderTheme.values()) {
+            theme.value = t
             compose.onNodeWithTag("more-popup", useUnmergedTree = true).assertExists()
         }
     }

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.16.0
-versionCode=113
+versionName=0.16.1
+versionCode=114


### PR DESCRIPTION
Part of feature #134 (Android reader More menu + book details + share) — Gate-5 follow-up.

The #134 Gate-5 acceptance verifier found two connected suites RED from a **test-code bug** shipped in merged WI-3 (`MorePopupTest`) and WI-4 (`BookDetailsSheetTest`): both `rendersAcrossThemes` tests looped `compose.setContent{}` inside `for (theme in ReaderTheme.values())`. `AndroidComposeTestRule.setContent` may be called only ONCE per test → the 2nd iteration threw `IllegalStateException: has already set content`. **No product defect** (the product itself verified end-to-end on real EPUB + TXT).

Fix: render every theme in a single `setContent` — the sheet uses a `Column` of `BookDetailsSheetContent(theme)` and asserts count == `ReaderTheme.values().size`; the popup drives the theme via `mutableStateOf` across one `MorePopup` tree (popup-safe). Production code untouched.

Both suites now green on `emulator-5554`:
- `BookDetailsSheetTest` — 14/0/0/0
- `MorePopupTest` — 11/0/0/0

Gate-4: ship-as-is (Codex, thread 019f515b…) — `.claude/codex-audits/fix-134-theme-test-setcontent-audit.md`.
Version: android/v0.16.1 (versionCode 114).