### PR TITLE
feat(#139 WI-1): port the 25 TXT TOC rules to Android (D1/D1b regex fixes)

### DIFF
--- a/.claude/codex-audits/feat-131-bilingual-gate2-round2.md
+++ b/.claude/codex-audits/feat-131-bilingual-gate2-round2.md
@@ -1,0 +1,5151 @@
+Reading additional input from stdin...
+OpenAI Codex v0.144.1
+--------
+workdir: /Users/ll/workspace/vreader
+model: gpt-5.6-sol
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: high
+reasoning summaries: none
+session id: 019f5401-9765-72d1-89db-2c61228e7071
+--------
+user
+You are an independent Gate-2 (round-2) plan auditor for feature #131 (Android bilingual interlinear reading) in this repo. The plan is at dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md (Gate-1 v2 — the round-1 REDESIGN is already resolved; this is a confirmation pass). READ the plan fully.
+
+This is a Kotlin/Android feature (under android/), the parity port of iOS features #56/#100 (interlinear bilingual: each source paragraph followed by an AI translation, cached to disk). The plan's KEY round-1 redesign: EPUB is the PRIMARY target via Readium's EpubNavigatorFragment.evaluateJavascript(script): String? (claimed PUBLIC in the shipped Readium 3.3.0 AAR), gated by a WI-0 throwaway spike that proves JS enumerate/inject/clear/re-apply-on-reflow works; TXT/MD are Compose (BilingualInterlinearBody); AZW3/PDF deferred.
+
+Audit for (rule 47 Gate-2 bar = ZERO open Critical/High/Medium):
+1. MODEL-ASSUMPTION VERIFICATION (the #1 bug class) — do the Android symbols/types/signatures the plan names ACTUALLY EXIST in the live code? Verify against android/ (grep/read): the #106 reader host (android/app/.../reader/ReaderActivity.kt + the Readium EpubNavigatorFragment usage), the #118 AI foundation (android/app/.../ai/), the #128 search/cache + ChapterSegmenter analog, Room DB for a translation cache, and whether EpubNavigatorFragment.evaluateJavascript is actually PUBLIC in the Readium 3.3.0 dependency (the plan says it verified via javap — sanity-check the claim's plausibility + where the AAR is). Flag any named file/type/method that does NOT exist or has a different signature.
+2. The WI-0 EPUB JS-injection SPIKE — is its go/no-go contract concrete enough? Does it de-risk the real unknowns (fragment recreation wiping injected nodes, pagination shift, enumerate-vs-segmenter count divergence — iOS #268/#330/#344)? Is the fallback (EPUB drops to a tracked follow-up, box D ships TXT/MD-only) clean?
+3. CONCURRENCY/LIFECYCLE hazards — the JS enumerate→prefetch(AI)→inject loop over a navigator the app does not own; re-apply on href-change/reflow; clear on teardown; coroutine scoping; the translation cache write/cancel.
+4. COHESION — is the ~10-WI split (WI-0 spike, WI-1..4 foundational JVM-testable, WI-5..9 behavioral, WI-7a/7b EPUB split) right? Any WI too big/small? Is the box-F entry-wiring dependency (WI-9 waits on #132/#134, both now VERIFIED) correct?
+5. Cross-platform parity — does it faithfully mirror iOS #56/#100 (segment-through-the-SAME-ChapterSegmenter on translate+render so 1:1 pairing holds; granularity in the cache key; source-always-kept offline fallback)?
+
+Output: a findings list grouped by severity (Critical/High/Medium/Low), each with the exact plan section + the concrete fix. End with an explicit VERDICT line: 'GATE-2 ROUND-2 VERDICT: CLEAN' (zero C/H/M) or 'GATE-2 ROUND-2 VERDICT: FINDINGS (N Critical, M High, K Medium)'. Do NOT edit any file — audit only.
+codex
+I’ll perform a read-only confirmation audit. I’ll first inspect repository state and the full plan/architecture, then verify every named Android symbol and the Readium artifact/signature against the local checkout and caches.
+exec
+/bin/zsh -lc "git status -sb && wc -l docs/architecture.md dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md && sed -n '1,240p' docs/architecture.md && sed -n '1,260p' dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md" in /Users/ll/workspace/vreader
+ succeeded in 949ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-HnyTtuhr' (errno=Operation not permitted)
+## main...origin/main
+?? .claude/codex-audits/feat-131-bilingual-gate2-round2.md
+?? android/2026-06-29-223908-this-session-is-being-continued-from-a-previous-c.txt
+?? dev-docs/security/
+     726 docs/architecture.md
+     217 dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md
+     943 total
+# VReader Architecture
+
+## Overview
+
+VReader is an iOS e-book reader built with SwiftUI + SwiftData. It supports TXT, EPUB, AZW3/MOBI, PDF, and Markdown formats, each rendered by a format-specific native host (UIKit/WebView bridges) selected internally by `ReaderEngine` (feature #54). AZW3/MOBI is rendered via Foliate-js inside a WKWebView. **Feature #42 Phase 2 (`kindleConvertOnImport`, default ON since the G2 flip 2026-06-02):** NEW AZW3/MOBI/KF8/PRC imports are converted to a first-class EPUB at import time (via the vendored libmobi MOBI→EPUB converter) and render via the default Readium EPUB engine; already-imported native `.azw3` books are unchanged and keep rendering via Foliate, and a user can revert via the persisted `kindleConvertOnImport` override OFF. The `UnifiedTextRenderer` (TextKit 2 reflow) stack is retained in the codebase but no longer wired into the reader dispatch.
+
+## System Diagram
+
+```
+┌──────────────────────────────────────────────────────┐
+│                    VReaderApp                         │
+│  SwiftData SchemaV10 · PersistenceActor · BookImporter│
+└─────────────────────┬────────────────────────────────┘
+                      │
+          ┌───────────┴───────────┐
+          │                       │
+    ┌─────▼──────────┐    ┌──────▼──────────────────┐
+    │  LibraryView    │    │  ReaderContainerView     │
+    │  LibraryViewModel│   │  (format dispatcher)     │
+    │  PreferenceStore │   │  ReaderTopChrome (overlay)│
+    └─────────────────┘   └──────┬───────────────────┘
+                                 │
+        ┌────────┬───────────┬───┴────┬─────────┐
+        │        │           │        │         │
+    ┌───▼──┐ ┌──▼───┐  ┌───▼──┐ ┌──▼───┐ ┌────▼─────┐
+    │ TXT  │ │ EPUB │  │ PDF  │ │  MD  │ │  AZW3 /  │
+    │Bridge│ │Bridge│  │Bridge│ │Bridge│ │  MOBI    │
+    └──────┘ └──────┘  └──────┘ └──────┘ └──────────┘
+    UITextView WKWebView PDFKit  UITextView WKWebView
+                                            (Foliate-js)
+```
+
+## Layers
+
+### 1. App Layer (`vreader/App/`)
+
+- `VReaderApp.swift` — SwiftData `ModelContainer` init (SchemaV10), migration plan (V1→…→V9→V10, all lightweight; V9→V10 adds the additive `Book.sourceCanonicalKey: String?` for feature #108's converted-Kindle cross-platform identity). Also runs the feature #109 one-shot `LocatorKeyBackfillMigration` synchronously at launch (flag-gated; recomputes derived locator keys under NFC canonicalization + repairs non-finite locators — a launch backfill, NOT a migration stage, since the transform changes no entity shape). Plus test seeding, error handling. Injects the live `PersistenceActor` into the SwiftUI environment via `\.persistenceActor` so settings sub-screens can construct backup providers without rewriting every parent's signature. Adopts `@UIApplicationDelegateAdaptor(VReaderAppDelegate.self)` for background-URLSession completion-handler delivery (feature #47).
+- `VReaderAppDelegate.swift` — `UIApplicationDelegate` adapter that captures `application(_:handleEventsForBackgroundURLSession:completionHandler:)` into a MainActor-isolated static dictionary keyed by URLSession identifier. The lazy-download coordinator retrieves and invokes the handler from `LazyDownloadDelegate.urlSessionDidFinishEvents` so iOS releases the app's background-launch grace period.
+
+### 2. Library Layer (`vreader/Views/LibraryView.swift`, `vreader/ViewModels/LibraryViewModel.swift`)
+
+- Grid/list view with sort (persisted via `PreferenceStore`)
+- Context menu: Info, Share, Set Cover, Add to Collection, Delete
+- Collections sidebar, OPDS catalog, AI chat entry points
+- Cover art (`BookCoverArtView`) renders a custom image when one exists, otherwise a generative typographic cover (Feature #60 WI-10 — `GenerativeCoverView`). The cover's style family + colour palette are deterministically derived from the book's `fingerprintKey` (FNV-1a hash → one of 5 style families × 12 design palettes in `GenerativeCoverStyle.swift`), so a given book always shows the same generated cover.
+
+### 3. Reader Layer (`vreader/Views/Reader/`)
+
+#### Dispatcher
+
+`ReaderContainerView.swift` routes to format-specific readers via
+`engineReaderView(fingerprint:)`, which switches on
+`ReaderEngine.resolve(format: fingerprint.format)` — an internal per-format
+engine selector (feature #54). Bug #246 / GH #1072 hardened the dispatch
+to route off `fingerprint.format` (the typed `BookFormat` already parsed
+from the canonical `book.fingerprintKey` by the body's
+`DocumentFingerprint(canonicalKey:)` guard) instead of `book.format` (a
+parallel String `@Model` column set once at `Book.init` and never re-synced).
+Routing off the structural primary key makes the dispatch drift-proof against
+any future writer that updates one without the other (SwiftData migration,
+direct context write, restore-path edit, CloudKit sync). The dispatch no
+longer consults a reading-mode preference, and the reader-settings Reading
+Mode picker UI is gone. The `readerReadingMode` UserDefaults key and the
+`ReadingMode` enum have been removed; `ReadingModeMigration` (run
+synchronously at launch from `VReaderApp`) clears the retired key from
+UserDefaults and strips the `readingMode` field from per-book override
+JSON files.
+
+- `.textNative` → `TXTReaderHost`, `.markdownNative` → `MDReaderHost`,
+  `.epubWKWebView` → `EPUBReaderHost`, `.pdfKit` → `PDFReaderHost`,
+  `.foliateWeb` → `FoliateBilingualContainerView` (AZW3/MOBI; the
+  bilingual wrapper from feature #56 WI-11 sits between the dispatcher
+  and `FoliateSpikeView`, adding the bilingual VM / orchestrator / setup-
+  sheet wiring without modifying the spike itself).
+- `resolve(format:)` maps `.epub` to `.epubWKWebView` unconditionally (it
+  stays the pure format→default-engine map). Feature #42 routes EPUB to the
+  Readium Swift Toolkit engine (`ReadiumEPUBHost`) via
+  `FeatureFlags.readiumEPUBEngine`, which is **default ON since the WI-14
+  human-gated G2 flip (2026-06-01)** — Readium is now the default reflowable EPUB
+  engine; a persisted user/debug override OFF reverts to the legacy
+  `EPUBReaderHost`. The flag read lives in the dispatcher
+  (`ReaderContainerView.engineReaderView` → `ReaderEngine.routeEPUB`), not in
+  `resolve`, so a flag-unaware caller still gets the legacy `EPUBReaderHost`. The
+  `.epubReadium` engine case exists for switch totality; `resolve` never returns
+  it. **Feature #85 (approach C) makes the routing layout-aware**:
+  `routeEPUB(readiumFlagEnabled:layout:)` sends EPUB **scroll** mode to the
+  legacy `EPUBReaderHost` (which activates the seamless feature-#71
+  continuous-scroll stitch) even when the Readium flag is ON — Readium's
+  per-resource paginator has an inherent chapter-boundary seam in scroll mode —
+  while **paged** mode keeps Readium. Because the SAME book is then rendered by
+  two engines depending on mode, a reading-mode toggle SWAPS hosts; an in-memory
+  `ReaderPositionHandoff` (a `@MainActor` per-book cache both hosts write
+  synchronously on every location change + read on open before persistence)
+  carries the position across the swap without loss, and a Readium open with no
+  `.readium` envelope (a scroll session cleared it) restores the legacy locator
+  post-open via `publication.readingOrder` + a one-shot `navCommander.navigate`.
+  `EPUBScrollAnchorResolver` tolerates the container- vs OPF-relative href forms
+  the two engines persist.
+
+#### Chrome
+
+Reader chrome (Feature #60 WI-6b — visual-identity-v2) is two custom overlays, floating on top of content with no safe-area impact:
+
+- `ReaderTopChrome.swift` — top bar: `← Library | Title | Search Bookmark More`. Composed once in `ReaderContainerView`, format-agnostic. The `⋯` More button toggles `ReaderMorePopover`.
+- `ReaderBottomChrome.swift` — bottom bar: progress scrubber + position labels + a Contents/Notes/Display/AI toolbar. Composed per format inside each container, each passing its own seek closure; the toolbar posts `.readerOpen*` notifications that `ReaderContainerView` observes. The four native containers (TXT/MD/EPUB/PDF) mount it in their `bottomOverlay`; Bug #260 added the Foliate (AZW3/MOBI) mount via `FoliateBilingualContainerView+BottomChrome.swift` — scrubber fed by the relocate `fraction`, seek via `.foliateRequestSeekFraction` → `readerAPI.goToFraction`, position labels via pure `FoliateBottomChromeLabels`. (Each container owns its own `isChromeVisible`; chrome visibility is not yet hoisted to the shared level — see Bug #262 for the cross-format desync follow-up.)
+- `ReaderMorePopover.swift` — anchored More-menu popover (Feature #60 WI-6c), composed in `ReaderContainerView`'s chrome overlay. Five rows (Read aloud / Auto-turn | Book details / Share / Export); each posts a `.readerMore*` notification that `ReaderContainerView` observes. The design's sixth row (Bilingual) is deferred — GH #790.
+
+Slot/button identity lives in `ReaderChromeButton.swift` (`ReaderTopChromeSlot` / `ReaderBottomChromeButton`); More-menu row identity lives in `ReaderMoreMenuRow.swift`.
+
+#### Sheets (Feature #60 WI-10 — visual-identity-v2)
+
+The app sheets share `ReaderSheetChrome.swift` — a reusable wrapper matching the design's `Sheet` component: a theme-tinted surface (`ReaderThemeV2.sheetSurfaceColor`), an optional centred Source Serif 4 title bar with 50pt leading/trailing slots (a default circular close button fills the trailing slot when an `onClose` is given and no custom trailing view is), and a scrollable body. The slide-up animation + drag grabber come from SwiftUI's own `.sheet` + `.presentationDragIndicator(.visible)`; `ReaderSheetChrome` supplies only the title bar + surface tint. It wraps the Display sheet (`ReaderSettingsPanel`), the two annotations sheets (`TOCSheet` + `HighlightsSheet`, feature #62 — see below), the reader Book Details sheet (`BookDetailsSheet`, feature #61 — opened from More → Book details, with a trailing Share button in place of the default close), and the AI sheet (`AIReaderPanel`, `title: nil` + a custom sparkle header). `SettingsView` (App Settings) keeps an inner `NavigationStack` for its `NavigationLink` push destinations, with `ReaderSheetChrome` above it. The per-sheet section contract is pinned in `SheetSectionContract.swift` (`ReaderSheetKind`). Reader sheets pass the book's `ReaderThemeV2`; the App Settings sheet uses `.paper` (the Library is not theme-switchable).
+
+**Annotations sheets (feature #62 — annotations-panel split).** The pre-#62 unified 4-tab `AnnotationsPanelView` (Contents / Bookmarks / Highlights / Notes) is split into two job-focused sheets, each with one honest title: `TOCSheet` (book-titled — Contents + Bookmarks navigation tabs) and `HighlightsSheet` (titled "Annotations" — All / Highlights / Notes / Bookmarks review filters + a Share/export button). `ReaderContainerView` presents them via a single `.sheet(item: $annotationsRoute)` over the `AnnotationsSheetRoute` enum (`.toc(initialTab:)` / `.highlights(initialFilter:)`) — the Contents bottom-chrome button and the Notes button each map to one route; the two sheets are mutually exclusive by that optional. `HighlightsSheet`'s unified card stream interleaves highlight + standalone-note cards via `AnnotationStreamBuilder`. Both sheets' designed empty states use the shared `AnnotationsEmptyStateView` (custom SVG art). The legacy `HighlightListView` / `AnnotationListView` / `TOCListView` / `BookmarkListView` list views were removed by feature #62. Each card carries a per-row **delete affordance** (Bug #249 — a trailing `⋯` `NotesActionMenu` of Edit · Copy · Delete + an inline `NotesDeleteConfirm` strip mirroring the in-reader `HighlightPopoverDeleteConfirm`, plus a left-swipe `NotesSwipeActions` drawer); the per-row interaction phase is held on the sheet by the SHEET-owned pure `NotesRowState` (at most one row non-default at a time), and Delete routes through `HighlightListViewModel.removeHighlight` / `AnnotationListViewModel.removeAnnotation`. The container stays `LazyVStack` (not a `List`), so the swipe is a custom `DragGesture` translate rather than `.swipeActions` (which requires a `List` host).
+
+`ReaderContainerView` drives `preferredColorScheme(_:)` from `ReaderThemeV2.preferredColorScheme` (`ReaderThemeV2+ColorScheme.swift`) so the status bar tints to match the theme — `.dark` for the Dark / OLED / Photo families, `.light` for Paper / Sepia.
+
+#### Format Hosts (`ReaderFormatHosts.swift`)
+
+Each host owns its ViewModel lifecycle via `@State`:
+
+- `TXTReaderHost` → `TXTReaderContainerView` → `TXTTextViewBridge` (small single-chapter / Paged) or `TXTChunkedReaderBridge` (>500K UTF-16, **and** chaptered TXT in Scroll layout — bug #180). Chaptered TXT in Scroll layout renders as one continuous `UITableView` surface fed the whole book: `TXTContinuousChunkBuilder` splits the decoded book into document-global-offset chunks, `TXTChapterOffsetIndex` layers chapter awareness so `currentChapterIdx` is *derived* from scroll offset (no per-chapter render unit, no chapter-swap).
+- `EPUBReaderHost` → `EPUBReaderContainerView` → `EPUBWebViewBridge` (WKWebView + JS injection). **Paged** EPUB loads one spine item per `loadFileURL`. **Continuous scroll** (feature #71, the DEFAULT for EPUB scroll layout since the terminal-WI flag flip on 2026-05-28 — `FeatureFlags.epubContinuousScroll` defaults ON; a persisted user/debug override can still disable it) instead loads a single bootstrap document and stitches a lazy ±1-chapter window into it: `EPUBContinuousScrollCoordinator` owns an `EPUBSpineWindow` `[lo…hi]` anchored on the reading chapter and, on the section-aware scroll observer's boundary signals, materializes the adjacent chapter (`EPUBContinuousChapterProvider` → `EPUBChapterBodyRewriter` → `EPUBContinuousScrollJS.append/prependChapterSectionJS`) and evicts the far side (`maxSpan`) to bound memory. Per-section highlight restore hangs off a `sectionMaterialized` lifecycle message (appended sections never fire `didFinish`); saved-position restore + TOC/bookmark/search navigation drive the coordinator (`navigate(toSpineIndex:fraction:)` — scroll within the window, or rebuild around an out-of-window target). The evaluator reaches the live `WKWebView` through a late-binding `EPUBWebViewEvaluatorHandle` the bridge binds in `makeUIView`.
+- `ReadiumEPUBHost` (feature #42 Phase 1, WI-5) → `ReadiumNavigatorRepresentable` → Readium Swift Toolkit `EPUBNavigatorViewController`. Selected by the dispatcher in place of `EPUBReaderHost` when `FeatureFlags.readiumEPUBEngine` is ON (**default ON since the WI-14 G2 flip 2026-06-01**; a persisted override OFF reverts to the legacy `EPUBReaderHost`). Opens the publication off-main via `ReadiumEPUBReaderViewModel` (`AssetRetriever` → `PublicationOpener`), then mounts the navigator; `EPUBPreferences(scroll:)` is mapped from `ReaderSettingsStore.epubLayout`. The `ReadiumReaderCoordinator` is the `EPUBNavigatorDelegate` + (DEBUG) `ReadiumNavigatorEvaluating` seam — it registers the active navigator with `DebugReaderRegistry.setActiveReadiumNavigator` and `markReaderSettled` on `locationDidChange`, and tears that registration down on `dismantleUIViewController` via `detach()` → `clearActiveReadiumNavigator` (the host registers no `DebugReaderProbe`, so it owns its own registry teardown). Reading-position save/restore landed in WI-6: the coordinator forwards `locationDidChange` to the VM's debounced save, which maps the Readium `Locator` → a `VReaderLocator` envelope (engine `.readium`, authoritative `readiumLocatorJSON` + a lossy legacy `Locator` leg) and dual-writes it through `PersistenceActor`'s `VReaderLocatorPersisting` conformance — `saveVReaderLocator` writes both the envelope blob into the SchemaV8 `ReadingPosition.vreaderLocatorData` column AND the legacy `locator`; legacy `savePosition` clears the envelope so a flag-OFF write can't be shadowed by a stale Readium position. On open, the host loads the saved envelope (`restoredReadiumLocator()`) before the navigator mounts and passes it as `initialLocation`. Theme/font landed in WI-7: the host body reads `ReaderSettingsStore.theme` + `.typography` + `.epubLayout` (tracked `@Observable` deps) and recomputes a full `EPUBPreferences` on any Display-settings change, which `updateUIViewController` re-submits live (`submitPreferences`). `ReadiumEPUBReaderViewModel+Mapping` translates the 5 `ReaderThemeV2` themes → Readium's 3 base `Theme`s + explicit `backgroundColor`/`textColor` (which win via `effectiveBackgroundColor`); font size from the per-format-calibrated `.epub` size (`FontSizeCalibrator`) → Readium's multiplier; `lineHeight` from `lineSpacing`; `fontFamily` (system→sansSerif, serif/sourceSerif4→serif, monospace→monospace, inter→sansSerif — custom-font registration deferred); `publisherStyles=false`. The WI-7 photo/custom-background refinement composites the decorative image behind the navigator: `ReadiumEPUBHost+Background.swift` layers the existing `ThemeBackgroundView` under the navigator in a `ZStack` (only when `useCustomBackground` + an image exists for the theme), and `ReadiumReaderCoordinator+Transparency` makes the navigator render through — `epubPreferences(..., transparentBackground:)` emits `backgroundColor: nil` (so ReadiumCSS injects no body bg rule), the representable forces `navigator.view`/spine `WKWebView`s `.clear`/`isOpaque=false`, and a read-only self-gating user script clears the opaque `html:root` ReadiumCSS paints (transparency state is authored into `localStorage` by Swift on each `locationDidChange`/toggle). Normal opaque themes are unchanged. Highlights landed in WI-8: `ReadiumDecorationHighlightAdapter` (a `HighlightRenderer`, the Readium counterpart of `EPUBHighlightRenderer`) renders stored highlights as Readium **Decorations** via `EPUBNavigatorViewController.apply(decorations:in:"highlights")` (declarative — the adapter holds the active set and re-submits the whole group on each apply/remove/restore). Re-anchoring is **text-quote** based (WI-8a migration spike): each `HighlightRecord` → `Decoration(locator: Locator(href:, text: .Text(highlight: selectedText, before/after: context)), style: .highlight(tint:))` — Readium re-finds the quote, so the legacy XPath `serializedRange` is never consulted or mutated (flag-OFF returns to legacy XPath rendering losslessly). The host owns the adapter + a `HighlightCoordinator(renderer: adapter)`, calls `restoreAll()` on open, and observes `.readerHighlightRemoved`/`.readerHighlightsDidImport`. The WI-8 new-highlight refinement adds CREATE from a live Readium selection: `ReadiumReaderCoordinator` conforms to `SelectableNavigatorDelegate` and `navigator(_:shouldShowMenuForSelection:)` forwards the finalized `Selection` to the host then returns `false` (suppressing Readium's native menu so the designed `SelectionPopoverView` is the sole selection surface — rule 51). `ReadiumEPUBHost+Highlights` stashes the `Selection` in a generic `ReadiumSelectionTokenCache<Selection>` under a token, presents the popover; on a color tap (`.readerHighlightRequested`) it resolves the token and `ReadiumSelectionHighlightBuilder` maps the `Selection`'s text-quote (highlight/before/after) + container-relative href → `HighlightRecord` inputs → `HighlightCoordinator.create` → the same `ReadiumDecorationHighlightAdapter` renders it immediately; `navCommander.clearSelection()` dismisses the selection. Navigation landed in WI-9a: the host observes the shared reader nav bus — `.readerNextPage`/`.readerPreviousPage` → the coordinator's `goForward`/`goBackward`, and `.readerNavigateToLocator` (TOC/bookmark/search-result tap, object = a vreader `Locator`) → `go(to:)` after mapping the vreader Locator → Readium Locator (`readiumLocator(fromVReader:spineHrefs:)`, reusing the WI-8 legacy→spine href resolution). Host→coordinator dispatch goes through a host-owned `ReadiumNavCommander` (`@State`, bound on `attach`/cleared on `detach`, mirrors the WI-8 adapter ownership). WI-9a also split the host into `ReadiumEPUBHost.swift` (View) + `ReadiumNavigatorRepresentable.swift` + `ReadiumReaderCoordinator.swift`. Footnotes (#138, WI-9b) remain. Search result-list extraction still uses the existing FTS/`SearchViewModel` stack — WI-9a maps only result *navigation*. **Bilingual landed in WI-11 (paged) and WI-12 (scroll parity): interlinear bilingual works under the flag by driving the enumerate→prefetch→inject loop through Readium's one-way `evaluateJavaScript(_:) async -> Result<Any,Error>` channel — NOT a script-message handler (the navigator owns its content controller, exposing no app-side message channel; this is why the WI-11a `ReadiumBilingualEvalAdapter` RETURNS the `[{bid,text}]` array rather than posting it). A host-owned `ReadiumBilingualCommander` (`@State`, the bilingual counterpart of `ReadiumNavCommander`) holds an evaluator closure the coordinator binds on `attach` (the production non-DEBUG `ReadiumReaderCoordinator.evaluateForBilingual`, returning Readium's raw `Result<Any,Error>?`) and clears on `detach`; `enumerate()` runs `ReadiumBilingualEvalAdapter.enumerateJS()` and parses the return value via `EPUBBilingualPipeline.parseEnumerateMessage`, `inject(_:)`/`clear()` run the engine-agnostic inject/clear builders. The host reuses the feature-#56 `EPUBBilingualOrchestrator` (paged `-1` bucket via `updateBlocks(_:)`) + `BilingualReadingViewModel` + the designed `BilingualSetupSheet` (rule 51 — no new UI). Source text comes from vreader's own `EPUBParser` (opened alongside the Readium open — Readium does not expose raw spine HTML), so the `EPUBChapterTextProvider` is keyed on OPF-relative spine hrefs; the Readium-produced vreader `Locator` carries Readium's CONTAINER-relative href, so `ReadiumBilingualCommander.normalizedLocator(_:toSpineHrefs:)` rewrites it onto the OPF spine via the shared `ReadiumDecorationHighlightAdapter.resolveHref` tolerance before `vm.handlePositionChange(...)` (the WI-8 href-consistency finding class — without it `unit(containing:)` returns nil and nothing translates). Chapter-change detection composes onto the existing `onLocationChange` (WI-6 position save still runs): a fresh enumerate runs only when the spine href changes, deduped intra-chapter by a reference-type `ReadiumBilingualChapterTracker`. WI-12 lifted the WI-11 paged-only gate (`isBilingualSupported` is true for both layouts) so bilingual works in scroll too — but PER-SPINE only: Readium scroll mode is per-resource (it emits `locationDidChange` at spine boundaries, driving the same per-spine enumerate the paged path uses), and Readium has no multi-spine-stitch API, so off-screen chapters enumerate when scrolled into view rather than eagerly. This is a documented behavior delta vs legacy #71 — the flag-OFF `EPUBWebViewBridge` engine keeps its full stitched cross-chapter continuous bilingual; the Readium engine does not reproduce it. A paged↔scroll layout change re-renders the spine (discarding the `data-vreader-bid` stamps + decorations), so the layout-change handler re-enumerates the current spine in both directions.** TTS (WI-10): read-aloud already works under the Readium engine with NO Readium-specific code — `ReaderContainerView.startTTS()` → `ReaderAICoordinator.loadBookTextContent(format: "epub")` extracts spine text from the **file** via `EPUBParser` (renderer-agnostic, independent of which engine renders), then feeds the shared `TTSService` pipeline. Device-verified under `readiumEPUBEngine` ON (speaking, `ttsOffsetUTF16` advancing 42→115, stop→idle). The speaking-position **follow** landed in WI-10b: as TTS speaks, the navigator auto-advances so the spoken text stays on screen. `ReadiumEPUBHost` observes the shared `TTSService.currentOffsetUTF16` (threaded in like `EPUBReaderHost`); a pure value-type `ReadiumTTSFollowMapper` maps the flat UTF-16 offset → (spine href, intra-spine fraction). CRITICAL alignment: the per-spine offset table is built from the SAME spine text the TTS engine reads — `EPUBTextExtractor.stripHTML` + trim, skip empties, join `"\n\n"` (the `ReaderAICoordinator.loadBookTextContent` recipe) — extracted off-main from the host's already-open `bilingualParser` (so the index matches the engine's offsets; the block-preserving bilingual stripper is deliberately NOT used here). `ReadiumEPUBHost+TTSFollow` throttles: it navigates on any spine-href change or an intra-spine fraction drift > 0.08 (so the navigator tracks ~chapter-eighth granularity, not every `willSpeakRange` word), maps the target → a vreader `Locator` → Readium `Locator` via the WI-9a `readiumLocator(fromVReader:spineHrefs:)` resolution, and drives the existing `navCommander.navigate(to:)` → `navigator.go(to:)`. Follow runs only while TTS state == `.speaking`; the cursor resets on each play start and on pause/stop. This unblocks the WI-14 default-ON flip.
+- `PDFReaderHost` → `PDFReaderContainerView` → `PDFViewBridge` (PDFKit)
+- `MDReaderHost` → `MDReaderContainerView` → reuses `TXTTextViewBridge` with NSAttributedString
+- AZW3/MOBI is dispatched directly to `FoliateSpikeView` (the AZW3 spike landed before the host abstraction; convergence is deferred). `FoliateReaderHost` / `FoliateReaderContainerView` exist but are not currently wired into `ReaderContainerView`. **Feature #73 added a windowed multi-section continuous-scroll surface inside the vendored Foliate-js `paginator.js`** (default ON for horizontal-writing scroll mode, gated behind the renderer's `#windowedScroll`). Instead of the per-section view-swap — whose `scrollToAnchor(0)` offset reset + blank-flash on `#createView` destroy/async-load + post-swap reflow were the three stacked discontinuities of the Bug #283 chapter-boundary jump — a K=3 window of adjacent sections is mounted into the single scrolling `#container` and recycled on scroll: `#ensureWindow` mounts neighbours (firing the same `load`/`create-overlayer` lifecycle so each neighbour doc is wired for selection/overlays), `#evictOutsideWindow` unmounts + unloads the far side with `scrollTop` compensation, `#promoteCurrentView` tracks the current section by scroll position (a pointer swap, no DOM move), and `#windowedResolve` emits the intra-section relocate fraction (`progress.js`/`SectionProgress` still owns whole-book conversion, preserving Bug #265 position restore). A `#windowGeneration` token aborts stale async mounts across navigation. Vertical writing + paged mode keep the single-`#view` swap path. The pure windowing math (window clamp, offset↔section mapping, intra-section fraction, evict adjustment, anchor translation) is mirrored + unit-tested in `FoliateScrolledWindowMath.swift`; flag-on behavior was device-verified and the JS diff passed a 2-round independent Codex audit.
+
+#### Foliate-js Bridge (`vreader/Views/Reader/`, `vreader/Services/Foliate/`)
+
+`FoliateViewBridge` (UIViewRepresentable) hosts a WKWebView and uses `loadHTMLString` with the IIFE-bundled `foliate-bundle.js` inlined; books are handed to JS as base64 (no scheme handler in the live load path — `FoliateURLSchemeHandler` exists in the codebase but isn't wired into the active bridge today). `FoliateViewCoordinator` (WKScriptMessageHandler + WKNavigationDelegate) receives JS messages, parses via `FoliateMessageParser`, and routes to typed callbacks. `FoliateHighlightRenderer` generates JS strings for SVG overlay annotations — but it is **not** plugged in as a `HighlightRenderer` adapter today; AZW3 highlight create has a TODO for persistence/JS injection and overlay restore is a no-op placeholder (`FoliateReaderContainerView+Highlights.swift`). `FoliateJSEscaper` provides shared sanitization for all JS/CSS string interpolation across the bridge. `FoliateReaderViewModel` maps bridge events to `Locator` for position persistence.
+
+The Foliate JS bundle is built from sources under `vreader/Services/Foliate/JS/` via `build-bundle.sh`, which calls a locally-pinned esbuild (`package.json` + `package-lock.json`, currently `esbuild@0.28.0`; bootstrapped via `npm ci` — node ≥18). `paginator.js` is the source of truth; `foliate-bundle.js` is checked in and must be rebuilt whenever the source changes (a parity check in `FoliatePaginatorScrollBoundaryTests` enforces this for the scroll-mode boundary-detect helper that resolved Bug #235).
+
+#### Unified Engine (retained, not dispatched)
+
+`ReaderUnifiedCoordinator` loads text + applies transforms (replacement rules, simp/trad); `UnifiedTextRenderer` displays with TextKit 2 pagination or scroll. Feature #54 removed the unified path from the reader dispatch and the reader-settings Reading Mode picker, so this stack is **no longer reachable from reader dispatch** — it is retained (a follow-up may consume it for bilingual reading, or delete it once provably orphaned). Content replacement rules and Chinese conversion that previously required Unified mode now run in the native readers directly: `MDFileLoader.load` composes `ReplacementTransform` + `SimpTradTransform` over the decoded source text before parsing (feature #54 WI-7); **native EPUB applies replacement rules via `EPUBReplacementJS` (feature #54 Phase D-1)** — a CFI-safe per-text-node JS injection that runs on both EPUB engines (Readium per-spine via `ReadiumReaderCoordinator+Replacement`; the legacy #71 WKWebView stitch on `didFinish` via `EPUBWebViewBridgeCoordinator`, plus a scroll-root `MutationObserver` for appended chapters), keyed by `MDReplacementRuleFetcher`; native TXT has Chinese conversion only — TXT replacement rules are deferred (they need a source↔display offset map). Replacement rules apply at chapter/document open; a mid-read rules edit takes effect on next open (v1 scope).
+
+### 4. Coordinator Layer (`vreader/Views/Reader/`)
+
+Cross-format coordinators that compose with multiple readers:
+
+| Coordinator                | Responsibility                                                      | Setup Timing                                                          |
+| -------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `ReaderAICoordinator`      | AI ViewModels, text loading, context extraction                     | On AI/TTS invoke                                                      |
+| `ReaderSearchCoordinator`  | Search service, indexing, FTS5                                      | Service+VM eagerly via `prepareEagerly()` on reader open (bug #79; cold SQLite open is `nonisolated`, off-MainActor); indexing still deferred to `setup()` on first sheet open |
+| `ReaderUnifiedCoordinator` | Unified renderer state, text transforms — retained but no longer dispatched (feature #54) | n/a (no dispatch path)                                     |
+| `HighlightCoordinator`     | Persists via `HighlightPersisting`, dispatches to `HighlightRenderer` adapters | On reader open per format (TXT/MD/PDF/EPUB)                          |
+
+Bridge-internal coordinators (`EPUBWebViewBridgeCoordinator`, `FoliateViewCoordinator`, `TXTTextViewBridgeCoordinator`) handle delegate / WKScriptMessageHandler plumbing for one bridge each; they're not cross-cutting and aren't enumerated here.
+
+### 5. Services Layer (`vreader/Services/`)
+
+| Service                              | Backing                    | Purpose                                                                   |
+| ------------------------------------ | -------------------------- | ------------------------------------------------------------------------- |
+| `PersistenceActor`                   | SwiftData (actor-isolated) | All DB writes serialized                                                  |
+| `SearchService` + `SearchIndexStore` | SQLite FTS5                | Full-text search with persistent index                                    |
+| `AIService`                          | OpenAI-compatible REST API | Summarize, translate, chat. Feature #56 added a resolved-provider seam — `ResolvedAIProviderConfig` (an immutable `{kind, baseURL, apiKey, model, maxTokens}` snapshot) plus `resolveActiveProviderConfig()` / `resolveProviderConfig(profileID:modelOverride:)` / `sendRequest(_:using:)`. A *multi-request* operation (chapter translation = one request per chunk) resolves the config ONCE and pins the credential + model for every chunk; `sendRequest(_:using:)` deliberately bypasses `AIResponseCache` (its key is not provider-aware). The original `resolveProvider()` / `sendRequest(_:)` / `streamRequest(_:)` are unchanged. **Feature #91 (agentic tool-calling)** added `supportsToolUse` + `sendToolRequest(_:)` on `AIProvider` (Anthropic `tool_use` / OpenAI `tool_calls`; default-off so non-tool providers compile unchanged), and on `AIService`: `resolveToolProvider()` (resolve the config ONCE + report tool-use capability), `sendToolTurn(_:using:)` + `streamRequest(_:using:)` (one turn/stream through the pinned config, RE-checking the live flag + consent each turn so a mid-loop revoke fails closed) |
+| `AgenticChatDriver` + `AIToolRegistry` (`Services/AI/`) | `AIService` + the tool executors | **Feature #91 — agentic AI chat.** `AgenticChatDriver` is the bounded send→tool→result→re-send loop (one pre-resolved provider via `AIServiceToolUseAdapter`, `maxIterations` cap, returns `{finalText, usedTools}`); `AIToolRegistry` dispatches a model `ToolCall` to its `AITool` (unknown tool → `isError` result, never throws). Four read-only executors wrap existing capabilities: `search_current_book` (the open book's FTS), `search_other_books` (the whole library, gated by the pure `LibraryBookSearchGate` over the persistent index), `get_book_content` (a book's text by title, locality/format-gated), and `list_library` (feature #97 — enumerate the bookshelf: title/author/format, over the same `LibrarySearchBackend.libraryBooks()`; dedupe, open-book exclude, total deterministic sort, cap+announce, canonical-format display, restore-placeholder friendliness). `AgenticToolRegistryBuilder.buildLive` assembles them over the production `LibrarySearchBackendAdapter` + `BookContentProviderAdapter` (+ `ClosedBookTextExtractor`) and the shared `PersistentSearchIndex` store. `AIChatViewModel.sendMessage` routes through the driver when `agenticTools` is on + the resolved provider supports tool-use (silent loop, single final answer, citations suppressed on a tool reply); otherwise the existing streaming path. Default OFF |
+| `PersistentSearchIndex` (`Services/Search/`) | `SearchIndexCore` + `SearchIndexStore` | The single Services-layer source of truth for the on-disk FTS index location (`Application Support/SearchIndex/search.sqlite3`) + persistent-store construction (`makeStore()`, in-memory fallback). `ReaderSearchCoordinator` delegates to it; Feature #91's agentic search tools open the SAME persisted index through it |
+| `TTSService`                         | `SpeechSynthesizing` seam | `@MainActor @Observable` read-aloud state machine (idle/speaking/paused + UTF-16 progress offset). Speaks through an injected `SpeechSynthesizing` and wires its `AVSpeechSynthesizerDelegate` callbacks generically via the protocol's `delegateTarget` (feature #72 WI-0), so any backend — on-device, XCUITest mock, or the cloud adapter — drives progress without type-casing. `defaultSynthesizer(configStore:)` picks the backend: XCUITest mock (DEBUG override) > `HTTPSpeechSynthesizer` when a valid `HTTPTTSConfig` is persisted (feature #72 WI-3) > `SystemSpeechSynthesizer` (on-device) |
+| `HTTPSpeechSynthesizer`              | `HTTPTTSProvider` + `HTTPTTSChunkPlayer` | Feature #72 WI-3 cloud-TTS adapter: the `SpeechSynthesizing` impl that finally wires the orphaned `HTTPTTSProvider` (bug #270) into live read-aloud. Per `speak`, chunks the utterance (`HTTPTTSProvider.chunkText`), synthesizes each chunk over HTTP, streams the audio blobs into `HTTPTTSChunkPlayer`, and emulates the `AVSpeechSynthesizerDelegate` callbacks `TTSService` consumes (chunk-range `willSpeakRange`, `didFinish`, `didCancel`). Conforms to the non-isolated protocol via `@unchecked Sendable` + `MainActor.assumeIsolated` wrappers over `@MainActor` impls; `TTSService` (its only caller) is `@MainActor`. Audio session stays owned by `TTSService` |
+| `HTTPTTSChunkPlayer`                 | `AVAudioPlayer` (behind `SpeechAudioPlaying` seam) | Feature #72 WI-2 sequential audio-chunk playback queue for the cloud path. Plays streamed `Data` chunks back-to-back, fires `onChunkStarted(index)` as each begins and `onFinished` once the LAST chunk of a COMPLETE input drains (drain ≠ complete — `markInputComplete()` gates the finish). Generation token ignores late finishes from stopped/replaced players. Does NOT manage `AVAudioSession` |
+| `HTTPTTSConfigStore`                 | `UserDefaults` + `KeychainService` | Feature #72 WI-1 loader: decodes the persisted `HTTPTTSConfig` from UserDefaults and splices the API key from Keychain; `loadValidConfig()` returns the config only when it passes `validate()`. Consumed by `TTSService.defaultSynthesizer` to decide whether the cloud path is active |
+| `BookContentCache`                   | In-memory                  | Text cache for AI context loading (TXT/MD only)                           |
+| `PreferenceStore`                    | UserDefaults               | Sort order, view mode persistence                                         |
+| `ReadingStatsAggregator`             | SwiftData (actor-isolated) | Reading-stats dashboard aggregator (feature #58). Sweeps `ReadingSession` + `Book` rows in one `ModelContext` pass and returns a `ReadingDashboardSnapshot` — per-window totals (today / 7d / 30d / 90d / 180d / 365d / all) + per-book breakdown. Derives every number from session rows, never from `ReadingStats`, so a stale stats cache cannot desync the dashboard. Holds a `@Sendable () -> Calendar` provider so window boundaries follow timezone/DST changes. **WI-6b**: `snapshot(window:sort:now:customRange:)` accepts an optional user-picked `ReadingStatsCustomRange` (calendar-day-inclusive `[start, end]`); when non-nil, the snapshot's `perBook` + `customRangeBreakdown` reflect that range while the seven enum totals stay populated for the pill bar |
+| `CustomCoverStore`                   | JPEG files                 | Custom book cover images                                                  |
+| `WebDAVClient`                       | HTTP                       | Low-level WebDAV transport (PROPFIND/PUT/GET/DELETE/MKCOL/MOVE)           |
+| `WebDAVProvider`                     | `WebDAVClient`             | `BackupProvider` impl — backup/restore/list/delete over a WebDAV server   |
+| `WebDAVProviderFactory`              | `WebDAVServerProfileStore`  | Assembles a `WebDAVProvider` from the active WebDAV profile (feature #52 WI-3 + WI-5). `make(persistence:profileStore:)` is the sole production path — the pre-#52 `make(keychain:)` flat-keychain variants were removed in WI-5 |
+| `WebDAVServerProfileStore`           | `UserDefaults` / `KeychainService` | Actor-isolated list of saved WebDAV server profiles with one active selection (feature #52 WI-1). Profiles + active-id persist as `UserDefaults` JSON; per-profile passwords persist in Keychain. Atomic `loadSnapshot`, `upsert` / `remove` / `setActiveProfileID`, single-hop `updateIfExists`. Mirrors `ProviderProfileStore` (feature #50) for the AI multi-profile precedent |
+| `WebDAVProfileMigrator`              | `KeychainService` / `WebDAVServerProfileStore` | One-shot migrator that lifts pre-#52 flat-keychain credentials (`com.vreader.webdav.{serverURL,username,password}`) into a `"Default"` profile and sets it active. Idempotent on both axes (marker key + non-empty store). Feature #52 WI-2 |
+| `ReadingModeMigration`               | `UserDefaults` / per-book JSON files | One-shot **synchronous** launch migration retiring the Native/Unified reading mode (feature #54). Removes the `readerReadingMode` UserDefaults key and strips the `readingMode` field from per-book override JSON files (edited as raw `JSONSerialization` objects so other keys are semantically preserved). Synchronous-before-setup — the per-book JSON store has no actor, so a detached migration could race a panel save/restore. Idempotent |
+| `BackupDataCollector`                | `PersistenceActor`         | Serializes 8 versioned JSON sections (annotations, positions, settings, library-manifest, …) |
+| `BackupDataRestorer`                 | `PersistenceActor`         | Decodes + dedupes by UUID/profileKey; rejects future schema versions      |
+| `BlobPath`                           | —                          | Pure utility: `(format, sha256, byteCount)` ↔ `VReader/books/<format>/<sha>_<bytes>.<ext>` (feature #46) |
+| `BackupBlobStore` (protocol pair)    | —                          | Transport-neutral read (`BackupBlobReading`) + write (`BackupBlobWriting`) blob API |
+| `WebDAVBlobStore`                    | `WebDAVTransport`          | Adapter that owns the temp+MOVE atomic-publication algorithm (feature #46) |
+| `BookFileMaterializer`               | `BackupBlobReading` + `BookImporting` | Restore-side: download + size/SHA-256 verify + import via `BookImporter`. Preflight-rehashes existing local files to catch corrupt content (feature #46). Refactored in feature #47 WI-4a to delegate verify + import + fingerprint match to `BookFileImportFinalizer`. |
+| `BookFileImportFinalizer`            | `BookImporting`            | Shared verify + import + fingerprint pipeline used by both `BookFileMaterializer` (restore-all path) and the lazy-download coordinator (feature #47 WI-4b). Streaming SHA-256 so very-large blobs don't spike memory. Caller owns temp-file lifetime. |
+| `RemoteBookCatalog`                  | —                          | Pure decoder: extracts `library-manifest.json` from a backup ZIP via `ZIPWriter.extractEntry(named:from:)` and returns `[BackupLibraryEntry]`. Surfaces `manifestMissing` (older backups) / `manifestUndecodable` / `manifestSchemaVersionTooNew` as typed errors. Feature #47 WI-4a. |
+| `SelectiveRestoreCoordinator`        | `BookFileMaterializer` + `PersistenceActor` + `BackupDataRestoring` | 3-phase orchestrator for the picker-driven restore: (1) preplant unselected entries as `.remoteOnly` rows, (2) materialize selected entries via `BookFileMaterializer`, (3) apply metadata sections so positions/annotations reattach to BOTH `.local` and `.remoteOnly` rows by fingerprintKey. Phase-weighted progress 0.10/0.75/0.15. Feature #47 WI-4b. |
+| `LazyDownloadCoordinator`            | `BackgroundDownloadSessioning` + `PersistenceActor` | `@MainActor @Observable`. Receives forwarded events from a non-isolated `LazyDownloadDelegate` and exposes per-fingerprintKey progress + outcome state to library rows. Reattaches in-flight tasks at init via `URLSession.getAllTasks(...)` and reconciles orphaned `.downloading` rows (no live task) to `.failed`. Race-safe sticky `terminalKeys` guard outlives `clearOutcome(for:)`. Feature #47 WI-3. |
+| `LazyDownloadDelegate`               | URLSessionDownloadDelegate | Nonisolated delegate that hops to MainActor via `Task` to forward `didWriteData` / `didFinishDownloadingTo` / `didCompleteWithError` / `urlSessionDidFinishEvents` events to the coordinator. Cancels orphaned tasks (missing/invalid `taskDescription`) and validates SHA/extension shape before staging. Feature #47 WI-3. |
+| `LazyDownloadTaskMeta`               | —                          | `Codable Sendable` payload encoded into `URLSessionDownloadTask.taskDescription` so identity (`fingerprintKey`, `blobPath`, `expectedSHA256`, `expectedByteCount`, `originalExtension`) survives crash + relaunch. `schemaVersion` gate (`1...currentSchemaVersion`) rejects future formats. Feature #47 WI-3. |
+| `BackgroundDownloadSessioning`       | `URLSession.background(...)` (production) / mock (tests) | Test seam for the background URLSession's `getAllTasks` enumeration. Production wrapper (`URLSessionBackgroundSession`) holds the live session; tests synthesize `LazyDownloadTaskDescriptor` values. Feature #47 WI-3b. |
+| `WebDAVNetworkPolicy`                | `NWPathMonitor`            | `@MainActor @Observable` Wi-Fi-only gate. UserDefault `com.vreader.webdav.wifiOnly` (default true) + `currentInterface: .unknown / .none / .cellular / .wifi`. `shouldStart() -> Bool` consulted by the lazy-download enqueue path (#47 WI-4 follow-up) and "Restore all" guards. URLSession's `allowsCellularAccess = false` cancels rather than pauses, so we keep cellular allowed and gate at enqueue. Feature #47 WI-3c. |
+| `FoliateURLSchemeHandler`            | WKURLSchemeHandler         | Scheme-handler implementation (not on the live load path; see Foliate-js Bridge note) |
+| `FoliateMessageParser`               | Pure functions             | Parses raw JS message bodies into typed Swift events                      |
+| `FoliateJSEscaper`                   | Pure functions             | Escapes/sanitizes strings for safe JS/CSS interpolation in Foliate bridge |
+| `ReaderSettingsStore`                | UserDefaults               | Global reader UI prefs: theme, typography, EPUB layout, auto-page-turn, page-turn animation, Chinese conversion, custom background |
+| `PerBookSettingsStore`               | Per-book JSON files        | Per-book overrides on top of `ReaderSettingsStore` (font/theme/spacing) |
+| `FontSizeCalibrator`                 | Pure value type            | Maps the stored unified font-size value to a per-renderer concrete value via `FontSizeCalibrationProfile` multipliers (`txt`/`md`/`epub`/`foliate`), so the same slider number renders at a consistent perceived size across reflow formats. TXT is the `1.0` anchor; result re-clamped to each renderer's legal band (`12...64` text, `8...72` Foliate). PDF is intentionally not a target. Feature #70 |
+| `KeychainService`                    | Keychain                   | Secure credential storage (used by `WebDAVProviderFactory`)               |
+| `BookSourcePipeline`                 | Actor + HTTP / rule engine | Search → BookInfo → TOC → Content scraping for Legado-style web novels    |
+| `SyncService`                        | CloudKit (feature-flagged) | Coordinates sync with `SyncConflictResolver`, tombstones, change tokens   |
+| `DebugBridge`                        | URL handler (DEBUG-only)   | `vreader-debug://` reset/seed/open/settle/snapshot/eval/tts/search/highlight/provider/present/ai/seed-sessions/seek/scroll-sheet/navigate/scroll-boundary/locate?highlight=N; feature #49 added position-aware open + DebugSnapshot schema v2 (TTS state, render phase, settings provenance); feature #74 added `locate?highlight=<N>` to drive `.readerNavigateToLocator` for the active TXT/MD reader CU-free so the locate "bloom" (highlight/note landing) fires on the real render path, plus DebugSnapshot schema v3 (`landingBloomCount` / `landingBloomPeakIntensity`) read back from `HighlightableTextView`'s persisted bloom counters — the ~1.5s sub-second bloom visual can't be screenshot/video-captured on the virtual display, so the snapshot proves it fired; feature #45 WI-4c-b added `tts?action=start\|stop` to bypass XCUITest's audio-session block; bug #238 added `search?query=...[&index=N]` to drive search-result-tap repros (Bug #182 / GH #621) CU-free; bug #237 added `highlight?start=...&end=...[&color=...]` for TXT/MD highlight creation CU-free; bug #243 added `provider?action=add\|remove\|clear` for AI provider configuration without driving Settings → AI through CU (unlocks Feature #56 b/d / Feature #65 / Feature #69 / Bug #93 autonomous AI verification); bug #253 added `present?sheet=...[&tab=...]` + bug #255 added `ai?action=summarize\|chat\|translate` for CU-free reader-sheet + AI-response-card verification; bug #263 added `seed-sessions?book=<key>[&seconds=<n>]` to seed a deterministic `ReadingSession` spread (one per dashboard window band) so the reading-stats dashboard (Feature #58) renders non-zero per-window totals CU-free; bug #267 added `seek?fraction=<0...1>` to drive the active Foliate (AZW3/MOBI) reader to a fractional position CU-free; bug #271 added `scroll-sheet?to=top\|bottom` to scroll the active presented sheet's content (today `TranslationResultCard`) so the accent translation card below the tall ORIGINAL card — beyond even the `detent=large` fold (Bug #256) — becomes screenshot-capturable, unblocking Feature #65 row 11; bug #273 added `navigate?spine=<N>[&fraction=<F>]` to drive `.readerNavigateToLocator` for the active EPUB reader CU-free (the `search` driver doesn't navigate in continuous mode), posting DEBUG-only `.debugBridgeNavigateCommand` → `EPUBReaderContainerView` resolves spine → href → `Locator` → re-posts `.readerNavigateToLocator` — unblocking feature #71 WI-8 continuous-mode navigation verification (paired with the `multi-chapter-epub` 4-tall-chapter fixture for the out-of-window rebuild branch); a follow-up added `scroll-boundary?spine=<N>&near=top\|bottom` to post a DEBUG-only `.debugBridgeScrollBoundaryCommand` → `EPUBReaderContainerView` builds an `EPUBScrollBoundarySignal` and calls `EPUBContinuousScrollCoordinator.handleBoundarySignal` directly — bypassing the rAF-throttled `continuousScrollObserverJS` (unverifiable CU-free on a virtual display) so feature #71's scroll-driven extend/evict RESPONSE can be device-verified. **Host-vs-runner driving constraint (bug #242 / GH #1054)**: bridge URLs MUST be invoked from the host (`xcrun simctl openurl` outside any iOS sandbox) — invoking them from inside an XCUITest binary fails with NSPOSIX 61 because the runner sandbox blocks the CoreSimulatorService XPC endpoint. In-runner verification flows use `XCTSkipUnless(bridgeReachable())` (PR #1053) when they cannot move the bridge-dependent assertion to a host-side driver. See `docs/subsystems/debug-bridge.md` § "Driving the bridge from a verification flow". |
+| `DebugPositionResolver`              | —                          | Pure parser: `?position=<value>` string → typed `DebugPosition` per BookFormat (TXT/MD UTF-16 offset, EPUB CFI, AZW3 Foliate-CFI, PDF page). Every format takes its native seek path (feature #54 retired the Native/Unified mode + its position-unsupported guard). Feature #49 WI-7a. |
+| `DebugReaderRegistry.awaitReader`    | DebugReaderRegistry singleton | Token-based keyed waiter that resumes when a reader matching `fingerprintKey` registers. Concurrent waiters with different timeouts each get their own continuation (UUID-token ownership). Feature #49 WI-7a. |
+| `DebugReaderRegistry.awaitReaderSettled` | DebugReaderRegistry singleton (`+Settle` extension) | Bug #141: render-settled signal keyed by `(fingerprintKey, token)`. Hosts call `markReaderSettled` on real render-complete — EPUB from `webView(_:didFinish:)`, AZW3/MOBI from the Foliate `relocate` message. `ReaderContainerView` wires `probe.settleStrategy` so `vreader-debug://settle` blocks until that signal (or `settleTimeout`) instead of the 100ms placeholder. TXT/MD/PDF keep the placeholder. Same UUID-token waiter machinery + stale-write guard as `awaitReader`. |
+| `ImportJobQueue`                     | Actor                      | Serializes book imports (avoids parallel `BookImporter` writes)           |
+| `FileURLImportRouter`                | `BookImporting` (protocol) | `@MainActor` dispatcher for incoming `file://` URLs from iOS Share Sheet / "Open in vreader" (Feature #59 WI-2). Wired by `VReaderApp`'s production `.onOpenURL`. Returns `false` for non-file URLs (Debug-bridge handler intercepts those upstream). Unsupported extensions reported via injected closure (App layer wires the user-facing alert; current production wiring is a no-op). Supported extensions kick off `bookImporter.importFile(at:source:.shareSheet)` in a fire-and-forget Task. Security-scope handling owned by `BookImporter`, not the router. |
+| `LibraryRefreshService`              | NotificationCenter         | Coalesces library refresh requests across views                           |
+| `FeatureFlags`                       | Static                     | Compile/runtime flag resolution (`SyncService` and others gate on it). Feature #91 added `agenticTools` (default OFF, persisted) — gates the AI chat's agentic tool-calling loop |
+| `DictionaryLookup`                   | UIKit                      | System dictionary + AI-translate hooks for selected text                  |
+| `DiagnosticsLogStore` + `OSLogDiagnosticsSource` + `DiagnosticsRedactor` (`Services/Diagnostics/`) | `OSLogStore` (current-process) | **Feature #96 — in-app runtime diagnostics.** `DiagnosticsLogStore` (`@MainActor @Observable`) reads the current session's `com.vreader.app` `Logger` entries back via the `DiagnosticsLogSource` seam (`OSLogDiagnosticsSource` runs the blocking `OSLogStore` enumeration off-main), holds them bounded, filters by level/category, and produces a `DiagnosticsRedactor`-scrubbed export string. `DiagnosticsRedactor` is a pure, context-driven secret/path scrubber (Authorization, keyed secrets, `sk-`/JWT keys, URL creds, container paths) — the defense-in-depth second line over OSLog's `.private` barrier for anything leaving the app (export file + Copy-entry). WI-2 added the Settings → Support → Diagnostics viewer (`Views/Settings/Diagnostics/`) binding to the store |
+| `ChapterTranslationStore`            | SwiftData (actor-isolated) | Persistent disk cache for feature #56 bilingual reading. Wraps its own `ModelContext` over the `ChapterTranslation` `@Model` (SchemaV7) — a separate actor from `PersistenceActor` so bulk translation writes during a global-translate run never block library reads. App-scoped `.shared` single instance (the `ProviderProfileStore.shared` precedent); idempotent `upsert` fetches by `lookupKey` and updates in place, never relying on the unique constraint to throw. Returns the value-type `ChapterTranslationRecord` DTO, never the `@Model`. Bug #342: lazily migrates pre-#342 5-field keys (profile UUID baked in) to the canonical 4-field key on first access, deduping to the newest row. The cache is derived, re-fetchable data — excluded from WebDAV backup |
+| `ChapterTranslationService`          | `ChapterTranslationStore` + `AIService` | Translates one chapter unit for feature #56 bilingual reading. Pipeline: cache lookup → (on miss) `ChapterSegmenter` → `ChapterTranslationChunker` → one `AIService.sendRequest(_:using:)` per chunk → strict `TranslationChunkContract` JSON-array decode → per-segment fallback on any decode/count/element mismatch → recombine → cache-write. Reaches the AI side through the `TranslationRequestSending` boundary protocol (tests inject a mock). `Task.checkCancellation()` between chunks so a cancelled prefetch stops promptly |
+| `ChapterTextProviding` (`Services/Reader/`) | per-format reader services | Feature #56 WI-2.5 boundary protocol — supplies a book's translation units (`translationUnits()`), per-unit plain source text (`sourceText(for:)`), and the `Locator → unit` resolution (`unit(containing:)` / `unit(after:)`) the bilingual prefetch trigger needs. The translation *unit* is the format's natural rendering segment, not the logical TOC chapter (plan Decision 2.7). Four concrete `Sendable` `struct` adapters: `EPUBChapterTextProvider` (spine documents, HTML-stripped via `EPUBTextExtractor`), `TXTChapterTextProvider` (`TXTChapterIndex` chapters, UTF-16 slicing), `MDChapterTextProvider` (`MDHeading`-bounded chapters), `PDFChapterTextProvider` (page ranges via PDFKit). The AZW3/MOBI `FoliateChapterTextProvider` (an `actor`, bridges the `@MainActor` Foliate coordinator via the `FoliateSectionExtracting` facade) lands in WI-11. `ChapterTranslationService` / `BookTranslationCoordinator` consume this boundary, never a format-specific extractor |
+| `FoliateChapterTextProvider` (`Services/Reader/`) | `FoliateSectionExtracting` | Feature #56 WI-11 — AZW3/MOBI `ChapterTextProviding` adapter. The odd one out: an `actor` (not a `struct`) because the live Foliate seam (`FoliateSpikeView.Coordinator` + `WKWebView`) is `@MainActor`. Stores an `any FoliateSectionExtracting` and reaches it via `await`; an `actor` is `Sendable` by construction so it satisfies `ChapterTextProviding: Sendable` without `nonisolated(unsafe)`. Caches the ordered section-id list on the first `translationUnits()` call; a book reopen rebuilds the provider from scratch so the cache never goes stale within one open book |
+| `FoliateSectionExtracting` (`Services/Reader/`) | `FoliateSpikeView.Coordinator` (extension) | Feature #56 WI-11 — `@MainActor protocol` bridging the live Foliate per-section text extraction seam (the `readerAPI.bilingualSectionIDs` / `readerAPI.bilingualSectionText` JS calls) into the `Sendable` `ChapterTextProviding` boundary. Class-bound + `Sendable` + `@MainActor` means a `@MainActor`-isolated `AnyObject` existential is safely `Sendable` (members are main-actor-isolated), so the `FoliateChapterTextProvider` actor can hold a single live reference without an unsafe escape hatch |
+| `ChapterPrefetching` (`Services/AI/`) | `BilingualReadingViewModel` | Feature #56 WI-7b seam — `translatedSegments(for:targetLanguage:granularity:)`, the single-method translation-prefetch boundary `BilingualReadingViewModel`'s unit-aware prefetch trigger depends on. Decouples the view model from provider resolution / the disk cache / chunking; production wires a thin adapter over `ChapterTranslationService` + `AIService`, tests inject a deterministic mock |
+| `ChapterTranslationPrefetcher` (`Services/AI/`) | `ChapterTranslationService` + `AIService` + `ChapterTextProviding` | Feature #56 WI-10 production `ChapterPrefetching` adapter. `Sendable` `struct` per open book. Each `translatedSegments(...)` call consults the disk cache FIRST (profile-free — Bugs #306/#342: a cached chapter renders with no/any provider), then resolves the active provider config once — a profile flip during a chapter prefetch does not split chunks across providers. Pulls per-unit source text from the injected `ChapterTextProviding` and routes the request through `ChapterTranslationService.translate(...)`. Default style is `.natural`; the re-translate picker (WI-15) is the only path that overrides it |
+| `BackgroundExecutionToken` (`Services/`) | `UIApplication` (via `BackgroundTaskRequesting`) | Feature #98 grace-window handle over `beginBackgroundTask`/`endBackgroundTask` behind the `BackgroundTaskRequesting` protocol seam (production = `UIApplication`, tests = recorder). `@MainActor` class; explicit `end()` is the contract (idempotent; `deinit` only DEBUG-logs leaks); the expiration handler strongly captures a shared end-state so even a leaked token self-ends at expiry; `.invalid` (iOS denied time) degrades to a no-op. Ships with `BackgroundExpiryLatch` — a lock-backed one-way latch the `@MainActor` expiry handler sets synchronously and the whole-book job loop reads between units. Consumers: `ChapterReTranslateViewModel.submit()` (one token per re-translate) and `BookTranslationCoordinator` (token renewed per translated unit; expiry → clean between-units stop with the `.failed` phase, completed units cached as the resume checkpoint) |
+| `BookTranslationCoordinator` (`Services/AI/`) | `ChapterTranslationService` + `ChapterTranslationStore` + `ChapterTextProviding` | Feature #56 WI-14 actor driving the "translate entire book" flow. App-scoped `.shared` instance (configured at `VReaderApp.init`). `start(...)` spawns a background task that iterates `ChapterTextProviding.translationUnits()`, skips units already covered in `ChapterTranslationStore.cachedUnits(...)`, hands each remaining unit to `ChapterTranslationService.translate(...)`, and emits monotonic `BookTranslationProgress` snapshots through an `AsyncStream` (`progressUpdates(forBookWithKey:)`). At most one running job per book — a second `start` for the same book is a silent no-op. `cancel(_:)` stops between units; `cancelAndPurge(_:)` additionally wipes the book's cache rows for the user-delete-book path (plan edge case (g)). Posts `.readerBookTranslationProgressDidChange` on every snapshot so a reader open on the book drives its `ReaderTranslateBanner`. Feature #98: renews a `BackgroundExecutionToken` per translated unit; on OS expiry stops cleanly BETWEEN units (`.failed` phase = the designed PAUSED rendering) and persists an `InterruptedTranslationJob` descriptor (`{v, bookKey, targetLanguage, style, providerProfileID}` in UserDefaults via `InterruptedTranslationJobStore`); `resumeInterruptedJob(bookFingerprintKey:textProvider:)` — triggered by the reader container's provider-arrival handler — re-resolves the PERSISTED profile through the `ProviderConfigResolving` seam (`AIService` conforms) and re-enters `start` (cached units skip = resume); descriptor cleared on completion / user cancel / book delete, retained on provider failure |
+| `BookTranslationViewModel` (`ViewModels/`) | `BookTranslationCoordinator` | Feature #56 WI-14 `@MainActor @Observable` UI-facing state for the translate-entire-book flow. Drives the confirm alert (`presentConfirm` loads `estimate` + shows alert), the status sheet (`startObserving` subscribes to the coordinator's progress stream and mirrors snapshots into `progress`), and the cancel alert (`requestCancel` opens the confirmation, `confirmCancel` propagates to the coordinator). One per surface (Book Details, library card, reader chrome); multiple VMs for the same book observe the same coordinator job |
+| `ChapterReTranslateViewModel` (`ViewModels/`) | `AIService` + `ChapterTranslationService` + `ChapterTranslationStore` | Feature #56 WI-15 `@MainActor @Observable` UI-facing state for the per-chapter re-translation flow. `presentPicker(...)` opens `ReTranslatePickerSheet` with the chosen unit + title + target language; `updateSelection(_:)` mutates the picker's `(providerProfileID, model, style, keepGlossary)` selection; `submit()` resolves the picker's `ResolvedAIProviderConfig` through the `RetranslateProviderResolving` boundary (`AIService` conforms), runs the translation through `ChapterReTranslating` (`ChapterTranslationService` conforms, with the cache READ bypassed so a fresh row can't no-op the re-translate — Bug #341 atomic swap + Bug #342 canonical key: the cache-write replaces the ONE `book|unit|lang|prompt` row in place, the original translation survives every failure/cancel path, and an override re-translation is readable by bilingual mode on reopen), and fires `onTranslationApplied` so the host posts `.readerBilingualReTranslateApplied`. Picker override never mutates `ProviderProfileStore` (acceptance criterion (f)) |
+| `EPUBBilingualPipeline` (`Views/Reader/Bilingual/`) | `EPUBBilingualJS` + `EPUBBilingualOrchestrator` | Feature #56 WI-10 pure glue between the EPUB WKWebView's `bilingualEnumerate` message payload and the `BilingualReadingViewModel`'s `translationsByUnit` cache. `parseEnumeratePayload(_:)` decodes the raw `Any` body into an `EPUBBilingualEnumeratePayload` (`{requestedSectionIndex, blocks}`) — accepting BOTH the paged bare-array shape (`[{bid,text}]`, no section identity) and the continuous-scroll envelope (`{sectionIndex, blocks}`); the envelope preserves the section identity on an EMPTY result so the container clears ONLY that section's bucket instead of every bucket (Feature #71 WI-7 Gate-4 round-3 MEDIUM 1). `parseEnumerateMessage(_:)` is the flat-`[BilingualBlock]` convenience over it; `translationsByBid(blocks:translatedSegments:)` maps the VM's ordered segment array onto a `[bid: text]` lookup by position. No `@MainActor` — pure value transforms |
+| `EPUBBilingualOrchestrator` (`Views/Reader/Bilingual/`) | `EPUBBilingualJS` + `EPUBBilingualPipeline` | Feature #56 WI-10 host-side `@MainActor @Observable` controller, one per open EPUB. Holds the current chapter's `[BilingualBlock]` list; emits enumerate / inject / clear JS for the bridge to evaluate. Stateless beyond the block list — the container drives transitions via `enumerateJS()` on `didFinish`, `updateBlocks(_:)` on the enumerate callback, `buildInjectJS(translatedSegments:)` when the VM's prefetch lands, and `clearJS()` on disable / chapter swap |
+| `FoliateBilingualPipeline` (`Views/Reader/Bilingual/`) | `FoliateBilingualJS` + `FoliateBilingualOrchestrator` | Feature #56 WI-11 — AZW3/MOBI sibling of `EPUBBilingualPipeline`. Same two static functions (`parseEnumerateMessage(_:)`, `translationsByBid(blocks:translatedSegments:)`) with the same shapes; reuses the `BilingualBlock` value type so the enumerate → translate → inject contract is byte-identical across formats. Independent file so format-specific test invariants don't cross-contaminate |
+| `FoliateBilingualOrchestrator` (`Views/Reader/Bilingual/`) | `FoliateBilingualJS` + `FoliateBilingualPipeline` | Feature #56 WI-11 — AZW3/MOBI sibling of `EPUBBilingualOrchestrator`. `@MainActor @Observable` controller, one per open AZW3/MOBI book. Owned by `FoliateBilingualContainerView`; emits enumerate / inject / clear JS that the container posts through `.foliateRequestBilingualEvalJS` for the live `FoliateSpikeView.Coordinator` to evaluate against its `WKWebView` |
+| `FoliateBilingualContainerView` (`Views/Reader/`) | `FoliateSpikeView` + `FoliateBilingualOrchestrator` + `BilingualReadingViewModel` + `FoliateChapterTextProvider` | Feature #56 WI-11 — AZW3/MOBI host wrapper that adds the bilingual VM / orchestrator / setup-sheet wiring around the unchanged `FoliateSpikeView`. Owns the bilingual `@State`, the first-enable `BilingualSetupSheet`, and the notification plumbing (`.readerMoreBilingual` → toggle, `.foliateSectionLoaded` → enumerate, `.foliateBilingualBlocksEnumerated` → cache + prefetch, `.readerBilingualDidChange` → inject) that mirrors `EPUBReaderContainerView+Bilingual` for the live Foliate path |
+| `BilingualDisplaySegmentMap` (`Services/Reader/`) | `BilingualTextRenderer`, `TXTReaderContainerView`, `MDReaderContainerView` | Feature #56 WI-12a pure `Sendable` value type — the TXT/MD source↔display UTF-16 offset map. Records ordered display segments tagged `.source(sourceRange:displayRange:)` or `.synthetic(displayRange:)`. `sourceOffset(forDisplayOffset:)` returns `nil` for synthetic ranges or out-of-bounds offsets; `displayOffset(forSourceOffset:)` clamps a past-end source position to display end. `identity(sourceLength:)` builds the 1:1 pass-through used when bilingual is off. WI-12b consumes the map in TXT/MD container offset-routing |
+| `BilingualTextRenderer` (`Views/Reader/Bilingual/`) | `BilingualDisplaySegmentMap` | Feature #56 WI-12a pure interlinear builder for TXT/MD. `render(sourceText:sourceParagraphRanges:translatedSegments:)` returns the rendered `NSAttributedString` (source paragraphs interleaved with synthetic translation runs, each carrying the `decorationAttributeKey` attribute) plus the matching `BilingualDisplaySegmentMap`. Nil or empty translations fall back to source + identity map. Partial translations inject the prefix and leave the tail source-only (plan Decision 2's silent-source-fallback). WI-12b wires the renderer's output into the live TXT/MD UITextView |
+| `BilingualParagraphRanges` (`Services/Reader/`) | `BilingualTextRenderer`, `BilingualDisplayPipeline` | Feature #56 WI-12b — pure paragraph-range scanner that splits a TXT/MD chapter's source text into UTF-16 paragraph ranges. Blank-line-separated content lines fuse into one paragraph (matches reflow conventions); blank lines + leading/trailing whitespace are excluded from ranges. Feeds the interlinear renderer's `sourceParagraphRanges` argument. Pure O(N) UTF-16 single-pass — covers CRLF / CJK / interspersed-blank-line edge cases |
+| `BilingualAttributedStringComposer` (`Views/Reader/Bilingual/`) | `BilingualDisplaySegmentMap`, `BilingualTextRenderer` | Feature #56 WI-12b — typography-preserving interlinear composer. `compose(sourceAttributed:sourceParagraphRanges:translatedSegments:)` takes an already-typographed source `NSAttributedString` (font, line spacing, drop-cap, heading restyle) and interleaves synthetic translation runs at paragraph boundaries. Synthetic runs inherit the prior source paragraph's attrs + carry the `decorationAttributeKey`. Used by TXT's chapter-paged path so the chapter-start drop-cap + heading restyle survive the bilingual interleave |
+| `BilingualDisplayPipeline` (`Views/Reader/Bilingual/`) | `BilingualTextRenderer`, `BilingualAttributedStringComposer`, `BilingualReadingViewModel` | Feature #56 WI-12b — `@MainActor` bridge between the bilingual VM state and the renderer/composer. `makeDisplay(...)` builds a fresh attrString from a plain `String` source; `compose(sourceAttributed:...)` preserves an upstream typographed attrString. Both off-path (no VM / disabled / no unit / no cached translation) returns the source + identity map — the byte-identical pass-through that gates the R-TXT-offsets risk |
+| `BilingualOffsetRouter` (`Views/Reader/Bilingual/`) | `BilingualDisplaySegmentMap` | Feature #56 WI-12b — pure source↔display offset router for the TXT/MD container's bilingual surfaces. Helpers: `displayOffset(forSourceOffset:map:)`, `sourceOffset(forDisplayOffset:map:)`, `displayRange(forSourceRange:map:)` (segment-union projection — a source range that crosses an intervening synthetic block produces a spanning display range), `displayNSRange(forSourceNSRange:map:)`, `isSynthetic(displayOffset:map:)`. Identity-map mode is byte-identical to today's offset code |
+| `BilingualTXTBridgeDelegateAdapter` (`Views/Reader/Bilingual/`) | `BilingualDisplaySegmentMap`, `TXTTextViewBridge` | Feature #56 WI-12b — `@MainActor` delegate wrapper that maps display-domain offsets the bridge reports (selection range, top-visible-char scroll offset) back to source-domain offsets via `BilingualOffsetRouter`, so the TXT VM keeps persisting positions in document source coordinates with bilingual on. A selection that starts inside a synthetic translation run is dropped; a scroll-into-synthetic projects to the end of the preceding source segment. Identity map (bilingual off) is a transparent pass-through |
+| `TXTLoaderBackedChapterTextProvider` (`Services/Reader/`) | `ChapterTextProviding`, `TXTChapterContentLoader` | Feature #56 WI-12b — chapter-paged-mode `ChapterTextProviding` adapter that reads each chapter on demand via the live reader's `TXTChapterContentLoader` actor. Sibling to `TXTChapterTextProvider` (full-book-slicing). Re-enables bilingual mode for chapter-paged TXT, the mode WI-12a's `makeTextProvider` explicitly disabled because the VM's `textContent` is chapter-local in that mode |
+| `PDFBilingualPanel` (`Views/Reader/Bilingual/`) | `PDFBilingualPanelState`, `BilingualLanguage`, `ReaderThemeV2` | Feature #56 WI-13 — PDF below-page bilingual translation panel. Stateless SwiftUI sub-view rendering the design's split-layout A1..A8: header (lang-glyph chip + page label + status suffix + chevron) + body switched on `PDFBilingualPanelState` (5 states: `.off` / `.loading` / `.translated([String])` / `.offline` / `.empty`). PDF is fixed-layout so the paragraph-interlinear renderer used by EPUB/Foliate/TXT/MD doesn't apply; the panel below the page is the entire user-visible bilingual surface for PDF. 260pt expanded / 38pt collapsed; attached to `PDFViewBridge` via SwiftUI's `.safeAreaInset(edge: .bottom)` so PDFKit's `autoScales` reflows the page rendering automatically |
+| `PDFBilingualPanelState` (`Views/Reader/Bilingual/`) | `BilingualReadingViewModel`, `PDFChapterTextProvider` | Feature #56 WI-13 — pure synchronous derivation of the panel's 5-state matrix from the bilingual VM + the PDF's `(currentPage, pagesPerUnit, totalPages)` triple. Computes the current `TranslationUnitID` synchronously (mirrors `PDFChapterTextProvider.pageRanges` arithmetic) instead of reading the VM's async-updated `lastTriggerUnit`, so page-turn-in-flight doesn't flash stale translations (Gate-2 v5 round-1 H1). `.empty` keyed on "translated segments empty after fetch" OR "totalPages <= 0", NOT `unit == nil` (which would never fire for a real PDF — Gate-2 v5 round-1 M1) |
+| `PDFReaderContainerView+Bilingual` (`Views/Reader/`) | `BilingualReadingViewModel`, `PDFChapterTextProvider`, `PDFBilingualPanel`, `PDFBilingualPanelState` | Feature #56 WI-13 — PDF host extension owning the bilingual VM lifecycle (lazy construction gated on `viewModel.isDocumentLoaded` + `totalPages > 0`), the `PDFChapterTextProvider` build, the prefetcher build (mirrors TXT/EPUB `makePrefetcher`), the first-enable setup sheet, the More-menu toggle observer, the retry observer (`.readerBilingualRetry`), and the `.safeAreaInset`-attached panel. On reopen of an already-enabled book, `ensureBilingualViewModel` kicks the initial `handlePositionChange` so the panel doesn't stick in `.loading` for the open page (Gate-4 round-1 H1). Mirrors `TXTReaderContainerView+Bilingual` / `MDReaderContainerView+Bilingual` / `EPUBReaderContainerView+Bilingual` structurally |
+
+### 6. Data Layer (`vreader/Models/`)
+
+SwiftData SchemaV10 entities (V9→V10 adds the additive optional `Book.sourceCanonicalKey: String?` — feature #108's converted-Kindle cross-platform identity, carried in the backup manifest; feature #109's NFC locator-key recompute runs as the launch-time `LocatorKeyBackfillMigration`, not a schema migration — see the App Layer note above):
+
+- `Book` (fingerprintKey unique; gains `originalExtension: String?` in SchemaV5 for backup blob extension preservation; gains `fileState: String` and `blobPath: String?` in SchemaV6 for feature #47's lazy-load row state; gains `sourceCanonicalKey: String?` in SchemaV10 — feature #108's converted-Kindle source-bytes cross-platform identity, while the converted-EPUB `fingerprintKey` stays the local primary) → `ReadingPosition` (gains `vreaderLocatorData: Data?` in SchemaV8 — feature #42's engine-agnostic `VReaderLocator` envelope, stored as raw JSON `Data?` mirroring `Highlight.anchorData`; additive/optional → lightweight migration, no stage), `Highlight`, `Bookmark`, `AnnotationNote`, `BookCollection`, `ChatSession` (SchemaV9 cascade child)
+# Feature #131 — Android Bilingual Interlinear Reading (parity-checklist box D)
+
+**Feature number assumption:** highest active row in `docs/features.md` is `#130`; `#131` is the next free number. The orchestrator adjusts if a row is claimed first.
+
+**Design authority (rule 51):** the **authoritative** bilingual surfaces are in `dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx` (`BilingualSetupSheet` / `BilingualPageContent` / `BilingualPill` / `BILINGUAL_LANGS`) and `.../vreader-reader.jsx` (`ReaderTopChrome` renders `BilingualPill`; the bilingual toggle is a More-menu row via `onMoreAction`) and `.../vreader-more.jsx` (the "Bilingual mode" More-menu Row toggle). `.../vreader-ai-android.jsx` contains a SECOND, differently-shaped `BilingualSetupSheet` — see §3's setup-sheet resolution for why this plan reproduces the `vreader-bilingual.jsx` sheet and design-gates the divergence. Where a surface is NOT depicted it is scoped out and flagged.
+
+**Status:** Gate-1 draft v2 (2026-07-11) — Gate-2 round-1 REDESIGN resolved. Awaiting Gate-2 round-2 audit.
+
+## 1. Problem
+
+iOS ships bilingual interlinear reading (#56/#100): a per-book toggle renders each source paragraph followed by its translation in a muted style, backed by an AI provider, cached to disk. Android shipped the #118 AI provider foundation (provider store, OpenAI-compat + Anthropic SSE clients, chat/summary) but has **no bilingual capability**. Box D of the parity checklist requires the interlinear renderer + the bilingual setup sheet, building on #118.
+
+The engineering questions are (a) **which render host(s)** get true interlinear, and (b) **where the entry point lives**. Both were mis-analysed in v1 and are corrected here:
+
+- **Host** — v1 claimed EPUB interlinear is "infeasible inside Readium's navigator." **That is FALSE** (§3): `EpubNavigatorFragment.evaluateJavascript(script): String?` is a public suspend method in the shipped Readium 3.3.0 AAR (verified via `javap` — see §3), so the app CAN inject and clear translation DOM nodes in Readium's WebView. EPUB is therefore the **primary** target (it is the app's main reading format). TXT/MD are still built but as a phased choice, not because EPUB requires a fork.
+- **Entry point** — v1 put the toggle in the bottom chrome. **The design puts it in the More-menu + a top-chrome pill** (`vreader-more.jsx`, `vreader-reader.jsx`), which are box-F surfaces — so #131's UI *entry wiring* depends on box F (§2, §4).
+
+## 2. Surface area
+
+### Render-host decision (corrected — see §3 for the full analysis)
+
+**v1 targets TWO hosts, in dependency order:**
+
+1. **EPUB (Readium `EpubNavigatorFragment`) — PRIMARY.** Interlinear IS feasible via `evaluateJavascript` (enumerate leaf blocks → inject translation nodes → clear on teardown/reflow), exactly mirroring iOS `EPUBBilingualOrchestrator`. This is validated first by **WI-0 (a Readium bilingual spike)** before the render WI is planned in detail, because JS injection into a navigator the app does not own has real unknowns (reflow, href changes, fragment recreation, pagination interaction).
+2. **TXT/MD (Compose `TxtReaderActivity`) — INCLUDED.** Trivially injectable (a translation `Text` after each source chunk in the confirmed `items(count = document.chunkCount)` loop, which already interleaves highlight + TTS spans). No WebView; deterministically Compose-testable.
+
+**AZW3 (foliate WebView)** and **PDF** remain follow-ups / out (§"Files OUT of scope").
+
+**Why both, not TXT/MD-only:** the honest thesis is that the *pipeline* (segment → chunk → translate → cache → interleave) is host-agnostic and fully built in v1; only the *render injection* is host-specific. EPUB is the format most users read, so shipping box D without it would under-deliver on the visible capability. TXT/MD are included because the Compose host is the cheapest, most testable place to prove the pipeline end-to-end (no WebView, deterministic tree assertions) — it de-risks the EPUB render adapter. This is not the box-B/E "one host and check the box" split; box D ships EPUB + TXT/MD together, with AZW3/PDF as tracked follow-ups. **Box D cannot be checked on the false "EPUB requires a fork" rationale** — that rationale is discarded.
+
+### New files
+
+**Pipeline / domain (host-agnostic, pure or coroutine — JVM-testable):**
+
+- `bilingual/TranslationUnitId.kt` — `data class TranslationUnitId(kind, value)` with `enum Kind { epubHref, foliateHref, txtChapterIndex, mdChapterIndex, pdfPageRange }`; `storageKey = "${kind.name}:$value"`. Mirrors iOS `TranslationUnitID.Kind` (verified: same five cases). v1 uses `epubHref` + `txtChapterIndex`/`mdChapterIndex`; others reserved so the cache-key format never breaks.
+- `bilingual/TranslationGranularity.kt` — `enum { paragraph, sentence }`. (Design's Granularity segment.)
+- `bilingual/BilingualLanguages.kt` — `BilingualLanguage(key, glyph, script)`; `BILINGUAL_LANGS` = the set from `vreader-bilingual.jsx` (`BILINGUAL_LANGS`) + `findOrDefault(key)`. Default `Chinese`.
+- `bilingual/ChapterSegmenter.kt` — `paragraphs(text)` / `sentences(text)`. Port of iOS `ChapterSegmenter.paragraphs(in:)`/`sentences(in:)` (verified exists, CJK-aware via sentence enumeration).
+- `bilingual/TranslationChunker.kt` — `chunk(segments, maxCharsPerChunk)` + `subSplit(text, maxChars)`. Port of iOS `ChapterTranslationChunker.chunk(...)` + `subSplit(...)` (verified: `chunk` returns `[[Int]]` index groups, oversize segment gets its own chunk; `subSplit` is the Bug #330 grapheme-safe over-budget splitter).
+- `bilingual/TranslationChunkContract.kt` — `userPrompt(segments, targetLanguage, style)`; `decode(raw, expectedCount)` (strict JSON-array + code-fence strip); `sealed class DecodeError { NotAStringArray; CountMismatch(expected, actual) }`. Port of iOS `TranslationChunkContract` (verified: same `userPrompt`/`decode` shape, same two DecodeError cases).
+- `bilingual/ChapterTextProvider.kt` — `interface { units(); sourceText(unit); unitContaining(locator); unitAfter(unit) }`. Resolution key is host-specific: TXT/MD key on `charOffsetUtf16` (Android `Locator` is offset-based there); EPUB keys on the current-resource `href` from `EpubNavigatorFragment.currentLocator`. Honest divergence from iOS's uniform Readium `Locator`, documented.
+- `bilingual/TxtChapterTextProvider.kt` — provider over `TxtDocument` + chapter model. MD source = raw markdown chapter (translation renders as plain muted text, not re-markdown-rendered — matches the muted-secondary design line).
+- `bilingual/EpubChapterTextProvider.kt` (WI-0-gated shape) — provider over the Readium `Publication` reading order; `units()` = spine hrefs, `unitContaining(locator)` = the locator's href. Its render-side collaborator (the JS enumerate/inject adapter) is defined by WI-0's findings, not pre-committed here.
+- `bilingual/ChapterTranslationError.kt` — `sealed { Offline; TimedOut; ProviderFailed(msg); Cancelled }`. Maps from `AiError` (verified cases: `Auth401`, `RateLimited429`, `Offline`, `Timeout`, `Http(code)`, `Decode`, `Stream`, `InsecureUrl`, `Config`).
+- `bilingual/ChapterTranslationService.kt` — `cachedTranslation(...)` (cache-only, no provider — #306 parity: a cached chapter renders even when AI is later unconfigured); `translate(...)` (segment → chunk → per-chunk `AiClient.chat` one-shot → `decode` → per-segment fallback → graceful per-chunk degrade (Bug #330 parity: a single failed chunk renders source-only and is NOT cached; all-chunks-fail throws) → cache-write only on full success). Uses `AiClient.chat(AiRequest)` (one-shot, NOT `streamChat`). Cancellation: `ensureActive()` between chunks AND immediately before the Room write (§6).
+- `bilingual/ChapterTranslationPrefetcher.kt` — resolves the active profile from one `AiProviderStore.snapshot()` (`snapshot.active`), decrypts via `store.apiKey(profile)` (snapshot-consistent), builds an `AiClient` via an **injected factory param** (see the DI correction below), cache-first then translate. Throws `ChapterTranslationError`. Mirrors iOS `ChapterTranslationPrefetcher` (verified: iOS snapshots the active profile after a cache miss and is a Sendable struct capturing its collaborators).
+- `bilingual/BilingualAiReadiness.kt` — `resolve(snapshot): Boolean` (active profile exists AND its decrypted key is non-empty). A cipher/decryption failure maps to **not-ready** (never crashes — §6), not to a thrown error. Drives the setup-sheet engine-strip configured/unconfigured state. Keep the gate to exactly what #118 enforces (no separate consent manager on Android — #118 has none; confirm during build).
+
+**State / persistence:**
+
+- `bilingual/PerBookBilingualStore.kt` — DataStore-Preferences, keyed by `bookFingerprintKey`, holding `{ enabled, targetLanguage, granularity }`. This is the Android `PerBookSettingsOverride` bilingual slice — the backup contract declares exactly `bilingualEnabled` / `bilingualTargetLanguage` / `bilingualGranularity` (verified in `PerBookSettings.swift` and the Android `BackupSectionsExtended.kt`), and **NO `bilingualStyle`** (verified — style is not a persisted per-book field on iOS either). So this store writes exactly those three fields. Wiring into backup collect/restore is scoped OUT (§7) — additive later, fields already in the contract; until then bilingual config is device-local.
+- `bilingual/BilingualViewModel.kt` — `StateFlow<BilingualUiState>` with `enabled`, `targetLanguage`, `granularity`, `needsSetupSheet`, `aiConfigured`, `translationsByUnit`, `inFlightUnits`, `unavailableUnits`, `errorUnit`. Setters + `dismissSetupSheet`, `onPositionChanged(locator)`, `retryUnit(unit)`. Generation/epoch-guarded prefetch (current + next unit), cancellation on disable / language / granularity change — port of iOS `BilingualReadingViewModel` + `+Prefetch` (verified both exist). Split to `BilingualPrefetchController.kt` if it nears ~300 lines. (No `style` field — the authoritative sheet has no Style control; see §3.)
+
+**Room (translation cache):**
+
+- `data/ChapterTranslationEntity.kt` — `@Entity(tableName="chapter_translations", indices=[Index("bookKey")], foreignKeys=[FK→books.fingerprintKey ON DELETE CASCADE])`. **`@PrimaryKey val lookupKey: String`** (Room REQUIRES a primary key; a "unique index without a PK" does not compile — verified against `HighlightEntity`, which pairs a `@PrimaryKey` with a separate unique index). `lookupKey` = `bookKey|unitStorageKey|targetLanguage|promptVersion` (see the cache-identity correction below). Other columns: `bookKey`, `unitStorageKey`, `targetLanguage`, `promptVersion`, `translatedJson`, `sourceParagraphCount`, `createdAt`. Mirrors iOS `ChapterTranslationRecord.lookupKey` (verified: iOS key is `book|unit|lang|prompt`, profile-agnostic — Bug #342).
+- `data/ChapterTranslationDao.kt` — `getByLookupKey(key)`, `@Upsert suspend fun upsert(row)` (Upsert identifies by PK = `lookupKey`, so it is a correct insert-or-replace by the cache identity), `deleteByLookupKey(key)`. The project's Room pattern is `@PrimaryKey` + `@Upsert` (verified: `BookDao.upsert`); making `lookupKey` the PK is exactly that pattern.
+- `bilingual/ChapterTranslationStore.kt` — coroutine wrapper returning a Sendable `CachedTranslation` (segments decoded from JSON), keeping Room entities off the boundary (the `AnnotationsRepository`/`HighlightRecord`/iOS `ChapterTranslationStore` precedent).
+
+**Cache-identity correction (audit HIGH — reconciled with iOS parity):** the audit asked to add granularity + style as key columns. iOS deliberately does the opposite — `ChapterTranslationRecord.lookupKey` is `book|unit|lang|promptVersion` and is profile-AGNOSTIC / granularity-AGNOSTIC / style-agnostic (Bug #342's fix was to *remove* dimensions from the key). Style is folded into the prompt content; granularity is a read-time count-check. **Resolution honoring both the audit's concern and iOS parity:** keep the 4-part key, but make `promptVersion` an **effective composite** that encodes the result-shaping inputs, e.g. `promptVersion = "bilingual-v1|g=${granularity}|s=${style}"` (iOS uses the literal `"bilingual-v1"` today because iOS forces `.paragraph` for bilingual and pins one style; Android carries granularity/style in the promptVersion string so a change re-keys correctly). Style is not a v1 user control (the authoritative sheet has none — §3), so `s=` is a constant this version; granularity IS user-selectable, so `g=` is load-bearing (a paragraph vs sentence translation is a different cache row — this also closes the iOS #344 "sentence silently ignored" class by construction). **Additionally** (audit's cancellation half): a granularity change must cancel in-flight jobs, bump the VM generation, clear shaped in-memory `translationsByUnit`, and force a correctly-keyed re-fetch — specified in WI-6.
+
+**DI / factory correction (audit HIGH):** the audit is right that `AiProviderFactory` is NOT a lambda — verified it is an `object` with `create(profile: AiProviderProfile, apiKey: String, dispatcher: CoroutineDispatcher = Dispatchers.IO): AiClient`. So `ChapterTranslationPrefetcher` takes its OWN injected `clientFactory: (AiProviderProfile, String) -> AiClient` param **defaulting to `AiProviderFactory::create`** (production) and overridden with a fake in tests. The prefetcher builds the exact `AiRequest(model = profile.model, messages = …, temperature = profile.temperature, maxTokens = profile.maxTokens, system = …)` from the resolved profile (verified `AiRequest` fields).
+
+**AppContainer / navigation correction (audit HIGH — genuine gap, NOT stale state):** verified against the real code — `AppContainer` does **NOT** provide `AiProviderStore` today, and there is **NO live navigation route to `AiProviderListScreen`** (MainActivity has no NavHost; the screen + store + `AiSettingsViewModel` exist from #118 but are only exercised by instrumented/round-trip tests — #118 was VERIFIED via component tests + a live SSE socket round-trip, not an in-app nav route). There is no `#119` row. Consequences for #131:
+- #131 **adds `AiProviderStore` to `AppContainer`** (lazy singleton: DataStore + `KeystoreSecretCipher`, the #116/#118 pattern) — the prefetcher + readiness need it and nothing provides it yet.
+- The setup-sheet unconfigured engine strip's **"Set up" CTA target does not exist in the running app.** #131 does NOT invent an AI-provider settings screen or its navigation (that is box-F chrome / a #118 follow-on, and inventing it violates rule 51). Until a live route to `AiProviderListScreen` ships, the "Set up" affordance is **design-gated** — see §3's design-gate list. #131 can ship the bilingual sheet's *configured* path (a provider already set via the tested path) end-to-end; the *unconfigured → Set up* nav is a stated dependency, not #131 scope.
+
+**UI (Compose — every state depicted, reproducing `vreader-bilingual.jsx`):**
+
+- `bilingual/BilingualSetupSheet.kt` — reproduces `vreader-bilingual.jsx`'s `BilingualSetupSheet` EXACTLY: header Cancel / Translate; a **preview strip**; a **language grid** over `BILINGUAL_LANGS` (glyph tiles, selected accent); a **Granularity** segmented control (Paragraph "Translate after each ¶" / Sentence "Translate after each sentence"); a **Translation engine** strip (configured: "Claude · with this book's context" + "Change…"; unconfigured: "No AI provider configured" + "Set up"). **No Style control, no provider/model card, no term-overrides toggle, no cost footer** — those belong to the *other* (`vreader-ai-android.jsx`) sheet, which this plan does not reproduce (§3).
+- `bilingual/BilingualInterlinearBody.kt` — per source chunk/paragraph: source `Text` then translation `Text` muted with accent left-border, `fontSize*0.88`, CJK font for cjk scripts, RTL handling for Arabic script. Consumes `translationsByUnit`. Loading state ("Translating chapter… N%" + per-paragraph dim — matches the design's chapter-level "38%"). Error state ("Couldn't translate" + Retry). Partial/offline (`unavailableUnits`): source-only silent fallback (design's original-always-kept guarantee — iOS Decision 2). This is the render surface for BOTH the TXT/MD Compose loop and (via the WI-0 adapter) the EPUB injection payload's Kotlin-side state.
+- `bilingual/BilingualPill.kt` — the `EN ↔ 中` reader-**top-chrome** pill (per `vreader-reader.jsx` `ReaderTopChrome` + `vreader-bilingual.jsx` `BilingualPill`). Rendered by box F's top chrome; #131 provides the composable, box F wires it in (§4).
+
+### Modified files
+
+- `data/VReaderDatabase.kt` — add `ChapterTranslationEntity`, bump `version` (allocated version-at-slot; **v5 today** — verified, so v5→v6, but the number is set at the merge slot, not pre-assigned), add `MIGRATION_5_6` (CREATE TABLE + `bookKey` index + FK CASCADE, DDL exactly matching Room's generated schema), append `ALL_MIGRATIONS`, add `abstract fun chapterTranslationDao()`.
+- `reader/TxtReaderActivity.kt` — own a `BilingualViewModel`; collect state; pass into `TxtBody`; on position change call `vm.onPositionChanged(...)`; render `BilingualInterlinearBody` output in the `items(count = document.chunkCount)` loop when bilingual is on and a translation exists (the confirmed injection point — verified it already interleaves highlight washes + TTS spans per chunk). Strictly gated to `originalFormat ∈ {txt, md}`; disabled = body byte-unchanged. **This file overlaps #129's TXT/MD WIs → gated on #129's FINAL merge (§4).**
+- `reader/ReaderActivity.kt` (Readium EPUB) — WI-0-gated: attach the JS enumerate/inject adapter to `navigator.evaluateJavascript`, re-apply on href change / reflow, clear on teardown. Concrete surface defined by WI-0's spike output.
+- `VReaderApp.kt` / `AppContainer` — **provide `AiProviderStore`** (new — see the AppContainer correction), `ChapterTranslationStore`, `PerBookBilingualStore`, and a `BilingualViewModel` factory. Mirrors #116/#118/#122 DI.
+
+**NOT modified (audit HIGH — Translate slot removed):** `reader/chrome/ReaderBottomChrome.kt` gets **no** bilingual/Translate slot. v1 wrongly added `onOpenBilingual` there; the design's entry is the More-menu toggle + the top-chrome pill (box F), NOT a bottom-chrome slot. `ReaderBottomChrome`'s existing `extraSlot` (the #129/#121 read-aloud entry) is untouched.
+
+### Files OUT of scope for v1
+
+- **`Azw3ReaderActivity.kt` / `reader/foliate/`** — foliate WebView interlinear IS feasible (JS enumerate+inject in the pinned bundle, mirroring iOS `FoliateBilingualOrchestrator`) but deferred to a follow-up (bundle-patch JS + secure-bridge additions touching the security-sensitive #126 surface). Once WI-0 proves the EPUB JS pipeline, the foliate host reuses it with a bundle adapter.
+- **`PdfReaderActivity.kt`** — no reflowable text layer. Out (the `pdfPageRange` Kind is reserved only).
+- **Live AI-provider settings navigation / the "Set up" destination screen** — box-F chrome / #118 follow-on; #131 does not invent it (rule 51). Design-gated dependency (§3).
+- **Backup collect/restore of `PerBookSettingsOverride` bilingual fields** — contract fields exist; wiring is a small additive follow-up (§7). Bilingual config is device-local until then.
+- **"Translate entire book…" batch, re-translate/style-swap picker, cost/token estimation, term-overrides** — iOS/`vreader-ai-android.jsx` extras not in the authoritative `vreader-bilingual.jsx` sheet. Out.
+- **Streaming translation progress** — the design's "38%" is chapter-level N-of-M chunk progress (from the chunker count), not token streaming. v1 shows N-of-M.
+
+## 3. Prior art / project precedent / rejected alternatives
+
+### The render-host decision (analysis — CORRECTED from v1)
+
+**How iOS does interlinear:** iOS renders EPUB/AZW3 in a WKWebView it fully controls. `EPUBBilingualOrchestrator` injects JS that (1) enumerates leaf blocks (`<p>/<li>/<blockquote>`) posting `[{bid,text}]` to Swift, (2) after translation injects a translation node after each block. TXT/MD render in a `UITextView`/attributed-string path where the renderer interleaves translation runs. The mechanism = **the app inserts translation nodes between source nodes.**
+
+**Android host-by-host injectability — the v1 verdict was WRONG for EPUB:**
+
+| Host | Layout tree owner | Content-insertion API | Interlinear feasible? |
+|---|---|---|---|
+| **Readium EPUB** (`EpubNavigatorFragment`) | Readium (internal WebView) | **`evaluateJavascript(script): String?`** is PUBLIC on the fragment (shipped 3.3.0 AAR) → arbitrary DOM read/write. Plus `currentLocator` (href), `firstVisibleElementLocator`, decorations (Highlight/Underline over existing text). | **YES — via JS injection** (not just decorations) |
+| **TXT/MD Compose** (`TxtReaderActivity`) | The app (`LazyColumn` over chunks) | Trivial — a translation `Text` after each source `Text` in the confirmed `items{}` loop | **YES** |
+| **AZW3 foliate** (`FoliateBridge` WebView) | The app (pinned foliate-js bundle) | Full DOM control via the bridge (same as iOS) | YES, but needs bundle-JS → follow-up |
+
+**Verification of the CRITICAL correction:** `javap -public org.readium.r2.navigator.epub.EpubNavigatorFragment` against the resolved AAR (`~/.gradle/caches/.../readium-navigator/3.3.0/.../readium-navigator-3.3.0.aar`) prints:
+```
+public final java.lang.Object evaluateJavascript(java.lang.String, kotlin.coroutines.Continuation<? super java.lang.String>);
+public kotlinx.coroutines.flow.StateFlow<org.readium.r2.shared.publication.Locator> getCurrentLocator();
+public java.lang.Object firstVisibleElementLocator(kotlin.coroutines.Continuation<...>);
+```
+i.e. `suspend fun evaluateJavascript(String): String?` exists. The app already holds the concrete fragment as `ReaderActivity.navigator` (it uses it for decorations/selection in #123). So EPUB interlinear via JS injection is feasible with the public API — **no Readium fork.** The v1 "infeasible inside Readium's navigator" rationale is discarded.
+
+**Chosen: EPUB (Readium JS-injection) as the PRIMARY host + TXT/MD (Compose) included.** WI-0 spikes the EPUB path first (it has the real unknowns); the Compose host is built alongside as the deterministic pipeline proof. AZW3/PDF deferred.
+
+**WI-0 — Readium bilingual spike (new, gates the EPUB render WI):** a throwaway harness that, against a real EPUB on the emulator, proves:
+- (a) **enumerate** current-resource leaf blocks via `navigator.evaluateJavascript(enumScript)` returning a JSON `[{id,text}]` array (parse the `String?` result);
+- (b) **inject** translation DOM nodes after each block, and **clear** them, via `evaluateJavascript`;
+- (c) **re-apply** after `currentLocator` href changes / reflow / page-fragment recreation (the WebView pager recreates fragments — injection must survive or re-fire);
+- (d) measure effects on **pagination/scroll** (does injecting content re-paginate? does it shift the reader's position?) and whether the **enumerated block count** diverges from `ChapterSegmenter` (the iOS #268 divergence class — if it diverges, adopt iOS's `translatePreSegmented` direct-block path).
+
+If WI-0 shows injection is stable → the EPUB render WI proceeds. If WI-0 surfaces a blocker (e.g. fragment recreation wipes injected nodes with no re-fire hook) → EPUB drops to a tracked follow-up and box D ships on TXT/MD (the phasing fallback), with the honest reason (a specific spike finding), never the false "requires a fork" claim.
+
+**Rejected alternatives:**
+1. **Readium interlinear via decorations only** — REJECTED (insufficient). Decorations style existing text; they cannot insert translation paragraphs. But `evaluateJavascript` (above) makes injection possible without decorations, so EPUB is feasible — it just uses the JS seam, not the decoration seam.
+2. **Forking Readium** — REJECTED + unnecessary (the public `evaluateJavascript` seam exists).
+3. **AZW3 foliate host first** — REJECTED for v1 (deferred, not dead). Feasible + design-aligned, but touches the security-sensitive #126 bridge; EPUB via the same JS-injection mechanism is the higher-value primary.
+4. **Eager whole-book pre-translation** — REJECTED (cost/latency). iOS lazily prefetches current+next + caches — port that.
+
+### The setup-sheet resolution (audit HIGH — rule 51)
+
+There are **two committed, differently-shaped** `BilingualSetupSheet`s:
+- `vreader-bilingual.jsx` → **language grid + Granularity (Paragraph/Sentence) + preview strip + Translation-engine strip (Set up/Change) + Cancel/Translate** header. **No Style, no provider/model card, no term-overrides, no cost.**
+- `vreader-ai-android.jsx` → **Languages (From/To) + Provider (provider/model card) + Style (Literal/Natural/Literary) + Keep-term-overrides toggle + cost footer.** **No language grid, no Granularity, no preview.**
+
+v1 merged both into a **third layout** — a rule-51 violation (self-designed UI). **Resolution:** this plan reproduces the **`vreader-bilingual.jsx` sheet EXACTLY** as the authoritative Android-native bilingual sheet (its language grid + granularity + preview + engine strip + CTA is the coherent bilingual-config surface, and its `BilingualPill`/`BilingualPageContent` are the matching reader surfaces). **Style is dropped from v1** (it is not in the authoritative sheet, and — verified — `bilingualStyle` is not a persisted contract field on either platform). Consequently the store/VM carry no `style`, and `promptVersion`'s `s=` component is a constant (§2 cache-identity correction).
+
+**Remaining design gate (rule 51):** a single Android sheet that offers **BOTH Style AND Granularity** (the union the `vreader-ai-android.jsx` "Style" and `vreader-bilingual.jsx` "Granularity" controls imply) is **not depicted anywhere** — no committed bundle shows both in one sheet. If style is wanted on Android as a user control, that needs an **updated committed design**. This plan does NOT invent it; it files a `needs-design` gate (see the §"Design gates" list) and ships the authoritative granularity-only sheet meanwhile.
+
+### Other precedents applied
+
+- **#118 provider seam**: reuse `AiProviderStore.snapshot()` (`snapshot.active`) + `store.apiKey(profile)` + `AiProviderFactory.create` (as the default of an injected factory param) + `AiClient.chat`. Prefetcher + readiness are the only new consumers; #118's AI files are unchanged; #131 additionally *wires* `AiProviderStore` into `AppContainer` (which #118 never did).
+- **Room additive-migration pattern** (#122/#123/#127): version bump + `MIGRATION_n_(n+1)` + exact-DDL + `VReaderDatabaseMigrationTest` PRAGMA guard. `@PrimaryKey` + `@Upsert` is the project's DAO pattern (`BookDao`).
+- **DataStore JSON-in-Preferences** for `PerBookBilingualStore` (the `ReaderSettingsStore`/`AiProviderStore` pattern).
+- **Pure-logic port**: iOS `ChapterSegmenter`/`ChapterTranslationChunker`/`TranslationChunkContract` are pure + heavily unit-tested — direct Kotlin ports with the same test vectors (all verified to exist).
+- **Entry point via box F**: the More-menu bilingual toggle + top-chrome pill are box-F surfaces; #131 depends on them (§4), mirroring how box B's annotations-review-sheet + bookmark "ride with item F."
+
+## 4. Work-item sequencing
+
+Foundational WI-1..4 (no UI, JVM-testable); a spike WI-0 (EPUB); behavioral WI-5..9. Each WI = one PR.
+
+**Dependency notes (audit HIGH — v1's graph was wrong):**
+- WI-3 depends on WI-1 (+2). WI-4 depends on WI-1+WI-3. WI-6 depends on WI-5. So WI-1..4 are NOT all independent — the graph below states the real edges.
+- **`Deps: [feat:#134, feat:#132]`** (transitively #129, #118) — box F is not yet decomposed (per `docs/parity/android-checklist.md`, box F "likely splits into ≥2 features: TOC/bookmarks; find-in-book; more-menu/details/share"); **#132 = the top-chrome sub-feature, #134 = the More-menu sub-feature** are the prospective box-F IDs this plan reserves. **#131's UI entry-point WIs (the pill mount + the More-menu toggle wiring) cannot ship until box F provides those surfaces.** The pipeline + setup sheet + interlinear render (WI-0..7) are built ahead; only the entry wiring (part of WI-9) waits on box F.
+- **Host-integration WIs are gated on #129's FINAL merge** — #129 owns `TxtReaderActivity`/`ReaderBottomChrome`; #131's `TxtReaderActivity` edit must land on top of #129's TXT/MD typography WIs (rule 48 one-writer-per-file).
+
+**WI-0 (spike): Readium EPUB bilingual injection.** The harness in §3 (enumerate / inject+clear / re-apply on reflow / pagination + count-divergence measurement). Output: a go/no-go on EPUB-in-v1 + the concrete `EpubChapterTextProvider` + injection-adapter surface. Deps: none (uses the existing #106 Readium host). Not TDD-gated (throwaway spike); its findings feed WI-7b's plan.
+
+**WI-1 (foundational): value types + pure segmentation/chunk/contract.** `TranslationUnitId`, `TranslationGranularity`, `BilingualLanguages`, `ChapterSegmenter`, `TranslationChunker`, `TranslationChunkContract`, `ChapterTranslationError`. Pure; ported iOS vectors. No Android deps. Deps: none.
+
+**WI-2 (foundational): Room translation cache.** `ChapterTranslationEntity` (PK = `lookupKey`) + `Dao` (`@Upsert`) + `ChapterTranslationStore`; `VReaderDatabase` migration (number at slot). Robolectric migration round-trip + upsert/get/delete-by-lookupKey + FK-CASCADE + exact-DDL guard. Deps: none.
+
+**WI-3 (foundational): `ChapterTranslationService`** against a fake `AiClient`. `cachedTranslation` (cache-only) + `translate` (per-chunk `chat`, per-segment decode-fail fallback, per-chunk graceful degrade, cancellation between chunks + before write, cache-write only on full success). Deps: **WI-1, WI-2**. Tests: cache hit → zero client calls; miss → translate + write; decode fail → per-segment fallback; one-chunk fail → source-only that chunk (others translated, NOT cached); all-chunks fail → throw; cancellation → `Cancelled` (no write); `AiError` mapping incl. `Config`/`InsecureUrl` → `ProviderFailed`.
+
+**WI-4 (foundational): `ChapterTextProvider` (TXT/MD) + `ChapterTranslationPrefetcher` + `BilingualAiReadiness`.** Provider slices per chapter from `TxtDocument`; `unitContaining`/`unitAfter`. Prefetcher resolves active profile from `snapshot()`, decrypts snapshot-consistent, builds client via the **injected factory param** (default `AiProviderFactory::create`), constructs `AiRequest` from the profile, cache-first then translate. Readiness = active profile with non-empty decrypted key; **cipher failure → not-ready, never a crash.** Fake store + fake factory. Deps: **WI-1, WI-3**. Tests: unit resolution + clamp + empty; cache-hit-no-profile still returns (#306); no-profile miss → `ProviderFailed`; readiness true/false; cipher-throw → readiness false (no crash).
+
+**WI-5 (behavioral): `PerBookBilingualStore` + `BilingualViewModel` state core.** Store per book (enabled/targetLanguage/granularity — no style); VM setters (persist + first-enable `needsSetupSheet`), language/granularity change clears cache-shaped state + bumps generation, the state fields. Turbine tests: first-enable raises sheet; re-enable persisted does not; disable clears; language change resets; granularity change resets + re-keys; round-trip through store. Deps: **WI-1** (+ store).
+
+**WI-6 (behavioral): VM prefetch trigger + generation/cancellation.** `onPositionChanged` derives current unit, dedupes, prefetches current+next; a **monotonic position-request sequence** checked after every suspension; **per-unit generation tokens**; a **captured language/granularity/provider snapshot per launch**; generation bumps on disable/language/granularity/unit-change discard stale; `CancellationException` handled BEFORE generic error mapping; `Offline`→`unavailableUnits`; transient failure leaves unit unfetched + clears anchor to retry; `retryUnit`. Fake prefetcher. Deps: **WI-4, WI-5**. Tests: current+next on unit change; same-unit no-op; cancel-mid discards stale; offline→unavailable; failure→retry-able; `retryUnit` re-fetches; granularity change cancels + re-fetches under the new key.
+
+**WI-7a (behavioral): Compose UI — setup sheet + interlinear body + pill.** Reproduce `vreader-bilingual.jsx` (setup sheet: language grid / granularity / preview / engine strip configured+unconfigured; body: translated / loading N%+dimmed / error+Retry / offline source-only; pill). Light+dark. Compose UI tests each state. Deps: **WI-5** (state shape). NO Style control; the unconfigured "Set up" CTA renders but its nav target is design-gated (§3).
+
+**WI-7b (behavioral): EPUB render adapter** (only if WI-0 = go). The JS enumerate/inject adapter + `EpubChapterTextProvider`, wired into `ReaderActivity`, driving `BilingualInterlinearBody` state from injected content. Deps: **WI-0, WI-3, WI-4, WI-7a**. Connected test on a real EPUB (seeded cache): enable → interlinear injects; disable → nodes cleared; reflow/href-change re-applies. (If WI-0 = no-go, this WI is dropped and box D ships TXT/MD-only, tracked.)
+
+**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into `TxtBody` loop + position-change + setup-sheet + DI (incl. adding `AiProviderStore` to `AppContainer`). `originalFormat`-gated (TXT/MD). **Gated on #129's final merge.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; disable → source-only byte-parity; reopen persists enabled + renders from cache with zero client calls. Deps: **WI-6, WI-7a, #129 final**.
+
+**WI-9 (behavioral): entry wiring + acceptance.** Mount `BilingualPill` in box F's top chrome; wire the More-menu bilingual toggle (box F) to the VM. **Gated on `feat:#132` (top chrome) + `feat:#134` (More menu).** Full acceptance pass across EPUB (if WI-7b landed) + TXT/MD. Flip box D note; update `docs/architecture.md` (bilingual pipeline + the new `chapter_translations` schema + `AiProviderStore` now in `AppContainer`). → DONE. Deps: **WI-8, WI-7b (if go), feat:#132, feat:#134**.
+
+## 5. Test catalogue
+
+JVM/Robolectric (`android/app/src/test/...bilingual/`): `ChapterSegmenterTest` (paragraph blank-line; sentence CJK 。！？ vs Latin; empty→[]; single); `TranslationChunkerTest` (packs to budget; oversize→own chunk+subSplit; empty→[]); `TranslationChunkContractTest` (prompt per style-constant; strict JSON decode; code-fence strip; count mismatch→`CountMismatch`; non-array→`NotAStringArray`); `ChapterTranslationServiceTest` (cache hit 0 calls; miss→translate→write; decode-fail per-segment fallback; one-chunk-fail partial-not-cached; all-fail→throw; cancellation→Cancelled no write; ensureActive-before-write; offline/timeout/429/http/config/insecure→error mapping; very long chapter N-of-M; stale-cache count-mismatch re-translates); `ChapterTranslationErrorMappingTest`; `TxtChapterTextProviderTest` (resolution; clamp-past-end; empty; unitAfter end→null); `ChapterTranslationPrefetcherTest` (snapshot-consistent profile+key; injected-factory used; `AiRequest` built from profile; cache-hit-no-profile #306; no-profile miss→ProviderFailed; CJK↔English + Latin round-trip via fake; cipher-throw→ProviderFailed not crash); `BilingualAiReadinessTest` (active+key→true; no active→false; empty key→false; **cipher-throw→false, no crash**); `PerBookBilingualStoreTest` (enabled/lang/granularity round-trip; no style field); `BilingualViewModelTest` (Turbine: first-enable sheet; re-enable no-sheet; disable clears; language reset; **granularity reset + re-key**; prefetch current+next; same-unit no-op; cancel-mid discards; offline→unavailable; error→errorUnit+retry; `retryUnit`; generation bump on style-N/A—granularity change).
+
+Room migration: `VReaderDatabaseMigrationTest` (extend) vPrev→vNext + full-chain + FK-CASCADE + `lookupKey`-as-PK; `ChapterTranslationDaoTest` (upsert-by-PK replaces; get/delete-by-lookupKey).
+
+Compose UI (`androidTest/...bilingual/`): `BilingualSetupSheetUiTest` (language grid, granularity, preview, engine configured vs unconfigured; **no Style control present**; light+dark); `BilingualInterlinearBodyUiTest` (translated incl. CJK font + RTL Arabic; loading N%+dimmed; error+Retry; offline source-only; empty translation→source-only no crash); `BilingualPillUiTest`.
+
+Connected (`androidTest/...reader/`): `TxtReaderBilingualConnectedTest` (API 35, fake `AiClient` via injected factory): enable→setup→confirm→interlinear from seeded Room cache; disable→source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; TXT/MD gated (PDF inert); very long chapter scroll responsive; cancellation leaves no partial cache row. `EpubReaderBilingualConnectedTest` (only if WI-0=go): enable→inject on a real EPUB; disable→clear; href-change→re-apply; count-divergence handled.
+
+Edge cases: empty translation, failed, partial per-chunk, CJK↔English + Latin + RTL, provider error/timeout/429/config/insecure, cancellation mid-translation + before-write, very long chapters, offline (cache-first + silent source-only), cipher-decrypt failure → not-ready (no crash).
+
+## 6. Risks + mitigations
+
+- **Live-translation verification is AI-credential-gated (the box-D caveat).** The whole pipeline is verified without live creds via a deterministic **fake `AiClient`** injected through the prefetcher's `clientFactory` param (default `AiProviderFactory::create`; tests override). WI-3/4/8 prove segment→chunk→decode→cache→interleave end-to-end incl. every error/edge path. The connected test seeds the Room cache directly and asserts render-from-cache with zero client calls (render path proven offline). **This mock/integration path is the box-D-required verification path** (the checklist states live translation is credential-gated); an optional live smoke confirms wire format but is NOT a gate.
+- **Acceptance proves BOTH cache-render AND the live pipeline path (via the fake).** WI-8's connected test drives the full enable→translate(fake)→cache→render→reopen cycle, not just cache rendering — the fake stands in only for the network leaf.
+- **EPUB JS-injection unknowns.** WI-0 de-risks before the render WI: pagination shift, fragment recreation wiping nodes, enumerate-vs-`ChapterSegmenter` count divergence (iOS #268). If a hard blocker appears, EPUB drops to a tracked follow-up (phasing fallback) with the specific spike reason — never the false "requires a fork."
+- **Concurrency (audit HIGH — was under-specified).** WI-6 adds: a monotonic position-request sequence checked after every suspension; per-unit generation tokens; a captured language/granularity/provider snapshot per launch; cancellation on granularity change; `CancellationException` handled BEFORE generic error mapping; `ensureActive()` immediately before the Room write; cipher/decrypt failures mapped to unconfigured/provider-failure (never a crash). Snapshot-consistent profile+key pairing (from one `snapshot()`) is preserved.
+- **Segment↔render count divergence** (iOS Bugs #268/#330/#344). TXT/MD segment through the SAME `ChapterSegmenter` on translate + render sides, so 1:1 pairing holds by construction; granularity is in the cache key so a paragraph row is never read as sentences. EPUB uses WI-0's finding (direct-block path if enumerate diverges — iOS `translatePreSegmented` parity).
+- **Cost/latency of translating on scroll.** Lazy current+next prefetch + disk cache; N-of-M progress; cancellation on navigate-away/generation-bump.
+- **Provider JSON non-compliance.** `TranslationChunkContract.decode` + per-segment fallback (iOS parity) — never drops a paragraph.
+- **DataStore per-book key growth.** One Preferences entry per book keyed by fingerprint; scales like `ReaderSettingsStore`/`AiProviderStore`.
+
+## 7. Backward compat
+
+- **Room migration additive** (new `chapter_translations`, FK CASCADE, `lookupKey` PK). Existing rows untouched; migration + structural test guard it. Version number allocated at the merge slot (v5 today → v6).
+- **Reader unchanged when bilingual off** — `TxtBody` render loop byte-identical unless `enabled && format∈{txt,md} && translation present`. `ReaderBottomChrome` is **not modified** (v1's Translate slot removed), so #129's chrome is unaffected. EPUB render adapter is inert unless bilingual is on.
+- **#118 AI provider files unchanged** — the prefetcher/readiness are new consumers; the only #118-adjacent change is *wiring* `AiProviderStore` into `AppContainer` (which #118 left unwired — it was component/round-trip-verified, not nav-integrated).
+- **Backup contract already compatible** — `PerBookSettingsOverride.bilingualEnabled/TargetLanguage/Granularity` exist (verified; **no `bilingualStyle`**), and there is **no translation-cache section** in `contracts/vectors/backup-sections.json` (verified — the cache is device-local, re-derivable). v1 introduces the store that writes the three fields locally; backup collect/restore of them is a small additive follow-up (no contract change), out of v1 scope; until then bilingual config is device-local (safe default). The `PerBookBilingualStore` is confirmed device-local; backup-collect/restore is the scoped-out follow-up.
+
+## Design gates (rule 51 — for `needs-design` filing)
+
+1. **"Bilingual mode" setup sheet with BOTH Style AND Granularity in one Android sheet** — `vreader-bilingual.jsx` depicts Granularity (no Style); `vreader-ai-android.jsx` depicts Style (no Granularity); no committed bundle shows both together. v1 reproduces the granularity-only `vreader-bilingual.jsx` sheet and DROPS Style. If Style is wanted as an Android user control, file `Design needed: bilingual setup sheet (Style + Granularity) for feature #131`. **This is the one open design gate for #131.**
+2. **Dependency gate (not a #131 design gate, but blocks the "Set up" affordance)** — the setup sheet's unconfigured "Set up" CTA has no live nav destination (`AiProviderListScreen` is unreachable in-app today; no `#119`). #131 does not invent it (box-F chrome / #118 follow-on); the CTA renders but is wired only once that route ships.
+
+## Revision history
+
+- v1 (2026-07-10): Gate-1 draft (Plan agent). Gate-2 Codex audit pending.
+- v2 (2026-07-11): Gate-2 round-1 REDESIGN resolved — Readium-feasibility corrected, entry-point rebased on box F, setup-sheet design-gated, DI/cache/concurrency fixed.
+
+codex
+The worktree is clean for tracked files, with unrelated untracked files already present; I will not touch them. The combined read was truncated, so I’m rereading the 217-line plan in bounded chunks and then mapping its claims to the live Android implementation.
+exec
+/bin/zsh -lc "sed -n '1,120p' dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md && sed -n '121,240p' dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md && rg -n \"Android|EpubNavigatorFragment|ReaderActivity|AiProviderStore|ChapterSegmenter|chapter_translations|VReaderDatabase\" docs/architecture.md" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+# Feature #131 — Android Bilingual Interlinear Reading (parity-checklist box D)
+
+**Feature number assumption:** highest active row in `docs/features.md` is `#130`; `#131` is the next free number. The orchestrator adjusts if a row is claimed first.
+
+**Design authority (rule 51):** the **authoritative** bilingual surfaces are in `dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx` (`BilingualSetupSheet` / `BilingualPageContent` / `BilingualPill` / `BILINGUAL_LANGS`) and `.../vreader-reader.jsx` (`ReaderTopChrome` renders `BilingualPill`; the bilingual toggle is a More-menu row via `onMoreAction`) and `.../vreader-more.jsx` (the "Bilingual mode" More-menu Row toggle). `.../vreader-ai-android.jsx` contains a SECOND, differently-shaped `BilingualSetupSheet` — see §3's setup-sheet resolution for why this plan reproduces the `vreader-bilingual.jsx` sheet and design-gates the divergence. Where a surface is NOT depicted it is scoped out and flagged.
+
+**Status:** Gate-1 draft v2 (2026-07-11) — Gate-2 round-1 REDESIGN resolved. Awaiting Gate-2 round-2 audit.
+
+## 1. Problem
+
+iOS ships bilingual interlinear reading (#56/#100): a per-book toggle renders each source paragraph followed by its translation in a muted style, backed by an AI provider, cached to disk. Android shipped the #118 AI provider foundation (provider store, OpenAI-compat + Anthropic SSE clients, chat/summary) but has **no bilingual capability**. Box D of the parity checklist requires the interlinear renderer + the bilingual setup sheet, building on #118.
+
+The engineering questions are (a) **which render host(s)** get true interlinear, and (b) **where the entry point lives**. Both were mis-analysed in v1 and are corrected here:
+
+- **Host** — v1 claimed EPUB interlinear is "infeasible inside Readium's navigator." **That is FALSE** (§3): `EpubNavigatorFragment.evaluateJavascript(script): String?` is a public suspend method in the shipped Readium 3.3.0 AAR (verified via `javap` — see §3), so the app CAN inject and clear translation DOM nodes in Readium's WebView. EPUB is therefore the **primary** target (it is the app's main reading format). TXT/MD are still built but as a phased choice, not because EPUB requires a fork.
+- **Entry point** — v1 put the toggle in the bottom chrome. **The design puts it in the More-menu + a top-chrome pill** (`vreader-more.jsx`, `vreader-reader.jsx`), which are box-F surfaces — so #131's UI *entry wiring* depends on box F (§2, §4).
+
+## 2. Surface area
+
+### Render-host decision (corrected — see §3 for the full analysis)
+
+**v1 targets TWO hosts, in dependency order:**
+
+1. **EPUB (Readium `EpubNavigatorFragment`) — PRIMARY.** Interlinear IS feasible via `evaluateJavascript` (enumerate leaf blocks → inject translation nodes → clear on teardown/reflow), exactly mirroring iOS `EPUBBilingualOrchestrator`. This is validated first by **WI-0 (a Readium bilingual spike)** before the render WI is planned in detail, because JS injection into a navigator the app does not own has real unknowns (reflow, href changes, fragment recreation, pagination interaction).
+2. **TXT/MD (Compose `TxtReaderActivity`) — INCLUDED.** Trivially injectable (a translation `Text` after each source chunk in the confirmed `items(count = document.chunkCount)` loop, which already interleaves highlight + TTS spans). No WebView; deterministically Compose-testable.
+
+**AZW3 (foliate WebView)** and **PDF** remain follow-ups / out (§"Files OUT of scope").
+
+**Why both, not TXT/MD-only:** the honest thesis is that the *pipeline* (segment → chunk → translate → cache → interleave) is host-agnostic and fully built in v1; only the *render injection* is host-specific. EPUB is the format most users read, so shipping box D without it would under-deliver on the visible capability. TXT/MD are included because the Compose host is the cheapest, most testable place to prove the pipeline end-to-end (no WebView, deterministic tree assertions) — it de-risks the EPUB render adapter. This is not the box-B/E "one host and check the box" split; box D ships EPUB + TXT/MD together, with AZW3/PDF as tracked follow-ups. **Box D cannot be checked on the false "EPUB requires a fork" rationale** — that rationale is discarded.
+
+### New files
+
+**Pipeline / domain (host-agnostic, pure or coroutine — JVM-testable):**
+
+- `bilingual/TranslationUnitId.kt` — `data class TranslationUnitId(kind, value)` with `enum Kind { epubHref, foliateHref, txtChapterIndex, mdChapterIndex, pdfPageRange }`; `storageKey = "${kind.name}:$value"`. Mirrors iOS `TranslationUnitID.Kind` (verified: same five cases). v1 uses `epubHref` + `txtChapterIndex`/`mdChapterIndex`; others reserved so the cache-key format never breaks.
+- `bilingual/TranslationGranularity.kt` — `enum { paragraph, sentence }`. (Design's Granularity segment.)
+- `bilingual/BilingualLanguages.kt` — `BilingualLanguage(key, glyph, script)`; `BILINGUAL_LANGS` = the set from `vreader-bilingual.jsx` (`BILINGUAL_LANGS`) + `findOrDefault(key)`. Default `Chinese`.
+- `bilingual/ChapterSegmenter.kt` — `paragraphs(text)` / `sentences(text)`. Port of iOS `ChapterSegmenter.paragraphs(in:)`/`sentences(in:)` (verified exists, CJK-aware via sentence enumeration).
+- `bilingual/TranslationChunker.kt` — `chunk(segments, maxCharsPerChunk)` + `subSplit(text, maxChars)`. Port of iOS `ChapterTranslationChunker.chunk(...)` + `subSplit(...)` (verified: `chunk` returns `[[Int]]` index groups, oversize segment gets its own chunk; `subSplit` is the Bug #330 grapheme-safe over-budget splitter).
+- `bilingual/TranslationChunkContract.kt` — `userPrompt(segments, targetLanguage, style)`; `decode(raw, expectedCount)` (strict JSON-array + code-fence strip); `sealed class DecodeError { NotAStringArray; CountMismatch(expected, actual) }`. Port of iOS `TranslationChunkContract` (verified: same `userPrompt`/`decode` shape, same two DecodeError cases).
+- `bilingual/ChapterTextProvider.kt` — `interface { units(); sourceText(unit); unitContaining(locator); unitAfter(unit) }`. Resolution key is host-specific: TXT/MD key on `charOffsetUtf16` (Android `Locator` is offset-based there); EPUB keys on the current-resource `href` from `EpubNavigatorFragment.currentLocator`. Honest divergence from iOS's uniform Readium `Locator`, documented.
+- `bilingual/TxtChapterTextProvider.kt` — provider over `TxtDocument` + chapter model. MD source = raw markdown chapter (translation renders as plain muted text, not re-markdown-rendered — matches the muted-secondary design line).
+- `bilingual/EpubChapterTextProvider.kt` (WI-0-gated shape) — provider over the Readium `Publication` reading order; `units()` = spine hrefs, `unitContaining(locator)` = the locator's href. Its render-side collaborator (the JS enumerate/inject adapter) is defined by WI-0's findings, not pre-committed here.
+- `bilingual/ChapterTranslationError.kt` — `sealed { Offline; TimedOut; ProviderFailed(msg); Cancelled }`. Maps from `AiError` (verified cases: `Auth401`, `RateLimited429`, `Offline`, `Timeout`, `Http(code)`, `Decode`, `Stream`, `InsecureUrl`, `Config`).
+- `bilingual/ChapterTranslationService.kt` — `cachedTranslation(...)` (cache-only, no provider — #306 parity: a cached chapter renders even when AI is later unconfigured); `translate(...)` (segment → chunk → per-chunk `AiClient.chat` one-shot → `decode` → per-segment fallback → graceful per-chunk degrade (Bug #330 parity: a single failed chunk renders source-only and is NOT cached; all-chunks-fail throws) → cache-write only on full success). Uses `AiClient.chat(AiRequest)` (one-shot, NOT `streamChat`). Cancellation: `ensureActive()` between chunks AND immediately before the Room write (§6).
+- `bilingual/ChapterTranslationPrefetcher.kt` — resolves the active profile from one `AiProviderStore.snapshot()` (`snapshot.active`), decrypts via `store.apiKey(profile)` (snapshot-consistent), builds an `AiClient` via an **injected factory param** (see the DI correction below), cache-first then translate. Throws `ChapterTranslationError`. Mirrors iOS `ChapterTranslationPrefetcher` (verified: iOS snapshots the active profile after a cache miss and is a Sendable struct capturing its collaborators).
+- `bilingual/BilingualAiReadiness.kt` — `resolve(snapshot): Boolean` (active profile exists AND its decrypted key is non-empty). A cipher/decryption failure maps to **not-ready** (never crashes — §6), not to a thrown error. Drives the setup-sheet engine-strip configured/unconfigured state. Keep the gate to exactly what #118 enforces (no separate consent manager on Android — #118 has none; confirm during build).
+
+**State / persistence:**
+
+- `bilingual/PerBookBilingualStore.kt` — DataStore-Preferences, keyed by `bookFingerprintKey`, holding `{ enabled, targetLanguage, granularity }`. This is the Android `PerBookSettingsOverride` bilingual slice — the backup contract declares exactly `bilingualEnabled` / `bilingualTargetLanguage` / `bilingualGranularity` (verified in `PerBookSettings.swift` and the Android `BackupSectionsExtended.kt`), and **NO `bilingualStyle`** (verified — style is not a persisted per-book field on iOS either). So this store writes exactly those three fields. Wiring into backup collect/restore is scoped OUT (§7) — additive later, fields already in the contract; until then bilingual config is device-local.
+- `bilingual/BilingualViewModel.kt` — `StateFlow<BilingualUiState>` with `enabled`, `targetLanguage`, `granularity`, `needsSetupSheet`, `aiConfigured`, `translationsByUnit`, `inFlightUnits`, `unavailableUnits`, `errorUnit`. Setters + `dismissSetupSheet`, `onPositionChanged(locator)`, `retryUnit(unit)`. Generation/epoch-guarded prefetch (current + next unit), cancellation on disable / language / granularity change — port of iOS `BilingualReadingViewModel` + `+Prefetch` (verified both exist). Split to `BilingualPrefetchController.kt` if it nears ~300 lines. (No `style` field — the authoritative sheet has no Style control; see §3.)
+
+**Room (translation cache):**
+
+- `data/ChapterTranslationEntity.kt` — `@Entity(tableName="chapter_translations", indices=[Index("bookKey")], foreignKeys=[FK→books.fingerprintKey ON DELETE CASCADE])`. **`@PrimaryKey val lookupKey: String`** (Room REQUIRES a primary key; a "unique index without a PK" does not compile — verified against `HighlightEntity`, which pairs a `@PrimaryKey` with a separate unique index). `lookupKey` = `bookKey|unitStorageKey|targetLanguage|promptVersion` (see the cache-identity correction below). Other columns: `bookKey`, `unitStorageKey`, `targetLanguage`, `promptVersion`, `translatedJson`, `sourceParagraphCount`, `createdAt`. Mirrors iOS `ChapterTranslationRecord.lookupKey` (verified: iOS key is `book|unit|lang|prompt`, profile-agnostic — Bug #342).
+- `data/ChapterTranslationDao.kt` — `getByLookupKey(key)`, `@Upsert suspend fun upsert(row)` (Upsert identifies by PK = `lookupKey`, so it is a correct insert-or-replace by the cache identity), `deleteByLookupKey(key)`. The project's Room pattern is `@PrimaryKey` + `@Upsert` (verified: `BookDao.upsert`); making `lookupKey` the PK is exactly that pattern.
+- `bilingual/ChapterTranslationStore.kt` — coroutine wrapper returning a Sendable `CachedTranslation` (segments decoded from JSON), keeping Room entities off the boundary (the `AnnotationsRepository`/`HighlightRecord`/iOS `ChapterTranslationStore` precedent).
+
+**Cache-identity correction (audit HIGH — reconciled with iOS parity):** the audit asked to add granularity + style as key columns. iOS deliberately does the opposite — `ChapterTranslationRecord.lookupKey` is `book|unit|lang|promptVersion` and is profile-AGNOSTIC / granularity-AGNOSTIC / style-agnostic (Bug #342's fix was to *remove* dimensions from the key). Style is folded into the prompt content; granularity is a read-time count-check. **Resolution honoring both the audit's concern and iOS parity:** keep the 4-part key, but make `promptVersion` an **effective composite** that encodes the result-shaping inputs, e.g. `promptVersion = "bilingual-v1|g=${granularity}|s=${style}"` (iOS uses the literal `"bilingual-v1"` today because iOS forces `.paragraph` for bilingual and pins one style; Android carries granularity/style in the promptVersion string so a change re-keys correctly). Style is not a v1 user control (the authoritative sheet has none — §3), so `s=` is a constant this version; granularity IS user-selectable, so `g=` is load-bearing (a paragraph vs sentence translation is a different cache row — this also closes the iOS #344 "sentence silently ignored" class by construction). **Additionally** (audit's cancellation half): a granularity change must cancel in-flight jobs, bump the VM generation, clear shaped in-memory `translationsByUnit`, and force a correctly-keyed re-fetch — specified in WI-6.
+
+**DI / factory correction (audit HIGH):** the audit is right that `AiProviderFactory` is NOT a lambda — verified it is an `object` with `create(profile: AiProviderProfile, apiKey: String, dispatcher: CoroutineDispatcher = Dispatchers.IO): AiClient`. So `ChapterTranslationPrefetcher` takes its OWN injected `clientFactory: (AiProviderProfile, String) -> AiClient` param **defaulting to `AiProviderFactory::create`** (production) and overridden with a fake in tests. The prefetcher builds the exact `AiRequest(model = profile.model, messages = …, temperature = profile.temperature, maxTokens = profile.maxTokens, system = …)` from the resolved profile (verified `AiRequest` fields).
+
+**AppContainer / navigation correction (audit HIGH — genuine gap, NOT stale state):** verified against the real code — `AppContainer` does **NOT** provide `AiProviderStore` today, and there is **NO live navigation route to `AiProviderListScreen`** (MainActivity has no NavHost; the screen + store + `AiSettingsViewModel` exist from #118 but are only exercised by instrumented/round-trip tests — #118 was VERIFIED via component tests + a live SSE socket round-trip, not an in-app nav route). There is no `#119` row. Consequences for #131:
+- #131 **adds `AiProviderStore` to `AppContainer`** (lazy singleton: DataStore + `KeystoreSecretCipher`, the #116/#118 pattern) — the prefetcher + readiness need it and nothing provides it yet.
+- The setup-sheet unconfigured engine strip's **"Set up" CTA target does not exist in the running app.** #131 does NOT invent an AI-provider settings screen or its navigation (that is box-F chrome / a #118 follow-on, and inventing it violates rule 51). Until a live route to `AiProviderListScreen` ships, the "Set up" affordance is **design-gated** — see §3's design-gate list. #131 can ship the bilingual sheet's *configured* path (a provider already set via the tested path) end-to-end; the *unconfigured → Set up* nav is a stated dependency, not #131 scope.
+
+**UI (Compose — every state depicted, reproducing `vreader-bilingual.jsx`):**
+
+- `bilingual/BilingualSetupSheet.kt` — reproduces `vreader-bilingual.jsx`'s `BilingualSetupSheet` EXACTLY: header Cancel / Translate; a **preview strip**; a **language grid** over `BILINGUAL_LANGS` (glyph tiles, selected accent); a **Granularity** segmented control (Paragraph "Translate after each ¶" / Sentence "Translate after each sentence"); a **Translation engine** strip (configured: "Claude · with this book's context" + "Change…"; unconfigured: "No AI provider configured" + "Set up"). **No Style control, no provider/model card, no term-overrides toggle, no cost footer** — those belong to the *other* (`vreader-ai-android.jsx`) sheet, which this plan does not reproduce (§3).
+- `bilingual/BilingualInterlinearBody.kt` — per source chunk/paragraph: source `Text` then translation `Text` muted with accent left-border, `fontSize*0.88`, CJK font for cjk scripts, RTL handling for Arabic script. Consumes `translationsByUnit`. Loading state ("Translating chapter… N%" + per-paragraph dim — matches the design's chapter-level "38%"). Error state ("Couldn't translate" + Retry). Partial/offline (`unavailableUnits`): source-only silent fallback (design's original-always-kept guarantee — iOS Decision 2). This is the render surface for BOTH the TXT/MD Compose loop and (via the WI-0 adapter) the EPUB injection payload's Kotlin-side state.
+- `bilingual/BilingualPill.kt` — the `EN ↔ 中` reader-**top-chrome** pill (per `vreader-reader.jsx` `ReaderTopChrome` + `vreader-bilingual.jsx` `BilingualPill`). Rendered by box F's top chrome; #131 provides the composable, box F wires it in (§4).
+
+### Modified files
+
+- `data/VReaderDatabase.kt` — add `ChapterTranslationEntity`, bump `version` (allocated version-at-slot; **v5 today** — verified, so v5→v6, but the number is set at the merge slot, not pre-assigned), add `MIGRATION_5_6` (CREATE TABLE + `bookKey` index + FK CASCADE, DDL exactly matching Room's generated schema), append `ALL_MIGRATIONS`, add `abstract fun chapterTranslationDao()`.
+- `reader/TxtReaderActivity.kt` — own a `BilingualViewModel`; collect state; pass into `TxtBody`; on position change call `vm.onPositionChanged(...)`; render `BilingualInterlinearBody` output in the `items(count = document.chunkCount)` loop when bilingual is on and a translation exists (the confirmed injection point — verified it already interleaves highlight washes + TTS spans per chunk). Strictly gated to `originalFormat ∈ {txt, md}`; disabled = body byte-unchanged. **This file overlaps #129's TXT/MD WIs → gated on #129's FINAL merge (§4).**
+- `reader/ReaderActivity.kt` (Readium EPUB) — WI-0-gated: attach the JS enumerate/inject adapter to `navigator.evaluateJavascript`, re-apply on href change / reflow, clear on teardown. Concrete surface defined by WI-0's spike output.
+- `VReaderApp.kt` / `AppContainer` — **provide `AiProviderStore`** (new — see the AppContainer correction), `ChapterTranslationStore`, `PerBookBilingualStore`, and a `BilingualViewModel` factory. Mirrors #116/#118/#122 DI.
+
+**NOT modified (audit HIGH — Translate slot removed):** `reader/chrome/ReaderBottomChrome.kt` gets **no** bilingual/Translate slot. v1 wrongly added `onOpenBilingual` there; the design's entry is the More-menu toggle + the top-chrome pill (box F), NOT a bottom-chrome slot. `ReaderBottomChrome`'s existing `extraSlot` (the #129/#121 read-aloud entry) is untouched.
+
+### Files OUT of scope for v1
+
+- **`Azw3ReaderActivity.kt` / `reader/foliate/`** — foliate WebView interlinear IS feasible (JS enumerate+inject in the pinned bundle, mirroring iOS `FoliateBilingualOrchestrator`) but deferred to a follow-up (bundle-patch JS + secure-bridge additions touching the security-sensitive #126 surface). Once WI-0 proves the EPUB JS pipeline, the foliate host reuses it with a bundle adapter.
+- **`PdfReaderActivity.kt`** — no reflowable text layer. Out (the `pdfPageRange` Kind is reserved only).
+- **Live AI-provider settings navigation / the "Set up" destination screen** — box-F chrome / #118 follow-on; #131 does not invent it (rule 51). Design-gated dependency (§3).
+- **Backup collect/restore of `PerBookSettingsOverride` bilingual fields** — contract fields exist; wiring is a small additive follow-up (§7). Bilingual config is device-local until then.
+- **"Translate entire book…" batch, re-translate/style-swap picker, cost/token estimation, term-overrides** — iOS/`vreader-ai-android.jsx` extras not in the authoritative `vreader-bilingual.jsx` sheet. Out.
+- **Streaming translation progress** — the design's "38%" is chapter-level N-of-M chunk progress (from the chunker count), not token streaming. v1 shows N-of-M.
+
+## 3. Prior art / project precedent / rejected alternatives
+
+### The render-host decision (analysis — CORRECTED from v1)
+
+**How iOS does interlinear:** iOS renders EPUB/AZW3 in a WKWebView it fully controls. `EPUBBilingualOrchestrator` injects JS that (1) enumerates leaf blocks (`<p>/<li>/<blockquote>`) posting `[{bid,text}]` to Swift, (2) after translation injects a translation node after each block. TXT/MD render in a `UITextView`/attributed-string path where the renderer interleaves translation runs. The mechanism = **the app inserts translation nodes between source nodes.**
+
+**Android host-by-host injectability — the v1 verdict was WRONG for EPUB:**
+
+| Host | Layout tree owner | Content-insertion API | Interlinear feasible? |
+|---|---|---|---|
+| **Readium EPUB** (`EpubNavigatorFragment`) | Readium (internal WebView) | **`evaluateJavascript(script): String?`** is PUBLIC on the fragment (shipped 3.3.0 AAR) → arbitrary DOM read/write. Plus `currentLocator` (href), `firstVisibleElementLocator`, decorations (Highlight/Underline over existing text). | **YES — via JS injection** (not just decorations) |
+| **TXT/MD Compose** (`TxtReaderActivity`) | The app (`LazyColumn` over chunks) | Trivial — a translation `Text` after each source `Text` in the confirmed `items{}` loop | **YES** |
+| **AZW3 foliate** (`FoliateBridge` WebView) | The app (pinned foliate-js bundle) | Full DOM control via the bridge (same as iOS) | YES, but needs bundle-JS → follow-up |
+
+**Verification of the CRITICAL correction:** `javap -public org.readium.r2.navigator.epub.EpubNavigatorFragment` against the resolved AAR (`~/.gradle/caches/.../readium-navigator/3.3.0/.../readium-navigator-3.3.0.aar`) prints:
+```
+public final java.lang.Object evaluateJavascript(java.lang.String, kotlin.coroutines.Continuation<? super java.lang.String>);
+public kotlinx.coroutines.flow.StateFlow<org.readium.r2.shared.publication.Locator> getCurrentLocator();
+public java.lang.Object firstVisibleElementLocator(kotlin.coroutines.Continuation<...>);
+```
+i.e. `suspend fun evaluateJavascript(String): String?` exists. The app already holds the concrete fragment as `ReaderActivity.navigator` (it uses it for decorations/selection in #123). So EPUB interlinear via JS injection is feasible with the public API — **no Readium fork.** The v1 "infeasible inside Readium's navigator" rationale is discarded.
+
+**Chosen: EPUB (Readium JS-injection) as the PRIMARY host + TXT/MD (Compose) included.** WI-0 spikes the EPUB path first (it has the real unknowns); the Compose host is built alongside as the deterministic pipeline proof. AZW3/PDF deferred.
+
+**WI-0 — Readium bilingual spike (new, gates the EPUB render WI):** a throwaway harness that, against a real EPUB on the emulator, proves:
+- (a) **enumerate** current-resource leaf blocks via `navigator.evaluateJavascript(enumScript)` returning a JSON `[{id,text}]` array (parse the `String?` result);
+- (b) **inject** translation DOM nodes after each block, and **clear** them, via `evaluateJavascript`;
+- (c) **re-apply** after `currentLocator` href changes / reflow / page-fragment recreation (the WebView pager recreates fragments — injection must survive or re-fire);
+- (d) measure effects on **pagination/scroll** (does injecting content re-paginate? does it shift the reader's position?) and whether the **enumerated block count** diverges from `ChapterSegmenter` (the iOS #268 divergence class — if it diverges, adopt iOS's `translatePreSegmented` direct-block path).
+
+If WI-0 shows injection is stable → the EPUB render WI proceeds. If WI-0 surfaces a blocker (e.g. fragment recreation wipes injected nodes with no re-fire hook) → EPUB drops to a tracked follow-up and box D ships on TXT/MD (the phasing fallback), with the honest reason (a specific spike finding), never the false "requires a fork" claim.
+
+**Rejected alternatives:**
+1. **Readium interlinear via decorations only** — REJECTED (insufficient). Decorations style existing text; they cannot insert translation paragraphs. But `evaluateJavascript` (above) makes injection possible without decorations, so EPUB is feasible — it just uses the JS seam, not the decoration seam.
+2. **Forking Readium** — REJECTED + unnecessary (the public `evaluateJavascript` seam exists).
+3. **AZW3 foliate host first** — REJECTED for v1 (deferred, not dead). Feasible + design-aligned, but touches the security-sensitive #126 bridge; EPUB via the same JS-injection mechanism is the higher-value primary.
+4. **Eager whole-book pre-translation** — REJECTED (cost/latency). iOS lazily prefetches current+next + caches — port that.
+
+### The setup-sheet resolution (audit HIGH — rule 51)
+
+There are **two committed, differently-shaped** `BilingualSetupSheet`s:
+- `vreader-bilingual.jsx` → **language grid + Granularity (Paragraph/Sentence) + preview strip + Translation-engine strip (Set up/Change) + Cancel/Translate** header. **No Style, no provider/model card, no term-overrides, no cost.**
+- `vreader-ai-android.jsx` → **Languages (From/To) + Provider (provider/model card) + Style (Literal/Natural/Literary) + Keep-term-overrides toggle + cost footer.** **No language grid, no Granularity, no preview.**
+
+v1 merged both into a **third layout** — a rule-51 violation (self-designed UI). **Resolution:** this plan reproduces the **`vreader-bilingual.jsx` sheet EXACTLY** as the authoritative Android-native bilingual sheet (its language grid + granularity + preview + engine strip + CTA is the coherent bilingual-config surface, and its `BilingualPill`/`BilingualPageContent` are the matching reader surfaces). **Style is dropped from v1** (it is not in the authoritative sheet, and — verified — `bilingualStyle` is not a persisted contract field on either platform). Consequently the store/VM carry no `style`, and `promptVersion`'s `s=` component is a constant (§2 cache-identity correction).
+
+**Remaining design gate (rule 51):** a single Android sheet that offers **BOTH Style AND Granularity** (the union the `vreader-ai-android.jsx` "Style" and `vreader-bilingual.jsx` "Granularity" controls imply) is **not depicted anywhere** — no committed bundle shows both in one sheet. If style is wanted on Android as a user control, that needs an **updated committed design**. This plan does NOT invent it; it files a `needs-design` gate (see the §"Design gates" list) and ships the authoritative granularity-only sheet meanwhile.
+
+### Other precedents applied
+
+- **#118 provider seam**: reuse `AiProviderStore.snapshot()` (`snapshot.active`) + `store.apiKey(profile)` + `AiProviderFactory.create` (as the default of an injected factory param) + `AiClient.chat`. Prefetcher + readiness are the only new consumers; #118's AI files are unchanged; #131 additionally *wires* `AiProviderStore` into `AppContainer` (which #118 never did).
+- **Room additive-migration pattern** (#122/#123/#127): version bump + `MIGRATION_n_(n+1)` + exact-DDL + `VReaderDatabaseMigrationTest` PRAGMA guard. `@PrimaryKey` + `@Upsert` is the project's DAO pattern (`BookDao`).
+- **DataStore JSON-in-Preferences** for `PerBookBilingualStore` (the `ReaderSettingsStore`/`AiProviderStore` pattern).
+- **Pure-logic port**: iOS `ChapterSegmenter`/`ChapterTranslationChunker`/`TranslationChunkContract` are pure + heavily unit-tested — direct Kotlin ports with the same test vectors (all verified to exist).
+- **Entry point via box F**: the More-menu bilingual toggle + top-chrome pill are box-F surfaces; #131 depends on them (§4), mirroring how box B's annotations-review-sheet + bookmark "ride with item F."
+
+## 4. Work-item sequencing
+
+Foundational WI-1..4 (no UI, JVM-testable); a spike WI-0 (EPUB); behavioral WI-5..9. Each WI = one PR.
+
+**Dependency notes (audit HIGH — v1's graph was wrong):**
+- WI-3 depends on WI-1 (+2). WI-4 depends on WI-1+WI-3. WI-6 depends on WI-5. So WI-1..4 are NOT all independent — the graph below states the real edges.
+- **`Deps: [feat:#134, feat:#132]`** (transitively #129, #118) — box F is not yet decomposed (per `docs/parity/android-checklist.md`, box F "likely splits into ≥2 features: TOC/bookmarks; find-in-book; more-menu/details/share"); **#132 = the top-chrome sub-feature, #134 = the More-menu sub-feature** are the prospective box-F IDs this plan reserves. **#131's UI entry-point WIs (the pill mount + the More-menu toggle wiring) cannot ship until box F provides those surfaces.** The pipeline + setup sheet + interlinear render (WI-0..7) are built ahead; only the entry wiring (part of WI-9) waits on box F.
+- **Host-integration WIs are gated on #129's FINAL merge** — #129 owns `TxtReaderActivity`/`ReaderBottomChrome`; #131's `TxtReaderActivity` edit must land on top of #129's TXT/MD typography WIs (rule 48 one-writer-per-file).
+
+**WI-0 (spike): Readium EPUB bilingual injection.** The harness in §3 (enumerate / inject+clear / re-apply on reflow / pagination + count-divergence measurement). Output: a go/no-go on EPUB-in-v1 + the concrete `EpubChapterTextProvider` + injection-adapter surface. Deps: none (uses the existing #106 Readium host). Not TDD-gated (throwaway spike); its findings feed WI-7b's plan.
+
+**WI-1 (foundational): value types + pure segmentation/chunk/contract.** `TranslationUnitId`, `TranslationGranularity`, `BilingualLanguages`, `ChapterSegmenter`, `TranslationChunker`, `TranslationChunkContract`, `ChapterTranslationError`. Pure; ported iOS vectors. No Android deps. Deps: none.
+
+**WI-2 (foundational): Room translation cache.** `ChapterTranslationEntity` (PK = `lookupKey`) + `Dao` (`@Upsert`) + `ChapterTranslationStore`; `VReaderDatabase` migration (number at slot). Robolectric migration round-trip + upsert/get/delete-by-lookupKey + FK-CASCADE + exact-DDL guard. Deps: none.
+
+**WI-3 (foundational): `ChapterTranslationService`** against a fake `AiClient`. `cachedTranslation` (cache-only) + `translate` (per-chunk `chat`, per-segment decode-fail fallback, per-chunk graceful degrade, cancellation between chunks + before write, cache-write only on full success). Deps: **WI-1, WI-2**. Tests: cache hit → zero client calls; miss → translate + write; decode fail → per-segment fallback; one-chunk fail → source-only that chunk (others translated, NOT cached); all-chunks fail → throw; cancellation → `Cancelled` (no write); `AiError` mapping incl. `Config`/`InsecureUrl` → `ProviderFailed`.
+
+**WI-4 (foundational): `ChapterTextProvider` (TXT/MD) + `ChapterTranslationPrefetcher` + `BilingualAiReadiness`.** Provider slices per chapter from `TxtDocument`; `unitContaining`/`unitAfter`. Prefetcher resolves active profile from `snapshot()`, decrypts snapshot-consistent, builds client via the **injected factory param** (default `AiProviderFactory::create`), constructs `AiRequest` from the profile, cache-first then translate. Readiness = active profile with non-empty decrypted key; **cipher failure → not-ready, never a crash.** Fake store + fake factory. Deps: **WI-1, WI-3**. Tests: unit resolution + clamp + empty; cache-hit-no-profile still returns (#306); no-profile miss → `ProviderFailed`; readiness true/false; cipher-throw → readiness false (no crash).
+
+**WI-5 (behavioral): `PerBookBilingualStore` + `BilingualViewModel` state core.** Store per book (enabled/targetLanguage/granularity — no style); VM setters (persist + first-enable `needsSetupSheet`), language/granularity change clears cache-shaped state + bumps generation, the state fields. Turbine tests: first-enable raises sheet; re-enable persisted does not; disable clears; language change resets; granularity change resets + re-keys; round-trip through store. Deps: **WI-1** (+ store).
+
+**WI-6 (behavioral): VM prefetch trigger + generation/cancellation.** `onPositionChanged` derives current unit, dedupes, prefetches current+next; a **monotonic position-request sequence** checked after every suspension; **per-unit generation tokens**; a **captured language/granularity/provider snapshot per launch**; generation bumps on disable/language/granularity/unit-change discard stale; `CancellationException` handled BEFORE generic error mapping; `Offline`→`unavailableUnits`; transient failure leaves unit unfetched + clears anchor to retry; `retryUnit`. Fake prefetcher. Deps: **WI-4, WI-5**. Tests: current+next on unit change; same-unit no-op; cancel-mid discards stale; offline→unavailable; failure→retry-able; `retryUnit` re-fetches; granularity change cancels + re-fetches under the new key.
+
+**WI-7a (behavioral): Compose UI — setup sheet + interlinear body + pill.** Reproduce `vreader-bilingual.jsx` (setup sheet: language grid / granularity / preview / engine strip configured+unconfigured; body: translated / loading N%+dimmed / error+Retry / offline source-only; pill). Light+dark. Compose UI tests each state. Deps: **WI-5** (state shape). NO Style control; the unconfigured "Set up" CTA renders but its nav target is design-gated (§3).
+
+**WI-7b (behavioral): EPUB render adapter** (only if WI-0 = go). The JS enumerate/inject adapter + `EpubChapterTextProvider`, wired into `ReaderActivity`, driving `BilingualInterlinearBody` state from injected content. Deps: **WI-0, WI-3, WI-4, WI-7a**. Connected test on a real EPUB (seeded cache): enable → interlinear injects; disable → nodes cleared; reflow/href-change re-applies. (If WI-0 = no-go, this WI is dropped and box D ships TXT/MD-only, tracked.)
+
+**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into `TxtBody` loop + position-change + setup-sheet + DI (incl. adding `AiProviderStore` to `AppContainer`). `originalFormat`-gated (TXT/MD). **Gated on #129's final merge.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; disable → source-only byte-parity; reopen persists enabled + renders from cache with zero client calls. Deps: **WI-6, WI-7a, #129 final**.
+
+**WI-9 (behavioral): entry wiring + acceptance.** Mount `BilingualPill` in box F's top chrome; wire the More-menu bilingual toggle (box F) to the VM. **Gated on `feat:#132` (top chrome) + `feat:#134` (More menu).** Full acceptance pass across EPUB (if WI-7b landed) + TXT/MD. Flip box D note; update `docs/architecture.md` (bilingual pipeline + the new `chapter_translations` schema + `AiProviderStore` now in `AppContainer`). → DONE. Deps: **WI-8, WI-7b (if go), feat:#132, feat:#134**.
+
+## 5. Test catalogue
+
+JVM/Robolectric (`android/app/src/test/...bilingual/`): `ChapterSegmenterTest` (paragraph blank-line; sentence CJK 。！？ vs Latin; empty→[]; single); `TranslationChunkerTest` (packs to budget; oversize→own chunk+subSplit; empty→[]); `TranslationChunkContractTest` (prompt per style-constant; strict JSON decode; code-fence strip; count mismatch→`CountMismatch`; non-array→`NotAStringArray`); `ChapterTranslationServiceTest` (cache hit 0 calls; miss→translate→write; decode-fail per-segment fallback; one-chunk-fail partial-not-cached; all-fail→throw; cancellation→Cancelled no write; ensureActive-before-write; offline/timeout/429/http/config/insecure→error mapping; very long chapter N-of-M; stale-cache count-mismatch re-translates); `ChapterTranslationErrorMappingTest`; `TxtChapterTextProviderTest` (resolution; clamp-past-end; empty; unitAfter end→null); `ChapterTranslationPrefetcherTest` (snapshot-consistent profile+key; injected-factory used; `AiRequest` built from profile; cache-hit-no-profile #306; no-profile miss→ProviderFailed; CJK↔English + Latin round-trip via fake; cipher-throw→ProviderFailed not crash); `BilingualAiReadinessTest` (active+key→true; no active→false; empty key→false; **cipher-throw→false, no crash**); `PerBookBilingualStoreTest` (enabled/lang/granularity round-trip; no style field); `BilingualViewModelTest` (Turbine: first-enable sheet; re-enable no-sheet; disable clears; language reset; **granularity reset + re-key**; prefetch current+next; same-unit no-op; cancel-mid discards; offline→unavailable; error→errorUnit+retry; `retryUnit`; generation bump on style-N/A—granularity change).
+
+Room migration: `VReaderDatabaseMigrationTest` (extend) vPrev→vNext + full-chain + FK-CASCADE + `lookupKey`-as-PK; `ChapterTranslationDaoTest` (upsert-by-PK replaces; get/delete-by-lookupKey).
+
+Compose UI (`androidTest/...bilingual/`): `BilingualSetupSheetUiTest` (language grid, granularity, preview, engine configured vs unconfigured; **no Style control present**; light+dark); `BilingualInterlinearBodyUiTest` (translated incl. CJK font + RTL Arabic; loading N%+dimmed; error+Retry; offline source-only; empty translation→source-only no crash); `BilingualPillUiTest`.
+
+Connected (`androidTest/...reader/`): `TxtReaderBilingualConnectedTest` (API 35, fake `AiClient` via injected factory): enable→setup→confirm→interlinear from seeded Room cache; disable→source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; TXT/MD gated (PDF inert); very long chapter scroll responsive; cancellation leaves no partial cache row. `EpubReaderBilingualConnectedTest` (only if WI-0=go): enable→inject on a real EPUB; disable→clear; href-change→re-apply; count-divergence handled.
+
+Edge cases: empty translation, failed, partial per-chunk, CJK↔English + Latin + RTL, provider error/timeout/429/config/insecure, cancellation mid-translation + before-write, very long chapters, offline (cache-first + silent source-only), cipher-decrypt failure → not-ready (no crash).
+
+## 6. Risks + mitigations
+
+- **Live-translation verification is AI-credential-gated (the box-D caveat).** The whole pipeline is verified without live creds via a deterministic **fake `AiClient`** injected through the prefetcher's `clientFactory` param (default `AiProviderFactory::create`; tests override). WI-3/4/8 prove segment→chunk→decode→cache→interleave end-to-end incl. every error/edge path. The connected test seeds the Room cache directly and asserts render-from-cache with zero client calls (render path proven offline). **This mock/integration path is the box-D-required verification path** (the checklist states live translation is credential-gated); an optional live smoke confirms wire format but is NOT a gate.
+- **Acceptance proves BOTH cache-render AND the live pipeline path (via the fake).** WI-8's connected test drives the full enable→translate(fake)→cache→render→reopen cycle, not just cache rendering — the fake stands in only for the network leaf.
+- **EPUB JS-injection unknowns.** WI-0 de-risks before the render WI: pagination shift, fragment recreation wiping nodes, enumerate-vs-`ChapterSegmenter` count divergence (iOS #268). If a hard blocker appears, EPUB drops to a tracked follow-up (phasing fallback) with the specific spike reason — never the false "requires a fork."
+- **Concurrency (audit HIGH — was under-specified).** WI-6 adds: a monotonic position-request sequence checked after every suspension; per-unit generation tokens; a captured language/granularity/provider snapshot per launch; cancellation on granularity change; `CancellationException` handled BEFORE generic error mapping; `ensureActive()` immediately before the Room write; cipher/decrypt failures mapped to unconfigured/provider-failure (never a crash). Snapshot-consistent profile+key pairing (from one `snapshot()`) is preserved.
+- **Segment↔render count divergence** (iOS Bugs #268/#330/#344). TXT/MD segment through the SAME `ChapterSegmenter` on translate + render sides, so 1:1 pairing holds by construction; granularity is in the cache key so a paragraph row is never read as sentences. EPUB uses WI-0's finding (direct-block path if enumerate diverges — iOS `translatePreSegmented` parity).
+- **Cost/latency of translating on scroll.** Lazy current+next prefetch + disk cache; N-of-M progress; cancellation on navigate-away/generation-bump.
+- **Provider JSON non-compliance.** `TranslationChunkContract.decode` + per-segment fallback (iOS parity) — never drops a paragraph.
+- **DataStore per-book key growth.** One Preferences entry per book keyed by fingerprint; scales like `ReaderSettingsStore`/`AiProviderStore`.
+
+## 7. Backward compat
+
+- **Room migration additive** (new `chapter_translations`, FK CASCADE, `lookupKey` PK). Existing rows untouched; migration + structural test guard it. Version number allocated at the merge slot (v5 today → v6).
+- **Reader unchanged when bilingual off** — `TxtBody` render loop byte-identical unless `enabled && format∈{txt,md} && translation present`. `ReaderBottomChrome` is **not modified** (v1's Translate slot removed), so #129's chrome is unaffected. EPUB render adapter is inert unless bilingual is on.
+- **#118 AI provider files unchanged** — the prefetcher/readiness are new consumers; the only #118-adjacent change is *wiring* `AiProviderStore` into `AppContainer` (which #118 left unwired — it was component/round-trip-verified, not nav-integrated).
+- **Backup contract already compatible** — `PerBookSettingsOverride.bilingualEnabled/TargetLanguage/Granularity` exist (verified; **no `bilingualStyle`**), and there is **no translation-cache section** in `contracts/vectors/backup-sections.json` (verified — the cache is device-local, re-derivable). v1 introduces the store that writes the three fields locally; backup collect/restore of them is a small additive follow-up (no contract change), out of v1 scope; until then bilingual config is device-local (safe default). The `PerBookBilingualStore` is confirmed device-local; backup-collect/restore is the scoped-out follow-up.
+
+## Design gates (rule 51 — for `needs-design` filing)
+
+1. **"Bilingual mode" setup sheet with BOTH Style AND Granularity in one Android sheet** — `vreader-bilingual.jsx` depicts Granularity (no Style); `vreader-ai-android.jsx` depicts Style (no Granularity); no committed bundle shows both together. v1 reproduces the granularity-only `vreader-bilingual.jsx` sheet and DROPS Style. If Style is wanted as an Android user control, file `Design needed: bilingual setup sheet (Style + Granularity) for feature #131`. **This is the one open design gate for #131.**
+2. **Dependency gate (not a #131 design gate, but blocks the "Set up" affordance)** — the setup sheet's unconfigured "Set up" CTA has no live nav destination (`AiProviderListScreen` is unreachable in-app today; no `#119`). #131 does not invent it (box-F chrome / #118 follow-on); the CTA renders but is wired only once that route ships.
+
+## Revision history
+
+- v1 (2026-07-10): Gate-1 draft (Plan agent). Gate-2 Codex audit pending.
+- v2 (2026-07-11): Gate-2 round-1 REDESIGN resolved — Readium-feasibility corrected, entry-point rebased on box F, setup-sheet design-gated, DI/cache/concurrency fixed.
+209:| `ChapterTranslationService`          | `ChapterTranslationStore` + `AIService` | Translates one chapter unit for feature #56 bilingual reading. Pipeline: cache lookup → (on miss) `ChapterSegmenter` → `ChapterTranslationChunker` → one `AIService.sendRequest(_:using:)` per chunk → strict `TranslationChunkContract` JSON-array decode → per-segment fallback on any decode/count/element mismatch → recombine → cache-write. Reaches the AI side through the `TranslationRequestSending` boundary protocol (tests inject a mock). `Task.checkCancellation()` between chunks so a cancelled prefetch stops promptly |
+512:## Android App (`android/` — feature #106 foundation bar)
+514:vreader's Android app is a **second, independently-shippable native app**
+535:| `:app` | Android application | Compose UI shell + the Room data layer + reader plumbing. `com.vreader.app`. |
+536:| `:identity` | pure Kotlin/JVM (no Android deps) | The shared canonical contracts — `Identity` (fingerprint canonical key), `CanonicalLocator` (engine-neutral canonical JSON), `DocumentFingerprint` (streaming SHA-256 + format detection), and the `Locator` / `VReaderLocator` / `ReaderLocatorEngine` value types. **Both `:app` AND the `contracts/conformance` lane depend on this one module**, so the golden-vector conformance test proves the SAME code the app runs. |
+540:- **Room** is the SwiftData analog. `VReaderDatabase` (`@Database` v4,
+604:<sha>_<bytes>.<canonicalExt>` = content-addressed blob store), so an Android
+612:| `net.SecretCipher` / `KeystoreSecretCipher` | AndroidKeyStore | AES-256-GCM (fresh IV, non-exportable key) for the password at rest — the EncryptedSharedPreferences replacement. |
+648:| `AiProviderStore` | DataStore JSON list of provider profiles + an active-id; API key kept ONLY as a `KeystoreSecretCipher` token. Snapshot-consistent `apiKey(profile)`. |
+667:| `AnnotationColor` | The 5 design colors (yellow/green/blue/pink/red — design parity; iOS has 4, `red` is Android-only). |
+674:`ReaderActivity` configures the `EpubNavigatorFragment` with a `selectionActionModeCallback` that
+677:(`ReaderActivityTest.seededHighlight_appliesAsDecoration_onLiveNavigator` drives the real WebView).
+679:**TXT highlighting (feature #124)** reuses the same domain on the `TxtReaderActivity` side via a
+685:`TxtHighlightHitTester`. **Feature #125 extended this to MD** (the same `TxtReaderActivity` hosts both):
+690:marker-only slice washes nothing). The old `BookFormat.txt` gate is gone — `TxtReaderActivity` builds the
+693:harness (`TxtReaderActivityTest` long-press/tap E2E), unlike the EPUB WebView gesture.
+710:The TXT reader (`TxtReaderActivity`) brackets a session from the Activity
+
+exec
+/bin/zsh -lc "nl -ba dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md | sed -n '90,170p'
+rg --files android/app/src | rg '(ReaderActivity|TxtReaderActivity|VReaderDatabase|AiProvider|AiClient|AiRequest|ChapterSegment|Translation|AppContainer|VReaderApp|BackupSections|ReaderSettingsStore)'
+rg -n \"class ReaderActivity|EpubNavigatorFragment|evaluateJavascript|currentLocator|submitPreferences|onDestroy|onStop|Fragment|class TxtReaderActivity|fun TxtBody|items\\(\" android/app/src/main android/app/src/test android/app/src/androidTest" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+    90	- **Streaming translation progress** — the design's "38%" is chapter-level N-of-M chunk progress (from the chunker count), not token streaming. v1 shows N-of-M.
+    91	
+    92	## 3. Prior art / project precedent / rejected alternatives
+    93	
+    94	### The render-host decision (analysis — CORRECTED from v1)
+    95	
+    96	**How iOS does interlinear:** iOS renders EPUB/AZW3 in a WKWebView it fully controls. `EPUBBilingualOrchestrator` injects JS that (1) enumerates leaf blocks (`<p>/<li>/<blockquote>`) posting `[{bid,text}]` to Swift, (2) after translation injects a translation node after each block. TXT/MD render in a `UITextView`/attributed-string path where the renderer interleaves translation runs. The mechanism = **the app inserts translation nodes between source nodes.**
+    97	
+    98	**Android host-by-host injectability — the v1 verdict was WRONG for EPUB:**
+    99	
+   100	| Host | Layout tree owner | Content-insertion API | Interlinear feasible? |
+   101	|---|---|---|---|
+   102	| **Readium EPUB** (`EpubNavigatorFragment`) | Readium (internal WebView) | **`evaluateJavascript(script): String?`** is PUBLIC on the fragment (shipped 3.3.0 AAR) → arbitrary DOM read/write. Plus `currentLocator` (href), `firstVisibleElementLocator`, decorations (Highlight/Underline over existing text). | **YES — via JS injection** (not just decorations) |
+   103	| **TXT/MD Compose** (`TxtReaderActivity`) | The app (`LazyColumn` over chunks) | Trivial — a translation `Text` after each source `Text` in the confirmed `items{}` loop | **YES** |
+   104	| **AZW3 foliate** (`FoliateBridge` WebView) | The app (pinned foliate-js bundle) | Full DOM control via the bridge (same as iOS) | YES, but needs bundle-JS → follow-up |
+   105	
+   106	**Verification of the CRITICAL correction:** `javap -public org.readium.r2.navigator.epub.EpubNavigatorFragment` against the resolved AAR (`~/.gradle/caches/.../readium-navigator/3.3.0/.../readium-navigator-3.3.0.aar`) prints:
+   107	```
+   108	public final java.lang.Object evaluateJavascript(java.lang.String, kotlin.coroutines.Continuation<? super java.lang.String>);
+   109	public kotlinx.coroutines.flow.StateFlow<org.readium.r2.shared.publication.Locator> getCurrentLocator();
+   110	public java.lang.Object firstVisibleElementLocator(kotlin.coroutines.Continuation<...>);
+   111	```
+   112	i.e. `suspend fun evaluateJavascript(String): String?` exists. The app already holds the concrete fragment as `ReaderActivity.navigator` (it uses it for decorations/selection in #123). So EPUB interlinear via JS injection is feasible with the public API — **no Readium fork.** The v1 "infeasible inside Readium's navigator" rationale is discarded.
+   113	
+   114	**Chosen: EPUB (Readium JS-injection) as the PRIMARY host + TXT/MD (Compose) included.** WI-0 spikes the EPUB path first (it has the real unknowns); the Compose host is built alongside as the deterministic pipeline proof. AZW3/PDF deferred.
+   115	
+   116	**WI-0 — Readium bilingual spike (new, gates the EPUB render WI):** a throwaway harness that, against a real EPUB on the emulator, proves:
+   117	- (a) **enumerate** current-resource leaf blocks via `navigator.evaluateJavascript(enumScript)` returning a JSON `[{id,text}]` array (parse the `String?` result);
+   118	- (b) **inject** translation DOM nodes after each block, and **clear** them, via `evaluateJavascript`;
+   119	- (c) **re-apply** after `currentLocator` href changes / reflow / page-fragment recreation (the WebView pager recreates fragments — injection must survive or re-fire);
+   120	- (d) measure effects on **pagination/scroll** (does injecting content re-paginate? does it shift the reader's position?) and whether the **enumerated block count** diverges from `ChapterSegmenter` (the iOS #268 divergence class — if it diverges, adopt iOS's `translatePreSegmented` direct-block path).
+   121	
+   122	If WI-0 shows injection is stable → the EPUB render WI proceeds. If WI-0 surfaces a blocker (e.g. fragment recreation wipes injected nodes with no re-fire hook) → EPUB drops to a tracked follow-up and box D ships on TXT/MD (the phasing fallback), with the honest reason (a specific spike finding), never the false "requires a fork" claim.
+   123	
+   124	**Rejected alternatives:**
+   125	1. **Readium interlinear via decorations only** — REJECTED (insufficient). Decorations style existing text; they cannot insert translation paragraphs. But `evaluateJavascript` (above) makes injection possible without decorations, so EPUB is feasible — it just uses the JS seam, not the decoration seam.
+   126	2. **Forking Readium** — REJECTED + unnecessary (the public `evaluateJavascript` seam exists).
+   127	3. **AZW3 foliate host first** — REJECTED for v1 (deferred, not dead). Feasible + design-aligned, but touches the security-sensitive #126 bridge; EPUB via the same JS-injection mechanism is the higher-value primary.
+   128	4. **Eager whole-book pre-translation** — REJECTED (cost/latency). iOS lazily prefetches current+next + caches — port that.
+   129	
+   130	### The setup-sheet resolution (audit HIGH — rule 51)
+   131	
+   132	There are **two committed, differently-shaped** `BilingualSetupSheet`s:
+   133	- `vreader-bilingual.jsx` → **language grid + Granularity (Paragraph/Sentence) + preview strip + Translation-engine strip (Set up/Change) + Cancel/Translate** header. **No Style, no provider/model card, no term-overrides, no cost.**
+   134	- `vreader-ai-android.jsx` → **Languages (From/To) + Provider (provider/model card) + Style (Literal/Natural/Literary) + Keep-term-overrides toggle + cost footer.** **No language grid, no Granularity, no preview.**
+   135	
+   136	v1 merged both into a **third layout** — a rule-51 violation (self-designed UI). **Resolution:** this plan reproduces the **`vreader-bilingual.jsx` sheet EXACTLY** as the authoritative Android-native bilingual sheet (its language grid + granularity + preview + engine strip + CTA is the coherent bilingual-config surface, and its `BilingualPill`/`BilingualPageContent` are the matching reader surfaces). **Style is dropped from v1** (it is not in the authoritative sheet, and — verified — `bilingualStyle` is not a persisted contract field on either platform). Consequently the store/VM carry no `style`, and `promptVersion`'s `s=` component is a constant (§2 cache-identity correction).
+   137	
+   138	**Remaining design gate (rule 51):** a single Android sheet that offers **BOTH Style AND Granularity** (the union the `vreader-ai-android.jsx` "Style" and `vreader-bilingual.jsx` "Granularity" controls imply) is **not depicted anywhere** — no committed bundle shows both in one sheet. If style is wanted on Android as a user control, that needs an **updated committed design**. This plan does NOT invent it; it files a `needs-design` gate (see the §"Design gates" list) and ships the authoritative granularity-only sheet meanwhile.
+   139	
+   140	### Other precedents applied
+   141	
+   142	- **#118 provider seam**: reuse `AiProviderStore.snapshot()` (`snapshot.active`) + `store.apiKey(profile)` + `AiProviderFactory.create` (as the default of an injected factory param) + `AiClient.chat`. Prefetcher + readiness are the only new consumers; #118's AI files are unchanged; #131 additionally *wires* `AiProviderStore` into `AppContainer` (which #118 never did).
+   143	- **Room additive-migration pattern** (#122/#123/#127): version bump + `MIGRATION_n_(n+1)` + exact-DDL + `VReaderDatabaseMigrationTest` PRAGMA guard. `@PrimaryKey` + `@Upsert` is the project's DAO pattern (`BookDao`).
+   144	- **DataStore JSON-in-Preferences** for `PerBookBilingualStore` (the `ReaderSettingsStore`/`AiProviderStore` pattern).
+   145	- **Pure-logic port**: iOS `ChapterSegmenter`/`ChapterTranslationChunker`/`TranslationChunkContract` are pure + heavily unit-tested — direct Kotlin ports with the same test vectors (all verified to exist).
+   146	- **Entry point via box F**: the More-menu bilingual toggle + top-chrome pill are box-F surfaces; #131 depends on them (§4), mirroring how box B's annotations-review-sheet + bookmark "ride with item F."
+   147	
+   148	## 4. Work-item sequencing
+   149	
+   150	Foundational WI-1..4 (no UI, JVM-testable); a spike WI-0 (EPUB); behavioral WI-5..9. Each WI = one PR.
+   151	
+   152	**Dependency notes (audit HIGH — v1's graph was wrong):**
+   153	- WI-3 depends on WI-1 (+2). WI-4 depends on WI-1+WI-3. WI-6 depends on WI-5. So WI-1..4 are NOT all independent — the graph below states the real edges.
+   154	- **`Deps: [feat:#134, feat:#132]`** (transitively #129, #118) — box F is not yet decomposed (per `docs/parity/android-checklist.md`, box F "likely splits into ≥2 features: TOC/bookmarks; find-in-book; more-menu/details/share"); **#132 = the top-chrome sub-feature, #134 = the More-menu sub-feature** are the prospective box-F IDs this plan reserves. **#131's UI entry-point WIs (the pill mount + the More-menu toggle wiring) cannot ship until box F provides those surfaces.** The pipeline + setup sheet + interlinear render (WI-0..7) are built ahead; only the entry wiring (part of WI-9) waits on box F.
+   155	- **Host-integration WIs are gated on #129's FINAL merge** — #129 owns `TxtReaderActivity`/`ReaderBottomChrome`; #131's `TxtReaderActivity` edit must land on top of #129's TXT/MD typography WIs (rule 48 one-writer-per-file).
+   156	
+   157	**WI-0 (spike): Readium EPUB bilingual injection.** The harness in §3 (enumerate / inject+clear / re-apply on reflow / pagination + count-divergence measurement). Output: a go/no-go on EPUB-in-v1 + the concrete `EpubChapterTextProvider` + injection-adapter surface. Deps: none (uses the existing #106 Readium host). Not TDD-gated (throwaway spike); its findings feed WI-7b's plan.
+   158	
+   159	**WI-1 (foundational): value types + pure segmentation/chunk/contract.** `TranslationUnitId`, `TranslationGranularity`, `BilingualLanguages`, `ChapterSegmenter`, `TranslationChunker`, `TranslationChunkContract`, `ChapterTranslationError`. Pure; ported iOS vectors. No Android deps. Deps: none.
+   160	
+   161	**WI-2 (foundational): Room translation cache.** `ChapterTranslationEntity` (PK = `lookupKey`) + `Dao` (`@Upsert`) + `ChapterTranslationStore`; `VReaderDatabase` migration (number at slot). Robolectric migration round-trip + upsert/get/delete-by-lookupKey + FK-CASCADE + exact-DDL guard. Deps: none.
+   162	
+   163	**WI-3 (foundational): `ChapterTranslationService`** against a fake `AiClient`. `cachedTranslation` (cache-only) + `translate` (per-chunk `chat`, per-segment decode-fail fallback, per-chunk graceful degrade, cancellation between chunks + before write, cache-write only on full success). Deps: **WI-1, WI-2**. Tests: cache hit → zero client calls; miss → translate + write; decode fail → per-segment fallback; one-chunk fail → source-only that chunk (others translated, NOT cached); all-chunks fail → throw; cancellation → `Cancelled` (no write); `AiError` mapping incl. `Config`/`InsecureUrl` → `ProviderFailed`.
+   164	
+   165	**WI-4 (foundational): `ChapterTextProvider` (TXT/MD) + `ChapterTranslationPrefetcher` + `BilingualAiReadiness`.** Provider slices per chapter from `TxtDocument`; `unitContaining`/`unitAfter`. Prefetcher resolves active profile from `snapshot()`, decrypts snapshot-consistent, builds client via the **injected factory param** (default `AiProviderFactory::create`), constructs `AiRequest` from the profile, cache-first then translate. Readiness = active profile with non-empty decrypted key; **cipher failure → not-ready, never a crash.** Fake store + fake factory. Deps: **WI-1, WI-3**. Tests: unit resolution + clamp + empty; cache-hit-no-profile still returns (#306); no-profile miss → `ProviderFailed`; readiness true/false; cipher-throw → readiness false (no crash).
+   166	
+   167	**WI-5 (behavioral): `PerBookBilingualStore` + `BilingualViewModel` state core.** Store per book (enabled/targetLanguage/granularity — no style); VM setters (persist + first-enable `needsSetupSheet`), language/granularity change clears cache-shaped state + bumps generation, the state fields. Turbine tests: first-enable raises sheet; re-enable persisted does not; disable clears; language change resets; granularity change resets + re-keys; round-trip through store. Deps: **WI-1** (+ store).
+   168	
+   169	**WI-6 (behavioral): VM prefetch trigger + generation/cancellation.** `onPositionChanged` derives current unit, dedupes, prefetches current+next; a **monotonic position-request sequence** checked after every suspension; **per-unit generation tokens**; a **captured language/granularity/provider snapshot per launch**; generation bumps on disable/language/granularity/unit-change discard stale; `CancellationException` handled BEFORE generic error mapping; `Offline`→`unavailableUnits`; transient failure leaves unit unfetched + clears anchor to retry; `retryUnit`. Fake prefetcher. Deps: **WI-4, WI-5**. Tests: current+next on unit change; same-unit no-op; cancel-mid discards stale; offline→unavailable; failure→retry-able; `retryUnit` re-fetches; granularity change cancels + re-fetches under the new key.
+   170	
+android/app/src/test/kotlin/com/vreader/app/data/VReaderDatabaseMigrationTest.kt
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderEditSheetTest.kt
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderListScreenTest.kt
+android/app/src/test/kotlin/com/vreader/app/ai/AiProviderStoreTest.kt
+android/app/src/test/kotlin/com/vreader/app/ai/AiProviderKindTest.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderFactory.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiClient.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderKind.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt
+android/app/src/test/kotlin/com/vreader/app/reader/settings/ReaderSettingsStoreTest.kt
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt
+android/app/src/androidTest/kotlin/com/vreader/app/reader/PdfReaderActivityTest.kt
+android/app/src/androidTest/kotlin/com/vreader/app/reader/TxtReaderActivityTest.kt
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt
+android/app/src/androidTest/kotlin/com/vreader/app/reader/Azw3ReaderActivityTest.kt
+android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderActivityTest.kt
+android/app/src/test/kotlin/com/vreader/app/opds/OpdsParserTest.kt:138:    @Test fun resolvesQueryAndFragmentOnlyHrefs_preserveBasePath() {
+android/app/src/main/assets/foliate/foliate-bundle.js:1500:  var NS, MIME, PREFIX, RELATORS, ONIX5, camel, normalizeWhitespace, filterAttribute, getAttributes, getElementText, childGetter, resolveURL, isExternal, pathRelative, pathDirname, replaceSeries, regexEscape, tidy, getPrefixes, getPropertyURL, getMetadata, parseNav, parseNCX, parseClock, MediaOverlay, isUUID, getUUID, getIdentifier, deobfuscate, WebCryptoSHA1, deobfuscators, Encryption, Resources, Loader, getHTMLFragment, getPageSpread, getDisplayOptions, EPUB;
+android/app/src/main/assets/foliate/foliate-bundle.js:2274:      getHTMLFragment = (doc, id) => doc.getElementById(id) ?? doc.querySelector(`[name="${CSS.escape(id)}"]`);
+android/app/src/main/assets/foliate/foliate-bundle.js:2402:          const anchor = hash ? (doc) => getHTMLFragment(doc, hash) : () => 0;
+android/app/src/main/assets/foliate/foliate-bundle.js:2408:        getTOCFragment(doc, id) {
+android/app/src/main/assets/foliate/foliate-bundle.js:2489:  var unescapeHTML, MIME2, PDB_HEADER, PALMDOC_HEADER, MOBI_HEADER, KF8_HEADER, EXTH_HEADER, INDX_HEADER, TAGX_HEADER, HUFF_HEADER, CDIC_HEADER, FDST_HEADER, FONT_HEADER, MOBI_ENCODING, EXTH_RECORD_TYPE, MOBI_LANG, concatTypedArray, concatTypedArray3, decoder, getString, getUint, getStruct, getDecoder, getVarLen, getVarLenFromEnd, countBitsSet, countUnsetEnd, decompressPalmDOC, read32Bits, huffcdic, getIndexData, getNCX, getEXTH, getFont, isMOBI, PDB, MOBI, mbpPagebreakRegex, fileposRegex, getIndent, MOBI6, kindleResourceRegex, kindlePosRegex, parseResourceURI, parsePosURI, makePosURI, getFragmentSelector, replaceSeries2, getPageSpread2, KF8;
+android/app/src/main/assets/foliate/foliate-bundle.js:3359:        getTOCFragment(doc, id) {
+android/app/src/main/assets/foliate/foliate-bundle.js:3381:      getFragmentSelector = (str) => {
+android/app/src/main/assets/foliate/foliate-bundle.js:3610:              const selector = getFragmentSelector(str);
+android/app/src/main/assets/foliate/foliate-bundle.js:3611:              this.#setFragmentSelector(frag.index, offset2, selector);
+android/app/src/main/assets/foliate/foliate-bundle.js:3642:        #setFragmentSelector(id, offset, selector) {
+android/app/src/main/assets/foliate/foliate-bundle.js:3662:          const selector = getFragmentSelector(str);
+android/app/src/main/assets/foliate/foliate-bundle.js:3663:          this.#setFragmentSelector(fid, off, selector);
+android/app/src/main/assets/foliate/foliate-bundle.js:3672:        getTOCFragment(doc, { fid, off }) {
+android/app/src/main/assets/foliate/foliate-bundle.js:5828:  var NS2, blockTags, getLang, getAlphabet, getSegmenter, fragmentToSSML, getFragmentWithMarks, rangeIsEmpty, ListIterator, TTS;
+android/app/src/main/assets/foliate/foliate-bundle.js:5946:      getFragmentWithMarks = (range, textWalker2, granularity) => {
+android/app/src/main/assets/foliate/foliate-bundle.js:6030:            const { entries, ssml } = getFragmentWithMarks(range, textWalker2, granularity);
+android/app/src/main/assets/foliate/foliate-bundle.js:6112:    async init({ toc, ids, splitHref, getFragment }) {
+android/app/src/main/assets/foliate/foliate-bundle.js:6129:      this.getFragment = getFragment;
+android/app/src/main/assets/foliate/foliate-bundle.js:6141:        const el = this.getFragment(doc, fragment);
+android/app/src/main/assets/foliate/foliate-bundle.js:6661:      if (book.splitTOCHref && book.getTOCFragment) {
+android/app/src/main/assets/foliate/foliate-bundle.js:6665:        const getFragment = book.getTOCFragment.bind(book);
+android/app/src/main/assets/foliate/foliate-bundle.js:6671:          getFragment
+android/app/src/main/assets/foliate/foliate-bundle.js:6678:          getFragment
+android/app/src/test/kotlin/com/vreader/app/reader/ReadiumLocatorReconstructorTest.kt:128:    fun cfi_carriedAsFragment() = runTest {
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:1500:  var NS, MIME, PREFIX, RELATORS, ONIX5, camel, normalizeWhitespace, filterAttribute, getAttributes, getElementText, childGetter, resolveURL, isExternal, pathRelative, pathDirname, replaceSeries, regexEscape, tidy, getPrefixes, getPropertyURL, getMetadata, parseNav, parseNCX, parseClock, MediaOverlay, isUUID, getUUID, getIdentifier, deobfuscate, WebCryptoSHA1, deobfuscators, Encryption, Resources, Loader, getHTMLFragment, getPageSpread, getDisplayOptions, EPUB;
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:2274:      getHTMLFragment = (doc, id) => doc.getElementById(id) ?? doc.querySelector(`[name="${CSS.escape(id)}"]`);
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:2402:          const anchor = hash ? (doc) => getHTMLFragment(doc, hash) : () => 0;
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:2408:        getTOCFragment(doc, id) {
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:2489:  var unescapeHTML, MIME2, PDB_HEADER, PALMDOC_HEADER, MOBI_HEADER, KF8_HEADER, EXTH_HEADER, INDX_HEADER, TAGX_HEADER, HUFF_HEADER, CDIC_HEADER, FDST_HEADER, FONT_HEADER, MOBI_ENCODING, EXTH_RECORD_TYPE, MOBI_LANG, concatTypedArray, concatTypedArray3, decoder, getString, getUint, getStruct, getDecoder, getVarLen, getVarLenFromEnd, countBitsSet, countUnsetEnd, decompressPalmDOC, read32Bits, huffcdic, getIndexData, getNCX, getEXTH, getFont, isMOBI, PDB, MOBI, mbpPagebreakRegex, fileposRegex, getIndent, MOBI6, kindleResourceRegex, kindlePosRegex, parseResourceURI, parsePosURI, makePosURI, getFragmentSelector, replaceSeries2, getPageSpread2, KF8;
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:3359:        getTOCFragment(doc, id) {
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:3381:      getFragmentSelector = (str) => {
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:3610:              const selector = getFragmentSelector(str);
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:3611:              this.#setFragmentSelector(frag.index, offset2, selector);
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:3642:        #setFragmentSelector(id, offset, selector) {
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:3662:          const selector = getFragmentSelector(str);
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:3663:          this.#setFragmentSelector(fid, off, selector);
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:3672:        getTOCFragment(doc, { fid, off }) {
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:5828:  var NS2, blockTags, getLang, getAlphabet, getSegmenter, fragmentToSSML, getFragmentWithMarks, rangeIsEmpty, ListIterator, TTS;
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:5946:      getFragmentWithMarks = (range, textWalker2, granularity) => {
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:6030:            const { entries, ssml } = getFragmentWithMarks(range, textWalker2, granularity);
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:6112:    async init({ toc, ids, splitHref, getFragment }) {
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:6129:      this.getFragment = getFragment;
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:6141:        const el = this.getFragment(doc, fragment);
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:6661:      if (book.splitTOCHref && book.getTOCFragment) {
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:6665:        const getFragment = book.getTOCFragment.bind(book);
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:6671:          getFragment
+android/app/src/androidTest/assets/foliate-spike/foliate-bundle.js:6678:          getFragment
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:78:     *  (e.g. the reader's onStop position flush — it must finish even as the activity
+android/app/src/main/kotlin/com/vreader/app/search/SearchScreen.kt:208:            items(recents, key = { "recent-$it" }) { r -> RecentRow(query = r, onTap = { onRecentTap(r) }) }
+android/app/src/main/kotlin/com/vreader/app/search/SearchScreen.kt:292:        items(state.results, key = { it.book.fingerprintKey }) { row ->
+android/app/src/main/kotlin/com/vreader/app/library/CollectionShelfBar.kt:45:        items(collections, key = { it.id }) { c ->
+android/app/src/main/kotlin/com/vreader/app/library/LibraryScreen.kt:179:        items(books, key = { it.id }) { book ->
+android/app/src/main/kotlin/com/vreader/app/library/LibraryScreen.kt:226:        items(books, key = { it.id }) { book ->
+android/app/src/test/kotlin/com/vreader/app/reader/nav/ReadiumTocProviderTest.kt:145:    fun duplicateHrefs_differentFragments_yieldDistinctEntries() = runTest {
+android/app/src/androidTest/kotlin/com/vreader/app/tts/TtsControlBarTest.kt:24:                onPlayPause = { pp = true }, onNext = { nx = true }, onPrevious = { pv = true }, onStop = { st = true },
+android/app/src/main/kotlin/com/vreader/app/search/EpubTextExtractor.kt:202:        val noFragment = href.substringBefore('#')
+android/app/src/main/kotlin/com/vreader/app/search/EpubTextExtractor.kt:204:            java.net.URLDecoder.decode(noFragment, Charsets.UTF_8.name())
+android/app/src/main/kotlin/com/vreader/app/search/EpubTextExtractor.kt:206:            noFragment
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatPanel.kt:112:            items(AiChatUiState.SUGGESTED_PROMPTS) { p ->
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatPanel.kt:118:        items(state.messages) { m -> MessageRow(m) }
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubFindInBookTest.kt:22: * #128 FTS index. Instrumented because Readium's EpubNavigatorFragment renders in a REAL WebView (not
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubFindInBookTest.kt:35: * The live Readium `SearchIterator` is disposed on dismiss + onDestroy (the WI-8 `closeAllEpubCursors`
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubFindInBookTest.kt:43: * only the cursor dispose), so this layer asserts VM survival, not a false Idle. The onDestroy path runs through
+android/app/src/main/kotlin/com/vreader/app/tts/TtsControlBar.kt:48:    onStop: () -> Unit = {},
+android/app/src/main/kotlin/com/vreader/app/tts/TtsControlBar.kt:66:        else TransportLayout(state, onPlayPause, onPrevious, onNext, onStop, onSpeed, onVoice)
+android/app/src/main/kotlin/com/vreader/app/tts/TtsControlBar.kt:73:    onStop: () -> Unit, onSpeed: () -> Unit, onVoice: () -> Unit,
+android/app/src/main/kotlin/com/vreader/app/tts/TtsControlBar.kt:101:            IconBtn(Icons.Filled.Close, "Stop read-aloud", c.Ink, onStop, "tts-stop")
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderScreen.kt:120:            items(count = document.pageCount, key = { it }) { i -> PdfPage(document, i) }
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderScreen.kt:159:    currentLocator: vreader.contracts.Locator? = null,
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderScreen.kt:188:            currentLocator = currentLocator,
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubBookmarkNavTest.kt:20: * Feature #135 WI-7 — the EPUB bookmark host wiring, instrumented because Readium's EpubNavigatorFragment
+android/app/src/androidTest/kotlin/com/vreader/app/reader/TxtReaderActivityTest.kt:33:class TxtReaderActivityTest {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderHighlightController.kt:1:// Purpose: feature #123 WI-3 — wraps Readium's selection + decoration APIs (EpubNavigatorFragment
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderHighlightController.kt:12:import org.readium.r2.navigator.epub.EpubNavigatorFragment
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderHighlightController.kt:17:class ReaderHighlightController(private val navigator: EpubNavigatorFragment) {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt:4:// EpubNavigatorFragment View under the chrome, not a Compose body), so it cannot reuse the Compose-native
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt:43: * read from the navigator's `currentLocator`) to [tocIndexFor].
+android/app/src/test/kotlin/com/vreader/app/reader/Azw3DisplayCssTest.kt:156:    // FoliateBridge.setStyles runs through evaluateJavascript) wraps the CSS in a JSON-encoded literal.
+android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderChromeConnectedTest.kt:19: * the Readium EpubNavigatorFragment. Instrumented because the navigator resolves its TOC + reading
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubDisplaySettingsConnectedTest.kt:19: * EpubNavigatorFragment resolves its settings against a real WebView (not Robolectric). Seeds a
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubDisplaySettingsConnectedTest.kt:22: * theme mid-read and asserts the accepted background updates (live re-submission via submitPreferences).
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeScaffold.kt:22:// (host wiring feeds the data in WI-7). [currentLocator] is threaded for the host to derive presence but the
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeScaffold.kt:81: * Contents/Notes-only callers stay valid). [currentLocator] is the current reading position the host uses
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeScaffold.kt:116:    currentLocator: Locator? = null,
+android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderActivityTest.kt:18: * EpubNavigatorFragment renders in a real WebView (not Robolectric). Imports the
+android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderActivityTest.kt:24:class ReaderActivityTest {
+android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderActivityTest.kt:63:            // Background the reader → onStop flushes the current position synchronously.
+android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderActivityTest.kt:72:            assertTrue("onStop flushed a reading position to Room", saved)
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:2:// EpubNavigatorFragment in scroll mode (Spike-B-verified), opening the stored EPUB
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:7:// EpubNavigatorFragment View under the chrome, not a Compose body) and the ONLY TOC-supplying host, so it
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:26:// disposed in onDestroy (onCleared → closeAllEpubCursors) BEFORE the publication closes, so the live Readium
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:88:import org.readium.r2.navigator.epub.EpubNavigatorFragment
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:101:class ReaderActivity : AppCompatActivity() {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:110:    private var navigator: EpubNavigatorFragment? = null
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:111:    private var publication: Publication? = null   // host-owned; closed in onDestroy
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:126:    // read from the navigator's currentLocator totalProgression (EPUB scroll mode).
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:149:    // onDestroy (`onCleared` → closeAllEpubCursors, so the live Readium SearchIterator never leaks). The sheet
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:168:        // The navigator fragment can't be restored before its FragmentFactory is set,
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:205:            // released in onDestroy; the activity recreates fresh on return).
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:206:            val nav: EpubNavigatorFragment? = withStarted {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:207:                if (supportFragmentManager.isStateSaved) return@withStarted null
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:208:                supportFragmentManager.fragmentFactory = factory.createFragmentFactory(
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:211:                    listener = object : EpubNavigatorFragment.Listener {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:214:                    configuration = EpubNavigatorFragment.Configuration().apply {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:219:                supportFragmentManager.commitNow {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:220:                    add(containerId, EpubNavigatorFragment::class.java, Bundle(), READER_TAG)
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:222:                supportFragmentManager.findFragmentByTag(READER_TAG) as EpubNavigatorFragment
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:252:     *  render the sheet. The VM's collectors run on [lifecycleScope]; it is disposed in [onDestroy]
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:268:    private suspend fun populateChromeModel(pub: Publication, current: Book, nav: EpubNavigatorFragment) {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:272:        val locator = nav.currentLocator.value
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:347:     *  first apply). Proves the reopen-render path ran against the real EpubNavigatorFragment. */
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:379:        override fun onDestroyActionMode(mode: ActionMode?) {}
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:444:    override fun onStop() {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:445:        super.onStop()
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:451:        val locator = nav.currentLocator.value
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:455:    override fun onDestroy() {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:456:        super.onDestroy()
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:463:        // fragment is torn down by super.onDestroy() above, then we release it.
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:482:    private fun observeDisplaySettings(nav: EpubNavigatorFragment) {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:485:                runCatching { nav.submitPreferences(EpubPreferences(scroll = true) + settings.toEpubPreferences()) }
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:486:                    .onFailure { android.util.Log.w("ReaderActivity", "submitPreferences failed; display change not applied", it) }
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:494:    private fun observePosition(nav: EpubNavigatorFragment, current: Book) {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:496:            nav.currentLocator
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:502:            nav.currentLocator.collect { locator ->
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:620:     *  body is a View (EpubNavigatorFragment), NOT a composable, the chrome cannot use the Compose-native
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:729:        val current = nav.currentLocator.value
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:849:    fun currentHref(): String? = navigator?.currentLocator?.value?.href?.toString()
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:897:     *  Proves the Display setting reached and was resolved by the live EpubNavigatorFragment — it does
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:955: * `currentLocator` as plain values so this stays pure/JVM-testable — the same thin-Readium-hop posture as
+android/app/src/androidTest/kotlin/com/vreader/app/reader/foliate/FoliateSpikeHarnessTest.kt:133:        InstrumentationRegistry.getInstrumentation().runOnMainSync { wv.evaluateJavascript(js, null) }
+android/app/src/main/kotlin/com/vreader/app/reader/EpubPreferencesMapper.kt:11:// @coordinates-with: ReaderActivity.kt (submits the mapped prefs live via submitPreferences()),
+android/app/src/main/kotlin/com/vreader/app/reader/EpubReaderChrome.kt:2:// (ReaderActivity). The EPUB host is the outlier: a Readium EpubNavigatorFragment (a View) renders the
+android/app/src/main/kotlin/com/vreader/app/reader/foliate/Azw3Document.kt:3:// state + the latest position (main-thread-owned, so the Activity's onStop can flush synchronously).
+android/app/src/main/kotlin/com/vreader/app/reader/foliate/Azw3Document.kt:45:    /** The latest position foliate reported, main-thread-owned so onStop can flush it synchronously. */
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:6:// DisposableEffect; the page index is saved (debounced + onStop flush) via a conflated,
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:72:    // Hoisted so onStop can flush the latest page synchronously (mirrors TxtReaderActivity).
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:82:    // serialized (latest-wins) — the debounced save + the onStop flush never land out of order.
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:91:        // The lone writer — drains in order; runs on the process scope so an onStop save
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:92:        // completes through teardown; ends when onDestroy closes the channel.
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:209:                            currentLocator = liveCanonical,
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:228:    override fun onStop() {
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:229:        super.onStop()
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:233:    override fun onDestroy() {
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:234:        super.onDestroy()
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:7:// VReaderLocator.wrapLegacy envelope (debounced + onStop flush) and restore it via
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:158:class TxtReaderActivity : ComponentActivity() {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:162:    // Hoisted out of composition so onStop can flush the latest position synchronously
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:163:    // (mirrors ReaderActivity's onStop flush). Set once the document is loaded.
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:172:    // saves are serialized (latest-wins) — the debounced save and the onStop flush can
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:183:        // pending one. Runs on the process scope so an onStop save completes through
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:184:        // teardown; ends when onDestroy closes the channel.
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:221:                        // onStop flush — captures the live list state + book/document.
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:402:                            currentLocator = liveCanonical,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:467:                                    onPrevious = ttsVm::previous, onNext = ttsVm::next, onStop = ttsVm::stop,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:587:    override fun onStop() {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:588:        super.onStop()
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:592:    override fun onDestroy() {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:593:        super.onDestroy()
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:853:    currentLocator: vreader.contracts.Locator? = null,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:881:            currentLocator = currentLocator,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:987:private fun TxtBody(
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1043:        items(count = document.chunkCount, key = { it }) { i ->
+android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateBridge.kt:83:        // the OS freezer can suspend it after a few idle seconds, so a page-turn (evaluateJavascript)
+android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateBridge.kt:161:     *  `evaluateJavascript` runs (no test-vs-production drift). Mirrors iOS Foliate `setStyles`. */
+android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateBridge.kt:166:    private fun eval(js: String) = webView.evaluateJavascript(js, null)
+android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateBridge.kt:303: * seam [FoliateBridge.setStyles] runs through `evaluateJavascript`, so the escaping the unit test pins
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:6:// + flushes on onStop, and recreates the WebView on render-process death.
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:98:    // Hoisted so onStop can flush the latest position synchronously (mirrors PdfReaderActivity).
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:108:        // The lone position writer — drains in order on the process scope so an onStop save survives
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:186:                        currentLocator = currentCanonical,
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:246:    override fun onStop() {
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:247:        super.onStop()
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:255:    override fun onDestroy() {
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:256:        super.onDestroy()
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:454:    currentLocator: Locator? = null,
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:484:            currentLocator = currentLocator,
+
+exec
+/bin/zsh -lc "sed -n '90,240p' android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt
+sed -n '430,530p' android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt
+sed -n '150,250p' android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt
+sed -n '970,1075p' android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt
+sed -n '1,240p' android/app/src/main/kotlin/com/vreader/app/ai/AiClient.kt
+sed -n '1,220p' android/app/src/main/kotlin/com/vreader/app/ai/AiProviderFactory.kt
+sed -n '1,260p' android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.util.AbsoluteUrl
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import java.io.File
+import vreader.contracts.Locator as CanonicalLocator
+
+@OptIn(ExperimentalReadiumApi::class)
+class ReaderActivity : AppCompatActivity() {
+
+    private val container get() = (application as VReaderApp).container
+    private val repository: LibraryRepository get() = container.repository
+    private val bridge = ReadiumLocatorBridge()
+
+    private val annotations: AnnotationsRepository get() = container.annotationsRepository
+
+    private var containerId: Int = 0
+    private var navigator: EpubNavigatorFragment? = null
+    private var publication: Publication? = null   // host-owned; closed in onDestroy
+    private var book: Book? = null
+
+    // feature #132 WI-7-EPUB — the persistent chrome model the top/bottom bands + sheet layer collect,
+    // populated as the async open completes and updated on every position change. The active Display
+    // theme (also read by the chrome bands' colors) is mirrored so the ComposeViews can render immediately.
+    private val chromeModel = MutableStateFlow(ReaderChromeModel())
+    private val chromeTheme = mutableStateOf(ReaderTheme.Paper)
+    // The hoisted top/bottom-visibility + open-sheet state (a Compose snapshot state, so the ComposeViews
+    // recompose on change). Kept in-memory for the reader's lifetime (rotation always starts fresh — see
+    // onCreate's super.onCreate(null)).
+    private val chromeState = mutableStateOf(ReaderChromeState())
+    // feature #129 — whether the Display settings sheet is open (opened from the bottom band's Aa slot).
+    private val showDisplaySheet = mutableStateOf(false)
+    // feature #132 WI-7-EPUB — the live reading fraction (0..1) for the bottom band's progress scrubber,
+    // read from the navigator's currentLocator totalProgression (EPUB scroll mode).
+    private val chromeProgress = mutableStateOf(0f)
+    // feature #134 WI-5 — the More menu's Book-details model (null until the book loads AND its collection
+    // names are read → the More button is omitted until then; no dead control). Rebuilt on collection change.
+    private val chromeBookDetails = mutableStateOf<com.vreader.app.reader.details.BookDetailsUiModel?>(null)
+
+    // feature #135 WI-7 — the top-bar bookmark toggle state + the Bookmarks-tab rows the chrome bands read.
+    // isCurrentBookmarked drives the filled/outline glyph; it is refreshed on every position change AND right
+    // after a toggle. currentCanonical is the live reading position mapped to canonical (the equality basis
+    // for presence/create). bookmarkRows is the projected List<BookmarkRowItem> (observeBookmarks → WI-4
+    // projection with a BookmarkTocIndex built ONCE per TOC). All in-memory for the reader's lifetime.
+    private val isCurrentBookmarked = mutableStateOf(false)
+    private val bookmarkRows = mutableStateOf<List<BookmarkRowItem>>(emptyList())
+    // The live reading position as a canonical Locator (null until the navigator has a locator). Read on the
+    // main thread; the toggle/presence reads snapshot it.
+    @Volatile private var currentCanonical: CanonicalLocator? = null
+    // The bookmark TOC index, built ONCE from the flattened TOC when the publication opens (WI-4 design —
+    // the host owns index construction), reused across every projected row.
+    @Volatile private var bookmarkTocIndex: BookmarkTocIndex? = null
+    private val bookmarkDate = bookmarkDateRenderer()
+
+    // feature #133 WI-11 — the in-book search VM (ONE per reader session), built once the publication opens
+    // over the LIVE Readium publication (Readium's own SearchService — NOT the FTS index). Disposed in
+    // onDestroy (`onCleared` → closeAllEpubCursors, so the live Readium SearchIterator never leaks). The sheet
+    // renders in the sheetLayer ComposeView; the Search-icon presence follows the VM's `hidesSearchEntry`.
+    private var inBookSearchVm: InBookSearchViewModel? = null
+    private val inBookSearchState = mutableStateOf<com.vreader.app.search.InBookSearchScreenState?>(null)
+    private val showSearchSheet = mutableStateOf(false)
+    // How many times the per-session search VM has been constructed — a test seam proving exactly ONE is
+    // built per reader open (never a fresh one per query/recomposition — the WI-8 one-per-session contract).
+    @Volatile private var inBookSearchVmBuildCount: Int = 0
+
+    // feature #123 — in-reader highlighting
+    private var highlightController: ReaderHighlightController? = null
+    private val popoverVm = SelectionPopoverViewModel()
+    // the Readium locator of the live selection (create context: set on a fresh selection)
+    private var pendingSelection: Locator? = null
+    // edit context: the existing highlight being edited (set on a decoration tap) + its text for copy/share
+    private var pendingHighlightId: String? = null
+    private var pendingSelectedText: String? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        // The navigator fragment can't be restored before its FragmentFactory is set,
+        // and we set the factory only after the async open completes — so always start
+        // fresh (the saved reading position is what actually persists across recreation).
+        super.onCreate(null)
+
+        val key = intent.getStringExtra(EXTRA_FINGERPRINT_KEY)
+        if (key == null) { finish(); return }
+        setContentView(buildChrome())
+
+        // feature #132 WI-7-EPUB — the chrome band colors follow the user's stored Display theme (open-time
+        // value + live updates), mirroring how observeDisplaySettings feeds the navigator.
+        lifecycleScope.launch {
+            container.readerSettingsStore.settings.collect { chromeTheme.value = it.theme }
+        }
+
+        lifecycleScope.launch {
+            val loaded = repository.findBook(key)
+            if (loaded?.localFilePath == null) { finish(); return@launch }
+            book = loaded
+            // Seed the chrome model title immediately (TOC + annotations arrive once the publication opens).
+            chromeModel.value = chromeModel.value.copy(title = loaded.title)
+
+            val pub = try {
+                BookOpener(this@ReaderActivity).open(File(loaded.localFilePath!!))
+            } catch (e: BookOpenException) {
+                finish(); return@launch
+            }
+            publication = pub
+
+            val initial = computeInitialLocator(key)
+            // feature #129 WI-5 — open with the user's stored Display settings already applied (so a
+            // non-default theme/typography renders on first paint, no flash), keeping the scroll layout.
+            val initialPrefs = EpubPreferences(scroll = true) + container.readerSettingsStore.current().toEpubPreferences()
+            val factory = EpubNavigatorFactory(pub)
+            // Attach only when the activity is at least STARTED AND its fragment state
+            // isn't already saved — `commitNow` against a state-saved manager throws
+            // IllegalStateException. If we can't commit, abort (the publication is
+            // released in onDestroy; the activity recreates fresh on return).
+            val nav: EpubNavigatorFragment? = withStarted {
+                if (supportFragmentManager.isStateSaved) return@withStarted null
+                supportFragmentManager.fragmentFactory = factory.createFragmentFactory(
+                    initialLocator = initial,
+                    initialPreferences = initialPrefs,
+                    listener = object : EpubNavigatorFragment.Listener {
+                        override fun onExternalLinkActivated(url: AbsoluteUrl) {}
+                    },
+                    configuration = EpubNavigatorFragment.Configuration().apply {
+                        // intercept the system selection menu → show the designed floating popover instead.
+                        selectionActionModeCallback = selectionCallback()
+                    },
+                )
+                supportFragmentManager.commitNow {
+                    add(containerId, EpubNavigatorFragment::class.java, Bundle(), READER_TAG)
+                }
+                supportFragmentManager.findFragmentByTag(READER_TAG) as EpubNavigatorFragment
+            }
+            if (nav == null) { finish(); return@launch }
+            navigator = nav
+            val controller = ReaderHighlightController(nav)
+            highlightController = controller
+            repository.markOpened(key, System.currentTimeMillis())
+            // feature #132 WI-7-EPUB — build the chrome model once the publication is open: the flattened
+            // TOC (each entry retaining its native Readium locator for the jump), the Notes snapshot, and
+            // the initial highlighted-chapter index for the current reading position.
+            populateChromeModel(pub, loaded, nav)
+            // feature #135 WI-7 — build the bookmark TOC index ONCE from the flattened TOC (WI-4 design),
+            // then observe this book's bookmarks (project → rows) + keep the top-bar presence in sync.
+            bookmarkTocIndex = BookmarkTocIndex.build(chromeModel.value.tocEntries)
+            observeBookmarks(loaded)
+            observePosition(nav, loaded)
+            observeDisplaySettings(nav)
+            observeHighlights(loaded, controller)
+            observeAnnotationsSnapshot(loaded)
+        val text = selectedTextForAction() ?: return
+        val send = Intent(Intent.ACTION_SEND).apply { type = "text/plain"; putExtra(Intent.EXTRA_TEXT, text) }
+        startActivity(Intent.createChooser(send, null))
+        clearSelectionAndDismiss()
+    }
+
+    private fun clearSelectionAndDismiss() {
+        highlightController?.clearSelection()
+        pendingSelection = null
+        pendingHighlightId = null
+        pendingSelectedText = null
+        popoverVm.dismiss()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        // Synchronous-intent flush: the last movement inside the debounce window would
+        // otherwise be lost on back/home/rotation. Launched on the process scope so it
+        // completes even as this activity is torn down.
+        val nav = navigator ?: return
+        val current = book ?: return
+        val locator = nav.currentLocator.value
+        container.appScope.launch { persist(locator, current) }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // feature #133 WI-11 — dispose the in-book search VM (its onCleared disposes the live Readium
+        // SearchIterator via closeAllEpubCursors) BEFORE releasing the publication it searches over — the
+        // iterator is a view over the publication, so it must go first (no leak, no use-after-close).
+        inBookSearchVm?.onCleared()
+        inBookSearchVm = null
+        // Host owns the Publication (Readium's navigator does not close it). The
+        // fragment is torn down by super.onDestroy() above, then we release it.
+        publication?.close()
+        publication = null
+    }
+
+    /** Restore precisely from the saved Readium locator; canonical-fallback (progression) is a follow-on. */
+    private suspend fun computeInitialLocator(key: String): Locator? {
+        val saved = repository.loadPosition(key) ?: return null
+        return when (val target = ResumeResolver.resolve(saved)) {
+            is ResumeTarget.Precise -> runCatching { Locator.fromJSON(JSONObject(target.readiumLocatorJSON)) }.getOrNull()
+            else -> null
+        }
+    }
+
+    /** feature #129 WI-5 — apply the live "Display" settings to the navigator: re-submit Readium
+     *  EpubPreferences (typography + per-theme colors) on every change so a settings edit updates the
+     *  open reader immediately. Scroll layout is preserved (WI-5 owns typography/theme only). The
+     *  open-time value is already applied via `initialPrefs`; re-submitting the same value is a cheap
+     *  no-op, so we don't drop the first emission (keeps the render authoritative). */
+    private fun observeDisplaySettings(nav: EpubNavigatorFragment) {
+        lifecycleScope.launch {
+            container.readerSettingsStore.settings.collect { settings ->
+                runCatching { nav.submitPreferences(EpubPreferences(scroll = true) + settings.toEpubPreferences()) }
+                    .onFailure { android.util.Log.w("ReaderActivity", "submitPreferences failed; display change not applied", it) }
+            }
+        }
+    }
+
+    /** Save the current Readium position as a VReaderLocator envelope (debounced steady-state) AND keep the
+     *  chrome model's highlighted-chapter index in sync as the reader scrolls (prompt, un-debounced — the
+     *  Contents-sheet highlight should track the live position, and tocIndexFor is a cheap pure map). */
+    private fun observePosition(nav: EpubNavigatorFragment, current: Book) {
+        lifecycleScope.launch {
+            nav.currentLocator
+                .drop(1)            // skip the initial emission
+                .debounce(1_000)
+                .collect { locator -> persist(locator, current) }
+        }
+        lifecycleScope.launch {
+            nav.currentLocator.collect { locator ->
+                val model = chromeModel.value
+                val index = tocIndexFor(locator.href.toString(), locator.locations.progression, tocPositions(model.tocEntries))
+                if (index != model.currentTocIndex) {
+                    chromeModel.value = chromeModel.value.copy(currentTocIndex = index)
+                }
+                chromeProgress.value = (locator.locations.totalProgression ?: 0.0).toFloat().coerceIn(0f, 1f)
+                // feature #135 WI-7 — map the live Readium position to canonical (the toggle's equality
+                // basis) + refresh the top-bar filled/outline presence as the reader scrolls.
+                val canonical = canonicalForCurrent(locator, current)
+                currentCanonical = canonical
+                isCurrentBookmarked.value = canonical != null &&
+                    runCatching { annotations.isBookmarked(current.fingerprintKey, canonical) }.getOrDefault(false)
+            }
+        }
+    }
+
+    /** feature #135 WI-7 — the live Readium position → canonical [CanonicalLocator] (the bookmark equality
+     *  basis). Extracts the plain values (href + progression + totalProgression + cfi) off the Readium
+     *  locator here (the thin Readium hop) and hands them to the pure [epubBookmarkLocator]. */
+    private fun canonicalForCurrent(locator: Locator, current: Book): CanonicalLocator? {
+        val href = locator.href.toString().takeIf { it.isNotBlank() } ?: return null
+        val cfi = locator.locations.fragments.firstOrNull { it.startsWith("epubcfi(") }
+        return runCatching {
+            epubBookmarkLocator(
+                href = href,
+                progression = locator.locations.progression,
+                totalProgression = locator.locations.totalProgression,
+                cfi = cfi,
+    data class Loaded(
+        val title: String,
+        val document: TxtDocument,
+        val book: Book,
+        val initialIndex: Int,
+    ) : TxtUiState
+}
+
+class TxtReaderActivity : ComponentActivity() {
+
+    private val container get() = (application as VReaderApp).container
+
+    // Hoisted out of composition so onStop can flush the latest position synchronously
+    // (mirrors ReaderActivity's onStop flush). Set once the document is loaded.
+    private var flushPosition: (() -> Unit)? = null
+
+    // feature #124 WI-4 — the existing TXT highlight being edited (set on a tap; null = create context)
+    // + the text to copy/share (the selection's, or the tapped highlight's).
+    private var pendingTxtHighlightId: String? = null
+    private var pendingTxtText: String? = null
+
+    // ALL position writes funnel through this CONFLATED channel + a SINGLE consumer, so
+    // saves are serialized (latest-wins) — the debounced save and the onStop flush can
+    // never land out of order and regress the position (Gate-4 High).
+    private val saveRequests = Channel<PendingSave>(Channel.CONFLATED)
+    private data class PendingSave(val book: Book, val offsetUtf16: Int)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val key = intent.getStringExtra(EXTRA_FINGERPRINT_KEY)
+        if (key == null) { finish(); return }
+
+        // The lone writer — drains requests in order; CONFLATED keeps only the latest
+        // pending one. Runs on the process scope so an onStop save completes through
+        // teardown; ends when onDestroy closes the channel.
+        container.appScope.launch {
+            for ((book, offset) in saveRequests) {
+                val locator = Locator(
+                    contentSHA256 = book.contentSHA256,
+                    fileByteCount = book.fileByteCount,
+                    format = book.originalFormat.name,
+                    charOffsetUTF16 = offset,
+                )
+                container.repository.savePosition(
+                    vreader.contracts.VReaderLocator.wrapLegacy(locator),
+                    System.currentTimeMillis(),
+                )
+            }
+        }
+
+        setContent {
+            VReaderTheme {
+                val state by produceState<TxtUiState>(TxtUiState.Loading, key) {
+                    value = withContext(Dispatchers.IO) {
+                        runCatching { load(key) }.getOrDefault(TxtUiState.Failed)
+                    }
+                }
+                // feature #129 — the live Display settings (theme/font/size/spacing/margin). NULL until
+                // the DataStore's first emission; the reader body is withheld until then (Gate-4 Medium:
+                // rendering defaults first would flash the wrong theme/typography for a user with stored
+                // non-default settings). The empty loading scaffold is the only pre-emission surface.
+                val settingsOrNull by container.readerSettingsStore.settings
+                    .collectAsStateWithLifecycle(initialValue = null)
+                val gated = if (settingsOrNull == null && state !is TxtUiState.Failed) TxtUiState.Loading else state
+                when (val s = gated) {
+                    is TxtUiState.Failed -> LaunchedEffect(Unit) { finish() }
+                    is TxtUiState.Loading -> TxtLoadingScaffold((settingsOrNull ?: ReaderSettings()).theme)
+                    is TxtUiState.Loaded -> {
+                        // non-null by the gate above (Loaded is unreachable pre-emission).
+                        val displaySettings = checkNotNull(settingsOrNull)
+                        val listState = rememberLazyListState(initialFirstVisibleItemIndex = s.initialIndex)
+                        // onStop flush — captures the live list state + book/document.
+                        SideEffect {
+                            flushPosition = { savePosition(s.book, s.document, listState.firstVisibleItemIndex) }
+                        }
+                        // Debounced steady-state save as the user scrolls.
+                        LaunchedEffect(listState, s.document) {
+                            snapshotFlow { listState.firstVisibleItemIndex }
+                                .drop(1)
+                                .debounce(1_000)
+                                .collect { savePosition(s.book, s.document, it) }
+                        }
+                        // feature #121 — read-aloud. The VM drives the designed control bar; the spoken
+                        // sentence is washed + auto-scrolled (TXT). Chunking is LAZY + off-main (only
+                        // on Read aloud) so a large book never scans the whole text on composition.
+                        val ttsVm: TtsViewModel = viewModel(factory = viewModelFactory {
+                            initializer { TtsViewModel(AndroidTtsEngine(applicationContext)) }
+                        })
+                        val tts by ttsVm.state.collectAsStateWithLifecycle()
+                        val ttsScope = rememberCoroutineScope()
+                        LaunchedEffect(ttsVm) { ttsVm.intents.collect { launchTtsIntent(it) } }
+                        // pause read-aloud when the reader is backgrounded (no MediaSession by design —
+                        // plan §OOS); the engine is shut down on Activity finish via the VM's onCleared.
+                        val lifecycleOwner = LocalLifecycleOwner.current
+                        DisposableEffect(lifecycleOwner) {
+                            // guard against ON_STOP firing on a rotation (config change) — the VM is
+                            // retained across rotation, so don't pause when we're just reconfiguring.
+                            val obs = LifecycleEventObserver { _, e -> if (e == Lifecycle.Event.ON_STOP && !isChangingConfigurations) ttsVm.pause() }
+                            lifecycleOwner.lifecycle.addObserver(obs)
+                            onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
+                        }
+            .clip(RoundedCornerShape(14.dp))
+            .clickable(enabled = enabled, onClick = onReadAloud)
+            .padding(horizontal = 12.dp, vertical = 4.dp)
+            .testTag("tts-read-aloud-entry"),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(3.dp),
+    ) {
+        Icon(Icons.AutoMirrored.Filled.VolumeUp, contentDescription = "Read aloud", tint = tint, modifier = Modifier.size(24.dp))
+        // accent label when enabled — the committed TtsEntry active treatment (pre-#129 TtsEntryBar parity).
+        Text("Read aloud", color = tint, fontFamily = VReaderFonts.Sans, fontSize = 10.sp, fontWeight = FontWeight.Medium)
+    }
+}
+
+/** The reading body — a LazyColumn over the document's chunk ranges. For BookFormat.md each chunk
+ *  renders through MarkdownRenderer (styled); else verbatim. [textStyle] + [marginDp] come from the
+ *  #129 Display settings (bodyTextStyle + the margin slider). */
+@Composable
+private fun TxtBody(
+    document: TxtDocument, listState: LazyListState, format: BookFormat,
+    // feature #125 — the single render owner. MD chunks render via mapper.renderedText so the body's
+    // TextLayoutResult matches the controller/wash's offset map exactly (no double render, no drift).
+    mapper: ChunkTextMapper,
+    textStyle: TextStyle, marginDp: Float,
+    highlightSpan: (chunkIndex: Int) -> IntRange? = { null },
+    // feature #124 — annotation highlight washes per chunk (TXT only; the activity passes empty for MD).
+    washesForChunk: (chunkIndex: Int) -> List<WashSpan> = { emptyList() },
+    // feature #124 — TXT custom selection (null = no selection, e.g. MD). onSelectionFinalized fires on
+    // long-press-drag release so the host can show the popover.
+    selectionController: TxtSelectionController? = null,
+    onSelectionFinalized: () -> Unit = {},
+    // feature #124 WI-4 — a tap (LazyColumn-local point) → host hit-tests an existing highlight to edit.
+    onTapAt: (androidx.compose.ui.geometry.Offset) -> Unit = {},
+) {
+    val isMarkdown = format == BookFormat.md
+    val wash = VReaderColors.Accent.copy(alpha = 0.18f)
+    val selectionAccent = Color(0x575C8FC4)   // design selection bg rgba(92,143,196,0.34)
+    val selection by (selectionController?.selection ?: flowOf(null)).collectAsState(null)
+    // the pointerInput block keys on selectionController (stable), so without this it would capture the
+    // INITIAL onTapAt/onSelectionFinalized closures (stale highlightsList → tap-to-edit never hits).
+    val currentOnTap by androidx.compose.runtime.rememberUpdatedState(onTapAt)
+    val currentOnFinalize by androidx.compose.runtime.rememberUpdatedState(onSelectionFinalized)
+    LazyColumn(
+        Modifier
+            .fillMaxSize()
+            .onGloballyPositioned { selectionController?.setLazyCoords(it) }
+            .then(
+                if (selectionController != null) {
+                    // ONE detector distinguishes a TAP (edit an existing highlight) from a LONG-PRESS+drag
+                    // (new selection) — two separate pointerInput detectors conflict over the same down event.
+                    Modifier.pointerInput(selectionController) {
+                        awaitEachGesture {
+                            val down = awaitFirstDown(requireUnconsumed = false)
+                            val longPress = awaitLongPressOrCancellation(down.id)
+                            if (longPress != null) {
+                                // long-press → selection; finalize only on a COMPLETED drag/up (not a cancel).
+                                selectionController.beginAt(longPress.position)
+                                val completed = drag(longPress.id) { change -> selectionController.extendTo(change.position); change.consume() }
+                                if (completed) currentOnFinalize() else selectionController.clear()
+                            } else if (!down.isConsumed) {
+                                // null also means cancel (e.g. a scroll won) — only a TAP leaves the down
+                                // unconsumed; a scroll consumes it, so it won't be misread as tap-to-edit.
+                                currentOnTap(down.position)
+                            }
+                        }
+                    }
+                } else {
+                    Modifier
+                },
+            ),
+        state = listState,
+        contentPadding = PaddingValues(horizontal = marginDp.dp, vertical = 16.dp),
+    ) {
+        // Count-based: indices on demand (a newline-dense 14MB file can be 100k+ chunks).
+        items(count = document.chunkCount, key = { it }) { i ->
+            val raw = document.textForChunk(i).toString()
+            // .md → styled markdown spans (no read-aloud span wash — markers shift offsets, plan §OOS).
+            // .txt → raw verbatim, with the spoken-sentence span washed when read-aloud is active.
+            val span = if (isMarkdown) null else highlightSpan(i)
+            val text = when {
+                isMarkdown -> mapper.renderedText(i)   // #125: the mapper is the single render owner
+                span != null -> buildAnnotatedString {
+                    append(raw)
+                    val a = span.first.coerceIn(0, raw.length); val b = (span.last + 1).coerceIn(a, raw.length)
+                    if (b > a) addStyle(SpanStyle(background = wash), a, b)
+                }
+                else -> AnnotatedString(raw)
+            }
+            // annotation washes drawn BEHIND the text (getPathForRange) — separate from the read-aloud span.
+            val washes = washesForChunk(i)
+            var layout by remember(i) { mutableStateOf<TextLayoutResult?>(null) }
+            var coords by remember(i) { mutableStateOf<androidx.compose.ui.layout.LayoutCoordinates?>(null) }
+            if (selectionController != null) {
+                LaunchedEffect(i, layout, coords) {
+                    val l = layout; val c = coords
+                    if (l != null && c != null) selectionController.registerChunk(i, l, c)
+                }
+                DisposableEffect(selectionController, i) { onDispose { selectionController.unregisterChunk(i) } }
+            }
+            // read `selection` (a State) so a selection change recomposes + redraws the accent.
+            val selRange = if (selection != null) selectionController?.selectionForChunk(i) else null
+            Text(
+                text = text,
+                // merge over the material default (the pre-#129 explicit-param behavior) so platform
+                // text defaults (letterSpacing etc.) are kept — only the Display settings change.
+                style = androidx.compose.material3.LocalTextStyle.current.merge(textStyle),
+                onTextLayout = { layout = it },
+// Purpose: feature #118 WI-2 (#110 Phase 3) — the AI client seam + the shared HTTP/SSE plumbing.
+// `AiClient` mirrors iOS `AIProvider` (stream + one-shot + test-connection); `BaseHttpAiClient` owns
+// the POST-over-HttpURLConnection transport (the #116/#117 precedent), the typed-error mapping, the
+// bounded streaming loop (cancellation disconnects), and a bounded one-shot read. The provider
+// concretes supply only the endpoint path, auth headers, request body, and the per-wire payload
+// parse (OpenAI vs Anthropic). The API key + auth headers are NEVER logged.
+package com.vreader.app.ai
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.job
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.SocketTimeoutException
+import java.net.URL
+import kotlin.coroutines.coroutineContext
+
+interface AiClient {
+    /** Streamed assistant text deltas. Cancelling the collector disconnects the HTTP stream. */
+    fun streamChat(request: AiRequest): Flow<AiChunk>
+    /** One-shot (non-streamed) completion. */
+    suspend fun chat(request: AiRequest): AiResponse
+    /** A tiny ping → Ok / typed Fail (the editor's Connection section). */
+    suspend fun testConnection(): AiTestResult
+}
+
+/** A parsed SSE delta: incremental [text] (or null if this event carries none) + a [done] sentinel. */
+data class DeltaParse(val text: String?, val done: Boolean)
+
+abstract class BaseHttpAiClient(
+    protected val baseUrl: String,
+    protected val apiKey: String,
+    protected val model: String,
+    protected val temperature: Double,
+    protected val maxTokens: Int,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val connectTimeoutMs: Int = 15_000,
+    private val readTimeoutMs: Int = 60_000,
+) : AiClient {
+
+    protected abstract val endpointPath: String
+    protected abstract fun applyAuth(conn: HttpURLConnection)
+    protected abstract fun requestBody(request: AiRequest, stream: Boolean): String
+    protected abstract fun parseDelta(event: SseEvent): DeltaParse
+    protected abstract fun parseOneShot(json: String): String
+
+    final override fun streamChat(request: AiRequest): Flow<AiChunk> = flow {
+        val conn = openPost(requestBody(request, stream = true))
+        // Disconnect PROMPTLY on cancellation — otherwise a blocking reader.read() inside the
+        // Sequence wouldn't honour cancel until readTimeout (up to 60s). Closing the socket makes
+        // the blocked read throw, unwinding immediately.
+        val onCancel = coroutineContext.job.invokeOnCompletion { runCatching { conn.disconnect() } }
+        try {
+            checkStatus(conn)
+            var emitted = 0
+            var sawTerminal = false
+            for (ev in SseEventReader.events(conn.inputStream)) {
+                coroutineContext.ensureActive()
+                val d = parseDelta(ev)
+                if (d.done) { sawTerminal = true; break }
+                val text = d.text ?: continue
+                emitted += text.length
+                if (emitted > MAX_ANSWER_CHARS) throw AiError.Stream("answer exceeds the length limit")
+                emit(AiChunk(text))
+            }
+            // EOF before the terminal sentinel ([DONE] / message_stop) = a dropped/truncated stream,
+            // not a clean finish — surface it rather than returning a silent partial answer.
+            if (!sawTerminal) { coroutineContext.ensureActive(); throw AiError.Stream("stream ended before its terminal event") }
+        } finally {
+            onCancel.dispose()
+            conn.disconnect()
+        }
+    }.flowOn(dispatcher)
+
+    final override suspend fun chat(request: AiRequest): AiResponse = withContext(dispatcher) {
+        val conn = openPost(requestBody(request, stream = false))
+        // Same prompt-cancellation guard as streamChat — a blocking one-shot read shouldn't hang to
+        // readTimeout if the caller cancels.
+        val onCancel = coroutineContext.job.invokeOnCompletion { runCatching { conn.disconnect() } }
+        try {
+            checkStatus(conn)
+            AiResponse(parseOneShot(conn.inputStream.readBoundedText(MAX_ONESHOT_BYTES)))
+        } finally {
+            onCancel.dispose()
+            conn.disconnect()
+        }
+    }
+
+    final override suspend fun testConnection(): AiTestResult = try {
+        chat(AiRequest(model, listOf(AiMessage(AiRole.user, "ping")), temperature, maxTokens = 8))
+        AiTestResult.Ok
+    } catch (e: AiError) {
+        AiTestResult.Fail(e, e.message ?: "connection failed")
+    }
+
+    // ── transport ─────────────────────────────────────────────
+
+    private fun openPost(body: String): HttpURLConnection {
+        // Path-dedup (iOS Bug #185): if the base already ends with the endpoint, don't append again.
+        val base = baseUrl.trim().trimEnd('/')
+        val full = if (base.endsWith(endpointPath)) base else base + endpointPath
+        val url = runCatching { URL(full) }.getOrNull() ?: throw AiError.Config("invalid base URL")
+        requireSafeScheme(url)  // never send the key over cleartext to a remote host
+        val conn = try { url.openConnection() as HttpURLConnection } catch (e: Exception) { throw AiError.Offline }
+        try {
+            conn.requestMethod = "POST"
+            conn.connectTimeout = connectTimeoutMs
+            conn.readTimeout = readTimeoutMs
+            conn.instanceFollowRedirects = false  // never let HUC silently re-POST/forward the key on a 3xx
+            conn.setRequestProperty("Content-Type", "application/json")
+            conn.setRequestProperty("Accept", "text/event-stream")
+            applyAuth(conn)  // NEVER logged
+            conn.doOutput = true
+            conn.outputStream.use { it.write(body.toByteArray(Charsets.UTF_8)) }
+            return conn
+        } catch (e: SocketTimeoutException) {
+            conn.disconnect(); throw AiError.Timeout
+        } catch (e: IOException) {
+            conn.disconnect(); throw AiError.Offline
+        }
+    }
+
+    /** Map the response status; a 2xx returns, anything else throws a typed error (error body is
+     *  bounded-discarded, never fully read). */
+    private fun checkStatus(conn: HttpURLConnection) {
+        val status = try {
+            conn.responseCode
+        } catch (e: SocketTimeoutException) {
+            throw AiError.Timeout
+        } catch (e: IOException) {
+            throw AiError.Offline
+        }
+        if (status / 100 == 2) return
+        // Do NOT read the error body — it could block/throw and mask the known status; disconnect
+        // (in the caller's finally) tears the connection down.
+        throw when (status) {
+            401, 403 -> AiError.Auth401
+            429 -> AiError.RateLimited429
+            else -> AiError.Http(status)
+        }
+    }
+
+    /** Refuse to send the API key over cleartext http:// to a non-local host (https required;
+     *  loopback / the emulator host alias are allowed for local dev + tests). */
+    private fun requireSafeScheme(url: URL) {
+        if (url.protocol.equals("https", ignoreCase = true)) return
+        val host = url.host
+        val local = host == "127.0.0.1" || host == "::1" || host.equals("localhost", true) || host == "10.0.2.2"
+        if (url.protocol.equals("http", ignoreCase = true) && local) return
+        throw AiError.InsecureUrl
+    }
+
+    /** Accumulate the bounded body as BYTES, then decode UTF-8 ONCE — so a multibyte (CJK)
+     *  character split across a read boundary isn't corrupted. */
+    private fun InputStream.readBoundedText(max: Long): String {
+        val out = ByteArrayOutputStream()
+        val buf = ByteArray(16 * 1024)
+        var total = 0L
+        use {
+            while (true) {
+                val n = read(buf)
+                if (n < 0) break
+                total += n
+                if (total > max) throw AiError.Decode("response exceeds the size limit")
+                out.write(buf, 0, n)
+            }
+        }
+        return out.toString("UTF-8")
+    }
+
+    protected companion object {
+        const val MAX_ANSWER_CHARS = 200_000
+        const val MAX_ONESHOT_BYTES = 4L * 1024 * 1024
+    }
+}
+// Purpose: feature #118 WI-2 (#110 Phase 3) — builds the right AiClient for a provider profile +
+// its decrypted API key. The chat/test request path resolves the active profile from a single
+// AiProviderStore.snapshot(), decrypts via apiKey(profile), and calls this — so the client is built
+// from one consistent snapshot, never live mid-request reads.
+package com.vreader.app.ai
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+object AiProviderFactory {
+    fun create(profile: AiProviderProfile, apiKey: String, dispatcher: CoroutineDispatcher = Dispatchers.IO): AiClient {
+        val base = profile.baseUrl.ifBlank { profile.kind.defaultBaseUrl }
+        val model = profile.model.ifBlank { profile.kind.defaultModel }
+        return when (profile.kind) {
+            AiProviderKind.openAiCompatible ->
+                OpenAiCompatibleProvider(base, apiKey, model, profile.temperature, profile.maxTokens, dispatcher)
+            AiProviderKind.anthropicNative ->
+                AnthropicProvider(base, apiKey, model, profile.temperature, profile.maxTokens, dispatcher)
+        }
+    }
+}
+// Purpose: feature #118 WI-1 (#110 Phase 3) — persists saved AI provider profiles + the active
+// selection. Profile metadata (name/kind/baseUrl/model/temperature/maxTokens) lives in DataStore
+// as a JSON list; the API key is kept ONLY as a SecretCipher token (the #116 KeystoreSecretCipher).
+// Reuses the #116 WebDavServerStore DataStore+SecretCipher credential pattern, adding an active-id
+// and a request-start `snapshot()` (a chat/test reads one consistent profile, not live mid-request
+// store reads). The key + auth headers are NEVER logged.
+package com.vreader.app.ai
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.vreader.app.backup.net.SecretCipher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/** A saved AI provider. `encryptedApiKey` is a [SecretCipher] token, never plaintext. */
+@Serializable
+data class AiProviderProfile(
+    val id: String,
+    val name: String,
+    val kind: AiProviderKind,
+    val baseUrl: String,
+    val model: String,
+    val temperature: Double = 0.7,
+    val maxTokens: Int = 2048,
+    val encryptedApiKey: String,
+)
+
+/** A consistent point-in-time view: the profiles + which is active. */
+data class AiProviderSnapshot(val profiles: List<AiProviderProfile>, val activeId: String?) {
+    val active: AiProviderProfile? get() = profiles.firstOrNull { it.id == activeId }
+}
+
+@Serializable
+private data class AiStoreState(val profiles: List<AiProviderProfile> = emptyList(), val activeId: String? = null)
+
+class AiProviderStore(
+    private val dataStore: DataStore<Preferences>,
+    private val cipher: SecretCipher,
+    private val json: Json = Json { ignoreUnknownKeys = true; encodeDefaults = true },
+) {
+    /** One consistent profiles + active-id view (read once at request start). */
+    suspend fun snapshot(): AiProviderSnapshot = read(dataStore.data.first()).toSnapshot()
+
+    fun observe(): Flow<AiProviderSnapshot> = dataStore.data.map { read(it).toSnapshot() }
+
+    suspend fun list(): List<AiProviderProfile> = snapshot().profiles
+
+    suspend fun activeProfile(): AiProviderProfile? = snapshot().active
+
+    /**
+     * Insert/update a profile by [id]. [apiKey] is the PLAINTEXT to encrypt; pass null on an edit
+     * that leaves the key unchanged (the existing ciphertext is kept). A brand-new id REQUIRES a
+     * key. The first profile added becomes active. Returns the saved profile (key encrypted).
+     */
+    suspend fun upsert(
+        id: String,
+        name: String,
+        kind: AiProviderKind,
+        baseUrl: String,
+        model: String,
+        temperature: Double,
+        maxTokens: Int,
+        apiKey: String?,
+    ): AiProviderProfile {
+        lateinit var saved: AiProviderProfile
+        dataStore.edit { prefs ->
+            val cur = read(prefs)
+            val existing = cur.profiles.firstOrNull { it.id == id }
+            val encrypted = when {
+                apiKey != null -> cipher.encrypt(apiKey)
+                existing != null -> existing.encryptedApiKey  // unchanged on edit
+                else -> throw IllegalArgumentException("a new provider ($id) requires an API key")
+            }
+            saved = AiProviderProfile(id, name, kind, baseUrl, model, temperature, maxTokens, encrypted)
+            val next = cur.profiles.filterNot { it.id == id } + saved
+            val activeId = cur.activeId ?: id  // first provider becomes active
+            prefs[KEY] = json.encodeToString(AiStoreState(next, activeId))
+        }
+        return saved
+    }
+
+    /** Remove a profile. If it was active, the active selection moves to the first remaining (or null). */
+    suspend fun delete(id: String) {
+        dataStore.edit { prefs ->
+            val cur = read(prefs)
+            val next = cur.profiles.filterNot { it.id == id }
+            val activeId = if (cur.activeId == id) next.firstOrNull()?.id else cur.activeId
+            prefs[KEY] = json.encodeToString(AiStoreState(next, activeId))
+        }
+    }
+
+    /** Select the active provider (no-op if the id isn't present). */
+    suspend fun setActive(id: String) {
+        dataStore.edit { prefs ->
+            val cur = read(prefs)
+            if (cur.profiles.any { it.id == id }) prefs[KEY] = json.encodeToString(cur.copy(activeId = id))
+        }
+    }
+
+    /** Decrypt the key from a CAPTURED [profile] — snapshot-consistent (no live store read). The
+     *  chat/test request path uses THIS with a profile from a single [snapshot], so it can't pair
+     *  snapshot metadata with a concurrently-edited/deleted key. */
+    fun apiKey(profile: AiProviderProfile): String = cipher.decrypt(profile.encryptedApiKey)
+
+    /** The decrypted API key for [id] via a live read, or null if absent. Convenience for UI flows
+     *  that aren't mid-request; the request path should prefer [apiKey] (profile). */
+    suspend fun apiKey(id: String): String? =
+        list().firstOrNull { it.id == id }?.let { cipher.decrypt(it.encryptedApiKey) }
+
+    private fun read(prefs: Preferences): AiStoreState {
+        val raw = prefs[KEY] ?: return AiStoreState()
+        return runCatching { json.decodeFromString<AiStoreState>(raw) }.getOrDefault(AiStoreState())
+    }
+
+    private fun AiStoreState.toSnapshot() = AiProviderSnapshot(profiles, activeId)
+
+    companion object {
+        private val KEY = stringPreferencesKey("ai_providers_json")
+    }
+}
+
+exec
+/bin/zsh -lc "rg -n \"data class AiRequest|sealed class AiError|data class AiResponse|data class AiMessage|enum class AiRole\" android/app/src/main/kotlin/com/vreader/app/ai -C 4
+sed -n '1,260p' android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt
+sed -n '1,240p' android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt
+rg -n \"data class TxtDocument|class TxtDocument|chapter|chunkStart|charOffset|originalFormat\" android/app/src/main/kotlin/com/vreader/app/reader android/app/src/main/kotlin/com/vreader/app -g '*.kt' | head -200" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-2-// iOS AITypes (AIRequest/AIResponse/AIStreamChunk/AIError). Provider-neutral; the OpenAI vs
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-3-// Anthropic wire differences live in the providers.
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-4-package com.vreader.app.ai
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-5-
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt:6:enum class AiRole { system, user, assistant }
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-7-
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt:8:data class AiMessage(val role: AiRole, val content: String)
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-9-
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-10-/** A chat request. `system` is the system prompt (Anthropic carries it top-level; the OpenAI
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-11- *  provider prepends it as a system message). */
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt:12:data class AiRequest(
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-13-    val model: String,
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-14-    val messages: List<AiMessage>,
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-15-    val temperature: Double,
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-16-    val maxTokens: Int,
+--
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-20-/** One streamed delta (the incremental assistant text). */
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-21-data class AiChunk(val deltaText: String)
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-22-
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-23-/** A one-shot (non-streamed) response. */
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt:24:data class AiResponse(val text: String)
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-25-
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-26-/** Typed AI failures (HTTP + transport + protocol). */
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt:27:sealed class AiError(message: String) : Exception(message) {
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-28-    object Auth401 : AiError("authentication failed (401) — check the API key")
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-29-    object RateLimited429 : AiError("rate limited (429) — try again shortly")
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-30-    object Offline : AiError("the provider couldn't be reached")
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt-31-    object Timeout : AiError("the provider took too long to respond")
+// Purpose: Room database + schema-versioned migration scaffold — feature #106 WI-3.
+// Version 8 is the current schema; v1 was the initial books+positions baseline and
+// MIGRATION_1_2 is the worked example of the additive-migration pattern (adds
+// books.lastOpenedAt). Subsequent additive migrations: 2→3 daily_reading (#122),
+// 3→4 annotations (#123), 4→5 collections (#127), 5→6 books.author (#128 search),
+// 6→7 the FTS search index (search_sections + search_sections_fts + search_index_state
+// + search_sections_staging, all #128 WI-4), 7→8 the composite UNIQUE (bookKey, profileKey)
+// index on `bookmarks` — preceded by an in-migration dedupe of pre-existing duplicate rows so
+// the unique index can't fail on a legacy duplicate (feature #135 WI-3). The migration round-trip
+// test (VReaderDatabaseMigrationTest) guards them. Future schema changes append a
+// Migration(n, n+1) to ALL_MIGRATIONS and bump `version`.
+package com.vreader.app.data
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+@Database(
+    entities = [
+        BookEntity::class, ReadingPositionEntity::class, DailyReadingEntity::class,
+        HighlightEntity::class, AnnotationNoteEntity::class, BookmarkEntity::class,
+        CollectionEntity::class, BookCollectionCrossRef::class,
+        SearchSectionEntity::class, SearchSectionFtsEntity::class,
+        SearchIndexStateEntity::class, SearchStagingEntity::class,
+    ],
+    version = 8,
+    exportSchema = true,
+)
+abstract class VReaderDatabase : RoomDatabase() {
+    abstract fun bookDao(): BookDao
+    abstract fun readingPositionDao(): ReadingPositionDao
+    abstract fun readingStatsDao(): ReadingStatsDao
+    abstract fun annotationDao(): AnnotationDao
+    abstract fun collectionDao(): CollectionDao
+    abstract fun searchDao(): SearchDao
+
+    companion object {
+        private const val DB_NAME = "vreader.db"
+
+        /** v1 → v2: add the nullable `lastOpenedAt` recents column to `books`. */
+        val MIGRATION_1_2: Migration = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE books ADD COLUMN lastOpenedAt INTEGER")
+            }
+        }
+
+        /** v2 → v3: feature #122 — add the additive `daily_reading` per-day/per-book stats table +
+         *  its bookKey index. No data transform. DDL matches Room's generated schema exactly. */
+        val MIGRATION_2_3: Migration = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `daily_reading` (`date` TEXT NOT NULL, `bookKey` TEXT NOT NULL, " +
+                        "`minutes` INTEGER NOT NULL, PRIMARY KEY(`date`, `bookKey`))",
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_daily_reading_bookKey` ON `daily_reading` (`bookKey`)")
+            }
+        }
+
+        /** v3 → v4: feature #123 — add the additive `highlights`, `annotation_notes`, and `bookmarks`
+         *  annotation tables (each FK→books ON DELETE CASCADE; highlights has the unique
+         *  `(profileKey, anchorKey)` dedupe index). No data transform. DDL matches Room's generated
+         *  schema for v4 exactly (the migration test opens the real Room DB, whose structural PRAGMA
+         *  validation catches any drift). */
+        val MIGRATION_3_4: Migration = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `highlights` (`highlightId` TEXT NOT NULL, " +
+                        "`bookKey` TEXT NOT NULL, `profileKey` TEXT NOT NULL, `anchorKey` TEXT NOT NULL, " +
+                        "`color` TEXT NOT NULL, `selectedText` TEXT NOT NULL, `note` TEXT, " +
+                        "`locatorJSON` TEXT NOT NULL, `anchorJSON` TEXT, `createdAt` INTEGER NOT NULL, " +
+                        "`updatedAt` INTEGER NOT NULL, PRIMARY KEY(`highlightId`), " +
+                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_highlights_bookKey` ON `highlights` (`bookKey`)")
+                db.execSQL(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS `index_highlights_profileKey_anchorKey` " +
+                        "ON `highlights` (`profileKey`, `anchorKey`)",
+                )
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `annotation_notes` (`noteId` TEXT NOT NULL, " +
+                        "`bookKey` TEXT NOT NULL, `profileKey` TEXT NOT NULL, `content` TEXT NOT NULL, " +
+                        "`locatorJSON` TEXT NOT NULL, `anchorJSON` TEXT, `createdAt` INTEGER NOT NULL, " +
+                        "`updatedAt` INTEGER NOT NULL, PRIMARY KEY(`noteId`), " +
+                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_annotation_notes_bookKey` " +
+                        "ON `annotation_notes` (`bookKey`)",
+                )
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `bookmarks` (`bookmarkId` TEXT NOT NULL, " +
+                        "`bookKey` TEXT NOT NULL, `profileKey` TEXT NOT NULL, `title` TEXT, " +
+                        "`locatorJSON` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, " +
+                        "`updatedAt` INTEGER NOT NULL, PRIMARY KEY(`bookmarkId`), " +
+                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_bookmarks_bookKey` ON `bookmarks` (`bookKey`)")
+            }
+        }
+
+        /** v4 → v5: feature #127 — add the additive `collections` table (unique `nameKey` index) +
+         *  the `book_collection` many-to-many join (composite PK, both FKs ON DELETE CASCADE, a
+         *  `collectionId` index for the reverse lookup). No data transform. DDL matches Room's generated
+         *  v5 schema exactly (the migration test opens the real Room DB, whose structural PRAGMA
+         *  validation catches any drift). */
+        val MIGRATION_4_5: Migration = object : Migration(4, 5) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `collections` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, " +
+                        "`nameKey` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+                )
+                db.execSQL(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS `index_collections_nameKey` ON `collections` (`nameKey`)",
+                )
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `book_collection` (`bookKey` TEXT NOT NULL, " +
+                        "`collectionId` TEXT NOT NULL, PRIMARY KEY(`bookKey`, `collectionId`), " +
+                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+                        "ON UPDATE NO ACTION ON DELETE CASCADE , " +
+                        "FOREIGN KEY(`collectionId`) REFERENCES `collections`(`id`) " +
+                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_book_collection_collectionId` " +
+                        "ON `book_collection` (`collectionId`)",
+                )
+            }
+        }
+
+        /** v5 → v6: feature #128 — add the nullable `author` column to `books` (library search).
+         *  Purely additive; migrated rows read `author = null` until a backfill or restore sets it. */
+        val MIGRATION_5_6: Migration = object : Migration(5, 6) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE books ADD COLUMN author TEXT")
+            }
+        }
+
+        /** v6 → v7: feature #128 WI-4 — add the cross-book search index (all in the one `vreader.db`):
+         *  `search_sections` (+ bookKey index + FK→books CASCADE), its FTS4/unicode61 content-table
+         *  shadow `search_sections_fts`, `search_index_state` (+ FK→books CASCADE), and the transient
+         *  `search_sections_staging` buffer (+ bookKey index + FK→books CASCADE). The migration ships
+         *  the base + FTS VIRTUAL tables only; Room recreates the FTS content-table sync triggers when
+         *  it opens the DB. DDL matches Room's generated v7 schema exactly (the migration test opens the
+         *  real Room DB, whose structural PRAGMA validation catches any drift). No data transform. */
+        val MIGRATION_6_7: Migration = object : Migration(6, 7) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `search_sections` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                        "`bookKey` TEXT NOT NULL, `sectionIndex` INTEGER NOT NULL, `chunkOrdinal` INTEGER NOT NULL, " +
+                        "`sectionTitle` TEXT, `text` TEXT NOT NULL, `indexedText` TEXT NOT NULL, " +
+                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_search_sections_bookKey` ON `search_sections` (`bookKey`)")
+                db.execSQL(
+                    "CREATE VIRTUAL TABLE IF NOT EXISTS `search_sections_fts` USING FTS4(" +
+                        "`indexedText` TEXT NOT NULL, tokenize=unicode61, content=`search_sections`)",
+                )
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `search_index_state` (`bookKey` TEXT NOT NULL, " +
+                        "`indexerVersion` INTEGER NOT NULL, `indexedAt` INTEGER NOT NULL, `status` TEXT NOT NULL, " +
+                        "PRIMARY KEY(`bookKey`), FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+                )
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `search_sections_staging` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                        "`bookKey` TEXT NOT NULL, `sectionIndex` INTEGER NOT NULL, `chunkOrdinal` INTEGER NOT NULL, " +
+                        "`sectionTitle` TEXT, `text` TEXT NOT NULL, `indexedText` TEXT NOT NULL, " +
+                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_search_sections_staging_bookKey` " +
+                        "ON `search_sections_staging` (`bookKey`)",
+                )
+            }
+        }
+
+        /** v7 → v8: feature #135 WI-3 — make re-bookmarking the same position idempotent by adding a
+         *  composite UNIQUE index on `bookmarks (bookKey, profileKey)` (the atomic-toggle enforcer,
+         *  mirroring the highlights `(profileKey, anchorKey)` dedupe precedent).
+         *
+         *  A pre-#135 create path (`upsertBookmark`, UUID-keyed) could have produced DUPLICATE rows at
+         *  the same `(bookKey, profileKey)`; `CREATE UNIQUE INDEX` would FAIL on such a duplicate. So
+         *  the migration first DEDUPES — deleting every duplicate LOSER, keeping a DETERMINISTIC winner
+         *  per `(bookKey, profileKey)`: the row with the greatest `updatedAt`, tie-broken by the
+         *  greatest `createdAt`, then the LOWEST `bookmarkId` (a total, stable order). This is a
+         *  targeted dedupe — a non-duplicate row (unique `(bookKey, profileKey)`) is never deleted, and
+         *  no other table is touched. THEN the unique index is created, matching Room's generated name
+         *  + columns (`index_bookmarks_bookKey_profileKey` on `(bookKey, profileKey)`) exactly, so
+         *  Room's structural PRAGMA validation passes. DDL is idempotent (`IF NOT EXISTS`). */
+        val MIGRATION_7_8: Migration = object : Migration(7, 8) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // 1) Dedupe: delete every row that is NOT the deterministic winner within its
+                //    (bookKey, profileKey) group. The winner is the row whose (updatedAt, createdAt,
+                //    -rowid-preference-on-bookmarkId) is greatest — expressed as: a row is a loser iff
+                //    another row in the same group ranks strictly higher by (updatedAt DESC,
+                //    createdAt DESC, bookmarkId ASC).
+                db.execSQL(
+                    "DELETE FROM `bookmarks` WHERE `bookmarkId` IN (" +
+                        "SELECT b.`bookmarkId` FROM `bookmarks` b JOIN `bookmarks` w " +
+                        "ON b.`bookKey` = w.`bookKey` AND b.`profileKey` = w.`profileKey` " +
+                        "AND b.`bookmarkId` <> w.`bookmarkId` " +
+                        "WHERE (w.`updatedAt` > b.`updatedAt`) " +
+                        "OR (w.`updatedAt` = b.`updatedAt` AND w.`createdAt` > b.`createdAt`) " +
+                        "OR (w.`updatedAt` = b.`updatedAt` AND w.`createdAt` = b.`createdAt` " +
+                        "AND w.`bookmarkId` < b.`bookmarkId`))",
+                )
+                // 2) Now that each (bookKey, profileKey) is unique, create the unique index.
+                db.execSQL(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS `index_bookmarks_bookKey_profileKey` " +
+                        "ON `bookmarks` (`bookKey`, `profileKey`)",
+                )
+            }
+        }
+
+        /** All registered migrations, oldest first. Append future Migration(n,n+1) here. */
+        val ALL_MIGRATIONS: Array<Migration> =
+            arrayOf(
+                MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
+                MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8,
+            )
+
+        /** The production on-disk database (app-private storage). */
+        fun build(context: Context): VReaderDatabase =
+            Room.databaseBuilder(context.applicationContext, VReaderDatabase::class.java, DB_NAME)
+                .addMigrations(*ALL_MIGRATIONS)
+                .build()
+    }
+}
+// Purpose: Application + manual DI container — feature #106 WI-8. Holds the
+// process-singleton Room database, repository, and importer so the Library
+// ViewModel gets shared instances (a Hilt module is a Phase-3 follow-on; manual
+// wiring at the app edge keeps the foundation bar dependency-light — rule 50 §5).
+package com.vreader.app
+
+import android.app.Application
+import android.content.Context
+import com.vreader.app.data.BookImporter
+import com.vreader.app.data.LibraryRepository
+import com.vreader.app.data.VReaderDatabase
+import com.vreader.app.reader.BookOpener
+import com.vreader.app.search.BookTextExtractor
+import com.vreader.app.search.EpubTextExtractor
+import com.vreader.app.search.asSearcher
+import com.vreader.app.search.SearchIndexCoordinator
+import com.vreader.app.search.TxtMdTextExtractor
+import com.vreader.app.annotations.AnnotationsRepository
+import com.vreader.app.stats.ReadingStatsRepository
+import com.vreader.app.stats.ReadingTimeTracker
+import com.vreader.app.stats.clock.SystemDateClock
+import com.vreader.app.stats.clock.SystemElapsedClock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.map
+import vreader.contracts.BookFormat
+import java.io.File
+
+/** Process-wide singletons, lazily built. */
+class AppContainer(context: Context) {
+    private val appContext = context.applicationContext
+
+    val database: VReaderDatabase by lazy { VReaderDatabase.build(appContext) }
+    val repository: LibraryRepository by lazy {
+        LibraryRepository(database.bookDao(), database.readingPositionDao())
+    }
+    val importer: BookImporter by lazy {
+        BookImporter(File(appContext.filesDir, "books"), repository)
+    }
+
+    // feature #122 — reading-stats. The repository + the time tracker are process-singletons so a
+    // reading session survives the (shorter-lived) reader ViewModel / rotation. ONE shared DateClock
+    // so the dashboard's "today" and the tracker's bucket dates can't drift apart.
+    private val dateClock: SystemDateClock by lazy { SystemDateClock() }
+    val statsRepository: ReadingStatsRepository by lazy {
+        ReadingStatsRepository(database.readingStatsDao(), repository, dateClock)
+    }
+    val readingTimeTracker: ReadingTimeTracker by lazy {
+        ReadingTimeTracker(statsRepository, SystemElapsedClock(), dateClock)
+    }
+
+    // feature #123 — annotations (EPUB highlights & notes). Process-singleton so the reader VM /
+    // rotation share one instance (the statsRepository precedent).
+    val annotationsRepository: AnnotationsRepository by lazy {
+        AnnotationsRepository(database.annotationDao())
+    }
+
+    // feature #127 — library collections. Process-singleton (the annotationsRepository precedent).
+    val collectionRepository: com.vreader.app.data.CollectionRepository by lazy {
+        com.vreader.app.data.CollectionRepository(database.collectionDao())
+    }
+
+    // feature #129 — reader display settings. A device-local DataStore (the OpdsSourceStore /
+    // AiProviderStore precedent), global (not per-book), process-singleton so a settings change
+    // propagates to whatever reader is open. Stored under noBackupFilesDir — display prefs are
+    // per-device (NOT in the backup contract), so they must be excluded from Android Auto Backup.
+    private val readerSettingsDataStore: androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences> by lazy {
+        androidx.datastore.preferences.core.PreferenceDataStoreFactory.create {
+            File(appContext.noBackupFilesDir, "reader_settings.preferences_pb")
+        }
+    }
+    val readerSettingsStore: com.vreader.app.reader.settings.ReaderSettingsStore by lazy {
+        com.vreader.app.reader.settings.ReaderSettingsStore(readerSettingsDataStore)
+    }
+
+    /** Process-lifetime scope for fire-and-forget writes that must outlive a screen
+     *  (e.g. the reader's onStop position flush — it must finish even as the activity
+     *  is being torn down). */
+    val appScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    // feature #128 WI-5 — cross-book search index. The coordinator observes the library and
+    // streams each indexable book (epub/txt/md) through the WI-3 extractors into WI-4's staging →
+    // atomic publish. Eagerly started once from onCreate; pdf/azw3 map to null (never indexable).
+    private val bookOpener: BookOpener by lazy { BookOpener(appContext) }
+    private val epubTextExtractor: EpubTextExtractor by lazy { EpubTextExtractor(bookOpener) }
+    private val txtMdTextExtractor: TxtMdTextExtractor by lazy { TxtMdTextExtractor() }
+    val searchIndexCoordinator: SearchIndexCoordinator by lazy {
+        SearchIndexCoordinator(
+            repository = repository,
+            searchDao = database.searchDao(),
+            extractorFor = { fmt: BookFormat ->
+                when (fmt) {
+                    BookFormat.epub -> epubTextExtractor
+                    BookFormat.txt, BookFormat.md -> txtMdTextExtractor
+                    BookFormat.pdf, BookFormat.azw3 -> null   // metadata-only — never indexed
+                }
+            },
+            scope = appScope,
+            ioDispatcher = Dispatchers.IO,
+        )
+    }
+
+    /** Idempotent — starts the single search-index collector (the coordinator's own AtomicBoolean
+     *  makes a repeat call a no-op). Called once from [VReaderApp.onCreate]. */
+    fun startSearchIndexing() = searchIndexCoordinator.startSearchIndexing()
+
+    // feature #128 WI-6 — the query pipeline. SearchRepository turns a raw query into an observable
+    // Flow of first-hit-per-book text hits (grows as indexing completes); RecentSearchesStore is a
+    // device-local DataStore under noBackupFilesDir (the readerSettingsStore precedent — recents are
+    // per-device, NOT in the backup contract). The SearchViewModel factory wires the metadata filter,
+    // the text-hit Flow, the completeness gate, and recent-recording for the WI-7 screen.
+    val searchRepository: com.vreader.app.search.SearchRepository by lazy {
+        com.vreader.app.search.SearchRepository(database.searchDao())
+    }
+    private val recentSearchesDataStore: androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences> by lazy {
+        androidx.datastore.preferences.core.PreferenceDataStoreFactory.create {
+            File(appContext.noBackupFilesDir, "recent_searches.preferences_pb")
+        }
+    }
+    val recentSearchesStore: com.vreader.app.search.RecentSearchesStore by lazy {
+        com.vreader.app.search.RecentSearchesStore(recentSearchesDataStore)
+    }
+
+    /**
+     * feature #133 WI-10 — the per-reader-session in-book-search ViewModel for a TXT/MD host. Wires the
+     * WI-6 [InBookSearchRepository] (FTS DAO page/count/resume + the WI-4 [TxtMdInBookHitResolver] over the
+     * already-decoded [decodedText]) behind the WI-8 [InBookSearchViewModel], gated by the WI-7
+     * [IndexStateGate] over the DAO's `observeIndexState` Flow and fed the GLOBAL recents store.
+     *
+     * The EPUB engine seam is NEVER invoked for a TXT/MD host (the repository dispatches only the TXT/MD
+     * branch for `txt`/`md`), so `epubEngineFor` is an error-throwing guard — a call would be a wiring bug.
+     * ONE [InBookSearchRepository] per session (the VM's `closeAllEpubCursors` lifecycle contract holds
+     * uniformly even though TXT has no cursors). [coroutineScope] is the VM's `viewModelScope` in production
+     * (the VM cancels its child collectors on `onCleared`).
+     */
+    fun inBookSearchViewModel(
+        bookKey: String,
+        format: BookFormat,
+        decodedText: String,
+        contentSHA256: String,
+        fileByteCount: Long,
+        coroutineScope: CoroutineScope,
+    ): com.vreader.app.search.InBookSearchViewModel {
+        val searchDao = database.searchDao()
+        val repository = com.vreader.app.search.InBookSearchRepository(
+            dispatcher = Dispatchers.Default,
+            fts = com.vreader.app.search.InBookFtsDeps(
+                matchingChunksPage = { ftsQuery, afterSectionIndex, afterChunkOrdinal, afterId, limit ->
+                    searchDao.matchingChunksPage(bookKey, ftsQuery, afterSectionIndex, afterChunkOrdinal, afterId, limit)
+                },
+                chunkAtOrAfter = { ftsQuery, atSectionIndex, atChunkOrdinal, atId ->
+                    searchDao.chunkAtOrAfter(bookKey, ftsQuery, atSectionIndex, atChunkOrdinal, atId)
+                },
+                // The resolver re-derives the chunk boundaries from the ALREADY-decoded reader text (no I/O);
+                // memoized per session inside the resolver (built once).
+                resolverFor = {
+                    com.vreader.app.search.TxtMdInBookHitResolver(
+                        contentSHA256 = contentSHA256,
+                        fileByteCount = fileByteCount,
+                        format = format.name,
+                        decodedText = decodedText,
+                    )
+                },
+            ),
+            // TXT/MD never reaches the EPUB branch — a call here is a dispatch bug, fail fast.
+            epubEngineFor = { error("EPUB in-book search engine requested on a TXT/MD host") },
+        )
+        return com.vreader.app.search.InBookSearchViewModel(
+            bookKey = bookKey,
+            format = format,
+            searcher = repository.asSearcher(),
+            indexStateGate = com.vreader.app.search.IndexStateGate(Dispatchers.Default),
+            indexStateFlow = searchDao.observeIndexState(bookKey),
+            // For a settled-`indexed` TXT/MD row the gate consults this to decide Ready vs definitive
+            // NoResults. `hasOccurrence` carries no query, so we report Ready (true) and let the actual
+            // `page(...)` be the source of truth: a settled book with zero matches runs one fast FTS query
+            // and the repository returns NoResults — the SAME UI outcome the gate's occurrence short-circuit
+            // would give, without threading the live query through a shared mutable seam (no race). The gate
+            // is only consulted on a settled-indexed row, so this never fires while Indexing/missing/failed.
+            hasOccurrence = { true },
+            recentsFlow = recentSearchesStore.recents(),
+            recordQuery = { q -> recentSearchesStore.record(q) },
+            dispatcher = Dispatchers.Default,
+            coroutineScope = coroutineScope,
+        )
+    }
+
+    /**
+     * feature #133 WI-11 — the per-reader-session in-book-search ViewModel for the EPUB host. EPUB search does
+     * NOT use the #128 FTS index at all (a chunk-level, location-less index cannot yield a jumpable position);
+     * instead the WI-6 [InBookSearchRepository]'s EPUB branch runs Readium's OWN `SearchService` over the LIVE
+     * [publication] via the WI-5 [EpubInBookSearchEngine] production constructor (which wraps the real
+     * publication behind the `PublicationSearchSource` seam), returning navigable Readium `Locator`s the host
+     * jumps to with `navigator.go`.
+     *
+     * EPUB bypasses the WI-7 index-state gate entirely: the [indexStateFlow] emits `null` (missing) and
+     * [hasOccurrence] reports Ready, so the gate resolves to Ready and the engine's own `isSearchable` probe
+     * is the real capability check (an un-searchable publication → the repository's [InBookSearchOutcome.Unsupported]
+     * → the WI-8 VM's `hidesSearchEntry`, so the host omits the Search icon). The TXT/MD FTS branch is NEVER
+     * invoked for an EPUB host, so its factories are error-throwing guards (a call would be a wiring bug).
+     *
+     * ONE [InBookSearchRepository] per session (so the live Readium `SearchIterator` behind
+     * `SearchCursor.Epub` is held once and disposed via `closeAllEpubCursors` on dismiss / `onCleared`).
+     * [coroutineScope] is the host's `lifecycleScope` in production (the VM cancels its child collectors on
+     * `onCleared`).
+     */
+    fun epubInBookSearchViewModel(
+        bookKey: String,
+        publication: org.readium.r2.shared.publication.Publication,
+        coroutineScope: CoroutineScope,
+    ): com.vreader.app.search.InBookSearchViewModel {
+        val repository = com.vreader.app.search.InBookSearchRepository(
+            dispatcher = Dispatchers.Default,
+            // The EPUB host never reaches the FTS branch (the repository dispatches only the EPUB branch for
+            // `epub`), so the TXT/MD deps are error-throwing guards — a call here is a wiring bug, fail fast.
+            fts = com.vreader.app.search.InBookFtsDeps(
+                matchingChunksPage = { _, _, _, _, _ -> error("FTS matchingChunksPage requested on an EPUB host") },
+                chunkAtOrAfter = { _, _, _, _ -> error("FTS chunkAtOrAfter requested on an EPUB host") },
+                resolverFor = { error("FTS resolver requested on an EPUB host") },
+            ),
+            // The LIVE wiring: build the WI-5 engine over the real Readium publication (its production
+            // constructor wraps the publication behind the `PublicationSearchSource` seam). One engine per
+            // repository/session; the repository memoizes it per bookKey.
+            epubEngineFor = { com.vreader.app.search.EpubInBookSearchEngine(publication) },
+        )
+        return com.vreader.app.search.InBookSearchViewModel(
+            bookKey = bookKey,
+            format = BookFormat.epub,
+            searcher = repository.asSearcher(),
+            indexStateGate = com.vreader.app.search.IndexStateGate(Dispatchers.Default),
+            // EPUB bypasses the FTS index-state gate: a `null` (missing) row + `hasOccurrence == true` resolve
+            // the gate to Ready, so the engine's own `isSearchable` probe is the capability check.
+            indexStateFlow = kotlinx.coroutines.flow.flowOf(null),
+            hasOccurrence = { true },
+            recentsFlow = recentSearchesStore.recents(),
+            recordQuery = { q -> recentSearchesStore.record(q) },
+            dispatcher = Dispatchers.Default,
+            coroutineScope = coroutineScope,
+        )
+android/app/src/main/kotlin/com/vreader/app/reader/share/BookShareIntent.kt:53:        type = mimeFor(book.originalFormat)
+android/app/src/main/kotlin/com/vreader/app/reader/share/BookFileProvider.kt:88:            val name = safeDisplayName(book.title, extensionFor(book.originalFormat))
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderScreen.kt:156:    // default so #132/#134 callers stay valid). The Bookmarks-tab row shows "p. N" (no preview/chapter).
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderScreen.kt:204:        format = book.originalFormat.name,
+android/app/src/main/kotlin/com/vreader/app/data/SearchDao.kt:81:            "WHERE b.originalFormat IN ('epub', 'txt', 'md') " +
+android/app/src/main/kotlin/com/vreader/app/data/SearchDao.kt:91:            "WHERE b.originalFormat IN ('epub', 'txt', 'md') " +
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:64:        "UPDATE books SET title = :title, originalFormat = :fmt, contentSHA256 = :sha, " +
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:89:                fmt = book.originalFormat,
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:87:            "One key unlocks bilingual translation, chat about a book, and chapter summaries. Your key is stored on-device only.",
+android/app/src/main/kotlin/com/vreader/app/reader/nav/ReadiumTocProvider.kt:42: * (`contentSHA256`/`fileByteCount`/`originalFormat`) is threaded into every canonical
+android/app/src/main/kotlin/com/vreader/app/reader/nav/ReadiumTocProvider.kt:80:            bookFormat = book.originalFormat,
+android/app/src/main/kotlin/com/vreader/app/data/SearchEntities.kt:50:    val sectionIndex: Int,       // per-book reading-order/section index (chapter attribution + tie-break)
+android/app/src/main/kotlin/com/vreader/app/data/SearchEntities.kt:52:    val sectionTitle: String?,   // chapter label for the snippet attribution; null for TXT/MD
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:8:// serif preview · `chapter · p.N · date` sub-line · chevron. Tap-to-jump is capability-gated (a null
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:277: * [BookmarkRowUi.preview] and the `chapter · p.N · date` meta sub-line, and a trailing chevron. The row is
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:286:    // chapter — else "Bookmark" — stands in so the row is never blank (still italic serif, per the design).
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:287:    val primary = ui.preview ?: ui.chapter ?: "Bookmark"
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:350: * The design's `chapter · p.N · date` meta sub-line — only the present parts, joined by " · ". A row
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:351: * with no chapter/page (TXT/MD, which carry a preview instead) shows just the date; nothing is fabricated.
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:354:    listOfNotNull(ui.chapter, ui.pageLabel, ui.dateLabel.takeIf { it.isNotBlank() })
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt:3:// produces a per-chapter summary cached by (book + chapter + source digest + provider + model +
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt:85:    /** Show the chapter summary — cache hit is instant; else a one-shot request, then cached. */
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt:86:    fun summarize(bookFingerprintKey: String, chapterId: String, chapterText: String, regenerate: Boolean = false) {
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt:94:            // different chapters can't share a cached summary.
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt:95:            val cacheKey = listOf(bookFingerprintKey, chapterId, sha256(chapterText), profile.id, effectiveModel, SUMMARY_PROMPT_VERSION).joinToString("|")
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt:105:                    listOf(AiMessage(AiRole.user, "Summarize this chapter in 4 concise key points (markdown bullet list):\n\n$chapterText")),
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:2:// a stored BookmarkRecord into a display row (BookmarkRowUi) DERIVED every call (Risk-7: preview/chapter
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:3:// are NEVER stored). Per format: EPUB/AZW3 = nearest-at-or-above TOC chapter via a PREVALIDATED
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:24:    /** EPUB/AZW3 only: the nearest-at-or-above TOC chapter title; null otherwise / before the first entry. */
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:25:    val chapter: String?,
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:46: * A prevalidated, searchable view of a book's reading-ordered TOC for EPUB/AZW3 bookmark-chapter lookup.
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:64:     * The nearest chapter at or before [target]:
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:67:     *  - **degraded TOC** → href-exact fallback (last same-href entry at/before the in-chapter
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:69:     * Returns null (never a fabricated chapter) when the target can't be placed / the TOC is empty.
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:100:     * The same-`href` TOC entry whose in-chapter `progression` is the GREATEST at or before the target's
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:101:     * — the chapter the bookmark lives in — chosen by `progression`, NOT by list order (a same-href TOC
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:103:     * (conservative: never select a chapter whose position can't be compared). Null when no same-href
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:155:     * @param tocIndex a PREVALIDATED [BookmarkTocIndex] for EPUB/AZW3 chapter lookup (built once from the
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:156:     *   TOC and reused across rows — see [BookmarkTocIndex]); null degrades to a null chapter.
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:176:                    chapter = entry?.title,
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:184:                chapter = null,
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:195:                val raw = locator.charOffsetUTF16
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:199:                    chapter = null,
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:260:    fun cacheOffset(fingerprintKey: String, charOffsetUtf16: Int) { lastOffsets[fingerprintKey] = charOffsetUtf16 }
+android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt:22:    val originalFormat: BookFormat,
+android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt:117:        originalFormat = BookFormat.valueOf(e.originalFormat),
+android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt:130:        originalFormat = originalFormat.name,
+android/app/src/main/kotlin/com/vreader/app/data/BookImporter.kt:97:                        originalFormat = format,
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:26:    val originalFormat: String,   // BookFormat raw value (epub/pdf/txt/md/azw3)
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:149: * `title` is the optional user/chapter label. The composite UNIQUE `(bookKey, profileKey)` index
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatUiState.kt:29:            "What themes appear in this chapter?",
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatUiState.kt:30:            "Summarize this chapter",
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocSheetRows.kt:3:// chapter number (the 1-based row position — our model carries no explicit `ch`), the section title
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocSheetRows.kt:4:// (serif; accent + heavier weight when it is the current chapter, per the design's highlighted row),
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocSheetRows.kt:40: * One Contents row for [entry] at [index]. Shows `chapter# · title · p.N`; when [isCurrent] the row
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocSheetRows.kt:42: * highlighted-chapter state). Tapping calls [onClick] with [index]. testTags: `toc-row-$index` (+
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocSheetRows.kt:62:    // A11y: announce the chapter number, the title, the page label, and the current-chapter state —
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocSheetRows.kt:68:        if (isCurrent) append(", current chapter")
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocSheetRows.kt:85:        // accent bg + accent/600 title is the visible form of the same "current chapter" state).
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocSheetRows.kt:100:        // Title — the highlighted chapter is accent + weight-600; nested entries indent by depth.
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocContentsSheet.kt:6:// `title="Pride and Prejudice"`), a bottom rule, then [TocEntry] rows (chapter# · title · p.N) with the
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocEntry.kt:13: * A single chapter/section row of a book's table of contents.
+android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:104:                    onOpenBook = { book -> openBook(book.originalFormat, book.id) },
+android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:138:                            openBook(row.book.originalFormat, row.book.fingerprintKey)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:3:// units against the RAW text — NO line-ending normalization, so charOffsetUTF16 stays
+android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:9:class TxtDocument private constructor(
+android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:63:            var chunkStart = 0
+android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:70:                        if (i < n) { push(i); chunkStart = i }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:75:                        if (i < n) { push(i); chunkStart = i }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:81:                        if (i - chunkStart >= maxChunkChars && i < n && !text[i - 1].isHighSurrogate()) {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:82:                            push(i); chunkStart = i
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPreviewProvider.kt:19:    /** A snippet starting near [charOffsetUTF16] (clamped >= 0), at most [maxLen] chars, or null. */
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPreviewProvider.kt:20:    fun snippet(charOffsetUTF16: Int, maxLen: Int): String?
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSourceOffsets.kt:27:            val chunkStart = base
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSourceOffsets.kt:29:            val s = maxOf(range.startInclusive, chunkStart) - base
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt:7:// locator for the jump), the highlighted-chapter index, and the Notes review snapshot. [tocIndexFor] is
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt:9:// TOC entry so the Contents sheet highlights the current chapter as the reader scrolls.
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt:20: * highlighted chapter row (-1 when there is no TOC or no positional signal maps to a row); [annotations]
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt:32: * A plain (Readium-free) descriptor of a TOC entry's reading position — its spine href and intra-chapter
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt:35: * [progression] is treated as 0.0 (chapter start).
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt:53: * [currentProgression]) among [positions] — i.e. the current chapter/section row to highlight in the
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt:62: * row, e.g. between chapters), a lexical href comparison is the best-effort fallback for the highlight —
+android/app/src/main/kotlin/com/vreader/app/backup/BackupCollector.kt:92:            val blobPath = BlobPath.make(book.originalFormat, book.contentSHA256, book.fileByteCount)
+android/app/src/main/kotlin/com/vreader/app/backup/BackupCollector.kt:94:            blobs += BlobUpload(blobPath, path, book.originalFormat, book.contentSHA256, book.fileByteCount)
+android/app/src/main/kotlin/com/vreader/app/backup/BackupCollector.kt:150:        format = originalFormat.name,
+android/app/src/main/kotlin/com/vreader/app/backup/BackupCollector.kt:153:        originalExtension = originalFormat.name,
+android/app/src/main/kotlin/com/vreader/app/reader/details/BookDetailsMapper.kt:27:            formatLabel = formatLabel(book.originalFormat),
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:98:                    format = book.originalFormat.name,
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:178:                            bookmarkRowItems(bookmarkRecords, s.book.originalFormat, tocIndex = null, previewProvider = null, dateRenderer = dateRenderer)
+android/app/src/main/kotlin/com/vreader/app/tts/TtsHighlight.kt:10:     * `[chunkStart, chunkEnd)` to wash for the spoken `[charStart, charEnd)`, or null when the spoken
+android/app/src/main/kotlin/com/vreader/app/tts/TtsHighlight.kt:13:    fun localSpan(chunkStart: Int, chunkEnd: Int, charStart: Int, charEnd: Int): IntRange? {
+android/app/src/main/kotlin/com/vreader/app/tts/TtsHighlight.kt:14:        if (chunkEnd <= chunkStart || charEnd <= charStart) return null
+android/app/src/main/kotlin/com/vreader/app/tts/TtsHighlight.kt:15:        val s = maxOf(charStart, chunkStart)
+android/app/src/main/kotlin/com/vreader/app/tts/TtsHighlight.kt:18:        return (s - chunkStart) until (e - chunkStart)
+android/app/src/main/kotlin/com/vreader/app/annotations/EpubAnnotationMapper.kt:34:            format = book.originalFormat.name,
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:146:                    // has no chapter/page (the WI-4 EPUB/AZW3 branch degrades to null fields — no crash) — a
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:231:            // the initial highlighted-chapter index for the current reading position.
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:492:     *  chrome model's highlighted-chapter index in sync as the reader scrolls (prompt, un-debounced — the
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:533:                format = current.originalFormat.name,
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:540:     *  extraction — chapter/page come from the TOC). Lifecycle-scoped so the collector is cancelled with
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:547:                    format = current.originalFormat,
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:613:                bookFormat = current.originalFormat,
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:983: * projection: EPUB/AZW3 chapter/page from the prevalidated [tocIndex] (built ONCE per host from its TOC),
+android/app/src/main/kotlin/com/vreader/app/reader/ReadiumLocatorBridge.kt:85:            originalFormat = bookFormat,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtProgress.kt:2:// chunks (not chapters) and no progress model; reading-stats' "time left in book" needs a 0..1
+android/app/src/main/kotlin/com/vreader/app/reader/TxtProgress.kt:3:// fraction. Pure: the top-visible char offset over the document's total length. No "left in chapter"
+android/app/src/main/kotlin/com/vreader/app/reader/TxtProgress.kt:4:// for TXT (no chapter index).
+android/app/src/main/kotlin/com/vreader/app/reader/ChunkTextMapper.kt:11://   TxtReaderActivity.kt (#125 WI-3 builds the right impl from book.originalFormat), TxtSelectionController.kt
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:6:// path (NOT the Readium bridge): save the top-visible chunk's charOffsetUTF16 as a
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:19:// (TXT/MD jump via the plain Locator's charRangeStartUTF16/charOffsetUTF16 → the existing chunk scroll
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:26:// hit's canonical charOffsetUTF16 resolves to a scroll via the EXISTING chunk-scroll seam
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:190:                    format = book.originalFormat.name,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:191:                    charOffsetUTF16 = offset,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:276:                        val annotatable = s.book.originalFormat == BookFormat.txt || s.book.originalFormat == BookFormat.md
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:277:                        val chunkMapper = remember(s.document, s.book.originalFormat) {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:278:                            if (s.book.originalFormat == BookFormat.md) MarkdownChunkTextMapper(s.document)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:344:                        // projection degrades chapter/page to null) but DOES supply a preview provider (a bounded
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:355:                            bookmarkRowItems(bookmarkRecords, s.book.originalFormat, tocIndex = null, previewProvider = previewProvider, dateRenderer = dateRenderer)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:372:                        val inBookSearchVm = remember(bookKey, s.book.originalFormat) {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:375:                                format = s.book.originalFormat,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:407:                                val target = txtBookmarkScrollTarget(record.locator.charOffsetUTF16, s.document.text.length)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:438:                                        // Resolve the tapped hit's canonical charOffsetUTF16 → scroll via the
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:448:                                            val off = hit.canonicalLocator?.charOffsetUTF16
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:513:                                    s.document, listState, s.book.originalFormat, chunkMapper,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:609:    /** Restore: the saved legacy locator's charOffsetUTF16 → the chunk containing it. */
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:616:        // (non-Readium) envelope → Canonical; its charOffsetUTF16 is the anchor.
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:618:            ?.locator?.charOffsetUTF16 ?: return 0
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:747:            book.contentSHA256, book.fileByteCount, book.originalFormat.name,   // #125: NOT hardcoded "txt" — MD key is "md:…"
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:896: * save-position construction (identity triple + `charOffsetUTF16`), so a bookmark's position lines up with
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:899:fun txtBookmarkLocator(book: com.vreader.app.data.Book, charOffsetUTF16: Int): vreader.contracts.Locator =
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:903:        format = book.originalFormat.name,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:904:        charOffsetUTF16 = charOffsetUTF16.coerceAtLeast(0),
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:927:    BookmarkPreviewProvider { charOffsetUTF16, maxLen ->
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:929:        val start = charOffsetUTF16.coerceAtLeast(0)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:943: *  `charRangeStartUTF16`; a standalone note (or a highlight without a range) at `charOffsetUTF16`; a
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:947:    return (loc.charRangeStartUTF16 ?: loc.charOffsetUTF16 ?: 0).coerceAtLeast(0)
+android/app/src/main/kotlin/com/vreader/app/reader/share/BookShareIntent.kt:53:        type = mimeFor(book.originalFormat)
+android/app/src/main/kotlin/com/vreader/app/reader/share/BookFileProvider.kt:88:            val name = safeDisplayName(book.title, extensionFor(book.originalFormat))
+android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:3:// units against the RAW text — NO line-ending normalization, so charOffsetUTF16 stays
+android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:9:class TxtDocument private constructor(
+android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:63:            var chunkStart = 0
+android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:70:                        if (i < n) { push(i); chunkStart = i }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:75:                        if (i < n) { push(i); chunkStart = i }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:81:                        if (i - chunkStart >= maxChunkChars && i < n && !text[i - 1].isHighSurrogate()) {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:82:                            push(i); chunkStart = i
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt:7:// locator for the jump), the highlighted-chapter index, and the Notes review snapshot. [tocIndexFor] is
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt:9:// TOC entry so the Contents sheet highlights the current chapter as the reader scrolls.
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt:20: * highlighted chapter row (-1 when there is no TOC or no positional signal maps to a row); [annotations]
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt:32: * A plain (Readium-free) descriptor of a TOC entry's reading position — its spine href and intra-chapter
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt:35: * [progression] is treated as 0.0 (chapter start).
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt:53: * [currentProgression]) among [positions] — i.e. the current chapter/section row to highlight in the
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt:62: * row, e.g. between chapters), a lexical href comparison is the best-effort fallback for the highlight —
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderScreen.kt:156:    // default so #132/#134 callers stay valid). The Bookmarks-tab row shows "p. N" (no preview/chapter).
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderScreen.kt:204:        format = book.originalFormat.name,
+android/app/src/main/kotlin/com/vreader/app/search/InBookSearchRepository.kt:293:    /** The 1-based human section label ("Section 1", …) or the stored chapter title when present. */
+android/app/src/main/kotlin/com/vreader/app/reader/nav/ReadiumTocProvider.kt:42: * (`contentSHA256`/`fileByteCount`/`originalFormat`) is threaded into every canonical
+android/app/src/main/kotlin/com/vreader/app/reader/nav/ReadiumTocProvider.kt:80:            bookFormat = book.originalFormat,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSourceOffsets.kt:27:            val chunkStart = base
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSourceOffsets.kt:29:            val s = maxOf(range.startInclusive, chunkStart) - base
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:231:            // the initial highlighted-chapter index for the current reading position.
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:492:     *  chrome model's highlighted-chapter index in sync as the reader scrolls (prompt, un-debounced — the
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:533:                format = current.originalFormat.name,
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:540:     *  extraction — chapter/page come from the TOC). Lifecycle-scoped so the collector is cancelled with
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:547:                    format = current.originalFormat,
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:613:                bookFormat = current.originalFormat,
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:983: * projection: EPUB/AZW3 chapter/page from the prevalidated [tocIndex] (built ONCE per host from its TOC),
+android/app/src/main/kotlin/com/vreader/app/search/InBookSearchHitResolver.kt:29: * `charOffsetUTF16` from `TxtDocument` — no stored offset column.
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:8:// serif preview · `chapter · p.N · date` sub-line · chevron. Tap-to-jump is capability-gated (a null
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:277: * [BookmarkRowUi.preview] and the `chapter · p.N · date` meta sub-line, and a trailing chevron. The row is
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:286:    // chapter — else "Bookmark" — stands in so the row is never blank (still italic serif, per the design).
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:287:    val primary = ui.preview ?: ui.chapter ?: "Bookmark"
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:350: * The design's `chapter · p.N · date` meta sub-line — only the present parts, joined by " · ". A row
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:351: * with no chapter/page (TXT/MD, which carry a preview instead) shows just the date; nothing is fabricated.
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:354:    listOfNotNull(ui.chapter, ui.pageLabel, ui.dateLabel.takeIf { it.isNotBlank() })
+android/app/src/main/kotlin/com/vreader/app/reader/details/BookDetailsMapper.kt:27:            formatLabel = formatLabel(book.originalFormat),
+android/app/src/main/kotlin/com/vreader/app/library/LibraryViewModel.kt:44:    val originalFormat: BookFormat,    // typed — drives reader routing
+android/app/src/main/kotlin/com/vreader/app/library/LibraryViewModel.kt:50:    val format: String get() = originalFormat.name.uppercase()
+android/app/src/main/kotlin/com/vreader/app/library/LibraryViewModel.kt:196:        originalFormat = book.originalFormat,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtProgress.kt:2:// chunks (not chapters) and no progress model; reading-stats' "time left in book" needs a 0..1
+android/app/src/main/kotlin/com/vreader/app/reader/TxtProgress.kt:3:// fraction. Pure: the top-visible char offset over the document's total length. No "left in chapter"
+android/app/src/main/kotlin/com/vreader/app/reader/TxtProgress.kt:4:// for TXT (no chapter index).
+android/app/src/main/kotlin/com/vreader/app/search/BookTextExtractor.kt:14:    /** Per-book reading-order/section index — chapter attribution + first-hit tie-break. */
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:146:                    // has no chapter/page (the WI-4 EPUB/AZW3 branch degrades to null fields — no crash) — a
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:2:// a stored BookmarkRecord into a display row (BookmarkRowUi) DERIVED every call (Risk-7: preview/chapter
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:3:// are NEVER stored). Per format: EPUB/AZW3 = nearest-at-or-above TOC chapter via a PREVALIDATED
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:24:    /** EPUB/AZW3 only: the nearest-at-or-above TOC chapter title; null otherwise / before the first entry. */
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:25:    val chapter: String?,
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:46: * A prevalidated, searchable view of a book's reading-ordered TOC for EPUB/AZW3 bookmark-chapter lookup.
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:64:     * The nearest chapter at or before [target]:
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:67:     *  - **degraded TOC** → href-exact fallback (last same-href entry at/before the in-chapter
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:69:     * Returns null (never a fabricated chapter) when the target can't be placed / the TOC is empty.
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:100:     * The same-`href` TOC entry whose in-chapter `progression` is the GREATEST at or before the target's
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:101:     * — the chapter the bookmark lives in — chosen by `progression`, NOT by list order (a same-href TOC
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:103:     * (conservative: never select a chapter whose position can't be compared). Null when no same-href
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:155:     * @param tocIndex a PREVALIDATED [BookmarkTocIndex] for EPUB/AZW3 chapter lookup (built once from the
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:156:     *   TOC and reused across rows — see [BookmarkTocIndex]); null degrades to a null chapter.
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:176:                    chapter = entry?.title,
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:184:                chapter = null,
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:195:                val raw = locator.charOffsetUTF16
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPresentation.kt:199:                    chapter = null,
+
+codex
+Two live-code mismatches have surfaced so far: the plan’s Room baseline is stale (`VReaderDatabase` is version 8, not 5), and the reader/chrome code already contains features #132/#134 rather than merely “prospective” surfaces. I’m checking whether these are documentation-only corrections or whether they alter WI dependencies and implementation scope.
+exec
+/bin/zsh -lc "rg -n \"\\| (129|131|132|134) \\||Feature #12?9|Feature #132|Feature #134|#129|#132|#134\" docs/features.md docs/parity/android-checklist.md | head -160
+sed -n '1,180p' android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt
+sed -n '1,220p' android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt
+sed -n '1,220p' android/app/src/main/kotlin/com/vreader/app/search/TxtMdTextExtractor.kt
+sed -n '1,260p' android/app/src/main/kotlin/com/vreader/app/search/EpubTextExtractor.kt
+rg -n \"ChapterSegmenter|TranslationChunkContract|ChapterTranslationChunker|translatePreSegmented|BilingualReadingViewModel|EPUBBilingualOrchestrator\" vreader vreaderTests | head -160" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+docs/features.md:129:| 76 | Vertical-writing windowed continuous scroll for Foliate (AZW3/MOBI) — extend Feature #73's K=3 windowed scroll to vertical-writing books (`vertical-rl`/`-lr`), which #73 gated out (`#ensureWindow` returns on `#vertical`), so they still use the per-section swap = the Bug #283 chapter-boundary jump | Reader/Foliate | Medium | VERIFIED | **VERIFIED 2026-06-02 (v3.42.40)** — WI-1 + WI-2 (axis-aware scrolled container layout, PR #1385) + WI-3 (remove the `#vertical` windowing gates + axis-aware primitives, PR #1386) merged = vertical-writing windowed-scroll implemented. All acceptance criteria device-verified on real books: **WI-4 horizontal continuity** (mini-azw3, no #73 regression); **WI-6 large-CJK K=3 memory gate** on the real `被讨厌的勇气` AZW3 (85 ch, 6.3 MB) — baseline RSS 402 MB → peak 403 MB across 60 idb swipes (delta +1 MB / ratio 1.0, far under `≤ baseline+120MB AND ≤ baseline×2.0`), `#evictOutsideWindow` keeps RSS bounded (resolves the #73 Gate-2 H7 concern); **WI-5 vertical-rl windowed crossing** — since no real vertical-rl AZW3 exists (the repo's only AZW3 is horizontal-tb; the `mini-cjk-vlong` vertical fixture is EPUB not AZW3), a DEBUG-only `--force-foliate-vertical-rl` harness (locked `window.__vreaderForceVerticalRL` → section `afterLoad` injects `writing-mode:vertical-rl` before `getDirection`) forces the REAL AZW3 to vertical-rl: it renders genuine vertical-rl columns + windowed-scrolls continuously across sections BOTH directions with RSS bounded (395→415 MB), exercising the full WI-3 vertical path; harness is Release-inert + 2-round-Codex-audited (closed a global-poisoning bypass). Evidence: `dev-docs/verification/feature-76-20260602.md` (result=pass). Residual (non-blocking): a real vertical-authored AZW3 for publisher-CSS coverage + rare vertical-lr. **Reclassified from Bug #283 / GH #1260** (2026-05-31, per user direction): Feature #73's windowing coordinate math is vertical-scroll-axis-only; vertical-WRITING books scroll on the horizontal axis, so windowing was gated out (never implemented for vertical), not broken — per AGENTS.md a feature, the vertical-axis sibling of #73. **Gate 1 + Gate 2 complete**: plan at `dev-docs/plans/20260531-feature-76-vertical-windowed-scroll.md`; Codex `codex exec` plan audit **3 rounds** → READY (zero open Critical/High/Medium). Audit (deepest of the remaining features) caught: vertical sections need an explicit `#container` flex LAYOUT (not just axis math); `getDirection` DISCARDS `writing-mode` (vertical-rl vs -lr lost — live `FIXME`) so an explicit `ScrollModel{axis,scrollProp,sizeProp,rectStartProp,directionSign}` is required; a single canonical `#logicalScrollOffset` API must route every existing axis caller (avoid double-normalize); `#onNeighbourExpand` is unguarded; a numeric memory-gate ceiling (K=3 ≤ baseline+120MB AND ≤ baseline×2.0, else K=2); a mandatory #73 horizontal-AZW3 regression WI. 7 WIs. **Gate 3 (TDD) IN PROGRESS: WI-1 Swift seam SHIPPED 2026-06-01** (commit `e0929934` / PR #1322 — `FoliateScrolledWindowMath.logicalOffset`/`rawOffset(sign:)` canonical logical-offset conversion + tests). **Remaining: the JS portion of WI-1 + WI-2/WI-3 in vendored `paginator.js`** (getDirection→`writingMode`/`ScrollModel`, route every axis caller through `#logicalScrollOffset`, axis-aware `#container` flex, ScrollModel-aware windowed primitives + `#onNeighbourExpand`) — coupled (vertical windowing is only device-verifiable once all land together) + device-gated (WI-5 on a real vertical-writing AZW3 book; no JS unit-test harness). High-risk vendored-Foliate-js; #73's shipped horizontal scroll is guarded by WI-4's regression. GH: #1260 |
+docs/features.md:130:| 74 | Locate/flash indicator when navigating to a saved highlight/note from the Notes/Highlights list (TXT) — after the jump, briefly emphasize the target so the reader can see where it landed | Reader/Annotations | Medium | VERIFIED | Filed 2026-05-30 via /triage. The persisted highlight DOES render at the navigated spot (no render-gap), but there is NO post-navigate flash/pulse/scroll-to-prominent emphasis: `handleNavigateToLocator` (`ReaderNotificationHandlers.swift:114-130`) sets a temporary highlight to the highlight's EXACT range, and `HighlightableTextView.setHighlightRanges(persisted:active:)` (`:156-161`) DROPS the temporary highlight when its range equals a persisted range (dedup to avoid double-fill darkening) — so tapping a saved highlight shows the unchanged persisted fill with nothing to call attention to the destination. The transient yellow flash exists for SEARCH results (Feature #2) but was never built for annotation-list jumps. **Rule 51**: the emphasis treatment (a distinct pulse/border/flash that survives the dedup without double-darkening) is a UI decision → needs-design when planned. Cross-ref Feature #2 (search-result flash at destination). **BLOCKED: needs-design (#1343)** — filed 2026-06-01; the highlight-landing emphasis has no committed design (the only designed motion cues are the tap-zone hint flash + skeleton-pulse, neither covers this). Resume Gate 1 once the design bundle lands. Not yet PLANNED → not mirrored to GH as a feature. **DESIGN LANDED 2026-06-02** — claude.ai/design handoff committed (`dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-highlight-landing.md`, canvas `VReader Highlight Landing Canvas.html`); resolves needs-design #1343. Decision: a one-shot "locate bloom" (wash value-lift 0.42→0.86 + same-hue focus ring + soft glow, ~1.5s, fires once; scroll-to-prominent if off-screen; reduce-motion = static-hold opacity fade; covers 5 themes). Also fixes the dedup no-op (temp==persisted is deduped away) via a third non-deduped `landing:` range layer. Scope TXT/MD first (EPUB/Foliate/PDF later). **Gate 1+2 complete 2026-06-03**: plan `dev-docs/plans/20260603-feature-74-locate-bloom.md`; **Gate-2 Codex audit 3 rounds** (`/tmp/feat74-planaudit{,-r2,-r3}.txt`, READY TO BUILD): R1 2 Med (wash baseline vs code's `fillAlpha`; perf-mitigation overstated) → v2; R2 1 Med (separate landing layer at rest still composites a 2nd 0.4 fill → darkens) → v3 **replace-don't-stack** render rule (the landing wash REPLACES the persisted fill for an equal range — design's single wash value-lift); R3 clean. **WI-1 SHIPPED** (v3.49.10, foundational/dormant): the landing render layer (replace-don't-stack vs the equal-range persisted fill, defeating the dedup no-op) + pure `LandingBloomPaint`. **WI-2 SHIPPED** (final WI → DONE): `LandingBloomCurve` (§3 motion + §5 reduce-motion), `reduceMotion`/`ringAlpha` paint, the `CADisplayLink` driver, and the nonce-gated cancellable navigate-from-list trigger. **Gate-4 Codex audit** (`.claude/codex-audits/feat-feature-74-wi2-locate-bloom-animation-audit.md`, **3 rounds**, ship-as-is): R1 2 High (re-tap never re-blooms; interruptibility unwired) + 2 Med (teardown; reduce-motion §5) → R2 1 High (highlight-hit tap didn't cancel) → R3 clean. 17 unit tests (curve / paint+reduce-motion / nonce-trigger / cancellation / render-layer). **Gate-5b**: the bloom is a transient ~1.5s animation; CU-free capture defeated the harness (`search?query=` CJK injection + sub-second screenshot timing) → visual-render `awaiting-device-verification` (logic exhaustively unit+audit-proven; render reuses the production `drawBackground` idiom). **2026-06-06 Gate-5b (CU-free harness, PR #1541, v3.59.2):** built a DEBUG `vreader-debug://locate?highlight=N` command + `landingBloomCount`/`landingBloomPeakIntensity` snapshot readback (the sub-second visual cannot be screenshot/video-captured on the virtual display — the plan's recommended unblock). **Non-chunked TXT bloom VERIFIED**: e2e on `bloom-sample` fixture → `locate?highlight=0` → snapshot `landingBloomCount` 0→1, `peakIntensity` 1.0 through the real `.readerNavigateToLocator` → `TXTTextViewBridge` → `playLandingBloom` CADisplayLink path. **BUT the bloom trigger is NOT wired into the chunked `TXTChunkedReaderBridge`** (chaptered TXT in Scroll layout — the large-CJK-novel case #74 targets): e2e on chaptered `war-and-peace` → `landingBloomCount=0` (no bloom). Filed **Bug #322 / GH #1542** (real coverage gap, not a verification gap). **2026-06-06 — Bug #322 FIXED (PR pending) + #74 → VERIFIED**: wired the bloom trigger into `TXTChunkedReaderBridge`; e2e on chaptered `war-and-peace` (chunked) now → `landingBloomCount` 0→1, `peakIntensity` 1.0. **BOTH TXT bridges verified** (non-chunked + chunked). Evidence `dev-docs/verification/feature-74-20260606.md` (result=pass, both paths). GH: #1456. |
+docs/features.md:138:| 84 | Secondary-text `sub`-token AA bump (Paper/Sepia ink@55%→68%) — implement the landed #1292 design so the Display panel's section headers / footers / value captions clear WCAG AA 4.5:1 (Paper 5.81:1, Sepia 4.88:1; Sepia is the binding case). A 2-value change in `ReaderThemeV2.subColor` + a RED→GREEN AA contrast test (the existing `ReaderSettingsPanelContrastTests` asserts only the project's 3.0 secondary bar). | Models/ReaderThemeV2.swift | Low | VERIFIED | Filed 2026-06-02 via /triage — the IMPLEMENTATION slice of the now-closed needs-design #1292 (design delivered PR #1317, `design-notes/secondary-text-sub-token.md`). Rule-51-exempt (restore-to-designed-state). **DONE 2026-06-02** (user lifted the hold): bumped Paper/Sepia `sub` ink@0.55→0.68 (`ReaderThemeV2.subColor`); new `ReaderSettingsPanelContrastTests.secondaryChromeLabelClearsAA` (≥4.5) + design-pin/EPUB-CSS/SettingsHeader test updates. PR #1417, v3.46.0 (build 823), merge `482be9f0`. Plan `dev-docs/plans/20260602-feature-84-sub-token-aa-bump.md`. Gate-4 Codex audit `019e88ef`, 1 round, follow-up-recommended (Medium EPUB-CSS pin fixed; Medium other-light-surface scope accepted + surfaced; 2 Lows fixed). **VERIFIED 2026-06-02** — Gate-5 contrast suites green on merged main (Paper 5.82:1 / Sepia 4.88:1 over `#fcf8f0`; evidence `dev-docs/verification/feature-84-20260602.md`). **Follow-up (surface to user, not filed):** Sepia `chromeColor`/`paperColor` sub (~4.27–4.39:1, improved from 3.36 but <AA) + Dark/OLED secondary (~3.06–3.75:1) — separate visual-weight design calls. GH: #1413. |
+docs/features.md:180:| 129| **Android reader display settings — typography slice** (Phase 3, #110 driver; parity-checklist item **E** minus the layout toggle). The designed "Display"/Aa sheet across the readers: the 5 reader themes, font family/size, line spacing, margin — persisted + applied live. **Layout (scroll/paged) is a tracked follow-up** (TXT/MD are scroll-only Compose hosts → a layout toggle would be non-functional there; needs a paged renderer first), so **box E checks only when BOTH #129 AND the layout follow-up are VERIFIED**. Reached via the designed `ReaderBottomChrome` Display slot (other slots omitted until F/D). iOS parity: #60 WI-10. | android/app/.../reader/settings/* + chrome/ReaderBottomChrome + per-host (Txt/Md/Pdf/Epub/Azw3) application | Medium | VERIFIED | **WI-4 (2026-07-11): merged — TXT/MD reader applies Display settings (theme colors/bg, fontSize/family/lineHeight, margin); MD inherits base size via em-relative headings; Display-settings writes serialized in `ReaderSettingsStore` (process-wide Mutex + synchronous per-field submission-sequence latest-wins). Gate-4 3 rounds (follow-up-recommended); JVM 16/16 + connected TxtDisplaySettingsUiTest 3/3. WI-1/2/3 previously merged (android/v0.13.9–v0.13.11).** **WI-5 (2026-07-11): merged — EPUB reader applies Display settings via Readium `EpubPreferences.submitPreferences` (fontSize=fontSizeSp/18.0, lineHeight=lineSpacing, pageMargins=marginDp/20.0, fontFamily SERIF/SANS_SERIF, per-theme backgroundColor/textColor from the 5 themes' ARGB; scroll left at default). Pure `EpubPreferencesMapper` (RED `EpubPreferencesMappingTest`, 12 cases) + open-time `initialPrefs` + live re-submit observer; Gate-4 1 round ship-as-is; connected `EpubDisplaySettingsConnectedTest` green on the real navigator.** **WI-6 (2026-07-11): merged — AZW3 reader applies Display settings via foliate-bridge CSS injection (theme bg/ink, font-family/size, line-height, padding; JS-escape-safe via the shared `foliateSetStylesJs` seam; `Azw3Document` re-applies at book-ready + after render-death recovery). Gate-4 1 round ship-as-is. RED `Azw3DisplayCssTest` (CSS-blob per theme/typography). AZW3 live render deferred to WI-8 (no in-lane AZW3 fixture; foliate WebView styling hard to assert CU-free — #68 precedent).** **WI-7 (2026-07-11): merged — PDF viewer backdrop inherits the theme background color from `ReaderSettingsStore` (composition gated on the first settings emission so a stored dark theme never flashes a bright frame); no Display sheet/Aa slot on PDF — rule 51. Pure `PdfDisplayBackdrop` (RED `PdfDisplayBackdropTest`, 5 themes + default + typography-inert) + connected `PdfDisplaySettingsConnectedTest` (open-time + live update on the synthetic PDF fixture). Gate-4 2 rounds ship-as-is.** **WI-8 (2026-07-11): VERIFIED** — Gate-5 acceptance PASS on `emulator-5554` (verifier observations, evidence `dev-docs/verification/feature-129-20260711.md`): 3 per-format DisplaySettings connected tests green (TXT/MD 3/3, EPUB 1/1, PDF 1/1) + 42 JVM mapping tests (0 fail); AZW3 live-render pipeline confirmed on a REAL 6MB CJK book (render+reopen connected tests pass, chromium renderer + 87 frames) with theme-CSS injection **documented-injecting** via the JVM-tested `setStyles` seam (the WebView bg isn't screencap-readable — sanctioned #68-class limitation, no false visual claim); persistence via ReaderSettingsStoreTest 9/9 + cross-activity read. **All 8 WIs done + VERIFIED.** Box E still needs the separate layout-toggle follow-up before it checks. **PLANNED 2026-06-29 — Gate-2 clean (3 Codex rounds, gpt-5.5/high: R1 1C/1H → R2 1H-resolved+4M → R3 2 mechanical WI-label typos; all applied).** Plan `dev-docs/plans/20260629-feature-129-android-reader-display-settings.md` v3. **Gate-2 caught a Critical pre-build**: a standalone Display Aa button is NOT design-grounded (the design shows Display only inside `ReaderBottomChrome`) → #129 builds the designed chrome shell with Contents/Notes/AI slots omitted-until-ready (LibraryScreen precedent). Readium 3.3.0 `EpubPreferences` (fontSize/family/lineHeight/pageMargins/backgroundColor/textColor + `submitPreferences()`) confirmed; exact sp/dp→Double conversions pinned. Layout toggle + brightness scoped out (tracked follow-ups). **8 WIs**: WI-1 store+themes (foundational); WI-2 Display sheet; WI-3 ReaderBottomChrome shell; WI-4 TXT/MD; WI-5 EPUB; WI-6 AZW3; WI-7 PDF theme-bg; WI-8 acceptance+VERIFIED. GH: #1879 |
+docs/features.md:184:| 131| **Android bilingual interlinear reading** (parity box D) — per-book toggle renders each source paragraph followed by an AI-backed translation (muted, accent border), cached to disk; Android parity of iOS #56/#100, building on the #118 AI foundation. | android/app/.../bilingual/* + reader hosts + ReaderBottomChrome/More-menu entry | Medium | PLANNED | Deps:[feat:#132, feat:#134] (entry wiring via box-F chrome + More-menu; #118 AI foundation DONE). Plan `dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md` (Gate-1 v2, ~62 WIs; WI-0 Readium JS-injection spike gates the render WIs). Design authority (landed): vreader-bilingual.jsx + vreader-reader.jsx + vreader-more.jsx. **Gate-2 round-2 audit pending — not yet dispatched; box-F chrome must land first.** GH: #1923 |
+docs/features.md:185:| 132| **Android reader nav chrome — shell + Contents (TOC) + annotations-review sheet** (parity box F pt1 + box B annotations-review remainder) — reader chrome shell (top bar + bottom-chrome Contents/Notes slots), the Contents/TOC sheet, the annotations-review (highlights+notes) sheet, and the full annotations.json (highlights+notes+bookmarks) backup round-trip. Root of box F. | android/app/.../reader/{ReaderTopChrome,ReaderChromeScaffold,ReaderChromeState} + panels/TOCSheet + annotations review sheet + backup/{BackupCollector,RestoreImporter} | High | VERIFIED | (root of box F — no deps; chrome files one-writer-coordinate with #129/#131 via nullable-default params). Plan `dev-docs/plans/20260710-feature-132-android-reader-nav-chrome-toc-bookmarks.md` (Gate-1 v4, ~51 WIs). Design authority (landed): vreader-reader.jsx + vreader-panels.jsx + the Android annotations sheet; per-card affordances design gate #1902 CLOSED. Box F checks done only when #132+#133+#134+#135 VERIFIED; box B when #132 review-sheet + #135 bookmark-create VERIFIED. **Gate-2 signed off (round-3 FIX-THEN-PROCEED, findings resolved — the #128 pass pattern). READY TO BUILD — box-F root; Gate-3 dispatch starts here.** **WI-1 (2026-07-11): merged — reader/nav TOC model + providers (foundational): TocEntry (canonical Locator with the Book identity triple + retained native epubReadiumLocator), TocProvider fun-interface, ReadiumTocProvider (flatten tableOfContents children with depth, locatorFromLink nullable-skip, epubReadiumLocator retained, canonical via the adapter-(i) toJSON then ReadiumLocatorBridge.toEnvelope hop so the bridge stays Readium-free; internal PublicationTocSource seam since Readium Publication is final/unmockable), EmptyTocProvider. Robolectric ReadiumTocProviderTest 9/9 green. Gate-4 Codex ship-as-is. Box-F chrome WIs (WI-2 ReaderTopChrome onward) build on this.** **WI-2 (2026-07-11): merged — ReaderTopChrome composable (implements vreader-reader.jsx ReaderTopChrome, rule 51): leading Library back + centered italic-serif title (maxLines=1 ellipsize) live; Search/More/bookmark slots OMITTED when null (no dead controls, #129 rule) - filled by #133/#134/#135 via existing nullable params. Same ReaderTheme token map as ReaderBottomChrome; testTags reader-top-chrome/chrome-back/chrome-search/chrome-more/chrome-bookmark-slot; a11y descriptions + >=48dp targets; RTL. Instrumented ReaderTopChromeTest (createComposeRule) compiles green + JVM suite green; live Compose run defers to a WI-5/WI-8 connected slice. Gate-4 Codex ship-as-is (3 rounds; High title-centering + two Mediums resolved).** **WI-3 (2026-07-11): merged — TocContentsSheet + TocSheetRows (implements vreader-panels.jsx TOCSheet Contents tab, rule 51): single-pane ModalBottomSheet (no dead Bookmarks tab - that is #135) with the design book-title Sheet header + bottom rule, over WI-1 TocEntry rows (ch/title/p.N), currentTocIndex row highlighted (theme-accent tint at design alphas 0.08 light/0.12 dark + accent/weight-600 title). Tap row -> onJump(index) Boolean; sheet dismisses ONLY on success, failed jump keeps sheet open with NO invented error surface (nav-error-presentation). testTags toc-sheet/toc-row-N/toc-empty/toc-title; empty entries -> toc-empty; richer row a11y. Instrumented TocContentsSheetTest compiles green + JVM green; live Compose run rides a WI-5/WI-8 connected slice. Gate-4 Codex 2 rounds -> ship-as-is (round-1 block: book-title header, exact alphas, row a11y - all fixed).** **WI-6b (2026-07-11): merged - annotation snapshot + restore seams (foundational): AnnotationsSnapshot + AnnotationsRepository.annotationsForBook (deterministic (createdAt,id)-sorted highlights+notes one-shot, corrupt rows dropped via toRecordOrNull), AnnotationDao.allNotes/allBookmarks (collector reads) + insertNote/BookmarkIfAbsent, and the UUID-preserving transactional restoreAnnotations(env, allowedBookKeys) -> RestoreAnnotationsReport(KindCounts per kind): preserves backed-up id+timestamps (NOT minting), insert-if-absent idempotent (repeat applies 0), allowed-book scope skips, locator parse / bookKey mismatch counts failed, one @Transaction. NO Room migration; updateNote deferred to the note-Edit WI. In-memory Room tests green. Gate-4 Codex ship-as-is. Unblocks WI-4 + WI-8. **WI-8 CONTRACT (from WI-6b): the restore seam decodes locatorJSON as a PLAIN BackupJson-decodable Locator (the position precedent) - WI-8 MUST encode locatorJSON = BackupJson.encode(locator), NOT canonicalJson() (which emits flattened dotted keys NOT Locator-decodable -> would count every restore row failed); verify vs what iOS writes for cross-platform parity.**** **WI-4 (2026-07-11): merged — AnnotationsReviewSheet + AnnotationCards (implements vreader-android-annotations.jsx AnnotationsSheet, rule 51): ModalBottomSheet over WI-6b AnnotationsSnapshot with All/Highlights/Notes filter chips (no Bookmarks chip - #135), HighlightCard + StandaloneNoteCard (no BookmarkCard - #135), empty (annot-empty) + populated, sheet-level trailing Share (onShareAll -> ACTION_SEND host-side), capability-based nullable onJumpToAnnotation (non-null card clickable+jumps, null card review-only non-clickable - no dead no-op). Per-card Copy/Share + the ... Edit/Delete menu GATED (absence-asserted - the Android cards depict neither; those live on the in-reader SelectionPopover / iOS notes-delete; GH #1902 design landed -> a follow-up WI with updateNote + jump-coupling). Cards render the design dashed note-rule + metaLine + card shadow (Gate-4 round-1 rule-51 fidelity fixes). testTags annotations-sheet/annot-filter-N/annot-card-id/annot-empty/annot-share. Instrumented AnnotationsReviewSheetTest compiles green + JVM green; live Compose run rides a WI-6/WI-8 connected slice. Gate-4 Codex ship-as-is (3 rounds). Notes bottom-chrome slot now has a live destination.** **WI-5 (2026-07-11): merged — chrome scaffold + state: ReaderBottomChrome extended (additive nullable onOpenContents/onOpenNotes; #129 Display slot preserved, Display-only callers still valid; AI omitted; Contents-Notes-Display design order), ReaderChromeState + ReaderSheet(None/Toc/Notes, no Bookmarks - #135) + ReaderChromeStateSaver (mirrors #127 SheetRouteSaver: string-encodes visible+sheet, garbage/empty/wrong-separator/unknown-sheet token -> None/false, never throws), ReaderChromeScaffold (stacks ReaderTopChrome + body + bottomChrome slot receiving Contents/Notes open callbacks + Toc-route->TocContentsSheet / Notes-route->AnnotationsReviewSheet; Contents control hidden when tocEntries empty; center-tap toggles chrome; no bookmark route). JVM ReaderChromeStateSaverTest 10/10 green (round-trip + invalid-token->None); instrumented slot/scaffold tests compile (live Compose run rides WI-6 connected slice). Gate-4 manual-fallback audit ship-as-is (Codex quota-limited) + one audit-driven hardening (fresh-read sheet transitions). WI-6 (TXT host) is the first to render the scaffold.** **WI-6 (2026-07-11): merged — TXT/MD host renders ReaderChromeScaffold: TxtReaderActivity upgraded from the #129 Display-only ReaderBottomChrome to the full scaffold (top bar with book title + Library back, Search/More/bookmark null-omitted; bottom Contents(hidden via empty tocEntries / EmptyTocProvider posture) / Notes / Display; center-tap toggles chrome via rememberSaveable ReaderChromeState + ReaderChromeStateSaver). Notes opens AnnotationsReviewSheet over annotationsForBook(this book) (reloaded on highlight change) with onShareAnnotations firing ACTION_SEND and non-null onJumpToAnnotation scrolling to charRangeStartUTF16/charOffsetUTF16 via the existing TXT chunk scroll seam. #129 Display settings sheet + #121 TTS bar preserved. New instrumented TxtReaderChromeUiTest compiles + JVM AnnotationScrollOffsetTest 5/5 (live Compose/host render rides WI-9 acceptance). Gate-4 ship-as-is (Codex quota exhausted, rule-47 manual fallback). First host to render the scaffold; WI-7-hosts (PDF/AZW3) + WI-7-EPUB follow.** **WI-7-hosts (2026-07-11): merged — PDF + AZW3 hosts render ReaderChromeScaffold (mirror of WI-6): PdfReaderActivity + Azw3ReaderActivity host the scaffold (top bar title + Library back, Search/More/bookmark null; Contents hidden via empty tocEntries/EmptyTocProvider posture; Notes -> AnnotationsReviewSheet over annotationsForBook; onShareAnnotations -> ACTION_SEND; center-tap toggles; ReaderChromeStateSaver-persisted). PDF onJumpToAnnotation NON-null jumps to the annotation page via the existing listState.scrollToItem page-scroll seam (pdfAnnotationPage, clamped); AZW3 onJumpToAnnotation NULL (review-only capability gate - no in-session goTo until #135, FoliateBridge/Azw3Document/foliate-js untouched, WebView sizing (bug #357 MATCH_PARENT) undisturbed; card non-clickable). Each host's #129 Display affordance preserved (PDF theme backdrop / AZW3 live foliate CSS, no control surface) so the bottom chrome is Notes-only. New instrumented PdfReaderChromeUiTest + Azw3ReaderChromeUiTest + JVM PdfAnnotationPageTest; both source sets compile + the JVM helper passes (live Compose run rides WI-9). Gate-4 ship-as-is (manual-fallback, Codex quota). WI-7-EPUB (persistent StateFlow chrome + native-locator TOC jump) is the last host.** **WI-7-EPUB (2026-07-11): merged — EPUB host chrome (the only TOC-supplying host): ReaderActivity now owns a persistent MutableStateFlow<ReaderChromeModel> (title, tocEntries via ReadiumTocProvider(publication,book), currentTocIndex, annotations) fed on async open + position change (tocIndexFor maps the live Readium locator to the nearest TOC entry, exact-href-match-first then a lexical fallback). Three ComposeViews over the fragment FrameLayout — a WRAP_CONTENT top band, a WRAP_CONTENT bottom band, and a full-screen sheet layer that renders NOTHING until a sheet opens — collect it via collectAsStateWithLifecycle, so the Readium fragment underneath keeps scroll/selection/link input (touch-through). Contents onJump -> navigator.go(epubReadiumLocator):Boolean (dismiss on success, stay-open on false, no invented error surface); Notes -> AnnotationsReviewSheet with jump-to-annotation NULL (EPUB review-only until #135, cards non-clickable); onShareAll -> ACTION_SEND via the shared annotationsShareText formatter. #129 observeDisplaySettings + Display sheet + selection popover + highlight decorations + position save + publication.close all preserved; chrome extracted to ReaderChromeModel.kt + EpubReaderChrome.kt to keep ReaderActivity focused. JVM ReaderChromeModelTest (tocIndexFor) 11/11 green; instrumented ReaderChromeConnectedTest compiles (live navigator/Compose render rides WI-9). Gate-4 manual-fallback ship-as-is. All 5 formats now render the nav chrome; WI-8 (annotations.json backup) + WI-9 (acceptance) remain.** **WI-8 (2026-07-11): merged — annotations.json backup+restore (box B remainder): BackupCollector emits a deterministic annotations.json section (BackupAnnotationsEnvelope of highlights+notes+bookmarks, filtered to the collected manifest books, byte-stably sorted by (bookFingerprintKey,id), UUID preserved, totalSize includes it) beside positions/collections; RestoreImporter decodes it + calls WI-6b restoreAnnotations(env, allowedBookKeys) (UUID-preserving, idempotent, per-kind counts) scoped to the manifest's in-selection books. CRITICAL locatorJSON is the PLAIN serialized Locator (BackupJson.encode(locator)) matching iOS encoder.encode(locator) + contracts/vectors/backup-sections.json + WI-6b's plain decode - NOT canonicalJson (the plan text was wrong; canonical emits non-Locator-decodable dotted keys); profileKey derived on restore, not emitted. bookmarks wired (usually empty until #135). pre-#132 backup (no annotations.json) restores zero annotations, no crash. #113 :identity DTOs reused, no contracts change. JVM BackupAnnotationsCollectorTest green (11 tests: plain-not-canonical, byte-stable sort, filter-to-manifest, populate bookmarks, empty, totalSize, round-trip UUID-preserve, idempotent, scope-filter, absent-section-no-crash, malformed-drop); connected AnnotationBackupRoundTripConnectedTest compiles (live WebDAV round-trip rides WI-9). Gate-4 manual-fallback ship-as-is (Codex quota outage).** **STATUS -> DONE (2026-07-11): all 8 code WIs merged (WI-1/2/3/6b/4/5/6/7-hosts/7-EPUB/8, android/v0.14.x->v0.15.3); implementation complete. Box B review-sheet + annotation backup now done on Android (bookmark half stays #135). Awaiting Gate-5 acceptance (all-5-format chrome + live WebDAV annotation round-trip) -> VERIFIED.** **VERIFIED (2026-07-11): Gate-5 acceptance PASS on emulator-5554 (v0.15.3). Live WebDAV annotation backup->wipe->restore round-trip green (highlight + note restored under ORIGINAL UUIDs over a real rclone server; AnnotationBackupRoundTripConnectedTest tests=1/0). 7 connected chrome suites green = 61 tests / 0 failures / 0 flakes first-try (TxtReaderChromeUiTest 6, PdfReaderChromeUiTest 5, Azw3ReaderChromeUiTest 5, ReaderChromeConnectedTest 6 (EPUB TOC/native-jump/touch-through/dismiss), nav.TocContentsSheetTest 11, AnnotationsReviewSheetTest 14, chrome.ReaderTopChromeTest 14). Real 19MB CJK EPUB on-device: top bar + Contents/Notes/Display bottom chrome, native Readium TOC populated + Contents-jump confirmed, review sheet (All/Highlights/Notes + Share). Evidence: dev-docs/verification/feature-132-20260711.md. Box F still open until #133/#134/#135 VERIFIED; box B still open until #135 bookmark-create VERIFIED.** GH: #1924 |
+docs/features.md:186:| 133| **Android find-in-book** (in-reader text search, parity box F pt2) — book-scoped full-text search returning matches grouped by chapter with p.N badges + jump-to-location, a NEW all-hits-in-one-book query shape over #128's existing FTS4 index. | android/app/.../search/* (additive DAO + book-scoped results) + reader top-bar Search entry | Medium | VERIFIED | Deps:[feat:#128, feat:#132] (#128 search index MERGED/VERIFIED; #132 reader top-bar Search entry). Plan `dev-docs/plans/20260710-feature-133-android-find-in-book.md` (Gate-1 draft, ~11 WIs). Design authority (landed): vreader-search.jsx 'This book' scope. **Gate-2 CLEANED round-3 (2026-07-12) — plan v3.1, READY TO BUILD.** 3 rounds (r1: 2C/5H/7M/2L; r2: 2C/2M; r3: 1M — all resolved). Key redesigns from the audits: (1) EPUB search does NOT reuse the FTS index for position — the text-quote-only reconstruction was IMPOSSIBLE (ReadiumLocatorReconstructor.toReadium REQUIRES a nonblank href; no publication-wide text-quote search; sectionIndex is a content-iterator counter, NOT readingOrder index + href never persisted) → EPUB pivots to Readium 3.3.0's own SearchService (Publication.search->SearchIterator->LocatorCollection; verified present + the bundled StringSearchService/IcuAlgorithm default engine in readium-shared-3.3.0-runtime.jar); the FTS index serves TXT/MD only. (2) Occurrence extraction can NOT reuse BuiltQuery.tokens (a flat highlight list, wrong for CJK phrases/prefix/AND) → new additive SearchQueryBuilder.structuredQuery + a dedicated RawOffsetMatcher (raw UTF-16 offsets, phrase/prefix/AND + CJK + surrogate + NFKC) with a RESUMABLE intra-chunk pagination cursor (sectionIndex, chunkOrdinal, id, occurrenceIndex) so append-on-scroll is COMPLETE (no silent hit drop). (3) DB stays v7 (Readium search obviates a href column). (4) No needs-design (p.N omitted matching shipped iOS; indexing=NoResults hint; PDF/AZW3 hidden; jump-failure=sheet-stays-open; truncation surface removed). 12 WIs, each with enumerated files; WI-10/WI-11 serialize the shared AppContainer edit in VReaderApp.kt. Full plan + revision history in dev-docs/plans/20260710-feature-133-android-find-in-book.md. **WI-1 (2026-07-12): merged — book-scoped find-in-book DAO surface added to SearchDao.kt (additive, query-only, NO schema change and NO DB version bump; the live DB @Database is already v8, #135 took it there): matchingChunksPage (cursor page over (sectionIndex, chunkOrdinal, id) strict-greater, s.id = f.rowid, MATCH search_sections_fts, book-scoped), chunkAtOrAfter (INCLUSIVE >= LIMIT 1 — the round-3 resume path so a partially-consumed chunk is not skipped), matchingChunkCount, observeIndexState (Flow). No occurrence logic (deferred WI-3); existing corpus query untouched. Robolectric in-memory Room InBookSearchDaoTest 10/10 (book exclusion, gapless/disjoint/ordered paging, empty last page, s.id=f.rowid, chunkAtOrAfter resume+advance+null, count, index-state Flow) + full JVM suite 881/881. Gate-4 follow-up-recommended (all Low, adjudicated; corrected the plan's stale 'DB stays v7' — live is v8). Feeds WI-6 repository. DOWNSTREAM NOTE: the plan v3.1 says 'DB stays v7' but the live @Database version is 8 — additive-no-migration conclusion unaffected; downstream WI notes should say 'no DB version bump' not pin v7.** **WI-2 (2026-07-12): merged — SearchQueryBuilder.structuredQuery(raw): StructuredQuery? added ADDITIVELY (round-2 Critical-2 half 1): typed QueryUnits (Phrase for a contiguous CJK run, PrefixTerm for the final Latin bareword, Term for AND barewords + quoted FTS keywords) from a SHARED private buildGroupedParts intermediate both ftsQuery + structuredQuery project from — NOT the flat BuiltQuery.tokens (which loses phrase/prefix/AND structure); special-only/blank -> null. ftsQuery + BuiltQuery return byte-for-byte UNCHANGED (existing SearchQueryBuilderTest 13/13 + a 10-input regression asserting exact fts+tokens). New StructuredQuery.kt model; buildFtsParts stayed private (file-private GroupedPart sealed intermediate, safely additive). Pure-JVM StructuredQueryTest green + full JVM suite green. Gate-4 ship-as-is (Codex 1 round). Feeds WI-3 RawOffsetMatcher.** **WI-3 (2026-07-12): merged — RawOffsetMatcher.occurrences(rawChunkText, StructuredQuery, fromOccurrenceIndex, maxThisPage): RawOccurrenceSlice (round-2 Critical-2 half 2): re-scans RAW chunk text by code point for every StructuredQuery occurrence, returning per-occurrence RAW UTF-16 spans (NOT the FTS4 offsets() segmented/byte trap, NOT display-collapsed). Normalization (NFKC full-width->half, case-fold, ss/ß, combining-mark strip) at COMPARISON time only — a length-changing fold never shifts the raw span; surrogate pairs never split; Phrase spans TIGHT (关于编程的书 + 编程 -> 编程 only); PrefixTerm boundary + Term whole-token; word boundaries mirror FTS unicode61 (punctuation separator; NFKC-fold-to-token compat chars stay in-word); overlapping-match dedupe (leftmost non-overlapping); folded-only-no-anchor -> 0 (head fallback). RESUMABLE within a chunk: fromOccurrenceIndex/maxThisPage page window + nextOccurrenceIndex (null=exhausted) so append-on-scroll is COMPLETE (40-occurrence chunk with maxThisPage=10 retrieved IN FULL across 4 gapless/dupe-free pages, 4th nextOccurrenceIndex=null); enumeration naturally bounded (each iteration advances >=1 UTF-16 unit) so NO artificial cap and NO truncation. New InBookSearchModels.kt (RawOccurrence, RawOccurrenceSlice, SearchCursor). Pure-JVM RawOffsetMatcherTest green + full JVM suite green. Gate-4 3 rounds all resolved (r1 block caught the FTS-unicode61 word-boundary Critical, follow-up-recommended). Feeds WI-4 TXT/MD resolver + WI-6 repository.** **WI-4 (2026-07-12): merged — TXT/MD hit resolver: NEW InBookSearchHitResolver interface (FTS-track resolver seam WI-6 dispatches to; EPUB resolves natively via Readium in WI-5, not this seam) + TxtMdInBookHitResolver mapping a matched chunk + RawOccurrence to a jumpable canonical Locator via charOffsetUTF16 = TxtDocument.offsetForChunk(sectionIndex) + rawOccurrence.startUtf16 (the round-2 Critical-2 deterministic re-derivation — no stored offset column; TxtDocument.of re-derives the same boundaries the FTS extractor used), fingerprintKey identity + validatedOrNull(); out-of-range sectionIndex/occurrence rejected BEFORE the offset math (offsetForChunk clamps + validatedOrNull only checks non-negativity/ordering) so a bogus/clamped jump is impossible. Pure-JVM TxtMdInBookHitResolverTest green (real TxtMdTextExtractor.extract round-trip returns the same chunk, exact charOffsetUTF16, CJK offset exact UTF-16 not byte, validatedOrNull non-null with correct fingerprint, edge/first/last chunk, md parity, out-of-range rejects) + full JVM suite green. Gate-4 ship-as-is (2 rounds; r1 block caught tests-not-driving-the-real-extractor + missing bounds check). Feeds WI-6 repository.** **WI-5 (2026-07-12): merged — EpubInBookSearchEngine over Readium's OWN SearchService (round-2 Critical-1 resolution: EPUB search/position does NOT use the FTS index). Behind a mockable PublicationSearchSource seam (Readium Publication is final, mirroring #135 PublicationLocatorSource): isSearchable gate (extension property; not searchable -> Unsupported, no iterator opened) -> publication.search(query) (nullable SearchIterator? -> null = immediately-exhausted) -> next() -> Try<LocatorCollection, SearchError> pages -> each Locator mapped to an EpubInBookHit (group by Locator.title chapter first-seen order, snippet from Locator.text.highlight + before/after all @Nullable orEmpty, raw readiumLocator retained for navigator.go jump); exhaustion -> moreAvailable=false; SearchError -> Error (surfaced); CJK passes through verbatim. Paging COMPLETE + resumable (round-3): a page over budget carries an EpubSearchCursor (live iterator + un-placed leftover) with idempotent close + atomic single-consumption (Gate-4 round-2 lifecycle fixes). Engine-only self-contained EPUB result types (EpubInBookHit/EpubGroup/EpubSearchPage/EpubSearchOutcome/EpubSearchCursor); WI-6 adapts to the shared DTOs. Pure-JVM EpubInBookSearchEngineTest green (fake seam, real Readium Locator/Locator.Text value types via Robolectric) + full JVM suite green. Gate-4 3 rounds ship-as-is (r1 Critical paging data-loss -> r2 2 Highs cursor-leak+reuse-race -> r3 clean). ACCEPTED-LOW: engine file ~348 lines (>300 soft guideline, cohesive; a split needs orchestrator regen). Feeds WI-6 repository (EPUB path) + WI-11 EPUB host wiring.** **WI-6 (2026-07-12): merged — InBookSearchRepository, the format-dispatch integrator that unifies WI-1..WI-5 behind one book-scoped search entry point returning the shared DTOs (InBookHit/InBookGroup/InBookSearchPage/InBookSearchOutcome added to InBookSearchModels.kt). EPUB -> EpubInBookSearchEngine (WI-5): the raw Readium locator is carried as readiumLocatorJson (String?, keeping the models file pure-JVM), the live SearchIterator held behind SearchCursor.Epub for resumable append-on-scroll, exposed closeAllEpubCursors() for reader-session dismiss + a Codex-r1 fix that closes abandoned/superseded iterators. TXT/MD -> the FTS pipeline (SearchDao book-scoped page -> RawOffsetMatcher occurrences -> TxtMdInBookHitResolver canonical Locator), grouped by Section in first-seen order, resume-within-chunk (SearchCursor.Fts occurrenceIndex) so a partially-consumed chunk is completed not skipped. Blank / special-only query -> NoResults with NO DAO call. Injected CoroutineDispatcher + ensureActive() cancellation guards throughout. Robolectric InBookSearchRepositoryTest 15/15 (format dispatch, EPUB cursor lifecycle + closeAll, FTS grouping/paging/resume, blank short-circuit, cancellation) + full JVM suite 968/968. Gate-4 ship-as-is (Codex 2 rounds; r1 caught an EPUB iterator leak). Feeds WI-8 ViewModel.** **WI-7 (2026-07-12): merged — search/IndexStateGate.kt -> a sealed InBookIndexState (Ready / Indexing / NoResults / Unsupported / Failed; Unsupported hides the Search entry) + a pure classify() ladder + an observe(format, bookKey, hasOccurrence, indexStateFlow) Flow the WI-8 ViewModel collects so a held query re-runs on settle. State mapping (TXT/MD): missing OR stale indexerVersion -> Indexing; current-version failed -> Failed (retryable); current-version indexed + >0 occ -> Ready, +0 -> NoResults; current-version skipped_unsupported -> Unsupported. EPUB-bypass invariant: EPUB always Ready, never subscribes to the FTS flow (Readium searches live); PDF/AZW3 -> Unsupported. Staleness MIRRORS SearchIndexCoordinator.isEligible exactly: version-staleness dominates (a stale row of any status is re-indexed -> Indexing), and a current-version UNEXPECTED status maps to Failed (not forever-Indexing) since isEligible never retries it (Gate-4 High, fixed r1). 25 JVM tests green; RUN-ANDROID-TESTS RESULT: SUCCEEDED (targeted InBookIndexStateTest + full :app:testDebugUnitTest). Gate-4 Codex 2 rounds -> ship-as-is. Feeds WI-8 ViewModel.** **WI-8 (2026-07-12): merged — InBookSearchViewModel state machine over WI-6 repo + WI-7 gate. UI state = InBookSearchScreenState(query, recents, content) where content sealed = Idle/Loading/Indexing/Results(groups,moreAvailable)/NoResults/Unsupported/Error (+hidesSearchEntry). 250ms debounce -> flatMapLatest(cancel-prior) -> IndexStateGate.observe; stale-tag + generation-token discard of superseded/dismissed sessions. TXT/MD Indexing held-query auto-re-runs on index settle (no re-type); EPUB bypasses Indexing. loadMore() single-flight, threads nextCursor for BOTH tracks (Fts + Epub) and coalesces same-section groups -> append complete, no gap/dup, moreAvailable=false stops. Global RecentSearchesStore reuse (record on commit, surface list; store owns dedupe/cap-8). closeAllEpubCursors() on empty-reset/dismiss/onCleared -> no Readium iterator leak (one repo instance/session). Split into InBookSearchViewModel.kt + InBookSearchViewState.kt (both <300 lines). 27 JVM tests; RUN-ANDROID-TESTS RESULT: SUCCEEDED (full module 1017 tests 0 fail). Gate-4 Codex 3 rounds -> follow-up-recommended (ACCEPTED-LOW: bounded stale-EPUB-cursor hold reaped at next beginSession/onCleared; the repo exposes only a close-ALL seam, so a precise per-session close is deferred to a WI-6 follow-up). Feeds WI-9 sheet.** **WI-9 (2026-07-12): merged — InBookSearchSheet + InBookSearchField + InBookSearchRows + InBookSearchStates built to vreader-search.jsx 'This book' scope (rule 51, no invented UI; the out-of-scope 'All books' scope toggle + 'Try searching' helper are intentionally omitted). Renders the WI-8 InBookSearchScreenState -> autofocus query pill (search / input / clear / 48dp Cancel), grouped chapter headers with 'N matches in M chapters' summary + per-group counts + tinted containers + 0.5dp separators, snippet rows bolded from InBookHit.matchRanges (surrogate-safe), recents (tap fills query via onPickRecent), TXT/MD Indexing hint, NoResults empty state; Loading/Error/Unsupported render no invented body (rule 51, library SearchScreen precedent). onJump dismisses only on JumpResult.Succeeded (Failed keeps sheet open, no error surface); append-on-scroll fires onLoadMore when the tail group nears the viewport, re-arming on (lastGroupIndex, lastGroupHitCount) for coalesced same-group pages, gated by moreAvailable, no disclosure row. testTags inbook-search-sheet/-field/-cancel/-clear/-result-g-i/-group-g/-results-summary/-no-results/-indexing/-recent-i. 18 instrumented Compose tests; the androidTest set COMPILES + full JVM unit suite green via scripts/run-android-tests.sh (RUN-ANDROID-TESTS RESULT: SUCCEEDED) -> the live render rides WI-10/WI-11 host wiring + WI-12 acceptance. Gate-4 Codex 3 rounds -> follow-up-recommended (High surrogate-split + Mediums: invented accent border, missing design structure, append re-arm, 48dp targets all fixed). Feeds WI-10/WI-11 host wiring.** **WI-10 (2026-07-12): merged — TXT/MD host wiring: top-bar Search slot filled (previously null); InBookSearchSheet mounted from TxtReaderActivity; per-session InBookSearchViewModel (ONE per reader open, built from the already-decoded reader text, closeAllEpubCursors/onCleared lifecycle on teardown + onDismiss on sheet close); hit-jump resolves canonicalLocator.charOffsetUTF16 via the existing chunkForOffset scroll seam (txtBookmarkScrollTarget range-guard -> Succeeded, out-of-range -> Failed sheet stays open); EPUB engine seam is an error-throwing guard, never reached for txt/md (EPUB-seam-null-safe); Search icon hidden only on the WI-7 Unsupported gate (no dead control); minimal additive VReaderApp.inBookSearchViewModel factory so WI-11 rebases cleanly; MD parity via the same host. Connected TxtFindInBookTest compiles + JVM suite green (RUN-ANDROID-TESTS RESULT: SUCCEEDED); live emulator run rides WI-12. Gate-4: 2 Codex rounds -> ship-as-is (round-1 Medium resolved, residual Lows = WI-12 test-strength debt). Feeds WI-11 EPUB host + WI-12 acceptance.** **WI-11 (2026-07-12): merged — EPUB host wiring (final host WI): EpubTopBand.onSearch added (icon hidden when hidesSearchEntry -> non-searchable publication), sheet in the sheetLayer ComposeView (open-only -> touch-through preserved), per-session InBookSearchViewModel over the LIVE Readium publication via new VReaderApp.epubInBookSearchViewModel factory wiring the WI-6 repository EPUB branch to EpubInBookSearchEngine(publication) (WI-5 production constructor over the real publication -> Readium SearchService, NOT the FTS index); the FTS branch is error-guarded (never invoked for EPUB), IndexStateGate bypasses EPUB. Hit-jump via Locator.fromJSON(readiumLocatorJson) -> navigator.go (Succeeded dismisses / Failed keeps open, no invented error surface); null/blank/malformed locator un-jumpable -> Failed not crash. One-VM-per-session + closeAllEpubCursors on dismiss (VM.onDismiss) AND onDestroy (VM.onCleared, BEFORE publication.close so the live SearchIterator never leaks). Reused WI-5 EpubInBookSearchEngine(publication) rather than a duplicate adapter (no dead code). Connected EpubFindInBookTest compiles + JVM unit suite green (RUN-ANDROID-TESTS RESULT: SUCCEEDED); connected + real-CJK-EPUB slice rides WI-12. Gate-4 Codex ship-as-is (round 1): 0 Critical/High/Medium; 3 test-file Lows fixed/accepted. docs-sync applied (architecture.md Android reader + README Reader feature). **STATUS -> DONE (2026-07-12): all 11 implementation WIs merged (WI-1..WI-11, android/v0.17.x -> v0.18.0); in-book find-in-book is code-complete + user-reachable across TXT/MD/EPUB (PDF/AZW3 Search hidden). Awaiting Gate-5 acceptance (WI-12: real-CJK find on TXT/MD/EPUB + PDF/AZW3 no-icon on emulator-5554) -> VERIFIED.**** **WI-12 test (2026-07-12): merged — SearchHiddenOnPdfAzw3Test asserts chrome-search absent on PDF + AZW3 host chromes (IndexStateGate Unsupported -> no onOpenSearch into ReaderChromeScaffold); positive controls (reader-top-chrome/chrome-back/chrome-notes) confirm the chrome rendered. androidTest compiles + JVM suite green; rides the WI-12 Gate-5 acceptance on emulator-5554. Gate-4 Codex ship-as-is (1 round).** **WI-13 (test-hardening, 2026-07-12): merged — the connected find-in-book suites (TxtFindInBookTest/EpubFindInBookTest) were async-mis-synchronized (waitForIdle did NOT await the 250ms VM debounce + index-state gate recompute) -> replaced waitForIdle-then-immediate-assert with bounded compose.waitUntil(5s) polls on the awaited node (result row / no-results body / gate-driven icon removal) mirroring the EPUB awaitFirstHit helper; unsupportedGate now types a query so the gate actually recomputes to Unsupported; the EPUB dismiss test dropped a false 'returns to Idle' assertion (onDismiss keeps the query, does NOT reset content -> verified against the VM + its dismiss_closesEpubCursors unit test) for the real vmSurvives contract (build-count unchanged + live queryable state). NO product change. Connected gate GREEN 14/0 (Txt 6/0, Epub 6/0, PdfAzw3 2/0) on emulator-5554 (orchestrator independent re-run also 14/0); JVM suite green. Gate-4 SHIP-AS-IS (2 rounds). This is the Gate-5 acceptance substantiation for the TXT/MD + EPUB find flows.** **VERIFIED (2026-07-12): Gate-5 acceptance PASS on emulator-5554 (v0.18.2, HEAD 84e6b2d5). The 3 find-in-book connected suites GREEN 14/0 (TxtFindInBookTest 6/0 = Search icon + type->grouped hits->tap->scroll-to-offset + zero-hit->NoResults + out-of-range->Failed + MD parity; EpubFindInBookTest 6/0 against the REAL Readium SearchService = grouped hits + navigator.go lands + null/malformed-un-jumpable-not-crash + one-VM-per-session; SearchHiddenOnPdfAzw3Test 2/0 = PDF/AZW3 Search hidden). Real 18MB CJK EPUB on-device: EPUB top-band Search icon + working search sheet confirmed. CJK correctness unit-verified (RawOffsetMatcher/EpubInBookSearchEngine/TxtMdInBookHitResolver). Documented modality gap: real-book CJK keystroke query->jump not adb-drivable (no ADBKeyboard IME; a 3rd-party IME install declined per rule 54) — covered by the unit CJK + the identical connected EPUB flow + the real-book entry smoke. Evidence: dev-docs/verification/feature-133-20260712.md. Box F pt2 complete.** GH: #1925 |
+docs/features.md:187:| 134| **Android reader More menu + book details + share** (parity box F pt3) — the reader More-menu popover + Book Details sheet + share, extending #132's chrome. | android/app/.../reader More-menu + BookDetailsSheet (extends #132 ReaderChromeState/ReaderSheet) | Medium | VERIFIED | Deps:[feat:#132] (HARD — ReaderTopChrome/ReaderChromeScaffold/ReaderChromeState land in #132; author line soft-deps #128 DONE). Plan `dev-docs/plans/20260710-feature-134-android-more-menu-book-details-share.md` (Gate-1 v3). Design authority (landed): vreader-more.jsx + vreader-book-details.jsx; generated-cover fallback design gate #1905 CLOSED. **Gate-2 SIGNED OFF (2026-07-11): round-1 audit = 4 findings (3 High, 1 Medium, all in the #132 chrome-extension coordination, core model assumptions verified correct); plan v3 corrected the ReaderChromeScaffold signature, enumerated all 4 exhaustive when(sheet) Details edit sites + the token round-trip, pinned moreMenuSlot-supersedes-onMore, named the EpubTopBand/EpubReaderSheets EPUB sites; round-2 re-audit CLEAN (Gate-3 ready). Codex quota-down -> independent fresh-subagent auditor per rule-47 manual fallback. READY TO BUILD.** **WI-1 (2026-07-11): merged — Book Details model foundation: BookDetailsUiModel + pure BookDetailsMapper (fingerprintFull==fingerprintKey + middle-truncated display, size 0/-1->Unknown + Long.MAX_VALUE-safe, format label per BookFormat md->Markdown, null author/location omitted, pagesLabel only when pageCount supplied, NO year/cover/tags) + CollectionDao.collectionNamesForBook join query (ordered names, empty when none). JVM + in-memory Room BookDetailsMapperTest (23 cases) green. Gate-4 ship-as-is (manual-fallback; Codex quota-limited). First #134 WI; feeds WI-4 BookDetailsSheet + WI-5 host wiring.** **WI-2 (2026-07-11): merged — FileProvider + share plumbing (foundational): res/xml/file_paths.xml grants ONLY filesDir/books; AndroidManifest FileProvider BookFileProvider (exported=false, grantUriPermissions, authority com.vreader.app.fileprovider); BookFileProvider DISPLAY_NAME reports title.ext for Unicode/CJK/illegal/all-illegal titles per BookFormat WITHOUT renaming the on-disk file; BookShareIntent.shareBookFileIntent builds ACTION_SEND with the content URI + per-format MIME + FLAG_GRANT_READ_URI_PERMISSION + ClipData; path-outside-books rejected (canonical-path prefix check + FileProvider IllegalArgumentException); ActivityNotFoundException/no-receiver -> silent no-op. Robolectric BookShareIntentTest + BookFileProviderDisplayNameTest green. Gate-4 ship-as-is (manual-fallback — Codex quota-exhausted). Feeds WI-5 host wiring.** **WI-3 (2026-07-11): merged — MorePopup + MoreRow (implements vreader-more.jsx, rule 51): the anchored top-right More popover over a MoreRow model (Action/Toggle/Disabled, MoreActionId DETAILS/SHARE/TTS/AUTO_TURN/BILINGUAL); renders ONLY supplied rows (unsupplied id ABSENT - no dead TTS/AutoTurn/Bilingual/Export rows, the more-row-ownership contract; no EXPORT id at all); Action fires onTap (chevron), Toggle reflects on + onToggle (switch), Disabled non-interactive + subText; backdrop-tap dismiss; TopEnd anchor flips under RTL, width clamps on narrow screen; reuses the ReaderTheme token map. Instrumented MorePopupTest compiles (live Compose run rides WI-6 acceptance). Gate-4 ship-as-is (manual-fallback, Codex quota-exhausted). Feeds WI-5 host wiring.** **WI-4 (2026-07-11): merged — BookDetailsSheet + BookDetailsRows (implements vreader-book-details.jsx, rule 51): non-interactive stacked details sheet over WI-1's BookDetailsUiModel; meta rows (title/author/format/size/location/pages/fingerprint/collections) each absent when its model value null/empty; copy-fingerprint invokes onCopyFingerprint with fingerprintFull (the FULL canonical key, not the truncated display); share invokes onShare; Location read-only. ABSENCE invariants held (Design-gate #1): NO cover art, NO Tap-to-add-cover placeholder, NO Export, no author-when-null, no tag-when-empty, no Pages-when-null. Tag chips wrap (FlowRow); Share row has the designed chevron. Instrumented BookDetailsSheetTest compiles (14 tests; live Compose run rides WI-6). Gate-4 ship-as-is (2 rounds; Codex ran). Feeds WI-5 host wiring.** **WI-5 (2026-07-11): merged — More-menu host wiring (the integrator): added ReaderSheet.Details + its token/sheetFromToken round-trip; ReaderChromeScaffold + EpubReaderChrome take a bookDetails param + render BookDetailsSheet on the Details route (null-model normalizes to None so the EPUB fragment dismiss overlay never blocks Readium touch-through — Gate-4 P1 fix); top-bar More button now shows WI-3 MorePopup (Details + Share rows only via one shared internal readerMoreRows() assembler — no dead TTS/AutoTurn/Bilingual/Export) across all 4 hosts (TxtReaderActivity TXT+MD, Azw3ReaderActivity, PdfReaderScreen/PdfReaderActivity, ReaderActivity/EpubReaderChrome); each host builds BookDetailsUiModel via BookDetailsMapper + collectionNamesForBook; Details opens the sheet, Share launches BookShareIntent for the on-disk book file (graceful no-receiver), copy-fingerprint copies fingerprintFull to the OS clipboard (no custom toast, rule 51). Both source sets compile + JVM tests (ReaderChromeStateSaverTest details round-trip, ReaderMoreRowsTest) green; live Compose/connected run rides WI-6 acceptance. Gate-4 ship-as-is (2 rounds; Codex ran, round-1 caught the touch-through P1). ORCHESTRATOR NOTE (rule-55 batch evidence): the lane edited PdfReaderActivity.kt (18-line host-model wiring mirroring the other 3 hosts) which the brief write-set under-declared (named PdfReaderScreen.kt only; the PDF host is split Activity+Screen) — surfaced not silent, on-platform reader-host file, no orchestrator surface, ACCEPTED. Feature code-complete; WI-6 = acceptance -> DONE -> VERIFIED.** **WI-6 / VERIFIED (2026-07-11): Gate-5 acceptance PASS on emulator-5554 — all 5 code WIs merged (android/v0.16.0), feature DONE then VERIFIED. Verifier ran the deferred live Compose/connected suites + real-book end-to-end on TWO CJK formats (19.4 MB EPUB via Readium + 14.1 MB TXT): More menu shows exactly Details + Share on both hosts (no dead TTS/AutoTurn/Bilingual/Export), Details opens the Book Details sheet with correct real metadata + absence invariants (no cover art, no Export, TXT omits author/pages/collections), Share launches the system chooser with the correct book filename, and copy-fingerprint's live clipboard overlay showed the FULL canonical key (epub:1f5aecb8659d9033…, not the truncated display). Connected suites all green: BookDetailsSheetTest 14/0, MorePopupTest 11/0, ReaderChromeScaffoldTest 11/0, EpubReaderChromeTest 3/0, PdfReaderChromeUiTest 5/0 regression (44/0 total). WI-6a: Gate-5 caught a test-authoring bug (both rendersAcrossThemes tests looped compose.setContent -> IllegalStateException; NO product defect) -> fixed single-setContent-per-test, Gate-4 ship-as-is (Codex 019f515b), shipped android/v0.16.1 (PR #1949); both suites re-run green. Evidence dev-docs/verification/feature-134-20260711.md. Box F pt3 complete.** GH: #1926 |
+docs/features.md:188:| 135| **Android reader bookmarks — create / toggle / list / jump** (parity box F, split from #132) — box F hardest coupled sub-problems: canonical->Readium locator reconstruction, awaited AZW3 foliate goTo, the bookmark unique-index migration. | android/app/.../reader bookmark locator reconstruction + foliate awaited-goTo + TOCSheet Bookmarks tab + unique-index migration | Medium | VERIFIED | Deps:[feat:#132] (#132 wires the annotations.json bookmark backup already; #135 needs no backup change). Plan `dev-docs/plans/20260710-feature-135-android-bookmarks.md` (Gate-1 v2, ~21 WIs). Design authority (landed): vreader-reader.jsx toggle + vreader-panels.jsx Bookmarks tab; row-deletion design gate #1903 CLOSED (deletion DESIGNED but deferred to a follow-up WI — #135 scoped to create/toggle/list/jump). **Gate-2 SIGNED OFF (2026-07-11): round-1 audit = 6 findings (2 High, 4 Medium; core design sound + API-grounded); plan v2 fixed the stale DB version (v5->v7, migration MIGRATION_7_8), removed the duplicate insertBookmarkIfAbsent declaration (reuse #132 WI-6b's), corrected linkWithHref(Url) + cited the locatorFromLink->copyWithLocations reconstruction seam, reworded the #1903-closed delete design. Round-2 re-audit CLEAN: awaited AZW3 goTo rides the existing secure post()/addWebMessageListener channel (never addJavascriptInterface); migration dedupe-before-unique-index. Codex quota-down -> independent fresh-subagent auditor per rule-47 manual fallback. READY TO BUILD.** **WI-1 (2026-07-11): merged — ReadiumLocatorReconstructor(expectedFingerprintKey, publication).toReadium(canonical): Readium Locator? via the faithful seam Url(href)?->linkWithHref(Url)->locatorFromLink(Link)->copyWithLocations(progression, fragments=cfi?) (+ text from textQuote/textContext via .copy(text=Locator.Text)), mirroring ReadiumTocProvider's extracted PublicationLocatorSource seam (Publication is final/unmockable). Kept SEPARATE from the pure-JVM Readium-free ReadiumLocatorBridge. Identity gate FIRST (Gate-4 fix): a canonical whose fingerprintKey differs from the book's is rejected before any publication access, so a bookmark for a different book cannot resolve a coincidentally-matching href. EVERY other degrade -> null so the caller keeps the bookmark sheet open (null Url, null linkWithHref, null locatorFromLink, structurally-invalid). Robolectric ReadiumLocatorReconstructorTest 14/0 (resolvable->valid, cfi->fragments, textQuote->text, all null-degrade paths incl. fingerprint-mismatch-asserts-seam-not-invoked, round-trip). Gate-4 codex 2 rounds ship-as-is (round-1 block on the missing fingerprint guard, fixed). First #135 WI; feeds WI-7 EPUB bookmark jump + WI-8 backup-restored jump.** **WI-3 (2026-07-11): merged — atomic bookmark toggle + unique-index migration. BookmarkEntity gains a composite UNIQUE @Index([bookKey, profileKey]) so re-bookmarking the same position is idempotent; DB version 7->8 with MIGRATION_7_8 that DEDUPES duplicate loser rows (deterministic winner: greatest updatedAt, then createdAt, then lowest bookmarkId) BEFORE CREATE UNIQUE INDEX index_bookmarks_bookKey_profileKey (matching Room's generated name/cols, 8.json validated) so a pre-existing duplicate can't fail the migration; MIGRATION_7_8 appended to ALL_MIGRATIONS. Daos.toggleBookmark (@Transaction, REUSES the pre-existing insertBookmarkIfAbsent; decides add-vs-remove by POSITION PRESENCE via findBookmarkByProfile, re-keys on a bookmarkId PK collision so Added is truthful) + findBookmarkByProfile/deleteBookmarkByProfile/isBookmarked; AnnotationsRepository.toggleBookmark/isBookmarked + BookmarkToggleResult. In-memory Room + migration harness green (Robolectric): 7->8 dedupe (winner survives, losers deleted, other tables preserved, index rejects new dup) + clean 7->8, toggle add->one/again->zero, concurrent/repeat add->exactly one (idempotent), isBookmarked presence, id-collision truthful-Added regression (11+10 tests). Gate-4 follow-up-recommended (2 correctness findings fixed over 3 rounds; sole residual an accepted-Low ~1-in-2^122 double-UUID-collision). Feeds WI-5 top-bar toggle + WI-7 host wiring.** **WI-4 (2026-07-11): merged — per-format bookmark presentation projection (pure, read-time): BookmarkPresentation.bookmarkRow(record, format, tocIndex?, previewProvider?, dateRenderer) -> BookmarkRowUi(preview?, chapter?, pageLabel?, dateLabel). EPUB/AZW3 chapter = nearest-at-or-above via a PREVALIDATED BookmarkTocIndex (built once from the TOC in a single up-to-O(n) pass validating totalProgression completeness+monotonicity; each lookup O(log n) binary search when monotonic, else an href-exact fallback picking the greatest progression at-or-below — huge-book safe + correct for partial/out-of-order TOCs) + page label from the TOC entry. PDF = one-based p.N (valid non-negative non-overflow only). TXT/MD preview = BookmarkPreviewProvider.snippet clamped <=120 single-line ellipsized. Deterministic dateLabel via an injected BookmarkDateRenderer (zone+formatter, no now()/default-locale). Absence-safe: no TOC / no provider / null-or-negative offset -> null fields, no crash; nothing stored (derived every call). fun interface BookmarkPreviewProvider (pure read contract). Pure-JVM BookmarkPresentationTest 29/0. DESIGN REFINEMENT vs plan: bookmarkRow takes BookmarkTocIndex? not List<TocEntry>? (Gate-4-required for correct O(log n) lookup); WI-6/WI-7 host builds the index once. Gate-4 ship-as-is (3 rounds; Codex caught the non-monotonic binary-search key + hrefFallback ordering). Feeds WI-6 Bookmarks surface + WI-7 host wiring (TXT supplies the provider).** **WI-2 (2026-07-11): merged — awaited AZW3/foliate goTo bridge. FoliateBridge.goTo(target): Azw3GoToResult mints a request id, evals the JSON-escaped (jsString) shell-shim call window.__vreaderGoTo(id,target), suspends on a CompletableDeferred keyed by id resolved by a matching goto-ack; withTimeoutOrNull(~3s) -> Timeout (entry cleared in finally, no leak); a caller cancellation OR supersede also clears the entry + completes the orphan (Gate-4 F1); a superseding goTo cancels the prior (Superseded). FoliateMessage.GoToAck(id, ok, cfi?, fraction?) + strict parser branch (id required, ok JSON-boolean-only, fraction finite-only). Azw3Document.goTo(canonical) derives CFI-first-else-fraction and maps the ack; render-death mid-jump survives document recreation via takePendingGoTo() + run(pendingGoTo=...) seeding the replacement, re-issued ONCE after book-ready (Gate-4 F2, wired by WI-7). Bundle patch: readerAPI.goTo/goToFraction now RETURN view.goTo's promise; reader.html window.__vreaderGoTo awaits it + posts goto-ack (id echoed) on resolve/reject; provenance SHA pin updated (bundle-patch.md Patch 2). SECURITY (#126): ack rides the existing addWebMessageListener vreaderHost channel (shell origin + main-frame only), NEVER addJavascriptInterface, unknown/stale/missing-id acks ignored. JVM FoliateGoToTest (10) + FoliateMessageParser goto-ack green; androidTest Azw3GoToSliceTest compiles (real relocate + render-death carry-across ride WI-7). Gate-4 ship-as-is (2 rounds: block -> ship). Feeds WI-7 AZW3 bookmark jump.** **WI-5 (2026-07-11): merged — top-bar bookmark toggle + Bookmarks route + current-locator state. NEW BookmarkToggleButton (implements vreader-reader.jsx, rule 51: filled Icons.Filled.Bookmark accent when isBookmarked / outline BookmarkBorder ink when not, 18dp icon in a 48dp touch target, a11y content-desc flips Add/Remove) fills #132's reserved topBookmarkSlot iff onToggleBookmark != null (so #132 Contents/Notes-only callers stay back-compatible + the slot is absent when null). ReaderSheet gains a Bookmarks case + its token/sheetFromToken round-trip + Saver (the #134 Details precedent, all 4 exhaustive when sites); ReaderChromeScaffold + EpubReaderChrome gain isCurrentBookmarked/onToggleBookmark/currentLocator params (mirroring annotations/bookDetails nullable defaults). NO undesigned Bookmarks-list surface (that is WI-6 TocBookmarksSheet) — the Bookmarks branch is a documented no-op; the EPUB host normalizes Bookmarks to None BEFORE the dismiss scrim so Readium touch-through is preserved. Params UNWIRED by hosts (WI-7 feeds them). Both source sets compile + JVM ReaderChromeStateSaver bookmarks round-trip 15/0; instrumented BookmarkToggleButtonTest + scaffold slot-absent test compile (live Compose rides WI-9). Gate-4 ship-as-is (Codex round 1, no blocking findings). Feeds WI-6 Bookmarks surface + WI-7 host wiring.** **WI-6 (2026-07-11): merged — Bookmarks surface: two-tab TocBookmarksSheet + review Bookmarks chip/card. NEW TocBookmarksSheet (implements vreader-panels.jsx, rule 51) is a WRAPPER hosting a Contents/Bookmarks tab bar that REUSES #132's TocContentsSheet UNCHANGED as the Contents tab (one-writer serialization — no in-place edit); Bookmarks tab = rows (OUTLINE bookmark icon / italic serif preview / chapter . p.N . date / chevron) rendered from List of BookmarkRowItem (BookmarkRowUi + source BookmarkRecord), tap -> onJumpBookmark + dismiss ONLY on JumpResult.Succeeded (a Failed jump keeps the sheet open, #132 navigation-outcome posture); onJumpBookmark nullable + capability-gated (null host -> review-only non-clickable rows, NO dead rows); empty-state; NO delete affordance (deferred). Declares JumpResult + BookmarkRowItem. ReaderChromeScaffold + EpubReaderChrome Toc arm switch to TocBookmarksSheet + the Bookmarks route opens it on the Bookmarks tab, adding bookmarks/onJumpBookmark nullable-defaulted params (#132 callers stay valid). AnnotationsReviewSheet gains a Bookmarks filter chip + BookmarkCard (vreader-android-annotations.jsx, FILLED icon / serif label / sans meta, capability-gated tap-to-jump). Both source sets compile + JVM suite green; instrumented TocBookmarksSheetTest + review-chip test compile (live Compose rides WI-9). Params UNWIRED by hosts (WI-7 feeds them). Gate-4 ship-as-is (2 rounds: r1 block-recommended caught clickable-dead-rows + filled-vs-outline TOC icon, both fixed). Feeds WI-7 host wiring.** **WI-7 (2026-07-11): merged — host wiring (the integrator, feature lights up): all 5 hosts (ReaderActivity EPUB, TxtReaderActivity TXT/MD, Azw3ReaderActivity, PdfReaderScreen/PdfReaderActivity) feed the chrome isCurrentBookmarked/onToggleBookmark/currentLocator (presence + toggle via repository.isBookmarked/toggleBookmark keyed by the current canonical locator, refreshed after toggle) + bookmarks List of BookmarkRowItem (observeBookmarks -> BookmarkPresentation.bookmarkRow with a BookmarkTocIndex built ONCE per host; TXT supplies the BookmarkPreviewProvider) + onJumpBookmark. Per-host jump: EPUB ReadiumLocatorReconstructor(publication).toReadium -> navigator.go (null/false -> Failed, sheet stays open; the fresh-process/backup-restored jump path); AZW3 Azw3Document.goTo launched off-thread with a SYNCHRONOUS target-validity dismiss decision (azw3JumpDecision — the awaited ~3s goTo cannot block the tap thread/ANR; render-death carry-across takePendingGoTo off the dying doc + run(pendingGoTo=) re-issue once wired in the host DisposableEffect); TXT scroll-to-charOffsetUTF16 (at/past-EOF rejected, Gate-4 R1 High fix); PDF page; out-of-range -> Failed. Dismiss only on JumpResult.Succeeded; NO invented error UI on Failed (rule 51 / #132 navigation-outcome). Both source sets compile + JVM BookmarkHostWiringTest 14/0; per-host instrumented slices (EpubBookmarkNavTest, TxtPdfBookmarkTest) compile — live runs ride WI-9 acceptance. NOTE: host Activity files already >300 lines pre-WI-7 (ReaderActivity 862, TxtReaderActivity 1002, Azw3ReaderActivity 569) — a file-split follow-up warranted, out of this WI's write-set. Gate-4 codex 2 rounds ship-as-is (R1 block on the TXT EOF clamp, fixed). Feeds WI-8 backup-restored jump + WI-9 acceptance.** **WI-8 (2026-07-12): merged — backup-restored bookmark jump + AZW3 nav connected tests (TEST-ONLY, no production change). BookmarkBackupRestoreJumpTest adapts #132's AnnotationBackupRoundTripConnectedTest live-WebDAV pattern for bookmarks: create bookmark -> back up -> wipe -> restore -> ORIGINAL-UUID preserved + canonical position intact -> canonical reconstruction via ReadiumLocatorReconstructor.toReadium resolves to the bookmarked resource + carries progression 0.25 (the fresh-process jump precondition; navigator.go landing rides WI-9) -> re-restore does NOT duplicate on the UUID PK AND a same-position different-UUID local bookmark keeps exactly one row (WI-3 (bookKey,profileKey) unique index via insertBookmarkIfAbsent IGNORE) -> renamed/unresolvable resource reconstructs to null (sheet stays open, rule 51). Azw3BookmarkNavTest: repository toggle create/remove one-row-per-position + presence, the created/listed bookmark threaded through azw3JumpDecision (jumpable->dismiss, un-jumpable->sheet-open) + azw3JumpResult awaited-landing map, render-death carry-across (takePendingGoTo/run re-issue against a real WebView, replacement reaches book-ready) + dead-bundle goTo->Timeout->JumpResult.Failed. androidTest source set compiles + JVM suite green; the LIVE emulator runs ride WI-9 acceptance. Fixtures: bundled minimal.epub (CI-appropriate synthetic, androidTest cannot read gitignored test-books/) + the local real book.azw3 (skips in CI). Gate-4 codex 2 rounds ship-as-is. Feeds WI-9 acceptance (all 5 formats end-to-end + live WebDAV bookmark round-trip).** **WI-8b (2026-07-12): merged — Gate-5-surfaced test-hardening (TEST-ONLY, no production change). A real-emulator Gate-5 acceptance run found the bookmark PRODUCT behavior correct (live-WebDAV backup->restore->jump PASS, EPUB/TXT toggle/list/jump PASS, TocBookmarksSheet 14/0, real-book toggle->filled + per-position presence corroborated) but 3 connected-test defects/gaps blocked a truthful VERIFIED; all fixed: (1) BookmarkToggleButtonTest.contentDescription_flipsWithState called setContent TWICE (the #134 IllegalStateException class the connected run catches, compile/JVM do not) -> single setContent driving a hoisted mutableStateOf flag, asserting the a11y content-desc flips Add<->Remove on the same node; (2) Azw3BookmarkNavTest.toggleAtAzw3Position never seeded the parent BookEntity -> insertBookmarkIfAbsent hit the bookmarks.bookKey->books.fingerprintKey FK (in-memory Room enforces FKs), aborting before assertions -> now seeds a BookEntity so the AZW3 repository create->one-row/remove->zero/same-position-different-UUID->one path ACTUALLY runs; (3) TxtPdfBookmarkTest covered only TXT despite its name -> added PDF-host coverage (render toggle + real top-bar create seam + host jump-decision pdfBookmarkPageTarget in/out-of-range) over the existing synthetic sample-3page.pdf (#115 fixture, no new asset). Live re-run confirmed GREEN: BookmarkToggleButtonTest 6/0, Azw3BookmarkNavTest 5 tests/0 failures (1 render test skipped = gitignored real book.azw3 absent in worktree; the target FK-fix toggle test PASSES), TxtPdfBookmarkTest 3/0. Gate-4 codex 2 rounds ship-as-is. Closes the AZW3-create + PDF verification gaps; feeds WI-9 finalize.** **WI-9 / VERIFIED (2026-07-12): Gate-5 acceptance PASS on emulator-5554 (v0.17.2, build 123, HEAD c7dd97b6). Evidence `dev-docs/verification/feature-135-20260712.md` (result: pass). Headline live-WebDAV bookmark backup->restore->jump round-trip UUID-preserving (BookmarkBackupRestoreJumpTest 1/0/0/0 over a throwaway rclone WebDAV); toggle/list/jump across all 5 formats (EPUB/TXT/MD/AZW3/PDF); TocBookmarksSheet 14/0; BookmarkToggleButtonTest 6/0; Azw3BookmarkNavTest 5/0-fail; TxtPdfBookmarkTest 3/0; real 19MB CJK EPUB + 14MB CJK TXT toggle->filled + per-position presence corroborated. All acceptance criteria met. Row -> VERIFIED; box B (annotations review sheet #132 + bookmark creation #135) COMPLETE; box F "Contents + bookmarks" half done (find-in-book #133 remains). GH #1927 closed.** GH: #1927 |
+docs/parity/android-checklist.md:58:  review sheet (#132) + bookmark creation/list (#135); all VERIFIED. Box B COMPLETE.
+docs/parity/android-checklist.md:69:  **Box B complete**: the annotations review sheet landed with **#132 VERIFIED 2026-07-11** (`android/v0.15.3`,
+docs/parity/android-checklist.md:94:  **IN PROGRESS — split (Gate-2 decision): #129 (GH #1879, PLANNED — Gate-2 clean 3 Codex rounds) is the
+docs/parity/android-checklist.md:98:  Box E checks when BOTH #129 AND the layout follow-up are VERIFIED.**
+docs/parity/android-checklist.md:106:  Status: **IN PROGRESS** — the chrome shell + Contents/TOC (**#132 VERIFIED 2026-07-11**, `android/v0.15.3`,
+docs/parity/android-checklist.md:107:  GH #1924), the More menu + Book Details + Share (**#134 VERIFIED 2026-07-11**, `android/v0.16.1`, GH #1926),
+// Purpose: feature #118 WI-2 (#110 Phase 3) — the AI client value types + typed errors, mirroring
+// iOS AITypes (AIRequest/AIResponse/AIStreamChunk/AIError). Provider-neutral; the OpenAI vs
+// Anthropic wire differences live in the providers.
+package com.vreader.app.ai
+
+enum class AiRole { system, user, assistant }
+
+data class AiMessage(val role: AiRole, val content: String)
+
+/** A chat request. `system` is the system prompt (Anthropic carries it top-level; the OpenAI
+ *  provider prepends it as a system message). */
+data class AiRequest(
+    val model: String,
+    val messages: List<AiMessage>,
+    val temperature: Double,
+    val maxTokens: Int,
+    val system: String? = null,
+)
+
+/** One streamed delta (the incremental assistant text). */
+data class AiChunk(val deltaText: String)
+
+/** A one-shot (non-streamed) response. */
+data class AiResponse(val text: String)
+
+/** Typed AI failures (HTTP + transport + protocol). */
+sealed class AiError(message: String) : Exception(message) {
+    object Auth401 : AiError("authentication failed (401) — check the API key")
+    object RateLimited429 : AiError("rate limited (429) — try again shortly")
+    object Offline : AiError("the provider couldn't be reached")
+    object Timeout : AiError("the provider took too long to respond")
+    class Http(val code: Int) : AiError("HTTP $code from the provider")
+    class Decode(detail: String) : AiError("couldn't parse the provider response: $detail")
+    class Stream(detail: String) : AiError("the stream ended abnormally: $detail")
+    /** Refused to send the API key over cleartext http:// to a non-local host. */
+    object InsecureUrl : AiError("the provider URL must be https:// (won't send the key over cleartext)")
+    class Config(detail: String) : AiError("provider misconfigured: $detail")
+}
+
+/** Test-connection outcome (the editor's Connection section). */
+sealed interface AiTestResult {
+    object Ok : AiTestResult
+    data class Fail(val error: AiError, val message: String) : AiTestResult
+}
+// Purpose: Addressable, range-based model of a decoded .txt — feature #111 WI-1.
+// Holds ONE backing decoded String and an array of chunk START offsets (UTF-16 code
+// units against the RAW text — NO line-ending normalization, so charOffsetUTF16 stays
+// exact for resume). Splits at line boundaries (CRLF/CR/LF kept inside the chunk);
+// hard-splits a runaway line at maxChunkChars (never mid-surrogate-pair). Visible
+// chunk text is materialized on demand (no per-chunk substrings retained). Pure JVM.
+package com.vreader.app.reader
+
+class TxtDocument private constructor(
+    val text: String,
+    private val starts: IntArray,
+) {
+    /** Number of chunks (0 for empty text). */
+    val chunkCount: Int get() = starts.size
+
+    /** The UTF-16 start offset of chunk [index] (clamped to a valid chunk). */
+    fun offsetForChunk(index: Int): Int {
+        if (starts.isEmpty()) return 0
+        return starts[index.coerceIn(0, starts.size - 1)]
+    }
+
+    /** The chunk index containing [offsetUtf16] (EOF-clamped); 0 for empty text. */
+    fun chunkForOffset(offsetUtf16: Int): Int {
+        if (starts.isEmpty()) return 0
+        val offset = offsetUtf16.coerceIn(0, text.length)
+        // Largest start <= offset (binary search).
+        var lo = 0; var hi = starts.size - 1; var ans = 0
+        while (lo <= hi) {
+            val mid = (lo + hi) ushr 1
+            if (starts[mid] <= offset) { ans = mid; lo = mid + 1 } else { hi = mid - 1 }
+        }
+        return ans
+    }
+
+    /** The text of chunk [index], materialized on demand from the backing string. */
+    fun textForChunk(index: Int): CharSequence {
+        if (starts.isEmpty()) return ""
+        val i = index.coerceIn(0, starts.size - 1)
+        val end = if (i + 1 < starts.size) starts[i + 1] else text.length
+        return text.subSequence(starts[i], end)
+    }
+
+    companion object {
+        const val DEFAULT_MAX_CHUNK_CHARS = 4000
+
+        /**
+         * Build a document from already-decoded [text]. Chunk boundaries fall after a
+         * line terminator (`\n`, `\r`, or `\r\n` — preserved in the chunk); a line longer
+         * than [maxChunkChars] is hard-split, but never between a surrogate pair.
+         */
+        fun of(text: String, maxChunkChars: Int = DEFAULT_MAX_CHUNK_CHARS): TxtDocument {
+            if (text.isEmpty()) return TxtDocument(text, IntArray(0))
+            // Primitive growable IntArray (no Int boxing) — a newline-dense 14MB file
+            // would otherwise spike tens of MB of boxed Integers + a duplicating copy.
+            var starts = IntArray(64)
+            var count = 0
+            fun push(v: Int) {
+                if (count == starts.size) starts = starts.copyOf(starts.size * 2)
+                starts[count++] = v
+            }
+            push(0)
+            var i = 0
+            var chunkStart = 0
+            val n = text.length
+            while (i < n) {
+                val c = text[i]
+                when {
+                    c == '\n' -> {
+                        i++
+                        if (i < n) { push(i); chunkStart = i }
+                    }
+                    c == '\r' -> {
+                        i++
+                        if (i < n && text[i] == '\n') i++   // CRLF stays one terminator
+                        if (i < n) { push(i); chunkStart = i }
+                    }
+                    else -> {
+                        i++
+                        // Hard-split a runaway line, but not mid-surrogate-pair (don't
+                        // split right after a high surrogate — its low half follows at i).
+                        if (i - chunkStart >= maxChunkChars && i < n && !text[i - 1].isHighSurrogate()) {
+                            push(i); chunkStart = i
+                        }
+                    }
+                }
+            }
+            return TxtDocument(text, starts.copyOf(count))
+        }
+    }
+}
+// Purpose: Extract TXT/MD text for the library search index, streaming each TxtDocument chunk to the
+// SectionSink — feature #128 WI-3. Serves both `txt` and `md` (raw markdown text; marker-stripping is
+// a nice-to-have deferred). Reuses the shipped reader decode/chunk path (TxtDecoder + TxtDocument).
+//
+// Memory note (Gate-2 round-3 HIGH): this path holds the whole decoded book String (via
+// TxtDecoder/TxtDocument) — O(book-size), the ACCEPTED EXISTING reader bound (indexing loads exactly
+// what the TXT/MD reader already loads to display the book). It is NOT O(batch). The sink still emits
+// chunks incrementally so the DB-write side stays batched.
+package com.vreader.app.search
+
+import com.vreader.app.data.Book
+import com.vreader.app.reader.TxtDecoder
+import com.vreader.app.reader.TxtDocument
+import kotlinx.coroutines.CancellationException
+import java.io.File
+
+/** Streams a TXT/MD book's TxtDocument chunks to a [SectionSink]; author is always null on Success. */
+class TxtMdTextExtractor : BookTextExtractor {
+
+    override suspend fun extract(book: Book, sink: SectionSink): ExtractResult {
+        val path = book.localFilePath ?: return ExtractResult.Unsupported
+        val file = File(path)
+        if (!file.exists()) return ExtractResult.Failed("file not found: $path")
+        return try {
+            val decoded = TxtDecoder.decode(file)
+            val document = TxtDocument.of(decoded.text)
+            // Emit one section per chunk; sectionIndex == chunkOrdinal == chunk index (TXT has no
+            // sub-resource grouping). Empty text → chunkCount 0 → zero emissions (still Success).
+            for (i in 0 until document.chunkCount) {
+                sink.emit(
+                    BookTextSection(
+                        sectionIndex = i,
+                        chunkOrdinal = i,
+                        title = null,
+                        text = document.textForChunk(i).toString(),
+                    ),
+                )
+            }
+            ExtractResult.Success(null)
+        } catch (e: CancellationException) {
+            throw e   // never swallow structured cancellation as a per-book failure
+        } catch (e: Exception) {
+            ExtractResult.Failed(e.message ?: e.javaClass.simpleName)
+        }
+    }
+}
+// Purpose: Extract EPUB text for the library search index via Readium's Publication content service,
+// streaming each finished section chunk to the SectionSink — feature #128 WI-3. Genuinely
+// bounded-memory (O(batch)): `content.iterator()` yields elements incrementally and only the current
+// section's in-progress buffer (+ one ~4 KB chunk) is resident — never `content.elements()` (which
+// materializes the whole publication) and never a growing List of all sections.
+//
+// Key decisions:
+// - `publication.content(locator = null)` is NULLABLE (no content service → protected/malformed EPUB)
+//   → typed ExtractResult.Unsupported.
+// - Section boundary = a change of reading-order resource (Locator.href) OR a Heading-role element
+//   (which starts a new titled section). Title = the element Locator's `title`, or the normalized-href
+//   TOC lookup (strip fragment + normalize percent-encoding before matching).
+// - A long section is chunked at ~4 KB with a UNIQUE monotonic `chunkOrdinal` across the WHOLE book so
+//   multiple chunks of one resource never collide on sectionIndex (deterministic first hit — WI-5 SQL).
+// - `finally { publication.close() }` on EVERY path (success, unsupported after open, exception) — the
+//   sink spans the open publication, so the close must be guaranteed.
+package com.vreader.app.search
+
+import com.vreader.app.data.Book
+import com.vreader.app.reader.BookOpener
+import kotlinx.coroutines.CancellationException
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.publication.services.content.Content
+import org.readium.r2.shared.publication.services.content.content
+import java.io.File
+
+/** Extracts EPUB text via Readium's content service, streaming section chunks to a [SectionSink]. */
+@OptIn(ExperimentalReadiumApi::class)
+class EpubTextExtractor(
+    private val bookOpener: BookOpener,
+    /** Approx max chunk size in UTF-16 chars before a section is split (deterministic ordinal). */
+    private val maxChunkChars: Int = DEFAULT_MAX_CHUNK_CHARS,
+) : BookTextExtractor {
+
+    init {
+        // A non-positive chunk size would make drainRemaining()/emitFullChunks() make no progress
+        // (cut == 0) and loop forever — reject it at construction.
+        require(maxChunkChars > 0) { "maxChunkChars must be > 0, was $maxChunkChars" }
+    }
+
+    override suspend fun extract(book: Book, sink: SectionSink): ExtractResult {
+        val path = book.localFilePath ?: return ExtractResult.Unsupported
+        val file = File(path)
+        if (!file.exists()) return ExtractResult.Failed("file not found: $path")
+
+        val publication = try {
+            bookOpener.open(file)
+        } catch (e: CancellationException) {
+            throw e   // never swallow structured cancellation as a per-book failure
+        } catch (e: Exception) {
+            return ExtractResult.Failed(e.message ?: e.javaClass.simpleName)
+        }
+        try {
+            val author = publication.metadata.authors.firstOrNull()?.name
+            val content = publication.content(null)
+                ?: return ExtractResult.Unsupported   // no content service → metadata-only book
+            val tocTitles = tocTitlesByHref(publication)
+            streamSections(content, tocTitles, sink)
+            return ExtractResult.Success(author)
+        } catch (e: CancellationException) {
+            throw e   // rethrow cancellation; the finally still closes the publication
+        } catch (e: Exception) {
+            return ExtractResult.Failed(e.message ?: e.javaClass.simpleName)
+        } finally {
+            publication.close()
+        }
+    }
+
+    /**
+     * Streams the publication's text via the content iterator, emitting each finished chunk. Groups
+     * text by reading-order resource (href) into `sectionIndex`; a Heading role starts a new titled
+     * section; a running `chunkOrdinal` is unique across the whole book.
+     */
+    private suspend fun streamSections(
+        content: Content,
+        tocTitles: Map<String, String>,
+        sink: SectionSink,
+    ) {
+        val iterator = content.iterator()
+        // Mutable extraction state carried across boundaries; the running chunkOrdinal is unique
+        // across the whole book, sectionIndex groups a resource's chunks for chapter attribution.
+        val state = StreamState()
+
+        while (iterator.hasNext()) {
+            val element = iterator.next()
+            if (element !is Content.TextElement) continue
+            val href = normalizeHref(element.locator.href.toString())
+            val isHeading = element.role is Content.TextElement.Role.Heading
+            // A resource change OR a heading starts a new section: drain the prior buffer first.
+            if (href != state.currentHref || isHeading) {
+                drainRemaining(state, sink)
+                state.sectionIndex++
+                state.currentHref = href
+                state.currentTitle = element.locator.title
+                    ?: tocTitles[href]
+                    ?: if (isHeading) element.text.trim().ifEmpty { null } else null
+            }
+            val text = element.text
+            if (text.isNotEmpty()) {
+                if (state.buffer.isNotEmpty()) state.buffer.append('\n')
+                state.buffer.append(text)
+                // Emit completed chunks from the FRONT as soon as the buffer crosses the threshold,
+                // retaining only a short (< maxChunkChars) tail — so at most ~one chunk + tail is
+                // resident regardless of the resource size (bounded-memory / O(batch), not O(book)).
+                emitFullChunks(state, sink)
+            }
+        }
+        drainRemaining(state, sink)
+    }
+
+    /** Emits every completed leading chunk (buffer ≥ maxChunkChars), keeping only the sub-chunk tail. */
+    private suspend fun emitFullChunks(state: StreamState, sink: SectionSink) {
+        while (state.buffer.length >= maxChunkChars) {
+            val end = splitBoundary(state.buffer, maxChunkChars)
+            if (end <= 0 || end >= state.buffer.length) break
+            emitChunk(state, sink, state.buffer.substring(0, end))
+            state.buffer.delete(0, end)
+        }
+    }
+
+    /** Drains any remaining buffered text for the current section (the partial tail). */
+    private suspend fun drainRemaining(state: StreamState, sink: SectionSink) {
+        while (state.buffer.length >= maxChunkChars) {
+            val end = splitBoundary(state.buffer, maxChunkChars)
+            val cut = if (end in 1 until state.buffer.length) end else state.buffer.length
+            emitChunk(state, sink, state.buffer.substring(0, cut))
+            state.buffer.delete(0, cut)
+        }
+        if (state.buffer.isNotEmpty()) {
+            emitChunk(state, sink, state.buffer.toString())
+            state.buffer.setLength(0)
+        }
+    }
+
+    private suspend fun emitChunk(state: StreamState, sink: SectionSink, chunk: String) {
+        if (chunk.isBlank()) return
+        sink.emit(
+            BookTextSection(
+                sectionIndex = state.sectionIndex,
+                chunkOrdinal = state.chunkOrdinal++,
+                title = state.currentTitle,
+                text = chunk,
+            ),
+        )
+    }
+
+    /** The split length for the FIRST chunk of [buffer] (≥ [target]), preferring a newline, never
+     *  mid-surrogate-pair. Returns the exclusive end index within `buffer`. */
+    private fun splitBoundary(buffer: CharSequence, target: Int): Int {
+        val n = buffer.length
+        if (n <= target) return n
+        var end = target.coerceAtMost(n)
+        // Prefer a newline boundary within the last quarter of the chunk for readable snippets.
+        val minNl = target * 3 / 4
+        val nl = lastNewline(buffer, minNl, end)
+        if (nl in 1 until end) end = nl + 1
+        // Never split between a high and low surrogate.
+        if (end < n && Character.isHighSurrogate(buffer[end - 1])) end++
+        return end.coerceAtMost(n)
+    }
+
+    private fun lastNewline(buffer: CharSequence, from: Int, to: Int): Int {
+        var i = to - 1
+        while (i >= from) {
+            if (buffer[i] == '\n') return i
+            i--
+        }
+        return -1
+    }
+
+    /** Mutable per-book extraction state carried across section boundaries. */
+    private class StreamState {
+        var chunkOrdinal = 0
+        var sectionIndex = -1
+        var currentHref: String? = null
+        var currentTitle: String? = null
+        val buffer = StringBuilder()
+    }
+
+    /** Builds an href → TOC title map, normalizing each TOC entry's href the same way. */
+    private fun tocTitlesByHref(publication: Publication): Map<String, String> {
+        val map = mutableMapOf<String, String>()
+        fun walk(links: List<Link>) {
+            for (link in links) {
+                val title = link.title
+                if (!title.isNullOrBlank()) {
+                    val href = normalizeHref(link.href.toString())
+                    map.putIfAbsent(href, title)
+                }
+                if (link.children.isNotEmpty()) walk(link.children)
+            }
+        }
+        walk(publication.tableOfContents)
+        return map
+    }
+
+    /** Strip the fragment and normalize percent-encoding so `chapter1.xhtml#a` matches `chapter1.xhtml`. */
+    private fun normalizeHref(href: String): String {
+        val noFragment = href.substringBefore('#')
+        return try {
+            java.net.URLDecoder.decode(noFragment, Charsets.UTF_8.name())
+        } catch (e: Exception) {
+            noFragment
+        }
+    }
+
+    companion object {
+        const val DEFAULT_MAX_CHUNK_CHARS = 4000
+    }
+}
+vreader/Services/AI/MockAIProvider.swift:103:            // Feature #56 chapter-translation (`TranslationChunkContract`) asks
+vreader/Services/AI/MockAIProvider.swift:128:    /// If `prompt` is a `TranslationChunkContract.userPrompt` (N numbered source
+vreader/Services/AI/ChapterPrefetching.swift:2:// `BilingualReadingViewModel` depends on. The VM's unit-aware prefetch trigger
+vreader/Services/AI/ChapterPrefetching.swift:20:// @coordinates-with: BilingualReadingViewModel.swift,
+vreader/Services/AI/ChapterTranslationPrefetcher.swift:29://   BilingualReadingViewModel.swift,
+vreader/Services/AI/ChapterTranslationPrefetcher.swift:84:    /// level (TXT/MD: both sides segment through `ChapterSegmenter`, so the
+vreader/Services/AI/ChapterTranslationPrefetcher.swift:113:        // through `ChapterSegmenter` (TXT/MD) hold the 1:1 contract at
+vreader/Services/AI/ChapterTranslationPrefetcher.swift:196:    /// then `ChapterTranslationService.translatePreSegmented` (no disk cache).
+vreader/Services/AI/ChapterTranslationPrefetcher.swift:220:            let out = try await translationService.translatePreSegmented(
+vreader/Services/AI/ChapterTranslationPrefetcher.swift:231:            Self.log.error("prefetchDirect translatePreSegmented failed: \(String(describing: error), privacy: .private)")
+vreader/Services/AI/ChapterTranslationChunker.swift:15:// @coordinates-with: ChapterSegmenter.swift, ChapterTranslationService.swift,
+vreader/Services/AI/ChapterTranslationChunker.swift:21:enum ChapterTranslationChunker {
+vreader/Services/Reader/EPUBChapterTextProvider.swift:50:            // service's `ChapterSegmenter.paragraphs` produces one
+vreader/Services/AI/TranslationChunkContract.swift:17:// @coordinates-with: ChapterSegmenter.swift, ChapterTranslationChunker.swift,
+vreader/Services/AI/TranslationChunkContract.swift:24:enum TranslationChunkContract {
+vreaderTests/Services/AI/ChapterTranslationServiceTests.swift:415:    // MARK: - translatePreSegmented (Bug #268 — block-text-direct translation)
+vreaderTests/Services/AI/ChapterTranslationServiceTests.swift:417:    @Test func translatePreSegmented_translatesGivenSegments1to1() async throws {
+vreaderTests/Services/AI/ChapterTranslationServiceTests.swift:425:        let result = try await service.translatePreSegmented(
+vreaderTests/Services/AI/ChapterTranslationServiceTests.swift:438:        _ = try await service.translatePreSegmented(
+vreaderTests/Services/AI/ChapterTranslationServiceTests.swift:446:    @Test func translatePreSegmented_emptyInput_returnsEmpty_withNoRequest() async throws {
+vreaderTests/Services/AI/ChapterTranslationServiceTests.swift:450:        let result = try await service.translatePreSegmented(
+vreaderTests/Services/AI/ChapterTranslationServiceTests.swift:458:    @Test func translatePreSegmented_malformedChunkDecode_fallsBackPerSegment_stays1to1() async throws {
+vreaderTests/Services/AI/ChapterTranslationServiceTests.swift:469:        let result = try await service.translatePreSegmented(
+vreaderTests/Services/AI/ChapterTranslationServiceTests.swift:726:    /// Bug #343 mechanism (1): `translatePreSegmented` was cache-FREE, so
+vreaderTests/Services/AI/ChapterTranslationServiceTests.swift:737:        let out = try await service.translatePreSegmented(
+vreaderTests/Services/AI/ChapterTranslationServiceTests.swift:777:        let out = try await service.translatePreSegmented(
+vreader/Services/Search/EPUBTextExtractor.swift:82:    /// `ChapterSegmenter.paragraphs` (blank-line-separated). Without
+vreaderTests/Services/AI/MockAIProviderTests.swift:95:        let prompt = TranslationChunkContract.userPrompt(
+vreaderTests/Services/AI/MockAIProviderTests.swift:100:        let decoded = try TranslationChunkContract.decode(reply, expectedCount: segments.count)
+vreaderTests/Services/AI/MockAIProviderTests.swift:112:        let prompt = TranslationChunkContract.userPrompt(
+vreaderTests/Services/AI/MockAIProviderTests.swift:115:        let decoded = try TranslationChunkContract.decode(reply, expectedCount: 2)
+vreaderTests/Services/AI/MockAIProviderTests.swift:124:        let prompt = TranslationChunkContract.userPrompt(
+vreaderTests/Services/AI/MockAIProviderTests.swift:127:        let decoded = try TranslationChunkContract.decode(reply, expectedCount: 3)
+vreader/Services/Foliate/JS/foliate-host.js:26:// `ChapterSegmenter.paragraphs`) MUST equal the enumerate path's block count
+vreader/Services/Foliate/JS/foliate-host.js:457:            // `ChapterSegmenter.paragraphs` splits on blank lines, so this makes
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:1:// Purpose: Tests for TranslationChunkContract — the strict JSON-array prompt +
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:6:// @coordinates-with: TranslationChunkContract.swift,
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:13:@Suite("TranslationChunkContract")
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:14:struct TranslationChunkContractTests {
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:19:        let prompt = TranslationChunkContract.userPrompt(
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:26:        let prompt = TranslationChunkContract.userPrompt(
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:34:        let prompt = TranslationChunkContract.userPrompt(
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:44:        let literal = TranslationChunkContract.userPrompt(
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:46:        let literary = TranslationChunkContract.userPrompt(
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:57:        let result = try TranslationChunkContract.decode(json, expectedCount: 3)
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:63:        let result = try TranslationChunkContract.decode(json, expectedCount: 2)
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:70:        let result = try TranslationChunkContract.decode(json, expectedCount: 2)
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:75:        #expect(throws: TranslationChunkContract.DecodeError.countMismatch(expected: 3, actual: 1)) {
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:76:            _ = try TranslationChunkContract.decode(#"["only one"]"#, expectedCount: 3)
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:81:        #expect(throws: TranslationChunkContract.DecodeError.countMismatch(expected: 2, actual: 4)) {
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:82:            _ = try TranslationChunkContract.decode(#"["a","b","c","d"]"#, expectedCount: 2)
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:88:        #expect(throws: TranslationChunkContract.DecodeError.notAStringArray) {
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:89:            _ = try TranslationChunkContract.decode(#"["ok", 42]"#, expectedCount: 2)
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:94:        #expect(throws: TranslationChunkContract.DecodeError.notAStringArray) {
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:95:            _ = try TranslationChunkContract.decode(#"[["nested"], "b"]"#, expectedCount: 2)
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:100:        #expect(throws: TranslationChunkContract.DecodeError.notAStringArray) {
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:101:            _ = try TranslationChunkContract.decode(#"{"text": "not an array"}"#, expectedCount: 1)
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:106:        #expect(throws: TranslationChunkContract.DecodeError.notAStringArray) {
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:107:            _ = try TranslationChunkContract.decode("this is not json at all", expectedCount: 1)
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:112:        let result = try TranslationChunkContract.decode("[]", expectedCount: 0)
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:119:        let result = try TranslationChunkContract.decode(#"["", "real", ""]"#, expectedCount: 3)
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:127:        let result = try TranslationChunkContract.decode(json, expectedCount: 2)
+vreaderTests/Services/AI/TranslationChunkContractTests.swift:135:        let result = try TranslationChunkContract.decode(json, expectedCount: 2)
+vreader/Services/AI/ChapterSegmenter.swift:14:// @coordinates-with: ChapterTranslationChunker.swift,
+vreader/Services/AI/ChapterSegmenter.swift:21:enum ChapterSegmenter {
+vreader/Services/AI/BilingualAIReadiness.swift:9:// (`BilingualReadingViewModel.aiConfigured`) so its `configured` descriptor
+vreader/Services/AI/BilingualAIReadiness.swift:14://   AIConsentManager.swift, BilingualReadingViewModel.swift
+vreader/Services/AI/TranslationStyle.swift:3:// folded into the translation chunk prompt by `TranslationChunkContract`, and
+vreader/Services/AI/TranslationStyle.swift:7:// @coordinates-with: TranslationChunkContract.swift,
+vreader/Services/AI/ResolvedAIProviderConfig.swift:16://   prompt-construction input consumed only by `TranslationChunkContract`
+vreader/Services/AI/ChapterTranslationService.swift:14:// - On any chunk decode failure (`TranslationChunkContract.DecodeError`) the
+vreader/Services/AI/ChapterTranslationService.swift:20:// @coordinates-with: ChapterTranslationStore.swift, ChapterSegmenter.swift,
+vreader/Services/AI/ChapterTranslationService.swift:21://   ChapterTranslationChunker.swift, TranslationChunkContract.swift,
+vreader/Services/AI/ChapterTranslationService.swift:134:        case .paragraph: segments = ChapterSegmenter.paragraphs(in: sourceText)
+vreader/Services/AI/ChapterTranslationService.swift:135:        case .sentence:  segments = ChapterSegmenter.sentences(in: sourceText)
+vreader/Services/AI/ChapterTranslationService.swift:202:        case .paragraph: segments = ChapterSegmenter.paragraphs(in: sourceText)
+vreader/Services/AI/ChapterTranslationService.swift:203:        case .sentence:  segments = ChapterSegmenter.sentences(in: sourceText)
+vreader/Services/AI/ChapterTranslationService.swift:232:        let chunks = ChapterTranslationChunker.chunk(
+vreader/Services/AI/ChapterTranslationService.swift:311:    /// bypassing `ChapterSegmenter`. Used by the bilingual EPUB
+vreader/Services/AI/ChapterTranslationService.swift:327:    func translatePreSegmented(
+vreader/Services/AI/ChapterTranslationService.swift:337:        let chunks = ChapterTranslationChunker.chunk(
+vreader/Services/AI/ChapterTranslationService.swift:412:            let pieces = ChapterTranslationChunker.subSplit(
+vreader/Services/AI/ChapterTranslationService.swift:418:                    let piecePrompt = TranslationChunkContract.userPrompt(
+vreader/Services/AI/ChapterTranslationService.swift:421:                    if let decoded = try? TranslationChunkContract.decode(
+vreader/Services/AI/ChapterTranslationService.swift:433:        let prompt = TranslationChunkContract.userPrompt(
+vreader/Services/AI/ChapterTranslationService.swift:436:        if let decoded = try? TranslationChunkContract.decode(
+vreader/Services/AI/ChapterTranslationService.swift:447:            let onePrompt = TranslationChunkContract.userPrompt(
+vreader/Services/AI/ChapterTranslationService.swift:450:            if let oneDecoded = try? TranslationChunkContract.decode(
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:1:// Purpose: Tests for ChapterSegmenter — paragraph + CJK-aware sentence
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:4:// @coordinates-with: ChapterSegmenter.swift,
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:29:@Suite("ChapterSegmenter")
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:30:struct ChapterSegmenterTests {
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:35:        #expect(ChapterSegmenter.paragraphs(in: "").isEmpty)
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:39:        #expect(ChapterSegmenter.paragraphs(in: "   \n\n  \t ").isEmpty)
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:43:        let result = ChapterSegmenter.paragraphs(in: "Just one paragraph here.")
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:49:        let result = ChapterSegmenter.paragraphs(in: text)
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:55:        let result = ChapterSegmenter.paragraphs(in: text)
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:61:        let result = ChapterSegmenter.paragraphs(in: text)
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:67:        let result = ChapterSegmenter.paragraphs(in: text)
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:75:        let result = ChapterSegmenter.paragraphs(in: text)
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:83:        #expect(ChapterSegmenter.sentences(in: "").isEmpty)
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:88:        let result = ChapterSegmenter.sentences(in: text)
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:99:        let result = ChapterSegmenter.sentences(in: text)
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:107:        let result = ChapterSegmenter.sentences(in: text)
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:114:        let result = ChapterSegmenter.sentences(in: text)
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:121:        let result = ChapterSegmenter.sentences(in: text)
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:127:        let result = ChapterSegmenter.sentences(in: text)
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:148:        let sentences = ChapterSegmenter.sentences(in: text)
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:149:        let ranges = ChapterSegmenter.sentenceRanges(in: text)
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:178:        let paragraphs = ChapterSegmenter.paragraphs(in: text)
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:186:        #expect(ChapterSegmenter.paragraphs(in: text) == ["第一段。", "第二段。"])
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:192:        #expect(ChapterSegmenter.paragraphs(in: "a\r\nb") == ["a\nb"])
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:193:        #expect(ChapterSegmenter.paragraphs(in: "a\rb\r\n\r\nc") == ["a\nb", "c"])
+vreaderTests/Services/AI/ChapterSegmenterTests.swift:198:        let ranges = ChapterSegmenter.sentenceRanges(in: text)
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:1:// Purpose: Tests for ChapterTranslationChunker — groups translation segment
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:4:// @coordinates-with: ChapterTranslationChunker.swift,
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:11:@Suite("ChapterTranslationChunker")
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:12:struct ChapterTranslationChunkerTests {
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:15:        let chunks = ChapterTranslationChunker.chunk(segments: [], maxCharsPerChunk: 100)
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:20:        let chunks = ChapterTranslationChunker.chunk(segments: ["hello"], maxCharsPerChunk: 100)
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:27:        let chunks = ChapterTranslationChunker.chunk(segments: segments, maxCharsPerChunk: 25)
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:34:        let chunks = ChapterTranslationChunker.chunk(segments: segments, maxCharsPerChunk: 12)
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:43:        let chunks = ChapterTranslationChunker.chunk(segments: segments, maxCharsPerChunk: 100)
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:53:        let chunks = ChapterTranslationChunker.chunk(segments: segments, maxCharsPerChunk: 100)
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:60:        let chunks = ChapterTranslationChunker.chunk(segments: segments, maxCharsPerChunk: 100)
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:67:        let chunks = ChapterTranslationChunker.chunk(segments: segments, maxCharsPerChunk: 100)
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:75:        let chunks = ChapterTranslationChunker.chunk(segments: segments, maxCharsPerChunk: 8)
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:82:        let chunks = ChapterTranslationChunker.chunk(segments: segments, maxCharsPerChunk: 10)
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:92:        let chunks = ChapterTranslationChunker.chunk(segments: segments, maxCharsPerChunk: 0)
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:98:        let chunks = ChapterTranslationChunker.chunk(segments: ["x", "y"], maxCharsPerChunk: -5)
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:105:        #expect(ChapterTranslationChunker.subSplit("hello", maxChars: 10) == ["hello"])
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:106:        #expect(ChapterTranslationChunker.subSplit("", maxChars: 10) == [""])
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:111:        let pieces = ChapterTranslationChunker.subSplit(text, maxChars: 10)
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:119:        let pieces = ChapterTranslationChunker.subSplit("alpha beta gamma", maxChars: 10)
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:126:        let pieces = ChapterTranslationChunker.subSplit(text, maxChars: 10)
+vreaderTests/Services/AI/ChapterTranslationChunkerTests.swift:134:        let pieces = ChapterTranslationChunker.subSplit(text, maxChars: 3)
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:1:// Purpose: Tests for BilingualReadingViewModel's WI-7a persistence/state core
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:6:// @coordinates-with: BilingualReadingViewModel.swift,
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:14:@Suite("BilingualReadingViewModel — persistence/state core (WI-7a)")
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:15:struct BilingualReadingViewModelCoreTests {
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:31:        let vm = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:51:        let vm = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:65:        let vm = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:75:        let vm = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:80:        let reloaded = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:91:        let vm = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:95:        let reloaded = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:107:        let vm = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:121:        let vm = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:124:        let reloaded = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:132:        let vm = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:135:        let reloaded = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:145:        let vm = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:155:        let vm = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:171:        let vm = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:180:        let vm = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:199:        let vm = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:216:        let vm = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:226:        let vm = BilingualReadingViewModel(
+vreaderTests/ViewModels/BilingualReadingViewModelCoreTests.swift:237:        let vm = BilingualReadingViewModel(
+
+exec
+/bin/zsh -lc "rg -n '"'^'"\\| 13[2345]\\|' docs/features.md
+rg -n \"bilingualEnabled|bilingualTargetLanguage|bilingualGranularity|PerBookSettingsOverride\" android vreader contracts
+rg -n \"readium-navigator|readium.*3\\.3\\.0|readiumVersion\" android gradle* buildSrc settings.gradle.kts -g '*.kts' -g '*.toml' -g '*.gradle' -g '*.properties'
+find \""'$HOME/.gradle/caches" -type f '"\\( -name 'readium-navigator-3.3.0.aar' -o -name '*navigator*3.3.0*.aar' \\) 2>/dev/null | head -20" in /Users/ll/workspace/vreader
+ succeeded in 1112ms:
+/Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-navigator/3.3.0/162dd7fdee9e61a10441e5262792ec0d76b6011e/readium-navigator-3.3.0.aar
+
+exec
+/bin/zsh -lc "rg -n \"readium-navigator|3\\.3\\.0\" android -g '*.toml' -g '*.kts' -g '*.gradle' -g '*.properties'
+find \""'$HOME/.gradle/caches" -type f -path '"'*readium-navigator*3.3.0*' | head -40
+AAR=\""'$HOME/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-navigator/3.3.0/162dd7fdee9e61a10441e5262792ec0d76b6011e/readium-navigator-3.3.0.aar"; unzip -l "$AAR" | head -30
+find "$HOME/.gradle/caches/transforms-*" -type f -name '"'*.jar' 2>/dev/null | rg 'readium|jetified' | head -30" in /Users/ll/workspace/vreader
+ succeeded in 609ms:
+/Users/ll/.gradle/caches/modules-2/metadata-2.107/descriptors/org.readium.kotlin-toolkit/readium-navigator/3.3.0/26c913274550a0b2221f47a0fe2d2358/descriptor.bin
+/Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-navigator/3.3.0/fa9ca42cd2606f432a5843df9cc4953fe808d696/readium-navigator-3.3.0.module
+/Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-navigator/3.3.0/ec205146a3401ca43792b37bfb4b9b2d51fa6a35/readium-navigator-3.3.0.pom
+/Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-navigator/3.3.0/162dd7fdee9e61a10441e5262792ec0d76b6011e/readium-navigator-3.3.0.aar
+/Users/ll/.gradle/caches/8.14.4/transforms/87fd454872d62994fa2f156d672a8156/transformed/readium-navigator-3.3.0-runtime.jar
+/Users/ll/.gradle/caches/8.14.4/transforms/1701b51ad5c53162237bb3eb7c18fd66/transformed/readium-navigator-3.3.0-runtime/readium-navigator-3.3.0-runtime_dex/classes.dex
+/Users/ll/.gradle/caches/8.14.4/transforms/20a535398e2b06999431a36d9970924d/transformed/readium-navigator-3.3.0-api.jar
+/Users/ll/.gradle/caches/8.14.4/transforms/13046fd0a3da406b28f8af209bcd07d2/transformed/readium-navigator-3.3.0-runtime
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/jars/classes.jar
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/jars/libs/PhotoView-2.3.0.jar
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/res/drawable/readium_media_notification_rewind.xml
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/res/drawable/readium_media_notification_fastforward.xml
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/res/layout/readium_navigator_fragment_fxllayout_single.xml
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/res/layout/readium_navigator_viewpager.xml
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/res/layout/readium_navigator_viewpager_fragment_epub.xml
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/res/layout/readium_navigator_viewpager_fragment_cbz.xml
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/res/layout/readium_navigator_fragment_fxllayout_double.xml
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/res/values-land/values-land.xml
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/res/values/values.xml
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/AndroidManifest.xml
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/META-INF/com/android/build/gradle/aar-metadata.properties
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/R.txt
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/assets/readium/readium-css/ReadiumCSS-before.css
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/assets/readium/readium-css/ReadiumCSS-default.css
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/assets/readium/readium-css/ReadiumCSS-ebpaj_fonts_patch.css
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/assets/readium/readium-css/cjk-vertical/ReadiumCSS-before.css
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/assets/readium/readium-css/cjk-vertical/ReadiumCSS-default.css
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/assets/readium/readium-css/cjk-vertical/ReadiumCSS-after.css
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/assets/readium/readium-css/ReadiumCSS-after.css
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/assets/readium/readium-css/ReadMe.md
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/assets/readium/readium-css/rtl/ReadiumCSS-before.css
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/assets/readium/readium-css/rtl/ReadiumCSS-default.css
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/assets/readium/readium-css/rtl/ReadiumCSS-after.css
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/assets/readium/readium-css/cjk-horizontal/ReadiumCSS-before.css
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/assets/readium/readium-css/cjk-horizontal/ReadiumCSS-default.css
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/assets/readium/readium-css/cjk-horizontal/ReadiumCSS-after.css
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/assets/readium/readium-css/fonts/AccessibleDfA.otf
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/assets/readium/readium-css/fonts/LICENSE-AccessibleDfa
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/assets/readium/readium-css/fonts/iAWriterDuospace-Regular.ttf
+/Users/ll/.gradle/caches/8.14.4/transforms/2762df196b77e1470ec8fa1ab436d4ad/transformed/readium-navigator-3.3.0/assets/readium/readium-css/fonts/LICENSE-IaWriterDuospace.md
+Archive:  /Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-navigator/3.3.0/162dd7fdee9e61a10441e5262792ec0d76b6011e/readium-navigator-3.3.0.aar
+  Length      Date    Time    Name
+---------  ---------- -----   ----
+      798  02-01-1980 00:00   R.txt
+      394  02-01-1980 00:00   AndroidManifest.xml
+   833856  02-01-1980 00:00   classes.jar
+        0  02-01-1980 00:00   res/
+        0  02-01-1980 00:00   res/drawable/
+     1224  02-01-1980 00:00   res/drawable/readium_media_notification_fastforward.xml
+     2416  02-01-1980 00:00   res/drawable/readium_media_notification_rewind.xml
+        0  02-01-1980 00:00   res/layout/
+     2186  02-01-1980 00:00   res/layout/readium_navigator_fragment_fxllayout_double.xml
+     1757  02-01-1980 00:00   res/layout/readium_navigator_fragment_fxllayout_single.xml
+      937  02-01-1980 00:00   res/layout/readium_navigator_viewpager.xml
+     1035  02-01-1980 00:00   res/layout/readium_navigator_viewpager_fragment_cbz.xml
+      708  02-01-1980 00:00   res/layout/readium_navigator_viewpager_fragment_epub.xml
+        0  02-01-1980 00:00   res/values/
+      371  02-01-1980 00:00   res/values/values.xml
+        0  02-01-1980 00:00   res/values-land/
+      134  02-01-1980 00:00   res/values-land/values-land.xml
+        0  02-01-1980 00:00   libs/
+    28195  02-01-1980 00:00   libs/PhotoView-2.3.0.jar
+        0  02-01-1980 00:00   assets/
+        0  02-01-1980 00:00   assets/readium/
+      693  02-01-1980 00:00   assets/readium/error.xhtml
+        0  02-01-1980 00:00   assets/readium/divina/
+      604  02-01-1980 00:00   assets/readium/divina/divinaPlayer.html
+   424586  02-01-1980 00:00   assets/readium/divina/divinaPlayer.js
+     2260  02-01-1980 00:00   assets/readium/divina/divinaTouchHandling.js
+        0  02-01-1980 00:00   assets/readium/fonts/
+
+exec
+/bin/zsh -lc 'JAR="$HOME/.gradle/caches/8.14.4/transforms/20a535398e2b06999431a36d9970924d/transformed/readium-navigator-3.3.0-api.jar"; javap -classpath "$JAR" -public org.readium.r2.navigator.epub.EpubNavigatorFragment | rg -n "evaluateJavascript|currentLocator|firstVisibleElementLocator|submitPreferences|public class|public final"
+JAR="$HOME/.gradle/caches/8.14.4/transforms/87fd454872d62994fa2f156d672a8156/transformed/readium-navigator-3.3.0-runtime.jar"; javap -classpath "$JAR" -public org.readium.r2.navigator.epub.EpubNavigatorFragment | rg -n "evaluateJavascript|currentLocator|firstVisibleElementLocator|submitPreferences|public class|public final"' in /Users/ll/workspace/vreader
+ exited 1 in 0ms:
+The operation couldn’t be completed. Unable to locate a Java Runtime.
+Please visit http://www.java.com for information on installing Java.
+
+The operation couldn’t be completed. Unable to locate a Java Runtime.
+Please visit http://www.java.com for information on installing Java.
+
+
+exec
+/bin/zsh -lc 'find /Applications "$HOME/Library" -path '"'*/bin/javap' -type f 2>/dev/null | head -20" in /Users/ll/workspace/vreader
+codex
+The exact Readium AAR and Gradle-transformed API/runtime JARs are present locally at version 3.3.0. The system `javap` lacks a configured Java runtime, so I’m locating the Android Studio JBR toolchain to independently inspect the public bytecode signature.
+ succeeded in 18110ms:
+exec
+/bin/zsh -lc "ls -l '/Applications/Android Studio.app/Contents/jbr/Contents/Home/bin/javap' '/Applications/Android Studio.app/Contents/jbr/bin/javap' 2>/dev/null || true
+rg -a -n \"evaluateJavascript|firstVisibleElementLocator|getCurrentLocator\" \""'$HOME/.gradle/caches/8.14.4/transforms/20a535398e2b06999431a36d9970924d/transformed/readium-navigator-3.3.0-api.jar" | head -30' in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+661:SourceFile RuntimeVisibleAnnotations            9   K     +	� ,� �    :      8 ;                         <                9   ;     +� �    :      D ;                  <       	    9   E     *+,� �    :      3 ;                        	   !  9   :     *+� #�    :      3 ;                   =      3 4	 6  7  >    8 ?   O  $  %[ I &I 'I ( )I * +I , -[ s . /[ s s 0s s 0s s s s s s s s 1PK      !!J{X|  |  (   org/readium/r2/navigator/Navigator.class����   7 A "org/readium/r2/navigator/Navigator  java/lang/Object  getCurrentLocator %()Lkotlinx/coroutines/flow/StateFlow; R()Lkotlinx/coroutines/flow/StateFlow<Lorg/readium/r2/shared/publication/Locator;>; #Lorg/jetbrains/annotations/NotNull; go /(Lorg/readium/r2/shared/publication/Locator;Z)Z 
+733:  	   goBackward$default  	   firstVisibleElementLocator d(Lorg/readium/r2/navigator/OverflowableNavigator;Lkotlin/coroutines/Continuation;)Ljava/lang/Object; �(Lorg/readium/r2/navigator/OverflowableNavigator;Lkotlin/coroutines/Continuation<-Lorg/readium/r2/shared/publication/Locator;>;)Ljava/lang/Object; Ljava/lang/Deprecated; $Lorg/jetbrains/annotations/Nullable; #Lorg/jetbrains/annotations/NotNull; $access$firstVisibleElementLocator$jd     $this 0Lorg/readium/r2/navigator/OverflowableNavigator; $completion  Lkotlin/coroutines/Continuation; Lkotlin/Metadata; mv           k xi   0 DefaultImpls VisualNavigator.kt Code 
+766:goBackward goBackward$default USuper calls with default arguments not supported in this target, function: goBackward      $access$firstVisibleElementLocator$jd d(Lorg/readium/r2/navigator/OverflowableNavigator;Lkotlin/coroutines/Continuation;)Ljava/lang/Object; firstVisibleElementLocator 4(Lkotlin/coroutines/Continuation;)Ljava/lang/Object; ! "  # $this 0Lorg/readium/r2/navigator/OverflowableNavigator; $completion  Lkotlin/coroutines/Continuation; .Lorg/readium/r2/shared/ExperimentalReadiumApi; Lkotlin/Metadata; mv           k    xi   0 d1 ���
+1629: onReceiveValue @(Lkotlin/jvm/functions/Function1;)Landroid/webkit/ValueCallback; 	 evaluateJavascript 3(Ljava/lang/String;Landroid/webkit/ValueCallback;)V
+2458:s s s es s s s s #s $s %s &s 's (s )s *s +s ,s Rs Us es Bs es 4s es f k     W   t     >  7PK      !!����  �  ;   org/readium/r2/navigator/VisualNavigator$DefaultImpls.class����   7 ) 5org/readium/r2/navigator/VisualNavigator$DefaultImpls  java/lang/Object  firstVisibleElementLocator ^(Lorg/readium/r2/navigator/VisualNavigator;Lkotlin/coroutines/Continuation;)Ljava/lang/Object; �(Lorg/readium/r2/navigator/VisualNavigator;Lkotlin/coroutines/Continuation<-Lorg/readium/r2/shared/publication/Locator;>;)Ljava/lang/Object; Ljava/lang/Deprecated; .Lorg/readium/r2/shared/ExperimentalReadiumApi; $Lorg/jetbrains/annotations/Nullable; #Lorg/jetbrains/annotations/NotNull; (org/readium/r2/navigator/VisualNavigator  $access$firstVisibleElementLocator$jd     $this *Lorg/readium/r2/navigator/VisualNavigator; $completion  Lkotlin/coroutines/Continuation; Lkotlin/Metadata; mv           k xi   0 DefaultImpls VisualNavigator.kt Code LineNumberTable LocalVariableTable 	Signature 
+2488:s s PK      !!|B��	  �	  .   org/readium/r2/navigator/VisualNavigator.class����   7 P (org/readium/r2/navigator/VisualNavigator  java/lang/Object  "org/readium/r2/navigator/Navigator  getPublicationView ()Landroid/view/View; #Lorg/jetbrains/annotations/NotNull; firstVisibleElementLocator 4(Lkotlin/coroutines/Continuation;)Ljava/lang/Object; b(Lkotlin/coroutines/Continuation<-Lorg/readium/r2/shared/publication/Locator;>;)Ljava/lang/Object; .Lorg/readium/r2/shared/ExperimentalReadiumApi; $Lorg/jetbrains/annotations/Nullable; &firstVisibleElementLocator$suspendImpl ^(Lorg/readium/r2/navigator/VisualNavigator;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;     this *Lorg/readium/r2/navigator/VisualNavigator; $completion  Lkotlin/coroutines/Continuation; �(Lorg/readium/r2/navigator/VisualNavigator;Lkotlin/coroutines/Continuation<-Lorg/readium/r2/shared/publication/Locator;>;)Ljava/lang/Object; getCurrentLocator %()Lkotlinx/coroutines/flow/StateFlow;     !kotlinx/coroutines/flow/StateFlow  getValue ()Ljava/lang/Object;      $this addInputListener 1(Lorg/readium/r2/navigator/input/InputListener;)V removeInputListener $access$firstVisibleElementLocator$jd 
+3455:[ I  [ I  [ I  [ s  [ s  s  s  I  ;  <[ I I =I  >I = ?I @PK      !!�j0�  �  N   org/readium/r2/navigator/epub/EpubNavigatorFragment$evaluateJavascript$1.class����   7 N Horg/readium/r2/navigator/epub/EpubNavigatorFragment$evaluateJavascript$1  /kotlin/coroutines/jvm/internal/ContinuationImpl  L$0 Ljava/lang/Object; L$1 .Lkotlin/coroutines/jvm/internal/DebugMetadata; f EpubNavigatorFragment.kt l  .  / nl���� i        s n script page m evaluateJavascript c 3org.readium.r2.navigator.epub.EpubNavigatorFragment v    <init> X(Lorg/readium/r2/navigator/epub/EpubNavigatorFragment;Lkotlin/coroutines/Continuation;)V �(Lorg/readium/r2/navigator/epub/EpubNavigatorFragment;Lkotlin/coroutines/Continuation<-Lorg/readium/r2/navigator/epub/EpubNavigatorFragment$evaluateJavascript$1;>;)V this$0 5Lorg/readium/r2/navigator/epub/EpubNavigatorFragment;   !	  " #(Lkotlin/coroutines/Continuation;)V  $
+3456:  % this JLorg/readium/r2/navigator/epub/EpubNavigatorFragment$evaluateJavascript$1; $completion  Lkotlin/coroutines/Continuation; invokeSuspend &(Ljava/lang/Object;)Ljava/lang/Object; $Lorg/jetbrains/annotations/Nullable; #Lorg/jetbrains/annotations/NotNull; result / 	  0 label I 2 3	  4�    kotlin/coroutines/Continuation 7 3org/readium/r2/navigator/epub/EpubNavigatorFragment 9 F(Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;  ;
+3461: [ I I  [ I I  [ I I I I  [ s s s s  [ s s s s  s  s  I  ?  @[ I I AI  BI A CI DPK      !!�C\`  `  V   org/readium/r2/navigator/epub/EpubNavigatorFragment$firstVisibleElementLocator$1.class����   7 J Porg/readium/r2/navigator/epub/EpubNavigatorFragment$firstVisibleElementLocator$1  /kotlin/coroutines/jvm/internal/ContinuationImpl  L$0 Ljava/lang/Object; .Lkotlin/coroutines/jvm/internal/DebugMetadata; f EpubNavigatorFragment.kt l  � nl  � i     s n resource m firstVisibleElementLocator c 3org.readium.r2.navigator.epub.EpubNavigatorFragment v    <init> X(Lorg/readium/r2/navigator/epub/EpubNavigatorFragment;Lkotlin/coroutines/Continuation;)V �(Lorg/readium/r2/navigator/epub/EpubNavigatorFragment;Lkotlin/coroutines/Continuation<-Lorg/readium/r2/navigator/epub/EpubNavigatorFragment$firstVisibleElementLocator$1;>;)V this$0 5Lorg/readium/r2/navigator/epub/EpubNavigatorFragment;  	   #(Lkotlin/coroutines/Continuation;)V   
+3462:  ! this RLorg/readium/r2/navigator/epub/EpubNavigatorFragment$firstVisibleElementLocator$1; $completion  Lkotlin/coroutines/Continuation; invokeSuspend &(Ljava/lang/Object;)Ljava/lang/Object; $Lorg/jetbrains/annotations/Nullable; #Lorg/jetbrains/annotations/NotNull; result + 	  , label I . /	  0�    kotlin/coroutines/Continuation 3 3org/readium/r2/navigator/epub/EpubNavigatorFragment 5 4(Lkotlin/coroutines/Continuation;)Ljava/lang/Object;  7
+3951: �a evaluateJavascript F(Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object; [(Ljava/lang/String;Lkotlin/coroutines/Continuation<-Ljava/lang/String;>;)Ljava/lang/Object; Horg/readium/r2/navigator/epub/EpubNavigatorFragment$evaluateJavascript$1f labelh/	gi�    X(Lorg/readium/r2/navigator/epub/EpubNavigatorFragment;Lkotlin/coroutines/Continuation;)V l
+4032: c event <Lorg/readium/r2/navigator/epub/EpubNavigatorViewModel$Event; :org/readium/r2/navigator/epub/EpubNavigatorViewModel$Eventg getCurrentLocatoriT
+4116:; ;$i$a$-forEach-EpubNavigatorFragment$loadedFragmentForHref$1 pageFragment R()Lkotlinx/coroutines/flow/StateFlow<Lorg/readium/r2/shared/publication/Locator;>; firstVisibleElementLocator b(Lkotlin/coroutines/Continuation<-Lorg/readium/r2/shared/publication/Locator;>;)Ljava/lang/Object; .Lorg/readium/r2/shared/ExperimentalReadiumApi; Porg/readium/r2/navigator/epub/EpubNavigatorFragment$firstVisibleElementLocator$1C	Di
+11599: � � getAdapter$readium_navigator 1()Lorg/readium/r2/navigator/pager/R2PagerAdapter; adapter /Lorg/readium/r2/navigator/pager/R2PagerAdapter; � �	  � � -org/readium/r2/navigator/pager/R2PagerAdapter � setAdapter$readium_navigator 2(Lorg/readium/r2/navigator/pager/R2PagerAdapter;)V getCurrentLocator %()Lkotlinx/coroutines/flow/StateFlow; R()Lkotlinx/coroutines/flow/StateFlow<Lorg/readium/r2/shared/publication/Locator;>; !kotlinx/coroutines/flow/StateFlow � getResources$readium_navigator &()Ljava/util/List<Ljava/lang/String;>; setResources$readium_navigator '(Ljava/util/List<Ljava/lang/String;>;)V 
+11652:  firstVisibleElementLocator 4(Lkotlin/coroutines/Continuation;)Ljava/lang/Object; b(Lkotlin/coroutines/Continuation<-Lorg/readium/r2/shared/publication/Locator;>;)Ljava/lang/Object;  $completion  Lkotlin/coroutines/Continuation; onCreate$lambda$0$0 H(Lorg/readium/r2/navigator/image/ImageNavigatorFragment;FF)Lkotlin/Unit; 'org/readium/r2/navigator/input/TapEvent$ android/graphics/PointF& (FF)V (
+13708: cd� onReceiveValue X(Landroid/webkit/WebView;Lkotlin/jvm/functions/Function0;)Landroid/webkit/ValueCallback;gh i android/webkit/WebViewk evaluateJavascript 3(Ljava/lang/String;Landroid/webkit/ValueCallback;)Vmn
+15440: �� getCurrentLocator R()Lkotlinx/coroutines/flow/StateFlow<Lorg/readium/r2/shared/publication/Locator;>;��
+15459: u firstVisibleElementLocator 4(Lkotlin/coroutines/Continuation;)Ljava/lang/Object; b(Lkotlin/coroutines/Continuation<-Lorg/readium/r2/shared/publication/Locator;>;)Ljava/lang/Object;  $completion  Lkotlin/coroutines/Continuation; >Lorg/readium/r2/navigator/pdf/PdfNavigatorViewModel$Companion; e	 � requireActivity *()Landroidx/fragment/app/FragmentActivity;
+15766:  b 	_settings d S	  e settings g ]	  h this 4Lorg/readium/r2/navigator/pdf/PdfNavigatorViewModel; Landroid/app/Application; initialLocations 5Lorg/readium/r2/shared/publication/Locator$Locations; ?Lorg/readium/r2/navigator/preferences/Configurable$Preferences; android/app/Application p =org/readium/r2/navigator/preferences/Configurable$Preferences r .org/readium/r2/navigator/pdf/PdfEngineProvider t getCurrentLocator %()Lkotlinx/coroutines/flow/StateFlow; R()Lkotlinx/coroutines/flow/StateFlow<Lorg/readium/r2/shared/publication/Locator;>; getSettings *()Lkotlinx/coroutines/flow/StateFlow<TS;>; submitPreferences Y(Lorg/readium/r2/navigator/preferences/Configurable$Preferences;)Lkotlinx/coroutines/Job; (TP;)Lkotlinx/coroutines/Job; preferences ~ androidx/lifecycle/ViewModel � androidx/lifecycle/ViewModelKt � getViewModelScope C(Landroidx/lifecycle/ViewModel;)Lkotlinx/coroutines/CoroutineScope; � �
+18327:�  �  L           ��� org/readium/r2/navigator/epub/EpubNavigatorFragment$applyDecorations$1.classPK       !!�V)�8  8  L           ��� org/readium/r2/navigator/epub/EpubNavigatorFragment$currentSelection$1.classPK       !!�j0�  �  N           ��k' org/readium/r2/navigator/epub/EpubNavigatorFragment$evaluateJavascript$1.classPK       !!�C\`  `  V           ��h/ org/readium/r2/navigator/epub/EpubNavigatorFragment$firstVisibleElementLocator$1.classPK       !!�7��D)  D)  Q           ��<7 org/readium/r2/navigator/epub/EpubNavigatorFragment$notifyCurrentLocation$1.classPK       !!?g~��	  �	  M           ���` org/readium/r2/navigator/epub/EpubNavigatorFragment$onViewCreated$1$1$1.classPK       !!�xvK�  �  M           ��#k org/readium/r2/navigator/epub/EpubNavigatorFragment$onViewCreated$1$1$2.classPK       !!m�S��  �  K           ��`{ org/readium/r2/navigator/epub/EpubNavigatorFragment$onViewCreated$1$1.classPK       !!�<��  �  I           ���� org/readium/r2/navigator/epub/EpubNavigatorFragment$onViewCreated$1.classPK       !!f��=�  �  n           ���� org/readium/r2/navigator/epub/EpubNavigatorFragment$onViewCreated$2$invokeSuspend$$inlined$withStarted$1.classPK       !!Xj[��  �  I           ��� org/readium/r2/navigator/epub/EpubNavigatorFragment$onViewCreated$2.classPK       !!�J��d  d  S           ��,� org/readium/r2/navigator/epub/EpubNavigatorFragment$positionsByReadingOrder$1.classPK       !!����	  �	  _           ��� org/readium/r2/navigator/epub/EpubNavigatorFragment$special$$inlined$viewModels$default$1.classPK       !!P�5S
+
+exec
+/bin/zsh -lc "nl -ba android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt | sed -n '1,150p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/search/TxtMdTextExtractor.kt | sed -n '1,180p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/search/BookTextExtractor.kt | sed -n '1,100p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt | sed -n '1,80p'
+nl -ba android/identity/src/main/kotlin/vreader/contracts/backup/BackupSectionsExtended.kt | sed -n '55,78p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+     1	// Purpose: Addressable, range-based model of a decoded .txt — feature #111 WI-1.
+     2	// Holds ONE backing decoded String and an array of chunk START offsets (UTF-16 code
+     3	// units against the RAW text — NO line-ending normalization, so charOffsetUTF16 stays
+     4	// exact for resume). Splits at line boundaries (CRLF/CR/LF kept inside the chunk);
+     5	// hard-splits a runaway line at maxChunkChars (never mid-surrogate-pair). Visible
+     6	// chunk text is materialized on demand (no per-chunk substrings retained). Pure JVM.
+     7	package com.vreader.app.reader
+     8	
+     9	class TxtDocument private constructor(
+    10	    val text: String,
+    11	    private val starts: IntArray,
+    12	) {
+    13	    /** Number of chunks (0 for empty text). */
+    14	    val chunkCount: Int get() = starts.size
+    15	
+    16	    /** The UTF-16 start offset of chunk [index] (clamped to a valid chunk). */
+    17	    fun offsetForChunk(index: Int): Int {
+    18	        if (starts.isEmpty()) return 0
+    19	        return starts[index.coerceIn(0, starts.size - 1)]
+    20	    }
+    21	
+    22	    /** The chunk index containing [offsetUtf16] (EOF-clamped); 0 for empty text. */
+    23	    fun chunkForOffset(offsetUtf16: Int): Int {
+    24	        if (starts.isEmpty()) return 0
+    25	        val offset = offsetUtf16.coerceIn(0, text.length)
+    26	        // Largest start <= offset (binary search).
+    27	        var lo = 0; var hi = starts.size - 1; var ans = 0
+    28	        while (lo <= hi) {
+    29	            val mid = (lo + hi) ushr 1
+    30	            if (starts[mid] <= offset) { ans = mid; lo = mid + 1 } else { hi = mid - 1 }
+    31	        }
+    32	        return ans
+    33	    }
+    34	
+    35	    /** The text of chunk [index], materialized on demand from the backing string. */
+    36	    fun textForChunk(index: Int): CharSequence {
+    37	        if (starts.isEmpty()) return ""
+    38	        val i = index.coerceIn(0, starts.size - 1)
+    39	        val end = if (i + 1 < starts.size) starts[i + 1] else text.length
+    40	        return text.subSequence(starts[i], end)
+    41	    }
+    42	
+    43	    companion object {
+    44	        const val DEFAULT_MAX_CHUNK_CHARS = 4000
+    45	
+    46	        /**
+    47	         * Build a document from already-decoded [text]. Chunk boundaries fall after a
+    48	         * line terminator (`\n`, `\r`, or `\r\n` — preserved in the chunk); a line longer
+    49	         * than [maxChunkChars] is hard-split, but never between a surrogate pair.
+    50	         */
+    51	        fun of(text: String, maxChunkChars: Int = DEFAULT_MAX_CHUNK_CHARS): TxtDocument {
+    52	            if (text.isEmpty()) return TxtDocument(text, IntArray(0))
+    53	            // Primitive growable IntArray (no Int boxing) — a newline-dense 14MB file
+    54	            // would otherwise spike tens of MB of boxed Integers + a duplicating copy.
+    55	            var starts = IntArray(64)
+    56	            var count = 0
+    57	            fun push(v: Int) {
+    58	                if (count == starts.size) starts = starts.copyOf(starts.size * 2)
+    59	                starts[count++] = v
+    60	            }
+    61	            push(0)
+    62	            var i = 0
+    63	            var chunkStart = 0
+    64	            val n = text.length
+    65	            while (i < n) {
+    66	                val c = text[i]
+    67	                when {
+    68	                    c == '\n' -> {
+    69	                        i++
+    70	                        if (i < n) { push(i); chunkStart = i }
+    71	                    }
+    72	                    c == '\r' -> {
+    73	                        i++
+    74	                        if (i < n && text[i] == '\n') i++   // CRLF stays one terminator
+    75	                        if (i < n) { push(i); chunkStart = i }
+    76	                    }
+    77	                    else -> {
+    78	                        i++
+    79	                        // Hard-split a runaway line, but not mid-surrogate-pair (don't
+    80	                        // split right after a high surrogate — its low half follows at i).
+    81	                        if (i - chunkStart >= maxChunkChars && i < n && !text[i - 1].isHighSurrogate()) {
+    82	                            push(i); chunkStart = i
+    83	                        }
+    84	                    }
+    85	                }
+    86	            }
+    87	            return TxtDocument(text, starts.copyOf(count))
+    88	        }
+    89	    }
+    90	}
+     1	// Purpose: Extract TXT/MD text for the library search index, streaming each TxtDocument chunk to the
+     2	// SectionSink — feature #128 WI-3. Serves both `txt` and `md` (raw markdown text; marker-stripping is
+     3	// a nice-to-have deferred). Reuses the shipped reader decode/chunk path (TxtDecoder + TxtDocument).
+     4	//
+     5	// Memory note (Gate-2 round-3 HIGH): this path holds the whole decoded book String (via
+     6	// TxtDecoder/TxtDocument) — O(book-size), the ACCEPTED EXISTING reader bound (indexing loads exactly
+     7	// what the TXT/MD reader already loads to display the book). It is NOT O(batch). The sink still emits
+     8	// chunks incrementally so the DB-write side stays batched.
+     9	package com.vreader.app.search
+    10	
+    11	import com.vreader.app.data.Book
+    12	import com.vreader.app.reader.TxtDecoder
+    13	import com.vreader.app.reader.TxtDocument
+    14	import kotlinx.coroutines.CancellationException
+    15	import java.io.File
+    16	
+    17	/** Streams a TXT/MD book's TxtDocument chunks to a [SectionSink]; author is always null on Success. */
+    18	class TxtMdTextExtractor : BookTextExtractor {
+    19	
+    20	    override suspend fun extract(book: Book, sink: SectionSink): ExtractResult {
+    21	        val path = book.localFilePath ?: return ExtractResult.Unsupported
+    22	        val file = File(path)
+    23	        if (!file.exists()) return ExtractResult.Failed("file not found: $path")
+    24	        return try {
+    25	            val decoded = TxtDecoder.decode(file)
+    26	            val document = TxtDocument.of(decoded.text)
+    27	            // Emit one section per chunk; sectionIndex == chunkOrdinal == chunk index (TXT has no
+    28	            // sub-resource grouping). Empty text → chunkCount 0 → zero emissions (still Success).
+    29	            for (i in 0 until document.chunkCount) {
+    30	                sink.emit(
+    31	                    BookTextSection(
+    32	                        sectionIndex = i,
+    33	                        chunkOrdinal = i,
+    34	                        title = null,
+    35	                        text = document.textForChunk(i).toString(),
+    36	                    ),
+    37	                )
+    38	            }
+    39	            ExtractResult.Success(null)
+    40	        } catch (e: CancellationException) {
+    41	            throw e   // never swallow structured cancellation as a per-book failure
+    42	        } catch (e: Exception) {
+    43	            ExtractResult.Failed(e.message ?: e.javaClass.simpleName)
+    44	        }
+    45	    }
+    46	}
+     1	// Purpose: The book text-extraction seam for library search indexing — feature #128 WI-3.
+     2	// Extraction STREAMS each finished section to a SectionSink (never returns a materialized List), so
+     3	// EPUB extraction is bounded-memory (O(batch)): the coordinator's sink flushes batches to the
+     4	// staging table and drops them, keeping at most one batch resident. The whole-book author is the one
+     5	// datum that cannot stream (book-level metadata read up front), so it rides on Success. A typed
+     6	// Unsupported / Failed result (not an exception or an empty stream) lets the coordinator record the
+     7	// right search_index_state.status (WI-5).
+     8	package com.vreader.app.search
+     9	
+    10	import com.vreader.app.data.Book
+    11	
+    12	/** One extracted, chunk-sized section streamed to a [SectionSink]. */
+    13	data class BookTextSection(
+    14	    /** Per-book reading-order/section index — chapter attribution + first-hit tie-break. */
+    15	    val sectionIndex: Int,
+    16	    /** UNIQUE monotonic ordinal within a book (a running per-chunk counter) — deterministic first hit. */
+    17	    val chunkOrdinal: Int,
+    18	    /** Chapter label for the snippet attribution; null for TXT/MD (and no-TOC EPUB sections). */
+    19	    val title: String?,
+    20	    /** RAW display text of this chunk (the snippet source). */
+    21	    val text: String,
+    22	)
+    23	
+    24	/**
+    25	 * The streaming sink the extractor emits each finished section to. The coordinator's implementation
+    26	 * writes to the staging table in batches; tests use a collecting fake.
+    27	 */
+    28	interface SectionSink {
+    29	    /** Emit one finished section. The sink may buffer into a batch. */
+    30	    suspend fun emit(section: BookTextSection)
+    31	
+    32	    /**
+    33	     * Flush any buffered-but-unwritten sections. The coordinator calls this exactly once after
+    34	     * `extract()` returns [ExtractResult.Success] and BEFORE publish, so a book with fewer sections
+    35	     * than one batch (or a non-multiple tail) still persists every section.
+    36	     */
+    37	    suspend fun flushRemaining()
+    38	}
+    39	
+    40	/** The typed outcome of an extract — distinguishes streamed success, unsupported, and failure. */
+    41	sealed interface ExtractResult {
+    42	    /** All sections were streamed to the sink; [author] is the only whole-book datum (for backfill). */
+    43	    data class Success(val author: String?) : ExtractResult
+    44	
+    45	    /** No text is extractable (e.g. EPUB with no content service, no local file). Metadata-only book. */
+    46	    data object Unsupported : ExtractResult
+    47	
+    48	    /** A transient/retryable failure ([reason] for logging); the coordinator records a `failed` state. */
+    49	    data class Failed(val reason: String) : ExtractResult
+    50	}
+    51	
+    52	/** Extracts a book's text, streaming each section to a [SectionSink]. NEVER accumulates the whole book. */
+    53	interface BookTextExtractor {
+    54	    /**
+    55	     * Streams each finished section to [sink] as it is produced. Returns [ExtractResult.Success] after
+    56	     * the last section, or [ExtractResult.Unsupported] / [ExtractResult.Failed] without emitting.
+    57	     */
+    58	    suspend fun extract(book: Book, sink: SectionSink): ExtractResult
+    59	}
+     1	// Purpose: feature #118 WI-2 (#110 Phase 3) — the AI client value types + typed errors, mirroring
+     2	// iOS AITypes (AIRequest/AIResponse/AIStreamChunk/AIError). Provider-neutral; the OpenAI vs
+     3	// Anthropic wire differences live in the providers.
+     4	package com.vreader.app.ai
+     5	
+     6	enum class AiRole { system, user, assistant }
+     7	
+     8	data class AiMessage(val role: AiRole, val content: String)
+     9	
+    10	/** A chat request. `system` is the system prompt (Anthropic carries it top-level; the OpenAI
+    11	 *  provider prepends it as a system message). */
+    12	data class AiRequest(
+    13	    val model: String,
+    14	    val messages: List<AiMessage>,
+    15	    val temperature: Double,
+    16	    val maxTokens: Int,
+    17	    val system: String? = null,
+    18	)
+    19	
+    20	/** One streamed delta (the incremental assistant text). */
+    21	data class AiChunk(val deltaText: String)
+    22	
+    23	/** A one-shot (non-streamed) response. */
+    24	data class AiResponse(val text: String)
+    25	
+    26	/** Typed AI failures (HTTP + transport + protocol). */
+    27	sealed class AiError(message: String) : Exception(message) {
+    28	    object Auth401 : AiError("authentication failed (401) — check the API key")
+    29	    object RateLimited429 : AiError("rate limited (429) — try again shortly")
+    30	    object Offline : AiError("the provider couldn't be reached")
+    31	    object Timeout : AiError("the provider took too long to respond")
+    32	    class Http(val code: Int) : AiError("HTTP $code from the provider")
+    33	    class Decode(detail: String) : AiError("couldn't parse the provider response: $detail")
+    34	    class Stream(detail: String) : AiError("the stream ended abnormally: $detail")
+    35	    /** Refused to send the API key over cleartext http:// to a non-local host. */
+    36	    object InsecureUrl : AiError("the provider URL must be https:// (won't send the key over cleartext)")
+    37	    class Config(detail: String) : AiError("provider misconfigured: $detail")
+    38	}
+    39	
+    40	/** Test-connection outcome (the editor's Connection section). */
+    41	sealed interface AiTestResult {
+    42	    object Ok : AiTestResult
+    43	    data class Fail(val error: AiError, val message: String) : AiTestResult
+    44	}
+    55	data class BackupPerBookSettingsEntry(
+    56	    val bookFingerprintKey: String,
+    57	    val override: PerBookSettingsOverride,
+    58	)
+    59	
+    60	/** Per-book reader overrides — mirrors Swift `PerBookSettingsOverride` (CGFloat ⇒ Double).
+    61	 *  All fields optional; a nil inherits the global default. */
+    62	@Serializable
+    63	data class PerBookSettingsOverride(
+    64	    val fontSize: Double? = null,
+    65	    val fontName: String? = null,
+    66	    val lineSpacing: Double? = null,
+    67	    val letterSpacing: Double? = null,
+    68	    val themeName: String? = null,
+    69	    val bilingualEnabled: Boolean? = null,
+    70	    val bilingualTargetLanguage: String? = null,
+    71	    val bilingualGranularity: String? = null,
+    72	    val metricsReadout: String? = null,
+    73	)
+    74	
+    75	// MARK: - Replacement Rules
+    76	
+    77	@Serializable
+    78	data class BackupReplacementRulesEnvelope(
+
+exec
+/bin/zsh -lc "nl -ba vreader/Services/AI/ChapterTranslationService.swift | sed -n '110,280p'
+nl -ba vreader/Views/Reader/Bilingual/BilingualPageContent.swift 2>/dev/null | sed -n '1,220p'
+rg -n \"translatedParagraphs|translation ==|source-only|original-always|translations\\[|zip\\(\" vreader/Views/Reader/Bilingual vreader/Services/AI | head -160
+nl -ba vreader/Services/AI/ChapterTranslationStore.swift | sed -n '1,180p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+   110	    /// Bug #342: profile-agnostic — the canonical row is shared across provider
+   111	    /// profiles, so no profile is needed for a read at all.
+   112	    /// Bug #343 `acceptCountMismatch`: self-healing consumers (the EPUB hosts
+   113	    /// with the divergence fallback) may opt in to receive a fresh row whose
+   114	    /// stored count differs from the live re-derived segmenter count — the
+   115	    /// row may carry the DOM-enumerate contract (written by the divergence
+   116	    /// fallback), which pairs 1:1 at inject time; on a true source change the
+   117	    /// fallback re-translates and replaces the row. Default-off callers keep
+   118	    /// the strict staleness guard.
+   119	    func cachedTranslation(
+   120	        bookFingerprintKey: String,
+   121	        unit: TranslationUnitID,
+   122	        sourceText: String,
+   123	        targetLanguage: String,
+   124	        granularity: TranslationGranularity = .paragraph,
+   125	        acceptCountMismatch: Bool = false
+   126	    ) async -> ChapterTranslationResult? {
+   127	        let lookupKey = ChapterTranslationRecord.lookupKey(
+   128	            bookFingerprintKey: bookFingerprintKey,
+   129	            unitStorageKey: unit.storageKey,
+   130	            targetLanguage: targetLanguage,
+   131	            promptVersion: promptVersion)
+   132	        let segments: [String]
+   133	        switch granularity {
+   134	        case .paragraph: segments = ChapterSegmenter.paragraphs(in: sourceText)
+   135	        case .sentence:  segments = ChapterSegmenter.sentences(in: sourceText)
+   136	        }
+   137	        guard let cached = await store.translation(forKey: lookupKey) else { return nil }
+   138	        guard cached.sourceParagraphCount == segments.count || acceptCountMismatch else {
+   139	            return nil
+   140	        }
+   141	        return ChapterTranslationResult(segments: cached.translatedSegments, fromCache: true)
+   142	    }
+   143	
+   144	    /// Bug #343: the divergence-fallback restore — serves the canonical row
+   145	    /// only when its STORED count matches the caller's own structure (the DOM
+   146	    /// enumerate's block count), so blocks↔segments pair 1:1 by contract.
+   147	    /// Needs no provider config and no source text.
+   148	    func cachedTranslation(
+   149	        bookFingerprintKey: String,
+   150	        unit: TranslationUnitID,
+   151	        expectedSegmentCount: Int,
+   152	        targetLanguage: String
+   153	    ) async -> ChapterTranslationResult? {
+   154	        let lookupKey = ChapterTranslationRecord.lookupKey(
+   155	            bookFingerprintKey: bookFingerprintKey,
+   156	            unitStorageKey: unit.storageKey,
+   157	            targetLanguage: targetLanguage,
+   158	            promptVersion: promptVersion)
+   159	        guard let cached = await store.translation(forKey: lookupKey),
+   160	              cached.sourceParagraphCount == expectedSegmentCount else { return nil }
+   161	        return ChapterTranslationResult(segments: cached.translatedSegments, fromCache: true)
+   162	    }
+   163	
+   164	    /// Translates `unit`'s source text into `targetLanguage`. Serves from the
+   165	    /// disk cache on a hit; on a miss segments → chunks → requests → decodes →
+   166	    /// caches. Throws `ChapterTranslationError` on a provider failure or
+   167	    /// cancellation.
+   168	    func translate(
+   169	        bookFingerprintKey: String,
+   170	        unit: TranslationUnitID,
+   171	        sourceText: String,
+   172	        targetLanguage: String,
+   173	        providerProfileID: UUID,
+   174	        config: ResolvedAIProviderConfig,
+   175	        style: TranslationStyle,
+   176	        granularity: TranslationGranularity = .paragraph,
+   177	        // Bug #341: when true, the cache READ is skipped — a fresh cached row
+   178	        // must not short-circuit an explicit re-translate into a stale no-op.
+   179	        // The cache WRITE still runs: the upsert replaces the row by lookupKey
+   180	        // in place, which is the atomic swap (the old translation survives
+   181	        // until the new one durably lands; a failure leaves it untouched).
+   182	        bypassCacheRead: Bool = false,
+   183	        // Bug #311: optional real progress source. Fired after each chunk
+   184	        // completes with `(completedChunks, totalChunks)` so a caller (the
+   185	        // re-translate VM) can drive an honest N-of-M progress bar instead of
+   186	        // a faked 0.5 pin during the opaque per-chunk network phase. nil by
+   187	        // default — the whole-book coordinator + bilingual paths don't use it.
+   188	        onChunkProgress: (@Sendable (Int, Int) -> Void)? = nil
+   189	    ) async throws -> ChapterTranslationResult {
+   190	        // Bug #342: the canonical key has no profile component —
+   191	        // `providerProfileID` is written as row provenance metadata only.
+   192	        let lookupKey = ChapterTranslationRecord.lookupKey(
+   193	            bookFingerprintKey: bookFingerprintKey,
+   194	            unitStorageKey: unit.storageKey,
+   195	            targetLanguage: targetLanguage,
+   196	            promptVersion: promptVersion)
+   197	
+   198	        // Segment the source per the requested granularity FIRST — the
+   199	        // segment count is needed to detect a stale cache row.
+   200	        let segments: [String]
+   201	        switch granularity {
+   202	        case .paragraph: segments = ChapterSegmenter.paragraphs(in: sourceText)
+   203	        case .sentence:  segments = ChapterSegmenter.sentences(in: sourceText)
+   204	        }
+   205	
+   206	        // Cache lookup. A row is served only when its `sourceParagraphCount`
+   207	        // still matches the live chapter — a chapter whose source has since
+   208	        // changed (content-replacement rule edit, re-import) produces a
+   209	        // mismatch, which is treated as STALE: the row is dropped and the
+   210	        // chapter re-translated (plan audit-driven addition).
+   211	        if !bypassCacheRead, let cached = await store.translation(forKey: lookupKey) {
+   212	            if cached.sourceParagraphCount == segments.count {
+   213	                return ChapterTranslationResult(
+   214	                    segments: cached.translatedSegments, fromCache: true)
+   215	            }
+   216	            log.info("Stale cache row (count \(cached.sourceParagraphCount) != live \(segments.count)); re-translating")
+   217	            // A delete failure does not block re-translation — the later
+   218	            // upsert refreshes the same lookupKey regardless. Logged so the
+   219	            // swallow is visible (rule 50 §6).
+   220	            do {
+   221	                try await store.deleteTranslation(forKey: lookupKey)
+   222	            } catch {
+   223	                log.error("Stale-row delete failed (upsert will still refresh it): \(String(describing: error), privacy: .public)")
+   224	            }
+   225	        }
+   226	
+   227	        guard !segments.isEmpty else {
+   228	            return ChapterTranslationResult(segments: [], fromCache: false)
+   229	        }
+   230	
+   231	        // Chunk → translate each chunk → recombine in source order.
+   232	        let chunks = ChapterTranslationChunker.chunk(
+   233	            segments: segments, maxCharsPerChunk: maxCharsPerChunk)
+   234	        var translated = [String](repeating: "", count: segments.count)
+   235	
+   236	        // Bug #330: a single chunk's provider failure must NOT abort the whole
+   237	        // chapter — leave that chunk's segments source-only (empty translation)
+   238	        // and continue. But if EVERY chunk fails (a genuine outage, not just one
+   239	        // over-budget chunk), surface the error rather than silently returning an
+   240	        // all-source-only result.
+   241	        var completedChunks = 0
+   242	        var anyChunkSucceeded = false
+   243	        var lastChunkError: Error?
+   244	        for chunk in chunks {
+   245	            do {
+   246	                try Task.checkCancellation()
+   247	            } catch {
+   248	                throw ChapterTranslationError.cancelled
+   249	            }
+   250	            let chunkSegments = chunk.map { segments[$0] }
+   251	            do {
+   252	                let chunkResult = try await translateChunk(
+   253	                    chunkSegments, targetLanguage: targetLanguage, config: config, style: style)
+   254	                for (offset, segmentIndex) in chunk.enumerated() {
+   255	                    translated[segmentIndex] = chunkResult[offset]
+   256	                }
+   257	                anyChunkSucceeded = true
+   258	            } catch is CancellationError {
+   259	                // The between-chunk / per-piece Task.checkCancellation() throws a
+   260	                // raw CancellationError — surface it as the typed .cancelled.
+   261	                throw ChapterTranslationError.cancelled
+   262	            } catch ChapterTranslationError.cancelled {
+   263	                // Bug #330 (Codex): `send()` maps a provider-side cancellation to
+   264	                // the TYPED `.cancelled`. It must NOT be degraded-and-continued —
+   265	                // a cancel aborts the whole translation. Rethrow before the
+   266	                // generic degradation catch below.
+   267	                throw ChapterTranslationError.cancelled
+   268	            } catch {
+   269	                // Bug #330: degrade this chunk to source-only and keep going.
+   270	                log.error("Chunk failed (segments \(chunk) left source-only): \(String(describing: error), privacy: .public)")
+   271	                lastChunkError = error
+   272	            }
+   273	            // Bug #311: real N-of-M progress — fire AFTER the chunk resolves
+   274	            // (success or graceful-degrade) so the count reflects committed work.
+   275	            completedChunks += 1
+   276	            onChunkProgress?(completedChunks, chunks.count)
+   277	        }
+   278	        if !anyChunkSucceeded, let err = lastChunkError {
+   279	            throw err
+   280	        }
+vreader/Services/AI/ChapterPrefetching.swift:67:    /// source-only (never worse than the current behavior).
+vreader/Views/Reader/Bilingual/EPUBBilingualOrchestrator.swift:164:    /// as source-only (silent-source-fallback semantics — plan
+vreader/Views/Reader/Bilingual/EPUBBilingualOrchestrator.swift:252:    /// source-only fallback) — the others still inject. Returns `nil` when no
+vreader/Views/Reader/Bilingual/EPUBBilingualOrchestrator.swift:263:            // empty map for that section → it stays source-only, the rest still
+vreader/Views/Reader/Bilingual/FoliateBilingualOrchestrator.swift:154:    /// as source-only (silent-source-fallback semantics — plan
+vreader/Views/Reader/Bilingual/BilingualSetupSheet+Sections.swift:158:        let sample = Self.translations[resolved.key] ?? Self.translations["Chinese"] ?? ""
+vreader/Views/Reader/Bilingual/BilingualPairing.swift:18:// paints source-only. The primary defense against the mismatch is making the
+vreader/Views/Reader/Bilingual/BilingualPairing.swift:31:    /// empty map (source-only) when there is no cached translation or the
+vreader/Views/Reader/Bilingual/FoliateBilingualPipeline.swift:166:    /// empty map → source-only — fail-safe (never a wrong pairing).
+vreader/Views/Reader/Bilingual/BilingualDisplayPipeline.swift:87:        // surviving a granularity switch) must paint source-only here —
+vreader/Services/AI/ChapterSegmenter.swift:34:        // source-only. Each scan range contains at least one
+vreader/Views/Reader/Bilingual/EPUBBilingualPipeline.swift:175:    /// empty map → the renderer paints source-only. A partial (min-count)
+vreader/Views/Reader/Bilingual/EPUBBilingualPipeline.swift:182:        // Bug #266: pair only on a 1:1 count match (source-only otherwise) via
+vreader/Views/Reader/Bilingual/BilingualTextRenderer.swift:38://   gets injected and the tail paragraphs render source-only (no
+vreader/Views/Reader/Bilingual/BilingualTextRenderer.swift:154:                let translationText = translations[index]
+vreader/Views/Reader/Bilingual/BilingualAttributedStringComposer.swift:113:                let translationText = translations[index]
+vreader/Views/Reader/Bilingual/EPUBBilingualJS.swift:498:                    existing.textContent = translations[bid];
+vreader/Views/Reader/Bilingual/EPUBBilingualJS.swift:501:                var node = makeBlock(translations[bid], block);
+vreader/Services/AI/ChapterTranslationService.swift:237:        // chapter — leave that chunk's segments source-only (empty translation)
+vreader/Services/AI/ChapterTranslationService.swift:240:        // all-source-only result.
+vreader/Services/AI/ChapterTranslationService.swift:269:                // Bug #330: degrade this chunk to source-only and keep going.
+vreader/Services/AI/ChapterTranslationService.swift:270:                log.error("Chunk failed (segments \(chunk) left source-only): \(String(describing: error), privacy: .public)")
+vreader/Services/AI/ChapterTranslationService.swift:288:        // (its segments are source-only ""), caching would make the gap permanent
+vreader/Services/AI/ChapterTranslationService.swift:316:    /// whole-chapter source-only fallback. The returned array is always the same
+vreader/Services/AI/ChapterTranslationService.swift:341:        // failure leaves its segments source-only; an all-chunks failure surfaces
+vreader/Services/AI/ChapterTranslationService.swift:366:                log.error("Pre-segmented chunk failed (segments \(chunk) source-only): \(String(describing: error), privacy: .public)")
+vreader/Services/AI/ChapterTranslationService.swift:493:    /// source-only per edge case (c)) from a generic provider failure.
+vreader/Services/AI/ChapterTranslationService.swift:499:    /// the source-only fallback on a provider/config fault (Gate-4 round-2).
+nl: vreader/Services/AI/ChapterTranslationStore.swift: No such file or directory
+
+exec
+/bin/zsh -lc 'find "$HOME/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-navigator/3.3.0" -type f -maxdepth 2 -print
+find "$HOME/.gradle/caches" -type f -name '"'*readium-navigator*source*.jar' -o -name '*readium-navigator*source*.aar' 2>/dev/null | head -20
+rg -n \"fun evaluateJavascript|suspend fun evaluateJavascript\" \""'$HOME/.gradle/caches" 2>/dev/null | head -20' in /Users/ll/workspace/vreader
+ succeeded in 1514ms:
+exec
+/bin/zsh -lc 'command -v java; command -v javap; /usr/libexec/java_home 2>/dev/null || true; ls -d "$HOME/Library/Java/JavaVirtualMachines"/*/Contents/Home 2>/dev/null || true; ls -d /opt/homebrew/opt/openjdk*/libexec/openjdk.jdk/Contents/Home 2>/dev/null || true; ls -d /Library/Java/JavaVirtualMachines/*/Contents/Home 2>/dev/null || true; ls -d "$HOME/.gradle/jdks"/* 2>/dev/null || true' in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+/usr/bin/java
+/usr/bin/javap
+zsh:1: no matches found: /Users/ll/Library/Java/JavaVirtualMachines/*/Contents/Home
+/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home
+/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home
+/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home
+/opt/homebrew/opt/openjdk@26/libexec/openjdk.jdk/Contents/Home
+zsh:1: no matches found: /Library/Java/JavaVirtualMachines/*/Contents/Home
+zsh:1: no matches found: /Users/ll/.gradle/jdks/*
+
+exec
+/bin/zsh -lc "JAVAP='/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home/bin/javap'; JAR=\""'$HOME/.gradle/caches/8.14.4/transforms/20a535398e2b06999431a36d9970924d/transformed/readium-navigator-3.3.0-api.jar"; "$JAVAP" -classpath "$JAR" -public org.readium.r2.navigator.epub.EpubNavigatorFragment | rg -n "class EpubNavigatorFragment|evaluateJavascript|getCurrentLocator|firstVisibleElementLocator|submitPreferences"' in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+12:  public void submitPreferences(org.readium.r2.navigator.epub.EpubPreferences);
+13:  public final java.lang.Object evaluateJavascript(java.lang.String, kotlin.coroutines.Continuation<? super java.lang.String>);
+41:  public kotlinx.coroutines.flow.StateFlow<org.readium.r2.shared.publication.Locator> getCurrentLocator();
+42:  public java.lang.Object firstVisibleElementLocator(kotlin.coroutines.Continuation<? super org.readium.r2.shared.publication.Locator>);
+43:  public void submitPreferences(org.readium.r2.navigator.preferences.Configurable$Preferences);
+
+exec
+/bin/zsh -lc "awk -F'|' '"'$2 ~ /''^ 13[2345]$/ {print $2 " status=" $6 " notes-prefix=" substr($7,1,240)}'"' docs/features.md
+rg -n \"class KeystoreSecretCipher|fun preferencesDataStore|DataStore<Preferences>|readerSettingsStore\" android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt android/app/src/main/kotlin/com/vreader/app -g '*.kt' | head -120
+sed -n '1,180p' android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+ 132 status= VERIFIED  notes-prefix= (root of box F — no deps; chrome files one-writer-coordinate with #129/#131 via nullable-default params). Plan `dev-docs/plans/20260710-feature-132-android-reader-nav-chrome-toc-bookmarks.md` (Gate-1 v4, ~51 WIs). Design authority (lande
+ 133 status= VERIFIED  notes-prefix= Deps:[feat:#128, feat:#132] (#128 search index MERGED/VERIFIED; #132 reader top-bar Search entry). Plan `dev-docs/plans/20260710-feature-133-android-find-in-book.md` (Gate-1 draft, ~11 WIs). Design authority (landed): vreader-search.jsx 'T
+ 134 status= VERIFIED  notes-prefix= Deps:[feat:#132] (HARD — ReaderTopChrome/ReaderChromeScaffold/ReaderChromeState land in #132; author line soft-deps #128 DONE). Plan `dev-docs/plans/20260710-feature-134-android-more-menu-book-details-share.md` (Gate-1 v3). Design author
+ 135 status= VERIFIED  notes-prefix= Deps:[feat:#132] (#132 wires the annotations.json bookmark backup already; #135 needs no backup change). Plan `dev-docs/plans/20260710-feature-135-android-bookmarks.md` (Gate-1 v2, ~21 WIs). Design authority (landed): vreader-reader.jsx to
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:73:    val readerSettingsStore: com.vreader.app.reader.settings.ReaderSettingsStore by lazy {
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:110:    // device-local DataStore under noBackupFilesDir (the readerSettingsStore precedent — recents are
+android/app/src/main/kotlin/com/vreader/app/opds/OpdsSourceStore.kt:33:    private val dataStore: DataStore<Preferences>,
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:73:    val readerSettingsStore: com.vreader.app.reader.settings.ReaderSettingsStore by lazy {
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:110:    // device-local DataStore under noBackupFilesDir (the readerSettingsStore precedent — recents are
+android/app/src/main/kotlin/com/vreader/app/search/RecentSearchesStore.kt:21:    private val dataStore: DataStore<Preferences>,
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:42:    private val dataStore: DataStore<Preferences>,
+android/app/src/main/kotlin/com/vreader/app/backup/net/WebDavServerStore.kt:30:    private val dataStore: DataStore<Preferences>,
+android/app/src/main/kotlin/com/vreader/app/backup/net/SecretCipher.kt:29:class KeystoreSecretCipher(private val alias: String = DEFAULT_ALIAS) : SecretCipher {
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:32:    private val dataStore: DataStore<Preferences>,
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:115:            val settingsOrNull by container.readerSettingsStore.settings.collectAsStateWithLifecycle(initialValue = null)
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:180:            container.readerSettingsStore.settings.collect { chromeTheme.value = it.theme }
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:200:            val initialPrefs = EpubPreferences(scroll = true) + container.readerSettingsStore.current().toEpubPreferences()
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:484:            container.readerSettingsStore.settings.collect { settings ->
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:755:            val settings = container.readerSettingsStore.settings.collectAsStateWithLifecycle(initialValue = null).value
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:757:                val store = container.readerSettingsStore
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:127:                    val displayTheme by container.readerSettingsStore.settings
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:216:                                settings = container.readerSettingsStore.settings,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:211:                val settingsOrNull by container.readerSettingsStore.settings
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:570:                            val store = container.readerSettingsStore
+// Purpose: Application + manual DI container — feature #106 WI-8. Holds the
+// process-singleton Room database, repository, and importer so the Library
+// ViewModel gets shared instances (a Hilt module is a Phase-3 follow-on; manual
+// wiring at the app edge keeps the foundation bar dependency-light — rule 50 §5).
+package com.vreader.app
+
+import android.app.Application
+import android.content.Context
+import com.vreader.app.data.BookImporter
+import com.vreader.app.data.LibraryRepository
+import com.vreader.app.data.VReaderDatabase
+import com.vreader.app.reader.BookOpener
+import com.vreader.app.search.BookTextExtractor
+import com.vreader.app.search.EpubTextExtractor
+import com.vreader.app.search.asSearcher
+import com.vreader.app.search.SearchIndexCoordinator
+import com.vreader.app.search.TxtMdTextExtractor
+import com.vreader.app.annotations.AnnotationsRepository
+import com.vreader.app.stats.ReadingStatsRepository
+import com.vreader.app.stats.ReadingTimeTracker
+import com.vreader.app.stats.clock.SystemDateClock
+import com.vreader.app.stats.clock.SystemElapsedClock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.map
+import vreader.contracts.BookFormat
+import java.io.File
+
+/** Process-wide singletons, lazily built. */
+class AppContainer(context: Context) {
+    private val appContext = context.applicationContext
+
+    val database: VReaderDatabase by lazy { VReaderDatabase.build(appContext) }
+    val repository: LibraryRepository by lazy {
+        LibraryRepository(database.bookDao(), database.readingPositionDao())
+    }
+    val importer: BookImporter by lazy {
+        BookImporter(File(appContext.filesDir, "books"), repository)
+    }
+
+    // feature #122 — reading-stats. The repository + the time tracker are process-singletons so a
+    // reading session survives the (shorter-lived) reader ViewModel / rotation. ONE shared DateClock
+    // so the dashboard's "today" and the tracker's bucket dates can't drift apart.
+    private val dateClock: SystemDateClock by lazy { SystemDateClock() }
+    val statsRepository: ReadingStatsRepository by lazy {
+        ReadingStatsRepository(database.readingStatsDao(), repository, dateClock)
+    }
+    val readingTimeTracker: ReadingTimeTracker by lazy {
+        ReadingTimeTracker(statsRepository, SystemElapsedClock(), dateClock)
+    }
+
+    // feature #123 — annotations (EPUB highlights & notes). Process-singleton so the reader VM /
+    // rotation share one instance (the statsRepository precedent).
+    val annotationsRepository: AnnotationsRepository by lazy {
+        AnnotationsRepository(database.annotationDao())
+    }
+
+    // feature #127 — library collections. Process-singleton (the annotationsRepository precedent).
+    val collectionRepository: com.vreader.app.data.CollectionRepository by lazy {
+        com.vreader.app.data.CollectionRepository(database.collectionDao())
+    }
+
+    // feature #129 — reader display settings. A device-local DataStore (the OpdsSourceStore /
+    // AiProviderStore precedent), global (not per-book), process-singleton so a settings change
+    // propagates to whatever reader is open. Stored under noBackupFilesDir — display prefs are
+    // per-device (NOT in the backup contract), so they must be excluded from Android Auto Backup.
+    private val readerSettingsDataStore: androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences> by lazy {
+        androidx.datastore.preferences.core.PreferenceDataStoreFactory.create {
+            File(appContext.noBackupFilesDir, "reader_settings.preferences_pb")
+        }
+    }
+    val readerSettingsStore: com.vreader.app.reader.settings.ReaderSettingsStore by lazy {
+        com.vreader.app.reader.settings.ReaderSettingsStore(readerSettingsDataStore)
+    }
+
+    /** Process-lifetime scope for fire-and-forget writes that must outlive a screen
+     *  (e.g. the reader's onStop position flush — it must finish even as the activity
+     *  is being torn down). */
+    val appScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    // feature #128 WI-5 — cross-book search index. The coordinator observes the library and
+    // streams each indexable book (epub/txt/md) through the WI-3 extractors into WI-4's staging →
+    // atomic publish. Eagerly started once from onCreate; pdf/azw3 map to null (never indexable).
+    private val bookOpener: BookOpener by lazy { BookOpener(appContext) }
+    private val epubTextExtractor: EpubTextExtractor by lazy { EpubTextExtractor(bookOpener) }
+    private val txtMdTextExtractor: TxtMdTextExtractor by lazy { TxtMdTextExtractor() }
+    val searchIndexCoordinator: SearchIndexCoordinator by lazy {
+        SearchIndexCoordinator(
+            repository = repository,
+            searchDao = database.searchDao(),
+            extractorFor = { fmt: BookFormat ->
+                when (fmt) {
+                    BookFormat.epub -> epubTextExtractor
+                    BookFormat.txt, BookFormat.md -> txtMdTextExtractor
+                    BookFormat.pdf, BookFormat.azw3 -> null   // metadata-only — never indexed
+                }
+            },
+            scope = appScope,
+            ioDispatcher = Dispatchers.IO,
+        )
+    }
+
+    /** Idempotent — starts the single search-index collector (the coordinator's own AtomicBoolean
+     *  makes a repeat call a no-op). Called once from [VReaderApp.onCreate]. */
+    fun startSearchIndexing() = searchIndexCoordinator.startSearchIndexing()
+
+    // feature #128 WI-6 — the query pipeline. SearchRepository turns a raw query into an observable
+    // Flow of first-hit-per-book text hits (grows as indexing completes); RecentSearchesStore is a
+    // device-local DataStore under noBackupFilesDir (the readerSettingsStore precedent — recents are
+    // per-device, NOT in the backup contract). The SearchViewModel factory wires the metadata filter,
+    // the text-hit Flow, the completeness gate, and recent-recording for the WI-7 screen.
+    val searchRepository: com.vreader.app.search.SearchRepository by lazy {
+        com.vreader.app.search.SearchRepository(database.searchDao())
+    }
+    private val recentSearchesDataStore: androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences> by lazy {
+        androidx.datastore.preferences.core.PreferenceDataStoreFactory.create {
+            File(appContext.noBackupFilesDir, "recent_searches.preferences_pb")
+        }
+    }
+    val recentSearchesStore: com.vreader.app.search.RecentSearchesStore by lazy {
+        com.vreader.app.search.RecentSearchesStore(recentSearchesDataStore)
+    }
+
+    /**
+     * feature #133 WI-10 — the per-reader-session in-book-search ViewModel for a TXT/MD host. Wires the
+     * WI-6 [InBookSearchRepository] (FTS DAO page/count/resume + the WI-4 [TxtMdInBookHitResolver] over the
+     * already-decoded [decodedText]) behind the WI-8 [InBookSearchViewModel], gated by the WI-7
+     * [IndexStateGate] over the DAO's `observeIndexState` Flow and fed the GLOBAL recents store.
+     *
+     * The EPUB engine seam is NEVER invoked for a TXT/MD host (the repository dispatches only the TXT/MD
+     * branch for `txt`/`md`), so `epubEngineFor` is an error-throwing guard — a call would be a wiring bug.
+     * ONE [InBookSearchRepository] per session (the VM's `closeAllEpubCursors` lifecycle contract holds
+     * uniformly even though TXT has no cursors). [coroutineScope] is the VM's `viewModelScope` in production
+     * (the VM cancels its child collectors on `onCleared`).
+     */
+    fun inBookSearchViewModel(
+        bookKey: String,
+        format: BookFormat,
+        decodedText: String,
+        contentSHA256: String,
+        fileByteCount: Long,
+        coroutineScope: CoroutineScope,
+    ): com.vreader.app.search.InBookSearchViewModel {
+        val searchDao = database.searchDao()
+        val repository = com.vreader.app.search.InBookSearchRepository(
+            dispatcher = Dispatchers.Default,
+            fts = com.vreader.app.search.InBookFtsDeps(
+                matchingChunksPage = { ftsQuery, afterSectionIndex, afterChunkOrdinal, afterId, limit ->
+                    searchDao.matchingChunksPage(bookKey, ftsQuery, afterSectionIndex, afterChunkOrdinal, afterId, limit)
+                },
+                chunkAtOrAfter = { ftsQuery, atSectionIndex, atChunkOrdinal, atId ->
+                    searchDao.chunkAtOrAfter(bookKey, ftsQuery, atSectionIndex, atChunkOrdinal, atId)
+                },
+                // The resolver re-derives the chunk boundaries from the ALREADY-decoded reader text (no I/O);
+                // memoized per session inside the resolver (built once).
+                resolverFor = {
+                    com.vreader.app.search.TxtMdInBookHitResolver(
+                        contentSHA256 = contentSHA256,
+                        fileByteCount = fileByteCount,
+                        format = format.name,
+                        decodedText = decodedText,
+                    )
+                },
+            ),
+            // TXT/MD never reaches the EPUB branch — a call here is a dispatch bug, fail fast.
+            epubEngineFor = { error("EPUB in-book search engine requested on a TXT/MD host") },
+        )
+        return com.vreader.app.search.InBookSearchViewModel(
+            bookKey = bookKey,
+            format = format,
+            searcher = repository.asSearcher(),
+            indexStateGate = com.vreader.app.search.IndexStateGate(Dispatchers.Default),
+            indexStateFlow = searchDao.observeIndexState(bookKey),
+            // For a settled-`indexed` TXT/MD row the gate consults this to decide Ready vs definitive
+            // NoResults. `hasOccurrence` carries no query, so we report Ready (true) and let the actual
+            // `page(...)` be the source of truth: a settled book with zero matches runs one fast FTS query
+            // and the repository returns NoResults — the SAME UI outcome the gate's occurrence short-circuit
+            // would give, without threading the live query through a shared mutable seam (no race). The gate
+            // is only consulted on a settled-indexed row, so this never fires while Indexing/missing/failed.
+
+exec
+/bin/zsh -lc "nl -ba vreader/Services/AI/ChapterTranslationService.swift | sed -n '300,395p'
+nl -ba vreader/Services/AI/ChapterTranslationPrefetcher.swift | sed -n '175,250p'
+nl -ba vreader/Views/Reader/Bilingual/EPUBBilingualOrchestrator.swift | sed -n '130,290p'
+rg -n \"BilingualInterlinearBody|BilingualPageContent\" dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md android/app/src/main" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+   300	                    translatedSegments: translated,
+   301	                    sourceParagraphCount: segments.count))
+   302	            } catch {
+   303	                log.error("Cache-write failed (translation still returned): \(String(describing: error), privacy: .public)")
+   304	            }
+   305	        }
+   306	
+   307	        return ChapterTranslationResult(segments: translated, fromCache: false)
+   308	    }
+   309	
+   310	    /// Bug #268: translates a PRE-SEGMENTED list of source segments directly,
+   311	    /// bypassing `ChapterSegmenter`. Used by the bilingual EPUB
+   312	    /// divergence-fallback: when the DOM leaf-enumerate's block count
+   313	    /// diverges from the plain-text paragraph segmentation (nested `<pre>` /
+   314	    /// mixed-content `<blockquote>`), translating the enumerate's OWN block
+   315	    /// `text[]` makes blocks↔segments 1:1 BY CONSTRUCTION — eliminating the
+   316	    /// whole-chapter source-only fallback. The returned array is always the same
+   317	    /// length as `segments`.
+   318	    ///
+   319	    /// Bug #343: the result IS cached now — the canonical row stores the
+   320	    /// ENUMERATE's count as its contract, so a toggle/reopen restores via
+   321	    /// `cachedTranslation(expectedSegmentCount:)` with zero provider calls.
+   322	    /// (#268 originally skipped the cache to avoid thrashing the plain-text
+   323	    /// path's differently-counted row; post-#342 there is ONE canonical row
+   324	    /// and the divergence fallback is its self-healing writer of last resort.)
+   325	    /// A partially-degraded result (Bug #330) is NOT cached, mirroring
+   326	    /// `translate`.
+   327	    func translatePreSegmented(
+   328	        bookFingerprintKey: String,
+   329	        unit: TranslationUnitID,
+   330	        segments: [String],
+   331	        targetLanguage: String,
+   332	        providerProfileID: UUID,
+   333	        config: ResolvedAIProviderConfig,
+   334	        style: TranslationStyle
+   335	    ) async throws -> [String] {
+   336	        guard !segments.isEmpty else { return [] }
+   337	        let chunks = ChapterTranslationChunker.chunk(
+   338	            segments: segments, maxCharsPerChunk: maxCharsPerChunk)
+   339	        var translated = [String](repeating: "", count: segments.count)
+   340	        // Bug #330: same graceful degradation as `translate` — a single chunk's
+   341	        // failure leaves its segments source-only; an all-chunks failure surfaces
+   342	        // the error.
+   343	        var anyChunkSucceeded = false
+   344	        var lastChunkError: Error?
+   345	        for chunk in chunks {
+   346	            do {
+   347	                try Task.checkCancellation()
+   348	            } catch {
+   349	                throw ChapterTranslationError.cancelled
+   350	            }
+   351	            let chunkSegments = chunk.map { segments[$0] }
+   352	            do {
+   353	                let chunkResult = try await translateChunk(
+   354	                    chunkSegments, targetLanguage: targetLanguage, config: config, style: style)
+   355	                for (offset, segmentIndex) in chunk.enumerated() {
+   356	                    translated[segmentIndex] = chunkResult[offset]
+   357	                }
+   358	                anyChunkSucceeded = true
+   359	            } catch is CancellationError {
+   360	                throw ChapterTranslationError.cancelled
+   361	            } catch ChapterTranslationError.cancelled {
+   362	                // Bug #330 (Codex): typed cancellation from `send()` must abort,
+   363	                // not degrade.
+   364	                throw ChapterTranslationError.cancelled
+   365	            } catch {
+   366	                log.error("Pre-segmented chunk failed (segments \(chunk) source-only): \(String(describing: error), privacy: .public)")
+   367	                lastChunkError = error
+   368	            }
+   369	        }
+   370	        if !anyChunkSucceeded, let err = lastChunkError {
+   371	            throw err
+   372	        }
+   373	
+   374	        // Bug #343: cache the fully-successful result under the canonical key
+   375	        // with the ENUMERATE's count as the stored contract. Mirrors
+   376	        // `translate`: a partial degrade is never cached (Bug #330), and a
+   377	        // store-write failure does not fail the translation (rule 50 §6).
+   378	        if lastChunkError == nil {
+   379	            do {
+   380	                try await store.upsert(ChapterTranslationRecord(
+   381	                    bookFingerprintKey: bookFingerprintKey,
+   382	                    unitStorageKey: unit.storageKey,
+   383	                    targetLanguage: targetLanguage,
+   384	                    providerProfileID: providerProfileID,
+   385	                    promptVersion: promptVersion,
+   386	                    translatedSegments: translated,
+   387	                    sourceParagraphCount: segments.count))
+   388	            } catch {
+   389	                log.error("Pre-segmented cache-write failed (translation still returned): \(String(describing: error), privacy: .public)")
+   390	            }
+   391	        }
+   392	        return translated
+   393	    }
+   394	
+   395	    // MARK: - Private
+   175	        do {
+   176	            let result = try await translationService.translate(
+   177	                bookFingerprintKey: bookFingerprintKey,
+   178	                unit: unit,
+   179	                sourceText: sourceText,
+   180	                targetLanguage: targetLanguage,
+   181	                providerProfileID: providerProfileID,
+   182	                config: config,
+   183	                style: style,
+   184	                granularity: effectiveGranularity
+   185	            )
+   186	            return result.segments
+   187	        } catch {
+   188	            Self.log.error("prefetch translate call failed for unit \(String(describing: unit), privacy: .public): \(String(describing: error), privacy: .private)")
+   189	            throw error
+   190	        }
+   191	    }
+   192	
+   193	    /// Bug #268: translate the render's OWN enumerated block texts directly
+   194	    /// (1:1 by construction), bypassing the unit's plain-text segmentation.
+   195	    /// Same provider snapshot + resolve + error contract as `translatedSegments`,
+   196	    /// then `ChapterTranslationService.translatePreSegmented` (no disk cache).
+   197	    func translatedSegmentsDirect(
+   198	        for unit: TranslationUnitID,
+   199	        sourceSegments: [String],
+   200	        targetLanguage: String
+   201	    ) async throws -> [String] {
+   202	        guard !sourceSegments.isEmpty else { return [] }
+   203	        Self.log.debug("prefetchDirect start: unit \(String(describing: unit), privacy: .public), \(sourceSegments.count) segments")
+   204	        // Snapshot the active profile + resolve its config (mirrors
+   205	        // `translatedSegments` so a provider switch can't straddle).
+   206	        guard let activeProfile = await ProviderProfileStore.shared
+   207	            .activeProfileSnapshot() else {
+   208	            Self.log.error("prefetchDirect: no active provider profile")
+   209	            throw ChapterTranslationError.providerFailed("no active provider profile")
+   210	        }
+   211	        let config: ResolvedAIProviderConfig
+   212	        do {
+   213	            config = try await aiService.resolveProviderConfig(
+   214	                profileID: activeProfile.id, modelOverride: nil)
+   215	        } catch {
+   216	            Self.log.error("prefetchDirect resolveProviderConfig failed: \(String(describing: error), privacy: .private)")
+   217	            throw ChapterTranslationError.providerFailed("provider config unavailable")
+   218	        }
+   219	        do {
+   220	            let out = try await translationService.translatePreSegmented(
+   221	                bookFingerprintKey: bookFingerprintKey,
+   222	                unit: unit,
+   223	                segments: sourceSegments,
+   224	                targetLanguage: targetLanguage,
+   225	                providerProfileID: activeProfile.id,
+   226	                config: config,
+   227	                style: style)
+   228	            Self.log.debug("prefetchDirect ok: \(out.count) translated segments")
+   229	            return out
+   230	        } catch {
+   231	            Self.log.error("prefetchDirect translatePreSegmented failed: \(String(describing: error), privacy: .private)")
+   232	            throw error
+   233	        }
+   234	    }
+   235	
+   236	    /// Bug #343: cache-only restore for the divergence fallback — serves the
+   237	    /// canonical row when its stored contract matches the enumerate's own
+   238	    /// block count. Needs no provider config (the #306 pre-gate precedent).
+   239	    func cachedSegmentsDirect(
+   240	        for unit: TranslationUnitID,
+   241	        expectedCount: Int,
+   242	        targetLanguage: String
+   243	    ) async -> [String]? {
+   244	        await translationService.cachedTranslation(
+   245	            bookFingerprintKey: bookFingerprintKey,
+   246	            unit: unit,
+   247	            expectedSegmentCount: expectedCount,
+   248	            targetLanguage: targetLanguage)?.segments
+   249	    }
+   250	}
+   130	    ) {
+   131	        // Drop empty bucketing so `blocksBySection[sectionIndex]` is
+   132	        // either present-and-non-empty or absent.
+   133	        if blocks.isEmpty {
+   134	            blocksBySection[sectionIndex] = nil
+   135	        } else {
+   136	            blocksBySection[sectionIndex] = blocks
+   137	        }
+   138	    }
+   139	
+   140	    /// Clear the cached blocks for one stitched section (e.g. after the
+   141	    /// section is evicted from the continuous-scroll window). Idempotent.
+   142	    func clearBlocks(forSection sectionIndex: Int) {
+   143	        blocksBySection[sectionIndex] = nil
+   144	    }
+   145	
+   146	    /// Feature #71 WI-7 (Gate-4 round-2): the section keys currently cached,
+   147	    /// ascending (render order). The container iterates these to reinject every
+   148	    /// MATERIALIZED stitched section whose translation unit just resolved — a
+   149	    /// `.readerBilingualDidChange` (prefetch lands) for one section must
+   150	    /// reinject only the sections that have blocks, not assume the current
+   151	    /// visible locator's section. The paged path's single `-1` bucket appears
+   152	    /// here too, so an unscoped caller is unaffected.
+   153	    var materializedSections: [Int] {
+   154	        blocksBySection.keys.sorted()
+   155	    }
+   156	
+   157	    /// Builds inject JS for the current blocks given an ordered
+   158	    /// `[String]` of translated segments (the VM's cache for the
+   159	    /// current unit). Returns `nil` when there is nothing to inject
+   160	    /// — either no enumerate has run yet or no translations are
+   161	    /// available.
+   162	    ///
+   163	    /// A short translation array maps the prefix and leaves the rest
+   164	    /// as source-only (silent-source-fallback semantics — plan
+   165	    /// Decision 2).
+   166	    ///
+   167	    /// Feature #71 WI-7: when `sectionIndex` is provided, only that
+   168	    /// section's blocks are paired + injected so one stitched
+   169	    /// chapter's translation never spills into an adjacent section.
+   170	    /// `sectionIndex == nil` keeps the original semantics (the
+   171	    /// flattened `currentBlocks`) for the paged path + bulk callers.
+   172	    func buildInjectJS(
+   173	        translatedSegments: [String]?,
+   174	        forSection sectionIndex: Int? = nil
+   175	    ) -> String? {
+   176	        guard let segments = translatedSegments, !segments.isEmpty else {
+   177	            return nil
+   178	        }
+   179	        let scoped: [BilingualBlock]
+   180	        if let sectionIndex {
+   181	            scoped = blocksBySection[sectionIndex] ?? []
+   182	        } else {
+   183	            scoped = currentBlocks
+   184	        }
+   185	        guard !scoped.isEmpty else { return nil }
+   186	        let map = EPUBBilingualPipeline.translationsByBid(
+   187	            blocks: scoped,
+   188	            translatedSegments: segments
+   189	        )
+   190	        guard !map.isEmpty else { return nil }
+   191	        return EPUBBilingualJS.bilingualInjectJS(
+   192	            translationsByBid: map,
+   193	            spineIndex: sectionIndex,
+   194	            targetIsCJK: targetIsCJK
+   195	        )
+   196	    }
+   197	
+   198	    /// Feature #77: builds the LOADING-shimmer inject JS for a section's enumerated
+   199	    /// bids (section/unit-scoped — all the in-flight unit's bids get the shimmer
+   200	    /// until each translation lands and replaces it in place). `sectionIndex == nil`
+   201	    /// uses the flattened `currentBlocks` (paged path). Returns `nil` when there are
+   202	    /// no enumerated blocks for the scope. The loading-inject JS itself skips any bid
+   203	    /// that already has a decoration, so it never downgrades a landed translation.
+   204	    func buildLoadingJS(forSection sectionIndex: Int? = nil) -> String? {
+   205	        let scoped: [BilingualBlock]
+   206	        if let sectionIndex {
+   207	            scoped = blocksBySection[sectionIndex] ?? []
+   208	        } else {
+   209	            scoped = currentBlocks
+   210	        }
+   211	        guard !scoped.isEmpty else { return nil }
+   212	        return EPUBBilingualJS.bilingualInjectLoadingJS(
+   213	            loadingBids: scoped.map(\.bid),
+   214	            spineIndex: sectionIndex,
+   215	            targetIsCJK: targetIsCJK
+   216	        )
+   217	    }
+   218	
+   219	    /// Feature #77: JS that removes ONLY the loading-shimmer decoration nodes (a
+   220	    /// failed / cancelled prefetch), leaving landed translations intact. The
+   221	    /// translation-landed path replaces a shimmer in place, so the shimmer must
+   222	    /// NOT be removed there — only here, for the no-translation outcome.
+   223	    ///
+   224	    /// Feature #77 WI-5: `spineIndex` scopes the clear to one stitched
+   225	    /// continuous-scroll section (a global clear would remove OTHER still-fetching
+   226	    /// sections' shimmers). `nil` (the paged default) clears the whole document.
+   227	    func clearLoadingJS(spineIndex: Int? = nil) -> String {
+   228	        EPUBBilingualJS.bilingualClearLoadingJS(spineIndex: spineIndex)
+   229	    }
+   230	
+   231	    /// Feature #71 WI-7 (Gate-4 round-2 HIGH 2): build ONE inject JS payload
+   232	    /// covering MULTIPLE stitched sections at once, pairing each section's
+   233	    /// ordered segments against ONLY that section's bids.
+   234	    ///
+   235	    /// This is the continuous-scroll reinject path. Two problems the
+   236	    /// per-section single-payload approach solved would otherwise recur:
+   237	    ///   1. **Single-slot overwrite (MEDIUM 1 sibling).** Pushing one
+   238	    ///      per-section inject through the bridge's single `pendingHighlightJS`
+   239	    ///      slot means a second section's inject overwrites the first before
+   240	    ///      the bridge evaluates it. A combined payload injects every section's
+   241	    ///      blocks in one eval.
+   242	    ///   2. **Cross-section flatten (the HIGH 2 bug).** Pairing the VM's
+   243	    ///      per-unit segments against the FLATTENED `currentBlocks`
+   244	    ///      (multi-section) would either no-op the Bug #266 1:1 count guard or
+   245	    ///      pair section A's segments against section B's blocks. Scoping each
+   246	    ///      section's segments to its own bucket keeps the 1:1 pairing per
+   247	    ///      section.
+   248	    ///
+   249	    /// `translationsBySection` maps `sectionIndex → ordered translated
+   250	    /// segments` (the VM's cache for that section's unit). A section whose
+   251	    /// segment count does not match its block count is dropped (Bug #266
+   252	    /// source-only fallback) — the others still inject. Returns `nil` when no
+   253	    /// section produced a non-empty 1:1 map.
+   254	    func buildInjectJS(translationsBySection: [Int: [String]]) -> String? {
+   255	        var combined: [String: String] = [:]
+   256	        for sectionIndex in translationsBySection.keys.sorted() {
+   257	            guard let segments = translationsBySection[sectionIndex],
+   258	                  !segments.isEmpty,
+   259	                  let blocks = blocksBySection[sectionIndex], !blocks.isEmpty else {
+   260	                continue
+   261	            }
+   262	            // Per-section 1:1 pairing (Bug #266): a count mismatch yields an
+   263	            // empty map for that section → it stays source-only, the rest still
+   264	            // inject. Bids are section-namespaced (`s{N}b…`) so the merge across
+   265	            // sections cannot collide keys.
+   266	            let map = EPUBBilingualPipeline.translationsByBid(
+   267	                blocks: blocks, translatedSegments: segments)
+   268	            for (bid, translation) in map { combined[bid] = translation }
+   269	        }
+   270	        guard !combined.isEmpty else { return nil }
+   271	        // bids are already globally unique (section-namespaced), so the global
+   272	        // bid-keyed inject resolves each block in its own section.
+   273	        return EPUBBilingualJS.bilingualInjectJS(
+   274	            translationsByBid: combined, targetIsCJK: targetIsCJK)
+   275	    }
+   276	}
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:5:**Design authority (rule 51):** the **authoritative** bilingual surfaces are in `dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx` (`BilingualSetupSheet` / `BilingualPageContent` / `BilingualPill` / `BILINGUAL_LANGS`) and `.../vreader-reader.jsx` (`ReaderTopChrome` renders `BilingualPill`; the bilingual toggle is a More-menu row via `onMoreAction`) and `.../vreader-more.jsx` (the "Bilingual mode" More-menu Row toggle). `.../vreader-ai-android.jsx` contains a SECOND, differently-shaped `BilingualSetupSheet` — see §3's setup-sheet resolution for why this plan reproduces the `vreader-bilingual.jsx` sheet and design-gates the divergence. Where a surface is NOT depicted it is scoped out and flagged.
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:71:- `bilingual/BilingualInterlinearBody.kt` — per source chunk/paragraph: source `Text` then translation `Text` muted with accent left-border, `fontSize*0.88`, CJK font for cjk scripts, RTL handling for Arabic script. Consumes `translationsByUnit`. Loading state ("Translating chapter… N%" + per-paragraph dim — matches the design's chapter-level "38%"). Error state ("Couldn't translate" + Retry). Partial/offline (`unavailableUnits`): source-only silent fallback (design's original-always-kept guarantee — iOS Decision 2). This is the render surface for BOTH the TXT/MD Compose loop and (via the WI-0 adapter) the EPUB injection payload's Kotlin-side state.
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:77:- `reader/TxtReaderActivity.kt` — own a `BilingualViewModel`; collect state; pass into `TxtBody`; on position change call `vm.onPositionChanged(...)`; render `BilingualInterlinearBody` output in the `items(count = document.chunkCount)` loop when bilingual is on and a translation exists (the confirmed injection point — verified it already interleaves highlight washes + TTS spans per chunk). Strictly gated to `originalFormat ∈ {txt, md}`; disabled = body byte-unchanged. **This file overlaps #129's TXT/MD WIs → gated on #129's FINAL merge (§4).**
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:136:v1 merged both into a **third layout** — a rule-51 violation (self-designed UI). **Resolution:** this plan reproduces the **`vreader-bilingual.jsx` sheet EXACTLY** as the authoritative Android-native bilingual sheet (its language grid + granularity + preview + engine strip + CTA is the coherent bilingual-config surface, and its `BilingualPill`/`BilingualPageContent` are the matching reader surfaces). **Style is dropped from v1** (it is not in the authoritative sheet, and — verified — `bilingualStyle` is not a persisted contract field on either platform). Consequently the store/VM carry no `style`, and `promptVersion`'s `s=` component is a constant (§2 cache-identity correction).
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:173:**WI-7b (behavioral): EPUB render adapter** (only if WI-0 = go). The JS enumerate/inject adapter + `EpubChapterTextProvider`, wired into `ReaderActivity`, driving `BilingualInterlinearBody` state from injected content. Deps: **WI-0, WI-3, WI-4, WI-7a**. Connected test on a real EPUB (seeded cache): enable → interlinear injects; disable → nodes cleared; reflow/href-change re-applies. (If WI-0 = no-go, this WI is dropped and box D ships TXT/MD-only, tracked.)
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:185:Compose UI (`androidTest/...bilingual/`): `BilingualSetupSheetUiTest` (language grid, granularity, preview, engine configured vs unconfigured; **no Style control present**; light+dark); `BilingualInterlinearBodyUiTest` (translated incl. CJK font + RTL Arabic; loading N%+dimmed; error+Retry; offline source-only; empty translation→source-only no crash); `BilingualPillUiTest`.
+
+exec
+/bin/zsh -lc "rg -n \"AiProviderListScreen|AiSettingsViewModel|AiProviderStore|Open.*AI|Settings|MoreAction|ReaderMore\" android/app/src/main/kotlin/com/vreader/app -g '*.kt' | head -240
+rg -n \"Set up|No AI provider|Bilingual mode|Translation engine\" dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx dev-docs/designs/vreader-fidelity-v1/project/vreader-more.jsx" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:65:    // AiProviderStore precedent), global (not per-book), process-singleton so a settings change
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:68:    private val readerSettingsDataStore: androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences> by lazy {
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:73:    val readerSettingsStore: com.vreader.app.reader.settings.ReaderSettingsStore by lazy {
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:74:        com.vreader.app.reader.settings.ReaderSettingsStore(readerSettingsDataStore)
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:110:    // device-local DataStore under noBackupFilesDir (the readerSettingsStore precedent — recents are
+android/app/src/main/kotlin/com/vreader/app/stats/StatsDashboard.kt:4:// table (Time + Hl/Nt + a per-row time hairline). Reuses the backup AppSheet/SettingsCard +
+android/app/src/main/kotlin/com/vreader/app/stats/StatsDashboard.kt:35:import com.vreader.app.backup.SettingsCard
+android/app/src/main/kotlin/com/vreader/app/stats/StatsDashboard.kt:84:    SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/stats/StatsDashboard.kt:116:    SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/stats/StatsDashboard.kt:140:    SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/opds/ui/OpdsSourceListScreen.kt:4:// vocabulary (NavScreen / SettingsCard / GroupHeader / GroupFooter / StatusDot / tokens). Stateless:
+android/app/src/main/kotlin/com/vreader/app/opds/ui/OpdsSourceListScreen.kt:42:import com.vreader.app.backup.SettingsCard
+android/app/src/main/kotlin/com/vreader/app/opds/ui/OpdsSourceListScreen.kt:75:                SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/opds/ui/OpdsSourceListScreen.kt:103:    SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/backup/ServerEditSheet.kt:73:                SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/backup/ServerEditSheet.kt:84:                SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/backup/ServerEditSheet.kt:91:                SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/backup/ServerEditSheet.kt:104:                SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/backup/ServerEditSheet.kt:115:                    SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/opds/ui/OpdsAddSheet.kt:43:import com.vreader.app.backup.SettingsCard
+android/app/src/main/kotlin/com/vreader/app/opds/ui/OpdsAddSheet.kt:76:                SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/opds/ui/OpdsAddSheet.kt:85:                SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/opds/ui/OpdsAddSheet.kt:103:                SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/opds/ui/OpdsAddSheet.kt:114:                    SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/opds/ui/OpdsSourcesViewModel.kt:4:// #118 AiSettingsViewModel test path), and saves/deletes. The password is never logged.
+android/app/src/main/kotlin/com/vreader/app/opds/ui/OpdsSourcesViewModel.kt:50:    // closed form). Mirrors AiSettingsViewModel.testGen.
+android/app/src/main/kotlin/com/vreader/app/tts/TtsVoiceSheet.kt:3:// not-installed → Download). Reuses the backup AppSheet/SettingsCard + BackupTokens. Stateless.
+android/app/src/main/kotlin/com/vreader/app/tts/TtsVoiceSheet.kt:36:import com.vreader.app.backup.SettingsCard
+android/app/src/main/kotlin/com/vreader/app/tts/TtsVoiceSheet.kt:60:                SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/tts/TtsVoiceSheet.kt:76:            SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/backup/BackupRestoreScreen.kt:60:                    SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/backup/BackupRestoreScreen.kt:77:    SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/backup/BackupRestoreScreen.kt:144:    SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/backup/BackupRestoreScreen.kt:184:            "Open Server Settings",
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderFactory.kt:3:// AiProviderStore.snapshot(), decrypts via apiKey(profile), and calls this — so the client is built
+android/app/src/main/kotlin/com/vreader/app/backup/BackupViewModel.kt:106:    fun openServerSettings() {
+android/app/src/main/kotlin/com/vreader/app/backup/BackupViewModel.kt:107:        viewModelScope.launch { _events.send(BackupEvent.OpenServerSettings) }
+android/app/src/main/kotlin/com/vreader/app/backup/BackupUiState.kt:30:    data object OpenServerSettings : BackupEvent
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:4:// Reuses the shared form vocabulary (NavScreen / SettingsCard / GroupHeader / StatusDot / tokens —
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:41:import com.vreader.app.backup.SettingsCard
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:46:fun AiProviderListScreen(
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:65:                SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:96:        GroupFooter("Works with Anthropic, OpenAI-compatible endpoints, and local models.")
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:41:class AiProviderStore(
+android/app/src/main/kotlin/com/vreader/app/backup/BackupScaffold.kt:55:/** Back ("Settings") + serif title (large title below, or centered compact), optional trailing. */
+android/app/src/main/kotlin/com/vreader/app/backup/BackupScaffold.kt:74:                Text("Settings", color = t.tint, fontFamily = BackupFonts.Sans, fontSize = 15.sp, fontWeight = FontWeight.Medium)
+android/app/src/main/kotlin/com/vreader/app/backup/BackupScaffold.kt:113:fun SettingsCard(content: @Composable ColumnScope.() -> Unit) {
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt:2:// iOS AITypes (AIRequest/AIResponse/AIStreamChunk/AIError). Provider-neutral; the OpenAI vs
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt:10:/** A chat request. `system` is the system prompt (Anthropic carries it top-level; the OpenAI
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatPanel.kt:49:    onOpenSettings: () -> Unit = {},
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatPanel.kt:78:                state.unconfigured -> UnconfiguredGate(onOpenSettings)
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatPanel.kt:89:private fun UnconfiguredGate(onOpenSettings: () -> Unit) {
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatPanel.kt:96:        Text("Chat and summaries need an AI provider. Add one in Settings — it takes a key and a minute.", color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 13.5.sp, lineHeight = 20.sp, textAlign = TextAlign.Center, modifier = Modifier.padding(top = 8.dp))
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatPanel.kt:99:                .clickable(onClick = onOpenSettings).testTag("ai-open-settings").padding(horizontal = 20.dp, vertical = 11.dp),
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatPanel.kt:100:        ) { Text("Open AI settings", color = Color.White, fontFamily = BackupFonts.Sans, fontSize = 14.sp, fontWeight = FontWeight.SemiBold) }
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheet.kt:2:// (vreader-panels.jsx ReaderSettingsSheet): a Theme 5-swatch row, a Font serif/sans toggle, and
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheet.kt:4:// `theme={t}` surface), so Dark/OLED/Photo look right. Pure function of [ReaderSettings] + callbacks;
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheet.kt:5:// the content is extracted ([ReaderSettingsSheetContent]) for direct UI testing (the #127 precedent).
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheet.kt:41:fun ReaderSettingsSheet(
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheet.kt:42:    settings: ReaderSettings,
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheet.kt:57:        ReaderSettingsSheetContent(settings, onTheme, onFontFamily, onFontSize, onLineSpacing, onMargin)
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheet.kt:61:/** The sheet content (extracted for direct UI testing). Colors derive from the active [ReaderSettings.theme]. */
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheet.kt:63:fun ReaderSettingsSheetContent(
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheet.kt:64:    settings: ReaderSettings,
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheet.kt:98:            valueRange = ReaderSettings.MIN_FONT_SIZE..ReaderSettings.MAX_FONT_SIZE,
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheet.kt:107:            valueRange = ReaderSettings.MIN_LINE_SPACING..ReaderSettings.MAX_LINE_SPACING,
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheet.kt:116:            valueRange = ReaderSettings.MIN_MARGIN..ReaderSettings.MAX_MARGIN,
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderScreen.kt:4:// theme-derived viewer backdrop (feature #129 WI-7: the backdrop = the global ReaderSettingsStore
+android/app/src/main/kotlin/com/vreader/app/search/RecentSearchesStore.kt:3:// noBackupFilesDir (recents are per-device, NOT in the backup contract — the ReaderSettingsStore /
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:178:        // value + live updates), mirroring how observeDisplaySettings feeds the navigator.
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:180:            container.readerSettingsStore.settings.collect { chromeTheme.value = it.theme }
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:200:            val initialPrefs = EpubPreferences(scroll = true) + container.readerSettingsStore.current().toEpubPreferences()
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:238:            observeDisplaySettings(nav)
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:482:    private fun observeDisplaySettings(nav: EpubNavigatorFragment) {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:484:            container.readerSettingsStore.settings.collect { settings ->
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:686:                DisplaySettingsHost {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:751:    private fun DisplaySettingsHost(content: @androidx.compose.runtime.Composable () -> Unit) {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:755:            val settings = container.readerSettingsStore.settings.collectAsStateWithLifecycle(initialValue = null).value
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:757:                val store = container.readerSettingsStore
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:758:                com.vreader.app.reader.settings.ReaderSettingsSheet(
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:896:     *  for its EpubSettings (the applied theme background), or null before the navigator/settings exist.
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt:2:// ACTIVE provider from one AiProviderStore snapshot, streams a chat answer (accumulating deltas),
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt:24:    private val store: AiProviderStore,
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettings.kt:2:// `TypographySettings` + `ReaderThemeV2`. Global (not per-book), device-local (not backed up). The
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettings.kt:4:// are the committed design's slider bounds (vreader-panels.jsx ReaderSettingsSheet).
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettings.kt:12: * (its background). A pure value type — the [ReaderSettingsStore] persists it, the hosts apply it.
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettings.kt:14:data class ReaderSettings(
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3DisplayCss.kt:1:// Purpose: feature #129 WI-6 (#110 Phase 3) — the pure `ReaderSettings → foliate CSS blob` the AZW3
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3DisplayCss.kt:12:// @coordinates-with: Azw3ReaderActivity.kt (collects ReaderSettings, injects the CSS through the
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3DisplayCss.kt:13://   FoliateBridge setStyles seam on change), FoliateBridge.kt (exposes setStyles), ReaderSettings.kt /
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3DisplayCss.kt:19:import com.vreader.app.reader.settings.ReaderSettings
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3DisplayCss.kt:29: * The deterministic foliate CSS blob for these display [ReaderSettings] — raw CSS (no `<style>` wrapper),
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3DisplayCss.kt:30: * as `readerAPI.setStyles(css)` expects. Assumes clamped inputs (the [ReaderSettingsStore] clamps on read
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3DisplayCss.kt:33:fun ReaderSettings.foliateDisplayCss(): String {
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeScaffold.kt:50:import com.vreader.app.reader.more.MoreActionId
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeScaffold.kt:256:    MoreRow.Action(id = MoreActionId.DETAILS, label = "Book details", icon = Icons.Filled.Info, onTap = onDetails),
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeScaffold.kt:257:    MoreRow.Action(id = MoreActionId.SHARE, label = "Share book", icon = Icons.Filled.Share, onTap = onShare),
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderTextStyles.kt:1:// Purpose: feature #129 WI-4 (#110 Phase 3) — the pure `ReaderSettings → Compose TextStyle` mapping
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderTextStyles.kt:4:// (VReaderFonts design approximations). Pure value types (JVM-unit-testable, TxtDisplaySettingsTest).
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderTextStyles.kt:9://   ReaderSettings.kt (the value type + clamped ranges this maps from).
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderTextStyles.kt:27: * Assumes clamped inputs (the [ReaderSettingsStore] clamps on read AND write).
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderTextStyles.kt:29:fun ReaderSettings.bodyTextStyle(): TextStyle = TextStyle(
+android/app/src/main/kotlin/com/vreader/app/reader/PdfDisplayBackdrop.kt:1:// Purpose: feature #129 WI-7 (#110 Phase 3) — the pure `ReaderSettings → PDF viewer backdrop Color`
+android/app/src/main/kotlin/com/vreader/app/reader/PdfDisplayBackdrop.kt:3:// inherits ONLY the theme background from the global ReaderSettingsStore — font family/size/spacing/
+android/app/src/main/kotlin/com/vreader/app/reader/PdfDisplayBackdrop.kt:9:// @coordinates-with: PdfReaderActivity.kt (collects ReaderSettings, applies pdfBackdrop() to the
+android/app/src/main/kotlin/com/vreader/app/reader/PdfDisplayBackdrop.kt:10://   viewer backdrop live), ReaderSettings.kt / ReaderTheme.kt (the value type + theme colors).
+android/app/src/main/kotlin/com/vreader/app/reader/PdfDisplayBackdrop.kt:14:import com.vreader.app.reader.settings.ReaderSettings
+android/app/src/main/kotlin/com/vreader/app/reader/PdfDisplayBackdrop.kt:18: * [ReaderSettings]. PDF applies the theme background ONLY (it can't reflow, so typography is inert);
+android/app/src/main/kotlin/com/vreader/app/reader/PdfDisplayBackdrop.kt:21:fun ReaderSettings.pdfBackdrop(): Color = theme.background
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:2:// AiProviderStore for the list, owns the editor form state, runs Test Connection against the LIVE
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:20:class AiSettingsViewModel(
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:21:    private val store: AiProviderStore,
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderKind.kt:32:            openAiCompatible -> "OpenAI-compatible"
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderBottomChrome.kt:4:// "Display" (Aa) slot (opens the WI-2 ReaderSettingsSheet) plus an optional host-provided extraSlot
+android/app/src/main/kotlin/com/vreader/app/ai/OpenAiCompatibleProvider.kt:1:// Purpose: feature #118 WI-2 (#110 Phase 3) — the OpenAI-compatible chat client (OpenAI, Azure,
+android/app/src/main/kotlin/com/vreader/app/ai/OpenAiCompatibleProvider.kt:4:// `choices[0].message.content`. Mirrors iOS OpenAICompatibleProvider.
+android/app/src/main/kotlin/com/vreader/app/ai/SseEventReader.kt:3:// interpret each event's data). Handles the SSE wire rules that both OpenAI and Anthropic streams
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:1:// Purpose: feature #129 WI-1 (#110 Phase 3) — persists the reader "Display" [ReaderSettings] in
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:2:// DataStore (the OpdsSourceStore / AiProviderStore JSON-in-Preferences precedent). Global, device-
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:23:private data class ReaderSettingsState(
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:26:    val fontSizeSp: Float = ReaderSettings.DEFAULT_FONT_SIZE,
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:27:    val lineSpacing: Float = ReaderSettings.DEFAULT_LINE_SPACING,
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:28:    val marginDp: Float = ReaderSettings.DEFAULT_MARGIN,
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:31:class ReaderSettingsStore(
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:62:    val settings: Flow<ReaderSettings> = dataStore.data.map { read(it).toSettings() }
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:65:    suspend fun current(): ReaderSettings = read(dataStore.data.first()).toSettings()
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:72:    suspend fun setFontSize(sp: Float, order: Long = nextSeq()) = update(Field.FONT_SIZE, order) { it.copy(fontSizeSp = ReaderSettings.clampFontSize(sp)) }
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:73:    suspend fun setLineSpacing(v: Float, order: Long = nextSeq()) = update(Field.LINE_SPACING, order) { it.copy(lineSpacing = ReaderSettings.clampLineSpacing(v)) }
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:74:    suspend fun setMargin(dp: Float, order: Long = nextSeq()) = update(Field.MARGIN, order) { it.copy(marginDp = ReaderSettings.clampMargin(dp)) }
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:76:    private suspend fun update(field: Field, order: Long, transform: (ReaderSettingsState) -> ReaderSettingsState) {
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:88:    private fun ReaderSettingsState.normalized() = copy(
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:89:        fontSizeSp = ReaderSettings.clampFontSize(fontSizeSp),
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:90:        lineSpacing = ReaderSettings.clampLineSpacing(lineSpacing),
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:91:        marginDp = ReaderSettings.clampMargin(marginDp),
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:94:    private fun read(prefs: Preferences): ReaderSettingsState {
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:95:        val raw = prefs[KEY] ?: return ReaderSettingsState()
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:96:        return runCatching { json.decodeFromString<ReaderSettingsState>(raw) }.getOrDefault(ReaderSettingsState())
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:101:    private fun ReaderSettingsState.toSettings() = ReaderSettings(
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:104:        fontSizeSp = ReaderSettings.clampFontSize(fontSizeSp),
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:105:        lineSpacing = ReaderSettings.clampLineSpacing(lineSpacing),
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:106:        marginDp = ReaderSettings.clampMargin(marginDp),
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt:51:import com.vreader.app.backup.SettingsCard
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt:90:                SettingsCard { Field("", state.name, "e.g. OpenRouter", onName) }
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt:94:                SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt:103:                SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt:111:                SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt:129:                SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/reader/EpubPreferencesMapper.kt:1:// Purpose: feature #129 WI-5 (#110 Phase 3) — the pure `ReaderSettings → EpubPreferences` mapping the
+android/app/src/main/kotlin/com/vreader/app/reader/EpubPreferencesMapper.kt:12://   ReaderSettings.kt / ReaderTheme.kt (the value type + theme colors this maps from).
+android/app/src/main/kotlin/com/vreader/app/reader/EpubPreferencesMapper.kt:17:import com.vreader.app.reader.settings.ReaderSettings
+android/app/src/main/kotlin/com/vreader/app/reader/EpubPreferencesMapper.kt:24: *  hardcoded body size and [ReaderSettings.DEFAULT_FONT_SIZE]. */
+android/app/src/main/kotlin/com/vreader/app/reader/EpubPreferencesMapper.kt:32: * Map these display [ReaderSettings] to a Readium [EpubPreferences] for live submission. Assumes clamped
+android/app/src/main/kotlin/com/vreader/app/reader/EpubPreferencesMapper.kt:33: * inputs (the [ReaderSettingsStore] clamps on read AND write). Only the typography/theme fields #129 owns
+android/app/src/main/kotlin/com/vreader/app/reader/EpubPreferencesMapper.kt:37:fun ReaderSettings.toEpubPreferences(): EpubPreferences = EpubPreferences(
+android/app/src/main/kotlin/com/vreader/app/ai/AiClient.kt:6:// parse (OpenAI vs Anthropic). The API key + auth headers are NEVER logged.
+android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:2:// rendered by [MorePopup]. A `sealed interface` so each row carries a stable [MoreActionId] + its own
+android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:19:enum class MoreActionId {
+android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:28:val MoreActionId.slug: String
+android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:42:    val id: MoreActionId
+android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:48:        override val id: MoreActionId,
+android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:57:        override val id: MoreActionId,
+android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:67:        override val id: MoreActionId,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:10:// feature #129 WI-4: the reader collects ReaderSettingsStore.settings live and applies them —
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:13:// slot, replacing the pre-chrome TtsEntryBar) which opens the ReaderSettingsSheet.
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:130:import com.vreader.app.reader.settings.ReaderSettings
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:131:import com.vreader.app.reader.settings.ReaderSettingsSheet
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:211:                val settingsOrNull by container.readerSettingsStore.settings
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:216:                    is TxtUiState.Loading -> TxtLoadingScaffold((settingsOrNull ?: ReaderSettings()).theme)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:219:                        val displaySettings = checkNotNull(settingsOrNull)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:387:                            theme = displaySettings.theme,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:432:                                        theme = displaySettings.theme,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:471:                                    theme = displaySettings.theme,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:492:                                            theme = displaySettings.theme,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:514:                                    textStyle = displaySettings.bodyTextStyle(),
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:515:                                    marginDp = displaySettings.marginDp,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:570:                            val store = container.readerSettingsStore
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:571:                            ReaderSettingsSheet(
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:572:                                settings = displaySettings,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:632:     *  (there is no public Settings.ACTION_TTS_SETTINGS — fall back to accessibility / settings). */
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:638:                android.content.Intent(android.provider.Settings.ACTION_ACCESSIBILITY_SETTINGS),
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:639:                android.content.Intent(android.provider.Settings.ACTION_SETTINGS),
+android/app/src/main/kotlin/com/vreader/app/backup/WebDavServersScreen.kt:57:                SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/backup/WebDavServersScreen.kt:65:                SettingsCard {
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:10:// the global ReaderSettingsStore — no font/size/spacing, and NO Display sheet / NO Aa slot (a
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:13:// bright frame) and threads `ReaderSettings.pdfBackdrop()` (= theme.background) to the viewer backdrop.
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:23://   (the settings→backdrop mapping), ReaderSettingsStore (the live settings source), AnnotationsRepository
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:115:            val settingsOrNull by container.readerSettingsStore.settings.collectAsStateWithLifecycle(initialValue = null)
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:127:                    val displayTheme by container.readerSettingsStore.settings
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:128:                        .collectAsStateWithLifecycle(initialValue = com.vreader.app.reader.settings.ReaderSettings())
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:216:                                settings = container.readerSettingsStore.settings,
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:337:    settings: kotlinx.coroutines.flow.Flow<com.vreader.app.reader.settings.ReaderSettings>,
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:350:    val displaySettings by settings.collectAsStateWithLifecycle(initialValue = com.vreader.app.reader.settings.ReaderSettings())
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:391:    // render (reload / render-death recovery) re-records the CSS, and on `displaySettings` so a live
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:394:    LaunchedEffect(holder, displaySettings) { holder.document.setStyles(displaySettings.foliateDisplayCss()) }
+dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx:1:// Bilingual mode — feature #60 follow-up (#790)
+dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx:33:    <Sheet theme={t} onClose={onClose} title="Bilingual mode" height={620}>
+dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx:105:          <SectionLabel theme={t}>Translation engine</SectionLabel>
+dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx:126:                {aiConfigured ? 'Claude · with this book\'s context' : 'No AI provider configured'}
+dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx:131:                  : 'Bilingual mode needs an AI provider to translate.'}
+dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx:142:            }}>{aiConfigured ? 'Change…' : 'Set up'}</button>
+dev-docs/designs/vreader-fidelity-v1/project/vreader-more.jsx:92:          <Row icon={Icons.Translate} label="Bilingual mode"
+dev-docs/designs/vreader-fidelity-v1/project/vreader-more.jsx:97:          <Row icon={Icons.Translate} label="Bilingual mode"
+
+exec
+/bin/zsh -lc "rg -n \"box D|\\| D|Bilingual|bilingual\" docs/parity/android-checklist.md -C 4
+nl -ba android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt | sed -n '1,100p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeScaffold.kt | sed -n '225,275p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+80-  proven end-to-end over live WebDAV; delete UI deferred to needs-design #1875) + #128 search (Android
+81-  `Book` has no author field + no cross-format FTS → search design/data gap, filed separately — NOT yet
+82-  done). Box C checks when BOTH #127 and #128 are VERIFIED — #127 ✓, #128 remains.**
+83-
+84:- [ ] **D. Bilingual interlinear reading** — interlinear original+translation rendering + the bilingual
+85-  setup sheet (languages · provider · model · style), building on the #118 AI provider.
+86:  Design: `vreader-ai-android.jsx` (BilingualReader/BilingualSetupSheet) + `vreader-bilingual.jsx`.
+87-  Note: the pipeline + UI are buildable autonomously; LIVE translation verification is
+88-  AI-credential-gated (a mock/integration path verifies the pipeline). iOS parity: #56/#100.
+89-
+90-- [ ] **E. Reader display settings** — the Aa sheet: theme (the 5 reader themes), font family/size,
+     1	// Purpose: feature #134 WI-3 — the reader More-menu ROW model (`vreader-more.jsx` `MorePopover` rows),
+     2	// rendered by [MorePopup]. A `sealed interface` so each row carries a stable [MoreActionId] + its own
+     3	// callback + (for toggles) its own on/onToggle state. The row's OWNER supplies it: #134 owns only
+     4	// DETAILS + SHARE (Action rows); TTS/AUTO_TURN/BILINGUAL ids exist so their owning features (#121/#131/
+     5	// a future Auto-turn feature) can supply rows, but a row is NEVER invented here — an id with no supplied
+     6	// row is simply absent from the popup (the plan's §more-row-ownership contract; the #129 no-dead-control
+     7	// rule). Pure model: an ImageVector icon ref + strings + lambdas, no Compose UI in the type itself.
+     8	package com.vreader.app.reader.more
+     9	
+    10	import androidx.compose.ui.graphics.vector.ImageVector
+    11	
+    12	/**
+    13	 * A stable identifier for a More-menu row. Used for the row's testTag (`more-row-$id`) and to key row
+    14	 * ownership. #134 owns [DETAILS] + [SHARE]; the others exist so their owning features can supply rows —
+    15	 * #134 supplies none of them and omits any id it is not given a row for. There is deliberately NO
+    16	 * `EXPORT` id: Android has no annotation-export subsystem, so the Export row is never rendered (the
+    17	 * plan's scoped-out invariant), and absence-by-omission is enforced by there being no id to supply.
+    18	 */
+    19	enum class MoreActionId {
+    20	    DETAILS,
+    21	    SHARE,
+    22	    TTS,
+    23	    AUTO_TURN,
+    24	    BILINGUAL,
+    25	}
+    26	
+    27	/** The lowercase stable slug for this id — the testTag / route suffix (e.g. `AUTO_TURN` → `auto_turn`). */
+    28	val MoreActionId.slug: String
+    29	    get() = name.lowercase()
+    30	
+    31	/**
+    32	 * A single More-menu row. Exactly one of three shapes, mirroring the design's three row treatments:
+    33	 *  - [Action]   — a tap row with a trailing chevron (`vreader-more.jsx` `onAction`).
+    34	 *  - [Toggle]   — a stateful row with a trailing switch reflecting [Toggle.on] (`onToggle`).
+    35	 *  - [Disabled] — the design's disabled state (e.g. Bilingual "Configure AI provider first"):
+    36	 *                 non-interactive, dimmed, shows its [Disabled.sub].
+    37	 *
+    38	 * Every row carries a stable [id] (its testTag key) and its own callback. The OWNER of a row's behavior
+    39	 * is the feature that supplies it — never [MorePopup] itself.
+    40	 */
+    41	sealed interface MoreRow {
+    42	    val id: MoreActionId
+    43	    val label: String
+    44	    val icon: ImageVector
+    45	
+    46	    /** A tap row: fires [onTap]; renders a trailing chevron accessory. */
+    47	    data class Action(
+    48	        override val id: MoreActionId,
+    49	        override val label: String,
+    50	        override val icon: ImageVector,
+    51	        val sub: String? = null,
+    52	        val onTap: () -> Unit,
+    53	    ) : MoreRow
+    54	
+    55	    /** A toggle row: the trailing switch reflects [on]; tapping the row calls [onToggle] with `!on`. */
+    56	    data class Toggle(
+    57	        override val id: MoreActionId,
+    58	        override val label: String,
+    59	        override val icon: ImageVector,
+    60	        val sub: String? = null,
+    61	        val on: Boolean,
+    62	        val onToggle: (Boolean) -> Unit,
+    63	    ) : MoreRow
+    64	
+    65	    /** A disabled row: non-interactive, dimmed, shows [sub] (the design's "Configure AI provider first"). */
+    66	    data class Disabled(
+    67	        override val id: MoreActionId,
+    68	        override val label: String,
+    69	        override val icon: ImageVector,
+    70	        val sub: String,
+    71	        val onTap: () -> Unit,
+    72	    ) : MoreRow
+    73	}
+   225	        ReaderSheet.Details -> if (bookDetails != null) BookDetailsSheet(
+   226	            theme = theme,
+   227	            model = bookDetails,
+   228	            onCopyFingerprint = onCopyFingerprint,
+   229	            onShare = onShareBook,
+   230	            onDismiss = { openSheet(ReaderSheet.None) },
+   231	        )
+   232	        // feature #135 WI-6 — the Bookmarks route opens the SAME two-tab sheet with the Bookmarks tab
+   233	        // pre-selected (the designed [TocBookmarksSheet]; rule 51 — no invented list surface).
+   234	        ReaderSheet.Bookmarks -> TocBookmarksSheet(
+   235	            theme = theme,
+   236	            bookTitle = title,
+   237	            entries = tocEntries,
+   238	            currentTocIndex = currentTocIndex,
+   239	            bookmarks = bookmarks,
+   240	            onJumpToc = onJumpToc,
+   241	            onJumpBookmark = onJumpBookmark,
+   242	            onDismiss = { openSheet(ReaderSheet.None) },
+   243	            initialTab = TocTab.Bookmarks,
+   244	        )
+   245	    }
+   246	}
+   247	
+   248	/**
+   249	 * feature #134 WI-5 — the reader More-menu rows the scaffold + the EPUB chrome feed to the WI-3
+   250	 * [MorePopup]. #134 owns ONLY the Details + Share rows (the design's `vreader-more.jsx` `Book details` /
+   251	 * `Share book` actions); TTS / Auto-turn / Bilingual / Export are OTHER features' rows and are never
+   252	 * invented here (the §more-row-ownership contract + the #129 no-dead-control rule — the popup renders only
+   253	 * the rows it is given). Pure function of its two callbacks (no Compose runtime beyond the icon refs).
+   254	 */
+   255	internal fun readerMoreRows(onDetails: () -> Unit, onShare: () -> Unit): List<MoreRow> = listOf(
+   256	    MoreRow.Action(id = MoreActionId.DETAILS, label = "Book details", icon = Icons.Filled.Info, onTap = onDetails),
+   257	    MoreRow.Action(id = MoreActionId.SHARE, label = "Share book", icon = Icons.Filled.Share, onTap = onShare),
+   258	)
+
+codex
+The central parity check found a substantive gap: the plan invokes iOS’s `translatePreSegmented` divergence recovery, but no Android work item actually builds the corresponding service, cache-only restore, or prefetch API. I’m doing a final cross-check of work-item edges and acceptance criteria before issuing the severity-counted verdict.
+exec
+/bin/zsh -lc "nl -ba dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md | sed -n '28,90p'
+nl -ba dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md | sed -n '148,217p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt | sed -n '1,45p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt | sed -n '100,120p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt | sed -n '25,85p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+    28	
+    29	**Why both, not TXT/MD-only:** the honest thesis is that the *pipeline* (segment → chunk → translate → cache → interleave) is host-agnostic and fully built in v1; only the *render injection* is host-specific. EPUB is the format most users read, so shipping box D without it would under-deliver on the visible capability. TXT/MD are included because the Compose host is the cheapest, most testable place to prove the pipeline end-to-end (no WebView, deterministic tree assertions) — it de-risks the EPUB render adapter. This is not the box-B/E "one host and check the box" split; box D ships EPUB + TXT/MD together, with AZW3/PDF as tracked follow-ups. **Box D cannot be checked on the false "EPUB requires a fork" rationale** — that rationale is discarded.
+    30	
+    31	### New files
+    32	
+    33	**Pipeline / domain (host-agnostic, pure or coroutine — JVM-testable):**
+    34	
+    35	- `bilingual/TranslationUnitId.kt` — `data class TranslationUnitId(kind, value)` with `enum Kind { epubHref, foliateHref, txtChapterIndex, mdChapterIndex, pdfPageRange }`; `storageKey = "${kind.name}:$value"`. Mirrors iOS `TranslationUnitID.Kind` (verified: same five cases). v1 uses `epubHref` + `txtChapterIndex`/`mdChapterIndex`; others reserved so the cache-key format never breaks.
+    36	- `bilingual/TranslationGranularity.kt` — `enum { paragraph, sentence }`. (Design's Granularity segment.)
+    37	- `bilingual/BilingualLanguages.kt` — `BilingualLanguage(key, glyph, script)`; `BILINGUAL_LANGS` = the set from `vreader-bilingual.jsx` (`BILINGUAL_LANGS`) + `findOrDefault(key)`. Default `Chinese`.
+    38	- `bilingual/ChapterSegmenter.kt` — `paragraphs(text)` / `sentences(text)`. Port of iOS `ChapterSegmenter.paragraphs(in:)`/`sentences(in:)` (verified exists, CJK-aware via sentence enumeration).
+    39	- `bilingual/TranslationChunker.kt` — `chunk(segments, maxCharsPerChunk)` + `subSplit(text, maxChars)`. Port of iOS `ChapterTranslationChunker.chunk(...)` + `subSplit(...)` (verified: `chunk` returns `[[Int]]` index groups, oversize segment gets its own chunk; `subSplit` is the Bug #330 grapheme-safe over-budget splitter).
+    40	- `bilingual/TranslationChunkContract.kt` — `userPrompt(segments, targetLanguage, style)`; `decode(raw, expectedCount)` (strict JSON-array + code-fence strip); `sealed class DecodeError { NotAStringArray; CountMismatch(expected, actual) }`. Port of iOS `TranslationChunkContract` (verified: same `userPrompt`/`decode` shape, same two DecodeError cases).
+    41	- `bilingual/ChapterTextProvider.kt` — `interface { units(); sourceText(unit); unitContaining(locator); unitAfter(unit) }`. Resolution key is host-specific: TXT/MD key on `charOffsetUtf16` (Android `Locator` is offset-based there); EPUB keys on the current-resource `href` from `EpubNavigatorFragment.currentLocator`. Honest divergence from iOS's uniform Readium `Locator`, documented.
+    42	- `bilingual/TxtChapterTextProvider.kt` — provider over `TxtDocument` + chapter model. MD source = raw markdown chapter (translation renders as plain muted text, not re-markdown-rendered — matches the muted-secondary design line).
+    43	- `bilingual/EpubChapterTextProvider.kt` (WI-0-gated shape) — provider over the Readium `Publication` reading order; `units()` = spine hrefs, `unitContaining(locator)` = the locator's href. Its render-side collaborator (the JS enumerate/inject adapter) is defined by WI-0's findings, not pre-committed here.
+    44	- `bilingual/ChapterTranslationError.kt` — `sealed { Offline; TimedOut; ProviderFailed(msg); Cancelled }`. Maps from `AiError` (verified cases: `Auth401`, `RateLimited429`, `Offline`, `Timeout`, `Http(code)`, `Decode`, `Stream`, `InsecureUrl`, `Config`).
+    45	- `bilingual/ChapterTranslationService.kt` — `cachedTranslation(...)` (cache-only, no provider — #306 parity: a cached chapter renders even when AI is later unconfigured); `translate(...)` (segment → chunk → per-chunk `AiClient.chat` one-shot → `decode` → per-segment fallback → graceful per-chunk degrade (Bug #330 parity: a single failed chunk renders source-only and is NOT cached; all-chunks-fail throws) → cache-write only on full success). Uses `AiClient.chat(AiRequest)` (one-shot, NOT `streamChat`). Cancellation: `ensureActive()` between chunks AND immediately before the Room write (§6).
+    46	- `bilingual/ChapterTranslationPrefetcher.kt` — resolves the active profile from one `AiProviderStore.snapshot()` (`snapshot.active`), decrypts via `store.apiKey(profile)` (snapshot-consistent), builds an `AiClient` via an **injected factory param** (see the DI correction below), cache-first then translate. Throws `ChapterTranslationError`. Mirrors iOS `ChapterTranslationPrefetcher` (verified: iOS snapshots the active profile after a cache miss and is a Sendable struct capturing its collaborators).
+    47	- `bilingual/BilingualAiReadiness.kt` — `resolve(snapshot): Boolean` (active profile exists AND its decrypted key is non-empty). A cipher/decryption failure maps to **not-ready** (never crashes — §6), not to a thrown error. Drives the setup-sheet engine-strip configured/unconfigured state. Keep the gate to exactly what #118 enforces (no separate consent manager on Android — #118 has none; confirm during build).
+    48	
+    49	**State / persistence:**
+    50	
+    51	- `bilingual/PerBookBilingualStore.kt` — DataStore-Preferences, keyed by `bookFingerprintKey`, holding `{ enabled, targetLanguage, granularity }`. This is the Android `PerBookSettingsOverride` bilingual slice — the backup contract declares exactly `bilingualEnabled` / `bilingualTargetLanguage` / `bilingualGranularity` (verified in `PerBookSettings.swift` and the Android `BackupSectionsExtended.kt`), and **NO `bilingualStyle`** (verified — style is not a persisted per-book field on iOS either). So this store writes exactly those three fields. Wiring into backup collect/restore is scoped OUT (§7) — additive later, fields already in the contract; until then bilingual config is device-local.
+    52	- `bilingual/BilingualViewModel.kt` — `StateFlow<BilingualUiState>` with `enabled`, `targetLanguage`, `granularity`, `needsSetupSheet`, `aiConfigured`, `translationsByUnit`, `inFlightUnits`, `unavailableUnits`, `errorUnit`. Setters + `dismissSetupSheet`, `onPositionChanged(locator)`, `retryUnit(unit)`. Generation/epoch-guarded prefetch (current + next unit), cancellation on disable / language / granularity change — port of iOS `BilingualReadingViewModel` + `+Prefetch` (verified both exist). Split to `BilingualPrefetchController.kt` if it nears ~300 lines. (No `style` field — the authoritative sheet has no Style control; see §3.)
+    53	
+    54	**Room (translation cache):**
+    55	
+    56	- `data/ChapterTranslationEntity.kt` — `@Entity(tableName="chapter_translations", indices=[Index("bookKey")], foreignKeys=[FK→books.fingerprintKey ON DELETE CASCADE])`. **`@PrimaryKey val lookupKey: String`** (Room REQUIRES a primary key; a "unique index without a PK" does not compile — verified against `HighlightEntity`, which pairs a `@PrimaryKey` with a separate unique index). `lookupKey` = `bookKey|unitStorageKey|targetLanguage|promptVersion` (see the cache-identity correction below). Other columns: `bookKey`, `unitStorageKey`, `targetLanguage`, `promptVersion`, `translatedJson`, `sourceParagraphCount`, `createdAt`. Mirrors iOS `ChapterTranslationRecord.lookupKey` (verified: iOS key is `book|unit|lang|prompt`, profile-agnostic — Bug #342).
+    57	- `data/ChapterTranslationDao.kt` — `getByLookupKey(key)`, `@Upsert suspend fun upsert(row)` (Upsert identifies by PK = `lookupKey`, so it is a correct insert-or-replace by the cache identity), `deleteByLookupKey(key)`. The project's Room pattern is `@PrimaryKey` + `@Upsert` (verified: `BookDao.upsert`); making `lookupKey` the PK is exactly that pattern.
+    58	- `bilingual/ChapterTranslationStore.kt` — coroutine wrapper returning a Sendable `CachedTranslation` (segments decoded from JSON), keeping Room entities off the boundary (the `AnnotationsRepository`/`HighlightRecord`/iOS `ChapterTranslationStore` precedent).
+    59	
+    60	**Cache-identity correction (audit HIGH — reconciled with iOS parity):** the audit asked to add granularity + style as key columns. iOS deliberately does the opposite — `ChapterTranslationRecord.lookupKey` is `book|unit|lang|promptVersion` and is profile-AGNOSTIC / granularity-AGNOSTIC / style-agnostic (Bug #342's fix was to *remove* dimensions from the key). Style is folded into the prompt content; granularity is a read-time count-check. **Resolution honoring both the audit's concern and iOS parity:** keep the 4-part key, but make `promptVersion` an **effective composite** that encodes the result-shaping inputs, e.g. `promptVersion = "bilingual-v1|g=${granularity}|s=${style}"` (iOS uses the literal `"bilingual-v1"` today because iOS forces `.paragraph` for bilingual and pins one style; Android carries granularity/style in the promptVersion string so a change re-keys correctly). Style is not a v1 user control (the authoritative sheet has none — §3), so `s=` is a constant this version; granularity IS user-selectable, so `g=` is load-bearing (a paragraph vs sentence translation is a different cache row — this also closes the iOS #344 "sentence silently ignored" class by construction). **Additionally** (audit's cancellation half): a granularity change must cancel in-flight jobs, bump the VM generation, clear shaped in-memory `translationsByUnit`, and force a correctly-keyed re-fetch — specified in WI-6.
+    61	
+    62	**DI / factory correction (audit HIGH):** the audit is right that `AiProviderFactory` is NOT a lambda — verified it is an `object` with `create(profile: AiProviderProfile, apiKey: String, dispatcher: CoroutineDispatcher = Dispatchers.IO): AiClient`. So `ChapterTranslationPrefetcher` takes its OWN injected `clientFactory: (AiProviderProfile, String) -> AiClient` param **defaulting to `AiProviderFactory::create`** (production) and overridden with a fake in tests. The prefetcher builds the exact `AiRequest(model = profile.model, messages = …, temperature = profile.temperature, maxTokens = profile.maxTokens, system = …)` from the resolved profile (verified `AiRequest` fields).
+    63	
+    64	**AppContainer / navigation correction (audit HIGH — genuine gap, NOT stale state):** verified against the real code — `AppContainer` does **NOT** provide `AiProviderStore` today, and there is **NO live navigation route to `AiProviderListScreen`** (MainActivity has no NavHost; the screen + store + `AiSettingsViewModel` exist from #118 but are only exercised by instrumented/round-trip tests — #118 was VERIFIED via component tests + a live SSE socket round-trip, not an in-app nav route). There is no `#119` row. Consequences for #131:
+    65	- #131 **adds `AiProviderStore` to `AppContainer`** (lazy singleton: DataStore + `KeystoreSecretCipher`, the #116/#118 pattern) — the prefetcher + readiness need it and nothing provides it yet.
+    66	- The setup-sheet unconfigured engine strip's **"Set up" CTA target does not exist in the running app.** #131 does NOT invent an AI-provider settings screen or its navigation (that is box-F chrome / a #118 follow-on, and inventing it violates rule 51). Until a live route to `AiProviderListScreen` ships, the "Set up" affordance is **design-gated** — see §3's design-gate list. #131 can ship the bilingual sheet's *configured* path (a provider already set via the tested path) end-to-end; the *unconfigured → Set up* nav is a stated dependency, not #131 scope.
+    67	
+    68	**UI (Compose — every state depicted, reproducing `vreader-bilingual.jsx`):**
+    69	
+    70	- `bilingual/BilingualSetupSheet.kt` — reproduces `vreader-bilingual.jsx`'s `BilingualSetupSheet` EXACTLY: header Cancel / Translate; a **preview strip**; a **language grid** over `BILINGUAL_LANGS` (glyph tiles, selected accent); a **Granularity** segmented control (Paragraph "Translate after each ¶" / Sentence "Translate after each sentence"); a **Translation engine** strip (configured: "Claude · with this book's context" + "Change…"; unconfigured: "No AI provider configured" + "Set up"). **No Style control, no provider/model card, no term-overrides toggle, no cost footer** — those belong to the *other* (`vreader-ai-android.jsx`) sheet, which this plan does not reproduce (§3).
+    71	- `bilingual/BilingualInterlinearBody.kt` — per source chunk/paragraph: source `Text` then translation `Text` muted with accent left-border, `fontSize*0.88`, CJK font for cjk scripts, RTL handling for Arabic script. Consumes `translationsByUnit`. Loading state ("Translating chapter… N%" + per-paragraph dim — matches the design's chapter-level "38%"). Error state ("Couldn't translate" + Retry). Partial/offline (`unavailableUnits`): source-only silent fallback (design's original-always-kept guarantee — iOS Decision 2). This is the render surface for BOTH the TXT/MD Compose loop and (via the WI-0 adapter) the EPUB injection payload's Kotlin-side state.
+    72	- `bilingual/BilingualPill.kt` — the `EN ↔ 中` reader-**top-chrome** pill (per `vreader-reader.jsx` `ReaderTopChrome` + `vreader-bilingual.jsx` `BilingualPill`). Rendered by box F's top chrome; #131 provides the composable, box F wires it in (§4).
+    73	
+    74	### Modified files
+    75	
+    76	- `data/VReaderDatabase.kt` — add `ChapterTranslationEntity`, bump `version` (allocated version-at-slot; **v5 today** — verified, so v5→v6, but the number is set at the merge slot, not pre-assigned), add `MIGRATION_5_6` (CREATE TABLE + `bookKey` index + FK CASCADE, DDL exactly matching Room's generated schema), append `ALL_MIGRATIONS`, add `abstract fun chapterTranslationDao()`.
+    77	- `reader/TxtReaderActivity.kt` — own a `BilingualViewModel`; collect state; pass into `TxtBody`; on position change call `vm.onPositionChanged(...)`; render `BilingualInterlinearBody` output in the `items(count = document.chunkCount)` loop when bilingual is on and a translation exists (the confirmed injection point — verified it already interleaves highlight washes + TTS spans per chunk). Strictly gated to `originalFormat ∈ {txt, md}`; disabled = body byte-unchanged. **This file overlaps #129's TXT/MD WIs → gated on #129's FINAL merge (§4).**
+    78	- `reader/ReaderActivity.kt` (Readium EPUB) — WI-0-gated: attach the JS enumerate/inject adapter to `navigator.evaluateJavascript`, re-apply on href change / reflow, clear on teardown. Concrete surface defined by WI-0's spike output.
+    79	- `VReaderApp.kt` / `AppContainer` — **provide `AiProviderStore`** (new — see the AppContainer correction), `ChapterTranslationStore`, `PerBookBilingualStore`, and a `BilingualViewModel` factory. Mirrors #116/#118/#122 DI.
+    80	
+    81	**NOT modified (audit HIGH — Translate slot removed):** `reader/chrome/ReaderBottomChrome.kt` gets **no** bilingual/Translate slot. v1 wrongly added `onOpenBilingual` there; the design's entry is the More-menu toggle + the top-chrome pill (box F), NOT a bottom-chrome slot. `ReaderBottomChrome`'s existing `extraSlot` (the #129/#121 read-aloud entry) is untouched.
+    82	
+    83	### Files OUT of scope for v1
+    84	
+    85	- **`Azw3ReaderActivity.kt` / `reader/foliate/`** — foliate WebView interlinear IS feasible (JS enumerate+inject in the pinned bundle, mirroring iOS `FoliateBilingualOrchestrator`) but deferred to a follow-up (bundle-patch JS + secure-bridge additions touching the security-sensitive #126 surface). Once WI-0 proves the EPUB JS pipeline, the foliate host reuses it with a bundle adapter.
+    86	- **`PdfReaderActivity.kt`** — no reflowable text layer. Out (the `pdfPageRange` Kind is reserved only).
+    87	- **Live AI-provider settings navigation / the "Set up" destination screen** — box-F chrome / #118 follow-on; #131 does not invent it (rule 51). Design-gated dependency (§3).
+    88	- **Backup collect/restore of `PerBookSettingsOverride` bilingual fields** — contract fields exist; wiring is a small additive follow-up (§7). Bilingual config is device-local until then.
+    89	- **"Translate entire book…" batch, re-translate/style-swap picker, cost/token estimation, term-overrides** — iOS/`vreader-ai-android.jsx` extras not in the authoritative `vreader-bilingual.jsx` sheet. Out.
+    90	- **Streaming translation progress** — the design's "38%" is chapter-level N-of-M chunk progress (from the chunker count), not token streaming. v1 shows N-of-M.
+   148	## 4. Work-item sequencing
+   149	
+   150	Foundational WI-1..4 (no UI, JVM-testable); a spike WI-0 (EPUB); behavioral WI-5..9. Each WI = one PR.
+   151	
+   152	**Dependency notes (audit HIGH — v1's graph was wrong):**
+   153	- WI-3 depends on WI-1 (+2). WI-4 depends on WI-1+WI-3. WI-6 depends on WI-5. So WI-1..4 are NOT all independent — the graph below states the real edges.
+   154	- **`Deps: [feat:#134, feat:#132]`** (transitively #129, #118) — box F is not yet decomposed (per `docs/parity/android-checklist.md`, box F "likely splits into ≥2 features: TOC/bookmarks; find-in-book; more-menu/details/share"); **#132 = the top-chrome sub-feature, #134 = the More-menu sub-feature** are the prospective box-F IDs this plan reserves. **#131's UI entry-point WIs (the pill mount + the More-menu toggle wiring) cannot ship until box F provides those surfaces.** The pipeline + setup sheet + interlinear render (WI-0..7) are built ahead; only the entry wiring (part of WI-9) waits on box F.
+   155	- **Host-integration WIs are gated on #129's FINAL merge** — #129 owns `TxtReaderActivity`/`ReaderBottomChrome`; #131's `TxtReaderActivity` edit must land on top of #129's TXT/MD typography WIs (rule 48 one-writer-per-file).
+   156	
+   157	**WI-0 (spike): Readium EPUB bilingual injection.** The harness in §3 (enumerate / inject+clear / re-apply on reflow / pagination + count-divergence measurement). Output: a go/no-go on EPUB-in-v1 + the concrete `EpubChapterTextProvider` + injection-adapter surface. Deps: none (uses the existing #106 Readium host). Not TDD-gated (throwaway spike); its findings feed WI-7b's plan.
+   158	
+   159	**WI-1 (foundational): value types + pure segmentation/chunk/contract.** `TranslationUnitId`, `TranslationGranularity`, `BilingualLanguages`, `ChapterSegmenter`, `TranslationChunker`, `TranslationChunkContract`, `ChapterTranslationError`. Pure; ported iOS vectors. No Android deps. Deps: none.
+   160	
+   161	**WI-2 (foundational): Room translation cache.** `ChapterTranslationEntity` (PK = `lookupKey`) + `Dao` (`@Upsert`) + `ChapterTranslationStore`; `VReaderDatabase` migration (number at slot). Robolectric migration round-trip + upsert/get/delete-by-lookupKey + FK-CASCADE + exact-DDL guard. Deps: none.
+   162	
+   163	**WI-3 (foundational): `ChapterTranslationService`** against a fake `AiClient`. `cachedTranslation` (cache-only) + `translate` (per-chunk `chat`, per-segment decode-fail fallback, per-chunk graceful degrade, cancellation between chunks + before write, cache-write only on full success). Deps: **WI-1, WI-2**. Tests: cache hit → zero client calls; miss → translate + write; decode fail → per-segment fallback; one-chunk fail → source-only that chunk (others translated, NOT cached); all-chunks fail → throw; cancellation → `Cancelled` (no write); `AiError` mapping incl. `Config`/`InsecureUrl` → `ProviderFailed`.
+   164	
+   165	**WI-4 (foundational): `ChapterTextProvider` (TXT/MD) + `ChapterTranslationPrefetcher` + `BilingualAiReadiness`.** Provider slices per chapter from `TxtDocument`; `unitContaining`/`unitAfter`. Prefetcher resolves active profile from `snapshot()`, decrypts snapshot-consistent, builds client via the **injected factory param** (default `AiProviderFactory::create`), constructs `AiRequest` from the profile, cache-first then translate. Readiness = active profile with non-empty decrypted key; **cipher failure → not-ready, never a crash.** Fake store + fake factory. Deps: **WI-1, WI-3**. Tests: unit resolution + clamp + empty; cache-hit-no-profile still returns (#306); no-profile miss → `ProviderFailed`; readiness true/false; cipher-throw → readiness false (no crash).
+   166	
+   167	**WI-5 (behavioral): `PerBookBilingualStore` + `BilingualViewModel` state core.** Store per book (enabled/targetLanguage/granularity — no style); VM setters (persist + first-enable `needsSetupSheet`), language/granularity change clears cache-shaped state + bumps generation, the state fields. Turbine tests: first-enable raises sheet; re-enable persisted does not; disable clears; language change resets; granularity change resets + re-keys; round-trip through store. Deps: **WI-1** (+ store).
+   168	
+   169	**WI-6 (behavioral): VM prefetch trigger + generation/cancellation.** `onPositionChanged` derives current unit, dedupes, prefetches current+next; a **monotonic position-request sequence** checked after every suspension; **per-unit generation tokens**; a **captured language/granularity/provider snapshot per launch**; generation bumps on disable/language/granularity/unit-change discard stale; `CancellationException` handled BEFORE generic error mapping; `Offline`→`unavailableUnits`; transient failure leaves unit unfetched + clears anchor to retry; `retryUnit`. Fake prefetcher. Deps: **WI-4, WI-5**. Tests: current+next on unit change; same-unit no-op; cancel-mid discards stale; offline→unavailable; failure→retry-able; `retryUnit` re-fetches; granularity change cancels + re-fetches under the new key.
+   170	
+   171	**WI-7a (behavioral): Compose UI — setup sheet + interlinear body + pill.** Reproduce `vreader-bilingual.jsx` (setup sheet: language grid / granularity / preview / engine strip configured+unconfigured; body: translated / loading N%+dimmed / error+Retry / offline source-only; pill). Light+dark. Compose UI tests each state. Deps: **WI-5** (state shape). NO Style control; the unconfigured "Set up" CTA renders but its nav target is design-gated (§3).
+   172	
+   173	**WI-7b (behavioral): EPUB render adapter** (only if WI-0 = go). The JS enumerate/inject adapter + `EpubChapterTextProvider`, wired into `ReaderActivity`, driving `BilingualInterlinearBody` state from injected content. Deps: **WI-0, WI-3, WI-4, WI-7a**. Connected test on a real EPUB (seeded cache): enable → interlinear injects; disable → nodes cleared; reflow/href-change re-applies. (If WI-0 = no-go, this WI is dropped and box D ships TXT/MD-only, tracked.)
+   174	
+   175	**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into `TxtBody` loop + position-change + setup-sheet + DI (incl. adding `AiProviderStore` to `AppContainer`). `originalFormat`-gated (TXT/MD). **Gated on #129's final merge.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; disable → source-only byte-parity; reopen persists enabled + renders from cache with zero client calls. Deps: **WI-6, WI-7a, #129 final**.
+   176	
+   177	**WI-9 (behavioral): entry wiring + acceptance.** Mount `BilingualPill` in box F's top chrome; wire the More-menu bilingual toggle (box F) to the VM. **Gated on `feat:#132` (top chrome) + `feat:#134` (More menu).** Full acceptance pass across EPUB (if WI-7b landed) + TXT/MD. Flip box D note; update `docs/architecture.md` (bilingual pipeline + the new `chapter_translations` schema + `AiProviderStore` now in `AppContainer`). → DONE. Deps: **WI-8, WI-7b (if go), feat:#132, feat:#134**.
+   178	
+   179	## 5. Test catalogue
+   180	
+   181	JVM/Robolectric (`android/app/src/test/...bilingual/`): `ChapterSegmenterTest` (paragraph blank-line; sentence CJK 。！？ vs Latin; empty→[]; single); `TranslationChunkerTest` (packs to budget; oversize→own chunk+subSplit; empty→[]); `TranslationChunkContractTest` (prompt per style-constant; strict JSON decode; code-fence strip; count mismatch→`CountMismatch`; non-array→`NotAStringArray`); `ChapterTranslationServiceTest` (cache hit 0 calls; miss→translate→write; decode-fail per-segment fallback; one-chunk-fail partial-not-cached; all-fail→throw; cancellation→Cancelled no write; ensureActive-before-write; offline/timeout/429/http/config/insecure→error mapping; very long chapter N-of-M; stale-cache count-mismatch re-translates); `ChapterTranslationErrorMappingTest`; `TxtChapterTextProviderTest` (resolution; clamp-past-end; empty; unitAfter end→null); `ChapterTranslationPrefetcherTest` (snapshot-consistent profile+key; injected-factory used; `AiRequest` built from profile; cache-hit-no-profile #306; no-profile miss→ProviderFailed; CJK↔English + Latin round-trip via fake; cipher-throw→ProviderFailed not crash); `BilingualAiReadinessTest` (active+key→true; no active→false; empty key→false; **cipher-throw→false, no crash**); `PerBookBilingualStoreTest` (enabled/lang/granularity round-trip; no style field); `BilingualViewModelTest` (Turbine: first-enable sheet; re-enable no-sheet; disable clears; language reset; **granularity reset + re-key**; prefetch current+next; same-unit no-op; cancel-mid discards; offline→unavailable; error→errorUnit+retry; `retryUnit`; generation bump on style-N/A—granularity change).
+   182	
+   183	Room migration: `VReaderDatabaseMigrationTest` (extend) vPrev→vNext + full-chain + FK-CASCADE + `lookupKey`-as-PK; `ChapterTranslationDaoTest` (upsert-by-PK replaces; get/delete-by-lookupKey).
+   184	
+   185	Compose UI (`androidTest/...bilingual/`): `BilingualSetupSheetUiTest` (language grid, granularity, preview, engine configured vs unconfigured; **no Style control present**; light+dark); `BilingualInterlinearBodyUiTest` (translated incl. CJK font + RTL Arabic; loading N%+dimmed; error+Retry; offline source-only; empty translation→source-only no crash); `BilingualPillUiTest`.
+   186	
+   187	Connected (`androidTest/...reader/`): `TxtReaderBilingualConnectedTest` (API 35, fake `AiClient` via injected factory): enable→setup→confirm→interlinear from seeded Room cache; disable→source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; TXT/MD gated (PDF inert); very long chapter scroll responsive; cancellation leaves no partial cache row. `EpubReaderBilingualConnectedTest` (only if WI-0=go): enable→inject on a real EPUB; disable→clear; href-change→re-apply; count-divergence handled.
+   188	
+   189	Edge cases: empty translation, failed, partial per-chunk, CJK↔English + Latin + RTL, provider error/timeout/429/config/insecure, cancellation mid-translation + before-write, very long chapters, offline (cache-first + silent source-only), cipher-decrypt failure → not-ready (no crash).
+   190	
+   191	## 6. Risks + mitigations
+   192	
+   193	- **Live-translation verification is AI-credential-gated (the box-D caveat).** The whole pipeline is verified without live creds via a deterministic **fake `AiClient`** injected through the prefetcher's `clientFactory` param (default `AiProviderFactory::create`; tests override). WI-3/4/8 prove segment→chunk→decode→cache→interleave end-to-end incl. every error/edge path. The connected test seeds the Room cache directly and asserts render-from-cache with zero client calls (render path proven offline). **This mock/integration path is the box-D-required verification path** (the checklist states live translation is credential-gated); an optional live smoke confirms wire format but is NOT a gate.
+   194	- **Acceptance proves BOTH cache-render AND the live pipeline path (via the fake).** WI-8's connected test drives the full enable→translate(fake)→cache→render→reopen cycle, not just cache rendering — the fake stands in only for the network leaf.
+   195	- **EPUB JS-injection unknowns.** WI-0 de-risks before the render WI: pagination shift, fragment recreation wiping nodes, enumerate-vs-`ChapterSegmenter` count divergence (iOS #268). If a hard blocker appears, EPUB drops to a tracked follow-up (phasing fallback) with the specific spike reason — never the false "requires a fork."
+   196	- **Concurrency (audit HIGH — was under-specified).** WI-6 adds: a monotonic position-request sequence checked after every suspension; per-unit generation tokens; a captured language/granularity/provider snapshot per launch; cancellation on granularity change; `CancellationException` handled BEFORE generic error mapping; `ensureActive()` immediately before the Room write; cipher/decrypt failures mapped to unconfigured/provider-failure (never a crash). Snapshot-consistent profile+key pairing (from one `snapshot()`) is preserved.
+   197	- **Segment↔render count divergence** (iOS Bugs #268/#330/#344). TXT/MD segment through the SAME `ChapterSegmenter` on translate + render sides, so 1:1 pairing holds by construction; granularity is in the cache key so a paragraph row is never read as sentences. EPUB uses WI-0's finding (direct-block path if enumerate diverges — iOS `translatePreSegmented` parity).
+   198	- **Cost/latency of translating on scroll.** Lazy current+next prefetch + disk cache; N-of-M progress; cancellation on navigate-away/generation-bump.
+   199	- **Provider JSON non-compliance.** `TranslationChunkContract.decode` + per-segment fallback (iOS parity) — never drops a paragraph.
+   200	- **DataStore per-book key growth.** One Preferences entry per book keyed by fingerprint; scales like `ReaderSettingsStore`/`AiProviderStore`.
+   201	
+   202	## 7. Backward compat
+   203	
+   204	- **Room migration additive** (new `chapter_translations`, FK CASCADE, `lookupKey` PK). Existing rows untouched; migration + structural test guard it. Version number allocated at the merge slot (v5 today → v6).
+   205	- **Reader unchanged when bilingual off** — `TxtBody` render loop byte-identical unless `enabled && format∈{txt,md} && translation present`. `ReaderBottomChrome` is **not modified** (v1's Translate slot removed), so #129's chrome is unaffected. EPUB render adapter is inert unless bilingual is on.
+   206	- **#118 AI provider files unchanged** — the prefetcher/readiness are new consumers; the only #118-adjacent change is *wiring* `AiProviderStore` into `AppContainer` (which #118 left unwired — it was component/round-trip-verified, not nav-integrated).
+   207	- **Backup contract already compatible** — `PerBookSettingsOverride.bilingualEnabled/TargetLanguage/Granularity` exist (verified; **no `bilingualStyle`**), and there is **no translation-cache section** in `contracts/vectors/backup-sections.json` (verified — the cache is device-local, re-derivable). v1 introduces the store that writes the three fields locally; backup collect/restore of them is a small additive follow-up (no contract change), out of v1 scope; until then bilingual config is device-local (safe default). The `PerBookBilingualStore` is confirmed device-local; backup-collect/restore is the scoped-out follow-up.
+   208	
+   209	## Design gates (rule 51 — for `needs-design` filing)
+   210	
+   211	1. **"Bilingual mode" setup sheet with BOTH Style AND Granularity in one Android sheet** — `vreader-bilingual.jsx` depicts Granularity (no Style); `vreader-ai-android.jsx` depicts Style (no Granularity); no committed bundle shows both together. v1 reproduces the granularity-only `vreader-bilingual.jsx` sheet and DROPS Style. If Style is wanted as an Android user control, file `Design needed: bilingual setup sheet (Style + Granularity) for feature #131`. **This is the one open design gate for #131.**
+   212	2. **Dependency gate (not a #131 design gate, but blocks the "Set up" affordance)** — the setup sheet's unconfigured "Set up" CTA has no live nav destination (`AiProviderListScreen` is unreachable in-app today; no `#119`). #131 does not invent it (box-F chrome / #118 follow-on); the CTA renders but is wired only once that route ships.
+   213	
+   214	## Revision history
+   215	
+   216	- v1 (2026-07-10): Gate-1 draft (Plan agent). Gate-2 Codex audit pending.
+   217	- v2 (2026-07-11): Gate-2 round-1 REDESIGN resolved — Readium-feasibility corrected, entry-point rebased on box F, setup-sheet design-gated, DI/cache/concurrency fixed.
+     1	// Purpose: Room database + schema-versioned migration scaffold — feature #106 WI-3.
+     2	// Version 8 is the current schema; v1 was the initial books+positions baseline and
+     3	// MIGRATION_1_2 is the worked example of the additive-migration pattern (adds
+     4	// books.lastOpenedAt). Subsequent additive migrations: 2→3 daily_reading (#122),
+     5	// 3→4 annotations (#123), 4→5 collections (#127), 5→6 books.author (#128 search),
+     6	// 6→7 the FTS search index (search_sections + search_sections_fts + search_index_state
+     7	// + search_sections_staging, all #128 WI-4), 7→8 the composite UNIQUE (bookKey, profileKey)
+     8	// index on `bookmarks` — preceded by an in-migration dedupe of pre-existing duplicate rows so
+     9	// the unique index can't fail on a legacy duplicate (feature #135 WI-3). The migration round-trip
+    10	// test (VReaderDatabaseMigrationTest) guards them. Future schema changes append a
+    11	// Migration(n, n+1) to ALL_MIGRATIONS and bump `version`.
+    12	package com.vreader.app.data
+    13	
+    14	import android.content.Context
+    15	import androidx.room.Database
+    16	import androidx.room.Room
+    17	import androidx.room.RoomDatabase
+    18	import androidx.room.migration.Migration
+    19	import androidx.sqlite.db.SupportSQLiteDatabase
+    20	
+    21	@Database(
+    22	    entities = [
+    23	        BookEntity::class, ReadingPositionEntity::class, DailyReadingEntity::class,
+    24	        HighlightEntity::class, AnnotationNoteEntity::class, BookmarkEntity::class,
+    25	        CollectionEntity::class, BookCollectionCrossRef::class,
+    26	        SearchSectionEntity::class, SearchSectionFtsEntity::class,
+    27	        SearchIndexStateEntity::class, SearchStagingEntity::class,
+    28	    ],
+    29	    version = 8,
+    30	    exportSchema = true,
+    31	)
+    32	abstract class VReaderDatabase : RoomDatabase() {
+    33	    abstract fun bookDao(): BookDao
+    34	    abstract fun readingPositionDao(): ReadingPositionDao
+    35	    abstract fun readingStatsDao(): ReadingStatsDao
+    36	    abstract fun annotationDao(): AnnotationDao
+    37	    abstract fun collectionDao(): CollectionDao
+    38	    abstract fun searchDao(): SearchDao
+    39	
+    40	    companion object {
+    41	        private const val DB_NAME = "vreader.db"
+    42	
+    43	        /** v1 → v2: add the nullable `lastOpenedAt` recents column to `books`. */
+    44	        val MIGRATION_1_2: Migration = object : Migration(1, 2) {
+    45	            override fun migrate(db: SupportSQLiteDatabase) {
+   100	@OptIn(ExperimentalReadiumApi::class)
+   101	class ReaderActivity : AppCompatActivity() {
+   102	
+   103	    private val container get() = (application as VReaderApp).container
+   104	    private val repository: LibraryRepository get() = container.repository
+   105	    private val bridge = ReadiumLocatorBridge()
+   106	
+   107	    private val annotations: AnnotationsRepository get() = container.annotationsRepository
+   108	
+   109	    private var containerId: Int = 0
+   110	    private var navigator: EpubNavigatorFragment? = null
+   111	    private var publication: Publication? = null   // host-owned; closed in onDestroy
+   112	    private var book: Book? = null
+   113	
+   114	    // feature #132 WI-7-EPUB — the persistent chrome model the top/bottom bands + sheet layer collect,
+   115	    // populated as the async open completes and updated on every position change. The active Display
+   116	    // theme (also read by the chrome bands' colors) is mirrored so the ComposeViews can render immediately.
+   117	    private val chromeModel = MutableStateFlow(ReaderChromeModel())
+   118	    private val chromeTheme = mutableStateOf(ReaderTheme.Paper)
+   119	    // The hoisted top/bottom-visibility + open-sheet state (a Compose snapshot state, so the ComposeViews
+   120	    // recompose on change). Kept in-memory for the reader's lifetime (rotation always starts fresh — see
+    25	import kotlinx.coroutines.SupervisorJob
+    26	import kotlinx.coroutines.flow.map
+    27	import vreader.contracts.BookFormat
+    28	import java.io.File
+    29	
+    30	/** Process-wide singletons, lazily built. */
+    31	class AppContainer(context: Context) {
+    32	    private val appContext = context.applicationContext
+    33	
+    34	    val database: VReaderDatabase by lazy { VReaderDatabase.build(appContext) }
+    35	    val repository: LibraryRepository by lazy {
+    36	        LibraryRepository(database.bookDao(), database.readingPositionDao())
+    37	    }
+    38	    val importer: BookImporter by lazy {
+    39	        BookImporter(File(appContext.filesDir, "books"), repository)
+    40	    }
+    41	
+    42	    // feature #122 — reading-stats. The repository + the time tracker are process-singletons so a
+    43	    // reading session survives the (shorter-lived) reader ViewModel / rotation. ONE shared DateClock
+    44	    // so the dashboard's "today" and the tracker's bucket dates can't drift apart.
+    45	    private val dateClock: SystemDateClock by lazy { SystemDateClock() }
+    46	    val statsRepository: ReadingStatsRepository by lazy {
+    47	        ReadingStatsRepository(database.readingStatsDao(), repository, dateClock)
+    48	    }
+    49	    val readingTimeTracker: ReadingTimeTracker by lazy {
+    50	        ReadingTimeTracker(statsRepository, SystemElapsedClock(), dateClock)
+    51	    }
+    52	
+    53	    // feature #123 — annotations (EPUB highlights & notes). Process-singleton so the reader VM /
+    54	    // rotation share one instance (the statsRepository precedent).
+    55	    val annotationsRepository: AnnotationsRepository by lazy {
+    56	        AnnotationsRepository(database.annotationDao())
+    57	    }
+    58	
+    59	    // feature #127 — library collections. Process-singleton (the annotationsRepository precedent).
+    60	    val collectionRepository: com.vreader.app.data.CollectionRepository by lazy {
+    61	        com.vreader.app.data.CollectionRepository(database.collectionDao())
+    62	    }
+    63	
+    64	    // feature #129 — reader display settings. A device-local DataStore (the OpdsSourceStore /
+    65	    // AiProviderStore precedent), global (not per-book), process-singleton so a settings change
+    66	    // propagates to whatever reader is open. Stored under noBackupFilesDir — display prefs are
+    67	    // per-device (NOT in the backup contract), so they must be excluded from Android Auto Backup.
+    68	    private val readerSettingsDataStore: androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences> by lazy {
+    69	        androidx.datastore.preferences.core.PreferenceDataStoreFactory.create {
+    70	            File(appContext.noBackupFilesDir, "reader_settings.preferences_pb")
+    71	        }
+    72	    }
+    73	    val readerSettingsStore: com.vreader.app.reader.settings.ReaderSettingsStore by lazy {
+    74	        com.vreader.app.reader.settings.ReaderSettingsStore(readerSettingsDataStore)
+    75	    }
+    76	
+    77	    /** Process-lifetime scope for fire-and-forget writes that must outlive a screen
+    78	     *  (e.g. the reader's onStop position flush — it must finish even as the activity
+    79	     *  is being torn down). */
+    80	    val appScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    81	
+    82	    // feature #128 WI-5 — cross-book search index. The coordinator observes the library and
+    83	    // streams each indexable book (epub/txt/md) through the WI-3 extractors into WI-4's staging →
+    84	    // atomic publish. Eagerly started once from onCreate; pdf/azw3 map to null (never indexable).
+    85	    private val bookOpener: BookOpener by lazy { BookOpener(appContext) }
+
+exec
+/bin/zsh -lc "nl -ba dev-docs/designs/vreader-fidelity-v1/project/vreader-more.jsx | sed -n '82,105p'
+nl -ba dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx | sed -n '118,148p'
+nl -ba docs/parity/android-checklist.md | sed -n '82,89p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+    82	             active={s.ttsPlaying}
+    83	             on={() => onAction('tts')}/>
+    84	
+    85	        <Row icon={Icons.Timer} label="Auto-turn pages"
+    86	             sub={s.autoTurn ? `Every ${s.autoTurnInterval || 30}s` : 'Off'}
+    87	             toggle={s.autoTurn}
+    88	             active={s.autoTurn}
+    89	             on={() => onToggle('autoTurn')}/>
+    90	
+    91	        {s.aiUnavailable ? (
+    92	          <Row icon={Icons.Translate} label="Bilingual mode"
+    93	               sub="Configure AI provider first"
+    94	               disabled
+    95	               on={() => onAction('configure-ai')}/>
+    96	        ) : (
+    97	          <Row icon={Icons.Translate} label="Bilingual mode"
+    98	               sub={s.bilingual ? `English ↔ ${s.bilingualLang || 'Chinese'}` : 'Translate inline'}
+    99	               toggle={s.bilingual}
+   100	               active={s.bilingual}
+   101	               on={() => onToggle('bilingual')}/>
+   102	        )}
+   103	
+   104	        <Row divider/>
+   105	
+   118	                : 'rgba(0,0,0,0.08)',
+   119	              display: 'flex', alignItems: 'center', justifyContent: 'center',
+   120	              flexShrink: 0,
+   121	            }}>
+   122	              <Icons.Sparkle size={14} color={aiConfigured ? '#fff' : t.sub} stroke={2}/>
+   123	            </div>
+   124	            <div style={{ flex: 1, minWidth: 0 }}>
+   125	              <div style={{ fontSize: 13.5, color: t.ink, fontWeight: 600 }}>
+   126	                {aiConfigured ? 'Claude · with this book\'s context' : 'No AI provider configured'}
+   127	              </div>
+   128	              <div style={{ fontSize: 11.5, color: t.sub, marginTop: 1 }}>
+   129	                {aiConfigured
+   130	                  ? 'Translations cached per paragraph, one page ahead.'
+   131	                  : 'Bilingual mode needs an AI provider to translate.'}
+   132	              </div>
+   133	            </div>
+   134	            <button style={{
+   135	              padding: '5px 11px', borderRadius: 100, border: 'none',
+   136	              background: aiConfigured
+   137	                ? (t.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)')
+   138	                : t.accent,
+   139	              color: aiConfigured ? t.ink : '#fff',
+   140	              fontFamily: 'inherit', fontSize: 11.5, fontWeight: 600, cursor: 'pointer',
+   141	              flexShrink: 0,
+   142	            }}>{aiConfigured ? 'Change…' : 'Set up'}</button>
+   143	          </div>
+   144	        </div>
+   145	
+   146	        {/* CTA */}
+   147	        <button onClick={onClose} style={{
+   148	          width: '100%', marginTop: 22, padding: '14px 0', borderRadius: 14,
+    82	  done). Box C checks when BOTH #127 and #128 are VERIFIED — #127 ✓, #128 remains.**
+    83	
+    84	- [ ] **D. Bilingual interlinear reading** — interlinear original+translation rendering + the bilingual
+    85	  setup sheet (languages · provider · model · style), building on the #118 AI provider.
+    86	  Design: `vreader-ai-android.jsx` (BilingualReader/BilingualSetupSheet) + `vreader-bilingual.jsx`.
+    87	  Note: the pipeline + UI are buildable autonomously; LIVE translation verification is
+    88	  AI-credential-gated (a mock/integration path verifies the pipeline). iOS parity: #56/#100.
+    89	
+
+codex
+The Readium feasibility correction is valid: the local 3.3.0 AAR exists, and its transformed API JAR exposes public `evaluateJavascript(String, Continuation<? super String>)`, `getCurrentLocator()`, `firstVisibleElementLocator(...)`, and `submitPreferences(...)`. `ReaderActivity.navigator` also exists with the claimed concrete type. The #118 AI signatures and backup fields are otherwise accurately described.
+
+## Critical
+
+None.
+
+## High
+
+1. **TXT/MD pairing is based on a nonexistent chapter model and the proposed render boundary is not the segmentation boundary.**  
+   Plan: [§2 New files / Modified files](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:35), [WI-4](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:165), [§6 parity claim](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:197).
+
+   `TxtDocument` has line-based, maximum-4,000-character chunks only; it has no chapter model. `TxtMdTextExtractor` explicitly treats each chunk as a section because “TXT has no sub-resource grouping.” Meanwhile the plan proposes `txtChapterIndex` units and rendering one `BilingualInterlinearBody` inside each existing `items(document.chunkCount)` item. A chunk can contain multiple paragraphs or split a long paragraph, so this does not establish the claimed “same `ChapterSegmenter` on translate and render” 1:1 contract.
+
+   **Concrete fix:** define the real TXT/MD unit and render mapping. Either:
+
+   - use document-global units with segment ranges produced once by `ChapterSegmenter`, map every segment to its source UTF-16 range/chunk span, and render source/translation pairs from those same ranges; or
+   - introduce an explicitly specified chapter detector/model, including deterministic UTF-16 chapter ranges, and then segment each chapter identically on both paths.
+
+   Add tests for paragraphs spanning chunk boundaries, multiple paragraphs in one chunk, a >4,000-character paragraph, CR/LF/CRLF, MD markers, locator-to-unit mapping, and source-byte parity while disabled.
+
+2. **The mandatory EPUB count-divergence recovery is named but never implemented by a WI.**  
+   Plan: [WI-0 divergence decision](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:116), [WI-3 service API](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:163), [WI-7b](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:173), [§6 parity claim](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:197).
+
+   The plan says divergence adopts iOS’s `translatePreSegmented` path, but WI-3 builds only `cachedTranslation` and `translate`; WI-4 has no direct-block prefetch/cache API. The iOS parity path actually includes:
+
+   - `translatePreSegmented`
+   - cache write using the enumerated count
+   - cache-only restore by `expectedSegmentCount`
+   - direct-block prefetch without requiring a provider on a cache hit
+
+   Therefore `EpubReaderBilingualConnectedTest.count-divergence handled` has no planned implementation behind it.
+
+   **Concrete fix:** add those APIs and their cache semantics to WI-3/WI-4, with cancellation and partial-failure behavior matching iOS Bugs #268/#330/#343. Add direct-path cache-hit/reopen, mismatch replacement, partial-not-cached, all-failed, and zero-provider-call cache-restore tests.
+
+3. **A fresh-install user cannot configure AI, and an expressly open design/acceptance gate remains.**  
+   Plan: [AppContainer/navigation correction](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:64), [out-of-scope route](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:87), [Design gates](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:209).
+
+   The live app has no route to `AiProviderListScreen`. The committed More design disables the bilingual row when AI is unavailable, while the setup sheet’s “Set up” control also has no destination. Thus a normal fresh install cannot reach either provider configuration or the configured bilingual flow. In addition, the parity checklist still defines box D as including provider/model/style, while the plan drops Style and nevertheless has WI-9 flip box D to done.
+
+   **Concrete fix:** make a tracked, designed AI-settings navigation feature a hard dependency and verify `unconfigured → Configure/Set up → add provider → return → enable → translate`. Resolve the Style/Granularity design conflict before WI-9, or explicitly amend the authoritative checklist through a product/design decision; until then, do not mark #131 DONE or flip box D.
+
+## Medium
+
+1. **WI-0 lacks enforceable go/no-go thresholds and a navigator-operation race contract.**  
+   Plan: [WI-0 contract](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:116), [WI-0 work item](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:157).
+
+   “Stable,” “measure effects,” and “re-apply” do not define pass criteria. The plan also does not serialize `enumerate → translate → inject` against disable/clear, href changes, reflow, or teardown. A late inject can otherwise land after a clear.
+
+   **Concrete fix:** require WI-0 to prove, on a real EPUB:
+
+   - deterministic, idempotent enumeration and node IDs;
+   - no duplicate nodes after repeated application;
+   - clear wins over every older inject;
+   - href away/back, same-href `submitPreferences` reflow, internal page-fragment recreation, and activity recreation all restore from cache;
+   - locator/visible-source preservation across injection, with a stated permissible delta;
+   - an identified production re-apply signal for every tested recreation case.
+
+   Specify a single actor/mutex or monotonic navigator-session token, checks after every suspended JS/AI call, and cancellation/clear before publication teardown. Failure to find a deterministic re-apply signal must be an explicit no-go.
+
+2. **WI-7b incorrectly treats a Compose body as the EPUB render surface.**  
+   Plan: [BilingualInterlinearBody description](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:71), [WI-7b](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:173).
+
+   `BilingualInterlinearBody` cannot render inside Readium’s WebView. EPUB needs DOM node construction and CSS; it can share state/value types with Compose, but not the composable render body.
+
+   **Concrete fix:** define separate `EpubBilingualJs`/adapter and DOM-CSS styling, consuming a host-neutral state DTO. Test escaping, CSP-safe text insertion, RTL/CJK style, empty translations, loading cleanup, idempotent replacement, and source-only fallback. Remove the misleading WI-7a UI dependency unless it is needed only for shared state types.
+
+3. **The dependency graph does not make EPUB integration buildable in sequence.**  
+   Plan: [WI-6](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:169), [WI-7b dependencies](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:173), [WI-8 DI ownership](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:175).
+
+   WI-7b needs VM prefetch behavior from WI-6 but does not depend on it. It also wires `ReaderActivity` before the AppContainer services/factory that are assigned to WI-8.
+
+   **Concrete fix:** extract DI/factory wiring into an earlier shared WI, then make both host integrations depend on it and WI-6. A suitable order is foundation/cache → service/direct-block APIs → provider/DI → VM state/prefetch → host-specific renderers → entry wiring.
+
+4. **The Room schema baseline is stale and names a conflicting migration.**  
+   Plan: [Modified files](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:76), [Backward compatibility](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:204).
+
+   The live database is version 8, not 5; `MIGRATION_5_6` already belongs to feature #128. Implementing the named migration would conflict with existing history.
+
+   **Concrete fix:** state “allocate current→next at implementation time”; against this checkout that is 8→9, `MIGRATION_8_9`, append after `MIGRATION_7_8`, and extend the exported-schema/full-chain tests from version 8.
+
+## Low
+
+1. **The feature-dependency description is stale.**  
+   Plan: [§4 dependency notes](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:152).
+
+   #129, #132, and #134 are now VERIFIED, and the live More model already reserves `MoreActionId.BILINGUAL`.
+
+   **Concrete fix:** replace “prospective/not yet decomposed/waits on” language with the exact landed integration points and mark these dependencies satisfied.
+
+2. **The work-item count is internally ambiguous.**  
+   Plan: [§4 introduction](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:148).
+
+   WI-0, WI-1…6, WI-7a, WI-7b, WI-8, and WI-9 are eleven PR-sized items, not ten.
+
+   **Concrete fix:** state “11 WIs/PRs” and list the conditional EPUB WI clearly.
+
+**GATE-2 ROUND-2 VERDICT: FINDINGS (0 Critical, 3 High, 4 Medium)**
+tokens used
+157,631
+The Readium feasibility correction is valid: the local 3.3.0 AAR exists, and its transformed API JAR exposes public `evaluateJavascript(String, Continuation<? super String>)`, `getCurrentLocator()`, `firstVisibleElementLocator(...)`, and `submitPreferences(...)`. `ReaderActivity.navigator` also exists with the claimed concrete type. The #118 AI signatures and backup fields are otherwise accurately described.
+
+## Critical
+
+None.
+
+## High
+
+1. **TXT/MD pairing is based on a nonexistent chapter model and the proposed render boundary is not the segmentation boundary.**  
+   Plan: [§2 New files / Modified files](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:35), [WI-4](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:165), [§6 parity claim](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:197).
+
+   `TxtDocument` has line-based, maximum-4,000-character chunks only; it has no chapter model. `TxtMdTextExtractor` explicitly treats each chunk as a section because “TXT has no sub-resource grouping.” Meanwhile the plan proposes `txtChapterIndex` units and rendering one `BilingualInterlinearBody` inside each existing `items(document.chunkCount)` item. A chunk can contain multiple paragraphs or split a long paragraph, so this does not establish the claimed “same `ChapterSegmenter` on translate and render” 1:1 contract.
+
+   **Concrete fix:** define the real TXT/MD unit and render mapping. Either:
+
+   - use document-global units with segment ranges produced once by `ChapterSegmenter`, map every segment to its source UTF-16 range/chunk span, and render source/translation pairs from those same ranges; or
+   - introduce an explicitly specified chapter detector/model, including deterministic UTF-16 chapter ranges, and then segment each chapter identically on both paths.
+
+   Add tests for paragraphs spanning chunk boundaries, multiple paragraphs in one chunk, a >4,000-character paragraph, CR/LF/CRLF, MD markers, locator-to-unit mapping, and source-byte parity while disabled.
+
+2. **The mandatory EPUB count-divergence recovery is named but never implemented by a WI.**  
+   Plan: [WI-0 divergence decision](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:116), [WI-3 service API](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:163), [WI-7b](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:173), [§6 parity claim](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:197).
+
+   The plan says divergence adopts iOS’s `translatePreSegmented` path, but WI-3 builds only `cachedTranslation` and `translate`; WI-4 has no direct-block prefetch/cache API. The iOS parity path actually includes:
+
+   - `translatePreSegmented`
+   - cache write using the enumerated count
+   - cache-only restore by `expectedSegmentCount`
+   - direct-block prefetch without requiring a provider on a cache hit
+
+   Therefore `EpubReaderBilingualConnectedTest.count-divergence handled` has no planned implementation behind it.
+
+   **Concrete fix:** add those APIs and their cache semantics to WI-3/WI-4, with cancellation and partial-failure behavior matching iOS Bugs #268/#330/#343. Add direct-path cache-hit/reopen, mismatch replacement, partial-not-cached, all-failed, and zero-provider-call cache-restore tests.
+
+3. **A fresh-install user cannot configure AI, and an expressly open design/acceptance gate remains.**  
+   Plan: [AppContainer/navigation correction](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:64), [out-of-scope route](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:87), [Design gates](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:209).
+
+   The live app has no route to `AiProviderListScreen`. The committed More design disables the bilingual row when AI is unavailable, while the setup sheet’s “Set up” control also has no destination. Thus a normal fresh install cannot reach either provider configuration or the configured bilingual flow. In addition, the parity checklist still defines box D as including provider/model/style, while the plan drops Style and nevertheless has WI-9 flip box D to done.
+
+   **Concrete fix:** make a tracked, designed AI-settings navigation feature a hard dependency and verify `unconfigured → Configure/Set up → add provider → return → enable → translate`. Resolve the Style/Granularity design conflict before WI-9, or explicitly amend the authoritative checklist through a product/design decision; until then, do not mark #131 DONE or flip box D.
+
+## Medium
+
+1. **WI-0 lacks enforceable go/no-go thresholds and a navigator-operation race contract.**  
+   Plan: [WI-0 contract](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:116), [WI-0 work item](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:157).
+
+   “Stable,” “measure effects,” and “re-apply” do not define pass criteria. The plan also does not serialize `enumerate → translate → inject` against disable/clear, href changes, reflow, or teardown. A late inject can otherwise land after a clear.
+
+   **Concrete fix:** require WI-0 to prove, on a real EPUB:
+
+   - deterministic, idempotent enumeration and node IDs;
+   - no duplicate nodes after repeated application;
+   - clear wins over every older inject;
+   - href away/back, same-href `submitPreferences` reflow, internal page-fragment recreation, and activity recreation all restore from cache;
+   - locator/visible-source preservation across injection, with a stated permissible delta;
+   - an identified production re-apply signal for every tested recreation case.
+
+   Specify a single actor/mutex or monotonic navigator-session token, checks after every suspended JS/AI call, and cancellation/clear before publication teardown. Failure to find a deterministic re-apply signal must be an explicit no-go.
+
+2. **WI-7b incorrectly treats a Compose body as the EPUB render surface.**  
+   Plan: [BilingualInterlinearBody description](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:71), [WI-7b](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:173).
+
+   `BilingualInterlinearBody` cannot render inside Readium’s WebView. EPUB needs DOM node construction and CSS; it can share state/value types with Compose, but not the composable render body.
+
+   **Concrete fix:** define separate `EpubBilingualJs`/adapter and DOM-CSS styling, consuming a host-neutral state DTO. Test escaping, CSP-safe text insertion, RTL/CJK style, empty translations, loading cleanup, idempotent replacement, and source-only fallback. Remove the misleading WI-7a UI dependency unless it is needed only for shared state types.
+
+3. **The dependency graph does not make EPUB integration buildable in sequence.**  
+   Plan: [WI-6](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:169), [WI-7b dependencies](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:173), [WI-8 DI ownership](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:175).
+
+   WI-7b needs VM prefetch behavior from WI-6 but does not depend on it. It also wires `ReaderActivity` before the AppContainer services/factory that are assigned to WI-8.
+
+   **Concrete fix:** extract DI/factory wiring into an earlier shared WI, then make both host integrations depend on it and WI-6. A suitable order is foundation/cache → service/direct-block APIs → provider/DI → VM state/prefetch → host-specific renderers → entry wiring.
+
+4. **The Room schema baseline is stale and names a conflicting migration.**  
+   Plan: [Modified files](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:76), [Backward compatibility](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:204).
+
+   The live database is version 8, not 5; `MIGRATION_5_6` already belongs to feature #128. Implementing the named migration would conflict with existing history.
+
+   **Concrete fix:** state “allocate current→next at implementation time”; against this checkout that is 8→9, `MIGRATION_8_9`, append after `MIGRATION_7_8`, and extend the exported-schema/full-chain tests from version 8.
+
+## Low
+
+1. **The feature-dependency description is stale.**  
+   Plan: [§4 dependency notes](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:152).
+
+   #129, #132, and #134 are now VERIFIED, and the live More model already reserves `MoreActionId.BILINGUAL`.
+
+   **Concrete fix:** replace “prospective/not yet decomposed/waits on” language with the exact landed integration points and mark these dependencies satisfied.
+
+2. **The work-item count is internally ambiguous.**  
+   Plan: [§4 introduction](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:148).
+
+   WI-0, WI-1…6, WI-7a, WI-7b, WI-8, and WI-9 are eleven PR-sized items, not ten.
+
+   **Concrete fix:** state “11 WIs/PRs” and list the conditional EPUB WI clearly.
+
+**GATE-2 ROUND-2 VERDICT: FINDINGS (0 Critical, 3 High, 4 Medium)**

--- a/.claude/codex-audits/feat-131-bilingual-gate2-round3.md
+++ b/.claude/codex-audits/feat-131-bilingual-gate2-round3.md
@@ -1,0 +1,3405 @@
+Reading additional input from stdin...
+OpenAI Codex v0.144.1
+--------
+workdir: /Users/ll/workspace/vreader
+model: gpt-5.6-sol
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: high
+reasoning summaries: none
+session id: 019f5433-221d-7dc0-9e3b-562083919c41
+--------
+user
+Independent Gate-2 plan audit (ROUND 3) for feature #131 (Android bilingual interlinear reading, parity box D). Read the plan at dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md (v3) and verify its round-2-finding resolutions against the LIVE code.
+
+Round 2 raised: H1 (TXT/MD has no chapter model — the render/translate unit must be real), H2 (EPUB enumerate-vs-segment count divergence recovery), H3 (#136 AI-config-reachability spinout + Style descope), M1 (WI-0 needs enforceable go/no-go + a navigator-race contract), M2 (EPUB render is DOM-injection NOT a Compose body), M3 (the DI/factory WI must come before the host renderers), M4 (Room version is 8, next is 8->9). v3 claims all are resolved. VERIFY the resolutions against live code:
+
+1. TxtDocument (android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt): confirm it exposes ONLY text/chunkCount/offsetForChunk/chunkForOffset/textForChunk (line-based <=4000-char UTF-16 chunks) and has NO chapter/section model. Is the v3 'document-global segment ranges produced once by the segmenter, grouped into unit windows, render keyed by segment-range overlap of each chunk span' model SOUND and 1:1? Look hard for a case where a segment/translation could render twice or drop (paragraph spanning a chunk boundary; a >4000-char paragraph; overlap anchoring at the chunk where the range ENDS).
+2. Readium 3.3.0: confirm EpubNavigatorFragment.evaluateJavascript + getCurrentLocator are public in the resolved AAR and ReaderActivity.navigator holds an EpubNavigatorFragment?.
+3. Room: confirm data/VReaderDatabase.kt @Database version is currently 8 with MIGRATION_1_2..MIGRATION_7_8 in ALL_MIGRATIONS, so 8->9 + MIGRATION_8_9 is correct. Confirm @PrimaryKey + @Upsert is the project's DAO pattern (BookDao).
+4. #118 seam: confirm AiProviderStore.snapshot() (with .active + apiKey(profile)), AiProviderFactory.create(profile,apiKey,dispatcher), AiClient.chat(AiRequest): AiResponse, AiRequest fields (model/messages/temperature/maxTokens/system), and AiError cases exist as the plan names them.
+5. iOS parity source symbols exist (read vreader/Services/AI/): ChapterTranslationService.translatePreSegmented + cachedTranslation(expectedSegmentCount:), ChapterTranslationPrefetcher.translatedSegmentsDirect + cachedSegmentsDirect, ChapterSegmenter.sentenceRanges(in:), TranslationChunkContract, ChapterTranslationChunker.subSplit. The Android ports must match these contracts.
+6. NEW risks the v3 changes introduce (the segment-window model, the direct-block path, the DI reorder, WI-4b+WI-9 both gating on #136). Any concurrency hazard in the VM generation/cancellation design.
+7. Cohesion of the 11-WI split (WI-0 spike + WI-1..4a + WI-4b DI + WI-5/6 + WI-7a/7b + WI-8/9).
+
+Output findings grouped by severity (Critical / High / Medium / Low), each with file:line evidence, then a FINAL VERDICT line exactly one of: ship-as-is | follow-up-recommended | block-recommended. ship-as-is or follow-up-recommended clears Gate-2 round 3.
+codex
+I’ll perform this as a read-only independent audit: first establish repository state, then inspect the v3 plan, live Android/iOS symbols, and the resolved Readium artifact. I’ll report only evidence-backed findings and the exact verdict token requested.
+exec
+/bin/zsh -lc "git status -sb && wc -l dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md docs/architecture.md && sed -n '1,260p' dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md" in /Users/ll/workspace/vreader
+ succeeded in 528ms:
+## main...origin/main
+ M dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md
+ M docs/features.md
+?? .claude/codex-audits/feat-131-bilingual-gate2-round2.md
+?? .claude/codex-audits/feat-131-bilingual-gate2-round3.md
+?? .claude/codex-audits/feat-136-ai-provider-reachable-gate2.md
+?? android/2026-06-29-223908-this-session-is-being-continued-from-a-previous-c.txt
+?? dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md
+?? dev-docs/security/
+     240 dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md
+     726 docs/architecture.md
+     966 total
+# Feature #131 — Android Bilingual Interlinear Reading (parity-checklist box D)
+
+**Feature number assumption:** highest active row in `docs/features.md` is `#136`; `#131` is a landed `PLANNED` row (`GH: #1923`). The orchestrator adjusts if a row is claimed first.
+
+**Design authority (rule 51):** the **authoritative** bilingual surfaces are in `dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx` (`BilingualSetupSheet` / `BilingualPageContent` / `BilingualPill` / `BILINGUAL_LANGS`) and `.../vreader-reader.jsx` (`ReaderTopChrome` renders `BilingualPill`; the bilingual toggle is a More-menu row via `onMoreAction`) and `.../vreader-more.jsx` (the "Bilingual mode" More-menu Row toggle). `.../vreader-ai-android.jsx` contains a SECOND, differently-shaped `BilingualSetupSheet` — see §3's setup-sheet resolution for why this plan reproduces the `vreader-bilingual.jsx` sheet and design-gates the divergence. Where a surface is NOT depicted it is scoped out and flagged.
+
+**Status:** Gate-1 draft v3 (2026-07-12) — Gate-2 round-1 REDESIGN + round-2 findings resolved. Awaiting Gate-2 round-3 audit.
+
+## 1. Problem
+
+iOS ships bilingual interlinear reading (#56/#100): a per-book toggle renders each source paragraph followed by its translation in a muted style, backed by an AI provider, cached to disk. Android shipped the #118 AI provider foundation (provider store, OpenAI-compat + Anthropic SSE clients, chat/summary) but has **no bilingual capability**. Box D of the parity checklist requires the interlinear renderer + the bilingual setup sheet, building on #118.
+
+The engineering questions are (a) **which render host(s)** get true interlinear, (b) **what the real TXT/MD segmentation unit is** (there is no chapter model — round-2 H1), and (c) **where the entry point lives**. The render-host feasibility was settled in v2 (EPUB-primary via Readium `EpubNavigatorFragment.evaluateJavascript`; TXT/MD Compose; AZW3/PDF deferred) and was **CONFIRMED correct by the Gate-2 round-2 audit** — it is not revisited here. This v3 resolves the round-2 findings that concern *how* the pipeline maps to real code:
+
+- **Host** — EPUB is the **primary** target via `EpubNavigatorFragment.evaluateJavascript(script): String?` (public suspend method in the shipped Readium 3.3.0 AAR — round-2 re-verified: the transformed API JAR exposes `evaluateJavascript`, `getCurrentLocator()`, `firstVisibleElementLocator(...)`, `submitPreferences(...)`, and `ReaderActivity.navigator` holds the concrete `EpubNavigatorFragment?`). TXT/MD (Compose) are built alongside as the deterministic pipeline proof.
+- **TXT/MD unit (round-2 H1)** — `TxtDocument` has NO chapter model; it is line-based ≤4000-char chunks addressed by UTF-16 offset. The v2 "one `BilingualInterlinearBody` per `items(chunkCount)` chunk on `txtChapterIndex` units" mapping is **discarded**: it does not give a 1:1 segment↔render contract. v3 defines **document-global units with segment UTF-16 ranges produced ONCE by the segmenter** and renders source/translation pairs from those same ranges (§2, §3).
+- **Entry point** — the design puts the toggle in the **More-menu** (`vreader-more.jsx`; the live `MoreActionId.BILINGUAL` id is already reserved, and `MoreRow.Toggle` carries `on`/`onToggle`) + a **top-chrome pill** (`vreader-reader.jsx`). Both landed as box-F sub-features **#132 (top chrome) and #134 (More menu), now VERIFIED** — the entry wiring targets them directly (§4).
+
+## 2. Surface area
+
+### Render-host decision (settled in v2, CONFIRMED by round-2 — not reopened)
+
+**Two hosts, in dependency order:**
+
+1. **EPUB (Readium `EpubNavigatorFragment`) — PRIMARY.** Interlinear via `evaluateJavascript` (enumerate leaf blocks → inject translation DOM nodes → clear on teardown/reflow), mirroring iOS `EPUBBilingualOrchestrator`. Gated by **WI-0 (a Readium bilingual spike with enforceable go/no-go thresholds + a navigator-race contract — round-2 M1)** before the EPUB render WI (WI-7b) is built.
+2. **TXT/MD (Compose `TxtReaderActivity`) — INCLUDED.** No WebView; deterministically Compose-testable. Renders from **document-global segment ranges** (round-2 H1), NOT one body per chunk.
+
+**AZW3 (foliate WebView)** and **PDF** remain follow-ups / out (§"Files OUT of scope").
+
+**Why both, not TXT/MD-only:** the *pipeline* (segment → chunk → translate → cache → interleave) is host-agnostic; only the *render injection* is host-specific. EPUB is the format most users read, so shipping box D without it would under-deliver. TXT/MD are included because the Compose host is the cheapest, most testable place to prove the pipeline end-to-end (deterministic tree assertions), de-risking the EPUB adapter. **Box D cannot be checked on a false "EPUB requires a fork" rationale** — that rationale is discarded and stays discarded.
+
+### The TXT/MD segmentation unit + render mapping (round-2 H1 — the core v3 correction)
+
+**Verified against live code:** `TxtDocument` (in `reader/TxtDocument.kt`) exposes only `text: String`, `chunkCount`, `offsetForChunk(index)`, `chunkForOffset(offsetUtf16)`, `textForChunk(index)` — line-based ≤4000-char chunks over UTF-16 offsets against the RAW text (no line-ending normalization). It has **no chapter/section concept**. `TxtMdTextExtractor` (in `search/`) explicitly emits one section per chunk "because TXT has no sub-resource grouping." A chunk can hold multiple paragraphs OR split one long paragraph. So the v2 "translate per chunk, render one body per chunk" contract is not achievable.
+
+**v3 model — document-global units with segment ranges produced ONCE:**
+
+- The whole `.txt`/`.md` is treated as **one translation document**. The **segmenter runs once over `TxtDocument.text`** (the full raw backing string) and emits, per segment, its **`IntRange` UTF-16 span** against that same backing string (the segmenter's `paragraphRanges(text)` / `sentenceRanges(text)` — the range-returning peers of `paragraphs`/`sentences`; iOS precedent `ChapterSegmenter.sentenceRanges(in:)` returns `[Range<Int>]`). These ranges are the SINGLE source of truth used by BOTH the translate side and the render side, so the two segment identically **by construction** (they read the same array).
+- **Unit granularity for TXT/MD is the whole document, sub-batched for cache/prefetch by a deterministic "unit window."** To avoid translating a 14 MB book at once (and to keep cache rows bounded), segment ranges are grouped into fixed **unit windows** of contiguous segments (window size a constant, e.g. covering ≈ one on-screen span; the exact constant is set at build time and does not change the 1:1 contract). Each window is a `TranslationUnitId(kind = txtDocSegmentWindow, value = windowIndex)` — a document-global index, NOT a chunk index. `unitContaining(locator)` maps the reader's saved `charOffsetUTF16` → the segment whose range contains it → its window index (via a precomputed segment-start binary search, the same shape as `TxtDocument.chunkForOffset`). `unitAfter(unit)` = next window index or null at document end.
+- **Render mapping (the LazyColumn):** the TXT/MD body still iterates the existing `items(count = document.chunkCount, key = { it })` loop (verified injection point, TxtReaderActivity.kt:1043) for source layout/selection/highlight parity — **but bilingual interlinear content is keyed by SEGMENT RANGE, not by chunk.** For each rendered chunk `i` (source UTF-16 span `[offsetForChunk(i), offsetForChunk(i+1))`), the body looks up every segment whose range **overlaps** that chunk span and, after the source text of that segment's portion, renders its cached translation (muted) — from the SAME range array the translator used. A segment spanning two chunks contributes its translation once, anchored at the chunk where its range ends (deterministic), so a paragraph split across a chunk boundary is translated once and rendered once. When bilingual is OFF, the loop is byte-identical to today (translations are additive overlays only).
+- **MD source** = raw markdown segment text (translation renders as plain muted text, not re-markdown-rendered — matches the muted-secondary design line). Segmentation runs over the raw markdown string; MD markers are treated as ordinary characters by the paragraph splitter (blank-line delimited), consistent with `TxtMdTextExtractor` shipping raw markdown to search.
+
+This closes H1: there is no invented chapter model, the render boundary IS the segmentation boundary, and disabled = source byte-parity because bilingual content is a pure overlay off the shared range array.
+
+### New files
+
+**Pipeline / domain (host-agnostic, pure or coroutine — JVM-testable):**
+
+- `bilingual/TranslationUnitId.kt` — `data class TranslationUnitId(kind, value)` with `enum Kind { epubHref, foliateHref, txtDocSegmentWindow, mdDocSegmentWindow, pdfPageRange }`; `storageKey = "${kind.name}:$value"`. Mirrors iOS `TranslationUnitID.Kind` in spirit; the TXT/MD kinds are **document-global segment-window indices** (H1), NOT chunk indices. v3 uses `epubHref` + `txtDocSegmentWindow`/`mdDocSegmentWindow`; others reserved so the cache-key format never breaks. *(Assumption I could not fully confirm: iOS's exact Kind case names for the TXT/MD variants — the Android names are chosen to describe the real unit; the storageKey format is what the cache contract depends on.)*
+- `bilingual/TranslationGranularity.kt` — `enum { paragraph, sentence }`. (Design's Granularity control.)
+- `bilingual/BilingualLanguages.kt` — `BilingualLanguage(key, glyph, script)`; `BILINGUAL_LANGS` = the set from `vreader-bilingual.jsx` + `findOrDefault(key)`. Default `Chinese`.
+- `bilingual/ChapterSegmenter.kt` — **NEW file (there is no existing Android segmenter; the `search/` module has none — verified).** Port of iOS `ChapterSegmenter`: `paragraphs(text)` / `sentences(text)` **plus the range-returning peers `paragraphRanges(text): List<IntRange>` / `sentenceRanges(text): List<IntRange>`** (UTF-16 spans against the input string — iOS `sentenceRanges(in:)` precedent). The ranges are what H1's mapping consumes. CJK-aware sentence enumeration (。！？ vs Latin). Pure.
+- `bilingual/TranslationChunker.kt` — `chunk(segments, maxCharsPerChunk)` + `subSplit(text, maxChars)`. Port of iOS `ChapterTranslationChunker.chunk(...)` + `subSplit(...)` (verified: `chunk` returns index groups, oversize segment gets its own chunk; `subSplit` is the Bug #330 grapheme-safe over-budget splitter).
+- `bilingual/TranslationChunkContract.kt` — `userPrompt(segments, targetLanguage)`; `decode(raw, expectedCount)` (strict JSON-array + code-fence strip); `sealed class DecodeError { NotAStringArray; CountMismatch(expected, actual) }`. Port of iOS `TranslationChunkContract`. (No `style` param — Style is descoped v1, §3/H3.)
+- `bilingual/ChapterTextProvider.kt` — `interface { units(); sourceSegments(unit); sourceText(unit); unitContaining(locator); unitAfter(unit) }`. **`sourceSegments(unit)` returns the exact segment strings (from the shared range array)** — this is what the EPUB direct-block and TXT/MD paths both feed to the translator so counts pair 1:1. Resolution is host-specific: TXT/MD key on `charOffsetUTF16` → segment-window; EPUB keys on the current-resource `href` from `EpubNavigatorFragment.currentLocator`. Honest divergence from iOS's uniform Readium `Locator`, documented.
+- `bilingual/TxtChapterTextProvider.kt` — provider over `TxtDocument` + the segmenter's range array (H1). Builds the document-global segment ranges once, groups them into windows, resolves `unitContaining` via a segment-start binary search over `charOffsetUTF16`. MD source = raw markdown segment text.
+- `bilingual/EpubChapterTextProvider.kt` (WI-0-gated shape) — provider over the Readium `Publication` reading order; `units()` = spine hrefs, `unitContaining(locator)` = the locator's href, `sourceSegments(unit)` = the DOM-enumerated block texts (the render's OWN enumeration, for direct-block 1:1 — H2). Its render-side collaborator (the JS enumerate/inject adapter) is `EpubBilingualJs` (M2), defined by WI-0's findings.
+- `bilingual/ChapterTranslationError.kt` — `sealed { Offline; TimedOut; ProviderFailed(msg); Cancelled }`. Maps from `AiError` (verified cases: `Auth401`, `RateLimited429`, `Offline`, `Timeout`, `Http(code)`, `Decode`, `Stream`, `InsecureUrl`, `Config`).
+- `bilingual/ChapterTranslationService.kt` — the iOS-parity service, now with the **full divergence-recovery surface (round-2 H2)**:
+  - `cachedTranslation(bookKey, unit, sourceText, targetLanguage, granularity, acceptCountMismatch=false)` — cache-only, segments the source to count-check; serves a row only when `sourceParagraphCount == segments.size` (or `acceptCountMismatch`). No provider (#306 parity).
+  - `cachedTranslation(bookKey, unit, expectedSegmentCount, targetLanguage)` — **the divergence-fallback cache-only restore (iOS Bug #343)**: serves the canonical row only when its STORED `sourceParagraphCount == expectedSegmentCount` (the DOM enumerate's block count). **Needs no source text and no provider** → a cache-hit toggle/reopen restores with **zero provider calls**.
+  - `translate(bookKey, unit, sourceText, targetLanguage, providerProfile, granularity, bypassCacheRead=false)` — segment → chunk → per-chunk `AiClient.chat` one-shot → `decode` → per-segment fallback → per-chunk graceful degrade (Bug #330: a single failed chunk renders source-only for its segments and is NOT cached; all-chunks-fail throws) → cache-write only on full success. Cache row stores `sourceParagraphCount = segments.size`. Cancellation: `ensureActive()` between chunks AND immediately before the Room write (§6).
+  - `translatePreSegmented(bookKey, unit, segments, targetLanguage, providerProfile)` — **the count-divergence recovery (round-2 H2; iOS Bugs #268/#330/#343).** Takes the render's OWN enumerated block texts as `segments` (1:1 by construction), chunks them, translates with the same per-chunk graceful-degrade + cancellation contract, and — on full success only — **caches under the canonical key with the ENUMERATE's count as the stored contract** (so a later reopen restores via `cachedTranslation(expectedSegmentCount:)`). A partial degrade is NOT cached. A cache-write failure does not fail the translation.
+  - Uses `AiClient.chat(AiRequest)` (one-shot, verified — NOT `streamChat`).
+- `bilingual/ChapterTranslationPrefetcher.kt` — resolves the active profile from one `AiProviderStore.snapshot()` (`snapshot.active`), decrypts via `store.apiKey(profile)` (snapshot-consistent), builds an `AiClient` via an **injected factory param** (below), cache-first then translate. Adds the **direct-block peers (H2)**:
+  - `prefetch(unit)` — the plain-text path (segment source → `translate`).
+  - `prefetchDirect(unit, sourceSegments, targetLanguage)` — the divergence path (iOS `translatedSegmentsDirect`): same snapshot+resolve+error contract, then `service.translatePreSegmented(...)`.
+  - `cachedDirect(unit, expectedCount, targetLanguage)` — the **zero-provider cache-only restore** (iOS `cachedSegmentsDirect` → `cachedTranslation(expectedSegmentCount:)`): **returns a cached translation on a hit WITHOUT requiring an active provider** (the #306 pre-gate precedent). This is what backs `EpubReaderBilingualConnectedTest.count-divergence handled` cache-restore assertions.
+  - Throws `ChapterTranslationError`. Mirrors iOS `ChapterTranslationPrefetcher`.
+- `bilingual/BilingualAiReadiness.kt` — `resolve(snapshot): Boolean` (active profile exists AND its decrypted key is non-empty). A cipher/decryption failure maps to **not-ready** (never crashes — §6). Drives the setup-sheet engine-strip configured/unconfigured state. Keep the gate to exactly what #118 enforces (no separate consent manager on Android — #118 has none; confirm during build).
+
+**State / persistence:**
+
+- `bilingual/PerBookBilingualStore.kt` — DataStore-Preferences, keyed by `bookFingerprintKey`, holding `{ enabled, targetLanguage, granularity }`. This is the Android `PerBookSettingsOverride` bilingual slice — the backup contract declares exactly `bilingualEnabled` / `bilingualTargetLanguage` / `bilingualGranularity` and **NO `bilingualStyle`** (verified). So this store writes exactly those three fields. Wiring into backup collect/restore is scoped OUT (§7) — additive later; until then bilingual config is device-local.
+- `bilingual/BilingualViewModel.kt` — `StateFlow<BilingualUiState>` with `enabled`, `targetLanguage`, `granularity`, `needsSetupSheet`, `aiConfigured`, `translationsByUnit`, `inFlightUnits`, `unavailableUnits`, `errorUnit`. Setters + `dismissSetupSheet`, `onPositionChanged(locator)`, `retryUnit(unit)`. Generation/epoch-guarded prefetch (current + next unit), cancellation on disable / language / granularity change — port of iOS `BilingualReadingViewModel` + `+Prefetch`. Split to `BilingualPrefetchController.kt` if it nears ~300 lines. (No `style` field — the authoritative sheet has no Style control; Style is descoped v1 — §3.)
+
+**Room (translation cache):**
+
+- `data/ChapterTranslationEntity.kt` — `@Entity(tableName="chapter_translations", indices=[Index("bookKey")], foreignKeys=[FK→books.fingerprintKey ON DELETE CASCADE])`. **`@PrimaryKey val lookupKey: String`** (Room REQUIRES a PK; verified against `HighlightEntity`, which pairs a `@PrimaryKey` with a separate unique index). `lookupKey` = `bookKey|unitStorageKey|targetLanguage|promptVersion`. Other columns: `bookKey`, `unitStorageKey`, `targetLanguage`, `promptVersion`, `translatedJson`, `sourceParagraphCount`, `createdAt`. Mirrors iOS `ChapterTranslationRecord.lookupKey` (`book|unit|lang|prompt`, profile-agnostic — Bug #342). **`sourceParagraphCount` is load-bearing for H2**: it stores the enumerate's count on the `translatePreSegmented` path so `cachedTranslation(expectedSegmentCount:)` can restore.
+- `data/ChapterTranslationDao.kt` — `getByLookupKey(key)`, `@Upsert suspend fun upsert(row)` (Upsert identifies by PK = `lookupKey`, so it is insert-or-replace by cache identity), `deleteByLookupKey(key)`. The project's Room pattern is `@PrimaryKey` + `@Upsert` (verified: `BookDao.upsert`).
+- `bilingual/ChapterTranslationStore.kt` — coroutine wrapper returning a `CachedTranslation` (segments decoded from JSON), keeping Room entities off the boundary (the iOS `ChapterTranslationStore` precedent).
+
+**Cache-identity (reconciled with iOS parity):** the 4-part key `book|unit|lang|promptVersion` is profile-AGNOSTIC / style-agnostic (Bug #342). Style is descoped v1 (§3/H3) so no `s=` component exists. **Granularity IS user-selectable**, so it is carried in `promptVersion` as an **effective composite**: `promptVersion = "bilingual-v1|g=${granularity}"` (a paragraph vs sentence translation is a different cache row — this also closes the iOS #344 "sentence silently ignored" class by construction). A granularity change must cancel in-flight jobs, bump the VM generation, clear shaped in-memory `translationsByUnit`, and force a correctly-keyed re-fetch (specified in WI-6).
+
+**DI / factory (verified live):** `AiProviderFactory` is an `object` with `create(profile: AiProviderProfile, apiKey: String, dispatcher: CoroutineDispatcher = Dispatchers.IO): AiClient` (verified). So `ChapterTranslationPrefetcher` takes its OWN injected `clientFactory: (AiProviderProfile, String) -> AiClient` param **defaulting to `AiProviderFactory::create`** (production) and overridden with a fake in tests. The prefetcher builds `AiRequest(model = profile.model, messages = …, temperature = profile.temperature, maxTokens = profile.maxTokens, system = …)` from the resolved profile (verified `AiRequest` fields).
+
+**AI-provider reachability — spun out to #136 (round-2 H3; ORCHESTRATOR/USER DECISION):** verified against the live code — `AppContainer` does **NOT** provide `AiProviderStore`, and there is **NO live navigation route to `AiProviderListScreen`** (MainActivity has no NavHost; the #118 screen + store + `AiSettingsViewModel` exist but are only exercised by instrumented/round-trip tests). A fresh-install user therefore cannot reach provider config today. This gap is now owned by a **NEW separate tiny feature #136 (AI provider setup made production-reachable)** — a **HARD dependency of #131**. #136 delivers: the AI-provider-entry sheet/route, its production reachability, `AiProviderStore` wired into `AppContainer`, and its own Gate-5 acceptance (`unconfigured → Set up → add provider → return → enable → translate`). **#131 keeps only the wiring** of the bilingual "Set up translation" affordance → #136's AI-provider-entry sheet (WI-9's entry-wiring), and consumes `AiProviderStore` from `AppContainer` (provided by #136). #131 does NOT invent the AI-config sheet or its nav (rule 51). *(Assumption: #136 IS now a `docs/features.md` row — filed 2026-07-12 as GH #1976; #131's `Deps` reference it.)*
+
+**UI (Compose — every state depicted, reproducing `vreader-bilingual.jsx`):**
+
+- `bilingual/BilingualSetupSheet.kt` — reproduces `vreader-bilingual.jsx`'s `BilingualSetupSheet` EXACTLY: header Cancel / Translate; a **preview strip**; a **language grid** over `BILINGUAL_LANGS` (glyph tiles, selected accent); a **Granularity** segmented control (Paragraph "Translate after each ¶" / Sentence "Translate after each sentence"); a **Translation engine** strip (configured: "Claude · with this book's context" + "Change…"; unconfigured: "No AI provider configured" + "Set up"). **No Style control, no provider/model card, no term-overrides toggle, no cost footer** — those belong to the other (`vreader-ai-android.jsx`) sheet, which this plan does not reproduce (§3). The **"Set up" CTA routes to #136's AI-provider-entry sheet** (wired in WI-9); "Change…" routes there too.
+- `bilingual/BilingualInterlinearBody.kt` — **the Compose render surface for the TXT/MD host ONLY** (round-2 M2). Per source segment (from the shared range array): source `Text` then translation `Text` muted with accent left-border, `fontSize*0.88`, CJK font for cjk scripts, RTL handling for Arabic script. Consumes a **host-neutral bilingual state DTO** (see `BilingualRenderState` below). Loading state ("Translating chapter… N%" + per-segment dim). Error state ("Couldn't translate" + Retry). Partial/offline (`unavailableUnits`): source-only silent fallback (design's original-always-kept guarantee — iOS Decision 2). **This is NOT the EPUB render surface** — EPUB uses `EpubBilingualJs` DOM injection (M2 below).
+- `bilingual/BilingualRenderState.kt` — the **host-neutral state DTO** shared by BOTH the Compose body and the EPUB adapter (round-2 M2): per-unit `{ segments: List<String>?, phase: Loaded|Loading(fraction)|Error|SourceOnly }`. Compose reads it to compose `Text`; the EPUB adapter reads the SAME type to build DOM. Compose and EPUB share the **state/value types, NOT the composable body**.
+- `bilingual/EpubBilingualJs.kt` (WI-0-gated) — **the EPUB render surface (round-2 M2).** A pure Kotlin builder that, from a `BilingualRenderState` unit, produces the **JS strings** for `navigator.evaluateJavascript(...)`: (a) `enumScript` (enumerate current-resource leaf blocks → JSON `[{id,text}]`), (b) `injectScript(blockId, translationText)` (construct a translation DOM node after the block, CSP-safe: text set via `textContent`/`createTextNode`, never `innerHTML` string-concat; RTL/CJK via a class + injected `<style>`), (c) `clearScript()` (remove all injected nodes idempotently). Escaping is done in Kotlin (JSON-encode every interpolated string) so a translation containing quotes/`</script>`/newlines cannot break out. **No Compose here.** Consumes `BilingualRenderState`.
+- `bilingual/EpubBilingualController.kt` (WI-0-gated) — the runtime actor that serializes enumerate→translate→inject/clear against the navigator using WI-0's chosen mechanism (a single mutex OR a monotonic navigator-session token — M1); checks the session token after every suspended JS/AI call; clears BEFORE publication teardown; re-applies on the identified production re-apply signal (M1).
+- `bilingual/BilingualPill.kt` — the `EN ↔ 中` reader-**top-chrome** pill (per `vreader-reader.jsx` `ReaderTopChrome` + `vreader-bilingual.jsx` `BilingualPill`). Rendered by #132's top chrome; #131 provides the composable, #132's surface hosts it (§4).
+
+### Modified files
+
+- `data/VReaderDatabase.kt` — add `ChapterTranslationEntity` to `@Database entities`, bump `version` **8 → 9** (round-2 M4: the live DB is **v8**, migrations `MIGRATION_1_2`..`MIGRATION_7_8`; the number is allocated current→next **at implementation time** — against this checkout that is **8→9**), add **`MIGRATION_8_9`** (CREATE TABLE `chapter_translations` + `bookKey` index + FK→`books.fingerprintKey` CASCADE, DDL exactly matching Room's generated schema), **append `MIGRATION_8_9` to `ALL_MIGRATIONS` after `MIGRATION_7_8`**, add `abstract fun chapterTranslationDao()`. The translation-cache table is purely additive.
+- `reader/TxtReaderActivity.kt` — own a `BilingualViewModel`; collect state; render translations in the existing `items(count = document.chunkCount, key = { it })` loop (verified injection point, TxtReaderActivity.kt:1043) **keyed by segment range overlap (H1)**, not per chunk; on position change call `vm.onPositionChanged(canonicalLocator.charOffsetUTF16)`. Strictly gated to `originalFormat ∈ {txt, md}`; disabled = body byte-unchanged (overlay-only). **This file is owned by #129 (VERIFIED); #131's edit lands on top of it (rule 48 one-writer-per-file) — #129 is merged, so this is a straight edit, not a blocker.**
+- `reader/ReaderActivity.kt` (Readium EPUB) — WI-0-gated: attach `EpubBilingualController` to `navigator.evaluateJavascript`; re-apply on the identified production re-apply signal (M1); clear on teardown BEFORE publication teardown. Concrete surface defined by WI-0's spike output. `navigator: EpubNavigatorFragment?` is the verified live field.
+- `VReaderApp.kt` / `AppContainer` — **consume `AiProviderStore` (provided by #136), and provide** `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, and a `BilingualViewModel` factory. **Extracted into the shared DI WI (WI-4b, round-2 M3)** so both host integrations depend on it. Mirrors #116/#118/#122 DI. *(Note: `AiProviderStore`-into-`AppContainer` is #136's deliverable; #131's DI WI wires the bilingual services around it.)*
+
+**NOT modified:** `reader/chrome/ReaderBottomChrome.kt` gets **no** bilingual/Translate slot — the design's entry is the More-menu toggle (#134) + the top-chrome pill (#132), NOT a bottom-chrome slot. `ReaderBottomChrome`'s existing `extraSlot` is untouched.
+
+### Files OUT of scope for v1
+
+- **`Azw3ReaderActivity.kt` / `reader/foliate/`** — foliate WebView interlinear IS feasible (JS enumerate+inject in the pinned bundle) but deferred (bundle-patch JS + secure-bridge additions touching the security-sensitive #126 surface). Once WI-0 proves the EPUB JS pipeline, the foliate host reuses `EpubBilingualJs` with a bundle adapter.
+- **`PdfReaderActivity.kt`** — no reflowable text layer. Out (`pdfPageRange` Kind reserved only).
+- **The AI-provider setup sheet + its production reachability + `AiProviderStore` in `AppContainer`** — owned by **#136** (a hard dependency). #131 wires only the "Set up"/"Change…" affordance to #136's sheet.
+- **Backup collect/restore of `PerBookSettingsOverride` bilingual fields** — contract fields exist; wiring is a small additive follow-up (§7). Bilingual config is device-local until then.
+- **Style control** — descoped v1 (user decision, §3/H3). #131 keeps provider/model/**granularity**, DROPS the bilingual "Style" control.
+- **"Translate entire book…" batch, re-translate/style-swap picker, cost/token estimation, term-overrides** — iOS/`vreader-ai-android.jsx` extras not in the authoritative `vreader-bilingual.jsx` sheet. Out.
+- **Streaming translation progress** — the design's "38%" is chapter-level N-of-M chunk progress (from the chunker count), not token streaming. v1 shows N-of-M.
+
+## 3. Prior art / project precedent / rejected alternatives
+
+### The render-host decision (settled v2, CONFIRMED round-2)
+
+**How iOS does interlinear:** iOS renders EPUB/AZW3 in a WKWebView it fully controls. `EPUBBilingualOrchestrator` injects JS that (1) enumerates leaf blocks posting `[{bid,text}]` to Swift, (2) after translation injects a translation node after each block. TXT/MD render in a text path where the renderer interleaves translation runs. The mechanism = **the app inserts translation nodes between source nodes.**
+
+**Android EPUB feasibility (round-2 re-verified):** `javap`/the transformed API JAR on the resolved Readium 3.3.0 AAR expose public `evaluateJavascript(String, Continuation<? super String>)`, `getCurrentLocator()`, `firstVisibleElementLocator(...)`, `submitPreferences(...)`; `ReaderActivity.navigator: EpubNavigatorFragment?` holds the concrete fragment. So EPUB interlinear via JS injection is feasible with the public API — **no Readium fork.** The audit CONFIRMED this correction; it is not reopened.
+
+**WI-0 — Readium bilingual spike (gates WI-7b; round-2 M1 rewrote its contract into enforceable go/no-go thresholds):** a throwaway harness that, against a real EPUB on the emulator, must PROVE (each is a pass/no-go criterion):
+
+- **(a) Enumeration is deterministic + idempotent, with stable node IDs.** Enumerating the same current resource twice yields the same block IDs in the same order. Repeated `apply` produces **no duplicate injected nodes** (idempotent replacement).
+- **(b) Clear wins over every older inject.** Under a rapid enable→disable / navigate sequence, a late-arriving inject issued before a `clear` must NOT survive the clear — enforced by the serialization mechanism below (a late inject checks the session token and no-ops).
+- **(c) Recreation restores from cache** for every case: href away/back, same-href `submitPreferences` reflow, internal page-fragment recreation (the WebView pager recreates fragments), and activity recreation — each must re-apply the interlinear from the disk cache (via `cachedDirect(expectedCount)`, zero provider calls) with **an identified PRODUCTION re-apply signal** (a concrete navigator/lifecycle callback or `currentLocator`/fragment-lifecycle hook) for each case.
+- **(d) Locator / visible-source preservation across injection**, with a stated permissible delta (injecting content may shift pagination by ≤ a stated bound; the reader's saved position must map back to the same source block).
+- **(e) The enumerated block count vs the segmenter count** is measured; if they diverge (iOS #268), the **direct-block path** (`prefetchDirect` → `translatePreSegmented`, cached by enumerate count, restored by `cachedDirect(expectedCount)` — H2) is the recovery, proven end-to-end in the spike.
+
+**Race contract (M1):** WI-0 specifies **either a single actor/mutex OR a monotonic navigator-session token**; every suspended JS/AI call is followed by a token/mutex check; cancellation/clear runs BEFORE publication teardown. **If WI-0 cannot find a deterministic production re-apply signal for a recreation case (c), that is an explicit NO-GO:** EPUB drops to a tracked follow-up and box D ships **TXT/MD-only** — with the honest reason (a specific spike finding), never the false "requires a fork."
+
+**Rejected alternatives:**
+1. **Readium interlinear via decorations only** — REJECTED (decorations style existing text; they cannot insert translation paragraphs). `evaluateJavascript` makes injection possible, so EPUB uses the JS seam.
+2. **Forking Readium** — REJECTED + unnecessary (public `evaluateJavascript` seam exists).
+3. **AZW3 foliate host first** — REJECTED for v1 (deferred, not dead; touches the security-sensitive #126 bridge).
+4. **Eager whole-book pre-translation** — REJECTED (cost/latency). Lazily prefetch current+next + cache — port iOS.
+5. **One `BilingualInterlinearBody` per chunk (v2)** — REJECTED (round-2 H1): a chunk is not a segment. Replaced by document-global segment ranges (§2).
+6. **A Compose body as the EPUB render surface (v2)** — REJECTED (round-2 M2): Compose cannot render inside Readium's WebView. Replaced by `EpubBilingualJs` DOM injection sharing only the `BilingualRenderState` DTO.
+
+### The setup-sheet resolution (rule 51) + Style descope (round-2 H3, USER DECISION)
+
+There are **two committed, differently-shaped** `BilingualSetupSheet`s:
+- `vreader-bilingual.jsx` → **language grid + Granularity + preview strip + Translation-engine strip (Set up/Change) + Cancel/Translate**. **No Style, no provider/model card, no term-overrides, no cost.**
+- `vreader-ai-android.jsx` → **Languages (From/To) + Provider card + Style (Literal/Natural/Literary) + Keep-term-overrides toggle + cost footer.** **No language grid, no Granularity, no preview.**
+
+**Resolution:** this plan reproduces the **`vreader-bilingual.jsx` sheet EXACTLY** as the authoritative Android-native bilingual sheet. **Style is DESCOPED for v1** (user decision): #131 keeps provider/model/**granularity**, DROPS the bilingual "Style" control. Consequently the store/VM carry no `style`, the chunk contract has no `style` param, and the cache key's `promptVersion` has no `s=` component. Keep rule 51: only implement the designed surface.
+
+**Box-D parity note (H3 — do NOT claim full box-D parity):** the box-D parity checklist lists provider/model/**style**. Because Style is descoped v1, **WI-9 flips box D to done ONLY for provider/model/granularity + a descope note** — it does NOT claim full box-D parity. A **follow-up tracker/checklist amendment records the Style descope** (the plan does not silently drop it). If Style is later wanted on Android as a user control, that needs an **updated committed design** (a single sheet showing BOTH Style AND Granularity is not depicted anywhere — the one open design gate below).
+
+### Other precedents applied
+
+- **#118 provider seam**: reuse `AiProviderStore.snapshot()` (`snapshot.active`) + `store.apiKey(profile)` + `AiProviderFactory.create` (default of an injected factory param) + `AiClient.chat`. #118's AI files are unchanged; **#136** wires `AiProviderStore` into `AppContainer`; #131's DI WI wires the bilingual services.
+- **Room additive-migration pattern** (#122/#123/#127/#128/#135): version bump + `MIGRATION_n_(n+1)` appended to `ALL_MIGRATIONS` + exact-DDL + `VReaderDatabaseMigrationTest` PRAGMA guard. `@PrimaryKey` + `@Upsert` is the project's DAO pattern (`BookDao`). Baseline is **v8** (M4).
+- **DataStore JSON-in-Preferences** for `PerBookBilingualStore` (the `ReaderSettingsStore`/`AiProviderStore` pattern).
+- **Pure-logic port**: iOS `ChapterSegmenter`/`ChapterTranslationChunker`/`TranslationChunkContract`/`ChapterTranslationService.translatePreSegmented`/`ChapterTranslationPrefetcher.translatedSegmentsDirect`+`cachedSegmentsDirect` are pure/heavily-unit-tested — direct Kotlin ports with the same test vectors (all verified to exist).
+- **Entry point via #132/#134 (VERIFIED)**: the More-menu bilingual toggle (`MoreActionId.BILINGUAL` reserved; `MoreRow.Toggle` carries `on`/`onToggle`) + top-chrome pill are the landed integration points; #131 mounts the pill + wires the toggle (§4).
+
+## 4. Work-item sequencing
+
+**11 WIs/PRs (round-2 L2):** WI-0 (spike), WI-1..WI-4a (foundation/service), **WI-4b (shared DI/factory)**, WI-5, WI-6, WI-7a (Compose UI), **WI-7b (conditional EPUB render adapter — dropped if WI-0 = no-go)**, WI-8 (TXT/MD host integration), WI-9 (entry wiring + acceptance). Each WI = one PR. Build order (round-2 M3): **foundation/cache → service/direct-block APIs → shared DI/factory → VM state/prefetch → host-specific renderers (TXT/MD + EPUB) → entry wiring.**
+
+**Dependency notes (round-2 L1 — exact landed integration points):**
+- **`Deps: [feat:#136, feat:#132, feat:#134]`.** **#132 (top chrome) and #134 (More menu) are VERIFIED — dependencies satisfied** (the top-chrome host + `MoreActionId.BILINGUAL` toggle row are landed). **#129 (TXT/MD reader) is VERIFIED** — `TxtReaderActivity` is a straight edit, not a blocker. **#136 (AI provider setup made production-reachable) is the NEW hard blocker** for #131's entry-wiring (the "Set up"/"Change…" route) AND the DONE flip; it provides `AiProviderStore` in `AppContainer` and the reachable AI-config sheet. The live More model already reserves `MoreActionId.BILINGUAL` (verified).
+- The pipeline + setup sheet + interlinear render (WI-0..WI-7) are built ahead; only the **entry wiring (WI-9)** and the **DI WI (WI-4b, for `AiProviderStore` in `AppContainer`)** wait on #136. The pill mount (WI-9) targets #132's VERIFIED top chrome; the toggle wire (WI-9) targets #134's VERIFIED More menu.
+
+**WI-0 (spike): Readium EPUB bilingual injection — with enforceable go/no-go + race contract (M1).** The harness + criteria (a)–(e) and the race contract in §3. Output: a **go/no-go on EPUB-in-v1** (no-go if no deterministic production re-apply signal — box D ships TXT/MD-only, tracked) + the concrete `EpubChapterTextProvider` / `EpubBilingualJs` / `EpubBilingualController` surfaces. Deps: none (uses the existing #106 Readium host). Not TDD-gated (throwaway spike); its findings feed WI-7b.
+
+**WI-1 (foundational): value types + pure segmentation/chunk/contract.** `TranslationUnitId` (document-global TXT/MD kinds — H1), `TranslationGranularity`, `BilingualLanguages`, **`ChapterSegmenter` (with `paragraphRanges`/`sentenceRanges` — H1)**, `TranslationChunker`, `TranslationChunkContract` (no `style` — H3), `ChapterTranslationError`. Pure; ported iOS vectors. Deps: none.
+
+**WI-2 (foundational): Room translation cache.** `ChapterTranslationEntity` (PK = `lookupKey`, `sourceParagraphCount` column) + `Dao` (`@Upsert`) + `ChapterTranslationStore`; `VReaderDatabase` **8→9 `MIGRATION_8_9`** appended after `MIGRATION_7_8` (M4). Robolectric migration round-trip from **v8** + full-chain + upsert/get/delete-by-lookupKey + FK-CASCADE + exact-DDL guard. Deps: none.
+
+**WI-3 (foundational): `ChapterTranslationService`** against a fake `AiClient`. `cachedTranslation` (both overloads incl. the **`expectedSegmentCount` divergence restore — H2**) + `translate` + **`translatePreSegmented` (H2: chunk, per-chunk degrade, cancellation, cache-write with the enumerate count on full success only)**. Deps: **WI-1, WI-2**. Tests: cache hit → zero client calls; miss → translate + write; decode fail → per-segment fallback; one-chunk fail → source-only that chunk (others translated, NOT cached); all-chunks fail → throw; cancellation → `Cancelled` (no write); `AiError` mapping incl. `Config`/`InsecureUrl` → `ProviderFailed`; **`translatePreSegmented` full-success caches under the enumerate count; partial degrade NOT cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` returns on stored-count match, null on mismatch, needs no provider**.
+
+**WI-4a (foundational): `ChapterTextProvider` (TXT/MD) + `ChapterTranslationPrefetcher` + `BilingualAiReadiness`.** `TxtChapterTextProvider` builds the **document-global segment ranges once (H1)**, groups into windows, resolves `unitContaining(charOffsetUTF16)` via segment-start binary search, `sourceSegments(unit)`. Prefetcher: `prefetch` + **`prefetchDirect` + `cachedDirect` (zero-provider cache restore — H2)**; resolves active profile from `snapshot()`, decrypts snapshot-consistent, builds client via the **injected factory param** (default `AiProviderFactory::create`), constructs `AiRequest` from the profile. Readiness = active profile with non-empty decrypted key; **cipher failure → not-ready, never a crash.** Fake store + fake factory. Deps: **WI-1, WI-3**. Tests: unit resolution + clamp + empty; **paragraph spanning a chunk boundary → one segment/one unit; multiple paragraphs in one chunk → distinct segments; a >4000-char paragraph → one segment across chunks; CR/LF/CRLF; MD markers; locator→unit mapping; source-byte parity while disabled**; cache-hit-no-profile still returns (#306); no-profile miss → `ProviderFailed`; `prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls; readiness true/false; cipher-throw → readiness false (no crash).
+
+**WI-4b (foundational — shared DI/factory, round-2 M3): AppContainer bilingual services.** Extract the DI/factory wiring into this EARLIER shared WI: `AppContainer` provides `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, and the `BilingualViewModel` factory — **consuming `AiProviderStore` from `AppContainer` (provided by #136).** Both host integrations (WI-7b, WI-8) depend on this. Deps: **WI-4a, feat:#136** (for `AiProviderStore` in `AppContainer`). Tests: container resolves the bilingual graph; the prefetcher's injected factory defaults to `AiProviderFactory::create`.
+
+**WI-5 (behavioral): `PerBookBilingualStore` + `BilingualViewModel` state core.** Store per book (enabled/targetLanguage/granularity — no style); VM setters (persist + first-enable `needsSetupSheet`), language/granularity change clears cache-shaped state + bumps generation. Turbine tests: first-enable raises sheet; re-enable persisted does not; disable clears; language change resets; granularity change resets + re-keys; round-trip through store; no style field. Deps: **WI-1** (+ store).
+
+**WI-6 (behavioral): VM prefetch trigger + generation/cancellation.** `onPositionChanged(charOffsetUTF16)` derives current unit, dedupes, prefetches current+next; a **monotonic position-request sequence** checked after every suspension; **per-unit generation tokens**; a **captured language/granularity/provider snapshot per launch**; generation bumps on disable/language/granularity/unit-change discard stale; `CancellationException` handled BEFORE generic error mapping; `Offline`→`unavailableUnits`; transient failure leaves unit unfetched + clears anchor to retry; `retryUnit`. Fake prefetcher. Deps: **WI-4a, WI-4b, WI-5**. Tests: current+next on unit change; same-unit no-op; cancel-mid discards stale; offline→unavailable; failure→retry-able; `retryUnit` re-fetches; granularity change cancels + re-fetches under the new key.
+
+**WI-7a (behavioral): Compose UI — setup sheet + interlinear body (TXT/MD) + pill.** Reproduce `vreader-bilingual.jsx` (setup sheet: language grid / granularity / preview / engine strip configured+unconfigured; body: translated / loading N%+dimmed / error+Retry / offline source-only; pill). Consumes the **host-neutral `BilingualRenderState` DTO (M2)**. Light+dark. Compose UI tests each state. Deps: **WI-5** (state shape). NO Style control; the unconfigured "Set up" CTA renders and (in WI-9) routes to #136's sheet.
+
+**WI-7b (behavioral, CONDITIONAL — only if WI-0 = go): EPUB render adapter (DOM injection, NOT Compose — round-2 M2).** `EpubBilingualJs` (enum/inject/clear JS builders, CSP-safe escaping) + `EpubBilingualController` (the serialization actor / session token — M1) + `EpubChapterTextProvider`, wired into `ReaderActivity`, driving DOM from the **shared `BilingualRenderState` DTO**. **Depends on WI-6 (VM prefetch) and WI-4b (DI) — the M3 fix; the WI-7a UI dependency is REMOVED except for the shared `BilingualRenderState`/value types.** Uses `prefetchDirect`/`cachedDirect` for the count-divergence path (H2). Connected test on a real EPUB (seeded cache): enable → interlinear injects; disable → nodes cleared; reflow/href-change/fragment-recreation/activity-recreation → re-applies from cache (zero provider calls); count-divergence handled (direct path). Unit tests: JS escaping/CSP-safe text insertion, RTL/CJK style, empty translations, loading cleanup, idempotent replacement, source-only fallback. Deps: **WI-0, WI-3, WI-4a, WI-4b, WI-6, (shared types from WI-7a)**. (If WI-0 = no-go, this WI is dropped and box D ships TXT/MD-only, tracked.)
+
+**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into the `items(chunkCount)` loop **keyed by segment-range overlap (H1)** + position-change (`charOffsetUTF16`) + setup-sheet. `originalFormat`-gated (TXT/MD). Uses WI-4b's DI. **#129 is VERIFIED — straight edit.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; disable → source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; paragraph-spanning-chunk-boundary renders one translation. Deps: **WI-6, WI-7a, WI-4b**.
+
+**WI-9 (behavioral): entry wiring + acceptance.** Mount `BilingualPill` in **#132's VERIFIED top chrome**; wire the **#134 VERIFIED More-menu `MoreActionId.BILINGUAL` toggle** (`MoreRow.Toggle` `on`/`onToggle`) to the VM; **wire the setup sheet's "Set up"/"Change…" affordance → #136's AI-provider-entry sheet.** Full acceptance pass across EPUB (if WI-7b landed) + TXT/MD, including the fresh-user path `unconfigured → Set up (→ #136 sheet) → add provider → return → enable → translate` (the #136-owned reachability verified jointly). **Flip box D to done ONLY for provider/model/granularity + the Style-descope note (H3); file the follow-up checklist amendment; do NOT claim full box-D parity, do NOT flip DONE until #136 is landed.** Update `docs/architecture.md` (bilingual pipeline + the new `chapter_translations` schema + bilingual services in `AppContainer`). → DONE. Deps: **WI-8, WI-7b (if go), feat:#136, feat:#132, feat:#134**.
+
+## 5. Test catalogue
+
+JVM/Robolectric (`android/app/src/test/...bilingual/`): `ChapterSegmenterTest` (paragraph blank-line; sentence CJK 。！？ vs Latin; empty→[]; single; **`paragraphRanges`/`sentenceRanges` return correct UTF-16 spans**); `TranslationChunkerTest` (packs to budget; oversize→own chunk+subSplit; empty→[]); `TranslationChunkContractTest` (prompt shape; strict JSON decode; code-fence strip; count mismatch→`CountMismatch`; non-array→`NotAStringArray`); `ChapterTranslationServiceTest` (cache hit 0 calls; miss→translate→write; decode-fail per-segment fallback; one-chunk-fail partial-not-cached; all-fail→throw; cancellation→Cancelled no write; ensureActive-before-write; offline/timeout/429/http/config/insecure→error mapping; very long chapter N-of-M; stale-cache count-mismatch re-translates; **`translatePreSegmented` caches under enumerate count on full success; partial degrade not cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` hit/miss with no provider**); `ChapterTranslationErrorMappingTest`; `TxtChapterTextProviderTest` (**paragraph spanning chunk boundary → one segment/unit; multiple paragraphs in one chunk → distinct segments; >4000-char paragraph → one segment across chunks; CR/LF/CRLF; MD markers; locator→unit mapping; unitAfter end→null; source-byte parity while disabled**); `ChapterTranslationPrefetcherTest` (snapshot-consistent profile+key; injected-factory used; `AiRequest` built from profile; cache-hit-no-profile #306; no-profile miss→ProviderFailed; **`prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls**; CJK↔English + Latin round-trip via fake; cipher-throw→ProviderFailed not crash); `BilingualAiReadinessTest` (active+key→true; no active→false; empty key→false; **cipher-throw→false, no crash**); `PerBookBilingualStoreTest` (enabled/lang/granularity round-trip; no style field); `BilingualViewModelTest` (Turbine: first-enable sheet; re-enable no-sheet; disable clears; language reset; **granularity reset + re-key**; prefetch current+next; same-unit no-op; cancel-mid discards; offline→unavailable; error→errorUnit+retry; `retryUnit`); `EpubBilingualJsTest` (**JS escaping / CSP-safe text insertion; RTL/CJK style; empty translations; clear idempotent; inject idempotent replacement; source-only fallback** — WI-7b, if go).
+
+Room migration: `VReaderDatabaseMigrationTest` (extend) **v8→v9 + full-chain from v8** + FK-CASCADE + `lookupKey`-as-PK; `ChapterTranslationDaoTest` (upsert-by-PK replaces; get/delete-by-lookupKey).
+
+Compose UI (`androidTest/...bilingual/`): `BilingualSetupSheetUiTest` (language grid, granularity, preview, engine configured vs unconfigured; **no Style control present**; light+dark); `BilingualInterlinearBodyUiTest` (translated incl. CJK font + RTL Arabic; loading N%+dimmed; error+Retry; offline source-only; empty translation→source-only no crash); `BilingualPillUiTest`.
+
+Connected (`androidTest/...reader/`): `TxtReaderBilingualConnectedTest` (API 35, fake `AiClient` via injected factory): enable→setup→confirm→interlinear from seeded Room cache; disable→source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-chunk-boundary renders one translation**; TXT/MD gated (PDF inert); very long chapter scroll responsive; cancellation leaves no partial cache row. `EpubReaderBilingualConnectedTest` (only if WI-0=go): enable→inject on a real EPUB; disable→clear; href-change/fragment-recreation/activity-recreation→re-apply from cache (zero provider calls); **count-divergence handled via `prefetchDirect`/`cachedDirect`**.
+
+Edge cases: empty translation, failed, partial per-chunk, CJK↔English + Latin + RTL, provider error/timeout/429/config/insecure, cancellation mid-translation + before-write, very long chapters, offline (cache-first + silent source-only), cipher-decrypt failure → not-ready (no crash), enumerate↔segment count divergence (direct path).
+
+## 6. Risks + mitigations
+
+- **Live-translation verification is AI-credential-gated (the box-D caveat).** The whole pipeline is verified without live creds via a deterministic **fake `AiClient`** injected through the prefetcher's `clientFactory` param (default `AiProviderFactory::create`; tests override). WI-3/4a/8 prove segment→chunk→decode→cache→interleave end-to-end incl. every error/edge path. Connected tests seed the Room cache and assert render-from-cache with zero client calls (render path proven offline). This mock/integration path is the box-D-required verification path; an optional live smoke confirms wire format but is NOT a gate. **#136's Gate-5 covers the fresh-user `unconfigured → Set up → add provider` reachability leg.**
+- **TXT/MD segment↔render pairing (round-2 H1).** Both sides read the SAME segment range array (`paragraphRanges`/`sentenceRanges` over `TxtDocument.text`), so 1:1 holds by construction — no chapter model is invented, and a paragraph split across a chunk boundary is translated + rendered once. Granularity is in the cache key so a paragraph row is never read as sentences.
+- **EPUB count divergence (round-2 H2).** The direct-block path (`prefetchDirect` → `translatePreSegmented`, cached by enumerate count, restored by `cachedDirect(expectedCount)` with zero provider calls) is now implemented across WI-3/WI-4a and exercised by `EpubReaderBilingualConnectedTest.count-divergence handled` — iOS Bugs #268/#330/#343 parity.
+- **EPUB JS-injection race (round-2 M1).** WI-0's contract (single actor/mutex OR monotonic navigator-session token; token check after every suspended JS/AI call; clear before publication teardown; identified production re-apply signal per recreation case). No deterministic re-apply signal = explicit NO-GO → TXT/MD-only ship.
+- **EPUB render surface (round-2 M2).** EPUB uses `EpubBilingualJs` DOM injection (CSP-safe, Kotlin-escaped), NOT the Compose body; both share only the `BilingualRenderState` DTO.
+- **Concurrency.** WI-6: monotonic position-request sequence; per-unit generation tokens; captured language/granularity/provider snapshot per launch; cancellation on granularity change; `CancellationException` before generic error mapping; `ensureActive()` before the Room write; cipher/decrypt failures → not-ready (never a crash). Snapshot-consistent profile+key from one `snapshot()`.
+- **Cost/latency of translating on scroll.** Lazy current+next prefetch + disk cache; N-of-M progress; cancellation on navigate-away/generation-bump.
+- **Provider JSON non-compliance.** `TranslationChunkContract.decode` + per-segment fallback — never drops a paragraph.
+- **DataStore per-book key growth.** One Preferences entry per book keyed by fingerprint; scales like `ReaderSettingsStore`/`AiProviderStore`.
+- **#136 dependency risk.** #131's DONE flip + the "Set up" route + `AiProviderStore` in `AppContainer` all block on #136. #131's pipeline/UI (WI-0..WI-8 except WI-4b's DI) build ahead; WI-4b + WI-9 gate on #136.
+
+## 7. Backward compat
+
+- **Room migration additive (round-2 M4).** New `chapter_translations` (FK CASCADE, `lookupKey` PK, `sourceParagraphCount`). Existing rows untouched. Version allocated current→next at the merge slot; against this checkout **8→9, `MIGRATION_8_9`** appended after `MIGRATION_7_8`; migration test extended from **v8** guards it.
+- **Reader unchanged when bilingual off** — the TXT/MD `items(chunkCount)` loop is byte-identical unless `enabled && format∈{txt,md} && translation present` (bilingual content is a pure segment-range overlay). `ReaderBottomChrome` is not modified. EPUB render adapter is inert unless bilingual is on.
+- **#118 AI provider files unchanged** — the prefetcher/readiness are new consumers. **`AiProviderStore` into `AppContainer` is #136's change, not #131's**; #131's DI WI (WI-4b) wires the bilingual services around it.
+- **Backup contract already compatible** — `PerBookSettingsOverride.bilingualEnabled/TargetLanguage/Granularity` exist (verified; no `bilingualStyle`), and there is no translation-cache backup section (the cache is device-local, re-derivable). #131 writes the three fields locally; backup collect/restore is a small additive follow-up (no contract change), out of v1 scope; until then bilingual config is device-local.
+- **#132/#134/#129 landed** — the top-chrome pill mount + More-menu toggle + `TxtReaderActivity` edit land on VERIFIED surfaces (rule 48 one-writer-per-file is satisfied; #129 is merged).
+
+## Design gates (rule 51 — for `needs-design` filing)
+
+1. **"Bilingual mode" setup sheet with BOTH Style AND Granularity in one Android sheet** — `vreader-bilingual.jsx` depicts Granularity (no Style); `vreader-ai-android.jsx` depicts Style (no Granularity); no committed bundle shows both together. v1 reproduces the granularity-only `vreader-bilingual.jsx` sheet and **DROPS Style (user descope decision — §3/H3)**. If Style is wanted as an Android user control, file `Design needed: bilingual setup sheet (Style + Granularity) for feature #131`. **This is the one open design gate for #131.** The box-D Style parity gap is tracked by the WI-9 follow-up checklist amendment.
+2. **#136 dependency (not a #131 design gate)** — the setup sheet's "Set up"/"Change…" affordance routes to #136's AI-provider-entry sheet. #136 owns the sheet + its production reachability + `AiProviderStore` in `AppContainer`; #131 wires the affordance and consumes the store. #131 does not invent the AI-config sheet (rule 51).
+
+## Revision history
+
+- v1 (2026-07-10): Gate-1 draft (Plan agent). Gate-2 Codex audit pending.
+- v2 (2026-07-11): Gate-2 round-1 REDESIGN resolved — Readium-feasibility corrected, entry-point rebased on box F, setup-sheet design-gated, DI/cache/concurrency fixed.
+- v3 (2026-07-12) — Gate-2 round-2 findings resolved: TXT/MD document-global segment model (H1); EPUB translatePreSegmented + count-keyed cache + direct-block prefetch (H2); #136 AI-provider-reachability spun out as a hard dependency (filed GH #1976) + Style descoped v1 (H3, user decision); WI-0 go/no-go + navigator-race contract (M1); EPUB DOM-injection adapter not Compose body (M2); DI/factory WI reordered (M3); Room 8→9 MIGRATION_8_9 (M4); deps/WI-count corrected (L1/L2). Awaiting Gate-2 round-3 audit.
+
+## Notes on assumptions not fully confirmed against live code
+
+- The exact iOS `TranslationUnitID.Kind` case names for the TXT/MD variants — the Android `Kind` names (`txtDocSegmentWindow`/`mdDocSegmentWindow`) describe the real document-global unit. Only the `storageKey` string format is load-bearing for the cache contract, and that is preserved.
+- The unit-window size constant for TXT/MD sub-batching is left to build time (it does not affect the 1:1 segment↔render contract, only cache-row granularity/prefetch scope).
+
+exec
+/bin/zsh -lc 'rg -n "''^## 3|''^## 4|WI-0|navigator-race|go/no-go|segment range|anchored|overlap|#136|Style" dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md && nl -ba android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt && rg -n "class ReaderActivity|EpubNavigatorFragment|navigator|evaluateJavascript|getCurrentLocator" android/app/src/main/kotlin android/app/src/test android/app/src/androidTest --glob '"'*.kt' && rg -n \"@Database|version\\s*=|ALL_MIGRATIONS|MIGRATION_[0-9]+_[0-9]+|@Upsert|@PrimaryKey\" android/app/src/main/kotlin/com/vreader/app/data --glob '*.kt'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+3:**Feature number assumption:** highest active row in `docs/features.md` is `#136`; `#131` is a landed `PLANNED` row (`GH: #1923`). The orchestrator adjusts if a row is claimed first.
+25:1. **EPUB (Readium `EpubNavigatorFragment`) — PRIMARY.** Interlinear via `evaluateJavascript` (enumerate leaf blocks → inject translation DOM nodes → clear on teardown/reflow), mirroring iOS `EPUBBilingualOrchestrator`. Gated by **WI-0 (a Readium bilingual spike with enforceable go/no-go thresholds + a navigator-race contract — round-2 M1)** before the EPUB render WI (WI-7b) is built.
+26:2. **TXT/MD (Compose `TxtReaderActivity`) — INCLUDED.** No WebView; deterministically Compose-testable. Renders from **document-global segment ranges** (round-2 H1), NOT one body per chunk.
+36:**v3 model — document-global units with segment ranges produced ONCE:**
+39:- **Unit granularity for TXT/MD is the whole document, sub-batched for cache/prefetch by a deterministic "unit window."** To avoid translating a 14 MB book at once (and to keep cache rows bounded), segment ranges are grouped into fixed **unit windows** of contiguous segments (window size a constant, e.g. covering ≈ one on-screen span; the exact constant is set at build time and does not change the 1:1 contract). Each window is a `TranslationUnitId(kind = txtDocSegmentWindow, value = windowIndex)` — a document-global index, NOT a chunk index. `unitContaining(locator)` maps the reader's saved `charOffsetUTF16` → the segment whose range contains it → its window index (via a precomputed segment-start binary search, the same shape as `TxtDocument.chunkForOffset`). `unitAfter(unit)` = next window index or null at document end.
+40:- **Render mapping (the LazyColumn):** the TXT/MD body still iterates the existing `items(count = document.chunkCount, key = { it })` loop (verified injection point, TxtReaderActivity.kt:1043) for source layout/selection/highlight parity — **but bilingual interlinear content is keyed by SEGMENT RANGE, not by chunk.** For each rendered chunk `i` (source UTF-16 span `[offsetForChunk(i), offsetForChunk(i+1))`), the body looks up every segment whose range **overlaps** that chunk span and, after the source text of that segment's portion, renders its cached translation (muted) — from the SAME range array the translator used. A segment spanning two chunks contributes its translation once, anchored at the chunk where its range ends (deterministic), so a paragraph split across a chunk boundary is translated once and rendered once. When bilingual is OFF, the loop is byte-identical to today (translations are additive overlays only).
+54:- `bilingual/TranslationChunkContract.kt` — `userPrompt(segments, targetLanguage)`; `decode(raw, expectedCount)` (strict JSON-array + code-fence strip); `sealed class DecodeError { NotAStringArray; CountMismatch(expected, actual) }`. Port of iOS `TranslationChunkContract`. (No `style` param — Style is descoped v1, §3/H3.)
+56:- `bilingual/TxtChapterTextProvider.kt` — provider over `TxtDocument` + the segmenter's range array (H1). Builds the document-global segment ranges once, groups them into windows, resolves `unitContaining` via a segment-start binary search over `charOffsetUTF16`. MD source = raw markdown segment text.
+57:- `bilingual/EpubChapterTextProvider.kt` (WI-0-gated shape) — provider over the Readium `Publication` reading order; `units()` = spine hrefs, `unitContaining(locator)` = the locator's href, `sourceSegments(unit)` = the DOM-enumerated block texts (the render's OWN enumeration, for direct-block 1:1 — H2). Its render-side collaborator (the JS enumerate/inject adapter) is `EpubBilingualJs` (M2), defined by WI-0's findings.
+74:- `bilingual/PerBookBilingualStore.kt` — DataStore-Preferences, keyed by `bookFingerprintKey`, holding `{ enabled, targetLanguage, granularity }`. This is the Android `PerBookSettingsOverride` bilingual slice — the backup contract declares exactly `bilingualEnabled` / `bilingualTargetLanguage` / `bilingualGranularity` and **NO `bilingualStyle`** (verified). So this store writes exactly those three fields. Wiring into backup collect/restore is scoped OUT (§7) — additive later; until then bilingual config is device-local.
+75:- `bilingual/BilingualViewModel.kt` — `StateFlow<BilingualUiState>` with `enabled`, `targetLanguage`, `granularity`, `needsSetupSheet`, `aiConfigured`, `translationsByUnit`, `inFlightUnits`, `unavailableUnits`, `errorUnit`. Setters + `dismissSetupSheet`, `onPositionChanged(locator)`, `retryUnit(unit)`. Generation/epoch-guarded prefetch (current + next unit), cancellation on disable / language / granularity change — port of iOS `BilingualReadingViewModel` + `+Prefetch`. Split to `BilingualPrefetchController.kt` if it nears ~300 lines. (No `style` field — the authoritative sheet has no Style control; Style is descoped v1 — §3.)
+83:**Cache-identity (reconciled with iOS parity):** the 4-part key `book|unit|lang|promptVersion` is profile-AGNOSTIC / style-agnostic (Bug #342). Style is descoped v1 (§3/H3) so no `s=` component exists. **Granularity IS user-selectable**, so it is carried in `promptVersion` as an **effective composite**: `promptVersion = "bilingual-v1|g=${granularity}"` (a paragraph vs sentence translation is a different cache row — this also closes the iOS #344 "sentence silently ignored" class by construction). A granularity change must cancel in-flight jobs, bump the VM generation, clear shaped in-memory `translationsByUnit`, and force a correctly-keyed re-fetch (specified in WI-6).
+87:**AI-provider reachability — spun out to #136 (round-2 H3; ORCHESTRATOR/USER DECISION):** verified against the live code — `AppContainer` does **NOT** provide `AiProviderStore`, and there is **NO live navigation route to `AiProviderListScreen`** (MainActivity has no NavHost; the #118 screen + store + `AiSettingsViewModel` exist but are only exercised by instrumented/round-trip tests). A fresh-install user therefore cannot reach provider config today. This gap is now owned by a **NEW separate tiny feature #136 (AI provider setup made production-reachable)** — a **HARD dependency of #131**. #136 delivers: the AI-provider-entry sheet/route, its production reachability, `AiProviderStore` wired into `AppContainer`, and its own Gate-5 acceptance (`unconfigured → Set up → add provider → return → enable → translate`). **#131 keeps only the wiring** of the bilingual "Set up translation" affordance → #136's AI-provider-entry sheet (WI-9's entry-wiring), and consumes `AiProviderStore` from `AppContainer` (provided by #136). #131 does NOT invent the AI-config sheet or its nav (rule 51). *(Assumption: #136 IS now a `docs/features.md` row — filed 2026-07-12 as GH #1976; #131's `Deps` reference it.)*
+91:- `bilingual/BilingualSetupSheet.kt` — reproduces `vreader-bilingual.jsx`'s `BilingualSetupSheet` EXACTLY: header Cancel / Translate; a **preview strip**; a **language grid** over `BILINGUAL_LANGS` (glyph tiles, selected accent); a **Granularity** segmented control (Paragraph "Translate after each ¶" / Sentence "Translate after each sentence"); a **Translation engine** strip (configured: "Claude · with this book's context" + "Change…"; unconfigured: "No AI provider configured" + "Set up"). **No Style control, no provider/model card, no term-overrides toggle, no cost footer** — those belong to the other (`vreader-ai-android.jsx`) sheet, which this plan does not reproduce (§3). The **"Set up" CTA routes to #136's AI-provider-entry sheet** (wired in WI-9); "Change…" routes there too.
+94:- `bilingual/EpubBilingualJs.kt` (WI-0-gated) — **the EPUB render surface (round-2 M2).** A pure Kotlin builder that, from a `BilingualRenderState` unit, produces the **JS strings** for `navigator.evaluateJavascript(...)`: (a) `enumScript` (enumerate current-resource leaf blocks → JSON `[{id,text}]`), (b) `injectScript(blockId, translationText)` (construct a translation DOM node after the block, CSP-safe: text set via `textContent`/`createTextNode`, never `innerHTML` string-concat; RTL/CJK via a class + injected `<style>`), (c) `clearScript()` (remove all injected nodes idempotently). Escaping is done in Kotlin (JSON-encode every interpolated string) so a translation containing quotes/`</script>`/newlines cannot break out. **No Compose here.** Consumes `BilingualRenderState`.
+95:- `bilingual/EpubBilingualController.kt` (WI-0-gated) — the runtime actor that serializes enumerate→translate→inject/clear against the navigator using WI-0's chosen mechanism (a single mutex OR a monotonic navigator-session token — M1); checks the session token after every suspended JS/AI call; clears BEFORE publication teardown; re-applies on the identified production re-apply signal (M1).
+101:- `reader/TxtReaderActivity.kt` — own a `BilingualViewModel`; collect state; render translations in the existing `items(count = document.chunkCount, key = { it })` loop (verified injection point, TxtReaderActivity.kt:1043) **keyed by segment range overlap (H1)**, not per chunk; on position change call `vm.onPositionChanged(canonicalLocator.charOffsetUTF16)`. Strictly gated to `originalFormat ∈ {txt, md}`; disabled = body byte-unchanged (overlay-only). **This file is owned by #129 (VERIFIED); #131's edit lands on top of it (rule 48 one-writer-per-file) — #129 is merged, so this is a straight edit, not a blocker.**
+102:- `reader/ReaderActivity.kt` (Readium EPUB) — WI-0-gated: attach `EpubBilingualController` to `navigator.evaluateJavascript`; re-apply on the identified production re-apply signal (M1); clear on teardown BEFORE publication teardown. Concrete surface defined by WI-0's spike output. `navigator: EpubNavigatorFragment?` is the verified live field.
+103:- `VReaderApp.kt` / `AppContainer` — **consume `AiProviderStore` (provided by #136), and provide** `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, and a `BilingualViewModel` factory. **Extracted into the shared DI WI (WI-4b, round-2 M3)** so both host integrations depend on it. Mirrors #116/#118/#122 DI. *(Note: `AiProviderStore`-into-`AppContainer` is #136's deliverable; #131's DI WI wires the bilingual services around it.)*
+109:- **`Azw3ReaderActivity.kt` / `reader/foliate/`** — foliate WebView interlinear IS feasible (JS enumerate+inject in the pinned bundle) but deferred (bundle-patch JS + secure-bridge additions touching the security-sensitive #126 surface). Once WI-0 proves the EPUB JS pipeline, the foliate host reuses `EpubBilingualJs` with a bundle adapter.
+111:- **The AI-provider setup sheet + its production reachability + `AiProviderStore` in `AppContainer`** — owned by **#136** (a hard dependency). #131 wires only the "Set up"/"Change…" affordance to #136's sheet.
+113:- **Style control** — descoped v1 (user decision, §3/H3). #131 keeps provider/model/**granularity**, DROPS the bilingual "Style" control.
+117:## 3. Prior art / project precedent / rejected alternatives
+125:**WI-0 — Readium bilingual spike (gates WI-7b; round-2 M1 rewrote its contract into enforceable go/no-go thresholds):** a throwaway harness that, against a real EPUB on the emulator, must PROVE (each is a pass/no-go criterion):
+133:**Race contract (M1):** WI-0 specifies **either a single actor/mutex OR a monotonic navigator-session token**; every suspended JS/AI call is followed by a token/mutex check; cancellation/clear runs BEFORE publication teardown. **If WI-0 cannot find a deterministic production re-apply signal for a recreation case (c), that is an explicit NO-GO:** EPUB drops to a tracked follow-up and box D ships **TXT/MD-only** — with the honest reason (a specific spike finding), never the false "requires a fork."
+140:5. **One `BilingualInterlinearBody` per chunk (v2)** — REJECTED (round-2 H1): a chunk is not a segment. Replaced by document-global segment ranges (§2).
+143:### The setup-sheet resolution (rule 51) + Style descope (round-2 H3, USER DECISION)
+146:- `vreader-bilingual.jsx` → **language grid + Granularity + preview strip + Translation-engine strip (Set up/Change) + Cancel/Translate**. **No Style, no provider/model card, no term-overrides, no cost.**
+147:- `vreader-ai-android.jsx` → **Languages (From/To) + Provider card + Style (Literal/Natural/Literary) + Keep-term-overrides toggle + cost footer.** **No language grid, no Granularity, no preview.**
+149:**Resolution:** this plan reproduces the **`vreader-bilingual.jsx` sheet EXACTLY** as the authoritative Android-native bilingual sheet. **Style is DESCOPED for v1** (user decision): #131 keeps provider/model/**granularity**, DROPS the bilingual "Style" control. Consequently the store/VM carry no `style`, the chunk contract has no `style` param, and the cache key's `promptVersion` has no `s=` component. Keep rule 51: only implement the designed surface.
+151:**Box-D parity note (H3 — do NOT claim full box-D parity):** the box-D parity checklist lists provider/model/**style**. Because Style is descoped v1, **WI-9 flips box D to done ONLY for provider/model/granularity + a descope note** — it does NOT claim full box-D parity. A **follow-up tracker/checklist amendment records the Style descope** (the plan does not silently drop it). If Style is later wanted on Android as a user control, that needs an **updated committed design** (a single sheet showing BOTH Style AND Granularity is not depicted anywhere — the one open design gate below).
+155:- **#118 provider seam**: reuse `AiProviderStore.snapshot()` (`snapshot.active`) + `store.apiKey(profile)` + `AiProviderFactory.create` (default of an injected factory param) + `AiClient.chat`. #118's AI files are unchanged; **#136** wires `AiProviderStore` into `AppContainer`; #131's DI WI wires the bilingual services.
+161:## 4. Work-item sequencing
+163:**11 WIs/PRs (round-2 L2):** WI-0 (spike), WI-1..WI-4a (foundation/service), **WI-4b (shared DI/factory)**, WI-5, WI-6, WI-7a (Compose UI), **WI-7b (conditional EPUB render adapter — dropped if WI-0 = no-go)**, WI-8 (TXT/MD host integration), WI-9 (entry wiring + acceptance). Each WI = one PR. Build order (round-2 M3): **foundation/cache → service/direct-block APIs → shared DI/factory → VM state/prefetch → host-specific renderers (TXT/MD + EPUB) → entry wiring.**
+166:- **`Deps: [feat:#136, feat:#132, feat:#134]`.** **#132 (top chrome) and #134 (More menu) are VERIFIED — dependencies satisfied** (the top-chrome host + `MoreActionId.BILINGUAL` toggle row are landed). **#129 (TXT/MD reader) is VERIFIED** — `TxtReaderActivity` is a straight edit, not a blocker. **#136 (AI provider setup made production-reachable) is the NEW hard blocker** for #131's entry-wiring (the "Set up"/"Change…" route) AND the DONE flip; it provides `AiProviderStore` in `AppContainer` and the reachable AI-config sheet. The live More model already reserves `MoreActionId.BILINGUAL` (verified).
+167:- The pipeline + setup sheet + interlinear render (WI-0..WI-7) are built ahead; only the **entry wiring (WI-9)** and the **DI WI (WI-4b, for `AiProviderStore` in `AppContainer`)** wait on #136. The pill mount (WI-9) targets #132's VERIFIED top chrome; the toggle wire (WI-9) targets #134's VERIFIED More menu.
+169:**WI-0 (spike): Readium EPUB bilingual injection — with enforceable go/no-go + race contract (M1).** The harness + criteria (a)–(e) and the race contract in §3. Output: a **go/no-go on EPUB-in-v1** (no-go if no deterministic production re-apply signal — box D ships TXT/MD-only, tracked) + the concrete `EpubChapterTextProvider` / `EpubBilingualJs` / `EpubBilingualController` surfaces. Deps: none (uses the existing #106 Readium host). Not TDD-gated (throwaway spike); its findings feed WI-7b.
+177:**WI-4a (foundational): `ChapterTextProvider` (TXT/MD) + `ChapterTranslationPrefetcher` + `BilingualAiReadiness`.** `TxtChapterTextProvider` builds the **document-global segment ranges once (H1)**, groups into windows, resolves `unitContaining(charOffsetUTF16)` via segment-start binary search, `sourceSegments(unit)`. Prefetcher: `prefetch` + **`prefetchDirect` + `cachedDirect` (zero-provider cache restore — H2)**; resolves active profile from `snapshot()`, decrypts snapshot-consistent, builds client via the **injected factory param** (default `AiProviderFactory::create`), constructs `AiRequest` from the profile. Readiness = active profile with non-empty decrypted key; **cipher failure → not-ready, never a crash.** Fake store + fake factory. Deps: **WI-1, WI-3**. Tests: unit resolution + clamp + empty; **paragraph spanning a chunk boundary → one segment/one unit; multiple paragraphs in one chunk → distinct segments; a >4000-char paragraph → one segment across chunks; CR/LF/CRLF; MD markers; locator→unit mapping; source-byte parity while disabled**; cache-hit-no-profile still returns (#306); no-profile miss → `ProviderFailed`; `prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls; readiness true/false; cipher-throw → readiness false (no crash).
+179:**WI-4b (foundational — shared DI/factory, round-2 M3): AppContainer bilingual services.** Extract the DI/factory wiring into this EARLIER shared WI: `AppContainer` provides `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, and the `BilingualViewModel` factory — **consuming `AiProviderStore` from `AppContainer` (provided by #136).** Both host integrations (WI-7b, WI-8) depend on this. Deps: **WI-4a, feat:#136** (for `AiProviderStore` in `AppContainer`). Tests: container resolves the bilingual graph; the prefetcher's injected factory defaults to `AiProviderFactory::create`.
+185:**WI-7a (behavioral): Compose UI — setup sheet + interlinear body (TXT/MD) + pill.** Reproduce `vreader-bilingual.jsx` (setup sheet: language grid / granularity / preview / engine strip configured+unconfigured; body: translated / loading N%+dimmed / error+Retry / offline source-only; pill). Consumes the **host-neutral `BilingualRenderState` DTO (M2)**. Light+dark. Compose UI tests each state. Deps: **WI-5** (state shape). NO Style control; the unconfigured "Set up" CTA renders and (in WI-9) routes to #136's sheet.
+187:**WI-7b (behavioral, CONDITIONAL — only if WI-0 = go): EPUB render adapter (DOM injection, NOT Compose — round-2 M2).** `EpubBilingualJs` (enum/inject/clear JS builders, CSP-safe escaping) + `EpubBilingualController` (the serialization actor / session token — M1) + `EpubChapterTextProvider`, wired into `ReaderActivity`, driving DOM from the **shared `BilingualRenderState` DTO**. **Depends on WI-6 (VM prefetch) and WI-4b (DI) — the M3 fix; the WI-7a UI dependency is REMOVED except for the shared `BilingualRenderState`/value types.** Uses `prefetchDirect`/`cachedDirect` for the count-divergence path (H2). Connected test on a real EPUB (seeded cache): enable → interlinear injects; disable → nodes cleared; reflow/href-change/fragment-recreation/activity-recreation → re-applies from cache (zero provider calls); count-divergence handled (direct path). Unit tests: JS escaping/CSP-safe text insertion, RTL/CJK style, empty translations, loading cleanup, idempotent replacement, source-only fallback. Deps: **WI-0, WI-3, WI-4a, WI-4b, WI-6, (shared types from WI-7a)**. (If WI-0 = no-go, this WI is dropped and box D ships TXT/MD-only, tracked.)
+189:**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into the `items(chunkCount)` loop **keyed by segment-range overlap (H1)** + position-change (`charOffsetUTF16`) + setup-sheet. `originalFormat`-gated (TXT/MD). Uses WI-4b's DI. **#129 is VERIFIED — straight edit.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; disable → source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; paragraph-spanning-chunk-boundary renders one translation. Deps: **WI-6, WI-7a, WI-4b**.
+191:**WI-9 (behavioral): entry wiring + acceptance.** Mount `BilingualPill` in **#132's VERIFIED top chrome**; wire the **#134 VERIFIED More-menu `MoreActionId.BILINGUAL` toggle** (`MoreRow.Toggle` `on`/`onToggle`) to the VM; **wire the setup sheet's "Set up"/"Change…" affordance → #136's AI-provider-entry sheet.** Full acceptance pass across EPUB (if WI-7b landed) + TXT/MD, including the fresh-user path `unconfigured → Set up (→ #136 sheet) → add provider → return → enable → translate` (the #136-owned reachability verified jointly). **Flip box D to done ONLY for provider/model/granularity + the Style-descope note (H3); file the follow-up checklist amendment; do NOT claim full box-D parity, do NOT flip DONE until #136 is landed.** Update `docs/architecture.md` (bilingual pipeline + the new `chapter_translations` schema + bilingual services in `AppContainer`). → DONE. Deps: **WI-8, WI-7b (if go), feat:#136, feat:#132, feat:#134**.
+199:Compose UI (`androidTest/...bilingual/`): `BilingualSetupSheetUiTest` (language grid, granularity, preview, engine configured vs unconfigured; **no Style control present**; light+dark); `BilingualInterlinearBodyUiTest` (translated incl. CJK font + RTL Arabic; loading N%+dimmed; error+Retry; offline source-only; empty translation→source-only no crash); `BilingualPillUiTest`.
+201:Connected (`androidTest/...reader/`): `TxtReaderBilingualConnectedTest` (API 35, fake `AiClient` via injected factory): enable→setup→confirm→interlinear from seeded Room cache; disable→source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-chunk-boundary renders one translation**; TXT/MD gated (PDF inert); very long chapter scroll responsive; cancellation leaves no partial cache row. `EpubReaderBilingualConnectedTest` (only if WI-0=go): enable→inject on a real EPUB; disable→clear; href-change/fragment-recreation/activity-recreation→re-apply from cache (zero provider calls); **count-divergence handled via `prefetchDirect`/`cachedDirect`**.
+207:- **Live-translation verification is AI-credential-gated (the box-D caveat).** The whole pipeline is verified without live creds via a deterministic **fake `AiClient`** injected through the prefetcher's `clientFactory` param (default `AiProviderFactory::create`; tests override). WI-3/4a/8 prove segment→chunk→decode→cache→interleave end-to-end incl. every error/edge path. Connected tests seed the Room cache and assert render-from-cache with zero client calls (render path proven offline). This mock/integration path is the box-D-required verification path; an optional live smoke confirms wire format but is NOT a gate. **#136's Gate-5 covers the fresh-user `unconfigured → Set up → add provider` reachability leg.**
+208:- **TXT/MD segment↔render pairing (round-2 H1).** Both sides read the SAME segment range array (`paragraphRanges`/`sentenceRanges` over `TxtDocument.text`), so 1:1 holds by construction — no chapter model is invented, and a paragraph split across a chunk boundary is translated + rendered once. Granularity is in the cache key so a paragraph row is never read as sentences.
+210:- **EPUB JS-injection race (round-2 M1).** WI-0's contract (single actor/mutex OR monotonic navigator-session token; token check after every suspended JS/AI call; clear before publication teardown; identified production re-apply signal per recreation case). No deterministic re-apply signal = explicit NO-GO → TXT/MD-only ship.
+216:- **#136 dependency risk.** #131's DONE flip + the "Set up" route + `AiProviderStore` in `AppContainer` all block on #136. #131's pipeline/UI (WI-0..WI-8 except WI-4b's DI) build ahead; WI-4b + WI-9 gate on #136.
+222:- **#118 AI provider files unchanged** — the prefetcher/readiness are new consumers. **`AiProviderStore` into `AppContainer` is #136's change, not #131's**; #131's DI WI (WI-4b) wires the bilingual services around it.
+223:- **Backup contract already compatible** — `PerBookSettingsOverride.bilingualEnabled/TargetLanguage/Granularity` exist (verified; no `bilingualStyle`), and there is no translation-cache backup section (the cache is device-local, re-derivable). #131 writes the three fields locally; backup collect/restore is a small additive follow-up (no contract change), out of v1 scope; until then bilingual config is device-local.
+228:1. **"Bilingual mode" setup sheet with BOTH Style AND Granularity in one Android sheet** — `vreader-bilingual.jsx` depicts Granularity (no Style); `vreader-ai-android.jsx` depicts Style (no Granularity); no committed bundle shows both together. v1 reproduces the granularity-only `vreader-bilingual.jsx` sheet and **DROPS Style (user descope decision — §3/H3)**. If Style is wanted as an Android user control, file `Design needed: bilingual setup sheet (Style + Granularity) for feature #131`. **This is the one open design gate for #131.** The box-D Style parity gap is tracked by the WI-9 follow-up checklist amendment.
+229:2. **#136 dependency (not a #131 design gate)** — the setup sheet's "Set up"/"Change…" affordance routes to #136's AI-provider-entry sheet. #136 owns the sheet + its production reachability + `AiProviderStore` in `AppContainer`; #131 wires the affordance and consumes the store. #131 does not invent the AI-config sheet (rule 51).
+235:- v3 (2026-07-12) — Gate-2 round-2 findings resolved: TXT/MD document-global segment model (H1); EPUB translatePreSegmented + count-keyed cache + direct-block prefetch (H2); #136 AI-provider-reachability spun out as a hard dependency (filed GH #1976) + Style descoped v1 (H3, user decision); WI-0 go/no-go + navigator-race contract (M1); EPUB DOM-injection adapter not Compose body (M2); DI/factory WI reordered (M3); Room 8→9 MIGRATION_8_9 (M4); deps/WI-count corrected (L1/L2). Awaiting Gate-2 round-3 audit.
+     1	// Purpose: Addressable, range-based model of a decoded .txt — feature #111 WI-1.
+     2	// Holds ONE backing decoded String and an array of chunk START offsets (UTF-16 code
+     3	// units against the RAW text — NO line-ending normalization, so charOffsetUTF16 stays
+     4	// exact for resume). Splits at line boundaries (CRLF/CR/LF kept inside the chunk);
+     5	// hard-splits a runaway line at maxChunkChars (never mid-surrogate-pair). Visible
+     6	// chunk text is materialized on demand (no per-chunk substrings retained). Pure JVM.
+     7	package com.vreader.app.reader
+     8	
+     9	class TxtDocument private constructor(
+    10	    val text: String,
+    11	    private val starts: IntArray,
+    12	) {
+    13	    /** Number of chunks (0 for empty text). */
+    14	    val chunkCount: Int get() = starts.size
+    15	
+    16	    /** The UTF-16 start offset of chunk [index] (clamped to a valid chunk). */
+    17	    fun offsetForChunk(index: Int): Int {
+    18	        if (starts.isEmpty()) return 0
+    19	        return starts[index.coerceIn(0, starts.size - 1)]
+    20	    }
+    21	
+    22	    /** The chunk index containing [offsetUtf16] (EOF-clamped); 0 for empty text. */
+    23	    fun chunkForOffset(offsetUtf16: Int): Int {
+    24	        if (starts.isEmpty()) return 0
+    25	        val offset = offsetUtf16.coerceIn(0, text.length)
+    26	        // Largest start <= offset (binary search).
+    27	        var lo = 0; var hi = starts.size - 1; var ans = 0
+    28	        while (lo <= hi) {
+    29	            val mid = (lo + hi) ushr 1
+    30	            if (starts[mid] <= offset) { ans = mid; lo = mid + 1 } else { hi = mid - 1 }
+    31	        }
+    32	        return ans
+    33	    }
+    34	
+    35	    /** The text of chunk [index], materialized on demand from the backing string. */
+    36	    fun textForChunk(index: Int): CharSequence {
+    37	        if (starts.isEmpty()) return ""
+    38	        val i = index.coerceIn(0, starts.size - 1)
+    39	        val end = if (i + 1 < starts.size) starts[i + 1] else text.length
+    40	        return text.subSequence(starts[i], end)
+    41	    }
+    42	
+    43	    companion object {
+    44	        const val DEFAULT_MAX_CHUNK_CHARS = 4000
+    45	
+    46	        /**
+    47	         * Build a document from already-decoded [text]. Chunk boundaries fall after a
+    48	         * line terminator (`\n`, `\r`, or `\r\n` — preserved in the chunk); a line longer
+    49	         * than [maxChunkChars] is hard-split, but never between a surrogate pair.
+    50	         */
+    51	        fun of(text: String, maxChunkChars: Int = DEFAULT_MAX_CHUNK_CHARS): TxtDocument {
+    52	            if (text.isEmpty()) return TxtDocument(text, IntArray(0))
+    53	            // Primitive growable IntArray (no Int boxing) — a newline-dense 14MB file
+    54	            // would otherwise spike tens of MB of boxed Integers + a duplicating copy.
+    55	            var starts = IntArray(64)
+    56	            var count = 0
+    57	            fun push(v: Int) {
+    58	                if (count == starts.size) starts = starts.copyOf(starts.size * 2)
+    59	                starts[count++] = v
+    60	            }
+    61	            push(0)
+    62	            var i = 0
+    63	            var chunkStart = 0
+    64	            val n = text.length
+    65	            while (i < n) {
+    66	                val c = text[i]
+    67	                when {
+    68	                    c == '\n' -> {
+    69	                        i++
+    70	                        if (i < n) { push(i); chunkStart = i }
+    71	                    }
+    72	                    c == '\r' -> {
+    73	                        i++
+    74	                        if (i < n && text[i] == '\n') i++   // CRLF stays one terminator
+    75	                        if (i < n) { push(i); chunkStart = i }
+    76	                    }
+    77	                    else -> {
+    78	                        i++
+    79	                        // Hard-split a runaway line, but not mid-surrogate-pair (don't
+    80	                        // split right after a high surrogate — its low half follows at i).
+    81	                        if (i - chunkStart >= maxChunkChars && i < n && !text[i - 1].isHighSurrogate()) {
+    82	                            push(i); chunkStart = i
+    83	                        }
+    84	                    }
+    85	                }
+    86	            }
+    87	            return TxtDocument(text, starts.copyOf(count))
+    88	        }
+    89	    }
+    90	}
+android/app/src/androidTest/kotlin/com/vreader/app/backup/BookmarkBackupRestoreJumpTest.kt:41: *     landing precondition (`navigator.go(readium)` in WI-9's live navigator);
+android/app/src/androidTest/kotlin/com/vreader/app/backup/BookmarkBackupRestoreJumpTest.kt:147:                // reconstructed Readium locator (the landing precision `navigator.go` uses at WI-9).
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubFindInBookTest.kt:22: * #128 FTS index. Instrumented because Readium's EpubNavigatorFragment renders in a REAL WebView (not
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubFindInBookTest.kt:30: *  - tapping a hit → `Locator.fromJSON(readiumLocatorJson)` → `navigator.go` LANDS (the reading href/
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubFindInBookTest.kt:91:            // The reading position actually moved (or at least the navigator accepted the go); the href is a
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubFindInBookTest.kt:99:            assertNotNull("the navigator still has a rendered locator after the jump", hrefAfter)
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubFindInBookTest.kt:193:     *  opens); returns the rendered href (asserts the navigator + VM are live). */
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubFindInBookTest.kt:205:        assertNotNull("the navigator rendered a reading locator", href)
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:195:     * jumps to with `navigator.go`.
+android/app/src/main/kotlin/com/vreader/app/annotations/EpubAnnotationMapper.kt:4:// Kept free of Compose/Activity so the mapping is unit-testable; the navigator wiring lives in
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubDisplaySettingsConnectedTest.kt:19: * EpubNavigatorFragment resolves its settings against a real WebView (not Robolectric). Seeds a
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubDisplaySettingsConnectedTest.kt:20: * non-default theme in the global ReaderSettingsStore, opens the reader, and asserts the navigator's
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubDisplaySettingsConnectedTest.kt:23: * This proves the setting reached + was resolved by the live navigator — not that the WebView painted
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubDisplaySettingsConnectedTest.kt:47:                assertNotNull("navigator accepted a background color", applied)
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubDisplaySettingsConnectedTest.kt:49:                    "the stored Dark theme background reached the live navigator",
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubDisplaySettingsConnectedTest.kt:60:                    "a live theme change re-submitted to the navigator",
+android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderActivityTest.kt:18: * EpubNavigatorFragment renders in a real WebView (not Robolectric). Imports the
+android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderActivityTest.kt:20: * asserts the navigator renders a locator (the content loaded) + the open marked
+android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderActivityTest.kt:24:class ReaderActivityTest {
+android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderActivityTest.kt:34:            // The open + render is async; poll the navigator's current locator.
+android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderActivityTest.kt:41:            assertNotNull("the navigator rendered a reading locator (content loaded)", href)
+android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderActivityTest.kt:77:     *  navigator/WebView (the reopen path `observeHighlights` → `applyHighlights`). Seeds the highlight
+android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderActivityTest.kt:89:            assertNotNull("navigator rendered", href)
+android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderActivityTest.kt:108:            assertTrue("the stored highlight applied as a decoration on the live navigator", applied >= 1)
+android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderChromeConnectedTest.kt:19: * the Readium EpubNavigatorFragment. Instrumented because the navigator resolves its TOC + reading
+android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderChromeConnectedTest.kt:22: * `navigator.go` (currentHref changes on a valid jump), that a false/stale jump leaves the sheet open with
+android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderChromeConnectedTest.kt:46:            // Wait for the navigator to render a locator (content loaded).
+android/app/src/androidTest/kotlin/com/vreader/app/reader/ReaderChromeConnectedTest.kt:57:            assertTrue("a valid TOC jump reported success (native navigator.go returned true)", jumped)
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubBookmarkNavTest.kt:20: * Feature #135 WI-7 — the EPUB bookmark host wiring, instrumented because Readium's EpubNavigatorFragment
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubBookmarkNavTest.kt:120:    /** Poll the navigator's rendered locator; returns the rendered href (asserts it rendered). */
+android/app/src/androidTest/kotlin/com/vreader/app/reader/EpubBookmarkNavTest.kt:128:        assertNotNull("the navigator rendered a reading locator", href)
+android/app/src/main/kotlin/com/vreader/app/search/InBookSearchModels.kt:85: *   never references the Readium type; the host reconstructs it and calls `navigator.go`.
+android/app/src/androidTest/kotlin/com/vreader/app/reader/foliate/FoliateSpikeHarnessTest.kt:133:        InstrumentationRegistry.getInstrumentation().runOnMainSync { wv.evaluateJavascript(js, null) }
+android/app/src/test/kotlin/com/vreader/app/reader/EpubPreferencesMappingTest.kt:15:import org.readium.r2.navigator.preferences.Color as ReadiumColor
+android/app/src/test/kotlin/com/vreader/app/reader/EpubPreferencesMappingTest.kt:16:import org.readium.r2.navigator.preferences.FontFamily as ReadiumFontFamily
+android/app/src/test/kotlin/com/vreader/app/search/EpubInBookSearchEngineTest.kt:23: * highlight -> snippet, the raw locator retained for `navigator.go`) is asserted against genuine objects,
+android/app/src/test/kotlin/com/vreader/app/search/EpubInBookSearchEngineTest.kt:142:        // The RAW Readium locator is retained verbatim for navigator.go.
+android/app/src/main/kotlin/com/vreader/app/search/EpubInBookSearchEngine.kt:5:// returns REAL href-bearing, snippet-bearing `Locator`s the navigator jumps to natively (`nav.go`), so the
+android/app/src/main/kotlin/com/vreader/app/search/EpubInBookSearchEngine.kt:30://   group (honest — the navigator still jumps by the raw locator).
+android/app/src/main/kotlin/com/vreader/app/search/EpubInBookSearchEngine.kt:50: * A single located EPUB search hit: the RAW Readium [readiumLocator] the navigator jumps to via
+android/app/src/main/kotlin/com/vreader/app/search/EpubInBookSearchEngine.kt:51: * `navigator.go`, plus the presentation fields the hit row needs — the chapter [sectionTitle] (grouping
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderHighlightController.kt:1:// Purpose: feature #123 WI-3 — wraps Readium's selection + decoration APIs (EpubNavigatorFragment
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderHighlightController.kt:10:import org.readium.r2.navigator.Decoration
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderHighlightController.kt:11:import org.readium.r2.navigator.DecorableNavigator
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderHighlightController.kt:12:import org.readium.r2.navigator.epub.EpubNavigatorFragment
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderHighlightController.kt:17:class ReaderHighlightController(private val navigator: EpubNavigatorFragment) {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderHighlightController.kt:31:        navigator.applyDecorations(decorations, GROUP)
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderHighlightController.kt:36:    suspend fun currentSelectionLocator(): ReadiumLocator? = navigator.currentSelection()?.locator
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderHighlightController.kt:38:    fun clearSelection() = navigator.clearSelection()
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderHighlightController.kt:43:        navigator.addDecorationListener(
+android/app/src/main/kotlin/com/vreader/app/reader/ReadiumLocatorBridge.kt:93:     * The verbatim Readium Locator JSON to feed back to the navigator for a PRECISE
+android/app/src/main/kotlin/com/vreader/app/reader/EpubPreferencesMapper.kt:18:import org.readium.r2.navigator.epub.EpubPreferences
+android/app/src/main/kotlin/com/vreader/app/reader/EpubPreferencesMapper.kt:19:import org.readium.r2.navigator.preferences.Color as ReadiumColor
+android/app/src/main/kotlin/com/vreader/app/reader/EpubPreferencesMapper.kt:20:import org.readium.r2.navigator.preferences.FontFamily as ReadiumFontFamily
+android/app/src/main/kotlin/com/vreader/app/reader/nav/ReadiumTocProvider.kt:5:// zero-reconstruction `navigator.go` jump and (b) converts to the engine-neutral
+android/app/src/test/kotlin/com/vreader/app/reader/Azw3DisplayCssTest.kt:156:    // FoliateBridge.setStyles runs through evaluateJavascript) wraps the CSS in a JSON-encoded literal.
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocEntry.kt:5:// `Locator` (null for non-Readium hosts) so a TOC jump feeds `navigator.go` its
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocEntry.kt:22: *                    zero-reconstruction `navigator.go` jump; null for non-Readium hosts.
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:63: * The outcome of a bookmark jump. A jump can fail (EPUB `toReadium` null / `navigator.go` false; AZW3
+android/app/src/main/kotlin/com/vreader/app/reader/EpubReaderChrome.kt:2:// (ReaderActivity). The EPUB host is the outlier: a Readium EpubNavigatorFragment (a View) renders the
+android/app/src/main/kotlin/com/vreader/app/reader/EpubReaderChrome.kt:17:// Contents onJump → the host's `navigator.go(entry.epubReadiumLocator)` (Boolean): dismiss on success,
+android/app/src/main/kotlin/com/vreader/app/reader/EpubReaderChrome.kt:24:// @coordinates-with: ReaderActivity.kt (owns the StateFlow + the ComposeViews + the navigator jump + the
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt:4:// EpubNavigatorFragment View under the chrome, not a Compose body), so it cannot reuse the Compose-native
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt:43: * read from the navigator's `currentLocator`) to [tocIndexFor].
+android/app/src/main/kotlin/com/vreader/app/reader/ResumeResolver.kt:7:// applies the target to the Readium navigator.
+android/app/src/main/kotlin/com/vreader/app/reader/ResumeResolver.kt:17:     * Feed [readiumLocatorJSON] to the navigator for an exact restore — and if that
+android/app/src/main/kotlin/com/vreader/app/reader/ReadiumLocatorReconstructor.kt:64: * persisted bookmark (canonical-only) can be jumped to via `navigator.go`.
+android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateBridge.kt:83:        // the OS freezer can suspend it after a few idle seconds, so a page-turn (evaluateJavascript)
+android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateBridge.kt:161:     *  `evaluateJavascript` runs (no test-vs-production drift). Mirrors iOS Foliate `setStyles`. */
+android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateBridge.kt:166:    private fun eval(js: String) = webView.evaluateJavascript(js, null)
+android/app/src/main/kotlin/com/vreader/app/reader/foliate/FoliateBridge.kt:303: * seam [FoliateBridge.setStyles] runs through `evaluateJavascript`, so the escaping the unit test pins
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:2:// EpubNavigatorFragment in scroll mode (Spike-B-verified), opening the stored EPUB
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:7:// EpubNavigatorFragment View under the chrome, not a Compose body) and the ONLY TOC-supplying host, so it
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:15:// onJump → navigator.go(entry.epubReadiumLocator):Boolean (dismiss on success, stay-open on false, no
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:24:// hit jumps via Locator.fromJSON(readiumLocatorJson) → navigator.go (Succeeded dismisses / Failed keeps open,
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:87:import org.readium.r2.navigator.epub.EpubNavigatorFactory
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:88:import org.readium.r2.navigator.epub.EpubNavigatorFragment
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:89:import org.readium.r2.navigator.epub.EpubPreferences
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:101:class ReaderActivity : AppCompatActivity() {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:110:    private var navigator: EpubNavigatorFragment? = null
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:126:    // read from the navigator's currentLocator totalProgression (EPUB scroll mode).
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:139:    // The live reading position as a canonical Locator (null until the navigator has a locator). Read on the
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:168:        // The navigator fragment can't be restored before its FragmentFactory is set,
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:178:        // value + live updates), mirroring how observeDisplaySettings feeds the navigator.
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:206:            val nav: EpubNavigatorFragment? = withStarted {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:211:                    listener = object : EpubNavigatorFragment.Listener {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:214:                    configuration = EpubNavigatorFragment.Configuration().apply {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:220:                    add(containerId, EpubNavigatorFragment::class.java, Bundle(), READER_TAG)
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:222:                supportFragmentManager.findFragmentByTag(READER_TAG) as EpubNavigatorFragment
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:225:            navigator = nav
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:268:    private suspend fun populateChromeModel(pub: Publication, current: Book, nav: EpubNavigatorFragment) {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:346:    /** Test hook: the count of highlights applied as decorations on the live navigator (-1 until the
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:347:     *  first apply). Proves the reopen-render path ran against the real EpubNavigatorFragment. */
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:361:                val nav = navigator ?: run { mode?.finish(); return@launch }
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:449:        val nav = navigator ?: return
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:462:        // Host owns the Publication (Readium's navigator does not close it). The
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:477:    /** feature #129 WI-5 — apply the live "Display" settings to the navigator: re-submit Readium
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:482:    private fun observeDisplaySettings(nav: EpubNavigatorFragment) {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:494:    private fun observePosition(nav: EpubNavigatorFragment, current: Book) {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:558:     *  navigator has no locator yet (currentCanonical null → no dead toggle). */
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:571:     *  `navigator.go`. A null reconstruction (malformed/unresolvable/renamed href, or a different-book
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:575:        val nav = navigator ?: return JumpResult.Failed
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:586:     *  `Locator.fromJSON(JSONObject(json))` and `navigator.go`. A null/blank/malformed JSON (an un-jumpable
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:592:        val nav = navigator ?: return JumpResult.Failed
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:620:     *  body is a View (EpubNavigatorFragment), NOT a composable, the chrome cannot use the Compose-native
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:715:     *  `navigator.go` (zero reconstruction). Returns Readium's Boolean success so the Contents sheet
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:719:        val nav = navigator ?: return false
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:726:     *  current href and navigates there. A tolerated no-op when the navigator/publication isn't ready. */
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:728:        val nav = navigator ?: return
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:847:    /** Test hook: the current reading href, or null until the navigator has rendered. */
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:849:    fun currentHref(): String? = navigator?.currentLocator?.value?.href?.toString()
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:895:    /** Test hook (feature #129 WI-5): the background ARGB the live navigator has *accepted/computed*
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:896:     *  for its EpubSettings (the applied theme background), or null before the navigator/settings exist.
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:897:     *  Proves the Display setting reached and was resolved by the live EpubNavigatorFragment — it does
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:900:    fun appliedBackgroundArgb(): Int? = navigator?.settings?.value?.backgroundColor?.int
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:932:        private const val READER_TAG = "reader-navigator"
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:954: * feature #135 WI-7 — map an EPUB reader's LIVE reading position (extracted from the navigator's Readium
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:18:    // @Upsert (insert-or-UPDATE), NOT @Insert(REPLACE). REPLACE is delete-then-insert
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:20:    // wipe a book's saved position on every re-import (Gate-4 Critical). @Upsert
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:23:    // NOTE: the SAF import path does NOT use this whole-row @Upsert — it uses
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:28:    @Upsert
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:118:    @Upsert
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:136:    // unreliable on API 26/27), and @Upsert can't increment. INSERT OR IGNORE a zero row, then UPDATE
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:231:    @Upsert
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:249:    @Upsert
+android/app/src/main/kotlin/com/vreader/app/data/CollectionEntities.kt:21:    @PrimaryKey val id: String,   // UUID string — internal PK, NOT the backup identity (name+createdAt is)
+android/app/src/main/kotlin/com/vreader/app/data/SearchEntities.kt:48:    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+android/app/src/main/kotlin/com/vreader/app/data/SearchEntities.kt:90:    @PrimaryKey val bookKey: String,
+android/app/src/main/kotlin/com/vreader/app/data/SearchEntities.kt:116:    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:20: * path goes through [BookDao.upsertPreservingAuthor], not the whole-row `@Upsert`).
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:24:    @PrimaryKey val fingerprintKey: String,
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:58:    @PrimaryKey val fingerprintKey: String,
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:105:    @PrimaryKey val highlightId: String,   // UUID string (iOS `highlightId: UUID` parity)
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:137:    @PrimaryKey val noteId: String,
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:170:    @PrimaryKey val bookmarkId: String,
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:3:// MIGRATION_1_2 is the worked example of the additive-migration pattern (adds
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:11:// Migration(n, n+1) to ALL_MIGRATIONS and bump `version`.
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:21:@Database(
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:29:    version = 8,
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:44:        val MIGRATION_1_2: Migration = object : Migration(1, 2) {
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:52:        val MIGRATION_2_3: Migration = object : Migration(2, 3) {
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:67:        val MIGRATION_3_4: Migration = object : Migration(3, 4) {
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:112:        val MIGRATION_4_5: Migration = object : Migration(4, 5) {
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:138:        val MIGRATION_5_6: Migration = object : Migration(5, 6) {
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:151:        val MIGRATION_6_7: Migration = object : Migration(6, 7) {
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:198:        val MIGRATION_7_8: Migration = object : Migration(7, 8) {
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:224:        val ALL_MIGRATIONS: Array<Migration> =
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:226:                MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:227:                MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8,
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:233:                .addMigrations(*ALL_MIGRATIONS)
+
+exec
+/bin/zsh -lc "nl -ba android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt && nl -ba android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt | sed -n '1015,1075p' && nl -ba android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt | sed -n '15,240p' && nl -ba android/app/src/main/kotlin/com/vreader/app/data/Daos.kt | sed -n '1,45p' && nl -ba android/app/src/main/kotlin/com/vreader/app/data/Entities.kt | sed -n '15,35p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+     1	// Purpose: Addressable, range-based model of a decoded .txt — feature #111 WI-1.
+     2	// Holds ONE backing decoded String and an array of chunk START offsets (UTF-16 code
+     3	// units against the RAW text — NO line-ending normalization, so charOffsetUTF16 stays
+     4	// exact for resume). Splits at line boundaries (CRLF/CR/LF kept inside the chunk);
+     5	// hard-splits a runaway line at maxChunkChars (never mid-surrogate-pair). Visible
+     6	// chunk text is materialized on demand (no per-chunk substrings retained). Pure JVM.
+     7	package com.vreader.app.reader
+     8	
+     9	class TxtDocument private constructor(
+    10	    val text: String,
+    11	    private val starts: IntArray,
+    12	) {
+    13	    /** Number of chunks (0 for empty text). */
+    14	    val chunkCount: Int get() = starts.size
+    15	
+    16	    /** The UTF-16 start offset of chunk [index] (clamped to a valid chunk). */
+    17	    fun offsetForChunk(index: Int): Int {
+    18	        if (starts.isEmpty()) return 0
+    19	        return starts[index.coerceIn(0, starts.size - 1)]
+    20	    }
+    21	
+    22	    /** The chunk index containing [offsetUtf16] (EOF-clamped); 0 for empty text. */
+    23	    fun chunkForOffset(offsetUtf16: Int): Int {
+    24	        if (starts.isEmpty()) return 0
+    25	        val offset = offsetUtf16.coerceIn(0, text.length)
+    26	        // Largest start <= offset (binary search).
+    27	        var lo = 0; var hi = starts.size - 1; var ans = 0
+    28	        while (lo <= hi) {
+    29	            val mid = (lo + hi) ushr 1
+    30	            if (starts[mid] <= offset) { ans = mid; lo = mid + 1 } else { hi = mid - 1 }
+    31	        }
+    32	        return ans
+    33	    }
+    34	
+    35	    /** The text of chunk [index], materialized on demand from the backing string. */
+    36	    fun textForChunk(index: Int): CharSequence {
+    37	        if (starts.isEmpty()) return ""
+    38	        val i = index.coerceIn(0, starts.size - 1)
+    39	        val end = if (i + 1 < starts.size) starts[i + 1] else text.length
+    40	        return text.subSequence(starts[i], end)
+    41	    }
+    42	
+    43	    companion object {
+    44	        const val DEFAULT_MAX_CHUNK_CHARS = 4000
+    45	
+    46	        /**
+    47	         * Build a document from already-decoded [text]. Chunk boundaries fall after a
+    48	         * line terminator (`\n`, `\r`, or `\r\n` — preserved in the chunk); a line longer
+    49	         * than [maxChunkChars] is hard-split, but never between a surrogate pair.
+    50	         */
+    51	        fun of(text: String, maxChunkChars: Int = DEFAULT_MAX_CHUNK_CHARS): TxtDocument {
+    52	            if (text.isEmpty()) return TxtDocument(text, IntArray(0))
+    53	            // Primitive growable IntArray (no Int boxing) — a newline-dense 14MB file
+    54	            // would otherwise spike tens of MB of boxed Integers + a duplicating copy.
+    55	            var starts = IntArray(64)
+    56	            var count = 0
+    57	            fun push(v: Int) {
+    58	                if (count == starts.size) starts = starts.copyOf(starts.size * 2)
+    59	                starts[count++] = v
+    60	            }
+    61	            push(0)
+    62	            var i = 0
+    63	            var chunkStart = 0
+    64	            val n = text.length
+    65	            while (i < n) {
+    66	                val c = text[i]
+    67	                when {
+    68	                    c == '\n' -> {
+    69	                        i++
+    70	                        if (i < n) { push(i); chunkStart = i }
+    71	                    }
+    72	                    c == '\r' -> {
+    73	                        i++
+    74	                        if (i < n && text[i] == '\n') i++   // CRLF stays one terminator
+    75	                        if (i < n) { push(i); chunkStart = i }
+    76	                    }
+    77	                    else -> {
+    78	                        i++
+    79	                        // Hard-split a runaway line, but not mid-surrogate-pair (don't
+    80	                        // split right after a high surrogate — its low half follows at i).
+    81	                        if (i - chunkStart >= maxChunkChars && i < n && !text[i - 1].isHighSurrogate()) {
+    82	                            push(i); chunkStart = i
+    83	                        }
+    84	                    }
+    85	                }
+    86	            }
+    87	            return TxtDocument(text, starts.copyOf(count))
+    88	        }
+    89	    }
+    90	}
+  1015	            .then(
+  1016	                if (selectionController != null) {
+  1017	                    // ONE detector distinguishes a TAP (edit an existing highlight) from a LONG-PRESS+drag
+  1018	                    // (new selection) — two separate pointerInput detectors conflict over the same down event.
+  1019	                    Modifier.pointerInput(selectionController) {
+  1020	                        awaitEachGesture {
+  1021	                            val down = awaitFirstDown(requireUnconsumed = false)
+  1022	                            val longPress = awaitLongPressOrCancellation(down.id)
+  1023	                            if (longPress != null) {
+  1024	                                // long-press → selection; finalize only on a COMPLETED drag/up (not a cancel).
+  1025	                                selectionController.beginAt(longPress.position)
+  1026	                                val completed = drag(longPress.id) { change -> selectionController.extendTo(change.position); change.consume() }
+  1027	                                if (completed) currentOnFinalize() else selectionController.clear()
+  1028	                            } else if (!down.isConsumed) {
+  1029	                                // null also means cancel (e.g. a scroll won) — only a TAP leaves the down
+  1030	                                // unconsumed; a scroll consumes it, so it won't be misread as tap-to-edit.
+  1031	                                currentOnTap(down.position)
+  1032	                            }
+  1033	                        }
+  1034	                    }
+  1035	                } else {
+  1036	                    Modifier
+  1037	                },
+  1038	            ),
+  1039	        state = listState,
+  1040	        contentPadding = PaddingValues(horizontal = marginDp.dp, vertical = 16.dp),
+  1041	    ) {
+  1042	        // Count-based: indices on demand (a newline-dense 14MB file can be 100k+ chunks).
+  1043	        items(count = document.chunkCount, key = { it }) { i ->
+  1044	            val raw = document.textForChunk(i).toString()
+  1045	            // .md → styled markdown spans (no read-aloud span wash — markers shift offsets, plan §OOS).
+  1046	            // .txt → raw verbatim, with the spoken-sentence span washed when read-aloud is active.
+  1047	            val span = if (isMarkdown) null else highlightSpan(i)
+  1048	            val text = when {
+  1049	                isMarkdown -> mapper.renderedText(i)   // #125: the mapper is the single render owner
+  1050	                span != null -> buildAnnotatedString {
+  1051	                    append(raw)
+  1052	                    val a = span.first.coerceIn(0, raw.length); val b = (span.last + 1).coerceIn(a, raw.length)
+  1053	                    if (b > a) addStyle(SpanStyle(background = wash), a, b)
+  1054	                }
+  1055	                else -> AnnotatedString(raw)
+  1056	            }
+  1057	            // annotation washes drawn BEHIND the text (getPathForRange) — separate from the read-aloud span.
+  1058	            val washes = washesForChunk(i)
+  1059	            var layout by remember(i) { mutableStateOf<TextLayoutResult?>(null) }
+  1060	            var coords by remember(i) { mutableStateOf<androidx.compose.ui.layout.LayoutCoordinates?>(null) }
+  1061	            if (selectionController != null) {
+  1062	                LaunchedEffect(i, layout, coords) {
+  1063	                    val l = layout; val c = coords
+  1064	                    if (l != null && c != null) selectionController.registerChunk(i, l, c)
+  1065	                }
+  1066	                DisposableEffect(selectionController, i) { onDispose { selectionController.unregisterChunk(i) } }
+  1067	            }
+  1068	            // read `selection` (a State) so a selection change recomposes + redraws the accent.
+  1069	            val selRange = if (selection != null) selectionController?.selectionForChunk(i) else null
+  1070	            Text(
+  1071	                text = text,
+  1072	                // merge over the material default (the pre-#129 explicit-param behavior) so platform
+  1073	                // text defaults (letterSpacing etc.) are kept — only the Display settings change.
+  1074	                style = androidx.compose.material3.LocalTextStyle.current.merge(textStyle),
+  1075	                onTextLayout = { layout = it },
+    15	import androidx.room.Database
+    16	import androidx.room.Room
+    17	import androidx.room.RoomDatabase
+    18	import androidx.room.migration.Migration
+    19	import androidx.sqlite.db.SupportSQLiteDatabase
+    20	
+    21	@Database(
+    22	    entities = [
+    23	        BookEntity::class, ReadingPositionEntity::class, DailyReadingEntity::class,
+    24	        HighlightEntity::class, AnnotationNoteEntity::class, BookmarkEntity::class,
+    25	        CollectionEntity::class, BookCollectionCrossRef::class,
+    26	        SearchSectionEntity::class, SearchSectionFtsEntity::class,
+    27	        SearchIndexStateEntity::class, SearchStagingEntity::class,
+    28	    ],
+    29	    version = 8,
+    30	    exportSchema = true,
+    31	)
+    32	abstract class VReaderDatabase : RoomDatabase() {
+    33	    abstract fun bookDao(): BookDao
+    34	    abstract fun readingPositionDao(): ReadingPositionDao
+    35	    abstract fun readingStatsDao(): ReadingStatsDao
+    36	    abstract fun annotationDao(): AnnotationDao
+    37	    abstract fun collectionDao(): CollectionDao
+    38	    abstract fun searchDao(): SearchDao
+    39	
+    40	    companion object {
+    41	        private const val DB_NAME = "vreader.db"
+    42	
+    43	        /** v1 → v2: add the nullable `lastOpenedAt` recents column to `books`. */
+    44	        val MIGRATION_1_2: Migration = object : Migration(1, 2) {
+    45	            override fun migrate(db: SupportSQLiteDatabase) {
+    46	                db.execSQL("ALTER TABLE books ADD COLUMN lastOpenedAt INTEGER")
+    47	            }
+    48	        }
+    49	
+    50	        /** v2 → v3: feature #122 — add the additive `daily_reading` per-day/per-book stats table +
+    51	         *  its bookKey index. No data transform. DDL matches Room's generated schema exactly. */
+    52	        val MIGRATION_2_3: Migration = object : Migration(2, 3) {
+    53	            override fun migrate(db: SupportSQLiteDatabase) {
+    54	                db.execSQL(
+    55	                    "CREATE TABLE IF NOT EXISTS `daily_reading` (`date` TEXT NOT NULL, `bookKey` TEXT NOT NULL, " +
+    56	                        "`minutes` INTEGER NOT NULL, PRIMARY KEY(`date`, `bookKey`))",
+    57	                )
+    58	                db.execSQL("CREATE INDEX IF NOT EXISTS `index_daily_reading_bookKey` ON `daily_reading` (`bookKey`)")
+    59	            }
+    60	        }
+    61	
+    62	        /** v3 → v4: feature #123 — add the additive `highlights`, `annotation_notes`, and `bookmarks`
+    63	         *  annotation tables (each FK→books ON DELETE CASCADE; highlights has the unique
+    64	         *  `(profileKey, anchorKey)` dedupe index). No data transform. DDL matches Room's generated
+    65	         *  schema for v4 exactly (the migration test opens the real Room DB, whose structural PRAGMA
+    66	         *  validation catches any drift). */
+    67	        val MIGRATION_3_4: Migration = object : Migration(3, 4) {
+    68	            override fun migrate(db: SupportSQLiteDatabase) {
+    69	                db.execSQL(
+    70	                    "CREATE TABLE IF NOT EXISTS `highlights` (`highlightId` TEXT NOT NULL, " +
+    71	                        "`bookKey` TEXT NOT NULL, `profileKey` TEXT NOT NULL, `anchorKey` TEXT NOT NULL, " +
+    72	                        "`color` TEXT NOT NULL, `selectedText` TEXT NOT NULL, `note` TEXT, " +
+    73	                        "`locatorJSON` TEXT NOT NULL, `anchorJSON` TEXT, `createdAt` INTEGER NOT NULL, " +
+    74	                        "`updatedAt` INTEGER NOT NULL, PRIMARY KEY(`highlightId`), " +
+    75	                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+    76	                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+    77	                )
+    78	                db.execSQL("CREATE INDEX IF NOT EXISTS `index_highlights_bookKey` ON `highlights` (`bookKey`)")
+    79	                db.execSQL(
+    80	                    "CREATE UNIQUE INDEX IF NOT EXISTS `index_highlights_profileKey_anchorKey` " +
+    81	                        "ON `highlights` (`profileKey`, `anchorKey`)",
+    82	                )
+    83	                db.execSQL(
+    84	                    "CREATE TABLE IF NOT EXISTS `annotation_notes` (`noteId` TEXT NOT NULL, " +
+    85	                        "`bookKey` TEXT NOT NULL, `profileKey` TEXT NOT NULL, `content` TEXT NOT NULL, " +
+    86	                        "`locatorJSON` TEXT NOT NULL, `anchorJSON` TEXT, `createdAt` INTEGER NOT NULL, " +
+    87	                        "`updatedAt` INTEGER NOT NULL, PRIMARY KEY(`noteId`), " +
+    88	                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+    89	                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+    90	                )
+    91	                db.execSQL(
+    92	                    "CREATE INDEX IF NOT EXISTS `index_annotation_notes_bookKey` " +
+    93	                        "ON `annotation_notes` (`bookKey`)",
+    94	                )
+    95	                db.execSQL(
+    96	                    "CREATE TABLE IF NOT EXISTS `bookmarks` (`bookmarkId` TEXT NOT NULL, " +
+    97	                        "`bookKey` TEXT NOT NULL, `profileKey` TEXT NOT NULL, `title` TEXT, " +
+    98	                        "`locatorJSON` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, " +
+    99	                        "`updatedAt` INTEGER NOT NULL, PRIMARY KEY(`bookmarkId`), " +
+   100	                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+   101	                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+   102	                )
+   103	                db.execSQL("CREATE INDEX IF NOT EXISTS `index_bookmarks_bookKey` ON `bookmarks` (`bookKey`)")
+   104	            }
+   105	        }
+   106	
+   107	        /** v4 → v5: feature #127 — add the additive `collections` table (unique `nameKey` index) +
+   108	         *  the `book_collection` many-to-many join (composite PK, both FKs ON DELETE CASCADE, a
+   109	         *  `collectionId` index for the reverse lookup). No data transform. DDL matches Room's generated
+   110	         *  v5 schema exactly (the migration test opens the real Room DB, whose structural PRAGMA
+   111	         *  validation catches any drift). */
+   112	        val MIGRATION_4_5: Migration = object : Migration(4, 5) {
+   113	            override fun migrate(db: SupportSQLiteDatabase) {
+   114	                db.execSQL(
+   115	                    "CREATE TABLE IF NOT EXISTS `collections` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, " +
+   116	                        "`nameKey` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+   117	                )
+   118	                db.execSQL(
+   119	                    "CREATE UNIQUE INDEX IF NOT EXISTS `index_collections_nameKey` ON `collections` (`nameKey`)",
+   120	                )
+   121	                db.execSQL(
+   122	                    "CREATE TABLE IF NOT EXISTS `book_collection` (`bookKey` TEXT NOT NULL, " +
+   123	                        "`collectionId` TEXT NOT NULL, PRIMARY KEY(`bookKey`, `collectionId`), " +
+   124	                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+   125	                        "ON UPDATE NO ACTION ON DELETE CASCADE , " +
+   126	                        "FOREIGN KEY(`collectionId`) REFERENCES `collections`(`id`) " +
+   127	                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+   128	                )
+   129	                db.execSQL(
+   130	                    "CREATE INDEX IF NOT EXISTS `index_book_collection_collectionId` " +
+   131	                        "ON `book_collection` (`collectionId`)",
+   132	                )
+   133	            }
+   134	        }
+   135	
+   136	        /** v5 → v6: feature #128 — add the nullable `author` column to `books` (library search).
+   137	         *  Purely additive; migrated rows read `author = null` until a backfill or restore sets it. */
+   138	        val MIGRATION_5_6: Migration = object : Migration(5, 6) {
+   139	            override fun migrate(db: SupportSQLiteDatabase) {
+   140	                db.execSQL("ALTER TABLE books ADD COLUMN author TEXT")
+   141	            }
+   142	        }
+   143	
+   144	        /** v6 → v7: feature #128 WI-4 — add the cross-book search index (all in the one `vreader.db`):
+   145	         *  `search_sections` (+ bookKey index + FK→books CASCADE), its FTS4/unicode61 content-table
+   146	         *  shadow `search_sections_fts`, `search_index_state` (+ FK→books CASCADE), and the transient
+   147	         *  `search_sections_staging` buffer (+ bookKey index + FK→books CASCADE). The migration ships
+   148	         *  the base + FTS VIRTUAL tables only; Room recreates the FTS content-table sync triggers when
+   149	         *  it opens the DB. DDL matches Room's generated v7 schema exactly (the migration test opens the
+   150	         *  real Room DB, whose structural PRAGMA validation catches any drift). No data transform. */
+   151	        val MIGRATION_6_7: Migration = object : Migration(6, 7) {
+   152	            override fun migrate(db: SupportSQLiteDatabase) {
+   153	                db.execSQL(
+   154	                    "CREATE TABLE IF NOT EXISTS `search_sections` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+   155	                        "`bookKey` TEXT NOT NULL, `sectionIndex` INTEGER NOT NULL, `chunkOrdinal` INTEGER NOT NULL, " +
+   156	                        "`sectionTitle` TEXT, `text` TEXT NOT NULL, `indexedText` TEXT NOT NULL, " +
+   157	                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+   158	                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+   159	                )
+   160	                db.execSQL("CREATE INDEX IF NOT EXISTS `index_search_sections_bookKey` ON `search_sections` (`bookKey`)")
+   161	                db.execSQL(
+   162	                    "CREATE VIRTUAL TABLE IF NOT EXISTS `search_sections_fts` USING FTS4(" +
+   163	                        "`indexedText` TEXT NOT NULL, tokenize=unicode61, content=`search_sections`)",
+   164	                )
+   165	                db.execSQL(
+   166	                    "CREATE TABLE IF NOT EXISTS `search_index_state` (`bookKey` TEXT NOT NULL, " +
+   167	                        "`indexerVersion` INTEGER NOT NULL, `indexedAt` INTEGER NOT NULL, `status` TEXT NOT NULL, " +
+   168	                        "PRIMARY KEY(`bookKey`), FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+   169	                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+   170	                )
+   171	                db.execSQL(
+   172	                    "CREATE TABLE IF NOT EXISTS `search_sections_staging` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+   173	                        "`bookKey` TEXT NOT NULL, `sectionIndex` INTEGER NOT NULL, `chunkOrdinal` INTEGER NOT NULL, " +
+   174	                        "`sectionTitle` TEXT, `text` TEXT NOT NULL, `indexedText` TEXT NOT NULL, " +
+   175	                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+   176	                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+   177	                )
+   178	                db.execSQL(
+   179	                    "CREATE INDEX IF NOT EXISTS `index_search_sections_staging_bookKey` " +
+   180	                        "ON `search_sections_staging` (`bookKey`)",
+   181	                )
+   182	            }
+   183	        }
+   184	
+   185	        /** v7 → v8: feature #135 WI-3 — make re-bookmarking the same position idempotent by adding a
+   186	         *  composite UNIQUE index on `bookmarks (bookKey, profileKey)` (the atomic-toggle enforcer,
+   187	         *  mirroring the highlights `(profileKey, anchorKey)` dedupe precedent).
+   188	         *
+   189	         *  A pre-#135 create path (`upsertBookmark`, UUID-keyed) could have produced DUPLICATE rows at
+   190	         *  the same `(bookKey, profileKey)`; `CREATE UNIQUE INDEX` would FAIL on such a duplicate. So
+   191	         *  the migration first DEDUPES — deleting every duplicate LOSER, keeping a DETERMINISTIC winner
+   192	         *  per `(bookKey, profileKey)`: the row with the greatest `updatedAt`, tie-broken by the
+   193	         *  greatest `createdAt`, then the LOWEST `bookmarkId` (a total, stable order). This is a
+   194	         *  targeted dedupe — a non-duplicate row (unique `(bookKey, profileKey)`) is never deleted, and
+   195	         *  no other table is touched. THEN the unique index is created, matching Room's generated name
+   196	         *  + columns (`index_bookmarks_bookKey_profileKey` on `(bookKey, profileKey)`) exactly, so
+   197	         *  Room's structural PRAGMA validation passes. DDL is idempotent (`IF NOT EXISTS`). */
+   198	        val MIGRATION_7_8: Migration = object : Migration(7, 8) {
+   199	            override fun migrate(db: SupportSQLiteDatabase) {
+   200	                // 1) Dedupe: delete every row that is NOT the deterministic winner within its
+   201	                //    (bookKey, profileKey) group. The winner is the row whose (updatedAt, createdAt,
+   202	                //    -rowid-preference-on-bookmarkId) is greatest — expressed as: a row is a loser iff
+   203	                //    another row in the same group ranks strictly higher by (updatedAt DESC,
+   204	                //    createdAt DESC, bookmarkId ASC).
+   205	                db.execSQL(
+   206	                    "DELETE FROM `bookmarks` WHERE `bookmarkId` IN (" +
+   207	                        "SELECT b.`bookmarkId` FROM `bookmarks` b JOIN `bookmarks` w " +
+   208	                        "ON b.`bookKey` = w.`bookKey` AND b.`profileKey` = w.`profileKey` " +
+   209	                        "AND b.`bookmarkId` <> w.`bookmarkId` " +
+   210	                        "WHERE (w.`updatedAt` > b.`updatedAt`) " +
+   211	                        "OR (w.`updatedAt` = b.`updatedAt` AND w.`createdAt` > b.`createdAt`) " +
+   212	                        "OR (w.`updatedAt` = b.`updatedAt` AND w.`createdAt` = b.`createdAt` " +
+   213	                        "AND w.`bookmarkId` < b.`bookmarkId`))",
+   214	                )
+   215	                // 2) Now that each (bookKey, profileKey) is unique, create the unique index.
+   216	                db.execSQL(
+   217	                    "CREATE UNIQUE INDEX IF NOT EXISTS `index_bookmarks_bookKey_profileKey` " +
+   218	                        "ON `bookmarks` (`bookKey`, `profileKey`)",
+   219	                )
+   220	            }
+   221	        }
+   222	
+   223	        /** All registered migrations, oldest first. Append future Migration(n,n+1) here. */
+   224	        val ALL_MIGRATIONS: Array<Migration> =
+   225	            arrayOf(
+   226	                MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
+   227	                MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8,
+   228	            )
+   229	
+   230	        /** The production on-disk database (app-private storage). */
+   231	        fun build(context: Context): VReaderDatabase =
+   232	            Room.databaseBuilder(context.applicationContext, VReaderDatabase::class.java, DB_NAME)
+   233	                .addMigrations(*ALL_MIGRATIONS)
+   234	                .build()
+   235	    }
+   236	}
+     1	// Purpose: Room DAOs — the Android analog of the iOS PersistenceActor CRUD
+     2	// extensions (feature #106 WI-3). DAOs expose suspend writes + Flow reads; Room
+     3	// serializes access off the main thread. Views never touch a DAO directly — the
+     4	// repository (DTOs) is the boundary (rule 50 §2: never return @Model/entity types
+     5	// across the layer).
+     6	package com.vreader.app.data
+     7	
+     8	import androidx.room.Dao
+     9	import androidx.room.Insert
+    10	import androidx.room.OnConflictStrategy
+    11	import androidx.room.Query
+    12	import androidx.room.Transaction
+    13	import androidx.room.Upsert
+    14	import kotlinx.coroutines.flow.Flow
+    15	
+    16	@Dao
+    17	interface BookDao {
+    18	    // @Upsert (insert-or-UPDATE), NOT @Insert(REPLACE). REPLACE is delete-then-insert
+    19	    // in SQLite, which would fire reading_positions' ON DELETE CASCADE and silently
+    20	    // wipe a book's saved position on every re-import (Gate-4 Critical). @Upsert
+    21	    // updates in place, preserving the child row.
+    22	    //
+    23	    // NOTE: the SAF import path does NOT use this whole-row @Upsert — it uses
+    24	    // [upsertPreservingAuthor] below, so a duplicate import can't null-clobber a
+    25	    // backfilled `author` (feature #128 WI-1 Gate-2 Critical). This whole-row upsert is
+    26	    // kept for callers (e.g. the restore path pre-#128) that intentionally write every
+    27	    // column, and is exercised by the reUpsert-preserves-position regression.
+    28	    @Upsert
+    29	    suspend fun upsert(book: BookEntity)
+    30	
+    31	    @Query("SELECT * FROM books ORDER BY addedAt DESC")
+    32	    fun observeAll(): Flow<List<BookEntity>>
+    33	
+    34	    @Query("SELECT * FROM books WHERE fingerprintKey = :key")
+    35	    suspend fun find(key: String): BookEntity?
+    36	
+    37	    // feature #116 WI-3 — one-shot snapshot for the backup collector (not the observable Flow).
+    38	    // Ordered by fingerprintKey (NOT the library-display addedAt) so a repeat backup of unchanged
+    39	    // content yields a byte-stable manifest (matches the iOS projection ordering).
+    40	    @Query("SELECT * FROM books ORDER BY fingerprintKey")
+    41	    suspend fun getAll(): List<BookEntity>
+    42	
+    43	    @Query("DELETE FROM books WHERE fingerprintKey = :key")
+    44	    suspend fun delete(key: String)
+    45	
+    15	 * (`DocumentFingerprint.canonicalKey`). `localFilePath`/`sourceUri` are nullable
+    16	 * until WI-4 wires SAF import → app-private-storage copy. `lastOpenedAt` is the
+    17	 * v2 schema addition (recents) — null until first open. `author` is the v6 addition
+    18	 * (feature #128 library search) — nullable, set by an author backfill or a restore,
+    19	 * NEVER by the SAF import path (a duplicate import must not null-clobber it: the import
+    20	 * path goes through [BookDao.upsertPreservingAuthor], not the whole-row `@Upsert`).
+    21	 */
+    22	@Entity(tableName = "books")
+    23	data class BookEntity(
+    24	    @PrimaryKey val fingerprintKey: String,
+    25	    val title: String,
+    26	    val originalFormat: String,   // BookFormat raw value (epub/pdf/txt/md/azw3)
+    27	    val contentSHA256: String,
+    28	    val fileByteCount: Long,
+    29	    val localFilePath: String?,   // app-private storage path (set at import, WI-4)
+    30	    val sourceUri: String?,       // SAF source URI metadata (WI-4)
+    31	    val addedAt: Long,            // epoch millis
+    32	    val lastOpenedAt: Long?,      // v2 addition — epoch millis of last open, or null
+    33	    val author: String? = null,   // v6 addition (feature #128) — nullable; tail default so no positional site breaks
+    34	)
+    35	
+
+codex
+The live TXT model confirms the premise, but the render mapping needs closer scrutiny: the current host renders each chunk as one `Text`, so “translation after the segment portion” implies splitting/reconstructing the source presentation while preserving selection, highlights, markdown mapping, and offsets. I’m checking whether the plan’s range ownership rule is precise enough to prevent boundary duplicates/drops and whether its tests cover those host invariants.
+exec
+/bin/zsh -lc "rg -n \"class AiProviderStore|data class AiProviderSnapshot|fun snapshot|suspend fun snapshot|fun apiKey|suspend fun apiKey|object AiProviderFactory|class AiProviderFactory|fun create\\(|interface AiClient|fun chat|data class AiRequest|sealed.*AiError|Auth401|RateLimited429|InsecureUrl\" android/app/src/main/kotlin --glob '*.kt' && rg --files android/app/src/main/kotlin | rg '/ai/|Ai'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+android/app/src/main/kotlin/com/vreader/app/tts/AndroidTtsEngine.kt:164:    override suspend fun create(enginePackage: String?): TtsEngine = AndroidTtsEngine(appContext, enginePackage)
+android/app/src/main/kotlin/com/vreader/app/tts/TtsEngine.kt:45:    suspend fun create(enginePackage: String? = null): TtsEngine
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderFactory.kt:10:object AiProviderFactory {
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderFactory.kt:11:    fun create(profile: AiProviderProfile, apiKey: String, dispatcher: CoroutineDispatcher = Dispatchers.IO): AiClient {
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:34:data class AiProviderSnapshot(val profiles: List<AiProviderProfile>, val activeId: String?) {
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:41:class AiProviderStore(
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:47:    suspend fun snapshot(): AiProviderSnapshot = read(dataStore.data.first()).toSnapshot()
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:108:    fun apiKey(profile: AiProviderProfile): String = cipher.decrypt(profile.encryptedApiKey)
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:112:    suspend fun apiKey(id: String): String? =
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt:12:data class AiRequest(
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt:27:sealed class AiError(message: String) : Exception(message) {
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt:28:    object Auth401 : AiError("authentication failed (401) — check the API key")
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt:29:    object RateLimited429 : AiError("rate limited (429) — try again shortly")
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt:36:    object InsecureUrl : AiError("the provider URL must be https:// (won't send the key over cleartext)")
+android/app/src/main/kotlin/com/vreader/app/ai/AiClient.kt:25:interface AiClient {
+android/app/src/main/kotlin/com/vreader/app/ai/AiClient.kt:29:    suspend fun chat(request: AiRequest): AiResponse
+android/app/src/main/kotlin/com/vreader/app/ai/AiClient.kt:82:    final override suspend fun chat(request: AiRequest): AiResponse = withContext(dispatcher) {
+android/app/src/main/kotlin/com/vreader/app/ai/AiClient.kt:144:            401, 403 -> AiError.Auth401
+android/app/src/main/kotlin/com/vreader/app/ai/AiClient.kt:145:            429 -> AiError.RateLimited429
+android/app/src/main/kotlin/com/vreader/app/ai/AiClient.kt:157:        throw AiError.InsecureUrl
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderFactory.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsUiState.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiMarkdownRenderer.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatPanel.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatUiState.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AnthropicProvider.kt
+android/app/src/main/kotlin/com/vreader/app/ai/SseEventReader.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiClient.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderKind.kt
+android/app/src/main/kotlin/com/vreader/app/ai/OpenAiCompatibleProvider.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt
+
+exec
+/bin/zsh -lc "nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt | sed -n '1,125p' && nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiProviderFactory.kt && nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiClient.kt | sed -n '1,45p' && nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt | sed -n '1,48p' && rg -n \"AiProviderStore|AiProviderListScreen|AiSettings\" android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt android/app/src/main/kotlin/com/vreader/app/MainActivity.kt android/app/src/main/kotlin --glob '*.kt'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+     1	// Purpose: feature #118 WI-1 (#110 Phase 3) — persists saved AI provider profiles + the active
+     2	// selection. Profile metadata (name/kind/baseUrl/model/temperature/maxTokens) lives in DataStore
+     3	// as a JSON list; the API key is kept ONLY as a SecretCipher token (the #116 KeystoreSecretCipher).
+     4	// Reuses the #116 WebDavServerStore DataStore+SecretCipher credential pattern, adding an active-id
+     5	// and a request-start `snapshot()` (a chat/test reads one consistent profile, not live mid-request
+     6	// store reads). The key + auth headers are NEVER logged.
+     7	package com.vreader.app.ai
+     8	
+     9	import androidx.datastore.core.DataStore
+    10	import androidx.datastore.preferences.core.Preferences
+    11	import androidx.datastore.preferences.core.edit
+    12	import androidx.datastore.preferences.core.stringPreferencesKey
+    13	import com.vreader.app.backup.net.SecretCipher
+    14	import kotlinx.coroutines.flow.Flow
+    15	import kotlinx.coroutines.flow.first
+    16	import kotlinx.coroutines.flow.map
+    17	import kotlinx.serialization.Serializable
+    18	import kotlinx.serialization.json.Json
+    19	
+    20	/** A saved AI provider. `encryptedApiKey` is a [SecretCipher] token, never plaintext. */
+    21	@Serializable
+    22	data class AiProviderProfile(
+    23	    val id: String,
+    24	    val name: String,
+    25	    val kind: AiProviderKind,
+    26	    val baseUrl: String,
+    27	    val model: String,
+    28	    val temperature: Double = 0.7,
+    29	    val maxTokens: Int = 2048,
+    30	    val encryptedApiKey: String,
+    31	)
+    32	
+    33	/** A consistent point-in-time view: the profiles + which is active. */
+    34	data class AiProviderSnapshot(val profiles: List<AiProviderProfile>, val activeId: String?) {
+    35	    val active: AiProviderProfile? get() = profiles.firstOrNull { it.id == activeId }
+    36	}
+    37	
+    38	@Serializable
+    39	private data class AiStoreState(val profiles: List<AiProviderProfile> = emptyList(), val activeId: String? = null)
+    40	
+    41	class AiProviderStore(
+    42	    private val dataStore: DataStore<Preferences>,
+    43	    private val cipher: SecretCipher,
+    44	    private val json: Json = Json { ignoreUnknownKeys = true; encodeDefaults = true },
+    45	) {
+    46	    /** One consistent profiles + active-id view (read once at request start). */
+    47	    suspend fun snapshot(): AiProviderSnapshot = read(dataStore.data.first()).toSnapshot()
+    48	
+    49	    fun observe(): Flow<AiProviderSnapshot> = dataStore.data.map { read(it).toSnapshot() }
+    50	
+    51	    suspend fun list(): List<AiProviderProfile> = snapshot().profiles
+    52	
+    53	    suspend fun activeProfile(): AiProviderProfile? = snapshot().active
+    54	
+    55	    /**
+    56	     * Insert/update a profile by [id]. [apiKey] is the PLAINTEXT to encrypt; pass null on an edit
+    57	     * that leaves the key unchanged (the existing ciphertext is kept). A brand-new id REQUIRES a
+    58	     * key. The first profile added becomes active. Returns the saved profile (key encrypted).
+    59	     */
+    60	    suspend fun upsert(
+    61	        id: String,
+    62	        name: String,
+    63	        kind: AiProviderKind,
+    64	        baseUrl: String,
+    65	        model: String,
+    66	        temperature: Double,
+    67	        maxTokens: Int,
+    68	        apiKey: String?,
+    69	    ): AiProviderProfile {
+    70	        lateinit var saved: AiProviderProfile
+    71	        dataStore.edit { prefs ->
+    72	            val cur = read(prefs)
+    73	            val existing = cur.profiles.firstOrNull { it.id == id }
+    74	            val encrypted = when {
+    75	                apiKey != null -> cipher.encrypt(apiKey)
+    76	                existing != null -> existing.encryptedApiKey  // unchanged on edit
+    77	                else -> throw IllegalArgumentException("a new provider ($id) requires an API key")
+    78	            }
+    79	            saved = AiProviderProfile(id, name, kind, baseUrl, model, temperature, maxTokens, encrypted)
+    80	            val next = cur.profiles.filterNot { it.id == id } + saved
+    81	            val activeId = cur.activeId ?: id  // first provider becomes active
+    82	            prefs[KEY] = json.encodeToString(AiStoreState(next, activeId))
+    83	        }
+    84	        return saved
+    85	    }
+    86	
+    87	    /** Remove a profile. If it was active, the active selection moves to the first remaining (or null). */
+    88	    suspend fun delete(id: String) {
+    89	        dataStore.edit { prefs ->
+    90	            val cur = read(prefs)
+    91	            val next = cur.profiles.filterNot { it.id == id }
+    92	            val activeId = if (cur.activeId == id) next.firstOrNull()?.id else cur.activeId
+    93	            prefs[KEY] = json.encodeToString(AiStoreState(next, activeId))
+    94	        }
+    95	    }
+    96	
+    97	    /** Select the active provider (no-op if the id isn't present). */
+    98	    suspend fun setActive(id: String) {
+    99	        dataStore.edit { prefs ->
+   100	            val cur = read(prefs)
+   101	            if (cur.profiles.any { it.id == id }) prefs[KEY] = json.encodeToString(cur.copy(activeId = id))
+   102	        }
+   103	    }
+   104	
+   105	    /** Decrypt the key from a CAPTURED [profile] — snapshot-consistent (no live store read). The
+   106	     *  chat/test request path uses THIS with a profile from a single [snapshot], so it can't pair
+   107	     *  snapshot metadata with a concurrently-edited/deleted key. */
+   108	    fun apiKey(profile: AiProviderProfile): String = cipher.decrypt(profile.encryptedApiKey)
+   109	
+   110	    /** The decrypted API key for [id] via a live read, or null if absent. Convenience for UI flows
+   111	     *  that aren't mid-request; the request path should prefer [apiKey] (profile). */
+   112	    suspend fun apiKey(id: String): String? =
+   113	        list().firstOrNull { it.id == id }?.let { cipher.decrypt(it.encryptedApiKey) }
+   114	
+   115	    private fun read(prefs: Preferences): AiStoreState {
+   116	        val raw = prefs[KEY] ?: return AiStoreState()
+   117	        return runCatching { json.decodeFromString<AiStoreState>(raw) }.getOrDefault(AiStoreState())
+   118	    }
+   119	
+   120	    private fun AiStoreState.toSnapshot() = AiProviderSnapshot(profiles, activeId)
+   121	
+   122	    companion object {
+   123	        private val KEY = stringPreferencesKey("ai_providers_json")
+   124	    }
+   125	}
+     1	// Purpose: feature #118 WI-2 (#110 Phase 3) — builds the right AiClient for a provider profile +
+     2	// its decrypted API key. The chat/test request path resolves the active profile from a single
+     3	// AiProviderStore.snapshot(), decrypts via apiKey(profile), and calls this — so the client is built
+     4	// from one consistent snapshot, never live mid-request reads.
+     5	package com.vreader.app.ai
+     6	
+     7	import kotlinx.coroutines.CoroutineDispatcher
+     8	import kotlinx.coroutines.Dispatchers
+     9	
+    10	object AiProviderFactory {
+    11	    fun create(profile: AiProviderProfile, apiKey: String, dispatcher: CoroutineDispatcher = Dispatchers.IO): AiClient {
+    12	        val base = profile.baseUrl.ifBlank { profile.kind.defaultBaseUrl }
+    13	        val model = profile.model.ifBlank { profile.kind.defaultModel }
+    14	        return when (profile.kind) {
+    15	            AiProviderKind.openAiCompatible ->
+    16	                OpenAiCompatibleProvider(base, apiKey, model, profile.temperature, profile.maxTokens, dispatcher)
+    17	            AiProviderKind.anthropicNative ->
+    18	                AnthropicProvider(base, apiKey, model, profile.temperature, profile.maxTokens, dispatcher)
+    19	        }
+    20	    }
+    21	}
+     1	// Purpose: feature #118 WI-2 (#110 Phase 3) — the AI client seam + the shared HTTP/SSE plumbing.
+     2	// `AiClient` mirrors iOS `AIProvider` (stream + one-shot + test-connection); `BaseHttpAiClient` owns
+     3	// the POST-over-HttpURLConnection transport (the #116/#117 precedent), the typed-error mapping, the
+     4	// bounded streaming loop (cancellation disconnects), and a bounded one-shot read. The provider
+     5	// concretes supply only the endpoint path, auth headers, request body, and the per-wire payload
+     6	// parse (OpenAI vs Anthropic). The API key + auth headers are NEVER logged.
+     7	package com.vreader.app.ai
+     8	
+     9	import kotlinx.coroutines.CoroutineDispatcher
+    10	import kotlinx.coroutines.Dispatchers
+    11	import kotlinx.coroutines.ensureActive
+    12	import kotlinx.coroutines.flow.Flow
+    13	import kotlinx.coroutines.flow.flow
+    14	import kotlinx.coroutines.flow.flowOn
+    15	import kotlinx.coroutines.job
+    16	import kotlinx.coroutines.withContext
+    17	import java.io.ByteArrayOutputStream
+    18	import java.io.IOException
+    19	import java.io.InputStream
+    20	import java.net.HttpURLConnection
+    21	import java.net.SocketTimeoutException
+    22	import java.net.URL
+    23	import kotlin.coroutines.coroutineContext
+    24	
+    25	interface AiClient {
+    26	    /** Streamed assistant text deltas. Cancelling the collector disconnects the HTTP stream. */
+    27	    fun streamChat(request: AiRequest): Flow<AiChunk>
+    28	    /** One-shot (non-streamed) completion. */
+    29	    suspend fun chat(request: AiRequest): AiResponse
+    30	    /** A tiny ping → Ok / typed Fail (the editor's Connection section). */
+    31	    suspend fun testConnection(): AiTestResult
+    32	}
+    33	
+    34	/** A parsed SSE delta: incremental [text] (or null if this event carries none) + a [done] sentinel. */
+    35	data class DeltaParse(val text: String?, val done: Boolean)
+    36	
+    37	abstract class BaseHttpAiClient(
+    38	    protected val baseUrl: String,
+    39	    protected val apiKey: String,
+    40	    protected val model: String,
+    41	    protected val temperature: Double,
+    42	    protected val maxTokens: Int,
+    43	    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    44	    private val connectTimeoutMs: Int = 15_000,
+    45	    private val readTimeoutMs: Int = 60_000,
+     1	// Purpose: feature #118 WI-2 (#110 Phase 3) — the AI client value types + typed errors, mirroring
+     2	// iOS AITypes (AIRequest/AIResponse/AIStreamChunk/AIError). Provider-neutral; the OpenAI vs
+     3	// Anthropic wire differences live in the providers.
+     4	package com.vreader.app.ai
+     5	
+     6	enum class AiRole { system, user, assistant }
+     7	
+     8	data class AiMessage(val role: AiRole, val content: String)
+     9	
+    10	/** A chat request. `system` is the system prompt (Anthropic carries it top-level; the OpenAI
+    11	 *  provider prepends it as a system message). */
+    12	data class AiRequest(
+    13	    val model: String,
+    14	    val messages: List<AiMessage>,
+    15	    val temperature: Double,
+    16	    val maxTokens: Int,
+    17	    val system: String? = null,
+    18	)
+    19	
+    20	/** One streamed delta (the incremental assistant text). */
+    21	data class AiChunk(val deltaText: String)
+    22	
+    23	/** A one-shot (non-streamed) response. */
+    24	data class AiResponse(val text: String)
+    25	
+    26	/** Typed AI failures (HTTP + transport + protocol). */
+    27	sealed class AiError(message: String) : Exception(message) {
+    28	    object Auth401 : AiError("authentication failed (401) — check the API key")
+    29	    object RateLimited429 : AiError("rate limited (429) — try again shortly")
+    30	    object Offline : AiError("the provider couldn't be reached")
+    31	    object Timeout : AiError("the provider took too long to respond")
+    32	    class Http(val code: Int) : AiError("HTTP $code from the provider")
+    33	    class Decode(detail: String) : AiError("couldn't parse the provider response: $detail")
+    34	    class Stream(detail: String) : AiError("the stream ended abnormally: $detail")
+    35	    /** Refused to send the API key over cleartext http:// to a non-local host. */
+    36	    object InsecureUrl : AiError("the provider URL must be https:// (won't send the key over cleartext)")
+    37	    class Config(detail: String) : AiError("provider misconfigured: $detail")
+    38	}
+    39	
+    40	/** Test-connection outcome (the editor's Connection section). */
+    41	sealed interface AiTestResult {
+    42	    object Ok : AiTestResult
+    43	    data class Fail(val error: AiError, val message: String) : AiTestResult
+    44	}
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:65:    // AiProviderStore precedent), global (not per-book), process-singleton so a settings change
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderFactory.kt:3:// AiProviderStore.snapshot(), decrypts via apiKey(profile), and calls this — so the client is built
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:46:fun AiProviderListScreen(
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:41:class AiProviderStore(
+android/app/src/main/kotlin/com/vreader/app/opds/ui/OpdsSourcesViewModel.kt:4:// #118 AiSettingsViewModel test path), and saves/deletes. The password is never logged.
+android/app/src/main/kotlin/com/vreader/app/opds/ui/OpdsSourcesViewModel.kt:50:    // closed form). Mirrors AiSettingsViewModel.testGen.
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt:2:// ACTIVE provider from one AiProviderStore snapshot, streams a chat answer (accumulating deltas),
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt:24:    private val store: AiProviderStore,
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:2:// AiProviderStore for the list, owns the editor form state, runs Test Connection against the LIVE
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:20:class AiSettingsViewModel(
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:21:    private val store: AiProviderStore,
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:65:    // AiProviderStore precedent), global (not per-book), process-singleton so a settings change
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:2:// DataStore (the OpdsSourceStore / AiProviderStore JSON-in-Preferences precedent). Global, device-
+
+exec
+/bin/zsh -lc "rg -n \"translatePreSegmented|cachedTranslation\\(|translatedSegmentsDirect|cachedSegmentsDirect|sentenceRanges\\(|struct TranslationChunkContract|enum TranslationChunkContract|class TranslationChunkContract|struct ChapterTranslationChunker|enum ChapterTranslationChunker|subSplit\\(\" vreader/Services/AI --glob '*.swift' && rg --files vreader/Services/AI" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+vreader/Services/AI/ChapterTranslationChunker.swift:21:enum ChapterTranslationChunker {
+vreader/Services/AI/ChapterTranslationChunker.swift:85:    static func subSplit(_ text: String, maxChars: Int) -> [String] {
+vreader/Services/AI/ChapterTranslationPrefetcher.swift:141:        if let cached = await translationService.cachedTranslation(
+vreader/Services/AI/ChapterTranslationPrefetcher.swift:196:    /// then `ChapterTranslationService.translatePreSegmented` (no disk cache).
+vreader/Services/AI/ChapterTranslationPrefetcher.swift:197:    func translatedSegmentsDirect(
+vreader/Services/AI/ChapterTranslationPrefetcher.swift:220:            let out = try await translationService.translatePreSegmented(
+vreader/Services/AI/ChapterTranslationPrefetcher.swift:231:            Self.log.error("prefetchDirect translatePreSegmented failed: \(String(describing: error), privacy: .private)")
+vreader/Services/AI/ChapterTranslationPrefetcher.swift:239:    func cachedSegmentsDirect(
+vreader/Services/AI/ChapterTranslationPrefetcher.swift:244:        await translationService.cachedTranslation(
+vreader/Services/AI/TranslationChunkContract.swift:24:enum TranslationChunkContract {
+vreader/Services/AI/ChapterSegmenter.swift:73:    /// COUNT-PARITY CONTRACT: `sentenceRanges(in: s).count ==
+vreader/Services/AI/ChapterSegmenter.swift:78:    static func sentenceRanges(in chapterText: String) -> [Range<Int>] {
+vreader/Services/AI/ChapterPrefetching.swift:46:    func translatedSegmentsDirect(
+vreader/Services/AI/ChapterPrefetching.swift:56:    func cachedSegmentsDirect(
+vreader/Services/AI/ChapterPrefetching.swift:68:    func translatedSegmentsDirect(
+vreader/Services/AI/ChapterPrefetching.swift:78:    func cachedSegmentsDirect(
+vreader/Services/AI/ChapterTranslationService.swift:119:    func cachedTranslation(
+vreader/Services/AI/ChapterTranslationService.swift:148:    func cachedTranslation(
+vreader/Services/AI/ChapterTranslationService.swift:321:    /// `cachedTranslation(expectedSegmentCount:)` with zero provider calls.
+vreader/Services/AI/ChapterTranslationService.swift:327:    func translatePreSegmented(
+vreader/Services/AI/ChapterTranslationService.swift:412:            let pieces = ChapterTranslationChunker.subSplit(
+vreader/Services/AI/AIProvider.swift
+vreader/Services/AI/AgenticChatDriver.swift
+vreader/Services/AI/MockAIProvider.swift
+vreader/Services/AI/AITypes.swift
+vreader/Services/AI/ChapterPrefetching.swift
+vreader/Services/AI/AIToolRegistry.swift
+vreader/Services/AI/ProviderKind.swift
+vreader/Services/AI/ChatContextScope.swift
+vreader/Services/AI/ProviderProfileStore.swift
+vreader/Services/AI/ProviderConfigResolving.swift
+vreader/Services/AI/ChapterTranslationPrefetcher.swift
+vreader/Services/AI/UTF16Clamp.swift
+vreader/Services/AI/AnthropicProvider+ToolUse.swift
+vreader/Services/AI/SummaryScope.swift
+vreader/Services/AI/InterruptedTranslationJobStore.swift
+vreader/Services/AI/ChapterTranslationChunker.swift
+vreader/Services/AI/AIConsentManager.swift
+vreader/Services/AI/TranslationChunkContract.swift
+vreader/Services/AI/WholeBookReducer.swift
+vreader/Services/AI/ProviderProfileMigrator.swift
+vreader/Services/AI/ProviderProfile.swift
+vreader/Services/AI/ChatAnnotationContext.swift
+vreader/Services/AI/SummaryScopeResolver.swift
+vreader/Services/AI/ChapterBounds.swift
+vreader/Services/AI/OpenAICompatibleProvider+ToolUse.swift
+vreader/Services/AI/AIContextExtractor.swift
+vreader/Services/AI/BookTranslationProgress.swift
+vreader/Services/AI/AIResponseCache.swift
+vreader/Services/AI/ChatAnnotationCache.swift
+vreader/Services/AI/ChatContextScope+Menu.swift
+vreader/Services/AI/ChatSourceSelection.swift
+vreader/Services/AI/AIConfigurationStore.swift
+vreader/Services/AI/AIContextExtracting.swift
+vreader/Services/AI/BookTranslationCoordinator.swift
+vreader/Services/AI/ChatCitation.swift
+vreader/Services/AI/AIError.swift
+vreader/Services/AI/ResolvedAIProviderConfig.swift
+vreader/Services/AI/AIService.swift
+vreader/Services/AI/ChatCitationFactory.swift
+vreader/Services/AI/UTF16TextSlicer.swift
+vreader/Services/AI/AIConfiguration.swift
+vreader/Services/AI/AITool.swift
+vreader/Services/AI/ChapterSegmenter.swift
+vreader/Services/AI/BilingualAIReadiness.swift
+vreader/Services/AI/TranslationStyle.swift
+vreader/Services/AI/Tools/GetBookContentTool.swift
+vreader/Services/AI/Tools/LibraryBookSearchGate.swift
+vreader/Services/AI/Tools/SearchCurrentBookTool.swift
+vreader/Services/AI/Tools/AgenticToolRegistryBuilder.swift
+vreader/Services/AI/Tools/ListLibraryTool.swift
+vreader/Services/AI/Tools/ToolResultText.swift
+vreader/Services/AI/Tools/LibrarySearchBackendAdapter.swift
+vreader/Services/AI/Tools/SearchOtherBooksTool.swift
+vreader/Services/AI/Tools/ClosedBookTextExtractor.swift
+vreader/Services/AI/Tools/BookContentProviderAdapter.swift
+vreader/Services/AI/Tools/GetBookContentGate.swift
+vreader/Services/AI/KeychainService+ProviderProfile.swift
+vreader/Services/AI/ChapterTranslationService.swift
+vreader/Services/AI/ChatContextAssembler.swift
+vreader/Services/AI/AnthropicProvider+Streaming.swift
+vreader/Services/AI/AnthropicProvider.swift
+vreader/Services/AI/AIChatAgenticSupport.swift
+vreader/Services/AI/AIReaderAvailability.swift
+
+exec
+/bin/zsh -lc "nl -ba vreader/Services/AI/ChapterSegmenter.swift | sed -n '1,125p' && nl -ba vreader/Services/AI/TranslationChunkContract.swift | sed -n '1,150p' && nl -ba vreader/Services/AI/ChapterTranslationChunker.swift | sed -n '1,125p' && nl -ba vreader/Services/AI/ChapterTranslationService.swift | sed -n '105,180p;300,390p' && nl -ba vreader/Services/AI/ChapterTranslationPrefetcher.swift | sed -n '185,260p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+     1	// Purpose: Pure segmentation utility for feature #56 bilingual reading. Splits
+     2	// a chapter's plain text into translation segments — either paragraphs or
+     3	// sentences, selected by the book's `granularity` setting (design §2.2).
+     4	//
+     5	// Key decisions:
+     6	// - Paragraph split is blank-line / block-boundary based: a single newline is
+     7	//   a soft wrap (same paragraph), a blank line separates paragraphs.
+     8	// - Sentence split uses `String.enumerateSubstrings(.bySentences)`, which is
+     9	//   locale-aware and handles CJK fullwidth terminators (。！？) as well as
+    10	//   Latin punctuation — no manual punctuation table.
+    11	// - Every produced segment is whitespace-trimmed and empty segments dropped,
+    12	//   so a translation request never carries a blank segment.
+    13	//
+    14	// @coordinates-with: ChapterTranslationChunker.swift,
+    15	//   ChapterTranslationService.swift,
+    16	//   dev-docs/plans/20260519-feature-56-bilingual-reading.md (WI-4)
+    17	
+    18	import Foundation
+    19	
+    20	/// Pure paragraph / sentence segmentation for chapter translation.
+    21	enum ChapterSegmenter {
+    22	
+    23	    /// Splits chapter text into paragraphs. Paragraphs are separated by one or
+    24	    /// more blank lines; a single line break inside a paragraph is a soft wrap
+    25	    /// and does not split. Each paragraph is trimmed; empty ones are dropped.
+    26	    static func paragraphs(in chapterText: String) -> [String] {
+    27	        // Bug #344 (Gate-4 Medium): derive from the SAME range scanner the
+    28	        // TXT/MD display side uses, so the blank-line definition can never
+    29	        // diverge between the two sides of the 1:1 contract. The old regex
+    30	        // split only on `\\n[ \\t]*\\n+`, while the display scanner treats ANY
+    31	        // whitespace-only line (incl. U+3000 / U+00A0 — common in CJK
+    32	        // files) as a separator — that divergence made the display side
+    33	        // count MORE paragraphs than the translation side and paint
+    34	        // source-only. Each scan range contains at least one
+    35	        // non-whitespace character by construction, so trimming never
+    36	        // yields an empty (and no filter is applied — a filter could
+    37	        // re-introduce a count skew against the raw ranges).
+    38	        let ns = chapterText as NSString
+    39	        return BilingualParagraphRanges.scan(sourceText: chapterText).map {
+    40	            ns.substring(with: NSRange(
+    41	                location: $0.lowerBound, length: $0.upperBound - $0.lowerBound))
+    42	                // Preserve the pre-#344 contract: soft-wrap line endings
+    43	                // inside a paragraph normalize to \n (Gate-4 round 2 —
+    44	                // translation prompts + cached rows carried \n, never \r\n).
+    45	                .replacingOccurrences(of: "\r\n", with: "\n")
+    46	                .replacingOccurrences(of: "\r", with: "\n")
+    47	                .trimmingCharacters(in: .whitespacesAndNewlines)
+    48	        }
+    49	    }
+    50	
+    51	    /// Splits chapter text into sentences. CJK-aware via
+    52	    /// `enumerateSubstrings(.bySentences)`. Each sentence is trimmed; empty
+    53	    /// fragments are dropped.
+    54	    static func sentences(in chapterText: String) -> [String] {
+    55	        var result: [String] = []
+    56	        let full = chapterText.startIndex..<chapterText.endIndex
+    57	        chapterText.enumerateSubstrings(in: full, options: [.bySentences, .localized]) {
+    58	            substring, _, _, _ in
+    59	            guard let substring else { return }
+    60	            let trimmed = substring.trimmingCharacters(in: .whitespacesAndNewlines)
+    61	            if !trimmed.isEmpty {
+    62	                result.append(trimmed)
+    63	            }
+    64	        }
+    65	        // `.bySentences` on a fragment with no terminal punctuation still
+    66	        // yields the fragment; only a fully-empty input yields nothing.
+    67	        return result
+    68	    }
+    69	
+    70	    /// Bug #344: UTF-16 half-open ranges of each sentence (trimmed bounds),
+    71	    /// in source order — the display-side twin of `sentences(in:)`.
+    72	    ///
+    73	    /// COUNT-PARITY CONTRACT: `sentenceRanges(in: s).count ==
+    74	    /// sentences(in: s).count` for every input. Both walk the same
+    75	    /// `.bySentences` enumeration with the same trim + drop-empty rules, so
+    76	    /// the TXT/MD sentence-interlinear renderer and the translation
+    77	    /// segmentation pair 1:1 by construction (the #266/#343 contract).
+    78	    static func sentenceRanges(in chapterText: String) -> [Range<Int>] {
+    79	        var result: [Range<Int>] = []
+    80	        let full = chapterText.startIndex..<chapterText.endIndex
+    81	        let whitespace = CharacterSet.whitespacesAndNewlines
+    82	        chapterText.enumerateSubstrings(in: full, options: [.bySentences, .localized]) {
+    83	            substring, substringRange, _, _ in
+    84	            guard let substring else { return }
+    85	            let nsRange = NSRange(substringRange, in: chapterText)
+    86	            // Shrink the range to the trimmed bounds so the interlinear row
+    87	            // lands flush after the sentence's last visible character —
+    88	            // mirroring `sentences(in:)`'s trim. Surrogate halves are never
+    89	            // whitespace, so per-UTF-16-unit scanning is safe.
+    90	            let units = Array(substring.utf16)
+    91	            var lead = 0
+    92	            while lead < units.count,
+    93	                  let scalar = Unicode.Scalar(UInt32(units[lead])),
+    94	                  whitespace.contains(scalar) {
+    95	                lead += 1
+    96	            }
+    97	            var trail = 0
+    98	            while trail < units.count - lead,
+    99	                  let scalar = Unicode.Scalar(UInt32(units[units.count - 1 - trail])),
+   100	                  whitespace.contains(scalar) {
+   101	                trail += 1
+   102	            }
+   103	            let start = nsRange.location + lead
+   104	            let end = nsRange.location + nsRange.length - trail
+   105	            // Whitespace-only fragments trim to nothing — `sentences(in:)`
+   106	            // drops them, so the range scanner must too (count parity).
+   107	            guard start < end else { return }
+   108	            result.append(start..<end)
+   109	        }
+   110	        return result
+   111	    }
+   112	
+   113	}
+     1	// Purpose: The strict JSON-array prompt + decode contract for feature #56
+     2	// bilingual chapter translation. The model is instructed to return ONLY a JSON
+     3	// array of N translated strings in source order; the decoder strictly
+     4	// validates that the response is exactly that — N string elements.
+     5	//
+     6	// Key decisions:
+     7	// - `AIRequest` has no API-level `response_format` field (verified), so the
+     8	//   "return only a JSON array" contract is prompt-level + strict JSON decode
+     9	//   (v4 Gate-2 finding F5 — rare-delimiter splitting was rejected because the
+    10	//   model can reproduce any delimiter; a JSON-array schema is unambiguous).
+    11	// - The decoder tolerates a leading/trailing ```json fence and surrounding
+    12	//   whitespace (models add them), but is strict about the element count and
+    13	//   that every element is a string — anything else throws so the caller
+    14	//   (`ChapterTranslationService`) falls back to one-segment-per-request.
+    15	// - `style` is folded into the prompt HERE and only here (Gate-2 round-2 N4).
+    16	//
+    17	// @coordinates-with: ChapterSegmenter.swift, ChapterTranslationChunker.swift,
+    18	//   ChapterTranslationService.swift, TranslationStyle.swift,
+    19	//   dev-docs/plans/20260519-feature-56-bilingual-reading.md (WI-4)
+    20	
+    21	import Foundation
+    22	
+    23	/// Builds the chunk translation prompt and strictly decodes the response.
+    24	enum TranslationChunkContract {
+    25	
+    26	    /// A decode failure — surfaced so the service can fall back to a
+    27	    /// one-segment-per-request retry.
+    28	    enum DecodeError: Error, Equatable {
+    29	        /// The response was not a JSON array of strings.
+    30	        case notAStringArray
+    31	        /// The array length did not equal the expected segment count.
+    32	        case countMismatch(expected: Int, actual: Int)
+    33	    }
+    34	
+    35	    /// Builds the `userPrompt` for one chunk of source segments. The model is
+    36	    /// told to translate each segment into `targetLanguage` in the given
+    37	    /// `style` and return ONLY a JSON array of exactly N strings, same order.
+    38	    static func userPrompt(
+    39	        segments: [String],
+    40	        targetLanguage: String,
+    41	        style: TranslationStyle
+    42	    ) -> String {
+    43	        let count = segments.count
+    44	        let styleClause: String
+    45	        switch style {
+    46	        case .literal:
+    47	            styleClause = "Use a LITERAL, word-for-word translation that stays "
+    48	                + "close to the source sentence structure."
+    49	        case .natural:
+    50	            styleClause = "Use NATURAL, idiomatic \(targetLanguage) phrasing that "
+    51	                + "reads fluently to a native speaker."
+    52	        case .literary:
+    53	            styleClause = "Use a LITERARY, polished translation with elevated, "
+    54	                + "well-crafted \(targetLanguage) prose."
+    55	        }
+    56	
+    57	        // Number the segments so the model's array ordering is unambiguous.
+    58	        let numbered = segments.enumerated()
+    59	            .map { "[\($0.offset)] \($0.element)" }
+    60	            .joined(separator: "\n\n")
+    61	
+    62	        return """
+    63	        Translate each of the following \(count) text segment(s) into \(targetLanguage).
+    64	        \(styleClause)
+    65	
+    66	        Respond with ONLY a JSON array of exactly \(count) string(s) — the \
+    67	        translation of each segment, in the same order. No commentary, no keys, \
+    68	        no markdown — just the JSON array.
+    69	
+    70	        Source segments:
+    71	        \(numbered)
+    72	        """
+    73	    }
+    74	
+    75	    /// Strictly decodes a model response into exactly `expectedCount`
+    76	    /// translated strings. Tolerates a surrounding ```json fence and
+    77	    /// whitespace; throws `DecodeError` on anything that is not a JSON array
+    78	    /// of exactly that many string elements.
+    79	    static func decode(_ raw: String, expectedCount: Int) throws -> [String] {
+    80	        let cleaned = stripCodeFence(raw).trimmingCharacters(in: .whitespacesAndNewlines)
+    81	        guard let data = cleaned.data(using: .utf8) else {
+    82	            throw DecodeError.notAStringArray
+    83	        }
+    84	        let decoded: [String]
+    85	        do {
+    86	            decoded = try JSONDecoder().decode([String].self, from: data)
+    87	        } catch {
+    88	            // Decodes-but-not-as-[String] (object, number element, nested
+    89	            // array, …) → not a string array.
+    90	            throw DecodeError.notAStringArray
+    91	        }
+    92	        guard decoded.count == expectedCount else {
+    93	            throw DecodeError.countMismatch(expected: expectedCount, actual: decoded.count)
+    94	        }
+    95	        return decoded
+    96	    }
+    97	
+    98	    /// Removes a leading/trailing Markdown code fence (```json … ``` or ``` … ```).
+    99	    ///
+   100	    /// The closing fence is removed ONLY when the final non-whitespace line is
+   101	    /// exactly ```` ``` ````. A bare ```` ``` ```` occurring *inside* the
+   102	    /// payload (e.g. a JSON string element that literally contains backticks)
+   103	    /// is left intact — searching backwards for any backtick run would
+   104	    /// truncate such a legitimate payload (Gate-4 round-1 Medium).
+   105	    private static func stripCodeFence(_ raw: String) -> String {
+   106	        let text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+   107	        guard text.hasPrefix("```") else { return text }
+   108	
+   109	        var lines = text.components(separatedBy: "\n")
+   110	        // Drop the opening fence line (``` or ```json). With no newline at all
+   111	        // the input is just a lone fence — nothing to unwrap.
+   112	        guard lines.count > 1 else { return text }
+   113	        lines.removeFirst()
+   114	
+   115	        // Drop the closing fence only if the LAST non-blank line is exactly ```.
+   116	        if let lastNonBlankIndex = lines.lastIndex(where: {
+   117	            !$0.trimmingCharacters(in: .whitespaces).isEmpty
+   118	        }), lines[lastNonBlankIndex].trimmingCharacters(in: .whitespaces) == "```" {
+   119	            lines.removeSubrange(lastNonBlankIndex...)
+   120	        }
+   121	        return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+   122	    }
+   123	}
+     1	// Purpose: Pure chunking utility for feature #56 bilingual reading. Groups
+     2	// translation segment indices into chunks each under a provider character
+     3	// budget, so a chapter that exceeds the provider's context window is sent as
+     4	// several requests (edge case (a)).
+     5	//
+     6	// Key decisions:
+     7	// - A segment is NEVER split across chunks — the response↔source mapping
+     8	//   depends on a 1:1 segment correspondence within a chunk.
+     9	// - One over-budget segment occupies its own chunk; recombination across
+    10	//   chunks is the caller's job (`ChapterTranslationService`).
+    11	// - The budget is a CHARACTER count (`String.count`), not a byte count —
+    12	//   CJK text is multi-byte in UTF-8 but the provider window is token/char
+    13	//   based and char count is the closer, format-agnostic proxy.
+    14	//
+    15	// @coordinates-with: ChapterSegmenter.swift, ChapterTranslationService.swift,
+    16	//   dev-docs/plans/20260519-feature-56-bilingual-reading.md (WI-4)
+    17	
+    18	import Foundation
+    19	
+    20	/// Pure segment-boundary chunker for chapter translation.
+    21	enum ChapterTranslationChunker {
+    22	
+    23	    /// Groups `segments` indices into chunks, each chunk's total character
+    24	    /// count not exceeding `maxCharsPerChunk` — except a single segment that
+    25	    /// is itself over budget, which occupies its own chunk.
+    26	    ///
+    27	    /// - Parameter maxCharsPerChunk: the per-chunk character budget; expected
+    28	    ///   to be `> 0`. A non-positive budget is defensively coerced to `1`
+    29	    ///   (every non-empty segment then gets its own chunk) so the function
+    30	    ///   never divides by zero or loops — but callers should pass a real
+    31	    ///   provider budget.
+    32	    /// - Returns: an ordered array of index arrays. Flattening it yields
+    33	    ///   `0..<segments.count` in order — every index appears exactly once.
+    34	    static func chunk(segments: [String], maxCharsPerChunk: Int) -> [[Int]] {
+    35	        guard !segments.isEmpty else { return [] }
+    36	        let budget = max(1, maxCharsPerChunk)
+    37	
+    38	        var chunks: [[Int]] = []
+    39	        var current: [Int] = []
+    40	        var currentCount = 0
+    41	
+    42	        for (index, segment) in segments.enumerated() {
+    43	            let segmentCount = segment.count
+    44	
+    45	            // An over-budget segment that would not fit even an empty chunk:
+    46	            // flush the current chunk, then give the big segment its own.
+    47	            if segmentCount > budget {
+    48	                if !current.isEmpty {
+    49	                    chunks.append(current)
+    50	                    current = []
+    51	                    currentCount = 0
+    52	                }
+    53	                chunks.append([index])
+    54	                continue
+    55	            }
+    56	
+    57	            // Adding this segment would overflow the current chunk → start one.
+    58	            if !current.isEmpty && currentCount + segmentCount > budget {
+    59	                chunks.append(current)
+    60	                current = []
+    61	                currentCount = 0
+    62	            }
+    63	
+    64	            current.append(index)
+    65	            currentCount += segmentCount
+    66	        }
+    67	
+    68	        if !current.isEmpty {
+    69	            chunks.append(current)
+    70	        }
+    71	        return chunks
+    72	    }
+    73	
+    74	    /// Bug #330: sub-splits a SINGLE over-budget segment (an oversized paragraph)
+    75	    /// into ordered pieces each `≤ maxChars`, so it can be translated piece by
+    76	    /// piece instead of sent whole (which overflows the provider context window
+    77	    /// → error). Splits on the last whitespace within each budget window when one
+    78	    /// exists (keeps words/sentences intact for space-delimited languages); falls
+    79	    /// back to a hard character boundary for a long unbroken run (e.g. CJK, which
+    80	    /// has no inter-word whitespace). Grapheme-based (`Character`/`String.Index`),
+    81	    /// so it never splits a surrogate pair or combining sequence.
+    82	    ///
+    83	    /// - Returns: `[text]` unchanged when `text.count ≤ maxChars`; otherwise the
+    84	    ///   ordered pieces, which concatenate back to `text`.
+    85	    static func subSplit(_ text: String, maxChars: Int) -> [String] {
+    86	        let cap = max(1, maxChars)
+    87	        guard text.count > cap else { return [text] }
+    88	
+    89	        var pieces: [String] = []
+    90	        var remaining = Substring(text)
+    91	        while remaining.count > cap {
+    92	            let hardEnd = remaining.index(remaining.startIndex, offsetBy: cap)
+    93	            // Back up to the last whitespace within the [start, hardEnd) window.
+    94	            var breakAt = hardEnd
+    95	            var i = hardEnd
+    96	            while i > remaining.startIndex {
+    97	                let prev = remaining.index(before: i)
+    98	                if remaining[prev].isWhitespace { breakAt = i; break }
+    99	                i = prev
+   100	            }
+   101	            // No whitespace in the window (one long token) → hard split at cap.
+   102	            if breakAt == remaining.startIndex { breakAt = hardEnd }
+   103	            pieces.append(String(remaining[remaining.startIndex..<breakAt]))
+   104	            remaining = remaining[breakAt...]
+   105	        }
+   106	        if !remaining.isEmpty { pieces.append(String(remaining)) }
+   107	        return pieces
+   108	    }
+   109	}
+   105	    /// cached translation when a fresh (count-matching) row exists, else nil.
+   106	    /// Lets the prefetcher serve an already-translated chapter BEFORE the
+   107	    /// provider gate (`resolveProviderConfig`), so a cached chapter still renders
+   108	    /// when AI is later disabled / unconfigured / key-less — previously the gate
+   109	    /// threw first and the disk cache (inside `translate`) was never reached.
+   110	    /// Bug #342: profile-agnostic — the canonical row is shared across provider
+   111	    /// profiles, so no profile is needed for a read at all.
+   112	    /// Bug #343 `acceptCountMismatch`: self-healing consumers (the EPUB hosts
+   113	    /// with the divergence fallback) may opt in to receive a fresh row whose
+   114	    /// stored count differs from the live re-derived segmenter count — the
+   115	    /// row may carry the DOM-enumerate contract (written by the divergence
+   116	    /// fallback), which pairs 1:1 at inject time; on a true source change the
+   117	    /// fallback re-translates and replaces the row. Default-off callers keep
+   118	    /// the strict staleness guard.
+   119	    func cachedTranslation(
+   120	        bookFingerprintKey: String,
+   121	        unit: TranslationUnitID,
+   122	        sourceText: String,
+   123	        targetLanguage: String,
+   124	        granularity: TranslationGranularity = .paragraph,
+   125	        acceptCountMismatch: Bool = false
+   126	    ) async -> ChapterTranslationResult? {
+   127	        let lookupKey = ChapterTranslationRecord.lookupKey(
+   128	            bookFingerprintKey: bookFingerprintKey,
+   129	            unitStorageKey: unit.storageKey,
+   130	            targetLanguage: targetLanguage,
+   131	            promptVersion: promptVersion)
+   132	        let segments: [String]
+   133	        switch granularity {
+   134	        case .paragraph: segments = ChapterSegmenter.paragraphs(in: sourceText)
+   135	        case .sentence:  segments = ChapterSegmenter.sentences(in: sourceText)
+   136	        }
+   137	        guard let cached = await store.translation(forKey: lookupKey) else { return nil }
+   138	        guard cached.sourceParagraphCount == segments.count || acceptCountMismatch else {
+   139	            return nil
+   140	        }
+   141	        return ChapterTranslationResult(segments: cached.translatedSegments, fromCache: true)
+   142	    }
+   143	
+   144	    /// Bug #343: the divergence-fallback restore — serves the canonical row
+   145	    /// only when its STORED count matches the caller's own structure (the DOM
+   146	    /// enumerate's block count), so blocks↔segments pair 1:1 by contract.
+   147	    /// Needs no provider config and no source text.
+   148	    func cachedTranslation(
+   149	        bookFingerprintKey: String,
+   150	        unit: TranslationUnitID,
+   151	        expectedSegmentCount: Int,
+   152	        targetLanguage: String
+   153	    ) async -> ChapterTranslationResult? {
+   154	        let lookupKey = ChapterTranslationRecord.lookupKey(
+   155	            bookFingerprintKey: bookFingerprintKey,
+   156	            unitStorageKey: unit.storageKey,
+   157	            targetLanguage: targetLanguage,
+   158	            promptVersion: promptVersion)
+   159	        guard let cached = await store.translation(forKey: lookupKey),
+   160	              cached.sourceParagraphCount == expectedSegmentCount else { return nil }
+   161	        return ChapterTranslationResult(segments: cached.translatedSegments, fromCache: true)
+   162	    }
+   163	
+   164	    /// Translates `unit`'s source text into `targetLanguage`. Serves from the
+   165	    /// disk cache on a hit; on a miss segments → chunks → requests → decodes →
+   166	    /// caches. Throws `ChapterTranslationError` on a provider failure or
+   167	    /// cancellation.
+   168	    func translate(
+   169	        bookFingerprintKey: String,
+   170	        unit: TranslationUnitID,
+   171	        sourceText: String,
+   172	        targetLanguage: String,
+   173	        providerProfileID: UUID,
+   174	        config: ResolvedAIProviderConfig,
+   175	        style: TranslationStyle,
+   176	        granularity: TranslationGranularity = .paragraph,
+   177	        // Bug #341: when true, the cache READ is skipped — a fresh cached row
+   178	        // must not short-circuit an explicit re-translate into a stale no-op.
+   179	        // The cache WRITE still runs: the upsert replaces the row by lookupKey
+   180	        // in place, which is the atomic swap (the old translation survives
+   300	                    translatedSegments: translated,
+   301	                    sourceParagraphCount: segments.count))
+   302	            } catch {
+   303	                log.error("Cache-write failed (translation still returned): \(String(describing: error), privacy: .public)")
+   304	            }
+   305	        }
+   306	
+   307	        return ChapterTranslationResult(segments: translated, fromCache: false)
+   308	    }
+   309	
+   310	    /// Bug #268: translates a PRE-SEGMENTED list of source segments directly,
+   311	    /// bypassing `ChapterSegmenter`. Used by the bilingual EPUB
+   312	    /// divergence-fallback: when the DOM leaf-enumerate's block count
+   313	    /// diverges from the plain-text paragraph segmentation (nested `<pre>` /
+   314	    /// mixed-content `<blockquote>`), translating the enumerate's OWN block
+   315	    /// `text[]` makes blocks↔segments 1:1 BY CONSTRUCTION — eliminating the
+   316	    /// whole-chapter source-only fallback. The returned array is always the same
+   317	    /// length as `segments`.
+   318	    ///
+   319	    /// Bug #343: the result IS cached now — the canonical row stores the
+   320	    /// ENUMERATE's count as its contract, so a toggle/reopen restores via
+   321	    /// `cachedTranslation(expectedSegmentCount:)` with zero provider calls.
+   322	    /// (#268 originally skipped the cache to avoid thrashing the plain-text
+   323	    /// path's differently-counted row; post-#342 there is ONE canonical row
+   324	    /// and the divergence fallback is its self-healing writer of last resort.)
+   325	    /// A partially-degraded result (Bug #330) is NOT cached, mirroring
+   326	    /// `translate`.
+   327	    func translatePreSegmented(
+   328	        bookFingerprintKey: String,
+   329	        unit: TranslationUnitID,
+   330	        segments: [String],
+   331	        targetLanguage: String,
+   332	        providerProfileID: UUID,
+   333	        config: ResolvedAIProviderConfig,
+   334	        style: TranslationStyle
+   335	    ) async throws -> [String] {
+   336	        guard !segments.isEmpty else { return [] }
+   337	        let chunks = ChapterTranslationChunker.chunk(
+   338	            segments: segments, maxCharsPerChunk: maxCharsPerChunk)
+   339	        var translated = [String](repeating: "", count: segments.count)
+   340	        // Bug #330: same graceful degradation as `translate` — a single chunk's
+   341	        // failure leaves its segments source-only; an all-chunks failure surfaces
+   342	        // the error.
+   343	        var anyChunkSucceeded = false
+   344	        var lastChunkError: Error?
+   345	        for chunk in chunks {
+   346	            do {
+   347	                try Task.checkCancellation()
+   348	            } catch {
+   349	                throw ChapterTranslationError.cancelled
+   350	            }
+   351	            let chunkSegments = chunk.map { segments[$0] }
+   352	            do {
+   353	                let chunkResult = try await translateChunk(
+   354	                    chunkSegments, targetLanguage: targetLanguage, config: config, style: style)
+   355	                for (offset, segmentIndex) in chunk.enumerated() {
+   356	                    translated[segmentIndex] = chunkResult[offset]
+   357	                }
+   358	                anyChunkSucceeded = true
+   359	            } catch is CancellationError {
+   360	                throw ChapterTranslationError.cancelled
+   361	            } catch ChapterTranslationError.cancelled {
+   362	                // Bug #330 (Codex): typed cancellation from `send()` must abort,
+   363	                // not degrade.
+   364	                throw ChapterTranslationError.cancelled
+   365	            } catch {
+   366	                log.error("Pre-segmented chunk failed (segments \(chunk) source-only): \(String(describing: error), privacy: .public)")
+   367	                lastChunkError = error
+   368	            }
+   369	        }
+   370	        if !anyChunkSucceeded, let err = lastChunkError {
+   371	            throw err
+   372	        }
+   373	
+   374	        // Bug #343: cache the fully-successful result under the canonical key
+   375	        // with the ENUMERATE's count as the stored contract. Mirrors
+   376	        // `translate`: a partial degrade is never cached (Bug #330), and a
+   377	        // store-write failure does not fail the translation (rule 50 §6).
+   378	        if lastChunkError == nil {
+   379	            do {
+   380	                try await store.upsert(ChapterTranslationRecord(
+   381	                    bookFingerprintKey: bookFingerprintKey,
+   382	                    unitStorageKey: unit.storageKey,
+   383	                    targetLanguage: targetLanguage,
+   384	                    providerProfileID: providerProfileID,
+   385	                    promptVersion: promptVersion,
+   386	                    translatedSegments: translated,
+   387	                    sourceParagraphCount: segments.count))
+   388	            } catch {
+   389	                log.error("Pre-segmented cache-write failed (translation still returned): \(String(describing: error), privacy: .public)")
+   390	            }
+   185	            )
+   186	            return result.segments
+   187	        } catch {
+   188	            Self.log.error("prefetch translate call failed for unit \(String(describing: unit), privacy: .public): \(String(describing: error), privacy: .private)")
+   189	            throw error
+   190	        }
+   191	    }
+   192	
+   193	    /// Bug #268: translate the render's OWN enumerated block texts directly
+   194	    /// (1:1 by construction), bypassing the unit's plain-text segmentation.
+   195	    /// Same provider snapshot + resolve + error contract as `translatedSegments`,
+   196	    /// then `ChapterTranslationService.translatePreSegmented` (no disk cache).
+   197	    func translatedSegmentsDirect(
+   198	        for unit: TranslationUnitID,
+   199	        sourceSegments: [String],
+   200	        targetLanguage: String
+   201	    ) async throws -> [String] {
+   202	        guard !sourceSegments.isEmpty else { return [] }
+   203	        Self.log.debug("prefetchDirect start: unit \(String(describing: unit), privacy: .public), \(sourceSegments.count) segments")
+   204	        // Snapshot the active profile + resolve its config (mirrors
+   205	        // `translatedSegments` so a provider switch can't straddle).
+   206	        guard let activeProfile = await ProviderProfileStore.shared
+   207	            .activeProfileSnapshot() else {
+   208	            Self.log.error("prefetchDirect: no active provider profile")
+   209	            throw ChapterTranslationError.providerFailed("no active provider profile")
+   210	        }
+   211	        let config: ResolvedAIProviderConfig
+   212	        do {
+   213	            config = try await aiService.resolveProviderConfig(
+   214	                profileID: activeProfile.id, modelOverride: nil)
+   215	        } catch {
+   216	            Self.log.error("prefetchDirect resolveProviderConfig failed: \(String(describing: error), privacy: .private)")
+   217	            throw ChapterTranslationError.providerFailed("provider config unavailable")
+   218	        }
+   219	        do {
+   220	            let out = try await translationService.translatePreSegmented(
+   221	                bookFingerprintKey: bookFingerprintKey,
+   222	                unit: unit,
+   223	                segments: sourceSegments,
+   224	                targetLanguage: targetLanguage,
+   225	                providerProfileID: activeProfile.id,
+   226	                config: config,
+   227	                style: style)
+   228	            Self.log.debug("prefetchDirect ok: \(out.count) translated segments")
+   229	            return out
+   230	        } catch {
+   231	            Self.log.error("prefetchDirect translatePreSegmented failed: \(String(describing: error), privacy: .private)")
+   232	            throw error
+   233	        }
+   234	    }
+   235	
+   236	    /// Bug #343: cache-only restore for the divergence fallback — serves the
+   237	    /// canonical row when its stored contract matches the enumerate's own
+   238	    /// block count. Needs no provider config (the #306 pre-gate precedent).
+   239	    func cachedSegmentsDirect(
+   240	        for unit: TranslationUnitID,
+   241	        expectedCount: Int,
+   242	        targetLanguage: String
+   243	    ) async -> [String]? {
+   244	        await translationService.cachedTranslation(
+   245	            bookFingerprintKey: bookFingerprintKey,
+   246	            unit: unit,
+   247	            expectedSegmentCount: expectedCount,
+   248	            targetLanguage: targetLanguage)?.segments
+   249	    }
+   250	}
+
+exec
+/bin/zsh -lc "rg -n \"readium|r2-navigator|3\\.3\\.0\" android gradle build.gradle.kts settings.gradle.kts gradle/libs.versions.toml --glob '*.kts' --glob '*.toml' --glob '*.gradle' 2>/dev/null; find ~/.gradle/caches/modules-2/files-2.1 -path '*readium*3.3.0*' -type f 2>/dev/null | head -50; find ~/.gradle/caches/transforms-* -type f \\( -name '*EpubNavigatorFragment*' -o -name 'classes.jar' \\) 2>/dev/null | head -20" in /Users/ll/workspace/vreader
+ succeeded in 216ms:
+/Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-streamer/3.3.0/64eae89c549412891cd2305bdc589ce78ce596e2/readium-streamer-3.3.0.pom
+/Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-streamer/3.3.0/295ee0de4c0d933009ef84a000683c5012b0b0ab/readium-streamer-3.3.0.module
+/Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-streamer/3.3.0/cd0c6f07bb9f17c4718645b421f80a7c8caeb29e/readium-streamer-3.3.0.aar
+/Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-navigator/3.3.0/fa9ca42cd2606f432a5843df9cc4953fe808d696/readium-navigator-3.3.0.module
+/Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-navigator/3.3.0/ec205146a3401ca43792b37bfb4b9b2d51fa6a35/readium-navigator-3.3.0.pom
+/Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-navigator/3.3.0/162dd7fdee9e61a10441e5262792ec0d76b6011e/readium-navigator-3.3.0.aar
+/Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-shared/3.3.0/a7670e6bf03624f06db1582204f2ef3bd27e092c/readium-shared-3.3.0.module
+/Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-shared/3.3.0/18cb1433ca2d1d0c99e437a0780593e167367c5/readium-shared-3.3.0.aar
+/Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-shared/3.3.0/b6c9f5890525ae8935421a147a8f315e86f9b57f/readium-shared-3.3.0.pom
+zsh:1: no matches found: /Users/ll/.gradle/caches/transforms-*
+
+exec
+/bin/zsh -lc 'find /Users/ll/.gradle/caches -type f -name classes.jar 2>/dev/null | while IFS= read -r f; do if jar tf "$f" 2>/dev/null | rg -q '"'org/readium/r2/navigator/epub/EpubNavigatorFragment.class'; then echo \""'$f"; fi; done' in /Users/ll/workspace/vreader
+ succeeded in 1742ms:
+exec
+/bin/zsh -lc 'AAR=/Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-navigator/3.3.0/162dd7fdee9e61a10441e5262792ec0d76b6011e/readium-navigator-3.3.0.aar; unzip -l "$AAR" | sed -n '"'1,35p'; unzip -p \""'$AAR" classes.jar | strings | rg -n -C 2 '"'evaluateJavascript|getCurrentLocator|EpubNavigatorFragment' | head -120" in /Users/ll/workspace/vreader
+ succeeded in 611ms:
+10639-#Z%�
+10640-�o��z
+10641:org/readium/r2/navigator/epub/EpubNavigatorFragment$Companion.class�X�s
+10642-C8S�b%
+10643-�W��
+--
+10803-[A�x
+10804-���
+10805:org/readium/r2/navigator/epub/EpubNavigatorFragment$Configuration$Companion.class
+10806-�����
+10807-�x`* V��
+--
+10891-��)�$ħ�
+10892-6žp�
+10893:org/readium/r2/navigator/epub/EpubNavigatorFragment$Configuration.class�[
+10894-l�ƶ06
+10895-�\��
+--
+11350-XTl<�ϧ
+11351-ݤ"R
+11352:org/readium/r2/navigator/epub/EpubNavigatorFragment$Listener$DefaultImpls.class�U�v
+11353-�d��
+11354-�4q��
+--
+11426-h#�z
+11427-vq��}
+11428:org/readium/r2/navigator/epub/EpubNavigatorFragment$Listener.class�V[S
+11429-��,�p���-
+11430-ձV�"�
+--
+11498-�cP4�lp���
+11499-w�^*�
+11500:org/readium/r2/navigator/epub/EpubNavigatorFragment$PageChangeListener.class
+11501-�n�tK
+11502-(�@[(S
+--
+11590-�>n�
+11591-�H��|\
+11592:org/readium/r2/navigator/epub/EpubNavigatorFragment$PagerAdapterListener.class�U�W
+11593-��&d
+11594-)��JjS(]��C�Z
+--
+11679->ShQ
+11680-Mէ-�
+11681:org/readium/r2/navigator/epub/EpubNavigatorFragment$PaginationListener$DefaultImpls.class
+11682-S�n�@
+11683-�F;�ey�
+--
+11736-�S�C�}�
+11737-�ش��
+11738:org/readium/r2/navigator/epub/EpubNavigatorFragment$PaginationListener.class
+11739-���8o
+11740-#V���H�
+--
+11797-|>�G)��
+11798-���i,j�4
+11799:org/readium/r2/navigator/epub/EpubNavigatorFragment$State$Initializing.class
+11800-�fwmo�N�
+11801-�qS~
+--
+11865-�)�K1c�
+11866-%#/�
+11867:org/readium/r2/navigator/epub/EpubNavigatorFragment$State$Loading.class
+11868-��&$�
+11869-��X�?�
+--
+11965-���y|
+11966-v�I�
+11967:org/readium/r2/navigator/epub/EpubNavigatorFragment$State$Ready.class�SKo
+11968-��<���i
+11969-6nʣ�
+--
+12031-;E!�L
+12032-�S�j9�eE�K
+12033:org/readium/r2/navigator/epub/EpubNavigatorFragment$State.class
+12034-�fw�-K
+12035-�����
+--
+12078-n(,(�TX�
+12079-�{e;
+12080:org/readium/r2/navigator/epub/EpubNavigatorFragment$WebViewListener.class�Z{|T�
+12081-���N�N&
+12082- �0@
+--
+12494-~��ks �y|
+12495-3e{��
+12496:org/readium/r2/navigator/epub/EpubNavigatorFragment$WhenMappings.class�S�N
+12497-C�EA.*� 
+12498-Zl�%���
+--
+12560-�q�Q�
+12561-t�9B�'��
+12562:org/readium/r2/navigator/epub/EpubNavigatorFragment$applyDecorations$1.class�T�o
+12563-��v��qi
+12564-���MC�
+--
+12630-�5�z��<)ް�p��M\l�
+12631-��.�'�F
+12632:org/readium/r2/navigator/epub/EpubNavigatorFragment$currentSelection$1.class�T[OSA
+12633-��--
+12634-bBb�m
+--
+12694-_��Q
+12695-�j0�W
+12696:org/readium/r2/navigator/epub/EpubNavigatorFragment$evaluateJavascript$1.class�UQS[E
+12697-^LiG
+12698-n�f��
+--
+12757-wX짻��
+12758-k!��
+12759:org/readium/r2/navigator/epub/EpubNavigatorFragment$firstVisibleElementLocator$1.class�T[O
+12760-o ((U�`
+12761-��Y�;���
+--
+12820-�nK{p8��9
+12821-Q�(��wPK
+12822:org/readium/r2/navigator/epub/EpubNavigatorFragment$notifyCurrentLocation$1.class�Z
+12823-X\�u�����c
+12824-#yl�H
+--
+
+exec
+/bin/zsh -lc 'AAR=/Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-navigator/3.3.0/162dd7fdee9e61a10441e5262792ec0d76b6011e/readium-navigator-3.3.0.aar; unzip -p "$AAR" classes.jar | bsdtar -xOf - org/readium/r2/navigator/epub/EpubNavigatorFragment.class | strings | rg -n -C 3 '"'evaluateJavascript|getCurrentLocator|currentLocator|firstVisibleElementLocator|submitPreferences'" in /Users/ll/workspace/vreader
+ succeeded in 515ms:
+131-#kotlinx/coroutines/flow/StateFlowKt
+132-MutableStateFlow
+133->(Ljava/lang/Object;)Lkotlinx/coroutines/flow/MutableStateFlow;
+134:_currentLocator
+135-*Lkotlinx/coroutines/flow/MutableStateFlow;
+136-,tableOfContentsTitleByHref_delegate$lambda$0
+137-@(Lorg/readium/r2/shared/publication/Publication;)Ljava/util/Map;
+--
+172-S()Lkotlinx/coroutines/flow/StateFlow<Lorg/readium/r2/navigator/epub/EpubSettings;>;
+173-getViewModel
+174-8()Lorg/readium/r2/navigator/epub/EpubNavigatorViewModel;
+175:submitPreferences
+176-2(Lorg/readium/r2/navigator/epub/EpubPreferences;)V
+177-preferences
+178-I(Lorg/readium/r2/navigator/epub/EpubPreferences;)Lkotlinx/coroutines/Job;
+179:evaluateJavascript
+180-F(Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+181-[(Ljava/lang/String;Lkotlin/coroutines/Continuation<-Ljava/lang/String;>;)Ljava/lang/Object;
+182:Horg/readium/r2/navigator/epub/EpubNavigatorFragment$evaluateJavascript$1
+183-label
+184-X(Lorg/readium/r2/navigator/epub/EpubNavigatorFragment;Lkotlin/coroutines/Continuation;)V
+185-result
+--
+419-event
+420-<Lorg/readium/r2/navigator/epub/EpubNavigatorViewModel$Event;
+421-:org/readium/r2/navigator/epub/EpubNavigatorViewModel$Event
+422:getCurrentLocator
+423-f(Lorg/readium/r2/navigator/Navigator;Lorg/readium/r2/shared/publication/Locator;ZILjava/lang/Object;)Z
+424-locator
+425-onSettingsChange
+--
+648-;$i$a$-forEach-EpubNavigatorFragment$loadedFragmentForHref$1
+649-pageFragment
+650-R()Lkotlinx/coroutines/flow/StateFlow<Lorg/readium/r2/shared/publication/Locator;>;
+651:firstVisibleElementLocator
+652-b(Lkotlin/coroutines/Continuation<-Lorg/readium/r2/shared/publication/Locator;>;)Ljava/lang/Object;
+653-.Lorg/readium/r2/shared/ExperimentalReadiumApi;
+654:Porg/readium/r2/navigator/epub/EpubNavigatorFragment$firstVisibleElementLocator$1
+655-)findFirstVisibleLocator$readium_navigator
+656-getMediaType
+657-2()Lorg/readium/r2/shared/util/mediatype/MediaType;
+--
+774-f(Lorg/readium/r2/navigator/epub/EpubNavigatorFragment;)Lorg/readium/r2/shared/publication/Publication;
+775-$access$getTableOfContentsTitleByHref
+776-F(Lorg/readium/r2/navigator/epub/EpubNavigatorFragment;)Ljava/util/Map;
+777:access$get_currentLocator$p
+778-a(Lorg/readium/r2/navigator/epub/EpubNavigatorFragment;)Lkotlinx/coroutines/flow/MutableStateFlow;
+779-<clinit>
+780-=org/readium/r2/navigator/epub/EpubNavigatorFragment$Companion
+--
+824-r2PagerAdapter
+825-currentReflowablePageFragment
+826-currentFragment
+827:currentLocator
+828-tableOfContentsTitleByHref
+829-(Lorg/readium/r2/shared/publication/Href;
+830-Configuration
+
+exec
+/bin/zsh -lc 'AAR=/Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-navigator/3.3.0/162dd7fdee9e61a10441e5262792ec0d76b6011e/readium-navigator-3.3.0.aar; unzip -p "$AAR" classes.jar | bsdtar -xOf - org/readium/r2/navigator/epub/EpubNavigatorFragment.class | strings | sed -n '"'155,190p;400,430p;635,660p'" in /Users/ll/workspace/vreader
+ succeeded in 519ms:
+*Lorg/readium/r2/shared/publication/Layout;
+)org/readium/r2/shared/publication/Locator
+-org/readium/r2/navigator/epub/EpubPreferences
+<org/readium/r2/navigator/epub/EpubNavigatorFragment$Listener
+Forg/readium/r2/navigator/epub/EpubNavigatorFragment$PaginationListener
+(org/readium/r2/shared/publication/Layout
+*org/readium/r2/navigator/epub/EpubDefaults
+kotlin/Lazy
+kotlin/reflect/KClass
+getListener$readium_navigator
+@()Lorg/readium/r2/navigator/epub/EpubNavigatorFragment$Listener;
+'getPaginationListener$readium_navigator
+J()Lorg/readium/r2/navigator/epub/EpubNavigatorFragment$PaginationListener;
+getConfig$readium_navigator
+E()Lorg/readium/r2/navigator/epub/EpubNavigatorFragment$Configuration;
+getSettings
+%()Lkotlinx/coroutines/flow/StateFlow;
+S()Lkotlinx/coroutines/flow/StateFlow<Lorg/readium/r2/navigator/epub/EpubSettings;>;
+getViewModel
+8()Lorg/readium/r2/navigator/epub/EpubNavigatorViewModel;
+submitPreferences
+2(Lorg/readium/r2/navigator/epub/EpubPreferences;)V
+preferences
+I(Lorg/readium/r2/navigator/epub/EpubPreferences;)Lkotlinx/coroutines/Job;
+evaluateJavascript
+F(Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+[(Ljava/lang/String;Lkotlin/coroutines/Continuation<-Ljava/lang/String;>;)Ljava/lang/Object;
+Horg/readium/r2/navigator/epub/EpubNavigatorFragment$evaluateJavascript$1
+label
+X(Lorg/readium/r2/navigator/epub/EpubNavigatorFragment;Lkotlin/coroutines/Continuation;)V
+result
+Ljava/lang/Object;
+)kotlin/coroutines/intrinsics/IntrinsicsKt
+getCOROUTINE_SUSPENDED
+kotlin/ResultKt
+throwOnFailure
+Corg/readium/r2/navigator/epub/EpubNavigatorFragment$onViewCreated$2
+k(Lorg/readium/r2/navigator/epub/EpubNavigatorFragment;Landroid/os/Bundle;Lkotlin/coroutines/Continuation;)V
+handleEvent
+?(Lorg/readium/r2/navigator/epub/EpubNavigatorViewModel$Event;)V
+Dorg/readium/r2/navigator/epub/EpubNavigatorViewModel$Event$RunScript
+getCommand
+I()Lorg/readium/r2/navigator/epub/EpubNavigatorViewModel$RunScriptCommand;
+J(Lorg/readium/r2/navigator/epub/EpubNavigatorViewModel$RunScriptCommand;)V
+Korg/readium/r2/navigator/epub/EpubNavigatorViewModel$Event$OpenInternalLink
+"org/readium/r2/navigator/Navigator
+getTarget
+*()Lorg/readium/r2/shared/publication/Link;
+go$default
+c(Lorg/readium/r2/navigator/Navigator;Lorg/readium/r2/shared/publication/Link;ZILjava/lang/Object;)Z
+Norg/readium/r2/navigator/epub/EpubNavigatorViewModel$Event$InvalidateViewPager
+PLorg/readium/r2/navigator/epub/EpubNavigatorViewModel$Event$InvalidateViewPager;
+areEqual
+'(Ljava/lang/Object;Ljava/lang/Object;)Z
+invalidateResourcePager
+event
+<Lorg/readium/r2/navigator/epub/EpubNavigatorViewModel$Event;
+:org/readium/r2/navigator/epub/EpubNavigatorViewModel$Event
+getCurrentLocator
+f(Lorg/readium/r2/navigator/Navigator;Lorg/readium/r2/shared/publication/Locator;ZILjava/lang/Object;)Z
+locator
+onSettingsChange
+[(Lorg/readium/r2/navigator/epub/EpubSettings;Lorg/readium/r2/navigator/epub/EpubSettings;)V
+REFLOWABLE
+getFontSize
+getR2PagerAdapter
+setFontSize
+6$i$a$-let-EpubNavigatorFragment$goToPreviousResource$2
+locatorToResourceAtIndex
+.(I)Lorg/readium/r2/shared/publication/Locator;
+:$i$a$-let-EpubNavigatorFragment$locatorToResourceAtIndex$1
+getCurrentFragment
+"()Landroidx/fragment/app/Fragment;
+fragmentAt
+#(I)Landroidx/fragment/app/Fragment;
+getItemId
+(J)Ljava/lang/Object;
+getLink$readium_navigator
+url$default
+(Lorg/readium/r2/shared/publication/Link;Lorg/readium/r2/shared/util/Url;Ljava/util/Map;ILjava/lang/Object;)Lorg/readium/r2/shared/util/Url;
+;$i$a$-forEach-EpubNavigatorFragment$loadedFragmentForHref$1
+pageFragment
+R()Lkotlinx/coroutines/flow/StateFlow<Lorg/readium/r2/shared/publication/Locator;>;
+firstVisibleElementLocator
+b(Lkotlin/coroutines/Continuation<-Lorg/readium/r2/shared/publication/Locator;>;)Ljava/lang/Object;
+.Lorg/readium/r2/shared/ExperimentalReadiumApi;
+Porg/readium/r2/navigator/epub/EpubNavigatorFragment$firstVisibleElementLocator$1
+)findFirstVisibleLocator$readium_navigator
+getMediaType
+2()Lorg/readium/r2/shared/util/mediatype/MediaType;
+.org/readium/r2/shared/util/mediatype/MediaType
+:Lorg/readium/r2/shared/util/mediatype/MediaType$Companion;
+8org/readium/r2/shared/util/mediatype/MediaType$Companion
+
+exec
+/bin/zsh -lc 'AAR=/Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-navigator/3.3.0/162dd7fdee9e61a10441e5262792ec0d76b6011e/readium-navigator-3.3.0.aar; unzip -p "$AAR" classes.jar | bsdtar -xOf - org/readium/r2/navigator/epub/EpubNavigatorFragment.class | python3 -c '"'import sys,struct
+b=sys.stdin.buffer.read(); p=8
+u1=lambda: None
+def u2():
+ global p; v=struct.unpack_from(\">H\",b,p)[0]; p+=2; return v
+def u4():
+ global p; v=struct.unpack_from(\">I\",b,p)[0]; p+=4; return v
+cp=[None]*u2(); i=1
+while i<len(cp):
+ t=b[p]; p+=1
+ if t==1:
+  n=u2(); cp[i]=b[p:p+n].decode(\"utf-8\",\"replace\"); p+=n
+ elif t in (3,4): p+=4
+ elif t in (5,6): p+=8; i+=1
+ elif t in (7,8,16,19,20): p+=2
+ elif t in (9,10,11,12,17,18): p+=4
+ elif t==15: p+=3
+ else: raise Exception(t)
+ i+=1
+p+=6
+for _ in range(u2()): p+=2
+def attrs():
+ global p
+ for _ in range(u2()): p+=2; p+=u4()
+for _ in range(u2()): p+=6; attrs()
+for _ in range(u2()):
+ a=u2(); n=cp[u2()]; d=cp[u2()]; attrs()
+ if n in (\"evaluateJavascript\",\"getCurrentLocator\",\"firstVisibleElementLocator\",\"submitPreferences\"): print(hex(a),n,d,\"PUBLIC\" if a&1 else \"NONPUBLIC\")'" in /Users/ll/workspace/vreader
+ exited 1 in 544ms:
+Traceback (most recent call last):
+  File "<string>", line 25, in <module>
+  File "<string>", line 24, in attrs
+  File "<string>", line 7, in u4
+struct.error: unpack_from requires a buffer of at least 110215 bytes for unpacking 4 bytes at offset 110211 (actual buffer size is 63601)
+
+exec
+/bin/zsh -lc 'AAR=/Users/ll/.gradle/caches/modules-2/files-2.1/org.readium.kotlin-toolkit/readium-navigator/3.3.0/162dd7fdee9e61a10441e5262792ec0d76b6011e/readium-navigator-3.3.0.aar; unzip -p "$AAR" classes.jar | bsdtar -xOf - org/readium/r2/navigator/epub/EpubNavigatorFragment.class | python3 -c '"'import sys,struct
+b=sys.stdin.buffer.read(); p=8
+def u2():
+ global p; v=struct.unpack_from(\">H\",b,p)[0]; p+=2; return v
+def u4():
+ global p; v=struct.unpack_from(\">I\",b,p)[0]; p+=4; return v
+cp=[None]*u2(); i=1
+while i<len(cp):
+ t=b[p]; p+=1
+ if t==1:
+  n=u2(); cp[i]=b[p:p+n].decode(\"utf-8\",\"replace\"); p+=n
+ elif t in (3,4): p+=4
+ elif t in (5,6): p+=8; i+=1
+ elif t in (7,8,16,19,20): p+=2
+ elif t in (9,10,11,12,17,18): p+=4
+ elif t==15: p+=3
+ else: raise Exception(t)
+ i+=1
+p+=6
+for _ in range(u2()): p+=2
+def attrs():
+ global p
+ for _ in range(u2()):
+  p+=2; n=u4(); p+=n
+for _ in range(u2()): p+=6; attrs()
+for _ in range(u2()):
+ a=u2(); n=cp[u2()]; d=cp[u2()]; attrs()
+ if n in (\"evaluateJavascript\",\"getCurrentLocator\",\"firstVisibleElementLocator\",\"submitPreferences\"): print(hex(a),n,d,\"PUBLIC\" if a&1 else \"NONPUBLIC\")'" in /Users/ll/workspace/vreader
+ succeeded in 522ms:
+0x1 submitPreferences (Lorg/readium/r2/navigator/epub/EpubPreferences;)V PUBLIC
+0x11 evaluateJavascript (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object; PUBLIC
+0x1 getCurrentLocator ()Lkotlinx/coroutines/flow/StateFlow; PUBLIC
+0x1 firstVisibleElementLocator (Lkotlin/coroutines/Continuation;)Ljava/lang/Object; PUBLIC
+0x1041 submitPreferences (Lorg/readium/r2/navigator/preferences/Configurable$Preferences;)V PUBLIC
+
+exec
+/bin/zsh -lc "nl -ba dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md | sed -n '20,105p;117,195p;213,240p' && nl -ba android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt | sed -n '80,120p;195,235p;445,470p;482,515p' && nl -ba android/app/build.gradle.kts | sed -n '103,117p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+    20	
+    21	### Render-host decision (settled in v2, CONFIRMED by round-2 — not reopened)
+    22	
+    23	**Two hosts, in dependency order:**
+    24	
+    25	1. **EPUB (Readium `EpubNavigatorFragment`) — PRIMARY.** Interlinear via `evaluateJavascript` (enumerate leaf blocks → inject translation DOM nodes → clear on teardown/reflow), mirroring iOS `EPUBBilingualOrchestrator`. Gated by **WI-0 (a Readium bilingual spike with enforceable go/no-go thresholds + a navigator-race contract — round-2 M1)** before the EPUB render WI (WI-7b) is built.
+    26	2. **TXT/MD (Compose `TxtReaderActivity`) — INCLUDED.** No WebView; deterministically Compose-testable. Renders from **document-global segment ranges** (round-2 H1), NOT one body per chunk.
+    27	
+    28	**AZW3 (foliate WebView)** and **PDF** remain follow-ups / out (§"Files OUT of scope").
+    29	
+    30	**Why both, not TXT/MD-only:** the *pipeline* (segment → chunk → translate → cache → interleave) is host-agnostic; only the *render injection* is host-specific. EPUB is the format most users read, so shipping box D without it would under-deliver. TXT/MD are included because the Compose host is the cheapest, most testable place to prove the pipeline end-to-end (deterministic tree assertions), de-risking the EPUB adapter. **Box D cannot be checked on a false "EPUB requires a fork" rationale** — that rationale is discarded and stays discarded.
+    31	
+    32	### The TXT/MD segmentation unit + render mapping (round-2 H1 — the core v3 correction)
+    33	
+    34	**Verified against live code:** `TxtDocument` (in `reader/TxtDocument.kt`) exposes only `text: String`, `chunkCount`, `offsetForChunk(index)`, `chunkForOffset(offsetUtf16)`, `textForChunk(index)` — line-based ≤4000-char chunks over UTF-16 offsets against the RAW text (no line-ending normalization). It has **no chapter/section concept**. `TxtMdTextExtractor` (in `search/`) explicitly emits one section per chunk "because TXT has no sub-resource grouping." A chunk can hold multiple paragraphs OR split one long paragraph. So the v2 "translate per chunk, render one body per chunk" contract is not achievable.
+    35	
+    36	**v3 model — document-global units with segment ranges produced ONCE:**
+    37	
+    38	- The whole `.txt`/`.md` is treated as **one translation document**. The **segmenter runs once over `TxtDocument.text`** (the full raw backing string) and emits, per segment, its **`IntRange` UTF-16 span** against that same backing string (the segmenter's `paragraphRanges(text)` / `sentenceRanges(text)` — the range-returning peers of `paragraphs`/`sentences`; iOS precedent `ChapterSegmenter.sentenceRanges(in:)` returns `[Range<Int>]`). These ranges are the SINGLE source of truth used by BOTH the translate side and the render side, so the two segment identically **by construction** (they read the same array).
+    39	- **Unit granularity for TXT/MD is the whole document, sub-batched for cache/prefetch by a deterministic "unit window."** To avoid translating a 14 MB book at once (and to keep cache rows bounded), segment ranges are grouped into fixed **unit windows** of contiguous segments (window size a constant, e.g. covering ≈ one on-screen span; the exact constant is set at build time and does not change the 1:1 contract). Each window is a `TranslationUnitId(kind = txtDocSegmentWindow, value = windowIndex)` — a document-global index, NOT a chunk index. `unitContaining(locator)` maps the reader's saved `charOffsetUTF16` → the segment whose range contains it → its window index (via a precomputed segment-start binary search, the same shape as `TxtDocument.chunkForOffset`). `unitAfter(unit)` = next window index or null at document end.
+    40	- **Render mapping (the LazyColumn):** the TXT/MD body still iterates the existing `items(count = document.chunkCount, key = { it })` loop (verified injection point, TxtReaderActivity.kt:1043) for source layout/selection/highlight parity — **but bilingual interlinear content is keyed by SEGMENT RANGE, not by chunk.** For each rendered chunk `i` (source UTF-16 span `[offsetForChunk(i), offsetForChunk(i+1))`), the body looks up every segment whose range **overlaps** that chunk span and, after the source text of that segment's portion, renders its cached translation (muted) — from the SAME range array the translator used. A segment spanning two chunks contributes its translation once, anchored at the chunk where its range ends (deterministic), so a paragraph split across a chunk boundary is translated once and rendered once. When bilingual is OFF, the loop is byte-identical to today (translations are additive overlays only).
+    41	- **MD source** = raw markdown segment text (translation renders as plain muted text, not re-markdown-rendered — matches the muted-secondary design line). Segmentation runs over the raw markdown string; MD markers are treated as ordinary characters by the paragraph splitter (blank-line delimited), consistent with `TxtMdTextExtractor` shipping raw markdown to search.
+    42	
+    43	This closes H1: there is no invented chapter model, the render boundary IS the segmentation boundary, and disabled = source byte-parity because bilingual content is a pure overlay off the shared range array.
+    44	
+    45	### New files
+    46	
+    47	**Pipeline / domain (host-agnostic, pure or coroutine — JVM-testable):**
+    48	
+    49	- `bilingual/TranslationUnitId.kt` — `data class TranslationUnitId(kind, value)` with `enum Kind { epubHref, foliateHref, txtDocSegmentWindow, mdDocSegmentWindow, pdfPageRange }`; `storageKey = "${kind.name}:$value"`. Mirrors iOS `TranslationUnitID.Kind` in spirit; the TXT/MD kinds are **document-global segment-window indices** (H1), NOT chunk indices. v3 uses `epubHref` + `txtDocSegmentWindow`/`mdDocSegmentWindow`; others reserved so the cache-key format never breaks. *(Assumption I could not fully confirm: iOS's exact Kind case names for the TXT/MD variants — the Android names are chosen to describe the real unit; the storageKey format is what the cache contract depends on.)*
+    50	- `bilingual/TranslationGranularity.kt` — `enum { paragraph, sentence }`. (Design's Granularity control.)
+    51	- `bilingual/BilingualLanguages.kt` — `BilingualLanguage(key, glyph, script)`; `BILINGUAL_LANGS` = the set from `vreader-bilingual.jsx` + `findOrDefault(key)`. Default `Chinese`.
+    52	- `bilingual/ChapterSegmenter.kt` — **NEW file (there is no existing Android segmenter; the `search/` module has none — verified).** Port of iOS `ChapterSegmenter`: `paragraphs(text)` / `sentences(text)` **plus the range-returning peers `paragraphRanges(text): List<IntRange>` / `sentenceRanges(text): List<IntRange>`** (UTF-16 spans against the input string — iOS `sentenceRanges(in:)` precedent). The ranges are what H1's mapping consumes. CJK-aware sentence enumeration (。！？ vs Latin). Pure.
+    53	- `bilingual/TranslationChunker.kt` — `chunk(segments, maxCharsPerChunk)` + `subSplit(text, maxChars)`. Port of iOS `ChapterTranslationChunker.chunk(...)` + `subSplit(...)` (verified: `chunk` returns index groups, oversize segment gets its own chunk; `subSplit` is the Bug #330 grapheme-safe over-budget splitter).
+    54	- `bilingual/TranslationChunkContract.kt` — `userPrompt(segments, targetLanguage)`; `decode(raw, expectedCount)` (strict JSON-array + code-fence strip); `sealed class DecodeError { NotAStringArray; CountMismatch(expected, actual) }`. Port of iOS `TranslationChunkContract`. (No `style` param — Style is descoped v1, §3/H3.)
+    55	- `bilingual/ChapterTextProvider.kt` — `interface { units(); sourceSegments(unit); sourceText(unit); unitContaining(locator); unitAfter(unit) }`. **`sourceSegments(unit)` returns the exact segment strings (from the shared range array)** — this is what the EPUB direct-block and TXT/MD paths both feed to the translator so counts pair 1:1. Resolution is host-specific: TXT/MD key on `charOffsetUTF16` → segment-window; EPUB keys on the current-resource `href` from `EpubNavigatorFragment.currentLocator`. Honest divergence from iOS's uniform Readium `Locator`, documented.
+    56	- `bilingual/TxtChapterTextProvider.kt` — provider over `TxtDocument` + the segmenter's range array (H1). Builds the document-global segment ranges once, groups them into windows, resolves `unitContaining` via a segment-start binary search over `charOffsetUTF16`. MD source = raw markdown segment text.
+    57	- `bilingual/EpubChapterTextProvider.kt` (WI-0-gated shape) — provider over the Readium `Publication` reading order; `units()` = spine hrefs, `unitContaining(locator)` = the locator's href, `sourceSegments(unit)` = the DOM-enumerated block texts (the render's OWN enumeration, for direct-block 1:1 — H2). Its render-side collaborator (the JS enumerate/inject adapter) is `EpubBilingualJs` (M2), defined by WI-0's findings.
+    58	- `bilingual/ChapterTranslationError.kt` — `sealed { Offline; TimedOut; ProviderFailed(msg); Cancelled }`. Maps from `AiError` (verified cases: `Auth401`, `RateLimited429`, `Offline`, `Timeout`, `Http(code)`, `Decode`, `Stream`, `InsecureUrl`, `Config`).
+    59	- `bilingual/ChapterTranslationService.kt` — the iOS-parity service, now with the **full divergence-recovery surface (round-2 H2)**:
+    60	  - `cachedTranslation(bookKey, unit, sourceText, targetLanguage, granularity, acceptCountMismatch=false)` — cache-only, segments the source to count-check; serves a row only when `sourceParagraphCount == segments.size` (or `acceptCountMismatch`). No provider (#306 parity).
+    61	  - `cachedTranslation(bookKey, unit, expectedSegmentCount, targetLanguage)` — **the divergence-fallback cache-only restore (iOS Bug #343)**: serves the canonical row only when its STORED `sourceParagraphCount == expectedSegmentCount` (the DOM enumerate's block count). **Needs no source text and no provider** → a cache-hit toggle/reopen restores with **zero provider calls**.
+    62	  - `translate(bookKey, unit, sourceText, targetLanguage, providerProfile, granularity, bypassCacheRead=false)` — segment → chunk → per-chunk `AiClient.chat` one-shot → `decode` → per-segment fallback → per-chunk graceful degrade (Bug #330: a single failed chunk renders source-only for its segments and is NOT cached; all-chunks-fail throws) → cache-write only on full success. Cache row stores `sourceParagraphCount = segments.size`. Cancellation: `ensureActive()` between chunks AND immediately before the Room write (§6).
+    63	  - `translatePreSegmented(bookKey, unit, segments, targetLanguage, providerProfile)` — **the count-divergence recovery (round-2 H2; iOS Bugs #268/#330/#343).** Takes the render's OWN enumerated block texts as `segments` (1:1 by construction), chunks them, translates with the same per-chunk graceful-degrade + cancellation contract, and — on full success only — **caches under the canonical key with the ENUMERATE's count as the stored contract** (so a later reopen restores via `cachedTranslation(expectedSegmentCount:)`). A partial degrade is NOT cached. A cache-write failure does not fail the translation.
+    64	  - Uses `AiClient.chat(AiRequest)` (one-shot, verified — NOT `streamChat`).
+    65	- `bilingual/ChapterTranslationPrefetcher.kt` — resolves the active profile from one `AiProviderStore.snapshot()` (`snapshot.active`), decrypts via `store.apiKey(profile)` (snapshot-consistent), builds an `AiClient` via an **injected factory param** (below), cache-first then translate. Adds the **direct-block peers (H2)**:
+    66	  - `prefetch(unit)` — the plain-text path (segment source → `translate`).
+    67	  - `prefetchDirect(unit, sourceSegments, targetLanguage)` — the divergence path (iOS `translatedSegmentsDirect`): same snapshot+resolve+error contract, then `service.translatePreSegmented(...)`.
+    68	  - `cachedDirect(unit, expectedCount, targetLanguage)` — the **zero-provider cache-only restore** (iOS `cachedSegmentsDirect` → `cachedTranslation(expectedSegmentCount:)`): **returns a cached translation on a hit WITHOUT requiring an active provider** (the #306 pre-gate precedent). This is what backs `EpubReaderBilingualConnectedTest.count-divergence handled` cache-restore assertions.
+    69	  - Throws `ChapterTranslationError`. Mirrors iOS `ChapterTranslationPrefetcher`.
+    70	- `bilingual/BilingualAiReadiness.kt` — `resolve(snapshot): Boolean` (active profile exists AND its decrypted key is non-empty). A cipher/decryption failure maps to **not-ready** (never crashes — §6). Drives the setup-sheet engine-strip configured/unconfigured state. Keep the gate to exactly what #118 enforces (no separate consent manager on Android — #118 has none; confirm during build).
+    71	
+    72	**State / persistence:**
+    73	
+    74	- `bilingual/PerBookBilingualStore.kt` — DataStore-Preferences, keyed by `bookFingerprintKey`, holding `{ enabled, targetLanguage, granularity }`. This is the Android `PerBookSettingsOverride` bilingual slice — the backup contract declares exactly `bilingualEnabled` / `bilingualTargetLanguage` / `bilingualGranularity` and **NO `bilingualStyle`** (verified). So this store writes exactly those three fields. Wiring into backup collect/restore is scoped OUT (§7) — additive later; until then bilingual config is device-local.
+    75	- `bilingual/BilingualViewModel.kt` — `StateFlow<BilingualUiState>` with `enabled`, `targetLanguage`, `granularity`, `needsSetupSheet`, `aiConfigured`, `translationsByUnit`, `inFlightUnits`, `unavailableUnits`, `errorUnit`. Setters + `dismissSetupSheet`, `onPositionChanged(locator)`, `retryUnit(unit)`. Generation/epoch-guarded prefetch (current + next unit), cancellation on disable / language / granularity change — port of iOS `BilingualReadingViewModel` + `+Prefetch`. Split to `BilingualPrefetchController.kt` if it nears ~300 lines. (No `style` field — the authoritative sheet has no Style control; Style is descoped v1 — §3.)
+    76	
+    77	**Room (translation cache):**
+    78	
+    79	- `data/ChapterTranslationEntity.kt` — `@Entity(tableName="chapter_translations", indices=[Index("bookKey")], foreignKeys=[FK→books.fingerprintKey ON DELETE CASCADE])`. **`@PrimaryKey val lookupKey: String`** (Room REQUIRES a PK; verified against `HighlightEntity`, which pairs a `@PrimaryKey` with a separate unique index). `lookupKey` = `bookKey|unitStorageKey|targetLanguage|promptVersion`. Other columns: `bookKey`, `unitStorageKey`, `targetLanguage`, `promptVersion`, `translatedJson`, `sourceParagraphCount`, `createdAt`. Mirrors iOS `ChapterTranslationRecord.lookupKey` (`book|unit|lang|prompt`, profile-agnostic — Bug #342). **`sourceParagraphCount` is load-bearing for H2**: it stores the enumerate's count on the `translatePreSegmented` path so `cachedTranslation(expectedSegmentCount:)` can restore.
+    80	- `data/ChapterTranslationDao.kt` — `getByLookupKey(key)`, `@Upsert suspend fun upsert(row)` (Upsert identifies by PK = `lookupKey`, so it is insert-or-replace by cache identity), `deleteByLookupKey(key)`. The project's Room pattern is `@PrimaryKey` + `@Upsert` (verified: `BookDao.upsert`).
+    81	- `bilingual/ChapterTranslationStore.kt` — coroutine wrapper returning a `CachedTranslation` (segments decoded from JSON), keeping Room entities off the boundary (the iOS `ChapterTranslationStore` precedent).
+    82	
+    83	**Cache-identity (reconciled with iOS parity):** the 4-part key `book|unit|lang|promptVersion` is profile-AGNOSTIC / style-agnostic (Bug #342). Style is descoped v1 (§3/H3) so no `s=` component exists. **Granularity IS user-selectable**, so it is carried in `promptVersion` as an **effective composite**: `promptVersion = "bilingual-v1|g=${granularity}"` (a paragraph vs sentence translation is a different cache row — this also closes the iOS #344 "sentence silently ignored" class by construction). A granularity change must cancel in-flight jobs, bump the VM generation, clear shaped in-memory `translationsByUnit`, and force a correctly-keyed re-fetch (specified in WI-6).
+    84	
+    85	**DI / factory (verified live):** `AiProviderFactory` is an `object` with `create(profile: AiProviderProfile, apiKey: String, dispatcher: CoroutineDispatcher = Dispatchers.IO): AiClient` (verified). So `ChapterTranslationPrefetcher` takes its OWN injected `clientFactory: (AiProviderProfile, String) -> AiClient` param **defaulting to `AiProviderFactory::create`** (production) and overridden with a fake in tests. The prefetcher builds `AiRequest(model = profile.model, messages = …, temperature = profile.temperature, maxTokens = profile.maxTokens, system = …)` from the resolved profile (verified `AiRequest` fields).
+    86	
+    87	**AI-provider reachability — spun out to #136 (round-2 H3; ORCHESTRATOR/USER DECISION):** verified against the live code — `AppContainer` does **NOT** provide `AiProviderStore`, and there is **NO live navigation route to `AiProviderListScreen`** (MainActivity has no NavHost; the #118 screen + store + `AiSettingsViewModel` exist but are only exercised by instrumented/round-trip tests). A fresh-install user therefore cannot reach provider config today. This gap is now owned by a **NEW separate tiny feature #136 (AI provider setup made production-reachable)** — a **HARD dependency of #131**. #136 delivers: the AI-provider-entry sheet/route, its production reachability, `AiProviderStore` wired into `AppContainer`, and its own Gate-5 acceptance (`unconfigured → Set up → add provider → return → enable → translate`). **#131 keeps only the wiring** of the bilingual "Set up translation" affordance → #136's AI-provider-entry sheet (WI-9's entry-wiring), and consumes `AiProviderStore` from `AppContainer` (provided by #136). #131 does NOT invent the AI-config sheet or its nav (rule 51). *(Assumption: #136 IS now a `docs/features.md` row — filed 2026-07-12 as GH #1976; #131's `Deps` reference it.)*
+    88	
+    89	**UI (Compose — every state depicted, reproducing `vreader-bilingual.jsx`):**
+    90	
+    91	- `bilingual/BilingualSetupSheet.kt` — reproduces `vreader-bilingual.jsx`'s `BilingualSetupSheet` EXACTLY: header Cancel / Translate; a **preview strip**; a **language grid** over `BILINGUAL_LANGS` (glyph tiles, selected accent); a **Granularity** segmented control (Paragraph "Translate after each ¶" / Sentence "Translate after each sentence"); a **Translation engine** strip (configured: "Claude · with this book's context" + "Change…"; unconfigured: "No AI provider configured" + "Set up"). **No Style control, no provider/model card, no term-overrides toggle, no cost footer** — those belong to the other (`vreader-ai-android.jsx`) sheet, which this plan does not reproduce (§3). The **"Set up" CTA routes to #136's AI-provider-entry sheet** (wired in WI-9); "Change…" routes there too.
+    92	- `bilingual/BilingualInterlinearBody.kt` — **the Compose render surface for the TXT/MD host ONLY** (round-2 M2). Per source segment (from the shared range array): source `Text` then translation `Text` muted with accent left-border, `fontSize*0.88`, CJK font for cjk scripts, RTL handling for Arabic script. Consumes a **host-neutral bilingual state DTO** (see `BilingualRenderState` below). Loading state ("Translating chapter… N%" + per-segment dim). Error state ("Couldn't translate" + Retry). Partial/offline (`unavailableUnits`): source-only silent fallback (design's original-always-kept guarantee — iOS Decision 2). **This is NOT the EPUB render surface** — EPUB uses `EpubBilingualJs` DOM injection (M2 below).
+    93	- `bilingual/BilingualRenderState.kt` — the **host-neutral state DTO** shared by BOTH the Compose body and the EPUB adapter (round-2 M2): per-unit `{ segments: List<String>?, phase: Loaded|Loading(fraction)|Error|SourceOnly }`. Compose reads it to compose `Text`; the EPUB adapter reads the SAME type to build DOM. Compose and EPUB share the **state/value types, NOT the composable body**.
+    94	- `bilingual/EpubBilingualJs.kt` (WI-0-gated) — **the EPUB render surface (round-2 M2).** A pure Kotlin builder that, from a `BilingualRenderState` unit, produces the **JS strings** for `navigator.evaluateJavascript(...)`: (a) `enumScript` (enumerate current-resource leaf blocks → JSON `[{id,text}]`), (b) `injectScript(blockId, translationText)` (construct a translation DOM node after the block, CSP-safe: text set via `textContent`/`createTextNode`, never `innerHTML` string-concat; RTL/CJK via a class + injected `<style>`), (c) `clearScript()` (remove all injected nodes idempotently). Escaping is done in Kotlin (JSON-encode every interpolated string) so a translation containing quotes/`</script>`/newlines cannot break out. **No Compose here.** Consumes `BilingualRenderState`.
+    95	- `bilingual/EpubBilingualController.kt` (WI-0-gated) — the runtime actor that serializes enumerate→translate→inject/clear against the navigator using WI-0's chosen mechanism (a single mutex OR a monotonic navigator-session token — M1); checks the session token after every suspended JS/AI call; clears BEFORE publication teardown; re-applies on the identified production re-apply signal (M1).
+    96	- `bilingual/BilingualPill.kt` — the `EN ↔ 中` reader-**top-chrome** pill (per `vreader-reader.jsx` `ReaderTopChrome` + `vreader-bilingual.jsx` `BilingualPill`). Rendered by #132's top chrome; #131 provides the composable, #132's surface hosts it (§4).
+    97	
+    98	### Modified files
+    99	
+   100	- `data/VReaderDatabase.kt` — add `ChapterTranslationEntity` to `@Database entities`, bump `version` **8 → 9** (round-2 M4: the live DB is **v8**, migrations `MIGRATION_1_2`..`MIGRATION_7_8`; the number is allocated current→next **at implementation time** — against this checkout that is **8→9**), add **`MIGRATION_8_9`** (CREATE TABLE `chapter_translations` + `bookKey` index + FK→`books.fingerprintKey` CASCADE, DDL exactly matching Room's generated schema), **append `MIGRATION_8_9` to `ALL_MIGRATIONS` after `MIGRATION_7_8`**, add `abstract fun chapterTranslationDao()`. The translation-cache table is purely additive.
+   101	- `reader/TxtReaderActivity.kt` — own a `BilingualViewModel`; collect state; render translations in the existing `items(count = document.chunkCount, key = { it })` loop (verified injection point, TxtReaderActivity.kt:1043) **keyed by segment range overlap (H1)**, not per chunk; on position change call `vm.onPositionChanged(canonicalLocator.charOffsetUTF16)`. Strictly gated to `originalFormat ∈ {txt, md}`; disabled = body byte-unchanged (overlay-only). **This file is owned by #129 (VERIFIED); #131's edit lands on top of it (rule 48 one-writer-per-file) — #129 is merged, so this is a straight edit, not a blocker.**
+   102	- `reader/ReaderActivity.kt` (Readium EPUB) — WI-0-gated: attach `EpubBilingualController` to `navigator.evaluateJavascript`; re-apply on the identified production re-apply signal (M1); clear on teardown BEFORE publication teardown. Concrete surface defined by WI-0's spike output. `navigator: EpubNavigatorFragment?` is the verified live field.
+   103	- `VReaderApp.kt` / `AppContainer` — **consume `AiProviderStore` (provided by #136), and provide** `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, and a `BilingualViewModel` factory. **Extracted into the shared DI WI (WI-4b, round-2 M3)** so both host integrations depend on it. Mirrors #116/#118/#122 DI. *(Note: `AiProviderStore`-into-`AppContainer` is #136's deliverable; #131's DI WI wires the bilingual services around it.)*
+   104	
+   105	**NOT modified:** `reader/chrome/ReaderBottomChrome.kt` gets **no** bilingual/Translate slot — the design's entry is the More-menu toggle (#134) + the top-chrome pill (#132), NOT a bottom-chrome slot. `ReaderBottomChrome`'s existing `extraSlot` is untouched.
+   117	## 3. Prior art / project precedent / rejected alternatives
+   118	
+   119	### The render-host decision (settled v2, CONFIRMED round-2)
+   120	
+   121	**How iOS does interlinear:** iOS renders EPUB/AZW3 in a WKWebView it fully controls. `EPUBBilingualOrchestrator` injects JS that (1) enumerates leaf blocks posting `[{bid,text}]` to Swift, (2) after translation injects a translation node after each block. TXT/MD render in a text path where the renderer interleaves translation runs. The mechanism = **the app inserts translation nodes between source nodes.**
+   122	
+   123	**Android EPUB feasibility (round-2 re-verified):** `javap`/the transformed API JAR on the resolved Readium 3.3.0 AAR expose public `evaluateJavascript(String, Continuation<? super String>)`, `getCurrentLocator()`, `firstVisibleElementLocator(...)`, `submitPreferences(...)`; `ReaderActivity.navigator: EpubNavigatorFragment?` holds the concrete fragment. So EPUB interlinear via JS injection is feasible with the public API — **no Readium fork.** The audit CONFIRMED this correction; it is not reopened.
+   124	
+   125	**WI-0 — Readium bilingual spike (gates WI-7b; round-2 M1 rewrote its contract into enforceable go/no-go thresholds):** a throwaway harness that, against a real EPUB on the emulator, must PROVE (each is a pass/no-go criterion):
+   126	
+   127	- **(a) Enumeration is deterministic + idempotent, with stable node IDs.** Enumerating the same current resource twice yields the same block IDs in the same order. Repeated `apply` produces **no duplicate injected nodes** (idempotent replacement).
+   128	- **(b) Clear wins over every older inject.** Under a rapid enable→disable / navigate sequence, a late-arriving inject issued before a `clear` must NOT survive the clear — enforced by the serialization mechanism below (a late inject checks the session token and no-ops).
+   129	- **(c) Recreation restores from cache** for every case: href away/back, same-href `submitPreferences` reflow, internal page-fragment recreation (the WebView pager recreates fragments), and activity recreation — each must re-apply the interlinear from the disk cache (via `cachedDirect(expectedCount)`, zero provider calls) with **an identified PRODUCTION re-apply signal** (a concrete navigator/lifecycle callback or `currentLocator`/fragment-lifecycle hook) for each case.
+   130	- **(d) Locator / visible-source preservation across injection**, with a stated permissible delta (injecting content may shift pagination by ≤ a stated bound; the reader's saved position must map back to the same source block).
+   131	- **(e) The enumerated block count vs the segmenter count** is measured; if they diverge (iOS #268), the **direct-block path** (`prefetchDirect` → `translatePreSegmented`, cached by enumerate count, restored by `cachedDirect(expectedCount)` — H2) is the recovery, proven end-to-end in the spike.
+   132	
+   133	**Race contract (M1):** WI-0 specifies **either a single actor/mutex OR a monotonic navigator-session token**; every suspended JS/AI call is followed by a token/mutex check; cancellation/clear runs BEFORE publication teardown. **If WI-0 cannot find a deterministic production re-apply signal for a recreation case (c), that is an explicit NO-GO:** EPUB drops to a tracked follow-up and box D ships **TXT/MD-only** — with the honest reason (a specific spike finding), never the false "requires a fork."
+   134	
+   135	**Rejected alternatives:**
+   136	1. **Readium interlinear via decorations only** — REJECTED (decorations style existing text; they cannot insert translation paragraphs). `evaluateJavascript` makes injection possible, so EPUB uses the JS seam.
+   137	2. **Forking Readium** — REJECTED + unnecessary (public `evaluateJavascript` seam exists).
+   138	3. **AZW3 foliate host first** — REJECTED for v1 (deferred, not dead; touches the security-sensitive #126 bridge).
+   139	4. **Eager whole-book pre-translation** — REJECTED (cost/latency). Lazily prefetch current+next + cache — port iOS.
+   140	5. **One `BilingualInterlinearBody` per chunk (v2)** — REJECTED (round-2 H1): a chunk is not a segment. Replaced by document-global segment ranges (§2).
+   141	6. **A Compose body as the EPUB render surface (v2)** — REJECTED (round-2 M2): Compose cannot render inside Readium's WebView. Replaced by `EpubBilingualJs` DOM injection sharing only the `BilingualRenderState` DTO.
+   142	
+   143	### The setup-sheet resolution (rule 51) + Style descope (round-2 H3, USER DECISION)
+   144	
+   145	There are **two committed, differently-shaped** `BilingualSetupSheet`s:
+   146	- `vreader-bilingual.jsx` → **language grid + Granularity + preview strip + Translation-engine strip (Set up/Change) + Cancel/Translate**. **No Style, no provider/model card, no term-overrides, no cost.**
+   147	- `vreader-ai-android.jsx` → **Languages (From/To) + Provider card + Style (Literal/Natural/Literary) + Keep-term-overrides toggle + cost footer.** **No language grid, no Granularity, no preview.**
+   148	
+   149	**Resolution:** this plan reproduces the **`vreader-bilingual.jsx` sheet EXACTLY** as the authoritative Android-native bilingual sheet. **Style is DESCOPED for v1** (user decision): #131 keeps provider/model/**granularity**, DROPS the bilingual "Style" control. Consequently the store/VM carry no `style`, the chunk contract has no `style` param, and the cache key's `promptVersion` has no `s=` component. Keep rule 51: only implement the designed surface.
+   150	
+   151	**Box-D parity note (H3 — do NOT claim full box-D parity):** the box-D parity checklist lists provider/model/**style**. Because Style is descoped v1, **WI-9 flips box D to done ONLY for provider/model/granularity + a descope note** — it does NOT claim full box-D parity. A **follow-up tracker/checklist amendment records the Style descope** (the plan does not silently drop it). If Style is later wanted on Android as a user control, that needs an **updated committed design** (a single sheet showing BOTH Style AND Granularity is not depicted anywhere — the one open design gate below).
+   152	
+   153	### Other precedents applied
+   154	
+   155	- **#118 provider seam**: reuse `AiProviderStore.snapshot()` (`snapshot.active`) + `store.apiKey(profile)` + `AiProviderFactory.create` (default of an injected factory param) + `AiClient.chat`. #118's AI files are unchanged; **#136** wires `AiProviderStore` into `AppContainer`; #131's DI WI wires the bilingual services.
+   156	- **Room additive-migration pattern** (#122/#123/#127/#128/#135): version bump + `MIGRATION_n_(n+1)` appended to `ALL_MIGRATIONS` + exact-DDL + `VReaderDatabaseMigrationTest` PRAGMA guard. `@PrimaryKey` + `@Upsert` is the project's DAO pattern (`BookDao`). Baseline is **v8** (M4).
+   157	- **DataStore JSON-in-Preferences** for `PerBookBilingualStore` (the `ReaderSettingsStore`/`AiProviderStore` pattern).
+   158	- **Pure-logic port**: iOS `ChapterSegmenter`/`ChapterTranslationChunker`/`TranslationChunkContract`/`ChapterTranslationService.translatePreSegmented`/`ChapterTranslationPrefetcher.translatedSegmentsDirect`+`cachedSegmentsDirect` are pure/heavily-unit-tested — direct Kotlin ports with the same test vectors (all verified to exist).
+   159	- **Entry point via #132/#134 (VERIFIED)**: the More-menu bilingual toggle (`MoreActionId.BILINGUAL` reserved; `MoreRow.Toggle` carries `on`/`onToggle`) + top-chrome pill are the landed integration points; #131 mounts the pill + wires the toggle (§4).
+   160	
+   161	## 4. Work-item sequencing
+   162	
+   163	**11 WIs/PRs (round-2 L2):** WI-0 (spike), WI-1..WI-4a (foundation/service), **WI-4b (shared DI/factory)**, WI-5, WI-6, WI-7a (Compose UI), **WI-7b (conditional EPUB render adapter — dropped if WI-0 = no-go)**, WI-8 (TXT/MD host integration), WI-9 (entry wiring + acceptance). Each WI = one PR. Build order (round-2 M3): **foundation/cache → service/direct-block APIs → shared DI/factory → VM state/prefetch → host-specific renderers (TXT/MD + EPUB) → entry wiring.**
+   164	
+   165	**Dependency notes (round-2 L1 — exact landed integration points):**
+   166	- **`Deps: [feat:#136, feat:#132, feat:#134]`.** **#132 (top chrome) and #134 (More menu) are VERIFIED — dependencies satisfied** (the top-chrome host + `MoreActionId.BILINGUAL` toggle row are landed). **#129 (TXT/MD reader) is VERIFIED** — `TxtReaderActivity` is a straight edit, not a blocker. **#136 (AI provider setup made production-reachable) is the NEW hard blocker** for #131's entry-wiring (the "Set up"/"Change…" route) AND the DONE flip; it provides `AiProviderStore` in `AppContainer` and the reachable AI-config sheet. The live More model already reserves `MoreActionId.BILINGUAL` (verified).
+   167	- The pipeline + setup sheet + interlinear render (WI-0..WI-7) are built ahead; only the **entry wiring (WI-9)** and the **DI WI (WI-4b, for `AiProviderStore` in `AppContainer`)** wait on #136. The pill mount (WI-9) targets #132's VERIFIED top chrome; the toggle wire (WI-9) targets #134's VERIFIED More menu.
+   168	
+   169	**WI-0 (spike): Readium EPUB bilingual injection — with enforceable go/no-go + race contract (M1).** The harness + criteria (a)–(e) and the race contract in §3. Output: a **go/no-go on EPUB-in-v1** (no-go if no deterministic production re-apply signal — box D ships TXT/MD-only, tracked) + the concrete `EpubChapterTextProvider` / `EpubBilingualJs` / `EpubBilingualController` surfaces. Deps: none (uses the existing #106 Readium host). Not TDD-gated (throwaway spike); its findings feed WI-7b.
+   170	
+   171	**WI-1 (foundational): value types + pure segmentation/chunk/contract.** `TranslationUnitId` (document-global TXT/MD kinds — H1), `TranslationGranularity`, `BilingualLanguages`, **`ChapterSegmenter` (with `paragraphRanges`/`sentenceRanges` — H1)**, `TranslationChunker`, `TranslationChunkContract` (no `style` — H3), `ChapterTranslationError`. Pure; ported iOS vectors. Deps: none.
+   172	
+   173	**WI-2 (foundational): Room translation cache.** `ChapterTranslationEntity` (PK = `lookupKey`, `sourceParagraphCount` column) + `Dao` (`@Upsert`) + `ChapterTranslationStore`; `VReaderDatabase` **8→9 `MIGRATION_8_9`** appended after `MIGRATION_7_8` (M4). Robolectric migration round-trip from **v8** + full-chain + upsert/get/delete-by-lookupKey + FK-CASCADE + exact-DDL guard. Deps: none.
+   174	
+   175	**WI-3 (foundational): `ChapterTranslationService`** against a fake `AiClient`. `cachedTranslation` (both overloads incl. the **`expectedSegmentCount` divergence restore — H2**) + `translate` + **`translatePreSegmented` (H2: chunk, per-chunk degrade, cancellation, cache-write with the enumerate count on full success only)**. Deps: **WI-1, WI-2**. Tests: cache hit → zero client calls; miss → translate + write; decode fail → per-segment fallback; one-chunk fail → source-only that chunk (others translated, NOT cached); all-chunks fail → throw; cancellation → `Cancelled` (no write); `AiError` mapping incl. `Config`/`InsecureUrl` → `ProviderFailed`; **`translatePreSegmented` full-success caches under the enumerate count; partial degrade NOT cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` returns on stored-count match, null on mismatch, needs no provider**.
+   176	
+   177	**WI-4a (foundational): `ChapterTextProvider` (TXT/MD) + `ChapterTranslationPrefetcher` + `BilingualAiReadiness`.** `TxtChapterTextProvider` builds the **document-global segment ranges once (H1)**, groups into windows, resolves `unitContaining(charOffsetUTF16)` via segment-start binary search, `sourceSegments(unit)`. Prefetcher: `prefetch` + **`prefetchDirect` + `cachedDirect` (zero-provider cache restore — H2)**; resolves active profile from `snapshot()`, decrypts snapshot-consistent, builds client via the **injected factory param** (default `AiProviderFactory::create`), constructs `AiRequest` from the profile. Readiness = active profile with non-empty decrypted key; **cipher failure → not-ready, never a crash.** Fake store + fake factory. Deps: **WI-1, WI-3**. Tests: unit resolution + clamp + empty; **paragraph spanning a chunk boundary → one segment/one unit; multiple paragraphs in one chunk → distinct segments; a >4000-char paragraph → one segment across chunks; CR/LF/CRLF; MD markers; locator→unit mapping; source-byte parity while disabled**; cache-hit-no-profile still returns (#306); no-profile miss → `ProviderFailed`; `prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls; readiness true/false; cipher-throw → readiness false (no crash).
+   178	
+   179	**WI-4b (foundational — shared DI/factory, round-2 M3): AppContainer bilingual services.** Extract the DI/factory wiring into this EARLIER shared WI: `AppContainer` provides `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, and the `BilingualViewModel` factory — **consuming `AiProviderStore` from `AppContainer` (provided by #136).** Both host integrations (WI-7b, WI-8) depend on this. Deps: **WI-4a, feat:#136** (for `AiProviderStore` in `AppContainer`). Tests: container resolves the bilingual graph; the prefetcher's injected factory defaults to `AiProviderFactory::create`.
+   180	
+   181	**WI-5 (behavioral): `PerBookBilingualStore` + `BilingualViewModel` state core.** Store per book (enabled/targetLanguage/granularity — no style); VM setters (persist + first-enable `needsSetupSheet`), language/granularity change clears cache-shaped state + bumps generation. Turbine tests: first-enable raises sheet; re-enable persisted does not; disable clears; language change resets; granularity change resets + re-keys; round-trip through store; no style field. Deps: **WI-1** (+ store).
+   182	
+   183	**WI-6 (behavioral): VM prefetch trigger + generation/cancellation.** `onPositionChanged(charOffsetUTF16)` derives current unit, dedupes, prefetches current+next; a **monotonic position-request sequence** checked after every suspension; **per-unit generation tokens**; a **captured language/granularity/provider snapshot per launch**; generation bumps on disable/language/granularity/unit-change discard stale; `CancellationException` handled BEFORE generic error mapping; `Offline`→`unavailableUnits`; transient failure leaves unit unfetched + clears anchor to retry; `retryUnit`. Fake prefetcher. Deps: **WI-4a, WI-4b, WI-5**. Tests: current+next on unit change; same-unit no-op; cancel-mid discards stale; offline→unavailable; failure→retry-able; `retryUnit` re-fetches; granularity change cancels + re-fetches under the new key.
+   184	
+   185	**WI-7a (behavioral): Compose UI — setup sheet + interlinear body (TXT/MD) + pill.** Reproduce `vreader-bilingual.jsx` (setup sheet: language grid / granularity / preview / engine strip configured+unconfigured; body: translated / loading N%+dimmed / error+Retry / offline source-only; pill). Consumes the **host-neutral `BilingualRenderState` DTO (M2)**. Light+dark. Compose UI tests each state. Deps: **WI-5** (state shape). NO Style control; the unconfigured "Set up" CTA renders and (in WI-9) routes to #136's sheet.
+   186	
+   187	**WI-7b (behavioral, CONDITIONAL — only if WI-0 = go): EPUB render adapter (DOM injection, NOT Compose — round-2 M2).** `EpubBilingualJs` (enum/inject/clear JS builders, CSP-safe escaping) + `EpubBilingualController` (the serialization actor / session token — M1) + `EpubChapterTextProvider`, wired into `ReaderActivity`, driving DOM from the **shared `BilingualRenderState` DTO**. **Depends on WI-6 (VM prefetch) and WI-4b (DI) — the M3 fix; the WI-7a UI dependency is REMOVED except for the shared `BilingualRenderState`/value types.** Uses `prefetchDirect`/`cachedDirect` for the count-divergence path (H2). Connected test on a real EPUB (seeded cache): enable → interlinear injects; disable → nodes cleared; reflow/href-change/fragment-recreation/activity-recreation → re-applies from cache (zero provider calls); count-divergence handled (direct path). Unit tests: JS escaping/CSP-safe text insertion, RTL/CJK style, empty translations, loading cleanup, idempotent replacement, source-only fallback. Deps: **WI-0, WI-3, WI-4a, WI-4b, WI-6, (shared types from WI-7a)**. (If WI-0 = no-go, this WI is dropped and box D ships TXT/MD-only, tracked.)
+   188	
+   189	**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into the `items(chunkCount)` loop **keyed by segment-range overlap (H1)** + position-change (`charOffsetUTF16`) + setup-sheet. `originalFormat`-gated (TXT/MD). Uses WI-4b's DI. **#129 is VERIFIED — straight edit.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; disable → source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; paragraph-spanning-chunk-boundary renders one translation. Deps: **WI-6, WI-7a, WI-4b**.
+   190	
+   191	**WI-9 (behavioral): entry wiring + acceptance.** Mount `BilingualPill` in **#132's VERIFIED top chrome**; wire the **#134 VERIFIED More-menu `MoreActionId.BILINGUAL` toggle** (`MoreRow.Toggle` `on`/`onToggle`) to the VM; **wire the setup sheet's "Set up"/"Change…" affordance → #136's AI-provider-entry sheet.** Full acceptance pass across EPUB (if WI-7b landed) + TXT/MD, including the fresh-user path `unconfigured → Set up (→ #136 sheet) → add provider → return → enable → translate` (the #136-owned reachability verified jointly). **Flip box D to done ONLY for provider/model/granularity + the Style-descope note (H3); file the follow-up checklist amendment; do NOT claim full box-D parity, do NOT flip DONE until #136 is landed.** Update `docs/architecture.md` (bilingual pipeline + the new `chapter_translations` schema + bilingual services in `AppContainer`). → DONE. Deps: **WI-8, WI-7b (if go), feat:#136, feat:#132, feat:#134**.
+   192	
+   193	## 5. Test catalogue
+   194	
+   195	JVM/Robolectric (`android/app/src/test/...bilingual/`): `ChapterSegmenterTest` (paragraph blank-line; sentence CJK 。！？ vs Latin; empty→[]; single; **`paragraphRanges`/`sentenceRanges` return correct UTF-16 spans**); `TranslationChunkerTest` (packs to budget; oversize→own chunk+subSplit; empty→[]); `TranslationChunkContractTest` (prompt shape; strict JSON decode; code-fence strip; count mismatch→`CountMismatch`; non-array→`NotAStringArray`); `ChapterTranslationServiceTest` (cache hit 0 calls; miss→translate→write; decode-fail per-segment fallback; one-chunk-fail partial-not-cached; all-fail→throw; cancellation→Cancelled no write; ensureActive-before-write; offline/timeout/429/http/config/insecure→error mapping; very long chapter N-of-M; stale-cache count-mismatch re-translates; **`translatePreSegmented` caches under enumerate count on full success; partial degrade not cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` hit/miss with no provider**); `ChapterTranslationErrorMappingTest`; `TxtChapterTextProviderTest` (**paragraph spanning chunk boundary → one segment/unit; multiple paragraphs in one chunk → distinct segments; >4000-char paragraph → one segment across chunks; CR/LF/CRLF; MD markers; locator→unit mapping; unitAfter end→null; source-byte parity while disabled**); `ChapterTranslationPrefetcherTest` (snapshot-consistent profile+key; injected-factory used; `AiRequest` built from profile; cache-hit-no-profile #306; no-profile miss→ProviderFailed; **`prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls**; CJK↔English + Latin round-trip via fake; cipher-throw→ProviderFailed not crash); `BilingualAiReadinessTest` (active+key→true; no active→false; empty key→false; **cipher-throw→false, no crash**); `PerBookBilingualStoreTest` (enabled/lang/granularity round-trip; no style field); `BilingualViewModelTest` (Turbine: first-enable sheet; re-enable no-sheet; disable clears; language reset; **granularity reset + re-key**; prefetch current+next; same-unit no-op; cancel-mid discards; offline→unavailable; error→errorUnit+retry; `retryUnit`); `EpubBilingualJsTest` (**JS escaping / CSP-safe text insertion; RTL/CJK style; empty translations; clear idempotent; inject idempotent replacement; source-only fallback** — WI-7b, if go).
+   213	- **Cost/latency of translating on scroll.** Lazy current+next prefetch + disk cache; N-of-M progress; cancellation on navigate-away/generation-bump.
+   214	- **Provider JSON non-compliance.** `TranslationChunkContract.decode` + per-segment fallback — never drops a paragraph.
+   215	- **DataStore per-book key growth.** One Preferences entry per book keyed by fingerprint; scales like `ReaderSettingsStore`/`AiProviderStore`.
+   216	- **#136 dependency risk.** #131's DONE flip + the "Set up" route + `AiProviderStore` in `AppContainer` all block on #136. #131's pipeline/UI (WI-0..WI-8 except WI-4b's DI) build ahead; WI-4b + WI-9 gate on #136.
+   217	
+   218	## 7. Backward compat
+   219	
+   220	- **Room migration additive (round-2 M4).** New `chapter_translations` (FK CASCADE, `lookupKey` PK, `sourceParagraphCount`). Existing rows untouched. Version allocated current→next at the merge slot; against this checkout **8→9, `MIGRATION_8_9`** appended after `MIGRATION_7_8`; migration test extended from **v8** guards it.
+   221	- **Reader unchanged when bilingual off** — the TXT/MD `items(chunkCount)` loop is byte-identical unless `enabled && format∈{txt,md} && translation present` (bilingual content is a pure segment-range overlay). `ReaderBottomChrome` is not modified. EPUB render adapter is inert unless bilingual is on.
+   222	- **#118 AI provider files unchanged** — the prefetcher/readiness are new consumers. **`AiProviderStore` into `AppContainer` is #136's change, not #131's**; #131's DI WI (WI-4b) wires the bilingual services around it.
+   223	- **Backup contract already compatible** — `PerBookSettingsOverride.bilingualEnabled/TargetLanguage/Granularity` exist (verified; no `bilingualStyle`), and there is no translation-cache backup section (the cache is device-local, re-derivable). #131 writes the three fields locally; backup collect/restore is a small additive follow-up (no contract change), out of v1 scope; until then bilingual config is device-local.
+   224	- **#132/#134/#129 landed** — the top-chrome pill mount + More-menu toggle + `TxtReaderActivity` edit land on VERIFIED surfaces (rule 48 one-writer-per-file is satisfied; #129 is merged).
+   225	
+   226	## Design gates (rule 51 — for `needs-design` filing)
+   227	
+   228	1. **"Bilingual mode" setup sheet with BOTH Style AND Granularity in one Android sheet** — `vreader-bilingual.jsx` depicts Granularity (no Style); `vreader-ai-android.jsx` depicts Style (no Granularity); no committed bundle shows both together. v1 reproduces the granularity-only `vreader-bilingual.jsx` sheet and **DROPS Style (user descope decision — §3/H3)**. If Style is wanted as an Android user control, file `Design needed: bilingual setup sheet (Style + Granularity) for feature #131`. **This is the one open design gate for #131.** The box-D Style parity gap is tracked by the WI-9 follow-up checklist amendment.
+   229	2. **#136 dependency (not a #131 design gate)** — the setup sheet's "Set up"/"Change…" affordance routes to #136's AI-provider-entry sheet. #136 owns the sheet + its production reachability + `AiProviderStore` in `AppContainer`; #131 wires the affordance and consumes the store. #131 does not invent the AI-config sheet (rule 51).
+   230	
+   231	## Revision history
+   232	
+   233	- v1 (2026-07-10): Gate-1 draft (Plan agent). Gate-2 Codex audit pending.
+   234	- v2 (2026-07-11): Gate-2 round-1 REDESIGN resolved — Readium-feasibility corrected, entry-point rebased on box F, setup-sheet design-gated, DI/cache/concurrency fixed.
+   235	- v3 (2026-07-12) — Gate-2 round-2 findings resolved: TXT/MD document-global segment model (H1); EPUB translatePreSegmented + count-keyed cache + direct-block prefetch (H2); #136 AI-provider-reachability spun out as a hard dependency (filed GH #1976) + Style descoped v1 (H3, user decision); WI-0 go/no-go + navigator-race contract (M1); EPUB DOM-injection adapter not Compose body (M2); DI/factory WI reordered (M3); Room 8→9 MIGRATION_8_9 (M4); deps/WI-count corrected (L1/L2). Awaiting Gate-2 round-3 audit.
+   236	
+   237	## Notes on assumptions not fully confirmed against live code
+   238	
+   239	- The exact iOS `TranslationUnitID.Kind` case names for the TXT/MD variants — the Android `Kind` names (`txtDocSegmentWindow`/`mdDocSegmentWindow`) describe the real document-global unit. Only the `storageKey` string format is load-bearing for the cache contract, and that is preserved.
+   240	- The unit-window size constant for TXT/MD sub-batching is left to build time (it does not affect the 1:1 segment↔render contract, only cache-row granularity/prefetch scope).
+    80	import com.vreader.app.search.InBookSearchSheet
+    81	import com.vreader.app.search.InBookSearchViewModel
+    82	import kotlinx.coroutines.flow.MutableStateFlow
+    83	import kotlinx.coroutines.flow.debounce
+    84	import kotlinx.coroutines.flow.drop
+    85	import kotlinx.coroutines.launch
+    86	import org.json.JSONObject
+    87	import org.readium.r2.navigator.epub.EpubNavigatorFactory
+    88	import org.readium.r2.navigator.epub.EpubNavigatorFragment
+    89	import org.readium.r2.navigator.epub.EpubPreferences
+    90	import org.readium.r2.shared.ExperimentalReadiumApi
+    91	import org.readium.r2.shared.publication.Locator
+    92	import org.readium.r2.shared.publication.Publication
+    93	import org.readium.r2.shared.util.AbsoluteUrl
+    94	import java.time.ZoneId
+    95	import java.time.format.DateTimeFormatter
+    96	import java.util.Locale
+    97	import java.io.File
+    98	import vreader.contracts.Locator as CanonicalLocator
+    99	
+   100	@OptIn(ExperimentalReadiumApi::class)
+   101	class ReaderActivity : AppCompatActivity() {
+   102	
+   103	    private val container get() = (application as VReaderApp).container
+   104	    private val repository: LibraryRepository get() = container.repository
+   105	    private val bridge = ReadiumLocatorBridge()
+   106	
+   107	    private val annotations: AnnotationsRepository get() = container.annotationsRepository
+   108	
+   109	    private var containerId: Int = 0
+   110	    private var navigator: EpubNavigatorFragment? = null
+   111	    private var publication: Publication? = null   // host-owned; closed in onDestroy
+   112	    private var book: Book? = null
+   113	
+   114	    // feature #132 WI-7-EPUB — the persistent chrome model the top/bottom bands + sheet layer collect,
+   115	    // populated as the async open completes and updated on every position change. The active Display
+   116	    // theme (also read by the chrome bands' colors) is mirrored so the ComposeViews can render immediately.
+   117	    private val chromeModel = MutableStateFlow(ReaderChromeModel())
+   118	    private val chromeTheme = mutableStateOf(ReaderTheme.Paper)
+   119	    // The hoisted top/bottom-visibility + open-sheet state (a Compose snapshot state, so the ComposeViews
+   120	    // recompose on change). Kept in-memory for the reader's lifetime (rotation always starts fresh — see
+   195	            publication = pub
+   196	
+   197	            val initial = computeInitialLocator(key)
+   198	            // feature #129 WI-5 — open with the user's stored Display settings already applied (so a
+   199	            // non-default theme/typography renders on first paint, no flash), keeping the scroll layout.
+   200	            val initialPrefs = EpubPreferences(scroll = true) + container.readerSettingsStore.current().toEpubPreferences()
+   201	            val factory = EpubNavigatorFactory(pub)
+   202	            // Attach only when the activity is at least STARTED AND its fragment state
+   203	            // isn't already saved — `commitNow` against a state-saved manager throws
+   204	            // IllegalStateException. If we can't commit, abort (the publication is
+   205	            // released in onDestroy; the activity recreates fresh on return).
+   206	            val nav: EpubNavigatorFragment? = withStarted {
+   207	                if (supportFragmentManager.isStateSaved) return@withStarted null
+   208	                supportFragmentManager.fragmentFactory = factory.createFragmentFactory(
+   209	                    initialLocator = initial,
+   210	                    initialPreferences = initialPrefs,
+   211	                    listener = object : EpubNavigatorFragment.Listener {
+   212	                        override fun onExternalLinkActivated(url: AbsoluteUrl) {}
+   213	                    },
+   214	                    configuration = EpubNavigatorFragment.Configuration().apply {
+   215	                        // intercept the system selection menu → show the designed floating popover instead.
+   216	                        selectionActionModeCallback = selectionCallback()
+   217	                    },
+   218	                )
+   219	                supportFragmentManager.commitNow {
+   220	                    add(containerId, EpubNavigatorFragment::class.java, Bundle(), READER_TAG)
+   221	                }
+   222	                supportFragmentManager.findFragmentByTag(READER_TAG) as EpubNavigatorFragment
+   223	            }
+   224	            if (nav == null) { finish(); return@launch }
+   225	            navigator = nav
+   226	            val controller = ReaderHighlightController(nav)
+   227	            highlightController = controller
+   228	            repository.markOpened(key, System.currentTimeMillis())
+   229	            // feature #132 WI-7-EPUB — build the chrome model once the publication is open: the flattened
+   230	            // TOC (each entry retaining its native Readium locator for the jump), the Notes snapshot, and
+   231	            // the initial highlighted-chapter index for the current reading position.
+   232	            populateChromeModel(pub, loaded, nav)
+   233	            // feature #135 WI-7 — build the bookmark TOC index ONCE from the flattened TOC (WI-4 design),
+   234	            // then observe this book's bookmarks (project → rows) + keep the top-bar presence in sync.
+   235	            bookmarkTocIndex = BookmarkTocIndex.build(chromeModel.value.tocEntries)
+   445	        super.onStop()
+   446	        // Synchronous-intent flush: the last movement inside the debounce window would
+   447	        // otherwise be lost on back/home/rotation. Launched on the process scope so it
+   448	        // completes even as this activity is torn down.
+   449	        val nav = navigator ?: return
+   450	        val current = book ?: return
+   451	        val locator = nav.currentLocator.value
+   452	        container.appScope.launch { persist(locator, current) }
+   453	    }
+   454	
+   455	    override fun onDestroy() {
+   456	        super.onDestroy()
+   457	        // feature #133 WI-11 — dispose the in-book search VM (its onCleared disposes the live Readium
+   458	        // SearchIterator via closeAllEpubCursors) BEFORE releasing the publication it searches over — the
+   459	        // iterator is a view over the publication, so it must go first (no leak, no use-after-close).
+   460	        inBookSearchVm?.onCleared()
+   461	        inBookSearchVm = null
+   462	        // Host owns the Publication (Readium's navigator does not close it). The
+   463	        // fragment is torn down by super.onDestroy() above, then we release it.
+   464	        publication?.close()
+   465	        publication = null
+   466	    }
+   467	
+   468	    /** Restore precisely from the saved Readium locator; canonical-fallback (progression) is a follow-on. */
+   469	    private suspend fun computeInitialLocator(key: String): Locator? {
+   470	        val saved = repository.loadPosition(key) ?: return null
+   482	    private fun observeDisplaySettings(nav: EpubNavigatorFragment) {
+   483	        lifecycleScope.launch {
+   484	            container.readerSettingsStore.settings.collect { settings ->
+   485	                runCatching { nav.submitPreferences(EpubPreferences(scroll = true) + settings.toEpubPreferences()) }
+   486	                    .onFailure { android.util.Log.w("ReaderActivity", "submitPreferences failed; display change not applied", it) }
+   487	            }
+   488	        }
+   489	    }
+   490	
+   491	    /** Save the current Readium position as a VReaderLocator envelope (debounced steady-state) AND keep the
+   492	     *  chrome model's highlighted-chapter index in sync as the reader scrolls (prompt, un-debounced — the
+   493	     *  Contents-sheet highlight should track the live position, and tocIndexFor is a cheap pure map). */
+   494	    private fun observePosition(nav: EpubNavigatorFragment, current: Book) {
+   495	        lifecycleScope.launch {
+   496	            nav.currentLocator
+   497	                .drop(1)            // skip the initial emission
+   498	                .debounce(1_000)
+   499	                .collect { locator -> persist(locator, current) }
+   500	        }
+   501	        lifecycleScope.launch {
+   502	            nav.currentLocator.collect { locator ->
+   503	                val model = chromeModel.value
+   504	                val index = tocIndexFor(locator.href.toString(), locator.locations.progression, tocPositions(model.tocEntries))
+   505	                if (index != model.currentTocIndex) {
+   506	                    chromeModel.value = chromeModel.value.copy(currentTocIndex = index)
+   507	                }
+   508	                chromeProgress.value = (locator.locations.totalProgression ?: 0.0).toFloat().coerceIn(0f, 1f)
+   509	                // feature #135 WI-7 — map the live Readium position to canonical (the toggle's equality
+   510	                // basis) + refresh the top-bar filled/outline presence as the reader scrolls.
+   511	                val canonical = canonicalForCurrent(locator, current)
+   512	                currentCanonical = canonical
+   513	                isCurrentBookmarked.value = canonical != null &&
+   514	                    runCatching { annotations.isBookmarked(current.fingerprintKey, canonical) }.getOrDefault(false)
+   515	            }
+   103	    // feature #116 WI-5 — saved WebDAV server profiles persist in DataStore (URL/user/wifiOnly,
+   104	    // password ciphertext); chosen over the deprecated EncryptedSharedPreferences (Gate-2 Low-2).
+   105	    implementation("androidx.datastore:datastore-preferences:1.1.1")
+   106	
+   107	    // feature #106 WI-5/WI-9 — Readium-Kotlin 3.3.0 EPUB open + render. shared +
+   108	    // streamer open the publication (WI-5); navigator renders it in the reader host
+   109	    // (WI-9). Pinned to the Spike-B-verified set; the navigator needs appcompat +
+   110	    // fragment (its EpubNavigatorFragment is an AppCompat-themed Fragment).
+   111	    val readium = "3.3.0"
+   112	    implementation("org.readium.kotlin-toolkit:readium-shared:$readium")
+   113	    implementation("org.readium.kotlin-toolkit:readium-streamer:$readium")
+   114	    implementation("org.readium.kotlin-toolkit:readium-navigator:$readium")
+   115	    implementation("androidx.appcompat:appcompat:1.7.1")
+   116	    implementation("androidx.fragment:fragment-ktx:1.8.9")
+   117	
+
+exec
+/bin/zsh -lc "nl -ba dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md | sed -n '117,192p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+   117	## 3. Prior art / project precedent / rejected alternatives
+   118	
+   119	### The render-host decision (settled v2, CONFIRMED round-2)
+   120	
+   121	**How iOS does interlinear:** iOS renders EPUB/AZW3 in a WKWebView it fully controls. `EPUBBilingualOrchestrator` injects JS that (1) enumerates leaf blocks posting `[{bid,text}]` to Swift, (2) after translation injects a translation node after each block. TXT/MD render in a text path where the renderer interleaves translation runs. The mechanism = **the app inserts translation nodes between source nodes.**
+   122	
+   123	**Android EPUB feasibility (round-2 re-verified):** `javap`/the transformed API JAR on the resolved Readium 3.3.0 AAR expose public `evaluateJavascript(String, Continuation<? super String>)`, `getCurrentLocator()`, `firstVisibleElementLocator(...)`, `submitPreferences(...)`; `ReaderActivity.navigator: EpubNavigatorFragment?` holds the concrete fragment. So EPUB interlinear via JS injection is feasible with the public API — **no Readium fork.** The audit CONFIRMED this correction; it is not reopened.
+   124	
+   125	**WI-0 — Readium bilingual spike (gates WI-7b; round-2 M1 rewrote its contract into enforceable go/no-go thresholds):** a throwaway harness that, against a real EPUB on the emulator, must PROVE (each is a pass/no-go criterion):
+   126	
+   127	- **(a) Enumeration is deterministic + idempotent, with stable node IDs.** Enumerating the same current resource twice yields the same block IDs in the same order. Repeated `apply` produces **no duplicate injected nodes** (idempotent replacement).
+   128	- **(b) Clear wins over every older inject.** Under a rapid enable→disable / navigate sequence, a late-arriving inject issued before a `clear` must NOT survive the clear — enforced by the serialization mechanism below (a late inject checks the session token and no-ops).
+   129	- **(c) Recreation restores from cache** for every case: href away/back, same-href `submitPreferences` reflow, internal page-fragment recreation (the WebView pager recreates fragments), and activity recreation — each must re-apply the interlinear from the disk cache (via `cachedDirect(expectedCount)`, zero provider calls) with **an identified PRODUCTION re-apply signal** (a concrete navigator/lifecycle callback or `currentLocator`/fragment-lifecycle hook) for each case.
+   130	- **(d) Locator / visible-source preservation across injection**, with a stated permissible delta (injecting content may shift pagination by ≤ a stated bound; the reader's saved position must map back to the same source block).
+   131	- **(e) The enumerated block count vs the segmenter count** is measured; if they diverge (iOS #268), the **direct-block path** (`prefetchDirect` → `translatePreSegmented`, cached by enumerate count, restored by `cachedDirect(expectedCount)` — H2) is the recovery, proven end-to-end in the spike.
+   132	
+   133	**Race contract (M1):** WI-0 specifies **either a single actor/mutex OR a monotonic navigator-session token**; every suspended JS/AI call is followed by a token/mutex check; cancellation/clear runs BEFORE publication teardown. **If WI-0 cannot find a deterministic production re-apply signal for a recreation case (c), that is an explicit NO-GO:** EPUB drops to a tracked follow-up and box D ships **TXT/MD-only** — with the honest reason (a specific spike finding), never the false "requires a fork."
+   134	
+   135	**Rejected alternatives:**
+   136	1. **Readium interlinear via decorations only** — REJECTED (decorations style existing text; they cannot insert translation paragraphs). `evaluateJavascript` makes injection possible, so EPUB uses the JS seam.
+   137	2. **Forking Readium** — REJECTED + unnecessary (public `evaluateJavascript` seam exists).
+   138	3. **AZW3 foliate host first** — REJECTED for v1 (deferred, not dead; touches the security-sensitive #126 bridge).
+   139	4. **Eager whole-book pre-translation** — REJECTED (cost/latency). Lazily prefetch current+next + cache — port iOS.
+   140	5. **One `BilingualInterlinearBody` per chunk (v2)** — REJECTED (round-2 H1): a chunk is not a segment. Replaced by document-global segment ranges (§2).
+   141	6. **A Compose body as the EPUB render surface (v2)** — REJECTED (round-2 M2): Compose cannot render inside Readium's WebView. Replaced by `EpubBilingualJs` DOM injection sharing only the `BilingualRenderState` DTO.
+   142	
+   143	### The setup-sheet resolution (rule 51) + Style descope (round-2 H3, USER DECISION)
+   144	
+   145	There are **two committed, differently-shaped** `BilingualSetupSheet`s:
+   146	- `vreader-bilingual.jsx` → **language grid + Granularity + preview strip + Translation-engine strip (Set up/Change) + Cancel/Translate**. **No Style, no provider/model card, no term-overrides, no cost.**
+   147	- `vreader-ai-android.jsx` → **Languages (From/To) + Provider card + Style (Literal/Natural/Literary) + Keep-term-overrides toggle + cost footer.** **No language grid, no Granularity, no preview.**
+   148	
+   149	**Resolution:** this plan reproduces the **`vreader-bilingual.jsx` sheet EXACTLY** as the authoritative Android-native bilingual sheet. **Style is DESCOPED for v1** (user decision): #131 keeps provider/model/**granularity**, DROPS the bilingual "Style" control. Consequently the store/VM carry no `style`, the chunk contract has no `style` param, and the cache key's `promptVersion` has no `s=` component. Keep rule 51: only implement the designed surface.
+   150	
+   151	**Box-D parity note (H3 — do NOT claim full box-D parity):** the box-D parity checklist lists provider/model/**style**. Because Style is descoped v1, **WI-9 flips box D to done ONLY for provider/model/granularity + a descope note** — it does NOT claim full box-D parity. A **follow-up tracker/checklist amendment records the Style descope** (the plan does not silently drop it). If Style is later wanted on Android as a user control, that needs an **updated committed design** (a single sheet showing BOTH Style AND Granularity is not depicted anywhere — the one open design gate below).
+   152	
+   153	### Other precedents applied
+   154	
+   155	- **#118 provider seam**: reuse `AiProviderStore.snapshot()` (`snapshot.active`) + `store.apiKey(profile)` + `AiProviderFactory.create` (default of an injected factory param) + `AiClient.chat`. #118's AI files are unchanged; **#136** wires `AiProviderStore` into `AppContainer`; #131's DI WI wires the bilingual services.
+   156	- **Room additive-migration pattern** (#122/#123/#127/#128/#135): version bump + `MIGRATION_n_(n+1)` appended to `ALL_MIGRATIONS` + exact-DDL + `VReaderDatabaseMigrationTest` PRAGMA guard. `@PrimaryKey` + `@Upsert` is the project's DAO pattern (`BookDao`). Baseline is **v8** (M4).
+   157	- **DataStore JSON-in-Preferences** for `PerBookBilingualStore` (the `ReaderSettingsStore`/`AiProviderStore` pattern).
+   158	- **Pure-logic port**: iOS `ChapterSegmenter`/`ChapterTranslationChunker`/`TranslationChunkContract`/`ChapterTranslationService.translatePreSegmented`/`ChapterTranslationPrefetcher.translatedSegmentsDirect`+`cachedSegmentsDirect` are pure/heavily-unit-tested — direct Kotlin ports with the same test vectors (all verified to exist).
+   159	- **Entry point via #132/#134 (VERIFIED)**: the More-menu bilingual toggle (`MoreActionId.BILINGUAL` reserved; `MoreRow.Toggle` carries `on`/`onToggle`) + top-chrome pill are the landed integration points; #131 mounts the pill + wires the toggle (§4).
+   160	
+   161	## 4. Work-item sequencing
+   162	
+   163	**11 WIs/PRs (round-2 L2):** WI-0 (spike), WI-1..WI-4a (foundation/service), **WI-4b (shared DI/factory)**, WI-5, WI-6, WI-7a (Compose UI), **WI-7b (conditional EPUB render adapter — dropped if WI-0 = no-go)**, WI-8 (TXT/MD host integration), WI-9 (entry wiring + acceptance). Each WI = one PR. Build order (round-2 M3): **foundation/cache → service/direct-block APIs → shared DI/factory → VM state/prefetch → host-specific renderers (TXT/MD + EPUB) → entry wiring.**
+   164	
+   165	**Dependency notes (round-2 L1 — exact landed integration points):**
+   166	- **`Deps: [feat:#136, feat:#132, feat:#134]`.** **#132 (top chrome) and #134 (More menu) are VERIFIED — dependencies satisfied** (the top-chrome host + `MoreActionId.BILINGUAL` toggle row are landed). **#129 (TXT/MD reader) is VERIFIED** — `TxtReaderActivity` is a straight edit, not a blocker. **#136 (AI provider setup made production-reachable) is the NEW hard blocker** for #131's entry-wiring (the "Set up"/"Change…" route) AND the DONE flip; it provides `AiProviderStore` in `AppContainer` and the reachable AI-config sheet. The live More model already reserves `MoreActionId.BILINGUAL` (verified).
+   167	- The pipeline + setup sheet + interlinear render (WI-0..WI-7) are built ahead; only the **entry wiring (WI-9)** and the **DI WI (WI-4b, for `AiProviderStore` in `AppContainer`)** wait on #136. The pill mount (WI-9) targets #132's VERIFIED top chrome; the toggle wire (WI-9) targets #134's VERIFIED More menu.
+   168	
+   169	**WI-0 (spike): Readium EPUB bilingual injection — with enforceable go/no-go + race contract (M1).** The harness + criteria (a)–(e) and the race contract in §3. Output: a **go/no-go on EPUB-in-v1** (no-go if no deterministic production re-apply signal — box D ships TXT/MD-only, tracked) + the concrete `EpubChapterTextProvider` / `EpubBilingualJs` / `EpubBilingualController` surfaces. Deps: none (uses the existing #106 Readium host). Not TDD-gated (throwaway spike); its findings feed WI-7b.
+   170	
+   171	**WI-1 (foundational): value types + pure segmentation/chunk/contract.** `TranslationUnitId` (document-global TXT/MD kinds — H1), `TranslationGranularity`, `BilingualLanguages`, **`ChapterSegmenter` (with `paragraphRanges`/`sentenceRanges` — H1)**, `TranslationChunker`, `TranslationChunkContract` (no `style` — H3), `ChapterTranslationError`. Pure; ported iOS vectors. Deps: none.
+   172	
+   173	**WI-2 (foundational): Room translation cache.** `ChapterTranslationEntity` (PK = `lookupKey`, `sourceParagraphCount` column) + `Dao` (`@Upsert`) + `ChapterTranslationStore`; `VReaderDatabase` **8→9 `MIGRATION_8_9`** appended after `MIGRATION_7_8` (M4). Robolectric migration round-trip from **v8** + full-chain + upsert/get/delete-by-lookupKey + FK-CASCADE + exact-DDL guard. Deps: none.
+   174	
+   175	**WI-3 (foundational): `ChapterTranslationService`** against a fake `AiClient`. `cachedTranslation` (both overloads incl. the **`expectedSegmentCount` divergence restore — H2**) + `translate` + **`translatePreSegmented` (H2: chunk, per-chunk degrade, cancellation, cache-write with the enumerate count on full success only)**. Deps: **WI-1, WI-2**. Tests: cache hit → zero client calls; miss → translate + write; decode fail → per-segment fallback; one-chunk fail → source-only that chunk (others translated, NOT cached); all-chunks fail → throw; cancellation → `Cancelled` (no write); `AiError` mapping incl. `Config`/`InsecureUrl` → `ProviderFailed`; **`translatePreSegmented` full-success caches under the enumerate count; partial degrade NOT cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` returns on stored-count match, null on mismatch, needs no provider**.
+   176	
+   177	**WI-4a (foundational): `ChapterTextProvider` (TXT/MD) + `ChapterTranslationPrefetcher` + `BilingualAiReadiness`.** `TxtChapterTextProvider` builds the **document-global segment ranges once (H1)**, groups into windows, resolves `unitContaining(charOffsetUTF16)` via segment-start binary search, `sourceSegments(unit)`. Prefetcher: `prefetch` + **`prefetchDirect` + `cachedDirect` (zero-provider cache restore — H2)**; resolves active profile from `snapshot()`, decrypts snapshot-consistent, builds client via the **injected factory param** (default `AiProviderFactory::create`), constructs `AiRequest` from the profile. Readiness = active profile with non-empty decrypted key; **cipher failure → not-ready, never a crash.** Fake store + fake factory. Deps: **WI-1, WI-3**. Tests: unit resolution + clamp + empty; **paragraph spanning a chunk boundary → one segment/one unit; multiple paragraphs in one chunk → distinct segments; a >4000-char paragraph → one segment across chunks; CR/LF/CRLF; MD markers; locator→unit mapping; source-byte parity while disabled**; cache-hit-no-profile still returns (#306); no-profile miss → `ProviderFailed`; `prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls; readiness true/false; cipher-throw → readiness false (no crash).
+   178	
+   179	**WI-4b (foundational — shared DI/factory, round-2 M3): AppContainer bilingual services.** Extract the DI/factory wiring into this EARLIER shared WI: `AppContainer` provides `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, and the `BilingualViewModel` factory — **consuming `AiProviderStore` from `AppContainer` (provided by #136).** Both host integrations (WI-7b, WI-8) depend on this. Deps: **WI-4a, feat:#136** (for `AiProviderStore` in `AppContainer`). Tests: container resolves the bilingual graph; the prefetcher's injected factory defaults to `AiProviderFactory::create`.
+   180	
+   181	**WI-5 (behavioral): `PerBookBilingualStore` + `BilingualViewModel` state core.** Store per book (enabled/targetLanguage/granularity — no style); VM setters (persist + first-enable `needsSetupSheet`), language/granularity change clears cache-shaped state + bumps generation. Turbine tests: first-enable raises sheet; re-enable persisted does not; disable clears; language change resets; granularity change resets + re-keys; round-trip through store; no style field. Deps: **WI-1** (+ store).
+   182	
+   183	**WI-6 (behavioral): VM prefetch trigger + generation/cancellation.** `onPositionChanged(charOffsetUTF16)` derives current unit, dedupes, prefetches current+next; a **monotonic position-request sequence** checked after every suspension; **per-unit generation tokens**; a **captured language/granularity/provider snapshot per launch**; generation bumps on disable/language/granularity/unit-change discard stale; `CancellationException` handled BEFORE generic error mapping; `Offline`→`unavailableUnits`; transient failure leaves unit unfetched + clears anchor to retry; `retryUnit`. Fake prefetcher. Deps: **WI-4a, WI-4b, WI-5**. Tests: current+next on unit change; same-unit no-op; cancel-mid discards stale; offline→unavailable; failure→retry-able; `retryUnit` re-fetches; granularity change cancels + re-fetches under the new key.
+   184	
+   185	**WI-7a (behavioral): Compose UI — setup sheet + interlinear body (TXT/MD) + pill.** Reproduce `vreader-bilingual.jsx` (setup sheet: language grid / granularity / preview / engine strip configured+unconfigured; body: translated / loading N%+dimmed / error+Retry / offline source-only; pill). Consumes the **host-neutral `BilingualRenderState` DTO (M2)**. Light+dark. Compose UI tests each state. Deps: **WI-5** (state shape). NO Style control; the unconfigured "Set up" CTA renders and (in WI-9) routes to #136's sheet.
+   186	
+   187	**WI-7b (behavioral, CONDITIONAL — only if WI-0 = go): EPUB render adapter (DOM injection, NOT Compose — round-2 M2).** `EpubBilingualJs` (enum/inject/clear JS builders, CSP-safe escaping) + `EpubBilingualController` (the serialization actor / session token — M1) + `EpubChapterTextProvider`, wired into `ReaderActivity`, driving DOM from the **shared `BilingualRenderState` DTO**. **Depends on WI-6 (VM prefetch) and WI-4b (DI) — the M3 fix; the WI-7a UI dependency is REMOVED except for the shared `BilingualRenderState`/value types.** Uses `prefetchDirect`/`cachedDirect` for the count-divergence path (H2). Connected test on a real EPUB (seeded cache): enable → interlinear injects; disable → nodes cleared; reflow/href-change/fragment-recreation/activity-recreation → re-applies from cache (zero provider calls); count-divergence handled (direct path). Unit tests: JS escaping/CSP-safe text insertion, RTL/CJK style, empty translations, loading cleanup, idempotent replacement, source-only fallback. Deps: **WI-0, WI-3, WI-4a, WI-4b, WI-6, (shared types from WI-7a)**. (If WI-0 = no-go, this WI is dropped and box D ships TXT/MD-only, tracked.)
+   188	
+   189	**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into the `items(chunkCount)` loop **keyed by segment-range overlap (H1)** + position-change (`charOffsetUTF16`) + setup-sheet. `originalFormat`-gated (TXT/MD). Uses WI-4b's DI. **#129 is VERIFIED — straight edit.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; disable → source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; paragraph-spanning-chunk-boundary renders one translation. Deps: **WI-6, WI-7a, WI-4b**.
+   190	
+   191	**WI-9 (behavioral): entry wiring + acceptance.** Mount `BilingualPill` in **#132's VERIFIED top chrome**; wire the **#134 VERIFIED More-menu `MoreActionId.BILINGUAL` toggle** (`MoreRow.Toggle` `on`/`onToggle`) to the VM; **wire the setup sheet's "Set up"/"Change…" affordance → #136's AI-provider-entry sheet.** Full acceptance pass across EPUB (if WI-7b landed) + TXT/MD, including the fresh-user path `unconfigured → Set up (→ #136 sheet) → add provider → return → enable → translate` (the #136-owned reachability verified jointly). **Flip box D to done ONLY for provider/model/granularity + the Style-descope note (H3); file the follow-up checklist amendment; do NOT claim full box-D parity, do NOT flip DONE until #136 is landed.** Update `docs/architecture.md` (bilingual pipeline + the new `chapter_translations` schema + bilingual services in `AppContainer`). → DONE. Deps: **WI-8, WI-7b (if go), feat:#136, feat:#132, feat:#134**.
+   192	
+
+exec
+/bin/zsh -lc "rg -n \"\\| 131 \\||\\| 136 \\||Feature #136|#136\" docs/features.md dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt android/app/src/main/kotlin/com/vreader/app/MainActivity.kt | head -120 && nl -ba android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt | sed -n '1,125p' && nl -ba android/app/src/main/kotlin/com/vreader/app/MainActivity.kt | sed -n '1,150p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:1:# Gate-1 Plan — Feature #136: AI provider setup made production-reachable (Android)
+dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:13:**#136 makes the already-designed, already-built AI provider config production-reachable and independently verifiable**, from a designed in-reader entry that does not depend on #131.
+dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:19:Two designed reader entries exist; #136 uses the one that is **independent of #131**:
+dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:23:This entry is reachable by a fresh user (open any book → More → "Configure AI provider first") with **no bilingual wiring present** — which is precisely what independent-verifiability requires. #131 will later ADD the *enabled* Bilingual toggle + its own bilingual-Set-up→here route; #136 owns only the `aiUnavailable`/`configure-ai` path.
+dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:44:- **Provider CRUD internals** — `AiProviderStore.upsert/delete/setActive/apiKey`, `AiSettingsViewModel.test/save`, `AiProviderFactory`, the provider clients, `SseEventReader`, `AiProviderKind`. All shipped and tested by #118; #136 constructs and reaches them, never re-implements them.
+dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:46:- **The AI-readiness sheet (flag + consent gates)** — `reader-ai-readiness.md`'s `ReaderAIReadinessSheet` (master AI toggle + consent ledger) is **design-landed but implementation-deferred** ("do NOT build without go-ahead"). #136 delivers the provider-list reachability only; the flag/consent capstone is a separate feature.
+dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:47:- **AI chat panel wiring** — `AiChatPanel`/`AiChatViewModel` are ALSO unwired, but chat's reader entry is #131/a chat feature's surface, not #136.
+dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:49:- **A Library-level Settings tree / More pill** (`LibraryScreen.kt:95`) — not built; #136 deliberately does NOT depend on it (see §3 rejected alt).
+dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:55:- `design-notes/reader-ai-provider-entry.md` — Variant **A** (CANONICAL): "a scoped, in-reader 'AI Providers' sheet … reusing the canonical `AIProviderEditSheet`", chosen over B (deep-link the whole SettingsView) and C (inline mini-form). Its stated win: "Keeps the reader context … the user never sees Cloud & Sync, OPDS, TTS." #136 implements A's Android analog.
+dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:62:- **#129/#132/#134/#135** wired every reader-chrome entry through the exact seams #136 reuses: the `readerMoreRows` assembler, `ReaderChromeState`/`ReaderSheet` + its saver, the `EpubReaderSheets` open-only sheet layer, and the additive-nullable-param "one-writer-coordinate" convention. #134 added Details/Share rows; #136 adds the `configure-ai` row by the same contract.
+dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:67:2. **Route only from #131's bilingual Set-up.** Rejected by independent-verifiability: it would couple #136 to #131 (still `PLANNED`) and make AI config unreachable until bilingual ships. The `aiUnavailable`/`configure-ai` More-row is reachable with zero bilingual wiring.
+dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:102:- **AI-key security surface (#118).** Mitigation: #136 constructs `AiProviderStore` with `KeystoreSecretCipher` under `noBackupFilesDir` (the #116 contract) and touches NO CRUD/crypto path. Keys stay device-local; no `contracts/` change.
+dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:110:- **Older reader-chrome state tokens.** Unknown-token → `None` means a persisted pre-#136 `ReaderChromeState` restores cleanly.
+dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:115:**#136 is a HARD dependency of #131.** #131's fresh-user AI-config path + its Gate-5 acceptance route both require a reachable AI provider config to land on; that destination is delivered by #136. #131 must not re-implement or inline provider config — it consumes #136's `ReaderSheet.AiProviders` sheet. **#131's bilingual-Set-up → #136 route (the enabled Bilingual `MoreRow.Toggle` + its "Set up"→AI-Providers navigation) is #131's OWN WI, not #136's** — #136 delivers only the independent `aiUnavailable`/`configure-ai` More-menu entry, so AI config is reachable + verifiable before #131 exists.
+docs/features.md:133:| 79 | AI provider editor — pre-filled Base URL / Model should behave as placeholders that clear on focus (currently seeded as real editable defaults the user must delete; `AIProviderEditSheet.swift:111-112`). | Settings/AI | Low | VERIFIED | Filed 2026-06-02 via /triage; needs-design #1363 **DESIGN LANDED** (`design-notes/ai-provider-editor-fields.md`, Variant A). Gate-2 Codex audit 3 rounds, converged 3→1→0. **DONE 2026-06-03** (Variant A, add-mode-only): add-mode binds Base URL/Model empty; pure statics `effectiveBaseURLText`/`effectiveModel` (add-mode blank → kind default; edit-mode raw) drive `canSave`/`save()`/`runTest()` + the live `baseURLError` onChange; `placeholderBaseURL`/`placeholderModel` (add-mode → kind default; edit-mode → "") drive the field placeholders; a muted "Default" tag shows beside an empty add-mode field. Edit-mode keeps raw validate/persist/test + no placeholder/tag. **Gate-4 Codex audit** (`/tmp/feat79-implaudit.txt`, 1 round, ship-as-is): Medium — `effectiveModel` trimmed in both modes → would normalize an edit-mode whitespace-padded model on save; fixed (edit-mode returns raw) + regression test. Tests: 7 helper/effective-value tests in `AISettingsViewModelEditorTests`. Audit log `.claude/codex-audits/feat-feature-79-wi1-placeholders-audit.md`. **VERIFIED 2026-06-03** — Gate-5b device pass (v3.48.0, `7b1d471c`): the Add Provider editor shows empty Base URL/Model + a "Default" tag + the kind-default muted placeholder (criteria 1/6 device-verified); blank→default save + edit-mode-raw are unit-pinned (7 tests). Evidence `dev-docs/verification/feature-79-20260603.md`. Sibling #80 (test-before-save) separate. GH: #1436. |
+docs/features.md:184:| 131| **Android bilingual interlinear reading** (parity box D) — per-book toggle renders each source paragraph followed by an AI-backed translation (muted, accent border), cached to disk; Android parity of iOS #56/#100, building on the #118 AI foundation. | android/app/.../bilingual/* + reader hosts + ReaderBottomChrome/More-menu entry | Medium | PLANNED | Deps:[feat:#136, feat:#132, feat:#134] (#132 top chrome + #134 More menu VERIFIED; #129 TXT reader VERIFIED = straight edit; **#136 AI-provider-reachability is the NEW hard blocker** for the "Set up" route + AppContainer AiProviderStore + the DONE flip). Plan `dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md` (Gate-1 v3, 11 WIs: WI-0 Readium JS-injection spike w/ go-no-go + navigator-race contract; WI-1..4a foundation/service; WI-4b shared DI; WI-5/6 VM state+prefetch; WI-7a Compose UI; WI-7b conditional EPUB DOM-injection adapter; WI-8 TXT/MD host; WI-9 entry wiring+acceptance). **Style DESCOPED v1** (user decision 2026-07-12): keep provider/model/granularity, drop the bilingual Style control (box D flips done for provider/model/granularity + a Style-descope follow-up amendment; a Style+Granularity single sheet is not depicted anywhere = the one open design gate). Design authority (landed, rule 51): vreader-bilingual.jsx (granularity-only setup sheet) + vreader-reader.jsx pill + vreader-more.jsx toggle. **Gate-2 round-2 = REDESIGN resolved (v3): TXT/MD document-global segment ranges (H1); EPUB translatePreSegmented + count-keyed cache + direct-block prefetch (H2); #136 spun out + Style descoped (H3); WI-0 go/no-go + race contract (M1); EPUB DOM-injection NOT Compose body (M2); DI/factory WI reordered (M3); Room 8->9 MIGRATION_8_9 (M4). Gate-2 round-3 audit pending.** GH: #1923 |
+docs/features.md:189:| 136| **Android AI provider setup made production-reachable** (prerequisite for AI features) — #118 shipped the whole Android AI provider stack (AiProviderStore / AiSettingsViewModel / AiProviderListScreen / AiProviderEditSheet — built + tested) but it is wired into NO production entry (AiProviderStore is never constructed in AppContainer; the screens are referenced only by tests; there is no NavHost/Settings/More route), so a fresh install has ZERO route to configure an AI provider — dead-ending every AI feature (bilingual #131, chat, translate). #136 makes the already-designed, already-built config production-reachable via the designed reader More-menu configure-ai entry ("Configure AI provider first" -> in-reader AI Providers sheet, Variant A). | android/app/.../ai wiring + reader/chrome/{ReaderChromeScaffold,ReaderChromeState} + VReaderApp/AppContainer + reader/ai/ReaderAiProvidersHost (new) | Medium | PLANNED | Deps:[feat:#118] (#118 shipped the AI provider stack; #136 = reachability only). Plan `dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md` (Gate-1 v1, 3 WIs: WI-1 AppContainer aiProviderStore + aiSettingsViewModel() factory [foundational]; WI-2 ReaderAiProvidersHost + ReaderSheet.AiProviders route + saver [behavioral]; WI-3 reader More-menu aiUnavailable->configure-ai disabled Bilingual row across 5 hosts + readerMoreRows(aiUnconfigured,onConfigureAi) [behavioral final]). Design authority (landed, rule 51): vreader-more.jsx configure-ai row + vreader-ai-android.jsx AiProviderList + vreader-ai-provider-entry.jsx + design-notes reader-ai-provider-entry.md / reader-ai-readiness.md (Variant A in-reader scoped sheet). Reuses #118's AiProviderListScreen/AiProviderEditSheet verbatim. Spun out per user decision (2026-07-12) from #131 Gate-2-round-2 High-3 (AI-config unreachable). **HARD dependency of #131.** Awaiting Gate-2 audit. GH: #1976 |
+     1	// Purpose: Application + manual DI container — feature #106 WI-8. Holds the
+     2	// process-singleton Room database, repository, and importer so the Library
+     3	// ViewModel gets shared instances (a Hilt module is a Phase-3 follow-on; manual
+     4	// wiring at the app edge keeps the foundation bar dependency-light — rule 50 §5).
+     5	package com.vreader.app
+     6	
+     7	import android.app.Application
+     8	import android.content.Context
+     9	import com.vreader.app.data.BookImporter
+    10	import com.vreader.app.data.LibraryRepository
+    11	import com.vreader.app.data.VReaderDatabase
+    12	import com.vreader.app.reader.BookOpener
+    13	import com.vreader.app.search.BookTextExtractor
+    14	import com.vreader.app.search.EpubTextExtractor
+    15	import com.vreader.app.search.asSearcher
+    16	import com.vreader.app.search.SearchIndexCoordinator
+    17	import com.vreader.app.search.TxtMdTextExtractor
+    18	import com.vreader.app.annotations.AnnotationsRepository
+    19	import com.vreader.app.stats.ReadingStatsRepository
+    20	import com.vreader.app.stats.ReadingTimeTracker
+    21	import com.vreader.app.stats.clock.SystemDateClock
+    22	import com.vreader.app.stats.clock.SystemElapsedClock
+    23	import kotlinx.coroutines.CoroutineScope
+    24	import kotlinx.coroutines.Dispatchers
+    25	import kotlinx.coroutines.SupervisorJob
+    26	import kotlinx.coroutines.flow.map
+    27	import vreader.contracts.BookFormat
+    28	import java.io.File
+    29	
+    30	/** Process-wide singletons, lazily built. */
+    31	class AppContainer(context: Context) {
+    32	    private val appContext = context.applicationContext
+    33	
+    34	    val database: VReaderDatabase by lazy { VReaderDatabase.build(appContext) }
+    35	    val repository: LibraryRepository by lazy {
+    36	        LibraryRepository(database.bookDao(), database.readingPositionDao())
+    37	    }
+    38	    val importer: BookImporter by lazy {
+    39	        BookImporter(File(appContext.filesDir, "books"), repository)
+    40	    }
+    41	
+    42	    // feature #122 — reading-stats. The repository + the time tracker are process-singletons so a
+    43	    // reading session survives the (shorter-lived) reader ViewModel / rotation. ONE shared DateClock
+    44	    // so the dashboard's "today" and the tracker's bucket dates can't drift apart.
+    45	    private val dateClock: SystemDateClock by lazy { SystemDateClock() }
+    46	    val statsRepository: ReadingStatsRepository by lazy {
+    47	        ReadingStatsRepository(database.readingStatsDao(), repository, dateClock)
+    48	    }
+    49	    val readingTimeTracker: ReadingTimeTracker by lazy {
+    50	        ReadingTimeTracker(statsRepository, SystemElapsedClock(), dateClock)
+    51	    }
+    52	
+    53	    // feature #123 — annotations (EPUB highlights & notes). Process-singleton so the reader VM /
+    54	    // rotation share one instance (the statsRepository precedent).
+    55	    val annotationsRepository: AnnotationsRepository by lazy {
+    56	        AnnotationsRepository(database.annotationDao())
+    57	    }
+    58	
+    59	    // feature #127 — library collections. Process-singleton (the annotationsRepository precedent).
+    60	    val collectionRepository: com.vreader.app.data.CollectionRepository by lazy {
+    61	        com.vreader.app.data.CollectionRepository(database.collectionDao())
+    62	    }
+    63	
+    64	    // feature #129 — reader display settings. A device-local DataStore (the OpdsSourceStore /
+    65	    // AiProviderStore precedent), global (not per-book), process-singleton so a settings change
+    66	    // propagates to whatever reader is open. Stored under noBackupFilesDir — display prefs are
+    67	    // per-device (NOT in the backup contract), so they must be excluded from Android Auto Backup.
+    68	    private val readerSettingsDataStore: androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences> by lazy {
+    69	        androidx.datastore.preferences.core.PreferenceDataStoreFactory.create {
+    70	            File(appContext.noBackupFilesDir, "reader_settings.preferences_pb")
+    71	        }
+    72	    }
+    73	    val readerSettingsStore: com.vreader.app.reader.settings.ReaderSettingsStore by lazy {
+    74	        com.vreader.app.reader.settings.ReaderSettingsStore(readerSettingsDataStore)
+    75	    }
+    76	
+    77	    /** Process-lifetime scope for fire-and-forget writes that must outlive a screen
+    78	     *  (e.g. the reader's onStop position flush — it must finish even as the activity
+    79	     *  is being torn down). */
+    80	    val appScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    81	
+    82	    // feature #128 WI-5 — cross-book search index. The coordinator observes the library and
+    83	    // streams each indexable book (epub/txt/md) through the WI-3 extractors into WI-4's staging →
+    84	    // atomic publish. Eagerly started once from onCreate; pdf/azw3 map to null (never indexable).
+    85	    private val bookOpener: BookOpener by lazy { BookOpener(appContext) }
+    86	    private val epubTextExtractor: EpubTextExtractor by lazy { EpubTextExtractor(bookOpener) }
+    87	    private val txtMdTextExtractor: TxtMdTextExtractor by lazy { TxtMdTextExtractor() }
+    88	    val searchIndexCoordinator: SearchIndexCoordinator by lazy {
+    89	        SearchIndexCoordinator(
+    90	            repository = repository,
+    91	            searchDao = database.searchDao(),
+    92	            extractorFor = { fmt: BookFormat ->
+    93	                when (fmt) {
+    94	                    BookFormat.epub -> epubTextExtractor
+    95	                    BookFormat.txt, BookFormat.md -> txtMdTextExtractor
+    96	                    BookFormat.pdf, BookFormat.azw3 -> null   // metadata-only — never indexed
+    97	                }
+    98	            },
+    99	            scope = appScope,
+   100	            ioDispatcher = Dispatchers.IO,
+   101	        )
+   102	    }
+   103	
+   104	    /** Idempotent — starts the single search-index collector (the coordinator's own AtomicBoolean
+   105	     *  makes a repeat call a no-op). Called once from [VReaderApp.onCreate]. */
+   106	    fun startSearchIndexing() = searchIndexCoordinator.startSearchIndexing()
+   107	
+   108	    // feature #128 WI-6 — the query pipeline. SearchRepository turns a raw query into an observable
+   109	    // Flow of first-hit-per-book text hits (grows as indexing completes); RecentSearchesStore is a
+   110	    // device-local DataStore under noBackupFilesDir (the readerSettingsStore precedent — recents are
+   111	    // per-device, NOT in the backup contract). The SearchViewModel factory wires the metadata filter,
+   112	    // the text-hit Flow, the completeness gate, and recent-recording for the WI-7 screen.
+   113	    val searchRepository: com.vreader.app.search.SearchRepository by lazy {
+   114	        com.vreader.app.search.SearchRepository(database.searchDao())
+   115	    }
+   116	    private val recentSearchesDataStore: androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences> by lazy {
+   117	        androidx.datastore.preferences.core.PreferenceDataStoreFactory.create {
+   118	            File(appContext.noBackupFilesDir, "recent_searches.preferences_pb")
+   119	        }
+   120	    }
+   121	    val recentSearchesStore: com.vreader.app.search.RecentSearchesStore by lazy {
+   122	        com.vreader.app.search.RecentSearchesStore(recentSearchesDataStore)
+   123	    }
+   124	
+   125	    /**
+     1	// Purpose: feature #106 — the vreader Android app's entry Activity. Hosts the
+     2	// Library screen (WI-8, the committed vreader-fidelity-v1 design) wired to the
+     3	// shipped plumbing: the LibraryViewModel (Room-backed StateFlow) + the SAF
+     4	// OpenDocument picker → BookImporter. Opening a book is the reader host (#1745),
+     5	// resumed against vreader-reader.jsx.
+     6	//
+     7	// @coordinates-with: AndroidManifest.xml (the launcher activity), VReaderApp.kt
+     8	//   (the DI container), library/LibraryViewModel.kt, library/LibraryScreen.kt
+     9	package com.vreader.app
+    10	
+    11	import android.os.Bundle
+    12	import android.widget.Toast
+    13	import androidx.activity.ComponentActivity
+    14	import androidx.activity.compose.rememberLauncherForActivityResult
+    15	import androidx.activity.compose.setContent
+    16	import androidx.activity.result.contract.ActivityResultContracts
+    17	import androidx.compose.runtime.getValue
+    18	import androidx.lifecycle.compose.collectAsStateWithLifecycle
+    19	import androidx.lifecycle.viewmodel.compose.viewModel
+    20	import androidx.lifecycle.viewmodel.initializer
+    21	import androidx.lifecycle.viewmodel.viewModelFactory
+    22	import androidx.compose.runtime.mutableStateOf
+    23	import androidx.compose.runtime.remember
+    24	import androidx.compose.runtime.saveable.rememberSaveable
+    25	import androidx.compose.runtime.setValue
+    26	import com.vreader.app.library.AssignToCollectionsSheet
+    27	import com.vreader.app.library.ManageCollectionsSheet
+    28	import com.vreader.app.library.LibraryEvent
+    29	import com.vreader.app.library.LibraryScreen
+    30	import com.vreader.app.library.LibraryViewModel
+    31	import com.vreader.app.library.SheetRoute
+    32	import com.vreader.app.library.SheetRouteSaver
+    33	import com.vreader.app.reader.Azw3ReaderActivity
+    34	import com.vreader.app.reader.ReaderActivity
+    35	import com.vreader.app.reader.PdfReaderActivity
+    36	import com.vreader.app.reader.TxtReaderActivity
+    37	import com.vreader.app.search.SearchScreen
+    38	import com.vreader.app.ui.theme.VReaderTheme
+    39	import vreader.contracts.BookFormat
+    40	import androidx.compose.runtime.LaunchedEffect
+    41	
+    42	class MainActivity : ComponentActivity() {
+    43	    override fun onCreate(savedInstanceState: Bundle?) {
+    44	        super.onCreate(savedInstanceState)
+    45	        val container = (application as VReaderApp).container
+    46	        val factory = viewModelFactory {
+    47	            initializer { LibraryViewModel(container.repository, container.importer, container.collectionRepository, contentResolver) }
+    48	        }
+    49	
+    50	        setContent {
+    51	            VReaderTheme {
+    52	                val viewModel: LibraryViewModel = viewModel(factory = factory)
+    53	                val state by viewModel.uiState.collectAsStateWithLifecycle()
+    54	                val collections by viewModel.collections.collectAsStateWithLifecycle()
+    55	                val selectedCollectionId by viewModel.selectedCollectionId.collectAsStateWithLifecycle()
+    56	                // feature #127 WI-4 — which collections sheet is open (survives rotation/process death).
+    57	                var sheetRoute by rememberSaveable(stateSaver = SheetRouteSaver) { mutableStateOf<SheetRoute>(SheetRoute.None) }
+    58	                // feature #128 WI-7 — the search takeover open/closed flag (the SheetRoute saveable
+    59	                // precedent; a Boolean needs no custom Saver, so rememberSaveable survives rotation/death).
+    60	                var searchOpen by rememberSaveable { mutableStateOf(false) }
+    61	
+    62	                val picker = rememberLauncherForActivityResult(
+    63	                    ActivityResultContracts.OpenDocument(),
+    64	                ) { uri -> uri?.let(viewModel::import) }
+    65	
+    66	                LaunchedEffect(Unit) {
+    67	                    viewModel.events.collect { event ->
+    68	                        val message = when (event) {
+    69	                            is LibraryEvent.ImportFailed -> event.message
+    70	                            is LibraryEvent.CollectionOpFailed -> event.message
+    71	                        }
+    72	                        Toast.makeText(this@MainActivity, message, Toast.LENGTH_SHORT).show()
+    73	                    }
+    74	                }
+    75	
+    76	                // Route by the typed format (exhaustive — never open a format into the wrong host).
+    77	                // Shared by the library grid tap and the search result tap (both carry a typed format +
+    78	                // fingerprintKey).
+    79	                fun openBook(format: BookFormat, key: String) {
+    80	                    when (format) {
+    81	                        BookFormat.epub ->
+    82	                            startActivity(ReaderActivity.intent(this@MainActivity, key))
+    83	                        BookFormat.txt, BookFormat.md ->
+    84	                            // .md reuses the text reader host (#112): same decode/
+    85	                            // document/resume/chrome, MarkdownRenderer per chunk.
+    86	                            startActivity(TxtReaderActivity.intent(this@MainActivity, key))
+    87	                        BookFormat.pdf ->
+    88	                            // #115 — continuous-scroll PdfRenderer reader.
+    89	                            startActivity(PdfReaderActivity.intent(this@MainActivity, key))
+    90	                        BookFormat.azw3 ->
+    91	                            // #126 — foliate-js WebView reader (AZW3/MOBI/KF8).
+    92	                            startActivity(Azw3ReaderActivity.intent(this@MainActivity, key))
+    93	                    }
+    94	                }
+    95	
+    96	                LibraryScreen(
+    97	                    state = state,
+    98	                    collections = collections,
+    99	                    selectedCollectionId = selectedCollectionId,
+   100	                    onSelectCollection = viewModel::selectCollection,
+   101	                    onAssignBook = { book -> sheetRoute = SheetRoute.Assign(book.id) },
+   102	                    onManageCollections = { sheetRoute = SheetRoute.Manage },
+   103	                    onOpenSearch = { searchOpen = true },
+   104	                    onOpenBook = { book -> openBook(book.originalFormat, book.id) },
+   105	                    // EPUBs are exposed by SAF providers under varied MIME types
+   106	                    // (epub+zip, octet-stream, generic); accept broadly and let
+   107	                    // BookImporter reject non-EPUBs by extension with a clear toast.
+   108	                    onImport = {
+   109	                        picker.launch(
+   110	                            arrayOf("application/epub+zip", "application/octet-stream", "*/*"),
+   111	                        )
+   112	                    },
+   113	                )
+   114	
+   115	                // feature #128 WI-7 — the search takeover. Rendered OVER the library when open; fed by
+   116	                // the AppContainer's SearchViewModel (WI-6). Obtained through `viewModel(factory=…)` so it's
+   117	                // owned by the Activity's ViewModelStore — its viewModelScope is properly cleared on the
+   118	                // Activity's destroy (a raw `remember { … }` would leak the coroutine collector forever).
+   119	                if (searchOpen) {
+   120	                    val searchViewModel: com.vreader.app.search.SearchViewModel = viewModel(
+   121	                        key = "search",
+   122	                        factory = viewModelFactory { initializer { container.searchViewModel() } },
+   123	                    )
+   124	                    val searchState by searchViewModel.state.collectAsStateWithLifecycle()
+   125	                    SearchScreen(
+   126	                        state = searchState,
+   127	                        onQueryChange = searchViewModel::onQueryChange,
+   128	                        onCancel = { searchOpen = false },
+   129	                        onRecentTap = searchViewModel::onQueryChange,
+   130	                        onPickCollection = { id ->
+   131	                            // Filter the library to the chosen collection and close the takeover.
+   132	                            viewModel.selectCollection(id)
+   133	                            searchOpen = false
+   134	                        },
+   135	                        onOpenResult = { row ->
+   136	                            // Record the query as recent (WI-6) AND open the book, then dismiss.
+   137	                            searchViewModel.recordCurrentQuery()
+   138	                            openBook(row.book.originalFormat, row.book.fingerprintKey)
+   139	                            searchOpen = false
+   140	                        },
+   141	                    )
+   142	                }
+   143	
+   144	                // feature #127 WI-4 — the assign-to-collections sheet (long-press a book).
+   145	                val route = sheetRoute
+   146	                if (route is SheetRoute.Assign) {
+   147	                    // resolve from the UNFILTERED library so unassigning from a filtered collection
+   148	                    // doesn't drop the book + close the sheet (Gate-4 WI-4 High).
+   149	                    val allBooks by viewModel.allBooks.collectAsStateWithLifecycle()
+   150	                    val book = allBooks.firstOrNull { it.id == route.bookKey }
+
+exec
+/bin/zsh -lc "rg -n \"bilingualEnabled|bilingualTargetLanguage|bilingualGranularity|bilingualStyle\" contracts android vreader --glob '*.kt' --glob '*.swift' --glob '*.json' --glob '*.md' | head -120; rg -n \"MoreActionId\\.BILINGUAL|BILINGUAL|data class Toggle|class Toggle|sealed.*MoreRow\" android/app/src/main/kotlin/com/vreader/app/reader --glob '*.kt' | head -100" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+android/identity/src/main/kotlin/vreader/contracts/backup/BackupSectionsExtended.kt:69:    val bilingualEnabled: Boolean? = null,
+android/identity/src/main/kotlin/vreader/contracts/backup/BackupSectionsExtended.kt:70:    val bilingualTargetLanguage: String? = null,
+android/identity/src/main/kotlin/vreader/contracts/backup/BackupSectionsExtended.kt:71:    val bilingualGranularity: String? = null,
+contracts/vectors/backup-sections.json:116:            "bilingualEnabled": true,
+contracts/vectors/backup-sections.json:117:            "bilingualTargetLanguage": "Chinese"
+android/identity/src/test/kotlin/vreader/contracts/backup/BackupSectionsExtendedTest.kt:86:            override = PerBookSettingsOverride(fontSize = 18.0, bilingualEnabled = true, bilingualTargetLanguage = "Chinese"),
+android/identity/src/test/kotlin/vreader/contracts/backup/BackupSectionsExtendedTest.kt:91:        assertTrue(json.contains("\"bilingualEnabled\""))
+vreader/ViewModels/BilingualReadingViewModel.swift:154:        self.isEnabled = override?.bilingualEnabled ?? false
+vreader/ViewModels/BilingualReadingViewModel.swift:155:        self.targetLanguage = override?.bilingualTargetLanguage ?? Self.defaultTargetLanguage
+vreader/ViewModels/BilingualReadingViewModel.swift:157:            rawValue: override?.bilingualGranularity ?? "") ?? .paragraph
+vreader/ViewModels/BilingualReadingViewModel.swift:256:        return override?.bilingualEnabled != nil
+vreader/ViewModels/BilingualReadingViewModel.swift:257:            || override?.bilingualTargetLanguage != nil
+vreader/ViewModels/BilingualReadingViewModel.swift:258:            || override?.bilingualGranularity != nil
+vreader/ViewModels/BilingualReadingViewModel.swift:266:        override.bilingualEnabled = isEnabled
+vreader/ViewModels/BilingualReadingViewModel.swift:267:        override.bilingualTargetLanguage = targetLanguage
+vreader/ViewModels/BilingualReadingViewModel.swift:268:        override.bilingualGranularity = granularity.rawValue
+vreader/ViewModels/AIAssistantViewModel.swift:77:    /// seeds the per-book `bilingualTargetLanguage` once on first appear
+vreader/Services/PerBookSettings.swift:33:    var bilingualEnabled: Bool?
+vreader/Services/PerBookSettings.swift:37:    var bilingualTargetLanguage: String?
+vreader/Services/PerBookSettings.swift:41:    var bilingualGranularity: String?
+vreader/Services/PerBookSettings.swift:53:        bilingualEnabled: Bool? = nil,
+vreader/Services/PerBookSettings.swift:54:        bilingualTargetLanguage: String? = nil,
+vreader/Services/PerBookSettings.swift:55:        bilingualGranularity: String? = nil
+vreader/Services/PerBookSettings.swift:62:        self.bilingualEnabled = bilingualEnabled
+vreader/Services/PerBookSettings.swift:63:        self.bilingualTargetLanguage = bilingualTargetLanguage
+vreader/Services/PerBookSettings.swift:64:        self.bilingualGranularity = bilingualGranularity
+vreader/Services/AI/ChapterTranslationService.swift:72:/// `bilingualGranularity`).
+vreader/Views/Reader/ReaderAICoordinator.swift:274:           let langKey = override.bilingualTargetLanguage {
+vreader/Views/Reader/ReaderContainerView+Sheets.swift:405:            rawValue: bilingualGranularity ?? "") ?? .paragraph
+vreader/Views/Reader/Bilingual/BilingualSetupSheet.swift:207:                    .accessibilityIdentifier("bilingualGranularity_\(option.rawValue)")
+vreader/Views/Reader/Bilingual/BilingualSetupSheet.swift:229:                .accessibilityIdentifier("bilingualGranularityUnavailableFootnote")
+vreader/Views/Reader/Bilingual/ReadiumBilingualEvalAdapter.swift:165:        EPUBBilingualJS.bilingualStyleJS(css: css)
+vreader/Views/Reader/Bilingual/BilingualLanguage.swift:3:// (`bilingualTargetLanguage`) all key off. Pinned to the design
+vreader/Views/Reader/Bilingual/BilingualLanguage.swift:28://   PerBookSettings.swift (`bilingualTargetLanguage`),
+vreader/Views/Reader/Bilingual/BilingualLanguage.swift:36:    /// Canonical key persisted in `PerBookSettings.bilingualTargetLanguage`
+vreader/Views/Reader/ReadiumEPUBHost+BilingualDriver.swift:248:        await bilingualCommander.setStyle(bilingualStyleCSS())
+vreader/Views/Reader/ReadiumEPUBHost+BilingualLoading.swift:62:                await bilingualCommander.setStyle(bilingualStyleCSS())
+vreader/Views/Reader/ReadiumEPUBHost+BilingualLoading.swift:78:    func bilingualStyleCSS() -> String {
+vreader/Views/Reader/Bilingual/EPUBBilingualJS.swift:393:    static func bilingualStyleJS(css: String) -> String {
+vreader/Views/Reader/ReaderTopChrome.swift:48:    /// `PerBookSettings.bilingualTargetLanguage`. `nil` (book never
+vreader/Views/Reader/ReadiumEPUBHost+Bilingual.swift:330:                    await bilingualCommander.setStyle(bilingualStyleCSS())
+vreader/Views/Reader/ReaderContainerView.swift:223:    @State var bilingualGranularity: String?
+vreader/Views/Reader/ReaderContainerView.swift:540:                bilingualGranularity = granularity
+android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:4:// DETAILS + SHARE (Action rows); TTS/AUTO_TURN/BILINGUAL ids exist so their owning features (#121/#131/
+android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:24:    BILINGUAL,
+android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:41:sealed interface MoreRow {
+android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:56:    data class Toggle(
+
+exec
+/bin/zsh -lc "nl -ba android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt | sed -n '15,70p' && rg -n \"BilingualPill|bilingual\" android/app/src/main/kotlin/com/vreader/app/reader --glob '*.kt' | head -100 && rg -n \"class BilingualParagraphRanges|enum BilingualParagraphRanges|struct BilingualParagraphRanges|scan\\(sourceText\" vreader --glob '*.swift'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+    15	 * #134 supplies none of them and omits any id it is not given a row for. There is deliberately NO
+    16	 * `EXPORT` id: Android has no annotation-export subsystem, so the Export row is never rendered (the
+    17	 * plan's scoped-out invariant), and absence-by-omission is enforced by there being no id to supply.
+    18	 */
+    19	enum class MoreActionId {
+    20	    DETAILS,
+    21	    SHARE,
+    22	    TTS,
+    23	    AUTO_TURN,
+    24	    BILINGUAL,
+    25	}
+    26	
+    27	/** The lowercase stable slug for this id — the testTag / route suffix (e.g. `AUTO_TURN` → `auto_turn`). */
+    28	val MoreActionId.slug: String
+    29	    get() = name.lowercase()
+    30	
+    31	/**
+    32	 * A single More-menu row. Exactly one of three shapes, mirroring the design's three row treatments:
+    33	 *  - [Action]   — a tap row with a trailing chevron (`vreader-more.jsx` `onAction`).
+    34	 *  - [Toggle]   — a stateful row with a trailing switch reflecting [Toggle.on] (`onToggle`).
+    35	 *  - [Disabled] — the design's disabled state (e.g. Bilingual "Configure AI provider first"):
+    36	 *                 non-interactive, dimmed, shows its [Disabled.sub].
+    37	 *
+    38	 * Every row carries a stable [id] (its testTag key) and its own callback. The OWNER of a row's behavior
+    39	 * is the feature that supplies it — never [MorePopup] itself.
+    40	 */
+    41	sealed interface MoreRow {
+    42	    val id: MoreActionId
+    43	    val label: String
+    44	    val icon: ImageVector
+    45	
+    46	    /** A tap row: fires [onTap]; renders a trailing chevron accessory. */
+    47	    data class Action(
+    48	        override val id: MoreActionId,
+    49	        override val label: String,
+    50	        override val icon: ImageVector,
+    51	        val sub: String? = null,
+    52	        val onTap: () -> Unit,
+    53	    ) : MoreRow
+    54	
+    55	    /** A toggle row: the trailing switch reflects [on]; tapping the row calls [onToggle] with `!on`. */
+    56	    data class Toggle(
+    57	        override val id: MoreActionId,
+    58	        override val label: String,
+    59	        override val icon: ImageVector,
+    60	        val sub: String? = null,
+    61	        val on: Boolean,
+    62	        val onToggle: (Boolean) -> Unit,
+    63	    ) : MoreRow
+    64	
+    65	    /** A disabled row: non-interactive, dimmed, shows [sub] (the design's "Configure AI provider first"). */
+    66	    data class Disabled(
+    67	        override val id: MoreActionId,
+    68	        override val label: String,
+    69	        override val icon: ImageVector,
+    70	        val sub: String,
+vreader/Services/Reader/BilingualParagraphRanges.swift:39:enum BilingualParagraphRanges {
+vreader/Services/Reader/BilingualParagraphRanges.swift:49:    static func scan(sourceText: String) -> [Range<Int>] {
+vreader/Services/AI/ChapterSegmenter.swift:39:        return BilingualParagraphRanges.scan(sourceText: chapterText).map {
+vreader/Views/Reader/Bilingual/BilingualDisplayPipeline.swift:152:            return BilingualParagraphRanges.scan(sourceText: sourceText)
+
+codex
+Most round-2 factual corrections check out: Readium 3.3.0’s resolved class exposes the named public methods; `ReaderActivity` holds the concrete fragment; Room is exactly v8 with migrations through 7→8; the #118 seams and named iOS parity APIs exist; and #136 is a real planned hard dependency. I found a concrete last-chunk failure in the new TXT/MD mapping, plus integration/concurrency gaps that prevent clearing this round as written.
+exec
+/bin/zsh -lc "rg -n \"request\\.model|model = request|AiRequest\\(\" android/app/src/main/kotlin/com/vreader/app/ai/OpenAiCompatibleProvider.kt android/app/src/main/kotlin/com/vreader/app/ai/AnthropicProvider.kt | head -80 && nl -ba android/app/src/main/kotlin/com/vreader/app/ai/OpenAiCompatibleProvider.kt | sed -n '35,75p' && nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AnthropicProvider.kt | sed -n '35,80p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+android/app/src/main/kotlin/com/vreader/app/ai/OpenAiCompatibleProvider.kt:39:        put("model", request.model)
+android/app/src/main/kotlin/com/vreader/app/ai/AnthropicProvider.kt:37:        put("model", request.model)
+    35	        conn.setRequestProperty("Authorization", "Bearer $apiKey")  // never logged
+    36	    }
+    37	
+    38	    override fun requestBody(request: AiRequest, stream: Boolean): String = buildJsonObject {
+    39	        put("model", request.model)
+    40	        put("temperature", request.temperature)
+    41	        put("max_tokens", request.maxTokens)
+    42	        put("stream", stream)
+    43	        putJsonArray("messages") {
+    44	            request.system?.let { addJsonObject { put("role", "system"); put("content", it) } }
+    45	            request.messages.forEach { m ->
+    46	                addJsonObject { put("role", m.role.name); put("content", m.content) }
+    47	            }
+    48	        }
+    49	    }.toString()
+    50	
+    51	    override fun parseDelta(event: SseEvent): DeltaParse {
+    52	        val data = event.data
+    53	        if (data == "[DONE]") return DeltaParse(null, done = true)
+    54	        val text = runCatching {
+    55	            JSON.parseToJsonElement(data).jsonObject["choices"]?.jsonArray
+    56	                ?.firstOrNull()?.jsonObject?.get("delta")?.jsonObject?.get("content")?.jsonPrimitive?.content
+    57	        }.getOrNull()
+    58	        return DeltaParse(text, done = false)
+    59	    }
+    60	
+    61	    override fun parseOneShot(json: String): String =
+    62	        runCatching {
+    63	            JSON.parseToJsonElement(json).jsonObject["choices"]?.jsonArray
+    64	                ?.firstOrNull()?.jsonObject?.get("message")?.jsonObject?.get("content")?.jsonPrimitive?.content
+    65	        }.getOrNull() ?: throw AiError.Decode("no choices[0].message.content")
+    66	
+    67	    private companion object { val JSON = Json { ignoreUnknownKeys = true } }
+    68	}
+    35	
+    36	    override fun requestBody(request: AiRequest, stream: Boolean): String = buildJsonObject {
+    37	        put("model", request.model)
+    38	        put("max_tokens", request.maxTokens)
+    39	        put("temperature", request.temperature)
+    40	        put("stream", stream)
+    41	        request.system?.let { put("system", it) }  // top-level, not a message
+    42	        putJsonArray("messages") {
+    43	            request.messages.forEach { m ->
+    44	                // Anthropic accepts user/assistant only; a stray system message folds to user.
+    45	                val role = if (m.role == AiRole.assistant) "assistant" else "user"
+    46	                addJsonObject { put("role", role); put("content", m.content) }
+    47	            }
+    48	        }
+    49	    }.toString()
+    50	
+    51	    override fun parseDelta(event: SseEvent): DeltaParse {
+    52	        // Prefer the event-type line; fall back to the data's own `type` (some servers omit event:).
+    53	        val data = runCatching { JSON.parseToJsonElement(event.data).jsonObject }.getOrNull()
+    54	        val type = event.event ?: data?.get("type")?.jsonPrimitive?.content
+    55	        return when (type) {
+    56	            "message_stop" -> DeltaParse(null, done = true)
+    57	            "error" -> throw AiError.Stream(data?.get("error")?.jsonObject?.get("message")?.jsonPrimitive?.content ?: "provider error")
+    58	            "content_block_delta" -> {
+    59	                val text = data?.get("delta")?.jsonObject?.get("text")?.jsonPrimitive?.content
+    60	                DeltaParse(text, done = false)
+    61	            }
+    62	            else -> DeltaParse(null, done = false)  // message_start / ping / content_block_start/stop
+    63	        }
+    64	    }
+    65	
+    66	    override fun parseOneShot(json: String): String =
+    67	        runCatching {
+    68	            JSON.parseToJsonElement(json).jsonObject["content"]?.jsonArray
+    69	                ?.firstOrNull()?.jsonObject?.get("text")?.jsonPrimitive?.content
+    70	        }.getOrNull() ?: throw AiError.Decode("no content[0].text")
+    71	
+    72	    private companion object {
+    73	        const val ANTHROPIC_VERSION = "2023-06-01"
+    74	        val JSON = Json { ignoreUnknownKeys = true }
+    75	    }
+    76	}
+
+exec
+/bin/zsh -lc "rg -n \"AiRequest\\(\" android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt -A12 -B3 && rg -n \"model.*ifBlank|defaultModel|model =\" android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt | head -80" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+58-        streamJob = viewModelScope.launch {
+59-            val (profile, key) = activeClient() ?: run { _state.update { it.copy(streaming = false, unconfigured = true) }; return@launch }
+60-            val history = _state.value.messages.map { AiMessage(if (it.fromUser) AiRole.user else AiRole.assistant, it.text) }
+61:            val request = AiRequest(profile.model.ifBlank { profile.kind.defaultModel }, history, profile.temperature, profile.maxTokens, system = CHAT_SYSTEM)
+62-            val sb = StringBuilder()
+63-            try {
+64-                factory(profile, key).streamChat(request).collect { chunk ->
+65-                    if (gen != chatGen) return@collect  // superseded by a provider swap / newer send
+66-                    sb.append(chunk.deltaText)
+67-                    _state.update { it.copy(streamingText = sb.toString()) }
+68-                }
+69-                if (gen == chatGen) _state.update { it.copy(messages = it.messages + ChatMessage(false, sb.toString()), streaming = false, streamingText = "") }
+70-            } catch (e: AiError) {
+71-                if (gen == chatGen) _state.update { it.copy(streaming = false, streamingText = "", error = e.message) }
+72-            }
+73-        }
+--
+100-            }
+101-            _state.update { it.copy(streaming = true, summary = null) }
+102-            try {
+103:                val req = AiRequest(
+104-                    profile.model.ifBlank { profile.kind.defaultModel },
+105-                    listOf(AiMessage(AiRole.user, "Summarize this chapter in 4 concise key points (markdown bullet list):\n\n$chapterText")),
+106-                    profile.temperature, profile.maxTokens, system = CHAT_SYSTEM,
+107-                )
+108-                val resp = factory(profile, key).chat(req)
+109-                summaryCache[cacheKey] = resp.text
+110-                _state.update { it.copy(summary = resp.text, summaryCached = false, streaming = false) }
+111-            } catch (e: AiError) {
+112-                _state.update { it.copy(streaming = false, error = e.message) }
+113-            }
+114-        }
+115-    }
+30:                    AiProviderRow(p.id, p.name, active = p.id == snap.activeId, statusOk = true, detail = p.model.ifBlank { p.kind.defaultModel })
+50:            editMode = true, id = p.id, kind = p.kind, name = p.name, baseUrl = p.baseUrl, model = p.model,
+70:                    model = s.effectiveModel, temperature = s.temperature, maxTokens = s.maxTokens, encryptedApiKey = "",
+91:                name = s.name, kind = s.kind, baseUrl = s.baseUrl, model = s.model,
+
+codex
+Critical
+
+None.
+
+High
+
+1. TXT/MD final-chunk translations can be dropped. The plan defines each chunk span as `[offsetForChunk(i), offsetForChunk(i+1))` and anchors a spanning segment in the chunk where its range ends ([plan:40](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:40)). But `offsetForChunk()` clamps out-of-range indices to the last valid chunk ([TxtDocument.kt:17](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:17)), whereas `textForChunk()` correctly uses `text.length` for the final end ([TxtDocument.kt:35](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:35)). Consequently, for the last chunk, `offsetForChunk(i+1) == offsetForChunk(i)`, producing an empty span. A one-chunk document drops every translation; a long paragraph ending in the final chunk also drops its sole translation. H1 is therefore not sound as written. Specify `endExclusive = if (i + 1 < chunkCount) offsetForChunk(i + 1) else text.length`, use explicit half-open ranges rather than ambiguous Kotlin `IntRange`, and test one-chunk, final-chunk, exact-boundary, and EOF anchors.
+
+2. The enabled TXT/MD render contract does not preserve the live host’s layout/selection/highlight invariants. The plan requires a source `Text` followed by translation `Text` per segment ([plan:92](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:92)), while retaining the chunk-based loop for selection/highlight parity ([plan:40](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:40)). Live code owns exactly one `TextLayoutResult` and one selection registration per chunk ([TxtReaderActivity.kt:1043](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1043), [TxtReaderActivity.kt:1058](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1058), [TxtReaderActivity.kt:1061](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1061)). Sentence granularity commonly puts several segments inside one line/chunk. Splitting that source into several `Text` nodes breaks the one-layout-per-chunk coordinate model; keeping one source `Text` cannot interleave each sentence translation at its segment boundary. The plan needs an explicit offset-preserving render/layout design and enabled-mode tests for selection, highlights, read-aloud wash, annotations, and Markdown mapping.
+
+Medium
+
+1. H2’s service APIs are present in the plan, but the EPUB direct-block control flow is not connected end-to-end. `BilingualViewModel` exposes position-driven state ([plan:75](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:75)); WI-6 only defines `onPositionChanged(charOffsetUTF16)` and ordinary current/next prefetch ([plan:183](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:183)). WI-7b says the controller enumerates DOM blocks and uses `prefetchDirect`/`cachedDirect` ([plan:187](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:187)), but no API says how those results enter `translationsByUnit`, how they are session-guarded, or how regular and direct prefetch are prevented from racing for the same canonical cache row. Define one owner and a concrete `enumeratedBlocks → cachedDirect/translatePreSegmented → guarded render-state commit` API.
+
+2. Cancellation handling is incomplete across the service/VM boundary. The service maps cancellation to `ChapterTranslationError.Cancelled` ([plan:58](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:58)), while WI-6 explicitly special-cases only `CancellationException` before generic error mapping ([plan:183](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:183)). The iOS parity implementation deliberately handles both native cancellation and typed `ChapterTranslationError.cancelled` ([ChapterTranslationService.swift:359](/Users/ll/workspace/vreader/vreader/Services/AI/ChapterTranslationService.swift:359)). Without the same rule, a cancelled stale request can surface as `errorUnit`. Also require a per-unit single-flight job registry so rapid retry/navigation cannot run overlapping translations or writes.
+
+3. The proposed `AiRequest` construction misses the live blank-model fallback. The plan uses `model = profile.model` ([plan:85](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:85)), but both wire clients serialize `request.model` directly ([OpenAiCompatibleProvider.kt:38](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/OpenAiCompatibleProvider.kt:38), [AnthropicProvider.kt:36](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AnthropicProvider.kt:36)). Existing chat code correctly uses `profile.model.ifBlank { profile.kind.defaultModel }` ([AiChatViewModel.kt:61](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt:61)). Match that precedent and add a blank-model regression test.
+
+4. #136 blocks more of the behavioral chain than the plan states. It says only WI-4b and WI-9 wait on #136 ([plan:167](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:167)), but WI-6 depends on WI-4b ([plan:183](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:183)), and both host integrations depend on WI-4b ([plan:187](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:187), [plan:189](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:189)). Thus #136 gates WI-6, WI-7b, and WI-8 transitively. Either state that honestly or move provider/container binding behind a later adapter so VM and host work can proceed with injected seams.
+
+Low
+
+1. The split contains twelve WIs, not eleven: WI-0, WI-1, WI-2, WI-3, WI-4a, WI-4b, WI-5, WI-6, WI-7a, WI-7b, WI-8, and WI-9 ([plan:163](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:163)). The tracker repeats the incorrect count ([features.md:184](/Users/ll/workspace/vreader/docs/features.md:184)).
+
+2. The statement that a live TXT chunk can hold multiple paragraphs is inaccurate ([plan:34](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:34)): `TxtDocument` starts a new chunk after every LF, CR, or CRLF ([TxtDocument.kt:65](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:65)). A chunk can contain multiple sentences, and a paragraph can span many chunks; tests and prose should use those real cases.
+
+Verified resolutions
+
+- `TxtDocument` exposes only the stated text/chunk API and has no chapter/section model ([TxtDocument.kt:9](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:9)).
+- The resolved Readium dependency is 3.3.0 ([build.gradle.kts:111](/Users/ll/workspace/vreader/android/app/build.gradle.kts:111)); binary inspection confirmed public `evaluateJavascript`, `getCurrentLocator`, `firstVisibleElementLocator`, and `submitPreferences`. `ReaderActivity.navigator` is `EpubNavigatorFragment?` ([ReaderActivity.kt:110](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:110)).
+- Room is v8 with migrations 1→2 through 7→8 registered ([VReaderDatabase.kt:21](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:21), [VReaderDatabase.kt:223](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:223)); 8→9 is correct. `BookEntity` uses `@PrimaryKey` and `BookDao` uses `@Upsert` ([Entities.kt:22](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:22), [Daos.kt:16](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:16)).
+- All named #118 seams and `AiError` cases exist ([AiProviderStore.kt:34](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:34), [AiProviderFactory.kt:10](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderFactory.kt:10), [AiClient.kt:25](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiClient.kt:25), [AiTypes.kt:12](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt:12)).
+- The named iOS parity symbols exist, including the pre-segmented/direct-cache recovery surface, sentence ranges, strict chunk contract, and grapheme-safe sub-split ([ChapterTranslationService.swift:327](/Users/ll/workspace/vreader/vreader/Services/AI/ChapterTranslationService.swift:327), [ChapterTranslationPrefetcher.swift:197](/Users/ll/workspace/vreader/vreader/Services/AI/ChapterTranslationPrefetcher.swift:197), [ChapterSegmenter.swift:78](/Users/ll/workspace/vreader/vreader/Services/AI/ChapterSegmenter.swift:78), [TranslationChunkContract.swift:24](/Users/ll/workspace/vreader/vreader/Services/AI/TranslationChunkContract.swift:24), [ChapterTranslationChunker.swift:85](/Users/ll/workspace/vreader/vreader/Services/AI/ChapterTranslationChunker.swift:85)).
+- M1, M2, M3, M4, #136 reachability spinout, and Style descope are otherwise materially reflected in v3.
+
+FINAL VERDICT: block-recommended
+tokens used
+114,538
+Critical
+
+None.
+
+High
+
+1. TXT/MD final-chunk translations can be dropped. The plan defines each chunk span as `[offsetForChunk(i), offsetForChunk(i+1))` and anchors a spanning segment in the chunk where its range ends ([plan:40](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:40)). But `offsetForChunk()` clamps out-of-range indices to the last valid chunk ([TxtDocument.kt:17](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:17)), whereas `textForChunk()` correctly uses `text.length` for the final end ([TxtDocument.kt:35](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:35)). Consequently, for the last chunk, `offsetForChunk(i+1) == offsetForChunk(i)`, producing an empty span. A one-chunk document drops every translation; a long paragraph ending in the final chunk also drops its sole translation. H1 is therefore not sound as written. Specify `endExclusive = if (i + 1 < chunkCount) offsetForChunk(i + 1) else text.length`, use explicit half-open ranges rather than ambiguous Kotlin `IntRange`, and test one-chunk, final-chunk, exact-boundary, and EOF anchors.
+
+2. The enabled TXT/MD render contract does not preserve the live host’s layout/selection/highlight invariants. The plan requires a source `Text` followed by translation `Text` per segment ([plan:92](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:92)), while retaining the chunk-based loop for selection/highlight parity ([plan:40](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:40)). Live code owns exactly one `TextLayoutResult` and one selection registration per chunk ([TxtReaderActivity.kt:1043](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1043), [TxtReaderActivity.kt:1058](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1058), [TxtReaderActivity.kt:1061](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1061)). Sentence granularity commonly puts several segments inside one line/chunk. Splitting that source into several `Text` nodes breaks the one-layout-per-chunk coordinate model; keeping one source `Text` cannot interleave each sentence translation at its segment boundary. The plan needs an explicit offset-preserving render/layout design and enabled-mode tests for selection, highlights, read-aloud wash, annotations, and Markdown mapping.
+
+Medium
+
+1. H2’s service APIs are present in the plan, but the EPUB direct-block control flow is not connected end-to-end. `BilingualViewModel` exposes position-driven state ([plan:75](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:75)); WI-6 only defines `onPositionChanged(charOffsetUTF16)` and ordinary current/next prefetch ([plan:183](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:183)). WI-7b says the controller enumerates DOM blocks and uses `prefetchDirect`/`cachedDirect` ([plan:187](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:187)), but no API says how those results enter `translationsByUnit`, how they are session-guarded, or how regular and direct prefetch are prevented from racing for the same canonical cache row. Define one owner and a concrete `enumeratedBlocks → cachedDirect/translatePreSegmented → guarded render-state commit` API.
+
+2. Cancellation handling is incomplete across the service/VM boundary. The service maps cancellation to `ChapterTranslationError.Cancelled` ([plan:58](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:58)), while WI-6 explicitly special-cases only `CancellationException` before generic error mapping ([plan:183](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:183)). The iOS parity implementation deliberately handles both native cancellation and typed `ChapterTranslationError.cancelled` ([ChapterTranslationService.swift:359](/Users/ll/workspace/vreader/vreader/Services/AI/ChapterTranslationService.swift:359)). Without the same rule, a cancelled stale request can surface as `errorUnit`. Also require a per-unit single-flight job registry so rapid retry/navigation cannot run overlapping translations or writes.
+
+3. The proposed `AiRequest` construction misses the live blank-model fallback. The plan uses `model = profile.model` ([plan:85](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:85)), but both wire clients serialize `request.model` directly ([OpenAiCompatibleProvider.kt:38](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/OpenAiCompatibleProvider.kt:38), [AnthropicProvider.kt:36](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AnthropicProvider.kt:36)). Existing chat code correctly uses `profile.model.ifBlank { profile.kind.defaultModel }` ([AiChatViewModel.kt:61](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt:61)). Match that precedent and add a blank-model regression test.
+
+4. #136 blocks more of the behavioral chain than the plan states. It says only WI-4b and WI-9 wait on #136 ([plan:167](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:167)), but WI-6 depends on WI-4b ([plan:183](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:183)), and both host integrations depend on WI-4b ([plan:187](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:187), [plan:189](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:189)). Thus #136 gates WI-6, WI-7b, and WI-8 transitively. Either state that honestly or move provider/container binding behind a later adapter so VM and host work can proceed with injected seams.
+
+Low
+
+1. The split contains twelve WIs, not eleven: WI-0, WI-1, WI-2, WI-3, WI-4a, WI-4b, WI-5, WI-6, WI-7a, WI-7b, WI-8, and WI-9 ([plan:163](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:163)). The tracker repeats the incorrect count ([features.md:184](/Users/ll/workspace/vreader/docs/features.md:184)).
+
+2. The statement that a live TXT chunk can hold multiple paragraphs is inaccurate ([plan:34](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:34)): `TxtDocument` starts a new chunk after every LF, CR, or CRLF ([TxtDocument.kt:65](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:65)). A chunk can contain multiple sentences, and a paragraph can span many chunks; tests and prose should use those real cases.
+
+Verified resolutions
+
+- `TxtDocument` exposes only the stated text/chunk API and has no chapter/section model ([TxtDocument.kt:9](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:9)).
+- The resolved Readium dependency is 3.3.0 ([build.gradle.kts:111](/Users/ll/workspace/vreader/android/app/build.gradle.kts:111)); binary inspection confirmed public `evaluateJavascript`, `getCurrentLocator`, `firstVisibleElementLocator`, and `submitPreferences`. `ReaderActivity.navigator` is `EpubNavigatorFragment?` ([ReaderActivity.kt:110](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:110)).
+- Room is v8 with migrations 1→2 through 7→8 registered ([VReaderDatabase.kt:21](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:21), [VReaderDatabase.kt:223](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:223)); 8→9 is correct. `BookEntity` uses `@PrimaryKey` and `BookDao` uses `@Upsert` ([Entities.kt:22](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:22), [Daos.kt:16](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:16)).
+- All named #118 seams and `AiError` cases exist ([AiProviderStore.kt:34](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:34), [AiProviderFactory.kt:10](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderFactory.kt:10), [AiClient.kt:25](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiClient.kt:25), [AiTypes.kt:12](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiTypes.kt:12)).
+- The named iOS parity symbols exist, including the pre-segmented/direct-cache recovery surface, sentence ranges, strict chunk contract, and grapheme-safe sub-split ([ChapterTranslationService.swift:327](/Users/ll/workspace/vreader/vreader/Services/AI/ChapterTranslationService.swift:327), [ChapterTranslationPrefetcher.swift:197](/Users/ll/workspace/vreader/vreader/Services/AI/ChapterTranslationPrefetcher.swift:197), [ChapterSegmenter.swift:78](/Users/ll/workspace/vreader/vreader/Services/AI/ChapterSegmenter.swift:78), [TranslationChunkContract.swift:24](/Users/ll/workspace/vreader/vreader/Services/AI/TranslationChunkContract.swift:24), [ChapterTranslationChunker.swift:85](/Users/ll/workspace/vreader/vreader/Services/AI/ChapterTranslationChunker.swift:85)).
+- M1, M2, M3, M4, #136 reachability spinout, and Style descope are otherwise materially reflected in v3.
+
+FINAL VERDICT: block-recommended

--- a/.claude/codex-audits/feat-131-bilingual-gate2-round4.md
+++ b/.claude/codex-audits/feat-131-bilingual-gate2-round4.md
@@ -1,0 +1,4037 @@
+Reading additional input from stdin...
+OpenAI Codex v0.144.1
+--------
+workdir: /Users/ll/workspace/vreader
+model: gpt-5.6-sol
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: high
+reasoning summaries: none
+session id: 019f545d-5aa1-7c30-8822-76137dc0b24c
+--------
+user
+Gate-2 plan audit ROUND 4 (DECISIVE) for feature #131 (Android bilingual interlinear reading). Read the v4 plan at dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md and verify its resolutions against the LIVE code. This is round 4; the remaining findings were concrete correctness/wiring (not architecture) plus a scope change (folding in the AI-config path). Be DECISIVE: state whether each round-3 finding is now correctly resolved and whether any NEW blocker exists.
+
+The round-3 findings v4 claims to resolve — verify each against live code:
+1. H1 (final-chunk drop): v4 specifies 'endExclusive = if (i+1 < document.chunkCount) offsetForChunk(i+1) else document.text.length' with explicit half-open [start,endExclusive) pairs (NOT Kotlin IntRange). Confirm TxtDocument.offsetForChunk clamps out-of-range to the last chunk (reader/TxtDocument.kt ~17) so this fix is necessary + correct; confirm chunkForOffset(segEndExclusive-1) anchoring is off-by-one-safe. Is a one-chunk doc / final-chunk / exact-boundary / EOF anchor now correct?
+2. H2 (render breaks per-chunk layout/selection): v4's binding contract is that translations are ADDITIVE LazyColumn items at chunk (line) boundaries and the source chunk Text is NEVER split (source loop byte-identical; a translation item is non-selectable + registers no chunk). Verify against reader/TxtReaderActivity.kt (~1043 items loop, ~1059 onTextLayout, ~1062-1066 registerChunk/unregisterChunk): does this ACTUALLY preserve one-TextLayoutResult + one-selection-registration per source chunk? Is the sentence-granularity rule-51 design-gate call correct (verify vreader-bilingual.jsx BilingualPageContent depicts ONLY paragraph interlinear, and sentence granularity appears only as a setup-sheet control)? Is 'Sentence selection falls back to paragraph render, cache still granularity-keyed' a sound v1 stance?
+3. M1 (EPUB direct-block flow): v4 makes EpubBilingualController the SINGLE OWNER of EPUB units (enumeratedBlocks -> cachedDirect else prefetchDirect -> session-token-guarded commit), VM position-driven prefetch is TXT/MD-only. Is this race-free + coherent (no two writers for the same canonical cache row)?
+4. M2 (cancellation): dual native CancellationException + typed ChapterTranslationError.Cancelled before generic mapping + a per-unit single-flight prefetchTasks: Map<TranslationUnitId, Job> (cancel-or-join prior). Confirm the iOS parity (vreader/Services/AI/ChapterTranslationService.swift ~359 dual-catch; BilingualReadingViewModel.swift prefetchTasks registry). Sound?
+5. M3 (blank model): AiRequest.model = profile.model.ifBlank { profile.kind.defaultModel }. Confirm AiChatViewModel.kt ~61 precedent + that OpenAiCompatibleProvider/AnthropicProvider serialize request.model directly.
+6. FOLD-IN (the closed #136): v4 adds WI-AIP (ReaderAiProvidersSheet) reusing the #118 AiProviderListScreen/AiProviderEditSheet/AiSettingsViewModel VERBATIM, pushed inside the bilingual flow, pop-back-on-first-Save, per reader-ai-provider-entry.md Variant A; WI-4b now constructs AiProviderStore in AppContainer (verify VReaderApp.kt AppContainer does NOT construct it today — only a comment ~66). Is this rule-51 compliant (reproduces only what reader-ai-provider-entry.md + vreader-ai-provider-entry.jsx depict, invents no AI-config UI)? Is aiConfigured = active-profile-exists AND its key decrypts-non-empty (NOT profiles.isEmpty), with cipher-failure -> not-ready, correct against AiProviderStore.kt (~34 active, ~108 apiKey/decrypt)? Is 'first Save -> store.setActive(savedId) + pop to bilingual' sound against AiProviderStore.upsert (~81 activeId = cur.activeId ?: id)?
+7. Deps now [feat:#132, feat:#134] (no #136), WI count 13. Correct?
+8. Any NEW risk/edge-case v4's changes introduce (the additive-item interleaving, the single-owner EPUB controller, WI-4b constructing AiProviderStore, the setActive-on-first-save).
+
+Output findings grouped by severity (Critical / High / Medium / Low), each with file:line evidence, then a FINAL VERDICT line exactly one of: ship-as-is | follow-up-recommended | block-recommended. ship-as-is or follow-up-recommended clears Gate-2 round 4.
+codex
+I’ll audit the v4 plan against the exact live implementations and committed design artifacts, then trace every round-3 item to a decisive resolved/unresolved judgment. I’ll begin with repository state and the governing architecture/parallel rules, then inspect the cited code paths.
+exec
+/bin/zsh -lc "git status -sb && sed -n '1,240p' docs/architecture.md && sed -n '1,260p' .claude/rules/48-parallel-execution.md" in /Users/ll/workspace/vreader
+ succeeded in 1065ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-cqKtg3GG' (errno=Operation not permitted)
+## main...origin/main
+ M dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md
+ M docs/features.md
+?? .claude/codex-audits/feat-131-bilingual-gate2-round2.md
+?? .claude/codex-audits/feat-131-bilingual-gate2-round3.md
+?? .claude/codex-audits/feat-131-bilingual-gate2-round4.md
+?? .claude/codex-audits/feat-136-ai-provider-reachable-gate2.md
+?? android/2026-06-29-223908-this-session-is-being-continued-from-a-previous-c.txt
+?? dev-docs/security/
+# VReader Architecture
+
+## Overview
+
+VReader is an iOS e-book reader built with SwiftUI + SwiftData. It supports TXT, EPUB, AZW3/MOBI, PDF, and Markdown formats, each rendered by a format-specific native host (UIKit/WebView bridges) selected internally by `ReaderEngine` (feature #54). AZW3/MOBI is rendered via Foliate-js inside a WKWebView. **Feature #42 Phase 2 (`kindleConvertOnImport`, default ON since the G2 flip 2026-06-02):** NEW AZW3/MOBI/KF8/PRC imports are converted to a first-class EPUB at import time (via the vendored libmobi MOBI→EPUB converter) and render via the default Readium EPUB engine; already-imported native `.azw3` books are unchanged and keep rendering via Foliate, and a user can revert via the persisted `kindleConvertOnImport` override OFF. The `UnifiedTextRenderer` (TextKit 2 reflow) stack is retained in the codebase but no longer wired into the reader dispatch.
+
+## System Diagram
+
+```
+┌──────────────────────────────────────────────────────┐
+│                    VReaderApp                         │
+│  SwiftData SchemaV10 · PersistenceActor · BookImporter│
+└─────────────────────┬────────────────────────────────┘
+                      │
+          ┌───────────┴───────────┐
+          │                       │
+    ┌─────▼──────────┐    ┌──────▼──────────────────┐
+    │  LibraryView    │    │  ReaderContainerView     │
+    │  LibraryViewModel│   │  (format dispatcher)     │
+    │  PreferenceStore │   │  ReaderTopChrome (overlay)│
+    └─────────────────┘   └──────┬───────────────────┘
+                                 │
+        ┌────────┬───────────┬───┴────┬─────────┐
+        │        │           │        │         │
+    ┌───▼──┐ ┌──▼───┐  ┌───▼──┐ ┌──▼───┐ ┌────▼─────┐
+    │ TXT  │ │ EPUB │  │ PDF  │ │  MD  │ │  AZW3 /  │
+    │Bridge│ │Bridge│  │Bridge│ │Bridge│ │  MOBI    │
+    └──────┘ └──────┘  └──────┘ └──────┘ └──────────┘
+    UITextView WKWebView PDFKit  UITextView WKWebView
+                                            (Foliate-js)
+```
+
+## Layers
+
+### 1. App Layer (`vreader/App/`)
+
+- `VReaderApp.swift` — SwiftData `ModelContainer` init (SchemaV10), migration plan (V1→…→V9→V10, all lightweight; V9→V10 adds the additive `Book.sourceCanonicalKey: String?` for feature #108's converted-Kindle cross-platform identity). Also runs the feature #109 one-shot `LocatorKeyBackfillMigration` synchronously at launch (flag-gated; recomputes derived locator keys under NFC canonicalization + repairs non-finite locators — a launch backfill, NOT a migration stage, since the transform changes no entity shape). Plus test seeding, error handling. Injects the live `PersistenceActor` into the SwiftUI environment via `\.persistenceActor` so settings sub-screens can construct backup providers without rewriting every parent's signature. Adopts `@UIApplicationDelegateAdaptor(VReaderAppDelegate.self)` for background-URLSession completion-handler delivery (feature #47).
+- `VReaderAppDelegate.swift` — `UIApplicationDelegate` adapter that captures `application(_:handleEventsForBackgroundURLSession:completionHandler:)` into a MainActor-isolated static dictionary keyed by URLSession identifier. The lazy-download coordinator retrieves and invokes the handler from `LazyDownloadDelegate.urlSessionDidFinishEvents` so iOS releases the app's background-launch grace period.
+
+### 2. Library Layer (`vreader/Views/LibraryView.swift`, `vreader/ViewModels/LibraryViewModel.swift`)
+
+- Grid/list view with sort (persisted via `PreferenceStore`)
+- Context menu: Info, Share, Set Cover, Add to Collection, Delete
+- Collections sidebar, OPDS catalog, AI chat entry points
+- Cover art (`BookCoverArtView`) renders a custom image when one exists, otherwise a generative typographic cover (Feature #60 WI-10 — `GenerativeCoverView`). The cover's style family + colour palette are deterministically derived from the book's `fingerprintKey` (FNV-1a hash → one of 5 style families × 12 design palettes in `GenerativeCoverStyle.swift`), so a given book always shows the same generated cover.
+
+### 3. Reader Layer (`vreader/Views/Reader/`)
+
+#### Dispatcher
+
+`ReaderContainerView.swift` routes to format-specific readers via
+`engineReaderView(fingerprint:)`, which switches on
+`ReaderEngine.resolve(format: fingerprint.format)` — an internal per-format
+engine selector (feature #54). Bug #246 / GH #1072 hardened the dispatch
+to route off `fingerprint.format` (the typed `BookFormat` already parsed
+from the canonical `book.fingerprintKey` by the body's
+`DocumentFingerprint(canonicalKey:)` guard) instead of `book.format` (a
+parallel String `@Model` column set once at `Book.init` and never re-synced).
+Routing off the structural primary key makes the dispatch drift-proof against
+any future writer that updates one without the other (SwiftData migration,
+direct context write, restore-path edit, CloudKit sync). The dispatch no
+longer consults a reading-mode preference, and the reader-settings Reading
+Mode picker UI is gone. The `readerReadingMode` UserDefaults key and the
+`ReadingMode` enum have been removed; `ReadingModeMigration` (run
+synchronously at launch from `VReaderApp`) clears the retired key from
+UserDefaults and strips the `readingMode` field from per-book override
+JSON files.
+
+- `.textNative` → `TXTReaderHost`, `.markdownNative` → `MDReaderHost`,
+  `.epubWKWebView` → `EPUBReaderHost`, `.pdfKit` → `PDFReaderHost`,
+  `.foliateWeb` → `FoliateBilingualContainerView` (AZW3/MOBI; the
+  bilingual wrapper from feature #56 WI-11 sits between the dispatcher
+  and `FoliateSpikeView`, adding the bilingual VM / orchestrator / setup-
+  sheet wiring without modifying the spike itself).
+- `resolve(format:)` maps `.epub` to `.epubWKWebView` unconditionally (it
+  stays the pure format→default-engine map). Feature #42 routes EPUB to the
+  Readium Swift Toolkit engine (`ReadiumEPUBHost`) via
+  `FeatureFlags.readiumEPUBEngine`, which is **default ON since the WI-14
+  human-gated G2 flip (2026-06-01)** — Readium is now the default reflowable EPUB
+  engine; a persisted user/debug override OFF reverts to the legacy
+  `EPUBReaderHost`. The flag read lives in the dispatcher
+  (`ReaderContainerView.engineReaderView` → `ReaderEngine.routeEPUB`), not in
+  `resolve`, so a flag-unaware caller still gets the legacy `EPUBReaderHost`. The
+  `.epubReadium` engine case exists for switch totality; `resolve` never returns
+  it. **Feature #85 (approach C) makes the routing layout-aware**:
+  `routeEPUB(readiumFlagEnabled:layout:)` sends EPUB **scroll** mode to the
+  legacy `EPUBReaderHost` (which activates the seamless feature-#71
+  continuous-scroll stitch) even when the Readium flag is ON — Readium's
+  per-resource paginator has an inherent chapter-boundary seam in scroll mode —
+  while **paged** mode keeps Readium. Because the SAME book is then rendered by
+  two engines depending on mode, a reading-mode toggle SWAPS hosts; an in-memory
+  `ReaderPositionHandoff` (a `@MainActor` per-book cache both hosts write
+  synchronously on every location change + read on open before persistence)
+  carries the position across the swap without loss, and a Readium open with no
+  `.readium` envelope (a scroll session cleared it) restores the legacy locator
+  post-open via `publication.readingOrder` + a one-shot `navCommander.navigate`.
+  `EPUBScrollAnchorResolver` tolerates the container- vs OPF-relative href forms
+  the two engines persist.
+
+#### Chrome
+
+Reader chrome (Feature #60 WI-6b — visual-identity-v2) is two custom overlays, floating on top of content with no safe-area impact:
+
+- `ReaderTopChrome.swift` — top bar: `← Library | Title | Search Bookmark More`. Composed once in `ReaderContainerView`, format-agnostic. The `⋯` More button toggles `ReaderMorePopover`.
+- `ReaderBottomChrome.swift` — bottom bar: progress scrubber + position labels + a Contents/Notes/Display/AI toolbar. Composed per format inside each container, each passing its own seek closure; the toolbar posts `.readerOpen*` notifications that `ReaderContainerView` observes. The four native containers (TXT/MD/EPUB/PDF) mount it in their `bottomOverlay`; Bug #260 added the Foliate (AZW3/MOBI) mount via `FoliateBilingualContainerView+BottomChrome.swift` — scrubber fed by the relocate `fraction`, seek via `.foliateRequestSeekFraction` → `readerAPI.goToFraction`, position labels via pure `FoliateBottomChromeLabels`. (Each container owns its own `isChromeVisible`; chrome visibility is not yet hoisted to the shared level — see Bug #262 for the cross-format desync follow-up.)
+- `ReaderMorePopover.swift` — anchored More-menu popover (Feature #60 WI-6c), composed in `ReaderContainerView`'s chrome overlay. Five rows (Read aloud / Auto-turn | Book details / Share / Export); each posts a `.readerMore*` notification that `ReaderContainerView` observes. The design's sixth row (Bilingual) is deferred — GH #790.
+
+Slot/button identity lives in `ReaderChromeButton.swift` (`ReaderTopChromeSlot` / `ReaderBottomChromeButton`); More-menu row identity lives in `ReaderMoreMenuRow.swift`.
+
+#### Sheets (Feature #60 WI-10 — visual-identity-v2)
+
+The app sheets share `ReaderSheetChrome.swift` — a reusable wrapper matching the design's `Sheet` component: a theme-tinted surface (`ReaderThemeV2.sheetSurfaceColor`), an optional centred Source Serif 4 title bar with 50pt leading/trailing slots (a default circular close button fills the trailing slot when an `onClose` is given and no custom trailing view is), and a scrollable body. The slide-up animation + drag grabber come from SwiftUI's own `.sheet` + `.presentationDragIndicator(.visible)`; `ReaderSheetChrome` supplies only the title bar + surface tint. It wraps the Display sheet (`ReaderSettingsPanel`), the two annotations sheets (`TOCSheet` + `HighlightsSheet`, feature #62 — see below), the reader Book Details sheet (`BookDetailsSheet`, feature #61 — opened from More → Book details, with a trailing Share button in place of the default close), and the AI sheet (`AIReaderPanel`, `title: nil` + a custom sparkle header). `SettingsView` (App Settings) keeps an inner `NavigationStack` for its `NavigationLink` push destinations, with `ReaderSheetChrome` above it. The per-sheet section contract is pinned in `SheetSectionContract.swift` (`ReaderSheetKind`). Reader sheets pass the book's `ReaderThemeV2`; the App Settings sheet uses `.paper` (the Library is not theme-switchable).
+
+**Annotations sheets (feature #62 — annotations-panel split).** The pre-#62 unified 4-tab `AnnotationsPanelView` (Contents / Bookmarks / Highlights / Notes) is split into two job-focused sheets, each with one honest title: `TOCSheet` (book-titled — Contents + Bookmarks navigation tabs) and `HighlightsSheet` (titled "Annotations" — All / Highlights / Notes / Bookmarks review filters + a Share/export button). `ReaderContainerView` presents them via a single `.sheet(item: $annotationsRoute)` over the `AnnotationsSheetRoute` enum (`.toc(initialTab:)` / `.highlights(initialFilter:)`) — the Contents bottom-chrome button and the Notes button each map to one route; the two sheets are mutually exclusive by that optional. `HighlightsSheet`'s unified card stream interleaves highlight + standalone-note cards via `AnnotationStreamBuilder`. Both sheets' designed empty states use the shared `AnnotationsEmptyStateView` (custom SVG art). The legacy `HighlightListView` / `AnnotationListView` / `TOCListView` / `BookmarkListView` list views were removed by feature #62. Each card carries a per-row **delete affordance** (Bug #249 — a trailing `⋯` `NotesActionMenu` of Edit · Copy · Delete + an inline `NotesDeleteConfirm` strip mirroring the in-reader `HighlightPopoverDeleteConfirm`, plus a left-swipe `NotesSwipeActions` drawer); the per-row interaction phase is held on the sheet by the SHEET-owned pure `NotesRowState` (at most one row non-default at a time), and Delete routes through `HighlightListViewModel.removeHighlight` / `AnnotationListViewModel.removeAnnotation`. The container stays `LazyVStack` (not a `List`), so the swipe is a custom `DragGesture` translate rather than `.swipeActions` (which requires a `List` host).
+
+`ReaderContainerView` drives `preferredColorScheme(_:)` from `ReaderThemeV2.preferredColorScheme` (`ReaderThemeV2+ColorScheme.swift`) so the status bar tints to match the theme — `.dark` for the Dark / OLED / Photo families, `.light` for Paper / Sepia.
+
+#### Format Hosts (`ReaderFormatHosts.swift`)
+
+Each host owns its ViewModel lifecycle via `@State`:
+
+- `TXTReaderHost` → `TXTReaderContainerView` → `TXTTextViewBridge` (small single-chapter / Paged) or `TXTChunkedReaderBridge` (>500K UTF-16, **and** chaptered TXT in Scroll layout — bug #180). Chaptered TXT in Scroll layout renders as one continuous `UITableView` surface fed the whole book: `TXTContinuousChunkBuilder` splits the decoded book into document-global-offset chunks, `TXTChapterOffsetIndex` layers chapter awareness so `currentChapterIdx` is *derived* from scroll offset (no per-chapter render unit, no chapter-swap).
+- `EPUBReaderHost` → `EPUBReaderContainerView` → `EPUBWebViewBridge` (WKWebView + JS injection). **Paged** EPUB loads one spine item per `loadFileURL`. **Continuous scroll** (feature #71, the DEFAULT for EPUB scroll layout since the terminal-WI flag flip on 2026-05-28 — `FeatureFlags.epubContinuousScroll` defaults ON; a persisted user/debug override can still disable it) instead loads a single bootstrap document and stitches a lazy ±1-chapter window into it: `EPUBContinuousScrollCoordinator` owns an `EPUBSpineWindow` `[lo…hi]` anchored on the reading chapter and, on the section-aware scroll observer's boundary signals, materializes the adjacent chapter (`EPUBContinuousChapterProvider` → `EPUBChapterBodyRewriter` → `EPUBContinuousScrollJS.append/prependChapterSectionJS`) and evicts the far side (`maxSpan`) to bound memory. Per-section highlight restore hangs off a `sectionMaterialized` lifecycle message (appended sections never fire `didFinish`); saved-position restore + TOC/bookmark/search navigation drive the coordinator (`navigate(toSpineIndex:fraction:)` — scroll within the window, or rebuild around an out-of-window target). The evaluator reaches the live `WKWebView` through a late-binding `EPUBWebViewEvaluatorHandle` the bridge binds in `makeUIView`.
+- `ReadiumEPUBHost` (feature #42 Phase 1, WI-5) → `ReadiumNavigatorRepresentable` → Readium Swift Toolkit `EPUBNavigatorViewController`. Selected by the dispatcher in place of `EPUBReaderHost` when `FeatureFlags.readiumEPUBEngine` is ON (**default ON since the WI-14 G2 flip 2026-06-01**; a persisted override OFF reverts to the legacy `EPUBReaderHost`). Opens the publication off-main via `ReadiumEPUBReaderViewModel` (`AssetRetriever` → `PublicationOpener`), then mounts the navigator; `EPUBPreferences(scroll:)` is mapped from `ReaderSettingsStore.epubLayout`. The `ReadiumReaderCoordinator` is the `EPUBNavigatorDelegate` + (DEBUG) `ReadiumNavigatorEvaluating` seam — it registers the active navigator with `DebugReaderRegistry.setActiveReadiumNavigator` and `markReaderSettled` on `locationDidChange`, and tears that registration down on `dismantleUIViewController` via `detach()` → `clearActiveReadiumNavigator` (the host registers no `DebugReaderProbe`, so it owns its own registry teardown). Reading-position save/restore landed in WI-6: the coordinator forwards `locationDidChange` to the VM's debounced save, which maps the Readium `Locator` → a `VReaderLocator` envelope (engine `.readium`, authoritative `readiumLocatorJSON` + a lossy legacy `Locator` leg) and dual-writes it through `PersistenceActor`'s `VReaderLocatorPersisting` conformance — `saveVReaderLocator` writes both the envelope blob into the SchemaV8 `ReadingPosition.vreaderLocatorData` column AND the legacy `locator`; legacy `savePosition` clears the envelope so a flag-OFF write can't be shadowed by a stale Readium position. On open, the host loads the saved envelope (`restoredReadiumLocator()`) before the navigator mounts and passes it as `initialLocation`. Theme/font landed in WI-7: the host body reads `ReaderSettingsStore.theme` + `.typography` + `.epubLayout` (tracked `@Observable` deps) and recomputes a full `EPUBPreferences` on any Display-settings change, which `updateUIViewController` re-submits live (`submitPreferences`). `ReadiumEPUBReaderViewModel+Mapping` translates the 5 `ReaderThemeV2` themes → Readium's 3 base `Theme`s + explicit `backgroundColor`/`textColor` (which win via `effectiveBackgroundColor`); font size from the per-format-calibrated `.epub` size (`FontSizeCalibrator`) → Readium's multiplier; `lineHeight` from `lineSpacing`; `fontFamily` (system→sansSerif, serif/sourceSerif4→serif, monospace→monospace, inter→sansSerif — custom-font registration deferred); `publisherStyles=false`. The WI-7 photo/custom-background refinement composites the decorative image behind the navigator: `ReadiumEPUBHost+Background.swift` layers the existing `ThemeBackgroundView` under the navigator in a `ZStack` (only when `useCustomBackground` + an image exists for the theme), and `ReadiumReaderCoordinator+Transparency` makes the navigator render through — `epubPreferences(..., transparentBackground:)` emits `backgroundColor: nil` (so ReadiumCSS injects no body bg rule), the representable forces `navigator.view`/spine `WKWebView`s `.clear`/`isOpaque=false`, and a read-only self-gating user script clears the opaque `html:root` ReadiumCSS paints (transparency state is authored into `localStorage` by Swift on each `locationDidChange`/toggle). Normal opaque themes are unchanged. Highlights landed in WI-8: `ReadiumDecorationHighlightAdapter` (a `HighlightRenderer`, the Readium counterpart of `EPUBHighlightRenderer`) renders stored highlights as Readium **Decorations** via `EPUBNavigatorViewController.apply(decorations:in:"highlights")` (declarative — the adapter holds the active set and re-submits the whole group on each apply/remove/restore). Re-anchoring is **text-quote** based (WI-8a migration spike): each `HighlightRecord` → `Decoration(locator: Locator(href:, text: .Text(highlight: selectedText, before/after: context)), style: .highlight(tint:))` — Readium re-finds the quote, so the legacy XPath `serializedRange` is never consulted or mutated (flag-OFF returns to legacy XPath rendering losslessly). The host owns the adapter + a `HighlightCoordinator(renderer: adapter)`, calls `restoreAll()` on open, and observes `.readerHighlightRemoved`/`.readerHighlightsDidImport`. The WI-8 new-highlight refinement adds CREATE from a live Readium selection: `ReadiumReaderCoordinator` conforms to `SelectableNavigatorDelegate` and `navigator(_:shouldShowMenuForSelection:)` forwards the finalized `Selection` to the host then returns `false` (suppressing Readium's native menu so the designed `SelectionPopoverView` is the sole selection surface — rule 51). `ReadiumEPUBHost+Highlights` stashes the `Selection` in a generic `ReadiumSelectionTokenCache<Selection>` under a token, presents the popover; on a color tap (`.readerHighlightRequested`) it resolves the token and `ReadiumSelectionHighlightBuilder` maps the `Selection`'s text-quote (highlight/before/after) + container-relative href → `HighlightRecord` inputs → `HighlightCoordinator.create` → the same `ReadiumDecorationHighlightAdapter` renders it immediately; `navCommander.clearSelection()` dismisses the selection. Navigation landed in WI-9a: the host observes the shared reader nav bus — `.readerNextPage`/`.readerPreviousPage` → the coordinator's `goForward`/`goBackward`, and `.readerNavigateToLocator` (TOC/bookmark/search-result tap, object = a vreader `Locator`) → `go(to:)` after mapping the vreader Locator → Readium Locator (`readiumLocator(fromVReader:spineHrefs:)`, reusing the WI-8 legacy→spine href resolution). Host→coordinator dispatch goes through a host-owned `ReadiumNavCommander` (`@State`, bound on `attach`/cleared on `detach`, mirrors the WI-8 adapter ownership). WI-9a also split the host into `ReadiumEPUBHost.swift` (View) + `ReadiumNavigatorRepresentable.swift` + `ReadiumReaderCoordinator.swift`. Footnotes (#138, WI-9b) remain. Search result-list extraction still uses the existing FTS/`SearchViewModel` stack — WI-9a maps only result *navigation*. **Bilingual landed in WI-11 (paged) and WI-12 (scroll parity): interlinear bilingual works under the flag by driving the enumerate→prefetch→inject loop through Readium's one-way `evaluateJavaScript(_:) async -> Result<Any,Error>` channel — NOT a script-message handler (the navigator owns its content controller, exposing no app-side message channel; this is why the WI-11a `ReadiumBilingualEvalAdapter` RETURNS the `[{bid,text}]` array rather than posting it). A host-owned `ReadiumBilingualCommander` (`@State`, the bilingual counterpart of `ReadiumNavCommander`) holds an evaluator closure the coordinator binds on `attach` (the production non-DEBUG `ReadiumReaderCoordinator.evaluateForBilingual`, returning Readium's raw `Result<Any,Error>?`) and clears on `detach`; `enumerate()` runs `ReadiumBilingualEvalAdapter.enumerateJS()` and parses the return value via `EPUBBilingualPipeline.parseEnumerateMessage`, `inject(_:)`/`clear()` run the engine-agnostic inject/clear builders. The host reuses the feature-#56 `EPUBBilingualOrchestrator` (paged `-1` bucket via `updateBlocks(_:)`) + `BilingualReadingViewModel` + the designed `BilingualSetupSheet` (rule 51 — no new UI). Source text comes from vreader's own `EPUBParser` (opened alongside the Readium open — Readium does not expose raw spine HTML), so the `EPUBChapterTextProvider` is keyed on OPF-relative spine hrefs; the Readium-produced vreader `Locator` carries Readium's CONTAINER-relative href, so `ReadiumBilingualCommander.normalizedLocator(_:toSpineHrefs:)` rewrites it onto the OPF spine via the shared `ReadiumDecorationHighlightAdapter.resolveHref` tolerance before `vm.handlePositionChange(...)` (the WI-8 href-consistency finding class — without it `unit(containing:)` returns nil and nothing translates). Chapter-change detection composes onto the existing `onLocationChange` (WI-6 position save still runs): a fresh enumerate runs only when the spine href changes, deduped intra-chapter by a reference-type `ReadiumBilingualChapterTracker`. WI-12 lifted the WI-11 paged-only gate (`isBilingualSupported` is true for both layouts) so bilingual works in scroll too — but PER-SPINE only: Readium scroll mode is per-resource (it emits `locationDidChange` at spine boundaries, driving the same per-spine enumerate the paged path uses), and Readium has no multi-spine-stitch API, so off-screen chapters enumerate when scrolled into view rather than eagerly. This is a documented behavior delta vs legacy #71 — the flag-OFF `EPUBWebViewBridge` engine keeps its full stitched cross-chapter continuous bilingual; the Readium engine does not reproduce it. A paged↔scroll layout change re-renders the spine (discarding the `data-vreader-bid` stamps + decorations), so the layout-change handler re-enumerates the current spine in both directions.** TTS (WI-10): read-aloud already works under the Readium engine with NO Readium-specific code — `ReaderContainerView.startTTS()` → `ReaderAICoordinator.loadBookTextContent(format: "epub")` extracts spine text from the **file** via `EPUBParser` (renderer-agnostic, independent of which engine renders), then feeds the shared `TTSService` pipeline. Device-verified under `readiumEPUBEngine` ON (speaking, `ttsOffsetUTF16` advancing 42→115, stop→idle). The speaking-position **follow** landed in WI-10b: as TTS speaks, the navigator auto-advances so the spoken text stays on screen. `ReadiumEPUBHost` observes the shared `TTSService.currentOffsetUTF16` (threaded in like `EPUBReaderHost`); a pure value-type `ReadiumTTSFollowMapper` maps the flat UTF-16 offset → (spine href, intra-spine fraction). CRITICAL alignment: the per-spine offset table is built from the SAME spine text the TTS engine reads — `EPUBTextExtractor.stripHTML` + trim, skip empties, join `"\n\n"` (the `ReaderAICoordinator.loadBookTextContent` recipe) — extracted off-main from the host's already-open `bilingualParser` (so the index matches the engine's offsets; the block-preserving bilingual stripper is deliberately NOT used here). `ReadiumEPUBHost+TTSFollow` throttles: it navigates on any spine-href change or an intra-spine fraction drift > 0.08 (so the navigator tracks ~chapter-eighth granularity, not every `willSpeakRange` word), maps the target → a vreader `Locator` → Readium `Locator` via the WI-9a `readiumLocator(fromVReader:spineHrefs:)` resolution, and drives the existing `navCommander.navigate(to:)` → `navigator.go(to:)`. Follow runs only while TTS state == `.speaking`; the cursor resets on each play start and on pause/stop. This unblocks the WI-14 default-ON flip.
+- `PDFReaderHost` → `PDFReaderContainerView` → `PDFViewBridge` (PDFKit)
+- `MDReaderHost` → `MDReaderContainerView` → reuses `TXTTextViewBridge` with NSAttributedString
+- AZW3/MOBI is dispatched directly to `FoliateSpikeView` (the AZW3 spike landed before the host abstraction; convergence is deferred). `FoliateReaderHost` / `FoliateReaderContainerView` exist but are not currently wired into `ReaderContainerView`. **Feature #73 added a windowed multi-section continuous-scroll surface inside the vendored Foliate-js `paginator.js`** (default ON for horizontal-writing scroll mode, gated behind the renderer's `#windowedScroll`). Instead of the per-section view-swap — whose `scrollToAnchor(0)` offset reset + blank-flash on `#createView` destroy/async-load + post-swap reflow were the three stacked discontinuities of the Bug #283 chapter-boundary jump — a K=3 window of adjacent sections is mounted into the single scrolling `#container` and recycled on scroll: `#ensureWindow` mounts neighbours (firing the same `load`/`create-overlayer` lifecycle so each neighbour doc is wired for selection/overlays), `#evictOutsideWindow` unmounts + unloads the far side with `scrollTop` compensation, `#promoteCurrentView` tracks the current section by scroll position (a pointer swap, no DOM move), and `#windowedResolve` emits the intra-section relocate fraction (`progress.js`/`SectionProgress` still owns whole-book conversion, preserving Bug #265 position restore). A `#windowGeneration` token aborts stale async mounts across navigation. Vertical writing + paged mode keep the single-`#view` swap path. The pure windowing math (window clamp, offset↔section mapping, intra-section fraction, evict adjustment, anchor translation) is mirrored + unit-tested in `FoliateScrolledWindowMath.swift`; flag-on behavior was device-verified and the JS diff passed a 2-round independent Codex audit.
+
+#### Foliate-js Bridge (`vreader/Views/Reader/`, `vreader/Services/Foliate/`)
+
+`FoliateViewBridge` (UIViewRepresentable) hosts a WKWebView and uses `loadHTMLString` with the IIFE-bundled `foliate-bundle.js` inlined; books are handed to JS as base64 (no scheme handler in the live load path — `FoliateURLSchemeHandler` exists in the codebase but isn't wired into the active bridge today). `FoliateViewCoordinator` (WKScriptMessageHandler + WKNavigationDelegate) receives JS messages, parses via `FoliateMessageParser`, and routes to typed callbacks. `FoliateHighlightRenderer` generates JS strings for SVG overlay annotations — but it is **not** plugged in as a `HighlightRenderer` adapter today; AZW3 highlight create has a TODO for persistence/JS injection and overlay restore is a no-op placeholder (`FoliateReaderContainerView+Highlights.swift`). `FoliateJSEscaper` provides shared sanitization for all JS/CSS string interpolation across the bridge. `FoliateReaderViewModel` maps bridge events to `Locator` for position persistence.
+
+The Foliate JS bundle is built from sources under `vreader/Services/Foliate/JS/` via `build-bundle.sh`, which calls a locally-pinned esbuild (`package.json` + `package-lock.json`, currently `esbuild@0.28.0`; bootstrapped via `npm ci` — node ≥18). `paginator.js` is the source of truth; `foliate-bundle.js` is checked in and must be rebuilt whenever the source changes (a parity check in `FoliatePaginatorScrollBoundaryTests` enforces this for the scroll-mode boundary-detect helper that resolved Bug #235).
+
+#### Unified Engine (retained, not dispatched)
+
+`ReaderUnifiedCoordinator` loads text + applies transforms (replacement rules, simp/trad); `UnifiedTextRenderer` displays with TextKit 2 pagination or scroll. Feature #54 removed the unified path from the reader dispatch and the reader-settings Reading Mode picker, so this stack is **no longer reachable from reader dispatch** — it is retained (a follow-up may consume it for bilingual reading, or delete it once provably orphaned). Content replacement rules and Chinese conversion that previously required Unified mode now run in the native readers directly: `MDFileLoader.load` composes `ReplacementTransform` + `SimpTradTransform` over the decoded source text before parsing (feature #54 WI-7); **native EPUB applies replacement rules via `EPUBReplacementJS` (feature #54 Phase D-1)** — a CFI-safe per-text-node JS injection that runs on both EPUB engines (Readium per-spine via `ReadiumReaderCoordinator+Replacement`; the legacy #71 WKWebView stitch on `didFinish` via `EPUBWebViewBridgeCoordinator`, plus a scroll-root `MutationObserver` for appended chapters), keyed by `MDReplacementRuleFetcher`; native TXT has Chinese conversion only — TXT replacement rules are deferred (they need a source↔display offset map). Replacement rules apply at chapter/document open; a mid-read rules edit takes effect on next open (v1 scope).
+
+### 4. Coordinator Layer (`vreader/Views/Reader/`)
+
+Cross-format coordinators that compose with multiple readers:
+
+| Coordinator                | Responsibility                                                      | Setup Timing                                                          |
+| -------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `ReaderAICoordinator`      | AI ViewModels, text loading, context extraction                     | On AI/TTS invoke                                                      |
+| `ReaderSearchCoordinator`  | Search service, indexing, FTS5                                      | Service+VM eagerly via `prepareEagerly()` on reader open (bug #79; cold SQLite open is `nonisolated`, off-MainActor); indexing still deferred to `setup()` on first sheet open |
+| `ReaderUnifiedCoordinator` | Unified renderer state, text transforms — retained but no longer dispatched (feature #54) | n/a (no dispatch path)                                     |
+| `HighlightCoordinator`     | Persists via `HighlightPersisting`, dispatches to `HighlightRenderer` adapters | On reader open per format (TXT/MD/PDF/EPUB)                          |
+
+Bridge-internal coordinators (`EPUBWebViewBridgeCoordinator`, `FoliateViewCoordinator`, `TXTTextViewBridgeCoordinator`) handle delegate / WKScriptMessageHandler plumbing for one bridge each; they're not cross-cutting and aren't enumerated here.
+
+### 5. Services Layer (`vreader/Services/`)
+
+| Service                              | Backing                    | Purpose                                                                   |
+| ------------------------------------ | -------------------------- | ------------------------------------------------------------------------- |
+| `PersistenceActor`                   | SwiftData (actor-isolated) | All DB writes serialized                                                  |
+| `SearchService` + `SearchIndexStore` | SQLite FTS5                | Full-text search with persistent index                                    |
+| `AIService`                          | OpenAI-compatible REST API | Summarize, translate, chat. Feature #56 added a resolved-provider seam — `ResolvedAIProviderConfig` (an immutable `{kind, baseURL, apiKey, model, maxTokens}` snapshot) plus `resolveActiveProviderConfig()` / `resolveProviderConfig(profileID:modelOverride:)` / `sendRequest(_:using:)`. A *multi-request* operation (chapter translation = one request per chunk) resolves the config ONCE and pins the credential + model for every chunk; `sendRequest(_:using:)` deliberately bypasses `AIResponseCache` (its key is not provider-aware). The original `resolveProvider()` / `sendRequest(_:)` / `streamRequest(_:)` are unchanged. **Feature #91 (agentic tool-calling)** added `supportsToolUse` + `sendToolRequest(_:)` on `AIProvider` (Anthropic `tool_use` / OpenAI `tool_calls`; default-off so non-tool providers compile unchanged), and on `AIService`: `resolveToolProvider()` (resolve the config ONCE + report tool-use capability), `sendToolTurn(_:using:)` + `streamRequest(_:using:)` (one turn/stream through the pinned config, RE-checking the live flag + consent each turn so a mid-loop revoke fails closed) |
+| `AgenticChatDriver` + `AIToolRegistry` (`Services/AI/`) | `AIService` + the tool executors | **Feature #91 — agentic AI chat.** `AgenticChatDriver` is the bounded send→tool→result→re-send loop (one pre-resolved provider via `AIServiceToolUseAdapter`, `maxIterations` cap, returns `{finalText, usedTools}`); `AIToolRegistry` dispatches a model `ToolCall` to its `AITool` (unknown tool → `isError` result, never throws). Four read-only executors wrap existing capabilities: `search_current_book` (the open book's FTS), `search_other_books` (the whole library, gated by the pure `LibraryBookSearchGate` over the persistent index), `get_book_content` (a book's text by title, locality/format-gated), and `list_library` (feature #97 — enumerate the bookshelf: title/author/format, over the same `LibrarySearchBackend.libraryBooks()`; dedupe, open-book exclude, total deterministic sort, cap+announce, canonical-format display, restore-placeholder friendliness). `AgenticToolRegistryBuilder.buildLive` assembles them over the production `LibrarySearchBackendAdapter` + `BookContentProviderAdapter` (+ `ClosedBookTextExtractor`) and the shared `PersistentSearchIndex` store. `AIChatViewModel.sendMessage` routes through the driver when `agenticTools` is on + the resolved provider supports tool-use (silent loop, single final answer, citations suppressed on a tool reply); otherwise the existing streaming path. Default OFF |
+| `PersistentSearchIndex` (`Services/Search/`) | `SearchIndexCore` + `SearchIndexStore` | The single Services-layer source of truth for the on-disk FTS index location (`Application Support/SearchIndex/search.sqlite3`) + persistent-store construction (`makeStore()`, in-memory fallback). `ReaderSearchCoordinator` delegates to it; Feature #91's agentic search tools open the SAME persisted index through it |
+| `TTSService`                         | `SpeechSynthesizing` seam | `@MainActor @Observable` read-aloud state machine (idle/speaking/paused + UTF-16 progress offset). Speaks through an injected `SpeechSynthesizing` and wires its `AVSpeechSynthesizerDelegate` callbacks generically via the protocol's `delegateTarget` (feature #72 WI-0), so any backend — on-device, XCUITest mock, or the cloud adapter — drives progress without type-casing. `defaultSynthesizer(configStore:)` picks the backend: XCUITest mock (DEBUG override) > `HTTPSpeechSynthesizer` when a valid `HTTPTTSConfig` is persisted (feature #72 WI-3) > `SystemSpeechSynthesizer` (on-device) |
+| `HTTPSpeechSynthesizer`              | `HTTPTTSProvider` + `HTTPTTSChunkPlayer` | Feature #72 WI-3 cloud-TTS adapter: the `SpeechSynthesizing` impl that finally wires the orphaned `HTTPTTSProvider` (bug #270) into live read-aloud. Per `speak`, chunks the utterance (`HTTPTTSProvider.chunkText`), synthesizes each chunk over HTTP, streams the audio blobs into `HTTPTTSChunkPlayer`, and emulates the `AVSpeechSynthesizerDelegate` callbacks `TTSService` consumes (chunk-range `willSpeakRange`, `didFinish`, `didCancel`). Conforms to the non-isolated protocol via `@unchecked Sendable` + `MainActor.assumeIsolated` wrappers over `@MainActor` impls; `TTSService` (its only caller) is `@MainActor`. Audio session stays owned by `TTSService` |
+| `HTTPTTSChunkPlayer`                 | `AVAudioPlayer` (behind `SpeechAudioPlaying` seam) | Feature #72 WI-2 sequential audio-chunk playback queue for the cloud path. Plays streamed `Data` chunks back-to-back, fires `onChunkStarted(index)` as each begins and `onFinished` once the LAST chunk of a COMPLETE input drains (drain ≠ complete — `markInputComplete()` gates the finish). Generation token ignores late finishes from stopped/replaced players. Does NOT manage `AVAudioSession` |
+| `HTTPTTSConfigStore`                 | `UserDefaults` + `KeychainService` | Feature #72 WI-1 loader: decodes the persisted `HTTPTTSConfig` from UserDefaults and splices the API key from Keychain; `loadValidConfig()` returns the config only when it passes `validate()`. Consumed by `TTSService.defaultSynthesizer` to decide whether the cloud path is active |
+| `BookContentCache`                   | In-memory                  | Text cache for AI context loading (TXT/MD only)                           |
+| `PreferenceStore`                    | UserDefaults               | Sort order, view mode persistence                                         |
+| `ReadingStatsAggregator`             | SwiftData (actor-isolated) | Reading-stats dashboard aggregator (feature #58). Sweeps `ReadingSession` + `Book` rows in one `ModelContext` pass and returns a `ReadingDashboardSnapshot` — per-window totals (today / 7d / 30d / 90d / 180d / 365d / all) + per-book breakdown. Derives every number from session rows, never from `ReadingStats`, so a stale stats cache cannot desync the dashboard. Holds a `@Sendable () -> Calendar` provider so window boundaries follow timezone/DST changes. **WI-6b**: `snapshot(window:sort:now:customRange:)` accepts an optional user-picked `ReadingStatsCustomRange` (calendar-day-inclusive `[start, end]`); when non-nil, the snapshot's `perBook` + `customRangeBreakdown` reflect that range while the seven enum totals stay populated for the pill bar |
+| `CustomCoverStore`                   | JPEG files                 | Custom book cover images                                                  |
+| `WebDAVClient`                       | HTTP                       | Low-level WebDAV transport (PROPFIND/PUT/GET/DELETE/MKCOL/MOVE)           |
+| `WebDAVProvider`                     | `WebDAVClient`             | `BackupProvider` impl — backup/restore/list/delete over a WebDAV server   |
+| `WebDAVProviderFactory`              | `WebDAVServerProfileStore`  | Assembles a `WebDAVProvider` from the active WebDAV profile (feature #52 WI-3 + WI-5). `make(persistence:profileStore:)` is the sole production path — the pre-#52 `make(keychain:)` flat-keychain variants were removed in WI-5 |
+| `WebDAVServerProfileStore`           | `UserDefaults` / `KeychainService` | Actor-isolated list of saved WebDAV server profiles with one active selection (feature #52 WI-1). Profiles + active-id persist as `UserDefaults` JSON; per-profile passwords persist in Keychain. Atomic `loadSnapshot`, `upsert` / `remove` / `setActiveProfileID`, single-hop `updateIfExists`. Mirrors `ProviderProfileStore` (feature #50) for the AI multi-profile precedent |
+| `WebDAVProfileMigrator`              | `KeychainService` / `WebDAVServerProfileStore` | One-shot migrator that lifts pre-#52 flat-keychain credentials (`com.vreader.webdav.{serverURL,username,password}`) into a `"Default"` profile and sets it active. Idempotent on both axes (marker key + non-empty store). Feature #52 WI-2 |
+| `ReadingModeMigration`               | `UserDefaults` / per-book JSON files | One-shot **synchronous** launch migration retiring the Native/Unified reading mode (feature #54). Removes the `readerReadingMode` UserDefaults key and strips the `readingMode` field from per-book override JSON files (edited as raw `JSONSerialization` objects so other keys are semantically preserved). Synchronous-before-setup — the per-book JSON store has no actor, so a detached migration could race a panel save/restore. Idempotent |
+| `BackupDataCollector`                | `PersistenceActor`         | Serializes 8 versioned JSON sections (annotations, positions, settings, library-manifest, …) |
+| `BackupDataRestorer`                 | `PersistenceActor`         | Decodes + dedupes by UUID/profileKey; rejects future schema versions      |
+| `BlobPath`                           | —                          | Pure utility: `(format, sha256, byteCount)` ↔ `VReader/books/<format>/<sha>_<bytes>.<ext>` (feature #46) |
+| `BackupBlobStore` (protocol pair)    | —                          | Transport-neutral read (`BackupBlobReading`) + write (`BackupBlobWriting`) blob API |
+| `WebDAVBlobStore`                    | `WebDAVTransport`          | Adapter that owns the temp+MOVE atomic-publication algorithm (feature #46) |
+| `BookFileMaterializer`               | `BackupBlobReading` + `BookImporting` | Restore-side: download + size/SHA-256 verify + import via `BookImporter`. Preflight-rehashes existing local files to catch corrupt content (feature #46). Refactored in feature #47 WI-4a to delegate verify + import + fingerprint match to `BookFileImportFinalizer`. |
+| `BookFileImportFinalizer`            | `BookImporting`            | Shared verify + import + fingerprint pipeline used by both `BookFileMaterializer` (restore-all path) and the lazy-download coordinator (feature #47 WI-4b). Streaming SHA-256 so very-large blobs don't spike memory. Caller owns temp-file lifetime. |
+| `RemoteBookCatalog`                  | —                          | Pure decoder: extracts `library-manifest.json` from a backup ZIP via `ZIPWriter.extractEntry(named:from:)` and returns `[BackupLibraryEntry]`. Surfaces `manifestMissing` (older backups) / `manifestUndecodable` / `manifestSchemaVersionTooNew` as typed errors. Feature #47 WI-4a. |
+| `SelectiveRestoreCoordinator`        | `BookFileMaterializer` + `PersistenceActor` + `BackupDataRestoring` | 3-phase orchestrator for the picker-driven restore: (1) preplant unselected entries as `.remoteOnly` rows, (2) materialize selected entries via `BookFileMaterializer`, (3) apply metadata sections so positions/annotations reattach to BOTH `.local` and `.remoteOnly` rows by fingerprintKey. Phase-weighted progress 0.10/0.75/0.15. Feature #47 WI-4b. |
+| `LazyDownloadCoordinator`            | `BackgroundDownloadSessioning` + `PersistenceActor` | `@MainActor @Observable`. Receives forwarded events from a non-isolated `LazyDownloadDelegate` and exposes per-fingerprintKey progress + outcome state to library rows. Reattaches in-flight tasks at init via `URLSession.getAllTasks(...)` and reconciles orphaned `.downloading` rows (no live task) to `.failed`. Race-safe sticky `terminalKeys` guard outlives `clearOutcome(for:)`. Feature #47 WI-3. |
+| `LazyDownloadDelegate`               | URLSessionDownloadDelegate | Nonisolated delegate that hops to MainActor via `Task` to forward `didWriteData` / `didFinishDownloadingTo` / `didCompleteWithError` / `urlSessionDidFinishEvents` events to the coordinator. Cancels orphaned tasks (missing/invalid `taskDescription`) and validates SHA/extension shape before staging. Feature #47 WI-3. |
+| `LazyDownloadTaskMeta`               | —                          | `Codable Sendable` payload encoded into `URLSessionDownloadTask.taskDescription` so identity (`fingerprintKey`, `blobPath`, `expectedSHA256`, `expectedByteCount`, `originalExtension`) survives crash + relaunch. `schemaVersion` gate (`1...currentSchemaVersion`) rejects future formats. Feature #47 WI-3. |
+| `BackgroundDownloadSessioning`       | `URLSession.background(...)` (production) / mock (tests) | Test seam for the background URLSession's `getAllTasks` enumeration. Production wrapper (`URLSessionBackgroundSession`) holds the live session; tests synthesize `LazyDownloadTaskDescriptor` values. Feature #47 WI-3b. |
+| `WebDAVNetworkPolicy`                | `NWPathMonitor`            | `@MainActor @Observable` Wi-Fi-only gate. UserDefault `com.vreader.webdav.wifiOnly` (default true) + `currentInterface: .unknown / .none / .cellular / .wifi`. `shouldStart() -> Bool` consulted by the lazy-download enqueue path (#47 WI-4 follow-up) and "Restore all" guards. URLSession's `allowsCellularAccess = false` cancels rather than pauses, so we keep cellular allowed and gate at enqueue. Feature #47 WI-3c. |
+| `FoliateURLSchemeHandler`            | WKURLSchemeHandler         | Scheme-handler implementation (not on the live load path; see Foliate-js Bridge note) |
+| `FoliateMessageParser`               | Pure functions             | Parses raw JS message bodies into typed Swift events                      |
+| `FoliateJSEscaper`                   | Pure functions             | Escapes/sanitizes strings for safe JS/CSS interpolation in Foliate bridge |
+| `ReaderSettingsStore`                | UserDefaults               | Global reader UI prefs: theme, typography, EPUB layout, auto-page-turn, page-turn animation, Chinese conversion, custom background |
+| `PerBookSettingsStore`               | Per-book JSON files        | Per-book overrides on top of `ReaderSettingsStore` (font/theme/spacing) |
+| `FontSizeCalibrator`                 | Pure value type            | Maps the stored unified font-size value to a per-renderer concrete value via `FontSizeCalibrationProfile` multipliers (`txt`/`md`/`epub`/`foliate`), so the same slider number renders at a consistent perceived size across reflow formats. TXT is the `1.0` anchor; result re-clamped to each renderer's legal band (`12...64` text, `8...72` Foliate). PDF is intentionally not a target. Feature #70 |
+| `KeychainService`                    | Keychain                   | Secure credential storage (used by `WebDAVProviderFactory`)               |
+| `BookSourcePipeline`                 | Actor + HTTP / rule engine | Search → BookInfo → TOC → Content scraping for Legado-style web novels    |
+| `SyncService`                        | CloudKit (feature-flagged) | Coordinates sync with `SyncConflictResolver`, tombstones, change tokens   |
+| `DebugBridge`                        | URL handler (DEBUG-only)   | `vreader-debug://` reset/seed/open/settle/snapshot/eval/tts/search/highlight/provider/present/ai/seed-sessions/seek/scroll-sheet/navigate/scroll-boundary/locate?highlight=N; feature #49 added position-aware open + DebugSnapshot schema v2 (TTS state, render phase, settings provenance); feature #74 added `locate?highlight=<N>` to drive `.readerNavigateToLocator` for the active TXT/MD reader CU-free so the locate "bloom" (highlight/note landing) fires on the real render path, plus DebugSnapshot schema v3 (`landingBloomCount` / `landingBloomPeakIntensity`) read back from `HighlightableTextView`'s persisted bloom counters — the ~1.5s sub-second bloom visual can't be screenshot/video-captured on the virtual display, so the snapshot proves it fired; feature #45 WI-4c-b added `tts?action=start\|stop` to bypass XCUITest's audio-session block; bug #238 added `search?query=...[&index=N]` to drive search-result-tap repros (Bug #182 / GH #621) CU-free; bug #237 added `highlight?start=...&end=...[&color=...]` for TXT/MD highlight creation CU-free; bug #243 added `provider?action=add\|remove\|clear` for AI provider configuration without driving Settings → AI through CU (unlocks Feature #56 b/d / Feature #65 / Feature #69 / Bug #93 autonomous AI verification); bug #253 added `present?sheet=...[&tab=...]` + bug #255 added `ai?action=summarize\|chat\|translate` for CU-free reader-sheet + AI-response-card verification; bug #263 added `seed-sessions?book=<key>[&seconds=<n>]` to seed a deterministic `ReadingSession` spread (one per dashboard window band) so the reading-stats dashboard (Feature #58) renders non-zero per-window totals CU-free; bug #267 added `seek?fraction=<0...1>` to drive the active Foliate (AZW3/MOBI) reader to a fractional position CU-free; bug #271 added `scroll-sheet?to=top\|bottom` to scroll the active presented sheet's content (today `TranslationResultCard`) so the accent translation card below the tall ORIGINAL card — beyond even the `detent=large` fold (Bug #256) — becomes screenshot-capturable, unblocking Feature #65 row 11; bug #273 added `navigate?spine=<N>[&fraction=<F>]` to drive `.readerNavigateToLocator` for the active EPUB reader CU-free (the `search` driver doesn't navigate in continuous mode), posting DEBUG-only `.debugBridgeNavigateCommand` → `EPUBReaderContainerView` resolves spine → href → `Locator` → re-posts `.readerNavigateToLocator` — unblocking feature #71 WI-8 continuous-mode navigation verification (paired with the `multi-chapter-epub` 4-tall-chapter fixture for the out-of-window rebuild branch); a follow-up added `scroll-boundary?spine=<N>&near=top\|bottom` to post a DEBUG-only `.debugBridgeScrollBoundaryCommand` → `EPUBReaderContainerView` builds an `EPUBScrollBoundarySignal` and calls `EPUBContinuousScrollCoordinator.handleBoundarySignal` directly — bypassing the rAF-throttled `continuousScrollObserverJS` (unverifiable CU-free on a virtual display) so feature #71's scroll-driven extend/evict RESPONSE can be device-verified. **Host-vs-runner driving constraint (bug #242 / GH #1054)**: bridge URLs MUST be invoked from the host (`xcrun simctl openurl` outside any iOS sandbox) — invoking them from inside an XCUITest binary fails with NSPOSIX 61 because the runner sandbox blocks the CoreSimulatorService XPC endpoint. In-runner verification flows use `XCTSkipUnless(bridgeReachable())` (PR #1053) when they cannot move the bridge-dependent assertion to a host-side driver. See `docs/subsystems/debug-bridge.md` § "Driving the bridge from a verification flow". |
+| `DebugPositionResolver`              | —                          | Pure parser: `?position=<value>` string → typed `DebugPosition` per BookFormat (TXT/MD UTF-16 offset, EPUB CFI, AZW3 Foliate-CFI, PDF page). Every format takes its native seek path (feature #54 retired the Native/Unified mode + its position-unsupported guard). Feature #49 WI-7a. |
+| `DebugReaderRegistry.awaitReader`    | DebugReaderRegistry singleton | Token-based keyed waiter that resumes when a reader matching `fingerprintKey` registers. Concurrent waiters with different timeouts each get their own continuation (UUID-token ownership). Feature #49 WI-7a. |
+| `DebugReaderRegistry.awaitReaderSettled` | DebugReaderRegistry singleton (`+Settle` extension) | Bug #141: render-settled signal keyed by `(fingerprintKey, token)`. Hosts call `markReaderSettled` on real render-complete — EPUB from `webView(_:didFinish:)`, AZW3/MOBI from the Foliate `relocate` message. `ReaderContainerView` wires `probe.settleStrategy` so `vreader-debug://settle` blocks until that signal (or `settleTimeout`) instead of the 100ms placeholder. TXT/MD/PDF keep the placeholder. Same UUID-token waiter machinery + stale-write guard as `awaitReader`. |
+| `ImportJobQueue`                     | Actor                      | Serializes book imports (avoids parallel `BookImporter` writes)           |
+| `FileURLImportRouter`                | `BookImporting` (protocol) | `@MainActor` dispatcher for incoming `file://` URLs from iOS Share Sheet / "Open in vreader" (Feature #59 WI-2). Wired by `VReaderApp`'s production `.onOpenURL`. Returns `false` for non-file URLs (Debug-bridge handler intercepts those upstream). Unsupported extensions reported via injected closure (App layer wires the user-facing alert; current production wiring is a no-op). Supported extensions kick off `bookImporter.importFile(at:source:.shareSheet)` in a fire-and-forget Task. Security-scope handling owned by `BookImporter`, not the router. |
+| `LibraryRefreshService`              | NotificationCenter         | Coalesces library refresh requests across views                           |
+| `FeatureFlags`                       | Static                     | Compile/runtime flag resolution (`SyncService` and others gate on it). Feature #91 added `agenticTools` (default OFF, persisted) — gates the AI chat's agentic tool-calling loop |
+| `DictionaryLookup`                   | UIKit                      | System dictionary + AI-translate hooks for selected text                  |
+| `DiagnosticsLogStore` + `OSLogDiagnosticsSource` + `DiagnosticsRedactor` (`Services/Diagnostics/`) | `OSLogStore` (current-process) | **Feature #96 — in-app runtime diagnostics.** `DiagnosticsLogStore` (`@MainActor @Observable`) reads the current session's `com.vreader.app` `Logger` entries back via the `DiagnosticsLogSource` seam (`OSLogDiagnosticsSource` runs the blocking `OSLogStore` enumeration off-main), holds them bounded, filters by level/category, and produces a `DiagnosticsRedactor`-scrubbed export string. `DiagnosticsRedactor` is a pure, context-driven secret/path scrubber (Authorization, keyed secrets, `sk-`/JWT keys, URL creds, container paths) — the defense-in-depth second line over OSLog's `.private` barrier for anything leaving the app (export file + Copy-entry). WI-2 added the Settings → Support → Diagnostics viewer (`Views/Settings/Diagnostics/`) binding to the store |
+| `ChapterTranslationStore`            | SwiftData (actor-isolated) | Persistent disk cache for feature #56 bilingual reading. Wraps its own `ModelContext` over the `ChapterTranslation` `@Model` (SchemaV7) — a separate actor from `PersistenceActor` so bulk translation writes during a global-translate run never block library reads. App-scoped `.shared` single instance (the `ProviderProfileStore.shared` precedent); idempotent `upsert` fetches by `lookupKey` and updates in place, never relying on the unique constraint to throw. Returns the value-type `ChapterTranslationRecord` DTO, never the `@Model`. Bug #342: lazily migrates pre-#342 5-field keys (profile UUID baked in) to the canonical 4-field key on first access, deduping to the newest row. The cache is derived, re-fetchable data — excluded from WebDAV backup |
+| `ChapterTranslationService`          | `ChapterTranslationStore` + `AIService` | Translates one chapter unit for feature #56 bilingual reading. Pipeline: cache lookup → (on miss) `ChapterSegmenter` → `ChapterTranslationChunker` → one `AIService.sendRequest(_:using:)` per chunk → strict `TranslationChunkContract` JSON-array decode → per-segment fallback on any decode/count/element mismatch → recombine → cache-write. Reaches the AI side through the `TranslationRequestSending` boundary protocol (tests inject a mock). `Task.checkCancellation()` between chunks so a cancelled prefetch stops promptly |
+| `ChapterTextProviding` (`Services/Reader/`) | per-format reader services | Feature #56 WI-2.5 boundary protocol — supplies a book's translation units (`translationUnits()`), per-unit plain source text (`sourceText(for:)`), and the `Locator → unit` resolution (`unit(containing:)` / `unit(after:)`) the bilingual prefetch trigger needs. The translation *unit* is the format's natural rendering segment, not the logical TOC chapter (plan Decision 2.7). Four concrete `Sendable` `struct` adapters: `EPUBChapterTextProvider` (spine documents, HTML-stripped via `EPUBTextExtractor`), `TXTChapterTextProvider` (`TXTChapterIndex` chapters, UTF-16 slicing), `MDChapterTextProvider` (`MDHeading`-bounded chapters), `PDFChapterTextProvider` (page ranges via PDFKit). The AZW3/MOBI `FoliateChapterTextProvider` (an `actor`, bridges the `@MainActor` Foliate coordinator via the `FoliateSectionExtracting` facade) lands in WI-11. `ChapterTranslationService` / `BookTranslationCoordinator` consume this boundary, never a format-specific extractor |
+| `FoliateChapterTextProvider` (`Services/Reader/`) | `FoliateSectionExtracting` | Feature #56 WI-11 — AZW3/MOBI `ChapterTextProviding` adapter. The odd one out: an `actor` (not a `struct`) because the live Foliate seam (`FoliateSpikeView.Coordinator` + `WKWebView`) is `@MainActor`. Stores an `any FoliateSectionExtracting` and reaches it via `await`; an `actor` is `Sendable` by construction so it satisfies `ChapterTextProviding: Sendable` without `nonisolated(unsafe)`. Caches the ordered section-id list on the first `translationUnits()` call; a book reopen rebuilds the provider from scratch so the cache never goes stale within one open book |
+| `FoliateSectionExtracting` (`Services/Reader/`) | `FoliateSpikeView.Coordinator` (extension) | Feature #56 WI-11 — `@MainActor protocol` bridging the live Foliate per-section text extraction seam (the `readerAPI.bilingualSectionIDs` / `readerAPI.bilingualSectionText` JS calls) into the `Sendable` `ChapterTextProviding` boundary. Class-bound + `Sendable` + `@MainActor` means a `@MainActor`-isolated `AnyObject` existential is safely `Sendable` (members are main-actor-isolated), so the `FoliateChapterTextProvider` actor can hold a single live reference without an unsafe escape hatch |
+| `ChapterPrefetching` (`Services/AI/`) | `BilingualReadingViewModel` | Feature #56 WI-7b seam — `translatedSegments(for:targetLanguage:granularity:)`, the single-method translation-prefetch boundary `BilingualReadingViewModel`'s unit-aware prefetch trigger depends on. Decouples the view model from provider resolution / the disk cache / chunking; production wires a thin adapter over `ChapterTranslationService` + `AIService`, tests inject a deterministic mock |
+| `ChapterTranslationPrefetcher` (`Services/AI/`) | `ChapterTranslationService` + `AIService` + `ChapterTextProviding` | Feature #56 WI-10 production `ChapterPrefetching` adapter. `Sendable` `struct` per open book. Each `translatedSegments(...)` call consults the disk cache FIRST (profile-free — Bugs #306/#342: a cached chapter renders with no/any provider), then resolves the active provider config once — a profile flip during a chapter prefetch does not split chunks across providers. Pulls per-unit source text from the injected `ChapterTextProviding` and routes the request through `ChapterTranslationService.translate(...)`. Default style is `.natural`; the re-translate picker (WI-15) is the only path that overrides it |
+| `BackgroundExecutionToken` (`Services/`) | `UIApplication` (via `BackgroundTaskRequesting`) | Feature #98 grace-window handle over `beginBackgroundTask`/`endBackgroundTask` behind the `BackgroundTaskRequesting` protocol seam (production = `UIApplication`, tests = recorder). `@MainActor` class; explicit `end()` is the contract (idempotent; `deinit` only DEBUG-logs leaks); the expiration handler strongly captures a shared end-state so even a leaked token self-ends at expiry; `.invalid` (iOS denied time) degrades to a no-op. Ships with `BackgroundExpiryLatch` — a lock-backed one-way latch the `@MainActor` expiry handler sets synchronously and the whole-book job loop reads between units. Consumers: `ChapterReTranslateViewModel.submit()` (one token per re-translate) and `BookTranslationCoordinator` (token renewed per translated unit; expiry → clean between-units stop with the `.failed` phase, completed units cached as the resume checkpoint) |
+| `BookTranslationCoordinator` (`Services/AI/`) | `ChapterTranslationService` + `ChapterTranslationStore` + `ChapterTextProviding` | Feature #56 WI-14 actor driving the "translate entire book" flow. App-scoped `.shared` instance (configured at `VReaderApp.init`). `start(...)` spawns a background task that iterates `ChapterTextProviding.translationUnits()`, skips units already covered in `ChapterTranslationStore.cachedUnits(...)`, hands each remaining unit to `ChapterTranslationService.translate(...)`, and emits monotonic `BookTranslationProgress` snapshots through an `AsyncStream` (`progressUpdates(forBookWithKey:)`). At most one running job per book — a second `start` for the same book is a silent no-op. `cancel(_:)` stops between units; `cancelAndPurge(_:)` additionally wipes the book's cache rows for the user-delete-book path (plan edge case (g)). Posts `.readerBookTranslationProgressDidChange` on every snapshot so a reader open on the book drives its `ReaderTranslateBanner`. Feature #98: renews a `BackgroundExecutionToken` per translated unit; on OS expiry stops cleanly BETWEEN units (`.failed` phase = the designed PAUSED rendering) and persists an `InterruptedTranslationJob` descriptor (`{v, bookKey, targetLanguage, style, providerProfileID}` in UserDefaults via `InterruptedTranslationJobStore`); `resumeInterruptedJob(bookFingerprintKey:textProvider:)` — triggered by the reader container's provider-arrival handler — re-resolves the PERSISTED profile through the `ProviderConfigResolving` seam (`AIService` conforms) and re-enters `start` (cached units skip = resume); descriptor cleared on completion / user cancel / book delete, retained on provider failure |
+| `BookTranslationViewModel` (`ViewModels/`) | `BookTranslationCoordinator` | Feature #56 WI-14 `@MainActor @Observable` UI-facing state for the translate-entire-book flow. Drives the confirm alert (`presentConfirm` loads `estimate` + shows alert), the status sheet (`startObserving` subscribes to the coordinator's progress stream and mirrors snapshots into `progress`), and the cancel alert (`requestCancel` opens the confirmation, `confirmCancel` propagates to the coordinator). One per surface (Book Details, library card, reader chrome); multiple VMs for the same book observe the same coordinator job |
+| `ChapterReTranslateViewModel` (`ViewModels/`) | `AIService` + `ChapterTranslationService` + `ChapterTranslationStore` | Feature #56 WI-15 `@MainActor @Observable` UI-facing state for the per-chapter re-translation flow. `presentPicker(...)` opens `ReTranslatePickerSheet` with the chosen unit + title + target language; `updateSelection(_:)` mutates the picker's `(providerProfileID, model, style, keepGlossary)` selection; `submit()` resolves the picker's `ResolvedAIProviderConfig` through the `RetranslateProviderResolving` boundary (`AIService` conforms), runs the translation through `ChapterReTranslating` (`ChapterTranslationService` conforms, with the cache READ bypassed so a fresh row can't no-op the re-translate — Bug #341 atomic swap + Bug #342 canonical key: the cache-write replaces the ONE `book|unit|lang|prompt` row in place, the original translation survives every failure/cancel path, and an override re-translation is readable by bilingual mode on reopen), and fires `onTranslationApplied` so the host posts `.readerBilingualReTranslateApplied`. Picker override never mutates `ProviderProfileStore` (acceptance criterion (f)) |
+| `EPUBBilingualPipeline` (`Views/Reader/Bilingual/`) | `EPUBBilingualJS` + `EPUBBilingualOrchestrator` | Feature #56 WI-10 pure glue between the EPUB WKWebView's `bilingualEnumerate` message payload and the `BilingualReadingViewModel`'s `translationsByUnit` cache. `parseEnumeratePayload(_:)` decodes the raw `Any` body into an `EPUBBilingualEnumeratePayload` (`{requestedSectionIndex, blocks}`) — accepting BOTH the paged bare-array shape (`[{bid,text}]`, no section identity) and the continuous-scroll envelope (`{sectionIndex, blocks}`); the envelope preserves the section identity on an EMPTY result so the container clears ONLY that section's bucket instead of every bucket (Feature #71 WI-7 Gate-4 round-3 MEDIUM 1). `parseEnumerateMessage(_:)` is the flat-`[BilingualBlock]` convenience over it; `translationsByBid(blocks:translatedSegments:)` maps the VM's ordered segment array onto a `[bid: text]` lookup by position. No `@MainActor` — pure value transforms |
+| `EPUBBilingualOrchestrator` (`Views/Reader/Bilingual/`) | `EPUBBilingualJS` + `EPUBBilingualPipeline` | Feature #56 WI-10 host-side `@MainActor @Observable` controller, one per open EPUB. Holds the current chapter's `[BilingualBlock]` list; emits enumerate / inject / clear JS for the bridge to evaluate. Stateless beyond the block list — the container drives transitions via `enumerateJS()` on `didFinish`, `updateBlocks(_:)` on the enumerate callback, `buildInjectJS(translatedSegments:)` when the VM's prefetch lands, and `clearJS()` on disable / chapter swap |
+| `FoliateBilingualPipeline` (`Views/Reader/Bilingual/`) | `FoliateBilingualJS` + `FoliateBilingualOrchestrator` | Feature #56 WI-11 — AZW3/MOBI sibling of `EPUBBilingualPipeline`. Same two static functions (`parseEnumerateMessage(_:)`, `translationsByBid(blocks:translatedSegments:)`) with the same shapes; reuses the `BilingualBlock` value type so the enumerate → translate → inject contract is byte-identical across formats. Independent file so format-specific test invariants don't cross-contaminate |
+| `FoliateBilingualOrchestrator` (`Views/Reader/Bilingual/`) | `FoliateBilingualJS` + `FoliateBilingualPipeline` | Feature #56 WI-11 — AZW3/MOBI sibling of `EPUBBilingualOrchestrator`. `@MainActor @Observable` controller, one per open AZW3/MOBI book. Owned by `FoliateBilingualContainerView`; emits enumerate / inject / clear JS that the container posts through `.foliateRequestBilingualEvalJS` for the live `FoliateSpikeView.Coordinator` to evaluate against its `WKWebView` |
+| `FoliateBilingualContainerView` (`Views/Reader/`) | `FoliateSpikeView` + `FoliateBilingualOrchestrator` + `BilingualReadingViewModel` + `FoliateChapterTextProvider` | Feature #56 WI-11 — AZW3/MOBI host wrapper that adds the bilingual VM / orchestrator / setup-sheet wiring around the unchanged `FoliateSpikeView`. Owns the bilingual `@State`, the first-enable `BilingualSetupSheet`, and the notification plumbing (`.readerMoreBilingual` → toggle, `.foliateSectionLoaded` → enumerate, `.foliateBilingualBlocksEnumerated` → cache + prefetch, `.readerBilingualDidChange` → inject) that mirrors `EPUBReaderContainerView+Bilingual` for the live Foliate path |
+| `BilingualDisplaySegmentMap` (`Services/Reader/`) | `BilingualTextRenderer`, `TXTReaderContainerView`, `MDReaderContainerView` | Feature #56 WI-12a pure `Sendable` value type — the TXT/MD source↔display UTF-16 offset map. Records ordered display segments tagged `.source(sourceRange:displayRange:)` or `.synthetic(displayRange:)`. `sourceOffset(forDisplayOffset:)` returns `nil` for synthetic ranges or out-of-bounds offsets; `displayOffset(forSourceOffset:)` clamps a past-end source position to display end. `identity(sourceLength:)` builds the 1:1 pass-through used when bilingual is off. WI-12b consumes the map in TXT/MD container offset-routing |
+| `BilingualTextRenderer` (`Views/Reader/Bilingual/`) | `BilingualDisplaySegmentMap` | Feature #56 WI-12a pure interlinear builder for TXT/MD. `render(sourceText:sourceParagraphRanges:translatedSegments:)` returns the rendered `NSAttributedString` (source paragraphs interleaved with synthetic translation runs, each carrying the `decorationAttributeKey` attribute) plus the matching `BilingualDisplaySegmentMap`. Nil or empty translations fall back to source + identity map. Partial translations inject the prefix and leave the tail source-only (plan Decision 2's silent-source-fallback). WI-12b wires the renderer's output into the live TXT/MD UITextView |
+| `BilingualParagraphRanges` (`Services/Reader/`) | `BilingualTextRenderer`, `BilingualDisplayPipeline` | Feature #56 WI-12b — pure paragraph-range scanner that splits a TXT/MD chapter's source text into UTF-16 paragraph ranges. Blank-line-separated content lines fuse into one paragraph (matches reflow conventions); blank lines + leading/trailing whitespace are excluded from ranges. Feeds the interlinear renderer's `sourceParagraphRanges` argument. Pure O(N) UTF-16 single-pass — covers CRLF / CJK / interspersed-blank-line edge cases |
+| `BilingualAttributedStringComposer` (`Views/Reader/Bilingual/`) | `BilingualDisplaySegmentMap`, `BilingualTextRenderer` | Feature #56 WI-12b — typography-preserving interlinear composer. `compose(sourceAttributed:sourceParagraphRanges:translatedSegments:)` takes an already-typographed source `NSAttributedString` (font, line spacing, drop-cap, heading restyle) and interleaves synthetic translation runs at paragraph boundaries. Synthetic runs inherit the prior source paragraph's attrs + carry the `decorationAttributeKey`. Used by TXT's chapter-paged path so the chapter-start drop-cap + heading restyle survive the bilingual interleave |
+| `BilingualDisplayPipeline` (`Views/Reader/Bilingual/`) | `BilingualTextRenderer`, `BilingualAttributedStringComposer`, `BilingualReadingViewModel` | Feature #56 WI-12b — `@MainActor` bridge between the bilingual VM state and the renderer/composer. `makeDisplay(...)` builds a fresh attrString from a plain `String` source; `compose(sourceAttributed:...)` preserves an upstream typographed attrString. Both off-path (no VM / disabled / no unit / no cached translation) returns the source + identity map — the byte-identical pass-through that gates the R-TXT-offsets risk |
+| `BilingualOffsetRouter` (`Views/Reader/Bilingual/`) | `BilingualDisplaySegmentMap` | Feature #56 WI-12b — pure source↔display offset router for the TXT/MD container's bilingual surfaces. Helpers: `displayOffset(forSourceOffset:map:)`, `sourceOffset(forDisplayOffset:map:)`, `displayRange(forSourceRange:map:)` (segment-union projection — a source range that crosses an intervening synthetic block produces a spanning display range), `displayNSRange(forSourceNSRange:map:)`, `isSynthetic(displayOffset:map:)`. Identity-map mode is byte-identical to today's offset code |
+| `BilingualTXTBridgeDelegateAdapter` (`Views/Reader/Bilingual/`) | `BilingualDisplaySegmentMap`, `TXTTextViewBridge` | Feature #56 WI-12b — `@MainActor` delegate wrapper that maps display-domain offsets the bridge reports (selection range, top-visible-char scroll offset) back to source-domain offsets via `BilingualOffsetRouter`, so the TXT VM keeps persisting positions in document source coordinates with bilingual on. A selection that starts inside a synthetic translation run is dropped; a scroll-into-synthetic projects to the end of the preceding source segment. Identity map (bilingual off) is a transparent pass-through |
+| `TXTLoaderBackedChapterTextProvider` (`Services/Reader/`) | `ChapterTextProviding`, `TXTChapterContentLoader` | Feature #56 WI-12b — chapter-paged-mode `ChapterTextProviding` adapter that reads each chapter on demand via the live reader's `TXTChapterContentLoader` actor. Sibling to `TXTChapterTextProvider` (full-book-slicing). Re-enables bilingual mode for chapter-paged TXT, the mode WI-12a's `makeTextProvider` explicitly disabled because the VM's `textContent` is chapter-local in that mode |
+| `PDFBilingualPanel` (`Views/Reader/Bilingual/`) | `PDFBilingualPanelState`, `BilingualLanguage`, `ReaderThemeV2` | Feature #56 WI-13 — PDF below-page bilingual translation panel. Stateless SwiftUI sub-view rendering the design's split-layout A1..A8: header (lang-glyph chip + page label + status suffix + chevron) + body switched on `PDFBilingualPanelState` (5 states: `.off` / `.loading` / `.translated([String])` / `.offline` / `.empty`). PDF is fixed-layout so the paragraph-interlinear renderer used by EPUB/Foliate/TXT/MD doesn't apply; the panel below the page is the entire user-visible bilingual surface for PDF. 260pt expanded / 38pt collapsed; attached to `PDFViewBridge` via SwiftUI's `.safeAreaInset(edge: .bottom)` so PDFKit's `autoScales` reflows the page rendering automatically |
+| `PDFBilingualPanelState` (`Views/Reader/Bilingual/`) | `BilingualReadingViewModel`, `PDFChapterTextProvider` | Feature #56 WI-13 — pure synchronous derivation of the panel's 5-state matrix from the bilingual VM + the PDF's `(currentPage, pagesPerUnit, totalPages)` triple. Computes the current `TranslationUnitID` synchronously (mirrors `PDFChapterTextProvider.pageRanges` arithmetic) instead of reading the VM's async-updated `lastTriggerUnit`, so page-turn-in-flight doesn't flash stale translations (Gate-2 v5 round-1 H1). `.empty` keyed on "translated segments empty after fetch" OR "totalPages <= 0", NOT `unit == nil` (which would never fire for a real PDF — Gate-2 v5 round-1 M1) |
+| `PDFReaderContainerView+Bilingual` (`Views/Reader/`) | `BilingualReadingViewModel`, `PDFChapterTextProvider`, `PDFBilingualPanel`, `PDFBilingualPanelState` | Feature #56 WI-13 — PDF host extension owning the bilingual VM lifecycle (lazy construction gated on `viewModel.isDocumentLoaded` + `totalPages > 0`), the `PDFChapterTextProvider` build, the prefetcher build (mirrors TXT/EPUB `makePrefetcher`), the first-enable setup sheet, the More-menu toggle observer, the retry observer (`.readerBilingualRetry`), and the `.safeAreaInset`-attached panel. On reopen of an already-enabled book, `ensureBilingualViewModel` kicks the initial `handlePositionChange` so the panel doesn't stick in `.loading` for the open page (Gate-4 round-1 H1). Mirrors `TXTReaderContainerView+Bilingual` / `MDReaderContainerView+Bilingual` / `EPUBReaderContainerView+Bilingual` structurally |
+
+### 6. Data Layer (`vreader/Models/`)
+
+SwiftData SchemaV10 entities (V9→V10 adds the additive optional `Book.sourceCanonicalKey: String?` — feature #108's converted-Kindle cross-platform identity, carried in the backup manifest; feature #109's NFC locator-key recompute runs as the launch-time `LocatorKeyBackfillMigration`, not a schema migration — see the App Layer note above):
+
+- `Book` (fingerprintKey unique; gains `originalExtension: String?` in SchemaV5 for backup blob extension preservation; gains `fileState: String` and `blobPath: String?` in SchemaV6 for feature #47's lazy-load row state; gains `sourceCanonicalKey: String?` in SchemaV10 — feature #108's converted-Kindle source-bytes cross-platform identity, while the converted-EPUB `fingerprintKey` stays the local primary) → `ReadingPosition` (gains `vreaderLocatorData: Data?` in SchemaV8 — feature #42's engine-agnostic `VReaderLocator` envelope, stored as raw JSON `Data?` mirroring `Highlight.anchorData`; additive/optional → lightweight migration, no stage), `Highlight`, `Bookmark`, `AnnotationNote`, `BookCollection`, `ChatSession` (SchemaV9 cascade child)
+# 48 — Parallel Execution
+
+## Purpose
+
+Parallelism is an **isolation tool first and a speed tool second**. Use it when it reduces wall-clock time without weakening review, audit, TDD order, or resource ownership. Use it wrong and you trade serial work for merge hell, audit gaps, or simulator flakiness.
+
+This rule applies to: spawning subagents, launching parallel `/fix-issue` runs, splitting work across git worktrees, or running concurrent feature implementations.
+
+## Decision test
+
+Before parallelizing, estimate honestly:
+
+```
+expected wall-clock saved  >  setup + review + conflict + resource-contention + failure cost
+```
+
+| Cost | What it covers |
+|---|---|
+| **setup** | Worktree creation, branch hygiene, subagent brief writing, DerivedData warmup |
+| **review** | Main-agent integration time when subagent returns |
+| **conflict** | Shared file edits (`project.yml`, `docs/features.md`, `docs/architecture.md`) → rebase |
+| **resource** | Single simulator, single device, one Codex/test session at a time |
+| **failure** | Probability the subagent drifts and needs collapse + redo |
+
+If the answer isn't clearly positive, don't parallelize.
+
+## Hard rules (non-negotiable)
+
+1. **Author/auditor separation**: the agent that writes a plan, code, or PR is never the agent that audits it. (cc-suite running Codex as a separate `codex exec` process satisfies this by accident; preserve the boundary explicitly.)
+2. **Hard dependency blocks downstream Gate 3**: if feature B depends on feature A, you cannot start B's TDD until A is `DONE`. Dependency graph in the tracker is the source of truth.
+3. **One writer per file/area at a time**: two agents can work the same feature if their write sets are disjoint and explicit. Two agents writing the same file is a merge conflict you will lose.
+
+## Cross-platform write isolation (Android port — feature #103 Phase 0)
+
+The repo now hosts two native apps (iOS at the root, Android under
+`android/`). Their *code* is disjoint, but the automation, trackers,
+contracts, designs, and release config are **shared, contended** surfaces.
+To prevent the `project.pbxproj`-contamination class (PR #1029) from
+recurring across the platform split:
+
+- **Android/Kotlin agents MUST NOT touch iOS code** — never `vreader/`,
+  `vreaderTests/`, `*.xcodeproj`, `project.yml`.
+- **iOS/Swift agents MUST NOT touch Android code** — never `android/`,
+  `spikes/`, `buildSrc/`, `gradle/`, root Gradle files, `gradlew*`,
+  `gradle.properties`, `*.kt`/`*.kts`, `AndroidManifest.xml`, or any
+  Android `res/` tree (the full set the audit classifier gates).
+- **Shared surfaces get a single writer per change**: `docs/*` (incl.
+  `dev-docs/*` — plans, designs, verification evidence), `contracts/*`,
+  `.claude/*`, `AGENTS.md`, root shared docs (`README.md`, `CLAUDE.md`),
+  release config. The existing "one writer per area" rule applies; the
+  platform split just makes the boundary explicit. A `contracts/`-touching
+  change is the canonical multi-platform-impacting edit — give it one owner
+  and the versioned contract merge gate (ADR-0001), not two parallel writers.
+- The audit gate's code-path classifier (`.claude/hooks/lib/code-paths.sh`)
+  decides which PRs need a Codex audit (code vs docs/meta); it's the
+  reference for the Android/Kotlin/`contracts/` paths above, but it is a
+  boolean gate, not a full ownership taxonomy.
+
+## Strong defaults (negotiable with cause)
+
+- Shared-file edits (status flips, version bumps, doc-sync) require **one owner** or a **final integration pass**. They batch at PR merge time, not in parallel.
+- Planning subagents are **read-only by default** — return content/patch for the main agent to apply. Write access only when the subagent has its own worktree.
+- Parallel Xcode builds require **explicit simulator/device ownership**. Otherwise contention produces misleading test failures.
+
+## Subagent contract (every spawn must specify)
+
+| Field | Required content |
+|---|---|
+| **Objective** | One sentence — what deliverable you want |
+| **Inputs** | Exact file paths to read; relevant audit-gap context (don't rely on "absorbing" parent conversation) |
+| **Allowed writes** | Either "none" (read-only, return content) or a specific path prefix |
+| **Forbidden actions** | What it must NOT do (e.g., "no Swift code", "no `xcodebuild`", "no PR") |
+| **Output format** | What the return message must contain |
+| **Stop condition** | When to return — explicit completion criteria |
+
+A subagent without one of these will drift.
+
+## Subagent failure handling
+
+- Subagent output is **advisory until reviewed** by the main agent.
+- If it drifts, **re-brief once** with a narrower task. Don't ask it to self-correct indefinitely.
+- If still bad, **collapse to the main agent**. Discard the subagent's output.
+- **Never merge or apply** generated code/plan text without main-agent review.
+
+## Decision matrix (gate-by-gate)
+
+| Two work units' state | Approach |
+|---|---|
+| Both Gate 1 (planning) | Single agent, sequential — context switch is cheap |
+| Mixed Gate 1 (planning) + Gate 3 (TDD) | Inline Gate 3 + read-only subagent for Gate 1 (tight brief) |
+| Both Gate 2 (plan audit) | Parallel OK — independent Codex sessions, different threads |
+| Same feature, Gate 2 of plan + Gate 3 of WI on same plan | **Serialize** — never implement against an unaudited plan |
+| Both Gate 3 (TDD) on disjoint files | Worktrees + one agent each |
+| Both Gate 3 (TDD) on overlapping files | **Serialize** — one writer per area |
+| Same feature, WI-N-1 Gate 5 + WI-N Gate 3 | Parallel only if WI-N doesn't depend on WI-N-1's verification result |
+| Both Gate 4 (impl audit) | Parallel OK — independent audits |
+| Both Gate 5 (verification) | **Serialize** — single device/simulator |
+| Mixed Gate 5 + Gate 3 | Parallel OK — different resources |
+
+## Worktree rules
+
+- Use a worktree when **isolation prevents more cost than it adds**. A 30-min high-risk schema change can deserve one; a 4-hour docs-only plan rarely does.
+- Worktrees go under `.claude/worktrees/<feature-or-issue-id>/`.
+- After removing a worktree, **clean its DerivedData**: each worktree creates its own (~5GB). The `/fix-issue` skill's multi-issue mode includes the cleanup pass; replicate it.
+- Never give two concurrent agents the same worktree. One worktree = one writer.
+- The main checkout's working tree must be clean before spawning a worktree-based agent — pre-existing dirty state poisons the agent's git context.
+
+## Worktree cwd discipline (binding for every worktree-isolated agent)
+
+**Failure mode.** When the orchestrator spawns a subagent with `Agent(subagent_type: claude, isolation: worktree, ...)`, the Agent harness creates the worktree but does **NOT** set the spawned subprocess's initial cwd to the worktree path. The agent's Bash tool starts with `cwd = orchestrator's cwd` (typically `/Users/ll/workspace/vreader`, the main checkout). The agent must explicitly `cd "<worktree-path>"` at the start of **every** Bash call. The Bash tool persists cwd between calls in a single session, but a single early call from the wrong cwd writes files to the wrong place — and any later `xcodegen generate` in the contaminated main checkout will fold those stray files into `vreader.xcodeproj/project.pbxproj`, producing a build that fails on any clean clone with "file not found in compile sources".
+
+**Standing precedent.** This class of bug has manifested multiple times:
+
+- **v3.37.18 → v3.37.19 hotfix (PR #1029)**: the WI-7b → WI-8 transition shipped stray `ReaderMoreMenuBilingualTests.swift` references in `project.pbxproj` without the source file being git-tracked. Required a dedicated hotfix PR to restore main.
+- **Bugfix #957 agent self-report**: the agent caught itself mid-flow — "my first 4 Bash calls accidentally cd'd into /Users/ll/workspace/vreader (main checkout) instead of staying in the worktree, so the initial RED→GREEN cycle ran in the main repo. I patched this mid-flow by saving the diff to /tmp, reverting the main checkout, and re-applying the patch inside the worktree on the proper branch before committing." Self-rescue, no main contamination shipped, but only because the agent noticed.
+- **Bug #241 filing (2026-05-20)**: filed by the verify cron after 3+ recurrences in a single session.
+
+The session-tested workaround: **the briefs from WI-10 onward all included an explicit "cd "<worktree-path>" first" discipline in their preamble, and no contamination recurred for the agents that received that discipline.** This subsection codifies that workaround into a rule.
+
+**Mandate.** Every worktree-isolated agent's brief MUST include a "Critical Operational" preamble that:
+
+1. States the exact worktree path the agent is expected to operate inside.
+2. Requires `cd "<worktree-path>"` at the **start of every `Bash` tool call** — not just the first one. (A single later call that omits the prefix can silently land work in the main checkout.)
+3. Requires `pwd` confirmation in the first Bash call, before any edit or write, so the agent fails loudly if it's not where it expects to be.
+4. Names the consequence explicitly so the agent treats the discipline as load-bearing, not decorative: contaminating main produces broken builds on clean clones and costs a hotfix PR.
+
+This requirement applies to **every** worktree-isolated agent spawn — feature agents, bugfix agents, audit subagents, verification subagents. There is no "small task" exemption; the contamination cost is the same whether the agent writes one file or twenty.
+
+**Copy-pasteable preamble template** (orchestrators: paste verbatim into the brief, substituting the worktree path):
+
+```
+## CRITICAL OPERATIONAL — binding
+
+Your worktree path is: <ABSOLUTE-WORKTREE-PATH>
+
+Every `Bash` tool call you issue MUST begin with `cd "<ABSOLUTE-WORKTREE-PATH>"`.
+Before your first edit or write, run `pwd` and confirm it prints the worktree
+path. If `pwd` does NOT match, stop and report — do NOT attempt to recover by
+guessing.
+
+The Agent harness creates the worktree but does NOT set your initial cwd to
+it. Your Bash tool starts with cwd = the orchestrator's main checkout
+(`/Users/ll/workspace/vreader`). A single Bash call that forgets the `cd`
+prefix can write to the main checkout instead of your worktree; a later
+`xcodegen generate` then folds stray files into `project.pbxproj` and breaks
+the build on every clean clone. Standing precedent: PR #1029 (v3.37.19) was a
+hotfix for exactly this pattern; bug #957's agent self-rescued from the same
+drift mid-flow.
+
+This is binding for every Bash call, not just the first. Do not skip this in
+the interest of brevity.
+```
+
+**Orchestrator checklist when spawning a worktree-isolated agent.** Before sending the brief:
+
+- [ ] The brief includes the "Critical Operational" preamble (or an equivalent that names the cwd, the `pwd` confirmation, and the consequence).
+- [ ] The worktree path is the **absolute** path, not a relative one.
+- [ ] If the brief includes multi-step bash sequences, every step starts with `cd "<worktree-path>"` (compound commands `cd X && Y && Z` are fine — what's not fine is a later Bash call that omits the prefix and assumes the previous call's cwd persists).
+- [ ] If the agent reports something that smells like contamination (PR has unexpected `project.pbxproj` references, `git status` in main checkout shows files the agent shouldn't have written), treat the agent's output as suspect and verify by inspecting the main checkout's working tree before merging.
+
+## Lane dispatch (feature #130 — THE sanctioned fan-out mechanism)
+
+Multi-item parallel work runs through **`/dispatch`**
+(`.claude/skills/dispatch/SKILL.md`) under the **rule 55** lane contract —
+worktree-isolated `implementer` lanes on leased simulators
+(`scripts/sim-lease.sh`), write-sets gated by `scripts/check-write-set.sh`,
+dependencies gated by `scripts/deps-check.sh`, one global `dispatch` lock
+(`scripts/agent-lock.sh`), a serial integration tail with version-at-slot,
+and ≤2 lanes (width 1 default). Lane briefs are GENERATED from the dispatch
+skill's template — never hand-written — and always embed this rule's
+"Critical Operational" preamble verbatim. The subagent contract above now
+includes the rule-55 HANDOFF JSON as the required return format for lanes.
+Hand-rolled multi-worktree orchestration (the old fix-issue M1–M5 prose) is
+dead — see the dispatch skill's "Dropped by design" section.
+
+## Worked examples
+
+**Good — mixed gates, this session's `#46 WI-0a + #48 planning`**:
+- Main agent on `feat/46-wi-0a-...` branch implementing Swift code (Gate 3).
+- Spawned read-only subagent reading 14 files + writing one markdown plan to `dev-docs/plans/20260503-feature-48-...md` (Gate 1).
+- No file-write overlap. Subagent's output reviewed and integrated by main agent.
+
+**Good — `/fix-issue` multi-issue mode**:
+- N issues, N worktrees, N agents. Each runs its own pipeline. Cleanup pass removes stale DerivedData after each worktree is removed.
+
+**Bad — would have been wrong**:
+- `#46` and `#47` in parallel: hard dependency (`#47` needs `#46`'s blob storage layout). Tracker says so explicitly. Parallelizing would have wasted `#47`'s implementation.
+
+**Bad — would have been wrong**:
+- Spawning a subagent with prompt "implement WI-0a, you have full context" — context absorption fails; the subagent will misremember field names and produce uncompilable code.
+
+## What this rule does NOT cover
+
+- Per-PR parallelism (CI runs across PRs) — handled by the CI infrastructure, not this rule.
+- Agent-to-agent communication mid-flight — out of scope; subagents are fire-and-forget with single return.
+
+exec
+/bin/zsh -lc "rg -n \"H1|H2|M1|M2|M3|FOLD|WI-AIP|WI-4b|Dependencies|dependency|13 work|endExclusive|chunkForOffset|Sentence selection|EpubBilingualController|prefetchTasks|CancellationException|AiRequest.model|ifBlank|ReaderAiProvidersSheet|aiConfigured|setActive|#136|#132|#134\" dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md && rg --files android vreader dev-docs/designs | rg '(TxtDocument|TxtReaderActivity|AiChatViewModel|Provider|AiProviderStore|VReaderApp|BilingualReadingViewModel|ChapterTranslationService|vreader-bilingual|reader-ai-provider-entry)'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+3:**Feature number assumption:** highest active row in `docs/features.md` is `#136` (now CLOSED, see below); `#131` is a landed `PLANNED` row (`GH: #1923`). The orchestrator adjusts if a row is claimed first.
+8:- **The in-reader AI-config surface (folded in from the closed #136):** `dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md` (the CANONICAL **Variant A** decision + navigation model, lines ~39–76, ~110–134) and `.../vreader-ai-provider-entry.jsx` (`AIProvidersSheet`, `BilingualEngineStrip`, `NavSheet`). `reader-ai-readiness.md` (iOS #82) is **informational only** — its 4-gate readiness (feature flag + consent manager + provider + key) is iOS-specific and **implementation-deferred**; Android #118 has no feature flag and no consent manager, so the Android readiness gate is provider+key only (see §"AI-config reachability").
+12:**Status:** Gate-1 draft **v4** (2026-07-12) — Gate-2 round-3 (block-recommended) findings resolved AND the AI-config path folded in (#136 closed). Awaiting Gate-2 round-4 audit.
+18:The engineering questions are (a) **which render host(s)** get true interlinear, (b) **what the real TXT/MD segmentation unit is** (there is no chapter model — round-2 H1), (c) **how the enabled render preserves the live per-chunk layout/selection model** (round-3 H2), and (d) **where the entry point AND the AI-config path live**. The render-host feasibility was settled in v2 (EPUB-primary via Readium `EpubNavigatorFragment.evaluateJavascript`; TXT/MD Compose; AZW3/PDF deferred) and was **CONFIRMED correct by the Gate-2 round-2 audit** — it is not revisited here. This v4 resolves the round-3 findings that concern *how the pipeline maps to real code* and folds in the AI-config reachability that the design proved is inseparable from the bilingual flow:
+21:- **TXT/MD unit (round-2 H1)** — `TxtDocument` has NO chapter model; it is line-based ≤4000-char chunks addressed by UTF-16 offset. v4 defines **document-global units with segment UTF-16 ranges produced ONCE by the segmenter** and renders source/translation pairs from those same ranges, with the **round-3 H1 final-chunk math fix** and the **round-3 H2 additive-item render contract** (§2, §3).
+22:- **Entry point** — the design puts the toggle in the **More-menu** (`vreader-more.jsx`; the live `MoreActionId.BILINGUAL` id is already reserved, and `MoreRow.Toggle` carries `on`/`onToggle` — `reader/more/MoreRow.kt:24,56–63`) + a **top-chrome pill** (`vreader-reader.jsx`). Both landed as box-F sub-features **#132 (top chrome) and #134 (More menu), now VERIFIED** — the entry wiring targets them directly (§4).
+23:- **AI-config path (folded in — #136 CLOSED)** — the ONLY designed Android AI-config reader surface is the **Variant A scoped "AI Providers" sheet pushed inside the bilingual flow**, reached from the bilingual engine strip's "Set up"/"Change…" button (`reader-ai-provider-entry.md`). #131 now owns it end-to-end (§"AI-config reachability", WI-4b + WI-AIP + WI-9).
+29:**Two hosts, in dependency order:**
+31:1. **EPUB (Readium `EpubNavigatorFragment`) — PRIMARY.** Interlinear via `evaluateJavascript` (enumerate leaf blocks → inject translation DOM nodes → clear on teardown/reflow), mirroring iOS `EPUBBilingualOrchestrator`. Gated by **WI-0 (a Readium bilingual spike with enforceable go/no-go thresholds + a navigator-race contract — round-2 M1)** before the EPUB render WI (WI-7b) is built.
+32:2. **TXT/MD (Compose `TxtReaderActivity`) — INCLUDED.** No WebView; deterministically Compose-testable. Renders translations as **additive `LazyColumn` items at chunk (line) boundaries** — the source chunk `Text` is never split (round-3 H2), from **document-global segment ranges** (round-2 H1).
+38:### The TXT/MD segmentation unit + render mapping (round-2 H1 + round-3 H1/H2 — the core corrections)
+40:**Verified against live code:** `TxtDocument` (`reader/TxtDocument.kt`) exposes only `text: String`, `chunkCount` (`starts.size`, TxtDocument.kt:14), `offsetForChunk(index)` (TxtDocument.kt:17), `chunkForOffset(offsetUtf16)` (TxtDocument.kt:23), `textForChunk(index)` (TxtDocument.kt:36) — line-based ≤4000-char chunks over UTF-16 offsets against the RAW text (no line-ending normalization). It has **no chapter/section concept**.
+49:- The whole `.txt`/`.md` is treated as **one translation document**. The **segmenter runs once over `TxtDocument.text`** (the full raw backing string) and emits, per segment, its **half-open UTF-16 span `[start, endExclusive)`** against that same backing string (the segmenter's `paragraphRanges(text): List<IntRange>` / `sentenceRanges(text): List<IntRange>` — the range-returning peers of `paragraphs`/`sentences`; iOS precedent `ChapterSegmenter.sentenceRanges(in:)` at `ChapterSegmenter.swift:78`, returns `[Range<Int>]`). These ranges are the SINGLE source of truth used by BOTH the translate side and the render side, so the two segment identically **by construction** (they read the same array). Ranges are stored/compared as explicit `(start, endExclusive)` integer pairs (see the H1 fix below), NOT re-derived on the render side.
+50:- **Unit granularity for TXT/MD is the whole document, sub-batched for cache/prefetch by a deterministic "unit window."** To avoid translating a 14 MB book at once (and to keep cache rows bounded), segment ranges are grouped into fixed **unit windows** of contiguous segments (window size a build-time constant; it does not change the 1:1 contract). Each window is a `TranslationUnitId(kind = txtDocSegmentWindow, value = windowIndex)` — a document-global index, NOT a chunk index. `unitContaining(charOffsetUTF16)` maps the reader's saved offset → the segment whose range contains it → its window index (via a precomputed segment-start binary search, the same shape as `TxtDocument.chunkForOffset`, TxtDocument.kt:23–33). `unitAfter(unit)` = next window index or null at document end.
+52:#### H1 fix (round-3 High-1) — final-chunk source span math (BINDING)
+57:val endExclusive = if (i + 1 < document.chunkCount) document.offsetForChunk(i + 1) else document.text.length
+58:// chunk i source span is the HALF-OPEN [document.offsetForChunk(i), endExclusive)
+61:- All chunk-span and segment-span computations use **explicit half-open `[start, endExclusive)` integer pairs**, NOT ambiguous Kotlin `IntRange` (an `IntRange` is inclusive-inclusive and `range.last` for an empty/at-EOF segment is a footgun). A segment's "end offset" for anchoring (below) is its `endExclusive`; the chunk that "contains a segment's end" is `document.chunkForOffset(segEndExclusive - 1)` when `segEndExclusive > segStart`, clamped to `[0, chunkCount-1]` (an empty segment is dropped by the segmenter and never anchored).
+64:#### H2 fix (round-3 High-2) — the enabled render contract (BINDING; preserves the live per-chunk model)
+70:> **Translations are ADDITIVE `LazyColumn` items rendered at CHUNK (line) boundaries. A source chunk's `Text` is NEVER split.** The existing `items(count = document.chunkCount, key = { it })` source loop stays **byte-identical to today** — same one `Text`, same one `TextLayoutResult`, same one `registerChunk(i, …)`/`unregisterChunk(i)`, same `highlightSpan(i)`/`washesForChunk(i)`/`selectionForChunk(i)` wiring. Each **translation is a NEW, separate `LazyColumn` item** inserted **AFTER** the source chunk that contains the segment's **end** offset (`document.chunkForOffset(segEndExclusive - 1)`, per the H1 math). The translation item is a plain muted `Text` (accent left-border, `fontSize*0.88`, CJK/RTL styling per `BilingualPageContent`) that is **non-selectable and registers NO chunk** — it does not call `registerChunk`, contributes no `TextLayoutResult` to the selection controller, and does not perturb any source chunk's UTF-16 offsets or index `i`.
+75:2. Look up the translations **anchored** to chunk `i` = every segment whose end resolves to `chunkForOffset(segEndExclusive - 1) == i`, in segment order, from the shared range array. For **paragraph** granularity there is at most one such translation per anchor chunk in the common case (a paragraph's translation renders after the paragraph's last line-chunk). For **sentence** granularity, when several sentences END in the same line-chunk (one line, multiple sentences), their translations are **grouped** and rendered as a stack of muted items after that chunk, in sentence order.
+76:3. Emit each anchored translation as its own additive item (keyed by the segment's `(start, endExclusive)` so a granularity/language change re-keys cleanly).
+80:- **Enabled-mode tests (WI-8 connected + WI-7a Compose, BINDING):** with bilingual ON — (a) each source chunk's **selection registration is UNCHANGED** (same `registerChunk(i, …)` count and coordinates as OFF; a translation item registers nothing); (b) **highlights/annotation washes/read-aloud wash still key off the source chunks** at the correct offsets (a translation item between chunks does not shift them); (c) a **translation item is non-selectable** and does not perturb source offsets (selecting across the boundary selects source only); (d) **MD source mapping** — the markdown renderer (`mapper.renderedText(i)`, TxtReaderActivity.kt:1049) still owns the source chunk render; the translation item is plain muted text; (e) **paragraph-spanning-many-chunks** renders exactly ONE translation (after the paragraph's last chunk), never per-line; (f) final-chunk/one-chunk anchors render (H1).
+82:- **Granularity depiction (round-3 H2 — rule-51 call, stated with evidence):** `vreader-bilingual.jsx` `BilingualPageContent` (lines 200–277) is a **paragraph-interlinear** renderer: it maps `page.paragraphs.map(...)` and renders **one source `<p>` followed by ONE translation `<p>`** per paragraph. **Sentence-granularity interlinear (a translation after the line where each sentence ends, grouped when several sentences share a line) is NOT depicted anywhere** — sentence granularity appears ONLY as an option in the `BilingualSetupSheet` Granularity segmented control (`vreader-bilingual.jsx:85–99`), never in the renderer. **Call:** paragraph granularity IS the depicted interlinear pattern and **ships in v1**. The **sentence-granularity render is a rule-51 design gate** (named precisely below) — v1 ships the setup-sheet Granularity control (both options selectable, as depicted) but the **renderer implements only the depicted paragraph pattern**; selecting Sentence in v1 falls back to the depicted paragraph interlinear (the granularity is still carried in the cache key so no wrong-shape row is served) until the sentence-interlinear render is designed. This keeps rule 51 (implement only what is depicted) while shipping the depicted paragraph parity. (The additive-item render contract above is written to accommodate sentence grouping so the gate, once designed, is a render-only follow-up.)
+86:This closes H1 (no dropped final-chunk translations), H2 (per-chunk layout/selection preserved; source `Text` never split), and Low-2 (correct chunk semantics).
+88:### AI-config reachability — FOLDED IN (#136 CLOSED; Variant A owned by #131)
+92:The Gate-2 audits + the two design-notes proved the ONLY designed Android AI-config reader surface is **Variant A** (`reader-ai-provider-entry.md`, CANONICAL): a **scoped "AI Providers" sheet pushed _inside_ the bilingual sheet**, reached from the bilingual engine-strip's "Set up"/"Change…" button. The design explicitly **rejected** a standalone entry (there is NO designed standalone More-menu "Configure AI" row), a full-Settings deep-link (alternative B), and inline expansion (alternative C). So AI-config reachability is **NOT separable** from the bilingual flow — the #136 spin-out is **CLOSED (GH #1976, not-planned)** and **#131 now owns it end-to-end** (user decision 2026-07-12).
+102:     ReaderAiProvidersSheet  [nav bar: ‹ Bilingual · "AI Providers"]
+114:- **"Change…"** (already-configured strip) opens the **SAME** `ReaderAiProvidersSheet`, populated, current provider checked.
+117:**Android readiness gate (BINDING — round-3/round-2 H3 + the #136-audit High-3 lesson):** `aiConfigured` on the engine strip is derived by `BilingualAiReadiness.resolve(snapshot)` = **an ACTIVE profile exists AND its API key decrypts to non-empty.** Deriving from `profiles.isEmpty()` alone is **WRONG**: the store keeps a separate `activeId` that can be **null with profiles present** (`AiProviderSnapshot.active = profiles.firstOrNull { it.id == activeId }`, AiProviderStore.kt:34–36), and key usability depends on **decrypting the active profile's token** (`apiKey(profile) = cipher.decrypt(profile.encryptedApiKey)`, AiProviderStore.kt:108). A cipher/keystore failure maps to **not-ready, never a crash** (the resolve wraps the decrypt in `runCatching`). **Note:** the iOS Variant A design-note (`reader-ai-provider-entry.md:172–174`) derives `aiConfigured` from `providers.isEmpty == false`, and iOS #82 (`reader-ai-readiness.md`) adds a 4-gate readiness (flag + consent + provider + key). **Android has NO consent manager and NO feature flag** (#118 has neither — confirm during build); the Android gate is exactly what #118 enforces = **provider (active) + key (decrypts non-empty)**. We do NOT invent a consent/flag gate.
+123:- `bilingual/TranslationUnitId.kt` — `data class TranslationUnitId(kind, value)` with `enum Kind { epubHref, foliateHref, txtDocSegmentWindow, mdDocSegmentWindow, pdfPageRange }`; `storageKey = "${kind.name}:$value"`. TXT/MD kinds are **document-global segment-window indices** (H1), NOT chunk indices. v4 uses `epubHref` + `txtDocSegmentWindow`/`mdDocSegmentWindow`; others reserved so the cache-key format never breaks. *(Assumption: iOS's exact Kind case names for the TXT/MD variants; only the `storageKey` string format is load-bearing for the cache contract, and that is preserved.)*
+124:- `bilingual/TranslationGranularity.kt` — `enum { paragraph, sentence }`. (Design's Granularity control; sentence-render is design-gated per H2.)
+126:- `bilingual/ChapterSegmenter.kt` — **NEW file (no existing Android segmenter — verified).** Port of iOS `ChapterSegmenter`: `paragraphs(text)` / `sentences(text)` **plus the range-returning peers `paragraphRanges(text): List<IntRange>` / `sentenceRanges(text): List<IntRange>`** (half-open UTF-16 spans against the input string — iOS `sentenceRanges(in:)` precedent). Ranges are exposed as explicit `(start, endExclusive)` pairs to the render side (H1). CJK-aware sentence enumeration (`。！？` vs Latin). Pure.
+130:- `bilingual/TxtChapterTextProvider.kt` — provider over `TxtDocument` + the segmenter's range array (H1). Builds the document-global segment `(start, endExclusive)` ranges once, groups them into windows, resolves `unitContaining` via a segment-start binary search over `charOffsetUTF16`. MD source = raw markdown segment text.
+131:- `bilingual/EpubChapterTextProvider.kt` (WI-0-gated shape) — provider over the Readium `Publication` reading order; `units()` = spine hrefs, `unitContaining` = the locator's href (from `EpubNavigatorFragment.getCurrentLocator()`), `sourceSegments(unit)` = the DOM-enumerated block texts (the render's OWN enumeration, for direct-block 1:1 — H2). Its render-side collaborator is `EpubBilingualJs`.
+133:- `bilingual/ChapterTranslationService.kt` — the iOS-parity service (full divergence-recovery surface, round-2 H2):
+136:  - `translate(bookKey, unit, sourceText, targetLanguage, providerProfile, granularity, bypassCacheRead=false)` — segment → chunk → per-chunk `AiClient.chat` one-shot → `decode` → per-segment fallback → per-chunk graceful degrade (Bug #330) → cache-write only on full success (`sourceParagraphCount = segments.size`). **Cancellation:** maps BOTH native `CancellationException` AND typed `ChapterTranslationError.Cancelled` to `Cancelled` (mirrors iOS `ChapterTranslationService.swift:359–364`); `ensureActive()` between chunks AND immediately before the Room write.
+139:- `bilingual/ChapterTranslationPrefetcher.kt` — resolves the active profile from one `AiProviderStore.snapshot()` (`snapshot.active`), decrypts via `store.apiKey(profile)` (snapshot-consistent, AiProviderStore.kt:108), builds an `AiClient` via an **injected factory param** (below), cache-first then translate. Adds the direct-block peers (H2):
+143:  - **`AiRequest` construction (round-3 M3 fix, BINDING):** `model = profile.model.ifBlank { profile.kind.defaultModel }` — matches `AiChatViewModel.kt:61`; both wire clients serialize `request.model` **directly** (`put("model", request.model)` in `OpenAiCompatibleProvider.kt:39` and `AnthropicProvider.kt:37`), so a blank `profile.model` would send an empty model. Full request: `AiRequest(model = profile.model.ifBlank { profile.kind.defaultModel }, messages = …, temperature = profile.temperature, maxTokens = profile.maxTokens, system = …)`. A **blank-model regression test** asserts the fallback is applied.
+150:- `bilingual/BilingualViewModel.kt` — `StateFlow<BilingualUiState>` with `enabled`, `targetLanguage`, `granularity`, `needsSetupSheet`, `aiConfigured`, `translationsByUnit`, `inFlightUnits`, `unavailableUnits`, `errorUnit`. Setters + `dismissSetupSheet`, `onPositionChanged(charOffsetUTF16)`, `retryUnit(unit)`, and the EPUB direct-block entry `onEpubBlocksEnumerated(unit, blocks)` (M1, below). Generation/epoch-guarded prefetch (current + next unit); a **per-unit single-flight job registry** (M2); dual-cancellation handling (M2). Port of iOS `BilingualReadingViewModel` (`prefetchTasks: [TranslationUnitID: Task]`, `BilingualReadingViewModel.swift:141`) + `+Prefetch`. Split to `BilingualPrefetchController.kt` if it nears ~300 lines. No `style` field.
+154:- `data/ChapterTranslationEntity.kt` — `@Entity(tableName="chapter_translations", indices=[Index("bookKey")], foreignKeys=[FK→books.fingerprintKey ON DELETE CASCADE])`. **`@PrimaryKey val lookupKey: String`** (Room requires a PK; project pattern `@PrimaryKey` + `@Upsert`, verified `BookEntity`/`BookDao`). `lookupKey` = `bookKey|unitStorageKey|targetLanguage|promptVersion`. Columns: `bookKey`, `unitStorageKey`, `targetLanguage`, `promptVersion`, `translatedJson`, `sourceParagraphCount`, `createdAt`. Mirrors iOS `ChapterTranslationRecord.lookupKey` (`book|unit|lang|prompt`, profile-agnostic — Bug #342). `sourceParagraphCount` is load-bearing for H2 (stores the enumerate's count on the `translatePreSegmented` path so `cachedTranslation(expectedSegmentCount:)` restores).
+158:**Cache-identity (reconciled with iOS parity):** the 4-part key `book|unit|lang|promptVersion` is profile-AGNOSTIC / style-agnostic (Bug #342). Style is descoped (§3) so no `s=` component. **Granularity IS user-selectable**, carried in `promptVersion` as an effective composite: `promptVersion = "bilingual-v1|g=${granularity}"` (a paragraph vs sentence translation is a different cache row — closes the iOS #344 "sentence silently ignored" class by construction; also means the H2 sentence design-gate never serves a paragraph row as sentences). A granularity change cancels in-flight jobs, bumps the VM generation, clears shaped `translationsByUnit`, and forces a correctly-keyed re-fetch (WI-6).
+164:- `bilingual/BilingualSetupSheet.kt` — reproduces `vreader-bilingual.jsx`'s `BilingualSetupSheet` (lines 27–156) EXACTLY: header; a preview strip (`BilingualPreview`); a language grid over `BILINGUAL_LANGS` (glyph tiles, selected accent); a **Granularity** segmented control (Paragraph "Translate after each ¶" / Sentence "Translate after each sentence"); a **Translation engine** strip (configured: "Claude · with this book's context" + "Change…"; unconfigured: "No AI provider configured" + "Bilingual mode needs an AI provider to translate." + "Set up"); the "Turn on bilingual mode" CTA. **No Style control, no provider/model card, no term-overrides toggle, no cost footer** (those belong to the `vreader-ai-android.jsx` sheet, not reproduced — §3). The `aiConfigured` flag comes from `BilingualAiReadiness.resolve`. The "Set up"/"Change…" CTA routes to `ReaderAiProvidersSheet` (wired in WI-9).
+165:- `bilingual/ReaderAiProvidersSheet.kt` — **NEW (folded in; the Android analog of iOS `ReaderAIProvidersView`).** The Variant A scoped in-reader AI Providers sheet, reproducing `vreader-ai-provider-entry.jsx` `AIProvidersSheet` + `NavSheet` (nav bar `‹ Bilingual` leading + centered "AI Providers" title). It hosts **ONLY the provider list** — nothing else from settings. It **reuses the #118 `AiProviderListScreen` (list, empty + populated states) and `AiProviderEditSheet` (the canonical add/edit modal) VERBATIM**, driven by the #118 `AiSettingsViewModel` (`listState`, `editState`, `openAdd/openEdit/save/setActive`, verified `AiSettingsViewModel.kt`). Behavior per the nav model:
+167:  - **Add provider** presents `AiProviderEditSheet` unchanged; **on the first Save** the new provider becomes active/the bilingual engine and the stack **pops all the way back** to the bilingual sheet with the engine strip now reading "Claude · configured / Change…". (First-provider-active is already the store's behavior — `AiProviderStore.upsert` sets `activeId = cur.activeId ?: id`, AiProviderStore.kt:81; the sheet additionally calls `store.setActive(savedId)` on the first-Save-from-bilingual path so the freshly-saved provider is the engine even if others existed.)
+169:  - "Change…" opens the SAME sheet, populated, current provider checked (tapping a row → `setActive`).
+171:- `bilingual/BilingualInterlinearBody.kt` — the Compose render surface for the **TXT/MD host ONLY** (round-2 M2). Emits the **additive translation `LazyColumn` items** per the H2 render contract (source chunks unchanged; translation items after the anchor chunk): muted `Text`, accent left-border, `fontSize*0.88`, CJK font for cjk scripts, RTL handling for Arabic (per `BilingualPageContent`, `vreader-bilingual.jsx:200–277`). Consumes the host-neutral `BilingualRenderState` DTO. Loading state ("Translating chapter… N%" + per-segment dim), error state ("Couldn't translate" + Retry), partial/offline (`unavailableUnits`): source-only silent fallback (iOS Decision 2). **NOT the EPUB render surface.**
+172:- `bilingual/BilingualRenderState.kt` — the host-neutral state DTO shared by the Compose body and the EPUB adapter (round-2 M2): per-unit `{ segments: List<String>?, phase: Loaded|Loading(fraction)|Error|SourceOnly }`. Compose and EPUB share the state/value types, NOT the composable body.
+173:- `bilingual/EpubBilingualJs.kt` (WI-0-gated) — the EPUB render surface (round-2 M2). Pure Kotlin builder producing JS strings for `navigator.evaluateJavascript(...)`: `enumScript` (enumerate current-resource leaf blocks → JSON `[{id,text}]`), `injectScript(blockId, translationText)` (translation DOM node after the block; CSP-safe: `textContent`/`createTextNode`, never `innerHTML` string-concat; RTL/CJK via class + injected `<style>`), `clearScript()` (idempotent removal). Escaping done in Kotlin (JSON-encode every interpolated string). No Compose. Consumes `BilingualRenderState`.
+174:- `bilingual/EpubBilingualController.kt` (WI-0-gated) — **the single owner of EPUB units (M1, below).** The runtime actor that serializes enumerate→(cache-restore|translate)→inject/clear against the navigator using WI-0's chosen mechanism (a single mutex OR a monotonic navigator-session token); checks the session token after every suspended JS/AI call; clears BEFORE publication teardown; re-applies on the identified production re-apply signal.
+175:- `bilingual/BilingualPill.kt` — the `EN ↔ 中` reader-top-chrome pill (per `vreader-reader.jsx` + `vreader-bilingual.jsx` `BilingualPill`:282–305). Rendered by #132's top chrome; #131 provides the composable, #132's surface hosts it (§4).
+179:The **`EpubBilingualController` is the SINGLE OWNER of EPUB units**; the VM's position-driven regular `prefetch` path is **TXT/MD-only**. Concretely, an EPUB position change routes THROUGH the controller (the VM does not run `prefetch(unit)` for `epubHref` units), so the **controller is the sole writer** of an EPUB unit's canonical cache row and its `BilingualRenderState`/`translationsByUnit` entry — the position-driven regular prefetch and the direct-block path can never both write the same canonical cache row. The control flow (every suspended step session-token-guarded):
+202:- **Dual-cancellation across the service/VM boundary:** both the service AND the VM handle **BOTH** native `CancellationException` **AND** the typed `ChapterTranslationError.Cancelled` **before** generic error mapping — matching iOS `ChapterTranslationService.swift:359–364` (which catches `is CancellationError` and `ChapterTranslationError.cancelled` separately, both re-throwing `cancelled`). A cancelled stale request MUST NOT surface as `errorUnit` (it is discarded).
+203:- **Per-unit single-flight job registry (VM):** a `prefetchTasks: MutableMap<TranslationUnitId, Job>` (iOS `prefetchTasks: [TranslationUnitID: Task]`, `BilingualReadingViewModel.swift:141`, cancelled/removed on disable/unit-change at :165). A NEW request for a unit **cancels-or-joins** the prior job (a stale prior is cancelled and awaited so it cannot run overlapping translations or Room writes), keyed by unit. Rapid retry/navigation cannot run overlapping translations for the same unit. `retryUnit(unit)` goes through the same registry. Tests: a mid-flight cancel discards (no `errorUnit`, no partial cache row); a rapid re-trigger for the same unit does not double-write.
+208:- `reader/TxtReaderActivity.kt` — own a `BilingualViewModel`; collect state; render translations as **additive items after the anchor chunk in the existing `items(count = document.chunkCount, key = { it })` loop (TxtReaderActivity.kt:1043), source chunks byte-unchanged (H2)**; on position change call `vm.onPositionChanged(charOffsetUTF16)`. Strictly gated to `originalFormat ∈ {txt, md}`; disabled = body byte-unchanged (overlay-only). **Owned by #129 (VERIFIED, merged) — a straight edit, rule 48 one-writer-per-file satisfied.**
+209:- `reader/ReaderActivity.kt` (Readium EPUB) — WI-0-gated: attach `EpubBilingualController` to `navigator.evaluateJavascript`; re-apply on the identified production re-apply signal; clear on teardown BEFORE publication teardown. `navigator: EpubNavigatorFragment?` is the verified live field (ReaderActivity.kt:110).
+210:- `reader/chrome/ReaderChromeScaffold.kt` — extend `readerMoreRows(...)` (currently supplies only `MoreActionId.DETAILS` + `SHARE`, ReaderChromeScaffold.kt:255–258) to ALSO supply the **`MoreRow.Toggle(id = MoreActionId.BILINGUAL, on = enabled, onToggle = …)`** row (or `MoreRow.Disabled` "Configure AI provider first" when not configured — `MoreRow.Disabled` exists for exactly this, MoreRow.kt:65–72). Threaded via new nullable params so #132/#134-only callers stay valid (the scaffold's established nullable-default pattern). This is the WI-9 entry-wiring edit.
+211:- `VReaderApp.kt` / `AppContainer` — **provide `AiProviderStore` INTO `AppContainer` itself** (it is NOT provided today — verified, only a comment names it at VReaderApp.kt:66) using the #116 `KeystoreSecretCipher` + a DataStore under the same convention as `readerSettingsStore`, PLUS provide `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, an `AiSettingsViewModel` factory (for the Variant A sheet), and a `BilingualViewModel` factory. **Extracted into the shared DI WI (WI-4b).** No `feat:#136` dependency remains — #131 owns the `AiProviderStore`-into-`AppContainer` wiring.
+213:**NOT modified:** `reader/chrome/ReaderBottomChrome.kt` gets **no** bilingual/Translate slot — the design's entry is the More-menu toggle (#134) + the top-chrome pill (#132), NOT a bottom-chrome slot. `ReaderBottomChrome`'s existing `extraSlot` is untouched.
+221:- **Sentence-granularity interlinear RENDER** — not depicted (H2); design-gated. v1 renders the depicted paragraph pattern; Sentence selection falls back to paragraph render (cache still granularity-keyed).
+230:**How iOS does interlinear:** iOS renders EPUB/AZW3 in a WKWebView it fully controls. `EPUBBilingualOrchestrator` injects JS that (1) enumerates leaf blocks posting `[{bid,text}]` to Swift, (2) after translation injects a translation node after each block. TXT/MD render in a text path where the renderer interleaves translation runs. The mechanism = **the app inserts translation nodes between source nodes** — which is exactly the Android additive-item contract (H2) for TXT/MD and the DOM-inject contract for EPUB.
+234:**WI-0 — Readium bilingual spike (gates WI-7b; round-2 M1):** a throwaway harness that, against a real EPUB on the emulator, must PROVE each go/no-go criterion: (a) enumeration deterministic + idempotent with stable node IDs (repeat apply = no duplicate nodes); (b) clear wins over every older inject (a late inject checks the session token and no-ops); (c) recreation restores from cache for every case (href away/back, same-href `submitPreferences` reflow, internal page-fragment recreation, activity recreation) via `cachedDirect(expectedCount)` (zero provider calls) with an identified PRODUCTION re-apply signal per case; (d) locator/visible-source preservation across injection (stated permissible pagination delta); (e) enumerated block count vs segmenter count measured — divergence → the direct-block path (`prefetchDirect`/`cachedDirect`, H2) is the recovery, proven end-to-end. **Race contract:** single actor/mutex OR monotonic navigator-session token; token/mutex check after every suspended JS/AI call; clear before publication teardown. **No deterministic re-apply signal for a recreation case (c) = explicit NO-GO** → EPUB drops to a tracked follow-up, box D ships **TXT/MD-only** with the honest reason (a specific spike finding), never the false "requires a fork."
+241:5. **One `BilingualInterlinearBody` per chunk (v2)** — REJECTED (round-2 H1): a chunk is not a segment.
+242:6. **A Compose body as the EPUB render surface (v2)** — REJECTED (round-2 M2): Compose cannot render inside Readium's WebView.
+243:7. **Splitting a chunk's source `Text` into per-segment `Text` nodes to interleave translations (v3)** — REJECTED (round-3 H2): breaks the live one-`TextLayoutResult` + one-selection-registration-per-chunk model. Replaced by additive `LazyColumn` items at chunk boundaries, source `Text` never split.
+244:8. **Deriving `aiConfigured` from `profiles.isEmpty()` (the iOS Variant A note's derivation)** — REJECTED for Android: `activeId` can be null with profiles present, and key usability needs the active profile's token to decrypt (H3). Android uses `BilingualAiReadiness.resolve` = active-profile + decrypts-non-empty.
+245:9. **Spinning AI-config reachability out as a separate feature #136** — REJECTED / CLOSED (2026-07-12): the design proved the ONLY designed Android AI-config reader surface is bilingual-coupled Variant A; there is no designed standalone entry, so it is not separable. #131 owns it.
+267:- **Single-flight job registry**: iOS `prefetchTasks: [TranslationUnitID: Task]` (`BilingualReadingViewModel.swift:141`) — ported as `prefetchTasks: Map<TranslationUnitId, Job>` (M2).
+268:- **Entry point via #132/#134 (VERIFIED)**: the More-menu bilingual toggle (`MoreActionId.BILINGUAL` reserved; `MoreRow.Toggle`/`MoreRow.Disabled`) + top-chrome pill are landed; #131 mounts the pill + wires the toggle (§4).
+272:**13 WIs/PRs (round-3 Low-1 fix — corrected count):** the list is exactly **WI-0, WI-1, WI-2, WI-3, WI-4a, WI-4b, WI-5, WI-6, WI-7a, WI-7b, WI-AIP, WI-8, WI-9** = **13 WIs**. (v3 had 12: WI-0,1,2,3,4a,4b,5,6,7a,7b,8,9. Folding in the Variant A "AI Providers" sheet adds **WI-AIP**, making 13. The prior "11 WIs" claim in the plan header and `docs/features.md` was wrong on two counts and is corrected here.) Each WI = one PR. Build order: **foundation/cache → service/direct-block APIs → shared DI/factory (incl. `AiProviderStore` in `AppContainer`) → VM state/prefetch → host-specific renderers (TXT/MD + EPUB) + the Variant A AI Providers sheet → entry wiring.**
+274:**Dependencies (round-3 Medium-4 — dependency honesty; #136 folded in):**
+276:- **`Deps: [feat:#132, feat:#134]`.** **#132 (top chrome) and #134 (More menu) are VERIFIED.** **#129 (TXT/MD reader) is VERIFIED** — `TxtReaderActivity` is a straight edit, not a blocker. **There is NO external AI-reachability blocker** — the former #136 is CLOSED (GH #1976, not-planned) and its scope is #131-owned.
+277:- **WI-4b is foundational and gates the behavioral chain.** WI-4b now provides `AiProviderStore` into `AppContainer` PLUS the bilingual services + factories. Per the audit's Medium-4, WI-4b transitively gates WI-6 (needs the prefetcher/DI), WI-7b (needs DI), WI-AIP (needs `AiProviderStore` + `AiSettingsViewModel` from `AppContainer`), and WI-8 (needs DI). **Chosen resolution: injected seams so the behavioral work proceeds against fakes before WI-4b lands, AND WI-4b is sequenced early.** Concretely: the VM (WI-5/WI-6) takes an injected `ChapterTranslationPrefetcher` (fake in tests) and an injected `AiProviderSnapshot` provider (fake); the TXT/MD host Compose/unit work (WI-8) and the Variant A sheet (WI-AIP) take injected VM/store/`AiSettingsViewModel` seams — so unit/Compose tests do not wait on `AppContainer`. **WI-4b is built right after WI-4a (before WI-6/WI-7b/WI-AIP/WI-8) so the production wiring lands before the host integrations that mount it.** This is stated honestly: the *production run-through* of WI-6/WI-7b/WI-AIP/WI-8 depends on WI-4b; their *unit/Compose gates* depend only on the injected seams. No external feature gates any of this.
+279:**WI-0 (spike): Readium EPUB bilingual injection — go/no-go + race contract (M1).** Harness + criteria (a)–(e) and the race contract in §3. Output: a go/no-go on EPUB-in-v1 (no-go = box D ships TXT/MD-only, tracked) + the concrete `EpubChapterTextProvider` / `EpubBilingualJs` / `EpubBilingualController` surfaces + the EPUB direct-block ownership sequence (Medium-1). Deps: none (uses the existing #106 Readium host). Not TDD-gated (throwaway spike); feeds WI-7b.
+281:**WI-1 (foundational): value types + pure segmentation/chunk/contract.** `TranslationUnitId`, `TranslationGranularity`, `BilingualLanguages`, **`ChapterSegmenter` (with `paragraphRanges`/`sentenceRanges` returning half-open UTF-16 `(start, endExclusive)` spans — H1)**, `TranslationChunker`, `TranslationChunkContract` (no `style`), `ChapterTranslationError`. Pure; ported iOS vectors. Deps: none.
+285:**WI-3 (foundational): `ChapterTranslationService`** against a fake `AiClient`. Both `cachedTranslation` overloads (incl. the `expectedSegmentCount` divergence restore — H2) + `translate` + `translatePreSegmented`. **Dual-cancellation (native + typed `Cancelled`) BEFORE generic mapping (M2).** Deps: WI-1, WI-2. Tests: cache hit → zero client calls; miss → translate + write; decode fail → per-segment fallback; one-chunk fail → source-only that chunk (others translated, NOT cached); all-chunks fail → throw; native-cancel → `Cancelled` (no write); typed-`Cancelled`-from-chunk → `Cancelled` (no write); ensureActive-before-write; `AiError` mapping incl. `Config`/`InsecureUrl` → `ProviderFailed`; `translatePreSegmented` full-success caches under the enumerate count; partial degrade NOT cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` returns on stored-count match, null on mismatch, needs no provider.
+287:**WI-4a (foundational): `ChapterTextProvider` (TXT/MD) + `ChapterTranslationPrefetcher` + `BilingualAiReadiness`.** `TxtChapterTextProvider` builds the document-global segment `(start, endExclusive)` ranges once (H1), groups into windows, resolves `unitContaining(charOffsetUTF16)` via segment-start binary search, `sourceSegments(unit)`. Prefetcher: `prefetch` + `prefetchDirect` + `cachedDirect`; resolves active profile from `snapshot()`, decrypts snapshot-consistent, builds client via the injected factory param (default `AiProviderFactory::create`), constructs `AiRequest` with **`model = profile.model.ifBlank { profile.kind.defaultModel }` (M3)**. Readiness = active profile with non-empty decrypted key; **cipher failure → not-ready, never a crash.** Fake store + fake factory. Deps: WI-1, WI-3. Tests (all half-open-range-based): unit resolution + clamp + empty; **one-chunk document (no trailing newline) → its segment translation renders, not dropped (H1)**; **final-chunk anchor → renders (H1)**; **exact-boundary → correct anchor (H1)**; **EOF anchor (`segEndExclusive == text.length`) → last chunk, no clamp-collapse (H1)**; paragraph spanning MANY chunks → one segment/one unit, anchored to the last chunk (Low-2); multiple SENTENCES in one chunk → distinct sentence segments (Low-2); a >4000-char paragraph hard-split across chunks → one segment; CR/LF/CRLF; MD markers; locator→unit mapping; `unitAfter` end→null; **source-byte parity while disabled**; cache-hit-no-profile still returns (#306); no-profile miss → `ProviderFailed`; `prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls; **blank `profile.model` → `AiRequest.model == kind.defaultModel` (M3 regression)**; readiness true/false; empty-key → false; no-active-with-profiles-present → false (H3); cipher-throw → readiness false (no crash).
+289:**WI-4b (foundational — shared DI/factory, incl. `AiProviderStore` in `AppContainer`): AppContainer bilingual + AI-config graph.** `AppContainer` **now constructs `AiProviderStore`** (DataStore + #116 `KeystoreSecretCipher`, following the `readerSettingsStore` convention — this is #131's change, not an external feature's) and provides `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, an `AiSettingsViewModel` factory (for WI-AIP), and the `BilingualViewModel` factory. Deps: **WI-4a** (no external dep — #136 closed). Tests: container resolves the bilingual + AI-config graph; `AiProviderStore` resolves and round-trips a profile; the prefetcher's injected factory defaults to `AiProviderFactory::create`.
+291:**WI-5 (behavioral): `PerBookBilingualStore` + `BilingualViewModel` state core.** Store per book (enabled/targetLanguage/granularity — no style); VM setters (persist + first-enable `needsSetupSheet`); `aiConfigured` from `BilingualAiReadiness.resolve` over an injected snapshot; language/granularity change clears cache-shaped state + bumps generation. Injected prefetcher/snapshot seams (Medium-4). Turbine tests: first-enable raises sheet; re-enable persisted does not; disable clears; language change resets; granularity change resets + re-keys; `aiConfigured` true/false from readiness; round-trip through store; no style field. Deps: WI-1 (+ store).
+293:**WI-6 (behavioral): VM prefetch trigger + generation/cancellation + single-flight (M2).** `onPositionChanged(charOffsetUTF16)` derives current unit (TXT/MD only), dedupes, prefetches current+next; a monotonic position-request sequence checked after every suspension; **per-unit single-flight `prefetchTasks: Map<TranslationUnitId, Job>` (a new request cancels/joins the prior — M2)**; a captured language/granularity/provider snapshot per launch; generation bumps on disable/language/granularity/unit-change discard stale; **BOTH `CancellationException` AND typed `ChapterTranslationError.Cancelled` handled BEFORE generic error mapping (M2)**; a cancelled stale request does NOT surface as `errorUnit`; `Offline`→`unavailableUnits`; transient failure leaves unit unfetched + clears anchor to retry; `retryUnit` routes through the registry. The EPUB `onEpubBlocksEnumerated` entry is present but EPUB prefetch is owned by the controller (Medium-1); the VM's position-driven `prefetch` dispatches TXT/MD units only. Fake prefetcher (Medium-4 seam). Deps: WI-4a, WI-4b, WI-5. Tests: current+next on unit change; same-unit no-op; cancel-mid discards stale (no `errorUnit`); typed-`Cancelled` discards (not `errorUnit`); rapid re-trigger same unit → single-flight, no double-write; offline→unavailable; failure→retry-able; `retryUnit` re-fetches; granularity change cancels + re-fetches under the new key.
+295:**WI-7a (behavioral): Compose UI — setup sheet + interlinear body (TXT/MD) + pill.** Reproduce `vreader-bilingual.jsx` (setup sheet: language grid / granularity / preview / engine strip configured+unconfigured; body: the **additive translation items** per the H2 render contract — translated / loading N%+dimmed / error+Retry / offline source-only; pill). Consumes the host-neutral `BilingualRenderState` DTO. Light+dark. Compose UI tests each state, incl. **paragraph interlinear renders a translation item after a paragraph (depicted)** and **Sentence selection falls back to paragraph render (H2 gate)**. Deps: WI-5 (state shape). NO Style control; the unconfigured "Set up" CTA renders and (in WI-9) routes to the Variant A sheet.
+297:**WI-7b (behavioral, CONDITIONAL — only if WI-0 = go): EPUB render adapter (DOM injection, NOT Compose — M2) + direct-block ownership (M1).** `EpubBilingualJs` (enum/inject/clear JS builders, CSP-safe escaping) + `EpubBilingualController` (the serialization actor / session token AND the **single-owner enumerate→cachedDirect/prefetchDirect→guarded-commit sequence — Medium-1**) + `EpubChapterTextProvider`, wired into `ReaderActivity`, driving DOM from the shared `BilingualRenderState` DTO. Uses `prefetchDirect`/`cachedDirect` for the count-divergence path (H2). Depends on WI-6 (VM state) and WI-4b (DI); the WI-7a UI dependency is only the shared `BilingualRenderState`/value types. Connected test on a real EPUB (seeded cache): enable → injects; disable → cleared; reflow/href-change/fragment-recreation/activity-recreation → re-applies from cache (zero provider calls) via `cachedDirect`; count-divergence handled (direct path); **the regular TXT/MD prefetch path is never invoked for an EPUB unit (Medium-1)**. Unit tests: JS escaping/CSP-safe insertion, RTL/CJK style, empty translations, loading cleanup, idempotent replacement, source-only fallback, stale-session-token commit discarded (no `errorUnit`). Deps: WI-0, WI-3, WI-4a, WI-4b, WI-6, (shared types from WI-7a). (If WI-0 = no-go, dropped; box D ships TXT/MD-only, tracked.)
+299:**WI-AIP (behavioral — the folded-in Variant A AI Providers sheet): `ReaderAiProvidersSheet`.** The scoped in-reader "AI Providers" push sheet (nav bar `‹ Bilingual` + "AI Providers" title) reproducing `vreader-ai-provider-entry.jsx` `AIProvidersSheet`/`NavSheet`, hosting ONLY the #118 `AiProviderListScreen` (empty + populated) + the canonical `AiProviderEditSheet`, driven by the #118 `AiSettingsViewModel` (from WI-4b's `AppContainer` factory). Empty state carries the bilingual-context copy ("Bilingual mode needs a provider to translate" / "Add provider" CTA). On first Save → the provider becomes the bilingual engine (`store.setActive(savedId)`) + pop the whole stack back to the bilingual sheet (engine strip now "configured / Change…"). `‹ Bilingual` without adding → unconfigured, no state mutated. No consent/flag surface (Android has none). Deps: WI-4b (for `AiProviderStore` + `AiSettingsViewModel` in `AppContainer`), WI-7a (bilingual sheet host). Tests (Compose + connected): empty → Add → Save → pop-to-bilingual with strip configured; `‹ Bilingual` without adding → strip unconfigured, snapshot unchanged; "Change…" → populated list, current provider checked, tap row → `setActive`; editor reused verbatim (no divergent form).
+301:**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into the `items(count = document.chunkCount)` loop as **additive translation items after the anchor chunk, source chunks byte-unchanged (H2)** + position-change (`charOffsetUTF16`) + setup-sheet. `originalFormat`-gated (TXT/MD). Uses WI-4b's DI. **#129 VERIFIED — straight edit.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2)**; **highlights/annotation-washes/read-aloud-wash still key off source chunks (H2)**; a translation item is non-selectable, does not perturb source offsets (H2); disable → source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders exactly one translation after its last chunk (H1/Low-2)**; **one-chunk/final-chunk anchors render (H1)**; MD source mapping. Deps: WI-6, WI-7a, WI-4b.
+303:**WI-9 (behavioral): entry wiring + acceptance.** Mount `BilingualPill` in #132's VERIFIED top chrome; extend `readerMoreRows(...)` to supply the #134 VERIFIED More-menu `MoreActionId.BILINGUAL` toggle (`MoreRow.Toggle` `on`/`onToggle`, or `MoreRow.Disabled` "Configure AI provider first" when not configured) wired to the VM; **wire the setup sheet's "Set up"/"Change…" affordance → the #131-owned `ReaderAiProvidersSheet` (Variant A)**. Full acceptance across EPUB (if WI-7b landed) + TXT/MD, including the fresh-user path `unconfigured → Set up (→ Variant A AI Providers sheet) → add provider → return → enable → translate` (now #131-owned end-to-end). **Flip box D to done ONLY for provider/model/granularity + the Style-descope note; file the follow-up checklist amendment; do NOT claim full box-D parity.** The DONE flip **no longer waits on #136** (closed). Update `docs/architecture.md` (bilingual pipeline + the new `chapter_translations` schema + `AiProviderStore` + bilingual services in `AppContainer` + the Variant A AI Providers sheet). → DONE. Deps: WI-8, WI-AIP, WI-7b (if go), feat:#132, feat:#134.
+307:JVM/Robolectric (`android/app/src/test/...bilingual/`): `ChapterSegmenterTest` (paragraph blank-line; sentence CJK `。！？` vs Latin; empty→[]; single; **`paragraphRanges`/`sentenceRanges` return correct half-open UTF-16 `(start, endExclusive)` spans**); `TranslationChunkerTest` (packs to budget; oversize→own chunk+subSplit; empty→[]); `TranslationChunkContractTest` (prompt shape; strict JSON decode; code-fence strip; count mismatch→`CountMismatch`; non-array→`NotAStringArray`); `ChapterTranslationServiceTest` (cache hit 0 calls; miss→translate→write; decode-fail per-segment fallback; one-chunk-fail partial-not-cached; all-fail→throw; **native-cancel→Cancelled no write; typed-`Cancelled`→Cancelled no write (M2)**; ensureActive-before-write; offline/timeout/429/http/config/insecure→error mapping; very long chapter N-of-M; stale-cache count-mismatch re-translates; `translatePreSegmented` caches under enumerate count on full success; partial degrade not cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` hit/miss with no provider); `ChapterTranslationErrorMappingTest`; `TxtChapterTextProviderTest` (**one-chunk document → renders (H1); final-chunk anchor → renders (H1); exact-boundary → correct anchor (H1); EOF anchor → last chunk, no clamp-collapse (H1)**; paragraph spanning MANY chunks → one segment/unit anchored to last chunk (Low-2); multiple SENTENCES in one chunk → distinct segments (Low-2); >4000-char paragraph → one segment across hard-split chunks; CR/LF/CRLF; MD markers; locator→unit mapping; `unitAfter` end→null; source-byte parity while disabled); `ChapterTranslationPrefetcherTest` (snapshot-consistent profile+key; injected-factory used; `AiRequest` built from profile; **blank `profile.model` → `kind.defaultModel` (M3 regression)**; cache-hit-no-profile #306; no-profile miss→ProviderFailed; `prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls; CJK↔English + Latin round-trip via fake; cipher-throw→ProviderFailed not crash); `BilingualAiReadinessTest` (active+key→true; **no-active-with-profiles-present→false (H3); activeId-null→false (H3)**; empty key→false; cipher-throw→false, no crash); `PerBookBilingualStoreTest` (enabled/lang/granularity round-trip; no style field); `BilingualViewModelTest` (Turbine: first-enable sheet; re-enable no-sheet; disable clears; language reset; granularity reset + re-key; `aiConfigured` from readiness; prefetch current+next; same-unit no-op; **cancel-mid discards (no errorUnit); typed-Cancelled discards (M2); rapid re-trigger same unit single-flight, no double-write (M2)**; offline→unavailable; error→errorUnit+retry; `retryUnit`); `EpubBilingualJsTest` (JS escaping / CSP-safe insertion; RTL/CJK style; empty translations; clear idempotent; inject idempotent replacement; source-only fallback — WI-7b if go); `EpubBilingualControllerTest` (**enumerate→cachedDirect/prefetchDirect→guarded commit; stale-session-token commit discarded, no errorUnit; single-owner (regular TXT/MD prefetch never runs for EPUB unit) — Medium-1** — WI-7b if go).
+311:Compose UI (`androidTest/...bilingual/`): `BilingualSetupSheetUiTest` (language grid, granularity, preview, engine configured vs unconfigured driven by `aiConfigured`; no Style control present; light+dark); `BilingualInterlinearBodyUiTest` (**additive translation item after a paragraph anchor chunk (depicted); paragraph interlinear translated incl. CJK font + RTL Arabic; Sentence selection → paragraph-render fallback (H2 gate)**; loading N%+dimmed; error+Retry; offline source-only; empty translation→source-only no crash); `ReaderAiProvidersSheetUiTest` (**empty state with bilingual-context copy + Add CTA; populated list + current-provider checked; `‹ Bilingual` back label; editor reused (WI-AIP)**); `BilingualPillUiTest`.
+313:Connected (`androidTest/...reader/`): `TxtReaderBilingualConnectedTest` (API 35, fake `AiClient` via injected factory): enable→setup→confirm→interlinear from seeded Room cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2); highlights/annotation-washes/read-aloud-wash still key off source chunks (H2); translation item non-selectable + no source-offset perturbation (H2)**; disable→source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders one translation (H1/Low-2); one-chunk/final-chunk anchors render (H1)**; TXT/MD gated (PDF inert); very long chapter scroll responsive; cancellation leaves no partial cache row. `ReaderAiProvidersConnectedTest` (WI-AIP + WI-9): `unconfigured → Set up → Variant A sheet → add provider → Save → pop-to-bilingual configured → enable → translate`; `‹ Bilingual` without adding → unconfigured, snapshot unchanged; "Change…" → populated, current checked. `EpubReaderBilingualConnectedTest` (only if WI-0=go): enable→inject on a real EPUB; disable→clear; href-change/fragment-recreation/activity-recreation→re-apply from cache (zero provider calls); count-divergence handled via `prefetchDirect`/`cachedDirect`; regular prefetch never runs for EPUB unit (Medium-1).
+315:Edge cases: empty translation, failed, partial per-chunk, CJK↔English + Latin + RTL, provider error/timeout/429/config/insecure, native + typed cancellation mid-translation + before-write, single-flight overlap, very long chapters, offline (cache-first + silent source-only), cipher-decrypt failure → not-ready (no crash), enumerate↔segment count divergence (direct path), one-chunk/final-chunk/EOF anchors (H1), blank model (M3).
+319:- **Live-translation verification is AI-credential-gated (the box-D caveat).** The whole pipeline is verified without live creds via a deterministic **fake `AiClient`** injected through the prefetcher's `clientFactory` param (default `AiProviderFactory::create`; tests override). WI-3/4a/8 prove segment→chunk→decode→cache→interleave end-to-end incl. every error/edge path. Connected tests seed the Room cache and assert render-from-cache with zero client calls. An optional live smoke confirms wire format but is NOT a gate. The fresh-user `unconfigured → Set up → add provider` reachability leg is now #131-owned (WI-AIP + WI-9) and verified by `ReaderAiProvidersConnectedTest`.
+320:- **Final-chunk translation drop (round-3 H1).** Fixed by `endExclusive = if (i+1<chunkCount) offsetForChunk(i+1) else text.length` + explicit half-open `(start, endExclusive)` computations everywhere; one-chunk/final-chunk/exact-boundary/EOF tests. `offsetForChunk`'s clamp (TxtDocument.kt:17) is never relied on for the final end.
+321:- **Enabled render breaking the per-chunk layout/selection model (round-3 H2).** Fixed by the additive-item render contract: source chunk `Text` is NEVER split; translations are separate, non-selectable, unregistered `LazyColumn` items after the anchor chunk. Enabled-mode tests assert selection/highlight/wash/annotation parity with disabled. Sentence-granularity render is design-gated (only paragraph interlinear is depicted); Sentence selection falls back to paragraph render, granularity still cache-keyed.
+322:- **TXT/MD segment↔render pairing (round-2 H1).** Both sides read the SAME segment `(start, endExclusive)` array over `TxtDocument.text`, so 1:1 holds by construction — no chapter model invented; a paragraph split across many chunks is translated + rendered once (anchored at its last chunk). Granularity is in the cache key.
+323:- **EPUB direct-block flow (round-3 Medium-1).** The `EpubBilingualController` is the single owner: `enumeratedBlocks → cachedDirect (zero-provider restore) else prefetchDirect → session-token-guarded commit into BilingualRenderState/translationsByUnit`. The VM's position-driven regular prefetch is TXT/MD-only, so the two paths never write the same canonical cache row. Every suspended step is token-guarded; a stale token discards silently.
+324:- **EPUB count divergence (round-2 H2).** The direct-block path (`prefetchDirect` → `translatePreSegmented`, cached by enumerate count, restored by `cachedDirect(expectedCount)` with zero provider calls) — iOS Bugs #268/#330/#343 parity.
+325:- **EPUB JS-injection race (round-2 M1).** WI-0's contract (single actor/mutex OR monotonic navigator-session token; token check after every suspended call; clear before publication teardown; identified production re-apply signal per recreation case). No deterministic re-apply signal = explicit NO-GO → TXT/MD-only ship.
+326:- **Cancellation + single-flight (round-3 Medium-2).** Both service and VM handle native `CancellationException` AND typed `ChapterTranslationError.Cancelled` before generic mapping (iOS `ChapterTranslationService.swift:359–364`); a per-unit `prefetchTasks: Map<TranslationUnitId, Job>` cancels/joins a prior request so rapid retry/navigation can't run overlapping translations or Room writes; a cancelled stale request never surfaces as `errorUnit`. `ensureActive()` before the Room write.
+327:- **Blank model (round-3 Medium-3).** The prefetcher builds `model = profile.model.ifBlank { profile.kind.defaultModel }` (matches `AiChatViewModel.kt:61`; both wire clients serialize `request.model` directly, `OpenAiCompatibleProvider.kt:39`/`AnthropicProvider.kt:37`). Blank-model regression test.
+332:- **Dependency honesty (round-3 Medium-4).** WI-4b (DI, incl. `AiProviderStore` in `AppContainer`) is foundational and gates the production run-through of WI-6/WI-7b/WI-AIP/WI-8; those WIs' unit/Compose gates proceed against injected fakes, and WI-4b is sequenced before them. No external feature gates the chain (#136 closed).
+337:- **Reader unchanged when bilingual off** — the TXT/MD `items(count = document.chunkCount)` source loop is **byte-identical** unless `enabled && format∈{txt,md} && translation present` (translations are additive, non-selectable overlay items — H2). `ReaderBottomChrome` is not modified. EPUB render adapter inert unless bilingual is on.
+341:- **#132/#134/#129 landed** — the top-chrome pill mount + More-menu toggle (`readerMoreRows` extension) + `TxtReaderActivity` edit land on VERIFIED surfaces (rule 48 one-writer-per-file satisfied).
+348:*(REMOVED: the v3 "#136 dependency" design-gate line — #136 is closed and the Variant A AI Providers sheet IS the committed design, reproduced by WI-AIP, not a gate.)*
+354:- v3 (2026-07-12): Gate-2 round-2 findings resolved — TXT/MD document-global segment model (H1); EPUB translatePreSegmented + count-keyed cache + direct-block prefetch (H2); #136 AI-provider-reachability spun out as a hard dependency (GH #1976) + Style descoped v1 (H3); WI-0 go/no-go + navigator-race contract (M1); EPUB DOM-injection adapter not Compose body (M2); DI/factory WI reordered (M3); Room 8→9 MIGRATION_8_9 (M4); deps/WI-count corrected (L1/L2). Gate-2 round-3 = block-recommended.
+356:  - **AI-config FOLDED IN (#136 CLOSED, GH #1976 not-planned; user decision 2026-07-12):** the design proved the ONLY designed Android AI-config reader surface is the bilingual-coupled **Variant A** "AI Providers" sheet (`reader-ai-provider-entry.md`); it is not separable, so #131 now owns it end-to-end. Added **WI-AIP** (`ReaderAiProvidersSheet`, reusing #118 `AiProviderListScreen`/`AiProviderEditSheet`/`AiSettingsViewModel` verbatim, `‹ Bilingual` push, pop-back-on-first-Save); WI-4b now provides `AiProviderStore` into `AppContainer` (verified not provided today — VReaderApp.kt:66 comment only) plus the bilingual services + `AiSettingsViewModel` factory; removed `feat:#136` from Deps (now `[feat:#132, feat:#134]`, no external AI-reachability blocker); the DONE flip no longer waits on #136; `aiConfigured` derivation kept as the correct active-profile+decrypts-non-empty gate (H3), NOT `profiles.isEmpty()` (the iOS note's derivation), with no consent/flag gate (Android has none).
+357:  - **H1 (round-3 High-1) final-chunk math:** `endExclusive = if (i+1<chunkCount) offsetForChunk(i+1) else text.length`; explicit half-open `(start, endExclusive)` computations (not `IntRange`); one-chunk/final-chunk/exact-boundary/EOF tests.
+358:  - **H2 (round-3 High-2) additive-item render contract:** translations are additive `LazyColumn` items at chunk (line) boundaries; the source chunk `Text` is NEVER split; per-chunk one-`TextLayoutResult`/one-selection-registration preserved (TxtReaderActivity.kt:1043/1059/1062–1066); enabled-mode selection/highlight/wash/annotation/MD tests; sentence-granularity render flagged as a rule-51 design gate (only paragraph interlinear is depicted), paragraph ships.
+359:  - **M1 (round-3 Medium-1) EPUB direct-block ownership/API:** `EpubBilingualController` single owner; `enumeratedBlocks → cachedDirect else prefetchDirect → session-token-guarded commit into BilingualRenderState/translationsByUnit`; regular prefetch is TXT/MD-only so the two paths never write the same canonical row.
+360:  - **M2 (round-3 Medium-2) dual-cancellation + single-flight:** service AND VM handle native `CancellationException` AND typed `ChapterTranslationError.Cancelled` before generic mapping (iOS `ChapterTranslationService.swift:359–364`); per-unit `prefetchTasks: Map<TranslationUnitId, Job>` cancels/joins a prior; a cancelled stale request never surfaces as `errorUnit`.
+361:  - **M3 (round-3 Medium-3) blank-model fallback:** `model = profile.model.ifBlank { profile.kind.defaultModel }` (matches `AiChatViewModel.kt:61`; clients serialize `request.model` directly); blank-model regression test.
+362:  - **M4 (round-3 Medium-4) dependency honesty:** WI-4b (DI incl. `AiProviderStore`) is foundational and gates the production run-through of WI-6/WI-7b/WI-AIP/WI-8; those WIs' unit/Compose gates use injected fakes; WI-4b sequenced before them; no external feature gates the chain.
+363:  - **Low fixes:** WI count corrected to **13** (added WI-AIP; the "11 WIs" claim was wrong — Low-1); chunk semantics corrected — a chunk is ONE LINE, holds multiple SENTENCES, a paragraph spans MANY chunks; removed the "a chunk can hold multiple paragraphs" claim (Low-2). Awaiting Gate-2 round-4 audit.
+dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual-suite.jsx
+dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual-offline.jsx
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx
+dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx
+dev-docs/designs/vreader-fidelity-v1/project/VReader AI Provider Entry Canvas.html
+dev-docs/designs/vreader-fidelity-v1/project/VReader AI Provider Editor Canvas.html
+vreader/Services/TOCProvider.swift
+vreader/Services/DebugBridge/RealDebugBridgeContext+Provider.swift
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md
+vreader/Services/Backup/BackupProvider.swift
+vreader/Services/Backup/WebDAVProviderFactory.swift
+vreader/Services/Backup/WebDAVProvider.swift
+vreader/Services/TXT/TXTLazyTextProvider.swift
+vreader/Services/Reader/TXTChapterTextProvider.swift
+vreader/Services/Reader/TXTLoaderBackedChapterTextProvider.swift
+vreader/Services/Reader/FoliateChapterTextProvider.swift
+vreader/Services/Reader/PDFChapterTextProvider.swift
+vreader/Services/Reader/MDChapterTextProvider.swift
+vreader/Services/Reader/EPUBChapterTextProvider.swift
+vreader/Services/AI/ChapterTranslationService.swift
+vreader/Services/AI/AnthropicProvider+Streaming.swift
+vreader/Services/AI/AnthropicProvider.swift
+vreader/Services/AI/ResolvedAIProviderConfig.swift
+vreader/Services/AI/Tools/BookContentProviderAdapter.swift
+vreader/Services/AI/KeychainService+ProviderProfile.swift
+vreader/Services/AI/OpenAICompatibleProvider+ToolUse.swift
+vreader/Services/AI/ProviderProfileMigrator.swift
+vreader/Services/AI/ProviderProfile.swift
+vreader/Services/AI/AIProvider.swift
+vreader/Services/AI/MockAIProvider.swift
+vreader/Services/AI/ProviderKind.swift
+vreader/Services/AI/ProviderProfileStore.swift
+vreader/Services/AI/ProviderConfigResolving.swift
+vreader/Services/AI/AnthropicProvider+ToolUse.swift
+vreader/ViewModels/AIProviderPickerViewModel.swift
+vreader/ViewModels/BilingualReadingViewModel+Prefetch.swift
+vreader/ViewModels/BilingualReadingViewModel.swift
+vreader/Services/TTS/TTSProviderProtocol.swift
+vreader/Services/TTS/HTTPTTSProvider.swift
+vreader/App/VReaderAppDelegate.swift
+vreader/App/VReaderApp.swift
+vreader/Views/Settings/AIProviderListView.swift
+vreader/Views/Reader/AIProviderPicker.swift
+vreader/Views/Settings/AIProviderEditSheet+Sections.swift
+vreader/Views/Settings/AIProviderEditSheet.swift
+vreader/Views/Settings/AIProviderListView+Rows.swift
+vreader/Views/Reader/Bilingual/ReaderAIProvidersFlow.swift
+vreader/Views/Reader/Bilingual/ReadinessProviderBlock.swift
+vreader/Views/Reader/EPUBContinuousChapterProvider.swift
+android/app/src/test/kotlin/com/vreader/app/ai/AiChatViewModelTest.kt
+android/app/src/test/kotlin/com/vreader/app/ai/AnthropicProviderTest.kt
+android/app/src/test/kotlin/com/vreader/app/ai/OpenAiCompatibleProviderTest.kt
+android/app/src/test/kotlin/com/vreader/app/ai/AiProviderStoreTest.kt
+android/app/src/test/kotlin/com/vreader/app/ai/AiProviderKindTest.kt
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt
+android/app/src/test/kotlin/com/vreader/app/reader/share/BookFileProviderDisplayNameTest.kt
+android/app/src/test/kotlin/com/vreader/app/reader/nav/ReadiumTocProviderTest.kt
+android/app/src/main/kotlin/com/vreader/app/reader/share/BookFileProvider.kt
+android/app/src/test/kotlin/com/vreader/app/reader/TxtDocumentTest.kt
+android/app/src/main/kotlin/com/vreader/app/reader/nav/ReadiumTocProvider.kt
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocProvider.kt
+android/app/src/main/kotlin/com/vreader/app/reader/nav/BookmarkPreviewProvider.kt
+android/app/src/main/kotlin/com/vreader/app/reader/nav/EmptyTocProvider.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderFactory.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AnthropicProvider.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderKind.kt
+android/app/src/main/kotlin/com/vreader/app/ai/OpenAiCompatibleProvider.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt
+android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderEditSheetTest.kt
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderListScreenTest.kt
+android/app/src/androidTest/kotlin/com/vreader/app/reader/TxtReaderActivityTest.kt
+
+codex
+The repository is clean except for the user’s in-progress plan/tracker/audit artifacts, which I’m treating as read-only. The v4 plan now states the intended fixes clearly; I’m checking whether those contracts fit the actual Compose item model, Kotlin offsets, provider persistence, and the iOS parity it cites.
+exec
+/bin/zsh -lc "sed -n '38,190p' dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md && sed -n '190,370p' dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md && nl -ba android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt && nl -ba android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt | sed -n '1000,1095p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+### The TXT/MD segmentation unit + render mapping (round-2 H1 + round-3 H1/H2 — the core corrections)
+
+**Verified against live code:** `TxtDocument` (`reader/TxtDocument.kt`) exposes only `text: String`, `chunkCount` (`starts.size`, TxtDocument.kt:14), `offsetForChunk(index)` (TxtDocument.kt:17), `chunkForOffset(offsetUtf16)` (TxtDocument.kt:23), `textForChunk(index)` (TxtDocument.kt:36) — line-based ≤4000-char chunks over UTF-16 offsets against the RAW text (no line-ending normalization). It has **no chapter/section concept**.
+
+**Chunk semantics (round-3 Low-2 correction — the real cases):** a chunk is **ONE LINE** — `TxtDocument.of` starts a new chunk after every `\n`, `\r`, or `\r\n` (TxtDocument.kt:65–86; a runaway line >4000 chars is additionally hard-split, never mid-surrogate-pair). Therefore:
+- A **chunk can hold multiple SENTENCES** (one line, several `。！？`/`. ! ?` sentences).
+- A **paragraph spans MANY chunks** (blank-line-delimited paragraph = several physical lines = several chunks).
+- The old v3 claim "a chunk can hold multiple **paragraphs**" is **WRONG and removed.** (A single chunk cannot straddle a line terminator, and paragraph boundaries are blank lines, i.e. chunk boundaries — so a chunk holds *part of one* paragraph, never a whole extra paragraph.)
+
+**v4 model — document-global units with segment ranges produced ONCE:**
+
+- The whole `.txt`/`.md` is treated as **one translation document**. The **segmenter runs once over `TxtDocument.text`** (the full raw backing string) and emits, per segment, its **half-open UTF-16 span `[start, endExclusive)`** against that same backing string (the segmenter's `paragraphRanges(text): List<IntRange>` / `sentenceRanges(text): List<IntRange>` — the range-returning peers of `paragraphs`/`sentences`; iOS precedent `ChapterSegmenter.sentenceRanges(in:)` at `ChapterSegmenter.swift:78`, returns `[Range<Int>]`). These ranges are the SINGLE source of truth used by BOTH the translate side and the render side, so the two segment identically **by construction** (they read the same array). Ranges are stored/compared as explicit `(start, endExclusive)` integer pairs (see the H1 fix below), NOT re-derived on the render side.
+- **Unit granularity for TXT/MD is the whole document, sub-batched for cache/prefetch by a deterministic "unit window."** To avoid translating a 14 MB book at once (and to keep cache rows bounded), segment ranges are grouped into fixed **unit windows** of contiguous segments (window size a build-time constant; it does not change the 1:1 contract). Each window is a `TranslationUnitId(kind = txtDocSegmentWindow, value = windowIndex)` — a document-global index, NOT a chunk index. `unitContaining(charOffsetUTF16)` maps the reader's saved offset → the segment whose range contains it → its window index (via a precomputed segment-start binary search, the same shape as `TxtDocument.chunkForOffset`, TxtDocument.kt:23–33). `unitAfter(unit)` = next window index or null at document end.
+
+#### H1 fix (round-3 High-1) — final-chunk source span math (BINDING)
+
+`offsetForChunk()` **CLAMPS** an out-of-range index to the last valid chunk (`starts[index.coerceIn(0, starts.size - 1)]`, TxtDocument.kt:17–20). So for the LAST chunk `i`, `offsetForChunk(i + 1) == offsetForChunk(i)` → an **empty span** → a one-chunk document drops EVERY translation and a paragraph ending in the final chunk drops its sole translation. `textForChunk()` avoids this by using `text.length` for the final end (TxtDocument.kt:39). The render side MUST do the same. **Binding rule:**
+
+```
+val endExclusive = if (i + 1 < document.chunkCount) document.offsetForChunk(i + 1) else document.text.length
+// chunk i source span is the HALF-OPEN [document.offsetForChunk(i), endExclusive)
+```
+
+- All chunk-span and segment-span computations use **explicit half-open `[start, endExclusive)` integer pairs**, NOT ambiguous Kotlin `IntRange` (an `IntRange` is inclusive-inclusive and `range.last` for an empty/at-EOF segment is a footgun). A segment's "end offset" for anchoring (below) is its `endExclusive`; the chunk that "contains a segment's end" is `document.chunkForOffset(segEndExclusive - 1)` when `segEndExclusive > segStart`, clamped to `[0, chunkCount-1]` (an empty segment is dropped by the segmenter and never anchored).
+- **Tests (WI-4a / WI-8):** one-chunk document (no trailing newline) → its single paragraph/sentence translation renders (not dropped); final-chunk anchor (a paragraph whose last line is the final chunk) → translation renders after the last chunk; exact-boundary (a segment ending exactly at a chunk `start`) → anchored to the correct chunk, not off-by-one; EOF anchor (`segEndExclusive == text.length`) → resolves to the last chunk, no clamp-collapse.
+
+#### H2 fix (round-3 High-2) — the enabled render contract (BINDING; preserves the live per-chunk model)
+
+**The live invariant (verified, TxtReaderActivity.kt:1043–1085):** the TXT/MD body iterates `items(count = document.chunkCount, key = { it })` (TxtReaderActivity.kt:1043). For **each chunk `i`** it owns **exactly ONE `TextLayoutResult`** (`var layout by remember(i) { … }`, set in `onTextLayout`, TxtReaderActivity.kt:1059/1075) and **exactly ONE selection registration** (`selectionController.registerChunk(i, l, c)` / `unregisterChunk(i)`, TxtReaderActivity.kt:1062–1066). Highlights (`highlightSpan(i)`, :1047), annotation washes (`washesForChunk(i)`, :1058), the read-aloud span wash (`addStyle(SpanStyle(background = wash), …)`, :1050–1054), and selection accents (`selectionForChunk(i)` → `drawRangeFill`, :1069/1081) all key off that **per-chunk** layout and the chunk-local UTF-16 offsets. **Splitting a chunk's source `Text` into multiple `Text` nodes (as v3 implied — "source `Text` then translation `Text` per segment") would break every one of these:** two `Text` nodes = two `TextLayoutResult`s = broken selection coordinates, misplaced highlight/wash/annotation ranges, and a shifted read-aloud wash. This is the crux the round-3 audit blocked on.
+
+**v4 binding render contract:**
+
+> **Translations are ADDITIVE `LazyColumn` items rendered at CHUNK (line) boundaries. A source chunk's `Text` is NEVER split.** The existing `items(count = document.chunkCount, key = { it })` source loop stays **byte-identical to today** — same one `Text`, same one `TextLayoutResult`, same one `registerChunk(i, …)`/`unregisterChunk(i)`, same `highlightSpan(i)`/`washesForChunk(i)`/`selectionForChunk(i)` wiring. Each **translation is a NEW, separate `LazyColumn` item** inserted **AFTER** the source chunk that contains the segment's **end** offset (`document.chunkForOffset(segEndExclusive - 1)`, per the H1 math). The translation item is a plain muted `Text` (accent left-border, `fontSize*0.88`, CJK/RTL styling per `BilingualPageContent`) that is **non-selectable and registers NO chunk** — it does not call `registerChunk`, contributes no `TextLayoutResult` to the selection controller, and does not perturb any source chunk's UTF-16 offsets or index `i`.
+
+Concretely the body becomes, per chunk `i` (in a single `items(count = document.chunkCount)` loop, or an explicit interleaving over a precomputed `chunkIndex -> List<translationItem>` map so keys stay stable):
+
+1. Render the source chunk `i` EXACTLY as today (unchanged code path).
+2. Look up the translations **anchored** to chunk `i` = every segment whose end resolves to `chunkForOffset(segEndExclusive - 1) == i`, in segment order, from the shared range array. For **paragraph** granularity there is at most one such translation per anchor chunk in the common case (a paragraph's translation renders after the paragraph's last line-chunk). For **sentence** granularity, when several sentences END in the same line-chunk (one line, multiple sentences), their translations are **grouped** and rendered as a stack of muted items after that chunk, in sentence order.
+3. Emit each anchored translation as its own additive item (keyed by the segment's `(start, endExclusive)` so a granularity/language change re-keys cleanly).
+
+When bilingual is **OFF**, no translation items are emitted → the loop is **byte-identical to today** (translations are additive overlay items only; this is asserted by a source-byte-parity test).
+
+- **Enabled-mode tests (WI-8 connected + WI-7a Compose, BINDING):** with bilingual ON — (a) each source chunk's **selection registration is UNCHANGED** (same `registerChunk(i, …)` count and coordinates as OFF; a translation item registers nothing); (b) **highlights/annotation washes/read-aloud wash still key off the source chunks** at the correct offsets (a translation item between chunks does not shift them); (c) a **translation item is non-selectable** and does not perturb source offsets (selecting across the boundary selects source only); (d) **MD source mapping** — the markdown renderer (`mapper.renderedText(i)`, TxtReaderActivity.kt:1049) still owns the source chunk render; the translation item is plain muted text; (e) **paragraph-spanning-many-chunks** renders exactly ONE translation (after the paragraph's last chunk), never per-line; (f) final-chunk/one-chunk anchors render (H1).
+
+- **Granularity depiction (round-3 H2 — rule-51 call, stated with evidence):** `vreader-bilingual.jsx` `BilingualPageContent` (lines 200–277) is a **paragraph-interlinear** renderer: it maps `page.paragraphs.map(...)` and renders **one source `<p>` followed by ONE translation `<p>`** per paragraph. **Sentence-granularity interlinear (a translation after the line where each sentence ends, grouped when several sentences share a line) is NOT depicted anywhere** — sentence granularity appears ONLY as an option in the `BilingualSetupSheet` Granularity segmented control (`vreader-bilingual.jsx:85–99`), never in the renderer. **Call:** paragraph granularity IS the depicted interlinear pattern and **ships in v1**. The **sentence-granularity render is a rule-51 design gate** (named precisely below) — v1 ships the setup-sheet Granularity control (both options selectable, as depicted) but the **renderer implements only the depicted paragraph pattern**; selecting Sentence in v1 falls back to the depicted paragraph interlinear (the granularity is still carried in the cache key so no wrong-shape row is served) until the sentence-interlinear render is designed. This keeps rule 51 (implement only what is depicted) while shipping the depicted paragraph parity. (The additive-item render contract above is written to accommodate sentence grouping so the gate, once designed, is a render-only follow-up.)
+
+- **MD source** = raw markdown segment text (translation renders as plain muted text, not re-markdown-rendered — matches the muted-secondary design line). Segmentation runs over the raw markdown string; MD markers are treated as ordinary characters by the paragraph splitter (blank-line delimited), consistent with `TxtMdTextExtractor` shipping raw markdown to search.
+
+This closes H1 (no dropped final-chunk translations), H2 (per-chunk layout/selection preserved; source `Text` never split), and Low-2 (correct chunk semantics).
+
+### AI-config reachability — FOLDED IN (#136 CLOSED; Variant A owned by #131)
+
+**Verified against live code:** `AppContainer` (`VReaderApp.kt:31–268`) constructs **NO `AiProviderStore`** — the only reference is a *comment* naming "the OpdsSourceStore / AiProviderStore precedent" (VReaderApp.kt:66), no actual instance/provision. There is **no live navigation route to `AiProviderListScreen`** (the #118 `AiProviderListScreen` / `AiProviderStore` / `AiSettingsViewModel` exist and are exercised only by instrumented/round-trip tests). A fresh-install user therefore cannot reach provider config today.
+
+The Gate-2 audits + the two design-notes proved the ONLY designed Android AI-config reader surface is **Variant A** (`reader-ai-provider-entry.md`, CANONICAL): a **scoped "AI Providers" sheet pushed _inside_ the bilingual sheet**, reached from the bilingual engine-strip's "Set up"/"Change…" button. The design explicitly **rejected** a standalone entry (there is NO designed standalone More-menu "Configure AI" row), a full-Settings deep-link (alternative B), and inline expansion (alternative C). So AI-config reachability is **NOT separable** from the bilingual flow — the #136 spin-out is **CLOSED (GH #1976, not-planned)** and **#131 now owns it end-to-end** (user decision 2026-07-12).
+
+**Navigation model (reproduced EXACTLY from `reader-ai-provider-entry.md`:110–134, invent nothing):**
+
+```
+More ▸ Bilingual mode (first toggle on)
+  └─ BilingualSetupSheet   [bottom sheet]
+       engine strip: "No AI provider configured"  [ Set up ]
+                             │  onOpenSettings
+                             ▼  (push, slide-left, same sheet frame)
+     ReaderAiProvidersSheet  [nav bar: ‹ Bilingual · "AI Providers"]
+       ├─ empty  → [ Add provider ] ─┐
+       └─ list   → tap a row sets it │  (present the canonical editor, full height)
+                             ▼        ▼
+                    AiProviderEditSheet   [reused VERBATIM from #118]
+                             │  Save
+                             ▼  (first provider becomes the bilingual engine,
+                                  pop the whole stack)
+     BilingualSetupSheet  ← engine strip now "Claude · configured" / Change…
+```
+
+- **`‹ Bilingual` without adding** returns to the bilingual sheet **still unconfigured — no state mutated.**
+- **"Change…"** (already-configured strip) opens the **SAME** `ReaderAiProvidersSheet`, populated, current provider checked.
+- The AI Providers view is a **push within the bilingual sheet**, NOT a modal over the reader and NOT the full app Settings.
+
+**Android readiness gate (BINDING — round-3/round-2 H3 + the #136-audit High-3 lesson):** `aiConfigured` on the engine strip is derived by `BilingualAiReadiness.resolve(snapshot)` = **an ACTIVE profile exists AND its API key decrypts to non-empty.** Deriving from `profiles.isEmpty()` alone is **WRONG**: the store keeps a separate `activeId` that can be **null with profiles present** (`AiProviderSnapshot.active = profiles.firstOrNull { it.id == activeId }`, AiProviderStore.kt:34–36), and key usability depends on **decrypting the active profile's token** (`apiKey(profile) = cipher.decrypt(profile.encryptedApiKey)`, AiProviderStore.kt:108). A cipher/keystore failure maps to **not-ready, never a crash** (the resolve wraps the decrypt in `runCatching`). **Note:** the iOS Variant A design-note (`reader-ai-provider-entry.md:172–174`) derives `aiConfigured` from `providers.isEmpty == false`, and iOS #82 (`reader-ai-readiness.md`) adds a 4-gate readiness (flag + consent + provider + key). **Android has NO consent manager and NO feature flag** (#118 has neither — confirm during build); the Android gate is exactly what #118 enforces = **provider (active) + key (decrypts non-empty)**. We do NOT invent a consent/flag gate.
+
+### New files
+
+**Pipeline / domain (host-agnostic, pure or coroutine — JVM-testable):**
+
+- `bilingual/TranslationUnitId.kt` — `data class TranslationUnitId(kind, value)` with `enum Kind { epubHref, foliateHref, txtDocSegmentWindow, mdDocSegmentWindow, pdfPageRange }`; `storageKey = "${kind.name}:$value"`. TXT/MD kinds are **document-global segment-window indices** (H1), NOT chunk indices. v4 uses `epubHref` + `txtDocSegmentWindow`/`mdDocSegmentWindow`; others reserved so the cache-key format never breaks. *(Assumption: iOS's exact Kind case names for the TXT/MD variants; only the `storageKey` string format is load-bearing for the cache contract, and that is preserved.)*
+- `bilingual/TranslationGranularity.kt` — `enum { paragraph, sentence }`. (Design's Granularity control; sentence-render is design-gated per H2.)
+- `bilingual/BilingualLanguages.kt` — `BilingualLanguage(key, glyph, script)`; `BILINGUAL_LANGS` = the exact set from `vreader-bilingual.jsx:15–25` (Chinese/Japanese/Korean cjk, Spanish/French/German/Italian latin, Arabic rtl, Russian cyrillic) + `findOrDefault(key)`. Default `Chinese`.
+- `bilingual/ChapterSegmenter.kt` — **NEW file (no existing Android segmenter — verified).** Port of iOS `ChapterSegmenter`: `paragraphs(text)` / `sentences(text)` **plus the range-returning peers `paragraphRanges(text): List<IntRange>` / `sentenceRanges(text): List<IntRange>`** (half-open UTF-16 spans against the input string — iOS `sentenceRanges(in:)` precedent). Ranges are exposed as explicit `(start, endExclusive)` pairs to the render side (H1). CJK-aware sentence enumeration (`。！？` vs Latin). Pure.
+- `bilingual/TranslationChunker.kt` — `chunk(segments, maxCharsPerChunk)` + `subSplit(text, maxChars)`. Port of iOS `ChapterTranslationChunker.chunk(...)` (`ChapterTranslationChunker.swift:85`) + `subSplit(...)` (returns index groups, oversize segment gets its own chunk; `subSplit` is the Bug #330 grapheme-safe over-budget splitter).
+- `bilingual/TranslationChunkContract.kt` — `userPrompt(segments, targetLanguage)`; `decode(raw, expectedCount)` (strict JSON-array + code-fence strip); `sealed class DecodeError { NotAStringArray; CountMismatch(expected, actual) }`. Port of iOS `TranslationChunkContract` (`TranslationChunkContract.swift:24`). No `style` param — Style descoped v1 (§3).
+- `bilingual/ChapterTextProvider.kt` — `interface { units(); sourceSegments(unit); sourceText(unit); unitContaining(charOffsetUTF16); unitAfter(unit) }`. `sourceSegments(unit)` returns the exact segment strings (from the shared range array). Resolution is host-specific: TXT/MD key on `charOffsetUTF16` → segment-window; EPUB keys on the current-resource `href`. Honest divergence from iOS's uniform Readium `Locator`, documented.
+- `bilingual/TxtChapterTextProvider.kt` — provider over `TxtDocument` + the segmenter's range array (H1). Builds the document-global segment `(start, endExclusive)` ranges once, groups them into windows, resolves `unitContaining` via a segment-start binary search over `charOffsetUTF16`. MD source = raw markdown segment text.
+- `bilingual/EpubChapterTextProvider.kt` (WI-0-gated shape) — provider over the Readium `Publication` reading order; `units()` = spine hrefs, `unitContaining` = the locator's href (from `EpubNavigatorFragment.getCurrentLocator()`), `sourceSegments(unit)` = the DOM-enumerated block texts (the render's OWN enumeration, for direct-block 1:1 — H2). Its render-side collaborator is `EpubBilingualJs`.
+- `bilingual/ChapterTranslationError.kt` — `sealed { Offline; TimedOut; ProviderFailed(msg); Cancelled }`. Maps from `AiError` (verified cases `Auth401`, `RateLimited429`, `Offline`, `Timeout`, `Http(code)`, `Decode`, `Stream`, `InsecureUrl`, `Config`, AiTypes.kt).
+- `bilingual/ChapterTranslationService.kt` — the iOS-parity service (full divergence-recovery surface, round-2 H2):
+  - `cachedTranslation(bookKey, unit, sourceText, targetLanguage, granularity, acceptCountMismatch=false)` — cache-only; serves a row only when `sourceParagraphCount == segments.size` (or `acceptCountMismatch`). No provider (#306 parity).
+  - `cachedTranslation(bookKey, unit, expectedSegmentCount, targetLanguage)` — the divergence-fallback cache-only restore (iOS Bug #343): serves the canonical row only when its STORED `sourceParagraphCount == expectedSegmentCount`. Needs no source text and no provider → a cache-hit toggle/reopen restores with **zero provider calls**.
+  - `translate(bookKey, unit, sourceText, targetLanguage, providerProfile, granularity, bypassCacheRead=false)` — segment → chunk → per-chunk `AiClient.chat` one-shot → `decode` → per-segment fallback → per-chunk graceful degrade (Bug #330) → cache-write only on full success (`sourceParagraphCount = segments.size`). **Cancellation:** maps BOTH native `CancellationException` AND typed `ChapterTranslationError.Cancelled` to `Cancelled` (mirrors iOS `ChapterTranslationService.swift:359–364`); `ensureActive()` between chunks AND immediately before the Room write.
+  - `translatePreSegmented(bookKey, unit, segments, targetLanguage, providerProfile)` — the count-divergence recovery (iOS Bugs #268/#330/#343). Takes the render's OWN enumerated block texts as `segments` (1:1), chunks them, translates with the same per-chunk graceful-degrade + dual-cancellation contract, and — on full success only — caches under the canonical key with the ENUMERATE's count as `sourceParagraphCount`. A partial degrade is NOT cached; a cache-write failure does not fail the translation (iOS `ChapterTranslationService.swift:374–384`).
+  - Uses `AiClient.chat(AiRequest)` (one-shot, verified — NOT `streamChat`).
+- `bilingual/ChapterTranslationPrefetcher.kt` — resolves the active profile from one `AiProviderStore.snapshot()` (`snapshot.active`), decrypts via `store.apiKey(profile)` (snapshot-consistent, AiProviderStore.kt:108), builds an `AiClient` via an **injected factory param** (below), cache-first then translate. Adds the direct-block peers (H2):
+  - `prefetch(unit)` — the plain-text path.
+  - `prefetchDirect(unit, sourceSegments, targetLanguage)` — the divergence path (iOS `translatedSegmentsDirect`, `ChapterTranslationPrefetcher.swift:197`).
+  - `cachedDirect(unit, expectedCount, targetLanguage)` — the **zero-provider cache-only restore** (iOS `cachedSegmentsDirect` → `cachedTranslation(expectedSegmentCount:)`, `ChapterTranslationPrefetcher.swift:236`): returns a cached translation on a hit WITHOUT requiring an active provider (#306 pre-gate precedent). Backs the EPUB cache-restore path.
+  - **`AiRequest` construction (round-3 M3 fix, BINDING):** `model = profile.model.ifBlank { profile.kind.defaultModel }` — matches `AiChatViewModel.kt:61`; both wire clients serialize `request.model` **directly** (`put("model", request.model)` in `OpenAiCompatibleProvider.kt:39` and `AnthropicProvider.kt:37`), so a blank `profile.model` would send an empty model. Full request: `AiRequest(model = profile.model.ifBlank { profile.kind.defaultModel }, messages = …, temperature = profile.temperature, maxTokens = profile.maxTokens, system = …)`. A **blank-model regression test** asserts the fallback is applied.
+  - Throws `ChapterTranslationError`. Mirrors iOS `ChapterTranslationPrefetcher`.
+- `bilingual/BilingualAiReadiness.kt` — `resolve(snapshot: AiProviderSnapshot): Boolean` — active profile exists (`snapshot.active != null`) AND `runCatching { store.apiKey(snapshot.active).isNotEmpty() }.getOrDefault(false)` (cipher/decryption failure → **not-ready**, never crashes). Drives the setup-sheet engine-strip configured/unconfigured state. Exactly the #118 gate (no consent manager / feature flag on Android — confirm during build).
+
+**State / persistence:**
+
+- `bilingual/PerBookBilingualStore.kt` — DataStore-Preferences, keyed by `bookFingerprintKey`, holding `{ enabled, targetLanguage, granularity }`. The Android `PerBookSettingsOverride` bilingual slice — the backup contract declares exactly `bilingualEnabled` / `bilingualTargetLanguage` / `bilingualGranularity` and **NO `bilingualStyle`** (verified). Wiring into backup collect/restore is scoped OUT (§7); until then bilingual config is device-local.
+- `bilingual/BilingualViewModel.kt` — `StateFlow<BilingualUiState>` with `enabled`, `targetLanguage`, `granularity`, `needsSetupSheet`, `aiConfigured`, `translationsByUnit`, `inFlightUnits`, `unavailableUnits`, `errorUnit`. Setters + `dismissSetupSheet`, `onPositionChanged(charOffsetUTF16)`, `retryUnit(unit)`, and the EPUB direct-block entry `onEpubBlocksEnumerated(unit, blocks)` (M1, below). Generation/epoch-guarded prefetch (current + next unit); a **per-unit single-flight job registry** (M2); dual-cancellation handling (M2). Port of iOS `BilingualReadingViewModel` (`prefetchTasks: [TranslationUnitID: Task]`, `BilingualReadingViewModel.swift:141`) + `+Prefetch`. Split to `BilingualPrefetchController.kt` if it nears ~300 lines. No `style` field.
+
+**Room (translation cache):**
+
+- `data/ChapterTranslationEntity.kt` — `@Entity(tableName="chapter_translations", indices=[Index("bookKey")], foreignKeys=[FK→books.fingerprintKey ON DELETE CASCADE])`. **`@PrimaryKey val lookupKey: String`** (Room requires a PK; project pattern `@PrimaryKey` + `@Upsert`, verified `BookEntity`/`BookDao`). `lookupKey` = `bookKey|unitStorageKey|targetLanguage|promptVersion`. Columns: `bookKey`, `unitStorageKey`, `targetLanguage`, `promptVersion`, `translatedJson`, `sourceParagraphCount`, `createdAt`. Mirrors iOS `ChapterTranslationRecord.lookupKey` (`book|unit|lang|prompt`, profile-agnostic — Bug #342). `sourceParagraphCount` is load-bearing for H2 (stores the enumerate's count on the `translatePreSegmented` path so `cachedTranslation(expectedSegmentCount:)` restores).
+- `data/ChapterTranslationDao.kt` — `getByLookupKey(key)`, `@Upsert suspend fun upsert(row)`, `deleteByLookupKey(key)`.
+- `bilingual/ChapterTranslationStore.kt` — coroutine wrapper returning a `CachedTranslation` (segments decoded from JSON), keeping Room entities off the boundary (iOS `ChapterTranslationStore` precedent).
+
+**Cache-identity (reconciled with iOS parity):** the 4-part key `book|unit|lang|promptVersion` is profile-AGNOSTIC / style-agnostic (Bug #342). Style is descoped (§3) so no `s=` component. **Granularity IS user-selectable**, carried in `promptVersion` as an effective composite: `promptVersion = "bilingual-v1|g=${granularity}"` (a paragraph vs sentence translation is a different cache row — closes the iOS #344 "sentence silently ignored" class by construction; also means the H2 sentence design-gate never serves a paragraph row as sentences). A granularity change cancels in-flight jobs, bumps the VM generation, clears shaped `translationsByUnit`, and forces a correctly-keyed re-fetch (WI-6).
+
+**DI / factory (verified live):** `AiProviderFactory` is an `object` with `create(profile, apiKey, dispatcher = Dispatchers.IO): AiClient` (verified, `AiProviderFactory.kt:10`). `ChapterTranslationPrefetcher` takes its OWN injected `clientFactory: (AiProviderProfile, String) -> AiClient` param **defaulting to `AiProviderFactory::create`**, overridden with a fake in tests.
+
+**UI (Compose — every state depicted, reproducing `vreader-bilingual.jsx` + `vreader-ai-provider-entry.jsx`):**
+
+- `bilingual/BilingualSetupSheet.kt` — reproduces `vreader-bilingual.jsx`'s `BilingualSetupSheet` (lines 27–156) EXACTLY: header; a preview strip (`BilingualPreview`); a language grid over `BILINGUAL_LANGS` (glyph tiles, selected accent); a **Granularity** segmented control (Paragraph "Translate after each ¶" / Sentence "Translate after each sentence"); a **Translation engine** strip (configured: "Claude · with this book's context" + "Change…"; unconfigured: "No AI provider configured" + "Bilingual mode needs an AI provider to translate." + "Set up"); the "Turn on bilingual mode" CTA. **No Style control, no provider/model card, no term-overrides toggle, no cost footer** (those belong to the `vreader-ai-android.jsx` sheet, not reproduced — §3). The `aiConfigured` flag comes from `BilingualAiReadiness.resolve`. The "Set up"/"Change…" CTA routes to `ReaderAiProvidersSheet` (wired in WI-9).
+- `bilingual/ReaderAiProvidersSheet.kt` — **NEW (folded in; the Android analog of iOS `ReaderAIProvidersView`).** The Variant A scoped in-reader AI Providers sheet, reproducing `vreader-ai-provider-entry.jsx` `AIProvidersSheet` + `NavSheet` (nav bar `‹ Bilingual` leading + centered "AI Providers" title). It hosts **ONLY the provider list** — nothing else from settings. It **reuses the #118 `AiProviderListScreen` (list, empty + populated states) and `AiProviderEditSheet` (the canonical add/edit modal) VERBATIM**, driven by the #118 `AiSettingsViewModel` (`listState`, `editState`, `openAdd/openEdit/save/setActive`, verified `AiSettingsViewModel.kt`). Behavior per the nav model:
+  - **Empty state** shows the bilingual-context copy "Bilingual mode needs a provider to translate" + an "Add provider" CTA (the design-note's line 47–49 copy; `AiProviderListScreen`'s `AiEmptyState` already renders an equivalent "Add a provider" CTA — the bilingual-context line is the sheet's own header context strip per `AIProvidersSheetBody`, `vreader-ai-provider-entry.jsx:167–183`).
+  - **Add provider** presents `AiProviderEditSheet` unchanged; **on the first Save** the new provider becomes active/the bilingual engine and the stack **pops all the way back** to the bilingual sheet with the engine strip now reading "Claude · configured / Change…". (First-provider-active is already the store's behavior — `AiProviderStore.upsert` sets `activeId = cur.activeId ?: id`, AiProviderStore.kt:81; the sheet additionally calls `store.setActive(savedId)` on the first-Save-from-bilingual path so the freshly-saved provider is the engine even if others existed.)
+  - `‹ Bilingual` **without adding** returns unconfigured — **no state mutated.**
+  - "Change…" opens the SAME sheet, populated, current provider checked (tapping a row → `setActive`).
+  - No consent card, no feature-flag toggle, no readiness tracker (that is iOS #82, deferred — §"AI-config reachability").
+- `bilingual/BilingualInterlinearBody.kt` — the Compose render surface for the **TXT/MD host ONLY** (round-2 M2). Emits the **additive translation `LazyColumn` items** per the H2 render contract (source chunks unchanged; translation items after the anchor chunk): muted `Text`, accent left-border, `fontSize*0.88`, CJK font for cjk scripts, RTL handling for Arabic (per `BilingualPageContent`, `vreader-bilingual.jsx:200–277`). Consumes the host-neutral `BilingualRenderState` DTO. Loading state ("Translating chapter… N%" + per-segment dim), error state ("Couldn't translate" + Retry), partial/offline (`unavailableUnits`): source-only silent fallback (iOS Decision 2). **NOT the EPUB render surface.**
+- `bilingual/BilingualRenderState.kt` — the host-neutral state DTO shared by the Compose body and the EPUB adapter (round-2 M2): per-unit `{ segments: List<String>?, phase: Loaded|Loading(fraction)|Error|SourceOnly }`. Compose and EPUB share the state/value types, NOT the composable body.
+- `bilingual/EpubBilingualJs.kt` (WI-0-gated) — the EPUB render surface (round-2 M2). Pure Kotlin builder producing JS strings for `navigator.evaluateJavascript(...)`: `enumScript` (enumerate current-resource leaf blocks → JSON `[{id,text}]`), `injectScript(blockId, translationText)` (translation DOM node after the block; CSP-safe: `textContent`/`createTextNode`, never `innerHTML` string-concat; RTL/CJK via class + injected `<style>`), `clearScript()` (idempotent removal). Escaping done in Kotlin (JSON-encode every interpolated string). No Compose. Consumes `BilingualRenderState`.
+- `bilingual/EpubBilingualController.kt` (WI-0-gated) — **the single owner of EPUB units (M1, below).** The runtime actor that serializes enumerate→(cache-restore|translate)→inject/clear against the navigator using WI-0's chosen mechanism (a single mutex OR a monotonic navigator-session token); checks the session token after every suspended JS/AI call; clears BEFORE publication teardown; re-applies on the identified production re-apply signal.
+- `bilingual/BilingualPill.kt` — the `EN ↔ 中` reader-top-chrome pill (per `vreader-reader.jsx` + `vreader-bilingual.jsx` `BilingualPill`:282–305). Rendered by #132's top chrome; #131 provides the composable, #132's surface hosts it (§4).
+
+### EPUB direct-block flow — one owner + concrete API (round-3 Medium-1, BINDING)
+
+The **`EpubBilingualController` is the SINGLE OWNER of EPUB units**; the VM's position-driven regular `prefetch` path is **TXT/MD-only**. Concretely, an EPUB position change routes THROUGH the controller (the VM does not run `prefetch(unit)` for `epubHref` units), so the **controller is the sole writer** of an EPUB unit's canonical cache row and its `BilingualRenderState`/`translationsByUnit` entry — the position-driven regular prefetch and the direct-block path can never both write the same canonical cache row. The control flow (every suspended step session-token-guarded):
+
+```
+enumeratedBlocks = navigator.evaluateJavascript(EpubBilingualJs.enumScript)   // [{id,text}] for current resource
+        │  (session token S captured before the call; re-checked after)
+        ▼
+count = enumeratedBlocks.size
+restore = prefetcher.cachedDirect(unit, expectedCount = count, targetLanguage)  // zero-provider cache restore
+        │
+        ├─ hit  → segments = restore
+        └─ miss → segments = prefetcher.prefetchDirect(unit, sourceSegments = enumeratedBlocks.texts, targetLanguage)
+        │  (token re-checked after each suspension; a stale token → discard, no commit, no error surfaced)
+        │  (token re-checked after each suspension; a stale token → discard, no commit, no error surfaced)
+        ▼
+if token S still current:  commit segments → BilingualRenderState[unit] / translationsByUnit[unit]  (single writer)
+        ▼
+EpubBilingualJs.injectScript per (blockId, translation)  via navigator.evaluateJavascript   // token-guarded
+```
+
+- The VM exposes `onEpubBlocksEnumerated(unit, blocks)` as the controller's entry into VM render state, but the **controller owns the enumerate→cachedDirect/prefetchDirect→guarded-commit sequence**; the VM never initiates an EPUB prefetch itself (its position-driven `prefetch` dispatches only `txtDocSegmentWindow`/`mdDocSegmentWindow` units). A stale session token at any commit point discards silently (no `errorUnit`).
+- WI-7b's connected test asserts: enable → inject; disable → clear; reflow/href-change/fragment-recreation/activity-recreation → re-apply from cache via `cachedDirect` (zero provider calls); count-divergence handled via `prefetchDirect`; and that the regular TXT/MD prefetch path is never invoked for an EPUB unit.
+
+### Cancellation + single-flight (round-3 Medium-2, BINDING)
+
+- **Dual-cancellation across the service/VM boundary:** both the service AND the VM handle **BOTH** native `CancellationException` **AND** the typed `ChapterTranslationError.Cancelled` **before** generic error mapping — matching iOS `ChapterTranslationService.swift:359–364` (which catches `is CancellationError` and `ChapterTranslationError.cancelled` separately, both re-throwing `cancelled`). A cancelled stale request MUST NOT surface as `errorUnit` (it is discarded).
+- **Per-unit single-flight job registry (VM):** a `prefetchTasks: MutableMap<TranslationUnitId, Job>` (iOS `prefetchTasks: [TranslationUnitID: Task]`, `BilingualReadingViewModel.swift:141`, cancelled/removed on disable/unit-change at :165). A NEW request for a unit **cancels-or-joins** the prior job (a stale prior is cancelled and awaited so it cannot run overlapping translations or Room writes), keyed by unit. Rapid retry/navigation cannot run overlapping translations for the same unit. `retryUnit(unit)` goes through the same registry. Tests: a mid-flight cancel discards (no `errorUnit`, no partial cache row); a rapid re-trigger for the same unit does not double-write.
+
+### Modified files
+
+- `data/VReaderDatabase.kt` — add `ChapterTranslationEntity` to `@Database entities`, bump `version` **8 → 9** (the live DB is v8, migrations `MIGRATION_1_2`..`MIGRATION_7_8`, `ALL_MIGRATIONS` ends at `MIGRATION_7_8` — verified VReaderDatabase.kt:29,224–228), add **`MIGRATION_8_9`** (CREATE TABLE `chapter_translations` + `bookKey` index + FK→`books.fingerprintKey` CASCADE, DDL exactly matching Room's generated schema), **append `MIGRATION_8_9` to `ALL_MIGRATIONS` after `MIGRATION_7_8`**, add `abstract fun chapterTranslationDao()`. Purely additive.
+- `reader/TxtReaderActivity.kt` — own a `BilingualViewModel`; collect state; render translations as **additive items after the anchor chunk in the existing `items(count = document.chunkCount, key = { it })` loop (TxtReaderActivity.kt:1043), source chunks byte-unchanged (H2)**; on position change call `vm.onPositionChanged(charOffsetUTF16)`. Strictly gated to `originalFormat ∈ {txt, md}`; disabled = body byte-unchanged (overlay-only). **Owned by #129 (VERIFIED, merged) — a straight edit, rule 48 one-writer-per-file satisfied.**
+- `reader/ReaderActivity.kt` (Readium EPUB) — WI-0-gated: attach `EpubBilingualController` to `navigator.evaluateJavascript`; re-apply on the identified production re-apply signal; clear on teardown BEFORE publication teardown. `navigator: EpubNavigatorFragment?` is the verified live field (ReaderActivity.kt:110).
+- `reader/chrome/ReaderChromeScaffold.kt` — extend `readerMoreRows(...)` (currently supplies only `MoreActionId.DETAILS` + `SHARE`, ReaderChromeScaffold.kt:255–258) to ALSO supply the **`MoreRow.Toggle(id = MoreActionId.BILINGUAL, on = enabled, onToggle = …)`** row (or `MoreRow.Disabled` "Configure AI provider first" when not configured — `MoreRow.Disabled` exists for exactly this, MoreRow.kt:65–72). Threaded via new nullable params so #132/#134-only callers stay valid (the scaffold's established nullable-default pattern). This is the WI-9 entry-wiring edit.
+- `VReaderApp.kt` / `AppContainer` — **provide `AiProviderStore` INTO `AppContainer` itself** (it is NOT provided today — verified, only a comment names it at VReaderApp.kt:66) using the #116 `KeystoreSecretCipher` + a DataStore under the same convention as `readerSettingsStore`, PLUS provide `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, an `AiSettingsViewModel` factory (for the Variant A sheet), and a `BilingualViewModel` factory. **Extracted into the shared DI WI (WI-4b).** No `feat:#136` dependency remains — #131 owns the `AiProviderStore`-into-`AppContainer` wiring.
+
+**NOT modified:** `reader/chrome/ReaderBottomChrome.kt` gets **no** bilingual/Translate slot — the design's entry is the More-menu toggle (#134) + the top-chrome pill (#132), NOT a bottom-chrome slot. `ReaderBottomChrome`'s existing `extraSlot` is untouched.
+
+### Files OUT of scope for v1
+
+- **`Azw3ReaderActivity.kt` / `reader/foliate/`** — foliate WebView interlinear IS feasible but deferred (bundle-patch JS + secure-bridge additions touch the security-sensitive #126 surface). Once WI-0 proves the EPUB JS pipeline, the foliate host reuses `EpubBilingualJs` with a bundle adapter.
+- **`PdfReaderActivity.kt`** — no reflowable text layer. Out (`pdfPageRange` Kind reserved only).
+- **Backup collect/restore of `PerBookSettingsOverride` bilingual fields** — contract fields exist; wiring is a small additive follow-up (§7). Device-local until then.
+- **Style control** — descoped v1 (user decision, §3). Keep provider/model/**granularity**, DROP the bilingual "Style" control.
+- **Sentence-granularity interlinear RENDER** — not depicted (H2); design-gated. v1 renders the depicted paragraph pattern; Sentence selection falls back to paragraph render (cache still granularity-keyed).
+- **The iOS #82 readiness sheet (feature-flag + consent gates)** — `reader-ai-readiness.md` is iOS-specific and implementation-deferred; Android has no flag/consent, so the Variant A provider-list sheet is the whole AI-config surface. Out.
+- **"Translate entire book…" batch, re-translate/style-swap picker, cost/token estimation, term-overrides** — iOS/`vreader-ai-android.jsx` extras not in the authoritative sheet. Out.
+- **Streaming translation progress** — the design's "38%" is chapter-level N-of-M chunk progress, not token streaming. v1 shows N-of-M.
+
+## 3. Prior art / project precedent / rejected alternatives
+
+### The render-host decision (settled v2, CONFIRMED round-2)
+
+**How iOS does interlinear:** iOS renders EPUB/AZW3 in a WKWebView it fully controls. `EPUBBilingualOrchestrator` injects JS that (1) enumerates leaf blocks posting `[{bid,text}]` to Swift, (2) after translation injects a translation node after each block. TXT/MD render in a text path where the renderer interleaves translation runs. The mechanism = **the app inserts translation nodes between source nodes** — which is exactly the Android additive-item contract (H2) for TXT/MD and the DOM-inject contract for EPUB.
+
+**Android EPUB feasibility (round-2 re-verified):** the transformed API JAR on the resolved Readium 3.3.0 AAR (build.gradle.kts:111) exposes public `evaluateJavascript`, `getCurrentLocator()`, `firstVisibleElementLocator(...)`, `submitPreferences(...)`; `ReaderActivity.navigator: EpubNavigatorFragment?` holds the concrete fragment (ReaderActivity.kt:110). EPUB interlinear via JS injection is feasible with the public API — **no Readium fork.** Not reopened.
+
+**WI-0 — Readium bilingual spike (gates WI-7b; round-2 M1):** a throwaway harness that, against a real EPUB on the emulator, must PROVE each go/no-go criterion: (a) enumeration deterministic + idempotent with stable node IDs (repeat apply = no duplicate nodes); (b) clear wins over every older inject (a late inject checks the session token and no-ops); (c) recreation restores from cache for every case (href away/back, same-href `submitPreferences` reflow, internal page-fragment recreation, activity recreation) via `cachedDirect(expectedCount)` (zero provider calls) with an identified PRODUCTION re-apply signal per case; (d) locator/visible-source preservation across injection (stated permissible pagination delta); (e) enumerated block count vs segmenter count measured — divergence → the direct-block path (`prefetchDirect`/`cachedDirect`, H2) is the recovery, proven end-to-end. **Race contract:** single actor/mutex OR monotonic navigator-session token; token/mutex check after every suspended JS/AI call; clear before publication teardown. **No deterministic re-apply signal for a recreation case (c) = explicit NO-GO** → EPUB drops to a tracked follow-up, box D ships **TXT/MD-only** with the honest reason (a specific spike finding), never the false "requires a fork."
+
+**Rejected alternatives:**
+1. **Readium interlinear via decorations only** — REJECTED (decorations style existing text; they cannot insert translation paragraphs).
+2. **Forking Readium** — REJECTED + unnecessary (public `evaluateJavascript` seam exists).
+3. **AZW3 foliate host first** — REJECTED for v1 (deferred; touches the security-sensitive #126 bridge).
+4. **Eager whole-book pre-translation** — REJECTED (cost/latency). Lazily prefetch current+next + cache.
+5. **One `BilingualInterlinearBody` per chunk (v2)** — REJECTED (round-2 H1): a chunk is not a segment.
+6. **A Compose body as the EPUB render surface (v2)** — REJECTED (round-2 M2): Compose cannot render inside Readium's WebView.
+7. **Splitting a chunk's source `Text` into per-segment `Text` nodes to interleave translations (v3)** — REJECTED (round-3 H2): breaks the live one-`TextLayoutResult` + one-selection-registration-per-chunk model. Replaced by additive `LazyColumn` items at chunk boundaries, source `Text` never split.
+8. **Deriving `aiConfigured` from `profiles.isEmpty()` (the iOS Variant A note's derivation)** — REJECTED for Android: `activeId` can be null with profiles present, and key usability needs the active profile's token to decrypt (H3). Android uses `BilingualAiReadiness.resolve` = active-profile + decrypts-non-empty.
+9. **Spinning AI-config reachability out as a separate feature #136** — REJECTED / CLOSED (2026-07-12): the design proved the ONLY designed Android AI-config reader surface is bilingual-coupled Variant A; there is no designed standalone entry, so it is not separable. #131 owns it.
+
+### The setup-sheet resolution (rule 51) + Style descope (round-2 H3, USER DECISION)
+
+There are **two committed, differently-shaped** `BilingualSetupSheet`s:
+- `vreader-bilingual.jsx` → **language grid + Granularity + preview strip + Translation-engine strip (Set up/Change) + Cancel/Translate**. No Style, no provider/model card, no term-overrides, no cost.
+- `vreader-ai-android.jsx` → **Languages (From/To) + Provider card + Style (Literal/Natural/Literary) + Keep-term-overrides toggle + cost footer**. No language grid, no Granularity, no preview.
+
+**Resolution:** this plan reproduces the **`vreader-bilingual.jsx` sheet EXACTLY**. **Style is DESCOPED for v1** (user decision): keep provider/model/**granularity**, DROP the bilingual "Style" control. Consequently store/VM carry no `style`, the chunk contract has no `style` param, and the cache key's `promptVersion` has no `s=` component.
+
+**Box-D parity note (do NOT claim full box-D parity):** the box-D checklist lists provider/model/**style**. Because Style is descoped, **WI-9 flips box D to done ONLY for provider/model/granularity + a descope note**; a follow-up tracker/checklist amendment records the Style descope. If Style is later wanted, that needs an updated committed design (a single sheet showing BOTH Style AND Granularity is not depicted anywhere — the one Style design gate below).
+
+### The AI-config path (rule 51) — Variant A is the committed design
+
+The canonical decision (`reader-ai-provider-entry.md`, Variant A) + its component canvas (`vreader-ai-provider-entry.jsx`) ARE the committed design; #131 reproduces only what they depict (a `‹ Bilingual`-titled push sheet hosting the #118 provider list + the canonical editor, pop-back-on-first-save). No AI-config sheet or nav is invented. The iOS #82 readiness additions (flag/consent) are explicitly **out** on Android (no such subsystems exist). This is a designed surface — it is NOT a design gate.
+
+### Other precedents applied
+
+- **#118 provider seam**: reuse `AiProviderStore.snapshot()` (`snapshot.active`) + `store.apiKey(profile)` + `AiProviderFactory.create` (default of an injected factory param) + `AiClient.chat`. #118's AI files are unchanged; #131 wires `AiProviderStore` into `AppContainer` and reuses `AiProviderListScreen`/`AiProviderEditSheet`/`AiSettingsViewModel` verbatim for the Variant A sheet.
+- **Room additive-migration pattern** (#122/#123/#127/#128/#135): version bump + `MIGRATION_n_(n+1)` appended to `ALL_MIGRATIONS` + exact-DDL + `VReaderDatabaseMigrationTest` PRAGMA guard. `@PrimaryKey` + `@Upsert` is the project DAO pattern (`BookDao`). Baseline v8.
+- **DataStore JSON-in-Preferences** for `PerBookBilingualStore` (the `ReaderSettingsStore`/`AiProviderStore` pattern).
+- **Pure-logic port**: iOS `ChapterSegmenter`/`ChapterTranslationChunker`/`TranslationChunkContract`/`ChapterTranslationService.translatePreSegmented`/`ChapterTranslationPrefetcher.translatedSegmentsDirect`+`cachedSegmentsDirect` are pure/heavily-unit-tested — direct Kotlin ports with the same test vectors (all verified to exist).
+- **Single-flight job registry**: iOS `prefetchTasks: [TranslationUnitID: Task]` (`BilingualReadingViewModel.swift:141`) — ported as `prefetchTasks: Map<TranslationUnitId, Job>` (M2).
+- **Entry point via #132/#134 (VERIFIED)**: the More-menu bilingual toggle (`MoreActionId.BILINGUAL` reserved; `MoreRow.Toggle`/`MoreRow.Disabled`) + top-chrome pill are landed; #131 mounts the pill + wires the toggle (§4).
+
+## 4. Work-item sequencing
+
+**13 WIs/PRs (round-3 Low-1 fix — corrected count):** the list is exactly **WI-0, WI-1, WI-2, WI-3, WI-4a, WI-4b, WI-5, WI-6, WI-7a, WI-7b, WI-AIP, WI-8, WI-9** = **13 WIs**. (v3 had 12: WI-0,1,2,3,4a,4b,5,6,7a,7b,8,9. Folding in the Variant A "AI Providers" sheet adds **WI-AIP**, making 13. The prior "11 WIs" claim in the plan header and `docs/features.md` was wrong on two counts and is corrected here.) Each WI = one PR. Build order: **foundation/cache → service/direct-block APIs → shared DI/factory (incl. `AiProviderStore` in `AppContainer`) → VM state/prefetch → host-specific renderers (TXT/MD + EPUB) + the Variant A AI Providers sheet → entry wiring.**
+
+**Dependencies (round-3 Medium-4 — dependency honesty; #136 folded in):**
+
+- **`Deps: [feat:#132, feat:#134]`.** **#132 (top chrome) and #134 (More menu) are VERIFIED.** **#129 (TXT/MD reader) is VERIFIED** — `TxtReaderActivity` is a straight edit, not a blocker. **There is NO external AI-reachability blocker** — the former #136 is CLOSED (GH #1976, not-planned) and its scope is #131-owned.
+- **WI-4b is foundational and gates the behavioral chain.** WI-4b now provides `AiProviderStore` into `AppContainer` PLUS the bilingual services + factories. Per the audit's Medium-4, WI-4b transitively gates WI-6 (needs the prefetcher/DI), WI-7b (needs DI), WI-AIP (needs `AiProviderStore` + `AiSettingsViewModel` from `AppContainer`), and WI-8 (needs DI). **Chosen resolution: injected seams so the behavioral work proceeds against fakes before WI-4b lands, AND WI-4b is sequenced early.** Concretely: the VM (WI-5/WI-6) takes an injected `ChapterTranslationPrefetcher` (fake in tests) and an injected `AiProviderSnapshot` provider (fake); the TXT/MD host Compose/unit work (WI-8) and the Variant A sheet (WI-AIP) take injected VM/store/`AiSettingsViewModel` seams — so unit/Compose tests do not wait on `AppContainer`. **WI-4b is built right after WI-4a (before WI-6/WI-7b/WI-AIP/WI-8) so the production wiring lands before the host integrations that mount it.** This is stated honestly: the *production run-through* of WI-6/WI-7b/WI-AIP/WI-8 depends on WI-4b; their *unit/Compose gates* depend only on the injected seams. No external feature gates any of this.
+
+**WI-0 (spike): Readium EPUB bilingual injection — go/no-go + race contract (M1).** Harness + criteria (a)–(e) and the race contract in §3. Output: a go/no-go on EPUB-in-v1 (no-go = box D ships TXT/MD-only, tracked) + the concrete `EpubChapterTextProvider` / `EpubBilingualJs` / `EpubBilingualController` surfaces + the EPUB direct-block ownership sequence (Medium-1). Deps: none (uses the existing #106 Readium host). Not TDD-gated (throwaway spike); feeds WI-7b.
+
+**WI-1 (foundational): value types + pure segmentation/chunk/contract.** `TranslationUnitId`, `TranslationGranularity`, `BilingualLanguages`, **`ChapterSegmenter` (with `paragraphRanges`/`sentenceRanges` returning half-open UTF-16 `(start, endExclusive)` spans — H1)**, `TranslationChunker`, `TranslationChunkContract` (no `style`), `ChapterTranslationError`. Pure; ported iOS vectors. Deps: none.
+
+**WI-2 (foundational): Room translation cache.** `ChapterTranslationEntity` (PK = `lookupKey`, `sourceParagraphCount` column) + `Dao` (`@Upsert`) + `ChapterTranslationStore`; `VReaderDatabase` **8→9 `MIGRATION_8_9`** appended after `MIGRATION_7_8`. Robolectric migration round-trip from v8 + full-chain + upsert/get/delete-by-lookupKey + FK-CASCADE + exact-DDL guard. Deps: none.
+
+**WI-3 (foundational): `ChapterTranslationService`** against a fake `AiClient`. Both `cachedTranslation` overloads (incl. the `expectedSegmentCount` divergence restore — H2) + `translate` + `translatePreSegmented`. **Dual-cancellation (native + typed `Cancelled`) BEFORE generic mapping (M2).** Deps: WI-1, WI-2. Tests: cache hit → zero client calls; miss → translate + write; decode fail → per-segment fallback; one-chunk fail → source-only that chunk (others translated, NOT cached); all-chunks fail → throw; native-cancel → `Cancelled` (no write); typed-`Cancelled`-from-chunk → `Cancelled` (no write); ensureActive-before-write; `AiError` mapping incl. `Config`/`InsecureUrl` → `ProviderFailed`; `translatePreSegmented` full-success caches under the enumerate count; partial degrade NOT cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` returns on stored-count match, null on mismatch, needs no provider.
+
+**WI-4a (foundational): `ChapterTextProvider` (TXT/MD) + `ChapterTranslationPrefetcher` + `BilingualAiReadiness`.** `TxtChapterTextProvider` builds the document-global segment `(start, endExclusive)` ranges once (H1), groups into windows, resolves `unitContaining(charOffsetUTF16)` via segment-start binary search, `sourceSegments(unit)`. Prefetcher: `prefetch` + `prefetchDirect` + `cachedDirect`; resolves active profile from `snapshot()`, decrypts snapshot-consistent, builds client via the injected factory param (default `AiProviderFactory::create`), constructs `AiRequest` with **`model = profile.model.ifBlank { profile.kind.defaultModel }` (M3)**. Readiness = active profile with non-empty decrypted key; **cipher failure → not-ready, never a crash.** Fake store + fake factory. Deps: WI-1, WI-3. Tests (all half-open-range-based): unit resolution + clamp + empty; **one-chunk document (no trailing newline) → its segment translation renders, not dropped (H1)**; **final-chunk anchor → renders (H1)**; **exact-boundary → correct anchor (H1)**; **EOF anchor (`segEndExclusive == text.length`) → last chunk, no clamp-collapse (H1)**; paragraph spanning MANY chunks → one segment/one unit, anchored to the last chunk (Low-2); multiple SENTENCES in one chunk → distinct sentence segments (Low-2); a >4000-char paragraph hard-split across chunks → one segment; CR/LF/CRLF; MD markers; locator→unit mapping; `unitAfter` end→null; **source-byte parity while disabled**; cache-hit-no-profile still returns (#306); no-profile miss → `ProviderFailed`; `prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls; **blank `profile.model` → `AiRequest.model == kind.defaultModel` (M3 regression)**; readiness true/false; empty-key → false; no-active-with-profiles-present → false (H3); cipher-throw → readiness false (no crash).
+
+**WI-4b (foundational — shared DI/factory, incl. `AiProviderStore` in `AppContainer`): AppContainer bilingual + AI-config graph.** `AppContainer` **now constructs `AiProviderStore`** (DataStore + #116 `KeystoreSecretCipher`, following the `readerSettingsStore` convention — this is #131's change, not an external feature's) and provides `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, an `AiSettingsViewModel` factory (for WI-AIP), and the `BilingualViewModel` factory. Deps: **WI-4a** (no external dep — #136 closed). Tests: container resolves the bilingual + AI-config graph; `AiProviderStore` resolves and round-trips a profile; the prefetcher's injected factory defaults to `AiProviderFactory::create`.
+
+**WI-5 (behavioral): `PerBookBilingualStore` + `BilingualViewModel` state core.** Store per book (enabled/targetLanguage/granularity — no style); VM setters (persist + first-enable `needsSetupSheet`); `aiConfigured` from `BilingualAiReadiness.resolve` over an injected snapshot; language/granularity change clears cache-shaped state + bumps generation. Injected prefetcher/snapshot seams (Medium-4). Turbine tests: first-enable raises sheet; re-enable persisted does not; disable clears; language change resets; granularity change resets + re-keys; `aiConfigured` true/false from readiness; round-trip through store; no style field. Deps: WI-1 (+ store).
+
+**WI-6 (behavioral): VM prefetch trigger + generation/cancellation + single-flight (M2).** `onPositionChanged(charOffsetUTF16)` derives current unit (TXT/MD only), dedupes, prefetches current+next; a monotonic position-request sequence checked after every suspension; **per-unit single-flight `prefetchTasks: Map<TranslationUnitId, Job>` (a new request cancels/joins the prior — M2)**; a captured language/granularity/provider snapshot per launch; generation bumps on disable/language/granularity/unit-change discard stale; **BOTH `CancellationException` AND typed `ChapterTranslationError.Cancelled` handled BEFORE generic error mapping (M2)**; a cancelled stale request does NOT surface as `errorUnit`; `Offline`→`unavailableUnits`; transient failure leaves unit unfetched + clears anchor to retry; `retryUnit` routes through the registry. The EPUB `onEpubBlocksEnumerated` entry is present but EPUB prefetch is owned by the controller (Medium-1); the VM's position-driven `prefetch` dispatches TXT/MD units only. Fake prefetcher (Medium-4 seam). Deps: WI-4a, WI-4b, WI-5. Tests: current+next on unit change; same-unit no-op; cancel-mid discards stale (no `errorUnit`); typed-`Cancelled` discards (not `errorUnit`); rapid re-trigger same unit → single-flight, no double-write; offline→unavailable; failure→retry-able; `retryUnit` re-fetches; granularity change cancels + re-fetches under the new key.
+
+**WI-7a (behavioral): Compose UI — setup sheet + interlinear body (TXT/MD) + pill.** Reproduce `vreader-bilingual.jsx` (setup sheet: language grid / granularity / preview / engine strip configured+unconfigured; body: the **additive translation items** per the H2 render contract — translated / loading N%+dimmed / error+Retry / offline source-only; pill). Consumes the host-neutral `BilingualRenderState` DTO. Light+dark. Compose UI tests each state, incl. **paragraph interlinear renders a translation item after a paragraph (depicted)** and **Sentence selection falls back to paragraph render (H2 gate)**. Deps: WI-5 (state shape). NO Style control; the unconfigured "Set up" CTA renders and (in WI-9) routes to the Variant A sheet.
+
+**WI-7b (behavioral, CONDITIONAL — only if WI-0 = go): EPUB render adapter (DOM injection, NOT Compose — M2) + direct-block ownership (M1).** `EpubBilingualJs` (enum/inject/clear JS builders, CSP-safe escaping) + `EpubBilingualController` (the serialization actor / session token AND the **single-owner enumerate→cachedDirect/prefetchDirect→guarded-commit sequence — Medium-1**) + `EpubChapterTextProvider`, wired into `ReaderActivity`, driving DOM from the shared `BilingualRenderState` DTO. Uses `prefetchDirect`/`cachedDirect` for the count-divergence path (H2). Depends on WI-6 (VM state) and WI-4b (DI); the WI-7a UI dependency is only the shared `BilingualRenderState`/value types. Connected test on a real EPUB (seeded cache): enable → injects; disable → cleared; reflow/href-change/fragment-recreation/activity-recreation → re-applies from cache (zero provider calls) via `cachedDirect`; count-divergence handled (direct path); **the regular TXT/MD prefetch path is never invoked for an EPUB unit (Medium-1)**. Unit tests: JS escaping/CSP-safe insertion, RTL/CJK style, empty translations, loading cleanup, idempotent replacement, source-only fallback, stale-session-token commit discarded (no `errorUnit`). Deps: WI-0, WI-3, WI-4a, WI-4b, WI-6, (shared types from WI-7a). (If WI-0 = no-go, dropped; box D ships TXT/MD-only, tracked.)
+
+**WI-AIP (behavioral — the folded-in Variant A AI Providers sheet): `ReaderAiProvidersSheet`.** The scoped in-reader "AI Providers" push sheet (nav bar `‹ Bilingual` + "AI Providers" title) reproducing `vreader-ai-provider-entry.jsx` `AIProvidersSheet`/`NavSheet`, hosting ONLY the #118 `AiProviderListScreen` (empty + populated) + the canonical `AiProviderEditSheet`, driven by the #118 `AiSettingsViewModel` (from WI-4b's `AppContainer` factory). Empty state carries the bilingual-context copy ("Bilingual mode needs a provider to translate" / "Add provider" CTA). On first Save → the provider becomes the bilingual engine (`store.setActive(savedId)`) + pop the whole stack back to the bilingual sheet (engine strip now "configured / Change…"). `‹ Bilingual` without adding → unconfigured, no state mutated. No consent/flag surface (Android has none). Deps: WI-4b (for `AiProviderStore` + `AiSettingsViewModel` in `AppContainer`), WI-7a (bilingual sheet host). Tests (Compose + connected): empty → Add → Save → pop-to-bilingual with strip configured; `‹ Bilingual` without adding → strip unconfigured, snapshot unchanged; "Change…" → populated list, current provider checked, tap row → `setActive`; editor reused verbatim (no divergent form).
+
+**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into the `items(count = document.chunkCount)` loop as **additive translation items after the anchor chunk, source chunks byte-unchanged (H2)** + position-change (`charOffsetUTF16`) + setup-sheet. `originalFormat`-gated (TXT/MD). Uses WI-4b's DI. **#129 VERIFIED — straight edit.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2)**; **highlights/annotation-washes/read-aloud-wash still key off source chunks (H2)**; a translation item is non-selectable, does not perturb source offsets (H2); disable → source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders exactly one translation after its last chunk (H1/Low-2)**; **one-chunk/final-chunk anchors render (H1)**; MD source mapping. Deps: WI-6, WI-7a, WI-4b.
+
+**WI-9 (behavioral): entry wiring + acceptance.** Mount `BilingualPill` in #132's VERIFIED top chrome; extend `readerMoreRows(...)` to supply the #134 VERIFIED More-menu `MoreActionId.BILINGUAL` toggle (`MoreRow.Toggle` `on`/`onToggle`, or `MoreRow.Disabled` "Configure AI provider first" when not configured) wired to the VM; **wire the setup sheet's "Set up"/"Change…" affordance → the #131-owned `ReaderAiProvidersSheet` (Variant A)**. Full acceptance across EPUB (if WI-7b landed) + TXT/MD, including the fresh-user path `unconfigured → Set up (→ Variant A AI Providers sheet) → add provider → return → enable → translate` (now #131-owned end-to-end). **Flip box D to done ONLY for provider/model/granularity + the Style-descope note; file the follow-up checklist amendment; do NOT claim full box-D parity.** The DONE flip **no longer waits on #136** (closed). Update `docs/architecture.md` (bilingual pipeline + the new `chapter_translations` schema + `AiProviderStore` + bilingual services in `AppContainer` + the Variant A AI Providers sheet). → DONE. Deps: WI-8, WI-AIP, WI-7b (if go), feat:#132, feat:#134.
+
+## 5. Test catalogue
+
+JVM/Robolectric (`android/app/src/test/...bilingual/`): `ChapterSegmenterTest` (paragraph blank-line; sentence CJK `。！？` vs Latin; empty→[]; single; **`paragraphRanges`/`sentenceRanges` return correct half-open UTF-16 `(start, endExclusive)` spans**); `TranslationChunkerTest` (packs to budget; oversize→own chunk+subSplit; empty→[]); `TranslationChunkContractTest` (prompt shape; strict JSON decode; code-fence strip; count mismatch→`CountMismatch`; non-array→`NotAStringArray`); `ChapterTranslationServiceTest` (cache hit 0 calls; miss→translate→write; decode-fail per-segment fallback; one-chunk-fail partial-not-cached; all-fail→throw; **native-cancel→Cancelled no write; typed-`Cancelled`→Cancelled no write (M2)**; ensureActive-before-write; offline/timeout/429/http/config/insecure→error mapping; very long chapter N-of-M; stale-cache count-mismatch re-translates; `translatePreSegmented` caches under enumerate count on full success; partial degrade not cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` hit/miss with no provider); `ChapterTranslationErrorMappingTest`; `TxtChapterTextProviderTest` (**one-chunk document → renders (H1); final-chunk anchor → renders (H1); exact-boundary → correct anchor (H1); EOF anchor → last chunk, no clamp-collapse (H1)**; paragraph spanning MANY chunks → one segment/unit anchored to last chunk (Low-2); multiple SENTENCES in one chunk → distinct segments (Low-2); >4000-char paragraph → one segment across hard-split chunks; CR/LF/CRLF; MD markers; locator→unit mapping; `unitAfter` end→null; source-byte parity while disabled); `ChapterTranslationPrefetcherTest` (snapshot-consistent profile+key; injected-factory used; `AiRequest` built from profile; **blank `profile.model` → `kind.defaultModel` (M3 regression)**; cache-hit-no-profile #306; no-profile miss→ProviderFailed; `prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls; CJK↔English + Latin round-trip via fake; cipher-throw→ProviderFailed not crash); `BilingualAiReadinessTest` (active+key→true; **no-active-with-profiles-present→false (H3); activeId-null→false (H3)**; empty key→false; cipher-throw→false, no crash); `PerBookBilingualStoreTest` (enabled/lang/granularity round-trip; no style field); `BilingualViewModelTest` (Turbine: first-enable sheet; re-enable no-sheet; disable clears; language reset; granularity reset + re-key; `aiConfigured` from readiness; prefetch current+next; same-unit no-op; **cancel-mid discards (no errorUnit); typed-Cancelled discards (M2); rapid re-trigger same unit single-flight, no double-write (M2)**; offline→unavailable; error→errorUnit+retry; `retryUnit`); `EpubBilingualJsTest` (JS escaping / CSP-safe insertion; RTL/CJK style; empty translations; clear idempotent; inject idempotent replacement; source-only fallback — WI-7b if go); `EpubBilingualControllerTest` (**enumerate→cachedDirect/prefetchDirect→guarded commit; stale-session-token commit discarded, no errorUnit; single-owner (regular TXT/MD prefetch never runs for EPUB unit) — Medium-1** — WI-7b if go).
+
+Room migration: `VReaderDatabaseMigrationTest` (extend) **v8→v9 + full-chain from v8** + FK-CASCADE + `lookupKey`-as-PK; `ChapterTranslationDaoTest` (upsert-by-PK replaces; get/delete-by-lookupKey).
+
+Compose UI (`androidTest/...bilingual/`): `BilingualSetupSheetUiTest` (language grid, granularity, preview, engine configured vs unconfigured driven by `aiConfigured`; no Style control present; light+dark); `BilingualInterlinearBodyUiTest` (**additive translation item after a paragraph anchor chunk (depicted); paragraph interlinear translated incl. CJK font + RTL Arabic; Sentence selection → paragraph-render fallback (H2 gate)**; loading N%+dimmed; error+Retry; offline source-only; empty translation→source-only no crash); `ReaderAiProvidersSheetUiTest` (**empty state with bilingual-context copy + Add CTA; populated list + current-provider checked; `‹ Bilingual` back label; editor reused (WI-AIP)**); `BilingualPillUiTest`.
+
+Connected (`androidTest/...reader/`): `TxtReaderBilingualConnectedTest` (API 35, fake `AiClient` via injected factory): enable→setup→confirm→interlinear from seeded Room cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2); highlights/annotation-washes/read-aloud-wash still key off source chunks (H2); translation item non-selectable + no source-offset perturbation (H2)**; disable→source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders one translation (H1/Low-2); one-chunk/final-chunk anchors render (H1)**; TXT/MD gated (PDF inert); very long chapter scroll responsive; cancellation leaves no partial cache row. `ReaderAiProvidersConnectedTest` (WI-AIP + WI-9): `unconfigured → Set up → Variant A sheet → add provider → Save → pop-to-bilingual configured → enable → translate`; `‹ Bilingual` without adding → unconfigured, snapshot unchanged; "Change…" → populated, current checked. `EpubReaderBilingualConnectedTest` (only if WI-0=go): enable→inject on a real EPUB; disable→clear; href-change/fragment-recreation/activity-recreation→re-apply from cache (zero provider calls); count-divergence handled via `prefetchDirect`/`cachedDirect`; regular prefetch never runs for EPUB unit (Medium-1).
+
+Edge cases: empty translation, failed, partial per-chunk, CJK↔English + Latin + RTL, provider error/timeout/429/config/insecure, native + typed cancellation mid-translation + before-write, single-flight overlap, very long chapters, offline (cache-first + silent source-only), cipher-decrypt failure → not-ready (no crash), enumerate↔segment count divergence (direct path), one-chunk/final-chunk/EOF anchors (H1), blank model (M3).
+
+## 6. Risks + mitigations
+
+- **Live-translation verification is AI-credential-gated (the box-D caveat).** The whole pipeline is verified without live creds via a deterministic **fake `AiClient`** injected through the prefetcher's `clientFactory` param (default `AiProviderFactory::create`; tests override). WI-3/4a/8 prove segment→chunk→decode→cache→interleave end-to-end incl. every error/edge path. Connected tests seed the Room cache and assert render-from-cache with zero client calls. An optional live smoke confirms wire format but is NOT a gate. The fresh-user `unconfigured → Set up → add provider` reachability leg is now #131-owned (WI-AIP + WI-9) and verified by `ReaderAiProvidersConnectedTest`.
+- **Final-chunk translation drop (round-3 H1).** Fixed by `endExclusive = if (i+1<chunkCount) offsetForChunk(i+1) else text.length` + explicit half-open `(start, endExclusive)` computations everywhere; one-chunk/final-chunk/exact-boundary/EOF tests. `offsetForChunk`'s clamp (TxtDocument.kt:17) is never relied on for the final end.
+- **Enabled render breaking the per-chunk layout/selection model (round-3 H2).** Fixed by the additive-item render contract: source chunk `Text` is NEVER split; translations are separate, non-selectable, unregistered `LazyColumn` items after the anchor chunk. Enabled-mode tests assert selection/highlight/wash/annotation parity with disabled. Sentence-granularity render is design-gated (only paragraph interlinear is depicted); Sentence selection falls back to paragraph render, granularity still cache-keyed.
+- **TXT/MD segment↔render pairing (round-2 H1).** Both sides read the SAME segment `(start, endExclusive)` array over `TxtDocument.text`, so 1:1 holds by construction — no chapter model invented; a paragraph split across many chunks is translated + rendered once (anchored at its last chunk). Granularity is in the cache key.
+- **EPUB direct-block flow (round-3 Medium-1).** The `EpubBilingualController` is the single owner: `enumeratedBlocks → cachedDirect (zero-provider restore) else prefetchDirect → session-token-guarded commit into BilingualRenderState/translationsByUnit`. The VM's position-driven regular prefetch is TXT/MD-only, so the two paths never write the same canonical cache row. Every suspended step is token-guarded; a stale token discards silently.
+- **EPUB count divergence (round-2 H2).** The direct-block path (`prefetchDirect` → `translatePreSegmented`, cached by enumerate count, restored by `cachedDirect(expectedCount)` with zero provider calls) — iOS Bugs #268/#330/#343 parity.
+- **EPUB JS-injection race (round-2 M1).** WI-0's contract (single actor/mutex OR monotonic navigator-session token; token check after every suspended call; clear before publication teardown; identified production re-apply signal per recreation case). No deterministic re-apply signal = explicit NO-GO → TXT/MD-only ship.
+- **Cancellation + single-flight (round-3 Medium-2).** Both service and VM handle native `CancellationException` AND typed `ChapterTranslationError.Cancelled` before generic mapping (iOS `ChapterTranslationService.swift:359–364`); a per-unit `prefetchTasks: Map<TranslationUnitId, Job>` cancels/joins a prior request so rapid retry/navigation can't run overlapping translations or Room writes; a cancelled stale request never surfaces as `errorUnit`. `ensureActive()` before the Room write.
+- **Blank model (round-3 Medium-3).** The prefetcher builds `model = profile.model.ifBlank { profile.kind.defaultModel }` (matches `AiChatViewModel.kt:61`; both wire clients serialize `request.model` directly, `OpenAiCompatibleProvider.kt:39`/`AnthropicProvider.kt:37`). Blank-model regression test.
+- **AI-config readiness (H3).** `BilingualAiReadiness.resolve` = active profile + decrypts-non-empty; `activeId` can be null with profiles present; cipher failure → not-ready (no crash). No consent/flag gate (Android has none).
+- **Cost/latency of translating on scroll.** Lazy current+next prefetch + disk cache; N-of-M progress; cancellation on navigate-away/generation-bump/single-flight supersede.
+- **Provider JSON non-compliance.** `TranslationChunkContract.decode` + per-segment fallback — never drops a paragraph.
+- **DataStore per-book key growth.** One Preferences entry per book keyed by fingerprint; scales like `ReaderSettingsStore`/`AiProviderStore`.
+- **Dependency honesty (round-3 Medium-4).** WI-4b (DI, incl. `AiProviderStore` in `AppContainer`) is foundational and gates the production run-through of WI-6/WI-7b/WI-AIP/WI-8; those WIs' unit/Compose gates proceed against injected fakes, and WI-4b is sequenced before them. No external feature gates the chain (#136 closed).
+
+## 7. Backward compat
+
+- **Room migration additive.** New `chapter_translations` (FK CASCADE, `lookupKey` PK, `sourceParagraphCount`). Existing rows untouched. Against this checkout **8→9, `MIGRATION_8_9`** appended after `MIGRATION_7_8` (VReaderDatabase.kt:224–228); migration test extended from v8 guards it.
+- **Reader unchanged when bilingual off** — the TXT/MD `items(count = document.chunkCount)` source loop is **byte-identical** unless `enabled && format∈{txt,md} && translation present` (translations are additive, non-selectable overlay items — H2). `ReaderBottomChrome` is not modified. EPUB render adapter inert unless bilingual is on.
+- **`AppContainer` gains `AiProviderStore`** (previously not provided — VReaderApp.kt:66 comment only) plus the bilingual services + `AiSettingsViewModel` factory; all additive lazy singletons following the `readerSettingsStore` pattern. #118 AI files (`AiProviderStore`, `AiProviderListScreen`, `AiProviderEditSheet`, `AiSettingsViewModel`) are consumed unchanged.
+- **#118 AI provider files unchanged** — the prefetcher/readiness/Variant A sheet are new consumers.
+- **Backup contract already compatible** — `PerBookSettingsOverride.bilingualEnabled/TargetLanguage/Granularity` exist (no `bilingualStyle`), no translation-cache backup section (device-local, re-derivable). #131 writes the three fields locally; backup collect/restore is a small additive follow-up (no contract change), out of v1; config device-local until then.
+- **#132/#134/#129 landed** — the top-chrome pill mount + More-menu toggle (`readerMoreRows` extension) + `TxtReaderActivity` edit land on VERIFIED surfaces (rule 48 one-writer-per-file satisfied).
+
+## Design gates (rule 51 — for `needs-design` filing)
+
+1. **"Bilingual mode" setup sheet with BOTH Style AND Granularity in one Android sheet** (unchanged — Style stays descoped v1) — `vreader-bilingual.jsx` depicts Granularity (no Style); `vreader-ai-android.jsx` depicts Style (no Granularity); no committed bundle shows both together. v1 reproduces the granularity-only `vreader-bilingual.jsx` sheet and DROPS Style (user descope, §3). If Style is wanted as an Android user control, file `Design needed: bilingual setup sheet (Style + Granularity) for feature #131`. The box-D Style parity gap is tracked by the WI-9 follow-up checklist amendment.
+2. **`Design needed: sentence-granularity bilingual interlinear render for feature #131`** — `vreader-bilingual.jsx` `BilingualPageContent` (lines 200–277) depicts ONLY paragraph interlinear (one translation `<p>` per source paragraph); a translation-after-each-sentence render (grouped when several sentences share a line-chunk) is depicted nowhere. v1 ships the depicted **paragraph** interlinear render + the setup-sheet Granularity control (both options selectable, as depicted); selecting **Sentence** falls back to the depicted paragraph render (granularity still carried in the cache key so no wrong-shape row is served). When the sentence-interlinear render is designed, it is a render-only follow-up (the additive-item render contract already accommodates per-line sentence grouping).
+
+*(REMOVED: the v3 "#136 dependency" design-gate line — #136 is closed and the Variant A AI Providers sheet IS the committed design, reproduced by WI-AIP, not a gate.)*
+
+## Revision history
+
+- v1 (2026-07-10): Gate-1 draft (Plan agent). Gate-2 Codex audit pending.
+- v2 (2026-07-11): Gate-2 round-1 REDESIGN resolved — Readium-feasibility corrected, entry-point rebased on box F, setup-sheet design-gated, DI/cache/concurrency fixed.
+- v3 (2026-07-12): Gate-2 round-2 findings resolved — TXT/MD document-global segment model (H1); EPUB translatePreSegmented + count-keyed cache + direct-block prefetch (H2); #136 AI-provider-reachability spun out as a hard dependency (GH #1976) + Style descoped v1 (H3); WI-0 go/no-go + navigator-race contract (M1); EPUB DOM-injection adapter not Compose body (M2); DI/factory WI reordered (M3); Room 8→9 MIGRATION_8_9 (M4); deps/WI-count corrected (L1/L2). Gate-2 round-3 = block-recommended.
+- **v4 (2026-07-12): Gate-2 round-3 (block-recommended) findings resolved AND the AI-config path folded in.**
+  - **AI-config FOLDED IN (#136 CLOSED, GH #1976 not-planned; user decision 2026-07-12):** the design proved the ONLY designed Android AI-config reader surface is the bilingual-coupled **Variant A** "AI Providers" sheet (`reader-ai-provider-entry.md`); it is not separable, so #131 now owns it end-to-end. Added **WI-AIP** (`ReaderAiProvidersSheet`, reusing #118 `AiProviderListScreen`/`AiProviderEditSheet`/`AiSettingsViewModel` verbatim, `‹ Bilingual` push, pop-back-on-first-Save); WI-4b now provides `AiProviderStore` into `AppContainer` (verified not provided today — VReaderApp.kt:66 comment only) plus the bilingual services + `AiSettingsViewModel` factory; removed `feat:#136` from Deps (now `[feat:#132, feat:#134]`, no external AI-reachability blocker); the DONE flip no longer waits on #136; `aiConfigured` derivation kept as the correct active-profile+decrypts-non-empty gate (H3), NOT `profiles.isEmpty()` (the iOS note's derivation), with no consent/flag gate (Android has none).
+  - **H1 (round-3 High-1) final-chunk math:** `endExclusive = if (i+1<chunkCount) offsetForChunk(i+1) else text.length`; explicit half-open `(start, endExclusive)` computations (not `IntRange`); one-chunk/final-chunk/exact-boundary/EOF tests.
+  - **H2 (round-3 High-2) additive-item render contract:** translations are additive `LazyColumn` items at chunk (line) boundaries; the source chunk `Text` is NEVER split; per-chunk one-`TextLayoutResult`/one-selection-registration preserved (TxtReaderActivity.kt:1043/1059/1062–1066); enabled-mode selection/highlight/wash/annotation/MD tests; sentence-granularity render flagged as a rule-51 design gate (only paragraph interlinear is depicted), paragraph ships.
+  - **M1 (round-3 Medium-1) EPUB direct-block ownership/API:** `EpubBilingualController` single owner; `enumeratedBlocks → cachedDirect else prefetchDirect → session-token-guarded commit into BilingualRenderState/translationsByUnit`; regular prefetch is TXT/MD-only so the two paths never write the same canonical row.
+  - **M2 (round-3 Medium-2) dual-cancellation + single-flight:** service AND VM handle native `CancellationException` AND typed `ChapterTranslationError.Cancelled` before generic mapping (iOS `ChapterTranslationService.swift:359–364`); per-unit `prefetchTasks: Map<TranslationUnitId, Job>` cancels/joins a prior; a cancelled stale request never surfaces as `errorUnit`.
+  - **M3 (round-3 Medium-3) blank-model fallback:** `model = profile.model.ifBlank { profile.kind.defaultModel }` (matches `AiChatViewModel.kt:61`; clients serialize `request.model` directly); blank-model regression test.
+  - **M4 (round-3 Medium-4) dependency honesty:** WI-4b (DI incl. `AiProviderStore`) is foundational and gates the production run-through of WI-6/WI-7b/WI-AIP/WI-8; those WIs' unit/Compose gates use injected fakes; WI-4b sequenced before them; no external feature gates the chain.
+  - **Low fixes:** WI count corrected to **13** (added WI-AIP; the "11 WIs" claim was wrong — Low-1); chunk semantics corrected — a chunk is ONE LINE, holds multiple SENTENCES, a paragraph spans MANY chunks; removed the "a chunk can hold multiple paragraphs" claim (Low-2). Awaiting Gate-2 round-4 audit.
+     1	// Purpose: Addressable, range-based model of a decoded .txt — feature #111 WI-1.
+     2	// Holds ONE backing decoded String and an array of chunk START offsets (UTF-16 code
+     3	// units against the RAW text — NO line-ending normalization, so charOffsetUTF16 stays
+     4	// exact for resume). Splits at line boundaries (CRLF/CR/LF kept inside the chunk);
+     5	// hard-splits a runaway line at maxChunkChars (never mid-surrogate-pair). Visible
+     6	// chunk text is materialized on demand (no per-chunk substrings retained). Pure JVM.
+     7	package com.vreader.app.reader
+     8	
+     9	class TxtDocument private constructor(
+    10	    val text: String,
+    11	    private val starts: IntArray,
+    12	) {
+    13	    /** Number of chunks (0 for empty text). */
+    14	    val chunkCount: Int get() = starts.size
+    15	
+    16	    /** The UTF-16 start offset of chunk [index] (clamped to a valid chunk). */
+    17	    fun offsetForChunk(index: Int): Int {
+    18	        if (starts.isEmpty()) return 0
+    19	        return starts[index.coerceIn(0, starts.size - 1)]
+    20	    }
+    21	
+    22	    /** The chunk index containing [offsetUtf16] (EOF-clamped); 0 for empty text. */
+    23	    fun chunkForOffset(offsetUtf16: Int): Int {
+    24	        if (starts.isEmpty()) return 0
+    25	        val offset = offsetUtf16.coerceIn(0, text.length)
+    26	        // Largest start <= offset (binary search).
+    27	        var lo = 0; var hi = starts.size - 1; var ans = 0
+    28	        while (lo <= hi) {
+    29	            val mid = (lo + hi) ushr 1
+    30	            if (starts[mid] <= offset) { ans = mid; lo = mid + 1 } else { hi = mid - 1 }
+    31	        }
+    32	        return ans
+    33	    }
+    34	
+    35	    /** The text of chunk [index], materialized on demand from the backing string. */
+    36	    fun textForChunk(index: Int): CharSequence {
+    37	        if (starts.isEmpty()) return ""
+    38	        val i = index.coerceIn(0, starts.size - 1)
+    39	        val end = if (i + 1 < starts.size) starts[i + 1] else text.length
+    40	        return text.subSequence(starts[i], end)
+    41	    }
+    42	
+    43	    companion object {
+    44	        const val DEFAULT_MAX_CHUNK_CHARS = 4000
+    45	
+    46	        /**
+    47	         * Build a document from already-decoded [text]. Chunk boundaries fall after a
+    48	         * line terminator (`\n`, `\r`, or `\r\n` — preserved in the chunk); a line longer
+    49	         * than [maxChunkChars] is hard-split, but never between a surrogate pair.
+    50	         */
+    51	        fun of(text: String, maxChunkChars: Int = DEFAULT_MAX_CHUNK_CHARS): TxtDocument {
+    52	            if (text.isEmpty()) return TxtDocument(text, IntArray(0))
+    53	            // Primitive growable IntArray (no Int boxing) — a newline-dense 14MB file
+    54	            // would otherwise spike tens of MB of boxed Integers + a duplicating copy.
+    55	            var starts = IntArray(64)
+    56	            var count = 0
+    57	            fun push(v: Int) {
+    58	                if (count == starts.size) starts = starts.copyOf(starts.size * 2)
+    59	                starts[count++] = v
+    60	            }
+    61	            push(0)
+    62	            var i = 0
+    63	            var chunkStart = 0
+    64	            val n = text.length
+    65	            while (i < n) {
+    66	                val c = text[i]
+    67	                when {
+    68	                    c == '\n' -> {
+    69	                        i++
+    70	                        if (i < n) { push(i); chunkStart = i }
+    71	                    }
+    72	                    c == '\r' -> {
+    73	                        i++
+    74	                        if (i < n && text[i] == '\n') i++   // CRLF stays one terminator
+    75	                        if (i < n) { push(i); chunkStart = i }
+    76	                    }
+    77	                    else -> {
+    78	                        i++
+    79	                        // Hard-split a runaway line, but not mid-surrogate-pair (don't
+    80	                        // split right after a high surrogate — its low half follows at i).
+    81	                        if (i - chunkStart >= maxChunkChars && i < n && !text[i - 1].isHighSurrogate()) {
+    82	                            push(i); chunkStart = i
+    83	                        }
+    84	                    }
+    85	                }
+    86	            }
+    87	            return TxtDocument(text, starts.copyOf(count))
+    88	        }
+    89	    }
+    90	}
+  1000	    // feature #124 WI-4 — a tap (LazyColumn-local point) → host hit-tests an existing highlight to edit.
+  1001	    onTapAt: (androidx.compose.ui.geometry.Offset) -> Unit = {},
+  1002	) {
+  1003	    val isMarkdown = format == BookFormat.md
+  1004	    val wash = VReaderColors.Accent.copy(alpha = 0.18f)
+  1005	    val selectionAccent = Color(0x575C8FC4)   // design selection bg rgba(92,143,196,0.34)
+  1006	    val selection by (selectionController?.selection ?: flowOf(null)).collectAsState(null)
+  1007	    // the pointerInput block keys on selectionController (stable), so without this it would capture the
+  1008	    // INITIAL onTapAt/onSelectionFinalized closures (stale highlightsList → tap-to-edit never hits).
+  1009	    val currentOnTap by androidx.compose.runtime.rememberUpdatedState(onTapAt)
+  1010	    val currentOnFinalize by androidx.compose.runtime.rememberUpdatedState(onSelectionFinalized)
+  1011	    LazyColumn(
+  1012	        Modifier
+  1013	            .fillMaxSize()
+  1014	            .onGloballyPositioned { selectionController?.setLazyCoords(it) }
+  1015	            .then(
+  1016	                if (selectionController != null) {
+  1017	                    // ONE detector distinguishes a TAP (edit an existing highlight) from a LONG-PRESS+drag
+  1018	                    // (new selection) — two separate pointerInput detectors conflict over the same down event.
+  1019	                    Modifier.pointerInput(selectionController) {
+  1020	                        awaitEachGesture {
+  1021	                            val down = awaitFirstDown(requireUnconsumed = false)
+  1022	                            val longPress = awaitLongPressOrCancellation(down.id)
+  1023	                            if (longPress != null) {
+  1024	                                // long-press → selection; finalize only on a COMPLETED drag/up (not a cancel).
+  1025	                                selectionController.beginAt(longPress.position)
+  1026	                                val completed = drag(longPress.id) { change -> selectionController.extendTo(change.position); change.consume() }
+  1027	                                if (completed) currentOnFinalize() else selectionController.clear()
+  1028	                            } else if (!down.isConsumed) {
+  1029	                                // null also means cancel (e.g. a scroll won) — only a TAP leaves the down
+  1030	                                // unconsumed; a scroll consumes it, so it won't be misread as tap-to-edit.
+  1031	                                currentOnTap(down.position)
+  1032	                            }
+  1033	                        }
+  1034	                    }
+  1035	                } else {
+  1036	                    Modifier
+  1037	                },
+  1038	            ),
+  1039	        state = listState,
+  1040	        contentPadding = PaddingValues(horizontal = marginDp.dp, vertical = 16.dp),
+  1041	    ) {
+  1042	        // Count-based: indices on demand (a newline-dense 14MB file can be 100k+ chunks).
+  1043	        items(count = document.chunkCount, key = { it }) { i ->
+  1044	            val raw = document.textForChunk(i).toString()
+  1045	            // .md → styled markdown spans (no read-aloud span wash — markers shift offsets, plan §OOS).
+  1046	            // .txt → raw verbatim, with the spoken-sentence span washed when read-aloud is active.
+  1047	            val span = if (isMarkdown) null else highlightSpan(i)
+  1048	            val text = when {
+  1049	                isMarkdown -> mapper.renderedText(i)   // #125: the mapper is the single render owner
+  1050	                span != null -> buildAnnotatedString {
+  1051	                    append(raw)
+  1052	                    val a = span.first.coerceIn(0, raw.length); val b = (span.last + 1).coerceIn(a, raw.length)
+  1053	                    if (b > a) addStyle(SpanStyle(background = wash), a, b)
+  1054	                }
+  1055	                else -> AnnotatedString(raw)
+  1056	            }
+  1057	            // annotation washes drawn BEHIND the text (getPathForRange) — separate from the read-aloud span.
+  1058	            val washes = washesForChunk(i)
+  1059	            var layout by remember(i) { mutableStateOf<TextLayoutResult?>(null) }
+  1060	            var coords by remember(i) { mutableStateOf<androidx.compose.ui.layout.LayoutCoordinates?>(null) }
+  1061	            if (selectionController != null) {
+  1062	                LaunchedEffect(i, layout, coords) {
+  1063	                    val l = layout; val c = coords
+  1064	                    if (l != null && c != null) selectionController.registerChunk(i, l, c)
+  1065	                }
+  1066	                DisposableEffect(selectionController, i) { onDispose { selectionController.unregisterChunk(i) } }
+  1067	            }
+  1068	            // read `selection` (a State) so a selection change recomposes + redraws the accent.
+  1069	            val selRange = if (selection != null) selectionController?.selectionForChunk(i) else null
+  1070	            Text(
+  1071	                text = text,
+  1072	                // merge over the material default (the pre-#129 explicit-param behavior) so platform
+  1073	                // text defaults (letterSpacing etc.) are kept — only the Display settings change.
+  1074	                style = androidx.compose.material3.LocalTextStyle.current.merge(textStyle),
+  1075	                onTextLayout = { layout = it },
+  1076	                modifier = Modifier
+  1077	                    .onGloballyPositioned { coords = it }
+  1078	                    .drawBehind {
+  1079	                        layout?.let { l ->
+  1080	                            drawWashes(l, washes)
+  1081	                            selRange?.let { drawRangeFill(l, it, selectionAccent) }
+  1082	                        }
+  1083	                    },
+  1084	            )
+  1085	        }
+  1086	    }
+  1087	}
+
+exec
+/bin/zsh -lc "rg -n \"firstVisibleItemIndex|scrollToItem|animateScrollToItem|layoutInfo|visibleItemsInfo|chunkForOffset|offsetForChunk|LazyListState|listState\" android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt android/app/src/main/kotlin/com/vreader/app/reader | head -240 && nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt && nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt | sed -n '42,78p' && nl -ba android/app/src/main/kotlin/com/vreader/app/ai/OpenAiCompatibleProvider.kt | sed -n '25,52p' && nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AnthropicProvider.kt | sed -n '25,52p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:8:// ResumeResolver → Canonical → chunkForOffset.
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:27:// (chunkForOffset), returning Succeeded (sheet dismisses) or Failed (out-of-range → sheet stays open). The
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:45:import androidx.compose.foundation.lazy.LazyListState
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:46:import androidx.compose.foundation.lazy.rememberLazyListState
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:220:                        val listState = rememberLazyListState(initialFirstVisibleItemIndex = s.initialIndex)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:223:                            flushPosition = { savePosition(s.book, s.document, listState.firstVisibleItemIndex) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:226:                        LaunchedEffect(listState, s.document) {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:227:                            snapshotFlow { listState.firstVisibleItemIndex }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:252:                        val spokenChunk = if (tts.phase == TtsPhase.speaking) s.document.chunkForOffset(tts.charStart) else -1
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:256:                            if (spokenChunk >= 0 && listState.layoutInfo.visibleItemsInfo.none { it.index == spokenChunk }) {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:257:                                runCatching { listState.animateScrollToItem(spokenChunk) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:358:                        val liveOffset = s.document.offsetForChunk(listState.firstVisibleItemIndex)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:411:                                    ttsScope.launch { listState.scrollToItem(s.document.chunkForOffset(target)) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:421:                                    listState.scrollToItem(s.document.chunkForOffset(target))
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:454:                                                ttsScope.launch { runCatching { listState.scrollToItem(s.document.chunkForOffset(target)) } }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:473:                                        s.document.offsetForChunk(listState.firstVisibleItemIndex),
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:481:                                            listState.scrollToItem(s.document.chunkForOffset(target))
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:513:                                    s.document, listState, s.book.originalFormat, chunkMapper,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:519:                                            val cs = s.document.offsetForChunk(chunkIndex)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:520:                                            val ce = if (chunkIndex + 1 < s.document.chunkCount) s.document.offsetForChunk(chunkIndex + 1) else s.document.text.length
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:613:        container.cachedOffset(key)?.let { return document.chunkForOffset(it) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:619:        return document.chunkForOffset(offset)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:624:        val offset = document.offsetForChunk(topIndex)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:988:    document: TxtDocument, listState: LazyListState, format: BookFormat,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1039:        state = listState,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:17:    fun offsetForChunk(index: Int): Int {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:23:    fun chunkForOffset(offsetUtf16: Int): Int {
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderScreen.kt:42:import androidx.compose.foundation.lazy.LazyListState
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderScreen.kt:112:internal fun PdfReaderBody(document: PdfDocument, listState: LazyListState, backdrop: Color) {
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderScreen.kt:116:            state = listState,
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderScreen.kt:124:            page = listState.firstVisibleItemIndex + 1,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:58:        return Hit(hit.key, hit.value, rendered, doc.offsetForChunk(hit.key) + localSource)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:65:        val base = doc.offsetForChunk(hit.chunkIndex)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:132:        val endChunk = doc.chunkForOffset((r.endExclusive - 1).coerceAtLeast(0)).coerceIn(0, doc.chunkCount - 1)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:134:        val base = doc.offsetForChunk(endChunk)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:8:// ResumeResolver → Canonical → chunkForOffset.
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:27:// (chunkForOffset), returning Succeeded (sheet dismisses) or Failed (out-of-range → sheet stays open). The
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:45:import androidx.compose.foundation.lazy.LazyListState
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:46:import androidx.compose.foundation.lazy.rememberLazyListState
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:220:                        val listState = rememberLazyListState(initialFirstVisibleItemIndex = s.initialIndex)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:223:                            flushPosition = { savePosition(s.book, s.document, listState.firstVisibleItemIndex) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:226:                        LaunchedEffect(listState, s.document) {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:227:                            snapshotFlow { listState.firstVisibleItemIndex }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:252:                        val spokenChunk = if (tts.phase == TtsPhase.speaking) s.document.chunkForOffset(tts.charStart) else -1
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:256:                            if (spokenChunk >= 0 && listState.layoutInfo.visibleItemsInfo.none { it.index == spokenChunk }) {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:257:                                runCatching { listState.animateScrollToItem(spokenChunk) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:358:                        val liveOffset = s.document.offsetForChunk(listState.firstVisibleItemIndex)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:411:                                    ttsScope.launch { listState.scrollToItem(s.document.chunkForOffset(target)) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:421:                                    listState.scrollToItem(s.document.chunkForOffset(target))
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:454:                                                ttsScope.launch { runCatching { listState.scrollToItem(s.document.chunkForOffset(target)) } }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:473:                                        s.document.offsetForChunk(listState.firstVisibleItemIndex),
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:481:                                            listState.scrollToItem(s.document.chunkForOffset(target))
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:513:                                    s.document, listState, s.book.originalFormat, chunkMapper,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:519:                                            val cs = s.document.offsetForChunk(chunkIndex)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:520:                                            val ce = if (chunkIndex + 1 < s.document.chunkCount) s.document.offsetForChunk(chunkIndex + 1) else s.document.text.length
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:613:        container.cachedOffset(key)?.let { return document.chunkForOffset(it) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:619:        return document.chunkForOffset(offset)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:624:        val offset = document.offsetForChunk(topIndex)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:988:    document: TxtDocument, listState: LazyListState, format: BookFormat,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1039:        state = listState,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSourceOffsets.kt:12:        doc.offsetForChunk(chunkIndex) + offsetInChunk
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSourceOffsets.kt:22:        var i = doc.chunkForOffset(range.startInclusive).coerceIn(0, doc.chunkCount - 1)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSourceOffsets.kt:24:            val base = doc.offsetForChunk(i)
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:32:import androidx.compose.foundation.lazy.rememberLazyListState
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:135:                        val listState = rememberLazyListState(initialFirstVisibleItemIndex = s.initialPage)
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:142:                        SideEffect { flushPosition = { savePage(s.book, listState.firstVisibleItemIndex) } }
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:143:                        LaunchedEffect(listState) {
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:144:                            snapshotFlow { listState.firstVisibleItemIndex }
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:180:                        val livePage = listState.firstVisibleItemIndex
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:193:                            // the existing resume/save page-scroll seam (listState.firstVisibleItemIndex).
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:195:                                jumpScope.launch { listState.scrollToItem(pdfAnnotationPage(item, s.document.pageCount)) }
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:198:                            body = { PdfReaderBody(s.document, listState, backdrop) },
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:217:                                    jumpScope.launch { listState.scrollToItem(target) }
+     1	// Purpose: feature #118 WI-1 (#110 Phase 3) — persists saved AI provider profiles + the active
+     2	// selection. Profile metadata (name/kind/baseUrl/model/temperature/maxTokens) lives in DataStore
+     3	// as a JSON list; the API key is kept ONLY as a SecretCipher token (the #116 KeystoreSecretCipher).
+     4	// Reuses the #116 WebDavServerStore DataStore+SecretCipher credential pattern, adding an active-id
+     5	// and a request-start `snapshot()` (a chat/test reads one consistent profile, not live mid-request
+     6	// store reads). The key + auth headers are NEVER logged.
+     7	package com.vreader.app.ai
+     8	
+     9	import androidx.datastore.core.DataStore
+    10	import androidx.datastore.preferences.core.Preferences
+    11	import androidx.datastore.preferences.core.edit
+    12	import androidx.datastore.preferences.core.stringPreferencesKey
+    13	import com.vreader.app.backup.net.SecretCipher
+    14	import kotlinx.coroutines.flow.Flow
+    15	import kotlinx.coroutines.flow.first
+    16	import kotlinx.coroutines.flow.map
+    17	import kotlinx.serialization.Serializable
+    18	import kotlinx.serialization.json.Json
+    19	
+    20	/** A saved AI provider. `encryptedApiKey` is a [SecretCipher] token, never plaintext. */
+    21	@Serializable
+    22	data class AiProviderProfile(
+    23	    val id: String,
+    24	    val name: String,
+    25	    val kind: AiProviderKind,
+    26	    val baseUrl: String,
+    27	    val model: String,
+    28	    val temperature: Double = 0.7,
+    29	    val maxTokens: Int = 2048,
+    30	    val encryptedApiKey: String,
+    31	)
+    32	
+    33	/** A consistent point-in-time view: the profiles + which is active. */
+    34	data class AiProviderSnapshot(val profiles: List<AiProviderProfile>, val activeId: String?) {
+    35	    val active: AiProviderProfile? get() = profiles.firstOrNull { it.id == activeId }
+    36	}
+    37	
+    38	@Serializable
+    39	private data class AiStoreState(val profiles: List<AiProviderProfile> = emptyList(), val activeId: String? = null)
+    40	
+    41	class AiProviderStore(
+    42	    private val dataStore: DataStore<Preferences>,
+    43	    private val cipher: SecretCipher,
+    44	    private val json: Json = Json { ignoreUnknownKeys = true; encodeDefaults = true },
+    45	) {
+    46	    /** One consistent profiles + active-id view (read once at request start). */
+    47	    suspend fun snapshot(): AiProviderSnapshot = read(dataStore.data.first()).toSnapshot()
+    48	
+    49	    fun observe(): Flow<AiProviderSnapshot> = dataStore.data.map { read(it).toSnapshot() }
+    50	
+    51	    suspend fun list(): List<AiProviderProfile> = snapshot().profiles
+    52	
+    53	    suspend fun activeProfile(): AiProviderProfile? = snapshot().active
+    54	
+    55	    /**
+    56	     * Insert/update a profile by [id]. [apiKey] is the PLAINTEXT to encrypt; pass null on an edit
+    57	     * that leaves the key unchanged (the existing ciphertext is kept). A brand-new id REQUIRES a
+    58	     * key. The first profile added becomes active. Returns the saved profile (key encrypted).
+    59	     */
+    60	    suspend fun upsert(
+    61	        id: String,
+    62	        name: String,
+    63	        kind: AiProviderKind,
+    64	        baseUrl: String,
+    65	        model: String,
+    66	        temperature: Double,
+    67	        maxTokens: Int,
+    68	        apiKey: String?,
+    69	    ): AiProviderProfile {
+    70	        lateinit var saved: AiProviderProfile
+    71	        dataStore.edit { prefs ->
+    72	            val cur = read(prefs)
+    73	            val existing = cur.profiles.firstOrNull { it.id == id }
+    74	            val encrypted = when {
+    75	                apiKey != null -> cipher.encrypt(apiKey)
+    76	                existing != null -> existing.encryptedApiKey  // unchanged on edit
+    77	                else -> throw IllegalArgumentException("a new provider ($id) requires an API key")
+    78	            }
+    79	            saved = AiProviderProfile(id, name, kind, baseUrl, model, temperature, maxTokens, encrypted)
+    80	            val next = cur.profiles.filterNot { it.id == id } + saved
+    81	            val activeId = cur.activeId ?: id  // first provider becomes active
+    82	            prefs[KEY] = json.encodeToString(AiStoreState(next, activeId))
+    83	        }
+    84	        return saved
+    85	    }
+    86	
+    87	    /** Remove a profile. If it was active, the active selection moves to the first remaining (or null). */
+    88	    suspend fun delete(id: String) {
+    89	        dataStore.edit { prefs ->
+    90	            val cur = read(prefs)
+    91	            val next = cur.profiles.filterNot { it.id == id }
+    92	            val activeId = if (cur.activeId == id) next.firstOrNull()?.id else cur.activeId
+    93	            prefs[KEY] = json.encodeToString(AiStoreState(next, activeId))
+    94	        }
+    95	    }
+    96	
+    97	    /** Select the active provider (no-op if the id isn't present). */
+    98	    suspend fun setActive(id: String) {
+    99	        dataStore.edit { prefs ->
+   100	            val cur = read(prefs)
+   101	            if (cur.profiles.any { it.id == id }) prefs[KEY] = json.encodeToString(cur.copy(activeId = id))
+   102	        }
+   103	    }
+   104	
+   105	    /** Decrypt the key from a CAPTURED [profile] — snapshot-consistent (no live store read). The
+   106	     *  chat/test request path uses THIS with a profile from a single [snapshot], so it can't pair
+   107	     *  snapshot metadata with a concurrently-edited/deleted key. */
+   108	    fun apiKey(profile: AiProviderProfile): String = cipher.decrypt(profile.encryptedApiKey)
+   109	
+   110	    /** The decrypted API key for [id] via a live read, or null if absent. Convenience for UI flows
+   111	     *  that aren't mid-request; the request path should prefer [apiKey] (profile). */
+   112	    suspend fun apiKey(id: String): String? =
+   113	        list().firstOrNull { it.id == id }?.let { cipher.decrypt(it.encryptedApiKey) }
+   114	
+   115	    private fun read(prefs: Preferences): AiStoreState {
+   116	        val raw = prefs[KEY] ?: return AiStoreState()
+   117	        return runCatching { json.decodeFromString<AiStoreState>(raw) }.getOrDefault(AiStoreState())
+   118	    }
+   119	
+   120	    private fun AiStoreState.toSnapshot() = AiProviderSnapshot(profiles, activeId)
+   121	
+   122	    companion object {
+   123	        private val KEY = stringPreferencesKey("ai_providers_json")
+   124	    }
+   125	}
+    42	    fun refreshProvider() = viewModelScope.launch {
+    43	        val active = withContext(clientDispatcher) { store.activeProfile() }
+    44	        if (active?.id != activeProviderId) {
+    45	            activeProviderId = active?.id
+    46	            chatGen++            // invalidate any in-flight answer started under the previous provider
+    47	            streamJob?.cancel()
+    48	            _state.update { it.copy(streaming = false, streamingText = "") }
+    49	        }
+    50	        _state.update { it.copy(unconfigured = active == null, providerName = active?.name) }
+    51	    }
+    52	
+    53	    fun send(prompt: String) {
+    54	        val s = _state.value
+    55	        if (s.unconfigured || prompt.isBlank() || s.streaming) return
+    56	        val gen = ++chatGen
+    57	        _state.update { it.copy(mode = AiChatMode.chat, messages = it.messages + ChatMessage(true, prompt), streaming = true, streamingText = "", error = null) }
+    58	        streamJob = viewModelScope.launch {
+    59	            val (profile, key) = activeClient() ?: run { _state.update { it.copy(streaming = false, unconfigured = true) }; return@launch }
+    60	            val history = _state.value.messages.map { AiMessage(if (it.fromUser) AiRole.user else AiRole.assistant, it.text) }
+    61	            val request = AiRequest(profile.model.ifBlank { profile.kind.defaultModel }, history, profile.temperature, profile.maxTokens, system = CHAT_SYSTEM)
+    62	            val sb = StringBuilder()
+    63	            try {
+    64	                factory(profile, key).streamChat(request).collect { chunk ->
+    65	                    if (gen != chatGen) return@collect  // superseded by a provider swap / newer send
+    66	                    sb.append(chunk.deltaText)
+    67	                    _state.update { it.copy(streamingText = sb.toString()) }
+    68	                }
+    69	                if (gen == chatGen) _state.update { it.copy(messages = it.messages + ChatMessage(false, sb.toString()), streaming = false, streamingText = "") }
+    70	            } catch (e: AiError) {
+    71	                if (gen == chatGen) _state.update { it.copy(streaming = false, streamingText = "", error = e.message) }
+    72	            }
+    73	        }
+    74	    }
+    75	
+    76	    /** Stop a streaming answer; keep whatever streamed so far as the assistant message. */
+    77	    fun stop() {
+    78	        streamJob?.cancel()
+    25	    apiKey: String,
+    26	    model: String,
+    27	    temperature: Double,
+    28	    maxTokens: Int,
+    29	    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    30	) : BaseHttpAiClient(baseUrl, apiKey, model, temperature, maxTokens, dispatcher) {
+    31	
+    32	    override val endpointPath = "/chat/completions"
+    33	
+    34	    override fun applyAuth(conn: HttpURLConnection) {
+    35	        conn.setRequestProperty("Authorization", "Bearer $apiKey")  // never logged
+    36	    }
+    37	
+    38	    override fun requestBody(request: AiRequest, stream: Boolean): String = buildJsonObject {
+    39	        put("model", request.model)
+    40	        put("temperature", request.temperature)
+    41	        put("max_tokens", request.maxTokens)
+    42	        put("stream", stream)
+    43	        putJsonArray("messages") {
+    44	            request.system?.let { addJsonObject { put("role", "system"); put("content", it) } }
+    45	            request.messages.forEach { m ->
+    46	                addJsonObject { put("role", m.role.name); put("content", m.content) }
+    47	            }
+    48	        }
+    49	    }.toString()
+    50	
+    51	    override fun parseDelta(event: SseEvent): DeltaParse {
+    52	        val data = event.data
+    25	    maxTokens: Int,
+    26	    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    27	) : BaseHttpAiClient(baseUrl, apiKey, model, temperature, maxTokens, dispatcher) {
+    28	
+    29	    override val endpointPath = "/v1/messages"
+    30	
+    31	    override fun applyAuth(conn: HttpURLConnection) {
+    32	        conn.setRequestProperty("x-api-key", apiKey)  // never logged
+    33	        conn.setRequestProperty("anthropic-version", ANTHROPIC_VERSION)
+    34	    }
+    35	
+    36	    override fun requestBody(request: AiRequest, stream: Boolean): String = buildJsonObject {
+    37	        put("model", request.model)
+    38	        put("max_tokens", request.maxTokens)
+    39	        put("temperature", request.temperature)
+    40	        put("stream", stream)
+    41	        request.system?.let { put("system", it) }  // top-level, not a message
+    42	        putJsonArray("messages") {
+    43	            request.messages.forEach { m ->
+    44	                // Anthropic accepts user/assistant only; a stray system message folds to user.
+    45	                val role = if (m.role == AiRole.assistant) "assistant" else "user"
+    46	                addJsonObject { put("role", role); put("content", m.content) }
+    47	            }
+    48	        }
+    49	    }.toString()
+    50	
+    51	    override fun parseDelta(event: SseEvent): DeltaParse {
+    52	        // Prefer the event-type line; fall back to the data's own `type` (some servers omit event:).
+
+exec
+/bin/zsh -lc "nl -ba dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx | sed -n '70,110p;190,285p' && nl -ba dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md | sed -n '35,190p' && nl -ba dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx | sed -n '1,280p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+    70	                  }}>{l.k}</span>
+    71	                </button>
+    72	              );
+    73	            })}
+    74	          </div>
+    75	        </div>
+    76	
+    77	        {/* granularity */}
+    78	        <div style={{ marginTop: 22 }}>
+    79	          <SectionLabel theme={t}>Granularity</SectionLabel>
+    80	          <div style={{
+    81	            display: 'flex', marginTop: 10, borderRadius: 12,
+    82	            background: t.isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.05)',
+    83	            padding: 3,
+    84	          }}>
+    85	            {[
+    86	              { k: 'paragraph', label: 'Paragraph', sub: 'Translate after each ¶' },
+    87	              { k: 'sentence',  label: 'Sentence',  sub: 'Translate after each sentence' },
+    88	            ].map(o => (
+    89	              <button key={o.k} onClick={() => update('granularity', o.k)} style={{
+    90	                flex: 1, padding: '10px 10px', borderRadius: 10, border: 'none',
+    91	                background: v.granularity === o.k ? (t.isDark ? '#3a3530' : '#fff') : 'transparent',
+    92	                color: t.ink, fontFamily: 'inherit', cursor: 'pointer',
+    93	                boxShadow: v.granularity === o.k ? '0 1px 2px rgba(0,0,0,0.08)' : 'none',
+    94	                textAlign: 'center',
+    95	              }}>
+    96	                <div style={{ fontSize: 13, fontWeight: 600 }}>{o.label}</div>
+    97	                <div style={{ fontSize: 10.5, color: t.sub, marginTop: 1 }}>{o.sub}</div>
+    98	              </button>
+    99	            ))}
+   100	          </div>
+   101	        </div>
+   102	
+   103	        {/* AI provider strip */}
+   104	        <div style={{ marginTop: 22 }}>
+   105	          <SectionLabel theme={t}>Translation engine</SectionLabel>
+   106	          <div style={{
+   107	            marginTop: 8, padding: '12px 14px', borderRadius: 12,
+   108	            background: aiConfigured
+   109	              ? (t.isDark ? 'rgba(255,255,255,0.04)' : '#fff')
+   110	              : `${t.accent}10`,
+   190	      }}>{sample}</div>
+   191	    </div>
+   192	  );
+   193	}
+   194	
+   195	// ────────────────────────────────────────────────────
+   196	// Paragraph-interlinear renderer
+   197	// Used by the reader when bilingual mode is on. Renders source + translation
+   198	// stacked, one source paragraph followed by its translation.
+   199	// ────────────────────────────────────────────────────
+   200	function BilingualPageContent({ page, theme, fontFamily, fontSize, lineHeight, margin,
+   201	                                pageDir, animating, pageIdx, lang = 'Chinese' }) {
+   202	  const t = theme;
+   203	  const ff = fontFamily === 'serif'
+   204	    ? '"Source Serif 4", Georgia, "Times New Roman", serif'
+   205	    : '"Inter", -apple-system, system-ui, sans-serif';
+   206	  const translatedFF = (lang === 'Chinese' || lang === 'Japanese' || lang === 'Korean')
+   207	    ? '"Songti SC", "Source Han Serif", serif'
+   208	    : ff;
+   209	  const isRTL = lang === 'Arabic';
+   210	
+   211	  const animTransform = animating
+   212	    ? `translateX(${pageDir > 0 ? -8 : 8}%) ` : 'translateX(0) ';
+   213	  const animOpacity = animating ? 0 : 1;
+   214	
+   215	  // Mock translations for the sample P&P paragraphs (matches vreader-data.jsx PP_PAGES)
+   216	  const TRANSLATIONS = {
+   217	    Chinese: {
+   218	      'It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife.':
+   219	        '凡是有钱的单身汉，总想娶位太太，这已经成了一条举世公认的真理。',
+   220	      'However little known the feelings or views of such a man may be on his first entering a neighbourhood, this truth is so well fixed in the minds of the surrounding families, that he is considered as the rightful property of some one or other of their daughters.':
+   221	        '这样的单身汉，每逢新搬到一个地方，四邻八舍虽然完全不了解他的性情如何，见解如何，可是，既然这样的一条真理早已在人们心目中根深蒂固，因此人们总是把他看作自己某一个女儿理所应得的一笔财产。',
+   222	    },
+   223	  };
+   224	  const fallback = (en) => '【' + (lang === 'Chinese' ? '译文' : lang) + '】 ' + en.slice(0, 60) + '…';
+   225	
+   226	  return (
+   227	    <div style={{
+   228	      position: 'absolute', top: 76, bottom: 56, left: margin, right: margin,
+   229	      overflow: 'hidden', transform: animTransform, opacity: animOpacity,
+   230	      transition: 'transform 0.28s cubic-bezier(0.32, 0.72, 0, 1), opacity 0.22s ease-out',
+   231	      direction: isRTL ? 'ltr' : 'ltr', // source is always LTR
+   232	    }}>
+   233	      {(pageIdx === 0 || page.chapter !== PP_PAGES[(pageIdx - 1 + PP_PAGES.length) % PP_PAGES.length].chapter) && (
+   234	        <div style={{
+   235	          fontFamily: '"Source Serif 4", Georgia, serif',
+   236	          fontSize: 13, color: t.sub, letterSpacing: 2,
+   237	          textTransform: 'uppercase', textAlign: 'center',
+   238	          marginBottom: 18, marginTop: 8, fontWeight: 500,
+   239	        }}>{page.chapter}</div>
+   240	      )}
+   241	      {page.paragraphs.map((para, i) => {
+   242	        const tr = (TRANSLATIONS[lang] && TRANSLATIONS[lang][para]) || fallback(para);
+   243	        return (
+   244	          <div key={i} style={{ marginBottom: lineHeight * fontSize * 0.55 }}>
+   245	            <p style={{
+   246	              fontFamily: ff, fontSize, lineHeight, color: t.ink, margin: 0,
+   247	              textIndent: i === 0 ? 0 : `${fontSize * 1.4}px`,
+   248	              textAlign: 'justify', hyphens: 'auto',
+   249	            }}>
+   250	              {i === 0 && (
+   251	                <span style={{
+   252	                  fontFamily: '"Source Serif 4", Georgia, serif',
+   253	                  fontSize: fontSize * 2.6, lineHeight: 0.85,
+   254	                  float: 'left', marginRight: 6, marginTop: 4,
+   255	                  color: t.accent, fontWeight: 600,
+   256	                }}>{para[0]}</span>
+   257	              )}
+   258	              {i === 0 ? para.slice(1) : para}
+   259	            </p>
+   260	            <p style={{
+   261	              fontFamily: translatedFF,
+   262	              fontSize: fontSize * 0.88, lineHeight: 1.55,
+   263	              color: t.sub, margin: '6px 0 0',
+   264	              paddingLeft: fontSize * 1.0, paddingRight: isRTL ? 0 : 0,
+   265	              direction: isRTL ? 'rtl' : 'ltr',
+   266	              textAlign: isRTL ? 'right' : 'left',
+   267	              borderLeft: isRTL ? 'none' : `2px solid ${t.accent}55`,
+   268	              borderRight: isRTL ? `2px solid ${t.accent}55` : 'none',
+   269	              paddingLeft: isRTL ? 0 : fontSize * 0.7,
+   270	              paddingRight: isRTL ? fontSize * 0.7 : 0,
+   271	            }}>{tr}</p>
+   272	          </div>
+   273	        );
+   274	      })}
+   275	    </div>
+   276	  );
+   277	}
+   278	
+   279	// ────────────────────────────────────────────────────
+   280	// The "EN ↔ 中" pill shown in the reader top chrome when bilingual is on
+   281	// ────────────────────────────────────────────────────
+   282	function BilingualPill({ theme, lang }) {
+   283	  const t = theme;
+   284	  const glyph = (BILINGUAL_LANGS.find(l => l.k === lang) || BILINGUAL_LANGS[0]).glyph;
+   285	  return (
+    35	---
+    36	
+    37	## Three approaches
+    38	
+    39	### A — Scoped AI Providers sheet, pushed in the bilingual flow  ·  CANONICAL
+    40	
+    41	"Set up" pushes a **navigation level inside the same bottom sheet** — same frame,
+    42	same height, slide-left push. Nav bar: `‹ Bilingual` leading, **AI Providers**
+    43	title. The body is *only* the `AISettingsSection` provider list — nothing else
+    44	from `SettingsView`.
+    45	
+    46	- **Zero providers** → the list shows an empty state (sparkle tile, one line of
+    47	  copy naming *why* the user is here — "Bilingual mode needs a provider to
+    48	  translate") and a single **Add provider** CTA.
+    49	- **Add provider** presents the canonical `AIProviderEditSheet`
+    50	  (`vreader-ai-provider-fields.jsx`) as its own modal sheet — full height,
+    51	  unchanged from the Library path. Kind / Name / Endpoint / Sampling / API Key /
+    52	  Test Connection all intact.
+    53	- **On the first Save**, the new provider becomes the bilingual engine default
+    54	  and the stack **pops all the way back to Bilingual**. The engine strip now reads
+    55	  *"Claude · configured" / "Change…"*, ready for **Turn on bilingual mode**. That
+    56	  return is the payoff — the user lands exactly where they started, with the one
+    57	  thing they were missing now filled in.
+    58	- Tapping `‹ Bilingual` *without* adding returns to Bilingual still unconfigured —
+    59	  no state mutated, no penalty for backing out.
+    60	
+    61	**Why A wins**
+    62	
+    63	- **Reuses the canonical editor.** No second, diverging "add a provider" form to
+    64	  maintain. Test Connection, keychain storage, endpoint hints — all the work
+    65	  already shipped in `AIProviderEditSheet` comes for free.
+    66	- **Keeps the reader context.** A scoped sheet, not the whole app-settings tree.
+    67	  The user never sees Cloud & Sync, OPDS catalogs, Book sources, TTS, replacement
+    68	  rules — none of which they came for.
+    69	- **Closes the loop.** The user's actual goal is "turn on bilingual"; A returns
+    70	  them to that goal with the blocker removed. B and C both leak that thread.
+    71	- **One surface for both entry points.** "Change…" (when already configured) lands
+    72	  on the *same* list, current provider checked — so add-first and change-later
+    73	  share a destination.
+    74	
+    75	The extra navigation level (list → editor) looks like a cost when there are zero
+    76	providers, but it isn't: the empty state is a one-tap shortcut into the editor.
+    77	When the user *does* already have providers (added from Library, or for the AI
+    78	chat assistant), the list is the correct landing — "Set up" should let them pick,
+    79	not silently create a duplicate.
+    80	
+    81	### B — Deep-link into the full `SettingsView`, scrolled to the AI section
+    82	
+    83	Present the entire app `SettingsView` modally over the reader, auto-scrolled and
+    84	briefly highlighting the AI section.
+    85	
+    86	- **Pro:** one surface, verbatim reuse of the Library path, no new navigation
+    87	  container.
+    88	- **Why not canonical:** it dumps a reader-context user into the *whole* app
+    89	  configuration — Cloud, OPDS, sources, TTS, Chinese conversion, About — to do one
+    90	  narrow thing. And the return is ambiguous: closing `SettingsView` drops the user
+    91	  back to the reader with the bilingual sheet already gone, so the "I was turning
+    92	  on bilingual" thread is lost. They have to re-open More → toggle bilingual again.
+    93	
+    94	### C — Inline expansion inside the bilingual sheet
+    95	
+    96	"Set up" expands the engine strip *in place* into a minimal provider-+-key form;
+    97	no navigation at all.
+    98	
+    99	- **Pro:** the tightest possible loop — the user never leaves the bilingual sheet.
+   100	- **Why not canonical:** the real provider model is not "provider + key". It's
+   101	  kind, name, base URL (with append-path hints), model, sampling, keychain-stored
+   102	  key, and a live connection test. A bilingual half-sheet can't host that without
+   103	  either cramping it or shipping a stripped-down form that **diverges from
+   104	  `AIProviderEditSheet`** — at which point a key saved here wouldn't be testable,
+   105	  and two "add provider" surfaces would drift. Held in reserve for a future
+   106	  "express setup" only if we ever ship a genuinely one-field provider kind.
+   107	
+   108	---
+   109	
+   110	## Navigation model (precise)
+   111	
+   112	```
+   113	   More ▸ Bilingual mode (first toggle on)
+   114	        └─ BilingualSetupSheet        [bottom sheet · height 620]
+   115	             engine strip: "No AI provider configured"  [ Set up ]
+   116	                                   │  onOpenSettings
+   117	                                   ▼   (push, slide-left, same sheet frame)
+   118	           AIProvidersSheet           [nav bar: ‹ Bilingual · "AI Providers"]
+   119	             ├─ empty  → [ Add provider ] ─┐
+   120	             └─ list   → tap a row sets it │  (present modal, full height)
+   121	                                   ▼        ▼
+   122	                          AIProviderEditSheet   [vreader-ai-provider-fields.jsx]
+   123	                                   │  Save
+   124	                                   ▼   (provider becomes bilingual engine,
+   125	                                        pop the whole stack)
+   126	           BilingualSetupSheet  ← engine strip now "Claude · configured" / Change…
+   127	```
+   128	
+   129	- The AI Providers view is a **push within the bilingual sheet**, NOT a modal over
+   130	  the reader and NOT the full `SettingsView`.
+   131	- The editor is a **modal on top** (tall form deserves full height).
+   132	- "Change…" on an already-configured strip opens the **same** `AIProvidersSheet`,
+   133	  populated, current provider checked.
+   134	
+   135	---
+   136	
+   137	## States — covered exhaustively in the canvas
+   138	
+   139	**Trigger**
+   140	- The bilingual sheet, engine unconfigured, "Set up" highlighted (start point) —
+   141	  paper + dark.
+   142	
+   143	**A · canonical**
+   144	- AI Providers — empty (no providers) + bilingual-context note + Add CTA.
+   145	- Add Provider — the canonical `AIProviderEditSheet`, pushed.
+   146	- AI Providers — populated, new provider "In use" checked, Done.
+   147	- Return to Bilingual — engine configured, "Change…", ready to turn on (payoff).
+   148	- Empty + populated in dark.
+   149	- Reached via "Change…" — multiple providers, switching the selected one.
+   150	
+   151	**B · alternative** — full `SettingsView` deep-link, AI section highlighted —
+   152	paper + dark.
+   153	
+   154	**C · alternative** — inline expansion in the bilingual strip — paper + dark.
+   155	
+   156	**D · anatomy** — the nav-stack diagram + engine-strip before/after, true size.
+   157	
+   158	---
+   159	
+   160	## Production wiring
+   161	
+   162	- New reader-scoped presentation: a lightweight nav container hosting **only**
+   163	  `AISettingsSection`'s provider list — call it `ReaderAIProvidersView`. It is NOT
+   164	  `SettingsView`; it reuses the same `AIProviderListView` + `AIProviderEditSheet`
+   165	  cells.
+   166	- `BilingualSetupSheet.onOpenSettings` → presents `ReaderAIProvidersView` as a
+   167	  push inside the bilingual sheet's own `NavigationStack` (so `‹ Bilingual` is a
+   168	  real back, not a dismiss).
+   169	- On `AIProviderEditSheet` Save when launched from this flow: set the saved
+   170	  provider as the bilingual mode engine (`BilingualConfig.engineProviderID`) and
+   171	  dismiss back to the bilingual sheet (pop to root).
+   172	- `aiConfigured` on the engine strip is derived from
+   173	  `AISettingsViewModel.providers.isEmpty == false`; the strip's CTA label is
+   174	  `Set up` when empty, `Change…` otherwise (already shipped by #301).
+   175	- The Library `SettingsView → AI provider` row is unchanged; it still opens the
+   176	  full list. This adds a *second*, scoped entry — it does not move the first.
+   177	
+   178	## Cross-references
+   179	
+   180	| File | Role |
+   181	|---|---|
+   182	| `VReader AI Provider Entry Canvas.html` | Canvas of every state across themes. Source of truth. |
+   183	| `vreader-ai-provider-entry.jsx` | `AIProvidersSheet`, `BilingualEngineStrip`, `EngineStripInline`, `NavFlowDiagram` — #1380 |
+   184	| `vreader-ai-provider-fields.jsx` | `EditorSheet` (`AIProviderEditSheet`) — reused unchanged for the add/edit step (#1363) |
+   185	| `vreader-bilingual.jsx` | `BilingualSetupSheet` — the surface whose "Set up" button this wires (#790) |
+   186	| `design-notes/feature-60-followups.md` | Parent bilingual feature notes (#60 / #56) |
+     1	// In-reader AI Providers entry — issue #1380.
+     2	//
+     3	// Wires the bilingual setup sheet's "Set up" button (shown when no AI provider
+     4	// is configured, per Bug #301) to an actual AI Providers surface — which does
+     5	// not exist in-reader today (the reader's showSettings sheet is display/fonts
+     6	// only; the full SettingsView with AISettingsSection is Library-only).
+     7	//
+     8	// CANONICAL (A): a scoped "AI Providers" sheet PUSHED inside the bilingual
+     9	//   flow (nav bar: ‹ Bilingual · "AI Providers"), hosting only the provider
+    10	//   list. Empty → "Add provider" → the canonical AIProviderEditSheet
+    11	//   (vreader-ai-provider-fields.jsx, reused unchanged). On first Save the
+    12	//   provider becomes the bilingual engine and the stack pops back to Bilingual,
+    13	//   whose engine strip now reads "configured / Change…".
+    14	//
+    15	// ALTERNATIVES shown for comparison:
+    16	//   B — deep-link into the full SettingsView, scrolled to the AI section.
+    17	//   C — inline expansion of the engine strip inside the bilingual sheet.
+    18	//
+    19	// Reuses: Sheet vocabulary, SectionLabel, Icons, THEMES tokens. The provider
+    20	// tile keeps the fixed #8c2f2f brand color used by the shipped AI Provider row.
+    21	
+    22	const AIPE_BRAND = '#8c2f2f';           // AI provider tile (theme-independent)
+    23	const AIPE_MONO  = 'ui-monospace, "SF Mono", "Menlo", monospace';
+    24	const AIPE_SERIF = '"Source Serif 4", Georgia, serif';
+    25	
+    26	// ────────────────────────────────────────────────────
+    27	// NavSheet — bottom sheet with an iOS-style navigation bar (back + centered
+    28	// title + trailing). This is the "push within the sheet" presentation: same
+    29	// grabber + frame as Sheet, but a real back affordance instead of a grabber-
+    30	// only modal. Title is absolutely centered so a wide back label can't shove it.
+    31	// ────────────────────────────────────────────────────
+    32	function NavSheet({ theme, height = 620, title, backLabel = 'Bilingual', onBack, trailing, children }) {
+    33	  const t = theme || THEMES.paper;
+    34	  return (
+    35	    <div style={{
+    36	      position: 'absolute', inset: 0, zIndex: 200,
+    37	      display: 'flex', flexDirection: 'column', justifyContent: 'flex-end',
+    38	      background: 'rgba(0,0,0,0.35)',
+    39	    }}>
+    40	      <div style={{
+    41	        background: t.isDark ? '#222020' : '#fcf8f0',
+    42	        height, borderTopLeftRadius: 22, borderTopRightRadius: 22,
+    43	        boxShadow: '0 -8px 28px rgba(0,0,0,0.25)',
+    44	        display: 'flex', flexDirection: 'column', overflow: 'hidden',
+    45	      }}>
+    46	        <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 8 }}>
+    47	          <div style={{
+    48	            width: 36, height: 5, borderRadius: 3,
+    49	            background: t.isDark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.12)',
+    50	          }}/>
+    51	        </div>
+    52	        <div style={{
+    53	          position: 'relative', display: 'flex', alignItems: 'center',
+    54	          padding: '13px 16px 12px',
+    55	          borderBottom: `0.5px solid ${t.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
+    56	        }}>
+    57	          <button onClick={onBack} style={{
+    58	            display: 'flex', alignItems: 'center', gap: 1, zIndex: 1,
+    59	            background: 'none', border: 'none', padding: 0, cursor: 'pointer',
+    60	            color: t.accent, fontFamily: 'inherit', fontSize: 15, fontWeight: 500,
+    61	            whiteSpace: 'nowrap',
+    62	          }}>
+    63	            <Icons.ChevronL size={19} color={t.accent} stroke={2.2}/>
+    64	            <span>{backLabel}</span>
+    65	          </button>
+    66	          <div style={{
+    67	            position: 'absolute', left: 0, right: 0, textAlign: 'center',
+    68	            fontFamily: AIPE_SERIF, fontSize: 17, fontWeight: 600, color: t.ink,
+    69	            pointerEvents: 'none',
+    70	          }}>{title}</div>
+    71	          <div style={{ marginLeft: 'auto', zIndex: 1 }}>{trailing}</div>
+    72	        </div>
+    73	        <div style={{ flex: 1, overflow: 'auto' }} className="hide-scroll">{children}</div>
+    74	      </div>
+    75	    </div>
+    76	  );
+    77	}
+    78	
+    79	// ────────────────────────────────────────────────────
+    80	// Bilingual engine strip — standalone replica of the strip inside
+    81	// BilingualSetupSheet, so the canvas can show the before ("Set up") and after
+    82	// ("Change…") states and the flow's payoff. justChanged adds a brief accent
+    83	// ring on the freshly-configured return.
+    84	// ────────────────────────────────────────────────────
+    85	function BilingualEngineStrip({ theme, configured, providerName = 'Claude', onSetup, justChanged = false }) {
+    86	  const t = theme;
+    87	  return (
+    88	    <div>
+    89	      <SectionLabel theme={t}>Translation engine</SectionLabel>
+    90	      <div style={{
+    91	        marginTop: 8, padding: '12px 14px', borderRadius: 12,
+    92	        background: configured ? (t.isDark ? 'rgba(255,255,255,0.04)' : '#fff') : `${t.accent}10`,
+    93	        border: configured ? `0.5px solid ${t.rule}` : `0.5px solid ${t.accent}55`,
+    94	        boxShadow: justChanged ? `0 0 0 2px ${t.accent}66` : 'none',
+    95	        display: 'flex', alignItems: 'center', gap: 12,
+    96	        transition: 'box-shadow 0.3s',
+    97	      }}>
+    98	        <div style={{
+    99	          width: 28, height: 28, borderRadius: 14, flexShrink: 0,
+   100	          background: configured ? `linear-gradient(135deg, ${t.accent}, ${t.accent}aa)` : 'rgba(0,0,0,0.08)',
+   101	          display: 'flex', alignItems: 'center', justifyContent: 'center',
+   102	        }}>
+   103	          <Icons.Sparkle size={14} color={configured ? '#fff' : t.sub} stroke={2}/>
+   104	        </div>
+   105	        <div style={{ flex: 1, minWidth: 0 }}>
+   106	          <div style={{ fontSize: 13.5, color: t.ink, fontWeight: 600 }}>
+   107	            {configured ? `${providerName} · with this book’s context` : 'No AI provider configured'}
+   108	          </div>
+   109	          <div style={{ fontSize: 11.5, color: t.sub, marginTop: 1 }}>
+   110	            {configured
+   111	              ? 'Translations cached per paragraph, one page ahead.'
+   112	              : 'Bilingual mode needs an AI provider to translate.'}
+   113	          </div>
+   114	        </div>
+   115	        <button onClick={onSetup} style={{
+   116	          padding: '5px 11px', borderRadius: 100, border: 'none',
+   117	          background: configured ? (t.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)') : t.accent,
+   118	          color: configured ? t.ink : '#fff',
+   119	          fontFamily: 'inherit', fontSize: 11.5, fontWeight: 600, cursor: 'pointer',
+   120	          flexShrink: 0,
+   121	        }}>{configured ? 'Change…' : 'Set up'}</button>
+   122	      </div>
+   123	    </div>
+   124	  );
+   125	}
+   126	
+   127	// ────────────────────────────────────────────────────
+   128	// Provider list row — matches the shipped SettingsRow vocabulary.
+   129	// ────────────────────────────────────────────────────
+   130	function ProviderRow({ theme, name, model, selected, onClick, last }) {
+   131	  const t = theme;
+   132	  return (
+   133	    <div onClick={onClick} style={{
+   134	      display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px',
+   135	      borderBottom: last ? 'none' : `0.5px solid ${t.rule}`, cursor: 'pointer',
+   136	    }}>
+   137	      <div style={{
+   138	        width: 30, height: 30, borderRadius: 8, flexShrink: 0, background: AIPE_BRAND,
+   139	        display: 'flex', alignItems: 'center', justifyContent: 'center',
+   140	      }}>
+   141	        <Icons.Sparkle size={17} color="#fff" stroke={1.8}/>
+   142	      </div>
+   143	      <div style={{ flex: 1, minWidth: 0 }}>
+   144	        <div style={{ fontSize: 15, color: t.ink }}>{name}</div>
+   145	        <div style={{ fontSize: 11, color: t.sub, marginTop: 1, fontFamily: AIPE_MONO }}>{model}</div>
+   146	      </div>
+   147	      {selected ? (
+   148	        <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
+   149	          <span style={{ fontSize: 10.5, fontWeight: 600, color: t.accent, letterSpacing: 0.4, textTransform: 'uppercase', whiteSpace: 'nowrap' }}>In use</span>
+   150	          <Icons.Check size={16} color={t.accent} stroke={2.6}/>
+   151	        </div>
+   152	      ) : (
+   153	        <Icons.Chevron size={13} color={t.sub} stroke={2}/>
+   154	      )}
+   155	    </div>
+   156	  );
+   157	}
+   158	
+   159	// ────────────────────────────────────────────────────
+   160	// AI Providers sheet body — empty + populated.
+   161	// ────────────────────────────────────────────────────
+   162	function AIProvidersSheetBody({ theme, providers, selectedId, onAdd, onSelect }) {
+   163	  const t = theme;
+   164	  const empty = !providers || providers.length === 0;
+   165	  return (
+   166	    <div style={{ padding: '14px 18px 28px' }}>
+   167	      {/* why-you're-here context — the bilingual thread, kept visible */}
+   168	      <div style={{
+   169	        display: 'flex', alignItems: 'center', gap: 10,
+   170	        padding: '10px 12px', borderRadius: 10,
+   171	        background: `${t.accent}10`, border: `0.5px solid ${t.accent}33`,
+   172	        marginBottom: 18,
+   173	      }}>
+   174	        <div style={{
+   175	          width: 22, height: 22, borderRadius: 11, flexShrink: 0,
+   176	          background: `${t.accent}1f`, display: 'flex', alignItems: 'center', justifyContent: 'center',
+   177	        }}>
+   178	          <Icons.Translate size={13} color={t.accent} stroke={1.9}/>
+   179	        </div>
+   180	        <div style={{ fontSize: 11.5, color: t.ink, lineHeight: 1.35 }}>
+   181	          Choose the provider <b style={{ fontWeight: 600 }}>bilingual mode</b> will use to translate this book.
+   182	        </div>
+   183	      </div>
+   184	
+   185	      {empty ? (
+   186	        <div style={{ textAlign: 'center', padding: '24px 12px 8px' }}>
+   187	          <div style={{
+   188	            width: 54, height: 54, borderRadius: 27, margin: '0 auto 14px',
+   189	            background: `linear-gradient(135deg, ${t.accent}, ${t.accent}aa)`,
+   190	            display: 'flex', alignItems: 'center', justifyContent: 'center',
+   191	            boxShadow: `0 6px 18px ${t.accent}44`,
+   192	          }}>
+   193	            <Icons.Sparkle size={26} color="#fff" stroke={1.7}/>
+   194	          </div>
+   195	          <div style={{ fontFamily: AIPE_SERIF, fontSize: 18, fontWeight: 600, color: t.ink }}>
+   196	            No providers yet
+   197	          </div>
+   198	          <div style={{ fontSize: 12.5, color: t.sub, lineHeight: 1.5, maxWidth: 268, margin: '6px auto 20px' }}>
+   199	            Add Claude, OpenAI, or any OpenAI-compatible endpoint. Your API key is stored in the device keychain — never synced.
+   200	          </div>
+   201	          <button onClick={onAdd} style={{
+   202	            display: 'inline-flex', alignItems: 'center', gap: 7,
+   203	            padding: '11px 20px', borderRadius: 100, border: 'none',
+   204	            background: t.accent, color: '#fff',
+   205	            fontFamily: 'inherit', fontSize: 14, fontWeight: 600, cursor: 'pointer',
+   206	            boxShadow: `0 4px 14px ${t.accent}55`,
+   207	          }}>
+   208	            <Icons.Plus size={17} color="#fff" stroke={2.2}/>Add provider
+   209	          </button>
+   210	        </div>
+   211	      ) : (
+   212	        <div>
+   213	          <SectionLabel theme={t}>Providers</SectionLabel>
+   214	          <div style={{
+   215	            marginTop: 8, borderRadius: 14, overflow: 'hidden',
+   216	            background: t.isDark ? 'rgba(255,255,255,0.04)' : '#fff',
+   217	            boxShadow: t.isDark ? 'none' : '0 1px 0 rgba(0,0,0,0.04)',
+   218	          }}>
+   219	            {providers.map((p) => (
+   220	              <ProviderRow key={p.id} theme={t} name={p.name} model={p.model}
+   221	                selected={p.id === selectedId} onClick={() => onSelect && onSelect(p.id)}/>
+   222	            ))}
+   223	            <div onClick={onAdd} style={{
+   224	              display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px', cursor: 'pointer',
+   225	            }}>
+   226	              <div style={{
+   227	                width: 30, height: 30, borderRadius: 8, flexShrink: 0,
+   228	                background: t.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)',
+   229	                display: 'flex', alignItems: 'center', justifyContent: 'center',
+   230	              }}>
+   231	                <Icons.Plus size={18} color={t.accent} stroke={2.2}/>
+   232	              </div>
+   233	              <div style={{ flex: 1, fontSize: 15, color: t.accent, fontWeight: 500 }}>Add provider</div>
+   234	            </div>
+   235	          </div>
+   236	          <div style={{ fontSize: 11.5, color: t.sub, lineHeight: 1.45, padding: '10px 4px 0' }}>
+   237	            Tap a provider to use it for translating this book.
+   238	          </div>
+   239	        </div>
+   240	      )}
+   241	    </div>
+   242	  );
+   243	}
+   244	
+   245	function AIProvidersSheet({ theme, providers = [], selectedId, onBack, onAdd, onSelect, trailing, height = 620 }) {
+   246	  return (
+   247	    <NavSheet theme={theme} height={height} title="AI Providers" backLabel="Bilingual" onBack={onBack} trailing={trailing}>
+   248	      <AIProvidersSheetBody theme={theme} providers={providers} selectedId={selectedId} onAdd={onAdd} onSelect={onSelect}/>
+   249	    </NavSheet>
+   250	  );
+   251	}
+   252	
+   253	// ────────────────────────────────────────────────────
+   254	// ALTERNATIVE C — inline expansion of the engine strip.
+   255	// Collapsed = the unconfigured strip; expanded = a minimal provider+key form
+   256	// in place. Shows why it can't host the real editor without diverging.
+   257	// ────────────────────────────────────────────────────
+   258	function EngineStripInline({ theme, expanded }) {
+   259	  const t = theme;
+   260	  const seg = ['Claude', 'OpenAI', 'Custom'];
+   261	  return (
+   262	    <div>
+   263	      <SectionLabel theme={t}>Translation engine</SectionLabel>
+   264	      <div style={{
+   265	        marginTop: 8, borderRadius: 12, overflow: 'hidden',
+   266	        background: `${t.accent}10`, border: `0.5px solid ${t.accent}55`,
+   267	      }}>
+   268	        <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px' }}>
+   269	          <div style={{
+   270	            width: 28, height: 28, borderRadius: 14, flexShrink: 0, background: 'rgba(0,0,0,0.08)',
+   271	            display: 'flex', alignItems: 'center', justifyContent: 'center',
+   272	          }}>
+   273	            <Icons.Sparkle size={14} color={t.sub} stroke={2}/>
+   274	          </div>
+   275	          <div style={{ flex: 1, minWidth: 0 }}>
+   276	            <div style={{ fontSize: 13.5, color: t.ink, fontWeight: 600 }}>No AI provider configured</div>
+   277	            <div style={{ fontSize: 11.5, color: t.sub, marginTop: 1 }}>
+   278	              {expanded ? 'Add one below to translate.' : 'Bilingual mode needs an AI provider to translate.'}
+   279	            </div>
+   280	          </div>
+
+exec
+/bin/zsh -lc "nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt | sed -n '1,300p' && nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt | sed -n '1,360p' && rg -n \"class AiSettingsViewModel|fun save|upsert|onSave|saved\" android/app/src/main/kotlin/com/vreader/app/ai android/app/src/test/kotlin/com/vreader/app/ai android/app/src/androidTest/kotlin/com/vreader/app/ai" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+     1	// Purpose: feature #118 WI-3 (#110 Phase 3) — the AI provider list (the gate), design surface A
+     2	// from vreader-ai-android.jsx `AiProviderList`: unconfigured onboards to a single Add action;
+     3	// configured shows the active provider + per-provider status (model, or the rejection reason).
+     4	// Reuses the shared form vocabulary (NavScreen / SettingsCard / GroupHeader / StatusDot / tokens —
+     5	// mapped from this surface's own design file). Stateless: a pure function of the list + callbacks.
+     6	package com.vreader.app.ai
+     7	
+     8	import androidx.compose.foundation.background
+     9	import androidx.compose.foundation.clickable
+    10	import androidx.compose.foundation.layout.Box
+    11	import androidx.compose.foundation.layout.Column
+    12	import androidx.compose.foundation.layout.Row
+    13	import androidx.compose.foundation.layout.fillMaxWidth
+    14	import androidx.compose.foundation.layout.height
+    15	import androidx.compose.foundation.layout.heightIn
+    16	import androidx.compose.foundation.layout.padding
+    17	import androidx.compose.foundation.layout.size
+    18	import androidx.compose.foundation.shape.CircleShape
+    19	import androidx.compose.foundation.shape.RoundedCornerShape
+    20	import androidx.compose.material.icons.Icons
+    21	import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+    22	import androidx.compose.material.icons.filled.Add
+    23	import androidx.compose.material.icons.filled.AutoAwesome
+    24	import androidx.compose.material3.Icon
+    25	import androidx.compose.material3.Text
+    26	import androidx.compose.runtime.Composable
+    27	import androidx.compose.ui.Alignment
+    28	import androidx.compose.ui.Modifier
+    29	import androidx.compose.ui.draw.clip
+    30	import androidx.compose.ui.graphics.Color
+    31	import androidx.compose.ui.platform.testTag
+    32	import androidx.compose.ui.text.font.FontWeight
+    33	import androidx.compose.ui.text.style.TextAlign
+    34	import androidx.compose.ui.unit.dp
+    35	import androidx.compose.ui.unit.sp
+    36	import com.vreader.app.backup.BackupFonts
+    37	import com.vreader.app.backup.GroupFooter
+    38	import com.vreader.app.backup.GroupHeader
+    39	import com.vreader.app.backup.LocalBackupTokens
+    40	import com.vreader.app.backup.NavScreen
+    41	import com.vreader.app.backup.SettingsCard
+    42	import com.vreader.app.backup.StatusDot
+    43	import com.vreader.app.backup.VSpace
+    44	
+    45	@Composable
+    46	fun AiProviderListScreen(
+    47	    state: AiProviderListState,
+    48	    onBack: () -> Unit = {},
+    49	    onAdd: () -> Unit = {},
+    50	    onEdit: (String) -> Unit = {},
+    51	) {
+    52	    val t = LocalBackupTokens.current
+    53	    val addButton: @Composable () -> Unit = {
+    54	        Box(
+    55	            Modifier.size(44.dp).clip(RoundedCornerShape(22.dp)).clickable(onClickLabel = "Add provider", onClick = onAdd),
+    56	            contentAlignment = Alignment.Center,
+    57	        ) { Icon(Icons.Filled.Add, contentDescription = "Add provider", tint = t.tint, modifier = Modifier.size(22.dp)) }
+    58	    }
+    59	    NavScreen(title = "AI Providers", large = true, onBack = onBack, trailing = addButton) {
+    60	        Column(Modifier.padding(horizontal = 18.dp).padding(bottom = 32.dp)) {
+    61	            if (state.unconfigured) {
+    62	                AiEmptyState(onAdd)
+    63	            } else {
+    64	                GroupHeader("Providers")
+    65	                SettingsCard {
+    66	                    state.providers.forEachIndexed { i, p ->
+    67	                        ProviderRow(p, last = i == state.providers.lastIndex, onEdit = onEdit)
+    68	                    }
+    69	                }
+    70	                GroupFooter("The selected provider is used for translation, chat, and summaries. Tap one to edit or test it.")
+    71	            }
+    72	        }
+    73	    }
+    74	}
+    75	
+    76	@Composable
+    77	private fun AiEmptyState(onAdd: () -> Unit) {
+    78	    val t = LocalBackupTokens.current
+    79	    Column(Modifier.fillMaxWidth().padding(top = 36.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+    80	        Box(Modifier.size(64.dp).clip(CircleShape).background(t.chipBg), contentAlignment = Alignment.Center) {
+    81	            Icon(Icons.Filled.AutoAwesome, contentDescription = null, tint = t.tint, modifier = Modifier.size(30.dp))
+    82	        }
+    83	        VSpace(18)
+    84	        Text("Connect an AI provider", color = t.ink, fontFamily = BackupFonts.Serif, fontSize = 21.sp, textAlign = TextAlign.Center)
+    85	        VSpace(8)
+    86	        Text(
+    87	            "One key unlocks bilingual translation, chat about a book, and chapter summaries. Your key is stored on-device only.",
+    88	            color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 14.sp, lineHeight = 22.sp, textAlign = TextAlign.Center,
+    89	        )
+    90	        VSpace(18)
+    91	        Box(
+    92	            Modifier.fillMaxWidth().clip(RoundedCornerShape(13.dp)).background(t.tint)
+    93	                .clickable(onClickLabel = "Add a provider", onClick = onAdd).testTag("ai-add-provider").padding(vertical = 14.dp),
+    94	            contentAlignment = Alignment.Center,
+    95	        ) { Text("Add a provider", color = Color.White, fontFamily = BackupFonts.Sans, fontSize = 15.sp, fontWeight = FontWeight.SemiBold) }
+    96	        GroupFooter("Works with Anthropic, OpenAI-compatible endpoints, and local models.")
+    97	    }
+    98	}
+    99	
+   100	@Composable
+   101	private fun ProviderRow(p: AiProviderRow, last: Boolean, onEdit: (String) -> Unit) {
+   102	    val t = LocalBackupTokens.current
+   103	    Box {
+   104	        Row(
+   105	            Modifier.fillMaxWidth().heightIn(min = 60.dp).clickable(onClick = { onEdit(p.id) })
+   106	                .testTag("provider-${p.id}").padding(horizontal = 14.dp),
+   107	            verticalAlignment = Alignment.CenterVertically,
+   108	        ) {
+   109	            // active = filled accent circle; inactive = hollow ring (sep ring + card-coloured core)
+   110	            Box(
+   111	                Modifier.size(20.dp).clip(CircleShape).background(if (p.active) t.tint else t.sep),
+   112	                contentAlignment = Alignment.Center,
+   113	            ) {
+   114	                if (!p.active) Box(Modifier.size(16.5.dp).clip(CircleShape).background(t.card))
+   115	            }
+   116	            Column(Modifier.weight(1f).padding(start = 12.dp)) {
+   117	                Text(p.name, color = t.ink, fontFamily = BackupFonts.Sans, fontSize = 15.5.sp, fontWeight = FontWeight.Medium)
+   118	                Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(top = 2.dp)) {
+   119	                    StatusDot(if (p.statusOk) t.green else t.red)
+   120	                    Text(
+   121	                        p.detail, color = if (p.statusOk) t.sec else t.red,
+   122	                        fontFamily = BackupFonts.Mono, fontSize = 11.5.sp, modifier = Modifier.padding(start = 6.dp),
+   123	                    )
+   124	                }
+   125	            }
+   126	            Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, tint = t.ter, modifier = Modifier.size(18.dp))
+   127	        }
+   128	        if (!last) Box(Modifier.fillMaxWidth().padding(start = 46.dp).height(0.5.dp).background(t.sep).align(Alignment.BottomStart))
+   129	    }
+   130	}
+     1	// Purpose: feature #118 WI-3 (#110 Phase 3) — the add/edit AI provider form (the committed
+     2	// EditorSheet contract from vreader-ai-provider-fields.jsx): Provider Type (segmented) · Name ·
+     3	// Endpoint (Base URL + Model, blank → kind default, with the path-append hint) · Sampling
+     4	// (Temperature slider + Max Tokens stepper) · API Key (secure; edit shows Delete Key) · Connection
+     5	// (Test — enabled once a key is available, idle/testing/ok/fail). Reuses the shared form
+     6	// vocabulary; stateless: a pure function of AiEditState + callbacks.
+     7	package com.vreader.app.ai
+     8	
+     9	import androidx.compose.foundation.background
+    10	import androidx.compose.foundation.clickable
+    11	import androidx.compose.foundation.gestures.detectTapGestures
+    12	import androidx.compose.foundation.layout.Box
+    13	import androidx.compose.foundation.layout.Column
+    14	import androidx.compose.foundation.layout.Row
+    15	import androidx.compose.foundation.layout.fillMaxSize
+    16	import androidx.compose.foundation.layout.fillMaxWidth
+    17	import androidx.compose.foundation.layout.height
+    18	import androidx.compose.foundation.layout.heightIn
+    19	import androidx.compose.foundation.layout.padding
+    20	import androidx.compose.foundation.layout.size
+    21	import androidx.compose.foundation.layout.sizeIn
+    22	import androidx.compose.foundation.shape.CircleShape
+    23	import androidx.compose.foundation.shape.RoundedCornerShape
+    24	import androidx.compose.foundation.text.BasicTextField
+    25	import androidx.compose.material3.Text
+    26	import androidx.compose.runtime.Composable
+    27	import androidx.compose.runtime.getValue
+    28	import androidx.compose.runtime.mutableIntStateOf
+    29	import androidx.compose.runtime.remember
+    30	import androidx.compose.runtime.setValue
+    31	import androidx.compose.ui.Alignment
+    32	import androidx.compose.ui.Modifier
+    33	import androidx.compose.ui.draw.clip
+    34	import androidx.compose.ui.graphics.Color
+    35	import androidx.compose.ui.graphics.SolidColor
+    36	import androidx.compose.ui.input.pointer.pointerInput
+    37	import androidx.compose.ui.layout.onSizeChanged
+    38	import androidx.compose.ui.platform.LocalDensity
+    39	import androidx.compose.ui.platform.testTag
+    40	import androidx.compose.ui.text.TextStyle
+    41	import androidx.compose.ui.text.font.FontWeight
+    42	import androidx.compose.ui.text.input.PasswordVisualTransformation
+    43	import androidx.compose.ui.text.input.VisualTransformation
+    44	import androidx.compose.ui.unit.dp
+    45	import androidx.compose.ui.unit.sp
+    46	import com.vreader.app.backup.AppSheet
+    47	import com.vreader.app.backup.BackupFonts
+    48	import com.vreader.app.backup.GroupFooter
+    49	import com.vreader.app.backup.GroupHeader
+    50	import com.vreader.app.backup.LocalBackupTokens
+    51	import com.vreader.app.backup.SettingsCard
+    52	import com.vreader.app.backup.VSpace
+    53	
+    54	@Composable
+    55	fun AiProviderEditSheet(
+    56	    state: AiEditState,
+    57	    onKind: (AiProviderKind) -> Unit = {},
+    58	    onName: (String) -> Unit = {},
+    59	    onBaseUrl: (String) -> Unit = {},
+    60	    onModel: (String) -> Unit = {},
+    61	    onTemperature: (Double) -> Unit = {},
+    62	    onMaxTokens: (Int) -> Unit = {},
+    63	    onApiKey: (String) -> Unit = {},
+    64	    onDeleteKey: () -> Unit = {},
+    65	    onTest: () -> Unit = {},
+    66	    onSave: () -> Unit = {},
+    67	    onCancel: () -> Unit = {},
+    68	) {
+    69	    val t = LocalBackupTokens.current
+    70	    Box(Modifier.fillMaxSize()) {
+    71	        AppSheet(
+    72	            title = if (state.editMode) "Edit Provider" else "Add Provider",
+    73	            leading = {
+    74	                Box(Modifier.sizeIn(minWidth = 48.dp, minHeight = 48.dp).clickable(onClick = onCancel), contentAlignment = Alignment.CenterStart) {
+    75	                    Text("Cancel", color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 15.sp)
+    76	                }
+    77	            },
+    78	            trailing = {
+    79	                Box(Modifier.sizeIn(minWidth = 48.dp, minHeight = 48.dp).clickable(enabled = state.canSave, onClick = onSave).testTag("ai-save"), contentAlignment = Alignment.CenterEnd) {
+    80	                    Text("Save", color = if (state.canSave) t.tint else t.ter, fontFamily = BackupFonts.Sans, fontSize = 15.sp, fontWeight = FontWeight.SemiBold)
+    81	                }
+    82	            },
+    83	        ) {
+    84	            Column(Modifier.padding(horizontal = 18.dp).padding(top = 16.dp, bottom = 32.dp)) {
+    85	                GroupHeader("Provider Type")
+    86	                Segmented(state.kind, onKind)
+    87	
+    88	                VSpace(20)
+    89	                GroupHeader("Name")
+    90	                SettingsCard { Field("", state.name, "e.g. OpenRouter", onName) }
+    91	
+    92	                VSpace(20)
+    93	                GroupHeader("Endpoint")
+    94	                SettingsCard {
+    95	                    Field("Base URL", state.baseUrl, state.kind.defaultBaseUrl, onBaseUrl, mono = true)
+    96	                    Divider()
+    97	                    Field("Model", state.model, state.kind.defaultModel, onModel)
+    98	                }
+    99	                GroupFooter(state.kind.endpointPathHint + "  Leave blank to use the default.")
+   100	
+   101	                VSpace(20)
+   102	                GroupHeader("Sampling")
+   103	                SettingsCard {
+   104	                    TemperatureRow(state.temperature, onTemperature)
+   105	                    Divider()
+   106	                    MaxTokensRow(state.maxTokens, onMaxTokens)
+   107	                }
+   108	
+   109	                VSpace(20)
+   110	                GroupHeader("API Key")
+   111	                SettingsCard {
+   112	                    if (state.editMode && state.keyAlreadySaved && state.apiKey.isBlank()) {
+   113	                        Row(Modifier.fillMaxWidth().heightIn(min = 48.dp).padding(horizontal = 14.dp), verticalAlignment = Alignment.CenterVertically) {
+   114	                            Text("••••••••••••••", color = t.ink, fontFamily = BackupFonts.Sans, fontSize = 16.sp, modifier = Modifier.weight(1f))
+   115	                            Box(Modifier.size(19.dp).clip(CircleShape).background(t.green))
+   116	                        }
+   117	                        Divider()
+   118	                        Box(Modifier.fillMaxWidth().heightIn(min = 44.dp).clickable(onClick = onDeleteKey).padding(horizontal = 14.dp), contentAlignment = Alignment.CenterStart) {
+   119	                            Text("Delete Key", color = t.red, fontFamily = BackupFonts.Sans, fontSize = 15.sp)
+   120	                        }
+   121	                    } else {
+   122	                        Field("", state.apiKey, "Enter API Key", onApiKey, secure = true)
+   123	                    }
+   124	                }
+   125	                if (!state.editMode) GroupFooter("Stored in the Android Keystore when you tap Save — but you can test it below first.")
+   126	
+   127	                VSpace(20)
+   128	                GroupHeader("Connection")
+   129	                SettingsCard {
+   130	                    Row(Modifier.fillMaxWidth().padding(14.dp)) { TestChip(state.test, state.canTest, onTest) }
+   131	                    if (state.test == AiConnTest.ok || state.test == AiConnTest.fail) TestResult(state.test, state.testMessage)
+   132	                }
+   133	                if (!state.canTest) GroupFooter("Enter an API key above to test — no need to save first.")
+   134	            }
+   135	        }
+   136	    }
+   137	}
+   138	
+   139	@Composable
+   140	private fun Segmented(value: AiProviderKind, onChange: (AiProviderKind) -> Unit) {
+   141	    val t = LocalBackupTokens.current
+   142	    Row(Modifier.fillMaxWidth().padding(top = 8.dp).clip(RoundedCornerShape(12.dp)).background(t.codeBg).padding(3.dp)) {
+   143	        AiProviderKind.entries.forEach { k ->
+   144	            val on = k == value
+   145	            Box(
+   146	                Modifier.weight(1f).clip(RoundedCornerShape(10.dp)).background(if (on) t.card else Color.Transparent)
+   147	                    .clickable { onChange(k) }.testTag("kind-${k.name}").padding(vertical = 9.dp),
+   148	                contentAlignment = Alignment.Center,
+   149	            ) {
+   150	                Text(k.displayName, color = t.ink, fontFamily = BackupFonts.Sans, fontSize = 13.5.sp, fontWeight = if (on) FontWeight.SemiBold else FontWeight.Medium)
+   151	            }
+   152	        }
+   153	    }
+   154	}
+   155	
+   156	@Composable
+   157	private fun Field(label: String, value: String, placeholder: String, onChange: (String) -> Unit, mono: Boolean = false, secure: Boolean = false) {
+   158	    val t = LocalBackupTokens.current
+   159	    Row(Modifier.fillMaxWidth().heightIn(min = 48.dp).padding(horizontal = 14.dp), verticalAlignment = Alignment.CenterVertically) {
+   160	        if (label.isNotEmpty()) Text(label, color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 15.sp, modifier = Modifier.padding(end = 10.dp))
+   161	        BasicTextField(
+   162	            value = value, onValueChange = onChange, singleLine = true,
+   163	            textStyle = TextStyle(color = t.ink, fontFamily = if (mono) BackupFonts.Mono else BackupFonts.Sans, fontSize = if (mono) 13.5.sp else 15.sp),
+   164	            cursorBrush = SolidColor(t.tint),
+   165	            visualTransformation = if (secure) PasswordVisualTransformation() else VisualTransformation.None,
+   166	            modifier = Modifier.weight(1f).testTag("field-${label.ifBlank { placeholder }}"),
+   167	            decorationBox = { inner ->
+   168	                Box(Modifier.fillMaxWidth(), contentAlignment = if (label.isEmpty()) Alignment.CenterStart else Alignment.CenterEnd) {
+   169	                    if (value.isEmpty()) Text(placeholder, color = t.placeholder, fontFamily = if (mono) BackupFonts.Mono else BackupFonts.Sans, fontSize = if (mono) 13.5.sp else 15.sp)
+   170	                    inner()
+   171	                }
+   172	            },
+   173	        )
+   174	    }
+   175	}
+   176	
+   177	@Composable
+   178	private fun Divider() {
+   179	    val t = LocalBackupTokens.current
+   180	    Box(Modifier.fillMaxWidth().padding(start = 14.dp).height(0.5.dp).background(t.sep))
+   181	}
+   182	
+   183	@Composable
+   184	private fun TemperatureRow(value: Double, onChange: (Double) -> Unit) {
+   185	    val t = LocalBackupTokens.current
+   186	    val density = LocalDensity.current
+   187	    var trackPx by remember { mutableIntStateOf(0) }  // measured track width, in px
+   188	    Column(Modifier.fillMaxWidth().padding(14.dp)) {
+   189	        Row(verticalAlignment = Alignment.CenterVertically) {
+   190	            Text("Temperature", color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 15.sp, modifier = Modifier.weight(1f))
+   191	            Text("%.1f".format(value), color = t.ink, fontFamily = BackupFonts.Sans, fontSize = 15.sp)
+   192	        }
+   193	        // Custom track + thumb (0.0–2.0); tap maps x → value using the MEASURED width.
+   194	        val frac = (value / 2.0).toFloat().coerceIn(0f, 1f)
+   195	        Box(
+   196	            Modifier.fillMaxWidth().padding(top = 14.dp, bottom = 4.dp).height(22.dp).testTag("temperature-slider")
+   197	                .onSizeChanged { trackPx = it.width }
+   198	                .pointerInput(Unit) {
+   199	                    detectTapGestures { offset -> if (trackPx > 0) onChange(((offset.x / trackPx) * 2.0).coerceIn(0.0, 2.0)) }
+   200	                },
+   201	            contentAlignment = Alignment.CenterStart,
+   202	        ) {
+   203	            Box(Modifier.fillMaxWidth().height(4.dp).clip(RoundedCornerShape(2.dp)).background(t.sep))
+   204	            Box(Modifier.fillMaxWidth(frac).height(4.dp).clip(RoundedCornerShape(2.dp)).background(t.tint))
+   205	            val trackDp = with(density) { trackPx.toDp() }
+   206	            val startPad = (trackDp * frac - 11.dp).coerceIn(0.dp, (trackDp - 22.dp).coerceAtLeast(0.dp))
+   207	            Box(Modifier.padding(start = startPad).size(22.dp).clip(CircleShape).background(Color.White))
+   208	        }
+   209	    }
+   210	}
+   211	
+   212	@Composable
+   213	private fun MaxTokensRow(value: Int, onChange: (Int) -> Unit) {
+   214	    val t = LocalBackupTokens.current
+   215	    Row(Modifier.fillMaxWidth().heightIn(min = 48.dp).padding(horizontal = 14.dp), verticalAlignment = Alignment.CenterVertically) {
+   216	        Text("Max Tokens: $value", color = t.ink, fontFamily = BackupFonts.Sans, fontSize = 15.sp, modifier = Modifier.weight(1f))
+   217	        Row(Modifier.clip(RoundedCornerShape(8.dp)).background(t.codeBg)) {
+   218	            Box(Modifier.size(width = 42.dp, height = 30.dp).clickable(onClickLabel = "decrease", onClick = { onChange((value - 256).coerceAtLeast(256)) }).testTag("tokens-dec"), contentAlignment = Alignment.Center) {
+   219	                Text("−", color = t.ink, fontSize = 19.sp)
+   220	            }
+   221	            Box(Modifier.size(width = 0.5.dp, height = 30.dp).background(t.sep))
+   222	            Box(Modifier.size(width = 42.dp, height = 30.dp).clickable(onClickLabel = "increase", onClick = { onChange((value + 256).coerceAtMost(8192)) }).testTag("tokens-inc"), contentAlignment = Alignment.Center) {
+   223	                Text("+", color = t.ink, fontSize = 19.sp)
+   224	            }
+   225	        }
+   226	    }
+   227	}
+   228	
+   229	@Composable
+   230	private fun TestChip(test: AiConnTest, enabled: Boolean, onTest: () -> Unit) {
+   231	    val t = LocalBackupTokens.current
+   232	    val label = if (test == AiConnTest.testing) "Testing…" else "Test Connection"
+   233	    Box(
+   234	        Modifier.clip(RoundedCornerShape(100.dp)).background(if (enabled) t.chipBg else Color.Transparent)
+   235	            .clickable(enabled = enabled && test != AiConnTest.testing, onClick = onTest).testTag("ai-test")
+   236	            .padding(horizontal = 15.dp, vertical = 8.dp),
+   237	    ) {
+   238	        Text(label, color = if (enabled) t.tint else t.ter, fontFamily = BackupFonts.Sans, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
+   239	    }
+   240	}
+   241	
+   242	@Composable
+   243	private fun TestResult(test: AiConnTest, message: String) {
+   244	    val t = LocalBackupTokens.current
+   245	    val ok = test == AiConnTest.ok
+   246	    val fallback = if (ok) "Connected — the provider responded successfully." else "Failed: 401 Unauthorized — check your API key."
+   247	    Row(Modifier.fillMaxWidth().padding(start = 14.dp, end = 14.dp, bottom = 14.dp), verticalAlignment = Alignment.Top) {
+   248	        Box(Modifier.size(16.dp).clip(CircleShape).background(if (ok) t.green else t.red))
+   249	        Text(message.ifBlank { fallback }, color = if (ok) t.green else t.red, fontFamily = BackupFonts.Sans, fontSize = 13.sp, lineHeight = 19.sp, modifier = Modifier.padding(start = 7.dp).testTag("ai-test-result"))
+   250	    }
+   251	}
+android/app/src/test/kotlin/com/vreader/app/ai/AiChatViewModelTest.kt:52:    private suspend fun configure() = store.upsert("p1", "Claude", AiProviderKind.anthropicNative, "", "claude-sonnet-4-6", 0.7, 2048, "k")
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:1:// Purpose: feature #118 WI-1 (#110 Phase 3) — persists saved AI provider profiles + the active
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:20:/** A saved AI provider. `encryptedApiKey` is a [SecretCipher] token, never plaintext. */
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:58:     * key. The first profile added becomes active. Returns the saved profile (key encrypted).
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:60:    suspend fun upsert(
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:70:        lateinit var saved: AiProviderProfile
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:79:            saved = AiProviderProfile(id, name, kind, baseUrl, model, temperature, maxTokens, encrypted)
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:80:            val next = cur.profiles.filterNot { it.id == id } + saved
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:84:        return saved
+android/app/src/test/kotlin/com/vreader/app/ai/AiProviderStoreTest.kt:45:        store.upsert(id, "Provider $id", kind, kind.defaultBaseUrl, kind.defaultModel, 0.7, 2048, key)
+android/app/src/test/kotlin/com/vreader/app/ai/AiProviderStoreTest.kt:47:    @Test fun upsert_storesCiphertext_firstBecomesActive() = runTest {
+android/app/src/test/kotlin/com/vreader/app/ai/AiProviderStoreTest.kt:66:        store.upsert("p1", "Renamed", AiProviderKind.openAiCompatible, "https://x/", "gpt-4o-mini", 0.9, 1024, apiKey = null)
+android/app/src/test/kotlin/com/vreader/app/ai/AiSettingsViewModelTest.kt:29:class AiSettingsViewModelTest {
+android/app/src/test/kotlin/com/vreader/app/ai/AiSettingsViewModelTest.kt:82:        store.upsert("p1", "Claude", AiProviderKind.anthropicNative, "", "claude-sonnet-4-6", 0.7, 2048, "k")
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsUiState.kt:40:    /** canSave = name non-empty AND a key is available — entered now, or already saved on edit (a
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsUiState.kt:44:    /** Test is enabled once a key is available (entered now, or already saved in edit mode). */
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt:66:    onSave: () -> Unit = {},
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt:79:                Box(Modifier.sizeIn(minWidth = 48.dp, minHeight = 48.dp).clickable(enabled = state.canSave, onClick = onSave).testTag("ai-save"), contentAlignment = Alignment.CenterEnd) {
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:20:class AiSettingsViewModel(
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:85:    fun save() {
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:89:            store.upsert(
+
+exec
+/bin/zsh -lc "nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt | sed -n '1,145p' && nl -ba android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt | sed -n '1,300p' && rg -n \"AiProviderStore|AiSettingsViewModel|SecretCipher|KeystoreSecretCipher|DataStore\" android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt android/app/src/main/kotlin/com/vreader/app | head -200" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+     1	// Purpose: feature #118 WI-3 (#110 Phase 3) — drives the AI provider list + editor: observes the
+     2	// AiProviderStore for the list, owns the editor form state, runs Test Connection against the LIVE
+     3	// form (a transient AiClient built from the form + key, no save first), and saves/deletes. v1 list
+     4	// status is ok+model (persisted per-provider test status is a follow-on). The key is never logged.
+     5	package com.vreader.app.ai
+     6	
+     7	import androidx.lifecycle.ViewModel
+     8	import androidx.lifecycle.viewModelScope
+     9	import kotlinx.coroutines.CoroutineDispatcher
+    10	import kotlinx.coroutines.Dispatchers
+    11	import kotlinx.coroutines.flow.MutableStateFlow
+    12	import kotlinx.coroutines.flow.SharingStarted
+    13	import kotlinx.coroutines.flow.StateFlow
+    14	import kotlinx.coroutines.flow.map
+    15	import kotlinx.coroutines.flow.stateIn
+    16	import kotlinx.coroutines.launch
+    17	import kotlinx.coroutines.withContext
+    18	import java.util.UUID
+    19	
+    20	class AiSettingsViewModel(
+    21	    private val store: AiProviderStore,
+    22	    private val clientDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    23	    private val factory: (AiProviderProfile, String) -> AiClient = { p, key -> AiProviderFactory.create(p, key) },
+    24	) : ViewModel() {
+    25	
+    26	    val listState: StateFlow<AiProviderListState> = store.observe()
+    27	        .map { snap ->
+    28	            AiProviderListState(
+    29	                snap.profiles.map { p ->
+    30	                    AiProviderRow(p.id, p.name, active = p.id == snap.activeId, statusOk = true, detail = p.model.ifBlank { p.kind.defaultModel })
+    31	                }
+    32	            )
+    33	        }
+    34	        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AiProviderListState())
+    35	
+    36	    private val _edit = MutableStateFlow<AiEditState?>(null)
+    37	    val editState: StateFlow<AiEditState?> = _edit
+    38	
+    39	    // Bumped whenever the editor opens/closes or a new test starts — an in-flight test result is
+    40	    // only applied if its generation still matches, so a stale Ok/Fail can't land on a different
+    41	    // form (the user closed it, opened another provider, or re-tested).
+    42	    private var testGen = 0
+    43	
+    44	    fun openAdd() { testGen++; _edit.value = AiEditState(editMode = false) }
+    45	
+    46	    fun openEdit(id: String) = viewModelScope.launch {
+    47	        val p = store.list().firstOrNull { it.id == id } ?: return@launch
+    48	        testGen++
+    49	        _edit.value = AiEditState(
+    50	            editMode = true, id = p.id, kind = p.kind, name = p.name, baseUrl = p.baseUrl, model = p.model,
+    51	            temperature = p.temperature, maxTokens = p.maxTokens, keyAlreadySaved = true,
+    52	        )
+    53	    }
+    54	
+    55	    fun close() { testGen++; _edit.value = null }
+    56	
+    57	    fun update(transform: (AiEditState) -> AiEditState) { _edit.value = _edit.value?.let(transform) }
+    58	
+    59	    fun test() {
+    60	        val s = _edit.value ?: return
+    61	        if (!s.canTest) return
+    62	        val gen = ++testGen
+    63	        update { it.copy(test = AiConnTest.testing, testMessage = "") }
+    64	        viewModelScope.launch {
+    65	            // Key lookup + client creation + the network call all off the main thread.
+    66	            val result = withContext(clientDispatcher) {
+    67	                val key = if (s.apiKey.isNotBlank()) s.apiKey else s.id?.let { store.apiKey(it) } ?: ""
+    68	                val profile = AiProviderProfile(
+    69	                    id = s.id ?: "transient", name = s.name, kind = s.kind, baseUrl = s.effectiveBaseUrl,
+    70	                    model = s.effectiveModel, temperature = s.temperature, maxTokens = s.maxTokens, encryptedApiKey = "",
+    71	                )
+    72	                runCatching { factory(profile, key).testConnection() }
+    73	                    .getOrElse { AiTestResult.Fail(AiError.Offline, it.message ?: "failed") }
+    74	            }
+    75	            if (gen != testGen) return@launch  // superseded by a newer test / form open / close
+    76	            update {
+    77	                when (result) {
+    78	                    is AiTestResult.Ok -> it.copy(test = AiConnTest.ok, testMessage = "Connected — the provider responded successfully.")
+    79	                    is AiTestResult.Fail -> it.copy(test = AiConnTest.fail, testMessage = result.message)
+    80	                }
+    81	            }
+    82	        }
+    83	    }
+    84	
+    85	    fun save() {
+    86	        val s = _edit.value ?: return
+    87	        if (!s.canSave) return
+    88	        viewModelScope.launch {
+    89	            store.upsert(
+    90	                id = s.id ?: UUID.randomUUID().toString(),
+    91	                name = s.name, kind = s.kind, baseUrl = s.baseUrl, model = s.model,
+    92	                temperature = s.temperature, maxTokens = s.maxTokens,
+    93	                apiKey = s.apiKey.ifBlank { null },  // blank on edit = keep existing
+    94	            )
+    95	            _edit.value = null
+    96	        }
+    97	    }
+    98	
+    99	    fun delete() {
+   100	        val id = _edit.value?.id ?: return
+   101	        viewModelScope.launch { store.delete(id); _edit.value = null }
+   102	    }
+   103	
+   104	    fun setActive(id: String) = viewModelScope.launch { store.setActive(id) }
+   105	}
+     1	// Purpose: Application + manual DI container — feature #106 WI-8. Holds the
+     2	// process-singleton Room database, repository, and importer so the Library
+     3	// ViewModel gets shared instances (a Hilt module is a Phase-3 follow-on; manual
+     4	// wiring at the app edge keeps the foundation bar dependency-light — rule 50 §5).
+     5	package com.vreader.app
+     6	
+     7	import android.app.Application
+     8	import android.content.Context
+     9	import com.vreader.app.data.BookImporter
+    10	import com.vreader.app.data.LibraryRepository
+    11	import com.vreader.app.data.VReaderDatabase
+    12	import com.vreader.app.reader.BookOpener
+    13	import com.vreader.app.search.BookTextExtractor
+    14	import com.vreader.app.search.EpubTextExtractor
+    15	import com.vreader.app.search.asSearcher
+    16	import com.vreader.app.search.SearchIndexCoordinator
+    17	import com.vreader.app.search.TxtMdTextExtractor
+    18	import com.vreader.app.annotations.AnnotationsRepository
+    19	import com.vreader.app.stats.ReadingStatsRepository
+    20	import com.vreader.app.stats.ReadingTimeTracker
+    21	import com.vreader.app.stats.clock.SystemDateClock
+    22	import com.vreader.app.stats.clock.SystemElapsedClock
+    23	import kotlinx.coroutines.CoroutineScope
+    24	import kotlinx.coroutines.Dispatchers
+    25	import kotlinx.coroutines.SupervisorJob
+    26	import kotlinx.coroutines.flow.map
+    27	import vreader.contracts.BookFormat
+    28	import java.io.File
+    29	
+    30	/** Process-wide singletons, lazily built. */
+    31	class AppContainer(context: Context) {
+    32	    private val appContext = context.applicationContext
+    33	
+    34	    val database: VReaderDatabase by lazy { VReaderDatabase.build(appContext) }
+    35	    val repository: LibraryRepository by lazy {
+    36	        LibraryRepository(database.bookDao(), database.readingPositionDao())
+    37	    }
+    38	    val importer: BookImporter by lazy {
+    39	        BookImporter(File(appContext.filesDir, "books"), repository)
+    40	    }
+    41	
+    42	    // feature #122 — reading-stats. The repository + the time tracker are process-singletons so a
+    43	    // reading session survives the (shorter-lived) reader ViewModel / rotation. ONE shared DateClock
+    44	    // so the dashboard's "today" and the tracker's bucket dates can't drift apart.
+    45	    private val dateClock: SystemDateClock by lazy { SystemDateClock() }
+    46	    val statsRepository: ReadingStatsRepository by lazy {
+    47	        ReadingStatsRepository(database.readingStatsDao(), repository, dateClock)
+    48	    }
+    49	    val readingTimeTracker: ReadingTimeTracker by lazy {
+    50	        ReadingTimeTracker(statsRepository, SystemElapsedClock(), dateClock)
+    51	    }
+    52	
+    53	    // feature #123 — annotations (EPUB highlights & notes). Process-singleton so the reader VM /
+    54	    // rotation share one instance (the statsRepository precedent).
+    55	    val annotationsRepository: AnnotationsRepository by lazy {
+    56	        AnnotationsRepository(database.annotationDao())
+    57	    }
+    58	
+    59	    // feature #127 — library collections. Process-singleton (the annotationsRepository precedent).
+    60	    val collectionRepository: com.vreader.app.data.CollectionRepository by lazy {
+    61	        com.vreader.app.data.CollectionRepository(database.collectionDao())
+    62	    }
+    63	
+    64	    // feature #129 — reader display settings. A device-local DataStore (the OpdsSourceStore /
+    65	    // AiProviderStore precedent), global (not per-book), process-singleton so a settings change
+    66	    // propagates to whatever reader is open. Stored under noBackupFilesDir — display prefs are
+    67	    // per-device (NOT in the backup contract), so they must be excluded from Android Auto Backup.
+    68	    private val readerSettingsDataStore: androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences> by lazy {
+    69	        androidx.datastore.preferences.core.PreferenceDataStoreFactory.create {
+    70	            File(appContext.noBackupFilesDir, "reader_settings.preferences_pb")
+    71	        }
+    72	    }
+    73	    val readerSettingsStore: com.vreader.app.reader.settings.ReaderSettingsStore by lazy {
+    74	        com.vreader.app.reader.settings.ReaderSettingsStore(readerSettingsDataStore)
+    75	    }
+    76	
+    77	    /** Process-lifetime scope for fire-and-forget writes that must outlive a screen
+    78	     *  (e.g. the reader's onStop position flush — it must finish even as the activity
+    79	     *  is being torn down). */
+    80	    val appScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    81	
+    82	    // feature #128 WI-5 — cross-book search index. The coordinator observes the library and
+    83	    // streams each indexable book (epub/txt/md) through the WI-3 extractors into WI-4's staging →
+    84	    // atomic publish. Eagerly started once from onCreate; pdf/azw3 map to null (never indexable).
+    85	    private val bookOpener: BookOpener by lazy { BookOpener(appContext) }
+    86	    private val epubTextExtractor: EpubTextExtractor by lazy { EpubTextExtractor(bookOpener) }
+    87	    private val txtMdTextExtractor: TxtMdTextExtractor by lazy { TxtMdTextExtractor() }
+    88	    val searchIndexCoordinator: SearchIndexCoordinator by lazy {
+    89	        SearchIndexCoordinator(
+    90	            repository = repository,
+    91	            searchDao = database.searchDao(),
+    92	            extractorFor = { fmt: BookFormat ->
+    93	                when (fmt) {
+    94	                    BookFormat.epub -> epubTextExtractor
+    95	                    BookFormat.txt, BookFormat.md -> txtMdTextExtractor
+    96	                    BookFormat.pdf, BookFormat.azw3 -> null   // metadata-only — never indexed
+    97	                }
+    98	            },
+    99	            scope = appScope,
+   100	            ioDispatcher = Dispatchers.IO,
+   101	        )
+   102	    }
+   103	
+   104	    /** Idempotent — starts the single search-index collector (the coordinator's own AtomicBoolean
+   105	     *  makes a repeat call a no-op). Called once from [VReaderApp.onCreate]. */
+   106	    fun startSearchIndexing() = searchIndexCoordinator.startSearchIndexing()
+   107	
+   108	    // feature #128 WI-6 — the query pipeline. SearchRepository turns a raw query into an observable
+   109	    // Flow of first-hit-per-book text hits (grows as indexing completes); RecentSearchesStore is a
+   110	    // device-local DataStore under noBackupFilesDir (the readerSettingsStore precedent — recents are
+   111	    // per-device, NOT in the backup contract). The SearchViewModel factory wires the metadata filter,
+   112	    // the text-hit Flow, the completeness gate, and recent-recording for the WI-7 screen.
+   113	    val searchRepository: com.vreader.app.search.SearchRepository by lazy {
+   114	        com.vreader.app.search.SearchRepository(database.searchDao())
+   115	    }
+   116	    private val recentSearchesDataStore: androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences> by lazy {
+   117	        androidx.datastore.preferences.core.PreferenceDataStoreFactory.create {
+   118	            File(appContext.noBackupFilesDir, "recent_searches.preferences_pb")
+   119	        }
+   120	    }
+   121	    val recentSearchesStore: com.vreader.app.search.RecentSearchesStore by lazy {
+   122	        com.vreader.app.search.RecentSearchesStore(recentSearchesDataStore)
+   123	    }
+   124	
+   125	    /**
+   126	     * feature #133 WI-10 — the per-reader-session in-book-search ViewModel for a TXT/MD host. Wires the
+   127	     * WI-6 [InBookSearchRepository] (FTS DAO page/count/resume + the WI-4 [TxtMdInBookHitResolver] over the
+   128	     * already-decoded [decodedText]) behind the WI-8 [InBookSearchViewModel], gated by the WI-7
+   129	     * [IndexStateGate] over the DAO's `observeIndexState` Flow and fed the GLOBAL recents store.
+   130	     *
+   131	     * The EPUB engine seam is NEVER invoked for a TXT/MD host (the repository dispatches only the TXT/MD
+   132	     * branch for `txt`/`md`), so `epubEngineFor` is an error-throwing guard — a call would be a wiring bug.
+   133	     * ONE [InBookSearchRepository] per session (the VM's `closeAllEpubCursors` lifecycle contract holds
+   134	     * uniformly even though TXT has no cursors). [coroutineScope] is the VM's `viewModelScope` in production
+   135	     * (the VM cancels its child collectors on `onCleared`).
+   136	     */
+   137	    fun inBookSearchViewModel(
+   138	        bookKey: String,
+   139	        format: BookFormat,
+   140	        decodedText: String,
+   141	        contentSHA256: String,
+   142	        fileByteCount: Long,
+   143	        coroutineScope: CoroutineScope,
+   144	    ): com.vreader.app.search.InBookSearchViewModel {
+   145	        val searchDao = database.searchDao()
+   146	        val repository = com.vreader.app.search.InBookSearchRepository(
+   147	            dispatcher = Dispatchers.Default,
+   148	            fts = com.vreader.app.search.InBookFtsDeps(
+   149	                matchingChunksPage = { ftsQuery, afterSectionIndex, afterChunkOrdinal, afterId, limit ->
+   150	                    searchDao.matchingChunksPage(bookKey, ftsQuery, afterSectionIndex, afterChunkOrdinal, afterId, limit)
+   151	                },
+   152	                chunkAtOrAfter = { ftsQuery, atSectionIndex, atChunkOrdinal, atId ->
+   153	                    searchDao.chunkAtOrAfter(bookKey, ftsQuery, atSectionIndex, atChunkOrdinal, atId)
+   154	                },
+   155	                // The resolver re-derives the chunk boundaries from the ALREADY-decoded reader text (no I/O);
+   156	                // memoized per session inside the resolver (built once).
+   157	                resolverFor = {
+   158	                    com.vreader.app.search.TxtMdInBookHitResolver(
+   159	                        contentSHA256 = contentSHA256,
+   160	                        fileByteCount = fileByteCount,
+   161	                        format = format.name,
+   162	                        decodedText = decodedText,
+   163	                    )
+   164	                },
+   165	            ),
+   166	            // TXT/MD never reaches the EPUB branch — a call here is a dispatch bug, fail fast.
+   167	            epubEngineFor = { error("EPUB in-book search engine requested on a TXT/MD host") },
+   168	        )
+   169	        return com.vreader.app.search.InBookSearchViewModel(
+   170	            bookKey = bookKey,
+   171	            format = format,
+   172	            searcher = repository.asSearcher(),
+   173	            indexStateGate = com.vreader.app.search.IndexStateGate(Dispatchers.Default),
+   174	            indexStateFlow = searchDao.observeIndexState(bookKey),
+   175	            // For a settled-`indexed` TXT/MD row the gate consults this to decide Ready vs definitive
+   176	            // NoResults. `hasOccurrence` carries no query, so we report Ready (true) and let the actual
+   177	            // `page(...)` be the source of truth: a settled book with zero matches runs one fast FTS query
+   178	            // and the repository returns NoResults — the SAME UI outcome the gate's occurrence short-circuit
+   179	            // would give, without threading the live query through a shared mutable seam (no race). The gate
+   180	            // is only consulted on a settled-indexed row, so this never fires while Indexing/missing/failed.
+   181	            hasOccurrence = { true },
+   182	            recentsFlow = recentSearchesStore.recents(),
+   183	            recordQuery = { q -> recentSearchesStore.record(q) },
+   184	            dispatcher = Dispatchers.Default,
+   185	            coroutineScope = coroutineScope,
+   186	        )
+   187	    }
+   188	
+   189	    /**
+   190	     * feature #133 WI-11 — the per-reader-session in-book-search ViewModel for the EPUB host. EPUB search does
+   191	     * NOT use the #128 FTS index at all (a chunk-level, location-less index cannot yield a jumpable position);
+   192	     * instead the WI-6 [InBookSearchRepository]'s EPUB branch runs Readium's OWN `SearchService` over the LIVE
+   193	     * [publication] via the WI-5 [EpubInBookSearchEngine] production constructor (which wraps the real
+   194	     * publication behind the `PublicationSearchSource` seam), returning navigable Readium `Locator`s the host
+   195	     * jumps to with `navigator.go`.
+   196	     *
+   197	     * EPUB bypasses the WI-7 index-state gate entirely: the [indexStateFlow] emits `null` (missing) and
+   198	     * [hasOccurrence] reports Ready, so the gate resolves to Ready and the engine's own `isSearchable` probe
+   199	     * is the real capability check (an un-searchable publication → the repository's [InBookSearchOutcome.Unsupported]
+   200	     * → the WI-8 VM's `hidesSearchEntry`, so the host omits the Search icon). The TXT/MD FTS branch is NEVER
+   201	     * invoked for an EPUB host, so its factories are error-throwing guards (a call would be a wiring bug).
+   202	     *
+   203	     * ONE [InBookSearchRepository] per session (so the live Readium `SearchIterator` behind
+   204	     * `SearchCursor.Epub` is held once and disposed via `closeAllEpubCursors` on dismiss / `onCleared`).
+   205	     * [coroutineScope] is the host's `lifecycleScope` in production (the VM cancels its child collectors on
+   206	     * `onCleared`).
+   207	     */
+   208	    fun epubInBookSearchViewModel(
+   209	        bookKey: String,
+   210	        publication: org.readium.r2.shared.publication.Publication,
+   211	        coroutineScope: CoroutineScope,
+   212	    ): com.vreader.app.search.InBookSearchViewModel {
+   213	        val repository = com.vreader.app.search.InBookSearchRepository(
+   214	            dispatcher = Dispatchers.Default,
+   215	            // The EPUB host never reaches the FTS branch (the repository dispatches only the EPUB branch for
+   216	            // `epub`), so the TXT/MD deps are error-throwing guards — a call here is a wiring bug, fail fast.
+   217	            fts = com.vreader.app.search.InBookFtsDeps(
+   218	                matchingChunksPage = { _, _, _, _, _ -> error("FTS matchingChunksPage requested on an EPUB host") },
+   219	                chunkAtOrAfter = { _, _, _, _ -> error("FTS chunkAtOrAfter requested on an EPUB host") },
+   220	                resolverFor = { error("FTS resolver requested on an EPUB host") },
+   221	            ),
+   222	            // The LIVE wiring: build the WI-5 engine over the real Readium publication (its production
+   223	            // constructor wraps the publication behind the `PublicationSearchSource` seam). One engine per
+   224	            // repository/session; the repository memoizes it per bookKey.
+   225	            epubEngineFor = { com.vreader.app.search.EpubInBookSearchEngine(publication) },
+   226	        )
+   227	        return com.vreader.app.search.InBookSearchViewModel(
+   228	            bookKey = bookKey,
+   229	            format = BookFormat.epub,
+   230	            searcher = repository.asSearcher(),
+   231	            indexStateGate = com.vreader.app.search.IndexStateGate(Dispatchers.Default),
+   232	            // EPUB bypasses the FTS index-state gate: a `null` (missing) row + `hasOccurrence == true` resolve
+   233	            // the gate to Ready, so the engine's own `isSearchable` probe is the capability check.
+   234	            indexStateFlow = kotlinx.coroutines.flow.flowOf(null),
+   235	            hasOccurrence = { true },
+   236	            recentsFlow = recentSearchesStore.recents(),
+   237	            recordQuery = { q -> recentSearchesStore.record(q) },
+   238	            dispatcher = Dispatchers.Default,
+   239	            coroutineScope = coroutineScope,
+   240	        )
+   241	    }
+   242	
+   243	    /** Builds a [com.vreader.app.search.SearchViewModel] wired to the live library, in-text repository,
+   244	     *  recents, collections, and the settled-completeness gate. */
+   245	    fun searchViewModel(): com.vreader.app.search.SearchViewModel =
+   246	        com.vreader.app.search.SearchViewModel(
+   247	            libraryFlow = repository.observeLibrary(),
+   248	            textHitsFor = { q -> searchRepository.textHits(q) },
+   249	            recentsFlow = recentSearchesStore.recents(),
+   250	            collectionsFlow = collectionRepository.observeCollections(),
+   251	            indexCompleteFlow = database.searchDao().observeUnsettledIndexableCount()
+   252	                .map { it == 0 },
+   253	            recordQuery = { q -> recentSearchesStore.record(q) },
+   254	        )
+   255	
+   256	    /** In-memory last reading char-offset per fingerprintKey. Written synchronously on
+   257	     *  save so a fast rotation / reopen restores the LATEST position without waiting for
+   258	     *  the async Room write to commit; Room remains the durable store across process death. */
+   259	    private val lastOffsets = java.util.concurrent.ConcurrentHashMap<String, Int>()
+   260	    fun cacheOffset(fingerprintKey: String, charOffsetUtf16: Int) { lastOffsets[fingerprintKey] = charOffsetUtf16 }
+   261	    fun cachedOffset(fingerprintKey: String): Int? = lastOffsets[fingerprintKey]
+   262	
+   263	    /** In-memory last PDF page index per fingerprintKey — a TYPED cache distinct from the
+   264	     *  char-offset one (feature #115; a PDF position is a page, not a UTF-16 offset). */
+   265	    private val lastPages = java.util.concurrent.ConcurrentHashMap<String, Int>()
+   266	    fun cachePage(fingerprintKey: String, page: Int) { lastPages[fingerprintKey] = page }
+   267	    fun cachedPage(fingerprintKey: String): Int? = lastPages[fingerprintKey]
+   268	}
+   269	
+   270	class VReaderApp : Application() {
+   271	    lateinit var container: AppContainer
+   272	        private set
+   273	
+   274	    override fun onCreate() {
+   275	        super.onCreate()
+   276	        container = AppContainer(this)
+   277	        // feature #128 WI-5 — eagerly start the cross-book search-index collector (idempotent).
+   278	        container.startSearchIndexing()
+   279	    }
+   280	}
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:64:    // feature #129 — reader display settings. A device-local DataStore (the OpdsSourceStore /
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:65:    // AiProviderStore precedent), global (not per-book), process-singleton so a settings change
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:68:    private val readerSettingsDataStore: androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences> by lazy {
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:69:        androidx.datastore.preferences.core.PreferenceDataStoreFactory.create {
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:74:        com.vreader.app.reader.settings.ReaderSettingsStore(readerSettingsDataStore)
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:110:    // device-local DataStore under noBackupFilesDir (the readerSettingsStore precedent — recents are
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:116:    private val recentSearchesDataStore: androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences> by lazy {
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:117:        androidx.datastore.preferences.core.PreferenceDataStoreFactory.create {
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:122:        com.vreader.app.search.RecentSearchesStore(recentSearchesDataStore)
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:113:            // until the DataStore's first emission — the composition is GATED on it (like the reflowable
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:2:// DataStore (the OpdsSourceStore / AiProviderStore JSON-in-Preferences precedent). Global, device-
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:8:import androidx.datastore.core.DataStore
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:32:    private val dataStore: DataStore<Preferences>,
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:208:                // the DataStore's first emission; the reader body is withheld until then (Gate-4 Medium:
+android/app/src/main/kotlin/com/vreader/app/opds/OpdsSourceStore.kt:2:// username live in DataStore as a JSON list; the optional password is kept ONLY as a SecretCipher
+android/app/src/main/kotlin/com/vreader/app/opds/OpdsSourceStore.kt:4:// WebDavServerStore DataStore+cipher pattern. `clientFor(source)` builds an origin-scoped #117
+android/app/src/main/kotlin/com/vreader/app/opds/OpdsSourceStore.kt:8:import androidx.datastore.core.DataStore
+android/app/src/main/kotlin/com/vreader/app/opds/OpdsSourceStore.kt:12:import com.vreader.app.backup.net.KeystoreSecretCipher
+android/app/src/main/kotlin/com/vreader/app/opds/OpdsSourceStore.kt:13:import com.vreader.app.backup.net.SecretCipher
+android/app/src/main/kotlin/com/vreader/app/opds/OpdsSourceStore.kt:21:/** A saved OPDS catalog. `encryptedPassword` is a [SecretCipher] token (blank when no auth). */
+android/app/src/main/kotlin/com/vreader/app/opds/OpdsSourceStore.kt:33:    private val dataStore: DataStore<Preferences>,
+android/app/src/main/kotlin/com/vreader/app/opds/OpdsSourceStore.kt:34:    private val cipher: SecretCipher = KeystoreSecretCipher(ALIAS),
+android/app/src/main/kotlin/com/vreader/app/backup/net/WebDavServerStore.kt:2:// name / wifiOnly live in DataStore as a JSON list; the password is kept only as a SecretCipher
+android/app/src/main/kotlin/com/vreader/app/backup/net/WebDavServerStore.kt:8:import androidx.datastore.core.DataStore
+android/app/src/main/kotlin/com/vreader/app/backup/net/WebDavServerStore.kt:18:/** A saved server. `encryptedPassword` is a [SecretCipher] token, never plaintext. */
+android/app/src/main/kotlin/com/vreader/app/backup/net/WebDavServerStore.kt:30:    private val dataStore: DataStore<Preferences>,
+android/app/src/main/kotlin/com/vreader/app/backup/net/WebDavServerStore.kt:31:    private val cipher: SecretCipher,
+android/app/src/main/kotlin/com/vreader/app/search/RecentSearchesStore.kt:2:// Stores an MRU list of recent query strings as JSON in a Preferences DataStore under
+android/app/src/main/kotlin/com/vreader/app/search/RecentSearchesStore.kt:4:// OpdsSourceStore precedent). `record` is atomic (DataStore.edit) so concurrent records never lose an
+android/app/src/main/kotlin/com/vreader/app/search/RecentSearchesStore.kt:12:import androidx.datastore.core.DataStore
+android/app/src/main/kotlin/com/vreader/app/search/RecentSearchesStore.kt:21:    private val dataStore: DataStore<Preferences>,
+android/app/src/main/kotlin/com/vreader/app/search/RecentSearchesStore.kt:28:     * Records [query] as the most-recent search. Atomic (DataStore.edit) so overlapping records keep a
+android/app/src/main/kotlin/com/vreader/app/backup/net/SecretCipher.kt:2:// The store keeps a password only as a SecretCipher token (never plaintext); the production
+android/app/src/main/kotlin/com/vreader/app/backup/net/SecretCipher.kt:19:interface SecretCipher {
+android/app/src/main/kotlin/com/vreader/app/backup/net/SecretCipher.kt:29:class KeystoreSecretCipher(private val alias: String = DEFAULT_ALIAS) : SecretCipher {
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:64:    // feature #129 — reader display settings. A device-local DataStore (the OpdsSourceStore /
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:65:    // AiProviderStore precedent), global (not per-book), process-singleton so a settings change
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:68:    private val readerSettingsDataStore: androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences> by lazy {
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:69:        androidx.datastore.preferences.core.PreferenceDataStoreFactory.create {
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:74:        com.vreader.app.reader.settings.ReaderSettingsStore(readerSettingsDataStore)
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:110:    // device-local DataStore under noBackupFilesDir (the readerSettingsStore precedent — recents are
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:116:    private val recentSearchesDataStore: androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences> by lazy {
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:117:        androidx.datastore.preferences.core.PreferenceDataStoreFactory.create {
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:122:        com.vreader.app.search.RecentSearchesStore(recentSearchesDataStore)
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderFactory.kt:3:// AiProviderStore.snapshot(), decrypts via apiKey(profile), and calls this — so the client is built
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:2:// AiProviderStore for the list, owns the editor form state, runs Test Connection against the LIVE
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:20:class AiSettingsViewModel(
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:21:    private val store: AiProviderStore,
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt:2:// ACTIVE provider from one AiProviderStore snapshot, streams a chat answer (accumulating deltas),
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt:24:    private val store: AiProviderStore,
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:2:// selection. Profile metadata (name/kind/baseUrl/model/temperature/maxTokens) lives in DataStore
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:3:// as a JSON list; the API key is kept ONLY as a SecretCipher token (the #116 KeystoreSecretCipher).
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:4:// Reuses the #116 WebDavServerStore DataStore+SecretCipher credential pattern, adding an active-id
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:9:import androidx.datastore.core.DataStore
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:13:import com.vreader.app.backup.net.SecretCipher
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:20:/** A saved AI provider. `encryptedApiKey` is a [SecretCipher] token, never plaintext. */
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:41:class AiProviderStore(
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:42:    private val dataStore: DataStore<Preferences>,
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:43:    private val cipher: SecretCipher,
+android/app/src/main/kotlin/com/vreader/app/opds/ui/OpdsSourcesViewModel.kt:4:// #118 AiSettingsViewModel test path), and saves/deletes. The password is never logged.
+android/app/src/main/kotlin/com/vreader/app/opds/ui/OpdsSourcesViewModel.kt:50:    // closed form). Mirrors AiSettingsViewModel.testGen.
+
+exec
+/bin/zsh -lc "nl -ba dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md | sed -n '180,315p' && rg -n \"Dependencies|Depends|WI count|13 work|13 WI|Work items|WI-AIP|WI-4b\" dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md docs/features.md | head -100" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+   180	
+   181	```
+   182	enumeratedBlocks = navigator.evaluateJavascript(EpubBilingualJs.enumScript)   // [{id,text}] for current resource
+   183	        │  (session token S captured before the call; re-checked after)
+   184	        ▼
+   185	count = enumeratedBlocks.size
+   186	restore = prefetcher.cachedDirect(unit, expectedCount = count, targetLanguage)  // zero-provider cache restore
+   187	        │
+   188	        ├─ hit  → segments = restore
+   189	        └─ miss → segments = prefetcher.prefetchDirect(unit, sourceSegments = enumeratedBlocks.texts, targetLanguage)
+   190	        │  (token re-checked after each suspension; a stale token → discard, no commit, no error surfaced)
+   191	        ▼
+   192	if token S still current:  commit segments → BilingualRenderState[unit] / translationsByUnit[unit]  (single writer)
+   193	        ▼
+   194	EpubBilingualJs.injectScript per (blockId, translation)  via navigator.evaluateJavascript   // token-guarded
+   195	```
+   196	
+   197	- The VM exposes `onEpubBlocksEnumerated(unit, blocks)` as the controller's entry into VM render state, but the **controller owns the enumerate→cachedDirect/prefetchDirect→guarded-commit sequence**; the VM never initiates an EPUB prefetch itself (its position-driven `prefetch` dispatches only `txtDocSegmentWindow`/`mdDocSegmentWindow` units). A stale session token at any commit point discards silently (no `errorUnit`).
+   198	- WI-7b's connected test asserts: enable → inject; disable → clear; reflow/href-change/fragment-recreation/activity-recreation → re-apply from cache via `cachedDirect` (zero provider calls); count-divergence handled via `prefetchDirect`; and that the regular TXT/MD prefetch path is never invoked for an EPUB unit.
+   199	
+   200	### Cancellation + single-flight (round-3 Medium-2, BINDING)
+   201	
+   202	- **Dual-cancellation across the service/VM boundary:** both the service AND the VM handle **BOTH** native `CancellationException` **AND** the typed `ChapterTranslationError.Cancelled` **before** generic error mapping — matching iOS `ChapterTranslationService.swift:359–364` (which catches `is CancellationError` and `ChapterTranslationError.cancelled` separately, both re-throwing `cancelled`). A cancelled stale request MUST NOT surface as `errorUnit` (it is discarded).
+   203	- **Per-unit single-flight job registry (VM):** a `prefetchTasks: MutableMap<TranslationUnitId, Job>` (iOS `prefetchTasks: [TranslationUnitID: Task]`, `BilingualReadingViewModel.swift:141`, cancelled/removed on disable/unit-change at :165). A NEW request for a unit **cancels-or-joins** the prior job (a stale prior is cancelled and awaited so it cannot run overlapping translations or Room writes), keyed by unit. Rapid retry/navigation cannot run overlapping translations for the same unit. `retryUnit(unit)` goes through the same registry. Tests: a mid-flight cancel discards (no `errorUnit`, no partial cache row); a rapid re-trigger for the same unit does not double-write.
+   204	
+   205	### Modified files
+   206	
+   207	- `data/VReaderDatabase.kt` — add `ChapterTranslationEntity` to `@Database entities`, bump `version` **8 → 9** (the live DB is v8, migrations `MIGRATION_1_2`..`MIGRATION_7_8`, `ALL_MIGRATIONS` ends at `MIGRATION_7_8` — verified VReaderDatabase.kt:29,224–228), add **`MIGRATION_8_9`** (CREATE TABLE `chapter_translations` + `bookKey` index + FK→`books.fingerprintKey` CASCADE, DDL exactly matching Room's generated schema), **append `MIGRATION_8_9` to `ALL_MIGRATIONS` after `MIGRATION_7_8`**, add `abstract fun chapterTranslationDao()`. Purely additive.
+   208	- `reader/TxtReaderActivity.kt` — own a `BilingualViewModel`; collect state; render translations as **additive items after the anchor chunk in the existing `items(count = document.chunkCount, key = { it })` loop (TxtReaderActivity.kt:1043), source chunks byte-unchanged (H2)**; on position change call `vm.onPositionChanged(charOffsetUTF16)`. Strictly gated to `originalFormat ∈ {txt, md}`; disabled = body byte-unchanged (overlay-only). **Owned by #129 (VERIFIED, merged) — a straight edit, rule 48 one-writer-per-file satisfied.**
+   209	- `reader/ReaderActivity.kt` (Readium EPUB) — WI-0-gated: attach `EpubBilingualController` to `navigator.evaluateJavascript`; re-apply on the identified production re-apply signal; clear on teardown BEFORE publication teardown. `navigator: EpubNavigatorFragment?` is the verified live field (ReaderActivity.kt:110).
+   210	- `reader/chrome/ReaderChromeScaffold.kt` — extend `readerMoreRows(...)` (currently supplies only `MoreActionId.DETAILS` + `SHARE`, ReaderChromeScaffold.kt:255–258) to ALSO supply the **`MoreRow.Toggle(id = MoreActionId.BILINGUAL, on = enabled, onToggle = …)`** row (or `MoreRow.Disabled` "Configure AI provider first" when not configured — `MoreRow.Disabled` exists for exactly this, MoreRow.kt:65–72). Threaded via new nullable params so #132/#134-only callers stay valid (the scaffold's established nullable-default pattern). This is the WI-9 entry-wiring edit.
+   211	- `VReaderApp.kt` / `AppContainer` — **provide `AiProviderStore` INTO `AppContainer` itself** (it is NOT provided today — verified, only a comment names it at VReaderApp.kt:66) using the #116 `KeystoreSecretCipher` + a DataStore under the same convention as `readerSettingsStore`, PLUS provide `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, an `AiSettingsViewModel` factory (for the Variant A sheet), and a `BilingualViewModel` factory. **Extracted into the shared DI WI (WI-4b).** No `feat:#136` dependency remains — #131 owns the `AiProviderStore`-into-`AppContainer` wiring.
+   212	
+   213	**NOT modified:** `reader/chrome/ReaderBottomChrome.kt` gets **no** bilingual/Translate slot — the design's entry is the More-menu toggle (#134) + the top-chrome pill (#132), NOT a bottom-chrome slot. `ReaderBottomChrome`'s existing `extraSlot` is untouched.
+   214	
+   215	### Files OUT of scope for v1
+   216	
+   217	- **`Azw3ReaderActivity.kt` / `reader/foliate/`** — foliate WebView interlinear IS feasible but deferred (bundle-patch JS + secure-bridge additions touch the security-sensitive #126 surface). Once WI-0 proves the EPUB JS pipeline, the foliate host reuses `EpubBilingualJs` with a bundle adapter.
+   218	- **`PdfReaderActivity.kt`** — no reflowable text layer. Out (`pdfPageRange` Kind reserved only).
+   219	- **Backup collect/restore of `PerBookSettingsOverride` bilingual fields** — contract fields exist; wiring is a small additive follow-up (§7). Device-local until then.
+   220	- **Style control** — descoped v1 (user decision, §3). Keep provider/model/**granularity**, DROP the bilingual "Style" control.
+   221	- **Sentence-granularity interlinear RENDER** — not depicted (H2); design-gated. v1 renders the depicted paragraph pattern; Sentence selection falls back to paragraph render (cache still granularity-keyed).
+   222	- **The iOS #82 readiness sheet (feature-flag + consent gates)** — `reader-ai-readiness.md` is iOS-specific and implementation-deferred; Android has no flag/consent, so the Variant A provider-list sheet is the whole AI-config surface. Out.
+   223	- **"Translate entire book…" batch, re-translate/style-swap picker, cost/token estimation, term-overrides** — iOS/`vreader-ai-android.jsx` extras not in the authoritative sheet. Out.
+   224	- **Streaming translation progress** — the design's "38%" is chapter-level N-of-M chunk progress, not token streaming. v1 shows N-of-M.
+   225	
+   226	## 3. Prior art / project precedent / rejected alternatives
+   227	
+   228	### The render-host decision (settled v2, CONFIRMED round-2)
+   229	
+   230	**How iOS does interlinear:** iOS renders EPUB/AZW3 in a WKWebView it fully controls. `EPUBBilingualOrchestrator` injects JS that (1) enumerates leaf blocks posting `[{bid,text}]` to Swift, (2) after translation injects a translation node after each block. TXT/MD render in a text path where the renderer interleaves translation runs. The mechanism = **the app inserts translation nodes between source nodes** — which is exactly the Android additive-item contract (H2) for TXT/MD and the DOM-inject contract for EPUB.
+   231	
+   232	**Android EPUB feasibility (round-2 re-verified):** the transformed API JAR on the resolved Readium 3.3.0 AAR (build.gradle.kts:111) exposes public `evaluateJavascript`, `getCurrentLocator()`, `firstVisibleElementLocator(...)`, `submitPreferences(...)`; `ReaderActivity.navigator: EpubNavigatorFragment?` holds the concrete fragment (ReaderActivity.kt:110). EPUB interlinear via JS injection is feasible with the public API — **no Readium fork.** Not reopened.
+   233	
+   234	**WI-0 — Readium bilingual spike (gates WI-7b; round-2 M1):** a throwaway harness that, against a real EPUB on the emulator, must PROVE each go/no-go criterion: (a) enumeration deterministic + idempotent with stable node IDs (repeat apply = no duplicate nodes); (b) clear wins over every older inject (a late inject checks the session token and no-ops); (c) recreation restores from cache for every case (href away/back, same-href `submitPreferences` reflow, internal page-fragment recreation, activity recreation) via `cachedDirect(expectedCount)` (zero provider calls) with an identified PRODUCTION re-apply signal per case; (d) locator/visible-source preservation across injection (stated permissible pagination delta); (e) enumerated block count vs segmenter count measured — divergence → the direct-block path (`prefetchDirect`/`cachedDirect`, H2) is the recovery, proven end-to-end. **Race contract:** single actor/mutex OR monotonic navigator-session token; token/mutex check after every suspended JS/AI call; clear before publication teardown. **No deterministic re-apply signal for a recreation case (c) = explicit NO-GO** → EPUB drops to a tracked follow-up, box D ships **TXT/MD-only** with the honest reason (a specific spike finding), never the false "requires a fork."
+   235	
+   236	**Rejected alternatives:**
+   237	1. **Readium interlinear via decorations only** — REJECTED (decorations style existing text; they cannot insert translation paragraphs).
+   238	2. **Forking Readium** — REJECTED + unnecessary (public `evaluateJavascript` seam exists).
+   239	3. **AZW3 foliate host first** — REJECTED for v1 (deferred; touches the security-sensitive #126 bridge).
+   240	4. **Eager whole-book pre-translation** — REJECTED (cost/latency). Lazily prefetch current+next + cache.
+   241	5. **One `BilingualInterlinearBody` per chunk (v2)** — REJECTED (round-2 H1): a chunk is not a segment.
+   242	6. **A Compose body as the EPUB render surface (v2)** — REJECTED (round-2 M2): Compose cannot render inside Readium's WebView.
+   243	7. **Splitting a chunk's source `Text` into per-segment `Text` nodes to interleave translations (v3)** — REJECTED (round-3 H2): breaks the live one-`TextLayoutResult` + one-selection-registration-per-chunk model. Replaced by additive `LazyColumn` items at chunk boundaries, source `Text` never split.
+   244	8. **Deriving `aiConfigured` from `profiles.isEmpty()` (the iOS Variant A note's derivation)** — REJECTED for Android: `activeId` can be null with profiles present, and key usability needs the active profile's token to decrypt (H3). Android uses `BilingualAiReadiness.resolve` = active-profile + decrypts-non-empty.
+   245	9. **Spinning AI-config reachability out as a separate feature #136** — REJECTED / CLOSED (2026-07-12): the design proved the ONLY designed Android AI-config reader surface is bilingual-coupled Variant A; there is no designed standalone entry, so it is not separable. #131 owns it.
+   246	
+   247	### The setup-sheet resolution (rule 51) + Style descope (round-2 H3, USER DECISION)
+   248	
+   249	There are **two committed, differently-shaped** `BilingualSetupSheet`s:
+   250	- `vreader-bilingual.jsx` → **language grid + Granularity + preview strip + Translation-engine strip (Set up/Change) + Cancel/Translate**. No Style, no provider/model card, no term-overrides, no cost.
+   251	- `vreader-ai-android.jsx` → **Languages (From/To) + Provider card + Style (Literal/Natural/Literary) + Keep-term-overrides toggle + cost footer**. No language grid, no Granularity, no preview.
+   252	
+   253	**Resolution:** this plan reproduces the **`vreader-bilingual.jsx` sheet EXACTLY**. **Style is DESCOPED for v1** (user decision): keep provider/model/**granularity**, DROP the bilingual "Style" control. Consequently store/VM carry no `style`, the chunk contract has no `style` param, and the cache key's `promptVersion` has no `s=` component.
+   254	
+   255	**Box-D parity note (do NOT claim full box-D parity):** the box-D checklist lists provider/model/**style**. Because Style is descoped, **WI-9 flips box D to done ONLY for provider/model/granularity + a descope note**; a follow-up tracker/checklist amendment records the Style descope. If Style is later wanted, that needs an updated committed design (a single sheet showing BOTH Style AND Granularity is not depicted anywhere — the one Style design gate below).
+   256	
+   257	### The AI-config path (rule 51) — Variant A is the committed design
+   258	
+   259	The canonical decision (`reader-ai-provider-entry.md`, Variant A) + its component canvas (`vreader-ai-provider-entry.jsx`) ARE the committed design; #131 reproduces only what they depict (a `‹ Bilingual`-titled push sheet hosting the #118 provider list + the canonical editor, pop-back-on-first-save). No AI-config sheet or nav is invented. The iOS #82 readiness additions (flag/consent) are explicitly **out** on Android (no such subsystems exist). This is a designed surface — it is NOT a design gate.
+   260	
+   261	### Other precedents applied
+   262	
+   263	- **#118 provider seam**: reuse `AiProviderStore.snapshot()` (`snapshot.active`) + `store.apiKey(profile)` + `AiProviderFactory.create` (default of an injected factory param) + `AiClient.chat`. #118's AI files are unchanged; #131 wires `AiProviderStore` into `AppContainer` and reuses `AiProviderListScreen`/`AiProviderEditSheet`/`AiSettingsViewModel` verbatim for the Variant A sheet.
+   264	- **Room additive-migration pattern** (#122/#123/#127/#128/#135): version bump + `MIGRATION_n_(n+1)` appended to `ALL_MIGRATIONS` + exact-DDL + `VReaderDatabaseMigrationTest` PRAGMA guard. `@PrimaryKey` + `@Upsert` is the project DAO pattern (`BookDao`). Baseline v8.
+   265	- **DataStore JSON-in-Preferences** for `PerBookBilingualStore` (the `ReaderSettingsStore`/`AiProviderStore` pattern).
+   266	- **Pure-logic port**: iOS `ChapterSegmenter`/`ChapterTranslationChunker`/`TranslationChunkContract`/`ChapterTranslationService.translatePreSegmented`/`ChapterTranslationPrefetcher.translatedSegmentsDirect`+`cachedSegmentsDirect` are pure/heavily-unit-tested — direct Kotlin ports with the same test vectors (all verified to exist).
+   267	- **Single-flight job registry**: iOS `prefetchTasks: [TranslationUnitID: Task]` (`BilingualReadingViewModel.swift:141`) — ported as `prefetchTasks: Map<TranslationUnitId, Job>` (M2).
+   268	- **Entry point via #132/#134 (VERIFIED)**: the More-menu bilingual toggle (`MoreActionId.BILINGUAL` reserved; `MoreRow.Toggle`/`MoreRow.Disabled`) + top-chrome pill are landed; #131 mounts the pill + wires the toggle (§4).
+   269	
+   270	## 4. Work-item sequencing
+   271	
+   272	**13 WIs/PRs (round-3 Low-1 fix — corrected count):** the list is exactly **WI-0, WI-1, WI-2, WI-3, WI-4a, WI-4b, WI-5, WI-6, WI-7a, WI-7b, WI-AIP, WI-8, WI-9** = **13 WIs**. (v3 had 12: WI-0,1,2,3,4a,4b,5,6,7a,7b,8,9. Folding in the Variant A "AI Providers" sheet adds **WI-AIP**, making 13. The prior "11 WIs" claim in the plan header and `docs/features.md` was wrong on two counts and is corrected here.) Each WI = one PR. Build order: **foundation/cache → service/direct-block APIs → shared DI/factory (incl. `AiProviderStore` in `AppContainer`) → VM state/prefetch → host-specific renderers (TXT/MD + EPUB) + the Variant A AI Providers sheet → entry wiring.**
+   273	
+   274	**Dependencies (round-3 Medium-4 — dependency honesty; #136 folded in):**
+   275	
+   276	- **`Deps: [feat:#132, feat:#134]`.** **#132 (top chrome) and #134 (More menu) are VERIFIED.** **#129 (TXT/MD reader) is VERIFIED** — `TxtReaderActivity` is a straight edit, not a blocker. **There is NO external AI-reachability blocker** — the former #136 is CLOSED (GH #1976, not-planned) and its scope is #131-owned.
+   277	- **WI-4b is foundational and gates the behavioral chain.** WI-4b now provides `AiProviderStore` into `AppContainer` PLUS the bilingual services + factories. Per the audit's Medium-4, WI-4b transitively gates WI-6 (needs the prefetcher/DI), WI-7b (needs DI), WI-AIP (needs `AiProviderStore` + `AiSettingsViewModel` from `AppContainer`), and WI-8 (needs DI). **Chosen resolution: injected seams so the behavioral work proceeds against fakes before WI-4b lands, AND WI-4b is sequenced early.** Concretely: the VM (WI-5/WI-6) takes an injected `ChapterTranslationPrefetcher` (fake in tests) and an injected `AiProviderSnapshot` provider (fake); the TXT/MD host Compose/unit work (WI-8) and the Variant A sheet (WI-AIP) take injected VM/store/`AiSettingsViewModel` seams — so unit/Compose tests do not wait on `AppContainer`. **WI-4b is built right after WI-4a (before WI-6/WI-7b/WI-AIP/WI-8) so the production wiring lands before the host integrations that mount it.** This is stated honestly: the *production run-through* of WI-6/WI-7b/WI-AIP/WI-8 depends on WI-4b; their *unit/Compose gates* depend only on the injected seams. No external feature gates any of this.
+   278	
+   279	**WI-0 (spike): Readium EPUB bilingual injection — go/no-go + race contract (M1).** Harness + criteria (a)–(e) and the race contract in §3. Output: a go/no-go on EPUB-in-v1 (no-go = box D ships TXT/MD-only, tracked) + the concrete `EpubChapterTextProvider` / `EpubBilingualJs` / `EpubBilingualController` surfaces + the EPUB direct-block ownership sequence (Medium-1). Deps: none (uses the existing #106 Readium host). Not TDD-gated (throwaway spike); feeds WI-7b.
+   280	
+   281	**WI-1 (foundational): value types + pure segmentation/chunk/contract.** `TranslationUnitId`, `TranslationGranularity`, `BilingualLanguages`, **`ChapterSegmenter` (with `paragraphRanges`/`sentenceRanges` returning half-open UTF-16 `(start, endExclusive)` spans — H1)**, `TranslationChunker`, `TranslationChunkContract` (no `style`), `ChapterTranslationError`. Pure; ported iOS vectors. Deps: none.
+   282	
+   283	**WI-2 (foundational): Room translation cache.** `ChapterTranslationEntity` (PK = `lookupKey`, `sourceParagraphCount` column) + `Dao` (`@Upsert`) + `ChapterTranslationStore`; `VReaderDatabase` **8→9 `MIGRATION_8_9`** appended after `MIGRATION_7_8`. Robolectric migration round-trip from v8 + full-chain + upsert/get/delete-by-lookupKey + FK-CASCADE + exact-DDL guard. Deps: none.
+   284	
+   285	**WI-3 (foundational): `ChapterTranslationService`** against a fake `AiClient`. Both `cachedTranslation` overloads (incl. the `expectedSegmentCount` divergence restore — H2) + `translate` + `translatePreSegmented`. **Dual-cancellation (native + typed `Cancelled`) BEFORE generic mapping (M2).** Deps: WI-1, WI-2. Tests: cache hit → zero client calls; miss → translate + write; decode fail → per-segment fallback; one-chunk fail → source-only that chunk (others translated, NOT cached); all-chunks fail → throw; native-cancel → `Cancelled` (no write); typed-`Cancelled`-from-chunk → `Cancelled` (no write); ensureActive-before-write; `AiError` mapping incl. `Config`/`InsecureUrl` → `ProviderFailed`; `translatePreSegmented` full-success caches under the enumerate count; partial degrade NOT cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` returns on stored-count match, null on mismatch, needs no provider.
+   286	
+   287	**WI-4a (foundational): `ChapterTextProvider` (TXT/MD) + `ChapterTranslationPrefetcher` + `BilingualAiReadiness`.** `TxtChapterTextProvider` builds the document-global segment `(start, endExclusive)` ranges once (H1), groups into windows, resolves `unitContaining(charOffsetUTF16)` via segment-start binary search, `sourceSegments(unit)`. Prefetcher: `prefetch` + `prefetchDirect` + `cachedDirect`; resolves active profile from `snapshot()`, decrypts snapshot-consistent, builds client via the injected factory param (default `AiProviderFactory::create`), constructs `AiRequest` with **`model = profile.model.ifBlank { profile.kind.defaultModel }` (M3)**. Readiness = active profile with non-empty decrypted key; **cipher failure → not-ready, never a crash.** Fake store + fake factory. Deps: WI-1, WI-3. Tests (all half-open-range-based): unit resolution + clamp + empty; **one-chunk document (no trailing newline) → its segment translation renders, not dropped (H1)**; **final-chunk anchor → renders (H1)**; **exact-boundary → correct anchor (H1)**; **EOF anchor (`segEndExclusive == text.length`) → last chunk, no clamp-collapse (H1)**; paragraph spanning MANY chunks → one segment/one unit, anchored to the last chunk (Low-2); multiple SENTENCES in one chunk → distinct sentence segments (Low-2); a >4000-char paragraph hard-split across chunks → one segment; CR/LF/CRLF; MD markers; locator→unit mapping; `unitAfter` end→null; **source-byte parity while disabled**; cache-hit-no-profile still returns (#306); no-profile miss → `ProviderFailed`; `prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls; **blank `profile.model` → `AiRequest.model == kind.defaultModel` (M3 regression)**; readiness true/false; empty-key → false; no-active-with-profiles-present → false (H3); cipher-throw → readiness false (no crash).
+   288	
+   289	**WI-4b (foundational — shared DI/factory, incl. `AiProviderStore` in `AppContainer`): AppContainer bilingual + AI-config graph.** `AppContainer` **now constructs `AiProviderStore`** (DataStore + #116 `KeystoreSecretCipher`, following the `readerSettingsStore` convention — this is #131's change, not an external feature's) and provides `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, an `AiSettingsViewModel` factory (for WI-AIP), and the `BilingualViewModel` factory. Deps: **WI-4a** (no external dep — #136 closed). Tests: container resolves the bilingual + AI-config graph; `AiProviderStore` resolves and round-trips a profile; the prefetcher's injected factory defaults to `AiProviderFactory::create`.
+   290	
+   291	**WI-5 (behavioral): `PerBookBilingualStore` + `BilingualViewModel` state core.** Store per book (enabled/targetLanguage/granularity — no style); VM setters (persist + first-enable `needsSetupSheet`); `aiConfigured` from `BilingualAiReadiness.resolve` over an injected snapshot; language/granularity change clears cache-shaped state + bumps generation. Injected prefetcher/snapshot seams (Medium-4). Turbine tests: first-enable raises sheet; re-enable persisted does not; disable clears; language change resets; granularity change resets + re-keys; `aiConfigured` true/false from readiness; round-trip through store; no style field. Deps: WI-1 (+ store).
+   292	
+   293	**WI-6 (behavioral): VM prefetch trigger + generation/cancellation + single-flight (M2).** `onPositionChanged(charOffsetUTF16)` derives current unit (TXT/MD only), dedupes, prefetches current+next; a monotonic position-request sequence checked after every suspension; **per-unit single-flight `prefetchTasks: Map<TranslationUnitId, Job>` (a new request cancels/joins the prior — M2)**; a captured language/granularity/provider snapshot per launch; generation bumps on disable/language/granularity/unit-change discard stale; **BOTH `CancellationException` AND typed `ChapterTranslationError.Cancelled` handled BEFORE generic error mapping (M2)**; a cancelled stale request does NOT surface as `errorUnit`; `Offline`→`unavailableUnits`; transient failure leaves unit unfetched + clears anchor to retry; `retryUnit` routes through the registry. The EPUB `onEpubBlocksEnumerated` entry is present but EPUB prefetch is owned by the controller (Medium-1); the VM's position-driven `prefetch` dispatches TXT/MD units only. Fake prefetcher (Medium-4 seam). Deps: WI-4a, WI-4b, WI-5. Tests: current+next on unit change; same-unit no-op; cancel-mid discards stale (no `errorUnit`); typed-`Cancelled` discards (not `errorUnit`); rapid re-trigger same unit → single-flight, no double-write; offline→unavailable; failure→retry-able; `retryUnit` re-fetches; granularity change cancels + re-fetches under the new key.
+   294	
+   295	**WI-7a (behavioral): Compose UI — setup sheet + interlinear body (TXT/MD) + pill.** Reproduce `vreader-bilingual.jsx` (setup sheet: language grid / granularity / preview / engine strip configured+unconfigured; body: the **additive translation items** per the H2 render contract — translated / loading N%+dimmed / error+Retry / offline source-only; pill). Consumes the host-neutral `BilingualRenderState` DTO. Light+dark. Compose UI tests each state, incl. **paragraph interlinear renders a translation item after a paragraph (depicted)** and **Sentence selection falls back to paragraph render (H2 gate)**. Deps: WI-5 (state shape). NO Style control; the unconfigured "Set up" CTA renders and (in WI-9) routes to the Variant A sheet.
+   296	
+   297	**WI-7b (behavioral, CONDITIONAL — only if WI-0 = go): EPUB render adapter (DOM injection, NOT Compose — M2) + direct-block ownership (M1).** `EpubBilingualJs` (enum/inject/clear JS builders, CSP-safe escaping) + `EpubBilingualController` (the serialization actor / session token AND the **single-owner enumerate→cachedDirect/prefetchDirect→guarded-commit sequence — Medium-1**) + `EpubChapterTextProvider`, wired into `ReaderActivity`, driving DOM from the shared `BilingualRenderState` DTO. Uses `prefetchDirect`/`cachedDirect` for the count-divergence path (H2). Depends on WI-6 (VM state) and WI-4b (DI); the WI-7a UI dependency is only the shared `BilingualRenderState`/value types. Connected test on a real EPUB (seeded cache): enable → injects; disable → cleared; reflow/href-change/fragment-recreation/activity-recreation → re-applies from cache (zero provider calls) via `cachedDirect`; count-divergence handled (direct path); **the regular TXT/MD prefetch path is never invoked for an EPUB unit (Medium-1)**. Unit tests: JS escaping/CSP-safe insertion, RTL/CJK style, empty translations, loading cleanup, idempotent replacement, source-only fallback, stale-session-token commit discarded (no `errorUnit`). Deps: WI-0, WI-3, WI-4a, WI-4b, WI-6, (shared types from WI-7a). (If WI-0 = no-go, dropped; box D ships TXT/MD-only, tracked.)
+   298	
+   299	**WI-AIP (behavioral — the folded-in Variant A AI Providers sheet): `ReaderAiProvidersSheet`.** The scoped in-reader "AI Providers" push sheet (nav bar `‹ Bilingual` + "AI Providers" title) reproducing `vreader-ai-provider-entry.jsx` `AIProvidersSheet`/`NavSheet`, hosting ONLY the #118 `AiProviderListScreen` (empty + populated) + the canonical `AiProviderEditSheet`, driven by the #118 `AiSettingsViewModel` (from WI-4b's `AppContainer` factory). Empty state carries the bilingual-context copy ("Bilingual mode needs a provider to translate" / "Add provider" CTA). On first Save → the provider becomes the bilingual engine (`store.setActive(savedId)`) + pop the whole stack back to the bilingual sheet (engine strip now "configured / Change…"). `‹ Bilingual` without adding → unconfigured, no state mutated. No consent/flag surface (Android has none). Deps: WI-4b (for `AiProviderStore` + `AiSettingsViewModel` in `AppContainer`), WI-7a (bilingual sheet host). Tests (Compose + connected): empty → Add → Save → pop-to-bilingual with strip configured; `‹ Bilingual` without adding → strip unconfigured, snapshot unchanged; "Change…" → populated list, current provider checked, tap row → `setActive`; editor reused verbatim (no divergent form).
+   300	
+   301	**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into the `items(count = document.chunkCount)` loop as **additive translation items after the anchor chunk, source chunks byte-unchanged (H2)** + position-change (`charOffsetUTF16`) + setup-sheet. `originalFormat`-gated (TXT/MD). Uses WI-4b's DI. **#129 VERIFIED — straight edit.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2)**; **highlights/annotation-washes/read-aloud-wash still key off source chunks (H2)**; a translation item is non-selectable, does not perturb source offsets (H2); disable → source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders exactly one translation after its last chunk (H1/Low-2)**; **one-chunk/final-chunk anchors render (H1)**; MD source mapping. Deps: WI-6, WI-7a, WI-4b.
+   302	
+   303	**WI-9 (behavioral): entry wiring + acceptance.** Mount `BilingualPill` in #132's VERIFIED top chrome; extend `readerMoreRows(...)` to supply the #134 VERIFIED More-menu `MoreActionId.BILINGUAL` toggle (`MoreRow.Toggle` `on`/`onToggle`, or `MoreRow.Disabled` "Configure AI provider first" when not configured) wired to the VM; **wire the setup sheet's "Set up"/"Change…" affordance → the #131-owned `ReaderAiProvidersSheet` (Variant A)**. Full acceptance across EPUB (if WI-7b landed) + TXT/MD, including the fresh-user path `unconfigured → Set up (→ Variant A AI Providers sheet) → add provider → return → enable → translate` (now #131-owned end-to-end). **Flip box D to done ONLY for provider/model/granularity + the Style-descope note; file the follow-up checklist amendment; do NOT claim full box-D parity.** The DONE flip **no longer waits on #136** (closed). Update `docs/architecture.md` (bilingual pipeline + the new `chapter_translations` schema + `AiProviderStore` + bilingual services in `AppContainer` + the Variant A AI Providers sheet). → DONE. Deps: WI-8, WI-AIP, WI-7b (if go), feat:#132, feat:#134.
+   304	
+   305	## 5. Test catalogue
+   306	
+   307	JVM/Robolectric (`android/app/src/test/...bilingual/`): `ChapterSegmenterTest` (paragraph blank-line; sentence CJK `。！？` vs Latin; empty→[]; single; **`paragraphRanges`/`sentenceRanges` return correct half-open UTF-16 `(start, endExclusive)` spans**); `TranslationChunkerTest` (packs to budget; oversize→own chunk+subSplit; empty→[]); `TranslationChunkContractTest` (prompt shape; strict JSON decode; code-fence strip; count mismatch→`CountMismatch`; non-array→`NotAStringArray`); `ChapterTranslationServiceTest` (cache hit 0 calls; miss→translate→write; decode-fail per-segment fallback; one-chunk-fail partial-not-cached; all-fail→throw; **native-cancel→Cancelled no write; typed-`Cancelled`→Cancelled no write (M2)**; ensureActive-before-write; offline/timeout/429/http/config/insecure→error mapping; very long chapter N-of-M; stale-cache count-mismatch re-translates; `translatePreSegmented` caches under enumerate count on full success; partial degrade not cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` hit/miss with no provider); `ChapterTranslationErrorMappingTest`; `TxtChapterTextProviderTest` (**one-chunk document → renders (H1); final-chunk anchor → renders (H1); exact-boundary → correct anchor (H1); EOF anchor → last chunk, no clamp-collapse (H1)**; paragraph spanning MANY chunks → one segment/unit anchored to last chunk (Low-2); multiple SENTENCES in one chunk → distinct segments (Low-2); >4000-char paragraph → one segment across hard-split chunks; CR/LF/CRLF; MD markers; locator→unit mapping; `unitAfter` end→null; source-byte parity while disabled); `ChapterTranslationPrefetcherTest` (snapshot-consistent profile+key; injected-factory used; `AiRequest` built from profile; **blank `profile.model` → `kind.defaultModel` (M3 regression)**; cache-hit-no-profile #306; no-profile miss→ProviderFailed; `prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls; CJK↔English + Latin round-trip via fake; cipher-throw→ProviderFailed not crash); `BilingualAiReadinessTest` (active+key→true; **no-active-with-profiles-present→false (H3); activeId-null→false (H3)**; empty key→false; cipher-throw→false, no crash); `PerBookBilingualStoreTest` (enabled/lang/granularity round-trip; no style field); `BilingualViewModelTest` (Turbine: first-enable sheet; re-enable no-sheet; disable clears; language reset; granularity reset + re-key; `aiConfigured` from readiness; prefetch current+next; same-unit no-op; **cancel-mid discards (no errorUnit); typed-Cancelled discards (M2); rapid re-trigger same unit single-flight, no double-write (M2)**; offline→unavailable; error→errorUnit+retry; `retryUnit`); `EpubBilingualJsTest` (JS escaping / CSP-safe insertion; RTL/CJK style; empty translations; clear idempotent; inject idempotent replacement; source-only fallback — WI-7b if go); `EpubBilingualControllerTest` (**enumerate→cachedDirect/prefetchDirect→guarded commit; stale-session-token commit discarded, no errorUnit; single-owner (regular TXT/MD prefetch never runs for EPUB unit) — Medium-1** — WI-7b if go).
+   308	
+   309	Room migration: `VReaderDatabaseMigrationTest` (extend) **v8→v9 + full-chain from v8** + FK-CASCADE + `lookupKey`-as-PK; `ChapterTranslationDaoTest` (upsert-by-PK replaces; get/delete-by-lookupKey).
+   310	
+   311	Compose UI (`androidTest/...bilingual/`): `BilingualSetupSheetUiTest` (language grid, granularity, preview, engine configured vs unconfigured driven by `aiConfigured`; no Style control present; light+dark); `BilingualInterlinearBodyUiTest` (**additive translation item after a paragraph anchor chunk (depicted); paragraph interlinear translated incl. CJK font + RTL Arabic; Sentence selection → paragraph-render fallback (H2 gate)**; loading N%+dimmed; error+Retry; offline source-only; empty translation→source-only no crash); `ReaderAiProvidersSheetUiTest` (**empty state with bilingual-context copy + Add CTA; populated list + current-provider checked; `‹ Bilingual` back label; editor reused (WI-AIP)**); `BilingualPillUiTest`.
+   312	
+   313	Connected (`androidTest/...reader/`): `TxtReaderBilingualConnectedTest` (API 35, fake `AiClient` via injected factory): enable→setup→confirm→interlinear from seeded Room cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2); highlights/annotation-washes/read-aloud-wash still key off source chunks (H2); translation item non-selectable + no source-offset perturbation (H2)**; disable→source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders one translation (H1/Low-2); one-chunk/final-chunk anchors render (H1)**; TXT/MD gated (PDF inert); very long chapter scroll responsive; cancellation leaves no partial cache row. `ReaderAiProvidersConnectedTest` (WI-AIP + WI-9): `unconfigured → Set up → Variant A sheet → add provider → Save → pop-to-bilingual configured → enable → translate`; `‹ Bilingual` without adding → unconfigured, snapshot unchanged; "Change…" → populated, current checked. `EpubReaderBilingualConnectedTest` (only if WI-0=go): enable→inject on a real EPUB; disable→clear; href-change/fragment-recreation/activity-recreation→re-apply from cache (zero provider calls); count-divergence handled via `prefetchDirect`/`cachedDirect`; regular prefetch never runs for EPUB unit (Medium-1).
+   314	
+   315	Edge cases: empty translation, failed, partial per-chunk, CJK↔English + Latin + RTL, provider error/timeout/429/config/insecure, native + typed cancellation mid-translation + before-write, single-flight overlap, very long chapters, offline (cache-first + silent source-only), cipher-decrypt failure → not-ready (no crash), enumerate↔segment count divergence (direct path), one-chunk/final-chunk/EOF anchors (H1), blank model (M3).
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:23:- **AI-config path (folded in — #136 CLOSED)** — the ONLY designed Android AI-config reader surface is the **Variant A scoped "AI Providers" sheet pushed inside the bilingual flow**, reached from the bilingual engine strip's "Set up"/"Change…" button (`reader-ai-provider-entry.md`). #131 now owns it end-to-end (§"AI-config reachability", WI-4b + WI-AIP + WI-9).
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:211:- `VReaderApp.kt` / `AppContainer` — **provide `AiProviderStore` INTO `AppContainer` itself** (it is NOT provided today — verified, only a comment names it at VReaderApp.kt:66) using the #116 `KeystoreSecretCipher` + a DataStore under the same convention as `readerSettingsStore`, PLUS provide `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, an `AiSettingsViewModel` factory (for the Variant A sheet), and a `BilingualViewModel` factory. **Extracted into the shared DI WI (WI-4b).** No `feat:#136` dependency remains — #131 owns the `AiProviderStore`-into-`AppContainer` wiring.
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:272:**13 WIs/PRs (round-3 Low-1 fix — corrected count):** the list is exactly **WI-0, WI-1, WI-2, WI-3, WI-4a, WI-4b, WI-5, WI-6, WI-7a, WI-7b, WI-AIP, WI-8, WI-9** = **13 WIs**. (v3 had 12: WI-0,1,2,3,4a,4b,5,6,7a,7b,8,9. Folding in the Variant A "AI Providers" sheet adds **WI-AIP**, making 13. The prior "11 WIs" claim in the plan header and `docs/features.md` was wrong on two counts and is corrected here.) Each WI = one PR. Build order: **foundation/cache → service/direct-block APIs → shared DI/factory (incl. `AiProviderStore` in `AppContainer`) → VM state/prefetch → host-specific renderers (TXT/MD + EPUB) + the Variant A AI Providers sheet → entry wiring.**
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:274:**Dependencies (round-3 Medium-4 — dependency honesty; #136 folded in):**
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:277:- **WI-4b is foundational and gates the behavioral chain.** WI-4b now provides `AiProviderStore` into `AppContainer` PLUS the bilingual services + factories. Per the audit's Medium-4, WI-4b transitively gates WI-6 (needs the prefetcher/DI), WI-7b (needs DI), WI-AIP (needs `AiProviderStore` + `AiSettingsViewModel` from `AppContainer`), and WI-8 (needs DI). **Chosen resolution: injected seams so the behavioral work proceeds against fakes before WI-4b lands, AND WI-4b is sequenced early.** Concretely: the VM (WI-5/WI-6) takes an injected `ChapterTranslationPrefetcher` (fake in tests) and an injected `AiProviderSnapshot` provider (fake); the TXT/MD host Compose/unit work (WI-8) and the Variant A sheet (WI-AIP) take injected VM/store/`AiSettingsViewModel` seams — so unit/Compose tests do not wait on `AppContainer`. **WI-4b is built right after WI-4a (before WI-6/WI-7b/WI-AIP/WI-8) so the production wiring lands before the host integrations that mount it.** This is stated honestly: the *production run-through* of WI-6/WI-7b/WI-AIP/WI-8 depends on WI-4b; their *unit/Compose gates* depend only on the injected seams. No external feature gates any of this.
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:289:**WI-4b (foundational — shared DI/factory, incl. `AiProviderStore` in `AppContainer`): AppContainer bilingual + AI-config graph.** `AppContainer` **now constructs `AiProviderStore`** (DataStore + #116 `KeystoreSecretCipher`, following the `readerSettingsStore` convention — this is #131's change, not an external feature's) and provides `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, an `AiSettingsViewModel` factory (for WI-AIP), and the `BilingualViewModel` factory. Deps: **WI-4a** (no external dep — #136 closed). Tests: container resolves the bilingual + AI-config graph; `AiProviderStore` resolves and round-trips a profile; the prefetcher's injected factory defaults to `AiProviderFactory::create`.
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:293:**WI-6 (behavioral): VM prefetch trigger + generation/cancellation + single-flight (M2).** `onPositionChanged(charOffsetUTF16)` derives current unit (TXT/MD only), dedupes, prefetches current+next; a monotonic position-request sequence checked after every suspension; **per-unit single-flight `prefetchTasks: Map<TranslationUnitId, Job>` (a new request cancels/joins the prior — M2)**; a captured language/granularity/provider snapshot per launch; generation bumps on disable/language/granularity/unit-change discard stale; **BOTH `CancellationException` AND typed `ChapterTranslationError.Cancelled` handled BEFORE generic error mapping (M2)**; a cancelled stale request does NOT surface as `errorUnit`; `Offline`→`unavailableUnits`; transient failure leaves unit unfetched + clears anchor to retry; `retryUnit` routes through the registry. The EPUB `onEpubBlocksEnumerated` entry is present but EPUB prefetch is owned by the controller (Medium-1); the VM's position-driven `prefetch` dispatches TXT/MD units only. Fake prefetcher (Medium-4 seam). Deps: WI-4a, WI-4b, WI-5. Tests: current+next on unit change; same-unit no-op; cancel-mid discards stale (no `errorUnit`); typed-`Cancelled` discards (not `errorUnit`); rapid re-trigger same unit → single-flight, no double-write; offline→unavailable; failure→retry-able; `retryUnit` re-fetches; granularity change cancels + re-fetches under the new key.
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:297:**WI-7b (behavioral, CONDITIONAL — only if WI-0 = go): EPUB render adapter (DOM injection, NOT Compose — M2) + direct-block ownership (M1).** `EpubBilingualJs` (enum/inject/clear JS builders, CSP-safe escaping) + `EpubBilingualController` (the serialization actor / session token AND the **single-owner enumerate→cachedDirect/prefetchDirect→guarded-commit sequence — Medium-1**) + `EpubChapterTextProvider`, wired into `ReaderActivity`, driving DOM from the shared `BilingualRenderState` DTO. Uses `prefetchDirect`/`cachedDirect` for the count-divergence path (H2). Depends on WI-6 (VM state) and WI-4b (DI); the WI-7a UI dependency is only the shared `BilingualRenderState`/value types. Connected test on a real EPUB (seeded cache): enable → injects; disable → cleared; reflow/href-change/fragment-recreation/activity-recreation → re-applies from cache (zero provider calls) via `cachedDirect`; count-divergence handled (direct path); **the regular TXT/MD prefetch path is never invoked for an EPUB unit (Medium-1)**. Unit tests: JS escaping/CSP-safe insertion, RTL/CJK style, empty translations, loading cleanup, idempotent replacement, source-only fallback, stale-session-token commit discarded (no `errorUnit`). Deps: WI-0, WI-3, WI-4a, WI-4b, WI-6, (shared types from WI-7a). (If WI-0 = no-go, dropped; box D ships TXT/MD-only, tracked.)
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:299:**WI-AIP (behavioral — the folded-in Variant A AI Providers sheet): `ReaderAiProvidersSheet`.** The scoped in-reader "AI Providers" push sheet (nav bar `‹ Bilingual` + "AI Providers" title) reproducing `vreader-ai-provider-entry.jsx` `AIProvidersSheet`/`NavSheet`, hosting ONLY the #118 `AiProviderListScreen` (empty + populated) + the canonical `AiProviderEditSheet`, driven by the #118 `AiSettingsViewModel` (from WI-4b's `AppContainer` factory). Empty state carries the bilingual-context copy ("Bilingual mode needs a provider to translate" / "Add provider" CTA). On first Save → the provider becomes the bilingual engine (`store.setActive(savedId)`) + pop the whole stack back to the bilingual sheet (engine strip now "configured / Change…"). `‹ Bilingual` without adding → unconfigured, no state mutated. No consent/flag surface (Android has none). Deps: WI-4b (for `AiProviderStore` + `AiSettingsViewModel` in `AppContainer`), WI-7a (bilingual sheet host). Tests (Compose + connected): empty → Add → Save → pop-to-bilingual with strip configured; `‹ Bilingual` without adding → strip unconfigured, snapshot unchanged; "Change…" → populated list, current provider checked, tap row → `setActive`; editor reused verbatim (no divergent form).
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:301:**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into the `items(count = document.chunkCount)` loop as **additive translation items after the anchor chunk, source chunks byte-unchanged (H2)** + position-change (`charOffsetUTF16`) + setup-sheet. `originalFormat`-gated (TXT/MD). Uses WI-4b's DI. **#129 VERIFIED — straight edit.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2)**; **highlights/annotation-washes/read-aloud-wash still key off source chunks (H2)**; a translation item is non-selectable, does not perturb source offsets (H2); disable → source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders exactly one translation after its last chunk (H1/Low-2)**; **one-chunk/final-chunk anchors render (H1)**; MD source mapping. Deps: WI-6, WI-7a, WI-4b.
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:303:**WI-9 (behavioral): entry wiring + acceptance.** Mount `BilingualPill` in #132's VERIFIED top chrome; extend `readerMoreRows(...)` to supply the #134 VERIFIED More-menu `MoreActionId.BILINGUAL` toggle (`MoreRow.Toggle` `on`/`onToggle`, or `MoreRow.Disabled` "Configure AI provider first" when not configured) wired to the VM; **wire the setup sheet's "Set up"/"Change…" affordance → the #131-owned `ReaderAiProvidersSheet` (Variant A)**. Full acceptance across EPUB (if WI-7b landed) + TXT/MD, including the fresh-user path `unconfigured → Set up (→ Variant A AI Providers sheet) → add provider → return → enable → translate` (now #131-owned end-to-end). **Flip box D to done ONLY for provider/model/granularity + the Style-descope note; file the follow-up checklist amendment; do NOT claim full box-D parity.** The DONE flip **no longer waits on #136** (closed). Update `docs/architecture.md` (bilingual pipeline + the new `chapter_translations` schema + `AiProviderStore` + bilingual services in `AppContainer` + the Variant A AI Providers sheet). → DONE. Deps: WI-8, WI-AIP, WI-7b (if go), feat:#132, feat:#134.
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:311:Compose UI (`androidTest/...bilingual/`): `BilingualSetupSheetUiTest` (language grid, granularity, preview, engine configured vs unconfigured driven by `aiConfigured`; no Style control present; light+dark); `BilingualInterlinearBodyUiTest` (**additive translation item after a paragraph anchor chunk (depicted); paragraph interlinear translated incl. CJK font + RTL Arabic; Sentence selection → paragraph-render fallback (H2 gate)**; loading N%+dimmed; error+Retry; offline source-only; empty translation→source-only no crash); `ReaderAiProvidersSheetUiTest` (**empty state with bilingual-context copy + Add CTA; populated list + current-provider checked; `‹ Bilingual` back label; editor reused (WI-AIP)**); `BilingualPillUiTest`.
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:313:Connected (`androidTest/...reader/`): `TxtReaderBilingualConnectedTest` (API 35, fake `AiClient` via injected factory): enable→setup→confirm→interlinear from seeded Room cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2); highlights/annotation-washes/read-aloud-wash still key off source chunks (H2); translation item non-selectable + no source-offset perturbation (H2)**; disable→source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders one translation (H1/Low-2); one-chunk/final-chunk anchors render (H1)**; TXT/MD gated (PDF inert); very long chapter scroll responsive; cancellation leaves no partial cache row. `ReaderAiProvidersConnectedTest` (WI-AIP + WI-9): `unconfigured → Set up → Variant A sheet → add provider → Save → pop-to-bilingual configured → enable → translate`; `‹ Bilingual` without adding → unconfigured, snapshot unchanged; "Change…" → populated, current checked. `EpubReaderBilingualConnectedTest` (only if WI-0=go): enable→inject on a real EPUB; disable→clear; href-change/fragment-recreation/activity-recreation→re-apply from cache (zero provider calls); count-divergence handled via `prefetchDirect`/`cachedDirect`; regular prefetch never runs for EPUB unit (Medium-1).
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:319:- **Live-translation verification is AI-credential-gated (the box-D caveat).** The whole pipeline is verified without live creds via a deterministic **fake `AiClient`** injected through the prefetcher's `clientFactory` param (default `AiProviderFactory::create`; tests override). WI-3/4a/8 prove segment→chunk→decode→cache→interleave end-to-end incl. every error/edge path. Connected tests seed the Room cache and assert render-from-cache with zero client calls. An optional live smoke confirms wire format but is NOT a gate. The fresh-user `unconfigured → Set up → add provider` reachability leg is now #131-owned (WI-AIP + WI-9) and verified by `ReaderAiProvidersConnectedTest`.
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:332:- **Dependency honesty (round-3 Medium-4).** WI-4b (DI, incl. `AiProviderStore` in `AppContainer`) is foundational and gates the production run-through of WI-6/WI-7b/WI-AIP/WI-8; those WIs' unit/Compose gates proceed against injected fakes, and WI-4b is sequenced before them. No external feature gates the chain (#136 closed).
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:348:*(REMOVED: the v3 "#136 dependency" design-gate line — #136 is closed and the Variant A AI Providers sheet IS the committed design, reproduced by WI-AIP, not a gate.)*
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:356:  - **AI-config FOLDED IN (#136 CLOSED, GH #1976 not-planned; user decision 2026-07-12):** the design proved the ONLY designed Android AI-config reader surface is the bilingual-coupled **Variant A** "AI Providers" sheet (`reader-ai-provider-entry.md`); it is not separable, so #131 now owns it end-to-end. Added **WI-AIP** (`ReaderAiProvidersSheet`, reusing #118 `AiProviderListScreen`/`AiProviderEditSheet`/`AiSettingsViewModel` verbatim, `‹ Bilingual` push, pop-back-on-first-Save); WI-4b now provides `AiProviderStore` into `AppContainer` (verified not provided today — VReaderApp.kt:66 comment only) plus the bilingual services + `AiSettingsViewModel` factory; removed `feat:#136` from Deps (now `[feat:#132, feat:#134]`, no external AI-reachability blocker); the DONE flip no longer waits on #136; `aiConfigured` derivation kept as the correct active-profile+decrypts-non-empty gate (H3), NOT `profiles.isEmpty()` (the iOS note's derivation), with no consent/flag gate (Android has none).
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:362:  - **M4 (round-3 Medium-4) dependency honesty:** WI-4b (DI incl. `AiProviderStore`) is foundational and gates the production run-through of WI-6/WI-7b/WI-AIP/WI-8; those WIs' unit/Compose gates use injected fakes; WI-4b sequenced before them; no external feature gates the chain.
+dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:363:  - **Low fixes:** WI count corrected to **13** (added WI-AIP; the "11 WIs" claim was wrong — Low-1); chunk semantics corrected — a chunk is ONE LINE, holds multiple SENTENCES, a paragraph spans MANY chunks; removed the "a chunk can hold multiple paragraphs" claim (Low-2). Awaiting Gate-2 round-4 audit.
+docs/features.md:100:| 45 | Verification harness sweep — retire the "Needs device verification" backlog    | DevTools/*   | High     | VERIFIED | XCUITest + DebugBridge recipes for 13 of 15 simulator-automatable backlog items. Adds VERIFIED status. Depends on #44. Plan: `dev-docs/plans/20260513-feature-45-verification-harness-sweep.md` (v3, 2026-05-15). **All WIs shipped** — WI-1 PR #581 v3.21.3; WI-2 PR #586; WI-3 PR #587; WI-4 PR #589; WI-4b PR #590; WI-4c-a PR #591; WI-4c-c PR #599; WI-4d commit `de5a73d`; WI-4e PR #643; WI-5 PR #679 v3.21.64; **WI-6 (named test-plan selector) PR #692 v3.21.69 commit `3753d2a`** — ships `TestPlans/Verification.xctestplan` (25 per-method identifiers across 13 classes) + `TestPlans/All.xctestplan` (no-flag default). Invocation: `xcodebuild test -scheme vreader -testPlan Verification`. **Recovery arc** — Bug #192 (PR #688) renamed `verify_*` → `test_verify_*` after WI-6 Gate 2 audit discovered the 25 methods were XCTest-invisible (vacuous `Executed 0 tests` passes had silently no-opped the harness across all 13 classes). Bug #193 (PR #691) fixed the Feature #36 OPDS XCUITest element-class mismatch surfaced by the post-rename re-run. WI-6's Gate 5 transport-success dispatch confirmed exactly 25 tests run end-to-end (10 passed, 13 XCTSkip-gated, 2 product failures filed as new bugs post-merge for Feature28/29). **2026-05-16 update (verify-cron progressive sampling)**: Feature #23 + Feature #31 confirmed clean in `dev-docs/verification/feature-45-20260516-sampling.md` (full plan run); Feature #31 re-confirmed in this iteration (2/2 PASS solo, 35s). **Feature #37 root-cause identified**: harness gap (XCUITest doesn't swipe-up to bring `perBookSection` into accessibility tree; production feature is fine per `feature-37-20260509.md`). Filed as **Bug #204 / GH #746** (DevTools/* Low). Net status: **7 of 13 classes still unsampled clean** (#11 EPUB load timing, #21 multi-page EPUB fixture, #28/#29 fixture-env-var gaps with 1-of-2 methods clean, #37 awaiting #204 harness fix, #40/#41 TTS control bar timing). VERIFIED status depends on Gate 5 final acceptance evidence file once those unsampled classes are sampled clean. **2026-05-16 round-2 sampling** (`dev-docs/verification/feature-45-20260516-round2.md`, result=partial) at v3.24.6 commit `a6103e5`: identical shape to round-1 (12 PASS, 13 SKIPPED, 0 FAILED in 410s). No regressions across the 40+ commits between v3.22.20 and v3.24.6. Same 7 classes remain gated by harness/fixture/env reasons. No new bugs filed. **2026-05-18 round-3 sampling** (`dev-docs/verification/feature-45-20260518-round3.md`, result=partial) at v3.27.23 commit `6936ccf`: 27 tests, 12 PASS / 15 SKIP / 0 FAIL — GREEN, no regressions across the feature #60 re-skin + Bug #209 repair + Bug #210/#214 changes landed since round-2. Progress: **Feature37 (2 methods) now PASS** (Bug #204 swipe-helper fix landed — previously gated); new `Feature11EPUBBottomChromeVerificationTests` (Bug #214, 2 tests) PASS. 9 method-groups still SKIP (Feature11Highlight, 21, 28-conversion, 29-backup-executes, 31, 35, 36-live, 40, 41 — fixture/harness/env gaps). No new bugs filed. **2026-05-18 round-4 sampling** (`dev-docs/verification/feature-45-20260518-round4.md`, result=partial) at v3.27.25 commit `8cab12a`: 27 tests, 12 PASS / 15 SKIP / 0 FAIL — GREEN, identical shape to round-3, zero regressions across the v3.27.23→v3.27.25 range (Bug #213/#216/#217 — GH #830/#838/#839 — test-infra fixes landed since round-3). Same 9 method-groups SKIP — unchanged fixture/harness/env gaps; no new bugs filed. **2026-05-18 round-5 sampling** (`dev-docs/verification/feature-45-20260518-round5.md`, result=partial) at v3.27.27 commit `9705693`: 27 tests, 12 PASS / 15 SKIP / 0 FAIL — GREEN, byte-identical shape to round-4, zero regressions across the v3.27.25→v3.27.27 range (Bug #219 / GH #846 — Feature11 EPUB-highlight XCUITest seed + readiness probe; Bug #182 / GH #847 — EPUB cross-chapter search highlight). Positive finding: Bug #219 converted `Feature11EPUBHighlightVerificationTests`'s reader-load gates from `XCTSkip` to hard `XCTAssert`; round-5 is the first full-plan run of that — both methods clear the hard gates and skip *deeper* at the WKWebView long-press step (`Feature11EPUBHighlightVerificationTests.swift:147/237`, Bug #220 / GH #845) rather than at the old seed gate. Skip count unchanged (still 9 method-groups). No new bugs filed. **2026-05-19 round-6 sampling** (`dev-docs/verification/feature-45-20260519-round6.md`, result=partial) at v3.34.15 commit `f47e1c5`: true shape **27 tests, 12 PASS / 15 SKIP / 0 FAIL — GREEN, byte-identical to round-5, zero regressions** across the ~7-version delta since round-5 (features #54/#55/#57/#63/#65/#68/#69 + Bug #225/#226 TTSService `rate` `didSet` recursion fix + test-infra fixes). The contended plan run on the shared simulator pool false-failed 6 classes (#28/#29/#34/#36/#40/#41 — testmanagerd wedged 427s on #28, #221-class flaky-parallel-pool cascade); a step-4 isolation re-run of all 6 on a dedicated idle simulator returned `** TEST SUCCEEDED **` (12 tests, 7 skipped, 0 failures), confirming the 6 plan-run failures were contention noise, not regressions. Same 9 method-groups SKIP — unchanged fixture/env/harness gaps; no new bugs filed. **2026-06-08 round-7 → VERIFIED** (`dev-docs/verification/feature-45-20260608.md`, `result: pass`, v3.59.23 `b6c74591`): the feature's purpose — retiring the device-verification backlog — is achieved: all 14 downstream target features (#11/#21/#23/#26/#27/#28/#29/#31/#34/#36/#37/#40/#41/#55) are independently VERIFIED with their own evidence files (the backlog is empty). Fresh harness run on current main (`Feature28` + `Feature31`) → `** TEST SUCCEEDED **`, 0 product failures, skips = env-gated/accepted-scope. Representative-subset run (no `timeout` watchdog binary available for a full unattended UITest run); substantive acceptance established by the downstream features' own VERIFIED evidence. Row → VERIFIED. GH: #576 |
+docs/features.md:102:| 47 | WebDAV restore — selective book picker + lazy-on-tap downloads                 | Backup/*     | Medium   | VERIFIED  | Phase 2 of feature #46. `BookFileState` (`local / remoteOnly / downloading / failed / missingRemote`), library rows with cloud icons, "Pick…" entry on each backup row → `SelectiveRestorePicker` against the manifest, on-tap blob fetch via background URLSession with `taskDescription` identity, Wi-Fi-only cellular policy via `NWPathMonitor`, "Clean unused remote files" GC carved out as feature #51. Depends on feature #46. **Shipped 2026-05-04** in v3.11.18..v3.12.0 (21 PRs). **VERIFIED 2026-05-04** in v3.12.9 after fixing 5 blocking bugs (#112, #113, #114, #115, #116) found during initial Gate-5 run. Evidence: `dev-docs/verification/feature-47-20260504.md` (initial partial) + `dev-docs/verification/feature-47-20260504b.md` (post-fix pass) + per-bug evidence files. GH: #407 (closed — VERIFIED). |
+docs/features.md:105:| 67 | Settings profile-header card + Stats entry point | App/* | Low | VERIFIED | **VERIFIED 2026-05-26 (Gate-5b, verify cron)** — CU-free XCUITest acceptance pass on iPhone 17 Pro Sim (iOS 26.4) at v3.39.17 build 638 (HEAD `14fe3861`). New suite `vreaderUITests/Verification/Feature67SettingsProfileCardVerificationTests.swift` (3 tests, 0 failures, 41.6s): (1) profile card present — "Your library" header + "… read this month" subline + `settingsProfileStatsButton` pill; (2) Stats pill → feature #58 `ReadingDashboardView` (cross-feature hand-off, #58 VERIFIED); (3) WI-6 AI-group Variant-A collapse — master `aiToggle` always present, `aiProvidersNavLink` + `consentToggle` appear only when AI on, collapse when off. Pixel-level design fidelity carried from Gate-5a screenshots (`feature-67-wi6-*-20260521.png`) + composition/snapshot unit tests. No bug discovered, no product code changed (verification scope). Evidence `dev-docs/verification/feature-67-20260526.md` (`result: pass`). **DONE 2026-05-21 (WI-6 — final WI) — feature complete, awaiting Gate-5b acceptance.** Now that `needs-design` #1068 is resolved (design `vreader-ai-toggles.jsx` + `ai-toggles-artboards.jsx` landed commit `3735529a`, Variant A recommended), WI-6 restyled the two deferred AI toggle rows to the design's colored-tile `SettingsToggleRow` + `PillSwitch`: **Enable AI Assistant** (oxblood `#8c2f2f` sparkle tile, master gate, always visible) and **Allow AI data sharing** (cool-blue `#4a6a8a` `checkmark.shield` tile, consent), merged with the AI Provider row into the design's single "AI" group (provider + consent hidden when AI off). New `PillSwitch` (a `ToggleStyle` over a real `Toggle` for native switch a11y) + `SettingsToggleRow` (peer of `SettingsIconRow`) + `SettingsRowPalette.aiAssistant`/`.aiDataSharing`. The `aiToggle`/`consentToggle`/`aiProvidersNavLink` identifiers + `AIProviderListView` destination preserved (identifier now lands on the actionable `Toggle`, not the row container). Gate-4 Codex audit: 2 rounds, **ship-as-is** (thread `019e4a37`); round-1 found 1 High (a11y identifier on container) + 1 Medium (button vs toggle semantics) + 1 Low (detail spacing), all resolved. Full suite green (7042 tests). Gate-5a slice-verified CU-free on iPhone 17 Pro Sim iOS 26.4 at v3.39.0 via the sim-drive-fallback tap path: AI-ON shows all 3 colored rows incl. the green/gray PillSwitches; toggling AI OFF collapses to the single master row (provider+consent hidden) — `dev-docs/verification/artifacts/feature-67-wi6-{02-ai-on-allrows,03-ai-off-collapsed}-20260521.png`. PR (this) v3.39.0 (minor — final WI completes the feature). This was the last remaining scope → row `IN PROGRESS` → `DONE`. Gate-5b end-to-end acceptance pass (`feature-67-<date>.md` evidence) pending before `VERIFIED`. Plan WI-6 addendum in `dev-docs/plans/20260519-feature-67-settings-profile-card.md`. **WI-5 (2026-05-20)** — `needs-design` #1068 filed for the AI Assistant + Data & Privacy toggle rows. The plan's WI-5 ("definitively restyles `AISettingsSection`") assumed all 3 AI rows would get colored-icon row chrome; Gate-3 audit of `vreader-panels.jsx:868-870` revealed the (then-)committed design depicted only the AI Provider row (`Icons.Sparkle` `#8c2f2f`). Per rule 51, WI-5's PR narrowed scope to restyle the AI Provider row only and added `SettingsRowPalette.aiProvider`; the two toggle rows stayed on plain-`Toggle` chrome pending design — **now unblocked + shipped in WI-6 (#1068 resolved)**. **WI-4 DONE 2026-05-20** — PR #1067 v3.38.15 commit `92cddd2`. Mounts `SettingsProfileCard` as the first `Form` row, restyles Cloud & Sync / Reading / About rows to `SettingsIconRow`, wires the Stats pill through `Notification.Name.openReadingStatsRequested` to a `SettingsStatsPresenter` that presents `ReadingDashboardView` (feature #58's surface shipped in PR #1061). Gate-4 audit: 2 rounds, ship-as-is (Codex `019e457e`); 1 High (stale-VM-on-reopen) + 1 Medium (state-machine test gap) resolved by extracting `SettingsStatsPresenter` (`@MainActor @Observable`) + 7 presenter state-machine tests. Gate-5a slice verified on iPhone 17 Pro Sim iOS 26.4 (5 PNG artifacts in `dev-docs/verification/artifacts/feature-67-wi-4-*.png`). **WI-1 DONE 2026-05-20** — reading-window persistence reads + `MonthBoundary` + `ReadingTimeFormatter.formatCompactHours` (foundational, no UI): PR #1014, 47 tests green, Codex-audited clean (thread `019e4146`). WI-2 (`SettingsRowPalette` + `SettingsIconRow`) PR #1016. WI-3 (`SettingsHeaderViewModel` + `SettingsProfileCard`) PR #1018. **WI-4 + WI-5 are HARD-BLOCKED on feature #58's dashboard-presenter WI (#58 WI-6) reaching `DONE` on `main`** — #58 WI-6 is itself blocked on product decisions D1–D4 (GH #665); per `.claude/rules/48-parallel-execution.md` hard rule 2, WI-4 (the WI that makes the Stats button user-visible) does not enter Gate 3 on an unmet hard dependency. **Depends: #58 (dashboard presenter, #58 WI-6).** **Gate 1+2 complete — plan dev-docs/plans/20260519-feature-67-settings-profile-card.md, Codex-audited clean.** **Design delivered 2026-05-18 — issue-canvas handoff resolves needs-design #862** — Gate-1 triage (2026-05-18): the design's profile-header card shows a user **name** + avatar initial, but the app has no user-account / no user-name source (only OPDS / WebDAV credentials); and the **Stats** button's destination is feature #58's reading dashboard — unbuilt and undesigned. The profile-card identity model + the reading-stats surface need a design decision → `needs-design` #862. The grouped-row restyle (30pt colored-icon rows) IS designed and unaffected. **Filed 2026-05-17** — surfaced by a component-by-component re-skin audit of the design bundle vs shipped state. **Problem**: `SettingsView.swift` re-skinned to v2 chrome with the four design groups, but omits the design's top **profile-header card** (avatar disc, name, "N books · Nh read this month") and the **Stats** button that opens the reading-stats dashboard; grouped rows are native `Form` `NavigationLink`s, not the design's 30pt colored-icon rows. **Design source**: `vreader-panels.jsx` — `SettingsSheet` / `Row`. **Cross-ref**: the Stats button is the entry point to feature #58 (reading-time dashboard, TODO). **Lineage**: v2 follow-on of feature #60 (VERIFIED). GH: #825 |
+docs/features.md:116:| 60 | VReader visual identity v2 — Source Serif 4 / Inter typography, 5-theme palette (Paper / Sepia / Dark / OLED / Photo), oxblood accent, redesigned reader chrome + sheets (Library / Reader / AI / TOC / Highlights / Reader Settings), new SelectionPopover for new-selection-from-long-press flow (4 colors + Note / Translate / Ask AI / Read), generative typographic covers — per `claude.ai/design` handoff bundle | App/*, Library/*, Reader/*, Theme/* | Medium | VERIFIED | **VERIFIED 2026-05-16 (v3.27.0)** — all 12 WIs merged (WI-1..WI-11 incl. WI-6a/6b/6c + WI-7a..7c5, WI-12). needs-design #760 resolved. Gate 5b full-acceptance pass: result=pass — all 7 acceptance criteria (a-g) exercised end-to-end on iPhone 17 Pro Simulator (build 414). Evidence: `dev-docs/verification/feature-60-20260516.md`. WI-12 (#795) renders the Photo theme background image inside the EPUB WKWebView via a base64 data URL. WI-7a (SelectionPopoverView + action-row contract) shipped in PR #762 as a no-UI-regression slice — view built per design, 8 contract tests pin action order/accent/identifiers. WI-7b (foundational `SelectionPopoverActionRouter` — pure-logic dispatch enum mapping `SelectionPopoverAction` → existing `.readerHighlightRequested` / `.readerAnnotationRequested` / `.readerTranslateRequested` notifications; `userInfo["color"]` carries `NamedHighlightColor.rawValue` additively; `.askAI` / `.read` return `.deferredNotYetWired`) shipping in this iteration — 10 router tests pin enum-case-exhaustive contract, Codex Gate 4 thread `019e2e83` 1 round ship-as-is. WI-7c1 (foundational `SelectionPopoverPresenter` — `.readerSelectionPopoverRequested` notification + typed `SelectionPopoverRequest.post/parse` helpers + SwiftUI `SelectionPopoverPresenterModifier` that presents `SelectionPopoverView` as a sheet; routes taps via `SelectionPopoverActionRouter` + `SelectionPopoverDismissPolicy` keeps the sheet open on `.deferredNotYetWired` results so `.askAI`/`.read` taps don't silently swallow) shipping in this iteration — 10 contract tests pin notification wire format + dismiss policy; `TextSelectionInfo` gained additive `Equatable + Sendable` conformance; Codex Gate 4 thread `019e2ea9` 2 rounds ship-as-is. WI-7c2..7c5 (behavioral, per-bridge swap of `TXTBridgeShared.buildReaderEditMenu` → `SelectionPopoverRequest.post` + attach presenter to the container) are the remaining slices for SelectionPopover. **Progress**: WI-1 (typography registry Swift API) shipped in PR #750; WI-2 (theme tokens, `ReaderThemeV2`) shipped in PR #749; WI-3 (foundational popover types) shipped in PR #745; WI-4 (EPUB theme injection) shipped in PR #753 — EPUB renders now route through `ReaderThemeV2.epubOverrideCSS` via the legacy → V2 projection (`ReaderTheme.asV2`); WI-5 (TXT + MD theme injection) shipped in PR #754 — TXT body bg/ink + MD body ink + MD blockquote sub + MD code-block paper now route through V2. **Slice verify 2026-05-16** (`dev-docs/verification/feature-60-20260516-wi5slice.md`, `result: partial`) closes acceptance criterion (c) for 3 of 5 reachable themes (paper/sepia/dark) on TXT end-to-end via DebugBridge theme switches — OLED + Photo deferred because they're not reachable from the legacy 3-case `ReaderSettingsStore.theme` enum until a later WI migrates the settings type. Remaining WIs 6-10 cover reader chrome, SelectionPopover, library re-skin (cards/rows then container), final sheet re-skin + status-bar tinting + generative covers. **Plan**: `dev-docs/plans/20260515-feature-60-visual-identity-v2.md` (v5, Codex Gate-2 audit clean inline per rule 47; v4 introduces the WI-6a/6b split + needs-design #760; v5 introduces the WI-7a/7b split — WI-7a ships the SelectionPopoverView + action-row contract as a no-regression slice, WI-7b replaces the legacy UIMenu). 10 WIs sequenced from foundational (typography, theme tokens, popover types) → behavioral (EPUB theme injection, TXT/MD theme + typography, reader chrome, SelectionPopover, library cards/rows, library container, sheet re-skins + covers + status bar). Per row Cross-refs: #53/#55 presenters re-skinned post-#60 in separate PRs (not consumed). **Origin**: bundle handed off 2026-05-15 from `claude.ai/design` (share token `tSClWWD84corsOcW52YmNw`). Full prototype committed under `dev-docs/designs/vreader-fidelity-v1/` — README, chat-1 intent log, 9 JSX/HTML source files, 31 PNG screenshots. **Problem**: VReader's current chrome is a mix of SwiftUI system defaults (Library), a TextKit-driven UITextView (TXT/MD), a WKWebView + CSS-injected theme (EPUB), Foliate-js with its own CSS (AZW3/MOBI), and PDFKit (PDF). Each surface drifted its own typography, accent, and theme story; the user wants a single coherent reader identity. The design ("Refined-literary meets native iOS") specifies a unified visual layer over all of these without changing behavior. **Scope (purely visual + UX; no behavioral change to readers, persistence, search, WebDAV, or AI)**: (1) **Typography** — bundle Source Serif 4 (body, default reader font) + Inter (UI chrome). Add a serif↔sans toggle in Reader Settings. Replace ad-hoc font selection across `TXTViewConfig`, EPUB CSS injection, Foliate `setStyles`, and PDFKit. (2) **5-theme palette** — extend `ThemeColor`/`ReaderTheme` to Paper / Sepia / Dark / OLED / Photo. Photo theme uses a user-chosen background image with translucent paper layer (per `vreader-themes.jsx:image`). Tokens: `bg`, `paper`, `ink`, `sub`, `rule`, `accent`, `chrome` + `isDark` flag for status-bar tinting. Replace current theme palette; migrate existing per-book setting. (3) **Oxblood accent** — `#8c2f2f` (light) / `#d6885a` (warm-dark) / `#e8b465` (photo) — single restrained hue across buttons, indicators, selection. (4) **Library redesign** — continue-reading rail + 3-column cover grid, filter chips, search bar, grid↔list toggle. Aligns with #6 view preferences (no behavior change). (5) **Reader chrome** — new top bar (back / title / bookmark / more) + bottom bar (TOC / Display / Highlights / AI) + page indicator + scrubber. Edges-tap-flip / middle-tap-toggle-chrome convention (resolves bug #165 as a side effect; aligns with feature #25 tap zones). (6) **SelectionPopover** — REPLACES the current `HighlightableTextView` 4-item UIMenu (Highlight / Add Note / Define / ▶) for the **new-selection-from-long-press** flow. 4 named highlight colors (yellow / pink / green / blue) + Note / Translate / Ask AI / Read actions. **Cross-ref**: This is distinct from feature #53 (tap-on-existing-highlight Edit/Delete) and feature #55 (tap-on-annotated-text note preview) — those are separate hit-test flows the design does NOT cover. (7) **Sheets** — re-skin TOC, Highlights, AI (Summarize / Chat / Translate tabs), Reader Settings (Brightness + theme picker + Size / Line-spacing / Margin sliders + font toggle), App Settings. (8) **Generative typographic covers** — fallback cover style (classic / modern / editorial / animal / minimal) when no real cover image is available. Coexists with feature #43 cover extraction (decision-policy in plan: real-cover-if-available, generative-fallback). (9) **Status bar tinting** — flips light/dark based on `theme.isDark`. **Out of scope for v1**: PDF chrome (stays on PDFKit defaults until extended), AZW3/MOBI chrome (Foliate-js shell; extension TBD), search results panel, WebDAV / restore picker UI (#52 in flight), AI provider editor (#50 / #185 surface), reading-time dashboard (#58 has no design — needs design extension before implementing), hierarchical TOC tree (#38), bilingual inline mode (#56 — design's Translate is point-in-time only). **Edge cases**: (a) Photo theme image storage / picker / clearing; (b) backward-compat: per-book `epubTheme` value `.warmDark` etc. need migration to the new 5-theme set; (c) cover-policy collision with #43 — choose order at runtime; (d) accent against highlight colors — ensure contrast on each theme; (e) dynamic-island top inset preserved across the new chrome (bug #179 territory); (f) PDF/AZW3 fall-through: if user picks a theme the underlying renderer can't honour, render closest approximation. **Acceptance criteria**: (a) Library matches design's grid + rail on iPhone 17 Pro Sim; (b) Reader (EPUB + TXT + MD) matches design's chrome + page layout pixel-close (within typography metric drift); (c) All 5 themes render correctly including Photo; (d) Long-press text in any reader format produces the new SelectionPopover with 4 colors + 4 actions; (e) AI sheet Summarize/Chat/Translate tabs match design; (f) Source Serif 4 ↔ Inter toggle works in reader; (g) Existing features (highlight persistence, search, AI, backup) unaffected — no regressions in feature #3 / #4 / #11 / #17 / #29 / #44 / #50 verification sets. **Dependencies**: blocks none; informs #53 (presenter could be re-skinned post-#60), #55 (same), #58 (needs design extension first). **Risks**: (a) typography metric drift between Source Serif 4 and current Georgia/system serif breaks scroll-position restore math (bug #179 family) — mitigate with offset re-projection on font change; (b) Photo theme image storage policy + WebDAV backup question (does the image travel?); (c) AZW3/MOBI fall-through — Foliate-js's own typography won't match Source Serif 4 unless we ship a font into the Foliate bundle; (d) re-skinning #53 + #55 presenters post-#60 = double-implementation cost vs gating those features behind #60. **Implementation gating**: per rule 47 follows /feature-workflow Gates 1-6 (Plan → Independent plan audit → TDD → Implementation audit → Device verification → Merge). Likely 8-15 WIs depending on Gate-1 split. Per rule 48 most WIs must serialize (one writer per file per area). Cron-friendly mechanical WIs: font asset bundling, theme-token extension, accent-color sweep. Human-loop WIs: Library redesign, Reader chrome, SelectionPopover swap. **Out-of-design surface decisions** (locked at triage time, plan can adjust): PDF/AZW3/MOBI reader chrome stays on current rendering for v1; #58 reading-time dashboard waits for design extension; #56 bilingual inline waits for design extension; #38 TOC tree waits for design extension; #43 generative covers folds into this feature. Reported by user 2026-05-15. GH: #718 |
+docs/features.md:117:| 59 | Register vreader as a system document handler — appear in iOS "Open in" / Share Sheet for `.epub`, `.azw3` (+ `.mobi`/`.prc`/`.azw`), `.md` (+ `.markdown`), `.txt`, `.pdf` and import the tapped file into the library | App/*, Library/* | Medium | VERIFIED | **VERIFIED 2026-05-16 round-3** (`dev-docs/verification/feature-59-20260516-round3.md`, `result: pass`) on iPhone 17 Pro Sim v3.22.23 (commit `cdefc5a5`). All 6/6 criteria PASS — Bug #197 / GH #708 fix (`75fc5409`, v3.22.22) unblocked criterion (b): `simctl openurl booted "file://...epub"` → new book appears in library within ~1s, no cold restart needed (`dev-docs/verification/artifacts/feature-59-verified-library-postfix-20260516.png`). **Round-2 device-verify 2026-05-16** (`dev-docs/verification/feature-59-20260516.md`, `result: partial`). 5/6 criteria PASS, only (b) still BLOCKED by Bug #197 (library not auto-refreshing post-import — still NEW). Round-2 confirmed: (a) Share Sheet shows vreader for PDF — Files-app → tap PDF → Quick Look → Share → Preview/vreader/More listed ✅; (c) `.mobi`/`.prc`/`.azw` dispatch correctly via simctl openurl (FileURLImportRouter logs + DB rows confirm import), `.pdf` dispatches via Share Sheet → tap vreader → DB row appears (lands on prior view due to Bug #197, but the import-to-DB path works) ✅; (e) Files-app context menu wording is "Open With" NOT "Copy to vreader" → `LSSupportsOpeningDocumentsInPlace: true` honored ✅; (f) "Open With" expanded list shows Preview labeled "Default" and vreader as alternative → `LSHandlerRank: Alternate` honored ✅. Combined with round-1 (`feature-59-20260515.md`): all 7 of 8 supported extensions verified to dispatch (only `.markdown` is broken at the Apple system-UTI level, not a vreader bug). Cannot flip to VERIFIED until Bug #197 lands a fix and criterion (b) reverifies. Plan: `dev-docs/plans/20260515-feature-59-share-sheet-open-in-vreader.md` (v1, Gate 2 round-1 audit clean via Codex `019e2a9e`). **2 WIs both shipped** — WI-1 (Info.plist metadata: CFBundleDocumentTypes + UTImportedTypeDeclarations + LSSupportsOpeningDocumentsInPlace) in PR #698 v3.21.73 commit `ba92440`. WI-2 (FileURLImportRouter + production .onOpenURL handler in both Debug & Release Scene branches + `BookFormat.isSupportedExtension`) in this PR. Test suite: 6 InfoPlist regression guards + 6 BookFormat extension cases + 9 router dispatch cases (including 10 supported-extension parameterized + 6 unsupported-extension parameterized). All pass. **Problem**: When the user taps a book file in another app (Files, Mail, Safari downloads, AirDrop receive, third-party file managers) iOS shows an "Open in…" / Share Sheet listing the apps that have declared support for that document type. vreader is not in the list because `Info.plist` declares no `CFBundleDocumentTypes` and no `UTImportedTypeDeclarations`. The app also has no production `.onOpenURL`/scene-delegate handler for `file://` URLs — the existing handler in `VReaderApp.swift:309` is wrapped in `#if DEBUG` and only matches `DebugCommand.scheme` (the `vreader-debug://` URL surface). All five formats (EPUB / PDF / TXT / MD / AZW3-MOBI-PRC-AZW) are otherwise fully supported — `BookImporter` already routes them through format-specific metadata extractors (`AZW3MetadataExtractor` for `.azw3/.azw/.mobi/.prc`, EPUB/PDF/TXT/MD extractors elsewhere) and the reader views all consume `URL` inputs via `open(url:)` ViewModels. So this is purely the missing system-level registration + import dispatch — not a new format-handling capability. **Scope**: (1) **Document-type declarations in `project.yml` Info.plist properties** — add `CFBundleDocumentTypes` array with one entry per supported family, each with `CFBundleTypeName` + `LSHandlerRank: Alternate` (so vreader appears alongside other readers without claiming primacy) + `LSItemContentTypes` listing the relevant UTIs. Standard UTIs: `org.idpf.epub-container` (EPUB), `com.adobe.pdf` (PDF), `public.plain-text` (TXT), `net.daringfireball.markdown` (MD — Apple-recognized public conformance). Custom UTIs declared in `UTImportedTypeDeclarations`: `com.amazon.azw3` / `com.amazon.mobi-pocket` / `com.amazon.kindle` covering the AZW3/MOBI/PRC/AZW extensions (Apple does not provide a system UTI for these). Each imported type spec: `UTTypeIdentifier`, `UTTypeConformsTo: [public.data]`, `UTTypeDescription`, `UTTypeTagSpecification` ({public.filename-extension: [...], public.mime-type: [...]}). (2) **`LSSupportsOpeningDocumentsInPlace: true`** — required so the Files app and document-pickers can hand the URL to vreader without copying the file first; pairs with `UIFileSharingEnabled` if the user wants their library exposed (separate scope decision). (3) **Production `.onOpenURL` handler** in `VReaderApp.swift` (outside the `#if DEBUG` block) that dispatches `file://` URLs to a new `BookImportRouter` (or extension on the existing `BookImporter`) which: securely scopes-the-resource (`url.startAccessingSecurityScopedResource()`), detects format via `BookFormat.from(fileExtension:)`, calls the existing `BookImporter.importBook(at:)` path, releases the scope, and navigates to the new library row (or directly opens the book — UX decision in plan). (4) **Edge cases**: (a) unknown extension reaching the handler (because UTI conformance can be looser than our extension list) — fall back to user-visible alert; (b) file URL points to iCloud / OneDrive lazy file not yet downloaded — surface a "downloading…" state before import; (c) huge AZW3 files imported under memory pressure — same risk surface as existing AZW3 import (covered by `BookImporter`); (d) duplicate import — `fingerprintKey` dedupe already handles this; the handler should still navigate to the existing row, not silently no-op; (e) MD file mistyped as plain text by source app — UTI dispatch picks the highest-conforming registered type; (f) iOS 17+ App Intents / Quick Actions integration is OUT of scope for this row. **Acceptance criteria**: (a) on iOS Share Sheet for an `.epub` file in Files / Mail / Safari, "vreader" appears in the destinations list; (b) tapping the destination launches vreader, imports the file, and lands on either the library or the freshly-opened reader (decide in plan); (c) same flow for `.azw3`, `.mobi`, `.prc`, `.azw`, `.md`, `.markdown`, `.txt`, `.pdf`; (d) duplicate handling: same file shared twice does not create a duplicate library row; (e) Files-app context menu shows "Open in vreader" without a copy step; (f) `LSHandlerRank: Alternate` confirmed by NOT becoming the default handler on a clean device. **Dependencies**: none (all format-handling already implemented). **Risks**: (a) UTI conformance for `.azw3`/`.mobi` is non-standard — Apple doesn't ship a public UTI for these, so we must declare them; if a competing reader app declared a slightly different conforming UTI tree, both apps might show or one might be hidden — confirm against Apple Books, Kindle, Marvin, KyBook on a real device during verification; (b) `LSSupportsOpeningDocumentsInPlace` interactions with the existing book-files-directory model in `BookImporter` — make sure scope-released URLs aren't re-read after `stopAccessingSecurityScopedResource`; (c) `UTImportedTypeDeclarations` declarations could conflict with already-installed system Markdown editors — test on a device with Bear / iA Writer / Drafts installed to confirm we appear in the sheet without breaking their defaults. Reported by user 2026-05-14. GH: #667 |
+docs/features.md:118:| 58 | Reading-time + activity dashboard — time-window aggregation (today / week / month / 3mo / 6mo / year / all-time), per-book breakdown with notes and highlights counts, sortable, included in WebDAV backup | Library/*, Stats/* | Medium | VERIFIED | **VERIFIED 2026-05-22 (verify-cron Gate-5b round 2)** — all 6 acceptance criteria PASS on merged `main` `1973b002` (v3.39.8). Round-2 unblocked by Bug #263 / GH #1138 (`vreader-debug://seed-sessions`): seeded a deterministic 6-session spread on-device, confirmed the live per-window ladder today=600<7d=1200<30d=1800<90d=2400<180d=3000<all=3600 + `ReadingStats`=3600s/6, and drove the SAME `ReadingStatsAggregator` over the SAME seeded data via the seam test (criterion b); `sortIsAppliedToPerBookTable` reorders rows + `StatsPerBookTable` exposes all 5 sortable columns + per-book notes/highlights projection (criterion c); VM UserDefaults sort round-trip across construction (criterion d); criterion a reachability carried from round-1 artifact; criteria e/f re-confirmed green by `BackupReadingHistoryTests`. Dashboard's *visual* surface is not CU-free reachable (no `present?sheet=stats` / `vreader-debug://stats`; CU down) so b/c/d verified at the data/behavioral substance layer per the verify-skill authorized path — 333 tests / 0 failures across 9 suites. Evidence: `dev-docs/verification/feature-58-20260522-round2.md` (`result: pass`). GH #665 closed. Round 1 (`feature-58-20260522.md`, `result: partial`) verified a + e/f; b/c/d were blocked on session-seeding (Bug #263, now FIXED). **DONE 2026-05-22 (feature-cron Gate-6)** — all WIs merged on `main` (WI-1–5 PRs #982/#994/#995/#999/#1001; WI-6a/6b/6c) and all 6 acceptance criteria have shipping code: `ReadingDashboardView`+`ReadingDashboardViewModel` (a), `ReadingStatsAggregator` 7-window (b), `StatsPerBookTable` 5-col sort (c) + persisted sort (d), `BackupReadingHistory` reading-history.json (e/f). Dashboard reachable via Feature #67's Stats button (now DONE). Implementation complete; awaiting Gate-5b VERIFIED (verify cron — exercise the acceptance criteria end-to-end incl. a WebDAV backup→wipe→restore round-trip). **D1–D4 RESOLVED 2026-05-20 — A/B/B/A.** D1=A: entry point amended to **"from Settings → profile card → Stats"** (accepts feature #67 dependency — #67 WI-4 owns the SettingsView Stats button, itself hard-blocked on this feature's WI-6 reaching `DONE`, the standard mutual-dependency knot — WI-6a ships a DEBUG-only `vreader-debug://stats` entry for Gate-5 verification while the user-facing hook waits on #67). D2=B: accept the design literally (`Year` calendar-YTD + `Custom` range picker) — **Custom range picker deferred to GH #1058** (filed `needs-design`). D3=B: ship 5 sort fields including `last-read` — **`last-read` column deferred to GH #1059** (filed `needs-design`). D4=A: hero + 7-pill bar (design). **Deferred per D2-B / D3-B: Custom range picker (GH #1058) + last-read sort column (GH #1059); WI-6a's first cut ships 6 windows (Today / 7d / 30d / 90d / Year / All — Custom dropped) + 4 sort fields (title / time / highlights / notes — last-read dropped).** WI-6 split into WI-6a (A-portion: dashboard view + 6-pill bar + 4-col table + DEBUG-only `vreader-debug://stats` entry, ships now), WI-6b (D2-B Custom range picker + Year calendar-YTD bucket swap, blocked on #1058 — **UNBLOCKED 2026-05-20 by PR #1060 Stats Followups design landing**; **WI-6b SHIPPED 2026-05-20** — Custom pill on `StatsTimeWindowBar` + new `StatsCustomRangePicker` sheet (month grid + quick-preset rail + start/end date chips + summary footer) + new `ReadingStatsCustomRange` value type + aggregator widened with optional `customRange` arg (additive; nil = WI-6a behaviour) + VM tracks/persists the applied range across launches; 100 WI-6a/6b tests green), WI-6c (D3-B `last-read` column, blocked on #1059 — **UNBLOCKED 2026-05-20 by PR #1060**; **WI-6c SHIPPED 2026-05-20** as PR #1063 — `.lastRead` case added to `ReadingDashboardSortField` + comparator (nil sinks to bottom regardless of direction); `StatsPerBookTable` gained a 5th `Read` header-tap-driven column (Alt-1 always-5-columns design variant); nil cells render as "—", non-nil reuse `ReadingTimeFormatter.formatRelativeLastRead`). **WI-1–5 MERGED to main 2026-05-19 (WI-1 ReadingStatsModels PR #982; WI-2 ReadingStatsAggregator PR #994; WI-3 ReadingTimeFormatter.formatDuration PR #995; WI-4 ReadingDashboardViewModel PR #999; WI-5 WebDAV reading-history backup section PR #1001 — each Codex-audited ship-as-is, 79 WI-1–5 tests green on main).** **Gate 1+2 complete — plan dev-docs/plans/20260519-feature-58-reading-dashboard.md, Codex-audited clean.** **Design delivered 2026-05-18 — issue-canvas handoff resolves needs-design #862** — triage 2026-05-18: the `ReadingDashboardView` UI (7 time-window cards + sortable per-book table) has no committed design; `needs-design` #862 covers it (bundled with feature #67's profile card — same reading-stats design family). The non-UI parts (the `ReadingStatsAggregator` service + the WebDAV backup-payload extension) are not design-gated and can be planned independently once the dashboard design lands. **Problem**: Per-session reading-time data is already collected (`ReadingSession` SwiftData model: `startedAt`, `endedAt`, `durationSeconds`, `bookFingerprintKey`) and per-book lifetime totals exist (`ReadingStats` model: `totalReadingSeconds`, `sessionCount`, `lastReadAt`), but there is no surface that exposes this data to the user. No view, no time-window aggregation, no per-book breakdown panel, no sorting beyond `LibrarySortOrder.totalReadingTime`. Notes (`AnnotationNote`) and highlights (`Highlight`) counts per book are queryable but never aggregated into a stats surface. WebDAV backup (`BackupDataCollector`) currently omits both `ReadingSession` and `ReadingStats` (CloudKit-only via `SyncReadingSessionRecord` / `VRReadingSession`), so stats are lost on restore-to-fresh-device. **Scope**: (1) **Time-window aggregator** — new `ReadingStatsAggregator` service (likely actor-isolated): query `ReadingSession` records over a `DateInterval`, sum `durationSeconds`, return totals for the standard windows (today / past-7d / past-30d / past-90d / past-180d / past-365d / all-time). Uses `startedAt` as the bucket anchor; sessions spanning a window boundary count toward the window containing `startedAt` (document this decision). (2) **Dashboard view** — new `ReadingDashboardView` (SwiftUI), accessible from **Settings → profile card → Stats** (D1=A resolution 2026-05-20; depends on feature #67's profile card). Top section shows the seven aggregate totals as cards (label + formatted duration via `ReadingTimeFormatter`). Middle section is a per-book table: columns for book title, reading time in the active window, notes count (from `PersistenceActor.fetchAnnotations(forBookWithKey:)`), highlights count (from `PersistenceActor.fetchHighlights(forBookWithKey:)`). Window picker at the top of the per-book table re-runs the aggregator and re-renders. (3) **Sorting** — per-book table sortable by: title (asc/desc), reading time (desc/asc), notes count (desc/asc), highlights count (desc/asc), last-read (desc/asc). Default: reading time desc within the active window. Persist last-used sort in `UserDefaults` mirroring `LibrarySortOrder` pattern. (4) **WebDAV backup inclusion** — extend `BackupDataCollector` with a `collectReadingHistory()` method that emits a new `reading-history.json` (or similar) section containing `ReadingSession` records (sessionId, bookFingerprintKey, bookFingerprint, startedAt, endedAt, durationSeconds, pagesRead, wordsRead) and `ReadingStats` aggregates. `BackupDataRestorer` mirrors with `restoreReadingHistory(...)`. Bumps `kBackupCurrentSchemaVersion`. **Edge cases**: (a) zero sessions for a book — still show row with "0m"; (b) book deleted but historical sessions exist — show row with `(deleted)` placeholder title or omit (decide in plan); (c) session crosses midnight / week boundary — counts to the bucket containing `startedAt`; (d) clock skew (device-time changes) — accept whatever `startedAt` records; (e) very long history (1000+ sessions) — aggregator must be efficient (`@Query`-style predicate over `startedAt`); (f) WebDAV restore from older backup with no `reading-history.json` — section is optional, aggregator falls back to local-only stats; (g) timezone — bucket boundaries computed in user's current timezone (today = local-midnight to local-midnight). **Acceptance criteria**: (a) dashboard surface reachable from Settings → profile card → Stats (D1=A); (b) all 7 windows render correct totals on a fixture with seeded sessions; (c) per-book table shows time/notes/highlights counts, sortable on all 4 columns; (d) sort selection persists across app launches; (e) `BackupDataCollector` emits `reading-history.json`; restore on a fresh device reproduces historical totals; (f) round-trip: backup → wipe → restore preserves `ReadingSession` + `ReadingStats` exactly. **Dependencies**: Feature #29 (WebDAV backup, VERIFIED — for the backup payload extension), `LibrarySortOrder.totalReadingTime` (already exists). **Risks**: (a) aggregator performance over large session histories — may need a denormalized per-day-bucket cache table if N+1 patterns appear; (b) WebDAV backup payload bloat — `ReadingSession` rows accumulate over time; consider compression or window-based truncation; (c) timezone semantics — buckets recomputed if user travels; this is correct but document in UI. **Notes**: builds on existing infrastructure — no new SwiftData @Models required for stats display; read-only over existing schemas plus the new backup payload section. Reported by user 2026-05-14. ~~WI-6 has 4 open product decisions (D1-D4) — blocked at Gate 3 pending user input.~~ (Superseded: D1-D4 were RESOLVED 2026-05-20 as A/B/B/A — see Notes head; WI-6a/6b/6c shipped accordingly and the feature reached DONE 2026-05-22.) GH: #665 |
+docs/features.md:119:| 57 | AZW3/MOBI TTS — wire `FoliateTTSAdapter` (or Foliate-webview text extraction) into production so the speaker button works for Foliate-rendered formats | Reader/TTS | Medium | VERIFIED | **VERIFIED 2026-05-26** — criterion-4 pause/resume gap closed CU-free. `Feature26TextToSpeechVerificationTests.test_verify_feature_57_azw3_start_pause_resume_stop_cycle` (seed `.azw3Fixture` — added by Bug #233/#964 — + `--tts-test-mode`) drove the full start → pause → resume → stop lifecycle on the live Foliate AZW3 reader via XCUITest accessibility taps (the play/pause control's "Pause"⇄"Resume" label flips prove `.speaking ⇄ .paused`); 1 test, 0 failures, 20.8 s. All in-scope criteria (1,2,3,4,7) now pass. Evidence: `dev-docs/verification/feature-57-20260526.md`. The 2026-05-19 partial was a framing error (XCUITest taps via accessibility, not CU). **Status**: all 4 WIs merged to `main` — WI-1 (`extractPlainText` JS helper + Swift channel, PR #913, v3.33.8), WI-2 (`startTTS()` AZW3 branch + in-flight extraction gate, PR #916, v3.34.1), WI-3 (re-add `.tts` capability, PR #919, v3.34.3), WI-4 (acceptance verification, this PR). **Verification**: `dev-docs/verification/feature-57-20260519.md`, `result: partial` — criteria 1, 2, 3, 7 verified end-to-end (device + unit); criteria 5 & 6 amended out of scope at the PLANNED flip; criterion 4's **pause/resume** could NOT be exercised end-to-end (the `vreader-debug://tts` grammar has only `start`/`stop`, and CU — the only path to the `TTSControlBar` pause button — is down). Row stays `DONE` (not `VERIFIED`); reaching `VERIFIED` needs a follow-up pause/resume verification (recommend extending `DebugCommand.tts` with `pause`/`resume` actions). **Problem**: AZW3 and MOBI files render through Foliate-js inside a WKWebView. Unlike TXT/MD/PDF/EPUB, the Swift side has no parsed view of the content — there is no `loadBookTextContent` case for these formats. Bug #176 capability-gated `.tts` off `.azw3` to stop the silent failure user-facing (PR forthcoming 2026-05-14, v3.21.42). This feature reverses that gate by implementing a real TTS path. **Plan**: `dev-docs/plans/20260518-feature-57-azw3-mobi-tts.md` (Gate 1; audited clean at Gate 2 round 3, Codex `019e3e3a`). **Scope decision — path (a) chosen** (plan §2): Foliate-webview whole-book plain-text extraction via a new `readerAPI.extractPlainText()` JS helper (walks `view.book.sections[].createDocument()`, the same seam `view.search()` uses) feeding the shared `AVSpeechSynthesizer` pipeline. Path (b) (Foliate in-webview SSML TTS) rejected — `FoliateTTSAdapter` expects a `tts-text` message the bundle never posts, Foliate-js TTS is SSML-based with no `AVSpeechUtterance` bridge, and it is per-section not whole-book. The `v1` path-(a) premise `document.body.innerText` was disproven (host `<body>` is shell-only; book content is two closed-shadow-roots + an iframe deep) — the plan re-bases on the real `createDocument()` seam. **Acceptance criteria**: (1) `.tts` re-added to `FormatCapabilities.capabilities(for: .azw3)`; speaker button visible in AZW3/MOBI reader chrome again. (2) Tapping speaker → TTS starts speaking the AZW3 text; `vreader-debug://snapshot` reports `ttsState: "speaking"` and `ttsOffsetUTF16` advances over time. (3) `vreader-debug://tts?action=start` URL path works for AZW3 (matches TXT/MD/PDF/EPUB behaviour). (4) Pause/Resume/Stop cycle exercised end-to-end on iPhone 17 Pro Sim. (5) **AMENDED at PLANNED flip (plan §7.1, Gate-2 audit-confirmed)**: visual sentence-highlight inside the Foliate WKWebView is **explicitly out of scope** for #57 — `TTSHighlightCoordinator` is TXT/MD-only (`TTSHighlightCoordinator.swift:7-10`) and is never instantiated for Foliate, so the #40 pipeline does not run there at all; a Foliate TTS-highlight overlay is a tracked follow-up feature, not a line item of #57. (6) **AMENDED at PLANNED flip (plan §7.1, Gate-2 audit-confirmed)**: auto-scroll inside the Foliate WKWebView is **explicitly out of scope** for #57, for the same reason — feature #41's own VERIFIED row already declares "EPUB/AZW3/PDF intentionally out of scope (different scroll surfaces)." (7) Removed regression-guard `azw3_doesNotSupportTTS()` test; replaced with positive `azw3_supportsTTS()` assertion. #57 delivers **TTS audio + pause/resume/stop** for AZW3/MOBI; visual highlight/scroll on Foliate is deferred to a separate feature. **Dependencies**: Feature #42 (Foliate unified reader engine) listed as a soft dependency only "if pursuing path a via Foliate's #42-introduced helpers" — **severed**: path (a) uses #57's own `extractPlainText` helper added to `foliate-host.js`, not a #42 helper; #57's Gate 3 does not wait on #42 (merge-order coordination only — plan §3.4). **Risks**: path (a) — `extractPlainText()` must return correct whole-book text and the returned `Promise<string>` must marshal across `evaluateJavaScript` (front-loaded into WI-1's device-verified feasibility slice); whole-book extraction may be slow on large books → handled by deferring to first speaker tap + an in-flight extraction gate (`azw3ExtractionTask`) for rapid repeated taps. Reported by user 2026-05-13 via bug #176 fix's deferral. GH: #904 |
+docs/features.md:120:| 56 | Bilingual reading mode — AI-translated chapter displayed inline below original, persistent disk cache, whole-book translation, per-chapter re-translation with provider override | AI/*, Reader/* | Medium | VERIFIED | **2026-05-20 — VERIFIED (Gate 5b round-3)**: all 6 acceptance criteria PASS via host-script + DebugBridge + live OpenRouter provider; criterion (b) re-verified post Bug #245 fix (PR #1076, v3.38.19) — TXT bilingual interleaved render directly observed via `mcp__computer-use__screenshot` (war-and-peace.txt chapter 3, English source + Chinese inline below each paragraph). Evidence: `dev-docs/verification/feature-56-20260520-round3.md` (round-3 result=pass) + `dev-docs/verification/feature-56-20260520-round2.md` (round-2 result=partial, criteria a/c/d/e/f PASS, criterion-b PARTIAL pre-fix). **2026-05-20 — DONE**: all 15 WIs shipped (WI-1..15 incl. WI-2.5 + WI-7a/7b split). WI-15 (final) — `ChapterReTranslateViewModel` + `ReTranslatePickerSheet` + host wiring (`ReaderContainerView+ReTranslate`) deliver acceptance criteria (e) per-chapter re-translate clears old cache and fetches fresh, and (f) provider override does not mutate `ProviderProfileStore`. Awaiting Gate 5b post-merge final-acceptance pass (every AC exercised end-to-end against a real provider) → `VERIFIED`. **Scope note — secondary TOC swipe affordance deferred to a follow-up `needs-design`**: the plan named `ChapterReTranslateSwipeAction` in `TOCListView`, but the existing TOC is `LazyVStack`-in-`ScrollView` and SwiftUI `.swipeActions` requires a `List` host — the designed swipe affordance cannot attach without inventing UI (rule 51). The primary path (More-menu row → picker → progress) fully delivers (e) and (f); the secondary TOC swipe is queued as a follow-up. **Gate 3 complete — WI-1..WI-15 merged (incl. WI-2.5, WI-7a/7b split).** **Gate 1+2 complete — plan dev-docs/plans/20260519-feature-56-bilingual-reading.md, Codex-audited clean.** **Design delivered 2026-05-18 — issue-canvas handoff resolves needs-design #863, #864** — triage 2026-05-18: the committed design (`vreader-bilingual.jsx` + `feature-60-followups.md` §2) covers the interlinear renderer, setup sheet, More-menu row, and `EN ↔ 中` pill — but NOT scope item (3) "Translate entire book" (entry point / confirmation / progress / cancel → `needs-design` #863) nor scope item (4) per-chapter re-translate UI + provider-override picker (→ `needs-design` #864). The core bilingual-reading slices are designed; the global-translate + re-translate slices are blocked. **Problem**: Feature #18 translates selected text within the AI panel (point-in-time, in-memory cache, session-only). Users reading foreign-language books want a full bilingual reading experience: the entire current chapter translated and displayed inline below the original text, cached to disk so translations survive app restarts, with a global translate-entire-book option and per-chapter re-translation control. **Scope**: (1) **Chapter bilingual mode** — a toggle in the reader AA panel (per-book, persisted in `PerBookSettings`) that, when enabled, fetches the full chapter text through `AIService.sendRequest` and renders the translation below the original in each reader format. For TXT/MD: append translation in a styled `UITextView` section below the chapter text. For EPUB: inject translated paragraphs after each `<p>` via a JS bridge call. For Foliate/AZW3: inject via Foliate message. For PDF: overlay translation panel below the page. Target language defaults to Chinese (user-configurable per-book or globally). (2) **Persistent translation cache** — `ChapterTranslationStore` actor (new SwiftData `@Model`): keyed by `(fingerprintKey, chapterHref, targetLanguage, providerProfileID, promptVersion)` → translated text + timestamp. `AIResponseCache` is session-only in-memory; this store persists to disk and survives relaunches. Stale-cache invalidation: user-driven only (re-translate). (3) **Global book translation** — "Translate entire book" action in the Library card or book detail screen. Presents a confirmation alert with estimated chapter count and a warning ("This will send all chapters to your AI provider, which may use a significant number of tokens"). Runs chapter-by-chapter as a `Task.detached` background operation with cancellability; progress bar in a translating status badge. Already-cached chapters are skipped. (4) **Per-chapter re-translation** — "Re-translate Chapter" option in the reader AA panel long-press menu or chapter list context menu. Clears the cached entry for that chapter and re-fetches. Provider override: a picker (using existing `ProviderProfileStore`) lets the user choose a different AI provider for the re-translation without changing the global active provider. **Edge cases**: (a) chapter text exceeds provider max_tokens — split into chunks with overlap, recombine; (b) translation in progress when user navigates away — cancel and discard partial result; (c) offline mode — load from disk cache if available, else show "Translation unavailable offline"; (d) provider changed after cache entry written — treat as stale (different providerProfileID); (e) CJK→CJK translation (e.g. Simplified→Traditional) — same pipeline, no special case; (f) concurrent global translation + single-chapter re-translate racing on the same chapter — last writer wins, or serialise via actor; (g) book deleted while global translation running — cancel the operation and clean up cache entries. **Acceptance criteria**: (a) bilingual mode toggle persists per book; (b) current chapter translation renders inline within 10 seconds for a typical chapter; (c) cached translation loads immediately on next app open without an API call; (d) global translate shows confirmation with chapter count and can be cancelled; (e) per-chapter re-translate clears old cache and fetches fresh; (f) provider override for re-translate does not change the global active provider. **Dependencies**: Feature #18 (VERIFIED — `AIService`, `AITranslationViewModel`), Feature #50 (VERIFIED — `ProviderProfileStore`). Reported by user 2026-05-14. **Design landed 2026-05-16**: `dev-docs/designs/vreader-fidelity-v1/project/design-notes/feature-60-followups.md` §2.1 is feature #56's design source — paragraph-interlinear rendering (each source paragraph followed by its translation at ~0.88× size, `sub` color, slight indent), a first-toggle setup sheet (target language / Paragraph|Sentence granularity / AI-provider chip), and a persistent on/off mode with an `EN ↔ 中` reader-chrome pill. Arrived via the feature #60 follow-up handoff — the #790 `Design needed:` issue proposed this as a new feature before realising #56 already tracked it. Feature #56 can be promoted TODO → PLANNED against this design. **Scope note 2026-05-17**: #56's scope explicitly includes the **More-menu bilingual toggle row** (`feature-60-followups.md §2.3` — off / on / AI-unavailable states) as bilingual mode's entry point. Feature #60 WI-6c deferred that row (`ReaderMoreMenuRow.swift` marks Bilingual deferred) and a "WI-6d" was named but never created; since #60 is VERIFIED the row has no home there — #56 owns it, and #56's eventual plan must implement the row alongside the backing mode. WI-13 (PDF below-page translation panel) + the bilingual-offline-affordance WI are needs-design-blocked. GH: #629 |
+docs/features.md:122:| 54 | Remove Native/Unified reading mode toggle — route by ReaderEngine internally | Reader/* | Medium | VERIFIED | **Problem**: The Native/Unified picker leaks an implementation detail. Users want "apply replacement rules" or "convert Chinese," not "Unified mode." A toggle that makes EPUB rendering worse is the wrong abstraction. Design decision documented in GH #493. **Scope**: (1) Hide picker when no transforms configured; (2) Introduce internal ReaderEngine routing (textNative/markdownNative/epubWKWebView/foliateWeb/pdfKit) replacing readingMode branch; (3) Wire replacement rules into native EPUB (JS text-node preprocessing, CFI-safe) and MD (TextMapper.apply before parse); (4) Migrate and remove readerReadingMode from UserDefaults + per-book PerBookSettings; (5) Retire UnifiedPlaceholderView and dead Unified paths. **Acceptance criteria**: no picker in normal use; replacement rules work in native EPUB and MD without mode switch; readingMode key removed with migration; all existing reader features unchanged. **Dependencies**: Feature #42 (Foliate-js) required for full EPUB engine swap — steps 1/3(MD)/4 can land independently. **Risks**: Foliate JS transforms must be CFI-safe; per-book override migration; transform parity tests required per engine before removing toggle. **Gate 1 + Gate 2 complete 2026-05-19**: implementation plan at `dev-docs/plans/20260518-feature-54-remove-reading-mode-toggle.md` (v3, 7 WIs across 3 autonomous phases + 1 deferred Phase D). Independent Codex plan audit ran 3 rounds; round-3 verdict clean (round-1 found 8 findings — TXT replacement rules deferred to Phase D, synchronous migration; round-2 found 3 — `openPositionUnsupportedInUnifiedMode` one-producer reality, semantic-not-byte migration preservation, WI-4 two-file scope; all resolved). EPUB replacement-rule wiring + `epubWKWebView`/`foliateWeb` differentiation + native-TXT replacement rules are explicitly DEFERRED (Phase D). **All 7 WIs shipped → DONE 2026-05-19**: WI-1 `ReaderEngine` enum + per-format `resolve` (PR #878, v3.31.4); WI-2 `ReadingModeMigration` namespace (PR #879, v3.31.5); WI-3 reader dispatch routed by `ReaderEngine`, Unified dispatch branch deleted (PR #883, v3.31.7); WI-4 Reading Mode + Tap Zones removed from the settings panel (PR #886, v3.31.9); WI-6 DebugBridge cleanup — retired `openPositionUnsupportedInUnifiedMode` (PR #888, v3.31.11); WI-5 `ReadingMode` enum + `readerReadingMode` key/field removed, one-shot launch migration (PR #893); WI-7 content replacement rules wired into the native MD reader via `MDFileLoader` transform chain — the final WI (PR #901). WI-5/WI-6 implementation order was swapped vs the plan (WI-5's field removal would not compile while WI-6's DebugBridge guard still read `store.readingMode`). Phase D (native EPUB replacement rules, `epubWKWebView`↔`foliateWeb` differentiation, native TXT replacement rules + offset map) remains deferred — see plan §4 Phase D. `VERIFIED` flip pending the final-WI full acceptance pass + evidence file. **2026-05-19 (Gate-5 CU-free XCUITest verification)** — `dev-docs/verification/feature-54-20260519-cu-free.md`, `result: partial`, on iPhone 17 Pro Simulator / iOS 26.4, `main` @ `306f7ce`, v3.34.3. A new CU-free XCUITest suite `Feature54ReadingModeRemovalVerificationTests` (4 tests, all green) drives the app through the accessibility API — no computer-use, no DebugBridge URL-confirm — and closes the headless-navigation gap that blocked the earlier `feature-54-20260519.md` partial. Verified end-to-end via the live reader UI: criterion 1 (no Reading Mode / Tap Zones / Native / Unified picker anywhere in the Display panel — for TXT, EPUB, MD, full 12-section scroll), criterion 2's structural half (MD opens into the native `markdownNative` engine with no mode switch — transform correctness still via the 20 integration tests), criterion 5 (TXT/EPUB/MD each open into their native `ReaderEngine` surface and render). Criterion 4 stays device-verified + unit (UserDefaults / launch-migration — no UI surface). **Row stays `DONE`, NOT `VERIFIED`**: criterion 3 (replacement rules in native EPUB without a mode switch) is in the acceptance contract but was DEFERRED to Phase D by the plan and Phase D has not shipped — one acceptance criterion is genuinely unimplemented, so per `SCHEMA.md` the `partial` result cannot flip the row. `VERIFIED` flip awaits Phase D shipping criterion 3 + a follow-up acceptance pass. **2026-06-08 Phase D-1 shipped → VERIFIED** (v3.59.26, evidence `dev-docs/verification/feature-54-20260608-phase-d1.md`, `result: pass`): criterion 3 (replacement rules in native EPUB) is now implemented + device-verified. NEW `EPUBReplacementJS.injectionJS` builds a CFI-safe per-text-node replacement JS (string replace-all / regex global; only `nodeValue` mutated, structure untouched, JSON-escaped rules) wired into BOTH EPUB engines per `ReaderEngine.routeEPUB`: the legacy #71 WKWebView stitch (inject on `EPUBWebViewBridgeCoordinator.didFinish` + a scroll-root `MutationObserver` for appended chapters) and Readium (`ReadiumReaderCoordinator+Replacement` per-spine on `locationDidChange`). Rules fetched via `MDReplacementRuleFetcher`. Device-verified on the legacy stitch (default scroll mode): a seeded global "Chapter"→"Sektion" rule auto-applies on open (`hasChapter=False, hasSektion=True`), both chapters covered (2/2 sections marked, "Sektion Two" present via the observer). 23 `EPUBReplacementJS` unit tests + the banner-copy test updated (EPUB now a supported format). Codex audit `follow-up-recommended`: 2 Medium accepted with rationale — both are the documented v1 limitation (rules apply at open; a mid-read edit takes effect on next open, since correct live re-apply needs original-text preservation). All 5 acceptance criteria met. Native-TXT replacement rules + `epubWKWebView`↔`foliateWeb` further differentiation remain separate deferrals. GH: #609 |
+docs/features.md:124:| 52 | Multiple WebDAV server profiles with active-server switching | Settings/Backup | Medium | VERIFIED | **Problem**: WebDAV backup stores exactly one server's credentials in Keychain under fixed account keys (`com.vreader.webdav.serverURL/username/password`). Users with multiple WebDAV services (Nextcloud at home, Synology at work, Nutstore) must re-enter credentials every time they switch. **Scope**: (1) `WebDAVServerProfile` value type: `id: UUID`, `name: String`, `serverURL: String`, `username: String`, password Keychain-backed per `id`; (2) `WebDAVServerProfileStore` actor: persists a list of profiles (UserDefaults JSON) + `activeProfileID`; (3) Keychain: per-profile key `com.vreader.webdav.profile.<id>.password`; (4) Migration: on first launch, if legacy flat keys exist, migrate them into a profile named "Default" and set as active; (5) Settings UI: replace `WebDAVSettingsView`'s single-server form with a profile list (add/edit/delete/set-active) — mirrors `AIProviderListView` / `AIProviderEditSheet` pattern; (6) `WebDAVProviderFactory.make(...)` reads the active profile from the store instead of reading flat Keychain keys. **Edge cases**: (a) zero profiles — disable Back Up Now / restore with "Add a server in WebDAV Settings" prompt; (b) active profile deleted — fall back to first remaining or disable; (c) credential migration from legacy flat keys — silent, no re-entry required; (d) duplicate URLs are allowed (same server, different credentials); (e) profile name empty — default to serverURL hostname; (f) server URL malformed — validation before save. **Acceptance criteria**: (a) user can add two WebDAV profiles and switch the active one — only the active server is used for backup; (b) existing single-server users migrate without re-entering credentials; (c) deleting the active profile falls back to remaining or disables backup; (d) backup + restore round-trip works with the selected profile. Reported by user 2026-05-12. **Gate 1 + Gate 2 complete 2026-05-14**: implementation plan at `dev-docs/plans/20260514-feature-52-multiple-webdav-profiles.md` (7 WIs sized after Feature #50's precedent; foundational/behavioral tier-marked). Manual-fallback audit (Codex MCP unavailable) inline in plan section 9 — 1 Medium finding (JSON corruption edge case → defensive `try?` fallback in store init) + 2 Low findings (Notification.Name + migrator-async invocation pattern), all fixed in plan. **WI-1 shipped 2026-05-14 in v3.21.46** (PR #648): `WebDAVServerProfile` value type + `WebDAVServerProfileStore` actor + 32 tests (12 + 20). Foundational tier; no user-observable behavior. Gate 4 manual-fallback audit (Codex unavailable): zero open findings, ship-as-is. **Status flipped IN PROGRESS**. **WI-2 shipped 2026-05-14**: `WebDAVProfileMigrator` enum (109 LOC) + 6 tests covering legacy-flat-keychain → "Default" profile migration with idempotency on two axes (marker `com.vreader.webdav.profilesMigrated.v1` set OR store non-empty) + partial-legacy edge (URL-only) + fresh-install + repeat-call safety. Foundational tier; migrator callable but currently unwired (WI-3 wires it into `VReaderApp.init` + `WebDAVProviderFactory`). Stable migrated UUID `00000002-AAAA-4000-8000-000000000001` ensures re-runs upsert in-place. Legacy keychain entries kept (cleanup deferred to a post-#52 WI). Gate 4 manual-fallback audit (Codex unavailable): zero open findings, ship-as-is. **WI-3 shipped 2026-05-14**: `WebDAVProviderFactory.make(persistence:profileStore:...)` async + `makeRequestBuilder(profileStore:)` async variants (read active profile from store, dispatch to `WebDAVProvider` / `WebDAVDownloadRequestBuilder` with the same error contract as legacy sync variants: `missingCredentials` for no-active / empty-fields / no-password, `invalidServerURL` for malformed URL). 8 dispatch tests (`WebDAVProviderFactoryProfileDispatchTests`) cover the contract. `VReaderApp.init()` schedules `WebDAVProfileMigrator.migrateIfNeeded(...)` as a fire-and-forget background `Task.detached` at the end of the success branch. Legacy sync variants left untouched (parallel paths until WI-5); the two existing call sites (`WebDAVSettingsView.swift:371`, `LibraryView.swift:147`) continue to use the legacy flat-keychain readers. **Deliberate divergence from plan section 2.4's "thin wrapper" wording**: making the existing sync `throws` variant a wrapper over the new async path would require either a semaphore (antipattern) or a signature change (breaks the "compiling unchanged" goal); parallel paths achieve the plan's stated after-WI-3 outcome ("backup still works for existing users via the migrated Default profile") without churning the two legacy call sites. Foundational tier. Gate 4 manual-fallback audit (Codex unavailable): zero open findings, ship-as-is. **WI-4a shipped 2026-05-14 in v3.21.54** (PR forthcoming): `WebDAVProfileListViewModel` @Observable @MainActor VM (loadProfiles via atomic loadSnapshot, setActive with stale-id guard, deleteProfile with VM-side state cleanup) + `WebDAVServerProfileListView` (radio-row selection, leading/trailing swipe actions, pencil-edit affordance, empty state with externaldrive icon + Add CTA, `webdavProfilesDidChange` notification observer for external resync) + `WebDAVServerProfileEditSheet` STUB body (Cancel + Add-mode placeholder save writing `WebDAVServerProfile(name: "New WebDAV Server", serverURL: "", username: "")` per the plan's "placeholder save" wording) + `WebDAVSettingsView` modified to add a top NavigationLink section (legacy single-server form retained until WI-4b ships the full editor, to avoid breaking credential entry between merges). Sheet presentation uses `.sheet(item: $editorContext)` with a `WebDAVEditorContext: Identifiable, Equatable, Sendable` wrapper mirroring bug #174's AIEditorContext race-fix pattern. **Unified `.alert(...)` plumbing** via `enum WebDAVListAlertItem` (Codex round-2 finding) collapses the listError + active-delete-confirm into one alert binding so SwiftUI's "one alert per branch" limitation can't drop a path. Active-row swipe-delete prompts a confirmation alert ("Delete active server?") naming the displayName + "leaves no active server" copy; inactive rows delete immediately. **Re-entrancy guard** on stub editor's Add button (`@State isAdding` + `.disabled(isAdding)`) prevents duplicate placeholder rows from rapid double-tap. **VoiceOver disambiguation**: row label joins displayName + username + URL host (so duplicate-named profiles don't sound identical). Codex MCP audit `019e257c` (4 verification rounds): round 1 = 2 Medium (active-delete confirmation + stub-cancel-only) + 2 Low (VoiceOver + UI tests). Round 2 = 2 Medium (dual `.alert` conflict + re-entrant Add button) — both addressed. Round 3 = 2 Medium (listError state inconsistency + dropped deferred listError) — both addressed via direct mutation in listError OK + `promoteDeferredListErrorIfAny()` helper. Round 4 = zero findings, ship-as-is. Test gate: 21/21 new tests pass (11 VM + 7 EditorContext id stability/Equatable + 2 stub editor placeholder save + 1 notification-driven resync). Per-WI Gate 5 slice verification PASS on iPhone 17 Pro Sim (iOS 26.5): Settings → WebDAV Backup → Servers nav-link → empty state with "Add Server" CTA → tap Add → stub editor presents → tap Add toolbar → placeholder row "New WebDAV Server" appears with empty radio → tap radio → row activates (`largecircle.fill.circle`) → swipe-left active row → red Delete chip appears → tap Delete → confirmation alert "Delete active server? 'New WebDAV Server' is currently the active backup server. Deleting it leaves no active server until you switch to another or add one." with Cancel + Delete buttons → tap Cancel → alert dismissed, active row preserved. 2 evidence screenshots (`feature-52-wi4a-01-list-with-active-row-20260514.png`, `feature-52-wi4a-02-active-delete-confirmation-20260514.png`). Behavioral tier — slice verified pre-merge per plan section 4 "Tier: Behavioral. List UI lands but full editor in WI-4b". Audit log: `.claude/codex-audits/feat-feature-52-wi-4a-profile-list-ui-audit.md`. **WI-4b shipped 2026-05-14 in v3.21.57**: replaced WI-4a's stub editor with the full add/edit form — `WebDAVServerProfileEditSheet.swift` (rewrite, ~240 LOC) + `WebDAVServerProfileEditSheet+Sections.swift` (NEW, ~150 LOC: nameSection / endpointSection / passwordSection / testConnectionSection) + `WebDAVProfileListViewModel+Editor.swift` (NEW, ~180 LOC: addProfile / updateProfile / savePassword / deletePassword / testConnection + WebDAVTestConnectionError + validatedServerURL shared static helper) + `WebDAVServerProfileStore.updateIfExists(_:)` single-hop atomic update. Bug #184 pattern: add-mode hides Save Password / Delete Password / Test Connection buttons and shows promoted footnote notes; edit-mode shows the real buttons. WebDAVError → LocalizedError conformance gives specific Test Connection failure messages (authenticationFailed → "check the username and password", httpError(405) → "Server doesn't support WebDAV PROPFIND ... verify this URL points at a WebDAV endpoint"). Behavioral tier; full feature reachable from Settings. **Codex MCP audit `019e26d6` (3 rounds)**: round 1 = 1 High (URL validator weak — accepted `https://` hostless) + 4 Medium (updateProfile stale-guard, WebDAVError generic, testConnection whitespace credentials, name autofill missing) + 1 Low (direct KeychainService in view bypasses test injection); all 6 fixed. Round 2 = 2 new Medium (updateProfile race across 2 actor hops, password whitespace persisted verbatim); both fixed via `updateIfExists` + trim-before-persist. Round 3 = **zero findings, ship-as-is**. Test gate: **31/31 new tests** pass (`WebDAVProfileListViewModelEditorTests`) covering all 5 editor methods + URL validator (6) + WebDAVError messages (3) + round-1 fixes (3) + keychain VM-probe (2) + round-2 fixes (4). Adjacent suites (`WebDAVProfileListViewModelTests` + `WebDAVServerProfileStoreTests` + `WebDAVServerProfileTests` + `WebDAVProviderTests`) all green. Audit log: `.claude/codex-audits/feat-feature-52-wi-4b-profile-editor-audit.md`. **WI-5 shipped 2026-05-14**: foundational cleanup. Removed the legacy single-server credentials form from `WebDAVSettingsView` entirely (Server URL / Username / Password fields + Test Connection + Save / Remove Credentials buttons + supporting state vars + helper methods + 3 keychain-account constants + the `keychain:` init parameter). Migrated the 2 remaining production call sites (`WebDAVSettingsView.refreshBackupVMIfNeeded` + `LibraryView`'s row-tap-to-enqueue observer) from legacy sync `WebDAVProviderFactory.make(keychain:)` / `makeRequestBuilder(keychain:)` to the async profile-store-backed variants from WI-3. Deleted those now-unused sync factory variants (~80 LOC removed; factory header comment rewritten to reflect post-WI-5 state). Wired `WebDAVServerProfileStore.writePassword(_:for:)` + `deletePassword(for:)` to post `.webdavProfilesDidChange` so observers re-evaluate active credentials on password-only mutations (round-2 fix — without this, password changes from the editor sheet would leave the backup section stale). Added `WebDAVSettingsView` `.onReceive(.webdavProfilesDidChange)` to refresh the backup VM on add/switch/password-update from the multi-profile list. Added 3 new UserDefaults keys (`com.vreader.webdav.profiles`, `.activeProfileID`, `.profilesMigrated.v1`) to `TestSeeder.knownPreferenceKeys` for `--reset-preferences` test isolation. Doc-synced `docs/architecture.md` (3 rows: `WebDAVProviderFactory` is profile-store-only now; `WebDAVServerProfileStore` backing is `UserDefaults` / `KeychainService`; `WebDAVProfileMigrator` added). Codex MCP audit `019e26ec` 4 rounds: round 1 = 1 High (source-of-truth divergence — surgical loadCredentials change introduced inconsistency with save/clear paths) + 1 Medium (flat-keychain fallback still in view layer) + 1 Low (arch.md backing column); resolved by escalating the WI-5 scope to remove the legacy form entirely. Round 2 = 1 Medium (writePassword/deletePassword didn't post notification) + 2 Low (stale arch.md rows + orphan `@Environment(\.dismiss)`). Round 3 = 2 Low (stale comments in VReaderApp.swift and WebDAVProviderFactory.swift referencing removed legacy variants). Round 4 = 1 Low (this tracker row narrative). All findings fixed. Test gate: 33/33 editor tests pass (added 2 new `webdavProfilesDidChange` notification-on-password-mutation tests) + 122/122 across 7 WebDAV-adjacent suites all green. Audit log: `.claude/codex-audits/feat-feature-52-wi-5-cleanup-audit.md`. **WI-6 round-1 partial 2026-05-14** (`dev-docs/verification/feature-52-20260514.md`, result=**partial**) on merged-main 942703b (v3.21.61, build 338) against iPhone 17 Pro Sim (iOS 26.5) + 2 test rclone WebDAV servers on 127.0.0.1:8082-8083 (live ~/vreader-webdav-data not touched). **UI-shape verification PASS**: WI-5 cleanup confirmed (WebDAV Backup screen has zero legacy single-server form remnants — just Servers nav-link + Network policy section); WI-4a list view renders with toolbar `+` / radio-row active marker / pencil-edit affordance; WI-4b editor add-mode shows the bug #184 pattern (Save Password / Test Connection buttons hidden, footnote notes shown instead); edit-mode shows the real buttons. Prior-session profile persisted across `vreader-debug://reset?backups=true` (UserDefaults-backed; library-scoped reset doesn't clear WebDAV keys — matches design). 4 screenshot artifacts. **DEFERRED to round-2**: acceptance (a) switch-active + per-profile backup observation, (c) live delete-active-profile fallback on backup section, (d) full backup+restore roundtrip — all blocked on CU `type` not reaching iOS Simulator text fields this session (CU/Simulator integration limitation, not a vreader defect). Three round-2 unblock paths documented in the evidence file: clipboard fast-path (`clipboardWrite` grant + cmd+v), pre-launch UserDefaults+Keychain seed, or a new `vreader-debug://webdav?profile=<json>&password=<pw>` URL. Status stays **IN PROGRESS**. **WI-6 round-2 final acceptance 2026-05-15** (`dev-docs/verification/feature-52-20260515.md`, result=**pass**) on merged-main 891c616 (v3.21.61, build 338) against iPhone 17 Pro Sim (iOS 26.5) + 2 test rclone WebDAV servers on 127.0.0.1:8082-8083. Unblock path: CU clipboard fast-path (`request_access` with `clipboardWrite: true` + `cmd+v` paste keystroke into focused TextFields) — reaches all fields where `type` couldn't. Acceptance: (a) **PASS** — two distinct backup zips landed in their respective server data dirs (`/tmp/vreader-test-webdav-a/.../2026-05-14T20-10-23Z_d6c6c5ce.vreader.zip` when A active; `/tmp/vreader-test-webdav-b/.../2026-05-14T20-12-21Z_d0348cab.vreader.zip` when B active); each server's dir empty when the other was active. (b) covered by 6 `WebDAVProfileMigratorTests` unit tests; live migration not exercisable post-WI-5 (no way to write pre-WI-5 flat-keychain state from a post-WI-5 install). (c) **PASS** — swipe-delete active row → confirmation alert with `"Server B (test)" is currently the active backup server. Deleting it leaves no active server until you switch to another or add one.` copy → Delete → plist `activeProfileID` key REMOVED, profiles array reduced by 1 (Server A preserved as inactive); WebDAV Backup screen Backup section disappears, "Add a WebDAV server above to enable backup." footnote shown. (d) **PASS (backup half)** — Test Connection returned "Connected — the WebDAV server responded successfully." against real rclone Server A; backup roundtrip uploaded zip + per-book blob to correct active-server-only directory via real PROPFIND + auth + MKCOL + PUT; restore button is wired but not explicitly clicked this round (covered by `WebDAVProviderTests` integration). 7 round-2 screenshot artifacts. **Bug discovered + filed** (per scope guardrail, NOT fixed): WebDAVServerProfileListView shows the empty-state empty-state after any mutation (Save, Add, setActive, delete) until view is dismissed and re-presented — underlying UserDefaults persistence is correct (verified via plist), SwiftUI list view doesn't re-render on `.webdavProfilesDidChange`. Status → **VERIFIED**. GH #565 closing. |
+docs/features.md:158:| 104| **Android Spike A — canonical cross-platform identity conformance** (the gate; ADR-0001 Risk 1). Decomposed from #102. Prove/decide deterministic book identity across Swift and Kotlin BEFORE promising library/backup interop: a `contracts/` canonical spec (fingerprint/locator/cache-key/backup-format distilled from the Swift reference), a libmobi cross-platform conversion-determinism harness, a Readium locator round-trip harness, the canonical-identity DECISION (exact-match / normalization / platform-local+mapping), legally-clean golden vectors + a dual-platform (Swift+Kotlin) conformance command. Library/CLI harnesses, NOT an Android app. **Depends on #103 (Phase 0 owns `contracts/` routing).** | contracts/ (new), contracts/conformance/{swift,kotlin}/, contracts/harness/ | High | VERIFIED | Decomposed 2026-06-16 from #102 (ADR-0001 Spike A). Plan: `dev-docs/plans/20260616-feature-104-android-spikeA-identity-conformance.md` (Gate-1 drafted; awaiting Gate-2 audit). **HELD with #102.** WI-1/2 Swift-only (doable without Android toolchain); WI-3+ need NDK+Kotlin/JVM (shared with Spike B). A conversion/locator DIVERGENCE is a successful spike result (it sets the canonical model), not a failure. **PLANNED 2026-06-16** (Gate-2 clean, Codex `019ed111`→`019ed122`); **IN PROGRESS 2026-06-17** — WI-1 `contracts/` canonical spec (README + identity/{fingerprint,locator,cache-key,backup-format}.md distilled from the Swift reference) done. WI-2 (Swift conformance, PR #1708→) + WI-5 SEEDED: dual-platform identity conformance lane DONE for fingerprint + cache-key — shared `contracts/vectors/`, Swift suite (vreaderTests/Contracts) + Kotlin suite (contracts/conformance/kotlin, pure Kotlin/JVM) both GREEN via `contracts/conformance/run.sh`. **Toolchain INSTALLED 2026-06-17** (JDK17, Kotlin 2.4, Android SDK platform-35 + NDK 29 + CMake, Gradle 9.5 — verified end-to-end). **DONE+VERIFIED 2026-06-17** — WI-4 added the **engine-neutral `Locator.canonicalJSON` cross-platform conformance** (Swift `Locator.canonicalJSON()` + a Kotlin `CanonicalLocator` reference impl produce a byte-identical canonical string for one shared `contracts/vectors/locator.json` — both suites GREEN), and the **canonical-identity DECISION** (`contracts/identity/DECISION.md`): exact-match for native fingerprint + cache-key + `Locator.canonicalJSON`; **source-bytes (not converted-EPUB)** for converted-Kindle cross-platform identity (the iOS `MobiEPUBConverter` is deterministic+content-addressed but pipeline-specific → source-bytes is the robust canonical key, NDK byte-identity harness off-critical-path); **CFI lossy-fallback** (resume on progression + text quotes; corroborated by #105 WI-3's ~2-paragraph fragment-restore approximation). All 4 acceptance criteria met. Evidence `dev-docs/verification/feature-104-20260617.md`. GH: #1702. |
+docs/features.md:159:| 105| **Android Spike B — CJK WebView reader benchmark** (instrumentation-first; ADR-0001 Risk 2). Decomposed from #102. Measure Readium-Kotlin 3.3.0 on a real 1000+-spine CJK novel (道诡异仙) — scroll smoothness/jank, memory+eviction over a long sweep, renderer stability, CFI+selection anchor restore — BEFORE committing to the WebView-engine plan. Throwaway harness module, NOT the product app; benchmark/instrumentation-driven, NOT UI-automation (the iOS verify stack doesn't transfer). Secondary deliverable: a minimally-automatable Android verification recipe. **Depends on #103 (Phase 0 must gate `spikes/` first); independent of #104, can run in parallel once #103 lands.** | spikes/android-reader-bench/ (harness root picked), dev-docs/verification/feature-105-* | High | VERIFIED | Decomposed 2026-06-16 from #102 (ADR-0001 Spike B). Plan: `dev-docs/plans/20260616-feature-105-android-spikeB-cjk-reader-benchmark.md` (Gate-1 drafted; awaiting Gate-2 audit). **HELD with #102.** All WIs gate on Android SDK/NDK+emulator+Readium-Kotlin toolchain (UNVERIFIED on the host — bring-up is WI-1). A jank/memory-unacceptable result reopens the engine strategy (a legitimate spike outcome). **PLANNED 2026-06-16** (Gate-2 clean, Codex `019ed111`); **IN PROGRESS 2026-06-17** — WI-1: toolchain + emulator stood up (the ADR-UNVERIFIED 'can the cron drive an Android device' = now YES); a minimal Android instrumentation test (`spikes/android-reader-bench`) builds + installs + RUNS on the android-35 arm64 emulator. **DONE+VERIFIED 2026-06-17** — all 4 WIs merged (WI-1 harness v3.66.24 PR#1710; WI-2 scroll/memory/stability bench v3.66.25 PR#1711, Codex 3-round; WI-3 anchor/selection restore v3.66.26 PR#1712, Codex 3-round; WI-4 verdict). **Verdict: Readium-Kotlin 3.3.0 scroll mode is VIABLE as the Android v1 reader engine — WebView-engine plan CONFIRMED, NOT reopened** (60fps / 0.23% jank; renderer memory bounded with working eviction, ~1.1GB high-water → 580-870MB oscillation, zero OOM; zero renderer crashes; chapter + Locator-JSON + selection restore faithful). Two recorded Phase-3 hardening obligations (not blockers): renderer ~1.1GB high-water (low-RAM watch-item) + fragment-restore ~2-paragraph CJK precision. Evidence `dev-docs/verification/feature-105-20260617.md`; ADR-0001 Spike-B amendment added; recipe `spikes/android-reader-bench/run-bench.sh`. GH: #1703. |
+docs/features.md:184:| 131| **Android bilingual interlinear reading** (parity box D) — per-book toggle renders each source paragraph followed by an AI-backed translation (muted, accent border), cached to disk; Android parity of iOS #56/#100, building on the #118 AI foundation. | android/app/.../bilingual/* + reader hosts + ReaderBottomChrome/More-menu entry | Medium | PLANNED | Deps:[feat:#132, feat:#134] (#132 top chrome + #134 More menu VERIFIED; #129 TXT reader VERIFIED = straight edit). **AI-config reachability FOLDED IN (2026-07-12, user decision): the #136 spin-out is CLOSED (GH #1976, not-planned) — the Gate-2 audit + committed design (reader-ai-provider-entry.md / reader-ai-readiness.md) proved the ONLY designed Android AI-config reader surface is the bilingual-coupled "Variant A" AI Providers sheet reached from the bilingual Set-up button; NO standalone AI-config entry is designed. #131 now owns it: AppContainer AiProviderStore DI + the Variant A AI Providers sheet (reuse #118 AiProviderListScreen/AiProviderEditSheet verbatim, pushed in the bilingual flow, pop-back-on-save) as its own WIs.** Plan `dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md` (Gate-1 v4, 13 WIs: WI-0 Readium JS-injection spike w/ go-no-go + navigator-race contract; WI-1..4a foundation/service; WI-4b shared DI incl. AiProviderStore-into-AppContainer; WI-5/6 VM state+prefetch+single-flight; WI-7a Compose UI; WI-7b conditional EPUB DOM-injection adapter; WI-AIP Variant-A in-bilingual AI Providers sheet [reuse #118 AiProviderListScreen/EditSheet verbatim, pop-back-on-Save]; WI-8 TXT/MD host; WI-9 entry wiring+acceptance). **Style DESCOPED v1** (user decision 2026-07-12): keep provider/model/granularity, drop the bilingual Style control (box D flips done for provider/model/granularity + a Style-descope follow-up amendment; a Style+Granularity single sheet is not depicted anywhere = the one open design gate). Design authority (landed, rule 51): vreader-bilingual.jsx (granularity-only setup sheet) + vreader-reader.jsx pill + vreader-more.jsx toggle. **Gate-2 round-2 = REDESIGN resolved (v3): TXT/MD document-global segment ranges (H1); EPUB translatePreSegmented + count-keyed cache + direct-block prefetch (H2); #136 spun out + Style descoped (H3); WI-0 go/no-go + race contract (M1); EPUB DOM-injection NOT Compose body (M2); DI/factory WI reordered (M3); Room 8->9 MIGRATION_8_9 (M4). Gate-2 round-3 = block-recommended (0 Critical; H1 TXT/MD final-chunk drop [offsetForChunk clamps the last chunk -> empty span; fix endExclusive = if(i+1<chunkCount) offsetForChunk(i+1) else text.length + half-open ranges + EOF tests]; H2 per-segment Text nodes break the live one-TextLayoutResult-per-chunk selection/highlight model -> needs an offset-preserving render/layout design + enabled-mode selection/highlight/read-aloud/annotation/MD tests; M1 EPUB direct-block flow not wired e2e; M2 cancellation must handle both native + typed Cancelled + a per-unit single-flight registry; M3 AiRequest.model needs the live ifBlank{kind.defaultModel} fallback). v4 rewrite (13 WIs) resolving those + folding in the designed Variant-A AI-config path (#136 CLOSED). NEW rule-51 design gate: sentence-granularity interlinear RENDER is undepicted (only paragraph interlinear is designed in vreader-bilingual.jsx BilingualPageContent) -> v1 ships the paragraph render + the granularity control, Sentence selection falls back to paragraph render (cache still granularity-keyed); a future sentence-render needs its own design bundle. Gate-2 round-4 pending.** GH: #1923 |
+
+exec
+/bin/zsh -lc "nl -ba android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt | sed -n '1,180p' && nl -ba android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt | sed -n '205,275p;345,490p;600,635p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+     1	// Purpose: feature #124 WI-3 — drives the TXT custom selection. Each visible chunk registers its
+     2	// TextLayoutResult + LayoutCoordinates; the controller converts a pointer (LazyColumn-local) → window
+     3	// space → the hit chunk's local space → rendered offset → SOURCE offset (TxtSourceOffsets), and resolves
+     4	// a word boundary at long-press. Selection is a SOURCE Utf16Range; the in-progress range renders as an
+     5	// accent wash. Kept off the Activity so the geometry is isolated; the Activity wires the gesture +
+     6	// popover + persistence.
+     7	package com.vreader.app.reader
+     8	
+     9	import androidx.compose.runtime.Stable
+    10	import androidx.compose.ui.geometry.Offset
+    11	import androidx.compose.ui.layout.LayoutCoordinates
+    12	import androidx.compose.ui.layout.boundsInWindow
+    13	import androidx.compose.ui.text.TextLayoutResult
+    14	import kotlinx.coroutines.flow.MutableStateFlow
+    15	import kotlinx.coroutines.flow.StateFlow
+    16	import kotlinx.coroutines.flow.asStateFlow
+    17	
+    18	@Stable
+    19	class TxtSelectionController(
+    20	    private val doc: TxtDocument,
+    21	    // feature #125 — format-aware rendered↔source bridge. The chunk TextLayoutResults are built from the
+    22	    // RENDERED text, so getOffsetForPosition/getWordBoundary/getCursorRect speak rendered coords; the
+    23	    // mapper converts them to/from the SOURCE coords selections + highlights are stored in. TXT = identity.
+    24	    private val mapper: ChunkTextMapper,
+    25	) {
+    26	    private data class ChunkInfo(val layout: TextLayoutResult, val coords: LayoutCoordinates)
+    27	    /** A resolved hit: the chunk index/info + the chunk-local rendered offset + the absolute source offset. */
+    28	    private data class Hit(val chunkIndex: Int, val info: ChunkInfo, val rendered: Int, val source: Int)
+    29	    private val chunks = HashMap<Int, ChunkInfo>()
+    30	    private var lazyCoords: LayoutCoordinates? = null
+    31	    // the initial word selected at long-press — the FIXED anchor; drags extend relative to it (never drop it).
+    32	    private var anchorRange: Utf16Range? = null
+    33	
+    34	    private val _selection = MutableStateFlow<Utf16Range?>(null)
+    35	    val selection: StateFlow<Utf16Range?> = _selection.asStateFlow()
+    36	
+    37	    fun setLazyCoords(coords: LayoutCoordinates) { lazyCoords = coords }
+    38	    fun registerChunk(index: Int, layout: TextLayoutResult, coords: LayoutCoordinates) {
+    39	        chunks[index] = ChunkInfo(layout, coords)
+    40	    }
+    41	    fun unregisterChunk(index: Int) { chunks.remove(index) }
+    42	
+    43	    /** Pointer (LazyColumn-local) → the hit chunk + chunk-local rendered offset + source offset. The hit
+    44	     *  chunk is used for BOTH the source mapping AND word-boundary lookup (avoids a chunk-boundary shift).
+    45	     *  [allowNearest]: for a DRAG, fall back to the nearest chunk when the point is past the text; for a
+    46	     *  TAP-to-edit, require the point to actually be inside a text chunk (else a margin tap could edit). */
+    47	    private fun hitAt(localPoint: Offset, allowNearest: Boolean = true): Hit? {
+    48	        val lz = lazyCoords ?: return null
+    49	        if (chunks.isEmpty()) return null
+    50	        val windowPoint = lz.localToWindow(localPoint)
+    51	        val hit = chunks.entries.firstOrNull { it.value.coords.boundsInWindow().contains(windowPoint) }
+    52	            ?: (if (allowNearest) chunks.entries.minByOrNull { verticalDistance(it.value.coords.boundsInWindow(), windowPoint) } else null)
+    53	            ?: return null
+    54	        val chunkLocal = hit.value.coords.windowToLocal(windowPoint)
+    55	        val rendered = hit.value.layout.getOffsetForPosition(chunkLocal).coerceIn(0, hit.value.layout.layoutInput.text.length)
+    56	        // rendered cursor → chunk-local source (empty rendered range maps to the source edge) → global source.
+    57	        val localSource = mapper.renderedRangeToSource(hit.key, Utf16Range(rendered, rendered)).startInclusive
+    58	        return Hit(hit.key, hit.value, rendered, doc.offsetForChunk(hit.key) + localSource)
+    59	    }
+    60	
+    61	    /** Long-press: select the word under [localPoint] (word boundary in the HIT chunk, mapped to source). */
+    62	    fun beginAt(localPoint: Offset) {
+    63	        val hit = hitAt(localPoint) ?: return
+    64	        val word = hit.info.layout.getWordBoundary(hit.rendered)   // RENDERED coords in the hit chunk
+    65	        val base = doc.offsetForChunk(hit.chunkIndex)
+    66	        // rendered word → chunk-local source span → global source (markers stripped for MD).
+    67	        val src = mapper.renderedRangeToSource(hit.chunkIndex, Utf16Range(word.start, word.end))
+    68	        val start = base + src.startInclusive
+    69	        val end = base + src.endExclusive
+    70	        val range = if (end > start) Utf16Range(start, end) else Utf16Range(hit.source, (hit.source + 1).coerceAtMost(doc.text.length))
+    71	        anchorRange = range
+    72	        _selection.value = range
+    73	    }
+    74	
+    75	    /** Drag: extend relative to the FIXED [anchorRange] (the initial word) — extending before it grows the
+    76	     *  start, after it grows the end, inside it keeps the word. The anchor word is never dropped. */
+    77	    fun extendTo(localPoint: Offset) {
+    78	        val anchor = anchorRange ?: return
+    79	        val off = (hitAt(localPoint) ?: return).source.coerceIn(0, doc.text.length)
+    80	        _selection.value = when {
+    81	            off <= anchor.startInclusive -> Utf16Range(off, anchor.endExclusive)
+    82	            off >= anchor.endExclusive -> Utf16Range(anchor.startInclusive, off)
+    83	            else -> anchor
+    84	        }
+    85	    }
+    86	
+    87	    fun clear() { _selection.value = null; anchorRange = null }
+    88	
+    89	    /** The current selection range, or null. */
+    90	    fun currentRange(): Utf16Range? = _selection.value
+    91	
+    92	    /** Resolve a tap (LazyColumn-local) to a SOURCE offset, for hit-testing an existing highlight. Strict
+    93	     *  (no nearest-chunk fallback) so a tap in the margin/blank space doesn't edit a nearby highlight. */
+    94	    fun resolveSourceOffset(localPoint: Offset): Int? = hitAt(localPoint, allowNearest = false)?.source
+    95	
+    96	    /** Convert a LazyColumn-local point to window coords (to anchor the edit popover at a tap). */
+    97	    fun toWindow(localPoint: Offset): Offset? = lazyCoords?.localToWindow(localPoint)
+    98	
+    99	    /** Whether the current selection is a persist-worthy range (in-bounds, non-empty, surrogate-safe). */
+   100	    fun isCurrentSelectionValid(): Boolean = _selection.value?.let { TxtSelection.isValid(it, doc.text) } ?: false
+   101	
+   102	    /** The VISIBLE (rendered) substring of the current selection — for the popover / copy / share / UI.
+   103	     *  For TXT this equals the source; for MD it's the marker-stripped rendered text the user sees. */
+   104	    fun selectedVisibleText(): String? {
+   105	        val r = _selection.value ?: return null
+   106	        if (r.isEmpty || r.endExclusive > doc.text.length) return null
+   107	        val sb = StringBuilder()
+   108	        for (cr in TxtSourceOffsets.chunkRanges(doc, r)) {
+   109	            sb.append(mapper.visibleText(cr.chunkIndex, mapper.sourceRangeToRendered(cr.chunkIndex, cr.local)))
+   110	        }
+   111	        return sb.toString().ifEmpty { null }
+   112	    }
+   113	
+   114	    /** The SOURCE (markdown/raw) substring of the current selection — for the locator textQuote + anchor. */
+   115	    fun selectedSourceText(): String? {
+   116	        val r = _selection.value ?: return null
+   117	        if (r.isEmpty || r.endExclusive > doc.text.length) return null
+   118	        return doc.text.substring(r.startInclusive, r.endExclusive)
+   119	    }
+   120	
+   121	    /** The in-progress selection projected onto [chunkIndex] as a chunk-local RENDERED range, for the
+   122	     *  accent wash (`getPathForRange` speaks rendered coords). Source→rendered via the mapper (MD). */
+   123	    fun selectionForChunk(chunkIndex: Int): Utf16Range? {
+   124	        val r = _selection.value ?: return null
+   125	        val localSource = TxtSourceOffsets.chunkRanges(doc, r).firstOrNull { it.chunkIndex == chunkIndex }?.local ?: return null
+   126	        return mapper.sourceRangeToRendered(chunkIndex, localSource)
+   127	    }
+   128	
+   129	    /** The window-space point just below the selection's end, to anchor the popover. */
+   130	    fun selectionEndAnchorWindow(): Offset? {
+   131	        val r = _selection.value ?: return null
+   132	        val endChunk = doc.chunkForOffset((r.endExclusive - 1).coerceAtLeast(0)).coerceIn(0, doc.chunkCount - 1)
+   133	        val info = chunks[endChunk] ?: return null
+   134	        val base = doc.offsetForChunk(endChunk)
+   135	        // source end → chunk-local source → rendered cursor (end-affinity) for getCursorRect.
+   136	        val localSourceEnd = (r.endExclusive - base).coerceAtLeast(0)
+   137	        val renderedEnd = mapper.renderedCursorForSourceEnd(endChunk, localSourceEnd).coerceIn(0, info.layout.layoutInput.text.length)
+   138	        val rect = info.layout.getCursorRect(renderedEnd)
+   139	        return info.coords.localToWindow(Offset(rect.left, rect.bottom))
+   140	    }
+   141	
+   142	    private fun verticalDistance(bounds: androidx.compose.ui.geometry.Rect, p: Offset): Float = when {
+   143	        p.y < bounds.top -> bounds.top - p.y
+   144	        p.y > bounds.bottom -> p.y - bounds.bottom
+   145	        else -> 0f
+   146	    }
+   147	}
+   205	                    }
+   206	                }
+   207	                // feature #129 — the live Display settings (theme/font/size/spacing/margin). NULL until
+   208	                // the DataStore's first emission; the reader body is withheld until then (Gate-4 Medium:
+   209	                // rendering defaults first would flash the wrong theme/typography for a user with stored
+   210	                // non-default settings). The empty loading scaffold is the only pre-emission surface.
+   211	                val settingsOrNull by container.readerSettingsStore.settings
+   212	                    .collectAsStateWithLifecycle(initialValue = null)
+   213	                val gated = if (settingsOrNull == null && state !is TxtUiState.Failed) TxtUiState.Loading else state
+   214	                when (val s = gated) {
+   215	                    is TxtUiState.Failed -> LaunchedEffect(Unit) { finish() }
+   216	                    is TxtUiState.Loading -> TxtLoadingScaffold((settingsOrNull ?: ReaderSettings()).theme)
+   217	                    is TxtUiState.Loaded -> {
+   218	                        // non-null by the gate above (Loaded is unreachable pre-emission).
+   219	                        val displaySettings = checkNotNull(settingsOrNull)
+   220	                        val listState = rememberLazyListState(initialFirstVisibleItemIndex = s.initialIndex)
+   221	                        // onStop flush — captures the live list state + book/document.
+   222	                        SideEffect {
+   223	                            flushPosition = { savePosition(s.book, s.document, listState.firstVisibleItemIndex) }
+   224	                        }
+   225	                        // Debounced steady-state save as the user scrolls.
+   226	                        LaunchedEffect(listState, s.document) {
+   227	                            snapshotFlow { listState.firstVisibleItemIndex }
+   228	                                .drop(1)
+   229	                                .debounce(1_000)
+   230	                                .collect { savePosition(s.book, s.document, it) }
+   231	                        }
+   232	                        // feature #121 — read-aloud. The VM drives the designed control bar; the spoken
+   233	                        // sentence is washed + auto-scrolled (TXT). Chunking is LAZY + off-main (only
+   234	                        // on Read aloud) so a large book never scans the whole text on composition.
+   235	                        val ttsVm: TtsViewModel = viewModel(factory = viewModelFactory {
+   236	                            initializer { TtsViewModel(AndroidTtsEngine(applicationContext)) }
+   237	                        })
+   238	                        val tts by ttsVm.state.collectAsStateWithLifecycle()
+   239	                        val ttsScope = rememberCoroutineScope()
+   240	                        LaunchedEffect(ttsVm) { ttsVm.intents.collect { launchTtsIntent(it) } }
+   241	                        // pause read-aloud when the reader is backgrounded (no MediaSession by design —
+   242	                        // plan §OOS); the engine is shut down on Activity finish via the VM's onCleared.
+   243	                        val lifecycleOwner = LocalLifecycleOwner.current
+   244	                        DisposableEffect(lifecycleOwner) {
+   245	                            // guard against ON_STOP firing on a rotation (config change) — the VM is
+   246	                            // retained across rotation, so don't pause when we're just reconfiguring.
+   247	                            val obs = LifecycleEventObserver { _, e -> if (e == Lifecycle.Event.ON_STOP && !isChangingConfigurations) ttsVm.pause() }
+   248	                            lifecycleOwner.lifecycle.addObserver(obs)
+   249	                            onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
+   250	                        }
+   251	                        val active = tts.phase != TtsPhase.idle
+   252	                        val spokenChunk = if (tts.phase == TtsPhase.speaking) s.document.chunkForOffset(tts.charStart) else -1
+   253	                        // auto-scroll ONLY when the spoken chunk is off-screen — so a small manual scroll
+   254	                        // while listening isn't fought on every sentence.
+   255	                        LaunchedEffect(spokenChunk) {
+   256	                            if (spokenChunk >= 0 && listState.layoutInfo.visibleItemsInfo.none { it.index == spokenChunk }) {
+   257	                                runCatching { listState.animateScrollToItem(spokenChunk) }
+   258	                            }
+   259	                        }
+   260	                        var showSpeed by remember { mutableStateOf(false) }
+   261	                        var showVoice by remember { mutableStateOf(false) }
+   262	                        var starting by remember { mutableStateOf(false) }   // guards double-tap → double-chunk
+   263	                        // snapshot the voice options once when the sheet opens (not every recomposition).
+   264	                        val voiceList = remember(showVoice) { if (showVoice) ttsVm.voiceListState() else com.vreader.app.tts.TtsVoiceListState() }
+   265	
+   266	                        // feature #122 — reading-stats: track this session (the process-singleton tracker
+   267	                        // survives rotation) + show the auto-fading session pill.
+   268	                        val tracker = container.readingTimeTracker
+   269	                        val bookKey = s.book.fingerprintKey
+   270	                        val sessionSeconds by tracker.sessionSeconds.collectAsStateWithLifecycle()
+   271	
+   272	                        // feature #124/#125 — stored highlights → per-chunk washes. Enabled for TXT AND MD
+   273	                        // (#125 added the MarkdownChunkTextMapper source-offset map, so MD is no longer
+   274	                        // render-only). The mapper is the single rendered↔source bridge + render owner,
+   275	                        // shared by the wash, the selection controller, and the body.
+   345	                        // snippet around the stored char offset — the host owns the decoded text). The current
+   346	                        // position is the top-visible chunk's char offset → a plain canonical Locator.
+   347	                        val previewProvider = remember(s.document) { txtBookmarkPreviewProvider(s.document) }
+   348	                        val dateRenderer = remember { bookmarkDateRenderer() }
+   349	                        val currentCanonical = remember(s.book) {
+   350	                            { off: Int -> txtBookmarkLocator(s.book, off) }
+   351	                        }
+   352	                        val bookmarkRecords by remember(bookKey) { container.annotationsRepository.bookmarks(bookKey) }
+   353	                            .collectAsStateWithLifecycle(emptyList())
+   354	                        val bookmarkRows = remember(bookmarkRecords, s.book) {
+   355	                            bookmarkRowItems(bookmarkRecords, s.book.originalFormat, tocIndex = null, previewProvider = previewProvider, dateRenderer = dateRenderer)
+   356	                        }
+   357	                        // The live top-visible offset → canonical (recomputed on scroll; the toggle/presence read it).
+   358	                        val liveOffset = s.document.offsetForChunk(listState.firstVisibleItemIndex)
+   359	                        val liveCanonical = remember(s.book, liveOffset) { txtBookmarkLocator(s.book, liveOffset) }
+   360	                        val isBookmarked by produceState(false, liveCanonical, bookmarkRecords) {
+   361	                            value = runCatching { container.annotationsRepository.isBookmarked(bookKey, liveCanonical) }.getOrDefault(false)
+   362	                        }
+   363	
+   364	                        // feature #133 WI-10 — the in-book search VM (ONE per reader session): built from the
+   365	                        // ALREADY-decoded reader text so a search never re-reads the file, scoped to a
+   366	                        // composition-lifetime scope so its collectors stop when the reader leaves. onDispose
+   367	                        // runs the VM's documented lifecycle (closeAllEpubCursors via onCleared) — TXT has no
+   368	                        // EPUB cursors, but the contract holds uniformly. Hidden only when the index-state gate
+   369	                        // reports Unsupported (a TXT/MD book skipped as unsupported); otherwise the Search icon
+   370	                        // is present.
+   371	                        val searchScope = rememberCoroutineScope()
+   372	                        val inBookSearchVm = remember(bookKey, s.book.originalFormat) {
+   373	                            container.inBookSearchViewModel(
+   374	                                bookKey = bookKey,
+   375	                                format = s.book.originalFormat,
+   376	                                decodedText = s.document.text,
+   377	                                contentSHA256 = s.book.contentSHA256,
+   378	                                fileByteCount = s.book.fileByteCount,
+   379	                                coroutineScope = searchScope,
+   380	                            )
+   381	                        }
+   382	                        DisposableEffect(inBookSearchVm) { onDispose { inBookSearchVm.onCleared() } }
+   383	                        val inBookSearchState by inBookSearchVm.state.collectAsStateWithLifecycle()
+   384	                        var showSearch by remember(bookKey) { mutableStateOf(false) }
+   385	
+   386	                        TxtReaderChrome(
+   387	                            theme = displaySettings.theme,
+   388	                            title = s.title,
+   389	                            chromeState = chromeState,
+   390	                            annotations = annotationsSnapshot,
+   391	                            onBack = ::finish,
+   392	                            bookDetails = bookDetails,
+   393	                            onShareBook = { com.vreader.app.reader.share.shareBook(this@TxtReaderActivity, s.book) },
+   394	                            onCopyFingerprint = { copyFingerprint(it) },
+   395	                            // feature #135 WI-7 — the top-bar bookmark toggle + Bookmarks-tab rows + TXT jump.
+   396	                            isCurrentBookmarked = isBookmarked,
+   397	                            onToggleBookmark = {
+   398	                                container.appScope.launch {
+   399	                                    runCatching { container.annotationsRepository.toggleBookmark(bookKey, title = null, locator = liveCanonical) }
+   400	                                }
+   401	                            },
+   402	                            currentLocator = liveCanonical,
+   403	                            bookmarks = bookmarkRows,
+   404	                            // TXT jump: scroll to the bookmark's char offset via the existing chunk scroll seam
+   405	                            // (the same path resume + the annotation jump use). Out-of-range → Failed (sheet stays open).
+   406	                            onJumpBookmark = { record ->
+   407	                                val target = txtBookmarkScrollTarget(record.locator.charOffsetUTF16, s.document.text.length)
+   408	                                if (target == null) {
+   409	                                    JumpResult.Failed
+   410	                                } else {
+   411	                                    ttsScope.launch { listState.scrollToItem(s.document.chunkForOffset(target)) }
+   412	                                    JumpResult.Succeeded
+   413	                                }
+   414	                            },
+   415	                            // TXT/MD jump: scroll to the annotation's UTF-16 offset via the existing chunk
+   416	                            // scroll seam (the same path used by resume + scrubber).
+   417	                            onJumpToAnnotation = { item ->
+   418	                                ttsScope.launch {
+   419	                                    val target = annotationScrollOffset(item)
+   420	                                        .coerceIn(0, (s.document.text.length - 1).coerceAtLeast(0))
+   421	                                    listState.scrollToItem(s.document.chunkForOffset(target))
+   422	                                }
+   423	                            },
+   424	                            onShareAnnotations = { shareAnnotations(annotationsSnapshot) },
+   425	                            // feature #133 WI-10 — the Search entry + sheet. The icon is hidden only when the
+   426	                            // index-state gate says Unsupported (a skipped-unsupported TXT/MD book — no dead
+   427	                            // control); otherwise tapping it opens the sheet for THIS book.
+   428	                            onOpenSearch = if (inBookSearchState.hidesSearchEntry) null else { { showSearch = true } },
+   429	                            searchSheet = if (!showSearch) null else {
+   430	                                {
+   431	                                    InBookSearchSheet(
+   432	                                        theme = displaySettings.theme,
+   433	                                        bookTitle = s.title,
+   434	                                        state = inBookSearchState,
+   435	                                        query = inBookSearchState.query,
+   436	                                        onQueryChange = inBookSearchVm::onQueryChange,
+   437	                                        onPickRecent = inBookSearchVm::onPickRecent,
+   438	                                        // Resolve the tapped hit's canonical charOffsetUTF16 → scroll via the
+   439	                                        // EXISTING chunk-scroll seam (the same path resume / annotation / bookmark
+   440	                                        // jumps use). The WI-9 sheet's onJump is NON-suspend (JumpResult returns
+   441	                                        // synchronously), so — like the sibling annotation/bookmark jumps — the
+   442	                                        // range is validated UP FRONT (out-of-range/null → Failed, sheet stays
+   443	                                        // open, rule 51) and a valid target returns Succeeded optimistically while
+   444	                                        // the actual scroll runs on ttsScope; the launch is runCatching-guarded so
+   445	                                        // a scroll cancelled during teardown can't crash. The recent is committed
+   446	                                        // only on a valid result-open (the VM's commitSearch contract).
+   447	                                        onJump = { hit ->
+   448	                                            val off = hit.canonicalLocator?.charOffsetUTF16
+   449	                                            val target = txtBookmarkScrollTarget(off, s.document.text.length)
+   450	                                            if (target == null) {
+   451	                                                JumpResult.Failed
+   452	                                            } else {
+   453	                                                inBookSearchVm.commitSearch()
+   454	                                                ttsScope.launch { runCatching { listState.scrollToItem(s.document.chunkForOffset(target)) } }
+   455	                                                JumpResult.Succeeded
+   456	                                            }
+   457	                                        },
+   458	                                        onLoadMore = inBookSearchVm::loadMore,
+   459	                                        onDismiss = { inBookSearchVm.onDismiss(); showSearch = false },
+   460	                                    )
+   461	                                }
+   462	                            },
+   463	                            bottomBar = { (openContents, openNotes) ->
+   464	                                if (active) TtsControlBar(
+   465	                                    tts,
+   466	                                    onPlayPause = { if (tts.phase == TtsPhase.speaking) ttsVm.pause() else ttsVm.play() },
+   467	                                    onPrevious = ttsVm::previous, onNext = ttsVm::next, onStop = ttsVm::stop,
+   468	                                    onSpeed = { showSpeed = true }, onVoice = { showVoice = true },
+   469	                                    onInstallVoice = ttsVm::installVoiceData, onSystemTts = ttsVm::openSystemTts,
+   470	                                ) else ReaderBottomChrome(
+   471	                                    theme = displaySettings.theme,
+   472	                                    progress = TxtProgress.fraction(
+   473	                                        s.document.offsetForChunk(listState.firstVisibleItemIndex),
+   474	                                        s.document.text.length,
+   475	                                    ),
+   476	                                    displayPage = 0, totalPages = 0,   // TXT/MD scroll-only — no page labels
+   477	                                    onScrub = { f ->
+   478	                                        ttsScope.launch {
+   479	                                            val target = (f * s.document.text.length).toInt()
+   480	                                                .coerceIn(0, (s.document.text.length - 1).coerceAtLeast(0))
+   481	                                            listState.scrollToItem(s.document.chunkForOffset(target))
+   482	                                        }
+   483	                                    },
+   484	                                    onOpenDisplay = { showDisplaySheet = true },
+   485	                                    // #132 WI-6: the scaffold hands the Contents/Notes open callbacks in.
+   486	                                    // TXT/MD has no TOC → openContents is null (Contents control hidden);
+   487	                                    // openNotes opens the review sheet.
+   488	                                    onOpenContents = openContents,
+   489	                                    onOpenNotes = openNotes,
+   490	                                    extraSlot = {
+   600	        val path = book?.localFilePath ?: return TxtUiState.Failed
+   601	        if (book == null) return TxtUiState.Failed
+   602	        val decoded = TxtDecoder.decode(File(path))
+   603	        val document = TxtDocument.of(decoded.text)
+   604	        container.repository.markOpened(key, System.currentTimeMillis())
+   605	        val initial = computeInitialIndex(key, document)
+   606	        return TxtUiState.Loaded(book.title, document, book, initial)
+   607	    }
+   608	
+   609	    /** Restore: the saved legacy locator's charOffsetUTF16 → the chunk containing it. */
+   610	    private suspend fun computeInitialIndex(key: String, document: TxtDocument): Int {
+   611	        // In-memory cache first — a fast rotation / reopen sees the latest offset even
+   612	        // before the prior instance's async Room flush commits. Falls to durable Room.
+   613	        container.cachedOffset(key)?.let { return document.chunkForOffset(it) }
+   614	        val saved = container.repository.loadPosition(key) ?: return 0
+   615	        // ResumeResolver/ResumeTarget are in this package. A TXT position is a legacy
+   616	        // (non-Readium) envelope → Canonical; its charOffsetUTF16 is the anchor.
+   617	        val offset = (ResumeResolver.resolve(saved) as? ResumeTarget.Canonical)
+   618	            ?.locator?.charOffsetUTF16 ?: return 0
+   619	        return document.chunkForOffset(offset)
+   620	    }
+   621	
+   622	    /** Enqueue the top-visible chunk's char offset; the lone writer persists it (latest-wins). */
+   623	    private fun savePosition(book: Book, document: TxtDocument, topIndex: Int) {
+   624	        val offset = document.offsetForChunk(topIndex)
+   625	        // Cache synchronously so an immediate reopen/rotation reads the latest position
+   626	        // even before the async Room write below commits.
+   627	        container.cacheOffset(book.fingerprintKey, offset)
+   628	        saveRequests.trySend(PendingSave(book, offset))
+   629	    }
+   630	
+   631	    /** Launch a system intent for a read-aloud one-shot, guarded by resolveActivity with fallbacks
+   632	     *  (there is no public Settings.ACTION_TTS_SETTINGS — fall back to accessibility / settings). */
+   633	    private fun launchTtsIntent(i: TtsIntent) {
+   634	        val candidates = when (i) {
+   635	            TtsIntent.InstallVoiceData -> listOf(android.content.Intent(TextToSpeech.Engine.ACTION_INSTALL_TTS_DATA))
+
+exec
+/bin/zsh -lc "nl -ba vreader/Services/AI/ChapterTranslationService.swift | sed -n '330,385p' && nl -ba vreader/ViewModels/BilingualReadingViewModel.swift | sed -n '120,185p' && nl -ba vreader/ViewModels/BilingualReadingViewModel+Prefetch.swift | sed -n '1,260p' && rg -n \"Deps:\\[feat:#132, feat:#134\\]|WI-AIP|WI-4b|setActive\\(savedId\\)|savedId|pop\" dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+   330	        segments: [String],
+   331	        targetLanguage: String,
+   332	        providerProfileID: UUID,
+   333	        config: ResolvedAIProviderConfig,
+   334	        style: TranslationStyle
+   335	    ) async throws -> [String] {
+   336	        guard !segments.isEmpty else { return [] }
+   337	        let chunks = ChapterTranslationChunker.chunk(
+   338	            segments: segments, maxCharsPerChunk: maxCharsPerChunk)
+   339	        var translated = [String](repeating: "", count: segments.count)
+   340	        // Bug #330: same graceful degradation as `translate` — a single chunk's
+   341	        // failure leaves its segments source-only; an all-chunks failure surfaces
+   342	        // the error.
+   343	        var anyChunkSucceeded = false
+   344	        var lastChunkError: Error?
+   345	        for chunk in chunks {
+   346	            do {
+   347	                try Task.checkCancellation()
+   348	            } catch {
+   349	                throw ChapterTranslationError.cancelled
+   350	            }
+   351	            let chunkSegments = chunk.map { segments[$0] }
+   352	            do {
+   353	                let chunkResult = try await translateChunk(
+   354	                    chunkSegments, targetLanguage: targetLanguage, config: config, style: style)
+   355	                for (offset, segmentIndex) in chunk.enumerated() {
+   356	                    translated[segmentIndex] = chunkResult[offset]
+   357	                }
+   358	                anyChunkSucceeded = true
+   359	            } catch is CancellationError {
+   360	                throw ChapterTranslationError.cancelled
+   361	            } catch ChapterTranslationError.cancelled {
+   362	                // Bug #330 (Codex): typed cancellation from `send()` must abort,
+   363	                // not degrade.
+   364	                throw ChapterTranslationError.cancelled
+   365	            } catch {
+   366	                log.error("Pre-segmented chunk failed (segments \(chunk) source-only): \(String(describing: error), privacy: .public)")
+   367	                lastChunkError = error
+   368	            }
+   369	        }
+   370	        if !anyChunkSucceeded, let err = lastChunkError {
+   371	            throw err
+   372	        }
+   373	
+   374	        // Bug #343: cache the fully-successful result under the canonical key
+   375	        // with the ENUMERATE's count as the stored contract. Mirrors
+   376	        // `translate`: a partial degrade is never cached (Bug #330), and a
+   377	        // store-write failure does not fail the translation (rule 50 §6).
+   378	        if lastChunkError == nil {
+   379	            do {
+   380	                try await store.upsert(ChapterTranslationRecord(
+   381	                    bookFingerprintKey: bookFingerprintKey,
+   382	                    unitStorageKey: unit.storageKey,
+   383	                    targetLanguage: targetLanguage,
+   384	                    providerProfileID: providerProfileID,
+   385	                    promptVersion: promptVersion,
+   120	            name: .readerBilingualPrefetchDidChange, object: nil,
+   121	            userInfo: [
+   122	                "fingerprintKey": bookFingerprintKey,
+   123	                "inFlightUnits": newSet
+   124	            ])
+   125	    }
+   126	
+   127	    /// Monotonic guard; bumps on disable / book-change / unit-change. A
+   128	    /// prefetch `Task` captures the epoch at launch and discards its result
+   129	    /// if the epoch has since moved.
+   130	    var epoch: Int = 0
+   131	
+   132	    /// Monotonic per-`handlePositionChange`-call counter. The trigger captures
+   133	    /// it at entry and re-checks it after the `unit(after:)` suspension — only
+   134	    /// the LATEST request proceeds, so two position changes interleaving
+   135	    /// across the suspension cannot let the older one win.
+   136	    var triggerRequestSeq: Int = 0
+   137	
+   138	    /// In-flight prefetch tasks keyed by unit, so a reset can cancel them, a
+   139	    /// completed task removes its own entry (no unbounded growth), and a test
+   140	    /// can await quiescence.
+   141	    var prefetchTasks: [TranslationUnitID: Task<Void, Never>] = [:]
+   142	
+   143	    /// Cancelled-but-still-unwinding prefetch tasks, kept only so the
+   144	    /// test-only `awaitPrefetchForTesting` can fully drain them after a
+   145	    /// disable / unit-change cancels them out of `prefetchTasks`.
+   146	    var cancelledPrefetchTasks: [Task<Void, Never>] = []
+   147	
+   148	    init(bookFingerprintKey: String, perBookBaseURL: URL) {
+   149	        self.bookFingerprintKey = bookFingerprintKey
+   150	        self.perBookBaseURL = perBookBaseURL
+   151	
+   152	        let override = PerBookSettingsStore.settings(
+   153	            for: bookFingerprintKey, baseURL: perBookBaseURL)
+   154	        self.isEnabled = override?.bilingualEnabled ?? false
+   155	        self.targetLanguage = override?.bilingualTargetLanguage ?? Self.defaultTargetLanguage
+   156	        self.granularity = TranslationGranularity(
+   157	            rawValue: override?.bilingualGranularity ?? "") ?? .paragraph
+   158	    }
+   159	
+   160	    // MARK: - Toggle
+   161	
+   162	    /// Enables / disables bilingual mode for this book and persists the change.
+   163	    /// The first time it is enabled the setup sheet is raised; disabling clears
+   164	    /// the per-unit translation cache and resets the prefetch trigger state.
+   165	    func setEnabled(_ enabled: Bool) {
+   166	        guard enabled != isEnabled else { return }
+   167	        if enabled && !hasBeenConfigured {
+   168	            needsSetupSheet = true
+   169	        }
+   170	        isEnabled = enabled
+   171	        if !enabled {
+   172	            resetTriggerState()
+   173	        }
+   174	        persist()
+   175	        postDidChange()
+   176	    }
+   177	
+   178	    /// Sets the target language and persists it.
+   179	    func setTargetLanguage(_ language: String) {
+   180	        guard language != targetLanguage else { return }
+   181	        targetLanguage = language
+   182	        // A language change invalidates the cached translations + the
+   183	        // prefetch trigger state — re-fetch fresh for the new language.
+   184	        resetTriggerState()
+   185	        persist()
+     1	// Purpose: Feature #56 WI-7b — the behavioral layer of
+     2	// `BilingualReadingViewModel`, split out of the main file to keep each under
+     3	// the ~300-line budget (rule 50 §9).
+     4	//
+     5	// This extension owns the unit-aware prefetch trigger: `handlePositionChange`
+     6	// derives the current `TranslationUnitID` from a position `Locator` via the
+     7	// injected `ChapterTextProviding`, dedupes against `lastTriggerUnit`, and on a
+     8	// real unit change bumps the epoch, cancels the prior epoch's in-flight
+     9	// prefetches, and prefetches the current + next unit through the
+    10	// `ChapterPrefetching` seam. A prefetch `Task` captures its epoch; a result
+    11	// from a superseded epoch is discarded. An offline cache-miss is recorded in
+    12	// `unavailableUnits` (the silent-source-fallback — plan Decision 2).
+    13	//
+    14	// Key decisions (Codex audit round 1):
+    15	// - `handlePositionChange` resolves the current + next unit **before**
+    16	//   mutating `epoch` / `lastTriggerUnit`, so a disable / unit-change during
+    17	//   the `unit(after:)` suspension cannot let a stale invocation start
+    18	//   superseded-epoch prefetches.
+    19	// - In-flight prefetch `Task`s are tracked in a `[TranslationUnitID: Task]`
+    20	//   dictionary so `finishPrefetch` removes the completed entry (no unbounded
+    21	//   growth) and `awaitPrefetchForTesting` awaits a stable snapshot.
+    22	// - A transient provider failure clears `lastTriggerUnit` when it names the
+    23	//   failed unit, so a later position change inside the same unit retries.
+    24	//
+    25	// @coordinates-with: BilingualReadingViewModel.swift, ChapterTextProviding.swift,
+    26	//   ChapterPrefetching.swift, ReaderNotifications.swift,
+    27	//   dev-docs/plans/20260519-feature-56-bilingual-reading.md (WI-7b)
+    28	
+    29	import Foundation
+    30	
+    31	extension BilingualReadingViewModel {
+    32	
+    33	    // MARK: - Collaborators
+    34	
+    35	    /// Attaches the format adapter that resolves `Locator → TranslationUnitID`.
+    36	    /// The format host calls this once after constructing the view model.
+    37	    func attachProvider(_ provider: any ChapterTextProviding) {
+    38	        textProvider = provider
+    39	    }
+    40	
+    41	    /// Attaches the translation-prefetch seam. The format host calls this once
+    42	    /// after constructing the view model.
+    43	    func attachPrefetcher(_ prefetcher: any ChapterPrefetching) {
+    44	        self.prefetcher = prefetcher
+    45	    }
+    46	
+    47	    // MARK: - Prefetch trigger
+    48	
+    49	    /// Whether a unit's translation is unavailable (offline cache-miss).
+    50	    func isUnavailable(_ unit: TranslationUnitID) -> Bool {
+    51	        unavailableUnits.contains(unit)
+    52	    }
+    53	
+    54	    /// Driven by `.readerPositionDidChange`. Derives the current unit from the
+    55	    /// position `Locator`; if the unit changed since the last trigger, bumps
+    56	    /// the epoch, cancels any in-flight prefetch, and prefetches the current +
+    57	    /// next unit. Repeated calls inside the same unit are no-ops.
+    58	    func handlePositionChange(_ locator: Locator) async {
+    59	        guard isEnabled, let provider = textProvider, prefetcher != nil else { return }
+    60	        // Claim a monotonic request token — only the latest request proceeds.
+    61	        triggerRequestSeq += 1
+    62	        let requestToken = triggerRequestSeq
+    63	
+    64	        guard let currentUnit = await provider.unit(containing: locator) else { return }
+    65	        // After the `unit(containing:)` suspension: bail if a newer request
+    66	        // has been claimed, or the VM was disabled.
+    67	        guard isEnabled, requestToken == triggerRequestSeq else { return }
+    68	        // Dedupe: the position is still inside the unit the trigger last
+    69	        // acted on — nothing to do.
+    70	        guard currentUnit != lastTriggerUnit else { return }
+    71	
+    72	        // Resolve the next unit BEFORE mutating any trigger state — this call
+    73	        // suspends, and a disable / another `handlePositionChange` during the
+    74	        // suspension must not let this (now stale) invocation start prefetches.
+    75	        let nextUnit = await provider.unit(after: currentUnit)
+    76	
+    77	        // Re-validate after the suspension: the VM must still be enabled AND
+    78	        // this must still be the latest request. The request-token check
+    79	        // (not just `currentUnit != lastTriggerUnit`) is what defeats the
+    80	        // interleaving race — a newer request for a *different* unit bumped
+    81	        // `triggerRequestSeq`, so the older invocation stops here even though
+    82	        // its `currentUnit` differs from the newer `lastTriggerUnit`.
+    83	        guard isEnabled, requestToken == triggerRequestSeq else { return }
+    84	
+    85	        // A real unit change — bump the epoch and cancel the prior epoch's
+    86	        // in-flight prefetches before starting the new ones.
+    87	        epoch += 1
+    88	        cancelInFlightPrefetches()
+    89	        lastTriggerUnit = currentUnit
+    90	
+    91	        let currentEpoch = epoch
+    92	        var targets: [TranslationUnitID] = [currentUnit]
+    93	        if let nextUnit { targets.append(nextUnit) }
+    94	        for unit in targets {
+    95	            startPrefetch(unit: unit, epoch: currentEpoch)
+    96	        }
+    97	    }
+    98	
+    99	    /// Test-only: awaits every prefetch `Task` — both still-registered and
+   100	    /// already-cancelled — so a test can assert deterministically after
+   101	    /// `handlePositionChange`.
+   102	    func awaitPrefetchForTesting() async {
+   103	        while !prefetchTasks.isEmpty || !cancelledPrefetchTasks.isEmpty {
+   104	            let active = Array(prefetchTasks.values)
+   105	            let cancelled = cancelledPrefetchTasks
+   106	            cancelledPrefetchTasks.removeAll()
+   107	            for task in cancelled { await task.value }
+   108	            for task in active { await task.value }
+   109	            // Drop finished+accounted active entries; loop if a new task
+   110	            // appeared (or a new cancellation occurred) while awaiting.
+   111	            for unit in prefetchTasks.keys where !inFlightUnits.contains(unit) {
+   112	                prefetchTasks.removeValue(forKey: unit)
+   113	            }
+   114	        }
+   115	    }
+   116	
+   117	    // MARK: - Unit-scoped prefetch (Feature #71 WI-7)
+   118	
+   119	    /// Prefetch ONE explicit unit's translation without touching the
+   120	    /// visible-locator trigger state (`lastTriggerUnit` / `triggerRequestSeq`).
+   121	    ///
+   122	    /// Feature #71 WI-7 (Gate-4 round-2 HIGH 1): continuous-scroll EPUB stitches
+   123	    /// multiple chapter sections into one document; an adjacent section that
+   124	    /// materializes is frequently OFF-SCREEN relative to the visible locator
+   125	    /// (the ±1 initial fill, lazy append/prepend). The whole-book
+   126	    /// `handlePositionChange` trigger resolves its prefetch targets from the
+   127	    /// CURRENT visible locator and dedupes against `lastTriggerUnit`, so reusing
+   128	    /// it for an off-screen section would either no-op (wrong unit) or clobber
+   129	    /// the dedupe anchor. This seam prefetches exactly the named unit through
+   130	    /// the same `startPrefetch` internals (cache-guarded, in-flight-guarded,
+   131	    /// epoch-stamped) so a section-materialize can warm its OWN unit's
+   132	    /// translation independent of where the reader is looking.
+   133	    ///
+   134	    /// No-op when bilingual is disabled, no prefetcher is attached, or the unit
+   135	    /// is already cached / already in flight (`startPrefetch` guards the latter
+   136	    /// two). Does NOT mark the unit unavailable on its own — the existing
+   137	    /// `finishPrefetch` outcome handling applies.
+   138	    func prefetchUnitIfNeeded(_ unit: TranslationUnitID) {
+   139	        guard isEnabled, prefetcher != nil else { return }
+   140	        startPrefetch(unit: unit, epoch: epoch)
+   141	    }
+   142	
+   143	    // MARK: - Unit-scoped retry (Feature #56 WI-13)
+   144	
+   145	    /// Retry one unit's translation fetch. Designed for the PDF
+   146	    /// offline-state CTA — and reusable by any future per-format
+   147	    /// retry affordance — when the user wants a single offline unit
+   148	    /// re-fetched without nuking the rest of the book's cache.
+   149	    ///
+   150	    /// Removes the unit from `unavailableUnits`, clears
+   151	    /// `lastTriggerUnit` only if it equals the retried unit (so the
+   152	    /// next position change is not deduped), bumps the epoch, then
+   153	    /// schedules a fresh prefetch via the same `startPrefetch` seam
+   154	    /// `handlePositionChange` uses. Other units' translations and
+   155	    /// other unavailable entries are untouched.
+   156	    ///
+   157	    /// Belt-and-braces: if an in-flight task already exists for the
+   158	    /// retried unit (a rare race between the prefetch starting and
+   159	    /// the user tapping Retry), cancel it before launching the
+   160	    /// fresh one — Gate-2 v5 round-2 M2.
+   161	    ///
+   162	    /// No-op when bilingual is disabled or no prefetcher is attached.
+   163	    func retryUnit(_ unit: TranslationUnitID) {
+   164	        guard isEnabled, prefetcher != nil else { return }
+   165	        if let priorTask = prefetchTasks.removeValue(forKey: unit) {
+   166	            priorTask.cancel()
+   167	            cancelledPrefetchTasks.append(priorTask)
+   168	        }
+   169	        setInFlight(inFlightUnits.subtracting([unit]))   // Feature #77 funnel
+   170	        unavailableUnits.remove(unit)
+   171	        if lastTriggerUnit == unit { lastTriggerUnit = nil }
+   172	        epoch += 1
+   173	        startPrefetch(unit: unit, epoch: epoch)
+   174	    }
+   175	
+   176	    /// Bug #268: when the EPUB plain-text prefetch's segment count diverges from
+   177	    /// the DOM leaf-enumerate's block count (nested `<pre>` / mixed-content
+   178	    /// `<blockquote>` → the shared 1:1 pairing falls back to source-only),
+   179	    /// translate the enumerate's OWN block texts directly so blocks↔segments are
+   180	    /// 1:1 BY CONSTRUCTION. Stores the result for the unit so the next inject
+   181	    /// pairs every block. A no-op when a matching-count translation already
+   182	    /// exists; never worse than source-only on failure (the divergence-fallback
+   183	    /// can only improve the divergent case, never regress the common one).
+   184	    func translateBlocksDirectly(_ blockTexts: [String], for unit: TranslationUnitID) async {
+   185	        guard isEnabled, let prefetcher, !blockTexts.isEmpty else { return }
+   186	        // Already have a translation that pairs 1:1 with these blocks → nothing to do.
+   187	        if let existing = translationsByUnit[unit], existing.count == blockTexts.count { return }
+   188	        // Bug #343: cache-only restore FIRST — a previous run's divergence
+   189	        // fallback persisted the canonical row with the enumerate's count as
+   190	        // its contract, so a toggle/reopen restores with zero provider calls.
+   191	        if let cached = await prefetcher.cachedSegmentsDirect(
+   192	            for: unit, expectedCount: blockTexts.count, targetLanguage: targetLanguage) {
+   193	            guard isEnabled else { return }
+   194	            translationsByUnit[unit] = cached
+   195	            postDidChange()
+   196	            return
+   197	        }
+   198	        do {
+   199	            let translated = try await prefetcher.translatedSegmentsDirect(
+   200	                for: unit, sourceSegments: blockTexts, targetLanguage: targetLanguage)
+   201	            guard isEnabled, translated.count == blockTexts.count else { return }
+   202	            translationsByUnit[unit] = translated
+   203	            postDidChange()
+   204	        } catch {
+   205	            // Leave the unit source-only — never worse than the current behavior.
+   206	        }
+   207	    }
+   208	
+   209	    // MARK: - Reset + notification (called from the main file's toggle setters)
+   210	
+   211	    /// Clears the per-unit translation cache + the unavailable set + the
+   212	    /// prefetch trigger state, and bumps the epoch so any in-flight result is
+   213	    /// discarded. Called on disable / language / granularity change.
+   214	    func resetTriggerState() {
+   215	        epoch += 1
+   216	        cancelInFlightPrefetches()
+   217	        translationsByUnit.removeAll()
+   218	        unavailableUnits.removeAll()
+   219	        lastTriggerUnit = nil
+   220	    }
+   221	
+   222	    /// Posts `.readerBilingualDidChange` for this book so each format renderer
+   223	    /// re-injects / clears its interlinear translation. The userInfo
+   224	    /// carries the book's fingerprintKey (observers filter by it),
+   225	    /// the current `isEnabled`, and the current `targetLanguage` so
+   226	    /// chrome-layer observers (the parent reader's pill mirror, More-
+   227	    /// menu row state) can paint without crossing the host boundary.
+   228	    /// The renderer-side observers use `isEnabled` to decide between
+   229	    /// inject and clear.
+   230	    func postDidChange() {
+   231	        NotificationCenter.default.post(
+   232	            name: .readerBilingualDidChange, object: nil,
+   233	            userInfo: [
+   234	                "fingerprintKey": bookFingerprintKey,
+   235	                "isEnabled": isEnabled,
+   236	                "targetLanguage": targetLanguage,
+   237	                // Feature #99 WI-3: the granularity rides the payload so the
+   238	                // parent chrome mirror can build the More-menu settings
+   239	                // sub-line ("Chinese · Paragraph · Claude").
+   240	                "granularity": granularity.rawValue
+   241	            ])
+   242	    }
+   243	
+   244	    // MARK: - Private — prefetch internals
+   245	
+   246	    /// The outcome of one prefetch task, applied back on the main actor.
+   247	    private enum PrefetchOutcome {
+   248	        case success([String])
+   249	        case offline
+   250	        case cancelled
+   251	        case failed
+   252	    }
+   253	
+   254	    /// Launches a prefetch for one unit unless it is already cached or already
+   255	    /// in flight. The task captures `epoch`; a stale result is discarded.
+   256	    private func startPrefetch(unit: TranslationUnitID, epoch launchEpoch: Int) {
+   257	        guard translationsByUnit[unit] == nil else { return }
+   258	        guard !inFlightUnits.contains(unit) else { return }
+   259	        guard let prefetcher else { return }
+   260	        setInFlight(inFlightUnits.union([unit]))   // Feature #77 funnel (was insert + isFetching=true)
+23:- **AI-config path (folded in — #136 CLOSED)** — the ONLY designed Android AI-config reader surface is the **Variant A scoped "AI Providers" sheet pushed inside the bilingual flow**, reached from the bilingual engine strip's "Set up"/"Change…" button (`reader-ai-provider-entry.md`). #131 now owns it end-to-end (§"AI-config reachability", WI-4b + WI-AIP + WI-9).
+109:                                  pop the whole stack)
+114:- **"Change…"** (already-configured strip) opens the **SAME** `ReaderAiProvidersSheet`, populated, current provider checked.
+165:- `bilingual/ReaderAiProvidersSheet.kt` — **NEW (folded in; the Android analog of iOS `ReaderAIProvidersView`).** The Variant A scoped in-reader AI Providers sheet, reproducing `vreader-ai-provider-entry.jsx` `AIProvidersSheet` + `NavSheet` (nav bar `‹ Bilingual` leading + centered "AI Providers" title). It hosts **ONLY the provider list** — nothing else from settings. It **reuses the #118 `AiProviderListScreen` (list, empty + populated states) and `AiProviderEditSheet` (the canonical add/edit modal) VERBATIM**, driven by the #118 `AiSettingsViewModel` (`listState`, `editState`, `openAdd/openEdit/save/setActive`, verified `AiSettingsViewModel.kt`). Behavior per the nav model:
+167:  - **Add provider** presents `AiProviderEditSheet` unchanged; **on the first Save** the new provider becomes active/the bilingual engine and the stack **pops all the way back** to the bilingual sheet with the engine strip now reading "Claude · configured / Change…". (First-provider-active is already the store's behavior — `AiProviderStore.upsert` sets `activeId = cur.activeId ?: id`, AiProviderStore.kt:81; the sheet additionally calls `store.setActive(savedId)` on the first-Save-from-bilingual path so the freshly-saved provider is the engine even if others existed.)
+169:  - "Change…" opens the SAME sheet, populated, current provider checked (tapping a row → `setActive`).
+211:- `VReaderApp.kt` / `AppContainer` — **provide `AiProviderStore` INTO `AppContainer` itself** (it is NOT provided today — verified, only a comment names it at VReaderApp.kt:66) using the #116 `KeystoreSecretCipher` + a DataStore under the same convention as `readerSettingsStore`, PLUS provide `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, an `AiSettingsViewModel` factory (for the Variant A sheet), and a `BilingualViewModel` factory. **Extracted into the shared DI WI (WI-4b).** No `feat:#136` dependency remains — #131 owns the `AiProviderStore`-into-`AppContainer` wiring.
+259:The canonical decision (`reader-ai-provider-entry.md`, Variant A) + its component canvas (`vreader-ai-provider-entry.jsx`) ARE the committed design; #131 reproduces only what they depict (a `‹ Bilingual`-titled push sheet hosting the #118 provider list + the canonical editor, pop-back-on-first-save). No AI-config sheet or nav is invented. The iOS #82 readiness additions (flag/consent) are explicitly **out** on Android (no such subsystems exist). This is a designed surface — it is NOT a design gate.
+272:**13 WIs/PRs (round-3 Low-1 fix — corrected count):** the list is exactly **WI-0, WI-1, WI-2, WI-3, WI-4a, WI-4b, WI-5, WI-6, WI-7a, WI-7b, WI-AIP, WI-8, WI-9** = **13 WIs**. (v3 had 12: WI-0,1,2,3,4a,4b,5,6,7a,7b,8,9. Folding in the Variant A "AI Providers" sheet adds **WI-AIP**, making 13. The prior "11 WIs" claim in the plan header and `docs/features.md` was wrong on two counts and is corrected here.) Each WI = one PR. Build order: **foundation/cache → service/direct-block APIs → shared DI/factory (incl. `AiProviderStore` in `AppContainer`) → VM state/prefetch → host-specific renderers (TXT/MD + EPUB) + the Variant A AI Providers sheet → entry wiring.**
+277:- **WI-4b is foundational and gates the behavioral chain.** WI-4b now provides `AiProviderStore` into `AppContainer` PLUS the bilingual services + factories. Per the audit's Medium-4, WI-4b transitively gates WI-6 (needs the prefetcher/DI), WI-7b (needs DI), WI-AIP (needs `AiProviderStore` + `AiSettingsViewModel` from `AppContainer`), and WI-8 (needs DI). **Chosen resolution: injected seams so the behavioral work proceeds against fakes before WI-4b lands, AND WI-4b is sequenced early.** Concretely: the VM (WI-5/WI-6) takes an injected `ChapterTranslationPrefetcher` (fake in tests) and an injected `AiProviderSnapshot` provider (fake); the TXT/MD host Compose/unit work (WI-8) and the Variant A sheet (WI-AIP) take injected VM/store/`AiSettingsViewModel` seams — so unit/Compose tests do not wait on `AppContainer`. **WI-4b is built right after WI-4a (before WI-6/WI-7b/WI-AIP/WI-8) so the production wiring lands before the host integrations that mount it.** This is stated honestly: the *production run-through* of WI-6/WI-7b/WI-AIP/WI-8 depends on WI-4b; their *unit/Compose gates* depend only on the injected seams. No external feature gates any of this.
+289:**WI-4b (foundational — shared DI/factory, incl. `AiProviderStore` in `AppContainer`): AppContainer bilingual + AI-config graph.** `AppContainer` **now constructs `AiProviderStore`** (DataStore + #116 `KeystoreSecretCipher`, following the `readerSettingsStore` convention — this is #131's change, not an external feature's) and provides `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, an `AiSettingsViewModel` factory (for WI-AIP), and the `BilingualViewModel` factory. Deps: **WI-4a** (no external dep — #136 closed). Tests: container resolves the bilingual + AI-config graph; `AiProviderStore` resolves and round-trips a profile; the prefetcher's injected factory defaults to `AiProviderFactory::create`.
+293:**WI-6 (behavioral): VM prefetch trigger + generation/cancellation + single-flight (M2).** `onPositionChanged(charOffsetUTF16)` derives current unit (TXT/MD only), dedupes, prefetches current+next; a monotonic position-request sequence checked after every suspension; **per-unit single-flight `prefetchTasks: Map<TranslationUnitId, Job>` (a new request cancels/joins the prior — M2)**; a captured language/granularity/provider snapshot per launch; generation bumps on disable/language/granularity/unit-change discard stale; **BOTH `CancellationException` AND typed `ChapterTranslationError.Cancelled` handled BEFORE generic error mapping (M2)**; a cancelled stale request does NOT surface as `errorUnit`; `Offline`→`unavailableUnits`; transient failure leaves unit unfetched + clears anchor to retry; `retryUnit` routes through the registry. The EPUB `onEpubBlocksEnumerated` entry is present but EPUB prefetch is owned by the controller (Medium-1); the VM's position-driven `prefetch` dispatches TXT/MD units only. Fake prefetcher (Medium-4 seam). Deps: WI-4a, WI-4b, WI-5. Tests: current+next on unit change; same-unit no-op; cancel-mid discards stale (no `errorUnit`); typed-`Cancelled` discards (not `errorUnit`); rapid re-trigger same unit → single-flight, no double-write; offline→unavailable; failure→retry-able; `retryUnit` re-fetches; granularity change cancels + re-fetches under the new key.
+297:**WI-7b (behavioral, CONDITIONAL — only if WI-0 = go): EPUB render adapter (DOM injection, NOT Compose — M2) + direct-block ownership (M1).** `EpubBilingualJs` (enum/inject/clear JS builders, CSP-safe escaping) + `EpubBilingualController` (the serialization actor / session token AND the **single-owner enumerate→cachedDirect/prefetchDirect→guarded-commit sequence — Medium-1**) + `EpubChapterTextProvider`, wired into `ReaderActivity`, driving DOM from the shared `BilingualRenderState` DTO. Uses `prefetchDirect`/`cachedDirect` for the count-divergence path (H2). Depends on WI-6 (VM state) and WI-4b (DI); the WI-7a UI dependency is only the shared `BilingualRenderState`/value types. Connected test on a real EPUB (seeded cache): enable → injects; disable → cleared; reflow/href-change/fragment-recreation/activity-recreation → re-applies from cache (zero provider calls) via `cachedDirect`; count-divergence handled (direct path); **the regular TXT/MD prefetch path is never invoked for an EPUB unit (Medium-1)**. Unit tests: JS escaping/CSP-safe insertion, RTL/CJK style, empty translations, loading cleanup, idempotent replacement, source-only fallback, stale-session-token commit discarded (no `errorUnit`). Deps: WI-0, WI-3, WI-4a, WI-4b, WI-6, (shared types from WI-7a). (If WI-0 = no-go, dropped; box D ships TXT/MD-only, tracked.)
+299:**WI-AIP (behavioral — the folded-in Variant A AI Providers sheet): `ReaderAiProvidersSheet`.** The scoped in-reader "AI Providers" push sheet (nav bar `‹ Bilingual` + "AI Providers" title) reproducing `vreader-ai-provider-entry.jsx` `AIProvidersSheet`/`NavSheet`, hosting ONLY the #118 `AiProviderListScreen` (empty + populated) + the canonical `AiProviderEditSheet`, driven by the #118 `AiSettingsViewModel` (from WI-4b's `AppContainer` factory). Empty state carries the bilingual-context copy ("Bilingual mode needs a provider to translate" / "Add provider" CTA). On first Save → the provider becomes the bilingual engine (`store.setActive(savedId)`) + pop the whole stack back to the bilingual sheet (engine strip now "configured / Change…"). `‹ Bilingual` without adding → unconfigured, no state mutated. No consent/flag surface (Android has none). Deps: WI-4b (for `AiProviderStore` + `AiSettingsViewModel` in `AppContainer`), WI-7a (bilingual sheet host). Tests (Compose + connected): empty → Add → Save → pop-to-bilingual with strip configured; `‹ Bilingual` without adding → strip unconfigured, snapshot unchanged; "Change…" → populated list, current provider checked, tap row → `setActive`; editor reused verbatim (no divergent form).
+301:**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into the `items(count = document.chunkCount)` loop as **additive translation items after the anchor chunk, source chunks byte-unchanged (H2)** + position-change (`charOffsetUTF16`) + setup-sheet. `originalFormat`-gated (TXT/MD). Uses WI-4b's DI. **#129 VERIFIED — straight edit.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2)**; **highlights/annotation-washes/read-aloud-wash still key off source chunks (H2)**; a translation item is non-selectable, does not perturb source offsets (H2); disable → source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders exactly one translation after its last chunk (H1/Low-2)**; **one-chunk/final-chunk anchors render (H1)**; MD source mapping. Deps: WI-6, WI-7a, WI-4b.
+303:**WI-9 (behavioral): entry wiring + acceptance.** Mount `BilingualPill` in #132's VERIFIED top chrome; extend `readerMoreRows(...)` to supply the #134 VERIFIED More-menu `MoreActionId.BILINGUAL` toggle (`MoreRow.Toggle` `on`/`onToggle`, or `MoreRow.Disabled` "Configure AI provider first" when not configured) wired to the VM; **wire the setup sheet's "Set up"/"Change…" affordance → the #131-owned `ReaderAiProvidersSheet` (Variant A)**. Full acceptance across EPUB (if WI-7b landed) + TXT/MD, including the fresh-user path `unconfigured → Set up (→ Variant A AI Providers sheet) → add provider → return → enable → translate` (now #131-owned end-to-end). **Flip box D to done ONLY for provider/model/granularity + the Style-descope note; file the follow-up checklist amendment; do NOT claim full box-D parity.** The DONE flip **no longer waits on #136** (closed). Update `docs/architecture.md` (bilingual pipeline + the new `chapter_translations` schema + `AiProviderStore` + bilingual services in `AppContainer` + the Variant A AI Providers sheet). → DONE. Deps: WI-8, WI-AIP, WI-7b (if go), feat:#132, feat:#134.
+311:Compose UI (`androidTest/...bilingual/`): `BilingualSetupSheetUiTest` (language grid, granularity, preview, engine configured vs unconfigured driven by `aiConfigured`; no Style control present; light+dark); `BilingualInterlinearBodyUiTest` (**additive translation item after a paragraph anchor chunk (depicted); paragraph interlinear translated incl. CJK font + RTL Arabic; Sentence selection → paragraph-render fallback (H2 gate)**; loading N%+dimmed; error+Retry; offline source-only; empty translation→source-only no crash); `ReaderAiProvidersSheetUiTest` (**empty state with bilingual-context copy + Add CTA; populated list + current-provider checked; `‹ Bilingual` back label; editor reused (WI-AIP)**); `BilingualPillUiTest`.
+313:Connected (`androidTest/...reader/`): `TxtReaderBilingualConnectedTest` (API 35, fake `AiClient` via injected factory): enable→setup→confirm→interlinear from seeded Room cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2); highlights/annotation-washes/read-aloud-wash still key off source chunks (H2); translation item non-selectable + no source-offset perturbation (H2)**; disable→source-only byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders one translation (H1/Low-2); one-chunk/final-chunk anchors render (H1)**; TXT/MD gated (PDF inert); very long chapter scroll responsive; cancellation leaves no partial cache row. `ReaderAiProvidersConnectedTest` (WI-AIP + WI-9): `unconfigured → Set up → Variant A sheet → add provider → Save → pop-to-bilingual configured → enable → translate`; `‹ Bilingual` without adding → unconfigured, snapshot unchanged; "Change…" → populated, current checked. `EpubReaderBilingualConnectedTest` (only if WI-0=go): enable→inject on a real EPUB; disable→clear; href-change/fragment-recreation/activity-recreation→re-apply from cache (zero provider calls); count-divergence handled via `prefetchDirect`/`cachedDirect`; regular prefetch never runs for EPUB unit (Medium-1).
+319:- **Live-translation verification is AI-credential-gated (the box-D caveat).** The whole pipeline is verified without live creds via a deterministic **fake `AiClient`** injected through the prefetcher's `clientFactory` param (default `AiProviderFactory::create`; tests override). WI-3/4a/8 prove segment→chunk→decode→cache→interleave end-to-end incl. every error/edge path. Connected tests seed the Room cache and assert render-from-cache with zero client calls. An optional live smoke confirms wire format but is NOT a gate. The fresh-user `unconfigured → Set up → add provider` reachability leg is now #131-owned (WI-AIP + WI-9) and verified by `ReaderAiProvidersConnectedTest`.
+332:- **Dependency honesty (round-3 Medium-4).** WI-4b (DI, incl. `AiProviderStore` in `AppContainer`) is foundational and gates the production run-through of WI-6/WI-7b/WI-AIP/WI-8; those WIs' unit/Compose gates proceed against injected fakes, and WI-4b is sequenced before them. No external feature gates the chain (#136 closed).
+348:*(REMOVED: the v3 "#136 dependency" design-gate line — #136 is closed and the Variant A AI Providers sheet IS the committed design, reproduced by WI-AIP, not a gate.)*
+356:  - **AI-config FOLDED IN (#136 CLOSED, GH #1976 not-planned; user decision 2026-07-12):** the design proved the ONLY designed Android AI-config reader surface is the bilingual-coupled **Variant A** "AI Providers" sheet (`reader-ai-provider-entry.md`); it is not separable, so #131 now owns it end-to-end. Added **WI-AIP** (`ReaderAiProvidersSheet`, reusing #118 `AiProviderListScreen`/`AiProviderEditSheet`/`AiSettingsViewModel` verbatim, `‹ Bilingual` push, pop-back-on-first-Save); WI-4b now provides `AiProviderStore` into `AppContainer` (verified not provided today — VReaderApp.kt:66 comment only) plus the bilingual services + `AiSettingsViewModel` factory; removed `feat:#136` from Deps (now `[feat:#132, feat:#134]`, no external AI-reachability blocker); the DONE flip no longer waits on #136; `aiConfigured` derivation kept as the correct active-profile+decrypts-non-empty gate (H3), NOT `profiles.isEmpty()` (the iOS note's derivation), with no consent/flag gate (Android has none).
+362:  - **M4 (round-3 Medium-4) dependency honesty:** WI-4b (DI incl. `AiProviderStore`) is foundational and gates the production run-through of WI-6/WI-7b/WI-AIP/WI-8; those WIs' unit/Compose gates use injected fakes; WI-4b sequenced before them; no external feature gates the chain.
+363:  - **Low fixes:** WI count corrected to **13** (added WI-AIP; the "11 WIs" claim was wrong — Low-1); chunk semantics corrected — a chunk is ONE LINE, holds multiple SENTENCES, a paragraph spans MANY chunks; removed the "a chunk can hold multiple paragraphs" claim (Low-2). Awaiting Gate-2 round-4 audit.
+
+codex
+## Critical
+
+None.
+
+## High
+
+1. **H1 is not fully resolved: the plan still specifies `List<IntRange>` for half-open ranges.**
+
+The v4 correction correctly identifies that Kotlin `IntRange` is inclusive-inclusive and requires explicit `(start, endExclusive)` pairs ([plan:49](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:49), [plan:61](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:61)). However, the proposed `ChapterSegmenter` API still declares `paragraphRanges` / `sentenceRanges` as `List<IntRange>` while calling them half-open ([plan:126](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:126), [plan:281](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:281)).
+
+Those contracts are mutually incompatible. Replace `IntRange` everywhere with a dedicated type such as `Utf16Span(start, endExclusive)`.
+
+The underlying math itself is correct:
+
+- `offsetForChunk` clamps `i + 1` to the final chunk start ([TxtDocument.kt:17](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:17)).
+- `textForChunk` proves the required final-end behavior by using `text.length` ([TxtDocument.kt:36](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:36)).
+- `chunkForOffset(endExclusive - 1)` correctly anchors non-empty half-open spans ([TxtDocument.kt:23](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:23)).
+
+Therefore one-chunk, final-chunk, exact-boundary, and EOF anchors are correct only after the remaining `IntRange` API contradiction is removed.
+
+2. **H2 remains blocked: separate additive lazy items break the reader’s chunk-index identity.**
+
+The live reader treats `LazyListState` item indices as `TxtDocument` chunk indices throughout:
+
+- Position saving converts `firstVisibleItemIndex` directly through `offsetForChunk` ([TxtReaderActivity.kt:220](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:220), [TxtReaderActivity.kt:623](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:623)).
+- Bookmark, annotation, search, scrubber, and TTS jumps call `scrollToItem(chunkForOffset(...))` ([TxtReaderActivity.kt:404](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:404), [TxtReaderActivity.kt:470](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:470)).
+- TTS visibility compares lazy-item indices directly with `spokenChunk` ([TxtReaderActivity.kt:252](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:252)).
+
+Inserting separate translation lazy items shifts every following lazy index, corrupting these mappings. Conversely, composables emitted inside the existing `items(count=chunkCount)` lambda are part of the same lazy item, not separately keyed `LazyColumn` items. Thus the plan’s claim that the existing loop remains byte-identical while separately keyed lazy items are inserted inside it is not implementable as written ([plan:70](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:70), [plan:208](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:208)).
+
+The source-`Text` preservation portion is correct: one unchanged `Text` retains one layout and one chunk registration ([TxtReaderActivity.kt:1043](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1043), [TxtReaderActivity.kt:1059](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1059), [TxtReaderActivity.kt:1062](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1062)). But the plan must choose one viable implementation:
+
+- Keep exactly one lazy item per chunk and put the unchanged source `Text` plus translations in a containing `Column`; or
+- Introduce an explicit lazy-index↔chunk-index mapping and update every position/jump/TTS consumer.
+
+The first is substantially safer. It also needs an explicit gesture exclusion because long-press selection currently falls back to the nearest registered source chunk when the pointer is outside source bounds ([TxtSelectionController.kt:43](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:43)); merely omitting translation registration does not make translation text non-selectable.
+
+3. **The Sentence fallback is underspecified and not yet sound.**
+
+The design evidence is correctly characterized: `BilingualPageContent` maps paragraphs and renders one translation paragraph per source paragraph ([vreader-bilingual.jsx:195](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx:195), [vreader-bilingual.jsx:241](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx:241)); Sentence appears only in the setup control ([vreader-bilingual.jsx:77](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx:77)).
+
+However, v4 says Sentence remains selectable, sentence segmentation/cache identity remains active, but rendering falls back to paragraphs ([plan:82](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:82)). It never defines how multiple sentence translations are deterministically reassembled into one paragraph translation or how sentence spans map back to paragraph spans. Without that shaping contract, implementation either renders sentence items—the prohibited undesigned surface—or serves paragraph-shaped content under a sentence cache key.
+
+For v1, specify deterministic sentence-result aggregation into the containing paragraph, with tests for punctuation, whitespace, multiline paragraphs, CJK, and RTL; otherwise constrain v1 to Paragraph.
+
+4. **FOLD-IN is not wireable “verbatim” against the live #118 UI/ViewModel.**
+
+`AiProviderListScreen` already owns a full `NavScreen`, generic empty-state copy, and row-tap-as-edit behavior ([AiProviderListScreen.kt:45](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:45), [AiProviderListScreen.kt:59](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:59), [AiProviderListScreen.kt:84](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:84), [AiProviderListScreen.kt:101](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:101)). It cannot simultaneously be reused verbatim and reproduce the designed reader-scoped navigation, bilingual-context empty state, checked active row, and tap-to-select behavior ([reader-ai-provider-entry.md:39](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:39), [vreader-ai-provider-entry.jsx:162](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:162)).
+
+Additionally, `AiSettingsViewModel.save()` returns no saved ID and performs `upsert` asynchronously ([AiSettingsViewModel.kt:85](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:85)). Therefore WI-AIP cannot perform the promised `setActive(savedId)` followed by pop-on-success while reusing that ViewModel verbatim. Popping immediately would race persistence; observing list state cannot reliably distinguish the newly saved profile from unrelated updates.
+
+The canonical editor can be reused verbatim, but the scoped list must be a new reader-specific presentation over shared state/components, and saving needs a completion/result seam returning the saved ID.
+
+## Medium
+
+No additional blockers.
+
+Round-3 resolution status:
+
+- **M1 EPUB ownership: resolved.** The controller-only enumerate → cache/direct-prefetch → token-guarded commit flow is coherent, and excluding EPUB kinds from position-driven VM prefetch prevents two planned writers for one canonical row ([plan:181](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:181), [plan:197](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:197)). WI-0 must still prove token lifetime across fragment/activity recreation.
+- **M2 cancellation: resolved.** Native and typed cancellation are ordered before generic mapping, and cancel-and-join single-flight is sound. The cited iOS dual catch and task registry exist ([ChapterTranslationService.swift:359](/Users/ll/workspace/vreader/vreader/Services/AI/ChapterTranslationService.swift:359), [BilingualReadingViewModel.swift:138](/Users/ll/workspace/vreader/vreader/ViewModels/BilingualReadingViewModel.swift:138)).
+- **M3 blank model: resolved.** The fallback matches live precedent ([AiChatViewModel.kt:61](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt:61)); both providers serialize `request.model` directly ([OpenAiCompatibleProvider.kt:38](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/OpenAiCompatibleProvider.kt:38), [AnthropicProvider.kt:36](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AnthropicProvider.kt:36)).
+- **M4 dependency sequencing: resolved.** WI-4b is placed before the production integrations that consume it.
+
+## Low
+
+- `AppContainer` indeed has no live `AiProviderStore`; the cited occurrence is only a comment ([VReaderApp.kt:64](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:64)). Constructing it there is appropriate.
+- `aiConfigured = active profile + successfully decrypted non-blank key`, with cipher failure mapped to false, is correct. Profiles can exist without an active match ([AiProviderStore.kt:34](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:34)), and decrypt can fail at `apiKey(profile)` ([AiProviderStore.kt:105](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:105)).
+- `AiProviderStore.upsert` already activates the first-ever provider ([AiProviderStore.kt:81](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:81)); explicit activation is needed only when adding through this flow while other profiles already exist.
+- Dependencies `[feat:#132, feat:#134]` and the enumerated count of 13 WIs are arithmetically correct ([plan:270](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:270), [docs/features.md:184](/Users/ll/workspace/vreader/docs/features.md:184)).
+
+FINAL VERDICT: block-recommended
+tokens used
+110,315
+## Critical
+
+None.
+
+## High
+
+1. **H1 is not fully resolved: the plan still specifies `List<IntRange>` for half-open ranges.**
+
+The v4 correction correctly identifies that Kotlin `IntRange` is inclusive-inclusive and requires explicit `(start, endExclusive)` pairs ([plan:49](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:49), [plan:61](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:61)). However, the proposed `ChapterSegmenter` API still declares `paragraphRanges` / `sentenceRanges` as `List<IntRange>` while calling them half-open ([plan:126](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:126), [plan:281](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:281)).
+
+Those contracts are mutually incompatible. Replace `IntRange` everywhere with a dedicated type such as `Utf16Span(start, endExclusive)`.
+
+The underlying math itself is correct:
+
+- `offsetForChunk` clamps `i + 1` to the final chunk start ([TxtDocument.kt:17](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:17)).
+- `textForChunk` proves the required final-end behavior by using `text.length` ([TxtDocument.kt:36](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:36)).
+- `chunkForOffset(endExclusive - 1)` correctly anchors non-empty half-open spans ([TxtDocument.kt:23](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:23)).
+
+Therefore one-chunk, final-chunk, exact-boundary, and EOF anchors are correct only after the remaining `IntRange` API contradiction is removed.
+
+2. **H2 remains blocked: separate additive lazy items break the reader’s chunk-index identity.**
+
+The live reader treats `LazyListState` item indices as `TxtDocument` chunk indices throughout:
+
+- Position saving converts `firstVisibleItemIndex` directly through `offsetForChunk` ([TxtReaderActivity.kt:220](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:220), [TxtReaderActivity.kt:623](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:623)).
+- Bookmark, annotation, search, scrubber, and TTS jumps call `scrollToItem(chunkForOffset(...))` ([TxtReaderActivity.kt:404](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:404), [TxtReaderActivity.kt:470](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:470)).
+- TTS visibility compares lazy-item indices directly with `spokenChunk` ([TxtReaderActivity.kt:252](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:252)).
+
+Inserting separate translation lazy items shifts every following lazy index, corrupting these mappings. Conversely, composables emitted inside the existing `items(count=chunkCount)` lambda are part of the same lazy item, not separately keyed `LazyColumn` items. Thus the plan’s claim that the existing loop remains byte-identical while separately keyed lazy items are inserted inside it is not implementable as written ([plan:70](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:70), [plan:208](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:208)).
+
+The source-`Text` preservation portion is correct: one unchanged `Text` retains one layout and one chunk registration ([TxtReaderActivity.kt:1043](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1043), [TxtReaderActivity.kt:1059](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1059), [TxtReaderActivity.kt:1062](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1062)). But the plan must choose one viable implementation:
+
+- Keep exactly one lazy item per chunk and put the unchanged source `Text` plus translations in a containing `Column`; or
+- Introduce an explicit lazy-index↔chunk-index mapping and update every position/jump/TTS consumer.
+
+The first is substantially safer. It also needs an explicit gesture exclusion because long-press selection currently falls back to the nearest registered source chunk when the pointer is outside source bounds ([TxtSelectionController.kt:43](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:43)); merely omitting translation registration does not make translation text non-selectable.
+
+3. **The Sentence fallback is underspecified and not yet sound.**
+
+The design evidence is correctly characterized: `BilingualPageContent` maps paragraphs and renders one translation paragraph per source paragraph ([vreader-bilingual.jsx:195](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx:195), [vreader-bilingual.jsx:241](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx:241)); Sentence appears only in the setup control ([vreader-bilingual.jsx:77](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx:77)).
+
+However, v4 says Sentence remains selectable, sentence segmentation/cache identity remains active, but rendering falls back to paragraphs ([plan:82](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:82)). It never defines how multiple sentence translations are deterministically reassembled into one paragraph translation or how sentence spans map back to paragraph spans. Without that shaping contract, implementation either renders sentence items—the prohibited undesigned surface—or serves paragraph-shaped content under a sentence cache key.
+
+For v1, specify deterministic sentence-result aggregation into the containing paragraph, with tests for punctuation, whitespace, multiline paragraphs, CJK, and RTL; otherwise constrain v1 to Paragraph.
+
+4. **FOLD-IN is not wireable “verbatim” against the live #118 UI/ViewModel.**
+
+`AiProviderListScreen` already owns a full `NavScreen`, generic empty-state copy, and row-tap-as-edit behavior ([AiProviderListScreen.kt:45](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:45), [AiProviderListScreen.kt:59](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:59), [AiProviderListScreen.kt:84](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:84), [AiProviderListScreen.kt:101](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:101)). It cannot simultaneously be reused verbatim and reproduce the designed reader-scoped navigation, bilingual-context empty state, checked active row, and tap-to-select behavior ([reader-ai-provider-entry.md:39](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:39), [vreader-ai-provider-entry.jsx:162](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:162)).
+
+Additionally, `AiSettingsViewModel.save()` returns no saved ID and performs `upsert` asynchronously ([AiSettingsViewModel.kt:85](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:85)). Therefore WI-AIP cannot perform the promised `setActive(savedId)` followed by pop-on-success while reusing that ViewModel verbatim. Popping immediately would race persistence; observing list state cannot reliably distinguish the newly saved profile from unrelated updates.
+
+The canonical editor can be reused verbatim, but the scoped list must be a new reader-specific presentation over shared state/components, and saving needs a completion/result seam returning the saved ID.
+
+## Medium
+
+No additional blockers.
+
+Round-3 resolution status:
+
+- **M1 EPUB ownership: resolved.** The controller-only enumerate → cache/direct-prefetch → token-guarded commit flow is coherent, and excluding EPUB kinds from position-driven VM prefetch prevents two planned writers for one canonical row ([plan:181](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:181), [plan:197](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:197)). WI-0 must still prove token lifetime across fragment/activity recreation.
+- **M2 cancellation: resolved.** Native and typed cancellation are ordered before generic mapping, and cancel-and-join single-flight is sound. The cited iOS dual catch and task registry exist ([ChapterTranslationService.swift:359](/Users/ll/workspace/vreader/vreader/Services/AI/ChapterTranslationService.swift:359), [BilingualReadingViewModel.swift:138](/Users/ll/workspace/vreader/vreader/ViewModels/BilingualReadingViewModel.swift:138)).
+- **M3 blank model: resolved.** The fallback matches live precedent ([AiChatViewModel.kt:61](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt:61)); both providers serialize `request.model` directly ([OpenAiCompatibleProvider.kt:38](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/OpenAiCompatibleProvider.kt:38), [AnthropicProvider.kt:36](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AnthropicProvider.kt:36)).
+- **M4 dependency sequencing: resolved.** WI-4b is placed before the production integrations that consume it.
+
+## Low
+
+- `AppContainer` indeed has no live `AiProviderStore`; the cited occurrence is only a comment ([VReaderApp.kt:64](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:64)). Constructing it there is appropriate.
+- `aiConfigured = active profile + successfully decrypted non-blank key`, with cipher failure mapped to false, is correct. Profiles can exist without an active match ([AiProviderStore.kt:34](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:34)), and decrypt can fail at `apiKey(profile)` ([AiProviderStore.kt:105](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:105)).
+- `AiProviderStore.upsert` already activates the first-ever provider ([AiProviderStore.kt:81](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:81)); explicit activation is needed only when adding through this flow while other profiles already exist.
+- Dependencies `[feat:#132, feat:#134]` and the enumerated count of 13 WIs are arithmetically correct ([plan:270](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:270), [docs/features.md:184](/Users/ll/workspace/vreader/docs/features.md:184)).
+
+FINAL VERDICT: block-recommended

--- a/.claude/codex-audits/feat-131-bilingual-gate2-round5.md
+++ b/.claude/codex-audits/feat-131-bilingual-gate2-round5.md
@@ -1,0 +1,3044 @@
+Reading additional input from stdin...
+OpenAI Codex v0.144.1
+--------
+workdir: /Users/ll/workspace/vreader
+model: gpt-5.6-sol
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: high
+reasoning summaries: none
+session id: 019f5489-08ac-7270-bd38-7a77afd2ef54
+--------
+user
+Gate-2 plan audit ROUND 5 (FOCUSED, DECISIVE) for feature #131 (Android bilingual interlinear reading). Read the v5 plan at dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md. Round 4 was block-recommended with 4 High and it CONFIRMED M1/M2/M3/M4 and the Lows resolved. v5 is a TARGETED PATCH resolving ONLY the 4 round-4 High findings plus 2 gaps. Audit ONLY these six items (do NOT re-audit M1/M2/M3/M4 or the Lows — round-4 already cleared them). Be DECISIVE: is each resolved, and is any NEW blocker introduced by the patch?
+
+1. H1 (round-4 High-1, type): v5 introduces a dedicated value type Utf16Span with fields start and endExclusive (new file bilingual/Utf16Span.kt, section 2 H1) replacing List of IntRange EVERYWHERE in the segment/span contracts (ChapterSegmenter.paragraphRanges/sentenceRanges now return List of Utf16Span). Confirm no IntRange remains in the segment/render contract and that Utf16Span (half-open, require endExclusive >= start) is a sound half-open type. Verify against reader/TxtDocument.kt that the final-chunk math (endExclusive = if i+1 less-than chunkCount then offsetForChunk(i+1) else text.length) plus chunkForOffset(span.endExclusive - 1) anchoring is still correct for one-chunk/final-chunk/exact-boundary/EOF.
+
+2. H2 (round-4 High-2, THE key fix, lazy-index identity): v5's binding render contract is now ONE lazy item per chunk — the items(count=chunkCount, key it) loop plus keys UNCHANGED, and INSIDE each item a Column holds the UNCHANGED source Text (one TextLayoutResult, one registerChunk(i)) followed by muted non-registered translation Text children anchored to chunk i. Verify against reader/TxtReaderActivity.kt that this preserves BOTH (a) the per-chunk one-TextLayoutResult/one-selection-registration invariant (~1043-1085) AND (b) the lazy-index equals chunk-index identity the reader relies on for position-save (~220/473/623 offsetForChunk of firstVisibleItemIndex), every jump (~411/421/454/481 scrollToItem of chunkForOffset), and TTS visibility (~252/256 visibleItemsInfo index equals spokenChunk). Confirm a Column child adds NO lazy item and shifts NO index. Verify the translation gesture-exclusion is required plus sound (reader/TxtSelectionController.kt ~47-53 hitAt nearest-chunk fallback means omitting registerChunk is NOT enough to make translation non-selectable). Look for ANY remaining way the in-item Column could still break selection/highlight/wash/position/jump/TTS.
+
+3. H3 (round-4 High-3, Paragraph-only v1): v5 constrains v1 to Paragraph granularity only (segments/caches/renders paragraph; promptVersion g=paragraph always; no sentenceRanges in the v1 render path; setup-sheet Granularity control Paragraph-only; TranslationGranularity.sentence plus ChapterSegmenter.sentenceRanges kept as reserved-foundational WI-1 code). Confirm this removes the underspecified sentence-to-paragraph aggregation AND the wrong-shape-cache-row risk, and is rule-51-clean (verify vreader-bilingual.jsx BilingualPageContent depicts only paragraph interlinear). Is descoping the Sentence CONTROL option (not just the render) sound?
+
+4. H4 (round-4 High-4, WI-AIP fold-in): v5 splits WI-AIP into (a) reuse AiProviderEditSheet VERBATIM, (b) a NEW ReaderAiProvidersList over the shared AiSettingsViewModel.listState reproducing the designed back-to-Bilingual nav plus bilingual-context empty state plus checked-active row plus tap-to-SELECT (NOT reusing AiProviderListScreen's NavScreen/chrome/AiEmptyState/row-tap-edit), (c) a save-result seam on AiSettingsViewModel.save() returning the saved id (from store.upsert result id which the store already returns — AiProviderStore.kt ~58/84) so setActive(savedId) plus pop is race-free. Verify against ai/AiProviderListScreen.kt (owns own NavScreen ~59, generic empty ~84, row-tap-edit ~105), ai/AiSettingsViewModel.kt (save ~85-97 discards id; listState ~26; row.active ~30), ai/AiProviderStore.kt (upsert returns saved profile ~58/84; setActive; activeId = cur.activeId or id ~81), and vreader-ai-provider-entry.jsx (NavSheet backLabel Bilingual ~247; selected/onSelect ~221; empty copy ~180-209). Is the split rule-51-clean plus race-free? Any NEW issue (e.g. the additive save seam touching #118 code)?
+
+5. Gap A (MIGRATION_8_9 DDL): section 2/WI-2 now spell out the exact CREATE TABLE chapter_translations DDL (all NOT NULL cols, PK lookupKey, index_chapter_translations_bookKey, FK to books fingerprintKey ON DELETE CASCADE, modeled on MIGRATION_6_7) plus require the migration test to validate against Room's generated 9.json. Verify the DDL shape matches the entity plus the other child tables in data/VReaderDatabase.kt, and that the exact-DDL-vs-generated-schema guard is the right approach.
+
+6. Gap B (backup granularity flag): v5 flags (sections 6/7) that the backup bilingualGranularity field's cross-platform conformance vector plus iOS parity are UNCONFIRMED, safe for v1 (backup descoped/device-local), follow-up when backup wiring lands. Confirm this is an adequate flag (not a v1 blocker).
+
+Output findings grouped by severity (Critical/High/Medium/Low), each with file:line evidence, then a FINAL VERDICT line exactly one of: ship-as-is | follow-up-recommended | block-recommended. ship-as-is or follow-up-recommended clears Gate-2.
+codex
+I’ll perform the narrowly scoped six-item audit only. I’ll first inspect repository status, the complete v5 plan, architecture context, design artifacts, and the cited Android implementation lines, then report only unresolved or newly introduced findings with precise evidence.
+exec
+/bin/zsh -lc "git status -sb && wc -l docs/architecture.md dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md && rg --files | rg '("'^|/)(TxtDocument|TxtReaderActivity|TxtSelectionController|AiProviderListScreen|AiSettingsViewModel|AiProviderStore|VReaderDatabase)'"\\.kt"'$|vreader-(bilingual|ai-provider-entry)'"\\.jsx"'$'"'" in /Users/ll/workspace/vreader
+ succeeded in 1100ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-dxUlxcxy' (errno=Operation not permitted)
+## main...origin/main
+ M dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md
+ M docs/features.md
+?? .claude/codex-audits/feat-131-bilingual-gate2-round2.md
+?? .claude/codex-audits/feat-131-bilingual-gate2-round3.md
+?? .claude/codex-audits/feat-131-bilingual-gate2-round4.md
+?? .claude/codex-audits/feat-131-bilingual-gate2-round5.md
+?? .claude/codex-audits/feat-136-ai-provider-reachable-gate2.md
+?? android/2026-06-29-223908-this-session-is-being-continued-from-a-previous-c.txt
+?? dev-docs/security/
+     726 docs/architecture.md
+     441 dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md
+    1167 total
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx
+dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt
+android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt
+
+exec
+/bin/zsh -lc "sed -n '1,500p' dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+# Feature #131 — Android Bilingual Interlinear Reading (parity-checklist box D)
+
+**Feature number assumption:** highest active row in `docs/features.md` is `#136` (now CLOSED, see below); `#131` is a landed `PLANNED` row (`GH: #1923`). The orchestrator adjusts if a row is claimed first.
+
+**Design authority (rule 51):** the **authoritative** bilingual surfaces are:
+- `dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx` (`BilingualSetupSheet` / `BilingualPageContent` / `BilingualPill` / `BILINGUAL_LANGS`) — the setup sheet, the **paragraph-interlinear** renderer, and the top-chrome pill.
+- `.../vreader-reader.jsx` (`ReaderTopChrome` renders `BilingualPill`; the bilingual toggle is a More-menu row via `onMoreAction`) and `.../vreader-more.jsx` (the "Bilingual mode" More-menu Row toggle).
+- **The in-reader AI-config surface (folded in from the closed #136):** `dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md` (the CANONICAL **Variant A** decision + navigation model, lines ~39–76, ~110–134) and `.../vreader-ai-provider-entry.jsx` (`AIProvidersSheet`, `AIProvidersSheetBody`, `ProviderRow`, `NavSheet`, `BilingualEngineStrip`). `reader-ai-readiness.md` (iOS #82) is **informational only** — its 4-gate readiness (feature flag + consent manager + provider + key) is iOS-specific and **implementation-deferred**; Android #118 has no feature flag and no consent manager, so the Android readiness gate is provider+key only (see §"AI-config reachability").
+
+`.../vreader-ai-android.jsx` contains a SECOND, differently-shaped `BilingualSetupSheet` — see §3's setup-sheet resolution for why this plan reproduces the `vreader-bilingual.jsx` sheet and design-gates the divergence. Where a surface is NOT depicted it is scoped out and flagged.
+
+**Status:** Gate-1 draft **v5** (2026-07-12) — Gate-2 round-4 (block-recommended) findings resolved (4 High + 2 gaps; targeted patch of v4). Round-4 CONFIRMED M1/M2/M3/M4 (EPUB single-owner flow, dual-cancellation + single-flight, blank-model fallback, DI sequencing) RESOLVED — those are UNCHANGED. Round-4 CONFIRMED the Lows (AppContainer has no `AiProviderStore`, `aiConfigured` semantics, upsert-first-activate, deps/WI-count) correct — those are KEPT. Awaiting Gate-2 round-5 audit.
+
+## 1. Problem
+
+iOS ships bilingual interlinear reading (#56/#100): a per-book toggle renders each source paragraph followed by its translation in a muted style, backed by an AI provider, cached to disk. Android shipped the #118 AI provider foundation (provider store, OpenAI-compat + Anthropic SSE clients, chat/summary) but has **no bilingual capability**, and — as the Gate-2 audits proved — **no production-reachable AI-provider config surface** either. Box D of the parity checklist requires the interlinear renderer + the bilingual setup sheet + the AI-config entry, all building on #118.
+
+The engineering questions are (a) **which render host(s)** get true interlinear, (b) **what the real TXT/MD segmentation unit is** (there is no chapter model — round-2 H1), (c) **how the enabled render preserves the live per-chunk layout/selection model AND the live lazy-index↔chunk-index identity** (round-3 H2 + round-4 H2), and (d) **where the entry point AND the AI-config path live**. The render-host feasibility was settled in v2 (EPUB-primary via Readium `EpubNavigatorFragment.evaluateJavascript`; TXT/MD Compose; AZW3/PDF deferred) and was **CONFIRMED correct by the Gate-2 round-2 audit** — it is not revisited here. This v5 resolves the round-4 findings that concern *how the render maps to real code* and preserves everything round-4 confirmed correct:
+
+- **Host** — EPUB is the **primary** target via `EpubNavigatorFragment.evaluateJavascript(script): String?` (public suspend method in the shipped Readium 3.3.0 AAR — round-2 re-verified; `ReaderActivity.navigator: EpubNavigatorFragment?` is the concrete field, `ReaderActivity.kt:110`). TXT/MD (Compose) are built alongside as the deterministic pipeline proof.
+- **TXT/MD unit (round-2 H1)** — `TxtDocument` has NO chapter model; it is line-based ≤4000-char chunks addressed by UTF-16 offset. v5 defines **document-global units with segment UTF-16 spans produced ONCE by the segmenter** and renders source/translation pairs from those same spans, with the **round-3 H1 final-chunk math fix**, the new **round-4 H1 `Utf16Span` value type** (§2, replacing `IntRange`), and the **round-4 H2 one-lazy-item-per-chunk `Column` render contract** (§2, §3).
+- **Entry point** — the design puts the toggle in the **More-menu** (`vreader-more.jsx`; the live `MoreActionId.BILINGUAL` id is already reserved, and `MoreRow.Toggle` carries `on`/`onToggle` — `reader/more/MoreRow.kt:24,56–63`) + a **top-chrome pill** (`vreader-reader.jsx`). Both landed as box-F sub-features **#132 (top chrome) and #134 (More menu), now VERIFIED** — the entry wiring targets them directly (§4).
+- **AI-config path (folded in — #136 CLOSED)** — the ONLY designed Android AI-config reader surface is the **Variant A scoped "AI Providers" sheet pushed inside the bilingual flow**, reached from the bilingual engine strip's "Set up"/"Change…" button (`reader-ai-provider-entry.md`). #131 now owns it end-to-end (§"AI-config reachability", WI-4b + WI-AIP + WI-9).
+
+## 2. Surface area
+
+### Render-host decision (settled in v2, CONFIRMED by round-2 — not reopened)
+
+**Two hosts, in dependency order:**
+
+1. **EPUB (Readium `EpubNavigatorFragment`) — PRIMARY.** Interlinear via `evaluateJavascript` (enumerate leaf blocks → inject translation DOM nodes → clear on teardown/reflow), mirroring iOS `EPUBBilingualOrchestrator`. Gated by **WI-0 (a Readium bilingual spike with enforceable go/no-go thresholds + a navigator-race contract — round-2 M1)** before the EPUB render WI (WI-7b) is built.
+2. **TXT/MD (Compose `TxtReaderActivity`) — INCLUDED.** No WebView; deterministically Compose-testable. Renders translations **inside the SAME lazy item as their anchor source chunk** (round-4 H2 — one lazy item per chunk, a wrapping `Column`), from **document-global segment `Utf16Span`s** (round-2 H1 + round-4 H1).
+
+**AZW3 (foliate WebView)** and **PDF** remain follow-ups / out (§"Files OUT of scope").
+
+**Why both, not TXT/MD-only:** the *pipeline* (segment → chunk → translate → cache → interleave) is host-agnostic; only the *render injection* is host-specific. EPUB is the format most users read, so shipping box D without it would under-deliver. TXT/MD are included because the Compose host is the cheapest, most testable place to prove the pipeline end-to-end (deterministic tree assertions), de-risking the EPUB adapter. **Box D cannot be checked on a false "EPUB requires a fork" rationale** — that rationale is discarded and stays discarded.
+
+### The TXT/MD segmentation unit + render mapping (round-2 H1 + round-3 H1 + round-4 H1/H2 — the core corrections)
+
+**Verified against live code:** `TxtDocument` (`reader/TxtDocument.kt`) exposes only `text: String`, `chunkCount` (`starts.size`, TxtDocument.kt:14), `offsetForChunk(index)` (TxtDocument.kt:17), `chunkForOffset(offsetUtf16)` (TxtDocument.kt:23), `textForChunk(index)` (TxtDocument.kt:36) — line-based ≤4000-char chunks over UTF-16 offsets against the RAW text (no line-ending normalization). It has **no chapter/section concept**.
+
+**Chunk semantics (round-3 Low-2 correction — the real cases):** a chunk is **ONE LINE** — `TxtDocument.of` starts a new chunk after every `\n`, `\r`, or `\r\n` (TxtDocument.kt:65–86; a runaway line >4000 chars is additionally hard-split, never mid-surrogate-pair). Therefore:
+- A **chunk can hold multiple SENTENCES** (one line, several `。！？`/`. ! ?` sentences).
+- A **paragraph spans MANY chunks** (blank-line-delimited paragraph = several physical lines = several chunks).
+- The old v3 claim "a chunk can hold multiple **paragraphs**" is **WRONG and removed.** (A single chunk cannot straddle a line terminator, and paragraph boundaries are blank lines, i.e. chunk boundaries — so a chunk holds *part of one* paragraph, never a whole extra paragraph.)
+
+**v5 model — document-global units with segment spans produced ONCE:**
+
+- The whole `.txt`/`.md` is treated as **one translation document**. The **segmenter runs once over `TxtDocument.text`** (the full raw backing string) and emits, per segment, its **UTF-16 span as a `Utf16Span(start, endExclusive)`** (half-open) against that same backing string (the segmenter's `paragraphRanges(text): List<Utf16Span>` / `sentenceRanges(text): List<Utf16Span>` — the span-returning peers of `paragraphs`/`sentences`; iOS precedent `ChapterSegmenter.sentenceRanges(in:)` at `ChapterSegmenter.swift:78`, returns `[Range<Int>]`). These spans are the SINGLE source of truth used by BOTH the translate side and the render side, so the two segment identically **by construction** (they read the same array). Spans are stored/compared as the explicit `Utf16Span` value type (see the H1 fix below), NOT re-derived on the render side.
+- **Unit granularity for TXT/MD is the whole document, sub-batched for cache/prefetch by a deterministic "unit window."** To avoid translating a 14 MB book at once (and to keep cache rows bounded), segment spans are grouped into fixed **unit windows** of contiguous segments (window size a build-time constant; it does not change the 1:1 contract). Each window is a `TranslationUnitId(kind = txtDocSegmentWindow, value = windowIndex)` — a document-global index, NOT a chunk index. `unitContaining(charOffsetUTF16)` maps the reader's saved offset → the segment whose span contains it → its window index (via a precomputed segment-start binary search, the same shape as `TxtDocument.chunkForOffset`, TxtDocument.kt:23–33). `unitAfter(unit)` = next window index or null at document end.
+
+#### H1 fix (round-3 High-1 math + round-4 High-1 type) — final-chunk source span + the `Utf16Span` value type (BINDING)
+
+**The math (round-3 High-1 — CONFIRMED correct by round-4, UNCHANGED):** `offsetForChunk()` **CLAMPS** an out-of-range index to the last valid chunk (`starts[index.coerceIn(0, starts.size - 1)]`, TxtDocument.kt:17–20). So for the LAST chunk `i`, `offsetForChunk(i + 1) == offsetForChunk(i)` → an **empty span** → a one-chunk document drops EVERY translation and a paragraph ending in the final chunk drops its sole translation. `textForChunk()` avoids this by using `text.length` for the final end (TxtDocument.kt:39). The render side MUST do the same. **Binding rule:**
+
+```
+val endExclusive = if (i + 1 < document.chunkCount) document.offsetForChunk(i + 1) else document.text.length
+// chunk i source span is the HALF-OPEN Utf16Span(document.offsetForChunk(i), endExclusive)
+```
+
+**The type (round-4 High-1 — THE fix this round):** v4 declared `paragraphRanges`/`sentenceRanges` as `List<IntRange>` while treating them as half-open `[start, endExclusive)`. That is a **type contradiction** — Kotlin `IntRange` is inclusive-inclusive (`range.last` is the last *included* index, and `range.last` for an empty/at-EOF span is a footgun). The half-open contract and the `IntRange` type are incompatible. **Resolution — a dedicated value type, replacing `IntRange` EVERYWHERE:**
+
+```
+// bilingual/Utf16Span.kt  (NEW FILE — rides WI-1)
+data class Utf16Span(val start: Int, val endExclusive: Int) {
+    init { require(endExclusive >= start) }
+    val isEmpty: Boolean get() = endExclusive == start
+    val length: Int get() = endExclusive - start
+}
+```
+
+- `ChapterSegmenter.paragraphRanges(text): List<Utf16Span>` / `sentenceRanges(text): List<Utf16Span>` return `Utf16Span`s (half-open, against the input string). `TxtChapterTextProvider` and the TXT/MD render path consume `Utf16Span` — there is **no `IntRange`** anywhere in the segment/span contracts. (`TxtSelectionController`'s own `Utf16Range` type is a *separate*, unrelated selection type and is untouched — see H2's gesture-exclusion note.)
+- A segment's "end offset" for anchoring (below) is its `endExclusive`; the chunk that "contains a segment's end" is `document.chunkForOffset(span.endExclusive - 1)` when `!span.isEmpty`, clamped to `[0, chunkCount-1]` (an empty segment is dropped by the segmenter and never anchored).
+- **Tests (WI-1 / WI-4a / WI-8):** `paragraphRanges`/`sentenceRanges` return correct half-open `Utf16Span(start, endExclusive)` spans (unit — WI-1); one-chunk document (no trailing newline) → its single paragraph/sentence translation renders (not dropped); final-chunk anchor (a paragraph whose last line is the final chunk) → translation renders after the last chunk; exact-boundary (a segment ending exactly at a chunk `start`) → anchored to the correct chunk, not off-by-one; EOF anchor (`span.endExclusive == text.length`) → resolves to the last chunk, no clamp-collapse.
+
+#### H2 fix (round-3 High-2 layout/selection + round-4 High-2 lazy-index identity) — the enabled render contract (BINDING; preserves BOTH the per-chunk model AND lazy-index==chunk-index)
+
+**Live invariant #1 — per-chunk layout/selection (round-3 High-2, verified TxtReaderActivity.kt:1043–1085):** the TXT/MD body iterates `items(count = document.chunkCount, key = { it })` (TxtReaderActivity.kt:1043). For **each chunk `i`** it owns **exactly ONE `TextLayoutResult`** (`var layout by remember(i) { … }`, set in `onTextLayout`, TxtReaderActivity.kt:1059/1075) and **exactly ONE selection registration** (`selectionController.registerChunk(i, l, c)` / `unregisterChunk(i)`, TxtReaderActivity.kt:1062–1066). Highlights (`highlightSpan(i)`, :1047), annotation washes (`washesForChunk(i)`, :1058), the read-aloud span wash (`addStyle(SpanStyle(background = wash), …)`, :1050–1054), and selection accents (`selectionForChunk(i)` → `drawRangeFill`, :1069/1081) all key off that **per-chunk** layout and the chunk-local UTF-16 offsets. **Splitting a chunk's source `Text` into multiple `Text` nodes would break every one of these** (two `Text` nodes = two `TextLayoutResult`s = broken selection coordinates, misplaced highlight/wash/annotation ranges, a shifted read-aloud wash).
+
+**Live invariant #2 — lazy-index == chunk-index (round-4 High-2 — THE key fix this round; verified):** the live reader treats `LazyListState` item indices as `TxtDocument` chunk indices EVERYWHERE:
+- **Position save** converts `firstVisibleItemIndex` → offset via `offsetForChunk` (`savePosition(...) { val offset = document.offsetForChunk(topIndex) }`, TxtReaderActivity.kt:623–624), and the steady-state/onStop save both pass `listState.firstVisibleItemIndex` directly (TxtReaderActivity.kt:220–223, :227–230). Resume converts back via `chunkForOffset` (`initialFirstVisibleItemIndex = s.initialIndex`, :220; `s.initialIndex` = `document.chunkForOffset(offset)`, :619). The bottom-chrome progress fraction reads `document.offsetForChunk(listState.firstVisibleItemIndex)` (:473).
+- **Bookmark / annotation / search / scrubber / TTS jumps** all call `listState.scrollToItem(document.chunkForOffset(target))` (bookmark :411, annotation :421, search :454, scrubber :481; TTS auto-scroll `animateScrollToItem(spokenChunk)` where `spokenChunk = document.chunkForOffset(tts.charStart)` — :252/:257).
+- **TTS visibility** compares lazy-item indices with the chunk directly: `listState.layoutInfo.visibleItemsInfo.none { it.index == spokenChunk }` (:256).
+
+**Therefore inserting SEPARATE translation `LazyColumn` items (the v4 "additive items after the anchor chunk" contract) is NOT implementable:** every separate translation item inserted before a given source chunk shifts that chunk's lazy index, so `offsetForChunk(firstVisibleItemIndex)` reads the wrong chunk's offset (corrupts position save + progress), `scrollToItem(chunkForOffset(target))` lands on the wrong item (corrupts every jump), and `visibleItemsInfo.index == spokenChunk` never matches (corrupts TTS auto-scroll). The v4 contract is **rejected**.
+
+**v5 binding render contract (one lazy item per chunk — a wrapping `Column`):**
+
+> **Keep EXACTLY ONE lazy item per chunk.** The existing `items(count = document.chunkCount, key = { it })` loop is **UNCHANGED** — so lazy-index == chunk-index is preserved and NO position/jump/TTS consumer breaks. INSIDE each item's lambda, wrap the content in a `Column`:
+> 1. the **UNCHANGED source `Text`** — one `TextLayoutResult`, one `registerChunk(i, …)`/`unregisterChunk(i)`, byte-identical to today (the exact code at TxtReaderActivity.kt:1044–1084 is unchanged, now nested in a `Column`);
+> 2. **below it, still inside the SAME lazy item**, the translation(s) **anchored** to chunk `i` (`chunkForOffset(span.endExclusive - 1) == i`) as **muted, non-registered** `Text`(s) (accent left-border, `fontSize*0.88`, CJK/RTL styling per `BilingualPageContent`).
+
+A paragraph spanning chunks `j..i` renders its ONE translation inside chunk `i`'s `Column` (after the paragraph's last source line). This preserves BOTH invariants: the per-chunk one-layout/one-registration model (the source `Text` is never split, the translation is a *sibling* `Text` in the `Column`, not a re-layout of the source) AND the lazy-index↔chunk-index identity (the translation lives inside the anchor's lazy item, adds no lazy item, shifts no index).
+
+Concretely the body becomes, per chunk `i` (in the same single `items(count = document.chunkCount, key = { it })` loop):
+
+1. Open a `Column` for item `i`.
+2. Render the source chunk `i` **EXACTLY as today** (the unchanged `Text` + its `remember(i)` layout/coords + `registerChunk(i, …)`/`unregisterChunk(i)` + `highlightSpan(i)`/`washesForChunk(i)`/`selectionForChunk(i)` — TxtReaderActivity.kt:1044–1084, now the first child of the `Column`).
+3. Look up the translations **anchored** to chunk `i` = every segment whose end resolves to `chunkForOffset(span.endExclusive - 1) == i`, in segment order, from the shared span array. For **paragraph** granularity (the only v1 granularity — see the granularity subsection) there is at most one such translation per anchor chunk in the common case (a paragraph's translation renders after the paragraph's last line-chunk).
+4. Emit each anchored translation as a muted, non-registered `Text` sibling **inside the same `Column`**, keyed by the segment's `Utf16Span` so a language change re-keys cleanly.
+
+When bilingual is **OFF**, no translation children are emitted → each item's `Column` holds only the unchanged source `Text`, so the tree is **behaviorally identical to today** (translations are additive in-item children only; this is asserted by a source-selection-parity test, since a single-child `Column` does not perturb the source `Text`'s layout/registration/offsets).
+
+- **Explicit translation gesture exclusion (round-4 High-2 — BINDING):** `TxtSelectionController.hitAt` (`reader/TxtSelectionController.kt:47`) falls back to the **nearest registered source chunk** when the pointer is outside all source-chunk bounds (`chunks.entries.minByOrNull { verticalDistance(...) }` when no chunk's `boundsInWindow()` contains the point, :51–53). So merely omitting `registerChunk` for the translation does **NOT** make it non-selectable — a long-press *on the translation text* would fall through to the nearest source chunk and select source. **WI-8 must add an explicit hit-test / gesture exclusion for the translation composable's bounds** so a long-press whose pointer lands inside a translation `Text`'s bounds is consumed (no selection begun) rather than routed to `hitAt`'s nearest-chunk fallback. (Options: the translation `Text` consumes the long-press gesture in its own `pointerInput`; or the selection gesture root records the translation composables' window bounds and short-circuits `beginAt` when the point is inside one. WI-8 picks and tests one.)
+
+- **Enabled-mode tests (WI-8 connected + WI-7a Compose, BINDING):** with bilingual ON —
+  - (a) each source chunk's **selection registration is UNCHANGED** (same `registerChunk(i, …)` count and coordinates as OFF; a translation child registers nothing);
+  - (b) **highlights/annotation washes/read-aloud wash still key off the source chunks** at the correct offsets (a translation child in the anchor's `Column` does not shift them);
+  - (c) **lazy-index == chunk-index preserved:** with bilingual ON — **position-save round-trips to the same chunk** (`offsetForChunk(firstVisibleItemIndex)` → save → reopen → `chunkForOffset(offset)` lands on the same chunk); **bookmark/annotation/search/scrubber jumps land on the correct chunk** (`scrollToItem(chunkForOffset(target))` scrolls to the right item); **TTS auto-scroll targets the correct chunk** (`visibleItemsInfo.index == spokenChunk` matches); (assert these are identical to the OFF baseline — no lazy index shift);
+  - (d) a **long-press on translation text does NOT select** (gesture exclusion — the nearest-source-chunk fallback is not reached);
+  - (e) a **translation child is non-selectable** and does not perturb source offsets (selecting across the source/translation boundary selects source only);
+  - (f) **MD source mapping** — the markdown renderer (`mapper.renderedText(i)`, TxtReaderActivity.kt:1049) still owns the source chunk render; the translation child is plain muted text;
+  - (g) **paragraph-spanning-many-chunks** renders exactly ONE translation (inside the paragraph's last chunk's `Column`), never per-line;
+  - (h) final-chunk/one-chunk anchors render (H1).
+
+- **Granularity — Paragraph ONLY in v1 (round-4 High-3):** `vreader-bilingual.jsx` `BilingualPageContent` (lines ~195–277) is a **paragraph-interlinear** renderer: it maps `page.paragraphs.map(...)` and renders **one source `<p>` followed by ONE translation `<p>`** per paragraph. **Sentence-granularity interlinear is depicted NOWHERE** — Sentence appears ONLY as an option in the `BilingualSetupSheet` Granularity segmented control (`vreader-bilingual.jsx:77`), never in the renderer, AND v4's "Sentence selectable + sentence cache identity active + paragraph-render fallback" was underspecified (no defined sentence→paragraph aggregation, so it would either render undesigned sentence items or serve paragraph content under a sentence cache key). **Resolution — v1 segments + caches + renders Paragraph ONLY:**
+  - The `TranslationGranularity` enum + `ChapterSegmenter.sentenceRanges` API **stay as reserved FOUNDATIONAL code** (WI-1, with unit tests) so the future sentence-render is a render-only follow-up.
+  - The v1 **render/cache/VM/setup-sheet path uses paragraph exclusively:** `promptVersion`'s granularity component is **always `paragraph` in v1**; there is **no `sentenceRanges` in the v1 render path**; the setup sheet's Granularity control is **descoped to Paragraph-only in v1** (a documented divergence, tracked by the sentence design gate below — the same treatment as the Style descope).
+  - This keeps rule 51 (implement only what is depicted — paragraph interlinear) while shipping the depicted paragraph parity. The one-lazy-item-per-chunk `Column` render contract already accommodates a future per-line sentence grouping (several translation children stacked in one chunk's `Column`), so the sentence gate, once designed, is render-only.
+
+- **MD source** = raw markdown segment text (translation renders as plain muted text, not re-markdown-rendered — matches the muted-secondary design line). Segmentation runs over the raw markdown string; MD markers are treated as ordinary characters by the paragraph splitter (blank-line delimited), consistent with `TxtMdTextExtractor` shipping raw markdown to search.
+
+This closes round-3 H1 (no dropped final-chunk translations), round-3 H2 (per-chunk layout/selection preserved; source `Text` never split), round-4 H1 (the `Utf16Span` type replaces the incompatible `IntRange`), round-4 H2 (one lazy item per chunk preserves lazy-index==chunk-index; translation gesture exclusion), round-4 H3 (Paragraph-only v1 granularity), and round-3 Low-2 (correct chunk semantics).
+
+### AI-config reachability — FOLDED IN (#136 CLOSED; Variant A owned by #131)
+
+**Verified against live code:** `AppContainer` (`VReaderApp.kt:31–268`) constructs **NO `AiProviderStore`** — the only reference is a *comment* naming "the OpdsSourceStore / AiProviderStore precedent" (VReaderApp.kt:64/66), no actual instance/provision. There is **no live navigation route to `AiProviderListScreen`** (the #118 `AiProviderListScreen` / `AiProviderStore` / `AiSettingsViewModel` exist and are exercised only by instrumented/round-trip tests). A fresh-install user therefore cannot reach provider config today.
+
+The Gate-2 audits + the two design-notes proved the ONLY designed Android AI-config reader surface is **Variant A** (`reader-ai-provider-entry.md`, CANONICAL): a **scoped "AI Providers" sheet pushed _inside_ the bilingual sheet**, reached from the bilingual engine-strip's "Set up"/"Change…" button. The design explicitly **rejected** a standalone entry (there is NO designed standalone More-menu "Configure AI" row), a full-Settings deep-link (alternative B), and inline expansion (alternative C). So AI-config reachability is **NOT separable** from the bilingual flow — the #136 spin-out is **CLOSED (GH #1976, not-planned)** and **#131 now owns it end-to-end** (user decision 2026-07-12).
+
+**Navigation model (reproduced EXACTLY from `reader-ai-provider-entry.md`:110–134, invent nothing):**
+
+```
+More ▸ Bilingual mode (first toggle on)
+  └─ BilingualSetupSheet   [bottom sheet]
+       engine strip: "No AI provider configured"  [ Set up ]
+                             │  onOpenSettings
+                             ▼  (push, slide-left, same sheet frame)
+     ReaderAiProvidersSheet  [nav bar: ‹ Bilingual · "AI Providers"]
+       ├─ empty  → [ Add provider ] ─┐
+       └─ list   → tap a row SELECTS it (setActive) │  (present the canonical editor, full height)
+                             ▼        ▼
+                    AiProviderEditSheet   [reused VERBATIM from #118]
+                             │  Save
+                             ▼  (saved provider becomes the bilingual engine,
+                                  pop the whole stack)
+     BilingualSetupSheet  ← engine strip now "Claude · configured" / Change…
+```
+
+- **`‹ Bilingual` without adding** returns to the bilingual sheet **still unconfigured — no state mutated.**
+- **"Change…"** (already-configured strip) opens the **SAME** `ReaderAiProvidersSheet`, populated, **current provider checked**; tapping a row **selects** it (`setActive`).
+- The AI Providers view is a **push within the bilingual sheet**, NOT a modal over the reader and NOT the full app Settings.
+
+**Android readiness gate (BINDING — round-3/round-2 H3 + the #136-audit High-3 lesson; round-4 CONFIRMED correct, UNCHANGED):** `aiConfigured` on the engine strip is derived by `BilingualAiReadiness.resolve(snapshot)` = **an ACTIVE profile exists AND its API key decrypts to non-empty.** Deriving from `profiles.isEmpty()` alone is **WRONG**: the store keeps a separate `activeId` that can be **null with profiles present** (`AiProviderSnapshot.active = profiles.firstOrNull { it.id == activeId }`, AiProviderStore.kt:34–36), and key usability depends on **decrypting the active profile's token** (`apiKey(profile) = cipher.decrypt(profile.encryptedApiKey)`, AiProviderStore.kt:108). A cipher/keystore failure maps to **not-ready, never a crash** (the resolve wraps the decrypt in `runCatching`). **Note:** the iOS Variant A design-note (`reader-ai-provider-entry.md:172–174`) derives `aiConfigured` from `providers.isEmpty == false`, and iOS #82 (`reader-ai-readiness.md`) adds a 4-gate readiness (flag + consent + provider + key). **Android has NO consent manager and NO feature flag** (#118 has neither — confirm during build); the Android gate is exactly what #118 enforces = **provider (active) + key (decrypts non-empty)**. We do NOT invent a consent/flag gate.
+
+### New files
+
+**Pipeline / domain (host-agnostic, pure or coroutine — JVM-testable):**
+
+- `bilingual/Utf16Span.kt` — **NEW (round-4 H1).** `data class Utf16Span(val start: Int, val endExclusive: Int)` (half-open UTF-16 span; `require(endExclusive >= start)`; `isEmpty`, `length`). The single span type shared by the segmenter and the TXT/MD render path, replacing the incompatible `IntRange`. Rides WI-1. (Distinct from `TxtSelectionController.Utf16Range`, the selection type, which is untouched.)
+- `bilingual/TranslationUnitId.kt` — `data class TranslationUnitId(kind, value)` with `enum Kind { epubHref, foliateHref, txtDocSegmentWindow, mdDocSegmentWindow, pdfPageRange }`; `storageKey = "${kind.name}:$value"`. TXT/MD kinds are **document-global segment-window indices** (H1), NOT chunk indices. v5 uses `epubHref` + `txtDocSegmentWindow`/`mdDocSegmentWindow`; others reserved so the cache-key format never breaks. *(Assumption: iOS's exact Kind case names for the TXT/MD variants; only the `storageKey` string format is load-bearing for the cache contract, and that is preserved.)*
+- `bilingual/TranslationGranularity.kt` — `enum { paragraph, sentence }`. **Reserved foundational code** (WI-1, unit-tested); the v1 render/cache/VM/setup-sheet path uses `paragraph` exclusively (round-4 H3). `sentence` is design-gated.
+- `bilingual/BilingualLanguages.kt` — `BilingualLanguage(key, glyph, script)`; `BILINGUAL_LANGS` = the exact set from `vreader-bilingual.jsx:15–25` (Chinese/Japanese/Korean cjk, Spanish/French/German/Italian latin, Arabic rtl, Russian cyrillic) + `findOrDefault(key)`. Default `Chinese`.
+- `bilingual/ChapterSegmenter.kt` — **NEW file (no existing Android segmenter — verified).** Port of iOS `ChapterSegmenter`: `paragraphs(text)` / `sentences(text)` **plus the span-returning peers `paragraphRanges(text): List<Utf16Span>` / `sentenceRanges(text): List<Utf16Span>`** (half-open UTF-16 spans against the input string, as `Utf16Span` — round-4 H1; iOS `sentenceRanges(in:)` precedent). CJK-aware sentence enumeration (`。！？` vs Latin). Pure. (`sentenceRanges` is reserved-foundational; the v1 render path calls only `paragraphRanges` — round-4 H3.)
+- `bilingual/TranslationChunker.kt` — `chunk(segments, maxCharsPerChunk)` + `subSplit(text, maxChars)`. Port of iOS `ChapterTranslationChunker.chunk(...)` (`ChapterTranslationChunker.swift:85`) + `subSplit(...)` (returns index groups, oversize segment gets its own chunk; `subSplit` is the Bug #330 grapheme-safe over-budget splitter).
+- `bilingual/TranslationChunkContract.kt` — `userPrompt(segments, targetLanguage)`; `decode(raw, expectedCount)` (strict JSON-array + code-fence strip); `sealed class DecodeError { NotAStringArray; CountMismatch(expected, actual) }`. Port of iOS `TranslationChunkContract` (`TranslationChunkContract.swift:24`). No `style` param — Style descoped v1 (§3).
+- `bilingual/ChapterTextProvider.kt` — `interface { units(); sourceSegments(unit); sourceText(unit); unitContaining(charOffsetUTF16); unitAfter(unit) }`. `sourceSegments(unit)` returns the exact segment strings (from the shared span array). Resolution is host-specific: TXT/MD key on `charOffsetUTF16` → segment-window; EPUB keys on the current-resource `href`. Honest divergence from iOS's uniform Readium `Locator`, documented.
+- `bilingual/TxtChapterTextProvider.kt` — provider over `TxtDocument` + the segmenter's `Utf16Span` array (H1). Builds the document-global segment `Utf16Span`s once (via `paragraphRanges` — paragraph only in v1), groups them into windows, resolves `unitContaining` via a segment-start binary search over `charOffsetUTF16`. MD source = raw markdown segment text.
+- `bilingual/EpubChapterTextProvider.kt` (WI-0-gated shape) — provider over the Readium `Publication` reading order; `units()` = spine hrefs, `unitContaining` = the locator's href (from `EpubNavigatorFragment.getCurrentLocator()`), `sourceSegments(unit)` = the DOM-enumerated block texts (the render's OWN enumeration, for direct-block 1:1 — H2). Its render-side collaborator is `EpubBilingualJs`.
+- `bilingual/ChapterTranslationError.kt` — `sealed { Offline; TimedOut; ProviderFailed(msg); Cancelled }`. Maps from `AiError` (verified cases `Auth401`, `RateLimited429`, `Offline`, `Timeout`, `Http(code)`, `Decode`, `Stream`, `InsecureUrl`, `Config`, AiTypes.kt).
+- `bilingual/ChapterTranslationService.kt` — the iOS-parity service (full divergence-recovery surface, round-2 H2):
+  - `cachedTranslation(bookKey, unit, sourceText, targetLanguage, granularity, acceptCountMismatch=false)` — cache-only; serves a row only when `sourceParagraphCount == segments.size` (or `acceptCountMismatch`). No provider (#306 parity).
+  - `cachedTranslation(bookKey, unit, expectedSegmentCount, targetLanguage)` — the divergence-fallback cache-only restore (iOS Bug #343): serves the canonical row only when its STORED `sourceParagraphCount == expectedSegmentCount`. Needs no source text and no provider → a cache-hit toggle/reopen restores with **zero provider calls**.
+  - `translate(bookKey, unit, sourceText, targetLanguage, providerProfile, granularity, bypassCacheRead=false)` — segment → chunk → per-chunk `AiClient.chat` one-shot → `decode` → per-segment fallback → per-chunk graceful degrade (Bug #330) → cache-write only on full success (`sourceParagraphCount = segments.size`). **Cancellation:** maps BOTH native `CancellationException` AND typed `ChapterTranslationError.Cancelled` to `Cancelled` (mirrors iOS `ChapterTranslationService.swift:359–364`); `ensureActive()` between chunks AND immediately before the Room write.
+  - `translatePreSegmented(bookKey, unit, segments, targetLanguage, providerProfile)` — the count-divergence recovery (iOS Bugs #268/#330/#343). Takes the render's OWN enumerated block texts as `segments` (1:1), chunks them, translates with the same per-chunk graceful-degrade + dual-cancellation contract, and — on full success only — caches under the canonical key with the ENUMERATE's count as `sourceParagraphCount`. A partial degrade is NOT cached; a cache-write failure does not fail the translation (iOS `ChapterTranslationService.swift:374–384`).
+  - Uses `AiClient.chat(AiRequest)` (one-shot, verified — NOT `streamChat`).
+- `bilingual/ChapterTranslationPrefetcher.kt` — resolves the active profile from one `AiProviderStore.snapshot()` (`snapshot.active`), decrypts via `store.apiKey(profile)` (snapshot-consistent, AiProviderStore.kt:108), builds an `AiClient` via an **injected factory param** (below), cache-first then translate. Adds the direct-block peers (H2):
+  - `prefetch(unit)` — the plain-text path.
+  - `prefetchDirect(unit, sourceSegments, targetLanguage)` — the divergence path (iOS `translatedSegmentsDirect`, `ChapterTranslationPrefetcher.swift:197`).
+  - `cachedDirect(unit, expectedCount, targetLanguage)` — the **zero-provider cache-only restore** (iOS `cachedSegmentsDirect` → `cachedTranslation(expectedSegmentCount:)`, `ChapterTranslationPrefetcher.swift:236`): returns a cached translation on a hit WITHOUT requiring an active provider (#306 pre-gate precedent). Backs the EPUB cache-restore path.
+  - **`AiRequest` construction (round-3 M3 fix, BINDING; round-4 CONFIRMED correct):** `model = profile.model.ifBlank { profile.kind.defaultModel }` — matches `AiChatViewModel.kt:61`; both wire clients serialize `request.model` **directly** (`put("model", request.model)` in `OpenAiCompatibleProvider.kt:38` and `AnthropicProvider.kt:36`), so a blank `profile.model` would send an empty model. Full request: `AiRequest(model = profile.model.ifBlank { profile.kind.defaultModel }, messages = …, temperature = profile.temperature, maxTokens = profile.maxTokens, system = …)`. A **blank-model regression test** asserts the fallback is applied.
+  - Throws `ChapterTranslationError`. Mirrors iOS `ChapterTranslationPrefetcher`.
+- `bilingual/BilingualAiReadiness.kt` — `resolve(snapshot: AiProviderSnapshot): Boolean` — active profile exists (`snapshot.active != null`) AND `runCatching { store.apiKey(snapshot.active).isNotEmpty() }.getOrDefault(false)` (cipher/decryption failure → **not-ready**, never crashes). Drives the setup-sheet engine-strip configured/unconfigured state. Exactly the #118 gate (no consent manager / feature flag on Android — confirm during build).
+
+**State / persistence:**
+
+- `bilingual/PerBookBilingualStore.kt` — DataStore-Preferences, keyed by `bookFingerprintKey`, holding `{ enabled, targetLanguage, granularity }` (`granularity` is persisted but pinned to `paragraph` in v1 — round-4 H3). The Android `PerBookSettingsOverride` bilingual slice — the backup contract declares exactly `bilingualEnabled` / `bilingualTargetLanguage` / `bilingualGranularity` and **NO `bilingualStyle`** (verified). Wiring into backup collect/restore is scoped OUT (§7); until then bilingual config is device-local.
+- `bilingual/BilingualViewModel.kt` — `StateFlow<BilingualUiState>` with `enabled`, `targetLanguage`, `granularity`, `needsSetupSheet`, `aiConfigured`, `translationsByUnit`, `inFlightUnits`, `unavailableUnits`, `errorUnit`. Setters + `dismissSetupSheet`, `onPositionChanged(charOffsetUTF16)`, `retryUnit(unit)`, and the EPUB direct-block entry `onEpubBlocksEnumerated(unit, blocks)` (M1, below). Generation/epoch-guarded prefetch (current + next unit); a **per-unit single-flight job registry** (M2); dual-cancellation handling (M2). Port of iOS `BilingualReadingViewModel` (`prefetchTasks: [TranslationUnitID: Task]`, `BilingualReadingViewModel.swift:141`) + `+Prefetch`. Split to `BilingualPrefetchController.kt` if it nears ~300 lines. No `style` field.
+
+**Room (translation cache):**
+
+- `data/ChapterTranslationEntity.kt` — `@Entity(tableName="chapter_translations", indices=[Index("bookKey")], foreignKeys=[FK→books.fingerprintKey ON DELETE CASCADE])`. **`@PrimaryKey val lookupKey: String`** (Room requires a PK; project pattern `@PrimaryKey` + `@Upsert`, verified `BookEntity` `@PrimaryKey val fingerprintKey`, Entities.kt:24). `lookupKey` = `bookKey|unitStorageKey|targetLanguage|promptVersion`. Columns: `lookupKey` (PK), `bookKey`, `unitStorageKey`, `targetLanguage`, `promptVersion`, `translatedJson`, `sourceParagraphCount`, `createdAt`. Mirrors iOS `ChapterTranslationRecord.lookupKey` (`book|unit|lang|prompt`, profile-agnostic — Bug #342). `sourceParagraphCount` is load-bearing for H2 (stores the enumerate's count on the `translatePreSegmented` path so `cachedTranslation(expectedSegmentCount:)` restores). **The exact `MIGRATION_8_9` DDL is authored in WI-2 — see below.**
+- `data/ChapterTranslationDao.kt` — `getByLookupKey(key)`, `@Upsert suspend fun upsert(row)`, `deleteByLookupKey(key)`.
+- `bilingual/ChapterTranslationStore.kt` — coroutine wrapper returning a `CachedTranslation` (segments decoded from JSON), keeping Room entities off the boundary (iOS `ChapterTranslationStore` precedent).
+
+**Cache-identity (reconciled with iOS parity):** the 4-part key `book|unit|lang|promptVersion` is profile-AGNOSTIC / style-agnostic (Bug #342). Style is descoped (§3) so no `s=` component. **Granularity is paragraph-only in v1** (round-4 H3): `promptVersion = "bilingual-v1|g=paragraph"` in v1 (the `g=` component is always `paragraph`). The composite `g=` slot is retained in the key format so a future granularity is a different cache row by construction (closes the iOS #344 "sentence silently ignored" class ahead of time), but v1 never emits `g=sentence`. A language change cancels in-flight jobs, bumps the VM generation, clears shaped `translationsByUnit`, and forces a correctly-keyed re-fetch (WI-6).
+
+**DI / factory (verified live):** `AiProviderFactory` is an `object` with `create(profile, apiKey, dispatcher = Dispatchers.IO): AiClient` (verified, `AiProviderFactory.kt:10`). `ChapterTranslationPrefetcher` takes its OWN injected `clientFactory: (AiProviderProfile, String) -> AiClient` param **defaulting to `AiProviderFactory::create`**, overridden with a fake in tests.
+
+**UI (Compose — every state depicted, reproducing `vreader-bilingual.jsx` + `vreader-ai-provider-entry.jsx`):**
+
+- `bilingual/BilingualSetupSheet.kt` — reproduces `vreader-bilingual.jsx`'s `BilingualSetupSheet` (lines 27–156) EXACTLY, with the granularity divergence: header; a preview strip (`BilingualPreview`); a language grid over `BILINGUAL_LANGS` (glyph tiles, selected accent); a **Granularity** segmented control **descoped to Paragraph-only in v1** ("Translate after each ¶"; the Sentence option is not rendered in v1 — round-4 H3, tracked by the sentence design gate); a **Translation engine** strip (configured: "Claude · with this book's context" + "Change…"; unconfigured: "No AI provider configured" + "Bilingual mode needs an AI provider to translate." + "Set up"); the "Turn on bilingual mode" CTA. **No Style control, no provider/model card, no term-overrides toggle, no cost footer** (those belong to the `vreader-ai-android.jsx` sheet, not reproduced — §3). The `aiConfigured` flag comes from `BilingualAiReadiness.resolve`. The "Set up"/"Change…" CTA routes to `ReaderAiProvidersSheet` (wired in WI-9).
+- `bilingual/ReaderAiProvidersSheet.kt` — **NEW (folded in; the Android analog of iOS `ReaderAIProvidersView`; round-4 High-4 rewritten).** The Variant A scoped in-reader AI Providers sheet, reproducing `vreader-ai-provider-entry.jsx` `AIProvidersSheet` + `AIProvidersSheetBody` + `NavSheet` (nav bar `‹ Bilingual` leading + centered "AI Providers" title, `vreader-ai-provider-entry.jsx:247`). **Round-4 High-4: the fold-in CANNOT be "reuse `AiProviderListScreen` verbatim."** `AiProviderListScreen` owns its OWN full `NavScreen(title="AI Providers", onBack)` (`AiProviderListScreen.kt:59`), a generic `AiEmptyState` ("Connect an AI provider" / "One key unlocks…", :84/:87), and **row-tap-as-EDIT** (`ProviderRow` → `onEdit(p.id)`, :105) with **no checked-active-tap-to-select** — it cannot reproduce the designed reader-scoped `‹ Bilingual` nav, the bilingual-context empty state, the checked-active row, or tap-to-SELECT. So the fold-in splits into **(a)/(b)/(c)**:
+  - **(a) EDITOR reused VERBATIM.** `AiProviderEditSheet` (the canonical add/edit modal, Kind / Name / Endpoint / Sampling / API Key / Test Connection) is presented UNCHANGED from the #118 Library path — that reuse is confirmed fine (`reader-ai-provider-entry.md:49–52`, :63–65).
+  - **(b) The scoped LIST is a NEW reader-specific presentation** (`ReaderAiProvidersList`, in this file) built over the **SHARED `AiSettingsViewModel` state** (`listState`, verified `AiSettingsViewModel.kt:26`) + shared row/cell components, reproducing: the reader-scoped nav (`‹ Bilingual` back label, "AI Providers" title — `NavSheet` at jsx:247, NOT `AiProviderListScreen`'s own `NavScreen`); the **bilingual-context empty state** ("Choose the provider bilingual mode will use to translate this book." context strip + "No providers yet" + "Add provider" CTA — jsx:180–209); the **checked-active row** (`selected={p.id === selectedId}` — jsx:221; the live `AiProviderListState`/`AiProviderRow` already carries `active` per row, `AiSettingsViewModel.kt:30`); and **tap-to-SELECT** (`onSelect(p.id)` → `vm.setActive(id)` — jsx:221/237). It does **NOT** reuse `AiProviderListScreen`'s `NavScreen`/chrome/`AiEmptyState`/`ProviderRow`-tap-edit.
+  - **(c) A save-result seam** (round-4 High-4): `AiSettingsViewModel.save()` today returns Unit and upserts async (generates `s.id ?: UUID.randomUUID().toString()` *inside* the launched coroutine, then `_edit.value = null`, no saved ID — `AiSettingsViewModel.kt:85–97`), so WI-AIP cannot deterministically `setActive(savedId)` + pop-on-success by reusing it verbatim (popping immediately races the async upsert; observing list state can't distinguish the new profile). **Note:** `AiProviderStore.upsert` ALREADY returns the saved profile (`suspend fun upsert(...): AiProviderProfile`, "Returns the saved profile", `AiProviderStore.kt:58/70/84`) — the ID is present at the store layer; only the VM discards it. So the seam is an **additive completion/result signal on `AiSettingsViewModel.save()`** (or a thin WI-AIP wrapper) returning the saved provider ID (from `store.upsert(...).id`), so WI-AIP can `setActive(savedId)` + pop-on-success **after** the upsert commits — no race. The #118 VM is currently production-UNWIRED (only test-referenced — verified), and this feature wires it to production for the FIRST time, so an additive save-result seam is safe and appropriate.
+  - **Behavior per the nav model:** empty → "Add provider" → `AiProviderEditSheet` → Save → `save()` returns the saved ID → `store.setActive(savedId)` (first-provider-active is already the store's default `activeId = cur.activeId ?: id`, AiProviderStore.kt:81; the explicit `setActive(savedId)` guarantees the freshly-saved provider is the engine even if others existed) → **pop the whole stack** back to the bilingual sheet, engine strip now "Claude · configured / Change…". `‹ Bilingual` without adding → unconfigured, **no state mutated**. "Change…" → the SAME sheet, populated, current provider checked, tap a row → `setActive`. No consent card, no feature-flag toggle, no readiness tracker (iOS #82, deferred).
+- `bilingual/BilingualInterlinearBody.kt` — the Compose render surface for the **TXT/MD host ONLY** (round-2 M2). Renders per the **one-lazy-item-per-chunk `Column`** H2 render contract (source chunk unchanged as the first `Column` child; translation(s) anchored to chunk `i` as muted non-registered `Text` siblings in the SAME `Column`): muted `Text`, accent left-border, `fontSize*0.88`, CJK font for cjk scripts, RTL handling for Arabic (per `BilingualPageContent`, `vreader-bilingual.jsx:200–277`). Consumes the host-neutral `BilingualRenderState` DTO. Loading state ("Translating chapter… N%" + per-segment dim), error state ("Couldn't translate" + Retry), partial/offline (`unavailableUnits`): source-only silent fallback (iOS Decision 2). Includes the **translation gesture-exclusion** (round-4 H2) so a long-press on a translation child does not route to `hitAt`'s nearest-source-chunk fallback. **NOT the EPUB render surface.**
+- `bilingual/BilingualRenderState.kt` — the host-neutral state DTO shared by the Compose body and the EPUB adapter (round-2 M2): per-unit `{ segments: List<String>?, phase: Loaded|Loading(fraction)|Error|SourceOnly }`. Compose and EPUB share the state/value types, NOT the composable body.
+- `bilingual/EpubBilingualJs.kt` (WI-0-gated) — the EPUB render surface (round-2 M2). Pure Kotlin builder producing JS strings for `navigator.evaluateJavascript(...)`: `enumScript` (enumerate current-resource leaf blocks → JSON `[{id,text}]`), `injectScript(blockId, translationText)` (translation DOM node after the block; CSP-safe: `textContent`/`createTextNode`, never `innerHTML` string-concat; RTL/CJK via class + injected `<style>`), `clearScript()` (idempotent removal). Escaping done in Kotlin (JSON-encode every interpolated string). No Compose. Consumes `BilingualRenderState`.
+- `bilingual/EpubBilingualController.kt` (WI-0-gated) — **the single owner of EPUB units (M1, below).** The runtime actor that serializes enumerate→(cache-restore|translate)→inject/clear against the navigator using WI-0's chosen mechanism (a single mutex OR a monotonic navigator-session token); checks the session token after every suspended JS/AI call; clears BEFORE publication teardown; re-applies on the identified production re-apply signal.
+- `bilingual/BilingualPill.kt` — the `EN ↔ 中` reader-top-chrome pill (per `vreader-reader.jsx` + `vreader-bilingual.jsx` `BilingualPill`:282–305). Rendered by #132's top chrome; #131 provides the composable, #132's surface hosts it (§4).
+
+### EPUB direct-block flow — one owner + concrete API (round-3 Medium-1, BINDING; round-4 CONFIRMED RESOLVED — UNCHANGED)
+
+The **`EpubBilingualController` is the SINGLE OWNER of EPUB units**; the VM's position-driven regular `prefetch` path is **TXT/MD-only**. Concretely, an EPUB position change routes THROUGH the controller (the VM does not run `prefetch(unit)` for `epubHref` units), so the **controller is the sole writer** of an EPUB unit's canonical cache row and its `BilingualRenderState`/`translationsByUnit` entry — the position-driven regular prefetch and the direct-block path can never both write the same canonical cache row. The control flow (every suspended step session-token-guarded):
+
+```
+enumeratedBlocks = navigator.evaluateJavascript(EpubBilingualJs.enumScript)   // [{id,text}] for current resource
+        │  (session token S captured before the call; re-checked after)
+        ▼
+count = enumeratedBlocks.size
+restore = prefetcher.cachedDirect(unit, expectedCount = count, targetLanguage)  // zero-provider cache restore
+        │
+        ├─ hit  → segments = restore
+        └─ miss → segments = prefetcher.prefetchDirect(unit, sourceSegments = enumeratedBlocks.texts, targetLanguage)
+        │  (token re-checked after each suspension; a stale token → discard, no commit, no error surfaced)
+        ▼
+if token S still current:  commit segments → BilingualRenderState[unit] / translationsByUnit[unit]  (single writer)
+        ▼
+EpubBilingualJs.injectScript per (blockId, translation)  via navigator.evaluateJavascript   // token-guarded
+```
+
+- The VM exposes `onEpubBlocksEnumerated(unit, blocks)` as the controller's entry into VM render state, but the **controller owns the enumerate→cachedDirect/prefetchDirect→guarded-commit sequence**; the VM never initiates an EPUB prefetch itself (its position-driven `prefetch` dispatches only `txtDocSegmentWindow`/`mdDocSegmentWindow` units). A stale session token at any commit point discards silently (no `errorUnit`).
+- WI-7b's connected test asserts: enable → inject; disable → clear; reflow/href-change/fragment-recreation/activity-recreation → re-apply from cache via `cachedDirect` (zero provider calls); count-divergence handled via `prefetchDirect`; and that the regular TXT/MD prefetch path is never invoked for an EPUB unit.
+
+### Cancellation + single-flight (round-3 Medium-2, BINDING; round-4 CONFIRMED RESOLVED — UNCHANGED)
+
+- **Dual-cancellation across the service/VM boundary:** both the service AND the VM handle **BOTH** native `CancellationException` **AND** the typed `ChapterTranslationError.Cancelled` **before** generic error mapping — matching iOS `ChapterTranslationService.swift:359–364` (which catches `is CancellationError` and `ChapterTranslationError.cancelled` separately, both re-throwing `cancelled`). A cancelled stale request MUST NOT surface as `errorUnit` (it is discarded).
+- **Per-unit single-flight job registry (VM):** a `prefetchTasks: MutableMap<TranslationUnitId, Job>` (iOS `prefetchTasks: [TranslationUnitID: Task]`, `BilingualReadingViewModel.swift:141`, cancelled/removed on disable/unit-change at :165). A NEW request for a unit **cancels-or-joins** the prior job (a stale prior is cancelled and awaited so it cannot run overlapping translations or Room writes), keyed by unit. Rapid retry/navigation cannot run overlapping translations for the same unit. `retryUnit(unit)` goes through the same registry. Tests: a mid-flight cancel discards (no `errorUnit`, no partial cache row); a rapid re-trigger for the same unit does not double-write.
+
+### Modified files
+
+- `data/VReaderDatabase.kt` — add `ChapterTranslationEntity` to `@Database entities`, bump `version` **8 → 9** (the live DB is v8, migrations `MIGRATION_1_2`..`MIGRATION_7_8`, `ALL_MIGRATIONS` ends at `MIGRATION_7_8` — verified VReaderDatabase.kt:29,224–228), add **`MIGRATION_8_9`** (exact DDL below — gap A), **append `MIGRATION_8_9` to `ALL_MIGRATIONS` after `MIGRATION_7_8`**, add `abstract fun chapterTranslationDao()`. Purely additive.
+
+  **`MIGRATION_8_9` exact DDL (gap A — BINDING; modeled on the verified `MIGRATION_6_7` `search_index_state` shape at VReaderDatabase.kt:154–169, whose DDL Room's PRAGMA validation already accepts):**
+
+  ```
+  val MIGRATION_8_9: Migration = object : Migration(8, 9) {
+      override fun migrate(db: SupportSQLiteDatabase) {
+          db.execSQL(
+              "CREATE TABLE IF NOT EXISTS `chapter_translations` (" +
+                  "`lookupKey` TEXT NOT NULL, " +
+                  "`bookKey` TEXT NOT NULL, " +
+                  "`unitStorageKey` TEXT NOT NULL, " +
+                  "`targetLanguage` TEXT NOT NULL, " +
+                  "`promptVersion` TEXT NOT NULL, " +
+                  "`translatedJson` TEXT NOT NULL, " +
+                  "`sourceParagraphCount` INTEGER NOT NULL, " +
+                  "`createdAt` INTEGER NOT NULL, " +
+                  "PRIMARY KEY(`lookupKey`), " +
+                  "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+                  "ON UPDATE NO ACTION ON DELETE CASCADE )"
+          )
+          db.execSQL(
+              "CREATE INDEX IF NOT EXISTS `index_chapter_translations_bookKey` " +
+                  "ON `chapter_translations` (`bookKey`)"
+          )
+      }
+  }
+  ```
+
+  The `ChapterTranslationEntity` column types/order MUST match this DDL exactly (all columns `NOT NULL`; PK `lookupKey`; the `Index("bookKey")` produces `index_chapter_translations_bookKey`; the FK is `bookKey → books(fingerprintKey) ON DELETE CASCADE` — the same shape as every other child table, VReaderDatabase.kt:75–76/88–89/100–101/157–158/168–169). **The migration test MUST diff this DDL against Room's GENERATED `9.json` schema** (`exportSchema = true` at VReaderDatabase.kt:30 emits `schemas/…/9.json`), NOT a hand-written approximation — the exact-DDL guard opens the real Room DB after the v8→v9 migration and lets Room's structural PRAGMA validation catch any drift (the recurring Android migration failure mode, cf. #135's stale-version finding; the `MIGRATION_6_7` comment at VReaderDatabase.kt:148–150 documents this exact "DDL matches Room's generated schema, validated by the migration test opening the real Room DB" contract).
+
+- `reader/TxtReaderActivity.kt` — own a `BilingualViewModel`; collect state; render translations **inside each chunk `i`'s lazy item as muted non-registered `Text` children of a wrapping `Column`, source chunk byte-unchanged, the `items(count = document.chunkCount, key = { it })` loop and its keys UNCHANGED so lazy-index==chunk-index is preserved (H2, TxtReaderActivity.kt:1043–1085)**; add the translation gesture-exclusion (H2); on position change call `vm.onPositionChanged(charOffsetUTF16)`. Strictly gated to `originalFormat ∈ {txt, md}`; disabled = each item's `Column` holds only the unchanged source `Text` (source-selection-parity preserved). **Owned by #129 (VERIFIED, merged) — a straight edit, rule 48 one-writer-per-file satisfied.**
+- `reader/ReaderActivity.kt` (Readium EPUB) — WI-0-gated: attach `EpubBilingualController` to `navigator.evaluateJavascript`; re-apply on the identified production re-apply signal; clear on teardown BEFORE publication teardown. `navigator: EpubNavigatorFragment?` is the verified live field (ReaderActivity.kt:110).
+- `reader/chrome/ReaderChromeScaffold.kt` — extend `readerMoreRows(...)` (currently supplies only `MoreActionId.DETAILS` + `SHARE`, ReaderChromeScaffold.kt:255–258) to ALSO supply the **`MoreRow.Toggle(id = MoreActionId.BILINGUAL, on = enabled, onToggle = …)`** row (or `MoreRow.Disabled` "Configure AI provider first" when not configured — `MoreRow.Disabled` exists for exactly this, MoreRow.kt:65–72). Threaded via new nullable params so #132/#134-only callers stay valid (the scaffold's established nullable-default pattern). This is the WI-9 entry-wiring edit.
+- `reader/TxtSelectionController.kt` — **may gain a small additive seam for the translation gesture-exclusion** (H2) IF WI-8's chosen exclusion approach records translation-composable bounds at the selection root (e.g. an optional "excluded bounds" setter the body populates). If WI-8 instead consumes the long-press in the translation `Text`'s own `pointerInput`, this file is untouched. WI-8 picks one; the `hitAt` nearest-chunk fallback (`reader/TxtSelectionController.kt:47–53`) is the reason an exclusion is required at all.
+- `VReaderApp.kt` / `AppContainer` — **provide `AiProviderStore` INTO `AppContainer` itself** (it is NOT provided today — verified, only a comment names it at VReaderApp.kt:64/66) using the #116 `KeystoreSecretCipher` + a DataStore under the same convention as `readerSettingsStore`, PLUS provide `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, an `AiSettingsViewModel` factory (for the Variant A sheet), and a `BilingualViewModel` factory. **Extracted into the shared DI WI (WI-4b).** No `feat:#136` dependency remains — #131 owns the `AiProviderStore`-into-`AppContainer` wiring.
+
+**NOT modified:** `reader/chrome/ReaderBottomChrome.kt` gets **no** bilingual/Translate slot — the design's entry is the More-menu toggle (#134) + the top-chrome pill (#132), NOT a bottom-chrome slot. `ReaderBottomChrome`'s existing `extraSlot` is untouched.
+
+### Files OUT of scope for v1
+
+- **`Azw3ReaderActivity.kt` / `reader/foliate/`** — foliate WebView interlinear IS feasible but deferred (bundle-patch JS + secure-bridge additions touch the security-sensitive #126 surface). Once WI-0 proves the EPUB JS pipeline, the foliate host reuses `EpubBilingualJs` with a bundle adapter.
+- **`PdfReaderActivity.kt`** — no reflowable text layer. Out (`pdfPageRange` Kind reserved only).
+- **Backup collect/restore of `PerBookSettingsOverride` bilingual fields** — contract fields exist; wiring is a small additive follow-up (§7). Device-local until then. **The `bilingualGranularity` field's cross-platform conformance vector + iOS parity are UNCONFIRMED (gap B, §6/§7) — a follow-up when the backup-wiring WI lands.**
+- **Style control** — descoped v1 (user decision, §3). Keep provider/model/**granularity (paragraph)**, DROP the bilingual "Style" control.
+- **Sentence granularity (both the setup-sheet Sentence control AND the sentence-interlinear RENDER)** — not depicted (round-4 H3); design-gated together (§Design gates). v1 renders + caches + offers **paragraph only**; `sentenceRanges`/`TranslationGranularity.sentence` remain reserved-foundational code (WI-1, unit-tested) but are absent from the v1 render/cache/VM/setup-sheet path.
+- **The iOS #82 readiness sheet (feature-flag + consent gates)** — `reader-ai-readiness.md` is iOS-specific and implementation-deferred; Android has no flag/consent, so the Variant A provider-list sheet is the whole AI-config surface. Out.
+- **"Translate entire book…" batch, re-translate/style-swap picker, cost/token estimation, term-overrides** — iOS/`vreader-ai-android.jsx` extras not in the authoritative sheet. Out.
+- **Streaming translation progress** — the design's "38%" is chapter-level N-of-M chunk progress, not token streaming. v1 shows N-of-M.
+
+## 3. Prior art / project precedent / rejected alternatives
+
+### The render-host decision (settled v2, CONFIRMED round-2)
+
+**How iOS does interlinear:** iOS renders EPUB/AZW3 in a WKWebView it fully controls. `EPUBBilingualOrchestrator` injects JS that (1) enumerates leaf blocks posting `[{bid,text}]` to Swift, (2) after translation injects a translation node after each block. TXT/MD render in a text path where the renderer interleaves translation runs. The mechanism = **the app inserts translation nodes between source nodes** — which is exactly the Android in-item `Column` contract (H2) for TXT/MD and the DOM-inject contract for EPUB.
+
+**Android EPUB feasibility (round-2 re-verified):** the transformed API JAR on the resolved Readium 3.3.0 AAR (build.gradle.kts:111) exposes public `evaluateJavascript`, `getCurrentLocator()`, `firstVisibleElementLocator(...)`, `submitPreferences(...)`; `ReaderActivity.navigator: EpubNavigatorFragment?` holds the concrete fragment (ReaderActivity.kt:110). EPUB interlinear via JS injection is feasible with the public API — **no Readium fork.** Not reopened.
+
+**WI-0 — Readium bilingual spike (gates WI-7b; round-2 M1):** a throwaway harness that, against a real EPUB on the emulator, must PROVE each go/no-go criterion: (a) enumeration deterministic + idempotent with stable node IDs (repeat apply = no duplicate nodes); (b) clear wins over every older inject (a late inject checks the session token and no-ops); (c) recreation restores from cache for every case (href away/back, same-href `submitPreferences` reflow, internal page-fragment recreation, activity recreation) via `cachedDirect(expectedCount)` (zero provider calls) with an identified PRODUCTION re-apply signal per case; (d) locator/visible-source preservation across injection (stated permissible pagination delta); (e) enumerated block count vs segmenter count measured — divergence → the direct-block path (`prefetchDirect`/`cachedDirect`, H2) is the recovery, proven end-to-end. **Race contract:** single actor/mutex OR monotonic navigator-session token; token/mutex check after every suspended JS/AI call; clear before publication teardown. **No deterministic re-apply signal for a recreation case (c) = explicit NO-GO** → EPUB drops to a tracked follow-up, box D ships **TXT/MD-only** with the honest reason (a specific spike finding), never the false "requires a fork."
+
+**Rejected alternatives:**
+1. **Readium interlinear via decorations only** — REJECTED (decorations style existing text; they cannot insert translation paragraphs).
+2. **Forking Readium** — REJECTED + unnecessary (public `evaluateJavascript` seam exists).
+3. **AZW3 foliate host first** — REJECTED for v1 (deferred; touches the security-sensitive #126 bridge).
+4. **Eager whole-book pre-translation** — REJECTED (cost/latency). Lazily prefetch current+next + cache.
+5. **One `BilingualInterlinearBody` per chunk (v2)** — REJECTED (round-2 H1): a chunk is not a segment.
+6. **A Compose body as the EPUB render surface (v2)** — REJECTED (round-2 M2): Compose cannot render inside Readium's WebView.
+7. **Splitting a chunk's source `Text` into per-segment `Text` nodes to interleave translations (v3)** — REJECTED (round-3 H2): breaks the live one-`TextLayoutResult` + one-selection-registration-per-chunk model.
+8. **SEPARATE additive `LazyColumn` items per translation, after the anchor chunk (v4)** — REJECTED (round-4 H2): separate lazy items shift every following lazy index, and the live reader treats lazy-item indices AS `TxtDocument` chunk indices (`offsetForChunk(firstVisibleItemIndex)` for position save/progress — TxtReaderActivity.kt:220/473/623; `scrollToItem(chunkForOffset(target))` for every bookmark/annotation/search/scrubber/TTS jump — :411/:421/:454/:481/:257; `visibleItemsInfo.index == spokenChunk` for TTS visibility — :256). Replaced by the **one-lazy-item-per-chunk `Column`** contract (source `Text` unchanged as the first child, translations as sibling children in the SAME lazy item — no lazy item added, no index shifted).
+9. **Deriving `aiConfigured` from `profiles.isEmpty()` (the iOS Variant A note's derivation)** — REJECTED for Android: `activeId` can be null with profiles present, and key usability needs the active profile's token to decrypt (H3). Android uses `BilingualAiReadiness.resolve` = active-profile + decrypts-non-empty.
+10. **Spinning AI-config reachability out as a separate feature #136** — REJECTED / CLOSED (2026-07-12): the design proved the ONLY designed Android AI-config reader surface is bilingual-coupled Variant A; there is no designed standalone entry, so it is not separable. #131 owns it.
+11. **Reusing `AiProviderListScreen` VERBATIM for the Variant A scoped list (v4)** — REJECTED (round-4 H4): `AiProviderListScreen` owns its own `NavScreen`/chrome (AiProviderListScreen.kt:59), a generic empty state (:84/:87), and row-tap-as-EDIT (:105), so it cannot reproduce the designed `‹ Bilingual` nav + bilingual-context empty state + checked-active row + tap-to-SELECT. Replaced by (a) reuse the EDITOR verbatim + (b) a NEW `ReaderAiProvidersList` over the shared `AiSettingsViewModel` state + (c) a save-result seam returning the saved ID.
+
+### The setup-sheet resolution (rule 51) + Style descope (round-2 H3, USER DECISION)
+
+There are **two committed, differently-shaped** `BilingualSetupSheet`s:
+- `vreader-bilingual.jsx` → **language grid + Granularity + preview strip + Translation-engine strip (Set up/Change) + Cancel/Translate**. No Style, no provider/model card, no term-overrides, no cost.
+- `vreader-ai-android.jsx` → **Languages (From/To) + Provider card + Style (Literal/Natural/Literary) + Keep-term-overrides toggle + cost footer**. No language grid, no Granularity, no preview.
+
+**Resolution:** this plan reproduces the **`vreader-bilingual.jsx` sheet EXACTLY**, with the round-4 H3 granularity divergence (Paragraph-only in v1). **Style is DESCOPED for v1** (user decision): keep provider/model/**granularity (paragraph)**, DROP the bilingual "Style" control. Consequently store/VM carry no `style`, the chunk contract has no `style` param, and the cache key's `promptVersion` has no `s=` component.
+
+**Box-D parity note (do NOT claim full box-D parity):** the box-D checklist lists provider/model/**style**. Because Style is descoped, **WI-9 flips box D to done ONLY for provider/model/granularity(paragraph) + a descope note**; a follow-up tracker/checklist amendment records the Style descope AND the Sentence-granularity descope. If Style is later wanted, that needs an updated committed design (a single sheet showing BOTH Style AND Granularity is not depicted anywhere — the one Style design gate below).
+
+### The AI-config path (rule 51) — Variant A is the committed design
+
+The canonical decision (`reader-ai-provider-entry.md`, Variant A) + its component canvas (`vreader-ai-provider-entry.jsx`) ARE the committed design; #131 reproduces only what they depict (a `‹ Bilingual`-titled push sheet hosting the provider list + the canonical editor, pop-back-on-first-save, checked-active row, tap-to-select). The scoped list is a NEW reader-specific presentation over the shared #118 VM state (round-4 H4) — it does not reuse `AiProviderListScreen`'s chrome/empty-state/row-tap-edit — but it invents no new AI-config sheet or nav beyond what the Variant A canvas depicts. The editor (`AiProviderEditSheet`) IS reused verbatim. The iOS #82 readiness additions (flag/consent) are explicitly **out** on Android (no such subsystems exist). This is a designed surface — it is NOT a design gate.
+
+### Other precedents applied
+
+- **#118 provider seam**: reuse `AiProviderStore.snapshot()` (`snapshot.active`) + `store.apiKey(profile)` + `AiProviderFactory.create` (default of an injected factory param) + `AiClient.chat`. #118's AI files are unchanged EXCEPT the additive save-result seam on `AiSettingsViewModel.save()` (round-4 H4c — returns the saved ID, which `AiProviderStore.upsert` already produces, AiProviderStore.kt:58/84); #131 wires `AiProviderStore` into `AppContainer` and reuses `AiProviderEditSheet`/`AiSettingsViewModel` for the Variant A sheet (the scoped list is new — H4b).
+- **Room additive-migration pattern** (#122/#123/#127/#128/#135): version bump + `MIGRATION_n_(n+1)` appended to `ALL_MIGRATIONS` + exact-DDL + `VReaderDatabaseMigrationTest` PRAGMA guard against Room's generated schema (gap A). `@PrimaryKey` + `@Upsert` is the project DAO pattern (`BookDao`). Baseline v8.
+- **DataStore JSON-in-Preferences** for `PerBookBilingualStore` (the `ReaderSettingsStore`/`AiProviderStore` pattern).
+- **Pure-logic port**: iOS `ChapterSegmenter`/`ChapterTranslationChunker`/`TranslationChunkContract`/`ChapterTranslationService.translatePreSegmented`/`ChapterTranslationPrefetcher.translatedSegmentsDirect`+`cachedSegmentsDirect` are pure/heavily-unit-tested — direct Kotlin ports with the same test vectors (all verified to exist).
+- **Single-flight job registry**: iOS `prefetchTasks: [TranslationUnitID: Task]` (`BilingualReadingViewModel.swift:141`) — ported as `prefetchTasks: Map<TranslationUnitId, Job>` (M2).
+- **Entry point via #132/#134 (VERIFIED)**: the More-menu bilingual toggle (`MoreActionId.BILINGUAL` reserved; `MoreRow.Toggle`/`MoreRow.Disabled`) + top-chrome pill are landed; #131 mounts the pill + wires the toggle (§4).
+
+## 4. Work-item sequencing
+
+**13 WIs/PRs (round-3 Low-1 fix — corrected count; UNCHANGED in v5):** the list is exactly **WI-0, WI-1, WI-2, WI-3, WI-4a, WI-4b, WI-5, WI-6, WI-7a, WI-7b, WI-AIP, WI-8, WI-9** = **13 WIs**. `Utf16Span` (round-4 H1) is a NEW file but **rides WI-1** (the foundational value-types + pure-segmentation WI) — it does not add a WI. Each WI = one PR. Build order: **foundation/cache → service/direct-block APIs → shared DI/factory (incl. `AiProviderStore` in `AppContainer`) → VM state/prefetch → host-specific renderers (TXT/MD + EPUB) + the Variant A AI Providers sheet → entry wiring.**
+
+**Dependencies (round-3 Medium-4 — dependency honesty; #136 folded in; round-4 CONFIRMED correct):**
+
+- **`Deps: [feat:#132, feat:#134]`.** **#132 (top chrome) and #134 (More menu) are VERIFIED.** **#129 (TXT/MD reader) is VERIFIED** — `TxtReaderActivity` is a straight edit, not a blocker. **There is NO external AI-reachability blocker** — the former #136 is CLOSED (GH #1976, not-planned) and its scope is #131-owned.
+- **WI-4b is foundational and gates the behavioral chain.** WI-4b provides `AiProviderStore` into `AppContainer` PLUS the bilingual services + factories. Per the audit's Medium-4, WI-4b transitively gates WI-6 (needs the prefetcher/DI), WI-7b (needs DI), WI-AIP (needs `AiProviderStore` + `AiSettingsViewModel` from `AppContainer`), and WI-8 (needs DI). **Chosen resolution: injected seams so the behavioral work proceeds against fakes before WI-4b lands, AND WI-4b is sequenced early.** Concretely: the VM (WI-5/WI-6) takes an injected `ChapterTranslationPrefetcher` (fake in tests) and an injected `AiProviderSnapshot` provider (fake); the TXT/MD host Compose/unit work (WI-8) and the Variant A sheet (WI-AIP) take injected VM/store/`AiSettingsViewModel` seams — so unit/Compose tests do not wait on `AppContainer`. **WI-4b is built right after WI-4a (before WI-6/WI-7b/WI-AIP/WI-8) so the production wiring lands before the host integrations that mount it.** This is stated honestly: the *production run-through* of WI-6/WI-7b/WI-AIP/WI-8 depends on WI-4b; their *unit/Compose gates* depend only on the injected seams. No external feature gates any of this.
+
+**WI-0 (spike): Readium EPUB bilingual injection — go/no-go + race contract (M1).** Harness + criteria (a)–(e) and the race contract in §3. Output: a go/no-go on EPUB-in-v1 (no-go = box D ships TXT/MD-only, tracked) + the concrete `EpubChapterTextProvider` / `EpubBilingualJs` / `EpubBilingualController` surfaces + the EPUB direct-block ownership sequence (Medium-1). Deps: none (uses the existing #106 Readium host). Not TDD-gated (throwaway spike); feeds WI-7b.
+
+**WI-1 (foundational): value types + pure segmentation/chunk/contract.** **`Utf16Span` (round-4 H1 — the half-open span value type replacing `IntRange`)**, `TranslationUnitId`, `TranslationGranularity` (reserved; v1 uses `paragraph` only — round-4 H3), `BilingualLanguages`, **`ChapterSegmenter` (with `paragraphRanges`/`sentenceRanges` returning `List<Utf16Span>` — H1; `sentenceRanges` is reserved-foundational, not in the v1 render path — H3)**, `TranslationChunker`, `TranslationChunkContract` (no `style`), `ChapterTranslationError`. Pure; ported iOS vectors. Deps: none. Tests: `paragraphRanges`/`sentenceRanges` return correct half-open `Utf16Span(start, endExclusive)` spans (both APIs unit-tested even though only `paragraphRanges` ships in the v1 render path — `sentenceRanges` stays covered as reserved-foundational code); chunker packs-to-budget/oversize/empty; contract prompt/decode/fence/mismatch; error mapping.
+
+**WI-2 (foundational): Room translation cache.** `ChapterTranslationEntity` (PK = `lookupKey`, all-`NOT NULL` columns matching the DDL, `sourceParagraphCount` column) + `Dao` (`@Upsert`) + `ChapterTranslationStore`; `VReaderDatabase` **8→9 `MIGRATION_8_9`** with the **exact DDL authored in §2 (gap A)**, appended after `MIGRATION_7_8`. Robolectric migration round-trip from v8 + full-chain + upsert/get/delete-by-lookupKey + FK-CASCADE + **exact-DDL guard validated against Room's GENERATED `9.json` schema (not a hand-written approximation — gap A)**. Deps: none.
+
+**WI-3 (foundational): `ChapterTranslationService`** against a fake `AiClient`. Both `cachedTranslation` overloads (incl. the `expectedSegmentCount` divergence restore — H2) + `translate` + `translatePreSegmented`. **Dual-cancellation (native + typed `Cancelled`) BEFORE generic mapping (M2).** Deps: WI-1, WI-2. Tests: cache hit → zero client calls; miss → translate + write; decode fail → per-segment fallback; one-chunk fail → source-only that chunk (others translated, NOT cached); all-chunks fail → throw; native-cancel → `Cancelled` (no write); typed-`Cancelled`-from-chunk → `Cancelled` (no write); ensureActive-before-write; `AiError` mapping incl. `Config`/`InsecureUrl` → `ProviderFailed`; `translatePreSegmented` full-success caches under the enumerate count; partial degrade NOT cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` returns on stored-count match, null on mismatch, needs no provider.
+
+**WI-4a (foundational): `ChapterTextProvider` (TXT/MD) + `ChapterTranslationPrefetcher` + `BilingualAiReadiness`.** `TxtChapterTextProvider` builds the document-global segment `Utf16Span`s once (via `paragraphRanges` — paragraph only, H1/H3), groups into windows, resolves `unitContaining(charOffsetUTF16)` via segment-start binary search, `sourceSegments(unit)`. Prefetcher: `prefetch` + `prefetchDirect` + `cachedDirect`; resolves active profile from `snapshot()`, decrypts snapshot-consistent, builds client via the injected factory param (default `AiProviderFactory::create`), constructs `AiRequest` with **`model = profile.model.ifBlank { profile.kind.defaultModel }` (M3)**. Readiness = active profile with non-empty decrypted key; **cipher failure → not-ready, never a crash.** Fake store + fake factory. Deps: WI-1, WI-3. Tests (all `Utf16Span`-based): unit resolution + clamp + empty; **one-chunk document (no trailing newline) → its segment translation renders, not dropped (H1)**; **final-chunk anchor → renders (H1)**; **exact-boundary → correct anchor (H1)**; **EOF anchor (`span.endExclusive == text.length`) → last chunk, no clamp-collapse (H1)**; paragraph spanning MANY chunks → one segment/one unit, anchored to the last chunk (Low-2); a >4000-char paragraph hard-split across chunks → one segment; CR/LF/CRLF; MD markers; locator→unit mapping; `unitAfter` end→null; **source-byte parity while disabled**; cache-hit-no-profile still returns (#306); no-profile miss → `ProviderFailed`; `prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls; **blank `profile.model` → `AiRequest.model == kind.defaultModel` (M3 regression)**; readiness true/false; empty-key → false; no-active-with-profiles-present → false (H3); cipher-throw → readiness false (no crash). (Sentence-multi-in-one-chunk is NOT a v1 render test — the v1 provider uses `paragraphRanges` only; `sentenceRanges` behavior is covered in WI-1's reserved-foundational unit tests.)
+
+**WI-4b (foundational — shared DI/factory, incl. `AiProviderStore` in `AppContainer`): AppContainer bilingual + AI-config graph.** `AppContainer` **now constructs `AiProviderStore`** (DataStore + #116 `KeystoreSecretCipher`, following the `readerSettingsStore` convention — this is #131's change, not an external feature's) and provides `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, an `AiSettingsViewModel` factory (for WI-AIP), and the `BilingualViewModel` factory. Deps: **WI-4a** (no external dep — #136 closed). Tests: container resolves the bilingual + AI-config graph; `AiProviderStore` resolves and round-trips a profile; the prefetcher's injected factory defaults to `AiProviderFactory::create`.
+
+**WI-5 (behavioral): `PerBookBilingualStore` + `BilingualViewModel` state core.** Store per book (enabled/targetLanguage/granularity — granularity pinned `paragraph` in v1, no style); VM setters (persist + first-enable `needsSetupSheet`); `aiConfigured` from `BilingualAiReadiness.resolve` over an injected snapshot; language change clears cache-shaped state + bumps generation. Injected prefetcher/snapshot seams (Medium-4). Turbine tests: first-enable raises sheet; re-enable persisted does not; disable clears; language change resets; `aiConfigured` true/false from readiness; round-trip through store; no style field; granularity persists as `paragraph`. Deps: WI-1 (+ store).
+
+**WI-6 (behavioral): VM prefetch trigger + generation/cancellation + single-flight (M2).** `onPositionChanged(charOffsetUTF16)` derives current unit (TXT/MD only), dedupes, prefetches current+next; a monotonic position-request sequence checked after every suspension; **per-unit single-flight `prefetchTasks: Map<TranslationUnitId, Job>` (a new request cancels/joins the prior — M2)**; a captured language/provider snapshot per launch; generation bumps on disable/language/unit-change discard stale; **BOTH `CancellationException` AND typed `ChapterTranslationError.Cancelled` handled BEFORE generic error mapping (M2)**; a cancelled stale request does NOT surface as `errorUnit`; `Offline`→`unavailableUnits`; transient failure leaves unit unfetched + clears anchor to retry; `retryUnit` routes through the registry. The EPUB `onEpubBlocksEnumerated` entry is present but EPUB prefetch is owned by the controller (Medium-1); the VM's position-driven `prefetch` dispatches TXT/MD units only. Fake prefetcher (Medium-4 seam). Deps: WI-4a, WI-4b, WI-5. Tests: current+next on unit change; same-unit no-op; cancel-mid discards stale (no `errorUnit`); typed-`Cancelled` discards (not `errorUnit`); rapid re-trigger same unit → single-flight, no double-write; offline→unavailable; failure→retry-able; `retryUnit` re-fetches.
+
+**WI-7a (behavioral): Compose UI — setup sheet + interlinear body (TXT/MD) + pill.** Reproduce `vreader-bilingual.jsx` (setup sheet: language grid / **Paragraph-only Granularity control (round-4 H3)** / preview / engine strip configured+unconfigured; body: the translation rendered **inside the anchor chunk's `Column` as a muted non-registered `Text` child** per the round-4 H2 render contract — translated / loading N%+dimmed / error+Retry / offline source-only; pill). Consumes the host-neutral `BilingualRenderState` DTO. Light+dark. Compose UI tests each state, incl. **paragraph interlinear renders a translation child after a paragraph's last source chunk (depicted)**; **the setup-sheet Granularity control shows Paragraph only, no Sentence option (H3)**. Deps: WI-5 (state shape). NO Style control; the unconfigured "Set up" CTA renders and (in WI-9) routes to the Variant A sheet.
+
+**WI-7b (behavioral, CONDITIONAL — only if WI-0 = go): EPUB render adapter (DOM injection, NOT Compose — M2) + direct-block ownership (M1).** `EpubBilingualJs` (enum/inject/clear JS builders, CSP-safe escaping) + `EpubBilingualController` (the serialization actor / session token AND the **single-owner enumerate→cachedDirect/prefetchDirect→guarded-commit sequence — Medium-1**) + `EpubChapterTextProvider`, wired into `ReaderActivity`, driving DOM from the shared `BilingualRenderState` DTO. Uses `prefetchDirect`/`cachedDirect` for the count-divergence path (H2). Depends on WI-6 (VM state) and WI-4b (DI); the WI-7a UI dependency is only the shared `BilingualRenderState`/value types. Connected test on a real EPUB (seeded cache): enable → injects; disable → cleared; reflow/href-change/fragment-recreation/activity-recreation → re-applies from cache (zero provider calls) via `cachedDirect`; count-divergence handled (direct path); **the regular TXT/MD prefetch path is never invoked for an EPUB unit (Medium-1)**. Unit tests: JS escaping/CSP-safe insertion, RTL/CJK style, empty translations, loading cleanup, idempotent replacement, source-only fallback, stale-session-token commit discarded (no `errorUnit`). Deps: WI-0, WI-3, WI-4a, WI-4b, WI-6, (shared types from WI-7a). (If WI-0 = no-go, dropped; box D ships TXT/MD-only, tracked.)
+
+**WI-AIP (behavioral — the folded-in Variant A AI Providers sheet; round-4 H4 rewritten): `ReaderAiProvidersSheet`.** The scoped in-reader "AI Providers" push sheet (nav bar `‹ Bilingual` + "AI Providers" title) reproducing `vreader-ai-provider-entry.jsx` `AIProvidersSheet`/`AIProvidersSheetBody`/`NavSheet`. Per round-4 H4:
+  - **(a)** present `AiProviderEditSheet` VERBATIM from #118 (Kind/Name/Endpoint/Sampling/API Key/Test Connection unchanged).
+  - **(b)** a NEW `ReaderAiProvidersList` presentation over the SHARED `AiSettingsViewModel.listState` (verified `AiSettingsViewModel.kt:26`; each `AiProviderRow` already carries `active`, :30) + shared row/cell components — reproducing the reader-scoped `‹ Bilingual` nav (`NavSheet`, jsx:247, NOT `AiProviderListScreen`'s `NavScreen`), the bilingual-context empty state ("Choose the provider bilingual mode will use to translate this book." + "No providers yet" + "Add provider" — jsx:180–209), the **checked-active row** (`selected = row.active` — jsx:221), and **tap-to-SELECT** (`onSelect(id) → vm.setActive(id)` — jsx:221/237). It does NOT reuse `AiProviderListScreen`'s NavScreen/chrome/`AiEmptyState`/`ProviderRow`-tap-edit.
+  - **(c)** the **save-result seam**: `AiSettingsViewModel.save()` (or a thin WI-AIP wrapper) is extended to return the saved provider ID (from `store.upsert(...).id`, which the store already returns — `AiProviderStore.kt:58/84`), so on first Save → `store.setActive(savedId)` → pop the whole stack back to the bilingual sheet (engine strip now "configured / Change…"), **deterministically, after the upsert commits (no race)**.
+  `‹ Bilingual` without adding → unconfigured, no state mutated. "Change…" → populated list, current provider checked, tap row → `setActive`. No consent/flag surface (Android has none). Deps: WI-4b (for `AiProviderStore` + `AiSettingsViewModel` in `AppContainer`), WI-7a (bilingual sheet host). Tests (Compose + connected): the scoped list renders **`‹ Bilingual` back label** + **bilingual-context empty copy** + **checked active row** + **tap-selects (`setActive`)**; empty → Add → Save → **save→result-id→`setActive`→pop deterministic (no race)** → bilingual strip configured; `‹ Bilingual` without adding → strip unconfigured, snapshot unchanged; "Change…" → populated, current checked; editor reused verbatim (no divergent form).
+
+**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into the `items(count = document.chunkCount, key = { it })` loop as **muted non-registered translation `Text` children inside each anchor chunk's wrapping `Column`, source chunk byte-unchanged, the loop + keys UNCHANGED so lazy-index==chunk-index is preserved (round-4 H2)** + the translation **gesture-exclusion** (round-4 H2) + position-change (`charOffsetUTF16`) + setup-sheet. `originalFormat`-gated (TXT/MD). Uses WI-4b's DI. **#129 VERIFIED — straight edit.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2)**; **highlights/annotation-washes/read-aloud-wash still key off source chunks (H2)**; **with bilingual ON — position-save round-trips to the same chunk; bookmark/search/scrubber/TTS jumps land on the correct chunk (lazy-index==chunk-index preserved — round-4 H2)**; **a long-press on translation text does NOT select (gesture exclusion — round-4 H2)**; a translation child is non-selectable, does not perturb source offsets (H2); disable → source-selection byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders exactly one translation inside its last chunk's `Column` (H1/Low-2)**; **one-chunk/final-chunk anchors render (H1)**; MD source mapping. Deps: WI-6, WI-7a, WI-4b.
+
+**WI-9 (behavioral): entry wiring + acceptance.** Mount `BilingualPill` in #132's VERIFIED top chrome; extend `readerMoreRows(...)` to supply the #134 VERIFIED More-menu `MoreActionId.BILINGUAL` toggle (`MoreRow.Toggle` `on`/`onToggle`, or `MoreRow.Disabled` "Configure AI provider first" when not configured) wired to the VM; **wire the setup sheet's "Set up"/"Change…" affordance → the #131-owned `ReaderAiProvidersSheet` (Variant A)**. Full acceptance across EPUB (if WI-7b landed) + TXT/MD, including the fresh-user path `unconfigured → Set up (→ Variant A AI Providers sheet) → add provider → Save → return → enable → translate` (now #131-owned end-to-end). **Flip box D to done ONLY for provider/model/granularity(paragraph) + the Style-descope AND Sentence-descope notes; file the follow-up checklist amendment; do NOT claim full box-D parity.** The DONE flip **no longer waits on #136** (closed). Update `docs/architecture.md` (bilingual pipeline + the new `chapter_translations` schema + `AiProviderStore` + bilingual services in `AppContainer` + the Variant A AI Providers sheet). → DONE. Deps: WI-8, WI-AIP, WI-7b (if go), feat:#132, feat:#134.
+
+## 5. Test catalogue
+
+JVM/Robolectric (`android/app/src/test/...bilingual/`): `Utf16SpanTest` (**half-open invariants: `endExclusive >= start`, `isEmpty`, `length`; round-4 H1**); `ChapterSegmenterTest` (paragraph blank-line; sentence CJK `。！？` vs Latin; empty→[]; single; **`paragraphRanges`/`sentenceRanges` return correct half-open `Utf16Span(start, endExclusive)` spans — both APIs covered even though only `paragraphRanges` ships in the v1 render path**); `TranslationChunkerTest` (packs to budget; oversize→own chunk+subSplit; empty→[]); `TranslationChunkContractTest` (prompt shape; strict JSON decode; code-fence strip; count mismatch→`CountMismatch`; non-array→`NotAStringArray`); `ChapterTranslationServiceTest` (cache hit 0 calls; miss→translate→write; decode-fail per-segment fallback; one-chunk-fail partial-not-cached; all-fail→throw; **native-cancel→Cancelled no write; typed-`Cancelled`→Cancelled no write (M2)**; ensureActive-before-write; offline/timeout/429/http/config/insecure→error mapping; very long chapter N-of-M; stale-cache count-mismatch re-translates; `translatePreSegmented` caches under enumerate count on full success; partial degrade not cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` hit/miss with no provider); `ChapterTranslationErrorMappingTest`; `TxtChapterTextProviderTest` (**one-chunk document → renders (H1); final-chunk anchor → renders (H1); exact-boundary → correct anchor (H1); EOF anchor → last chunk, no clamp-collapse (H1)**; paragraph spanning MANY chunks → one segment/unit anchored to last chunk (Low-2); >4000-char paragraph → one segment across hard-split chunks; CR/LF/CRLF; MD markers; locator→unit mapping; `unitAfter` end→null; source-byte parity while disabled; **provider uses `paragraphRanges` only — H3**); `ChapterTranslationPrefetcherTest` (snapshot-consistent profile+key; injected-factory used; `AiRequest` built from profile; **blank `profile.model` → `kind.defaultModel` (M3 regression)**; cache-hit-no-profile #306; no-profile miss→ProviderFailed; `prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls; CJK↔English + Latin round-trip via fake; cipher-throw→ProviderFailed not crash); `BilingualAiReadinessTest` (active+key→true; **no-active-with-profiles-present→false (H3); activeId-null→false (H3)**; empty key→false; cipher-throw→false, no crash); `PerBookBilingualStoreTest` (enabled/lang/granularity round-trip; granularity pinned paragraph; no style field); `BilingualViewModelTest` (Turbine: first-enable sheet; re-enable no-sheet; disable clears; language reset; `aiConfigured` from readiness; prefetch current+next; same-unit no-op; **cancel-mid discards (no errorUnit); typed-Cancelled discards (M2); rapid re-trigger same unit single-flight, no double-write (M2)**; offline→unavailable; error→errorUnit+retry; `retryUnit`); `AiSettingsViewModelSaveResultTest` (**`save()` returns the saved provider ID after the upsert commits — round-4 H4c seam; the returned ID matches `store.upsert(...).id`**); `EpubBilingualJsTest` (JS escaping / CSP-safe insertion; RTL/CJK style; empty translations; clear idempotent; inject idempotent replacement; source-only fallback — WI-7b if go); `EpubBilingualControllerTest` (**enumerate→cachedDirect/prefetchDirect→guarded commit; stale-session-token commit discarded, no errorUnit; single-owner (regular TXT/MD prefetch never runs for EPUB unit) — Medium-1** — WI-7b if go).
+
+Room migration: `VReaderDatabaseMigrationTest` (extend) **v8→v9 + full-chain from v8** + FK-CASCADE + `lookupKey`-as-PK + **exact-DDL validated against Room's generated `9.json` schema, not a hand-written approximation (gap A)**; `ChapterTranslationDaoTest` (upsert-by-PK replaces; get/delete-by-lookupKey).
+
+Compose UI (`androidTest/...bilingual/`): `BilingualSetupSheetUiTest` (language grid, **Granularity control shows Paragraph only — no Sentence option (H3)**, preview, engine configured vs unconfigured driven by `aiConfigured`; no Style control present; light+dark); `BilingualInterlinearBodyUiTest` (**translation rendered as a muted `Text` child inside the anchor chunk's `Column` (round-4 H2 render contract); paragraph interlinear translated incl. CJK font + RTL Arabic**; loading N%+dimmed; error+Retry; offline source-only; empty translation→source-only no crash); `ReaderAiProvidersSheetUiTest` (**the scoped list renders `‹ Bilingual` back label + bilingual-context empty copy + checked active row + tap-selects (`setActive`) — round-4 H4b; editor (`AiProviderEditSheet`) reused verbatim (H4a)**); `BilingualPillUiTest`.
+
+Connected (`androidTest/...reader/`): `TxtReaderBilingualConnectedTest` (API 35, fake `AiClient` via injected factory): enable→setup→confirm→interlinear from seeded Room cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2); highlights/annotation-washes/read-aloud-wash still key off source chunks (H2)**; **with bilingual ON — position-save round-trips to the same chunk; bookmark/search/scrubber/TTS jumps land on the correct chunk (lazy-index==chunk-index preserved — round-4 H2)**; **long-press on translation text does NOT select (gesture exclusion — round-4 H2)**; translation child non-selectable + no source-offset perturbation (H2); disable→source-selection byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders one translation (H1/Low-2); one-chunk/final-chunk anchors render (H1)**; TXT/MD gated (PDF inert); very long chapter scroll responsive; cancellation leaves no partial cache row. `ReaderAiProvidersConnectedTest` (WI-AIP + WI-9): `unconfigured → Set up → Variant A sheet → add provider → Save → save-result-id → setActive → pop-to-bilingual configured (deterministic, no race — round-4 H4c) → enable → translate`; `‹ Bilingual` without adding → unconfigured, snapshot unchanged; "Change…" → populated, current checked, tap → setActive. `EpubReaderBilingualConnectedTest` (only if WI-0=go): enable→inject on a real EPUB; disable→clear; href-change/fragment-recreation/activity-recreation→re-apply from cache (zero provider calls); count-divergence handled via `prefetchDirect`/`cachedDirect`; regular prefetch never runs for EPUB unit (Medium-1).
+
+Edge cases: empty translation, failed, partial per-chunk, CJK↔English + Latin + RTL, provider error/timeout/429/config/insecure, native + typed cancellation mid-translation + before-write, single-flight overlap, very long chapters, offline (cache-first + silent source-only), cipher-decrypt failure → not-ready (no crash), enumerate↔segment count divergence (direct path), one-chunk/final-chunk/EOF anchors (H1), blank model (M3), lazy-index==chunk-index parity with bilingual on (round-4 H2), translation-text long-press excluded (round-4 H2), save-result-id determinism (round-4 H4).
+
+## 6. Risks + mitigations
+
+- **Live-translation verification is AI-credential-gated (the box-D caveat).** The whole pipeline is verified without live creds via a deterministic **fake `AiClient`** injected through the prefetcher's `clientFactory` param (default `AiProviderFactory::create`; tests override). WI-3/4a/8 prove segment→chunk→decode→cache→interleave end-to-end incl. every error/edge path. Connected tests seed the Room cache and assert render-from-cache with zero client calls. An optional live smoke confirms wire format but is NOT a gate. The fresh-user `unconfigured → Set up → add provider` reachability leg is now #131-owned (WI-AIP + WI-9) and verified by `ReaderAiProvidersConnectedTest`.
+- **Final-chunk translation drop + span type (round-3 H1 + round-4 H1).** Fixed by `endExclusive = if (i+1<chunkCount) offsetForChunk(i+1) else text.length` + the dedicated **`Utf16Span(start, endExclusive)`** half-open value type replacing the incompatible `IntRange` everywhere in the segment/render contracts; one-chunk/final-chunk/exact-boundary/EOF tests. `offsetForChunk`'s clamp (TxtDocument.kt:17) is never relied on for the final end.
+- **Enabled render breaking the per-chunk layout/selection model AND the lazy-index↔chunk-index identity (round-3 H2 + round-4 H2).** Fixed by the **one-lazy-item-per-chunk `Column`** render contract: the `items(count = chunkCount, key = { it })` loop + keys are UNCHANGED (lazy-index==chunk-index preserved, so position-save/progress/every jump/TTS visibility — TxtReaderActivity.kt:220/252/256/411/421/454/481/623 — stay correct); inside each item a `Column` holds the UNCHANGED source `Text` (one `TextLayoutResult`, one `registerChunk(i)`) then the muted non-registered translation child(ren); an explicit **gesture-exclusion** stops a long-press on translation text from routing to `hitAt`'s nearest-source-chunk fallback (TxtSelectionController.kt:47–53). Enabled-mode tests assert selection/highlight/wash/annotation parity AND lazy-index==chunk-index parity with disabled, plus translation-not-selectable.
+- **TXT/MD segment↔render pairing (round-2 H1).** Both sides read the SAME segment `Utf16Span` array over `TxtDocument.text`, so 1:1 holds by construction — no chapter model invented; a paragraph split across many chunks is translated + rendered once (inside its last chunk's `Column`). Granularity is paragraph-only in v1; the `g=` cache slot is retained for a future granularity.
+- **Undesigned sentence render (round-4 H3).** v1 segments + caches + renders + offers **paragraph only** — the only depicted interlinear pattern. `TranslationGranularity.sentence` + `ChapterSegmenter.sentenceRanges` stay as reserved-foundational code (WI-1, unit-tested) but never appear in the v1 render/cache/VM/setup-sheet path. The Sentence control AND its render are design-gated together (§Design gates).
+- **Variant A fold-in not wireable verbatim (round-4 H4).** The EDITOR (`AiProviderEditSheet`) is reused verbatim (a); the scoped LIST is a NEW `ReaderAiProvidersList` over the shared `AiSettingsViewModel` state reproducing the designed `‹ Bilingual` nav + bilingual empty state + checked-active row + tap-to-select (b); a save-result seam returns the saved ID (which `AiProviderStore.upsert` already produces, AiProviderStore.kt:58/84) so `setActive(savedId)` + pop-on-success is deterministic and race-free (c). No "reuse `AiProviderListScreen` verbatim" claim remains anywhere.
+- **EPUB direct-block flow (round-3 Medium-1 — CONFIRMED RESOLVED).** The `EpubBilingualController` is the single owner: `enumeratedBlocks → cachedDirect (zero-provider restore) else prefetchDirect → session-token-guarded commit into BilingualRenderState/translationsByUnit`. The VM's position-driven regular prefetch is TXT/MD-only, so the two paths never write the same canonical cache row. Every suspended step is token-guarded; a stale token discards silently.
+- **EPUB count divergence (round-2 H2).** The direct-block path (`prefetchDirect` → `translatePreSegmented`, cached by enumerate count, restored by `cachedDirect(expectedCount)` with zero provider calls) — iOS Bugs #268/#330/#343 parity.
+- **EPUB JS-injection race (round-2 M1).** WI-0's contract (single actor/mutex OR monotonic navigator-session token; token check after every suspended call; clear before publication teardown; identified production re-apply signal per recreation case). No deterministic re-apply signal = explicit NO-GO → TXT/MD-only ship.
+- **Cancellation + single-flight (round-3 Medium-2 — CONFIRMED RESOLVED).** Both service and VM handle native `CancellationException` AND typed `ChapterTranslationError.Cancelled` before generic mapping (iOS `ChapterTranslationService.swift:359–364`); a per-unit `prefetchTasks: Map<TranslationUnitId, Job>` cancels/joins a prior request so rapid retry/navigation can't run overlapping translations or Room writes; a cancelled stale request never surfaces as `errorUnit`. `ensureActive()` before the Room write.
+- **Blank model (round-3 Medium-3 — CONFIRMED RESOLVED).** The prefetcher builds `model = profile.model.ifBlank { profile.kind.defaultModel }` (matches `AiChatViewModel.kt:61`; both wire clients serialize `request.model` directly, `OpenAiCompatibleProvider.kt:38`/`AnthropicProvider.kt:36`). Blank-model regression test.
+- **AI-config readiness (H3 — CONFIRMED correct).** `BilingualAiReadiness.resolve` = active profile + decrypts-non-empty; `activeId` can be null with profiles present; cipher failure → not-ready (no crash). No consent/flag gate (Android has none).
+- **Migration schema drift (gap A).** `MIGRATION_8_9`'s exact DDL is authored in §2 and validated against Room's GENERATED `9.json` schema (not a hand-written approximation) by the extended `VReaderDatabaseMigrationTest` opening the real Room DB — the recurring Android migration failure mode (cf. #135's stale-version finding).
+- **Backup `bilingualGranularity` cross-platform parity UNCONFIRMED (gap B).** The backup-contract `bilingualGranularity` field's cross-platform conformance vector + iOS parity are UNCONFIRMED. Safe for v1 (backup collect/restore is descoped / device-local — §7), but flagged as a follow-up: **when the backup-wiring WI lands, add a conformance vector under `contracts/vectors/` and confirm iOS parity before shipping backup of the field.**
+- **Cost/latency of translating on scroll.** Lazy current+next prefetch + disk cache; N-of-M progress; cancellation on navigate-away/generation-bump/single-flight supersede.
+- **Provider JSON non-compliance.** `TranslationChunkContract.decode` + per-segment fallback — never drops a paragraph.
+- **DataStore per-book key growth.** One Preferences entry per book keyed by fingerprint; scales like `ReaderSettingsStore`/`AiProviderStore`.
+- **Dependency honesty (round-3 Medium-4 — CONFIRMED RESOLVED).** WI-4b (DI, incl. `AiProviderStore` in `AppContainer`) is foundational and gates the production run-through of WI-6/WI-7b/WI-AIP/WI-8; those WIs' unit/Compose gates proceed against injected fakes, and WI-4b is sequenced before them. No external feature gates the chain (#136 closed).
+
+## 7. Backward compat
+
+- **Room migration additive.** New `chapter_translations` (FK CASCADE, `lookupKey` PK, `sourceParagraphCount`, all columns `NOT NULL`). Existing rows untouched. Against this checkout **8→9, `MIGRATION_8_9`** with the **exact DDL in §2** appended after `MIGRATION_7_8` (VReaderDatabase.kt:224–228); the migration test extended from v8 validates it against Room's generated `9.json` schema (gap A).
+- **Reader unchanged when bilingual off** — the TXT/MD `items(count = document.chunkCount, key = { it })` source loop + keys are **unchanged** (lazy-index==chunk-index preserved); each item's `Column` holds only the unchanged source `Text` unless `enabled && format∈{txt,md} && translation present` (translations are additive in-item children, non-registered, non-selectable — round-4 H2). `ReaderBottomChrome` is not modified. EPUB render adapter inert unless bilingual is on.
+- **`AppContainer` gains `AiProviderStore`** (previously not provided — VReaderApp.kt:64/66 comment only) plus the bilingual services + `AiSettingsViewModel` factory; all additive lazy singletons following the `readerSettingsStore` pattern. #118 AI files are consumed unchanged **except** the additive save-result seam on `AiSettingsViewModel.save()` (returns the saved ID — round-4 H4c; the underlying `AiProviderStore.upsert` already returns the saved profile, so this exposes existing information without changing persistence behavior).
+- **#118 AI provider files otherwise unchanged** — the prefetcher/readiness/Variant A sheet are new consumers; the scoped list is a new presentation over the shared VM state (round-4 H4b), not an edit to `AiProviderListScreen`.
+- **Backup contract already compatible** — `PerBookSettingsOverride.bilingualEnabled/TargetLanguage/Granularity` exist (no `bilingualStyle`), no translation-cache backup section (device-local, re-derivable). #131 writes the three fields locally; backup collect/restore is a small additive follow-up (no contract change), out of v1; config device-local until then. **`bilingualGranularity` cross-platform conformance vector + iOS parity are UNCONFIRMED (gap B) — a follow-up when the backup-wiring WI lands: add a `contracts/vectors/` conformance vector + confirm iOS parity before shipping backup of the field.**
+- **#132/#134/#129 landed** — the top-chrome pill mount + More-menu toggle (`readerMoreRows` extension) + `TxtReaderActivity` edit land on VERIFIED surfaces (rule 48 one-writer-per-file satisfied).
+
+## Design gates (rule 51 — for `needs-design` filing)
+
+1. **"Bilingual mode" setup sheet with BOTH Style AND Granularity in one Android sheet** (unchanged — Style stays descoped v1) — `vreader-bilingual.jsx` depicts Granularity (no Style); `vreader-ai-android.jsx` depicts Style (no Granularity); no committed bundle shows both together. v1 reproduces the granularity-only `vreader-bilingual.jsx` sheet and DROPS Style (user descope, §3). If Style is wanted as an Android user control, file `Design needed: bilingual setup sheet (Style + Granularity) for feature #131`. The box-D Style parity gap is tracked by the WI-9 follow-up checklist amendment.
+2. **`Design needed: sentence-granularity bilingual interlinear — BOTH the setup-sheet Sentence control AND its render — for feature #131`** (round-4 H3 — broadened to cover both, filed together) — `vreader-bilingual.jsx` `BilingualPageContent` (lines ~195–277) depicts ONLY paragraph interlinear (one translation `<p>` per source paragraph), and a translation-after-each-sentence render (grouped when several sentences share a line-chunk) is depicted nowhere; the Sentence option appears only in the setup control (`vreader-bilingual.jsx:77`) with no matching renderer. v1 ships the depicted **paragraph** interlinear render + a **Paragraph-only** setup-sheet Granularity control; **Sentence is descoped from BOTH the control and the render in v1** (no undesigned surface, no paragraph-content-under-a-sentence-key). `TranslationGranularity.sentence` + `ChapterSegmenter.sentenceRanges` remain reserved-foundational code (WI-1). When the sentence-interlinear render (and its control option) is designed, it is a render-only follow-up (the one-lazy-item-per-chunk `Column` contract already accommodates several stacked sentence translation children per anchor chunk). The box-D Sentence gap is tracked by the WI-9 follow-up checklist amendment.
+
+*(REMOVED in v4: the v3 "#136 dependency" design-gate line — #136 is closed and the Variant A AI Providers sheet IS the committed design, reproduced by WI-AIP, not a gate.)*
+
+## Revision history
+
+- v1 (2026-07-10): Gate-1 draft (Plan agent). Gate-2 Codex audit pending.
+- v2 (2026-07-11): Gate-2 round-1 REDESIGN resolved — Readium-feasibility corrected, entry-point rebased on box F, setup-sheet design-gated, DI/cache/concurrency fixed.
+- v3 (2026-07-12): Gate-2 round-2 findings resolved — TXT/MD document-global segment model (H1); EPUB translatePreSegmented + count-keyed cache + direct-block prefetch (H2); #136 AI-provider-reachability spun out as a hard dependency (GH #1976) + Style descoped v1 (H3); WI-0 go/no-go + navigator-race contract (M1); EPUB DOM-injection adapter not Compose body (M2); DI/factory WI reordered (M3); Room 8→9 MIGRATION_8_9 (M4); deps/WI-count corrected (L1/L2). Gate-2 round-3 = block-recommended.
+- v4 (2026-07-12): Gate-2 round-3 (block-recommended) findings resolved AND the AI-config path folded in — AI-config FOLDED IN (#136 CLOSED); WI-AIP added; WI-4b provides `AiProviderStore` into `AppContainer`; H1 final-chunk math; H2 additive-item render contract; M1 EPUB single-owner; M2 dual-cancellation + single-flight; M3 blank-model fallback; M4 dependency honesty; WI count corrected to 13; chunk semantics corrected. Gate-2 round-4 = block-recommended.
+- **v5 (2026-07-12): Gate-2 round-4 (block-recommended) findings resolved — 4 High + 2 gaps; a TARGETED PATCH of v4. Round-4 CONFIRMED M1/M2/M3/M4 RESOLVED and the Lows correct — those are UNCHANGED/KEPT.**
+  - **H1 (round-4 High-1) — `Utf16Span` value type:** the final-chunk MATH stays (confirmed correct); the ONLY problem was the type contradiction — v4 declared `paragraphRanges`/`sentenceRanges` as `List<IntRange>` while treating them half-open, but Kotlin `IntRange` is inclusive-inclusive. Replaced `IntRange` EVERYWHERE with a dedicated `Utf16Span(start, endExclusive)` value type (NEW file `bilingual/Utf16Span.kt`, rides WI-1). `ChapterSegmenter.paragraphRanges`/`sentenceRanges` return `List<Utf16Span>`; `TxtChapterTextProvider` + the render path consume `Utf16Span`. Updated §2 H1, the segmenter/provider file entries, WI-1, and every test-catalogue "half-open UTF-16 (start,endExclusive)" mention.
+  - **H2 (round-4 High-2) — one-lazy-item-per-chunk `Column` (THE key fix):** the v4 "separate additive `LazyColumn` items after the anchor chunk" contract is NOT implementable — the live reader treats lazy-item indices AS `TxtDocument` chunk indices (position-save via `offsetForChunk(firstVisibleItemIndex)`, TxtReaderActivity.kt:220/473/623; every bookmark/annotation/search/scrubber/TTS jump via `scrollToItem(chunkForOffset(...))`, :411/:421/:454/:481/:257; TTS visibility via `visibleItemsInfo.index == spokenChunk`, :256), so inserting separate translation items shifts every following lazy index and corrupts all of these. New binding contract: keep EXACTLY ONE lazy item per chunk (the `items(count=chunkCount, key={it})` loop + keys UNCHANGED → lazy-index==chunk-index preserved); INSIDE each item wrap the content in a `Column` — the UNCHANGED source `Text` (one `TextLayoutResult`, one `registerChunk(i)`) then the muted non-registered translation child(ren) anchored to chunk `i`. ADDED explicit translation **gesture exclusion** (TxtSelectionController.hitAt falls back to the nearest source chunk when the pointer is past source bounds, :47–53, so omitting `registerChunk` is not enough). Updated §2 H2, the `BilingualInterlinearBody` file entry, the rejected-alternatives list (added the separate-lazy-items rejection), WI-7a, WI-8, and the enabled-mode tests (position-save round-trips to the same chunk; jumps/TTS land on the correct chunk; long-press on translation does NOT select).
+  - **H3 (round-4 High-3) — Paragraph-only v1 granularity:** v4's "Sentence selectable + sentence cache identity active + paragraph-render fallback" was underspecified (no sentence→paragraph aggregation) and would render undesigned sentence items or serve paragraph content under a sentence key. Resolution: v1 segments + caches + renders **Paragraph ONLY**. `TranslationGranularity` + `ChapterSegmenter.sentenceRanges` stay as reserved-foundational code (WI-1, unit-tested) but the v1 render/cache/VM/setup-sheet path is paragraph-exclusive (`promptVersion` `g=paragraph` always; no `sentenceRanges` in the v1 render path; the setup-sheet Granularity control is Paragraph-only). Broadened the sentence design gate to cover BOTH the control option AND its render (filed together). Updated §2 H2 granularity subsection, the cache-identity section, WI-5/WI-7a, and the tests.
+  - **H4 (round-4 High-4) — WI-AIP editor-verbatim + new scoped list + save-result seam:** `AiProviderListScreen` owns its own `NavScreen`/chrome + generic empty state + row-tap-as-EDIT (AiProviderListScreen.kt:45/59/84/101/105), so it CANNOT be reused verbatim to reproduce the designed `‹ Bilingual` nav + bilingual empty state + checked-active row + tap-to-SELECT; AND `AiSettingsViewModel.save()` returns no ID and upserts async (:85–97), so a verbatim reuse can't deterministically `setActive(savedId)` + pop-on-success without racing the upsert. Resolution: (a) reuse the EDITOR (`AiProviderEditSheet`) VERBATIM; (b) the scoped LIST is a NEW `ReaderAiProvidersList` over the SHARED `AiSettingsViewModel` state reproducing the designed nav/empty-state/checked-row/tap-to-select; (c) an additive **save-result seam** on `save()` returning the saved provider ID (which `AiProviderStore.upsert` already produces, AiProviderStore.kt:58/84 — the #118 VM is production-unwired, wired for the first time here, so the seam is safe). Removed every "reuse `AiProviderListScreen` VERBATIM" claim. Updated the `ReaderAiProvidersSheet` file entry, §AI-config reachability, the rejected-alternatives list, WI-AIP, and its tests.
+  - **Gap A (workflow completeness) — MIGRATION_8_9 exact DDL:** authored the exact `CREATE TABLE chapter_translations (...)` DDL (all `NOT NULL` columns + PK `lookupKey` + `index_chapter_translations_bookKey` + FK→`books(fingerprintKey)` ON DELETE CASCADE, modeled on the verified `MIGRATION_6_7` shape) in §2/WI-2 as a build-time contract, and required the migration test to validate it against Room's GENERATED `9.json` schema (not a hand-written approximation — cf. #135's stale-version finding).
+  - **Gap B (workflow completeness) — backup granularity parity flag:** flagged (§6 Risks + §7 Backward compat) that the backup-contract `bilingualGranularity` field's cross-platform conformance vector + iOS parity are UNCONFIRMED — safe for v1 (backup collect/restore descoped / device-local), but a follow-up: when the backup-wiring WI lands, add a `contracts/vectors/` conformance vector + confirm iOS parity before shipping backup of the field.
+  - WI count UNCHANGED at **13** (`Utf16Span` rides WI-1). Awaiting Gate-2 round-5 audit.
+
+exec
+/bin/zsh -lc 'rg -n "IntRange|Utf16Span|sentenceRanges|Paragraph-only|paragraph-only|promptVersion|MIGRATION_8_9|CREATE TABLE chapter_translations|ReaderAiProvidersList|save-result|AiProviderEditSheet|bilingualGranularity|backup|WI-AIP|WI-2|WI-8" dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md' in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+21:- **TXT/MD unit (round-2 H1)** — `TxtDocument` has NO chapter model; it is line-based ≤4000-char chunks addressed by UTF-16 offset. v5 defines **document-global units with segment UTF-16 spans produced ONCE by the segmenter** and renders source/translation pairs from those same spans, with the **round-3 H1 final-chunk math fix**, the new **round-4 H1 `Utf16Span` value type** (§2, replacing `IntRange`), and the **round-4 H2 one-lazy-item-per-chunk `Column` render contract** (§2, §3).
+23:- **AI-config path (folded in — #136 CLOSED)** — the ONLY designed Android AI-config reader surface is the **Variant A scoped "AI Providers" sheet pushed inside the bilingual flow**, reached from the bilingual engine strip's "Set up"/"Change…" button (`reader-ai-provider-entry.md`). #131 now owns it end-to-end (§"AI-config reachability", WI-4b + WI-AIP + WI-9).
+32:2. **TXT/MD (Compose `TxtReaderActivity`) — INCLUDED.** No WebView; deterministically Compose-testable. Renders translations **inside the SAME lazy item as their anchor source chunk** (round-4 H2 — one lazy item per chunk, a wrapping `Column`), from **document-global segment `Utf16Span`s** (round-2 H1 + round-4 H1).
+49:- The whole `.txt`/`.md` is treated as **one translation document**. The **segmenter runs once over `TxtDocument.text`** (the full raw backing string) and emits, per segment, its **UTF-16 span as a `Utf16Span(start, endExclusive)`** (half-open) against that same backing string (the segmenter's `paragraphRanges(text): List<Utf16Span>` / `sentenceRanges(text): List<Utf16Span>` — the span-returning peers of `paragraphs`/`sentences`; iOS precedent `ChapterSegmenter.sentenceRanges(in:)` at `ChapterSegmenter.swift:78`, returns `[Range<Int>]`). These spans are the SINGLE source of truth used by BOTH the translate side and the render side, so the two segment identically **by construction** (they read the same array). Spans are stored/compared as the explicit `Utf16Span` value type (see the H1 fix below), NOT re-derived on the render side.
+52:#### H1 fix (round-3 High-1 math + round-4 High-1 type) — final-chunk source span + the `Utf16Span` value type (BINDING)
+58:// chunk i source span is the HALF-OPEN Utf16Span(document.offsetForChunk(i), endExclusive)
+61:**The type (round-4 High-1 — THE fix this round):** v4 declared `paragraphRanges`/`sentenceRanges` as `List<IntRange>` while treating them as half-open `[start, endExclusive)`. That is a **type contradiction** — Kotlin `IntRange` is inclusive-inclusive (`range.last` is the last *included* index, and `range.last` for an empty/at-EOF span is a footgun). The half-open contract and the `IntRange` type are incompatible. **Resolution — a dedicated value type, replacing `IntRange` EVERYWHERE:**
+64:// bilingual/Utf16Span.kt  (NEW FILE — rides WI-1)
+65:data class Utf16Span(val start: Int, val endExclusive: Int) {
+72:- `ChapterSegmenter.paragraphRanges(text): List<Utf16Span>` / `sentenceRanges(text): List<Utf16Span>` return `Utf16Span`s (half-open, against the input string). `TxtChapterTextProvider` and the TXT/MD render path consume `Utf16Span` — there is **no `IntRange`** anywhere in the segment/span contracts. (`TxtSelectionController`'s own `Utf16Range` type is a *separate*, unrelated selection type and is untouched — see H2's gesture-exclusion note.)
+74:- **Tests (WI-1 / WI-4a / WI-8):** `paragraphRanges`/`sentenceRanges` return correct half-open `Utf16Span(start, endExclusive)` spans (unit — WI-1); one-chunk document (no trailing newline) → its single paragraph/sentence translation renders (not dropped); final-chunk anchor (a paragraph whose last line is the final chunk) → translation renders after the last chunk; exact-boundary (a segment ending exactly at a chunk `start`) → anchored to the correct chunk, not off-by-one; EOF anchor (`span.endExclusive == text.length`) → resolves to the last chunk, no clamp-collapse.
+100:4. Emit each anchored translation as a muted, non-registered `Text` sibling **inside the same `Column`**, keyed by the segment's `Utf16Span` so a language change re-keys cleanly.
+104:- **Explicit translation gesture exclusion (round-4 High-2 — BINDING):** `TxtSelectionController.hitAt` (`reader/TxtSelectionController.kt:47`) falls back to the **nearest registered source chunk** when the pointer is outside all source-chunk bounds (`chunks.entries.minByOrNull { verticalDistance(...) }` when no chunk's `boundsInWindow()` contains the point, :51–53). So merely omitting `registerChunk` for the translation does **NOT** make it non-selectable — a long-press *on the translation text* would fall through to the nearest source chunk and select source. **WI-8 must add an explicit hit-test / gesture exclusion for the translation composable's bounds** so a long-press whose pointer lands inside a translation `Text`'s bounds is consumed (no selection begun) rather than routed to `hitAt`'s nearest-chunk fallback. (Options: the translation `Text` consumes the long-press gesture in its own `pointerInput`; or the selection gesture root records the translation composables' window bounds and short-circuits `beginAt` when the point is inside one. WI-8 picks and tests one.)
+106:- **Enabled-mode tests (WI-8 connected + WI-7a Compose, BINDING):** with bilingual ON —
+117:  - The `TranslationGranularity` enum + `ChapterSegmenter.sentenceRanges` API **stay as reserved FOUNDATIONAL code** (WI-1, with unit tests) so the future sentence-render is a render-only follow-up.
+118:  - The v1 **render/cache/VM/setup-sheet path uses paragraph exclusively:** `promptVersion`'s granularity component is **always `paragraph` in v1**; there is **no `sentenceRanges` in the v1 render path**; the setup sheet's Granularity control is **descoped to Paragraph-only in v1** (a documented divergence, tracked by the sentence design gate below — the same treatment as the Style descope).
+123:This closes round-3 H1 (no dropped final-chunk translations), round-3 H2 (per-chunk layout/selection preserved; source `Text` never split), round-4 H1 (the `Utf16Span` type replaces the incompatible `IntRange`), round-4 H2 (one lazy item per chunk preserves lazy-index==chunk-index; translation gesture exclusion), round-4 H3 (Paragraph-only v1 granularity), and round-3 Low-2 (correct chunk semantics).
+143:                    AiProviderEditSheet   [reused VERBATIM from #118]
+160:- `bilingual/Utf16Span.kt` — **NEW (round-4 H1).** `data class Utf16Span(val start: Int, val endExclusive: Int)` (half-open UTF-16 span; `require(endExclusive >= start)`; `isEmpty`, `length`). The single span type shared by the segmenter and the TXT/MD render path, replacing the incompatible `IntRange`. Rides WI-1. (Distinct from `TxtSelectionController.Utf16Range`, the selection type, which is untouched.)
+164:- `bilingual/ChapterSegmenter.kt` — **NEW file (no existing Android segmenter — verified).** Port of iOS `ChapterSegmenter`: `paragraphs(text)` / `sentences(text)` **plus the span-returning peers `paragraphRanges(text): List<Utf16Span>` / `sentenceRanges(text): List<Utf16Span>`** (half-open UTF-16 spans against the input string, as `Utf16Span` — round-4 H1; iOS `sentenceRanges(in:)` precedent). CJK-aware sentence enumeration (`。！？` vs Latin). Pure. (`sentenceRanges` is reserved-foundational; the v1 render path calls only `paragraphRanges` — round-4 H3.)
+168:- `bilingual/TxtChapterTextProvider.kt` — provider over `TxtDocument` + the segmenter's `Utf16Span` array (H1). Builds the document-global segment `Utf16Span`s once (via `paragraphRanges` — paragraph only in v1), groups them into windows, resolves `unitContaining` via a segment-start binary search over `charOffsetUTF16`. MD source = raw markdown segment text.
+187:- `bilingual/PerBookBilingualStore.kt` — DataStore-Preferences, keyed by `bookFingerprintKey`, holding `{ enabled, targetLanguage, granularity }` (`granularity` is persisted but pinned to `paragraph` in v1 — round-4 H3). The Android `PerBookSettingsOverride` bilingual slice — the backup contract declares exactly `bilingualEnabled` / `bilingualTargetLanguage` / `bilingualGranularity` and **NO `bilingualStyle`** (verified). Wiring into backup collect/restore is scoped OUT (§7); until then bilingual config is device-local.
+192:- `data/ChapterTranslationEntity.kt` — `@Entity(tableName="chapter_translations", indices=[Index("bookKey")], foreignKeys=[FK→books.fingerprintKey ON DELETE CASCADE])`. **`@PrimaryKey val lookupKey: String`** (Room requires a PK; project pattern `@PrimaryKey` + `@Upsert`, verified `BookEntity` `@PrimaryKey val fingerprintKey`, Entities.kt:24). `lookupKey` = `bookKey|unitStorageKey|targetLanguage|promptVersion`. Columns: `lookupKey` (PK), `bookKey`, `unitStorageKey`, `targetLanguage`, `promptVersion`, `translatedJson`, `sourceParagraphCount`, `createdAt`. Mirrors iOS `ChapterTranslationRecord.lookupKey` (`book|unit|lang|prompt`, profile-agnostic — Bug #342). `sourceParagraphCount` is load-bearing for H2 (stores the enumerate's count on the `translatePreSegmented` path so `cachedTranslation(expectedSegmentCount:)` restores). **The exact `MIGRATION_8_9` DDL is authored in WI-2 — see below.**
+196:**Cache-identity (reconciled with iOS parity):** the 4-part key `book|unit|lang|promptVersion` is profile-AGNOSTIC / style-agnostic (Bug #342). Style is descoped (§3) so no `s=` component. **Granularity is paragraph-only in v1** (round-4 H3): `promptVersion = "bilingual-v1|g=paragraph"` in v1 (the `g=` component is always `paragraph`). The composite `g=` slot is retained in the key format so a future granularity is a different cache row by construction (closes the iOS #344 "sentence silently ignored" class ahead of time), but v1 never emits `g=sentence`. A language change cancels in-flight jobs, bumps the VM generation, clears shaped `translationsByUnit`, and forces a correctly-keyed re-fetch (WI-6).
+202:- `bilingual/BilingualSetupSheet.kt` — reproduces `vreader-bilingual.jsx`'s `BilingualSetupSheet` (lines 27–156) EXACTLY, with the granularity divergence: header; a preview strip (`BilingualPreview`); a language grid over `BILINGUAL_LANGS` (glyph tiles, selected accent); a **Granularity** segmented control **descoped to Paragraph-only in v1** ("Translate after each ¶"; the Sentence option is not rendered in v1 — round-4 H3, tracked by the sentence design gate); a **Translation engine** strip (configured: "Claude · with this book's context" + "Change…"; unconfigured: "No AI provider configured" + "Bilingual mode needs an AI provider to translate." + "Set up"); the "Turn on bilingual mode" CTA. **No Style control, no provider/model card, no term-overrides toggle, no cost footer** (those belong to the `vreader-ai-android.jsx` sheet, not reproduced — §3). The `aiConfigured` flag comes from `BilingualAiReadiness.resolve`. The "Set up"/"Change…" CTA routes to `ReaderAiProvidersSheet` (wired in WI-9).
+204:  - **(a) EDITOR reused VERBATIM.** `AiProviderEditSheet` (the canonical add/edit modal, Kind / Name / Endpoint / Sampling / API Key / Test Connection) is presented UNCHANGED from the #118 Library path — that reuse is confirmed fine (`reader-ai-provider-entry.md:49–52`, :63–65).
+205:  - **(b) The scoped LIST is a NEW reader-specific presentation** (`ReaderAiProvidersList`, in this file) built over the **SHARED `AiSettingsViewModel` state** (`listState`, verified `AiSettingsViewModel.kt:26`) + shared row/cell components, reproducing: the reader-scoped nav (`‹ Bilingual` back label, "AI Providers" title — `NavSheet` at jsx:247, NOT `AiProviderListScreen`'s own `NavScreen`); the **bilingual-context empty state** ("Choose the provider bilingual mode will use to translate this book." context strip + "No providers yet" + "Add provider" CTA — jsx:180–209); the **checked-active row** (`selected={p.id === selectedId}` — jsx:221; the live `AiProviderListState`/`AiProviderRow` already carries `active` per row, `AiSettingsViewModel.kt:30`); and **tap-to-SELECT** (`onSelect(p.id)` → `vm.setActive(id)` — jsx:221/237). It does **NOT** reuse `AiProviderListScreen`'s `NavScreen`/chrome/`AiEmptyState`/`ProviderRow`-tap-edit.
+206:  - **(c) A save-result seam** (round-4 High-4): `AiSettingsViewModel.save()` today returns Unit and upserts async (generates `s.id ?: UUID.randomUUID().toString()` *inside* the launched coroutine, then `_edit.value = null`, no saved ID — `AiSettingsViewModel.kt:85–97`), so WI-AIP cannot deterministically `setActive(savedId)` + pop-on-success by reusing it verbatim (popping immediately races the async upsert; observing list state can't distinguish the new profile). **Note:** `AiProviderStore.upsert` ALREADY returns the saved profile (`suspend fun upsert(...): AiProviderProfile`, "Returns the saved profile", `AiProviderStore.kt:58/70/84`) — the ID is present at the store layer; only the VM discards it. So the seam is an **additive completion/result signal on `AiSettingsViewModel.save()`** (or a thin WI-AIP wrapper) returning the saved provider ID (from `store.upsert(...).id`), so WI-AIP can `setActive(savedId)` + pop-on-success **after** the upsert commits — no race. The #118 VM is currently production-UNWIRED (only test-referenced — verified), and this feature wires it to production for the FIRST time, so an additive save-result seam is safe and appropriate.
+207:  - **Behavior per the nav model:** empty → "Add provider" → `AiProviderEditSheet` → Save → `save()` returns the saved ID → `store.setActive(savedId)` (first-provider-active is already the store's default `activeId = cur.activeId ?: id`, AiProviderStore.kt:81; the explicit `setActive(savedId)` guarantees the freshly-saved provider is the engine even if others existed) → **pop the whole stack** back to the bilingual sheet, engine strip now "Claude · configured / Change…". `‹ Bilingual` without adding → unconfigured, **no state mutated**. "Change…" → the SAME sheet, populated, current provider checked, tap a row → `setActive`. No consent card, no feature-flag toggle, no readiness tracker (iOS #82, deferred).
+244:- `data/VReaderDatabase.kt` — add `ChapterTranslationEntity` to `@Database entities`, bump `version` **8 → 9** (the live DB is v8, migrations `MIGRATION_1_2`..`MIGRATION_7_8`, `ALL_MIGRATIONS` ends at `MIGRATION_7_8` — verified VReaderDatabase.kt:29,224–228), add **`MIGRATION_8_9`** (exact DDL below — gap A), **append `MIGRATION_8_9` to `ALL_MIGRATIONS` after `MIGRATION_7_8`**, add `abstract fun chapterTranslationDao()`. Purely additive.
+246:  **`MIGRATION_8_9` exact DDL (gap A — BINDING; modeled on the verified `MIGRATION_6_7` `search_index_state` shape at VReaderDatabase.kt:154–169, whose DDL Room's PRAGMA validation already accepts):**
+249:  val MIGRATION_8_9: Migration = object : Migration(8, 9) {
+257:                  "`promptVersion` TEXT NOT NULL, " +
+278:- `reader/TxtSelectionController.kt` — **may gain a small additive seam for the translation gesture-exclusion** (H2) IF WI-8's chosen exclusion approach records translation-composable bounds at the selection root (e.g. an optional "excluded bounds" setter the body populates). If WI-8 instead consumes the long-press in the translation `Text`'s own `pointerInput`, this file is untouched. WI-8 picks one; the `hitAt` nearest-chunk fallback (`reader/TxtSelectionController.kt:47–53`) is the reason an exclusion is required at all.
+287:- **Backup collect/restore of `PerBookSettingsOverride` bilingual fields** — contract fields exist; wiring is a small additive follow-up (§7). Device-local until then. **The `bilingualGranularity` field's cross-platform conformance vector + iOS parity are UNCONFIRMED (gap B, §6/§7) — a follow-up when the backup-wiring WI lands.**
+289:- **Sentence granularity (both the setup-sheet Sentence control AND the sentence-interlinear RENDER)** — not depicted (round-4 H3); design-gated together (§Design gates). v1 renders + caches + offers **paragraph only**; `sentenceRanges`/`TranslationGranularity.sentence` remain reserved-foundational code (WI-1, unit-tested) but are absent from the v1 render/cache/VM/setup-sheet path.
+315:11. **Reusing `AiProviderListScreen` VERBATIM for the Variant A scoped list (v4)** — REJECTED (round-4 H4): `AiProviderListScreen` owns its own `NavScreen`/chrome (AiProviderListScreen.kt:59), a generic empty state (:84/:87), and row-tap-as-EDIT (:105), so it cannot reproduce the designed `‹ Bilingual` nav + bilingual-context empty state + checked-active row + tap-to-SELECT. Replaced by (a) reuse the EDITOR verbatim + (b) a NEW `ReaderAiProvidersList` over the shared `AiSettingsViewModel` state + (c) a save-result seam returning the saved ID.
+323:**Resolution:** this plan reproduces the **`vreader-bilingual.jsx` sheet EXACTLY**, with the round-4 H3 granularity divergence (Paragraph-only in v1). **Style is DESCOPED for v1** (user decision): keep provider/model/**granularity (paragraph)**, DROP the bilingual "Style" control. Consequently store/VM carry no `style`, the chunk contract has no `style` param, and the cache key's `promptVersion` has no `s=` component.
+329:The canonical decision (`reader-ai-provider-entry.md`, Variant A) + its component canvas (`vreader-ai-provider-entry.jsx`) ARE the committed design; #131 reproduces only what they depict (a `‹ Bilingual`-titled push sheet hosting the provider list + the canonical editor, pop-back-on-first-save, checked-active row, tap-to-select). The scoped list is a NEW reader-specific presentation over the shared #118 VM state (round-4 H4) — it does not reuse `AiProviderListScreen`'s chrome/empty-state/row-tap-edit — but it invents no new AI-config sheet or nav beyond what the Variant A canvas depicts. The editor (`AiProviderEditSheet`) IS reused verbatim. The iOS #82 readiness additions (flag/consent) are explicitly **out** on Android (no such subsystems exist). This is a designed surface — it is NOT a design gate.
+333:- **#118 provider seam**: reuse `AiProviderStore.snapshot()` (`snapshot.active`) + `store.apiKey(profile)` + `AiProviderFactory.create` (default of an injected factory param) + `AiClient.chat`. #118's AI files are unchanged EXCEPT the additive save-result seam on `AiSettingsViewModel.save()` (round-4 H4c — returns the saved ID, which `AiProviderStore.upsert` already produces, AiProviderStore.kt:58/84); #131 wires `AiProviderStore` into `AppContainer` and reuses `AiProviderEditSheet`/`AiSettingsViewModel` for the Variant A sheet (the scoped list is new — H4b).
+342:**13 WIs/PRs (round-3 Low-1 fix — corrected count; UNCHANGED in v5):** the list is exactly **WI-0, WI-1, WI-2, WI-3, WI-4a, WI-4b, WI-5, WI-6, WI-7a, WI-7b, WI-AIP, WI-8, WI-9** = **13 WIs**. `Utf16Span` (round-4 H1) is a NEW file but **rides WI-1** (the foundational value-types + pure-segmentation WI) — it does not add a WI. Each WI = one PR. Build order: **foundation/cache → service/direct-block APIs → shared DI/factory (incl. `AiProviderStore` in `AppContainer`) → VM state/prefetch → host-specific renderers (TXT/MD + EPUB) + the Variant A AI Providers sheet → entry wiring.**
+347:- **WI-4b is foundational and gates the behavioral chain.** WI-4b provides `AiProviderStore` into `AppContainer` PLUS the bilingual services + factories. Per the audit's Medium-4, WI-4b transitively gates WI-6 (needs the prefetcher/DI), WI-7b (needs DI), WI-AIP (needs `AiProviderStore` + `AiSettingsViewModel` from `AppContainer`), and WI-8 (needs DI). **Chosen resolution: injected seams so the behavioral work proceeds against fakes before WI-4b lands, AND WI-4b is sequenced early.** Concretely: the VM (WI-5/WI-6) takes an injected `ChapterTranslationPrefetcher` (fake in tests) and an injected `AiProviderSnapshot` provider (fake); the TXT/MD host Compose/unit work (WI-8) and the Variant A sheet (WI-AIP) take injected VM/store/`AiSettingsViewModel` seams — so unit/Compose tests do not wait on `AppContainer`. **WI-4b is built right after WI-4a (before WI-6/WI-7b/WI-AIP/WI-8) so the production wiring lands before the host integrations that mount it.** This is stated honestly: the *production run-through* of WI-6/WI-7b/WI-AIP/WI-8 depends on WI-4b; their *unit/Compose gates* depend only on the injected seams. No external feature gates any of this.
+351:**WI-1 (foundational): value types + pure segmentation/chunk/contract.** **`Utf16Span` (round-4 H1 — the half-open span value type replacing `IntRange`)**, `TranslationUnitId`, `TranslationGranularity` (reserved; v1 uses `paragraph` only — round-4 H3), `BilingualLanguages`, **`ChapterSegmenter` (with `paragraphRanges`/`sentenceRanges` returning `List<Utf16Span>` — H1; `sentenceRanges` is reserved-foundational, not in the v1 render path — H3)**, `TranslationChunker`, `TranslationChunkContract` (no `style`), `ChapterTranslationError`. Pure; ported iOS vectors. Deps: none. Tests: `paragraphRanges`/`sentenceRanges` return correct half-open `Utf16Span(start, endExclusive)` spans (both APIs unit-tested even though only `paragraphRanges` ships in the v1 render path — `sentenceRanges` stays covered as reserved-foundational code); chunker packs-to-budget/oversize/empty; contract prompt/decode/fence/mismatch; error mapping.
+353:**WI-2 (foundational): Room translation cache.** `ChapterTranslationEntity` (PK = `lookupKey`, all-`NOT NULL` columns matching the DDL, `sourceParagraphCount` column) + `Dao` (`@Upsert`) + `ChapterTranslationStore`; `VReaderDatabase` **8→9 `MIGRATION_8_9`** with the **exact DDL authored in §2 (gap A)**, appended after `MIGRATION_7_8`. Robolectric migration round-trip from v8 + full-chain + upsert/get/delete-by-lookupKey + FK-CASCADE + **exact-DDL guard validated against Room's GENERATED `9.json` schema (not a hand-written approximation — gap A)**. Deps: none.
+355:**WI-3 (foundational): `ChapterTranslationService`** against a fake `AiClient`. Both `cachedTranslation` overloads (incl. the `expectedSegmentCount` divergence restore — H2) + `translate` + `translatePreSegmented`. **Dual-cancellation (native + typed `Cancelled`) BEFORE generic mapping (M2).** Deps: WI-1, WI-2. Tests: cache hit → zero client calls; miss → translate + write; decode fail → per-segment fallback; one-chunk fail → source-only that chunk (others translated, NOT cached); all-chunks fail → throw; native-cancel → `Cancelled` (no write); typed-`Cancelled`-from-chunk → `Cancelled` (no write); ensureActive-before-write; `AiError` mapping incl. `Config`/`InsecureUrl` → `ProviderFailed`; `translatePreSegmented` full-success caches under the enumerate count; partial degrade NOT cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` returns on stored-count match, null on mismatch, needs no provider.
+357:**WI-4a (foundational): `ChapterTextProvider` (TXT/MD) + `ChapterTranslationPrefetcher` + `BilingualAiReadiness`.** `TxtChapterTextProvider` builds the document-global segment `Utf16Span`s once (via `paragraphRanges` — paragraph only, H1/H3), groups into windows, resolves `unitContaining(charOffsetUTF16)` via segment-start binary search, `sourceSegments(unit)`. Prefetcher: `prefetch` + `prefetchDirect` + `cachedDirect`; resolves active profile from `snapshot()`, decrypts snapshot-consistent, builds client via the injected factory param (default `AiProviderFactory::create`), constructs `AiRequest` with **`model = profile.model.ifBlank { profile.kind.defaultModel }` (M3)**. Readiness = active profile with non-empty decrypted key; **cipher failure → not-ready, never a crash.** Fake store + fake factory. Deps: WI-1, WI-3. Tests (all `Utf16Span`-based): unit resolution + clamp + empty; **one-chunk document (no trailing newline) → its segment translation renders, not dropped (H1)**; **final-chunk anchor → renders (H1)**; **exact-boundary → correct anchor (H1)**; **EOF anchor (`span.endExclusive == text.length`) → last chunk, no clamp-collapse (H1)**; paragraph spanning MANY chunks → one segment/one unit, anchored to the last chunk (Low-2); a >4000-char paragraph hard-split across chunks → one segment; CR/LF/CRLF; MD markers; locator→unit mapping; `unitAfter` end→null; **source-byte parity while disabled**; cache-hit-no-profile still returns (#306); no-profile miss → `ProviderFailed`; `prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls; **blank `profile.model` → `AiRequest.model == kind.defaultModel` (M3 regression)**; readiness true/false; empty-key → false; no-active-with-profiles-present → false (H3); cipher-throw → readiness false (no crash). (Sentence-multi-in-one-chunk is NOT a v1 render test — the v1 provider uses `paragraphRanges` only; `sentenceRanges` behavior is covered in WI-1's reserved-foundational unit tests.)
+359:**WI-4b (foundational — shared DI/factory, incl. `AiProviderStore` in `AppContainer`): AppContainer bilingual + AI-config graph.** `AppContainer` **now constructs `AiProviderStore`** (DataStore + #116 `KeystoreSecretCipher`, following the `readerSettingsStore` convention — this is #131's change, not an external feature's) and provides `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, an `AiSettingsViewModel` factory (for WI-AIP), and the `BilingualViewModel` factory. Deps: **WI-4a** (no external dep — #136 closed). Tests: container resolves the bilingual + AI-config graph; `AiProviderStore` resolves and round-trips a profile; the prefetcher's injected factory defaults to `AiProviderFactory::create`.
+365:**WI-7a (behavioral): Compose UI — setup sheet + interlinear body (TXT/MD) + pill.** Reproduce `vreader-bilingual.jsx` (setup sheet: language grid / **Paragraph-only Granularity control (round-4 H3)** / preview / engine strip configured+unconfigured; body: the translation rendered **inside the anchor chunk's `Column` as a muted non-registered `Text` child** per the round-4 H2 render contract — translated / loading N%+dimmed / error+Retry / offline source-only; pill). Consumes the host-neutral `BilingualRenderState` DTO. Light+dark. Compose UI tests each state, incl. **paragraph interlinear renders a translation child after a paragraph's last source chunk (depicted)**; **the setup-sheet Granularity control shows Paragraph only, no Sentence option (H3)**. Deps: WI-5 (state shape). NO Style control; the unconfigured "Set up" CTA renders and (in WI-9) routes to the Variant A sheet.
+369:**WI-AIP (behavioral — the folded-in Variant A AI Providers sheet; round-4 H4 rewritten): `ReaderAiProvidersSheet`.** The scoped in-reader "AI Providers" push sheet (nav bar `‹ Bilingual` + "AI Providers" title) reproducing `vreader-ai-provider-entry.jsx` `AIProvidersSheet`/`AIProvidersSheetBody`/`NavSheet`. Per round-4 H4:
+370:  - **(a)** present `AiProviderEditSheet` VERBATIM from #118 (Kind/Name/Endpoint/Sampling/API Key/Test Connection unchanged).
+371:  - **(b)** a NEW `ReaderAiProvidersList` presentation over the SHARED `AiSettingsViewModel.listState` (verified `AiSettingsViewModel.kt:26`; each `AiProviderRow` already carries `active`, :30) + shared row/cell components — reproducing the reader-scoped `‹ Bilingual` nav (`NavSheet`, jsx:247, NOT `AiProviderListScreen`'s `NavScreen`), the bilingual-context empty state ("Choose the provider bilingual mode will use to translate this book." + "No providers yet" + "Add provider" — jsx:180–209), the **checked-active row** (`selected = row.active` — jsx:221), and **tap-to-SELECT** (`onSelect(id) → vm.setActive(id)` — jsx:221/237). It does NOT reuse `AiProviderListScreen`'s NavScreen/chrome/`AiEmptyState`/`ProviderRow`-tap-edit.
+372:  - **(c)** the **save-result seam**: `AiSettingsViewModel.save()` (or a thin WI-AIP wrapper) is extended to return the saved provider ID (from `store.upsert(...).id`, which the store already returns — `AiProviderStore.kt:58/84`), so on first Save → `store.setActive(savedId)` → pop the whole stack back to the bilingual sheet (engine strip now "configured / Change…"), **deterministically, after the upsert commits (no race)**.
+375:**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into the `items(count = document.chunkCount, key = { it })` loop as **muted non-registered translation `Text` children inside each anchor chunk's wrapping `Column`, source chunk byte-unchanged, the loop + keys UNCHANGED so lazy-index==chunk-index is preserved (round-4 H2)** + the translation **gesture-exclusion** (round-4 H2) + position-change (`charOffsetUTF16`) + setup-sheet. `originalFormat`-gated (TXT/MD). Uses WI-4b's DI. **#129 VERIFIED — straight edit.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2)**; **highlights/annotation-washes/read-aloud-wash still key off source chunks (H2)**; **with bilingual ON — position-save round-trips to the same chunk; bookmark/search/scrubber/TTS jumps land on the correct chunk (lazy-index==chunk-index preserved — round-4 H2)**; **a long-press on translation text does NOT select (gesture exclusion — round-4 H2)**; a translation child is non-selectable, does not perturb source offsets (H2); disable → source-selection byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders exactly one translation inside its last chunk's `Column` (H1/Low-2)**; **one-chunk/final-chunk anchors render (H1)**; MD source mapping. Deps: WI-6, WI-7a, WI-4b.
+377:**WI-9 (behavioral): entry wiring + acceptance.** Mount `BilingualPill` in #132's VERIFIED top chrome; extend `readerMoreRows(...)` to supply the #134 VERIFIED More-menu `MoreActionId.BILINGUAL` toggle (`MoreRow.Toggle` `on`/`onToggle`, or `MoreRow.Disabled` "Configure AI provider first" when not configured) wired to the VM; **wire the setup sheet's "Set up"/"Change…" affordance → the #131-owned `ReaderAiProvidersSheet` (Variant A)**. Full acceptance across EPUB (if WI-7b landed) + TXT/MD, including the fresh-user path `unconfigured → Set up (→ Variant A AI Providers sheet) → add provider → Save → return → enable → translate` (now #131-owned end-to-end). **Flip box D to done ONLY for provider/model/granularity(paragraph) + the Style-descope AND Sentence-descope notes; file the follow-up checklist amendment; do NOT claim full box-D parity.** The DONE flip **no longer waits on #136** (closed). Update `docs/architecture.md` (bilingual pipeline + the new `chapter_translations` schema + `AiProviderStore` + bilingual services in `AppContainer` + the Variant A AI Providers sheet). → DONE. Deps: WI-8, WI-AIP, WI-7b (if go), feat:#132, feat:#134.
+381:JVM/Robolectric (`android/app/src/test/...bilingual/`): `Utf16SpanTest` (**half-open invariants: `endExclusive >= start`, `isEmpty`, `length`; round-4 H1**); `ChapterSegmenterTest` (paragraph blank-line; sentence CJK `。！？` vs Latin; empty→[]; single; **`paragraphRanges`/`sentenceRanges` return correct half-open `Utf16Span(start, endExclusive)` spans — both APIs covered even though only `paragraphRanges` ships in the v1 render path**); `TranslationChunkerTest` (packs to budget; oversize→own chunk+subSplit; empty→[]); `TranslationChunkContractTest` (prompt shape; strict JSON decode; code-fence strip; count mismatch→`CountMismatch`; non-array→`NotAStringArray`); `ChapterTranslationServiceTest` (cache hit 0 calls; miss→translate→write; decode-fail per-segment fallback; one-chunk-fail partial-not-cached; all-fail→throw; **native-cancel→Cancelled no write; typed-`Cancelled`→Cancelled no write (M2)**; ensureActive-before-write; offline/timeout/429/http/config/insecure→error mapping; very long chapter N-of-M; stale-cache count-mismatch re-translates; `translatePreSegmented` caches under enumerate count on full success; partial degrade not cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` hit/miss with no provider); `ChapterTranslationErrorMappingTest`; `TxtChapterTextProviderTest` (**one-chunk document → renders (H1); final-chunk anchor → renders (H1); exact-boundary → correct anchor (H1); EOF anchor → last chunk, no clamp-collapse (H1)**; paragraph spanning MANY chunks → one segment/unit anchored to last chunk (Low-2); >4000-char paragraph → one segment across hard-split chunks; CR/LF/CRLF; MD markers; locator→unit mapping; `unitAfter` end→null; source-byte parity while disabled; **provider uses `paragraphRanges` only — H3**); `ChapterTranslationPrefetcherTest` (snapshot-consistent profile+key; injected-factory used; `AiRequest` built from profile; **blank `profile.model` → `kind.defaultModel` (M3 regression)**; cache-hit-no-profile #306; no-profile miss→ProviderFailed; `prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls; CJK↔English + Latin round-trip via fake; cipher-throw→ProviderFailed not crash); `BilingualAiReadinessTest` (active+key→true; **no-active-with-profiles-present→false (H3); activeId-null→false (H3)**; empty key→false; cipher-throw→false, no crash); `PerBookBilingualStoreTest` (enabled/lang/granularity round-trip; granularity pinned paragraph; no style field); `BilingualViewModelTest` (Turbine: first-enable sheet; re-enable no-sheet; disable clears; language reset; `aiConfigured` from readiness; prefetch current+next; same-unit no-op; **cancel-mid discards (no errorUnit); typed-Cancelled discards (M2); rapid re-trigger same unit single-flight, no double-write (M2)**; offline→unavailable; error→errorUnit+retry; `retryUnit`); `AiSettingsViewModelSaveResultTest` (**`save()` returns the saved provider ID after the upsert commits — round-4 H4c seam; the returned ID matches `store.upsert(...).id`**); `EpubBilingualJsTest` (JS escaping / CSP-safe insertion; RTL/CJK style; empty translations; clear idempotent; inject idempotent replacement; source-only fallback — WI-7b if go); `EpubBilingualControllerTest` (**enumerate→cachedDirect/prefetchDirect→guarded commit; stale-session-token commit discarded, no errorUnit; single-owner (regular TXT/MD prefetch never runs for EPUB unit) — Medium-1** — WI-7b if go).
+385:Compose UI (`androidTest/...bilingual/`): `BilingualSetupSheetUiTest` (language grid, **Granularity control shows Paragraph only — no Sentence option (H3)**, preview, engine configured vs unconfigured driven by `aiConfigured`; no Style control present; light+dark); `BilingualInterlinearBodyUiTest` (**translation rendered as a muted `Text` child inside the anchor chunk's `Column` (round-4 H2 render contract); paragraph interlinear translated incl. CJK font + RTL Arabic**; loading N%+dimmed; error+Retry; offline source-only; empty translation→source-only no crash); `ReaderAiProvidersSheetUiTest` (**the scoped list renders `‹ Bilingual` back label + bilingual-context empty copy + checked active row + tap-selects (`setActive`) — round-4 H4b; editor (`AiProviderEditSheet`) reused verbatim (H4a)**); `BilingualPillUiTest`.
+387:Connected (`androidTest/...reader/`): `TxtReaderBilingualConnectedTest` (API 35, fake `AiClient` via injected factory): enable→setup→confirm→interlinear from seeded Room cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2); highlights/annotation-washes/read-aloud-wash still key off source chunks (H2)**; **with bilingual ON — position-save round-trips to the same chunk; bookmark/search/scrubber/TTS jumps land on the correct chunk (lazy-index==chunk-index preserved — round-4 H2)**; **long-press on translation text does NOT select (gesture exclusion — round-4 H2)**; translation child non-selectable + no source-offset perturbation (H2); disable→source-selection byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders one translation (H1/Low-2); one-chunk/final-chunk anchors render (H1)**; TXT/MD gated (PDF inert); very long chapter scroll responsive; cancellation leaves no partial cache row. `ReaderAiProvidersConnectedTest` (WI-AIP + WI-9): `unconfigured → Set up → Variant A sheet → add provider → Save → save-result-id → setActive → pop-to-bilingual configured (deterministic, no race — round-4 H4c) → enable → translate`; `‹ Bilingual` without adding → unconfigured, snapshot unchanged; "Change…" → populated, current checked, tap → setActive. `EpubReaderBilingualConnectedTest` (only if WI-0=go): enable→inject on a real EPUB; disable→clear; href-change/fragment-recreation/activity-recreation→re-apply from cache (zero provider calls); count-divergence handled via `prefetchDirect`/`cachedDirect`; regular prefetch never runs for EPUB unit (Medium-1).
+389:Edge cases: empty translation, failed, partial per-chunk, CJK↔English + Latin + RTL, provider error/timeout/429/config/insecure, native + typed cancellation mid-translation + before-write, single-flight overlap, very long chapters, offline (cache-first + silent source-only), cipher-decrypt failure → not-ready (no crash), enumerate↔segment count divergence (direct path), one-chunk/final-chunk/EOF anchors (H1), blank model (M3), lazy-index==chunk-index parity with bilingual on (round-4 H2), translation-text long-press excluded (round-4 H2), save-result-id determinism (round-4 H4).
+393:- **Live-translation verification is AI-credential-gated (the box-D caveat).** The whole pipeline is verified without live creds via a deterministic **fake `AiClient`** injected through the prefetcher's `clientFactory` param (default `AiProviderFactory::create`; tests override). WI-3/4a/8 prove segment→chunk→decode→cache→interleave end-to-end incl. every error/edge path. Connected tests seed the Room cache and assert render-from-cache with zero client calls. An optional live smoke confirms wire format but is NOT a gate. The fresh-user `unconfigured → Set up → add provider` reachability leg is now #131-owned (WI-AIP + WI-9) and verified by `ReaderAiProvidersConnectedTest`.
+394:- **Final-chunk translation drop + span type (round-3 H1 + round-4 H1).** Fixed by `endExclusive = if (i+1<chunkCount) offsetForChunk(i+1) else text.length` + the dedicated **`Utf16Span(start, endExclusive)`** half-open value type replacing the incompatible `IntRange` everywhere in the segment/render contracts; one-chunk/final-chunk/exact-boundary/EOF tests. `offsetForChunk`'s clamp (TxtDocument.kt:17) is never relied on for the final end.
+396:- **TXT/MD segment↔render pairing (round-2 H1).** Both sides read the SAME segment `Utf16Span` array over `TxtDocument.text`, so 1:1 holds by construction — no chapter model invented; a paragraph split across many chunks is translated + rendered once (inside its last chunk's `Column`). Granularity is paragraph-only in v1; the `g=` cache slot is retained for a future granularity.
+397:- **Undesigned sentence render (round-4 H3).** v1 segments + caches + renders + offers **paragraph only** — the only depicted interlinear pattern. `TranslationGranularity.sentence` + `ChapterSegmenter.sentenceRanges` stay as reserved-foundational code (WI-1, unit-tested) but never appear in the v1 render/cache/VM/setup-sheet path. The Sentence control AND its render are design-gated together (§Design gates).
+398:- **Variant A fold-in not wireable verbatim (round-4 H4).** The EDITOR (`AiProviderEditSheet`) is reused verbatim (a); the scoped LIST is a NEW `ReaderAiProvidersList` over the shared `AiSettingsViewModel` state reproducing the designed `‹ Bilingual` nav + bilingual empty state + checked-active row + tap-to-select (b); a save-result seam returns the saved ID (which `AiProviderStore.upsert` already produces, AiProviderStore.kt:58/84) so `setActive(savedId)` + pop-on-success is deterministic and race-free (c). No "reuse `AiProviderListScreen` verbatim" claim remains anywhere.
+405:- **Migration schema drift (gap A).** `MIGRATION_8_9`'s exact DDL is authored in §2 and validated against Room's GENERATED `9.json` schema (not a hand-written approximation) by the extended `VReaderDatabaseMigrationTest` opening the real Room DB — the recurring Android migration failure mode (cf. #135's stale-version finding).
+406:- **Backup `bilingualGranularity` cross-platform parity UNCONFIRMED (gap B).** The backup-contract `bilingualGranularity` field's cross-platform conformance vector + iOS parity are UNCONFIRMED. Safe for v1 (backup collect/restore is descoped / device-local — §7), but flagged as a follow-up: **when the backup-wiring WI lands, add a conformance vector under `contracts/vectors/` and confirm iOS parity before shipping backup of the field.**
+410:- **Dependency honesty (round-3 Medium-4 — CONFIRMED RESOLVED).** WI-4b (DI, incl. `AiProviderStore` in `AppContainer`) is foundational and gates the production run-through of WI-6/WI-7b/WI-AIP/WI-8; those WIs' unit/Compose gates proceed against injected fakes, and WI-4b is sequenced before them. No external feature gates the chain (#136 closed).
+414:- **Room migration additive.** New `chapter_translations` (FK CASCADE, `lookupKey` PK, `sourceParagraphCount`, all columns `NOT NULL`). Existing rows untouched. Against this checkout **8→9, `MIGRATION_8_9`** with the **exact DDL in §2** appended after `MIGRATION_7_8` (VReaderDatabase.kt:224–228); the migration test extended from v8 validates it against Room's generated `9.json` schema (gap A).
+416:- **`AppContainer` gains `AiProviderStore`** (previously not provided — VReaderApp.kt:64/66 comment only) plus the bilingual services + `AiSettingsViewModel` factory; all additive lazy singletons following the `readerSettingsStore` pattern. #118 AI files are consumed unchanged **except** the additive save-result seam on `AiSettingsViewModel.save()` (returns the saved ID — round-4 H4c; the underlying `AiProviderStore.upsert` already returns the saved profile, so this exposes existing information without changing persistence behavior).
+418:- **Backup contract already compatible** — `PerBookSettingsOverride.bilingualEnabled/TargetLanguage/Granularity` exist (no `bilingualStyle`), no translation-cache backup section (device-local, re-derivable). #131 writes the three fields locally; backup collect/restore is a small additive follow-up (no contract change), out of v1; config device-local until then. **`bilingualGranularity` cross-platform conformance vector + iOS parity are UNCONFIRMED (gap B) — a follow-up when the backup-wiring WI lands: add a `contracts/vectors/` conformance vector + confirm iOS parity before shipping backup of the field.**
+424:2. **`Design needed: sentence-granularity bilingual interlinear — BOTH the setup-sheet Sentence control AND its render — for feature #131`** (round-4 H3 — broadened to cover both, filed together) — `vreader-bilingual.jsx` `BilingualPageContent` (lines ~195–277) depicts ONLY paragraph interlinear (one translation `<p>` per source paragraph), and a translation-after-each-sentence render (grouped when several sentences share a line-chunk) is depicted nowhere; the Sentence option appears only in the setup control (`vreader-bilingual.jsx:77`) with no matching renderer. v1 ships the depicted **paragraph** interlinear render + a **Paragraph-only** setup-sheet Granularity control; **Sentence is descoped from BOTH the control and the render in v1** (no undesigned surface, no paragraph-content-under-a-sentence-key). `TranslationGranularity.sentence` + `ChapterSegmenter.sentenceRanges` remain reserved-foundational code (WI-1). When the sentence-interlinear render (and its control option) is designed, it is a render-only follow-up (the one-lazy-item-per-chunk `Column` contract already accommodates several stacked sentence translation children per anchor chunk). The box-D Sentence gap is tracked by the WI-9 follow-up checklist amendment.
+426:*(REMOVED in v4: the v3 "#136 dependency" design-gate line — #136 is closed and the Variant A AI Providers sheet IS the committed design, reproduced by WI-AIP, not a gate.)*
+432:- v3 (2026-07-12): Gate-2 round-2 findings resolved — TXT/MD document-global segment model (H1); EPUB translatePreSegmented + count-keyed cache + direct-block prefetch (H2); #136 AI-provider-reachability spun out as a hard dependency (GH #1976) + Style descoped v1 (H3); WI-0 go/no-go + navigator-race contract (M1); EPUB DOM-injection adapter not Compose body (M2); DI/factory WI reordered (M3); Room 8→9 MIGRATION_8_9 (M4); deps/WI-count corrected (L1/L2). Gate-2 round-3 = block-recommended.
+433:- v4 (2026-07-12): Gate-2 round-3 (block-recommended) findings resolved AND the AI-config path folded in — AI-config FOLDED IN (#136 CLOSED); WI-AIP added; WI-4b provides `AiProviderStore` into `AppContainer`; H1 final-chunk math; H2 additive-item render contract; M1 EPUB single-owner; M2 dual-cancellation + single-flight; M3 blank-model fallback; M4 dependency honesty; WI count corrected to 13; chunk semantics corrected. Gate-2 round-4 = block-recommended.
+435:  - **H1 (round-4 High-1) — `Utf16Span` value type:** the final-chunk MATH stays (confirmed correct); the ONLY problem was the type contradiction — v4 declared `paragraphRanges`/`sentenceRanges` as `List<IntRange>` while treating them half-open, but Kotlin `IntRange` is inclusive-inclusive. Replaced `IntRange` EVERYWHERE with a dedicated `Utf16Span(start, endExclusive)` value type (NEW file `bilingual/Utf16Span.kt`, rides WI-1). `ChapterSegmenter.paragraphRanges`/`sentenceRanges` return `List<Utf16Span>`; `TxtChapterTextProvider` + the render path consume `Utf16Span`. Updated §2 H1, the segmenter/provider file entries, WI-1, and every test-catalogue "half-open UTF-16 (start,endExclusive)" mention.
+436:  - **H2 (round-4 High-2) — one-lazy-item-per-chunk `Column` (THE key fix):** the v4 "separate additive `LazyColumn` items after the anchor chunk" contract is NOT implementable — the live reader treats lazy-item indices AS `TxtDocument` chunk indices (position-save via `offsetForChunk(firstVisibleItemIndex)`, TxtReaderActivity.kt:220/473/623; every bookmark/annotation/search/scrubber/TTS jump via `scrollToItem(chunkForOffset(...))`, :411/:421/:454/:481/:257; TTS visibility via `visibleItemsInfo.index == spokenChunk`, :256), so inserting separate translation items shifts every following lazy index and corrupts all of these. New binding contract: keep EXACTLY ONE lazy item per chunk (the `items(count=chunkCount, key={it})` loop + keys UNCHANGED → lazy-index==chunk-index preserved); INSIDE each item wrap the content in a `Column` — the UNCHANGED source `Text` (one `TextLayoutResult`, one `registerChunk(i)`) then the muted non-registered translation child(ren) anchored to chunk `i`. ADDED explicit translation **gesture exclusion** (TxtSelectionController.hitAt falls back to the nearest source chunk when the pointer is past source bounds, :47–53, so omitting `registerChunk` is not enough). Updated §2 H2, the `BilingualInterlinearBody` file entry, the rejected-alternatives list (added the separate-lazy-items rejection), WI-7a, WI-8, and the enabled-mode tests (position-save round-trips to the same chunk; jumps/TTS land on the correct chunk; long-press on translation does NOT select).
+437:  - **H3 (round-4 High-3) — Paragraph-only v1 granularity:** v4's "Sentence selectable + sentence cache identity active + paragraph-render fallback" was underspecified (no sentence→paragraph aggregation) and would render undesigned sentence items or serve paragraph content under a sentence key. Resolution: v1 segments + caches + renders **Paragraph ONLY**. `TranslationGranularity` + `ChapterSegmenter.sentenceRanges` stay as reserved-foundational code (WI-1, unit-tested) but the v1 render/cache/VM/setup-sheet path is paragraph-exclusive (`promptVersion` `g=paragraph` always; no `sentenceRanges` in the v1 render path; the setup-sheet Granularity control is Paragraph-only). Broadened the sentence design gate to cover BOTH the control option AND its render (filed together). Updated §2 H2 granularity subsection, the cache-identity section, WI-5/WI-7a, and the tests.
+438:  - **H4 (round-4 High-4) — WI-AIP editor-verbatim + new scoped list + save-result seam:** `AiProviderListScreen` owns its own `NavScreen`/chrome + generic empty state + row-tap-as-EDIT (AiProviderListScreen.kt:45/59/84/101/105), so it CANNOT be reused verbatim to reproduce the designed `‹ Bilingual` nav + bilingual empty state + checked-active row + tap-to-SELECT; AND `AiSettingsViewModel.save()` returns no ID and upserts async (:85–97), so a verbatim reuse can't deterministically `setActive(savedId)` + pop-on-success without racing the upsert. Resolution: (a) reuse the EDITOR (`AiProviderEditSheet`) VERBATIM; (b) the scoped LIST is a NEW `ReaderAiProvidersList` over the SHARED `AiSettingsViewModel` state reproducing the designed nav/empty-state/checked-row/tap-to-select; (c) an additive **save-result seam** on `save()` returning the saved provider ID (which `AiProviderStore.upsert` already produces, AiProviderStore.kt:58/84 — the #118 VM is production-unwired, wired for the first time here, so the seam is safe). Removed every "reuse `AiProviderListScreen` VERBATIM" claim. Updated the `ReaderAiProvidersSheet` file entry, §AI-config reachability, the rejected-alternatives list, WI-AIP, and its tests.
+439:  - **Gap A (workflow completeness) — MIGRATION_8_9 exact DDL:** authored the exact `CREATE TABLE chapter_translations (...)` DDL (all `NOT NULL` columns + PK `lookupKey` + `index_chapter_translations_bookKey` + FK→`books(fingerprintKey)` ON DELETE CASCADE, modeled on the verified `MIGRATION_6_7` shape) in §2/WI-2 as a build-time contract, and required the migration test to validate it against Room's GENERATED `9.json` schema (not a hand-written approximation — cf. #135's stale-version finding).
+440:  - **Gap B (workflow completeness) — backup granularity parity flag:** flagged (§6 Risks + §7 Backward compat) that the backup-contract `bilingualGranularity` field's cross-platform conformance vector + iOS parity are UNCONFIRMED — safe for v1 (backup collect/restore descoped / device-local), but a follow-up: when the backup-wiring WI lands, add a `contracts/vectors/` conformance vector + confirm iOS parity before shipping backup of the field.
+441:  - WI count UNCHANGED at **13** (`Utf16Span` rides WI-1). Awaiting Gate-2 round-5 audit.
+
+exec
+/bin/zsh -lc "nl -ba dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md | sed -n '45,125p;130,215p;238,270p;350,390p;393,425p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+    45	- The old v3 claim "a chunk can hold multiple **paragraphs**" is **WRONG and removed.** (A single chunk cannot straddle a line terminator, and paragraph boundaries are blank lines, i.e. chunk boundaries — so a chunk holds *part of one* paragraph, never a whole extra paragraph.)
+    46	
+    47	**v5 model — document-global units with segment spans produced ONCE:**
+    48	
+    49	- The whole `.txt`/`.md` is treated as **one translation document**. The **segmenter runs once over `TxtDocument.text`** (the full raw backing string) and emits, per segment, its **UTF-16 span as a `Utf16Span(start, endExclusive)`** (half-open) against that same backing string (the segmenter's `paragraphRanges(text): List<Utf16Span>` / `sentenceRanges(text): List<Utf16Span>` — the span-returning peers of `paragraphs`/`sentences`; iOS precedent `ChapterSegmenter.sentenceRanges(in:)` at `ChapterSegmenter.swift:78`, returns `[Range<Int>]`). These spans are the SINGLE source of truth used by BOTH the translate side and the render side, so the two segment identically **by construction** (they read the same array). Spans are stored/compared as the explicit `Utf16Span` value type (see the H1 fix below), NOT re-derived on the render side.
+    50	- **Unit granularity for TXT/MD is the whole document, sub-batched for cache/prefetch by a deterministic "unit window."** To avoid translating a 14 MB book at once (and to keep cache rows bounded), segment spans are grouped into fixed **unit windows** of contiguous segments (window size a build-time constant; it does not change the 1:1 contract). Each window is a `TranslationUnitId(kind = txtDocSegmentWindow, value = windowIndex)` — a document-global index, NOT a chunk index. `unitContaining(charOffsetUTF16)` maps the reader's saved offset → the segment whose span contains it → its window index (via a precomputed segment-start binary search, the same shape as `TxtDocument.chunkForOffset`, TxtDocument.kt:23–33). `unitAfter(unit)` = next window index or null at document end.
+    51	
+    52	#### H1 fix (round-3 High-1 math + round-4 High-1 type) — final-chunk source span + the `Utf16Span` value type (BINDING)
+    53	
+    54	**The math (round-3 High-1 — CONFIRMED correct by round-4, UNCHANGED):** `offsetForChunk()` **CLAMPS** an out-of-range index to the last valid chunk (`starts[index.coerceIn(0, starts.size - 1)]`, TxtDocument.kt:17–20). So for the LAST chunk `i`, `offsetForChunk(i + 1) == offsetForChunk(i)` → an **empty span** → a one-chunk document drops EVERY translation and a paragraph ending in the final chunk drops its sole translation. `textForChunk()` avoids this by using `text.length` for the final end (TxtDocument.kt:39). The render side MUST do the same. **Binding rule:**
+    55	
+    56	```
+    57	val endExclusive = if (i + 1 < document.chunkCount) document.offsetForChunk(i + 1) else document.text.length
+    58	// chunk i source span is the HALF-OPEN Utf16Span(document.offsetForChunk(i), endExclusive)
+    59	```
+    60	
+    61	**The type (round-4 High-1 — THE fix this round):** v4 declared `paragraphRanges`/`sentenceRanges` as `List<IntRange>` while treating them as half-open `[start, endExclusive)`. That is a **type contradiction** — Kotlin `IntRange` is inclusive-inclusive (`range.last` is the last *included* index, and `range.last` for an empty/at-EOF span is a footgun). The half-open contract and the `IntRange` type are incompatible. **Resolution — a dedicated value type, replacing `IntRange` EVERYWHERE:**
+    62	
+    63	```
+    64	// bilingual/Utf16Span.kt  (NEW FILE — rides WI-1)
+    65	data class Utf16Span(val start: Int, val endExclusive: Int) {
+    66	    init { require(endExclusive >= start) }
+    67	    val isEmpty: Boolean get() = endExclusive == start
+    68	    val length: Int get() = endExclusive - start
+    69	}
+    70	```
+    71	
+    72	- `ChapterSegmenter.paragraphRanges(text): List<Utf16Span>` / `sentenceRanges(text): List<Utf16Span>` return `Utf16Span`s (half-open, against the input string). `TxtChapterTextProvider` and the TXT/MD render path consume `Utf16Span` — there is **no `IntRange`** anywhere in the segment/span contracts. (`TxtSelectionController`'s own `Utf16Range` type is a *separate*, unrelated selection type and is untouched — see H2's gesture-exclusion note.)
+    73	- A segment's "end offset" for anchoring (below) is its `endExclusive`; the chunk that "contains a segment's end" is `document.chunkForOffset(span.endExclusive - 1)` when `!span.isEmpty`, clamped to `[0, chunkCount-1]` (an empty segment is dropped by the segmenter and never anchored).
+    74	- **Tests (WI-1 / WI-4a / WI-8):** `paragraphRanges`/`sentenceRanges` return correct half-open `Utf16Span(start, endExclusive)` spans (unit — WI-1); one-chunk document (no trailing newline) → its single paragraph/sentence translation renders (not dropped); final-chunk anchor (a paragraph whose last line is the final chunk) → translation renders after the last chunk; exact-boundary (a segment ending exactly at a chunk `start`) → anchored to the correct chunk, not off-by-one; EOF anchor (`span.endExclusive == text.length`) → resolves to the last chunk, no clamp-collapse.
+    75	
+    76	#### H2 fix (round-3 High-2 layout/selection + round-4 High-2 lazy-index identity) — the enabled render contract (BINDING; preserves BOTH the per-chunk model AND lazy-index==chunk-index)
+    77	
+    78	**Live invariant #1 — per-chunk layout/selection (round-3 High-2, verified TxtReaderActivity.kt:1043–1085):** the TXT/MD body iterates `items(count = document.chunkCount, key = { it })` (TxtReaderActivity.kt:1043). For **each chunk `i`** it owns **exactly ONE `TextLayoutResult`** (`var layout by remember(i) { … }`, set in `onTextLayout`, TxtReaderActivity.kt:1059/1075) and **exactly ONE selection registration** (`selectionController.registerChunk(i, l, c)` / `unregisterChunk(i)`, TxtReaderActivity.kt:1062–1066). Highlights (`highlightSpan(i)`, :1047), annotation washes (`washesForChunk(i)`, :1058), the read-aloud span wash (`addStyle(SpanStyle(background = wash), …)`, :1050–1054), and selection accents (`selectionForChunk(i)` → `drawRangeFill`, :1069/1081) all key off that **per-chunk** layout and the chunk-local UTF-16 offsets. **Splitting a chunk's source `Text` into multiple `Text` nodes would break every one of these** (two `Text` nodes = two `TextLayoutResult`s = broken selection coordinates, misplaced highlight/wash/annotation ranges, a shifted read-aloud wash).
+    79	
+    80	**Live invariant #2 — lazy-index == chunk-index (round-4 High-2 — THE key fix this round; verified):** the live reader treats `LazyListState` item indices as `TxtDocument` chunk indices EVERYWHERE:
+    81	- **Position save** converts `firstVisibleItemIndex` → offset via `offsetForChunk` (`savePosition(...) { val offset = document.offsetForChunk(topIndex) }`, TxtReaderActivity.kt:623–624), and the steady-state/onStop save both pass `listState.firstVisibleItemIndex` directly (TxtReaderActivity.kt:220–223, :227–230). Resume converts back via `chunkForOffset` (`initialFirstVisibleItemIndex = s.initialIndex`, :220; `s.initialIndex` = `document.chunkForOffset(offset)`, :619). The bottom-chrome progress fraction reads `document.offsetForChunk(listState.firstVisibleItemIndex)` (:473).
+    82	- **Bookmark / annotation / search / scrubber / TTS jumps** all call `listState.scrollToItem(document.chunkForOffset(target))` (bookmark :411, annotation :421, search :454, scrubber :481; TTS auto-scroll `animateScrollToItem(spokenChunk)` where `spokenChunk = document.chunkForOffset(tts.charStart)` — :252/:257).
+    83	- **TTS visibility** compares lazy-item indices with the chunk directly: `listState.layoutInfo.visibleItemsInfo.none { it.index == spokenChunk }` (:256).
+    84	
+    85	**Therefore inserting SEPARATE translation `LazyColumn` items (the v4 "additive items after the anchor chunk" contract) is NOT implementable:** every separate translation item inserted before a given source chunk shifts that chunk's lazy index, so `offsetForChunk(firstVisibleItemIndex)` reads the wrong chunk's offset (corrupts position save + progress), `scrollToItem(chunkForOffset(target))` lands on the wrong item (corrupts every jump), and `visibleItemsInfo.index == spokenChunk` never matches (corrupts TTS auto-scroll). The v4 contract is **rejected**.
+    86	
+    87	**v5 binding render contract (one lazy item per chunk — a wrapping `Column`):**
+    88	
+    89	> **Keep EXACTLY ONE lazy item per chunk.** The existing `items(count = document.chunkCount, key = { it })` loop is **UNCHANGED** — so lazy-index == chunk-index is preserved and NO position/jump/TTS consumer breaks. INSIDE each item's lambda, wrap the content in a `Column`:
+    90	> 1. the **UNCHANGED source `Text`** — one `TextLayoutResult`, one `registerChunk(i, …)`/`unregisterChunk(i)`, byte-identical to today (the exact code at TxtReaderActivity.kt:1044–1084 is unchanged, now nested in a `Column`);
+    91	> 2. **below it, still inside the SAME lazy item**, the translation(s) **anchored** to chunk `i` (`chunkForOffset(span.endExclusive - 1) == i`) as **muted, non-registered** `Text`(s) (accent left-border, `fontSize*0.88`, CJK/RTL styling per `BilingualPageContent`).
+    92	
+    93	A paragraph spanning chunks `j..i` renders its ONE translation inside chunk `i`'s `Column` (after the paragraph's last source line). This preserves BOTH invariants: the per-chunk one-layout/one-registration model (the source `Text` is never split, the translation is a *sibling* `Text` in the `Column`, not a re-layout of the source) AND the lazy-index↔chunk-index identity (the translation lives inside the anchor's lazy item, adds no lazy item, shifts no index).
+    94	
+    95	Concretely the body becomes, per chunk `i` (in the same single `items(count = document.chunkCount, key = { it })` loop):
+    96	
+    97	1. Open a `Column` for item `i`.
+    98	2. Render the source chunk `i` **EXACTLY as today** (the unchanged `Text` + its `remember(i)` layout/coords + `registerChunk(i, …)`/`unregisterChunk(i)` + `highlightSpan(i)`/`washesForChunk(i)`/`selectionForChunk(i)` — TxtReaderActivity.kt:1044–1084, now the first child of the `Column`).
+    99	3. Look up the translations **anchored** to chunk `i` = every segment whose end resolves to `chunkForOffset(span.endExclusive - 1) == i`, in segment order, from the shared span array. For **paragraph** granularity (the only v1 granularity — see the granularity subsection) there is at most one such translation per anchor chunk in the common case (a paragraph's translation renders after the paragraph's last line-chunk).
+   100	4. Emit each anchored translation as a muted, non-registered `Text` sibling **inside the same `Column`**, keyed by the segment's `Utf16Span` so a language change re-keys cleanly.
+   101	
+   102	When bilingual is **OFF**, no translation children are emitted → each item's `Column` holds only the unchanged source `Text`, so the tree is **behaviorally identical to today** (translations are additive in-item children only; this is asserted by a source-selection-parity test, since a single-child `Column` does not perturb the source `Text`'s layout/registration/offsets).
+   103	
+   104	- **Explicit translation gesture exclusion (round-4 High-2 — BINDING):** `TxtSelectionController.hitAt` (`reader/TxtSelectionController.kt:47`) falls back to the **nearest registered source chunk** when the pointer is outside all source-chunk bounds (`chunks.entries.minByOrNull { verticalDistance(...) }` when no chunk's `boundsInWindow()` contains the point, :51–53). So merely omitting `registerChunk` for the translation does **NOT** make it non-selectable — a long-press *on the translation text* would fall through to the nearest source chunk and select source. **WI-8 must add an explicit hit-test / gesture exclusion for the translation composable's bounds** so a long-press whose pointer lands inside a translation `Text`'s bounds is consumed (no selection begun) rather than routed to `hitAt`'s nearest-chunk fallback. (Options: the translation `Text` consumes the long-press gesture in its own `pointerInput`; or the selection gesture root records the translation composables' window bounds and short-circuits `beginAt` when the point is inside one. WI-8 picks and tests one.)
+   105	
+   106	- **Enabled-mode tests (WI-8 connected + WI-7a Compose, BINDING):** with bilingual ON —
+   107	  - (a) each source chunk's **selection registration is UNCHANGED** (same `registerChunk(i, …)` count and coordinates as OFF; a translation child registers nothing);
+   108	  - (b) **highlights/annotation washes/read-aloud wash still key off the source chunks** at the correct offsets (a translation child in the anchor's `Column` does not shift them);
+   109	  - (c) **lazy-index == chunk-index preserved:** with bilingual ON — **position-save round-trips to the same chunk** (`offsetForChunk(firstVisibleItemIndex)` → save → reopen → `chunkForOffset(offset)` lands on the same chunk); **bookmark/annotation/search/scrubber jumps land on the correct chunk** (`scrollToItem(chunkForOffset(target))` scrolls to the right item); **TTS auto-scroll targets the correct chunk** (`visibleItemsInfo.index == spokenChunk` matches); (assert these are identical to the OFF baseline — no lazy index shift);
+   110	  - (d) a **long-press on translation text does NOT select** (gesture exclusion — the nearest-source-chunk fallback is not reached);
+   111	  - (e) a **translation child is non-selectable** and does not perturb source offsets (selecting across the source/translation boundary selects source only);
+   112	  - (f) **MD source mapping** — the markdown renderer (`mapper.renderedText(i)`, TxtReaderActivity.kt:1049) still owns the source chunk render; the translation child is plain muted text;
+   113	  - (g) **paragraph-spanning-many-chunks** renders exactly ONE translation (inside the paragraph's last chunk's `Column`), never per-line;
+   114	  - (h) final-chunk/one-chunk anchors render (H1).
+   115	
+   116	- **Granularity — Paragraph ONLY in v1 (round-4 High-3):** `vreader-bilingual.jsx` `BilingualPageContent` (lines ~195–277) is a **paragraph-interlinear** renderer: it maps `page.paragraphs.map(...)` and renders **one source `<p>` followed by ONE translation `<p>`** per paragraph. **Sentence-granularity interlinear is depicted NOWHERE** — Sentence appears ONLY as an option in the `BilingualSetupSheet` Granularity segmented control (`vreader-bilingual.jsx:77`), never in the renderer, AND v4's "Sentence selectable + sentence cache identity active + paragraph-render fallback" was underspecified (no defined sentence→paragraph aggregation, so it would either render undesigned sentence items or serve paragraph content under a sentence cache key). **Resolution — v1 segments + caches + renders Paragraph ONLY:**
+   117	  - The `TranslationGranularity` enum + `ChapterSegmenter.sentenceRanges` API **stay as reserved FOUNDATIONAL code** (WI-1, with unit tests) so the future sentence-render is a render-only follow-up.
+   118	  - The v1 **render/cache/VM/setup-sheet path uses paragraph exclusively:** `promptVersion`'s granularity component is **always `paragraph` in v1**; there is **no `sentenceRanges` in the v1 render path**; the setup sheet's Granularity control is **descoped to Paragraph-only in v1** (a documented divergence, tracked by the sentence design gate below — the same treatment as the Style descope).
+   119	  - This keeps rule 51 (implement only what is depicted — paragraph interlinear) while shipping the depicted paragraph parity. The one-lazy-item-per-chunk `Column` render contract already accommodates a future per-line sentence grouping (several translation children stacked in one chunk's `Column`), so the sentence gate, once designed, is render-only.
+   120	
+   121	- **MD source** = raw markdown segment text (translation renders as plain muted text, not re-markdown-rendered — matches the muted-secondary design line). Segmentation runs over the raw markdown string; MD markers are treated as ordinary characters by the paragraph splitter (blank-line delimited), consistent with `TxtMdTextExtractor` shipping raw markdown to search.
+   122	
+   123	This closes round-3 H1 (no dropped final-chunk translations), round-3 H2 (per-chunk layout/selection preserved; source `Text` never split), round-4 H1 (the `Utf16Span` type replaces the incompatible `IntRange`), round-4 H2 (one lazy item per chunk preserves lazy-index==chunk-index; translation gesture exclusion), round-4 H3 (Paragraph-only v1 granularity), and round-3 Low-2 (correct chunk semantics).
+   124	
+   125	### AI-config reachability — FOLDED IN (#136 CLOSED; Variant A owned by #131)
+   130	
+   131	**Navigation model (reproduced EXACTLY from `reader-ai-provider-entry.md`:110–134, invent nothing):**
+   132	
+   133	```
+   134	More ▸ Bilingual mode (first toggle on)
+   135	  └─ BilingualSetupSheet   [bottom sheet]
+   136	       engine strip: "No AI provider configured"  [ Set up ]
+   137	                             │  onOpenSettings
+   138	                             ▼  (push, slide-left, same sheet frame)
+   139	     ReaderAiProvidersSheet  [nav bar: ‹ Bilingual · "AI Providers"]
+   140	       ├─ empty  → [ Add provider ] ─┐
+   141	       └─ list   → tap a row SELECTS it (setActive) │  (present the canonical editor, full height)
+   142	                             ▼        ▼
+   143	                    AiProviderEditSheet   [reused VERBATIM from #118]
+   144	                             │  Save
+   145	                             ▼  (saved provider becomes the bilingual engine,
+   146	                                  pop the whole stack)
+   147	     BilingualSetupSheet  ← engine strip now "Claude · configured" / Change…
+   148	```
+   149	
+   150	- **`‹ Bilingual` without adding** returns to the bilingual sheet **still unconfigured — no state mutated.**
+   151	- **"Change…"** (already-configured strip) opens the **SAME** `ReaderAiProvidersSheet`, populated, **current provider checked**; tapping a row **selects** it (`setActive`).
+   152	- The AI Providers view is a **push within the bilingual sheet**, NOT a modal over the reader and NOT the full app Settings.
+   153	
+   154	**Android readiness gate (BINDING — round-3/round-2 H3 + the #136-audit High-3 lesson; round-4 CONFIRMED correct, UNCHANGED):** `aiConfigured` on the engine strip is derived by `BilingualAiReadiness.resolve(snapshot)` = **an ACTIVE profile exists AND its API key decrypts to non-empty.** Deriving from `profiles.isEmpty()` alone is **WRONG**: the store keeps a separate `activeId` that can be **null with profiles present** (`AiProviderSnapshot.active = profiles.firstOrNull { it.id == activeId }`, AiProviderStore.kt:34–36), and key usability depends on **decrypting the active profile's token** (`apiKey(profile) = cipher.decrypt(profile.encryptedApiKey)`, AiProviderStore.kt:108). A cipher/keystore failure maps to **not-ready, never a crash** (the resolve wraps the decrypt in `runCatching`). **Note:** the iOS Variant A design-note (`reader-ai-provider-entry.md:172–174`) derives `aiConfigured` from `providers.isEmpty == false`, and iOS #82 (`reader-ai-readiness.md`) adds a 4-gate readiness (flag + consent + provider + key). **Android has NO consent manager and NO feature flag** (#118 has neither — confirm during build); the Android gate is exactly what #118 enforces = **provider (active) + key (decrypts non-empty)**. We do NOT invent a consent/flag gate.
+   155	
+   156	### New files
+   157	
+   158	**Pipeline / domain (host-agnostic, pure or coroutine — JVM-testable):**
+   159	
+   160	- `bilingual/Utf16Span.kt` — **NEW (round-4 H1).** `data class Utf16Span(val start: Int, val endExclusive: Int)` (half-open UTF-16 span; `require(endExclusive >= start)`; `isEmpty`, `length`). The single span type shared by the segmenter and the TXT/MD render path, replacing the incompatible `IntRange`. Rides WI-1. (Distinct from `TxtSelectionController.Utf16Range`, the selection type, which is untouched.)
+   161	- `bilingual/TranslationUnitId.kt` — `data class TranslationUnitId(kind, value)` with `enum Kind { epubHref, foliateHref, txtDocSegmentWindow, mdDocSegmentWindow, pdfPageRange }`; `storageKey = "${kind.name}:$value"`. TXT/MD kinds are **document-global segment-window indices** (H1), NOT chunk indices. v5 uses `epubHref` + `txtDocSegmentWindow`/`mdDocSegmentWindow`; others reserved so the cache-key format never breaks. *(Assumption: iOS's exact Kind case names for the TXT/MD variants; only the `storageKey` string format is load-bearing for the cache contract, and that is preserved.)*
+   162	- `bilingual/TranslationGranularity.kt` — `enum { paragraph, sentence }`. **Reserved foundational code** (WI-1, unit-tested); the v1 render/cache/VM/setup-sheet path uses `paragraph` exclusively (round-4 H3). `sentence` is design-gated.
+   163	- `bilingual/BilingualLanguages.kt` — `BilingualLanguage(key, glyph, script)`; `BILINGUAL_LANGS` = the exact set from `vreader-bilingual.jsx:15–25` (Chinese/Japanese/Korean cjk, Spanish/French/German/Italian latin, Arabic rtl, Russian cyrillic) + `findOrDefault(key)`. Default `Chinese`.
+   164	- `bilingual/ChapterSegmenter.kt` — **NEW file (no existing Android segmenter — verified).** Port of iOS `ChapterSegmenter`: `paragraphs(text)` / `sentences(text)` **plus the span-returning peers `paragraphRanges(text): List<Utf16Span>` / `sentenceRanges(text): List<Utf16Span>`** (half-open UTF-16 spans against the input string, as `Utf16Span` — round-4 H1; iOS `sentenceRanges(in:)` precedent). CJK-aware sentence enumeration (`。！？` vs Latin). Pure. (`sentenceRanges` is reserved-foundational; the v1 render path calls only `paragraphRanges` — round-4 H3.)
+   165	- `bilingual/TranslationChunker.kt` — `chunk(segments, maxCharsPerChunk)` + `subSplit(text, maxChars)`. Port of iOS `ChapterTranslationChunker.chunk(...)` (`ChapterTranslationChunker.swift:85`) + `subSplit(...)` (returns index groups, oversize segment gets its own chunk; `subSplit` is the Bug #330 grapheme-safe over-budget splitter).
+   166	- `bilingual/TranslationChunkContract.kt` — `userPrompt(segments, targetLanguage)`; `decode(raw, expectedCount)` (strict JSON-array + code-fence strip); `sealed class DecodeError { NotAStringArray; CountMismatch(expected, actual) }`. Port of iOS `TranslationChunkContract` (`TranslationChunkContract.swift:24`). No `style` param — Style descoped v1 (§3).
+   167	- `bilingual/ChapterTextProvider.kt` — `interface { units(); sourceSegments(unit); sourceText(unit); unitContaining(charOffsetUTF16); unitAfter(unit) }`. `sourceSegments(unit)` returns the exact segment strings (from the shared span array). Resolution is host-specific: TXT/MD key on `charOffsetUTF16` → segment-window; EPUB keys on the current-resource `href`. Honest divergence from iOS's uniform Readium `Locator`, documented.
+   168	- `bilingual/TxtChapterTextProvider.kt` — provider over `TxtDocument` + the segmenter's `Utf16Span` array (H1). Builds the document-global segment `Utf16Span`s once (via `paragraphRanges` — paragraph only in v1), groups them into windows, resolves `unitContaining` via a segment-start binary search over `charOffsetUTF16`. MD source = raw markdown segment text.
+   169	- `bilingual/EpubChapterTextProvider.kt` (WI-0-gated shape) — provider over the Readium `Publication` reading order; `units()` = spine hrefs, `unitContaining` = the locator's href (from `EpubNavigatorFragment.getCurrentLocator()`), `sourceSegments(unit)` = the DOM-enumerated block texts (the render's OWN enumeration, for direct-block 1:1 — H2). Its render-side collaborator is `EpubBilingualJs`.
+   170	- `bilingual/ChapterTranslationError.kt` — `sealed { Offline; TimedOut; ProviderFailed(msg); Cancelled }`. Maps from `AiError` (verified cases `Auth401`, `RateLimited429`, `Offline`, `Timeout`, `Http(code)`, `Decode`, `Stream`, `InsecureUrl`, `Config`, AiTypes.kt).
+   171	- `bilingual/ChapterTranslationService.kt` — the iOS-parity service (full divergence-recovery surface, round-2 H2):
+   172	  - `cachedTranslation(bookKey, unit, sourceText, targetLanguage, granularity, acceptCountMismatch=false)` — cache-only; serves a row only when `sourceParagraphCount == segments.size` (or `acceptCountMismatch`). No provider (#306 parity).
+   173	  - `cachedTranslation(bookKey, unit, expectedSegmentCount, targetLanguage)` — the divergence-fallback cache-only restore (iOS Bug #343): serves the canonical row only when its STORED `sourceParagraphCount == expectedSegmentCount`. Needs no source text and no provider → a cache-hit toggle/reopen restores with **zero provider calls**.
+   174	  - `translate(bookKey, unit, sourceText, targetLanguage, providerProfile, granularity, bypassCacheRead=false)` — segment → chunk → per-chunk `AiClient.chat` one-shot → `decode` → per-segment fallback → per-chunk graceful degrade (Bug #330) → cache-write only on full success (`sourceParagraphCount = segments.size`). **Cancellation:** maps BOTH native `CancellationException` AND typed `ChapterTranslationError.Cancelled` to `Cancelled` (mirrors iOS `ChapterTranslationService.swift:359–364`); `ensureActive()` between chunks AND immediately before the Room write.
+   175	  - `translatePreSegmented(bookKey, unit, segments, targetLanguage, providerProfile)` — the count-divergence recovery (iOS Bugs #268/#330/#343). Takes the render's OWN enumerated block texts as `segments` (1:1), chunks them, translates with the same per-chunk graceful-degrade + dual-cancellation contract, and — on full success only — caches under the canonical key with the ENUMERATE's count as `sourceParagraphCount`. A partial degrade is NOT cached; a cache-write failure does not fail the translation (iOS `ChapterTranslationService.swift:374–384`).
+   176	  - Uses `AiClient.chat(AiRequest)` (one-shot, verified — NOT `streamChat`).
+   177	- `bilingual/ChapterTranslationPrefetcher.kt` — resolves the active profile from one `AiProviderStore.snapshot()` (`snapshot.active`), decrypts via `store.apiKey(profile)` (snapshot-consistent, AiProviderStore.kt:108), builds an `AiClient` via an **injected factory param** (below), cache-first then translate. Adds the direct-block peers (H2):
+   178	  - `prefetch(unit)` — the plain-text path.
+   179	  - `prefetchDirect(unit, sourceSegments, targetLanguage)` — the divergence path (iOS `translatedSegmentsDirect`, `ChapterTranslationPrefetcher.swift:197`).
+   180	  - `cachedDirect(unit, expectedCount, targetLanguage)` — the **zero-provider cache-only restore** (iOS `cachedSegmentsDirect` → `cachedTranslation(expectedSegmentCount:)`, `ChapterTranslationPrefetcher.swift:236`): returns a cached translation on a hit WITHOUT requiring an active provider (#306 pre-gate precedent). Backs the EPUB cache-restore path.
+   181	  - **`AiRequest` construction (round-3 M3 fix, BINDING; round-4 CONFIRMED correct):** `model = profile.model.ifBlank { profile.kind.defaultModel }` — matches `AiChatViewModel.kt:61`; both wire clients serialize `request.model` **directly** (`put("model", request.model)` in `OpenAiCompatibleProvider.kt:38` and `AnthropicProvider.kt:36`), so a blank `profile.model` would send an empty model. Full request: `AiRequest(model = profile.model.ifBlank { profile.kind.defaultModel }, messages = …, temperature = profile.temperature, maxTokens = profile.maxTokens, system = …)`. A **blank-model regression test** asserts the fallback is applied.
+   182	  - Throws `ChapterTranslationError`. Mirrors iOS `ChapterTranslationPrefetcher`.
+   183	- `bilingual/BilingualAiReadiness.kt` — `resolve(snapshot: AiProviderSnapshot): Boolean` — active profile exists (`snapshot.active != null`) AND `runCatching { store.apiKey(snapshot.active).isNotEmpty() }.getOrDefault(false)` (cipher/decryption failure → **not-ready**, never crashes). Drives the setup-sheet engine-strip configured/unconfigured state. Exactly the #118 gate (no consent manager / feature flag on Android — confirm during build).
+   184	
+   185	**State / persistence:**
+   186	
+   187	- `bilingual/PerBookBilingualStore.kt` — DataStore-Preferences, keyed by `bookFingerprintKey`, holding `{ enabled, targetLanguage, granularity }` (`granularity` is persisted but pinned to `paragraph` in v1 — round-4 H3). The Android `PerBookSettingsOverride` bilingual slice — the backup contract declares exactly `bilingualEnabled` / `bilingualTargetLanguage` / `bilingualGranularity` and **NO `bilingualStyle`** (verified). Wiring into backup collect/restore is scoped OUT (§7); until then bilingual config is device-local.
+   188	- `bilingual/BilingualViewModel.kt` — `StateFlow<BilingualUiState>` with `enabled`, `targetLanguage`, `granularity`, `needsSetupSheet`, `aiConfigured`, `translationsByUnit`, `inFlightUnits`, `unavailableUnits`, `errorUnit`. Setters + `dismissSetupSheet`, `onPositionChanged(charOffsetUTF16)`, `retryUnit(unit)`, and the EPUB direct-block entry `onEpubBlocksEnumerated(unit, blocks)` (M1, below). Generation/epoch-guarded prefetch (current + next unit); a **per-unit single-flight job registry** (M2); dual-cancellation handling (M2). Port of iOS `BilingualReadingViewModel` (`prefetchTasks: [TranslationUnitID: Task]`, `BilingualReadingViewModel.swift:141`) + `+Prefetch`. Split to `BilingualPrefetchController.kt` if it nears ~300 lines. No `style` field.
+   189	
+   190	**Room (translation cache):**
+   191	
+   192	- `data/ChapterTranslationEntity.kt` — `@Entity(tableName="chapter_translations", indices=[Index("bookKey")], foreignKeys=[FK→books.fingerprintKey ON DELETE CASCADE])`. **`@PrimaryKey val lookupKey: String`** (Room requires a PK; project pattern `@PrimaryKey` + `@Upsert`, verified `BookEntity` `@PrimaryKey val fingerprintKey`, Entities.kt:24). `lookupKey` = `bookKey|unitStorageKey|targetLanguage|promptVersion`. Columns: `lookupKey` (PK), `bookKey`, `unitStorageKey`, `targetLanguage`, `promptVersion`, `translatedJson`, `sourceParagraphCount`, `createdAt`. Mirrors iOS `ChapterTranslationRecord.lookupKey` (`book|unit|lang|prompt`, profile-agnostic — Bug #342). `sourceParagraphCount` is load-bearing for H2 (stores the enumerate's count on the `translatePreSegmented` path so `cachedTranslation(expectedSegmentCount:)` restores). **The exact `MIGRATION_8_9` DDL is authored in WI-2 — see below.**
+   193	- `data/ChapterTranslationDao.kt` — `getByLookupKey(key)`, `@Upsert suspend fun upsert(row)`, `deleteByLookupKey(key)`.
+   194	- `bilingual/ChapterTranslationStore.kt` — coroutine wrapper returning a `CachedTranslation` (segments decoded from JSON), keeping Room entities off the boundary (iOS `ChapterTranslationStore` precedent).
+   195	
+   196	**Cache-identity (reconciled with iOS parity):** the 4-part key `book|unit|lang|promptVersion` is profile-AGNOSTIC / style-agnostic (Bug #342). Style is descoped (§3) so no `s=` component. **Granularity is paragraph-only in v1** (round-4 H3): `promptVersion = "bilingual-v1|g=paragraph"` in v1 (the `g=` component is always `paragraph`). The composite `g=` slot is retained in the key format so a future granularity is a different cache row by construction (closes the iOS #344 "sentence silently ignored" class ahead of time), but v1 never emits `g=sentence`. A language change cancels in-flight jobs, bumps the VM generation, clears shaped `translationsByUnit`, and forces a correctly-keyed re-fetch (WI-6).
+   197	
+   198	**DI / factory (verified live):** `AiProviderFactory` is an `object` with `create(profile, apiKey, dispatcher = Dispatchers.IO): AiClient` (verified, `AiProviderFactory.kt:10`). `ChapterTranslationPrefetcher` takes its OWN injected `clientFactory: (AiProviderProfile, String) -> AiClient` param **defaulting to `AiProviderFactory::create`**, overridden with a fake in tests.
+   199	
+   200	**UI (Compose — every state depicted, reproducing `vreader-bilingual.jsx` + `vreader-ai-provider-entry.jsx`):**
+   201	
+   202	- `bilingual/BilingualSetupSheet.kt` — reproduces `vreader-bilingual.jsx`'s `BilingualSetupSheet` (lines 27–156) EXACTLY, with the granularity divergence: header; a preview strip (`BilingualPreview`); a language grid over `BILINGUAL_LANGS` (glyph tiles, selected accent); a **Granularity** segmented control **descoped to Paragraph-only in v1** ("Translate after each ¶"; the Sentence option is not rendered in v1 — round-4 H3, tracked by the sentence design gate); a **Translation engine** strip (configured: "Claude · with this book's context" + "Change…"; unconfigured: "No AI provider configured" + "Bilingual mode needs an AI provider to translate." + "Set up"); the "Turn on bilingual mode" CTA. **No Style control, no provider/model card, no term-overrides toggle, no cost footer** (those belong to the `vreader-ai-android.jsx` sheet, not reproduced — §3). The `aiConfigured` flag comes from `BilingualAiReadiness.resolve`. The "Set up"/"Change…" CTA routes to `ReaderAiProvidersSheet` (wired in WI-9).
+   203	- `bilingual/ReaderAiProvidersSheet.kt` — **NEW (folded in; the Android analog of iOS `ReaderAIProvidersView`; round-4 High-4 rewritten).** The Variant A scoped in-reader AI Providers sheet, reproducing `vreader-ai-provider-entry.jsx` `AIProvidersSheet` + `AIProvidersSheetBody` + `NavSheet` (nav bar `‹ Bilingual` leading + centered "AI Providers" title, `vreader-ai-provider-entry.jsx:247`). **Round-4 High-4: the fold-in CANNOT be "reuse `AiProviderListScreen` verbatim."** `AiProviderListScreen` owns its OWN full `NavScreen(title="AI Providers", onBack)` (`AiProviderListScreen.kt:59`), a generic `AiEmptyState` ("Connect an AI provider" / "One key unlocks…", :84/:87), and **row-tap-as-EDIT** (`ProviderRow` → `onEdit(p.id)`, :105) with **no checked-active-tap-to-select** — it cannot reproduce the designed reader-scoped `‹ Bilingual` nav, the bilingual-context empty state, the checked-active row, or tap-to-SELECT. So the fold-in splits into **(a)/(b)/(c)**:
+   204	  - **(a) EDITOR reused VERBATIM.** `AiProviderEditSheet` (the canonical add/edit modal, Kind / Name / Endpoint / Sampling / API Key / Test Connection) is presented UNCHANGED from the #118 Library path — that reuse is confirmed fine (`reader-ai-provider-entry.md:49–52`, :63–65).
+   205	  - **(b) The scoped LIST is a NEW reader-specific presentation** (`ReaderAiProvidersList`, in this file) built over the **SHARED `AiSettingsViewModel` state** (`listState`, verified `AiSettingsViewModel.kt:26`) + shared row/cell components, reproducing: the reader-scoped nav (`‹ Bilingual` back label, "AI Providers" title — `NavSheet` at jsx:247, NOT `AiProviderListScreen`'s own `NavScreen`); the **bilingual-context empty state** ("Choose the provider bilingual mode will use to translate this book." context strip + "No providers yet" + "Add provider" CTA — jsx:180–209); the **checked-active row** (`selected={p.id === selectedId}` — jsx:221; the live `AiProviderListState`/`AiProviderRow` already carries `active` per row, `AiSettingsViewModel.kt:30`); and **tap-to-SELECT** (`onSelect(p.id)` → `vm.setActive(id)` — jsx:221/237). It does **NOT** reuse `AiProviderListScreen`'s `NavScreen`/chrome/`AiEmptyState`/`ProviderRow`-tap-edit.
+   206	  - **(c) A save-result seam** (round-4 High-4): `AiSettingsViewModel.save()` today returns Unit and upserts async (generates `s.id ?: UUID.randomUUID().toString()` *inside* the launched coroutine, then `_edit.value = null`, no saved ID — `AiSettingsViewModel.kt:85–97`), so WI-AIP cannot deterministically `setActive(savedId)` + pop-on-success by reusing it verbatim (popping immediately races the async upsert; observing list state can't distinguish the new profile). **Note:** `AiProviderStore.upsert` ALREADY returns the saved profile (`suspend fun upsert(...): AiProviderProfile`, "Returns the saved profile", `AiProviderStore.kt:58/70/84`) — the ID is present at the store layer; only the VM discards it. So the seam is an **additive completion/result signal on `AiSettingsViewModel.save()`** (or a thin WI-AIP wrapper) returning the saved provider ID (from `store.upsert(...).id`), so WI-AIP can `setActive(savedId)` + pop-on-success **after** the upsert commits — no race. The #118 VM is currently production-UNWIRED (only test-referenced — verified), and this feature wires it to production for the FIRST time, so an additive save-result seam is safe and appropriate.
+   207	  - **Behavior per the nav model:** empty → "Add provider" → `AiProviderEditSheet` → Save → `save()` returns the saved ID → `store.setActive(savedId)` (first-provider-active is already the store's default `activeId = cur.activeId ?: id`, AiProviderStore.kt:81; the explicit `setActive(savedId)` guarantees the freshly-saved provider is the engine even if others existed) → **pop the whole stack** back to the bilingual sheet, engine strip now "Claude · configured / Change…". `‹ Bilingual` without adding → unconfigured, **no state mutated**. "Change…" → the SAME sheet, populated, current provider checked, tap a row → `setActive`. No consent card, no feature-flag toggle, no readiness tracker (iOS #82, deferred).
+   208	- `bilingual/BilingualInterlinearBody.kt` — the Compose render surface for the **TXT/MD host ONLY** (round-2 M2). Renders per the **one-lazy-item-per-chunk `Column`** H2 render contract (source chunk unchanged as the first `Column` child; translation(s) anchored to chunk `i` as muted non-registered `Text` siblings in the SAME `Column`): muted `Text`, accent left-border, `fontSize*0.88`, CJK font for cjk scripts, RTL handling for Arabic (per `BilingualPageContent`, `vreader-bilingual.jsx:200–277`). Consumes the host-neutral `BilingualRenderState` DTO. Loading state ("Translating chapter… N%" + per-segment dim), error state ("Couldn't translate" + Retry), partial/offline (`unavailableUnits`): source-only silent fallback (iOS Decision 2). Includes the **translation gesture-exclusion** (round-4 H2) so a long-press on a translation child does not route to `hitAt`'s nearest-source-chunk fallback. **NOT the EPUB render surface.**
+   209	- `bilingual/BilingualRenderState.kt` — the host-neutral state DTO shared by the Compose body and the EPUB adapter (round-2 M2): per-unit `{ segments: List<String>?, phase: Loaded|Loading(fraction)|Error|SourceOnly }`. Compose and EPUB share the state/value types, NOT the composable body.
+   210	- `bilingual/EpubBilingualJs.kt` (WI-0-gated) — the EPUB render surface (round-2 M2). Pure Kotlin builder producing JS strings for `navigator.evaluateJavascript(...)`: `enumScript` (enumerate current-resource leaf blocks → JSON `[{id,text}]`), `injectScript(blockId, translationText)` (translation DOM node after the block; CSP-safe: `textContent`/`createTextNode`, never `innerHTML` string-concat; RTL/CJK via class + injected `<style>`), `clearScript()` (idempotent removal). Escaping done in Kotlin (JSON-encode every interpolated string). No Compose. Consumes `BilingualRenderState`.
+   211	- `bilingual/EpubBilingualController.kt` (WI-0-gated) — **the single owner of EPUB units (M1, below).** The runtime actor that serializes enumerate→(cache-restore|translate)→inject/clear against the navigator using WI-0's chosen mechanism (a single mutex OR a monotonic navigator-session token); checks the session token after every suspended JS/AI call; clears BEFORE publication teardown; re-applies on the identified production re-apply signal.
+   212	- `bilingual/BilingualPill.kt` — the `EN ↔ 中` reader-top-chrome pill (per `vreader-reader.jsx` + `vreader-bilingual.jsx` `BilingualPill`:282–305). Rendered by #132's top chrome; #131 provides the composable, #132's surface hosts it (§4).
+   213	
+   214	### EPUB direct-block flow — one owner + concrete API (round-3 Medium-1, BINDING; round-4 CONFIRMED RESOLVED — UNCHANGED)
+   215	
+   238	
+   239	- **Dual-cancellation across the service/VM boundary:** both the service AND the VM handle **BOTH** native `CancellationException` **AND** the typed `ChapterTranslationError.Cancelled` **before** generic error mapping — matching iOS `ChapterTranslationService.swift:359–364` (which catches `is CancellationError` and `ChapterTranslationError.cancelled` separately, both re-throwing `cancelled`). A cancelled stale request MUST NOT surface as `errorUnit` (it is discarded).
+   240	- **Per-unit single-flight job registry (VM):** a `prefetchTasks: MutableMap<TranslationUnitId, Job>` (iOS `prefetchTasks: [TranslationUnitID: Task]`, `BilingualReadingViewModel.swift:141`, cancelled/removed on disable/unit-change at :165). A NEW request for a unit **cancels-or-joins** the prior job (a stale prior is cancelled and awaited so it cannot run overlapping translations or Room writes), keyed by unit. Rapid retry/navigation cannot run overlapping translations for the same unit. `retryUnit(unit)` goes through the same registry. Tests: a mid-flight cancel discards (no `errorUnit`, no partial cache row); a rapid re-trigger for the same unit does not double-write.
+   241	
+   242	### Modified files
+   243	
+   244	- `data/VReaderDatabase.kt` — add `ChapterTranslationEntity` to `@Database entities`, bump `version` **8 → 9** (the live DB is v8, migrations `MIGRATION_1_2`..`MIGRATION_7_8`, `ALL_MIGRATIONS` ends at `MIGRATION_7_8` — verified VReaderDatabase.kt:29,224–228), add **`MIGRATION_8_9`** (exact DDL below — gap A), **append `MIGRATION_8_9` to `ALL_MIGRATIONS` after `MIGRATION_7_8`**, add `abstract fun chapterTranslationDao()`. Purely additive.
+   245	
+   246	  **`MIGRATION_8_9` exact DDL (gap A — BINDING; modeled on the verified `MIGRATION_6_7` `search_index_state` shape at VReaderDatabase.kt:154–169, whose DDL Room's PRAGMA validation already accepts):**
+   247	
+   248	  ```
+   249	  val MIGRATION_8_9: Migration = object : Migration(8, 9) {
+   250	      override fun migrate(db: SupportSQLiteDatabase) {
+   251	          db.execSQL(
+   252	              "CREATE TABLE IF NOT EXISTS `chapter_translations` (" +
+   253	                  "`lookupKey` TEXT NOT NULL, " +
+   254	                  "`bookKey` TEXT NOT NULL, " +
+   255	                  "`unitStorageKey` TEXT NOT NULL, " +
+   256	                  "`targetLanguage` TEXT NOT NULL, " +
+   257	                  "`promptVersion` TEXT NOT NULL, " +
+   258	                  "`translatedJson` TEXT NOT NULL, " +
+   259	                  "`sourceParagraphCount` INTEGER NOT NULL, " +
+   260	                  "`createdAt` INTEGER NOT NULL, " +
+   261	                  "PRIMARY KEY(`lookupKey`), " +
+   262	                  "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+   263	                  "ON UPDATE NO ACTION ON DELETE CASCADE )"
+   264	          )
+   265	          db.execSQL(
+   266	              "CREATE INDEX IF NOT EXISTS `index_chapter_translations_bookKey` " +
+   267	                  "ON `chapter_translations` (`bookKey`)"
+   268	          )
+   269	      }
+   270	  }
+   350	
+   351	**WI-1 (foundational): value types + pure segmentation/chunk/contract.** **`Utf16Span` (round-4 H1 — the half-open span value type replacing `IntRange`)**, `TranslationUnitId`, `TranslationGranularity` (reserved; v1 uses `paragraph` only — round-4 H3), `BilingualLanguages`, **`ChapterSegmenter` (with `paragraphRanges`/`sentenceRanges` returning `List<Utf16Span>` — H1; `sentenceRanges` is reserved-foundational, not in the v1 render path — H3)**, `TranslationChunker`, `TranslationChunkContract` (no `style`), `ChapterTranslationError`. Pure; ported iOS vectors. Deps: none. Tests: `paragraphRanges`/`sentenceRanges` return correct half-open `Utf16Span(start, endExclusive)` spans (both APIs unit-tested even though only `paragraphRanges` ships in the v1 render path — `sentenceRanges` stays covered as reserved-foundational code); chunker packs-to-budget/oversize/empty; contract prompt/decode/fence/mismatch; error mapping.
+   352	
+   353	**WI-2 (foundational): Room translation cache.** `ChapterTranslationEntity` (PK = `lookupKey`, all-`NOT NULL` columns matching the DDL, `sourceParagraphCount` column) + `Dao` (`@Upsert`) + `ChapterTranslationStore`; `VReaderDatabase` **8→9 `MIGRATION_8_9`** with the **exact DDL authored in §2 (gap A)**, appended after `MIGRATION_7_8`. Robolectric migration round-trip from v8 + full-chain + upsert/get/delete-by-lookupKey + FK-CASCADE + **exact-DDL guard validated against Room's GENERATED `9.json` schema (not a hand-written approximation — gap A)**. Deps: none.
+   354	
+   355	**WI-3 (foundational): `ChapterTranslationService`** against a fake `AiClient`. Both `cachedTranslation` overloads (incl. the `expectedSegmentCount` divergence restore — H2) + `translate` + `translatePreSegmented`. **Dual-cancellation (native + typed `Cancelled`) BEFORE generic mapping (M2).** Deps: WI-1, WI-2. Tests: cache hit → zero client calls; miss → translate + write; decode fail → per-segment fallback; one-chunk fail → source-only that chunk (others translated, NOT cached); all-chunks fail → throw; native-cancel → `Cancelled` (no write); typed-`Cancelled`-from-chunk → `Cancelled` (no write); ensureActive-before-write; `AiError` mapping incl. `Config`/`InsecureUrl` → `ProviderFailed`; `translatePreSegmented` full-success caches under the enumerate count; partial degrade NOT cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` returns on stored-count match, null on mismatch, needs no provider.
+   356	
+   357	**WI-4a (foundational): `ChapterTextProvider` (TXT/MD) + `ChapterTranslationPrefetcher` + `BilingualAiReadiness`.** `TxtChapterTextProvider` builds the document-global segment `Utf16Span`s once (via `paragraphRanges` — paragraph only, H1/H3), groups into windows, resolves `unitContaining(charOffsetUTF16)` via segment-start binary search, `sourceSegments(unit)`. Prefetcher: `prefetch` + `prefetchDirect` + `cachedDirect`; resolves active profile from `snapshot()`, decrypts snapshot-consistent, builds client via the injected factory param (default `AiProviderFactory::create`), constructs `AiRequest` with **`model = profile.model.ifBlank { profile.kind.defaultModel }` (M3)**. Readiness = active profile with non-empty decrypted key; **cipher failure → not-ready, never a crash.** Fake store + fake factory. Deps: WI-1, WI-3. Tests (all `Utf16Span`-based): unit resolution + clamp + empty; **one-chunk document (no trailing newline) → its segment translation renders, not dropped (H1)**; **final-chunk anchor → renders (H1)**; **exact-boundary → correct anchor (H1)**; **EOF anchor (`span.endExclusive == text.length`) → last chunk, no clamp-collapse (H1)**; paragraph spanning MANY chunks → one segment/one unit, anchored to the last chunk (Low-2); a >4000-char paragraph hard-split across chunks → one segment; CR/LF/CRLF; MD markers; locator→unit mapping; `unitAfter` end→null; **source-byte parity while disabled**; cache-hit-no-profile still returns (#306); no-profile miss → `ProviderFailed`; `prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls; **blank `profile.model` → `AiRequest.model == kind.defaultModel` (M3 regression)**; readiness true/false; empty-key → false; no-active-with-profiles-present → false (H3); cipher-throw → readiness false (no crash). (Sentence-multi-in-one-chunk is NOT a v1 render test — the v1 provider uses `paragraphRanges` only; `sentenceRanges` behavior is covered in WI-1's reserved-foundational unit tests.)
+   358	
+   359	**WI-4b (foundational — shared DI/factory, incl. `AiProviderStore` in `AppContainer`): AppContainer bilingual + AI-config graph.** `AppContainer` **now constructs `AiProviderStore`** (DataStore + #116 `KeystoreSecretCipher`, following the `readerSettingsStore` convention — this is #131's change, not an external feature's) and provides `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, an `AiSettingsViewModel` factory (for WI-AIP), and the `BilingualViewModel` factory. Deps: **WI-4a** (no external dep — #136 closed). Tests: container resolves the bilingual + AI-config graph; `AiProviderStore` resolves and round-trips a profile; the prefetcher's injected factory defaults to `AiProviderFactory::create`.
+   360	
+   361	**WI-5 (behavioral): `PerBookBilingualStore` + `BilingualViewModel` state core.** Store per book (enabled/targetLanguage/granularity — granularity pinned `paragraph` in v1, no style); VM setters (persist + first-enable `needsSetupSheet`); `aiConfigured` from `BilingualAiReadiness.resolve` over an injected snapshot; language change clears cache-shaped state + bumps generation. Injected prefetcher/snapshot seams (Medium-4). Turbine tests: first-enable raises sheet; re-enable persisted does not; disable clears; language change resets; `aiConfigured` true/false from readiness; round-trip through store; no style field; granularity persists as `paragraph`. Deps: WI-1 (+ store).
+   362	
+   363	**WI-6 (behavioral): VM prefetch trigger + generation/cancellation + single-flight (M2).** `onPositionChanged(charOffsetUTF16)` derives current unit (TXT/MD only), dedupes, prefetches current+next; a monotonic position-request sequence checked after every suspension; **per-unit single-flight `prefetchTasks: Map<TranslationUnitId, Job>` (a new request cancels/joins the prior — M2)**; a captured language/provider snapshot per launch; generation bumps on disable/language/unit-change discard stale; **BOTH `CancellationException` AND typed `ChapterTranslationError.Cancelled` handled BEFORE generic error mapping (M2)**; a cancelled stale request does NOT surface as `errorUnit`; `Offline`→`unavailableUnits`; transient failure leaves unit unfetched + clears anchor to retry; `retryUnit` routes through the registry. The EPUB `onEpubBlocksEnumerated` entry is present but EPUB prefetch is owned by the controller (Medium-1); the VM's position-driven `prefetch` dispatches TXT/MD units only. Fake prefetcher (Medium-4 seam). Deps: WI-4a, WI-4b, WI-5. Tests: current+next on unit change; same-unit no-op; cancel-mid discards stale (no `errorUnit`); typed-`Cancelled` discards (not `errorUnit`); rapid re-trigger same unit → single-flight, no double-write; offline→unavailable; failure→retry-able; `retryUnit` re-fetches.
+   364	
+   365	**WI-7a (behavioral): Compose UI — setup sheet + interlinear body (TXT/MD) + pill.** Reproduce `vreader-bilingual.jsx` (setup sheet: language grid / **Paragraph-only Granularity control (round-4 H3)** / preview / engine strip configured+unconfigured; body: the translation rendered **inside the anchor chunk's `Column` as a muted non-registered `Text` child** per the round-4 H2 render contract — translated / loading N%+dimmed / error+Retry / offline source-only; pill). Consumes the host-neutral `BilingualRenderState` DTO. Light+dark. Compose UI tests each state, incl. **paragraph interlinear renders a translation child after a paragraph's last source chunk (depicted)**; **the setup-sheet Granularity control shows Paragraph only, no Sentence option (H3)**. Deps: WI-5 (state shape). NO Style control; the unconfigured "Set up" CTA renders and (in WI-9) routes to the Variant A sheet.
+   366	
+   367	**WI-7b (behavioral, CONDITIONAL — only if WI-0 = go): EPUB render adapter (DOM injection, NOT Compose — M2) + direct-block ownership (M1).** `EpubBilingualJs` (enum/inject/clear JS builders, CSP-safe escaping) + `EpubBilingualController` (the serialization actor / session token AND the **single-owner enumerate→cachedDirect/prefetchDirect→guarded-commit sequence — Medium-1**) + `EpubChapterTextProvider`, wired into `ReaderActivity`, driving DOM from the shared `BilingualRenderState` DTO. Uses `prefetchDirect`/`cachedDirect` for the count-divergence path (H2). Depends on WI-6 (VM state) and WI-4b (DI); the WI-7a UI dependency is only the shared `BilingualRenderState`/value types. Connected test on a real EPUB (seeded cache): enable → injects; disable → cleared; reflow/href-change/fragment-recreation/activity-recreation → re-applies from cache (zero provider calls) via `cachedDirect`; count-divergence handled (direct path); **the regular TXT/MD prefetch path is never invoked for an EPUB unit (Medium-1)**. Unit tests: JS escaping/CSP-safe insertion, RTL/CJK style, empty translations, loading cleanup, idempotent replacement, source-only fallback, stale-session-token commit discarded (no `errorUnit`). Deps: WI-0, WI-3, WI-4a, WI-4b, WI-6, (shared types from WI-7a). (If WI-0 = no-go, dropped; box D ships TXT/MD-only, tracked.)
+   368	
+   369	**WI-AIP (behavioral — the folded-in Variant A AI Providers sheet; round-4 H4 rewritten): `ReaderAiProvidersSheet`.** The scoped in-reader "AI Providers" push sheet (nav bar `‹ Bilingual` + "AI Providers" title) reproducing `vreader-ai-provider-entry.jsx` `AIProvidersSheet`/`AIProvidersSheetBody`/`NavSheet`. Per round-4 H4:
+   370	  - **(a)** present `AiProviderEditSheet` VERBATIM from #118 (Kind/Name/Endpoint/Sampling/API Key/Test Connection unchanged).
+   371	  - **(b)** a NEW `ReaderAiProvidersList` presentation over the SHARED `AiSettingsViewModel.listState` (verified `AiSettingsViewModel.kt:26`; each `AiProviderRow` already carries `active`, :30) + shared row/cell components — reproducing the reader-scoped `‹ Bilingual` nav (`NavSheet`, jsx:247, NOT `AiProviderListScreen`'s `NavScreen`), the bilingual-context empty state ("Choose the provider bilingual mode will use to translate this book." + "No providers yet" + "Add provider" — jsx:180–209), the **checked-active row** (`selected = row.active` — jsx:221), and **tap-to-SELECT** (`onSelect(id) → vm.setActive(id)` — jsx:221/237). It does NOT reuse `AiProviderListScreen`'s NavScreen/chrome/`AiEmptyState`/`ProviderRow`-tap-edit.
+   372	  - **(c)** the **save-result seam**: `AiSettingsViewModel.save()` (or a thin WI-AIP wrapper) is extended to return the saved provider ID (from `store.upsert(...).id`, which the store already returns — `AiProviderStore.kt:58/84`), so on first Save → `store.setActive(savedId)` → pop the whole stack back to the bilingual sheet (engine strip now "configured / Change…"), **deterministically, after the upsert commits (no race)**.
+   373	  `‹ Bilingual` without adding → unconfigured, no state mutated. "Change…" → populated list, current provider checked, tap row → `setActive`. No consent/flag surface (Android has none). Deps: WI-4b (for `AiProviderStore` + `AiSettingsViewModel` in `AppContainer`), WI-7a (bilingual sheet host). Tests (Compose + connected): the scoped list renders **`‹ Bilingual` back label** + **bilingual-context empty copy** + **checked active row** + **tap-selects (`setActive`)**; empty → Add → Save → **save→result-id→`setActive`→pop deterministic (no race)** → bilingual strip configured; `‹ Bilingual` without adding → strip unconfigured, snapshot unchanged; "Change…" → populated, current checked; editor reused verbatim (no divergent form).
+   374	
+   375	**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into the `items(count = document.chunkCount, key = { it })` loop as **muted non-registered translation `Text` children inside each anchor chunk's wrapping `Column`, source chunk byte-unchanged, the loop + keys UNCHANGED so lazy-index==chunk-index is preserved (round-4 H2)** + the translation **gesture-exclusion** (round-4 H2) + position-change (`charOffsetUTF16`) + setup-sheet. `originalFormat`-gated (TXT/MD). Uses WI-4b's DI. **#129 VERIFIED — straight edit.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2)**; **highlights/annotation-washes/read-aloud-wash still key off source chunks (H2)**; **with bilingual ON — position-save round-trips to the same chunk; bookmark/search/scrubber/TTS jumps land on the correct chunk (lazy-index==chunk-index preserved — round-4 H2)**; **a long-press on translation text does NOT select (gesture exclusion — round-4 H2)**; a translation child is non-selectable, does not perturb source offsets (H2); disable → source-selection byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders exactly one translation inside its last chunk's `Column` (H1/Low-2)**; **one-chunk/final-chunk anchors render (H1)**; MD source mapping. Deps: WI-6, WI-7a, WI-4b.
+   376	
+   377	**WI-9 (behavioral): entry wiring + acceptance.** Mount `BilingualPill` in #132's VERIFIED top chrome; extend `readerMoreRows(...)` to supply the #134 VERIFIED More-menu `MoreActionId.BILINGUAL` toggle (`MoreRow.Toggle` `on`/`onToggle`, or `MoreRow.Disabled` "Configure AI provider first" when not configured) wired to the VM; **wire the setup sheet's "Set up"/"Change…" affordance → the #131-owned `ReaderAiProvidersSheet` (Variant A)**. Full acceptance across EPUB (if WI-7b landed) + TXT/MD, including the fresh-user path `unconfigured → Set up (→ Variant A AI Providers sheet) → add provider → Save → return → enable → translate` (now #131-owned end-to-end). **Flip box D to done ONLY for provider/model/granularity(paragraph) + the Style-descope AND Sentence-descope notes; file the follow-up checklist amendment; do NOT claim full box-D parity.** The DONE flip **no longer waits on #136** (closed). Update `docs/architecture.md` (bilingual pipeline + the new `chapter_translations` schema + `AiProviderStore` + bilingual services in `AppContainer` + the Variant A AI Providers sheet). → DONE. Deps: WI-8, WI-AIP, WI-7b (if go), feat:#132, feat:#134.
+   378	
+   379	## 5. Test catalogue
+   380	
+   381	JVM/Robolectric (`android/app/src/test/...bilingual/`): `Utf16SpanTest` (**half-open invariants: `endExclusive >= start`, `isEmpty`, `length`; round-4 H1**); `ChapterSegmenterTest` (paragraph blank-line; sentence CJK `。！？` vs Latin; empty→[]; single; **`paragraphRanges`/`sentenceRanges` return correct half-open `Utf16Span(start, endExclusive)` spans — both APIs covered even though only `paragraphRanges` ships in the v1 render path**); `TranslationChunkerTest` (packs to budget; oversize→own chunk+subSplit; empty→[]); `TranslationChunkContractTest` (prompt shape; strict JSON decode; code-fence strip; count mismatch→`CountMismatch`; non-array→`NotAStringArray`); `ChapterTranslationServiceTest` (cache hit 0 calls; miss→translate→write; decode-fail per-segment fallback; one-chunk-fail partial-not-cached; all-fail→throw; **native-cancel→Cancelled no write; typed-`Cancelled`→Cancelled no write (M2)**; ensureActive-before-write; offline/timeout/429/http/config/insecure→error mapping; very long chapter N-of-M; stale-cache count-mismatch re-translates; `translatePreSegmented` caches under enumerate count on full success; partial degrade not cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` hit/miss with no provider); `ChapterTranslationErrorMappingTest`; `TxtChapterTextProviderTest` (**one-chunk document → renders (H1); final-chunk anchor → renders (H1); exact-boundary → correct anchor (H1); EOF anchor → last chunk, no clamp-collapse (H1)**; paragraph spanning MANY chunks → one segment/unit anchored to last chunk (Low-2); >4000-char paragraph → one segment across hard-split chunks; CR/LF/CRLF; MD markers; locator→unit mapping; `unitAfter` end→null; source-byte parity while disabled; **provider uses `paragraphRanges` only — H3**); `ChapterTranslationPrefetcherTest` (snapshot-consistent profile+key; injected-factory used; `AiRequest` built from profile; **blank `profile.model` → `kind.defaultModel` (M3 regression)**; cache-hit-no-profile #306; no-profile miss→ProviderFailed; `prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls; CJK↔English + Latin round-trip via fake; cipher-throw→ProviderFailed not crash); `BilingualAiReadinessTest` (active+key→true; **no-active-with-profiles-present→false (H3); activeId-null→false (H3)**; empty key→false; cipher-throw→false, no crash); `PerBookBilingualStoreTest` (enabled/lang/granularity round-trip; granularity pinned paragraph; no style field); `BilingualViewModelTest` (Turbine: first-enable sheet; re-enable no-sheet; disable clears; language reset; `aiConfigured` from readiness; prefetch current+next; same-unit no-op; **cancel-mid discards (no errorUnit); typed-Cancelled discards (M2); rapid re-trigger same unit single-flight, no double-write (M2)**; offline→unavailable; error→errorUnit+retry; `retryUnit`); `AiSettingsViewModelSaveResultTest` (**`save()` returns the saved provider ID after the upsert commits — round-4 H4c seam; the returned ID matches `store.upsert(...).id`**); `EpubBilingualJsTest` (JS escaping / CSP-safe insertion; RTL/CJK style; empty translations; clear idempotent; inject idempotent replacement; source-only fallback — WI-7b if go); `EpubBilingualControllerTest` (**enumerate→cachedDirect/prefetchDirect→guarded commit; stale-session-token commit discarded, no errorUnit; single-owner (regular TXT/MD prefetch never runs for EPUB unit) — Medium-1** — WI-7b if go).
+   382	
+   383	Room migration: `VReaderDatabaseMigrationTest` (extend) **v8→v9 + full-chain from v8** + FK-CASCADE + `lookupKey`-as-PK + **exact-DDL validated against Room's generated `9.json` schema, not a hand-written approximation (gap A)**; `ChapterTranslationDaoTest` (upsert-by-PK replaces; get/delete-by-lookupKey).
+   384	
+   385	Compose UI (`androidTest/...bilingual/`): `BilingualSetupSheetUiTest` (language grid, **Granularity control shows Paragraph only — no Sentence option (H3)**, preview, engine configured vs unconfigured driven by `aiConfigured`; no Style control present; light+dark); `BilingualInterlinearBodyUiTest` (**translation rendered as a muted `Text` child inside the anchor chunk's `Column` (round-4 H2 render contract); paragraph interlinear translated incl. CJK font + RTL Arabic**; loading N%+dimmed; error+Retry; offline source-only; empty translation→source-only no crash); `ReaderAiProvidersSheetUiTest` (**the scoped list renders `‹ Bilingual` back label + bilingual-context empty copy + checked active row + tap-selects (`setActive`) — round-4 H4b; editor (`AiProviderEditSheet`) reused verbatim (H4a)**); `BilingualPillUiTest`.
+   386	
+   387	Connected (`androidTest/...reader/`): `TxtReaderBilingualConnectedTest` (API 35, fake `AiClient` via injected factory): enable→setup→confirm→interlinear from seeded Room cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2); highlights/annotation-washes/read-aloud-wash still key off source chunks (H2)**; **with bilingual ON — position-save round-trips to the same chunk; bookmark/search/scrubber/TTS jumps land on the correct chunk (lazy-index==chunk-index preserved — round-4 H2)**; **long-press on translation text does NOT select (gesture exclusion — round-4 H2)**; translation child non-selectable + no source-offset perturbation (H2); disable→source-selection byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders one translation (H1/Low-2); one-chunk/final-chunk anchors render (H1)**; TXT/MD gated (PDF inert); very long chapter scroll responsive; cancellation leaves no partial cache row. `ReaderAiProvidersConnectedTest` (WI-AIP + WI-9): `unconfigured → Set up → Variant A sheet → add provider → Save → save-result-id → setActive → pop-to-bilingual configured (deterministic, no race — round-4 H4c) → enable → translate`; `‹ Bilingual` without adding → unconfigured, snapshot unchanged; "Change…" → populated, current checked, tap → setActive. `EpubReaderBilingualConnectedTest` (only if WI-0=go): enable→inject on a real EPUB; disable→clear; href-change/fragment-recreation/activity-recreation→re-apply from cache (zero provider calls); count-divergence handled via `prefetchDirect`/`cachedDirect`; regular prefetch never runs for EPUB unit (Medium-1).
+   388	
+   389	Edge cases: empty translation, failed, partial per-chunk, CJK↔English + Latin + RTL, provider error/timeout/429/config/insecure, native + typed cancellation mid-translation + before-write, single-flight overlap, very long chapters, offline (cache-first + silent source-only), cipher-decrypt failure → not-ready (no crash), enumerate↔segment count divergence (direct path), one-chunk/final-chunk/EOF anchors (H1), blank model (M3), lazy-index==chunk-index parity with bilingual on (round-4 H2), translation-text long-press excluded (round-4 H2), save-result-id determinism (round-4 H4).
+   390	
+   393	- **Live-translation verification is AI-credential-gated (the box-D caveat).** The whole pipeline is verified without live creds via a deterministic **fake `AiClient`** injected through the prefetcher's `clientFactory` param (default `AiProviderFactory::create`; tests override). WI-3/4a/8 prove segment→chunk→decode→cache→interleave end-to-end incl. every error/edge path. Connected tests seed the Room cache and assert render-from-cache with zero client calls. An optional live smoke confirms wire format but is NOT a gate. The fresh-user `unconfigured → Set up → add provider` reachability leg is now #131-owned (WI-AIP + WI-9) and verified by `ReaderAiProvidersConnectedTest`.
+   394	- **Final-chunk translation drop + span type (round-3 H1 + round-4 H1).** Fixed by `endExclusive = if (i+1<chunkCount) offsetForChunk(i+1) else text.length` + the dedicated **`Utf16Span(start, endExclusive)`** half-open value type replacing the incompatible `IntRange` everywhere in the segment/render contracts; one-chunk/final-chunk/exact-boundary/EOF tests. `offsetForChunk`'s clamp (TxtDocument.kt:17) is never relied on for the final end.
+   395	- **Enabled render breaking the per-chunk layout/selection model AND the lazy-index↔chunk-index identity (round-3 H2 + round-4 H2).** Fixed by the **one-lazy-item-per-chunk `Column`** render contract: the `items(count = chunkCount, key = { it })` loop + keys are UNCHANGED (lazy-index==chunk-index preserved, so position-save/progress/every jump/TTS visibility — TxtReaderActivity.kt:220/252/256/411/421/454/481/623 — stay correct); inside each item a `Column` holds the UNCHANGED source `Text` (one `TextLayoutResult`, one `registerChunk(i)`) then the muted non-registered translation child(ren); an explicit **gesture-exclusion** stops a long-press on translation text from routing to `hitAt`'s nearest-source-chunk fallback (TxtSelectionController.kt:47–53). Enabled-mode tests assert selection/highlight/wash/annotation parity AND lazy-index==chunk-index parity with disabled, plus translation-not-selectable.
+   396	- **TXT/MD segment↔render pairing (round-2 H1).** Both sides read the SAME segment `Utf16Span` array over `TxtDocument.text`, so 1:1 holds by construction — no chapter model invented; a paragraph split across many chunks is translated + rendered once (inside its last chunk's `Column`). Granularity is paragraph-only in v1; the `g=` cache slot is retained for a future granularity.
+   397	- **Undesigned sentence render (round-4 H3).** v1 segments + caches + renders + offers **paragraph only** — the only depicted interlinear pattern. `TranslationGranularity.sentence` + `ChapterSegmenter.sentenceRanges` stay as reserved-foundational code (WI-1, unit-tested) but never appear in the v1 render/cache/VM/setup-sheet path. The Sentence control AND its render are design-gated together (§Design gates).
+   398	- **Variant A fold-in not wireable verbatim (round-4 H4).** The EDITOR (`AiProviderEditSheet`) is reused verbatim (a); the scoped LIST is a NEW `ReaderAiProvidersList` over the shared `AiSettingsViewModel` state reproducing the designed `‹ Bilingual` nav + bilingual empty state + checked-active row + tap-to-select (b); a save-result seam returns the saved ID (which `AiProviderStore.upsert` already produces, AiProviderStore.kt:58/84) so `setActive(savedId)` + pop-on-success is deterministic and race-free (c). No "reuse `AiProviderListScreen` verbatim" claim remains anywhere.
+   399	- **EPUB direct-block flow (round-3 Medium-1 — CONFIRMED RESOLVED).** The `EpubBilingualController` is the single owner: `enumeratedBlocks → cachedDirect (zero-provider restore) else prefetchDirect → session-token-guarded commit into BilingualRenderState/translationsByUnit`. The VM's position-driven regular prefetch is TXT/MD-only, so the two paths never write the same canonical cache row. Every suspended step is token-guarded; a stale token discards silently.
+   400	- **EPUB count divergence (round-2 H2).** The direct-block path (`prefetchDirect` → `translatePreSegmented`, cached by enumerate count, restored by `cachedDirect(expectedCount)` with zero provider calls) — iOS Bugs #268/#330/#343 parity.
+   401	- **EPUB JS-injection race (round-2 M1).** WI-0's contract (single actor/mutex OR monotonic navigator-session token; token check after every suspended call; clear before publication teardown; identified production re-apply signal per recreation case). No deterministic re-apply signal = explicit NO-GO → TXT/MD-only ship.
+   402	- **Cancellation + single-flight (round-3 Medium-2 — CONFIRMED RESOLVED).** Both service and VM handle native `CancellationException` AND typed `ChapterTranslationError.Cancelled` before generic mapping (iOS `ChapterTranslationService.swift:359–364`); a per-unit `prefetchTasks: Map<TranslationUnitId, Job>` cancels/joins a prior request so rapid retry/navigation can't run overlapping translations or Room writes; a cancelled stale request never surfaces as `errorUnit`. `ensureActive()` before the Room write.
+   403	- **Blank model (round-3 Medium-3 — CONFIRMED RESOLVED).** The prefetcher builds `model = profile.model.ifBlank { profile.kind.defaultModel }` (matches `AiChatViewModel.kt:61`; both wire clients serialize `request.model` directly, `OpenAiCompatibleProvider.kt:38`/`AnthropicProvider.kt:36`). Blank-model regression test.
+   404	- **AI-config readiness (H3 — CONFIRMED correct).** `BilingualAiReadiness.resolve` = active profile + decrypts-non-empty; `activeId` can be null with profiles present; cipher failure → not-ready (no crash). No consent/flag gate (Android has none).
+   405	- **Migration schema drift (gap A).** `MIGRATION_8_9`'s exact DDL is authored in §2 and validated against Room's GENERATED `9.json` schema (not a hand-written approximation) by the extended `VReaderDatabaseMigrationTest` opening the real Room DB — the recurring Android migration failure mode (cf. #135's stale-version finding).
+   406	- **Backup `bilingualGranularity` cross-platform parity UNCONFIRMED (gap B).** The backup-contract `bilingualGranularity` field's cross-platform conformance vector + iOS parity are UNCONFIRMED. Safe for v1 (backup collect/restore is descoped / device-local — §7), but flagged as a follow-up: **when the backup-wiring WI lands, add a conformance vector under `contracts/vectors/` and confirm iOS parity before shipping backup of the field.**
+   407	- **Cost/latency of translating on scroll.** Lazy current+next prefetch + disk cache; N-of-M progress; cancellation on navigate-away/generation-bump/single-flight supersede.
+   408	- **Provider JSON non-compliance.** `TranslationChunkContract.decode` + per-segment fallback — never drops a paragraph.
+   409	- **DataStore per-book key growth.** One Preferences entry per book keyed by fingerprint; scales like `ReaderSettingsStore`/`AiProviderStore`.
+   410	- **Dependency honesty (round-3 Medium-4 — CONFIRMED RESOLVED).** WI-4b (DI, incl. `AiProviderStore` in `AppContainer`) is foundational and gates the production run-through of WI-6/WI-7b/WI-AIP/WI-8; those WIs' unit/Compose gates proceed against injected fakes, and WI-4b is sequenced before them. No external feature gates the chain (#136 closed).
+   411	
+   412	## 7. Backward compat
+   413	
+   414	- **Room migration additive.** New `chapter_translations` (FK CASCADE, `lookupKey` PK, `sourceParagraphCount`, all columns `NOT NULL`). Existing rows untouched. Against this checkout **8→9, `MIGRATION_8_9`** with the **exact DDL in §2** appended after `MIGRATION_7_8` (VReaderDatabase.kt:224–228); the migration test extended from v8 validates it against Room's generated `9.json` schema (gap A).
+   415	- **Reader unchanged when bilingual off** — the TXT/MD `items(count = document.chunkCount, key = { it })` source loop + keys are **unchanged** (lazy-index==chunk-index preserved); each item's `Column` holds only the unchanged source `Text` unless `enabled && format∈{txt,md} && translation present` (translations are additive in-item children, non-registered, non-selectable — round-4 H2). `ReaderBottomChrome` is not modified. EPUB render adapter inert unless bilingual is on.
+   416	- **`AppContainer` gains `AiProviderStore`** (previously not provided — VReaderApp.kt:64/66 comment only) plus the bilingual services + `AiSettingsViewModel` factory; all additive lazy singletons following the `readerSettingsStore` pattern. #118 AI files are consumed unchanged **except** the additive save-result seam on `AiSettingsViewModel.save()` (returns the saved ID — round-4 H4c; the underlying `AiProviderStore.upsert` already returns the saved profile, so this exposes existing information without changing persistence behavior).
+   417	- **#118 AI provider files otherwise unchanged** — the prefetcher/readiness/Variant A sheet are new consumers; the scoped list is a new presentation over the shared VM state (round-4 H4b), not an edit to `AiProviderListScreen`.
+   418	- **Backup contract already compatible** — `PerBookSettingsOverride.bilingualEnabled/TargetLanguage/Granularity` exist (no `bilingualStyle`), no translation-cache backup section (device-local, re-derivable). #131 writes the three fields locally; backup collect/restore is a small additive follow-up (no contract change), out of v1; config device-local until then. **`bilingualGranularity` cross-platform conformance vector + iOS parity are UNCONFIRMED (gap B) — a follow-up when the backup-wiring WI lands: add a `contracts/vectors/` conformance vector + confirm iOS parity before shipping backup of the field.**
+   419	- **#132/#134/#129 landed** — the top-chrome pill mount + More-menu toggle (`readerMoreRows` extension) + `TxtReaderActivity` edit land on VERIFIED surfaces (rule 48 one-writer-per-file satisfied).
+   420	
+   421	## Design gates (rule 51 — for `needs-design` filing)
+   422	
+   423	1. **"Bilingual mode" setup sheet with BOTH Style AND Granularity in one Android sheet** (unchanged — Style stays descoped v1) — `vreader-bilingual.jsx` depicts Granularity (no Style); `vreader-ai-android.jsx` depicts Style (no Granularity); no committed bundle shows both together. v1 reproduces the granularity-only `vreader-bilingual.jsx` sheet and DROPS Style (user descope, §3). If Style is wanted as an Android user control, file `Design needed: bilingual setup sheet (Style + Granularity) for feature #131`. The box-D Style parity gap is tracked by the WI-9 follow-up checklist amendment.
+   424	2. **`Design needed: sentence-granularity bilingual interlinear — BOTH the setup-sheet Sentence control AND its render — for feature #131`** (round-4 H3 — broadened to cover both, filed together) — `vreader-bilingual.jsx` `BilingualPageContent` (lines ~195–277) depicts ONLY paragraph interlinear (one translation `<p>` per source paragraph), and a translation-after-each-sentence render (grouped when several sentences share a line-chunk) is depicted nowhere; the Sentence option appears only in the setup control (`vreader-bilingual.jsx:77`) with no matching renderer. v1 ships the depicted **paragraph** interlinear render + a **Paragraph-only** setup-sheet Granularity control; **Sentence is descoped from BOTH the control and the render in v1** (no undesigned surface, no paragraph-content-under-a-sentence-key). `TranslationGranularity.sentence` + `ChapterSegmenter.sentenceRanges` remain reserved-foundational code (WI-1). When the sentence-interlinear render (and its control option) is designed, it is a render-only follow-up (the one-lazy-item-per-chunk `Column` contract already accommodates several stacked sentence translation children per anchor chunk). The box-D Sentence gap is tracked by the WI-9 follow-up checklist amendment.
+   425	
+
+codex
+The v5 patch is internally consistent on the span and one-item render contracts so far. I’m now checking the contracts against the live chunking, selection geometry, AI-store/VM behavior, Room conventions, and the committed JSX designs—especially for subtle new regressions caused by nesting the source `Text` in a `Column`.
+exec
+/bin/zsh -lc "nl -ba android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt | sed -n '1,115p'; nl -ba android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt | sed -n '1,125p'; nl -ba android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt | sed -n '200,270p;395,490p;605,635p;1010,1100p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+     1	// Purpose: Addressable, range-based model of a decoded .txt — feature #111 WI-1.
+     2	// Holds ONE backing decoded String and an array of chunk START offsets (UTF-16 code
+     3	// units against the RAW text — NO line-ending normalization, so charOffsetUTF16 stays
+     4	// exact for resume). Splits at line boundaries (CRLF/CR/LF kept inside the chunk);
+     5	// hard-splits a runaway line at maxChunkChars (never mid-surrogate-pair). Visible
+     6	// chunk text is materialized on demand (no per-chunk substrings retained). Pure JVM.
+     7	package com.vreader.app.reader
+     8	
+     9	class TxtDocument private constructor(
+    10	    val text: String,
+    11	    private val starts: IntArray,
+    12	) {
+    13	    /** Number of chunks (0 for empty text). */
+    14	    val chunkCount: Int get() = starts.size
+    15	
+    16	    /** The UTF-16 start offset of chunk [index] (clamped to a valid chunk). */
+    17	    fun offsetForChunk(index: Int): Int {
+    18	        if (starts.isEmpty()) return 0
+    19	        return starts[index.coerceIn(0, starts.size - 1)]
+    20	    }
+    21	
+    22	    /** The chunk index containing [offsetUtf16] (EOF-clamped); 0 for empty text. */
+    23	    fun chunkForOffset(offsetUtf16: Int): Int {
+    24	        if (starts.isEmpty()) return 0
+    25	        val offset = offsetUtf16.coerceIn(0, text.length)
+    26	        // Largest start <= offset (binary search).
+    27	        var lo = 0; var hi = starts.size - 1; var ans = 0
+    28	        while (lo <= hi) {
+    29	            val mid = (lo + hi) ushr 1
+    30	            if (starts[mid] <= offset) { ans = mid; lo = mid + 1 } else { hi = mid - 1 }
+    31	        }
+    32	        return ans
+    33	    }
+    34	
+    35	    /** The text of chunk [index], materialized on demand from the backing string. */
+    36	    fun textForChunk(index: Int): CharSequence {
+    37	        if (starts.isEmpty()) return ""
+    38	        val i = index.coerceIn(0, starts.size - 1)
+    39	        val end = if (i + 1 < starts.size) starts[i + 1] else text.length
+    40	        return text.subSequence(starts[i], end)
+    41	    }
+    42	
+    43	    companion object {
+    44	        const val DEFAULT_MAX_CHUNK_CHARS = 4000
+    45	
+    46	        /**
+    47	         * Build a document from already-decoded [text]. Chunk boundaries fall after a
+    48	         * line terminator (`\n`, `\r`, or `\r\n` — preserved in the chunk); a line longer
+    49	         * than [maxChunkChars] is hard-split, but never between a surrogate pair.
+    50	         */
+    51	        fun of(text: String, maxChunkChars: Int = DEFAULT_MAX_CHUNK_CHARS): TxtDocument {
+    52	            if (text.isEmpty()) return TxtDocument(text, IntArray(0))
+    53	            // Primitive growable IntArray (no Int boxing) — a newline-dense 14MB file
+    54	            // would otherwise spike tens of MB of boxed Integers + a duplicating copy.
+    55	            var starts = IntArray(64)
+    56	            var count = 0
+    57	            fun push(v: Int) {
+    58	                if (count == starts.size) starts = starts.copyOf(starts.size * 2)
+    59	                starts[count++] = v
+    60	            }
+    61	            push(0)
+    62	            var i = 0
+    63	            var chunkStart = 0
+    64	            val n = text.length
+    65	            while (i < n) {
+    66	                val c = text[i]
+    67	                when {
+    68	                    c == '\n' -> {
+    69	                        i++
+    70	                        if (i < n) { push(i); chunkStart = i }
+    71	                    }
+    72	                    c == '\r' -> {
+    73	                        i++
+    74	                        if (i < n && text[i] == '\n') i++   // CRLF stays one terminator
+    75	                        if (i < n) { push(i); chunkStart = i }
+    76	                    }
+    77	                    else -> {
+    78	                        i++
+    79	                        // Hard-split a runaway line, but not mid-surrogate-pair (don't
+    80	                        // split right after a high surrogate — its low half follows at i).
+    81	                        if (i - chunkStart >= maxChunkChars && i < n && !text[i - 1].isHighSurrogate()) {
+    82	                            push(i); chunkStart = i
+    83	                        }
+    84	                    }
+    85	                }
+    86	            }
+    87	            return TxtDocument(text, starts.copyOf(count))
+    88	        }
+    89	    }
+    90	}
+     1	// Purpose: feature #124 WI-3 — drives the TXT custom selection. Each visible chunk registers its
+     2	// TextLayoutResult + LayoutCoordinates; the controller converts a pointer (LazyColumn-local) → window
+     3	// space → the hit chunk's local space → rendered offset → SOURCE offset (TxtSourceOffsets), and resolves
+     4	// a word boundary at long-press. Selection is a SOURCE Utf16Range; the in-progress range renders as an
+     5	// accent wash. Kept off the Activity so the geometry is isolated; the Activity wires the gesture +
+     6	// popover + persistence.
+     7	package com.vreader.app.reader
+     8	
+     9	import androidx.compose.runtime.Stable
+    10	import androidx.compose.ui.geometry.Offset
+    11	import androidx.compose.ui.layout.LayoutCoordinates
+    12	import androidx.compose.ui.layout.boundsInWindow
+    13	import androidx.compose.ui.text.TextLayoutResult
+    14	import kotlinx.coroutines.flow.MutableStateFlow
+    15	import kotlinx.coroutines.flow.StateFlow
+    16	import kotlinx.coroutines.flow.asStateFlow
+    17	
+    18	@Stable
+    19	class TxtSelectionController(
+    20	    private val doc: TxtDocument,
+    21	    // feature #125 — format-aware rendered↔source bridge. The chunk TextLayoutResults are built from the
+    22	    // RENDERED text, so getOffsetForPosition/getWordBoundary/getCursorRect speak rendered coords; the
+    23	    // mapper converts them to/from the SOURCE coords selections + highlights are stored in. TXT = identity.
+    24	    private val mapper: ChunkTextMapper,
+    25	) {
+    26	    private data class ChunkInfo(val layout: TextLayoutResult, val coords: LayoutCoordinates)
+    27	    /** A resolved hit: the chunk index/info + the chunk-local rendered offset + the absolute source offset. */
+    28	    private data class Hit(val chunkIndex: Int, val info: ChunkInfo, val rendered: Int, val source: Int)
+    29	    private val chunks = HashMap<Int, ChunkInfo>()
+    30	    private var lazyCoords: LayoutCoordinates? = null
+    31	    // the initial word selected at long-press — the FIXED anchor; drags extend relative to it (never drop it).
+    32	    private var anchorRange: Utf16Range? = null
+    33	
+    34	    private val _selection = MutableStateFlow<Utf16Range?>(null)
+    35	    val selection: StateFlow<Utf16Range?> = _selection.asStateFlow()
+    36	
+    37	    fun setLazyCoords(coords: LayoutCoordinates) { lazyCoords = coords }
+    38	    fun registerChunk(index: Int, layout: TextLayoutResult, coords: LayoutCoordinates) {
+    39	        chunks[index] = ChunkInfo(layout, coords)
+    40	    }
+    41	    fun unregisterChunk(index: Int) { chunks.remove(index) }
+    42	
+    43	    /** Pointer (LazyColumn-local) → the hit chunk + chunk-local rendered offset + source offset. The hit
+    44	     *  chunk is used for BOTH the source mapping AND word-boundary lookup (avoids a chunk-boundary shift).
+    45	     *  [allowNearest]: for a DRAG, fall back to the nearest chunk when the point is past the text; for a
+    46	     *  TAP-to-edit, require the point to actually be inside a text chunk (else a margin tap could edit). */
+    47	    private fun hitAt(localPoint: Offset, allowNearest: Boolean = true): Hit? {
+    48	        val lz = lazyCoords ?: return null
+    49	        if (chunks.isEmpty()) return null
+    50	        val windowPoint = lz.localToWindow(localPoint)
+    51	        val hit = chunks.entries.firstOrNull { it.value.coords.boundsInWindow().contains(windowPoint) }
+    52	            ?: (if (allowNearest) chunks.entries.minByOrNull { verticalDistance(it.value.coords.boundsInWindow(), windowPoint) } else null)
+    53	            ?: return null
+    54	        val chunkLocal = hit.value.coords.windowToLocal(windowPoint)
+    55	        val rendered = hit.value.layout.getOffsetForPosition(chunkLocal).coerceIn(0, hit.value.layout.layoutInput.text.length)
+    56	        // rendered cursor → chunk-local source (empty rendered range maps to the source edge) → global source.
+    57	        val localSource = mapper.renderedRangeToSource(hit.key, Utf16Range(rendered, rendered)).startInclusive
+    58	        return Hit(hit.key, hit.value, rendered, doc.offsetForChunk(hit.key) + localSource)
+    59	    }
+    60	
+    61	    /** Long-press: select the word under [localPoint] (word boundary in the HIT chunk, mapped to source). */
+    62	    fun beginAt(localPoint: Offset) {
+    63	        val hit = hitAt(localPoint) ?: return
+    64	        val word = hit.info.layout.getWordBoundary(hit.rendered)   // RENDERED coords in the hit chunk
+    65	        val base = doc.offsetForChunk(hit.chunkIndex)
+    66	        // rendered word → chunk-local source span → global source (markers stripped for MD).
+    67	        val src = mapper.renderedRangeToSource(hit.chunkIndex, Utf16Range(word.start, word.end))
+    68	        val start = base + src.startInclusive
+    69	        val end = base + src.endExclusive
+    70	        val range = if (end > start) Utf16Range(start, end) else Utf16Range(hit.source, (hit.source + 1).coerceAtMost(doc.text.length))
+    71	        anchorRange = range
+    72	        _selection.value = range
+    73	    }
+    74	
+    75	    /** Drag: extend relative to the FIXED [anchorRange] (the initial word) — extending before it grows the
+    76	     *  start, after it grows the end, inside it keeps the word. The anchor word is never dropped. */
+    77	    fun extendTo(localPoint: Offset) {
+    78	        val anchor = anchorRange ?: return
+    79	        val off = (hitAt(localPoint) ?: return).source.coerceIn(0, doc.text.length)
+    80	        _selection.value = when {
+    81	            off <= anchor.startInclusive -> Utf16Range(off, anchor.endExclusive)
+    82	            off >= anchor.endExclusive -> Utf16Range(anchor.startInclusive, off)
+    83	            else -> anchor
+    84	        }
+    85	    }
+    86	
+    87	    fun clear() { _selection.value = null; anchorRange = null }
+    88	
+    89	    /** The current selection range, or null. */
+    90	    fun currentRange(): Utf16Range? = _selection.value
+    91	
+    92	    /** Resolve a tap (LazyColumn-local) to a SOURCE offset, for hit-testing an existing highlight. Strict
+    93	     *  (no nearest-chunk fallback) so a tap in the margin/blank space doesn't edit a nearby highlight. */
+    94	    fun resolveSourceOffset(localPoint: Offset): Int? = hitAt(localPoint, allowNearest = false)?.source
+    95	
+    96	    /** Convert a LazyColumn-local point to window coords (to anchor the edit popover at a tap). */
+    97	    fun toWindow(localPoint: Offset): Offset? = lazyCoords?.localToWindow(localPoint)
+    98	
+    99	    /** Whether the current selection is a persist-worthy range (in-bounds, non-empty, surrogate-safe). */
+   100	    fun isCurrentSelectionValid(): Boolean = _selection.value?.let { TxtSelection.isValid(it, doc.text) } ?: false
+   101	
+   102	    /** The VISIBLE (rendered) substring of the current selection — for the popover / copy / share / UI.
+   103	     *  For TXT this equals the source; for MD it's the marker-stripped rendered text the user sees. */
+   104	    fun selectedVisibleText(): String? {
+   105	        val r = _selection.value ?: return null
+   106	        if (r.isEmpty || r.endExclusive > doc.text.length) return null
+   107	        val sb = StringBuilder()
+   108	        for (cr in TxtSourceOffsets.chunkRanges(doc, r)) {
+   109	            sb.append(mapper.visibleText(cr.chunkIndex, mapper.sourceRangeToRendered(cr.chunkIndex, cr.local)))
+   110	        }
+   111	        return sb.toString().ifEmpty { null }
+   112	    }
+   113	
+   114	    /** The SOURCE (markdown/raw) substring of the current selection — for the locator textQuote + anchor. */
+   115	    fun selectedSourceText(): String? {
+   116	        val r = _selection.value ?: return null
+   117	        if (r.isEmpty || r.endExclusive > doc.text.length) return null
+   118	        return doc.text.substring(r.startInclusive, r.endExclusive)
+   119	    }
+   120	
+   121	    /** The in-progress selection projected onto [chunkIndex] as a chunk-local RENDERED range, for the
+   122	     *  accent wash (`getPathForRange` speaks rendered coords). Source→rendered via the mapper (MD). */
+   123	    fun selectionForChunk(chunkIndex: Int): Utf16Range? {
+   124	        val r = _selection.value ?: return null
+   125	        val localSource = TxtSourceOffsets.chunkRanges(doc, r).firstOrNull { it.chunkIndex == chunkIndex }?.local ?: return null
+   200	        setContent {
+   201	            VReaderTheme {
+   202	                val state by produceState<TxtUiState>(TxtUiState.Loading, key) {
+   203	                    value = withContext(Dispatchers.IO) {
+   204	                        runCatching { load(key) }.getOrDefault(TxtUiState.Failed)
+   205	                    }
+   206	                }
+   207	                // feature #129 — the live Display settings (theme/font/size/spacing/margin). NULL until
+   208	                // the DataStore's first emission; the reader body is withheld until then (Gate-4 Medium:
+   209	                // rendering defaults first would flash the wrong theme/typography for a user with stored
+   210	                // non-default settings). The empty loading scaffold is the only pre-emission surface.
+   211	                val settingsOrNull by container.readerSettingsStore.settings
+   212	                    .collectAsStateWithLifecycle(initialValue = null)
+   213	                val gated = if (settingsOrNull == null && state !is TxtUiState.Failed) TxtUiState.Loading else state
+   214	                when (val s = gated) {
+   215	                    is TxtUiState.Failed -> LaunchedEffect(Unit) { finish() }
+   216	                    is TxtUiState.Loading -> TxtLoadingScaffold((settingsOrNull ?: ReaderSettings()).theme)
+   217	                    is TxtUiState.Loaded -> {
+   218	                        // non-null by the gate above (Loaded is unreachable pre-emission).
+   219	                        val displaySettings = checkNotNull(settingsOrNull)
+   220	                        val listState = rememberLazyListState(initialFirstVisibleItemIndex = s.initialIndex)
+   221	                        // onStop flush — captures the live list state + book/document.
+   222	                        SideEffect {
+   223	                            flushPosition = { savePosition(s.book, s.document, listState.firstVisibleItemIndex) }
+   224	                        }
+   225	                        // Debounced steady-state save as the user scrolls.
+   226	                        LaunchedEffect(listState, s.document) {
+   227	                            snapshotFlow { listState.firstVisibleItemIndex }
+   228	                                .drop(1)
+   229	                                .debounce(1_000)
+   230	                                .collect { savePosition(s.book, s.document, it) }
+   231	                        }
+   232	                        // feature #121 — read-aloud. The VM drives the designed control bar; the spoken
+   233	                        // sentence is washed + auto-scrolled (TXT). Chunking is LAZY + off-main (only
+   234	                        // on Read aloud) so a large book never scans the whole text on composition.
+   235	                        val ttsVm: TtsViewModel = viewModel(factory = viewModelFactory {
+   236	                            initializer { TtsViewModel(AndroidTtsEngine(applicationContext)) }
+   237	                        })
+   238	                        val tts by ttsVm.state.collectAsStateWithLifecycle()
+   239	                        val ttsScope = rememberCoroutineScope()
+   240	                        LaunchedEffect(ttsVm) { ttsVm.intents.collect { launchTtsIntent(it) } }
+   241	                        // pause read-aloud when the reader is backgrounded (no MediaSession by design —
+   242	                        // plan §OOS); the engine is shut down on Activity finish via the VM's onCleared.
+   243	                        val lifecycleOwner = LocalLifecycleOwner.current
+   244	                        DisposableEffect(lifecycleOwner) {
+   245	                            // guard against ON_STOP firing on a rotation (config change) — the VM is
+   246	                            // retained across rotation, so don't pause when we're just reconfiguring.
+   247	                            val obs = LifecycleEventObserver { _, e -> if (e == Lifecycle.Event.ON_STOP && !isChangingConfigurations) ttsVm.pause() }
+   248	                            lifecycleOwner.lifecycle.addObserver(obs)
+   249	                            onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
+   250	                        }
+   251	                        val active = tts.phase != TtsPhase.idle
+   252	                        val spokenChunk = if (tts.phase == TtsPhase.speaking) s.document.chunkForOffset(tts.charStart) else -1
+   253	                        // auto-scroll ONLY when the spoken chunk is off-screen — so a small manual scroll
+   254	                        // while listening isn't fought on every sentence.
+   255	                        LaunchedEffect(spokenChunk) {
+   256	                            if (spokenChunk >= 0 && listState.layoutInfo.visibleItemsInfo.none { it.index == spokenChunk }) {
+   257	                                runCatching { listState.animateScrollToItem(spokenChunk) }
+   258	                            }
+   259	                        }
+   260	                        var showSpeed by remember { mutableStateOf(false) }
+   261	                        var showVoice by remember { mutableStateOf(false) }
+   262	                        var starting by remember { mutableStateOf(false) }   // guards double-tap → double-chunk
+   263	                        // snapshot the voice options once when the sheet opens (not every recomposition).
+   264	                        val voiceList = remember(showVoice) { if (showVoice) ttsVm.voiceListState() else com.vreader.app.tts.TtsVoiceListState() }
+   265	
+   266	                        // feature #122 — reading-stats: track this session (the process-singleton tracker
+   267	                        // survives rotation) + show the auto-fading session pill.
+   268	                        val tracker = container.readingTimeTracker
+   269	                        val bookKey = s.book.fingerprintKey
+   270	                        val sessionSeconds by tracker.sessionSeconds.collectAsStateWithLifecycle()
+   395	                            // feature #135 WI-7 — the top-bar bookmark toggle + Bookmarks-tab rows + TXT jump.
+   396	                            isCurrentBookmarked = isBookmarked,
+   397	                            onToggleBookmark = {
+   398	                                container.appScope.launch {
+   399	                                    runCatching { container.annotationsRepository.toggleBookmark(bookKey, title = null, locator = liveCanonical) }
+   400	                                }
+   401	                            },
+   402	                            currentLocator = liveCanonical,
+   403	                            bookmarks = bookmarkRows,
+   404	                            // TXT jump: scroll to the bookmark's char offset via the existing chunk scroll seam
+   405	                            // (the same path resume + the annotation jump use). Out-of-range → Failed (sheet stays open).
+   406	                            onJumpBookmark = { record ->
+   407	                                val target = txtBookmarkScrollTarget(record.locator.charOffsetUTF16, s.document.text.length)
+   408	                                if (target == null) {
+   409	                                    JumpResult.Failed
+   410	                                } else {
+   411	                                    ttsScope.launch { listState.scrollToItem(s.document.chunkForOffset(target)) }
+   412	                                    JumpResult.Succeeded
+   413	                                }
+   414	                            },
+   415	                            // TXT/MD jump: scroll to the annotation's UTF-16 offset via the existing chunk
+   416	                            // scroll seam (the same path used by resume + scrubber).
+   417	                            onJumpToAnnotation = { item ->
+   418	                                ttsScope.launch {
+   419	                                    val target = annotationScrollOffset(item)
+   420	                                        .coerceIn(0, (s.document.text.length - 1).coerceAtLeast(0))
+   421	                                    listState.scrollToItem(s.document.chunkForOffset(target))
+   422	                                }
+   423	                            },
+   424	                            onShareAnnotations = { shareAnnotations(annotationsSnapshot) },
+   425	                            // feature #133 WI-10 — the Search entry + sheet. The icon is hidden only when the
+   426	                            // index-state gate says Unsupported (a skipped-unsupported TXT/MD book — no dead
+   427	                            // control); otherwise tapping it opens the sheet for THIS book.
+   428	                            onOpenSearch = if (inBookSearchState.hidesSearchEntry) null else { { showSearch = true } },
+   429	                            searchSheet = if (!showSearch) null else {
+   430	                                {
+   431	                                    InBookSearchSheet(
+   432	                                        theme = displaySettings.theme,
+   433	                                        bookTitle = s.title,
+   434	                                        state = inBookSearchState,
+   435	                                        query = inBookSearchState.query,
+   436	                                        onQueryChange = inBookSearchVm::onQueryChange,
+   437	                                        onPickRecent = inBookSearchVm::onPickRecent,
+   438	                                        // Resolve the tapped hit's canonical charOffsetUTF16 → scroll via the
+   439	                                        // EXISTING chunk-scroll seam (the same path resume / annotation / bookmark
+   440	                                        // jumps use). The WI-9 sheet's onJump is NON-suspend (JumpResult returns
+   441	                                        // synchronously), so — like the sibling annotation/bookmark jumps — the
+   442	                                        // range is validated UP FRONT (out-of-range/null → Failed, sheet stays
+   443	                                        // open, rule 51) and a valid target returns Succeeded optimistically while
+   444	                                        // the actual scroll runs on ttsScope; the launch is runCatching-guarded so
+   445	                                        // a scroll cancelled during teardown can't crash. The recent is committed
+   446	                                        // only on a valid result-open (the VM's commitSearch contract).
+   447	                                        onJump = { hit ->
+   448	                                            val off = hit.canonicalLocator?.charOffsetUTF16
+   449	                                            val target = txtBookmarkScrollTarget(off, s.document.text.length)
+   450	                                            if (target == null) {
+   451	                                                JumpResult.Failed
+   452	                                            } else {
+   453	                                                inBookSearchVm.commitSearch()
+   454	                                                ttsScope.launch { runCatching { listState.scrollToItem(s.document.chunkForOffset(target)) } }
+   455	                                                JumpResult.Succeeded
+   456	                                            }
+   457	                                        },
+   458	                                        onLoadMore = inBookSearchVm::loadMore,
+   459	                                        onDismiss = { inBookSearchVm.onDismiss(); showSearch = false },
+   460	                                    )
+   461	                                }
+   462	                            },
+   463	                            bottomBar = { (openContents, openNotes) ->
+   464	                                if (active) TtsControlBar(
+   465	                                    tts,
+   466	                                    onPlayPause = { if (tts.phase == TtsPhase.speaking) ttsVm.pause() else ttsVm.play() },
+   467	                                    onPrevious = ttsVm::previous, onNext = ttsVm::next, onStop = ttsVm::stop,
+   468	                                    onSpeed = { showSpeed = true }, onVoice = { showVoice = true },
+   469	                                    onInstallVoice = ttsVm::installVoiceData, onSystemTts = ttsVm::openSystemTts,
+   470	                                ) else ReaderBottomChrome(
+   471	                                    theme = displaySettings.theme,
+   472	                                    progress = TxtProgress.fraction(
+   473	                                        s.document.offsetForChunk(listState.firstVisibleItemIndex),
+   474	                                        s.document.text.length,
+   475	                                    ),
+   476	                                    displayPage = 0, totalPages = 0,   // TXT/MD scroll-only — no page labels
+   477	                                    onScrub = { f ->
+   478	                                        ttsScope.launch {
+   479	                                            val target = (f * s.document.text.length).toInt()
+   480	                                                .coerceIn(0, (s.document.text.length - 1).coerceAtLeast(0))
+   481	                                            listState.scrollToItem(s.document.chunkForOffset(target))
+   482	                                        }
+   483	                                    },
+   484	                                    onOpenDisplay = { showDisplaySheet = true },
+   485	                                    // #132 WI-6: the scaffold hands the Contents/Notes open callbacks in.
+   486	                                    // TXT/MD has no TOC → openContents is null (Contents control hidden);
+   487	                                    // openNotes opens the review sheet.
+   488	                                    onOpenContents = openContents,
+   489	                                    onOpenNotes = openNotes,
+   490	                                    extraSlot = {
+   605	        val initial = computeInitialIndex(key, document)
+   606	        return TxtUiState.Loaded(book.title, document, book, initial)
+   607	    }
+   608	
+   609	    /** Restore: the saved legacy locator's charOffsetUTF16 → the chunk containing it. */
+   610	    private suspend fun computeInitialIndex(key: String, document: TxtDocument): Int {
+   611	        // In-memory cache first — a fast rotation / reopen sees the latest offset even
+   612	        // before the prior instance's async Room flush commits. Falls to durable Room.
+   613	        container.cachedOffset(key)?.let { return document.chunkForOffset(it) }
+   614	        val saved = container.repository.loadPosition(key) ?: return 0
+   615	        // ResumeResolver/ResumeTarget are in this package. A TXT position is a legacy
+   616	        // (non-Readium) envelope → Canonical; its charOffsetUTF16 is the anchor.
+   617	        val offset = (ResumeResolver.resolve(saved) as? ResumeTarget.Canonical)
+   618	            ?.locator?.charOffsetUTF16 ?: return 0
+   619	        return document.chunkForOffset(offset)
+   620	    }
+   621	
+   622	    /** Enqueue the top-visible chunk's char offset; the lone writer persists it (latest-wins). */
+   623	    private fun savePosition(book: Book, document: TxtDocument, topIndex: Int) {
+   624	        val offset = document.offsetForChunk(topIndex)
+   625	        // Cache synchronously so an immediate reopen/rotation reads the latest position
+   626	        // even before the async Room write below commits.
+   627	        container.cacheOffset(book.fingerprintKey, offset)
+   628	        saveRequests.trySend(PendingSave(book, offset))
+   629	    }
+   630	
+   631	    /** Launch a system intent for a read-aloud one-shot, guarded by resolveActivity with fallbacks
+   632	     *  (there is no public Settings.ACTION_TTS_SETTINGS — fall back to accessibility / settings). */
+   633	    private fun launchTtsIntent(i: TtsIntent) {
+   634	        val candidates = when (i) {
+   635	            TtsIntent.InstallVoiceData -> listOf(android.content.Intent(TextToSpeech.Engine.ACTION_INSTALL_TTS_DATA))
+  1010	    val currentOnFinalize by androidx.compose.runtime.rememberUpdatedState(onSelectionFinalized)
+  1011	    LazyColumn(
+  1012	        Modifier
+  1013	            .fillMaxSize()
+  1014	            .onGloballyPositioned { selectionController?.setLazyCoords(it) }
+  1015	            .then(
+  1016	                if (selectionController != null) {
+  1017	                    // ONE detector distinguishes a TAP (edit an existing highlight) from a LONG-PRESS+drag
+  1018	                    // (new selection) — two separate pointerInput detectors conflict over the same down event.
+  1019	                    Modifier.pointerInput(selectionController) {
+  1020	                        awaitEachGesture {
+  1021	                            val down = awaitFirstDown(requireUnconsumed = false)
+  1022	                            val longPress = awaitLongPressOrCancellation(down.id)
+  1023	                            if (longPress != null) {
+  1024	                                // long-press → selection; finalize only on a COMPLETED drag/up (not a cancel).
+  1025	                                selectionController.beginAt(longPress.position)
+  1026	                                val completed = drag(longPress.id) { change -> selectionController.extendTo(change.position); change.consume() }
+  1027	                                if (completed) currentOnFinalize() else selectionController.clear()
+  1028	                            } else if (!down.isConsumed) {
+  1029	                                // null also means cancel (e.g. a scroll won) — only a TAP leaves the down
+  1030	                                // unconsumed; a scroll consumes it, so it won't be misread as tap-to-edit.
+  1031	                                currentOnTap(down.position)
+  1032	                            }
+  1033	                        }
+  1034	                    }
+  1035	                } else {
+  1036	                    Modifier
+  1037	                },
+  1038	            ),
+  1039	        state = listState,
+  1040	        contentPadding = PaddingValues(horizontal = marginDp.dp, vertical = 16.dp),
+  1041	    ) {
+  1042	        // Count-based: indices on demand (a newline-dense 14MB file can be 100k+ chunks).
+  1043	        items(count = document.chunkCount, key = { it }) { i ->
+  1044	            val raw = document.textForChunk(i).toString()
+  1045	            // .md → styled markdown spans (no read-aloud span wash — markers shift offsets, plan §OOS).
+  1046	            // .txt → raw verbatim, with the spoken-sentence span washed when read-aloud is active.
+  1047	            val span = if (isMarkdown) null else highlightSpan(i)
+  1048	            val text = when {
+  1049	                isMarkdown -> mapper.renderedText(i)   // #125: the mapper is the single render owner
+  1050	                span != null -> buildAnnotatedString {
+  1051	                    append(raw)
+  1052	                    val a = span.first.coerceIn(0, raw.length); val b = (span.last + 1).coerceIn(a, raw.length)
+  1053	                    if (b > a) addStyle(SpanStyle(background = wash), a, b)
+  1054	                }
+  1055	                else -> AnnotatedString(raw)
+  1056	            }
+  1057	            // annotation washes drawn BEHIND the text (getPathForRange) — separate from the read-aloud span.
+  1058	            val washes = washesForChunk(i)
+  1059	            var layout by remember(i) { mutableStateOf<TextLayoutResult?>(null) }
+  1060	            var coords by remember(i) { mutableStateOf<androidx.compose.ui.layout.LayoutCoordinates?>(null) }
+  1061	            if (selectionController != null) {
+  1062	                LaunchedEffect(i, layout, coords) {
+  1063	                    val l = layout; val c = coords
+  1064	                    if (l != null && c != null) selectionController.registerChunk(i, l, c)
+  1065	                }
+  1066	                DisposableEffect(selectionController, i) { onDispose { selectionController.unregisterChunk(i) } }
+  1067	            }
+  1068	            // read `selection` (a State) so a selection change recomposes + redraws the accent.
+  1069	            val selRange = if (selection != null) selectionController?.selectionForChunk(i) else null
+  1070	            Text(
+  1071	                text = text,
+  1072	                // merge over the material default (the pre-#129 explicit-param behavior) so platform
+  1073	                // text defaults (letterSpacing etc.) are kept — only the Display settings change.
+  1074	                style = androidx.compose.material3.LocalTextStyle.current.merge(textStyle),
+  1075	                onTextLayout = { layout = it },
+  1076	                modifier = Modifier
+  1077	                    .onGloballyPositioned { coords = it }
+  1078	                    .drawBehind {
+  1079	                        layout?.let { l ->
+  1080	                            drawWashes(l, washes)
+  1081	                            selRange?.let { drawRangeFill(l, it, selectionAccent) }
+  1082	                        }
+  1083	                    },
+  1084	            )
+  1085	        }
+  1086	    }
+  1087	}
+
+exec
+/bin/zsh -lc "nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt | sed -n '1,145p'; nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt | sed -n '1,145p'; nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt | sed -n '1,135p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+     1	// Purpose: feature #118 WI-3 (#110 Phase 3) — the AI provider list (the gate), design surface A
+     2	// from vreader-ai-android.jsx `AiProviderList`: unconfigured onboards to a single Add action;
+     3	// configured shows the active provider + per-provider status (model, or the rejection reason).
+     4	// Reuses the shared form vocabulary (NavScreen / SettingsCard / GroupHeader / StatusDot / tokens —
+     5	// mapped from this surface's own design file). Stateless: a pure function of the list + callbacks.
+     6	package com.vreader.app.ai
+     7	
+     8	import androidx.compose.foundation.background
+     9	import androidx.compose.foundation.clickable
+    10	import androidx.compose.foundation.layout.Box
+    11	import androidx.compose.foundation.layout.Column
+    12	import androidx.compose.foundation.layout.Row
+    13	import androidx.compose.foundation.layout.fillMaxWidth
+    14	import androidx.compose.foundation.layout.height
+    15	import androidx.compose.foundation.layout.heightIn
+    16	import androidx.compose.foundation.layout.padding
+    17	import androidx.compose.foundation.layout.size
+    18	import androidx.compose.foundation.shape.CircleShape
+    19	import androidx.compose.foundation.shape.RoundedCornerShape
+    20	import androidx.compose.material.icons.Icons
+    21	import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+    22	import androidx.compose.material.icons.filled.Add
+    23	import androidx.compose.material.icons.filled.AutoAwesome
+    24	import androidx.compose.material3.Icon
+    25	import androidx.compose.material3.Text
+    26	import androidx.compose.runtime.Composable
+    27	import androidx.compose.ui.Alignment
+    28	import androidx.compose.ui.Modifier
+    29	import androidx.compose.ui.draw.clip
+    30	import androidx.compose.ui.graphics.Color
+    31	import androidx.compose.ui.platform.testTag
+    32	import androidx.compose.ui.text.font.FontWeight
+    33	import androidx.compose.ui.text.style.TextAlign
+    34	import androidx.compose.ui.unit.dp
+    35	import androidx.compose.ui.unit.sp
+    36	import com.vreader.app.backup.BackupFonts
+    37	import com.vreader.app.backup.GroupFooter
+    38	import com.vreader.app.backup.GroupHeader
+    39	import com.vreader.app.backup.LocalBackupTokens
+    40	import com.vreader.app.backup.NavScreen
+    41	import com.vreader.app.backup.SettingsCard
+    42	import com.vreader.app.backup.StatusDot
+    43	import com.vreader.app.backup.VSpace
+    44	
+    45	@Composable
+    46	fun AiProviderListScreen(
+    47	    state: AiProviderListState,
+    48	    onBack: () -> Unit = {},
+    49	    onAdd: () -> Unit = {},
+    50	    onEdit: (String) -> Unit = {},
+    51	) {
+    52	    val t = LocalBackupTokens.current
+    53	    val addButton: @Composable () -> Unit = {
+    54	        Box(
+    55	            Modifier.size(44.dp).clip(RoundedCornerShape(22.dp)).clickable(onClickLabel = "Add provider", onClick = onAdd),
+    56	            contentAlignment = Alignment.Center,
+    57	        ) { Icon(Icons.Filled.Add, contentDescription = "Add provider", tint = t.tint, modifier = Modifier.size(22.dp)) }
+    58	    }
+    59	    NavScreen(title = "AI Providers", large = true, onBack = onBack, trailing = addButton) {
+    60	        Column(Modifier.padding(horizontal = 18.dp).padding(bottom = 32.dp)) {
+    61	            if (state.unconfigured) {
+    62	                AiEmptyState(onAdd)
+    63	            } else {
+    64	                GroupHeader("Providers")
+    65	                SettingsCard {
+    66	                    state.providers.forEachIndexed { i, p ->
+    67	                        ProviderRow(p, last = i == state.providers.lastIndex, onEdit = onEdit)
+    68	                    }
+    69	                }
+    70	                GroupFooter("The selected provider is used for translation, chat, and summaries. Tap one to edit or test it.")
+    71	            }
+    72	        }
+    73	    }
+    74	}
+    75	
+    76	@Composable
+    77	private fun AiEmptyState(onAdd: () -> Unit) {
+    78	    val t = LocalBackupTokens.current
+    79	    Column(Modifier.fillMaxWidth().padding(top = 36.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+    80	        Box(Modifier.size(64.dp).clip(CircleShape).background(t.chipBg), contentAlignment = Alignment.Center) {
+    81	            Icon(Icons.Filled.AutoAwesome, contentDescription = null, tint = t.tint, modifier = Modifier.size(30.dp))
+    82	        }
+    83	        VSpace(18)
+    84	        Text("Connect an AI provider", color = t.ink, fontFamily = BackupFonts.Serif, fontSize = 21.sp, textAlign = TextAlign.Center)
+    85	        VSpace(8)
+    86	        Text(
+    87	            "One key unlocks bilingual translation, chat about a book, and chapter summaries. Your key is stored on-device only.",
+    88	            color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 14.sp, lineHeight = 22.sp, textAlign = TextAlign.Center,
+    89	        )
+    90	        VSpace(18)
+    91	        Box(
+    92	            Modifier.fillMaxWidth().clip(RoundedCornerShape(13.dp)).background(t.tint)
+    93	                .clickable(onClickLabel = "Add a provider", onClick = onAdd).testTag("ai-add-provider").padding(vertical = 14.dp),
+    94	            contentAlignment = Alignment.Center,
+    95	        ) { Text("Add a provider", color = Color.White, fontFamily = BackupFonts.Sans, fontSize = 15.sp, fontWeight = FontWeight.SemiBold) }
+    96	        GroupFooter("Works with Anthropic, OpenAI-compatible endpoints, and local models.")
+    97	    }
+    98	}
+    99	
+   100	@Composable
+   101	private fun ProviderRow(p: AiProviderRow, last: Boolean, onEdit: (String) -> Unit) {
+   102	    val t = LocalBackupTokens.current
+   103	    Box {
+   104	        Row(
+   105	            Modifier.fillMaxWidth().heightIn(min = 60.dp).clickable(onClick = { onEdit(p.id) })
+   106	                .testTag("provider-${p.id}").padding(horizontal = 14.dp),
+   107	            verticalAlignment = Alignment.CenterVertically,
+   108	        ) {
+   109	            // active = filled accent circle; inactive = hollow ring (sep ring + card-coloured core)
+   110	            Box(
+   111	                Modifier.size(20.dp).clip(CircleShape).background(if (p.active) t.tint else t.sep),
+   112	                contentAlignment = Alignment.Center,
+   113	            ) {
+   114	                if (!p.active) Box(Modifier.size(16.5.dp).clip(CircleShape).background(t.card))
+   115	            }
+   116	            Column(Modifier.weight(1f).padding(start = 12.dp)) {
+   117	                Text(p.name, color = t.ink, fontFamily = BackupFonts.Sans, fontSize = 15.5.sp, fontWeight = FontWeight.Medium)
+   118	                Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(top = 2.dp)) {
+   119	                    StatusDot(if (p.statusOk) t.green else t.red)
+   120	                    Text(
+   121	                        p.detail, color = if (p.statusOk) t.sec else t.red,
+   122	                        fontFamily = BackupFonts.Mono, fontSize = 11.5.sp, modifier = Modifier.padding(start = 6.dp),
+   123	                    )
+   124	                }
+   125	            }
+   126	            Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, tint = t.ter, modifier = Modifier.size(18.dp))
+   127	        }
+   128	        if (!last) Box(Modifier.fillMaxWidth().padding(start = 46.dp).height(0.5.dp).background(t.sep).align(Alignment.BottomStart))
+   129	    }
+   130	}
+     1	// Purpose: feature #118 WI-3 (#110 Phase 3) — drives the AI provider list + editor: observes the
+     2	// AiProviderStore for the list, owns the editor form state, runs Test Connection against the LIVE
+     3	// form (a transient AiClient built from the form + key, no save first), and saves/deletes. v1 list
+     4	// status is ok+model (persisted per-provider test status is a follow-on). The key is never logged.
+     5	package com.vreader.app.ai
+     6	
+     7	import androidx.lifecycle.ViewModel
+     8	import androidx.lifecycle.viewModelScope
+     9	import kotlinx.coroutines.CoroutineDispatcher
+    10	import kotlinx.coroutines.Dispatchers
+    11	import kotlinx.coroutines.flow.MutableStateFlow
+    12	import kotlinx.coroutines.flow.SharingStarted
+    13	import kotlinx.coroutines.flow.StateFlow
+    14	import kotlinx.coroutines.flow.map
+    15	import kotlinx.coroutines.flow.stateIn
+    16	import kotlinx.coroutines.launch
+    17	import kotlinx.coroutines.withContext
+    18	import java.util.UUID
+    19	
+    20	class AiSettingsViewModel(
+    21	    private val store: AiProviderStore,
+    22	    private val clientDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    23	    private val factory: (AiProviderProfile, String) -> AiClient = { p, key -> AiProviderFactory.create(p, key) },
+    24	) : ViewModel() {
+    25	
+    26	    val listState: StateFlow<AiProviderListState> = store.observe()
+    27	        .map { snap ->
+    28	            AiProviderListState(
+    29	                snap.profiles.map { p ->
+    30	                    AiProviderRow(p.id, p.name, active = p.id == snap.activeId, statusOk = true, detail = p.model.ifBlank { p.kind.defaultModel })
+    31	                }
+    32	            )
+    33	        }
+    34	        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AiProviderListState())
+    35	
+    36	    private val _edit = MutableStateFlow<AiEditState?>(null)
+    37	    val editState: StateFlow<AiEditState?> = _edit
+    38	
+    39	    // Bumped whenever the editor opens/closes or a new test starts — an in-flight test result is
+    40	    // only applied if its generation still matches, so a stale Ok/Fail can't land on a different
+    41	    // form (the user closed it, opened another provider, or re-tested).
+    42	    private var testGen = 0
+    43	
+    44	    fun openAdd() { testGen++; _edit.value = AiEditState(editMode = false) }
+    45	
+    46	    fun openEdit(id: String) = viewModelScope.launch {
+    47	        val p = store.list().firstOrNull { it.id == id } ?: return@launch
+    48	        testGen++
+    49	        _edit.value = AiEditState(
+    50	            editMode = true, id = p.id, kind = p.kind, name = p.name, baseUrl = p.baseUrl, model = p.model,
+    51	            temperature = p.temperature, maxTokens = p.maxTokens, keyAlreadySaved = true,
+    52	        )
+    53	    }
+    54	
+    55	    fun close() { testGen++; _edit.value = null }
+    56	
+    57	    fun update(transform: (AiEditState) -> AiEditState) { _edit.value = _edit.value?.let(transform) }
+    58	
+    59	    fun test() {
+    60	        val s = _edit.value ?: return
+    61	        if (!s.canTest) return
+    62	        val gen = ++testGen
+    63	        update { it.copy(test = AiConnTest.testing, testMessage = "") }
+    64	        viewModelScope.launch {
+    65	            // Key lookup + client creation + the network call all off the main thread.
+    66	            val result = withContext(clientDispatcher) {
+    67	                val key = if (s.apiKey.isNotBlank()) s.apiKey else s.id?.let { store.apiKey(it) } ?: ""
+    68	                val profile = AiProviderProfile(
+    69	                    id = s.id ?: "transient", name = s.name, kind = s.kind, baseUrl = s.effectiveBaseUrl,
+    70	                    model = s.effectiveModel, temperature = s.temperature, maxTokens = s.maxTokens, encryptedApiKey = "",
+    71	                )
+    72	                runCatching { factory(profile, key).testConnection() }
+    73	                    .getOrElse { AiTestResult.Fail(AiError.Offline, it.message ?: "failed") }
+    74	            }
+    75	            if (gen != testGen) return@launch  // superseded by a newer test / form open / close
+    76	            update {
+    77	                when (result) {
+    78	                    is AiTestResult.Ok -> it.copy(test = AiConnTest.ok, testMessage = "Connected — the provider responded successfully.")
+    79	                    is AiTestResult.Fail -> it.copy(test = AiConnTest.fail, testMessage = result.message)
+    80	                }
+    81	            }
+    82	        }
+    83	    }
+    84	
+    85	    fun save() {
+    86	        val s = _edit.value ?: return
+    87	        if (!s.canSave) return
+    88	        viewModelScope.launch {
+    89	            store.upsert(
+    90	                id = s.id ?: UUID.randomUUID().toString(),
+    91	                name = s.name, kind = s.kind, baseUrl = s.baseUrl, model = s.model,
+    92	                temperature = s.temperature, maxTokens = s.maxTokens,
+    93	                apiKey = s.apiKey.ifBlank { null },  // blank on edit = keep existing
+    94	            )
+    95	            _edit.value = null
+    96	        }
+    97	    }
+    98	
+    99	    fun delete() {
+   100	        val id = _edit.value?.id ?: return
+   101	        viewModelScope.launch { store.delete(id); _edit.value = null }
+   102	    }
+   103	
+   104	    fun setActive(id: String) = viewModelScope.launch { store.setActive(id) }
+   105	}
+     1	// Purpose: feature #118 WI-1 (#110 Phase 3) — persists saved AI provider profiles + the active
+     2	// selection. Profile metadata (name/kind/baseUrl/model/temperature/maxTokens) lives in DataStore
+     3	// as a JSON list; the API key is kept ONLY as a SecretCipher token (the #116 KeystoreSecretCipher).
+     4	// Reuses the #116 WebDavServerStore DataStore+SecretCipher credential pattern, adding an active-id
+     5	// and a request-start `snapshot()` (a chat/test reads one consistent profile, not live mid-request
+     6	// store reads). The key + auth headers are NEVER logged.
+     7	package com.vreader.app.ai
+     8	
+     9	import androidx.datastore.core.DataStore
+    10	import androidx.datastore.preferences.core.Preferences
+    11	import androidx.datastore.preferences.core.edit
+    12	import androidx.datastore.preferences.core.stringPreferencesKey
+    13	import com.vreader.app.backup.net.SecretCipher
+    14	import kotlinx.coroutines.flow.Flow
+    15	import kotlinx.coroutines.flow.first
+    16	import kotlinx.coroutines.flow.map
+    17	import kotlinx.serialization.Serializable
+    18	import kotlinx.serialization.json.Json
+    19	
+    20	/** A saved AI provider. `encryptedApiKey` is a [SecretCipher] token, never plaintext. */
+    21	@Serializable
+    22	data class AiProviderProfile(
+    23	    val id: String,
+    24	    val name: String,
+    25	    val kind: AiProviderKind,
+    26	    val baseUrl: String,
+    27	    val model: String,
+    28	    val temperature: Double = 0.7,
+    29	    val maxTokens: Int = 2048,
+    30	    val encryptedApiKey: String,
+    31	)
+    32	
+    33	/** A consistent point-in-time view: the profiles + which is active. */
+    34	data class AiProviderSnapshot(val profiles: List<AiProviderProfile>, val activeId: String?) {
+    35	    val active: AiProviderProfile? get() = profiles.firstOrNull { it.id == activeId }
+    36	}
+    37	
+    38	@Serializable
+    39	private data class AiStoreState(val profiles: List<AiProviderProfile> = emptyList(), val activeId: String? = null)
+    40	
+    41	class AiProviderStore(
+    42	    private val dataStore: DataStore<Preferences>,
+    43	    private val cipher: SecretCipher,
+    44	    private val json: Json = Json { ignoreUnknownKeys = true; encodeDefaults = true },
+    45	) {
+    46	    /** One consistent profiles + active-id view (read once at request start). */
+    47	    suspend fun snapshot(): AiProviderSnapshot = read(dataStore.data.first()).toSnapshot()
+    48	
+    49	    fun observe(): Flow<AiProviderSnapshot> = dataStore.data.map { read(it).toSnapshot() }
+    50	
+    51	    suspend fun list(): List<AiProviderProfile> = snapshot().profiles
+    52	
+    53	    suspend fun activeProfile(): AiProviderProfile? = snapshot().active
+    54	
+    55	    /**
+    56	     * Insert/update a profile by [id]. [apiKey] is the PLAINTEXT to encrypt; pass null on an edit
+    57	     * that leaves the key unchanged (the existing ciphertext is kept). A brand-new id REQUIRES a
+    58	     * key. The first profile added becomes active. Returns the saved profile (key encrypted).
+    59	     */
+    60	    suspend fun upsert(
+    61	        id: String,
+    62	        name: String,
+    63	        kind: AiProviderKind,
+    64	        baseUrl: String,
+    65	        model: String,
+    66	        temperature: Double,
+    67	        maxTokens: Int,
+    68	        apiKey: String?,
+    69	    ): AiProviderProfile {
+    70	        lateinit var saved: AiProviderProfile
+    71	        dataStore.edit { prefs ->
+    72	            val cur = read(prefs)
+    73	            val existing = cur.profiles.firstOrNull { it.id == id }
+    74	            val encrypted = when {
+    75	                apiKey != null -> cipher.encrypt(apiKey)
+    76	                existing != null -> existing.encryptedApiKey  // unchanged on edit
+    77	                else -> throw IllegalArgumentException("a new provider ($id) requires an API key")
+    78	            }
+    79	            saved = AiProviderProfile(id, name, kind, baseUrl, model, temperature, maxTokens, encrypted)
+    80	            val next = cur.profiles.filterNot { it.id == id } + saved
+    81	            val activeId = cur.activeId ?: id  // first provider becomes active
+    82	            prefs[KEY] = json.encodeToString(AiStoreState(next, activeId))
+    83	        }
+    84	        return saved
+    85	    }
+    86	
+    87	    /** Remove a profile. If it was active, the active selection moves to the first remaining (or null). */
+    88	    suspend fun delete(id: String) {
+    89	        dataStore.edit { prefs ->
+    90	            val cur = read(prefs)
+    91	            val next = cur.profiles.filterNot { it.id == id }
+    92	            val activeId = if (cur.activeId == id) next.firstOrNull()?.id else cur.activeId
+    93	            prefs[KEY] = json.encodeToString(AiStoreState(next, activeId))
+    94	        }
+    95	    }
+    96	
+    97	    /** Select the active provider (no-op if the id isn't present). */
+    98	    suspend fun setActive(id: String) {
+    99	        dataStore.edit { prefs ->
+   100	            val cur = read(prefs)
+   101	            if (cur.profiles.any { it.id == id }) prefs[KEY] = json.encodeToString(cur.copy(activeId = id))
+   102	        }
+   103	    }
+   104	
+   105	    /** Decrypt the key from a CAPTURED [profile] — snapshot-consistent (no live store read). The
+   106	     *  chat/test request path uses THIS with a profile from a single [snapshot], so it can't pair
+   107	     *  snapshot metadata with a concurrently-edited/deleted key. */
+   108	    fun apiKey(profile: AiProviderProfile): String = cipher.decrypt(profile.encryptedApiKey)
+   109	
+   110	    /** The decrypted API key for [id] via a live read, or null if absent. Convenience for UI flows
+   111	     *  that aren't mid-request; the request path should prefer [apiKey] (profile). */
+   112	    suspend fun apiKey(id: String): String? =
+   113	        list().firstOrNull { it.id == id }?.let { cipher.decrypt(it.encryptedApiKey) }
+   114	
+   115	    private fun read(prefs: Preferences): AiStoreState {
+   116	        val raw = prefs[KEY] ?: return AiStoreState()
+   117	        return runCatching { json.decodeFromString<AiStoreState>(raw) }.getOrDefault(AiStoreState())
+   118	    }
+   119	
+   120	    private fun AiStoreState.toSnapshot() = AiProviderSnapshot(profiles, activeId)
+   121	
+   122	    companion object {
+   123	        private val KEY = stringPreferencesKey("ai_providers_json")
+   124	    }
+   125	}
+
+exec
+/bin/zsh -lc "rg -n \"\\.save\\(\\)|vm::save|AiSettingsViewModel\\(\" android/app/src | head -80; rg -n \"fun AiProviderEditSheet|onSave\" android/app/src/main/kotlin/com/vreader/app/ai -g '*.kt'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+android/app/src/test/kotlin/com/vreader/app/opds/ui/OpdsSourcesViewModelTest.kt:90:        v.save(); advanceUntilIdle()
+android/app/src/test/kotlin/com/vreader/app/opds/ui/OpdsSourcesViewModelTest.kt:130:        v.save(); advanceUntilIdle()
+android/app/src/test/kotlin/com/vreader/app/ai/AiSettingsViewModelTest.kt:57:        AiSettingsViewModel(store, dispatcher) { _, _ -> FakeClient(result) }
+android/app/src/test/kotlin/com/vreader/app/ai/AiSettingsViewModelTest.kt:66:        vm.save(); advanceUntilIdle()
+android/app/src/androidTest/kotlin/com/vreader/app/opds/ui/OpdsUiRoundTripConnectedTest.kt:59:            sourcesVm.save()
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:20:class AiSettingsViewModel(
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt:55:fun AiProviderEditSheet(
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt:66:    onSave: () -> Unit = {},
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt:79:                Box(Modifier.sizeIn(minWidth = 48.dp, minHeight = 48.dp).clickable(enabled = state.canSave, onClick = onSave).testTag("ai-save"), contentAlignment = Alignment.CenterEnd) {
+
+exec
+/bin/zsh -lc "nl -ba dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx | sed -n '20,165p;185,285p'; nl -ba dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx | sed -n '165,260p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+    20	  { k: 'French',   glyph: 'Fr', script: 'latin' },
+    21	  { k: 'German',   glyph: 'De', script: 'latin' },
+    22	  { k: 'Italian',  glyph: 'It', script: 'latin' },
+    23	  { k: 'Arabic',   glyph: 'ع',  script: 'rtl' },
+    24	  { k: 'Russian',  glyph: 'Ru', script: 'cyrillic' },
+    25	];
+    26	
+    27	function BilingualSetupSheet({ theme, value, onChange, onClose, aiConfigured = true }) {
+    28	  const t = theme;
+    29	  const v = value || { lang: 'Chinese', granularity: 'paragraph' };
+    30	  const update = (k, val) => onChange({ ...v, [k]: val });
+    31	
+    32	  return (
+    33	    <Sheet theme={t} onClose={onClose} title="Bilingual mode" height={620}>
+    34	      <div style={{ padding: '12px 22px 28px' }}>
+    35	        {/* preview strip */}
+    36	        <BilingualPreview t={t} lang={v.lang}/>
+    37	
+    38	        {/* target language */}
+    39	        <div style={{ marginTop: 22 }}>
+    40	          <SectionLabel theme={t}>Target language</SectionLabel>
+    41	          <div style={{
+    42	            marginTop: 10, display: 'grid',
+    43	            gridTemplateColumns: 'repeat(3, 1fr)', gap: 8,
+    44	          }}>
+    45	            {BILINGUAL_LANGS.map(l => {
+    46	              const active = l.k === v.lang;
+    47	              return (
+    48	                <button key={l.k} onClick={() => update('lang', l.k)} style={{
+    49	                  display: 'flex', alignItems: 'center', gap: 8,
+    50	                  padding: '10px 10px', borderRadius: 12, border: 'none',
+    51	                  background: active
+    52	                    ? (t.isDark ? `${t.accent}26` : `${t.accent}14`)
+    53	                    : (t.isDark ? 'rgba(255,255,255,0.04)' : '#fff'),
+    54	                  boxShadow: active
+    55	                    ? `inset 0 0 0 1.5px ${t.accent}`
+    56	                    : (t.isDark ? `inset 0 0 0 0.5px ${t.rule}` : `inset 0 0 0 0.5px ${t.rule}`),
+    57	                  cursor: 'pointer',
+    58	                }}>
+    59	                  <span style={{
+    60	                    width: 22, height: 22, borderRadius: 6, flexShrink: 0,
+    61	                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    62	                    background: active ? t.accent : (t.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)'),
+    63	                    color: active ? '#fff' : t.ink, fontWeight: 700,
+    64	                    fontFamily: l.script === 'cjk' || l.script === 'rtl'
+    65	                      ? '"Songti SC", "Source Han Serif", serif' : 'inherit',
+    66	                    fontSize: l.script === 'cjk' ? 13 : 11,
+    67	                  }}>{l.glyph}</span>
+    68	                  <span style={{
+    69	                    fontSize: 12.5, color: t.ink, fontWeight: active ? 600 : 500,
+    70	                  }}>{l.k}</span>
+    71	                </button>
+    72	              );
+    73	            })}
+    74	          </div>
+    75	        </div>
+    76	
+    77	        {/* granularity */}
+    78	        <div style={{ marginTop: 22 }}>
+    79	          <SectionLabel theme={t}>Granularity</SectionLabel>
+    80	          <div style={{
+    81	            display: 'flex', marginTop: 10, borderRadius: 12,
+    82	            background: t.isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.05)',
+    83	            padding: 3,
+    84	          }}>
+    85	            {[
+    86	              { k: 'paragraph', label: 'Paragraph', sub: 'Translate after each ¶' },
+    87	              { k: 'sentence',  label: 'Sentence',  sub: 'Translate after each sentence' },
+    88	            ].map(o => (
+    89	              <button key={o.k} onClick={() => update('granularity', o.k)} style={{
+    90	                flex: 1, padding: '10px 10px', borderRadius: 10, border: 'none',
+    91	                background: v.granularity === o.k ? (t.isDark ? '#3a3530' : '#fff') : 'transparent',
+    92	                color: t.ink, fontFamily: 'inherit', cursor: 'pointer',
+    93	                boxShadow: v.granularity === o.k ? '0 1px 2px rgba(0,0,0,0.08)' : 'none',
+    94	                textAlign: 'center',
+    95	              }}>
+    96	                <div style={{ fontSize: 13, fontWeight: 600 }}>{o.label}</div>
+    97	                <div style={{ fontSize: 10.5, color: t.sub, marginTop: 1 }}>{o.sub}</div>
+    98	              </button>
+    99	            ))}
+   100	          </div>
+   101	        </div>
+   102	
+   103	        {/* AI provider strip */}
+   104	        <div style={{ marginTop: 22 }}>
+   105	          <SectionLabel theme={t}>Translation engine</SectionLabel>
+   106	          <div style={{
+   107	            marginTop: 8, padding: '12px 14px', borderRadius: 12,
+   108	            background: aiConfigured
+   109	              ? (t.isDark ? 'rgba(255,255,255,0.04)' : '#fff')
+   110	              : `${t.accent}10`,
+   111	            border: aiConfigured ? `0.5px solid ${t.rule}` : `0.5px solid ${t.accent}55`,
+   112	            display: 'flex', alignItems: 'center', gap: 12,
+   113	          }}>
+   114	            <div style={{
+   115	              width: 28, height: 28, borderRadius: 14,
+   116	              background: aiConfigured
+   117	                ? `linear-gradient(135deg, ${t.accent}, ${t.accent}aa)`
+   118	                : 'rgba(0,0,0,0.08)',
+   119	              display: 'flex', alignItems: 'center', justifyContent: 'center',
+   120	              flexShrink: 0,
+   121	            }}>
+   122	              <Icons.Sparkle size={14} color={aiConfigured ? '#fff' : t.sub} stroke={2}/>
+   123	            </div>
+   124	            <div style={{ flex: 1, minWidth: 0 }}>
+   125	              <div style={{ fontSize: 13.5, color: t.ink, fontWeight: 600 }}>
+   126	                {aiConfigured ? 'Claude · with this book\'s context' : 'No AI provider configured'}
+   127	              </div>
+   128	              <div style={{ fontSize: 11.5, color: t.sub, marginTop: 1 }}>
+   129	                {aiConfigured
+   130	                  ? 'Translations cached per paragraph, one page ahead.'
+   131	                  : 'Bilingual mode needs an AI provider to translate.'}
+   132	              </div>
+   133	            </div>
+   134	            <button style={{
+   135	              padding: '5px 11px', borderRadius: 100, border: 'none',
+   136	              background: aiConfigured
+   137	                ? (t.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)')
+   138	                : t.accent,
+   139	              color: aiConfigured ? t.ink : '#fff',
+   140	              fontFamily: 'inherit', fontSize: 11.5, fontWeight: 600, cursor: 'pointer',
+   141	              flexShrink: 0,
+   142	            }}>{aiConfigured ? 'Change…' : 'Set up'}</button>
+   143	          </div>
+   144	        </div>
+   145	
+   146	        {/* CTA */}
+   147	        <button onClick={onClose} style={{
+   148	          width: '100%', marginTop: 22, padding: '14px 0', borderRadius: 14,
+   149	          border: 'none', background: t.accent, color: '#fff',
+   150	          fontFamily: 'inherit', fontSize: 15, fontWeight: 600, cursor: 'pointer',
+   151	          boxShadow: `0 4px 14px ${t.accent}55`,
+   152	        }}>Turn on bilingual mode</button>
+   153	      </div>
+   154	    </Sheet>
+   155	  );
+   156	}
+   157	
+   158	function BilingualPreview({ t, lang }) {
+   159	  const samples = {
+   160	    Chinese:  '凡是有钱的单身汉，总想娶位太太，这已经成了一条举世公认的真理。',
+   161	    Japanese: '相当な財産を持っている独身の男性は妻を欲しがっているに違いない、というのは世間一般に認められた真理である。',
+   162	    Korean:   '재산이 많은 독신 남성에게 아내가 필요하다는 것은 누구나 인정하는 진리이다.',
+   163	    Spanish:  'Es una verdad universalmente reconocida que un hombre soltero en posesión de una buena fortuna necesita una esposa.',
+   164	    French:   'C\'est une vérité universellement reconnue qu\'un homme célibataire possédant une bonne fortune doit avoir besoin d\'une épouse.',
+   165	    German:   'Es ist eine allgemein anerkannte Wahrheit, dass ein lediger Mann im Besitz eines schönen Vermögens nach einer Frau verlangen muss.',
+   185	      <div style={{
+   186	        marginTop: 8, paddingLeft: 14, borderLeft: `2px solid ${t.accent}88`,
+   187	        fontFamily: ff,
+   188	        fontSize: 13, color: t.sub, lineHeight: 1.55,
+   189	        direction: lang === 'Arabic' ? 'rtl' : 'ltr',
+   190	      }}>{sample}</div>
+   191	    </div>
+   192	  );
+   193	}
+   194	
+   195	// ────────────────────────────────────────────────────
+   196	// Paragraph-interlinear renderer
+   197	// Used by the reader when bilingual mode is on. Renders source + translation
+   198	// stacked, one source paragraph followed by its translation.
+   199	// ────────────────────────────────────────────────────
+   200	function BilingualPageContent({ page, theme, fontFamily, fontSize, lineHeight, margin,
+   201	                                pageDir, animating, pageIdx, lang = 'Chinese' }) {
+   202	  const t = theme;
+   203	  const ff = fontFamily === 'serif'
+   204	    ? '"Source Serif 4", Georgia, "Times New Roman", serif'
+   205	    : '"Inter", -apple-system, system-ui, sans-serif';
+   206	  const translatedFF = (lang === 'Chinese' || lang === 'Japanese' || lang === 'Korean')
+   207	    ? '"Songti SC", "Source Han Serif", serif'
+   208	    : ff;
+   209	  const isRTL = lang === 'Arabic';
+   210	
+   211	  const animTransform = animating
+   212	    ? `translateX(${pageDir > 0 ? -8 : 8}%) ` : 'translateX(0) ';
+   213	  const animOpacity = animating ? 0 : 1;
+   214	
+   215	  // Mock translations for the sample P&P paragraphs (matches vreader-data.jsx PP_PAGES)
+   216	  const TRANSLATIONS = {
+   217	    Chinese: {
+   218	      'It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife.':
+   219	        '凡是有钱的单身汉，总想娶位太太，这已经成了一条举世公认的真理。',
+   220	      'However little known the feelings or views of such a man may be on his first entering a neighbourhood, this truth is so well fixed in the minds of the surrounding families, that he is considered as the rightful property of some one or other of their daughters.':
+   221	        '这样的单身汉，每逢新搬到一个地方，四邻八舍虽然完全不了解他的性情如何，见解如何，可是，既然这样的一条真理早已在人们心目中根深蒂固，因此人们总是把他看作自己某一个女儿理所应得的一笔财产。',
+   222	    },
+   223	  };
+   224	  const fallback = (en) => '【' + (lang === 'Chinese' ? '译文' : lang) + '】 ' + en.slice(0, 60) + '…';
+   225	
+   226	  return (
+   227	    <div style={{
+   228	      position: 'absolute', top: 76, bottom: 56, left: margin, right: margin,
+   229	      overflow: 'hidden', transform: animTransform, opacity: animOpacity,
+   230	      transition: 'transform 0.28s cubic-bezier(0.32, 0.72, 0, 1), opacity 0.22s ease-out',
+   231	      direction: isRTL ? 'ltr' : 'ltr', // source is always LTR
+   232	    }}>
+   233	      {(pageIdx === 0 || page.chapter !== PP_PAGES[(pageIdx - 1 + PP_PAGES.length) % PP_PAGES.length].chapter) && (
+   234	        <div style={{
+   235	          fontFamily: '"Source Serif 4", Georgia, serif',
+   236	          fontSize: 13, color: t.sub, letterSpacing: 2,
+   237	          textTransform: 'uppercase', textAlign: 'center',
+   238	          marginBottom: 18, marginTop: 8, fontWeight: 500,
+   239	        }}>{page.chapter}</div>
+   240	      )}
+   241	      {page.paragraphs.map((para, i) => {
+   242	        const tr = (TRANSLATIONS[lang] && TRANSLATIONS[lang][para]) || fallback(para);
+   243	        return (
+   244	          <div key={i} style={{ marginBottom: lineHeight * fontSize * 0.55 }}>
+   245	            <p style={{
+   246	              fontFamily: ff, fontSize, lineHeight, color: t.ink, margin: 0,
+   247	              textIndent: i === 0 ? 0 : `${fontSize * 1.4}px`,
+   248	              textAlign: 'justify', hyphens: 'auto',
+   249	            }}>
+   250	              {i === 0 && (
+   251	                <span style={{
+   252	                  fontFamily: '"Source Serif 4", Georgia, serif',
+   253	                  fontSize: fontSize * 2.6, lineHeight: 0.85,
+   254	                  float: 'left', marginRight: 6, marginTop: 4,
+   255	                  color: t.accent, fontWeight: 600,
+   256	                }}>{para[0]}</span>
+   257	              )}
+   258	              {i === 0 ? para.slice(1) : para}
+   259	            </p>
+   260	            <p style={{
+   261	              fontFamily: translatedFF,
+   262	              fontSize: fontSize * 0.88, lineHeight: 1.55,
+   263	              color: t.sub, margin: '6px 0 0',
+   264	              paddingLeft: fontSize * 1.0, paddingRight: isRTL ? 0 : 0,
+   265	              direction: isRTL ? 'rtl' : 'ltr',
+   266	              textAlign: isRTL ? 'right' : 'left',
+   267	              borderLeft: isRTL ? 'none' : `2px solid ${t.accent}55`,
+   268	              borderRight: isRTL ? `2px solid ${t.accent}55` : 'none',
+   269	              paddingLeft: isRTL ? 0 : fontSize * 0.7,
+   270	              paddingRight: isRTL ? fontSize * 0.7 : 0,
+   271	            }}>{tr}</p>
+   272	          </div>
+   273	        );
+   274	      })}
+   275	    </div>
+   276	  );
+   277	}
+   278	
+   279	// ────────────────────────────────────────────────────
+   280	// The "EN ↔ 中" pill shown in the reader top chrome when bilingual is on
+   281	// ────────────────────────────────────────────────────
+   282	function BilingualPill({ theme, lang }) {
+   283	  const t = theme;
+   284	  const glyph = (BILINGUAL_LANGS.find(l => l.k === lang) || BILINGUAL_LANGS[0]).glyph;
+   285	  return (
+   165	  return (
+   166	    <div style={{ padding: '14px 18px 28px' }}>
+   167	      {/* why-you're-here context — the bilingual thread, kept visible */}
+   168	      <div style={{
+   169	        display: 'flex', alignItems: 'center', gap: 10,
+   170	        padding: '10px 12px', borderRadius: 10,
+   171	        background: `${t.accent}10`, border: `0.5px solid ${t.accent}33`,
+   172	        marginBottom: 18,
+   173	      }}>
+   174	        <div style={{
+   175	          width: 22, height: 22, borderRadius: 11, flexShrink: 0,
+   176	          background: `${t.accent}1f`, display: 'flex', alignItems: 'center', justifyContent: 'center',
+   177	        }}>
+   178	          <Icons.Translate size={13} color={t.accent} stroke={1.9}/>
+   179	        </div>
+   180	        <div style={{ fontSize: 11.5, color: t.ink, lineHeight: 1.35 }}>
+   181	          Choose the provider <b style={{ fontWeight: 600 }}>bilingual mode</b> will use to translate this book.
+   182	        </div>
+   183	      </div>
+   184	
+   185	      {empty ? (
+   186	        <div style={{ textAlign: 'center', padding: '24px 12px 8px' }}>
+   187	          <div style={{
+   188	            width: 54, height: 54, borderRadius: 27, margin: '0 auto 14px',
+   189	            background: `linear-gradient(135deg, ${t.accent}, ${t.accent}aa)`,
+   190	            display: 'flex', alignItems: 'center', justifyContent: 'center',
+   191	            boxShadow: `0 6px 18px ${t.accent}44`,
+   192	          }}>
+   193	            <Icons.Sparkle size={26} color="#fff" stroke={1.7}/>
+   194	          </div>
+   195	          <div style={{ fontFamily: AIPE_SERIF, fontSize: 18, fontWeight: 600, color: t.ink }}>
+   196	            No providers yet
+   197	          </div>
+   198	          <div style={{ fontSize: 12.5, color: t.sub, lineHeight: 1.5, maxWidth: 268, margin: '6px auto 20px' }}>
+   199	            Add Claude, OpenAI, or any OpenAI-compatible endpoint. Your API key is stored in the device keychain — never synced.
+   200	          </div>
+   201	          <button onClick={onAdd} style={{
+   202	            display: 'inline-flex', alignItems: 'center', gap: 7,
+   203	            padding: '11px 20px', borderRadius: 100, border: 'none',
+   204	            background: t.accent, color: '#fff',
+   205	            fontFamily: 'inherit', fontSize: 14, fontWeight: 600, cursor: 'pointer',
+   206	            boxShadow: `0 4px 14px ${t.accent}55`,
+   207	          }}>
+   208	            <Icons.Plus size={17} color="#fff" stroke={2.2}/>Add provider
+   209	          </button>
+   210	        </div>
+   211	      ) : (
+   212	        <div>
+   213	          <SectionLabel theme={t}>Providers</SectionLabel>
+   214	          <div style={{
+   215	            marginTop: 8, borderRadius: 14, overflow: 'hidden',
+   216	            background: t.isDark ? 'rgba(255,255,255,0.04)' : '#fff',
+   217	            boxShadow: t.isDark ? 'none' : '0 1px 0 rgba(0,0,0,0.04)',
+   218	          }}>
+   219	            {providers.map((p) => (
+   220	              <ProviderRow key={p.id} theme={t} name={p.name} model={p.model}
+   221	                selected={p.id === selectedId} onClick={() => onSelect && onSelect(p.id)}/>
+   222	            ))}
+   223	            <div onClick={onAdd} style={{
+   224	              display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px', cursor: 'pointer',
+   225	            }}>
+   226	              <div style={{
+   227	                width: 30, height: 30, borderRadius: 8, flexShrink: 0,
+   228	                background: t.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)',
+   229	                display: 'flex', alignItems: 'center', justifyContent: 'center',
+   230	              }}>
+   231	                <Icons.Plus size={18} color={t.accent} stroke={2.2}/>
+   232	              </div>
+   233	              <div style={{ flex: 1, fontSize: 15, color: t.accent, fontWeight: 500 }}>Add provider</div>
+   234	            </div>
+   235	          </div>
+   236	          <div style={{ fontSize: 11.5, color: t.sub, lineHeight: 1.45, padding: '10px 4px 0' }}>
+   237	            Tap a provider to use it for translating this book.
+   238	          </div>
+   239	        </div>
+   240	      )}
+   241	    </div>
+   242	  );
+   243	}
+   244	
+   245	function AIProvidersSheet({ theme, providers = [], selectedId, onBack, onAdd, onSelect, trailing, height = 620 }) {
+   246	  return (
+   247	    <NavSheet theme={theme} height={height} title="AI Providers" backLabel="Bilingual" onBack={onBack} trailing={trailing}>
+   248	      <AIProvidersSheetBody theme={theme} providers={providers} selectedId={selectedId} onAdd={onAdd} onSelect={onSelect}/>
+   249	    </NavSheet>
+   250	  );
+   251	}
+   252	
+   253	// ────────────────────────────────────────────────────
+   254	// ALTERNATIVE C — inline expansion of the engine strip.
+   255	// Collapsed = the unconfigured strip; expanded = a minimal provider+key form
+   256	// in place. Shows why it can't host the real editor without diverging.
+   257	// ────────────────────────────────────────────────────
+   258	function EngineStripInline({ theme, expanded }) {
+   259	  const t = theme;
+   260	  const seg = ['Claude', 'OpenAI', 'Custom'];
+
+exec
+/bin/zsh -lc "nl -ba dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md | sed -n '188,212p;238,268p;355,378p'; nl -ba android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt | sed -n '1,245p'; rg -n \"data class BookEntity|@Entity\\(|fingerprintKey|foreignKeys|Index\\(\" android/app/src/main/kotlin/com/vreader/app/data -g '*.kt'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+   188	- `bilingual/BilingualViewModel.kt` — `StateFlow<BilingualUiState>` with `enabled`, `targetLanguage`, `granularity`, `needsSetupSheet`, `aiConfigured`, `translationsByUnit`, `inFlightUnits`, `unavailableUnits`, `errorUnit`. Setters + `dismissSetupSheet`, `onPositionChanged(charOffsetUTF16)`, `retryUnit(unit)`, and the EPUB direct-block entry `onEpubBlocksEnumerated(unit, blocks)` (M1, below). Generation/epoch-guarded prefetch (current + next unit); a **per-unit single-flight job registry** (M2); dual-cancellation handling (M2). Port of iOS `BilingualReadingViewModel` (`prefetchTasks: [TranslationUnitID: Task]`, `BilingualReadingViewModel.swift:141`) + `+Prefetch`. Split to `BilingualPrefetchController.kt` if it nears ~300 lines. No `style` field.
+   189	
+   190	**Room (translation cache):**
+   191	
+   192	- `data/ChapterTranslationEntity.kt` — `@Entity(tableName="chapter_translations", indices=[Index("bookKey")], foreignKeys=[FK→books.fingerprintKey ON DELETE CASCADE])`. **`@PrimaryKey val lookupKey: String`** (Room requires a PK; project pattern `@PrimaryKey` + `@Upsert`, verified `BookEntity` `@PrimaryKey val fingerprintKey`, Entities.kt:24). `lookupKey` = `bookKey|unitStorageKey|targetLanguage|promptVersion`. Columns: `lookupKey` (PK), `bookKey`, `unitStorageKey`, `targetLanguage`, `promptVersion`, `translatedJson`, `sourceParagraphCount`, `createdAt`. Mirrors iOS `ChapterTranslationRecord.lookupKey` (`book|unit|lang|prompt`, profile-agnostic — Bug #342). `sourceParagraphCount` is load-bearing for H2 (stores the enumerate's count on the `translatePreSegmented` path so `cachedTranslation(expectedSegmentCount:)` restores). **The exact `MIGRATION_8_9` DDL is authored in WI-2 — see below.**
+   193	- `data/ChapterTranslationDao.kt` — `getByLookupKey(key)`, `@Upsert suspend fun upsert(row)`, `deleteByLookupKey(key)`.
+   194	- `bilingual/ChapterTranslationStore.kt` — coroutine wrapper returning a `CachedTranslation` (segments decoded from JSON), keeping Room entities off the boundary (iOS `ChapterTranslationStore` precedent).
+   195	
+   196	**Cache-identity (reconciled with iOS parity):** the 4-part key `book|unit|lang|promptVersion` is profile-AGNOSTIC / style-agnostic (Bug #342). Style is descoped (§3) so no `s=` component. **Granularity is paragraph-only in v1** (round-4 H3): `promptVersion = "bilingual-v1|g=paragraph"` in v1 (the `g=` component is always `paragraph`). The composite `g=` slot is retained in the key format so a future granularity is a different cache row by construction (closes the iOS #344 "sentence silently ignored" class ahead of time), but v1 never emits `g=sentence`. A language change cancels in-flight jobs, bumps the VM generation, clears shaped `translationsByUnit`, and forces a correctly-keyed re-fetch (WI-6).
+   197	
+   198	**DI / factory (verified live):** `AiProviderFactory` is an `object` with `create(profile, apiKey, dispatcher = Dispatchers.IO): AiClient` (verified, `AiProviderFactory.kt:10`). `ChapterTranslationPrefetcher` takes its OWN injected `clientFactory: (AiProviderProfile, String) -> AiClient` param **defaulting to `AiProviderFactory::create`**, overridden with a fake in tests.
+   199	
+   200	**UI (Compose — every state depicted, reproducing `vreader-bilingual.jsx` + `vreader-ai-provider-entry.jsx`):**
+   201	
+   202	- `bilingual/BilingualSetupSheet.kt` — reproduces `vreader-bilingual.jsx`'s `BilingualSetupSheet` (lines 27–156) EXACTLY, with the granularity divergence: header; a preview strip (`BilingualPreview`); a language grid over `BILINGUAL_LANGS` (glyph tiles, selected accent); a **Granularity** segmented control **descoped to Paragraph-only in v1** ("Translate after each ¶"; the Sentence option is not rendered in v1 — round-4 H3, tracked by the sentence design gate); a **Translation engine** strip (configured: "Claude · with this book's context" + "Change…"; unconfigured: "No AI provider configured" + "Bilingual mode needs an AI provider to translate." + "Set up"); the "Turn on bilingual mode" CTA. **No Style control, no provider/model card, no term-overrides toggle, no cost footer** (those belong to the `vreader-ai-android.jsx` sheet, not reproduced — §3). The `aiConfigured` flag comes from `BilingualAiReadiness.resolve`. The "Set up"/"Change…" CTA routes to `ReaderAiProvidersSheet` (wired in WI-9).
+   203	- `bilingual/ReaderAiProvidersSheet.kt` — **NEW (folded in; the Android analog of iOS `ReaderAIProvidersView`; round-4 High-4 rewritten).** The Variant A scoped in-reader AI Providers sheet, reproducing `vreader-ai-provider-entry.jsx` `AIProvidersSheet` + `AIProvidersSheetBody` + `NavSheet` (nav bar `‹ Bilingual` leading + centered "AI Providers" title, `vreader-ai-provider-entry.jsx:247`). **Round-4 High-4: the fold-in CANNOT be "reuse `AiProviderListScreen` verbatim."** `AiProviderListScreen` owns its OWN full `NavScreen(title="AI Providers", onBack)` (`AiProviderListScreen.kt:59`), a generic `AiEmptyState` ("Connect an AI provider" / "One key unlocks…", :84/:87), and **row-tap-as-EDIT** (`ProviderRow` → `onEdit(p.id)`, :105) with **no checked-active-tap-to-select** — it cannot reproduce the designed reader-scoped `‹ Bilingual` nav, the bilingual-context empty state, the checked-active row, or tap-to-SELECT. So the fold-in splits into **(a)/(b)/(c)**:
+   204	  - **(a) EDITOR reused VERBATIM.** `AiProviderEditSheet` (the canonical add/edit modal, Kind / Name / Endpoint / Sampling / API Key / Test Connection) is presented UNCHANGED from the #118 Library path — that reuse is confirmed fine (`reader-ai-provider-entry.md:49–52`, :63–65).
+   205	  - **(b) The scoped LIST is a NEW reader-specific presentation** (`ReaderAiProvidersList`, in this file) built over the **SHARED `AiSettingsViewModel` state** (`listState`, verified `AiSettingsViewModel.kt:26`) + shared row/cell components, reproducing: the reader-scoped nav (`‹ Bilingual` back label, "AI Providers" title — `NavSheet` at jsx:247, NOT `AiProviderListScreen`'s own `NavScreen`); the **bilingual-context empty state** ("Choose the provider bilingual mode will use to translate this book." context strip + "No providers yet" + "Add provider" CTA — jsx:180–209); the **checked-active row** (`selected={p.id === selectedId}` — jsx:221; the live `AiProviderListState`/`AiProviderRow` already carries `active` per row, `AiSettingsViewModel.kt:30`); and **tap-to-SELECT** (`onSelect(p.id)` → `vm.setActive(id)` — jsx:221/237). It does **NOT** reuse `AiProviderListScreen`'s `NavScreen`/chrome/`AiEmptyState`/`ProviderRow`-tap-edit.
+   206	  - **(c) A save-result seam** (round-4 High-4): `AiSettingsViewModel.save()` today returns Unit and upserts async (generates `s.id ?: UUID.randomUUID().toString()` *inside* the launched coroutine, then `_edit.value = null`, no saved ID — `AiSettingsViewModel.kt:85–97`), so WI-AIP cannot deterministically `setActive(savedId)` + pop-on-success by reusing it verbatim (popping immediately races the async upsert; observing list state can't distinguish the new profile). **Note:** `AiProviderStore.upsert` ALREADY returns the saved profile (`suspend fun upsert(...): AiProviderProfile`, "Returns the saved profile", `AiProviderStore.kt:58/70/84`) — the ID is present at the store layer; only the VM discards it. So the seam is an **additive completion/result signal on `AiSettingsViewModel.save()`** (or a thin WI-AIP wrapper) returning the saved provider ID (from `store.upsert(...).id`), so WI-AIP can `setActive(savedId)` + pop-on-success **after** the upsert commits — no race. The #118 VM is currently production-UNWIRED (only test-referenced — verified), and this feature wires it to production for the FIRST time, so an additive save-result seam is safe and appropriate.
+   207	  - **Behavior per the nav model:** empty → "Add provider" → `AiProviderEditSheet` → Save → `save()` returns the saved ID → `store.setActive(savedId)` (first-provider-active is already the store's default `activeId = cur.activeId ?: id`, AiProviderStore.kt:81; the explicit `setActive(savedId)` guarantees the freshly-saved provider is the engine even if others existed) → **pop the whole stack** back to the bilingual sheet, engine strip now "Claude · configured / Change…". `‹ Bilingual` without adding → unconfigured, **no state mutated**. "Change…" → the SAME sheet, populated, current provider checked, tap a row → `setActive`. No consent card, no feature-flag toggle, no readiness tracker (iOS #82, deferred).
+   208	- `bilingual/BilingualInterlinearBody.kt` — the Compose render surface for the **TXT/MD host ONLY** (round-2 M2). Renders per the **one-lazy-item-per-chunk `Column`** H2 render contract (source chunk unchanged as the first `Column` child; translation(s) anchored to chunk `i` as muted non-registered `Text` siblings in the SAME `Column`): muted `Text`, accent left-border, `fontSize*0.88`, CJK font for cjk scripts, RTL handling for Arabic (per `BilingualPageContent`, `vreader-bilingual.jsx:200–277`). Consumes the host-neutral `BilingualRenderState` DTO. Loading state ("Translating chapter… N%" + per-segment dim), error state ("Couldn't translate" + Retry), partial/offline (`unavailableUnits`): source-only silent fallback (iOS Decision 2). Includes the **translation gesture-exclusion** (round-4 H2) so a long-press on a translation child does not route to `hitAt`'s nearest-source-chunk fallback. **NOT the EPUB render surface.**
+   209	- `bilingual/BilingualRenderState.kt` — the host-neutral state DTO shared by the Compose body and the EPUB adapter (round-2 M2): per-unit `{ segments: List<String>?, phase: Loaded|Loading(fraction)|Error|SourceOnly }`. Compose and EPUB share the state/value types, NOT the composable body.
+   210	- `bilingual/EpubBilingualJs.kt` (WI-0-gated) — the EPUB render surface (round-2 M2). Pure Kotlin builder producing JS strings for `navigator.evaluateJavascript(...)`: `enumScript` (enumerate current-resource leaf blocks → JSON `[{id,text}]`), `injectScript(blockId, translationText)` (translation DOM node after the block; CSP-safe: `textContent`/`createTextNode`, never `innerHTML` string-concat; RTL/CJK via class + injected `<style>`), `clearScript()` (idempotent removal). Escaping done in Kotlin (JSON-encode every interpolated string). No Compose. Consumes `BilingualRenderState`.
+   211	- `bilingual/EpubBilingualController.kt` (WI-0-gated) — **the single owner of EPUB units (M1, below).** The runtime actor that serializes enumerate→(cache-restore|translate)→inject/clear against the navigator using WI-0's chosen mechanism (a single mutex OR a monotonic navigator-session token); checks the session token after every suspended JS/AI call; clears BEFORE publication teardown; re-applies on the identified production re-apply signal.
+   212	- `bilingual/BilingualPill.kt` — the `EN ↔ 中` reader-top-chrome pill (per `vreader-reader.jsx` + `vreader-bilingual.jsx` `BilingualPill`:282–305). Rendered by #132's top chrome; #131 provides the composable, #132's surface hosts it (§4).
+   238	
+   239	- **Dual-cancellation across the service/VM boundary:** both the service AND the VM handle **BOTH** native `CancellationException` **AND** the typed `ChapterTranslationError.Cancelled` **before** generic error mapping — matching iOS `ChapterTranslationService.swift:359–364` (which catches `is CancellationError` and `ChapterTranslationError.cancelled` separately, both re-throwing `cancelled`). A cancelled stale request MUST NOT surface as `errorUnit` (it is discarded).
+   240	- **Per-unit single-flight job registry (VM):** a `prefetchTasks: MutableMap<TranslationUnitId, Job>` (iOS `prefetchTasks: [TranslationUnitID: Task]`, `BilingualReadingViewModel.swift:141`, cancelled/removed on disable/unit-change at :165). A NEW request for a unit **cancels-or-joins** the prior job (a stale prior is cancelled and awaited so it cannot run overlapping translations or Room writes), keyed by unit. Rapid retry/navigation cannot run overlapping translations for the same unit. `retryUnit(unit)` goes through the same registry. Tests: a mid-flight cancel discards (no `errorUnit`, no partial cache row); a rapid re-trigger for the same unit does not double-write.
+   241	
+   242	### Modified files
+   243	
+   244	- `data/VReaderDatabase.kt` — add `ChapterTranslationEntity` to `@Database entities`, bump `version` **8 → 9** (the live DB is v8, migrations `MIGRATION_1_2`..`MIGRATION_7_8`, `ALL_MIGRATIONS` ends at `MIGRATION_7_8` — verified VReaderDatabase.kt:29,224–228), add **`MIGRATION_8_9`** (exact DDL below — gap A), **append `MIGRATION_8_9` to `ALL_MIGRATIONS` after `MIGRATION_7_8`**, add `abstract fun chapterTranslationDao()`. Purely additive.
+   245	
+   246	  **`MIGRATION_8_9` exact DDL (gap A — BINDING; modeled on the verified `MIGRATION_6_7` `search_index_state` shape at VReaderDatabase.kt:154–169, whose DDL Room's PRAGMA validation already accepts):**
+   247	
+   248	  ```
+   249	  val MIGRATION_8_9: Migration = object : Migration(8, 9) {
+   250	      override fun migrate(db: SupportSQLiteDatabase) {
+   251	          db.execSQL(
+   252	              "CREATE TABLE IF NOT EXISTS `chapter_translations` (" +
+   253	                  "`lookupKey` TEXT NOT NULL, " +
+   254	                  "`bookKey` TEXT NOT NULL, " +
+   255	                  "`unitStorageKey` TEXT NOT NULL, " +
+   256	                  "`targetLanguage` TEXT NOT NULL, " +
+   257	                  "`promptVersion` TEXT NOT NULL, " +
+   258	                  "`translatedJson` TEXT NOT NULL, " +
+   259	                  "`sourceParagraphCount` INTEGER NOT NULL, " +
+   260	                  "`createdAt` INTEGER NOT NULL, " +
+   261	                  "PRIMARY KEY(`lookupKey`), " +
+   262	                  "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+   263	                  "ON UPDATE NO ACTION ON DELETE CASCADE )"
+   264	          )
+   265	          db.execSQL(
+   266	              "CREATE INDEX IF NOT EXISTS `index_chapter_translations_bookKey` " +
+   267	                  "ON `chapter_translations` (`bookKey`)"
+   268	          )
+   355	**WI-3 (foundational): `ChapterTranslationService`** against a fake `AiClient`. Both `cachedTranslation` overloads (incl. the `expectedSegmentCount` divergence restore — H2) + `translate` + `translatePreSegmented`. **Dual-cancellation (native + typed `Cancelled`) BEFORE generic mapping (M2).** Deps: WI-1, WI-2. Tests: cache hit → zero client calls; miss → translate + write; decode fail → per-segment fallback; one-chunk fail → source-only that chunk (others translated, NOT cached); all-chunks fail → throw; native-cancel → `Cancelled` (no write); typed-`Cancelled`-from-chunk → `Cancelled` (no write); ensureActive-before-write; `AiError` mapping incl. `Config`/`InsecureUrl` → `ProviderFailed`; `translatePreSegmented` full-success caches under the enumerate count; partial degrade NOT cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` returns on stored-count match, null on mismatch, needs no provider.
+   356	
+   357	**WI-4a (foundational): `ChapterTextProvider` (TXT/MD) + `ChapterTranslationPrefetcher` + `BilingualAiReadiness`.** `TxtChapterTextProvider` builds the document-global segment `Utf16Span`s once (via `paragraphRanges` — paragraph only, H1/H3), groups into windows, resolves `unitContaining(charOffsetUTF16)` via segment-start binary search, `sourceSegments(unit)`. Prefetcher: `prefetch` + `prefetchDirect` + `cachedDirect`; resolves active profile from `snapshot()`, decrypts snapshot-consistent, builds client via the injected factory param (default `AiProviderFactory::create`), constructs `AiRequest` with **`model = profile.model.ifBlank { profile.kind.defaultModel }` (M3)**. Readiness = active profile with non-empty decrypted key; **cipher failure → not-ready, never a crash.** Fake store + fake factory. Deps: WI-1, WI-3. Tests (all `Utf16Span`-based): unit resolution + clamp + empty; **one-chunk document (no trailing newline) → its segment translation renders, not dropped (H1)**; **final-chunk anchor → renders (H1)**; **exact-boundary → correct anchor (H1)**; **EOF anchor (`span.endExclusive == text.length`) → last chunk, no clamp-collapse (H1)**; paragraph spanning MANY chunks → one segment/one unit, anchored to the last chunk (Low-2); a >4000-char paragraph hard-split across chunks → one segment; CR/LF/CRLF; MD markers; locator→unit mapping; `unitAfter` end→null; **source-byte parity while disabled**; cache-hit-no-profile still returns (#306); no-profile miss → `ProviderFailed`; `prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls; **blank `profile.model` → `AiRequest.model == kind.defaultModel` (M3 regression)**; readiness true/false; empty-key → false; no-active-with-profiles-present → false (H3); cipher-throw → readiness false (no crash). (Sentence-multi-in-one-chunk is NOT a v1 render test — the v1 provider uses `paragraphRanges` only; `sentenceRanges` behavior is covered in WI-1's reserved-foundational unit tests.)
+   358	
+   359	**WI-4b (foundational — shared DI/factory, incl. `AiProviderStore` in `AppContainer`): AppContainer bilingual + AI-config graph.** `AppContainer` **now constructs `AiProviderStore`** (DataStore + #116 `KeystoreSecretCipher`, following the `readerSettingsStore` convention — this is #131's change, not an external feature's) and provides `ChapterTranslationStore`, `PerBookBilingualStore`, `ChapterTranslationService`, `ChapterTranslationPrefetcher`, an `AiSettingsViewModel` factory (for WI-AIP), and the `BilingualViewModel` factory. Deps: **WI-4a** (no external dep — #136 closed). Tests: container resolves the bilingual + AI-config graph; `AiProviderStore` resolves and round-trips a profile; the prefetcher's injected factory defaults to `AiProviderFactory::create`.
+   360	
+   361	**WI-5 (behavioral): `PerBookBilingualStore` + `BilingualViewModel` state core.** Store per book (enabled/targetLanguage/granularity — granularity pinned `paragraph` in v1, no style); VM setters (persist + first-enable `needsSetupSheet`); `aiConfigured` from `BilingualAiReadiness.resolve` over an injected snapshot; language change clears cache-shaped state + bumps generation. Injected prefetcher/snapshot seams (Medium-4). Turbine tests: first-enable raises sheet; re-enable persisted does not; disable clears; language change resets; `aiConfigured` true/false from readiness; round-trip through store; no style field; granularity persists as `paragraph`. Deps: WI-1 (+ store).
+   362	
+   363	**WI-6 (behavioral): VM prefetch trigger + generation/cancellation + single-flight (M2).** `onPositionChanged(charOffsetUTF16)` derives current unit (TXT/MD only), dedupes, prefetches current+next; a monotonic position-request sequence checked after every suspension; **per-unit single-flight `prefetchTasks: Map<TranslationUnitId, Job>` (a new request cancels/joins the prior — M2)**; a captured language/provider snapshot per launch; generation bumps on disable/language/unit-change discard stale; **BOTH `CancellationException` AND typed `ChapterTranslationError.Cancelled` handled BEFORE generic error mapping (M2)**; a cancelled stale request does NOT surface as `errorUnit`; `Offline`→`unavailableUnits`; transient failure leaves unit unfetched + clears anchor to retry; `retryUnit` routes through the registry. The EPUB `onEpubBlocksEnumerated` entry is present but EPUB prefetch is owned by the controller (Medium-1); the VM's position-driven `prefetch` dispatches TXT/MD units only. Fake prefetcher (Medium-4 seam). Deps: WI-4a, WI-4b, WI-5. Tests: current+next on unit change; same-unit no-op; cancel-mid discards stale (no `errorUnit`); typed-`Cancelled` discards (not `errorUnit`); rapid re-trigger same unit → single-flight, no double-write; offline→unavailable; failure→retry-able; `retryUnit` re-fetches.
+   364	
+   365	**WI-7a (behavioral): Compose UI — setup sheet + interlinear body (TXT/MD) + pill.** Reproduce `vreader-bilingual.jsx` (setup sheet: language grid / **Paragraph-only Granularity control (round-4 H3)** / preview / engine strip configured+unconfigured; body: the translation rendered **inside the anchor chunk's `Column` as a muted non-registered `Text` child** per the round-4 H2 render contract — translated / loading N%+dimmed / error+Retry / offline source-only; pill). Consumes the host-neutral `BilingualRenderState` DTO. Light+dark. Compose UI tests each state, incl. **paragraph interlinear renders a translation child after a paragraph's last source chunk (depicted)**; **the setup-sheet Granularity control shows Paragraph only, no Sentence option (H3)**. Deps: WI-5 (state shape). NO Style control; the unconfigured "Set up" CTA renders and (in WI-9) routes to the Variant A sheet.
+   366	
+   367	**WI-7b (behavioral, CONDITIONAL — only if WI-0 = go): EPUB render adapter (DOM injection, NOT Compose — M2) + direct-block ownership (M1).** `EpubBilingualJs` (enum/inject/clear JS builders, CSP-safe escaping) + `EpubBilingualController` (the serialization actor / session token AND the **single-owner enumerate→cachedDirect/prefetchDirect→guarded-commit sequence — Medium-1**) + `EpubChapterTextProvider`, wired into `ReaderActivity`, driving DOM from the shared `BilingualRenderState` DTO. Uses `prefetchDirect`/`cachedDirect` for the count-divergence path (H2). Depends on WI-6 (VM state) and WI-4b (DI); the WI-7a UI dependency is only the shared `BilingualRenderState`/value types. Connected test on a real EPUB (seeded cache): enable → injects; disable → cleared; reflow/href-change/fragment-recreation/activity-recreation → re-applies from cache (zero provider calls) via `cachedDirect`; count-divergence handled (direct path); **the regular TXT/MD prefetch path is never invoked for an EPUB unit (Medium-1)**. Unit tests: JS escaping/CSP-safe insertion, RTL/CJK style, empty translations, loading cleanup, idempotent replacement, source-only fallback, stale-session-token commit discarded (no `errorUnit`). Deps: WI-0, WI-3, WI-4a, WI-4b, WI-6, (shared types from WI-7a). (If WI-0 = no-go, dropped; box D ships TXT/MD-only, tracked.)
+   368	
+   369	**WI-AIP (behavioral — the folded-in Variant A AI Providers sheet; round-4 H4 rewritten): `ReaderAiProvidersSheet`.** The scoped in-reader "AI Providers" push sheet (nav bar `‹ Bilingual` + "AI Providers" title) reproducing `vreader-ai-provider-entry.jsx` `AIProvidersSheet`/`AIProvidersSheetBody`/`NavSheet`. Per round-4 H4:
+   370	  - **(a)** present `AiProviderEditSheet` VERBATIM from #118 (Kind/Name/Endpoint/Sampling/API Key/Test Connection unchanged).
+   371	  - **(b)** a NEW `ReaderAiProvidersList` presentation over the SHARED `AiSettingsViewModel.listState` (verified `AiSettingsViewModel.kt:26`; each `AiProviderRow` already carries `active`, :30) + shared row/cell components — reproducing the reader-scoped `‹ Bilingual` nav (`NavSheet`, jsx:247, NOT `AiProviderListScreen`'s `NavScreen`), the bilingual-context empty state ("Choose the provider bilingual mode will use to translate this book." + "No providers yet" + "Add provider" — jsx:180–209), the **checked-active row** (`selected = row.active` — jsx:221), and **tap-to-SELECT** (`onSelect(id) → vm.setActive(id)` — jsx:221/237). It does NOT reuse `AiProviderListScreen`'s NavScreen/chrome/`AiEmptyState`/`ProviderRow`-tap-edit.
+   372	  - **(c)** the **save-result seam**: `AiSettingsViewModel.save()` (or a thin WI-AIP wrapper) is extended to return the saved provider ID (from `store.upsert(...).id`, which the store already returns — `AiProviderStore.kt:58/84`), so on first Save → `store.setActive(savedId)` → pop the whole stack back to the bilingual sheet (engine strip now "configured / Change…"), **deterministically, after the upsert commits (no race)**.
+   373	  `‹ Bilingual` without adding → unconfigured, no state mutated. "Change…" → populated list, current provider checked, tap row → `setActive`. No consent/flag surface (Android has none). Deps: WI-4b (for `AiProviderStore` + `AiSettingsViewModel` in `AppContainer`), WI-7a (bilingual sheet host). Tests (Compose + connected): the scoped list renders **`‹ Bilingual` back label** + **bilingual-context empty copy** + **checked active row** + **tap-selects (`setActive`)**; empty → Add → Save → **save→result-id→`setActive`→pop deterministic (no race)** → bilingual strip configured; `‹ Bilingual` without adding → strip unconfigured, snapshot unchanged; "Change…" → populated, current checked; editor reused verbatim (no divergent form).
+   374	
+   375	**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into the `items(count = document.chunkCount, key = { it })` loop as **muted non-registered translation `Text` children inside each anchor chunk's wrapping `Column`, source chunk byte-unchanged, the loop + keys UNCHANGED so lazy-index==chunk-index is preserved (round-4 H2)** + the translation **gesture-exclusion** (round-4 H2) + position-change (`charOffsetUTF16`) + setup-sheet. `originalFormat`-gated (TXT/MD). Uses WI-4b's DI. **#129 VERIFIED — straight edit.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2)**; **highlights/annotation-washes/read-aloud-wash still key off source chunks (H2)**; **with bilingual ON — position-save round-trips to the same chunk; bookmark/search/scrubber/TTS jumps land on the correct chunk (lazy-index==chunk-index preserved — round-4 H2)**; **a long-press on translation text does NOT select (gesture exclusion — round-4 H2)**; a translation child is non-selectable, does not perturb source offsets (H2); disable → source-selection byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders exactly one translation inside its last chunk's `Column` (H1/Low-2)**; **one-chunk/final-chunk anchors render (H1)**; MD source mapping. Deps: WI-6, WI-7a, WI-4b.
+   376	
+   377	**WI-9 (behavioral): entry wiring + acceptance.** Mount `BilingualPill` in #132's VERIFIED top chrome; extend `readerMoreRows(...)` to supply the #134 VERIFIED More-menu `MoreActionId.BILINGUAL` toggle (`MoreRow.Toggle` `on`/`onToggle`, or `MoreRow.Disabled` "Configure AI provider first" when not configured) wired to the VM; **wire the setup sheet's "Set up"/"Change…" affordance → the #131-owned `ReaderAiProvidersSheet` (Variant A)**. Full acceptance across EPUB (if WI-7b landed) + TXT/MD, including the fresh-user path `unconfigured → Set up (→ Variant A AI Providers sheet) → add provider → Save → return → enable → translate` (now #131-owned end-to-end). **Flip box D to done ONLY for provider/model/granularity(paragraph) + the Style-descope AND Sentence-descope notes; file the follow-up checklist amendment; do NOT claim full box-D parity.** The DONE flip **no longer waits on #136** (closed). Update `docs/architecture.md` (bilingual pipeline + the new `chapter_translations` schema + `AiProviderStore` + bilingual services in `AppContainer` + the Variant A AI Providers sheet). → DONE. Deps: WI-8, WI-AIP, WI-7b (if go), feat:#132, feat:#134.
+   378	
+     1	// Purpose: Room database + schema-versioned migration scaffold — feature #106 WI-3.
+     2	// Version 8 is the current schema; v1 was the initial books+positions baseline and
+     3	// MIGRATION_1_2 is the worked example of the additive-migration pattern (adds
+     4	// books.lastOpenedAt). Subsequent additive migrations: 2→3 daily_reading (#122),
+     5	// 3→4 annotations (#123), 4→5 collections (#127), 5→6 books.author (#128 search),
+     6	// 6→7 the FTS search index (search_sections + search_sections_fts + search_index_state
+     7	// + search_sections_staging, all #128 WI-4), 7→8 the composite UNIQUE (bookKey, profileKey)
+     8	// index on `bookmarks` — preceded by an in-migration dedupe of pre-existing duplicate rows so
+     9	// the unique index can't fail on a legacy duplicate (feature #135 WI-3). The migration round-trip
+    10	// test (VReaderDatabaseMigrationTest) guards them. Future schema changes append a
+    11	// Migration(n, n+1) to ALL_MIGRATIONS and bump `version`.
+    12	package com.vreader.app.data
+    13	
+    14	import android.content.Context
+    15	import androidx.room.Database
+    16	import androidx.room.Room
+    17	import androidx.room.RoomDatabase
+    18	import androidx.room.migration.Migration
+    19	import androidx.sqlite.db.SupportSQLiteDatabase
+    20	
+    21	@Database(
+    22	    entities = [
+    23	        BookEntity::class, ReadingPositionEntity::class, DailyReadingEntity::class,
+    24	        HighlightEntity::class, AnnotationNoteEntity::class, BookmarkEntity::class,
+    25	        CollectionEntity::class, BookCollectionCrossRef::class,
+    26	        SearchSectionEntity::class, SearchSectionFtsEntity::class,
+    27	        SearchIndexStateEntity::class, SearchStagingEntity::class,
+    28	    ],
+    29	    version = 8,
+    30	    exportSchema = true,
+    31	)
+    32	abstract class VReaderDatabase : RoomDatabase() {
+    33	    abstract fun bookDao(): BookDao
+    34	    abstract fun readingPositionDao(): ReadingPositionDao
+    35	    abstract fun readingStatsDao(): ReadingStatsDao
+    36	    abstract fun annotationDao(): AnnotationDao
+    37	    abstract fun collectionDao(): CollectionDao
+    38	    abstract fun searchDao(): SearchDao
+    39	
+    40	    companion object {
+    41	        private const val DB_NAME = "vreader.db"
+    42	
+    43	        /** v1 → v2: add the nullable `lastOpenedAt` recents column to `books`. */
+    44	        val MIGRATION_1_2: Migration = object : Migration(1, 2) {
+    45	            override fun migrate(db: SupportSQLiteDatabase) {
+    46	                db.execSQL("ALTER TABLE books ADD COLUMN lastOpenedAt INTEGER")
+    47	            }
+    48	        }
+    49	
+    50	        /** v2 → v3: feature #122 — add the additive `daily_reading` per-day/per-book stats table +
+    51	         *  its bookKey index. No data transform. DDL matches Room's generated schema exactly. */
+    52	        val MIGRATION_2_3: Migration = object : Migration(2, 3) {
+    53	            override fun migrate(db: SupportSQLiteDatabase) {
+    54	                db.execSQL(
+    55	                    "CREATE TABLE IF NOT EXISTS `daily_reading` (`date` TEXT NOT NULL, `bookKey` TEXT NOT NULL, " +
+    56	                        "`minutes` INTEGER NOT NULL, PRIMARY KEY(`date`, `bookKey`))",
+    57	                )
+    58	                db.execSQL("CREATE INDEX IF NOT EXISTS `index_daily_reading_bookKey` ON `daily_reading` (`bookKey`)")
+    59	            }
+    60	        }
+    61	
+    62	        /** v3 → v4: feature #123 — add the additive `highlights`, `annotation_notes`, and `bookmarks`
+    63	         *  annotation tables (each FK→books ON DELETE CASCADE; highlights has the unique
+    64	         *  `(profileKey, anchorKey)` dedupe index). No data transform. DDL matches Room's generated
+    65	         *  schema for v4 exactly (the migration test opens the real Room DB, whose structural PRAGMA
+    66	         *  validation catches any drift). */
+    67	        val MIGRATION_3_4: Migration = object : Migration(3, 4) {
+    68	            override fun migrate(db: SupportSQLiteDatabase) {
+    69	                db.execSQL(
+    70	                    "CREATE TABLE IF NOT EXISTS `highlights` (`highlightId` TEXT NOT NULL, " +
+    71	                        "`bookKey` TEXT NOT NULL, `profileKey` TEXT NOT NULL, `anchorKey` TEXT NOT NULL, " +
+    72	                        "`color` TEXT NOT NULL, `selectedText` TEXT NOT NULL, `note` TEXT, " +
+    73	                        "`locatorJSON` TEXT NOT NULL, `anchorJSON` TEXT, `createdAt` INTEGER NOT NULL, " +
+    74	                        "`updatedAt` INTEGER NOT NULL, PRIMARY KEY(`highlightId`), " +
+    75	                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+    76	                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+    77	                )
+    78	                db.execSQL("CREATE INDEX IF NOT EXISTS `index_highlights_bookKey` ON `highlights` (`bookKey`)")
+    79	                db.execSQL(
+    80	                    "CREATE UNIQUE INDEX IF NOT EXISTS `index_highlights_profileKey_anchorKey` " +
+    81	                        "ON `highlights` (`profileKey`, `anchorKey`)",
+    82	                )
+    83	                db.execSQL(
+    84	                    "CREATE TABLE IF NOT EXISTS `annotation_notes` (`noteId` TEXT NOT NULL, " +
+    85	                        "`bookKey` TEXT NOT NULL, `profileKey` TEXT NOT NULL, `content` TEXT NOT NULL, " +
+    86	                        "`locatorJSON` TEXT NOT NULL, `anchorJSON` TEXT, `createdAt` INTEGER NOT NULL, " +
+    87	                        "`updatedAt` INTEGER NOT NULL, PRIMARY KEY(`noteId`), " +
+    88	                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+    89	                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+    90	                )
+    91	                db.execSQL(
+    92	                    "CREATE INDEX IF NOT EXISTS `index_annotation_notes_bookKey` " +
+    93	                        "ON `annotation_notes` (`bookKey`)",
+    94	                )
+    95	                db.execSQL(
+    96	                    "CREATE TABLE IF NOT EXISTS `bookmarks` (`bookmarkId` TEXT NOT NULL, " +
+    97	                        "`bookKey` TEXT NOT NULL, `profileKey` TEXT NOT NULL, `title` TEXT, " +
+    98	                        "`locatorJSON` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, " +
+    99	                        "`updatedAt` INTEGER NOT NULL, PRIMARY KEY(`bookmarkId`), " +
+   100	                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+   101	                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+   102	                )
+   103	                db.execSQL("CREATE INDEX IF NOT EXISTS `index_bookmarks_bookKey` ON `bookmarks` (`bookKey`)")
+   104	            }
+   105	        }
+   106	
+   107	        /** v4 → v5: feature #127 — add the additive `collections` table (unique `nameKey` index) +
+   108	         *  the `book_collection` many-to-many join (composite PK, both FKs ON DELETE CASCADE, a
+   109	         *  `collectionId` index for the reverse lookup). No data transform. DDL matches Room's generated
+   110	         *  v5 schema exactly (the migration test opens the real Room DB, whose structural PRAGMA
+   111	         *  validation catches any drift). */
+   112	        val MIGRATION_4_5: Migration = object : Migration(4, 5) {
+   113	            override fun migrate(db: SupportSQLiteDatabase) {
+   114	                db.execSQL(
+   115	                    "CREATE TABLE IF NOT EXISTS `collections` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, " +
+   116	                        "`nameKey` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+   117	                )
+   118	                db.execSQL(
+   119	                    "CREATE UNIQUE INDEX IF NOT EXISTS `index_collections_nameKey` ON `collections` (`nameKey`)",
+   120	                )
+   121	                db.execSQL(
+   122	                    "CREATE TABLE IF NOT EXISTS `book_collection` (`bookKey` TEXT NOT NULL, " +
+   123	                        "`collectionId` TEXT NOT NULL, PRIMARY KEY(`bookKey`, `collectionId`), " +
+   124	                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+   125	                        "ON UPDATE NO ACTION ON DELETE CASCADE , " +
+   126	                        "FOREIGN KEY(`collectionId`) REFERENCES `collections`(`id`) " +
+   127	                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+   128	                )
+   129	                db.execSQL(
+   130	                    "CREATE INDEX IF NOT EXISTS `index_book_collection_collectionId` " +
+   131	                        "ON `book_collection` (`collectionId`)",
+   132	                )
+   133	            }
+   134	        }
+   135	
+   136	        /** v5 → v6: feature #128 — add the nullable `author` column to `books` (library search).
+   137	         *  Purely additive; migrated rows read `author = null` until a backfill or restore sets it. */
+   138	        val MIGRATION_5_6: Migration = object : Migration(5, 6) {
+   139	            override fun migrate(db: SupportSQLiteDatabase) {
+   140	                db.execSQL("ALTER TABLE books ADD COLUMN author TEXT")
+   141	            }
+   142	        }
+   143	
+   144	        /** v6 → v7: feature #128 WI-4 — add the cross-book search index (all in the one `vreader.db`):
+   145	         *  `search_sections` (+ bookKey index + FK→books CASCADE), its FTS4/unicode61 content-table
+   146	         *  shadow `search_sections_fts`, `search_index_state` (+ FK→books CASCADE), and the transient
+   147	         *  `search_sections_staging` buffer (+ bookKey index + FK→books CASCADE). The migration ships
+   148	         *  the base + FTS VIRTUAL tables only; Room recreates the FTS content-table sync triggers when
+   149	         *  it opens the DB. DDL matches Room's generated v7 schema exactly (the migration test opens the
+   150	         *  real Room DB, whose structural PRAGMA validation catches any drift). No data transform. */
+   151	        val MIGRATION_6_7: Migration = object : Migration(6, 7) {
+   152	            override fun migrate(db: SupportSQLiteDatabase) {
+   153	                db.execSQL(
+   154	                    "CREATE TABLE IF NOT EXISTS `search_sections` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+   155	                        "`bookKey` TEXT NOT NULL, `sectionIndex` INTEGER NOT NULL, `chunkOrdinal` INTEGER NOT NULL, " +
+   156	                        "`sectionTitle` TEXT, `text` TEXT NOT NULL, `indexedText` TEXT NOT NULL, " +
+   157	                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+   158	                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+   159	                )
+   160	                db.execSQL("CREATE INDEX IF NOT EXISTS `index_search_sections_bookKey` ON `search_sections` (`bookKey`)")
+   161	                db.execSQL(
+   162	                    "CREATE VIRTUAL TABLE IF NOT EXISTS `search_sections_fts` USING FTS4(" +
+   163	                        "`indexedText` TEXT NOT NULL, tokenize=unicode61, content=`search_sections`)",
+   164	                )
+   165	                db.execSQL(
+   166	                    "CREATE TABLE IF NOT EXISTS `search_index_state` (`bookKey` TEXT NOT NULL, " +
+   167	                        "`indexerVersion` INTEGER NOT NULL, `indexedAt` INTEGER NOT NULL, `status` TEXT NOT NULL, " +
+   168	                        "PRIMARY KEY(`bookKey`), FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+   169	                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+   170	                )
+   171	                db.execSQL(
+   172	                    "CREATE TABLE IF NOT EXISTS `search_sections_staging` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+   173	                        "`bookKey` TEXT NOT NULL, `sectionIndex` INTEGER NOT NULL, `chunkOrdinal` INTEGER NOT NULL, " +
+   174	                        "`sectionTitle` TEXT, `text` TEXT NOT NULL, `indexedText` TEXT NOT NULL, " +
+   175	                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+   176	                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+   177	                )
+   178	                db.execSQL(
+   179	                    "CREATE INDEX IF NOT EXISTS `index_search_sections_staging_bookKey` " +
+   180	                        "ON `search_sections_staging` (`bookKey`)",
+   181	                )
+   182	            }
+   183	        }
+   184	
+   185	        /** v7 → v8: feature #135 WI-3 — make re-bookmarking the same position idempotent by adding a
+   186	         *  composite UNIQUE index on `bookmarks (bookKey, profileKey)` (the atomic-toggle enforcer,
+   187	         *  mirroring the highlights `(profileKey, anchorKey)` dedupe precedent).
+   188	         *
+   189	         *  A pre-#135 create path (`upsertBookmark`, UUID-keyed) could have produced DUPLICATE rows at
+   190	         *  the same `(bookKey, profileKey)`; `CREATE UNIQUE INDEX` would FAIL on such a duplicate. So
+   191	         *  the migration first DEDUPES — deleting every duplicate LOSER, keeping a DETERMINISTIC winner
+   192	         *  per `(bookKey, profileKey)`: the row with the greatest `updatedAt`, tie-broken by the
+   193	         *  greatest `createdAt`, then the LOWEST `bookmarkId` (a total, stable order). This is a
+   194	         *  targeted dedupe — a non-duplicate row (unique `(bookKey, profileKey)`) is never deleted, and
+   195	         *  no other table is touched. THEN the unique index is created, matching Room's generated name
+   196	         *  + columns (`index_bookmarks_bookKey_profileKey` on `(bookKey, profileKey)`) exactly, so
+   197	         *  Room's structural PRAGMA validation passes. DDL is idempotent (`IF NOT EXISTS`). */
+   198	        val MIGRATION_7_8: Migration = object : Migration(7, 8) {
+   199	            override fun migrate(db: SupportSQLiteDatabase) {
+   200	                // 1) Dedupe: delete every row that is NOT the deterministic winner within its
+   201	                //    (bookKey, profileKey) group. The winner is the row whose (updatedAt, createdAt,
+   202	                //    -rowid-preference-on-bookmarkId) is greatest — expressed as: a row is a loser iff
+   203	                //    another row in the same group ranks strictly higher by (updatedAt DESC,
+   204	                //    createdAt DESC, bookmarkId ASC).
+   205	                db.execSQL(
+   206	                    "DELETE FROM `bookmarks` WHERE `bookmarkId` IN (" +
+   207	                        "SELECT b.`bookmarkId` FROM `bookmarks` b JOIN `bookmarks` w " +
+   208	                        "ON b.`bookKey` = w.`bookKey` AND b.`profileKey` = w.`profileKey` " +
+   209	                        "AND b.`bookmarkId` <> w.`bookmarkId` " +
+   210	                        "WHERE (w.`updatedAt` > b.`updatedAt`) " +
+   211	                        "OR (w.`updatedAt` = b.`updatedAt` AND w.`createdAt` > b.`createdAt`) " +
+   212	                        "OR (w.`updatedAt` = b.`updatedAt` AND w.`createdAt` = b.`createdAt` " +
+   213	                        "AND w.`bookmarkId` < b.`bookmarkId`))",
+   214	                )
+   215	                // 2) Now that each (bookKey, profileKey) is unique, create the unique index.
+   216	                db.execSQL(
+   217	                    "CREATE UNIQUE INDEX IF NOT EXISTS `index_bookmarks_bookKey_profileKey` " +
+   218	                        "ON `bookmarks` (`bookKey`, `profileKey`)",
+   219	                )
+   220	            }
+   221	        }
+   222	
+   223	        /** All registered migrations, oldest first. Append future Migration(n,n+1) here. */
+   224	        val ALL_MIGRATIONS: Array<Migration> =
+   225	            arrayOf(
+   226	                MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5,
+   227	                MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8,
+   228	            )
+   229	
+   230	        /** The production on-disk database (app-private storage). */
+   231	        fun build(context: Context): VReaderDatabase =
+   232	            Room.databaseBuilder(context.applicationContext, VReaderDatabase::class.java, DB_NAME)
+   233	                .addMigrations(*ALL_MIGRATIONS)
+   234	                .build()
+   235	    }
+   236	}
+android/app/src/main/kotlin/com/vreader/app/data/SearchDao.kt:63:    @Query("SELECT EXISTS(SELECT 1 FROM books WHERE fingerprintKey = :bookKey)")
+android/app/src/main/kotlin/com/vreader/app/data/SearchDao.kt:80:            "LEFT JOIN search_index_state s ON s.bookKey = b.fingerprintKey " +
+android/app/src/main/kotlin/com/vreader/app/data/SearchDao.kt:90:            "LEFT JOIN search_index_state s ON s.bookKey = b.fingerprintKey " +
+android/app/src/main/kotlin/com/vreader/app/data/SearchDao.kt:220:    @Query("UPDATE books SET author = :author WHERE fingerprintKey = :bookKey AND author IS NULL")
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:34:    @Query("SELECT * FROM books WHERE fingerprintKey = :key")
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:38:    // Ordered by fingerprintKey (NOT the library-display addedAt) so a repeat backup of unchanged
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:40:    @Query("SELECT * FROM books ORDER BY fingerprintKey")
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:43:    @Query("DELETE FROM books WHERE fingerprintKey = :key")
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:46:    @Query("UPDATE books SET lastOpenedAt = :openedAt WHERE fingerprintKey = :key")
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:52:    @Query("UPDATE books SET author = :author WHERE fingerprintKey = :key AND author IS NULL")
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:66:            "WHERE fingerprintKey = :key",
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:87:                key = book.fingerprintKey,
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:105:            "author = COALESCE(:manifestAuthor, author) WHERE fingerprintKey = :key",
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:121:    @Query("SELECT * FROM reading_positions WHERE fingerprintKey = :key")
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:124:    // feature #116 WI-3 — all saved positions, for the backup collector. Ordered by fingerprintKey
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:126:    @Query("SELECT * FROM reading_positions ORDER BY fingerprintKey")
+android/app/src/main/kotlin/com/vreader/app/data/Daos.kt:129:    @Query("DELETE FROM reading_positions WHERE fingerprintKey = :key")
+android/app/src/main/kotlin/com/vreader/app/data/CollectionEntities.kt:7:// (iOS rejects duplicates case-insensitively). Membership is a many-to-many to `books` by fingerprintKey.
+android/app/src/main/kotlin/com/vreader/app/data/CollectionEntities.kt:16:@Entity(
+android/app/src/main/kotlin/com/vreader/app/data/CollectionEntities.kt:18:    indices = [Index(value = ["nameKey"], unique = true)],
+android/app/src/main/kotlin/com/vreader/app/data/CollectionEntities.kt:33:@Entity(
+android/app/src/main/kotlin/com/vreader/app/data/CollectionEntities.kt:36:    foreignKeys = [
+android/app/src/main/kotlin/com/vreader/app/data/CollectionEntities.kt:39:            parentColumns = ["fingerprintKey"],
+android/app/src/main/kotlin/com/vreader/app/data/CollectionEntities.kt:50:    indices = [Index("collectionId")],
+android/app/src/main/kotlin/com/vreader/app/data/CollectionEntities.kt:53:    val bookKey: String,        // fingerprintKey (FK → books)
+android/app/src/main/kotlin/com/vreader/app/data/SearchEntities.kt:35:@Entity(
+android/app/src/main/kotlin/com/vreader/app/data/SearchEntities.kt:37:    foreignKeys = [
+android/app/src/main/kotlin/com/vreader/app/data/SearchEntities.kt:40:            parentColumns = ["fingerprintKey"],
+android/app/src/main/kotlin/com/vreader/app/data/SearchEntities.kt:45:    indices = [Index("bookKey")],
+android/app/src/main/kotlin/com/vreader/app/data/SearchEntities.kt:65:@Entity(tableName = "search_sections_fts")
+android/app/src/main/kotlin/com/vreader/app/data/SearchEntities.kt:78:@Entity(
+android/app/src/main/kotlin/com/vreader/app/data/SearchEntities.kt:80:    foreignKeys = [
+android/app/src/main/kotlin/com/vreader/app/data/SearchEntities.kt:83:            parentColumns = ["fingerprintKey"],
+android/app/src/main/kotlin/com/vreader/app/data/SearchEntities.kt:103:@Entity(
+android/app/src/main/kotlin/com/vreader/app/data/SearchEntities.kt:105:    foreignKeys = [
+android/app/src/main/kotlin/com/vreader/app/data/SearchEntities.kt:108:            parentColumns = ["fingerprintKey"],
+android/app/src/main/kotlin/com/vreader/app/data/SearchEntities.kt:113:    indices = [Index("bookKey")],
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:22:@Entity(tableName = "books")
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:23:data class BookEntity(
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:24:    @PrimaryKey val fingerprintKey: String,
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:39: * fingerprintKey). Storing the entire envelope (not flattened columns) is the
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:43: * column, kept for dedup/sync lookups. `fingerprintKey` is both PK and the FK child
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:46:@Entity(
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:48:    foreignKeys = [
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:51:            parentColumns = ["fingerprintKey"],
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:52:            childColumns = ["fingerprintKey"],
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:58:    @PrimaryKey val fingerprintKey: String,
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:68: * per-book dashboard table joins live titles and omits orphans). An `@Index("bookKey")` supports the
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:71:@Entity(tableName = "daily_reading", primaryKeys = ["date", "bookKey"], indices = [Index("bookKey")])
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:74:    val bookKey: String,   // fingerprintKey
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:92:@Entity(
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:94:    foreignKeys = [
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:97:            parentColumns = ["fingerprintKey"],
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:102:    indices = [Index("bookKey"), Index(value = ["profileKey", "anchorKey"], unique = true)],
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:106:    val bookKey: String,                   // fingerprintKey (FK)
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:124:@Entity(
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:126:    foreignKeys = [
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:129:            parentColumns = ["fingerprintKey"],
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:134:    indices = [Index("bookKey")],
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:157:@Entity(
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:159:    foreignKeys = [
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:162:            parentColumns = ["fingerprintKey"],
+android/app/src/main/kotlin/com/vreader/app/data/Entities.kt:167:    indices = [Index("bookKey"), Index(value = ["bookKey", "profileKey"], unique = true)],
+android/app/src/main/kotlin/com/vreader/app/data/CollectionDao.kt:63:            "SELECT :bookKey, :collectionId WHERE EXISTS (SELECT 1 FROM books WHERE fingerprintKey = :bookKey)",
+android/app/src/main/kotlin/com/vreader/app/data/CollectionDao.kt:73:    /** The book fingerprintKeys in a collection (reverse lookup, served by the collectionId index). */
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:75:                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:88:                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:100:                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:124:                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:157:                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:168:                        "PRIMARY KEY(`bookKey`), FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:175:                        "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+android/app/src/main/kotlin/com/vreader/app/data/BookImporter.kt:45:     * Idempotent: re-importing identical bytes yields the same `fingerprintKey` and
+android/app/src/main/kotlin/com/vreader/app/data/BookImporter.kt:95:                        fingerprintKey = key,
+android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt:17: * `BookRecord`). `fingerprintKey` is the canonical identity.
+android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt:20:    val fingerprintKey: String,
+android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt:38:    val fingerprintKey: String,
+android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt:60:            ReadingPositionRecord(e.fingerprintKey, e.toEnvelope(json), e.updatedAt)
+android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt:85:    suspend fun findBook(fingerprintKey: String): Book? = bookDao.find(fingerprintKey)?.let(::toBook)
+android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt:87:    suspend fun deleteBook(fingerprintKey: String) = bookDao.delete(fingerprintKey)
+android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt:89:    suspend fun markOpened(fingerprintKey: String, openedAt: Long) =
+android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt:90:        bookDao.markOpened(fingerprintKey, openedAt)
+android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt:107:    suspend fun loadPosition(fingerprintKey: String): VReaderLocator? =
+android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt:108:        positionDao.find(fingerprintKey)?.toEnvelope(json)
+android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt:110:    suspend fun clearPosition(fingerprintKey: String) = positionDao.delete(fingerprintKey)
+android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt:115:        fingerprintKey = e.fingerprintKey,
+android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt:128:        fingerprintKey = fingerprintKey,
+android/app/src/main/kotlin/com/vreader/app/data/LibraryRepository.kt:146:            fingerprintKey = fingerprintKey,
+
+exec
+/bin/zsh -lc "nl -ba dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md | sed -n '246,276p;342,355p;365,378p'; nl -ba android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt | sed -n '1,45p'; nl -ba android/app/src/main/kotlin/com/vreader/app/data/Entities.kt | sed -n '20,62p;88,142p'; nl -ba docs/architecture.md | sed -n '1,40p'; rg -n \"Android|Room|AI provider|backup|bilingual\" docs/architecture.md | head -50" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+   246	  **`MIGRATION_8_9` exact DDL (gap A — BINDING; modeled on the verified `MIGRATION_6_7` `search_index_state` shape at VReaderDatabase.kt:154–169, whose DDL Room's PRAGMA validation already accepts):**
+   247	
+   248	  ```
+   249	  val MIGRATION_8_9: Migration = object : Migration(8, 9) {
+   250	      override fun migrate(db: SupportSQLiteDatabase) {
+   251	          db.execSQL(
+   252	              "CREATE TABLE IF NOT EXISTS `chapter_translations` (" +
+   253	                  "`lookupKey` TEXT NOT NULL, " +
+   254	                  "`bookKey` TEXT NOT NULL, " +
+   255	                  "`unitStorageKey` TEXT NOT NULL, " +
+   256	                  "`targetLanguage` TEXT NOT NULL, " +
+   257	                  "`promptVersion` TEXT NOT NULL, " +
+   258	                  "`translatedJson` TEXT NOT NULL, " +
+   259	                  "`sourceParagraphCount` INTEGER NOT NULL, " +
+   260	                  "`createdAt` INTEGER NOT NULL, " +
+   261	                  "PRIMARY KEY(`lookupKey`), " +
+   262	                  "FOREIGN KEY(`bookKey`) REFERENCES `books`(`fingerprintKey`) " +
+   263	                  "ON UPDATE NO ACTION ON DELETE CASCADE )"
+   264	          )
+   265	          db.execSQL(
+   266	              "CREATE INDEX IF NOT EXISTS `index_chapter_translations_bookKey` " +
+   267	                  "ON `chapter_translations` (`bookKey`)"
+   268	          )
+   269	      }
+   270	  }
+   271	  ```
+   272	
+   273	  The `ChapterTranslationEntity` column types/order MUST match this DDL exactly (all columns `NOT NULL`; PK `lookupKey`; the `Index("bookKey")` produces `index_chapter_translations_bookKey`; the FK is `bookKey → books(fingerprintKey) ON DELETE CASCADE` — the same shape as every other child table, VReaderDatabase.kt:75–76/88–89/100–101/157–158/168–169). **The migration test MUST diff this DDL against Room's GENERATED `9.json` schema** (`exportSchema = true` at VReaderDatabase.kt:30 emits `schemas/…/9.json`), NOT a hand-written approximation — the exact-DDL guard opens the real Room DB after the v8→v9 migration and lets Room's structural PRAGMA validation catch any drift (the recurring Android migration failure mode, cf. #135's stale-version finding; the `MIGRATION_6_7` comment at VReaderDatabase.kt:148–150 documents this exact "DDL matches Room's generated schema, validated by the migration test opening the real Room DB" contract).
+   274	
+   275	- `reader/TxtReaderActivity.kt` — own a `BilingualViewModel`; collect state; render translations **inside each chunk `i`'s lazy item as muted non-registered `Text` children of a wrapping `Column`, source chunk byte-unchanged, the `items(count = document.chunkCount, key = { it })` loop and its keys UNCHANGED so lazy-index==chunk-index is preserved (H2, TxtReaderActivity.kt:1043–1085)**; add the translation gesture-exclusion (H2); on position change call `vm.onPositionChanged(charOffsetUTF16)`. Strictly gated to `originalFormat ∈ {txt, md}`; disabled = each item's `Column` holds only the unchanged source `Text` (source-selection-parity preserved). **Owned by #129 (VERIFIED, merged) — a straight edit, rule 48 one-writer-per-file satisfied.**
+   276	- `reader/ReaderActivity.kt` (Readium EPUB) — WI-0-gated: attach `EpubBilingualController` to `navigator.evaluateJavascript`; re-apply on the identified production re-apply signal; clear on teardown BEFORE publication teardown. `navigator: EpubNavigatorFragment?` is the verified live field (ReaderActivity.kt:110).
+   342	**13 WIs/PRs (round-3 Low-1 fix — corrected count; UNCHANGED in v5):** the list is exactly **WI-0, WI-1, WI-2, WI-3, WI-4a, WI-4b, WI-5, WI-6, WI-7a, WI-7b, WI-AIP, WI-8, WI-9** = **13 WIs**. `Utf16Span` (round-4 H1) is a NEW file but **rides WI-1** (the foundational value-types + pure-segmentation WI) — it does not add a WI. Each WI = one PR. Build order: **foundation/cache → service/direct-block APIs → shared DI/factory (incl. `AiProviderStore` in `AppContainer`) → VM state/prefetch → host-specific renderers (TXT/MD + EPUB) + the Variant A AI Providers sheet → entry wiring.**
+   343	
+   344	**Dependencies (round-3 Medium-4 — dependency honesty; #136 folded in; round-4 CONFIRMED correct):**
+   345	
+   346	- **`Deps: [feat:#132, feat:#134]`.** **#132 (top chrome) and #134 (More menu) are VERIFIED.** **#129 (TXT/MD reader) is VERIFIED** — `TxtReaderActivity` is a straight edit, not a blocker. **There is NO external AI-reachability blocker** — the former #136 is CLOSED (GH #1976, not-planned) and its scope is #131-owned.
+   347	- **WI-4b is foundational and gates the behavioral chain.** WI-4b provides `AiProviderStore` into `AppContainer` PLUS the bilingual services + factories. Per the audit's Medium-4, WI-4b transitively gates WI-6 (needs the prefetcher/DI), WI-7b (needs DI), WI-AIP (needs `AiProviderStore` + `AiSettingsViewModel` from `AppContainer`), and WI-8 (needs DI). **Chosen resolution: injected seams so the behavioral work proceeds against fakes before WI-4b lands, AND WI-4b is sequenced early.** Concretely: the VM (WI-5/WI-6) takes an injected `ChapterTranslationPrefetcher` (fake in tests) and an injected `AiProviderSnapshot` provider (fake); the TXT/MD host Compose/unit work (WI-8) and the Variant A sheet (WI-AIP) take injected VM/store/`AiSettingsViewModel` seams — so unit/Compose tests do not wait on `AppContainer`. **WI-4b is built right after WI-4a (before WI-6/WI-7b/WI-AIP/WI-8) so the production wiring lands before the host integrations that mount it.** This is stated honestly: the *production run-through* of WI-6/WI-7b/WI-AIP/WI-8 depends on WI-4b; their *unit/Compose gates* depend only on the injected seams. No external feature gates any of this.
+   348	
+   349	**WI-0 (spike): Readium EPUB bilingual injection — go/no-go + race contract (M1).** Harness + criteria (a)–(e) and the race contract in §3. Output: a go/no-go on EPUB-in-v1 (no-go = box D ships TXT/MD-only, tracked) + the concrete `EpubChapterTextProvider` / `EpubBilingualJs` / `EpubBilingualController` surfaces + the EPUB direct-block ownership sequence (Medium-1). Deps: none (uses the existing #106 Readium host). Not TDD-gated (throwaway spike); feeds WI-7b.
+   350	
+   351	**WI-1 (foundational): value types + pure segmentation/chunk/contract.** **`Utf16Span` (round-4 H1 — the half-open span value type replacing `IntRange`)**, `TranslationUnitId`, `TranslationGranularity` (reserved; v1 uses `paragraph` only — round-4 H3), `BilingualLanguages`, **`ChapterSegmenter` (with `paragraphRanges`/`sentenceRanges` returning `List<Utf16Span>` — H1; `sentenceRanges` is reserved-foundational, not in the v1 render path — H3)**, `TranslationChunker`, `TranslationChunkContract` (no `style`), `ChapterTranslationError`. Pure; ported iOS vectors. Deps: none. Tests: `paragraphRanges`/`sentenceRanges` return correct half-open `Utf16Span(start, endExclusive)` spans (both APIs unit-tested even though only `paragraphRanges` ships in the v1 render path — `sentenceRanges` stays covered as reserved-foundational code); chunker packs-to-budget/oversize/empty; contract prompt/decode/fence/mismatch; error mapping.
+   352	
+   353	**WI-2 (foundational): Room translation cache.** `ChapterTranslationEntity` (PK = `lookupKey`, all-`NOT NULL` columns matching the DDL, `sourceParagraphCount` column) + `Dao` (`@Upsert`) + `ChapterTranslationStore`; `VReaderDatabase` **8→9 `MIGRATION_8_9`** with the **exact DDL authored in §2 (gap A)**, appended after `MIGRATION_7_8`. Robolectric migration round-trip from v8 + full-chain + upsert/get/delete-by-lookupKey + FK-CASCADE + **exact-DDL guard validated against Room's GENERATED `9.json` schema (not a hand-written approximation — gap A)**. Deps: none.
+   354	
+   355	**WI-3 (foundational): `ChapterTranslationService`** against a fake `AiClient`. Both `cachedTranslation` overloads (incl. the `expectedSegmentCount` divergence restore — H2) + `translate` + `translatePreSegmented`. **Dual-cancellation (native + typed `Cancelled`) BEFORE generic mapping (M2).** Deps: WI-1, WI-2. Tests: cache hit → zero client calls; miss → translate + write; decode fail → per-segment fallback; one-chunk fail → source-only that chunk (others translated, NOT cached); all-chunks fail → throw; native-cancel → `Cancelled` (no write); typed-`Cancelled`-from-chunk → `Cancelled` (no write); ensureActive-before-write; `AiError` mapping incl. `Config`/`InsecureUrl` → `ProviderFailed`; `translatePreSegmented` full-success caches under the enumerate count; partial degrade NOT cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` returns on stored-count match, null on mismatch, needs no provider.
+   365	**WI-7a (behavioral): Compose UI — setup sheet + interlinear body (TXT/MD) + pill.** Reproduce `vreader-bilingual.jsx` (setup sheet: language grid / **Paragraph-only Granularity control (round-4 H3)** / preview / engine strip configured+unconfigured; body: the translation rendered **inside the anchor chunk's `Column` as a muted non-registered `Text` child** per the round-4 H2 render contract — translated / loading N%+dimmed / error+Retry / offline source-only; pill). Consumes the host-neutral `BilingualRenderState` DTO. Light+dark. Compose UI tests each state, incl. **paragraph interlinear renders a translation child after a paragraph's last source chunk (depicted)**; **the setup-sheet Granularity control shows Paragraph only, no Sentence option (H3)**. Deps: WI-5 (state shape). NO Style control; the unconfigured "Set up" CTA renders and (in WI-9) routes to the Variant A sheet.
+   366	
+   367	**WI-7b (behavioral, CONDITIONAL — only if WI-0 = go): EPUB render adapter (DOM injection, NOT Compose — M2) + direct-block ownership (M1).** `EpubBilingualJs` (enum/inject/clear JS builders, CSP-safe escaping) + `EpubBilingualController` (the serialization actor / session token AND the **single-owner enumerate→cachedDirect/prefetchDirect→guarded-commit sequence — Medium-1**) + `EpubChapterTextProvider`, wired into `ReaderActivity`, driving DOM from the shared `BilingualRenderState` DTO. Uses `prefetchDirect`/`cachedDirect` for the count-divergence path (H2). Depends on WI-6 (VM state) and WI-4b (DI); the WI-7a UI dependency is only the shared `BilingualRenderState`/value types. Connected test on a real EPUB (seeded cache): enable → injects; disable → cleared; reflow/href-change/fragment-recreation/activity-recreation → re-applies from cache (zero provider calls) via `cachedDirect`; count-divergence handled (direct path); **the regular TXT/MD prefetch path is never invoked for an EPUB unit (Medium-1)**. Unit tests: JS escaping/CSP-safe insertion, RTL/CJK style, empty translations, loading cleanup, idempotent replacement, source-only fallback, stale-session-token commit discarded (no `errorUnit`). Deps: WI-0, WI-3, WI-4a, WI-4b, WI-6, (shared types from WI-7a). (If WI-0 = no-go, dropped; box D ships TXT/MD-only, tracked.)
+   368	
+   369	**WI-AIP (behavioral — the folded-in Variant A AI Providers sheet; round-4 H4 rewritten): `ReaderAiProvidersSheet`.** The scoped in-reader "AI Providers" push sheet (nav bar `‹ Bilingual` + "AI Providers" title) reproducing `vreader-ai-provider-entry.jsx` `AIProvidersSheet`/`AIProvidersSheetBody`/`NavSheet`. Per round-4 H4:
+   370	  - **(a)** present `AiProviderEditSheet` VERBATIM from #118 (Kind/Name/Endpoint/Sampling/API Key/Test Connection unchanged).
+   371	  - **(b)** a NEW `ReaderAiProvidersList` presentation over the SHARED `AiSettingsViewModel.listState` (verified `AiSettingsViewModel.kt:26`; each `AiProviderRow` already carries `active`, :30) + shared row/cell components — reproducing the reader-scoped `‹ Bilingual` nav (`NavSheet`, jsx:247, NOT `AiProviderListScreen`'s `NavScreen`), the bilingual-context empty state ("Choose the provider bilingual mode will use to translate this book." + "No providers yet" + "Add provider" — jsx:180–209), the **checked-active row** (`selected = row.active` — jsx:221), and **tap-to-SELECT** (`onSelect(id) → vm.setActive(id)` — jsx:221/237). It does NOT reuse `AiProviderListScreen`'s NavScreen/chrome/`AiEmptyState`/`ProviderRow`-tap-edit.
+   372	  - **(c)** the **save-result seam**: `AiSettingsViewModel.save()` (or a thin WI-AIP wrapper) is extended to return the saved provider ID (from `store.upsert(...).id`, which the store already returns — `AiProviderStore.kt:58/84`), so on first Save → `store.setActive(savedId)` → pop the whole stack back to the bilingual sheet (engine strip now "configured / Change…"), **deterministically, after the upsert commits (no race)**.
+   373	  `‹ Bilingual` without adding → unconfigured, no state mutated. "Change…" → populated list, current provider checked, tap row → `setActive`. No consent/flag surface (Android has none). Deps: WI-4b (for `AiProviderStore` + `AiSettingsViewModel` in `AppContainer`), WI-7a (bilingual sheet host). Tests (Compose + connected): the scoped list renders **`‹ Bilingual` back label** + **bilingual-context empty copy** + **checked active row** + **tap-selects (`setActive`)**; empty → Add → Save → **save→result-id→`setActive`→pop deterministic (no race)** → bilingual strip configured; `‹ Bilingual` without adding → strip unconfigured, snapshot unchanged; "Change…" → populated, current checked; editor reused verbatim (no divergent form).
+   374	
+   375	**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into the `items(count = document.chunkCount, key = { it })` loop as **muted non-registered translation `Text` children inside each anchor chunk's wrapping `Column`, source chunk byte-unchanged, the loop + keys UNCHANGED so lazy-index==chunk-index is preserved (round-4 H2)** + the translation **gesture-exclusion** (round-4 H2) + position-change (`charOffsetUTF16`) + setup-sheet. `originalFormat`-gated (TXT/MD). Uses WI-4b's DI. **#129 VERIFIED — straight edit.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2)**; **highlights/annotation-washes/read-aloud-wash still key off source chunks (H2)**; **with bilingual ON — position-save round-trips to the same chunk; bookmark/search/scrubber/TTS jumps land on the correct chunk (lazy-index==chunk-index preserved — round-4 H2)**; **a long-press on translation text does NOT select (gesture exclusion — round-4 H2)**; a translation child is non-selectable, does not perturb source offsets (H2); disable → source-selection byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders exactly one translation inside its last chunk's `Column` (H1/Low-2)**; **one-chunk/final-chunk anchors render (H1)**; MD source mapping. Deps: WI-6, WI-7a, WI-4b.
+   376	
+   377	**WI-9 (behavioral): entry wiring + acceptance.** Mount `BilingualPill` in #132's VERIFIED top chrome; extend `readerMoreRows(...)` to supply the #134 VERIFIED More-menu `MoreActionId.BILINGUAL` toggle (`MoreRow.Toggle` `on`/`onToggle`, or `MoreRow.Disabled` "Configure AI provider first" when not configured) wired to the VM; **wire the setup sheet's "Set up"/"Change…" affordance → the #131-owned `ReaderAiProvidersSheet` (Variant A)**. Full acceptance across EPUB (if WI-7b landed) + TXT/MD, including the fresh-user path `unconfigured → Set up (→ Variant A AI Providers sheet) → add provider → Save → return → enable → translate` (now #131-owned end-to-end). **Flip box D to done ONLY for provider/model/granularity(paragraph) + the Style-descope AND Sentence-descope notes; file the follow-up checklist amendment; do NOT claim full box-D parity.** The DONE flip **no longer waits on #136** (closed). Update `docs/architecture.md` (bilingual pipeline + the new `chapter_translations` schema + `AiProviderStore` + bilingual services in `AppContainer` + the Variant A AI Providers sheet). → DONE. Deps: WI-8, WI-AIP, WI-7b (if go), feat:#132, feat:#134.
+   378	
+     1	// Purpose: Room database + schema-versioned migration scaffold — feature #106 WI-3.
+     2	// Version 8 is the current schema; v1 was the initial books+positions baseline and
+     3	// MIGRATION_1_2 is the worked example of the additive-migration pattern (adds
+     4	// books.lastOpenedAt). Subsequent additive migrations: 2→3 daily_reading (#122),
+     5	// 3→4 annotations (#123), 4→5 collections (#127), 5→6 books.author (#128 search),
+     6	// 6→7 the FTS search index (search_sections + search_sections_fts + search_index_state
+     7	// + search_sections_staging, all #128 WI-4), 7→8 the composite UNIQUE (bookKey, profileKey)
+     8	// index on `bookmarks` — preceded by an in-migration dedupe of pre-existing duplicate rows so
+     9	// the unique index can't fail on a legacy duplicate (feature #135 WI-3). The migration round-trip
+    10	// test (VReaderDatabaseMigrationTest) guards them. Future schema changes append a
+    11	// Migration(n, n+1) to ALL_MIGRATIONS and bump `version`.
+    12	package com.vreader.app.data
+    13	
+    14	import android.content.Context
+    15	import androidx.room.Database
+    16	import androidx.room.Room
+    17	import androidx.room.RoomDatabase
+    18	import androidx.room.migration.Migration
+    19	import androidx.sqlite.db.SupportSQLiteDatabase
+    20	
+    21	@Database(
+    22	    entities = [
+    23	        BookEntity::class, ReadingPositionEntity::class, DailyReadingEntity::class,
+    24	        HighlightEntity::class, AnnotationNoteEntity::class, BookmarkEntity::class,
+    25	        CollectionEntity::class, BookCollectionCrossRef::class,
+    26	        SearchSectionEntity::class, SearchSectionFtsEntity::class,
+    27	        SearchIndexStateEntity::class, SearchStagingEntity::class,
+    28	    ],
+    29	    version = 8,
+    30	    exportSchema = true,
+    31	)
+    32	abstract class VReaderDatabase : RoomDatabase() {
+    33	    abstract fun bookDao(): BookDao
+    34	    abstract fun readingPositionDao(): ReadingPositionDao
+    35	    abstract fun readingStatsDao(): ReadingStatsDao
+    36	    abstract fun annotationDao(): AnnotationDao
+    37	    abstract fun collectionDao(): CollectionDao
+    38	    abstract fun searchDao(): SearchDao
+    39	
+    40	    companion object {
+    41	        private const val DB_NAME = "vreader.db"
+    42	
+    43	        /** v1 → v2: add the nullable `lastOpenedAt` recents column to `books`. */
+    44	        val MIGRATION_1_2: Migration = object : Migration(1, 2) {
+    45	            override fun migrate(db: SupportSQLiteDatabase) {
+    20	 * path goes through [BookDao.upsertPreservingAuthor], not the whole-row `@Upsert`).
+    21	 */
+    22	@Entity(tableName = "books")
+    23	data class BookEntity(
+    24	    @PrimaryKey val fingerprintKey: String,
+    25	    val title: String,
+    26	    val originalFormat: String,   // BookFormat raw value (epub/pdf/txt/md/azw3)
+    27	    val contentSHA256: String,
+    28	    val fileByteCount: Long,
+    29	    val localFilePath: String?,   // app-private storage path (set at import, WI-4)
+    30	    val sourceUri: String?,       // SAF source URI metadata (WI-4)
+    31	    val addedAt: Long,            // epoch millis
+    32	    val lastOpenedAt: Long?,      // v2 addition — epoch millis of last open, or null
+    33	    val author: String? = null,   // v6 addition (feature #128) — nullable; tail default so no positional site breaks
+    34	)
+    35	
+    36	/**
+    37	 * The persisted reading position for a book — the WHOLE [VReaderLocator] envelope
+    38	 * serialized into a single `vreaderLocatorJSON` column (one position per book; PK =
+    39	 * fingerprintKey). Storing the entire envelope (not flattened columns) is the
+    40	 * iOS-parity contract: a new envelope field gated by its own `schemaVersion` evolves
+    41	 * WITHOUT a Room schema change (Gate-4 Medium — the iOS analog persists the envelope
+    42	 * as one `Data?` blob on `ReadingPosition`). `canonicalHash` is the only derived
+    43	 * column, kept for dedup/sync lookups. `fingerprintKey` is both PK and the FK child
+    44	 * column, so it is already indexed — no separate index needed.
+    45	 */
+    46	@Entity(
+    47	    tableName = "reading_positions",
+    48	    foreignKeys = [
+    49	        ForeignKey(
+    50	            entity = BookEntity::class,
+    51	            parentColumns = ["fingerprintKey"],
+    52	            childColumns = ["fingerprintKey"],
+    53	            onDelete = ForeignKey.CASCADE,
+    54	        ),
+    55	    ],
+    56	)
+    57	data class ReadingPositionEntity(
+    58	    @PrimaryKey val fingerprintKey: String,
+    59	    val vreaderLocatorJSON: String,   // the FULL serialized VReaderLocator envelope
+    60	    val canonicalHash: String,        // derived dedup/sync key (locally deterministic)
+    61	    val updatedAt: Long,              // epoch millis of last save
+    62	)
+    88	 * `anchorHash ?: "__nil_anchor__"` sentinel (SQLite treats NULLs as distinct in a unique index, so a
+    89	 * nullable column would let repeated null-anchor highlights bypass dedupe — the sentinel collapses
+    90	 * them per `profileKey`, matching iOS's nil-anchor-by-profileKey dedupe).
+    91	 */
+    92	@Entity(
+    93	    tableName = "highlights",
+    94	    foreignKeys = [
+    95	        ForeignKey(
+    96	            entity = BookEntity::class,
+    97	            parentColumns = ["fingerprintKey"],
+    98	            childColumns = ["bookKey"],
+    99	            onDelete = ForeignKey.CASCADE,
+   100	        ),
+   101	    ],
+   102	    indices = [Index("bookKey"), Index(value = ["profileKey", "anchorKey"], unique = true)],
+   103	)
+   104	data class HighlightEntity(
+   105	    @PrimaryKey val highlightId: String,   // UUID string (iOS `highlightId: UUID` parity)
+   106	    val bookKey: String,                   // fingerprintKey (FK)
+   107	    val profileKey: String,                // "$bookKey:${locator.canonicalHash}"
+   108	    val anchorKey: String,                 // anchorHash ?: "__nil_anchor__" (non-null dedupe key)
+   109	    val color: String,                     // AnnotationColor.key (yellow/green/blue/pink/red) or hex
+   110	    val selectedText: String,
+   111	    val note: String?,                     // optional inline note on the highlight
+   112	    val locatorJSON: String,               // full round-trippable plain Locator JSON (backup converts to canonicalJson)
+   113	    val anchorJSON: String?,               // serialized AnnotationAnchor (engine-precise)
+   114	    val createdAt: Long,
+   115	    val updatedAt: Long,
+   116	)
+   117	
+   118	/**
+   119	 * A standalone note — feature #123. Mirrors the iOS `AnnotationNote` @Model (the design's
+   120	 * "STANDALONE" card). Same `locatorJSON` (full round-trippable plain Locator; backup converts to
+   121	 * canonical) + `anchorJSON` (precise) contract as [HighlightEntity]. No range-dedupe (a reader may
+   122	 * keep several notes at one spot).
+   123	 */
+   124	@Entity(
+   125	    tableName = "annotation_notes",
+   126	    foreignKeys = [
+   127	        ForeignKey(
+   128	            entity = BookEntity::class,
+   129	            parentColumns = ["fingerprintKey"],
+   130	            childColumns = ["bookKey"],
+   131	            onDelete = ForeignKey.CASCADE,
+   132	        ),
+   133	    ],
+   134	    indices = [Index("bookKey")],
+   135	)
+   136	data class AnnotationNoteEntity(
+   137	    @PrimaryKey val noteId: String,
+   138	    val bookKey: String,
+   139	    val profileKey: String,
+   140	    val content: String,
+   141	    val locatorJSON: String,
+   142	    val anchorJSON: String?,
+     1	# VReader Architecture
+     2	
+     3	## Overview
+     4	
+     5	VReader is an iOS e-book reader built with SwiftUI + SwiftData. It supports TXT, EPUB, AZW3/MOBI, PDF, and Markdown formats, each rendered by a format-specific native host (UIKit/WebView bridges) selected internally by `ReaderEngine` (feature #54). AZW3/MOBI is rendered via Foliate-js inside a WKWebView. **Feature #42 Phase 2 (`kindleConvertOnImport`, default ON since the G2 flip 2026-06-02):** NEW AZW3/MOBI/KF8/PRC imports are converted to a first-class EPUB at import time (via the vendored libmobi MOBI→EPUB converter) and render via the default Readium EPUB engine; already-imported native `.azw3` books are unchanged and keep rendering via Foliate, and a user can revert via the persisted `kindleConvertOnImport` override OFF. The `UnifiedTextRenderer` (TextKit 2 reflow) stack is retained in the codebase but no longer wired into the reader dispatch.
+     6	
+     7	## System Diagram
+     8	
+     9	```
+    10	┌──────────────────────────────────────────────────────┐
+    11	│                    VReaderApp                         │
+    12	│  SwiftData SchemaV10 · PersistenceActor · BookImporter│
+    13	└─────────────────────┬────────────────────────────────┘
+    14	                      │
+    15	          ┌───────────┴───────────┐
+    16	          │                       │
+    17	    ┌─────▼──────────┐    ┌──────▼──────────────────┐
+    18	    │  LibraryView    │    │  ReaderContainerView     │
+    19	    │  LibraryViewModel│   │  (format dispatcher)     │
+    20	    │  PreferenceStore │   │  ReaderTopChrome (overlay)│
+    21	    └─────────────────┘   └──────┬───────────────────┘
+    22	                                 │
+    23	        ┌────────┬───────────┬───┴────┬─────────┐
+    24	        │        │           │        │         │
+    25	    ┌───▼──┐ ┌──▼───┐  ┌───▼──┐ ┌──▼───┐ ┌────▼─────┐
+    26	    │ TXT  │ │ EPUB │  │ PDF  │ │  MD  │ │  AZW3 /  │
+    27	    │Bridge│ │Bridge│  │Bridge│ │Bridge│ │  MOBI    │
+    28	    └──────┘ └──────┘  └──────┘ └──────┘ └──────────┘
+    29	    UITextView WKWebView PDFKit  UITextView WKWebView
+    30	                                            (Foliate-js)
+    31	```
+    32	
+    33	## Layers
+    34	
+    35	### 1. App Layer (`vreader/App/`)
+    36	
+    37	- `VReaderApp.swift` — SwiftData `ModelContainer` init (SchemaV10), migration plan (V1→…→V9→V10, all lightweight; V9→V10 adds the additive `Book.sourceCanonicalKey: String?` for feature #108's converted-Kindle cross-platform identity). Also runs the feature #109 one-shot `LocatorKeyBackfillMigration` synchronously at launch (flag-gated; recomputes derived locator keys under NFC canonicalization + repairs non-finite locators — a launch backfill, NOT a migration stage, since the transform changes no entity shape). Plus test seeding, error handling. Injects the live `PersistenceActor` into the SwiftUI environment via `\.persistenceActor` so settings sub-screens can construct backup providers without rewriting every parent's signature. Adopts `@UIApplicationDelegateAdaptor(VReaderAppDelegate.self)` for background-URLSession completion-handler delivery (feature #47).
+    38	- `VReaderAppDelegate.swift` — `UIApplicationDelegate` adapter that captures `application(_:handleEventsForBackgroundURLSession:completionHandler:)` into a MainActor-isolated static dictionary keyed by URLSession identifier. The lazy-download coordinator retrieves and invokes the handler from `LazyDownloadDelegate.urlSessionDidFinishEvents` so iOS releases the app's background-launch grace period.
+    39	
+    40	### 2. Library Layer (`vreader/Views/LibraryView.swift`, `vreader/ViewModels/LibraryViewModel.swift`)
+37:- `VReaderApp.swift` — SwiftData `ModelContainer` init (SchemaV10), migration plan (V1→…→V9→V10, all lightweight; V9→V10 adds the additive `Book.sourceCanonicalKey: String?` for feature #108's converted-Kindle cross-platform identity). Also runs the feature #109 one-shot `LocatorKeyBackfillMigration` synchronously at launch (flag-gated; recomputes derived locator keys under NFC canonicalization + repairs non-finite locators — a launch backfill, NOT a migration stage, since the transform changes no entity shape). Plus test seeding, error handling. Injects the live `PersistenceActor` into the SwiftUI environment via `\.persistenceActor` so settings sub-screens can construct backup providers without rewriting every parent's signature. Adopts `@UIApplicationDelegateAdaptor(VReaderAppDelegate.self)` for background-URLSession completion-handler delivery (feature #47).
+72:  bilingual wrapper from feature #56 WI-11 sits between the dispatcher
+73:  and `FoliateSpikeView`, adding the bilingual VM / orchestrator / setup-
+124:- `ReadiumEPUBHost` (feature #42 Phase 1, WI-5) → `ReadiumNavigatorRepresentable` → Readium Swift Toolkit `EPUBNavigatorViewController`. Selected by the dispatcher in place of `EPUBReaderHost` when `FeatureFlags.readiumEPUBEngine` is ON (**default ON since the WI-14 G2 flip 2026-06-01**; a persisted override OFF reverts to the legacy `EPUBReaderHost`). Opens the publication off-main via `ReadiumEPUBReaderViewModel` (`AssetRetriever` → `PublicationOpener`), then mounts the navigator; `EPUBPreferences(scroll:)` is mapped from `ReaderSettingsStore.epubLayout`. The `ReadiumReaderCoordinator` is the `EPUBNavigatorDelegate` + (DEBUG) `ReadiumNavigatorEvaluating` seam — it registers the active navigator with `DebugReaderRegistry.setActiveReadiumNavigator` and `markReaderSettled` on `locationDidChange`, and tears that registration down on `dismantleUIViewController` via `detach()` → `clearActiveReadiumNavigator` (the host registers no `DebugReaderProbe`, so it owns its own registry teardown). Reading-position save/restore landed in WI-6: the coordinator forwards `locationDidChange` to the VM's debounced save, which maps the Readium `Locator` → a `VReaderLocator` envelope (engine `.readium`, authoritative `readiumLocatorJSON` + a lossy legacy `Locator` leg) and dual-writes it through `PersistenceActor`'s `VReaderLocatorPersisting` conformance — `saveVReaderLocator` writes both the envelope blob into the SchemaV8 `ReadingPosition.vreaderLocatorData` column AND the legacy `locator`; legacy `savePosition` clears the envelope so a flag-OFF write can't be shadowed by a stale Readium position. On open, the host loads the saved envelope (`restoredReadiumLocator()`) before the navigator mounts and passes it as `initialLocation`. Theme/font landed in WI-7: the host body reads `ReaderSettingsStore.theme` + `.typography` + `.epubLayout` (tracked `@Observable` deps) and recomputes a full `EPUBPreferences` on any Display-settings change, which `updateUIViewController` re-submits live (`submitPreferences`). `ReadiumEPUBReaderViewModel+Mapping` translates the 5 `ReaderThemeV2` themes → Readium's 3 base `Theme`s + explicit `backgroundColor`/`textColor` (which win via `effectiveBackgroundColor`); font size from the per-format-calibrated `.epub` size (`FontSizeCalibrator`) → Readium's multiplier; `lineHeight` from `lineSpacing`; `fontFamily` (system→sansSerif, serif/sourceSerif4→serif, monospace→monospace, inter→sansSerif — custom-font registration deferred); `publisherStyles=false`. The WI-7 photo/custom-background refinement composites the decorative image behind the navigator: `ReadiumEPUBHost+Background.swift` layers the existing `ThemeBackgroundView` under the navigator in a `ZStack` (only when `useCustomBackground` + an image exists for the theme), and `ReadiumReaderCoordinator+Transparency` makes the navigator render through — `epubPreferences(..., transparentBackground:)` emits `backgroundColor: nil` (so ReadiumCSS injects no body bg rule), the representable forces `navigator.view`/spine `WKWebView`s `.clear`/`isOpaque=false`, and a read-only self-gating user script clears the opaque `html:root` ReadiumCSS paints (transparency state is authored into `localStorage` by Swift on each `locationDidChange`/toggle). Normal opaque themes are unchanged. Highlights landed in WI-8: `ReadiumDecorationHighlightAdapter` (a `HighlightRenderer`, the Readium counterpart of `EPUBHighlightRenderer`) renders stored highlights as Readium **Decorations** via `EPUBNavigatorViewController.apply(decorations:in:"highlights")` (declarative — the adapter holds the active set and re-submits the whole group on each apply/remove/restore). Re-anchoring is **text-quote** based (WI-8a migration spike): each `HighlightRecord` → `Decoration(locator: Locator(href:, text: .Text(highlight: selectedText, before/after: context)), style: .highlight(tint:))` — Readium re-finds the quote, so the legacy XPath `serializedRange` is never consulted or mutated (flag-OFF returns to legacy XPath rendering losslessly). The host owns the adapter + a `HighlightCoordinator(renderer: adapter)`, calls `restoreAll()` on open, and observes `.readerHighlightRemoved`/`.readerHighlightsDidImport`. The WI-8 new-highlight refinement adds CREATE from a live Readium selection: `ReadiumReaderCoordinator` conforms to `SelectableNavigatorDelegate` and `navigator(_:shouldShowMenuForSelection:)` forwards the finalized `Selection` to the host then returns `false` (suppressing Readium's native menu so the designed `SelectionPopoverView` is the sole selection surface — rule 51). `ReadiumEPUBHost+Highlights` stashes the `Selection` in a generic `ReadiumSelectionTokenCache<Selection>` under a token, presents the popover; on a color tap (`.readerHighlightRequested`) it resolves the token and `ReadiumSelectionHighlightBuilder` maps the `Selection`'s text-quote (highlight/before/after) + container-relative href → `HighlightRecord` inputs → `HighlightCoordinator.create` → the same `ReadiumDecorationHighlightAdapter` renders it immediately; `navCommander.clearSelection()` dismisses the selection. Navigation landed in WI-9a: the host observes the shared reader nav bus — `.readerNextPage`/`.readerPreviousPage` → the coordinator's `goForward`/`goBackward`, and `.readerNavigateToLocator` (TOC/bookmark/search-result tap, object = a vreader `Locator`) → `go(to:)` after mapping the vreader Locator → Readium Locator (`readiumLocator(fromVReader:spineHrefs:)`, reusing the WI-8 legacy→spine href resolution). Host→coordinator dispatch goes through a host-owned `ReadiumNavCommander` (`@State`, bound on `attach`/cleared on `detach`, mirrors the WI-8 adapter ownership). WI-9a also split the host into `ReadiumEPUBHost.swift` (View) + `ReadiumNavigatorRepresentable.swift` + `ReadiumReaderCoordinator.swift`. Footnotes (#138, WI-9b) remain. Search result-list extraction still uses the existing FTS/`SearchViewModel` stack — WI-9a maps only result *navigation*. **Bilingual landed in WI-11 (paged) and WI-12 (scroll parity): interlinear bilingual works under the flag by driving the enumerate→prefetch→inject loop through Readium's one-way `evaluateJavaScript(_:) async -> Result<Any,Error>` channel — NOT a script-message handler (the navigator owns its content controller, exposing no app-side message channel; this is why the WI-11a `ReadiumBilingualEvalAdapter` RETURNS the `[{bid,text}]` array rather than posting it). A host-owned `ReadiumBilingualCommander` (`@State`, the bilingual counterpart of `ReadiumNavCommander`) holds an evaluator closure the coordinator binds on `attach` (the production non-DEBUG `ReadiumReaderCoordinator.evaluateForBilingual`, returning Readium's raw `Result<Any,Error>?`) and clears on `detach`; `enumerate()` runs `ReadiumBilingualEvalAdapter.enumerateJS()` and parses the return value via `EPUBBilingualPipeline.parseEnumerateMessage`, `inject(_:)`/`clear()` run the engine-agnostic inject/clear builders. The host reuses the feature-#56 `EPUBBilingualOrchestrator` (paged `-1` bucket via `updateBlocks(_:)`) + `BilingualReadingViewModel` + the designed `BilingualSetupSheet` (rule 51 — no new UI). Source text comes from vreader's own `EPUBParser` (opened alongside the Readium open — Readium does not expose raw spine HTML), so the `EPUBChapterTextProvider` is keyed on OPF-relative spine hrefs; the Readium-produced vreader `Locator` carries Readium's CONTAINER-relative href, so `ReadiumBilingualCommander.normalizedLocator(_:toSpineHrefs:)` rewrites it onto the OPF spine via the shared `ReadiumDecorationHighlightAdapter.resolveHref` tolerance before `vm.handlePositionChange(...)` (the WI-8 href-consistency finding class — without it `unit(containing:)` returns nil and nothing translates). Chapter-change detection composes onto the existing `onLocationChange` (WI-6 position save still runs): a fresh enumerate runs only when the spine href changes, deduped intra-chapter by a reference-type `ReadiumBilingualChapterTracker`. WI-12 lifted the WI-11 paged-only gate (`isBilingualSupported` is true for both layouts) so bilingual works in scroll too — but PER-SPINE only: Readium scroll mode is per-resource (it emits `locationDidChange` at spine boundaries, driving the same per-spine enumerate the paged path uses), and Readium has no multi-spine-stitch API, so off-screen chapters enumerate when scrolled into view rather than eagerly. This is a documented behavior delta vs legacy #71 — the flag-OFF `EPUBWebViewBridge` engine keeps its full stitched cross-chapter continuous bilingual; the Readium engine does not reproduce it. A paged↔scroll layout change re-renders the spine (discarding the `data-vreader-bid` stamps + decorations), so the layout-change handler re-enumerates the current spine in both directions.** TTS (WI-10): read-aloud already works under the Readium engine with NO Readium-specific code — `ReaderContainerView.startTTS()` → `ReaderAICoordinator.loadBookTextContent(format: "epub")` extracts spine text from the **file** via `EPUBParser` (renderer-agnostic, independent of which engine renders), then feeds the shared `TTSService` pipeline. Device-verified under `readiumEPUBEngine` ON (speaking, `ttsOffsetUTF16` advancing 42→115, stop→idle). The speaking-position **follow** landed in WI-10b: as TTS speaks, the navigator auto-advances so the spoken text stays on screen. `ReadiumEPUBHost` observes the shared `TTSService.currentOffsetUTF16` (threaded in like `EPUBReaderHost`); a pure value-type `ReadiumTTSFollowMapper` maps the flat UTF-16 offset → (spine href, intra-spine fraction). CRITICAL alignment: the per-spine offset table is built from the SAME spine text the TTS engine reads — `EPUBTextExtractor.stripHTML` + trim, skip empties, join `"\n\n"` (the `ReaderAICoordinator.loadBookTextContent` recipe) — extracted off-main from the host's already-open `bilingualParser` (so the index matches the engine's offsets; the block-preserving bilingual stripper is deliberately NOT used here). `ReadiumEPUBHost+TTSFollow` throttles: it navigates on any spine-href change or an intra-spine fraction drift > 0.08 (so the navigator tracks ~chapter-eighth granularity, not every `willSpeakRange` word), maps the target → a vreader `Locator` → Readium `Locator` via the WI-9a `readiumLocator(fromVReader:spineHrefs:)` resolution, and drives the existing `navCommander.navigate(to:)` → `navigator.go(to:)`. Follow runs only while TTS state == `.speaking`; the cursor resets on each play start and on pause/stop. This unblocks the WI-14 default-ON flip.
+137:`ReaderUnifiedCoordinator` loads text + applies transforms (replacement rules, simp/trad); `UnifiedTextRenderer` displays with TextKit 2 pagination or scroll. Feature #54 removed the unified path from the reader dispatch and the reader-settings Reading Mode picker, so this stack is **no longer reachable from reader dispatch** — it is retained (a follow-up may consume it for bilingual reading, or delete it once provably orphaned). Content replacement rules and Chinese conversion that previously required Unified mode now run in the native readers directly: `MDFileLoader.load` composes `ReplacementTransform` + `SimpTradTransform` over the decoded source text before parsing (feature #54 WI-7); **native EPUB applies replacement rules via `EPUBReplacementJS` (feature #54 Phase D-1)** — a CFI-safe per-text-node JS injection that runs on both EPUB engines (Readium per-spine via `ReadiumReaderCoordinator+Replacement`; the legacy #71 WKWebView stitch on `didFinish` via `EPUBWebViewBridgeCoordinator`, plus a scroll-root `MutationObserver` for appended chapters), keyed by `MDReplacementRuleFetcher`; native TXT has Chinese conversion only — TXT replacement rules are deferred (they need a source↔display offset map). Replacement rules apply at chapter/document open; a mid-read rules edit takes effect on next open (v1 scope).
+170:| `WebDAVProvider`                     | `WebDAVClient`             | `BackupProvider` impl — backup/restore/list/delete over a WebDAV server   |
+182:| `RemoteBookCatalog`                  | —                          | Pure decoder: extracts `library-manifest.json` from a backup ZIP via `ZIPWriter.extractEntry(named:from:)` and returns `[BackupLibraryEntry]`. Surfaces `manifestMissing` (older backups) / `manifestUndecodable` / `manifestSchemaVersionTooNew` as typed errors. Feature #47 WI-4a. |
+198:| `DebugBridge`                        | URL handler (DEBUG-only)   | `vreader-debug://` reset/seed/open/settle/snapshot/eval/tts/search/highlight/provider/present/ai/seed-sessions/seek/scroll-sheet/navigate/scroll-boundary/locate?highlight=N; feature #49 added position-aware open + DebugSnapshot schema v2 (TTS state, render phase, settings provenance); feature #74 added `locate?highlight=<N>` to drive `.readerNavigateToLocator` for the active TXT/MD reader CU-free so the locate "bloom" (highlight/note landing) fires on the real render path, plus DebugSnapshot schema v3 (`landingBloomCount` / `landingBloomPeakIntensity`) read back from `HighlightableTextView`'s persisted bloom counters — the ~1.5s sub-second bloom visual can't be screenshot/video-captured on the virtual display, so the snapshot proves it fired; feature #45 WI-4c-b added `tts?action=start\|stop` to bypass XCUITest's audio-session block; bug #238 added `search?query=...[&index=N]` to drive search-result-tap repros (Bug #182 / GH #621) CU-free; bug #237 added `highlight?start=...&end=...[&color=...]` for TXT/MD highlight creation CU-free; bug #243 added `provider?action=add\|remove\|clear` for AI provider configuration without driving Settings → AI through CU (unlocks Feature #56 b/d / Feature #65 / Feature #69 / Bug #93 autonomous AI verification); bug #253 added `present?sheet=...[&tab=...]` + bug #255 added `ai?action=summarize\|chat\|translate` for CU-free reader-sheet + AI-response-card verification; bug #263 added `seed-sessions?book=<key>[&seconds=<n>]` to seed a deterministic `ReadingSession` spread (one per dashboard window band) so the reading-stats dashboard (Feature #58) renders non-zero per-window totals CU-free; bug #267 added `seek?fraction=<0...1>` to drive the active Foliate (AZW3/MOBI) reader to a fractional position CU-free; bug #271 added `scroll-sheet?to=top\|bottom` to scroll the active presented sheet's content (today `TranslationResultCard`) so the accent translation card below the tall ORIGINAL card — beyond even the `detent=large` fold (Bug #256) — becomes screenshot-capturable, unblocking Feature #65 row 11; bug #273 added `navigate?spine=<N>[&fraction=<F>]` to drive `.readerNavigateToLocator` for the active EPUB reader CU-free (the `search` driver doesn't navigate in continuous mode), posting DEBUG-only `.debugBridgeNavigateCommand` → `EPUBReaderContainerView` resolves spine → href → `Locator` → re-posts `.readerNavigateToLocator` — unblocking feature #71 WI-8 continuous-mode navigation verification (paired with the `multi-chapter-epub` 4-tall-chapter fixture for the out-of-window rebuild branch); a follow-up added `scroll-boundary?spine=<N>&near=top\|bottom` to post a DEBUG-only `.debugBridgeScrollBoundaryCommand` → `EPUBReaderContainerView` builds an `EPUBScrollBoundarySignal` and calls `EPUBContinuousScrollCoordinator.handleBoundarySignal` directly — bypassing the rAF-throttled `continuousScrollObserverJS` (unverifiable CU-free on a virtual display) so feature #71's scroll-driven extend/evict RESPONSE can be device-verified. **Host-vs-runner driving constraint (bug #242 / GH #1054)**: bridge URLs MUST be invoked from the host (`xcrun simctl openurl` outside any iOS sandbox) — invoking them from inside an XCUITest binary fails with NSPOSIX 61 because the runner sandbox blocks the CoreSimulatorService XPC endpoint. In-runner verification flows use `XCTSkipUnless(bridgeReachable())` (PR #1053) when they cannot move the bridge-dependent assertion to a host-side driver. See `docs/subsystems/debug-bridge.md` § "Driving the bridge from a verification flow". |
+208:| `ChapterTranslationStore`            | SwiftData (actor-isolated) | Persistent disk cache for feature #56 bilingual reading. Wraps its own `ModelContext` over the `ChapterTranslation` `@Model` (SchemaV7) — a separate actor from `PersistenceActor` so bulk translation writes during a global-translate run never block library reads. App-scoped `.shared` single instance (the `ProviderProfileStore.shared` precedent); idempotent `upsert` fetches by `lookupKey` and updates in place, never relying on the unique constraint to throw. Returns the value-type `ChapterTranslationRecord` DTO, never the `@Model`. Bug #342: lazily migrates pre-#342 5-field keys (profile UUID baked in) to the canonical 4-field key on first access, deduping to the newest row. The cache is derived, re-fetchable data — excluded from WebDAV backup |
+209:| `ChapterTranslationService`          | `ChapterTranslationStore` + `AIService` | Translates one chapter unit for feature #56 bilingual reading. Pipeline: cache lookup → (on miss) `ChapterSegmenter` → `ChapterTranslationChunker` → one `AIService.sendRequest(_:using:)` per chunk → strict `TranslationChunkContract` JSON-array decode → per-segment fallback on any decode/count/element mismatch → recombine → cache-write. Reaches the AI side through the `TranslationRequestSending` boundary protocol (tests inject a mock). `Task.checkCancellation()` between chunks so a cancelled prefetch stops promptly |
+210:| `ChapterTextProviding` (`Services/Reader/`) | per-format reader services | Feature #56 WI-2.5 boundary protocol — supplies a book's translation units (`translationUnits()`), per-unit plain source text (`sourceText(for:)`), and the `Locator → unit` resolution (`unit(containing:)` / `unit(after:)`) the bilingual prefetch trigger needs. The translation *unit* is the format's natural rendering segment, not the logical TOC chapter (plan Decision 2.7). Four concrete `Sendable` `struct` adapters: `EPUBChapterTextProvider` (spine documents, HTML-stripped via `EPUBTextExtractor`), `TXTChapterTextProvider` (`TXTChapterIndex` chapters, UTF-16 slicing), `MDChapterTextProvider` (`MDHeading`-bounded chapters), `PDFChapterTextProvider` (page ranges via PDFKit). The AZW3/MOBI `FoliateChapterTextProvider` (an `actor`, bridges the `@MainActor` Foliate coordinator via the `FoliateSectionExtracting` facade) lands in WI-11. `ChapterTranslationService` / `BookTranslationCoordinator` consume this boundary, never a format-specific extractor |
+212:| `FoliateSectionExtracting` (`Services/Reader/`) | `FoliateSpikeView.Coordinator` (extension) | Feature #56 WI-11 — `@MainActor protocol` bridging the live Foliate per-section text extraction seam (the `readerAPI.bilingualSectionIDs` / `readerAPI.bilingualSectionText` JS calls) into the `Sendable` `ChapterTextProviding` boundary. Class-bound + `Sendable` + `@MainActor` means a `@MainActor`-isolated `AnyObject` existential is safely `Sendable` (members are main-actor-isolated), so the `FoliateChapterTextProvider` actor can hold a single live reference without an unsafe escape hatch |
+218:| `ChapterReTranslateViewModel` (`ViewModels/`) | `AIService` + `ChapterTranslationService` + `ChapterTranslationStore` | Feature #56 WI-15 `@MainActor @Observable` UI-facing state for the per-chapter re-translation flow. `presentPicker(...)` opens `ReTranslatePickerSheet` with the chosen unit + title + target language; `updateSelection(_:)` mutates the picker's `(providerProfileID, model, style, keepGlossary)` selection; `submit()` resolves the picker's `ResolvedAIProviderConfig` through the `RetranslateProviderResolving` boundary (`AIService` conforms), runs the translation through `ChapterReTranslating` (`ChapterTranslationService` conforms, with the cache READ bypassed so a fresh row can't no-op the re-translate — Bug #341 atomic swap + Bug #342 canonical key: the cache-write replaces the ONE `book|unit|lang|prompt` row in place, the original translation survives every failure/cancel path, and an override re-translation is readable by bilingual mode on reopen), and fires `onTranslationApplied` so the host posts `.readerBilingualReTranslateApplied`. Picker override never mutates `ProviderProfileStore` (acceptance criterion (f)) |
+219:| `EPUBBilingualPipeline` (`Views/Reader/Bilingual/`) | `EPUBBilingualJS` + `EPUBBilingualOrchestrator` | Feature #56 WI-10 pure glue between the EPUB WKWebView's `bilingualEnumerate` message payload and the `BilingualReadingViewModel`'s `translationsByUnit` cache. `parseEnumeratePayload(_:)` decodes the raw `Any` body into an `EPUBBilingualEnumeratePayload` (`{requestedSectionIndex, blocks}`) — accepting BOTH the paged bare-array shape (`[{bid,text}]`, no section identity) and the continuous-scroll envelope (`{sectionIndex, blocks}`); the envelope preserves the section identity on an EMPTY result so the container clears ONLY that section's bucket instead of every bucket (Feature #71 WI-7 Gate-4 round-3 MEDIUM 1). `parseEnumerateMessage(_:)` is the flat-`[BilingualBlock]` convenience over it; `translationsByBid(blocks:translatedSegments:)` maps the VM's ordered segment array onto a `[bid: text]` lookup by position. No `@MainActor` — pure value transforms |
+223:| `FoliateBilingualContainerView` (`Views/Reader/`) | `FoliateSpikeView` + `FoliateBilingualOrchestrator` + `BilingualReadingViewModel` + `FoliateChapterTextProvider` | Feature #56 WI-11 — AZW3/MOBI host wrapper that adds the bilingual VM / orchestrator / setup-sheet wiring around the unchanged `FoliateSpikeView`. Owns the bilingual `@State`, the first-enable `BilingualSetupSheet`, and the notification plumbing (`.readerMoreBilingual` → toggle, `.foliateSectionLoaded` → enumerate, `.foliateBilingualBlocksEnumerated` → cache + prefetch, `.readerBilingualDidChange` → inject) that mirrors `EPUBReaderContainerView+Bilingual` for the live Foliate path |
+224:| `BilingualDisplaySegmentMap` (`Services/Reader/`) | `BilingualTextRenderer`, `TXTReaderContainerView`, `MDReaderContainerView` | Feature #56 WI-12a pure `Sendable` value type — the TXT/MD source↔display UTF-16 offset map. Records ordered display segments tagged `.source(sourceRange:displayRange:)` or `.synthetic(displayRange:)`. `sourceOffset(forDisplayOffset:)` returns `nil` for synthetic ranges or out-of-bounds offsets; `displayOffset(forSourceOffset:)` clamps a past-end source position to display end. `identity(sourceLength:)` builds the 1:1 pass-through used when bilingual is off. WI-12b consumes the map in TXT/MD container offset-routing |
+227:| `BilingualAttributedStringComposer` (`Views/Reader/Bilingual/`) | `BilingualDisplaySegmentMap`, `BilingualTextRenderer` | Feature #56 WI-12b — typography-preserving interlinear composer. `compose(sourceAttributed:sourceParagraphRanges:translatedSegments:)` takes an already-typographed source `NSAttributedString` (font, line spacing, drop-cap, heading restyle) and interleaves synthetic translation runs at paragraph boundaries. Synthetic runs inherit the prior source paragraph's attrs + carry the `decorationAttributeKey`. Used by TXT's chapter-paged path so the chapter-start drop-cap + heading restyle survive the bilingual interleave |
+228:| `BilingualDisplayPipeline` (`Views/Reader/Bilingual/`) | `BilingualTextRenderer`, `BilingualAttributedStringComposer`, `BilingualReadingViewModel` | Feature #56 WI-12b — `@MainActor` bridge between the bilingual VM state and the renderer/composer. `makeDisplay(...)` builds a fresh attrString from a plain `String` source; `compose(sourceAttributed:...)` preserves an upstream typographed attrString. Both off-path (no VM / disabled / no unit / no cached translation) returns the source + identity map — the byte-identical pass-through that gates the R-TXT-offsets risk |
+229:| `BilingualOffsetRouter` (`Views/Reader/Bilingual/`) | `BilingualDisplaySegmentMap` | Feature #56 WI-12b — pure source↔display offset router for the TXT/MD container's bilingual surfaces. Helpers: `displayOffset(forSourceOffset:map:)`, `sourceOffset(forDisplayOffset:map:)`, `displayRange(forSourceRange:map:)` (segment-union projection — a source range that crosses an intervening synthetic block produces a spanning display range), `displayNSRange(forSourceNSRange:map:)`, `isSynthetic(displayOffset:map:)`. Identity-map mode is byte-identical to today's offset code |
+230:| `BilingualTXTBridgeDelegateAdapter` (`Views/Reader/Bilingual/`) | `BilingualDisplaySegmentMap`, `TXTTextViewBridge` | Feature #56 WI-12b — `@MainActor` delegate wrapper that maps display-domain offsets the bridge reports (selection range, top-visible-char scroll offset) back to source-domain offsets via `BilingualOffsetRouter`, so the TXT VM keeps persisting positions in document source coordinates with bilingual on. A selection that starts inside a synthetic translation run is dropped; a scroll-into-synthetic projects to the end of the preceding source segment. Identity map (bilingual off) is a transparent pass-through |
+231:| `TXTLoaderBackedChapterTextProvider` (`Services/Reader/`) | `ChapterTextProviding`, `TXTChapterContentLoader` | Feature #56 WI-12b — chapter-paged-mode `ChapterTextProviding` adapter that reads each chapter on demand via the live reader's `TXTChapterContentLoader` actor. Sibling to `TXTChapterTextProvider` (full-book-slicing). Re-enables bilingual mode for chapter-paged TXT, the mode WI-12a's `makeTextProvider` explicitly disabled because the VM's `textContent` is chapter-local in that mode |
+232:| `PDFBilingualPanel` (`Views/Reader/Bilingual/`) | `PDFBilingualPanelState`, `BilingualLanguage`, `ReaderThemeV2` | Feature #56 WI-13 — PDF below-page bilingual translation panel. Stateless SwiftUI sub-view rendering the design's split-layout A1..A8: header (lang-glyph chip + page label + status suffix + chevron) + body switched on `PDFBilingualPanelState` (5 states: `.off` / `.loading` / `.translated([String])` / `.offline` / `.empty`). PDF is fixed-layout so the paragraph-interlinear renderer used by EPUB/Foliate/TXT/MD doesn't apply; the panel below the page is the entire user-visible bilingual surface for PDF. 260pt expanded / 38pt collapsed; attached to `PDFViewBridge` via SwiftUI's `.safeAreaInset(edge: .bottom)` so PDFKit's `autoScales` reflows the page rendering automatically |
+233:| `PDFBilingualPanelState` (`Views/Reader/Bilingual/`) | `BilingualReadingViewModel`, `PDFChapterTextProvider` | Feature #56 WI-13 — pure synchronous derivation of the panel's 5-state matrix from the bilingual VM + the PDF's `(currentPage, pagesPerUnit, totalPages)` triple. Computes the current `TranslationUnitID` synchronously (mirrors `PDFChapterTextProvider.pageRanges` arithmetic) instead of reading the VM's async-updated `lastTriggerUnit`, so page-turn-in-flight doesn't flash stale translations (Gate-2 v5 round-1 H1). `.empty` keyed on "translated segments empty after fetch" OR "totalPages <= 0", NOT `unit == nil` (which would never fire for a real PDF — Gate-2 v5 round-1 M1) |
+234:| `PDFReaderContainerView+Bilingual` (`Views/Reader/`) | `BilingualReadingViewModel`, `PDFChapterTextProvider`, `PDFBilingualPanel`, `PDFBilingualPanelState` | Feature #56 WI-13 — PDF host extension owning the bilingual VM lifecycle (lazy construction gated on `viewModel.isDocumentLoaded` + `totalPages > 0`), the `PDFChapterTextProvider` build, the prefetcher build (mirrors TXT/EPUB `makePrefetcher`), the first-enable setup sheet, the More-menu toggle observer, the retry observer (`.readerBilingualRetry`), and the `.safeAreaInset`-attached panel. On reopen of an already-enabled book, `ensureBilingualViewModel` kicks the initial `handlePositionChange` so the panel doesn't stick in `.loading` for the open page (Gate-4 round-1 H1). Mirrors `TXTReaderContainerView+Bilingual` / `MDReaderContainerView+Bilingual` / `EPUBReaderContainerView+Bilingual` structurally |
+238:SwiftData SchemaV10 entities (V9→V10 adds the additive optional `Book.sourceCanonicalKey: String?` — feature #108's converted-Kindle cross-platform identity, carried in the backup manifest; feature #109's NFC locator-key recompute runs as the launch-time `LocatorKeyBackfillMigration`, not a schema migration — see the App Layer note above):
+240:- `Book` (fingerprintKey unique; gains `originalExtension: String?` in SchemaV5 for backup blob extension preservation; gains `fileState: String` and `blobPath: String?` in SchemaV6 for feature #47's lazy-load row state; gains `sourceCanonicalKey: String?` in SchemaV10 — feature #108's converted-Kindle source-bytes cross-platform identity, while the converted-EPUB `fingerprintKey` stays the local primary) → `ReadingPosition` (gains `vreaderLocatorData: Data?` in SchemaV8 — feature #42's engine-agnostic `VReaderLocator` envelope, stored as raw JSON `Data?` mirroring `Highlight.anchorData`; additive/optional → lightweight migration, no stage), `Highlight`, `Bookmark`, `AnnotationNote`, `BookCollection`, `ChatSession` (SchemaV9 cascade child)
+243:- `ChapterTranslation` (added in SchemaV7 — feature #56 bilingual-reading persistent translation cache; independent entity, no `@Relationship` to `Book`; `lookupKey: String` is the `@Attribute(.unique)` dedupe key joined from `bookFingerprintKey` + `unitStorageKey` + `targetLanguage` + `promptVersion` — Bug #342 dropped `providerProfileID` from the key (now provenance metadata only; one canonical translation shared by bilingual reading + re-translate), with a lazy in-store migration for pre-#342 rows)
+246:`PersistenceActor.fetchAllBooksForBackup() -> [BackupBookProjection]` (in `PersistenceActor+Backup.swift`) returns a Sendable value-type view of every book — used by feature #46's WebDAV backup to emit `library-manifest.json` without leaking `@Model` instances across the actor boundary. Legacy V4 rows (no `originalExtension`) coalesce to the canonical extension for their format.
+250:**Feature #46 — WebDAV materializing restore (data layer)**: backup ZIPs now carry an additional `library-manifest.json` section (one `BackupLibraryEntry` per book, including content-addressed `blobPath`). On `backup`, `WebDAVProvider` uploads each missing book blob atomically — `WebDAVBlobStore` PUTs to `VReader/uploads/tmp/<uuid>.part`, PROPFIND-verifies the size, then `MOVE`s into the canonical `VReader/books/<format>/<sha256>_<byteCount>.<ext>` path. Repeat backups skip already-published blobs via PROPFIND-by-size dedupe. On `restore`, when the manifest is present and a `BookImporter` is wired in (production: via `\.bookImporter` SwiftUI Environment), `BookFileMaterializer` downloads + verifies + imports each missing blob before metadata sections apply. v1-format backups (no manifest) restore as before — books silently skipped if missing locally. The 412 response from `MOVE Overwrite: F` is treated as "blob already converged" (content-addressing). 501 from `MOVE` raises `BackupBlobStoreError.serverCapabilityMissing` — no silent atomicity loss.
+252:**Feature #89 — AI conversations backup (data layer)**: backup ZIPs carry an
+262:by the unique `sessionId`, always re-keys `bookFingerprintKey` to the backup
+263:("backup value wins"), re-associates `row.book` when the book is present locally
+318:| `.readerMoreBilingual`         | nil                  | `ReaderMorePopover` → format containers (Feature #56 WI-8 — tap the bilingual row; per-format containers route to `BilingualReadingViewModel.setEnabled(...)`, or to AI Settings when bilingual is `.unavailable`) |
+321:| `.readerBilingualDidChange`    | `["fingerprintKey": String, "isEnabled": Bool, "targetLanguage": String, "granularity": String]` | `BilingualReadingViewModel` → format renderers + parent reader chrome (Feature #56 WI-7b/WI-10/WI-11 — bilingual toggled on/off, language changed, or a unit's translation became available; renderers re-inject or clear the interlinear translation, the parent `ReaderContainerView` mirrors `isEnabled` + `targetLanguage` into `bilingualActive` / `bilingualLanguage` so the `BilingualPill` and More-menu row paint without crossing the host boundary) |
+323:| `.readerMoreTranslationSettings` | `["fingerprintKey": String, "bookTitle": String]` | More-menu settings row + bilingual pill → per-format bilingual hosts (Feature #99 — keyed re-entry; the host presents the edit-framed `BilingualSetupSheet`. Every More-menu row post now carries `fingerprintKey`; only this one REQUIRES filtering) |
+326:| `.readerBilingualRetry`        | nil | PDF below-page bilingual panel offline-state Retry button → `PDFReaderContainerView+Bilingual` (Feature #56 WI-13 — host calls `BilingualReadingViewModel.retryUnit(currentUnit)`, scoped to the current page's unit, NOT the whole-book `resetTriggerState()`) |
+327:| `.readerBilingualSectionMaterialized` | `["fingerprintKey": String, "spineIndex": Int]` | `EPUBContinuousScrollCoordinator` (via `EPUBContinuousScrollConfig.onSectionMaterialized`) → `EPUBReaderContainerView+ContinuousBilingual` (Feature #71 WI-7 — a stitched chapter section materialized in EPUB continuous-scroll mode; the modifier drives a SECTION-SCOPED enumerate `bilingualEnumerateJS(spineIndex:)` through the live evaluator, then prefetches + injects THAT section's own unit. Posted with no View capture from the long-lived config closure) |
+329:| `.readerOpenAITranslate`       | nil | PDF below-page bilingual panel offline-state "Open AI tab" button → ReaderContainerView (Feature #56 WI-13 — gated on `resolvedAICoordinator.isAIAvailable`; resets `translationViewModel` then sets `aiInitialTab = .translate` + `showAIPanel = true` to open the AI Translate tab cold without a selection) |
+332:| `.foliateBilingualBlocksEnumerated` | `["blocks": [BilingualBlock], "fingerprintKey": String]` | `FoliateSpikeView.Coordinator` → `FoliateBilingualContainerView` (Feature #56 WI-11 — AZW3/MOBI live `bilingualEnumerate` JS message parsed into `[BilingualBlock]`; the container caches blocks on the orchestrator and asks the bilingual VM to prefetch translations for the current unit) |
+338:| `.foliateSectionLoaded`        | `["sectionIndex": Int, "fingerprintKey": String]` | `FoliateSpikeView.Coordinator` → `FoliateBilingualContainerView` (Feature #56 WI-11 — Foliate-js `section-load` event surfaced so the bilingual container refreshes its enumerate payload against the freshly-rendered section) |
+512:## Android App (`android/` — feature #106 foundation bar)
+514:vreader's Android app is a **second, independently-shippable native app**
+516:shares the identity / locator / cache-key / backup **contracts**
+524:> module, Room persistence, EPUB import, and the resume bridge. The
+535:| `:app` | Android application | Compose UI shell + the Room data layer + reader plumbing. `com.vreader.app`. |
+536:| `:identity` | pure Kotlin/JVM (no Android deps) | The shared canonical contracts — `Identity` (fingerprint canonical key), `CanonicalLocator` (engine-neutral canonical JSON), `DocumentFingerprint` (streaming SHA-256 + format detection), and the `Locator` / `VReaderLocator` / `ReaderLocatorEngine` value types. **Both `:app` AND the `contracts/conformance` lane depend on this one module**, so the golden-vector conformance test proves the SAME code the app runs. |
+540:- **Room** is the SwiftData analog. `VReaderDatabase` (`@Database` v4,
+550:  is the canonical `Locator.canonicalJson()` (the #113 backup contract); the
+555:  the Room schema.
+560:  never Room entities, across the boundary (the rule-50 §2 analog).
+
+exec
+/bin/zsh -lc "rg -n \"bilingualGranularity|bilingualEnabled|bilingualTargetLanguage\" contracts android vreader | head -120; rg -n \"ChapterTranslationEntity|sourceParagraphCount|unitStorageKey|translatedJson\" android/app/src/main/kotlin android/app/schemas 2>/dev/null | head -80; rg --files android/app | rg '/schemas/|VReaderDatabaseMigrationTest' | tail -30" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+contracts/vectors/backup-sections.json:116:            "bilingualEnabled": true,
+contracts/vectors/backup-sections.json:117:            "bilingualTargetLanguage": "Chinese"
+android/identity/src/main/kotlin/vreader/contracts/backup/BackupSectionsExtended.kt:69:    val bilingualEnabled: Boolean? = null,
+android/identity/src/main/kotlin/vreader/contracts/backup/BackupSectionsExtended.kt:70:    val bilingualTargetLanguage: String? = null,
+android/identity/src/main/kotlin/vreader/contracts/backup/BackupSectionsExtended.kt:71:    val bilingualGranularity: String? = null,
+android/identity/src/test/kotlin/vreader/contracts/backup/BackupSectionsExtendedTest.kt:86:            override = PerBookSettingsOverride(fontSize = 18.0, bilingualEnabled = true, bilingualTargetLanguage = "Chinese"),
+android/identity/src/test/kotlin/vreader/contracts/backup/BackupSectionsExtendedTest.kt:91:        assertTrue(json.contains("\"bilingualEnabled\""))
+vreader/Services/AI/ChapterTranslationService.swift:72:/// `bilingualGranularity`).
+vreader/Services/PerBookSettings.swift:33:    var bilingualEnabled: Bool?
+vreader/Services/PerBookSettings.swift:37:    var bilingualTargetLanguage: String?
+vreader/Services/PerBookSettings.swift:41:    var bilingualGranularity: String?
+vreader/Services/PerBookSettings.swift:53:        bilingualEnabled: Bool? = nil,
+vreader/Services/PerBookSettings.swift:54:        bilingualTargetLanguage: String? = nil,
+vreader/Services/PerBookSettings.swift:55:        bilingualGranularity: String? = nil
+vreader/Services/PerBookSettings.swift:62:        self.bilingualEnabled = bilingualEnabled
+vreader/Services/PerBookSettings.swift:63:        self.bilingualTargetLanguage = bilingualTargetLanguage
+vreader/Services/PerBookSettings.swift:64:        self.bilingualGranularity = bilingualGranularity
+vreader/Views/Reader/ReaderContainerView+Sheets.swift:405:            rawValue: bilingualGranularity ?? "") ?? .paragraph
+vreader/ViewModels/AIAssistantViewModel.swift:77:    /// seeds the per-book `bilingualTargetLanguage` once on first appear
+vreader/ViewModels/BilingualReadingViewModel.swift:154:        self.isEnabled = override?.bilingualEnabled ?? false
+vreader/ViewModels/BilingualReadingViewModel.swift:155:        self.targetLanguage = override?.bilingualTargetLanguage ?? Self.defaultTargetLanguage
+vreader/ViewModels/BilingualReadingViewModel.swift:157:            rawValue: override?.bilingualGranularity ?? "") ?? .paragraph
+vreader/ViewModels/BilingualReadingViewModel.swift:256:        return override?.bilingualEnabled != nil
+vreader/ViewModels/BilingualReadingViewModel.swift:257:            || override?.bilingualTargetLanguage != nil
+vreader/ViewModels/BilingualReadingViewModel.swift:258:            || override?.bilingualGranularity != nil
+vreader/ViewModels/BilingualReadingViewModel.swift:266:        override.bilingualEnabled = isEnabled
+vreader/ViewModels/BilingualReadingViewModel.swift:267:        override.bilingualTargetLanguage = targetLanguage
+vreader/ViewModels/BilingualReadingViewModel.swift:268:        override.bilingualGranularity = granularity.rawValue
+vreader/Views/Reader/ReaderAICoordinator.swift:274:           let langKey = override.bilingualTargetLanguage {
+vreader/Views/Reader/Bilingual/BilingualLanguage.swift:3:// (`bilingualTargetLanguage`) all key off. Pinned to the design
+vreader/Views/Reader/Bilingual/BilingualLanguage.swift:28://   PerBookSettings.swift (`bilingualTargetLanguage`),
+vreader/Views/Reader/Bilingual/BilingualLanguage.swift:36:    /// Canonical key persisted in `PerBookSettings.bilingualTargetLanguage`
+vreader/Views/Reader/Bilingual/BilingualSetupSheet.swift:207:                    .accessibilityIdentifier("bilingualGranularity_\(option.rawValue)")
+vreader/Views/Reader/Bilingual/BilingualSetupSheet.swift:229:                .accessibilityIdentifier("bilingualGranularityUnavailableFootnote")
+vreader/Views/Reader/ReaderTopChrome.swift:48:    /// `PerBookSettings.bilingualTargetLanguage`. `nil` (book never
+vreader/Views/Reader/ReaderContainerView.swift:223:    @State var bilingualGranularity: String?
+vreader/Views/Reader/ReaderContainerView.swift:540:                bilingualGranularity = granularity
+android/app/schemas/com.vreader.app.data.VReaderDatabase/5.json
+android/app/schemas/com.vreader.app.data.VReaderDatabase/4.json
+android/app/schemas/com.vreader.app.data.VReaderDatabase/8.json
+android/app/schemas/com.vreader.app.data.VReaderDatabase/3.json
+android/app/schemas/com.vreader.app.data.VReaderDatabase/2.json
+android/app/schemas/com.vreader.app.data.VReaderDatabase/7.json
+android/app/schemas/com.vreader.app.data.VReaderDatabase/6.json
+android/app/src/test/kotlin/com/vreader/app/data/VReaderDatabaseMigrationTest.kt
+
+exec
+/bin/zsh -lc "nl -ba android/app/src/test/kotlin/com/vreader/app/ai/AiSettingsViewModelTest.kt | sed -n '45,78p'; nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt | sed -n '45,90p'; rg -n \"AiProviderListScreen\\(\" android/app/src/main android/app/src/test android/app/src/androidTest" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+    45	    @Before fun setUp() {
+    46	        Dispatchers.setMain(dispatcher)
+    47	        // DataStore on the SAME test dispatcher so advanceUntilIdle() drives its IO too.
+    48	        store = AiProviderStore(
+    49	            PreferenceDataStoreFactory.create(scope = CoroutineScope(dispatcher)) { tmp.newFile("ai.preferences_pb") },
+    50	            cipher,
+    51	        )
+    52	    }
+    53	
+    54	    @After fun tearDown() = Dispatchers.resetMain()
+    55	
+    56	    private fun vm(result: AiTestResult = AiTestResult.Ok) =
+    57	        AiSettingsViewModel(store, dispatcher) { _, _ -> FakeClient(result) }
+    58	
+    59	    @Test fun openAdd_test_ok_thenSave_persists() = runTest(dispatcher) {
+    60	        val vm = vm(AiTestResult.Ok)
+    61	        vm.openAdd()
+    62	        vm.update { it.copy(name = "OpenRouter", apiKey = "sk-test") }
+    63	        vm.test(); advanceUntilIdle()
+    64	        assertEquals(AiConnTest.ok, vm.editState.value!!.test)
+    65	
+    66	        vm.save(); advanceUntilIdle()
+    67	        assertNull(vm.editState.value)                     // sheet closed
+    68	        assertEquals(1, store.list().size)                 // persisted
+    69	        assertEquals("sk-test", store.apiKey(store.list()[0].id))
+    70	    }
+    71	
+    72	    @Test fun test_fail_surfacesMessage() = runTest(dispatcher) {
+    73	        val vm = vm(AiTestResult.Fail(AiError.Auth401, "Failed: 401"))
+    74	        vm.openAdd()
+    75	        vm.update { it.copy(name = "X", apiKey = "bad") }
+    76	        vm.test(); advanceUntilIdle()
+    77	        assertEquals(AiConnTest.fail, vm.editState.value!!.test)
+    78	        assertTrue(vm.editState.value!!.testMessage.contains("401"))
+    45	import androidx.compose.ui.unit.sp
+    46	import com.vreader.app.backup.AppSheet
+    47	import com.vreader.app.backup.BackupFonts
+    48	import com.vreader.app.backup.GroupFooter
+    49	import com.vreader.app.backup.GroupHeader
+    50	import com.vreader.app.backup.LocalBackupTokens
+    51	import com.vreader.app.backup.SettingsCard
+    52	import com.vreader.app.backup.VSpace
+    53	
+    54	@Composable
+    55	fun AiProviderEditSheet(
+    56	    state: AiEditState,
+    57	    onKind: (AiProviderKind) -> Unit = {},
+    58	    onName: (String) -> Unit = {},
+    59	    onBaseUrl: (String) -> Unit = {},
+    60	    onModel: (String) -> Unit = {},
+    61	    onTemperature: (Double) -> Unit = {},
+    62	    onMaxTokens: (Int) -> Unit = {},
+    63	    onApiKey: (String) -> Unit = {},
+    64	    onDeleteKey: () -> Unit = {},
+    65	    onTest: () -> Unit = {},
+    66	    onSave: () -> Unit = {},
+    67	    onCancel: () -> Unit = {},
+    68	) {
+    69	    val t = LocalBackupTokens.current
+    70	    Box(Modifier.fillMaxSize()) {
+    71	        AppSheet(
+    72	            title = if (state.editMode) "Edit Provider" else "Add Provider",
+    73	            leading = {
+    74	                Box(Modifier.sizeIn(minWidth = 48.dp, minHeight = 48.dp).clickable(onClick = onCancel), contentAlignment = Alignment.CenterStart) {
+    75	                    Text("Cancel", color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 15.sp)
+    76	                }
+    77	            },
+    78	            trailing = {
+    79	                Box(Modifier.sizeIn(minWidth = 48.dp, minHeight = 48.dp).clickable(enabled = state.canSave, onClick = onSave).testTag("ai-save"), contentAlignment = Alignment.CenterEnd) {
+    80	                    Text("Save", color = if (state.canSave) t.tint else t.ter, fontFamily = BackupFonts.Sans, fontSize = 15.sp, fontWeight = FontWeight.SemiBold)
+    81	                }
+    82	            },
+    83	        ) {
+    84	            Column(Modifier.padding(horizontal = 18.dp).padding(top = 16.dp, bottom = 32.dp)) {
+    85	                GroupHeader("Provider Type")
+    86	                Segmented(state.kind, onKind)
+    87	
+    88	                VSpace(20)
+    89	                GroupHeader("Name")
+    90	                SettingsCard { Field("", state.name, "e.g. OpenRouter", onName) }
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderListScreenTest.kt:23:            BackupSurface(darkOverride = false) { AiProviderListScreen(AiProviderListState(emptyList()), onAdd = { added = true }) }
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderListScreenTest.kt:38:        compose.setContent { BackupSurface(darkOverride = false) { AiProviderListScreen(state, onEdit = { edited = it }) } }
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:46:fun AiProviderListScreen(
+
+exec
+/bin/zsh -lc "rg -n \"enum BilingualGranularity|case paragraph|case sentence\" vreader | head -30; nl -ba android/identity/src/main/kotlin/vreader/contracts/backup/BackupSectionsExtended.kt | sed -n '55,78p'; nl -ba contracts/vectors/backup-sections.json | sed -n '105,125p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+vreader/Services/AI/ChapterTranslationService.swift:74:    case paragraph
+vreader/Services/AI/ChapterTranslationService.swift:75:    case sentence
+    55	data class BackupPerBookSettingsEntry(
+    56	    val bookFingerprintKey: String,
+    57	    val override: PerBookSettingsOverride,
+    58	)
+    59	
+    60	/** Per-book reader overrides — mirrors Swift `PerBookSettingsOverride` (CGFloat ⇒ Double).
+    61	 *  All fields optional; a nil inherits the global default. */
+    62	@Serializable
+    63	data class PerBookSettingsOverride(
+    64	    val fontSize: Double? = null,
+    65	    val fontName: String? = null,
+    66	    val lineSpacing: Double? = null,
+    67	    val letterSpacing: Double? = null,
+    68	    val themeName: String? = null,
+    69	    val bilingualEnabled: Boolean? = null,
+    70	    val bilingualTargetLanguage: String? = null,
+    71	    val bilingualGranularity: String? = null,
+    72	    val metricsReadout: String? = null,
+    73	)
+    74	
+    75	// MARK: - Replacement Rules
+    76	
+    77	@Serializable
+    78	data class BackupReplacementRulesEnvelope(
+   105	          "customOrder": 0
+   106	        }
+   107	      ]
+   108	    },
+   109	    "per-book-settings": {
+   110	      "schemaVersion": 3,
+   111	      "entries": [
+   112	        {
+   113	          "bookFingerprintKey": "epub:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:1024",
+   114	          "override": {
+   115	            "fontSize": 18.0,
+   116	            "bilingualEnabled": true,
+   117	            "bilingualTargetLanguage": "Chinese"
+   118	          }
+   119	        }
+   120	      ]
+   121	    },
+   122	    "replacement-rules": {
+   123	      "schemaVersion": 3,
+   124	      "rules": [
+   125	        {
+
+codex
+## Critical
+
+None.
+
+## High
+
+- **H2 remains unresolved: item-level visibility no longer proves source-text visibility.** The `Column` correctly preserves one lazy item per chunk and therefore preserves index identity. However, adding translation content increases that item’s height. When the source `Text` has scrolled above the viewport but its translation sibling remains visible, `visibleItemsInfo` still contains the chunk’s item index. The existing TTS guard therefore suppresses `animateScrollToItem(spokenChunk)`, leaving the spoken source off-screen ([TxtReaderActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:252), [TxtReaderActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:256)). The plan incorrectly equates item visibility with source visibility and does not test the translation-only-visible case ([plan](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:89), [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:109), [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:375)).  
+  **Required patch:** define TTS visibility using the registered source `Text` bounds—not merely `visibleItemsInfo.index`—and add a test where only the translation portion of `spokenChunk`’s item is visible. This is newly introduced by the in-item `Column`.
+
+## Medium
+
+None.
+
+## Low
+
+None.
+
+## Resolved checks
+
+- **H1 resolved.** `Utf16Span(start, endExclusive)` is consistently half-open and replaces contractual `IntRange` signatures ([plan](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:61), [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:72)). The final-chunk calculation matches `textForChunk` ([TxtDocument.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:36)); `endExclusive - 1` correctly anchors one-chunk, final-chunk, exact-boundary, and EOF spans because `chunkForOffset` chooses the greatest start not exceeding the offset ([TxtDocument.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:23)).
+
+- **H2 otherwise resolved.** A `Column` child creates no lazy item, so position saving, progress, jumps, and lazy keys retain chunk-index identity. Source layout/registration remains one-per-chunk ([TxtReaderActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1043), [TxtReaderActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1059)). Explicit gesture exclusion is necessary because `hitAt` falls back to the nearest registered source chunk ([TxtSelectionController.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:47)).
+
+- **H3 resolved.** The renderer design is paragraph-interlinear only ([vreader-bilingual.jsx](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx:195), [vreader-bilingual.jsx](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx:241)). Descoping the Sentence control alongside its unsupported behavior is sound: it prevents sentence-keyed paragraph rows and exposes no undesigned sentence renderer. The divergence and follow-up are explicit ([plan](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:116), [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:424)).
+
+- **H4 resolved.** The live list screen owns incompatible chrome, generic empty copy, and edit-on-tap behavior ([AiProviderListScreen.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:59), [AiProviderListScreen.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:84), [AiProviderListScreen.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:105)). A new scoped list matches the designed back label, empty state, checked row, and select action ([vreader-ai-provider-entry.jsx](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:180), [vreader-ai-provider-entry.jsx](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:221), [vreader-ai-provider-entry.jsx](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:247)). Awaiting `upsert`’s returned profile ID before `setActive` and pop is race-free ([AiProviderStore.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:60), [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:372)).
+
+- **Gap A resolved.** The DDL matches the proposed non-null entity columns, PK, index, and existing FK/CASCADE conventions ([plan](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:246), [VReaderDatabase.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:151)). Opening the migrated database against generated `9.json` is the correct structural guard.
+
+- **Gap B resolved.** Android already declares the nullable field, while the shared vector currently omits it ([BackupSectionsExtended.kt](/Users/ll/workspace/vreader/android/identity/src/main/kotlin/vreader/contracts/backup/BackupSectionsExtended.kt:63), [backup-sections.json](/Users/ll/workspace/vreader/contracts/vectors/backup-sections.json:109)). Because backup collection/restoration is explicitly outside v1, the conformance-vector and iOS-parity follow-up is adequate and non-blocking.
+
+FINAL VERDICT: block-recommended
+tokens used
+101,368
+## Critical
+
+None.
+
+## High
+
+- **H2 remains unresolved: item-level visibility no longer proves source-text visibility.** The `Column` correctly preserves one lazy item per chunk and therefore preserves index identity. However, adding translation content increases that item’s height. When the source `Text` has scrolled above the viewport but its translation sibling remains visible, `visibleItemsInfo` still contains the chunk’s item index. The existing TTS guard therefore suppresses `animateScrollToItem(spokenChunk)`, leaving the spoken source off-screen ([TxtReaderActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:252), [TxtReaderActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:256)). The plan incorrectly equates item visibility with source visibility and does not test the translation-only-visible case ([plan](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:89), [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:109), [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:375)).  
+  **Required patch:** define TTS visibility using the registered source `Text` bounds—not merely `visibleItemsInfo.index`—and add a test where only the translation portion of `spokenChunk`’s item is visible. This is newly introduced by the in-item `Column`.
+
+## Medium
+
+None.
+
+## Low
+
+None.
+
+## Resolved checks
+
+- **H1 resolved.** `Utf16Span(start, endExclusive)` is consistently half-open and replaces contractual `IntRange` signatures ([plan](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:61), [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:72)). The final-chunk calculation matches `textForChunk` ([TxtDocument.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:36)); `endExclusive - 1` correctly anchors one-chunk, final-chunk, exact-boundary, and EOF spans because `chunkForOffset` chooses the greatest start not exceeding the offset ([TxtDocument.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtDocument.kt:23)).
+
+- **H2 otherwise resolved.** A `Column` child creates no lazy item, so position saving, progress, jumps, and lazy keys retain chunk-index identity. Source layout/registration remains one-per-chunk ([TxtReaderActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1043), [TxtReaderActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1059)). Explicit gesture exclusion is necessary because `hitAt` falls back to the nearest registered source chunk ([TxtSelectionController.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:47)).
+
+- **H3 resolved.** The renderer design is paragraph-interlinear only ([vreader-bilingual.jsx](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx:195), [vreader-bilingual.jsx](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx:241)). Descoping the Sentence control alongside its unsupported behavior is sound: it prevents sentence-keyed paragraph rows and exposes no undesigned sentence renderer. The divergence and follow-up are explicit ([plan](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:116), [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:424)).
+
+- **H4 resolved.** The live list screen owns incompatible chrome, generic empty copy, and edit-on-tap behavior ([AiProviderListScreen.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:59), [AiProviderListScreen.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:84), [AiProviderListScreen.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:105)). A new scoped list matches the designed back label, empty state, checked row, and select action ([vreader-ai-provider-entry.jsx](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:180), [vreader-ai-provider-entry.jsx](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:221), [vreader-ai-provider-entry.jsx](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:247)). Awaiting `upsert`’s returned profile ID before `setActive` and pop is race-free ([AiProviderStore.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:60), [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:372)).
+
+- **Gap A resolved.** The DDL matches the proposed non-null entity columns, PK, index, and existing FK/CASCADE conventions ([plan](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:246), [VReaderDatabase.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/data/VReaderDatabase.kt:151)). Opening the migrated database against generated `9.json` is the correct structural guard.
+
+- **Gap B resolved.** Android already declares the nullable field, while the shared vector currently omits it ([BackupSectionsExtended.kt](/Users/ll/workspace/vreader/android/identity/src/main/kotlin/vreader/contracts/backup/BackupSectionsExtended.kt:63), [backup-sections.json](/Users/ll/workspace/vreader/contracts/vectors/backup-sections.json:109)). Because backup collection/restoration is explicitly outside v1, the conformance-vector and iOS-parity follow-up is adequate and non-blocking.
+
+FINAL VERDICT: block-recommended

--- a/.claude/codex-audits/feat-131-bilingual-gate2-round6.md
+++ b/.claude/codex-audits/feat-131-bilingual-gate2-round6.md
@@ -1,0 +1,754 @@
+Reading additional input from stdin...
+OpenAI Codex v0.144.1
+--------
+workdir: /Users/ll/workspace/vreader
+model: gpt-5.6-sol
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: high
+reasoning summaries: none
+session id: 019f549b-0a35-7e51-8599-a276d74a5557
+--------
+user
+Gate-2 plan audit ROUND 6 (MICRO-CONFIRM, DECISIVE) for feature #131 (Android bilingual interlinear reading). Read the v6 plan at dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md. Round 5 was block-recommended with EXACTLY ONE residual High (all other items — H1 Utf16Span, H3 Paragraph-only, H4 WI-AIP split, Gap A DDL, Gap B backup flag, and H2's index/layout core — were confirmed RESOLVED and must NOT be re-audited). v6 is a MICRO-PATCH resolving only that one residual.
+
+The residual (round-5 High): the in-item Column render contract (round-4 H2 fix) makes each TXT/MD lazy item taller than its source line (source Text + translation children), so the TTS auto-scroll guard's item-level visibility check (listState.layoutInfo.visibleItemsInfo item index equals spokenChunk, reader/TxtReaderActivity.kt ~252/256) no longer proves SOURCE visibility: when spokenChunk's source Text has scrolled above the viewport but its translation sibling is still visible, visibleItemsInfo still contains the item index, so the guard falsely suppresses animateScrollToItem(spokenChunk) and leaves the spoken source off-screen.
+
+v6 fix (audit ONLY this): the plan's new section-2 H2 TTS-visibility bullet + WI-8 now require the TTS-visibility predicate to key off the registered SOURCE Text bounds instead of visibleItemsInfo item index — spokenChunk is visible iff its registered source bounds intersect the list viewport, else animateScrollToItem(spokenChunk) scrolls the source into view; a translation-only-visible connected test is added; the fix is inert when bilingual is OFF (item height equals source height).
+
+Verify against live code:
+1. Does the selection controller actually track each source chunk's LayoutCoordinates / boundsInWindow that the TTS predicate can consult? Check reader/TxtSelectionController.kt (registerChunk signature and what it stores — coordinates/bounds) and reader/TxtReaderActivity.kt (registerChunk call site ~1062, the current TTS guard ~252/256). Confirm the registered source bounds are available and sufficient to compute source-in-viewport for spokenChunk.
+2. Does keying TTS visibility off the source bounds correctly resolve the translation-only-visible case (source above viewport, translation visible) AND all prior cases (source fully visible -> no scroll; source below viewport -> scroll)?
+3. Is the fix genuinely inert when bilingual is OFF (item height equals source height, so source-bounds visibility equals item-index visibility)?
+4. Any NEW issue introduced by this micro-patch (e.g. the source bounds being stale/null before first layout, or a chunk not yet registered)? If so, is it bounded/handled?
+
+Do NOT re-audit anything else. Output findings by severity (Critical/High/Medium/Low) with file:line evidence, then a FINAL VERDICT line exactly one of: ship-as-is | follow-up-recommended | block-recommended. ship-as-is or follow-up-recommended clears Gate-2.
+codex
+I’ll perform the requested micro-audit only: the new v6 TTS source-bounds contract, its WI-8 coverage, and the live selection/reader plumbing it depends on. I’ll first capture repository state, then read the plan and only the cited code paths.
+exec
+/bin/zsh -lc "git status -sb && sed -n '1,240p' dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md && rg -n \"registerChunk|visibleItemsInfo|animateScrollToItem|spokenChunk|boundsInWindow|LayoutCoordinates\" android reader . 2>/dev/null" in /Users/ll/workspace/vreader
+ exited 2 in 941ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-DRPjDRgd' (errno=Operation not permitted)
+## main...origin/main
+ M dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md
+ M docs/features.md
+?? .claude/codex-audits/feat-131-bilingual-gate2-round2.md
+?? .claude/codex-audits/feat-131-bilingual-gate2-round3.md
+?? .claude/codex-audits/feat-131-bilingual-gate2-round4.md
+?? .claude/codex-audits/feat-131-bilingual-gate2-round5.md
+?? .claude/codex-audits/feat-131-bilingual-gate2-round6.md
+?? .claude/codex-audits/feat-136-ai-provider-reachable-gate2.md
+?? android/2026-06-29-223908-this-session-is-being-continued-from-a-previous-c.txt
+?? dev-docs/security/
+# Feature #131 — Android Bilingual Interlinear Reading (parity-checklist box D)
+
+**Feature number assumption:** highest active row in `docs/features.md` is `#136` (now CLOSED, see below); `#131` is a landed `PLANNED` row (`GH: #1923`). The orchestrator adjusts if a row is claimed first.
+
+**Design authority (rule 51):** the **authoritative** bilingual surfaces are:
+- `dev-docs/designs/vreader-fidelity-v1/project/vreader-bilingual.jsx` (`BilingualSetupSheet` / `BilingualPageContent` / `BilingualPill` / `BILINGUAL_LANGS`) — the setup sheet, the **paragraph-interlinear** renderer, and the top-chrome pill.
+- `.../vreader-reader.jsx` (`ReaderTopChrome` renders `BilingualPill`; the bilingual toggle is a More-menu row via `onMoreAction`) and `.../vreader-more.jsx` (the "Bilingual mode" More-menu Row toggle).
+- **The in-reader AI-config surface (folded in from the closed #136):** `dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md` (the CANONICAL **Variant A** decision + navigation model, lines ~39–76, ~110–134) and `.../vreader-ai-provider-entry.jsx` (`AIProvidersSheet`, `AIProvidersSheetBody`, `ProviderRow`, `NavSheet`, `BilingualEngineStrip`). `reader-ai-readiness.md` (iOS #82) is **informational only** — its 4-gate readiness (feature flag + consent manager + provider + key) is iOS-specific and **implementation-deferred**; Android #118 has no feature flag and no consent manager, so the Android readiness gate is provider+key only (see §"AI-config reachability").
+
+`.../vreader-ai-android.jsx` contains a SECOND, differently-shaped `BilingualSetupSheet` — see §3's setup-sheet resolution for why this plan reproduces the `vreader-bilingual.jsx` sheet and design-gates the divergence. Where a surface is NOT depicted it is scoped out and flagged.
+
+**Status:** Gate-1 draft **v6** (2026-07-12) — Gate-2 round-4 (block-recommended) findings resolved (4 High + 2 gaps; targeted patch of v4). Round-4 CONFIRMED M1/M2/M3/M4 (EPUB single-owner flow, dual-cancellation + single-flight, blank-model fallback, DI sequencing) RESOLVED — those are UNCHANGED. Round-4 CONFIRMED the Lows (AppContainer has no `AiProviderStore`, `aiConfigured` semantics, upsert-first-activate, deps/WI-count) correct — those are KEPT. Round-5 (focused) CONFIRMED H1/H3/H4 + gaps A/B resolved and H2's index/layout core resolved, but found ONE narrow NEW High: the in-item `Column` (the round-4 H2 fix) makes each item taller than its source line (source + translation), so the TTS auto-scroll guard's item-index visibility check no longer proves SOURCE visibility — **fixed in v6** (TTS visibility keys off the registered source `Text` bounds). Awaiting Gate-2 round-6 (micro-confirm of the TTS fix).
+
+## 1. Problem
+
+iOS ships bilingual interlinear reading (#56/#100): a per-book toggle renders each source paragraph followed by its translation in a muted style, backed by an AI provider, cached to disk. Android shipped the #118 AI provider foundation (provider store, OpenAI-compat + Anthropic SSE clients, chat/summary) but has **no bilingual capability**, and — as the Gate-2 audits proved — **no production-reachable AI-provider config surface** either. Box D of the parity checklist requires the interlinear renderer + the bilingual setup sheet + the AI-config entry, all building on #118.
+
+The engineering questions are (a) **which render host(s)** get true interlinear, (b) **what the real TXT/MD segmentation unit is** (there is no chapter model — round-2 H1), (c) **how the enabled render preserves the live per-chunk layout/selection model AND the live lazy-index↔chunk-index identity** (round-3 H2 + round-4 H2), and (d) **where the entry point AND the AI-config path live**. The render-host feasibility was settled in v2 (EPUB-primary via Readium `EpubNavigatorFragment.evaluateJavascript`; TXT/MD Compose; AZW3/PDF deferred) and was **CONFIRMED correct by the Gate-2 round-2 audit** — it is not revisited here. This v5 resolves the round-4 findings that concern *how the render maps to real code* and preserves everything round-4 confirmed correct:
+
+- **Host** — EPUB is the **primary** target via `EpubNavigatorFragment.evaluateJavascript(script): String?` (public suspend method in the shipped Readium 3.3.0 AAR — round-2 re-verified; `ReaderActivity.navigator: EpubNavigatorFragment?` is the concrete field, `ReaderActivity.kt:110`). TXT/MD (Compose) are built alongside as the deterministic pipeline proof.
+- **TXT/MD unit (round-2 H1)** — `TxtDocument` has NO chapter model; it is line-based ≤4000-char chunks addressed by UTF-16 offset. v5 defines **document-global units with segment UTF-16 spans produced ONCE by the segmenter** and renders source/translation pairs from those same spans, with the **round-3 H1 final-chunk math fix**, the new **round-4 H1 `Utf16Span` value type** (§2, replacing `IntRange`), and the **round-4 H2 one-lazy-item-per-chunk `Column` render contract** (§2, §3).
+- **Entry point** — the design puts the toggle in the **More-menu** (`vreader-more.jsx`; the live `MoreActionId.BILINGUAL` id is already reserved, and `MoreRow.Toggle` carries `on`/`onToggle` — `reader/more/MoreRow.kt:24,56–63`) + a **top-chrome pill** (`vreader-reader.jsx`). Both landed as box-F sub-features **#132 (top chrome) and #134 (More menu), now VERIFIED** — the entry wiring targets them directly (§4).
+- **AI-config path (folded in — #136 CLOSED)** — the ONLY designed Android AI-config reader surface is the **Variant A scoped "AI Providers" sheet pushed inside the bilingual flow**, reached from the bilingual engine strip's "Set up"/"Change…" button (`reader-ai-provider-entry.md`). #131 now owns it end-to-end (§"AI-config reachability", WI-4b + WI-AIP + WI-9).
+
+## 2. Surface area
+
+### Render-host decision (settled in v2, CONFIRMED by round-2 — not reopened)
+
+**Two hosts, in dependency order:**
+
+1. **EPUB (Readium `EpubNavigatorFragment`) — PRIMARY.** Interlinear via `evaluateJavascript` (enumerate leaf blocks → inject translation DOM nodes → clear on teardown/reflow), mirroring iOS `EPUBBilingualOrchestrator`. Gated by **WI-0 (a Readium bilingual spike with enforceable go/no-go thresholds + a navigator-race contract — round-2 M1)** before the EPUB render WI (WI-7b) is built.
+2. **TXT/MD (Compose `TxtReaderActivity`) — INCLUDED.** No WebView; deterministically Compose-testable. Renders translations **inside the SAME lazy item as their anchor source chunk** (round-4 H2 — one lazy item per chunk, a wrapping `Column`), from **document-global segment `Utf16Span`s** (round-2 H1 + round-4 H1).
+
+**AZW3 (foliate WebView)** and **PDF** remain follow-ups / out (§"Files OUT of scope").
+
+**Why both, not TXT/MD-only:** the *pipeline* (segment → chunk → translate → cache → interleave) is host-agnostic; only the *render injection* is host-specific. EPUB is the format most users read, so shipping box D without it would under-deliver. TXT/MD are included because the Compose host is the cheapest, most testable place to prove the pipeline end-to-end (deterministic tree assertions), de-risking the EPUB adapter. **Box D cannot be checked on a false "EPUB requires a fork" rationale** — that rationale is discarded and stays discarded.
+
+### The TXT/MD segmentation unit + render mapping (round-2 H1 + round-3 H1 + round-4 H1/H2 — the core corrections)
+
+**Verified against live code:** `TxtDocument` (`reader/TxtDocument.kt`) exposes only `text: String`, `chunkCount` (`starts.size`, TxtDocument.kt:14), `offsetForChunk(index)` (TxtDocument.kt:17), `chunkForOffset(offsetUtf16)` (TxtDocument.kt:23), `textForChunk(index)` (TxtDocument.kt:36) — line-based ≤4000-char chunks over UTF-16 offsets against the RAW text (no line-ending normalization). It has **no chapter/section concept**.
+
+**Chunk semantics (round-3 Low-2 correction — the real cases):** a chunk is **ONE LINE** — `TxtDocument.of` starts a new chunk after every `\n`, `\r`, or `\r\n` (TxtDocument.kt:65–86; a runaway line >4000 chars is additionally hard-split, never mid-surrogate-pair). Therefore:
+- A **chunk can hold multiple SENTENCES** (one line, several `。！？`/`. ! ?` sentences).
+- A **paragraph spans MANY chunks** (blank-line-delimited paragraph = several physical lines = several chunks).
+- The old v3 claim "a chunk can hold multiple **paragraphs**" is **WRONG and removed.** (A single chunk cannot straddle a line terminator, and paragraph boundaries are blank lines, i.e. chunk boundaries — so a chunk holds *part of one* paragraph, never a whole extra paragraph.)
+
+**v5 model — document-global units with segment spans produced ONCE:**
+
+- The whole `.txt`/`.md` is treated as **one translation document**. The **segmenter runs once over `TxtDocument.text`** (the full raw backing string) and emits, per segment, its **UTF-16 span as a `Utf16Span(start, endExclusive)`** (half-open) against that same backing string (the segmenter's `paragraphRanges(text): List<Utf16Span>` / `sentenceRanges(text): List<Utf16Span>` — the span-returning peers of `paragraphs`/`sentences`; iOS precedent `ChapterSegmenter.sentenceRanges(in:)` at `ChapterSegmenter.swift:78`, returns `[Range<Int>]`). These spans are the SINGLE source of truth used by BOTH the translate side and the render side, so the two segment identically **by construction** (they read the same array). Spans are stored/compared as the explicit `Utf16Span` value type (see the H1 fix below), NOT re-derived on the render side.
+- **Unit granularity for TXT/MD is the whole document, sub-batched for cache/prefetch by a deterministic "unit window."** To avoid translating a 14 MB book at once (and to keep cache rows bounded), segment spans are grouped into fixed **unit windows** of contiguous segments (window size a build-time constant; it does not change the 1:1 contract). Each window is a `TranslationUnitId(kind = txtDocSegmentWindow, value = windowIndex)` — a document-global index, NOT a chunk index. `unitContaining(charOffsetUTF16)` maps the reader's saved offset → the segment whose span contains it → its window index (via a precomputed segment-start binary search, the same shape as `TxtDocument.chunkForOffset`, TxtDocument.kt:23–33). `unitAfter(unit)` = next window index or null at document end.
+
+#### H1 fix (round-3 High-1 math + round-4 High-1 type) — final-chunk source span + the `Utf16Span` value type (BINDING)
+
+**The math (round-3 High-1 — CONFIRMED correct by round-4, UNCHANGED):** `offsetForChunk()` **CLAMPS** an out-of-range index to the last valid chunk (`starts[index.coerceIn(0, starts.size - 1)]`, TxtDocument.kt:17–20). So for the LAST chunk `i`, `offsetForChunk(i + 1) == offsetForChunk(i)` → an **empty span** → a one-chunk document drops EVERY translation and a paragraph ending in the final chunk drops its sole translation. `textForChunk()` avoids this by using `text.length` for the final end (TxtDocument.kt:39). The render side MUST do the same. **Binding rule:**
+
+```
+val endExclusive = if (i + 1 < document.chunkCount) document.offsetForChunk(i + 1) else document.text.length
+// chunk i source span is the HALF-OPEN Utf16Span(document.offsetForChunk(i), endExclusive)
+```
+
+**The type (round-4 High-1 — THE fix this round):** v4 declared `paragraphRanges`/`sentenceRanges` as `List<IntRange>` while treating them as half-open `[start, endExclusive)`. That is a **type contradiction** — Kotlin `IntRange` is inclusive-inclusive (`range.last` is the last *included* index, and `range.last` for an empty/at-EOF span is a footgun). The half-open contract and the `IntRange` type are incompatible. **Resolution — a dedicated value type, replacing `IntRange` EVERYWHERE:**
+
+```
+// bilingual/Utf16Span.kt  (NEW FILE — rides WI-1)
+data class Utf16Span(val start: Int, val endExclusive: Int) {
+    init { require(endExclusive >= start) }
+    val isEmpty: Boolean get() = endExclusive == start
+    val length: Int get() = endExclusive - start
+}
+```
+
+- `ChapterSegmenter.paragraphRanges(text): List<Utf16Span>` / `sentenceRanges(text): List<Utf16Span>` return `Utf16Span`s (half-open, against the input string). `TxtChapterTextProvider` and the TXT/MD render path consume `Utf16Span` — there is **no `IntRange`** anywhere in the segment/span contracts. (`TxtSelectionController`'s own `Utf16Range` type is a *separate*, unrelated selection type and is untouched — see H2's gesture-exclusion note.)
+- A segment's "end offset" for anchoring (below) is its `endExclusive`; the chunk that "contains a segment's end" is `document.chunkForOffset(span.endExclusive - 1)` when `!span.isEmpty`, clamped to `[0, chunkCount-1]` (an empty segment is dropped by the segmenter and never anchored).
+- **Tests (WI-1 / WI-4a / WI-8):** `paragraphRanges`/`sentenceRanges` return correct half-open `Utf16Span(start, endExclusive)` spans (unit — WI-1); one-chunk document (no trailing newline) → its single paragraph/sentence translation renders (not dropped); final-chunk anchor (a paragraph whose last line is the final chunk) → translation renders after the last chunk; exact-boundary (a segment ending exactly at a chunk `start`) → anchored to the correct chunk, not off-by-one; EOF anchor (`span.endExclusive == text.length`) → resolves to the last chunk, no clamp-collapse.
+
+#### H2 fix (round-3 High-2 layout/selection + round-4 High-2 lazy-index identity) — the enabled render contract (BINDING; preserves BOTH the per-chunk model AND lazy-index==chunk-index)
+
+**Live invariant #1 — per-chunk layout/selection (round-3 High-2, verified TxtReaderActivity.kt:1043–1085):** the TXT/MD body iterates `items(count = document.chunkCount, key = { it })` (TxtReaderActivity.kt:1043). For **each chunk `i`** it owns **exactly ONE `TextLayoutResult`** (`var layout by remember(i) { … }`, set in `onTextLayout`, TxtReaderActivity.kt:1059/1075) and **exactly ONE selection registration** (`selectionController.registerChunk(i, l, c)` / `unregisterChunk(i)`, TxtReaderActivity.kt:1062–1066). Highlights (`highlightSpan(i)`, :1047), annotation washes (`washesForChunk(i)`, :1058), the read-aloud span wash (`addStyle(SpanStyle(background = wash), …)`, :1050–1054), and selection accents (`selectionForChunk(i)` → `drawRangeFill`, :1069/1081) all key off that **per-chunk** layout and the chunk-local UTF-16 offsets. **Splitting a chunk's source `Text` into multiple `Text` nodes would break every one of these** (two `Text` nodes = two `TextLayoutResult`s = broken selection coordinates, misplaced highlight/wash/annotation ranges, a shifted read-aloud wash).
+
+**Live invariant #2 — lazy-index == chunk-index (round-4 High-2 — THE key fix this round; verified):** the live reader treats `LazyListState` item indices as `TxtDocument` chunk indices EVERYWHERE:
+- **Position save** converts `firstVisibleItemIndex` → offset via `offsetForChunk` (`savePosition(...) { val offset = document.offsetForChunk(topIndex) }`, TxtReaderActivity.kt:623–624), and the steady-state/onStop save both pass `listState.firstVisibleItemIndex` directly (TxtReaderActivity.kt:220–223, :227–230). Resume converts back via `chunkForOffset` (`initialFirstVisibleItemIndex = s.initialIndex`, :220; `s.initialIndex` = `document.chunkForOffset(offset)`, :619). The bottom-chrome progress fraction reads `document.offsetForChunk(listState.firstVisibleItemIndex)` (:473).
+- **Bookmark / annotation / search / scrubber / TTS jumps** all call `listState.scrollToItem(document.chunkForOffset(target))` (bookmark :411, annotation :421, search :454, scrubber :481; TTS auto-scroll `animateScrollToItem(spokenChunk)` where `spokenChunk = document.chunkForOffset(tts.charStart)` — :252/:257).
+- **TTS visibility** compares lazy-item indices with the chunk directly: `listState.layoutInfo.visibleItemsInfo.none { it.index == spokenChunk }` (:256).
+
+**Therefore inserting SEPARATE translation `LazyColumn` items (the v4 "additive items after the anchor chunk" contract) is NOT implementable:** every separate translation item inserted before a given source chunk shifts that chunk's lazy index, so `offsetForChunk(firstVisibleItemIndex)` reads the wrong chunk's offset (corrupts position save + progress), `scrollToItem(chunkForOffset(target))` lands on the wrong item (corrupts every jump), and `visibleItemsInfo.index == spokenChunk` never matches (corrupts TTS auto-scroll). The v4 contract is **rejected**.
+
+**v5 binding render contract (one lazy item per chunk — a wrapping `Column`):**
+
+> **Keep EXACTLY ONE lazy item per chunk.** The existing `items(count = document.chunkCount, key = { it })` loop is **UNCHANGED** — so lazy-index == chunk-index is preserved and NO position/jump/TTS consumer breaks. INSIDE each item's lambda, wrap the content in a `Column`:
+> 1. the **UNCHANGED source `Text`** — one `TextLayoutResult`, one `registerChunk(i, …)`/`unregisterChunk(i)`, byte-identical to today (the exact code at TxtReaderActivity.kt:1044–1084 is unchanged, now nested in a `Column`);
+> 2. **below it, still inside the SAME lazy item**, the translation(s) **anchored** to chunk `i` (`chunkForOffset(span.endExclusive - 1) == i`) as **muted, non-registered** `Text`(s) (accent left-border, `fontSize*0.88`, CJK/RTL styling per `BilingualPageContent`).
+
+A paragraph spanning chunks `j..i` renders its ONE translation inside chunk `i`'s `Column` (after the paragraph's last source line). This preserves BOTH invariants: the per-chunk one-layout/one-registration model (the source `Text` is never split, the translation is a *sibling* `Text` in the `Column`, not a re-layout of the source) AND the lazy-index↔chunk-index identity (the translation lives inside the anchor's lazy item, adds no lazy item, shifts no index).
+
+Concretely the body becomes, per chunk `i` (in the same single `items(count = document.chunkCount, key = { it })` loop):
+
+1. Open a `Column` for item `i`.
+2. Render the source chunk `i` **EXACTLY as today** (the unchanged `Text` + its `remember(i)` layout/coords + `registerChunk(i, …)`/`unregisterChunk(i)` + `highlightSpan(i)`/`washesForChunk(i)`/`selectionForChunk(i)` — TxtReaderActivity.kt:1044–1084, now the first child of the `Column`).
+3. Look up the translations **anchored** to chunk `i` = every segment whose end resolves to `chunkForOffset(span.endExclusive - 1) == i`, in segment order, from the shared span array. For **paragraph** granularity (the only v1 granularity — see the granularity subsection) there is at most one such translation per anchor chunk in the common case (a paragraph's translation renders after the paragraph's last line-chunk).
+4. Emit each anchored translation as a muted, non-registered `Text` sibling **inside the same `Column`**, keyed by the segment's `Utf16Span` so a language change re-keys cleanly.
+
+When bilingual is **OFF**, no translation children are emitted → each item's `Column` holds only the unchanged source `Text`, so the tree is **behaviorally identical to today** (translations are additive in-item children only; this is asserted by a source-selection-parity test, since a single-child `Column` does not perturb the source `Text`'s layout/registration/offsets).
+
+- **Explicit translation gesture exclusion (round-4 High-2 — BINDING):** `TxtSelectionController.hitAt` (`reader/TxtSelectionController.kt:47`) falls back to the **nearest registered source chunk** when the pointer is outside all source-chunk bounds (`chunks.entries.minByOrNull { verticalDistance(...) }` when no chunk's `boundsInWindow()` contains the point, :51–53). So merely omitting `registerChunk` for the translation does **NOT** make it non-selectable — a long-press *on the translation text* would fall through to the nearest source chunk and select source. **WI-8 must add an explicit hit-test / gesture exclusion for the translation composable's bounds** so a long-press whose pointer lands inside a translation `Text`'s bounds is consumed (no selection begun) rather than routed to `hitAt`'s nearest-chunk fallback. (Options: the translation `Text` consumes the long-press gesture in its own `pointerInput`; or the selection gesture root records the translation composables' window bounds and short-circuits `beginAt` when the point is inside one. WI-8 picks and tests one.)
+
+- **TTS auto-scroll visibility must key off the SOURCE `Text` bounds, NOT the item index (round-5 High — a NEW consequence of the in-item `Column`):** the TTS auto-scroll guard (TxtReaderActivity.kt:252/256) currently keeps the spoken chunk on screen via `listState.layoutInfo.visibleItemsInfo.none { it.index == spokenChunk }` — item-level visibility. With the in-item `Column`, an item is now taller than its source line (source + translation children), so when `spokenChunk`'s SOURCE `Text` has scrolled above the viewport but its translation sibling is still visible, `visibleItemsInfo` still contains the item's index → the guard falsely suppresses `animateScrollToItem(spokenChunk)` and leaves the spoken SOURCE off-screen. **WI-8 must redefine the TTS-visibility predicate to test the registered SOURCE `Text` bounds** — the selection controller already tracks each source chunk's `LayoutCoordinates`/`boundsInWindow()` via `registerChunk(i, layout, coordinates)` (TxtSelectionController.kt): `spokenChunk` is visible iff its registered source bounds intersect the list viewport; otherwise `animateScrollToItem(spokenChunk)` scrolls the item's top (the source) into view. This is **inert when bilingual is OFF** (no translation child → item height == source height → item-index visibility already equals source visibility), so the disabled path is byte-identical.
+
+- **Enabled-mode tests (WI-8 connected + WI-7a Compose, BINDING):** with bilingual ON —
+  - (a) each source chunk's **selection registration is UNCHANGED** (same `registerChunk(i, …)` count and coordinates as OFF; a translation child registers nothing);
+  - (b) **highlights/annotation washes/read-aloud wash still key off the source chunks** at the correct offsets (a translation child in the anchor's `Column` does not shift them);
+  - (c) **lazy-index == chunk-index preserved:** with bilingual ON — **position-save round-trips to the same chunk** (`offsetForChunk(firstVisibleItemIndex)` → save → reopen → `chunkForOffset(offset)` lands on the same chunk); **bookmark/annotation/search/scrubber jumps land on the correct chunk** (`scrollToItem(chunkForOffset(target))` scrolls to the right item); **TTS auto-scroll keeps the spoken SOURCE on screen — visibility keyed off the registered source `Text` bounds, NOT `visibleItemsInfo.index` (round-5 High)**, INCLUDING the case where only `spokenChunk`'s translation portion is visible (its source scrolled above the viewport) → TTS brings the SOURCE back on-screen; (assert the index-identity behaviors above are identical to the OFF baseline — no lazy index shift);
+  - (d) a **long-press on translation text does NOT select** (gesture exclusion — the nearest-source-chunk fallback is not reached);
+  - (e) a **translation child is non-selectable** and does not perturb source offsets (selecting across the source/translation boundary selects source only);
+  - (f) **MD source mapping** — the markdown renderer (`mapper.renderedText(i)`, TxtReaderActivity.kt:1049) still owns the source chunk render; the translation child is plain muted text;
+  - (g) **paragraph-spanning-many-chunks** renders exactly ONE translation (inside the paragraph's last chunk's `Column`), never per-line;
+  - (h) final-chunk/one-chunk anchors render (H1).
+
+- **Granularity — Paragraph ONLY in v1 (round-4 High-3):** `vreader-bilingual.jsx` `BilingualPageContent` (lines ~195–277) is a **paragraph-interlinear** renderer: it maps `page.paragraphs.map(...)` and renders **one source `<p>` followed by ONE translation `<p>`** per paragraph. **Sentence-granularity interlinear is depicted NOWHERE** — Sentence appears ONLY as an option in the `BilingualSetupSheet` Granularity segmented control (`vreader-bilingual.jsx:77`), never in the renderer, AND v4's "Sentence selectable + sentence cache identity active + paragraph-render fallback" was underspecified (no defined sentence→paragraph aggregation, so it would either render undesigned sentence items or serve paragraph content under a sentence cache key). **Resolution — v1 segments + caches + renders Paragraph ONLY:**
+  - The `TranslationGranularity` enum + `ChapterSegmenter.sentenceRanges` API **stay as reserved FOUNDATIONAL code** (WI-1, with unit tests) so the future sentence-render is a render-only follow-up.
+  - The v1 **render/cache/VM/setup-sheet path uses paragraph exclusively:** `promptVersion`'s granularity component is **always `paragraph` in v1**; there is **no `sentenceRanges` in the v1 render path**; the setup sheet's Granularity control is **descoped to Paragraph-only in v1** (a documented divergence, tracked by the sentence design gate below — the same treatment as the Style descope).
+  - This keeps rule 51 (implement only what is depicted — paragraph interlinear) while shipping the depicted paragraph parity. The one-lazy-item-per-chunk `Column` render contract already accommodates a future per-line sentence grouping (several translation children stacked in one chunk's `Column`), so the sentence gate, once designed, is render-only.
+
+- **MD source** = raw markdown segment text (translation renders as plain muted text, not re-markdown-rendered — matches the muted-secondary design line). Segmentation runs over the raw markdown string; MD markers are treated as ordinary characters by the paragraph splitter (blank-line delimited), consistent with `TxtMdTextExtractor` shipping raw markdown to search.
+
+This closes round-3 H1 (no dropped final-chunk translations), round-3 H2 (per-chunk layout/selection preserved; source `Text` never split), round-4 H1 (the `Utf16Span` type replaces the incompatible `IntRange`), round-4 H2 (one lazy item per chunk preserves lazy-index==chunk-index; translation gesture exclusion), round-4 H3 (Paragraph-only v1 granularity), and round-3 Low-2 (correct chunk semantics).
+
+### AI-config reachability — FOLDED IN (#136 CLOSED; Variant A owned by #131)
+
+**Verified against live code:** `AppContainer` (`VReaderApp.kt:31–268`) constructs **NO `AiProviderStore`** — the only reference is a *comment* naming "the OpdsSourceStore / AiProviderStore precedent" (VReaderApp.kt:64/66), no actual instance/provision. There is **no live navigation route to `AiProviderListScreen`** (the #118 `AiProviderListScreen` / `AiProviderStore` / `AiSettingsViewModel` exist and are exercised only by instrumented/round-trip tests). A fresh-install user therefore cannot reach provider config today.
+
+The Gate-2 audits + the two design-notes proved the ONLY designed Android AI-config reader surface is **Variant A** (`reader-ai-provider-entry.md`, CANONICAL): a **scoped "AI Providers" sheet pushed _inside_ the bilingual sheet**, reached from the bilingual engine-strip's "Set up"/"Change…" button. The design explicitly **rejected** a standalone entry (there is NO designed standalone More-menu "Configure AI" row), a full-Settings deep-link (alternative B), and inline expansion (alternative C). So AI-config reachability is **NOT separable** from the bilingual flow — the #136 spin-out is **CLOSED (GH #1976, not-planned)** and **#131 now owns it end-to-end** (user decision 2026-07-12).
+
+**Navigation model (reproduced EXACTLY from `reader-ai-provider-entry.md`:110–134, invent nothing):**
+
+```
+More ▸ Bilingual mode (first toggle on)
+  └─ BilingualSetupSheet   [bottom sheet]
+       engine strip: "No AI provider configured"  [ Set up ]
+                             │  onOpenSettings
+                             ▼  (push, slide-left, same sheet frame)
+     ReaderAiProvidersSheet  [nav bar: ‹ Bilingual · "AI Providers"]
+       ├─ empty  → [ Add provider ] ─┐
+       └─ list   → tap a row SELECTS it (setActive) │  (present the canonical editor, full height)
+                             ▼        ▼
+                    AiProviderEditSheet   [reused VERBATIM from #118]
+                             │  Save
+                             ▼  (saved provider becomes the bilingual engine,
+                                  pop the whole stack)
+     BilingualSetupSheet  ← engine strip now "Claude · configured" / Change…
+```
+
+- **`‹ Bilingual` without adding** returns to the bilingual sheet **still unconfigured — no state mutated.**
+- **"Change…"** (already-configured strip) opens the **SAME** `ReaderAiProvidersSheet`, populated, **current provider checked**; tapping a row **selects** it (`setActive`).
+- The AI Providers view is a **push within the bilingual sheet**, NOT a modal over the reader and NOT the full app Settings.
+
+**Android readiness gate (BINDING — round-3/round-2 H3 + the #136-audit High-3 lesson; round-4 CONFIRMED correct, UNCHANGED):** `aiConfigured` on the engine strip is derived by `BilingualAiReadiness.resolve(snapshot)` = **an ACTIVE profile exists AND its API key decrypts to non-empty.** Deriving from `profiles.isEmpty()` alone is **WRONG**: the store keeps a separate `activeId` that can be **null with profiles present** (`AiProviderSnapshot.active = profiles.firstOrNull { it.id == activeId }`, AiProviderStore.kt:34–36), and key usability depends on **decrypting the active profile's token** (`apiKey(profile) = cipher.decrypt(profile.encryptedApiKey)`, AiProviderStore.kt:108). A cipher/keystore failure maps to **not-ready, never a crash** (the resolve wraps the decrypt in `runCatching`). **Note:** the iOS Variant A design-note (`reader-ai-provider-entry.md:172–174`) derives `aiConfigured` from `providers.isEmpty == false`, and iOS #82 (`reader-ai-readiness.md`) adds a 4-gate readiness (flag + consent + provider + key). **Android has NO consent manager and NO feature flag** (#118 has neither — confirm during build); the Android gate is exactly what #118 enforces = **provider (active) + key (decrypts non-empty)**. We do NOT invent a consent/flag gate.
+
+### New files
+
+**Pipeline / domain (host-agnostic, pure or coroutine — JVM-testable):**
+
+- `bilingual/Utf16Span.kt` — **NEW (round-4 H1).** `data class Utf16Span(val start: Int, val endExclusive: Int)` (half-open UTF-16 span; `require(endExclusive >= start)`; `isEmpty`, `length`). The single span type shared by the segmenter and the TXT/MD render path, replacing the incompatible `IntRange`. Rides WI-1. (Distinct from `TxtSelectionController.Utf16Range`, the selection type, which is untouched.)
+- `bilingual/TranslationUnitId.kt` — `data class TranslationUnitId(kind, value)` with `enum Kind { epubHref, foliateHref, txtDocSegmentWindow, mdDocSegmentWindow, pdfPageRange }`; `storageKey = "${kind.name}:$value"`. TXT/MD kinds are **document-global segment-window indices** (H1), NOT chunk indices. v5 uses `epubHref` + `txtDocSegmentWindow`/`mdDocSegmentWindow`; others reserved so the cache-key format never breaks. *(Assumption: iOS's exact Kind case names for the TXT/MD variants; only the `storageKey` string format is load-bearing for the cache contract, and that is preserved.)*
+- `bilingual/TranslationGranularity.kt` — `enum { paragraph, sentence }`. **Reserved foundational code** (WI-1, unit-tested); the v1 render/cache/VM/setup-sheet path uses `paragraph` exclusively (round-4 H3). `sentence` is design-gated.
+- `bilingual/BilingualLanguages.kt` — `BilingualLanguage(key, glyph, script)`; `BILINGUAL_LANGS` = the exact set from `vreader-bilingual.jsx:15–25` (Chinese/Japanese/Korean cjk, Spanish/French/German/Italian latin, Arabic rtl, Russian cyrillic) + `findOrDefault(key)`. Default `Chinese`.
+- `bilingual/ChapterSegmenter.kt` — **NEW file (no existing Android segmenter — verified).** Port of iOS `ChapterSegmenter`: `paragraphs(text)` / `sentences(text)` **plus the span-returning peers `paragraphRanges(text): List<Utf16Span>` / `sentenceRanges(text): List<Utf16Span>`** (half-open UTF-16 spans against the input string, as `Utf16Span` — round-4 H1; iOS `sentenceRanges(in:)` precedent). CJK-aware sentence enumeration (`。！？` vs Latin). Pure. (`sentenceRanges` is reserved-foundational; the v1 render path calls only `paragraphRanges` — round-4 H3.)
+- `bilingual/TranslationChunker.kt` — `chunk(segments, maxCharsPerChunk)` + `subSplit(text, maxChars)`. Port of iOS `ChapterTranslationChunker.chunk(...)` (`ChapterTranslationChunker.swift:85`) + `subSplit(...)` (returns index groups, oversize segment gets its own chunk; `subSplit` is the Bug #330 grapheme-safe over-budget splitter).
+- `bilingual/TranslationChunkContract.kt` — `userPrompt(segments, targetLanguage)`; `decode(raw, expectedCount)` (strict JSON-array + code-fence strip); `sealed class DecodeError { NotAStringArray; CountMismatch(expected, actual) }`. Port of iOS `TranslationChunkContract` (`TranslationChunkContract.swift:24`). No `style` param — Style descoped v1 (§3).
+- `bilingual/ChapterTextProvider.kt` — `interface { units(); sourceSegments(unit); sourceText(unit); unitContaining(charOffsetUTF16); unitAfter(unit) }`. `sourceSegments(unit)` returns the exact segment strings (from the shared span array). Resolution is host-specific: TXT/MD key on `charOffsetUTF16` → segment-window; EPUB keys on the current-resource `href`. Honest divergence from iOS's uniform Readium `Locator`, documented.
+- `bilingual/TxtChapterTextProvider.kt` — provider over `TxtDocument` + the segmenter's `Utf16Span` array (H1). Builds the document-global segment `Utf16Span`s once (via `paragraphRanges` — paragraph only in v1), groups them into windows, resolves `unitContaining` via a segment-start binary search over `charOffsetUTF16`. MD source = raw markdown segment text.
+- `bilingual/EpubChapterTextProvider.kt` (WI-0-gated shape) — provider over the Readium `Publication` reading order; `units()` = spine hrefs, `unitContaining` = the locator's href (from `EpubNavigatorFragment.getCurrentLocator()`), `sourceSegments(unit)` = the DOM-enumerated block texts (the render's OWN enumeration, for direct-block 1:1 — H2). Its render-side collaborator is `EpubBilingualJs`.
+- `bilingual/ChapterTranslationError.kt` — `sealed { Offline; TimedOut; ProviderFailed(msg); Cancelled }`. Maps from `AiError` (verified cases `Auth401`, `RateLimited429`, `Offline`, `Timeout`, `Http(code)`, `Decode`, `Stream`, `InsecureUrl`, `Config`, AiTypes.kt).
+- `bilingual/ChapterTranslationService.kt` — the iOS-parity service (full divergence-recovery surface, round-2 H2):
+  - `cachedTranslation(bookKey, unit, sourceText, targetLanguage, granularity, acceptCountMismatch=false)` — cache-only; serves a row only when `sourceParagraphCount == segments.size` (or `acceptCountMismatch`). No provider (#306 parity).
+  - `cachedTranslation(bookKey, unit, expectedSegmentCount, targetLanguage)` — the divergence-fallback cache-only restore (iOS Bug #343): serves the canonical row only when its STORED `sourceParagraphCount == expectedSegmentCount`. Needs no source text and no provider → a cache-hit toggle/reopen restores with **zero provider calls**.
+  - `translate(bookKey, unit, sourceText, targetLanguage, providerProfile, granularity, bypassCacheRead=false)` — segment → chunk → per-chunk `AiClient.chat` one-shot → `decode` → per-segment fallback → per-chunk graceful degrade (Bug #330) → cache-write only on full success (`sourceParagraphCount = segments.size`). **Cancellation:** maps BOTH native `CancellationException` AND typed `ChapterTranslationError.Cancelled` to `Cancelled` (mirrors iOS `ChapterTranslationService.swift:359–364`); `ensureActive()` between chunks AND immediately before the Room write.
+  - `translatePreSegmented(bookKey, unit, segments, targetLanguage, providerProfile)` — the count-divergence recovery (iOS Bugs #268/#330/#343). Takes the render's OWN enumerated block texts as `segments` (1:1), chunks them, translates with the same per-chunk graceful-degrade + dual-cancellation contract, and — on full success only — caches under the canonical key with the ENUMERATE's count as `sourceParagraphCount`. A partial degrade is NOT cached; a cache-write failure does not fail the translation (iOS `ChapterTranslationService.swift:374–384`).
+  - Uses `AiClient.chat(AiRequest)` (one-shot, verified — NOT `streamChat`).
+- `bilingual/ChapterTranslationPrefetcher.kt` — resolves the active profile from one `AiProviderStore.snapshot()` (`snapshot.active`), decrypts via `store.apiKey(profile)` (snapshot-consistent, AiProviderStore.kt:108), builds an `AiClient` via an **injected factory param** (below), cache-first then translate. Adds the direct-block peers (H2):
+  - `prefetch(unit)` — the plain-text path.
+  - `prefetchDirect(unit, sourceSegments, targetLanguage)` — the divergence path (iOS `translatedSegmentsDirect`, `ChapterTranslationPrefetcher.swift:197`).
+  - `cachedDirect(unit, expectedCount, targetLanguage)` — the **zero-provider cache-only restore** (iOS `cachedSegmentsDirect` → `cachedTranslation(expectedSegmentCount:)`, `ChapterTranslationPrefetcher.swift:236`): returns a cached translation on a hit WITHOUT requiring an active provider (#306 pre-gate precedent). Backs the EPUB cache-restore path.
+  - **`AiRequest` construction (round-3 M3 fix, BINDING; round-4 CONFIRMED correct):** `model = profile.model.ifBlank { profile.kind.defaultModel }` — matches `AiChatViewModel.kt:61`; both wire clients serialize `request.model` **directly** (`put("model", request.model)` in `OpenAiCompatibleProvider.kt:38` and `AnthropicProvider.kt:36`), so a blank `profile.model` would send an empty model. Full request: `AiRequest(model = profile.model.ifBlank { profile.kind.defaultModel }, messages = …, temperature = profile.temperature, maxTokens = profile.maxTokens, system = …)`. A **blank-model regression test** asserts the fallback is applied.
+  - Throws `ChapterTranslationError`. Mirrors iOS `ChapterTranslationPrefetcher`.
+- `bilingual/BilingualAiReadiness.kt` — `resolve(snapshot: AiProviderSnapshot): Boolean` — active profile exists (`snapshot.active != null`) AND `runCatching { store.apiKey(snapshot.active).isNotEmpty() }.getOrDefault(false)` (cipher/decryption failure → **not-ready**, never crashes). Drives the setup-sheet engine-strip configured/unconfigured state. Exactly the #118 gate (no consent manager / feature flag on Android — confirm during build).
+
+**State / persistence:**
+
+- `bilingual/PerBookBilingualStore.kt` — DataStore-Preferences, keyed by `bookFingerprintKey`, holding `{ enabled, targetLanguage, granularity }` (`granularity` is persisted but pinned to `paragraph` in v1 — round-4 H3). The Android `PerBookSettingsOverride` bilingual slice — the backup contract declares exactly `bilingualEnabled` / `bilingualTargetLanguage` / `bilingualGranularity` and **NO `bilingualStyle`** (verified). Wiring into backup collect/restore is scoped OUT (§7); until then bilingual config is device-local.
+- `bilingual/BilingualViewModel.kt` — `StateFlow<BilingualUiState>` with `enabled`, `targetLanguage`, `granularity`, `needsSetupSheet`, `aiConfigured`, `translationsByUnit`, `inFlightUnits`, `unavailableUnits`, `errorUnit`. Setters + `dismissSetupSheet`, `onPositionChanged(charOffsetUTF16)`, `retryUnit(unit)`, and the EPUB direct-block entry `onEpubBlocksEnumerated(unit, blocks)` (M1, below). Generation/epoch-guarded prefetch (current + next unit); a **per-unit single-flight job registry** (M2); dual-cancellation handling (M2). Port of iOS `BilingualReadingViewModel` (`prefetchTasks: [TranslationUnitID: Task]`, `BilingualReadingViewModel.swift:141`) + `+Prefetch`. Split to `BilingualPrefetchController.kt` if it nears ~300 lines. No `style` field.
+
+**Room (translation cache):**
+
+- `data/ChapterTranslationEntity.kt` — `@Entity(tableName="chapter_translations", indices=[Index("bookKey")], foreignKeys=[FK→books.fingerprintKey ON DELETE CASCADE])`. **`@PrimaryKey val lookupKey: String`** (Room requires a PK; project pattern `@PrimaryKey` + `@Upsert`, verified `BookEntity` `@PrimaryKey val fingerprintKey`, Entities.kt:24). `lookupKey` = `bookKey|unitStorageKey|targetLanguage|promptVersion`. Columns: `lookupKey` (PK), `bookKey`, `unitStorageKey`, `targetLanguage`, `promptVersion`, `translatedJson`, `sourceParagraphCount`, `createdAt`. Mirrors iOS `ChapterTranslationRecord.lookupKey` (`book|unit|lang|prompt`, profile-agnostic — Bug #342). `sourceParagraphCount` is load-bearing for H2 (stores the enumerate's count on the `translatePreSegmented` path so `cachedTranslation(expectedSegmentCount:)` restores). **The exact `MIGRATION_8_9` DDL is authored in WI-2 — see below.**
+- `data/ChapterTranslationDao.kt` — `getByLookupKey(key)`, `@Upsert suspend fun upsert(row)`, `deleteByLookupKey(key)`.
+- `bilingual/ChapterTranslationStore.kt` — coroutine wrapper returning a `CachedTranslation` (segments decoded from JSON), keeping Room entities off the boundary (iOS `ChapterTranslationStore` precedent).
+
+**Cache-identity (reconciled with iOS parity):** the 4-part key `book|unit|lang|promptVersion` is profile-AGNOSTIC / style-agnostic (Bug #342). Style is descoped (§3) so no `s=` component. **Granularity is paragraph-only in v1** (round-4 H3): `promptVersion = "bilingual-v1|g=paragraph"` in v1 (the `g=` component is always `paragraph`). The composite `g=` slot is retained in the key format so a future granularity is a different cache row by construction (closes the iOS #344 "sentence silently ignored" class ahead of time), but v1 never emits `g=sentence`. A language change cancels in-flight jobs, bumps the VM generation, clears shaped `translationsByUnit`, and forces a correctly-keyed re-fetch (WI-6).
+
+**DI / factory (verified live):** `AiProviderFactory` is an `object` with `create(profile, apiKey, dispatcher = Dispatchers.IO): AiClient` (verified, `AiProviderFactory.kt:10`). `ChapterTranslationPrefetcher` takes its OWN injected `clientFactory: (AiProviderProfile, String) -> AiClient` param **defaulting to `AiProviderFactory::create`**, overridden with a fake in tests.
+
+**UI (Compose — every state depicted, reproducing `vreader-bilingual.jsx` + `vreader-ai-provider-entry.jsx`):**
+
+- `bilingual/BilingualSetupSheet.kt` — reproduces `vreader-bilingual.jsx`'s `BilingualSetupSheet` (lines 27–156) EXACTLY, with the granularity divergence: header; a preview strip (`BilingualPreview`); a language grid over `BILINGUAL_LANGS` (glyph tiles, selected accent); a **Granularity** segmented control **descoped to Paragraph-only in v1** ("Translate after each ¶"; the Sentence option is not rendered in v1 — round-4 H3, tracked by the sentence design gate); a **Translation engine** strip (configured: "Claude · with this book's context" + "Change…"; unconfigured: "No AI provider configured" + "Bilingual mode needs an AI provider to translate." + "Set up"); the "Turn on bilingual mode" CTA. **No Style control, no provider/model card, no term-overrides toggle, no cost footer** (those belong to the `vreader-ai-android.jsx` sheet, not reproduced — §3). The `aiConfigured` flag comes from `BilingualAiReadiness.resolve`. The "Set up"/"Change…" CTA routes to `ReaderAiProvidersSheet` (wired in WI-9).
+- `bilingual/ReaderAiProvidersSheet.kt` — **NEW (folded in; the Android analog of iOS `ReaderAIProvidersView`; round-4 High-4 rewritten).** The Variant A scoped in-reader AI Providers sheet, reproducing `vreader-ai-provider-entry.jsx` `AIProvidersSheet` + `AIProvidersSheetBody` + `NavSheet` (nav bar `‹ Bilingual` leading + centered "AI Providers" title, `vreader-ai-provider-entry.jsx:247`). **Round-4 High-4: the fold-in CANNOT be "reuse `AiProviderListScreen` verbatim."** `AiProviderListScreen` owns its OWN full `NavScreen(title="AI Providers", onBack)` (`AiProviderListScreen.kt:59`), a generic `AiEmptyState` ("Connect an AI provider" / "One key unlocks…", :84/:87), and **row-tap-as-EDIT** (`ProviderRow` → `onEdit(p.id)`, :105) with **no checked-active-tap-to-select** — it cannot reproduce the designed reader-scoped `‹ Bilingual` nav, the bilingual-context empty state, the checked-active row, or tap-to-SELECT. So the fold-in splits into **(a)/(b)/(c)**:
+  - **(a) EDITOR reused VERBATIM.** `AiProviderEditSheet` (the canonical add/edit modal, Kind / Name / Endpoint / Sampling / API Key / Test Connection) is presented UNCHANGED from the #118 Library path — that reuse is confirmed fine (`reader-ai-provider-entry.md:49–52`, :63–65).
+  - **(b) The scoped LIST is a NEW reader-specific presentation** (`ReaderAiProvidersList`, in this file) built over the **SHARED `AiSettingsViewModel` state** (`listState`, verified `AiSettingsViewModel.kt:26`) + shared row/cell components, reproducing: the reader-scoped nav (`‹ Bilingual` back label, "AI Providers" title — `NavSheet` at jsx:247, NOT `AiProviderListScreen`'s own `NavScreen`); the **bilingual-context empty state** ("Choose the provider bilingual mode will use to translate this book." context strip + "No providers yet" + "Add provider" CTA — jsx:180–209); the **checked-active row** (`selected={p.id === selectedId}` — jsx:221; the live `AiProviderListState`/`AiProviderRow` already carries `active` per row, `AiSettingsViewModel.kt:30`); and **tap-to-SELECT** (`onSelect(p.id)` → `vm.setActive(id)` — jsx:221/237). It does **NOT** reuse `AiProviderListScreen`'s `NavScreen`/chrome/`AiEmptyState`/`ProviderRow`-tap-edit.
+  - **(c) A save-result seam** (round-4 High-4): `AiSettingsViewModel.save()` today returns Unit and upserts async (generates `s.id ?: UUID.randomUUID().toString()` *inside* the launched coroutine, then `_edit.value = null`, no saved ID — `AiSettingsViewModel.kt:85–97`), so WI-AIP cannot deterministically `setActive(savedId)` + pop-on-success by reusing it verbatim (popping immediately races the async upsert; observing list state can't distinguish the new profile). **Note:** `AiProviderStore.upsert` ALREADY returns the saved profile (`suspend fun upsert(...): AiProviderProfile`, "Returns the saved profile", `AiProviderStore.kt:58/70/84`) — the ID is present at the store layer; only the VM discards it. So the seam is an **additive completion/result signal on `AiSettingsViewModel.save()`** (or a thin WI-AIP wrapper) returning the saved provider ID (from `store.upsert(...).id`), so WI-AIP can `setActive(savedId)` + pop-on-success **after** the upsert commits — no race. The #118 VM is currently production-UNWIRED (only test-referenced — verified), and this feature wires it to production for the FIRST time, so an additive save-result seam is safe and appropriate.
+  - **Behavior per the nav model:** empty → "Add provider" → `AiProviderEditSheet` → Save → `save()` returns the saved ID → `store.setActive(savedId)` (first-provider-active is already the store's default `activeId = cur.activeId ?: id`, AiProviderStore.kt:81; the explicit `setActive(savedId)` guarantees the freshly-saved provider is the engine even if others existed) → **pop the whole stack** back to the bilingual sheet, engine strip now "Claude · configured / Change…". `‹ Bilingual` without adding → unconfigured, **no state mutated**. "Change…" → the SAME sheet, populated, current provider checked, tap a row → `setActive`. No consent card, no feature-flag toggle, no readiness tracker (iOS #82, deferred).
+- `bilingual/BilingualInterlinearBody.kt` — the Compose render surface for the **TXT/MD host ONLY** (round-2 M2). Renders per the **one-lazy-item-per-chunk `Column`** H2 render contract (source chunk unchanged as the first `Column` child; translation(s) anchored to chunk `i` as muted non-registered `Text` siblings in the SAME `Column`): muted `Text`, accent left-border, `fontSize*0.88`, CJK font for cjk scripts, RTL handling for Arabic (per `BilingualPageContent`, `vreader-bilingual.jsx:200–277`). Consumes the host-neutral `BilingualRenderState` DTO. Loading state ("Translating chapter… N%" + per-segment dim), error state ("Couldn't translate" + Retry), partial/offline (`unavailableUnits`): source-only silent fallback (iOS Decision 2). Includes the **translation gesture-exclusion** (round-4 H2) so a long-press on a translation child does not route to `hitAt`'s nearest-source-chunk fallback. **NOT the EPUB render surface.**
+- `bilingual/BilingualRenderState.kt` — the host-neutral state DTO shared by the Compose body and the EPUB adapter (round-2 M2): per-unit `{ segments: List<String>?, phase: Loaded|Loading(fraction)|Error|SourceOnly }`. Compose and EPUB share the state/value types, NOT the composable body.
+- `bilingual/EpubBilingualJs.kt` (WI-0-gated) — the EPUB render surface (round-2 M2). Pure Kotlin builder producing JS strings for `navigator.evaluateJavascript(...)`: `enumScript` (enumerate current-resource leaf blocks → JSON `[{id,text}]`), `injectScript(blockId, translationText)` (translation DOM node after the block; CSP-safe: `textContent`/`createTextNode`, never `innerHTML` string-concat; RTL/CJK via class + injected `<style>`), `clearScript()` (idempotent removal). Escaping done in Kotlin (JSON-encode every interpolated string). No Compose. Consumes `BilingualRenderState`.
+- `bilingual/EpubBilingualController.kt` (WI-0-gated) — **the single owner of EPUB units (M1, below).** The runtime actor that serializes enumerate→(cache-restore|translate)→inject/clear against the navigator using WI-0's chosen mechanism (a single mutex OR a monotonic navigator-session token); checks the session token after every suspended JS/AI call; clears BEFORE publication teardown; re-applies on the identified production re-apply signal.
+- `bilingual/BilingualPill.kt` — the `EN ↔ 中` reader-top-chrome pill (per `vreader-reader.jsx` + `vreader-bilingual.jsx` `BilingualPill`:282–305). Rendered by #132's top chrome; #131 provides the composable, #132's surface hosts it (§4).
+
+### EPUB direct-block flow — one owner + concrete API (round-3 Medium-1, BINDING; round-4 CONFIRMED RESOLVED — UNCHANGED)
+
+The **`EpubBilingualController` is the SINGLE OWNER of EPUB units**; the VM's position-driven regular `prefetch` path is **TXT/MD-only**. Concretely, an EPUB position change routes THROUGH the controller (the VM does not run `prefetch(unit)` for `epubHref` units), so the **controller is the sole writer** of an EPUB unit's canonical cache row and its `BilingualRenderState`/`translationsByUnit` entry — the position-driven regular prefetch and the direct-block path can never both write the same canonical cache row. The control flow (every suspended step session-token-guarded):
+
+```
+enumeratedBlocks = navigator.evaluateJavascript(EpubBilingualJs.enumScript)   // [{id,text}] for current resource
+        │  (session token S captured before the call; re-checked after)
+        ▼
+count = enumeratedBlocks.size
+restore = prefetcher.cachedDirect(unit, expectedCount = count, targetLanguage)  // zero-provider cache restore
+        │
+        ├─ hit  → segments = restore
+        └─ miss → segments = prefetcher.prefetchDirect(unit, sourceSegments = enumeratedBlocks.texts, targetLanguage)
+        │  (token re-checked after each suspension; a stale token → discard, no commit, no error surfaced)
+        ▼
+if token S still current:  commit segments → BilingualRenderState[unit] / translationsByUnit[unit]  (single writer)
+        ▼
+EpubBilingualJs.injectScript per (blockId, translation)  via navigator.evaluateJavascript   // token-guarded
+```
+
+- The VM exposes `onEpubBlocksEnumerated(unit, blocks)` as the controller's entry into VM render state, but the **controller owns the enumerate→cachedDirect/prefetchDirect→guarded-commit sequence**; the VM never initiates an EPUB prefetch itself (its position-driven `prefetch` dispatches only `txtDocSegmentWindow`/`mdDocSegmentWindow` units). A stale session token at any commit point discards silently (no `errorUnit`).
+- WI-7b's connected test asserts: enable → inject; disable → clear; reflow/href-change/fragment-recreation/activity-recreation → re-apply from cache via `cachedDirect` (zero provider calls); count-divergence handled via `prefetchDirect`; and that the regular TXT/MD prefetch path is never invoked for an EPUB unit.
+
+### Cancellation + single-flight (round-3 Medium-2, BINDING; round-4 CONFIRMED RESOLVED — UNCHANGED)
+
+android/2026-06-29-223908-this-session-is-being-continued-from-a-previous-c.txt:3320:           chunk `LayoutCoordinates`+root→local+auto-scroll+`getWordBound
+android/2026-06-29-223908-this-session-is-being-continued-from-a-previous-c.txt:3818:           chunk `LayoutCoordinates`+root→local+auto-scroll+`getWordBound
+android/2026-06-29-223908-this-session-is-being-continued-from-a-previous-c.txt:5156:           chunk `LayoutCoordinates`+root→local+auto-scroll+`getWordBound
+./android/2026-06-29-223908-this-session-is-being-continued-from-a-previous-c.txt:3320:           chunk `LayoutCoordinates`+root→local+auto-scroll+`getWordBound
+./android/2026-06-29-223908-this-session-is-being-continued-from-a-previous-c.txt:3818:           chunk `LayoutCoordinates`+root→local+auto-scroll+`getWordBound
+./android/2026-06-29-223908-this-session-is-being-continued-from-a-previous-c.txt:5156:           chunk `LayoutCoordinates`+root→local+auto-scroll+`getWordBound
+./docs/features.md:177:| 124| **Android TXT highlights & notes** (Phase 3, #110 driver; part of checklist B). Custom Compose long-press-drag selection in the TXT reader → 5-color highlight / note / copy / share (reuses #123's annotation domain); washes via `drawBehind`+`getPathForRange`; persists + re-renders + tap-to-edit/remove. | android/app/.../reader/Txt*selection/wash/* + TxtReaderActivity | Medium | VERIFIED | **VERIFIED 2026-06-28 (Gate-5b) — `dev-docs/verification/feature-124-20260628.md` (`result: pass`), merge `a325493b` (`android/v0.12.0`).** All acceptance criteria on emulator API 35: a real long-press selects + popovers, long-press→tap-color creates+persists, tap-existing→edit→Remove deletes, wash render on the live reader, JVM offset/validate/hit-test/wash suites, the binding TXT gate (MD inert). The TXT gesture is automatable via the Compose harness (unlike #123's WebView). GH #1841 closed. **DONE 2026-06-28 (WI-4, final WI — all 4 WIs merged on main).** WI-1 offsets/validate/hit-test (`android/v0.11.1`), WI-2 wash render (`v0.11.2`), WI-3 gesture+popover create (`v0.11.3`), WI-4 tap-edit/remove (`v0.12.0`). Each Gate-4 Codex-audited ship-as-is. On emulator API 35 (`TxtReaderActivityTest`): a REAL long-press selects a word + shows the popover, long-press→tap-color creates+persists a highlight, tap-existing→edit popover→Remove deletes it; the gesture is automatable via the Compose harness. Plan `dev-docs/plans/20260628-feature-124-android-txt-md-highlights.md` v3. Gate-2 Codex audit 2 rounds (gpt-5.5/high; R1 verdict split 6H/5M/2L → R2 1H/1M, all fixed): **scoped to TXT-only** (MD → follow-on #125 — needs a MarkdownRenderer source-offset map; the visible-vs-source `textQuote` + `renderWithMap` Highs are MD-specific); washes via `drawBehind`+`getPathForRange` (not `SpanStyle` background — overlaps don't compose); gesture coords via per-chunk `LayoutCoordinates`+root→local+auto-scroll+`getWordBoundary`; **binding TXT gate** (all annotation paths gated on `BookFormat.txt`; MD render-only + regression — TXT/MD share `TxtReaderActivity`); half-open `Utf16Range`; range validation incl. mid-surrogate; `sourceUnitId=text-document:<key>`; hit-tester overlap precedence. 4 WIs: WI-1 offsets/validate/hit-test; WI-2 wash render; WI-3 gesture+popover create; WI-4 edit/remove+accept. **Box B then needs #125 (MD) + review-sheet/bookmark (item F).** GH: #1841 |
+./dev-docs/plans/20260628-feature-124-android-txt-md-highlights.md:67:  `LazyColumn`. Per visible chunk: capture `TextLayoutResult` (`onTextLayout`) **and** `LayoutCoordinates`
+./dev-docs/plans/20260628-feature-124-android-txt-md-highlights.md:95:  `LayoutCoordinates` — rejected `SelectionContainer` (no durable source offsets across the chunked
+./dev-docs/plans/20260628-feature-124-android-txt-md-highlights.md:124:- **R1 — gesture coordinate mapping** across a scrolling LazyColumn (Gate-2 High): per-chunk `TextLayoutResult` + `LayoutCoordinates` via `onGloballyPositioned`; convert root→local before `getOffsetForPosition`; auto-scroll near edges. Keep the pure offset math in `TxtSourceOffsets` (unit-tested); the gesture stays thin.
+./dev-docs/plans/20260628-feature-124-android-txt-md-highlights.md:146:  `drawBehind`+`getPathForRange` (not `SpanStyle`); gesture coords via per-chunk `LayoutCoordinates` +
+./docs/architecture.md:681:visible chunk's `TextLayoutResult` + `LayoutCoordinates`; one `awaitEachGesture` distinguishes a tap
+./dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:78:**Live invariant #1 — per-chunk layout/selection (round-3 High-2, verified TxtReaderActivity.kt:1043–1085):** the TXT/MD body iterates `items(count = document.chunkCount, key = { it })` (TxtReaderActivity.kt:1043). For **each chunk `i`** it owns **exactly ONE `TextLayoutResult`** (`var layout by remember(i) { … }`, set in `onTextLayout`, TxtReaderActivity.kt:1059/1075) and **exactly ONE selection registration** (`selectionController.registerChunk(i, l, c)` / `unregisterChunk(i)`, TxtReaderActivity.kt:1062–1066). Highlights (`highlightSpan(i)`, :1047), annotation washes (`washesForChunk(i)`, :1058), the read-aloud span wash (`addStyle(SpanStyle(background = wash), …)`, :1050–1054), and selection accents (`selectionForChunk(i)` → `drawRangeFill`, :1069/1081) all key off that **per-chunk** layout and the chunk-local UTF-16 offsets. **Splitting a chunk's source `Text` into multiple `Text` nodes would break every one of these** (two `Text` nodes = two `TextLayoutResult`s = broken selection coordinates, misplaced highlight/wash/annotation ranges, a shifted read-aloud wash).
+./dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:82:- **Bookmark / annotation / search / scrubber / TTS jumps** all call `listState.scrollToItem(document.chunkForOffset(target))` (bookmark :411, annotation :421, search :454, scrubber :481; TTS auto-scroll `animateScrollToItem(spokenChunk)` where `spokenChunk = document.chunkForOffset(tts.charStart)` — :252/:257).
+./dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:83:- **TTS visibility** compares lazy-item indices with the chunk directly: `listState.layoutInfo.visibleItemsInfo.none { it.index == spokenChunk }` (:256).
+./dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:85:**Therefore inserting SEPARATE translation `LazyColumn` items (the v4 "additive items after the anchor chunk" contract) is NOT implementable:** every separate translation item inserted before a given source chunk shifts that chunk's lazy index, so `offsetForChunk(firstVisibleItemIndex)` reads the wrong chunk's offset (corrupts position save + progress), `scrollToItem(chunkForOffset(target))` lands on the wrong item (corrupts every jump), and `visibleItemsInfo.index == spokenChunk` never matches (corrupts TTS auto-scroll). The v4 contract is **rejected**.
+./dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:90:> 1. the **UNCHANGED source `Text`** — one `TextLayoutResult`, one `registerChunk(i, …)`/`unregisterChunk(i)`, byte-identical to today (the exact code at TxtReaderActivity.kt:1044–1084 is unchanged, now nested in a `Column`);
+./dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:98:2. Render the source chunk `i` **EXACTLY as today** (the unchanged `Text` + its `remember(i)` layout/coords + `registerChunk(i, …)`/`unregisterChunk(i)` + `highlightSpan(i)`/`washesForChunk(i)`/`selectionForChunk(i)` — TxtReaderActivity.kt:1044–1084, now the first child of the `Column`).
+./dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:104:- **Explicit translation gesture exclusion (round-4 High-2 — BINDING):** `TxtSelectionController.hitAt` (`reader/TxtSelectionController.kt:47`) falls back to the **nearest registered source chunk** when the pointer is outside all source-chunk bounds (`chunks.entries.minByOrNull { verticalDistance(...) }` when no chunk's `boundsInWindow()` contains the point, :51–53). So merely omitting `registerChunk` for the translation does **NOT** make it non-selectable — a long-press *on the translation text* would fall through to the nearest source chunk and select source. **WI-8 must add an explicit hit-test / gesture exclusion for the translation composable's bounds** so a long-press whose pointer lands inside a translation `Text`'s bounds is consumed (no selection begun) rather than routed to `hitAt`'s nearest-chunk fallback. (Options: the translation `Text` consumes the long-press gesture in its own `pointerInput`; or the selection gesture root records the translation composables' window bounds and short-circuits `beginAt` when the point is inside one. WI-8 picks and tests one.)
+./dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:106:- **TTS auto-scroll visibility must key off the SOURCE `Text` bounds, NOT the item index (round-5 High — a NEW consequence of the in-item `Column`):** the TTS auto-scroll guard (TxtReaderActivity.kt:252/256) currently keeps the spoken chunk on screen via `listState.layoutInfo.visibleItemsInfo.none { it.index == spokenChunk }` — item-level visibility. With the in-item `Column`, an item is now taller than its source line (source + translation children), so when `spokenChunk`'s SOURCE `Text` has scrolled above the viewport but its translation sibling is still visible, `visibleItemsInfo` still contains the item's index → the guard falsely suppresses `animateScrollToItem(spokenChunk)` and leaves the spoken SOURCE off-screen. **WI-8 must redefine the TTS-visibility predicate to test the registered SOURCE `Text` bounds** — the selection controller already tracks each source chunk's `LayoutCoordinates`/`boundsInWindow()` via `registerChunk(i, layout, coordinates)` (TxtSelectionController.kt): `spokenChunk` is visible iff its registered source bounds intersect the list viewport; otherwise `animateScrollToItem(spokenChunk)` scrolls the item's top (the source) into view. This is **inert when bilingual is OFF** (no translation child → item height == source height → item-index visibility already equals source visibility), so the disabled path is byte-identical.
+./dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:109:  - (a) each source chunk's **selection registration is UNCHANGED** (same `registerChunk(i, …)` count and coordinates as OFF; a translation child registers nothing);
+./dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:111:  - (c) **lazy-index == chunk-index preserved:** with bilingual ON — **position-save round-trips to the same chunk** (`offsetForChunk(firstVisibleItemIndex)` → save → reopen → `chunkForOffset(offset)` lands on the same chunk); **bookmark/annotation/search/scrubber jumps land on the correct chunk** (`scrollToItem(chunkForOffset(target))` scrolls to the right item); **TTS auto-scroll keeps the spoken SOURCE on screen — visibility keyed off the registered source `Text` bounds, NOT `visibleItemsInfo.index` (round-5 High)**, INCLUDING the case where only `spokenChunk`'s translation portion is visible (its source scrolled above the viewport) → TTS brings the SOURCE back on-screen; (assert the index-identity behaviors above are identical to the OFF baseline — no lazy index shift);
+./dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:314:8. **SEPARATE additive `LazyColumn` items per translation, after the anchor chunk (v4)** — REJECTED (round-4 H2): separate lazy items shift every following lazy index, and the live reader treats lazy-item indices AS `TxtDocument` chunk indices (`offsetForChunk(firstVisibleItemIndex)` for position save/progress — TxtReaderActivity.kt:220/473/623; `scrollToItem(chunkForOffset(target))` for every bookmark/annotation/search/scrubber/TTS jump — :411/:421/:454/:481/:257; `visibleItemsInfo.index == spokenChunk` for TTS visibility — :256). Replaced by the **one-lazy-item-per-chunk `Column`** contract (source `Text` unchanged as the first child, translations as sibling children in the SAME lazy item — no lazy item added, no index shifted).
+./dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:377:**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into the `items(count = document.chunkCount, key = { it })` loop as **muted non-registered translation `Text` children inside each anchor chunk's wrapping `Column`, source chunk byte-unchanged, the loop + keys UNCHANGED so lazy-index==chunk-index is preserved (round-4 H2)** + the translation **gesture-exclusion** (round-4 H2) + the **TTS source-bounds visibility fix** (round-5 H: the TTS auto-scroll predicate keys off the registered source `Text` bounds, not `visibleItemsInfo.index`, so a translation-only-visible item does not falsely suppress the auto-scroll) + position-change (`charOffsetUTF16`) + setup-sheet. `originalFormat`-gated (TXT/MD). Uses WI-4b's DI. **#129 VERIFIED — straight edit.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2)**; **highlights/annotation-washes/read-aloud-wash still key off source chunks (H2)**; **with bilingual ON — position-save round-trips to the same chunk; bookmark/search/scrubber/TTS jumps land on the correct chunk (lazy-index==chunk-index preserved — round-4 H2); TTS auto-scroll brings the spoken SOURCE on-screen even when only its translation portion is visible (source-bounds visibility — round-5 H)**; **a long-press on translation text does NOT select (gesture exclusion — round-4 H2)**; a translation child is non-selectable, does not perturb source offsets (H2); disable → source-selection byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders exactly one translation inside its last chunk's `Column` (H1/Low-2)**; **one-chunk/final-chunk anchors render (H1)**; MD source mapping. Deps: WI-6, WI-7a, WI-4b.
+./dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:397:- **Enabled render breaking the per-chunk layout/selection model AND the lazy-index↔chunk-index identity (round-3 H2 + round-4 H2).** Fixed by the **one-lazy-item-per-chunk `Column`** render contract: the `items(count = chunkCount, key = { it })` loop + keys are UNCHANGED (lazy-index==chunk-index preserved, so position-save/progress/every jump/TTS visibility — TxtReaderActivity.kt:220/252/256/411/421/454/481/623 — stay correct); inside each item a `Column` holds the UNCHANGED source `Text` (one `TextLayoutResult`, one `registerChunk(i)`) then the muted non-registered translation child(ren); an explicit **gesture-exclusion** stops a long-press on translation text from routing to `hitAt`'s nearest-source-chunk fallback (TxtSelectionController.kt:47–53). Enabled-mode tests assert selection/highlight/wash/annotation parity AND lazy-index==chunk-index parity with disabled, plus translation-not-selectable.
+./dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:438:  - **H2 (round-4 High-2) — one-lazy-item-per-chunk `Column` (THE key fix):** the v4 "separate additive `LazyColumn` items after the anchor chunk" contract is NOT implementable — the live reader treats lazy-item indices AS `TxtDocument` chunk indices (position-save via `offsetForChunk(firstVisibleItemIndex)`, TxtReaderActivity.kt:220/473/623; every bookmark/annotation/search/scrubber/TTS jump via `scrollToItem(chunkForOffset(...))`, :411/:421/:454/:481/:257; TTS visibility via `visibleItemsInfo.index == spokenChunk`, :256), so inserting separate translation items shifts every following lazy index and corrupts all of these. New binding contract: keep EXACTLY ONE lazy item per chunk (the `items(count=chunkCount, key={it})` loop + keys UNCHANGED → lazy-index==chunk-index preserved); INSIDE each item wrap the content in a `Column` — the UNCHANGED source `Text` (one `TextLayoutResult`, one `registerChunk(i)`) then the muted non-registered translation child(ren) anchored to chunk `i`. ADDED explicit translation **gesture exclusion** (TxtSelectionController.hitAt falls back to the nearest source chunk when the pointer is past source bounds, :47–53, so omitting `registerChunk` is not enough). Updated §2 H2, the `BilingualInterlinearBody` file entry, the rejected-alternatives list (added the separate-lazy-items rejection), WI-7a, WI-8, and the enabled-mode tests (position-save round-trips to the same chunk; jumps/TTS land on the correct chunk; long-press on translation does NOT select).
+./dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:444:- **v6 (2026-07-12): Gate-2 round-5's one residual High resolved — TTS source-bounds visibility.** The in-item `Column` (round-4 H2 fix) makes each item taller than its source line, so the TTS auto-scroll guard's item-index visibility check (`visibleItemsInfo.index == spokenChunk`, TxtReaderActivity.kt:252/256) no longer proves SOURCE visibility: when the spoken source has scrolled above the viewport but its translation sibling is still visible, the guard falsely suppresses the auto-scroll and leaves the source off-screen. Fix: WI-8 redefines the TTS-visibility predicate to test the registered SOURCE `Text` bounds (the selection controller already tracks each source chunk's `LayoutCoordinates` via `registerChunk`), + a translation-only-visible connected test. Inert when bilingual is OFF (item height == source height → item-index visibility already equals source visibility). Updated §2 H2 (new TTS-visibility bullet + enabled-mode test (c)), WI-8 (scope + test), and the connected-test list. WI count UNCHANGED at 13. Awaiting Gate-2 round-6 (micro-confirm).
+./android/app/src/main/kotlin/com/vreader/app/search/InBookSearchSheet.kt:194:            listState.layoutInfo.visibleItemsInfo.lastOrNull()?.key == "group-$lastGroupIndex"
+android/app/src/main/kotlin/com/vreader/app/search/InBookSearchSheet.kt:194:            listState.layoutInfo.visibleItemsInfo.lastOrNull()?.key == "group-$lastGroupIndex"
+./android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:2:// TextLayoutResult + LayoutCoordinates; the controller converts a pointer (LazyColumn-local) → window
+./android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:11:import androidx.compose.ui.layout.LayoutCoordinates
+./android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:12:import androidx.compose.ui.layout.boundsInWindow
+./android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:26:    private data class ChunkInfo(val layout: TextLayoutResult, val coords: LayoutCoordinates)
+./android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:30:    private var lazyCoords: LayoutCoordinates? = null
+./android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:37:    fun setLazyCoords(coords: LayoutCoordinates) { lazyCoords = coords }
+./android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:38:    fun registerChunk(index: Int, layout: TextLayoutResult, coords: LayoutCoordinates) {
+./android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:41:    fun unregisterChunk(index: Int) { chunks.remove(index) }
+./android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:51:        val hit = chunks.entries.firstOrNull { it.value.coords.boundsInWindow().contains(windowPoint) }
+./android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:52:            ?: (if (allowNearest) chunks.entries.minByOrNull { verticalDistance(it.value.coords.boundsInWindow(), windowPoint) } else null)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:2:// TextLayoutResult + LayoutCoordinates; the controller converts a pointer (LazyColumn-local) → window
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:11:import androidx.compose.ui.layout.LayoutCoordinates
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:12:import androidx.compose.ui.layout.boundsInWindow
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:26:    private data class ChunkInfo(val layout: TextLayoutResult, val coords: LayoutCoordinates)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:30:    private var lazyCoords: LayoutCoordinates? = null
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:37:    fun setLazyCoords(coords: LayoutCoordinates) { lazyCoords = coords }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:38:    fun registerChunk(index: Int, layout: TextLayoutResult, coords: LayoutCoordinates) {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:41:    fun unregisterChunk(index: Int) { chunks.remove(index) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:51:        val hit = chunks.entries.firstOrNull { it.value.coords.boundsInWindow().contains(windowPoint) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:52:            ?: (if (allowNearest) chunks.entries.minByOrNull { verticalDistance(it.value.coords.boundsInWindow(), windowPoint) } else null)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:252:                        val spokenChunk = if (tts.phase == TtsPhase.speaking) s.document.chunkForOffset(tts.charStart) else -1
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:255:                        LaunchedEffect(spokenChunk) {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:256:                            if (spokenChunk >= 0 && listState.layoutInfo.visibleItemsInfo.none { it.index == spokenChunk }) {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:257:                                runCatching { listState.animateScrollToItem(spokenChunk) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1060:            var coords by remember(i) { mutableStateOf<androidx.compose.ui.layout.LayoutCoordinates?>(null) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1064:                    if (l != null && c != null) selectionController.registerChunk(i, l, c)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1066:                DisposableEffect(selectionController, i) { onDispose { selectionController.unregisterChunk(i) } }
+./android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:252:                        val spokenChunk = if (tts.phase == TtsPhase.speaking) s.document.chunkForOffset(tts.charStart) else -1
+./android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:255:                        LaunchedEffect(spokenChunk) {
+./android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:256:                            if (spokenChunk >= 0 && listState.layoutInfo.visibleItemsInfo.none { it.index == spokenChunk }) {
+./android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:257:                                runCatching { listState.animateScrollToItem(spokenChunk) }
+./android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1060:            var coords by remember(i) { mutableStateOf<androidx.compose.ui.layout.LayoutCoordinates?>(null) }
+./android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1064:                    if (l != null && c != null) selectionController.registerChunk(i, l, c)
+./android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1066:                DisposableEffect(selectionController, i) { onDispose { selectionController.unregisterChunk(i) } }
+
+codex
+The live code confirms the essential raw data exists, but I’m checking one important implementation detail before deciding: whether the controller exposes enough viewport geometry (and how detached/unregistered chunks behave), since the plan’s “bounds intersect list viewport” predicate needs both source bounds and a reliable list viewport in the same coordinate space.
+exec
+/bin/zsh -lc "nl -ba android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt | sed -n '1,150p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt | sed -n '205,270p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt | sed -n '1025,1095p'
+rg -n -C 5 \"setLazyCoords|TxtSelectionController\\(\" android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt
+nl -ba dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md | sed -n '96,116p'
+nl -ba dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md | sed -n '366,384p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+     1	// Purpose: feature #124 WI-3 — drives the TXT custom selection. Each visible chunk registers its
+     2	// TextLayoutResult + LayoutCoordinates; the controller converts a pointer (LazyColumn-local) → window
+     3	// space → the hit chunk's local space → rendered offset → SOURCE offset (TxtSourceOffsets), and resolves
+     4	// a word boundary at long-press. Selection is a SOURCE Utf16Range; the in-progress range renders as an
+     5	// accent wash. Kept off the Activity so the geometry is isolated; the Activity wires the gesture +
+     6	// popover + persistence.
+     7	package com.vreader.app.reader
+     8	
+     9	import androidx.compose.runtime.Stable
+    10	import androidx.compose.ui.geometry.Offset
+    11	import androidx.compose.ui.layout.LayoutCoordinates
+    12	import androidx.compose.ui.layout.boundsInWindow
+    13	import androidx.compose.ui.text.TextLayoutResult
+    14	import kotlinx.coroutines.flow.MutableStateFlow
+    15	import kotlinx.coroutines.flow.StateFlow
+    16	import kotlinx.coroutines.flow.asStateFlow
+    17	
+    18	@Stable
+    19	class TxtSelectionController(
+    20	    private val doc: TxtDocument,
+    21	    // feature #125 — format-aware rendered↔source bridge. The chunk TextLayoutResults are built from the
+    22	    // RENDERED text, so getOffsetForPosition/getWordBoundary/getCursorRect speak rendered coords; the
+    23	    // mapper converts them to/from the SOURCE coords selections + highlights are stored in. TXT = identity.
+    24	    private val mapper: ChunkTextMapper,
+    25	) {
+    26	    private data class ChunkInfo(val layout: TextLayoutResult, val coords: LayoutCoordinates)
+    27	    /** A resolved hit: the chunk index/info + the chunk-local rendered offset + the absolute source offset. */
+    28	    private data class Hit(val chunkIndex: Int, val info: ChunkInfo, val rendered: Int, val source: Int)
+    29	    private val chunks = HashMap<Int, ChunkInfo>()
+    30	    private var lazyCoords: LayoutCoordinates? = null
+    31	    // the initial word selected at long-press — the FIXED anchor; drags extend relative to it (never drop it).
+    32	    private var anchorRange: Utf16Range? = null
+    33	
+    34	    private val _selection = MutableStateFlow<Utf16Range?>(null)
+    35	    val selection: StateFlow<Utf16Range?> = _selection.asStateFlow()
+    36	
+    37	    fun setLazyCoords(coords: LayoutCoordinates) { lazyCoords = coords }
+    38	    fun registerChunk(index: Int, layout: TextLayoutResult, coords: LayoutCoordinates) {
+    39	        chunks[index] = ChunkInfo(layout, coords)
+    40	    }
+    41	    fun unregisterChunk(index: Int) { chunks.remove(index) }
+    42	
+    43	    /** Pointer (LazyColumn-local) → the hit chunk + chunk-local rendered offset + source offset. The hit
+    44	     *  chunk is used for BOTH the source mapping AND word-boundary lookup (avoids a chunk-boundary shift).
+    45	     *  [allowNearest]: for a DRAG, fall back to the nearest chunk when the point is past the text; for a
+    46	     *  TAP-to-edit, require the point to actually be inside a text chunk (else a margin tap could edit). */
+    47	    private fun hitAt(localPoint: Offset, allowNearest: Boolean = true): Hit? {
+    48	        val lz = lazyCoords ?: return null
+    49	        if (chunks.isEmpty()) return null
+    50	        val windowPoint = lz.localToWindow(localPoint)
+    51	        val hit = chunks.entries.firstOrNull { it.value.coords.boundsInWindow().contains(windowPoint) }
+    52	            ?: (if (allowNearest) chunks.entries.minByOrNull { verticalDistance(it.value.coords.boundsInWindow(), windowPoint) } else null)
+    53	            ?: return null
+    54	        val chunkLocal = hit.value.coords.windowToLocal(windowPoint)
+    55	        val rendered = hit.value.layout.getOffsetForPosition(chunkLocal).coerceIn(0, hit.value.layout.layoutInput.text.length)
+    56	        // rendered cursor → chunk-local source (empty rendered range maps to the source edge) → global source.
+    57	        val localSource = mapper.renderedRangeToSource(hit.key, Utf16Range(rendered, rendered)).startInclusive
+    58	        return Hit(hit.key, hit.value, rendered, doc.offsetForChunk(hit.key) + localSource)
+    59	    }
+    60	
+    61	    /** Long-press: select the word under [localPoint] (word boundary in the HIT chunk, mapped to source). */
+    62	    fun beginAt(localPoint: Offset) {
+    63	        val hit = hitAt(localPoint) ?: return
+    64	        val word = hit.info.layout.getWordBoundary(hit.rendered)   // RENDERED coords in the hit chunk
+    65	        val base = doc.offsetForChunk(hit.chunkIndex)
+    66	        // rendered word → chunk-local source span → global source (markers stripped for MD).
+    67	        val src = mapper.renderedRangeToSource(hit.chunkIndex, Utf16Range(word.start, word.end))
+    68	        val start = base + src.startInclusive
+    69	        val end = base + src.endExclusive
+    70	        val range = if (end > start) Utf16Range(start, end) else Utf16Range(hit.source, (hit.source + 1).coerceAtMost(doc.text.length))
+    71	        anchorRange = range
+    72	        _selection.value = range
+    73	    }
+    74	
+    75	    /** Drag: extend relative to the FIXED [anchorRange] (the initial word) — extending before it grows the
+    76	     *  start, after it grows the end, inside it keeps the word. The anchor word is never dropped. */
+    77	    fun extendTo(localPoint: Offset) {
+    78	        val anchor = anchorRange ?: return
+    79	        val off = (hitAt(localPoint) ?: return).source.coerceIn(0, doc.text.length)
+    80	        _selection.value = when {
+    81	            off <= anchor.startInclusive -> Utf16Range(off, anchor.endExclusive)
+    82	            off >= anchor.endExclusive -> Utf16Range(anchor.startInclusive, off)
+    83	            else -> anchor
+    84	        }
+    85	    }
+    86	
+    87	    fun clear() { _selection.value = null; anchorRange = null }
+    88	
+    89	    /** The current selection range, or null. */
+    90	    fun currentRange(): Utf16Range? = _selection.value
+    91	
+    92	    /** Resolve a tap (LazyColumn-local) to a SOURCE offset, for hit-testing an existing highlight. Strict
+    93	     *  (no nearest-chunk fallback) so a tap in the margin/blank space doesn't edit a nearby highlight. */
+    94	    fun resolveSourceOffset(localPoint: Offset): Int? = hitAt(localPoint, allowNearest = false)?.source
+    95	
+    96	    /** Convert a LazyColumn-local point to window coords (to anchor the edit popover at a tap). */
+    97	    fun toWindow(localPoint: Offset): Offset? = lazyCoords?.localToWindow(localPoint)
+    98	
+    99	    /** Whether the current selection is a persist-worthy range (in-bounds, non-empty, surrogate-safe). */
+   100	    fun isCurrentSelectionValid(): Boolean = _selection.value?.let { TxtSelection.isValid(it, doc.text) } ?: false
+   101	
+   102	    /** The VISIBLE (rendered) substring of the current selection — for the popover / copy / share / UI.
+   103	     *  For TXT this equals the source; for MD it's the marker-stripped rendered text the user sees. */
+   104	    fun selectedVisibleText(): String? {
+   105	        val r = _selection.value ?: return null
+   106	        if (r.isEmpty || r.endExclusive > doc.text.length) return null
+   107	        val sb = StringBuilder()
+   108	        for (cr in TxtSourceOffsets.chunkRanges(doc, r)) {
+   109	            sb.append(mapper.visibleText(cr.chunkIndex, mapper.sourceRangeToRendered(cr.chunkIndex, cr.local)))
+   110	        }
+   111	        return sb.toString().ifEmpty { null }
+   112	    }
+   113	
+   114	    /** The SOURCE (markdown/raw) substring of the current selection — for the locator textQuote + anchor. */
+   115	    fun selectedSourceText(): String? {
+   116	        val r = _selection.value ?: return null
+   117	        if (r.isEmpty || r.endExclusive > doc.text.length) return null
+   118	        return doc.text.substring(r.startInclusive, r.endExclusive)
+   119	    }
+   120	
+   121	    /** The in-progress selection projected onto [chunkIndex] as a chunk-local RENDERED range, for the
+   122	     *  accent wash (`getPathForRange` speaks rendered coords). Source→rendered via the mapper (MD). */
+   123	    fun selectionForChunk(chunkIndex: Int): Utf16Range? {
+   124	        val r = _selection.value ?: return null
+   125	        val localSource = TxtSourceOffsets.chunkRanges(doc, r).firstOrNull { it.chunkIndex == chunkIndex }?.local ?: return null
+   126	        return mapper.sourceRangeToRendered(chunkIndex, localSource)
+   127	    }
+   128	
+   129	    /** The window-space point just below the selection's end, to anchor the popover. */
+   130	    fun selectionEndAnchorWindow(): Offset? {
+   131	        val r = _selection.value ?: return null
+   132	        val endChunk = doc.chunkForOffset((r.endExclusive - 1).coerceAtLeast(0)).coerceIn(0, doc.chunkCount - 1)
+   133	        val info = chunks[endChunk] ?: return null
+   134	        val base = doc.offsetForChunk(endChunk)
+   135	        // source end → chunk-local source → rendered cursor (end-affinity) for getCursorRect.
+   136	        val localSourceEnd = (r.endExclusive - base).coerceAtLeast(0)
+   137	        val renderedEnd = mapper.renderedCursorForSourceEnd(endChunk, localSourceEnd).coerceIn(0, info.layout.layoutInput.text.length)
+   138	        val rect = info.layout.getCursorRect(renderedEnd)
+   139	        return info.coords.localToWindow(Offset(rect.left, rect.bottom))
+   140	    }
+   141	
+   142	    private fun verticalDistance(bounds: androidx.compose.ui.geometry.Rect, p: Offset): Float = when {
+   143	        p.y < bounds.top -> bounds.top - p.y
+   144	        p.y > bounds.bottom -> p.y - bounds.bottom
+   145	        else -> 0f
+   146	    }
+   147	}
+   205	                    }
+   206	                }
+   207	                // feature #129 — the live Display settings (theme/font/size/spacing/margin). NULL until
+   208	                // the DataStore's first emission; the reader body is withheld until then (Gate-4 Medium:
+   209	                // rendering defaults first would flash the wrong theme/typography for a user with stored
+   210	                // non-default settings). The empty loading scaffold is the only pre-emission surface.
+   211	                val settingsOrNull by container.readerSettingsStore.settings
+   212	                    .collectAsStateWithLifecycle(initialValue = null)
+   213	                val gated = if (settingsOrNull == null && state !is TxtUiState.Failed) TxtUiState.Loading else state
+   214	                when (val s = gated) {
+   215	                    is TxtUiState.Failed -> LaunchedEffect(Unit) { finish() }
+   216	                    is TxtUiState.Loading -> TxtLoadingScaffold((settingsOrNull ?: ReaderSettings()).theme)
+   217	                    is TxtUiState.Loaded -> {
+   218	                        // non-null by the gate above (Loaded is unreachable pre-emission).
+   219	                        val displaySettings = checkNotNull(settingsOrNull)
+   220	                        val listState = rememberLazyListState(initialFirstVisibleItemIndex = s.initialIndex)
+   221	                        // onStop flush — captures the live list state + book/document.
+   222	                        SideEffect {
+   223	                            flushPosition = { savePosition(s.book, s.document, listState.firstVisibleItemIndex) }
+   224	                        }
+   225	                        // Debounced steady-state save as the user scrolls.
+   226	                        LaunchedEffect(listState, s.document) {
+   227	                            snapshotFlow { listState.firstVisibleItemIndex }
+   228	                                .drop(1)
+   229	                                .debounce(1_000)
+   230	                                .collect { savePosition(s.book, s.document, it) }
+   231	                        }
+   232	                        // feature #121 — read-aloud. The VM drives the designed control bar; the spoken
+   233	                        // sentence is washed + auto-scrolled (TXT). Chunking is LAZY + off-main (only
+   234	                        // on Read aloud) so a large book never scans the whole text on composition.
+   235	                        val ttsVm: TtsViewModel = viewModel(factory = viewModelFactory {
+   236	                            initializer { TtsViewModel(AndroidTtsEngine(applicationContext)) }
+   237	                        })
+   238	                        val tts by ttsVm.state.collectAsStateWithLifecycle()
+   239	                        val ttsScope = rememberCoroutineScope()
+   240	                        LaunchedEffect(ttsVm) { ttsVm.intents.collect { launchTtsIntent(it) } }
+   241	                        // pause read-aloud when the reader is backgrounded (no MediaSession by design —
+   242	                        // plan §OOS); the engine is shut down on Activity finish via the VM's onCleared.
+   243	                        val lifecycleOwner = LocalLifecycleOwner.current
+   244	                        DisposableEffect(lifecycleOwner) {
+   245	                            // guard against ON_STOP firing on a rotation (config change) — the VM is
+   246	                            // retained across rotation, so don't pause when we're just reconfiguring.
+   247	                            val obs = LifecycleEventObserver { _, e -> if (e == Lifecycle.Event.ON_STOP && !isChangingConfigurations) ttsVm.pause() }
+   248	                            lifecycleOwner.lifecycle.addObserver(obs)
+   249	                            onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
+   250	                        }
+   251	                        val active = tts.phase != TtsPhase.idle
+   252	                        val spokenChunk = if (tts.phase == TtsPhase.speaking) s.document.chunkForOffset(tts.charStart) else -1
+   253	                        // auto-scroll ONLY when the spoken chunk is off-screen — so a small manual scroll
+   254	                        // while listening isn't fought on every sentence.
+   255	                        LaunchedEffect(spokenChunk) {
+   256	                            if (spokenChunk >= 0 && listState.layoutInfo.visibleItemsInfo.none { it.index == spokenChunk }) {
+   257	                                runCatching { listState.animateScrollToItem(spokenChunk) }
+   258	                            }
+   259	                        }
+   260	                        var showSpeed by remember { mutableStateOf(false) }
+   261	                        var showVoice by remember { mutableStateOf(false) }
+   262	                        var starting by remember { mutableStateOf(false) }   // guards double-tap → double-chunk
+   263	                        // snapshot the voice options once when the sheet opens (not every recomposition).
+   264	                        val voiceList = remember(showVoice) { if (showVoice) ttsVm.voiceListState() else com.vreader.app.tts.TtsVoiceListState() }
+   265	
+   266	                        // feature #122 — reading-stats: track this session (the process-singleton tracker
+   267	                        // survives rotation) + show the auto-fading session pill.
+   268	                        val tracker = container.readingTimeTracker
+   269	                        val bookKey = s.book.fingerprintKey
+   270	                        val sessionSeconds by tracker.sessionSeconds.collectAsStateWithLifecycle()
+  1025	                                selectionController.beginAt(longPress.position)
+  1026	                                val completed = drag(longPress.id) { change -> selectionController.extendTo(change.position); change.consume() }
+  1027	                                if (completed) currentOnFinalize() else selectionController.clear()
+  1028	                            } else if (!down.isConsumed) {
+  1029	                                // null also means cancel (e.g. a scroll won) — only a TAP leaves the down
+  1030	                                // unconsumed; a scroll consumes it, so it won't be misread as tap-to-edit.
+  1031	                                currentOnTap(down.position)
+  1032	                            }
+  1033	                        }
+  1034	                    }
+  1035	                } else {
+  1036	                    Modifier
+  1037	                },
+  1038	            ),
+  1039	        state = listState,
+  1040	        contentPadding = PaddingValues(horizontal = marginDp.dp, vertical = 16.dp),
+  1041	    ) {
+  1042	        // Count-based: indices on demand (a newline-dense 14MB file can be 100k+ chunks).
+  1043	        items(count = document.chunkCount, key = { it }) { i ->
+  1044	            val raw = document.textForChunk(i).toString()
+  1045	            // .md → styled markdown spans (no read-aloud span wash — markers shift offsets, plan §OOS).
+  1046	            // .txt → raw verbatim, with the spoken-sentence span washed when read-aloud is active.
+  1047	            val span = if (isMarkdown) null else highlightSpan(i)
+  1048	            val text = when {
+  1049	                isMarkdown -> mapper.renderedText(i)   // #125: the mapper is the single render owner
+  1050	                span != null -> buildAnnotatedString {
+  1051	                    append(raw)
+  1052	                    val a = span.first.coerceIn(0, raw.length); val b = (span.last + 1).coerceIn(a, raw.length)
+  1053	                    if (b > a) addStyle(SpanStyle(background = wash), a, b)
+  1054	                }
+  1055	                else -> AnnotatedString(raw)
+  1056	            }
+  1057	            // annotation washes drawn BEHIND the text (getPathForRange) — separate from the read-aloud span.
+  1058	            val washes = washesForChunk(i)
+  1059	            var layout by remember(i) { mutableStateOf<TextLayoutResult?>(null) }
+  1060	            var coords by remember(i) { mutableStateOf<androidx.compose.ui.layout.LayoutCoordinates?>(null) }
+  1061	            if (selectionController != null) {
+  1062	                LaunchedEffect(i, layout, coords) {
+  1063	                    val l = layout; val c = coords
+  1064	                    if (l != null && c != null) selectionController.registerChunk(i, l, c)
+  1065	                }
+  1066	                DisposableEffect(selectionController, i) { onDispose { selectionController.unregisterChunk(i) } }
+  1067	            }
+  1068	            // read `selection` (a State) so a selection change recomposes + redraws the accent.
+  1069	            val selRange = if (selection != null) selectionController?.selectionForChunk(i) else null
+  1070	            Text(
+  1071	                text = text,
+  1072	                // merge over the material default (the pre-#129 explicit-param behavior) so platform
+  1073	                // text defaults (letterSpacing etc.) are kept — only the Display settings change.
+  1074	                style = androidx.compose.material3.LocalTextStyle.current.merge(textStyle),
+  1075	                onTextLayout = { layout = it },
+  1076	                modifier = Modifier
+  1077	                    .onGloballyPositioned { coords = it }
+  1078	                    .drawBehind {
+  1079	                        layout?.let { l ->
+  1080	                            drawWashes(l, washes)
+  1081	                            selRange?.let { drawRangeFill(l, it, selectionAccent) }
+  1082	                        }
+  1083	                    },
+  1084	            )
+  1085	        }
+  1086	    }
+  1087	}
+282-                            if (annotatable) container.annotationsRepository.highlights(bookKey) else flowOf(emptyList())
+283-                        }.collectAsStateWithLifecycle(emptyList())
+284-                        val washMap = remember(highlightsList, s.document, chunkMapper) { TxtWashMapper.washesByChunk(s.document, highlightsList, chunkMapper) }
+285-
+286-                        // feature #124/#125 — custom selection + popover (TXT + MD).
+287:                        val selectionController = remember(s.document, chunkMapper) { if (annotatable) TxtSelectionController(s.document, chunkMapper) else null }
+288-                        val popoverVm = remember(bookKey) { com.vreader.app.annotations.SelectionPopoverViewModel() }
+289-                        val popoverState by popoverVm.state.collectAsStateWithLifecycle()
+290-                        DisposableEffect(lifecycleOwner, bookKey) {
+291-                            val obs = LifecycleEventObserver { _, e ->
+292-                                when (e) {
+--
+1009-    val currentOnTap by androidx.compose.runtime.rememberUpdatedState(onTapAt)
+1010-    val currentOnFinalize by androidx.compose.runtime.rememberUpdatedState(onSelectionFinalized)
+1011-    LazyColumn(
+1012-        Modifier
+1013-            .fillMaxSize()
+1014:            .onGloballyPositioned { selectionController?.setLazyCoords(it) }
+1015-            .then(
+1016-                if (selectionController != null) {
+1017-                    // ONE detector distinguishes a TAP (edit an existing highlight) from a LONG-PRESS+drag
+1018-                    // (new selection) — two separate pointerInput detectors conflict over the same down event.
+1019-                    Modifier.pointerInput(selectionController) {
+    96	
+    97	1. Open a `Column` for item `i`.
+    98	2. Render the source chunk `i` **EXACTLY as today** (the unchanged `Text` + its `remember(i)` layout/coords + `registerChunk(i, …)`/`unregisterChunk(i)` + `highlightSpan(i)`/`washesForChunk(i)`/`selectionForChunk(i)` — TxtReaderActivity.kt:1044–1084, now the first child of the `Column`).
+    99	3. Look up the translations **anchored** to chunk `i` = every segment whose end resolves to `chunkForOffset(span.endExclusive - 1) == i`, in segment order, from the shared span array. For **paragraph** granularity (the only v1 granularity — see the granularity subsection) there is at most one such translation per anchor chunk in the common case (a paragraph's translation renders after the paragraph's last line-chunk).
+   100	4. Emit each anchored translation as a muted, non-registered `Text` sibling **inside the same `Column`**, keyed by the segment's `Utf16Span` so a language change re-keys cleanly.
+   101	
+   102	When bilingual is **OFF**, no translation children are emitted → each item's `Column` holds only the unchanged source `Text`, so the tree is **behaviorally identical to today** (translations are additive in-item children only; this is asserted by a source-selection-parity test, since a single-child `Column` does not perturb the source `Text`'s layout/registration/offsets).
+   103	
+   104	- **Explicit translation gesture exclusion (round-4 High-2 — BINDING):** `TxtSelectionController.hitAt` (`reader/TxtSelectionController.kt:47`) falls back to the **nearest registered source chunk** when the pointer is outside all source-chunk bounds (`chunks.entries.minByOrNull { verticalDistance(...) }` when no chunk's `boundsInWindow()` contains the point, :51–53). So merely omitting `registerChunk` for the translation does **NOT** make it non-selectable — a long-press *on the translation text* would fall through to the nearest source chunk and select source. **WI-8 must add an explicit hit-test / gesture exclusion for the translation composable's bounds** so a long-press whose pointer lands inside a translation `Text`'s bounds is consumed (no selection begun) rather than routed to `hitAt`'s nearest-chunk fallback. (Options: the translation `Text` consumes the long-press gesture in its own `pointerInput`; or the selection gesture root records the translation composables' window bounds and short-circuits `beginAt` when the point is inside one. WI-8 picks and tests one.)
+   105	
+   106	- **TTS auto-scroll visibility must key off the SOURCE `Text` bounds, NOT the item index (round-5 High — a NEW consequence of the in-item `Column`):** the TTS auto-scroll guard (TxtReaderActivity.kt:252/256) currently keeps the spoken chunk on screen via `listState.layoutInfo.visibleItemsInfo.none { it.index == spokenChunk }` — item-level visibility. With the in-item `Column`, an item is now taller than its source line (source + translation children), so when `spokenChunk`'s SOURCE `Text` has scrolled above the viewport but its translation sibling is still visible, `visibleItemsInfo` still contains the item's index → the guard falsely suppresses `animateScrollToItem(spokenChunk)` and leaves the spoken SOURCE off-screen. **WI-8 must redefine the TTS-visibility predicate to test the registered SOURCE `Text` bounds** — the selection controller already tracks each source chunk's `LayoutCoordinates`/`boundsInWindow()` via `registerChunk(i, layout, coordinates)` (TxtSelectionController.kt): `spokenChunk` is visible iff its registered source bounds intersect the list viewport; otherwise `animateScrollToItem(spokenChunk)` scrolls the item's top (the source) into view. This is **inert when bilingual is OFF** (no translation child → item height == source height → item-index visibility already equals source visibility), so the disabled path is byte-identical.
+   107	
+   108	- **Enabled-mode tests (WI-8 connected + WI-7a Compose, BINDING):** with bilingual ON —
+   109	  - (a) each source chunk's **selection registration is UNCHANGED** (same `registerChunk(i, …)` count and coordinates as OFF; a translation child registers nothing);
+   110	  - (b) **highlights/annotation washes/read-aloud wash still key off the source chunks** at the correct offsets (a translation child in the anchor's `Column` does not shift them);
+   111	  - (c) **lazy-index == chunk-index preserved:** with bilingual ON — **position-save round-trips to the same chunk** (`offsetForChunk(firstVisibleItemIndex)` → save → reopen → `chunkForOffset(offset)` lands on the same chunk); **bookmark/annotation/search/scrubber jumps land on the correct chunk** (`scrollToItem(chunkForOffset(target))` scrolls to the right item); **TTS auto-scroll keeps the spoken SOURCE on screen — visibility keyed off the registered source `Text` bounds, NOT `visibleItemsInfo.index` (round-5 High)**, INCLUDING the case where only `spokenChunk`'s translation portion is visible (its source scrolled above the viewport) → TTS brings the SOURCE back on-screen; (assert the index-identity behaviors above are identical to the OFF baseline — no lazy index shift);
+   112	  - (d) a **long-press on translation text does NOT select** (gesture exclusion — the nearest-source-chunk fallback is not reached);
+   113	  - (e) a **translation child is non-selectable** and does not perturb source offsets (selecting across the source/translation boundary selects source only);
+   114	  - (f) **MD source mapping** — the markdown renderer (`mapper.renderedText(i)`, TxtReaderActivity.kt:1049) still owns the source chunk render; the translation child is plain muted text;
+   115	  - (g) **paragraph-spanning-many-chunks** renders exactly ONE translation (inside the paragraph's last chunk's `Column`), never per-line;
+   116	  - (h) final-chunk/one-chunk anchors render (H1).
+   366	
+   367	**WI-7a (behavioral): Compose UI — setup sheet + interlinear body (TXT/MD) + pill.** Reproduce `vreader-bilingual.jsx` (setup sheet: language grid / **Paragraph-only Granularity control (round-4 H3)** / preview / engine strip configured+unconfigured; body: the translation rendered **inside the anchor chunk's `Column` as a muted non-registered `Text` child** per the round-4 H2 render contract — translated / loading N%+dimmed / error+Retry / offline source-only; pill). Consumes the host-neutral `BilingualRenderState` DTO. Light+dark. Compose UI tests each state, incl. **paragraph interlinear renders a translation child after a paragraph's last source chunk (depicted)**; **the setup-sheet Granularity control shows Paragraph only, no Sentence option (H3)**. Deps: WI-5 (state shape). NO Style control; the unconfigured "Set up" CTA renders and (in WI-9) routes to the Variant A sheet.
+   368	
+   369	**WI-7b (behavioral, CONDITIONAL — only if WI-0 = go): EPUB render adapter (DOM injection, NOT Compose — M2) + direct-block ownership (M1).** `EpubBilingualJs` (enum/inject/clear JS builders, CSP-safe escaping) + `EpubBilingualController` (the serialization actor / session token AND the **single-owner enumerate→cachedDirect/prefetchDirect→guarded-commit sequence — Medium-1**) + `EpubChapterTextProvider`, wired into `ReaderActivity`, driving DOM from the shared `BilingualRenderState` DTO. Uses `prefetchDirect`/`cachedDirect` for the count-divergence path (H2). Depends on WI-6 (VM state) and WI-4b (DI); the WI-7a UI dependency is only the shared `BilingualRenderState`/value types. Connected test on a real EPUB (seeded cache): enable → injects; disable → cleared; reflow/href-change/fragment-recreation/activity-recreation → re-applies from cache (zero provider calls) via `cachedDirect`; count-divergence handled (direct path); **the regular TXT/MD prefetch path is never invoked for an EPUB unit (Medium-1)**. Unit tests: JS escaping/CSP-safe insertion, RTL/CJK style, empty translations, loading cleanup, idempotent replacement, source-only fallback, stale-session-token commit discarded (no `errorUnit`). Deps: WI-0, WI-3, WI-4a, WI-4b, WI-6, (shared types from WI-7a). (If WI-0 = no-go, dropped; box D ships TXT/MD-only, tracked.)
+   370	
+   371	**WI-AIP (behavioral — the folded-in Variant A AI Providers sheet; round-4 H4 rewritten): `ReaderAiProvidersSheet`.** The scoped in-reader "AI Providers" push sheet (nav bar `‹ Bilingual` + "AI Providers" title) reproducing `vreader-ai-provider-entry.jsx` `AIProvidersSheet`/`AIProvidersSheetBody`/`NavSheet`. Per round-4 H4:
+   372	  - **(a)** present `AiProviderEditSheet` VERBATIM from #118 (Kind/Name/Endpoint/Sampling/API Key/Test Connection unchanged).
+   373	  - **(b)** a NEW `ReaderAiProvidersList` presentation over the SHARED `AiSettingsViewModel.listState` (verified `AiSettingsViewModel.kt:26`; each `AiProviderRow` already carries `active`, :30) + shared row/cell components — reproducing the reader-scoped `‹ Bilingual` nav (`NavSheet`, jsx:247, NOT `AiProviderListScreen`'s `NavScreen`), the bilingual-context empty state ("Choose the provider bilingual mode will use to translate this book." + "No providers yet" + "Add provider" — jsx:180–209), the **checked-active row** (`selected = row.active` — jsx:221), and **tap-to-SELECT** (`onSelect(id) → vm.setActive(id)` — jsx:221/237). It does NOT reuse `AiProviderListScreen`'s NavScreen/chrome/`AiEmptyState`/`ProviderRow`-tap-edit.
+   374	  - **(c)** the **save-result seam**: `AiSettingsViewModel.save()` (or a thin WI-AIP wrapper) is extended to return the saved provider ID (from `store.upsert(...).id`, which the store already returns — `AiProviderStore.kt:58/84`), so on first Save → `store.setActive(savedId)` → pop the whole stack back to the bilingual sheet (engine strip now "configured / Change…"), **deterministically, after the upsert commits (no race)**.
+   375	  `‹ Bilingual` without adding → unconfigured, no state mutated. "Change…" → populated list, current provider checked, tap row → `setActive`. No consent/flag surface (Android has none). Deps: WI-4b (for `AiProviderStore` + `AiSettingsViewModel` in `AppContainer`), WI-7a (bilingual sheet host). Tests (Compose + connected): the scoped list renders **`‹ Bilingual` back label** + **bilingual-context empty copy** + **checked active row** + **tap-selects (`setActive`)**; empty → Add → Save → **save→result-id→`setActive`→pop deterministic (no race)** → bilingual strip configured; `‹ Bilingual` without adding → strip unconfigured, snapshot unchanged; "Change…" → populated, current checked; editor reused verbatim (no divergent form).
+   376	
+   377	**WI-8 (behavioral): `TxtReaderActivity` integration.** Wire VM into the `items(count = document.chunkCount, key = { it })` loop as **muted non-registered translation `Text` children inside each anchor chunk's wrapping `Column`, source chunk byte-unchanged, the loop + keys UNCHANGED so lazy-index==chunk-index is preserved (round-4 H2)** + the translation **gesture-exclusion** (round-4 H2) + the **TTS source-bounds visibility fix** (round-5 H: the TTS auto-scroll predicate keys off the registered source `Text` bounds, not `visibleItemsInfo.index`, so a translation-only-visible item does not falsely suppress the auto-scroll) + position-change (`charOffsetUTF16`) + setup-sheet. `originalFormat`-gated (TXT/MD). Uses WI-4b's DI. **#129 VERIFIED — straight edit.** Connected test (fake `AiClient` seam): enable → setup → confirm → interlinear from seeded cache; **enabled-mode source-chunk selection registrations UNCHANGED vs disabled (H2)**; **highlights/annotation-washes/read-aloud-wash still key off source chunks (H2)**; **with bilingual ON — position-save round-trips to the same chunk; bookmark/search/scrubber/TTS jumps land on the correct chunk (lazy-index==chunk-index preserved — round-4 H2); TTS auto-scroll brings the spoken SOURCE on-screen even when only its translation portion is visible (source-bounds visibility — round-5 H)**; **a long-press on translation text does NOT select (gesture exclusion — round-4 H2)**; a translation child is non-selectable, does not perturb source offsets (H2); disable → source-selection byte-parity; reopen persists enabled + renders from cache with zero client calls; **paragraph-spanning-many-chunks renders exactly one translation inside its last chunk's `Column` (H1/Low-2)**; **one-chunk/final-chunk anchors render (H1)**; MD source mapping. Deps: WI-6, WI-7a, WI-4b.
+   378	
+   379	**WI-9 (behavioral): entry wiring + acceptance.** Mount `BilingualPill` in #132's VERIFIED top chrome; extend `readerMoreRows(...)` to supply the #134 VERIFIED More-menu `MoreActionId.BILINGUAL` toggle (`MoreRow.Toggle` `on`/`onToggle`, or `MoreRow.Disabled` "Configure AI provider first" when not configured) wired to the VM; **wire the setup sheet's "Set up"/"Change…" affordance → the #131-owned `ReaderAiProvidersSheet` (Variant A)**. Full acceptance across EPUB (if WI-7b landed) + TXT/MD, including the fresh-user path `unconfigured → Set up (→ Variant A AI Providers sheet) → add provider → Save → return → enable → translate` (now #131-owned end-to-end). **Flip box D to done ONLY for provider/model/granularity(paragraph) + the Style-descope AND Sentence-descope notes; file the follow-up checklist amendment; do NOT claim full box-D parity.** The DONE flip **no longer waits on #136** (closed). Update `docs/architecture.md` (bilingual pipeline + the new `chapter_translations` schema + `AiProviderStore` + bilingual services in `AppContainer` + the Variant A AI Providers sheet). → DONE. Deps: WI-8, WI-AIP, WI-7b (if go), feat:#132, feat:#134.
+   380	
+   381	## 5. Test catalogue
+   382	
+   383	JVM/Robolectric (`android/app/src/test/...bilingual/`): `Utf16SpanTest` (**half-open invariants: `endExclusive >= start`, `isEmpty`, `length`; round-4 H1**); `ChapterSegmenterTest` (paragraph blank-line; sentence CJK `。！？` vs Latin; empty→[]; single; **`paragraphRanges`/`sentenceRanges` return correct half-open `Utf16Span(start, endExclusive)` spans — both APIs covered even though only `paragraphRanges` ships in the v1 render path**); `TranslationChunkerTest` (packs to budget; oversize→own chunk+subSplit; empty→[]); `TranslationChunkContractTest` (prompt shape; strict JSON decode; code-fence strip; count mismatch→`CountMismatch`; non-array→`NotAStringArray`); `ChapterTranslationServiceTest` (cache hit 0 calls; miss→translate→write; decode-fail per-segment fallback; one-chunk-fail partial-not-cached; all-fail→throw; **native-cancel→Cancelled no write; typed-`Cancelled`→Cancelled no write (M2)**; ensureActive-before-write; offline/timeout/429/http/config/insecure→error mapping; very long chapter N-of-M; stale-cache count-mismatch re-translates; `translatePreSegmented` caches under enumerate count on full success; partial degrade not cached; all-fail throws; `cachedTranslation(expectedSegmentCount)` hit/miss with no provider); `ChapterTranslationErrorMappingTest`; `TxtChapterTextProviderTest` (**one-chunk document → renders (H1); final-chunk anchor → renders (H1); exact-boundary → correct anchor (H1); EOF anchor → last chunk, no clamp-collapse (H1)**; paragraph spanning MANY chunks → one segment/unit anchored to last chunk (Low-2); >4000-char paragraph → one segment across hard-split chunks; CR/LF/CRLF; MD markers; locator→unit mapping; `unitAfter` end→null; source-byte parity while disabled; **provider uses `paragraphRanges` only — H3**); `ChapterTranslationPrefetcherTest` (snapshot-consistent profile+key; injected-factory used; `AiRequest` built from profile; **blank `profile.model` → `kind.defaultModel` (M3 regression)**; cache-hit-no-profile #306; no-profile miss→ProviderFailed; `prefetchDirect` 1:1; `cachedDirect` restores with zero provider calls; CJK↔English + Latin round-trip via fake; cipher-throw→ProviderFailed not crash); `BilingualAiReadinessTest` (active+key→true; **no-active-with-profiles-present→false (H3); activeId-null→false (H3)**; empty key→false; cipher-throw→false, no crash); `PerBookBilingualStoreTest` (enabled/lang/granularity round-trip; granularity pinned paragraph; no style field); `BilingualViewModelTest` (Turbine: first-enable sheet; re-enable no-sheet; disable clears; language reset; `aiConfigured` from readiness; prefetch current+next; same-unit no-op; **cancel-mid discards (no errorUnit); typed-Cancelled discards (M2); rapid re-trigger same unit single-flight, no double-write (M2)**; offline→unavailable; error→errorUnit+retry; `retryUnit`); `AiSettingsViewModelSaveResultTest` (**`save()` returns the saved provider ID after the upsert commits — round-4 H4c seam; the returned ID matches `store.upsert(...).id`**); `EpubBilingualJsTest` (JS escaping / CSP-safe insertion; RTL/CJK style; empty translations; clear idempotent; inject idempotent replacement; source-only fallback — WI-7b if go); `EpubBilingualControllerTest` (**enumerate→cachedDirect/prefetchDirect→guarded commit; stale-session-token commit discarded, no errorUnit; single-owner (regular TXT/MD prefetch never runs for EPUB unit) — Medium-1** — WI-7b if go).
+   384	
+
+exec
+/bin/zsh -lc "nl -ba android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt | sed -n '270,310p'
+rg -n \"val annotatable|annotatable =|originalFormat\" android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt | head -30
+rg -n \"fun boundsInWindow|boundsInWindow\\(\" \""'$HOME/.gradle/caches" 2>/dev/null | head -20' in /Users/ll/workspace/vreader
+ succeeded in 433ms:
+codex
+Critical
+
+None.
+
+High
+
+None.
+
+Medium
+
+None.
+
+Low
+
+- Detached-coordinate handling should be explicit. The controller stores each source chunk’s `LayoutCoordinates`, but disposal and scrolling can briefly leave detached coordinates before `unregisterChunk()` completes ([TxtSelectionController.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:26), [TxtReaderActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1060)). WI-8 should define `null`, missing, or `!coords.isAttached` as “not visible,” causing `animateScrollToItem(spokenChunk)`, and ideally test the unregistered/pre-layout case. This is bounded and does not undermine the fix.
+
+Confirmation:
+
+- `registerChunk()` stores the source `TextLayoutResult` and `LayoutCoordinates`; the `LazyColumn` coordinates are also stored, providing source and viewport geometry in window coordinates ([TxtSelectionController.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:26), [TxtSelectionController.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:37), [TxtReaderActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1011), [TxtReaderActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1064)). The map is private, so WI-8 must add a controller query rather than access it directly.
+- Source-bounds intersection correctly distinguishes translation-only visibility: source above viewport → scroll; source intersecting viewport → no scroll; source below or unregistered → scroll. This directly replaces the insufficient item-index guard ([TxtReaderActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:252)).
+- With bilingual OFF, the single-child item has the same extent as its source `Text`, so steady-state source visibility and item visibility are equivalent. The patch is behaviorally inert apart from the harmless missing/pre-layout fallback noted above.
+- The plan includes the decisive translation-only-visible connected regression test ([20260710-feature-131-android-bilingual-interlinear.md](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:377)).
+
+FINAL VERDICT: follow-up-recommended
+tokens used
+33,630
+Critical
+
+None.
+
+High
+
+None.
+
+Medium
+
+None.
+
+Low
+
+- Detached-coordinate handling should be explicit. The controller stores each source chunk’s `LayoutCoordinates`, but disposal and scrolling can briefly leave detached coordinates before `unregisterChunk()` completes ([TxtSelectionController.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:26), [TxtReaderActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1060)). WI-8 should define `null`, missing, or `!coords.isAttached` as “not visible,” causing `animateScrollToItem(spokenChunk)`, and ideally test the unregistered/pre-layout case. This is bounded and does not undermine the fix.
+
+Confirmation:
+
+- `registerChunk()` stores the source `TextLayoutResult` and `LayoutCoordinates`; the `LazyColumn` coordinates are also stored, providing source and viewport geometry in window coordinates ([TxtSelectionController.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:26), [TxtSelectionController.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtSelectionController.kt:37), [TxtReaderActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1011), [TxtReaderActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:1064)). The map is private, so WI-8 must add a controller query rather than access it directly.
+- Source-bounds intersection correctly distinguishes translation-only visibility: source above viewport → scroll; source intersecting viewport → no scroll; source below or unregistered → scroll. This directly replaces the insufficient item-index guard ([TxtReaderActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:252)).
+- With bilingual OFF, the single-child item has the same extent as its source `Text`, so steady-state source visibility and item visibility are equivalent. The patch is behaviorally inert apart from the harmless missing/pre-layout fallback noted above.
+- The plan includes the decisive translation-only-visible connected regression test ([20260710-feature-131-android-bilingual-interlinear.md](/Users/ll/workspace/vreader/dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md:377)).
+
+FINAL VERDICT: follow-up-recommended

--- a/.claude/codex-audits/feat-136-ai-provider-reachable-gate2.md
+++ b/.claude/codex-audits/feat-136-ai-provider-reachable-gate2.md
@@ -1,0 +1,5828 @@
+Reading additional input from stdin...
+OpenAI Codex v0.144.1
+--------
+workdir: /Users/ll/workspace/vreader
+model: gpt-5.6-sol
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: high
+reasoning summaries: none
+session id: 019f5432-e326-7561-a958-07641fd41323
+--------
+user
+Independent Gate-2 plan audit (round 1) for feature #136 (Android: make the already-built #118 AI provider config PRODUCTION-REACHABLE). Read the plan at dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md and verify it against the LIVE code in this repo.
+
+Required checks:
+1. MODEL/API ASSUMPTION VERIFICATION (the highest-value check — read the actual files): Do these named Kotlin symbols/files exist as the plan claims? android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt, AiProviderEditSheet.kt, AiSettingsViewModel.kt, and the AiProviderStore type. The AppContainer inside android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt (or wherever AppContainer lives). reader/chrome/ReaderChromeScaffold.kt — confirm readerMoreRows(...), MoreActionId.BILINGUAL, MoreRow.Disabled, and MorePopup.MoreRowItem exist and that MoreRow.Disabled currently renders with a NON-interactive onClick. CRITICALLY: confirm the plan's core premise — that AiProviderStore is NOT currently constructed in AppContainer, and AiProviderListScreen is reachable from NO production NavHost/route (only tests reference it). If that premise is wrong, this is a Critical finding.
+2. DESIGN AUTHORITY (rule 51): confirm the design bundles the plan cites exist and depict the surfaces — dev-docs/designs/.../vreader-more.jsx (a configure-ai row), vreader-ai-android.jsx (AiProviderList), vreader-ai-provider-entry.jsx, and design-notes reader-ai-provider-entry.md / reader-ai-readiness.md. If the in-reader AI Providers sheet (Variant A) the plan reuses is NOT depicted, that is a rule-51 blocker.
+3. WI COHESION: is the 3-WI split right? WI-1 = AppContainer aiProviderStore + aiSettingsViewModel() factory (claimed FOUNDATIONAL — verify it has no user-observable behavior). WI-2 = ReaderAiProvidersHost + ReaderSheet.AiProviders route + saver (behavioral). WI-3 = reader More-menu configure-ai entry across 5 hosts + readerMoreRows(aiUnconfigured,onConfigureAi) making MoreRow.Disabled tappable (behavioral final). Is any WI too big/small? Does WI-3's write-set (5 reader hosts) risk one-writer conflicts?
+4. RISKS + MISSING EDGE CASES: DataStore under noBackupFilesDir + KeystoreSecretCipher; cipher/keystore failure paths; the aiUnavailable gate (active profile with non-empty key); config-change/process-death of the in-reader sheet; the 5-host entry duplication.
+5. CONCURRENCY: DataStore reads, cipher decryption, StateFlow exposure.
+
+Output findings grouped by severity (Critical / High / Medium / Low), each with file:line evidence, then a FINAL VERDICT line exactly one of: ship-as-is | follow-up-recommended | block-recommended. ship-as-is or follow-up-recommended clears Gate-2.
+codex
+I’ll perform this as a read-only, evidence-based audit: first the repository state and governing architecture/rules, then the plan, live Kotlin symbols/routes, and the cited design bundles.
+exec
+/bin/zsh -lc "git status -sb && sed -n '1,240p' docs/architecture.md && sed -n '1,280p' .claude/rules/47-feature-workflow.md && sed -n '1,260p' .claude/rules/51-no-self-designed-ui.md" in /Users/ll/workspace/vreader
+ succeeded in 1203ms:
+git: warning: confstr() failed with code 5: couldn't get path of DARWIN_USER_TEMP_DIR; using /tmp instead
+git: error: couldn't create cache file '/tmp/xcrun_db-M8iOP9DG' (errno=Operation not permitted)
+## main...origin/main
+ M dev-docs/plans/20260710-feature-131-android-bilingual-interlinear.md
+ M docs/features.md
+?? .claude/codex-audits/feat-131-bilingual-gate2-round2.md
+?? .claude/codex-audits/feat-136-ai-provider-reachable-gate2.md
+?? android/2026-06-29-223908-this-session-is-being-continued-from-a-previous-c.txt
+?? dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md
+?? dev-docs/security/
+# VReader Architecture
+
+## Overview
+
+VReader is an iOS e-book reader built with SwiftUI + SwiftData. It supports TXT, EPUB, AZW3/MOBI, PDF, and Markdown formats, each rendered by a format-specific native host (UIKit/WebView bridges) selected internally by `ReaderEngine` (feature #54). AZW3/MOBI is rendered via Foliate-js inside a WKWebView. **Feature #42 Phase 2 (`kindleConvertOnImport`, default ON since the G2 flip 2026-06-02):** NEW AZW3/MOBI/KF8/PRC imports are converted to a first-class EPUB at import time (via the vendored libmobi MOBI→EPUB converter) and render via the default Readium EPUB engine; already-imported native `.azw3` books are unchanged and keep rendering via Foliate, and a user can revert via the persisted `kindleConvertOnImport` override OFF. The `UnifiedTextRenderer` (TextKit 2 reflow) stack is retained in the codebase but no longer wired into the reader dispatch.
+
+## System Diagram
+
+```
+┌──────────────────────────────────────────────────────┐
+│                    VReaderApp                         │
+│  SwiftData SchemaV10 · PersistenceActor · BookImporter│
+└─────────────────────┬────────────────────────────────┘
+                      │
+          ┌───────────┴───────────┐
+          │                       │
+    ┌─────▼──────────┐    ┌──────▼──────────────────┐
+    │  LibraryView    │    │  ReaderContainerView     │
+    │  LibraryViewModel│   │  (format dispatcher)     │
+    │  PreferenceStore │   │  ReaderTopChrome (overlay)│
+    └─────────────────┘   └──────┬───────────────────┘
+                                 │
+        ┌────────┬───────────┬───┴────┬─────────┐
+        │        │           │        │         │
+    ┌───▼──┐ ┌──▼───┐  ┌───▼──┐ ┌──▼───┐ ┌────▼─────┐
+    │ TXT  │ │ EPUB │  │ PDF  │ │  MD  │ │  AZW3 /  │
+    │Bridge│ │Bridge│  │Bridge│ │Bridge│ │  MOBI    │
+    └──────┘ └──────┘  └──────┘ └──────┘ └──────────┘
+    UITextView WKWebView PDFKit  UITextView WKWebView
+                                            (Foliate-js)
+```
+
+## Layers
+
+### 1. App Layer (`vreader/App/`)
+
+- `VReaderApp.swift` — SwiftData `ModelContainer` init (SchemaV10), migration plan (V1→…→V9→V10, all lightweight; V9→V10 adds the additive `Book.sourceCanonicalKey: String?` for feature #108's converted-Kindle cross-platform identity). Also runs the feature #109 one-shot `LocatorKeyBackfillMigration` synchronously at launch (flag-gated; recomputes derived locator keys under NFC canonicalization + repairs non-finite locators — a launch backfill, NOT a migration stage, since the transform changes no entity shape). Plus test seeding, error handling. Injects the live `PersistenceActor` into the SwiftUI environment via `\.persistenceActor` so settings sub-screens can construct backup providers without rewriting every parent's signature. Adopts `@UIApplicationDelegateAdaptor(VReaderAppDelegate.self)` for background-URLSession completion-handler delivery (feature #47).
+- `VReaderAppDelegate.swift` — `UIApplicationDelegate` adapter that captures `application(_:handleEventsForBackgroundURLSession:completionHandler:)` into a MainActor-isolated static dictionary keyed by URLSession identifier. The lazy-download coordinator retrieves and invokes the handler from `LazyDownloadDelegate.urlSessionDidFinishEvents` so iOS releases the app's background-launch grace period.
+
+### 2. Library Layer (`vreader/Views/LibraryView.swift`, `vreader/ViewModels/LibraryViewModel.swift`)
+
+- Grid/list view with sort (persisted via `PreferenceStore`)
+- Context menu: Info, Share, Set Cover, Add to Collection, Delete
+- Collections sidebar, OPDS catalog, AI chat entry points
+- Cover art (`BookCoverArtView`) renders a custom image when one exists, otherwise a generative typographic cover (Feature #60 WI-10 — `GenerativeCoverView`). The cover's style family + colour palette are deterministically derived from the book's `fingerprintKey` (FNV-1a hash → one of 5 style families × 12 design palettes in `GenerativeCoverStyle.swift`), so a given book always shows the same generated cover.
+
+### 3. Reader Layer (`vreader/Views/Reader/`)
+
+#### Dispatcher
+
+`ReaderContainerView.swift` routes to format-specific readers via
+`engineReaderView(fingerprint:)`, which switches on
+`ReaderEngine.resolve(format: fingerprint.format)` — an internal per-format
+engine selector (feature #54). Bug #246 / GH #1072 hardened the dispatch
+to route off `fingerprint.format` (the typed `BookFormat` already parsed
+from the canonical `book.fingerprintKey` by the body's
+`DocumentFingerprint(canonicalKey:)` guard) instead of `book.format` (a
+parallel String `@Model` column set once at `Book.init` and never re-synced).
+Routing off the structural primary key makes the dispatch drift-proof against
+any future writer that updates one without the other (SwiftData migration,
+direct context write, restore-path edit, CloudKit sync). The dispatch no
+longer consults a reading-mode preference, and the reader-settings Reading
+Mode picker UI is gone. The `readerReadingMode` UserDefaults key and the
+`ReadingMode` enum have been removed; `ReadingModeMigration` (run
+synchronously at launch from `VReaderApp`) clears the retired key from
+UserDefaults and strips the `readingMode` field from per-book override
+JSON files.
+
+- `.textNative` → `TXTReaderHost`, `.markdownNative` → `MDReaderHost`,
+  `.epubWKWebView` → `EPUBReaderHost`, `.pdfKit` → `PDFReaderHost`,
+  `.foliateWeb` → `FoliateBilingualContainerView` (AZW3/MOBI; the
+  bilingual wrapper from feature #56 WI-11 sits between the dispatcher
+  and `FoliateSpikeView`, adding the bilingual VM / orchestrator / setup-
+  sheet wiring without modifying the spike itself).
+- `resolve(format:)` maps `.epub` to `.epubWKWebView` unconditionally (it
+  stays the pure format→default-engine map). Feature #42 routes EPUB to the
+  Readium Swift Toolkit engine (`ReadiumEPUBHost`) via
+  `FeatureFlags.readiumEPUBEngine`, which is **default ON since the WI-14
+  human-gated G2 flip (2026-06-01)** — Readium is now the default reflowable EPUB
+  engine; a persisted user/debug override OFF reverts to the legacy
+  `EPUBReaderHost`. The flag read lives in the dispatcher
+  (`ReaderContainerView.engineReaderView` → `ReaderEngine.routeEPUB`), not in
+  `resolve`, so a flag-unaware caller still gets the legacy `EPUBReaderHost`. The
+  `.epubReadium` engine case exists for switch totality; `resolve` never returns
+  it. **Feature #85 (approach C) makes the routing layout-aware**:
+  `routeEPUB(readiumFlagEnabled:layout:)` sends EPUB **scroll** mode to the
+  legacy `EPUBReaderHost` (which activates the seamless feature-#71
+  continuous-scroll stitch) even when the Readium flag is ON — Readium's
+  per-resource paginator has an inherent chapter-boundary seam in scroll mode —
+  while **paged** mode keeps Readium. Because the SAME book is then rendered by
+  two engines depending on mode, a reading-mode toggle SWAPS hosts; an in-memory
+  `ReaderPositionHandoff` (a `@MainActor` per-book cache both hosts write
+  synchronously on every location change + read on open before persistence)
+  carries the position across the swap without loss, and a Readium open with no
+  `.readium` envelope (a scroll session cleared it) restores the legacy locator
+  post-open via `publication.readingOrder` + a one-shot `navCommander.navigate`.
+  `EPUBScrollAnchorResolver` tolerates the container- vs OPF-relative href forms
+  the two engines persist.
+
+#### Chrome
+
+Reader chrome (Feature #60 WI-6b — visual-identity-v2) is two custom overlays, floating on top of content with no safe-area impact:
+
+- `ReaderTopChrome.swift` — top bar: `← Library | Title | Search Bookmark More`. Composed once in `ReaderContainerView`, format-agnostic. The `⋯` More button toggles `ReaderMorePopover`.
+- `ReaderBottomChrome.swift` — bottom bar: progress scrubber + position labels + a Contents/Notes/Display/AI toolbar. Composed per format inside each container, each passing its own seek closure; the toolbar posts `.readerOpen*` notifications that `ReaderContainerView` observes. The four native containers (TXT/MD/EPUB/PDF) mount it in their `bottomOverlay`; Bug #260 added the Foliate (AZW3/MOBI) mount via `FoliateBilingualContainerView+BottomChrome.swift` — scrubber fed by the relocate `fraction`, seek via `.foliateRequestSeekFraction` → `readerAPI.goToFraction`, position labels via pure `FoliateBottomChromeLabels`. (Each container owns its own `isChromeVisible`; chrome visibility is not yet hoisted to the shared level — see Bug #262 for the cross-format desync follow-up.)
+- `ReaderMorePopover.swift` — anchored More-menu popover (Feature #60 WI-6c), composed in `ReaderContainerView`'s chrome overlay. Five rows (Read aloud / Auto-turn | Book details / Share / Export); each posts a `.readerMore*` notification that `ReaderContainerView` observes. The design's sixth row (Bilingual) is deferred — GH #790.
+
+Slot/button identity lives in `ReaderChromeButton.swift` (`ReaderTopChromeSlot` / `ReaderBottomChromeButton`); More-menu row identity lives in `ReaderMoreMenuRow.swift`.
+
+#### Sheets (Feature #60 WI-10 — visual-identity-v2)
+
+The app sheets share `ReaderSheetChrome.swift` — a reusable wrapper matching the design's `Sheet` component: a theme-tinted surface (`ReaderThemeV2.sheetSurfaceColor`), an optional centred Source Serif 4 title bar with 50pt leading/trailing slots (a default circular close button fills the trailing slot when an `onClose` is given and no custom trailing view is), and a scrollable body. The slide-up animation + drag grabber come from SwiftUI's own `.sheet` + `.presentationDragIndicator(.visible)`; `ReaderSheetChrome` supplies only the title bar + surface tint. It wraps the Display sheet (`ReaderSettingsPanel`), the two annotations sheets (`TOCSheet` + `HighlightsSheet`, feature #62 — see below), the reader Book Details sheet (`BookDetailsSheet`, feature #61 — opened from More → Book details, with a trailing Share button in place of the default close), and the AI sheet (`AIReaderPanel`, `title: nil` + a custom sparkle header). `SettingsView` (App Settings) keeps an inner `NavigationStack` for its `NavigationLink` push destinations, with `ReaderSheetChrome` above it. The per-sheet section contract is pinned in `SheetSectionContract.swift` (`ReaderSheetKind`). Reader sheets pass the book's `ReaderThemeV2`; the App Settings sheet uses `.paper` (the Library is not theme-switchable).
+
+**Annotations sheets (feature #62 — annotations-panel split).** The pre-#62 unified 4-tab `AnnotationsPanelView` (Contents / Bookmarks / Highlights / Notes) is split into two job-focused sheets, each with one honest title: `TOCSheet` (book-titled — Contents + Bookmarks navigation tabs) and `HighlightsSheet` (titled "Annotations" — All / Highlights / Notes / Bookmarks review filters + a Share/export button). `ReaderContainerView` presents them via a single `.sheet(item: $annotationsRoute)` over the `AnnotationsSheetRoute` enum (`.toc(initialTab:)` / `.highlights(initialFilter:)`) — the Contents bottom-chrome button and the Notes button each map to one route; the two sheets are mutually exclusive by that optional. `HighlightsSheet`'s unified card stream interleaves highlight + standalone-note cards via `AnnotationStreamBuilder`. Both sheets' designed empty states use the shared `AnnotationsEmptyStateView` (custom SVG art). The legacy `HighlightListView` / `AnnotationListView` / `TOCListView` / `BookmarkListView` list views were removed by feature #62. Each card carries a per-row **delete affordance** (Bug #249 — a trailing `⋯` `NotesActionMenu` of Edit · Copy · Delete + an inline `NotesDeleteConfirm` strip mirroring the in-reader `HighlightPopoverDeleteConfirm`, plus a left-swipe `NotesSwipeActions` drawer); the per-row interaction phase is held on the sheet by the SHEET-owned pure `NotesRowState` (at most one row non-default at a time), and Delete routes through `HighlightListViewModel.removeHighlight` / `AnnotationListViewModel.removeAnnotation`. The container stays `LazyVStack` (not a `List`), so the swipe is a custom `DragGesture` translate rather than `.swipeActions` (which requires a `List` host).
+
+`ReaderContainerView` drives `preferredColorScheme(_:)` from `ReaderThemeV2.preferredColorScheme` (`ReaderThemeV2+ColorScheme.swift`) so the status bar tints to match the theme — `.dark` for the Dark / OLED / Photo families, `.light` for Paper / Sepia.
+
+#### Format Hosts (`ReaderFormatHosts.swift`)
+
+Each host owns its ViewModel lifecycle via `@State`:
+
+- `TXTReaderHost` → `TXTReaderContainerView` → `TXTTextViewBridge` (small single-chapter / Paged) or `TXTChunkedReaderBridge` (>500K UTF-16, **and** chaptered TXT in Scroll layout — bug #180). Chaptered TXT in Scroll layout renders as one continuous `UITableView` surface fed the whole book: `TXTContinuousChunkBuilder` splits the decoded book into document-global-offset chunks, `TXTChapterOffsetIndex` layers chapter awareness so `currentChapterIdx` is *derived* from scroll offset (no per-chapter render unit, no chapter-swap).
+- `EPUBReaderHost` → `EPUBReaderContainerView` → `EPUBWebViewBridge` (WKWebView + JS injection). **Paged** EPUB loads one spine item per `loadFileURL`. **Continuous scroll** (feature #71, the DEFAULT for EPUB scroll layout since the terminal-WI flag flip on 2026-05-28 — `FeatureFlags.epubContinuousScroll` defaults ON; a persisted user/debug override can still disable it) instead loads a single bootstrap document and stitches a lazy ±1-chapter window into it: `EPUBContinuousScrollCoordinator` owns an `EPUBSpineWindow` `[lo…hi]` anchored on the reading chapter and, on the section-aware scroll observer's boundary signals, materializes the adjacent chapter (`EPUBContinuousChapterProvider` → `EPUBChapterBodyRewriter` → `EPUBContinuousScrollJS.append/prependChapterSectionJS`) and evicts the far side (`maxSpan`) to bound memory. Per-section highlight restore hangs off a `sectionMaterialized` lifecycle message (appended sections never fire `didFinish`); saved-position restore + TOC/bookmark/search navigation drive the coordinator (`navigate(toSpineIndex:fraction:)` — scroll within the window, or rebuild around an out-of-window target). The evaluator reaches the live `WKWebView` through a late-binding `EPUBWebViewEvaluatorHandle` the bridge binds in `makeUIView`.
+- `ReadiumEPUBHost` (feature #42 Phase 1, WI-5) → `ReadiumNavigatorRepresentable` → Readium Swift Toolkit `EPUBNavigatorViewController`. Selected by the dispatcher in place of `EPUBReaderHost` when `FeatureFlags.readiumEPUBEngine` is ON (**default ON since the WI-14 G2 flip 2026-06-01**; a persisted override OFF reverts to the legacy `EPUBReaderHost`). Opens the publication off-main via `ReadiumEPUBReaderViewModel` (`AssetRetriever` → `PublicationOpener`), then mounts the navigator; `EPUBPreferences(scroll:)` is mapped from `ReaderSettingsStore.epubLayout`. The `ReadiumReaderCoordinator` is the `EPUBNavigatorDelegate` + (DEBUG) `ReadiumNavigatorEvaluating` seam — it registers the active navigator with `DebugReaderRegistry.setActiveReadiumNavigator` and `markReaderSettled` on `locationDidChange`, and tears that registration down on `dismantleUIViewController` via `detach()` → `clearActiveReadiumNavigator` (the host registers no `DebugReaderProbe`, so it owns its own registry teardown). Reading-position save/restore landed in WI-6: the coordinator forwards `locationDidChange` to the VM's debounced save, which maps the Readium `Locator` → a `VReaderLocator` envelope (engine `.readium`, authoritative `readiumLocatorJSON` + a lossy legacy `Locator` leg) and dual-writes it through `PersistenceActor`'s `VReaderLocatorPersisting` conformance — `saveVReaderLocator` writes both the envelope blob into the SchemaV8 `ReadingPosition.vreaderLocatorData` column AND the legacy `locator`; legacy `savePosition` clears the envelope so a flag-OFF write can't be shadowed by a stale Readium position. On open, the host loads the saved envelope (`restoredReadiumLocator()`) before the navigator mounts and passes it as `initialLocation`. Theme/font landed in WI-7: the host body reads `ReaderSettingsStore.theme` + `.typography` + `.epubLayout` (tracked `@Observable` deps) and recomputes a full `EPUBPreferences` on any Display-settings change, which `updateUIViewController` re-submits live (`submitPreferences`). `ReadiumEPUBReaderViewModel+Mapping` translates the 5 `ReaderThemeV2` themes → Readium's 3 base `Theme`s + explicit `backgroundColor`/`textColor` (which win via `effectiveBackgroundColor`); font size from the per-format-calibrated `.epub` size (`FontSizeCalibrator`) → Readium's multiplier; `lineHeight` from `lineSpacing`; `fontFamily` (system→sansSerif, serif/sourceSerif4→serif, monospace→monospace, inter→sansSerif — custom-font registration deferred); `publisherStyles=false`. The WI-7 photo/custom-background refinement composites the decorative image behind the navigator: `ReadiumEPUBHost+Background.swift` layers the existing `ThemeBackgroundView` under the navigator in a `ZStack` (only when `useCustomBackground` + an image exists for the theme), and `ReadiumReaderCoordinator+Transparency` makes the navigator render through — `epubPreferences(..., transparentBackground:)` emits `backgroundColor: nil` (so ReadiumCSS injects no body bg rule), the representable forces `navigator.view`/spine `WKWebView`s `.clear`/`isOpaque=false`, and a read-only self-gating user script clears the opaque `html:root` ReadiumCSS paints (transparency state is authored into `localStorage` by Swift on each `locationDidChange`/toggle). Normal opaque themes are unchanged. Highlights landed in WI-8: `ReadiumDecorationHighlightAdapter` (a `HighlightRenderer`, the Readium counterpart of `EPUBHighlightRenderer`) renders stored highlights as Readium **Decorations** via `EPUBNavigatorViewController.apply(decorations:in:"highlights")` (declarative — the adapter holds the active set and re-submits the whole group on each apply/remove/restore). Re-anchoring is **text-quote** based (WI-8a migration spike): each `HighlightRecord` → `Decoration(locator: Locator(href:, text: .Text(highlight: selectedText, before/after: context)), style: .highlight(tint:))` — Readium re-finds the quote, so the legacy XPath `serializedRange` is never consulted or mutated (flag-OFF returns to legacy XPath rendering losslessly). The host owns the adapter + a `HighlightCoordinator(renderer: adapter)`, calls `restoreAll()` on open, and observes `.readerHighlightRemoved`/`.readerHighlightsDidImport`. The WI-8 new-highlight refinement adds CREATE from a live Readium selection: `ReadiumReaderCoordinator` conforms to `SelectableNavigatorDelegate` and `navigator(_:shouldShowMenuForSelection:)` forwards the finalized `Selection` to the host then returns `false` (suppressing Readium's native menu so the designed `SelectionPopoverView` is the sole selection surface — rule 51). `ReadiumEPUBHost+Highlights` stashes the `Selection` in a generic `ReadiumSelectionTokenCache<Selection>` under a token, presents the popover; on a color tap (`.readerHighlightRequested`) it resolves the token and `ReadiumSelectionHighlightBuilder` maps the `Selection`'s text-quote (highlight/before/after) + container-relative href → `HighlightRecord` inputs → `HighlightCoordinator.create` → the same `ReadiumDecorationHighlightAdapter` renders it immediately; `navCommander.clearSelection()` dismisses the selection. Navigation landed in WI-9a: the host observes the shared reader nav bus — `.readerNextPage`/`.readerPreviousPage` → the coordinator's `goForward`/`goBackward`, and `.readerNavigateToLocator` (TOC/bookmark/search-result tap, object = a vreader `Locator`) → `go(to:)` after mapping the vreader Locator → Readium Locator (`readiumLocator(fromVReader:spineHrefs:)`, reusing the WI-8 legacy→spine href resolution). Host→coordinator dispatch goes through a host-owned `ReadiumNavCommander` (`@State`, bound on `attach`/cleared on `detach`, mirrors the WI-8 adapter ownership). WI-9a also split the host into `ReadiumEPUBHost.swift` (View) + `ReadiumNavigatorRepresentable.swift` + `ReadiumReaderCoordinator.swift`. Footnotes (#138, WI-9b) remain. Search result-list extraction still uses the existing FTS/`SearchViewModel` stack — WI-9a maps only result *navigation*. **Bilingual landed in WI-11 (paged) and WI-12 (scroll parity): interlinear bilingual works under the flag by driving the enumerate→prefetch→inject loop through Readium's one-way `evaluateJavaScript(_:) async -> Result<Any,Error>` channel — NOT a script-message handler (the navigator owns its content controller, exposing no app-side message channel; this is why the WI-11a `ReadiumBilingualEvalAdapter` RETURNS the `[{bid,text}]` array rather than posting it). A host-owned `ReadiumBilingualCommander` (`@State`, the bilingual counterpart of `ReadiumNavCommander`) holds an evaluator closure the coordinator binds on `attach` (the production non-DEBUG `ReadiumReaderCoordinator.evaluateForBilingual`, returning Readium's raw `Result<Any,Error>?`) and clears on `detach`; `enumerate()` runs `ReadiumBilingualEvalAdapter.enumerateJS()` and parses the return value via `EPUBBilingualPipeline.parseEnumerateMessage`, `inject(_:)`/`clear()` run the engine-agnostic inject/clear builders. The host reuses the feature-#56 `EPUBBilingualOrchestrator` (paged `-1` bucket via `updateBlocks(_:)`) + `BilingualReadingViewModel` + the designed `BilingualSetupSheet` (rule 51 — no new UI). Source text comes from vreader's own `EPUBParser` (opened alongside the Readium open — Readium does not expose raw spine HTML), so the `EPUBChapterTextProvider` is keyed on OPF-relative spine hrefs; the Readium-produced vreader `Locator` carries Readium's CONTAINER-relative href, so `ReadiumBilingualCommander.normalizedLocator(_:toSpineHrefs:)` rewrites it onto the OPF spine via the shared `ReadiumDecorationHighlightAdapter.resolveHref` tolerance before `vm.handlePositionChange(...)` (the WI-8 href-consistency finding class — without it `unit(containing:)` returns nil and nothing translates). Chapter-change detection composes onto the existing `onLocationChange` (WI-6 position save still runs): a fresh enumerate runs only when the spine href changes, deduped intra-chapter by a reference-type `ReadiumBilingualChapterTracker`. WI-12 lifted the WI-11 paged-only gate (`isBilingualSupported` is true for both layouts) so bilingual works in scroll too — but PER-SPINE only: Readium scroll mode is per-resource (it emits `locationDidChange` at spine boundaries, driving the same per-spine enumerate the paged path uses), and Readium has no multi-spine-stitch API, so off-screen chapters enumerate when scrolled into view rather than eagerly. This is a documented behavior delta vs legacy #71 — the flag-OFF `EPUBWebViewBridge` engine keeps its full stitched cross-chapter continuous bilingual; the Readium engine does not reproduce it. A paged↔scroll layout change re-renders the spine (discarding the `data-vreader-bid` stamps + decorations), so the layout-change handler re-enumerates the current spine in both directions.** TTS (WI-10): read-aloud already works under the Readium engine with NO Readium-specific code — `ReaderContainerView.startTTS()` → `ReaderAICoordinator.loadBookTextContent(format: "epub")` extracts spine text from the **file** via `EPUBParser` (renderer-agnostic, independent of which engine renders), then feeds the shared `TTSService` pipeline. Device-verified under `readiumEPUBEngine` ON (speaking, `ttsOffsetUTF16` advancing 42→115, stop→idle). The speaking-position **follow** landed in WI-10b: as TTS speaks, the navigator auto-advances so the spoken text stays on screen. `ReadiumEPUBHost` observes the shared `TTSService.currentOffsetUTF16` (threaded in like `EPUBReaderHost`); a pure value-type `ReadiumTTSFollowMapper` maps the flat UTF-16 offset → (spine href, intra-spine fraction). CRITICAL alignment: the per-spine offset table is built from the SAME spine text the TTS engine reads — `EPUBTextExtractor.stripHTML` + trim, skip empties, join `"\n\n"` (the `ReaderAICoordinator.loadBookTextContent` recipe) — extracted off-main from the host's already-open `bilingualParser` (so the index matches the engine's offsets; the block-preserving bilingual stripper is deliberately NOT used here). `ReadiumEPUBHost+TTSFollow` throttles: it navigates on any spine-href change or an intra-spine fraction drift > 0.08 (so the navigator tracks ~chapter-eighth granularity, not every `willSpeakRange` word), maps the target → a vreader `Locator` → Readium `Locator` via the WI-9a `readiumLocator(fromVReader:spineHrefs:)` resolution, and drives the existing `navCommander.navigate(to:)` → `navigator.go(to:)`. Follow runs only while TTS state == `.speaking`; the cursor resets on each play start and on pause/stop. This unblocks the WI-14 default-ON flip.
+- `PDFReaderHost` → `PDFReaderContainerView` → `PDFViewBridge` (PDFKit)
+- `MDReaderHost` → `MDReaderContainerView` → reuses `TXTTextViewBridge` with NSAttributedString
+- AZW3/MOBI is dispatched directly to `FoliateSpikeView` (the AZW3 spike landed before the host abstraction; convergence is deferred). `FoliateReaderHost` / `FoliateReaderContainerView` exist but are not currently wired into `ReaderContainerView`. **Feature #73 added a windowed multi-section continuous-scroll surface inside the vendored Foliate-js `paginator.js`** (default ON for horizontal-writing scroll mode, gated behind the renderer's `#windowedScroll`). Instead of the per-section view-swap — whose `scrollToAnchor(0)` offset reset + blank-flash on `#createView` destroy/async-load + post-swap reflow were the three stacked discontinuities of the Bug #283 chapter-boundary jump — a K=3 window of adjacent sections is mounted into the single scrolling `#container` and recycled on scroll: `#ensureWindow` mounts neighbours (firing the same `load`/`create-overlayer` lifecycle so each neighbour doc is wired for selection/overlays), `#evictOutsideWindow` unmounts + unloads the far side with `scrollTop` compensation, `#promoteCurrentView` tracks the current section by scroll position (a pointer swap, no DOM move), and `#windowedResolve` emits the intra-section relocate fraction (`progress.js`/`SectionProgress` still owns whole-book conversion, preserving Bug #265 position restore). A `#windowGeneration` token aborts stale async mounts across navigation. Vertical writing + paged mode keep the single-`#view` swap path. The pure windowing math (window clamp, offset↔section mapping, intra-section fraction, evict adjustment, anchor translation) is mirrored + unit-tested in `FoliateScrolledWindowMath.swift`; flag-on behavior was device-verified and the JS diff passed a 2-round independent Codex audit.
+
+#### Foliate-js Bridge (`vreader/Views/Reader/`, `vreader/Services/Foliate/`)
+
+`FoliateViewBridge` (UIViewRepresentable) hosts a WKWebView and uses `loadHTMLString` with the IIFE-bundled `foliate-bundle.js` inlined; books are handed to JS as base64 (no scheme handler in the live load path — `FoliateURLSchemeHandler` exists in the codebase but isn't wired into the active bridge today). `FoliateViewCoordinator` (WKScriptMessageHandler + WKNavigationDelegate) receives JS messages, parses via `FoliateMessageParser`, and routes to typed callbacks. `FoliateHighlightRenderer` generates JS strings for SVG overlay annotations — but it is **not** plugged in as a `HighlightRenderer` adapter today; AZW3 highlight create has a TODO for persistence/JS injection and overlay restore is a no-op placeholder (`FoliateReaderContainerView+Highlights.swift`). `FoliateJSEscaper` provides shared sanitization for all JS/CSS string interpolation across the bridge. `FoliateReaderViewModel` maps bridge events to `Locator` for position persistence.
+
+The Foliate JS bundle is built from sources under `vreader/Services/Foliate/JS/` via `build-bundle.sh`, which calls a locally-pinned esbuild (`package.json` + `package-lock.json`, currently `esbuild@0.28.0`; bootstrapped via `npm ci` — node ≥18). `paginator.js` is the source of truth; `foliate-bundle.js` is checked in and must be rebuilt whenever the source changes (a parity check in `FoliatePaginatorScrollBoundaryTests` enforces this for the scroll-mode boundary-detect helper that resolved Bug #235).
+
+#### Unified Engine (retained, not dispatched)
+
+`ReaderUnifiedCoordinator` loads text + applies transforms (replacement rules, simp/trad); `UnifiedTextRenderer` displays with TextKit 2 pagination or scroll. Feature #54 removed the unified path from the reader dispatch and the reader-settings Reading Mode picker, so this stack is **no longer reachable from reader dispatch** — it is retained (a follow-up may consume it for bilingual reading, or delete it once provably orphaned). Content replacement rules and Chinese conversion that previously required Unified mode now run in the native readers directly: `MDFileLoader.load` composes `ReplacementTransform` + `SimpTradTransform` over the decoded source text before parsing (feature #54 WI-7); **native EPUB applies replacement rules via `EPUBReplacementJS` (feature #54 Phase D-1)** — a CFI-safe per-text-node JS injection that runs on both EPUB engines (Readium per-spine via `ReadiumReaderCoordinator+Replacement`; the legacy #71 WKWebView stitch on `didFinish` via `EPUBWebViewBridgeCoordinator`, plus a scroll-root `MutationObserver` for appended chapters), keyed by `MDReplacementRuleFetcher`; native TXT has Chinese conversion only — TXT replacement rules are deferred (they need a source↔display offset map). Replacement rules apply at chapter/document open; a mid-read rules edit takes effect on next open (v1 scope).
+
+### 4. Coordinator Layer (`vreader/Views/Reader/`)
+
+Cross-format coordinators that compose with multiple readers:
+
+| Coordinator                | Responsibility                                                      | Setup Timing                                                          |
+| -------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `ReaderAICoordinator`      | AI ViewModels, text loading, context extraction                     | On AI/TTS invoke                                                      |
+| `ReaderSearchCoordinator`  | Search service, indexing, FTS5                                      | Service+VM eagerly via `prepareEagerly()` on reader open (bug #79; cold SQLite open is `nonisolated`, off-MainActor); indexing still deferred to `setup()` on first sheet open |
+| `ReaderUnifiedCoordinator` | Unified renderer state, text transforms — retained but no longer dispatched (feature #54) | n/a (no dispatch path)                                     |
+| `HighlightCoordinator`     | Persists via `HighlightPersisting`, dispatches to `HighlightRenderer` adapters | On reader open per format (TXT/MD/PDF/EPUB)                          |
+
+Bridge-internal coordinators (`EPUBWebViewBridgeCoordinator`, `FoliateViewCoordinator`, `TXTTextViewBridgeCoordinator`) handle delegate / WKScriptMessageHandler plumbing for one bridge each; they're not cross-cutting and aren't enumerated here.
+
+### 5. Services Layer (`vreader/Services/`)
+
+| Service                              | Backing                    | Purpose                                                                   |
+| ------------------------------------ | -------------------------- | ------------------------------------------------------------------------- |
+| `PersistenceActor`                   | SwiftData (actor-isolated) | All DB writes serialized                                                  |
+| `SearchService` + `SearchIndexStore` | SQLite FTS5                | Full-text search with persistent index                                    |
+| `AIService`                          | OpenAI-compatible REST API | Summarize, translate, chat. Feature #56 added a resolved-provider seam — `ResolvedAIProviderConfig` (an immutable `{kind, baseURL, apiKey, model, maxTokens}` snapshot) plus `resolveActiveProviderConfig()` / `resolveProviderConfig(profileID:modelOverride:)` / `sendRequest(_:using:)`. A *multi-request* operation (chapter translation = one request per chunk) resolves the config ONCE and pins the credential + model for every chunk; `sendRequest(_:using:)` deliberately bypasses `AIResponseCache` (its key is not provider-aware). The original `resolveProvider()` / `sendRequest(_:)` / `streamRequest(_:)` are unchanged. **Feature #91 (agentic tool-calling)** added `supportsToolUse` + `sendToolRequest(_:)` on `AIProvider` (Anthropic `tool_use` / OpenAI `tool_calls`; default-off so non-tool providers compile unchanged), and on `AIService`: `resolveToolProvider()` (resolve the config ONCE + report tool-use capability), `sendToolTurn(_:using:)` + `streamRequest(_:using:)` (one turn/stream through the pinned config, RE-checking the live flag + consent each turn so a mid-loop revoke fails closed) |
+| `AgenticChatDriver` + `AIToolRegistry` (`Services/AI/`) | `AIService` + the tool executors | **Feature #91 — agentic AI chat.** `AgenticChatDriver` is the bounded send→tool→result→re-send loop (one pre-resolved provider via `AIServiceToolUseAdapter`, `maxIterations` cap, returns `{finalText, usedTools}`); `AIToolRegistry` dispatches a model `ToolCall` to its `AITool` (unknown tool → `isError` result, never throws). Four read-only executors wrap existing capabilities: `search_current_book` (the open book's FTS), `search_other_books` (the whole library, gated by the pure `LibraryBookSearchGate` over the persistent index), `get_book_content` (a book's text by title, locality/format-gated), and `list_library` (feature #97 — enumerate the bookshelf: title/author/format, over the same `LibrarySearchBackend.libraryBooks()`; dedupe, open-book exclude, total deterministic sort, cap+announce, canonical-format display, restore-placeholder friendliness). `AgenticToolRegistryBuilder.buildLive` assembles them over the production `LibrarySearchBackendAdapter` + `BookContentProviderAdapter` (+ `ClosedBookTextExtractor`) and the shared `PersistentSearchIndex` store. `AIChatViewModel.sendMessage` routes through the driver when `agenticTools` is on + the resolved provider supports tool-use (silent loop, single final answer, citations suppressed on a tool reply); otherwise the existing streaming path. Default OFF |
+| `PersistentSearchIndex` (`Services/Search/`) | `SearchIndexCore` + `SearchIndexStore` | The single Services-layer source of truth for the on-disk FTS index location (`Application Support/SearchIndex/search.sqlite3`) + persistent-store construction (`makeStore()`, in-memory fallback). `ReaderSearchCoordinator` delegates to it; Feature #91's agentic search tools open the SAME persisted index through it |
+| `TTSService`                         | `SpeechSynthesizing` seam | `@MainActor @Observable` read-aloud state machine (idle/speaking/paused + UTF-16 progress offset). Speaks through an injected `SpeechSynthesizing` and wires its `AVSpeechSynthesizerDelegate` callbacks generically via the protocol's `delegateTarget` (feature #72 WI-0), so any backend — on-device, XCUITest mock, or the cloud adapter — drives progress without type-casing. `defaultSynthesizer(configStore:)` picks the backend: XCUITest mock (DEBUG override) > `HTTPSpeechSynthesizer` when a valid `HTTPTTSConfig` is persisted (feature #72 WI-3) > `SystemSpeechSynthesizer` (on-device) |
+| `HTTPSpeechSynthesizer`              | `HTTPTTSProvider` + `HTTPTTSChunkPlayer` | Feature #72 WI-3 cloud-TTS adapter: the `SpeechSynthesizing` impl that finally wires the orphaned `HTTPTTSProvider` (bug #270) into live read-aloud. Per `speak`, chunks the utterance (`HTTPTTSProvider.chunkText`), synthesizes each chunk over HTTP, streams the audio blobs into `HTTPTTSChunkPlayer`, and emulates the `AVSpeechSynthesizerDelegate` callbacks `TTSService` consumes (chunk-range `willSpeakRange`, `didFinish`, `didCancel`). Conforms to the non-isolated protocol via `@unchecked Sendable` + `MainActor.assumeIsolated` wrappers over `@MainActor` impls; `TTSService` (its only caller) is `@MainActor`. Audio session stays owned by `TTSService` |
+| `HTTPTTSChunkPlayer`                 | `AVAudioPlayer` (behind `SpeechAudioPlaying` seam) | Feature #72 WI-2 sequential audio-chunk playback queue for the cloud path. Plays streamed `Data` chunks back-to-back, fires `onChunkStarted(index)` as each begins and `onFinished` once the LAST chunk of a COMPLETE input drains (drain ≠ complete — `markInputComplete()` gates the finish). Generation token ignores late finishes from stopped/replaced players. Does NOT manage `AVAudioSession` |
+| `HTTPTTSConfigStore`                 | `UserDefaults` + `KeychainService` | Feature #72 WI-1 loader: decodes the persisted `HTTPTTSConfig` from UserDefaults and splices the API key from Keychain; `loadValidConfig()` returns the config only when it passes `validate()`. Consumed by `TTSService.defaultSynthesizer` to decide whether the cloud path is active |
+| `BookContentCache`                   | In-memory                  | Text cache for AI context loading (TXT/MD only)                           |
+| `PreferenceStore`                    | UserDefaults               | Sort order, view mode persistence                                         |
+| `ReadingStatsAggregator`             | SwiftData (actor-isolated) | Reading-stats dashboard aggregator (feature #58). Sweeps `ReadingSession` + `Book` rows in one `ModelContext` pass and returns a `ReadingDashboardSnapshot` — per-window totals (today / 7d / 30d / 90d / 180d / 365d / all) + per-book breakdown. Derives every number from session rows, never from `ReadingStats`, so a stale stats cache cannot desync the dashboard. Holds a `@Sendable () -> Calendar` provider so window boundaries follow timezone/DST changes. **WI-6b**: `snapshot(window:sort:now:customRange:)` accepts an optional user-picked `ReadingStatsCustomRange` (calendar-day-inclusive `[start, end]`); when non-nil, the snapshot's `perBook` + `customRangeBreakdown` reflect that range while the seven enum totals stay populated for the pill bar |
+| `CustomCoverStore`                   | JPEG files                 | Custom book cover images                                                  |
+| `WebDAVClient`                       | HTTP                       | Low-level WebDAV transport (PROPFIND/PUT/GET/DELETE/MKCOL/MOVE)           |
+| `WebDAVProvider`                     | `WebDAVClient`             | `BackupProvider` impl — backup/restore/list/delete over a WebDAV server   |
+| `WebDAVProviderFactory`              | `WebDAVServerProfileStore`  | Assembles a `WebDAVProvider` from the active WebDAV profile (feature #52 WI-3 + WI-5). `make(persistence:profileStore:)` is the sole production path — the pre-#52 `make(keychain:)` flat-keychain variants were removed in WI-5 |
+| `WebDAVServerProfileStore`           | `UserDefaults` / `KeychainService` | Actor-isolated list of saved WebDAV server profiles with one active selection (feature #52 WI-1). Profiles + active-id persist as `UserDefaults` JSON; per-profile passwords persist in Keychain. Atomic `loadSnapshot`, `upsert` / `remove` / `setActiveProfileID`, single-hop `updateIfExists`. Mirrors `ProviderProfileStore` (feature #50) for the AI multi-profile precedent |
+| `WebDAVProfileMigrator`              | `KeychainService` / `WebDAVServerProfileStore` | One-shot migrator that lifts pre-#52 flat-keychain credentials (`com.vreader.webdav.{serverURL,username,password}`) into a `"Default"` profile and sets it active. Idempotent on both axes (marker key + non-empty store). Feature #52 WI-2 |
+| `ReadingModeMigration`               | `UserDefaults` / per-book JSON files | One-shot **synchronous** launch migration retiring the Native/Unified reading mode (feature #54). Removes the `readerReadingMode` UserDefaults key and strips the `readingMode` field from per-book override JSON files (edited as raw `JSONSerialization` objects so other keys are semantically preserved). Synchronous-before-setup — the per-book JSON store has no actor, so a detached migration could race a panel save/restore. Idempotent |
+| `BackupDataCollector`                | `PersistenceActor`         | Serializes 8 versioned JSON sections (annotations, positions, settings, library-manifest, …) |
+| `BackupDataRestorer`                 | `PersistenceActor`         | Decodes + dedupes by UUID/profileKey; rejects future schema versions      |
+| `BlobPath`                           | —                          | Pure utility: `(format, sha256, byteCount)` ↔ `VReader/books/<format>/<sha>_<bytes>.<ext>` (feature #46) |
+| `BackupBlobStore` (protocol pair)    | —                          | Transport-neutral read (`BackupBlobReading`) + write (`BackupBlobWriting`) blob API |
+| `WebDAVBlobStore`                    | `WebDAVTransport`          | Adapter that owns the temp+MOVE atomic-publication algorithm (feature #46) |
+| `BookFileMaterializer`               | `BackupBlobReading` + `BookImporting` | Restore-side: download + size/SHA-256 verify + import via `BookImporter`. Preflight-rehashes existing local files to catch corrupt content (feature #46). Refactored in feature #47 WI-4a to delegate verify + import + fingerprint match to `BookFileImportFinalizer`. |
+| `BookFileImportFinalizer`            | `BookImporting`            | Shared verify + import + fingerprint pipeline used by both `BookFileMaterializer` (restore-all path) and the lazy-download coordinator (feature #47 WI-4b). Streaming SHA-256 so very-large blobs don't spike memory. Caller owns temp-file lifetime. |
+| `RemoteBookCatalog`                  | —                          | Pure decoder: extracts `library-manifest.json` from a backup ZIP via `ZIPWriter.extractEntry(named:from:)` and returns `[BackupLibraryEntry]`. Surfaces `manifestMissing` (older backups) / `manifestUndecodable` / `manifestSchemaVersionTooNew` as typed errors. Feature #47 WI-4a. |
+| `SelectiveRestoreCoordinator`        | `BookFileMaterializer` + `PersistenceActor` + `BackupDataRestoring` | 3-phase orchestrator for the picker-driven restore: (1) preplant unselected entries as `.remoteOnly` rows, (2) materialize selected entries via `BookFileMaterializer`, (3) apply metadata sections so positions/annotations reattach to BOTH `.local` and `.remoteOnly` rows by fingerprintKey. Phase-weighted progress 0.10/0.75/0.15. Feature #47 WI-4b. |
+| `LazyDownloadCoordinator`            | `BackgroundDownloadSessioning` + `PersistenceActor` | `@MainActor @Observable`. Receives forwarded events from a non-isolated `LazyDownloadDelegate` and exposes per-fingerprintKey progress + outcome state to library rows. Reattaches in-flight tasks at init via `URLSession.getAllTasks(...)` and reconciles orphaned `.downloading` rows (no live task) to `.failed`. Race-safe sticky `terminalKeys` guard outlives `clearOutcome(for:)`. Feature #47 WI-3. |
+| `LazyDownloadDelegate`               | URLSessionDownloadDelegate | Nonisolated delegate that hops to MainActor via `Task` to forward `didWriteData` / `didFinishDownloadingTo` / `didCompleteWithError` / `urlSessionDidFinishEvents` events to the coordinator. Cancels orphaned tasks (missing/invalid `taskDescription`) and validates SHA/extension shape before staging. Feature #47 WI-3. |
+| `LazyDownloadTaskMeta`               | —                          | `Codable Sendable` payload encoded into `URLSessionDownloadTask.taskDescription` so identity (`fingerprintKey`, `blobPath`, `expectedSHA256`, `expectedByteCount`, `originalExtension`) survives crash + relaunch. `schemaVersion` gate (`1...currentSchemaVersion`) rejects future formats. Feature #47 WI-3. |
+| `BackgroundDownloadSessioning`       | `URLSession.background(...)` (production) / mock (tests) | Test seam for the background URLSession's `getAllTasks` enumeration. Production wrapper (`URLSessionBackgroundSession`) holds the live session; tests synthesize `LazyDownloadTaskDescriptor` values. Feature #47 WI-3b. |
+| `WebDAVNetworkPolicy`                | `NWPathMonitor`            | `@MainActor @Observable` Wi-Fi-only gate. UserDefault `com.vreader.webdav.wifiOnly` (default true) + `currentInterface: .unknown / .none / .cellular / .wifi`. `shouldStart() -> Bool` consulted by the lazy-download enqueue path (#47 WI-4 follow-up) and "Restore all" guards. URLSession's `allowsCellularAccess = false` cancels rather than pauses, so we keep cellular allowed and gate at enqueue. Feature #47 WI-3c. |
+| `FoliateURLSchemeHandler`            | WKURLSchemeHandler         | Scheme-handler implementation (not on the live load path; see Foliate-js Bridge note) |
+| `FoliateMessageParser`               | Pure functions             | Parses raw JS message bodies into typed Swift events                      |
+| `FoliateJSEscaper`                   | Pure functions             | Escapes/sanitizes strings for safe JS/CSS interpolation in Foliate bridge |
+| `ReaderSettingsStore`                | UserDefaults               | Global reader UI prefs: theme, typography, EPUB layout, auto-page-turn, page-turn animation, Chinese conversion, custom background |
+| `PerBookSettingsStore`               | Per-book JSON files        | Per-book overrides on top of `ReaderSettingsStore` (font/theme/spacing) |
+| `FontSizeCalibrator`                 | Pure value type            | Maps the stored unified font-size value to a per-renderer concrete value via `FontSizeCalibrationProfile` multipliers (`txt`/`md`/`epub`/`foliate`), so the same slider number renders at a consistent perceived size across reflow formats. TXT is the `1.0` anchor; result re-clamped to each renderer's legal band (`12...64` text, `8...72` Foliate). PDF is intentionally not a target. Feature #70 |
+| `KeychainService`                    | Keychain                   | Secure credential storage (used by `WebDAVProviderFactory`)               |
+| `BookSourcePipeline`                 | Actor + HTTP / rule engine | Search → BookInfo → TOC → Content scraping for Legado-style web novels    |
+| `SyncService`                        | CloudKit (feature-flagged) | Coordinates sync with `SyncConflictResolver`, tombstones, change tokens   |
+| `DebugBridge`                        | URL handler (DEBUG-only)   | `vreader-debug://` reset/seed/open/settle/snapshot/eval/tts/search/highlight/provider/present/ai/seed-sessions/seek/scroll-sheet/navigate/scroll-boundary/locate?highlight=N; feature #49 added position-aware open + DebugSnapshot schema v2 (TTS state, render phase, settings provenance); feature #74 added `locate?highlight=<N>` to drive `.readerNavigateToLocator` for the active TXT/MD reader CU-free so the locate "bloom" (highlight/note landing) fires on the real render path, plus DebugSnapshot schema v3 (`landingBloomCount` / `landingBloomPeakIntensity`) read back from `HighlightableTextView`'s persisted bloom counters — the ~1.5s sub-second bloom visual can't be screenshot/video-captured on the virtual display, so the snapshot proves it fired; feature #45 WI-4c-b added `tts?action=start\|stop` to bypass XCUITest's audio-session block; bug #238 added `search?query=...[&index=N]` to drive search-result-tap repros (Bug #182 / GH #621) CU-free; bug #237 added `highlight?start=...&end=...[&color=...]` for TXT/MD highlight creation CU-free; bug #243 added `provider?action=add\|remove\|clear` for AI provider configuration without driving Settings → AI through CU (unlocks Feature #56 b/d / Feature #65 / Feature #69 / Bug #93 autonomous AI verification); bug #253 added `present?sheet=...[&tab=...]` + bug #255 added `ai?action=summarize\|chat\|translate` for CU-free reader-sheet + AI-response-card verification; bug #263 added `seed-sessions?book=<key>[&seconds=<n>]` to seed a deterministic `ReadingSession` spread (one per dashboard window band) so the reading-stats dashboard (Feature #58) renders non-zero per-window totals CU-free; bug #267 added `seek?fraction=<0...1>` to drive the active Foliate (AZW3/MOBI) reader to a fractional position CU-free; bug #271 added `scroll-sheet?to=top\|bottom` to scroll the active presented sheet's content (today `TranslationResultCard`) so the accent translation card below the tall ORIGINAL card — beyond even the `detent=large` fold (Bug #256) — becomes screenshot-capturable, unblocking Feature #65 row 11; bug #273 added `navigate?spine=<N>[&fraction=<F>]` to drive `.readerNavigateToLocator` for the active EPUB reader CU-free (the `search` driver doesn't navigate in continuous mode), posting DEBUG-only `.debugBridgeNavigateCommand` → `EPUBReaderContainerView` resolves spine → href → `Locator` → re-posts `.readerNavigateToLocator` — unblocking feature #71 WI-8 continuous-mode navigation verification (paired with the `multi-chapter-epub` 4-tall-chapter fixture for the out-of-window rebuild branch); a follow-up added `scroll-boundary?spine=<N>&near=top\|bottom` to post a DEBUG-only `.debugBridgeScrollBoundaryCommand` → `EPUBReaderContainerView` builds an `EPUBScrollBoundarySignal` and calls `EPUBContinuousScrollCoordinator.handleBoundarySignal` directly — bypassing the rAF-throttled `continuousScrollObserverJS` (unverifiable CU-free on a virtual display) so feature #71's scroll-driven extend/evict RESPONSE can be device-verified. **Host-vs-runner driving constraint (bug #242 / GH #1054)**: bridge URLs MUST be invoked from the host (`xcrun simctl openurl` outside any iOS sandbox) — invoking them from inside an XCUITest binary fails with NSPOSIX 61 because the runner sandbox blocks the CoreSimulatorService XPC endpoint. In-runner verification flows use `XCTSkipUnless(bridgeReachable())` (PR #1053) when they cannot move the bridge-dependent assertion to a host-side driver. See `docs/subsystems/debug-bridge.md` § "Driving the bridge from a verification flow". |
+| `DebugPositionResolver`              | —                          | Pure parser: `?position=<value>` string → typed `DebugPosition` per BookFormat (TXT/MD UTF-16 offset, EPUB CFI, AZW3 Foliate-CFI, PDF page). Every format takes its native seek path (feature #54 retired the Native/Unified mode + its position-unsupported guard). Feature #49 WI-7a. |
+| `DebugReaderRegistry.awaitReader`    | DebugReaderRegistry singleton | Token-based keyed waiter that resumes when a reader matching `fingerprintKey` registers. Concurrent waiters with different timeouts each get their own continuation (UUID-token ownership). Feature #49 WI-7a. |
+| `DebugReaderRegistry.awaitReaderSettled` | DebugReaderRegistry singleton (`+Settle` extension) | Bug #141: render-settled signal keyed by `(fingerprintKey, token)`. Hosts call `markReaderSettled` on real render-complete — EPUB from `webView(_:didFinish:)`, AZW3/MOBI from the Foliate `relocate` message. `ReaderContainerView` wires `probe.settleStrategy` so `vreader-debug://settle` blocks until that signal (or `settleTimeout`) instead of the 100ms placeholder. TXT/MD/PDF keep the placeholder. Same UUID-token waiter machinery + stale-write guard as `awaitReader`. |
+| `ImportJobQueue`                     | Actor                      | Serializes book imports (avoids parallel `BookImporter` writes)           |
+| `FileURLImportRouter`                | `BookImporting` (protocol) | `@MainActor` dispatcher for incoming `file://` URLs from iOS Share Sheet / "Open in vreader" (Feature #59 WI-2). Wired by `VReaderApp`'s production `.onOpenURL`. Returns `false` for non-file URLs (Debug-bridge handler intercepts those upstream). Unsupported extensions reported via injected closure (App layer wires the user-facing alert; current production wiring is a no-op). Supported extensions kick off `bookImporter.importFile(at:source:.shareSheet)` in a fire-and-forget Task. Security-scope handling owned by `BookImporter`, not the router. |
+| `LibraryRefreshService`              | NotificationCenter         | Coalesces library refresh requests across views                           |
+| `FeatureFlags`                       | Static                     | Compile/runtime flag resolution (`SyncService` and others gate on it). Feature #91 added `agenticTools` (default OFF, persisted) — gates the AI chat's agentic tool-calling loop |
+| `DictionaryLookup`                   | UIKit                      | System dictionary + AI-translate hooks for selected text                  |
+| `DiagnosticsLogStore` + `OSLogDiagnosticsSource` + `DiagnosticsRedactor` (`Services/Diagnostics/`) | `OSLogStore` (current-process) | **Feature #96 — in-app runtime diagnostics.** `DiagnosticsLogStore` (`@MainActor @Observable`) reads the current session's `com.vreader.app` `Logger` entries back via the `DiagnosticsLogSource` seam (`OSLogDiagnosticsSource` runs the blocking `OSLogStore` enumeration off-main), holds them bounded, filters by level/category, and produces a `DiagnosticsRedactor`-scrubbed export string. `DiagnosticsRedactor` is a pure, context-driven secret/path scrubber (Authorization, keyed secrets, `sk-`/JWT keys, URL creds, container paths) — the defense-in-depth second line over OSLog's `.private` barrier for anything leaving the app (export file + Copy-entry). WI-2 added the Settings → Support → Diagnostics viewer (`Views/Settings/Diagnostics/`) binding to the store |
+| `ChapterTranslationStore`            | SwiftData (actor-isolated) | Persistent disk cache for feature #56 bilingual reading. Wraps its own `ModelContext` over the `ChapterTranslation` `@Model` (SchemaV7) — a separate actor from `PersistenceActor` so bulk translation writes during a global-translate run never block library reads. App-scoped `.shared` single instance (the `ProviderProfileStore.shared` precedent); idempotent `upsert` fetches by `lookupKey` and updates in place, never relying on the unique constraint to throw. Returns the value-type `ChapterTranslationRecord` DTO, never the `@Model`. Bug #342: lazily migrates pre-#342 5-field keys (profile UUID baked in) to the canonical 4-field key on first access, deduping to the newest row. The cache is derived, re-fetchable data — excluded from WebDAV backup |
+| `ChapterTranslationService`          | `ChapterTranslationStore` + `AIService` | Translates one chapter unit for feature #56 bilingual reading. Pipeline: cache lookup → (on miss) `ChapterSegmenter` → `ChapterTranslationChunker` → one `AIService.sendRequest(_:using:)` per chunk → strict `TranslationChunkContract` JSON-array decode → per-segment fallback on any decode/count/element mismatch → recombine → cache-write. Reaches the AI side through the `TranslationRequestSending` boundary protocol (tests inject a mock). `Task.checkCancellation()` between chunks so a cancelled prefetch stops promptly |
+| `ChapterTextProviding` (`Services/Reader/`) | per-format reader services | Feature #56 WI-2.5 boundary protocol — supplies a book's translation units (`translationUnits()`), per-unit plain source text (`sourceText(for:)`), and the `Locator → unit` resolution (`unit(containing:)` / `unit(after:)`) the bilingual prefetch trigger needs. The translation *unit* is the format's natural rendering segment, not the logical TOC chapter (plan Decision 2.7). Four concrete `Sendable` `struct` adapters: `EPUBChapterTextProvider` (spine documents, HTML-stripped via `EPUBTextExtractor`), `TXTChapterTextProvider` (`TXTChapterIndex` chapters, UTF-16 slicing), `MDChapterTextProvider` (`MDHeading`-bounded chapters), `PDFChapterTextProvider` (page ranges via PDFKit). The AZW3/MOBI `FoliateChapterTextProvider` (an `actor`, bridges the `@MainActor` Foliate coordinator via the `FoliateSectionExtracting` facade) lands in WI-11. `ChapterTranslationService` / `BookTranslationCoordinator` consume this boundary, never a format-specific extractor |
+| `FoliateChapterTextProvider` (`Services/Reader/`) | `FoliateSectionExtracting` | Feature #56 WI-11 — AZW3/MOBI `ChapterTextProviding` adapter. The odd one out: an `actor` (not a `struct`) because the live Foliate seam (`FoliateSpikeView.Coordinator` + `WKWebView`) is `@MainActor`. Stores an `any FoliateSectionExtracting` and reaches it via `await`; an `actor` is `Sendable` by construction so it satisfies `ChapterTextProviding: Sendable` without `nonisolated(unsafe)`. Caches the ordered section-id list on the first `translationUnits()` call; a book reopen rebuilds the provider from scratch so the cache never goes stale within one open book |
+| `FoliateSectionExtracting` (`Services/Reader/`) | `FoliateSpikeView.Coordinator` (extension) | Feature #56 WI-11 — `@MainActor protocol` bridging the live Foliate per-section text extraction seam (the `readerAPI.bilingualSectionIDs` / `readerAPI.bilingualSectionText` JS calls) into the `Sendable` `ChapterTextProviding` boundary. Class-bound + `Sendable` + `@MainActor` means a `@MainActor`-isolated `AnyObject` existential is safely `Sendable` (members are main-actor-isolated), so the `FoliateChapterTextProvider` actor can hold a single live reference without an unsafe escape hatch |
+| `ChapterPrefetching` (`Services/AI/`) | `BilingualReadingViewModel` | Feature #56 WI-7b seam — `translatedSegments(for:targetLanguage:granularity:)`, the single-method translation-prefetch boundary `BilingualReadingViewModel`'s unit-aware prefetch trigger depends on. Decouples the view model from provider resolution / the disk cache / chunking; production wires a thin adapter over `ChapterTranslationService` + `AIService`, tests inject a deterministic mock |
+| `ChapterTranslationPrefetcher` (`Services/AI/`) | `ChapterTranslationService` + `AIService` + `ChapterTextProviding` | Feature #56 WI-10 production `ChapterPrefetching` adapter. `Sendable` `struct` per open book. Each `translatedSegments(...)` call consults the disk cache FIRST (profile-free — Bugs #306/#342: a cached chapter renders with no/any provider), then resolves the active provider config once — a profile flip during a chapter prefetch does not split chunks across providers. Pulls per-unit source text from the injected `ChapterTextProviding` and routes the request through `ChapterTranslationService.translate(...)`. Default style is `.natural`; the re-translate picker (WI-15) is the only path that overrides it |
+| `BackgroundExecutionToken` (`Services/`) | `UIApplication` (via `BackgroundTaskRequesting`) | Feature #98 grace-window handle over `beginBackgroundTask`/`endBackgroundTask` behind the `BackgroundTaskRequesting` protocol seam (production = `UIApplication`, tests = recorder). `@MainActor` class; explicit `end()` is the contract (idempotent; `deinit` only DEBUG-logs leaks); the expiration handler strongly captures a shared end-state so even a leaked token self-ends at expiry; `.invalid` (iOS denied time) degrades to a no-op. Ships with `BackgroundExpiryLatch` — a lock-backed one-way latch the `@MainActor` expiry handler sets synchronously and the whole-book job loop reads between units. Consumers: `ChapterReTranslateViewModel.submit()` (one token per re-translate) and `BookTranslationCoordinator` (token renewed per translated unit; expiry → clean between-units stop with the `.failed` phase, completed units cached as the resume checkpoint) |
+| `BookTranslationCoordinator` (`Services/AI/`) | `ChapterTranslationService` + `ChapterTranslationStore` + `ChapterTextProviding` | Feature #56 WI-14 actor driving the "translate entire book" flow. App-scoped `.shared` instance (configured at `VReaderApp.init`). `start(...)` spawns a background task that iterates `ChapterTextProviding.translationUnits()`, skips units already covered in `ChapterTranslationStore.cachedUnits(...)`, hands each remaining unit to `ChapterTranslationService.translate(...)`, and emits monotonic `BookTranslationProgress` snapshots through an `AsyncStream` (`progressUpdates(forBookWithKey:)`). At most one running job per book — a second `start` for the same book is a silent no-op. `cancel(_:)` stops between units; `cancelAndPurge(_:)` additionally wipes the book's cache rows for the user-delete-book path (plan edge case (g)). Posts `.readerBookTranslationProgressDidChange` on every snapshot so a reader open on the book drives its `ReaderTranslateBanner`. Feature #98: renews a `BackgroundExecutionToken` per translated unit; on OS expiry stops cleanly BETWEEN units (`.failed` phase = the designed PAUSED rendering) and persists an `InterruptedTranslationJob` descriptor (`{v, bookKey, targetLanguage, style, providerProfileID}` in UserDefaults via `InterruptedTranslationJobStore`); `resumeInterruptedJob(bookFingerprintKey:textProvider:)` — triggered by the reader container's provider-arrival handler — re-resolves the PERSISTED profile through the `ProviderConfigResolving` seam (`AIService` conforms) and re-enters `start` (cached units skip = resume); descriptor cleared on completion / user cancel / book delete, retained on provider failure |
+| `BookTranslationViewModel` (`ViewModels/`) | `BookTranslationCoordinator` | Feature #56 WI-14 `@MainActor @Observable` UI-facing state for the translate-entire-book flow. Drives the confirm alert (`presentConfirm` loads `estimate` + shows alert), the status sheet (`startObserving` subscribes to the coordinator's progress stream and mirrors snapshots into `progress`), and the cancel alert (`requestCancel` opens the confirmation, `confirmCancel` propagates to the coordinator). One per surface (Book Details, library card, reader chrome); multiple VMs for the same book observe the same coordinator job |
+| `ChapterReTranslateViewModel` (`ViewModels/`) | `AIService` + `ChapterTranslationService` + `ChapterTranslationStore` | Feature #56 WI-15 `@MainActor @Observable` UI-facing state for the per-chapter re-translation flow. `presentPicker(...)` opens `ReTranslatePickerSheet` with the chosen unit + title + target language; `updateSelection(_:)` mutates the picker's `(providerProfileID, model, style, keepGlossary)` selection; `submit()` resolves the picker's `ResolvedAIProviderConfig` through the `RetranslateProviderResolving` boundary (`AIService` conforms), runs the translation through `ChapterReTranslating` (`ChapterTranslationService` conforms, with the cache READ bypassed so a fresh row can't no-op the re-translate — Bug #341 atomic swap + Bug #342 canonical key: the cache-write replaces the ONE `book|unit|lang|prompt` row in place, the original translation survives every failure/cancel path, and an override re-translation is readable by bilingual mode on reopen), and fires `onTranslationApplied` so the host posts `.readerBilingualReTranslateApplied`. Picker override never mutates `ProviderProfileStore` (acceptance criterion (f)) |
+| `EPUBBilingualPipeline` (`Views/Reader/Bilingual/`) | `EPUBBilingualJS` + `EPUBBilingualOrchestrator` | Feature #56 WI-10 pure glue between the EPUB WKWebView's `bilingualEnumerate` message payload and the `BilingualReadingViewModel`'s `translationsByUnit` cache. `parseEnumeratePayload(_:)` decodes the raw `Any` body into an `EPUBBilingualEnumeratePayload` (`{requestedSectionIndex, blocks}`) — accepting BOTH the paged bare-array shape (`[{bid,text}]`, no section identity) and the continuous-scroll envelope (`{sectionIndex, blocks}`); the envelope preserves the section identity on an EMPTY result so the container clears ONLY that section's bucket instead of every bucket (Feature #71 WI-7 Gate-4 round-3 MEDIUM 1). `parseEnumerateMessage(_:)` is the flat-`[BilingualBlock]` convenience over it; `translationsByBid(blocks:translatedSegments:)` maps the VM's ordered segment array onto a `[bid: text]` lookup by position. No `@MainActor` — pure value transforms |
+| `EPUBBilingualOrchestrator` (`Views/Reader/Bilingual/`) | `EPUBBilingualJS` + `EPUBBilingualPipeline` | Feature #56 WI-10 host-side `@MainActor @Observable` controller, one per open EPUB. Holds the current chapter's `[BilingualBlock]` list; emits enumerate / inject / clear JS for the bridge to evaluate. Stateless beyond the block list — the container drives transitions via `enumerateJS()` on `didFinish`, `updateBlocks(_:)` on the enumerate callback, `buildInjectJS(translatedSegments:)` when the VM's prefetch lands, and `clearJS()` on disable / chapter swap |
+| `FoliateBilingualPipeline` (`Views/Reader/Bilingual/`) | `FoliateBilingualJS` + `FoliateBilingualOrchestrator` | Feature #56 WI-11 — AZW3/MOBI sibling of `EPUBBilingualPipeline`. Same two static functions (`parseEnumerateMessage(_:)`, `translationsByBid(blocks:translatedSegments:)`) with the same shapes; reuses the `BilingualBlock` value type so the enumerate → translate → inject contract is byte-identical across formats. Independent file so format-specific test invariants don't cross-contaminate |
+| `FoliateBilingualOrchestrator` (`Views/Reader/Bilingual/`) | `FoliateBilingualJS` + `FoliateBilingualPipeline` | Feature #56 WI-11 — AZW3/MOBI sibling of `EPUBBilingualOrchestrator`. `@MainActor @Observable` controller, one per open AZW3/MOBI book. Owned by `FoliateBilingualContainerView`; emits enumerate / inject / clear JS that the container posts through `.foliateRequestBilingualEvalJS` for the live `FoliateSpikeView.Coordinator` to evaluate against its `WKWebView` |
+| `FoliateBilingualContainerView` (`Views/Reader/`) | `FoliateSpikeView` + `FoliateBilingualOrchestrator` + `BilingualReadingViewModel` + `FoliateChapterTextProvider` | Feature #56 WI-11 — AZW3/MOBI host wrapper that adds the bilingual VM / orchestrator / setup-sheet wiring around the unchanged `FoliateSpikeView`. Owns the bilingual `@State`, the first-enable `BilingualSetupSheet`, and the notification plumbing (`.readerMoreBilingual` → toggle, `.foliateSectionLoaded` → enumerate, `.foliateBilingualBlocksEnumerated` → cache + prefetch, `.readerBilingualDidChange` → inject) that mirrors `EPUBReaderContainerView+Bilingual` for the live Foliate path |
+| `BilingualDisplaySegmentMap` (`Services/Reader/`) | `BilingualTextRenderer`, `TXTReaderContainerView`, `MDReaderContainerView` | Feature #56 WI-12a pure `Sendable` value type — the TXT/MD source↔display UTF-16 offset map. Records ordered display segments tagged `.source(sourceRange:displayRange:)` or `.synthetic(displayRange:)`. `sourceOffset(forDisplayOffset:)` returns `nil` for synthetic ranges or out-of-bounds offsets; `displayOffset(forSourceOffset:)` clamps a past-end source position to display end. `identity(sourceLength:)` builds the 1:1 pass-through used when bilingual is off. WI-12b consumes the map in TXT/MD container offset-routing |
+| `BilingualTextRenderer` (`Views/Reader/Bilingual/`) | `BilingualDisplaySegmentMap` | Feature #56 WI-12a pure interlinear builder for TXT/MD. `render(sourceText:sourceParagraphRanges:translatedSegments:)` returns the rendered `NSAttributedString` (source paragraphs interleaved with synthetic translation runs, each carrying the `decorationAttributeKey` attribute) plus the matching `BilingualDisplaySegmentMap`. Nil or empty translations fall back to source + identity map. Partial translations inject the prefix and leave the tail source-only (plan Decision 2's silent-source-fallback). WI-12b wires the renderer's output into the live TXT/MD UITextView |
+| `BilingualParagraphRanges` (`Services/Reader/`) | `BilingualTextRenderer`, `BilingualDisplayPipeline` | Feature #56 WI-12b — pure paragraph-range scanner that splits a TXT/MD chapter's source text into UTF-16 paragraph ranges. Blank-line-separated content lines fuse into one paragraph (matches reflow conventions); blank lines + leading/trailing whitespace are excluded from ranges. Feeds the interlinear renderer's `sourceParagraphRanges` argument. Pure O(N) UTF-16 single-pass — covers CRLF / CJK / interspersed-blank-line edge cases |
+| `BilingualAttributedStringComposer` (`Views/Reader/Bilingual/`) | `BilingualDisplaySegmentMap`, `BilingualTextRenderer` | Feature #56 WI-12b — typography-preserving interlinear composer. `compose(sourceAttributed:sourceParagraphRanges:translatedSegments:)` takes an already-typographed source `NSAttributedString` (font, line spacing, drop-cap, heading restyle) and interleaves synthetic translation runs at paragraph boundaries. Synthetic runs inherit the prior source paragraph's attrs + carry the `decorationAttributeKey`. Used by TXT's chapter-paged path so the chapter-start drop-cap + heading restyle survive the bilingual interleave |
+| `BilingualDisplayPipeline` (`Views/Reader/Bilingual/`) | `BilingualTextRenderer`, `BilingualAttributedStringComposer`, `BilingualReadingViewModel` | Feature #56 WI-12b — `@MainActor` bridge between the bilingual VM state and the renderer/composer. `makeDisplay(...)` builds a fresh attrString from a plain `String` source; `compose(sourceAttributed:...)` preserves an upstream typographed attrString. Both off-path (no VM / disabled / no unit / no cached translation) returns the source + identity map — the byte-identical pass-through that gates the R-TXT-offsets risk |
+| `BilingualOffsetRouter` (`Views/Reader/Bilingual/`) | `BilingualDisplaySegmentMap` | Feature #56 WI-12b — pure source↔display offset router for the TXT/MD container's bilingual surfaces. Helpers: `displayOffset(forSourceOffset:map:)`, `sourceOffset(forDisplayOffset:map:)`, `displayRange(forSourceRange:map:)` (segment-union projection — a source range that crosses an intervening synthetic block produces a spanning display range), `displayNSRange(forSourceNSRange:map:)`, `isSynthetic(displayOffset:map:)`. Identity-map mode is byte-identical to today's offset code |
+| `BilingualTXTBridgeDelegateAdapter` (`Views/Reader/Bilingual/`) | `BilingualDisplaySegmentMap`, `TXTTextViewBridge` | Feature #56 WI-12b — `@MainActor` delegate wrapper that maps display-domain offsets the bridge reports (selection range, top-visible-char scroll offset) back to source-domain offsets via `BilingualOffsetRouter`, so the TXT VM keeps persisting positions in document source coordinates with bilingual on. A selection that starts inside a synthetic translation run is dropped; a scroll-into-synthetic projects to the end of the preceding source segment. Identity map (bilingual off) is a transparent pass-through |
+| `TXTLoaderBackedChapterTextProvider` (`Services/Reader/`) | `ChapterTextProviding`, `TXTChapterContentLoader` | Feature #56 WI-12b — chapter-paged-mode `ChapterTextProviding` adapter that reads each chapter on demand via the live reader's `TXTChapterContentLoader` actor. Sibling to `TXTChapterTextProvider` (full-book-slicing). Re-enables bilingual mode for chapter-paged TXT, the mode WI-12a's `makeTextProvider` explicitly disabled because the VM's `textContent` is chapter-local in that mode |
+| `PDFBilingualPanel` (`Views/Reader/Bilingual/`) | `PDFBilingualPanelState`, `BilingualLanguage`, `ReaderThemeV2` | Feature #56 WI-13 — PDF below-page bilingual translation panel. Stateless SwiftUI sub-view rendering the design's split-layout A1..A8: header (lang-glyph chip + page label + status suffix + chevron) + body switched on `PDFBilingualPanelState` (5 states: `.off` / `.loading` / `.translated([String])` / `.offline` / `.empty`). PDF is fixed-layout so the paragraph-interlinear renderer used by EPUB/Foliate/TXT/MD doesn't apply; the panel below the page is the entire user-visible bilingual surface for PDF. 260pt expanded / 38pt collapsed; attached to `PDFViewBridge` via SwiftUI's `.safeAreaInset(edge: .bottom)` so PDFKit's `autoScales` reflows the page rendering automatically |
+| `PDFBilingualPanelState` (`Views/Reader/Bilingual/`) | `BilingualReadingViewModel`, `PDFChapterTextProvider` | Feature #56 WI-13 — pure synchronous derivation of the panel's 5-state matrix from the bilingual VM + the PDF's `(currentPage, pagesPerUnit, totalPages)` triple. Computes the current `TranslationUnitID` synchronously (mirrors `PDFChapterTextProvider.pageRanges` arithmetic) instead of reading the VM's async-updated `lastTriggerUnit`, so page-turn-in-flight doesn't flash stale translations (Gate-2 v5 round-1 H1). `.empty` keyed on "translated segments empty after fetch" OR "totalPages <= 0", NOT `unit == nil` (which would never fire for a real PDF — Gate-2 v5 round-1 M1) |
+| `PDFReaderContainerView+Bilingual` (`Views/Reader/`) | `BilingualReadingViewModel`, `PDFChapterTextProvider`, `PDFBilingualPanel`, `PDFBilingualPanelState` | Feature #56 WI-13 — PDF host extension owning the bilingual VM lifecycle (lazy construction gated on `viewModel.isDocumentLoaded` + `totalPages > 0`), the `PDFChapterTextProvider` build, the prefetcher build (mirrors TXT/EPUB `makePrefetcher`), the first-enable setup sheet, the More-menu toggle observer, the retry observer (`.readerBilingualRetry`), and the `.safeAreaInset`-attached panel. On reopen of an already-enabled book, `ensureBilingualViewModel` kicks the initial `handlePositionChange` so the panel doesn't stick in `.loading` for the open page (Gate-4 round-1 H1). Mirrors `TXTReaderContainerView+Bilingual` / `MDReaderContainerView+Bilingual` / `EPUBReaderContainerView+Bilingual` structurally |
+
+### 6. Data Layer (`vreader/Models/`)
+
+SwiftData SchemaV10 entities (V9→V10 adds the additive optional `Book.sourceCanonicalKey: String?` — feature #108's converted-Kindle cross-platform identity, carried in the backup manifest; feature #109's NFC locator-key recompute runs as the launch-time `LocatorKeyBackfillMigration`, not a schema migration — see the App Layer note above):
+
+- `Book` (fingerprintKey unique; gains `originalExtension: String?` in SchemaV5 for backup blob extension preservation; gains `fileState: String` and `blobPath: String?` in SchemaV6 for feature #47's lazy-load row state; gains `sourceCanonicalKey: String?` in SchemaV10 — feature #108's converted-Kindle source-bytes cross-platform identity, while the converted-EPUB `fingerprintKey` stays the local primary) → `ReadingPosition` (gains `vreaderLocatorData: Data?` in SchemaV8 — feature #42's engine-agnostic `VReaderLocator` envelope, stored as raw JSON `Data?` mirroring `Highlight.anchorData`; additive/optional → lightweight migration, no stage), `Highlight`, `Bookmark`, `AnnotationNote`, `BookCollection`, `ChatSession` (SchemaV9 cascade child)
+# 47 — Feature Implementation Workflow
+
+Binding sequence for every feature implementation. Six gates, never skip one.
+
+> **Plan → Independent plan audit → TDD implementation → Implementation audit loop → Device/integration verification → Merge**
+
+This is a **gate model**, not a chronological task list. Each gate has an explicit acceptance bar; you do not enter the next gate until the current gate's bar is met. Multiple iterations within a gate are normal.
+
+## Gate 1 — Plan
+
+Write `dev-docs/plans/YYYYMMDD-feature-N-<slug>.md` covering, at minimum:
+
+- **Problem** — what user need this addresses (mirror or refine the row's `Problem` field).
+- **Surface area** — file-by-file with concrete signatures (which protocols, types, methods get added or modified). Includes a "files OUT of scope" subsection.
+- **Prior art / project precedent / rejected alternatives** — what existing patterns we're building on, what we considered and rejected, and why. **Research is part of the plan**, not a separate step.
+- **Work-item sequencing** — small, testable units (typically 1-15 WIs). Each WI is one PR's worth of work. Estimated PR size per WI.
+- **Test catalogue** — concrete test files, what each covers, including the audit-driven additions (corruption, partial failure, idempotency edge cases).
+- **Risks + mitigations** — known unknowns and how we'll handle them.
+- **Backward compat** — what happens to existing data / older clients / older backups when this ships.
+
+The features.md "Plan Template" fields (Problem, Scope, Edge Cases, Test plan, Acceptance criteria) live in the row; the implementation-detail plan in `dev-docs/plans/` expands on them with file paths, signatures, and sequencing.
+
+**Acceptance bar**: plan exists at the documented path; status moves to `PLANNED` only when this gate passes.
+
+## Gate 2 — Independent Plan Audit
+
+Send the plan to an independent AI auditor (not the same agent/model/context as the plan author). cc-suite (driving Codex via `codex exec`) is the current default; Gemini, OpenCode, or any equivalent satisfies the gate. The invariant is **independence**, not the brand.
+
+Audit prompt must explicitly request:
+
+- **Model assumption verification** — do the SwiftData fields, enum cases, function signatures, file paths I named actually exist? (This catches the largest class of pre-implementation bugs.)
+- **Risks + missing edge cases** — what failure modes the plan misses.
+- **Protocol signature critique** — are new interfaces well-shaped, or do they leak implementation concerns?
+- **Concurrency hazards** — actor isolation, Sendable, race conditions in mutable state.
+- **Cohesion check** — is the WI split right, or are some WIs too big or too small?
+
+**Acceptance bar**:
+
+- Zero open Critical/High/Medium findings.
+- Low findings either fixed in the plan or explicitly accepted with rationale (in the plan's "Known limitations" or "Audit fixes applied" section).
+- **Maximum 3 audit rounds**. If unresolved findings remain after round 3, stop and escalate to the user — accept, defer, or redesign.
+
+Track audit rounds in the plan's revision history. The author rewrites the plan to address findings; the auditor re-reviews. Same loop until clean.
+
+**Why this gate exists**: Codex audits routinely catch 5-10 real bugs per round on non-trivial plans (compile-breaking model assumptions, missing preconditions, protocol shape mistakes). Skipping the audit shifts that cost into wasted implementation work.
+
+## Gate 3 — TDD Implementation
+
+Per work item:
+
+1. **RED** — write a failing test that captures the WI's behavior. See `.claude/rules/10-tdd.md` for pattern catalogue.
+2. **GREEN** — write minimal implementation to make the test pass.
+3. **REFACTOR** — clean up without changing behavior. Tests stay green.
+4. **PR** — small, focused PR per WI. Apply per-PR rules: docs sync (`24-doc-sync.md`), version bump (`40-version-bump.md`).
+
+Status: feature → `IN PROGRESS` when WI-1's PR opens.
+
+**Acceptance bar per WI**: tests pass under `xcodebuild test -only-testing:vreaderTests`; new code follows codebase conventions (`.claude/rules/50-codebase-conventions.md`).
+
+## Gate 4 — Implementation Audit Loop
+
+After implementation but before merge: independent audit of the changed files (read-only sandbox). This is what `/fix-issue` already runs.
+
+Audit prompt focuses on:
+
+- Correctness against the plan
+- Edge cases in the diff (boundary conditions, nil, Unicode/CJK, concurrent access)
+- Security (JS injection in evaluateJavaScript, WKWebView bridge safety, etc.)
+- Duplicate / dead code introduced
+- VReader compliance (Swift 6 concurrency, @MainActor correctness, file size <300 lines)
+- Bridge safety (FoliateJSEscaper for JS interpolation, message parser edge cases)
+
+**Acceptance bar**:
+
+- Zero open Critical/High/Medium findings.
+- Low findings fixed or explicitly accepted with rationale in the PR body.
+- **Maximum 3 audit-fix rounds**. After round 3, escalate.
+
+Same author/auditor separation as Gate 2.
+
+## Gate 5 — Device / Integration Verification
+
+For each PR before it merges:
+
+- **Foundational WIs** (DTOs, protocols, utilities, pure types — no user-observable behavior): unit + integration tests + audit are sufficient. No device verification required.
+- **Behavioral WIs** (anything that changes app behavior, persistence, networking, backup format, reader rendering, or UI flow): **slice verification** — exercise the slice end-to-end against the real environment available at this point. Run on iPhone 17 Pro Simulator with `vreader-debug://` harness; for backup/network features, against a real WebDAV server (or local Docker WebDAV equivalent); for reader features, with a fixture book.
+- **Final WI** (the one that completes the feature): full end-to-end acceptance pass — every acceptance criterion exercised. This is what flips the feature row from `DONE` to `VERIFIED`.
+
+Record slice verification in the PR description (what was run, what was observed). Record final acceptance verification in a structured evidence file at `dev-docs/verification/feature-<id>-<YYYYMMDD>.md` per the schema in `dev-docs/verification/SCHEMA.md`. The PreToolUse hook `.claude/hooks/check_terminal_status_evidence.sh` blocks any tracker edit that flips a row to `VERIFIED` (features) or `FIXED` (bugs) without a matching evidence file.
+
+**Android tier (feature #107)** — the platform-router (`code_paths_platform`) picks the lane:
+- **iOS WIs**: iPhone 17 Pro Simulator + `vreader-debug://` harness, as above.
+- **Android WIs** (`android-app` / `android-spike`): verify on a booted **Android emulator** (AVD, android-35+) via `scripts/run-android-verify.sh` (the emulator analog of driving the simulator — rule 49/52/53). The CU-free instrumentation lane is the Spike-B `am instrument` pattern (#104/#105 precedent); the evidence file's `device_or_simulator` records the AVD (e.g. "Pixel 7 API 35 emulator"). Until #106's app shell exists, the only Android target is the `spikes/` harness, so Android-app Gate-5 is itself blocked on #106; pre-#106 Android work is spike/tooling (no device-verify, like a foundational WI).
+- **Shared WIs** route to the iOS lane (rule 40 — shared is iOS while Android is pre-foundation).
+
+**Acceptance bar per PR**: every behavioral slice in the PR has been verified end-to-end at the level appropriate to its WI tier. Final WI requires full acceptance pass + evidence file.
+
+**"Tooling unavailable" is NOT an acceptable deferral reason** unless a specific tool is named and confirmed missing (e.g., `xcrun simctl` returns "command not found", a real device is required and none is connected, the rclone WebDAV server is down). "I'll do it next session" is not a tool-unavailability claim — it's a discipline lapse. The Stop hook (`.claude/hooks/check_unfinished_verification.sh`) surfaces unverified `DONE` rows at session end so the gap doesn't quietly carry over.
+
+## Gate 6 — Merge
+
+PR may merge when ALL of the following hold:
+
+- Tests pass (the merge gate from `AGENTS.md`).
+- Implementation audit loop is clean (Gate 4).
+- Device / integration verification is complete for the PR's tier (Gate 5).
+- Docs sync completed if triggered (`.claude/rules/24-doc-sync.md`).
+- Version bump committed as the last commit before opening the PR (`.claude/rules/40-version-bump.md`).
+- For PRs that reference an open bug/feature: the referenced row has reached its terminal status (`FIXED` for bugs, `DONE` for features) — the existing fix-or-implement merge gate.
+
+After merge:
+
+- Feature status moves to `DONE` only after **all** WIs are merged AND every acceptance criterion is implemented.
+- `VERIFIED` is a separate post-implementation status, set after Gate 5's final-WI acceptance pass lands and is recorded in the row. Requires a `dev-docs/verification/feature-<id>-<YYYYMMDD>.md` evidence file (PreToolUse hook enforces).
+- GH issue closes per close-gate rule (closure comment cites the verification: commit SHA + what was tested + what was observed).
+
+## Gate progress is recorded in the GH issue (binding)
+
+The GH issue mirror is not just a creation-time pointer — it is the **running record** of the feature's path through the six gates. Once the issue exists (created at the Gate 2 → `PLANNED` flip), every gate transition posts a short, append-only comment so the issue reads as a verifiable timeline of the workflow. A reviewer who only sees GitHub can then audit gate compliance without cloning the repo.
+
+Post one comment at each of these transitions:
+
+| Transition | Comment records |
+| --- | --- |
+| Gate 2 passes (issue just created) | plan path + audit verdict (Codex threadId + rounds, or `manual-fallback`) + the WI list with foundational/behavioral tiers |
+| Each WI's PR merges (Gate 6) | WI number + tier, PR number, version bumped to, merge-commit SHA, Gate 4 audit verdict, Gate 5a slice result |
+| Final WI merges → row `DONE` | "shipped in vX.Y.Z (commit `<sha>`), awaiting verification" — this is the existing close-gate comment |
+| Gate 5b acceptance pass → row `VERIFIED` | evidence-file path + `result:` + a one-line acceptance-criteria summary — this is the existing closure comment, posted just before `gh issue close` |
+
+Rules for these comments:
+
+- **Append-only, short, factual.** Paths, SHAs, verdicts, version numbers — not prose. One comment per transition; do not edit prior comments.
+- **The markdown artifacts stay the source of truth.** The `dev-docs/plans/` plan, the `.claude/codex-audits/` logs, `docs/features.md`, and the `dev-docs/verification/` evidence file are authoritative. The issue comments are a timeline that *points at* them; never copy a plan's full contents into the issue.
+- **A skipped comment is a gate-process lapse, not a hard-blocked one.** No hook enforces these (they are post-action `gh issue comment` calls), so the discipline is the gate. If a transition happened without its comment, back-fill it before the next transition.
+
+The two bottom rows already exist in the close-gate / finalizer flow; this rule adds the Gate-2 and per-WI-merge rows so the *middle* of the workflow is visible on GitHub, not just its endpoints.
+
+## Audit count by feature size
+
+To keep the audit cost honest:
+
+| Size   | WIs     | Plan audits             | PR audits                                                                               |
+| ------ | ------- | ----------------------- | --------------------------------------------------------------------------------------- |
+| Small  | 1 PR    | 1                       | 1                                                                                       |
+| Medium | 2-4 WIs | 1                       | 1 per WI                                                                                |
+| Large  | 5+ WIs  | 1+ rounds (until clean) | 1 per WI; mechanical low-risk WIs that share the same surface MAY batch under one audit |
+
+If a feature is genuinely 10+ WIs, consider whether the plan should split into multiple features.
+
+## Author / auditor separation (invariant)
+
+The agent that writes the plan must NOT be the same agent that audits it. Today this happens by accident (cc-suite runs Codex as a separate `codex exec` process from the implementing Claude Code session). The rule preserves this invariant explicitly so a future single-agent setup doesn't degenerate into self-marking.
+
+If a future setup runs everything through one agent, the audit step requires invoking a different model/context boundary explicitly (e.g., a fresh subagent with read-only sandbox + explicit "audit, don't implement" framing).
+
+## Manual fallback when AI auditor unavailable
+
+When Codex / Gemini / equivalent is unavailable (network, quota, outage), do the audit manually AND record evidence in the plan or PR. Required `Manual Audit Evidence` section:
+
+- **Files read** (paths)
+- **Symbols / signatures verified** (which fields/types/enums you confirmed exist)
+- **Edge cases checked** (the list)
+- **Risks accepted** (with rationale)
+- **Tests added or intentionally deferred**
+
+Manual fallback is allowed only when the independent audit tool is genuinely unavailable, not just inconvenient. The audit step is non-negotiable; manual fallback is an evidence-bearing alternative, not a way to skip.
+
+## What this rule does NOT change
+
+- TDD discipline (`10-tdd.md`) is unchanged.
+- Per-PR Codex audit in `/fix-issue` skill is exactly Gate 4 — reference, don't duplicate.
+- Merge gate (fix-or-implement) and close gate (verified, not just merged) are unchanged — this rule names where they fit in the workflow.
+- Bug fix workflow (`docs/bugs.md` `## Rules`) is unchanged — bugs follow Understand → RED → GREEN → REFACTOR → Verify → Track. Bugs do NOT require a separate plan + plan audit (they're reactive); they do require the implementation audit loop and verification gates.
+
+## Worked example
+
+Feature #46 (WebDAV materializing restore, 11 WIs, High priority):
+
+- **Gate 1 (Plan)**: `dev-docs/plans/20260503-feature-46-materializing-restore.md` — drafted v1.
+- **Gate 2 (Plan audit)**: 2 Codex rounds. Round 1 found compile-breaking model assumptions (`Book.originalFilename` doesn't exist), missing `ImportSource.restore`, MOBI handling gap, idempotency hole in `BookImporter`, MOVE 501 silent fallback. Round 2 found `Book.fileExtension` also doesn't exist, weak `BackupBlobStore` signature, weak error shape. Plan v2 incorporates all findings.
+- **Gate 3 (TDD impl)**: 11 WIs sequenced (WI-0a model migration, WI-0b enum case, WI-1 BlobPath, etc.). Each ships its own PR.
+- **Gate 4 (Impl audit)**: per-PR via `/fix-issue` audit loop.
+- **Gate 5 (Verification)**: WI-0a, WI-0b, WI-1, WI-2 = foundational, no device verify. WI-7 (provider integration) = slice verify against Docker WebDAV. WI-10 (UI) = device verify on simulator. Final WI = full acceptance pass (backup → wipe → restore with positions/annotations).
+- **Gate 6 (Merge + close)**: each WI's PR merges through its own gate. Final WI moves feature row to `DONE`. After Gate 5 final acceptance pass: row → `VERIFIED`, GH #144 closes with citation.
+
+# 51 — UI/UX from claude.ai/design only
+
+Binding rule for every agent (Claude, Codex, others). Applies to every feature, bug fix, refactor, and verification slice that introduces a new visible UI element.
+
+## Hard rule
+
+**Do not invent UI/UX.** If a feature, bug fix, or slice needs a UI element on a surface that is NOT depicted in a committed design bundle under `dev-docs/designs/...`, stop that slice and file a `needs-design` GitHub issue. The user manually carries it through `claude.ai/design`, re-handoffs a fresh bundle, and only then does the slice resume.
+
+This applies to:
+
+- New SwiftUI / UIKit views, sheets, modals, popovers, alerts, toasts.
+- New rows, sections, settings entries, buttons, indicators, or empty states within existing screens.
+- New visual states (loading, error, empty, partial, in-progress) when not depicted in the design.
+- "Placeholder" UI introduced with intent to re-skin later — same prohibition.
+- UI affordances introduced by a bug fix (e.g., a new confirmation dialog, a new status chip) — same prohibition.
+- AZW3/Foliate-js / EPUB CSS / WKWebView injection — same prohibition when it changes visible chrome.
+
+## What "designed" means
+
+A surface is **designed** when ALL of the following hold:
+
+1. A committed design bundle exists at `dev-docs/designs/<bundle-name>/`.
+2. The specific surface (screen, sheet, popover, interaction state) is depicted in that bundle's HTML/JSX/screenshots — by name and by visual content.
+3. "Looks similar to existing X" does NOT count. "Inherits the same chrome" does NOT count. The actual surface must appear in the design.
+
+If you cannot point at a file in `dev-docs/designs/` that shows the surface you are about to build, it is **not designed**.
+
+## Workflow
+
+When you reach a slice that would touch undesigned UI:
+
+1. **Stop that slice.** Do not write the View. Do not write a placeholder. Do not improvise.
+2. **File a GitHub issue**:
+   - Title: `Design needed: <surface name> for feature #<N>` (or `for bug #<N>`)
+   - Labels: `enhancement` + `needs-design`
+   - Body must include:
+     - The surface being requested (screen / sheet / state)
+     - The parent feature or bug (`Refs #<N>`)
+     - The user-facing behavior the UI must expose
+     - Screenshots of the current chrome if any
+     - List of states the design must cover (default, loading, error, empty, etc.)
+3. **Pause that slice** in the tracker — add a `BLOCKED: needs-design (#<new-issue>)` note on the WI or bug row.
+4. **Continue parallel slices** that DO have design — see `.claude/rules/48-parallel-execution.md` for safe parallel execution.
+5. **User loop**: the user manually takes the `needs-design` issue through `claude.ai/design`, gets a handoff bundle, and commits it under `dev-docs/designs/...` in a separate PR. The slice can then resume.
+
+## What is NOT covered by this rule
+
+- **System chrome (status bar, home indicator, dynamic island)** — iOS / SwiftUI handles these by default; no design needed.
+- **Pure code changes with no visible delta** — refactors, persistence-only fixes, performance fixes, test-only changes.
+- **Existing-surface bug fixes that restore broken UI back to its designed state** — fixing a typo in a label, fixing a hidden button, etc.
+- **Verification-only artifacts** — XCUITest helpers, DebugBridge surfaces (`vreader-debug://...`), `dev-docs/verification/*` markdown — these are dev-only, never user-visible in Release.
+- **CLI / config / hook / script files** — never user-facing.
+
+## Anti-patterns
+
+| Anti-pattern | Why it fails | Right move |
+|---|---|---|
+| "I'll match the existing chrome for now" | That's self-designed UI. Existing chrome IS the thing being replaced (feature #60). | File `needs-design`. |
+| "Just a placeholder until v2" | Placeholders are committed code that ships in releases. Fragmenting UI for 2-3 versions is worse than pausing. | File `needs-design`. |
+| "It's a small dialog, an Apple HIG default works fine" | HIG defaults look fine in isolation but clash with the specified design system over time. | File `needs-design`. |
+| Inventing UI for a bug-fix toast / status chip / error sheet | Bug fixes don't escape this rule — they can introduce UI debt the same way features do. | File `needs-design`. |
+| Inventing UI in a feature-workflow Gate 3 implementation because the WI list said "small change" | Gate-3 must reference the designed surface; if no design exists for a WI's UI, that WI itself was misclassified in Gate 1 — escalate. | Stop the WI, file `needs-design`, fix the Gate-1 plan. |
+
+## Origin
+
+2026-05-15 user directive after filing feature #60 (visual identity v2 design bundle). The user wants a one-way design loop:
+
+```
+design tool → handoff bundle → commit → implement
+```
+
+and explicitly rejects the round-trip:
+
+```
+agent invents UI → ships → user notices → user redesigns → re-implement
+```
+
+The cost of pausing a slice to file `needs-design` is far below the cost of producing UI debt that has to be re-skinned later. This rule encodes that trade-off.
+
+codex
+The worktree is already dirty with unrelated/user-owned changes, including this untracked plan and an audit artifact; I’ll preserve everything and make no edits. The first command’s architecture output was truncated, so I’m narrowing the reads to the Android architecture section and exact plan/code paths.
+exec
+/bin/zsh -lc "sed -n '1,360p' dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md
+rg -n \"Android|AiProvider|AppContainer|ReaderChromeScaffold|ReaderSheet\" docs/architecture.md
+rg --files android/app/src/main/kotlin android/app/src/test android/app/src/androidTest dev-docs/designs | rg '(AiProvider|AiSettings|VReaderApp|ReaderChromeScaffold|vreader-more\\.jsx|vreader-ai-android\\.jsx|vreader-ai-provider-entry\\.jsx|reader-ai-provider-entry\\.md|reader-ai-readiness\\.md)"'$'"'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+# Gate-1 Plan — Feature #136: AI provider setup made production-reachable (Android)
+
+> Status target: `TODO` → `PLANNED` (on Gate-2 pass)
+> Platform lane: `android-app` (Gate-5 = Android emulator connected run, rule 47 Android tier)
+> Design authority (rule 51, LANDED — no `needs-design`): `vreader-more.jsx` (the reader More-menu `configure-ai` disabled-Bilingual row), `vreader-ai-android.jsx` (`AiProviderList` surface A), `vreader-ai-provider-entry.jsx` + `design-notes/reader-ai-provider-entry.md` + `design-notes/reader-ai-readiness.md` (the in-reader scoped AI-Providers entry decision), `vreader-ai-provider-fields.jsx` (the reused editor).
+
+## 1. Problem
+
+Feature #118 shipped the entire Android AI provider stack — `AiProviderStore` (keystore-encrypted profile persistence, #116 `KeystoreSecretCipher` precedent), `AiSettingsViewModel` (list + editor + Test Connection), `AiProviderListScreen` (the designed "AI Providers" gate surface), and `AiProviderEditSheet` (the canonical add/edit form). It is fully unit- and connected-tested. **But none of it is wired into any production entry.** Grep confirms `AiProviderListScreen`, `AiSettingsViewModel`, and `AiProviderEditSheet` are referenced **only** by `androidTest`/`test` sources; `AiProviderStore` is **never constructed** in `AppContainer` (it appears only in comments as a naming precedent); and `MainActivity` is a single Library Activity that `startActivity`-launches reader hosts — there is **no `NavHost`, no Settings tree, and no More-menu AI row** that reaches the AI screens. `LibraryScreen.kt:95-96` explicitly records that the design's Library settings/More pill "is added when that feature lands (a separate WI) … still omitted."
+
+Consequence: **a fresh install has zero production route to configure an AI provider.** With no provider, every downstream AI feature is dead — bilingual (#131), chat (`AiChatPanel`, also unwired), translate, summaries. This is exactly the Gate-2-round-2 audit High-3 recorded against #131: bilingual's fresh-user path and its Gate-5 acceptance route both dead-end because there is no reachable AI config to land on.
+
+**#136 makes the already-designed, already-built AI provider config production-reachable and independently verifiable**, from a designed in-reader entry that does not depend on #131.
+
+## 2. Surface area
+
+### Designed entry point (the decision)
+
+Two designed reader entries exist; #136 uses the one that is **independent of #131**:
+
+- **`vreader-more.jsx:91-95`** depicts the reader More-menu row: when `s.aiUnavailable`, a **disabled "Bilingual mode" row** with `sub="Configure AI provider first"` whose tap fires `onAction('configure-ai')`. This is the canonical "AI unconfigured → route to config" affordance in the reader chrome, and the Kotlin scaffolding already exists for it: `MoreActionId.BILINGUAL`, `MoreRow.Disabled(id, label, icon, sub, onTap)`, and the `readerMoreRows(...)` assembler in `ReaderChromeScaffold.kt`. The `configure-ai` action → presents the **AI Providers sheet** (`AiProviderListScreen`), matching `reader-ai-provider-entry.md`'s "closes the Library→Settings→AI gap inside the reader" decision (Variant A: a scoped in-reader provider sheet reusing the canonical editor, NOT the full SettingsView).
+
+This entry is reachable by a fresh user (open any book → More → "Configure AI provider first") with **no bilingual wiring present** — which is precisely what independent-verifiability requires. #131 will later ADD the *enabled* Bilingual toggle + its own bilingual-Set-up→here route; #136 owns only the `aiUnavailable`/`configure-ai` path.
+
+### Files MODIFIED
+
+| File | Change (concrete signature) |
+|---|---|
+| `android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt` (`AppContainer`) | Add process-singleton `val aiProviderStore: AiProviderStore by lazy { AiProviderStore(<DataStore under noBackupFilesDir "ai_providers.preferences_pb">, KeystoreSecretCipher(<alias>)) }` (the `readerSettingsStore`/`OpdsSourceStore` DataStore-under-`noBackupFilesDir` + `KeystoreSecretCipher` precedent — keys are per-device, NOT in the backup contract). Add `fun aiSettingsViewModel(): AiSettingsViewModel = AiSettingsViewModel(aiProviderStore)` factory. |
+| `android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeScaffold.kt` (`readerMoreRows`) | Extend the assembler to additively accept the AI-entry callback and emit the designed disabled Bilingual row when AI is unconfigured: `internal fun readerMoreRows(onDetails, onShare, aiUnconfigured: Boolean = false, onConfigureAi: (() -> Unit)? = null): List<MoreRow>` → prepends `MoreRow.Disabled(id = MoreActionId.BILINGUAL, label = "Bilingual mode", icon = Icons.…Translate-analog, sub = "Configure AI provider first", onTap = onConfigureAi ?: {})` **only when `aiUnconfigured && onConfigureAi != null`** (no dead control — #129 rule; absent otherwise). Nullable defaults keep #134/#131 callers valid. Note: `MoreRow.Disabled` is currently non-interactive in `MorePopup.MoreRowItem` (`onClick = {}`); making the `configure-ai` row tappable is a **row-treatment change** — see Risks §6 (the design shows `disabled` + an `on` handler, so the row is dimmed-but-tappable). |
+| `android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeState.kt` (+`…StateSaver`) | Add `ReaderSheet.AiProviders` to the sealed `ReaderSheet` set and to the string saver (round-trips like `Toc`/`Notes`/`Bookmarks`; unknown token → `None`, never throws — the existing saver contract). Survives rotation/process-death. |
+| `android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeScaffold.kt` (host sheet layer) + `android/app/src/main/kotlin/com/vreader/app/reader/EpubReaderChrome.kt` (`EpubReaderSheets`) | Render the `ReaderSheet.AiProviders` route: host the `AiProviderListScreen` + `AiProviderEditSheet` fed by an `AiSettingsViewModel` (obtained via the Activity's `ViewModelStore`, `viewModel(factory = …container.aiSettingsViewModel())` — the `SearchViewModel` precedent in `MainActivity`), wired to `AiSettingsViewModel.openAdd/openEdit/close/update/test/save/delete/setActive` and the `editState`/`listState` flows. Back / Done → `ReaderSheet.None`. |
+| The five reader host Activities that assemble chrome — `ReaderActivity.kt` (EPUB, via `EpubTopBand`/`EpubReaderSheets`) + `TxtReaderActivity.kt`, `PdfReaderActivity.kt`, `Azw3ReaderActivity.kt` (scaffold hosts) | Pass `aiUnconfigured` (derived from `container.aiProviderStore.observe().map { it.profiles.isEmpty() }` collected as state) + `onConfigureAi = { chromeState = …copy(sheet = ReaderSheet.AiProviders) }` into `readerMoreRows(...)` / `EpubTopBand`. This is the one-writer-coordinate additive pattern #132/#134/#135 already use for the chrome files. |
+
+### Files ADDED
+
+| File | Purpose |
+|---|---|
+| `android/app/src/main/kotlin/com/vreader/app/reader/ai/ReaderAiProvidersHost.kt` (new, ~120 lines) | The reader-scoped presentation container: a `@Composable ReaderAiProvidersHost(vm: AiSettingsViewModel, onClose: () -> Unit)` that observes `vm.listState`/`vm.editState` and hosts `AiProviderListScreen` (list/empty) + the `AiProviderEditSheet` modal-on-top (the `reader-ai-provider-entry.md` "list is a push, editor is a modal on top" nav model). **Rule 51: renders ONLY the existing designed surfaces** (`AiProviderListScreen`, `AiProviderEditSheet`) — no new visual chrome. New Kotlin file → lane-dispatchable (Gradle source-set glob). |
+| Tests — see §5. | JVM/Robolectric + connected. |
+
+### Files OUT of scope
+
+- **Provider CRUD internals** — `AiProviderStore.upsert/delete/setActive/apiKey`, `AiSettingsViewModel.test/save`, `AiProviderFactory`, the provider clients, `SseEventReader`, `AiProviderKind`. All shipped and tested by #118; #136 constructs and reaches them, never re-implements them.
+- **The designed surfaces themselves** — `AiProviderListScreen.kt`, `AiProviderEditSheet.kt`, `AiSettingsUiState.kt`. Used verbatim.
+- **The AI-readiness sheet (flag + consent gates)** — `reader-ai-readiness.md`'s `ReaderAIReadinessSheet` (master AI toggle + consent ledger) is **design-landed but implementation-deferred** ("do NOT build without go-ahead"). #136 delivers the provider-list reachability only; the flag/consent capstone is a separate feature.
+- **AI chat panel wiring** — `AiChatPanel`/`AiChatViewModel` are ALSO unwired, but chat's reader entry is #131/a chat feature's surface, not #136.
+- **Bilingual toggle + bilingual Set-up → AI route** — #131 owns the enabled Bilingual `MoreRow.Toggle` and its own route into this same sheet.
+- **A Library-level Settings tree / More pill** (`LibraryScreen.kt:95`) — not built; #136 deliberately does NOT depend on it (see §3 rejected alt).
+- **`contracts/`** — no cross-platform contract change (keys are device-local, excluded from backup).
+
+## 3. Prior art / precedent / rejected alternatives
+
+**Committed design (rule 51 satisfied):**
+- `design-notes/reader-ai-provider-entry.md` — Variant **A** (CANONICAL): "a scoped, in-reader 'AI Providers' sheet … reusing the canonical `AIProviderEditSheet`", chosen over B (deep-link the whole SettingsView) and C (inline mini-form). Its stated win: "Keeps the reader context … the user never sees Cloud & Sync, OPDS, TTS." #136 implements A's Android analog.
+- `design-notes/reader-ai-readiness.md` — the same "close the loop **inside the reader**" decision, naming this the surface "every 'AI unconfigured' silent-no-op should route to."
+- `vreader-more.jsx:91-95` — the exact reader-chrome affordance: `aiUnavailable` → disabled Bilingual row `sub="Configure AI provider first"` → `onAction('configure-ai')`.
+- `vreader-ai-android.jsx` `AiProviderList` (surface A, "the gate for everything") — already implemented verbatim as `AiProviderListScreen.kt` (its header comment cites this).
+
+**Project precedent for the wiring shape:**
+- **#118** built the whole stack; **#116** `KeystoreSecretCipher` + `WebDavServerStore`/`OpdsSourceStore` established the "DataStore-under-`noBackupFilesDir` + keystore cipher, constructed once in `AppContainer`" pattern this plan follows for `aiProviderStore`.
+- **#129/#132/#134/#135** wired every reader-chrome entry through the exact seams #136 reuses: the `readerMoreRows` assembler, `ReaderChromeState`/`ReaderSheet` + its saver, the `EpubReaderSheets` open-only sheet layer, and the additive-nullable-param "one-writer-coordinate" convention. #134 added Details/Share rows; #136 adds the `configure-ai` row by the same contract.
+- **`MainActivity` `SearchViewModel`** precedent — obtaining a container-built ViewModel via `viewModel(factory = viewModelFactory { initializer { container.searchViewModel() } })` so its `viewModelScope` is cleared on Activity destroy. `aiSettingsViewModel()` follows this exactly.
+
+**Rejected alternatives:**
+1. **Library Settings tree / More pill entry (`LibraryScreen.kt:95`).** Rejected: that Settings tree does not exist on Android, and `OpdsSourcesViewModel`/`OpdsSourceStore` are *also* still test-only — building the whole Library Settings host is a large, separate feature. The design's own decision (both notes) is the in-reader scoped entry.
+2. **Route only from #131's bilingual Set-up.** Rejected by independent-verifiability: it would couple #136 to #131 (still `PLANNED`) and make AI config unreachable until bilingual ships. The `aiUnavailable`/`configure-ai` More-row is reachable with zero bilingual wiring.
+3. **Deep-link the full SettingsView (Variant B) / inline mini-form (Variant C).** Rejected by the design notes themselves.
+4. **Build the deferred AI-readiness sheet (flag+consent) now.** Rejected: `reader-ai-readiness.md` marks it "implementation deferred — do NOT build without go-ahead."
+
+## 4. Work-item sequencing (small feature — 3 WIs)
+
+**WI-1 — `AppContainer` AI store + VM factory (FOUNDATIONAL).**
+Construct `aiProviderStore` (DataStore under `noBackupFilesDir` + `KeystoreSecretCipher`) and `aiSettingsViewModel()` in `AppContainer`. No user-observable behavior → unit tests + audit suffice (Gate-5 foundational tier, no device verify). *PR size: XS.* Lane-dispatchable (edits one existing file + new test).
+
+**WI-2 — `ReaderAiProvidersHost` + `ReaderSheet.AiProviders` route (BEHAVIORAL).**
+Add the new `ReaderAiProvidersHost.kt` (hosts `AiProviderListScreen` + `AiProviderEditSheet` over the VM), the `ReaderSheet.AiProviders` sealed case + saver round-trip, and render it in the scaffold sheet layer + `EpubReaderSheets`. *PR size: S.* Connected Compose slice: open route → empty state → Add → editor → Save → list shows provider → back.
+
+**WI-3 — reader More-menu `configure-ai` entry across all five hosts (BEHAVIORAL, FINAL WI).**
+Extend `readerMoreRows` with the `aiUnconfigured`/`onConfigureAi` params emitting the designed disabled-Bilingual row, and wire `aiUnconfigured` (from `aiProviderStore.observe()`) + `onConfigureAi` (opens `ReaderSheet.AiProviders`) in the four host Activities + `EpubTopBand`. *PR size: M.* Closes the feature → full Gate-5 acceptance (the reachable end-to-end flow on emulator).
+
+> Sequencing: WI-1 is a pure foundation WI-2 depends on; WI-2 makes the destination renderable + independently testable *before* any entry exists; WI-3 lights the entry across hosts. Each is one PR.
+
+## 5. Test catalogue
+
+**JVM / Robolectric (`app/src/test`):**
+- `AppContainerAiWiringTest.kt` (new) — `aiProviderStore` is a stable singleton; `aiSettingsViewModel()` returns a VM whose `listState` reflects the store (empty fresh, non-empty after `upsert`). Guards WI-1.
+- Extend `ReaderChromeStateSaverTest.kt` — `ReaderSheet.AiProviders` round-trips; unknown/garbage token → `None` (never throws). Guards WI-2 process-death.
+- `ReaderMoreRowsAiEntryTest.kt` (new, JVM/pure) — `readerMoreRows(aiUnconfigured = true, onConfigureAi = {…})` includes exactly one `MoreRow.Disabled`/`configure-ai` row with the designed label + sub; `aiUnconfigured = false` OR `onConfigureAi = null` omits it (no dead control). Guards WI-3.
+
+**Connected Compose (`app/src/androidTest`) — the #132/#134/#135 pattern; the connected run IS the Gate-5 acceptance:**
+- Reuse existing `AiProviderListScreenTest`/`AiProviderEditSheetTest`/`AiRoundTripConnectedTest` (unchanged — surfaces verbatim).
+- `ReaderAiProvidersHostConnectedTest.kt` (new) — drives `ReaderAiProvidersHost` over a real `AiSettingsViewModel`+`AiProviderStore`: empty state (`ai-add-provider`) → Add → `AiProviderEditSheet` (`ai-save`) → save → list shows `provider-<id>` → back → `ReaderSheet.None`.
+- `ReaderMoreAiEntryConnectedTest.kt` (new) — the **reachability acceptance**: launch a reader host on a fresh (no-provider) store → open More → "Configure AI provider first" row present + tappable → tap → `AiProviderListScreen` empty state → add a provider → return → re-open More → the `configure-ai` row is now **absent**. The "fresh user can reach AI config, add a provider, and return" acceptance, independent of #131.
+
+**Audit-driven additions:** corrupt/partial DataStore token (saver → `None`); process-death mid-editor (route restores, editor state transient by design); a provider deleted while the sheet is open (list re-derives from the store Flow).
+
+## 6. Risks + mitigations
+
+- **Coupling with #131.** Mitigation: the entry is the `aiUnavailable`/`configure-ai` More-row, reachable with zero bilingual code; #131 separately adds the *enabled* Bilingual toggle + its Set-up→here route. `readerMoreRows` params additive-nullable so #131's later change is one-writer-coordinate.
+- **`MoreRow.Disabled` is currently non-interactive.** `MorePopup.MoreRowItem` renders `Disabled` with `onClick = {}`. The design (`vreader-more.jsx:94-95`) shows the row `disabled` AND `on={() => onAction('configure-ai')}` — dimmed but tappable. Mitigation: WI-3 makes the `Disabled` row's `onTap` fire (a small `MorePopup` change), matching the design; covered by `ReaderMoreAiEntryConnectedTest`. Restore-to-designed-state, rule-51-clean.
+- **AI-key security surface (#118).** Mitigation: #136 constructs `AiProviderStore` with `KeystoreSecretCipher` under `noBackupFilesDir` (the #116 contract) and touches NO CRUD/crypto path. Keys stay device-local; no `contracts/` change.
+- **Config-change / process-death.** Mitigation: `ReaderSheet.AiProviders` is in the `rememberSaveable` saver (rotation/death safe); the editor's transient form re-opens empty by design; the VM is Activity-`ViewModelStore`-owned (`SearchViewModel` precedent), scope cleared on destroy.
+- **Five-host fan-out.** Mitigation: EPUB routes through `EpubTopBand`/`EpubReaderSheets`; the other three through the shared `ReaderChromeScaffold` — the split #134 already validated. One connected test per family confirms parity.
+
+## 7. Backward compatibility
+
+- **Fresh install, no providers (the designed onboarding state).** `aiProviderStore.observe()` → `profiles.isEmpty()` → the More-menu "Configure AI provider first" row → tapping lands on `AiProviderListScreen`'s empty state. No crash, no dead control before a provider exists.
+- **Existing DEBUG-configured provider.** `profiles.isNotEmpty()` → the `configure-ai` row is **absent** from More (AI available); the store schema unchanged (#118 JSON-in-DataStore); no migration.
+- **Older reader-chrome state tokens.** Unknown-token → `None` means a persisted pre-#136 `ReaderChromeState` restores cleanly.
+- **No `contracts/` / backup-format impact** — keys device-local, excluded from the backup contract.
+
+## Dependency statement (binding)
+
+**#136 is a HARD dependency of #131.** #131's fresh-user AI-config path + its Gate-5 acceptance route both require a reachable AI provider config to land on; that destination is delivered by #136. #131 must not re-implement or inline provider config — it consumes #136's `ReaderSheet.AiProviders` sheet. **#131's bilingual-Set-up → #136 route (the enabled Bilingual `MoreRow.Toggle` + its "Set up"→AI-Providers navigation) is #131's OWN WI, not #136's** — #136 delivers only the independent `aiUnavailable`/`configure-ai` More-menu entry, so AI config is reachable + verifiable before #131 exists.
+
+## Revision history
+
+- v1 (2026-07-12) — Gate-1 draft. Authored to resolve #131 Gate-2-round-2 High-3 (AI-config unreachable): the #118 AI provider stack is production-reachable via the designed reader More-menu `configure-ai` entry (Variant A in-reader AI-Providers sheet). 3 WIs. Spun out per the orchestrator/user decision (2026-07-12) that AI-settings navigation is its own tiny feature + a hard dependency of #131.
+112:The app sheets share `ReaderSheetChrome.swift` — a reusable wrapper matching the design's `Sheet` component: a theme-tinted surface (`ReaderThemeV2.sheetSurfaceColor`), an optional centred Source Serif 4 title bar with 50pt leading/trailing slots (a default circular close button fills the trailing slot when an `onClose` is given and no custom trailing view is), and a scrollable body. The slide-up animation + drag grabber come from SwiftUI's own `.sheet` + `.presentationDragIndicator(.visible)`; `ReaderSheetChrome` supplies only the title bar + surface tint. It wraps the Display sheet (`ReaderSettingsPanel`), the two annotations sheets (`TOCSheet` + `HighlightsSheet`, feature #62 — see below), the reader Book Details sheet (`BookDetailsSheet`, feature #61 — opened from More → Book details, with a trailing Share button in place of the default close), and the AI sheet (`AIReaderPanel`, `title: nil` + a custom sparkle header). `SettingsView` (App Settings) keeps an inner `NavigationStack` for its `NavigationLink` push destinations, with `ReaderSheetChrome` above it. The per-sheet section contract is pinned in `SheetSectionContract.swift` (`ReaderSheetKind`). Reader sheets pass the book's `ReaderThemeV2`; the App Settings sheet uses `.paper` (the Library is not theme-switchable).
+512:## Android App (`android/` — feature #106 foundation bar)
+514:vreader's Android app is a **second, independently-shippable native app**
+535:| `:app` | Android application | Compose UI shell + the Room data layer + reader plumbing. `com.vreader.app`. |
+536:| `:identity` | pure Kotlin/JVM (no Android deps) | The shared canonical contracts — `Identity` (fingerprint canonical key), `CanonicalLocator` (engine-neutral canonical JSON), `DocumentFingerprint` (streaming SHA-256 + format detection), and the `Locator` / `VReaderLocator` / `ReaderLocatorEngine` value types. **Both `:app` AND the `contracts/conformance` lane depend on this one module**, so the golden-vector conformance test proves the SAME code the app runs. |
+604:<sha>_<bytes>.<canonicalExt>` = content-addressed blob store), so an Android
+612:| `net.SecretCipher` / `KeystoreSecretCipher` | AndroidKeyStore | AES-256-GCM (fresh IV, non-exportable key) for the password at rest — the EncryptedSharedPreferences replacement. |
+647:| `AiProviderKind` | `openAiCompatible` / `anthropicNative` + default base URL/model + appended endpoint path (`@SerialName` = iOS raw values). |
+648:| `AiProviderStore` | DataStore JSON list of provider profiles + an active-id; API key kept ONLY as a `KeystoreSecretCipher` token. Snapshot-consistent `apiKey(profile)`. |
+652:| `AiSettingsViewModel` + `AiProviderListScreen`/`AiProviderEditSheet` | The provider gate + the `EditorSheet` (test-connection against the live form). |
+667:| `AnnotationColor` | The 5 design colors (yellow/green/blue/pink/red — design parity; iOS has 4, `red` is Android-only). |
+669:| `AnnotationsRepository` | DTO boundary over `AnnotationDao`: CRUD + Flow reads; `addHighlight` dedupes via the transactional upsert and returns the PERSISTED row; rejects a locator whose `fingerprintKey` ≠ the book. Process-singleton in `AppContainer`. |
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx
+dev-docs/designs/vreader-fidelity-v1/project/vreader-more.jsx
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-android.jsx
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-readiness.md
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md
+
+exec
+/bin/zsh -lc "rg --files android/app/src/main/kotlin | rg 'AiProvider|AiSettings|VReaderApp|ReaderChrome|ReaderActivity|EpubReaderChrome|TxtReaderActivity|PdfReaderActivity|Azw3ReaderActivity|MainActivity|LibraryScreen|SecretCipher|SourceStore'
+rg -n \"class AiProviderStore|interface AiProviderStore|typealias AiProviderStore|class AiSettingsViewModel|fun AiProviderListScreen|fun AiProviderEditSheet|class AppContainer|object AppContainer|data class AppContainer|AiProviderStore\\(|AiProviderListScreen\\(|AiSettingsViewModel\\(|AiProviderEditSheet\\(\" android/app/src/main android/app/src/test android/app/src/androidTest" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+android/app/src/main/kotlin/com/vreader/app/backup/net/SecretCipher.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderFactory.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsUiState.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderKind.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt
+android/app/src/main/kotlin/com/vreader/app/MainActivity.kt
+android/app/src/main/kotlin/com/vreader/app/opds/OpdsSourceStore.kt
+android/app/src/main/kotlin/com/vreader/app/library/LibraryScreen.kt
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt
+android/app/src/main/kotlin/com/vreader/app/reader/EpubReaderChrome.kt
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderChromeModel.kt
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeState.kt
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeScaffold.kt
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:46:fun AiProviderListScreen(
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:41:class AiProviderStore(
+android/app/src/test/kotlin/com/vreader/app/ai/AiChatViewModelTest.kt:48:        store = AiProviderStore(PreferenceDataStoreFactory.create(scope = CoroutineScope(dispatcher)) { tmp.newFile("ai.preferences_pb") }, cipher)
+android/app/src/test/kotlin/com/vreader/app/ai/AiProviderStoreTest.kt:26:class AiProviderStoreTest {
+android/app/src/test/kotlin/com/vreader/app/ai/AiProviderStoreTest.kt:39:        store = AiProviderStore(dataStore, fakeCipher)
+android/app/src/test/kotlin/com/vreader/app/ai/AiSettingsViewModelTest.kt:29:class AiSettingsViewModelTest {
+android/app/src/test/kotlin/com/vreader/app/ai/AiSettingsViewModelTest.kt:48:        store = AiProviderStore(
+android/app/src/test/kotlin/com/vreader/app/ai/AiSettingsViewModelTest.kt:57:        AiSettingsViewModel(store, dispatcher) { _, _ -> FakeClient(result) }
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:20:class AiSettingsViewModel(
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt:55:fun AiProviderEditSheet(
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:31:class AppContainer(context: Context) {
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderEditSheetTest.kt:25:        compose.setContent { BackupSurface(darkOverride = false) { AiProviderEditSheet(AiEditState(editMode = false)) } }
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderEditSheetTest.kt:38:        compose.setContent { BackupSurface(darkOverride = false) { AiProviderEditSheet(AiEditState(), onKind = { picked = it }) } }
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderEditSheetTest.kt:44:        compose.setContent { BackupSurface(darkOverride = false) { AiProviderEditSheet(AiEditState(apiKey = "")) } }
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderEditSheetTest.kt:51:                AiProviderEditSheet(AiEditState(apiKey = "sk", test = AiConnTest.ok, testMessage = "Connected — the provider responded successfully."))
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderEditSheetTest.kt:60:                AiProviderEditSheet(AiEditState(editMode = true, id = "x", name = "DeepSeek", keyAlreadySaved = true))
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderListScreenTest.kt:23:            BackupSurface(darkOverride = false) { AiProviderListScreen(AiProviderListState(emptyList()), onAdd = { added = true }) }
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderListScreenTest.kt:38:        compose.setContent { BackupSurface(darkOverride = false) { AiProviderListScreen(state, onEdit = { edited = it }) } }
+
+exec
+/bin/zsh -lc "nl -ba android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt | sed -n '1,240p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt | sed -n '1,280p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt | sed -n '1,300p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt | sed -n '1,240p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt | sed -n '1,280p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+     1	// Purpose: Application + manual DI container — feature #106 WI-8. Holds the
+     2	// process-singleton Room database, repository, and importer so the Library
+     3	// ViewModel gets shared instances (a Hilt module is a Phase-3 follow-on; manual
+     4	// wiring at the app edge keeps the foundation bar dependency-light — rule 50 §5).
+     5	package com.vreader.app
+     6	
+     7	import android.app.Application
+     8	import android.content.Context
+     9	import com.vreader.app.data.BookImporter
+    10	import com.vreader.app.data.LibraryRepository
+    11	import com.vreader.app.data.VReaderDatabase
+    12	import com.vreader.app.reader.BookOpener
+    13	import com.vreader.app.search.BookTextExtractor
+    14	import com.vreader.app.search.EpubTextExtractor
+    15	import com.vreader.app.search.asSearcher
+    16	import com.vreader.app.search.SearchIndexCoordinator
+    17	import com.vreader.app.search.TxtMdTextExtractor
+    18	import com.vreader.app.annotations.AnnotationsRepository
+    19	import com.vreader.app.stats.ReadingStatsRepository
+    20	import com.vreader.app.stats.ReadingTimeTracker
+    21	import com.vreader.app.stats.clock.SystemDateClock
+    22	import com.vreader.app.stats.clock.SystemElapsedClock
+    23	import kotlinx.coroutines.CoroutineScope
+    24	import kotlinx.coroutines.Dispatchers
+    25	import kotlinx.coroutines.SupervisorJob
+    26	import kotlinx.coroutines.flow.map
+    27	import vreader.contracts.BookFormat
+    28	import java.io.File
+    29	
+    30	/** Process-wide singletons, lazily built. */
+    31	class AppContainer(context: Context) {
+    32	    private val appContext = context.applicationContext
+    33	
+    34	    val database: VReaderDatabase by lazy { VReaderDatabase.build(appContext) }
+    35	    val repository: LibraryRepository by lazy {
+    36	        LibraryRepository(database.bookDao(), database.readingPositionDao())
+    37	    }
+    38	    val importer: BookImporter by lazy {
+    39	        BookImporter(File(appContext.filesDir, "books"), repository)
+    40	    }
+    41	
+    42	    // feature #122 — reading-stats. The repository + the time tracker are process-singletons so a
+    43	    // reading session survives the (shorter-lived) reader ViewModel / rotation. ONE shared DateClock
+    44	    // so the dashboard's "today" and the tracker's bucket dates can't drift apart.
+    45	    private val dateClock: SystemDateClock by lazy { SystemDateClock() }
+    46	    val statsRepository: ReadingStatsRepository by lazy {
+    47	        ReadingStatsRepository(database.readingStatsDao(), repository, dateClock)
+    48	    }
+    49	    val readingTimeTracker: ReadingTimeTracker by lazy {
+    50	        ReadingTimeTracker(statsRepository, SystemElapsedClock(), dateClock)
+    51	    }
+    52	
+    53	    // feature #123 — annotations (EPUB highlights & notes). Process-singleton so the reader VM /
+    54	    // rotation share one instance (the statsRepository precedent).
+    55	    val annotationsRepository: AnnotationsRepository by lazy {
+    56	        AnnotationsRepository(database.annotationDao())
+    57	    }
+    58	
+    59	    // feature #127 — library collections. Process-singleton (the annotationsRepository precedent).
+    60	    val collectionRepository: com.vreader.app.data.CollectionRepository by lazy {
+    61	        com.vreader.app.data.CollectionRepository(database.collectionDao())
+    62	    }
+    63	
+    64	    // feature #129 — reader display settings. A device-local DataStore (the OpdsSourceStore /
+    65	    // AiProviderStore precedent), global (not per-book), process-singleton so a settings change
+    66	    // propagates to whatever reader is open. Stored under noBackupFilesDir — display prefs are
+    67	    // per-device (NOT in the backup contract), so they must be excluded from Android Auto Backup.
+    68	    private val readerSettingsDataStore: androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences> by lazy {
+    69	        androidx.datastore.preferences.core.PreferenceDataStoreFactory.create {
+    70	            File(appContext.noBackupFilesDir, "reader_settings.preferences_pb")
+    71	        }
+    72	    }
+    73	    val readerSettingsStore: com.vreader.app.reader.settings.ReaderSettingsStore by lazy {
+    74	        com.vreader.app.reader.settings.ReaderSettingsStore(readerSettingsDataStore)
+    75	    }
+    76	
+    77	    /** Process-lifetime scope for fire-and-forget writes that must outlive a screen
+    78	     *  (e.g. the reader's onStop position flush — it must finish even as the activity
+    79	     *  is being torn down). */
+    80	    val appScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    81	
+    82	    // feature #128 WI-5 — cross-book search index. The coordinator observes the library and
+    83	    // streams each indexable book (epub/txt/md) through the WI-3 extractors into WI-4's staging →
+    84	    // atomic publish. Eagerly started once from onCreate; pdf/azw3 map to null (never indexable).
+    85	    private val bookOpener: BookOpener by lazy { BookOpener(appContext) }
+    86	    private val epubTextExtractor: EpubTextExtractor by lazy { EpubTextExtractor(bookOpener) }
+    87	    private val txtMdTextExtractor: TxtMdTextExtractor by lazy { TxtMdTextExtractor() }
+    88	    val searchIndexCoordinator: SearchIndexCoordinator by lazy {
+    89	        SearchIndexCoordinator(
+    90	            repository = repository,
+    91	            searchDao = database.searchDao(),
+    92	            extractorFor = { fmt: BookFormat ->
+    93	                when (fmt) {
+    94	                    BookFormat.epub -> epubTextExtractor
+    95	                    BookFormat.txt, BookFormat.md -> txtMdTextExtractor
+    96	                    BookFormat.pdf, BookFormat.azw3 -> null   // metadata-only — never indexed
+    97	                }
+    98	            },
+    99	            scope = appScope,
+   100	            ioDispatcher = Dispatchers.IO,
+   101	        )
+   102	    }
+   103	
+   104	    /** Idempotent — starts the single search-index collector (the coordinator's own AtomicBoolean
+   105	     *  makes a repeat call a no-op). Called once from [VReaderApp.onCreate]. */
+   106	    fun startSearchIndexing() = searchIndexCoordinator.startSearchIndexing()
+   107	
+   108	    // feature #128 WI-6 — the query pipeline. SearchRepository turns a raw query into an observable
+   109	    // Flow of first-hit-per-book text hits (grows as indexing completes); RecentSearchesStore is a
+   110	    // device-local DataStore under noBackupFilesDir (the readerSettingsStore precedent — recents are
+   111	    // per-device, NOT in the backup contract). The SearchViewModel factory wires the metadata filter,
+   112	    // the text-hit Flow, the completeness gate, and recent-recording for the WI-7 screen.
+   113	    val searchRepository: com.vreader.app.search.SearchRepository by lazy {
+   114	        com.vreader.app.search.SearchRepository(database.searchDao())
+   115	    }
+   116	    private val recentSearchesDataStore: androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences> by lazy {
+   117	        androidx.datastore.preferences.core.PreferenceDataStoreFactory.create {
+   118	            File(appContext.noBackupFilesDir, "recent_searches.preferences_pb")
+   119	        }
+   120	    }
+   121	    val recentSearchesStore: com.vreader.app.search.RecentSearchesStore by lazy {
+   122	        com.vreader.app.search.RecentSearchesStore(recentSearchesDataStore)
+   123	    }
+   124	
+   125	    /**
+   126	     * feature #133 WI-10 — the per-reader-session in-book-search ViewModel for a TXT/MD host. Wires the
+   127	     * WI-6 [InBookSearchRepository] (FTS DAO page/count/resume + the WI-4 [TxtMdInBookHitResolver] over the
+   128	     * already-decoded [decodedText]) behind the WI-8 [InBookSearchViewModel], gated by the WI-7
+   129	     * [IndexStateGate] over the DAO's `observeIndexState` Flow and fed the GLOBAL recents store.
+   130	     *
+   131	     * The EPUB engine seam is NEVER invoked for a TXT/MD host (the repository dispatches only the TXT/MD
+   132	     * branch for `txt`/`md`), so `epubEngineFor` is an error-throwing guard — a call would be a wiring bug.
+   133	     * ONE [InBookSearchRepository] per session (the VM's `closeAllEpubCursors` lifecycle contract holds
+   134	     * uniformly even though TXT has no cursors). [coroutineScope] is the VM's `viewModelScope` in production
+   135	     * (the VM cancels its child collectors on `onCleared`).
+   136	     */
+   137	    fun inBookSearchViewModel(
+   138	        bookKey: String,
+   139	        format: BookFormat,
+   140	        decodedText: String,
+   141	        contentSHA256: String,
+   142	        fileByteCount: Long,
+   143	        coroutineScope: CoroutineScope,
+   144	    ): com.vreader.app.search.InBookSearchViewModel {
+   145	        val searchDao = database.searchDao()
+   146	        val repository = com.vreader.app.search.InBookSearchRepository(
+   147	            dispatcher = Dispatchers.Default,
+   148	            fts = com.vreader.app.search.InBookFtsDeps(
+   149	                matchingChunksPage = { ftsQuery, afterSectionIndex, afterChunkOrdinal, afterId, limit ->
+   150	                    searchDao.matchingChunksPage(bookKey, ftsQuery, afterSectionIndex, afterChunkOrdinal, afterId, limit)
+   151	                },
+   152	                chunkAtOrAfter = { ftsQuery, atSectionIndex, atChunkOrdinal, atId ->
+   153	                    searchDao.chunkAtOrAfter(bookKey, ftsQuery, atSectionIndex, atChunkOrdinal, atId)
+   154	                },
+   155	                // The resolver re-derives the chunk boundaries from the ALREADY-decoded reader text (no I/O);
+   156	                // memoized per session inside the resolver (built once).
+   157	                resolverFor = {
+   158	                    com.vreader.app.search.TxtMdInBookHitResolver(
+   159	                        contentSHA256 = contentSHA256,
+   160	                        fileByteCount = fileByteCount,
+   161	                        format = format.name,
+   162	                        decodedText = decodedText,
+   163	                    )
+   164	                },
+   165	            ),
+   166	            // TXT/MD never reaches the EPUB branch — a call here is a dispatch bug, fail fast.
+   167	            epubEngineFor = { error("EPUB in-book search engine requested on a TXT/MD host") },
+   168	        )
+   169	        return com.vreader.app.search.InBookSearchViewModel(
+   170	            bookKey = bookKey,
+   171	            format = format,
+   172	            searcher = repository.asSearcher(),
+   173	            indexStateGate = com.vreader.app.search.IndexStateGate(Dispatchers.Default),
+   174	            indexStateFlow = searchDao.observeIndexState(bookKey),
+   175	            // For a settled-`indexed` TXT/MD row the gate consults this to decide Ready vs definitive
+   176	            // NoResults. `hasOccurrence` carries no query, so we report Ready (true) and let the actual
+   177	            // `page(...)` be the source of truth: a settled book with zero matches runs one fast FTS query
+   178	            // and the repository returns NoResults — the SAME UI outcome the gate's occurrence short-circuit
+   179	            // would give, without threading the live query through a shared mutable seam (no race). The gate
+   180	            // is only consulted on a settled-indexed row, so this never fires while Indexing/missing/failed.
+   181	            hasOccurrence = { true },
+   182	            recentsFlow = recentSearchesStore.recents(),
+   183	            recordQuery = { q -> recentSearchesStore.record(q) },
+   184	            dispatcher = Dispatchers.Default,
+   185	            coroutineScope = coroutineScope,
+   186	        )
+   187	    }
+   188	
+   189	    /**
+   190	     * feature #133 WI-11 — the per-reader-session in-book-search ViewModel for the EPUB host. EPUB search does
+   191	     * NOT use the #128 FTS index at all (a chunk-level, location-less index cannot yield a jumpable position);
+   192	     * instead the WI-6 [InBookSearchRepository]'s EPUB branch runs Readium's OWN `SearchService` over the LIVE
+   193	     * [publication] via the WI-5 [EpubInBookSearchEngine] production constructor (which wraps the real
+   194	     * publication behind the `PublicationSearchSource` seam), returning navigable Readium `Locator`s the host
+   195	     * jumps to with `navigator.go`.
+   196	     *
+   197	     * EPUB bypasses the WI-7 index-state gate entirely: the [indexStateFlow] emits `null` (missing) and
+   198	     * [hasOccurrence] reports Ready, so the gate resolves to Ready and the engine's own `isSearchable` probe
+   199	     * is the real capability check (an un-searchable publication → the repository's [InBookSearchOutcome.Unsupported]
+   200	     * → the WI-8 VM's `hidesSearchEntry`, so the host omits the Search icon). The TXT/MD FTS branch is NEVER
+   201	     * invoked for an EPUB host, so its factories are error-throwing guards (a call would be a wiring bug).
+   202	     *
+   203	     * ONE [InBookSearchRepository] per session (so the live Readium `SearchIterator` behind
+   204	     * `SearchCursor.Epub` is held once and disposed via `closeAllEpubCursors` on dismiss / `onCleared`).
+   205	     * [coroutineScope] is the host's `lifecycleScope` in production (the VM cancels its child collectors on
+   206	     * `onCleared`).
+   207	     */
+   208	    fun epubInBookSearchViewModel(
+   209	        bookKey: String,
+   210	        publication: org.readium.r2.shared.publication.Publication,
+   211	        coroutineScope: CoroutineScope,
+   212	    ): com.vreader.app.search.InBookSearchViewModel {
+   213	        val repository = com.vreader.app.search.InBookSearchRepository(
+   214	            dispatcher = Dispatchers.Default,
+   215	            // The EPUB host never reaches the FTS branch (the repository dispatches only the EPUB branch for
+   216	            // `epub`), so the TXT/MD deps are error-throwing guards — a call here is a wiring bug, fail fast.
+   217	            fts = com.vreader.app.search.InBookFtsDeps(
+   218	                matchingChunksPage = { _, _, _, _, _ -> error("FTS matchingChunksPage requested on an EPUB host") },
+   219	                chunkAtOrAfter = { _, _, _, _ -> error("FTS chunkAtOrAfter requested on an EPUB host") },
+   220	                resolverFor = { error("FTS resolver requested on an EPUB host") },
+   221	            ),
+   222	            // The LIVE wiring: build the WI-5 engine over the real Readium publication (its production
+   223	            // constructor wraps the publication behind the `PublicationSearchSource` seam). One engine per
+   224	            // repository/session; the repository memoizes it per bookKey.
+   225	            epubEngineFor = { com.vreader.app.search.EpubInBookSearchEngine(publication) },
+   226	        )
+   227	        return com.vreader.app.search.InBookSearchViewModel(
+   228	            bookKey = bookKey,
+   229	            format = BookFormat.epub,
+   230	            searcher = repository.asSearcher(),
+   231	            indexStateGate = com.vreader.app.search.IndexStateGate(Dispatchers.Default),
+   232	            // EPUB bypasses the FTS index-state gate: a `null` (missing) row + `hasOccurrence == true` resolve
+   233	            // the gate to Ready, so the engine's own `isSearchable` probe is the capability check.
+   234	            indexStateFlow = kotlinx.coroutines.flow.flowOf(null),
+   235	            hasOccurrence = { true },
+   236	            recentsFlow = recentSearchesStore.recents(),
+   237	            recordQuery = { q -> recentSearchesStore.record(q) },
+   238	            dispatcher = Dispatchers.Default,
+   239	            coroutineScope = coroutineScope,
+   240	        )
+     1	// Purpose: feature #118 WI-1 (#110 Phase 3) — persists saved AI provider profiles + the active
+     2	// selection. Profile metadata (name/kind/baseUrl/model/temperature/maxTokens) lives in DataStore
+     3	// as a JSON list; the API key is kept ONLY as a SecretCipher token (the #116 KeystoreSecretCipher).
+     4	// Reuses the #116 WebDavServerStore DataStore+SecretCipher credential pattern, adding an active-id
+     5	// and a request-start `snapshot()` (a chat/test reads one consistent profile, not live mid-request
+     6	// store reads). The key + auth headers are NEVER logged.
+     7	package com.vreader.app.ai
+     8	
+     9	import androidx.datastore.core.DataStore
+    10	import androidx.datastore.preferences.core.Preferences
+    11	import androidx.datastore.preferences.core.edit
+    12	import androidx.datastore.preferences.core.stringPreferencesKey
+    13	import com.vreader.app.backup.net.SecretCipher
+    14	import kotlinx.coroutines.flow.Flow
+    15	import kotlinx.coroutines.flow.first
+    16	import kotlinx.coroutines.flow.map
+    17	import kotlinx.serialization.Serializable
+    18	import kotlinx.serialization.json.Json
+    19	
+    20	/** A saved AI provider. `encryptedApiKey` is a [SecretCipher] token, never plaintext. */
+    21	@Serializable
+    22	data class AiProviderProfile(
+    23	    val id: String,
+    24	    val name: String,
+    25	    val kind: AiProviderKind,
+    26	    val baseUrl: String,
+    27	    val model: String,
+    28	    val temperature: Double = 0.7,
+    29	    val maxTokens: Int = 2048,
+    30	    val encryptedApiKey: String,
+    31	)
+    32	
+    33	/** A consistent point-in-time view: the profiles + which is active. */
+    34	data class AiProviderSnapshot(val profiles: List<AiProviderProfile>, val activeId: String?) {
+    35	    val active: AiProviderProfile? get() = profiles.firstOrNull { it.id == activeId }
+    36	}
+    37	
+    38	@Serializable
+    39	private data class AiStoreState(val profiles: List<AiProviderProfile> = emptyList(), val activeId: String? = null)
+    40	
+    41	class AiProviderStore(
+    42	    private val dataStore: DataStore<Preferences>,
+    43	    private val cipher: SecretCipher,
+    44	    private val json: Json = Json { ignoreUnknownKeys = true; encodeDefaults = true },
+    45	) {
+    46	    /** One consistent profiles + active-id view (read once at request start). */
+    47	    suspend fun snapshot(): AiProviderSnapshot = read(dataStore.data.first()).toSnapshot()
+    48	
+    49	    fun observe(): Flow<AiProviderSnapshot> = dataStore.data.map { read(it).toSnapshot() }
+    50	
+    51	    suspend fun list(): List<AiProviderProfile> = snapshot().profiles
+    52	
+    53	    suspend fun activeProfile(): AiProviderProfile? = snapshot().active
+    54	
+    55	    /**
+    56	     * Insert/update a profile by [id]. [apiKey] is the PLAINTEXT to encrypt; pass null on an edit
+    57	     * that leaves the key unchanged (the existing ciphertext is kept). A brand-new id REQUIRES a
+    58	     * key. The first profile added becomes active. Returns the saved profile (key encrypted).
+    59	     */
+    60	    suspend fun upsert(
+    61	        id: String,
+    62	        name: String,
+    63	        kind: AiProviderKind,
+    64	        baseUrl: String,
+    65	        model: String,
+    66	        temperature: Double,
+    67	        maxTokens: Int,
+    68	        apiKey: String?,
+    69	    ): AiProviderProfile {
+    70	        lateinit var saved: AiProviderProfile
+    71	        dataStore.edit { prefs ->
+    72	            val cur = read(prefs)
+    73	            val existing = cur.profiles.firstOrNull { it.id == id }
+    74	            val encrypted = when {
+    75	                apiKey != null -> cipher.encrypt(apiKey)
+    76	                existing != null -> existing.encryptedApiKey  // unchanged on edit
+    77	                else -> throw IllegalArgumentException("a new provider ($id) requires an API key")
+    78	            }
+    79	            saved = AiProviderProfile(id, name, kind, baseUrl, model, temperature, maxTokens, encrypted)
+    80	            val next = cur.profiles.filterNot { it.id == id } + saved
+    81	            val activeId = cur.activeId ?: id  // first provider becomes active
+    82	            prefs[KEY] = json.encodeToString(AiStoreState(next, activeId))
+    83	        }
+    84	        return saved
+    85	    }
+    86	
+    87	    /** Remove a profile. If it was active, the active selection moves to the first remaining (or null). */
+    88	    suspend fun delete(id: String) {
+    89	        dataStore.edit { prefs ->
+    90	            val cur = read(prefs)
+    91	            val next = cur.profiles.filterNot { it.id == id }
+    92	            val activeId = if (cur.activeId == id) next.firstOrNull()?.id else cur.activeId
+    93	            prefs[KEY] = json.encodeToString(AiStoreState(next, activeId))
+    94	        }
+    95	    }
+    96	
+    97	    /** Select the active provider (no-op if the id isn't present). */
+    98	    suspend fun setActive(id: String) {
+    99	        dataStore.edit { prefs ->
+   100	            val cur = read(prefs)
+   101	            if (cur.profiles.any { it.id == id }) prefs[KEY] = json.encodeToString(cur.copy(activeId = id))
+   102	        }
+   103	    }
+   104	
+   105	    /** Decrypt the key from a CAPTURED [profile] — snapshot-consistent (no live store read). The
+   106	     *  chat/test request path uses THIS with a profile from a single [snapshot], so it can't pair
+   107	     *  snapshot metadata with a concurrently-edited/deleted key. */
+   108	    fun apiKey(profile: AiProviderProfile): String = cipher.decrypt(profile.encryptedApiKey)
+   109	
+   110	    /** The decrypted API key for [id] via a live read, or null if absent. Convenience for UI flows
+   111	     *  that aren't mid-request; the request path should prefer [apiKey] (profile). */
+   112	    suspend fun apiKey(id: String): String? =
+   113	        list().firstOrNull { it.id == id }?.let { cipher.decrypt(it.encryptedApiKey) }
+   114	
+   115	    private fun read(prefs: Preferences): AiStoreState {
+   116	        val raw = prefs[KEY] ?: return AiStoreState()
+   117	        return runCatching { json.decodeFromString<AiStoreState>(raw) }.getOrDefault(AiStoreState())
+   118	    }
+   119	
+   120	    private fun AiStoreState.toSnapshot() = AiProviderSnapshot(profiles, activeId)
+   121	
+   122	    companion object {
+   123	        private val KEY = stringPreferencesKey("ai_providers_json")
+   124	    }
+   125	}
+     1	// Purpose: feature #118 WI-3 (#110 Phase 3) — drives the AI provider list + editor: observes the
+     2	// AiProviderStore for the list, owns the editor form state, runs Test Connection against the LIVE
+     3	// form (a transient AiClient built from the form + key, no save first), and saves/deletes. v1 list
+     4	// status is ok+model (persisted per-provider test status is a follow-on). The key is never logged.
+     5	package com.vreader.app.ai
+     6	
+     7	import androidx.lifecycle.ViewModel
+     8	import androidx.lifecycle.viewModelScope
+     9	import kotlinx.coroutines.CoroutineDispatcher
+    10	import kotlinx.coroutines.Dispatchers
+    11	import kotlinx.coroutines.flow.MutableStateFlow
+    12	import kotlinx.coroutines.flow.SharingStarted
+    13	import kotlinx.coroutines.flow.StateFlow
+    14	import kotlinx.coroutines.flow.map
+    15	import kotlinx.coroutines.flow.stateIn
+    16	import kotlinx.coroutines.launch
+    17	import kotlinx.coroutines.withContext
+    18	import java.util.UUID
+    19	
+    20	class AiSettingsViewModel(
+    21	    private val store: AiProviderStore,
+    22	    private val clientDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    23	    private val factory: (AiProviderProfile, String) -> AiClient = { p, key -> AiProviderFactory.create(p, key) },
+    24	) : ViewModel() {
+    25	
+    26	    val listState: StateFlow<AiProviderListState> = store.observe()
+    27	        .map { snap ->
+    28	            AiProviderListState(
+    29	                snap.profiles.map { p ->
+    30	                    AiProviderRow(p.id, p.name, active = p.id == snap.activeId, statusOk = true, detail = p.model.ifBlank { p.kind.defaultModel })
+    31	                }
+    32	            )
+    33	        }
+    34	        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AiProviderListState())
+    35	
+    36	    private val _edit = MutableStateFlow<AiEditState?>(null)
+    37	    val editState: StateFlow<AiEditState?> = _edit
+    38	
+    39	    // Bumped whenever the editor opens/closes or a new test starts — an in-flight test result is
+    40	    // only applied if its generation still matches, so a stale Ok/Fail can't land on a different
+    41	    // form (the user closed it, opened another provider, or re-tested).
+    42	    private var testGen = 0
+    43	
+    44	    fun openAdd() { testGen++; _edit.value = AiEditState(editMode = false) }
+    45	
+    46	    fun openEdit(id: String) = viewModelScope.launch {
+    47	        val p = store.list().firstOrNull { it.id == id } ?: return@launch
+    48	        testGen++
+    49	        _edit.value = AiEditState(
+    50	            editMode = true, id = p.id, kind = p.kind, name = p.name, baseUrl = p.baseUrl, model = p.model,
+    51	            temperature = p.temperature, maxTokens = p.maxTokens, keyAlreadySaved = true,
+    52	        )
+    53	    }
+    54	
+    55	    fun close() { testGen++; _edit.value = null }
+    56	
+    57	    fun update(transform: (AiEditState) -> AiEditState) { _edit.value = _edit.value?.let(transform) }
+    58	
+    59	    fun test() {
+    60	        val s = _edit.value ?: return
+    61	        if (!s.canTest) return
+    62	        val gen = ++testGen
+    63	        update { it.copy(test = AiConnTest.testing, testMessage = "") }
+    64	        viewModelScope.launch {
+    65	            // Key lookup + client creation + the network call all off the main thread.
+    66	            val result = withContext(clientDispatcher) {
+    67	                val key = if (s.apiKey.isNotBlank()) s.apiKey else s.id?.let { store.apiKey(it) } ?: ""
+    68	                val profile = AiProviderProfile(
+    69	                    id = s.id ?: "transient", name = s.name, kind = s.kind, baseUrl = s.effectiveBaseUrl,
+    70	                    model = s.effectiveModel, temperature = s.temperature, maxTokens = s.maxTokens, encryptedApiKey = "",
+    71	                )
+    72	                runCatching { factory(profile, key).testConnection() }
+    73	                    .getOrElse { AiTestResult.Fail(AiError.Offline, it.message ?: "failed") }
+    74	            }
+    75	            if (gen != testGen) return@launch  // superseded by a newer test / form open / close
+    76	            update {
+    77	                when (result) {
+    78	                    is AiTestResult.Ok -> it.copy(test = AiConnTest.ok, testMessage = "Connected — the provider responded successfully.")
+    79	                    is AiTestResult.Fail -> it.copy(test = AiConnTest.fail, testMessage = result.message)
+    80	                }
+    81	            }
+    82	        }
+    83	    }
+    84	
+    85	    fun save() {
+    86	        val s = _edit.value ?: return
+    87	        if (!s.canSave) return
+    88	        viewModelScope.launch {
+    89	            store.upsert(
+    90	                id = s.id ?: UUID.randomUUID().toString(),
+    91	                name = s.name, kind = s.kind, baseUrl = s.baseUrl, model = s.model,
+    92	                temperature = s.temperature, maxTokens = s.maxTokens,
+    93	                apiKey = s.apiKey.ifBlank { null },  // blank on edit = keep existing
+    94	            )
+    95	            _edit.value = null
+    96	        }
+    97	    }
+    98	
+    99	    fun delete() {
+   100	        val id = _edit.value?.id ?: return
+   101	        viewModelScope.launch { store.delete(id); _edit.value = null }
+   102	    }
+   103	
+   104	    fun setActive(id: String) = viewModelScope.launch { store.setActive(id) }
+   105	}
+     1	// Purpose: feature #118 WI-3 (#110 Phase 3) — the AI provider list (the gate), design surface A
+     2	// from vreader-ai-android.jsx `AiProviderList`: unconfigured onboards to a single Add action;
+     3	// configured shows the active provider + per-provider status (model, or the rejection reason).
+     4	// Reuses the shared form vocabulary (NavScreen / SettingsCard / GroupHeader / StatusDot / tokens —
+     5	// mapped from this surface's own design file). Stateless: a pure function of the list + callbacks.
+     6	package com.vreader.app.ai
+     7	
+     8	import androidx.compose.foundation.background
+     9	import androidx.compose.foundation.clickable
+    10	import androidx.compose.foundation.layout.Box
+    11	import androidx.compose.foundation.layout.Column
+    12	import androidx.compose.foundation.layout.Row
+    13	import androidx.compose.foundation.layout.fillMaxWidth
+    14	import androidx.compose.foundation.layout.height
+    15	import androidx.compose.foundation.layout.heightIn
+    16	import androidx.compose.foundation.layout.padding
+    17	import androidx.compose.foundation.layout.size
+    18	import androidx.compose.foundation.shape.CircleShape
+    19	import androidx.compose.foundation.shape.RoundedCornerShape
+    20	import androidx.compose.material.icons.Icons
+    21	import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+    22	import androidx.compose.material.icons.filled.Add
+    23	import androidx.compose.material.icons.filled.AutoAwesome
+    24	import androidx.compose.material3.Icon
+    25	import androidx.compose.material3.Text
+    26	import androidx.compose.runtime.Composable
+    27	import androidx.compose.ui.Alignment
+    28	import androidx.compose.ui.Modifier
+    29	import androidx.compose.ui.draw.clip
+    30	import androidx.compose.ui.graphics.Color
+    31	import androidx.compose.ui.platform.testTag
+    32	import androidx.compose.ui.text.font.FontWeight
+    33	import androidx.compose.ui.text.style.TextAlign
+    34	import androidx.compose.ui.unit.dp
+    35	import androidx.compose.ui.unit.sp
+    36	import com.vreader.app.backup.BackupFonts
+    37	import com.vreader.app.backup.GroupFooter
+    38	import com.vreader.app.backup.GroupHeader
+    39	import com.vreader.app.backup.LocalBackupTokens
+    40	import com.vreader.app.backup.NavScreen
+    41	import com.vreader.app.backup.SettingsCard
+    42	import com.vreader.app.backup.StatusDot
+    43	import com.vreader.app.backup.VSpace
+    44	
+    45	@Composable
+    46	fun AiProviderListScreen(
+    47	    state: AiProviderListState,
+    48	    onBack: () -> Unit = {},
+    49	    onAdd: () -> Unit = {},
+    50	    onEdit: (String) -> Unit = {},
+    51	) {
+    52	    val t = LocalBackupTokens.current
+    53	    val addButton: @Composable () -> Unit = {
+    54	        Box(
+    55	            Modifier.size(44.dp).clip(RoundedCornerShape(22.dp)).clickable(onClickLabel = "Add provider", onClick = onAdd),
+    56	            contentAlignment = Alignment.Center,
+    57	        ) { Icon(Icons.Filled.Add, contentDescription = "Add provider", tint = t.tint, modifier = Modifier.size(22.dp)) }
+    58	    }
+    59	    NavScreen(title = "AI Providers", large = true, onBack = onBack, trailing = addButton) {
+    60	        Column(Modifier.padding(horizontal = 18.dp).padding(bottom = 32.dp)) {
+    61	            if (state.unconfigured) {
+    62	                AiEmptyState(onAdd)
+    63	            } else {
+    64	                GroupHeader("Providers")
+    65	                SettingsCard {
+    66	                    state.providers.forEachIndexed { i, p ->
+    67	                        ProviderRow(p, last = i == state.providers.lastIndex, onEdit = onEdit)
+    68	                    }
+    69	                }
+    70	                GroupFooter("The selected provider is used for translation, chat, and summaries. Tap one to edit or test it.")
+    71	            }
+    72	        }
+    73	    }
+    74	}
+    75	
+    76	@Composable
+    77	private fun AiEmptyState(onAdd: () -> Unit) {
+    78	    val t = LocalBackupTokens.current
+    79	    Column(Modifier.fillMaxWidth().padding(top = 36.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+    80	        Box(Modifier.size(64.dp).clip(CircleShape).background(t.chipBg), contentAlignment = Alignment.Center) {
+    81	            Icon(Icons.Filled.AutoAwesome, contentDescription = null, tint = t.tint, modifier = Modifier.size(30.dp))
+    82	        }
+    83	        VSpace(18)
+    84	        Text("Connect an AI provider", color = t.ink, fontFamily = BackupFonts.Serif, fontSize = 21.sp, textAlign = TextAlign.Center)
+    85	        VSpace(8)
+    86	        Text(
+    87	            "One key unlocks bilingual translation, chat about a book, and chapter summaries. Your key is stored on-device only.",
+    88	            color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 14.sp, lineHeight = 22.sp, textAlign = TextAlign.Center,
+    89	        )
+    90	        VSpace(18)
+    91	        Box(
+    92	            Modifier.fillMaxWidth().clip(RoundedCornerShape(13.dp)).background(t.tint)
+    93	                .clickable(onClickLabel = "Add a provider", onClick = onAdd).testTag("ai-add-provider").padding(vertical = 14.dp),
+    94	            contentAlignment = Alignment.Center,
+    95	        ) { Text("Add a provider", color = Color.White, fontFamily = BackupFonts.Sans, fontSize = 15.sp, fontWeight = FontWeight.SemiBold) }
+    96	        GroupFooter("Works with Anthropic, OpenAI-compatible endpoints, and local models.")
+    97	    }
+    98	}
+    99	
+   100	@Composable
+   101	private fun ProviderRow(p: AiProviderRow, last: Boolean, onEdit: (String) -> Unit) {
+   102	    val t = LocalBackupTokens.current
+   103	    Box {
+   104	        Row(
+   105	            Modifier.fillMaxWidth().heightIn(min = 60.dp).clickable(onClick = { onEdit(p.id) })
+   106	                .testTag("provider-${p.id}").padding(horizontal = 14.dp),
+   107	            verticalAlignment = Alignment.CenterVertically,
+   108	        ) {
+   109	            // active = filled accent circle; inactive = hollow ring (sep ring + card-coloured core)
+   110	            Box(
+   111	                Modifier.size(20.dp).clip(CircleShape).background(if (p.active) t.tint else t.sep),
+   112	                contentAlignment = Alignment.Center,
+   113	            ) {
+   114	                if (!p.active) Box(Modifier.size(16.5.dp).clip(CircleShape).background(t.card))
+   115	            }
+   116	            Column(Modifier.weight(1f).padding(start = 12.dp)) {
+   117	                Text(p.name, color = t.ink, fontFamily = BackupFonts.Sans, fontSize = 15.5.sp, fontWeight = FontWeight.Medium)
+   118	                Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(top = 2.dp)) {
+   119	                    StatusDot(if (p.statusOk) t.green else t.red)
+   120	                    Text(
+   121	                        p.detail, color = if (p.statusOk) t.sec else t.red,
+   122	                        fontFamily = BackupFonts.Mono, fontSize = 11.5.sp, modifier = Modifier.padding(start = 6.dp),
+   123	                    )
+   124	                }
+   125	            }
+   126	            Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, tint = t.ter, modifier = Modifier.size(18.dp))
+   127	        }
+   128	        if (!last) Box(Modifier.fillMaxWidth().padding(start = 46.dp).height(0.5.dp).background(t.sep).align(Alignment.BottomStart))
+   129	    }
+   130	}
+     1	// Purpose: feature #118 WI-3 (#110 Phase 3) — the add/edit AI provider form (the committed
+     2	// EditorSheet contract from vreader-ai-provider-fields.jsx): Provider Type (segmented) · Name ·
+     3	// Endpoint (Base URL + Model, blank → kind default, with the path-append hint) · Sampling
+     4	// (Temperature slider + Max Tokens stepper) · API Key (secure; edit shows Delete Key) · Connection
+     5	// (Test — enabled once a key is available, idle/testing/ok/fail). Reuses the shared form
+     6	// vocabulary; stateless: a pure function of AiEditState + callbacks.
+     7	package com.vreader.app.ai
+     8	
+     9	import androidx.compose.foundation.background
+    10	import androidx.compose.foundation.clickable
+    11	import androidx.compose.foundation.gestures.detectTapGestures
+    12	import androidx.compose.foundation.layout.Box
+    13	import androidx.compose.foundation.layout.Column
+    14	import androidx.compose.foundation.layout.Row
+    15	import androidx.compose.foundation.layout.fillMaxSize
+    16	import androidx.compose.foundation.layout.fillMaxWidth
+    17	import androidx.compose.foundation.layout.height
+    18	import androidx.compose.foundation.layout.heightIn
+    19	import androidx.compose.foundation.layout.padding
+    20	import androidx.compose.foundation.layout.size
+    21	import androidx.compose.foundation.layout.sizeIn
+    22	import androidx.compose.foundation.shape.CircleShape
+    23	import androidx.compose.foundation.shape.RoundedCornerShape
+    24	import androidx.compose.foundation.text.BasicTextField
+    25	import androidx.compose.material3.Text
+    26	import androidx.compose.runtime.Composable
+    27	import androidx.compose.runtime.getValue
+    28	import androidx.compose.runtime.mutableIntStateOf
+    29	import androidx.compose.runtime.remember
+    30	import androidx.compose.runtime.setValue
+    31	import androidx.compose.ui.Alignment
+    32	import androidx.compose.ui.Modifier
+    33	import androidx.compose.ui.draw.clip
+    34	import androidx.compose.ui.graphics.Color
+    35	import androidx.compose.ui.graphics.SolidColor
+    36	import androidx.compose.ui.input.pointer.pointerInput
+    37	import androidx.compose.ui.layout.onSizeChanged
+    38	import androidx.compose.ui.platform.LocalDensity
+    39	import androidx.compose.ui.platform.testTag
+    40	import androidx.compose.ui.text.TextStyle
+    41	import androidx.compose.ui.text.font.FontWeight
+    42	import androidx.compose.ui.text.input.PasswordVisualTransformation
+    43	import androidx.compose.ui.text.input.VisualTransformation
+    44	import androidx.compose.ui.unit.dp
+    45	import androidx.compose.ui.unit.sp
+    46	import com.vreader.app.backup.AppSheet
+    47	import com.vreader.app.backup.BackupFonts
+    48	import com.vreader.app.backup.GroupFooter
+    49	import com.vreader.app.backup.GroupHeader
+    50	import com.vreader.app.backup.LocalBackupTokens
+    51	import com.vreader.app.backup.SettingsCard
+    52	import com.vreader.app.backup.VSpace
+    53	
+    54	@Composable
+    55	fun AiProviderEditSheet(
+    56	    state: AiEditState,
+    57	    onKind: (AiProviderKind) -> Unit = {},
+    58	    onName: (String) -> Unit = {},
+    59	    onBaseUrl: (String) -> Unit = {},
+    60	    onModel: (String) -> Unit = {},
+    61	    onTemperature: (Double) -> Unit = {},
+    62	    onMaxTokens: (Int) -> Unit = {},
+    63	    onApiKey: (String) -> Unit = {},
+    64	    onDeleteKey: () -> Unit = {},
+    65	    onTest: () -> Unit = {},
+    66	    onSave: () -> Unit = {},
+    67	    onCancel: () -> Unit = {},
+    68	) {
+    69	    val t = LocalBackupTokens.current
+    70	    Box(Modifier.fillMaxSize()) {
+    71	        AppSheet(
+    72	            title = if (state.editMode) "Edit Provider" else "Add Provider",
+    73	            leading = {
+    74	                Box(Modifier.sizeIn(minWidth = 48.dp, minHeight = 48.dp).clickable(onClick = onCancel), contentAlignment = Alignment.CenterStart) {
+    75	                    Text("Cancel", color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 15.sp)
+    76	                }
+    77	            },
+    78	            trailing = {
+    79	                Box(Modifier.sizeIn(minWidth = 48.dp, minHeight = 48.dp).clickable(enabled = state.canSave, onClick = onSave).testTag("ai-save"), contentAlignment = Alignment.CenterEnd) {
+    80	                    Text("Save", color = if (state.canSave) t.tint else t.ter, fontFamily = BackupFonts.Sans, fontSize = 15.sp, fontWeight = FontWeight.SemiBold)
+    81	                }
+    82	            },
+    83	        ) {
+    84	            Column(Modifier.padding(horizontal = 18.dp).padding(top = 16.dp, bottom = 32.dp)) {
+    85	                GroupHeader("Provider Type")
+    86	                Segmented(state.kind, onKind)
+    87	
+    88	                VSpace(20)
+    89	                GroupHeader("Name")
+    90	                SettingsCard { Field("", state.name, "e.g. OpenRouter", onName) }
+    91	
+    92	                VSpace(20)
+    93	                GroupHeader("Endpoint")
+    94	                SettingsCard {
+    95	                    Field("Base URL", state.baseUrl, state.kind.defaultBaseUrl, onBaseUrl, mono = true)
+    96	                    Divider()
+    97	                    Field("Model", state.model, state.kind.defaultModel, onModel)
+    98	                }
+    99	                GroupFooter(state.kind.endpointPathHint + "  Leave blank to use the default.")
+   100	
+   101	                VSpace(20)
+   102	                GroupHeader("Sampling")
+   103	                SettingsCard {
+   104	                    TemperatureRow(state.temperature, onTemperature)
+   105	                    Divider()
+   106	                    MaxTokensRow(state.maxTokens, onMaxTokens)
+   107	                }
+   108	
+   109	                VSpace(20)
+   110	                GroupHeader("API Key")
+   111	                SettingsCard {
+   112	                    if (state.editMode && state.keyAlreadySaved && state.apiKey.isBlank()) {
+   113	                        Row(Modifier.fillMaxWidth().heightIn(min = 48.dp).padding(horizontal = 14.dp), verticalAlignment = Alignment.CenterVertically) {
+   114	                            Text("••••••••••••••", color = t.ink, fontFamily = BackupFonts.Sans, fontSize = 16.sp, modifier = Modifier.weight(1f))
+   115	                            Box(Modifier.size(19.dp).clip(CircleShape).background(t.green))
+   116	                        }
+   117	                        Divider()
+   118	                        Box(Modifier.fillMaxWidth().heightIn(min = 44.dp).clickable(onClick = onDeleteKey).padding(horizontal = 14.dp), contentAlignment = Alignment.CenterStart) {
+   119	                            Text("Delete Key", color = t.red, fontFamily = BackupFonts.Sans, fontSize = 15.sp)
+   120	                        }
+   121	                    } else {
+   122	                        Field("", state.apiKey, "Enter API Key", onApiKey, secure = true)
+   123	                    }
+   124	                }
+   125	                if (!state.editMode) GroupFooter("Stored in the Android Keystore when you tap Save — but you can test it below first.")
+   126	
+   127	                VSpace(20)
+   128	                GroupHeader("Connection")
+   129	                SettingsCard {
+   130	                    Row(Modifier.fillMaxWidth().padding(14.dp)) { TestChip(state.test, state.canTest, onTest) }
+   131	                    if (state.test == AiConnTest.ok || state.test == AiConnTest.fail) TestResult(state.test, state.testMessage)
+   132	                }
+   133	                if (!state.canTest) GroupFooter("Enter an API key above to test — no need to save first.")
+   134	            }
+   135	        }
+   136	    }
+   137	}
+   138	
+   139	@Composable
+   140	private fun Segmented(value: AiProviderKind, onChange: (AiProviderKind) -> Unit) {
+   141	    val t = LocalBackupTokens.current
+   142	    Row(Modifier.fillMaxWidth().padding(top = 8.dp).clip(RoundedCornerShape(12.dp)).background(t.codeBg).padding(3.dp)) {
+   143	        AiProviderKind.entries.forEach { k ->
+   144	            val on = k == value
+   145	            Box(
+   146	                Modifier.weight(1f).clip(RoundedCornerShape(10.dp)).background(if (on) t.card else Color.Transparent)
+   147	                    .clickable { onChange(k) }.testTag("kind-${k.name}").padding(vertical = 9.dp),
+   148	                contentAlignment = Alignment.Center,
+   149	            ) {
+   150	                Text(k.displayName, color = t.ink, fontFamily = BackupFonts.Sans, fontSize = 13.5.sp, fontWeight = if (on) FontWeight.SemiBold else FontWeight.Medium)
+   151	            }
+   152	        }
+   153	    }
+   154	}
+   155	
+   156	@Composable
+   157	private fun Field(label: String, value: String, placeholder: String, onChange: (String) -> Unit, mono: Boolean = false, secure: Boolean = false) {
+   158	    val t = LocalBackupTokens.current
+   159	    Row(Modifier.fillMaxWidth().heightIn(min = 48.dp).padding(horizontal = 14.dp), verticalAlignment = Alignment.CenterVertically) {
+   160	        if (label.isNotEmpty()) Text(label, color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 15.sp, modifier = Modifier.padding(end = 10.dp))
+   161	        BasicTextField(
+   162	            value = value, onValueChange = onChange, singleLine = true,
+   163	            textStyle = TextStyle(color = t.ink, fontFamily = if (mono) BackupFonts.Mono else BackupFonts.Sans, fontSize = if (mono) 13.5.sp else 15.sp),
+   164	            cursorBrush = SolidColor(t.tint),
+   165	            visualTransformation = if (secure) PasswordVisualTransformation() else VisualTransformation.None,
+   166	            modifier = Modifier.weight(1f).testTag("field-${label.ifBlank { placeholder }}"),
+   167	            decorationBox = { inner ->
+   168	                Box(Modifier.fillMaxWidth(), contentAlignment = if (label.isEmpty()) Alignment.CenterStart else Alignment.CenterEnd) {
+   169	                    if (value.isEmpty()) Text(placeholder, color = t.placeholder, fontFamily = if (mono) BackupFonts.Mono else BackupFonts.Sans, fontSize = if (mono) 13.5.sp else 15.sp)
+   170	                    inner()
+   171	                }
+   172	            },
+   173	        )
+   174	    }
+   175	}
+   176	
+   177	@Composable
+   178	private fun Divider() {
+   179	    val t = LocalBackupTokens.current
+   180	    Box(Modifier.fillMaxWidth().padding(start = 14.dp).height(0.5.dp).background(t.sep))
+   181	}
+   182	
+   183	@Composable
+   184	private fun TemperatureRow(value: Double, onChange: (Double) -> Unit) {
+   185	    val t = LocalBackupTokens.current
+   186	    val density = LocalDensity.current
+   187	    var trackPx by remember { mutableIntStateOf(0) }  // measured track width, in px
+   188	    Column(Modifier.fillMaxWidth().padding(14.dp)) {
+   189	        Row(verticalAlignment = Alignment.CenterVertically) {
+   190	            Text("Temperature", color = t.sec, fontFamily = BackupFonts.Sans, fontSize = 15.sp, modifier = Modifier.weight(1f))
+   191	            Text("%.1f".format(value), color = t.ink, fontFamily = BackupFonts.Sans, fontSize = 15.sp)
+   192	        }
+   193	        // Custom track + thumb (0.0–2.0); tap maps x → value using the MEASURED width.
+   194	        val frac = (value / 2.0).toFloat().coerceIn(0f, 1f)
+   195	        Box(
+   196	            Modifier.fillMaxWidth().padding(top = 14.dp, bottom = 4.dp).height(22.dp).testTag("temperature-slider")
+   197	                .onSizeChanged { trackPx = it.width }
+   198	                .pointerInput(Unit) {
+   199	                    detectTapGestures { offset -> if (trackPx > 0) onChange(((offset.x / trackPx) * 2.0).coerceIn(0.0, 2.0)) }
+   200	                },
+   201	            contentAlignment = Alignment.CenterStart,
+   202	        ) {
+   203	            Box(Modifier.fillMaxWidth().height(4.dp).clip(RoundedCornerShape(2.dp)).background(t.sep))
+   204	            Box(Modifier.fillMaxWidth(frac).height(4.dp).clip(RoundedCornerShape(2.dp)).background(t.tint))
+   205	            val trackDp = with(density) { trackPx.toDp() }
+   206	            val startPad = (trackDp * frac - 11.dp).coerceIn(0.dp, (trackDp - 22.dp).coerceAtLeast(0.dp))
+   207	            Box(Modifier.padding(start = startPad).size(22.dp).clip(CircleShape).background(Color.White))
+   208	        }
+   209	    }
+   210	}
+   211	
+   212	@Composable
+   213	private fun MaxTokensRow(value: Int, onChange: (Int) -> Unit) {
+   214	    val t = LocalBackupTokens.current
+   215	    Row(Modifier.fillMaxWidth().heightIn(min = 48.dp).padding(horizontal = 14.dp), verticalAlignment = Alignment.CenterVertically) {
+   216	        Text("Max Tokens: $value", color = t.ink, fontFamily = BackupFonts.Sans, fontSize = 15.sp, modifier = Modifier.weight(1f))
+   217	        Row(Modifier.clip(RoundedCornerShape(8.dp)).background(t.codeBg)) {
+   218	            Box(Modifier.size(width = 42.dp, height = 30.dp).clickable(onClickLabel = "decrease", onClick = { onChange((value - 256).coerceAtLeast(256)) }).testTag("tokens-dec"), contentAlignment = Alignment.Center) {
+   219	                Text("−", color = t.ink, fontSize = 19.sp)
+   220	            }
+   221	            Box(Modifier.size(width = 0.5.dp, height = 30.dp).background(t.sep))
+   222	            Box(Modifier.size(width = 42.dp, height = 30.dp).clickable(onClickLabel = "increase", onClick = { onChange((value + 256).coerceAtMost(8192)) }).testTag("tokens-inc"), contentAlignment = Alignment.Center) {
+   223	                Text("+", color = t.ink, fontSize = 19.sp)
+   224	            }
+   225	        }
+   226	    }
+   227	}
+   228	
+   229	@Composable
+   230	private fun TestChip(test: AiConnTest, enabled: Boolean, onTest: () -> Unit) {
+   231	    val t = LocalBackupTokens.current
+   232	    val label = if (test == AiConnTest.testing) "Testing…" else "Test Connection"
+   233	    Box(
+   234	        Modifier.clip(RoundedCornerShape(100.dp)).background(if (enabled) t.chipBg else Color.Transparent)
+   235	            .clickable(enabled = enabled && test != AiConnTest.testing, onClick = onTest).testTag("ai-test")
+   236	            .padding(horizontal = 15.dp, vertical = 8.dp),
+   237	    ) {
+   238	        Text(label, color = if (enabled) t.tint else t.ter, fontFamily = BackupFonts.Sans, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
+   239	    }
+   240	}
+   241	
+   242	@Composable
+   243	private fun TestResult(test: AiConnTest, message: String) {
+   244	    val t = LocalBackupTokens.current
+   245	    val ok = test == AiConnTest.ok
+   246	    val fallback = if (ok) "Connected — the provider responded successfully." else "Failed: 401 Unauthorized — check your API key."
+   247	    Row(Modifier.fillMaxWidth().padding(start = 14.dp, end = 14.dp, bottom = 14.dp), verticalAlignment = Alignment.Top) {
+   248	        Box(Modifier.size(16.dp).clip(CircleShape).background(if (ok) t.green else t.red))
+   249	        Text(message.ifBlank { fallback }, color = if (ok) t.green else t.red, fontFamily = BackupFonts.Sans, fontSize = 13.sp, lineHeight = 19.sp, modifier = Modifier.padding(start = 7.dp).testTag("ai-test-result"))
+   250	    }
+   251	}
+
+exec
+/bin/zsh -lc "nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt | sed -n '38,220p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt | sed -n '1,260p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeScaffold.kt | sed -n '1,340p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeState.kt | sed -n '1,260p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+    38	@Serializable
+    39	private data class AiStoreState(val profiles: List<AiProviderProfile> = emptyList(), val activeId: String? = null)
+    40	
+    41	class AiProviderStore(
+    42	    private val dataStore: DataStore<Preferences>,
+    43	    private val cipher: SecretCipher,
+    44	    private val json: Json = Json { ignoreUnknownKeys = true; encodeDefaults = true },
+    45	) {
+    46	    /** One consistent profiles + active-id view (read once at request start). */
+    47	    suspend fun snapshot(): AiProviderSnapshot = read(dataStore.data.first()).toSnapshot()
+    48	
+    49	    fun observe(): Flow<AiProviderSnapshot> = dataStore.data.map { read(it).toSnapshot() }
+    50	
+    51	    suspend fun list(): List<AiProviderProfile> = snapshot().profiles
+    52	
+    53	    suspend fun activeProfile(): AiProviderProfile? = snapshot().active
+    54	
+    55	    /**
+    56	     * Insert/update a profile by [id]. [apiKey] is the PLAINTEXT to encrypt; pass null on an edit
+    57	     * that leaves the key unchanged (the existing ciphertext is kept). A brand-new id REQUIRES a
+    58	     * key. The first profile added becomes active. Returns the saved profile (key encrypted).
+    59	     */
+    60	    suspend fun upsert(
+    61	        id: String,
+    62	        name: String,
+    63	        kind: AiProviderKind,
+    64	        baseUrl: String,
+    65	        model: String,
+    66	        temperature: Double,
+    67	        maxTokens: Int,
+    68	        apiKey: String?,
+    69	    ): AiProviderProfile {
+    70	        lateinit var saved: AiProviderProfile
+    71	        dataStore.edit { prefs ->
+    72	            val cur = read(prefs)
+    73	            val existing = cur.profiles.firstOrNull { it.id == id }
+    74	            val encrypted = when {
+    75	                apiKey != null -> cipher.encrypt(apiKey)
+    76	                existing != null -> existing.encryptedApiKey  // unchanged on edit
+    77	                else -> throw IllegalArgumentException("a new provider ($id) requires an API key")
+    78	            }
+    79	            saved = AiProviderProfile(id, name, kind, baseUrl, model, temperature, maxTokens, encrypted)
+    80	            val next = cur.profiles.filterNot { it.id == id } + saved
+    81	            val activeId = cur.activeId ?: id  // first provider becomes active
+    82	            prefs[KEY] = json.encodeToString(AiStoreState(next, activeId))
+    83	        }
+    84	        return saved
+    85	    }
+    86	
+    87	    /** Remove a profile. If it was active, the active selection moves to the first remaining (or null). */
+    88	    suspend fun delete(id: String) {
+    89	        dataStore.edit { prefs ->
+    90	            val cur = read(prefs)
+    91	            val next = cur.profiles.filterNot { it.id == id }
+    92	            val activeId = if (cur.activeId == id) next.firstOrNull()?.id else cur.activeId
+    93	            prefs[KEY] = json.encodeToString(AiStoreState(next, activeId))
+    94	        }
+    95	    }
+    96	
+    97	    /** Select the active provider (no-op if the id isn't present). */
+    98	    suspend fun setActive(id: String) {
+    99	        dataStore.edit { prefs ->
+   100	            val cur = read(prefs)
+   101	            if (cur.profiles.any { it.id == id }) prefs[KEY] = json.encodeToString(cur.copy(activeId = id))
+   102	        }
+   103	    }
+   104	
+   105	    /** Decrypt the key from a CAPTURED [profile] — snapshot-consistent (no live store read). The
+   106	     *  chat/test request path uses THIS with a profile from a single [snapshot], so it can't pair
+   107	     *  snapshot metadata with a concurrently-edited/deleted key. */
+   108	    fun apiKey(profile: AiProviderProfile): String = cipher.decrypt(profile.encryptedApiKey)
+   109	
+   110	    /** The decrypted API key for [id] via a live read, or null if absent. Convenience for UI flows
+   111	     *  that aren't mid-request; the request path should prefer [apiKey] (profile). */
+   112	    suspend fun apiKey(id: String): String? =
+   113	        list().firstOrNull { it.id == id }?.let { cipher.decrypt(it.encryptedApiKey) }
+   114	
+   115	    private fun read(prefs: Preferences): AiStoreState {
+   116	        val raw = prefs[KEY] ?: return AiStoreState()
+   117	        return runCatching { json.decodeFromString<AiStoreState>(raw) }.getOrDefault(AiStoreState())
+   118	    }
+   119	
+   120	    private fun AiStoreState.toSnapshot() = AiProviderSnapshot(profiles, activeId)
+   121	
+   122	    companion object {
+   123	        private val KEY = stringPreferencesKey("ai_providers_json")
+   124	    }
+   125	}
+     1	// Purpose: feature #118 WI-3 (#110 Phase 3) — drives the AI provider list + editor: observes the
+     2	// AiProviderStore for the list, owns the editor form state, runs Test Connection against the LIVE
+     3	// form (a transient AiClient built from the form + key, no save first), and saves/deletes. v1 list
+     4	// status is ok+model (persisted per-provider test status is a follow-on). The key is never logged.
+     5	package com.vreader.app.ai
+     6	
+     7	import androidx.lifecycle.ViewModel
+     8	import androidx.lifecycle.viewModelScope
+     9	import kotlinx.coroutines.CoroutineDispatcher
+    10	import kotlinx.coroutines.Dispatchers
+    11	import kotlinx.coroutines.flow.MutableStateFlow
+    12	import kotlinx.coroutines.flow.SharingStarted
+    13	import kotlinx.coroutines.flow.StateFlow
+    14	import kotlinx.coroutines.flow.map
+    15	import kotlinx.coroutines.flow.stateIn
+    16	import kotlinx.coroutines.launch
+    17	import kotlinx.coroutines.withContext
+    18	import java.util.UUID
+    19	
+    20	class AiSettingsViewModel(
+    21	    private val store: AiProviderStore,
+    22	    private val clientDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    23	    private val factory: (AiProviderProfile, String) -> AiClient = { p, key -> AiProviderFactory.create(p, key) },
+    24	) : ViewModel() {
+    25	
+    26	    val listState: StateFlow<AiProviderListState> = store.observe()
+    27	        .map { snap ->
+    28	            AiProviderListState(
+    29	                snap.profiles.map { p ->
+    30	                    AiProviderRow(p.id, p.name, active = p.id == snap.activeId, statusOk = true, detail = p.model.ifBlank { p.kind.defaultModel })
+    31	                }
+    32	            )
+    33	        }
+    34	        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AiProviderListState())
+    35	
+    36	    private val _edit = MutableStateFlow<AiEditState?>(null)
+    37	    val editState: StateFlow<AiEditState?> = _edit
+    38	
+    39	    // Bumped whenever the editor opens/closes or a new test starts — an in-flight test result is
+    40	    // only applied if its generation still matches, so a stale Ok/Fail can't land on a different
+    41	    // form (the user closed it, opened another provider, or re-tested).
+    42	    private var testGen = 0
+    43	
+    44	    fun openAdd() { testGen++; _edit.value = AiEditState(editMode = false) }
+    45	
+    46	    fun openEdit(id: String) = viewModelScope.launch {
+    47	        val p = store.list().firstOrNull { it.id == id } ?: return@launch
+    48	        testGen++
+    49	        _edit.value = AiEditState(
+    50	            editMode = true, id = p.id, kind = p.kind, name = p.name, baseUrl = p.baseUrl, model = p.model,
+    51	            temperature = p.temperature, maxTokens = p.maxTokens, keyAlreadySaved = true,
+    52	        )
+    53	    }
+    54	
+    55	    fun close() { testGen++; _edit.value = null }
+    56	
+    57	    fun update(transform: (AiEditState) -> AiEditState) { _edit.value = _edit.value?.let(transform) }
+    58	
+    59	    fun test() {
+    60	        val s = _edit.value ?: return
+    61	        if (!s.canTest) return
+    62	        val gen = ++testGen
+    63	        update { it.copy(test = AiConnTest.testing, testMessage = "") }
+    64	        viewModelScope.launch {
+    65	            // Key lookup + client creation + the network call all off the main thread.
+    66	            val result = withContext(clientDispatcher) {
+    67	                val key = if (s.apiKey.isNotBlank()) s.apiKey else s.id?.let { store.apiKey(it) } ?: ""
+    68	                val profile = AiProviderProfile(
+    69	                    id = s.id ?: "transient", name = s.name, kind = s.kind, baseUrl = s.effectiveBaseUrl,
+    70	                    model = s.effectiveModel, temperature = s.temperature, maxTokens = s.maxTokens, encryptedApiKey = "",
+    71	                )
+    72	                runCatching { factory(profile, key).testConnection() }
+    73	                    .getOrElse { AiTestResult.Fail(AiError.Offline, it.message ?: "failed") }
+    74	            }
+    75	            if (gen != testGen) return@launch  // superseded by a newer test / form open / close
+    76	            update {
+    77	                when (result) {
+    78	                    is AiTestResult.Ok -> it.copy(test = AiConnTest.ok, testMessage = "Connected — the provider responded successfully.")
+    79	                    is AiTestResult.Fail -> it.copy(test = AiConnTest.fail, testMessage = result.message)
+    80	                }
+    81	            }
+    82	        }
+    83	    }
+    84	
+    85	    fun save() {
+    86	        val s = _edit.value ?: return
+    87	        if (!s.canSave) return
+    88	        viewModelScope.launch {
+    89	            store.upsert(
+    90	                id = s.id ?: UUID.randomUUID().toString(),
+    91	                name = s.name, kind = s.kind, baseUrl = s.baseUrl, model = s.model,
+    92	                temperature = s.temperature, maxTokens = s.maxTokens,
+    93	                apiKey = s.apiKey.ifBlank { null },  // blank on edit = keep existing
+    94	            )
+    95	            _edit.value = null
+    96	        }
+    97	    }
+    98	
+    99	    fun delete() {
+   100	        val id = _edit.value?.id ?: return
+   101	        viewModelScope.launch { store.delete(id); _edit.value = null }
+   102	    }
+   103	
+   104	    fun setActive(id: String) = viewModelScope.launch { store.setActive(id) }
+   105	}
+     1	// Purpose: feature #132 WI-5 (#110 Phase 3) — the host-agnostic reader chrome scaffold that stitches
+     2	// the designed reader chrome + modal sheets over any reader body. It stacks [ReaderTopChrome] (WI-2) at
+     3	// the top, the host's [body] filling the middle, and the host's [bottomChrome] at the bottom — passing
+     4	// the Contents/Notes open callbacks INTO the bottom-chrome slot so the host wires them without reaching
+     5	// into scaffold state. A center-tap on the body toggles chrome visibility (the top + bottom bars hide
+     6	// together). It hosts the modal sheets driven by the hoisted [ReaderChromeState.sheet]:
+     7	// [ReaderSheet.Toc] → the #135 WI-6 [TocBookmarksSheet] (the promoted two-tab Contents|Bookmarks sheet,
+     8	// which REUSES #132's Contents body), [ReaderSheet.Notes] → the WI-4 [AnnotationsReviewSheet], and —
+     9	// feature #134 WI-5 — [ReaderSheet.Details] → the WI-4 [BookDetailsSheet]. The top-bar More button
+    10	// (rendered iff [bookDetails] is non-null) toggles the WI-3 [MorePopup] carrying ONLY the Details + Share
+    11	// rows (the §more-row-ownership contract — TTS/Auto-turn/Bilingual/Export belong to other features):
+    12	// Details opens the Details sheet, Share fires [onShareBook], and the Details sheet's copy-fingerprint
+    13	// mini-action fires [onCopyFingerprint] (the host copies to the OS clipboard — no invented toast, rule 51).
+    14	// The Contents control is HIDDEN when [tocEntries] is empty (the scaffold passes a null open callback,
+    15	// so the bottom chrome omits it — the no-dead-controls rule). feature #135 WI-5 — the top-bar bookmark
+    16	// toggle: when [onToggleBookmark] is non-null the scaffold fills [ReaderTopChrome]'s reserved bookmark
+    17	// slot with the WI-5 [BookmarkToggleButton] (filled/outline by [isCurrentBookmarked]); a null callback
+    18	// omits it (the #129 no-dead-control rule → #132 Contents/Notes-only callers stay back-compatible). feature
+    19	// #135 WI-6 — the promoted two-tab TOC sheet: the [ReaderSheet.Toc] route now renders [TocBookmarksSheet]
+    20	// (Contents|Bookmarks), and [bookmarks]/[onJumpBookmark] feed its Bookmarks tab (nullable/defaulted → #132
+    21	// Contents/Notes-only callers stay valid); the [ReaderSheet.Bookmarks] route opens the SAME two-tab sheet
+    22	// (host wiring feeds the data in WI-7). [currentLocator] is threaded for the host to derive presence but the
+    23	// scaffold does not read it. Pure function of hoisted state + callbacks (rule 50 §4); same [ReaderTheme]
+    24	// token map as the reader chrome.
+    25	package com.vreader.app.reader.chrome
+    26	
+    27	import androidx.compose.foundation.background
+    28	import androidx.compose.foundation.gestures.detectTapGestures
+    29	import androidx.compose.foundation.layout.Box
+    30	import androidx.compose.foundation.layout.Column
+    31	import androidx.compose.foundation.layout.fillMaxSize
+    32	import androidx.compose.foundation.layout.fillMaxWidth
+    33	import androidx.compose.material.icons.Icons
+    34	import androidx.compose.material.icons.filled.Info
+    35	import androidx.compose.material.icons.filled.Share
+    36	import androidx.compose.runtime.Composable
+    37	import androidx.compose.runtime.MutableState
+    38	import androidx.compose.runtime.getValue
+    39	import androidx.compose.runtime.mutableStateOf
+    40	import androidx.compose.runtime.remember
+    41	import androidx.compose.runtime.setValue
+    42	import androidx.compose.ui.Modifier
+    43	import androidx.compose.ui.input.pointer.pointerInput
+    44	import com.vreader.app.annotations.AnnotationItem
+    45	import com.vreader.app.annotations.AnnotationsReviewSheet
+    46	import com.vreader.app.annotations.AnnotationsSnapshot
+    47	import com.vreader.app.reader.details.BookDetailsSheet
+    48	import com.vreader.app.reader.details.BookDetailsUiModel
+    49	import com.vreader.app.annotations.BookmarkRecord
+    50	import com.vreader.app.reader.more.MoreActionId
+    51	import com.vreader.app.reader.more.MorePopup
+    52	import com.vreader.app.reader.more.MoreRow
+    53	import com.vreader.app.reader.nav.BookmarkRowItem
+    54	import com.vreader.app.reader.nav.JumpResult
+    55	import com.vreader.app.reader.nav.TocBookmarksSheet
+    56	import com.vreader.app.reader.nav.TocEntry
+    57	import com.vreader.app.reader.nav.TocTab
+    58	import com.vreader.app.reader.settings.ReaderTheme
+    59	import vreader.contracts.Locator
+    60	
+    61	/**
+    62	 * The host-agnostic reader chrome scaffold. [chromeState] is the hoisted [ReaderChromeState]
+    63	 * (visibility + open sheet). [title] fills the top bar; [onBack] fires the "‹ Library" control;
+    64	 * [onOpenSearch] populates the top-bar Search slot (null → omitted; #133); [topBookmarkSlot] fills the
+    65	 * top-bar bookmark slot (null in #132; #135). [tocEntries]/[currentTocIndex] drive the Contents sheet
+    66	 * (empty entries → the Contents control is hidden). [annotations] is the one-shot snapshot for the Notes
+    67	 * sheet; [onJumpToc] performs a TOC jump (returns success for dismiss-on-success); [onJumpToAnnotation] is
+    68	 * the capability-based nullable annotation jump; [onShareAnnotations] is the Notes sheet-level Share.
+    69	 *
+    70	 * feature #134 WI-5 — the top-bar More menu + Book Details: when [bookDetails] is non-null the top-bar
+    71	 * More button appears and toggles the WI-3 [MorePopup] carrying ONLY the Details + Share rows; tapping
+    72	 * Details opens the [ReaderSheet.Details] sheet (the WI-4 [BookDetailsSheet] over [bookDetails]), tapping
+    73	 * Share fires [onShareBook], and the Details sheet's copy-fingerprint mini-action fires [onCopyFingerprint]
+    74	 * (the host copies to the OS clipboard — no invented copy-confirmation UI, rule 51). When [bookDetails] is
+    75	 * null the More button is omitted (no dead control) — a caller-supplied [onOpenMore] still populates the
+    76	 * More slot for hosts that want a different More action.
+    77	 *
+    78	 * feature #135 WI-5 — the top-bar bookmark toggle: when [onToggleBookmark] is non-null the scaffold fills
+    79	 * [ReaderTopChrome]'s reserved bookmark slot with the WI-5 [BookmarkToggleButton], rendered filled/outline
+    80	 * by [isCurrentBookmarked]; a null callback omits the slot (the #129 no-dead-control rule → #132
+    81	 * Contents/Notes-only callers stay valid). [currentLocator] is the current reading position the host uses
+    82	 * to derive presence + create the bookmark (threaded through for WI-7's host wiring; the scaffold itself
+    83	 * does not read it). A host that passes [topBookmarkSlot] directly overrides the built toggle (kept for
+    84	 * symmetry with [onOpenMore]).
+    85	 *
+    86	 * feature #135 WI-6 — the promoted two-tab TOC sheet: [ReaderSheet.Toc] renders [TocBookmarksSheet]
+    87	 * (Contents|Bookmarks, the Contents tab REUSING #132's body), and [ReaderSheet.Bookmarks] opens the same
+    88	 * sheet with the Bookmarks tab pre-selected. [bookmarks] are the projected Bookmarks-tab rows (default
+    89	 * empty); [onJumpBookmark] is the capability-based nullable bookmark jump (non-null → clickable rows +
+    90	 * dismiss-on-Succeeded; null → review-only, non-clickable rows, NO dead no-op). Both are nullable/defaulted
+    91	 * so #132 Contents/Notes-only callers stay valid (WI-7 feeds them per host).
+    92	 *
+    93	 * [bottomChrome] receives the Contents/Notes open callbacks (a null Contents callback when [tocEntries] is
+    94	 * empty) and renders the reader's bottom chrome. [body] is the reader content; a center-tap on it toggles
+    95	 * [ReaderChromeState.chromeVisible].
+    96	 */
+    97	@Composable
+    98	fun ReaderChromeScaffold(
+    99	    theme: ReaderTheme,
+   100	    title: String,
+   101	    chromeState: MutableState<ReaderChromeState>,
+   102	    onBack: () -> Unit,
+   103	    tocEntries: List<TocEntry>,
+   104	    currentTocIndex: Int,
+   105	    annotations: AnnotationsSnapshot,
+   106	    onJumpToc: (Int) -> Boolean,
+   107	    onJumpToAnnotation: ((AnnotationItem) -> Unit)?,
+   108	    onShareAnnotations: () -> Unit,
+   109	    bottomChrome: @Composable (onOpenContents: (() -> Unit)?, onOpenNotes: (() -> Unit)?) -> Unit,
+   110	    body: @Composable () -> Unit,
+   111	    modifier: Modifier = Modifier,
+   112	    onOpenSearch: (() -> Unit)? = null,
+   113	    onOpenMore: (() -> Unit)? = null,
+   114	    isCurrentBookmarked: Boolean = false,
+   115	    onToggleBookmark: (() -> Unit)? = null,
+   116	    currentLocator: Locator? = null,
+   117	    topBookmarkSlot: (@Composable () -> Unit)? = null,
+   118	    bookmarks: List<BookmarkRowItem> = emptyList(),
+   119	    onJumpBookmark: ((BookmarkRecord) -> JumpResult)? = null,
+   120	    bookDetails: BookDetailsUiModel? = null,
+   121	    onShareBook: () -> Unit = {},
+   122	    onCopyFingerprint: (String) -> Unit = {},
+   123	) {
+   124	    val state = chromeState.value
+   125	
+   126	    // feature #135 WI-5 — build the top-bar bookmark slot from the WI-5 [BookmarkToggleButton] when the
+   127	    // host opts in via [onToggleBookmark]. An explicit [topBookmarkSlot] (rare) wins; otherwise a non-null
+   128	    // toggle synthesizes the button, and a null toggle leaves the slot empty (no dead control).
+   129	    val bookmarkSlot: (@Composable () -> Unit)? = when {
+   130	        topBookmarkSlot != null -> topBookmarkSlot
+   131	        onToggleBookmark != null -> {
+   132	            { BookmarkToggleButton(theme = theme, isBookmarked = isCurrentBookmarked, onToggle = onToggleBookmark) }
+   133	        }
+   134	        else -> null
+   135	    }
+   136	
+   137	    // Sheet transitions read `chromeState.value` FRESH (never the composed-time [state] snapshot) so a
+   138	    // rapid open/dismiss can't clobber a concurrent visibility toggle.
+   139	    fun openSheet(sheet: ReaderSheet) { chromeState.value = chromeState.value.copy(sheet = sheet) }
+   140	
+   141	    // Contents is available only when there IS a table of contents; an empty TOC hides the control
+   142	    // (the scaffold hands the bottom chrome a null open callback, so it omits it — no dead control).
+   143	    val onOpenContents: (() -> Unit)? =
+   144	        if (tocEntries.isEmpty()) null else { { openSheet(ReaderSheet.Toc) } }
+   145	    val onOpenNotes: () -> Unit = { openSheet(ReaderSheet.Notes) }
+   146	
+   147	    // feature #134 WI-5 — the More menu is available only when this host has a Book-details data source.
+   148	    // The scaffold owns the popup-open state so the More button toggles it; a null [bookDetails] omits the
+   149	    // button (no dead control), falling back to any caller-supplied [onOpenMore].
+   150	    var showMore by remember { mutableStateOf(false) }
+   151	    val onMore: (() -> Unit)? = when {
+   152	        bookDetails != null -> { { showMore = true } }
+   153	        else -> onOpenMore
+   154	    }
+   155	
+   156	    Column(modifier.fillMaxSize().background(theme.background)) {
+   157	        if (state.chromeVisible) {
+   158	            ReaderTopChrome(
+   159	                theme = theme,
+   160	                title = title,
+   161	                onBack = onBack,
+   162	                onSearch = onOpenSearch,
+   163	                onMore = onMore,
+   164	                bookmarkSlot = bookmarkSlot,
+   165	            )
+   166	        }
+   167	
+   168	        // Body — fills the space between the bars; a center-tap toggles the chrome visibility.
+   169	        Box(
+   170	            Modifier
+   171	                .fillMaxWidth()
+   172	                .weight(1f)
+   173	                .pointerInput(Unit) {
+   174	                    detectTapGestures { chromeState.value = chromeState.value.copy(chromeVisible = !chromeState.value.chromeVisible) }
+   175	                },
+   176	        ) {
+   177	            body()
+   178	        }
+   179	
+   180	        if (state.chromeVisible) {
+   181	            bottomChrome(onOpenContents, onOpenNotes)
+   182	        }
+   183	    }
+   184	
+   185	    // feature #134 WI-5 — the More popover (Details + Share only). Details opens the Details sheet; Share
+   186	    // fires the host's book-share flow. Dismisses on a backdrop tap or after either action.
+   187	    if (showMore && bookDetails != null) {
+   188	        MorePopup(
+   189	            theme = theme,
+   190	            rows = readerMoreRows(
+   191	                onDetails = { showMore = false; openSheet(ReaderSheet.Details) },
+   192	                onShare = { showMore = false; onShareBook() },
+   193	            ),
+   194	            onDismiss = { showMore = false },
+   195	        )
+   196	    }
+   197	
+   198	    // Modal sheets — driven by the hoisted open-sheet state. Dismiss returns to [ReaderSheet.None].
+   199	    // feature #135 WI-6 — [onJumpBookmark] is passed through nullable (capability-gated); an unwired host
+   200	    // (#132/#134/#135-WI-5 callers) passes null → the Bookmarks-tab rows are review-only, NOT clickable
+   201	    // dead rows (WI-7 supplies the real per-host jump).
+   202	    when (state.sheet) {
+   203	        ReaderSheet.None -> Unit
+   204	        // feature #135 WI-6 — the promoted two-tab TOC sheet (Contents|Bookmarks). The Contents tab REUSES
+   205	        // #132's TocContentsSheet body unchanged; the Bookmarks tab renders [bookmarks].
+   206	        ReaderSheet.Toc -> TocBookmarksSheet(
+   207	            theme = theme,
+   208	            bookTitle = title,
+   209	            entries = tocEntries,
+   210	            currentTocIndex = currentTocIndex,
+   211	            bookmarks = bookmarks,
+   212	            onJumpToc = onJumpToc,
+   213	            onJumpBookmark = onJumpBookmark,
+   214	            onDismiss = { openSheet(ReaderSheet.None) },
+   215	        )
+   216	        ReaderSheet.Notes -> AnnotationsReviewSheet(
+   217	            theme = theme,
+   218	            snapshot = annotations,
+   219	            onShareAll = onShareAnnotations,
+   220	            onJumpToAnnotation = onJumpToAnnotation,
+   221	            onDismiss = { openSheet(ReaderSheet.None) },
+   222	        )
+   223	        // Render the Details sheet only when there IS a model; a Details route with no model (should not
+   224	        // happen — the route is only reachable when [bookDetails] fed the More menu) is a safe no-op.
+   225	        ReaderSheet.Details -> if (bookDetails != null) BookDetailsSheet(
+   226	            theme = theme,
+   227	            model = bookDetails,
+   228	            onCopyFingerprint = onCopyFingerprint,
+   229	            onShare = onShareBook,
+   230	            onDismiss = { openSheet(ReaderSheet.None) },
+   231	        )
+   232	        // feature #135 WI-6 — the Bookmarks route opens the SAME two-tab sheet with the Bookmarks tab
+   233	        // pre-selected (the designed [TocBookmarksSheet]; rule 51 — no invented list surface).
+   234	        ReaderSheet.Bookmarks -> TocBookmarksSheet(
+   235	            theme = theme,
+   236	            bookTitle = title,
+   237	            entries = tocEntries,
+   238	            currentTocIndex = currentTocIndex,
+   239	            bookmarks = bookmarks,
+   240	            onJumpToc = onJumpToc,
+   241	            onJumpBookmark = onJumpBookmark,
+   242	            onDismiss = { openSheet(ReaderSheet.None) },
+   243	            initialTab = TocTab.Bookmarks,
+   244	        )
+   245	    }
+   246	}
+   247	
+   248	/**
+   249	 * feature #134 WI-5 — the reader More-menu rows the scaffold + the EPUB chrome feed to the WI-3
+   250	 * [MorePopup]. #134 owns ONLY the Details + Share rows (the design's `vreader-more.jsx` `Book details` /
+   251	 * `Share book` actions); TTS / Auto-turn / Bilingual / Export are OTHER features' rows and are never
+   252	 * invented here (the §more-row-ownership contract + the #129 no-dead-control rule — the popup renders only
+   253	 * the rows it is given). Pure function of its two callbacks (no Compose runtime beyond the icon refs).
+   254	 */
+   255	internal fun readerMoreRows(onDetails: () -> Unit, onShare: () -> Unit): List<MoreRow> = listOf(
+   256	    MoreRow.Action(id = MoreActionId.DETAILS, label = "Book details", icon = Icons.Filled.Info, onTap = onDetails),
+   257	    MoreRow.Action(id = MoreActionId.SHARE, label = "Share book", icon = Icons.Filled.Share, onTap = onShare),
+   258	)
+     1	// Purpose: feature #132 WI-5 (#110 Phase 3) — the host-agnostic reader chrome state consumed by
+     2	// [ReaderChromeScaffold]: whether the top/bottom chrome is visible, and which modal sheet (if any) is
+     3	// open. #132 ships the Contents + Notes sheet routes; #134 WI-5 adds the [Details] (Book details) route
+     4	// reached from the top-bar More menu; #135 WI-5 adds the [Bookmarks] route (the token/Saver land here so
+     5	// the route survives process death; the designed Bookmarks LIST surface is WI-6's TocBookmarksSheet, so
+     6	// WI-5's render of this route is a no-op — no dead route until it has a data source).
+     7	// Persisted across rotation / process death via [ReaderChromeStateSaver] — a custom
+     8	// `Saver<ReaderChromeState, String>` mirroring #127's `SheetRouteSaver` (library/CollectionSheets.kt),
+     9	// because `rememberSaveable` cannot auto-persist an arbitrary class. Any unrecognized/malformed token
+    10	// restores to the safe fallback (`chromeVisible=false`, `sheet=None`) and NEVER throws.
+    11	package com.vreader.app.reader.chrome
+    12	
+    13	import androidx.compose.runtime.saveable.Saver
+    14	
+    15	/**
+    16	 * Which modal sheet the reader chrome currently shows. #132 has Contents ([Toc]) and Notes; #134 WI-5
+    17	 * adds [Details] (the Book details sheet, opened from the More menu); #135 WI-5 adds [Bookmarks] (the
+    18	 * two-tab TOC sheet's Bookmarks surface — routed here so it persists across process death; WI-6 renders
+    19	 * the designed surface, so WI-5 treats this route as a documented no-op).
+    20	 */
+    21	sealed interface ReaderSheet {
+    22	    data object None : ReaderSheet
+    23	    data object Toc : ReaderSheet
+    24	    data object Notes : ReaderSheet
+    25	    data object Details : ReaderSheet
+    26	    data object Bookmarks : ReaderSheet
+    27	}
+    28	
+    29	/**
+    30	 * Hoisted reader-chrome UI state. [chromeVisible] toggles the top/bottom bars (a center-tap on the body
+    31	 * flips it); [sheet] names the open modal sheet (default [ReaderSheet.None]). Defaults to chrome VISIBLE
+    32	 * with no sheet — the reader opens with its chrome shown.
+    33	 */
+    34	data class ReaderChromeState(
+    35	    val chromeVisible: Boolean = true,
+    36	    val sheet: ReaderSheet = ReaderSheet.None,
+    37	)
+    38	
+    39	/** The stable token for a [ReaderSheet] (used by [ReaderChromeStateSaver]; `None` never appears in a token). */
+    40	private fun ReaderSheet.token(): String = when (this) {
+    41	    ReaderSheet.None -> "none"
+    42	    ReaderSheet.Toc -> "toc"
+    43	    ReaderSheet.Notes -> "notes"
+    44	    ReaderSheet.Details -> "details"
+    45	    ReaderSheet.Bookmarks -> "bookmarks"
+    46	}
+    47	
+    48	/** Parses a sheet token; any unknown value falls back to [ReaderSheet.None] (never throws). */
+    49	private fun sheetFromToken(token: String): ReaderSheet = when (token) {
+    50	    "toc" -> ReaderSheet.Toc
+    51	    "notes" -> ReaderSheet.Notes
+    52	    "details" -> ReaderSheet.Details
+    53	    "bookmarks" -> ReaderSheet.Bookmarks
+    54	    else -> ReaderSheet.None
+    55	}
+    56	
+    57	/**
+    58	 * Serializes [ReaderChromeState] to a `"<visible>|<sheet>"` String so `rememberSaveable` survives
+    59	 * process death — the #127 `SheetRouteSaver` pattern. Restore is total: a malformed/empty/unknown token
+    60	 * (wrong separator, non-boolean flag, unknown sheet name) restores to the safe fallback
+    61	 * (`chromeVisible=false`, `sheet=None`) rather than throwing.
+    62	 */
+    63	val ReaderChromeStateSaver: Saver<ReaderChromeState, String> = Saver(
+    64	    save = { "${it.chromeVisible}|${it.sheet.token()}" },
+    65	    restore = { token ->
+    66	        val parts = token.split("|")
+    67	        if (parts.size != 2) {
+    68	            ReaderChromeState(chromeVisible = false, sheet = ReaderSheet.None)
+    69	        } else {
+    70	            val visible = parts[0].toBooleanStrictOrNull() ?: false
+    71	            ReaderChromeState(chromeVisible = visible, sheet = sheetFromToken(parts[1]))
+    72	        }
+    73	    },
+    74	)
+
+exec
+/bin/zsh -lc "rg -n \"enum class MoreActionId|sealed interface MoreRow|sealed class MoreRow|data class Disabled|fun MoreRowItem|MoreRowItem|onClick\" android/app/src/main/kotlin/com/vreader/app/reader/more android/app/src/main/kotlin/com/vreader/app/reader
+nl -ba android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt | sed -n '1,300p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/reader/EpubReaderChrome.kt | sed -n '1,360p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt:86:                    .clickable(onClick = onDismiss)
+android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt:110:                    rows.forEach { row -> MoreRowItem(theme, row) }
+android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt:128:private fun MoreRowItem(theme: ReaderTheme, row: MoreRow) {
+android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt:139:            enabled = true, onClick = row.onTap,
+android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt:146:            enabled = false, dim = true, subBold = true, onClick = {},
+android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt:153:            enabled = true, active = row.on, onClick = { row.onToggle(!row.on) },
+android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt:184:    onClick: () -> Unit,
+android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt:192:    val rowModifier = if (enabled) base.clickable(onClick = onClick) else base
+android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:19:enum class MoreActionId {
+android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:41:sealed interface MoreRow {
+android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:66:    data class Disabled(
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderScreen.kt:88:                Modifier.heightIn(min = 48.dp).clip(RoundedCornerShape(8.dp)).clickable(onClickLabel = "Library", onClick = onBack).padding(horizontal = 6.dp),
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderScreen.kt:244:                    .clickable(onClick = onOpenNotes)
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:266:                onClick = onJumpBookmark?.let { jump ->
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:278: * clickable → [onClick] ONLY when [onClick] is non-null (the capability gate — a null callback leaves it
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:282:private fun BookmarkRow(theme: ReaderTheme, item: BookmarkRowItem, onClick: (() -> Unit)?) {
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocBookmarksSheet.kt:297:    val rowModifier = (if (onClick != null) base.clickable { onClick() } else base)
+android/app/src/main/kotlin/com/vreader/app/reader/details/BookDetailsSheet.kt:149:                .clickable(onClick = onShare)
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocSheetRows.kt:42: * highlighted-chapter state). Tapping calls [onClick] with [index]. testTags: `toc-row-$index` (+
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocSheetRows.kt:51:    onClick: (Int) -> Unit,
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocSheetRows.kt:75:            .clickable { onClick(index) }
+android/app/src/main/kotlin/com/vreader/app/reader/details/BookDetailsRows.kt:243:                    .clickable(onClick = onShare)
+android/app/src/main/kotlin/com/vreader/app/reader/nav/TocContentsSheet.kt:142:                    onClick = { tapped -> if (onJump(tapped)) onDismiss() },
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:515:                    .clickable(onClick = onOpenNotes)
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:543:                Modifier.heightIn(min = 48.dp).clip(RoundedCornerShape(8.dp)).clickable(onClickLabel = "Library", onClick = onBack).padding(horizontal = 6.dp),
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheet.kt:87:                ThemeSwatch(swatch, selected = theme == swatch, ringColor = accent, labelColor = sub, onClick = { onTheme(swatch) }, modifier = Modifier.weight(1f))
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheet.kt:139:    onClick: () -> Unit,
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsSheet.kt:142:    Column(modifier.testTag("theme-${theme.name}").clickable { onClick() }, horizontalAlignment = Alignment.CenterHorizontally) {
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderTopChrome.kt:106:                    .clickable(onClick = onBack)
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderTopChrome.kt:141:                        onClick = onSearch,
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderTopChrome.kt:158:                        onClick = onMore,
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderTopChrome.kt:179:    onClick: () -> Unit,
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderTopChrome.kt:185:            .clickable(onClick = onClick)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:971:            .clickable(enabled = enabled, onClick = onReadAloud)
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/BookmarkToggleButton.kt:51:            .clickable(onClick = onToggle)
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderBottomChrome.kt:133:                        ink = ink, sub = sub, onClick = onOpenContents,
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderBottomChrome.kt:139:                        ink = ink, sub = sub, onClick = onOpenNotes,
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderBottomChrome.kt:168:    onClick: () -> Unit,
+android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderBottomChrome.kt:172:            .clickable(onClick = onClick)
+android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:19:enum class MoreActionId {
+android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:41:sealed interface MoreRow {
+android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:66:    data class Disabled(
+android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt:86:                    .clickable(onClick = onDismiss)
+android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt:110:                    rows.forEach { row -> MoreRowItem(theme, row) }
+android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt:128:private fun MoreRowItem(theme: ReaderTheme, row: MoreRow) {
+android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt:139:            enabled = true, onClick = row.onTap,
+android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt:146:            enabled = false, dim = true, subBold = true, onClick = {},
+android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt:153:            enabled = true, active = row.on, onClick = { row.onToggle(!row.on) },
+android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt:184:    onClick: () -> Unit,
+android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt:192:    val rowModifier = if (enabled) base.clickable(onClick = onClick) else base
+     1	// Purpose: feature #134 WI-3 — the reader More popover (`vreader-more.jsx` `MorePopover`): an anchored
+     2	// top-right popover (width 268, radius 16, a notch pointing at the "..." button) over a list of [MoreRow]
+     3	// rows the caller supplies. Renders ONLY the supplied rows — an id with no row is absent (no dead TTS/
+     4	// Auto-turn/Bilingual/Export rows; the plan's §more-row-ownership + #129 no-dead-control rule). Action
+     5	// rows fire onTap (chevron accessory), Toggle rows reflect `on` + call onToggle (switch accessory),
+     6	// Disabled rows are non-interactive with a sub-text. A transparent full-bleed backdrop dismisses on tap.
+     7	// Reuses the active [ReaderTheme]'s token map (ink/accent/isDark → the design's ink/sub/rule/surface
+     8	// tokens) so it matches the reader chrome. The host renders this inside the More-button anchor slot so
+     9	// the popup positions off the button's own layout coordinates (WI-5 wiring). Pure function of state.
+    10	package com.vreader.app.reader.more
+    11	
+    12	import androidx.compose.foundation.background
+    13	import androidx.compose.foundation.clickable
+    14	import androidx.compose.foundation.layout.Arrangement
+    15	import androidx.compose.foundation.layout.Box
+    16	import androidx.compose.foundation.layout.Column
+    17	import androidx.compose.foundation.layout.Row
+    18	import androidx.compose.foundation.layout.Spacer
+    19	import androidx.compose.foundation.layout.fillMaxSize
+    20	import androidx.compose.foundation.layout.fillMaxWidth
+    21	import androidx.compose.foundation.layout.height
+    22	import androidx.compose.foundation.layout.padding
+    23	import androidx.compose.foundation.layout.size
+    24	import androidx.compose.foundation.layout.width
+    25	import androidx.compose.foundation.layout.widthIn
+    26	import androidx.compose.foundation.shape.RoundedCornerShape
+    27	import androidx.compose.material.icons.Icons
+    28	import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+    29	import androidx.compose.material3.Icon
+    30	import androidx.compose.material3.Surface
+    31	import androidx.compose.material3.Switch
+    32	import androidx.compose.material3.SwitchDefaults
+    33	import androidx.compose.material3.Text
+    34	import androidx.compose.runtime.Composable
+    35	import androidx.compose.ui.Alignment
+    36	import androidx.compose.ui.Modifier
+    37	import androidx.compose.ui.draw.clip
+    38	import androidx.compose.ui.graphics.Color
+    39	import androidx.compose.ui.graphics.vector.ImageVector
+    40	import androidx.compose.ui.platform.testTag
+    41	import androidx.compose.ui.semantics.contentDescription
+    42	import androidx.compose.ui.semantics.semantics
+    43	import androidx.compose.ui.text.font.FontWeight
+    44	import androidx.compose.ui.text.style.TextOverflow
+    45	import androidx.compose.ui.unit.dp
+    46	import androidx.compose.ui.unit.sp
+    47	import androidx.compose.ui.window.Popup
+    48	import androidx.compose.ui.window.PopupProperties
+    49	import com.vreader.app.reader.settings.ReaderTheme
+    50	
+    51	private val POPUP_WIDTH = 268.dp
+    52	private val POPUP_RADIUS = 16.dp
+    53	private val SWITCH_ON_TRACK = Color(0xFF3A6A5A) // vreader-more.jsx ToggleSwitch on-track.
+    54	
+    55	/**
+    56	 * The reader More popover. [rows] are the caller-supplied rows in design order — the popup renders ONLY
+    57	 * these (no invented/dead rows). [onDismiss] fires on a backdrop tap. Anchored to the top-trailing edge
+    58	 * (under the "..." button in the top chrome) via a [Popup] with [Alignment.TopEnd]. Renders in [theme]'s
+    59	 * colors.
+    60	 */
+    61	@Composable
+    62	fun MorePopup(
+    63	    theme: ReaderTheme,
+    64	    rows: List<MoreRow>,
+    65	    onDismiss: () -> Unit,
+    66	    modifier: Modifier = Modifier,
+    67	) {
+    68	    // A single Popup that fills the window so the transparent backdrop can catch outside taps, and the
+    69	    // popover card is aligned to the top-trailing corner (the design's `top:92 right:14`). Compose flips
+    70	    // TopEnd to the leading edge automatically under RTL. `focusable` so the back button dismisses.
+    71	    Popup(
+    72	        alignment = Alignment.TopEnd,
+    73	        onDismissRequest = onDismiss,
+    74	        properties = PopupProperties(focusable = true),
+    75	    ) {
+    76	        Box(
+    77	            modifier
+    78	                .fillMaxSize()
+    79	                .testTag("more-popup"),
+    80	        ) {
+    81	            // Transparent full-bleed backdrop — a tap outside the card dismisses (the design's dim layer).
+    82	            Box(
+    83	                Modifier
+    84	                    .fillMaxSize()
+    85	                    .testTag("more-backdrop")
+    86	                    .clickable(onClick = onDismiss)
+    87	                    .semantics { contentDescription = "Dismiss menu" },
+    88	            )
+    89	
+    90	            // The popover card, offset from the top-trailing corner to sit under the "..." button. The
+    91	            // width is the design's 268dp but clamped ≤ available width (`widthIn(max)` + `fillMaxWidth`
+    92	            // capped by the parent 14dp end padding) so it never clips on a narrow screen.
+    93	            Surface(
+    94	                shape = RoundedCornerShape(POPUP_RADIUS),
+    95	                color = surfaceColor(theme),
+    96	                shadowElevation = 12.dp,
+    97	                tonalElevation = 0.dp,
+    98	                modifier = Modifier
+    99	                    .align(Alignment.TopEnd)
+   100	                    .padding(top = 8.dp, end = 14.dp)
+   101	                    .widthIn(max = POPUP_WIDTH)
+   102	                    .testTag("more-popup-card"),
+   103	            ) {
+   104	                // The design's fixed 268dp column; the Surface's widthIn(max) clamps it on a narrow window.
+   105	                Column(
+   106	                    Modifier
+   107	                        .width(POPUP_WIDTH)
+   108	                        .padding(vertical = 6.dp),
+   109	                ) {
+   110	                    rows.forEach { row -> MoreRowItem(theme, row) }
+   111	                }
+   112	            }
+   113	        }
+   114	    }
+   115	}
+   116	
+   117	/** The popover's fill color — the design's `#2a2724` (dark) / `#fcf8f0` (light). */
+   118	private fun surfaceColor(theme: ReaderTheme): Color =
+   119	    if (theme.isDark) Color(0xFF2A2724) else Color(0xFFFCF8F0)
+   120	
+   121	/**
+   122	 * One More-menu row, dispatched on the [MoreRow] shape. Layout mirrors `vreader-more.jsx` `Row`: a 28dp
+   123	 * rounded icon tile + a label (+ optional sub-text) + a trailing accessory (a switch for [MoreRow.Toggle],
+   124	 * a chevron for [MoreRow.Action]/[MoreRow.Disabled]). Renders in [theme]'s tokens. Disabled rows are
+   125	 * dimmed + non-interactive.
+   126	 */
+   127	@Composable
+   128	private fun MoreRowItem(theme: ReaderTheme, row: MoreRow) {
+   129	    val ink = theme.ink
+   130	    val sub = theme.ink.copy(alpha = 0.6f)
+   131	    val accent = theme.accent
+   132	    val slug = row.id.slug
+   133	
+   134	    when (row) {
+   135	        is MoreRow.Action -> RowScaffold(
+   136	            testTag = "more-row-$slug",
+   137	            icon = row.icon, label = row.label, sub = row.sub,
+   138	            ink = ink, sub_ = sub, accent = accent, isDark = theme.isDark,
+   139	            enabled = true, onClick = row.onTap,
+   140	        ) { ChevronAccessory(sub) }
+   141	
+   142	        is MoreRow.Disabled -> RowScaffold(
+   143	            testTag = "more-row-$slug",
+   144	            icon = row.icon, label = row.label, sub = row.sub,
+   145	            ink = ink, sub_ = accent, accent = accent, isDark = theme.isDark,
+   146	            enabled = false, dim = true, subBold = true, onClick = {},
+   147	        ) { ChevronAccessory(sub) }
+   148	
+   149	        is MoreRow.Toggle -> RowScaffold(
+   150	            testTag = "more-row-$slug",
+   151	            icon = row.icon, label = row.label, sub = row.sub,
+   152	            ink = ink, sub_ = sub, accent = accent, isDark = theme.isDark,
+   153	            enabled = true, active = row.on, onClick = { row.onToggle(!row.on) },
+   154	        ) {
+   155	            Switch(
+   156	                checked = row.on,
+   157	                onCheckedChange = { row.onToggle(it) },
+   158	                modifier = Modifier.testTag("more-row-toggle-$slug"),
+   159	                colors = SwitchDefaults.colors(checkedTrackColor = SWITCH_ON_TRACK),
+   160	            )
+   161	        }
+   162	    }
+   163	}
+   164	
+   165	/**
+   166	 * The shared row shell: an optional-click wrapper around the icon tile + text block + trailing
+   167	 * [accessory]. [enabled]=false makes the row non-interactive (no click action). [dim] applies the
+   168	 * design's disabled opacity; [active] tints the icon tile with the accent.
+   169	 */
+   170	@Composable
+   171	private fun RowScaffold(
+   172	    testTag: String,
+   173	    icon: ImageVector,
+   174	    label: String,
+   175	    sub: String?,
+   176	    ink: Color,
+   177	    sub_: Color,
+   178	    accent: Color,
+   179	    isDark: Boolean,
+   180	    enabled: Boolean,
+   181	    active: Boolean = false,
+   182	    dim: Boolean = false,
+   183	    subBold: Boolean = false,
+   184	    onClick: () -> Unit,
+   185	    accessory: @Composable () -> Unit,
+   186	) {
+   187	    val base = Modifier
+   188	        .fillMaxWidth()
+   189	        .testTag(testTag)
+   190	        .semantics { contentDescription = label }
+   191	    // A disabled row carries no click action (non-interactive, per the design + the test).
+   192	    val rowModifier = if (enabled) base.clickable(onClick = onClick) else base
+   193	    val contentAlpha = if (dim) 0.55f else 1f
+   194	
+   195	    Row(
+   196	        rowModifier.padding(horizontal = 14.dp, vertical = 11.dp),
+   197	        verticalAlignment = Alignment.CenterVertically,
+   198	        horizontalArrangement = Arrangement.spacedBy(12.dp),
+   199	    ) {
+   200	        // Icon tile — 28dp rounded (radius 8); accent-tinted background when active.
+   201	        Box(
+   202	            Modifier
+   203	                .size(28.dp)
+   204	                .clip(RoundedCornerShape(8.dp))
+   205	                .background(
+   206	                    if (active) accent.copy(alpha = if (isDark) 0.20f else 0.10f)
+   207	                    else ink.copy(alpha = if (isDark) 0.05f else 0.04f),
+   208	                ),
+   209	            contentAlignment = Alignment.Center,
+   210	        ) {
+   211	            Icon(
+   212	                icon, contentDescription = null,
+   213	                tint = (if (active) accent else ink).copy(alpha = contentAlpha),
+   214	                modifier = Modifier.size(15.dp),
+   215	            )
+   216	        }
+   217	
+   218	        // Text block — label (+ optional sub-text). Takes the remaining width; the accessory follows.
+   219	        Column(Modifier.weight(1f)) {
+   220	            Text(
+   221	                label,
+   222	                color = ink.copy(alpha = contentAlpha),
+   223	                fontSize = 14.5.sp,
+   224	                fontWeight = FontWeight.Medium,
+   225	                maxLines = 1,
+   226	                overflow = TextOverflow.Ellipsis,
+   227	            )
+   228	            if (sub != null) {
+   229	                Text(
+   230	                    sub,
+   231	                    color = sub_,
+   232	                    fontSize = 11.sp,
+   233	                    fontWeight = if (subBold) FontWeight.SemiBold else FontWeight.Normal,
+   234	                    maxLines = 1,
+   235	                    overflow = TextOverflow.Ellipsis,
+   236	                )
+   237	            }
+   238	        }
+   239	
+   240	        accessory()
+   241	    }
+   242	}
+   243	
+   244	@Composable
+   245	private fun ChevronAccessory(tint: Color) {
+   246	    Icon(
+   247	        Icons.AutoMirrored.Filled.KeyboardArrowRight,
+   248	        contentDescription = null,
+   249	        tint = tint,
+   250	        modifier = Modifier.size(16.dp),
+   251	    )
+   252	}
+   253	
+   254	/** A design divider between row groups (0.5dp, the theme rule token, inset 14dp). Kept for host use. */
+   255	@Composable
+   256	fun MoreMenuDivider(theme: ReaderTheme) {
+   257	    Box(
+   258	        Modifier
+   259	            .fillMaxWidth()
+   260	            .padding(horizontal = 14.dp, vertical = 4.dp),
+   261	    ) {
+   262	        Spacer(
+   263	            Modifier
+   264	                .fillMaxWidth()
+   265	                .height(0.5.dp)
+   266	                .background(theme.ink.copy(alpha = 0.10f)),
+   267	        )
+   268	    }
+   269	}
+     1	// Purpose: feature #132 WI-7-EPUB (#110 Phase 3) — the Compose chrome CONTENT for the EPUB reader host
+     2	// (ReaderActivity). The EPUB host is the outlier: a Readium EpubNavigatorFragment (a View) renders the
+     3	// page under the chrome, so — unlike the Compose-native TXT/PDF/AZW3 hosts — it CANNOT wrap the
+     4	// full-screen ReaderChromeScaffold (which owns a `weight(1f)` composable body). Instead the host stacks
+     5	// THREE separately-sized ComposeViews over the fragment's FrameLayout, each rendered by one composable
+     6	// here and each fed the persistent MutableStateFlow<ReaderChromeModel> + a hoisted ReaderChromeState:
+     7	//   • [EpubTopBand]    — the top ComposeView (title + "‹ Library" + — feature #134 WI-5 — the More button
+     8	//                         that toggles the WI-3 MorePopup); sized to the top chrome only.
+     9	//   • [EpubBottomBand] — the bottom ComposeView (progress + Contents/Notes/Display toolbar); sized to the
+    10	//                         bottom chrome only. Contents shown only when the model's TOC is non-empty.
+    11	//   • [EpubReaderSheets] — a full-screen ComposeView that is EMPTY (renders nothing, so it does not cover
+    12	//                         the fragment) until a sheet is open, at which point it lays a full-screen dismiss
+    13	//                         overlay + the Contents/Notes/Details ModalBottomSheet. This "open-only"
+    14	//                         full-screen posture is what keeps the Readium fragment's scroll/selection/link
+    15	//                         input working while no sheet is up — the top/bottom bands only cover the chrome
+    16	//                         regions.
+    17	// Contents onJump → the host's `navigator.go(entry.epubReadiumLocator)` (Boolean): dismiss on success,
+    18	// stay-open on false, NO invented error surface (rule 51 §nav-error-presentation). Notes → the WI-4 review
+    19	// sheet with onJumpToAnnotation NULL (EPUB review-only, cards non-clickable, until #135 supplies the nav
+    20	// seam). feature #134 WI-5 — Details → the WI-4 BookDetailsSheet over the host-supplied [bookDetails];
+    21	// the More menu carries ONLY Details + Share (Share → the host's book-share flow; copy-fingerprint → the
+    22	// host's OS clipboard copy, no invented toast — rule 51). Pure functions of state + callbacks (rule 50 §4);
+    23	// same ReaderTheme token map as the other hosts.
+    24	// @coordinates-with: ReaderActivity.kt (owns the StateFlow + the ComposeViews + the navigator jump + the
+    25	//   Book-details model/share/copy wiring), ReaderChromeModel.kt (the collected model), chrome/ReaderTopChrome
+    26	//   + chrome/ReaderBottomChrome (the reused designed bands), chrome/BookmarkToggleButton (the #135 top-bar
+    27	//   bookmark toggle filling the top band's bookmark slot), chrome/ReaderChromeState (the hoisted
+    28	//   sheet/visibility state incl. the #135 Bookmarks route), chrome/ReaderChromeScaffold (the shared
+    29	//   readerMoreRows assembler), more/MorePopup + details/BookDetailsSheet + nav/TocBookmarksSheet (the #135
+    30	//   WI-6 promoted two-tab Contents|Bookmarks sheet, which reuses nav/TocContentsSheet's Contents body) +
+    31	//   annotations/AnnotationsReviewSheet (the popup + modal sheets).
+    32	package com.vreader.app.reader
+    33	
+    34	import androidx.compose.foundation.clickable
+    35	import androidx.compose.foundation.interaction.MutableInteractionSource
+    36	import androidx.compose.foundation.layout.Box
+    37	import androidx.compose.foundation.layout.fillMaxSize
+    38	import androidx.compose.runtime.Composable
+    39	import androidx.compose.runtime.MutableState
+    40	import androidx.compose.runtime.getValue
+    41	import androidx.compose.runtime.mutableStateOf
+    42	import androidx.compose.runtime.remember
+    43	import androidx.compose.runtime.setValue
+    44	import androidx.compose.ui.Modifier
+    45	import androidx.compose.ui.platform.testTag
+    46	import androidx.lifecycle.compose.collectAsStateWithLifecycle
+    47	import com.vreader.app.annotations.AnnotationsReviewSheet
+    48	import com.vreader.app.reader.chrome.BookmarkToggleButton
+    49	import com.vreader.app.reader.chrome.ReaderBottomChrome
+    50	import com.vreader.app.reader.chrome.ReaderChromeState
+    51	import com.vreader.app.reader.chrome.ReaderSheet
+    52	import com.vreader.app.reader.chrome.ReaderTopChrome
+    53	import com.vreader.app.reader.chrome.readerMoreRows
+    54	import com.vreader.app.annotations.BookmarkRecord
+    55	import com.vreader.app.reader.details.BookDetailsSheet
+    56	import com.vreader.app.reader.details.BookDetailsUiModel
+    57	import com.vreader.app.reader.more.MorePopup
+    58	import com.vreader.app.reader.nav.BookmarkRowItem
+    59	import com.vreader.app.reader.nav.JumpResult
+    60	import com.vreader.app.reader.nav.TocBookmarksSheet
+    61	import com.vreader.app.reader.nav.TocTab
+    62	import com.vreader.app.reader.settings.ReaderTheme
+    63	import kotlinx.coroutines.flow.StateFlow
+    64	
+    65	/**
+    66	 * The EPUB top chrome band — the title + "‹ Library" back control (the WI-2 [ReaderTopChrome]) + —
+    67	 * feature #134 WI-5 — the More button. Rendered in its OWN top ComposeView sized to WRAP_CONTENT so it
+    68	 * covers only the top strip; the Readium fragment fills the rest. [model] supplies the live title;
+    69	 * [onBack] fires the back control. The More button appears ONLY when [bookDetails] is non-null (no dead
+    70	 * control) and toggles the WI-3 [MorePopup] carrying ONLY the Details + Share rows: Details writes
+    71	 * [ReaderSheet.Details] onto [chromeState] (so [EpubReaderSheets] shows the Book Details sheet), Share
+    72	 * fires [onShareBook]. The popup renders in its own window (a full-screen backdrop) so the WRAP_CONTENT
+    73	 * band height doesn't clip it. feature #133 WI-11 — the top-bar Search slot is now WIRED: [onSearch] fills
+    74	 * [ReaderTopChrome]'s Search slot (null → the icon is omitted — the #129 no-dead-control rule; a host whose
+    75	 * publication is not searchable / whose index-state gate reports Unsupported passes null so the icon
+    76	 * disappears). feature #135 WI-5 — the top-bar bookmark toggle: when [onToggleBookmark] is non-null the
+    77	 * band fills [ReaderTopChrome]'s bookmark slot with the WI-5 [BookmarkToggleButton] (filled/outline by
+    78	 * [isCurrentBookmarked]); a null callback leaves the slot empty (no dead control).
+    79	 */
+    80	@Composable
+    81	fun EpubTopBand(
+    82	    model: StateFlow<ReaderChromeModel>,
+    83	    theme: ReaderTheme,
+    84	    onBack: () -> Unit,
+    85	    chromeState: MutableState<ReaderChromeState>,
+    86	    bookDetails: BookDetailsUiModel?,
+    87	    onShareBook: () -> Unit,
+    88	    // feature #133 WI-11 — the in-book Search entry. A null [onSearch] omits the top-bar Search icon
+    89	    // (a non-searchable publication / Unsupported gate — no dead control). Nullable/default so #132/#134/#135
+    90	    // callers stay valid.
+    91	    onSearch: (() -> Unit)? = null,
+    92	    isCurrentBookmarked: Boolean = false,
+    93	    onToggleBookmark: (() -> Unit)? = null,
+    94	) {
+    95	    val chrome by model.collectAsStateWithLifecycle()
+    96	    var showMore by remember { mutableStateOf(false) }
+    97	    // More is available only when this book has a Book-details data source (no dead control).
+    98	    val onMore: (() -> Unit)? = if (bookDetails != null) ({ showMore = true }) else null
+    99	    // feature #135 WI-5 — the bookmark slot is built only when the host opts in via [onToggleBookmark].
+   100	    val bookmarkSlot: (@Composable () -> Unit)? =
+   101	        if (onToggleBookmark != null) {
+   102	            { BookmarkToggleButton(theme = theme, isBookmarked = isCurrentBookmarked, onToggle = onToggleBookmark) }
+   103	        } else {
+   104	            null
+   105	        }
+   106	    ReaderTopChrome(theme = theme, title = chrome.title, onBack = onBack, onSearch = onSearch, onMore = onMore, bookmarkSlot = bookmarkSlot)
+   107	    if (showMore && bookDetails != null) {
+   108	        MorePopup(
+   109	            theme = theme,
+   110	            rows = readerMoreRows(
+   111	                onDetails = { showMore = false; chromeState.value = chromeState.value.copy(sheet = ReaderSheet.Details) },
+   112	                onShare = { showMore = false; onShareBook() },
+   113	            ),
+   114	            onDismiss = { showMore = false },
+   115	        )
+   116	    }
+   117	}
+   118	
+   119	/**
+   120	 * The EPUB bottom chrome band — the progress scrubber + the Contents/Notes/Display toolbar (the extended
+   121	 * WI-5 [ReaderBottomChrome]). Rendered in its OWN bottom ComposeView sized to WRAP_CONTENT so it covers
+   122	 * only the bottom strip. Contents opens the TOC sheet ONLY when the model has a non-empty TOC (else the
+   123	 * control is omitted — no dead control); Notes opens the review sheet; Display opens the #129 settings
+   124	 * sheet ([onOpenDisplay], preserved). [progress] is 0..1 (the host's live reading fraction); [onScrub]
+   125	 * seeks. Opening a sheet writes [chromeState] so [EpubReaderSheets] shows it.
+   126	 */
+   127	@Composable
+   128	fun EpubBottomBand(
+   129	    model: StateFlow<ReaderChromeModel>,
+   130	    theme: ReaderTheme,
+   131	    chromeState: MutableState<ReaderChromeState>,
+   132	    progress: Float,
+   133	    onScrub: (Float) -> Unit,
+   134	    onOpenDisplay: () -> Unit,
+   135	) {
+   136	    val chrome by model.collectAsStateWithLifecycle()
+   137	    // Contents available only when there IS a TOC — an empty TOC hides the control (no dead control).
+   138	    val onOpenContents: (() -> Unit)? =
+   139	        if (chrome.tocEntries.isEmpty()) null
+   140	        else { { chromeState.value = chromeState.value.copy(sheet = ReaderSheet.Toc) } }
+   141	    ReaderBottomChrome(
+   142	        theme = theme,
+   143	        progress = progress,
+   144	        displayPage = 0,
+   145	        totalPages = 0, // EPUB scroll layout — no page labels (Spike-B scroll mode)
+   146	        onScrub = onScrub,
+   147	        onOpenDisplay = onOpenDisplay,
+   148	        onOpenContents = onOpenContents,
+   149	        onOpenNotes = { chromeState.value = chromeState.value.copy(sheet = ReaderSheet.Notes) },
+   150	    )
+   151	}
+   152	
+   153	/**
+   154	 * The EPUB modal-sheet layer — the open-only full-screen dismiss overlay + the Contents / Notes / Details
+   155	 * sheets. Rendered in a FULL-SCREEN ComposeView that renders NOTHING while [ReaderChromeState.sheet] is
+   156	 * [ReaderSheet.None] (so it does not cover the fragment); the instant a sheet opens it lays a full-screen
+   157	 * dismiss overlay (a transparent scrim that dismisses the sheet on an outside tap) beneath the
+   158	 * ModalBottomSheet. This keeps the Readium fragment's scroll/selection/link input alive whenever no sheet
+   159	 * is up.
+   160	 *
+   161	 * [onJumpToc] performs the native-locator TOC jump (returns success → the Contents tab dismisses on
+   162	 * success, stays open on false — no invented error surface). [onShareAnnotations] is the Notes sheet-level
+   163	 * Share. EPUB Notes cards are review-only (onJumpToAnnotation NULL) until #135's nav seam lands. feature
+   164	 * #135 WI-6 — the Toc route renders the promoted two-tab [TocBookmarksSheet]; [bookmarks] feed its
+   165	 * Bookmarks tab and [onJumpBookmark] is the capability-based nullable bookmark jump (non-null → clickable
+   166	 * rows + dismiss-on-Succeeded; null → review-only, non-clickable rows before WI-7 lights up the EPUB jump);
+   167	 * the Bookmarks route opens the same sheet on its Bookmarks tab. feature #134 WI-5 — [bookDetails] drives the Details sheet
+   168	 * (the WI-4 [BookDetailsSheet]); [onShareBook] is its Share flow and [onCopyFingerprint] its copy-fingerprint
+   169	 * mini-action (the host copies to the OS clipboard — no invented toast, rule 51). A Details route with no
+   170	 * [bookDetails] (should not happen — the route is only reachable when the More menu was fed a model) treats
+   171	 * the scrim as present but shows no sheet (a safe no-op).
+   172	 */
+   173	@Composable
+   174	fun EpubReaderSheets(
+   175	    model: StateFlow<ReaderChromeModel>,
+   176	    theme: ReaderTheme,
+   177	    chromeState: MutableState<ReaderChromeState>,
+   178	    onJumpToc: (Int) -> Boolean,
+   179	    onShareAnnotations: () -> Unit,
+   180	    bookDetails: BookDetailsUiModel? = null,
+   181	    onShareBook: () -> Unit = {},
+   182	    onCopyFingerprint: (String) -> Unit = {},
+   183	    bookmarks: List<BookmarkRowItem> = emptyList(),
+   184	    onJumpBookmark: ((BookmarkRecord) -> JumpResult)? = null,
+   185	) {
+   186	    val chrome by model.collectAsStateWithLifecycle()
+   187	    val sheet = chromeState.value.sheet
+   188	    if (sheet is ReaderSheet.None) return // render nothing → the fragment keeps all input
+   189	
+   190	    fun closeSheet() { chromeState.value = chromeState.value.copy(sheet = ReaderSheet.None) }
+   191	
+   192	    // feature #134 WI-5 — a Details route with NO model would render no sheet yet still lay the
+   193	    // full-screen dismiss overlay below, silently intercepting Readium scroll/selection/link input (a
+   194	    // dead route). Normalize it back to None so touch-through is preserved (Gate-4 P1). In practice this
+   195	    // route is only reached once [bookDetails] fed the More menu, so this is a defensive guard.
+   196	    if (sheet is ReaderSheet.Details && bookDetails == null) {
+   197	        closeSheet()
+   198	        return
+   199	    }
+   200	
+   201	    // feature #135 WI-6 — the Bookmarks route now DOES render (the two-tab TocBookmarksSheet with the
+   202	    // Bookmarks tab pre-selected), so it is NOT normalized away — it lays the scrim + the sheet like Toc.
+   203	
+   204	    // The open-only full-screen dismiss overlay — a transparent scrim under the sheet. An outside tap
+   205	    // (a tap that reaches the scrim, not the sheet) closes the sheet. Present ONLY while a sheet is open.
+   206	    Box(
+   207	        Modifier
+   208	            .fillMaxSize()
+   209	            .testTag("epub-sheet-dismiss-overlay")
+   210	            .clickable(
+   211	                interactionSource = remember { MutableInteractionSource() },
+   212	                indication = null,
+   213	            ) { closeSheet() },
+   214	    )
+   215	
+   216	    when (sheet) {
+   217	        ReaderSheet.None -> Unit
+   218	        // feature #135 WI-6 — the promoted two-tab TOC sheet (Contents|Bookmarks). The Contents tab REUSES
+   219	        // #132's TocContentsSheet body unchanged; dismiss-on-success (Contents) / dismiss-on-Succeeded
+   220	        // (Bookmarks) — a false/Failed jump keeps the sheet open, NO invented error surface (rule 51).
+   221	        ReaderSheet.Toc -> TocBookmarksSheet(
+   222	            theme = theme,
+   223	            bookTitle = chrome.title,
+   224	            entries = chrome.tocEntries,
+   225	            currentTocIndex = chrome.currentTocIndex,
+   226	            bookmarks = bookmarks,
+   227	            onJumpToc = onJumpToc,
+   228	            onJumpBookmark = onJumpBookmark,
+   229	            onDismiss = { closeSheet() },
+   230	        )
+   231	        ReaderSheet.Notes -> AnnotationsReviewSheet(
+   232	            theme = theme,
+   233	            snapshot = chrome.annotations,
+   234	            onShareAll = onShareAnnotations,
+   235	            // EPUB is review-only until #135 supplies the jump-to-annotation nav seam → cards non-clickable.
+   236	            onJumpToAnnotation = null,
+   237	            onDismiss = { closeSheet() },
+   238	        )
+   239	        // feature #134 WI-5 — the Book Details sheet. Rendered only when there IS a model (the Details
+   240	        // route is only reachable when [bookDetails] fed the More menu); a null model is a safe no-op.
+   241	        ReaderSheet.Details -> if (bookDetails != null) BookDetailsSheet(
+   242	            theme = theme,
+   243	            model = bookDetails,
+   244	            onCopyFingerprint = onCopyFingerprint,
+   245	            onShare = onShareBook,
+   246	            onDismiss = { closeSheet() },
+   247	        )
+   248	        // feature #135 WI-6 — the Bookmarks route opens the SAME two-tab sheet with the Bookmarks tab
+   249	        // pre-selected (the designed [TocBookmarksSheet]; rule 51 — no invented list surface).
+   250	        ReaderSheet.Bookmarks -> TocBookmarksSheet(
+   251	            theme = theme,
+   252	            bookTitle = chrome.title,
+   253	            entries = chrome.tocEntries,
+   254	            currentTocIndex = chrome.currentTocIndex,
+   255	            bookmarks = bookmarks,
+   256	            onJumpToc = onJumpToc,
+   257	            onJumpBookmark = onJumpBookmark,
+   258	            onDismiss = { closeSheet() },
+   259	            initialTab = TocTab.Bookmarks,
+   260	        )
+   261	    }
+   262	}
+
+exec
+/bin/zsh -lc "nl -ba android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt | sed -n '1,130p'
+rg -n \"NavHost|composable\\(|navigation\\(|AiProviderListScreen|AiProviderEditSheet|AiSettingsViewModel|AiProviderStore\" android/app/src/main/kotlin android/app/src/test/kotlin android/app/src/androidTest/kotlin
+rg -n \"setContent|LibraryScreen|startActivity|ReaderActivity|TxtReaderActivity|PdfReaderActivity|Azw3ReaderActivity\" android/app/src/main/kotlin/com/vreader/app/MainActivity.kt android/app/src/main/kotlin/com/vreader/app/library/LibraryScreen.kt" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+     1	// Purpose: feature #134 WI-3 — the reader More-menu ROW model (`vreader-more.jsx` `MorePopover` rows),
+     2	// rendered by [MorePopup]. A `sealed interface` so each row carries a stable [MoreActionId] + its own
+     3	// callback + (for toggles) its own on/onToggle state. The row's OWNER supplies it: #134 owns only
+     4	// DETAILS + SHARE (Action rows); TTS/AUTO_TURN/BILINGUAL ids exist so their owning features (#121/#131/
+     5	// a future Auto-turn feature) can supply rows, but a row is NEVER invented here — an id with no supplied
+     6	// row is simply absent from the popup (the plan's §more-row-ownership contract; the #129 no-dead-control
+     7	// rule). Pure model: an ImageVector icon ref + strings + lambdas, no Compose UI in the type itself.
+     8	package com.vreader.app.reader.more
+     9	
+    10	import androidx.compose.ui.graphics.vector.ImageVector
+    11	
+    12	/**
+    13	 * A stable identifier for a More-menu row. Used for the row's testTag (`more-row-$id`) and to key row
+    14	 * ownership. #134 owns [DETAILS] + [SHARE]; the others exist so their owning features can supply rows —
+    15	 * #134 supplies none of them and omits any id it is not given a row for. There is deliberately NO
+    16	 * `EXPORT` id: Android has no annotation-export subsystem, so the Export row is never rendered (the
+    17	 * plan's scoped-out invariant), and absence-by-omission is enforced by there being no id to supply.
+    18	 */
+    19	enum class MoreActionId {
+    20	    DETAILS,
+    21	    SHARE,
+    22	    TTS,
+    23	    AUTO_TURN,
+    24	    BILINGUAL,
+    25	}
+    26	
+    27	/** The lowercase stable slug for this id — the testTag / route suffix (e.g. `AUTO_TURN` → `auto_turn`). */
+    28	val MoreActionId.slug: String
+    29	    get() = name.lowercase()
+    30	
+    31	/**
+    32	 * A single More-menu row. Exactly one of three shapes, mirroring the design's three row treatments:
+    33	 *  - [Action]   — a tap row with a trailing chevron (`vreader-more.jsx` `onAction`).
+    34	 *  - [Toggle]   — a stateful row with a trailing switch reflecting [Toggle.on] (`onToggle`).
+    35	 *  - [Disabled] — the design's disabled state (e.g. Bilingual "Configure AI provider first"):
+    36	 *                 non-interactive, dimmed, shows its [Disabled.sub].
+    37	 *
+    38	 * Every row carries a stable [id] (its testTag key) and its own callback. The OWNER of a row's behavior
+    39	 * is the feature that supplies it — never [MorePopup] itself.
+    40	 */
+    41	sealed interface MoreRow {
+    42	    val id: MoreActionId
+    43	    val label: String
+    44	    val icon: ImageVector
+    45	
+    46	    /** A tap row: fires [onTap]; renders a trailing chevron accessory. */
+    47	    data class Action(
+    48	        override val id: MoreActionId,
+    49	        override val label: String,
+    50	        override val icon: ImageVector,
+    51	        val sub: String? = null,
+    52	        val onTap: () -> Unit,
+    53	    ) : MoreRow
+    54	
+    55	    /** A toggle row: the trailing switch reflects [on]; tapping the row calls [onToggle] with `!on`. */
+    56	    data class Toggle(
+    57	        override val id: MoreActionId,
+    58	        override val label: String,
+    59	        override val icon: ImageVector,
+    60	        val sub: String? = null,
+    61	        val on: Boolean,
+    62	        val onToggle: (Boolean) -> Unit,
+    63	    ) : MoreRow
+    64	
+    65	    /** A disabled row: non-interactive, dimmed, shows [sub] (the design's "Configure AI provider first"). */
+    66	    data class Disabled(
+    67	        override val id: MoreActionId,
+    68	        override val label: String,
+    69	        override val icon: ImageVector,
+    70	        val sub: String,
+    71	        val onTap: () -> Unit,
+    72	    ) : MoreRow
+    73	}
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderEditSheetTest.kt:21:class AiProviderEditSheetTest {
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderEditSheetTest.kt:25:        compose.setContent { BackupSurface(darkOverride = false) { AiProviderEditSheet(AiEditState(editMode = false)) } }
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderEditSheetTest.kt:38:        compose.setContent { BackupSurface(darkOverride = false) { AiProviderEditSheet(AiEditState(), onKind = { picked = it }) } }
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderEditSheetTest.kt:44:        compose.setContent { BackupSurface(darkOverride = false) { AiProviderEditSheet(AiEditState(apiKey = "")) } }
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderEditSheetTest.kt:51:                AiProviderEditSheet(AiEditState(apiKey = "sk", test = AiConnTest.ok, testMessage = "Connected — the provider responded successfully."))
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderEditSheetTest.kt:60:                AiProviderEditSheet(AiEditState(editMode = true, id = "x", name = "DeepSeek", keyAlreadySaved = true))
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderListScreenTest.kt:17:class AiProviderListScreenTest {
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderListScreenTest.kt:23:            BackupSurface(darkOverride = false) { AiProviderListScreen(AiProviderListState(emptyList()), onAdd = { added = true }) }
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderListScreenTest.kt:38:        compose.setContent { BackupSurface(darkOverride = false) { AiProviderListScreen(state, onEdit = { edited = it }) } }
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderFactory.kt:3:// AiProviderStore.snapshot(), decrypts via apiKey(profile), and calls this — so the client is built
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:46:fun AiProviderListScreen(
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:41:class AiProviderStore(
+android/app/src/test/kotlin/com/vreader/app/ai/AiChatViewModelTest.kt:36:    private lateinit var store: AiProviderStore
+android/app/src/test/kotlin/com/vreader/app/ai/AiChatViewModelTest.kt:48:        store = AiProviderStore(PreferenceDataStoreFactory.create(scope = CoroutineScope(dispatcher)) { tmp.newFile("ai.preferences_pb") }, cipher)
+android/app/src/test/kotlin/com/vreader/app/ai/AiSettingsViewModelTest.kt:29:class AiSettingsViewModelTest {
+android/app/src/test/kotlin/com/vreader/app/ai/AiSettingsViewModelTest.kt:37:    private lateinit var store: AiProviderStore
+android/app/src/test/kotlin/com/vreader/app/ai/AiSettingsViewModelTest.kt:48:        store = AiProviderStore(
+android/app/src/test/kotlin/com/vreader/app/ai/AiSettingsViewModelTest.kt:57:        AiSettingsViewModel(store, dispatcher) { _, _ -> FakeClient(result) }
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt:2:// ACTIVE provider from one AiProviderStore snapshot, streams a chat answer (accumulating deltas),
+android/app/src/main/kotlin/com/vreader/app/ai/AiChatViewModel.kt:24:    private val store: AiProviderStore,
+android/app/src/test/kotlin/com/vreader/app/ai/AiProviderStoreTest.kt:21: * Feature #118 WI-1 — AiProviderStore CRUD + active-id + key-as-cipher-token, with a temp DataStore
+android/app/src/test/kotlin/com/vreader/app/ai/AiProviderStoreTest.kt:26:class AiProviderStoreTest {
+android/app/src/test/kotlin/com/vreader/app/ai/AiProviderStoreTest.kt:35:    private lateinit var store: AiProviderStore
+android/app/src/test/kotlin/com/vreader/app/ai/AiProviderStoreTest.kt:39:        store = AiProviderStore(dataStore, fakeCipher)
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:2:// AiProviderStore for the list, owns the editor form state, runs Test Connection against the LIVE
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:20:class AiSettingsViewModel(
+android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:21:    private val store: AiProviderStore,
+android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt:55:fun AiProviderEditSheet(
+android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:65:    // AiProviderStore precedent), global (not per-book), process-singleton so a settings change
+android/app/src/main/kotlin/com/vreader/app/opds/ui/OpdsSourcesViewModel.kt:4:// #118 AiSettingsViewModel test path), and saves/deletes. The password is never logged.
+android/app/src/main/kotlin/com/vreader/app/opds/ui/OpdsSourcesViewModel.kt:50:    // closed form). Mirrors AiSettingsViewModel.testGen.
+android/app/src/main/kotlin/com/vreader/app/reader/settings/ReaderSettingsStore.kt:2:// DataStore (the OpdsSourceStore / AiProviderStore JSON-in-Preferences precedent). Global, device-
+android/app/src/main/kotlin/com/vreader/app/library/LibraryScreen.kt:56:fun LibraryScreen(
+android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:8://   (the DI container), library/LibraryViewModel.kt, library/LibraryScreen.kt
+android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:15:import androidx.activity.compose.setContent
+android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:29:import com.vreader.app.library.LibraryScreen
+android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:33:import com.vreader.app.reader.Azw3ReaderActivity
+android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:34:import com.vreader.app.reader.ReaderActivity
+android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:35:import com.vreader.app.reader.PdfReaderActivity
+android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:36:import com.vreader.app.reader.TxtReaderActivity
+android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:50:        setContent {
+android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:82:                            startActivity(ReaderActivity.intent(this@MainActivity, key))
+android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:86:                            startActivity(TxtReaderActivity.intent(this@MainActivity, key))
+android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:89:                            startActivity(PdfReaderActivity.intent(this@MainActivity, key))
+android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:92:                            startActivity(Azw3ReaderActivity.intent(this@MainActivity, key))
+android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:96:                LibraryScreen(
+
+codex
+The core reachability premise is confirmed so far: the production tree contains the types, but the only direct screen invocations are connected tests, and `AppContainer` mentions `AiProviderStore` only in a comment. I’m now checking the higher-risk mismatch: the plan equates “any profile exists” with “AI is configured,” while the requested readiness contract is an active profile with a usable, non-empty key.
+exec
+/bin/zsh -lc "nl -ba android/app/src/main/kotlin/com/vreader/app/backup/net/SecretCipher.kt | sed -n '1,260p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/backup/net/WebDavServerStore.kt | sed -n '1,260p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/opds/OpdsSourceStore.kt | sed -n '1,180p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsUiState.kt | sed -n '1,250p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/MainActivity.kt | sed -n '35,120p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/library/LibraryScreen.kt | sed -n '45,115p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+     1	// Purpose: feature #116 WI-5 (#110 Phase 3) — symmetric encryption for WebDAV passwords at rest.
+     2	// The store keeps a password only as a SecretCipher token (never plaintext); the production
+     3	// impl wraps an AndroidKeyStore AES-GCM key (hardware-backed where available, non-exportable),
+     4	// chosen over EncryptedSharedPreferences (deprecated AndroidX Security-Crypto — Gate-2 Low-2).
+     5	// The interface lets WebDavServerStore be unit-tested with a fake (AndroidKeyStore isn't
+     6	// available under Robolectric/JVM).
+     7	package com.vreader.app.backup.net
+     8	
+     9	import android.security.keystore.KeyGenParameterSpec
+    10	import android.security.keystore.KeyProperties
+    11	import java.security.KeyStore
+    12	import java.util.Base64
+    13	import javax.crypto.Cipher
+    14	import javax.crypto.KeyGenerator
+    15	import javax.crypto.SecretKey
+    16	import javax.crypto.spec.GCMParameterSpec
+    17	
+    18	/** Reversibly protects a secret string. [encrypt]/[decrypt] round-trip; the token is opaque. */
+    19	interface SecretCipher {
+    20	    fun encrypt(plaintext: String): String
+    21	    fun decrypt(token: String): String
+    22	}
+    23	
+    24	/**
+    25	 * AES-256-GCM via a non-exportable AndroidKeyStore key. The token is base64( iv ‖ ciphertext ),
+    26	 * a fresh random IV per encryption (GCM requirement). Not unit-testable under Robolectric (no
+    27	 * AndroidKeyStore); exercised on-device in WI-6.
+    28	 */
+    29	class KeystoreSecretCipher(private val alias: String = DEFAULT_ALIAS) : SecretCipher {
+    30	    override fun encrypt(plaintext: String): String {
+    31	        val cipher = Cipher.getInstance(TRANSFORMATION)
+    32	        cipher.init(Cipher.ENCRYPT_MODE, key())
+    33	        val iv = cipher.iv
+    34	        val ct = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
+    35	        return Base64.getEncoder().encodeToString(iv + ct)
+    36	    }
+    37	
+    38	    override fun decrypt(token: String): String {
+    39	        val blob = Base64.getDecoder().decode(token)
+    40	        val iv = blob.copyOfRange(0, IV_BYTES)
+    41	        val ct = blob.copyOfRange(IV_BYTES, blob.size)
+    42	        val cipher = Cipher.getInstance(TRANSFORMATION)
+    43	        cipher.init(Cipher.DECRYPT_MODE, key(), GCMParameterSpec(TAG_BITS, iv))
+    44	        return String(cipher.doFinal(ct), Charsets.UTF_8)
+    45	    }
+    46	
+    47	    private fun key(): SecretKey {
+    48	        val ks = KeyStore.getInstance(KEYSTORE).apply { load(null) }
+    49	        (ks.getEntry(alias, null) as? KeyStore.SecretKeyEntry)?.let { return it.secretKey }
+    50	        val gen = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEYSTORE)
+    51	        gen.init(
+    52	            KeyGenParameterSpec.Builder(
+    53	                alias, KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+    54	            )
+    55	                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+    56	                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+    57	                .setKeySize(256)
+    58	                .build()
+    59	        )
+    60	        return gen.generateKey()
+    61	    }
+    62	
+    63	    companion object {
+    64	        const val DEFAULT_ALIAS = "vreader.webdav.password"
+    65	        private const val KEYSTORE = "AndroidKeyStore"
+    66	        private const val TRANSFORMATION = "AES/GCM/NoPadding"
+    67	        private const val IV_BYTES = 12
+    68	        private const val TAG_BITS = 128
+    69	    }
+    70	}
+     1	// Purpose: feature #116 WI-5 (#110 Phase 3) — persists saved WebDAV server profiles. URL / user /
+     2	// name / wifiOnly live in DataStore as a JSON list; the password is kept only as a SecretCipher
+     3	// token (AndroidKeyStore AES-GCM in production). The WebDavBackupService (WI-5b) reads a profile +
+     4	// decrypts its password to build a WebDavClient. Chosen over EncryptedSharedPreferences (Gate-2
+     5	// Low-2). All ops suspend; `observe()` is reactive for the #114 server-list UI.
+     6	package com.vreader.app.backup.net
+     7	
+     8	import androidx.datastore.core.DataStore
+     9	import androidx.datastore.preferences.core.Preferences
+    10	import androidx.datastore.preferences.core.edit
+    11	import androidx.datastore.preferences.core.stringPreferencesKey
+    12	import kotlinx.coroutines.flow.Flow
+    13	import kotlinx.coroutines.flow.first
+    14	import kotlinx.coroutines.flow.map
+    15	import kotlinx.serialization.Serializable
+    16	import kotlinx.serialization.json.Json
+    17	
+    18	/** A saved server. `encryptedPassword` is a [SecretCipher] token, never plaintext. */
+    19	@Serializable
+    20	data class WebDavServerProfile(
+    21	    val id: String,
+    22	    val name: String,
+    23	    val baseUrl: String,
+    24	    val username: String,
+    25	    val encryptedPassword: String,
+    26	    val wifiOnly: Boolean,
+    27	)
+    28	
+    29	class WebDavServerStore(
+    30	    private val dataStore: DataStore<Preferences>,
+    31	    private val cipher: SecretCipher,
+    32	    private val json: Json = Json { ignoreUnknownKeys = true; encodeDefaults = true },
+    33	) {
+    34	    /** All saved profiles (password still encrypted). */
+    35	    suspend fun list(): List<WebDavServerProfile> = read(dataStore.data.first())
+    36	
+    37	    /** Reactive list for the server-list UI. */
+    38	    fun observe(): Flow<List<WebDavServerProfile>> = dataStore.data.map(::read)
+    39	
+    40	    /**
+    41	     * Inserts or updates a profile by [id]. [password] is the PLAINTEXT to encrypt; pass null on an
+    42	     * edit that leaves the password unchanged (the existing ciphertext is kept). Returns the saved
+    43	     * profile (password encrypted). Throws if [password] is null for a brand-new id.
+    44	     */
+    45	    suspend fun upsert(
+    46	        id: String,
+    47	        name: String,
+    48	        baseUrl: String,
+    49	        username: String,
+    50	        password: String?,
+    51	        wifiOnly: Boolean,
+    52	    ): WebDavServerProfile {
+    53	        lateinit var saved: WebDavServerProfile
+    54	        dataStore.edit { prefs ->
+    55	            val current = read(prefs)
+    56	            val existing = current.firstOrNull { it.id == id }
+    57	            val encrypted = when {
+    58	                password != null -> cipher.encrypt(password)
+    59	                existing != null -> existing.encryptedPassword  // unchanged on edit
+    60	                else -> throw IllegalArgumentException("a new server ($id) requires a password")
+    61	            }
+    62	            saved = WebDavServerProfile(id, name, baseUrl, username, encrypted, wifiOnly)
+    63	            val next = current.filterNot { it.id == id } + saved
+    64	            prefs[KEY] = json.encodeToString(next)
+    65	        }
+    66	        return saved
+    67	    }
+    68	
+    69	    /** Removes a profile (no-op if absent). */
+    70	    suspend fun delete(id: String) {
+    71	        dataStore.edit { prefs ->
+    72	            val next = read(prefs).filterNot { it.id == id }
+    73	            prefs[KEY] = json.encodeToString(next)
+    74	        }
+    75	    }
+    76	
+    77	    /** The decrypted password for [id], or null if the profile doesn't exist. */
+    78	    suspend fun password(id: String): String? =
+    79	        list().firstOrNull { it.id == id }?.let { cipher.decrypt(it.encryptedPassword) }
+    80	
+    81	    private fun read(prefs: Preferences): List<WebDavServerProfile> {
+    82	        val raw = prefs[KEY] ?: return emptyList()
+    83	        return runCatching { json.decodeFromString<List<WebDavServerProfile>>(raw) }.getOrDefault(emptyList())
+    84	    }
+    85	
+    86	    companion object {
+    87	        private val KEY = stringPreferencesKey("webdav_servers_json")
+    88	    }
+    89	}
+     1	// Purpose: feature #120 WI-1 (#110 Phase 3) — persists saved OPDS catalogs. Name/URL/requiresAuth/
+     2	// username live in DataStore as a JSON list; the optional password is kept ONLY as a SecretCipher
+     3	// token (a DISTINCT AndroidKeyStore alias from WebDAV/AI — `vreader.opds.password`). Reuses the #116
+     4	// WebDavServerStore DataStore+cipher pattern. `clientFor(source)` builds an origin-scoped #117
+     5	// OpdsClient. The password is never logged.
+     6	package com.vreader.app.opds
+     7	
+     8	import androidx.datastore.core.DataStore
+     9	import androidx.datastore.preferences.core.Preferences
+    10	import androidx.datastore.preferences.core.edit
+    11	import androidx.datastore.preferences.core.stringPreferencesKey
+    12	import com.vreader.app.backup.net.KeystoreSecretCipher
+    13	import com.vreader.app.backup.net.SecretCipher
+    14	import kotlinx.coroutines.flow.Flow
+    15	import kotlinx.coroutines.flow.first
+    16	import kotlinx.coroutines.flow.map
+    17	import kotlinx.serialization.Serializable
+    18	import kotlinx.serialization.json.Json
+    19	import java.net.URL
+    20	
+    21	/** A saved OPDS catalog. `encryptedPassword` is a [SecretCipher] token (blank when no auth). */
+    22	@Serializable
+    23	data class OpdsSource(
+    24	    val id: String,
+    25	    val name: String,
+    26	    val url: String,
+    27	    val requiresAuth: Boolean = false,
+    28	    val username: String = "",
+    29	    val encryptedPassword: String = "",
+    30	)
+    31	
+    32	class OpdsSourceStore(
+    33	    private val dataStore: DataStore<Preferences>,
+    34	    private val cipher: SecretCipher = KeystoreSecretCipher(ALIAS),
+    35	    private val json: Json = Json { ignoreUnknownKeys = true; encodeDefaults = true },
+    36	) {
+    37	    suspend fun list(): List<OpdsSource> = read(dataStore.data.first())
+    38	    fun observe(): Flow<List<OpdsSource>> = dataStore.data.map(::read)
+    39	
+    40	    /**
+    41	     * Insert/update by [id]. [password] is the PLAINTEXT to encrypt; pass null to keep the existing
+    42	     * (edit without changing it). When [requiresAuth] is false the username/password are CLEARED.
+    43	     */
+    44	    suspend fun upsert(
+    45	        id: String,
+    46	        name: String,
+    47	        url: String,
+    48	        requiresAuth: Boolean,
+    49	        username: String,
+    50	        password: String?,
+    51	    ): OpdsSource {
+    52	        lateinit var saved: OpdsSource
+    53	        dataStore.edit { prefs ->
+    54	            val cur = read(prefs)
+    55	            val existing = cur.firstOrNull { it.id == id }
+    56	            saved = if (!requiresAuth) {
+    57	                OpdsSource(id, name, url, requiresAuth = false)  // auth off → no creds stored
+    58	            } else {
+    59	                val enc = when {
+    60	                    password != null -> cipher.encrypt(password)
+    61	                    existing != null && existing.requiresAuth -> existing.encryptedPassword
+    62	                    else -> ""  // auth on but no password yet (the user can still browse public sections)
+    63	                }
+    64	                OpdsSource(id, name, url, requiresAuth = true, username = username, encryptedPassword = enc)
+    65	            }
+    66	            prefs[KEY] = json.encodeToString(cur.filterNot { it.id == id } + saved)
+    67	        }
+    68	        return saved
+    69	    }
+    70	
+    71	    suspend fun delete(id: String) {
+    72	        dataStore.edit { prefs -> prefs[KEY] = json.encodeToString(read(prefs).filterNot { it.id == id }) }
+    73	    }
+    74	
+    75	    /** The decrypted password for [source], or null if it has no auth / no password. */
+    76	    fun password(source: OpdsSource): String? =
+    77	        if (source.requiresAuth && source.encryptedPassword.isNotBlank()) cipher.decrypt(source.encryptedPassword) else null
+    78	
+    79	    /** Build a #117 OpdsClient scoped to this catalog's origin (so auth never leaks cross-origin). */
+    80	    fun clientFor(source: OpdsSource): OpdsClient {
+    81	        val user = if (source.requiresAuth && source.username.isNotBlank()) source.username else null
+    82	        // Decrypt ONLY when a usable auth client will actually be built — a corrupt/stale token on a
+    83	        // source with no username would otherwise throw even though no auth header would be sent.
+    84	        val pass = if (user != null) password(source) else null
+    85	        return OpdsClient(username = user, password = pass, authOrigin = if (user != null) originOf(source.url) else null)
+    86	    }
+    87	
+    88	    private fun originOf(url: String): String? = runCatching {
+    89	        val u = URL(url); val port = if (u.port == -1) u.defaultPort else u.port
+    90	        "${u.protocol.lowercase()}://${u.host.lowercase()}:$port"
+    91	    }.getOrNull()
+    92	
+    93	    private fun read(prefs: Preferences): List<OpdsSource> {
+    94	        val raw = prefs[KEY] ?: return emptyList()
+    95	        return runCatching { json.decodeFromString<List<OpdsSource>>(raw) }.getOrDefault(emptyList())
+    96	    }
+    97	
+    98	    companion object {
+    99	        const val ALIAS = "vreader.opds.password"
+   100	        private val KEY = stringPreferencesKey("opds_sources_json")
+   101	    }
+   102	}
+     1	// Purpose: feature #118 WI-3 (#110 Phase 3) — UI state for the AI provider list + editor surfaces
+     2	// (the committed `AiProviderList` + the `EditorSheet` contract from vreader-ai-android.jsx /
+     3	// vreader-ai-provider-fields.jsx). Stateless composables render a pure function of these.
+     4	package com.vreader.app.ai
+     5	
+     6	/** Test-connection state for the editor's Connection section (mirrors the design's test states). */
+     7	enum class AiConnTest { idle, testing, ok, fail }
+     8	
+     9	/** One row in the provider list: active radio + name + model (ok) or the rejection reason (fail). */
+    10	data class AiProviderRow(
+    11	    val id: String,
+    12	    val name: String,
+    13	    val active: Boolean,
+    14	    val statusOk: Boolean,
+    15	    val detail: String,  // model when ok, e.g. "401 — key rejected" when fail
+    16	)
+    17	
+    18	/** The provider-list screen state. */
+    19	data class AiProviderListState(
+    20	    val providers: List<AiProviderRow> = emptyList(),
+    21	) {
+    22	    val unconfigured: Boolean get() = providers.isEmpty()
+    23	}
+    24	
+    25	/** The add/edit provider form state (the EditorSheet contract). */
+    26	data class AiEditState(
+    27	    val editMode: Boolean = false,
+    28	    val id: String? = null,
+    29	    val kind: AiProviderKind = AiProviderKind.openAiCompatible,
+    30	    val name: String = "",
+    31	    val baseUrl: String = "",      // blank → kind default
+    32	    val model: String = "",        // blank → kind default
+    33	    val temperature: Double = 0.7,
+    34	    val maxTokens: Int = 2048,
+    35	    val apiKey: String = "",       // entered key (blank in edit = keep existing)
+    36	    val keyAlreadySaved: Boolean = false,  // edit mode with a stored key
+    37	    val test: AiConnTest = AiConnTest.idle,
+    38	    val testMessage: String = "",
+    39	) {
+    40	    /** canSave = name non-empty AND a key is available — entered now, or already saved on edit (a
+    41	     *  blank base/model fall back to the kind default = valid; a NEW provider must have a key, since
+    42	     *  the store rejects a keyless new profile). */
+    43	    val canSave: Boolean get() = name.isNotBlank() && (apiKey.isNotBlank() || (editMode && keyAlreadySaved))
+    44	    /** Test is enabled once a key is available (entered now, or already saved in edit mode). */
+    45	    val canTest: Boolean get() = apiKey.isNotBlank() || keyAlreadySaved
+    46	    val effectiveBaseUrl: String get() = baseUrl.ifBlank { kind.defaultBaseUrl }
+    47	    val effectiveModel: String get() = model.ifBlank { kind.defaultModel }
+    48	}
+    35	import com.vreader.app.reader.PdfReaderActivity
+    36	import com.vreader.app.reader.TxtReaderActivity
+    37	import com.vreader.app.search.SearchScreen
+    38	import com.vreader.app.ui.theme.VReaderTheme
+    39	import vreader.contracts.BookFormat
+    40	import androidx.compose.runtime.LaunchedEffect
+    41	
+    42	class MainActivity : ComponentActivity() {
+    43	    override fun onCreate(savedInstanceState: Bundle?) {
+    44	        super.onCreate(savedInstanceState)
+    45	        val container = (application as VReaderApp).container
+    46	        val factory = viewModelFactory {
+    47	            initializer { LibraryViewModel(container.repository, container.importer, container.collectionRepository, contentResolver) }
+    48	        }
+    49	
+    50	        setContent {
+    51	            VReaderTheme {
+    52	                val viewModel: LibraryViewModel = viewModel(factory = factory)
+    53	                val state by viewModel.uiState.collectAsStateWithLifecycle()
+    54	                val collections by viewModel.collections.collectAsStateWithLifecycle()
+    55	                val selectedCollectionId by viewModel.selectedCollectionId.collectAsStateWithLifecycle()
+    56	                // feature #127 WI-4 — which collections sheet is open (survives rotation/process death).
+    57	                var sheetRoute by rememberSaveable(stateSaver = SheetRouteSaver) { mutableStateOf<SheetRoute>(SheetRoute.None) }
+    58	                // feature #128 WI-7 — the search takeover open/closed flag (the SheetRoute saveable
+    59	                // precedent; a Boolean needs no custom Saver, so rememberSaveable survives rotation/death).
+    60	                var searchOpen by rememberSaveable { mutableStateOf(false) }
+    61	
+    62	                val picker = rememberLauncherForActivityResult(
+    63	                    ActivityResultContracts.OpenDocument(),
+    64	                ) { uri -> uri?.let(viewModel::import) }
+    65	
+    66	                LaunchedEffect(Unit) {
+    67	                    viewModel.events.collect { event ->
+    68	                        val message = when (event) {
+    69	                            is LibraryEvent.ImportFailed -> event.message
+    70	                            is LibraryEvent.CollectionOpFailed -> event.message
+    71	                        }
+    72	                        Toast.makeText(this@MainActivity, message, Toast.LENGTH_SHORT).show()
+    73	                    }
+    74	                }
+    75	
+    76	                // Route by the typed format (exhaustive — never open a format into the wrong host).
+    77	                // Shared by the library grid tap and the search result tap (both carry a typed format +
+    78	                // fingerprintKey).
+    79	                fun openBook(format: BookFormat, key: String) {
+    80	                    when (format) {
+    81	                        BookFormat.epub ->
+    82	                            startActivity(ReaderActivity.intent(this@MainActivity, key))
+    83	                        BookFormat.txt, BookFormat.md ->
+    84	                            // .md reuses the text reader host (#112): same decode/
+    85	                            // document/resume/chrome, MarkdownRenderer per chunk.
+    86	                            startActivity(TxtReaderActivity.intent(this@MainActivity, key))
+    87	                        BookFormat.pdf ->
+    88	                            // #115 — continuous-scroll PdfRenderer reader.
+    89	                            startActivity(PdfReaderActivity.intent(this@MainActivity, key))
+    90	                        BookFormat.azw3 ->
+    91	                            // #126 — foliate-js WebView reader (AZW3/MOBI/KF8).
+    92	                            startActivity(Azw3ReaderActivity.intent(this@MainActivity, key))
+    93	                    }
+    94	                }
+    95	
+    96	                LibraryScreen(
+    97	                    state = state,
+    98	                    collections = collections,
+    99	                    selectedCollectionId = selectedCollectionId,
+   100	                    onSelectCollection = viewModel::selectCollection,
+   101	                    onAssignBook = { book -> sheetRoute = SheetRoute.Assign(book.id) },
+   102	                    onManageCollections = { sheetRoute = SheetRoute.Manage },
+   103	                    onOpenSearch = { searchOpen = true },
+   104	                    onOpenBook = { book -> openBook(book.originalFormat, book.id) },
+   105	                    // EPUBs are exposed by SAF providers under varied MIME types
+   106	                    // (epub+zip, octet-stream, generic); accept broadly and let
+   107	                    // BookImporter reject non-EPUBs by extension with a clear toast.
+   108	                    onImport = {
+   109	                        picker.launch(
+   110	                            arrayOf("application/epub+zip", "application/octet-stream", "*/*"),
+   111	                        )
+   112	                    },
+   113	                )
+   114	
+   115	                // feature #128 WI-7 — the search takeover. Rendered OVER the library when open; fed by
+   116	                // the AppContainer's SearchViewModel (WI-6). Obtained through `viewModel(factory=…)` so it's
+   117	                // owned by the Activity's ViewModelStore — its viewModelScope is properly cleared on the
+   118	                // Activity's destroy (a raw `remember { … }` would leak the coroutine collector forever).
+   119	                if (searchOpen) {
+   120	                    val searchViewModel: com.vreader.app.search.SearchViewModel = viewModel(
+    45	import androidx.compose.ui.graphics.Color
+    46	import androidx.compose.ui.text.font.FontWeight
+    47	import androidx.compose.ui.text.style.TextOverflow
+    48	import androidx.compose.ui.unit.dp
+    49	import androidx.compose.ui.unit.sp
+    50	import com.vreader.app.ui.theme.VReaderColors
+    51	import com.vreader.app.ui.theme.VReaderFonts
+    52	
+    53	private enum class LibraryView { Grid, List }
+    54	
+    55	@Composable
+    56	fun LibraryScreen(
+    57	    state: LibraryUiState,
+    58	    onOpenBook: (LibraryBook) -> Unit,
+    59	    onImport: () -> Unit,
+    60	    // feature #128 WI-7 — the functional Search pill in the nav row opens the search takeover.
+    61	    onOpenSearch: () -> Unit = {},
+    62	    // feature #127 — collections shelf-bar (empty list = no bar; "All" = null selection).
+    63	    collections: List<com.vreader.app.data.Collection> = emptyList(),
+    64	    selectedCollectionId: String? = null,
+    65	    onSelectCollection: (String?) -> Unit = {},
+    66	    // feature #127 WI-4 — long-press a book to assign it to collections.
+    67	    onAssignBook: (LibraryBook) -> Unit = {},
+    68	    // feature #127 WI-5 — open the manage-collections sheet (shown once a collection exists).
+    69	    onManageCollections: () -> Unit = {},
+    70	) {
+    71	    // Boolean (not the enum) so rememberSaveable persists the mode across rotation /
+    72	    // process recreation without a custom Saver.
+    73	    var isGrid by rememberSaveable { mutableStateOf(true) }
+    74	    val view = if (isGrid) LibraryView.Grid else LibraryView.List
+    75	
+    76	    Column(
+    77	        Modifier.fillMaxSize().background(VReaderColors.Background).systemBarsPadding(),
+    78	    ) {
+    79	        // feature #127 — header. When a collection is selected the design's `scope === 'collection'`
+    80	        // surface replaces the WHOLE all-library header (nav pills + "Library" title + shelf-bar) with
+    81	        // just the scoped-collection header: a back breadcrumb to "All", the collection name (serif), and
+    82	        // a "N books · edit collection" subtitle (the DESIGNED manage-sheet entry). The scoped view has NO
+    83	        // action pills (Gate-4 WI-5 round-2 Medium, rule 51) — the nav pills live only in the All branch.
+    84	        val selectedCollection = collections.firstOrNull { it.id == selectedCollectionId }
+    85	        if (selectedCollection != null) {
+    86	            ScopedCollectionHeader(
+    87	                collectionName = selectedCollection.name,
+    88	                bookCount = state.books.size,
+    89	                onBack = { onSelectCollection(null) },
+    90	                onEditCollection = onManageCollections,
+    91	            )
+    92	        } else {
+    93	            // Nav bar — the functional controls (search / view-toggle / import). The Search pill
+    94	            // is wired as of feature #128 WI-7 (opens the search takeover). The design's
+    95	            // settings/More pill is added when that feature lands (a separate WI); shipping a
+    96	            // non-functional control is a fidelity defect, so it's still omitted.
+    97	            Row(
+    98	                Modifier.fillMaxWidth().padding(start = 18.dp, end = 18.dp, top = 6.dp),
+    99	                horizontalArrangement = Arrangement.End,
+   100	                verticalAlignment = Alignment.CenterVertically,
+   101	            ) {
+   102	                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+   103	                    PillIcon(Icons.Filled.Search, "Search", onOpenSearch)
+   104	                    PillIcon(
+   105	                        if (view == LibraryView.Grid) Icons.AutoMirrored.Filled.ViewList else Icons.Filled.GridView,
+   106	                        "Toggle view",
+   107	                    ) { isGrid = !isGrid }
+   108	                    PillIcon(Icons.Filled.Add, "Import book", onImport)
+   109	                }
+   110	            }
+   111	
+   112	            // Title + count.
+   113	            Text(
+   114	                "Library",
+   115	                Modifier.padding(start = 22.dp, end = 22.dp, top = 12.dp, bottom = 4.dp),
+
+exec
+/bin/zsh -lc "nl -ba dev-docs/designs/vreader-fidelity-v1/project/vreader-more.jsx | sed -n '1,180p'
+rg -n \"AiProviderList|AI Providers|Provider|Variant A|scoped|in-reader|sheet|configure-ai|deferred|do NOT build|Do not build\" dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-android.jsx dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-readiness.md
+nl -ba dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md | sed -n '1,280p'
+nl -ba dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-readiness.md | sed -n '1,280p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+     1	// More-menu popover — anchored to the "..." button in reader top chrome.
+     2	// Issue #760: design the contents of the More menu.
+     3	
+     4	function MorePopover({ theme, state, onToggle, onAction, onClose }) {
+     5	  const t = theme;
+     6	  const s = state || {};
+     7	
+     8	  const Row = ({ icon, label, sub, value, toggle, active, danger, divider, on, disabled }) => {
+     9	    if (divider) {
+    10	      return <div style={{
+    11	        height: 0.5, background: t.rule, margin: '4px 14px',
+    12	      }}/>;
+    13	    }
+    14	    const Ico = icon;
+    15	    return (
+    16	      <button onClick={disabled ? undefined : on} style={{
+    17	        display: 'flex', alignItems: 'center', gap: 12,
+    18	        padding: '11px 14px', width: '100%', border: 'none',
+    19	        background: 'transparent', cursor: disabled ? 'default' : 'pointer', textAlign: 'left',
+    20	        opacity: disabled ? 0.55 : 1,
+    21	      }}>
+    22	        <div style={{
+    23	          width: 28, height: 28, borderRadius: 8,
+    24	          background: active
+    25	            ? (t.isDark ? `${t.accent}33` : `${t.accent}1a`)
+    26	            : (t.isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.04)'),
+    27	          display: 'flex', alignItems: 'center', justifyContent: 'center',
+    28	          flexShrink: 0,
+    29	        }}>
+    30	          <Ico size={15} color={active ? t.accent : t.ink} stroke={1.7}/>
+    31	        </div>
+    32	        <div style={{ flex: 1, minWidth: 0 }}>
+    33	          <div style={{
+    34	            fontSize: 14.5, color: danger ? '#c44' : t.ink,
+    35	            fontWeight: 500, lineHeight: 1.2,
+    36	          }}>{label}</div>
+    37	          {sub && (
+    38	            <div style={{
+    39	              fontSize: 11, color: disabled ? t.accent : t.sub, marginTop: 2, lineHeight: 1.2,
+    40	              fontWeight: disabled ? 600 : 400,
+    41	            }}>{sub}</div>
+    42	          )}
+    43	        </div>
+    44	        {toggle !== undefined && !disabled && (
+    45	          <ToggleSwitch on={!!toggle} theme={t}/>
+    46	        )}
+    47	        {value && (
+    48	          <span style={{ fontSize: 12, color: t.sub, marginRight: 2 }}>{value}</span>
+    49	        )}
+    50	        {(disabled || (toggle === undefined && value === undefined)) && (
+    51	          <Icons.Chevron size={13} color={t.sub} stroke={2}/>
+    52	        )}
+    53	      </button>
+    54	    );
+    55	  };
+    56	
+    57	  return (
+    58	    <>
+    59	      {/* dim backdrop */}
+    60	      <div onClick={onClose} style={{
+    61	        position: 'absolute', inset: 0, zIndex: 70,
+    62	        background: 'transparent',
+    63	      }}/>
+    64	      {/* popover */}
+    65	      <div style={{
+    66	        position: 'absolute', top: 92, right: 14, zIndex: 75,
+    67	        width: 268, borderRadius: 16,
+    68	        background: t.isDark ? '#2a2724' : '#fcf8f0',
+    69	        boxShadow: '0 12px 36px rgba(0,0,0,0.28), 0 0 0 0.5px ' + (t.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'),
+    70	        padding: '6px 0', overflow: 'hidden',
+    71	      }}>
+    72	        {/* notch pointing to ... button */}
+    73	        <div style={{
+    74	          position: 'absolute', top: -6, right: 24,
+    75	          width: 12, height: 12, transform: 'rotate(45deg)',
+    76	          background: t.isDark ? '#2a2724' : '#fcf8f0',
+    77	          boxShadow: '-1px -1px 0 0 ' + (t.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'),
+    78	        }}/>
+    79	
+    80	        <Row icon={Icons.Volume} label="Read aloud"
+    81	             sub={s.ttsPlaying ? 'Playing · System voice' : 'Start text-to-speech'}
+    82	             active={s.ttsPlaying}
+    83	             on={() => onAction('tts')}/>
+    84	
+    85	        <Row icon={Icons.Timer} label="Auto-turn pages"
+    86	             sub={s.autoTurn ? `Every ${s.autoTurnInterval || 30}s` : 'Off'}
+    87	             toggle={s.autoTurn}
+    88	             active={s.autoTurn}
+    89	             on={() => onToggle('autoTurn')}/>
+    90	
+    91	        {s.aiUnavailable ? (
+    92	          <Row icon={Icons.Translate} label="Bilingual mode"
+    93	               sub="Configure AI provider first"
+    94	               disabled
+    95	               on={() => onAction('configure-ai')}/>
+    96	        ) : (
+    97	          <Row icon={Icons.Translate} label="Bilingual mode"
+    98	               sub={s.bilingual ? `English ↔ ${s.bilingualLang || 'Chinese'}` : 'Translate inline'}
+    99	               toggle={s.bilingual}
+   100	               active={s.bilingual}
+   101	               on={() => onToggle('bilingual')}/>
+   102	        )}
+   103	
+   104	        <Row divider/>
+   105	
+   106	        <Row icon={Icons.Info} label="Book details"
+   107	             on={() => onAction('details')}/>
+   108	
+   109	        <Row icon={Icons.Share} label="Share book"
+   110	             on={() => onAction('share')}/>
+   111	
+   112	        <Row icon={Icons.Download} label="Export annotations"
+   113	             sub="Markdown · JSON · VReader JSON"
+   114	             on={() => onAction('export')}/>
+   115	      </div>
+   116	    </>
+   117	  );
+   118	}
+   119	
+   120	// Tiny iOS-style toggle
+   121	function ToggleSwitch({ on, theme }) {
+   122	  const t = theme;
+   123	  return (
+   124	    <div style={{
+   125	      width: 34, height: 20, borderRadius: 10, position: 'relative',
+   126	      background: on ? '#3a6a5a' : (t.isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)'),
+   127	      transition: 'background 0.15s',
+   128	      flexShrink: 0,
+   129	    }}>
+   130	      <div style={{
+   131	        position: 'absolute', top: 2, left: on ? 16 : 2,
+   132	        width: 16, height: 16, borderRadius: 8, background: '#fff',
+   133	        transition: 'left 0.15s',
+   134	        boxShadow: '0 1px 2px rgba(0,0,0,0.2), 0 0.5px 0 rgba(0,0,0,0.06)',
+   135	      }}/>
+   136	    </div>
+   137	  );
+   138	}
+   139	
+   140	Object.assign(window, { MorePopover });
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-android.jsx:17:function AiProviderList({ ui, state = 'configured', height = 880 }) {
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-android.jsx:30:          <div style={{ flex: 1, fontFamily: AI_SERIF, fontSize: 18, fontWeight: 600, color: ui.ink }}>AI Providers</div>
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-android.jsx:50:              <GroupHeader ui={ui}>Providers</GroupHeader>
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-android.jsx:164:          <GroupHeader ui={ui}>Provider</GroupHeader>
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-android.jsx:166:            <Row ui={ui} label="Provider"><ValueText ui={ui} text="Claude (Anthropic)" /></Row>
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-android.jsx:210:        {/* chat sheet */}
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-android.jsx:306:Object.assign(window, { AiProviderList, BilingualReader, BilingualSetupSheet, AiChatPanel });
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-readiness.md:5:> Resolves needs-design [#1394](https://github.com/lllyys/vreader/issues/1394) (Feature **#82**). Follow-up to Feature #81 (#1380, in-reader provider entry) and Bug #301 (truthful engine strip).
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-readiness.md:6:> Status: **design landed — implementation deferred** (recorded, not built; Swift held for a separate go-ahead per the handoff convention).
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-readiness.md:12:Feature #81 lets a user **add a provider** in-reader — but on a fresh device the **flag and
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-readiness.md:21:## Decision (binding) — Variant A: "Set up translation" readiness sheet
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-readiness.md:23:Reached from the bilingual engine strip's **"Set up"**. One scoped sheet makes the whole
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-readiness.md:34:4. **Provider step** — reuses the canonical `AIProviderEditSheet` (#81/#1363) **unchanged**
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-readiness.md:50:## Production wiring (deferred — do NOT build without go-ahead)
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-readiness.md:52:- New `ReaderAIReadinessSheet` (or extend the #81 `ReaderAIProvidersView` into a readiness
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-readiness.md:53:  container) presented from `BilingualSetupSheet.onOpenSettings` (currently the deferred slice
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-readiness.md:56:  the #81 provider list (`AIProviderEditSheet` reused).
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-readiness.md:59:- The same readiness sheet is the route target for **Bug #308** (bottom-bar AI button) and the
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:1:# In-reader AI Providers entry — from the bilingual "Set up" button
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:5:> Source of truth: `VReader AI Provider Entry Canvas.html` (every state across themes).
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:8:**Decision: a scoped, in-reader "AI Providers" sheet pushed inside the bilingual
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:9:flow, reusing the canonical `AIProviderEditSheet` for the actual add/edit, and
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:10:returning to the bilingual sheet with the new provider already selected as the
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:11:engine.** Components: `AIProvidersSheet` (list, empty + populated), `BilingualEngineStrip`
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:18:Bug #301 made the bilingual setup sheet *truthful*: when no AI provider is
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:21:sheet** — it routes nowhere.
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:23:Wiring it is not a one-liner, because the in-reader → AI Providers path does not
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:26:- The reader's `showSettings` sheet presents **only** `ReaderSettingsPanel`
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:31:So "Set up" has nothing to call. This is a new in-reader navigation surface →
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:39:### A — Scoped AI Providers sheet, pushed in the bilingual flow  ·  CANONICAL
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:41:"Set up" pushes a **navigation level inside the same bottom sheet** — same frame,
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:42:same height, slide-left push. Nav bar: `‹ Bilingual` leading, **AI Providers**
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:49:- **Add provider** presents the canonical `AIProviderEditSheet`
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:50:  (`vreader-ai-provider-fields.jsx`) as its own modal sheet — full height,
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:65:  already shipped in `AIProviderEditSheet` comes for free.
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:66:- **Keeps the reader context.** A scoped sheet, not the whole app-settings tree.
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:91:  back to the reader with the bilingual sheet already gone, so the "I was turning
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:94:### C — Inline expansion inside the bilingual sheet
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:99:- **Pro:** the tightest possible loop — the user never leaves the bilingual sheet.
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:102:  key, and a live connection test. A bilingual half-sheet can't host that without
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:104:  `AIProviderEditSheet`** — at which point a key saved here wouldn't be testable,
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:114:        └─ BilingualSetupSheet        [bottom sheet · height 620]
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:117:                                   ▼   (push, slide-left, same sheet frame)
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:118:           AIProvidersSheet           [nav bar: ‹ Bilingual · "AI Providers"]
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:122:                          AIProviderEditSheet   [vreader-ai-provider-fields.jsx]
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:129:- The AI Providers view is a **push within the bilingual sheet**, NOT a modal over
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:132:- "Change…" on an already-configured strip opens the **same** `AIProvidersSheet`,
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:140:- The bilingual sheet, engine unconfigured, "Set up" highlighted (start point) —
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:144:- AI Providers — empty (no providers) + bilingual-context note + Add CTA.
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:145:- Add Provider — the canonical `AIProviderEditSheet`, pushed.
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:146:- AI Providers — populated, new provider "In use" checked, Done.
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:162:- New reader-scoped presentation: a lightweight nav container hosting **only**
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:163:  `AISettingsSection`'s provider list — call it `ReaderAIProvidersView`. It is NOT
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:164:  `SettingsView`; it reuses the same `AIProviderListView` + `AIProviderEditSheet`
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:166:- `BilingualSetupSheet.onOpenSettings` → presents `ReaderAIProvidersView` as a
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:167:  push inside the bilingual sheet's own `NavigationStack` (so `‹ Bilingual` is a
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:169:- On `AIProviderEditSheet` Save when launched from this flow: set the saved
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:170:  provider as the bilingual mode engine (`BilingualConfig.engineProviderID`) and
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:171:  dismiss back to the bilingual sheet (pop to root).
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:176:  full list. This adds a *second*, scoped entry — it does not move the first.
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:182:| `VReader AI Provider Entry Canvas.html` | Canvas of every state across themes. Source of truth. |
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:183:| `vreader-ai-provider-entry.jsx` | `AIProvidersSheet`, `BilingualEngineStrip`, `EngineStripInline`, `NavFlowDiagram` — #1380 |
+dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:184:| `vreader-ai-provider-fields.jsx` | `EditorSheet` (`AIProviderEditSheet`) — reused unchanged for the add/edit step (#1363) |
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:1:// In-reader AI Providers entry — issue #1380.
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:3:// Wires the bilingual setup sheet's "Set up" button (shown when no AI provider
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:4:// is configured, per Bug #301) to an actual AI Providers surface — which does
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:5:// not exist in-reader today (the reader's showSettings sheet is display/fonts
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:8:// CANONICAL (A): a scoped "AI Providers" sheet PUSHED inside the bilingual
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:9://   flow (nav bar: ‹ Bilingual · "AI Providers"), hosting only the provider
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:10://   list. Empty → "Add provider" → the canonical AIProviderEditSheet
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:17://   C — inline expansion of the engine strip inside the bilingual sheet.
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:20:// tile keeps the fixed #8c2f2f brand color used by the shipped AI Provider row.
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:27:// NavSheet — bottom sheet with an iOS-style navigation bar (back + centered
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:28:// title + trailing). This is the "push within the sheet" presentation: same
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:128:// Provider list row — matches the shipped SettingsRow vocabulary.
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:130:function ProviderRow({ theme, name, model, selected, onClick, last }) {
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:160:// AI Providers sheet body — empty + populated.
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:162:function AIProvidersSheetBody({ theme, providers, selectedId, onAdd, onSelect }) {
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:213:          <SectionLabel theme={t}>Providers</SectionLabel>
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:220:              <ProviderRow key={p.id} theme={t} name={p.name} model={p.model}
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:245:function AIProvidersSheet({ theme, providers = [], selectedId, onBack, onAdd, onSelect, trailing, height = 620 }) {
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:247:    <NavSheet theme={theme} height={height} title="AI Providers" backLabel="Bilingual" onBack={onBack} trailing={trailing}>
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:248:      <AIProvidersSheetBody theme={theme} providers={providers} selectedId={selectedId} onAdd={onAdd} onSelect={onSelect}/>
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:398:  NavSheet, BilingualEngineStrip, ProviderRow,
+dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:399:  AIProvidersSheetBody, AIProvidersSheet,
+     1	# In-reader AI Providers entry — from the bilingual "Set up" button
+     2	
+     3	> Resolves [#1380](https://github.com/lllyys/vreader/issues/1380). Splits off the
+     4	> routing slice of Bug [#301](https://github.com/lllyys/vreader/pull/301) (GH [#1356](https://github.com/lllyys/vreader/issues/1356)).
+     5	> Source of truth: `VReader AI Provider Entry Canvas.html` (every state across themes).
+     6	> Component file: `vreader-ai-provider-entry.jsx`. Editor reused from `vreader-ai-provider-fields.jsx`.
+     7	
+     8	**Decision: a scoped, in-reader "AI Providers" sheet pushed inside the bilingual
+     9	flow, reusing the canonical `AIProviderEditSheet` for the actual add/edit, and
+    10	returning to the bilingual sheet with the new provider already selected as the
+    11	engine.** Components: `AIProvidersSheet` (list, empty + populated), `BilingualEngineStrip`
+    12	(before/after), plus the inline-expansion alternative `EngineStripInline`.
+    13	
+    14	---
+    15	
+    16	## The gap this fills
+    17	
+    18	Bug #301 made the bilingual setup sheet *truthful*: when no AI provider is
+    19	configured, the engine strip stops claiming "configured" and shows a **"Set up"**
+    20	button. But `BilingualSetupSheet.onOpenSettings` currently just **dismisses the
+    21	sheet** — it routes nowhere.
+    22	
+    23	Wiring it is not a one-liner, because the in-reader → AI Providers path does not
+    24	exist:
+    25	
+    26	- The reader's `showSettings` sheet presents **only** `ReaderSettingsPanel`
+    27	  (display / fonts / theme).
+    28	- The full `SettingsView` — the one that contains `AISettingsSection` — is
+    29	  presented **only from the Library**.
+    30	
+    31	So "Set up" has nothing to call. This is a new in-reader navigation surface →
+    32	`needs-design` per rule 51. The question the issue poses: **where does "Set up"
+    33	land, and how is it presented?**
+    34	
+    35	---
+    36	
+    37	## Three approaches
+    38	
+    39	### A — Scoped AI Providers sheet, pushed in the bilingual flow  ·  CANONICAL
+    40	
+    41	"Set up" pushes a **navigation level inside the same bottom sheet** — same frame,
+    42	same height, slide-left push. Nav bar: `‹ Bilingual` leading, **AI Providers**
+    43	title. The body is *only* the `AISettingsSection` provider list — nothing else
+    44	from `SettingsView`.
+    45	
+    46	- **Zero providers** → the list shows an empty state (sparkle tile, one line of
+    47	  copy naming *why* the user is here — "Bilingual mode needs a provider to
+    48	  translate") and a single **Add provider** CTA.
+    49	- **Add provider** presents the canonical `AIProviderEditSheet`
+    50	  (`vreader-ai-provider-fields.jsx`) as its own modal sheet — full height,
+    51	  unchanged from the Library path. Kind / Name / Endpoint / Sampling / API Key /
+    52	  Test Connection all intact.
+    53	- **On the first Save**, the new provider becomes the bilingual engine default
+    54	  and the stack **pops all the way back to Bilingual**. The engine strip now reads
+    55	  *"Claude · configured" / "Change…"*, ready for **Turn on bilingual mode**. That
+    56	  return is the payoff — the user lands exactly where they started, with the one
+    57	  thing they were missing now filled in.
+    58	- Tapping `‹ Bilingual` *without* adding returns to Bilingual still unconfigured —
+    59	  no state mutated, no penalty for backing out.
+    60	
+    61	**Why A wins**
+    62	
+    63	- **Reuses the canonical editor.** No second, diverging "add a provider" form to
+    64	  maintain. Test Connection, keychain storage, endpoint hints — all the work
+    65	  already shipped in `AIProviderEditSheet` comes for free.
+    66	- **Keeps the reader context.** A scoped sheet, not the whole app-settings tree.
+    67	  The user never sees Cloud & Sync, OPDS catalogs, Book sources, TTS, replacement
+    68	  rules — none of which they came for.
+    69	- **Closes the loop.** The user's actual goal is "turn on bilingual"; A returns
+    70	  them to that goal with the blocker removed. B and C both leak that thread.
+    71	- **One surface for both entry points.** "Change…" (when already configured) lands
+    72	  on the *same* list, current provider checked — so add-first and change-later
+    73	  share a destination.
+    74	
+    75	The extra navigation level (list → editor) looks like a cost when there are zero
+    76	providers, but it isn't: the empty state is a one-tap shortcut into the editor.
+    77	When the user *does* already have providers (added from Library, or for the AI
+    78	chat assistant), the list is the correct landing — "Set up" should let them pick,
+    79	not silently create a duplicate.
+    80	
+    81	### B — Deep-link into the full `SettingsView`, scrolled to the AI section
+    82	
+    83	Present the entire app `SettingsView` modally over the reader, auto-scrolled and
+    84	briefly highlighting the AI section.
+    85	
+    86	- **Pro:** one surface, verbatim reuse of the Library path, no new navigation
+    87	  container.
+    88	- **Why not canonical:** it dumps a reader-context user into the *whole* app
+    89	  configuration — Cloud, OPDS, sources, TTS, Chinese conversion, About — to do one
+    90	  narrow thing. And the return is ambiguous: closing `SettingsView` drops the user
+    91	  back to the reader with the bilingual sheet already gone, so the "I was turning
+    92	  on bilingual" thread is lost. They have to re-open More → toggle bilingual again.
+    93	
+    94	### C — Inline expansion inside the bilingual sheet
+    95	
+    96	"Set up" expands the engine strip *in place* into a minimal provider-+-key form;
+    97	no navigation at all.
+    98	
+    99	- **Pro:** the tightest possible loop — the user never leaves the bilingual sheet.
+   100	- **Why not canonical:** the real provider model is not "provider + key". It's
+   101	  kind, name, base URL (with append-path hints), model, sampling, keychain-stored
+   102	  key, and a live connection test. A bilingual half-sheet can't host that without
+   103	  either cramping it or shipping a stripped-down form that **diverges from
+   104	  `AIProviderEditSheet`** — at which point a key saved here wouldn't be testable,
+   105	  and two "add provider" surfaces would drift. Held in reserve for a future
+   106	  "express setup" only if we ever ship a genuinely one-field provider kind.
+   107	
+   108	---
+   109	
+   110	## Navigation model (precise)
+   111	
+   112	```
+   113	   More ▸ Bilingual mode (first toggle on)
+   114	        └─ BilingualSetupSheet        [bottom sheet · height 620]
+   115	             engine strip: "No AI provider configured"  [ Set up ]
+   116	                                   │  onOpenSettings
+   117	                                   ▼   (push, slide-left, same sheet frame)
+   118	           AIProvidersSheet           [nav bar: ‹ Bilingual · "AI Providers"]
+   119	             ├─ empty  → [ Add provider ] ─┐
+   120	             └─ list   → tap a row sets it │  (present modal, full height)
+   121	                                   ▼        ▼
+   122	                          AIProviderEditSheet   [vreader-ai-provider-fields.jsx]
+   123	                                   │  Save
+   124	                                   ▼   (provider becomes bilingual engine,
+   125	                                        pop the whole stack)
+   126	           BilingualSetupSheet  ← engine strip now "Claude · configured" / Change…
+   127	```
+   128	
+   129	- The AI Providers view is a **push within the bilingual sheet**, NOT a modal over
+   130	  the reader and NOT the full `SettingsView`.
+   131	- The editor is a **modal on top** (tall form deserves full height).
+   132	- "Change…" on an already-configured strip opens the **same** `AIProvidersSheet`,
+   133	  populated, current provider checked.
+   134	
+   135	---
+   136	
+   137	## States — covered exhaustively in the canvas
+   138	
+   139	**Trigger**
+   140	- The bilingual sheet, engine unconfigured, "Set up" highlighted (start point) —
+   141	  paper + dark.
+   142	
+   143	**A · canonical**
+   144	- AI Providers — empty (no providers) + bilingual-context note + Add CTA.
+   145	- Add Provider — the canonical `AIProviderEditSheet`, pushed.
+   146	- AI Providers — populated, new provider "In use" checked, Done.
+   147	- Return to Bilingual — engine configured, "Change…", ready to turn on (payoff).
+   148	- Empty + populated in dark.
+   149	- Reached via "Change…" — multiple providers, switching the selected one.
+   150	
+   151	**B · alternative** — full `SettingsView` deep-link, AI section highlighted —
+   152	paper + dark.
+   153	
+   154	**C · alternative** — inline expansion in the bilingual strip — paper + dark.
+   155	
+   156	**D · anatomy** — the nav-stack diagram + engine-strip before/after, true size.
+   157	
+   158	---
+   159	
+   160	## Production wiring
+   161	
+   162	- New reader-scoped presentation: a lightweight nav container hosting **only**
+   163	  `AISettingsSection`'s provider list — call it `ReaderAIProvidersView`. It is NOT
+   164	  `SettingsView`; it reuses the same `AIProviderListView` + `AIProviderEditSheet`
+   165	  cells.
+   166	- `BilingualSetupSheet.onOpenSettings` → presents `ReaderAIProvidersView` as a
+   167	  push inside the bilingual sheet's own `NavigationStack` (so `‹ Bilingual` is a
+   168	  real back, not a dismiss).
+   169	- On `AIProviderEditSheet` Save when launched from this flow: set the saved
+   170	  provider as the bilingual mode engine (`BilingualConfig.engineProviderID`) and
+   171	  dismiss back to the bilingual sheet (pop to root).
+   172	- `aiConfigured` on the engine strip is derived from
+   173	  `AISettingsViewModel.providers.isEmpty == false`; the strip's CTA label is
+   174	  `Set up` when empty, `Change…` otherwise (already shipped by #301).
+   175	- The Library `SettingsView → AI provider` row is unchanged; it still opens the
+   176	  full list. This adds a *second*, scoped entry — it does not move the first.
+   177	
+   178	## Cross-references
+   179	
+   180	| File | Role |
+   181	|---|---|
+   182	| `VReader AI Provider Entry Canvas.html` | Canvas of every state across themes. Source of truth. |
+   183	| `vreader-ai-provider-entry.jsx` | `AIProvidersSheet`, `BilingualEngineStrip`, `EngineStripInline`, `NavFlowDiagram` — #1380 |
+   184	| `vreader-ai-provider-fields.jsx` | `EditorSheet` (`AIProviderEditSheet`) — reused unchanged for the add/edit step (#1363) |
+   185	| `vreader-bilingual.jsx` | `BilingualSetupSheet` — the surface whose "Set up" button this wires (#790) |
+   186	| `design-notes/feature-60-followups.md` | Parent bilingual feature notes (#60 / #56) |
+     1	# In-reader AI-enable + consent readiness affordance (#1394 · Feature #82)
+     2	
+     3	> Source of truth (design): `VReader AI Readiness Canvas.html` → `ai-readiness-artboards.jsx` + `vreader-ai-readiness.jsx` (+ a clickable happy-path `VReader AI Readiness Prototype.html`).
+     4	> Chat transcript: `chats/chat17-ai-readiness-1394.md`.
+     5	> Resolves needs-design [#1394](https://github.com/lllyys/vreader/issues/1394) (Feature **#82**). Follow-up to Feature #81 (#1380, in-reader provider entry) and Bug #301 (truthful engine strip).
+     6	> Status: **design landed — implementation deferred** (recorded, not built; Swift held for a separate go-ahead per the handoff convention).
+     7	
+     8	## The gap
+     9	
+    10	`BilingualAIReadiness` requires **all four gates**: `FeatureFlags.aiAssistant` ON · explicit
+    11	consent (`AIConsentManager.hasConsent`) · a provider profile · that profile's API key.
+    12	Feature #81 lets a user **add a provider** in-reader — but on a fresh device the **flag and
+    13	consent default OFF**, so adding a provider *alone* leaves readiness false and the bilingual
+    14	engine strip correctly still shows **"Set up."** Today the only way to flip the flag + grant
+    15	consent is a trip to Library → Settings → AI. This closes that loop **inside the reader**.
+    16	
+    17	This is the **capstone of the AI-gating cluster** — the surface every "AI unconfigured"
+    18	silent-no-op should route to: Bug #301 (bilingual "Set up" routing), Bug #308 (bottom-bar AI
+    19	button no-op), and the gate behind Bug #306 (cache) all resolve to *this* readiness flow.
+    20	
+    21	## Decision (binding) — Variant A: "Set up translation" readiness sheet
+    22	
+    23	Reached from the bilingual engine strip's **"Set up"**. One scoped sheet makes the whole
+    24	`BilingualAIReadiness` legible and satisfiable top-to-bottom:
+    25	
+    26	1. **3-step tracker** — *Turn on AI · Allow data · Add provider* — doubles as the explainer
+    27	   ("why am I still seeing Set up?") by showing exactly which gates remain. Each clears with a
+    28	   check as it's satisfied.
+    29	2. **Master AI toggle** (`aiAssistant` flag) — the first gate, satisfied in place.
+    30	3. **Explicit full-disclosure consent card** — the two-column **"sent to provider / stays on
+    31	   device"** ledger from #1068 (Variant C), tuned to translation. **Consent is NEVER
+    32	   auto-granted** — it has its own toggle, and the card only **appears once AI is on** (matches
+    33	   the #1068 gating logic).
+    34	4. **Provider step** — reuses the canonical `AIProviderEditSheet` (#81/#1363) **unchanged**
+    35	   (provider + key); on save it becomes the bilingual engine.
+    36	5. **"Ready" payoff** — all four gates cleared → the engine strip flips to **"Claude ·
+    37	   configured / Change…"**, ready to turn on bilingual. The user lands back where they started
+    38	   with the blocker removed.
+    39	
+    40	Covered across **paper / sepia / dark / oled**, all four gate states, plus the reused editor.
+    41	
+    42	### Rejected alternatives (explored in the canvas)
+    43	- **B · guided 1·2·3 stepper** — clear for a first-timer, but **order-forces every visit**: a
+    44	  returning user who only lacks consent still walks the whole rail, and step 3 re-presents the
+    45	  #81 editor mid-flow.
+    46	- **C · pre-flight enable+consent gate** — demands both switches before the provider list is
+    47	  reachable. One tidy consent moment, but it **front-loads privacy before the user has
+    48	  committed** to anything, and re-gates returning users who already granted it.
+    49	
+    50	## Production wiring (deferred — do NOT build without go-ahead)
+    51	
+    52	- New `ReaderAIReadinessSheet` (or extend the #81 `ReaderAIProvidersView` into a readiness
+    53	  container) presented from `BilingualSetupSheet.onOpenSettings` (currently the deferred slice
+    54	  of Bug #301). It hosts: the tracker, the `aiAssistant` master toggle (`FeatureFlags`), the
+    55	  consent card (`AIConsentManager.grantConsent` on its own toggle, shown only when AI on), and
+    56	  the #81 provider list (`AIProviderEditSheet` reused).
+    57	- On all-four-cleared: set the saved provider as the bilingual engine and pop back to Bilingual
+    58	  with the strip reading "configured / Change…".
+    59	- The same readiness sheet is the route target for **Bug #308** (bottom-bar AI button) and the
+    60	  bilingual "Set up"/"Change…" (Feature #81). One surface, multiple entry points.
+    61	- `aiConfigured`/readiness derives from `BilingualAIReadiness.resolve` (already mirrors the live
+    62	  `AIService` gate per the #301 fix). Rule 51 satisfied (this note + canvas are the committed
+    63	  design).
+
+exec
+/bin/zsh -lc "rg -n \"ReaderChromeScaffold\\(|EpubTopBand\\(|EpubReaderSheets\\(|rememberSaveable.*ReaderChromeStateSaver|ReaderChromeStateSaver\" android/app/src/main/kotlin/com/vreader/app/reader/{ReaderActivity.kt,TxtReaderActivity.kt,PdfReaderActivity.kt,Azw3ReaderActivity.kt,EpubReaderChrome.kt}
+rg -n \"application as VReaderApp|container|readerSettingsStore|collectAsStateWithLifecycle|observe\\(\\)\" android/app/src/main/kotlin/com/vreader/app/reader/{ReaderActivity.kt,TxtReaderActivity.kt,PdfReaderActivity.kt,Azw3ReaderActivity.kt} | head -n 240
+nl -ba android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt | sed -n '235,370p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt | sed -n '230,360p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt | sed -n '100,240p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt | sed -n '110,260p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+android/app/src/main/kotlin/com/vreader/app/reader/EpubReaderChrome.kt:81:fun EpubTopBand(
+android/app/src/main/kotlin/com/vreader/app/reader/EpubReaderChrome.kt:174:fun EpubReaderSheets(
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:76:import com.vreader.app.reader.chrome.ReaderChromeStateSaver
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:122:                    // process death via ReaderChromeStateSaver (keyed on the book).
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:124:                    val chromeState = rememberSaveable(bookKey, stateSaver = ReaderChromeStateSaver) {
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:459:        ReaderChromeScaffold(
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:19:// state is persisted across rotation via ReaderChromeStateSaver; the Notes snapshot is a one-shot read
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:49:import com.vreader.app.reader.chrome.ReaderChromeStateSaver
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:148:                        // rotation / process death via ReaderChromeStateSaver (keyed on the book).
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:150:                        val chromeState = rememberSaveable(bookKey, stateSaver = ReaderChromeStateSaver) {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:640:                EpubReaderSheets(
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:670:                EpubTopBand(
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:126:import com.vreader.app.reader.chrome.ReaderChromeStateSaver
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:318:                        // sheet), persisted across rotation / process death via ReaderChromeStateSaver.
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:319:                        val chromeState = rememberSaveable(bookKey, stateSaver = ReaderChromeStateSaver) {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:858:        ReaderChromeScaffold(
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:69:import androidx.lifecycle.compose.collectAsStateWithLifecycle
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:96:    private val container get() = (application as VReaderApp).container
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:110:        container.appScope.launch {
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:111:            for (locator in saveRequests) container.repository.savePosition(locator, System.currentTimeMillis())
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:127:                    val displayTheme by container.readerSettingsStore.settings
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:128:                        .collectAsStateWithLifecycle(initialValue = com.vreader.app.reader.settings.ReaderSettings())
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:133:                        value = runCatching { container.annotationsRepository.annotationsForBook(bookKey) }
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:138:                    val collectionNames by container.collectionRepository
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:140:                        .collectAsStateWithLifecycle(initialValue = emptyList())
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:149:                    val bookmarkRecords by container.annotationsRepository.bookmarks(bookKey)
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:150:                        .collectAsStateWithLifecycle(initialValue = emptyList())
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:162:                        value = c != null && runCatching { container.annotationsRepository.isBookmarked(bookKey, c) }.getOrDefault(false)
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:181:                                if (c != null) container.appScope.launch {
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:182:                                    runCatching { container.annotationsRepository.toggleBookmark(bookKey, title = null, locator = c) }
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:216:                                settings = container.readerSettingsStore.settings,
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:233:        val book = container.repository.findBook(key) ?: return OuterState.NoBook
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:236:        container.repository.markOpened(key, System.currentTimeMillis())
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:237:        return OuterState.Ready(book, path, container.repository.loadPosition(key))
+android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt:350:    val displaySettings by settings.collectAsStateWithLifecycle(initialValue = com.vreader.app.reader.settings.ReaderSettings())
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:44:import androidx.lifecycle.compose.collectAsStateWithLifecycle
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:70:    private val container get() = (application as VReaderApp).container
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:93:        container.appScope.launch {
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:101:                container.repository.savePosition(
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:115:            val settingsOrNull by container.readerSettingsStore.settings.collectAsStateWithLifecycle(initialValue = null)
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:140:                            onDispose { container.appScope.launch { s.document.close() } }
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:157:                            value = runCatching { container.annotationsRepository.annotationsForBook(bookKey) }
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:163:                        val collectionNames by container.collectionRepository
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:165:                            .collectAsStateWithLifecycle(initialValue = emptyList())
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:175:                            container.annotationsRepository.bookmarks(bookKey)
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:176:                        }.collectAsStateWithLifecycle(emptyList())
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:183:                            value = runCatching { container.annotationsRepository.isBookmarked(bookKey, liveCanonical) }.getOrDefault(false)
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:205:                                container.appScope.launch {
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:206:                                    runCatching { container.annotationsRepository.toggleBookmark(bookKey, title = null, locator = liveCanonical) }
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:257:        val book = container.repository.findBook(key) ?: return PdfUiState.Corrupt
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:261:                container.repository.markOpened(key, System.currentTimeMillis())
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:273:        val cached = container.cachedPage(key)
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:275:            val saved = container.repository.loadPosition(key) ?: return 0
+android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt:283:        container.cachePage(book.fingerprintKey, page)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:113:import androidx.lifecycle.compose.collectAsStateWithLifecycle
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:160:    private val container get() = (application as VReaderApp).container
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:185:        container.appScope.launch {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:193:                container.repository.savePosition(
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:211:                val settingsOrNull by container.readerSettingsStore.settings
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:212:                    .collectAsStateWithLifecycle(initialValue = null)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:238:                        val tts by ttsVm.state.collectAsStateWithLifecycle()
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:268:                        val tracker = container.readingTimeTracker
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:270:                        val sessionSeconds by tracker.sessionSeconds.collectAsStateWithLifecycle()
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:282:                            if (annotatable) container.annotationsRepository.highlights(bookKey) else flowOf(emptyList())
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:283:                        }.collectAsStateWithLifecycle(emptyList())
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:289:                        val popoverState by popoverVm.state.collectAsStateWithLifecycle()
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:295:                                    Lifecycle.Event.ON_RESUME -> container.appScope.launch { tracker.start(bookKey) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:298:                                    Lifecycle.Event.ON_STOP -> if (!isChangingConfigurations) container.appScope.launch { tracker.stop(bookKey) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:329:                            else runCatching { container.annotationsRepository.annotationsForBook(bookKey) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:336:                        val collectionNames by container.collectionRepository
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:338:                            .collectAsStateWithLifecycle(initialValue = emptyList())
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:352:                        val bookmarkRecords by remember(bookKey) { container.annotationsRepository.bookmarks(bookKey) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:353:                            .collectAsStateWithLifecycle(emptyList())
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:361:                            value = runCatching { container.annotationsRepository.isBookmarked(bookKey, liveCanonical) }.getOrDefault(false)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:373:                            container.inBookSearchViewModel(
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:383:                        val inBookSearchState by inBookSearchVm.state.collectAsStateWithLifecycle()
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:398:                                container.appScope.launch {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:399:                                    runCatching { container.annotationsRepository.toggleBookmark(bookKey, title = null, locator = liveCanonical) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:570:                            val store = container.readerSettingsStore
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:573:                                onTheme = { v -> val o = store.nextSeq(); container.appScope.launch { store.setTheme(v, o) } },
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:574:                                onFontFamily = { v -> val o = store.nextSeq(); container.appScope.launch { store.setFontFamily(v, o) } },
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:575:                                onFontSize = { v -> val o = store.nextSeq(); container.appScope.launch { store.setFontSize(v, o) } },
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:576:                                onLineSpacing = { v -> val o = store.nextSeq(); container.appScope.launch { store.setLineSpacing(v, o) } },
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:577:                                onMargin = { v -> val o = store.nextSeq(); container.appScope.launch { store.setMargin(v, o) } },
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:599:        val book = container.repository.findBook(key)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:604:        container.repository.markOpened(key, System.currentTimeMillis())
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:613:        container.cachedOffset(key)?.let { return document.chunkForOffset(it) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:614:        val saved = container.repository.loadPosition(key) ?: return 0
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:627:        container.cacheOffset(book.fingerprintKey, offset)
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:710:            container.appScope.launch { container.annotationsRepository.updateHighlight(id, vm.state.value.activeColor, note) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:724:        container.appScope.launch { container.annotationsRepository.updateHighlight(id, color, note) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:730:        container.appScope.launch { container.annotationsRepository.removeHighlight(id) }
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:751:        container.appScope.launch {
+android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt:752:            container.annotationsRepository.addHighlight(book.fingerprintKey, color, visible, locator, anchor, note)
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:53:import androidx.lifecycle.compose.collectAsStateWithLifecycle
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:103:    private val container get() = (application as VReaderApp).container
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:104:    private val repository: LibraryRepository get() = container.repository
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:107:    private val annotations: AnnotationsRepository get() = container.annotationsRepository
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:109:    private var containerId: Int = 0
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:180:            container.readerSettingsStore.settings.collect { chromeTheme.value = it.theme }
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:200:            val initialPrefs = EpubPreferences(scroll = true) + container.readerSettingsStore.current().toEpubPreferences()
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:220:                    add(containerId, EpubNavigatorFragment::class.java, Bundle(), READER_TAG)
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:255:        val vm = container.epubInBookSearchViewModel(
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:301:            container.collectionRepository.observeCollectionNamesForBook(current.fingerprintKey).collect { names ->
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:388:        container.appScope.launch {
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:398:        container.appScope.launch { annotations.updateHighlight(id, color, note) }
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:406:            container.appScope.launch { annotations.updateHighlight(id, popoverVm.state.value.activeColor, note) }
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:415:        container.appScope.launch { annotations.removeHighlight(id) }
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:452:        container.appScope.launch { persist(locator, current) }
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:484:            container.readerSettingsStore.settings.collect { settings ->
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:622:     *    1. the fragment container — MATCH_PARENT (the reading area fills the WHOLE screen, under the bands);
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:635:        containerId = frame.id
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:755:            val settings = container.readerSettingsStore.settings.collectAsStateWithLifecycle(initialValue = null).value
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:757:                val store = container.readerSettingsStore
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:760:                    onTheme = { v -> val o = store.nextSeq(); container.appScope.launch { store.setTheme(v, o) } },
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:761:                    onFontFamily = { v -> val o = store.nextSeq(); container.appScope.launch { store.setFontFamily(v, o) } },
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:762:                    onFontSize = { v -> val o = store.nextSeq(); container.appScope.launch { store.setFontSize(v, o) } },
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:763:                    onLineSpacing = { v -> val o = store.nextSeq(); container.appScope.launch { store.setLineSpacing(v, o) } },
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:764:                    onMargin = { v -> val o = store.nextSeq(); container.appScope.launch { store.setMargin(v, o) } },
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:781:        val screen by vm.state.collectAsStateWithLifecycle()
+android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt:802:        val state by popoverVm.state.collectAsStateWithLifecycle()
+   235	            bookmarkTocIndex = BookmarkTocIndex.build(chromeModel.value.tocEntries)
+   236	            observeBookmarks(loaded)
+   237	            observePosition(nav, loaded)
+   238	            observeDisplaySettings(nav)
+   239	            observeHighlights(loaded, controller)
+   240	            observeAnnotationsSnapshot(loaded)
+   241	            observeBookDetails(loaded)
+   242	            controller.observeActivations { id, rect -> onHighlightTapped(id, rect) }
+   243	            // feature #133 WI-11 — build the per-session in-book search VM over the LIVE publication (Readium
+   244	            // SearchService) + observe its state for the top-bar Search-icon presence + the sheet.
+   245	            buildInBookSearch(key, pub)
+   246	        }
+   247	    }
+   248	
+   249	    /** feature #133 WI-11 — construct the ONE per-session in-book search VM (over the live Readium
+   250	     *  [publication], Readium's own SearchService — NOT the FTS index) and collect its state into
+   251	     *  [inBookSearchState] so the top band knows whether to show the Search icon and the sheet layer can
+   252	     *  render the sheet. The VM's collectors run on [lifecycleScope]; it is disposed in [onDestroy]
+   253	     *  (`onCleared` → closeAllEpubCursors → no leaked Readium SearchIterator). */
+   254	    private fun buildInBookSearch(bookKey: String, publication: Publication) {
+   255	        val vm = container.epubInBookSearchViewModel(
+   256	            bookKey = bookKey,
+   257	            publication = publication,
+   258	            coroutineScope = lifecycleScope,
+   259	        )
+   260	        inBookSearchVm = vm
+   261	        inBookSearchVmBuildCount += 1
+   262	        lifecycleScope.launch { vm.state.collect { inBookSearchState.value = it } }
+   263	    }
+   264	
+   265	    /** feature #132 WI-7-EPUB — populate the persistent chrome model after open: title + flattened TOC
+   266	     *  (ReadiumTocProvider) + the Notes snapshot + the initial currentTocIndex. Failures are tolerated (a
+   267	     *  book with no/broken TOC still renders the chrome with an empty Contents control). */
+   268	    private suspend fun populateChromeModel(pub: Publication, current: Book, nav: EpubNavigatorFragment) {
+   269	        val entries = runCatching { ReadiumTocProvider(pub, current).toc() }.getOrDefault(emptyList())
+   270	        val snapshot = runCatching { annotations.annotationsForBook(current.fingerprintKey) }
+   271	            .getOrDefault(AnnotationsSnapshot(emptyList(), emptyList()))
+   272	        val locator = nav.currentLocator.value
+   273	        val index = tocIndexFor(locator.href.toString(), locator.locations.progression, tocPositions(entries))
+   274	        chromeModel.value = chromeModel.value.copy(
+   275	            title = current.title,
+   276	            tocEntries = entries,
+   277	            annotations = snapshot,
+   278	            currentTocIndex = index,
+   279	        )
+   280	    }
+   281	
+   282	    /** feature #132 WI-7-EPUB — reload the Notes snapshot whenever this book's stored highlights change (a
+   283	     *  fresh highlight/edit/remove), so a newly added annotation appears in the review sheet without a
+   284	     *  reopen. Notes are review-only for EPUB (no jump-to-annotation) until #135. */
+   285	    private fun observeAnnotationsSnapshot(current: Book) {
+   286	        lifecycleScope.launch {
+   287	            annotations.highlights(current.fingerprintKey).collect {
+   288	                val snapshot = runCatching { annotations.annotationsForBook(current.fingerprintKey) }
+   289	                    .getOrDefault(AnnotationsSnapshot(emptyList(), emptyList()))
+   290	                chromeModel.value = chromeModel.value.copy(annotations = snapshot)
+   291	            }
+   292	        }
+   293	    }
+   294	
+   295	    /** feature #134 WI-5 — build + keep the More menu's Book-details model in sync with this book's live
+   296	     *  collection names (EPUB supplies no page count → the Pages row is omitted). The mapped model appears
+   297	     *  on the [chromeBookDetails] state the top band/sheet layer read, so the More button appears once the
+   298	     *  book + its collections are known (null until then — no dead control). */
+   299	    private fun observeBookDetails(current: Book) {
+   300	        lifecycleScope.launch {
+   301	            container.collectionRepository.observeCollectionNamesForBook(current.fingerprintKey).collect { names ->
+   302	                chromeBookDetails.value =
+   303	                    com.vreader.app.reader.details.BookDetailsMapper.map(current, names, pageCount = null)
+   304	            }
+   305	        }
+   306	    }
+   307	
+   308	    /** feature #134 WI-5 — copy the FULL canonical fingerprint to the OS clipboard (the Book Details
+   309	     *  copy-fingerprint mini-action). Rely on the OS copy confirmation — no invented toast (rule 51). */
+   310	    private fun copyFingerprint(fingerprintFull: String) {
+   311	        val clip = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+   312	        clip.setPrimaryClip(ClipData.newPlainText("fingerprint", fingerprintFull))
+   313	    }
+   314	
+   315	    /** feature #134 WI-5 — the More menu's Share book action: launch the WI-2 book-file share chooser for
+   316	     *  the current book (a missing/out-of-scope file or no receiver is a silent no-op — WI-2 handles it). */
+   317	    private fun shareBookFile() {
+   318	        val current = book ?: return
+   319	        com.vreader.app.reader.share.shareBook(this, current)
+   320	    }
+   321	
+   322	    /** A tap on an existing highlight decoration → open the popover in EDIT mode (Note/Copy/Share/Remove). */
+   323	    private fun onHighlightTapped(id: String, rect: android.graphics.RectF?) {
+   324	        lifecycleScope.launch {
+   325	            val h = annotations.findHighlight(id) ?: return@launch
+   326	            pendingHighlightId = id
+   327	            pendingSelectedText = h.selectedText
+   328	            pendingSelection = null
+   329	            val d = resources.displayMetrics.density
+   330	            popoverVm.showForExisting(h.color, h.note, (rect?.centerX() ?: 0f) / d, (rect?.bottom ?: 0f) / d)
+   331	        }
+   332	    }
+   333	
+   334	    /** Re-apply the book's stored highlights as Readium decorations whenever the set changes. */
+   335	    private fun observeHighlights(current: Book, controller: ReaderHighlightController) {
+   336	        lifecycleScope.launch {
+   337	            annotations.highlights(current.fingerprintKey).collect { highlights ->
+   338	                runCatching { controller.applyHighlights(highlights) }
+   339	                    .onSuccess { built -> appliedHighlightCount = built }   // decorations actually built/applied
+   340	            }
+   341	        }
+   342	    }
+   343	
+   344	    @Volatile private var appliedHighlightCount: Int = -1
+   345	
+   346	    /** Test hook: the count of highlights applied as decorations on the live navigator (-1 until the
+   347	     *  first apply). Proves the reopen-render path ran against the real EpubNavigatorFragment. */
+   348	    @androidx.annotation.VisibleForTesting
+   349	    fun appliedHighlightCount(): Int = appliedHighlightCount
+   350	
+   351	    /** The selection action-mode callback. We KEEP the action mode alive (return true) with an emptied
+   352	     *  menu so the WebView selection survives the suspend `currentSelection()` read, capture the
+   353	     *  selection (text + rect) → show the floating popover, then `finish()` to drop the (empty) system
+   354	     *  bar. Reading the selection while the mode is still alive avoids the "cancellation clears the
+   355	     *  selection" race of a bare `return false`. The empty bar is transient (gone the same tick the
+   356	     *  suspend read resolves), not persistent undesigned chrome. */
+   357	    private fun selectionCallback(): ActionMode.Callback = object : ActionMode.Callback {
+   358	        override fun onCreateActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+   359	            menu?.clear()
+   360	            lifecycleScope.launch {
+   361	                val nav = navigator ?: run { mode?.finish(); return@launch }
+   362	                val selection = nav.currentSelection()
+   363	                if (selection == null || selection.locator.text.highlight.isNullOrBlank()) {
+   364	                    mode?.finish(); return@launch
+   365	                }
+   366	                pendingSelection = selection.locator
+   367	                pendingHighlightId = null       // entering CREATE context — drop any stale EDIT context
+   368	                pendingSelectedText = null
+   369	                val rect = selection.rect
+   370	                val density = resources.displayMetrics.density
+   230	                                .collect { savePosition(s.book, s.document, it) }
+   231	                        }
+   232	                        // feature #121 — read-aloud. The VM drives the designed control bar; the spoken
+   233	                        // sentence is washed + auto-scrolled (TXT). Chunking is LAZY + off-main (only
+   234	                        // on Read aloud) so a large book never scans the whole text on composition.
+   235	                        val ttsVm: TtsViewModel = viewModel(factory = viewModelFactory {
+   236	                            initializer { TtsViewModel(AndroidTtsEngine(applicationContext)) }
+   237	                        })
+   238	                        val tts by ttsVm.state.collectAsStateWithLifecycle()
+   239	                        val ttsScope = rememberCoroutineScope()
+   240	                        LaunchedEffect(ttsVm) { ttsVm.intents.collect { launchTtsIntent(it) } }
+   241	                        // pause read-aloud when the reader is backgrounded (no MediaSession by design —
+   242	                        // plan §OOS); the engine is shut down on Activity finish via the VM's onCleared.
+   243	                        val lifecycleOwner = LocalLifecycleOwner.current
+   244	                        DisposableEffect(lifecycleOwner) {
+   245	                            // guard against ON_STOP firing on a rotation (config change) — the VM is
+   246	                            // retained across rotation, so don't pause when we're just reconfiguring.
+   247	                            val obs = LifecycleEventObserver { _, e -> if (e == Lifecycle.Event.ON_STOP && !isChangingConfigurations) ttsVm.pause() }
+   248	                            lifecycleOwner.lifecycle.addObserver(obs)
+   249	                            onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
+   250	                        }
+   251	                        val active = tts.phase != TtsPhase.idle
+   252	                        val spokenChunk = if (tts.phase == TtsPhase.speaking) s.document.chunkForOffset(tts.charStart) else -1
+   253	                        // auto-scroll ONLY when the spoken chunk is off-screen — so a small manual scroll
+   254	                        // while listening isn't fought on every sentence.
+   255	                        LaunchedEffect(spokenChunk) {
+   256	                            if (spokenChunk >= 0 && listState.layoutInfo.visibleItemsInfo.none { it.index == spokenChunk }) {
+   257	                                runCatching { listState.animateScrollToItem(spokenChunk) }
+   258	                            }
+   259	                        }
+   260	                        var showSpeed by remember { mutableStateOf(false) }
+   261	                        var showVoice by remember { mutableStateOf(false) }
+   262	                        var starting by remember { mutableStateOf(false) }   // guards double-tap → double-chunk
+   263	                        // snapshot the voice options once when the sheet opens (not every recomposition).
+   264	                        val voiceList = remember(showVoice) { if (showVoice) ttsVm.voiceListState() else com.vreader.app.tts.TtsVoiceListState() }
+   265	
+   266	                        // feature #122 — reading-stats: track this session (the process-singleton tracker
+   267	                        // survives rotation) + show the auto-fading session pill.
+   268	                        val tracker = container.readingTimeTracker
+   269	                        val bookKey = s.book.fingerprintKey
+   270	                        val sessionSeconds by tracker.sessionSeconds.collectAsStateWithLifecycle()
+   271	
+   272	                        // feature #124/#125 — stored highlights → per-chunk washes. Enabled for TXT AND MD
+   273	                        // (#125 added the MarkdownChunkTextMapper source-offset map, so MD is no longer
+   274	                        // render-only). The mapper is the single rendered↔source bridge + render owner,
+   275	                        // shared by the wash, the selection controller, and the body.
+   276	                        val annotatable = s.book.originalFormat == BookFormat.txt || s.book.originalFormat == BookFormat.md
+   277	                        val chunkMapper = remember(s.document, s.book.originalFormat) {
+   278	                            if (s.book.originalFormat == BookFormat.md) MarkdownChunkTextMapper(s.document)
+   279	                            else IdentityChunkTextMapper(s.document)
+   280	                        }
+   281	                        val highlightsList by remember(bookKey, annotatable) {
+   282	                            if (annotatable) container.annotationsRepository.highlights(bookKey) else flowOf(emptyList())
+   283	                        }.collectAsStateWithLifecycle(emptyList())
+   284	                        val washMap = remember(highlightsList, s.document, chunkMapper) { TxtWashMapper.washesByChunk(s.document, highlightsList, chunkMapper) }
+   285	
+   286	                        // feature #124/#125 — custom selection + popover (TXT + MD).
+   287	                        val selectionController = remember(s.document, chunkMapper) { if (annotatable) TxtSelectionController(s.document, chunkMapper) else null }
+   288	                        val popoverVm = remember(bookKey) { com.vreader.app.annotations.SelectionPopoverViewModel() }
+   289	                        val popoverState by popoverVm.state.collectAsStateWithLifecycle()
+   290	                        DisposableEffect(lifecycleOwner, bookKey) {
+   291	                            val obs = LifecycleEventObserver { _, e ->
+   292	                                when (e) {
+   293	                                    // start/stop on the PROCESS scope (not the composition-scoped ttsScope) so the
+   294	                                    // durable bank in stop()/flush() can't be cancelled by the reader's teardown.
+   295	                                    Lifecycle.Event.ON_RESUME -> container.appScope.launch { tracker.start(bookKey) }
+   296	                                    // don't end the session on a rotation (config change) — only a real background.
+   297	                                    // keyed stop: a no-op unless THIS book is the active session (stale-Activity safe).
+   298	                                    Lifecycle.Event.ON_STOP -> if (!isChangingConfigurations) container.appScope.launch { tracker.stop(bookKey) }
+   299	                                    else -> Unit
+   300	                                }
+   301	                            }
+   302	                            // addObserver replays lifecycle events up to the current state — so a Loaded
+   303	                            // composition that arrives AFTER ON_RESUME still receives ON_RESUME here and the
+   304	                            // initial open is tracked (no missed first session).
+   305	                            lifecycleOwner.lifecycle.addObserver(obs)
+   306	                            onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
+   307	                        }
+   308	                        // live pill + periodic bank — gated to RESUMED so neither loop wakes while backgrounded.
+   309	                        LaunchedEffect(Unit) { lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) { while (true) { delay(1_000); tracker.tickSessionSeconds() } } }
+   310	                        LaunchedEffect(Unit) { lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) { while (true) { delay(60_000); tracker.flush() } } }
+   311	                        var pillVisible by remember { mutableStateOf(true) }
+   312	                        LaunchedEffect(Unit) { delay(5_000); pillVisible = false }                             // auto-fade
+   313	
+   314	                        // feature #129 WI-4 — the Display sheet, opened from the chrome's Aa slot.
+   315	                        var showDisplaySheet by remember { mutableStateOf(false) }
+   316	
+   317	                        // feature #132 WI-6 — the shared reader-chrome state (top/bottom visibility + open
+   318	                        // sheet), persisted across rotation / process death via ReaderChromeStateSaver.
+   319	                        val chromeState = rememberSaveable(bookKey, stateSaver = ReaderChromeStateSaver) {
+   320	                            mutableStateOf(ReaderChromeState())
+   321	                        }
+   322	                        // The Notes review sheet's one-shot snapshot. Reloads whenever this book's stored
+   323	                        // highlights change (a fresh highlight/edit/remove OR a #124/#125 wash) so a newly
+   324	                        // added annotation appears in the sheet without reopening the reader.
+   325	                        val annotationsSnapshot by produceState(
+   326	                            AnnotationsSnapshot(emptyList(), emptyList()), bookKey, annotatable, highlightsList,
+   327	                        ) {
+   328	                            value = if (!annotatable) AnnotationsSnapshot(emptyList(), emptyList())
+   329	                            else runCatching { container.annotationsRepository.annotationsForBook(bookKey) }
+   330	                                .getOrDefault(AnnotationsSnapshot(emptyList(), emptyList()))
+   331	                        }
+   332	
+   333	                        // feature #134 WI-5 — the More menu's Book-details model (mapped from the loaded
+   334	                        // book + its live collection names via BookDetailsMapper). TXT/MD supplies no page
+   335	                        // count (pageCount=null). Rebuilds when the book's collection membership changes.
+   336	                        val collectionNames by container.collectionRepository
+   337	                            .observeCollectionNamesForBook(bookKey)
+   338	                            .collectAsStateWithLifecycle(initialValue = emptyList())
+   339	                        val bookDetails = remember(s.book, collectionNames) {
+   340	                            com.vreader.app.reader.details.BookDetailsMapper.map(s.book, collectionNames, pageCount = null)
+   341	                        }
+   342	
+   343	                        // feature #135 WI-7 — the bookmark wiring. TXT/MD has no TOC (null tocIndex → the WI-4
+   344	                        // projection degrades chapter/page to null) but DOES supply a preview provider (a bounded
+   345	                        // snippet around the stored char offset — the host owns the decoded text). The current
+   346	                        // position is the top-visible chunk's char offset → a plain canonical Locator.
+   347	                        val previewProvider = remember(s.document) { txtBookmarkPreviewProvider(s.document) }
+   348	                        val dateRenderer = remember { bookmarkDateRenderer() }
+   349	                        val currentCanonical = remember(s.book) {
+   350	                            { off: Int -> txtBookmarkLocator(s.book, off) }
+   351	                        }
+   352	                        val bookmarkRecords by remember(bookKey) { container.annotationsRepository.bookmarks(bookKey) }
+   353	                            .collectAsStateWithLifecycle(emptyList())
+   354	                        val bookmarkRows = remember(bookmarkRecords, s.book) {
+   355	                            bookmarkRowItems(bookmarkRecords, s.book.originalFormat, tocIndex = null, previewProvider = previewProvider, dateRenderer = dateRenderer)
+   356	                        }
+   357	                        // The live top-visible offset → canonical (recomputed on scroll; the toggle/presence read it).
+   358	                        val liveOffset = s.document.offsetForChunk(listState.firstVisibleItemIndex)
+   359	                        val liveCanonical = remember(s.book, liveOffset) { txtBookmarkLocator(s.book, liveOffset) }
+   360	                        val isBookmarked by produceState(false, liveCanonical, bookmarkRecords) {
+   100	                )
+   101	                container.repository.savePosition(
+   102	                    vreader.contracts.VReaderLocator.wrapLegacy(locator),
+   103	                    System.currentTimeMillis(),
+   104	                )
+   105	            }
+   106	        }
+   107	
+   108	        setContent {
+   109	            val state by produceState<PdfUiState>(PdfUiState.Loading, key) {
+   110	                value = withContext(Dispatchers.IO) { load(key) }
+   111	            }
+   112	            // feature #129 WI-7 — the live Display settings; PDF reads ONLY the theme background. NULL
+   113	            // until the DataStore's first emission — the composition is GATED on it (like the reflowable
+   114	            // readers) so a user with a stored dark theme never sees a wrong bright frame on open/rotation.
+   115	            val settingsOrNull by container.readerSettingsStore.settings.collectAsStateWithLifecycle(initialValue = null)
+   116	            val settings = settingsOrNull
+   117	            if (settings == null) {
+   118	                // Pre-emission: nothing painted (an empty full-screen surface), the test hook stays null.
+   119	                Box(Modifier.fillMaxSize())
+   120	            } else {
+   121	                val backdrop = settings.pdfBackdrop()
+   122	                SideEffect { appliedBackdropArgb = backdrop.toArgb() }
+   123	                when (val s = state) {
+   124	                    is PdfUiState.Loading -> PdfScaffold("", ::finish, backdrop) { CenterMessage("Opening…") }
+   125	                    is PdfUiState.Protected -> PdfScaffold("", ::finish, backdrop) {
+   126	                        CenterMessage("This PDF is protected", "It's password-protected or uses a security scheme this reader can't open.")
+   127	                    }
+   128	                    is PdfUiState.Corrupt -> PdfScaffold("", ::finish, backdrop) {
+   129	                        CenterMessage("Couldn’t open this PDF", "The file appears to be damaged or uses a format the reader can’t decode.")
+   130	                    }
+   131	                    is PdfUiState.Empty -> PdfScaffold("", ::finish, backdrop) {
+   132	                        CenterMessage("This PDF has no pages", null)
+   133	                    }
+   134	                    is PdfUiState.Loaded -> {
+   135	                        val listState = rememberLazyListState(initialFirstVisibleItemIndex = s.initialPage)
+   136	                        // Close the renderer when the reader leaves composition — launched on the
+   137	                        // process scope (NOT runBlocking on main: close() awaits the doc mutex behind
+   138	                        // any in-flight render, which could ANR the teardown/rotation frame).
+   139	                        DisposableEffect(s.document) {
+   140	                            onDispose { container.appScope.launch { s.document.close() } }
+   141	                        }
+   142	                        SideEffect { flushPosition = { savePage(s.book, listState.firstVisibleItemIndex) } }
+   143	                        LaunchedEffect(listState) {
+   144	                            snapshotFlow { listState.firstVisibleItemIndex }
+   145	                                .drop(1).debounce(800).collect { savePage(s.book, it) }
+   146	                        }
+   147	                        // feature #132 WI-7-hosts — the shared reader chrome. State persists across
+   148	                        // rotation / process death via ReaderChromeStateSaver (keyed on the book).
+   149	                        val bookKey = s.book.fingerprintKey
+   150	                        val chromeState = rememberSaveable(bookKey, stateSaver = ReaderChromeStateSaver) {
+   151	                            mutableStateOf(ReaderChromeState())
+   152	                        }
+   153	                        // The Notes review sheet's one-shot snapshot of this book's highlights + notes.
+   154	                        val annotationsSnapshot by produceState(
+   155	                            AnnotationsSnapshot(emptyList(), emptyList()), bookKey,
+   156	                        ) {
+   157	                            value = runCatching { container.annotationsRepository.annotationsForBook(bookKey) }
+   158	                                .getOrDefault(AnnotationsSnapshot(emptyList(), emptyList()))
+   159	                        }
+   160	                        val jumpScope = rememberCoroutineScope()
+   161	                        // feature #134 WI-5 — the More menu's Book-details model (mapped from the book + its
+   162	                        // live collection names + the real PDF page count → the Pages row).
+   163	                        val collectionNames by container.collectionRepository
+   164	                            .observeCollectionNamesForBook(bookKey)
+   165	                            .collectAsStateWithLifecycle(initialValue = emptyList())
+   166	                        val bookDetails = androidx.compose.runtime.remember(s.book, collectionNames, s.document.pageCount) {
+   167	                            com.vreader.app.reader.details.BookDetailsMapper.map(s.book, collectionNames, pageCount = s.document.pageCount)
+   168	                        }
+   169	
+   170	                        // feature #135 WI-7 — the bookmark wiring. PDF has no TOC or preview (null tocIndex +
+   171	                        // null provider → the WI-4 projection shows just "p. N"). The current position is the
+   172	                        // top-visible page → a plain canonical Locator; the jump scrolls to the page.
+   173	                        val dateRenderer = androidx.compose.runtime.remember { bookmarkDateRenderer() }
+   174	                        val bookmarkRecords by androidx.compose.runtime.remember(bookKey) {
+   175	                            container.annotationsRepository.bookmarks(bookKey)
+   176	                        }.collectAsStateWithLifecycle(emptyList())
+   177	                        val bookmarkRows = androidx.compose.runtime.remember(bookmarkRecords, s.book) {
+   178	                            bookmarkRowItems(bookmarkRecords, s.book.originalFormat, tocIndex = null, previewProvider = null, dateRenderer = dateRenderer)
+   179	                        }
+   180	                        val livePage = listState.firstVisibleItemIndex
+   181	                        val liveCanonical = androidx.compose.runtime.remember(s.book, livePage) { pdfBookmarkLocator(s.book, livePage) }
+   182	                        val isBookmarked by produceState(false, liveCanonical, bookmarkRecords) {
+   183	                            value = runCatching { container.annotationsRepository.isBookmarked(bookKey, liveCanonical) }.getOrDefault(false)
+   184	                        }
+   185	
+   186	                        PdfReaderChrome(
+   187	                            theme = settings.theme,
+   188	                            title = s.title,
+   189	                            chromeState = chromeState,
+   190	                            annotations = annotationsSnapshot,
+   191	                            onBack = ::finish,
+   192	                            // PDF tap-to-jump: scroll the page list to the annotation's clamped page —
+   193	                            // the existing resume/save page-scroll seam (listState.firstVisibleItemIndex).
+   194	                            onJumpToAnnotation = { item ->
+   195	                                jumpScope.launch { listState.scrollToItem(pdfAnnotationPage(item, s.document.pageCount)) }
+   196	                            },
+   197	                            onShareAnnotations = { shareAnnotations(annotationsSnapshot) },
+   198	                            body = { PdfReaderBody(s.document, listState, backdrop) },
+   199	                            bookDetails = bookDetails,
+   200	                            onShareBook = { com.vreader.app.reader.share.shareBook(this@PdfReaderActivity, s.book) },
+   201	                            onCopyFingerprint = { copyFingerprint(it) },
+   202	                            // feature #135 WI-7 — the top-bar bookmark toggle + Bookmarks-tab rows + PDF jump.
+   203	                            isCurrentBookmarked = isBookmarked,
+   204	                            onToggleBookmark = {
+   205	                                container.appScope.launch {
+   206	                                    runCatching { container.annotationsRepository.toggleBookmark(bookKey, title = null, locator = liveCanonical) }
+   207	                                }
+   208	                            },
+   209	                            currentLocator = liveCanonical,
+   210	                            bookmarks = bookmarkRows,
+   211	                            // PDF jump: scroll to the bookmark's page; out-of-range → Failed (sheet stays open).
+   212	                            onJumpBookmark = { record ->
+   213	                                val target = pdfBookmarkPageTarget(record.locator.page, s.document.pageCount)
+   214	                                if (target == null) {
+   215	                                    JumpResult.Failed
+   216	                                } else {
+   217	                                    jumpScope.launch { listState.scrollToItem(target) }
+   218	                                    JumpResult.Succeeded
+   219	                                }
+   220	                            },
+   221	                        )
+   222	                    }
+   223	                }
+   224	            }
+   225	        }
+   226	    }
+   227	
+   228	    override fun onStop() {
+   229	        super.onStop()
+   230	        flushPosition?.invoke()
+   231	    }
+   232	
+   233	    override fun onDestroy() {
+   234	        super.onDestroy()
+   235	        saveRequests.close()
+   236	    }
+   237	
+   238	    /** feature #134 WI-5 — copy the FULL canonical fingerprint to the OS clipboard (the Book Details
+   239	     *  copy-fingerprint mini-action). Rely on the OS copy confirmation — no invented toast (rule 51). */
+   240	    private fun copyFingerprint(fingerprintFull: String) {
+   110	        container.appScope.launch {
+   111	            for (locator in saveRequests) container.repository.savePosition(locator, System.currentTimeMillis())
+   112	        }
+   113	
+   114	        setContent {
+   115	            val outer by produceState<OuterState>(OuterState.Loading, key) { value = loadOuter(key) }
+   116	            when (val o = outer) {
+   117	                OuterState.Loading -> ReaderScaffold("", ::finish) { Centered { CircularProgressIndicator() } }
+   118	                OuterState.NoBook -> ReaderScaffold("", ::finish) { Centered { Text("This book can’t be opened.", color = Ink) } }
+   119	                is OuterState.Ready -> {
+   120	                    currentBook = o.book
+   121	                    // feature #132 WI-7-hosts — the shared reader chrome. State persists across rotation /
+   122	                    // process death via ReaderChromeStateSaver (keyed on the book).
+   123	                    val bookKey = o.book.fingerprintKey
+   124	                    val chromeState = rememberSaveable(bookKey, stateSaver = ReaderChromeStateSaver) {
+   125	                        mutableStateOf(ReaderChromeState())
+   126	                    }
+   127	                    val displayTheme by container.readerSettingsStore.settings
+   128	                        .collectAsStateWithLifecycle(initialValue = com.vreader.app.reader.settings.ReaderSettings())
+   129	                    // The Notes review sheet's one-shot snapshot of this book's highlights + notes.
+   130	                    val annotationsSnapshot by produceState(
+   131	                        AnnotationsSnapshot(emptyList(), emptyList()), bookKey,
+   132	                    ) {
+   133	                        value = runCatching { container.annotationsRepository.annotationsForBook(bookKey) }
+   134	                            .getOrDefault(AnnotationsSnapshot(emptyList(), emptyList()))
+   135	                    }
+   136	                    // feature #134 WI-5 — the More menu's Book-details model (mapped from the book + its
+   137	                    // live collection names). AZW3 supplies no page count (pageCount=null).
+   138	                    val collectionNames by container.collectionRepository
+   139	                        .observeCollectionNamesForBook(bookKey)
+   140	                        .collectAsStateWithLifecycle(initialValue = emptyList())
+   141	                    val bookDetails = remember(o.book, collectionNames) {
+   142	                        com.vreader.app.reader.details.BookDetailsMapper.map(o.book, collectionNames, pageCount = null)
+   143	                    }
+   144	
+   145	                    // feature #135 WI-7 — the bookmark wiring. AZW3 has no reader TOC, so the row projection
+   146	                    // has no chapter/page (the WI-4 EPUB/AZW3 branch degrades to null fields — no crash) — a
+   147	                    // null tocIndex. The current position comes from the relocate-derived canonical Locator;
+   148	                    // the jump uses Azw3Document.goTo (CFI-first→fraction, render-death carry-across).
+   149	                    val bookmarkRecords by container.annotationsRepository.bookmarks(bookKey)
+   150	                        .collectAsStateWithLifecycle(initialValue = emptyList())
+   151	                    val dateRenderer = remember { bookmarkDateRenderer() }
+   152	                    val bookmarkRows = remember(bookmarkRecords) {
+   153	                        bookmarkRowItems(bookmarkRecords, BookFormat.azw3, tocIndex = null, previewProvider = null, dateRenderer = dateRenderer)
+   154	                    }
+   155	                    // The live position + the document to jump into, hoisted from the body so the chrome-level
+   156	                    // toggle/jump can reach them. currentCanonical is null until foliate's first relocate.
+   157	                    var currentCanonical by remember { mutableStateOf<Locator?>(null) }
+   158	                    var liveDocument by remember { mutableStateOf<Azw3Document?>(null) }
+   159	                    // Presence — refreshed on every relocate AND right after a toggle.
+   160	                    val isBookmarked by produceState(false, currentCanonical, bookmarkRecords) {
+   161	                        val c = currentCanonical
+   162	                        value = c != null && runCatching { container.annotationsRepository.isBookmarked(bookKey, c) }.getOrDefault(false)
+   163	                    }
+   164	                    val jumpScope = rememberCoroutineScope()
+   165	
+   166	                    Azw3ReaderChrome(
+   167	                        theme = displayTheme.theme,
+   168	                        title = o.book.title,
+   169	                        chromeState = chromeState,
+   170	                        annotations = annotationsSnapshot,
+   171	                        onBack = ::finish,
+   172	                        onShareAnnotations = { shareAnnotations(annotationsSnapshot) },
+   173	                        bookDetails = bookDetails,
+   174	                        onShareBook = { com.vreader.app.reader.share.shareBook(this@Azw3ReaderActivity, o.book) },
+   175	                        onCopyFingerprint = { copyFingerprint(it) },
+   176	                        // feature #135 WI-7 — the top-bar bookmark toggle + Bookmarks-tab rows + AZW3 jump.
+   177	                        isCurrentBookmarked = isBookmarked,
+   178	                        onToggleBookmark = if (currentCanonical != null) {
+   179	                            {
+   180	                                val c = currentCanonical
+   181	                                if (c != null) container.appScope.launch {
+   182	                                    runCatching { container.annotationsRepository.toggleBookmark(bookKey, title = null, locator = c) }
+   183	                                }
+   184	                            }
+   185	                        } else null,
+   186	                        currentLocator = currentCanonical,
+   187	                        bookmarks = bookmarkRows,
+   188	                        onJumpBookmark = { record ->
+   189	                            val doc = liveDocument
+   190	                            // Decide the sheet's dismiss SYNCHRONOUSLY from target validity: an unjumpable
+   191	                            // bookmark (no cfi + no finite progression) → Failed (sheet stays open, no
+   192	                            // invented error surface — rule 51); a jumpable one → Succeeded (dismiss). The
+   193	                            // ACTUAL landing is the awaited Azw3Document.goTo (CFI-first→fraction) launched
+   194	                            // off the jump scope — it blocks ~3s on the bundle relocate ack, so it CANNOT run
+   195	                            // on the tap thread (that would ANR). render-death mid-jump is carried across by
+   196	                            // the host's recreate path (takePendingGoTo → run(pendingGoTo=)); goTo re-lands once.
+   197	                            val decision = azw3JumpDecision(doc, record.locator)
+   198	                            if (decision == JumpResult.Succeeded && doc != null) {
+   199	                                jumpScope.launch {
+   200	                                    // The awaited landing (mapped for symmetry with the plan's Succeeded/
+   201	                                    // Timeout/Failed contract); a landed jump relocates → presence refreshes.
+   202	                                    val landed = runCatching { doc.goTo(record.locator) }
+   203	                                        .getOrDefault(Azw3GoToResult.Failed)
+   204	                                    if (azw3JumpResult(landed) == JumpResult.Succeeded && currentCanonical != null) {
+   205	                                        currentCanonical = record.locator // reflect the reached position promptly
+   206	                                    }
+   207	                                }
+   208	                            }
+   209	                            decision
+   210	                        },
+   211	                        body = {
+   212	                            Azw3ReaderHost(
+   213	                                book = o.book,
+   214	                                bookFile = File(o.path),
+   215	                                restore = o.restore,
+   216	                                settings = container.readerSettingsStore.settings,
+   217	                                onRelocate = { rel ->
+   218	                                    enqueueSave(o.book, rel)
+   219	                                    currentCanonical = Azw3LocatorBridge
+   220	                                        .toEnvelope(rel, o.book.contentSHA256, o.book.fileByteCount)
+   221	                                        .legacyLocator?.copy(format = BookFormat.azw3.name)?.validatedOrNull()
+   222	                                },
+   223	                                onDocument = { doc -> liveDocument = doc },
+   224	                            )
+   225	                        },
+   226	                    )
+   227	                }
+   228	            }
+   229	        }
+   230	    }
+   231	
+   232	    private suspend fun loadOuter(key: String): OuterState {
+   233	        val book = container.repository.findBook(key) ?: return OuterState.NoBook
+   234	        val path = book.localFilePath ?: return OuterState.NoBook
+   235	        if (!File(path).isFile) return OuterState.NoBook
+   236	        container.repository.markOpened(key, System.currentTimeMillis())
+   237	        return OuterState.Ready(book, path, container.repository.loadPosition(key))
+   238	    }
+   239	
+   240	    private fun enqueueSave(book: Book, relocate: FoliateMessage.Relocate) {
+   241	        currentBook = book
+   242	        latestRelocate = relocate
+   243	        saveRequests.trySend(Azw3LocatorBridge.toEnvelope(relocate, book.contentSHA256, book.fileByteCount))
+   244	    }
+   245	
+   246	    override fun onStop() {
+   247	        super.onStop()
+   248	        val book = currentBook
+   249	        val relocate = latestRelocate
+   250	        if (book != null && relocate != null) {
+   251	            saveRequests.trySend(Azw3LocatorBridge.toEnvelope(relocate, book.contentSHA256, book.fileByteCount))
+   252	        }
+   253	    }
+   254	
+   255	    override fun onDestroy() {
+   256	        super.onDestroy()
+   257	        saveRequests.close()
+   258	    }
+   259	
+   260	    /** feature #134 WI-5 — copy the FULL canonical fingerprint to the OS clipboard (the Book Details
+
+exec
+/bin/zsh -lc "rg --files android/app/src/androidTest android/app/src/test | rg 'Ai|ReaderChromeStateSaver|ReaderMoreRows|MorePopup'
+rg -n \"class AiRoundTripConnectedTest|AiRoundTrip\" android/app/src
+nl -ba dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx | sed -n '1,280p'
+nl -ba dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-android.jsx | sed -n '1,115p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+android/app/src/test/kotlin/com/vreader/app/ai/AiChatViewModelTest.kt
+android/app/src/test/kotlin/com/vreader/app/ai/AiFakeServer.kt
+android/app/src/test/kotlin/com/vreader/app/ai/AiSettingsViewModelTest.kt
+android/app/src/test/kotlin/com/vreader/app/ai/OpenAiCompatibleProviderTest.kt
+android/app/src/test/kotlin/com/vreader/app/ai/AiProviderStoreTest.kt
+android/app/src/test/kotlin/com/vreader/app/ai/AiMarkdownRendererTest.kt
+android/app/src/test/kotlin/com/vreader/app/ai/AiProviderKindTest.kt
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiRoundTripConnectedTest.kt
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderEditSheetTest.kt
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiProviderListScreenTest.kt
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiChatPanelTest.kt
+android/app/src/test/kotlin/com/vreader/app/reader/chrome/ReaderMoreRowsTest.kt
+android/app/src/test/kotlin/com/vreader/app/reader/chrome/ReaderChromeStateSaverTest.kt
+android/app/src/androidTest/kotlin/com/vreader/app/reader/more/MorePopupTest.kt
+android/app/src/androidTest/kotlin/com/vreader/app/ai/AiRoundTripConnectedTest.kt:22:class AiRoundTripConnectedTest {
+     1	// In-reader AI Providers entry — issue #1380.
+     2	//
+     3	// Wires the bilingual setup sheet's "Set up" button (shown when no AI provider
+     4	// is configured, per Bug #301) to an actual AI Providers surface — which does
+     5	// not exist in-reader today (the reader's showSettings sheet is display/fonts
+     6	// only; the full SettingsView with AISettingsSection is Library-only).
+     7	//
+     8	// CANONICAL (A): a scoped "AI Providers" sheet PUSHED inside the bilingual
+     9	//   flow (nav bar: ‹ Bilingual · "AI Providers"), hosting only the provider
+    10	//   list. Empty → "Add provider" → the canonical AIProviderEditSheet
+    11	//   (vreader-ai-provider-fields.jsx, reused unchanged). On first Save the
+    12	//   provider becomes the bilingual engine and the stack pops back to Bilingual,
+    13	//   whose engine strip now reads "configured / Change…".
+    14	//
+    15	// ALTERNATIVES shown for comparison:
+    16	//   B — deep-link into the full SettingsView, scrolled to the AI section.
+    17	//   C — inline expansion of the engine strip inside the bilingual sheet.
+    18	//
+    19	// Reuses: Sheet vocabulary, SectionLabel, Icons, THEMES tokens. The provider
+    20	// tile keeps the fixed #8c2f2f brand color used by the shipped AI Provider row.
+    21	
+    22	const AIPE_BRAND = '#8c2f2f';           // AI provider tile (theme-independent)
+    23	const AIPE_MONO  = 'ui-monospace, "SF Mono", "Menlo", monospace';
+    24	const AIPE_SERIF = '"Source Serif 4", Georgia, serif';
+    25	
+    26	// ────────────────────────────────────────────────────
+    27	// NavSheet — bottom sheet with an iOS-style navigation bar (back + centered
+    28	// title + trailing). This is the "push within the sheet" presentation: same
+    29	// grabber + frame as Sheet, but a real back affordance instead of a grabber-
+    30	// only modal. Title is absolutely centered so a wide back label can't shove it.
+    31	// ────────────────────────────────────────────────────
+    32	function NavSheet({ theme, height = 620, title, backLabel = 'Bilingual', onBack, trailing, children }) {
+    33	  const t = theme || THEMES.paper;
+    34	  return (
+    35	    <div style={{
+    36	      position: 'absolute', inset: 0, zIndex: 200,
+    37	      display: 'flex', flexDirection: 'column', justifyContent: 'flex-end',
+    38	      background: 'rgba(0,0,0,0.35)',
+    39	    }}>
+    40	      <div style={{
+    41	        background: t.isDark ? '#222020' : '#fcf8f0',
+    42	        height, borderTopLeftRadius: 22, borderTopRightRadius: 22,
+    43	        boxShadow: '0 -8px 28px rgba(0,0,0,0.25)',
+    44	        display: 'flex', flexDirection: 'column', overflow: 'hidden',
+    45	      }}>
+    46	        <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 8 }}>
+    47	          <div style={{
+    48	            width: 36, height: 5, borderRadius: 3,
+    49	            background: t.isDark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.12)',
+    50	          }}/>
+    51	        </div>
+    52	        <div style={{
+    53	          position: 'relative', display: 'flex', alignItems: 'center',
+    54	          padding: '13px 16px 12px',
+    55	          borderBottom: `0.5px solid ${t.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
+    56	        }}>
+    57	          <button onClick={onBack} style={{
+    58	            display: 'flex', alignItems: 'center', gap: 1, zIndex: 1,
+    59	            background: 'none', border: 'none', padding: 0, cursor: 'pointer',
+    60	            color: t.accent, fontFamily: 'inherit', fontSize: 15, fontWeight: 500,
+    61	            whiteSpace: 'nowrap',
+    62	          }}>
+    63	            <Icons.ChevronL size={19} color={t.accent} stroke={2.2}/>
+    64	            <span>{backLabel}</span>
+    65	          </button>
+    66	          <div style={{
+    67	            position: 'absolute', left: 0, right: 0, textAlign: 'center',
+    68	            fontFamily: AIPE_SERIF, fontSize: 17, fontWeight: 600, color: t.ink,
+    69	            pointerEvents: 'none',
+    70	          }}>{title}</div>
+    71	          <div style={{ marginLeft: 'auto', zIndex: 1 }}>{trailing}</div>
+    72	        </div>
+    73	        <div style={{ flex: 1, overflow: 'auto' }} className="hide-scroll">{children}</div>
+    74	      </div>
+    75	    </div>
+    76	  );
+    77	}
+    78	
+    79	// ────────────────────────────────────────────────────
+    80	// Bilingual engine strip — standalone replica of the strip inside
+    81	// BilingualSetupSheet, so the canvas can show the before ("Set up") and after
+    82	// ("Change…") states and the flow's payoff. justChanged adds a brief accent
+    83	// ring on the freshly-configured return.
+    84	// ────────────────────────────────────────────────────
+    85	function BilingualEngineStrip({ theme, configured, providerName = 'Claude', onSetup, justChanged = false }) {
+    86	  const t = theme;
+    87	  return (
+    88	    <div>
+    89	      <SectionLabel theme={t}>Translation engine</SectionLabel>
+    90	      <div style={{
+    91	        marginTop: 8, padding: '12px 14px', borderRadius: 12,
+    92	        background: configured ? (t.isDark ? 'rgba(255,255,255,0.04)' : '#fff') : `${t.accent}10`,
+    93	        border: configured ? `0.5px solid ${t.rule}` : `0.5px solid ${t.accent}55`,
+    94	        boxShadow: justChanged ? `0 0 0 2px ${t.accent}66` : 'none',
+    95	        display: 'flex', alignItems: 'center', gap: 12,
+    96	        transition: 'box-shadow 0.3s',
+    97	      }}>
+    98	        <div style={{
+    99	          width: 28, height: 28, borderRadius: 14, flexShrink: 0,
+   100	          background: configured ? `linear-gradient(135deg, ${t.accent}, ${t.accent}aa)` : 'rgba(0,0,0,0.08)',
+   101	          display: 'flex', alignItems: 'center', justifyContent: 'center',
+   102	        }}>
+   103	          <Icons.Sparkle size={14} color={configured ? '#fff' : t.sub} stroke={2}/>
+   104	        </div>
+   105	        <div style={{ flex: 1, minWidth: 0 }}>
+   106	          <div style={{ fontSize: 13.5, color: t.ink, fontWeight: 600 }}>
+   107	            {configured ? `${providerName} · with this book’s context` : 'No AI provider configured'}
+   108	          </div>
+   109	          <div style={{ fontSize: 11.5, color: t.sub, marginTop: 1 }}>
+   110	            {configured
+   111	              ? 'Translations cached per paragraph, one page ahead.'
+   112	              : 'Bilingual mode needs an AI provider to translate.'}
+   113	          </div>
+   114	        </div>
+   115	        <button onClick={onSetup} style={{
+   116	          padding: '5px 11px', borderRadius: 100, border: 'none',
+   117	          background: configured ? (t.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)') : t.accent,
+   118	          color: configured ? t.ink : '#fff',
+   119	          fontFamily: 'inherit', fontSize: 11.5, fontWeight: 600, cursor: 'pointer',
+   120	          flexShrink: 0,
+   121	        }}>{configured ? 'Change…' : 'Set up'}</button>
+   122	      </div>
+   123	    </div>
+   124	  );
+   125	}
+   126	
+   127	// ────────────────────────────────────────────────────
+   128	// Provider list row — matches the shipped SettingsRow vocabulary.
+   129	// ────────────────────────────────────────────────────
+   130	function ProviderRow({ theme, name, model, selected, onClick, last }) {
+   131	  const t = theme;
+   132	  return (
+   133	    <div onClick={onClick} style={{
+   134	      display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px',
+   135	      borderBottom: last ? 'none' : `0.5px solid ${t.rule}`, cursor: 'pointer',
+   136	    }}>
+   137	      <div style={{
+   138	        width: 30, height: 30, borderRadius: 8, flexShrink: 0, background: AIPE_BRAND,
+   139	        display: 'flex', alignItems: 'center', justifyContent: 'center',
+   140	      }}>
+   141	        <Icons.Sparkle size={17} color="#fff" stroke={1.8}/>
+   142	      </div>
+   143	      <div style={{ flex: 1, minWidth: 0 }}>
+   144	        <div style={{ fontSize: 15, color: t.ink }}>{name}</div>
+   145	        <div style={{ fontSize: 11, color: t.sub, marginTop: 1, fontFamily: AIPE_MONO }}>{model}</div>
+   146	      </div>
+   147	      {selected ? (
+   148	        <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
+   149	          <span style={{ fontSize: 10.5, fontWeight: 600, color: t.accent, letterSpacing: 0.4, textTransform: 'uppercase', whiteSpace: 'nowrap' }}>In use</span>
+   150	          <Icons.Check size={16} color={t.accent} stroke={2.6}/>
+   151	        </div>
+   152	      ) : (
+   153	        <Icons.Chevron size={13} color={t.sub} stroke={2}/>
+   154	      )}
+   155	    </div>
+   156	  );
+   157	}
+   158	
+   159	// ────────────────────────────────────────────────────
+   160	// AI Providers sheet body — empty + populated.
+   161	// ────────────────────────────────────────────────────
+   162	function AIProvidersSheetBody({ theme, providers, selectedId, onAdd, onSelect }) {
+   163	  const t = theme;
+   164	  const empty = !providers || providers.length === 0;
+   165	  return (
+   166	    <div style={{ padding: '14px 18px 28px' }}>
+   167	      {/* why-you're-here context — the bilingual thread, kept visible */}
+   168	      <div style={{
+   169	        display: 'flex', alignItems: 'center', gap: 10,
+   170	        padding: '10px 12px', borderRadius: 10,
+   171	        background: `${t.accent}10`, border: `0.5px solid ${t.accent}33`,
+   172	        marginBottom: 18,
+   173	      }}>
+   174	        <div style={{
+   175	          width: 22, height: 22, borderRadius: 11, flexShrink: 0,
+   176	          background: `${t.accent}1f`, display: 'flex', alignItems: 'center', justifyContent: 'center',
+   177	        }}>
+   178	          <Icons.Translate size={13} color={t.accent} stroke={1.9}/>
+   179	        </div>
+   180	        <div style={{ fontSize: 11.5, color: t.ink, lineHeight: 1.35 }}>
+   181	          Choose the provider <b style={{ fontWeight: 600 }}>bilingual mode</b> will use to translate this book.
+   182	        </div>
+   183	      </div>
+   184	
+   185	      {empty ? (
+   186	        <div style={{ textAlign: 'center', padding: '24px 12px 8px' }}>
+   187	          <div style={{
+   188	            width: 54, height: 54, borderRadius: 27, margin: '0 auto 14px',
+   189	            background: `linear-gradient(135deg, ${t.accent}, ${t.accent}aa)`,
+   190	            display: 'flex', alignItems: 'center', justifyContent: 'center',
+   191	            boxShadow: `0 6px 18px ${t.accent}44`,
+   192	          }}>
+   193	            <Icons.Sparkle size={26} color="#fff" stroke={1.7}/>
+   194	          </div>
+   195	          <div style={{ fontFamily: AIPE_SERIF, fontSize: 18, fontWeight: 600, color: t.ink }}>
+   196	            No providers yet
+   197	          </div>
+   198	          <div style={{ fontSize: 12.5, color: t.sub, lineHeight: 1.5, maxWidth: 268, margin: '6px auto 20px' }}>
+   199	            Add Claude, OpenAI, or any OpenAI-compatible endpoint. Your API key is stored in the device keychain — never synced.
+   200	          </div>
+   201	          <button onClick={onAdd} style={{
+   202	            display: 'inline-flex', alignItems: 'center', gap: 7,
+   203	            padding: '11px 20px', borderRadius: 100, border: 'none',
+   204	            background: t.accent, color: '#fff',
+   205	            fontFamily: 'inherit', fontSize: 14, fontWeight: 600, cursor: 'pointer',
+   206	            boxShadow: `0 4px 14px ${t.accent}55`,
+   207	          }}>
+   208	            <Icons.Plus size={17} color="#fff" stroke={2.2}/>Add provider
+   209	          </button>
+   210	        </div>
+   211	      ) : (
+   212	        <div>
+   213	          <SectionLabel theme={t}>Providers</SectionLabel>
+   214	          <div style={{
+   215	            marginTop: 8, borderRadius: 14, overflow: 'hidden',
+   216	            background: t.isDark ? 'rgba(255,255,255,0.04)' : '#fff',
+   217	            boxShadow: t.isDark ? 'none' : '0 1px 0 rgba(0,0,0,0.04)',
+   218	          }}>
+   219	            {providers.map((p) => (
+   220	              <ProviderRow key={p.id} theme={t} name={p.name} model={p.model}
+   221	                selected={p.id === selectedId} onClick={() => onSelect && onSelect(p.id)}/>
+   222	            ))}
+   223	            <div onClick={onAdd} style={{
+   224	              display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px', cursor: 'pointer',
+   225	            }}>
+   226	              <div style={{
+   227	                width: 30, height: 30, borderRadius: 8, flexShrink: 0,
+   228	                background: t.isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)',
+   229	                display: 'flex', alignItems: 'center', justifyContent: 'center',
+   230	              }}>
+   231	                <Icons.Plus size={18} color={t.accent} stroke={2.2}/>
+   232	              </div>
+   233	              <div style={{ flex: 1, fontSize: 15, color: t.accent, fontWeight: 500 }}>Add provider</div>
+   234	            </div>
+   235	          </div>
+   236	          <div style={{ fontSize: 11.5, color: t.sub, lineHeight: 1.45, padding: '10px 4px 0' }}>
+   237	            Tap a provider to use it for translating this book.
+   238	          </div>
+   239	        </div>
+   240	      )}
+   241	    </div>
+   242	  );
+   243	}
+   244	
+   245	function AIProvidersSheet({ theme, providers = [], selectedId, onBack, onAdd, onSelect, trailing, height = 620 }) {
+   246	  return (
+   247	    <NavSheet theme={theme} height={height} title="AI Providers" backLabel="Bilingual" onBack={onBack} trailing={trailing}>
+   248	      <AIProvidersSheetBody theme={theme} providers={providers} selectedId={selectedId} onAdd={onAdd} onSelect={onSelect}/>
+   249	    </NavSheet>
+   250	  );
+   251	}
+   252	
+   253	// ────────────────────────────────────────────────────
+   254	// ALTERNATIVE C — inline expansion of the engine strip.
+   255	// Collapsed = the unconfigured strip; expanded = a minimal provider+key form
+   256	// in place. Shows why it can't host the real editor without diverging.
+   257	// ────────────────────────────────────────────────────
+   258	function EngineStripInline({ theme, expanded }) {
+   259	  const t = theme;
+   260	  const seg = ['Claude', 'OpenAI', 'Custom'];
+   261	  return (
+   262	    <div>
+   263	      <SectionLabel theme={t}>Translation engine</SectionLabel>
+   264	      <div style={{
+   265	        marginTop: 8, borderRadius: 12, overflow: 'hidden',
+   266	        background: `${t.accent}10`, border: `0.5px solid ${t.accent}55`,
+   267	      }}>
+   268	        <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px' }}>
+   269	          <div style={{
+   270	            width: 28, height: 28, borderRadius: 14, flexShrink: 0, background: 'rgba(0,0,0,0.08)',
+   271	            display: 'flex', alignItems: 'center', justifyContent: 'center',
+   272	          }}>
+   273	            <Icons.Sparkle size={14} color={t.sub} stroke={2}/>
+   274	          </div>
+   275	          <div style={{ flex: 1, minWidth: 0 }}>
+   276	            <div style={{ fontSize: 13.5, color: t.ink, fontWeight: 600 }}>No AI provider configured</div>
+   277	            <div style={{ fontSize: 11.5, color: t.sub, marginTop: 1 }}>
+   278	              {expanded ? 'Add one below to translate.' : 'Bilingual mode needs an AI provider to translate.'}
+   279	            </div>
+   280	          </div>
+     1	// Issue #1798 / Feature #110 (Android Phase-3) — AI provider + bilingual + chat.
+     2	//
+     3	// iOS has bilingual interlinear translation (#56) + AI chat (#89); Android
+     4	// needs both UIs AND a user-configured provider credential. None of these were
+     5	// in a committed bundle (rule 51). Built in VReader's vocabulary; the provider
+     6	// editor itself is the already-designed EditorSheet (vreader-ai-provider-
+     7	// fields.jsx) — this file adds the provider LIST, the bilingual interlinear
+     8	// reader + setup, and the reader AI-chat / summary panel.
+     9	//
+    10	// One credential powers all three features, so the through-line is the four
+    11	// states the issue calls out: unconfigured → configured → in-flight → error.
+    12	
+    13	const AI_SERIF = '"Source Serif 4", Georgia, serif';
+    14	const AI_SANS = "'Inter', -apple-system, system-ui, sans-serif";
+    15	
+    16	// ── A · provider list (the gate for everything) ──────────────
+    17	function AiProviderList({ ui, state = 'configured', height = 880 }) {
+    18	  const unconf = state === 'unconfigured';
+    19	  const providers = [
+    20	    { name: 'Claude (Anthropic)', model: 'claude-sonnet-4-6', active: true, status: 'ok' },
+    21	    { name: 'OpenAI', model: 'gpt-4o-mini', active: false, status: 'ok' },
+    22	    { name: 'DeepSeek', model: 'deepseek-chat', active: false, status: 'fail' },
+    23	  ];
+    24	  return (
+    25	    <PhoneFrame ui={ui} height={height}>
+    26	      <div style={{ position: 'absolute', inset: 0, background: ui.bg, display: 'flex', flexDirection: 'column' }}>
+    27	        <div style={{ height: 30 }} />
+    28	        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '6px 14px 12px', borderBottom: `0.5px solid ${ui.sep}` }}>
+    29	          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke={ui.tint} strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round"><path d="M15 6l-6 6 6 6"/></svg>
+    30	          <div style={{ flex: 1, fontFamily: AI_SERIF, fontSize: 18, fontWeight: 600, color: ui.ink }}>AI Providers</div>
+    31	          <window.Icons.Plus size={24} color={ui.tint} />
+    32	        </div>
+    33	        <div className="hide-scroll" style={{ flex: 1, overflow: 'auto', padding: '14px 16px 32px' }}>
+    34	          {unconf ? (
+    35	            <>
+    36	              <div style={{ textAlign: 'center', padding: '36px 24px 10px' }}>
+    37	                <div style={{ width: 64, height: 64, borderRadius: 32, background: ui.isDark ? 'rgba(214,136,90,0.14)' : 'rgba(140,47,47,0.09)', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 18px' }}>
+    38	                  <window.Icons.Sparkle size={30} color={ui.tint} />
+    39	                </div>
+    40	                <div style={{ fontFamily: AI_SERIF, fontSize: 21, color: ui.ink, marginBottom: 8 }}>Connect an AI provider</div>
+    41	                <div style={{ fontFamily: AI_SANS, fontSize: 14, color: ui.sec, lineHeight: 1.55 }}>
+    42	                  One key unlocks bilingual translation, chat about a book, and chapter summaries. Your key is stored on-device only.
+    43	                </div>
+    44	              </div>
+    45	              <button style={{ width: '100%', border: 'none', cursor: 'pointer', background: ui.tint, color: '#fff', borderRadius: 13, padding: '14px 0', fontFamily: AI_SANS, fontSize: 15, fontWeight: 600, marginTop: 18 }}>Add a provider</button>
+    46	              <GroupFooter ui={ui}>Works with Anthropic, OpenAI-compatible endpoints, and local models.</GroupFooter>
+    47	            </>
+    48	          ) : (
+    49	            <>
+    50	              <GroupHeader ui={ui}>Providers</GroupHeader>
+    51	              <Card ui={ui}>
+    52	                {providers.map((p, i) => (
+    53	                  <div key={p.name} style={{ display: 'flex', alignItems: 'center', minHeight: 60, padding: '0 14px', position: 'relative' }}>
+    54	                    {p.active
+    55	                      ? <svg width="20" height="20" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="9" fill={ui.tint}/><path d="M8 12.3l3 3 5.5-6" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none"/></svg>
+    56	                      : <div style={{ width: 20, height: 20, borderRadius: 10, boxShadow: `inset 0 0 0 1.7px ${ui.sep}` }} />}
+    57	                    <div style={{ flex: 1, minWidth: 0, marginLeft: 12 }}>
+    58	                      <div style={{ fontFamily: AI_SANS, fontSize: 15.5, fontWeight: 500, color: ui.ink }}>{p.name}</div>
+    59	                      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 2 }}>
+    60	                        <span style={{ width: 7, height: 7, borderRadius: 4, background: p.status === 'ok' ? ui.green : ui.red }} />
+    61	                        <span style={{ fontFamily: window.MONO, fontSize: 11.5, color: p.status === 'ok' ? ui.sec : ui.red }}>{p.status === 'ok' ? p.model : '401 — key rejected'}</span>
+    62	                      </div>
+    63	                    </div>
+    64	                    <window.Icons.ChevronD size={18} color={ui.ter} style={{ transform: 'rotate(-90deg)' }} />
+    65	                    {i < providers.length - 1 && <div style={{ position: 'absolute', left: 46, right: 0, bottom: 0, height: 0.5, background: ui.sep }} />}
+    66	                  </div>
+    67	                ))}
+    68	              </Card>
+    69	              <GroupFooter ui={ui}>The selected provider is used for translation, chat, and summaries. Tap one to edit or test it.</GroupFooter>
+    70	            </>
+    71	          )}
+    72	        </div>
+    73	      </div>
+    74	    </PhoneFrame>
+    75	  );
+    76	}
+    77	
+    78	// ── B · bilingual interlinear reader ─────────────────────────
+    79	const BL_PAIRS = [
+    80	  ['It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife.', '凡是有钱的单身汉，总想娶位太太，这已成了一条举世公认的真理。'],
+    81	  ['However little known the feelings of such a man may be, this truth is so well fixed in the minds of the surrounding families…', '这样的单身汉，每逢新搬到一个地方，四邻八舍虽然完全不了解他的性情……'],
+    82	  ['…that he is considered as the rightful property of some one or other of their daughters.', '……却把他视作自己某一个女儿理所应得的一笔财产。'],
+    83	];
+    84	
+    85	function BilingualReader({ themeKey = 'paper', state = 'on', height = 880 }) {
+    86	  const t = window.THEMES[themeKey];
+    87	  const trans = t.isDark ? '#d6885a' : '#8c2f2f';
+    88	  return (
+    89	    <window.TtsFrame t={t} height={height}>
+    90	      <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column' }}>
+    91	        <window.StatusStrip t={t} />
+    92	        <window.ReaderChrome t={t} />
+    93	        {state === 'inflight' && (
+    94	          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 9, padding: '6px 0 10px' }}>
+    95	            <svg className="apf-spin" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke={trans} strokeWidth="2.6" strokeLinecap="round"><path d="M12 3a9 9 0 1 0 9 9"/></svg>
+    96	            <span style={{ fontFamily: AI_SANS, fontSize: 12.5, fontWeight: 600, color: trans }}>Translating chapter… 38%</span>
+    97	          </div>
+    98	        )}
+    99	        <div style={{ flex: 1, overflow: 'hidden', padding: '6px 26px 0' }}>
+   100	          {state === 'error' ? (
+   101	            <div style={{ textAlign: 'center', padding: '90px 20px' }}>
+   102	              <div style={{ width: 58, height: 58, borderRadius: 29, background: t.isDark ? 'rgba(224,119,90,0.14)' : 'rgba(168,64,47,0.1)', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 16px' }}>
+   103	                <window.Icons.Translate size={28} color={trans} />
+   104	              </div>
+   105	              <div style={{ fontFamily: AI_SERIF, fontSize: 18, color: t.ink, marginBottom: 8 }}>Couldn't translate</div>
+   106	              <div style={{ fontFamily: AI_SANS, fontSize: 13.5, color: t.sub, lineHeight: 1.5, marginBottom: 18 }}>Claude returned a 429 (rate limit). The original text is unchanged — try again or switch provider.</div>
+   107	              <button style={{ border: 'none', cursor: 'pointer', background: t.accent, color: '#fff', borderRadius: 11, padding: '10px 20px', fontFamily: AI_SANS, fontSize: 14, fontWeight: 600 }}>Retry</button>
+   108	            </div>
+   109	          ) : (
+   110	            <div style={{ fontFamily: AI_SERIF, fontSize: 18, lineHeight: 1.5, color: t.ink, textWrap: 'pretty' }}>
+   111	              {BL_PAIRS.map(([en, zh], i) => (
+   112	                <div key={i} style={{ marginBottom: 19 }}>
+   113	                  <div style={{ color: state === 'inflight' && i > 0 ? t.sub : t.ink, opacity: state === 'inflight' && i > 0 ? 0.5 : 1 }}>{en}</div>
+   114	                  {(state === 'on' || (state === 'inflight' && i === 0)) && (
+   115	                    <div style={{ color: trans, fontSize: 16, marginTop: 5, lineHeight: 1.5, paddingLeft: 11, borderLeft: `2px solid ${trans}`, opacity: 0.92 }}>{zh}</div>
+
+exec
+/bin/zsh -lc "nl -ba dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md | sed -n '1,260p'
+nl -ba android/app/src/androidTest/kotlin/com/vreader/app/ai/AiRoundTripConnectedTest.kt | sed -n '1,200p'
+nl -ba android/app/src/test/kotlin/com/vreader/app/reader/chrome/ReaderMoreRowsTest.kt | sed -n '1,180p'
+nl -ba android/app/src/androidTest/kotlin/com/vreader/app/reader/more/MorePopupTest.kt | sed -n '1,240p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+     1	# Gate-1 Plan — Feature #136: AI provider setup made production-reachable (Android)
+     2	
+     3	> Status target: `TODO` → `PLANNED` (on Gate-2 pass)
+     4	> Platform lane: `android-app` (Gate-5 = Android emulator connected run, rule 47 Android tier)
+     5	> Design authority (rule 51, LANDED — no `needs-design`): `vreader-more.jsx` (the reader More-menu `configure-ai` disabled-Bilingual row), `vreader-ai-android.jsx` (`AiProviderList` surface A), `vreader-ai-provider-entry.jsx` + `design-notes/reader-ai-provider-entry.md` + `design-notes/reader-ai-readiness.md` (the in-reader scoped AI-Providers entry decision), `vreader-ai-provider-fields.jsx` (the reused editor).
+     6	
+     7	## 1. Problem
+     8	
+     9	Feature #118 shipped the entire Android AI provider stack — `AiProviderStore` (keystore-encrypted profile persistence, #116 `KeystoreSecretCipher` precedent), `AiSettingsViewModel` (list + editor + Test Connection), `AiProviderListScreen` (the designed "AI Providers" gate surface), and `AiProviderEditSheet` (the canonical add/edit form). It is fully unit- and connected-tested. **But none of it is wired into any production entry.** Grep confirms `AiProviderListScreen`, `AiSettingsViewModel`, and `AiProviderEditSheet` are referenced **only** by `androidTest`/`test` sources; `AiProviderStore` is **never constructed** in `AppContainer` (it appears only in comments as a naming precedent); and `MainActivity` is a single Library Activity that `startActivity`-launches reader hosts — there is **no `NavHost`, no Settings tree, and no More-menu AI row** that reaches the AI screens. `LibraryScreen.kt:95-96` explicitly records that the design's Library settings/More pill "is added when that feature lands (a separate WI) … still omitted."
+    10	
+    11	Consequence: **a fresh install has zero production route to configure an AI provider.** With no provider, every downstream AI feature is dead — bilingual (#131), chat (`AiChatPanel`, also unwired), translate, summaries. This is exactly the Gate-2-round-2 audit High-3 recorded against #131: bilingual's fresh-user path and its Gate-5 acceptance route both dead-end because there is no reachable AI config to land on.
+    12	
+    13	**#136 makes the already-designed, already-built AI provider config production-reachable and independently verifiable**, from a designed in-reader entry that does not depend on #131.
+    14	
+    15	## 2. Surface area
+    16	
+    17	### Designed entry point (the decision)
+    18	
+    19	Two designed reader entries exist; #136 uses the one that is **independent of #131**:
+    20	
+    21	- **`vreader-more.jsx:91-95`** depicts the reader More-menu row: when `s.aiUnavailable`, a **disabled "Bilingual mode" row** with `sub="Configure AI provider first"` whose tap fires `onAction('configure-ai')`. This is the canonical "AI unconfigured → route to config" affordance in the reader chrome, and the Kotlin scaffolding already exists for it: `MoreActionId.BILINGUAL`, `MoreRow.Disabled(id, label, icon, sub, onTap)`, and the `readerMoreRows(...)` assembler in `ReaderChromeScaffold.kt`. The `configure-ai` action → presents the **AI Providers sheet** (`AiProviderListScreen`), matching `reader-ai-provider-entry.md`'s "closes the Library→Settings→AI gap inside the reader" decision (Variant A: a scoped in-reader provider sheet reusing the canonical editor, NOT the full SettingsView).
+    22	
+    23	This entry is reachable by a fresh user (open any book → More → "Configure AI provider first") with **no bilingual wiring present** — which is precisely what independent-verifiability requires. #131 will later ADD the *enabled* Bilingual toggle + its own bilingual-Set-up→here route; #136 owns only the `aiUnavailable`/`configure-ai` path.
+    24	
+    25	### Files MODIFIED
+    26	
+    27	| File | Change (concrete signature) |
+    28	|---|---|
+    29	| `android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt` (`AppContainer`) | Add process-singleton `val aiProviderStore: AiProviderStore by lazy { AiProviderStore(<DataStore under noBackupFilesDir "ai_providers.preferences_pb">, KeystoreSecretCipher(<alias>)) }` (the `readerSettingsStore`/`OpdsSourceStore` DataStore-under-`noBackupFilesDir` + `KeystoreSecretCipher` precedent — keys are per-device, NOT in the backup contract). Add `fun aiSettingsViewModel(): AiSettingsViewModel = AiSettingsViewModel(aiProviderStore)` factory. |
+    30	| `android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeScaffold.kt` (`readerMoreRows`) | Extend the assembler to additively accept the AI-entry callback and emit the designed disabled Bilingual row when AI is unconfigured: `internal fun readerMoreRows(onDetails, onShare, aiUnconfigured: Boolean = false, onConfigureAi: (() -> Unit)? = null): List<MoreRow>` → prepends `MoreRow.Disabled(id = MoreActionId.BILINGUAL, label = "Bilingual mode", icon = Icons.…Translate-analog, sub = "Configure AI provider first", onTap = onConfigureAi ?: {})` **only when `aiUnconfigured && onConfigureAi != null`** (no dead control — #129 rule; absent otherwise). Nullable defaults keep #134/#131 callers valid. Note: `MoreRow.Disabled` is currently non-interactive in `MorePopup.MoreRowItem` (`onClick = {}`); making the `configure-ai` row tappable is a **row-treatment change** — see Risks §6 (the design shows `disabled` + an `on` handler, so the row is dimmed-but-tappable). |
+    31	| `android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeState.kt` (+`…StateSaver`) | Add `ReaderSheet.AiProviders` to the sealed `ReaderSheet` set and to the string saver (round-trips like `Toc`/`Notes`/`Bookmarks`; unknown token → `None`, never throws — the existing saver contract). Survives rotation/process-death. |
+    32	| `android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeScaffold.kt` (host sheet layer) + `android/app/src/main/kotlin/com/vreader/app/reader/EpubReaderChrome.kt` (`EpubReaderSheets`) | Render the `ReaderSheet.AiProviders` route: host the `AiProviderListScreen` + `AiProviderEditSheet` fed by an `AiSettingsViewModel` (obtained via the Activity's `ViewModelStore`, `viewModel(factory = …container.aiSettingsViewModel())` — the `SearchViewModel` precedent in `MainActivity`), wired to `AiSettingsViewModel.openAdd/openEdit/close/update/test/save/delete/setActive` and the `editState`/`listState` flows. Back / Done → `ReaderSheet.None`. |
+    33	| The five reader host Activities that assemble chrome — `ReaderActivity.kt` (EPUB, via `EpubTopBand`/`EpubReaderSheets`) + `TxtReaderActivity.kt`, `PdfReaderActivity.kt`, `Azw3ReaderActivity.kt` (scaffold hosts) | Pass `aiUnconfigured` (derived from `container.aiProviderStore.observe().map { it.profiles.isEmpty() }` collected as state) + `onConfigureAi = { chromeState = …copy(sheet = ReaderSheet.AiProviders) }` into `readerMoreRows(...)` / `EpubTopBand`. This is the one-writer-coordinate additive pattern #132/#134/#135 already use for the chrome files. |
+    34	
+    35	### Files ADDED
+    36	
+    37	| File | Purpose |
+    38	|---|---|
+    39	| `android/app/src/main/kotlin/com/vreader/app/reader/ai/ReaderAiProvidersHost.kt` (new, ~120 lines) | The reader-scoped presentation container: a `@Composable ReaderAiProvidersHost(vm: AiSettingsViewModel, onClose: () -> Unit)` that observes `vm.listState`/`vm.editState` and hosts `AiProviderListScreen` (list/empty) + the `AiProviderEditSheet` modal-on-top (the `reader-ai-provider-entry.md` "list is a push, editor is a modal on top" nav model). **Rule 51: renders ONLY the existing designed surfaces** (`AiProviderListScreen`, `AiProviderEditSheet`) — no new visual chrome. New Kotlin file → lane-dispatchable (Gradle source-set glob). |
+    40	| Tests — see §5. | JVM/Robolectric + connected. |
+    41	
+    42	### Files OUT of scope
+    43	
+    44	- **Provider CRUD internals** — `AiProviderStore.upsert/delete/setActive/apiKey`, `AiSettingsViewModel.test/save`, `AiProviderFactory`, the provider clients, `SseEventReader`, `AiProviderKind`. All shipped and tested by #118; #136 constructs and reaches them, never re-implements them.
+    45	- **The designed surfaces themselves** — `AiProviderListScreen.kt`, `AiProviderEditSheet.kt`, `AiSettingsUiState.kt`. Used verbatim.
+    46	- **The AI-readiness sheet (flag + consent gates)** — `reader-ai-readiness.md`'s `ReaderAIReadinessSheet` (master AI toggle + consent ledger) is **design-landed but implementation-deferred** ("do NOT build without go-ahead"). #136 delivers the provider-list reachability only; the flag/consent capstone is a separate feature.
+    47	- **AI chat panel wiring** — `AiChatPanel`/`AiChatViewModel` are ALSO unwired, but chat's reader entry is #131/a chat feature's surface, not #136.
+    48	- **Bilingual toggle + bilingual Set-up → AI route** — #131 owns the enabled Bilingual `MoreRow.Toggle` and its own route into this same sheet.
+    49	- **A Library-level Settings tree / More pill** (`LibraryScreen.kt:95`) — not built; #136 deliberately does NOT depend on it (see §3 rejected alt).
+    50	- **`contracts/`** — no cross-platform contract change (keys are device-local, excluded from backup).
+    51	
+    52	## 3. Prior art / precedent / rejected alternatives
+    53	
+    54	**Committed design (rule 51 satisfied):**
+    55	- `design-notes/reader-ai-provider-entry.md` — Variant **A** (CANONICAL): "a scoped, in-reader 'AI Providers' sheet … reusing the canonical `AIProviderEditSheet`", chosen over B (deep-link the whole SettingsView) and C (inline mini-form). Its stated win: "Keeps the reader context … the user never sees Cloud & Sync, OPDS, TTS." #136 implements A's Android analog.
+    56	- `design-notes/reader-ai-readiness.md` — the same "close the loop **inside the reader**" decision, naming this the surface "every 'AI unconfigured' silent-no-op should route to."
+    57	- `vreader-more.jsx:91-95` — the exact reader-chrome affordance: `aiUnavailable` → disabled Bilingual row `sub="Configure AI provider first"` → `onAction('configure-ai')`.
+    58	- `vreader-ai-android.jsx` `AiProviderList` (surface A, "the gate for everything") — already implemented verbatim as `AiProviderListScreen.kt` (its header comment cites this).
+    59	
+    60	**Project precedent for the wiring shape:**
+    61	- **#118** built the whole stack; **#116** `KeystoreSecretCipher` + `WebDavServerStore`/`OpdsSourceStore` established the "DataStore-under-`noBackupFilesDir` + keystore cipher, constructed once in `AppContainer`" pattern this plan follows for `aiProviderStore`.
+    62	- **#129/#132/#134/#135** wired every reader-chrome entry through the exact seams #136 reuses: the `readerMoreRows` assembler, `ReaderChromeState`/`ReaderSheet` + its saver, the `EpubReaderSheets` open-only sheet layer, and the additive-nullable-param "one-writer-coordinate" convention. #134 added Details/Share rows; #136 adds the `configure-ai` row by the same contract.
+    63	- **`MainActivity` `SearchViewModel`** precedent — obtaining a container-built ViewModel via `viewModel(factory = viewModelFactory { initializer { container.searchViewModel() } })` so its `viewModelScope` is cleared on Activity destroy. `aiSettingsViewModel()` follows this exactly.
+    64	
+    65	**Rejected alternatives:**
+    66	1. **Library Settings tree / More pill entry (`LibraryScreen.kt:95`).** Rejected: that Settings tree does not exist on Android, and `OpdsSourcesViewModel`/`OpdsSourceStore` are *also* still test-only — building the whole Library Settings host is a large, separate feature. The design's own decision (both notes) is the in-reader scoped entry.
+    67	2. **Route only from #131's bilingual Set-up.** Rejected by independent-verifiability: it would couple #136 to #131 (still `PLANNED`) and make AI config unreachable until bilingual ships. The `aiUnavailable`/`configure-ai` More-row is reachable with zero bilingual wiring.
+    68	3. **Deep-link the full SettingsView (Variant B) / inline mini-form (Variant C).** Rejected by the design notes themselves.
+    69	4. **Build the deferred AI-readiness sheet (flag+consent) now.** Rejected: `reader-ai-readiness.md` marks it "implementation deferred — do NOT build without go-ahead."
+    70	
+    71	## 4. Work-item sequencing (small feature — 3 WIs)
+    72	
+    73	**WI-1 — `AppContainer` AI store + VM factory (FOUNDATIONAL).**
+    74	Construct `aiProviderStore` (DataStore under `noBackupFilesDir` + `KeystoreSecretCipher`) and `aiSettingsViewModel()` in `AppContainer`. No user-observable behavior → unit tests + audit suffice (Gate-5 foundational tier, no device verify). *PR size: XS.* Lane-dispatchable (edits one existing file + new test).
+    75	
+    76	**WI-2 — `ReaderAiProvidersHost` + `ReaderSheet.AiProviders` route (BEHAVIORAL).**
+    77	Add the new `ReaderAiProvidersHost.kt` (hosts `AiProviderListScreen` + `AiProviderEditSheet` over the VM), the `ReaderSheet.AiProviders` sealed case + saver round-trip, and render it in the scaffold sheet layer + `EpubReaderSheets`. *PR size: S.* Connected Compose slice: open route → empty state → Add → editor → Save → list shows provider → back.
+    78	
+    79	**WI-3 — reader More-menu `configure-ai` entry across all five hosts (BEHAVIORAL, FINAL WI).**
+    80	Extend `readerMoreRows` with the `aiUnconfigured`/`onConfigureAi` params emitting the designed disabled-Bilingual row, and wire `aiUnconfigured` (from `aiProviderStore.observe()`) + `onConfigureAi` (opens `ReaderSheet.AiProviders`) in the four host Activities + `EpubTopBand`. *PR size: M.* Closes the feature → full Gate-5 acceptance (the reachable end-to-end flow on emulator).
+    81	
+    82	> Sequencing: WI-1 is a pure foundation WI-2 depends on; WI-2 makes the destination renderable + independently testable *before* any entry exists; WI-3 lights the entry across hosts. Each is one PR.
+    83	
+    84	## 5. Test catalogue
+    85	
+    86	**JVM / Robolectric (`app/src/test`):**
+    87	- `AppContainerAiWiringTest.kt` (new) — `aiProviderStore` is a stable singleton; `aiSettingsViewModel()` returns a VM whose `listState` reflects the store (empty fresh, non-empty after `upsert`). Guards WI-1.
+    88	- Extend `ReaderChromeStateSaverTest.kt` — `ReaderSheet.AiProviders` round-trips; unknown/garbage token → `None` (never throws). Guards WI-2 process-death.
+    89	- `ReaderMoreRowsAiEntryTest.kt` (new, JVM/pure) — `readerMoreRows(aiUnconfigured = true, onConfigureAi = {…})` includes exactly one `MoreRow.Disabled`/`configure-ai` row with the designed label + sub; `aiUnconfigured = false` OR `onConfigureAi = null` omits it (no dead control). Guards WI-3.
+    90	
+    91	**Connected Compose (`app/src/androidTest`) — the #132/#134/#135 pattern; the connected run IS the Gate-5 acceptance:**
+    92	- Reuse existing `AiProviderListScreenTest`/`AiProviderEditSheetTest`/`AiRoundTripConnectedTest` (unchanged — surfaces verbatim).
+    93	- `ReaderAiProvidersHostConnectedTest.kt` (new) — drives `ReaderAiProvidersHost` over a real `AiSettingsViewModel`+`AiProviderStore`: empty state (`ai-add-provider`) → Add → `AiProviderEditSheet` (`ai-save`) → save → list shows `provider-<id>` → back → `ReaderSheet.None`.
+    94	- `ReaderMoreAiEntryConnectedTest.kt` (new) — the **reachability acceptance**: launch a reader host on a fresh (no-provider) store → open More → "Configure AI provider first" row present + tappable → tap → `AiProviderListScreen` empty state → add a provider → return → re-open More → the `configure-ai` row is now **absent**. The "fresh user can reach AI config, add a provider, and return" acceptance, independent of #131.
+    95	
+    96	**Audit-driven additions:** corrupt/partial DataStore token (saver → `None`); process-death mid-editor (route restores, editor state transient by design); a provider deleted while the sheet is open (list re-derives from the store Flow).
+    97	
+    98	## 6. Risks + mitigations
+    99	
+   100	- **Coupling with #131.** Mitigation: the entry is the `aiUnavailable`/`configure-ai` More-row, reachable with zero bilingual code; #131 separately adds the *enabled* Bilingual toggle + its Set-up→here route. `readerMoreRows` params additive-nullable so #131's later change is one-writer-coordinate.
+   101	- **`MoreRow.Disabled` is currently non-interactive.** `MorePopup.MoreRowItem` renders `Disabled` with `onClick = {}`. The design (`vreader-more.jsx:94-95`) shows the row `disabled` AND `on={() => onAction('configure-ai')}` — dimmed but tappable. Mitigation: WI-3 makes the `Disabled` row's `onTap` fire (a small `MorePopup` change), matching the design; covered by `ReaderMoreAiEntryConnectedTest`. Restore-to-designed-state, rule-51-clean.
+   102	- **AI-key security surface (#118).** Mitigation: #136 constructs `AiProviderStore` with `KeystoreSecretCipher` under `noBackupFilesDir` (the #116 contract) and touches NO CRUD/crypto path. Keys stay device-local; no `contracts/` change.
+   103	- **Config-change / process-death.** Mitigation: `ReaderSheet.AiProviders` is in the `rememberSaveable` saver (rotation/death safe); the editor's transient form re-opens empty by design; the VM is Activity-`ViewModelStore`-owned (`SearchViewModel` precedent), scope cleared on destroy.
+   104	- **Five-host fan-out.** Mitigation: EPUB routes through `EpubTopBand`/`EpubReaderSheets`; the other three through the shared `ReaderChromeScaffold` — the split #134 already validated. One connected test per family confirms parity.
+   105	
+   106	## 7. Backward compatibility
+   107	
+   108	- **Fresh install, no providers (the designed onboarding state).** `aiProviderStore.observe()` → `profiles.isEmpty()` → the More-menu "Configure AI provider first" row → tapping lands on `AiProviderListScreen`'s empty state. No crash, no dead control before a provider exists.
+   109	- **Existing DEBUG-configured provider.** `profiles.isNotEmpty()` → the `configure-ai` row is **absent** from More (AI available); the store schema unchanged (#118 JSON-in-DataStore); no migration.
+   110	- **Older reader-chrome state tokens.** Unknown-token → `None` means a persisted pre-#136 `ReaderChromeState` restores cleanly.
+   111	- **No `contracts/` / backup-format impact** — keys device-local, excluded from the backup contract.
+   112	
+   113	## Dependency statement (binding)
+   114	
+   115	**#136 is a HARD dependency of #131.** #131's fresh-user AI-config path + its Gate-5 acceptance route both require a reachable AI provider config to land on; that destination is delivered by #136. #131 must not re-implement or inline provider config — it consumes #136's `ReaderSheet.AiProviders` sheet. **#131's bilingual-Set-up → #136 route (the enabled Bilingual `MoreRow.Toggle` + its "Set up"→AI-Providers navigation) is #131's OWN WI, not #136's** — #136 delivers only the independent `aiUnavailable`/`configure-ai` More-menu entry, so AI config is reachable + verifiable before #131 exists.
+   116	
+   117	## Revision history
+   118	
+   119	- v1 (2026-07-12) — Gate-1 draft. Authored to resolve #131 Gate-2-round-2 High-3 (AI-config unreachable): the #118 AI provider stack is production-reachable via the designed reader More-menu `configure-ai` entry (Variant A in-reader AI-Providers sheet). 3 WIs. Spun out per the orchestrator/user decision (2026-07-12) that AI-settings navigation is its own tiny feature + a hard dependency of #131.
+     1	package com.vreader.app.ai
+     2	
+     3	import androidx.test.ext.junit.runners.AndroidJUnit4
+     4	import androidx.test.platform.app.InstrumentationRegistry
+     5	import kotlinx.coroutines.Dispatchers
+     6	import kotlinx.coroutines.flow.toList
+     7	import kotlinx.coroutines.runBlocking
+     8	import org.junit.Assert.assertEquals
+     9	import org.junit.Assert.assertTrue
+    10	import org.junit.Assume.assumeNotNull
+    11	import org.junit.Test
+    12	import org.junit.runner.RunWith
+    13	
+    14	/**
+    15	 * Feature #118 WI-5 — the LIVE AI acceptance (Gate-5). Drives the REAL OpenAiCompatibleProvider
+    16	 * (HttpURLConnection + the bounded SSE framer) against a local OpenAI-compatible SSE stub on the Mac
+    17	 * host (reachable from the emulator at 10.0.2.2): test-connection (one-shot) succeeds, and a sent
+    18	 * prompt streams an assembled answer over a real socket SSE stream. Skips unless
+    19	 * scripts/run-ai-roundtrip.sh passes the `aiBaseUrl` instrumentation arg.
+    20	 */
+    21	@RunWith(AndroidJUnit4::class)
+    22	class AiRoundTripConnectedTest {
+    23	
+    24	    @Test
+    25	    fun testConnection_and_streamChat_overLiveSse() = runBlocking {
+    26	        val base = InstrumentationRegistry.getArguments().getString("aiBaseUrl")
+    27	        assumeNotNull("set -e aiBaseUrl to run (via scripts/run-ai-roundtrip.sh)", base)
+    28	
+    29	        val client = OpenAiCompatibleProvider(base!!, "sk-test", "gpt-4o-mini", 0.7, 64, Dispatchers.IO)
+    30	
+    31	        // Test connection = a one-shot ping; the stub returns choices[0].message.content.
+    32	        assertTrue("testConnection ok", client.testConnection() is AiTestResult.Ok)
+    33	
+    34	        // Stream a chat completion; the stub streams 4 deltas then [DONE].
+    35	        val answer = client.streamChat(
+    36	            AiRequest("gpt-4o-mini", listOf(AiMessage(AiRole.user, "hello")), 0.7, 64)
+    37	        ).toList().joinToString("") { it.deltaText }
+    38	        assertEquals("Hello from the vreader stub.", answer)
+    39	    }
+    40	}
+     1	package com.vreader.app.reader.chrome
+     2	
+     3	import com.vreader.app.reader.more.MoreActionId
+     4	import com.vreader.app.reader.more.MoreRow
+     5	import org.junit.Assert.assertEquals
+     6	import org.junit.Assert.assertFalse
+     7	import org.junit.Assert.assertTrue
+     8	import org.junit.Test
+     9	import org.junit.runner.RunWith
+    10	import org.robolectric.RobolectricTestRunner
+    11	
+    12	/**
+    13	 * Feature #134 WI-5 — the pure [readerMoreRows] assembler that the reader chrome feeds to the WI-3
+    14	 * [com.vreader.app.reader.more.MorePopup]. #134 owns ONLY the Details + Share rows: no TTS / Auto-turn /
+    15	 * Bilingual / Export (those belong to other features and are supplied by them, never invented here — the
+    16	 * §more-row-ownership contract + the #129 no-dead-control rule). Both are [MoreRow.Action]s wiring their
+    17	 * respective callbacks. Robolectric only because constructing the material `ImageVector` icon refs touches
+    18	 * Compose's graphics vector; the function itself has no Android/Compose-runtime dependency.
+    19	 */
+    20	@RunWith(RobolectricTestRunner::class)
+    21	class ReaderMoreRowsTest {
+    22	
+    23	    @Test fun assemblesOnlyDetailsAndShare() {
+    24	        val rows = readerMoreRows(onDetails = {}, onShare = {})
+    25	        assertEquals(listOf(MoreActionId.DETAILS, MoreActionId.SHARE), rows.map { it.id })
+    26	    }
+    27	
+    28	    @Test fun bothAreActionRows_withDesignedLabels() {
+    29	        val rows = readerMoreRows(onDetails = {}, onShare = {})
+    30	        val details = rows.single { it.id == MoreActionId.DETAILS }
+    31	        val share = rows.single { it.id == MoreActionId.SHARE }
+    32	        assertTrue(details is MoreRow.Action)
+    33	        assertTrue(share is MoreRow.Action)
+    34	        assertEquals("Book details", details.label)
+    35	        assertEquals("Share book", share.label)
+    36	    }
+    37	
+    38	    @Test fun detailsActionFiresOnlyOnDetailsTap() {
+    39	        var detailed = false
+    40	        var shared = false
+    41	        val rows = readerMoreRows(onDetails = { detailed = true }, onShare = { shared = true })
+    42	        (rows.single { it.id == MoreActionId.DETAILS } as MoreRow.Action).onTap()
+    43	        assertTrue(detailed)
+    44	        assertFalse(shared)
+    45	    }
+    46	
+    47	    @Test fun shareActionFiresOnlyOnShareTap() {
+    48	        var detailed = false
+    49	        var shared = false
+    50	        val rows = readerMoreRows(onDetails = { detailed = true }, onShare = { shared = true })
+    51	        (rows.single { it.id == MoreActionId.SHARE } as MoreRow.Action).onTap()
+    52	        assertTrue(shared)
+    53	        assertFalse(detailed)
+    54	    }
+    55	
+    56	    @Test fun noTtsAutoTurnBilingualOrExportRows() {
+    57	        val rows = readerMoreRows(onDetails = {}, onShare = {})
+    58	        val ids = rows.map { it.id }.toSet()
+    59	        assertFalse(ids.contains(MoreActionId.TTS))
+    60	        assertFalse(ids.contains(MoreActionId.AUTO_TURN))
+    61	        assertFalse(ids.contains(MoreActionId.BILINGUAL))
+    62	        // There is deliberately no EXPORT id in MoreActionId — absence is structural.
+    63	    }
+    64	}
+     1	package com.vreader.app.reader.more
+     2	
+     3	import androidx.compose.material.icons.Icons
+     4	import androidx.compose.material.icons.filled.Info
+     5	import androidx.compose.material.icons.filled.Share
+     6	import androidx.compose.material.icons.outlined.Timer
+     7	import androidx.compose.material.icons.outlined.Translate
+     8	import androidx.compose.runtime.CompositionLocalProvider
+     9	import androidx.compose.ui.platform.LocalLayoutDirection
+    10	import androidx.compose.ui.test.assertCountEquals
+    11	import androidx.compose.ui.test.assertHasClickAction
+    12	import androidx.compose.ui.test.assertIsOff
+    13	import androidx.compose.ui.test.assertIsOn
+    14	import androidx.compose.ui.test.junit4.createComposeRule
+    15	import androidx.compose.ui.test.onAllNodesWithTag
+    16	import androidx.compose.ui.test.onNodeWithTag
+    17	import androidx.compose.ui.test.onNodeWithText
+    18	import androidx.compose.ui.test.performClick
+    19	import androidx.compose.ui.unit.LayoutDirection
+    20	import androidx.test.ext.junit.runners.AndroidJUnit4
+    21	import com.vreader.app.reader.settings.ReaderTheme
+    22	import org.junit.Assert.assertFalse
+    23	import org.junit.Assert.assertTrue
+    24	import org.junit.Rule
+    25	import org.junit.Test
+    26	import org.junit.runner.RunWith
+    27	
+    28	/**
+    29	 * Feature #134 WI-3 — the reader More popover (`vreader-more.jsx` `MorePopover`) over the `MoreRow`
+    30	 * model. The popup renders ONLY the rows the caller supplies (the §more-row-ownership contract): an
+    31	 * action id with NO supplied row is ABSENT — no dead TTS/Auto-turn/Bilingual/Export rows. #134 owns
+    32	 * only DETAILS + SHARE. Action rows fire onTap, Toggle rows reflect `on` + call onToggle, Disabled rows
+    33	 * are non-interactive with a sub-text. Backdrop tap dismisses. Reuses the [ReaderTheme] token map.
+    34	 */
+    35	@RunWith(AndroidJUnit4::class)
+    36	class MorePopupTest {
+    37	    @get:Rule val compose = createComposeRule()
+    38	
+    39	    private fun detailsRow(onTap: () -> Unit = {}) =
+    40	        MoreRow.Action(id = MoreActionId.DETAILS, label = "Book details", icon = Icons.Filled.Info, onTap = onTap)
+    41	
+    42	    private fun shareRow(onTap: () -> Unit = {}) =
+    43	        MoreRow.Action(id = MoreActionId.SHARE, label = "Share book", icon = Icons.Filled.Share, onTap = onTap)
+    44	
+    45	    @Test fun popupRendersWithTestTag() {
+    46	        compose.setContent {
+    47	            MorePopup(theme = ReaderTheme.Paper, rows = listOf(detailsRow(), shareRow()), onDismiss = {})
+    48	        }
+    49	        compose.onNodeWithTag("more-popup", useUnmergedTree = true).assertExists()
+    50	    }
+    51	
+    52	    @Test fun detailsAndShareRowsRenderAndFireCallbacks() {
+    53	        var detailed = false
+    54	        var shared = false
+    55	        compose.setContent {
+    56	            MorePopup(
+    57	                theme = ReaderTheme.Paper,
+    58	                rows = listOf(detailsRow { detailed = true }, shareRow { shared = true }),
+    59	                onDismiss = {},
+    60	            )
+    61	        }
+    62	        compose.onNodeWithText("Book details", useUnmergedTree = true).assertExists()
+    63	        compose.onNodeWithText("Share book", useUnmergedTree = true).assertExists()
+    64	
+    65	        compose.onNodeWithTag("more-row-details", useUnmergedTree = true).performClick()
+    66	        assertTrue(detailed)
+    67	        assertFalse(shared)
+    68	
+    69	        compose.onNodeWithTag("more-row-share", useUnmergedTree = true).performClick()
+    70	        assertTrue(shared)
+    71	    }
+    72	
+    73	    @Test fun suppliedToggleRowReflectsOnAndFiresOnToggle() {
+    74	        var toggledTo: Boolean? = null
+    75	        compose.setContent {
+    76	            MorePopup(
+    77	                theme = ReaderTheme.Dark,
+    78	                rows = listOf(
+    79	                    MoreRow.Toggle(
+    80	                        id = MoreActionId.AUTO_TURN, label = "Auto-turn pages", icon = Icons.Outlined.Timer,
+    81	                        sub = "Every 30s", on = true, onToggle = { toggledTo = it },
+    82	                    ),
+    83	                ),
+    84	                onDismiss = {},
+    85	            )
+    86	        }
+    87	        compose.onNodeWithText("Auto-turn pages", useUnmergedTree = true).assertExists()
+    88	        // The switch reflects on=true.
+    89	        compose.onNodeWithTag("more-row-toggle-auto_turn", useUnmergedTree = true).assertIsOn()
+    90	        // Tapping the row toggles it.
+    91	        compose.onNodeWithTag("more-row-auto_turn", useUnmergedTree = true).performClick()
+    92	        assertTrue(toggledTo == false)
+    93	    }
+    94	
+    95	    @Test fun suppliedToggleRowReflectsOffState() {
+    96	        compose.setContent {
+    97	            MorePopup(
+    98	                theme = ReaderTheme.Paper,
+    99	                rows = listOf(
+   100	                    MoreRow.Toggle(
+   101	                        id = MoreActionId.AUTO_TURN, label = "Auto-turn pages", icon = Icons.Outlined.Timer,
+   102	                        sub = "Off", on = false, onToggle = {},
+   103	                    ),
+   104	                ),
+   105	                onDismiss = {},
+   106	            )
+   107	        }
+   108	        compose.onNodeWithTag("more-row-toggle-auto_turn", useUnmergedTree = true).assertIsOff()
+   109	    }
+   110	
+   111	    @Test fun disabledRowRendersNonInteractiveWithSubText() {
+   112	        var tapped = false
+   113	        compose.setContent {
+   114	            MorePopup(
+   115	                theme = ReaderTheme.Paper,
+   116	                rows = listOf(
+   117	                    MoreRow.Disabled(
+   118	                        id = MoreActionId.BILINGUAL, label = "Bilingual mode", icon = Icons.Outlined.Translate,
+   119	                        sub = "Configure AI provider first", onTap = { tapped = true },
+   120	                    ),
+   121	                ),
+   122	                onDismiss = {},
+   123	            )
+   124	        }
+   125	        compose.onNodeWithText("Bilingual mode", useUnmergedTree = true).assertExists()
+   126	        compose.onNodeWithText("Configure AI provider first", useUnmergedTree = true).assertExists()
+   127	        // A disabled row is non-interactive: clicking it does nothing (no crash, callback not fired).
+   128	        compose.onNodeWithTag("more-row-bilingual", useUnmergedTree = true).performClick()
+   129	        assertFalse(tapped)
+   130	    }
+   131	
+   132	    @Test fun unsuppliedIdsAreAbsent_noDeadTtsAutoTurnBilingual() {
+   133	        // Only DETAILS + SHARE supplied → TTS / Auto-turn / Bilingual rows are ABSENT (§more-row-ownership).
+   134	        compose.setContent {
+   135	            MorePopup(theme = ReaderTheme.Paper, rows = listOf(detailsRow(), shareRow()), onDismiss = {})
+   136	        }
+   137	        compose.onAllNodesWithTag("more-row-tts", useUnmergedTree = true).assertCountEquals(0)
+   138	        compose.onAllNodesWithTag("more-row-auto_turn", useUnmergedTree = true).assertCountEquals(0)
+   139	        compose.onAllNodesWithTag("more-row-bilingual", useUnmergedTree = true).assertCountEquals(0)
+   140	        compose.onNodeWithText("Read aloud", useUnmergedTree = true).assertDoesNotExist()
+   141	        compose.onNodeWithText("Auto-turn pages", useUnmergedTree = true).assertDoesNotExist()
+   142	        compose.onNodeWithText("Bilingual mode", useUnmergedTree = true).assertDoesNotExist()
+   143	    }
+   144	
+   145	    @Test fun exportRowNeverPresent() {
+   146	        // #134 has no export subsystem — the Export row is never rendered, even by absence there is no
+   147	        // MoreActionId for it. Assert by label + that no export row is present.
+   148	        compose.setContent {
+   149	            MorePopup(theme = ReaderTheme.Paper, rows = listOf(detailsRow(), shareRow()), onDismiss = {})
+   150	        }
+   151	        compose.onNodeWithText("Export annotations", useUnmergedTree = true).assertDoesNotExist()
+   152	        compose.onAllNodesWithTag("more-row-export", useUnmergedTree = true).assertCountEquals(0)
+   153	    }
+   154	
+   155	    @Test fun backdropTapDismisses() {
+   156	        var dismissed = false
+   157	        compose.setContent {
+   158	            MorePopup(theme = ReaderTheme.Paper, rows = listOf(detailsRow()), onDismiss = { dismissed = true })
+   159	        }
+   160	        compose.onNodeWithTag("more-backdrop", useUnmergedTree = true).assertHasClickAction().performClick()
+   161	        assertTrue(dismissed)
+   162	    }
+   163	
+   164	    @Test fun rendersUnderRtlLayout() {
+   165	        // The popup anchors to the trailing edge; under RTL it still renders (Compose flips automatically).
+   166	        compose.setContent {
+   167	            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+   168	                MorePopup(theme = ReaderTheme.Paper, rows = listOf(detailsRow(), shareRow()), onDismiss = {})
+   169	            }
+   170	        }
+   171	        compose.onNodeWithTag("more-popup", useUnmergedTree = true).assertExists()
+   172	        compose.onNodeWithText("Book details", useUnmergedTree = true).assertExists()
+   173	    }
+   174	
+   175	    @Test fun rendersAcrossThemes() {
+   176	        // The popup is a pure function of the theme tokens — it renders in every theme (light + dark).
+   177	        // AndroidComposeTestRule.setContent may be called only ONCE per test; drive the theme via
+   178	        // state across a single content tree instead of looping setContent (which throws
+   179	        // "has already set content").
+   180	        val theme = androidx.compose.runtime.mutableStateOf(ReaderTheme.values().first())
+   181	        compose.setContent {
+   182	            MorePopup(theme = theme.value, rows = listOf(detailsRow(), shareRow()), onDismiss = {})
+   183	        }
+   184	        for (t in ReaderTheme.values()) {
+   185	            theme.value = t
+   186	            compose.onNodeWithTag("more-popup", useUnmergedTree = true).assertExists()
+   187	        }
+   188	    }
+   189	
+   190	    @Test fun emptyRowsRendersEmptyPopupWithoutCrash() {
+   191	        // Degenerate case: no supplied rows → the popup surface exists but has no rows (no crash).
+   192	        compose.setContent {
+   193	            MorePopup(theme = ReaderTheme.Paper, rows = emptyList(), onDismiss = {})
+   194	        }
+   195	        compose.onNodeWithTag("more-popup", useUnmergedTree = true).assertExists()
+   196	    }
+   197	}
+
+exec
+/bin/zsh -lc "nl -ba android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt | sed -n '38,78p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt | tail -n 100
+nl -ba android/app/src/main/kotlin/com/vreader/app/reader/ReaderActivity.kt | sed -n '600,700p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt | sed -n '835,900p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/reader/PdfReaderActivity.kt | sed -n '390,450p'
+nl -ba android/app/src/main/kotlin/com/vreader/app/reader/Azw3ReaderActivity.kt | sed -n '440,490p'" in /Users/ll/workspace/vreader
+ succeeded in 0ms:
+    38	import com.vreader.app.backup.GroupHeader
+    39	import com.vreader.app.backup.LocalBackupTokens
+    40	import com.vreader.app.backup.NavScreen
+    41	import com.vreader.app.backup.SettingsCard
+    42	import com.vreader.app.backup.StatusDot
+    43	import com.vreader.app.backup.VSpace
+    44	
+    45	@Composable
+    46	fun AiProviderListScreen(
+    47	    state: AiProviderListState,
+    48	    onBack: () -> Unit = {},
+    49	    onAdd: () -> Unit = {},
+    50	    onEdit: (String) -> Unit = {},
+    51	) {
+    52	    val t = LocalBackupTokens.current
+    53	    val addButton: @Composable () -> Unit = {
+    54	        Box(
+    55	            Modifier.size(44.dp).clip(RoundedCornerShape(22.dp)).clickable(onClickLabel = "Add provider", onClick = onAdd),
+    56	            contentAlignment = Alignment.Center,
+    57	        ) { Icon(Icons.Filled.Add, contentDescription = "Add provider", tint = t.tint, modifier = Modifier.size(22.dp)) }
+    58	    }
+    59	    NavScreen(title = "AI Providers", large = true, onBack = onBack, trailing = addButton) {
+    60	        Column(Modifier.padding(horizontal = 18.dp).padding(bottom = 32.dp)) {
+    61	            if (state.unconfigured) {
+    62	                AiEmptyState(onAdd)
+    63	            } else {
+    64	                GroupHeader("Providers")
+    65	                SettingsCard {
+    66	                    state.providers.forEachIndexed { i, p ->
+    67	                        ProviderRow(p, last = i == state.providers.lastIndex, onEdit = onEdit)
+    68	                    }
+    69	                }
+    70	                GroupFooter("The selected provider is used for translation, chat, and summaries. Tap one to edit or test it.")
+    71	            }
+    72	        }
+    73	    }
+    74	}
+    75	
+    76	@Composable
+    77	private fun AiEmptyState(onAdd: () -> Unit) {
+    78	    val t = LocalBackupTokens.current
+   181	            hasOccurrence = { true },
+   182	            recentsFlow = recentSearchesStore.recents(),
+   183	            recordQuery = { q -> recentSearchesStore.record(q) },
+   184	            dispatcher = Dispatchers.Default,
+   185	            coroutineScope = coroutineScope,
+   186	        )
+   187	    }
+   188	
+   189	    /**
+   190	     * feature #133 WI-11 — the per-reader-session in-book-search ViewModel for the EPUB host. EPUB search does
+   191	     * NOT use the #128 FTS index at all (a chunk-level, location-less index cannot yield a jumpable position);
+   192	     * instead the WI-6 [InBookSearchRepository]'s EPUB branch runs Readium's OWN `SearchService` over the LIVE
+   193	     * [publication] via the WI-5 [EpubInBookSearchEngine] production constructor (which wraps the real
+   194	     * publication behind the `PublicationSearchSource` seam), returning navigable Readium `Locator`s the host
+   195	     * jumps to with `navigator.go`.
+   196	     *
+   197	     * EPUB bypasses the WI-7 index-state gate entirely: the [indexStateFlow] emits `null` (missing) and
+   198	     * [hasOccurrence] reports Ready, so the gate resolves to Ready and the engine's own `isSearchable` probe
+   199	     * is the real capability check (an un-searchable publication → the repository's [InBookSearchOutcome.Unsupported]
+   200	     * → the WI-8 VM's `hidesSearchEntry`, so the host omits the Search icon). The TXT/MD FTS branch is NEVER
+   201	     * invoked for an EPUB host, so its factories are error-throwing guards (a call would be a wiring bug).
+   202	     *
+   203	     * ONE [InBookSearchRepository] per session (so the live Readium `SearchIterator` behind
+   204	     * `SearchCursor.Epub` is held once and disposed via `closeAllEpubCursors` on dismiss / `onCleared`).
+   205	     * [coroutineScope] is the host's `lifecycleScope` in production (the VM cancels its child collectors on
+   206	     * `onCleared`).
+   207	     */
+   208	    fun epubInBookSearchViewModel(
+   209	        bookKey: String,
+   210	        publication: org.readium.r2.shared.publication.Publication,
+   211	        coroutineScope: CoroutineScope,
+   212	    ): com.vreader.app.search.InBookSearchViewModel {
+   213	        val repository = com.vreader.app.search.InBookSearchRepository(
+   214	            dispatcher = Dispatchers.Default,
+   215	            // The EPUB host never reaches the FTS branch (the repository dispatches only the EPUB branch for
+   216	            // `epub`), so the TXT/MD deps are error-throwing guards — a call here is a wiring bug, fail fast.
+   217	            fts = com.vreader.app.search.InBookFtsDeps(
+   218	                matchingChunksPage = { _, _, _, _, _ -> error("FTS matchingChunksPage requested on an EPUB host") },
+   219	                chunkAtOrAfter = { _, _, _, _ -> error("FTS chunkAtOrAfter requested on an EPUB host") },
+   220	                resolverFor = { error("FTS resolver requested on an EPUB host") },
+   221	            ),
+   222	            // The LIVE wiring: build the WI-5 engine over the real Readium publication (its production
+   223	            // constructor wraps the publication behind the `PublicationSearchSource` seam). One engine per
+   224	            // repository/session; the repository memoizes it per bookKey.
+   225	            epubEngineFor = { com.vreader.app.search.EpubInBookSearchEngine(publication) },
+   226	        )
+   227	        return com.vreader.app.search.InBookSearchViewModel(
+   228	            bookKey = bookKey,
+   229	            format = BookFormat.epub,
+   230	            searcher = repository.asSearcher(),
+   231	            indexStateGate = com.vreader.app.search.IndexStateGate(Dispatchers.Default),
+   232	            // EPUB bypasses the FTS index-state gate: a `null` (missing) row + `hasOccurrence == true` resolve
+   233	            // the gate to Ready, so the engine's own `isSearchable` probe is the capability check.
+   234	            indexStateFlow = kotlinx.coroutines.flow.flowOf(null),
+   235	            hasOccurrence = { true },
+   236	            recentsFlow = recentSearchesStore.recents(),
+   237	            recordQuery = { q -> recentSearchesStore.record(q) },
+   238	            dispatcher = Dispatchers.Default,
+   239	            coroutineScope = coroutineScope,
+   240	        )
+   241	    }
+   242	
+   243	    /** Builds a [com.vreader.app.search.SearchViewModel] wired to the live library, in-text repository,
+   244	     *  recents, collections, and the settled-completeness gate. */
+   245	    fun searchViewModel(): com.vreader.app.search.SearchViewModel =
+   246	        com.vreader.app.search.SearchViewModel(
+   247	            libraryFlow = repository.observeLibrary(),
+   248	            textHitsFor = { q -> searchRepository.textHits(q) },
+   249	            recentsFlow = recentSearchesStore.recents(),
+   250	            collectionsFlow = collectionRepository.observeCollections(),
+   251	            indexCompleteFlow = database.searchDao().observeUnsettledIndexableCount()
+   252	                .map { it == 0 },
+   253	            recordQuery = { q -> recentSearchesStore.record(q) },
+   254	        )
+   255	
+   256	    /** In-memory last reading char-offset per fingerprintKey. Written synchronously on
+   257	     *  save so a fast rotation / reopen restores the LATEST position without waiting for
+   258	     *  the async Room write to commit; Room remains the durable store across process death. */
+   259	    private val lastOffsets = java.util.concurrent.ConcurrentHashMap<String, Int>()
+   260	    fun cacheOffset(fingerprintKey: String, charOffsetUtf16: Int) { lastOffsets[fingerprintKey] = charOffsetUtf16 }
+   261	    fun cachedOffset(fingerprintKey: String): Int? = lastOffsets[fingerprintKey]
+   262	
+   263	    /** In-memory last PDF page index per fingerprintKey — a TYPED cache distinct from the
+   264	     *  char-offset one (feature #115; a PDF position is a page, not a UTF-16 offset). */
+   265	    private val lastPages = java.util.concurrent.ConcurrentHashMap<String, Int>()
+   266	    fun cachePage(fingerprintKey: String, page: Int) { lastPages[fingerprintKey] = page }
+   267	    fun cachedPage(fingerprintKey: String): Int? = lastPages[fingerprintKey]
+   268	}
+   269	
+   270	class VReaderApp : Application() {
+   271	    lateinit var container: AppContainer
+   272	        private set
+   273	
+   274	    override fun onCreate() {
+   275	        super.onCreate()
+   276	        container = AppContainer(this)
+   277	        // feature #128 WI-5 — eagerly start the cross-book search-index collector (idempotent).
+   278	        container.startSearchIndexing()
+   279	    }
+   280	}
+   600	    /** feature #133 WI-11 — dismiss the in-book search sheet: run the VM's dismiss (invalidates the active
+   601	     *  session + disposes the live Readium SearchIterator via closeAllEpubCursors — no leak) then hide it. */
+   602	    private fun dismissInBookSearch() {
+   603	        inBookSearchVm?.onDismiss()
+   604	        showSearchSheet.value = false
+   605	    }
+   606	
+   607	    private suspend fun persist(locator: Locator, current: Book) {
+   608	        val envelope = runCatching {
+   609	            bridge.toEnvelope(
+   610	                readiumLocatorJSON = locator.toJSON().toString(),
+   611	                bookContentSHA256 = current.contentSHA256,
+   612	                bookFileByteCount = current.fileByteCount,
+   613	                bookFormat = current.originalFormat,
+   614	            )
+   615	        }.getOrNull() ?: return
+   616	        repository.savePosition(envelope, System.currentTimeMillis())
+   617	    }
+   618	
+   619	    /** feature #132 WI-7-EPUB — the full reader nav chrome over the Readium fragment. Because the reader
+   620	     *  body is a View (EpubNavigatorFragment), NOT a composable, the chrome cannot use the Compose-native
+   621	     *  ReaderChromeScaffold. Instead a single root FrameLayout stacks, bottom-to-top:
+   622	     *    1. the fragment container — MATCH_PARENT (the reading area fills the WHOLE screen, under the bands);
+   623	     *    2. the selection-popover overlay — MATCH_PARENT (unchanged; renders nothing unless a selection);
+   624	     *    3. the sheet layer — MATCH_PARENT but EMPTY until a sheet opens (so it's touch-through: the
+   625	     *       fragment keeps scroll/selection/link input whenever no sheet is up), then a full-screen dismiss
+   626	     *       overlay + the Contents/Notes ModalBottomSheet;
+   627	     *    4. the top band — WRAP_CONTENT, gravity TOP (covers only the top chrome strip);
+   628	     *    5. the bottom band — WRAP_CONTENT, gravity BOTTOM (covers only the bottom chrome strip).
+   629	     *  The two bands sit ON TOP of the fragment but occupy only their own height, so the reading area
+   630	     *  between them stays the fragment's — touch-through by construction. */
+   631	    private fun buildChrome(): View {
+   632	        val root = FrameLayout(this).apply { setBackgroundColor(chromeTheme.value.background.toArgb()) }
+   633	
+   634	        val frame = FrameLayout(this).apply { id = View.generateViewId() }
+   635	        containerId = frame.id
+   636	
+   637	        val popoverOverlay = ComposeView(this).apply { setContent { PopoverOverlay() } }
+   638	        val sheetLayer = ComposeView(this).apply {
+   639	            setContent {
+   640	                EpubReaderSheets(
+   641	                    model = chromeModel,
+   642	                    theme = chromeTheme.value,
+   643	                    chromeState = chromeState,
+   644	                    onJumpToc = ::jumpToTocEntry,
+   645	                    onShareAnnotations = { shareAnnotations(chromeModel.value.annotations) },
+   646	                    // feature #134 WI-5 — the Book Details route + its Share / copy-fingerprint actions.
+   647	                    bookDetails = chromeBookDetails.value,
+   648	                    onShareBook = ::shareBookFile,
+   649	                    onCopyFingerprint = ::copyFingerprint,
+   650	                    // feature #135 WI-7 — the Bookmarks-tab rows + the per-bookmark jump (canonical → Readium).
+   651	                    bookmarks = bookmarkRows.value,
+   652	                    onJumpBookmark = ::jumpToBookmark,
+   653	                )
+   654	                // feature #133 WI-11 — the in-book search sheet renders in the SAME sheet-layer ComposeView
+   655	                // (open-only, so it does not cover the fragment while closed → touch-through preserved). It is
+   656	                // a ModalBottomSheet (its own window), driven by the per-session VM's live Readium search;
+   657	                // tapping a hit → jumpToSearchHit (Locator.fromJSON → nav.go), dismiss disposes the iterator.
+   658	                InBookSearchLayer()
+   659	            }
+   660	        }
+   661	        val topBand = ComposeView(this).apply {
+   662	            setContent {
+   663	                // feature #133 WI-11 — the Search icon is shown UNLESS the VM reports the entry is hidden (a
+   664	                // non-searchable publication → Unsupported → hidesSearchEntry). A null onSearch omits the icon
+   665	                // (no dead control). feature #134 WI-5 — the top-bar More button (shown once chromeBookDetails
+   666	                // is populated) toggles the More popup; Details writes ReaderSheet.Details, Share launches share.
+   667	                val searchState = inBookSearchState.value
+   668	                val onSearch: (() -> Unit)? =
+   669	                    if (searchState != null && !searchState.hidesSearchEntry) ({ showSearchSheet.value = true }) else null
+   670	                EpubTopBand(
+   671	                    model = chromeModel,
+   672	                    theme = chromeTheme.value,
+   673	                    onBack = { finish() },
+   674	                    chromeState = chromeState,
+   675	                    bookDetails = chromeBookDetails.value,
+   676	                    onShareBook = ::shareBookFile,
+   677	                    onSearch = onSearch,
+   678	                    // feature #135 WI-7 — the top-bar bookmark toggle (filled/outline by presence).
+   679	                    isCurrentBookmarked = isCurrentBookmarked.value,
+   680	                    onToggleBookmark = ::toggleCurrentBookmark,
+   681	                )
+   682	            }
+   683	        }
+   684	        val bottomBand = ComposeView(this).apply {
+   685	            setContent {
+   686	                DisplaySettingsHost {
+   687	                    EpubBottomBand(
+   688	                        model = chromeModel,
+   689	                        theme = chromeTheme.value,
+   690	                        chromeState = chromeState,
+   691	                        progress = chromeProgress.value,
+   692	                        onScrub = ::scrubTo,
+   693	                        onOpenDisplay = { showDisplaySheet.value = true },
+   694	                    )
+   695	                }
+   696	            }
+   697	        }
+   698	
+   699	        val match = FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT)
+   700	        root.addView(frame, FrameLayout.LayoutParams(match))
+   835	    annotations: AnnotationsSnapshot,
+   836	    onBack: () -> Unit,
+   837	    onJumpToAnnotation: (AnnotationItem) -> Unit,
+   838	    onShareAnnotations: () -> Unit,
+   839	    bottomBar: @Composable (Pair<(() -> Unit)?, (() -> Unit)?>) -> Unit,
+   840	    body: @Composable () -> Unit,
+   841	    // feature #133 WI-10 — the in-book Search entry + sheet overlay (nullable/default so #132/#134/#135
+   842	    // callers stay valid). A null [onOpenSearch] omits the top-bar Search icon (Unsupported / no-dead-control).
+   843	    onOpenSearch: (() -> Unit)? = null,
+   844	    searchSheet: (@Composable () -> Unit)? = null,
+   845	    // feature #134 WI-5 — the More menu's Book-details model + Share/copy actions (null model → no More).
+   846	    bookDetails: com.vreader.app.reader.details.BookDetailsUiModel? = null,
+   847	    onShareBook: () -> Unit = {},
+   848	    onCopyFingerprint: (String) -> Unit = {},
+   849	    // feature #135 WI-7 — the top-bar bookmark toggle + Bookmarks-tab rows + TXT/MD jump (all nullable/default
+   850	    // so #132/#134 callers stay valid). TXT supplies a preview provider (the Bookmarks-tab snippet).
+   851	    isCurrentBookmarked: Boolean = false,
+   852	    onToggleBookmark: (() -> Unit)? = null,
+   853	    currentLocator: vreader.contracts.Locator? = null,
+   854	    bookmarks: List<BookmarkRowItem> = emptyList(),
+   855	    onJumpBookmark: ((BookmarkRecord) -> JumpResult)? = null,
+   856	) {
+   857	    Column(Modifier.fillMaxSize().background(theme.background).systemBarsPadding()) {
+   858	        ReaderChromeScaffold(
+   859	            theme = theme,
+   860	            title = title,
+   861	            chromeState = chromeState,
+   862	            onBack = onBack,
+   863	            tocEntries = emptyList(),           // no TOC → the scaffold hides the Contents control
+   864	            currentTocIndex = 0,
+   865	            annotations = annotations,
+   866	            onJumpToc = { false },              // unreachable: Contents is hidden with an empty TOC
+   867	            onJumpToAnnotation = onJumpToAnnotation,
+   868	            onShareAnnotations = onShareAnnotations,
+   869	            // feature #133 WI-10 — the top-bar Search slot is now WIRED (the scaffold forwards it to
+   870	            // ReaderTopChrome(onSearch=…)). A null [onOpenSearch] omits the icon (Unsupported / no-dead-
+   871	            // control). feature #134 WI-5: the More button + Book Details / Share ride the scaffold's More menu.
+   872	            onOpenSearch = onOpenSearch,
+   873	            bottomChrome = { onOpenContents, onOpenNotes -> bottomBar(onOpenContents to onOpenNotes) },
+   874	            body = body,
+   875	            bookDetails = bookDetails,
+   876	            onShareBook = onShareBook,
+   877	            onCopyFingerprint = onCopyFingerprint,
+   878	            // feature #135 WI-7 — the bookmark toggle + Bookmarks tab, now lit up for TXT/MD.
+   879	            isCurrentBookmarked = isCurrentBookmarked,
+   880	            onToggleBookmark = onToggleBookmark,
+   881	            currentLocator = currentLocator,
+   882	            bookmarks = bookmarks,
+   883	            onJumpBookmark = onJumpBookmark,
+   884	        )
+   885	    }
+   886	    // feature #133 WI-10 — the in-book search sheet overlay (a ModalBottomSheet; the host renders it when
+   887	    // its search-open state is set). Layered outside the chrome Column so it covers the full reader.
+   888	    searchSheet?.invoke()
+   889	}
+   890	
+   891	// ---- feature #135 WI-7 — TXT/MD pure host wiring helpers ----
+   892	
+   893	/**
+   894	 * feature #135 WI-7 — the current TXT/MD reading position (a top-visible char offset) as a plain canonical
+   895	 * [vreader.contracts.Locator] (the bookmark equality basis + create/jump anchor). Mirrors the host's
+   896	 * save-position construction (identity triple + `charOffsetUTF16`), so a bookmark's position lines up with
+   897	 * the resume seam. Pure/JVM-testable.
+   898	 */
+   899	fun txtBookmarkLocator(book: com.vreader.app.data.Book, charOffsetUTF16: Int): vreader.contracts.Locator =
+   900	    vreader.contracts.Locator(
+   440	    chromeState: MutableState<ReaderChromeState>,
+   441	    annotations: AnnotationsSnapshot,
+   442	    onBack: () -> Unit,
+   443	    onShareAnnotations: () -> Unit,
+   444	    body: @Composable () -> Unit,
+   445	    // feature #134 WI-5 — the More menu's Book-details model + Share/copy actions (null model → no More).
+   446	    bookDetails: com.vreader.app.reader.details.BookDetailsUiModel? = null,
+   447	    onShareBook: () -> Unit = {},
+   448	    onCopyFingerprint: (String) -> Unit = {},
+   449	    // feature #135 WI-7 — the top-bar bookmark toggle + Bookmarks-tab rows + AZW3 jump (all nullable/default
+   450	    // so #132/#134 callers stay valid). A non-null onToggleBookmark fills the toggle; onJumpBookmark makes
+   451	    // the Bookmarks-tab rows clickable + dismiss-on-Succeeded (null → review-only rows).
+   452	    isCurrentBookmarked: Boolean = false,
+   453	    onToggleBookmark: (() -> Unit)? = null,
+   454	    currentLocator: Locator? = null,
+   455	    bookmarks: List<BookmarkRowItem> = emptyList(),
+   456	    onJumpBookmark: ((BookmarkRecord) -> JumpResult)? = null,
+   457	) {
+   458	    Column(Modifier.fillMaxSize().background(theme.background).systemBarsPadding()) {
+   459	        ReaderChromeScaffold(
+   460	            theme = theme,
+   461	            title = title,
+   462	            chromeState = chromeState,
+   463	            onBack = onBack,
+   464	            tocEntries = emptyList(),           // no TOC → the scaffold hides the Contents control
+   465	            currentTocIndex = 0,
+   466	            annotations = annotations,
+   467	            onJumpToc = { false },              // unreachable: Contents is hidden with an empty TOC
+   468	            // AZW3 tap-to-jump is NULL — review-only capability gate (no goTo until #135); cards non-clickable.
+   469	            onJumpToAnnotation = null,
+   470	            onShareAnnotations = onShareAnnotations,
+   471	            // Search top-bar slot stays null (#133 — no dead control). feature #134 WI-5:
+   472	            // the More button + Book Details / Share are wired through the scaffold's More menu below.
+   473	            bottomChrome = { _, onOpenNotes ->
+   474	                // AZW3 has no Contents (empty TOC) + no Display control → Notes only.
+   475	                Azw3NotesBottomChrome(theme = theme, onOpenNotes = onOpenNotes)
+   476	            },
+   477	            body = body,
+   478	            bookDetails = bookDetails,
+   479	            onShareBook = onShareBook,
+   480	            onCopyFingerprint = onCopyFingerprint,
+   481	            // feature #135 WI-7 — the bookmark toggle + Bookmarks tab, now lit up for AZW3.
+   482	            isCurrentBookmarked = isCurrentBookmarked,
+   483	            onToggleBookmark = onToggleBookmark,
+   484	            currentLocator = currentLocator,
+   485	            bookmarks = bookmarks,
+   486	            onJumpBookmark = onJumpBookmark,
+   487	        )
+   488	    }
+   489	}
+   490	
+
+codex
+## Critical
+
+None. The plan’s core premise is correct:
+
+- All named AI types exist: [AiProviderStore.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:41), [AiSettingsViewModel.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:20), [AiProviderListScreen.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:46), and [AiProviderEditSheet.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt:55).
+- `AppContainer` exists, but constructs no `AiProviderStore`; its only current mention is a precedent comment at [VReaderApp.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:64).
+- Production navigation is Activity-based, with books launched using `startActivity`; there is no `NavHost` route to the provider UI at [MainActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:76).
+- Direct calls to `AiProviderListScreen` and `AiProviderEditSheet` occur only in `androidTest`. `AiSettingsViewModel` and `AiProviderStore` are likewise not constructed by production wiring.
+- `readerMoreRows`, `MoreActionId.BILINGUAL`, and `MoreRow.Disabled` exist at [ReaderChromeScaffold.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeScaffold.kt:255) and [MoreRow.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:19).
+
+## High
+
+1. Rule 51 blocker: the proposed tappable “disabled” More row contradicts the cited design.
+
+   The plan claims `disabled` plus an `on` callback depicts a dimmed-but-tappable row at [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:101). In the actual JSX, however, `disabled` explicitly suppresses the callback via `onClick={disabled ? undefined : on}` at [vreader-more.jsx](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-more.jsx:16). Current Kotlin faithfully implements that behavior at [MorePopup.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt:142), and the connected test expressly requires no callback at [MorePopupTest.kt](/Users/ll/workspace/vreader/android/app/src/androidTest/kotlin/com/vreader/app/reader/more/MorePopupTest.kt:111).
+
+   Making `MoreRow.Disabled` interactive is therefore a new, undesigned interaction state, not a restoration to design.
+
+2. Rule 51 blocker: the direct More → generic provider screen is not Variant A as depicted.
+
+   Variant A is specifically a push inside the bilingual sheet, with a `‹ Bilingual` back control, bilingual-context content, selection semantics, and return to Bilingual after save: [reader-ai-provider-entry.md](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:39), [vreader-ai-provider-entry.jsx](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:27), and [vreader-ai-provider-entry.jsx](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:245).
+
+   The plan instead opens `ReaderSheet.AiProviders` directly from More, renders the generic full-screen Android `AiProviderListScreen`, and closes back to the reader at [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:21) and [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:32). The reused screen has generic copy and only `onBack/onAdd/onEdit`, not Variant A’s bilingual-context selection contract, at [AiProviderListScreen.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:46).
+
+   Thus the proposed standalone in-reader sheet is not actually depicted by the cited Variant A bundle.
+
+3. The `aiUnavailable` predicate is materially wrong.
+
+   WI-3 derives availability solely from `profiles.isEmpty()` at [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:33). The live model separately stores `activeId`, and `active` can be null even with profiles present at [AiProviderStore.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:33). API-key usability additionally depends on successfully decrypting the active profile’s token at [AiProviderStore.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:105).
+
+   Consequently, an orphaned/unknown `activeId`, blank token, corrupt token, or invalidated keystore key would hide the configuration entry while AI remains unusable. The plan needs a single readiness definition covering an active profile plus a non-empty, decryptable key, with explicit failure behavior.
+
+4. Keystore and DataStore failures are not handled despite becoming production-reachable.
+
+   `KeystoreSecretCipher` can throw during keystore loading, key generation, Base64 decoding, GCM initialization, or authentication at [SecretCipher.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/backup/net/SecretCipher.kt:29). `AiSettingsViewModel.save()` performs `store.upsert` without catching failures at [AiSettingsViewModel.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:85), while `observe()` has no DataStore I/O recovery at [AiProviderStore.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:49).
+
+   The plan explicitly declares crypto/CRUD untouched and supplies no failure-state contract or tests at [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:44). Production wiring can therefore surface uncaught save failures or permanently cancel UI collection. Error presentation may itself require design authority.
+
+## Medium
+
+1. The planned JVM `AppContainerAiWiringTest` cannot exercise the stated real upsert path as written.
+
+   The test proposes constructing the production container and performing `upsert` at [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:87). The production cipher explicitly cannot be unit-tested under Robolectric because AndroidKeyStore is unavailable at [SecretCipher.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/backup/net/SecretCipher.kt:24). The plan needs an injected cipher/DataStore seam or must move the real-container encryption assertion to instrumentation.
+
+2. Process-death behavior is inaccurately specified.
+
+   Only `ReaderSheet` is persisted by the saver at [ReaderChromeState.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeState.kt:63). Editor state is a plain `MutableStateFlow`, not `SavedStateHandle` state, at [AiSettingsViewModel.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:36). After process death during editing, `ReaderSheet.AiProviders` can restore, but the editor will be closed and the list displayed; it will not “re-open empty” as claimed at [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:103). The plan should state and test the exact intended fallback.
+
+3. The keystore alias is underspecified.
+
+   WI-1 uses `KeystoreSecretCipher(<alias>)` without naming a stable, AI-specific alias at [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:29). Omitting it would silently use the WebDAV default alias, `vreader.webdav.password`, at [SecretCipher.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/backup/net/SecretCipher.kt:63). The plan should pin a distinct constant such as `vreader.ai.api-key` and test it on-device.
+
+4. WI-3 needs explicit serialization against #131.
+
+   WI-3 modifies the shared More assembler, popup treatment, EPUB chrome, scaffold, and every Activity family at [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:79). Those are also the exact integration seams #131 will modify. The dependency statement correctly blocks #131 conceptually, but the write-isolation plan should explicitly forbid concurrent implementation of #131’s chrome WI until #136 WI-3 merges.
+
+## Low
+
+1. The host count is imprecise.
+
+   The plan repeatedly says “five host Activities” but names four Activity classes at [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:33). There are five formats because TXT and Markdown share `TxtReaderActivity`, as shown at [MainActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:83). The write set is four Activities plus the shared EPUB/scaffold chrome files.
+
+2. The three-WI split is otherwise cohesive.
+
+   WI-1 is genuinely foundational: lazy construction alone has no visible behavior. WI-2 and WI-3 are appropriately behavioral. DataStore’s atomic edits and snapshot-based request API are sound concurrency foundations at [AiProviderStore.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:46) and [AiProviderStore.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:70). The split should remain three WIs after resolving design, readiness, and failure handling.
+
+FINAL VERDICT: block-recommended
+tokens used
+120,709
+## Critical
+
+None. The plan’s core premise is correct:
+
+- All named AI types exist: [AiProviderStore.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:41), [AiSettingsViewModel.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:20), [AiProviderListScreen.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:46), and [AiProviderEditSheet.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderEditSheet.kt:55).
+- `AppContainer` exists, but constructs no `AiProviderStore`; its only current mention is a precedent comment at [VReaderApp.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/VReaderApp.kt:64).
+- Production navigation is Activity-based, with books launched using `startActivity`; there is no `NavHost` route to the provider UI at [MainActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:76).
+- Direct calls to `AiProviderListScreen` and `AiProviderEditSheet` occur only in `androidTest`. `AiSettingsViewModel` and `AiProviderStore` are likewise not constructed by production wiring.
+- `readerMoreRows`, `MoreActionId.BILINGUAL`, and `MoreRow.Disabled` exist at [ReaderChromeScaffold.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeScaffold.kt:255) and [MoreRow.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/more/MoreRow.kt:19).
+
+## High
+
+1. Rule 51 blocker: the proposed tappable “disabled” More row contradicts the cited design.
+
+   The plan claims `disabled` plus an `on` callback depicts a dimmed-but-tappable row at [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:101). In the actual JSX, however, `disabled` explicitly suppresses the callback via `onClick={disabled ? undefined : on}` at [vreader-more.jsx](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-more.jsx:16). Current Kotlin faithfully implements that behavior at [MorePopup.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/more/MorePopup.kt:142), and the connected test expressly requires no callback at [MorePopupTest.kt](/Users/ll/workspace/vreader/android/app/src/androidTest/kotlin/com/vreader/app/reader/more/MorePopupTest.kt:111).
+
+   Making `MoreRow.Disabled` interactive is therefore a new, undesigned interaction state, not a restoration to design.
+
+2. Rule 51 blocker: the direct More → generic provider screen is not Variant A as depicted.
+
+   Variant A is specifically a push inside the bilingual sheet, with a `‹ Bilingual` back control, bilingual-context content, selection semantics, and return to Bilingual after save: [reader-ai-provider-entry.md](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/design-notes/reader-ai-provider-entry.md:39), [vreader-ai-provider-entry.jsx](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:27), and [vreader-ai-provider-entry.jsx](/Users/ll/workspace/vreader/dev-docs/designs/vreader-fidelity-v1/project/vreader-ai-provider-entry.jsx:245).
+
+   The plan instead opens `ReaderSheet.AiProviders` directly from More, renders the generic full-screen Android `AiProviderListScreen`, and closes back to the reader at [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:21) and [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:32). The reused screen has generic copy and only `onBack/onAdd/onEdit`, not Variant A’s bilingual-context selection contract, at [AiProviderListScreen.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderListScreen.kt:46).
+
+   Thus the proposed standalone in-reader sheet is not actually depicted by the cited Variant A bundle.
+
+3. The `aiUnavailable` predicate is materially wrong.
+
+   WI-3 derives availability solely from `profiles.isEmpty()` at [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:33). The live model separately stores `activeId`, and `active` can be null even with profiles present at [AiProviderStore.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:33). API-key usability additionally depends on successfully decrypting the active profile’s token at [AiProviderStore.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:105).
+
+   Consequently, an orphaned/unknown `activeId`, blank token, corrupt token, or invalidated keystore key would hide the configuration entry while AI remains unusable. The plan needs a single readiness definition covering an active profile plus a non-empty, decryptable key, with explicit failure behavior.
+
+4. Keystore and DataStore failures are not handled despite becoming production-reachable.
+
+   `KeystoreSecretCipher` can throw during keystore loading, key generation, Base64 decoding, GCM initialization, or authentication at [SecretCipher.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/backup/net/SecretCipher.kt:29). `AiSettingsViewModel.save()` performs `store.upsert` without catching failures at [AiSettingsViewModel.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:85), while `observe()` has no DataStore I/O recovery at [AiProviderStore.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:49).
+
+   The plan explicitly declares crypto/CRUD untouched and supplies no failure-state contract or tests at [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:44). Production wiring can therefore surface uncaught save failures or permanently cancel UI collection. Error presentation may itself require design authority.
+
+## Medium
+
+1. The planned JVM `AppContainerAiWiringTest` cannot exercise the stated real upsert path as written.
+
+   The test proposes constructing the production container and performing `upsert` at [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:87). The production cipher explicitly cannot be unit-tested under Robolectric because AndroidKeyStore is unavailable at [SecretCipher.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/backup/net/SecretCipher.kt:24). The plan needs an injected cipher/DataStore seam or must move the real-container encryption assertion to instrumentation.
+
+2. Process-death behavior is inaccurately specified.
+
+   Only `ReaderSheet` is persisted by the saver at [ReaderChromeState.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/reader/chrome/ReaderChromeState.kt:63). Editor state is a plain `MutableStateFlow`, not `SavedStateHandle` state, at [AiSettingsViewModel.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiSettingsViewModel.kt:36). After process death during editing, `ReaderSheet.AiProviders` can restore, but the editor will be closed and the list displayed; it will not “re-open empty” as claimed at [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:103). The plan should state and test the exact intended fallback.
+
+3. The keystore alias is underspecified.
+
+   WI-1 uses `KeystoreSecretCipher(<alias>)` without naming a stable, AI-specific alias at [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:29). Omitting it would silently use the WebDAV default alias, `vreader.webdav.password`, at [SecretCipher.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/backup/net/SecretCipher.kt:63). The plan should pin a distinct constant such as `vreader.ai.api-key` and test it on-device.
+
+4. WI-3 needs explicit serialization against #131.
+
+   WI-3 modifies the shared More assembler, popup treatment, EPUB chrome, scaffold, and every Activity family at [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:79). Those are also the exact integration seams #131 will modify. The dependency statement correctly blocks #131 conceptually, but the write-isolation plan should explicitly forbid concurrent implementation of #131’s chrome WI until #136 WI-3 merges.
+
+## Low
+
+1. The host count is imprecise.
+
+   The plan repeatedly says “five host Activities” but names four Activity classes at [plan](/Users/ll/workspace/vreader/dev-docs/plans/20260712-feature-136-android-ai-provider-reachable.md:33). There are five formats because TXT and Markdown share `TxtReaderActivity`, as shown at [MainActivity.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/MainActivity.kt:83). The write set is four Activities plus the shared EPUB/scaffold chrome files.
+
+2. The three-WI split is otherwise cohesive.
+
+   WI-1 is genuinely foundational: lazy construction alone has no visible behavior. WI-2 and WI-3 are appropriately behavioral. DataStore’s atomic edits and snapshot-based request API are sound concurrency foundations at [AiProviderStore.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:46) and [AiProviderStore.kt](/Users/ll/workspace/vreader/android/app/src/main/kotlin/com/vreader/app/ai/AiProviderStore.kt:70). The split should remain three WIs after resolving design, readiness, and failure handling.
+
+FINAL VERDICT: block-recommended

--- a/.claude/codex-audits/feat-139-wi-1-toc-rules-audit.md
+++ b/.claude/codex-audits/feat-139-wi-1-toc-rules-audit.md
@@ -1,5 +1,5 @@
 ---
-branch: worktree-agent-a88fda8d3ce3433c2
+branch: feat/139-wi-1-toc-rules
 threadId: 019fcb40-8348-76d2-999e-2be4c26eeeda
 rounds: 3
 final_verdict: follow-up-recommended

--- a/.claude/codex-audits/worktree-agent-a88fda8d3ce3433c2-audit.md
+++ b/.claude/codex-audits/worktree-agent-a88fda8d3ce3433c2-audit.md
@@ -1,0 +1,77 @@
+---
+branch: worktree-agent-a88fda8d3ce3433c2
+threadId: 019fcb40-8348-76d2-999e-2be4c26eeeda
+rounds: 3
+final_verdict: follow-up-recommended
+date: 2026-08-04
+---
+
+# Gate-4 audit — feature #139 WI-1 (ported TXT TOC rule data)
+
+Item: `feat:#139/WI-1`. Auditor: Codex `gpt-5.6-sol` via `scripts/run-codex.sh` (rule 53),
+read-only sandbox, three rounds. Thread ids: r1 `019fcb40-8348-76d2-999e-2be4c26eeeda`,
+r2 `019fcb45-e8ab-7a33-9739-c0448857f8ab`, r3 `019fcb48-1b81-70b3-8419-c073733c4879`.
+Raw transcripts: `.reports/audit-r{1,2,3}.txt` (gitignored, lane-local).
+
+Scope audited: `TxtTocRule.kt`, `TxtTocRules.kt`, `TxtTocRulesTest.kt`, and the committed
+Gate-1 probes, against the iOS source of truth `vreader/Services/TXT/TXTTocRuleEngine.swift:142-350`.
+
+## Round 1 — verdict `block-recommended`
+
+| Sev | Finding | Disposition |
+| --- | --- | --- |
+| HIGH | All 25 rules widened the **leading indent** class to `WS`. Not a D1b repair — iOS writes the indent as a literal `[space, U+3000, tab]` class and uses `\s` only for interior positions. `WS` contains line terminators, so at a blank line the indent consumed that line's own terminator and the match started one line early; WI-2 turns match starts into navigation locators, so every heading preceded by a blank line (ubiquitous in real books) would carry an off-by-one-line offset. | **FIXED** (`20101fa2`). `INDENT` is now iOS's literal class, built from a code point. New test `everyRule_keepsTheLiteralIosIndentClass`; the old test that *pinned* the defect was replaced by `headingAfterBlankLines_matchesAtTheHeadingLine_notTheBlankLine`. |
+| MEDIUM | No independent fidelity pin — a pattern and its example could drift together and still pass "matches its own example". | **FIXED** (`20101fa2`). Golden table `iosRules` transcribed independently from the Swift source; every rule's name, example and pattern asserted against it. |
+| MEDIUM | D1/D1b populations were derived from the implementation under test, so one wrong removal plus one wrong addition could cancel out. | **FIXED** (`20101fa2`). `IOS_DIGIT_RULE_IDS` / `IOS_WHITESPACE_RULE_IDS` hard-coded from Swift; both the derived population and the sample-table keys assert against them. |
+| LOW | `inlineFlags()` KDoc overclaimed completeness. | **FIXED** (`20101fa2`). Reworded; backstopped by `noRule_containsAnyForbiddenFlagToken`. |
+| LOW | Docs framed the offset shift as a "known limitation", risking WI-2 treating it as contractual. | **FIXED** (`20101fa2`) — the defect itself was removed. |
+
+The HIGH was raised to the auditor as an explicit question because plan §3.5 *mandates* the
+normalization. The auditor's independent verdict: ship iOS's literal class, "there is no
+ICU/Java incompatibility to repair here". Corroborating evidence found in the plan itself — its
+Appendix A.5 non-regression measurement kept the leading class literal and widened only interior
+positions, so the "widening is non-regressive" evidence never covered the indent. **This is a
+deliberate, audited deviation from plan §3.5** and is recorded in the HANDOFF for the plan to be
+corrected.
+
+## Round 2 — verdict `follow-up-recommended`
+
+| Sev | Finding | Disposition |
+| --- | --- | --- |
+| MEDIUM | The fidelity check reversed the substitutions and compared back to iOS, but the reversal is **not injective**: a bracketed class and its bare contents both reverse to the same token, so a pattern splicing class contents where the whole class belongs (`\s\p{Z}\x{0085}{0,4}` outside a class is a literal sequence, not whitespace) would reverse cleanly and pass. | **FIXED** (`6f2017b6`). Reversal deleted; replaced by `expandIosPattern()` — a forward, context-aware expansion (class-depth tracking, escape skipping) compared for character equality. `expandIosPattern_isContextAware` pins the expander. |
+
+Round 2 also positively verified: all 25 golden names/bodies/examples character-identical to
+Swift; substitution ordering correct; `INDENT` produces exactly Swift's prefix; blank-line
+offsets correct for LF, repeated LF and CRLF; both hard-coded id sets match the Swift patterns.
+
+## Round 3 (final) — verdict `follow-up-recommended`
+
+**Zero Critical, zero High, zero Medium.** Two LOW findings, both closed in-lane:
+
+| Sev | Finding | Disposition |
+| --- | --- | --- |
+| LOW | Golden-table KDoc still described round-tripping after the forward-expansion rewrite. | **FIXED** — KDoc rewritten. |
+| LOW | The expander's own tests stated expectations in terms of the production constants, so a consistently-wrong constant could ride through every assertion. | **FIXED** — `theWidenedClasses_areExactlyWhatTheyClaimToBe` pins all four constants against literals, with the full-width digit bounds built from code points. |
+
+Round 3 confirmed: the expander handles all 25 golden bodies correctly (every backslash has a
+following character; `\(`, `\)`, `\.`, `\[`, `\-` copied atomically; only unescaped brackets
+change class state); the equality is injective over shipped rule strings; the golden table
+faithfully matches Swift including numeral inventories, enabled flags and ordering;
+`narrowedWhitespace` / `narrowedDigits` are still used and correct; no dead production code.
+
+## Port-fidelity result (auditor-confirmed across all three rounds)
+
+All 25 ids, serialNumbers, enabled flags, names and examples match iOS. The three CJK numeral
+inventories are correctly distinct (rules 1/2/7/23 include `〇`, `两` and the financial forms;
+rule 22 excludes `两` and the financial forms; rule 19 excludes `〇` and `两` but keeps the
+financial forms). No bare `\d` or `\s` survives; nothing was widened that iOS did not write as
+`\d`/`\s` — rule 17's full-width-only class is correctly left alone. The D1/D1b negative controls
+are real, not vacuous.
+
+## Test gate (re-run after every audit-driven change)
+
+```
+RUN-ANDROID-TESTS RESULT: SUCCEEDED
+```
+`ANDROID_CMD="./gradlew :app:testDebugUnitTest --tests '*TxtTocRulesTest*'"` — 21 tests,
+0 failures, 0 errors, 0 skipped.

--- a/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocRule.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocRule.kt
@@ -1,0 +1,35 @@
+// Purpose: Model for one TXT table-of-contents detection rule (feature #139 WI-1).
+// The Kotlin analog of iOS `TXTTocRule` (vreader/Services/TXT/TXTTocRule.swift) — the
+// 25 regex rules originally ported from Legado's txtTocRule.json. The rule DATA lives in
+// [TxtTocRules]; this file is only its shape.
+//
+// Key decisions:
+// - `id`/`serialNumber`/`enabled` mirror iOS 1:1 so both platforms detect the same chapters.
+// - `pattern` is a raw regex STRING, not a compiled `Regex`: compilation flags are the
+//   engine's contract (MULTILINE only — never DOT_MATCHES_ALL / IGNORE_CASE), and a data
+//   class of Strings stays cheap to hold, compare, and (later) persist.
+// - Field named `pattern` rather than iOS's `rule` — `TxtTocRule.rule` reads as a self
+//   reference in Kotlin call sites.
+//
+// @coordinates-with: TxtTocRules.kt, TxtTocRuleEngine.kt
+package com.vreader.app.reader.nav
+
+/**
+ * A single TXT chapter-detection rule.
+ *
+ * @param id           unique identifier (matches iOS / Legado numbering).
+ * @param enabled      whether the rule participates in auto-detection.
+ * @param name         human-readable description of what the rule matches.
+ * @param pattern      regex pattern string — applied with `RegexOption.MULTILINE` ONLY.
+ * @param example      a sample line the pattern matches (pinned by test).
+ * @param serialNumber original Legado ordering key; detection ties break toward the
+ *                     lowest serial number, so list order is load-bearing.
+ */
+data class TxtTocRule(
+    val id: Int,
+    val enabled: Boolean,
+    val name: String,
+    val pattern: String,
+    val example: String,
+    val serialNumber: Int,
+)

--- a/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocRules.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocRules.kt
@@ -1,0 +1,289 @@
+// Purpose: The 25 TXT chapter-detection rules, ported 1:1 from iOS
+// `TXTTocRuleEngine.buildDefaultRules()` (vreader/Services/TXT/TXTTocRuleEngine.swift:142-350),
+// itself a port of Legado's txtTocRule.json. Data only — detection/extraction is the engine's.
+// Feature #139 WI-1.
+//
+// Key decisions:
+// - Ids, serialNumbers and `enabled` flags mirror iOS EXACTLY (14 enabled: 1-10, 13, 14, 20, 23),
+//   so a book that gets a Contents on iOS gets the same one on Android. The port follows iOS's
+//   DATA, not its stale header comment (TXTTocRuleEngine.swift:27 still says "8 enabled").
+// - List order IS serialNumber order, and detection breaks ties toward the FIRST rule, so the
+//   order is behaviour, not presentation.
+// - TWO regex-engine divergences are repaired here, because iOS runs ICU (NSRegularExpression)
+//   and Android runs java.util.regex (see [DIGIT] and [WS]). Everything else is verbatim.
+// - Patterns are compiled by the caller with MULTILINE and NOTHING else: DOT_MATCHES_ALL would
+//   let a title swallow the chapter (the bounded `.{0,30}$` tail is what confines it to one
+//   line), and IGNORE_CASE would reintroduce the Unicode case-folding divergence the explicit
+//   `[Cc]hapter`-style spellings avoid. No pattern carries an inline flag either — `(?U)` in
+//   particular is banned: it would fix \d and \s but ALSO redefine \w, \b and POSIX classes.
+//
+// Known limitation: [WS] is a superset of iOS's literal `[space, U+3000, tab]` indent class and
+// includes line terminators, so at a BLANK line the leading indent can consume that line's own
+// terminator and a match can start one line early. Titles are unaffected (they are trimmed);
+// the source offset shifts to the blank line's start. Pinned by TxtTocRulesTest.
+//
+// @coordinates-with: TxtTocRule.kt, TxtTocRuleEngine.kt
+package com.vreader.app.reader.nav
+
+/**
+ * The default TXT TOC rule set (all 25; 14 enabled), plus the two character classes that repair
+ * the ICU-vs-Java regex divergences.
+ */
+object TxtTocRules {
+
+    // ------------------------------------------------------------------ divergence repairs
+
+    /**
+     * D1b — the ICU `\s` equivalent for `java.util.regex`, as CLASS CONTENTS (no brackets) so it
+     * can also be spliced into a larger character class such as `[.、：:$WS_CHARS]`.
+     *
+     * ICU defines `\s` as `[\t\n\v\f\r\p{Z}]`; Java's is ASCII-only (`[ \t\n\x0B\f\r]`).
+     * `\p{Z}` = Zs ∪ Zl ∪ Zp, so this covers U+3000 IDEOGRAPHIC SPACE, NBSP, U+2028 and U+2029;
+     * `\x{0085}` (NEL) is added explicitly because it is `Cc`, not `Z`.
+     *
+     * Load-bearing for CJK: U+3000 is the normal separator in Chinese typesetting, so a book
+     * whose headings read `第 一 章` builds a TOC on iOS and, with bare Java `\s`, none here.
+     */
+    const val WS_CHARS = "\\s\\p{Z}\\x{0085}"
+
+    /** [WS_CHARS] as a standalone character class — one whitespace character, ICU semantics. */
+    const val WS = "[$WS_CHARS]"
+
+    /**
+     * D1 — the ICU `\d` equivalent, as CLASS CONTENTS. ICU `\d` is Unicode `Nd` (it matches
+     * `０-９`); Java's `\d` is ASCII `[0-9]`, so a verbatim port silently fails on full-width
+     * digits — i.e. on exactly the CJK books this feature exists for.
+     */
+    const val DIGIT_CHARS = "0-9０-９"
+
+    /** [DIGIT_CHARS] as a standalone character class — one digit, ICU semantics. */
+    const val DIGIT = "[$DIGIT_CHARS]"
+
+    // ------------------------------------------------------------------ numeral inventories
+    // Three DISTINCT sets on iOS; the differences are deliberate and preserved verbatim.
+
+    /** Rules 1, 2, 7, 23 — Chinese numerals incl. 两 and the financial forms 壹…仟. */
+    private const val CJK_NUM = "〇零一二两三四五六七八九十百千万壹贰叁肆伍陆柒捌玖拾佰仟"
+
+    /** Rule 22 (Japanese) — no 两, no financial forms. */
+    private const val CJK_NUM_JA = "〇零一二三四五六七八九十百千万"
+
+    /** Rule 19 (parenthesised) — no 〇, no 两. */
+    private const val CJK_NUM_PAREN = "零一二三四五六七八九十百千万壹贰叁肆伍陆柒捌玖拾佰仟"
+
+    /** The bounded leading-indent prefix every rule shares. */
+    private const val INDENT = "^$WS{0,4}"
+
+    // ------------------------------------------------------------------ the rules
+
+    /** All 25 rules in serialNumber order. 14 ship enabled — same set as iOS. */
+    val defaults: List<TxtTocRule> = listOf(
+        TxtTocRule(
+            id = 1,
+            enabled = true,
+            name = "中文章节（通用）",
+            pattern = "$INDENT(?:序章|楔子|正文(?!完|结)|终章|后记|尾声|番外|" +
+                "第$WS{0,4}[$DIGIT_CHARS$CJK_NUM]+?$WS{0,4}" +
+                "(?:章|节(?!课)|卷|集(?![合和])|部(?![分赛游])|篇(?!张))).{0,30}$",
+            example = "第一章 标题",
+            serialNumber = 1,
+        ),
+        TxtTocRule(
+            id = 2,
+            enabled = true,
+            name = "中文数字章节",
+            pattern = "$INDENT[第（\\(]?$WS{0,4}[$DIGIT_CHARS$CJK_NUM]+?$WS{0,4}[章节卷集部篇回话]$WS?.{0,30}$",
+            example = "第123章 标题",
+            serialNumber = 2,
+        ),
+        TxtTocRule(
+            id = 3,
+            enabled = true,
+            name = "英文Chapter/Section/Part",
+            pattern = "$INDENT(?:[Cc]hapter|[Ss]ection|[Pp]art|[Ee]pisode)$WS{0,4}$DIGIT{1,4}.{0,30}$",
+            example = "Chapter 1 Title",
+            serialNumber = 3,
+        ),
+        TxtTocRule(
+            id = 4,
+            enabled = true,
+            name = "数字+标点标题",
+            pattern = "$INDENT$DIGIT{1,5}[：:,.， 、_—\\-].{1,30}$",
+            example = "1、这个标题",
+            serialNumber = 4,
+        ),
+        TxtTocRule(
+            id = 5,
+            enabled = true,
+            name = "特殊符号·章节",
+            pattern = "$INDENT[【\\[☆★●◆◇○◎□■△▲※卐].{1,30}$",
+            example = "【第一章 标题】",
+            serialNumber = 5,
+        ),
+        TxtTocRule(
+            id = 6,
+            enabled = true,
+            name = "正文+标题",
+            // `${'$'}INDENT` is braced because a CJK letter is a valid Kotlin identifier
+            // character — an unbraced `$INDENT正文` would parse as the identifier `INDENT正文`.
+            pattern = "${INDENT}正文$WS.{0,20}$",
+            example = "正文 第一章",
+            serialNumber = 6,
+        ),
+        TxtTocRule(
+            id = 7,
+            enabled = true,
+            name = "中文卷/篇/部/集",
+            pattern = "$INDENT(?:卷|篇|部|集)$WS{0,4}[$DIGIT_CHARS$CJK_NUM]+.{0,30}$",
+            example = "卷五 开源盛世",
+            serialNumber = 7,
+        ),
+        TxtTocRule(
+            id = 8,
+            enabled = true,
+            name = "星号标题",
+            pattern = "$INDENT[☆★].{1,30}$",
+            example = "☆、第一个故事",
+            serialNumber = 8,
+        ),
+        TxtTocRule(
+            id = 9,
+            enabled = true,
+            name = "Volume + Number",
+            pattern = "$INDENT[Vv]ol(?:ume)?$WS{0,4}$DIGIT{1,4}.{0,30}$",
+            example = "Volume 1 Title",
+            serialNumber = 9,
+        ),
+        TxtTocRule(
+            id = 10,
+            enabled = true,
+            name = "Book + Number",
+            pattern = "$INDENT[Bb]ook$WS{0,4}$DIGIT{1,4}.{0,30}$",
+            example = "Book 1 Title",
+            serialNumber = 10,
+        ),
+        TxtTocRule(
+            id = 11,
+            enabled = false,
+            name = "Act + Number",
+            pattern = "$INDENT[Aa]ct$WS{0,4}$DIGIT{1,4}.{0,30}$",
+            example = "Act 1 Title",
+            serialNumber = 11,
+        ),
+        TxtTocRule(
+            id = 12,
+            enabled = false,
+            name = "Scene + Number",
+            pattern = "$INDENT[Ss]cene$WS{0,4}$DIGIT{1,4}.{0,30}$",
+            example = "Scene 1 Title",
+            serialNumber = 12,
+        ),
+        TxtTocRule(
+            id = 13,
+            enabled = true,
+            name = "数字序号（圆括号）",
+            pattern = "$INDENT[\\(（]$DIGIT{1,5}[\\)）].{1,30}$",
+            example = "(1) 标题",
+            serialNumber = 13,
+        ),
+        TxtTocRule(
+            id = 14,
+            enabled = true,
+            name = "数字序号（点号）",
+            pattern = "$INDENT$DIGIT{1,5}\\..{1,30}$",
+            example = "1.标题",
+            serialNumber = 14,
+        ),
+        TxtTocRule(
+            id = 15,
+            enabled = false,
+            name = "罗马数字章节",
+            pattern = "$INDENT(?:I{1,3}|IV|VI{0,3}|IX|XI{0,3}|XIV|XVI{0,3}|XIX|XXI{0,3})[.、：:$WS_CHARS].{0,30}$",
+            example = "III. 标题",
+            serialNumber = 15,
+        ),
+        TxtTocRule(
+            id = 16,
+            enabled = false,
+            name = "天干地支",
+            pattern = "$INDENT[甲乙丙丁戊己庚辛壬癸][.、：:$WS_CHARS].{0,30}$",
+            example = "甲、标题",
+            serialNumber = 16,
+        ),
+        TxtTocRule(
+            id = 17,
+            enabled = false,
+            name = "全角数字章节",
+            // Deliberately NOT widened to [DIGIT]: on iOS this rule is full-width ONLY, and it is
+            // the marker itself (not a `\d` shorthand), so D1 does not apply.
+            pattern = "$INDENT[０-９]{1,5}[.、：:$WS_CHARS].{0,30}$",
+            example = "０１、标题",
+            serialNumber = 17,
+        ),
+        TxtTocRule(
+            id = 18,
+            enabled = false,
+            name = "圆圈数字",
+            pattern = "$INDENT[①②③④⑤⑥⑦⑧⑨⑩⑪⑫⑬⑭⑮⑯⑰⑱⑲⑳].{0,30}$",
+            example = "① 标题",
+            serialNumber = 18,
+        ),
+        TxtTocRule(
+            id = 19,
+            enabled = false,
+            name = "括号+中文数字",
+            pattern = "$INDENT[（\\(][$CJK_NUM_PAREN]+[）\\)].{0,30}$",
+            example = "(一) 标题",
+            serialNumber = 19,
+        ),
+        TxtTocRule(
+            id = 20,
+            enabled = true,
+            name = "Prologue/Epilogue/Interlude",
+            pattern = "$INDENT(?:[Pp]rologue|[Ee]pilogue|[Ii]nterlude|[Pp]reface|[Ff]oreword|" +
+                "[Aa]fterword|[Ii]ntroduction|[Cc]onclusion).{0,30}$",
+            example = "Prologue",
+            serialNumber = 20,
+        ),
+        TxtTocRule(
+            id = 21,
+            enabled = false,
+            name = "中文括号标题",
+            pattern = "${INDENT}〔.{1,20}〕$WS{0,4}$",
+            example = "〔一〕",
+            serialNumber = 21,
+        ),
+        TxtTocRule(
+            id = 22,
+            enabled = false,
+            name = "日文章节",
+            pattern = "${INDENT}第[$DIGIT_CHARS$CJK_NUM_JA]+?(?:章|節|巻|話|編).{0,30}$",
+            example = "第一章 始まり",
+            serialNumber = 22,
+        ),
+        TxtTocRule(
+            id = 23,
+            enabled = true,
+            name = "中文回/话",
+            pattern = "${INDENT}第$WS{0,4}[$DIGIT_CHARS$CJK_NUM]+?$WS{0,4}[回话].{0,30}$",
+            example = "第一回 标题",
+            serialNumber = 23,
+        ),
+        TxtTocRule(
+            id = 24,
+            enabled = false,
+            name = "短线分隔章节",
+            pattern = "$INDENT[—\\-]{3,}.{0,30}$",
+            example = "--- 章节标题",
+            serialNumber = 24,
+        ),
+        TxtTocRule(
+            id = 25,
+            enabled = false,
+            name = "等号分隔章节",
+            pattern = "$INDENT[=]{3,}.{0,30}$",
+            example = "=== 章节标题",
+            serialNumber = 25,
+        ),
+    )
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocRules.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocRules.kt
@@ -17,10 +17,14 @@
 //   `[Cc]hapter`-style spellings avoid. No pattern carries an inline flag either — `(?U)` in
 //   particular is banned: it would fix \d and \s but ALSO redefine \w, \b and POSIX classes.
 //
-// Known limitation: [WS] is a superset of iOS's literal `[space, U+3000, tab]` indent class and
-// includes line terminators, so at a BLANK line the leading indent can consume that line's own
-// terminator and a match can start one line early. Titles are unaffected (they are trimmed);
-// the source offset shifts to the blank line's start. Pinned by TxtTocRulesTest.
+// - The leading indent class stays iOS's LITERAL `[space, U+3000, tab]` (see [INDENT]). The
+//   plan's §3.5 asked for it to be normalized to [WS] too; that was implemented, audited, and
+//   reverted, because [WS] contains LINE TERMINATORS while iOS's indent class does not. At a
+//   blank line the widened indent consumed that line's own terminator, so a match started one
+//   line early and WI-2 would have turned a systematically-off-by-one-line offset into a
+//   navigation locator. iOS never wrote `\s` in the indent, so there is no ICU divergence to
+//   repair here — and the plan's own Appendix A.5 non-regression measurement kept this class
+//   literal, so it never covered the normalization it asked for.
 //
 // @coordinates-with: TxtTocRule.kt, TxtTocRuleEngine.kt
 package com.vreader.app.reader.nav
@@ -71,8 +75,20 @@ object TxtTocRules {
     /** Rule 19 (parenthesised) — no 〇, no 两. */
     private const val CJK_NUM_PAREN = "零一二三四五六七八九十百千万壹贰叁肆伍陆柒捌玖拾佰仟"
 
-    /** The bounded leading-indent prefix every rule shares. */
-    private const val INDENT = "^$WS{0,4}"
+    /**
+     * The bounded leading-indent prefix every rule shares — iOS's LITERAL `[space, U+3000, tab]`
+     * class, deliberately NOT widened to [WS].
+     *
+     * iOS wrote this class out by hand rather than as `\s`, so there is no ICU-vs-Java
+     * divergence to repair. Widening it would be a *new* divergence with a real cost: [WS]
+     * matches line terminators, so at a blank line the indent swallows that line's own
+     * terminator and the match — hence the heading's source offset, hence WI-2's navigation
+     * locator — starts one line early.
+     *
+     * U+3000 is built from its code point rather than written literally: an invisible character
+     * in a regex is exactly what Gate-2 rounds 3 and 4 caught being silently normalized.
+     */
+    internal val INDENT = "^[ " + Char(0x3000) + "\\t]{0,4}"
 
     // ------------------------------------------------------------------ the rules
 

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocRulesTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocRulesTest.kt
@@ -141,10 +141,11 @@ class TxtTocRulesTest {
 
     /**
      * The iOS table, transcribed INDEPENDENTLY from `TXTTocRuleEngine.swift:142-350` — id to
-     * (name, pattern body after the leading indent, example). This is the golden source: the
-     * shipped rule must round-trip back to exactly this text once the two permitted
-     * substitutions are undone. Transcribing rather than deriving is the point — a pattern and
-     * its example can otherwise drift together and still satisfy "matches its own example".
+     * (name, pattern body after the leading indent, example). This is the golden source: running
+     * [expandIosPattern] over a body must produce the shipped pattern character for character,
+     * so the ONLY permitted difference from iOS is the D1/D1b substitution. Transcribing rather
+     * than deriving is the point — a pattern and its example can otherwise drift together and
+     * still satisfy "matches its own example".
      */
     private val iosRules: Map<Int, Triple<String, String, String>> = mapOf(
         1 to Triple(
@@ -226,6 +227,21 @@ class TxtTocRulesTest {
                 IOS_INDENT + expandIosPattern(iosBody), rule.pattern,
             )
         }
+    }
+
+    @Test
+    fun theWidenedClasses_areExactlyWhatTheyClaimToBe() {
+        // Everything else in this suite states its expectations in terms of these four constants,
+        // so a consistently-wrong constant (an extra character in WS_CHARS, say) would ride
+        // through every other assertion. Pin them independently; the full-width digit bounds come
+        // from code points because they are easy to confuse with their ASCII twins by eye.
+        assertEquals("ICU \\s = [\\t\\n\\v\\f\\r\\p{Z}], plus NEL which is Cc not Z",
+            "\\s\\p{Z}\\x{0085}", TxtTocRules.WS_CHARS)
+        assertEquals("[\\s\\p{Z}\\x{0085}]", TxtTocRules.WS)
+        val fullWidthRange = Char(0xFF10).toString() + "-" + Char(0xFF19)
+        assertEquals("ASCII digits plus the full-width range ICU's \\d covers",
+            "0-9$fullWidthRange", TxtTocRules.DIGIT_CHARS)
+        assertEquals("[0-9$fullWidthRange]", TxtTocRules.DIGIT)
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocRulesTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocRulesTest.kt
@@ -38,6 +38,17 @@ class TxtTocRulesTest {
          */
         val IDEO: String = Char(0x3000).toString() // IDEOGRAPHIC SPACE
         val NBSP: String = Char(0x00A0).toString() // NO-BREAK SPACE
+
+        /** iOS's literal leading-indent class, `^[ U+3000 \t]{0,4}` (TXTTocRuleEngine.swift). */
+        val IOS_INDENT: String = "^[ " + IDEO + "\\t]{0,4}"
+
+        /**
+         * The rules that use `\d` / `\s` **in iOS**, read off the Swift source — NOT derived from
+         * the Kotlin under test. Deriving both sides from the implementation would let one wrong
+         * removal plus one wrong addition cancel out; these are the independent expectation.
+         */
+        val IOS_DIGIT_RULE_IDS = setOf(1, 2, 3, 4, 7, 9, 10, 11, 12, 13, 14, 22, 23)
+        val IOS_WHITESPACE_RULE_IDS = setOf(1, 2, 3, 6, 7, 9, 10, 11, 12, 15, 16, 17, 21, 23)
     }
 
     private val rules: List<TxtTocRule> get() = TxtTocRules.defaults
@@ -45,13 +56,24 @@ class TxtTocRulesTest {
     private fun compiled(rule: TxtTocRule) = Regex(rule.pattern, RegexOption.MULTILINE)
 
     /** The pattern with the leading indent class stripped — i.e. its non-indent body. */
-    private fun body(rule: TxtTocRule) = rule.pattern.removePrefix("^${TxtTocRules.WS}{0,4}")
+    private fun body(rule: TxtTocRule) = rule.pattern.removePrefix(TxtTocRules.INDENT)
 
     /** Rules that reference the widened digit class (the D1 population), derived from the data. */
     private fun digitRules() = rules.filter { it.pattern.contains(TxtTocRules.DIGIT_CHARS) }
 
     /** Rules with a whitespace position beyond the leading indent (the D1b population). */
     private fun whitespaceRules() = rules.filter { body(it).contains(TxtTocRules.WS_CHARS) }
+
+    /**
+     * Undo the two permitted substitutions, turning a shipped pattern back into the iOS text it
+     * was ported from. Bracketed forms are undone first so both an in-class occurrence
+     * (`[0-9…〇零…]` → `[\d〇零…]`) and a standalone one (`[0-9…]{1,4}` → `\d{1,4}`) round-trip.
+     */
+    private fun roundTripToIos(pattern: String) = pattern
+        .replace(TxtTocRules.WS, "\\s")
+        .replace(TxtTocRules.WS_CHARS, "\\s")
+        .replace(TxtTocRules.DIGIT, "\\d")
+        .replace(TxtTocRules.DIGIT_CHARS, "\\d")
 
     /** Narrow a pattern back to stock-Java semantics — the negative control. */
     private fun narrowedWhitespace(pattern: String) =
@@ -96,6 +118,113 @@ class TxtTocRulesTest {
         assertEquals("no duplicated pattern survived the port", 25, rules.map { it.pattern }.toSet().size)
     }
 
+    /**
+     * The iOS table, transcribed INDEPENDENTLY from `TXTTocRuleEngine.swift:142-350` — id to
+     * (name, pattern body after the leading indent, example). This is the golden source: the
+     * shipped rule must round-trip back to exactly this text once the two permitted
+     * substitutions are undone. Transcribing rather than deriving is the point — a pattern and
+     * its example can otherwise drift together and still satisfy "matches its own example".
+     */
+    private val iosRules: Map<Int, Triple<String, String, String>> = mapOf(
+        1 to Triple(
+            "中文章节（通用）",
+            "(?:序章|楔子|正文(?!完|结)|终章|后记|尾声|番外|第\\s{0,4}" +
+                "[\\d〇零一二两三四五六七八九十百千万壹贰叁肆伍陆柒捌玖拾佰仟]+?\\s{0,4}" +
+                "(?:章|节(?!课)|卷|集(?![合和])|部(?![分赛游])|篇(?!张))).{0,30}$",
+            "第一章 标题",
+        ),
+        2 to Triple(
+            "中文数字章节",
+            "[第（\\(]?\\s{0,4}[\\d〇零一二两三四五六七八九十百千万壹贰叁肆伍陆柒捌玖拾佰仟]+?" +
+                "\\s{0,4}[章节卷集部篇回话]\\s?.{0,30}$",
+            "第123章 标题",
+        ),
+        3 to Triple(
+            "英文Chapter/Section/Part",
+            "(?:[Cc]hapter|[Ss]ection|[Pp]art|[Ee]pisode)\\s{0,4}\\d{1,4}.{0,30}$",
+            "Chapter 1 Title",
+        ),
+        4 to Triple("数字+标点标题", "\\d{1,5}[：:,.， 、_—\\-].{1,30}$", "1、这个标题"),
+        5 to Triple("特殊符号·章节", "[【\\[☆★●◆◇○◎□■△▲※卐].{1,30}$", "【第一章 标题】"),
+        6 to Triple("正文+标题", "正文\\s.{0,20}$", "正文 第一章"),
+        7 to Triple(
+            "中文卷/篇/部/集",
+            "(?:卷|篇|部|集)\\s{0,4}[\\d〇零一二两三四五六七八九十百千万壹贰叁肆伍陆柒捌玖拾佰仟]+.{0,30}$",
+            "卷五 开源盛世",
+        ),
+        8 to Triple("星号标题", "[☆★].{1,30}$", "☆、第一个故事"),
+        9 to Triple("Volume + Number", "[Vv]ol(?:ume)?\\s{0,4}\\d{1,4}.{0,30}$", "Volume 1 Title"),
+        10 to Triple("Book + Number", "[Bb]ook\\s{0,4}\\d{1,4}.{0,30}$", "Book 1 Title"),
+        11 to Triple("Act + Number", "[Aa]ct\\s{0,4}\\d{1,4}.{0,30}$", "Act 1 Title"),
+        12 to Triple("Scene + Number", "[Ss]cene\\s{0,4}\\d{1,4}.{0,30}$", "Scene 1 Title"),
+        13 to Triple("数字序号（圆括号）", "[\\(（]\\d{1,5}[\\)）].{1,30}$", "(1) 标题"),
+        14 to Triple("数字序号（点号）", "\\d{1,5}\\..{1,30}$", "1.标题"),
+        15 to Triple(
+            "罗马数字章节",
+            "(?:I{1,3}|IV|VI{0,3}|IX|XI{0,3}|XIV|XVI{0,3}|XIX|XXI{0,3})[.、：:\\s].{0,30}$",
+            "III. 标题",
+        ),
+        16 to Triple("天干地支", "[甲乙丙丁戊己庚辛壬癸][.、：:\\s].{0,30}$", "甲、标题"),
+        17 to Triple("全角数字章节", "[０-９]{1,5}[.、：:\\s].{0,30}$", "０１、标题"),
+        18 to Triple("圆圈数字", "[①②③④⑤⑥⑦⑧⑨⑩⑪⑫⑬⑭⑮⑯⑰⑱⑲⑳].{0,30}$", "① 标题"),
+        19 to Triple(
+            "括号+中文数字",
+            "[（\\(][零一二三四五六七八九十百千万壹贰叁肆伍陆柒捌玖拾佰仟]+[）\\)].{0,30}$",
+            "(一) 标题",
+        ),
+        20 to Triple(
+            "Prologue/Epilogue/Interlude",
+            "(?:[Pp]rologue|[Ee]pilogue|[Ii]nterlude|[Pp]reface|[Ff]oreword|[Aa]fterword|" +
+                "[Ii]ntroduction|[Cc]onclusion).{0,30}$",
+            "Prologue",
+        ),
+        21 to Triple("中文括号标题", "〔.{1,20}〕\\s{0,4}$", "〔一〕"),
+        22 to Triple(
+            "日文章节",
+            "第[\\d〇零一二三四五六七八九十百千万]+?(?:章|節|巻|話|編).{0,30}$",
+            "第一章 始まり",
+        ),
+        23 to Triple(
+            "中文回/话",
+            "第\\s{0,4}[\\d〇零一二两三四五六七八九十百千万壹贰叁肆伍陆柒捌玖拾佰仟]+?\\s{0,4}[回话].{0,30}$",
+            "第一回 标题",
+        ),
+        24 to Triple("短线分隔章节", "[—\\-]{3,}.{0,30}$", "--- 章节标题"),
+        25 to Triple("等号分隔章节", "[=]{3,}.{0,30}$", "=== 章节标题"),
+    )
+
+    @Test
+    fun everyRule_roundTripsToTheIosPatternExactly() {
+        assertEquals("the golden table covers all 25 iOS rules", 25, iosRules.size)
+        rules.forEach { rule ->
+            val (name, iosBody, example) = iosRules.getValue(rule.id)
+            assertEquals("rule ${rule.id} name", name, rule.name)
+            assertEquals("rule ${rule.id} example", example, rule.example)
+            assertEquals(
+                "rule ${rule.id} must differ from iOS ONLY by the D1/D1b substitutions",
+                IOS_INDENT + iosBody, roundTripToIos(rule.pattern),
+            )
+        }
+    }
+
+    @Test
+    fun everyRule_keepsTheLiteralIosIndentClass() {
+        // The indent is the one whitespace position iOS did NOT write as \s, so widening it
+        // would be a NEW divergence, not a repair — and one that shifts heading offsets onto the
+        // preceding blank line. Pinned so the plan's §3.5 wording cannot reintroduce it.
+        assertEquals("INDENT is iOS's literal class", IOS_INDENT, TxtTocRules.INDENT)
+        rules.forEach {
+            assertTrue(
+                "rule ${it.id} must start with the literal indent class, not a widened one",
+                it.pattern.startsWith(IOS_INDENT),
+            )
+            assertFalse(
+                "rule ${it.id} must not widen the indent to WS",
+                it.pattern.startsWith("^${TxtTocRules.WS}"),
+            )
+        }
+    }
+
     @Test
     fun everyRule_compiles_underMultiline() {
         rules.forEach { assertNotNull("rule ${it.id} compiles", compiled(it)) }
@@ -132,10 +261,13 @@ class TxtTocRulesTest {
         )
         val population = digitRules()
         assertEquals(
-            "the D1 sample table must cover EVERY rule using the digit class (incl. disabled 11/12/22)",
-            population.map { it.id }.toSet(), samples.keys,
+            "the shipped rules must widen \\d in EXACTLY the rules iOS wrote it in",
+            IOS_DIGIT_RULE_IDS, population.map { it.id }.toSet(),
         )
-        assertEquals("13 of the 25 rules use \\d on iOS", 13, population.size)
+        assertEquals(
+            "the D1 sample table must cover EVERY such rule (incl. disabled 11/12/22)",
+            IOS_DIGIT_RULE_IDS, samples.keys,
+        )
 
         population.forEach { rule ->
             val sample = samples.getValue(rule.id)
@@ -186,10 +318,13 @@ class TxtTocRulesTest {
     private fun assertWhitespaceSamples(samples: Map<Int, String>, label: String) {
         val population = whitespaceRules()
         assertEquals(
-            "the D1b sample table must cover EVERY rule with a \\s position (incl. disabled 11/12/15/16/17/21)",
-            population.map { it.id }.toSet(), samples.keys,
+            "the shipped rules must widen \\s in EXACTLY the rules iOS wrote it in",
+            IOS_WHITESPACE_RULE_IDS, population.map { it.id }.toSet(),
         )
-        assertEquals("14 of the 25 rules use \\s on iOS", 14, population.size)
+        assertEquals(
+            "the D1b sample table must cover EVERY such rule (incl. disabled 11/12/15/16/17/21)",
+            IOS_WHITESPACE_RULE_IDS, samples.keys,
+        )
 
         population.forEach { rule ->
             val sample = samples.getValue(rule.id)
@@ -242,10 +377,32 @@ class TxtTocRulesTest {
         }
     }
 
-    /** The flag letters of every inline flag group `(?idmsuxU…)` in a pattern; empty when none. */
+    /**
+     * The flag letters of every inline flag group in a pattern; empty when none.
+     *
+     * A deliberately simple textual scan of the conventional Java forms — `(?i)`, `(?i:…)`,
+     * `(?i-m)`, `(?idmsux)` — not a regex parser. That is sufficient here because these patterns
+     * are a fixed, reviewed data table, and [noRule_containsAnyForbiddenFlagToken] backstops it
+     * with a blunt token check that cannot be out-parsed.
+     */
     private fun inlineFlags(pattern: String): String =
         Regex("""\(\?(?![:=!<>])([a-zA-Z-]*)[:)]""").findAll(pattern)
             .joinToString("") { it.groupValues[1] }
+
+    @Test
+    fun noRule_containsAnyForbiddenFlagToken() {
+        // Backstop for inlineFlags(): whatever the exact syntax, a flag group must begin with
+        // "(?" followed by a flag letter. No rule may contain that sequence at all.
+        val forbidden = listOf("(?i", "(?s", "(?m", "(?u", "(?U", "(?x", "(?d", "(?-")
+        rules.forEach { rule ->
+            forbidden.forEach { token ->
+                assertFalse(
+                    "rule ${rule.id} must not contain the inline-flag token '$token'",
+                    rule.pattern.contains(token),
+                )
+            }
+        }
+    }
 
     @Test
     fun noRule_containsBareBackslashD_orBackslashS() {
@@ -288,18 +445,27 @@ class TxtTocRulesTest {
     }
 
     @Test
-    fun leadingWs_widenedPerPlan_consumesAPrecedingBlankLineTerminator() {
-        // DOCUMENTED CONSEQUENCE of plan §3.5's "the leading [space, U+3000, tab]{0,4} indent
-        // class is normalized to WS{0,4}": WS is a superset that includes line terminators, so at
-        // a BLANK line the indent can consume that line's own terminator and the match starts one
-        // line early. Titles are unaffected (they are trimmed), but the reported source offset is
-        // the blank line's start. Pinned here so WI-2's offset tests inherit a known value rather
-        // than a surprise.
+    fun headingAfterBlankLines_matchesAtTheHeadingLine_notTheBlankLine() {
+        // The regression behind the reverted indent widening (Gate-4 HIGH). Blank lines before a
+        // chapter heading are ubiquitous in real books; a widened indent would consume the blank
+        // line's own terminator and start the match there, so every such heading's source offset
+        // — WI-2's navigation locator — would land one line early.
         val rule1 = rules.first { it.id == 1 }
-        val match = compiled(rule1).find("\n第一章 标题")
-        assertNotNull(match)
-        assertEquals("match starts at the blank line, not the heading line", 0, match!!.range.first)
-        assertEquals("the title is unaffected once trimmed", "第一章 标题", match.value.trim())
+        listOf("\n", "\n\n", "\r\n\r\n").forEach { blanks ->
+            val match = compiled(rule1).find(blanks + "第一章 标题")
+            assertNotNull("rule 1 still matches after blank lines", match)
+            assertEquals(
+                "the match must start AT the heading, not at the preceding blank line",
+                blanks.length, match!!.range.first,
+            )
+            assertEquals("第一章 标题", match.value)
+        }
+        // …and a genuine in-line indent is still consumed, exactly as iOS does it.
+        // Braced: a CJK letter is a valid Kotlin identifier character, so `$IDEO第一章` would
+        // parse as the identifier `IDEO第一章`.
+        val indented = compiled(rule1).find("\n$IDEO${IDEO}第一章 标题")
+        assertNotNull(indented)
+        assertEquals("the U+3000 indent is part of the match, as on iOS", 1, indented!!.range.first)
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocRulesTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocRulesTest.kt
@@ -65,15 +65,36 @@ class TxtTocRulesTest {
     private fun whitespaceRules() = rules.filter { body(it).contains(TxtTocRules.WS_CHARS) }
 
     /**
-     * Undo the two permitted substitutions, turning a shipped pattern back into the iOS text it
-     * was ported from. Bracketed forms are undone first so both an in-class occurrence
-     * (`[0-9…〇零…]` → `[\d〇零…]`) and a standalone one (`[0-9…]{1,4}` → `\d{1,4}`) round-trip.
+     * Apply the two permitted substitutions to an iOS pattern, producing the EXACT pattern
+     * Android must ship. Forward and context-aware, deliberately not a reverse normalization:
+     * undoing the substitutions is not injective (bracketed `[0-9０-９]` and bare `0-9０-９` both
+     * reverse to `\d`), so a pattern that spliced a class where only its contents belong — e.g.
+     * `\s\p{Z}\x{0085}{0,4}` outside a class, which is a literal sequence and not whitespace at
+     * all — would reverse cleanly and pass while behaving nothing like iOS.
+     *
+     * `\d` / `\s` INSIDE a character class expand to the class CONTENTS; outside, to the whole
+     * bracketed class. Escapes are skipped, so `\[` and `\-` do not affect class tracking.
      */
-    private fun roundTripToIos(pattern: String) = pattern
-        .replace(TxtTocRules.WS, "\\s")
-        .replace(TxtTocRules.WS_CHARS, "\\s")
-        .replace(TxtTocRules.DIGIT, "\\d")
-        .replace(TxtTocRules.DIGIT_CHARS, "\\d")
+    private fun expandIosPattern(iosPattern: String): String = buildString {
+        var i = 0
+        var inClass = false
+        while (i < iosPattern.length) {
+            val c = iosPattern[i]
+            when {
+                c == '\\' && i + 1 < iosPattern.length -> {
+                    when (val escaped = iosPattern[i + 1]) {
+                        'd' -> append(if (inClass) TxtTocRules.DIGIT_CHARS else TxtTocRules.DIGIT)
+                        's' -> append(if (inClass) TxtTocRules.WS_CHARS else TxtTocRules.WS)
+                        else -> append(c).append(escaped)
+                    }
+                    i += 2
+                }
+                c == '[' && !inClass -> { inClass = true; append(c); i++ }
+                c == ']' && inClass -> { inClass = false; append(c); i++ }
+                else -> { append(c); i++ }
+            }
+        }
+    }
 
     /** Narrow a pattern back to stock-Java semantics — the negative control. */
     private fun narrowedWhitespace(pattern: String) =
@@ -194,17 +215,30 @@ class TxtTocRulesTest {
     )
 
     @Test
-    fun everyRule_roundTripsToTheIosPatternExactly() {
+    fun everyRule_isTheIosPatternWithOnlyTheD1AndD1bSubstitutions() {
         assertEquals("the golden table covers all 25 iOS rules", 25, iosRules.size)
         rules.forEach { rule ->
             val (name, iosBody, example) = iosRules.getValue(rule.id)
             assertEquals("rule ${rule.id} name", name, rule.name)
             assertEquals("rule ${rule.id} example", example, rule.example)
             assertEquals(
-                "rule ${rule.id} must differ from iOS ONLY by the D1/D1b substitutions",
-                IOS_INDENT + iosBody, roundTripToIos(rule.pattern),
+                "rule ${rule.id} must be iOS's pattern with ONLY the D1/D1b substitutions applied",
+                IOS_INDENT + expandIosPattern(iosBody), rule.pattern,
             )
         }
+    }
+
+    @Test
+    fun expandIosPattern_isContextAware() {
+        // Guards the guard: the fidelity test is only as good as this expansion, so pin the two
+        // contexts and the escape handling it has to get right.
+        assertEquals("[.、：:${TxtTocRules.WS_CHARS}]", expandIosPattern("[.、：:\\s]"))
+        assertEquals("${TxtTocRules.WS}{0,4}", expandIosPattern("\\s{0,4}"))
+        assertEquals("[${TxtTocRules.DIGIT_CHARS}〇]", expandIosPattern("[\\d〇]"))
+        assertEquals("${TxtTocRules.DIGIT}{1,4}", expandIosPattern("\\d{1,4}"))
+        // An escaped bracket must not open or close a class.
+        assertEquals("[\\[x]${TxtTocRules.WS}", expandIosPattern("[\\[x]\\s"))
+        assertEquals("[a\\-b]${TxtTocRules.DIGIT}", expandIosPattern("[a\\-b]\\d"))
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocRulesTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocRulesTest.kt
@@ -1,0 +1,316 @@
+package com.vreader.app.reader.nav
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Feature #139 WI-1 — [TxtTocRules]: the 25 TXT chapter-detection rules ported from iOS
+ * (`vreader/Services/TXT/TXTTocRuleEngine.swift:142-350`, itself a Legado `txtTocRule.json` port).
+ *
+ * Two porting traps this suite exists to pin (plan §3.5), both **CJK-critical** and both
+ * asserted over ALL 25 rules — including the 11 that ship disabled — so enabling a rule
+ * later cannot resurrect a divergence:
+ *
+ * - **D1** — ICU (iOS) `\d` matches Unicode `Nd` (so full-width digits); `java.util.regex` `\d`
+ *   is ASCII-only. Every `\d` becomes the explicit class [TxtTocRules.DIGIT].
+ * - **D1b** — ICU `\s` covers `\p{Z}` (U+3000 IDEOGRAPHIC SPACE, NBSP, U+2028/29); Java's
+ *   `\s` is `[ \t\n\x0B\f\r]`. Every whitespace position becomes [TxtTocRules.WS].
+ *
+ * Each divergence test carries its own **negative control**: the same pattern with the
+ * widened class narrowed back to bare `\d` / `\s` must NOT match, proving the assertion is
+ * load-bearing rather than vacuously true.
+ *
+ * Pure JVM — no Android runtime, no Robolectric.
+ */
+class TxtTocRulesTest {
+
+    private companion object {
+        /**
+         * The two separators the D1b regression turns on, built from their CODE POINTS.
+         *
+         * Never write them as literal characters: Gate-2 rounds 3 and 4 each caught an NBSP
+         * that copy-paste had silently normalized to an ASCII space, which turns a divergence
+         * regression into a vacuous pass. An integer code point is pure ASCII in the source and
+         * cannot be mangled by re-encoding.
+         */
+        val IDEO: String = Char(0x3000).toString() // IDEOGRAPHIC SPACE
+        val NBSP: String = Char(0x00A0).toString() // NO-BREAK SPACE
+    }
+
+    private val rules: List<TxtTocRule> get() = TxtTocRules.defaults
+
+    private fun compiled(rule: TxtTocRule) = Regex(rule.pattern, RegexOption.MULTILINE)
+
+    /** The pattern with the leading indent class stripped — i.e. its non-indent body. */
+    private fun body(rule: TxtTocRule) = rule.pattern.removePrefix("^${TxtTocRules.WS}{0,4}")
+
+    /** Rules that reference the widened digit class (the D1 population), derived from the data. */
+    private fun digitRules() = rules.filter { it.pattern.contains(TxtTocRules.DIGIT_CHARS) }
+
+    /** Rules with a whitespace position beyond the leading indent (the D1b population). */
+    private fun whitespaceRules() = rules.filter { body(it).contains(TxtTocRules.WS_CHARS) }
+
+    /** Narrow a pattern back to stock-Java semantics — the negative control. */
+    private fun narrowedWhitespace(pattern: String) =
+        pattern.replace(TxtTocRules.WS, "\\s").replace(TxtTocRules.WS_CHARS, "\\s")
+
+    private fun narrowedDigits(pattern: String) = pattern.replace(TxtTocRules.DIGIT_CHARS, "\\d")
+
+    // ---------------------------------------------------------------- structure / fidelity
+
+    @Test
+    fun defaults_containsAll25Rules_inSerialNumberOrder() {
+        assertEquals("all 25 iOS rules are ported", 25, rules.size)
+        assertEquals((1..25).toList(), rules.map { it.id })
+        assertEquals(
+            "serialNumber == id on iOS, and list order IS tie-break order",
+            (1..25).toList(), rules.map { it.serialNumber },
+        )
+        rules.forEach {
+            assertTrue("rule ${it.id} has a name", it.name.isNotBlank())
+            assertTrue("rule ${it.id} has an example", it.example.isNotBlank())
+            assertTrue("rule ${it.id} has a pattern", it.pattern.isNotBlank())
+        }
+    }
+
+    @Test
+    fun defaults_enabledIdsAreExactly_1_2_3_4_5_6_7_8_9_10_13_14_20_23() {
+        // Pins the iOS DATA (TXTTocRuleEngine.swift:142-350, broadened by bug #83), NOT the
+        // stale iOS header comment at :27 which still claims "8 enabled".
+        assertEquals(
+            listOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 13, 14, 20, 23),
+            rules.filter { it.enabled }.map { it.id },
+        )
+        assertEquals(
+            listOf(11, 12, 15, 16, 17, 18, 19, 21, 22, 24, 25),
+            rules.filterNot { it.enabled }.map { it.id },
+        )
+    }
+
+    @Test
+    fun ids_andPatterns_areUnique() {
+        assertEquals(25, rules.map { it.id }.toSet().size)
+        assertEquals("no duplicated pattern survived the port", 25, rules.map { it.pattern }.toSet().size)
+    }
+
+    @Test
+    fun everyRule_compiles_underMultiline() {
+        rules.forEach { assertNotNull("rule ${it.id} compiles", compiled(it)) }
+    }
+
+    @Test
+    fun everyRule_matchesItsOwnExample() {
+        rules.forEach {
+            assertTrue(
+                "rule ${it.id} (${it.name}) must match its own example '${it.example}'",
+                compiled(it).containsMatchIn(it.example),
+            )
+        }
+    }
+
+    // ---------------------------------------------------------------- D1 — full-width digits
+
+    @Test
+    fun fullWidthDigits_matchOnJavaRegex() {
+        val samples = mapOf(
+            1 to "第１２章 全角数字",
+            2 to "第１２３章 标题",
+            3 to "Chapter １ Title",
+            4 to "１、这个标题",
+            7 to "卷５ 开源盛世",
+            9 to "Volume １ Title",
+            10 to "Book １ Title",
+            11 to "Act １ Title",
+            12 to "Scene １ Title",
+            13 to "(１) 标题",
+            14 to "１.标题",
+            22 to "第１章 始まり",
+            23 to "第１回 标题",
+        )
+        val population = digitRules()
+        assertEquals(
+            "the D1 sample table must cover EVERY rule using the digit class (incl. disabled 11/12/22)",
+            population.map { it.id }.toSet(), samples.keys,
+        )
+        assertEquals("13 of the 25 rules use \\d on iOS", 13, population.size)
+
+        population.forEach { rule ->
+            val sample = samples.getValue(rule.id)
+            assertTrue(
+                "rule ${rule.id} must match full-width digits on java.util.regex: '$sample'",
+                compiled(rule).containsMatchIn(sample),
+            )
+            assertFalse(
+                "negative control: bare \\d must NOT match '$sample' (rule ${rule.id})",
+                Regex(narrowedDigits(rule.pattern), RegexOption.MULTILINE).containsMatchIn(sample),
+            )
+        }
+    }
+
+    // ---------------------------------------------------------------- D1b — widened whitespace
+
+    /** U+3000 IDEOGRAPHIC SPACE separators; the NBSP variants are derived by substitution. */
+    private val ideographicSamples = mapOf(
+        1 to "第${IDEO}一${IDEO}章 标题",
+        2 to "第${IDEO}一${IDEO}章 标题",
+        3 to "Chapter${IDEO}1 Title",
+        6 to "正文${IDEO}第一章",
+        7 to "卷${IDEO}五 开源盛世",
+        9 to "Volume${IDEO}1 Title",
+        10 to "Book${IDEO}1 Title",
+        11 to "Act${IDEO}1 Title",
+        12 to "Scene${IDEO}1 Title",
+        15 to "III${IDEO}标题",
+        16 to "甲${IDEO}标题",
+        17 to "０１${IDEO}标题",
+        21 to "〔一〕$IDEO",
+        23 to "第${IDEO}一${IDEO}回 标题",
+    )
+
+    @Test
+    fun ideographicSpaceSeparator_matchesOnJavaRegex() {
+        assertWhitespaceSamples(ideographicSamples, "U+3000")
+    }
+
+    @Test
+    fun nbspSeparator_matchesOnJavaRegex() {
+        assertWhitespaceSamples(
+            ideographicSamples.mapValues { (_, sample) -> sample.replace(IDEO, NBSP) },
+            "U+00A0",
+        )
+    }
+
+    private fun assertWhitespaceSamples(samples: Map<Int, String>, label: String) {
+        val population = whitespaceRules()
+        assertEquals(
+            "the D1b sample table must cover EVERY rule with a \\s position (incl. disabled 11/12/15/16/17/21)",
+            population.map { it.id }.toSet(), samples.keys,
+        )
+        assertEquals("14 of the 25 rules use \\s on iOS", 14, population.size)
+
+        population.forEach { rule ->
+            val sample = samples.getValue(rule.id)
+            assertTrue(
+                "rule ${rule.id} must accept a $label separator: '$sample'",
+                compiled(rule).containsMatchIn(sample),
+            )
+            assertFalse(
+                "negative control: bare \\s must NOT match the $label sample (rule ${rule.id})",
+                Regex(narrowedWhitespace(rule.pattern), RegexOption.MULTILINE).containsMatchIn(sample),
+            )
+        }
+    }
+
+    // ---------------------------------------------------------------- banned constructs
+
+    @Test
+    fun noRule_setsDotMatchesAll() {
+        // The bounded `.{0,30}$` tail is what confines a title to ONE line; DOTALL would let a
+        // "title" swallow the chapter. No rule may enable it via an inline flag.
+        rules.forEach {
+            assertFalse("rule ${it.id} must not enable DOTALL inline", inlineFlags(it.pattern).contains('s'))
+        }
+    }
+
+    @Test
+    fun noRule_setsIgnoreCase() {
+        // The rules spell both cases explicitly ([Cc]hapter), which avoids non-ASCII case-folding
+        // divergence between ICU and Java entirely. IGNORE_CASE would reintroduce it.
+        rules.forEach {
+            assertFalse("rule ${it.id} must not enable IGNORE_CASE inline", inlineFlags(it.pattern).contains('i'))
+        }
+        listOf(3 to "[Cc]hapter", 9 to "[Vv]ol", 10 to "[Bb]ook", 20 to "[Pp]rologue").forEach { (id, spelling) ->
+            assertTrue(
+                "rule $id spells both cases explicitly instead of relying on a flag",
+                rules.first { it.id == id }.pattern.contains(spelling),
+            )
+        }
+    }
+
+    @Test
+    fun noRule_usesUnicodeCharacterClassFlag() {
+        // (?U) would fix \d and \s in one stroke but ALSO redefines \w, \b, POSIX classes and
+        // case folding. The surgical explicit classes are the fix (plan §3.5 "Why not (?U)").
+        rules.forEach {
+            assertTrue(
+                "rule ${it.id} must not carry ANY inline flag group (found '${inlineFlags(it.pattern)}')",
+                inlineFlags(it.pattern).isEmpty(),
+            )
+        }
+    }
+
+    /** The flag letters of every inline flag group `(?idmsuxU…)` in a pattern; empty when none. */
+    private fun inlineFlags(pattern: String): String =
+        Regex("""\(\?(?![:=!<>])([a-zA-Z-]*)[:)]""").findAll(pattern)
+            .joinToString("") { it.groupValues[1] }
+
+    @Test
+    fun noRule_containsBareBackslashD_orBackslashS() {
+        rules.forEach {
+            val outsideWidenedClasses = it.pattern
+                .replace(TxtTocRules.WS, "")
+                .replace(TxtTocRules.WS_CHARS, "")
+                .replace(TxtTocRules.DIGIT_CHARS, "")
+            assertFalse("rule ${it.id} still has a bare \\d — D1 unfixed", outsideWidenedClasses.contains("\\d"))
+            assertFalse("rule ${it.id} still has a bare \\s — D1b unfixed", outsideWidenedClasses.contains("\\s"))
+        }
+    }
+
+    // ---------------------------------------------------------------- edge cases
+
+    @Test
+    fun emptyText_matchesNoRule() {
+        rules.forEach { assertFalse("rule ${it.id} must not match empty text", compiled(it).containsMatchIn("")) }
+    }
+
+    @Test
+    fun everyRulesExample_anchorsUnderLf_crlf_andCr() {
+        listOf("\n", "\r\n", "\r").forEach { eol ->
+            rules.forEach { rule ->
+                val text = "prose$eol${rule.example}${eol}prose"
+                val match = compiled(rule).find(text)
+                assertNotNull("rule ${rule.id} must still match with ${eolName(eol)} endings", match)
+                assertEquals(
+                    "rule ${rule.id}: the ${eolName(eol)} match must be the heading LINE, not a run-on",
+                    rule.example.trim(), match!!.value.trim(),
+                )
+            }
+        }
+    }
+
+    private fun eolName(eol: String) = when (eol) {
+        "\n" -> "LF"
+        "\r\n" -> "CRLF"
+        else -> "CR"
+    }
+
+    @Test
+    fun leadingWs_widenedPerPlan_consumesAPrecedingBlankLineTerminator() {
+        // DOCUMENTED CONSEQUENCE of plan §3.5's "the leading [space, U+3000, tab]{0,4} indent
+        // class is normalized to WS{0,4}": WS is a superset that includes line terminators, so at
+        // a BLANK line the indent can consume that line's own terminator and the match starts one
+        // line early. Titles are unaffected (they are trimmed), but the reported source offset is
+        // the blank line's start. Pinned here so WI-2's offset tests inherit a known value rather
+        // than a surprise.
+        val rule1 = rules.first { it.id == 1 }
+        val match = compiled(rule1).find("\n第一章 标题")
+        assertNotNull(match)
+        assertEquals("match starts at the blank line, not the heading line", 0, match!!.range.first)
+        assertEquals("the title is unaffected once trimmed", "第一章 标题", match.value.trim())
+    }
+
+    @Test
+    fun pathologicalNumeralRun_terminatesQuickly() {
+        // R4 (ReDoS): 2 000 consecutive CJK numerals with no unit character. The bounded
+        // `.{0,30}$` tail keeps the search space small — measured at ~1 ms (plan Appendix A.3).
+        val pathological = "第" + "一".repeat(2000) + "的故事没有章字"
+        val started = System.nanoTime()
+        val found = compiled(rules.first { it.id == 1 }).containsMatchIn(pathological)
+        val elapsedMs = (System.nanoTime() - started) / 1_000_000
+        assertFalse("no unit character, so no match", found)
+        assertTrue("rule 1 must not backtrack catastrophically (took ${elapsedMs}ms)", elapsedMs < 5_000)
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.20.14
-versionCode=167
+versionName=0.20.15
+versionCode=168

--- a/dev-docs/benchmarks/feature-139/DigitTest.java
+++ b/dev-docs/benchmarks/feature-139/DigitTest.java
@@ -1,0 +1,16 @@
+import java.util.regex.*;
+public class DigitTest {
+  public static void main(String[] x){
+    String fw = "第１２章　全角数字";
+    System.out.println("java \\d on fullwidth: " + Pattern.compile("第[\\d]+章").matcher(fw).find());
+    System.out.println("java \\d +U flag     : " + Pattern.compile("(?U)第[\\d]+章").matcher(fw).find());
+    System.out.println("explicit 0-9０-９    : " + Pattern.compile("第[0-9０-９]+章").matcher(fw).find());
+    StringBuilder sb = new StringBuilder("第");
+    for (int i = 0; i < 2000; i++) sb.append("一");
+    sb.append("的故事没有章字");
+    String p = "^[ 　\t]{0,4}(?:第\\s{0,4}[\\d一二三十百千万]+?\\s{0,4}(?:章|节)).{0,30}$";
+    long t0 = System.nanoTime();
+    boolean f = Pattern.compile(p, Pattern.MULTILINE).matcher(sb).find();
+    System.out.println("ReDoS probe(2000 numerals) found=" + f + " ms=" + (System.nanoTime()-t0)/1_000_000);
+  }
+}

--- a/dev-docs/benchmarks/feature-139/HeadScan.java
+++ b/dev-docs/benchmarks/feature-139/HeadScan.java
@@ -1,0 +1,39 @@
+import java.nio.file.*; import java.nio.charset.*;
+
+public class HeadScan {
+    static boolean isCjkNum(char c) { return "零〇一二三四五六七八九十百千万两".indexOf(c) >= 0; }
+    static boolean isAsciiDigit(char c) { return c >= '0' && c <= '9'; }
+    static boolean isFullWidthDigit(char c) { return c >= '０' && c <= '９'; }
+
+    public static void main(String[] args) throws Exception {
+        String text = new String(Files.readAllBytes(Paths.get(args[0])), "UTF-16");
+        int n = text.length();
+        int[] starts = new int[1024]; int count = 0; starts[count++] = 0;
+        for (int i = 0; i < n; ) {
+            char c = text.charAt(i);
+            if (c == '\n') { i++; if (i < n) { if (count == starts.length) starts = java.util.Arrays.copyOf(starts, starts.length*2); starts[count++] = i; } }
+            else if (c == '\r') { i++; if (i < n && text.charAt(i)=='\n') i++;
+                if (i < n) { if (count == starts.length) starts = java.util.Arrays.copyOf(starts, starts.length*2); starts[count++] = i; } }
+            else i++;
+        }
+        System.out.println("line starts = " + count);
+        for (int rep = 0; rep < 3; rep++) {
+            long s0 = System.nanoTime(); int hits = 0; final int PREFIX = 64;
+            for (int li = 0; li < count; li++) {
+                int st = starts[li], end = (li + 1 < count) ? starts[li+1] : n, p = st;
+                while (p < end && (text.charAt(p)==' '||text.charAt(p)=='\t'||text.charAt(p)=='　')) p++;
+                if (p >= end) continue;
+                char c0 = text.charAt(p);
+                if (c0 != '第' && c0 != '#') continue;
+                int lineEnd = Math.min(end, p + PREFIX);
+                if (c0 == '第') {
+                    int q = p + 1, numLen = 0;
+                    while (q < lineEnd && (isCjkNum(text.charAt(q)) || isAsciiDigit(text.charAt(q)) || isFullWidthDigit(text.charAt(q)))) { q++; numLen++; }
+                    if (numLen > 0 && q < lineEnd) { char u = text.charAt(q);
+                        if (u=='章'||u=='节'||u=='卷'||u=='回'||u=='部'||u=='篇') hits++; }
+                } else hits++;
+            }
+            System.out.println("rep " + rep + ": headings = " + hits + "  scan ms = " + (System.nanoTime()-s0)/1_000_000);
+        }
+    }
+}

--- a/dev-docs/benchmarks/feature-139/README.md
+++ b/dev-docs/benchmarks/feature-139/README.md
@@ -1,0 +1,96 @@
+# Feature #139 — Gate-1 measurement probes (TXT/MD auto-generated Contents)
+
+The four standalone Java programs behind every number in
+`dev-docs/plans/20260804-feature-139-android-txt-md-toc.md` §5 and §3.5, committed by WI-1 so the
+plan's evidence is reproducible instead of merely quoted. They are **historical evidence, not
+build inputs** — nothing in `android/` compiles or runs them, and no Gradle source set includes
+this directory.
+
+| File | Plan appendix | Answers |
+| --- | --- | --- |
+| `RuleScan.java` | A.1 | Port-fidelity + cost: runs the 14 iOS-enabled rules over the real 14 MB CJK book — detection over the 512 K sample, extraction over the full text. |
+| `HeadScan.java` | A.2 | Independent cross-validation of the entry count by a regex-free prefix scanner. |
+| `DigitTest.java` | A.3 | The **D1** divergence (Java `\d` vs ICU `\d`) and the R4 ReDoS bound. |
+| `WsTest.java` | A.4 | The **D1b** divergence (Java `\s` vs ICU `\s`) on U+3000 and NBSP. |
+
+## Running them
+
+JDK 17 (`/opt/homebrew/opt/openjdk@17` on this machine). Compile out-of-tree so no `.class`
+files land in the repo:
+
+```bash
+javac -encoding UTF-8 -d /tmp/f139 dev-docs/benchmarks/feature-139/*.java
+
+java -cp /tmp/f139 DigitTest
+java -cp /tmp/f139 WsTest
+java -Xmx1g -cp /tmp/f139 RuleScan test-books/books/txt/黑暗血时代.txt
+java -Xmx1g -cp /tmp/f139 HeadScan test-books/books/txt/黑暗血时代.txt
+```
+
+`test-books/` is gitignored and local-only, so the two book-scale probes only run on a machine
+that has the fixture; `DigitTest` and `WsTest` are self-contained and run anywhere.
+
+## Output reproduced by WI-1 (2026-08-04, JDK 17, Apple silicon)
+
+```
+$ java -cp /tmp/f139 DigitTest
+java \d on fullwidth: false      <- the D1 divergence
+java \d +U flag     : true       <- ICU semantics
+explicit 0-9０-９    : true       <- the D1 fix, shipped as TxtTocRules.DIGIT
+ReDoS probe(2000 numerals) found=false ms=1   <- the R4 bound
+
+$ java -cp /tmp/f139 WsTest
+java \s  + U+3000 -> false       <- the D1b divergence (CJK-critical)
+java \s  + U+00A0 -> false
+WS class + U+3000  -> true       <- the D1b fix, shipped as TxtTocRules.WS
+WS class + U+00A0  -> true
+separators tested: U+3000 and U+00A0
+
+$ java -Xmx1g -cp /tmp/f139 RuleScan test-books/books/txt/黑暗血时代.txt
+decoded as UTF-16
+chars = 7029609
+rep0 DETECT best=1 matches=171 ms=80
+  EXTRACT entries=1859 ms=23 firstOffset=20 first='　　第一章　太阳消失' last='　　第一千八百六十章 左旋封锁'
+rep1 DETECT best=1 matches=171 ms=24
+  EXTRACT entries=1859 ms=22 …
+rep2 DETECT best=1 matches=171 ms=24
+  EXTRACT entries=1859 ms=22 …
+
+$ java -Xmx1g -cp /tmp/f139 HeadScan test-books/books/txt/黑暗血时代.txt
+line starts = 254109
+rep 0: headings = 1860  scan ms = 12
+rep 1: headings = 1860  scan ms = 3
+rep 2: headings = 1860  scan ms = 5
+```
+
+`DigitTest`, `WsTest` and `RuleScan` reproduce the plan's appendices **exactly**. Two deltas are
+recorded below rather than papered over.
+
+## Recorded deltas between these listings and the plan / iOS
+
+1. **`HeadScan` counts 1 860, not the 1 859 claimed in Appendix A.2.** The plan reads this probe
+   as agreeing exactly with `RuleScan`'s 1 859; it is off by one. The extra hit is the *loose*
+   match Appendix A.5's own Python probe already isolates (`loose: 1860  strict: 1859` — a line
+   such as `第一回合，…` that a boundary refinement rejects). So the cross-validation still holds
+   in substance — two unrelated algorithms agree to within that single known loose match — but
+   the number in A.2 is wrong and the plan should be corrected. **No effect on shipped code:**
+   `HeadScan` is the rejected hand-rolled alternative (plan §3.4), not the algorithm being ported.
+
+2. **`RuleScan`'s rule 5 uses U+534D where iOS uses U+5350** (two variants of the same symbol;
+   both are `e5 8d …` in UTF-8, differing in the last byte). The listing is committed verbatim as
+   the plan requires, so the discrepancy is preserved here; **the production port follows iOS**
+   (`TxtTocRules` rule 5 carries U+5350, matching `TXTTocRuleEngine.swift:182`). The benchmark
+   numbers are unaffected — rule 1 wins detection on this book with 171 sample matches, and rule
+   5 never becomes the extraction rule.
+
+3. **`WsTest` deviates from A.4's mandated form.** A.4 binds WI-1 to write every CJK character and
+   separator as a unicode escape, because Gate-2 rounds 3 and 4 each caught a literal NBSP that
+   copy-paste had silently normalized to an ASCII space. Committing it hit that exact failure
+   twice more (the authoring pipeline rewrote each escape back into a literal, then flattened the
+   NBSP to a space), so the committed probe builds each character from its **code point** — a
+   strictly stronger version of the same guarantee, with no non-ASCII byte in the file at all.
+   The added `separators tested:` line prints the code points actually exercised, so the output
+   proves it really tested U+00A0 and not a space.
+
+The same code-point discipline is used in `TxtTocRulesTest.kt` for the D1b samples, for the same
+reason.

--- a/dev-docs/benchmarks/feature-139/RuleScan.java
+++ b/dev-docs/benchmarks/feature-139/RuleScan.java
@@ -1,0 +1,59 @@
+import java.nio.file.*; import java.nio.charset.*; import java.util.*; import java.util.regex.*;
+
+public class RuleScan {
+    static final String CJKNUM = "\\d〇零一二两三四五六七八九十百千万壹贰叁肆伍陆柒捌玖拾佰仟";
+    static final String[][] RULES = {
+        {"1","^[ 　\t]{0,4}(?:序章|楔子|正文(?!完|结)|终章|后记|尾声|番外|第\\s{0,4}["+CJKNUM+"]+?\\s{0,4}(?:章|节(?!课)|卷|集(?![合和])|部(?![分赛游])|篇(?!张))).{0,30}$"},
+        {"2","^[ 　\t]{0,4}[第（(]?\\s{0,4}["+CJKNUM+"]+?\\s{0,4}[章节卷集部篇回话]\\s?.{0,30}$"},
+        {"3","^[ 　\t]{0,4}(?:[Cc]hapter|[Ss]ection|[Pp]art|[Ee]pisode)\\s{0,4}\\d{1,4}.{0,30}$"},
+        {"4","^[ 　\t]{0,4}\\d{1,5}[：:,.， 、_—\\-].{1,30}$"},
+        {"5","^[ 　\t]{0,4}[【\\[☆★●◆◇○◎□■△▲※卍].{1,30}$"},
+        {"6","^[ 　\t]{0,4}正文\\s.{0,20}$"},
+        {"7","^[ 　\t]{0,4}(?:卷|篇|部|集)\\s{0,4}["+CJKNUM+"]+.{0,30}$"},
+        {"8","^[ 　\t]{0,4}[☆★].{1,30}$"},
+        {"9","^[ 　\t]{0,4}[Vv]ol(?:ume)?\\s{0,4}\\d{1,4}.{0,30}$"},
+        {"10","^[ 　\t]{0,4}[Bb]ook\\s{0,4}\\d{1,4}.{0,30}$"},
+        {"13","^[ 　\t]{0,4}[\\(（]\\d{1,5}[\\)）].{1,30}$"},
+        {"14","^[ 　\t]{0,4}\\d{1,5}\\..{1,30}$"},
+        {"20","^[ 　\t]{0,4}(?:[Pp]rologue|[Ee]pilogue|[Ii]nterlude|[Pp]reface|[Ff]oreword|[Aa]fterword|[Ii]ntroduction|[Cc]onclusion).{0,30}$"},
+        {"23","^[ 　\t]{0,4}第\\s{0,4}["+CJKNUM+"]+?\\s{0,4}[回话].{0,30}$"},
+    };
+
+    public static void main(String[] a) throws Exception {
+        byte[] raw = Files.readAllBytes(Paths.get(a[0]));
+        String text = null;
+        for (String cs : new String[]{"UTF-16","UTF-8","GBK","GB18030"}) {
+            CharsetDecoder d = Charset.forName(cs).newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT);
+            try { text = d.decode(java.nio.ByteBuffer.wrap(raw)).toString();
+                  System.out.println("decoded as " + cs); break; } catch (Exception e) { }
+        }
+        if (text == null) { System.out.println("undecodable"); return; }
+        System.out.println("chars = " + text.length());
+        int SAMPLE = 512 * 1024;
+        String sample = text.length() > SAMPLE ? text.substring(0, SAMPLE) : text;
+
+        for (int rep = 0; rep < 3; rep++) {
+            long t0 = System.nanoTime();
+            String bestId = null, bestPat = null; int best = 0;
+            for (String[] r : RULES) {
+                Matcher m = Pattern.compile(r[1], Pattern.MULTILINE).matcher(sample);
+                int c = 0; while (m.find()) c++;
+                if (c > best) { best = c; bestId = r[0]; bestPat = r[1]; }
+            }
+            long t1 = System.nanoTime();
+            System.out.println("rep"+rep+" DETECT best=" + bestId + " matches=" + best
+                + " ms=" + (t1-t0)/1_000_000);
+            if (best < 2) { System.out.println("  below threshold, no TOC"); continue; }
+            long t2 = System.nanoTime();
+            Matcher m = Pattern.compile(bestPat, Pattern.MULTILINE).matcher(text);
+            int n = 0; String first = null, last = null; int firstOff = -1;
+            while (m.find()) { n++; if (first == null) { first = m.group().trim(); firstOff = m.start(); }
+                               last = m.group().trim(); }
+            long t3 = System.nanoTime();
+            System.out.println("  EXTRACT entries=" + n + " ms=" + (t3-t2)/1_000_000
+                + " firstOffset=" + firstOff + " first='" + first + "' last='" + last + "'");
+        }
+    }
+}

--- a/dev-docs/benchmarks/feature-139/WsTest.java
+++ b/dev-docs/benchmarks/feature-139/WsTest.java
@@ -1,0 +1,46 @@
+import java.util.regex.*;
+
+/**
+ * D1b probe - does java.util.regex `\s` accept the separators ICU's `\s` accepts?
+ *
+ * DELIBERATE DEVIATION from the plan's Appendix A.4 listing, which mandates unicode-escaped
+ * literals: every CJK character and separator here is built from its CODE POINT instead.
+ * Same guarantee, strictly stronger. The plan's clause exists because a literal NBSP is
+ * fragile - Gate-2 rounds 3 and 4 each caught one that copy-paste had silently normalized to an
+ * ASCII space, which makes the probe's output a lie. Committing this file hit that failure
+ * twice more (the authoring pipeline rewrote each unicode escape back into a literal, then
+ * flattened the NBSP literal to a plain space), so nothing load-bearing is written literally
+ * here and no re-encoding can mangle it. The closing `separators tested:` line prints the code
+ * points actually exercised, so the output proves its own provenance.
+ *
+ *   U+7B2C chapter-ordinal head   U+4E00 numeral one   U+7AE0 chapter unit
+ *   U+3000 IDEOGRAPHIC SPACE      U+00A0 NO-BREAK SPACE
+ */
+public class WsTest {
+  static final String WS = "[\\s\\p{Z}\\x{0085}]";
+
+  static String cp(int c) { return new String(Character.toChars(c)); }
+
+  static final String DI = cp(0x7B2C);
+  static final String YI = cp(0x4E00);
+  static final String ZHANG = cp(0x7AE0);
+  static final String IDEO = cp(0x3000);
+  static final String NBSP = cp(0x00A0);
+
+  static void t(String label, String pat, String s){
+    System.out.println(label + " -> " + Pattern.compile(pat).matcher(s).find());
+  }
+
+  public static void main(String[] a){
+    String ideo = DI + IDEO + YI + IDEO + ZHANG;
+    String nbsp = DI + NBSP + YI + NBSP + ZHANG;
+    String rx   = DI + "\\s{0,4}[" + YI + "]\\s{0,4}" + ZHANG;
+    String rxWs = DI + WS + "{0,4}[" + YI + "]" + WS + "{0,4}" + ZHANG;
+    t("java \\s  + U+3000", rx,   ideo);
+    t("java \\s  + U+00A0", rx,   nbsp);
+    t("WS class + U+3000 ", rxWs, ideo);
+    t("WS class + U+00A0 ", rxWs, nbsp);
+    System.out.println("separators tested: U+" + String.format("%04X", (int) ideo.charAt(1))
+        + " and U+" + String.format("%04X", (int) nbsp.charAt(1)));
+  }
+}

--- a/dev-docs/plans/20260804-feature-139-android-txt-md-toc.md
+++ b/dev-docs/plans/20260804-feature-139-android-txt-md-toc.md
@@ -241,7 +241,25 @@ equivalence is now true rather than approximate.
 MULTILINE, so they cannot actually occur *within* a line the rules are matching. Including them
 costs nothing and makes the class provably equivalent to ICU's rather than "equivalent for the
 characters we expect" — which is the kind of assumption that produced the `\d` bug in the first
-place. The leading `[ 　\t]{0,4}` indent class is normalized to `$WS{0,4}` for the same reason.
+place.
+
+> **CORRECTION (WI-1 implementation + its Gate-4 audit, 2026-08-04) — the leading indent class is
+> NOT normalized.** v4 of this plan directed that the leading `[ 　\t]{0,4}` indent class also be
+> normalized to `$WS{0,4}`. That instruction was **wrong and is withdrawn.** `$WS` contains line
+> terminators; the indent class sits at the *start* of the match, so at a blank line the indent
+> consumes that line's own terminator and the match begins **one line early**. WI-2 converts match
+> starts into navigation locators, so every heading preceded by a blank line — ubiquitous in real
+> books — would have carried an off-by-one-line offset. Gate-4 round 1 rated this **High**.
+>
+> There is no divergence to repair here in the first place: **iOS never wrote `\s` in the indent**,
+> it wrote a literal `[space, U+3000, tab]` class, so ICU and Java already agree. The
+> "widening is non-regressive" evidence below was measured on *interior* positions and never
+> covered the indent normalization it was cited for.
+>
+> **Shipped**: iOS's literal indent class, pinned by `everyRule_keepsTheLiteralIosIndentClass` and
+> `headingAfterBlankLines_matchesAtTheHeadingLine_notTheBlankLine`. §3.6's D1b row is superseded
+> accordingly. Widening still applies to interior whitespace positions, where the ICU/Java
+> divergence is real.
 
 **Verified non-regressive on real data**: re-running rule 1 over the 14 MB book with the widened
 class yields **1 859 matches — identical to the narrow class** (the widened class is a strict
@@ -1549,8 +1567,14 @@ public class HeadScan {
 }
 ```
 
-Measured: `line starts = 254109`, **`headings = 1859`, `scan ms = 13 / 11 / 6`** — the same 1 859
-A.1 finds, from a completely different algorithm.
+Measured: `line starts = 254109`, **`headings = 1860`, `scan ms = 13 / 11 / 6`** — cross-validating
+A.1's 1 859 from a completely different algorithm.
+
+> **CORRECTION (WI-1, 2026-08-04)**: this appendix previously claimed `headings = 1859`. Re-running
+> the committed probe reproduces **1860**. The one extra hit is the loose match that A.5's own probe
+> already isolates (`loose: 1860 / strict: 1859`), so the cross-validation holds in substance — but
+> the number was wrong and is corrected here. No effect on shipped code: `HeadScan` is the *rejected*
+> alternative algorithm, kept only as independent evidence.
 
 ### A.3 `DigitTest.java` — the D1 probe + the R4 ReDoS bound
 


### PR DESCRIPTION
## Summary

- Ports all **25** iOS TXT TOC detection rules (`TXTTocRuleEngine.swift`) to Kotlin with iOS's ids, serialNumbers and enabled flags exactly (14 enabled: 1–10, 13, 14, 20, 23).
- Repairs the two **ICU → Java regex divergences** that would have silently broken CJK detection.
- Commits the four Gate-1 probe programs as reproducible evidence.

Part of feature #2025 (#139). Foundational WI — no user-visible behavior yet.

## The two divergences this WI exists to pin

1. **Java's `\d` does not match full-width `０-９`; ICU's does.** A verbatim port silently fails on CJK books — and the canonical real fixture is a 14MB CJK novel. Fixed with explicit `[0-9０-９]`. `(?U)` is deliberately *not* used: it would also widen `\s`/`\w`/`\b`.
2. **Java's `\s` does not match U+3000 / U+00A0** the way the iOS patterns assume. Fixed with an explicit whitespace class at interior positions.

Both regressions are **parameterized over all 25 rules — including the ones that ship disabled** (`\d`: 11/12/22; `\s`: 11/12/15/16/17/21), each with a negative control, so enabling a rule later cannot resurrect the divergence. This was a Gate-2 High.

## Audited deviation from the plan (§3.5) — please note

The Gate-2-clean plan directed that the **leading indent class** also be normalized to `$WS{0,4}`. The lane implemented that literally and **Gate-4 round 1 rated it High**:

`$WS` contains line terminators, and the indent sits at the *start* of the match — so at a blank line the indent consumes that line's own terminator and the match begins **one line early**. WI-2 turns match starts into navigation locators, so every heading preceded by a blank line (ubiquitous in real books) would have carried an off-by-one-line offset.

There was no divergence to repair there in the first place: **iOS never wrote `\s` in the indent**, it wrote a literal `[space, U+3000, tab]` class, so ICU and Java already agree. The plan's "widening is non-regressive" evidence was measured on *interior* positions and never covered the normalization it was cited for.

Shipped: iOS's literal indent class, pinned by `everyRule_keepsTheLiteralIosIndentClass` and `headingAfterBlankLines_matchesAtTheHeadingLine_notTheBlankLine`. **The plan is corrected in this PR** so WI-2 doesn't inherit the bug.

## Also corrected in the plan

Appendix A.2 claimed `headings = 1859`; the committed probe reproduces **1860**. The extra hit is the loose match A.5 already isolates (`loose 1860 / strict 1859`), so the cross-validation holds — but the number was wrong. No effect on shipped code (`HeadScan` is the rejected alternative).

## Validation

- **Test gate independently re-run by the orchestrator on the rebased branch**: `RUN-ANDROID-TESTS RESULT: SUCCEEDED` — **21 tests, 0 failures, 0 errors**.
- Write-set verified: exactly the 9 declared paths, no contamination of the main checkout.
- Gate-4 Codex audit: 3 rounds, verdict `follow-up-recommended`, **zero open Critical/High/Medium**. Log: `.claude/codex-audits/feat-139-wi-1-toc-rules-audit.md`.
- Gate 5a: foundational tier — unit tests + audit are sufficient, no device verification required.
- Docs sync: not triggered (no new service/schema/notification).
- Version bumped: `android/v0.20.14` → `android/v0.20.15`.

## Kotlin gotcha worth knowing

A CJK character is a valid Kotlin identifier character, so an unbraced template like `"$INDENT正文"` parses as the identifier `INDENT正文`. This bit both the production data and a test, and is invisible until compile.

## Type of Change

- [x] Feature WI (part of feature #2025)