### PR TITLE
feat(#139 WI-5): txtTocIndexFor — O(log n) current-chapter highlight + differential oracle

### DIFF
--- a/.claude/codex-audits/feat-139-wi-5-toc-index-audit.md
+++ b/.claude/codex-audits/feat-139-wi-5-toc-index-audit.md
@@ -1,0 +1,115 @@
+---
+branch: feat/139-wi-5-toc-index
+threadId: 019fcbcf-7e64-7123-a053-23318a0de3a4
+rounds: 3
+final_verdict: block-recommended
+date: 2026-08-04
+---
+
+# Gate-4 audit — feature #139 WI-5 (`txtTocIndexFor`)
+
+Scope: `android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocIndex.kt` +
+`android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocIndexTest.kt`. Auditor: Codex
+(`gpt-5.6-sol`) via `scripts/run-codex.sh` (rule 53). Raw transcripts: `.reports/audit-r{1,2,3}.txt`
+(not committed — lane-local).
+
+Three questions drove every round: (Q1) does the function mirror `ReaderChromeModel.tocIndexFor`'s
+contract at every boundary, (Q2) is the search genuinely O(log n), (Q3) could any named test pass
+vacuously — the last being the priority, since WI-2 of this same feature shipped a test that passed
+for free and WI-3's final round had to re-derive its arithmetic to rule out the same shape.
+
+## Round 1 — `ship-as-is` (thread `019fcbc4-d665-7d30-9719-ab3cfad5d401`, effort low)
+
+Zero findings. Confirmed the `-1`/`0` split, the `<=` boundary, duplicate right-bias, overflow-safe
+`ushr` midpoint, loop termination, and that `CountingIntList.get` is reached by every ordinary
+traversal shape. Because this ran at the wrapper's default low reasoning effort on a plan that has
+already been wrong twice at High severity, it was not treated as sufficient.
+
+## Round 2 — `block-recommended` (thread `019fcbc6-ab41-7131-b80a-70acf4881795`, effort high)
+
+Prompted adversarially: *construct a wrong implementation that passes all 11 tests*.
+
+**HIGH — a size-keyed mutant passed the whole suite.** `if (entryOffsets.size <= 2) return 0`
+placed before the search: correct for one entry, wrong for two, and invisible because no fixture had
+size 2. Traced by the auditor against all 11 tests.
+
+**Fixes applied**
+- Added `twoEntries_secondBoundaryAndDuplicateRightBias`.
+- Generalized the single-fixture `everyOffsetInARange_agreesWithTheLinearReference` into
+  `everyOffsetAndShape_agreesWithTheLinearReference` — the whole offset domain across 11 shapes
+  (sizes 0..8, duplicate runs, a TOC starting at offset 0).
+
+**Secondary findings, also fixed**
+- The 32-read bound in the complexity probe could false-fail a *correct* O(log n) implementation
+  doing two bound searches plus endpoint probes (~34 reads) → raised to `MAX_READS = 64`, which
+  round 3 endorsed: still rejects √n jump search (~224), read-heavy O(log²n) (~256), linear (50 001).
+- A single evenly-spaced fixture does not prove O(log n) — interpolation search is near-constant on
+  `it * 10` while degrading on real, unevenly-chaptered books → added a second, skewed distribution.
+  Round 3 measured a representative interpolation search at **13 557 probes** on it, confirming the
+  fixture is genuinely adversarial.
+- A test comment called 50 001 "the largest list that can ever reach this function"; the provider
+  *rejects* >50 000 (emitting an empty TOC), so production's largest is 50 000 → comment corrected.
+
+## Round 3 — `block-recommended` (thread `019fcbcf-7e64-7123-a053-23318a0de3a4`, effort high)
+
+Verified every round-2 fix landed (the `size <= 2` mutant now dies; 64 is the right bound; the
+skewed fixture is adversarial; the cap comment is accurate; the shapes are well-formed and the
+skewed array is strictly increasing with no `Int` overflow) and explicitly re-confirmed **no
+implementation defect** in the unchanged `TxtTocIndex.kt`.
+
+**HIGH — a second size-keyed mutant, in the next gap.**
+`if (entryOffsets.size in 9..TxtMdTocProvider.MAX_TOC_ENTRIES) return 0` passed all 12 tests,
+because correctness shapes stopped at size 8 while the only large fixture was cap **+ 1**.
+
+**Fixes applied.** Enumerating more sizes only moves the gap, so the response closes the family
+rather than the example:
+- `intermediateAndCapSizes_agreeWithTheLinearReference` — sizes 9, 16, 17, 33, 257, 1 000 and the
+  production cap (50 000), each with a planted duplicate run and boundary/midpoint/past-last queries.
+- `randomizedMonotonicShapes_agreeWithTheLinearReference` — 300 **seeded** (deterministic, never
+  flaky) random sizes and non-decreasing shapes, each swept across its whole offset domain.
+- The complexity probe now runs the real cap (50 000) as well as cap + 1, in both distributions.
+
+This fix is **not auditor-confirmed**: confirming it would be a 4th round, beyond the lane's 3-round
+budget, so the lane stops and reports rather than self-certifying. It is, however, confirmed
+mechanically — see the mutation log.
+
+## Mutation log (author-run; every probe executed against the real suite)
+
+A test that cannot fail is worth nothing, so each claim below was verified by breaking the
+implementation and observing which named tests went red.
+
+| # | Mutation | Result |
+|---|---|---|
+| 0 | RED baseline: `= -1` stub | 10 of 11 fail (only `emptyEntries_returnsMinusOne` passes, coincidentally) |
+| 1 | Correct but **linear** (`forEachIndexed`) | **only** `isBinarySearch_not_linear_over50000Entries` fails — "read 50001 of 50001 elements" |
+| 2 | `<` instead of `<=` | 5 fail incl. `offsetExactlyAtEntryStart_returnsThatEntry`, `duplicateOffsets_*` |
+| 3 | nothing-at-or-before → `-1` | 5 fail incl. `offsetBeforeFirstEntry_returnsZero`, `negativeOffset_*` |
+| 4 | empty-list guard deleted | `emptyEntries_returnsMinusOne` fails (expected -1, got 0) |
+| 5 | stdlib `binarySearch`, insertion point not decremented | 5 fail incl. `offsetInsideChapter_*`, `duplicateOffsets_*` |
+| 6 | round-2 auditor's `size <= 2` mutant | fails `twoEntries_*` and `everyOffsetAndShape_*` |
+| 7 | round-3 auditor's `size in 9..MAX_TOC_ENTRIES` mutant | fails `intermediateAndCapSizes_*`, `randomizedMonotonicShapes_*`, and `isBinarySearch_*` (`uniform@50000 … read nothing`) |
+
+Probe 1 is the load-bearing one: it proves the complexity test discriminates on *complexity alone*,
+rejecting an implementation that is otherwise entirely correct.
+
+## Accepted / reported-upward, not fixed here
+
+- **`ReaderChromeModel.kt:19` KDoc is inaccurate** (round 2, Low): it says `currentTocIndex` is `-1`
+  when "there is no TOC **or no positional signal maps to a row**", but `tocIndexFor(null, null,
+  nonEmptyPositions)` returns `0` — only an empty TOC yields `-1`. Real, but that file is outside
+  WI-5's write-set (and the plan lists it OUT of scope), so it is reported in the HANDOFF rather
+  than edited.
+- **A read-counting probe cannot see CPU-only cost** between list reads (round 2): an O(log²n)
+  implementation doing extra arithmetic between 16 reads would pass. Accepted — it is an inherent
+  limit of counting reads, and the alternative (wall-clock timing) is flaky and would itself pass
+  for a fast linear scan.
+- **`entryOffsets` monotonicity is a documented precondition, not re-asserted here.** It is pinned at
+  the source by `TxtTocRuleEngineTest` and `TxtMdTocProviderTest`, which each assert the emitted
+  offsets equal their own `sorted()`. Re-validating inside the lookup would make it O(n) and defeat
+  the whole point; round 2 confirmed unsorted input still returns an in-range row and cannot throw.
+
+## Test gate
+
+`RUN-ANDROID-TESTS RESULT: SUCCEEDED` — `:app:testDebugUnitTest --tests '*TxtTocIndexTest*'
+--rerun-tasks`, **14 tests, 0 failures, 0 errors** (counts read from the JUnit XML, not the
+`BUILD SUCCESSFUL` line). JVM only; no emulator.

--- a/.claude/codex-audits/feat-139-wi-5-toc-index-audit.md
+++ b/.claude/codex-audits/feat-139-wi-5-toc-index-audit.md
@@ -1,8 +1,8 @@
 ---
 branch: feat/139-wi-5-toc-index
-threadId: 019fcbcf-7e64-7123-a053-23318a0de3a4
-rounds: 3
-final_verdict: block-recommended
+threadId: 019fcbd7-e6aa-7b11-86e1-d47186a13752
+rounds: 4
+final_verdict: follow-up-recommended
 date: 2026-08-04
 ---
 
@@ -69,9 +69,42 @@ rather than the example:
   flaky) random sizes and non-decreasing shapes, each swept across its whole offset domain.
 - The complexity probe now runs the real cap (50 000) as well as cap + 1, in both distributions.
 
-This fix is **not auditor-confirmed**: confirming it would be a 4th round, beyond the lane's 3-round
-budget, so the lane stops and reports rather than self-certifying. It is, however, confirmed
-mechanically — see the mutation log.
+The lane stopped here rather than self-certifying its own fix to an auditor's High (rule 48 hard
+rule 1), and handed back `blocked` for a confirming round.
+
+## Round 4 — `findings` (thread `019fcbd7-e6aa-7b11-86e1-d47186a13752`, run by the ORCHESTRATOR)
+
+Run by the orchestrator, not the lane, so author/auditor separation held on the round-3 fix.
+
+**Confirmed**: the complexity probe is a real discriminator — a correct-but-linear implementation
+satisfies the value oracle but exceeds `MAX_READS` on the counted 50 000-entry list, so the lane's
+"fails only that test" claim holds by inspection (matching mutation probe 1 below).
+
+**HIGH — a third size-keyed mutant**, `if (entryOffsets.size == 65 && currentOffsetUtf16 >=
+entryOffsets[1]) return 0`, passed all 14 tests, because nothing exercised size 65.
+
+**Fix — the standard closure, not another fixture.** Three rounds of "add the size the auditor
+picked" is an unbounded standard: any finite fixture list loses to a mutant keyed on an untested
+exact size. So WI-5 adds **differential testing against a reference implementation**
+(`differentialAgainstLinearReference_acrossSizesToTheCap`): a one-line linear
+`referenceTocIndexFor` oracle, compared against the real function across many sizes and probe
+offsets under a fixed seed (`20260804`). Its value is less the size coverage than that
+**behavioural** mutants — the class that actually occurs, e.g. off-by-one boundaries — now fail on
+essentially every sample instead of at one hand-picked fixture.
+
+**Deviation from the prescribed sampling, deliberate and load-bearing.** The instruction was ~200
+sizes drawn randomly from `1..MAX_TOC_ENTRIES`. A uniform draw hits any *specific* size with
+probability ≈0.4%, so it would almost certainly not sample 65 — the acceptance criterion ("verify
+the size-65 mutant now fails") would have failed. The sweep is therefore **exhaustive over 1..96**
+(where hand-written special cases actually live; the lists are tiny, so it is nearly free) **plus
+~104 log-uniform samples over 97..cap** (log-uniform because a uniform draw puts ~90% of samples
+above 5 000 and never probes the hundreds). Same budget, same determinism, strictly more coverage.
+
+**A gap the lane found in its own new test.** Mutation probe 10 (a *behavioural* "nearest entry"
+mutant) initially failed six tests but **not** the differential one: its probes sat at entry starts
+and entry+1, while "nearest" only diverges past a gap's midpoint. A floored gap-midpoint probe was
+also insufficient (it rounds back into the agreeing half). The probe set now includes
+`backing[i + 1] - 1` — late in the gap — and the differential catches that mutant too (7 failures).
 
 ## Mutation log (author-run; every probe executed against the real suite)
 
@@ -88,9 +121,26 @@ implementation and observing which named tests went red.
 | 5 | stdlib `binarySearch`, insertion point not decremented | 5 fail incl. `offsetInsideChapter_*`, `duplicateOffsets_*` |
 | 6 | round-2 auditor's `size <= 2` mutant | fails `twoEntries_*` and `everyOffsetAndShape_*` |
 | 7 | round-3 auditor's `size in 9..MAX_TOC_ENTRIES` mutant | fails `intermediateAndCapSizes_*`, `randomizedMonotonicShapes_*`, and `isBinarySearch_*` (`uniform@50000 … read nothing`) |
+| 8 | round-4 auditor's `size == 65 && offset >= entryOffsets[1]` mutant, verbatim | fails `differentialAgainstLinearReference_*` — `size=65 offset=157 expected:<32> but was:<0>` |
+| 9 | same shape at a different exhaustive-band size (`size == 91`) | fails `differentialAgainstLinearReference_*` — `size=91 offset=0 expected:<3> but was:<0>` |
+| 10 | **behavioural** (not size-keyed): nearest entry instead of last at-or-before | fails 7 tests incl. the differential (after the late-in-gap probe was added; 6 without it — see round 4) |
+| 11 | **residual probe**: `size == 4096` (one large size the sweep does not sample) | **SURVIVES — 0 failures.** Recorded, not solved. |
 
-Probe 1 is the load-bearing one: it proves the complexity test discriminates on *complexity alone*,
-rejecting an implementation that is otherwise entirely correct.
+Probe 1 is the load-bearing one for complexity: it proves the complexity test discriminates on
+*complexity alone*, rejecting an implementation that is otherwise entirely correct. Probe 10 is the
+load-bearing one for the differential oracle: it is the mutant class that actually occurs in
+practice, and it fails nearly everywhere. Probe 11 is the honest counterweight — see below.
+
+## Why `follow-up-recommended` and not `ship-as-is`
+
+The implementation is correct and was explicitly cleared by all four rounds — no round found a
+defect in `TxtTocIndex.kt`. `block-recommended` would be wrong: it implies a defect, and there is
+none. But `ship-as-is` would overclaim, because **mutation probe 11 demonstrates a measured
+residual**: a mutant keyed on one exact size the sweep does not sample (4096) still passes the whole
+suite. That is inherent to example-based testing — no finite suite excludes "special-case exactly
+the untested input" — and the differential oracle reduces it to an adversarial curiosity rather than
+a realistic defect class. It is recorded here rather than claimed solved. Accepted on that basis by
+the orchestrator, who also ruled out a fifth round.
 
 ## Accepted / reported-upward, not fixed here
 
@@ -111,5 +161,8 @@ rejecting an implementation that is otherwise entirely correct.
 ## Test gate
 
 `RUN-ANDROID-TESTS RESULT: SUCCEEDED` — `:app:testDebugUnitTest --tests '*TxtTocIndexTest*'
---rerun-tasks`, **14 tests, 0 failures, 0 errors** (counts read from the JUnit XML, not the
-`BUILD SUCCESSFUL` line). JVM only; no emulator.
+--rerun-tasks`, **15 tests, 0 failures, 0 errors** in 0.094s (counts read from the JUnit XML, not
+the `BUILD SUCCESSFUL` line). JVM only; no emulator.
+
+Note on `ReaderChromeModel.kt:19` (the out-of-write-set KDoc defect this audit surfaced): the
+orchestrator is handling it separately on `docs/bug-362-chrome-kdoc`.

--- a/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocIndex.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocIndex.kt
@@ -1,0 +1,71 @@
+// Purpose: The TXT/MD Contents sheet's current-chapter highlight (feature #139 WI-5) — map the
+// reader's live SOURCE offset to the TOC row to highlight. The offset analog of the EPUB chrome's
+// `ReaderChromeModel.tocIndexFor` (href + progression), and its exact behavioural mirror: -1 only
+// when there is no TOC at all, 0 rather than -1 when a TOC exists but nothing sits at-or-before.
+//
+// Key decisions:
+// - The highlight is COSMETIC, not a navigation target (the jump uses the row's own
+//   `canonicalLocator`), so a best-effort row always beats a missing one. That is why an offset
+//   before every entry answers 0 instead of -1 — the same trade `tocIndexFor` documents.
+// - O(log n) by binary search, not a scan. The Contents list is bounded by
+//   [TxtMdTocProvider.MAX_TOC_ENTRIES] (50 000 — Chinese web novels really do reach 20 000–30 000
+//   chapters) and this runs on EVERY position change while scrolling, so a linear scan would be
+//   50 000 comparisons per frame-ish update. `TxtTocIndexTest.isBinarySearch_not_linear_over50000Entries`
+//   counts element reads at that cap and fails a linear implementation.
+// - It takes plain `List<Int>` offsets rather than `List<TocEntry>` — the same "extract the
+//   comparable key, keep the comparison pure" split `tocPositions` / `tocIndexFor` uses on the EPUB
+//   side. No Readium types, no Android runtime, no allocation.
+// - Deliberately NOT merged with [BookmarkTocIndex.nearest]'s binary search despite the similar
+//   shape: that one answers a DIFFERENT question (which chapter does this bookmark belong to) and
+//   must return null before the first entry rather than fabricating chapter 1. Sharing the code
+//   would mean sharing an edge-case contract that is correct for neither caller.
+//
+// @coordinates-with: ../ReaderChromeModel.kt (`tocIndexFor`, the EPUB analog whose contract this
+//                    mirrors), TxtMdTocProvider.kt (produces the entries, in document order),
+//                    TocSheetRows.kt (renders the returned index as the highlighted row)
+package com.vreader.app.reader.nav
+
+/**
+ * The index of the TOC row to highlight for a reading position of [currentOffsetUtf16] — the LAST
+ * entry starting at-or-before it.
+ *
+ * @param currentOffsetUtf16 the live reading position as a UTF-16 offset into the raw decoded
+ *        document, the same coordinate space [DetectedHeading.sourceOffsetUtf16] and
+ *        `txtBookmarkLocator` use. A negative value (no position known yet) is treated as "before
+ *        everything".
+ * @param entryOffsets one source offset per TOC entry, in list order. **Precondition:** document
+ *        order, i.e. non-decreasing — which is what both scanners emit and what
+ *        `TxtTocRuleEngineTest` / `TxtMdTocProviderTest` pin. Unsorted input yields an unspecified
+ *        (but in-range) row; it cannot throw.
+ *
+ * Edge behavior — identical to `ReaderChromeModel.tocIndexFor`:
+ *  - empty [entryOffsets] → `-1` (there is no row to highlight; the Contents control is hidden
+ *    anyway when the TOC is empty);
+ *  - a non-empty TOC with no entry at-or-before the position → `0` (highlight the first row; never
+ *    `-1` once a TOC exists — a missing highlight is worse than a best-effort first row).
+ *
+ * When several entries share one offset the LAST of them wins, mirroring `tocIndexFor`'s
+ * last-match-wins loop over same-href rows.
+ *
+ * Pure function of its inputs — no side effects, no platform types.
+ */
+fun txtTocIndexFor(currentOffsetUtf16: Int, entryOffsets: List<Int>): Int {
+    if (entryOffsets.isEmpty()) return -1
+
+    // Rightmost entry whose offset <= the reading position. `<=` (not `<`) is what puts an offset
+    // exactly AT a heading's first code unit inside THAT chapter, and what makes a run of equal
+    // offsets resolve to its last member.
+    var lo = 0
+    var hi = entryOffsets.size - 1
+    var found = -1
+    while (lo <= hi) {
+        val mid = (lo + hi) ushr 1 // ushr, not /2: overflow-safe for any in-range index pair.
+        if (entryOffsets[mid] <= currentOffsetUtf16) {
+            found = mid
+            lo = mid + 1
+        } else {
+            hi = mid - 1
+        }
+    }
+    return if (found >= 0) found else 0
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocIndexTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocIndexTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.random.Random
 
 /**
  * Feature #139 WI-5 — [txtTocIndexFor]: the offset analog of the EPUB chrome's
@@ -25,8 +26,17 @@ import org.junit.Test
  * - **The search is genuinely O(log n).** [isBinarySearch_not_linear_over50000Entries] does not
  *   time anything (timings are flaky and pass for a fast linear scan on a fast machine) — it
  *   COUNTS element reads through a [CountingIntList] at the real
- *   [TxtMdTocProvider.MAX_TOC_ENTRIES]-sized cap. A linear scan reads tens of thousands of
- *   elements and fails the bound; a binary search reads ~16.
+ *   [TxtMdTocProvider.MAX_TOC_ENTRIES]-sized cap, over both an evenly-spaced and a heavily skewed
+ *   offset distribution. A linear scan reads tens of thousands of elements and fails the bound; a
+ *   binary search reads ~16 on either shape.
+ * - **No size- or shape-keyed special case can hide.** Three tests sweep an independent
+ *   `indexOfLast` oracle across the whole offset domain:
+ *   [everyOffsetAndShape_agreesWithTheLinearReference] over sizes 0..8 (duplicate runs, a TOC
+ *   starting at offset 0), [intermediateAndCapSizes_agreeWithTheLinearReference] over 9..the
+ *   production cap, and [randomizedMonotonicShapes_agreeWithTheLinearReference] over 300 seeded
+ *   random shapes. Successive Gate-4 rounds each built a mutant living in whatever size gap the
+ *   fixtures left — first `size <= 2`, then `size in 9..MAX_TOC_ENTRIES` — so the answer is a
+ *   continuum plus randomization, not one more hand-listed size.
  *
  * Precondition (NOT re-asserted here): [entryOffsets] are in document order, non-decreasing. That
  * invariant is produced and pinned upstream — `TxtTocRuleEngineTest` and `TxtMdTocProviderTest`
@@ -39,6 +49,9 @@ class TxtTocIndexTest {
     private companion object {
         /** Three chapters at plausible source offsets; the workhorse fixture. */
         val THREE = listOf(100, 200, 300)
+
+        /** The element-read ceiling the complexity probe enforces — see its own comment. */
+        const val MAX_READS = 64
     }
 
     // ── The -1-vs-0 contract ────────────────────────────────────────────────────────────────
@@ -126,13 +139,104 @@ class TxtTocIndexTest {
     }
 
     @Test
-    fun everyOffsetInARange_agreesWithTheLinearReference() {
-        // Exhaustive cross-check of the whole domain around a small TOC against the plain-English
-        // rule ("last entry at-or-before, else 0"), so no single hand-picked probe can hide a gap.
-        val entries = listOf(3, 7, 8, 15, 16, 23, 42)
-        for (offset in -5..50) {
-            val expected = entries.indexOfLast { it <= offset }.let { if (it >= 0) it else 0 }
-            assertEquals("offset=$offset", expected, txtTocIndexFor(offset, entries))
+    fun twoEntries_secondBoundaryAndDuplicateRightBias() {
+        // The size-2 shape specifically. It is the smallest list where "always answer 0" stops being
+        // correct, so a suite that jumps from 1 entry to 3 leaves a hole a size-keyed fast path
+        // (`if (size <= 2) return 0`) slips through — correct for one entry, wrong for two.
+        val two = listOf(100, 200)
+        assertEquals(0, txtTocIndexFor(99, two))
+        assertEquals(0, txtTocIndexFor(199, two))
+        assertEquals(1, txtTocIndexFor(200, two))
+        assertEquals(1, txtTocIndexFor(Int.MAX_VALUE, two))
+        // Right-bias with exactly two equal offsets.
+        assertEquals(1, txtTocIndexFor(100, listOf(100, 100)))
+    }
+
+    @Test
+    fun everyOffsetAndShape_agreesWithTheLinearReference() {
+        // Exhaustive cross-check of the whole offset domain against the plain-English rule ("last
+        // entry at-or-before, else 0; -1 only when empty") across MANY SHAPES AND SIZES — not one
+        // fixture. Sweeping sizes 0..8, duplicate runs, and a list starting at offset 0 is what
+        // closes the door on size- or shape-keyed special casing, which any single-fixture suite
+        // (however dense in the offset dimension) cannot see. The oracle is `indexOfLast`, which
+        // shares no mechanics with the binary search under test, so this is not a tautology.
+        val shapes = listOf(
+            emptyList(),
+            listOf(3),
+            listOf(3, 7),
+            listOf(0, 1),
+            listOf(4, 4),
+            listOf(3, 7, 8),
+            listOf(5, 5, 5),
+            listOf(3, 7, 8, 15),
+            listOf(0, 4, 4, 9, 9, 9, 12),
+            listOf(3, 7, 8, 15, 16, 23, 42),
+            listOf(0, 1, 2, 3, 4, 5, 6, 7),
+        )
+        for (entries in shapes) {
+            for (offset in -5..50) {
+                val expected = if (entries.isEmpty()) {
+                    -1
+                } else {
+                    entries.indexOfLast { it <= offset }.let { if (it >= 0) it else 0 }
+                }
+                assertEquals("entries=$entries offset=$offset", expected, txtTocIndexFor(offset, entries))
+            }
+        }
+    }
+
+    @Test
+    fun intermediateAndCapSizes_agreeWithTheLinearReference() {
+        // The sizes BETWEEN the small shapes above and the complexity fixture below — including the
+        // production cap itself, the largest TOC TxtMdTocProvider will ever emit. A Gate-4 round-3
+        // mutant lived exactly in this hole (`if (size in 9..MAX_TOC_ENTRIES) return 0`), invisible
+        // while the correctness shapes stopped at 8 and the only large fixture was cap + 1.
+        val sizes = listOf(9, 16, 17, 33, 257, 1_000, TxtMdTocProvider.MAX_TOC_ENTRIES)
+        for (size in sizes) {
+            val backing = IntArray(size) { it * 7 }
+            // Plant a duplicate run mid-list so right-bias is exercised at every size, not just the
+            // hand-built small shapes. Still non-decreasing: the slot is lowered onto its predecessor.
+            if (size >= 3) backing[size / 2] = backing[size / 2 - 1]
+            val entries = backing.toList()
+
+            val queries = listOf(
+                -1, 0,
+                backing[0], backing[0] + 1,
+                backing[size / 2 - 1], backing[size / 2], backing[size / 2] + 1,
+                backing[size - 2], backing[size - 1], backing[size - 1] + 1,
+                Int.MAX_VALUE,
+            )
+            for (query in queries) {
+                val expected = backing.indexOfLast { it <= query }.let { if (it >= 0) it else 0 }
+                assertEquals("size=$size offset=$query", expected, txtTocIndexFor(query, entries))
+            }
+        }
+    }
+
+    @Test
+    fun randomizedMonotonicShapes_agreeWithTheLinearReference() {
+        // A SEEDED (deterministic — never flaky) sweep over many random sizes and random
+        // non-decreasing offset shapes, each queried across its whole domain.
+        //
+        // Why this exists: no finite list of example shapes can rule out "special-case exactly the
+        // sizes nobody tested" — two Gate-4 rounds each found a fresh size-keyed mutant in whatever
+        // gap the previous fixtures left. Enumerating more sizes only moves the gap. This test
+        // changes the shape of the argument: an implementation that survives hundreds of
+        // pseudo-randomly sized and spaced shapes AND the cap-sized fixtures above is no longer
+        // "untested at some size", it is one that special-cases nothing.
+        val random = Random(seed = 1395L)
+        repeat(300) {
+            val size = 1 + random.nextInt(64)
+            var next = random.nextInt(5)
+            val entries = ArrayList<Int>(size)
+            repeat(size) {
+                entries.add(next)
+                next += random.nextInt(4) // a 0 step plants duplicate offsets naturally
+            }
+            for (offset in -2..(entries.last() + 3)) {
+                val expected = entries.indexOfLast { it <= offset }.let { if (it >= 0) it else 0 }
+                assertEquals("entries=$entries offset=$offset", expected, txtTocIndexFor(offset, entries))
+            }
         }
     }
 
@@ -140,36 +244,60 @@ class TxtTocIndexTest {
 
     @Test
     fun isBinarySearch_not_linear_over50000Entries() {
-        // The real cap (TxtMdTocProvider.MAX_TOC_ENTRIES) + 1, i.e. the largest list that can ever
-        // reach this function. Entries every 10 code units so offsets and indices differ.
-        val size = TxtMdTocProvider.MAX_TOC_ENTRIES + 1
-        val backing = IntArray(size) { it * 10 }
-        val list = CountingIntList(backing)
+        // BOTH the production cap — TxtMdTocProvider REJECTS a document with more than
+        // MAX_TOC_ENTRIES headings (it emits an empty TOC rather than truncating), so a 50 000-row
+        // TOC is the largest list that can actually reach this function — and cap + 1 as a margin.
+        val cap = TxtMdTocProvider.MAX_TOC_ENTRIES
 
-        // ceil(log2(50002)) == 16, so a correct binary search reads ~16 elements. 32 leaves 2x
-        // headroom for an extra probe/early-out while staying ~1500x below a linear scan's 50001.
-        val maxReads = 32
+        // TWO monotonic distributions per size. A single evenly-spaced fixture would let an
+        // interpolation search look logarithmic here while degrading towards linear on a real book,
+        // whose chapters are not evenly spaced: `skewed` packs all but the last 100 entries into a
+        // narrow head and then jumps three orders of magnitude, its worst case.
+        fun uniform(n: Int) = IntArray(n) { it * 10 }
+        fun skewed(n: Int) = IntArray(n) { i -> if (i < n - 100) i * 2 else 500_000_000 + (i - (n - 100)) * 1_000 }
 
-        // Worst-case-ish queries spread across the list, INCLUDING both ends and a miss-before-first.
-        val queries = listOf(-1, 0, 5, 250_000, 250_005, size * 10, Int.MAX_VALUE)
-        for (query in queries) {
-            list.resetReads()
-            val index = txtTocIndexFor(query, list)
-
-            // The probe must also prove the answer is RIGHT — a function that returns a constant
-            // without reading anything would otherwise "pass" the read-count bound for free.
-            val expected = when {
-                query < 0 -> 0
-                query / 10 >= size -> size - 1
-                else -> query / 10
-            }
-            assertEquals("index for offset=$query", expected, index)
-            assertTrue(
-                "offset=$query read ${list.reads} of $size elements; a binary search reads <= $maxReads " +
-                    "(a linear scan would read ~$size)",
-                list.reads <= maxReads,
+        val fixtures = listOf(
+            "uniform@$cap" to uniform(cap),
+            "uniform@${cap + 1}" to uniform(cap + 1),
+            "skewed@$cap" to skewed(cap),
+            "skewed@${cap + 1}" to skewed(cap + 1),
+        )
+        for ((shape, backing) in fixtures) {
+            val size = backing.size
+            val list = CountingIntList(backing)
+            val queries = listOf(
+                -1,                        // before everything
+                backing[0],                // exactly the first
+                backing[0] + 1,
+                backing[size / 2],         // exactly a midpoint entry
+                backing[size / 2] + 1,     // just inside it
+                backing[size - 1],         // exactly the last
+                Int.MAX_VALUE,             // past everything
             )
-            assertTrue("offset=$query read nothing — the answer cannot have been searched for", list.reads > 0)
+            for (query in queries) {
+                list.resetReads()
+                val index = txtTocIndexFor(query, list)
+                val label = "$shape offset=$query"
+
+                // The probe must also prove the answer is RIGHT — a function that returned a
+                // constant without reading anything would otherwise pass the bound for free. The
+                // oracle scans the raw IntArray (never the counted list), so it neither perturbs
+                // the counter nor re-derives the fixture's arithmetic.
+                val expected = backing.indexOfLast { it <= query }.let { if (it >= 0) it else 0 }
+                assertEquals("index for $label", expected, index)
+
+                // ceil(log2(50002)) == 16, so one probe per level reads ~16. MAX_READS = 64 leaves
+                // 4x headroom, so a correct-but-constant-heavier O(log n) variant (e.g. two bound
+                // searches plus endpoint probes, ~34 reads) cannot false-fail — while staying well
+                // below sqrt-n jump search (~224), read-heavy O(log^2 n) (~256) and a linear scan
+                // (50 001), all of which this bound still rejects.
+                assertTrue(
+                    "$label read ${list.reads} of $size elements; a logarithmic search reads " +
+                        "<= $MAX_READS (a linear scan would read ~$size)",
+                    list.reads <= MAX_READS,
+                )
+                assertTrue("$label read nothing — the answer cannot have been searched for", list.reads > 0)
+            }
         }
     }
 

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocIndexTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocIndexTest.kt
@@ -4,6 +4,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.math.exp
+import kotlin.math.ln
 import kotlin.random.Random
 
 /**
@@ -29,14 +31,18 @@ import kotlin.random.Random
  *   [TxtMdTocProvider.MAX_TOC_ENTRIES]-sized cap, over both an evenly-spaced and a heavily skewed
  *   offset distribution. A linear scan reads tens of thousands of elements and fails the bound; a
  *   binary search reads ~16 on either shape.
- * - **No size- or shape-keyed special case can hide.** Three tests sweep an independent
- *   `indexOfLast` oracle across the whole offset domain:
- *   [everyOffsetAndShape_agreesWithTheLinearReference] over sizes 0..8 (duplicate runs, a TOC
- *   starting at offset 0), [intermediateAndCapSizes_agreeWithTheLinearReference] over 9..the
- *   production cap, and [randomizedMonotonicShapes_agreeWithTheLinearReference] over 300 seeded
- *   random shapes. Successive Gate-4 rounds each built a mutant living in whatever size gap the
- *   fixtures left — first `size <= 2`, then `size in 9..MAX_TOC_ENTRIES` — so the answer is a
- *   continuum plus randomization, not one more hand-listed size.
+ * - **Behaviour is pinned DIFFERENTIALLY, not by fixtures alone.**
+ *   [differentialAgainstLinearReference_acrossSizesToTheCap] compares every answer against
+ *   [referenceTocIndexFor], a one-line linear reference, across every size 1..96 plus log-uniform
+ *   samples to the production cap. Four successive Gate-4 rounds each built a mutant living in
+ *   whatever exact size the fixtures missed (`size <= 2`, `size in 9..MAX_TOC_ENTRIES`,
+ *   `size == 65`); enumerating one more size only moves the gap, so the closure is a reference
+ *   oracle — which also makes ordinary behavioural mutants (off-by-one boundaries, first-vs-last
+ *   duplicate) fail on nearly every sample rather than at one fixture.
+ *   [everyOffsetAndShape_agreesWithTheLinearReference],
+ *   [intermediateAndCapSizes_agreeWithTheLinearReference] and
+ *   [randomizedMonotonicShapes_agreeWithTheLinearReference] keep the exhaustive small-shape,
+ *   named-size and random-shape sweeps as fast, readable first-line defences.
  *
  * Precondition (NOT re-asserted here): [entryOffsets] are in document order, non-decreasing. That
  * invariant is produced and pinned upstream — `TxtTocRuleEngineTest` and `TxtMdTocProviderTest`
@@ -52,6 +58,9 @@ class TxtTocIndexTest {
 
         /** The element-read ceiling the complexity probe enforces — see its own comment. */
         const val MAX_READS = 64
+
+        /** Fixed so the differential sweep is reproducible, never flaky. */
+        const val DIFFERENTIAL_SEED = 20_260_804L
     }
 
     // ── The -1-vs-0 contract ────────────────────────────────────────────────────────────────
@@ -236,6 +245,89 @@ class TxtTocIndexTest {
             for (offset in -2..(entries.last() + 3)) {
                 val expected = entries.indexOfLast { it <= offset }.let { if (it >= 0) it else 0 }
                 assertEquals("entries=$entries offset=$offset", expected, txtTocIndexFor(offset, entries))
+            }
+        }
+    }
+
+    // ── Differential (the standard closure for the size-keyed family) ───────────────────────
+
+    /**
+     * A trivial, obviously-correct linear reference — the differential oracle. It restates the
+     * contract in one line of `indexOfLast` plus the two documented edge rules, sharing NO
+     * mechanics with the binary search under test, so agreement between them is real evidence
+     * rather than a tautology.
+     */
+    private fun referenceTocIndexFor(currentOffsetUtf16: Int, entryOffsets: List<Int>): Int {
+        if (entryOffsets.isEmpty()) return -1
+        val at = entryOffsets.indexOfLast { it <= currentOffsetUtf16 }
+        return if (at >= 0) at else 0
+    }
+
+    @Test
+    fun differentialAgainstLinearReference_acrossSizesToTheCap() {
+        // WHY THIS TEST REPLACES "ADD ANOTHER SIZE": four Gate-4 rounds each constructed a mutant
+        // keyed on whatever exact size the fixtures missed (`size <= 2`, then
+        // `size in 9..MAX_TOC_ENTRIES`, then `size == 65`). Enumerating one more size just moves
+        // the gap — the standard technique that actually closes it is differential testing against
+        // a reference implementation, which makes BEHAVIOURAL mutants (the class that actually
+        // occurs — off-by-one boundary logic, first-vs-last duplicate) fail on essentially every
+        // sample rather than only at a hand-picked fixture.
+        //
+        // SAMPLING (deliberate deviation from a plain uniform draw, and the reason it works):
+        // 200 sizes drawn uniformly from 1..50 000 hit any SPECIFIC size with probability ~0.4%,
+        // so a uniform sweep would not reliably catch the `size == 65` mutant it exists to kill.
+        // Instead: EXHAUSTIVE over 1..96 — where hand-written special cases actually live, and
+        // cheap because the lists are tiny — plus LOG-UNIFORM samples over 97..cap, which spread
+        // across magnitudes (a uniform draw puts ~90% of its samples above 5 000 and never probes
+        // the hundreds). Residual, stated honestly: a mutant keyed on one exact untested size above
+        // 96 can still survive; that is inherent to example-based testing, not fixable by more
+        // fixtures, and is recorded in the Gate-4 artifact rather than claimed solved.
+        val random = Random(seed = DIFFERENTIAL_SEED)
+        val cap = TxtMdTocProvider.MAX_TOC_ENTRIES
+        val sizes = buildList {
+            addAll(1..96)
+            repeat(104) {
+                val logLow = ln(97.0)
+                val logHigh = ln(cap.toDouble())
+                add(exp(logLow + random.nextDouble() * (logHigh - logLow)).toInt().coerceIn(97, cap))
+            }
+        }
+
+        for (size in sizes) {
+            // Non-uniform gaps, and a 0 step plants duplicate offsets naturally.
+            val backing = IntArray(size)
+            var next = random.nextInt(3)
+            for (i in 0 until size) {
+                backing[i] = next
+                next += random.nextInt(10)
+            }
+            val entries = backing.toList()
+
+            val probes = mutableListOf(
+                Int.MIN_VALUE, -1,                                   // before everything
+                backing[0] - 1, backing[0], backing[0] + 1,          // the first boundary
+                backing[size / 2], backing[size / 2] + 1,            // a midpoint boundary + its gap
+                backing[size - 1], backing[size - 1] + 1,            // the last boundary
+                Int.MAX_VALUE,                                       // past everything
+            )
+            repeat(4) {
+                val i = random.nextInt(size)
+                probes += backing[i]      // exactly at some entry start
+                probes += backing[i] + 1  // just inside the gap after it
+                // ...and LATE in the gap, just before the next entry starts. A "nearest entry"
+                // mutant agrees with the contract through the first half of a gap and only
+                // diverges past its midpoint, so probing entry-starts and entry+1 alone cannot see
+                // it (a mutation probe caught this suite missing exactly that). A floored midpoint
+                // is not enough either — it rounds back into the agreeing half.
+                if (i + 1 < size) probes += backing[i + 1] - 1
+            }
+
+            for (offset in probes) {
+                assertEquals(
+                    "size=$size offset=$offset (seed=$DIFFERENTIAL_SEED)",
+                    referenceTocIndexFor(offset, entries),
+                    txtTocIndexFor(offset, entries),
+                )
             }
         }
     }

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocIndexTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocIndexTest.kt
@@ -1,0 +1,196 @@
+package com.vreader.app.reader.nav
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Feature #139 WI-5 — [txtTocIndexFor]: the offset analog of the EPUB chrome's
+ * `ReaderChromeModel.tocIndexFor`, mapping a TXT/MD reader's live source offset to the Contents
+ * row to highlight.
+ *
+ * The properties this suite exists to protect:
+ *
+ * - **The `-1`-vs-`0` contract is EXACTLY `tocIndexFor`'s.** `-1` means "there is no row to
+ *   highlight", and that is true only when the TOC is empty. Once a TOC exists the answer is never
+ *   `-1`: an offset before every entry highlights the first row, because a missing highlight is
+ *   worse than a best-effort one. [emptyEntries_returnsMinusOne] and
+ *   [offsetBeforeFirstEntry_returnsZero] pin the two halves against each other — an implementation
+ *   that collapses them (returns `-1` when nothing is at-or-before) fails the second.
+ * - **Every boundary is pinned, not just the interior.** An offset exactly AT an entry start
+ *   belongs to THAT entry (not the previous one); an offset past the last entry stays on the last
+ *   entry; a one-entry TOC always answers 0. These are the off-by-one seams a `<` / `<=` slip or a
+ *   `found` / `lo` mix-up moves, and each has its own test.
+ * - **The search is genuinely O(log n).** [isBinarySearch_not_linear_over50000Entries] does not
+ *   time anything (timings are flaky and pass for a fast linear scan on a fast machine) — it
+ *   COUNTS element reads through a [CountingIntList] at the real
+ *   [TxtMdTocProvider.MAX_TOC_ENTRIES]-sized cap. A linear scan reads tens of thousands of
+ *   elements and fails the bound; a binary search reads ~16.
+ *
+ * Precondition (NOT re-asserted here): [entryOffsets] are in document order, non-decreasing. That
+ * invariant is produced and pinned upstream — `TxtTocRuleEngineTest` and `TxtMdTocProviderTest`
+ * both assert the emitted offsets equal their own `sorted()`. This suite tests the consumer.
+ *
+ * Pure JVM — no Android runtime, no Robolectric, no emulator.
+ */
+class TxtTocIndexTest {
+
+    private companion object {
+        /** Three chapters at plausible source offsets; the workhorse fixture. */
+        val THREE = listOf(100, 200, 300)
+    }
+
+    // ── The -1-vs-0 contract ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun emptyEntries_returnsMinusOne() {
+        // The ONLY input that may answer -1: no TOC, so there is no row to highlight.
+        assertEquals(-1, txtTocIndexFor(0, emptyList()))
+        assertEquals(-1, txtTocIndexFor(12_345, emptyList()))
+        assertEquals(-1, txtTocIndexFor(Int.MAX_VALUE, emptyList()))
+    }
+
+    @Test
+    fun offsetBeforeFirstEntry_returnsZero() {
+        // A TOC exists but nothing is at-or-before → the FIRST row, never -1 (tocIndexFor's rule).
+        assertEquals(0, txtTocIndexFor(0, THREE))
+        assertEquals(0, txtTocIndexFor(99, THREE))
+        // Stated as its own assertion so the -1/0 confusion can never pass silently.
+        assertNotEquals(-1, txtTocIndexFor(0, THREE))
+    }
+
+    @Test
+    fun negativeOffset_stillReturnsZero_neverMinusOne() {
+        // Defensive: a not-yet-known reading position must not be mistaken for "no TOC".
+        assertEquals(0, txtTocIndexFor(-1, THREE))
+        assertEquals(0, txtTocIndexFor(Int.MIN_VALUE, THREE))
+    }
+
+    // ── Boundaries ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun offsetExactlyAtEntryStart_returnsThatEntry() {
+        // At-or-before is inclusive: the heading line's own first code unit is INSIDE that chapter.
+        assertEquals(0, txtTocIndexFor(100, THREE))
+        assertEquals(1, txtTocIndexFor(200, THREE))
+        assertEquals(2, txtTocIndexFor(300, THREE))
+    }
+
+    @Test
+    fun offsetInsideChapter_returnsLastEntryAtOrBefore() {
+        assertEquals(0, txtTocIndexFor(101, THREE))
+        assertEquals(0, txtTocIndexFor(199, THREE))
+        assertEquals(1, txtTocIndexFor(250, THREE))
+        assertEquals(1, txtTocIndexFor(299, THREE))
+    }
+
+    @Test
+    fun offsetPastLastEntry_returnsLastEntry() {
+        assertEquals(2, txtTocIndexFor(301, THREE))
+        assertEquals(2, txtTocIndexFor(9_999_999, THREE))
+        assertEquals(2, txtTocIndexFor(Int.MAX_VALUE, THREE))
+    }
+
+    @Test
+    fun singleEntry_alwaysReturnsZero() {
+        val one = listOf(500)
+        assertEquals(0, txtTocIndexFor(0, one))       // before it
+        assertEquals(0, txtTocIndexFor(499, one))     // just before it
+        assertEquals(0, txtTocIndexFor(500, one))     // exactly at it
+        assertEquals(0, txtTocIndexFor(501, one))     // just after it
+        assertEquals(0, txtTocIndexFor(Int.MAX_VALUE, one))
+    }
+
+    @Test
+    fun firstEntryAtOffsetZero_isSelectedAtOffsetZero() {
+        // A document whose very first line is a heading: offset 0 is a real at-entry hit, not the
+        // nothing-at-or-before fallback. Both paths answer 0, so this pins the fixture where they
+        // differ — entry 0 at offset 0 must still be beaten by a later entry once passed.
+        val fromZero = listOf(0, 50, 120)
+        assertEquals(0, txtTocIndexFor(0, fromZero))
+        assertEquals(0, txtTocIndexFor(49, fromZero))
+        assertEquals(1, txtTocIndexFor(50, fromZero))
+        assertEquals(2, txtTocIndexFor(120, fromZero))
+    }
+
+    @Test
+    fun duplicateOffsets_returnTheLastEntryAtThatOffset() {
+        // Two headings can share a line start (e.g. an MD setext title re-detected at the same
+        // line). tocIndexFor keeps the LAST such row (its exact-href loop overwrites), so does this.
+        val dupes = listOf(0, 100, 100, 100, 300)
+        assertEquals(3, txtTocIndexFor(100, dupes))
+        assertEquals(3, txtTocIndexFor(299, dupes))
+        assertEquals(4, txtTocIndexFor(300, dupes))
+        assertEquals(0, txtTocIndexFor(0, dupes))
+    }
+
+    @Test
+    fun everyOffsetInARange_agreesWithTheLinearReference() {
+        // Exhaustive cross-check of the whole domain around a small TOC against the plain-English
+        // rule ("last entry at-or-before, else 0"), so no single hand-picked probe can hide a gap.
+        val entries = listOf(3, 7, 8, 15, 16, 23, 42)
+        for (offset in -5..50) {
+            val expected = entries.indexOfLast { it <= offset }.let { if (it >= 0) it else 0 }
+            assertEquals("offset=$offset", expected, txtTocIndexFor(offset, entries))
+        }
+    }
+
+    // ── Complexity ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun isBinarySearch_not_linear_over50000Entries() {
+        // The real cap (TxtMdTocProvider.MAX_TOC_ENTRIES) + 1, i.e. the largest list that can ever
+        // reach this function. Entries every 10 code units so offsets and indices differ.
+        val size = TxtMdTocProvider.MAX_TOC_ENTRIES + 1
+        val backing = IntArray(size) { it * 10 }
+        val list = CountingIntList(backing)
+
+        // ceil(log2(50002)) == 16, so a correct binary search reads ~16 elements. 32 leaves 2x
+        // headroom for an extra probe/early-out while staying ~1500x below a linear scan's 50001.
+        val maxReads = 32
+
+        // Worst-case-ish queries spread across the list, INCLUDING both ends and a miss-before-first.
+        val queries = listOf(-1, 0, 5, 250_000, 250_005, size * 10, Int.MAX_VALUE)
+        for (query in queries) {
+            list.resetReads()
+            val index = txtTocIndexFor(query, list)
+
+            // The probe must also prove the answer is RIGHT — a function that returns a constant
+            // without reading anything would otherwise "pass" the read-count bound for free.
+            val expected = when {
+                query < 0 -> 0
+                query / 10 >= size -> size - 1
+                else -> query / 10
+            }
+            assertEquals("index for offset=$query", expected, index)
+            assertTrue(
+                "offset=$query read ${list.reads} of $size elements; a binary search reads <= $maxReads " +
+                    "(a linear scan would read ~$size)",
+                list.reads <= maxReads,
+            )
+            assertTrue("offset=$query read nothing — the answer cannot have been searched for", list.reads > 0)
+        }
+    }
+
+    /**
+     * A `List<Int>` that counts element reads. Every traversal shape lands on [get] — indexing
+     * directly, `forEachIndexed`, and iteration (`kotlin.collections.AbstractList`'s iterator is
+     * implemented in terms of [get]) — so a linear implementation cannot dodge the counter.
+     */
+    private class CountingIntList(private val backing: IntArray) : AbstractList<Int>() {
+        var reads: Int = 0
+            private set
+
+        override val size: Int get() = backing.size
+
+        override fun get(index: Int): Int {
+            reads++
+            return backing[index]
+        }
+
+        fun resetReads() {
+            reads = 0
+        }
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.20.18
-versionCode=171
+versionName=0.20.19
+versionCode=172


### PR DESCRIPTION
## Summary

- `txtTocIndexFor` — the current-chapter highlight index for the TXT/MD Contents sheet. O(log n) binary search over the cap-sized entry list.
- Mirrors `ReaderChromeModel.tocIndexFor`'s contract exactly: `-1` **only** when there are no entries; `0` (not -1) when a TOC exists but nothing sits at-or-before the offset.

Part of feature #2025 (#139). Foundational WI — ~70 lines of implementation.

## Gate 4: four rounds, and no round found an implementation defect

Every finding across all four rounds was about **test strength**, not behaviour. That is worth stating plainly, because it shapes the verdict.

**Round 3** raised a High by construction — it exhibited a *wrong* implementation that passed the entire then-12-test suite:

```kotlin
if (entryOffsets.size in 9..TxtMdTocProvider.MAX_TOC_ENTRIES) return 0
```

It survived because correctness fixtures stopped at size 8 while the only large fixture was cap+1, leaving the size continuum between them unexercised. A mutant keyed on list **size** was invisible.

**Round 4** (run by the orchestrator, preserving author/auditor separation — the lane could not certify its own fix to the auditor's finding) confirmed the family was *still* open, exhibiting `size == 65 && offset >= entryOffsets[1]`.

## Why fixtures were the wrong fix

Adding size 65 would only relocate the gap — the next round picks 66. **Enumerating fixtures is an unbounded standard: any finite suite loses to a mutant keyed on an untested exact size.** The closure is differential testing against a reference implementation, which kills the class that actually occurs in practice: nobody accidentally writes `if (size == 65)`, they write off-by-one boundary logic, and a differential oracle catches that on every sample.

## The lane improved on the prescribed design, correctly

The orchestrator specified ~200 sizes drawn uniformly from `1..MAX_TOC_ENTRIES`. The lane pointed out that a uniform draw hits any specific size with p≈0.4%, so it would very likely **not** have sampled 65 — failing the very acceptance criterion it was given. Instead:

- **exhaustive** over sizes `1..96`, where hand-written special cases live (tiny lists, near-free), plus
- ~104 **log-uniform** samples over `97..cap` — uniform sampling puts ~90% of draws above 5,000 and never probes the hundreds.

Same budget, same seeded determinism (seed `20260804`, stated in every assertion message), strictly more coverage.

## Mutation verification

| Probe | Mutant | Result |
|---|---|---|
| 8 | the auditor's verbatim `size == 65 && offset >= entryOffsets[1]` | **FAILS** — `size=65 offset=157 expected:<32> but was:<0>` |
| 9 | same shape at size 91 | **FAILS** — `size=91 offset=0` |
| 10 | behavioural "nearest entry" mutant | **FAILS** 7 tests incl. the differential |
| 11 | `size == 4096` (one large unsampled size) | **SURVIVES** — see residual |

**Probe 10 exposed a gap in the lane's own new test.** With only entry-start and entry+1 probes the differential *missed* it, because "nearest" diverges only past a gap's midpoint — and a floored-midpoint probe was still insufficient, since it rounds back into the agreeing half. Fixed by probing `backing[i+1] - 1`, late in the gap.

## Residual — measured, not assumed

Probe 11 survives: a mutant keyed on one large unsampled size (`4096`) still passes. That is why the verdict is **`follow-up-recommended`** rather than `ship-as-is`. The implementation is correct and was cleared by every round; the differential oracle closes the practically-occurring mutant space; adversarial mutants at an unsampled exact size remain possible and are recorded rather than claimed solved.

## Confirmed as a byproduct

The complexity probe is a **real discriminator**, not decorative: a correct-but-linear implementation satisfies the value oracle but exceeds the read budget on the 50,000-entry counted list — so it fails *only* that test, which is exactly what a complexity probe should do.

## Validation

- Test gate **independently re-run by the orchestrator on the rebased branch with `--rerun-tasks`**: `RUN-ANDROID-TESTS RESULT: SUCCEEDED` — **15 tests, 0 failures, 0 errors**, count read from the JUnit XML.
- `TxtTocIndex.kt` is byte-identical to its original commit — every mutation reverted, verified with `git diff --quiet`.
- Write-set verified: exactly the 3 declared paths.
- Gate 5a: foundational tier — unit tests + audit sufficient.
- Version bumped: `android/v0.20.18` → `android/v0.20.19`.

## Filed separately

`ReaderChromeModel.kt:19`'s KDoc contradicts its own code at `:79-80` — it claims -1 for "no positional signal", but a null href with a non-empty TOC returns 0. Found by this lane while mirroring that contract, and correctly reported rather than fixed (outside its write-set). Filed as bug #362 / GH #2038.

## Type of Change

- [x] Feature WI (part of feature #2025)
