### PR TITLE
feat(#139 WI-7): host wiring — Contents becomes reachable on TXT/MD

### DIFF
--- a/.claude/codex-audits/feat-139-wi-7-host-wiring-audit.md
+++ b/.claude/codex-audits/feat-139-wi-7-host-wiring-audit.md
@@ -1,0 +1,109 @@
+---
+branch: feat/139-wi-7-host-wiring
+threadId: 019fcd1e-bb0f-7242-8b7f-47ee071e50da
+rounds: 2
+final_verdict: ship-as-is
+date: 2026-08-04
+---
+
+# Codex Audit Log — Feature #139 WI-7 (host wiring: TXT/MD table of contents)
+
+Wire the already-merged `TxtMdTocProvider` into `TxtReaderActivity` so the
+Contents control becomes reachable for TXT/MD books. Before this WI the host
+passed `tocEntries = emptyList()` unconditionally, so `ReaderChromeScaffold`'s
+empty-list rule hid Contents on every TXT/MD book — WI-1..WI-6 were plumbing
+behind a hidden control.
+
+Plan: `dev-docs/plans/20260804-feature-139-android-txt-md-toc.md` (§4.5 the
+readiness gate, §7 the WI-7 spec block, **§7a the binding Gate-4 focus**).
+
+## Scope of audit
+
+Three files:
+
+- `android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt` (modified)
+- `android/app/src/test/kotlin/com/vreader/app/reader/TxtTocHostWiringTest.kt` (new, JVM)
+- `android/app/src/androidTest/kotlin/com/vreader/app/reader/TxtTocConnectedTest.kt` (new, connected)
+
+Session threads: round 1 `019fcd1e-bb0f-7242-8b7f-47ee071e50da`
+(`.reports/audit-r1.txt`), round 2 `019fcd23-51e2-7561-be40-3136bc985bf0`
+(`.reports/audit-r2.txt`). Both run through `scripts/run-codex.sh` (rule 53).
+
+The round-1 prompt carried §7a verbatim as a binding focus: for every value the
+readiness gate observes, confirm against the REAL source that it actually
+re-emits; enumerate deadlock paths; confirm the scan runs in scroll, in paged,
+and after a mid-session toggle; and hunt a **fourth** instance of the
+"mechanism that can never fire" family that this plan produced three times.
+
+## Round 1 findings (3)
+
+| File:line | Severity | Issue | Resolution |
+|---|---|---|---|
+| `TxtReaderActivity.kt` (`awaitTocScanGate`) | **High** | **The fourth never-fires instance, and a real one.** A *mounted* paged body does not always publish a settled page: when the page index is degenerate or empty, `TxtPagedBody` renders `TxtScrollFallback` instead of a pager (`TxtReaderBody.kt:445-450`), so `onSaveSourceOffset` — and therefore the host's `pagedOffset` — never fires for the whole session. `pagedBodyMounted` stays `true` (it tracks the host's `usePaged`, not the body's internal fallback), so the unbounded `snapshotFlow { … }.first { it }` suspends forever and Contents stays hidden with no crash and no log. | **Fixed** in `548b6644`. Stage 2 of the gate is now `withTimeoutOrNull(PAGED_READY_TIMEOUT_MS)` (3 s, injectable per call). This is the correct degrade rather than a workaround: only stage 1 (`withFrameNanos`) was ever a hard guarantee — the settled-page wait is an optimization to keep the scan off the first-paint path, and the scan is off-main either way. A navigation affordance must not depend on a signal that may never arrive. `TxtReaderBody.kt` is outside this WI's write-set, so a body-side terminal-readiness signal was not available; round 2 confirmed the bounded wait is the best localized fix. |
+| `TxtTocHostWiringTest.kt` | Medium | The JVM gate tests drive `runTxtTocScan` with synthetic `mutableStateOf` values, not the production `TxtPagedBody → onSaveSourceOffset → pagedOffset` chain, so they could not have detected the stranding above; no connected test covered a mid-session layout toggle either. | **Fixed.** Added connected `pagedMode_scanCompletes_evenForABookWithNoChapters` (drives the real chain to completion for a headings-free book — the case where a stranded gate would be invisible, since the control is hidden either way) and `layoutToggleMidSession_keepsContentsAvailable`. Added JVM `pagedMode_gateNeverStrands_whenNoSettledPageEverArrives` and `pagedReadyTimeoutIsBounded`. |
+| `TxtReaderActivity.kt:441,822` | Low | Two comments still asserted "TXT/MD has no TOC" — false after this WI (rule 22). | **Fixed.** The bottom-chrome comment now says `openContents` is null only while the detected-entry list is empty; the bookmark-row comment names the un-labelled chapter column as the deliberate out-of-scope follow-up F3 (plan §6.3). |
+
+### Round-1 §7a conclusions (recorded, since §7a says a pass that does not address these is not a pass)
+
+- **Every gate read re-emits.** `pagedBodyMounted` and `pagedOffset` are both
+  host-owned `mutableStateOf` (created at the host's `remember(s.document)`),
+  written by the body's `SideEffect` and its `onSaveSourceOffset` callback
+  respectively. Neither is `TxtPageNavigator.index` (a plain `var`) — the banned
+  shape that would never re-emit.
+- **Deadlock sweep.** Reader closed mid-wait → the composition-scoped effect is
+  cancelled. Layout or bilingual toggled mid-wait → `pagedBodyMounted` flips and
+  the `!mounted || offset >= 0` predicate releases. Document reloaded → the
+  `LaunchedEffect(s.document)` restarts with fresh state. Paged body never
+  mounts → `pagedBodyMounted` stays false, so the gate opens on the frame alone.
+  Deep resume (`resumePage`/`programmaticPending`) delays but does not withhold
+  publication. The one unresolved path was the degenerate/empty fallback above.
+- **All three modes scan.** Scroll scans after the first frame; paged after the
+  first settled page (or the bound); a mid-session toggle correctly does *not*
+  re-scan, because the document is unchanged and the entries are already
+  published — now asserted by a connected test.
+- **`followSpokenChunkInScroll` extraction is behaviour-preserving**: keys,
+  visibility decision, animation and exception swallowing all match the
+  pre-change inline effect.
+- **Test vacuity check**: the connected positive tests fail if the host passes an
+  empty `tocEntries`; the negative test waits for `tocScanCompletedForTest()` so
+  it cannot pass via a stuck gate.
+- **Rule 51**: no new visible surface. `txtTocIndexFor` recomputes on position
+  change but only over the bounded heading-offset list — not material.
+
+## Round 2 findings
+
+**None.** All three round-1 findings confirmed RESOLVED against the current
+source, with the High re-checked path-by-path (degenerate index, empty document,
+index never publishing, fallback rendering, delayed deep resume all now proceed
+within the bound; parent cancellation propagates correctly through
+`withTimeoutOrNull`, so a closed composition never triggers a stale scan). The
+remaining gap — no connected test for a *degenerate-layout* fallback
+specifically — was judged not material, because the timeout's behaviour does not
+depend on which production condition withholds the offset.
+
+Verdict: **ship-as-is**.
+
+## Mutation evidence (author-run, before the audit)
+
+A gate test that cannot fail is worse than no test, so each claim was checked by
+breaking the implementation and confirming the named tests go red:
+
+| Mutation | Result |
+|---|---|
+| A — delete `withFrameNanos { }` (the gate fires too early) | JVM 10/0 → **10/6**: `scanMustNotStartBeforeTheFirstFrame`, the paged tests' `produceFrame` awaiter assertion, and `preScanState_passesEmptyEntries…` all fail |
+| B — `.first { false }` (the gate can never open — the banned shape) | JVM 10/0 → **10/6**: every "the gate releases" and "the scan ran/published" assertion fails |
+| C — pass `tocEntries = emptyList()` to the chrome unconditionally (the pre-WI-7 bug, restored) | connected 8/0 → **8/5**: control-visibility, the real UI row tap, the MD sheet, the live highlight and the scroll TTS re-follow all fail. (The two paged tests drive the jump lambda directly and are by design unaffected — the scroll-mode test is the one that walks the production UI path.) |
+
+## Test results at the audited commit
+
+- JVM `TxtTocHostWiringTest`: **12 tests, 0 failures**
+- Connected `TxtTocConnectedTest`: **10 tests, 0 failures** (emulator-5554)
+- Full `:app:testDebugUnitTest`: **1586 tests, 0 failures**
+- Connected regressions, one class per run: `TxtReaderChromeUiTest` 6/0,
+  `TxtPagedTtsFindConnectedTest` 4/0, `TxtFindInBookTest` 6/0,
+  `TxtReaderBilingualConnectedTest` 8/0.
+- `TxtReaderActivityTest` 6 tests / 1 failure
+  (`tapExistingHighlight_opensEditPopover_andRemoveDeletesIt`) — **proven
+  pre-existing** by stashing this branch's changes and re-running the same class
+  on the clean base, where it fails identically. Known long-press/gesture
+  emulator-flake class; unrelated to this WI.

--- a/android/app/src/androidTest/kotlin/com/vreader/app/reader/TxtTocConnectedTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/reader/TxtTocConnectedTest.kt
@@ -235,6 +235,44 @@ class TxtTocConnectedTest {
         }
     }
 
+    @Test
+    fun pagedMode_scanCompletes_evenForABookWithNoChapters() {
+        // Gate-4 R1: the paged readiness gate must TERMINATE through the real
+        // TxtPagedBody → onSaveSourceOffset → pagedOffset chain, not only against synthetic state in
+        // the JVM test. A headings-free book is the case where nothing downstream would ever notice a
+        // stranded gate (the control is hidden either way), so it is asserted on the scan itself.
+        setLayoutAndConfirm(ReaderLayout.Paged)
+        val key = importAsset("resume-sample.txt")
+        withReader(key) { scenario ->
+            scenario.awaitPageIndex()
+            scenario.awaitScan()
+            assertTrue("the paged body is mounted", scenario.read { it.pagedBodyMountedForTest() } == true)
+            assertEquals("no headings detected", 0, scenario.read { it.tocEntriesForTest().size })
+            assertEquals("the Contents control stays hidden", 0, nodeCount("chrome-contents"))
+        }
+    }
+
+    @Test
+    fun layoutToggleMidSession_keepsContentsAvailable() {
+        // The scan is keyed on the DOCUMENT, so a layout toggle must not re-scan — and must not lose
+        // the TOC either. Scroll → Paged mid-session, with the entries already published.
+        val key = importContent("toc-toggle.txt", chapteredTxt())
+        withReader(key) { scenario ->
+            scenario.awaitScan()
+            compose.waitUntil(20_000) { nodeCount("chrome-contents") > 0 }
+            val before = scenario.read { it.tocEntriesForTest() }
+            assertEquals(3, before.size)
+
+            setLayoutAndConfirm(ReaderLayout.Paged)
+            compose.waitUntil(20_000) { scenario.read { it.pagedBodyMountedForTest() } == true }
+            scenario.awaitPageIndex()
+
+            assertEquals("the TOC survives the layout toggle unchanged", before, scenario.read { it.tocEntriesForTest() })
+            compose.waitUntil(20_000) { nodeCount("chrome-contents") > 0 }
+            assertTrue("Contents is still reachable in the other layout", nodeCount("chrome-contents") > 0)
+        }
+    }
+
     // ---- jumps -----------------------------------------------------------------------------------
 
     @Test

--- a/android/app/src/androidTest/kotlin/com/vreader/app/reader/TxtTocConnectedTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/reader/TxtTocConnectedTest.kt
@@ -1,0 +1,412 @@
+package com.vreader.app.reader
+
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vreader.app.VReaderApp
+import com.vreader.app.reader.settings.ReaderFontFamily
+import com.vreader.app.reader.settings.ReaderLayout
+import com.vreader.app.reader.settings.ReaderSettings
+import com.vreader.app.reader.settings.ReaderTheme
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Feature #139 WI-7 — connected proof that the TXT/MD table of contents is REAL in the running reader:
+ *
+ *  - a TXT book WITH chapter headings shows the Contents control (which every build before this WI
+ *    hid, because the host passed `tocEntries = emptyList()` unconditionally);
+ *  - a TXT book WITHOUT them still hides it — asserted only after the scan has actually COMPLETED
+ *    (`tocScanCompletedForTest`), so a stuck gate can never be mistaken for "this book has no TOC";
+ *  - a tapped Contents row navigates in BOTH layouts — the scroll chunk seam and the paged pager
+ *    (over the #138 windowed index);
+ *  - the two layouts' read-aloud interaction, which genuinely DIFFERS (plan §WI-7 note): scroll
+ *    re-follows the narration immediately, paged holds until narration next advances;
+ *  - an MD book's nested headings render indented, and the highlighted row tracks reading position.
+ *
+ * Fixtures: generated TXT/MD written to the app cache and imported through the REAL importer. Real
+ * books first (AGENTS.md) does not apply usefully here — `test-books/` is gitignored and unreachable
+ * from an instrumented run, and these assertions need a deterministic tiny structure (exact chapter
+ * count, known char offsets, exactly three MD depths) that a 14 MB novel cannot give cheaply. WI-8's
+ * acceptance pass is where the real 黑暗血时代.txt is exercised. The headings-free case reuses the
+ * committed `resume-sample.txt` asset rather than inventing prose.
+ *
+ * Run ONE class per connected invocation (MEMORY #129/#133); never drive the emulator while this runs.
+ */
+@RunWith(AndroidJUnit4::class)
+class TxtTocConnectedTest {
+    @get:Rule val compose = createEmptyComposeRule()
+
+    private val instrumentation get() = InstrumentationRegistry.getInstrumentation()
+    private val app get() = instrumentation.targetContext.applicationContext as VReaderApp
+
+    @Before
+    fun pinDefaults() = runBlocking<Unit> {
+        val store = app.container.readerSettingsStore
+        store.setTheme(ReaderTheme.Paper)
+        store.setFontFamily(ReaderFontFamily.Serif)
+        store.setFontSize(ReaderSettings.DEFAULT_FONT_SIZE)
+        store.setLineSpacing(ReaderSettings.DEFAULT_LINE_SPACING)
+        store.setMargin(ReaderSettings.DEFAULT_MARGIN)
+        // Scroll is the default for every test that does not opt into Paged, and it must be CONFIRMED
+        // committed, not merely requested: a DataStore write is async, so a bare `setLayout` lets a
+        // leftover `Paged` value from a previous test reach the reader — which then routes jumps to the
+        // pager and fails every scroll assertion. (Only ONE @Before: JUnit does not order two of them.)
+        store.setLayout(ReaderLayout.Scroll)
+        for (i in 0 until 100) {
+            if (store.current().layout == ReaderLayout.Scroll) return@runBlocking
+            kotlinx.coroutines.delay(20)
+        }
+        throw AssertionError("Scroll layout not committed to the store in time")
+    }
+
+    @After
+    fun restoreScroll() = runBlocking<Unit> {
+        app.container.readerSettingsStore.setLayout(ReaderLayout.Scroll)
+    }
+
+    // ---- fixtures ------------------------------------------------------------------------------
+
+    /** Three rule-3 ("Chapter N …") headings, each followed by enough body to span chunks/pages. */
+    private fun chapteredTxt(): String = buildString {
+        append("A short preface line which is not a heading.\n")
+        for (c in 1..3) {
+            append("Chapter $c The Part\n")
+            repeat(30) { append("Body line ${it + 1} of chapter $c.\n") }
+        }
+    }
+
+    /** ATX headings at three levels → depths 0 / 1 / 2, which the sheet renders as indentation. */
+    private fun nestedMd(): String = buildString {
+        append("# Top level\n\n")
+        repeat(10) { append("Body text under top, line ${it + 1}.\n") }
+        append("\n## Nested one\n\n")
+        repeat(10) { append("Body text under nested one, line ${it + 1}.\n") }
+        append("\n### Nested two\n\n")
+        repeat(10) { append("Body text under nested two, line ${it + 1}.\n") }
+    }
+
+    private fun importContent(displayName: String, content: String): String {
+        val staged = File(instrumentation.targetContext.cacheDir, "toc-${System.nanoTime()}-$displayName")
+        staged.writeText(content)
+        val book = runBlocking {
+            app.container.importer.importStream("content://test/$displayName", displayName, staged.inputStream())
+        }
+        app.container.cacheOffset(book.fingerprintKey, 0)
+        return book.fingerprintKey
+    }
+
+    private fun importAsset(asset: String): String {
+        val staged = File(instrumentation.targetContext.cacheDir, "toc-${System.nanoTime()}-$asset")
+        instrumentation.context.assets.open(asset).use { input ->
+            staged.outputStream().use { output -> input.copyTo(output) }
+        }
+        val book = runBlocking {
+            app.container.importer.importStream("content://test/$asset", asset, staged.inputStream())
+        }
+        app.container.cacheOffset(book.fingerprintKey, 0)
+        return book.fingerprintKey
+    }
+
+    // ---- harness -------------------------------------------------------------------------------
+
+    private fun setLayoutAndConfirm(layout: ReaderLayout) = runBlocking<Unit> {
+        val store = app.container.readerSettingsStore
+        store.setLayout(layout)
+        for (i in 0 until 50) {
+            if (store.current().layout == layout) return@runBlocking
+            kotlinx.coroutines.delay(20)
+        }
+        throw AssertionError("layout $layout not committed to the store in time")
+    }
+
+    private fun nodeCount(tag: String) =
+        compose.onAllNodesWithTag(tag, useUnmergedTree = true).fetchSemanticsNodes().size
+
+    /** The laid-out left edge of the title `Text` inside a Contents row — the row's own indentation as
+     *  rendered, which is what a reader actually sees for a nested MD heading. */
+    private fun titleLeftInRow(rowTag: String, title: String): Float {
+        val row = compose.onNodeWithTag(rowTag, useUnmergedTree = true).fetchSemanticsNode()
+        val child = row.children.firstOrNull { node ->
+            node.config.getOrNull(SemanticsProperties.Text)?.any { it.text.contains(title) } == true
+        } ?: throw AssertionError("no '$title' title text inside $rowTag")
+        return child.positionInRoot.x
+    }
+
+    private fun <T> ActivityScenario<TxtReaderActivity>.read(block: (TxtReaderActivity) -> T): T {
+        var value: Any? = null
+        onActivity { value = block(it) }
+        @Suppress("UNCHECKED_CAST")
+        return value as T
+    }
+
+    private fun ActivityScenario<TxtReaderActivity>.awaitScan(timeoutMs: Long = 20_000) {
+        compose.waitUntil(timeoutMs) { read { it.tocScanCompletedForTest() } }
+        // For a book WITH chapters, also wait until the chrome has RECEIVED them: `currentTocIndex` and
+        // the row-jump lambda are composition-derived and land one recomposition after the scan
+        // publishes. A jump driven before that closes over the pre-scan empty list and reports failure.
+        // A headings-free book stays at `-1` by contract, so this barrier applies only when non-empty.
+        if (read { it.tocEntriesForTest().isNotEmpty() }) {
+            compose.waitUntil(timeoutMs) { read { it.currentTocIndexForTest() } >= 0 }
+        }
+    }
+
+    private fun ActivityScenario<TxtReaderActivity>.awaitPageIndex(timeoutMs: Long = 20_000) {
+        compose.waitUntil(timeoutMs) { read { it.pagedPageCountForTest()?.let { c -> c > 0 } == true } }
+    }
+
+    private fun ActivityScenario<TxtReaderActivity>.tocOffset(index: Int): Int =
+        read { it.tocEntriesForTest()[index].canonicalLocator.charOffsetUTF16!! }
+
+    /** Run a suspend host seam on the Activity's scope, blocking for completion. */
+    private fun ActivityScenario<TxtReaderActivity>.blocking(block: suspend (TxtReaderActivity) -> Unit) {
+        val latch = CountDownLatch(1)
+        val error = arrayOfNulls<Throwable>(1)
+        onActivity { activity ->
+            activity.lifecycleScope.launch {
+                try { block(activity) } catch (t: Throwable) { error[0] = t } finally { latch.countDown() }
+            }
+        }
+        if (!latch.await(30, TimeUnit.SECONDS)) throw AssertionError("host seam timed out")
+        error[0]?.let { throw it }
+    }
+
+    /** Open the Contents sheet through the PRODUCTION path: the bottom-chrome Contents control. */
+    private fun openContentsSheet() {
+        compose.waitUntil(20_000) { nodeCount("chrome-contents") > 0 }
+        compose.onNodeWithTag("chrome-contents", useUnmergedTree = true).performClick()
+        compose.waitUntil(20_000) { nodeCount("toc-sheet-content") > 0 }
+    }
+
+    private inline fun withReader(key: String, block: (ActivityScenario<TxtReaderActivity>) -> Unit) {
+        ActivityScenario.launch<TxtReaderActivity>(
+            TxtReaderActivity.intent(instrumentation.targetContext, key),
+        ).use(block)
+    }
+
+    // ---- control visibility --------------------------------------------------------------------
+
+    @Test
+    fun txtBookWithChapters_showsContentsControl() {
+        val key = importContent("toc-chapters.txt", chapteredTxt())
+        withReader(key) { scenario ->
+            scenario.awaitScan()
+            assertEquals("the three chapter headings were detected", 3, scenario.read { it.tocEntriesForTest().size })
+            // The user-visible delta of this WI: the Contents control is now REACHABLE.
+            compose.waitUntil(20_000) { nodeCount("chrome-contents") > 0 }
+            // And it opens the designed Contents sheet with one row per chapter.
+            openContentsSheet()
+            assertTrue("the Contents sheet lists the chapters", nodeCount("toc-row-0") > 0)
+            assertEquals("no empty state for a book that HAS chapters", 0, nodeCount("toc-empty"))
+        }
+    }
+
+    @Test
+    fun txtBookWithoutChapters_hidesContentsControl() {
+        // A real committed fixture: 100 lines of "Line NNN of the resume fixture." — no chapter markers.
+        val key = importAsset("resume-sample.txt")
+        withReader(key) { scenario ->
+            // The scan COMPLETED (so this is not a stuck-gate false pass) and found nothing.
+            scenario.awaitScan()
+            assertEquals("no headings detected", 0, scenario.read { it.tocEntriesForTest().size })
+            compose.waitUntil(20_000) { nodeCount("reader-bottom-chrome") > 0 }
+            assertEquals("the Contents control stays hidden with an empty TOC", 0, nodeCount("chrome-contents"))
+            // Notes is still there — the toolbar is not broken, only Contents is absent.
+            assertTrue("the rest of the bottom chrome is unaffected", nodeCount("chrome-notes") > 0)
+        }
+    }
+
+    // ---- jumps -----------------------------------------------------------------------------------
+
+    @Test
+    fun tapChapterRow_scrollMode_navigatesToThatOffset() {
+        val key = importContent("toc-scrolljump.txt", chapteredTxt())
+        withReader(key) { scenario ->
+            scenario.awaitScan()
+            compose.waitUntil(20_000) {
+                compose.onAllNodesWithText("A short preface", substring = true).fetchSemanticsNodes().isNotEmpty()
+            }
+            assertEquals("the reader opens at the top", 0, scenario.read { it.firstVisibleChunkForTest() })
+
+            openContentsSheet()
+            compose.onNodeWithTag("toc-row-2", useUnmergedTree = true).performClick()
+
+            // A successful jump dismisses the sheet and lands the list on chapter 3's line.
+            compose.waitUntil(20_000) { nodeCount("toc-sheet-content") == 0 }
+            val chapter3 = scenario.tocOffset(2)
+            compose.waitUntil(20_000) { scenario.read { it.firstVisibleChunkForTest() ?: 0 } > 0 }
+            val landed = scenario.read { it.firstVisibleChunkForTest()!! }
+            assertTrue("the list scrolled forward to chapter 3", landed > 0)
+            compose.waitUntil(20_000) {
+                compose.onAllNodesWithText("Chapter 3", substring = true).fetchSemanticsNodes().isNotEmpty()
+            }
+            // The row's own offset is what drove it (the jump target IS the heading's char offset).
+            assertEquals(chapter3, scenario.read { it.tocEntriesForTest()[2].canonicalLocator.charOffsetUTF16 })
+        }
+    }
+
+    @Test
+    fun tapChapterRow_pagedMode_navigatesToThatOffset() {
+        setLayoutAndConfirm(ReaderLayout.Paged)
+        val key = importContent("toc-pagedjump.txt", chapteredTxt())
+        withReader(key) { scenario ->
+            scenario.awaitPageIndex()
+            scenario.awaitScan()
+            assertTrue("the paged body is mounted", scenario.read { it.pagedBodyMountedForTest() } == true)
+            assertEquals(3, scenario.read { it.tocEntriesForTest().size })
+
+            val chapter3 = scenario.tocOffset(2)
+            val expectedPage = scenario.read { it.pagedPageContainingForTest(chapter3)!! }
+            assertNotEquals("chapter 3 is not on the opening page", 0, expectedPage)
+
+            // Drive the SAME lambda the Contents row taps (the modal sheet's own click is covered by the
+            // scroll-mode test; here the point is that the PAGER — not the hidden list — moves).
+            assertTrue("a valid row reports a successful jump", scenario.read { it.jumpTocForTest(2) })
+            // The landing page is asserted as "the page that CONTAINS chapter 3", re-evaluated against
+            // the live index — not against the page number computed before the jump. With #138's
+            // windowed pagination the index can still be PARTIAL at jump time, so the body extends it
+            // on demand and the offset's page number legitimately shifts as pages seal.
+            compose.waitUntil(20_000) {
+                val page = scenario.read { it.pagedCurrentPageForTest() ?: -1 }
+                page > 0 && scenario.read { it.pagedPageContainingForTest(chapter3) } == page
+            }
+            val landed = scenario.read { it.pagedCurrentPageForTest()!! }
+            assertTrue("the pager left the opening page", landed > 0)
+            assertEquals("the pager is on chapter 3's page", landed, scenario.read { it.pagedPageContainingForTest(chapter3) })
+        }
+    }
+
+    // ---- read-aloud interaction (the two layouts genuinely differ) --------------------------------
+
+    @Test
+    fun tocJump_scrollMode_whileTtsSpeaking_isImmediatelyRefollowed() {
+        val key = importContent("toc-scrolltts.txt", chapteredTxt())
+        withReader(key) { scenario ->
+            scenario.awaitScan()
+            compose.waitUntil(20_000) { nodeCount("chrome-contents") > 0 }
+
+            // Narration is on chunk 0 (the emulator has no TTS voice data, so the follow decision is
+            // driven through the production helper — the #137 simulatePagedTtsFollow precedent).
+            assertTrue("a valid row reports a successful jump", scenario.read { it.jumpTocForTest(2) })
+            compose.waitUntil(20_000) { scenario.read { it.firstVisibleChunkForTest() ?: 0 } > 0 }
+
+            // In SCROLL mode the follow effect is keyed on firstVisibleItemIndex, so the jump itself
+            // re-runs it at once: the spoken chunk is no longer visible → the reader is yanked back.
+            scenario.blocking { it.simulateScrollTtsFollowForTest(0) }
+            compose.waitUntil(20_000) { scenario.read { it.firstVisibleChunkForTest() } == 0 }
+            assertEquals(
+                "scroll mode re-follows narration immediately after a TOC jump (accepted, pre-existing — F5)",
+                0, scenario.read { it.firstVisibleChunkForTest() },
+            )
+        }
+    }
+
+    @Test
+    fun tocJump_pagedMode_whileTtsSpeaking_holdsUntilNarrationAdvances() {
+        setLayoutAndConfirm(ReaderLayout.Paged)
+        val key = importContent("toc-pagedtts.txt", chapteredTxt())
+        withReader(key) { scenario ->
+            scenario.awaitPageIndex()
+            scenario.awaitScan()
+
+            // Narration lands on chapter 2's page (one follow).
+            val chapter2 = scenario.tocOffset(1)
+            val narrationPage = scenario.read { it.pagedPageContainingForTest(chapter2)!! }
+            scenario.read { it.simulatePagedTtsFollowForTest(chapter2) }
+            compose.waitUntil(20_000) { scenario.read { it.pagedCurrentPageForTest() } == narrationPage }
+
+            // The user now jumps to chapter 3 from Contents while narration's charStart is unchanged.
+            val chapter3 = scenario.tocOffset(2)
+            val jumpPage = scenario.read { it.pagedPageContainingForTest(chapter3)!! }
+            assertNotEquals("the jump target is a different page", narrationPage, jumpPage)
+            assertTrue(scenario.read { it.jumpTocForTest(2) })
+            compose.waitUntil(20_000) { scenario.read { it.pagedCurrentPageForTest() } == jumpPage }
+
+            // PAGED mode HOLDS: the follow effect keys only on the narration signal, so a TOC jump is
+            // not fought. Give any wrongly-keyed effect a chance to yank back.
+            compose.waitForIdle()
+            assertEquals(
+                "paged mode holds the TOC jump until narration next advances",
+                jumpPage, scenario.read { it.pagedCurrentPageForTest() },
+            )
+
+            // ...and when narration DOES advance, the pager follows again.
+            val chapter1 = scenario.tocOffset(0)
+            scenario.read { it.simulatePagedTtsFollowForTest(chapter1) }
+            val followPage = scenario.read { it.pagedPageContainingForTest(chapter1)!! }
+            compose.waitUntil(20_000) { scenario.read { it.pagedCurrentPageForTest() } == followPage }
+            assertEquals(followPage, scenario.read { it.pagedCurrentPageForTest() })
+        }
+    }
+
+    // ---- MD + live highlight ---------------------------------------------------------------------
+
+    @Test
+    fun mdBook_showsContentsControl_withDepthIndentation() {
+        val key = importContent("toc-nested.md", nestedMd())
+        withReader(key) { scenario ->
+            scenario.awaitScan()
+            assertEquals(
+                "the three ATX levels are detected with their real depths",
+                listOf(0, 1, 2), scenario.read { it.tocEntriesForTest().map { e -> e.depth } },
+            )
+            assertEquals(
+                listOf("Top level", "Nested one", "Nested two"),
+                scenario.read { it.tocEntriesForTest().map { e -> e.title } },
+            )
+            compose.waitUntil(20_000) { nodeCount("chrome-contents") > 0 }
+            openContentsSheet()
+            // The designed row indentation (depth * 12dp on the title) is what makes the nesting
+            // VISIBLE — measured on the laid-out title, not inferred from the depth field.
+            // Compared between rows 1 and 2 ONLY. Row 0 is the current-chapter row, and its zero-size
+            // `toc-current-marker` child still consumes the Row's 14dp arrangement spacing — that shifts
+            // its title further right than a 12dp depth step, so a row-0 baseline would compare two
+            // different things. (Row 0's own highlight is asserted in currentChapterHighlight_*.)
+            val one = titleLeftInRow("toc-row-1", "Nested one")
+            val two = titleLeftInRow("toc-row-2", "Nested two")
+            assertTrue("depth 2 indents past depth 1 (was $two vs $one)", two > one)
+        }
+    }
+
+    @Test
+    fun currentChapterHighlight_followsReadingPosition() {
+        val key = importContent("toc-highlight.txt", chapteredTxt())
+        withReader(key) { scenario ->
+            scenario.awaitScan()
+            // The highlight is a composition-derived value, so it lands one recomposition after the
+            // scan publishes — poll for it rather than reading the pre-scan `-1`.
+            compose.waitUntil(20_000) { scenario.read { it.currentTocIndexForTest() } == 0 }
+            assertEquals("at the top the first chapter is highlighted", 0, scenario.read { it.currentTocIndexForTest() })
+
+            // Move the reading position into chapter 3 (the same chunk scroll a user's swipe produces).
+            val chapter3 = scenario.tocOffset(2)
+            assertTrue(scenario.read { it.jumpTocForTest(2) })
+            compose.waitUntil(20_000) { scenario.read { it.currentTocIndexForTest() } == 2 }
+            assertEquals("the highlight follows the position into chapter 3", 2, scenario.read { it.currentTocIndexForTest() })
+            assertTrue("chapter 3's offset is past chapter 1's", chapter3 > scenario.tocOffset(0))
+
+            // The sheet renders the highlight marker on that row.
+            openContentsSheet()
+            assertTrue("the current-chapter marker is rendered", nodeCount("toc-current-marker") > 0)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt
@@ -439,8 +439,10 @@ class TxtReaderActivity : ComponentActivity() {
                             com.vreader.app.reader.details.BookDetailsMapper.map(s.book, collectionNames, pageCount = null)
                         }
 
-                        // feature #135 WI-7 — the bookmark wiring. TXT/MD has no TOC (null tocIndex → the WI-4
-                        // projection degrades chapter/page to null) but DOES supply a preview provider (a bounded
+                        // feature #135 WI-7 — the bookmark wiring. Bookmark ROWS still pass a null tocIndex (the
+                        // WI-4 projection degrades chapter/page to null) — labelling them from #139's detected
+                        // chapters is deliberately out of scope (#139 §6.3, follow-up F3) — but the host DOES
+                        // supply a preview provider (a bounded
                         // snippet around the stored char offset — the host owns the decoded text). The current
                         // position is the top-visible chunk's char offset → a plain canonical Locator.
                         val previewProvider = remember(s.document) { txtBookmarkPreviewProvider(s.document) }
@@ -818,7 +820,8 @@ class TxtReaderActivity : ComponentActivity() {
                                     },
                                     onOpenDisplay = { showDisplaySheet = true },
                                     // #132 WI-6: the scaffold hands the Contents/Notes open callbacks in.
-                                    // TXT/MD has no TOC → openContents is null (Contents control hidden);
+                                    // feature #139 WI-7 — openContents is null ONLY while the detected-entry
+                                    // list is empty (a book with no headings, or before the scan publishes);
                                     // openNotes opens the review sheet.
                                     onOpenContents = openContents,
                                     onOpenNotes = openNotes,
@@ -1654,14 +1657,33 @@ fun txtBookmarkPreviewProvider(document: TxtDocument): BookmarkPreviewProvider =
  *    document, so it never restarts).
  *
  * Terminates on the first satisfying emission — this is a one-shot gate, not a subscription.
+ *
+ * **Stage 2 is BOUNDED by [pagedReadyTimeoutMs], and that bound is load-bearing** (Gate-4 R1 High —
+ * the fourth "mechanism that can never fire" in this feature's history). Not every mounted paged body
+ * ever publishes a settled page: on a degenerate content box or an empty document `TxtPagedBody`
+ * renders `TxtScrollFallback` instead of a pager, so `onSaveSourceOffset` is never called and
+ * `pagedOffset` stays `-1` for the whole session — an unbounded wait would hide Contents forever with
+ * no crash and no log. Only stage 1 is a hard guarantee; stage 2 is an OPTIMIZATION (keep the scan off
+ * the first-paint path), so timing it out and scanning anyway is the correct degrade: the scan is
+ * off-main either way, and a navigation affordance must never depend on a signal that may not come.
  */
 internal suspend fun awaitTocScanGate(
     pagedBodyMounted: State<Boolean>,
     pagedOffset: State<Int>,
+    pagedReadyTimeoutMs: Long = PAGED_READY_TIMEOUT_MS,
 ) {
     withFrameNanos { }
-    snapshotFlow { !pagedBodyMounted.value || pagedOffset.value >= 0 }.first { it }
+    kotlinx.coroutines.withTimeoutOrNull(pagedReadyTimeoutMs) {
+        snapshotFlow { !pagedBodyMounted.value || pagedOffset.value >= 0 }.first { it }
+    }
 }
+
+/**
+ * How long the TOC scan waits for the paged body's first settled page before scanning anyway. Sized
+ * far above the real signal (#138 publishes its first window in ~8 ms) and far below anything a user
+ * would notice as a missing control.
+ */
+internal const val PAGED_READY_TIMEOUT_MS: Long = 3_000L
 
 /**
  * feature #139 WI-7 — ONE table-of-contents scan for one document: wait for [awaitTocScanGate], then
@@ -1676,9 +1698,10 @@ internal suspend fun runTxtTocScan(
     provider: TocProvider,
     pagedBodyMounted: State<Boolean>,
     pagedOffset: State<Int>,
+    pagedReadyTimeoutMs: Long = PAGED_READY_TIMEOUT_MS,
     publish: (List<TocEntry>) -> Unit,
 ) {
-    awaitTocScanGate(pagedBodyMounted, pagedOffset)
+    awaitTocScanGate(pagedBodyMounted, pagedOffset, pagedReadyTimeoutMs)
     val entries = try {
         provider.toc()
     } catch (cancellation: kotlinx.coroutines.CancellationException) {

--- a/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/TxtReaderActivity.kt
@@ -13,8 +13,7 @@
 // slot, replacing the pre-chrome TtsEntryBar) which opens the ReaderSettingsSheet.
 //
 // feature #132 WI-6: the FIRST host to render the shared ReaderChromeScaffold (ReaderTopChrome +
-// the extended ReaderBottomChrome Contents/Notes/Display toolbar + the Notes review sheet). TXT/MD has
-// no TOC → Contents is hidden (EmptyTocProvider / empty tocEntries). Notes opens the
+// the extended ReaderBottomChrome Contents/Notes/Display toolbar + the Notes review sheet). Notes opens the
 // AnnotationsReviewSheet over this book's annotationsForBook snapshot; onJumpToAnnotation is non-null
 // (TXT/MD jump via the plain Locator's charRangeStartUTF16/charOffsetUTF16 → the existing chunk scroll
 // seam). The #129 Display sheet + the #121 TTS bar are preserved unchanged inside the scaffold's bottom
@@ -37,6 +36,18 @@
 // long-press on translation is excluded from the nearest-source-chunk fallback (gesture exclusion). TTS
 // auto-scroll visibility now keys off the registered SOURCE `Text` bounds (isSourceChunkInViewport), not
 // the item index, since an in-item translation makes items taller than their source line (round-5/6).
+//
+// feature #139 WI-7: TXT/MD now HAS a table of contents. A per-document TxtMdTocProvider scan (over the
+// already-decoded text, on the provider's own injected dispatcher) publishes the detected chapters into
+// `tocEntries`, so the scaffold's existing empty-list rule un-hides the Contents control for a book with
+// headings and still hides it for one without (no new visible surface — rule 51). The scan is GATED on
+// readiness (plan §4.5): `withFrameNanos` in both layouts, plus — while the PAGED body is mounted — the
+// host-owned `pagedOffset` settled-page signal, so it never competes with first paint. Both gate signals
+// are Compose state, deliberately NOT TxtPageNavigator.index (a plain `var` that would never re-emit),
+// and the paged predicate also releases when the body flips to scroll mid-wait so a bilingual/layout
+// toggle cannot strand the scan. `currentTocIndex` is txtTocIndexFor(liveOffset, entryOffsets) and a
+// tapped row jumps through the EXISTING mode-aware jumpToOffset seam (pager in paged, chunk scroll in
+// scroll) — nothing in the pagination stack changes.
 package com.vreader.app.reader
 
 import android.os.Bundle
@@ -63,8 +74,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.State
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
@@ -80,6 +93,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -139,6 +153,10 @@ import com.vreader.app.reader.chrome.ReaderChromeStateSaver
 import com.vreader.app.reader.nav.BookmarkPreviewProvider
 import com.vreader.app.reader.nav.BookmarkRowItem
 import com.vreader.app.reader.nav.JumpResult
+import com.vreader.app.reader.nav.TocEntry
+import com.vreader.app.reader.nav.TocProvider
+import com.vreader.app.reader.nav.TxtMdTocProvider
+import com.vreader.app.reader.nav.txtTocIndexFor
 import com.vreader.app.reader.settings.ReaderSettings
 import com.vreader.app.reader.settings.ReaderSettingsSheet
 import com.vreader.app.search.InBookSearchSheet
@@ -358,11 +376,13 @@ class TxtReaderActivity : ComponentActivity() {
                         // (pagedBodyMounted == false). In paged mode the scroll LazyListState is hidden, so
                         // animating it would be a wasted no-op; the paged pager-follow effect (below, after
                         // usePaged/jumpToOffset are in scope) drives the spoken page instead.
+                        // feature #139 WI-7 — the body moved UNCHANGED into [followSpokenChunkInScroll] so the
+                        // connected TOC-jump test can drive the SAME decision (a real TTS engine cannot speak
+                        // on the emulator — no voice data; the #137 simulatePagedTtsFollowForTest precedent).
+                        // The effect KEYS are unchanged, and they are what make a scroll-mode TOC jump get
+                        // re-followed immediately: the jump changes firstVisibleItemIndex, which re-runs this.
                         LaunchedEffect(spokenChunk, listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset, pagedBodyMounted.value) {
-                            if (spokenChunk < 0 || pagedBodyMounted.value) return@LaunchedEffect
-                            val visible = selectionController?.isSourceChunkInViewport(spokenChunk)
-                                ?: listState.layoutInfo.visibleItemsInfo.any { it.index == spokenChunk }
-                            if (!visible) runCatching { listState.animateScrollToItem(spokenChunk) }
+                            followSpokenChunkInScroll(spokenChunk, pagedBodyMounted.value, selectionController, listState)
                         }
                         val popoverVm = remember(bookKey) { com.vreader.app.annotations.SelectionPopoverViewModel() }
                         val popoverState by popoverVm.state.collectAsStateWithLifecycle()
@@ -590,6 +610,48 @@ class TxtReaderActivity : ComponentActivity() {
                             }
                         }
 
+                        // feature #139 WI-7 — the auto-generated TXT/MD table of contents. ONE provider per
+                        // document over the ALREADY-decoded text (no new I/O, no new memory class); it owns
+                        // its own dispatcher hop, so the host never wraps the call. `originalFormat` is the
+                        // SAME typed format MainActivity routed on (there is no parallel format column on
+                        // Android), and it selects the scanner: txt → rule engine, md → the MD scanner.
+                        val tocProvider: TocProvider = remember(s.document, s.book) {
+                            TxtMdTocProvider(
+                                text = s.document.text,
+                                book = s.book,
+                                format = s.book.originalFormat,
+                                dispatcher = Dispatchers.Default,
+                            )
+                        }
+                        // Empty until the gated scan publishes → the scaffold hides Contents → the pre-scan
+                        // frame is behaviorally identical to pre-#139. Keyed on the DOCUMENT, so a reload /
+                        // rotation re-scans but a layout toggle or any other recomposition does NOT.
+                        val tocEntriesState = remember(s.document) { mutableStateOf(emptyList<TocEntry>()) }
+                        LaunchedEffect(s.document) {
+                            runTxtTocScan(tocProvider, pagedBodyMounted, pagedOffset) { scanned ->
+                                tocEntriesState.value = scanned
+                                testTocEntries = scanned
+                                testTocScanned = true
+                            }
+                        }
+                        val tocEntries = tocEntriesState.value
+                        val tocOffsets = remember(tocEntries) { txtTocEntryOffsets(tocEntries) }
+                        // The highlighted row for the CURRENT position — mode-aware via liveOffset (the paged
+                        // page-start offset in paged mode, the top-visible chunk's offset in scroll mode).
+                        val currentTocIndex = txtTocIndexFor(liveOffset, tocOffsets)
+                        // A tapped row navigates through the EXISTING mode-aware seam: the pager in paged
+                        // mode (which extends a partial #138 window on demand), the chunk scroll otherwise.
+                        // An out-of-range row / offset returns false → the sheet stays open (rule 51).
+                        val onJumpToc: (Int) -> Boolean = { index ->
+                            val target = txtTocJumpTarget(tocEntries, index, s.document.text.length)
+                            if (target == null) false else { jumpToOffset(target); true }
+                        }
+                        SideEffect {
+                            testTocEntries = tocEntries
+                            testCurrentTocIndex = currentTocIndex
+                            testJumpToc = onJumpToc
+                        }
+
                         // feature #137 WI-9 / #138 WI-5a — PAGED TTS follow: auto-advance the pager to the page
                         // containing the currently-spoken SOURCE offset (tts.charStart, the SAME signal
                         // spokenChunk is derived from). Keyed ONLY on the NARRATION signal (tts.phase +
@@ -620,6 +682,11 @@ class TxtReaderActivity : ComponentActivity() {
                             chromeState = chromeState,
                             annotations = annotationsSnapshot,
                             onBack = ::finish,
+                            // feature #139 WI-7 — the detected TXT/MD chapters + the live highlight + the
+                            // row jump. An EMPTY list keeps the Contents control hidden (scaffold rule).
+                            tocEntries = tocEntries,
+                            currentTocIndex = currentTocIndex,
+                            onJumpToc = onJumpToc,
                             bookDetails = bookDetails,
                             onShareBook = { com.vreader.app.reader.share.shareBook(this@TxtReaderActivity, s.book) },
                             onCopyFingerprint = { copyFingerprint(it) },
@@ -1365,6 +1432,55 @@ class TxtReaderActivity : ComponentActivity() {
     @androidx.annotation.VisibleForTesting
     fun pagedDocLengthForTest(): Int = testPagedDocLength
 
+    // ---- feature #139 WI-7 — TXT/MD table-of-contents seams. [testCurrentTocIndex] / [testJumpToc]
+    // are published from the SAME SideEffect that feeds TxtReaderChrome, so a connected test reads what
+    // the Contents control/sheet reads rather than a parallel computation; [testTocEntries] is written
+    // at scan time TOO, because publishing an empty result changes no state and therefore triggers no
+    // recomposition (see [testTocScanned]). ----
+    @Volatile private var testTocEntries: List<TocEntry> = emptyList()
+    @Volatile private var testCurrentTocIndex: Int = -1
+    @Volatile private var testJumpToc: ((Int) -> Boolean)? = null
+    // Raised by the scan's publish callback, so "no TOC" is distinguishable from "the gate never
+    // opened" — without it a hidden-Contents assertion would pass for the WRONG reason. Set THERE and
+    // not in the SideEffect below, because publishing an empty result into an already-empty state is
+    // not a state CHANGE: no recomposition follows, so a SideEffect-driven flag would never rise for
+    // exactly the headings-free book the negative test is about.
+    @Volatile private var testTocScanned: Boolean = false
+
+    /** Whether the gated TOC scan has completed and published (however many entries). */
+    @androidx.annotation.VisibleForTesting
+    fun tocScanCompletedForTest(): Boolean = testTocScanned
+
+    /** The detected chapters currently passed to the chrome (empty → the Contents control is hidden). */
+    @androidx.annotation.VisibleForTesting
+    fun tocEntriesForTest(): List<TocEntry> = testTocEntries
+
+    /** The highlighted Contents row for the CURRENT reading position (`-1` only when there is no TOC). */
+    @androidx.annotation.VisibleForTesting
+    fun currentTocIndexForTest(): Int = testCurrentTocIndex
+
+    /** Perform the SAME row jump a Contents tap performs (the sheet dismisses only on `true`). */
+    @androidx.annotation.VisibleForTesting
+    fun jumpTocForTest(index: Int): Boolean = testJumpToc?.invoke(index) ?: false
+
+    /** feature #139 WI-7 — drive the SCROLL-mode read-aloud follow for a simulated spoken chunk through
+     *  the EXACT production decision ([followSpokenChunkInScroll]). The emulator has no TTS voice data,
+     *  so this is the scroll analog of #137's `simulatePagedTtsFollowForTest`: it proves what the live
+     *  effect does when it re-runs, which — because the effect is keyed on `firstVisibleItemIndex` — is
+     *  immediately after any jump that moves the list.
+     *
+     *  Runs on [androidx.compose.ui.platform.AndroidUiDispatcher.Main] because that is what the real
+     *  `LaunchedEffect` runs on: it carries a `MonotonicFrameClock`, without which `animateScrollToItem`
+     *  throws (and the production `runCatching` would silently swallow it, so the seam would look like
+     *  a working no-op). A caller's `lifecycleScope` (plain `Dispatchers.Main`) has no frame clock. */
+    @androidx.annotation.VisibleForTesting
+    suspend fun simulateScrollTtsFollowForTest(spokenChunk: Int) {
+        val list = testListState ?: return
+        withContext(androidx.compose.ui.platform.AndroidUiDispatcher.Main) {
+            followSpokenChunkInScroll(spokenChunk, testPagedBodyMounted?.value == true, testSelectionController, list)
+        }
+    }
+
     companion object {
         const val EXTRA_FINGERPRINT_KEY = "fingerprintKey"
 
@@ -1376,8 +1492,7 @@ class TxtReaderActivity : ComponentActivity() {
 
 /**
  * The TXT/MD reader host chrome — feature #132 WI-6. Renders the shared [ReaderChromeScaffold] (top bar +
- * the extended bottom chrome + the Notes review sheet) over the reading [body]. TXT/MD has no TOC, so
- * `tocEntries` is EMPTY (the [EmptyTocProvider] posture) → the scaffold hides the Contents control. The
+ * the extended bottom chrome + the Notes review sheet) over the reading [body]. The
  * top bar's Search/More/bookmark slots are omitted (null — #133/#134/#135; no dead controls). [bottomBar]
  * receives the scaffold's `(onOpenContents, onOpenNotes)` open callbacks and renders the host's bottom bar
  * — either the #121 TTS control bar (while read-aloud is active) or the #129 [ReaderBottomChrome] (Display
@@ -1391,6 +1506,12 @@ class TxtReaderActivity : ComponentActivity() {
  * the in-book search sheet when the host's search-open state is set; it is layered OVER the scaffold (the
  * sheet is a `ModalBottomSheet`, its own window), null when the sheet is closed. The host owns the
  * search-open state + the VM (one per reader session) so the scaffold stays a pure signal.
+ *
+ * feature #139 WI-7 — TXT/MD now has a TOC: [tocEntries] are the detected chapters ([TxtMdTocProvider]),
+ * [currentTocIndex] the row to highlight, [onJumpToc] the row jump (true → the sheet dismisses, false →
+ * it stays open with no invented error surface). All three are DEFAULTED to the pre-#139 posture (empty /
+ * 0 / always-false) so an omitting caller still hides the Contents control and compiles unchanged.
+ * Nothing about the Contents sheet itself changes — this host simply now has entries to give it.
  */
 @Composable
 internal fun TxtReaderChrome(
@@ -1403,6 +1524,12 @@ internal fun TxtReaderChrome(
     onShareAnnotations: () -> Unit,
     bottomBar: @Composable (Pair<(() -> Unit)?, (() -> Unit)?>) -> Unit,
     body: @Composable () -> Unit,
+    // feature #139 WI-7 — the auto-generated TXT/MD TOC. Defaulted so the two androidTest callers (and
+    // any future non-TOC caller) stay valid AND keep the pre-#139 posture: an EMPTY list is the
+    // scaffold's hide-the-Contents-control signal, so a caller that supplies none sees no Contents.
+    tocEntries: List<TocEntry> = emptyList(),
+    currentTocIndex: Int = 0,
+    onJumpToc: (Int) -> Boolean = { false },
     // feature #133 WI-10 — the in-book Search entry + sheet overlay (nullable/default so #132/#134/#135
     // callers stay valid). A null [onOpenSearch] omits the top-bar Search icon (Unsupported / no-dead-control).
     onOpenSearch: (() -> Unit)? = null,
@@ -1429,10 +1556,12 @@ internal fun TxtReaderChrome(
             title = title,
             chromeState = chromeState,
             onBack = onBack,
-            tocEntries = emptyList(),           // no TOC → the scaffold hides the Contents control
-            currentTocIndex = 0,
+            // feature #139 WI-7 — the host's detected TXT/MD chapters (empty until the gated scan
+            // publishes, and permanently empty for a book with no headings → Contents stays hidden).
+            tocEntries = tocEntries,
+            currentTocIndex = currentTocIndex,
             annotations = annotations,
-            onJumpToc = { false },              // unreachable: Contents is hidden with an empty TOC
+            onJumpToc = onJumpToc,
             onJumpToAnnotation = onJumpToAnnotation,
             onShareAnnotations = onShareAnnotations,
             // feature #133 WI-10 — the top-bar Search slot is now WIRED (the scaffold forwards it to
@@ -1502,6 +1631,103 @@ fun txtBookmarkPreviewProvider(document: TxtDocument): BookmarkPreviewProvider =
         if (text.isEmpty() || start >= text.length) return@BookmarkPreviewProvider null
         text.substring(start, (start + maxLen).coerceAtMost(text.length))
     }
+
+// ---- feature #139 WI-7 — TXT/MD table-of-contents host wiring ----
+
+/**
+ * feature #139 WI-7 — suspend until the reader is READY for the TOC scan to run (plan §4.5), so a
+ * whole-document heading scan never competes with first paint.
+ *
+ * Two stages, both built on signals that ALREADY exist in this host:
+ *  1. `withFrameNanos` — the hard guarantee in BOTH layouts that a frame has been produced. Needs
+ *     nothing from [TxtReaderBody] and no new API.
+ *  2. while the PAGED body is mounted, its first settled page. [pagedOffset] is what the body's
+ *     `onSaveSourceOffset` callback publishes; `-1` means "no page published yet".
+ *
+ * The stage-2 predicate is `!pagedBodyMounted || pagedOffset >= 0`, evaluated inside a `snapshotFlow`,
+ * which matters twice:
+ *  - **Both reads must be Compose state so the flow actually re-emits.** A gate over
+ *    `TxtPageNavigator.index` — a plain `var` — would suspend forever and leave Contents permanently
+ *    hidden in paged mode. Never reach for that; `TxtTocHostWiringTest` pins the working form.
+ *  - **It also releases when the body STOPS being paged.** A bilingual toggle or a layout change
+ *    mid-wait would otherwise strand the scan for the whole session (the effect is keyed on the
+ *    document, so it never restarts).
+ *
+ * Terminates on the first satisfying emission — this is a one-shot gate, not a subscription.
+ */
+internal suspend fun awaitTocScanGate(
+    pagedBodyMounted: State<Boolean>,
+    pagedOffset: State<Int>,
+) {
+    withFrameNanos { }
+    snapshotFlow { !pagedBodyMounted.value || pagedOffset.value >= 0 }.first { it }
+}
+
+/**
+ * feature #139 WI-7 — ONE table-of-contents scan for one document: wait for [awaitTocScanGate], then
+ * hand the provider's entries to [publish] exactly once. Called from `LaunchedEffect(s.document)`, so a
+ * document reload (or a rotation) re-scans while an ordinary recomposition does not.
+ *
+ * A scan failure degrades to NO table of contents (the Contents control stays hidden) rather than taking
+ * the reader down — a navigation affordance is never worth a crash. Cancellation is re-thrown so closing
+ * the reader mid-scan stops promptly and does not publish into a dead composition.
+ */
+internal suspend fun runTxtTocScan(
+    provider: TocProvider,
+    pagedBodyMounted: State<Boolean>,
+    pagedOffset: State<Int>,
+    publish: (List<TocEntry>) -> Unit,
+) {
+    awaitTocScanGate(pagedBodyMounted, pagedOffset)
+    val entries = try {
+        provider.toc()
+    } catch (cancellation: kotlinx.coroutines.CancellationException) {
+        throw cancellation
+    } catch (_: Exception) {
+        emptyList()
+    }
+    publish(entries)
+}
+
+/**
+ * feature #139 WI-7 — the comparable key per TOC row for [txtTocIndexFor]: each entry's source UTF-16
+ * offset, in list (document) order. A row without an offset (never produced by [TxtMdTocProvider], but
+ * the field is nullable on the shared contract) sorts as the start of the document. Pure/JVM-testable.
+ */
+internal fun txtTocEntryOffsets(entries: List<TocEntry>): List<Int> =
+    entries.map { it.canonicalLocator.charOffsetUTF16 ?: 0 }
+
+/**
+ * feature #139 WI-7 — the TXT/MD Contents jump target: the source UTF-16 offset row [index] navigates
+ * to, or null when the row does not exist or its offset is out of range for a document of [textLength]
+ * (→ the sheet stays open, rule 51 §nav-error-presentation — no invented error surface). Reuses
+ * [txtBookmarkScrollTarget] so a TOC row, a bookmark and a search hit at one offset resolve identically.
+ * Pure/JVM-testable.
+ */
+internal fun txtTocJumpTarget(entries: List<TocEntry>, index: Int, textLength: Int): Int? {
+    val entry = entries.getOrNull(index) ?: return null
+    return txtBookmarkScrollTarget(entry.canonicalLocator.charOffsetUTF16, textLength)
+}
+
+/**
+ * feature #137 WI-9 / #131 WI-8 — the SCROLL-mode read-aloud follow, extracted UNCHANGED from its
+ * `LaunchedEffect` (feature #139 WI-7) so a connected test can drive the same decision without a
+ * speaking TTS engine (the emulator has no voice data). Scrolls the spoken source chunk back into view
+ * when it is not visible; a no-op in paged mode (the pager-follow effect owns that) or with no spoken
+ * chunk. Visibility keys off the registered SOURCE `Text` bounds, not the lazy item index, because an
+ * in-item bilingual translation makes items taller than their source line.
+ */
+internal suspend fun followSpokenChunkInScroll(
+    spokenChunk: Int,
+    pagedBodyMounted: Boolean,
+    selectionController: TxtSelectionController?,
+    listState: LazyListState,
+) {
+    if (spokenChunk < 0 || pagedBodyMounted) return
+    val visible = selectionController?.isSourceChunkInViewport(spokenChunk)
+        ?: listState.layoutInfo.visibleItemsInfo.any { it.index == spokenChunk }
+    if (!visible) runCatching { listState.animateScrollToItem(spokenChunk) }
+}
 
 /** The pre-emission loading surface — a bare theme-colored full-screen fill while the Display settings +
  *  document load (the only pre-emission surface; the reader body is withheld until settings emit — Gate-4

--- a/android/app/src/test/kotlin/com/vreader/app/reader/TxtTocHostWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/TxtTocHostWiringTest.kt
@@ -1,0 +1,317 @@
+package com.vreader.app.reader
+
+import androidx.compose.runtime.BroadcastFrameClock
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.snapshots.Snapshot
+import com.vreader.app.data.Book
+import com.vreader.app.reader.nav.TocEntry
+import com.vreader.app.reader.nav.TocProvider
+import com.vreader.app.reader.nav.TxtMdTocProvider
+import com.vreader.app.reader.nav.txtTocIndexFor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import vreader.contracts.BookFormat
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Feature #139 WI-7 — the host-side TOC wiring seams of [TxtReaderActivity], driven as the host drives
+ * them (real Compose state, a real [BroadcastFrameClock], the REAL [TxtMdTocProvider]):
+ *
+ *  - [awaitTocScanGate] / [runTxtTocScan] — the §4.5 readiness gate. The three gate tests are the JVM
+ *    half of the plan's §7a Gate-4 focus: **every value the gate observes must actually re-emit.** They
+ *    mutate the same `mutableStateOf` handles the host creates (`pagedBodyMounted` at the host's
+ *    `remember(s.document)`, `pagedOffset` likewise) and assert the suspended gate wakes. A gate built on
+ *    `TxtPageNavigator.index` — a plain `var`, NOT Compose state — cannot pass
+ *    `pagedMode_scanWaitsForFirstSettledPage`, because nothing would ever re-emit.
+ *  - the pre-scan posture: until the scan publishes, the host hands the chrome an EMPTY list, which is
+ *    exactly `ReaderChromeScaffold`'s hide-the-Contents-control signal.
+ *  - [txtTocEntryOffsets] / [txtTocJumpTarget] — the highlight key and the jump target, over entries the
+ *    REAL provider produced from real text (not hand-built `TocEntry`s).
+ *
+ * The composition-level wiring (the control actually appearing, a tapped row navigating, the live
+ * highlight) is `TxtTocConnectedTest` — Compose UI testing is not available to this source set.
+ */
+class TxtTocHostWiringTest {
+
+    // ---- fixtures ------------------------------------------------------------------------------
+
+    private val sha = "c".repeat(64)
+
+    private fun book(format: BookFormat = BookFormat.txt, bytes: Long = 4096L) = Book(
+        fingerprintKey = "${format.name}:$sha:$bytes",
+        title = "A Book",
+        originalFormat = format,
+        contentSHA256 = sha,
+        fileByteCount = bytes,
+        addedAt = 0L,
+    )
+
+    /** Three rule-3 ("Chapter N …") headings — the enabled English chapter rule, ≥2 matches so
+     *  detection has a winner. */
+    private val chapteredText = buildString {
+        append("Front matter that is not a heading.\n")
+        append("Chapter 1 The Beginning\n")
+        append("Body of the first chapter.\n")
+        append("Chapter 2 The Middle\n")
+        append("Body of the second chapter.\n")
+        append("Chapter 3 The End\n")
+        append("Body of the third chapter.\n")
+    }
+
+    /** CJK chapters (rule 1) — proves the offsets the jump uses are UTF-16 code-unit offsets into the
+     *  raw decoded text, which is what `txtBookmarkLocator` / the chunk-scroll seam consume. */
+    private val cjkText = buildString {
+        // Body lines deliberately start with a non-marker character: rule 1 also fires on a line
+        // BEGINNING with 楔子 / 正文 / 序章, so a careless "正文内容…" body line would itself be detected
+        // as a heading and the fixture would silently assert the wrong thing.
+        append("这是一段导语，不是标题。\n")
+        append("第一章 起点\n")
+        append("随便写几句内容。\n")
+        append("第二章 转折\n")
+        append("又是一些内容。\n")
+    }
+
+    /** Plain prose — deliberately matches NO enabled rule (no Chapter+digit, no leading digit, no
+     *  bracket/star marker, no Prologue/Epilogue word). */
+    private val proseText = buildString {
+        repeat(40) { append("The quick brown fox jumps over the lazy dog again and again.\n") }
+    }
+
+    private val markdownText = """
+        # Top level
+        Some body text.
+        ## Nested one
+        More body text.
+        ### Nested two
+        Even more body text.
+    """.trimIndent()
+
+    private fun providerFor(text: String, format: BookFormat = BookFormat.txt) =
+        TxtMdTocProvider(text = text, book = book(format), format = format, dispatcher = Dispatchers.Default)
+
+    /** Counts `toc()` calls so a gate that fires more than once (or not at all) is visible. */
+    private class CountingProvider(private val delegate: TocProvider) : TocProvider {
+        val calls = AtomicInteger(0)
+        override suspend fun toc(): List<TocEntry> {
+            calls.incrementAndGet()
+            return delegate.toc()
+        }
+    }
+
+    // ---- gate harness --------------------------------------------------------------------------
+
+    private val clock = BroadcastFrameClock()
+    private val job = Job()
+    private val scope = CoroutineScope(Dispatchers.Default + job + clock)
+
+    @After fun cancelScope() { job.cancel() }
+
+    private fun awaitTrue(timeoutMs: Long = 5_000, predicate: () -> Boolean): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (predicate()) return true
+            Thread.sleep(5)
+        }
+        return predicate()
+    }
+
+    /** True when [predicate] held for the whole window (the "it did NOT fire" assertion). */
+    private fun heldFor(windowMs: Long = 300, predicate: () -> Boolean): Boolean {
+        val deadline = System.currentTimeMillis() + windowMs
+        while (System.currentTimeMillis() < deadline) {
+            if (!predicate()) return false
+            Thread.sleep(5)
+        }
+        return predicate()
+    }
+
+    /** Produce exactly one frame, once the gate has actually parked on the frame clock. */
+    private fun produceFrame() {
+        assertTrue("the gate parked on the frame clock", awaitTrue { clock.hasAwaiters })
+        clock.sendFrame(0L)
+    }
+
+    private fun publishState(): AtomicReference<List<TocEntry>?> = AtomicReference(null)
+
+    // ---- the §4.5 readiness gate ---------------------------------------------------------------
+
+    @Test fun scrollMode_scanWaitsForFirstFrame() {
+        val pagedBodyMounted = mutableStateOf(false)   // scroll body
+        val pagedOffset = mutableStateOf(-1)
+        val provider = CountingProvider(providerFor(chapteredText))
+        val published = publishState()
+
+        scope.launch { runTxtTocScan(provider, pagedBodyMounted, pagedOffset) { published.set(it) } }
+
+        // No frame yet → the scan has not even been ASKED for (it must stay off the first-paint path).
+        assertTrue(
+            "the scan must not start before the first frame",
+            heldFor { published.get() == null && provider.calls.get() == 0 },
+        )
+
+        produceFrame()
+
+        assertTrue("a frame releases the scroll-mode gate", awaitTrue { published.get() != null })
+        assertEquals(3, published.get()!!.size)
+    }
+
+    @Test fun pagedMode_scanWaitsForFirstSettledPage() {
+        val pagedBodyMounted = mutableStateOf(true)    // paged body
+        val pagedOffset = mutableStateOf(-1)           // no settled page published yet
+        val provider = CountingProvider(providerFor(chapteredText))
+        val published = publishState()
+
+        scope.launch { runTxtTocScan(provider, pagedBodyMounted, pagedOffset) { published.set(it) } }
+        produceFrame()
+
+        // A frame alone is NOT enough in paged mode — the paged body has not published a page.
+        assertTrue(
+            "the paged gate holds until the first settled page",
+            heldFor { published.get() == null && provider.calls.get() == 0 },
+        )
+
+        // The paged body's onSaveSourceOffset callback publishes page 0's start offset. This is
+        // Compose state, so the gate's snapshotFlow re-evaluates — the whole point of NOT using
+        // TxtPageNavigator.index (a plain `var`, which would never re-emit).
+        pagedOffset.value = 0
+        Snapshot.sendApplyNotifications()
+
+        assertTrue("the first settled page releases the paged gate", awaitTrue { published.get() != null })
+        assertEquals(3, published.get()!!.size)
+    }
+
+    @Test fun pagedMode_gateReleasesIfBodyFlipsToScrollMidWait() {
+        val pagedBodyMounted = mutableStateOf(true)
+        val pagedOffset = mutableStateOf(-1)           // and it never publishes one
+        val provider = CountingProvider(providerFor(chapteredText))
+        val published = publishState()
+
+        scope.launch { runTxtTocScan(provider, pagedBodyMounted, pagedOffset) { published.set(it) } }
+        produceFrame()
+        assertTrue("still parked in paged mode", heldFor { published.get() == null })
+
+        // A bilingual toggle / layout change unmounts the paged body mid-wait. The scan must NOT be
+        // stranded for the rest of the session (Gate-2 R4 HIGH).
+        pagedBodyMounted.value = false
+        Snapshot.sendApplyNotifications()
+
+        assertTrue("a flip to scroll releases the gate", awaitTrue { published.get() != null })
+    }
+
+    @Test fun scanIsKeyedOnDocument_notOnEveryRecomposition() {
+        val pagedBodyMounted = mutableStateOf(true)
+        val pagedOffset = mutableStateOf(-1)
+        val provider = CountingProvider(providerFor(chapteredText))
+        val publishes = AtomicInteger(0)
+
+        scope.launch { runTxtTocScan(provider, pagedBodyMounted, pagedOffset) { publishes.incrementAndGet() } }
+        produceFrame()
+        pagedOffset.value = 0
+        Snapshot.sendApplyNotifications()
+        assertTrue(awaitTrue { publishes.get() == 1 })
+
+        // Every further change to the state the gate observed — page turns, a layout flip — is a
+        // recomposition-level event. ONE scan per document: the gate terminates, it does not keep
+        // collecting and re-publishing.
+        repeat(6) { i ->
+            pagedOffset.value = i + 1
+            pagedBodyMounted.value = i % 2 == 0
+            Snapshot.sendApplyNotifications()
+            Thread.sleep(10)
+        }
+        assertTrue("the scan ran exactly once", heldFor { provider.calls.get() == 1 && publishes.get() == 1 })
+    }
+
+    // ---- the pre-scan posture ------------------------------------------------------------------
+
+    @Test fun preScanState_passesEmptyEntries_soContentsStaysHidden() {
+        val pagedBodyMounted = mutableStateOf(false)
+        val pagedOffset = mutableStateOf(-1)
+        // The host's `remember(s.document) { mutableStateOf(emptyList()) }` — what TxtReaderChrome reads.
+        val entries = mutableStateOf(emptyList<TocEntry>())
+
+        scope.launch { runTxtTocScan(providerFor(chapteredText), pagedBodyMounted, pagedOffset) { entries.value = it } }
+
+        // Pre-scan the host is byte-identical to today: an empty list, which is exactly
+        // ReaderChromeScaffold's "hide the Contents control" signal.
+        assertTrue("pre-scan entries are empty", heldFor { entries.value.isEmpty() })
+        produceFrame()
+        assertTrue("the scan publishes the chapters", awaitTrue { entries.value.isNotEmpty() })
+    }
+
+    @Test fun zeroDetectedHeadings_keepsContentsControlHidden() {
+        val pagedBodyMounted = mutableStateOf(false)
+        val pagedOffset = mutableStateOf(-1)
+        val provider = CountingProvider(providerFor(proseText))
+        val entries = mutableStateOf(emptyList<TocEntry>())
+
+        scope.launch { runTxtTocScan(provider, pagedBodyMounted, pagedOffset) { entries.value = it } }
+        produceFrame()
+
+        // The scan RAN (so this is not a false pass from a stuck gate) and found nothing → the list
+        // stays empty → the Contents control stays hidden. No empty sheet is ever reachable.
+        assertTrue("the scan ran", awaitTrue { provider.calls.get() == 1 })
+        assertTrue("prose with no chapter markers yields no TOC", heldFor { entries.value.isEmpty() })
+    }
+
+    // ---- highlight key + jump target -----------------------------------------------------------
+
+    @Test fun jumpTargetIsEntryCharOffsetUtf16() {
+        val entries = runBlocking { providerFor(chapteredText).toc() }
+        assertEquals(3, entries.size)
+
+        // Each entry's offset is the heading line's start in the RAW decoded text.
+        assertEquals(chapteredText.indexOf("Chapter 1"), entries[0].canonicalLocator.charOffsetUTF16)
+        assertEquals(chapteredText.indexOf("Chapter 2"), entries[1].canonicalLocator.charOffsetUTF16)
+        assertEquals(chapteredText.indexOf("Chapter 3"), entries[2].canonicalLocator.charOffsetUTF16)
+
+        // The jump target IS that offset — no re-derivation, no page, no chunk index.
+        assertEquals(
+            entries[1].canonicalLocator.charOffsetUTF16,
+            txtTocJumpTarget(entries, 1, chapteredText.length),
+        )
+        // Out-of-range row indices degrade to null → the sheet stays open (rule 51), never a crash.
+        assertNull(txtTocJumpTarget(entries, -1, chapteredText.length))
+        assertNull(txtTocJumpTarget(entries, entries.size, chapteredText.length))
+        assertNull(txtTocJumpTarget(emptyList(), 0, chapteredText.length))
+        // An offset at/past EOF (an empty document) is out of range, exactly like a bookmark's.
+        assertNull(txtTocJumpTarget(entries, 0, 0))
+    }
+
+    @Test fun jumpTargetIsUtf16Offset_forCjkChapters() {
+        val entries = runBlocking { providerFor(cjkText).toc() }
+        assertEquals(2, entries.size)
+        assertEquals(cjkText.indexOf("第一章"), txtTocJumpTarget(entries, 0, cjkText.length))
+        assertEquals(cjkText.indexOf("第二章"), txtTocJumpTarget(entries, 1, cjkText.length))
+    }
+
+    @Test fun entryOffsetsFeedTheCurrentChapterHighlight() {
+        val entries = runBlocking { providerFor(chapteredText).toc() }
+        val offsets = txtTocEntryOffsets(entries)
+        assertEquals(entries.map { it.canonicalLocator.charOffsetUTF16 }, offsets)
+
+        // The live reading position resolves to the last chapter at-or-before it (WI-5's contract).
+        assertEquals(0, txtTocIndexFor(0, offsets))                       // before chapter 1 → row 0
+        assertEquals(0, txtTocIndexFor(offsets[0], offsets))              // exactly at chapter 1
+        assertEquals(1, txtTocIndexFor(offsets[1] + 3, offsets))          // inside chapter 2
+        assertEquals(2, txtTocIndexFor(chapteredText.length, offsets))    // past the last heading
+        assertEquals(-1, txtTocIndexFor(0, txtTocEntryOffsets(emptyList())))
+    }
+
+    @Test fun markdownEntriesCarryHeadingDepth() {
+        val entries = runBlocking { providerFor(markdownText, BookFormat.md).toc() }
+        assertEquals(listOf(0, 1, 2), entries.map { it.depth })
+        assertEquals(listOf("Top level", "Nested one", "Nested two"), entries.map { it.title })
+        // TXT stays flat (plan §4.3) — the indentation the sheet renders is MD-only.
+        assertEquals(listOf(0, 0, 0), runBlocking { providerFor(chapteredText).toc() }.map { it.depth })
+    }
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/TxtTocHostWiringTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/TxtTocHostWiringTest.kt
@@ -207,6 +207,32 @@ class TxtTocHostWiringTest {
         assertTrue("a flip to scroll releases the gate", awaitTrue { published.get() != null })
     }
 
+    @Test fun pagedMode_gateNeverStrands_whenNoSettledPageEverArrives() {
+        // Gate-4 R1 HIGH, the FOURTH never-fires instance: a mounted paged body does NOT always publish
+        // a settled page. On a degenerate content box or an empty document `TxtPagedBody` renders
+        // `TxtScrollFallback` instead of a pager, so `onSaveSourceOffset` — and therefore `pagedOffset`
+        // — never fires for the whole session. An unbounded stage-2 wait would hide Contents forever,
+        // silently. The bound is what makes that impossible, so it is pinned here.
+        val pagedBodyMounted = mutableStateOf(true)
+        val pagedOffset = mutableStateOf(-1)             // and nothing ever publishes one
+        val provider = CountingProvider(providerFor(chapteredText))
+        val published = publishState()
+
+        scope.launch {
+            runTxtTocScan(provider, pagedBodyMounted, pagedOffset, pagedReadyTimeoutMs = 250L) { published.set(it) }
+        }
+        produceFrame()
+
+        assertTrue("the scan runs anyway once the paged wait times out", awaitTrue { published.get() != null })
+        assertEquals(3, published.get()!!.size)
+    }
+
+    @Test fun pagedReadyTimeoutIsBounded() {
+        // The production default must be a real, finite bound — a 0 would defeat the settled-page wait
+        // entirely, and an enormous one would re-create the stranding it exists to prevent.
+        assertTrue("the paged-ready wait is bounded and non-trivial", PAGED_READY_TIMEOUT_MS in 100L..10_000L)
+    }
+
     @Test fun scanIsKeyedOnDocument_notOnEveryRecomposition() {
         val pagedBodyMounted = mutableStateOf(true)
         val pagedOffset = mutableStateOf(-1)

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.20.20
-versionCode=173
+versionName=0.20.21
+versionCode=174


### PR DESCRIPTION
## Summary

`TxtMdTocProvider` is wired into `TxtReaderActivity`. **Contents is now reachable on TXT and MD.**

Part of feature #2025 (#139). Behavioral WI.

## Why this is the WI that matters

`TxtReaderActivity` passed `tocEntries = emptyList()` unconditionally, so `ReaderChromeScaffold`'s empty-list rule hid Contents on **every** TXT/MD book. WI-1…WI-6 built the whole pipeline behind a control no user could reach. A 254,109-line CJK book had no chapter navigation at all; now it does.

## §7a earned its keep a fourth time

The plan makes "does this gate actually re-emit?" a binding Gate-4 focus, because three *"mechanism that can never fire"* defects already appeared during planning. **Round 1 found a fourth — one the plan's own §4.5 missed:**

A *mounted* paged body does not always publish a settled page. On a degenerate/empty index, `TxtPagedBody` renders `TxtScrollFallback` instead of a pager (`TxtReaderBody.kt:445-450`), so `onSaveSourceOffset`/`pagedOffset` **never fire** — and the unbounded gate would have hidden Contents for the entire session, with no crash and no log entry.

Fixed by bounding stage 2 (`PAGED_READY_TIMEOUT_MS = 3s`, injectable). The reasoning: only `withFrameNanos` was ever a hard guarantee; the settled-page wait is an *optimization*, and the scan is off-main either way — so a bounded wait loses nothing and cannot strand.

## Gate 5a slice — passed on `emulator-5554`

`TxtTocConnectedTest` **10 tests / 0 failures**. Observed:

- A TXT book with three `Chapter N` headings shows the `chrome-contents` control and opens a Contents sheet with one row per chapter, no empty state.
- The committed headings-free `resume-sample.txt` keeps the control **hidden** while `chrome-notes` stays present — and this is asserted **only after `tocScanCompletedForTest()`**, so a stuck gate cannot pass it by accident.
- Tapping `toc-row-2` in the real modal sheet dismisses it and scrolls the reader to the `Chapter 3` line.
- In **paged** mode the row jump lands the pager on the page containing chapter 3's offset, re-evaluated against the live index (since #138's windowed index can still be partial at jump time).
- A Scroll→Paged toggle mid-session keeps the identical TOC and the control.
- The MD book's depth-2 row is measurably indented past its depth-1 sibling.

## Mutation-checked

| Mutation | Result |
|---|---|
| delete the frame gate | JVM **10/6 red** |
| a never-opening gate | JVM **10/6 red** |
| restore `tocEntries = emptyList()` | connected **8/5 red** |

## TTS: the two modes genuinely differ, and that is pre-existing

Scroll mode's follow effect keys on `firstVisibleItemIndex`, so a TOC jump is **immediately re-followed** and yanked back; paged mode deliberately **holds**. Asserted separately, per mode. This asymmetry already affects #135 bookmark and #133 search jumps — it is the plan's accepted follow-up **F5** and is deliberately *not* "fixed" here.

Because a real TTS engine cannot speak on the emulator (no voice data), both read-aloud tests drive the production follow decision through a seam, following the #137 `simulatePagedTtsFollowForTest` precedent.

## Three deliberate deviations

1. **The scroll-mode follow body was extracted unchanged** from its `LaunchedEffect` into `followSpokenChunkInScroll`, so the connected test drives the *same* decision. Effect keys untouched; `TxtPagedTtsFindConnectedTest` 4/0 and `TxtReaderBilingualConnectedTest` 8/0 confirm no regression, and round 2 confirmed it behaviour-preserving.
2. **Connected fixtures are generated TXT/MD imported through the real importer**, not real books — `test-books/` is gitignored and unreachable from an instrumented run, and these assertions need exact chapter counts, known offsets, and three MD depths. This is the "deterministic tiny structure" exception; **WI-8 owns the real 14 MB CJK book.**
3. **The JVM suite has 12 tests, not the plan's 7** — three composition-level names moved to the connected file (`createComposeRule` is androidTest-only here), and four were added for the audit fix and CJK/MD coverage.

## Validation

- JVM `TxtTocHostWiringTest`: **12 / 0**, re-run by the orchestrator with `--rerun-tasks` (35/35 executed).
- Connected `TxtTocConnectedTest`: **10 / 0**, re-run by the orchestrator on the rebased branch.
- Regressions clean: full `:app:testDebugUnitTest` **1586 / 0**, `TxtReaderChromeUiTest` 6/0, `TxtFindInBookTest` 6/0.
- Gate-4 Codex audit: 2 rounds, **`ship-as-is`**, zero open Critical/High/Medium.
- Rule 51: clean — no new surface; an existing conditional now evaluates non-empty.
- Rule 22: `TxtReaderActivity`'s `Purpose:` header updated (it previously stated TXT/MD had no TOC).
- Version bumped: `android/v0.20.20` → `android/v0.20.21`.

## One pre-existing failure, independently confirmed

`TxtReaderActivityTest.tapExistingHighlight_opensEditPopover_andRemoveDeletesIt` fails on this branch **and identically on clean `main`** — the orchestrator verified this by checking out `main` and re-running the class (6 tests / 1 failure, same test). It is the known long-press/gesture emulator-flake class, not a WI-7 regression.

## Known debt (pre-existing, not addressable here)

`TxtReaderActivity.kt` is now 1,836 lines against the ~300 guideline. It was already far over before this WI (+~130 here); splitting the host is pre-existing debt outside this WI's write-set.

## Type of Change

- [x] Feature WI (part of feature #2025)
