### PR TITLE
fix(hooks): enforce rule 55's no-Bash-file-edits — close the tracker-guard bypass

### DIFF
--- a/.claude/hooks/check_bash_file_edit.sh
+++ b/.claude/hooks/check_bash_file_edit.sh
@@ -1,0 +1,373 @@
+#!/bin/bash
+# PreToolUse hook for the Bash tool.
+#
+# Purpose: blocks a Bash command that mutates a repo-TRACKED file in
+# place (heredoc/redirect, `sed -i`, `tee`, an interpreter one-liner
+# that opens a repo path for writing). Those writes bypass the two
+# PreToolUse tracker guards — `check_terminal_status_evidence.sh` and
+# `check_gh_issue_mirror.sh` — because both are registered ONLY on the
+# `Edit|Write|MultiEdit` matcher. A single
+# `cat > docs/features.md <<'EOF' … EOF` can therefore flip a row to
+# VERIFIED with no evidence file, or add a PLANNED row with no GH
+# mirror, with nothing in the way.
+#
+# `.claude/rules/55-lane-dispatch.md` already forbids this ("lanes …
+# never edit ANY file via Bash … use Edit/Write tools, everywhere, so
+# hooks fire"), and the rule binds the orchestrator too. It was
+# unenforced until now: on 2026-08-04 TWO separate agents heredoc-wrote
+# tracker files in one day, both self-reported it, both while
+# explicitly briefed not to. When two well-briefed agents violate the
+# same rule the same way, the gap is in enforcement, not discipline.
+# This hook is that enforcement.
+#
+# Detected constructs (each must resolve to a tracked repo path):
+#   - `> path` / `>> path` (incl. `cat > f <<EOF`, `printf … > f`,
+#     `echo … >> f`, `awk … > f`) and `&> path`
+#   - `sed -i` / `perl -i` / `ruby -i` in-place edits
+#   - `tee path` / `tee -a path`
+#   - `python3 -c '… open(p, "w") …'`, `python3 - <<EOF`, `node -e`,
+#     `ruby -e`, `perl -e` — interpreter + a write API + a repo path
+#
+# Deliberately NOT blocked (false positives here would get the hook
+# disabled, which is worse than no hook):
+#   - anything outside the repo: the scratchpad, /tmp, $TMPDIR
+#   - untracked output: `build/`, `*/build/`, `.gradle/`, `DerivedData`,
+#     `node_modules/`, `.reports/`, `test-books/`, `*.log`, `*.output`
+#   - `.claude/cron-logs/*.log` appends (the cron prompts do this)
+#   - `git` / `gh` / `xcodegen` — rewriting tracked files IS their job
+#   - read-only pipelines (`grep`, `cat f | …`, `sed` without `-i`)
+#   - paths that are not under a tracked directory
+#   - a QUOTED mention of a write (`grep -rn "> docs/features.md" …`,
+#     `echo "never sed -i docs/bugs.md"`) — an operator inside shell
+#     quotes is text, not a redirect
+#   - anything whose target is unresolvable (unexpanded `$VAR`) —
+#     ambiguity ALLOWS; the rule-55 discipline covers the remainder.
+#
+# Known residual gaps (deliberate — each would cost false positives on
+# routine traffic, which is the failure mode that gets a hook disabled):
+#   - a write wrapped in quotes for another shell: `bash -c "sed -i … f"`
+#   - `mv` / `cp` of an untracked file OVER a tracked path
+#   - a target built from an unexpanded variable other than
+#     $CLAUDE_PROJECT_DIR
+#   - a write into a SIBLING worktree from the main checkout (the repo
+#     root is resolved from the invocation cwd, so the target reads as
+#     out-of-repo)
+#
+# Escape hatch (documented, warns, never silent): set
+# `VREADER_ALLOW_BASH_EDIT=1`, either in the hook's environment or as an
+# inline prefix on the command itself:
+#     VREADER_ALLOW_BASH_EDIT=1 sed -i '' 's/a/b/' docs/foo.md
+# Use it only when no Edit/Write tool call can express the mutation.
+#
+# Speed: this runs on EVERY Bash call. Hot path is one `jq` (matching
+# the sibling Bash hook) plus a pure-bash regex prefilter; `python3` is
+# spawned only when the command actually contains a write construct.
+# Tracked-ness is a STATIC top-level prefix check — no `git ls-files`,
+# no git invocation at all.
+#
+# Reads PreToolUse JSON from stdin. Exits 0 to allow, 2 to block.
+
+set -euo pipefail
+
+INPUT="$(cat)"
+
+if ! command -v jq >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then
+    # Tool missing — fail open rather than block the agent.
+    exit 0
+fi
+
+# `|| echo ""` on every extraction: a malformed payload must fail OPEN
+# (exit 0), not die with jq's exit code under `set -e` — a hook on the
+# Bash hot path that errors noisily is a hook someone disables.
+TOOL_NAME="$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null || echo "")"
+[[ "$TOOL_NAME" == "Bash" ]] || exit 0
+
+COMMAND="$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")"
+[[ -n "$COMMAND" ]] || exit 0
+
+# Escape hatch — env var, or an inline `VREADER_ALLOW_BASH_EDIT=1` prefix
+# (the hook process does not inherit the command's own assignments).
+if [[ "${VREADER_ALLOW_BASH_EDIT:-}" == "1" ]] \
+   || [[ "$COMMAND" == *"VREADER_ALLOW_BASH_EDIT=1"* ]]; then
+    echo "[bash-file-edit-hook] WARNING: VREADER_ALLOW_BASH_EDIT=1 — Bash file-edit guard bypassed for this command. Prefer the Edit/Write tools (.claude/rules/55-lane-dispatch.md)." >&2
+    exit 0
+fi
+
+# Cheap pure-bash prefilter: no redirect / tee / in-place / interpreter
+# token means there is nothing to analyse. Keeps python3 off the hot path.
+if [[ ! "$COMMAND" =~ ([>]|(^|[^[:alnum:]_./-])(tee|sed|gsed|perl|python|python3|node|ruby|deno|bun)([^[:alnum:]_-]|$)) ]]; then
+    exit 0
+fi
+
+# cwd of the invocation (a worktree lane runs elsewhere than
+# $CLAUDE_PROJECT_DIR — see check_codex_audit_artifact.sh's note).
+HOOK_CWD="$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || echo "")"
+[[ -n "$HOOK_CWD" ]] || HOOK_CWD="$(pwd)"
+
+# Command text travels on stdin, never argv/env: a heredoc body can be
+# large and env+argv share ARG_MAX (E2BIG — the same trap documented in
+# check_gh_issue_mirror.sh).
+FINDINGS="$(printf '%s' "$COMMAND" | HOOK_CWD="$HOOK_CWD" \
+    PROJECT_DIR="${CLAUDE_PROJECT_DIR:-}" python3 -c '
+import os, re, sys
+
+cmd = sys.stdin.read()
+
+# ---------------------------------------------------------------- config
+# Top-level tracked directories + tracked root files (static: a per-call
+# `git ls-files` would be a subprocess on every Bash invocation).
+TRACKED_DIRS = {
+    ".claude", ".codex", ".gemini", ".github", "TestPlans", "android",
+    "archive", "canon", "contracts", "dev-docs", "docs", "scripts",
+    "spikes", "vreader", "vreader.xcodeproj", "vreaderTests",
+    "vreaderUITests",
+}
+TRACKED_ROOT_FILES = {
+    ".cc-suite.md", ".gitignore", "AGENTS.md", "BUREAU.md", "CLAUDE.md",
+    "GEMINI.md", "README.md", "project.yml",
+}
+# Any path component in this set makes the target untracked build/report
+# output — allowed even under a tracked dir (android/app/build/..., etc).
+ALLOW_COMPONENTS = {
+    "build", ".gradle", ".git", "DerivedData", "node_modules", ".reports",
+    "cron-logs", "test-books", "tmp", ".tokenize", ".secrets", "logs",
+}
+ALLOW_EXT = {".log", ".output"}
+# Tools whose whole purpose is rewriting tracked files.
+ALLOW_TOOLS = {"git", "gh", "xcodegen"}
+
+# --------------------------------------------------- heredoc body split
+# Bodies are removed from the "code" text so a doc/plan being written
+# cannot trip the detector with example commands in its own prose. They
+# are kept separately for the interpreter-write scan (python3 - <<EOF).
+HEREDOC = re.compile(r"(?<!<)<<-?\s*(?!<)([\"\x27]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+lines = cmd.split("\n")
+code_lines, body_lines = [], []
+i = 0
+while i < len(lines):
+    line = lines[i]
+    code_lines.append(line)
+    delims = [m.group(2) for m in HEREDOC.finditer(line)]
+    i += 1
+    for d in delims:
+        while i < len(lines) and lines[i].strip() != d:
+            body_lines.append(lines[i])
+            i += 1
+        if i < len(lines):
+            i += 1
+code = "\n".join(code_lines)
+full = cmd
+
+# ------------------------------------------------------- root + cwd
+def strip_quotes(tok):
+    tok = tok.strip()
+    while len(tok) >= 2 and tok[0] == tok[-1] and tok[0] in "\"\x27":
+        tok = tok[1:-1]
+    return tok
+
+cwd = os.environ.get("HOOK_CWD") or os.getcwd()
+# A leading `cd <abs> &&` retargets every relative path in the command.
+m = re.match(r"\s*cd\s+(\"[^\"]*\"|\x27[^\x27]*\x27|[^\s;&|]+)\s*(?:&&|;)", cmd)
+if m:
+    lead = strip_quotes(m.group(1))
+    if lead.startswith("/"):
+        cwd = lead
+
+root = ""
+probe = os.path.normpath(cwd)
+while True:
+    if os.path.exists(os.path.join(probe, ".git")):
+        root = probe
+        break
+    parent = os.path.dirname(probe)
+    if parent == probe:
+        break
+    probe = parent
+if not root:
+    root = os.environ.get("PROJECT_DIR", "")
+if not root:
+    sys.exit(0)
+root = root.rstrip("/")
+
+# --------------------------------------------------------- classifier
+def is_blocked_path(raw):
+    p = strip_quotes(raw)
+    if not p or p.startswith("-"):
+        return None
+    # Only $CLAUDE_PROJECT_DIR is resolvable; any other expansion is
+    # ambiguous, and ambiguity ALLOWS.
+    p = p.replace("$CLAUDE_PROJECT_DIR", root).replace("${CLAUDE_PROJECT_DIR}", root)
+    if "$" in p or "`" in p or "*" in p or "?" in p:
+        return None
+    if p.startswith("~"):
+        p = os.path.expanduser(p)
+    if not p.startswith("/"):
+        p = os.path.join(cwd, p)
+    p = os.path.normpath(p)
+    if not p.startswith(root + "/"):
+        return None
+    rel = p[len(root) + 1:]
+    parts = rel.split("/")
+    if any(part in ALLOW_COMPONENTS for part in parts):
+        return None
+    if os.path.splitext(rel)[1] in ALLOW_EXT:
+        return None
+    if parts[0] in TRACKED_DIRS and len(parts) > 1:
+        return rel
+    if len(parts) == 1 and rel in TRACKED_ROOT_FILES:
+        return rel
+    return None
+
+def quoted_mask(s):
+    """1 for every offset inside a shell quote. A `>` there is text, not a
+    redirect — `grep -rn "> docs/features.md" .claude/rules/` and any command
+    that merely QUOTES a write (a test fixture, a doc example) must not
+    block. Trade-off: `bash -c "sed -i ... docs/x"` is missed; a false block
+    on routine grep/echo traffic is the worse failure (it gets hooks
+    disabled), so ambiguity ALLOWS."""
+    mask = bytearray(len(s))
+    q = None
+    i = 0
+    while i < len(s):
+        c = s[i]
+        if q is None:
+            if c in "\"\x27":
+                q = c
+                mask[i] = 1
+            elif c == "\\":
+                i += 1
+        else:
+            mask[i] = 1
+            if c == "\\" and q == "\"":
+                if i + 1 < len(s):
+                    mask[i + 1] = 1
+                i += 1
+            elif c == q:
+                q = None
+        i += 1
+    return mask
+
+def segment_tool(text, idx):
+    """Command name of the pipeline segment containing offset idx."""
+    start = 0
+    for sep in (";", "&&", "||", "|", "\n", "(", "{"):
+        j = text.rfind(sep, 0, idx)
+        if j + len(sep) > start:
+            start = j + len(sep)
+    seg = text[start:idx]
+    for tok in seg.split():
+        if re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", tok):
+            continue  # leading VAR=value assignment
+        return os.path.basename(strip_quotes(tok))
+    return ""
+
+findings = []
+seen = set()
+
+def record(construct, raw, offset=None, text=None):
+    if offset is not None and text is not None:
+        if segment_tool(text, offset) in ALLOW_TOOLS:
+            return
+    rel = is_blocked_path(raw)
+    if rel and (construct, rel) not in seen:
+        seen.add((construct, rel))
+        findings.append((construct, rel))
+
+# ------------------------------------------------------- 1. redirects
+norm = re.sub(r"(\d)?>&\s*(\d|-)", "  ", code)        # fd dup: 2>&1, >&-
+norm = norm.replace("&>>", " >>").replace("&>", " >")  # bash both-streams
+norm_q = quoted_mask(norm)
+for m in re.finditer(
+        r"(?<![<>&])(>>?)\s*(\"[^\"]*\"|\x27[^\x27]*\x27|[^\s;|&<>()]+)", norm):
+    if norm_q[m.start()]:
+        continue                                       # quoted text, not a redirect
+    target = m.group(2)
+    if target.startswith("("):
+        continue                                       # process substitution
+    label = "shell redirect `%s`" % m.group(1)
+    record(label, target, m.start(), norm)
+
+code_q = quoted_mask(code)
+
+# ------------------------------------------------------------ 2. tee
+for m in re.finditer(r"(?:^|[\s;|&(])(tee)\b([^|;&\n]*)", code):
+    if code_q[m.start(1)]:
+        continue
+    for tok in m.group(2).split():
+        if tok.startswith("-"):
+            continue
+        record("`tee`", tok, m.start(1), code)
+
+# --------------------------------------------- 3. in-place stream edits
+INPLACE_FLAG = re.compile(r"^--?[a-zA-Z]*i([.\x27\"].*)?$")
+for m in re.finditer(r"(?:^|[\s;|&(])(sed|gsed|perl|ruby)\b([^;|&\n]*)", code):
+    if code_q[m.start(1)]:
+        continue
+    tool, args = m.group(1), m.group(2)
+    toks = args.split()
+    if not any(INPLACE_FLAG.match(t) or t.startswith("--in-place") for t in toks):
+        continue
+    for tok in toks:
+        if tok.startswith("-"):
+            continue
+        record("`%s -i` in-place edit" % tool, tok, m.start(1), code)
+
+# ------------------------------------------- 4. interpreter write calls
+INTERP = re.compile(r"(?:^|[\s;|&(])(python3?|node|ruby|perl|deno|bun)\b")
+WRITE_API = re.compile(
+    r"open\s*\([^()]*[,\s][\"\x27][rwxab+t]{1,3}[\"\x27]"
+    r"|writeFileSync|appendFileSync|createWriteStream"
+    r"|\.write_text\s*\(|\.write_bytes\s*\("
+    r"|File\.(?:write|open)|IO\.write|fs\.writeFile|fs\.appendFile")
+LITERAL = re.compile(r"([\"\x27])([^\"\x27\n]+)\1")   # paired quotes only
+if INTERP.search(code):
+    lang = INTERP.search(code).group(1)
+    for hit in WRITE_API.finditer(full):
+        if hit.group(0).startswith("open"):
+            mode = re.findall(r"[\"\x27]([rwxab+t]{1,3})[\"\x27]", hit.group(0))
+            if not mode or not any(c in mode[-1] for c in "wax"):
+                continue                              # read-only open()
+        # Bounded window around the write call — the path literal sits
+        # inside it (open("p","w")) or just before it (Path("p").write_text).
+        close = full.find(")", hit.end())
+        end = close + 1 if 0 <= close <= hit.end() + 200 else hit.end() + 200
+        window = full[max(0, hit.start() - 120):end]
+        for lm in LITERAL.finditer(window):
+            lit = lm.group(2)
+            if "/" in lit or lit in TRACKED_ROOT_FILES:
+                record("interpreter write (`%s`)" % lang, lit)
+
+for construct, rel in findings[:6]:
+    print("%s\t%s" % (rel, construct))
+' 2>/dev/null || true)"
+
+[[ -n "$FINDINGS" ]] || exit 0
+
+cat >&2 <<'EOF'
+[bash-file-edit-hook] BLOCKED.
+
+This Bash command writes to repo-tracked file(s) in place:
+
+EOF
+while IFS=$'\t' read -r rel construct; do
+    [[ -n "$rel" ]] || continue
+    echo "  - $rel   (via $construct)" >&2
+done <<< "$FINDINGS"
+cat >&2 <<'EOF'
+
+Bash-mediated writes bypass the PreToolUse tracker guards
+(check_terminal_status_evidence.sh, check_gh_issue_mirror.sh) — both are
+registered ONLY on the Edit|Write|MultiEdit matcher, so they never see a
+heredoc, `sed -i`, or `tee`. That is how a tracker row can reach VERIFIED
+with no evidence file, or land as PLANNED with no GH mirror.
+
+Per .claude/rules/55-lane-dispatch.md ("never edit ANY file via Bash"):
+make this change with the Edit / Write / MultiEdit tools instead. The rule
+binds every session — orchestrator, lane, and cron alike.
+
+If the mutation genuinely cannot be expressed as a tool call, re-run with
+the documented escape hatch (it warns, it does not hide):
+
+    VREADER_ALLOW_BASH_EDIT=1 <your command>
+EOF
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,6 +37,11 @@
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check_codex_audit_artifact.sh",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check_bash_file_edit.sh",
+            "timeout": 15
           }
         ]
       }

--- a/scripts/__tests__/check-bash-file-edit.test.sh
+++ b/scripts/__tests__/check-bash-file-edit.test.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Contract tests for .claude/hooks/check_bash_file_edit.sh — the PreToolUse
+# guard that stops a Bash command from mutating a repo-tracked file in place.
+#
+# Why the hook exists: the two tracker guards (check_terminal_status_evidence,
+# check_gh_issue_mirror) are registered ONLY on the Edit|Write|MultiEdit
+# matcher, so `cat > docs/features.md <<EOF` bypasses both. Rule 55 forbids
+# Bash file edits; on 2026-08-04 two separately-briefed agents did it anyway.
+#
+# Everything runs against a TEMPORARY fixture repo (a dir with a `.git`
+# marker), never the real checkout, so the verdict never moves when the real
+# tracker files change. The blocked/allowed split is the whole contract:
+# a false block on a routine command is worse than a missed exotic write.
+#
+# Run: bash scripts/__tests__/check-bash-file-edit.test.sh
+
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+HOOK="$ROOT/.claude/hooks/check_bash_file_edit.sh"
+fails=0
+
+ok()   { echo "ok   — $1"; }
+fail() { echo "FAIL — $1"; fails=$((fails+1)); }
+
+echo "== check_bash_file_edit =="
+
+if [ ! -f "$HOOK" ]; then
+    echo "FAIL — $HOOK missing"; echo "1 FAILURE(S)"; exit 1
+fi
+if ! bash -n "$HOOK" 2>/dev/null; then
+    echo "FAIL — $HOOK is not valid bash"; echo "1 FAILURE(S)"; exit 1
+fi
+
+FIX="$(mktemp -d -t bash-edit-fixture.XXXXXX)"
+trap 'rm -rf "$FIX"' EXIT
+mkdir -p "$FIX/.git" "$FIX/docs" "$FIX/dev-docs" "$FIX/vreader/Services" \
+         "$FIX/.claude/cron-logs" "$FIX/build" "$FIX/android/app/build" \
+         "$FIX/.reports" "$FIX/scripts"
+: > "$FIX/docs/features.md"
+: > "$FIX/docs/bugs.md"
+
+OUT=""; RC=0
+run() { # <command>  — payload cwd is the fixture repo
+    OUT="$(python3 -c '
+import json, sys
+print(json.dumps({"tool_name": "Bash", "cwd": sys.argv[1],
+                  "tool_input": {"command": sys.argv[2]}}))' "$FIX" "$1" \
+        | env -u VREADER_ALLOW_BASH_EDIT bash "$HOOK" 2>&1)"
+    RC=$?
+}
+
+blocks() { # <label> <command> <path-that-must-be-named>
+    run "$2"
+    if [ "$RC" -ne 2 ]; then
+        fail "$1: expected exit 2, got $RC"
+    elif ! grep -q "BLOCKED" <<<"$OUT"; then
+        fail "$1: exit 2 but no BLOCKED banner"
+    elif ! grep -q -- "$3" <<<"$OUT"; then
+        fail "$1: block message does not name '$3' — got: $(head -6 <<<"$OUT" | tr '\n' ' ')"
+    else
+        ok "$1"
+    fi
+}
+
+allows() { # <label> <command>
+    run "$2"
+    if [ "$RC" -eq 0 ]; then
+        ok "$1"
+    else
+        fail "$1: expected exit 0, got $RC — $(grep -E '^  - ' <<<"$OUT" | tr '\n' ' ')"
+    fi
+}
+
+# --- BLOCKED: the constructs rule 55 forbids --------------------------------
+
+blocks "heredoc into docs/features.md is blocked" \
+"cat > docs/features.md <<'EOF'
+| 5 | thing | Reader | High | VERIFIED | done |
+EOF" "docs/features.md"
+
+blocks "sed -i on a tracked file is blocked" \
+    "sed -i '' 's/TODO/FIXED/' docs/bugs.md" "docs/bugs.md"
+
+blocks "perl -i on a tracked file is blocked" \
+    "perl -pi -e 's/a/b/' docs/bugs.md" "docs/bugs.md"
+
+blocks "tee to a tracked file is blocked" \
+    "echo x | tee docs/features.md" "docs/features.md"
+
+blocks "tee -a to a tracked file is blocked" \
+    "echo x | tee -a dev-docs/notes.md" "dev-docs/notes.md"
+
+blocks "python3 -c write to a tracked file is blocked" \
+    "python3 -c 'open(\"docs/features.md\",\"w\").write(\"rows\")'" "docs/features.md"
+
+blocks "python3 - <<EOF write is blocked" \
+"python3 - <<'PY'
+open('docs/bugs.md','a').write('| 9 | x |')
+PY" "docs/bugs.md"
+
+blocks "node -e writeFileSync is blocked" \
+    "node -e 'require(\"fs\").writeFileSync(\"docs/features.md\",\"y\")'" "docs/features.md"
+
+blocks "append redirect to source is blocked" \
+    "printf 'x' >> vreader/Services/Foo.swift" "vreader/Services/Foo.swift"
+
+blocks "absolute path into the repo is blocked" \
+"cat > $FIX/docs/features.md <<EOF
+x
+EOF" "docs/features.md"
+
+blocks "awk redirect to a tracked file is blocked" \
+    "awk '{print}' /tmp/in > docs/bugs.md" "docs/bugs.md"
+
+blocks "block message cites rule 55 and the Edit tools" \
+    "sed -i '' 's/a/b/' docs/features.md" "55-lane-dispatch.md"
+
+blocks "block message names the construct" \
+    "echo x | tee docs/bugs.md" 'via `tee`'
+
+# --- ALLOWED: the routine traffic a false positive would break --------------
+
+allows "scratchpad heredoc" \
+"cat > /private/tmp/claude-501/proj/session/scratchpad/plan.md <<'EOF'
+notes
+EOF"
+
+allows "/tmp redirect" "echo hi > /tmp/out.txt"
+
+allows "cron-log append" \
+    'echo "$(date +%F) verify FIRED" >> .claude/cron-logs/verify.log'
+
+allows "git commit -F - heredoc" \
+"git commit -F - <<'EOF'
+fix: thing
+EOF"
+
+allows "git checkout of a tracked file" "git checkout docs/features.md"
+allows "gh pr comment" "gh pr comment 12 --body 'see docs/features.md'"
+allows "xcodegen generate" "xcodegen generate"
+
+allows "read-only grep pipeline" \
+    "grep -rn 'VERIFIED' docs/features.md | sed 's/^/> /' | head -5"
+
+allows "read-only sed -n on a tracked file" "sed -n '1,20p' docs/bugs.md"
+allows "cat of a tracked file into a pipe" "cat docs/bugs.md | awk '{print}' | wc -l"
+
+allows "write under build/" "echo done > build/marker"
+allows "write under android/**/build/" "echo x > android/app/build/gen.kt"
+allows "write under .reports/" "./gradlew test > .reports/gradle.output 2>&1"
+allows "*.log under a tracked dir" "echo x > scripts/run.log"
+
+allows "fd duplication is not a file write" \
+    "scripts/run-tests.sh vreaderTests/FooTests > /tmp/t.out 2>&1"
+
+allows "unresolvable \$VAR target" 'echo x > "$LOG"'
+
+allows "read-only open() in python3" \
+    "python3 -c 'print(open(\"docs/features.md\").read()[:40])'"
+
+allows "interpreter writing outside the repo" \
+    "python3 -c 'open(\"/tmp/o.json\",\"w\").write(x)' < docs/bugs.md"
+
+allows "heredoc BODY mentioning a write to a tracked file" \
+"cat > /tmp/rule.md <<'EOF'
+Never do: sed -i '' 's/a/b/' docs/features.md
+Never do: cat > docs/bugs.md <<INNER
+EOF"
+
+allows "untracked path at repo root" "echo x > notes-scratch.md"
+
+# Quoted mentions of a write are text, not a write. This class bit live
+# during development: a test driver whose ARGUMENT contained the heredoc
+# literal was blocked. Routine grep/echo traffic must survive.
+allows "grep for a redirect pattern" \
+    "grep -rn '> docs/features.md' .claude/rules/ | head"
+allows "echo mentioning a forbidden write" \
+    "echo 'never run: cat > docs/bugs.md or sed -i docs/bugs.md'"
+allows "quoted tee mention" "echo 'do not tee docs/features.md'"
+
+# --- escape hatch + non-Bash tools ------------------------------------------
+
+run "VREADER_ALLOW_BASH_EDIT=1 sed -i '' 's/a/b/' docs/features.md"
+if [ "$RC" -eq 0 ] && grep -q "WARNING" <<<"$OUT"; then
+    ok "inline VREADER_ALLOW_BASH_EDIT=1 bypasses with a warning"
+else
+    fail "inline escape hatch wrong (rc=$RC out='$(head -2 <<<"$OUT")')"
+fi
+
+ENVOUT="$(python3 -c '
+import json, sys
+print(json.dumps({"tool_name": "Bash", "cwd": sys.argv[1],
+                  "tool_input": {"command": sys.argv[2]}}))' \
+    "$FIX" "cat > docs/features.md <<EOF
+x
+EOF" | VREADER_ALLOW_BASH_EDIT=1 bash "$HOOK" 2>&1)"
+ENVRC=$?
+if [ "$ENVRC" -eq 0 ] && grep -q "WARNING" <<<"$ENVOUT"; then
+    ok "env VREADER_ALLOW_BASH_EDIT=1 bypasses with a warning"
+else
+    fail "env escape hatch wrong (rc=$ENVRC out='$(head -2 <<<"$ENVOUT")')"
+fi
+
+NB="$(printf '{"tool_name":"Edit","tool_input":{"file_path":"%s/docs/features.md"}}' "$FIX" \
+      | bash "$HOOK" 2>&1)"; NBRC=$?
+if [ "$NBRC" -eq 0 ] && [ -z "$NB" ]; then
+    ok "non-Bash tool call passes through untouched"
+else
+    fail "non-Bash tool mishandled (rc=$NBRC out='$NB')"
+fi
+
+EMPTY="$(printf '{"tool_name":"Bash","tool_input":{"command":""}}' | bash "$HOOK" 2>&1)"; ERC=$?
+if [ "$ERC" -eq 0 ]; then ok "empty command allowed"; else fail "empty command exited $ERC"; fi
+
+MALFORMED="$(printf 'not json' | bash "$HOOK" 2>&1)"; MRC=$?
+if [ "$MRC" -eq 0 ]; then
+    ok "malformed payload fails open"
+else
+    fail "malformed payload exited $MRC (must fail open)"
+fi
+
+# --- registration: the hook is wired on the Bash matcher --------------------
+
+if python3 -c '
+import json, sys
+cfg = json.load(open(sys.argv[1]))
+pre = cfg["hooks"]["PreToolUse"]
+bash_entries = [e for e in pre if e.get("matcher") == "Bash"]
+assert bash_entries, "no Bash matcher in PreToolUse"
+cmds = " ".join(h["command"] for e in bash_entries for h in e["hooks"])
+assert "check_bash_file_edit.sh" in cmds, cmds
+assert "check_codex_audit_artifact.sh" in cmds, "existing Bash hook lost"
+' "$ROOT/.claude/settings.json" 2>/dev/null; then
+    ok "registered as a PreToolUse Bash hook in .claude/settings.json"
+else
+    fail "not registered on the Bash matcher in .claude/settings.json"
+fi
+
+echo
+if [ "$fails" -eq 0 ]; then echo "ALL PASS"; exit 0; else echo "$fails FAILURE(S)"; exit 1; fi


### PR DESCRIPTION
## The gap

Rule 55 says agents must never edit files via Bash, because Bash writes bypass the PreToolUse hooks. **That rule was entirely unenforced:**

| PreToolUse matcher | Hooks |
|---|---|
| `Edit\|Write\|MultiEdit` | `check_terminal_status_evidence.sh`, `check_gh_issue_mirror.sh` |
| `Bash` | `check_codex_audit_artifact.sh` **only** |

So `cat > docs/features.md <<'EOF'` silently bypassed **both** tracker guards — a path by which a row reaches `VERIFIED` with no evidence file, or lands as `PLANNED` with no GH mirror. That's the same class of gap that let four Android features ship `VERIFIED` with unreachable UI (#2019).

**Not hypothetical:** two separate agents did it in one session today, both self-reported, both explicitly briefed not to. When two well-briefed agents violate the same rule the same way, the gap is in enforcement, not discipline.

## What it does

Blocks in-place writes to git-tracked repo paths — shell redirects (incl. heredocs), `sed -i`/`perl -i`, `tee`, and interpreter writes. Allows what legitimately writes here: scratchpad and `/tmp`, `.claude/cron-logs` appends, build output, and `git`/`gh`/`xcodegen`. Read-only pipelines untouched.

## Design constraints (it runs on every Bash call)

- **8ms hot path** — one `jq` + a pure-bash prefilter; `python3` spawns only when a write construct is present (38ms)
- **Zero git invocations** — static top-level prefix check
- **Fails open** on malformed payloads or missing `jq`/`python3`. A hook that can wedge every Bash call is worse than the gap it closes
- **Heredoc bodies stripped** before scanning, so documenting a forbidden command doesn't self-trip
- **Shell-quote aware** — found the hard way: mid-development the hook blocked its own test driver, because the command embedded `cat > docs/features.md` as a quoted argument. `grep "> docs/features.md"` is routine here and must stay legal

## Verification

42-assertion suite → `ALL PASS`. Plus 8 real command shapes from this session:

| Command | Result |
|---|---|
| heredoc → `docs/features.md` | **BLOCKED** |
| `sed -i` on `docs/bugs.md` | **BLOCKED** |
| scratchpad heredoc | allowed |
| `.claude/cron-logs` append | allowed |
| `git commit -F -` | allowed |
| `grep` quoting the pattern | allowed |
| read-only `awk` pipeline | allowed |
| `gh pr create` | allowed |

## Known limits (deliberate allows, documented in the header)

`bash -c "sed -i … docs/x"` (quoting masks the operator; fixing it re-breaks routine greps), `mv`/`cp` over a tracked path, and targets built from variables. The escape hatch (`VREADER_ALLOW_BASH_EDIT=1`) is a soft bypass by design — a hard one would just get the hook disabled.

Hooks/tests only — no app code, no version bump.