### PR TITLE
perf(#172 WI-2): one Matcher per scan — 6,525ms to 61ms on the real 14MB CJK book

### DIFF
--- a/.claude/codex-audits/feat-172-wi-2-one-matcher-audit.md
+++ b/.claude/codex-audits/feat-172-wi-2-one-matcher-audit.md
@@ -1,0 +1,95 @@
+---
+branch: feat/172-wi-2-one-matcher
+threadId: 019fce24-0077-7871-841b-342824fbff70
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-08-05
+---
+
+# Gate-4 audit — feature #172 WI-2 (one `Matcher` per scan)
+
+Auditor: Codex `gpt-5.6-sol` via `scripts/run-codex.sh` (rule 53), read-only, three rounds.
+Author/auditor separation held: the implementing lane never audited its own work.
+
+| Round | Thread | Verdict |
+| --- | --- | --- |
+| 1 | `019fce0b-534b-75d1-8f8f-5986b80cfca5` | `follow-up-recommended (C=0 H=0 M=1 L=2)` |
+| 2 | `019fce18-75b6-7301-9ec1-d5bd318b398b` | `follow-up-recommended (C=0 H=0 M=1 L=2)` |
+| 3 | `019fce24-0077-7871-841b-342824fbff70` | **`ship-as-is (C=0 H=0 M=0 L=0)`** |
+
+Raw transcripts: `.reports/audit-r1.txt`, `.reports/audit-r2.txt`, `.reports/audit-r3.txt`
+(worktree-local, not committed — long output travels as paths per rule 55).
+
+## Scope
+
+- `android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocRuleEngine.kt` (the change)
+- `android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocEngineWalkEquivalenceTest.kt` (new, JVM oracle)
+- `android/app/src/androidTest/kotlin/com/vreader/app/reader/nav/TxtTocScanCostTest.kt` (RED added)
+- `android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocRules.kt` (read-only context)
+
+Every round was asked the same six adversarial questions: is exactly ONE `Matcher` constructed per
+scan on every path; is the walk driven by no-arg `find()` and never `find(int)`; is the
+`(title, offset)` sequence provably identical; are `limit` / empty-title / cancellation / `sampleOf`
+semantics preserved; is the oracle's corpus genuinely adversarial or vacuous; is the budget tight
+enough to fail a `find(int)` implementation.
+
+## Headline
+
+**No round found a single defect in the production change.** All six findings across rounds 1–2 were
+in the new test file, and every one was about the *strength of the evidence*, not the behaviour.
+Round 3 independently re-derived the equivalence argument, the `\G` claim, the surrogate-advancement
+claim and the cancellation cadence, and closed with no findings.
+
+## Findings and dispositions
+
+### Round 1 — `C=0 H=0 M=1 L=2`
+
+| # | Sev | Finding | Disposition |
+| --- | --- | --- | --- |
+| 1 | **Medium** | `cancellationCadenceIsUnchanged` used a 40-match fixture, so it never reached the every-`CANCELLATION_CHECK_INTERVAL` (1024) branch — it would have passed with the whole `sinceCheck` block deleted. | **FIXED** (`56f02ecf`). The fixture now walks `2 × INTERVAL + 953` matches whose titles are ALL empty and counts the checks: `assertEquals(1 + 2 + 1, checks)`. Because zero headings are emitted, this also discriminates per-match-EXAMINED from per-heading-EMITTED (the latter would give 2). A `CancelAfter(1)` is additionally asserted to stop AT the interval check (`checks == 2`), and the same count check was added for `countMatches` via `detectBestRule`. |
+| 2 | Low | `theCorpusDiscriminatesEveryPlausiblyWrongWalk` claimed more than four loop-body mutations prove; nothing covered resume-state constructs (`\G`, lookbehind, zero-width at EOF, astral-boundary advancement). | **FIXED** (`56f02ecf`). Renamed to `theCorpusDiscriminatesTheFourLoopBodyMistakes` with a KDoc naming where resume-state mistakes are actually covered. Three rules added to the MAIN sweep — a lookbehind rule, a bare `$` rule, and the EMPTY pattern — so those are demonstrated rather than argued. New `noShippedRuleUsesAResumeSensitiveConstruct` guards the equivalence's one genuine precondition: `\G` is the only construct that can observe *where* a walk resumed (old walk anchored it at `end + 1` after an empty match, new walk at `end`), so a future `\G` rule fails the guard instead of silently changing behaviour. The engine header records it. |
+| 3 | Low | The new test file is 607 lines vs the repo's ~300-line guidance. | **ACCEPTED with rationale.** The sibling suites in this area are 624–1207 lines by established precedent (`MdTocScannerTest` 624, `TxtTocRuleEngineTest` 697, `TxtTocAcceptanceTest` 1207) and the plan's own §8 test catalogue cites those counts approvingly. Splitting the legacy oracle from the corpus that discriminates it would separate the reference implementation from its evidence — the opposite of readable. **No production file grew**; `TxtTocRuleEngine.kt` is 247 lines. |
+
+### Round 2 — `C=0 H=0 M=1 L=2`
+
+| # | Sev | Finding | Disposition |
+| --- | --- | --- | --- |
+| 4 | **Medium** | Round 1's own fix was half-real: `emptyPatternRule` and `endAnchorRule` DO match zero-width inside a surrogate pair and at end-of-input, but every such match trims to `""` and is **dropped**, so the emitted-output sweep compared two empty lists on exactly the positions the rules were added to cover. A walk skipping the inside-a-surrogate position would still have passed. | **FIXED** (`da2d350a`). `theTwoResumeStrategiesAgreeOnRawOffsetsIncludingTheInvisibleOnes` drops below the engine and compares the strategies themselves over the whole corpus: `legacyResumeOffsets` (a FRESH `Matcher` per match, `find(from)`, `from = end + (if end == start) 1 else 0` — `MatcherMatchResult.next()` transcribed) vs `newResumeOffsets` (ONE `Matcher`, `while (find())`). Every raw offset is compared, dropped or not, and the two invisible positions are asserted PRESENT: an empty pattern matches at `[0, 1, 2]` of a surrogate pair (advancement is by code UNIT — code-POINT advancement would make the strategies diverge there) and a bare `$` matches at end-of-input. Both walks carry a step cap so a non-advancing regression fails loudly instead of hanging the suite. |
+| 5 | Low | Detection cadence asserted only as `>= 4`, permitting an over-checking regression. | **FIXED** (`da2d350a`). `assertEquals` on the exact 5 (entry + per-rule + 2 interval checks inside `countMatches` + post-loop). |
+| 6 | Low | `allRules` KDoc still said "five synthetic" rules; `extraRules` has eight. | **FIXED** (`da2d350a`). |
+
+### Round 3 — `ship-as-is (C=0 H=0 M=0 L=0)`
+
+> "No findings. R2's M1 is closed: `legacyResumeOffsets` faithfully models Kotlin's initial
+> `Regex.find(input, 0)`, zero-width advancement, and `nextIndex > input.length` termination.
+> Android's API 35 matcher advances empty matches by one UTF-16 code unit, so `[0, 1, 2]` is correct
+> for a surrogate pair; `$` also matches at EOF. The detection cadence is exactly five checks: entry
+> + pre-rule + two interval checks across 3001 matches + post-loop. Production behavior, matcher
+> allocation, cancellation, limits, compilation parity, documentation, imports, and thread safety
+> show no blocking defect."
+
+## What the audit independently confirmed about the production change
+
+- Exactly ONE `Matcher` is constructed per scan on **every** path of `extractHeadings` and
+  `countMatches`, including the empty-text early return, the uncompilable-pattern return, the
+  `limit` early-return and every cancellation exit.
+- The walk is driven by **no-arg `find()`** everywhere; `find(int)` appears nowhere in production.
+- The `(title, offset)` sequence is identical to the pre-change Kotlin walk, with `\G` as the single
+  documented and mechanically-guarded precondition.
+- `Regex(p, MULTILINE)` and `Pattern.compile(p, Pattern.MULTILINE)` have exception-type parity
+  (`PatternSyntaxException`), so the iOS-parity `try?`-style skip is unchanged.
+- No `Matcher` instance is shared across threads (each is a local in the call that made it).
+- Rule-22: the header's new `Key decisions` block matches the code sentence by sentence.
+
+## Test evidence at the audited HEAD
+
+| Gate | Result |
+| --- | --- |
+| JVM (`:app:testDebugUnitTest --rerun-tasks --tests '*TxtToc*' --tests '*MdTocScanner*' --tests '*TxtMdTocProvider*'`) | `RUN-ANDROID-TESTS RESULT: SUCCEEDED` — 174 tests, 0 failures, 0 errors |
+| Connected (`:app:connectedDebugAndroidTest`, `TxtTocScanCostTest`, emulator-5554 / API 35) | `RUN-ANDROID-TESTS RESULT: SUCCEEDED` — 6 tests, 0 failures |
+| RED before / after | `extractionMeetsEngineBudget` 7111 ms **FAIL** → 83 ms **PASS** (300 ms budget) |
+
+The declared JVM gate's `--tests '*TxtToc*'` glob does **not** match `TxtMdTocProviderTest`; the run
+above adds `--tests '*TxtMdTocProvider*'` so all five regression suites the WI-2 spec names are
+actually executed. All five pass **unmodified** — the only test files touched are the new oracle and
+the connected harness the RED was added to.

--- a/android/app/src/androidTest/kotlin/com/vreader/app/reader/nav/TxtTocScanCostTest.kt
+++ b/android/app/src/androidTest/kotlin/com/vreader/app/reader/nav/TxtTocScanCostTest.kt
@@ -52,11 +52,16 @@ import java.util.regex.Pattern
  * prices PATHS and deliberately does not claim an exclusive construction-vs-reset split — see its
  * own documentation for exactly what it does and does not establish.
  *
- * **Assertions are EQUIVALENCE, never budgets.** Arms (a)/(b)/(c) must agree on the match count and
- * (a)/(b) element-for-element on `(title, offset)`; arm (h)'s three walks must return the identical
- * offset sequence, which is what makes their timings comparable at all. There is deliberately **no
- * latency assertion anywhere in this class** — a benchmark that gates on the number it was written
- * to discover is not evidence.
+ * **The MEASUREMENT arms assert EQUIVALENCE, never budgets.** Arms (a)/(b)/(c) must agree on the
+ * match count and (a)/(b) element-for-element on `(title, offset)`; arm (h)'s three walks must
+ * return the identical offset sequence, which is what makes their timings comparable at all. No
+ * measurement arm gates on a latency — a benchmark that gates on the number it was written to
+ * discover is not evidence.
+ *
+ * **The one exception is [extractionMeetsEngineBudget], added by WI-2** — and it is an exception
+ * precisely because it inverts that relationship. Its number was not discovered by the assertion;
+ * it was measured FIRST by arm (b) above and is being HELD afterwards. It is the RED for WI-2: red
+ * on the shipped engine, green on the one-`Matcher` walk. See [ENGINE_BUDGET_MS].
  *
  * **Confounder handling** (every arm's number is only worth its controls):
  *  - *JIT warm-up*: every timed arm is preceded by a warm-up that exercises the same shapes, so no
@@ -118,10 +123,12 @@ import java.util.regex.Pattern
  * after a plain `connectedDebugAndroidTest`.
  *
  * Run ONE class per connected invocation, and never drive the emulator while it runs (rule 52).
- * Method order is pinned so the log reads in a fixed sequence. Two methods each run one full
- * baseline extraction; on a 2.5 GB emulator that is where the process peaks (the `lowmemorykiller`
- * truncated #139 WI-8 runs at ~1.4 GB RSS). If a run is truncated, reboot the emulator or split the
- * class by `#method`.
+ * Method order is pinned so the log reads in a fixed sequence. THREE methods each run at least one
+ * full extraction through the production engine; on a 2.5 GB emulator that is where the process
+ * peaks (the `lowmemorykiller` truncated #139 WI-8 runs at ~1.4 GB RSS). That is why
+ * [extractionMeetsEngineBudget] stops retrying a pass that is wildly over budget instead of taking
+ * all [BUDGET_ATTEMPTS]. If a run is truncated, reboot the emulator or split the class by
+ * `#method`.
  */
 @RunWith(AndroidJUnit4::class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -172,6 +179,45 @@ class TxtTocScanCostTest {
 
         /** `TxtMdTocProvider.SCAN_LIMIT` — `MAX_TOC_ENTRIES + 1`, so arm (a) walks to end-of-text. */
         const val SCAN_LIMIT = 50_001
+
+        /**
+         * **WI-2's RED budget**, in milliseconds, for one full `extractHeadings` pass over the real
+         * book — and the one number in this class that is an ASSERTION rather than a report.
+         *
+         * Derived from WI-1's arm (b), which measured the identical walk driven by ONE reused
+         * `Matcher` and no-arg `find()` at **61–62 ms** (paired readings, before and after the
+         * baseline arm). 300 ms is ~5× that, which absorbs emulator load, the in-band
+         * `Pattern.compile` the engine pays and arm (b) did not, and the two cancellation checks
+         * a 1 859-match scan performs.
+         *
+         * **It is deliberately tight enough to reject a wrong fix, not just the shipped one.**
+         * Three implementations, all measured on this device in WI-1:
+         *
+         * | Implementation | Measured cost of one full scan |
+         * | --- | --- |
+         * | shipped `Regex.find()/next()` — a fresh `Matcher` per match | **6 525 ms** (21× over) |
+         * | ONE reused `Matcher` driven by `find(int)` | ≈ 1 859 × 1.7 ms ≈ **3 160 ms** (10× over) |
+         * | ONE reused `Matcher` driven by no-arg `find()` | **61–62 ms** (4.8× under) |
+         *
+         * The middle row is why the budget is 300 ms and not, say, 2 000 ms: arm (h) priced
+         * `find(int) − find()` at 1.7–2.1 ms per operation because `find(int)` RESETS, and reset is
+         * the length-proportional half. A fix that stops constructing `Matcher`s but keeps driving
+         * them with `find(int)` would look like a fix and still miss by an order of magnitude; this
+         * budget fails it.
+         */
+        const val ENGINE_BUDGET_MS = 300L
+
+        /**
+         * How many timed passes the budget test may take, reporting the MINIMUM.
+         *
+         * The minimum is the statistic most generous to the implementation, which is what makes a
+         * failure decisive rather than a claim about emulator load. Attempts stop early on the
+         * first pass within budget — and also on any pass more than [BUDGET_BLOWOUT_FACTOR] × over
+         * it, because a scan that far over is not a noise question and repeating it only risks the
+         * `lowmemorykiller` (the shipped walk grows process PSS by ~1.1 GB per pass).
+         */
+        const val BUDGET_ATTEMPTS = 3
+        const val BUDGET_BLOWOUT_FACTOR = 5
 
         /** Arm (h): how many matches (or resets) each of the five sub-arms performs. */
         const val WALK_MATCHES = 200
@@ -518,6 +564,68 @@ class TxtTocScanCostTest {
             )
         }
         report("EQUIVALENCE-DETAIL all ${shipped.value.headings.size} (title,offset) pairs identical")
+    }
+
+    // ---- 1b. WI-2's RED: the engine-level budget ---------------------------------------------------
+
+    /**
+     * **WI-2's RED.** One full `extractHeadings` pass over the real book must finish within
+     * [ENGINE_BUDGET_MS].
+     *
+     * This is the only assertion in this class that gates on a latency, and it is legitimate here
+     * for the reason the rest of the class is not: the number is not being discovered, it was
+     * MEASURED FIRST by WI-1 (arm (b), 61–62 ms) and is being held. It is RED on the shipped
+     * `Regex.find()/next()` engine (6 525 ms) and GREEN once the walk uses one reused `Matcher`
+     * driven by no-arg `find()` — see [ENGINE_BUDGET_MS] for why a `find(int)`-driven reuse, the
+     * plausible wrong fix, also fails it.
+     *
+     * It calls the PRODUCTION entry point, not a hand-written arm, so it measures what ships —
+     * including the in-band `Pattern.compile` and the cancellation checks. The result is checked
+     * against the book's known chapter count as well: a walk that got fast by finding fewer
+     * headings is not a fix, and the budget alone would not notice.
+     */
+    @Test
+    fun extractionMeetsEngineBudget() {
+        val text = requireRealBookText()
+        val rule = requireWinningRule(text)
+        val pattern = compileWinning(rule)
+        warmUpWalks(text, pattern, rule)
+
+        var bestMs = Long.MAX_VALUE
+        var last: ExtractResult? = null
+        for (attempt in 1..BUDGET_ATTEMPTS) {
+            gcSettle()
+            val t0 = SystemClock.elapsedRealtime()
+            val result = runBlocking { TxtTocRuleEngine.extractHeadings(text, rule, SCAN_LIMIT) }
+            val ms = SystemClock.elapsedRealtime() - t0
+            report(
+                "ARM red-engine-budget attempt=$attempt/$BUDGET_ATTEMPTS ms=$ms " +
+                    "budget_ms=$ENGINE_BUDGET_MS headings=${result.headings.size}",
+            )
+            bestMs = minOf(bestMs, ms)
+            last = result
+            if (ms <= ENGINE_BUDGET_MS) break
+            if (ms > ENGINE_BUDGET_MS * BUDGET_BLOWOUT_FACTOR) break
+        }
+
+        val extracted = requireNotNull(last) { "the budget loop must run at least once" }
+        report(
+            "ENGINE-BUDGET best_ms=$bestMs budget_ms=$ENGINE_BUDGET_MS " +
+                "headings=${extracted.headings.size} hit_limit=${extracted.hitLimit}",
+        )
+
+        assertEquals(
+            "a fast scan that finds fewer chapters is not a fix",
+            EXPECTED_HEADINGS, extracted.headings.size,
+        )
+        assertTrue("the production scan must not hit the scan limit on this book", !extracted.hitLimit)
+        assertTrue(
+            "extractHeadings took ${bestMs}ms (best of up to $BUDGET_ATTEMPTS passes) against a " +
+                "${ENGINE_BUDGET_MS}ms budget derived from WI-1 arm (b)'s measured 61-62ms. The scan " +
+                "must construct ONE Matcher and drive it with no-arg find(); a fresh Matcher per " +
+                "match costs ~6525ms and a reused Matcher driven by find(int) ~3160ms",
+            bestMs <= ENGINE_BUDGET_MS,
+        )
     }
 
     // ---- 2. target-semantic logging (arm f) --------------------------------------------------------

--- a/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocRuleEngine.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocRuleEngine.kt
@@ -47,6 +47,14 @@
 //   at `end + (if (end == start) 1 else 0)` and no-arg `find()` applies the same rule, and the
 //   reset `find(int)` performs is unobservable here (no region is ever set, no append is
 //   performed, and matching uses the full text with default bounds).
+//   ONE PRECONDITION, and it is guarded by test: no rule may use `\G`. `\G` is the only construct
+//   that can OBSERVE where a walk resumed — after an EMPTY match the old walk anchored it at
+//   `end + 1` and this one anchors it at `end` — so a `\G` rule would be the one pattern this
+//   rewrite silently changes. `TxtTocEngineWalkEquivalenceTest#noShippedRuleUsesAResumeSensitive
+//   Construct` fails if one is ever added. Lookbehind is NOT affected (the region is the whole
+//   text either way, and the bounds flags are never touched, so `reset()` restores the defaults
+//   they already had) — the oracle sweeps a lookbehind rule to demonstrate that rather than argue
+//   it.
 // - No Android imports and no logging: this is pure CPU work that must stay JVM-unit-testable
 //   (`android.util.Log` throws "not mocked" in a plain unit test). A rule that fails to compile is
 //   skipped, mirroring iOS's `try?` — degrading to "no Contents" beats crashing a working reader,
@@ -179,7 +187,7 @@ object TxtTocRuleEngine {
         }
 
         // A cancel landing DURING the final `find()` — the long walk to end-of-text — would
-        // otherwise be swallowed: the loop exits on null and returns a normal result. Check once
+        // otherwise be swallowed: the loop exits on `false` and returns a normal result. Check once
         // more so the outcome is always "cancelled" rather than "a full result for a job nobody
         // is waiting on".
         coroutineContext.ensureActive()

--- a/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocRuleEngine.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/reader/nav/TxtTocRuleEngine.kt
@@ -8,7 +8,8 @@
 // - Detection samples the first [SAMPLE_SIZE_UTF16] code units and requires [MIN_MATCHES] hits,
 //   both iOS parity. Ties resolve toward the rule that appears FIRST in the supplied list
 //   (strictly-greater comparison), which is [TxtTocRules.defaults]' serialNumber order.
-// - Patterns compile with `RegexOption.MULTILINE` and NOTHING else. `DOT_MATCHES_ALL` would let a
+// - Patterns compile with `Pattern.MULTILINE` and NOTHING else — the same int
+//   `RegexOption.MULTILINE` carries, so this is unchanged from the port. `DOT_MATCHES_ALL` would let a
 //   title swallow the rest of the document (the bounded `.{0,30}$` tail cannot cross a line
 //   terminator) and `IGNORE_CASE` would reintroduce the Unicode case-folding divergence the rules
 //   avoid by spelling both cases. See TxtTocRules' header for the D1/D1b class repairs.
@@ -23,19 +24,39 @@
 //   offset and never land inside a surrogate pair. `^` under MULTILINE only matches at 0 or just
 //   after a line terminator, and no terminator is a surrogate, so the boundary property holds by
 //   construction — and is pinned by test.
-// - Extraction is BOUNDED BEFORE MATERIALIZATION: it walks matches one at a time via
-//   `MatchResult.next()` and returns the moment it has `limit` headings, so a pathological
-//   all-match document never builds a full match list to be truncated afterwards (plan §4.4).
+// - Extraction is BOUNDED BEFORE MATERIALIZATION: it walks matches one at a time and returns the
+//   moment it has `limit` headings, so a pathological all-match document never builds a full match
+//   list to be truncated afterwards (#139 plan §4.4).
+// - THE WALK IS HAND-WRITTEN OVER ONE `java.util.regex.Matcher`, NOT `Regex.findAll` /
+//   `MatchResult.next()` — DO NOT "modernise" IT BACK (feature #172 WI-2). Kotlin's
+//   `MatcherMatchResult.next()` calls `Pattern.matcher(input)`, i.e. it builds a BRAND-NEW
+//   `Matcher` over the WHOLE input for EVERY match. On Android (API 35) that construction+reset is
+//   LENGTH-PROPORTIONAL — measured at 0.2734-0.2897 ns per character, ~7 GB/s, the signature of a
+//   linear copy of the UTF-16 buffer — where on the desktop JVM it is effectively free. So the
+//   idiomatic walk is O(matches x text length): on the real 14 MB CJK book (7 029 609 code units,
+//   1 859 chapters) it cost 6 525 ms and grew process PSS by 1.07 GB, against 61-62 ms and 14 MB
+//   for the identical walk over one reused `Matcher` — a 105x difference, measured on-device by
+//   `TxtTocScanCostTest` before this code was written, not predicted.
+//   The walk MUST be driven by NO-ARG `find()`, which resumes from the matcher's own last match.
+//   `find(int)` additionally RESETS, and the reset is the expensive half: arm (h) priced
+//   `find(int) - find()` at 1.7-2.1 ms per call on this input, so a reused `Matcher` driven by
+//   `find(int)` would still cost ~3 200 ms. `TxtTocScanCostTest#extractionMeetsEngineBudget` holds
+//   a 300 ms budget precisely so that regression fails too, and
+//   `TxtTocEngineWalkEquivalenceTest` pins that this walk emits the identical `(title, offset)`
+//   sequence the Kotlin idiom emitted. The equivalence is exact, not approximate: `next()` resumes
+//   at `end + (if (end == start) 1 else 0)` and no-arg `find()` applies the same rule, and the
+//   reset `find(int)` performs is unobservable here (no region is ever set, no append is
+//   performed, and matching uses the full text with default bounds).
 // - No Android imports and no logging: this is pure CPU work that must stay JVM-unit-testable
 //   (`android.util.Log` throws "not mocked" in a plain unit test). A rule that fails to compile is
 //   skipped, mirroring iOS's `try?` — degrading to "no Contents" beats crashing a working reader,
 //   and TxtTocRulesTest already pins that all 25 shipped rules compile.
 // - Both entry points are cancellation-cooperative, with a PRECISELY BOUNDED granularity: a check
 //   at entry, one before each detection rule, and one every [CANCELLATION_CHECK_INTERVAL] matches.
-//   A single `find()` / `next()` is a non-suspending `java.util.regex` call that cannot observe
+//   A single `Matcher.find()` is a non-suspending `java.util.regex` call that cannot observe
 //   cancellation, so the worst case after a cancel is one uninterrupted walk of the gap to the
 //   next match — bounded by a full pass over the text (measured at ~100 ms for the real 14 MB CJK
-//   book, plan §5 / Appendix A.1). That pass is off the MAIN thread only because
+//   book, #139 plan §5 / Appendix A.1). That pass is off the MAIN thread only because
 //   `TxtMdTocProvider` (WI-4) owns the `withContext(dispatcher)` hop; this engine does not hop by
 //   itself and must not be called on the main thread. Splitting the scan into line-bounded
 //   regions to tighten that was REJECTED, not overlooked: `TxtTocRules.WS` widens whitespace to
@@ -48,6 +69,7 @@
 package com.vreader.app.reader.nav
 
 import kotlinx.coroutines.ensureActive
+import java.util.regex.Pattern
 import java.util.regex.PatternSyntaxException
 import kotlin.coroutines.coroutineContext
 
@@ -101,8 +123,8 @@ object TxtTocRuleEngine {
         for (rule in rules) {
             if (!rule.enabled) continue
             coroutineContext.ensureActive()
-            val regex = compile(rule) ?: continue
-            val count = countMatches(regex, sample)
+            val pattern = compile(rule) ?: continue
+            val count = countMatches(pattern, sample)
             if (count > bestCount) {
                 bestCount = count
                 bestRule = rule
@@ -135,27 +157,28 @@ object TxtTocRuleEngine {
         require(limit > 0) { "limit must be positive, was $limit" }
         coroutineContext.ensureActive()
         if (text.isEmpty()) return ExtractResult.EMPTY
-        val regex = compile(rule) ?: return ExtractResult.EMPTY
+        val pattern = compile(rule) ?: return ExtractResult.EMPTY
 
         val headings = ArrayList<DetectedHeading>()
         var sinceCheck = 0
-        var match = regex.find(text)
+        // ONE Matcher for the whole scan, advanced by its own no-arg find(). See the file header's
+        // "the walk is hand-written" decision for why this must not become Regex.findAll/next().
+        val matcher = pattern.matcher(text)
 
-        while (match != null) {
+        while (matcher.find()) {
             if (++sinceCheck >= CANCELLATION_CHECK_INTERVAL) {
                 sinceCheck = 0
                 coroutineContext.ensureActive()
             }
-            val title = match.value.trim()
+            val title = matcher.group().trim()
             if (title.isNotEmpty()) {
-                headings.add(DetectedHeading(title = title, sourceOffsetUtf16 = match.range.first))
+                headings.add(DetectedHeading(title = title, sourceOffsetUtf16 = matcher.start()))
                 // Stop the SCAN, not just the returned list: the next match is never even sought.
                 if (headings.size == limit) return ExtractResult(headings, hitLimit = true)
             }
-            match = match.next()
         }
 
-        // A cancel landing DURING the final `next()` — the long walk to end-of-text — would
+        // A cancel landing DURING the final `find()` — the long walk to end-of-text — would
         // otherwise be swallowed: the loop exits on null and returns a normal result. Check once
         // more so the outcome is always "cancelled" rather than "a full result for a job nobody
         // is waiting on".
@@ -181,25 +204,36 @@ object TxtTocRuleEngine {
         return text.substring(0, end)
     }
 
-    /** Streams over the matches rather than collecting them — the sample is up to 512 KB. */
-    private suspend fun countMatches(regex: Regex, sample: String): Int {
+    /**
+     * Streams over the matches rather than collecting them — the sample is up to 512 KB.
+     *
+     * ONE [java.util.regex.Matcher] per call, advanced by its own no-arg `find()`, for the same
+     * reason [extractHeadings] does (file header). Detection runs this once per enabled rule, so
+     * the per-match construction it replaces was paid 14 times over.
+     */
+    private suspend fun countMatches(pattern: Pattern, sample: String): Int {
         var count = 0
         var sinceCheck = 0
-        var match = regex.find(sample)
-        while (match != null) {
+        val matcher = pattern.matcher(sample)
+        while (matcher.find()) {
             count++
             if (++sinceCheck >= CANCELLATION_CHECK_INTERVAL) {
                 sinceCheck = 0
                 coroutineContext.ensureActive()
             }
-            match = match.next()
         }
         return count
     }
 
-    /** `null` for a pattern `java.util.regex` rejects — iOS's `try?` skips the same way. */
-    private fun compile(rule: TxtTocRule): Regex? = try {
-        Regex(rule.pattern, RegexOption.MULTILINE)
+    /**
+     * `null` for a pattern `java.util.regex` rejects — iOS's `try?` skips the same way.
+     *
+     * Returns the raw [java.util.regex.Pattern] rather than a Kotlin [Regex] because the walks
+     * need the `Matcher` directly. `RegexOption.MULTILINE` IS [Pattern.MULTILINE] (it is a thin
+     * wrapper over the same int), so the compiled semantics are byte-for-byte what they were.
+     */
+    private fun compile(rule: TxtTocRule): Pattern? = try {
+        Pattern.compile(rule.pattern, Pattern.MULTILINE)
     } catch (_: PatternSyntaxException) {
         null
     }

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocEngineWalkEquivalenceTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocEngineWalkEquivalenceTest.kt
@@ -1,0 +1,607 @@
+package com.vreader.app.reader.nav
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.InternalForInheritanceCoroutinesApi
+import kotlinx.coroutines.Job
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.regex.Pattern
+import java.util.regex.PatternSyntaxException
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.startCoroutine
+
+/**
+ * Feature #172 WI-2 — the **differential oracle** for the one-`Matcher` rewrite of
+ * [TxtTocRuleEngine].
+ *
+ * WI-2 replaced Kotlin's `Regex.find()` / `MatchResult.next()` walk with a hand-written walk over a
+ * single `java.util.regex.Matcher` driven by no-arg `find()`, because `next()` constructs a fresh
+ * `Matcher` over the WHOLE input per match and that construction is length-proportional on Android
+ * (6 525 ms → 61 ms on the real book; see the engine's header). The performance claim is held by
+ * `TxtTocScanCostTest#extractionMeetsEngineBudget` on the device.
+ *
+ * **This suite holds the other half: that nothing else changed.** [legacyExtractHeadings] and
+ * [legacyDetectBestRule] below are the PRE-WI-2 bodies, copied verbatim from commit `407c3d5d`, and
+ * every corpus document is run through both implementations with an element-for-element comparison
+ * of `(title, offset)` plus `hitLimit`. If a future edit to the engine changes the match sequence
+ * by one pair, this fails.
+ *
+ * **This is a REGRESSION GUARD, not WI-2's RED.** It passes on both the old and the new engine by
+ * construction — that is the entire point of an oracle. The RED is the connected budget assertion,
+ * which the JVM cannot run (the real 14 MB book is gitignored and not in CI).
+ *
+ * **Why the corpus is shaped the way it is.** The equivalence argument rests on `next()` resuming
+ * at `end + (if (end == start) 1 else 0)` and no-arg `find()` applying the same rule, with
+ * `find(int)`'s extra `reset()` unobservable here. Every clause of that argument gets a document:
+ * zero-width matches (the `end == start` branch), a match at offset 0 and a match ending at the
+ * final character (the boundaries where a resume position can fall off the end), back-to-back
+ * matches (zero gap), an all-headings document and a no-headings document (the two degenerate
+ * walks), plus the terminator, indent, CJK/full-width, surrogate and `limit` families the engine's
+ * own invariants depend on.
+ *
+ * **Real content where it can be** (AGENTS.md "real books first"): the real 14 MB CJK book is not
+ * readable from a JVM unit test, so whole-book equivalence lives in `TxtTocScanCostTest`'s arm
+ * comparison on the device. The documents here are synthetic under the rule's explicit
+ * "deterministic tiny structure" exception — a lone U+2028, an unpaired surrogate and exactly
+ * `limit ± 1` headings are precisely what a 14 MB novel cannot be relied on to contain.
+ *
+ * Pure JVM — no Android runtime, no Robolectric, no emulator.
+ */
+class TxtTocEngineWalkEquivalenceTest {
+
+    private companion object {
+        /** Invisible characters are built from code points — #139's Gate-2 caught them normalised. */
+        val IDEO = Char(0x3000).toString()
+        val NBSP = Char(0x00A0).toString()
+        val NEL = Char(0x0085).toString()
+        val LS = Char(0x2028).toString()
+        val PS = Char(0x2029).toString()
+
+        /** An astral character (U+1F600) as a surrogate pair, and each half alone. */
+        const val HIGH = '\uD83D'
+        const val LOW = '\uDE00'
+        val ASTRAL = "$HIGH$LOW"
+
+        /** `TxtMdTocProvider.SCAN_LIMIT`'s shape; the limit families use small explicit values. */
+        const val BIG_LIMIT = 50_001
+    }
+
+    // ------------------------------------------------------------------ suspend-call harness
+
+    /** See `TxtTocRuleEngineTest.runWithJob` — `startCoroutine` hands the engine the context verbatim. */
+    private fun <T> runWithJob(job: Job, block: suspend () -> T): Result<T> {
+        var outcome: Result<T>? = null
+        block.startCoroutine(Continuation(job) { outcome = it })
+        return requireNotNull(outcome) { "TxtTocRuleEngine must not suspend — it is pure CPU work" }
+    }
+
+    private fun <T> run(block: suspend () -> T): T = runWithJob(Job(), block).getOrThrow()
+
+    /** A [Job] that cancels itself on the query after [activeChecks]. See `TxtTocRuleEngineTest`. */
+    @OptIn(InternalForInheritanceCoroutinesApi::class)
+    private class CancelAfter(
+        private val activeChecks: Int,
+        private val delegate: CompletableJob = Job(),
+    ) : Job by delegate {
+        var checks: Int = 0
+            private set
+
+        override val isActive: Boolean
+            get() {
+                if (checks++ >= activeChecks) delegate.cancel()
+                return delegate.isActive
+            }
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <E : CoroutineContext.Element> get(key: CoroutineContext.Key<E>): E? =
+            if (key == Job) this as E else null
+    }
+
+    // ------------------------------------------------------------------ the PRE-WI-2 engine
+
+    /**
+     * `TxtTocRuleEngine.extractHeadings` **as it was before WI-2**, copied verbatim from commit
+     * `407c3d5d` — Kotlin `Regex.find()` + `MatchResult.next()`, i.e. a fresh `Matcher` per match.
+     *
+     * It lives in the test because production no longer has it, and it must NOT be "kept in sync"
+     * with the engine: the whole value of an oracle is that it is an INDEPENDENT second
+     * implementation. Only the cancellation checks are dropped (this reference is never run under a
+     * cancelling job; the engine's own cadence is asserted separately below and by
+     * `TxtTocRuleEngineTest`).
+     */
+    private fun legacyExtractHeadings(text: String, rule: TxtTocRule, limit: Int): ExtractResult {
+        require(limit > 0) { "limit must be positive, was $limit" }
+        if (text.isEmpty()) return ExtractResult.EMPTY
+        val regex = legacyCompile(rule) ?: return ExtractResult.EMPTY
+
+        val headings = ArrayList<DetectedHeading>()
+        var match = regex.find(text)
+        while (match != null) {
+            val title = match.value.trim()
+            if (title.isNotEmpty()) {
+                headings.add(DetectedHeading(title = title, sourceOffsetUtf16 = match.range.first))
+                if (headings.size == limit) return ExtractResult(headings, hitLimit = true)
+            }
+            match = match.next()
+        }
+        return ExtractResult(headings, hitLimit = false)
+    }
+
+    /** `TxtTocRuleEngine.detectBestRule` as it was before WI-2 (same walk, counting only). */
+    private fun legacyDetectBestRule(text: String, rules: List<TxtTocRule>): TxtTocRule? {
+        if (text.isEmpty()) return null
+        val sample = TxtTocRuleEngine.sampleOf(text)
+        var bestRule: TxtTocRule? = null
+        var bestCount = 0
+        for (rule in rules) {
+            if (!rule.enabled) continue
+            val regex = legacyCompile(rule) ?: continue
+            var count = 0
+            var match = regex.find(sample)
+            while (match != null) {
+                count++
+                match = match.next()
+            }
+            if (count > bestCount) {
+                bestCount = count
+                bestRule = rule
+            }
+        }
+        return if (bestCount >= TxtTocRuleEngine.MIN_MATCHES) bestRule else null
+    }
+
+    private fun legacyCompile(rule: TxtTocRule): Regex? = try {
+        Regex(rule.pattern, RegexOption.MULTILINE)
+    } catch (_: PatternSyntaxException) {
+        null
+    }
+
+    // ------------------------------------------------------------------ corpus
+
+    private class Doc(val name: String, val text: String)
+
+    private fun rule(id: Int) = TxtTocRules.defaults.first { it.id == id }
+
+    /**
+     * A rule that matches EMPTY at every multiline line start.
+     *
+     * This is the corpus's most load-bearing entry and it is a rule rather than a document: a
+     * zero-width match is the ONLY case where `next()`'s resume arithmetic differs from a plain
+     * "continue at `end`", so it is the one place the two walks could legally diverge into an
+     * infinite loop or a skipped position. Every match trims to `""`, so it also drives the
+     * empty-title drop on every single position.
+     */
+    private val zeroWidthRule = TxtTocRule(
+        id = 990, enabled = true, name = "zero-width", pattern = "^",
+        example = "", serialNumber = 990,
+    )
+
+    /** Zero-width, but only where a line start is followed by an indent character. */
+    private val zeroWidthIndentRule = TxtTocRule(
+        id = 991, enabled = true, name = "zero-width-indent", pattern = "^[ $IDEO\\t]{0,4}",
+        example = "  ", serialNumber = 991,
+    )
+
+    /** Matches a whitespace-only line — a NON-empty match whose title trims to `""`. */
+    private val blankTitleRule = TxtTocRule(
+        id = 992, enabled = true, name = "blank-title", pattern = "^[ $IDEO\\t]{1,4}$",
+        example = "  ", serialNumber = 992,
+    )
+
+    /** A pattern `java.util.regex` rejects — both engines must skip it identically. */
+    private val uncompilableRule = TxtTocRule(
+        id = 993, enabled = true, name = "broken", pattern = "^[unclosed",
+        example = "n/a", serialNumber = 993,
+    )
+
+    /** Matches every line that has any content — the "document is entirely headings" driver. */
+    private val everyLineRule = TxtTocRule(
+        id = 994, enabled = true, name = "every-line", pattern = "^.{1,30}$",
+        example = "x", serialNumber = 994,
+    )
+
+    private val extraRules = listOf(
+        zeroWidthRule, zeroWidthIndentRule, blankTitleRule, uncompilableRule, everyLineRule,
+    )
+
+    /**
+     * Every rule the oracle runs: all 25 shipped rules (disabled ones included — `extractHeadings`
+     * never looks at `enabled`, so a disabled rule is still a live extraction path) plus the five
+     * synthetic ones that reach behaviours no shipped rule can.
+     */
+    private val allRules: List<TxtTocRule> = TxtTocRules.defaults + extraRules
+
+    private fun corpus(): List<Doc> = listOf(
+        // ---- degenerate ----
+        Doc("empty", ""),
+        Doc("single-newline", "\n"),
+        Doc("no-matches-at-all", "just prose\nmore prose\nand more\n"),
+        Doc("whitespace-only", "   \n$IDEO$IDEO\n\t\n"),
+
+        // ---- boundaries: offset 0, final character, back-to-back ----
+        Doc("match-at-offset-zero", "第一章 甲\nprose\n"),
+        Doc("match-ends-at-final-char-no-terminator", "prose\n第一章 甲"),
+        Doc("match-is-the-whole-document", "第一章 甲"),
+        Doc("back-to-back-matches", "第一章 甲\n第二章 乙\n第三章 丙\n"),
+        Doc("back-to-back-no-trailing-terminator", "第一章 甲\n第二章 乙\n第三章 丙"),
+        Doc("entirely-headings", (1..40).joinToString("\n") { "第${it}章 标题$it" } + "\n"),
+        Doc("single-char", "x"),
+        Doc("terminator-at-eof-only", "第一章 甲\n\n\n"),
+
+        // ---- terminator families (Java regex line terminators, all six) ----
+        Doc("lf", "第一章 甲\n第二章 乙\n"),
+        Doc("crlf", "第一章 甲\r\n第二章 乙\r\n"),
+        Doc("lone-cr", "第一章 甲\r第二章 乙\r"),
+        Doc("cr-at-eof", "第一章 甲\r"),
+        Doc("crlf-split-across-matches", "第一章 甲\r\n\r\n第二章 乙\r\n"),
+        Doc("nel", "第一章 甲${NEL}第二章 乙$NEL"),
+        Doc("line-separator-u2028", "第一章 甲${LS}第二章 乙$LS"),
+        Doc("paragraph-separator-u2029", "第一章 甲${PS}第二章 乙$PS"),
+        Doc("mixed-terminators", "第一章 甲\r\n第二章 乙\n第三章 丙\r第四章 丁${NEL}第五章 戊$LS"),
+        Doc("blank-lines-between", "第一章 甲\n\n\n第二章 乙\n\n"),
+
+        // ---- indentation ----
+        Doc("indent-0-to-4", (0..4).joinToString("\n") { " ".repeat(it) + "第${it + 1}章 标题" } + "\n"),
+        Doc("indent-5-too-deep", "     第一章 甲\n第二章 乙\n"),
+        // NOTE: `${…}` braces are mandatory around every interpolation followed by a CJK character
+        // — a Kotlin identifier may CONTAIN CJK, so `"$IDEO第一章"` parses as one unresolved name.
+        Doc("indent-ideographic", "${IDEO}${IDEO}第一章 甲\n"),
+        Doc("indent-tab", "\t\t第一章 甲\n"),
+        Doc("indent-nbsp-not-in-class", "${NBSP}第一章 甲\n第二章 乙\n"),
+        Doc("indent-mixed", " $IDEO\t 第一章 甲\n"),
+
+        // ---- CJK / full-width / the D1 + D1b repairs ----
+        Doc("full-width-digits", "第１２章 标题\n第１３章 标题\n"),
+        Doc("financial-numerals", "第壹章 甲\n第贰章 乙\n第拾伍章 丙\n"),
+        Doc("ideographic-space-separators", "第${IDEO}一${IDEO}章 标题\n第${IDEO}二${IDEO}章 标题\n"),
+        Doc("cross-terminator-heading", "第\n一\n章 标题\nprose\n"),
+        Doc("cjk-prose-with-headings", "第一章 开始\n他说：“走吧。”\n第二章 结束\n夜色渐深。\n"),
+        Doc("english-chapters", "Chapter 1 The Start\nprose\nchapter 22 The End\n"),
+        Doc("numbered-punctuated", "1、这个标题\n2. Another\n30：第三\n"),
+        Doc("symbol-headings", "【第一章 标题】\n★ 第二章\n◆ 第三章\n"),
+
+        // ---- surrogates ----
+        Doc("astral-line-starts", "$ASTRAL 第一章 甲\n$ASTRAL 第二章 乙\n"),
+        Doc("astral-in-title-tail", "第一章 甲$ASTRAL\n第二章 乙$ASTRAL\n"),
+        Doc("lone-high-surrogate", "${HIGH}第一章 甲\n$HIGH\n第二章 乙\n"),
+        Doc("lone-low-surrogate", "${LOW}第一章 甲\n$LOW\n第二章 乙\n"),
+        Doc("astral-only", ASTRAL),
+        Doc("astral-at-eof", "第一章 甲\n$ASTRAL"),
+
+        // ---- limit families (small documents; the limits are applied per-document below) ----
+        Doc("exactly-five-headings", (1..5).joinToString("\n") { "第${it}章 标题" } + "\n"),
+        Doc(
+            "five-headings-with-blank-title-matches",
+            "  \n第一章 甲\n  \n第二章 乙\n  \n第三章 丙\n  \n第四章 丁\n  \n第五章 戊\n  \n",
+        ),
+    )
+
+    /**
+     * The limits each document is walked at.
+     *
+     * `BIG_LIMIT` is the production shape (walk to end-of-text). 1 and 2 exercise a `limit`
+     * early-return on almost every document. 4/5/6 straddle the five-heading documents, so the
+     * `limit − 1` / `limit` / `limit + 1` boundary is covered with `hitLimit` differing across it.
+     */
+    private val limits = listOf(BIG_LIMIT, 1, 2, 4, 5, 6)
+
+    // ------------------------------------------------------------------ the oracle
+
+    /**
+     * The whole claim, in one test: for every (document, rule, limit), the new engine emits exactly
+     * the sequence the pre-WI-2 walk emitted.
+     *
+     * Divergences are reported at the first differing pair with the document, rule and limit named,
+     * because "expected 12 headings, got 11" on a 45 × 30 × 6 sweep is not a diagnosis.
+     */
+    @Test
+    fun newWalkEmitsTheIdenticalTitleAndOffsetSequenceAsTheLegacyWalk() {
+        var comparisons = 0
+        var pairsCompared = 0
+        for (doc in corpus()) {
+            for (rule in allRules) {
+                for (limit in limits) {
+                    val expected = legacyExtractHeadings(doc.text, rule, limit)
+                    val actual = run { TxtTocRuleEngine.extractHeadings(doc.text, rule, limit) }
+                    val where = "doc='${doc.name}' rule=${rule.id} limit=$limit"
+
+                    assertEquals(
+                        "$where — heading COUNT diverged",
+                        expected.headings.size, actual.headings.size,
+                    )
+                    assertEquals("$where — hitLimit diverged", expected.hitLimit, actual.hitLimit)
+                    expected.headings.forEachIndexed { i, want ->
+                        val got = actual.headings[i]
+                        assertEquals("$where — heading $i TITLE diverged", want.title, got.title)
+                        assertEquals(
+                            "$where — heading $i OFFSET diverged (title '${want.title}')",
+                            want.sourceOffsetUtf16, got.sourceOffsetUtf16,
+                        )
+                        assertEquals("$where — heading $i DEPTH diverged", want.depth, got.depth)
+                    }
+                    comparisons++
+                    pairsCompared += expected.headings.size
+                }
+            }
+        }
+        // The oracle must not be vacuous: a corpus that produced no headings anywhere would pass
+        // every assertion above and prove nothing.
+        assertTrue("the sweep must actually run", comparisons > 1_000)
+        assertTrue("the sweep must actually COMPARE headings, not just empty lists", pairsCompared > 1_000)
+    }
+
+    /** Detection walks the same matches too — `countMatches` was rewritten with the same shape. */
+    @Test
+    fun detectionPicksTheIdenticalRuleAsTheLegacyWalk() {
+        var nonNullDetections = 0
+        for (doc in corpus()) {
+            val expected = legacyDetectBestRule(doc.text, TxtTocRules.defaults)
+            val actual = run { TxtTocRuleEngine.detectBestRule(doc.text, TxtTocRules.defaults) }
+            assertEquals("doc='${doc.name}' — detected rule diverged", expected?.id, actual?.id)
+            if (actual != null) nonNullDetections++
+
+            // Again with the synthetic rules in the list, so the zero-width and uncompilable paths
+            // participate in detection's tie-breaking too.
+            val expectedAll = legacyDetectBestRule(doc.text, allRules)
+            val actualAll = run { TxtTocRuleEngine.detectBestRule(doc.text, allRules) }
+            assertEquals(
+                "doc='${doc.name}' (all rules) — detected rule diverged",
+                expectedAll?.id, actualAll?.id,
+            )
+        }
+        assertTrue(
+            "the detection sweep must actually detect something, or it proves nothing",
+            nonNullDetections > 5,
+        )
+    }
+
+    // ------------------------------------------------------------------ the oracle is not vacuous
+
+    /**
+     * A walk that is correct EXCEPT for one named property — the shape of every plausible mistake
+     * the WI-2 rewrite could have made in the loop body.
+     */
+    private enum class Mutation { OFFSET_IS_MATCH_END, NO_EMPTY_TITLE_DROP, UNTRIMMED_TITLE, TRUNCATE_AFTER_COLLECTING }
+
+    /** The new walk with exactly one property broken, for the corpus-discrimination proof below. */
+    private fun mutatedWalk(text: String, rule: TxtTocRule, limit: Int, how: Mutation): ExtractResult {
+        require(limit > 0)
+        if (text.isEmpty()) return ExtractResult.EMPTY
+        val pattern = try {
+            Pattern.compile(rule.pattern, Pattern.MULTILINE)
+        } catch (_: PatternSyntaxException) {
+            return ExtractResult.EMPTY
+        }
+        val headings = ArrayList<DetectedHeading>()
+        val m = pattern.matcher(text)
+        while (m.find()) {
+            val raw = m.group()
+            val title = if (how == Mutation.UNTRIMMED_TITLE) raw else raw.trim()
+            val offset = if (how == Mutation.OFFSET_IS_MATCH_END) m.end() else m.start()
+            if (title.isNotEmpty() || how == Mutation.NO_EMPTY_TITLE_DROP) {
+                headings.add(DetectedHeading(title = title, sourceOffsetUtf16 = offset))
+                if (how != Mutation.TRUNCATE_AFTER_COLLECTING && headings.size == limit) {
+                    return ExtractResult(headings, hitLimit = true)
+                }
+            }
+        }
+        if (how == Mutation.TRUNCATE_AFTER_COLLECTING && headings.size > limit) {
+            return ExtractResult(headings.take(limit), hitLimit = true)
+        }
+        return ExtractResult(headings, hitLimit = false)
+    }
+
+    /**
+     * **Proof that the sweep above is not vacuous.**
+     *
+     * An oracle whose corpus cannot distinguish a wrong implementation is decoration. Each
+     * [Mutation] is a walk that differs from the engine in exactly one named way; every one of them
+     * must be CAUGHT by some (document, rule, limit) in the corpus. If a mutation ever survives,
+     * the corpus has a hole and the equality asserted above is weaker than it looks.
+     *
+     * The failure message names the mutation that got through, not just "a test failed".
+     */
+    @Test
+    fun theCorpusDiscriminatesEveryPlausiblyWrongWalk() {
+        for (how in Mutation.entries) {
+            var caughtBy: String? = null
+            outer@ for (doc in corpus()) {
+                for (rule in allRules) {
+                    for (limit in limits) {
+                        val want = legacyExtractHeadings(doc.text, rule, limit)
+                        val got = mutatedWalk(doc.text, rule, limit, how)
+                        if (want != got) {
+                            caughtBy = "doc='${doc.name}' rule=${rule.id} limit=$limit"
+                            break@outer
+                        }
+                    }
+                }
+            }
+            assertTrue(
+                "the corpus does NOT distinguish the '$how' walk from the correct one — it has a " +
+                    "hole, so the equivalence sweep is weaker than it appears",
+                caughtBy != null,
+            )
+        }
+    }
+
+    /**
+     * The one mutation [mutatedWalk] cannot express, because it would not terminate: resuming at
+     * `end` with no `+1` after an EMPTY match.
+     *
+     * This is the single clause of the equivalence argument that "just continue where you stopped"
+     * does not give you for free, so it gets its own bounded demonstration: the naive resume spins
+     * on offset 0 forever, while Java's own `find()` walks the real line starts.
+     */
+    @Test
+    fun theZeroWidthResumeRuleIsLoadBearing() {
+        val text = "a\nb\r\nc\rd${NEL}e"
+        val naive = ArrayList<Int>()
+        val m = Pattern.compile("^", Pattern.MULTILINE).matcher(text)
+        var from = 0
+        var steps = 0
+        while (steps++ < 8 && m.find(from)) {
+            naive.add(m.start())
+            from = m.end() // the bug: an empty match leaves `from` exactly where it was
+        }
+        assertEquals("the naive resume must indeed spin on one position", List(8) { 0 }, naive)
+
+        val real = ArrayList<Int>()
+        val m2 = Pattern.compile("^", Pattern.MULTILINE).matcher(text)
+        while (m2.find()) real.add(m2.start())
+        assertEquals(
+            "no-arg find() must advance past an empty match to the next line start",
+            javaMultilineLineStarts(text), real,
+        )
+        assertNotEquals("and that is not what the naive resume produces", real.take(8), naive)
+    }
+
+    /**
+     * The zero-width rule must TERMINATE and must visit every line start exactly once.
+     *
+     * `find()` on an empty match advances by one code unit; if the rewrite had lost that, the walk
+     * would spin forever at offset 0 and this test would hang rather than fail. It is asserted
+     * against an independently computed expectation (Java's `^` positions) rather than against the
+     * legacy walk, so it stands even if the legacy reference were itself wrong.
+     */
+    @Test
+    fun zeroWidthMatchesTerminateAndVisitEveryLineStart() {
+        val text = "a\nb\r\nc\rd${NEL}e${LS}f${PS}g"
+        val expectedLineStarts = javaMultilineLineStarts(text)
+        assertTrue("the fixture must have several line starts", expectedLineStarts.size >= 7)
+
+        // Every zero-width match trims to "", so extraction emits NOTHING — the visible proof that
+        // the walk terminated is that this returns at all, with the empty-title drop intact.
+        val extracted = run { TxtTocRuleEngine.extractHeadings(text, zeroWidthRule, BIG_LIMIT) }
+        assertEquals("a zero-width match trims to empty and must be dropped", 0, extracted.headings.size)
+        assertTrue("dropping every match is not hitting the limit", !extracted.hitLimit)
+
+        // The positions themselves are checked through detection's counting walk, which does not
+        // drop anything: it must count exactly one match per Java `^` position.
+        val counting = TxtTocRule(995, true, "count-zero-width", "^", "", 995)
+        val detected = run { TxtTocRuleEngine.detectBestRule(text, listOf(counting)) }
+        assertEquals("a rule matching every line start must be detected", 995, detected?.id)
+
+        val legacy = legacyExtractHeadings(text, zeroWidthRule, BIG_LIMIT)
+        assertEquals("legacy and new agree that everything is dropped", 0, legacy.headings.size)
+    }
+
+    /** Java's MULTILINE `^` positions: index 0, or after a terminator, never inside CRLF, never at EOF. */
+    private fun javaMultilineLineStarts(text: String): List<Int> {
+        if (text.isEmpty()) return emptyList()
+        val out = ArrayList<Int>()
+        out.add(0)
+        var i = 0
+        while (i < text.length) {
+            val c = text[i]
+            val isTerminator = c == '\n' || c == '\r' || c == Char(0x0085) ||
+                c == Char(0x2028) || c == Char(0x2029)
+            if (isTerminator) {
+                var next = i + 1
+                if (c == '\r' && next < text.length && text[next] == '\n') next++
+                if (next < text.length) out.add(next)
+                i = next
+            } else {
+                i++
+            }
+        }
+        return out
+    }
+
+    // ------------------------------------------------------------------ preserved semantics
+
+    /**
+     * The `limit` early-return still stops the SCAN, and empty titles still cost nothing against it.
+     *
+     * Both are properties of the loop body WI-2 rewrote, and both are exactly the kind of thing a
+     * "just swap the iterator" edit silently loses.
+     */
+    @Test
+    fun limitAndEmptyTitleSemanticsAreUnchanged() {
+        val text = "  \n第一章 甲\n  \n第二章 乙\n  \n第三章 丙\n  \n"
+        val r = rule(1)
+
+        val underLimit = run { TxtTocRuleEngine.extractHeadings(text, r, 4) }
+        assertEquals("three headings, blank lines dropped and not counted", 3, underLimit.headings.size)
+        assertTrue("under the limit means hitLimit is false", !underLimit.hitLimit)
+
+        val atLimit = run { TxtTocRuleEngine.extractHeadings(text, r, 3) }
+        assertEquals(3, atLimit.headings.size)
+        assertTrue("reaching the limit must be reported", atLimit.hitLimit)
+
+        val belowLimit = run { TxtTocRuleEngine.extractHeadings(text, r, 2) }
+        assertEquals(2, belowLimit.headings.size)
+        assertTrue(belowLimit.hitLimit)
+
+        // The legacy walk agrees on all three.
+        listOf(4, 3, 2).forEach { limit ->
+            val want = legacyExtractHeadings(text, r, limit)
+            val got = run { TxtTocRuleEngine.extractHeadings(text, r, limit) }
+            assertEquals("limit=$limit count", want.headings.size, got.headings.size)
+            assertEquals("limit=$limit hitLimit", want.hitLimit, got.hitLimit)
+        }
+
+        assertTrue(
+            "a non-positive limit must still be rejected",
+            runCatching { run { TxtTocRuleEngine.extractHeadings(text, r, 0) } }
+                .exceptionOrNull() is IllegalArgumentException,
+        )
+    }
+
+    /** An uncompilable pattern still degrades to "no Contents", never a crash — both engines. */
+    @Test
+    fun uncompilablePatternStillDegradesToEmpty() {
+        val text = "第一章 甲\n第二章 乙\n"
+        val extracted = run { TxtTocRuleEngine.extractHeadings(text, uncompilableRule, BIG_LIMIT) }
+        assertEquals(0, extracted.headings.size)
+        assertTrue(!extracted.hitLimit)
+        assertEquals(
+            legacyExtractHeadings(text, uncompilableRule, BIG_LIMIT).headings.size,
+            extracted.headings.size,
+        )
+        // And detection skips it rather than failing the whole pass.
+        val detected = run { TxtTocRuleEngine.detectBestRule(text, listOf(uncompilableRule, rule(1))) }
+        assertEquals(1, detected?.id)
+    }
+
+    /**
+     * The cancellation cadence survived the rewrite.
+     *
+     * Not a comparison against the legacy walk (the reference above deliberately has no checks) but
+     * against the engine's own documented contract: one check at entry, one every
+     * `CANCELLATION_CHECK_INTERVAL` matches EXAMINED, and one after the loop so a cancel during the
+     * final `find()` is not swallowed.
+     */
+    @Test
+    fun cancellationCadenceIsUnchanged() {
+        val text = (1..40).joinToString("\n") { "第${it}章 标题$it" } + "\n"
+
+        val alreadyCancelled = Job().apply { cancel() }
+        val atEntry = runWithJob(alreadyCancelled) {
+            TxtTocRuleEngine.extractHeadings(text, rule(1), BIG_LIMIT)
+        }
+        assertTrue("an already-cancelled scope must not run the scan", atEntry.isFailure)
+        assertTrue(atEntry.exceptionOrNull() is CancellationException)
+
+        // The entry check passes; the post-loop check is the next query and must cancel there.
+        val duringFinalStep = CancelAfter(activeChecks = 1)
+        val late = runWithJob(duringFinalStep) {
+            TxtTocRuleEngine.extractHeadings(text, rule(1), BIG_LIMIT)
+        }
+        assertTrue("a cancel during the final scan step must not be swallowed", late.isFailure)
+        assertTrue(late.exceptionOrNull() is CancellationException)
+
+        // Detection: entry check, then one before each rule.
+        val betweenRules = CancelAfter(activeChecks = 1)
+        val detection = runWithJob(betweenRules) {
+            TxtTocRuleEngine.detectBestRule(text, TxtTocRules.defaults)
+        }
+        assertTrue("detection must stay cancellation-cooperative", detection.isFailure)
+        assertTrue(detection.exceptionOrNull() is CancellationException)
+    }
+
+}

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocEngineWalkEquivalenceTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocEngineWalkEquivalenceTest.kt
@@ -204,8 +204,50 @@ class TxtTocEngineWalkEquivalenceTest {
         example = "x", serialNumber = 994,
     )
 
+    /**
+     * A LOOKBEHIND rule — a construct that reads text BEFORE the match start.
+     *
+     * The equivalence argument claims `find(int)`'s extra `reset()` is unobservable because no
+     * region is ever set. Lookbehind is where that claim would break if it were wrong: with
+     * non-transparent bounds (the default, and what `reset()` restores) a lookbehind cannot see
+     * outside the REGION — and the region is the whole text in both walks, so it sees everything
+     * either way. Sweeping it proves that rather than asserting it.
+     */
+    private val lookbehindRule = TxtTocRule(
+        id = 996, enabled = true, name = "lookbehind", pattern = "(?<=\\n)第[一二三四五]章.{0,10}$",
+        example = "第一章", serialNumber = 996,
+    )
+
+    /**
+     * `$` alone — a zero-width match at every line END, INCLUDING end-of-input.
+     *
+     * A zero-width match at the very last position is the boundary where a resume position can
+     * legally run off the end of the input: Kotlin's `next()` computes `end + 1` and returns null
+     * when that exceeds the length, while no-arg `find()` reaches the same conclusion internally.
+     * They must agree, and this is the rule that makes them prove it.
+     */
+    private val endAnchorRule = TxtTocRule(
+        id = 997, enabled = true, name = "end-anchor", pattern = "$",
+        example = "", serialNumber = 997,
+    )
+
+    /**
+     * The EMPTY pattern — matches empty at EVERY code-unit position, including between the two
+     * halves of a surrogate pair.
+     *
+     * This is the strongest available probe of empty-match advancement: both walks advance by one
+     * CODE UNIT, so on the corpus's astral documents they must step through a surrogate pair
+     * identically. (Nothing is emitted — every title trims to `""` — so its value is entirely in
+     * the walk agreeing, and in the walk terminating at all.)
+     */
+    private val emptyPatternRule = TxtTocRule(
+        id = 998, enabled = true, name = "empty-pattern", pattern = "",
+        example = "", serialNumber = 998,
+    )
+
     private val extraRules = listOf(
         zeroWidthRule, zeroWidthIndentRule, blankTitleRule, uncompilableRule, everyLineRule,
+        lookbehindRule, endAnchorRule, emptyPatternRule,
     )
 
     /**
@@ -396,17 +438,26 @@ class TxtTocEngineWalkEquivalenceTest {
     }
 
     /**
-     * **Proof that the sweep above is not vacuous.**
+     * **Proof that the sweep above is not vacuous — for the four LOOP-BODY mistakes named in
+     * [Mutation], and only those.**
      *
-     * An oracle whose corpus cannot distinguish a wrong implementation is decoration. Each
-     * [Mutation] is a walk that differs from the engine in exactly one named way; every one of them
-     * must be CAUGHT by some (document, rule, limit) in the corpus. If a mutation ever survives,
-     * the corpus has a hole and the equality asserted above is weaker than it looks.
+     * An oracle whose corpus cannot distinguish a wrong implementation is decoration, so each
+     * [Mutation] — a walk differing from the correct one in exactly one named way — must be CAUGHT
+     * by some (document, rule, limit) in the corpus. If one ever survives, the corpus has a hole.
+     *
+     * **What this does NOT prove** (Gate-4 R1 Low, stated rather than implied by the name): it says
+     * nothing about RESUME-STATE mistakes, because a walk that resumes wrongly either does not
+     * terminate or is not expressible as a one-line variant of the loop body. Those are covered
+     * elsewhere and deliberately: empty-match advancement by
+     * [theZeroWidthResumeRuleIsLoadBearing], zero-width matches at end-of-input and across a
+     * surrogate pair by [emptyPatternRule] and [endAnchorRule] in the main sweep, lookbehind across
+     * the resume point by [lookbehindRule], and `\G` — the ONE construct under which the two walks
+     * genuinely differ — by [noShippedRuleUsesAResumeSensitiveConstruct].
      *
      * The failure message names the mutation that got through, not just "a test failed".
      */
     @Test
-    fun theCorpusDiscriminatesEveryPlausiblyWrongWalk() {
+    fun theCorpusDiscriminatesTheFourLoopBodyMistakes() {
         for (how in Mutation.entries) {
             var caughtBy: String? = null
             outer@ for (doc in corpus()) {
@@ -512,6 +563,36 @@ class TxtTocEngineWalkEquivalenceTest {
         return out
     }
 
+    /**
+     * **The equivalence's one genuine precondition, guarded mechanically.**
+     *
+     * `\G` ("where the previous match ended") is the single regex construct that can OBSERVE how a
+     * walk resumes, and it is the one place the two walks are not interchangeable: the legacy walk
+     * called `find(from)` on a fresh matcher with `from = end + 1` after an EMPTY match, so its
+     * `\G` anchored at `end + 1`, while a reused matcher's no-arg `find()` anchors at `end`. No
+     * shipped rule uses it, which is exactly why the rewrite is safe — so that precondition is
+     * asserted here rather than left as a comment nobody re-checks.
+     *
+     * If someone adds a `\G` rule, this fails and points at the engine header's decision block
+     * instead of shipping a silent behaviour change on a pattern nobody thought about.
+     *
+     * Lookbehind and the bounds flags are deliberately NOT guarded: they are resume-INsensitive
+     * (the region is the whole text in both walks and `useTransparentBounds` / `useAnchoringBounds`
+     * are never called, so `reset()` restores values that were already the defaults), and the
+     * main sweep runs [lookbehindRule] to demonstrate it rather than argue it.
+     */
+    @Test
+    fun noShippedRuleUsesAResumeSensitiveConstruct() {
+        val offenders = TxtTocRules.defaults.filter { it.pattern.contains("\\G") }
+        assertEquals(
+            "a rule using \\G would observe WHERE the walk resumed, which is the one property the " +
+                "one-Matcher rewrite (feature #172 WI-2) does not preserve — see TxtTocRuleEngine's " +
+                "header before adding one: $offenders",
+            emptyList<TxtTocRule>(), offenders,
+        )
+        assertEquals("the guard must have inspected the real rule set", 25, TxtTocRules.defaults.size)
+    }
+
     // ------------------------------------------------------------------ preserved semantics
 
     /**
@@ -569,17 +650,53 @@ class TxtTocEngineWalkEquivalenceTest {
     }
 
     /**
-     * The cancellation cadence survived the rewrite.
+     * The cancellation cadence survived the rewrite — including the INTERVAL branch, counted.
      *
      * Not a comparison against the legacy walk (the reference above deliberately has no checks) but
      * against the engine's own documented contract: one check at entry, one every
      * `CANCELLATION_CHECK_INTERVAL` matches EXAMINED, and one after the loop so a cancel during the
      * final `find()` is not swallowed.
+     *
+     * **The document is sized to REACH the interval branch** (Gate-4 R1 Medium): an earlier revision
+     * used a 40-match fixture, which never gets past the entry and post-loop checks, so it would
+     * have passed with the whole `sinceCheck` block deleted. This one produces
+     * `2 × CANCELLATION_CHECK_INTERVAL + 953` matches, and every one of them has an EMPTY title —
+     * so it also discriminates "per match EXAMINED" from "per heading EMITTED": zero headings are
+     * emitted, and if the counter had been moved onto emissions the observed check count would be 2
+     * instead of 4.
      */
     @Test
     fun cancellationCadenceIsUnchanged() {
+        val interval = TxtTocRuleEngine.CANCELLATION_CHECK_INTERVAL
+        val blankMatches = 2 * interval + 953
+        val blanks = "  \n".repeat(blankMatches)
         val text = (1..40).joinToString("\n") { "第${it}章 标题$it" } + "\n"
 
+        // --- the cadence itself, counted on a job that never cancels ---
+        val counting = CancelAfter(activeChecks = Int.MAX_VALUE)
+        val walked = runWithJob(counting) {
+            TxtTocRuleEngine.extractHeadings(blanks, blankTitleRule, BIG_LIMIT)
+        }.getOrThrow()
+        assertEquals("every match's title trims to empty, so nothing is emitted", 0, walked.headings.size)
+        assertEquals(
+            "expected 1 entry check + ${blankMatches / interval} interval checks + 1 post-loop check " +
+                "over $blankMatches EXAMINED matches; a per-EMITTED-heading cadence would give 2",
+            1 + blankMatches / interval + 1, counting.checks,
+        )
+
+        // --- and it is genuinely a CANCELLATION point, not just a query ---
+        val cancelAtInterval = CancelAfter(activeChecks = 1) // entry passes; the interval check cancels
+        val interrupted = runWithJob(cancelAtInterval) {
+            TxtTocRuleEngine.extractHeadings(blanks, blankTitleRule, BIG_LIMIT)
+        }
+        assertTrue("a cancel at the interval check must propagate", interrupted.isFailure)
+        assertTrue(interrupted.exceptionOrNull() is CancellationException)
+        assertEquals(
+            "the scan must stop AT the interval check, not run to completion and report later",
+            2, cancelAtInterval.checks,
+        )
+
+        // --- entry, post-loop, and detection ---
         val alreadyCancelled = Job().apply { cancel() }
         val atEntry = runWithJob(alreadyCancelled) {
             TxtTocRuleEngine.extractHeadings(text, rule(1), BIG_LIMIT)
@@ -587,7 +704,7 @@ class TxtTocEngineWalkEquivalenceTest {
         assertTrue("an already-cancelled scope must not run the scan", atEntry.isFailure)
         assertTrue(atEntry.exceptionOrNull() is CancellationException)
 
-        // The entry check passes; the post-loop check is the next query and must cancel there.
+        // 40 matches never reach the interval, so here the next query IS the post-loop check.
         val duringFinalStep = CancelAfter(activeChecks = 1)
         val late = runWithJob(duringFinalStep) {
             TxtTocRuleEngine.extractHeadings(text, rule(1), BIG_LIMIT)
@@ -602,6 +719,17 @@ class TxtTocEngineWalkEquivalenceTest {
         }
         assertTrue("detection must stay cancellation-cooperative", detection.isFailure)
         assertTrue(detection.exceptionOrNull() is CancellationException)
+
+        // Detection's counting walk has the same interval cadence — the countMatches rewrite.
+        val countingDetection = CancelAfter(activeChecks = Int.MAX_VALUE)
+        runWithJob(countingDetection) {
+            TxtTocRuleEngine.detectBestRule(blanks, listOf(blankTitleRule))
+        }.getOrThrow()
+        assertTrue(
+            "countMatches must check cancellation DURING the count, not only around it " +
+                "(${countingDetection.checks} checks over $blankMatches matches)",
+            countingDetection.checks >= 2 + blankMatches / interval,
+        )
     }
 
 }

--- a/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocEngineWalkEquivalenceTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/reader/nav/TxtTocEngineWalkEquivalenceTest.kt
@@ -252,8 +252,8 @@ class TxtTocEngineWalkEquivalenceTest {
 
     /**
      * Every rule the oracle runs: all 25 shipped rules (disabled ones included — `extractHeadings`
-     * never looks at `enabled`, so a disabled rule is still a live extraction path) plus the five
-     * synthetic ones that reach behaviours no shipped rule can.
+     * never looks at `enabled`, so a disabled rule is still a live extraction path) plus the eight
+     * synthetic ones in [extraRules], which reach behaviours no shipped rule can.
      */
     private val allRules: List<TxtTocRule> = TxtTocRules.defaults + extraRules
 
@@ -374,6 +374,108 @@ class TxtTocEngineWalkEquivalenceTest {
         // every assertion above and prove nothing.
         assertTrue("the sweep must actually run", comparisons > 1_000)
         assertTrue("the sweep must actually COMPARE headings, not just empty lists", pairsCompared > 1_000)
+    }
+
+    /**
+     * The two resume strategies agree on the RAW match offsets — including the ones
+     * [newWalkEmitsTheIdenticalTitleAndOffsetSequenceAsTheLegacyWalk] structurally cannot see.
+     *
+     * **Why this exists** (Gate-4 R2 Medium). [emptyPatternRule] and [endAnchorRule] match
+     * zero-width — inside a surrogate pair, at end-of-input — and every such match trims to `""`,
+     * so `extractHeadings` DROPS it. The sweep above therefore compares two empty lists on exactly
+     * the positions those rules were added to cover: a walk that skipped the inside-a-surrogate
+     * position would pass it. The claim was real but the observation was not.
+     *
+     * So this test drops below the engine and compares the two strategies themselves:
+     *
+     *  - [legacyResumeOffsets] — a FRESH `Matcher` per match with `find(from)`, `from = end + (if
+     *    end == start) 1 else 0`, stopping when `from` exceeds the length. That is
+     *    `MatcherMatchResult.next()` transcribed.
+     *  - [newResumeOffsets] — ONE `Matcher`, `while (find())`. That is what the engine now does.
+     *
+     * Every offset is compared, dropped or not. The invisible positions are additionally asserted
+     * to be PRESENT, so the coverage claim is checked rather than assumed.
+     */
+    @Test
+    fun theTwoResumeStrategiesAgreeOnRawOffsetsIncludingTheInvisibleOnes() {
+        var swept = 0
+        for (doc in corpus()) {
+            for (rule in allRules) {
+                val pattern = try {
+                    Pattern.compile(rule.pattern, Pattern.MULTILINE)
+                } catch (_: PatternSyntaxException) {
+                    continue
+                }
+                val legacy = legacyResumeOffsets(pattern, doc.text)
+                val new = newResumeOffsets(pattern, doc.text)
+                assertEquals(
+                    "doc='${doc.name}' rule=${rule.id} — the two resume strategies found a " +
+                        "different NUMBER of raw matches",
+                    legacy.size, new.size,
+                )
+                legacy.forEachIndexed { i, want ->
+                    assertEquals(
+                        "doc='${doc.name}' rule=${rule.id} — raw match $i starts at a different offset",
+                        want, new[i],
+                    )
+                }
+                swept++
+            }
+        }
+        assertTrue("the raw sweep must actually run", swept > 1_000)
+
+        // The two positions the emitted-output sweep cannot see, asserted directly.
+        val astral = Pattern.compile(emptyPatternRule.pattern, Pattern.MULTILINE)
+        val insidePair = newResumeOffsets(astral, ASTRAL).toList()
+        assertEquals(
+            "an empty pattern must match at EVERY code unit of a surrogate pair, i.e. advancement " +
+                "is by code UNIT — if either strategy advanced by code POINT they would diverge here",
+            listOf(0, 1, 2), insidePair,
+        )
+        assertEquals(
+            "and the legacy strategy must agree on that interior position",
+            insidePair, legacyResumeOffsets(astral, ASTRAL).toList(),
+        )
+
+        val eofDoc = "第一章 甲"
+        val dollar = Pattern.compile(endAnchorRule.pattern, Pattern.MULTILINE)
+        val eofOffsets = newResumeOffsets(dollar, eofDoc).toList()
+        assertTrue(
+            "a bare \$ must produce a zero-width match AT end-of-input (offset ${eofDoc.length}), " +
+                "which is the boundary where a resume position can run off the end: $eofOffsets",
+            eofOffsets.contains(eofDoc.length),
+        )
+        assertEquals(
+            "and the legacy strategy must agree at end-of-input",
+            eofOffsets, legacyResumeOffsets(dollar, eofDoc).toList(),
+        )
+    }
+
+    /** `MatcherMatchResult.next()` transcribed: a FRESH matcher per match, resumed with `find(from)`. */
+    private fun legacyResumeOffsets(pattern: Pattern, text: String): IntArray {
+        val out = ArrayList<Int>()
+        val cap = 2 * text.length + 16 // a non-advancing walk must FAIL, never hang the suite
+        var from = 0
+        while (from <= text.length) {
+            assertTrue("the legacy resume strategy failed to advance", out.size <= cap)
+            val m = pattern.matcher(text)
+            if (!m.find(from)) break
+            out.add(m.start())
+            from = m.end() + if (m.end() == m.start()) 1 else 0
+        }
+        return out.toIntArray()
+    }
+
+    /** What the engine now does: ONE matcher, advanced by its own no-arg `find()`. */
+    private fun newResumeOffsets(pattern: Pattern, text: String): IntArray {
+        val out = ArrayList<Int>()
+        val cap = 2 * text.length + 16
+        val m = pattern.matcher(text)
+        while (m.find()) {
+            assertTrue("the new resume strategy failed to advance", out.size <= cap)
+            out.add(m.start())
+        }
+        return out.toIntArray()
     }
 
     /** Detection walks the same matches too — `countMatches` was rewritten with the same shape. */
@@ -725,10 +827,11 @@ class TxtTocEngineWalkEquivalenceTest {
         runWithJob(countingDetection) {
             TxtTocRuleEngine.detectBestRule(blanks, listOf(blankTitleRule))
         }.getOrThrow()
-        assertTrue(
-            "countMatches must check cancellation DURING the count, not only around it " +
-                "(${countingDetection.checks} checks over $blankMatches matches)",
-            countingDetection.checks >= 2 + blankMatches / interval,
+        assertEquals(
+            "detection's cadence is EXACTLY 1 entry + 1 per rule + ${blankMatches / interval} " +
+                "interval checks inside countMatches + 1 post-loop; asserting only a lower bound " +
+                "would permit an over-checking regression (Gate-4 R2 Low)",
+            1 + 1 + blankMatches / interval + 1, countingDetection.checks,
         )
     }
 

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.20.23
-versionCode=176
+versionName=0.20.24
+versionCode=177

--- a/dev-docs/plans/20260805-feature-172-android-toc-scan-perf.md
+++ b/dev-docs/plans/20260805-feature-172-android-toc-scan-perf.md
@@ -600,7 +600,12 @@ tests:
 gate:
   # BOTH commands are the WI-2 gate. The JVM command alone would NOT execute the declared RED,
   # which is a connected test — a gate that cannot run its own RED is not a gate (Gate-2 R1 HIGH).
-  - ANDROID_CMD="./gradlew :app:testDebugUnitTest --rerun-tasks --tests '*TxtToc*' --tests '*MdTocScanner*'" scripts/run-android-tests.sh
+  # CORRECTED (WI-2, 2026-08-05): '*TxtToc*' does NOT match TxtMdTocProviderTest — the class is
+  # TxtMdTocProvider*, not TxtToc*. As originally written this gate SILENTLY OMITTED one of the five
+  # suites it requires to pass unmodified. WI-2's lane ran the declared command verbatim AND this
+  # superset; use the superset from WI-3 onward. A gate that quietly skips a required suite is worse
+  # than a missing gate, because it reports green.
+  - ANDROID_CMD="./gradlew :app:testDebugUnitTest --rerun-tasks --tests '*TxtToc*' --tests '*MdTocScanner*' --tests '*TxtMdTocProvider*'" scripts/run-android-tests.sh
   - ANDROID_SERIAL=emulator-5554 ANDROID_CMD="./gradlew :app:connectedDebugAndroidTest --rerun-tasks -Pandroid.testInstrumentationRunnerArguments.class=com.vreader.app.reader.nav.TxtTocScanCostTest" scripts/run-android-tests.sh
 acceptance: >
   The connected RED (extractionMeetsEngineBudget) is RED on the pre-WI-2 engine and GREEN after —


### PR DESCRIPTION
## Summary

One `java.util.regex.Matcher` per scan, advanced by **no-arg `find()`**. A ~10-line production change worth **~107×**.

Part of feature #2043 (#172). Foundational WI.

## Result — orchestrator-reproduced on a fresh run

| | before | after |
|---|---|---|
| `extractHeadings` (real 14 MB CJK book) | **6,525 ms** | **61 ms** |
| process-PSS Δ | **+1,099,187 KB** | **+14,004 KB** |
| connected RED `extractionMeetsEngineBudget` | **7,111 ms — FAILED** | **83 ms — PASSED** (300 ms budget) |

**The structural corroboration is the convincing part**: in the same run, `a_shipped_ms=61` and `b1_reused_ms=58`. The shipped engine now measures the same as WI-1's independently-written reused-`Matcher` reference — not a timing claim, but evidence the engine performs exactly the arm-(b) walk.

## Root cause

Kotlin's `MatchResult.next()` calls `Pattern.matcher(input)` — a **fresh `Matcher` over the whole 7,029,609-char text per match**, ×1,859. On API 35 that construction+reset is **length-proportional**, making the scan O(matches × text length).

**The `find(int)` trap, priced.** `reset` is the expensive half and `find(int)` resets on every call — arm (h) measured `find(int) − find()` at 1.7–2.1 ms/op. A reused `Matcher` driven by `find(int)` would cost **~3,200 ms**: it looks like the fix, and still misses the budget.

## The budget discriminates against the wrong fix

**300 ms** = ~5× arm (b)'s measured 58–62 ms (absorbing emulator load, the in-band `Pattern.compile` the engine pays and arm (b) does not — measured 48–51 µs — and two cancellation checks), while sitting **>10× below the ~3,160 ms floor of the plausible wrong fix** and 21× below the shipped 6,525 ms.

So the assertion actively fails a `find(int)` implementation rather than merely passing the right one. The statistic is min-of-3 with early break on success **and** on a >5× blowout — a pass that far over is not a noise question, and repeating it risks the lowmemorykiller at ~1.4 GB RSS.

## Behaviour is pinned, not assumed

`TxtTocEngineWalkEquivalenceTest` is a differential oracle against the **verbatim pre-WI-2 walk** over a 45-document × 33-rule × 6-limit sweep.

**Non-vacuity proved by mutation**: four one-property-wrong walks — offset at match end, no empty-title drop, untrimmed title, truncate-after-collecting instead of stopping the scan — are each *required* to be caught, and the test names any mutation that survives.

**Gate-4 round 2 caught that round 1's "strengthening" was half-real**: the zero-width rules added there match inside a surrogate pair and at end-of-input, but every such match trims to empty and is dropped — so the emitted-output sweep was comparing two empty lists exactly at the interesting positions. Fixed by comparing the two resume *strategies* at raw-offset level across the whole corpus, with the invisible positions asserted present (`[0,1,2]` across a surrogate pair proves advancement is by code unit; a bare `$` matching at `text.length` proves the end-of-input boundary).

**Five suites pass UNMODIFIED**: `TxtTocRuleEngineTest` 46, `TxtTocRulesTest` 21, `TxtMdTocProviderTest` 26, `TxtTocIndexTest` 15, `MdTocScannerTest` 44 — **174 JVM tests, 0 failures** on the orchestrator's superset run.

## Rule 22 — the note that stops this being reverted

The engine header now records, in its `Key decisions` block, that the walk is hand-written **and why**, ending with *"DO NOT 'modernise' IT BACK"*, the mechanism, arm (h)'s numbers, and the test that holds the line. Without it a future cleanup reverts a 107× fix in the name of idiom, and nothing in the suite would obviously object.

It also records the **one construct where old and new walks genuinely differ** — `\G` (the old walk anchored it at `end+1` after an empty match, the new one at `end`) — guarded mechanically by `noShippedRuleUsesAResumeSensitiveConstruct`. That is the honest boundary of an equivalence the rest of the repo will otherwise treat as total.

## Plan defect found and fixed in this PR

The WI-2 spec's JVM gate `--tests '*TxtToc*'` **does not match `TxtMdTocProviderTest`** (the class is `TxtMdTocProvider*`), so the declared command **silently omitted one of the five suites it requires**. The lane ran the declared command verbatim *and* a superset; the plan's gate line is corrected here for WI-3 onward.

A gate that quietly skips a required suite is worse than a missing gate, because it reports green.

## Validation

- JVM superset re-run by the orchestrator: **174 tests / 0 failures**.
- Connected re-run by the orchestrator with `--rerun-tasks` (76/76 tasks executed): **6 tests / 0 failures**, `ENGINE-BUDGET best_ms=83`.
- Gate-4 Codex audit: 3 rounds, **`ship-as-is`**, zero open Critical/High/Medium.
- Write-set: exactly the 4 declared paths. `TxtTocRuleEngine.kt` is 248 lines — no production file grew.
- Version bumped: `android/v0.20.23` → `android/v0.20.24`.

## Accepted Low

The oracle file is 838 lines vs the ~300 guidance; sibling suites here run 624–1,207 lines by precedent, and splitting the reference implementation from the corpus that discriminates it would be worse.

## Type of Change

- [x] Feature WI (part of feature #2043)
