### PR TITLE
feat(#164 WI-2): DiagnosticsRedactor — scanner replaces the non-converging regex grammar

### DIFF
--- a/.claude/codex-audits/feat-164-wi-2b-redactor-scanner-audit.md
+++ b/.claude/codex-audits/feat-164-wi-2b-redactor-scanner-audit.md
@@ -1,0 +1,157 @@
+---
+branch: feat/164-wi-2b-redactor-scanner
+threadId: 019fcef0-b770-7e11-b2dd-1264781377ee
+rounds: 3
+final_verdict: ship-as-is
+date: 2026-08-05
+---
+
+# Codex Audit Log — Feature #164 WI-2b (DiagnosticsRedactor scanner redesign)
+
+Redesign of the keyed-value half of `DiagnosticsRedactor` from a 13-rule regex
+grammar into a hand-written left-to-right scanner with an explicit quote state
+machine. This function is the ONLY barrier between a captured Android logcat
+entry and a user-initiated share-sheet / clipboard export.
+
+## Scope of audit
+
+- `android/app/src/main/kotlin/com/vreader/app/diagnostics/DiagnosticsRedactor.kt`
+- `android/app/src/test/kotlin/com/vreader/app/diagnostics/DiagnosticsRedactorTest.kt`
+
+Each round's prompt asked the auditor to **construct** a credential-bearing log
+line that survives redaction, rather than to comment generically — that is how
+every real defect in this WI (and in the abandoned regex predecessor) was found.
+Accepted, documented decisions were listed as out of scope each round so the
+auditor spent its budget on new ground: the bare-opaque-secret non-goal, the
+deleted entropy heuristic, unredacted book titles/filenames, and the file's
+length (~150 of its lines are the security rationale header; the lane's
+write-set forbids splitting into a new file).
+
+Runner: `scripts/run-codex.sh` (rule 53). Full transcripts in `.reports/audit-r{1,2,3}.txt`.
+
+## Round 1 — thread `019fcee4-9e81-7a71-b935-a86c8fa16f17` — VERDICT: block-recommended
+
+Two High findings, each with a constructed survivor, and three Mediums.
+
+| # | Severity | Finding | Resolution |
+| - | -------- | ------- | ---------- |
+| 1 | High | `state={\"password\":\"abc\\\"SUFFIX\"}` leaked `SUFFIX`. A boolean "is the opener escaped" cannot distinguish a structural close (`\"`) from a quote inside the value (`\\\"`), so the scan ended early. | FIXED. `closingQuote()` takes `openRun` — the backslash-run length before the OPENING quote — and closes only on a quote whose preceding run is exactly `openRun`. A longer run is value content; no matching close fails closed to end of line. |
+| 2 | High | `state={\\\"password\\\":\\\"TOPSECRET123\\\"}` survived ENTIRELY. The separator run required a backslash run of exactly one before a quote, so a double-serialized dump never reached the assignment check. | FIXED. The separator run consumes a backslash run of ANY length followed by a quote and records its length. |
+| 3 | High | `Dump{password=abc},USABLE-SUFFIX` leaked `USABLE-SUFFIX`. A closing bracket followed by `,` was treated as proof the dump ended — but `},SUFFIX` is a legal password character sequence. | FIXED. `closesTheDump()` accepts a trailing `,`/`;` only when `nextKeyFollows()` confirms a real next key/value pair. |
+| 4 | Medium | `"(".repeat(n) + "password=" + "x)".repeat(n)` was quadratic: bracket state was an `ArrayDeque` and `contains()` is linear in depth, while the value body never pops. | FIXED. Bracket state is an `IntArray(3)` of counters. Pinned by `linear_deepBracketNestingInAnUnquotedValue` (n=50 000). |
+| 5 | Medium | `/storage/<FAT-volume-id>` (an SD-card import failure, carrying the user's own folder names) was redacted only when it arrived as a `file://` URL. | FIXED. `PATH_ROOT_ANY` gained `/storage/XXXX-XXXX`, `/mnt/expand/<uuid>`, `/mnt/media_rw`, `/mnt/runtime/<x>`, `/data/misc_{ce,de}/<n>`, all shape-bounded so prose beginning `/storage/` is not swallowed. |
+| 6 | Medium | Unrestricted identifier-suffix matching destroyed real diagnostics: `deauthorization=true`, `compassphrase=enabled`. | PARTIALLY ACCEPTED, then closed in round 2. See below. |
+
+### Finding 6 — the argued half
+
+The word-boundary rule was applied to `authorization` **only**, and the position
+was put to the auditor explicitly in round 2 rather than asserted. Rationale:
+`authorization` is the one credential word with a real English superstring AND
+its class consumes the rest of the line, whereas `dbpassword` / `userpassword` /
+`oldSecret` are plausible lowercase third-party field names — for the sole egress
+barrier a missed credential costs more than an over-redacted contrived
+identifier. Round 2 was asked to disprove this by naming a REAL non-credential
+identifier ending in one of the unrestricted words. It did (see below), and that
+half was then fixed. Both directions are test-pinned
+(`negative_englishSuperstringsOfAuthorizationSurvive`,
+`lowercaseCompoundCredentialKeys_areStillRedacted`).
+
+## Round 2 — thread `019fceec-f1d9-7681-82e4-51090a35e324` — VERDICT: follow-up-recommended
+
+All six round-1 fixes independently re-traced and confirmed to hold, including
+the `from` bound in `closingQuote()`'s run counter (leading backslashes can only
+lengthen a candidate run, so the failure mode is over-redaction, never a leak).
+No new credential survivor. Zero Critical/High/Medium.
+
+One **Low**, and it produced the counter-example round 1's rationale had claimed
+did not exist: Android package-signing diagnostics and JVM tooling emit
+`methodSignature=` / `packageSignature=` / `typeSignature=`, none of which
+authenticate anything, and the unrestricted `signature` suffix redacted them.
+
+FIXED in `a8a0a25f`: `signature` moved out of `TOKEN_WORDS` into its own branch,
+gated by `SIGNATURE_NON_CREDENTIAL` as a **DENY**-list (via
+`qualified(..., allowEmpty = false)`) rather than an allow-list — so an
+unrecognised `*signature` still redacts. `sig=`, `X-Amz-Signature=`,
+`awsSignature=`, `httpSignature=` and a bare HTTP-Signature `signature=` all
+remain covered. Pinned by `negative_nonCredentialSignatureIdentifiersSurvive`.
+
+Adversarial cases the auditor tried and could not break: three-plus
+serialization layers; mixed escaped/raw quotes; one quote character "closed" by
+the other; CRLF and lone-CR line endings; a newline inside an unquoted SPACED
+value; CJK/RTL-adjacent keys; the `Authorization` scheme-skip followed by a tab
+or multiple spaces.
+
+## Round 3 — thread `019fcef0-b770-7e11-b2dd-1264781377ee` — VERDICT: ship-as-is
+
+**No findings at Critical, High, Medium or Low.** The auditor re-traced the
+`signature` deny-list (confirming `X-Amz-Signature` prefix `X-Amz` matches no
+deny qualifier, and that an empty prefix under `allowEmpty = false` correctly
+falls through to "credential"), confirmed `a8a0a25f` introduces neither
+super-linear behaviour nor new over-redaction, and stated plainly that it could
+not construct a credential-bearing input that survives whole or leaves a usable
+suffix outside the accepted residuals.
+
+Its closing position: it would ship this as the diagnostics export's sole egress
+redaction barrier, provided the documented complementary controls — the `VLog`
+seam and the WI-3 raw-`android.util.Log` containment check — remain enforced.
+
+## Mutation discipline (16 mutations, 16 killed, 0 shadowed)
+
+Run against the GREEN implementation in five batches, each chosen so every
+mutation had at least one uniquely-attributed named test. No branch was
+unkillable — the predecessor lane found two shadowed rules that hid real gaps,
+and this pass looked specifically for that shape.
+
+| Mutation | Killed by (uniquely) |
+| -------- | -------------------- |
+| escaped-quote separator branch disabled | `survivor2_escapedJsonAuthorizationContainer`, `quoted_nestedJsonDumpWithEscapedStructuralQuotes` |
+| escape-aware close disabled | `quoted_escapedQuoteInsideValue_doesNotTerminateEarly` |
+| `qualified()` always true | `negative_nonCredentialTokenIdentifiersSurvive`, `negative_nonCredentialKeyIdentifiersSurvive` |
+| AUTH structural-container requirement dropped | `negative_proseAfterAnAuthSchemeWordSurvives` |
+| fail-closed quoting → decline | `survivor3_quotedValueContainingTheOtherQuote`, `quoted_truncatedClosingQuote_failsClosedToEndOfLine`, `oracle_aPartialRedactionIsRejected…` |
+| stop at EVERY `,`/`&`/`;` (drop next-key gate) | `survivor4_unquotedValueContainingStructuralCharacters` |
+| assignment (`:`/`=`) requirement dropped | `negative_keyWordWithoutAnAssignmentSeparatorSurvives`, `negative_nonCredentialTokenIdentifiersSurvive` |
+| separator run capped at `{0,8}` (the regex's width) | `survivor1_arbitrarilyLongSeparatorRunBeforeAScheme` |
+| `AUTH_SCHEMES` emptied | `auth_serializedJsonHeader`, `auth_webDavBasicHeader`, `auth_proxyAuthorization` |
+| TOKEN whitespace stop removed | `unquoted_signedRedirectUrl`, `unquoted_anthropicXApiKeyHeader`, `unquoted_tokenValueStopsAtWhitespace` |
+| next-key delimiter never fires | `unquoted_spacedValueRunsPast…`, `unquoted_serializedEntityDump`, `unquoted_queryStringApiKey`, `unquoted_entityDumpWithPlainAndEncrypted` |
+| `closesTheDump()` refinement dropped | `survivor4_unquotedValueContainingStructuralCharacters` |
+| bracket-closer stop removed entirely | `auth_bracketedAndPairContainers`, `auth_allLetterAndShortCredentials` |
+| `sk-` rule disabled | `shape_bareOpenAiKeyWithNoKeyName`, `shape_cjkAdjacentKeyIsStillRedacted` |
+| JWT rule disabled | `shape_bareJwt_isRedacted` |
+| URL-userinfo rule disabled | all four `url_*` |
+| app-books path rule disabled | `path_appBooksPath…`, `path_fileUrlToAnAppBook…` |
+| `file://` rule disabled | `path_genericFileUrl…` |
+| `content://` rule disabled | `path_safContentUri…` |
+| generic path rule disabled | `path_multiUser…`, `path_legacyDataData…`, `path_sharedStorage…`, `path_directoryNameWithASpace…`, `path_spaceHeuristicResidual…` |
+
+## Can idempotency mask a partial redaction?
+
+Yes — which is why it is not relied on. Survivor 3's pre-fix output
+(`password=‹redacted›'BrienNeverClose`) was a FIXED POINT of `redact()`, so the
+idempotency assertion could not see it. The oracle therefore adds a **per-suffix
+absence** assertion: for every secret, no suffix of length ≥ 4 may survive. That
+is the exact shape of a partial redaction. `oracle_idempotencyIsNotACompletenessOracle`
+pins the point directly, using the accepted bare-secret non-goal as a witness: a
+string that is idempotent under `redact()` and still contains the secret.
+
+The suffix oracle also caught two of my own fixtures whose secrets ended in
+`word` — the surviving key name `password` contains it. Those fixtures were
+changed rather than the assertion weakened.
+
+## Residuals — stated, not hidden
+
+1. **Bare opaque secret, no key / container / shape** — not redacted. Accepted
+   non-goal (a `SecretCipher` token is `base64(iv‖ct)` with no framing; the only
+   rule that catches it also swallows every content hash, Room row id and
+   `fingerprintKey`). Controls: the `VLog` seam and WI-3's containment check.
+2. **An unquoted SPACED value literally containing `, <identifier>=`** is
+   truncated there. This is the price of preserving `wifiOnly=true` in every
+   `toString()`; no lexical rule separates the two.
+3. **An unrecognised `Authorization` scheme** consumes the rest of the line.
+4. **A value ending in a backslash, or whose closing quote is many lines later**,
+   over-redacts — the safe direction.
+5. **A bare `signature=<cert>`** loses that one token; keeping it a credential is
+   the safe side, since an HTTP-Signature header spells its credential that way.
+6. **Lowercase compound non-credential identifiers** ending in a credential word
+   (`compassphrase`) over-redact, deliberately — see finding 6.

--- a/android/app/src/main/kotlin/com/vreader/app/diagnostics/DiagnosticsRedactor.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/diagnostics/DiagnosticsRedactor.kt
@@ -1,0 +1,427 @@
+package com.vreader.app.diagnostics
+
+/**
+ * Purpose: Feature #164 WI-2 — scrubs credentials, tokens and filesystem paths out of a captured
+ * log message before it can leave the device. Pure and idempotent.
+ *
+ * Threat model — on Android this is the ONLY barrier. iOS has a first line of defence in OSLog's
+ * `privacy:` annotations (a `.private` interpolation reads back as `<private>`), so its redactor is
+ * defence in depth. Android's logcat is PLAINTEXT: every byte the app or any library logs sits in
+ * the ring buffer verbatim, so this function is load-bearing. It is written to be called at EVERY
+ * egress — the export payload AND the viewer's "copy entry" clipboard write (WI-4 / WI-6a).
+ *
+ * Strategy — CONTEXT-ANCHORED. Nothing is redacted on shape or entropy alone; every branch is
+ * anchored on a label the app actually writes (a key name, an `Authorization` header, a URL scheme,
+ * a path root). Two deliberate non-strategies: it does NOT blanket-redact long hex/base64 runs
+ * (that swallows content hashes, fingerprint keys and row ids — the handles every bug report is
+ * filed against), and it does NOT use an entropy heuristic. One was tried and DELETED after failing
+ * in BOTH directions across two audit rounds: it missed a real all-letter `OpdsClient` Basic token
+ * and over-redacted `Basic SHA256withRSA2048`.
+ *
+ * WHY A SCANNER, NOT A REGEX (the WI-2b redesign). The keyed-value half was first built as 13
+ * regex rules. Three audit rounds went 4 High → 3 High → 4 NEW High: each fix moved a boundary and
+ * the next input class walked around it. The diagnosis: **a regex cannot delimit an unquoted or
+ * partially-quoted credential value, because the delimiter depends on QUOTE STATE, not on a
+ * character class.** The four survivors — an over-wide separator run, an escaped-JSON container, a
+ * quoted value containing the other quote character, and an unquoted value containing a structural
+ * character — are all instances of that one fact. [scanKeyedValues] is therefore a single
+ * left-to-right pass with an explicit quote state machine; the pattern-shaped rules that were never
+ * holed (`sk-`, JWT, URL userinfo, path roots) stay regexes in [SHAPE_RULES].
+ *
+ * Key decisions:
+ * - **Separator runs are UNBOUNDED, and an escaped quote is a separator.** The regex container was
+ *   `{0,8}` wide, so `Authorization:` + 10 spaces + `Bearer …` fell through every rule; and it
+ *   excluded `\`, so the real `state={\"Authorization\":\"Basic …\"}` dump survived entirely. The
+ *   run consumes `\"` pairs and remembers the last quote as the OPENING quote.
+ * - **A quoted value runs to its MATCHING close, honouring backslash escapes, and FAILS CLOSED to
+ *   end of line when there is none** (logd truncates at 4068 bytes, cutting the quote off exactly
+ *   where a credential sits). Never to the first embedded quote: that produced
+ *   `password=‹redacted›'BrienNeverClose`, a partial redaction STABLE under re-redaction, so the
+ *   idempotency assertions could not see it.
+ * - **The unquoted-value delimiter policy is a decision, not a character class.** Keys split by
+ *   whether the value can contain a space. An API key / signature / bearer token travels in an HTTP
+ *   header or query string where a raw space is ILLEGAL, so [Kind.TOKEN] stops at whitespace and
+ *   `-> HTTP 401` survives. A password / passphrase / `authHeader` can contain anything, so
+ *   [Kind.SPACED] runs to END OF LINE and stops early ONLY at a structural character that is
+ *   *demonstrably a field boundary*: a `,`/`&`/`;` followed by a new `identifier[:=]`, or a bracket
+ *   closing an opener seen before the key that is itself followed by the end of the dump. The trade
+ *   is asymmetric ON PURPOSE — a wider delimiter set leaks less credential but destroys more
+ *   same-line context, and this is the sole egress barrier, so it prefers SAFETY:
+ *   `password=foo,bar` redacts whole, while `password=x, wifiOnly=true` keeps `wifiOnly=true`
+ *   because the comma provably starts another field.
+ * - **`Authorization` is a key in its own right** needing only a structural container (`:`, `=`,
+ *   `,`, `]`, `)`) — `headers[Authorization]=Basic x` and `Pair(Authorization, Basic x)` are neither
+ *   `key: value`. Every OTHER key requires a `:` or `=`, which keeps "the session token was
+ *   refreshed successfully" intact. A recognised scheme (`Bearer`/`Basic`) survives as context;
+ *   an unrecognised one consumes the rest of the LINE, because a Digest credential is spread across
+ *   comma-separated parameters and anything less leaks `response=`.
+ * - **Key names match as an identifier SUFFIX**, covering the camel-case fields this codebase
+ *   persists (`encryptedApiKey`, `encryptedPassword`, `authHeader`) where the iOS `api[_-]?key`
+ *   alternation misses them. `token` and `key` are QUALIFIER-GATED: ~70 non-credential
+ *   `*Token`/`*Key` identifiers exist here (`activeToken`, `maxTokens`, `fingerprintKey`) whose
+ *   redaction would destroy real diagnostics.
+ * - Boundaries are explicit ASCII, never `\b` — Java's `\b` is Unicode-aware while `\w` is ASCII,
+ *   so `\bsk-…` silently FAILS in `前sk-proj-…`. The fingerprint-key path exception is pinned to
+ *   THIS app's applicationId and a terminal single segment (`filesDir/books/<fingerprintKey>`); if
+ *   `applicationIdSuffix` is ever introduced, [PATH_ROOT_APP_BOOKS] must be widened with it. A space
+ *   joins a path only when the next token still holds a `/`, which swallows an intermediate
+ *   directory name while keeping a trailing exception class.
+ *
+ * Known limitations (accepted, NOT mitigated — do not read this as coverage):
+ * - A BARE-VALUE opaque secret, with no key name, no `Authorization` container and no `sk-`/JWT
+ *   shape, is NOT redacted. A `SecretCipher` token is `base64(iv ‖ ciphertext)` with no prefix,
+ *   length field or magic — structurally identical to a hash, a row id or a thumbnail — so only one
+ *   of the two non-strategies above would catch it. The complementary controls are the `VLog` seam,
+ *   WI-3's `android.util.Log` containment check, and a typed secret wrapper a logging API cannot
+ *   accept (named follow-up).
+ * - An unquoted SPACED value whose text contains `, <identifier>=` (or the dump's closing bracket
+ *   followed by end-of-line) is truncated there, leaking the remainder. Preserving `wifiOnly=true`
+ *   in every `toString()` costs exactly this; no lexical rule can tell the two apart.
+ * - An unrecognised `Authorization` scheme consumes the rest of the line, so same-line text after
+ *   such a header is lost. A quoted value whose closing quote appears many lines later
+ *   over-redacts to that quote (the safe direction).
+ * - Book titles and filenames are NOT redacted (parity with iOS #96) — redacting them would gut the
+ *   export's diagnostic value, since most import/reader failures name the book.
+ *
+ * @coordinates-with DiagnosticsLogStore.kt (export egress, WI-4), the viewer's copy-entry action
+ */
+object DiagnosticsRedactor {
+
+    const val PLACEHOLDER = "‹redacted›"
+    const val PATH_PLACEHOLDER = "‹path›"
+
+    /**
+     * Scrubs [message] for safe egress.
+     *
+     * Idempotent — `redact(redact(x)) == redact(x)` — because every replacement is either an
+     * acceptable match for the branch that produced it (rewriting the placeholder to itself) or
+     * cannot match any branch at all. Idempotency is NOT a completeness oracle: see the test suite's
+     * `oracle_idempotencyIsNotACompletenessOracle`.
+     */
+    fun redact(message: String): String {
+        if (message.isEmpty()) return message
+        var out = scanKeyedValues(message)
+        for (rule in SHAPE_RULES) out = rule.apply(out)
+        return out
+    }
+
+    // ============================================================== key classification
+
+    /** How far an unquoted value for this key class may run. */
+    private enum class Kind { TOKEN, SPACED, AUTH, LINE }
+
+    /** Keys whose value MAY contain spaces (a passphrase; an `authHeader` is `<scheme> <token>`). */
+    private val SPACED_WORDS = listOf(
+        "password", "passwd", "passphrase", "secret", "credential",
+        "authheader", "auth_header", "auth-header",
+    )
+
+    /** Keys whose value is a single whitespace-free token. */
+    private val TOKEN_WORDS = listOf("apikey", "api_key", "api-key", "signature", "sig")
+
+    /** `*token` is a credential only behind these qualifiers — see the class doc. */
+    private val TOKEN_QUALIFIERS = listOf(
+        "auth", "access", "refresh", "bearer", "session", "id", "api", "sas", "csrf", "xsrf",
+        "encrypted",
+    )
+
+    /** `*key` likewise — a bare `key=` is a cache handle, `fingerprintKey` is a bug-report handle. */
+    private val KEY_QUALIFIERS = listOf(
+        "api", "secret", "private", "access", "encrypted", "signing", "auth",
+    )
+
+    private val AUTH_SCHEMES = listOf("Bearer", "Basic")
+
+    private fun classify(id: String): Kind? {
+        val lower = id.lowercase()
+        if (lower.endsWith("authorization")) return Kind.AUTH
+        SPACED_WORDS.forEach { if (lower.endsWith(it)) return Kind.SPACED }
+        TOKEN_WORDS.forEach { if (lower.endsWith(it)) return Kind.TOKEN }
+        if (lower.endsWith("token") && qualified(id, id.length - 5, TOKEN_QUALIFIERS, true)) {
+            return Kind.TOKEN
+        }
+        if (lower.endsWith("key") && qualified(id, id.length - 3, KEY_QUALIFIERS, false)) {
+            return Kind.TOKEN
+        }
+        return null
+    }
+
+    /**
+     * True when the identifier text before [cut] ends with one of [quals] at a word boundary —
+     * position 0, after a `_`/`-`, or at a camelCase hump. The boundary check is what keeps
+     * `validToken` (`val` + `id`) and `PaginationToken` out while admitting `x-auth-token`.
+     */
+    private fun qualified(id: String, cut: Int, quals: List<String>, allowEmpty: Boolean): Boolean {
+        var p = id.substring(0, cut)
+        while (p.isNotEmpty() && (p.last() == '_' || p.last() == '-')) p = p.dropLast(1)
+        if (p.isEmpty()) return allowEmpty
+        val lower = p.lowercase()
+        for (q in quals) {
+            if (!lower.endsWith(q)) continue
+            val at = p.length - q.length
+            if (at == 0) return true
+            val before = p[at - 1]
+            if (before == '_' || before == '-') return true
+            if (p[at].isUpperCase() && before.isLowerCase()) return true
+        }
+        return false
+    }
+
+    // ============================================================== the scanner
+
+    private fun isIdentChar(c: Char): Boolean =
+        c in 'a'..'z' || c in 'A'..'Z' || c in '0'..'9' || c == '_' || c == '-'
+
+    private fun isIdentStart(c: Char): Boolean =
+        c in 'a'..'z' || c in 'A'..'Z' || c == '_' || c == '-'
+
+    private fun opener(closer: Char): Char = when (closer) {
+        ')' -> '('
+        ']' -> '['
+        else -> '{'
+    }
+
+    /**
+     * One left-to-right pass. Every maximal ASCII identifier run is classified once; a credential
+     * key hands off to [findValue], and the returned span is replaced by [PLACEHOLDER]. No
+     * backtracking anywhere, so the cost is linear in the message length.
+     */
+    private fun scanKeyedValues(text: String): String {
+        val out = StringBuilder(text.length + 16)
+        val open = ArrayDeque<Char>()
+        var i = 0
+        while (i < text.length) {
+            val c = text[i]
+            if (isIdentStart(c) && (i == 0 || !isIdentChar(text[i - 1]))) {
+                var j = i
+                while (j < text.length && isIdentChar(text[j])) j++
+                val kind = classify(text.substring(i, j))
+                val span = if (kind == null) null else findValue(text, j, kind, open)
+                if (span != null) {
+                    for (k in i until span.first) track(text[k], open)
+                    out.append(text, i, span.first).append(PLACEHOLDER)
+                    i = span.second
+                } else {
+                    out.append(text, i, j)
+                    i = j
+                }
+                continue
+            }
+            track(c, open)
+            out.append(c)
+            i++
+        }
+        return out.toString()
+    }
+
+    private fun track(c: Char, open: ArrayDeque<Char>) {
+        when (c) {
+            '\n' -> open.clear()
+            '(', '[', '{' -> open.addLast(c)
+            ')', ']', '}' -> if (open.isNotEmpty() && open.last() == opener(c)) open.removeLast()
+        }
+    }
+
+    /**
+     * Given a credential key ending at [pos], returns the half-open span of its VALUE, or null when
+     * the text is not a credential assignment after all.
+     */
+    private fun findValue(text: String, pos: Int, kind: Kind, open: ArrayDeque<Char>): Pair<Int, Int>? {
+        var k = pos
+        var sawAssign = false
+        var sawStructural = false
+        var quote = '\u0000'
+        var quoteEscaped = false
+        loop@ while (k < text.length) {
+            val c = text[k]
+            when {
+                c == ' ' || c == '\t' || c == '\r' -> k++
+                c == ':' || c == '=' -> { sawAssign = true; sawStructural = true; quote = '\u0000'; k++ }
+                // A container comma/bracket only counts BEFORE the assignment; afterwards it is the
+                // start of the next field, and consuming it would redact that field's value.
+                (c == ',' || c == ']' || c == ')' || c == '}') && !sawAssign ->
+                    { sawStructural = true; quote = '\u0000'; k++ }
+                c == '"' || c == '\'' -> { quote = c; quoteEscaped = false; k++ }
+                c == '\\' && k + 1 < text.length && (text[k + 1] == '"' || text[k + 1] == '\'') ->
+                    { quote = text[k + 1]; quoteEscaped = true; k += 2 }
+                else -> break@loop
+            }
+        }
+        if (k == pos) return null
+        if (kind == Kind.AUTH) {
+            if (!sawStructural) return null
+        } else if (!sawAssign) return null
+
+        var start = k
+        var end = if (quote != '\u0000') {
+            closingQuote(text, k, quote, quoteEscaped) ?: lineEnd(text, k)
+        } else {
+            -1
+        }
+        var effective = kind
+        if (kind == Kind.AUTH) {
+            val afterScheme = schemeEnd(text, start, if (end >= 0) end else lineEnd(text, start))
+            if (afterScheme > 0) {
+                start = afterScheme
+                effective = Kind.TOKEN
+            } else {
+                effective = Kind.LINE
+            }
+        }
+        if (end < 0) end = unquotedEnd(text, start, effective, open)
+        return if (end <= start) null else start to end
+    }
+
+    /** Index just past a recognised scheme word plus its trailing spaces, or -1. */
+    private fun schemeEnd(text: String, start: Int, limit: Int): Int {
+        for (scheme in AUTH_SCHEMES) {
+            val after = start + scheme.length
+            if (after >= limit) continue
+            if (!text.regionMatches(start, scheme, 0, scheme.length, ignoreCase = true)) continue
+            if (text[after] != ' ' && text[after] != '\t') continue
+            var k = after
+            while (k < limit && (text[k] == ' ' || text[k] == '\t')) k++
+            if (k < limit) return k
+        }
+        return -1
+    }
+
+    /** Index of the matching close quote, honouring backslash escapes; null when unbalanced. */
+    private fun closingQuote(text: String, from: Int, quote: Char, escaped: Boolean): Int? {
+        var k = from
+        if (!escaped) {
+            while (k < text.length) {
+                when {
+                    text[k] == '\\' -> k += 2
+                    text[k] == quote -> return k
+                    else -> k++
+                }
+            }
+        } else {
+            while (k + 1 < text.length) {
+                if (text[k] == '\\') {
+                    if (text[k + 1] == quote) return k
+                    k += 2
+                } else {
+                    k++
+                }
+            }
+        }
+        return null
+    }
+
+    private fun lineEnd(text: String, from: Int): Int {
+        val nl = text.indexOf('\n', from)
+        return if (nl < 0) text.length else nl
+    }
+
+    /** The unquoted-value terminator policy — see the class doc's "delimiter policy" decision. */
+    private fun unquotedEnd(text: String, start: Int, kind: Kind, open: ArrayDeque<Char>): Int {
+        var k = start
+        while (k < text.length) {
+            val c = text[k]
+            if (c == '\n') return k
+            if (kind == Kind.TOKEN && (c == ' ' || c == '\t' || c == '\r')) return k
+            if ((c == ')' || c == ']' || c == '}') && open.contains(opener(c)) && closesTheDump(text, k + 1)) {
+                return k
+            }
+            // NOT for [Kind.LINE]: a Digest credential IS a comma-separated parameter list, so
+            // honouring a field boundary there would leak `response=…`.
+            if (kind != Kind.LINE && (c == ',' || c == '&' || c == ';') && nextKeyFollows(text, k + 1)) {
+                return k
+            }
+            k++
+        }
+        return text.length
+    }
+
+    /** True when nothing but the end of the dump follows — the bracket really terminated a field. */
+    private fun closesTheDump(text: String, from: Int): Boolean {
+        var k = from
+        while (k < text.length && (text[k] == ' ' || text[k] == '\t')) k++
+        if (k >= text.length) return true
+        val c = text[k]
+        return c == '\n' || c == ')' || c == ']' || c == '}' || c == ',' || c == ';'
+    }
+
+    /** True when `[quote] identifier [quote] [:=]` follows — i.e. a genuinely new key/value pair. */
+    private fun nextKeyFollows(text: String, from: Int): Boolean {
+        var k = from
+        while (k < text.length && (text[k] == ' ' || text[k] == '\t')) k++
+        if (k < text.length && text[k] == '\\') k++
+        if (k < text.length && (text[k] == '"' || text[k] == '\'')) k++
+        if (k >= text.length || !isIdentStart(text[k])) return false
+        while (k < text.length && (isIdentChar(text[k]) || text[k] == '.')) k++
+        if (k < text.length && text[k] == '\\') k++
+        if (k < text.length && (text[k] == '"' || text[k] == '\'')) k++
+        while (k < text.length && (text[k] == ' ' || text[k] == '\t')) k++
+        return k < text.length && (text[k] == ':' || text[k] == '=')
+    }
+
+    // ============================================================== shape rules (never holed)
+
+    private class Rule(pattern: String, private val template: String) {
+        private val regex = Regex(pattern, RegexOption.IGNORE_CASE)
+        fun apply(text: String): String = regex.replace(text, template)
+    }
+
+    private const val HEAD = """(?<![A-Za-z0-9_])"""
+
+    /** One character of a path body. `/` is included; whitespace and structural chars are not. */
+    private const val PATH_CHAR = """[^\s"',()\[\]{}\n]"""
+
+    /** A path body, admitting an internal space only when the next token still contains a `/`. */
+    private const val PATH_BODY = """(?:$PATH_CHAR|[ ](?=$PATH_CHAR*/))*"""
+
+    /** Either a `file://` URL prefix, or a real token start (never mid-token: `pkg/data/data/x`). */
+    private const val PATH_START = """(?:file://|(?<![\w/]))"""
+
+    private const val PATH_ROOT_ANY =
+        """/(?:data/user(?:_de)?/\d+|data/data|data/media/\d+|""" +
+            """storage/emulated/\d+|storage/self/primary|sdcard|mnt/sdcard|mnt/user/\d+)"""
+
+    /** THIS app's artifact directory — `applicationId` is pinned; see the class doc. */
+    private const val PATH_ROOT_APP_BOOKS =
+        """/(?:data/user(?:_de)?/\d+|data/data)/com\.vreader\.app/files/books/"""
+
+    /**
+     * Applied IN ORDER, after [scanKeyedValues]. Only the app-books rule is order-dependent (it must
+     * precede the generic path rules, which would swallow the fingerprint key).
+     */
+    private val SHAPE_RULES: List<Rule> = listOf(
+        // OpenAI-style provider keys (`sk-…`, `sk-proj-…`, `sk-ant-…`) with no key name at all.
+        Rule("""${HEAD}sk-[A-Za-z0-9_-]{12,}""", PLACEHOLDER),
+
+        // JWT — three base64url segments.
+        Rule("""${HEAD}eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+""", PLACEHOLDER),
+
+        // URL credentials `scheme://user:pass@host` — user and host are diagnostic context and
+        // survive. The username may be EMPTY (`https://:pw@host` is legal userinfo). The password
+        // class admits `@` and relies on greedy backtracking to the last `@` WITHIN the authority:
+        // `?` and `#` are excluded so a query-string `@` cannot pull the match past the host.
+        // The head EXCLUDES `+.-` as well as word characters, and the scheme run is POSSESSIVE:
+        // without both, `a-a-a-…` gives every `a` a viable start whose scheme run consumes the rest
+        // of the input before failing — measured quadratic (15s timeout) on a 100 KB run. The class
+        // cannot span `://` anyway, so possessiveness costs no real match.
+        Rule("""(?<![A-Za-z0-9_+.\-])([a-z][a-z0-9+.-]*+://[^\s:/@]*:)[^\s/?#]+(@)""",
+            "\$1$PLACEHOLDER\$2"),
+
+        // THIS app's book artifact — the trailing segment is the sanitised fingerprintKey and
+        // SURVIVES. The trailing `(?!$PATH_CHAR)` demands a real path END so a nested
+        // `books/sub/evil.epub` cannot satisfy it by backtracking the capture.
+        Rule(
+            """$PATH_START$PATH_ROOT_APP_BOOKS([^/\s"',()\[\]{}\n]+)(?!$PATH_CHAR)""",
+            "$PATH_PLACEHOLDER/\$1",
+        ),
+
+        // `file://` URLs — the whole URL is a path, with the same space handling as a raw path.
+        Rule("""file://$PATH_BODY""", PATH_PLACEHOLDER),
+
+        // SAF `content://` URIs — the AUTHORITY says which provider failed and is kept; the
+        // document path embeds user filenames and goes.
+        Rule("""(content://[^/\s"',()\[\]{}\n]+)/$PATH_BODY""", "\$1/$PATH_PLACEHOLDER"),
+
+        // Every other app-private or shared-storage path.
+        Rule("""$PATH_START$PATH_ROOT_ANY$PATH_BODY""", PATH_PLACEHOLDER),
+    )
+}

--- a/android/app/src/main/kotlin/com/vreader/app/diagnostics/DiagnosticsRedactor.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/diagnostics/DiagnosticsRedactor.kt
@@ -134,7 +134,13 @@ object DiagnosticsRedactor {
 
     private fun classify(id: String): Kind? {
         val lower = id.lowercase()
-        if (lower.endsWith("authorization")) return Kind.AUTH
+        // `authorization` — and ONLY it — demands a word boundary: it is the one credential word
+        // with a real English superstring (`deauthorization`), and its class is the aggressive one
+        // (an unrecognised scheme consumes the rest of the line). The other words take an
+        // unrestricted suffix DELIBERATELY: `dbpassword` / `userpassword` / `oldSecret` are
+        // plausible third-party field names, and missing a credential costs more than
+        // over-redacting a contrived identifier. See the header's "Known limitations".
+        if (lower.endsWith("authorization") && boundaryAt(id, id.length - 13)) return Kind.AUTH
         SPACED_WORDS.forEach { if (lower.endsWith(it)) return Kind.SPACED }
         TOKEN_WORDS.forEach { if (lower.endsWith(it)) return Kind.TOKEN }
         if (lower.endsWith("token") && qualified(id, id.length - 5, TOKEN_QUALIFIERS, true)) {
@@ -157,14 +163,17 @@ object DiagnosticsRedactor {
         if (p.isEmpty()) return allowEmpty
         val lower = p.lowercase()
         for (q in quals) {
-            if (!lower.endsWith(q)) continue
-            val at = p.length - q.length
-            if (at == 0) return true
-            val before = p[at - 1]
-            if (before == '_' || before == '-') return true
-            if (p[at].isUpperCase() && before.isLowerCase()) return true
+            if (lower.endsWith(q) && boundaryAt(p, p.length - q.length)) return true
         }
         return false
+    }
+
+    /** True when [at] starts a word in [id] — position 0, after a `_`/`-`, or at a camelCase hump. */
+    private fun boundaryAt(id: String, at: Int): Boolean {
+        if (at <= 0) return at == 0
+        val before = id[at - 1]
+        if (before == '_' || before == '-') return true
+        return id[at].isUpperCase() && before.isLowerCase()
     }
 
     // ============================================================== the scanner
@@ -175,10 +184,15 @@ object DiagnosticsRedactor {
     private fun isIdentStart(c: Char): Boolean =
         c in 'a'..'z' || c in 'A'..'Z' || c == '_' || c == '-'
 
-    private fun opener(closer: Char): Char = when (closer) {
-        ')' -> '('
-        ']' -> '['
-        else -> '{'
+    /**
+     * Bracket bookkeeping is three COUNTERS, not a stack of characters. `ArrayDeque.contains()` is
+     * linear in depth, and since the value body never updates the state, a crafted
+     * `"(".repeat(n) + "password=" + "x)".repeat(n)` made [unquotedEnd] quadratic.
+     */
+    private fun bracketIndex(c: Char): Int = when (c) {
+        '(', ')' -> 0
+        '[', ']' -> 1
+        else -> 2
     }
 
     /**
@@ -188,7 +202,7 @@ object DiagnosticsRedactor {
      */
     private fun scanKeyedValues(text: String): String {
         val out = StringBuilder(text.length + 16)
-        val open = ArrayDeque<Char>()
+        val open = IntArray(3)
         var i = 0
         while (i < text.length) {
             val c = text[i]
@@ -214,11 +228,14 @@ object DiagnosticsRedactor {
         return out.toString()
     }
 
-    private fun track(c: Char, open: ArrayDeque<Char>) {
+    private fun track(c: Char, open: IntArray) {
         when (c) {
-            '\n' -> open.clear()
-            '(', '[', '{' -> open.addLast(c)
-            ')', ']', '}' -> if (open.isNotEmpty() && open.last() == opener(c)) open.removeLast()
+            '\n' -> open.fill(0)
+            '(', '[', '{' -> open[bracketIndex(c)]++
+            ')', ']', '}' -> {
+                val i = bracketIndex(c)
+                if (open[i] > 0) open[i]--
+            }
         }
     }
 
@@ -226,12 +243,16 @@ object DiagnosticsRedactor {
      * Given a credential key ending at [pos], returns the half-open span of its VALUE, or null when
      * the text is not a credential assignment after all.
      */
-    private fun findValue(text: String, pos: Int, kind: Kind, open: ArrayDeque<Char>): Pair<Int, Int>? {
+    private fun findValue(text: String, pos: Int, kind: Kind, open: IntArray): Pair<Int, Int>? {
         var k = pos
         var sawAssign = false
         var sawStructural = false
         var quote = '\u0000'
-        var quoteEscaped = false
+        // Backslashes immediately before the OPENING quote — the serialization depth. 0 = a raw
+        // quote, 1 = one JSON layer (`\"`), 3 = two layers (`\\\"`). The MATCHING close carries the
+        // SAME run; a quote INSIDE the value carries a longer one. Comparing run lengths is the only
+        // way to tell those apart — collapsing it to a boolean leaked a credential suffix.
+        var openRun = 0
         loop@ while (k < text.length) {
             val c = text[k]
             when {
@@ -241,9 +262,18 @@ object DiagnosticsRedactor {
                 // start of the next field, and consuming it would redact that field's value.
                 (c == ',' || c == ']' || c == ')' || c == '}') && !sawAssign ->
                     { sawStructural = true; quote = '\u0000'; k++ }
-                c == '"' || c == '\'' -> { quote = c; quoteEscaped = false; k++ }
-                c == '\\' && k + 1 < text.length && (text[k + 1] == '"' || text[k + 1] == '\'') ->
-                    { quote = text[k + 1]; quoteEscaped = true; k += 2 }
+                c == '"' || c == '\'' -> { quote = c; openRun = 0; k++ }
+                // A backslash RUN of any length followed by a quote is an opening quote at that
+                // serialization depth. Requiring a run of exactly one missed `\\\"…` entirely, so a
+                // double-serialized dump never even reached the assignment check.
+                c == '\\' -> {
+                    var r = k
+                    while (r < text.length && text[r] == '\\') r++
+                    if (r >= text.length || (text[r] != '"' && text[r] != '\'')) break@loop
+                    quote = text[r]
+                    openRun = r - k
+                    k = r + 1
+                }
                 else -> break@loop
             }
         }
@@ -254,7 +284,7 @@ object DiagnosticsRedactor {
 
         var start = k
         var end = if (quote != '\u0000') {
-            closingQuote(text, k, quote, quoteEscaped) ?: lineEnd(text, k)
+            closingQuote(text, k, quote, openRun) ?: lineEnd(text, k)
         } else {
             -1
         }
@@ -286,26 +316,25 @@ object DiagnosticsRedactor {
         return -1
     }
 
-    /** Index of the matching close quote, honouring backslash escapes; null when unbalanced. */
-    private fun closingQuote(text: String, from: Int, quote: Char, escaped: Boolean): Int? {
+    /**
+     * Index at which the value ends, i.e. the start of the MATCHING close quote's backslash run —
+     * or null when the value is unbalanced, in which case the caller fails closed to end of line.
+     *
+     * A quote closes the value only when the backslash run immediately before it is exactly
+     * [openRun] long: at serialization depth d the structural delimiter is `\^d "` while a quote
+     * inside the value is `\^(2d+1) "`. Anything longer is value content and the scan continues, so
+     * an ambiguous run (a value that genuinely ends in a backslash) over-redacts rather than leaking.
+     */
+    private fun closingQuote(text: String, from: Int, quote: Char, openRun: Int): Int? {
         var k = from
-        if (!escaped) {
-            while (k < text.length) {
-                when {
-                    text[k] == '\\' -> k += 2
-                    text[k] == quote -> return k
-                    else -> k++
-                }
+        while (k < text.length) {
+            if (text[k] == quote) {
+                var run = 0
+                var j = k - 1
+                while (j >= from && text[j] == '\\') { run++; j-- }
+                if (run == openRun) return k - openRun
             }
-        } else {
-            while (k + 1 < text.length) {
-                if (text[k] == '\\') {
-                    if (text[k + 1] == quote) return k
-                    k += 2
-                } else {
-                    k++
-                }
-            }
+            k++
         }
         return null
     }
@@ -316,13 +345,15 @@ object DiagnosticsRedactor {
     }
 
     /** The unquoted-value terminator policy — see the class doc's "delimiter policy" decision. */
-    private fun unquotedEnd(text: String, start: Int, kind: Kind, open: ArrayDeque<Char>): Int {
+    private fun unquotedEnd(text: String, start: Int, kind: Kind, open: IntArray): Int {
         var k = start
         while (k < text.length) {
             val c = text[k]
             if (c == '\n') return k
             if (kind == Kind.TOKEN && (c == ' ' || c == '\t' || c == '\r')) return k
-            if ((c == ')' || c == ']' || c == '}') && open.contains(opener(c)) && closesTheDump(text, k + 1)) {
+            if ((c == ')' || c == ']' || c == '}') && open[bracketIndex(c)] > 0 &&
+                closesTheDump(text, k + 1)
+            ) {
                 return k
             }
             // NOT for [Kind.LINE]: a Digest credential IS a comma-separated parameter list, so
@@ -335,13 +366,20 @@ object DiagnosticsRedactor {
         return text.length
     }
 
-    /** True when nothing but the end of the dump follows — the bracket really terminated a field. */
+    /**
+     * True when nothing but the end of the dump follows — the bracket really terminated the field.
+     *
+     * A trailing `,`/`;` is NOT by itself proof: `Dump{password=abc},SUFFIX` would end the value at
+     * the `}` and leak `SUFFIX`, which is a legal password character sequence. The delimiter must
+     * itself introduce a new key/value pair.
+     */
     private fun closesTheDump(text: String, from: Int): Boolean {
         var k = from
         while (k < text.length && (text[k] == ' ' || text[k] == '\t')) k++
         if (k >= text.length) return true
         val c = text[k]
-        return c == '\n' || c == ')' || c == ']' || c == '}' || c == ',' || c == ';'
+        if (c == '\n' || c == ')' || c == ']' || c == '}') return true
+        return (c == ',' || c == ';') && nextKeyFollows(text, k + 1)
     }
 
     /** True when `[quote] identifier [quote] [:=]` follows — i.e. a genuinely new key/value pair. */
@@ -376,9 +414,18 @@ object DiagnosticsRedactor {
     /** Either a `file://` URL prefix, or a real token start (never mid-token: `pkg/data/data/x`). */
     private const val PATH_START = """(?:file://|(?<![\w/]))"""
 
+    /**
+     * Android storage roots. Beyond the app-private and primary-shared families, this covers the
+     * REMOVABLE/adopted volumes a real import failure names — `/storage/1A2B-3C4D/...` (the FAT
+     * volume id an SD card gets) carries the user's own folder names and was previously redacted
+     * only when it happened to arrive as a `file://` URL. The volume forms are shape-bounded so
+     * prose beginning `/storage/` is not swallowed.
+     */
     private const val PATH_ROOT_ANY =
-        """/(?:data/user(?:_de)?/\d+|data/data|data/media/\d+|""" +
-            """storage/emulated/\d+|storage/self/primary|sdcard|mnt/sdcard|mnt/user/\d+)"""
+        """/(?:data/user(?:_de)?/\d+|data/data|data/media/\d+|data/misc_(?:ce|de)/\d+|""" +
+            """storage/emulated/\d+|storage/self/primary|""" +
+            """storage/[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}|mnt/expand/[0-9a-fA-F-]{8,}|""" +
+            """sdcard|mnt/sdcard|mnt/user/\d+|mnt/media_rw|mnt/runtime/[a-z]+)"""
 
     /** THIS app's artifact directory — `applicationId` is pinned; see the class doc. */
     private const val PATH_ROOT_APP_BOOKS =

--- a/android/app/src/main/kotlin/com/vreader/app/diagnostics/DiagnosticsRedactor.kt
+++ b/android/app/src/main/kotlin/com/vreader/app/diagnostics/DiagnosticsRedactor.kt
@@ -79,7 +79,12 @@ package com.vreader.app.diagnostics
  *   in every `toString()` costs exactly this; no lexical rule can tell the two apart.
  * - An unrecognised `Authorization` scheme consumes the rest of the line, so same-line text after
  *   such a header is lost. A quoted value whose closing quote appears many lines later
- *   over-redacts to that quote (the safe direction).
+ *   over-redacts to that quote (the safe direction), as does a value that itself ends in a
+ *   backslash (indistinguishable from an escaped inner quote).
+ * - A BARE `signature=` is treated as a credential. `methodSignature` / `packageSignature` and the
+ *   rest of [SIGNATURE_NON_CREDENTIAL] are excluded, but an unqualified package-signing
+ *   `signature=<cert>` line loses that one token. Keeping it is the safe side: an HTTP-Signature
+ *   header spells its credential exactly that way.
  * - Book titles and filenames are NOT redacted (parity with iOS #96) — redacting them would gut the
  *   export's diagnostic value, since most import/reader failures name the book.
  *
@@ -117,7 +122,19 @@ object DiagnosticsRedactor {
     )
 
     /** Keys whose value is a single whitespace-free token. */
-    private val TOKEN_WORDS = listOf("apikey", "api_key", "api-key", "signature", "sig")
+    private val TOKEN_WORDS = listOf("apikey", "api_key", "api-key", "sig")
+
+    /**
+     * `*signature` qualifiers that mean "NOT a credential". Gate-4 round 2 named the real ones:
+     * Android package-signing diagnostics and JVM tooling emit `methodSignature=` / a type or
+     * package signature, none of which authenticate anything. This is a DENY-list rather than the
+     * allow-list used for `token`/`key`, so an unrecognised `*signature` still redacts — `sig=`,
+     * `X-Amz-Signature=` and an HTTP-Signature `signature=` are all credentials.
+     */
+    private val SIGNATURE_NON_CREDENTIAL = listOf(
+        "method", "type", "class", "package", "cert", "certificate", "schema", "function",
+        "field", "descriptor", "jvm", "java", "kotlin",
+    )
 
     /** `*token` is a credential only behind these qualifiers — see the class doc. */
     private val TOKEN_QUALIFIERS = listOf(
@@ -143,6 +160,11 @@ object DiagnosticsRedactor {
         if (lower.endsWith("authorization") && boundaryAt(id, id.length - 13)) return Kind.AUTH
         SPACED_WORDS.forEach { if (lower.endsWith(it)) return Kind.SPACED }
         TOKEN_WORDS.forEach { if (lower.endsWith(it)) return Kind.TOKEN }
+        if (lower.endsWith("signature") &&
+            !qualified(id, id.length - 9, SIGNATURE_NON_CREDENTIAL, allowEmpty = false)
+        ) {
+            return Kind.TOKEN
+        }
         if (lower.endsWith("token") && qualified(id, id.length - 5, TOKEN_QUALIFIERS, true)) {
             return Kind.TOKEN
         }
@@ -156,6 +178,9 @@ object DiagnosticsRedactor {
      * True when the identifier text before [cut] ends with one of [quals] at a word boundary —
      * position 0, after a `_`/`-`, or at a camelCase hump. The boundary check is what keeps
      * `validToken` (`val` + `id`) and `PaginationToken` out while admitting `x-auth-token`.
+     *
+     * Used as an ALLOW-list for `token`/`key` and as a DENY-list for `signature`; [allowEmpty]
+     * decides which way a bare, unqualified word falls.
      */
     private fun qualified(id: String, cut: Int, quals: List<String>, allowEmpty: Boolean): Boolean {
         var p = id.substring(0, cut)

--- a/android/app/src/test/kotlin/com/vreader/app/diagnostics/DiagnosticsRedactorTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/diagnostics/DiagnosticsRedactorTest.kt
@@ -339,6 +339,43 @@ class DiagnosticsRedactorTest {
     }
 
     @Test
+    fun quoted_escapedContainerWhoseValueContainsAnEscapedQuote_isFullyRedacted() {
+        // Gate-4 round 1, High. A boolean "is the opener escaped" cannot tell a structural close
+        // (`\"`) from a quote INSIDE the value (`\\\"`), so the scan ended early and leaked the
+        // tail. The close is now the quote whose preceding backslash run MATCHES the opener's.
+        check(
+            """state={\"password\":\"abc\\\"USABLE-SUFFIX\"} -> 401""",
+            """state={\"password\":\"$redacted\"} -> 401""",
+            secrets = listOf("""abc\\\"USABLE-SUFFIX"""),
+            context = listOf("state=", "password", "-> 401"),
+        )
+    }
+
+    @Test
+    fun quoted_doubleSerializedContainer_isRedacted() {
+        // Gate-4 round 1, High. The separator run required a backslash run of exactly ONE before a
+        // quote, so a twice-serialized dump never reached the assignment check and survived whole.
+        check(
+            """state={\\\"password\\\":\\\"TOPSECRET123\\\"}""",
+            """state={\\\"password\\\":\\\"$redacted\\\"}""",
+            secrets = listOf("TOPSECRET123"),
+            context = listOf("state=", "password"),
+        )
+    }
+
+    @Test
+    fun quoted_valueEndingInABackslashOverRedactsRatherThanLeaking() {
+        // The one genuinely ambiguous run — a value that itself ends in a backslash looks exactly
+        // like an escaped inner quote. It fails CLOSED (to end of line), which is the safe side.
+        check(
+            """cfg {"password": "hunter2\\"} loaded""",
+            """cfg {"password": "$redacted""",
+            secrets = listOf("hunter2"),
+            context = listOf("cfg", "password"),
+        )
+    }
+
+    @Test
     fun quoted_nestedJsonDumpWithEscapedStructuralQuotes_isRedacted() {
         check(
             """state={\"encryptedApiKey\":\"AAAAFGhlbGxvd29ybGQxMjM0\"}""",
@@ -471,6 +508,26 @@ class DiagnosticsRedactorTest {
             secrets = listOf("sk-or-v1-abc123def456", "AAAAFGhlbGxvMTIz"),
             // maxTokens must SURVIVE — the over-redaction pin for the camel-case key rule.
             context = listOf("id=p1", "openrouter.ai", "maxTokens=4096"),
+        )
+    }
+
+    @Test
+    fun unquoted_bracketFollowedByANonFieldDelimiter_doesNotTerminateTheValue() {
+        // Gate-4 round 1, High. A closing bracket followed by `,` was treated as proof the dump
+        // ended, so `Dump{password=abc},SUFFIX` leaked `SUFFIX` — which is a legal password
+        // character sequence. The delimiter must now itself introduce a new key/value pair.
+        check(
+            "Dump{password=abc},USABLE-SUFFIX",
+            "Dump{password=$redacted",
+            secrets = listOf("abc},USABLE-SUFFIX"),
+            context = listOf("Dump{password="),
+        )
+        // …while a bracket that IS followed by a real next field still ends the value.
+        check(
+            "Dump{password=hunter2}, next=1",
+            "Dump{password=$redacted}, next=1",
+            secrets = listOf("hunter2"),
+            context = listOf("next=1"),
         )
     }
 
@@ -721,6 +778,31 @@ class DiagnosticsRedactorTest {
     }
 
     @Test
+    fun path_removableAndAdoptedVolumeRoots_areRedacted() {
+        // Gate-4 round 1, Medium. `/storage/<FAT-volume-id>` is where an SD-card import fails, and
+        // it carries the user's own folder names. It was covered only when it arrived as a
+        // `file://` URL; a raw path survived untouched.
+        check(
+            "BookImporter failed at /storage/1A2B-3C4D/Books/Alice/private.epub: Permission denied",
+            "BookImporter failed at $path Permission denied",
+            secrets = listOf("1A2B-3C4D", "private.epub"),
+            context = listOf("BookImporter failed at", "Permission denied"),
+        )
+        check(
+            "scan /mnt/media_rw/1A2B-3C4D/Books/private.epub failed",
+            "scan $path failed",
+            secrets = listOf("private.epub"),
+            context = listOf("scan", "failed"),
+        )
+        check(
+            "prefs /data/misc_ce/10/com.vreader.app/blob unreadable",
+            "prefs $path unreadable",
+            secrets = listOf("/data/misc_ce/10"),
+            context = listOf("prefs", "unreadable"),
+        )
+    }
+
+    @Test
     fun path_legacyDataDataPath_isRedacted() {
         check(
             "prefs /data/data/com.vreader.app/shared_prefs/settings.xml unreadable",
@@ -809,6 +891,42 @@ class DiagnosticsRedactorTest {
         assertUnchanged("Bearer tokens rejected")
         // No `:`/`=`/`,`/`]`/`)` after the header name — not a container, so not a credential.
         assertUnchanged("Authorization is required for this endpoint")
+    }
+
+    @Test
+    fun negative_englishSuperstringsOfAuthorizationSurvive() {
+        // Gate-4 round 1, Medium. `deauthorization` ends with `authorization`, and the AUTH class
+        // consumes the rest of the LINE, so an unrestricted suffix destroyed a whole diagnostic
+        // line. `authorization` — alone among the credential words — now demands a word boundary.
+        assertUnchanged("policy deauthorization=true result=completed")
+        assertUnchanged("session reauthorization=pending retries=2")
+        // …but the real header names are all at a boundary and still match.
+        check(
+            "Proxy-Authorization: Basic cHJveHk6c2VjcmV0OTk5",
+            "Proxy-Authorization: Basic $redacted",
+            secrets = listOf("cHJveHk6c2VjcmV0OTk5"),
+            context = listOf("Proxy-Authorization: Basic"),
+        )
+    }
+
+    @Test
+    fun lowercaseCompoundCredentialKeys_areStillRedacted() {
+        // The deliberate ASYMMETRY: the boundary rule applies to `authorization` ONLY. A lowercase
+        // compound like `dbpassword` is a plausible third-party field name, and missing a
+        // credential costs more than over-redacting a contrived identifier. Pinned so the
+        // asymmetry is a visible decision rather than an accident.
+        check(
+            "pool init dbpassword=hunter2secret999 host=db.internal",
+            "pool init dbpassword=$redacted",
+            secrets = listOf("hunter2secret999"),
+            context = listOf("pool init", "dbpassword="),
+        )
+        check(
+            "legacy userpassword=hunter2secret999",
+            "legacy userpassword=$redacted",
+            secrets = listOf("hunter2secret999"),
+            context = listOf("legacy", "userpassword="),
+        )
     }
 
     @Test
@@ -939,6 +1057,15 @@ class DiagnosticsRedactorTest {
     fun linear_repeatedKeyAssignment() {
         DiagnosticsRedactor.redact("api-key=".repeat(12_000))
         DiagnosticsRedactor.redact("Authorization:".repeat(12_000))
+    }
+
+    @Test(timeout = 15_000)
+    fun linear_deepBracketNestingInAnUnquotedValue() {
+        // Gate-4 round 1, Medium. Bracket state was an ArrayDeque and `contains()` is linear in
+        // depth, so every closer in the value body cost O(depth) — measured quadratic. It is three
+        // counters now.
+        val n = 50_000
+        DiagnosticsRedactor.redact("(".repeat(n) + "password=" + "x)".repeat(n))
     }
 
     @Test(timeout = 15_000)

--- a/android/app/src/test/kotlin/com/vreader/app/diagnostics/DiagnosticsRedactorTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/diagnostics/DiagnosticsRedactorTest.kt
@@ -910,6 +910,28 @@ class DiagnosticsRedactorTest {
     }
 
     @Test
+    fun negative_nonCredentialSignatureIdentifiersSurvive() {
+        // Gate-4 round 2, Low. Android package-signing diagnostics and JVM tooling emit these, and
+        // none of them authenticate anything. A DENY-list (not an allow-list) gates them, so an
+        // unrecognised `*signature` still redacts.
+        assertUnchanged("verify methodSignature=(Ljava/lang/String;)V result=ok")
+        assertUnchanged("apk packageSignature=308201e2 typeSignature=Lcom/vreader/Book;")
+        // …while every credential-bearing spelling still goes.
+        check(
+            "blob url ?sig=QWxhZGRpbjpvcGVuIHNlc2FtZQ== retrying",
+            "blob url ?sig=$redacted retrying",
+            secrets = listOf("QWxhZGRpbjpvcGVuIHNlc2FtZQ=="),
+            context = listOf("blob url", "retrying"),
+        )
+        check(
+            "signed request signature=QWxhZGRpbjpvcGVuIHNlc2FtZQ== -> 403",
+            "signed request signature=$redacted -> 403",
+            secrets = listOf("QWxhZGRpbjpvcGVuIHNlc2FtZQ=="),
+            context = listOf("signed request", "-> 403"),
+        )
+    }
+
+    @Test
     fun lowercaseCompoundCredentialKeys_areStillRedacted() {
         // The deliberate ASYMMETRY: the boundary rule applies to `authorization` ONLY. A lowercase
         // compound like `dbpassword` is a plausible third-party field name, and missing a

--- a/android/app/src/test/kotlin/com/vreader/app/diagnostics/DiagnosticsRedactorTest.kt
+++ b/android/app/src/test/kotlin/com/vreader/app/diagnostics/DiagnosticsRedactorTest.kt
@@ -1,0 +1,968 @@
+package com.vreader.app.diagnostics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Feature #164 WI-2b — the feature's security gate.
+ *
+ * On Android logcat is plaintext with no `privacy:` barrier, so [DiagnosticsRedactor] is the ONLY
+ * thing standing between a captured log entry and a share sheet / clipboard. Every vector below is
+ * drawn from a real credential path in this app (`WebDavClient.authHeader`, `OpdsClient`'s Basic
+ * token, `OpenAiCompatibleProvider`, `AnthropicProvider`, `SecretCipher`, `WebDavServerStore`,
+ * `AiProviderStore`, `OpdsSourcesViewModel.TestSignature`, `BookImporter`).
+ *
+ * The oracle is deliberately strict, because a redactor test is the classic place to pass for free:
+ *  - every security vector asserts the EXACT output, not just "the secret is absent" — a substring
+ *    check silently accepts a surviving suffix whenever a delimiter splits the credential;
+ *  - [check] asserts each secret was genuinely present BEFORE redaction, so a mistyped fixture
+ *    cannot make a test pass;
+ *  - multi-word secrets are additionally asserted word-by-word, and EVERY secret is asserted
+ *    suffix-by-suffix — a partial redaction that eats a prefix and leaves the tail is the exact
+ *    failure the previous regex design shipped, and it is stable under re-redaction, so
+ *    idempotency cannot see it (pinned by [oracle_idempotencyIsNotACompletenessOracle]);
+ *  - assertions are TWO-SIDED — the surrounding diagnostic context (host, scheme, HTTP status,
+ *    exception class, entity id) must SURVIVE. A redactor that destroys diagnosability fails too.
+ *
+ * Test names carry the scanner branch or shape rule they pin, so the mutation pass (disable one
+ * branch, expect a named test to go red) has an unambiguous mapping.
+ */
+class DiagnosticsRedactorTest {
+
+    private val redacted = DiagnosticsRedactor.PLACEHOLDER
+    private val path = DiagnosticsRedactor.PATH_PLACEHOLDER
+
+    /**
+     * Asserts the full contract for one vector: pre-redaction presence, exact output, secret
+     * absence (whole, per-word AND per-suffix), context survival, and idempotency.
+     */
+    private fun check(
+        input: String,
+        expected: String,
+        secrets: List<String>,
+        context: List<String> = emptyList(),
+    ) {
+        secrets.forEach {
+            assertTrue(
+                "fixture bug: input does not actually contain the secret <$it>",
+                input.contains(it),
+            )
+        }
+        val out = DiagnosticsRedactor.redact(input)
+        assertEquals("exact output", expected, out)
+        secrets.forEach { secret ->
+            assertFalse("secret <$secret> survived: $out", out.contains(secret))
+            // A delimiter inside the secret must not leave a usable fragment behind.
+            secret.split(' ').filter { it.length >= 4 }.forEach { word ->
+                assertFalse("secret fragment <$word> survived: $out", out.contains(word))
+            }
+            // A partial redaction leaves a SUFFIX — the previous design's whole failure class.
+            for (from in 0..(secret.length - 4)) {
+                val tail = secret.substring(from)
+                assertFalse("secret suffix <$tail> survived: $out", out.contains(tail))
+            }
+        }
+        context.forEach {
+            assertTrue("diagnostic context <$it> was destroyed: $out", out.contains(it))
+        }
+        assertEquals("redact() must be idempotent", out, DiagnosticsRedactor.redact(out))
+    }
+
+    private fun assertUnchanged(input: String) {
+        assertEquals("must not be over-redacted", input, DiagnosticsRedactor.redact(input))
+    }
+
+    // ================================================================ the four regex survivors
+    // Each of these was returned UNCHANGED (or partially redacted) by the 13-rule regex design on
+    // `feat/164-wi-2-redactor` after three audit rounds. They are the reason the keyed-value
+    // matcher is a scanner and not a pattern.
+
+    @Test
+    fun survivor1_arbitrarilyLongSeparatorRunBeforeAScheme_isRedacted() {
+        // The regex container class was bounded `{0,8}` and the fallback rule DECLINED whenever it
+        // saw a recognised scheme, so a wide separator run fell through BOTH rules. The scanner's
+        // separator run is unbounded, so no gap width exists.
+        check(
+            "Authorization:" + " ".repeat(10) + "Bearer abcdefghijkl -> 401",
+            "Authorization:" + " ".repeat(10) + "Bearer $redacted -> 401",
+            secrets = listOf("abcdefghijkl"),
+            context = listOf("Authorization:", "Bearer", "-> 401"),
+        )
+        check(
+            "Authorization:" + "\t".repeat(40) + "Basic WEtBQTpIRXFrQVdHZFFM",
+            "Authorization:" + "\t".repeat(40) + "Basic $redacted",
+            secrets = listOf("WEtBQTpIRXFrQVdHZFFM"),
+            context = listOf("Authorization:", "Basic"),
+        )
+    }
+
+    @Test
+    fun survivor2_escapedJsonAuthorizationContainer_isRedacted() {
+        // The real `OpdsClient` / `WebDavClient` Basic shape inside a nested JSON dump. The regex
+        // container class excluded `\`, and `Authorization` was not in the keyed-name set, so this
+        // survived ENTIRELY. The scanner's separator run consumes `\"` pairs.
+        check(
+            """state={\"Authorization\":\"Basic WEtBQTpIRXFrQVdHZFFM\"} -> 401""",
+            """state={\"Authorization\":\"Basic $redacted\"} -> 401""",
+            secrets = listOf("WEtBQTpIRXFrQVdHZFFM"),
+            context = listOf("state=", "Authorization", "Basic", "-> 401"),
+        )
+        check(
+            """req={\"headers\":{\"Authorization\":\"Bearer sk-ant-api03-AbC123def456\"}}""",
+            """req={\"headers\":{\"Authorization\":\"Bearer $redacted\"}}""",
+            secrets = listOf("sk-ant-api03-AbC123def456"),
+            context = listOf("headers", "Authorization", "Bearer"),
+        )
+    }
+
+    @Test
+    fun survivor3_quotedValueContainingTheOtherQuote_isFullyRedacted() {
+        // The regex body `[^"'\n\\]*` stopped at the first embedded quote, producing
+        // `password=‹redacted›'BrienNeverClose` — a STABLE partial redaction that idempotency
+        // cannot detect. The scanner's quote state machine consumes to the MATCHING close, and
+        // fails closed to end of line when there is none (logd truncates at 4068 bytes).
+        check(
+            """password="O'BrienNeverClose""",
+            """password="$redacted""",
+            secrets = listOf("O'BrienNeverClose"),
+            context = listOf("password="),
+        )
+        check(
+            """AiProviderProfile(apiKey='it"s-complicated-9988""",
+            """AiProviderProfile(apiKey='$redacted""",
+            secrets = listOf("""it"s-complicated-9988"""),
+            context = listOf("AiProviderProfile", "apiKey="),
+        )
+        // Balanced, but the value contains the OTHER quote character throughout.
+        check(
+            """{"password": "O'Brien's passphrase"} rejected""",
+            """{"password": "$redacted"} rejected""",
+            secrets = listOf("O'Brien's passphrase"),
+            context = listOf("\"password\"", "rejected"),
+        )
+    }
+
+    @Test
+    fun survivor4_unquotedValueContainingStructuralCharacters_isFullyRedacted() {
+        // The regex value class excluded `,&)]}` and quotes, so `password=foo,bar` leaked `,bar`.
+        // Commas, ampersands and brackets are all legal in a passphrase. The scanner terminates an
+        // unquoted value at a structural character ONLY when a NEW key/value pair follows it.
+        check(
+            "WebDAV auth failed password=hunter2,continued&more)tail",
+            "WebDAV auth failed password=$redacted",
+            secrets = listOf("hunter2,continued&more)tail"),
+            context = listOf("WebDAV auth failed", "password="),
+        )
+        // …while a genuine following field still survives, which is the whole point of the policy.
+        check(
+            "ServerDraft(password=hunter2,continued, wifiOnly=true)",
+            "ServerDraft(password=$redacted, wifiOnly=true)",
+            secrets = listOf("hunter2,continued"),
+            context = listOf("ServerDraft", "wifiOnly=true"),
+        )
+        // A closer that does NOT terminate a field is not a delimiter either — only the one that
+        // actually ends the dump is. (The secret avoids the word "word": `password` contains it,
+        // and the suffix oracle would fire on the surviving KEY NAME.)
+        check(
+            "ServerDraft(password=p@ss)Tr0ub4dor)",
+            "ServerDraft(password=$redacted)",
+            secrets = listOf("p@ss)Tr0ub4dor"),
+            context = listOf("ServerDraft", "password="),
+        )
+    }
+
+    // ================================================================ Authorization container
+
+    @Test
+    fun auth_webDavBasicHeader_redactsTokenKeepsSchemeAndStatus() {
+        check(
+            "WebDAV PROPFIND /remote.php/dav/ -> 401 Unauthorized; sent " +
+                "Authorization: Basic dXNlcjpwYXNzd29yZA==",
+            "WebDAV PROPFIND /remote.php/dav/ -> 401 Unauthorized; sent " +
+                "Authorization: Basic $redacted",
+            secrets = listOf("dXNlcjpwYXNzd29yZA=="),
+            context = listOf("401 Unauthorized", "/remote.php/dav/", "Authorization: Basic"),
+        )
+    }
+
+    @Test
+    fun auth_openAiBearerHeader_redactsKeyKeepsSchemeAndStatus() {
+        check(
+            "AI request failed: Authorization: Bearer sk-proj-AbC123def456GHI789jkl -> HTTP 401",
+            "AI request failed: Authorization: Bearer $redacted -> HTTP 401",
+            secrets = listOf("sk-proj-AbC123def456GHI789jkl"),
+            context = listOf("AI request failed", "-> HTTP 401"),
+        )
+    }
+
+    @Test
+    fun auth_serializedJsonHeader_redactsInsideQuotes() {
+        check(
+            """headers {"Authorization": "Basic YWxpY2U6cHcxMjM="} -> 401""",
+            """headers {"Authorization": "Basic $redacted"} -> 401""",
+            secrets = listOf("YWxpY2U6cHcxMjM="),
+            context = listOf("headers", "\"Authorization\"", "-> 401"),
+        )
+    }
+
+    @Test
+    fun auth_bracketedAndPairContainers_areCoveredByTheSameBranch() {
+        // Neither shape is a `key: value` pair, so a header-name-plus-colon rule cannot see them.
+        check(
+            "headers[Authorization]=Basic dXNlcjpwQHNzIHdvcmQ= -> 401",
+            "headers[Authorization]=Basic $redacted -> 401",
+            secrets = listOf("dXNlcjpwQHNzIHdvcmQ="),
+            context = listOf("headers[Authorization]", "-> 401"),
+        )
+        check(
+            "request=(Authorization, Basic dXNlcjpwQHNzIHdvcmQ=)",
+            "request=(Authorization, Basic $redacted)",
+            secrets = listOf("dXNlcjpwQHNzIHdvcmQ="),
+            context = listOf("Authorization"),
+        )
+    }
+
+    @Test
+    fun auth_allLetterAndShortCredentials_areRedactedBecauseTheBranchIsContextAnchored() {
+        // `OpdsClient` base64-encodes `user:pass`, which routinely yields an ALL-LETTER token —
+        // an entropy/shape heuristic ("16+ chars containing a digit") lets this real credential
+        // through, and over-redacts `Basic SHA256withRSA2048`. Such a heuristic was tried, failed
+        // in BOTH directions across two audit rounds, and was deleted. Anchoring on the container
+        // removes the need for one.
+        check(
+            "request=(Authorization, Basic WEtBQTpIRXFrQVdHZFFM)",
+            "request=(Authorization, Basic $redacted)",
+            secrets = listOf("WEtBQTpIRXFrQVdHZFFM"),
+            context = listOf("Authorization"),
+        )
+        check(
+            "Authorization: Bearer abcdefgh -> 401",
+            "Authorization: Bearer $redacted -> 401",
+            secrets = listOf("abcdefgh"),
+            context = listOf("Authorization: Bearer", "-> 401"),
+        )
+        check(
+            "Authorization: Basic YWxpY2U= -> 401",
+            "Authorization: Basic $redacted -> 401",
+            secrets = listOf("YWxpY2U="),
+            context = listOf("Authorization: Basic", "-> 401"),
+        )
+    }
+
+    @Test
+    fun auth_proxyAuthorizationIsTreatedAsTheSameHeaderFamily() {
+        check(
+            "Proxy-Authorization: Basic cHJveHk6c2VjcmV0OTk5 -> 407",
+            "Proxy-Authorization: Basic $redacted -> 407",
+            secrets = listOf("cHJveHk6c2VjcmV0OTk5"),
+            context = listOf("Proxy-Authorization: Basic", "-> 407"),
+        )
+    }
+
+    @Test
+    fun auth_unknownScheme_redactsWholeHeaderValueToEndOfLine() {
+        // A Digest credential is spread across quoted, comma-separated parameters, so anything
+        // less than "to end of line" leaks `response=`. Same-line context after such a header is
+        // therefore lost BY DESIGN (documented in the class header); adjacent lines survive.
+        check(
+            "proxy auth failed\n" +
+                "Authorization: Digest username=\"alice\", response=deadbeefcafe1234, nonce=abc99\n" +
+                "retrying in 2s",
+            "proxy auth failed\nAuthorization: $redacted\nretrying in 2s",
+            secrets = listOf("deadbeefcafe1234", "nonce=abc99"),
+            context = listOf("proxy auth failed", "retrying in 2s"),
+        )
+    }
+
+    // ================================================================ quoted keyed values
+
+    @Test
+    fun quoted_multiWordSecret_consumesToClosingQuote() {
+        check(
+            """request body {"password": "correct horse battery staple"} rejected""",
+            """request body {"password": "$redacted"} rejected""",
+            secrets = listOf("correct horse battery staple"),
+            context = listOf("request body", "\"password\"", "rejected"),
+        )
+    }
+
+    @Test
+    fun quoted_singleQuotedValue_isRedacted() {
+        // Kotlin/Room/OkHttp dumps quote with either character; handling only `"` leaked this.
+        check(
+            "OPDS test password='p@ss phrase' -> 401",
+            "OPDS test password='$redacted' -> 401",
+            secrets = listOf("p@ss phrase"),
+            context = listOf("OPDS test", "password=", "-> 401"),
+        )
+    }
+
+    @Test
+    fun quoted_escapedQuoteInsideValue_doesNotTerminateEarly() {
+        check(
+            """ServerDraft(password="p@ss\"Tr0ub4dor", wifiOnly=true)""",
+            """ServerDraft(password="$redacted", wifiOnly=true)""",
+            secrets = listOf("""p@ss\"Tr0ub4dor"""),
+            context = listOf("ServerDraft", "wifiOnly=true"),
+        )
+    }
+
+    @Test
+    fun quoted_secretSpanningNewlines_isFullyRedacted() {
+        check(
+            "cfg {\"client_secret\": \"line one\nline two\"} loaded",
+            """cfg {"client_secret": "$redacted"} loaded""",
+            secrets = listOf("line one", "line two"),
+            context = listOf("cfg", "client_secret", "loaded"),
+        )
+    }
+
+    @Test
+    fun quoted_truncatedClosingQuote_failsClosedToEndOfLine() {
+        // logd truncates a line at 4068 bytes; a balanced-quote rule alone fails OPEN on the
+        // truncated remainder, which is exactly the tail a credential sits in.
+        check(
+            """AiProviderProfile(apiKey="azureOpaqueSecret123""",
+            """AiProviderProfile(apiKey="$redacted""",
+            secrets = listOf("azureOpaqueSecret123"),
+            context = listOf("AiProviderProfile", "apiKey="),
+        )
+        // …and only to the END OF LINE — a later line is not swallowed.
+        check(
+            "AiProviderProfile(apiKey=\"azureOpaqueSecret123\nretrying in 2s",
+            "AiProviderProfile(apiKey=\"$redacted\nretrying in 2s",
+            secrets = listOf("azureOpaqueSecret123"),
+            context = listOf("retrying in 2s"),
+        )
+    }
+
+    @Test
+    fun quoted_nestedJsonDumpWithEscapedStructuralQuotes_isRedacted() {
+        check(
+            """state={\"encryptedApiKey\":\"AAAAFGhlbGxvd29ybGQxMjM0\"}""",
+            """state={\"encryptedApiKey\":\"$redacted\"}""",
+            secrets = listOf("AAAAFGhlbGxvd29ybGQxMjM0"),
+            context = listOf("state=", "encryptedApiKey"),
+        )
+    }
+
+    // ================================================================ unquoted keyed values
+
+    @Test
+    fun unquoted_spacedValueRunsPastWhitespaceToTheNextFieldOnly() {
+        // OpdsSourceStore.upsert / WebDavServerStore.upsert take PLAINTEXT passwords and
+        // OpdsSourcesViewModel.TestSignature is a data class that prints one unquoted, so a
+        // space-containing password in a toString() is real. Whitespace termination would have
+        // leaked "horse battery staple".
+        check(
+            "WebDAV failed password=correct horse battery staple, wifiOnly=true",
+            "WebDAV failed password=$redacted, wifiOnly=true",
+            secrets = listOf("correct horse battery staple"),
+            context = listOf("WebDAV failed", "wifiOnly=true"),
+        )
+    }
+
+    @Test
+    fun unquoted_webDavAuthHeaderProperty_isRedactedIncludingItsScheme() {
+        // `authHeader` is the real property name at WebDavClient.kt:71, and its value is
+        // `<scheme> <credential>` — it contains a space, so it belongs to the space-bearing class.
+        check(
+            "WebDavClient authHeader=Basic dXNlcjpwQHNzIHdvcmQ=",
+            "WebDavClient authHeader=$redacted",
+            secrets = listOf("dXNlcjpwQHNzIHdvcmQ="),
+            context = listOf("WebDavClient", "authHeader"),
+        )
+    }
+
+    @Test
+    fun unquoted_camelCaseEncryptedPasswordWithColon_isRedacted() {
+        check(
+            "WebDavServerStore not decodable encryptedPassword: AAAAFGhlbGxvd29ybGQ5OTk=",
+            "WebDavServerStore not decodable encryptedPassword: $redacted",
+            secrets = listOf("AAAAFGhlbGxvd29ybGQ5OTk="),
+            context = listOf("WebDavServerStore", "not decodable", "encryptedPassword"),
+        )
+    }
+
+    @Test
+    fun unquoted_serializedEntityDump_redactsBlobAndKeepsIdUrlUsername() {
+        check(
+            "upsert WebDavServerProfile(id=3, url=https://dav.example.com/remote.php/dav/, " +
+                "username=alice, encryptedPassword=AAAAFGhlbGxvd29ybGQxMjM=, wifiOnly=true)",
+            "upsert WebDavServerProfile(id=3, url=https://dav.example.com/remote.php/dav/, " +
+                "username=alice, encryptedPassword=$redacted, wifiOnly=true)",
+            secrets = listOf("AAAAFGhlbGxvd29ybGQxMjM="),
+            context = listOf("id=3", "dav.example.com", "username=alice", "wifiOnly=true"),
+        )
+    }
+
+    @Test
+    fun unquoted_tokenValueStopsAtWhitespaceSoSameLineContextSurvives() {
+        // The class split exists for this: an API key / signature / bearer token has no space in
+        // its grammar (it travels in an HTTP header or a query string, where a raw space is
+        // illegal), so terminating at a structural delimiter would needlessly destroy the line.
+        check(
+            "paging token = WEtBQTpIRXFrQVdHZFFM HTTP 401 retrying",
+            "paging token = $redacted HTTP 401 retrying",
+            secrets = listOf("WEtBQTpIRXFrQVdHZFFM"),
+            context = listOf("paging token", "HTTP 401 retrying"),
+        )
+    }
+
+    @Test
+    fun unquoted_anthropicXApiKeyHeader_redactsKeyKeepsHeaderNameAndStatus() {
+        check(
+            "AnthropicProvider POST /v1/messages header " +
+                "x-api-key: sk-ant-api03-AbC123def456 -> HTTP 401",
+            "AnthropicProvider POST /v1/messages header x-api-key: $redacted -> HTTP 401",
+            secrets = listOf("sk-ant-api03-AbC123def456"),
+            context = listOf("x-api-key", "/v1/messages", "-> HTTP 401"),
+        )
+    }
+
+    @Test
+    fun unquoted_queryStringApiKey_redactsValueKeepsHostAndOtherParams() {
+        check(
+            "at OpenAiCompatibleProvider.post(https://api.example.com/v1/chat" +
+                "?api_key=abc123secret&model=gpt-4o) HTTP 401",
+            "at OpenAiCompatibleProvider.post(https://api.example.com/v1/chat" +
+                "?api_key=$redacted&model=gpt-4o) HTTP 401",
+            secrets = listOf("abc123secret"),
+            context = listOf("api.example.com", "/v1/chat", "model=gpt-4o", "HTTP 401"),
+        )
+    }
+
+    @Test
+    fun unquoted_signedRedirectUrl_redactsSignatureKeepsHostAndStatus() {
+        // WebDavClient follows absolute redirect Locations and embeds the path in exceptions.
+        check(
+            "WebDavException: 403 https://blob.example/vreader.zip" +
+                "?sv=2024-11-04&sig=QWxhZGRpbjpvcGVuIHNlc2FtZQ== retrying",
+            "WebDavException: 403 https://blob.example/vreader.zip" +
+                "?sv=2024-11-04&sig=$redacted retrying",
+            secrets = listOf("QWxhZGRpbjpvcGVuIHNlc2FtZQ=="),
+            context = listOf("WebDavException: 403", "blob.example", "sv=2024-11-04", "retrying"),
+        )
+    }
+
+    @Test
+    fun unquoted_camelCaseEncryptedApiKey_isRedacted() {
+        // The iOS `api[_-]?key` alternation does NOT match `encryptedApiKey` (its separator-or-
+        // word-start requirement fails mid-token). This is the coverage iOS lacks.
+        check(
+            "AiProviderStore decrypt failed encryptedApiKey=AAAAFGhlbGxvd29ybGQxMjM0NTY3ODkw " +
+                "javax.crypto.AEADBadTagException",
+            "AiProviderStore decrypt failed encryptedApiKey=$redacted " +
+                "javax.crypto.AEADBadTagException",
+            secrets = listOf("AAAAFGhlbGxvd29ybGQxMjM0NTY3ODkw"),
+            context = listOf("AiProviderStore", "AEADBadTagException", "encryptedApiKey"),
+        )
+    }
+
+    @Test
+    fun unquoted_entityDumpWithPlainAndEncryptedCredential_redactsBothKeepsTuning() {
+        check(
+            "AiProviderProfile(id=p1, baseUrl=https://openrouter.ai/api/v1, " +
+                "apiKey=sk-or-v1-abc123def456, encryptedApiKey=AAAAFGhlbGxvMTIz, maxTokens=4096)",
+            "AiProviderProfile(id=p1, baseUrl=https://openrouter.ai/api/v1, " +
+                "apiKey=$redacted, encryptedApiKey=$redacted, maxTokens=4096)",
+            secrets = listOf("sk-or-v1-abc123def456", "AAAAFGhlbGxvMTIz"),
+            // maxTokens must SURVIVE — the over-redaction pin for the camel-case key rule.
+            context = listOf("id=p1", "openrouter.ai", "maxTokens=4096"),
+        )
+    }
+
+    @Test
+    fun unquoted_commandLineStyleDoubleDashKey_isRedacted() {
+        check(
+            "spawn rclone --password=hunter2secret999 serve",
+            "spawn rclone --password=$redacted",
+            secrets = listOf("hunter2secret999"),
+            context = listOf("spawn rclone", "--password="),
+        )
+    }
+
+    @Test
+    fun unquoted_secretAndAccessKeyFamilies_areRedacted() {
+        check(
+            "S3 upload denied accessKey=AKIAIOSFODNN7EXAMPLE region=eu-west-1",
+            "S3 upload denied accessKey=$redacted region=eu-west-1",
+            secrets = listOf("AKIAIOSFODNN7EXAMPLE"),
+            context = listOf("S3 upload denied", "region=eu-west-1"),
+        )
+        check(
+            "signer init secretKey=wJalrXUtnFEMIK7MDENGbPxRfiCY status=ready",
+            "signer init secretKey=$redacted status=ready",
+            secrets = listOf("wJalrXUtnFEMIK7MDENGbPxRfiCY"),
+            context = listOf("signer init", "status=ready"),
+        )
+    }
+
+    @Test
+    fun unquoted_allKeyedSecretSpellings_areRedacted() {
+        // (key + separator, secret value) — the expected output is the separator plus the
+        // placeholder, so a branch that ate the key name or the separator fails here too.
+        listOf(
+            "apiKey=" to "SUPERSECRETVALUE123",
+            "api_key=" to "SUPERSECRETVALUE123",
+            "api-key=" to "SUPERSECRETVALUE123",
+            "x-api-key: " to "xk9988776655",
+            "access_token: " to "aaaaaaaaaaaaaaaa",
+            "refresh_token=" to "rrrrrrrrrrrr",
+            "refreshToken=" to "rrrrrrrrrrrr",
+            "x-auth-token=" to "xa9988776655",
+            "client_secret: " to "csXYZ987654",
+            "password=" to "hunter2hunter2",
+            "passwd=" to "pw9988776655",
+            "passphrase=" to "pp9988776655",
+            "authToken=" to "tk9988776655",
+            "sessionToken=" to "st9988776655",
+            "idToken=" to "id9988776655",
+            "token=" to "bare9988776655",
+            "credential=" to "cr9988776655",
+            "X-Amz-Signature=" to "sg9988776655",
+        ).forEach { (keyWithSeparator, secret) ->
+            check(
+                "provider probe -> HTTP 401 for $keyWithSeparator$secret",
+                "provider probe -> HTTP 401 for $keyWithSeparator$redacted",
+                secrets = listOf(secret),
+                context = listOf("provider probe -> HTTP 401 for", keyWithSeparator.trimEnd()),
+            )
+        }
+    }
+
+    // ================================================================ shapes with no key name
+
+    @Test
+    fun shape_bareOpenAiKeyWithNoKeyName_isRedacted() {
+        // `value` is not a secret word, so ONLY the sk- rule can fire here.
+        check(
+            "provider probe rejected value sk-proj-AbCdEf1234567890XyZqrs at OpenAiCompatibleProvider",
+            "provider probe rejected value $redacted at OpenAiCompatibleProvider",
+            secrets = listOf("sk-proj-AbCdEf1234567890XyZqrs"),
+            context = listOf("provider probe rejected", "OpenAiCompatibleProvider"),
+        )
+    }
+
+    @Test
+    fun shape_cjkAdjacentKeyIsStillRedacted() {
+        // Java's `\b` is Unicode-aware, so `\bsk-` FAILS after a CJK character. The rule uses an
+        // explicit ASCII lookbehind instead; this vector is the regression pin.
+        check(
+            "密钥sk-proj-AbCdEf123456后 rejected",
+            "密钥${redacted}后 rejected",
+            secrets = listOf("sk-proj-AbCdEf123456"),
+            context = listOf("密钥", "后 rejected"),
+        )
+    }
+
+    @Test
+    fun shape_bareJwt_isRedacted() {
+        val jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NSJ9.SflKxwRJSMeKKF2QT4f"
+        check(
+            "OIDC session $jwt expired at AuthInterceptor",
+            "OIDC session $redacted expired at AuthInterceptor",
+            secrets = listOf(jwt),
+            context = listOf("OIDC session", "expired at AuthInterceptor"),
+        )
+    }
+
+    // ================================================================ URL credentials
+
+    @Test
+    fun url_credentials_redactPasswordKeepUserAndHost() {
+        check(
+            "WebDAV connect https://alice:hunter2secret@dav.example.com/remote.php/dav/ -> 401",
+            "WebDAV connect https://alice:$redacted@dav.example.com/remote.php/dav/ -> 401",
+            secrets = listOf("hunter2secret"),
+            context = listOf("alice", "dav.example.com", "/remote.php/dav/", "-> 401"),
+        )
+    }
+
+    @Test
+    fun url_passwordContainingAtSign_isFullyRedactedWithoutCrossingTheQuery() {
+        check(
+            "invalid URL: https://alice:p@ss@catalog.example/feed",
+            "invalid URL: https://alice:$redacted@catalog.example/feed",
+            secrets = listOf("p@ss"),
+            context = listOf("alice", "catalog.example/feed"),
+        )
+        // A query-string `@` must not pull the match past the host.
+        check(
+            "invalid URL: https://alice:p@ss@catalog.example?next=a@b",
+            "invalid URL: https://alice:$redacted@catalog.example?next=a@b",
+            secrets = listOf("p@ss"),
+            context = listOf("alice", "catalog.example", "next=a@b"),
+        )
+    }
+
+    @Test
+    fun url_emptyUsernameUserinfo_isStillRedacted() {
+        // `https://:password@host` is legal userinfo; requiring a non-empty username leaked it.
+        check(
+            "network error: response from https://:hunter2@catalog.example/feed exceeds the limit",
+            "network error: response from https://:$redacted@catalog.example/feed exceeds the limit",
+            secrets = listOf("hunter2"),
+            context = listOf("network error", "catalog.example/feed", "exceeds the limit"),
+        )
+    }
+
+    @Test
+    fun url_rtlAdjacentCredentials_areStillRedacted() {
+        check(
+            "فشلhttps://alice:hunter2@dav.example/dav",
+            "فشلhttps://alice:$redacted@dav.example/dav",
+            secrets = listOf("hunter2"),
+            context = listOf("فشل", "alice", "dav.example/dav"),
+        )
+    }
+
+    // ================================================================ paths and URIs
+
+    @Test
+    fun path_appBooksPath_redactsContainerButKeepsFingerprintKeyFilename() {
+        // Book artifacts live at filesDir/books/<sanitised fingerprintKey>, and that key is the
+        // handle every import/reader bug is filed against — it must SURVIVE.
+        check(
+            "java.io.FileNotFoundException: " +
+                "/data/user/0/com.vreader.app/files/books/epub_984f8611bb2842e0_2956 " +
+                "(No such file)",
+            "java.io.FileNotFoundException: $path/epub_984f8611bb2842e0_2956 (No such file)",
+            secrets = listOf("/data/user/0", "com.vreader.app/files"),
+            context = listOf("epub_984f8611bb2842e0_2956", "FileNotFoundException", "(No such file)"),
+        )
+    }
+
+    @Test
+    fun path_fileUrlToAnAppBookAlsoKeepsTheFingerprintKey() {
+        check(
+            "loaded file:///data/user/0/com.vreader.app/files/books/epub_984f_1 ok",
+            "loaded $path/epub_984f_1 ok",
+            secrets = listOf("/data/user/0", "com.vreader.app"),
+            context = listOf("epub_984f_1", "loaded", "ok"),
+        )
+    }
+
+    @Test
+    fun path_theFingerprintExceptionIsScopedToThisAppsArtifactDirectory() {
+        // A nested tail under the app's books dir must NOT satisfy the terminal-segment guard.
+        check(
+            "open /data/user/0/com.vreader.app/files/books/sub/evil.epub gone",
+            "open $path gone",
+            secrets = listOf("sub/evil.epub", "/data/user/0"),
+            context = listOf("open", "gone"),
+        )
+        // Another app's private books dir gets NO exception — the applicationId is pinned.
+        check(
+            "open /data/user/0/com.other.app/files/books/private_customer_name gone",
+            "open $path gone",
+            secrets = listOf("com.other.app", "private_customer_name"),
+            context = listOf("open", "gone"),
+        )
+        // A user's own "Books" folder on shared storage is not the app artifact dir either.
+        check(
+            "import /storage/emulated/0/Books/Alice/Tax Return.pdf failed",
+            // A terminal filename containing a space keeps its last word — filenames are outside
+            // redaction policy (parity with iOS #96); the DIRECTORY name is not, and it goes.
+            "import $path Return.pdf failed",
+            secrets = listOf("/storage/emulated/0/Books", "Alice"),
+            context = listOf("import", "failed"),
+        )
+    }
+
+    @Test
+    fun path_genericFileUrl_isRedactedWithTheSameSpaceHandling() {
+        check(
+            "loaded file:///data/user/0/com.vreader.app/files/x.epub ok",
+            "loaded $path ok",
+            secrets = listOf("/data/user/0/com.vreader.app/files/x.epub"),
+            context = listOf("loaded", "ok"),
+        )
+        // A file URL OUTSIDE every known Android root — a removable SD card carries the volume id
+        // and the user's own folder names, and no path-root rule matches it.
+        check(
+            "loaded file:///storage/1A2B-3C4D/Books/Alice Smith/tax.pdf failed",
+            "loaded $path failed",
+            secrets = listOf("1A2B-3C4D", "Alice Smith", "tax.pdf"),
+            context = listOf("loaded", "failed"),
+        )
+    }
+
+    @Test
+    fun path_safContentUri_keepsAuthorityRedactsDocumentPath() {
+        check(
+            "import content://com.android.providers.downloads.documents/document/msf%3A1000 " +
+                "failed SecurityException",
+            "import content://com.android.providers.downloads.documents/$path " +
+                "failed SecurityException",
+            secrets = listOf("document/msf%3A1000"),
+            context = listOf("com.android.providers.downloads.documents", "SecurityException"),
+        )
+    }
+
+    @Test
+    fun path_multiUserAppPrivatePath_isRedacted() {
+        // The user id is NOT hard-coded to 0 — a work profile / secondary user must redact too.
+        check(
+            "Room open failed android.database.sqlite.SQLiteException at " +
+                "/data/user/11/com.vreader.app/databases/vreader.db",
+            "Room open failed android.database.sqlite.SQLiteException at $path",
+            secrets = listOf("/data/user/11/com.vreader.app"),
+            context = listOf("SQLiteException"),
+        )
+        check(
+            "prefs /data/user_de/10/com.vreader.app/shared_prefs/settings.xml unreadable",
+            "prefs $path unreadable",
+            secrets = listOf("/data/user_de/10/com.vreader.app"),
+            context = listOf("prefs", "unreadable"),
+        )
+    }
+
+    @Test
+    fun path_legacyDataDataPath_isRedacted() {
+        check(
+            "prefs /data/data/com.vreader.app/shared_prefs/settings.xml unreadable",
+            "prefs $path unreadable",
+            secrets = listOf("/data/data/com.vreader.app"),
+            context = listOf("prefs", "unreadable"),
+        )
+    }
+
+    @Test
+    fun path_sharedStoragePaths_areRedacted() {
+        check(
+            "import from /storage/emulated/0/Download/foo.epub denied SecurityException",
+            "import from $path denied SecurityException",
+            secrets = listOf("/storage/emulated/0/Download"),
+            context = listOf("import from", "denied SecurityException"),
+        )
+        check(
+            "import from /sdcard/Download/foo.epub denied SecurityException",
+            "import from $path denied SecurityException",
+            secrets = listOf("/sdcard/Download"),
+            context = listOf("import from", "denied SecurityException"),
+        )
+    }
+
+    @Test
+    fun path_directoryNameWithASpace_doesNotLeakTheRestOfThePath() {
+        // Whitespace termination leaked "Smith/tax.pdf" — a real name plus a document title.
+        check(
+            "import /storage/emulated/0/Download/Alice Smith/tax.pdf failed",
+            "import $path failed",
+            secrets = listOf("Alice Smith", "tax.pdf"),
+            context = listOf("import", "failed"),
+        )
+    }
+
+    @Test
+    fun path_spaceHeuristicResidualImperfectionsArePinnedNotImplicit() {
+        // No lexical rule separates "a directory name containing a space" from "trailing prose",
+        // so the heuristic ("a space joins the path only if the next token holds a `/`") has two
+        // known residuals. They are asserted so a future change to the rule is a visible decision
+        // rather than a silent regression.
+
+        // (a) A TERMINAL directory containing a space keeps its last word.
+        check(
+            "cannot create /storage/emulated/0/Download/Alice Smith",
+            "cannot create $path Smith",
+            secrets = listOf("/storage/emulated/0/Download", "Alice"),
+            context = listOf("cannot create"),
+        )
+        // (b) Prose containing a `/` right after a path is over-redacted (the safe direction).
+        check(
+            "open /storage/emulated/0/Download/x read/write failed",
+            "open $path failed",
+            secrets = listOf("/storage/emulated/0/Download"),
+            context = listOf("open", "failed"),
+        )
+    }
+
+    // ================================================================ negatives: no over-redaction
+
+    @Test
+    fun negative_nonCredentialTokenIdentifiersSurvive() {
+        // This codebase has ~70 `*Token` identifiers that are NOT credentials; redacting them
+        // would destroy exactly the pagination/session diagnostics an export exists to carry.
+        assertUnchanged("paging startToken=abc123 activeToken=def456 maxTokens=4096")
+        assertUnchanged("PaginationToken=p9 iteratorToken=t7 finalToken=f1 rawTokens=12")
+        assertUnchanged("validToken=true uuidToken=u1 nextToken=n2")
+        assertUnchanged("the session token was refreshed successfully")
+    }
+
+    @Test
+    fun negative_nonCredentialKeyIdentifiersSurvive() {
+        // The `*Key` family is qualifier-gated for the same reason: `fingerprintKey` is the handle
+        // every import/reader bug is filed against, and a bare `key=` is a cache/map handle.
+        assertUnchanged("book fingerprintKey=epub_984f8611bb2842e0bc3a7b90cef7ffed37e4cc23_2956 opened")
+        assertUnchanged("cache key=chapter-12 sortKey=title primaryKey=42 publicKey=short")
+    }
+
+    @Test
+    fun negative_proseAfterAnAuthSchemeWordSurvives() {
+        // An entropy-shaped bare rule redacted `Basic SHA256withRSA2048`; the scanner is anchored
+        // on a real container instead, so prose is untouched.
+        assertUnchanged("Basic authentication required by the server")
+        assertUnchanged("Basic SHA256withRSA2048 unsupported")
+        assertUnchanged("Bearer tokens rejected")
+        // No `:`/`=`/`,`/`]`/`)` after the header name — not a container, so not a credential.
+        assertUnchanged("Authorization is required for this endpoint")
+    }
+
+    @Test
+    fun negative_keyWordWithoutAnAssignmentSeparatorSurvives() {
+        // `password` here is a KEYSTORE ALIAS, not a `key=value` pair. Requiring a `:` or `=` in
+        // the separator run is what keeps "the session token was refreshed" intact too.
+        assertUnchanged("keystore alias vreader.webdav.password rotated")
+        assertUnchanged("TestSignature(probe) completed in 12ms")
+    }
+
+    @Test
+    fun negative_identifiersHashesAndVersionsAreUnchanged() {
+        assertUnchanged("content sha256 984f8611bb2842e0bc3a7b90cef7ffed37e4cc23 verified")
+        assertUnchanged("deleted books row id=42 in 12ms")
+        assertUnchanged("versionName=0.13.4 versionCode=134")
+        assertUnchanged("design=material config=default assign=true")
+    }
+
+    @Test
+    fun negative_messageWithNoSecretIsByteIdentical() {
+        val msg = "loaded 12 books in 0.34s"
+        assertEquals(msg, DiagnosticsRedactor.redact(msg))
+    }
+
+    // ================================================================ oracle self-check
+
+    @Test
+    fun oracle_idempotencyIsNotACompletenessOracle() {
+        // Survivor 3's partial output (`password=‹redacted›'BrienNeverClose`) was STABLE under
+        // re-redaction, so the idempotency assertion could not see it. This test pins that
+        // idempotency proves nothing about completeness — using the ACCEPTED non-goal as the
+        // demonstration: a bare `SecretCipher` blob with no key name and no `sk-`/JWT shape is a
+        // fixed point of redact() AND still contains the secret.
+        val leaking = "SecretCipher decrypt failed for AAAAFGhlbGxvd29ybGQxMjM0"
+        val once = DiagnosticsRedactor.redact(leaking)
+        assertEquals("idempotent…", once, DiagnosticsRedactor.redact(once))
+        assertTrue(
+            "…yet the secret survives — idempotency is not a completeness oracle",
+            once.contains("AAAAFGhlbGxvd29ybGQxMjM0"),
+        )
+        // The controls for this class are the `VLog` seam and the `android.util.Log` containment
+        // check, NOT this function. A blanket base64 rule would swallow every hash, row id and
+        // fingerprint key — see negative_identifiersHashesAndVersionsAreUnchanged.
+    }
+
+    @Test
+    fun oracle_aPartialRedactionIsRejectedByTheExactAndSuffixAssertions() {
+        // The shape the previous design produced. It must NOT be what redact() returns.
+        val partial = """password="$redacted'BrienNeverClose"""
+        val actual = DiagnosticsRedactor.redact("""password="O'BrienNeverClose""")
+        assertFalse("a partial redaction must not be the output", actual == partial)
+        assertFalse("no suffix of the secret may survive", actual.contains("BrienNeverClose"))
+    }
+
+    // ================================================================ robustness
+
+    @Test
+    fun robustness_emptyCjkAndRtlMessagesAreUnchanged() {
+        assertEquals("", DiagnosticsRedactor.redact(""))
+        assertUnchanged("已加载 12 本书，用时 0.34 秒")
+        assertUnchanged("فشل تحميل الكتاب بعد 3 محاولات")
+        assertUnchanged("مرحبا 已加载 mixed ‏RTL‏ 12")
+    }
+
+    @Test
+    fun robustness_cjkMessageStillRedactsAnEmbeddedSecret() {
+        check(
+            "同步失败 Authorization: Basic dXNlcjpwYXNzd29yZA== 请重试",
+            "同步失败 Authorization: Basic $redacted 请重试",
+            secrets = listOf("dXNlcjpwYXNzd29yZA=="),
+            context = listOf("同步失败", "请重试"),
+        )
+    }
+
+    @Test
+    fun robustness_oneMegabyteMessageDoesNotThrowAndStillRedacts() {
+        val line = "loaded 12 books in 0.34s and reopened the library index cleanly\n"
+        val bulk = StringBuilder(1_100_000)
+        while (bulk.length < 1_000_000) bulk.append(line)
+        bulk.append("Authorization: Bearer sk-proj-OneMegabyteTailSecret999\n")
+        val input = bulk.toString()
+        assertTrue("fixture must exceed 1 MB", input.length > 1_000_000)
+        val out = DiagnosticsRedactor.redact(input)
+        assertFalse(out.contains("sk-proj-OneMegabyteTailSecret999"))
+        assertTrue(out.contains("Authorization: Bearer $redacted"))
+    }
+
+    @Test
+    fun robustness_pathologicalInputsDoNotThrow() {
+        listOf(
+            " ", "\n", "\t", "=", ":", "\"", "'", "{}", "://", "content://",
+            "Authorization:", "Authorization: Bearer", "Authorization: Bearer ", "password=",
+            "sk-", "eyJ", "/data/user/", "/sdcard", "file://", "  nul", "password=\"unterminated",
+            "password='", """state={\"apiKey\":\"""", "https://:@", "Authorization]=",
+            "--", "--password=", "-", "key=", "a-b-c-key=", "token", "token=", "\\\"", "\\",
+            "Authorization" + " ".repeat(40), "password" + "=".repeat(40),
+        ).forEach { DiagnosticsRedactor.redact(it) }
+    }
+
+    // ================================================================ ReDoS / linearity bounds
+    // Each of these was measured super-linear against the previous regex design. The scanner is a
+    // single left-to-right pass with no backtracking, so the timeout is the assertion.
+
+    @Test(timeout = 15_000)
+    fun linear_longWhitespaceRunAfterAuthorization() {
+        DiagnosticsRedactor.redact("Authorization:" + " ".repeat(100_000) + "Bearer $redacted")
+    }
+
+    @Test(timeout = 15_000)
+    fun linear_longSingleIdentifier() {
+        DiagnosticsRedactor.redact("a".repeat(100_000))
+    }
+
+    @Test(timeout = 15_000)
+    fun linear_repeatedKeyWord() {
+        DiagnosticsRedactor.redact("password".repeat(12_000))
+    }
+
+    @Test(timeout = 15_000)
+    fun linear_longHyphenatedRun() {
+        // Measured QUADRATIC before the fix: the URL-credential rule's `[a-z][a-z0-9+.-]*` gave
+        // every `a` in `a-a-a-…` a viable start whose scheme run consumed the rest of the input
+        // before failing. Fixed by a head that also excludes `+.-` plus a possessive scheme run.
+        DiagnosticsRedactor.redact("a-".repeat(50_000))
+    }
+
+    @Test(timeout = 15_000)
+    fun linear_repeatedKeyAssignment() {
+        DiagnosticsRedactor.redact("api-key=".repeat(12_000))
+        DiagnosticsRedactor.redact("Authorization:".repeat(12_000))
+    }
+
+    @Test(timeout = 15_000)
+    fun linear_unterminatedQuotedValueWithBackslashRun() {
+        DiagnosticsRedactor.redact("password=\"" + "\\".repeat(4_000))
+        DiagnosticsRedactor.redact("""state={\"apiKey\":\"""" + "\\".repeat(4_000))
+    }
+
+    // ================================================================ idempotency, combined
+
+    @Test
+    fun idempotency_holdsForACombinedMultiSecretMessage() {
+        val msg = "Authorization: Bearer sk-abc123def456ghijk, " +
+            "at /data/user/0/com.vreader.app/files/books/epub_a1b2_4, " +
+            "via https://alice:pw123456@dav.example.com/dav/, " +
+            "uri content://com.android.providers.media.documents/document/x%3A9, " +
+            "apiKey=ZZTOP1234567"
+        val once = DiagnosticsRedactor.redact(msg)
+        assertEquals(once, DiagnosticsRedactor.redact(once))
+        assertEquals(once, DiagnosticsRedactor.redact(DiagnosticsRedactor.redact(once)))
+        listOf("sk-abc123def456ghijk", "/data/user/0", "ZZTOP1234567", "pw123456", "document/x%3A9")
+            .forEach { assertFalse("<$it> survived: $once", once.contains(it)) }
+        listOf("epub_a1b2_4", "alice", "dav.example.com",
+            "content://com.android.providers.media.documents")
+            .forEach { assertTrue("<$it> destroyed: $once", once.contains(it)) }
+    }
+}

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,4 +1,4 @@
 # vreader Android app version (feature #106). Per rule 40: Android tags are
 # `android/vX.Y.Z` (iOS keeps plain `vX.Y.Z`). versionCode is monotonic.
-versionName=0.20.25
-versionCode=178
+versionName=0.20.26
+versionCode=179


### PR DESCRIPTION
## Summary

`DiagnosticsRedactor` — the security control that stands between a user's diagnostics export and their live credentials. On Android it is the **only** line of defence (iOS has OSLog's `privacy:` barrier ahead of it; logcat is plaintext).

The keyed-value matcher is a hand-written **scanner with an explicit quote state machine**, not a regex grammar.

Part of feature #2023 (#164). Foundational WI.

## Why a scanner, and why the regex version was not merged

A first lane built a 13-rule regex redactor (branch `feat/164-wi-2-redactor`, **deliberately not merged**). Its Gate-4 went **4 High → 3 High → 4 NEW High** — not converging. Four labelled credential shapes survived, each verified:

| # | Shape | Old behaviour |
|---|---|---|
| 1 | `Authorization:` + 10 spaces + `Bearer …` | returned **unchanged** — the container class was `{0,8}` and the fallback rule *declined* on seeing a scheme |
| 2 | `state={\"Authorization\":\"Basic WEtBQTpIRXFrQVdHZFFM\"}` | survived **entirely** (the real `OpdsClient`/`WebDavClient` Basic shape) |
| 3 | `password="O'BrienNeverClose` | → `password=‹redacted›'BrienNeverClose` |
| 4 | `password=hunter2,continued&more)tail` | leaked `,continued&more)tail` |

**Survivor 3 is why this was a redesign and not a 14th rule**: its partial output is *stable under re-redaction*, so the idempotency assertions could never detect it. A partial redaction that looks correct to the test suite is worse than an obvious miss.

The underlying diagnosis — the first lane's real deliverable — is that **a regex cannot delimit an unquoted or partially-quoted value, because the correct delimiter depends on quote *state*, not on a character class.**

All four are now named RED tests, verified red against the previous implementation and green here.

## The unquoted-delimiter policy, argued rather than inherited

Documented in the file header. Keys split by whether the value can contain a space:

- **TOKEN keys** (api key, signature, bearer token) stop at **whitespace** — because those values travel in an HTTP header or query string where a raw space is *illegal*. That is a fact about the grammar, not a guess, and it is what keeps `-> HTTP 401` alive on the same line.
- **SPACED keys** (password, passphrase, authHeader) run to **end of line**, stopping early only at a structural character that is *demonstrably* a field boundary: a `,`/`&`/`;` followed by a new `identifier[:=]`, or a bracket closing an opener seen before the key.

Deliberately asymmetric, toward safety. `ServerDraft(password=hunter2,continued, wifiOnly=true)` still keeps `wifiOnly=true`.

## Gate 4 — 3 rounds, `ship-as-is`, auditor could not construct a survivor

- **Round 1** `block-recommended`: two Highs, **both with constructed survivors** — an escaped-JSON suffix leak from collapsing quote depth to a boolean, and `Dump{password=abc},SUFFIX` where a bracket+comma was wrongly taken as proof the dump had ended. Plus a genuine **quadratic** from `ArrayDeque.contains` on deep brackets.
- **Round 2** `follow-up-recommended`: all six fixes re-traced and held, no new survivor. One Low — it produced the real counter-example the lane's own round-1 rationale had claimed did not exist (`methodSignature=` / `packageSignature=`).
- **Round 3** `ship-as-is`: **zero findings at any severity**, and the auditor stated it could not construct a survivor.

## Mutation pass: 16/16 killed, none shadowed

The previous lane had **two rules that were initially unkillable because another rule shadowed them**, and both hid real gaps. This lane looked specifically for that pattern and found none. Full kill map in the audit artifact.

Two things the lane caught on itself, both worth recording:

- Its new **suffix oracle** (no suffix of a secret of length ≥4 may survive) failed on two of its *own* fixtures whose secrets ended in `word` — because the surviving key name `password` contains it. It changed the fixtures, **not the assertion**.
- It found a **pre-existing ReDoS the previous design shared**: the URL-credential rule was quadratic on `"a-".repeat(50000)` (every `a` a viable scheme start). Fixed with a tighter head plus a possessive scheme run, pinned by `linear_longHyphenatedRun`.

## What still cannot be redacted — stated plainly

1. **A bare opaque secret** with no key name, no `Authorization` container, and no `sk-`/JWT shape. This is the accepted non-goal: a `SecretCipher` token is `base64(iv‖ct)` with no framing, so only a blanket base64 rule would catch it — and that would swallow every hash, row id and fingerprint key. The real control is logging discipline at the `VLog` seam. **`oracle_idempotencyIsNotACompletenessOracle` pins this as a live witness** that a fixed point of `redact()` can still contain a secret.
2. An unquoted **spaced** value literally containing `, identifier=` is truncated there — the price of keeping `wifiOnly=true` in every `toString()`.
3. A bare `signature=<cert>` loses that token (kept deliberately: HTTP-Signature spells its credential that way).
4. A value ending in a backslash over-redacts to end of line rather than risk a leak.

An entropy heuristic was tried by the previous lane and **deleted** after failing in both directions — it missed a real all-letter `OpdsClient` Basic token and over-redacted `Basic SHA256withRSA2048`. Not reintroduced.

## Validation

- **123 tests, 0 failures** re-run by the orchestrator (`DiagnosticsRedactorTest` 75 + WI-1's `DiagnosticsLevelTest` 5 and `LogcatLineParserTest` 43), counts from the JUnit XML.
- All four survivor tests confirmed present **and executed** in the XML.
- Two-sided assertions throughout: the shared `check()` helper asserts the secret was present *before* redaction (so a mistyped fixture cannot pass for free), the exact output, whole-secret absence, per-word fragment absence, each named diagnostic-context substring surviving, and idempotency.
- Version bumped: `android/v0.20.25` → `android/v0.20.26`.

## Disclosed deviation

The lane seeded its RED baseline with `git show <old-branch>:<file> > file` — a Bash-mediated write. It was a git-restored blob rather than authored content, was overwritten via `Write` before any commit, and every committed byte went through Write/Edit. Flagged by the lane rather than left implicit.

## Accepted

`DiagnosticsRedactor.kt` is 447 lines, ~155 of which are the security-rationale header this brief required; ~260 are code. The write-set forbade a new file, so splitting was not available in-lane.

## Type of Change

- [x] Feature WI (part of feature #2023)
