### PR TITLE
feat(#139 WI-3): MdTocScanner — ATX/fence iOS parity + setext + YAML front matter

### DIFF
--- a/.claude/codex-audits/feat-139-wi-3-md-scanner-audit.md
+++ b/.claude/codex-audits/feat-139-wi-3-md-scanner-audit.md
@@ -1,8 +1,8 @@
 ---
 branch: feat/139-wi-3-md-scanner
-threadId: 019fcb8f-c586-7e30-a06c-27ca5991a5f9
-rounds: 3
-final_verdict: block-recommended
+threadId: 019fcb97-9687-7823-a40b-54be17f6e8bb
+rounds: 4
+final_verdict: ship-as-is
 date: 2026-08-04
 ---
 
@@ -13,9 +13,9 @@ Files under review (both new on this branch):
 - `android/app/src/main/kotlin/com/vreader/app/reader/nav/MdTocScanner.kt`
 - `android/app/src/test/kotlin/com/vreader/app/reader/nav/MdTocScannerTest.kt`
 
-Auditor: Codex `gpt-5.6-sol` via `scripts/run-codex.sh` (rule 53), read-only sandbox, three
-independent sessions. Raw transcripts: `.reports/audit-r1.txt`, `-r2.txt`, `-r3.txt` (not
-committed — they are ~170 KB each).
+Auditor: Codex `gpt-5.6-sol` via `scripts/run-codex.sh` (rule 53), read-only sandbox, four
+independent sessions. Raw transcripts: `.reports/audit-r{1,2,3,4}.txt` (not committed — ~90–215 KB
+each); the round-4 scope diff is `.reports/r4-scope.diff`.
 
 Every round was asked for the same five things: fidelity to the iOS original
 (`vreader/Services/TOCBuilder.swift:107-216`), fence/setext/front-matter edge cases,
@@ -55,24 +55,40 @@ and that `scan(text, MAX_TOC_ENTRIES + 1)` remains compatible with WI-4's `apply
 
 | Sev | Finding | Disposition |
 | --- | --- | --- |
-| Medium | Cancellation was still unbounded during range *classification*: `trimmedStart`, `trimmedEnd`, `fenceRunLength`, `parseAtxHeading` and `setextDepth` could each traverse an arbitrarily long line without a check (a huge all-space line, a huge marker run), so the header's "observed every 8 192 units inside one line" claim overclaimed. The enormous-line test cancelled inside `contentEnd()` and could not detect it. | **FIXED after the round** (`02072f85`) — every traversal that can run a line's length now goes through one shared checked pair, `walkForward` / `walkBackward`; `contentEnd` is expressed in terms of it. The header claim is restated to say exactly that. New test `scan_isCancellationCooperative_insideALongClassifierRun` cancels on the sixth query — the first one raised *inside* the setext run — with the query accounting written out in the test. |
+| Medium | Cancellation was still unbounded during range *classification*: `trimmedStart`, `trimmedEnd`, `fenceRunLength`, `parseAtxHeading` and `setextDepth` could each traverse an arbitrarily long line without a check (a huge all-space line, a huge marker run), so the header's "observed every 8 192 units inside one line" claim overclaimed. The enormous-line test cancelled inside `contentEnd()` and could not detect it. | **FIXED** (`02072f85`) — every traversal that can run a line's length now goes through one shared checked pair, `walkForward` / `walkBackward`; `contentEnd` is expressed in terms of it. The header claim is restated to say exactly that. New test `scan_isCancellationCooperative_insideALongClassifierRun` cancels on the sixth query — the first one raised *inside* the setext run — with the query accounting written out in the test. **Independently confirmed closed by round 4.** |
 
-## Status — why this artifact says `block-recommended`
+## Round 4 — threadId `019fcb97-9687-7823-a40b-54be17f6e8bb` — ship-as-is
 
-Rule 47 / rule 55 cap the in-lane audit loop at **3 rounds**, and round 3 ended
-`block-recommended`. Its single Medium is **fixed on the branch and the targeted gate is green
-(44/44)**, but that fix is itself **unaudited** — a fourth round would exceed the cap, so the lane
-stops here and reports rather than self-certifying.
+**Sanctioned override of rule 47's 3-round cap — authorized by the orchestrator, reason recorded
+so the cap is not treated as advisory by default.** Round 3 ended `block-recommended`; its single
+Medium was fixed immediately afterwards in `02072f85`, which left the fix itself unaudited. The
+lane offered an accept-with-precedent instead (merged WI-2 documents a strictly larger residual of
+the same class), and the orchestrator declined it for a specific reason: the artifact's
+`final_verdict` was `block-recommended`, the merge hook accepts only `ship-as-is` /
+`follow-up-recommended`, so the real choice was "one scoped round" versus "hand-edit a verdict
+nobody earned". One round on a ~60-line diff was the cheaper and more honest path. This is the
+same shape of override the Gate-2 plan audit took (its R4), and for the same kind of reason.
 
-To clear this, the orchestrator needs exactly one of:
+Scope was narrowed to the fix ONLY — three questions, with the `ExtractResult` signature
+deviation, ATX/fence/setext/front-matter semantics, the CR-only improvement and the file length
+declared out of scope and non-reportable.
 
-1. **One confirmation audit round** scoped to the r3 fix (the `walkForward`/`walkBackward`
-   extraction + the header claim + the new test) — then update `final_verdict` here; or
-2. **An explicit accept** of the residual with rationale. The precedent for accepting it is in
-   this feature's own merged WI-2: `TxtTocRuleEngine`'s header documents and accepts exactly this
-   class ("the worst case after a cancel is one uninterrupted walk … bounded by a full pass over
-   the text (~100 ms for the real 14 MB book)"), on a background dispatcher. The MD residual was
-   strictly smaller than that even before the fix.
+| Question | Result |
+| --- | --- |
+| Is EVERY line-length traversal now routed through the checked pair, or did the refactor move the unbounded work elsewhere? | **No finding.** Confirmed for `contentEnd`, both trims, the fence run, the fence info-string scan, the ATX opening and closing hash runs, and the setext run. "Each predicate is O(1), and no alternative unchecked loop bypasses the pair or skips checks during a pathological matching run." |
+| Does `scan_isCancellationCooperative_insideALongClassifierRun` genuinely exercise a classifier, or pass vacuously (specifically: the wrong-object shape a sibling WI hit)? | **No finding.** The auditor re-derived the query arithmetic independently — entry 1, four during the 32 768-unit terminator scan, so query 6 lands 8 192 units into `setextDepth` — and confirmed `CancelAfter`'s `CoroutineContext.get(Job)` override makes the scanner query the wrapper, "if it queried the delegate instead, the cancellation assertion would fail". The no-cancel control confirms the fixture is a valid setext heading. |
+| Does the header now claim exactly what is true? | **No finding** — "precise for the scanner's line traversals: neither overclaiming nor underclaiming". |
+
+**Severity counts: Critical 0, High 0, Medium 0, Low 0. Verdict: ship-as-is.**
+
+No code changed in round 4, so no re-test was required by the lane order; the gate was re-run
+against the final tree anyway and stayed green.
+
+## Status
+
+**Gate 4 CLOSED — zero open Critical/High/Medium findings** across four rounds (r1 H=1 M=1 L=2,
+r2 M=1 L=2, r3 M=1, r4 clean). Every finding is dispositioned above; none was accepted-with-
+rationale, all were fixed.
 
 ## Test gate
 

--- a/.claude/codex-audits/feat-139-wi-3-md-scanner-audit.md
+++ b/.claude/codex-audits/feat-139-wi-3-md-scanner-audit.md
@@ -1,0 +1,89 @@
+---
+branch: feat/139-wi-3-md-scanner
+threadId: 019fcb8f-c586-7e30-a06c-27ca5991a5f9
+rounds: 3
+final_verdict: block-recommended
+date: 2026-08-04
+---
+
+# Gate-4 audit — feature #139 WI-3 (`MdTocScanner`)
+
+Files under review (both new on this branch):
+
+- `android/app/src/main/kotlin/com/vreader/app/reader/nav/MdTocScanner.kt`
+- `android/app/src/test/kotlin/com/vreader/app/reader/nav/MdTocScannerTest.kt`
+
+Auditor: Codex `gpt-5.6-sol` via `scripts/run-codex.sh` (rule 53), read-only sandbox, three
+independent sessions. Raw transcripts: `.reports/audit-r1.txt`, `-r2.txt`, `-r3.txt` (not
+committed — they are ~170 KB each).
+
+Every round was asked for the same five things: fidelity to the iOS original
+(`vreader/Services/TOCBuilder.swift:107-216`), fence/setext/front-matter edge cases,
+source-offset correctness under LF/CRLF/CR, **whether any named test passes vacuously**, and
+Kotlin-specific hazards.
+
+## Round 1 — threadId `019fcb83-2b74-7ac1-8682-2ed15bda82ee` — block-recommended
+
+| Sev | Finding | Disposition |
+| --- | --- | --- |
+| High | MD extraction was unbounded before materialization: `scan` returned a bare `List` and built every heading of a pathological document before WI-4 could apply plan §4.4's 50 000 cap. It also disagreed with the `ExtractResult` shape WI-4's own `applyCap(result: ExtractResult)` expects. | **FIXED** (`b23e961d`) — `scan(text, limit): ExtractResult`, `require(limit > 0)`, stops the walk at the budget. Plan §6.1's `scan(text): List<DetectedHeading>` signature is superseded; §4.4 and WI-4's surface both want the bounded shape. |
+| Medium | The two-pass whole-document `lineStarts()` index ran to completion — and allocated an O(lines) `IntArray` — before the first cancellation check. | **FIXED** (`b23e961d`) — replaced by a streaming line walk; the front-matter pre-pass is bounded to 100 lines. |
+| Low | No coverage for a document ending WITH a terminator under each line ending. | **FIXED** — `md_documentEndingWithATerminator_doesNotShiftOffsets`. |
+| Low | `emptyDocument_yieldsNoHeadings` would pass against a scanner that never scans. | **FIXED** — positive control added in the same test. |
+
+Verified clean in r1: ATX/fence parity construct by construct, the trim set (Zs ∪ TAB), the
+guarded closing-hash strip, front-matter conditions, setext negatives, and "all 36 tests checked;
+none asserts against the wrong object."
+
+## Round 2 — threadId `019fcb88-0ec2-7f52-b4ec-16450c8eaf32` — block-recommended
+
+Confirmed r1's fixes landed with **no offset regression** across LF, CRLF, lone CR, terminal
+separators, separator-only input, unterminated input, empty input, and front matter ending at EOF.
+
+| Sev | Finding | Disposition |
+| --- | --- | --- |
+| Medium | Cancellation and allocation were still unbounded WITHIN one line: `contentEnd()` had no check, and every line was `substring`'d merely to classify it, so a multi-megabyte terminator-free document was copied twice and deferred a cancel for the whole walk. | **FIXED** (`6871eff3`) — classification is RANGE-based (`from`/`to` indices); the only string allocated is a heading title about to be emitted, plus one front-matter probe bounded by `MAX_FRONT_MATTER_LINE_LENGTH`. `contentEnd()` checks every 8 192 code units. |
+| Low | `scan_stopsAtLimit_doesNotMaterializeBeyondIt` only asserted the returned shape — a scan-everything-then-truncate implementation would pass it. | **FIXED** — the test now proves the early stop observably with a cancel-on-second-query job plus a same-document/no-limit control that must throw. |
+| Low | Cancellation was only tested pre-cancelled, never mid-walk. | **FIXED** — `scan_isCancellationCooperative_evenInsideOneEnormousLine`. |
+
+## Round 3 — threadId `019fcb8f-c586-7e30-a06c-27ca5991a5f9` — block-recommended
+
+No Critical, High or Low. The auditor re-derived every range bound by hand after the refactor and
+found **no offset or classifier regression**; it confirmed the bounded-allocation claim is now
+accurate, that the rewritten limit test genuinely queries the job and its control discriminates,
+and that `scan(text, MAX_TOC_ENTRIES + 1)` remains compatible with WI-4's `applyCap` flow.
+
+| Sev | Finding | Disposition |
+| --- | --- | --- |
+| Medium | Cancellation was still unbounded during range *classification*: `trimmedStart`, `trimmedEnd`, `fenceRunLength`, `parseAtxHeading` and `setextDepth` could each traverse an arbitrarily long line without a check (a huge all-space line, a huge marker run), so the header's "observed every 8 192 units inside one line" claim overclaimed. The enormous-line test cancelled inside `contentEnd()` and could not detect it. | **FIXED after the round** (`02072f85`) — every traversal that can run a line's length now goes through one shared checked pair, `walkForward` / `walkBackward`; `contentEnd` is expressed in terms of it. The header claim is restated to say exactly that. New test `scan_isCancellationCooperative_insideALongClassifierRun` cancels on the sixth query — the first one raised *inside* the setext run — with the query accounting written out in the test. |
+
+## Status — why this artifact says `block-recommended`
+
+Rule 47 / rule 55 cap the in-lane audit loop at **3 rounds**, and round 3 ended
+`block-recommended`. Its single Medium is **fixed on the branch and the targeted gate is green
+(44/44)**, but that fix is itself **unaudited** — a fourth round would exceed the cap, so the lane
+stops here and reports rather than self-certifying.
+
+To clear this, the orchestrator needs exactly one of:
+
+1. **One confirmation audit round** scoped to the r3 fix (the `walkForward`/`walkBackward`
+   extraction + the header claim + the new test) — then update `final_verdict` here; or
+2. **An explicit accept** of the residual with rationale. The precedent for accepting it is in
+   this feature's own merged WI-2: `TxtTocRuleEngine`'s header documents and accepts exactly this
+   class ("the worst case after a cancel is one uninterrupted walk … bounded by a full pass over
+   the text (~100 ms for the real 14 MB book)"), on a background dispatcher. The MD residual was
+   strictly smaller than that even before the fix.
+
+## Test gate
+
+`RUN-ANDROID-TESTS RESULT: SUCCEEDED` — `./gradlew :app:testDebugUnitTest --tests
+'*MdTocScannerTest*' --rerun-tasks`, 44 tests / 0 failures / 0 errors. JVM only; no emulator.
+
+## Deviations from the plan, recorded
+
+- **`MdTocScanner.scan` signature** — plan §6.1 says `suspend fun scan(text: String):
+  List<DetectedHeading>`; shipped as `suspend fun scan(text: String, limit: Int): ExtractResult`
+  (r1 High). WI-4 calls `scan(text, MAX_TOC_ENTRIES + 1)` and feeds `applyCap`.
+- **File length** — `MdTocScanner.kt` is 338 lines against the ~300 guideline, of which ~140 are
+  documentation. Splitting the classifiers into a third file was not available: WI-3's declared
+  write-set is exactly two files. Named as a candidate follow-up, not a defect.

--- a/android/app/src/main/kotlin/com/vreader/app/reader/nav/MdTocScanner.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/nav/MdTocScanner.kt
@@ -1,0 +1,307 @@
+// Purpose: Markdown chapter detection — walk a decoded `.md` document line by line and emit one
+// [DetectedHeading] per ATX or setext heading (feature #139 WI-3). The Kotlin port of iOS
+// `TOCBuilder.forMD` (vreader/Services/TOCBuilder.swift:107-216), plus the setext + YAML
+// front-matter extensions the #139 row scopes (plan §4.6, divergence D2).
+//
+// Pipeline: text ──lineStarts──► per-line walk (front matter → fence → blank → ATX → setext)
+//                                                              └─► List<DetectedHeading>
+//
+// Key decisions:
+// - Offsets are RAW-SOURCE UTF-16 offsets at the heading LINE's start, leading indent included —
+//   never rendered/markup-stripped ones. Everything downstream (the Contents jump, and through it
+//   #138's paged `ensureMeasuredThrough` seam) treats them as source offsets, so a display-settings
+//   reflow cannot invalidate them. A setext heading's offset is its TITLE line, not the underline.
+// - iOS parity where iOS has an opinion: each line is TRIMMED before both the fence and the
+//   heading test, so arbitrary leading indentation is legal (deliberately looser than
+//   CommonMark's 3-space limit); ATX requires exactly a U+0020 after the hashes (a tab, an NBSP
+//   or an ideographic space does NOT qualify); a trailing closing-hash run is stripped only when
+//   what remains is non-empty; depth is `hashCount - 1`, i.e. 0-based. The trim set is Swift
+//   `CharacterSet.whitespaces` = Zs ∪ {TAB}, spelled out below because Kotlin's
+//   `Char.isWhitespace()` disagrees at both ends (excludes NBSP, includes line terminators).
+// - Line splitting accepts LF, CRLF and CR — iOS splits on "\n" only, which mis-handles CR-only
+//   documents; offsets stay each variant's own source offsets (pinned by test). The one place
+//   this port is deliberately better than the original rather than merely equal.
+// - Setext (D2, Android-only — iOS has none) and YAML front matter follow plan §4.6; the exact
+//   predicates live on the functions below. Both are conservative: anything that does not fully
+//   qualify degrades to ordinary Markdown, never to swallowed content.
+//
+// Known limitations (deliberate, not oversights):
+// - This is a LINE scanner, not a CommonMark block parser: a setext underline titles the single
+//   preceding line rather than the whole preceding paragraph, and a `---` directly under a list
+//   item reads as an underline where CommonMark says thematic break. Both are confined to the
+//   Contents list (an odd row at worst); exactness would need a real block parser.
+// - No Android imports and no logging: pure CPU work that must stay JVM-unit-testable
+//   (`android.util.Log` throws "not mocked" in a plain unit test). Cancellation-cooperative, but
+//   it does not hop threads — `TxtMdTocProvider` (WI-4) owns the `withContext(dispatcher)` hop,
+//   so this object must not be called on the main thread.
+// - Unbounded by design: unlike `TxtTocRuleEngine.extractHeadings` there is no `limit` — the plan
+//   pins this signature, an MD heading costs one line of an already-resident document, and WI-4
+//   wraps the result for the cap.
+//
+// @coordinates-with: DetectedHeading.kt, TxtTocRuleEngine.kt, TxtMdTocProvider.kt
+package com.vreader.app.reader.nav
+
+import kotlinx.coroutines.ensureActive
+import kotlin.coroutines.coroutineContext
+
+/** Extracts a Markdown document's heading structure as source-offset-bearing entries. */
+object MdTocScanner {
+
+    /**
+     * A closing `---` further into the document than this many lines is not front matter.
+     *
+     * Counted as a zero-based LINE INDEX over the whole document, so the opening `---` occupies
+     * index 0 and the last accepted closing position is `MAX_FRONT_MATTER_LINES - 1`. The bound
+     * stops a document that merely OPENS with a thematic break from swallowing arbitrary content
+     * because another `---` appears much later.
+     */
+    internal const val MAX_FRONT_MATTER_LINES: Int = 100
+
+    /** Lines walked between cancellation checks. */
+    internal const val CANCELLATION_CHECK_INTERVAL: Int = 1024
+
+    /** A YAML mapping entry: `title: Foo`, or a valueless `title:`. */
+    private val YAML_MAPPING = Regex("""^\s*[A-Za-z0-9_.\-]+\s*:(\s|$)""")
+
+    /** A YAML sequence entry that is itself a mapping: `- title: Foo`. A bare `- item` is NOT. */
+    private val YAML_SEQUENCE_MAPPING = Regex("""^\s*-\s+[A-Za-z0-9_.\-]+\s*:(\s|$)""")
+
+    /**
+     * Every heading in [text], in document order.
+     *
+     * One forward pass holds two pieces of state: the open fence (char + run length), and the
+     * previous line when it was an ordinary PARAGRAPH line. A setext underline fires only against
+     * that paragraph state, and a blank line, a fence line, a line inside a fence, an ATX heading,
+     * a front-matter line and a candidate underline itself all clear it — which is precisely why
+     * `---` after any of them stays a thematic break rather than becoming a heading (plan §4.6).
+     *
+     * @return ATX and setext headings with 0-based [DetectedHeading.depth] and raw-source UTF-16
+     *         offsets. Empty for an empty document, a document with no headings, or one whose
+     *         headings all live inside fenced code blocks or YAML front matter.
+     * @throws kotlinx.coroutines.CancellationException if the calling coroutine is cancelled.
+     */
+    suspend fun scan(text: String): List<DetectedHeading> {
+        coroutineContext.ensureActive()
+        if (text.isEmpty()) return emptyList()
+
+        val starts = lineStarts(text)
+        val headings = ArrayList<DetectedHeading>()
+
+        var fenceChar: Char? = null
+        var fenceLength = 0
+        var paragraph: String? = null
+        var paragraphOffset = 0
+        var sinceCheck = 0
+
+        var index = frontMatterEndExclusive(text, starts)
+        while (index < starts.size) {
+            if (++sinceCheck >= CANCELLATION_CHECK_INTERVAL) {
+                sinceCheck = 0
+                coroutineContext.ensureActive()
+            }
+            val lineStart = starts[index]
+            val trimmed = trimmedLine(text, starts, index)
+            index++
+
+            val fence = parseFenceLine(trimmed)
+            if (fence != null) {
+                if (fenceChar == null) {
+                    fenceChar = fence.first
+                    fenceLength = fence.second
+                } else if (fence.first == fenceChar && fence.second >= fenceLength) {
+                    fenceChar = null
+                    fenceLength = 0
+                }
+                paragraph = null
+                continue
+            }
+            if (fenceChar != null || trimmed.isEmpty()) {
+                paragraph = null
+                continue
+            }
+
+            val atx = parseAtxHeading(trimmed)
+            if (atx != null) {
+                headings.add(
+                    DetectedHeading(
+                        title = atx.second,
+                        sourceOffsetUtf16 = lineStart,
+                        depth = atx.first,
+                    ),
+                )
+                paragraph = null
+                continue
+            }
+
+            val underline = setextDepth(trimmed)
+            if (underline != null) {
+                val title = paragraph
+                if (title != null) {
+                    headings.add(
+                        DetectedHeading(
+                            title = title,
+                            sourceOffsetUtf16 = paragraphOffset,
+                            depth = underline,
+                        ),
+                    )
+                }
+                // A candidate underline is never itself a paragraph, whether or not it fired.
+                paragraph = null
+                continue
+            }
+
+            paragraph = trimmed
+            paragraphOffset = lineStart
+        }
+
+        coroutineContext.ensureActive()
+        return headings
+    }
+
+    // ------------------------------------------------------------------ lines
+
+    /**
+     * The UTF-16 offset of every line start in [text], LF / CRLF / CR alike.
+     *
+     * Stores offsets rather than substrings so a large document is never copied wholesale; each
+     * line's text is materialized one at a time by [trimmedLine]. A document ending in a
+     * terminator gets a final empty line, matching iOS's `components(separatedBy:)`.
+     */
+    private fun lineStarts(text: String): IntArray {
+        var count = 1
+        var i = 0
+        while (i < text.length) {
+            val c = text[i]
+            if (c == '\n') {
+                count++
+            } else if (c == '\r') {
+                count++
+                if (i + 1 < text.length && text[i + 1] == '\n') i++
+            }
+            i++
+        }
+
+        val starts = IntArray(count)
+        var line = 1
+        i = 0
+        while (i < text.length) {
+            val c = text[i]
+            if (c == '\n') {
+                starts[line++] = i + 1
+            } else if (c == '\r') {
+                if (i + 1 < text.length && text[i + 1] == '\n') i++
+                starts[line++] = i + 1
+            }
+            i++
+        }
+        return starts
+    }
+
+    /** Line [index]'s text without its terminator, trimmed the way Swift `.whitespaces` trims. */
+    private fun trimmedLine(text: String, starts: IntArray, index: Int): String {
+        var end = if (index + 1 < starts.size) starts[index + 1] else text.length
+        while (end > starts[index] && (text[end - 1] == '\n' || text[end - 1] == '\r')) end--
+        return text.substring(starts[index], end).trim(::isInlineSpace)
+    }
+
+    /** Swift `CharacterSet.whitespaces` = Unicode Zs plus CHARACTER TABULATION. */
+    private fun isInlineSpace(c: Char): Boolean =
+        c == '\t' || Character.getType(c) == Character.SPACE_SEPARATOR.toInt()
+
+    // ------------------------------------------------------------------ front matter
+
+    /**
+     * The line index scanning starts at: past a recognized YAML front-matter block, else 0.
+     *
+     * All three conditions of plan §4.6(1) must hold — first line exactly `---`, a closing `---`
+     * within [MAX_FRONT_MATTER_LINES], and at least one YAML-looking line between them. If any
+     * fails the block is NOT front matter and the leading `---` is left to the ordinary walk,
+     * where it is simply a thematic break.
+     */
+    private fun frontMatterEndExclusive(text: String, starts: IntArray): Int {
+        if (starts.isEmpty() || trimmedLine(text, starts, 0) != FRONT_MATTER_DELIMITER) return 0
+
+        val limit = minOf(starts.size, MAX_FRONT_MATTER_LINES)
+        var closing = -1
+        var i = 1
+        while (i < limit) {
+            if (trimmedLine(text, starts, i) == FRONT_MATTER_DELIMITER) {
+                closing = i
+                break
+            }
+            i++
+        }
+        if (closing < 0) return 0
+
+        var looksYaml = false
+        var j = 1
+        while (j < closing) {
+            val line = trimmedLine(text, starts, j)
+            if (YAML_MAPPING.find(line) != null || YAML_SEQUENCE_MAPPING.find(line) != null) {
+                looksYaml = true
+                break
+            }
+            j++
+        }
+        return if (looksYaml) closing + 1 else 0
+    }
+
+    private const val FRONT_MATTER_DELIMITER = "---"
+
+    // ------------------------------------------------------------------ line classifiers
+
+    /**
+     * [trimmed] as a fenced-code delimiter: its marker char and run length, or `null`.
+     *
+     * iOS parity (`TOCBuilder.parseFenceLine`): the run must be at least 3 long, and a backtick
+     * fence's info string may not itself contain a backtick — `` ```kotlin` `` is not a fence.
+     */
+    private fun parseFenceLine(trimmed: String): Pair<Char, Int>? {
+        val first = trimmed.firstOrNull() ?: return null
+        if (first != '`' && first != '~') return null
+        var count = 0
+        while (count < trimmed.length && trimmed[count] == first) count++
+        if (count < 3) return null
+        if (first == '`' && trimmed.indexOf('`', count) >= 0) return null
+        return first to count
+    }
+
+    /**
+     * [trimmed] as an ATX heading: its 0-based depth and title, or `null`.
+     *
+     * iOS parity (`TOCBuilder.parseATXHeading`): 1–6 hashes, then literally a U+0020; the title is
+     * trimmed; a trailing closing-hash run is dropped only when what is left is non-empty (so
+     * `### ###` keeps `###` as its title); an empty title is not a heading.
+     */
+    private fun parseAtxHeading(trimmed: String): Pair<Int, String>? {
+        if (!trimmed.startsWith("#")) return null
+        var hashes = 0
+        while (hashes < trimmed.length && trimmed[hashes] == '#') hashes++
+        if (hashes > 6) return null
+
+        val afterHashes = trimmed.substring(hashes)
+        if (!afterHashes.startsWith(" ")) return null
+
+        var title = afterHashes.trim(::isInlineSpace)
+        if (title.endsWith("#")) {
+            val stripped = title.trimEnd('#').trim(::isInlineSpace)
+            if (stripped.isNotEmpty()) title = stripped
+        }
+        if (title.isEmpty()) return null
+        return (hashes - 1) to title
+    }
+
+    /**
+     * [trimmed] as a setext underline: depth 0 for `=`, depth 1 for `-`, or `null`.
+     *
+     * The line must be ONE contiguous run of a single marker character (length >= 1 — a lone `-`
+     * is a valid underline per CommonMark). Interior whitespace disqualifies it, so `- - -` stays
+     * a thematic break.
+     */
+    private fun setextDepth(trimmed: String): Int? {
+        val first = trimmed.firstOrNull() ?: return null
+        if (first != '=' && first != '-') return null
+        for (c in trimmed) if (c != first) return null
+        return if (first == '=') 0 else 1
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/nav/MdTocScanner.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/nav/MdTocScanner.kt
@@ -6,28 +6,25 @@
 // Pipeline: text ──streaming line walk (front matter → fence → blank → ATX → setext)──► ExtractResult
 //
 // Key decisions:
-// - Offsets are RAW-SOURCE UTF-16 offsets at the heading LINE's start, leading indent included —
-//   never rendered/markup-stripped ones. Everything downstream (the Contents jump, and through it
-//   #138's paged `ensureMeasuredThrough` seam) treats them as source offsets, so a display-settings
+// - Offsets are RAW-SOURCE UTF-16 offsets at the heading LINE's start, indent included — never
+//   rendered/markup-stripped ones. Everything downstream (the Contents jump, and through it #138's
+//   paged `ensureMeasuredThrough` seam) treats them as source offsets, so a display-settings
 //   reflow cannot invalidate them. A setext heading's offset is its TITLE line, not the underline.
-// - iOS parity where iOS has an opinion: each line is TRIMMED before both the fence and the
-//   heading test, so arbitrary leading indentation is legal (deliberately looser than
-//   CommonMark's 3-space limit); ATX requires exactly a U+0020 after the hashes (a tab, an NBSP
-//   or an ideographic space does NOT qualify); a trailing closing-hash run is stripped only when
-//   what remains is non-empty; depth is `hashCount - 1`, i.e. 0-based. The trim set is Swift
-//   `CharacterSet.whitespaces` = Zs ∪ {TAB}, spelled out below because Kotlin's
-//   `Char.isWhitespace()` disagrees at both ends (excludes NBSP, includes line terminators).
+// - iOS parity where iOS has an opinion: TRIM the line before both the fence and the heading test
+//   (so arbitrary leading indentation is legal — looser than CommonMark's 3 spaces); ATX needs
+//   exactly a U+0020 after the hashes (tab / NBSP / U+3000 do NOT qualify); the closing-hash strip
+//   is guarded; depth is `hashCount - 1`. The trim set is Swift `CharacterSet.whitespaces` =
+//   Zs ∪ {TAB}, spelled out below because Kotlin's `Char.isWhitespace()` disagrees at both ends.
 // - Line splitting accepts LF, CRLF and CR — iOS splits on "\n" only, which mis-handles CR-only
-//   documents; offsets stay each variant's own source offsets (pinned by test). The one place
-//   this port is deliberately better than the original rather than merely equal.
+//   documents; offsets stay each variant's own source offsets (pinned by test).
 // - Setext (D2, Android-only — iOS has none) and YAML front matter follow plan §4.6; the exact
 //   predicates live on the functions below. Both are conservative: anything that does not fully
 //   qualify degrades to ordinary Markdown, never to swallowed content.
-// - BOUNDED BEFORE MATERIALIZATION, exactly like `TxtTocRuleEngine.extractHeadings`: the walk
-//   takes a `limit`, returns [ExtractResult], and stops the moment it has that many headings, so
-//   a pathological all-heading document is never fully built and then truncated (plan §4.4).
-//   Nothing document-sized is allocated up front either — the walk streams line by line rather
-//   than pre-indexing every line start, which is also what keeps cancellation prompt.
+// - BOUNDED BEFORE MATERIALIZATION like `TxtTocRuleEngine.extractHeadings`: the walk takes a
+//   `limit`, returns [ExtractResult], and stops the moment it has that many headings (plan §4.4).
+//   Classification is RANGE-based — lines are tested through `(from, to)` indices — so the only
+//   string allocated is a heading TITLE about to be emitted (plus one bounded front-matter probe),
+//   and even a multi-megabyte document with no terminator at all is classified without a copy.
 //
 // Known limitations (deliberate, not oversights):
 // - This is a LINE scanner, not a CommonMark block parser: a setext underline titles the single
@@ -35,9 +32,10 @@
 //   item reads as an underline where CommonMark says thematic break. Both are confined to the
 //   Contents list (an odd row at worst); exactness would need a real block parser.
 // - No Android imports and no logging: pure CPU work that must stay JVM-unit-testable
-//   (`android.util.Log` throws "not mocked" in a plain unit test). Cancellation-cooperative at a
-//   line granularity, but it does not hop threads — `TxtMdTocProvider` (WI-4) owns the
-//   `withContext(dispatcher)` hop, so this object must not be called on the main thread.
+//   (`android.util.Log` throws "not mocked" in a plain unit test). It does not hop threads —
+//   `TxtMdTocProvider` (WI-4) owns the `withContext(dispatcher)` hop, so never call this on the
+//   main thread. Cancellation is observed every [CANCELLATION_CHECK_INTERVAL] lines AND every
+//   [CANCELLATION_CHECK_UNITS] code units inside one line, so one enormous line cannot defer it.
 //
 // @coordinates-with: DetectedHeading.kt, TxtTocRuleEngine.kt, TxtMdTocProvider.kt
 package com.vreader.app.reader.nav
@@ -49,19 +47,26 @@ import kotlin.coroutines.coroutineContext
 object MdTocScanner {
 
     /**
-     * A closing `---` further into the document than this many lines is not front matter.
-     *
-     * Counted as a zero-based LINE INDEX, so the opening `---` occupies index 0 and the last
-     * accepted closing position is `MAX_FRONT_MATTER_LINES - 1`. The bound stops a document that
-     * merely OPENS with a thematic break from swallowing arbitrary content because another `---`
-     * appears much later.
+     * A closing `---` further into the document than this many lines is not front matter. Counted
+     * as a zero-based LINE INDEX, so the opening `---` is index 0 and the last accepted closing
+     * position is `MAX_FRONT_MATTER_LINES - 1`. The bound stops a document that merely OPENS with
+     * a thematic break from swallowing arbitrary content because another `---` appears far later.
      */
     internal const val MAX_FRONT_MATTER_LINES: Int = 100
+
+    /**
+     * A front-matter line longer than this is never tested for YAML shape — the probes are the one
+     * place a `Regex` needs a real `String`, so what may be copied is bounded here rather than by
+     * the document. A 4 KB metadata key is not YAML anybody wrote, and calling it "not YAML-like"
+     * only ever degrades toward scanning the block as ordinary Markdown.
+     */
+    internal const val MAX_FRONT_MATTER_LINE_LENGTH: Int = 4096
 
     /** Lines walked between cancellation checks. */
     internal const val CANCELLATION_CHECK_INTERVAL: Int = 1024
 
-    private const val FRONT_MATTER_DELIMITER = "---"
+    /** UTF-16 code units walked WITHIN one line between cancellation checks. */
+    internal const val CANCELLATION_CHECK_UNITS: Int = 8192
 
     /** A YAML mapping entry: `title: Foo`, or a valueless `title:`. */
     private val YAML_MAPPING = Regex("""^\s*[A-Za-z0-9_.\-]+\s*:(\s|$)""")
@@ -73,18 +78,18 @@ object MdTocScanner {
      * Every heading in [text], in document order, stopping early at [limit].
      *
      * One forward pass holds two pieces of state: the open fence (char + run length), and the
-     * previous line when it was an ordinary PARAGRAPH line. A setext underline fires only against
-     * that paragraph state, and a blank line, a fence line, a line inside a fence, an ATX heading,
-     * a front-matter line and a candidate underline itself all clear it — which is precisely why
-     * `---` after any of them stays a thematic break rather than becoming a heading (plan §4.6).
+     * previous line's trimmed RANGE when it was an ordinary PARAGRAPH line. A setext underline
+     * fires only against that paragraph state, and a blank line, a fence line, a line inside a
+     * fence, an ATX heading, a front-matter line and a candidate underline itself all clear it —
+     * which is precisely why `---` after any of them stays a thematic break (plan §4.6).
      *
      * @param limit the maximum number of headings to collect; must be positive. Callers pass
      *              `cap + 1` so [ExtractResult.hitLimit] reads as "more than `cap` headings
      *              exist" (plan §4.4). Deliberately has no default, matching
      *              [TxtTocRuleEngine.extractHeadings]: every call site states its own budget.
      * @return ATX and setext headings with 0-based [DetectedHeading.depth] and raw-source UTF-16
-     *         offsets. Empty for an empty document, a document with no headings, or one whose
-     *         headings all live inside fenced code blocks or YAML front matter.
+     *         offsets. Empty for an empty document, one with no headings, or one whose headings
+     *         all live inside fenced code blocks or YAML front matter.
      * @throws IllegalArgumentException if [limit] is not positive.
      * @throws kotlinx.coroutines.CancellationException if the calling coroutine is cancelled.
      */
@@ -96,7 +101,8 @@ object MdTocScanner {
         val headings = ArrayList<DetectedHeading>()
         var fenceChar: Char? = null
         var fenceLength = 0
-        var paragraph: String? = null
+        var paragraphFrom = -1
+        var paragraphTo = -1
         var paragraphOffset = 0
         var sinceCheck = 0
 
@@ -107,48 +113,50 @@ object MdTocScanner {
                 coroutineContext.ensureActive()
             }
             val contentEnd = contentEnd(text, lineStart)
-            val trimmed = text.substring(lineStart, contentEnd).trim(::isInlineSpace)
+            val from = trimmedStart(text, lineStart, contentEnd)
+            val to = trimmedEnd(text, from, contentEnd)
             val thisLineStart = lineStart
             lineStart = nextLineStart(text, contentEnd)
 
-            val fence = parseFenceLine(trimmed)
-            if (fence != null) {
+            val fenceRun = fenceRunLength(text, from, to)
+            if (fenceRun > 0) {
                 if (fenceChar == null) {
-                    fenceChar = fence.first
-                    fenceLength = fence.second
-                } else if (fence.first == fenceChar && fence.second >= fenceLength) {
+                    fenceChar = text[from]
+                    fenceLength = fenceRun
+                } else if (text[from] == fenceChar && fenceRun >= fenceLength) {
                     fenceChar = null
                     fenceLength = 0
                 }
-                paragraph = null
+                paragraphFrom = -1
                 continue
             }
-            if (fenceChar != null || trimmed.isEmpty()) {
-                paragraph = null
+            if (fenceChar != null || from == to) {
+                paragraphFrom = -1
                 continue
             }
 
-            val atx = parseAtxHeading(trimmed)
+            val atx = parseAtxHeading(text, from, to)
             if (atx != null) {
                 headings.add(DetectedHeading(atx.second, thisLineStart, atx.first))
                 if (headings.size == limit) return ExtractResult(headings, hitLimit = true)
-                paragraph = null
+                paragraphFrom = -1
                 continue
             }
 
-            val underline = setextDepth(trimmed)
+            val underline = setextDepth(text, from, to)
             if (underline != null) {
-                val title = paragraph
-                if (title != null) {
+                if (paragraphFrom >= 0) {
+                    val title = text.substring(paragraphFrom, paragraphTo)
                     headings.add(DetectedHeading(title, paragraphOffset, underline))
                     if (headings.size == limit) return ExtractResult(headings, hitLimit = true)
                 }
                 // A candidate underline is never itself a paragraph, whether or not it fired.
-                paragraph = null
+                paragraphFrom = -1
                 continue
             }
 
-            paragraph = trimmed
+            paragraphFrom = from
+            paragraphTo = to
             paragraphOffset = thisLineStart
         }
 
@@ -158,19 +166,28 @@ object MdTocScanner {
 
     // ------------------------------------------------------------------ line walking
 
-    /** The offset just past line-[start]'s own text: its terminator, or the end of the document. */
-    private fun contentEnd(text: String, start: Int): Int {
+    /**
+     * The offset just past line-[start]'s own text: its terminator, or the end of the document.
+     * The only walk here whose length is the DOCUMENT's rather than a marker's — hence the
+     * intra-line cancellation check (a terminator-free document is one single line).
+     */
+    private suspend fun contentEnd(text: String, start: Int): Int {
         var end = start
-        while (end < text.length && text[end] != '\n' && text[end] != '\r') end++
+        var sinceCheck = 0
+        while (end < text.length && text[end] != '\n' && text[end] != '\r') {
+            if (++sinceCheck >= CANCELLATION_CHECK_UNITS) {
+                sinceCheck = 0
+                coroutineContext.ensureActive()
+            }
+            end++
+        }
         return end
     }
 
     /**
      * The start of the line after the one whose content ends at [contentEnd], or `-1` when that
-     * line was the document's last.
-     *
-     * LF, CRLF and CR are all one terminator. A document that ends WITH a terminator therefore
-     * yields one final empty line — matching iOS's `components(separatedBy:)` — and only then -1.
+     * line was the document's last. LF, CRLF and CR are all one terminator, so a document ending
+     * WITH one yields a final empty line — as iOS's `components(separatedBy:)` does — then -1.
      */
     private fun nextLineStart(text: String, contentEnd: Int): Int {
         if (contentEnd >= text.length) return -1
@@ -178,6 +195,18 @@ object MdTocScanner {
             contentEnd + 1 < text.length &&
             text[contentEnd + 1] == '\n'
         return contentEnd + if (crlf) 2 else 1
+    }
+
+    private fun trimmedStart(text: String, from: Int, to: Int): Int {
+        var start = from
+        while (start < to && isInlineSpace(text[start])) start++
+        return start
+    }
+
+    private fun trimmedEnd(text: String, from: Int, to: Int): Int {
+        var end = to
+        while (end > from && isInlineSpace(text[end - 1])) end--
+        return end
     }
 
     /** Swift `CharacterSet.whitespaces` = Unicode Zs plus CHARACTER TABULATION. */
@@ -192,27 +221,28 @@ object MdTocScanner {
      *
      * All three conditions of plan §4.6(1) must hold — first line exactly `---`, a closing `---`
      * within [MAX_FRONT_MATTER_LINES], and at least one YAML-looking line between them. If any
-     * fails the block is NOT front matter and the leading `---` is left to the ordinary walk,
-     * where it is simply a thematic break. The pre-pass is bounded to at most
-     * [MAX_FRONT_MATTER_LINES] lines, so it can never become a document-sized scan of its own.
+     * fails the block is NOT front matter and the leading `---` is left to the ordinary walk as a
+     * thematic break. Bounded in line COUNT and line LENGTH, so never a document-sized pre-pass.
      */
-    private fun frontMatterEndOffset(text: String): Int {
+    private suspend fun frontMatterEndOffset(text: String): Int {
         var end = contentEnd(text, 0)
-        if (text.substring(0, end).trim(::isInlineSpace) != FRONT_MATTER_DELIMITER) return 0
+        val openFrom = trimmedStart(text, 0, end)
+        if (!isDelimiter(text, openFrom, trimmedEnd(text, openFrom, end))) return 0
 
         var looksYaml = false
         var index = 1
         var start = nextLineStart(text, end)
         while (start >= 0 && index < MAX_FRONT_MATTER_LINES) {
             end = contentEnd(text, start)
-            val line = text.substring(start, end).trim(::isInlineSpace)
-            if (line == FRONT_MATTER_DELIMITER) {
+            val from = trimmedStart(text, start, end)
+            val to = trimmedEnd(text, from, end)
+            if (isDelimiter(text, from, to)) {
                 return if (looksYaml) nextLineStart(text, end) else 0
             }
-            if (!looksYaml && (YAML_MAPPING.containsMatchIn(line) ||
-                    YAML_SEQUENCE_MAPPING.containsMatchIn(line))
-            ) {
-                looksYaml = true
+            if (!looksYaml && to - from in 1..MAX_FRONT_MATTER_LINE_LENGTH) {
+                val line = text.substring(from, to)
+                looksYaml = YAML_MAPPING.containsMatchIn(line) ||
+                    YAML_SEQUENCE_MAPPING.containsMatchIn(line)
             }
             start = nextLineStart(text, end)
             index++
@@ -220,60 +250,75 @@ object MdTocScanner {
         return 0
     }
 
+    /** `[from, to)` is exactly `---`, the front-matter delimiter. */
+    private fun isDelimiter(text: String, from: Int, to: Int): Boolean =
+        to - from == 3 && text[from] == '-' && text[from + 1] == '-' && text[from + 2] == '-'
+
     // ------------------------------------------------------------------ line classifiers
 
     /**
-     * [trimmed] as a fenced-code delimiter: its marker char and run length, or `null`.
-     *
-     * iOS parity (`TOCBuilder.parseFenceLine`): the run must be at least 3 long, and a backtick
-     * fence's info string may not itself contain a backtick — `` ```kotlin` `` is not a fence.
+     * The fence run length when trimmed line `[from, to)` is a fenced-code delimiter, else 0. iOS
+     * parity (`TOCBuilder.parseFenceLine`): run of at least 3, and a backtick fence's info string
+     * may not itself contain a backtick — `` ```kotlin` `` is not a fence.
      */
-    private fun parseFenceLine(trimmed: String): Pair<Char, Int>? {
-        val first = trimmed.firstOrNull() ?: return null
-        if (first != '`' && first != '~') return null
-        var count = 0
-        while (count < trimmed.length && trimmed[count] == first) count++
-        if (count < 3) return null
-        if (first == '`' && trimmed.indexOf('`', count) >= 0) return null
-        return first to count
-    }
-
-    /**
-     * [trimmed] as an ATX heading: its 0-based depth and title, or `null`.
-     *
-     * iOS parity (`TOCBuilder.parseATXHeading`): 1–6 hashes, then literally a U+0020; the title is
-     * trimmed; a trailing closing-hash run is dropped only when what is left is non-empty (so
-     * `### ###` keeps `###` as its title); an empty title is not a heading.
-     */
-    private fun parseAtxHeading(trimmed: String): Pair<Int, String>? {
-        if (!trimmed.startsWith("#")) return null
-        var hashes = 0
-        while (hashes < trimmed.length && trimmed[hashes] == '#') hashes++
-        if (hashes > 6) return null
-
-        val afterHashes = trimmed.substring(hashes)
-        if (!afterHashes.startsWith(" ")) return null
-
-        var title = afterHashes.trim(::isInlineSpace)
-        if (title.endsWith("#")) {
-            val stripped = title.trimEnd('#').trim(::isInlineSpace)
-            if (stripped.isNotEmpty()) title = stripped
+    private fun fenceRunLength(text: String, from: Int, to: Int): Int {
+        if (from >= to) return 0
+        val first = text[from]
+        if (first != '`' && first != '~') return 0
+        var i = from
+        while (i < to && text[i] == first) i++
+        val count = i - from
+        if (count < 3) return 0
+        if (first == '`') {
+            var j = i
+            while (j < to) {
+                if (text[j] == '`') return 0
+                j++
+            }
         }
-        if (title.isEmpty()) return null
-        return (hashes - 1) to title
+        return count
     }
 
     /**
-     * [trimmed] as a setext underline: depth 0 for `=`, depth 1 for `-`, or `null`.
-     *
-     * The line must be ONE contiguous run of a single marker character (length >= 1 — a lone `-`
-     * is a valid underline per CommonMark). Interior whitespace disqualifies it, so `- - -` stays
-     * a thematic break.
+     * Trimmed line `[from, to)` as an ATX heading: its 0-based depth and title, or `null`. iOS
+     * parity (`TOCBuilder.parseATXHeading`): 1–6 hashes, then literally a U+0020; title trimmed; a
+     * trailing closing-hash run dropped only when what is left is non-empty (so `### ###` keeps
+     * `###` as its title); an empty title is not a heading.
      */
-    private fun setextDepth(trimmed: String): Int? {
-        val first = trimmed.firstOrNull() ?: return null
+    private fun parseAtxHeading(text: String, from: Int, to: Int): Pair<Int, String>? {
+        if (from >= to || text[from] != '#') return null
+        var i = from
+        while (i < to && text[i] == '#') i++
+        val hashes = i - from
+        if (hashes > 6) return null
+        if (i >= to || text[i] != ' ') return null
+
+        val start = trimmedStart(text, i, to)
+        var end = trimmedEnd(text, start, to)
+        if (end > start && text[end - 1] == '#') {
+            var stripped = end
+            while (stripped > start && text[stripped - 1] == '#') stripped--
+            stripped = trimmedEnd(text, start, stripped)
+            if (stripped > start) end = stripped
+        }
+        if (start >= end) return null
+        return (hashes - 1) to text.substring(start, end)
+    }
+
+    /**
+     * Trimmed line `[from, to)` as a setext underline: depth 0 for `=`, 1 for `-`, else `null`. It
+     * must be ONE contiguous run of a single marker char (length >= 1 — a lone `-` is a valid
+     * underline per CommonMark); interior whitespace disqualifies it, so `- - -` stays a break.
+     */
+    private fun setextDepth(text: String, from: Int, to: Int): Int? {
+        if (from >= to) return null
+        val first = text[from]
         if (first != '=' && first != '-') return null
-        for (c in trimmed) if (c != first) return null
+        var i = from
+        while (i < to) {
+            if (text[i] != first) return null
+            i++
+        }
         return if (first == '=') 0 else 1
     }
 }

--- a/android/app/src/main/kotlin/com/vreader/app/reader/nav/MdTocScanner.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/nav/MdTocScanner.kt
@@ -3,8 +3,7 @@
 // `TOCBuilder.forMD` (vreader/Services/TOCBuilder.swift:107-216), plus the setext + YAML
 // front-matter extensions the #139 row scopes (plan §4.6, divergence D2).
 //
-// Pipeline: text ──lineStarts──► per-line walk (front matter → fence → blank → ATX → setext)
-//                                                              └─► List<DetectedHeading>
+// Pipeline: text ──streaming line walk (front matter → fence → blank → ATX → setext)──► ExtractResult
 //
 // Key decisions:
 // - Offsets are RAW-SOURCE UTF-16 offsets at the heading LINE's start, leading indent included —
@@ -24,6 +23,11 @@
 // - Setext (D2, Android-only — iOS has none) and YAML front matter follow plan §4.6; the exact
 //   predicates live on the functions below. Both are conservative: anything that does not fully
 //   qualify degrades to ordinary Markdown, never to swallowed content.
+// - BOUNDED BEFORE MATERIALIZATION, exactly like `TxtTocRuleEngine.extractHeadings`: the walk
+//   takes a `limit`, returns [ExtractResult], and stops the moment it has that many headings, so
+//   a pathological all-heading document is never fully built and then truncated (plan §4.4).
+//   Nothing document-sized is allocated up front either — the walk streams line by line rather
+//   than pre-indexing every line start, which is also what keeps cancellation prompt.
 //
 // Known limitations (deliberate, not oversights):
 // - This is a LINE scanner, not a CommonMark block parser: a setext underline titles the single
@@ -31,12 +35,9 @@
 //   item reads as an underline where CommonMark says thematic break. Both are confined to the
 //   Contents list (an odd row at worst); exactness would need a real block parser.
 // - No Android imports and no logging: pure CPU work that must stay JVM-unit-testable
-//   (`android.util.Log` throws "not mocked" in a plain unit test). Cancellation-cooperative, but
-//   it does not hop threads — `TxtMdTocProvider` (WI-4) owns the `withContext(dispatcher)` hop,
-//   so this object must not be called on the main thread.
-// - Unbounded by design: unlike `TxtTocRuleEngine.extractHeadings` there is no `limit` — the plan
-//   pins this signature, an MD heading costs one line of an already-resident document, and WI-4
-//   wraps the result for the cap.
+//   (`android.util.Log` throws "not mocked" in a plain unit test). Cancellation-cooperative at a
+//   line granularity, but it does not hop threads — `TxtMdTocProvider` (WI-4) owns the
+//   `withContext(dispatcher)` hop, so this object must not be called on the main thread.
 //
 // @coordinates-with: DetectedHeading.kt, TxtTocRuleEngine.kt, TxtMdTocProvider.kt
 package com.vreader.app.reader.nav
@@ -50,15 +51,17 @@ object MdTocScanner {
     /**
      * A closing `---` further into the document than this many lines is not front matter.
      *
-     * Counted as a zero-based LINE INDEX over the whole document, so the opening `---` occupies
-     * index 0 and the last accepted closing position is `MAX_FRONT_MATTER_LINES - 1`. The bound
-     * stops a document that merely OPENS with a thematic break from swallowing arbitrary content
-     * because another `---` appears much later.
+     * Counted as a zero-based LINE INDEX, so the opening `---` occupies index 0 and the last
+     * accepted closing position is `MAX_FRONT_MATTER_LINES - 1`. The bound stops a document that
+     * merely OPENS with a thematic break from swallowing arbitrary content because another `---`
+     * appears much later.
      */
     internal const val MAX_FRONT_MATTER_LINES: Int = 100
 
     /** Lines walked between cancellation checks. */
     internal const val CANCELLATION_CHECK_INTERVAL: Int = 1024
+
+    private const val FRONT_MATTER_DELIMITER = "---"
 
     /** A YAML mapping entry: `title: Foo`, or a valueless `title:`. */
     private val YAML_MAPPING = Regex("""^\s*[A-Za-z0-9_.\-]+\s*:(\s|$)""")
@@ -67,7 +70,7 @@ object MdTocScanner {
     private val YAML_SEQUENCE_MAPPING = Regex("""^\s*-\s+[A-Za-z0-9_.\-]+\s*:(\s|$)""")
 
     /**
-     * Every heading in [text], in document order.
+     * Every heading in [text], in document order, stopping early at [limit].
      *
      * One forward pass holds two pieces of state: the open fence (char + run length), and the
      * previous line when it was an ordinary PARAGRAPH line. A setext underline fires only against
@@ -75,33 +78,38 @@ object MdTocScanner {
      * a front-matter line and a candidate underline itself all clear it — which is precisely why
      * `---` after any of them stays a thematic break rather than becoming a heading (plan §4.6).
      *
+     * @param limit the maximum number of headings to collect; must be positive. Callers pass
+     *              `cap + 1` so [ExtractResult.hitLimit] reads as "more than `cap` headings
+     *              exist" (plan §4.4). Deliberately has no default, matching
+     *              [TxtTocRuleEngine.extractHeadings]: every call site states its own budget.
      * @return ATX and setext headings with 0-based [DetectedHeading.depth] and raw-source UTF-16
      *         offsets. Empty for an empty document, a document with no headings, or one whose
      *         headings all live inside fenced code blocks or YAML front matter.
+     * @throws IllegalArgumentException if [limit] is not positive.
      * @throws kotlinx.coroutines.CancellationException if the calling coroutine is cancelled.
      */
-    suspend fun scan(text: String): List<DetectedHeading> {
+    suspend fun scan(text: String, limit: Int): ExtractResult {
+        require(limit > 0) { "limit must be positive, was $limit" }
         coroutineContext.ensureActive()
-        if (text.isEmpty()) return emptyList()
+        if (text.isEmpty()) return ExtractResult.EMPTY
 
-        val starts = lineStarts(text)
         val headings = ArrayList<DetectedHeading>()
-
         var fenceChar: Char? = null
         var fenceLength = 0
         var paragraph: String? = null
         var paragraphOffset = 0
         var sinceCheck = 0
 
-        var index = frontMatterEndExclusive(text, starts)
-        while (index < starts.size) {
+        var lineStart = frontMatterEndOffset(text)
+        while (lineStart >= 0) {
             if (++sinceCheck >= CANCELLATION_CHECK_INTERVAL) {
                 sinceCheck = 0
                 coroutineContext.ensureActive()
             }
-            val lineStart = starts[index]
-            val trimmed = trimmedLine(text, starts, index)
-            index++
+            val contentEnd = contentEnd(text, lineStart)
+            val trimmed = text.substring(lineStart, contentEnd).trim(::isInlineSpace)
+            val thisLineStart = lineStart
+            lineStart = nextLineStart(text, contentEnd)
 
             val fence = parseFenceLine(trimmed)
             if (fence != null) {
@@ -122,13 +130,8 @@ object MdTocScanner {
 
             val atx = parseAtxHeading(trimmed)
             if (atx != null) {
-                headings.add(
-                    DetectedHeading(
-                        title = atx.second,
-                        sourceOffsetUtf16 = lineStart,
-                        depth = atx.first,
-                    ),
-                )
+                headings.add(DetectedHeading(atx.second, thisLineStart, atx.first))
+                if (headings.size == limit) return ExtractResult(headings, hitLimit = true)
                 paragraph = null
                 continue
             }
@@ -137,13 +140,8 @@ object MdTocScanner {
             if (underline != null) {
                 val title = paragraph
                 if (title != null) {
-                    headings.add(
-                        DetectedHeading(
-                            title = title,
-                            sourceOffsetUtf16 = paragraphOffset,
-                            depth = underline,
-                        ),
-                    )
+                    headings.add(DetectedHeading(title, paragraphOffset, underline))
+                    if (headings.size == limit) return ExtractResult(headings, hitLimit = true)
                 }
                 // A candidate underline is never itself a paragraph, whether or not it fired.
                 paragraph = null
@@ -151,57 +149,35 @@ object MdTocScanner {
             }
 
             paragraph = trimmed
-            paragraphOffset = lineStart
+            paragraphOffset = thisLineStart
         }
 
         coroutineContext.ensureActive()
-        return headings
+        return ExtractResult(headings, hitLimit = false)
     }
 
-    // ------------------------------------------------------------------ lines
+    // ------------------------------------------------------------------ line walking
+
+    /** The offset just past line-[start]'s own text: its terminator, or the end of the document. */
+    private fun contentEnd(text: String, start: Int): Int {
+        var end = start
+        while (end < text.length && text[end] != '\n' && text[end] != '\r') end++
+        return end
+    }
 
     /**
-     * The UTF-16 offset of every line start in [text], LF / CRLF / CR alike.
+     * The start of the line after the one whose content ends at [contentEnd], or `-1` when that
+     * line was the document's last.
      *
-     * Stores offsets rather than substrings so a large document is never copied wholesale; each
-     * line's text is materialized one at a time by [trimmedLine]. A document ending in a
-     * terminator gets a final empty line, matching iOS's `components(separatedBy:)`.
+     * LF, CRLF and CR are all one terminator. A document that ends WITH a terminator therefore
+     * yields one final empty line — matching iOS's `components(separatedBy:)` — and only then -1.
      */
-    private fun lineStarts(text: String): IntArray {
-        var count = 1
-        var i = 0
-        while (i < text.length) {
-            val c = text[i]
-            if (c == '\n') {
-                count++
-            } else if (c == '\r') {
-                count++
-                if (i + 1 < text.length && text[i + 1] == '\n') i++
-            }
-            i++
-        }
-
-        val starts = IntArray(count)
-        var line = 1
-        i = 0
-        while (i < text.length) {
-            val c = text[i]
-            if (c == '\n') {
-                starts[line++] = i + 1
-            } else if (c == '\r') {
-                if (i + 1 < text.length && text[i + 1] == '\n') i++
-                starts[line++] = i + 1
-            }
-            i++
-        }
-        return starts
-    }
-
-    /** Line [index]'s text without its terminator, trimmed the way Swift `.whitespaces` trims. */
-    private fun trimmedLine(text: String, starts: IntArray, index: Int): String {
-        var end = if (index + 1 < starts.size) starts[index + 1] else text.length
-        while (end > starts[index] && (text[end - 1] == '\n' || text[end - 1] == '\r')) end--
-        return text.substring(starts[index], end).trim(::isInlineSpace)
+    private fun nextLineStart(text: String, contentEnd: Int): Int {
+        if (contentEnd >= text.length) return -1
+        val crlf = text[contentEnd] == '\r' &&
+            contentEnd + 1 < text.length &&
+            text[contentEnd + 1] == '\n'
+        return contentEnd + if (crlf) 2 else 1
     }
 
     /** Swift `CharacterSet.whitespaces` = Unicode Zs plus CHARACTER TABULATION. */
@@ -211,42 +187,38 @@ object MdTocScanner {
     // ------------------------------------------------------------------ front matter
 
     /**
-     * The line index scanning starts at: past a recognized YAML front-matter block, else 0.
+     * The offset scanning starts at: past a recognized YAML front-matter block, else 0 (or `-1`
+     * when a recognized block runs to the very end of the document).
      *
      * All three conditions of plan §4.6(1) must hold — first line exactly `---`, a closing `---`
      * within [MAX_FRONT_MATTER_LINES], and at least one YAML-looking line between them. If any
      * fails the block is NOT front matter and the leading `---` is left to the ordinary walk,
-     * where it is simply a thematic break.
+     * where it is simply a thematic break. The pre-pass is bounded to at most
+     * [MAX_FRONT_MATTER_LINES] lines, so it can never become a document-sized scan of its own.
      */
-    private fun frontMatterEndExclusive(text: String, starts: IntArray): Int {
-        if (starts.isEmpty() || trimmedLine(text, starts, 0) != FRONT_MATTER_DELIMITER) return 0
-
-        val limit = minOf(starts.size, MAX_FRONT_MATTER_LINES)
-        var closing = -1
-        var i = 1
-        while (i < limit) {
-            if (trimmedLine(text, starts, i) == FRONT_MATTER_DELIMITER) {
-                closing = i
-                break
-            }
-            i++
-        }
-        if (closing < 0) return 0
+    private fun frontMatterEndOffset(text: String): Int {
+        var end = contentEnd(text, 0)
+        if (text.substring(0, end).trim(::isInlineSpace) != FRONT_MATTER_DELIMITER) return 0
 
         var looksYaml = false
-        var j = 1
-        while (j < closing) {
-            val line = trimmedLine(text, starts, j)
-            if (YAML_MAPPING.find(line) != null || YAML_SEQUENCE_MAPPING.find(line) != null) {
-                looksYaml = true
-                break
+        var index = 1
+        var start = nextLineStart(text, end)
+        while (start >= 0 && index < MAX_FRONT_MATTER_LINES) {
+            end = contentEnd(text, start)
+            val line = text.substring(start, end).trim(::isInlineSpace)
+            if (line == FRONT_MATTER_DELIMITER) {
+                return if (looksYaml) nextLineStart(text, end) else 0
             }
-            j++
+            if (!looksYaml && (YAML_MAPPING.containsMatchIn(line) ||
+                    YAML_SEQUENCE_MAPPING.containsMatchIn(line))
+            ) {
+                looksYaml = true
+            }
+            start = nextLineStart(text, end)
+            index++
         }
-        return if (looksYaml) closing + 1 else 0
+        return 0
     }
-
-    private const val FRONT_MATTER_DELIMITER = "---"
 
     // ------------------------------------------------------------------ line classifiers
 

--- a/android/app/src/main/kotlin/com/vreader/app/reader/nav/MdTocScanner.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/nav/MdTocScanner.kt
@@ -34,8 +34,10 @@
 // - No Android imports and no logging: pure CPU work that must stay JVM-unit-testable
 //   (`android.util.Log` throws "not mocked" in a plain unit test). It does not hop threads —
 //   `TxtMdTocProvider` (WI-4) owns the `withContext(dispatcher)` hop, so never call this on the
-//   main thread. Cancellation is observed every [CANCELLATION_CHECK_INTERVAL] lines AND every
-//   [CANCELLATION_CHECK_UNITS] code units inside one line, so one enormous line cannot defer it.
+//   main thread. Cancellation is observed every [CANCELLATION_CHECK_INTERVAL] lines and, inside a
+//   line, every [CANCELLATION_CHECK_UNITS] code units — EVERY traversal that can run a line's
+//   length (the terminator scan, both trims, the fence/hash/underline runs) goes through the one
+//   checked `walkForward`/`walkBackward` pair, so one enormous line cannot defer a cancel either.
 //
 // @coordinates-with: DetectedHeading.kt, TxtTocRuleEngine.kt, TxtMdTocProvider.kt
 package com.vreader.app.reader.nav
@@ -167,22 +169,53 @@ object MdTocScanner {
     // ------------------------------------------------------------------ line walking
 
     /**
-     * The offset just past line-[start]'s own text: its terminator, or the end of the document.
-     * The only walk here whose length is the DOCUMENT's rather than a marker's — hence the
-     * intra-line cancellation check (a terminator-free document is one single line).
+     * The first index at or after [from] (and before [to]) whose char fails [predicate], or [to].
+     *
+     * THE shared walk: every traversal in this file that can run the length of a line goes through
+     * it, so the cancellation check lives in exactly one place and no single enormous line — a
+     * terminator-free document is one line — can defer a cancel past
+     * [CANCELLATION_CHECK_UNITS] code units.
      */
-    private suspend fun contentEnd(text: String, start: Int): Int {
-        var end = start
+    private suspend fun walkForward(
+        text: String,
+        from: Int,
+        to: Int,
+        predicate: (Char) -> Boolean,
+    ): Int {
+        var i = from
         var sinceCheck = 0
-        while (end < text.length && text[end] != '\n' && text[end] != '\r') {
+        while (i < to && predicate(text[i])) {
             if (++sinceCheck >= CANCELLATION_CHECK_UNITS) {
                 sinceCheck = 0
                 coroutineContext.ensureActive()
             }
-            end++
+            i++
         }
-        return end
+        return i
     }
+
+    /** [walkForward]'s mirror: the first index walking back from [to] whose char fails. */
+    private suspend fun walkBackward(
+        text: String,
+        from: Int,
+        to: Int,
+        predicate: (Char) -> Boolean,
+    ): Int {
+        var i = to
+        var sinceCheck = 0
+        while (i > from && predicate(text[i - 1])) {
+            if (++sinceCheck >= CANCELLATION_CHECK_UNITS) {
+                sinceCheck = 0
+                coroutineContext.ensureActive()
+            }
+            i--
+        }
+        return i
+    }
+
+    /** The offset just past line-[start]'s own text: its terminator, or the end of the document. */
+    private suspend fun contentEnd(text: String, start: Int): Int =
+        walkForward(text, start, text.length) { it != '\n' && it != '\r' }
 
     /**
      * The start of the line after the one whose content ends at [contentEnd], or `-1` when that
@@ -197,17 +230,11 @@ object MdTocScanner {
         return contentEnd + if (crlf) 2 else 1
     }
 
-    private fun trimmedStart(text: String, from: Int, to: Int): Int {
-        var start = from
-        while (start < to && isInlineSpace(text[start])) start++
-        return start
-    }
+    private suspend fun trimmedStart(text: String, from: Int, to: Int): Int =
+        walkForward(text, from, to) { isInlineSpace(it) }
 
-    private fun trimmedEnd(text: String, from: Int, to: Int): Int {
-        var end = to
-        while (end > from && isInlineSpace(text[end - 1])) end--
-        return end
-    }
+    private suspend fun trimmedEnd(text: String, from: Int, to: Int): Int =
+        walkBackward(text, from, to) { isInlineSpace(it) }
 
     /** Swift `CharacterSet.whitespaces` = Unicode Zs plus CHARACTER TABULATION. */
     private fun isInlineSpace(c: Char): Boolean =
@@ -261,21 +288,15 @@ object MdTocScanner {
      * parity (`TOCBuilder.parseFenceLine`): run of at least 3, and a backtick fence's info string
      * may not itself contain a backtick — `` ```kotlin` `` is not a fence.
      */
-    private fun fenceRunLength(text: String, from: Int, to: Int): Int {
+    private suspend fun fenceRunLength(text: String, from: Int, to: Int): Int {
         if (from >= to) return 0
         val first = text[from]
         if (first != '`' && first != '~') return 0
-        var i = from
-        while (i < to && text[i] == first) i++
-        val count = i - from
+        val afterRun = walkForward(text, from, to) { it == first }
+        val count = afterRun - from
         if (count < 3) return 0
-        if (first == '`') {
-            var j = i
-            while (j < to) {
-                if (text[j] == '`') return 0
-                j++
-            }
-        }
+        // A backtick anywhere in the info string disqualifies the line.
+        if (first == '`' && walkForward(text, afterRun, to) { it != '`' } < to) return 0
         return count
     }
 
@@ -285,20 +306,17 @@ object MdTocScanner {
      * trailing closing-hash run dropped only when what is left is non-empty (so `### ###` keeps
      * `###` as its title); an empty title is not a heading.
      */
-    private fun parseAtxHeading(text: String, from: Int, to: Int): Pair<Int, String>? {
+    private suspend fun parseAtxHeading(text: String, from: Int, to: Int): Pair<Int, String>? {
         if (from >= to || text[from] != '#') return null
-        var i = from
-        while (i < to && text[i] == '#') i++
-        val hashes = i - from
+        val afterHashes = walkForward(text, from, to) { it == '#' }
+        val hashes = afterHashes - from
         if (hashes > 6) return null
-        if (i >= to || text[i] != ' ') return null
+        if (afterHashes >= to || text[afterHashes] != ' ') return null
 
-        val start = trimmedStart(text, i, to)
+        val start = trimmedStart(text, afterHashes, to)
         var end = trimmedEnd(text, start, to)
         if (end > start && text[end - 1] == '#') {
-            var stripped = end
-            while (stripped > start && text[stripped - 1] == '#') stripped--
-            stripped = trimmedEnd(text, start, stripped)
+            val stripped = trimmedEnd(text, start, walkBackward(text, start, end) { it == '#' })
             if (stripped > start) end = stripped
         }
         if (start >= end) return null
@@ -310,15 +328,11 @@ object MdTocScanner {
      * must be ONE contiguous run of a single marker char (length >= 1 — a lone `-` is a valid
      * underline per CommonMark); interior whitespace disqualifies it, so `- - -` stays a break.
      */
-    private fun setextDepth(text: String, from: Int, to: Int): Int? {
+    private suspend fun setextDepth(text: String, from: Int, to: Int): Int? {
         if (from >= to) return null
         val first = text[from]
         if (first != '=' && first != '-') return null
-        var i = from
-        while (i < to) {
-            if (text[i] != first) return null
-            i++
-        }
+        if (walkForward(text, from, to) { it == first } < to) return null
         return if (first == '=') 0 else 1
     }
 }

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/MdTocScannerTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/MdTocScannerTest.kt
@@ -555,6 +555,25 @@ class MdTocScannerTest {
     }
 
     @Test
+    fun scan_isCancellationCooperative_insideALongClassifierRun() {
+        // Gate-4 r3 MEDIUM: the terminator scan was checked but the CLASSIFIERS were not, so a
+        // line that is one enormous marker run could still defer a cancel. Query accounting for
+        // this fixture: 1 at scan's entry, then 4 while the terminator scan crosses the 32 768-unit
+        // line (one per 8 192 units) = 5. Letting exactly those 5 pass means the SIXTH query — the
+        // first one raised inside the setext underline run — is the one that cancels.
+        val units = MdTocScanner.CANCELLATION_CHECK_UNITS
+        val text = "Title\n" + "=".repeat(units * 4)
+
+        val outcome = scanWithJob(CancelAfter(5), text, limit = NO_CAP)
+
+        assertTrue(outcome.exceptionOrNull() is CancellationException)
+
+        // ...and with nothing cancelling, the same fixture is an ordinary setext heading, so the
+        // assertion above is about cancellation and not about a malformed document.
+        assertEquals(listOf("Title|0@0"), scan(text).rendered())
+    }
+
+    @Test
     fun scan_setextHeadingAlsoCountsAgainstLimit() {
         val text = "One\n===\nTwo\n---\nThree\n===\n"
 

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/MdTocScannerTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/MdTocScannerTest.kt
@@ -1,0 +1,469 @@
+package com.vreader.app.reader.nav
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.startCoroutine
+
+/**
+ * Feature #139 WI-3 — [MdTocScanner]: ATX + fence parity with iOS `TOCBuilder.forMD`
+ * (`vreader/Services/TOCBuilder.swift:107-216`), plus the Android-only setext + YAML
+ * front-matter extensions (plan §4.6, divergence D2).
+ *
+ * The properties this suite exists to protect:
+ *
+ * - **Every offset is a RAW-SOURCE UTF-16 offset at the heading LINE's start** — never a
+ *   rendered/markup-stripped offset, and correct under LF / CRLF / CR. Everything downstream
+ *   (the Contents jump, and through it #138's paged `ensureMeasuredThrough` seam) treats it
+ *   as a source offset.
+ * - **iOS parity where iOS has an opinion**: trim-before-test (so arbitrary leading
+ *   indentation is legal), a SPACE — not a tab — after the hashes, and the guarded
+ *   closing-hash strip.
+ * - **The setext/front-matter extension never fires where it must not**: inside fences, after
+ *   a blank line, after an ATX heading, or on a YAML front-matter delimiter.
+ *
+ * Pure JVM — no Android runtime, no Robolectric, no emulator.
+ */
+class MdTocScannerTest {
+
+    private companion object {
+        /** Kept out of the raw strings so a stray edit cannot silently unbalance a fence. */
+        const val TICK3 = "```"
+        const val TICK4 = "````"
+        const val TILDE3 = "~~~"
+
+        /** U+3000 IDEOGRAPHIC SPACE — a Zs, so `trim`-before-test must treat it as indent. */
+        val IDEO: String = Char(0x3000).toString()
+
+        /** U+00A0 NO-BREAK SPACE — also a Zs, and also NOT the space ATX requires. */
+        val NBSP: String = Char(0x00A0).toString()
+
+        /** Two would-be ATX lines whose separator is a Zs rather than U+0020. */
+        val NBSP_LINE: String = "\n#" + NBSP + "Nbsp\n#" + IDEO + "Ideographic"
+    }
+
+    // ------------------------------------------------------------------ suspend-call harness
+
+    /**
+     * Runs [MdTocScanner.scan] with exactly [job] as its context and returns the outcome.
+     *
+     * Deliberately not `runBlocking` / `runTest`: those install a NEW `Job` in the context, so a
+     * cancelled job under test would never be the object `ensureActive()` queries. It also pins a
+     * real property — the scanner is pure CPU work and must never actually suspend.
+     */
+    private fun scanWithJob(job: Job, text: String): Result<List<DetectedHeading>> {
+        var outcome: Result<List<DetectedHeading>>? = null
+        val block: suspend () -> List<DetectedHeading> = { MdTocScanner.scan(text) }
+        block.startCoroutine(Continuation(job) { outcome = it })
+        return requireNotNull(outcome) { "MdTocScanner must not suspend — it is pure CPU work" }
+    }
+
+    private fun scan(text: String): List<DetectedHeading> =
+        scanWithJob(Job(), text).getOrThrow()
+
+    /** `title|depth@offset` — one readable string per heading, so a diff names what moved. */
+    private fun List<DetectedHeading>.rendered(): List<String> =
+        map { "${it.title}|${it.depth}@${it.sourceOffsetUtf16}" }
+
+    private fun titles(text: String): List<String> = scan(text).map { it.title }
+
+    /** The offset the heading LINE starts at in the raw source — the assertion's own oracle. */
+    private fun offsetOfLineContaining(text: String, needle: String): Int {
+        val at = text.indexOf(needle)
+        assertTrue("fixture does not contain '$needle'", at >= 0)
+        val nl = text.lastIndexOfAny(charArrayOf('\n', '\r'), at)
+        return nl + 1
+    }
+
+    // ------------------------------------------------------------------ ATX
+
+    @Test
+    fun atx_levels1To6_mapToDepth0To5() {
+        val text = """
+            # H1
+            ## H2
+            ### H3
+            #### H4
+            ##### H5
+            ###### H6
+        """.trimIndent()
+
+        val headings = scan(text)
+
+        assertEquals(listOf("H1", "H2", "H3", "H4", "H5", "H6"), headings.map { it.title })
+        assertEquals(listOf(0, 1, 2, 3, 4, 5), headings.map { it.depth })
+        assertEquals(
+            listOf("H1", "H2", "H3", "H4", "H5", "H6").map { offsetOfLineContaining(text, "# $it") },
+            headings.map { it.sourceOffsetUtf16 },
+        )
+    }
+
+    @Test
+    fun atx_sevenHashes_isNotAHeading() {
+        val text = "####### Seven\n# Six or fewer\n"
+
+        assertEquals(listOf("Six or fewer"), titles(text))
+    }
+
+    @Test
+    fun atx_requiresSpaceAfterHashes_tabDoesNotQualify() {
+        val text = "#\tTabbed\n#NoSpace" + NBSP_LINE + "\n# Nbsp\n# Real\n"
+
+        // iOS: `afterHashes.hasPrefix(" ")` — literally U+0020, nothing else. A tab, an NBSP and
+        // an ideographic space are all whitespace and none of them qualifies. The trailing
+        // U+0020 line is the positive control: the rejections are about the separator, not the
+        // fixture. (Two of the four rejected lines carry a NBSP — deliberate belt and braces.)
+        assertEquals(listOf("Real"), titles(text))
+    }
+
+    @Test
+    fun atx_arbitraryLeadingIndentation_isAllowed() {
+        // 6 spaces is past CommonMark's 3-space limit; iOS trims first, so it is a heading.
+        val text = "      # Deep\n\t\t# Tabbed\n$IDEO# Ideographic\n"
+
+        val headings = scan(text)
+
+        assertEquals(listOf("Deep", "Tabbed", "Ideographic"), headings.map { it.title })
+        // The offset is the LINE start — the indent is INCLUDED, exactly as WI-2's TXT offsets are.
+        assertEquals(0, headings[0].sourceOffsetUtf16)
+        assertEquals(text.indexOf("\t\t#"), headings[1].sourceOffsetUtf16)
+        assertEquals(text.indexOf(IDEO), headings[2].sourceOffsetUtf16)
+    }
+
+    @Test
+    fun atx_closingHashRun_isStripped_unlessResultWouldBeEmpty() {
+        val text = """
+            # Closed #
+            ## Bare ###
+            ### ###
+            #### Hash # Middle #
+        """.trimIndent()
+
+        // "### ###" would strip to "", so the run is KEPT as the title (iOS guard).
+        assertEquals(listOf("Closed", "Bare", "###", "Hash # Middle"), titles(text))
+    }
+
+    @Test
+    fun atx_offsetIsSourceOffset_notRenderedOffset() {
+        val text = "Some **bold** and `code` and [link](http://example.com) here.\n\n## Target\n"
+
+        val heading = scan(text).single()
+
+        val sourceOffset = text.indexOf("## Target")
+        assertEquals(sourceOffset, heading.sourceOffsetUtf16)
+
+        // A RENDERED offset would sit far earlier: the markup above collapses substantially.
+        val rendered = "Some bold and code and link here.\n\nTarget\n"
+        val renderedOffset = rendered.indexOf("Target")
+        assertNotEquals(
+            "fixture is too weak to distinguish source from rendered offsets",
+            renderedOffset,
+            sourceOffset,
+        )
+    }
+
+    @Test
+    fun atx_cjkAndSurrogateTitles_arePreserved_withCodeUnitOffsets() {
+        val emoji = "📘" // U+1F4D8 BLUE BOOK — a surrogate PAIR, 2 UTF-16 units
+        val text = "$emoji intro\n# 第一章 太阳消失\n## $emoji Ends\n"
+
+        val headings = scan(text)
+
+        assertEquals(listOf("第一章 太阳消失", "$emoji Ends"), headings.map { it.title })
+        assertEquals(text.indexOf("# 第"), headings[0].sourceOffsetUtf16)
+        assertEquals(text.indexOf("## "), headings[1].sourceOffsetUtf16)
+        // Offsets are UTF-16 CODE UNITS and never land inside a pair.
+        headings.forEach { assertTrue(!text[it.sourceOffsetUtf16].isLowSurrogate()) }
+    }
+
+    @Test
+    fun headingTitles_neverContainALineTerminator() {
+        val text = "Setext title\n===\n# Atx title\n"
+
+        val headings = scan(text)
+
+        // Both kinds must actually be present, or the loop below asserts nothing.
+        assertEquals(listOf("Setext title", "Atx title"), headings.map { it.title })
+        headings.forEach { assertTrue(it.title.none { c -> c == '\n' || c == '\r' }) }
+    }
+
+    // ------------------------------------------------------------------ fences
+
+    @Test
+    fun fence_backtickFencedAtxHeading_isExcluded() {
+        val text = "$TICK3\n# Inside the fence\n$TICK3\n# Outside\n"
+
+        assertEquals(listOf("Outside"), titles(text))
+    }
+
+    @Test
+    fun fence_tildeFencedAtxHeading_isExcluded() {
+        val text = "$TILDE3\n# Inside the fence\n$TILDE3\n# Outside\n"
+
+        assertEquals(listOf("Outside"), titles(text))
+    }
+
+    @Test
+    fun fence_backtickRunWithTrailingBacktick_isNotAFence() {
+        // An info string containing a backtick disqualifies the line (iOS parseFenceLine).
+        val text = "${TICK3}kotlin`\n# Still scanned\n"
+
+        assertEquals(listOf("Still scanned"), titles(text))
+    }
+
+    @Test
+    fun fence_closingRunShorterThanOpening_doesNotClose() {
+        val text = "$TICK4\n# Inside\n$TICK3\n# Still inside\n$TICK4\n# Outside\n"
+
+        assertEquals(listOf("Outside"), titles(text))
+    }
+
+    @Test
+    fun fence_unterminatedFence_swallowsRestOfDocument() {
+        val text = "# Before\n$TICK3\n# After\n## Later\n"
+
+        assertEquals(listOf("Before"), titles(text))
+    }
+
+    @Test
+    fun fence_mismatchedCharDoesNotCloseTheOtherFence() {
+        val text = "$TICK3\n$TILDE3\n# Inside\n$TICK3\n# Outside\n"
+
+        assertEquals(listOf("Outside"), titles(text))
+    }
+
+    // ------------------------------------------------------------------ setext (D2)
+
+    @Test
+    fun setext_equalsUnderline_yieldsDepth0() {
+        val text = "Document Title\n==============\n\nbody\n"
+
+        val heading = scan(text).single()
+
+        assertEquals("Document Title", heading.title)
+        assertEquals(0, heading.depth)
+        // The heading's position is its TITLE line, not the underline.
+        assertEquals(0, heading.sourceOffsetUtf16)
+    }
+
+    @Test
+    fun setext_dashUnderline_yieldsDepth1() {
+        val text = "intro\n\nSection Title\n-------------\n"
+
+        val heading = scan(text).single()
+
+        assertEquals("Section Title", heading.title)
+        assertEquals(1, heading.depth)
+        assertEquals(text.indexOf("Section Title"), heading.sourceOffsetUtf16)
+    }
+
+    @Test
+    fun setext_singleCharUnderline_isValid() {
+        val text = "Equals One\n=\nblank\n\nDash One\n-\n"
+
+        assertEquals(
+            listOf("Equals One|0@${text.indexOf("Equals One")}", "Dash One|1@${text.indexOf("Dash One")}"),
+            scan(text).rendered(),
+        )
+    }
+
+    @Test
+    fun setext_underlineAfterBlankLine_isNotAHeading() {
+        val text = "Not a title\n\n---\n\nAlso not\n\n===\n"
+
+        assertEquals(emptyList<String>(), titles(text))
+
+        // Positive control: delete the blank lines and the SAME underlines do fire, so an
+        // always-empty scanner cannot pass this test by accident.
+        assertEquals(listOf("Not a title", "Also not"), titles(text.replace("\n\n", "\n")))
+    }
+
+    @Test
+    fun setext_underlineInsideFence_isNotAHeading() {
+        val text = "$TICK3\nTitle\n=====\n$TICK3\n# After\n"
+
+        assertEquals(listOf("After"), titles(text))
+    }
+
+    @Test
+    fun setext_underlineAfterAtxHeading_isNotAHeading() {
+        val text = "# Atx Title\n---\n"
+
+        val heading = scan(text).single()
+
+        assertEquals("Atx Title", heading.title)
+        assertEquals(0, heading.depth)
+    }
+
+    @Test
+    fun setext_underlineWithInteriorSpaces_isNotAHeading() {
+        // "- - -" is a thematic break, not an underline: the run must be contiguous.
+        val text = "Paragraph\n- - -\nOther paragraph\n= =\n"
+
+        assertEquals(emptyList<String>(), titles(text))
+
+        // Positive control: close the runs up and the same two lines DO underline.
+        assertEquals(
+            listOf("Paragraph", "Other paragraph"),
+            titles(text.replace("- - -", "---").replace("= =", "==")),
+        )
+    }
+
+    @Test
+    fun setext_underlineIsNotItselfAParagraphForTheNextUnderline() {
+        val text = "Title\n===\n===\n"
+
+        assertEquals(listOf("Title|0@0"), scan(text).rendered())
+    }
+
+    // ------------------------------------------------------------------ YAML front matter
+
+    @Test
+    fun frontMatter_closingDelimiter_doesNotEmitHeading() {
+        val text = "---\ntitle: My Document\n---\n# Real\n"
+
+        // Without the guard the closing `---` reads as a setext underline for "title: My Document".
+        assertEquals(listOf("Real"), titles(text))
+    }
+
+    @Test
+    fun frontMatter_onlyRecognizedWhenFirstLine() {
+        val text = "\n---\ntitle: My Document\n---\n# Real\n"
+
+        // Line 1 is blank, so this is NOT front matter — the delimiter is a setext underline.
+        assertEquals(listOf("title: My Document", "Real"), titles(text))
+    }
+
+    @Test
+    fun frontMatter_unterminated_isTreatedAsAbsent() {
+        val text = "---\ntitle: My Document\n# Real\n## Also real\n"
+
+        // A lone leading `---` is just a thematic break; nothing is swallowed.
+        assertEquals(listOf("Real", "Also real"), titles(text))
+    }
+
+    @Test
+    fun frontMatter_contents_yieldNoHeadings() {
+        val text = "---\ntitle: X\nblurb: |\n  # Looks like a heading\n" +
+            "Setext bait\n===\n---\n# Real\n"
+
+        assertEquals(listOf("Real"), titles(text))
+    }
+
+    @Test
+    fun frontMatter_requiresYamlLikeLine_proseBlockIsNotFrontMatter() {
+        val text = "---\nJust prose with no key here\n---\n# Real\n"
+
+        assertEquals(listOf("Just prose with no key here", "Real"), titles(text))
+    }
+
+    @Test
+    fun frontMatter_leadingThematicBreak_laterDelimiter_headingsBetweenSurvive() {
+        val text = "---\nChapter one begins here\n\n# Between A\n## Between B\n\n---\ntail\n"
+
+        assertEquals(listOf("Between A", "Between B"), titles(text))
+    }
+
+    @Test
+    fun frontMatter_closingBeyond100Lines_isTreatedAsAbsent() {
+        val body = (0 until 100).joinToString("") { "key" + it + ": v\n" }
+        val text = "---\n" + body + "---\n# Real\n"
+
+        // The closing delimiter sits at line index 101 — past MAX_FRONT_MATTER_LINES, so the
+        // block is scanned as ordinary Markdown and the last key line becomes a setext heading.
+        assertEquals(listOf("key99: v", "Real"), titles(text))
+    }
+
+    @Test
+    fun frontMatter_closingAtExactly100thLine_isRecognized() {
+        val body = (0 until 98).joinToString("") { "key" + it + ": v\n" }
+        val text = "---\n" + body + "---\n# Real\n"
+
+        // `---` at index 0, 98 keys at 1..98, closing at index 99 — the last accepted position.
+        assertEquals(listOf("Real"), titles(text))
+    }
+
+    @Test
+    fun frontMatter_sequenceMapping_dashTitleColon_isRecognized() {
+        val text = "---\n- title: Foo\n---\n# Real\n"
+
+        assertEquals(listOf("Real"), titles(text))
+    }
+
+    @Test
+    fun frontMatter_bareBulletList_isNotFrontMatter_headingsSurvive() {
+        val text = "---\n- item one\n- item two\n---\n# Real Heading\n"
+
+        // A bare sequence item is NOT a mapping, so this is a bullet list under a thematic
+        // break, not metadata: the real heading below it must survive. The line-based scanner
+        // also reads the trailing `---` as a setext underline for "- item two" (documented
+        // limitation — see MdTocScanner's header).
+        assertEquals(listOf("- item two", "Real Heading"), titles(text))
+    }
+
+    // ------------------------------------------------------------------ line endings + edges
+
+    @Test
+    fun md_crlf_cr_lf_allProduceSameSourceOffsets() {
+        val logical = listOf("# One", "body text", "## Two", "Setext", "======")
+        val lf = logical.joinToString("\n")
+        val crlf = logical.joinToString("\r\n")
+        val cr = logical.joinToString("\r")
+
+        val byLf = scan(lf)
+        val byCrlf = scan(crlf)
+        val byCr = scan(cr)
+
+        // Same headings, same order, same depths under all three conventions...
+        listOf(byLf, byCrlf, byCr).forEach {
+            assertEquals(listOf("One", "Two", "Setext"), it.map { h -> h.title })
+            assertEquals(listOf(0, 1, 0), it.map { h -> h.depth })
+        }
+        // ...and every offset is that variant's own RAW-SOURCE line start.
+        listOf(lf to byLf, crlf to byCrlf, cr to byCr).forEach { (text, headings) ->
+            assertEquals(
+                listOf("# One", "## Two", "Setext").map { offsetOfLineContaining(text, it) },
+                headings.map { it.sourceOffsetUtf16 },
+            )
+        }
+        // Source offsets, so the two-unit CRLF terminator genuinely shifts them — this test
+        // would be vacuous if the scanner normalized line endings before measuring.
+        assertNotEquals(
+            byLf.map { it.sourceOffsetUtf16 },
+            byCrlf.map { it.sourceOffsetUtf16 },
+        )
+        assertEquals(byLf.map { it.sourceOffsetUtf16 }, byCr.map { it.sourceOffsetUtf16 })
+    }
+
+    @Test
+    fun md_headingAsFinalLine_noTrailingNewline_isFound() {
+        val atx = "intro\n# Final"
+        assertEquals(listOf("Final|0@${atx.indexOf("# Final")}"), scan(atx).rendered())
+
+        val setext = "intro\n\nFinal Title\n==="
+        assertEquals(
+            listOf("Final Title|0@${setext.indexOf("Final Title")}"),
+            scan(setext).rendered(),
+        )
+    }
+
+    @Test
+    fun emptyDocument_yieldsNoHeadings() {
+        assertEquals(emptyList<DetectedHeading>(), scan(""))
+        assertEquals(emptyList<DetectedHeading>(), scan("   \n\t\n\n"))
+        assertEquals(emptyList<DetectedHeading>(), scan("just prose, no headings at all\n"))
+    }
+
+    @Test
+    fun scan_cancelledBeforeStart_throwsCancellation() {
+        val cancelled = Job().apply { cancel() }
+
+        val outcome = scanWithJob(cancelled, "# Heading\n")
+
+        assertTrue(outcome.exceptionOrNull() is CancellationException)
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/MdTocScannerTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/MdTocScannerTest.kt
@@ -3,6 +3,7 @@ package com.vreader.app.reader.nav
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -39,6 +40,9 @@ class MdTocScannerTest {
         /** U+3000 IDEOGRAPHIC SPACE — a Zs, so `trim`-before-test must treat it as indent. */
         val IDEO: String = Char(0x3000).toString()
 
+        /** A budget no semantic fixture can reach; the cap has its own tests. */
+        const val NO_CAP: Int = Int.MAX_VALUE
+
         /** U+00A0 NO-BREAK SPACE — also a Zs, and also NOT the space ATX requires. */
         val NBSP: String = Char(0x00A0).toString()
 
@@ -55,15 +59,16 @@ class MdTocScannerTest {
      * cancelled job under test would never be the object `ensureActive()` queries. It also pins a
      * real property — the scanner is pure CPU work and must never actually suspend.
      */
-    private fun scanWithJob(job: Job, text: String): Result<List<DetectedHeading>> {
-        var outcome: Result<List<DetectedHeading>>? = null
-        val block: suspend () -> List<DetectedHeading> = { MdTocScanner.scan(text) }
+    private fun scanWithJob(job: Job, text: String, limit: Int = NO_CAP): Result<ExtractResult> {
+        var outcome: Result<ExtractResult>? = null
+        val block: suspend () -> ExtractResult = { MdTocScanner.scan(text, limit) }
         block.startCoroutine(Continuation(job) { outcome = it })
         return requireNotNull(outcome) { "MdTocScanner must not suspend — it is pure CPU work" }
     }
 
+    /** The plain-result path every semantic test uses; the cap gets its own dedicated tests. */
     private fun scan(text: String): List<DetectedHeading> =
-        scanWithJob(Job(), text).getOrThrow()
+        scanWithJob(Job(), text).getOrThrow().headings
 
     /** `title|depth@offset` — one readable string per heading, so a diff names what moved. */
     private fun List<DetectedHeading>.rendered(): List<String> =
@@ -452,10 +457,84 @@ class MdTocScannerTest {
     }
 
     @Test
+    fun md_documentEndingWithATerminator_doesNotShiftOffsets() {
+        // The final terminator creates a trailing empty line; the two-line-ending bookkeeping
+        // must survive it under all three conventions (Gate-4 r1 LOW).
+        listOf("\n", "\r\n", "\r").forEach { eol ->
+            val text = "# A" + eol + "body" + eol + "## B" + eol
+
+            assertEquals(
+                listOf(
+                    "A|0@0",
+                    "B|1@" + text.indexOf("## B"),
+                ),
+                scan(text).rendered(),
+            )
+        }
+    }
+
+    @Test
     fun emptyDocument_yieldsNoHeadings() {
         assertEquals(emptyList<DetectedHeading>(), scan(""))
         assertEquals(emptyList<DetectedHeading>(), scan("   \n\t\n\n"))
         assertEquals(emptyList<DetectedHeading>(), scan("just prose, no headings at all\n"))
+
+        // Positive control: the same prose WITH a heading is not empty, so this test cannot pass
+        // against a scanner that simply never scans (Gate-4 r1 LOW).
+        assertEquals(listOf("Real"), titles("just prose, no headings at all\n# Real\n"))
+    }
+
+    // ------------------------------------------------------------------ bounded extraction
+
+    @Test
+    fun scan_stopsAtLimit_doesNotMaterializeBeyondIt() {
+        val text = (1..500).joinToString("") { "# H" + it + "\n" }
+
+        val result = scanWithJob(Job(), text, limit = 3).getOrThrow()
+
+        assertTrue(result.hitLimit)
+        assertEquals(listOf("H1", "H2", "H3"), result.headings.map { it.title })
+        assertEquals(3, result.headings.size)
+    }
+
+    @Test
+    fun scan_setextHeadingAlsoCountsAgainstLimit() {
+        val text = "One\n===\nTwo\n---\nThree\n===\n"
+
+        val result = scanWithJob(Job(), text, limit = 2).getOrThrow()
+
+        assertTrue(result.hitLimit)
+        assertEquals(listOf("One", "Two"), result.headings.map { it.title })
+    }
+
+    @Test
+    fun scan_underTheLimit_reportsNoHitLimit() {
+        val text = "# One\n# Two\n"
+
+        val result = scanWithJob(Job(), text, limit = 3).getOrThrow()
+
+        assertFalse(result.hitLimit)
+        assertEquals(2, result.headings.size)
+    }
+
+    @Test
+    fun scan_atExactlyTheLimit_reportsHitLimit() {
+        // `limit` is a collection budget, not a cap on the document: a caller that passes
+        // `cap + 1` reads `hitLimit` as "more than `cap` headings exist".
+        val text = "# One\n# Two\n"
+
+        val result = scanWithJob(Job(), text, limit = 2).getOrThrow()
+
+        assertTrue(result.hitLimit)
+        assertEquals(2, result.headings.size)
+    }
+
+    @Test
+    fun scan_nonPositiveLimit_isRejected() {
+        listOf(0, -1).forEach { bad ->
+            val outcome = scanWithJob(Job(), "# H\n", limit = bad)
+            assertTrue(outcome.exceptionOrNull() is IllegalArgumentException)
+        }
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/MdTocScannerTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/MdTocScannerTest.kt
@@ -1,12 +1,15 @@
 package com.vreader.app.reader.nav
 
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.InternalForInheritanceCoroutinesApi
 import kotlinx.coroutines.Job
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.startCoroutine
 
@@ -69,6 +72,34 @@ class MdTocScannerTest {
     /** The plain-result path every semantic test uses; the cap gets its own dedicated tests. */
     private fun scan(text: String): List<DetectedHeading> =
         scanWithJob(Job(), text).getOrThrow().headings
+
+    /**
+     * A [Job] that reports `isActive` for the first [activeChecks] queries and cancels itself on
+     * the next one — a deterministic stand-in for "the reader was closed mid-scan", with no
+     * sleeps, no threads, and no dependence on how fast the machine runs.
+     *
+     * Same shape as `TxtTocRuleEngineTest.CancelAfter`, including the `get` override: `Job by
+     * delegate` forwards EVERY interface member — `CoroutineContext.get` included — so without it
+     * `coroutineContext[Job]` hands back the delegate, [isActive] is never called, the job never
+     * cancels, and every assertion built on it passes vacuously.
+     */
+    @OptIn(InternalForInheritanceCoroutinesApi::class)
+    private class CancelAfter(
+        private val activeChecks: Int,
+        private val delegate: CompletableJob = Job(),
+    ) : Job by delegate {
+        private var checks: Int = 0
+
+        override val isActive: Boolean
+            get() {
+                if (checks++ >= activeChecks) delegate.cancel()
+                return delegate.isActive
+            }
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <E : CoroutineContext.Element> get(key: CoroutineContext.Key<E>): E? =
+            if (key == Job) this as E else null
+    }
 
     /** `title|depth@offset` — one readable string per heading, so a diff names what moved. */
     private fun List<DetectedHeading>.rendered(): List<String> =
@@ -488,13 +519,39 @@ class MdTocScannerTest {
 
     @Test
     fun scan_stopsAtLimit_doesNotMaterializeBeyondIt() {
-        val text = (1..500).joinToString("") { "# H" + it + "\n" }
+        // Long enough that a scanner which walks the whole document MUST reach the periodic
+        // cancellation check; the three headings are all in the first three lines.
+        val text = (1..3).joinToString("") { "# H" + it + "\n" } +
+            "filler\n".repeat(MdTocScanner.CANCELLATION_CHECK_INTERVAL * 3)
 
-        val result = scanWithJob(Job(), text, limit = 3).getOrThrow()
+        // A job that goes inactive on its SECOND query. `scan`'s entry check is the first, so a
+        // walk that keeps going past the limit trips the in-loop check and throws — while a walk
+        // that genuinely stops at the third heading never queries again. That makes the early
+        // stop OBSERVABLE, rather than merely asserting the returned list was truncated.
+        val stopped = scanWithJob(CancelAfter(1), text, limit = 3)
 
+        val result = stopped.getOrThrow()
         assertTrue(result.hitLimit)
         assertEquals(listOf("H1", "H2", "H3"), result.headings.map { it.title })
-        assertEquals(3, result.headings.size)
+
+        // The control: same document, same job shape, a limit it cannot reach — now the walk DOES
+        // continue and the pending cancellation is observed. If this did not throw, the assertion
+        // above would prove nothing.
+        assertTrue(
+            scanWithJob(CancelAfter(1), text, limit = NO_CAP).exceptionOrNull()
+                is CancellationException,
+        )
+    }
+
+    @Test
+    fun scan_isCancellationCooperative_evenInsideOneEnormousLine() {
+        // One line, no terminator, longer than the intra-line check interval — the case a
+        // whole-line scan would have deferred cancellation for (Gate-4 r2 MEDIUM).
+        val text = "x".repeat(MdTocScanner.CANCELLATION_CHECK_UNITS * 4)
+
+        val outcome = scanWithJob(CancelAfter(1), text, limit = NO_CAP)
+
+        assertTrue(outcome.exceptionOrNull() is CancellationException)
     }
 
     @Test

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.20.16
-versionCode=169
+versionName=0.20.17
+versionCode=170


### PR DESCRIPTION
## Summary

- `MdTocScanner` — Markdown heading detection: ATX + fenced-code exclusion + setext + a YAML front-matter state machine.
- ATX and fence semantics are construct-by-construct parity with iOS `TOCBuilder.forMD`: trim-before-test (so arbitrary leading indentation is legal), a literal U+0020 required after the hashes (tab / NBSP / U+3000 all rejected), the guarded closing-hash strip (so `### ###` keeps `###`), 0-based depth.
- Offsets are raw-source UTF-16 **line** starts, identical under LF / CRLF / CR.

Part of feature #2025 (#139). Foundational WI — no user-visible behavior yet.

## One deliberate improvement over iOS

iOS splits on `\n` only and mis-handles CR-only documents. This scanner handles all three line endings, pinned by test.

## Setext is an Android-only extension

Verified rather than assumed: `grep` confirms iOS has **no setext support anywhere** in `vreader/`. Divergence D2 is therefore a genuine extension, not a port gap — the plan's claim was re-derived against `TOCBuilder.swift:107-216` and holds.

## Audited deviation from plan §6.1

Shipped `suspend fun scan(text: String, limit: Int): ExtractResult`, **not** the planned `scan(text): List<DetectedHeading>`.

Gate-4 round 1 rated the planned signature **High**: it materialized a pathological document's entire heading list *before* WI-4 could apply the 50,000 cap, and WI-4's own `applyCap(result: ExtractResult)` already expects the bounded shape. The plan's §6.1 contradicted its own §4.4 bounded-before-materialization requirement.

There is no default `limit` — deliberate, mirroring `TxtTocRuleEngine.extractHeadings` from WI-2. **WI-4 must state its own budget at the call site** (`scan(text, MAX_TOC_ENTRIES + 1)`); forgetting is a compile error rather than a silent bug.

## Gate 4 — closed, zero open findings over 4 rounds

| Round | Findings | What it caught |
|---|---|---|
| r1 | H=1 M=1 L=2 | unbounded materialization before the cap |
| r2 | M=1 L=2 | ranges still substring'd per line |
| r3 | M=1 | the classifiers dodged the cancellation check |
| r4 | **clean** | verified the repair |

Every finding fixed; none accepted-with-rationale. **R4 was an orchestrator-authorized one-off override** of rule 47's 3-round cap, scoped strictly to confirming r3's Medium was closed by the fix that followed it. The alternative was hand-editing a `final_verdict` nobody earned — the merge gate accepts only `ship-as-is` / `follow-up-recommended`. The audit's arc is itself the argument for the override: each round found a distinct real defect.

Round 4 specifically re-derived the cancellation test's query arithmetic and confirmed the wrapper — not the delegate — is what the scanner queries, i.e. it checked for the **vacuous-test shape that WI-2 was burned by**, where a `Job by delegate` forwarded `CoroutineContext.get` and an assertion passed for free.

## Cross-WI answer for WI-6

**MD titles can never contain a line terminator** (ATX and setext are line-oriented; terminators are consumed as line boundaries), pinned by `headingTitles_neverContainALineTerminator`. So unlike WI-2's TXT titles — which genuinely can span a newline — the Contents row needs **no** presentation-layer whitespace collapsing for Markdown.

## Two known limitations, both pinned by test

This is a line scanner, not a CommonMark block parser:

1. A setext underline titles only the single preceding **line**, not the whole preceding paragraph.
2. A `---` directly under a bullet list reads as an underline where CommonMark says thematic break.

Both are confined to an odd Contents row. Exactness would need a real block parser.

## Validation

- Test gate **independently re-run by the orchestrator on the rebased branch with `--rerun-tasks`**: `RUN-ANDROID-TESTS RESULT: SUCCEEDED` — **44 tests, 0 failures, 0 errors** (35/35 tasks executed, nothing cached).
- Write-set verified: exactly the 3 declared paths.
- Gate 5a: foundational tier — unit tests + audit sufficient.
- Docs sync: not triggered.
- Version bumped: `android/v0.20.16` → `android/v0.20.17`.

## Accepted follow-up candidate

`MdTocScanner.kt` is 338 lines against the ~300 guideline (~140 of them documentation). Splitting the classifiers needs a third path this WI's write-set did not include.

## Type of Change

- [x] Feature WI (part of feature #2025)
