### PR TITLE
docs(parity): record #139 as DONE-but-blocked in box G1

### DIFF
--- a/docs/parity/android-checklist.md
+++ b/docs/parity/android-checklist.md
@@ -187,7 +187,15 @@ dispatches that isn't READY).
 
 ## G1. Reader navigation — Contents (TOC) on every format
 
-- [ ] **#139 TXT/MD auto-generated TOC** — TXT/MD hide Contents entirely today. iOS: #23 + #12.
+- [~] **#139 TXT/MD auto-generated TOC** — iOS: #23 + #12. **All 8 implementation WIs merged
+      2026-08-04/05 (`android/v0.20.15`→`v0.20.22`); Contents is now REACHABLE on TXT/MD** — a
+      254,109-line CJK book is navigable for the first time, driven end-to-end through the
+      production path (app launch → Library → tap book → reader → Contents → tap chapter).
+      **Row is `DONE`, NOT `VERIFIED` — blocked on #172.** Gate-5b on the real 14MB CJK book found
+      the scan takes **8,300–11,449 ms** against a stated **1,500 ms** budget (§5 gate 1), because
+      the plan's no-persistence decision rested on a *desktop-JVM* 46–102 ms measurement — ~100×
+      off on-device. The blocking PRIMARY gate passes (open-to-first-page 47 ms quiet / 7 ms
+      concurrent vs <2,000 ms), so #138's windowed pagination is intact and nothing regressed.
 - [ ] **#140 AZW3 Contents (TOC)** — foliate exposes a real TOC; Android hides it. iOS: #38.
 - [ ] **#141 Filterable TOC** — designed filter field (`toc-filter-artboards.jsx`). iOS: #94.
       `Deps:[feat:#139, feat:#140]`.


### PR DESCRIPTION
All 8 of #139's implementation WIs merged (`android/v0.20.15`→`v0.20.22`) and **TXT/MD Contents is now reachable** — a 254,109-line CJK book is navigable for the first time, verified end-to-end through the production path.

**But the box does not check.** Gate-5b on the real 14 MB CJK book found the scan takes **8,300–11,449 ms** against the stated **1,500 ms** budget (plan §5 gate 1) — because that plan's no-persistence decision rested on a *desktop-JVM* measurement of 46–102 ms, roughly **100× off** on-device. Filed as #172; #139 carries `Deps:[feat:#172]` and `deps-check` reports it BLOCKED.

Marking the box `[~]` rather than `[x]` is exactly the point of the phase-4 definition of done: **a box may only be checked when the capability is genuinely delivered, not when the code merged.**

The blocking PRIMARY gate does pass (open-to-first-page 47 ms quiet / 7 ms concurrent vs <2,000 ms), so #138's windowed pagination is intact — the feature is incomplete, not broken.

Tracker-only. No code, no version bump.

GH: #2025, #2043