### PR TITLE
feat(#139 WI-2): TxtTocRuleEngine — iOS-parity detect + bounded extract

### DIFF
--- a/.claude/codex-audits/feat-139-wi-2-toc-engine-audit.md
+++ b/.claude/codex-audits/feat-139-wi-2-toc-engine-audit.md
@@ -1,0 +1,95 @@
+---
+branch: feat/139-wi-2-toc-engine
+threadId: 019fcb5c-0411-7f20-a842-a04e4d019c30
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-08-04
+---
+
+# Gate-4 audit — feature #139 WI-2 (`TxtTocRuleEngine`: detect + bounded extract)
+
+Item: `feat:#139/WI-2`. Auditor: Codex via `scripts/run-codex.sh` (rule 53), read-only sandbox,
+three rounds. Thread ids: r1 `019fcb5c-0411-7f20-a842-a04e4d019c30`,
+r2 `019fcb64-2f8d-7b90-8a12-b0150eac7ea5`, r3 in `.reports/audit-r3.txt`.
+Raw transcripts: `.reports/audit-r{1,2,3}.txt` (lane-local, gitignored).
+
+Scope audited: `DetectedHeading.kt`, `TxtTocRuleEngine.kt`, `TxtTocRuleEngineTest.kt`, against the
+iOS source of truth `vreader/Services/TXT/TXTTocRuleEngine.swift:38-132` and WI-1's `TxtTocRules.kt`.
+
+The audit prompt named the load-bearing risk explicitly: every `sourceOffsetUtf16` becomes a
+**navigation locator** (it feeds `txtBookmarkLocator` / `jumpToOffset` and #138's paged
+`ensureMeasuredThrough` seam), so an off-by-one offset is a user-visible defect. Round 1 was
+therefore pointed at offset correctness, the early-stop `limit` (Gate-2 R2 MEDIUM), cancellation,
+and ReDoS bounds — and at whether any test was vacuous.
+
+## Round 1 — verdict `follow-up-recommended`
+
+| Sev | Finding | Disposition |
+| --- | --- | --- |
+| MEDIUM | Cancellation is checked every 1 024 **matches**, not per scanned input. One `find()` / `next()` is a non-suspending `java.util.regex` call that can traverse a 14 MB document uninterrupted, so the header's "stops promptly" / "well under a frame" claims were not guaranteed. Proposed fix: scan by bounded **line regions**. | **PARTIALLY ACCEPTED** (`aa93faa3`). Diagnosis accepted — the over-claim is rewritten to state the real bound (one uninterrupted walk of the gap to the next match, ≈ a full pass, measured ~100 ms on the real book) and `extractHeadings_largeNoMatchDocument_isACatastrophicRegressionSmokeTest` makes the worst case an executed assertion. **The prescribed fix was REJECTED as unsound** — see below. |
+| LOW | `detectBestRule_isCancellationCooperative` would pass even if `countMatches` had no cancellation check at all (with `activeChecks = 1` the cancelling query lands on the rule boundary, before counting starts). | **FIXED** (`aa93faa3`). Split into `_betweenRules` and `_whileCountingOneRulesMatches` (one enabled rule, 4× the check interval in matches, `CancelAfter(activeChecks = 2)` so the cancelling query must originate inside `countMatches`). |
+| LOW | The sampling tests never discriminate `sampleOf`'s surrogate-boundary branch — a regression at exactly 512 K, at a straddling pair, or on a lone surrogate would go unnoticed. | **FIXED** (`aa93faa3`). `sampleOf` is `internal` with four direct boundary tests: exactly-the-window, pair straddling the boundary, pair ending at the boundary, lone unpaired surrogate preserved. |
+
+### Why line-region chunking was rejected (the round-1 MEDIUM's prescribed fix)
+
+`TxtTocRules.WS` is the D1b widening to ICU-`\s` semantics — `[\s\p{Z}\x{0085}]` — which **contains
+line terminators**. The rules' whitespace positions therefore genuinely match across a newline:
+probed directly with `java.util.regex` MULTILINE, rule 1 matches `"第\n一\n章 标题"` at offset 0,
+spanning two terminators. iOS's ICU `\s` behaves identically, so this is **parity, not a bug**.
+Splitting the scan into line-bounded regions would silently drop such matches — trading a bounded
+~100 ms *background* latency for a correctness divergence from iOS.
+
+Round 2 was asked to verify this independently rather than take the author's word, and did:
+
+> "The cross-terminator claim is true for shipped rule 1: both `{0,4}` whitespace positions can
+> consume line terminators… Rejecting simple line-bounded scanning was correct. An
+> equivalence-preserving overlapping-region scheme is theoretically possible … but disabled rules
+> 24/25 allow unbounded same-line matches, Unicode terminator/CRLF handling is delicate, and a huge
+> single line remains unsplittable without changing semantics. The complexity is not justified for
+> the measured background cost."
+
+The behaviour is now pinned by `extractHeadings_aRuleCanMatchAcrossALineTerminator_soTheScanIsNotLineSplittable`,
+so a future "scan line by line" optimization fails a test instead of silently regressing.
+
+## Round 2 — verdict `follow-up-recommended` (zero Critical/High/Medium)
+
+| Sev | Finding | Disposition |
+| --- | --- | --- |
+| LOW | A cancel landing during the **final** `next()` / initial `find()` that returns `null` is swallowed: both loops exit and return a normal result without a further `ensureActive()`. | **FIXED**. `coroutineContext.ensureActive()` now runs after each scan loop before the normal return, in both entry points. Two deterministic regression tests: `extractHeadings_cancelDuringTheFinalScanStep_isNotSwallowed` (document too small for any in-loop interval check, asserts exactly 2 queries = entry + post-loop) and `detectBestRule_cancelAfterTheLastRule_isNotSwallowed` (`activeChecks = 1 + enabled-rule count`, so the cancelling query must be the post-loop one). |
+| LOW | Rule-22 drift: the comments promised a single-line match/title, which the newly pinned cross-terminator behaviour contradicts; and "off the main thread" is a caller property (WI-4's `withContext`), not something this engine enforces. | **FIXED**. Header + `extractHeadings` KDoc now state that the `.` tail cannot cross a terminator but the marker's `WS` positions can, so a title may carry an embedded newline (iOS parity); `DetectedHeading.title`'s KDoc says the same and points collapsing at the presentation layer; the header states the engine does not hop threads itself and must not be called on the main thread. |
+| LOW | The no-match timing test claimed "bounded and linear" and cited ~100 ms, but tests one size against a 10 s ceiling; also mislabelled the fixture as 14 MB. | **FIXED**. Renamed to `…_isACatastrophicRegressionSmokeTest`; the comment now disclaims linearity and the ~100 ms figure, defers a real budget to WI-8's device evidence, and states the fixture is ~14 M UTF-16 code units — about twice the real book's 7 029 609. |
+| LOW | The 664-line test file exceeds the ~300-line convention. | **ACCEPTED, not fixed.** (a) The convention (`.claude/rules/00-engineering-principles.md`) is written for code files, and this module's suites routinely exceed it — `VReaderDatabaseMigrationTest.kt` 832, `InBookSearchViewModelTest.kt` 658, `InBookSearchRepositoryTest.kt` 545, `ChapterTranslationServiceTest.kt` 542, `TxtTocRulesTest.kt` 532 (the immediately preceding WI). (b) Splitting needs a shared harness file (the `CancelAfter` Job and the `runWithJob`/`startCoroutine` helper) **outside this lane's declared three-file write-set**. Round 3 concurred: "maintainability debt, but splitting it within this narrowly declared write-set would be disproportionate and is not a shipping defect." |
+
+Round 2 also confirmed, from scratch: iOS fidelity of the sampling window, enabled filter,
+strictly-greater tie-break, `>= 2` threshold, whole-match trimmed titles, blank-title drop, document
+order and skip-on-uncompilable; offsets at true line starts under LF/CR/CRLF, in bounds, never
+inside a surrogate pair; coherent `hitLimit` for the `cap + 1` caller; blank titles not consuming
+the limit; genuine early stop (the next match is never sought); no material ReDoS exposure; and the
+`CancelAfter` / `runWithJob` harness non-vacuous.
+
+## Round 3 — verdict `ship-as-is` (zero findings at any severity)
+
+Verification round. Confirmed both terminal `ensureActive()` calls are correctly placed, that both
+new regression tests **would fail without the fix** and their query-count arithmetic is right, that
+no cancellation path remains swallowed, that all comments in both production files are now literally
+true, that the fixture is exactly 14 000 000 UTF-16 code units, and that the terminal checks change
+no uncancelled result, no matching fidelity, no offset and no limit behaviour ("throwing instead of
+returning when the caller's job is cancelled is the correct coroutine contract"). L4 accepted.
+
+## Author-side defect caught before round 1
+
+The first local run of the suite exposed a **false-passing test harness**: `CancelAfter` was written
+as `Job by delegate`, and Kotlin interface delegation forwards *every* member — including
+`CoroutineContext.get`. `coroutineContext[Job]` therefore returned the delegate, never the counting
+job, so `isActive` was never queried, cancellation never fired, and
+`extractHeadings_stopsAtLimit_doesNotMaterializeBeyondIt` passed **vacuously** (`job.checks == 0 <
+195`). Fixed by overriding `get`, and guarded permanently by an explicit anti-vacuity assertion
+(`job.checks >= 1`) plus a KDoc naming the trap. Two engine bugs were also caught by the same first
+run being honest: the CRLF offset expectation in the test was the author's arithmetic error, not the
+engine's (the engine was right).
+
+## Test gate
+
+`RUN-ANDROID-TESTS RESULT: SUCCEEDED` —
+`./gradlew :app:testDebugUnitTest --tests '*TxtTocRuleEngineTest*' --tests '*TxtTocRulesTest*'`,
+**46 + 21 = 67 tests, 0 failures, 0 skipped**. JVM only; no emulator required.

--- a/android/app/src/main/kotlin/com/vreader/app/reader/nav/DetectedHeading.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/nav/DetectedHeading.kt
@@ -1,0 +1,50 @@
+// Purpose: The format-neutral intermediate every TXT/MD table-of-contents scanner emits
+// (feature #139 WI-2), plus the bounded result wrapper extraction returns.
+//
+// Key decisions:
+// - `sourceOffsetUtf16` is an offset into the RAW decoded document text, in UTF-16 code units,
+//   pointing at the heading LINE's first code unit (leading indent included). It is deliberately
+//   NOT a rendered/paginated offset: the whole point is that a display-settings reflow cannot
+//   invalidate it, and that it feeds `txtBookmarkLocator` / `jumpToOffset` unchanged.
+// - `depth` is 0-based. TXT is always flat (plan §4.3 — the single-winning-rule model cannot tell
+//   卷 from 章, and the real book's 卷 headings are interleaved out of order); MD carries real
+//   heading levels.
+// - [ExtractResult] carries `hitLimit` rather than an over-cap list so a caller can REJECT a
+//   pathological document without the scan ever materializing it (plan §4.4 / Gate-2 R2).
+//
+// @coordinates-with: TxtTocRuleEngine.kt, MdTocScanner.kt, TxtMdTocProvider.kt
+package com.vreader.app.reader.nav
+
+/**
+ * One detected heading, before it becomes a [TocEntry].
+ *
+ * @param title             the heading text, already trimmed. Never blank — a match whose text
+ *                          trims to nothing is dropped rather than emitted.
+ * @param sourceOffsetUtf16 UTF-16 offset of the heading LINE's start in the raw document text.
+ *                          Guaranteed to be a code-point boundary (never inside a surrogate pair).
+ * @param depth             0-based nesting level; TXT is always 0.
+ */
+data class DetectedHeading(
+    val title: String,
+    val sourceOffsetUtf16: Int,
+    val depth: Int = 0,
+)
+
+/**
+ * The outcome of a bounded extraction pass.
+ *
+ * @param headings  the headings found, in document order; never longer than the caller's `limit`.
+ * @param hitLimit  `true` when collection STOPPED because `limit` was reached. Callers pass
+ *                  `cap + 1` so this reads exactly as "the document has more than `cap` headings",
+ *                  which is the reject-don't-truncate signal (a silently truncated Contents list
+ *                  is worse than none — the user cannot tell it is incomplete).
+ */
+data class ExtractResult(
+    val headings: List<DetectedHeading>,
+    val hitLimit: Boolean,
+) {
+    companion object {
+        /** Nothing found, nothing truncated — the empty-document / unusable-rule outcome. */
+        val EMPTY = ExtractResult(emptyList(), hitLimit = false)
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/nav/DetectedHeading.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/nav/DetectedHeading.kt
@@ -19,7 +19,11 @@ package com.vreader.app.reader.nav
  * One detected heading, before it becomes a [TocEntry].
  *
  * @param title             the heading text, already trimmed. Never blank — a match whose text
- *                          trims to nothing is dropped rather than emitted.
+ *                          trims to nothing is dropped rather than emitted. Usually a single
+ *                          line, but a TXT rule's whitespace positions are ICU-`\s` (which
+ *                          includes line terminators), so a heading split across lines yields a
+ *                          title with an embedded newline — iOS parity; a renderer that must show
+ *                          one line should collapse it at the presentation layer, not here.
  * @param sourceOffsetUtf16 UTF-16 offset of the heading LINE's start in the raw document text.
  *                          Guaranteed to be a code-point boundary (never inside a surrogate pair).
  * @param depth             0-based nesting level; TXT is always 0.

--- a/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocRuleEngine.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocRuleEngine.kt
@@ -1,0 +1,174 @@
+// Purpose: TXT chapter detection — pick the best-matching rule from [TxtTocRules] by sampling the
+// document, then extract every heading with that one rule (feature #139 WI-2). The Kotlin port of
+// iOS `TXTTocRuleEngine` (vreader/Services/TXT/TXTTocRuleEngine.swift:38-132).
+//
+// Pipeline: text ──detectBestRule──► winning rule ──extractHeadings──► List<DetectedHeading>
+//
+// Key decisions:
+// - Detection samples the first [SAMPLE_SIZE_UTF16] code units and requires [MIN_MATCHES] hits,
+//   both iOS parity. Ties resolve toward the rule that appears FIRST in the supplied list
+//   (strictly-greater comparison), which is [TxtTocRules.defaults]' serialNumber order.
+// - Patterns compile with `RegexOption.MULTILINE` and NOTHING else. `DOT_MATCHES_ALL` would let a
+//   title swallow the rest of the document (the bounded `.{0,30}$` tail is what confines a match
+//   to one line) and `IGNORE_CASE` would reintroduce the Unicode case-folding divergence the rules
+//   avoid by spelling both cases. See TxtTocRules' header for the D1/D1b class repairs.
+// - An offset is the match START = the LINE start, leading indent included, in UTF-16 code units
+//   over the RAW text. Everything downstream (the Contents jump, #138's paged
+//   `ensureMeasuredThrough` seam) treats it as a source offset, so it must never be a rendered
+//   offset and never land inside a surrogate pair. `^` under MULTILINE only matches at 0 or just
+//   after a line terminator, and no terminator is a surrogate, so the boundary property holds by
+//   construction — and is pinned by test.
+// - Extraction is BOUNDED BEFORE MATERIALIZATION: it walks matches one at a time via
+//   `MatchResult.next()` and returns the moment it has `limit` headings, so a pathological
+//   all-match document never builds a full match list to be truncated afterwards (plan §4.4).
+// - No Android imports and no logging: this is pure CPU work that must stay JVM-unit-testable
+//   (`android.util.Log` throws "not mocked" in a plain unit test). A rule that fails to compile is
+//   skipped, mirroring iOS's `try?` — degrading to "no Contents" beats crashing a working reader,
+//   and TxtTocRulesTest already pins that all 25 shipped rules compile.
+// - Both entry points are cancellation-cooperative (`ensureActive()` at entry, then every
+//   [CANCELLATION_CHECK_INTERVAL] matches and between detection rules), so closing the reader
+//   mid-scan stops promptly instead of burning a background thread on a 14 MB book.
+//
+// @coordinates-with: TxtTocRules.kt, DetectedHeading.kt, TxtMdTocProvider.kt
+package com.vreader.app.reader.nav
+
+import kotlinx.coroutines.ensureActive
+import java.util.regex.PatternSyntaxException
+import kotlin.coroutines.coroutineContext
+
+/** Detects and applies TXT chapter-heading rules over a whole decoded document. */
+object TxtTocRuleEngine {
+
+    /**
+     * Auto-detection reads only this many leading UTF-16 code units (iOS parity:
+     * `TXTTocRuleEngine.sampleSizeUTF16`). Extraction, by contrast, always scans the full text.
+     */
+    const val SAMPLE_SIZE_UTF16: Int = 512 * 1024
+
+    /**
+     * A rule must match at least this often within the sample to be trusted (iOS parity:
+     * `TXTTocRuleEngine.swift:77`). One match is a coincidence, not a chapter scheme.
+     */
+    const val MIN_MATCHES: Int = 2
+
+    /**
+     * Matches examined between cancellation checks. Small enough that a cancelled scan of a 14 MB
+     * book stops in well under a frame; large enough that the check is not the inner loop's cost.
+     */
+    const val CANCELLATION_CHECK_INTERVAL: Int = 1024
+
+    /**
+     * Finds the rule that best explains [text], or `null` when none is convincing.
+     *
+     * Mirrors iOS exactly: sample the first [SAMPLE_SIZE_UTF16] code units, count matches for each
+     * ENABLED rule in list order, keep the rule with strictly the most matches (so a tie goes to
+     * the earlier rule), and return it only if that count reaches [MIN_MATCHES].
+     *
+     * @param rules the candidate set; disabled entries are ignored. The returned instance is the
+     *              caller's own object, so a customized rule set round-trips.
+     * @throws kotlinx.coroutines.CancellationException if the calling coroutine is cancelled.
+     */
+    suspend fun detectBestRule(
+        text: String,
+        rules: List<TxtTocRule> = TxtTocRules.defaults,
+    ): TxtTocRule? {
+        coroutineContext.ensureActive()
+        if (text.isEmpty()) return null
+
+        val sample = sampleOf(text)
+        var bestRule: TxtTocRule? = null
+        var bestCount = 0
+
+        for (rule in rules) {
+            if (!rule.enabled) continue
+            coroutineContext.ensureActive()
+            val regex = compile(rule) ?: continue
+            val count = countMatches(regex, sample)
+            if (count > bestCount) {
+                bestCount = count
+                bestRule = rule
+            }
+        }
+
+        return if (bestCount >= MIN_MATCHES) bestRule else null
+    }
+
+    /**
+     * Extracts every heading [rule] finds in [text], in document order, stopping early at [limit].
+     *
+     * Each heading's title is the whole matched LINE trimmed; matches that trim to nothing are
+     * dropped (iOS parity) and cost nothing against [limit]. Each offset is the match start — the
+     * line start, leading indent included — as a UTF-16 offset into [text].
+     *
+     * @param limit the maximum number of headings to collect; must be positive. Callers pass
+     *              `cap + 1` so [ExtractResult.hitLimit] reads as "more than `cap` headings exist"
+     *              (plan §4.4). Deliberately has no default: an unbounded extraction of an
+     *              adversarial document is exactly the failure this parameter exists to prevent,
+     *              so every call site states its own budget.
+     * @throws IllegalArgumentException if [limit] is not positive.
+     * @throws kotlinx.coroutines.CancellationException if the calling coroutine is cancelled.
+     */
+    suspend fun extractHeadings(text: String, rule: TxtTocRule, limit: Int): ExtractResult {
+        require(limit > 0) { "limit must be positive, was $limit" }
+        coroutineContext.ensureActive()
+        if (text.isEmpty()) return ExtractResult.EMPTY
+        val regex = compile(rule) ?: return ExtractResult.EMPTY
+
+        val headings = ArrayList<DetectedHeading>()
+        var sinceCheck = 0
+        var match = regex.find(text)
+
+        while (match != null) {
+            if (++sinceCheck >= CANCELLATION_CHECK_INTERVAL) {
+                sinceCheck = 0
+                coroutineContext.ensureActive()
+            }
+            val title = match.value.trim()
+            if (title.isNotEmpty()) {
+                headings.add(DetectedHeading(title = title, sourceOffsetUtf16 = match.range.first))
+                // Stop the SCAN, not just the returned list: the next match is never even sought.
+                if (headings.size == limit) return ExtractResult(headings, hitLimit = true)
+            }
+            match = match.next()
+        }
+
+        return ExtractResult(headings, hitLimit = false)
+    }
+
+    /**
+     * The leading [SAMPLE_SIZE_UTF16] code units of [text], never splitting a surrogate pair.
+     *
+     * Swift's `String.Index(utf16Offset:in:)` rounds to a Character boundary; a bare Kotlin
+     * `substring` would leave a lone high surrogate at the end, which is not a character in either
+     * engine's sense and would only ever confuse a `.{0,30}` count.
+     */
+    private fun sampleOf(text: String): String {
+        if (text.length <= SAMPLE_SIZE_UTF16) return text
+        var end = SAMPLE_SIZE_UTF16
+        if (text[end - 1].isHighSurrogate() && text[end].isLowSurrogate()) end--
+        return text.substring(0, end)
+    }
+
+    /** Streams over the matches rather than collecting them — the sample is up to 512 KB. */
+    private suspend fun countMatches(regex: Regex, sample: String): Int {
+        var count = 0
+        var sinceCheck = 0
+        var match = regex.find(sample)
+        while (match != null) {
+            count++
+            if (++sinceCheck >= CANCELLATION_CHECK_INTERVAL) {
+                sinceCheck = 0
+                coroutineContext.ensureActive()
+            }
+            match = match.next()
+        }
+        return count
+    }
+
+    /** `null` for a pattern `java.util.regex` rejects — iOS's `try?` skips the same way. */
+    private fun compile(rule: TxtTocRule): Regex? = try {
+        Regex(rule.pattern, RegexOption.MULTILINE)
+    } catch (_: PatternSyntaxException) {
+        null
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocRuleEngine.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocRuleEngine.kt
@@ -25,9 +25,17 @@
 //   (`android.util.Log` throws "not mocked" in a plain unit test). A rule that fails to compile is
 //   skipped, mirroring iOS's `try?` — degrading to "no Contents" beats crashing a working reader,
 //   and TxtTocRulesTest already pins that all 25 shipped rules compile.
-// - Both entry points are cancellation-cooperative (`ensureActive()` at entry, then every
-//   [CANCELLATION_CHECK_INTERVAL] matches and between detection rules), so closing the reader
-//   mid-scan stops promptly instead of burning a background thread on a 14 MB book.
+// - Both entry points are cancellation-cooperative, with a PRECISELY BOUNDED granularity: a check
+//   at entry, one before each detection rule, and one every [CANCELLATION_CHECK_INTERVAL] matches.
+//   A single `find()` / `next()` is a non-suspending `java.util.regex` call that cannot observe
+//   cancellation, so the worst case after a cancel is one uninterrupted walk of the gap to the
+//   next match — bounded by a full pass over the text (measured at ~100 ms for the real 14 MB CJK
+//   book, plan §5 / Appendix A.1), off the main thread. Splitting the scan into line-bounded
+//   regions to tighten that was REJECTED, not overlooked: `TxtTocRules.WS` widens whitespace to
+//   ICU's `\s`, which contains line terminators, so a rule genuinely can match ACROSS a newline
+//   (probed: rule 1 matches "第\n一\n章 标题" at offset 0 — and iOS's ICU `\s` behaves the same).
+//   Region-splitting would therefore silently drop real matches, trading a bounded ~100 ms
+//   background latency for a correctness divergence.
 //
 // @coordinates-with: TxtTocRules.kt, DetectedHeading.kt, TxtMdTocProvider.kt
 package com.vreader.app.reader.nav
@@ -52,8 +60,12 @@ object TxtTocRuleEngine {
     const val MIN_MATCHES: Int = 2
 
     /**
-     * Matches examined between cancellation checks. Small enough that a cancelled scan of a 14 MB
-     * book stops in well under a frame; large enough that the check is not the inner loop's cost.
+     * Matches EXAMINED between cancellation checks (not headings emitted — a document of dropped
+     * blank titles stays interruptible too).
+     *
+     * This bounds the check frequency in match-space only. The residual latency is the gap between
+     * two matches, which one non-suspending regex call walks in a single step; see the file header
+     * for why that is accepted rather than chunked away.
      */
     const val CANCELLATION_CHECK_INTERVAL: Int = 1024
 
@@ -140,9 +152,13 @@ object TxtTocRuleEngine {
      *
      * Swift's `String.Index(utf16Offset:in:)` rounds to a Character boundary; a bare Kotlin
      * `substring` would leave a lone high surrogate at the end, which is not a character in either
-     * engine's sense and would only ever confuse a `.{0,30}` count.
+     * engine's sense and would only ever confuse a `.{0,30}` count. A lone surrogate ALREADY in
+     * the text (malformed input) is preserved as-is — only a genuine pair is stepped back over.
+     *
+     * `internal` so the boundary cases can be asserted directly; they are not observable through
+     * [detectBestRule], whose result is the same either way for every realistic rule.
      */
-    private fun sampleOf(text: String): String {
+    internal fun sampleOf(text: String): String {
         if (text.length <= SAMPLE_SIZE_UTF16) return text
         var end = SAMPLE_SIZE_UTF16
         if (text[end - 1].isHighSurrogate() && text[end].isLowSurrogate()) end--

--- a/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocRuleEngine.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocRuleEngine.kt
@@ -9,9 +9,14 @@
 //   both iOS parity. Ties resolve toward the rule that appears FIRST in the supplied list
 //   (strictly-greater comparison), which is [TxtTocRules.defaults]' serialNumber order.
 // - Patterns compile with `RegexOption.MULTILINE` and NOTHING else. `DOT_MATCHES_ALL` would let a
-//   title swallow the rest of the document (the bounded `.{0,30}$` tail is what confines a match
-//   to one line) and `IGNORE_CASE` would reintroduce the Unicode case-folding divergence the rules
+//   title swallow the rest of the document (the bounded `.{0,30}$` tail cannot cross a line
+//   terminator) and `IGNORE_CASE` would reintroduce the Unicode case-folding divergence the rules
 //   avoid by spelling both cases. See TxtTocRules' header for the D1/D1b class repairs.
+// - A title is the WHOLE MATCH, trimmed — usually one line, but not necessarily: the `.` tail
+//   cannot cross a terminator, yet the marker's own bounded whitespace positions are `WS` =
+//   ICU-`\s`, which CONTAINS terminators, so a heading split as "第\n一\n章 标题" matches and its
+//   title carries the embedded newline. That is iOS's ICU behavior too, so it is parity, not a
+//   defect; it is pinned by test and is what makes the scan non-splittable by line (below).
 // - An offset is the match START = the LINE start, leading indent included, in UTF-16 code units
 //   over the RAW text. Everything downstream (the Contents jump, #138's paged
 //   `ensureMeasuredThrough` seam) treats it as a source offset, so it must never be a rendered
@@ -30,7 +35,9 @@
 //   A single `find()` / `next()` is a non-suspending `java.util.regex` call that cannot observe
 //   cancellation, so the worst case after a cancel is one uninterrupted walk of the gap to the
 //   next match — bounded by a full pass over the text (measured at ~100 ms for the real 14 MB CJK
-//   book, plan §5 / Appendix A.1), off the main thread. Splitting the scan into line-bounded
+//   book, plan §5 / Appendix A.1). That pass is off the MAIN thread only because
+//   `TxtMdTocProvider` (WI-4) owns the `withContext(dispatcher)` hop; this engine does not hop by
+//   itself and must not be called on the main thread. Splitting the scan into line-bounded
 //   regions to tighten that was REJECTED, not overlooked: `TxtTocRules.WS` widens whitespace to
 //   ICU's `\s`, which contains line terminators, so a rule genuinely can match ACROSS a newline
 //   (probed: rule 1 matches "第\n一\n章 标题" at offset 0 — and iOS's ICU `\s` behaves the same).
@@ -102,15 +109,19 @@ object TxtTocRuleEngine {
             }
         }
 
+        // Same reason as extractHeadings': a cancel during the LAST rule's count must not be
+        // swallowed by the loop simply running out of rules.
+        coroutineContext.ensureActive()
         return if (bestCount >= MIN_MATCHES) bestRule else null
     }
 
     /**
      * Extracts every heading [rule] finds in [text], in document order, stopping early at [limit].
      *
-     * Each heading's title is the whole matched LINE trimmed; matches that trim to nothing are
-     * dropped (iOS parity) and cost nothing against [limit]. Each offset is the match start — the
-     * line start, leading indent included — as a UTF-16 offset into [text].
+     * Each heading's title is the whole MATCH trimmed — one line for every ordinary heading, but
+     * see the file header for the legitimate cross-terminator case. Matches that trim to nothing
+     * are dropped (iOS parity) and cost nothing against [limit]. Each offset is the match start —
+     * the line start, leading indent included — as a UTF-16 offset into [text].
      *
      * @param limit the maximum number of headings to collect; must be positive. Callers pass
      *              `cap + 1` so [ExtractResult.hitLimit] reads as "more than `cap` headings exist"
@@ -144,6 +155,11 @@ object TxtTocRuleEngine {
             match = match.next()
         }
 
+        // A cancel landing DURING the final `next()` — the long walk to end-of-text — would
+        // otherwise be swallowed: the loop exits on null and returns a normal result. Check once
+        // more so the outcome is always "cancelled" rather than "a full result for a job nobody
+        // is waiting on".
+        coroutineContext.ensureActive()
         return ExtractResult(headings, hitLimit = false)
     }
 

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocRuleEngineTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocRuleEngineTest.kt
@@ -187,6 +187,54 @@ class TxtTocRuleEngineTest {
         )
     }
 
+    // ------------------------------------------------------------------ the sampling window edge
+
+    @Test
+    fun sampleOf_shorterThanTheWindow_returnsTheTextUntouched() {
+        val text = "第一章 甲\n"
+        assertSame(text, TxtTocRuleEngine.sampleOf(text))
+    }
+
+    @Test
+    fun sampleOf_exactlyTheWindow_returnsTheTextUntouched() {
+        // The `<=` boundary: one code unit longer and the truncation branch runs instead.
+        val text = "x".repeat(TxtTocRuleEngine.SAMPLE_SIZE_UTF16)
+        assertEquals(TxtTocRuleEngine.SAMPLE_SIZE_UTF16, TxtTocRuleEngine.sampleOf(text).length)
+        assertSame(text, TxtTocRuleEngine.sampleOf(text))
+    }
+
+    @Test
+    fun sampleOf_surrogatePairStraddlingTheBoundary_stepsBackOverIt() {
+        // High surrogate at SAMPLE - 1, low surrogate at SAMPLE: a bare substring would leave a
+        // lone high surrogate as the sample's last code unit.
+        val text = "x".repeat(TxtTocRuleEngine.SAMPLE_SIZE_UTF16 - 1) + "😀" + "x".repeat(10)
+        val sample = TxtTocRuleEngine.sampleOf(text)
+
+        assertEquals(TxtTocRuleEngine.SAMPLE_SIZE_UTF16 - 1, sample.length)
+        assertFalse("the sample must not end on a lone high surrogate", sample.last().isHighSurrogate())
+        assertEquals("x", sample.takeLast(1))
+    }
+
+    @Test
+    fun sampleOf_surrogatePairEndingExactlyAtTheBoundary_isKeptWhole() {
+        // Low surrogate at SAMPLE - 1: the pair is fully inside the window, so no back-off.
+        val text = "x".repeat(TxtTocRuleEngine.SAMPLE_SIZE_UTF16 - 2) + "😀" + "x".repeat(10)
+        val sample = TxtTocRuleEngine.sampleOf(text)
+
+        assertEquals(TxtTocRuleEngine.SAMPLE_SIZE_UTF16, sample.length)
+        assertTrue("the whole pair survives", sample.endsWith("😀"))
+    }
+
+    @Test
+    fun sampleOf_loneSurrogateAtTheBoundary_isPreserved_notSteppedOver() {
+        // Malformed input: an unpaired high surrogate is a code point of its own. Stepping back
+        // over it would drop a real code unit for no reason, so the back-off must require a PAIR.
+        val loneHigh = Char(0xD83D).toString()
+        val text = "x".repeat(TxtTocRuleEngine.SAMPLE_SIZE_UTF16 - 1) + loneHigh + "x".repeat(10)
+
+        assertEquals(TxtTocRuleEngine.SAMPLE_SIZE_UTF16, TxtTocRuleEngine.sampleOf(text).length)
+    }
+
     @Test
     fun detectBestRule_returnsTheRuleInstanceFromTheSuppliedList() {
         val supplied = defaults.map { it.copy(name = it.name + " (tagged)") }
@@ -491,6 +539,25 @@ class TxtTocRuleEngineTest {
         assertTrue("must not backtrack catastrophically (took ${elapsedMs}ms)", elapsedMs < 10_000)
     }
 
+    @Test
+    fun extractHeadings_largeNoMatchDocument_terminatesWithinTheBoundedWindow() {
+        // The worst-case UNINTERRUPTIBLE window, made an asserted number rather than a claim:
+        // `find()` is one non-suspending java.util.regex call, so a document with no match at all
+        // is walked in a single uncancellable step. 14 MB is the real CJK book's size; the plan
+        // measures a full pass at ~100 ms (§5 / Appendix A.1). The ceiling below is deliberately
+        // loose — this pins the ORDER of magnitude (bounded, linear), not a benchmark.
+        val text = "没有任何章节标记的正文段落。".repeat(1_000_000) // ~14M UTF-16 units
+        val startedNs = System.nanoTime()
+        val result = run { TxtTocRuleEngine.extractHeadings(text, rule(1), noCap) }
+        val elapsedMs = (System.nanoTime() - startedNs) / 1_000_000
+
+        assertEquals(emptyList<DetectedHeading>(), result.headings)
+        assertTrue(
+            "a full no-match pass must stay bounded and linear (took ${elapsedMs}ms over ${text.length} units)",
+            elapsedMs < 10_000,
+        )
+    }
+
     // ------------------------------------------------------------------ cancellation
 
     @Test
@@ -522,13 +589,30 @@ class TxtTocRuleEngineTest {
     }
 
     @Test
-    fun detectBestRule_isCancellationCooperative() {
+    fun detectBestRule_isCancellationCooperative_betweenRules() {
         val text = (1..50_000).joinToString("\n") { "第${it}章 标题" }
         val job = CancelAfter(activeChecks = 1)
         val outcome = runWithJob(job) { TxtTocRuleEngine.detectBestRule(text, defaults) }
 
         assertTrue("cancellation must propagate out of detection", outcome.isFailure)
         assertTrue(outcome.exceptionOrNull() is CancellationException)
+    }
+
+    @Test
+    fun detectBestRule_isCancellationCooperative_whileCountingOneRulesMatches() {
+        // The between-rules test above would still pass if match COUNTING never checked at all:
+        // with one enabled rule, the checks are entry (0) and the rule boundary (1), and counting
+        // is where all the time actually goes. Cancelling only after those two forces the third
+        // check to come from INSIDE countMatches — so this fails if that check is removed.
+        val single = listOf(rule(2))
+        val matchesPerRule = TxtTocRuleEngine.CANCELLATION_CHECK_INTERVAL * 4
+        val text = (1..matchesPerRule).joinToString("\n") { "第${it}章 标题" }
+        val job = CancelAfter(activeChecks = 2)
+        val outcome = runWithJob(job) { TxtTocRuleEngine.detectBestRule(text, single) }
+
+        assertTrue("cancellation must propagate out of match counting", outcome.isFailure)
+        assertTrue(outcome.exceptionOrNull() is CancellationException)
+        assertTrue("the third check must come from inside countMatches", job.checks > 2)
     }
 
     @Test
@@ -543,6 +627,21 @@ class TxtTocRuleEngineTest {
     }
 
     // ------------------------------------------------------------------ detect → extract, joined
+
+    @Test
+    fun extractHeadings_aRuleCanMatchAcrossALineTerminator_soTheScanIsNotLineSplittable() {
+        // Load-bearing for the engine header's REJECTION of line-region chunking (Gate-4 round 1
+        // proposed it to tighten cancellation latency). TxtTocRules.WS widens whitespace to ICU's
+        // `\s`, which CONTAINS line terminators — so a heading split across lines still matches,
+        // exactly as it does on iOS's ICU. Any future "scan line by line" optimization would
+        // silently drop this match; this test is what makes that a failure instead of a shrug.
+        val text = "第\n一\n章 标题\n"
+        val headings = run { TxtTocRuleEngine.extractHeadings(text, rule(1), noCap) }.headings
+
+        assertEquals(1, headings.size)
+        assertEquals(0, headings[0].sourceOffsetUtf16)
+        assertTrue("the match spans terminators", headings[0].title.contains("\n"))
+    }
 
     @Test
     fun detectThenExtract_onARealisticCjkDocument_findsEveryChapterAtItsLineStart() {

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocRuleEngineTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocRuleEngineTest.kt
@@ -1,0 +1,565 @@
+package com.vreader.app.reader.nav
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.InternalForInheritanceCoroutinesApi
+import kotlinx.coroutines.Job
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.startCoroutine
+
+/**
+ * Feature #139 WI-2 — [TxtTocRuleEngine]: the Kotlin port of iOS `TXTTocRuleEngine`
+ * (`vreader/Services/TXT/TXTTocRuleEngine.swift:38-132`).
+ *
+ * Two properties this suite exists to protect, because everything downstream (the Contents
+ * sheet's jump target, and through it #138's paged `ensureMeasuredThrough` seam) is built on
+ * them:
+ *
+ * - **Offsets are SOURCE UTF-16 offsets at the LINE START**, leading ideographic space
+ *   included, identical under LF / CRLF / CR, and never landing inside a surrogate pair.
+ * - **Extraction is bounded BEFORE materialization** (plan §4.4 / Gate-2 R2 MEDIUM): a
+ *   pathological all-match document must stop at `limit`, not build the full match list and
+ *   then truncate.
+ *
+ * Pure JVM — no Android runtime, no Robolectric, no emulator.
+ */
+class TxtTocRuleEngineTest {
+
+    private companion object {
+        /** U+3000 IDEOGRAPHIC SPACE, built from its code point so re-encoding cannot mangle it. */
+        val IDEO: String = Char(0x3000).toString()
+
+        /** A rule that only ever matches a whitespace-only line, so its title trims to "". */
+        val BLANK_TITLE_RULE = TxtTocRule(
+            id = 900, enabled = true, name = "blank", pattern = "^[ ]{1,4}$",
+            example = "  ", serialNumber = 900,
+        )
+
+        /** A pattern `java.util.regex` cannot compile — iOS's `try?` skips these silently. */
+        val UNCOMPILABLE_RULE = TxtTocRule(
+            id = 901, enabled = true, name = "broken", pattern = "^[unclosed",
+            example = "n/a", serialNumber = 901,
+        )
+    }
+
+    private val defaults get() = TxtTocRules.defaults
+    private fun rule(id: Int) = defaults.first { it.id == id }
+
+    /** A generous per-call cap; the cap semantics get their own dedicated tests. */
+    private val noCap = Int.MAX_VALUE
+
+    // ------------------------------------------------------------------ suspend-call harness
+
+    /**
+     * Runs a suspend block with EXACTLY [job] as its coroutine context and returns the outcome.
+     *
+     * Deliberately not `runBlocking(job)` / `runTest`: those wrap the call in a NEW coroutine
+     * whose own `Job` element replaces the one under test, so a counting/self-cancelling job
+     * would never be the object `ensureActive()` queries. `startCoroutine` with a hand-built
+     * [Continuation] hands the engine the context verbatim.
+     *
+     * It also pins a real property: the engine is CPU-bound and must never actually suspend —
+     * if it did, `outcome` would still be null when this returns.
+     */
+    private fun <T> runWithJob(job: Job, block: suspend () -> T): Result<T> {
+        var outcome: Result<T>? = null
+        block.startCoroutine(Continuation(job) { outcome = it })
+        return requireNotNull(outcome) { "TxtTocRuleEngine must not suspend — it is pure CPU work" }
+    }
+
+    private fun <T> run(block: suspend () -> T): T = runWithJob(Job(), block).getOrThrow()
+
+    /**
+     * A [Job] that reports `isActive` for the first [activeChecks] queries and cancels itself on
+     * the next one — a deterministic stand-in for "the reader was closed mid-scan", with no
+     * sleeps, no threads, and no dependence on how fast the machine runs the regex.
+     *
+     * The delegate is cancelled (not merely reported inactive) so `ensureActive()` can obtain a
+     * real `CancellationException` from it.
+     */
+    @OptIn(InternalForInheritanceCoroutinesApi::class)
+    private class CancelAfter(
+        private val activeChecks: Int,
+        private val delegate: CompletableJob = Job(),
+    ) : Job by delegate {
+        var checks: Int = 0
+            private set
+
+        override val isActive: Boolean
+            get() {
+                if (checks++ >= activeChecks) delegate.cancel()
+                return delegate.isActive
+            }
+
+        /**
+         * MUST be overridden. `Job by delegate` forwards EVERY interface member — including
+         * `CoroutineContext.get` — so without this, `coroutineContext[Job]` hands back the
+         * delegate and [isActive] above is never called: the job never cancels and every
+         * assertion built on [checks] passes vacuously. (Observed exactly that, first run.)
+         */
+        @Suppress("UNCHECKED_CAST")
+        override fun <E : CoroutineContext.Element> get(key: CoroutineContext.Key<E>): E? =
+            if (key == Job) this as E else null
+    }
+
+    // ------------------------------------------------------------------ detectBestRule
+
+    @Test
+    fun detectBestRule_emptyText_returnsNull() {
+        assertNull(run { TxtTocRuleEngine.detectBestRule("", defaults) })
+    }
+
+    @Test
+    fun detectBestRule_noEnabledRules_returnsNull() {
+        val text = "第一章 甲\n第二章 乙\n"
+        assertNull(run { TxtTocRuleEngine.detectBestRule(text, emptyList()) })
+        assertNull(run { TxtTocRuleEngine.detectBestRule(text, defaults.map { it.copy(enabled = false) }) })
+    }
+
+    @Test
+    fun detectBestRule_belowTwoMatches_returnsNull() {
+        // iOS requires >= 2 matches for confidence (TXTTocRuleEngine.swift:77).
+        assertNull(run { TxtTocRuleEngine.detectBestRule("prose\n第一章 甲\nprose\n", defaults) })
+    }
+
+    @Test
+    fun detectBestRule_exactlyTwoMatches_returnsRule() {
+        val detected = run { TxtTocRuleEngine.detectBestRule("第一章 甲\nprose\n第二章 乙\n", defaults) }
+        assertNotNull("two matches is exactly the threshold, not one above it", detected)
+    }
+
+    @Test
+    fun detectBestRule_tie_firstRuleInOrderWins() {
+        // Strictly-greater comparison (`count > bestCount`) is what makes ties resolve toward the
+        // rule that appears FIRST in the list — iOS's serialNumber ordering. Two rules with the
+        // SAME pattern isolate the tie-break from any difference in matching power, and swapping
+        // the list order proves LIST ORDER decides, not the id.
+        val a = TxtTocRule(101, true, "a", rule(1).pattern, rule(1).example, 101)
+        val b = TxtTocRule(102, true, "b", rule(1).pattern, rule(1).example, 102)
+        val text = "第一章 甲\n第二章 乙\n"
+
+        assertEquals(101, run { TxtTocRuleEngine.detectBestRule(text, listOf(a, b)) }?.id)
+        assertEquals(102, run { TxtTocRuleEngine.detectBestRule(text, listOf(b, a)) }?.id)
+    }
+
+    @Test
+    fun detectBestRule_picksTheRuleWithTheMostMatches_notTheFirstThatMatches() {
+        val few = TxtTocRule(101, true, "few", "^ONLY-ONCE.*$", "ONLY-ONCE", 101)
+        val many = TxtTocRule(102, true, "many", "^第.*章.*$", "第一章", 102)
+        val text = "ONLY-ONCE x\n第一章 甲\n第二章 乙\n第三章 丙\n"
+
+        assertEquals(102, run { TxtTocRuleEngine.detectBestRule(text, listOf(few, many)) }?.id)
+    }
+
+    @Test
+    fun detectBestRule_ignoresDisabledRules() {
+        // Rule 18 (圆圈数字) ships disabled, and no ENABLED rule matches a circled-numeral line.
+        val text = "① 甲\n② 乙\n③ 丙\n"
+        assertNull("a disabled rule must not win", run { TxtTocRuleEngine.detectBestRule(text, defaults) })
+
+        // Control: the same text with that one rule enabled DOES detect — proving the null above
+        // is the enabled-filter, not a pattern that simply cannot match.
+        val enabled = defaults.map { if (it.id == 18) it.copy(enabled = true) else it }
+        assertEquals(18, run { TxtTocRuleEngine.detectBestRule(text, enabled) }?.id)
+    }
+
+    @Test
+    fun detectBestRule_samplesOnlyFirst512KUtf16Units() {
+        val filler = "x".repeat(TxtTocRuleEngine.SAMPLE_SIZE_UTF16)
+        val headings = "\n第一章 甲\n第二章 乙\n第三章 丙\n"
+
+        assertNull(
+            "headings beyond the 512K sampling window must not be counted",
+            run { TxtTocRuleEngine.detectBestRule(filler + headings, defaults) },
+        )
+        assertNotNull(
+            "control: the same headings INSIDE the window are counted",
+            run { TxtTocRuleEngine.detectBestRule(headings + filler, defaults) },
+        )
+    }
+
+    @Test
+    fun detectBestRule_returnsTheRuleInstanceFromTheSuppliedList() {
+        val supplied = defaults.map { it.copy(name = it.name + " (tagged)") }
+        val detected = run { TxtTocRuleEngine.detectBestRule("第一章 甲\n第二章 乙\n", supplied) }
+        assertNotNull(detected)
+        assertSame("the winner must be the caller's own rule object", supplied.first { it.id == detected!!.id }, detected)
+    }
+
+    @Test
+    fun detectBestRule_skipsUncompilableRules_ratherThanThrowing() {
+        // iOS uses `try?` and `continue`s past a rule that will not compile.
+        val text = "第一章 甲\n第二章 乙\n"
+        val withBroken = listOf(UNCOMPILABLE_RULE) + defaults
+        assertNotNull(run { TxtTocRuleEngine.detectBestRule(text, withBroken) })
+    }
+
+    // ------------------------------------------------------------------ extractHeadings: titles
+
+    @Test
+    fun extractHeadings_emptyText_returnsNothing() {
+        val result = run { TxtTocRuleEngine.extractHeadings("", rule(1), noCap) }
+        assertEquals(emptyList<DetectedHeading>(), result.headings)
+        assertFalse(result.hitLimit)
+    }
+
+    @Test
+    fun extractHeadings_titleIsWholeMatchedLineTrimmed() {
+        val text = "prose\n   第一章 太阳消失   \nprose\n"
+        val headings = run { TxtTocRuleEngine.extractHeadings(text, rule(1), noCap) }.headings
+
+        assertEquals(1, headings.size)
+        assertEquals("第一章 太阳消失", headings[0].title)
+        assertEquals("TXT depth is flat (plan §4.3 / D5)", 0, headings[0].depth)
+    }
+
+    @Test
+    fun extractHeadings_offsetIsLineStart_includingLeadingIdeographicSpace() {
+        // The indent is PART of the match on iOS, so the offset is the line start, not the first
+        // non-space glyph. This is the property the whole navigation path rests on.
+        // Braced: a CJK letter is a valid Kotlin identifier character, so an unbraced
+        // `$IDEO第一章` would parse as the identifier `IDEO第一章` (the WI-1 gotcha).
+        val text = "prose\n$IDEO${IDEO}第一章 太阳消失\nprose\n"
+        val headings = run { TxtTocRuleEngine.extractHeadings(text, rule(1), noCap) }.headings
+
+        assertEquals(1, headings.size)
+        assertEquals("offset is the LINE start", text.indexOf(IDEO), headings[0].sourceOffsetUtf16)
+        assertEquals("but the title is trimmed", "第一章 太阳消失", headings[0].title)
+    }
+
+    @Test
+    fun extractHeadings_headingAfterBlankLines_offsetIsTheHeadingLine_notTheBlankLine() {
+        // WI-1's reverted indent-widening bug, asserted where it would actually have hurt: as an
+        // off-by-one-LINE navigation offset. See TxtTocRules.INDENT's KDoc.
+        val text = "prose\n\n\n第一章 太阳消失\n"
+        val headings = run { TxtTocRuleEngine.extractHeadings(text, rule(1), noCap) }.headings
+
+        assertEquals(1, headings.size)
+        assertEquals(text.indexOf("第一章"), headings[0].sourceOffsetUtf16)
+    }
+
+    @Test
+    fun extractHeadings_skipsBlankTitles() {
+        // A match whose whole line trims to "" yields no entry — iOS's `guard !title.isEmpty`.
+        val text = "prose\n   \nprose\n  \n"
+        val result = run { TxtTocRuleEngine.extractHeadings(text, BLANK_TITLE_RULE, noCap) }
+
+        assertEquals(emptyList<DetectedHeading>(), result.headings)
+        assertFalse("skipped entries are not 'hit the limit'", result.hitLimit)
+    }
+
+    @Test
+    fun extractHeadings_skippedBlankTitles_doNotConsumeTheLimit() {
+        // Two blank-title lines then one real one, with limit = 1: the real heading must still be
+        // reached, i.e. skipped matches cannot silently spend the budget.
+        val mixed = TxtTocRule(902, true, "mixed", "^[ 第].{0,30}$", "第一章", 902)
+        val text = "  \n  \n第一章 甲\n"
+        val result = run { TxtTocRuleEngine.extractHeadings(text, mixed, limit = 1) }
+
+        assertEquals(listOf("第一章 甲"), result.headings.map { it.title })
+    }
+
+    @Test
+    fun extractHeadings_uncompilableRule_returnsEmpty_ratherThanThrowing() {
+        // iOS's `try?` returns []. A malformed rule must degrade to "no Contents", never crash a
+        // reader that is otherwise working.
+        val result = run { TxtTocRuleEngine.extractHeadings("第一章 甲\n", UNCOMPILABLE_RULE, noCap) }
+        assertEquals(emptyList<DetectedHeading>(), result.headings)
+        assertFalse(result.hitLimit)
+    }
+
+    // ------------------------------------------------------------------ extractHeadings: offsets
+
+    @Test
+    fun extractHeadings_headingAtOffsetZero_yieldsOffsetZero() {
+        val text = "第一章 甲\nprose\n"
+        val headings = run { TxtTocRuleEngine.extractHeadings(text, rule(1), noCap) }.headings
+
+        assertEquals(1, headings.size)
+        assertEquals(0, headings[0].sourceOffsetUtf16)
+    }
+
+    @Test
+    fun extractHeadings_headingAsFinalLine_noTrailingNewline_isFound() {
+        val text = "prose\n第一章 甲"
+        val headings = run { TxtTocRuleEngine.extractHeadings(text, rule(1), noCap) }.headings
+
+        assertEquals(listOf("第一章 甲"), headings.map { it.title })
+        assertEquals(text.indexOf("第一章"), headings[0].sourceOffsetUtf16)
+    }
+
+    @Test
+    fun extractHeadings_crlf_cr_lf_allProduceSameOffsets() {
+        // "Same offsets" means each offset is the LINE START within its own text. LF and CR are
+        // one code unit, so their offset LISTS are byte-identical; CRLF shifts by one per
+        // preceding break, and the assertion that matters is that every offset still indexes the
+        // exact heading line in that text (in particular, never the preceding "\r").
+        val lines = listOf("prose", "第一章 甲", "prose", "第二章 乙", "prose")
+        val perEol = listOf("\n", "\r", "\r\n").associateWith { eol ->
+            val text = lines.joinToString(eol)
+            val headings = run { TxtTocRuleEngine.extractHeadings(text, rule(1), noCap) }.headings
+
+            assertEquals("titles under ${eol.map { it.code }}", listOf("第一章 甲", "第二章 乙"), headings.map { it.title })
+            headings.forEach { h ->
+                assertEquals(
+                    "offset must index the heading's own first character",
+                    h.title, text.substring(h.sourceOffsetUtf16, h.sourceOffsetUtf16 + h.title.length),
+                )
+            }
+            headings.map { it.sourceOffsetUtf16 }
+        }
+
+        assertEquals("LF and CR are both one code unit", perEol["\n"], perEol["\r"])
+        // The headings sit on line indices 1 and 3, so CRLF adds exactly that many extra units —
+        // i.e. the offset tracks the SOURCE, and the extra "\r"s are counted, never skipped.
+        val breaksBeforeEachHeading = listOf(1, 3)
+        assertEquals(
+            "CRLF shifts by exactly one unit per preceding line break",
+            perEol.getValue("\n").zip(breaksBeforeEachHeading) { off, breaks -> off + breaks },
+            perEol["\r\n"],
+        )
+    }
+
+    @Test
+    fun extractHeadings_surrogatePairInTitle_offsetsAreUtf16Consistent() {
+        val emoji = "😀" // U+1F600, two UTF-16 code units
+        val text = "第一章 $emoji 甲\nprose\n第二章 乙\n"
+        val headings = run { TxtTocRuleEngine.extractHeadings(text, rule(1), noCap) }.headings
+
+        assertEquals(2, headings.size)
+        assertEquals("第一章 $emoji 甲", headings[0].title)
+        // The second heading's offset must account for BOTH code units of the pair.
+        assertEquals(text.indexOf("第二章"), headings[1].sourceOffsetUtf16)
+        assertEquals("第二章 乙", text.substring(headings[1].sourceOffsetUtf16).substringBefore("\n"))
+    }
+
+    @Test
+    fun extractHeadings_offsetNeverLandsMidSurrogatePair() {
+        val emoji = "😀"
+        val text = buildString {
+            repeat(50) { i -> append("$emoji prose $i\n第").append(i).append("章 $emoji 标题\n") }
+        }
+        val headings = run { TxtTocRuleEngine.extractHeadings(text, rule(2), noCap) }.headings
+
+        assertTrue("the fixture must actually produce headings", headings.isNotEmpty())
+        headings.forEach { h ->
+            val at = h.sourceOffsetUtf16
+            assertTrue("offset $at is in bounds", at in text.indices)
+            assertFalse(
+                "offset $at landed on a LOW surrogate — it is inside a pair",
+                text[at].isLowSurrogate(),
+            )
+            assertEquals(
+                "the code point at the offset round-trips",
+                text.codePointAt(at), text.substring(at).codePointAt(0),
+            )
+        }
+    }
+
+    @Test
+    fun extractHeadings_rtlTitle_isPreservedByteForByte() {
+        val hebrew = "שלום עולם"
+        val arabic = "الفصل الأول"
+        val text = "1. $hebrew\nprose\n2. $arabic\n"
+        val headings = run { TxtTocRuleEngine.extractHeadings(text, rule(14), noCap) }.headings
+
+        assertEquals(listOf("1. $hebrew", "2. $arabic"), headings.map { it.title })
+        headings.forEach { h ->
+            assertEquals(
+                "no reordering, no normalization, no bidi marks added",
+                h.title, text.substring(h.sourceOffsetUtf16, h.sourceOffsetUtf16 + h.title.length),
+            )
+        }
+    }
+
+    @Test
+    fun extractHeadings_returnsEntriesInDocumentOrder() {
+        val text = (1..20).joinToString("\n") { "第${it}章 标题$it\nprose $it" }
+        val headings = run { TxtTocRuleEngine.extractHeadings(text, rule(2), noCap) }.headings
+
+        assertEquals(20, headings.size)
+        assertEquals(
+            headings.map { it.sourceOffsetUtf16 }.sorted(), headings.map { it.sourceOffsetUtf16 },
+        )
+    }
+
+    // ------------------------------------------------------------------ the bounded `limit`
+
+    @Test
+    fun extractHeadings_underTheLimit_reportsNoHit() {
+        val text = (1..10).joinToString("\n") { "第${it}章 标题" }
+        val result = run { TxtTocRuleEngine.extractHeadings(text, rule(2), limit = 11) }
+
+        assertEquals(10, result.headings.size)
+        assertFalse(result.hitLimit)
+    }
+
+    @Test
+    fun extractHeadings_stopsAtLimit_doesNotMaterializeBeyondIt() {
+        // The Gate-2 R2 MEDIUM: the cap must bound the SCAN, not just the returned list.
+        //
+        // Proof is structural, not timing-based: the engine checks cancellation every
+        // CANCELLATION_CHECK_INTERVAL matches EXAMINED, so a scan that walked all 200 000 matches
+        // before truncating would query `isActive` hundreds of times. An early-stopping scan
+        // queries it only at entry. The counting Job makes that observable exactly.
+        val text = (1..200_000).joinToString("\n") { "第${it}章 标题" }
+        val job = CancelAfter(activeChecks = Int.MAX_VALUE)
+        val result = runWithJob(job) { TxtTocRuleEngine.extractHeadings(text, rule(2), limit = 10) }.getOrThrow()
+
+        assertEquals(10, result.headings.size)
+        assertTrue("reaching the limit is reported", result.hitLimit)
+        assertEquals("第1章 标题", result.headings.first().title)
+        assertEquals("第10章 标题", result.headings.last().title)
+
+        val checksIfFullScanned = 200_000 / TxtTocRuleEngine.CANCELLATION_CHECK_INTERVAL
+        assertTrue(
+            "anti-vacuity: the counting job must actually be the one the engine queries " +
+                "(a `Job by delegate` that forwards `get` would report 0 and pass trivially)",
+            job.checks >= 1,
+        )
+        assertTrue(
+            "the scan must stop at the limit, not walk all 200 000 matches " +
+                "(${job.checks} cancellation checks; a full scan would be ~$checksIfFullScanned)",
+            job.checks < checksIfFullScanned,
+        )
+    }
+
+    @Test
+    fun extractHeadings_limitOfOne_returnsExactlyTheFirstHeading() {
+        val text = "第一章 甲\n第二章 乙\n第三章 丙\n"
+        val result = run { TxtTocRuleEngine.extractHeadings(text, rule(1), limit = 1) }
+
+        assertEquals(listOf("第一章 甲"), result.headings.map { it.title })
+        assertTrue(result.hitLimit)
+    }
+
+    @Test
+    fun extractHeadings_exactlyLimitManyHeadings_reportsHitLimit() {
+        // Deliberate, documented semantics: `hitLimit` means "collection stopped because the
+        // budget was reached", so a document with EXACTLY `limit` headings reports it too. WI-4
+        // passes MAX_TOC_ENTRIES + 1, which turns this into the precise predicate "the document
+        // has MORE than MAX_TOC_ENTRIES headings".
+        val text = (1..5).joinToString("\n") { "第${it}章 标题" }
+        assertTrue(run { TxtTocRuleEngine.extractHeadings(text, rule(2), limit = 5) }.hitLimit)
+        assertFalse(run { TxtTocRuleEngine.extractHeadings(text, rule(2), limit = 6) }.hitLimit)
+    }
+
+    @Test
+    fun extractHeadings_nonPositiveLimit_isRejected() {
+        listOf(0, -1, Int.MIN_VALUE).forEach { bad ->
+            assertThrows(IllegalArgumentException::class.java) {
+                run { TxtTocRuleEngine.extractHeadings("第一章 甲\n", rule(1), limit = bad) }
+            }
+        }
+    }
+
+    @Test
+    fun extractHeadings_pathologicalAllMatchDocument_isTimeAndAllocationBounded() {
+        // Every one of 300 000 lines matches rule 14 ("1." style). Allocation is bounded by the
+        // returned list never exceeding `limit`; time is bounded by the early stop.
+        val text = (1..300_000).joinToString("\n") { "$it. 标题" }
+        val limit = 50_001
+        val startedNs = System.nanoTime()
+        val result = run { TxtTocRuleEngine.extractHeadings(text, rule(14), limit) }
+        val elapsedMs = (System.nanoTime() - startedNs) / 1_000_000
+
+        assertEquals("never more than `limit` entries are allocated", limit, result.headings.size)
+        assertTrue(result.hitLimit)
+        assertTrue("bounded in time (took ${elapsedMs}ms)", elapsedMs < 10_000)
+    }
+
+    @Test
+    fun extractHeadings_singleEnormousLine_terminatesQuickly() {
+        // R4 (ReDoS): one 2 000 000-character line whose prefix is rule 1's lazy-numeral trap and
+        // which never supplies a unit character. The bounded `.{0,30}$` tail is what keeps the
+        // search space small.
+        val text = "第" + "一".repeat(2_000_000) + "的故事没有章字"
+        val startedNs = System.nanoTime()
+        val result = run { TxtTocRuleEngine.extractHeadings(text, rule(1), noCap) }
+        val elapsedMs = (System.nanoTime() - startedNs) / 1_000_000
+
+        assertEquals(emptyList<DetectedHeading>(), result.headings)
+        assertTrue("must not backtrack catastrophically (took ${elapsedMs}ms)", elapsedMs < 10_000)
+    }
+
+    // ------------------------------------------------------------------ cancellation
+
+    @Test
+    fun extractHeadings_alreadyCancelledScope_throwsCancellationException() {
+        // A NON-cooperative loop would return a full result here; only an `ensureActive()` makes
+        // this throw. That is what makes the assertion load-bearing rather than vacuous.
+        val cancelled = Job().apply { cancel() }
+        val outcome = runWithJob(cancelled) {
+            TxtTocRuleEngine.extractHeadings("第一章 甲\n第二章 乙\n", rule(1), noCap)
+        }
+
+        assertTrue("cancellation must propagate, never be swallowed", outcome.isFailure)
+        assertTrue(outcome.exceptionOrNull() is CancellationException)
+    }
+
+    @Test
+    fun extractHeadings_isCancellationCooperative() {
+        // Cancelled MID-scan (after the 2nd check), deterministically: no sleeps, no threads.
+        val text = (1..200_000).joinToString("\n") { "第${it}章 标题" }
+        val job = CancelAfter(activeChecks = 2)
+        val outcome = runWithJob(job) { TxtTocRuleEngine.extractHeadings(text, rule(2), noCap) }
+
+        assertTrue("cancellation must propagate out of extraction", outcome.isFailure)
+        assertTrue(outcome.exceptionOrNull() is CancellationException)
+        assertTrue(
+            "the engine must check cancellation repeatedly DURING the scan, not once at entry",
+            job.checks > 2,
+        )
+    }
+
+    @Test
+    fun detectBestRule_isCancellationCooperative() {
+        val text = (1..50_000).joinToString("\n") { "第${it}章 标题" }
+        val job = CancelAfter(activeChecks = 1)
+        val outcome = runWithJob(job) { TxtTocRuleEngine.detectBestRule(text, defaults) }
+
+        assertTrue("cancellation must propagate out of detection", outcome.isFailure)
+        assertTrue(outcome.exceptionOrNull() is CancellationException)
+    }
+
+    @Test
+    fun detectBestRule_alreadyCancelledScope_throwsCancellationException() {
+        val cancelled = Job().apply { cancel() }
+        val outcome = runWithJob(cancelled) {
+            TxtTocRuleEngine.detectBestRule("第一章 甲\n第二章 乙\n", defaults)
+        }
+
+        assertTrue(outcome.isFailure)
+        assertTrue(outcome.exceptionOrNull() is CancellationException)
+    }
+
+    // ------------------------------------------------------------------ detect → extract, joined
+
+    @Test
+    fun detectThenExtract_onARealisticCjkDocument_findsEveryChapterAtItsLineStart() {
+        val chapters = listOf("第一章${IDEO}太阳消失", "第二章${IDEO}黑暗降临", "第三章${IDEO}血色黎明")
+        val text = buildString {
+            append("书名：黑暗血时代\n\n")
+            chapters.forEach { c -> append(c).append("\n\n").append("正文段落。".repeat(20)).append("\n\n") }
+        }
+
+        val detected = run { TxtTocRuleEngine.detectBestRule(text, defaults) }
+        assertNotNull(detected)
+
+        val headings = run { TxtTocRuleEngine.extractHeadings(text, detected!!, noCap) }.headings
+        assertEquals(chapters, headings.map { it.title })
+        headings.forEachIndexed { i, h ->
+            assertEquals(text.indexOf(chapters[i]), h.sourceOffsetUtf16)
+            assertEquals(0, h.depth)
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocRuleEngineTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocRuleEngineTest.kt
@@ -540,20 +540,23 @@ class TxtTocRuleEngineTest {
     }
 
     @Test
-    fun extractHeadings_largeNoMatchDocument_terminatesWithinTheBoundedWindow() {
-        // The worst-case UNINTERRUPTIBLE window, made an asserted number rather than a claim:
-        // `find()` is one non-suspending java.util.regex call, so a document with no match at all
-        // is walked in a single uncancellable step. 14 MB is the real CJK book's size; the plan
-        // measures a full pass at ~100 ms (§5 / Appendix A.1). The ceiling below is deliberately
-        // loose — this pins the ORDER of magnitude (bounded, linear), not a benchmark.
-        val text = "没有任何章节标记的正文段落。".repeat(1_000_000) // ~14M UTF-16 units
+    fun extractHeadings_largeNoMatchDocument_isACatastrophicRegressionSmokeTest() {
+        // The worst-case UNINTERRUPTIBLE window: `find()` is one non-suspending java.util.regex
+        // call, so a document with NO match at all is walked in a single uncancellable step.
+        //
+        // Stated honestly (Gate-4 round 2): one input size against a loose ceiling is a
+        // CATASTROPHIC-regression smoke test — it does not measure the ~100 ms the plan reports
+        // (§5 / Appendix A.1) and does not establish linearity. A precise budget belongs to WI-8's
+        // measured evidence on the real device, not to a JVM unit test on a shared machine.
+        // Fixture size is ~14M UTF-16 code units — about twice the real book's 7 029 609.
+        val text = "没有任何章节标记的正文段落。".repeat(1_000_000)
         val startedNs = System.nanoTime()
         val result = run { TxtTocRuleEngine.extractHeadings(text, rule(1), noCap) }
         val elapsedMs = (System.nanoTime() - startedNs) / 1_000_000
 
         assertEquals(emptyList<DetectedHeading>(), result.headings)
         assertTrue(
-            "a full no-match pass must stay bounded and linear (took ${elapsedMs}ms over ${text.length} units)",
+            "a full no-match pass must not blow up (took ${elapsedMs}ms over ${text.length} units)",
             elapsedMs < 10_000,
         )
     }
@@ -613,6 +616,36 @@ class TxtTocRuleEngineTest {
         assertTrue("cancellation must propagate out of match counting", outcome.isFailure)
         assertTrue(outcome.exceptionOrNull() is CancellationException)
         assertTrue("the third check must come from inside countMatches", job.checks > 2)
+    }
+
+    @Test
+    fun extractHeadings_cancelDuringTheFinalScanStep_isNotSwallowed() {
+        // Gate-4 round 2 LOW: a cancel landing during the LAST `next()` — the long walk to
+        // end-of-text — used to be lost, because the loop exits on null and returned a normal
+        // result. Reproduced exactly: too few matches for any in-loop interval check to fire, so
+        // the ONLY query after entry is the post-loop one.
+        val text = "第一章 甲\n第二章 乙\n"
+        val job = CancelAfter(activeChecks = 1) // entry check passes; the next query cancels
+        val outcome = runWithJob(job) { TxtTocRuleEngine.extractHeadings(text, rule(1), noCap) }
+
+        assertTrue("a cancel during the final scan step must not be swallowed", outcome.isFailure)
+        assertTrue(outcome.exceptionOrNull() is CancellationException)
+        assertEquals("exactly the entry check plus the post-loop check", 2, job.checks)
+    }
+
+    @Test
+    fun detectBestRule_cancelAfterTheLastRule_isNotSwallowed() {
+        // The detection-side twin: exhaust the entry check and every per-rule check, so the only
+        // query left is the post-loop one. The document is small enough that countMatches never
+        // reaches its interval, making the query count exact rather than approximate.
+        val text = "第一章 甲\n第二章 乙\n"
+        val checksBeforeTheEnd = 1 + defaults.count { it.enabled }
+        val job = CancelAfter(activeChecks = checksBeforeTheEnd)
+        val outcome = runWithJob(job) { TxtTocRuleEngine.detectBestRule(text, defaults) }
+
+        assertTrue("a cancel after the last rule must not be swallowed", outcome.isFailure)
+        assertTrue(outcome.exceptionOrNull() is CancellationException)
+        assertEquals(checksBeforeTheEnd + 1, job.checks)
     }
 
     @Test

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.20.15
-versionCode=168
+versionName=0.20.16
+versionCode=169


### PR DESCRIPTION
## Summary

- `TxtTocRuleEngine.detectBestRule` — iOS-parity 512K UTF-16 sampling window, `>= 2` match threshold, first-rule-in-order tie-break, disabled rules skipped.
- `TxtTocRuleEngine.extractHeadings` — line-start **source** UTF-16 offsets, whole-line trimmed titles, identical under LF / CRLF / CR, with an early-stopping `limit` and `ExtractResult.hitLimit`.
- `DetectedHeading` value type.

Part of feature #2025 (#139). Foundational WI — no user-visible behavior yet.

## Two findings worth carrying forward

**1. A TXT rule can genuinely match ACROSS a line terminator — and that is iOS parity, not a defect.** WI-1's D1b widening makes `WS` equal to ICU's `\s`, which *contains* line terminators. So rule 1 matches `第\n一\n章 标题` at offset 0, and such a title carries an embedded newline. The offset remains a valid line-start locator, so this is correct — but it has two consequences, both verified independently by the auditor:

- **WI-6's Contents row must collapse whitespace at the presentation layer** rather than assume a single-line title.
- **The scan is NOT line-splittable**, which is why round 1's prescribed chunking fix was rejected. Pinned by `extractHeadings_aRuleCanMatchAcrossALineTerminator_soTheScanIsNotLineSplittable`.

**2. A false-passing test harness was caught and fixed.** `Job by delegate` forwards `CoroutineContext.get`, so the counting job was never the one queried — the early-stop test was passing **vacuously**. Fixed by overriding `get`, and permanently guarded by an anti-vacuity assertion so it cannot silently regress.

## Deliberate signature deviation from plan §6.1

`extractHeadings(text, rule, limit)` has **no default**. The plan specified `limit = MAX_TOC_ENTRIES + 1`, but `MAX_TOC_ENTRIES` lives in WI-4's `TxtMdTocProvider.kt` — outside this WI's write-set — so a default would have duplicated `50_000` across two files, a silent-divergence risk. A required parameter is the stronger form of the audited Gate-2 R2 requirement that every call site state its own budget: **WI-4 forgetting it is now a compile error, not a silent bug.**

## Validation

- **Test gate independently re-run by the orchestrator, with `--rerun-tasks` to defeat Gradle caching**: `RUN-ANDROID-TESTS RESULT: SUCCEEDED` — **46 tests, 0 failures, 0 errors**.
- Write-set verified: exactly the 4 declared paths.
- Gate-4 Codex audit: 3 rounds, verdict **`ship-as-is`**, zero open Critical/High/Medium. Log: `.claude/codex-audits/feat-139-wi-2-toc-engine-audit.md`.
- Gate 5a: foundational tier — unit tests + audit sufficient, no device verification required.
- Docs sync: not triggered.
- Version bumped: `android/v0.20.15` → `android/v0.20.16`.

## Accepted Low

The test file is 697 lines vs the ~300 convention. Splitting needs a shared harness outside this lane's three-file write-set; module precedent includes 832/658/545/542/532-line suites. Auditor: "not a shipping defect."

## Type of Change

- [x] Feature WI (part of feature #2025)