### PR TITLE
feat(#139 WI-4): TxtMdTocProvider — one provider for TXT + MD, iOS detection policy

### DIFF
--- a/.claude/codex-audits/feat-139-wi-4-toc-provider-audit.md
+++ b/.claude/codex-audits/feat-139-wi-4-toc-provider-audit.md
@@ -1,0 +1,101 @@
+---
+branch: feat/139-wi-4-toc-provider
+threadId: 019fcbb0-bcc3-78a2-8bfb-7a4630f41eae
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-08-04
+---
+
+# Gate-4 audit — feature #139 WI-4 (`TxtMdTocProvider`)
+
+Files under review:
+
+- `android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtMdTocProvider.kt` (new)
+- `android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtMdTocProviderTest.kt` (new)
+- `docs/architecture.md` (one added service bullet under "Reader plumbing", rule 24)
+
+Auditor: Codex `gpt-5.5` effort=high via `scripts/run-codex.sh` (rule 53), read-only sandbox, two
+independent sessions. Raw transcripts: `.reports/audit-r{1,2}.txt` (not committed — 519 KB / 1.8 MB).
+Round-1 thread `019fcba9-a88d-7ed3-927f-4f7f1e021e9b`; round-2 thread (recorded above)
+`019fcbb0-bcc3-78a2-8bfb-7a4630f41eae`.
+
+Both rounds were asked the same eight questions against the real source (not the plan's prose):
+locator construction identity with a #135 bookmark, the 50 000 cap boundary on both branches,
+whether rejection can happen without materializing the full list, whether ANY named test could pass
+vacuously (with the fixtures' arithmetic re-derived independently), dispatcher injection + the test
+harness's soundness, cancellation/concurrency/edge cases, vreader compliance (rule 22 comment
+accuracy, file size, no Android imports in JVM-testable code), and the accuracy of the docs bullet.
+
+Both rounds were explicitly told that plan §4.4 **deleted** the density/saturation/ambiguous-rule
+guards (Option A) and that recommending one is out of scope — so no round could "fix" the tripwire
+this WI exists to pin.
+
+## Round 1 — C=0 H=0 M=1 L=2, verdict `follow-up-recommended`
+
+| # | Sev | Finding | Disposition |
+| --- | --- | --- | --- |
+| R1-1 | **Medium** | The cap boundary tests exercised only the **MD** branch. The TXT branch is a second, independent `extractHeadings` call site with its own budget, so a wrong limit / a truncation / an over-materialization there would have passed. | **FIXED** — added `cap_txtAtExactlyMaxTocEntries_returnsEntries` and `cap_txtAtMaxPlusOne_returnsEmpty`, and narrowed `cap_rejectionHappensWithoutMaterializingFullList`'s comment so it claims only what it proves (the scanner stops at the budget; the *budget itself* is pinned by the two boundary pairs). |
+| R1-2 | Low | `docs/architecture.md` read as though the TXT/MD host already sourced Contents from this provider. It does not — `TxtReaderActivity.kt:1432` still passes `tocEntries = emptyList()`; host wiring is WI-7. | **FIXED** — the bullet now states that explicitly. |
+| R1-3 | Low | The test file is over the repo's ~300-line guideline. | **ACCEPTED with rationale** — the lane's declared write-set is exactly four paths, so creating a second test file is outside it; and at 365 lines the file is the second *smallest* in its package (`ReadiumTocProviderTest` 193, `BookmarkPresentationTest` 485, `TxtTocRulesTest` 532, `MdTocScannerTest` 624, `TxtTocRuleEngineTest` 697). Round 2 accepted the rationale. |
+
+## Round 2 — C=0 H=0 M=0 L=1, verdict `follow-up-recommended` → fixed to `ship-as-is`
+
+Round 2 re-verified every round-1 disposition against the code rather than the claim, and
+independently re-derived the TXT fixtures' arithmetic: `txtChapters(n)` emits exactly `n` lines of
+`第<i>章 甲`, every one matched by rule 1 (rule 2 ties; `detectBestRule`'s strictly-greater
+comparison keeps the earlier rule), and both fixtures sit under the 512 KiB detection sample
+(50 000 → 488 894 UTF-16 units; 50 001 → 488 904), so detection sees every heading and the `>= 2`
+threshold is satisfied. It confirmed the boundary pair genuinely binds the TXT branch's own budget.
+
+| # | Sev | Finding | Disposition |
+| --- | --- | --- | --- |
+| R2-1 | Low | Rule 22: the file header claimed a mis-detected TOC is harmless because "`LazyColumn` bounds rendering" — but WI-6 (the lazy sheet) has not landed on this branch, so the claim was false *as written*. | **FIXED** — the header now says WI-6 makes the sheet lazy and lands **before** WI-7 wires this provider to a host, so no user can reach a large TOC through today's eager sheet. |
+
+Everything else came back clean and is recorded here as the round-2 findings of fact:
+
+- **Locator identity**: `toEntry` calls `txtBookmarkLocator(book, heading.sourceOffsetUtf16)`
+  directly, so a TOC row and a #135 bookmark at one offset are the same value by construction.
+  The locator's `format` leg is `book.originalFormat.name` (the ctor's `format` param only routes),
+  matching the bookmark path exactly.
+- **Cap boundary**: both scanner loops append then return `hitLimit = true` at `size == limit`, and
+  the provider passes `SCAN_LIMIT = 50 001`. 49 999 / 50 000 are kept; 50 001 rejects to an empty
+  list. Reject, never truncate; TXT and MD agree by code.
+- **No materialization**: a 5 M-heading document never becomes a 5 M-element list — TXT detection
+  samples 512 KiB, both extractions stop at 50 001, and allocation is proportional to the
+  already-resident document `String` plus a cap-sized heading list.
+- **Dispatcher**: the provider (not the host) owns `withContext(dispatcher)` on an injected
+  dispatcher; nothing is hardcoded; the `RecordingDispatcher` harness proves the hop by observing
+  execution on its own named thread and shuts its executor down in a `finally`.
+- **Concurrency / cancellation / edge cases**: provider state is immutable and each scan uses local
+  state, so concurrent `toc()` calls are safe; cancellation is cooperative inside both scanners;
+  empty text, an unsupported format, a heading at offset 0, and CJK/astral titles all behave.
+
+## Mutation probes (author-run, beyond the audit)
+
+Because this feature has twice shipped a test that passed for free (WI-2 asserted against the wrong
+object; WI-3 needed its arithmetic re-derived), each load-bearing claim was probed by breaking the
+production code and confirming the *named* test goes red:
+
+| Mutation | Tests that failed |
+| --- | --- |
+| `applyCap` truncates instead of rejecting | `cap_aboveMaxTocEntries_returnsEmpty_notTruncated`, `cap_atMaxPlusOne_returnsEmpty`, `cap_rejectionHappensWithoutMaterializingFullList`, `applyCap_isTheWholePolicy` |
+| `SCAN_LIMIT = MAX_TOC_ENTRIES` (budget one too small) | `cap_atExactlyMaxTocEntries_returnsEntries` |
+| TXT branch budget `SCAN_LIMIT + 1` (one too large, TXT only) | `cap_txtAtMaxPlusOne_returnsEmpty` |
+| `withContext` on `EmptyCoroutineContext` (no hop) | `runsOnInjectedDispatcher_providerOwnsWithContext` |
+| a 90 %-saturation guard reintroduced (the withdrawn D4) | `noDensityOrSaturationGuardExists`, `mdAllHeadingOutline_isKept`, + 3 collateral |
+
+The last row is the one that matters most: the D4-deletion tripwire fires loudly, so a future change
+cannot quietly reintroduce a density or saturation guard without also editing the plan.
+
+## Test gate
+
+`RUN-ANDROID-TESTS RESULT: SUCCEEDED` — `:app:testDebugUnitTest --rerun-tasks --tests
+'*TxtMdTocProviderTest*'`, **26 tests, 0 failures, 0 errors, 0 skipped** (the plan's 18 named tests
+plus 8 author-added edge cases: unsupported format, empty text, the `>= 2` threshold observed
+end-to-end, document order, verbatim CJK/astral titles, `applyCap` in isolation, and the TXT cap
+boundary pair). JVM only — no emulator.
+
+## Verdict
+
+**ship-as-is.** Zero open Critical/High/Medium findings; both Lows fixed, the third accepted with
+the rationale round 2 endorsed.

--- a/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtMdTocProvider.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtMdTocProvider.kt
@@ -1,0 +1,122 @@
+// Purpose: The [TocProvider] for the two non-Readium text formats — it turns an already-decoded
+// TXT or MD document into the Contents sheet's [TocEntry] rows (feature #139 WI-4). The
+// TXT/MD counterpart of [ReadiumTocProvider]; [EmptyTocProvider] still serves PDF and AZW3.
+//
+// Pipeline:
+//   txt ──TxtTocRuleEngine.detectBestRule──► winning rule ──extractHeadings(cap+1)──┐
+//   md  ──MdTocScanner.scan(cap+1)───────────────────────────────────────────────────┤
+//                                                                                    ▼
+//                                            applyCap ──► List<DetectedHeading> ──► List<TocEntry>
+//
+// Key decisions:
+// - DETECTION POLICY IS EXACTLY iOS's: the engine's `>= 2` match threshold plus [MAX_TOC_ENTRIES].
+//   There is deliberately NO density guard, NO saturation guard, NO ambiguous-rule set and NO
+//   format-specific exemption — plan §4.4 (Option A) DELETED that machinery after four Gate-2
+//   rounds failed to make an invented heuristic sound, and iOS ships none across features #23/#12.
+//   A mis-detected TOC is ugly, not harmful: `LazyColumn` bounds rendering, the cap bounds memory,
+//   nothing crashes. `TxtMdTocProviderTest.noDensityOrSaturationGuardExists` pins the deletion; if
+//   a real book ever needs a guard it is designed FROM that failure (follow-up F6), not before it.
+// - The cap REJECTS rather than truncates. A Contents list that silently stops at entry 50 000 of a
+//   larger book is worse than none, because the user cannot tell it is incomplete.
+// - Both scanners are called with `MAX_TOC_ENTRIES + 1`, so [ExtractResult.hitLimit] reads exactly
+//   as "more than the cap" AND the scan stops there — a pathological document is never fully
+//   materialized. Neither scanner supplies a default limit, precisely so this budget is stated here.
+// - A row's `canonicalLocator` is built by CALLING `txtBookmarkLocator` — the same function #135's
+//   bookmarks and the resume seam use — rather than by re-spelling its fields. Construction
+//   identity is the point: a TOC row and a bookmark at one source offset must be one position.
+//   Note this makes the locator's `format` leg `book.originalFormat`, not [format] (which only
+//   routes); the host passes the canonical fingerprint-parsed format for routing (bug #246).
+// - `pageLabel` is null (no page in scroll layout; the #138 paged index is windowed, so labelling
+//   every entry would force a measure of the whole book at sheet-build time) and
+//   `epubReadiumLocator` is null (non-Readium host). TXT depth is flat 0 (plan §4.3); MD carries
+//   the scanner's real heading level, which `TocSheetRows` renders as indentation.
+// - An EMPTY list is the "hide the Contents control" signal, not an error: `ReaderChromeScaffold`
+//   derives the control's visibility from `tocEntries.isEmpty()`. A format this provider does not
+//   serve therefore degrades to "no Contents" rather than throwing inside a working reader.
+// - THIS type owns the `withContext(dispatcher)` hop on an INJECTED dispatcher (plan §4.5); the
+//   host must not wrap the call, and nothing here may hardcode Dispatchers.IO/Default. Everything
+//   it calls is pure CPU work that must not run on the main thread.
+//
+// @coordinates-with: TocProvider.kt, TocEntry.kt, TxtTocRuleEngine.kt, MdTocScanner.kt,
+//                    DetectedHeading.kt, ../TxtReaderActivity.kt (txtBookmarkLocator)
+package com.vreader.app.reader.nav
+
+import com.vreader.app.data.Book
+import com.vreader.app.reader.txtBookmarkLocator
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import vreader.contracts.BookFormat
+
+/**
+ * Builds the auto-generated table of contents for a TXT or MD book.
+ *
+ * @param text       the FULL decoded document — the same `String` the reader already holds
+ *                   (`TxtDocument.text`), so the scan adds no new memory or I/O class.
+ * @param book       the identity source for every row's canonical locator.
+ * @param format     which scanner to run. Anything other than `txt`/`md` yields an empty TOC.
+ * @param dispatcher the background dispatcher this provider hops onto; injected so tests and the
+ *                   host control it (rule 50 §12.1 — never a hardcoded dispatcher).
+ */
+class TxtMdTocProvider(
+    private val text: String,
+    private val book: Book,
+    private val format: BookFormat,
+    private val dispatcher: CoroutineDispatcher,
+) : TocProvider {
+
+    /**
+     * The book's chapter rows, or an empty list when it has no detectable headings — or more than
+     * [MAX_TOC_ENTRIES] of them.
+     *
+     * @throws kotlinx.coroutines.CancellationException if the calling coroutine is cancelled; both
+     *         scanners are cancellation-cooperative, so closing the reader mid-scan stops promptly.
+     */
+    override suspend fun toc(): List<TocEntry> = withContext(dispatcher) {
+        val result = when (format) {
+            BookFormat.txt -> {
+                val rule = TxtTocRuleEngine.detectBestRule(text) ?: return@withContext emptyList()
+                TxtTocRuleEngine.extractHeadings(text, rule, SCAN_LIMIT)
+            }
+            BookFormat.md -> MdTocScanner.scan(text, SCAN_LIMIT)
+            else -> return@withContext emptyList()
+        }
+        applyCap(result).map(::toEntry)
+    }
+
+    private fun toEntry(heading: DetectedHeading): TocEntry = TocEntry(
+        title = heading.title,
+        depth = heading.depth,
+        pageLabel = null,
+        canonicalLocator = txtBookmarkLocator(book, heading.sourceOffsetUtf16),
+        epubReadiumLocator = null,
+    )
+
+    companion object {
+        /**
+         * The most entries a Contents list may hold. Above this the TOC is REJECTED, never
+         * truncated.
+         *
+         * Sized to sit above any plausible real book — Chinese web novels reach 20 000–30 000
+         * chapters — while bounding memory (50 000 × ~80 B ≈ 4 MB) and staying renderable by the
+         * lazy sheet. This is a memory/sanity backstop, NOT a mis-detection heuristic.
+         */
+        const val MAX_TOC_ENTRIES: Int = 50_000
+
+        /**
+         * The budget handed to both scanners. `cap + 1` is what makes [ExtractResult.hitLimit] mean
+         * "more than [MAX_TOC_ENTRIES] exist" while stopping the scan one heading past the cap.
+         */
+        private const val SCAN_LIMIT: Int = MAX_TOC_ENTRIES + 1
+
+        /**
+         * The ENTIRE post-scan policy: keep everything, or — if the scan hit its limit, i.e. the
+         * document has more than [MAX_TOC_ENTRIES] headings — keep nothing.
+         *
+         * It reads only [ExtractResult.hitLimit]: no entry count, no line count, no ratio, no
+         * format and no rule identity. That is the shape plan §4.4 settled on, and a change here is
+         * a change to the plan.
+         */
+        internal fun applyCap(result: ExtractResult): List<DetectedHeading> =
+            if (result.hitLimit) emptyList() else result.headings
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtMdTocProvider.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtMdTocProvider.kt
@@ -13,9 +13,11 @@
 //   There is deliberately NO density guard, NO saturation guard, NO ambiguous-rule set and NO
 //   format-specific exemption — plan §4.4 (Option A) DELETED that machinery after four Gate-2
 //   rounds failed to make an invented heuristic sound, and iOS ships none across features #23/#12.
-//   A mis-detected TOC is ugly, not harmful: `LazyColumn` bounds rendering, the cap bounds memory,
-//   nothing crashes. `TxtMdTocProviderTest.noDensityOrSaturationGuardExists` pins the deletion; if
-//   a real book ever needs a guard it is designed FROM that failure (follow-up F6), not before it.
+//   A mis-detected TOC is then ugly rather than harmful: the cap bounds memory, and WI-6 makes the
+//   Contents sheet lazy so it bounds rendering too — WI-6 lands BEFORE WI-7 wires this provider to
+//   a host, so no user can reach a large TOC through today's eager sheet.
+//   `TxtMdTocProviderTest.noDensityOrSaturationGuardExists` pins the deletion; if a real book ever
+//   needs a guard it is designed FROM that failure (follow-up F6), not before it.
 // - The cap REJECTS rather than truncates. A Contents list that silently stops at entry 50 000 of a
 //   larger book is worse than none, because the user cannot tell it is incomplete.
 // - Both scanners are called with `MAX_TOC_ENTRIES + 1`, so [ExtractResult.hitLimit] reads exactly

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtMdTocProviderTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtMdTocProviderTest.kt
@@ -1,0 +1,347 @@
+package com.vreader.app.reader.nav
+
+import com.vreader.app.data.Book
+import com.vreader.app.reader.txtBookmarkLocator
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import vreader.contracts.BookFormat
+import java.util.Collections
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Feature #139 WI-4 — [TxtMdTocProvider]: the one [TocProvider] serving BOTH non-Readium text
+ * formats, turning a decoded document into the Contents sheet's [TocEntry] rows.
+ *
+ * The properties this suite exists to protect:
+ *
+ * - **Format routing is real**, not incidental: the same fixture yields the MD scanner's answer
+ *   under `md` and the TXT rule engine's *different* answer under `txt`.
+ * - **A row's `canonicalLocator` is CONSTRUCTION-IDENTICAL to a #135 bookmark** at the same source
+ *   offset — that identity is what makes "the chapter I jumped to" and "the chapter I bookmarked"
+ *   the same position across restore/engine swap.
+ * - **The 50 000 cap REJECTS, never truncates**, and both boundaries are pinned — which together
+ *   also pin that the provider passes exactly `MAX_TOC_ENTRIES + 1` as its scan budget (a smaller
+ *   limit fails the at-exactly test; a larger one fails the at-max-plus-one test).
+ * - **Detection policy is EXACTLY iOS's**: the `>= 2` match threshold plus that cap. There is no
+ *   density guard, no saturation guard, no ambiguous-rule set and no format-specific exemption —
+ *   divergence D4 was deleted (plan §4.4, Option A), and [noDensityOrSaturationGuardExists] fails
+ *   loudly if one is reintroduced.
+ *
+ * Pure JVM — no Android runtime, no Robolectric, no emulator.
+ */
+class TxtMdTocProviderTest {
+
+    private companion object {
+        /** 64 lowercase-hex chars — a well-formed identity triple leg. */
+        val SHA: String = "ab12cd34".repeat(8)
+        const val BYTES: Long = 4_096L
+
+        /** Matches NO rule in [TxtTocRules]: no leading digit+punctuation, no marker char, no keyword. */
+        const val BODY = "hello world"
+
+        /**
+         * One fixture, two legitimate readings — the routing oracle.
+         *
+         * As **MD** it is two ATX headings ("Alpha" depth 0, "Beta" depth 1) and two paragraph
+         * lines. As **TXT** it is two rule-1 chapter headings (`第…章`) and two lines matching
+         * nothing (`#` starts no rule). The two answers are disjoint, so neither routing test can
+         * pass through the other's code path.
+         */
+        val MIXED: String = "# Alpha\n第一章 甲\n第二章 乙\n## Beta\n"
+
+        /** The MD reading of [MIXED]. */
+        val MIXED_AS_MD = listOf("Alpha", "Beta")
+
+        /** The TXT reading of [MIXED]. */
+        val MIXED_AS_TXT = listOf("第一章 甲", "第二章 乙")
+    }
+
+    // ------------------------------------------------------------------ harness
+
+    private fun book(format: BookFormat): Book = Book(
+        fingerprintKey = "${format.name}:$SHA:$BYTES",
+        title = "Fixture",
+        originalFormat = format,
+        contentSHA256 = SHA,
+        fileByteCount = BYTES,
+        addedAt = 0L,
+    )
+
+    /** The provider under test, on an unconfined dispatcher (the hop itself has its own test). */
+    private fun provider(
+        text: String,
+        format: BookFormat,
+        dispatcher: CoroutineDispatcher = Dispatchers.Unconfined,
+        book: Book = book(format),
+    ) = TxtMdTocProvider(text = text, book = book, format = format, dispatcher = dispatcher)
+
+    private fun toc(
+        text: String,
+        format: BookFormat,
+        book: Book = book(format),
+    ): List<TocEntry> = runBlocking { provider(text, format, book = book).toc() }
+
+    private fun titles(text: String, format: BookFormat): List<String?> =
+        toc(text, format).map { it.title }
+
+    /** `n` TXT chapter headings, one per line, every line a heading (100 % saturation). */
+    private fun txtChapters(n: Int, body: Boolean = false): String = buildString(n * 12) {
+        for (i in 1..n) {
+            append("第").append(i).append("章 甲\n")
+            if (body) append(BODY).append('\n')
+        }
+    }
+
+    /** `n` ATX headings, one per line, every line a heading (100 % saturation). */
+    private fun mdHeadings(n: Int): String = buildString(n * 10) {
+        for (i in 1..n) append("## Item ").append(i).append('\n')
+    }
+
+    /** The raw-source offset of the line containing [needle] — the assertion's own oracle. */
+    private fun offsetOfLineContaining(text: String, needle: String): Int {
+        val at = text.indexOf(needle)
+        assertTrue("fixture does not contain '$needle'", at >= 0)
+        return text.lastIndexOfAny(charArrayOf('\n', '\r'), at) + 1
+    }
+
+    // ------------------------------------------------------------------ format routing
+
+    @Test fun txtFormat_routesToRuleEngine() {
+        assertEquals(MIXED_AS_TXT, titles(MIXED, BookFormat.txt))
+    }
+
+    @Test fun mdFormat_routesToMdScanner() {
+        assertEquals(MIXED_AS_MD, titles(MIXED, BookFormat.md))
+    }
+
+    @Test fun unsupportedFormat_returnsEmptyList() {
+        // A mis-constructed provider degrades to "no Contents", never to a crash in a working reader.
+        for (format in listOf(BookFormat.epub, BookFormat.pdf, BookFormat.azw3)) {
+            assertEquals("format=$format", emptyList<TocEntry>(), toc(MIXED, format))
+        }
+    }
+
+    // ------------------------------------------------------------------ the empty outcomes
+
+    @Test fun noHeadings_returnsEmptyList() {
+        // Empty is the "hide the Contents control" signal (ReaderChromeScaffold), not an error.
+        val prose = "$BODY\n$BODY\n$BODY\n"
+        assertEquals(emptyList<TocEntry>(), toc(prose, BookFormat.txt))
+        assertEquals(emptyList<TocEntry>(), toc(prose, BookFormat.md))
+    }
+
+    @Test fun emptyText_returnsEmptyList() {
+        assertEquals(emptyList<TocEntry>(), toc("", BookFormat.txt))
+        assertEquals(emptyList<TocEntry>(), toc("", BookFormat.md))
+    }
+
+    @Test fun singleHeading_belowMatchThreshold_returnsEmptyList() {
+        // iOS's `>= 2` confidence threshold, observed end-to-end: one match is a coincidence.
+        assertEquals(emptyList<TocEntry>(), toc("第一章 甲\n$BODY\n", BookFormat.txt))
+        // MD has no threshold — a single ATX heading IS a heading (syntactically unambiguous).
+        assertEquals(listOf("Only"), titles("# Only\n$BODY\n", BookFormat.md))
+    }
+
+    // ------------------------------------------------------------------ entry shape
+
+    @Test fun entries_carryIdentityTripleFromBook() {
+        val book = book(BookFormat.md)
+        val entries = toc(MIXED, BookFormat.md, book = book)
+        assertEquals(MIXED_AS_MD.size, entries.size)
+        for (entry in entries) {
+            assertEquals(book.contentSHA256, entry.canonicalLocator.contentSHA256)
+            assertEquals(book.fileByteCount, entry.canonicalLocator.fileByteCount)
+            assertEquals(book.originalFormat.name, entry.canonicalLocator.format)
+            assertEquals(book.fingerprintKey, entry.canonicalLocator.fingerprintKey)
+        }
+    }
+
+    @Test fun entries_canonicalLocatorMatches_txtBookmarkLocator_forSameOffset() {
+        // The load-bearing parity assertion: a TOC row and a #135 bookmark at the same source
+        // offset must be the SAME canonical position, field for field.
+        val book = book(BookFormat.txt)
+        val entries = toc(MIXED, BookFormat.txt, book = book)
+        assertEquals(MIXED_AS_TXT.size, entries.size)
+        for ((index, title) in MIXED_AS_TXT.withIndex()) {
+            val offset = offsetOfLineContaining(MIXED, title)
+            assertEquals("entry $index", txtBookmarkLocator(book, offset), entries[index].canonicalLocator)
+            assertEquals("entry $index offset", offset, entries[index].canonicalLocator.charOffsetUTF16)
+        }
+    }
+
+    @Test fun entries_epubReadiumLocatorIsNull() {
+        val entries = toc(MIXED, BookFormat.md) + toc(MIXED, BookFormat.txt)
+        assertEquals(MIXED_AS_MD.size + MIXED_AS_TXT.size, entries.size)
+        entries.forEach { assertNull(it.epubReadiumLocator) }
+    }
+
+    @Test fun entries_pageLabelIsNull() {
+        // Scroll layout has no page; the paged #138 index is windowed, so a label would force a
+        // measure of every chapter at sheet-build time. Null is both correct and cheap.
+        val entries = toc(MIXED, BookFormat.md) + toc(MIXED, BookFormat.txt)
+        assertEquals(MIXED_AS_MD.size + MIXED_AS_TXT.size, entries.size)
+        entries.forEach { assertNull(it.pageLabel) }
+    }
+
+    @Test fun txtEntries_areAllDepthZero() {
+        val entries = toc(txtChapters(5), BookFormat.txt)
+        assertEquals(5, entries.size)
+        assertEquals(List(5) { 0 }, entries.map { it.depth })
+    }
+
+    @Test fun mdEntries_carryScannerDepth() {
+        val entries = toc("# Top\n$BODY\n## Second\n$BODY\n### Third\n", BookFormat.md)
+        assertEquals(listOf("Top", "Second", "Third"), entries.map { it.title })
+        assertEquals(listOf(0, 1, 2), entries.map { it.depth })
+    }
+
+    @Test fun entries_areInAscendingDocumentOrder() {
+        val offsets = toc(txtChapters(6), BookFormat.txt).map {
+            requireNotNull(it.canonicalLocator.charOffsetUTF16) { "every TXT/MD row carries a source offset" }
+        }
+        assertEquals(6, offsets.size)
+        assertEquals(offsets.sorted(), offsets)
+        assertEquals(offsets.distinct(), offsets)
+    }
+
+    @Test fun titles_arePreservedVerbatim_includingCjkAndAstralPlane() {
+        // A surrogate pair in a title must survive, and the offset must be the LINE start.
+        val astral = "𝕬"   // U+1D56C MATHEMATICAL BOLD FRAKTUR CAPITAL A
+        val text = "# 甲$astral 標題\n$BODY\n## 乙\n"
+        val entries = toc(text, BookFormat.md)
+        assertEquals(listOf("甲$astral 標題", "乙"), entries.map { it.title })
+        assertEquals(0, entries[0].canonicalLocator.charOffsetUTF16)
+        assertEquals(
+            offsetOfLineContaining(text, "## 乙"),
+            entries[1].canonicalLocator.charOffsetUTF16,
+        )
+    }
+
+    // ------------------------------------------------------------------ the cap (reject, never truncate)
+
+    @Test fun cap_aboveMaxTocEntries_returnsEmpty_notTruncated() {
+        // A Contents list that silently stops at 50 000 of a larger book is worse than none — the
+        // user cannot tell it is incomplete. So: reject the whole thing.
+        val entries = toc(mdHeadings(TxtMdTocProvider.MAX_TOC_ENTRIES + 10), BookFormat.md)
+        assertEquals(emptyList<TocEntry>(), entries)
+    }
+
+    @Test fun cap_atExactlyMaxTocEntries_returnsEntries() {
+        val entries = toc(mdHeadings(TxtMdTocProvider.MAX_TOC_ENTRIES), BookFormat.md)
+        assertEquals(TxtMdTocProvider.MAX_TOC_ENTRIES, entries.size)
+    }
+
+    @Test fun cap_atMaxPlusOne_returnsEmpty() {
+        val entries = toc(mdHeadings(TxtMdTocProvider.MAX_TOC_ENTRIES + 1), BookFormat.md)
+        assertEquals(emptyList<TocEntry>(), entries)
+    }
+
+    @Test fun cap_rejectionHappensWithoutMaterializingFullList() {
+        val text = mdHeadings(TxtMdTocProvider.MAX_TOC_ENTRIES + 10_000)
+        assertEquals(emptyList<TocEntry>(), toc(text, BookFormat.md))
+        // The bound the provider relies on: the scan STOPS at `cap + 1` rather than building the
+        // document's full 60 000-heading list and truncating it afterwards.
+        val bounded = runBlocking {
+            MdTocScanner.scan(text, TxtMdTocProvider.MAX_TOC_ENTRIES + 1)
+        }
+        assertTrue(bounded.hitLimit)
+        assertEquals(TxtMdTocProvider.MAX_TOC_ENTRIES + 1, bounded.headings.size)
+    }
+
+    @Test fun applyCap_isTheWholePolicy() {
+        // The cap decision reads ONLY `hitLimit` — no count, no ratio, no format, no rule identity.
+        val headings = listOf(DetectedHeading("a", 0), DetectedHeading("b", 4))
+        assertEquals(headings, TxtMdTocProvider.applyCap(ExtractResult(headings, hitLimit = false)))
+        assertEquals(emptyList<DetectedHeading>(), TxtMdTocProvider.applyCap(ExtractResult(headings, hitLimit = true)))
+        assertEquals(emptyList<DetectedHeading>(), TxtMdTocProvider.applyCap(ExtractResult.EMPTY))
+    }
+
+    // ------------------------------------------------------------------ D4 deletion is pinned
+
+    @Test fun noDensityOrSaturationGuardExists() {
+        // Divergence D4 (invented density/saturation guards) was DELETED after four Gate-2 rounds
+        // failed to make it sound; iOS ships no such guard. Each case below would be REJECTED by
+        // at least one of the four withdrawn schemes, and must be KEPT IN FULL:
+        //   (a) TXT, explicit rule 1, 100 % saturation  → R3/R4's 90 % saturation guard
+        //   (b) TXT, ambiguous rule 4 ("1. …"), 100 %   → R2/R4's 25 % ambiguous-rule guard
+        //   (c) MD, every line a heading, 100 %         → R1/R3's unconditional density guard
+        assertEquals(200, toc(txtChapters(200), BookFormat.txt).size)
+
+        val numbered = buildString { for (i in 1..150) append(i).append(". Title\n") }
+        assertEquals(150, toc(numbered, BookFormat.txt).size)
+
+        assertEquals(120, toc(mdHeadings(120), BookFormat.md).size)
+    }
+
+    @Test fun eightLineDocWithThreeHeadings_isKept() {
+        // Gate-2 R1's false rejection (37.5 % density). Trivially true now the guards are gone —
+        // kept as a tripwire.
+        val text = "第一章 甲\n$BODY\n$BODY\n第二章 乙\n$BODY\n第三章 丙\n$BODY\n$BODY\n"
+        assertEquals(listOf("第一章 甲", "第二章 乙", "第三章 丙"), titles(text, BookFormat.txt))
+    }
+
+    @Test fun mdAllHeadingOutline_isKept() {
+        // Gate-2 R3's false rejection: a legitimate 100 %-heading Markdown outline. Also a tripwire.
+        assertEquals(40, toc(mdHeadings(40), BookFormat.md).size)
+    }
+
+    @Test fun twentyFiveThousandChapterNovel_isKept() {
+        // Real Chinese web novels reach 20 000–30 000 chapters; the cap must sit above them.
+        val entries = toc(txtChapters(25_000, body = true), BookFormat.txt)
+        assertEquals(25_000, entries.size)
+        assertEquals("第1章 甲", entries.first().title)
+        assertEquals("第25000章 甲", entries.last().title)
+    }
+
+    // ------------------------------------------------------------------ threading
+
+    @Test fun runsOnInjectedDispatcher_providerOwnsWithContext() {
+        // The PROVIDER owns the hop (plan §4.5) — the host must not have to wrap the call, and
+        // nothing may hardcode Dispatchers.IO/Default. Without an internal `withContext`, the
+        // recording dispatcher would never see a dispatch at all.
+        val dispatcher = RecordingDispatcher()
+        try {
+            val callerThread = Thread.currentThread().name
+            val entries = runBlocking { provider(MIXED, BookFormat.txt, dispatcher).toc() }
+            assertEquals(MIXED_AS_TXT, entries.map { it.title })
+            assertTrue("provider never hopped to the injected dispatcher", dispatcher.dispatches.get() >= 1)
+            assertEquals(setOf(RecordingDispatcher.THREAD_NAME), dispatcher.observedThreads())
+            assertNotEquals(RecordingDispatcher.THREAD_NAME, callerThread)
+        } finally {
+            dispatcher.shutdown()
+        }
+    }
+
+    /** A real dispatcher (one named thread) that records every dispatch it is asked to perform. */
+    private class RecordingDispatcher : CoroutineDispatcher() {
+        private val threads = Collections.synchronizedSet(mutableSetOf<String>())
+        private val executor = Executors.newSingleThreadExecutor { r -> Thread(r, THREAD_NAME) }
+        val dispatches = AtomicInteger(0)
+
+        override fun dispatch(context: CoroutineContext, block: Runnable) {
+            dispatches.incrementAndGet()
+            executor.execute {
+                threads.add(Thread.currentThread().name)
+                block.run()
+            }
+        }
+
+        fun observedThreads(): Set<String> = synchronized(threads) { threads.toSet() }
+
+        fun shutdown() {
+            executor.shutdownNow()
+        }
+
+        companion object {
+            const val THREAD_NAME = "toc-provider-test-dispatcher"
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtMdTocProviderTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtMdTocProviderTest.kt
@@ -27,9 +27,10 @@ import kotlin.coroutines.CoroutineContext
  * - **A row's `canonicalLocator` is CONSTRUCTION-IDENTICAL to a #135 bookmark** at the same source
  *   offset — that identity is what makes "the chapter I jumped to" and "the chapter I bookmarked"
  *   the same position across restore/engine swap.
- * - **The 50 000 cap REJECTS, never truncates**, and both boundaries are pinned — which together
- *   also pin that the provider passes exactly `MAX_TOC_ENTRIES + 1` as its scan budget (a smaller
- *   limit fails the at-exactly test; a larger one fails the at-max-plus-one test).
+ * - **The 50 000 cap REJECTS, never truncates**, with both boundaries pinned on BOTH branches
+ *   (TXT and MD are two separate call sites with their own budgets) — which together also pin that
+ *   the provider passes exactly `MAX_TOC_ENTRIES + 1` as its scan budget: a smaller limit fails the
+ *   at-exactly test, a larger one fails the at-max-plus-one test.
  * - **Detection policy is EXACTLY iOS's**: the `>= 2` match threshold plus that cap. There is no
  *   density guard, no saturation guard, no ambiguous-rule set and no format-specific exemption —
  *   divergence D4 was deleted (plan §4.4, Option A), and [noDensityOrSaturationGuardExists] fails
@@ -244,11 +245,26 @@ class TxtMdTocProviderTest {
         assertEquals(emptyList<TocEntry>(), entries)
     }
 
+    // The TXT branch is a SECOND call site with its own budget, so it gets its own boundary pair
+    // rather than inheriting the MD one (Gate-4 round 1, Medium).
+
+    @Test fun cap_txtAtExactlyMaxTocEntries_returnsEntries() {
+        val entries = toc(txtChapters(TxtMdTocProvider.MAX_TOC_ENTRIES), BookFormat.txt)
+        assertEquals(TxtMdTocProvider.MAX_TOC_ENTRIES, entries.size)
+    }
+
+    @Test fun cap_txtAtMaxPlusOne_returnsEmpty() {
+        val entries = toc(txtChapters(TxtMdTocProvider.MAX_TOC_ENTRIES + 1), BookFormat.txt)
+        assertEquals(emptyList<TocEntry>(), entries)
+    }
+
     @Test fun cap_rejectionHappensWithoutMaterializingFullList() {
         val text = mdHeadings(TxtMdTocProvider.MAX_TOC_ENTRIES + 10_000)
         assertEquals(emptyList<TocEntry>(), toc(text, BookFormat.md))
-        // The bound the provider relies on: the scan STOPS at `cap + 1` rather than building the
-        // document's full 60 000-heading list and truncating it afterwards.
+        // The two boundary pairs above pin the provider's budget at exactly `cap + 1` (a smaller
+        // limit rejects the at-exactly case; a larger one keeps the at-max-plus-one case). This
+        // adds the other half: at that budget the scan STOPS rather than building the document's
+        // full 60 000-heading list and truncating it afterwards.
         val bounded = runBlocking {
             MdTocScanner.scan(text, TxtMdTocProvider.MAX_TOC_ENTRIES + 1)
         }

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.20.17
-versionCode=170
+versionName=0.20.18
+versionCode=171

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -592,6 +592,19 @@ language reconcile).
   (`contracts/identity/locator.md`): precise-first / canonical-fallback,
   with `ResumeTarget.Precise` carrying the canonical fallback so the host can
   degrade if the Readium anchor won't reapply.
+- `reader.nav.TxtMdTocProvider` (feature #139) is the `TocProvider` for TXT/MD —
+  the auto-generated Contents source beside `ReadiumTocProvider` (EPUB) and
+  `EmptyTocProvider` (PDF/AZW3). It runs the ported iOS heuristics over the
+  already-decoded document on an **injected** dispatcher it hops onto itself
+  (`TxtTocRuleEngine` = the 25 Legado-derived regex rules with the ICU→Java
+  `\d`/`\s` repairs, ≥2-match confidence threshold, for `.txt`; `MdTocScanner`
+  = ATX/fence/setext/YAML-front-matter line walk for `.md`), and emits
+  `TocEntry` rows whose `canonicalLocator` is built by the same
+  `txtBookmarkLocator` a #135 bookmark uses, so a chapter row and a bookmark at
+  one source offset are one position. Detection policy is exactly iOS's: no
+  density or saturation guard, plus a `MAX_TOC_ENTRIES = 50_000` backstop that
+  **rejects rather than truncates**. Nothing is persisted — the TOC is derived
+  per reader session, so a display-settings reflow cannot invalidate it.
 
 ### In-book search (`com.vreader.app.search`) — feature #133
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -592,9 +592,12 @@ language reconcile).
   (`contracts/identity/locator.md`): precise-first / canonical-fallback,
   with `ResumeTarget.Precise` carrying the canonical fallback so the host can
   degrade if the Readium anchor won't reapply.
-- `reader.nav.TxtMdTocProvider` (feature #139) is the `TocProvider` for TXT/MD —
-  the auto-generated Contents source beside `ReadiumTocProvider` (EPUB) and
-  `EmptyTocProvider` (PDF/AZW3). It runs the ported iOS heuristics over the
+- `reader.nav.TxtMdTocProvider` (feature #139) is the `TocProvider`
+  implementation for TXT/MD — the auto-generated Contents source beside
+  `ReadiumTocProvider` (EPUB) and `EmptyTocProvider` (PDF/AZW3). *(Host wiring
+  lands in #139 WI-7; until then `TxtReaderActivity` still passes an empty
+  `tocEntries`, so the Contents control stays hidden on TXT/MD.)* It runs the
+  ported iOS heuristics over the
   already-decoded document on an **injected** dispatcher it hops onto itself
   (`TxtTocRuleEngine` = the 25 Legado-derived regex rules with the ICU→Java
   `\d`/`\s` repairs, ≥2-match confidence threshold, for `.txt`; `MdTocScanner`


### PR DESCRIPTION
## Summary

- `TxtMdTocProvider` — one `TocProvider` serving both formats: TXT via `TxtTocRuleEngine`, MD via `MdTocScanner`, sitting beside `ReadiumTocProvider` (EPUB) and `EmptyTocProvider` (PDF/AZW3).
- Row locators are built by **calling** `txtBookmarkLocator`, so a chapter row and a #135 bookmark at the same source offset are literally one canonical position.
- The provider (not the host) owns the `withContext` hop, on an **injected** dispatcher.
- `docs/architecture.md` gains the service row in this PR (rule 24 — same-PR docs sync for a new service).

Part of feature #2025 (#139). Foundational WI — host wiring lands in WI-7, so the Contents control stays hidden on TXT/MD until then.

## Detection policy: exactly iOS's, no invented guards

`>= 2` match threshold plus `MAX_TOC_ENTRIES = 50_000`, which **rejects rather than truncates**. There is no density guard, no saturation guard, no ambiguous-rule set, no format-specific exemption.

Divergence **D4 stays deleted** (Option A after Gate-2 R4, where an invented density guard failed from both directions across four rounds while iOS ships none). `noDensityOrSaturationGuardExists` pins the deletion so a future change cannot quietly reintroduce a ratio guard without updating the plan.

## Both bounded APIs are called with an explicit budget

`TxtTocRuleEngine.extractHeadings` and `MdTocScanner.scan` were each shipped with **no default `limit`**, deliberately, so this WI states its budget at every call site. Both are called with `MAX_TOC_ENTRIES + 1` — the scan stops one heading past the cap, so rejection happens without materializing a pathological document's full list. Omitting the budget is a compile error, not a silent bug.

## Five mutation probes against vacuous passes

This feature shipped a free-passing test in WI-2 (a `Job by delegate` forwarded `CoroutineContext.get`, so an assertion queried the wrong object), and WI-3's final round had to re-derive its test arithmetic to rule out the same shape. So beyond the audit, each of these mutations was applied and confirmed to turn the named test **red**:

1. `applyCap` truncating instead of rejecting
2. a one-too-small `SCAN_LIMIT`
3. a one-too-large TXT-branch budget
4. the dispatcher hop removed
5. a 90% saturation guard reintroduced

Details in the audit artifact.

## Two claims verified against merged code rather than trusted

- Both scanners' `limit` parameters genuinely have no default.
- `txtBookmarkLocator` is a top-level function in `TxtReaderActivity.kt` already exercised from JVM unit tests (`BookmarkHostWiringTest`) — so **calling** it, rather than re-spelling its fields, is both safe and makes construction drift impossible.

## Plan deviations (none blocking)

1. **§6.1 doesn't say what a non-TXT/MD format should do.** Returns an empty list — the "hide the Contents control" signal — rather than throwing, matching the engine's documented posture that degrading to no Contents beats crashing a working reader. Pinned by `unsupportedFormat_returnsEmptyList`.
2. **8 tests beyond the plan's 18 named ones**: unsupported format, empty text, the `>= 2` threshold observed end-to-end, document order, verbatim CJK/astral titles, `applyCap` in isolation, and a TXT cap boundary pair added for round 1's Medium.

## Validation

- Test gate **independently re-run by the orchestrator on the rebased branch with `--rerun-tasks`** (35/35 tasks executed, nothing cached): `RUN-ANDROID-TESTS RESULT: SUCCEEDED` — **26 tests, 0 failures, 0 errors**, count read from the JUnit XML rather than the BUILD SUCCESSFUL line.
- Write-set verified: exactly the 4 declared paths.
- Gate-4 Codex audit: 2 rounds, **`ship-as-is`**, zero open Critical/High/Medium.
- Gate 5a: foundational tier — unit tests + audit sufficient.
- Version bumped: `android/v0.20.17` → `android/v0.20.18`.

## Accepted Low

The test file is 365 lines vs the ~300 guideline; splitting needs a fifth path outside the declared write-set, and it is the second-smallest test file in its package (siblings run 485–697). The auditor endorsed that rationale in round 2.

## Type of Change

- [x] Feature WI (part of feature #2025)
